### PR TITLE
feat(fuse): add metadata caching on client side (close #538)

### DIFF
--- a/curvine-client/src/file/fs_writer_base.rs
+++ b/curvine-client/src/file/fs_writer_base.rs
@@ -304,7 +304,9 @@ impl FsWriterBase {
         let len = opts.len;
 
         // Step 1: Submit all blocks before resize
-        self.complete0(true).await?;
+        if self.len > 0 {
+            self.complete0(true).await?;
+        }
 
         // Step 2: Execute resize operation
         let file_blocks = self.fs_client.resize(&self.path, opts).await?;

--- a/curvine-common/src/conf/client_conf.rs
+++ b/curvine-common/src/conf/client_conf.rs
@@ -397,8 +397,8 @@ impl Default for ClientConf {
             small_file_size: 0,
             small_file_size_str: "4MB".to_string(),
 
-            block_conn_idle_time: Duration::from_secs(30),
-            block_conn_idle_time_str: "30s".to_string(),
+            block_conn_idle_time: Duration::from_secs(60),
+            block_conn_idle_time_str: "60s".to_string(),
         };
 
         conf.init().unwrap();

--- a/curvine-common/src/conf/fuse_conf.rs
+++ b/curvine-common/src/conf/fuse_conf.rs
@@ -109,6 +109,15 @@ pub struct FuseConf {
 
     pub congestion_threshold: u16,
 
+    // Whether to enable metadata cache
+    pub enable_meta_cache: bool,
+
+    // Metadata cache capacity (number of entries)
+    pub meta_cache_capacity: u64,
+
+    // Metadata cache TTL (time to live)
+    pub meta_cache_ttl: String,
+
     pub node_cache_size: u64,
 
     pub node_cache_timeout: String,
@@ -135,6 +144,9 @@ pub struct FuseConf {
     #[serde(skip_serializing, skip_deserializing)]
     pub node_cache_ttl: Duration,
 
+    #[serde(skip_serializing, skip_deserializing)]
+    pub meta_cache_ttl_duration: Duration,
+
     pub log: LogConf,
 }
 
@@ -156,6 +168,7 @@ impl FuseConf {
         self.entry_ttl = Duration::from_secs_f64(self.entry_timeout);
         self.negative_ttl = Duration::from_secs_f64(self.negative_timeout);
         self.node_cache_ttl = DurationUnit::from_str(&self.node_cache_timeout)?.as_duration();
+        self.meta_cache_ttl_duration = DurationUnit::from_str(&self.meta_cache_ttl)?.as_duration();
 
         if self.mnt_per_task == 0 {
             self.mnt_per_task = self.io_threads;
@@ -276,6 +289,10 @@ impl Default for FuseConf {
             max_background: 256,
             congestion_threshold: 192,
 
+            enable_meta_cache: false,
+            meta_cache_capacity: 100000,
+            meta_cache_ttl: "120s".to_string(),
+
             node_cache_size: 200000,
             node_cache_timeout: "24h".to_string(),
 
@@ -288,6 +305,7 @@ impl Default for FuseConf {
             entry_ttl: Default::default(),
             negative_ttl: Default::default(),
             node_cache_ttl: Default::default(),
+            meta_cache_ttl_duration: Default::default(),
 
             log: LogConf::default(),
         };

--- a/curvine-common/src/fs/meta_cache.rs
+++ b/curvine-common/src/fs/meta_cache.rs
@@ -1,0 +1,86 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::fs::Path;
+use crate::state::{FileBlocks, FileStatus};
+use orpc::sync::FastSyncCache;
+use std::time::Duration;
+
+pub struct MetaCache {
+    list_cache: FastSyncCache<String, Vec<FileStatus>>,
+    status_cache: FastSyncCache<String, FileStatus>,
+    open_cache: FastSyncCache<String, FileBlocks>,
+}
+
+impl MetaCache {
+    pub fn new(capacity: u64, ttl: Duration) -> Self {
+        Self {
+            list_cache: FastSyncCache::new(capacity, ttl),
+            status_cache: FastSyncCache::new(capacity, ttl),
+            open_cache: FastSyncCache::new(capacity, ttl),
+        }
+    }
+
+    pub fn get_list(&self, path: &Path) -> Option<Vec<FileStatus>> {
+        self.list_cache.get(path.full_path())
+    }
+
+    pub fn get_status(&self, path: &Path) -> Option<FileStatus> {
+        self.status_cache.get(path.full_path())
+    }
+
+    pub fn get_blocks(&self, path: &Path) -> Option<FileBlocks> {
+        self.open_cache.get(path.full_path())
+    }
+
+    pub fn get_open(&self, path: &Path) -> Option<FileBlocks> {
+        self.open_cache.get(path.full_path())
+    }
+
+    pub fn put_list(&self, path: &Path, list: Vec<FileStatus>) {
+        self.list_cache.insert(path.clone_uri(), list);
+    }
+
+    pub fn put_status(&self, path: &Path, status: FileStatus) {
+        self.status_cache.insert(path.clone_uri(), status);
+    }
+
+    pub fn put_open(&self, path: &Path, blocks: FileBlocks) {
+        self.open_cache.insert(path.clone_uri(), blocks);
+    }
+
+    pub fn invalidate(&self, path: &Path) {
+        self.list_cache.invalidate(path.full_path());
+        self.status_cache.invalidate(path.full_path());
+        self.open_cache.invalidate(path.full_path());
+    }
+
+    pub fn invalidate_list(&self, path: &Path) {
+        self.list_cache.invalidate(path.full_path());
+    }
+
+    pub fn invalidate_status(&self, path: &Path) {
+        self.status_cache.invalidate(path.full_path());
+    }
+
+    pub fn invalidate_open(&self, path: &Path) {
+        self.open_cache.invalidate(path.full_path());
+    }
+
+    pub fn clear(&self) {
+        self.list_cache.invalidate_all();
+        self.status_cache.invalidate_all();
+        self.open_cache.invalidate_all();
+    }
+}

--- a/curvine-common/src/fs/mod.rs
+++ b/curvine-common/src/fs/mod.rs
@@ -27,5 +27,8 @@ pub use self::writer::Writer;
 mod filesystem;
 pub use self::filesystem::FileSystem;
 
+mod meta_cache;
+pub use self::meta_cache::MetaCache;
+
 // CurvineURI is used in the Curvine system to describe paths, including external storage
 pub type CurvineURI = Path;

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -225,16 +225,15 @@ impl CurvineFileSystem {
         }
     }
 
-    // fuse.c peer implementation of lookup_path function.
     async fn lookup_path<T: AsRef<str>>(
         &self,
         parent: u64,
         name: Option<T>,
         path: &Path,
     ) -> FuseResult<fuse_attr> {
-        let status = self.fs_get_status(path).await?;
+        let name = name.as_ref();
+        let status = self.get_cached_status(path).await?;
         let attr = self.state.do_lookup(parent, name, &status)?;
-        // Apply time overrides if present
         Ok(attr)
     }
 
@@ -244,6 +243,7 @@ impl CurvineFileSystem {
         name: Option<T>,
         status: &FileStatus,
     ) -> FuseResult<fuse_attr> {
+        let name = name.as_ref();
         let attr = self.state.do_lookup(parent, name, status)?;
         Ok(attr)
     }
@@ -524,6 +524,57 @@ impl CurvineFileSystem {
             self.fs.resize(path, opts).await?;
         };
 
+        self.invalidate_cache(path)?;
+        Ok(())
+    }
+
+    async fn get_cached_status(&self, path: &Path) -> FuseResult<FileStatus> {
+        if self.conf.enable_meta_cache {
+            if let Some(status) = self.state.meta_cache().get_status(path) {
+                return Ok(status);
+            }
+        }
+
+        let status = self.fs_get_status(path).await?;
+        if self.conf.enable_meta_cache {
+            self.state.meta_cache().put_status(path, status.clone());
+        }
+
+        Ok(status)
+    }
+
+    async fn get_cached_list(&self, path: &Path) -> FuseResult<Vec<FileStatus>> {
+        if self.conf.enable_meta_cache {
+            if let Some(list) = self.state.meta_cache().get_list(path) {
+                return Ok(list);
+            }
+        }
+
+        let list = self.fs.list_status(path).await?;
+        let mut res = Vec::with_capacity(list.len() + 2);
+        res.push(CurvineFileSystem::new_dot_status(FUSE_CURRENT_DIR));
+        res.push(CurvineFileSystem::new_dot_status(FUSE_PARENT_DIR));
+        for status in list {
+            res.push(status);
+        }
+
+        if self.conf.enable_meta_cache {
+            self.state.meta_cache().put_list(path, res.clone());
+        }
+
+        Ok(res)
+    }
+    fn invalidate_cache(&self, path: &Path) -> FuseResult<()> {
+        if !self.conf.enable_meta_cache {
+            return Ok(());
+        }
+
+        self.state.meta_cache().invalidate(path);
+
+        if let Ok(Some(parent)) = path.parent() {
+            self.state.meta_cache().invalidate_list(&parent);
+        }
+
         Ok(())
     }
 }
@@ -599,7 +650,7 @@ impl fs::FileSystem for CurvineFileSystem {
         };
 
         let parent_path = self.state.get_path(parent)?;
-        let parent_status = self.fs_get_status(&parent_path).await?;
+        let parent_status = self.get_cached_status(&parent_path).await?;
         self.check_access_permissions(&parent_status, op.header, libc::X_OK as u32)?;
 
         // Get the path.
@@ -646,7 +697,7 @@ impl fs::FileSystem for CurvineFileSystem {
         let path = self.state.get_path(op.header.nodeid)?;
         debug!("Getting xattr: path='{}' name='{}'", path, name);
 
-        let status = self.fs_get_status(&path).await?;
+        let status = self.get_cached_status(&path).await?;
 
         let mut buf = FuseBuf::default();
         match name {
@@ -721,6 +772,7 @@ impl fs::FileSystem for CurvineFileSystem {
         };
 
         let _ = self.fs_set_attr(&path, opts).await?;
+        self.invalidate_cache(&path)?;
         Ok(())
     }
 
@@ -754,6 +806,7 @@ impl fs::FileSystem for CurvineFileSystem {
         };
 
         let _ = self.fs_set_attr(&path, opts).await?;
+        self.invalidate_cache(&path)?;
         Ok(())
     }
 
@@ -763,7 +816,7 @@ impl fs::FileSystem for CurvineFileSystem {
         let path = self.state.get_path(op.header.nodeid)?;
         debug!("Listing xattrs: path='{}' size={}", path, op.arg.size);
 
-        let status = self.fs_get_status(&path).await?;
+        let status = self.get_cached_status(&path).await?;
 
         // Build the list of xattr names
         let mut xattr_names = Vec::new();
@@ -799,14 +852,13 @@ impl fs::FileSystem for CurvineFileSystem {
         Ok(buf.take())
     }
 
-    // Get the attribute of the specified inode.
     async fn get_attr(&self, op: GetAttr<'_>) -> FuseResult<fuse_attr_out> {
         let path = self.state.get_path(op.header.nodeid)?;
 
-        let status = self.fs_get_status(&path).await?;
+        let status = self.get_cached_status(&path).await?;
 
         let mut fuse_attr = Self::status_to_attr(&self.conf, &status)?;
-        fuse_attr.ino = op.header.nodeid; // Use FUSE inode, not backend inode
+        fuse_attr.ino = op.header.nodeid;
 
         let attr = fuse_attr_out {
             attr_valid: self.conf.attr_ttl.as_secs(),
@@ -843,7 +895,7 @@ impl fs::FileSystem for CurvineFileSystem {
         // If kernel didn't provide FATTR_MODE, we still need to clear bits accordingly.
         if (op.arg.valid & (FATTR_UID | FATTR_GID)) != 0 {
             // Fetch current status to determine file type and mode
-            let cur_status = self.fs_get_status(&path).await?;
+            let cur_status = self.get_cached_status(&path).await?;
             if cur_status.file_type == curvine_common::state::FileType::File {
                 let mut new_mode = if let Some(mode) = opts.mode {
                     mode
@@ -866,7 +918,6 @@ impl fs::FileSystem for CurvineFileSystem {
             None => self.fs_get_status(&path).await?,
         };
 
-        // Handle file size change (truncate/resize)
         if (op.arg.valid & FATTR_SIZE) != 0 {
             let expect_len = op.arg.size as i64;
             if expect_len != status.len {
@@ -877,6 +928,7 @@ impl fs::FileSystem for CurvineFileSystem {
             }
         }
 
+        self.invalidate_cache(&path)?;
         let mut attr = Self::status_to_attr(&self.conf, &status)?;
         attr.ino = op.header.nodeid;
 
@@ -898,13 +950,13 @@ impl fs::FileSystem for CurvineFileSystem {
             // Skip when parent_id is invalid (e.g., root has no parent). Inode 0 is invalid.
             if parent_id != 0 {
                 let parent_path = self.state.get_path(parent_id)?;
-                let parent_status = self.fs_get_status(&parent_path).await?;
+                let parent_status = self.get_cached_status(&parent_path).await?;
                 self.check_access_permissions(&parent_status, op.header, libc::X_OK as u32)?;
             }
         }
 
         // Get file status to check permissions
-        let status = self.fs.get_status(&path).await?;
+        let status = self.get_cached_status(&path).await?;
         self.check_access_permissions(&status, op.header, op.arg.mask)?;
 
         Ok(())
@@ -916,15 +968,13 @@ impl fs::FileSystem for CurvineFileSystem {
 
         // Check directory permissions based on open action
         let dir_path = self.state.get_path(op.header.nodeid)?;
-        let dir_status = self.fs_get_status(&dir_path).await?;
+        let dir_status = self.get_cached_status(&dir_path).await?;
 
         // Use existing permission check function to verify access
         self.check_access_permissions(&dir_status, op.header, action.acl_mask())?;
 
-        let handle = self
-            .state
-            .new_dir_handle(op.header.nodeid, &dir_path)
-            .await?;
+        let list = self.get_cached_list(&dir_path).await?;
+        let handle = self.state.new_dir_handle(op.header.nodeid, list).await?;
         let open_flags = Self::fill_open_flags(&self.conf, op.arg.flags);
         let attr = fuse_open_out {
             fh: handle.fh,
@@ -990,6 +1040,7 @@ impl fs::FileSystem for CurvineFileSystem {
             }
         };
 
+        self.invalidate_cache(&path)?;
         let entry = self.lookup_status(op.header.nodeid, Some(name), &status)?;
         Ok(Self::create_entry_out(&self.conf, entry))
     }
@@ -1066,6 +1117,14 @@ impl fs::FileSystem for CurvineFileSystem {
             padding: 0,
         };
 
+        // Invalidate cache for write operations because:
+        // 1. O_TRUNC flag may truncate the file immediately, changing file size
+        // 2. Overwrite operations may change file metadata (size, mtime) immediately
+        // 3. Ensures subsequent read operations get fresh metadata
+        if action.write() {
+            self.invalidate_cache(&path)?;
+        }
+
         Ok(entry)
     }
 
@@ -1104,6 +1163,7 @@ impl fs::FileSystem for CurvineFileSystem {
             .await?;
 
         let attr = self.lookup_status(id, Some(name), handle.status())?;
+        self.invalidate_cache(&path)?;
         let r = fuse_create_out(
             fuse_entry_out {
                 nodeid: handle.ino,
@@ -1132,7 +1192,11 @@ impl fs::FileSystem for CurvineFileSystem {
     async fn flush(&self, op: Flush<'_>, reply: FuseResponse) -> FuseResult<()> {
         let handle = self.state.find_handle(op.header.nodeid, op.arg.fh)?;
         self.fs_unlock(&handle, LockFlags::Plock).await?;
-        handle.flush(Some(reply)).await
+        handle.flush(Some(reply)).await?;
+
+        let path = Path::from_str(&handle.status.path)?;
+        self.invalidate_cache(&path)?;
+        Ok(())
     }
 
     async fn release(&self, op: Release<'_>, reply: FuseResponse) -> FuseResult<()> {
@@ -1157,6 +1221,8 @@ impl fs::FileSystem for CurvineFileSystem {
             }
         }
 
+        let path = Path::from_str(&handle.status.path)?;
+        self.invalidate_cache(&path)?;
         complete_result
     }
 
@@ -1168,11 +1234,13 @@ impl fs::FileSystem for CurvineFileSystem {
         let name = try_option!(op.name.to_str());
         let parent_ino = op.header.nodeid;
 
+        let path = self.state.get_path_common(parent_ino, Some(name))?;
         if self.state.should_delete_now(parent_ino, Some(name))? {
-            let path = self.state.get_path_common(parent_ino, Some(name))?;
             self.fs.delete(&path, false).await?;
         }
         self.state.unlink_node(parent_ino, Some(name))?;
+        self.invalidate_cache(&path)?;
+
         Ok(())
     }
 
@@ -1189,8 +1257,12 @@ impl fs::FileSystem for CurvineFileSystem {
         );
 
         self.fs.link(&src_path, &des_path).await?;
-        let src_status = self.fs_get_status(&src_path).await?;
+        let src_status = self.get_cached_status(&src_path).await?;
         self.state.find_link_inode(src_status.id, oldnodeid);
+
+        self.invalidate_cache(&des_path)?;
+        self.invalidate_cache(&src_path)?;
+
         let attr = self
             .lookup_path(op.header.nodeid, Some(name), &des_path)
             .await?;
@@ -1202,8 +1274,11 @@ impl fs::FileSystem for CurvineFileSystem {
     async fn rm_dir(&self, op: RmDir<'_>) -> FuseResult<()> {
         let name = try_option!(op.name.to_str());
         let path = self.state.get_path_common(op.header.nodeid, Some(name))?;
+
         self.fs.delete(&path, false).await?;
         self.state.unlink_node(op.header.nodeid, Some(name))?;
+
+        self.invalidate_cache(&path)?;
         Ok(())
     }
 
@@ -1222,6 +1297,9 @@ impl fs::FileSystem for CurvineFileSystem {
 
         self.state
             .rename_node(op.header.nodeid, old_name, op.arg.newdir, new_name)?;
+
+        self.invalidate_cache(&old_path)?;
+        self.invalidate_cache(&new_path)?;
 
         Ok(())
     }
@@ -1251,14 +1329,11 @@ impl fs::FileSystem for CurvineFileSystem {
         };
 
         let link_path = self.state.get_path_common(parent, linkname)?;
-
-        // Call backend filesystem to create the symbolic link
-        // Use force=false to prevent overwriting existing files (standard ln -s behavior)
         self.fs.symlink(target, &link_path, false).await?;
 
-        // Get the created symlink's attributes
-        let entry = self.lookup_path(parent, linkname, &link_path).await?;
+        self.invalidate_cache(&link_path)?;
 
+        let entry = self.lookup_path(parent, linkname, &link_path).await?;
         Ok(Self::create_entry_out(&self.conf, entry))
     }
 
@@ -1267,7 +1342,7 @@ impl fs::FileSystem for CurvineFileSystem {
         let path = self.state.get_path(op.header.nodeid)?;
 
         // Get file status to read the symlink target
-        let status = self.fs_get_status(&path).await?;
+        let status = self.get_cached_status(&path).await?;
 
         // Check if it's actually a symlink
         if status.file_type != curvine_common::state::FileType::Link {
@@ -1293,7 +1368,11 @@ impl fs::FileSystem for CurvineFileSystem {
 
     async fn fsync(&self, op: FSync<'_>, reply: FuseResponse) -> FuseResult<()> {
         let handle = self.state.find_handle(op.header.nodeid, op.arg.fh)?;
-        handle.flush(Some(reply)).await
+        handle.flush(Some(reply)).await?;
+
+        let path = Path::from_str(&handle.status.path)?;
+        self.invalidate_cache(&path)?;
+        Ok(())
     }
 
     /// Create a file system node (mknod system call)


### PR DESCRIPTION
# FUSE-Side Metadata Cache

## Overview

The FUSE-side metadata cache is an in-process caching mechanism designed to reduce metadata access overhead in Curvine FUSE filesystem. It caches file status (`FileStatus`), directory listings (`Vec<FileStatus>`), and file block information (`FileBlocks`) within the FUSE process to minimize redundant metadata requests to the backend storage system.

## Key Features

### 1. Process-Level Consistency

The metadata cache maintains **consistency within a single FUSE process**. When metadata modification operations occur, the cache is immediately invalidated to ensure that subsequent operations see the latest data.

**Important Limitation**: The cache does **not** maintain consistency across multiple FUSE processes. For example, if one FUSE process creates a file, other FUSE processes will not immediately see this change until their cache entries expire or are invalidated through their own operations.

### 2. Performance Benefits

- **Default State**: The cache is **disabled by default** to ensure predictable behavior.
- **Cache TTL**: Default cache time-to-live is **120 seconds**.
- **Performance Improvement**: In scenarios like `rclone` copying large numbers of small files, enabling the cache can reduce metadata access by approximately **30%**.

### 3. Cache Types

The metadata cache maintains three separate caches:

- **Status Cache**: Caches `FileStatus` for individual files and directories
- **List Cache**: Caches directory listings (`Vec<FileStatus>`)
- **Open Cache**: Caches file block information (`FileBlocks`) for opened files

## Cache Usage

The following operations **read from** the metadata cache:

### File Status Operations
- `lookup()` - Looks up file/directory status
- `getattr()` - Gets file attributes
- `access()` - Checks file access permissions
- `open_dir()` - Opens directory (checks directory status)

### Directory Listing Operations
- `readdir()` - Reads directory contents

### File Block Operations
- File open operations that require block information

## Cache Invalidation

The following operations **invalidate** the metadata cache immediately after successful completion:

### File/Directory Creation and Deletion
- `create()` - Creates a new file
- `mkdir()` - Creates a new directory
- `unlink()` - Deletes a file
- `rmdir()` - Removes a directory

### File Modification
- `set_attr()` - Sets file attributes (mode, owner, group, size, timestamps)
- `fs_resize()` - Resizes a file
- `open()` - Opens a file with write flags (may overwrite/truncate)
- `flush()` - Flushes file data
- `release()` - Releases file handle
- `fsync()` - Synchronizes file data

### File System Operations
- `link()` - Creates a hard link
- `symlink()` - Creates a symbolic link
- `rename()` - Renames/moves a file or directory
- `set_xattr()` - Sets extended attributes
- `remove_xattr()` - Removes extended attributes

### Cache Invalidation Behavior

When a file or directory is modified:
1. The cache entry for the modified path is invalidated
2. The parent directory's list cache is also invalidated (since directory mtime changes when files are created/deleted/renamed)

## Configuration

### Enabling the Cache

To enable the metadata cache, set the following configuration options in your FUSE configuration file:

```toml
[fuse]
enable_meta_cache = true
meta_cache_capacity = 100000
meta_cache_ttl = "120s"
```

### Configuration Options

#### `enable_meta_cache` (bool, default: `false`)

Enables or disables the metadata cache. Set to `true` to enable caching.

**Recommendation**: Enable this option when:
- You have workloads with many small files (e.g., `rclone` copy operations)
- Metadata access is a performance bottleneck
- You can tolerate potential inconsistencies across multiple FUSE processes

#### `meta_cache_capacity` (u64, default: `100000`)

Specifies the maximum number of cache entries. Each cache type (status, list, open) maintains its own capacity limit.

**Recommendation**: 
- Increase this value if you have a large number of frequently accessed files
- Monitor memory usage, as each cache entry consumes memory
- Default value of 100,000 entries is suitable for most workloads

#### `meta_cache_ttl` (String, default: `"120s"`)

Specifies the time-to-live for cache entries. Format supports time units:
- `s` - seconds (e.g., `"120s"`)
- `m` - minutes (e.g., `"2m"`)
- `h` - hours (e.g., `"1h"`)

**Recommendation**:
- Shorter TTL (60-120s) for frequently changing filesystems
- Longer TTL (300-600s) for relatively static filesystems
- Default 120 seconds provides a good balance between performance and freshness

### Example Configuration

```toml
[fs]
# Enable metadata cache
enable_meta_cache = true

# Cache up to 200,000 entries
meta_cache_capacity = 200000

# Cache entries expire after 2 minutes
meta_cache_ttl = "120s"
```

## Implementation Details

### Cache Storage

The cache uses `FastSyncCache` internally, which provides:
- Thread-safe concurrent access
- Time-based expiration (TTL)
- Efficient hash-based lookups

### Cache Key Strategy

The cache uses **full path strings** as keys, allowing efficient lookups by file path. Paths are normalized and stored in their full URI format.

### Cache Invalidation Strategy

Cache invalidation follows these principles:

1. **Immediate Invalidation**: Cache is invalidated immediately after successful metadata modification operations
2. **Parent Directory Invalidation**: When a file is created/deleted/renamed, both the file's cache and its parent directory's list cache are invalidated
3. **Selective Invalidation**: Different cache types (status, list, open) can be invalidated independently

### Cache Update Strategy

When `set_attr()` is called:
- If the backend returns updated status, the cache is updated with the new status
- If the backend doesn't return updated status, the cache is invalidated to ensure fresh data is fetched on next access

This ensures that metadata modifications are immediately reflected in subsequent operations.

## Performance Considerations

### When to Enable

Enable the metadata cache when:
- ✅ You have workloads with many small files
- ✅ Metadata access is a bottleneck
- ✅ You're using a single FUSE process
- ✅ You can tolerate eventual consistency across processes

### When to Disable

Disable the metadata cache when:
- ❌ You require strict consistency across multiple FUSE processes
- ❌ You have very large files with infrequent metadata access
- ❌ Memory usage is a concern
- ❌ You're debugging metadata-related issues

### Monitoring

Monitor the following metrics to evaluate cache effectiveness:

- **Cache Hit Rate**: Percentage of metadata requests served from cache
- **Memory Usage**: Total memory consumed by cache entries
- **Metadata Request Reduction**: Reduction in backend metadata requests

## Limitations

1. **Multi-Process Consistency**: The cache does not maintain consistency across multiple FUSE processes. Changes made by one process may not be immediately visible to others.

2. **Memory Usage**: Each cache entry consumes memory. With large `meta_cache_capacity` values, memory usage can be significant.

3. **TTL-Based Expiration**: Cache entries expire based on TTL, not on actual backend changes. Stale data may be served until expiration.

4. **Path-Based Keys**: The cache uses path strings as keys, which may not be optimal for all access patterns.

## Troubleshooting

### Cache Not Working

1. Verify `enable_meta_cache` is set to `true`
2. Check that cache capacity is not exhausted
3. Verify TTL is appropriate for your workload
4. Check logs for cache-related errors

### Stale Data Issues

1. Reduce `meta_cache_ttl` to ensure fresher data
2. Verify cache invalidation is working correctly
3. Consider disabling cache if strict consistency is required

### High Memory Usage

1. Reduce `meta_cache_capacity`
2. Reduce `meta_cache_ttl` to allow faster expiration
3. Monitor cache hit rates to ensure cache is effective

## Future Improvements

Potential enhancements for future versions:

- Cross-process cache invalidation mechanisms
- Cache hit/miss metrics and monitoring
- Adaptive TTL based on access patterns
- Inode-based cache keys for better performance
- Cache warming strategies for common access patterns

