### PR TITLE
docs: simplify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,25 +75,6 @@ Curvine adopts a modular design and is mainly composed of the following core com
 - Linux or macOS (Limited support on Windows)
 - FUSE library (for file system functionality)
 
-## 🗂️ Cached File System Access
-### 🦀 Rust API (Recommended for Native Integration)
-```
-use curvine_common::conf::ClusterConf;
-use curvine_common::fs::Path;
-use std::sync::Arc;
-
-let conf = ClusterConf::from(conf_path);
-let rt = Arc::new(conf.client_rpc_conf().create_runtime());
-let fs = CurvineFileSystem::with_rt(conf, rt)?;
-
-let path = Path::from_str("/dir")?;
-fs.mkdir(&path).await?;
-```
-
-### 📌 FUSE (Filesystem in Userspace)
-```
-ls /curvine-fuse
-```
 
 **Officially Supported Linux Distributions**​
 
@@ -105,17 +86,6 @@ ls /curvine-fuse
 | ​**RHEL 9**​        | ≥5.14.0            | 9.5            | fuse3-3.10.2 |
 | ​**Ubuntu 22**​      | ≥5.15.0            | 22.4           | fuse3-3.10.5 |
 
-### 🐘 Hadoop Compatible API
-```
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.*;
-
-Configuration conf = new Configuration();
-conf.set("fs.cv.impl", "io.curvine.CurvineFileSystem");
-
-FileSystem fs = FileSystem.get(URI.create("cv://master:8995"), conf);
-FSDataInputStream in = fs.open(new Path("/user/test/file.txt"));
-```
 
 ## 🛠 Build Instructions
 


### PR DESCRIPTION
Removed sections on Cached File System Access and Hadoop Compatible API from README.