### PR TITLE
feat: support access to HDFS with Kerberos authentication enabled

### DIFF
--- a/curvine-cli/src/cmds/mount.rs
+++ b/curvine-cli/src/cmds/mount.rs
@@ -103,6 +103,19 @@ impl MountCommand {
             }
         }
 
+        // If any Kerberos-related config is present, require both principal and keytab.
+        let kerberos_present = configs.keys().any(|k| k.starts_with("hdfs.kerberos."));
+        if kerberos_present {
+            let has_principal = configs.contains_key("hdfs.kerberos.principal");
+            let has_keytab = configs.contains_key("hdfs.kerberos.keytab");
+            if !(has_principal && has_keytab) {
+                eprintln!(
+                    "Error: When using Kerberos, both 'hdfs.kerberos.principal' and 'hdfs.kerberos.keytab' must be provided via --config"
+                );
+                std::process::exit(1);
+            }
+        }
+
         let validation_result = validate_path_and_configs(&self.ufs_path, &configs);
         if let Err(error_msg) = validation_result {
             eprintln!("Error: {}", error_msg);

--- a/curvine-ufs/src/opendal.rs
+++ b/curvine-ufs/src/opendal.rs
@@ -323,6 +323,22 @@ impl OpendalFileSystem {
                     builder = builder.user(&user);
                 }
 
+                if let Some(principal) = conf.get("hdfs.kerberos.principal") {
+                    builder = builder.kerberos_principal(principal);
+                }
+
+                if let Some(keytab) = conf.get("hdfs.kerberos.keytab") {
+                    builder = builder.kerberos_keytab(keytab);
+                }
+
+                if let Some(ccache) = conf.get("hdfs.kerberos.ccache") {
+                    std::env::set_var("KRB5CCNAME", ccache);
+                }
+
+                if let Some(krb5_conf) = conf.get("hdfs.kerberos.krb5_conf") {
+                    std::env::set_var("KRB5_CONFIG", krb5_conf);
+                }
+
                 if conf
                     .get("hdfs.atomic_write_dir")
                     .map(|s| s == "true")


### PR DESCRIPTION
Now you can mount an HDFS cluster with Kerberos authentication enabled using the following parameters, e.g.:
```
curvine mount hdfs://nn:8020/ /cv \
  -c hdfs.namenode=hdfs://nn:8020 \
  -c hdfs.kerberos.principal=user@REALM \
  -c hdfs.kerberos.keytab=/path/user.keytab
```
Optional parameters：
```
-c hdfs.kerberos.ccache=FILE:/tmp/krb5cc_curvine \
-c hdfs.kerberos.krb5_conf=/etc/krb5.conf
```
Validation: if any hdfs.kerberos.* is provided, both hdfs.kerberos.principal and hdfs.kerberos.keytab must be present; otherwise the command exits with a clear error.