### PR TITLE
feat: add ufs_mtime attribute to set_attr interface

### DIFF
--- a/curvine-cli/src/cmds/fs/mkdir.rs
+++ b/curvine-cli/src/cmds/fs/mkdir.rs
@@ -3,7 +3,6 @@ use curvine_client::unified::UnifiedFileSystem;
 use curvine_common::fs::{CurvineURI, FileSystem};
 use curvine_common::state::SetAttrOpts;
 use orpc::CommonResult;
-use std::collections::HashMap;
 
 #[derive(Subcommand, Debug)]
 pub enum MkdirCommand {
@@ -28,19 +27,10 @@ impl MkdirCommand {
                 let gid = orpc::sys::get_gid();
                 let owner = orpc::sys::get_username_by_uid(uid);
                 let group = orpc::sys::get_groupname_by_gid(gid);
-                let add_x_attr = HashMap::new();
                 let opts = SetAttrOpts {
-                    recursive: false,
-                    replicas: None,
                     owner,
                     group,
-                    mode: None,
-                    atime: None,
-                    mtime: None,
-                    ttl_ms: None,
-                    ttl_action: None,
-                    add_x_attr,
-                    remove_x_attr: Vec::new(),
+                    ..Default::default()
                 };
                 client.set_attr(&path, opts).await?;
 

--- a/curvine-client/src/file/curvine_filesystem.rs
+++ b/curvine-client/src/file/curvine_filesystem.rs
@@ -113,7 +113,7 @@ impl CurvineFileSystem {
         Ok(writer)
     }
 
-    fn create_opts_builder(&self) -> CreateFileOptsBuilder {
+    pub fn create_opts_builder(&self) -> CreateFileOptsBuilder {
         CreateFileOptsBuilder::with_conf(&self.fs_context.conf.client)
             .client_name(self.fs_context.clone_client_name())
     }
@@ -236,14 +236,11 @@ impl CurvineFileSystem {
             return err_box!("mount path can not be root");
         }
 
-        if !opts.update
-            && opts.mount_type == MountType::Cst
-            && ufs_path.authority_path() != cv_path.path()
-        {
+        if !opts.update && opts.mount_type == MountType::Cst && ufs_path.path() != cv_path.path() {
             return err_box!(
                 "for Cst mount type, the ufs path and the cv path must be identical. \
                      current ufs path: {},  current cv path: {}",
-                ufs_path.authority_path(),
+                ufs_path.path(),
                 cv_path.path()
             );
         }

--- a/curvine-common/proto/master.proto
+++ b/curvine-common/proto/master.proto
@@ -184,6 +184,7 @@ message SetAttrOptsProto {
     optional TtlActionProto ttl_action = 9;
     map<string, bytes> add_x_attr = 10;
     repeated string remove_x_attr = 11;
+    optional int64 ufs_mtime = 12;
 }
 
 message SetAttrRequest {

--- a/curvine-common/src/error/fs_error.rs
+++ b/curvine-common/src/error/fs_error.rs
@@ -331,6 +331,12 @@ impl From<tokio::sync::oneshot::error::RecvError> for FsError {
     }
 }
 
+impl From<Elapsed> for FsError {
+    fn from(value: Elapsed) -> Self {
+        Self::Timeout(ErrorImpl::with_source(value))
+    }
+}
+
 impl ErrorExt for FsError {
     fn ctx(self, ctx: impl Into<String>) -> Self {
         match self {

--- a/curvine-common/src/state/file_status.rs
+++ b/curvine-common/src/state/file_status.rs
@@ -81,4 +81,9 @@ impl FileStatus {
     pub fn exists_links(&self) -> bool {
         !self.is_dir && self.nlink > 1 && self.id > 0
     }
+
+    /// Returns true if the file exists only in Curvine and not in UFS
+    pub fn is_cv_only(&self) -> bool {
+        self.storage_policy.ufs_mtime == 0
+    }
 }

--- a/curvine-common/src/state/opts.rs
+++ b/curvine-common/src/state/opts.rs
@@ -356,6 +356,7 @@ pub struct SetAttrOpts {
     pub ttl_action: Option<TtlAction>,
     pub add_x_attr: HashMap<String, Vec<u8>>,
     pub remove_x_attr: Vec<String>,
+    pub ufs_mtime: Option<i64>,
 }
 
 impl SetAttrOpts {
@@ -373,6 +374,7 @@ impl SetAttrOpts {
             ttl_action: None,
             add_x_attr: HashMap::default(),
             remove_x_attr: vec![],
+            ufs_mtime: None,
         }
     }
 }
@@ -389,6 +391,7 @@ pub struct SetAttrOptsBuilder {
     ttl_action: Option<TtlAction>,
     add_x_attr: HashMap<String, Vec<u8>>,
     remove_x_attr: Vec<String>,
+    ufs_mtime: Option<i64>,
 }
 
 impl Default for SetAttrOptsBuilder {
@@ -411,6 +414,7 @@ impl SetAttrOptsBuilder {
             ttl_action: None,
             add_x_attr: HashMap::new(),
             remove_x_attr: vec![],
+            ufs_mtime: None,
         }
     }
 
@@ -469,6 +473,11 @@ impl SetAttrOptsBuilder {
         self
     }
 
+    pub fn ufs_mtime(mut self, mtime: i64) -> Self {
+        let _ = self.ufs_mtime.insert(mtime);
+        self
+    }
+
     pub fn build(self) -> SetAttrOpts {
         SetAttrOpts {
             recursive: self.recursive,
@@ -482,6 +491,7 @@ impl SetAttrOptsBuilder {
             ttl_action: self.ttl_action,
             add_x_attr: self.add_x_attr,
             remove_x_attr: self.remove_x_attr,
+            ufs_mtime: self.ufs_mtime,
         }
     }
 }

--- a/curvine-common/src/utils/proto_utils.rs
+++ b/curvine-common/src/utils/proto_utils.rs
@@ -441,6 +441,7 @@ impl ProtoUtils {
             ttl_action: opts.ttl_action.map(|v| v as i32),
             add_x_attr: opts.add_x_attr,
             remove_x_attr: opts.remove_x_attr,
+            ufs_mtime: opts.ufs_mtime,
         }
     }
 
@@ -457,6 +458,7 @@ impl ProtoUtils {
             ttl_action: opts.ttl_action.map(TtlAction::from),
             add_x_attr: opts.add_x_attr,
             remove_x_attr: opts.remove_x_attr,
+            ufs_mtime: opts.ufs_mtime,
         }
     }
 

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -473,17 +473,12 @@ impl CurvineFileSystem {
         }
 
         Ok(SetAttrOpts {
-            recursive: false,
-            replicas: None,
             owner,
             group,
             mode,
             atime,
             mtime,
-            ttl_ms: None,
-            ttl_action: None,
-            add_x_attr: HashMap::new(),
-            remove_x_attr: Vec::new(),
+            ..Default::default()
         })
     }
 

--- a/curvine-server/src/master/master_handler.rs
+++ b/curvine-server/src/master/master_handler.rs
@@ -158,6 +158,10 @@ impl MasterHandler {
         opts: CreateFileOpts,
         flags: OpenFlags,
     ) -> FsResult<FileBlocks> {
+        if flags.read_only() {
+            return self.fs.get_block_locations(&path);
+        }
+
         if self.check_is_retry(req_id)? {
             return self.fs.get_block_locations(&path);
         }

--- a/curvine-server/src/master/meta/inode/inode_view.rs
+++ b/curvine-server/src/master/meta/inode/inode_view.rs
@@ -378,6 +378,10 @@ impl InodeView {
         for key in opts.remove_x_attr {
             let _ = self.x_attr_mut().remove(&key);
         }
+
+        if let Some(ufs_mtime) = opts.ufs_mtime {
+            self.storage_policy_mut().ufs_mtime = ufs_mtime;
+        }
     }
 
     pub fn to_file_status(&self, path: &str) -> FileStatus {


### PR DESCRIPTION
Adds a ufs_mtime update feature to the set_attr interface.

Currently, in UFS, mtimeis generated only when a file is closed and cannot be modified afterward. In write-back cache scenarios, after data is synchronized from Curvine to UFS, it is necessary to retrieve the UFS mtimeand update it into Curvine’s metadata. This ensures that the mtimecan be used as a basis for subsequent consistency checks.