### PR TITLE
refactor: optimize network polling and timeout parameters (close #508)

### DIFF
--- a/curvine-common/src/conf/client_conf.rs
+++ b/curvine-common/src/conf/client_conf.rs
@@ -324,18 +324,18 @@ impl Default for ClientConf {
             auto_cache_ttl: "7d".to_string(),
             default_cache_ttl: Some("7d".to_string()),
 
-            conn_retry_max_duration_ms: 2 * 60 * 1000,
-            conn_retry_min_sleep_ms: 300,
-            conn_retry_max_sleep_ms: 10 * 1000,
+            conn_retry_max_duration_ms: 60 * 1000,
+            conn_retry_min_sleep_ms: 100,
+            conn_retry_max_sleep_ms: 2 * 1000,
 
-            rpc_retry_max_duration_ms: 5 * 60 * 1000,
-            rpc_retry_min_sleep_ms: 300,
-            rpc_retry_max_sleep_ms: 30 * 1000,
+            rpc_retry_max_duration_ms: 120 * 1000,
+            rpc_retry_min_sleep_ms: 100,
+            rpc_retry_max_sleep_ms: 10 * 1000,
 
             rpc_close_idle: true,
             conn_timeout_ms: 30 * 1000,
             rpc_timeout_ms: 120 * 1000,
-            data_timeout_ms: 5 * 60 * 1000,
+            data_timeout_ms: 120 * 1000,
             master_conn_pool_size: 1,
 
             enable_read_ahead: true,

--- a/curvine-libsdk/java/src/main/java/io/curvine/FilesystemConf.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/FilesystemConf.java
@@ -45,14 +45,14 @@ public class FilesystemConf {
     public String ttl_action = "none";
 
     // Set up the customer service retry policy
-    public long conn_retry_max_duration_ms = 2 * 60 * 1000;
-    public long conn_retry_min_sleep_ms = 300;
-    public long conn_retry_max_sleep_ms = 10 * 1000;
+    public long conn_retry_max_duration_ms = 60 * 1000;
+    public long conn_retry_min_sleep_ms = 100;
+    public long conn_retry_max_sleep_ms = 2 * 1000;
 
     // rpc requests retry policy.
-    public long rpc_retry_max_duration_ms = 5 * 60 * 1000;
-    public long rpc_retry_min_sleep_ms = 300;
-    public long rpc_retry_max_sleep_ms = 30 * 1000;
+    public long rpc_retry_max_duration_ms = 120 * 1000;
+    public long rpc_retry_min_sleep_ms = 100;
+    public long rpc_retry_max_sleep_ms = 10 * 1000;
 
     // Whether to close the idle rpc connection.
     public boolean rpc_close_idle = true;
@@ -60,7 +60,7 @@ public class FilesystemConf {
     //Configuration of timeout for a request.
     public long conn_timeout_ms = 30 * 1000;
     public long rpc_timeout_ms = 120 * 1000;
-    public long data_timeout_ms = 5 * 60 * 1000;
+    public long data_timeout_ms = 120 * 1000;
 
     // Number of fs master connections.
     public int master_conn_pool_size = 1;

--- a/orpc/src/client/buffer_client.rs
+++ b/orpc/src/client/buffer_client.rs
@@ -116,7 +116,7 @@ impl BufferClient {
             let req_id = env.msg.req_id();
             if env.is_canceled() {
                 // The callback has been cancelled, and the next request is executed.
-                warn!(
+                info!(
                     "Request({},{}) has been canceled",
                     req_id,
                     client_state.conn_info()
@@ -146,7 +146,7 @@ impl BufferClient {
                             e
                         );
                         if let Err(e) = cb.send(error) {
-                            warn!(
+                            info!(
                                 "Request({},{}) callback execute fail: {:?}",
                                 req_id,
                                 client_state.conn_info(),
@@ -208,7 +208,7 @@ impl BufferClient {
                 Some(cb) => {
                     // The callback notification failed, which may be because the caller has been destroyed, and the response_future only prints the log and the task does not end.
                     if let Err(e) = cb.send(Ok(msg)) {
-                        error!(
+                        info!(
                             "Request({},{}) callback execute fail: {:?}",
                             req_id,
                             client_state.conn_info(),
@@ -231,7 +231,7 @@ impl BufferClient {
             let error: IOResult<Message> =
                 err_box!("Connection {} closed", client_state.conn_info());
             if let Err(e) = cb.send(error) {
-                error!(
+                info!(
                     "Request({},{}) callback execute fail: {:?}",
                     id,
                     client_state.conn_info(),

--- a/orpc/src/client/client_conf.rs
+++ b/orpc/src/client/client_conf.rs
@@ -89,17 +89,17 @@ impl Default for ClientConf {
             close_idle: false,
             message_size: 16,
 
-            conn_retry_max_duration_ms: 2 * 60 * 1000,
-            conn_retry_min_sleep_ms: 300,
-            conn_retry_max_sleep_ms: 10 * 1000,
+            conn_retry_max_duration_ms: 60 * 1000,
+            conn_retry_min_sleep_ms: 100,
+            conn_retry_max_sleep_ms: 2 * 1000,
 
-            io_retry_max_duration_ms: 5 * 60 * 1000,
-            io_retry_min_sleep_ms: 300,
-            io_retry_max_sleep_ms: 30 * 1000,
+            io_retry_max_duration_ms: 120 * 1000,
+            io_retry_min_sleep_ms: 100,
+            io_retry_max_sleep_ms: 10 * 1000,
 
             conn_timeout_ms: 30 * 1000,
             rpc_timeout_ms: 2 * 60 * 1000,
-            data_timeout_ms: 5 * 60 * 1000,
+            data_timeout_ms: 2 * 60 * 1000,
 
             conn_size: 1,
 

--- a/orpc/src/client/raw_client.rs
+++ b/orpc/src/client/raw_client.rs
@@ -32,7 +32,7 @@ pub struct RawClient {
 
 impl RawClient {
     pub async fn new(addr: &InetAddr, conf: &ClientConf) -> IOResult<Self> {
-        let stream = Self::conn_retry(addr, conf).await?;
+        let stream = Self::conn(addr, conf).await?;
         let sock_ref = SockRef::from(&stream);
         // @todo Whether to set the network timeout time, follow-up research.
         sock_ref.set_nodelay(true)?;


### PR DESCRIPTION
### Changes

1. **Remove connection retry mechanism**
   - Connection retries are unnecessary and redundant with RPC-level retries
   - Simplifies codebase following best practices from similar projects

2. **Reduce timeout: 5min → 2min**
   - Applies to both read and write operations
   - Faster failure detection while still sufficient for normal operations

3. **Parallelize cluster retry requests**
   - Changed from sequential to parallel requests across cluster nodes
   - Significantly reduces latency when primary node is slow/unavailable
   - First successful response wins

4. **Reduce max retry backoff: 30s → 10s**
   - Decreases maximum wait time between retry attempts
   - Enables faster recovery from transient failures
   - Improves overall system responsiveness

### Impact
- Better performance and faster failure recovery
- Improved system responsiveness
- Reduced client-side hangs