### PR TITLE
feat: support setting the quota_rate parameter in mount point

### DIFF
--- a/curvine-cli/src/cmds/mount.rs
+++ b/curvine-cli/src/cmds/mount.rs
@@ -63,6 +63,10 @@ pub struct MountCommand {
 
     #[arg(short, long)]
     storage_type: Option<String>,
+
+    /// Set quota rate limit for the mount point as a ratio of cluster capacity (0.0-1.0, e.g., 0.5 for 50%)
+    #[arg(long = "quota-rate")]
+    quota_rate: Option<f64>,
 }
 
 impl MountCommand {
@@ -175,6 +179,12 @@ impl MountCommand {
         }
         if let Some(storage_type) = self.storage_type.as_ref() {
             opts = opts.storage_type(StorageType::try_from(storage_type.as_str())?);
+        }
+        if let Some(quota_rate) = self.quota_rate {
+            if quota_rate <= 0.0 || quota_rate > 1.0 {
+                return err_box!("quota rate must be in range (0.0, 1.0], got {}", quota_rate);
+            }
+            opts = opts.quota_rate(quota_rate);
         }
 
         Ok(opts.build())

--- a/curvine-common/proto/mount.proto
+++ b/curvine-common/proto/mount.proto
@@ -24,6 +24,7 @@ message MountInfoProto {
     optional int64 block_size = 9;
     optional int32 replicas = 10;
     required MountTypeProto mount_type = 11;
+    optional double quota_rate = 12;
 }
 
 message MountOptionsProto {
@@ -37,6 +38,7 @@ message MountOptionsProto {
     optional int32 replicas = 8;
     required MountTypeProto mount_type = 9;
     repeated string remove_properties = 10;
+    optional double quota_rate = 11;
 }
 
 enum ConsistencyStrategyProto {

--- a/curvine-common/src/state/mount.rs
+++ b/curvine-common/src/state/mount.rs
@@ -89,7 +89,7 @@ impl TryFrom<&str> for ConsistencyStrategy {
 }
 
 /// Mount information structure
-#[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq, Default)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Default)]
 pub struct MountInfo {
     pub cv_path: String,
     pub ufs_path: String,
@@ -102,6 +102,7 @@ pub struct MountInfo {
     pub block_size: Option<i64>,
     pub replicas: Option<i32>,
     pub mount_type: MountType,
+    pub quota_rate: Option<f64>,
 }
 
 impl MountInfo {
@@ -156,6 +157,7 @@ pub struct MountOptions {
     pub replicas: Option<i32>,
     pub mount_type: MountType,
     pub remove_properties: Vec<String>,
+    pub quota_rate: Option<f64>,
 }
 
 impl MountOptions {
@@ -179,6 +181,7 @@ impl MountOptions {
             block_size: self.block_size,
             replicas: self.replicas,
             mount_type: self.mount_type,
+            quota_rate: self.quota_rate,
         }
     }
 }
@@ -195,6 +198,7 @@ pub struct MountOptionsBuilder {
     replicas: Option<i32>,
     mount_type: MountType,
     remove_properties: Vec<String>,
+    quota_rate: Option<f64>,
 }
 
 impl MountOptionsBuilder {
@@ -266,6 +270,11 @@ impl MountOptionsBuilder {
         self
     }
 
+    pub fn quota_rate(mut self, quota_rate: f64) -> Self {
+        self.quota_rate = Some(quota_rate);
+        self
+    }
+
     pub fn build(self) -> MountOptions {
         MountOptions {
             update: self.update,
@@ -278,6 +287,7 @@ impl MountOptionsBuilder {
             replicas: self.replicas,
             mount_type: self.mount_type,
             remove_properties: self.remove_properties,
+            quota_rate: self.quota_rate,
         }
     }
 }

--- a/curvine-common/src/utils/proto_utils.rs
+++ b/curvine-common/src/utils/proto_utils.rs
@@ -511,6 +511,7 @@ impl ProtoUtils {
             block_size: info.block_size,
             replicas: info.replicas,
             mount_type: info.mount_type.into(),
+            quota_rate: info.quota_rate,
         }
     }
 
@@ -527,6 +528,7 @@ impl ProtoUtils {
             block_size: info.block_size,
             replicas: info.replicas,
             mount_type: info.mount_type.into(),
+            quota_rate: info.quota_rate,
         }
     }
 
@@ -542,6 +544,7 @@ impl ProtoUtils {
             replicas: opts.replicas,
             mount_type: opts.mount_type.into(),
             remove_properties: opts.remove_properties,
+            quota_rate: opts.quota_rate,
         }
     }
 
@@ -557,6 +560,7 @@ impl ProtoUtils {
             replicas: opts.replicas,
             mount_type: MountType::from(opts.mount_type),
             remove_properties: opts.remove_properties,
+            quota_rate: opts.quota_rate,
         }
     }
 

--- a/curvine-server/src/master/meta/fs_stats.rs
+++ b/curvine-server/src/master/meta/fs_stats.rs
@@ -53,7 +53,7 @@ impl FileSystemStats {
 
     pub fn set_counts(&self, file_count: i64, dir_count: i64) {
         self.metrics.inode_file_num.set(file_count);
-        self.metrics.inode_file_num.set(dir_count);
+        self.metrics.inode_dir_num.set(dir_count);
     }
 }
 

--- a/curvine-server/src/master/mount/mount_manager.rs
+++ b/curvine-server/src/master/mount/mount_manager.rs
@@ -83,8 +83,8 @@ impl MountManager {
         ufs_path: &str,
         mnt_opt: &MountOptions,
     ) -> FsResult<()> {
-        if !self.mount_table.exists(cv_path) {
-            return err_box!("update mode: mount point {} does not exist", ufs_path);
+        if !self.mount_table.cv_path_exists(cv_path) {
+            return err_box!("update mode: mount point {} does not exist", cv_path);
         }
 
         self.mount_table.umount(cv_path)?;

--- a/curvine-server/src/master/mount/mount_table.rs
+++ b/curvine-server/src/master/mount/mount_table.rs
@@ -68,6 +68,11 @@ impl MountTable {
         false
     }
 
+    pub fn cv_path_exists(&self, cv_path: &str) -> bool {
+        let inner = self.inner.read().unwrap();
+        inner.mountpath2id.contains_key(cv_path)
+    }
+
     pub fn check_conflict(&self, cv_path: &str, _ufs_path: &str) -> FsResult<()> {
         let inner = self.inner.read().unwrap();
         for info in inner.mountid2entry.values() {


### PR DESCRIPTION
Support setting the quota_size parameter in mount point

#### Create mount point，with 10GB quota
`./build/dist/bin/cv mount s3://bucket/path /mount/point --quota-size 10GB`

#### Update quota to 20GB
`./build/dist/bin/cv mount s3://bucket/path /mount/point --quota-size 20GB --update`

#### Remove quota restrictions
`./build/dist/bin/cv mount s3://bucket/path /mount/point --update`

#### Re-add quota
`./build/dist/bin/cv mount s3://bucket/path /mount/point --quota-size 15GB --update`