### PR TITLE
feat: support access to HDFS with Kerberos authentication enabled

### DIFF
--- a/curvine-ufs/src/opendal.rs
+++ b/curvine-ufs/src/opendal.rs
@@ -323,16 +323,10 @@ impl OpendalFileSystem {
                     builder = builder.user(&user);
                 }
 
-                if let Some(principal) = conf.get("hdfs.kerberos.principal") {
-                    builder = builder.kerberos_principal(principal);
-                }
-
-                if let Some(keytab) = conf.get("hdfs.kerberos.keytab") {
-                    builder = builder.kerberos_keytab(keytab);
-                }
-
                 if let Some(ccache) = conf.get("hdfs.kerberos.ccache") {
-                    std::env::set_var("KRB5CCNAME", ccache);
+                    builder = builder.kerberos_ticket_cache_path(ccache);
+                } else if let Ok(ccache) = std::env::var("KRB5CCNAME") {
+                    builder = builder.kerberos_ticket_cache_path(&ccache);
                 }
 
                 if let Some(krb5_conf) = conf.get("hdfs.kerberos.krb5_conf") {


### PR DESCRIPTION
## Three Configuration Methods

### Method 1: Using Configuration Parameters (Recommended)
```bash
bin/cv mount hdfs://namenode:8020/data /mnt \
--config hdfs.kerberos.ccache=/tmp/krb5cc_1000
```

### Method 2: Using Environment Variables
```bash
export KRB5CCNAME=/tmp/krb5cc_1000
bin/cv mount hdfs://namenode:8020/data /mnt
```

### Method 3: Combining the Two
```bash
export KRB5CCNAME=/tmp/krb5cc_1000
bin/cv mount hdfs://namenode:8020/data /mnt \
--config hdfs.kerberos.krb5_conf=/etc/krb5.conf
```