### PR TITLE
[curvine-fuse] support setxattr (#37)

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -6,7 +6,7 @@ on:
       push_image:
         description: '是否推送镜像到 GitHub Container Registry'
         required: false
-        default: 'false'
+        default: false
         type: boolean
 
 permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Compile and Test
 on:
   push:
     branches:
-      - '**'
+      - 'main'
   pull_request:
     branches:
       - '**'
@@ -13,8 +13,23 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clean hostedtoolcache to free disk space on host
+        run: |
+          echo "Disk usage before cleanup:"
+          df -h
+          
+          # Remove GitHub Actions pre-installed toolchain cache on host machine
+          sudo rm -rf /opt/hostedtoolcache || true
+          
+          echo "Disk usage after cleanup:"
+          df -h
+
   build:
     runs-on: ubuntu-latest
+    needs: cleanup
     container:
       image: ghcr.io/curvineio/curvine-compile:latest
       credentials:
@@ -37,14 +52,62 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "curvine-build"
+          # 减少缓存大小
+          cache-all-crates: false
+          cache-targets: false
       
-      - name: Build
-        run: cargo build --verbose
-        
       - name: Run fmt
-        run: cargo fmt --check
+        run: |
+          echo "Running fmt check (fastest, no compilation needed)"
+          cargo fmt --check
+          
+          echo "After fmt, disk usage:"
+          df -h
         
       - name: Run clippy
         env:
           CLIPPY_LEVEL: deny 
-        run: cargo clippy --release --all-targets -- --${CLIPPY_LEVEL}=warnings
+        run: |
+          echo "Running clippy (static code analysis)"
+          # Run clippy in debug mode to match build
+          cargo clippy --all-targets --jobs 2 -- --${CLIPPY_LEVEL}=warnings
+          
+          echo "After clippy, disk usage:"
+          df -h
+      
+      - name: Clean after clippy
+        run: |
+          # Clean clippy artifacts to save space
+          find target -name "*.rlib" -delete || true
+          find target -name "*.rmeta" -delete || true
+          rm -rf target/debug/incremental || true
+          
+          echo "After clippy cleanup, disk usage:"
+          df -h
+        
+      - name: Build
+        run: |
+          echo "Starting final build, disk usage:"
+          df -h
+          
+          # Build with limited parallelism to save memory  
+          cargo build --verbose --jobs 2
+          
+          echo "After build, disk usage:"
+          df -h
+      
+      - name: Final cleanup before cache save
+        run: |
+          echo "Final cleanup before cache save"
+          
+          # Clean all temporary files
+          rm -rf target/release/incremental || true
+          rm -rf target/release/.fingerprint || true
+          find target -name "*.d" -delete || true
+          
+          # Clean cargo cache
+          rm -rf ~/.cargo/registry/cache || true
+          rm -rf ~/.cargo/.package-cache || true
+          
+          echo "Final disk usage:"
+          df -h

--- a/curvine-client/src/unified/mod.rs
+++ b/curvine-client/src/unified/mod.rs
@@ -74,7 +74,8 @@ impl UfsFileSystem {
                 let fs = S3FileSystem::new(UfsConf::with_map(conf))?;
                 Ok(UfsFileSystem::S3(fs))
             }
-            Some("gcs") | Some("gs") | Some("azure") | Some("azblob") | Some("abfs") | Some("oss") => {
+            Some("gcs") | Some("gs") | Some("azure") | Some("azblob") | Some("abfs")
+            | Some("oss") => {
                 let fs = OpendalFileSystem::new(path, UfsConf::with_map(conf))?;
                 Ok(UfsFileSystem::OpenDAL(fs))
             }

--- a/curvine-fuse/src/fs/file_system.rs
+++ b/curvine-fuse/src/fs/file_system.rs
@@ -41,6 +41,16 @@ pub trait FileSystem: Send + Sync + 'static {
         async move { err_fuse!(libc::ENOSYS, "{}", msg) }
     }
 
+    async fn set_xattr(&self, op: SetXAttr<'_>) -> FuseResult<()> {
+        let msg = format!("{:?}", op);
+        async move { err_fuse!(libc::ENOSYS, "{}", msg) }
+    }
+
+    async fn remove_xattr(&self, op: RemoveXAttr<'_>) -> FuseResult<()> {
+        let msg = format!("{:?}", op);
+        async move { err_fuse!(libc::ENOSYS, "{}", msg) }
+    }
+
     async fn get_attr(&self, op: GetAttr<'_>) -> FuseResult<fuse_attr_out> {
         let msg = format!("{:?}", op);
         async move { err_fuse!(libc::ENOSYS, "{}", msg) }

--- a/curvine-fuse/src/fs/operator.rs
+++ b/curvine-fuse/src/fs/operator.rs
@@ -29,6 +29,8 @@ pub enum FuseOperator<'a> {
     GetAttr(GetAttr<'a>),
     SetAttr(SetAttr<'a>),
     GetXAttr(GetXAttr<'a>),
+    SetXAttr(SetXAttr<'a>),
+    RemoveXAttr(RemoveXAttr<'a>),
     OpenDir(OpenDir<'a>),
     Mkdir(MkDir<'a>),
     FAllocate(FAllocate<'a>),
@@ -225,6 +227,28 @@ pub struct Access<'a> {
 pub struct GetXAttr<'a> {
     pub header: &'a fuse_in_header,
     pub arg: &'a fuse_getxattr_in,
+    pub name: &'a OsStr,
+}
+
+/// SetXAttr request structure:
+/// +0                         +40                    +56           +56+len(name)+1
+/// |--------------------------|---------------------|-------------|--------------------------|
+/// |    fuse_in_header        | fuse_setxattr_in    |    name     |    value                 |
+/// |      (40 bytes)          |     (16 bytes)      | (variable)  | (size bytes)             |
+/// |--------------------------|---------------------|-------------|--------------------------|
+
+#[derive(Debug)]
+pub struct SetXAttr<'a> {
+    pub header: &'a fuse_in_header,
+    pub arg: &'a fuse_setxattr_in,
+    pub name: &'a OsStr,
+    pub value: &'a [u8],
+}
+
+#[derive(Debug)]
+pub struct RemoveXAttr<'a> {
+    pub header: &'a fuse_in_header,
+    pub arg: &'a fuse_removexattr_in,
     pub name: &'a OsStr,
 }
 

--- a/curvine-fuse/src/raw/fuse_abi.rs
+++ b/curvine-fuse/src/raw/fuse_abi.rs
@@ -234,6 +234,24 @@ pub struct fuse_getxattr_in {
     pub padding: u32,
 }
 
+#[repr(C)]
+#[derive(Debug, Default)]
+pub struct fuse_setxattr_in {
+    pub size: u32,
+    pub flags: u32,
+    //maybe different in version
+    pub setxattr_flags: u32,
+    pub padding: u32,
+}
+
+// Note: FUSE_REMOVEXATTR has no input structure
+// The name is passed directly in the payload
+#[repr(C)]
+#[derive(Debug, Default)]
+pub struct fuse_removexattr_in {
+    pub padding: u32,
+}
+
 #[allow(non_camel_case_types)]
 #[repr(C)]
 #[derive(Debug)]

--- a/curvine-fuse/src/session/fuse_decoder.rs
+++ b/curvine-fuse/src/session/fuse_decoder.rs
@@ -86,6 +86,14 @@ impl<'a> FuseDecoder<'a> {
         self.buf = &[];
         Ok(bytes)
     }
+
+    /// Get exactly the specified number of bytes (for FUSE_SETXATTR value)
+    pub fn get_bytes(&mut self, size: usize) -> FuseResult<&'a [u8]> {
+        if size > self.buf.len() {
+            return err_box!("Not enough data for specified size");
+        }
+        self.get_slice(size)
+    }
 }
 
 #[cfg(test)]

--- a/curvine-fuse/src/session/fuse_request.rs
+++ b/curvine-fuse/src/session/fuse_request.rs
@@ -120,6 +120,22 @@ impl FuseRequest {
                 name: decoder.get_os_str()?,
             }),
 
+            FUSE_SETXATTR => {
+                let arg = decoder.get_struct()?;
+                FuseOperator::SetXAttr(SetXAttr {
+                    header,
+                    arg,
+                    name: decoder.get_os_str()?,
+                    value: decoder.get_bytes(arg.size as usize)?,
+                })
+            }
+
+            FUSE_REMOVEXATTR => FuseOperator::RemoveXAttr(RemoveXAttr {
+                header,
+                arg: decoder.get_struct()?,
+                name: decoder.get_os_str()?,
+            }),
+
             FUSE_SETATTR => FuseOperator::SetAttr(SetAttr {
                 header,
                 arg: decoder.get_struct()?,

--- a/curvine-fuse/src/session/fuse_session.rs
+++ b/curvine-fuse/src/session/fuse_session.rs
@@ -249,6 +249,18 @@ impl<T: FileSystem> FuseSession<T> {
 
             FuseOperator::GetXAttr(op) => reply.send_buf(fs.get_xattr(op).await).await,
 
+            FuseOperator::SetXAttr(op) => {
+                fs.set_xattr(op).await?;
+                reply.send_empty().await
+            }
+
+            FuseOperator::RemoveXAttr(op) => {
+                fs.remove_xattr(op).await?;
+                reply.send_empty().await
+            }
+
+            FuseOperator::ListXAttr(op) => reply.send_rep(fs.list_xattr(op).await).await,
+
             FuseOperator::OpenDir(op) => reply.send_rep(fs.open_dir(op).await).await,
 
             FuseOperator::Mkdir(op) => reply.send_rep(fs.mkdir(op).await).await,


### PR DESCRIPTION
This patch only covers the fuse framework itself, so setxattr or getxattr is invalid, only keeping the interface compatible, curvine support xattr will continue to be improved in later patches