### PR TITLE
fix(orpc): trigger error callbacks immediately on network exceptions

### DIFF
--- a/curvine-client/src/file/read_detector.rs
+++ b/curvine-client/src/file/read_detector.rs
@@ -173,7 +173,7 @@ impl ReadDetector {
         self.last_read_pos = -1;
 
         if self.read_pattern.is_sequential() {
-            log::info!(
+            log::debug!(
                 "file {} read pattern changed: {:?} -> {:?}",
                 path,
                 self.read_pattern,
@@ -203,7 +203,7 @@ impl ReadDetector {
         };
 
         if self.read_pattern != read_pattern {
-            log::info!(
+            log::debug!(
                 "file {} read pattern changed: {:?} -> {:?}",
                 path,
                 self.read_pattern,

--- a/orpc/src/handler/read_frame.rs
+++ b/orpc/src/handler/read_frame.rs
@@ -49,10 +49,7 @@ impl ReadFrame {
         loop {
             match state {
                 FrameSate::Head => {
-                    let mut buf = match self.read_full(message::PROTOCOL_SIZE).await {
-                        Ok(v) => v,
-                        Err(_) => return Ok(Message::empty()),
-                    };
+                    let mut buf = self.read_full(message::PROTOCOL_SIZE).await?;
 
                     let (protocol, header_size, data_size) = Message::decode_protocol(&mut buf)?;
                     let _ = mem::replace(


### PR DESCRIPTION
Previously, when a network exception occurred, the error callback was not invoked in a timely manner, potentially leaving the caller unaware of the failure. This change ensures the callback is executed as soon as the exception is detected, improving error visibility and system robustness.