### PR TITLE
fix: Exit on journal writing failure

### DIFF
--- a/curvine-server/src/master/journal/sender_task.rs
+++ b/curvine-server/src/master/journal/sender_task.rs
@@ -56,7 +56,7 @@ impl SenderTask {
         let task = self;
         thread::Builder::new().name(name.clone()).spawn(move || {
             if let Err(e) = Self::loop0(receiver, poll, task) {
-                error!("thread {} stop: {:?}", name, e)
+                panic!("thread {} stop: {:?}", name, e);
             }
         })?;
         Ok(())


### PR DESCRIPTION
If master keeps accepting the newly coming requests when the journal writing thread exit, the inconsistency will happen. This is dangerous