### PR TITLE
refactor: improve error handling and optimize resource management in curvine filesystem classes

### DIFF
--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineFallbackInputStream.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineFallbackInputStream.java
@@ -14,14 +14,13 @@
 
 package io.curvine;
 
-import org.apache.hadoop.fs.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.annotation.Nonnull;
 import java.io.EOFException;
 import java.io.IOException;
 import java.util.function.Supplier;
+import javax.annotation.Nonnull;
+import org.apache.hadoop.fs.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class CurvineFallbackInputStream extends FSInputStream {
     public static final Logger LOGGER = LoggerFactory.getLogger(CurvineFallbackInputStream.class);
@@ -125,6 +124,7 @@ public class CurvineFallbackInputStream extends FSInputStream {
 
     @Override
     public long getPos() throws IOException {
+        checkClosed();
         if (ufsInputStream != null) {
             return ufsInputStream.getPos();
         } else {

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineFileSystem.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineFileSystem.java
@@ -14,22 +14,36 @@
 
 package io.curvine;
 
-import io.curvine.exception.CurvineException;
-import io.curvine.proto.*;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.StorageSize;
-import org.apache.hadoop.fs.*;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FSInputStream;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.FsStatus;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.util.Progressable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.net.URI;
-import java.util.Optional;
+import io.curvine.proto.FileStatusProto;
+import io.curvine.proto.GetFileStatusResponse;
+import io.curvine.proto.GetMasterInfoResponse;
+import io.curvine.proto.GetMountInfoResponse;
+import io.curvine.proto.ListStatusResponse;
+import io.curvine.proto.MountInfoProto;
 
 /****************************************************************
  * Implement the Hadoop FileSystem API for Curvine
@@ -39,10 +53,43 @@ import java.util.Optional;
 public class CurvineFileSystem extends FileSystem {
     public static final Logger LOGGER = LoggerFactory.getLogger(CurvineFileSystem.class);
 
+    /**
+     * Global cache for CurvineFsMount instances to avoid creating too many Tokio runtimes.
+     * Key: master_addrs (e.g., "master-0:8995")
+     * Value: CachedMount containing the shared CurvineFsMount and reference count
+     */
+    private static final ConcurrentHashMap<String, CachedMount> MOUNT_CACHE = new ConcurrentHashMap<>();
+    
+    private static class CachedMount {
+        final CurvineFsMount mount;
+        final AtomicInteger refCount;
+        
+        CachedMount(CurvineFsMount mount) {
+            this.mount = mount;
+            this.refCount = new AtomicInteger(1);
+        }
+    }
+    
+    static {
+        // Register shutdown hook to clean up all cached mounts
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            LOGGER.info("Shutting down CurvineFileSystem, closing {} cached mounts", MOUNT_CACHE.size());
+            for (CachedMount cached : MOUNT_CACHE.values()) {
+                try {
+                    cached.mount.close();
+                } catch (IOException e) {
+                    LOGGER.warn("Error closing cached mount", e);
+                }
+            }
+            MOUNT_CACHE.clear();
+        }));
+    }
+
     private CurvineFsMount libFs;
     private FilesystemConf filesystemConf;
     private Path workingDir;
     private URI uri;
+    private String cacheKey;  // Key used for mount cache lookup
 
     private int writeChunkSize;
     private int writeChunkNum;
@@ -100,12 +147,42 @@ public class CurvineFileSystem extends FileSystem {
 
         this.uri = URI.create(name.getScheme() + "://" + authority);
         this.workingDir = getHomeDirectory();
-        this.libFs = new CurvineFsMount(filesystemConf);
-
+        
+        this.cacheKey = filesystemConf.master_addrs;
+        this.libFs = getOrCreateMount(filesystemConf);
 
         StorageSize size = StorageSize.parse(filesystemConf.write_chunk_size);
         this.writeChunkSize = (int) size.getUnit().toBytes(size.getValue());
         this.writeChunkNum = filesystemConf.write_chunk_num;
+    }
+    
+    /**
+     * Get or create a cached CurvineFsMount instance.
+     * This method is thread-safe and ensures only one mount is created per master_addrs.
+     */
+    private CurvineFsMount getOrCreateMount(FilesystemConf conf) throws IOException {
+        String key = conf.master_addrs;
+        
+        CachedMount cached = MOUNT_CACHE.get(key);
+        if (cached != null) {
+            cached.refCount.incrementAndGet();
+            LOGGER.debug("Reusing cached CurvineFsMount for {}, refCount={}", key, cached.refCount.get());
+            return cached.mount;
+        }
+        
+        synchronized (MOUNT_CACHE) {
+            cached = MOUNT_CACHE.get(key);
+            if (cached != null) {
+                cached.refCount.incrementAndGet();
+                LOGGER.debug("Reusing cached CurvineFsMount for {} (after lock), refCount={}", key, cached.refCount.get());
+                return cached.mount;
+            }
+            
+            LOGGER.info("Creating new cached CurvineFsMount for {}", key);
+            CurvineFsMount newMount = new CurvineFsMount(conf);
+            MOUNT_CACHE.put(key, new CachedMount(newMount));
+            return newMount;
+        }
     }
 
     private String formatPath(Path path) {
@@ -155,13 +232,29 @@ public class CurvineFileSystem extends FileSystem {
     }
 
     @Override
+    public boolean exists(Path f) throws IOException {
+        if (statistics != null) {
+            statistics.incrementReadOps(1);
+        }
+        try {
+            getFileStatus(f);
+            return true;
+        } catch (FileNotFoundException e) {
+            return false;
+        }
+    }
+
+    @Override
     public boolean rename(Path src, Path dst) throws IOException {
         if (statistics != null) {
             statistics.incrementWriteOps(1);
         }
-
-        libFs.rename(formatPath(src), formatPath(dst));
-        return true;
+        try {
+            libFs.rename(formatPath(src), formatPath(dst));
+            return true;
+        } catch (FileNotFoundException e) {
+            return false;
+        }
     }
 
     @Override
@@ -169,9 +262,12 @@ public class CurvineFileSystem extends FileSystem {
         if (statistics != null) {
             statistics.incrementWriteOps(1);
         }
-
-        libFs.delete(formatPath(f), recursive);
-        return true;
+        try {
+            libFs.delete(formatPath(f), recursive);
+            return true;
+        } catch (FileNotFoundException e) {
+            return false;
+        }
     }
 
     @Override
@@ -179,17 +275,31 @@ public class CurvineFileSystem extends FileSystem {
         if (statistics != null) {
             statistics.incrementWriteOps(1);
         }
-
-        libFs.mkdir(formatPath(f), true);
-        return true;
+        try {
+            libFs.mkdir(formatPath(f), true);
+            return true;
+        } catch (IOException e) {
+            // mkdir may fail if parent doesn't exist or other reasons
+            LOGGER.warn("mkdirs failed for path: {}", f, e);
+            return false;
+        }
     }
 
     @Override
     public void close() throws IOException {
-        if (libFs != null) {
-            libFs.close();
+        // Don't close the shared mount, just decrement reference count
+        if (libFs != null && cacheKey != null) {
+            CachedMount cached = MOUNT_CACHE.get(cacheKey);
+            if (cached != null) {
+                int remaining = cached.refCount.decrementAndGet();
+                LOGGER.debug("Closing CurvineFileSystem for {}, remaining refCount={}", cacheKey, remaining);
+                // Note: We don't remove from cache even when refCount reaches 0
+                // because new FileSystem instances may be created later.
+                // The mount will be cleaned up by the shutdown hook.
+            }
             libFs = null;
         }
+        super.close();
     }
 
     @Override

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineFsMount.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineFsMount.java
@@ -14,12 +14,12 @@
 
 package io.curvine;
 
-import io.curvine.exception.CurvineException;
-import sun.nio.ch.DirectBuffer;
-
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Optional;
+
+import io.curvine.exception.CurvineException;
+import sun.nio.ch.DirectBuffer;
 
 public class CurvineFsMount {
     private final long nativeHandle;
@@ -38,13 +38,13 @@ public class CurvineFsMount {
 
     public void checkError(long errno, String msg) throws IOException {
         if (errno < SUCCESS) {
-            throw new CurvineException((int) errno, msg);
+            throw CurvineException.create((int) errno, msg);
         }
     }
 
     public void checkError(long errno) throws IOException {
         if (errno < SUCCESS) {
-            throw new CurvineException((int) errno, "lib error");
+            throw CurvineException.create((int) errno, "lib error");
         }
     }
 

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineNative.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineNative.java
@@ -109,10 +109,10 @@ public class CurvineNative {
             return "unknown";
         }
 
-        BufferedReader reader;
-        try {
-            reader = new BufferedReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8));
-            String line = null;
+        // Use try-with-resources to ensure BufferedReader is properly closed
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8))) {
+            String line;
             String id = null;
             String version = null;
             while ((line = reader.readLine()) != null) {

--- a/curvine-libsdk/java/src/main/java/io/curvine/exception/CurvineException.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/exception/CurvineException.java
@@ -16,11 +16,28 @@ package io.curvine.exception;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.NotDirectoryException;
 
+/**
+ * Curvine filesystem exception with error code mapping.
+ * Maps Curvine error codes to standard Java IO exceptions for HDFS compatibility.
+ */
 public class CurvineException extends IOException {
+    // Error codes from curvine-common/src/error.rs
+    public final static int INVALID_ARGUMENT = 1;
+    public final static int IO_ERROR = 2;
+    public final static int TIMEOUT = 3;
+    public final static int INTERNAL_ERROR = 4;
+    public final static int NOT_SUPPORTED = 5;
+    public final static int PERMISSION_DENIED = 6;
     public final static int FILE_ALREADY_EXISTS = 7;
     public final static int FILE_NOT_FOUND = 8;
+    public final static int NOT_A_DIRECTORY = 9;
+    public final static int IS_A_DIRECTORY = 10;
+    public final static int DIRECTORY_NOT_EMPTY = 11;
     public final static int FILE_EXPIRED = 21;
     public final static int UNSUPPORTED_UFS_READ = 22;
 
@@ -40,13 +57,51 @@ public class CurvineException extends IOException {
         return errno;
     }
 
+    /**
+     * Create appropriate IOException subclass based on error code.
+     * This ensures HDFS compatibility by throwing standard Java exceptions.
+     * 
+     * Note: Curvine server may return Common(10000) error code with "not exits" message
+     * for file not found cases. We handle this by checking the message content.
+     */
     public static IOException create(int errno, String message) {
+        // First check by error code
         switch (errno) {
             case FILE_NOT_FOUND:
                 return new FileNotFoundException(message);
             case FILE_ALREADY_EXISTS:
                 return new FileAlreadyExistsException(message);
+            case PERMISSION_DENIED:
+                return new AccessDeniedException(message);
+            case NOT_A_DIRECTORY:
+                return new NotDirectoryException(message);
+            case DIRECTORY_NOT_EMPTY:
+                return new DirectoryNotEmptyException(message);
+            case IS_A_DIRECTORY:
+                // Java doesn't have IsADirectoryException, use IOException with clear message
+                return new IOException("Is a directory: " + message);
             default:
+                // Fallback: check message content for common error patterns
+                // Curvine server sometimes returns Common(10000) with descriptive messages
+                if (message != null) {
+                    String lowerMsg = message.toLowerCase();
+                    if (lowerMsg.contains("not exits") || lowerMsg.contains("not exist") 
+                            || lowerMsg.contains("no such file") || lowerMsg.contains("file not found")) {
+                        return new FileNotFoundException(message);
+                    }
+                    if (lowerMsg.contains("already exists") || lowerMsg.contains("file exists")) {
+                        return new FileAlreadyExistsException(message);
+                    }
+                    if (lowerMsg.contains("permission denied") || lowerMsg.contains("access denied")) {
+                        return new AccessDeniedException(message);
+                    }
+                    if (lowerMsg.contains("not a directory")) {
+                        return new NotDirectoryException(message);
+                    }
+                    if (lowerMsg.contains("directory not empty")) {
+                        return new DirectoryNotEmptyException(message);
+                    }
+                }
                 return new CurvineException(errno, message);
         }
     }


### PR DESCRIPTION
This PR addresses critical stability and performance issues in the StarRocks HDFS client cache and enhances the Curvine Java SDK to be resilient against client-side cache bypasses.

#### 1. StarRocks HDFS Cache Optimization
**Problem:**
Previously, `hdfsBuilderSetForceNewInstance` was called unconditionally in [hdfs_fs_cache.cpp](cci:7://file:///home/oppo/Documents/starrocks/be/src/fs/hdfs/hdfs_fs_cache.cpp:0:0-0:0). This forced the creation of a new Hadoop `FileSystem` instance for every connection, bypassing Hadoop's internal cache. For heavy clients like Curvine (where each instance initializes a Tokio runtime with ~20 threads), this led to thread explosion and OOM when handling thousands of concurrent requests.

#### 2. Curvine Java SDK Resilience & Fixes
To prevent similar issues in the future (even if the client/engine bypasses Hadoop's FileSystem cache), we implemented a robust internal caching mechanism in the SDK.

- **Internal Mount Caching ([CurvineFileSystem.java](cci:7://file:///home/oppo/Documents/curvine/curvine-libsdk/java/src/main/java/io/curvine/CurvineFileSystem.java:0:0-0:0)):**
  - **Why:** To ensure stability even if the upstream caller (like StarRocks) forces new FileSystem instances.
  - **How:** Implemented a static `MOUNT_CACHE` to share the underlying native [CurvineFsMount](cci:2://file:///home/oppo/Documents/curvine/curvine-libsdk/java/src/main/java/io/curvine/CurvineFsMount.java:23:0-145:1) (and its heavy Tokio runtime) across multiple [CurvineFileSystem](cci:2://file:///home/oppo/Documents/curvine/curvine-libsdk/java/src/main/java/io/curvine/CurvineFileSystem.java:50:0-393:1) instances. Even if thousands of [CurvineFileSystem](cci:2://file:///home/oppo/Documents/curvine/curvine-libsdk/java/src/main/java/io/curvine/CurvineFileSystem.java:50:0-393:1) objects are created, they all share the same underlying native connection and thread pool, preventing resource exhaustion. The [close()](cci:1://file:///home/oppo/Documents/curvine/curvine-libsdk/java/src/main/java/io/curvine/CurvineFsMount.java:101:4-103:5) method uses reference counting to keep the mount alive for reuse.
- **Concurrency Fix ([CurvineFilesystemProvider.java](cci:7://file:///home/oppo/Documents/curvine/curvine-libsdk/java/src/main/java/io/curvine/CurvineFilesystemProvider.java:0:0-0:0)):**
  - Fixed a race condition in [getFs()](cci:1://file:///home/oppo/Documents/curvine/curvine-libsdk/java/src/main/java/io/curvine/CurvineFilesystemProvider.java:126:4-145:5) using double-checked locking with `volatile`, ensuring correct singleton initialization.
- **Resource Leak ([CurvineNative.java](cci:7://file:///home/oppo/Documents/curvine/curvine-libsdk/java/src/main/java/io/curvine/CurvineNative.java:0:0-0:0)):**
  - Use try-with-resources in [getOsVersion](cci:1://file:///home/oppo/Documents/curvine/curvine-libsdk/java/src/main/java/io/curvine/CurvineNative.java:101:4-103:5) to ensure `BufferedReader` is closed.
- **Data Integrity ([CurvineOutputStream.java](cci:7://file:///home/oppo/Documents/curvine/curvine-libsdk/java/src/main/java/io/curvine/CurvineOutputStream.java:0:0-0:0)):**
  - Fixed a critical bug where [flushBuffer()](cci:1://file:///home/oppo/Documents/curvine/curvine-libsdk/java/src/main/java/io/curvine/CurvineOutputStream.java:115:4-121:5) failed to clear the buffer, causing duplicate writes.
- **Error Handling ([CurvineException.java](cci:7://file:///home/oppo/Documents/curvine/curvine-libsdk/java/src/main/java/io/curvine/exception/CurvineException.java:0:0-0:0)):**
  - Enhanced exception mapping to parse generic server errors (e.g., "not exits") into standard `FileNotFoundException`.