### PR TITLE
refactor: optimize metadata data storage

### DIFF
--- a/curvine-server/src/master/journal/journal_loader.rs
+++ b/curvine-server/src/master/journal/journal_loader.rs
@@ -82,7 +82,8 @@ impl JournalLoader {
         let mut fs_dir = self.fs_dir.write();
         fs_dir.update_last_inode_id(entry.dir.id)?;
         let inp = InodePath::resolve(fs_dir.root_ptr(), entry.path)?;
-        let _ = fs_dir.add_last_inode(inp, Dir(entry.dir))?;
+        let name = inp.name().to_string();
+        let _ = fs_dir.add_last_inode(inp, Dir(name, entry.dir))?;
         Ok(())
     }
 
@@ -90,7 +91,8 @@ impl JournalLoader {
         let mut fs_dir = self.fs_dir.write();
         fs_dir.update_last_inode_id(entry.file.id)?;
         let inp = InodePath::resolve(fs_dir.root_ptr(), entry.path)?;
-        let _ = fs_dir.add_last_inode(inp, File(entry.file))?;
+        let name = inp.name().to_string();
+        let _ = fs_dir.add_last_inode(inp, File(name, entry.file))?;
         Ok(())
     }
 

--- a/curvine-server/src/master/journal/journal_writer.rs
+++ b/curvine-server/src/master/journal/journal_writer.rs
@@ -106,11 +106,16 @@ impl JournalWriter {
         self.send(JournalEntry::CreateFile(entry))
     }
 
