### PR TITLE
feat: add --version for all components

### DIFF
--- a/curvine-cli/src/main.rs
+++ b/curvine-cli/src/main.rs
@@ -126,7 +126,7 @@ fn main() -> CommonResult<()> {
             Commands::UnMount(cmd) => cmd.execute(fs_client).await,
             Commands::Node(cmd) => cmd.execute(fs_client, conf.clone()).await,
             Commands::Version => {
-                println!("Curvine version: {}", version::GIT_VERSION);
+                println!("curvine-cli {}", version::VERSION);
                 Ok(())
             }
         };

--- a/curvine-common/src/version.rs
+++ b/curvine-common/src/version.rs
@@ -12,4 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Include the version constants generated at build time
 include!(concat!(env!("OUT_DIR"), "/version.rs"));

--- a/curvine-csi/Dockerfile
+++ b/curvine-csi/Dockerfile
@@ -63,9 +63,20 @@ RUN echo "Building Curvine from source..." && \
     fi && \
     rm -rf /workspace/tmp
 
-# Build CSI binary
+# Build CSI binary with version info
 RUN cd /workspace/curvine-csi && \
-    go build -o bin/csi main.go
+    VERSION=$(grep '^version =' /workspace/Cargo.toml | head -1 | sed 's/^version = "\(.*\)"/\1/') && \
+    GIT_COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown") && \
+    GIT_TAG=$(git describe --tags --exact-match HEAD 2>/dev/null || echo "") && \
+    GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "") && \
+    BUILD_DATE=$(date -u '+%Y-%m-%d_%H:%M:%S') && \
+    go build \
+        -ldflags "-X github.com/curvineio/curvine-csi/pkg/csi.driverVersion=${VERSION} \
+                  -X github.com/curvineio/curvine-csi/pkg/csi.gitCommit=${GIT_COMMIT} \
+                  -X github.com/curvineio/curvine-csi/pkg/csi.gitTag=${GIT_TAG} \
+                  -X github.com/curvineio/curvine-csi/pkg/csi.gitBranch=${GIT_BRANCH} \
+                  -X github.com/curvineio/curvine-csi/pkg/csi.buildDate=${BUILD_DATE}" \
+        -o bin/csi main.go
 
 # Create output directory and copy build artifacts
 RUN mkdir -p /build-output && \

