### PR TITLE
fix(fuse): invalidate attribute cache in flush and release (close #58…

### DIFF
--- a/curvine-fuse/src/fs/state/node_state.rs
+++ b/curvine-fuse/src/fs/state/node_state.rs
@@ -216,7 +216,7 @@ impl NodeState {
         }
 
         let writer = self.fs.open_with_opts(path, opts, flags).await?;
-        let writer = FuseWriter::new(&self.conf, self.fs.clone_runtime(), writer);
+        let writer = FuseWriter::new(&self.conf, self.fs.clone_runtime(), writer, ino);
         Ok(Arc::new(Mutex::new(writer)))
     }
 


### PR DESCRIPTION
# Add attribute cache invalidation mechanism to FuseWriter

## Problem

When files are written through FUSE, the kernel may cache file attributes (size, mtime, etc.) for `attr_timeout` seconds. This can lead to data visibility issues:

- Writer completes writing and closes the file
- Kernel attribute cache still shows old file size
- Reader immediately opens the file and reads stale metadata
- Results in incomplete or incorrect data reads

## Solution

Added attribute cache invalidation mechanism to FuseWriter:

- Proactively invalidate kernel attribute cache after write operations
- Invalidate cache on:
  - File creation (`create`)
  - Write operations (`flush`) when opening for flush
  - File close (`release`) after completing writes

This ensures readers always fetch fresh file attributes from the master, even when `attr_timeout > 0`.