-    pub fn log_append_file(&self, op_ms: u64, inp: &InodePath) -> FsResult<()> {
+    pub fn log_append_file<P: AsRef<str>>(
+        &self,
+        op_ms: u64,
+        path: P,
+        file: &InodeFile,
+    ) -> FsResult<()> {
         let entry = AppendFileEntry {
             op_ms,
-            path: inp.path().to_string(),
-            file: inp.clone_last_file()?,
+            path: path.as_ref().to_string(),
+            file: file.clone(),
         };
         self.send(JournalEntry::AppendFile(entry))
     }
@@ -196,11 +201,17 @@ impl JournalWriter {
         self.send(JournalEntry::SetAttr(entry))
     }
 
-    pub fn log_symlink(&self, op_ms: u64, link: &InodePath, force: bool) -> FsResult<()> {
+    pub fn log_symlink<P: AsRef<str>>(
+        &self,
+        op_ms: u64,
+        link: P,
+        new_inode: InodeFile,
+        force: bool,
+    ) -> FsResult<()> {
         let entry = SymlinkEntry {
             op_ms,
-            link: link.path().to_string(),
-            new_inode: link.clone_last_file()?,
+            link: link.as_ref().to_string(),
+            new_inode,
             force,
         };
         self.send(JournalEntry::Symlink(entry))

--- a/curvine-server/src/master/meta/feature/file_feature.rs
+++ b/curvine-server/src/master/meta/feature/file_feature.rs
@@ -46,6 +46,10 @@ impl FileFeature {
         self.x_attr = map
     }
 
+    pub fn complete_write(&mut self) {
+        self.file_write = None;
+    }
+
     pub fn set_writing(&mut self, client_name: String) {
         let _ = self.file_write.replace(WriteFeature::new(client_name));
     }

--- a/curvine-server/src/master/meta/inode/inode_dir.rs
+++ b/curvine-server/src/master/meta/inode/inode_dir.rs
@@ -93,7 +93,7 @@ impl InodeDir {
         for child in self.children.iter() {
             let t = if child.is_dir() { "dir" } else { "file" };
 
-            println!("{} {}", t, child.id());
+            println!("{} {} {}", t, child.id(), child.name());
         }
     }
 

--- a/curvine-server/src/master/meta/inode/inode_dir.rs
+++ b/curvine-server/src/master/meta/inode/inode_dir.rs
@@ -26,7 +26,6 @@ use serde::{Deserialize, Serialize};
 pub struct InodeDir {
     pub(crate) id: i64,
     pub(crate) parent_id: i64,
-    pub(crate) name: String,
     pub(crate) mtime: i64,
     pub(crate) atime: i64,
     pub(crate) storage_policy: StoragePolicy,
@@ -38,11 +37,10 @@ pub struct InodeDir {
 }
 
 impl InodeDir {
-    pub fn new(id: i64, name: &str, time: i64) -> Self {
+    pub fn new(id: i64, time: i64) -> Self {
         Self {
             id,
             parent_id: EMPTY_PARENT_ID,
-            name: name.to_string(),
             mtime: time,
             atime: time,
             storage_policy: Default::default(),
@@ -51,11 +49,10 @@ impl InodeDir {
         }
     }
 
-    pub fn with_opts(id: i64, name: &str, time: i64, opts: MkdirOpts) -> Self {
+    pub fn with_opts(id: i64, time: i64, opts: MkdirOpts) -> Self {
         Self {
             id,
             parent_id: EMPTY_PARENT_ID,
-            name: name.to_string(),
             mtime: time,
             atime: time,
             storage_policy: opts.storage_policy,
@@ -96,7 +93,7 @@ impl InodeDir {
         for child in self.children.iter() {
             let t = if child.is_dir() { "dir" } else { "file" };
 
-            println!("{} {}, {}", t, child.id(), child.name());
+            println!("{} {}", t, child.id());
         }
     }
 
@@ -112,22 +109,18 @@ impl InodeDir {
         self.children.len()
     }
 
-    pub fn add_file_child(&mut self, file: InodeFile) -> CommonResult<InodePtr> {
-        self.add_child(File(file))
+    pub fn add_file_child(&mut self, name: &str, file: InodeFile) -> CommonResult<InodePtr> {
+        self.add_child(File(name.to_string(), file))
     }
 
-    pub fn add_dir_child(&mut self, dir: InodeDir) -> CommonResult<InodePtr> {
-        self.add_child(Dir(dir))
+    pub fn add_dir_child(&mut self, name: &str, dir: InodeDir) -> CommonResult<InodePtr> {
+        self.add_child(Dir(name.to_string(), dir))
     }
 }
 
 impl Inode for InodeDir {
     fn id(&self) -> i64 {
         self.id
-    }
-
-    fn name(&self) -> &str {
-        &self.name
     }
 
     fn parent_id(&self) -> i64 {

--- a/curvine-server/src/master/meta/inode/inode_file.rs
+++ b/curvine-server/src/master/meta/inode/inode_file.rs
@@ -25,7 +25,6 @@ use std::fmt::Debug;
 pub struct InodeFile {
     pub(crate) id: i64,
     pub(crate) parent_id: i64,
-    pub(crate) name: String,
     pub(crate) file_type: FileType,
     pub(crate) mtime: i64,
     pub(crate) atime: i64,
@@ -44,14 +43,12 @@ pub struct InodeFile {
 }
 
 impl InodeFile {
-    pub fn new(id: i64, name: &str, time: i64) -> Self {
+    pub fn new(id: i64, time: i64) -> Self {
         Self {
             id,
-            name: name.to_string(),
             file_type: FileType::File,
             mtime: time,
             atime: time,
-
             len: 0,
             block_size: 0,
             replicas: 0,
@@ -65,14 +62,12 @@ impl InodeFile {
         }
     }
 
-    pub fn with_opts(id: i64, name: &str, time: i64, opts: CreateFileOpts) -> InodeFile {
+    pub fn with_opts(id: i64, time: i64, opts: CreateFileOpts) -> InodeFile {
         let mut file = Self {
             id,
-            name: name.to_string(),
             file_type: opts.file_type,
             mtime: time,
             atime: time,
-
             len: 0,
             block_size: opts.block_size,
             replicas: opts.replicas,
@@ -95,14 +90,12 @@ impl InodeFile {
         file
     }
 
-    pub fn with_link(id: i64, name: &str, time: i64, target: impl Into<String>, mode: u32) -> Self {
+    pub fn with_link(id: i64, time: i64, target: impl Into<String>, mode: u32) -> Self {
         Self {
             id,
-            name: name.to_string(),
             file_type: FileType::Link,
             mtime: time,
             atime: time,
-
             len: 0,
             block_size: 0,
             replicas: 0,
@@ -215,10 +208,9 @@ impl InodeFile {
 
     pub fn simple_string(&self) -> String {
         format!(
-            "id={}, pid={}, name={}, len={}, blocks={:?}",
+            "id={}, pid={}, len={}, blocks={:?}",
             self.id,
             self.parent_id,
-            self.name,
             self.len,
             self.block_ids()
         )
@@ -228,10 +220,6 @@ impl InodeFile {
 impl Inode for InodeFile {
     fn id(&self) -> i64 {
         self.id
-    }
-
-    fn name(&self) -> &str {
-        &self.name
     }
 
     fn parent_id(&self) -> i64 {

--- a/curvine-server/src/master/meta/inode/inode_path.rs
+++ b/curvine-server/src/master/meta/inode/inode_path.rs
@@ -47,7 +47,7 @@ impl InodePath {
             index += 1;
             let child_name: &str = components[index].as_str();
             match cur_inode.as_mut() {
-                Dir(d) => {
+                Dir(_, d) => {
                     if let Some(child) = d.get_child_ptr(child_name) {
                         cur_inode = child;
                     } else {
@@ -56,7 +56,7 @@ impl InodePath {
                     }
                 }
 
-                File(_) => {
+                File(_, _) => {
                     // The current path is a file, there is no need to search again.
                     break;
                 }

--- a/curvine-server/src/master/meta/inode/mod.rs
+++ b/curvine-server/src/master/meta/inode/mod.rs
@@ -46,9 +46,6 @@ pub trait Inode {
     // inode id
     fn id(&self) -> i64;
 
-    // inode name
-    fn name(&self) -> &str;
-
     // Previous level id.
     fn parent_id(&self) -> i64;
 

--- a/curvine-server/src/master/meta/inode/ttl/ttl_checker.rs
+++ b/curvine-server/src/master/meta/inode/ttl/ttl_checker.rs
@@ -19,6 +19,7 @@ use crate::master::meta::inode::ttl::ttl_types::{
     TtlAction, TtlCleanupConfig, TtlCleanupResult, TtlResult,
 };
 use crate::master::meta::inode::InodeView;
+use curvine_common::state::StoragePolicy;
 use log::{debug, error, info, warn};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -187,6 +188,7 @@ impl InodeTtlChecker {
         let storage_policy = match &inode_view {
             InodeView::File(_, file) => &file.storage_policy,
             InodeView::Dir(_, dir) => &dir.storage_policy,
+            InodeView::FileEntry(..) => &StoragePolicy::default(),
         };
 
         let action = &storage_policy.ttl_action;

--- a/curvine-server/src/master/meta/inode/ttl/ttl_checker.rs
+++ b/curvine-server/src/master/meta/inode/ttl/ttl_checker.rs
@@ -185,8 +185,8 @@ impl InodeTtlChecker {
         };
 
         let storage_policy = match &inode_view {
-            InodeView::File(file) => &file.storage_policy,
-            InodeView::Dir(dir) => &dir.storage_policy,
+            InodeView::File(_, file) => &file.storage_policy,
+            InodeView::Dir(_, dir) => &dir.storage_policy,
         };
 
         let action = &storage_policy.ttl_action;

--- a/curvine-server/src/master/meta/inode/ttl/ttl_executor.rs
+++ b/curvine-server/src/master/meta/inode/ttl/ttl_executor.rs
@@ -104,6 +104,10 @@ impl InodeTtlExecutor {
                     };
                     return Ok(dir_path);
                 }
+                InodeView::FileEntry(name, _) => {
+                    // For empty files, we can't determine parent_id, so return a basic path
+                    return Ok(format!("/{}", name));
+                }
             }
         }
 
@@ -223,6 +227,13 @@ impl InodeTtlExecutor {
                     warn!("Cannot free directory: {}", path);
                     Err(TtlError::ActionExecutionError(format!(
                         "Cannot free directory: {}",
+                        path
+                    )))
+                }
+                InodeView::FileEntry(..) => {
+                    warn!("Cannot free empty file: {}", path);
+                    Err(TtlError::ActionExecutionError(format!(
+                        "Cannot free empty file: {}",
                         path
                     )))
                 }

--- a/curvine-server/src/master/meta/inode/ttl/ttl_executor.rs
+++ b/curvine-server/src/master/meta/inode/ttl/ttl_executor.rs
@@ -86,21 +86,21 @@ impl InodeTtlExecutor {
 
         if let Ok(Some(inode_view)) = self.inode_store.get_inode(inode_id) {
             match &inode_view {
-                InodeView::File(file) => {
+                InodeView::File(name, file) => {
                     let parent_path = self.build_path_recursive(file.parent_id())?;
                     let file_path = if parent_path == "/" {
-                        format!("/{}", file.name())
+                        format!("/{}", name)
                     } else {
-                        format!("{}/{}", parent_path, file.name())
+                        format!("{}/{}", parent_path, name)
                     };
                     return Ok(file_path);
                 }
-                InodeView::Dir(dir) => {
+                InodeView::Dir(name, dir) => {
                     let parent_path = self.build_path_recursive(dir.parent_id())?;
                     let dir_path = if parent_path == "/" {
-                        format!("/{}", dir.name())
+                        format!("/{}", name)
                     } else {
-                        format!("{}/{}", parent_path, dir.name())
+                        format!("{}/{}", parent_path, name)
                     };
                     return Ok(dir_path);
                 }
@@ -208,7 +208,7 @@ impl InodeTtlExecutor {
 
         if let Some(inode) = self.get_inode_from_store(inode_id)? {
             match &inode {
-                InodeView::File(file) => {
+                InodeView::File(_, file) => {
                     info!(
                         "Executing Inode ttl free operation for file: inode={}, path={}",
                         inode_id, path
@@ -219,7 +219,7 @@ impl InodeTtlExecutor {
                     info!("Inode ttl free completed: {}", path);
                     Ok(())
                 }
-                InodeView::Dir(_) => {
+                InodeView::Dir(_, _) => {
                     warn!("Cannot free directory: {}", path);
                     Err(TtlError::ActionExecutionError(format!(
                         "Cannot free directory: {}",

--- a/curvine-server/src/master/meta/store/inode_store.rs
+++ b/curvine-server/src/master/meta/store/inode_store.rs
@@ -74,6 +74,7 @@ impl InodeStore {
                     self.fs_stats.increment_dir_count();
                 }
             }
+            InodeView::FileEntry(..) => self.fs_stats.increment_file_count(),
         }
 
         Ok(())
@@ -125,6 +126,10 @@ impl InodeStore {
                     for item in dir.children_iter() {
                         stack.push_back((inode.id(), item))
                     }
+                }
+
+                InodeView::FileEntry(..) => {
+                    deleted_files += 1;
                 }
             }
         }
@@ -267,6 +272,7 @@ impl InodeStore {
                             dir_count += 1;
                         }
                     }
+                    InodeView::FileEntry(..) => file_count += 1,
                 }
 
                 parent.add_child(inode)?

--- a/curvine-server/src/master/meta/store/inode_store.rs
+++ b/curvine-server/src/master/meta/store/inode_store.rs
@@ -67,8 +67,8 @@ impl InodeStore {
         }
 
         match child {
-            InodeView::File(_) => self.fs_stats.increment_file_count(),
-            InodeView::Dir(dir) => {
+            InodeView::File(_, _) => self.fs_stats.increment_file_count(),
+            InodeView::Dir(_, dir) => {
                 // Don't count root directory
                 if dir.id != ROOT_INODE_ID {
                     self.fs_stats.increment_dir_count();
@@ -100,7 +100,7 @@ impl InodeStore {
             }
 
             match inode {
-                InodeView::File(file) => {
+                InodeView::File(_, file) => {
                     deleted_files += 1;
                     for meta in &file.blocks {
                         if meta.is_writing() {
@@ -117,7 +117,7 @@ impl InodeStore {
                     }
                 }
 
-                InodeView::Dir(dir) => {
+                InodeView::Dir(_, dir) => {
                     // Don't count root directory
                     if dir.id != ROOT_INODE_ID {
                         deleted_dirs += 1;
@@ -260,8 +260,8 @@ impl InodeStore {
 
                 // Count files and directories during tree reconstruction
                 match &inode {
-                    InodeView::File(_) => file_count += 1,
-                    InodeView::Dir(dir) => {
+                    InodeView::File(_, _) => file_count += 1,
+                    InodeView::Dir(_, dir) => {
                         // Don't count root directory
                         if dir.id != ROOT_INODE_ID {
                             dir_count += 1;

--- a/curvine-server/tests/inode_test.rs
+++ b/curvine-server/tests/inode_test.rs
@@ -20,12 +20,12 @@ use orpc::CommonResult;
 
 #[test]
 fn inode_dir() {
-    let mut root = InodeDir::new(0, "123", 0);
+    let mut root = InodeDir::new(0, 0);
     println!("{:?}", root);
-    root.add_file_child(InodeFile::new(1, "aa1", 0)).unwrap();
-    root.add_file_child(InodeFile::new(2, "aa3", 0)).unwrap();
-    root.add_file_child(InodeFile::new(3, "aa2", 0)).unwrap();
-    root.add_file_child(InodeFile::new(5, "b", 0)).unwrap();
+    root.add_file_child("aa1", InodeFile::new(1, 0)).unwrap();
+    root.add_file_child("aa3", InodeFile::new(2, 0)).unwrap();
+    root.add_file_child("aa2", InodeFile::new(3, 0)).unwrap();
+    root.add_file_child("b", InodeFile::new(5, 0)).unwrap();
 
     root.print_child();
 


### PR DESCRIPTION
- remove the name field from INode
- store the file directly in store and only maintain a simple FileEntry in memory