### PR TITLE
docs: create CONTRIBUTORS.md for project contributors

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,19 @@
+# Contributors
+
+This document lists the maintainers and contributors of Curvine project.
+
+## Current Maintainers
+
+| Name | Email | GitHub | Role |
+|------|-------|--------|------|
+| David Fu | curvine86@gmail.com | @szbr9486 | Lead Maintainer |
+| SeanX | -- | @bigbigxu | Maintainer |
+| Barry | lzj7179@163.com | @lzjqsdd | Maintainer |
+| John | hellojlong@163.com| @jlon | Maintainer |
+
+## Contributors
+
+| Name | Email | GitHub |
+|------|-------|--------|
+| joss | 1186093704@qq.com | @201341 |
+| Junfan Zhang | zuston@apache.org | @zuston |


### PR DESCRIPTION
Added a CONTRIBUTORS.md file listing maintainers and contributors.