### PR TITLE
fix: avoid duplicate tree recovery

### DIFF
--- a/curvine-server/src/master/meta/fs_dir.rs
+++ b/curvine-server/src/master/meta/fs_dir.rs
@@ -54,7 +54,7 @@ impl FsDir {
 
         let store = RocksInodeStore::new(db_conf, conf.format_master)?;
         let state = InodeStore::new(store, ttl_bucket_list);
-        let (last_inode_id, root_dir) = state.create_tree()?;
+        let (last_inode_id, root_dir) = state.create_blank_tree()?;
 
         let fs_dir = Self {
             root_dir,

--- a/curvine-server/src/master/meta/store/inode_store.rs
+++ b/curvine-server/src/master/meta/store/inode_store.rs
@@ -376,6 +376,12 @@ impl InodeStore {
         Ok(())
     }
 
+    pub fn create_blank_tree(&self) -> CommonResult<(i64, InodeView)> {
+        let root = FsDir::create_root();
+        self.fs_stats.set_counts(0, 0);
+        Ok((ROOT_INODE_ID, root))
+    }
+
     // Restore to a directory tree from rocksdb
     pub fn create_tree(&self) -> CommonResult<(i64, InodeView)> {
         let mut root = FsDir::create_root();


### PR DESCRIPTION
In the previous code, when starting the cluster, fs_dir::new would call create_tree to restore the directory tree. Afterwards, journal replay would restore the directory tree again. If the previous snapshot contains hardlink, fs_dir::unprotected_link detects that the file already exists and throws an error.