### PR TITLE
docs: add guidelines for reporting security vulnerabilities

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,18 +1,33 @@
 # Security Policy
 
-## Supported Versions
+## Reporting Security Vulnerabilities
 
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
+### Please do not report security vulnerabilities through public GitHub issues.
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 0.1.x   | :white_check_mark: |
 
-## Reporting a Vulnerability
+If you discover a security vulnerability, please report it by emailing curvine86@gmail.com.
 
-Use this section to tell people how to report a vulnerability.
+Please include the following information in your report:
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+Description of the vulnerability
+Steps to reproduce the issue
+Affected versions
+Potential impact
+Any suggested fixes (if available)
+
+# Response Timeline
+We will acknowledge your report within 5 business days and provide a detailed response within 15 business days indicating the next steps in handling your report.
+
+We will keep you informed of the progress towards a fix and may ask for additional information or guidance.
+
+# Security Updates
+Security updates will be released as soon as possible after a fix is available. 
+We recommend keeping your installation up to date with the latest releases.
+
+# Security Best Practices
+When using Curvine, we recommend:
+
+Keep the software updated to the latest version
+Follow the principle of least privilege
+Review and audit your configurations regularly
+Thank you for helping to keep Curvine and our users safe!


### PR DESCRIPTION
Added detailed guidelines for reporting security vulnerabilities and best practices.