### PR TITLE
fix: build with macos

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,14 @@
 [env]
 #RUST_TEST_NOCAPTURE = "1"
+
+[target.x86_64-apple-darwin]
+rustflags = [
+    "-C", "link-arg=-undefined",
+    "-C", "link-arg=dynamic_lookup",
+]
+
+[target.aarch64-apple-darwin]
+rustflags = [
+    "-C", "link-arg=-undefined",
+    "-C", "link-arg=dynamic_lookup",
+]

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 yarn.lock
+
+# macOS
+.DS_Store

--- a/build/build.sh
+++ b/build/build.sh
@@ -25,7 +25,7 @@ get_arch_name() {
         i386 | i686)
             echo "x86_32"
             ;;
-        aarch64)
+        aarch64 | arm64)
              echo "aarch_64"
             ;;
         armv7l | armv6l)
@@ -38,9 +38,15 @@ get_arch_name() {
 }
 
 get_os_version() {
-  id=$(grep -E '^ID=' /etc/os-release | cut -d= -f2- | tr -d '"')
-  ver=$(grep ^VERSION_ID= /etc/os-release | cut -d '"' -f 2| cut -d '.' -f 1)
-  echo $id$ver
+  if [ -f "/etc/os-release" ]; then
+    id=$(grep -E '^ID=' /etc/os-release | cut -d= -f2- | tr -d '"')
+    ver=$(grep ^VERSION_ID= /etc/os-release | cut -d '"' -f 2| cut -d '.' -f 1)
+    echo $id$ver
+  elif [[ "$OSTYPE" == "darwin"* ]]; then
+    echo "mac"
+  else
+    echo "unknown"
+  fi
 }
 
 get_fuse_version() {

--- a/curvine-server/src/master/journal/sender_task.rs
+++ b/curvine-server/src/master/journal/sender_task.rs
@@ -18,7 +18,6 @@ use curvine_common::conf::JournalConf;
 use curvine_common::raft::RaftClient;
 use curvine_common::utils::SerdeUtils;
 use curvine_common::FsResult;
-use log::error;
 use orpc::common::{LocalTime, TimeSpent};
 use orpc::err_box;
 use std::sync::mpsc;


### PR DESCRIPTION
```
            "__Py_TrueStruct", referenced from:
                curvine_libsdk::python::python_abi::_$LT$impl$u20$curvine_libsdk..python..python_abi..python_io_curvine_curvine_native_mkdir..MakeDef$GT$::_PYO3_DEF::trampoline::he964c70bb0259eca in curvine_libsdk.curvine_libsdk.73d1ab1ccdf2bec-cgu.15.rcgu.o
                curvine_libsdk::python::python_abi::_$LT$impl$u20$curvine_libsdk..python..python_abi..python_io_curvine_curvine_native_rename..MakeDef$GT$::_PYO3_DEF::trampoline::h750af222637f9962 in curvine_libsdk.curvine_libsdk.73d1ab1ccdf2bec-cgu.15.rcgu.o
                pyo3::types::boolobject::_$LT$impl$u20$pyo3..conversion..FromPyObject$u20$for$u20$bool$GT$::extract_bound::h459c3f925f7caf0a in libpyo3-e4dddc6720d0f117.rlib[18](pyo3-e4dddc6720d0f117.pyo3.778925ced38c08b5-cgu.15.rcgu.o)
                pyo3::types::boolobject::_$LT$impl$u20$pyo3..conversion..FromPyObject$u20$for$u20$bool$GT$::extract_bound::h459c3f925f7caf0a in libpyo3-e4dddc6720d0f117.rlib[18](pyo3-e4dddc6720d0f117.pyo3.778925ced38c08b5-cgu.15.rcgu.o)
          ld: symbol(s) not found for architecture arm64
          clang: error: linker command failed with exit code 1 (use -v to see invocation)


error: could not compile `curvine-libsdk` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
Cargo build failed. Exiting...
make: *** [build] Error 1
```