### PR TITLE
Revert "[#64] fix: Fast return in different fuse2/3 features"

### DIFF
--- a/curvine-fuse/src/raw/fuse_sys.rs
+++ b/curvine-fuse/src/raw/fuse_sys.rs
@@ -59,7 +59,7 @@ pub fn fuse_mount(
     {
         let res = unsafe { fuse_mount_compat25(mnt, args) };
         let fd = err_io!(res)?;
-        return Ok((fd, None));
+        Ok((fd, None))
     }
 
     #[cfg(all(target_os = "linux", feature = "fuse3"))]
@@ -75,7 +75,7 @@ pub fn fuse_mount(
 
         let res = unsafe { fuse_session_fd(session) };
         let fd = err_io!(res)?;
-        return Ok((fd, Some(session)));
+        Ok((fd, Some(session)))
     }
 
     #[cfg(not(target_os = "linux"))]


### PR DESCRIPTION
Reverts CurvineIO/curvine#65
In the clippy check, the final return is not necessary.