### PR TITLE
fix: fuse cp file to s3 and hdfs error number handle

### DIFF
--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -197,7 +197,7 @@ impl CurvineFileSystem {
             Err(e) => {
                 return match e {
                     FsError::FileNotFound(_) => err_fuse!(libc::ENOENT, "{}", e),
-                    _ => err_fuse!(libc::ENOSYS, "{}", e),
+                    _ => Err(FuseError::from(e)),
                 }
             }
         };

--- a/curvine-ufs/src/s3/s3_filesystem.rs
+++ b/curvine-ufs/src/s3/s3_filesystem.rs
@@ -28,6 +28,7 @@ use aws_sdk_s3::Client;
 use aws_smithy_types::error::display::DisplayErrorContext;
 use aws_types::region::Region;
 use aws_types::SdkConfig;
+use curvine_common::error::FsError;
 use curvine_common::fs::{FileSystem, Path};
 use curvine_common::state::{FileStatus, FileType, SetAttrOpts};
 use curvine_common::FsResult;
@@ -447,7 +448,7 @@ impl FileSystem<S3Writer, S3Reader> for S3FileSystem {
     async fn get_status(&self, path: &Path) -> FsResult<FileStatus> {
         let res = self.get_file_status(path).await?;
         match res {
-            None => err_ufs!("Path {} not found", path.full_path()),
+            None => Err(FsError::file_not_found(path.full_path())),
             Some(v) => Ok(v),
         }
     }


### PR DESCRIPTION
1. Enhance the conversion processing from curvine error to fuse error, ensuring that fuse can recognize more sys error no
2. Fixed S3 write status error and segmented upload complete logic
3. Fixing the issue of incorrect return due to HDFS permission errors