### PR TITLE
fix: resolve node cache reference count inconsistencies (close #477)

### DIFF
--- a/curvine-common/src/conf/fuse_conf.rs
+++ b/curvine-common/src/conf/fuse_conf.rs
@@ -277,7 +277,7 @@ impl Default for FuseConf {
             congestion_threshold: 192,
 
             node_cache_size: 200000,
-            node_cache_timeout: "1h".to_string(),
+            node_cache_timeout: "24h".to_string(),
 
             direct_io: false,
             write_back_cache: false,

--- a/curvine-fuse/src/fs/state/node_attr.rs
+++ b/curvine-fuse/src/fs/state/node_attr.rs
@@ -30,7 +30,7 @@ pub struct NodeAttr {
     pub generation: u64,
 
     // Number of references, application layer
-    pub ref_ctr: i32,
+    pub ref_ctr: u32,
 
     // lookup times.Kernel layer.
     pub n_lookup: u64,
@@ -45,8 +45,6 @@ pub struct NodeAttr {
     pub mtime: i64,
 
     pub len: i64,
-
-    pub is_hidden: bool,
 
     pub cache_valid: bool,
 }
@@ -64,14 +62,31 @@ impl NodeAttr {
         }
     }
 
-    pub fn inc_lookup(&mut self) {
-        if self.n_lookup == 0 {
-            self.ref_ctr += 1;
-        }
-        self.n_lookup += 1;
-    }
-
     pub fn is_root(&self) -> bool {
         self.id == FUSE_ROOT_ID
+    }
+
+    pub fn add_lookup(&mut self, v: u64) -> u64 {
+        self.n_lookup = self.n_lookup.saturating_add(v);
+        self.n_lookup
+    }
+
+    pub fn sub_lookup(&mut self, v: u64) -> u64 {
+        self.n_lookup = self.n_lookup.saturating_sub(v);
+        self.n_lookup
+    }
+
+    pub fn add_ref(&mut self, v: u32) -> u32 {
+        self.ref_ctr = self.ref_ctr.saturating_add(v);
+        self.ref_ctr
+    }
+
+    pub fn sub_ref(&mut self, v: u32) -> u32 {
+        self.ref_ctr = self.ref_ctr.saturating_sub(v);
+        self.ref_ctr
+    }
+
+    pub fn should_unref(&self) -> bool {
+        self.n_lookup == 0 && self.ref_ctr == 0 && !self.is_root()
     }
 }


### PR DESCRIPTION
## Title
fix: correct node reference counting and lookup consistency

## Description

### Problem
The current node management implementation has several reference counting issues:
1. Inconsistent `n_lookup` counting between user space and kernel
2. Incorrect `ref_ctr` calculation leading to premature node deletion
3. Performance issues in `list_status` due to redundant `n_lookup` calculations

### Solution
This PR fixes node reference counting to ensure proper lifecycle management:

1. **Kernel-User Space Consistency**
   - Align `n_lookup` increment/decrement logic with kernel expectations
   - Ensure `FUSE_FORGET` requests properly decrement lookup counts
   - Fix race conditions in concurrent lookup operations

2. **Correct Reference Counting Semantics**
   - Implement proper `ref_ctr` calculation for active references
   - Prevent node deletion when `ref_ctr > 0`
   - Add validation to avoid use-after-free scenarios

3. **Performance Optimization**
   - Eliminate redundant `n_lookup` calculations in `list_status`
   - Cache node metadata where appropriate
