### PR TITLE
fix: (cli) resolve -h short flag conflicts in subcommands

### DIFF
--- a/curvine-cli/src/cmds/fs/commands.rs
+++ b/curvine-cli/src/cmds/fs/commands.rs
@@ -12,12 +12,7 @@ use crate::cmds::fs::{
 
 #[derive(Parser, Debug)]
 pub struct FsCommand {
-    #[clap(
-        short = 'c',
-        long,
-        global = true,
-        help = "Query only Curvine cached data"
-    )]
+    #[clap(long, global = true, help = "Query only Curvine cached data")]
     pub cache_only: bool,
 
     #[clap(subcommand)]
@@ -111,9 +106,12 @@ pub enum FsSubCommand {
     },
 
     /// Show disk usage statistics
+    #[command(disable_help_flag = true)]
     Df {
         #[clap(short, long, help = "Show human-readable sizes")]
         human_readable: bool,
+        #[clap(long, action = clap::ArgAction::Help, help = "Print help")]
+        help: Option<bool>,
     },
 
     /// Create an empty file or update timestamp
@@ -123,6 +121,7 @@ pub enum FsSubCommand {
     },
 
     /// Calculate directory space usage
+    #[command(disable_help_flag = true)]
     Du {
         #[clap(help = "Path of the directory to calculate")]
         path: String,
@@ -132,6 +131,9 @@ pub enum FsSubCommand {
 
         #[clap(short, long, help = "Display the names of columns as a header line")]
         verbose: bool,
+
+        #[clap(long, action = clap::ArgAction::Help, help = "Print help")]
+        help: Option<bool>,
     },
 
     /// Get file to local
@@ -264,9 +266,10 @@ impl FsCommand {
                 cat_cmd.execute(client).await
             }
 
-            FsSubCommand::Df { human_readable } => {
+            FsSubCommand::Df { human_readable, .. } => {
                 let df_cmd = DfCommand::Df {
                     human_readable: *human_readable,
+                    help: None,
                 };
                 df_cmd.execute(client).await
             }
@@ -280,11 +283,13 @@ impl FsCommand {
                 path,
                 human_readable,
                 verbose,
+                ..
             } => {
                 let du_cmd = DuCommand::Du {
                     path: path.clone(),
                     human_readable: *human_readable,
                     verbose: *verbose,
+                    help: None,
                 };
                 du_cmd.execute(client).await
             }

--- a/curvine-cli/src/cmds/fs/df.rs
+++ b/curvine-cli/src/cmds/fs/df.rs
@@ -8,13 +8,15 @@ pub enum DfCommand {
     Df {
         #[clap(short, long, help = "Show human-readable sizes")]
         human_readable: bool,
+        #[clap(long, action = clap::ArgAction::Help, help = "Print help")]
+        help: Option<bool>,
     },
 }
 
 impl DfCommand {
     pub async fn execute(&self, client: UnifiedFileSystem) -> CommonResult<()> {
         match self {
-            DfCommand::Df { human_readable } => {
+            DfCommand::Df { human_readable, .. } => {
                 // Get master info from the filesystem
                 match client.get_master_info().await {
                     Ok(master_info) => {

--- a/curvine-cli/src/cmds/fs/du.rs
+++ b/curvine-cli/src/cmds/fs/du.rs
@@ -15,6 +15,9 @@ pub enum DuCommand {
 
         #[clap(short, long, help = "Display the names of columns as a header line")]
         verbose: bool,
+
+        #[clap(long, action = clap::ArgAction::Help, help = "Print help")]
+        help: Option<bool>,
     },
 }
 
@@ -25,6 +28,7 @@ impl DuCommand {
                 path,
                 human_readable,
                 verbose,
+                ..
             } => {
                 let path = CurvineURI::new(path)?;
 


### PR DESCRIPTION
## Problem
build with debug version
``` shell
$ ./bin/cv fs --help

thread 'main' panicked at /home/gongxun/.cargo/registry/src/rsproxy.cn-e3de039b2554c837/clap_builder-4.5.44/src/builder/debug_asserts.rs:112:17:

Command fs: Short option names must be unique for each argument, but '-c' is in use by both 'cache_only' and 'conf

```
A similar conflict exists between --human-readable and --help, both of which were assigned the short option -h.

## Changes
- Disable auto-generated help flag for `df` and `du` subcommands
- Manually implement `--help` functionality
- Remove the `-c` short flag for `cache_only` option (still supports `--cache-only`)

## Breaking Changes
- The `cache_only` option no longer supports the `-c` short flag; use `--cache-only` instead
- For `df` and `du` commands, `-h` is only used for `--human-readable`; use `--help` for help information


## After fixed
``` shell
./bin/cv fs df --help
Show disk usage statistics

Usage: curvine-cli fs df [OPTIONS]

Options:
  -c, --conf <CONF>                  Configuration file path (optional)
      --cache-only                   Query only Curvine cached data
  -h, --human-readable               Show human-readable sizes
      --help                         Print help
      --master-addrs <MASTER_ADDRS>  Master address list (e.g., 'm1:8995,m2:8995')

./bin/cv fs du --help
Calculate directory space usage

Usage: curvine-cli fs du [OPTIONS] <PATH>

Arguments:
  <PATH>  Path of the directory to calculate

Options:
  -c, --conf <CONF>                  Configuration file path (optional)
      --cache-only                   Query only Curvine cached data
  -h, --human-readable               Show human-readable sizes
      --master-addrs <MASTER_ADDRS>  Master address list (e.g., 'm1:8995,m2:8995')
  -v, --verbose                      Display the names of columns as a header line
      --help                         Print help
```