--- a/curvine-csi/main.go
+++ b/curvine-csi/main.go
@@ -25,14 +25,19 @@ import (
 )
 
 var (
-	endpoint = flag.String("endpoint", "unix://tmp/csi.sock", "CSI Endpoint")
-	version  = flag.Bool("version", false, "Print the version and exit.")
-	nodeID   = flag.String("nodeid", "", "Node ID")
+	endpoint    = flag.String("endpoint", "unix://tmp/csi.sock", "CSI Endpoint")
+	version     = flag.Bool("version", false, "Print the version and exit.")
+	versionJSON = flag.Bool("version-json", false, "Print the version in JSON format and exit.")
+	nodeID      = flag.String("nodeid", "", "Node ID")
 )
 
 func main() {
 	flag.Parse()
 	if *version {
+		fmt.Printf("curvine-csi %s\n", csi.GetVersionString())
+		os.Exit(0)
+	}
+	if *versionJSON {
 		info, err := csi.GetVersionJSON()
 		if err != nil {
 			klog.Fatalln(err)

--- a/curvine-csi/pkg/csi/version.go
+++ b/curvine-csi/pkg/csi/version.go
@@ -22,19 +22,23 @@ import (
 
 // These are set during build time via -ldflags
 var (
-	driverVersion string
-	gitCommit     string
-	buildDate     string
+	driverVersion = "unknown"
+	gitCommit     = "unknown"
+	gitTag        = ""
+	gitBranch     = ""
+	buildDate     = "unknown"
 )
 
 // VersionInfo struct
 type VersionInfo struct {
-	DriverVersion string
-	GitCommit     string
-	BuildDate     string
-	GoVersion     string
-	Compiler      string
-	Platform      string
+	DriverVersion string `json:"DriverVersion"`
+	GitCommit     string `json:"GitCommit"`
+	GitTag        string `json:"GitTag,omitempty"`
+	GitBranch     string `json:"GitBranch,omitempty"`
+	BuildDate     string `json:"BuildDate"`
+	GoVersion     string `json:"GoVersion"`
+	Compiler      string `json:"Compiler"`
+	Platform      string `json:"Platform"`
 }
 
 // GetVersion returns VersionInfo
@@ -42,6 +46,8 @@ func GetVersion() VersionInfo {
 	return VersionInfo{
 		DriverVersion: driverVersion,
 		GitCommit:     gitCommit,
+		GitTag:        gitTag,
+		GitBranch:     gitBranch,
 		BuildDate:     buildDate,
 		GoVersion:     runtime.Version(),
 		Compiler:      runtime.Compiler,
@@ -57,4 +63,27 @@ func GetVersionJSON() (string, error) {
 		return "", err
 	}
 	return string(marshalled), nil
+}
+
+// GetVersionString returns a simple version string: "version (commit: commit-id, tag/branch: name)"
+// This format matches other Curvine components for consistency
+func GetVersionString() string {
+	version := driverVersion
+	if version == "" || version == "unknown" {
+		version = "dev"
+	}
+	commit := gitCommit
+	if commit == "" || commit == "unknown" {
+		commit = "unknown"
+	}
+
+	// Build source info: prefer tag over branch
+	sourceInfo := ""
+	if gitTag != "" && gitTag != "unknown" {
+		sourceInfo = fmt.Sprintf(", tag: %s", gitTag)
+	} else if gitBranch != "" && gitBranch != "unknown" && gitBranch != "HEAD" {
+		sourceInfo = fmt.Sprintf(", branch: %s", gitBranch)
+	}
+
+	return fmt.Sprintf("%s (commit: %s%s)", version, commit, sourceInfo)
 }

--- a/curvine-fuse/src/bin/curvine-fuse.rs
+++ b/curvine-fuse/src/bin/curvine-fuse.rs
@@ -14,6 +14,7 @@
 
 use clap::Parser;
 use curvine_common::conf::ClusterConf;
+use curvine_common::version;
 use curvine_fuse::fs::CurvineFileSystem;
 use curvine_fuse::session::FuseSession;
 use curvine_fuse::web_server::WebServer;
@@ -65,6 +66,7 @@ fn main() -> CommonResult<()> {
 
 // Mount command function parameters
 #[derive(Debug, Parser, Clone)]
+#[command(version = version::VERSION)]
 pub struct FuseArgs {
     // Mount the mount point, mount the file system to a directory of the machine.
     #[arg(long, default_value = "/curvine-fuse")]

--- a/curvine-s3-gateway/src/bin/curvine-s3-gateway.rs
+++ b/curvine-s3-gateway/src/bin/curvine-s3-gateway.rs
@@ -14,6 +14,7 @@
 
 use clap::{Parser, Subcommand};
 use curvine_common::conf::ClusterConf;
+use curvine_common::version;
 use curvine_s3_gateway::auth::{
     AccessKeyStoreEnum, CredentialEntry, CredentialStore, CurvineAccessKeyStore,
     LocalAccessKeyStore,
@@ -24,6 +25,7 @@ use rand::Rng;
 use std::sync::Arc;
 
 #[derive(Debug, Parser, Clone)]
+#[command(version = version::VERSION)]
 pub struct ObjectArgs {
     #[arg(
         short,

--- a/curvine-server/src/bin/curvine-server.rs
+++ b/curvine-server/src/bin/curvine-server.rs
@@ -51,6 +51,7 @@ fn main() -> CommonResult<()> {
 }
 
 #[derive(Debug, Parser, Clone)]
+#[command(version = version::VERSION)]
 pub struct ServerArgs {
     // Start the worker or the master
     #[arg(long, default_value = "")]

--- a/curvine-tests/src/bench_args.rs
+++ b/curvine-tests/src/bench_args.rs
@@ -13,9 +13,10 @@
 // limitations under the License.
 
 use clap::Parser;
+use curvine_common::version;
 
 #[derive(Debug, Parser, Clone, Default)]
-#[command(arg_required_else_help = true)]
+#[command(arg_required_else_help = true, version = version::VERSION)]
 pub struct BenchArgs {
     #[arg(short, long, default_value = "")]
     pub action: String,


### PR DESCRIPTION
show version for all bins

curvine-server:     0.2.0 (commit: edec1133, branch: build-version) 
curvine-fuse:       0.2.0 (commit: edec1133, branch: build-version) 
curvine-s3-gateway: 0.2.0 (commit: edec1133, branch: build-version) 
curvine-bench:      0.2.0 (commit: edec1133, branch: build-version) 
curvine-cli:        0.2.0 (commit: edec1133, branch: build-version) 
curvine-csi:        0.2.0 (commit: edec1133, branch: build-version) 

show tags when build from release
curvine-server 0.2.0 (commit: edec1133, tag: v0.2.0-test)
curvine-csi 0.2.0 (commit: edec1133, tag: v0.2.0-test)