### PR TITLE
fix: avoid panic without any bench params

### DIFF
--- a/curvine-tests/src/bench_args.rs
+++ b/curvine-tests/src/bench_args.rs
@@ -15,6 +15,7 @@
 use clap::Parser;
 
 #[derive(Debug, Parser, Clone, Default)]
+#[command(arg_required_else_help = true)]
 pub struct BenchArgs {
     #[arg(short, long, default_value = "")]
     pub action: String,


### PR DESCRIPTION
To fix #66 

<img width="919" height="364" alt="image" src="https://github.com/user-attachments/assets/6b645235-2473-417c-8d45-ed8be401f407" />
