### PR TITLE
fix(client): fix metadata inconsistency issue in write cache mode (#597)

### DIFF
--- a/curvine-client/src/file/fs_client.rs
+++ b/curvine-client/src/file/fs_client.rs
@@ -14,7 +14,7 @@
 
 use crate::file::FsContext;
 use bytes::BytesMut;
-use curvine_common::conf::{ClientConf, UfsConf, UfsConfBuilder};
+use curvine_common::conf::{ClientConf, ClusterConf, UfsConf, UfsConfBuilder};
 use curvine_common::error::FsError;
 use curvine_common::fs::{Path, RpcCode};
 use curvine_common::proto::*;
@@ -41,8 +41,12 @@ impl FsClient {
         Self { context, connector }
     }
 
-    pub fn context(&self) -> Arc<FsContext> {
-        self.context.clone()
+    pub fn context(&self) -> &Arc<FsContext> {
+        &self.context
+    }
+
+    pub fn conf(&self) -> &ClusterConf {
+        &self.context.conf
     }
 
     pub async fn mkdir(&self, path: &Path, opts: MkdirOpts) -> FsResult<FileStatus> {

--- a/curvine-client/src/file/fs_reader_base.rs
+++ b/curvine-client/src/file/fs_reader_base.rs
@@ -123,6 +123,10 @@ impl FsReaderBase {
     pub async fn seek(&mut self, pos: i64) -> FsResult<()> {
         if pos == self.pos {
             return Ok(());
+        } else if pos == self.len {
+            self.pos = pos;
+            self.update_reader(None, false).await?;
+            return Ok(());
         } else if pos > self.len {
             return err_box!("seek position {} can not exceed file len {}", pos, self.len);
         }

--- a/curvine-client/src/unified/cache_sync_reader.rs
+++ b/curvine-client/src/unified/cache_sync_reader.rs
@@ -52,7 +52,7 @@ impl CacheSyncReader {
                 ticks += 1;
                 let file_blocks = self.fs.get_block_locations(self.path()).await?;
 
-                if file_blocks.len != self.len() {
+                if file_blocks.len != self.len() || file_blocks.status.is_complete {
                     let mut reader = FsReader::new(
                         self.path().clone(),
                         self.fs.fs_context.clone(),
@@ -61,10 +61,11 @@ impl CacheSyncReader {
                     reader.seek(self.inner.pos()).await?;
 
                     info!(
-                        "file {} len change {} -> {}",
+                        "file {} len change {} -> {}, complete: {}",
                         self.path(),
                         self.len(),
-                        reader.len()
+                        reader.len(),
+                        reader.status().is_complete
                     );
                     self.inner = reader;
                     break;

--- a/curvine-common/src/error/fs_error.rs
+++ b/curvine-common/src/error/fs_error.rs
@@ -57,6 +57,7 @@ pub enum ErrorKind {
     Ufs = 20,
     Expired = 21,
     UnsupportedUfsRead = 22,
+    JobNotFound = 23,
 
     #[num_enum(default)]
     Common = 10000,
@@ -150,6 +151,10 @@ pub enum FsError {
     #[error("{0}")]
     UnsupportedUfsRead(ErrorImpl<StringError>),
 
+    // Job not found
+    #[error("{0}")]
+    JobNotFound(ErrorImpl<StringError>),
+
     // Other errors that are not defined.
     #[error("{0}")]
     Common(ErrorImpl<StringError>),
@@ -191,6 +196,11 @@ impl FsError {
     pub fn unsupported_ufs_read(path: impl AsRef<str>) -> Self {
         let msg = format!("File {} unsupported ufs read", path.as_ref());
         Self::UnsupportedUfsRead(ErrorImpl::with_source(msg.into()))
+    }
+
+    pub fn job_not_found(job_id: impl AsRef<str>) -> Self {
+        let msg = format!("Job {} not found", job_id.as_ref());
+        Self::JobNotFound(ErrorImpl::with_source(msg.into()))
     }
 
     pub fn file_exists(path: impl AsRef<str>) -> Self {
@@ -259,6 +269,7 @@ impl FsError {
             FsError::Ufs(_) => ErrorKind::Ufs,
             FsError::Expired(_) => ErrorKind::Expired,
             FsError::UnsupportedUfsRead(_) => ErrorKind::UnsupportedUfsRead,
+            FsError::JobNotFound(_) => ErrorKind::JobNotFound,
             FsError::Common(_) => ErrorKind::Common,
         }
     }
@@ -372,6 +383,7 @@ impl ErrorExt for FsError {
             FsError::Ufs(e) => FsError::Ufs(e.ctx(ctx)),
             FsError::Expired(e) => FsError::Expired(e.ctx(ctx)),
             FsError::UnsupportedUfsRead(e) => FsError::UnsupportedUfsRead(e.ctx(ctx)),
+            FsError::JobNotFound(e) => FsError::JobNotFound(e.ctx(ctx)),
             FsError::Common(e) => FsError::Common(e.ctx(ctx)),
         }
     }
@@ -400,6 +412,7 @@ impl ErrorExt for FsError {
             FsError::Ufs(e) => e.encode(ErrorKind::Ufs),
             FsError::Expired(e) => e.encode(ErrorKind::Expired),
             FsError::UnsupportedUfsRead(e) => e.encode(ErrorKind::UnsupportedUfsRead),
+            FsError::JobNotFound(e) => e.encode(ErrorKind::JobNotFound),
             FsError::Common(e) => e.encode(ErrorKind::Common),
         }
     }
@@ -431,6 +444,7 @@ impl ErrorExt for FsError {
             ErrorKind::Ufs => FsError::Ufs(de.into_string()),
             ErrorKind::Expired => FsError::Expired(de.into_string()),
             ErrorKind::UnsupportedUfsRead => FsError::UnsupportedUfsRead(de.into_string()),
+            ErrorKind::JobNotFound => FsError::JobNotFound(de.into_string()),
             ErrorKind::Common => FsError::Common(de.into_string()),
         }
     }

--- a/curvine-common/src/state/mount.rs
+++ b/curvine-common/src/state/mount.rs
@@ -155,6 +155,20 @@ impl MountInfo {
             .ttl_action(self.ttl_action)
             .build()
     }
+
+    pub fn is_write_through(&self) -> bool {
+        matches!(
+            self.write_type,
+            WriteType::CacheThrough | WriteType::AsyncThrough
+        )
+    }
+
+    /// Check if this write type stores data in UFS
+    /// Cache mode only stores data in Curvine, not in UFS
+    /// Other modes (Through/AsyncThrough/CacheThrough) store data in UFS
+    pub fn has_ufs_data(&self) -> bool {
+        !matches!(self.write_type, WriteType::Cache)
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/curvine-common/src/utils/common_utils.rs
+++ b/curvine-common/src/utils/common_utils.rs
@@ -1,0 +1,25 @@
+//  Copyright 2025 OPPO.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+use orpc::common::Utils;
+
+pub struct CommonUtils;
+
+impl CommonUtils {
+    pub const JOB_ID_PREFIX: &'static str = "job_";
+
+    pub fn create_job_id(source: impl AsRef<str>) -> String {
+        format!("{}{}", Self::JOB_ID_PREFIX, Utils::md5(source))
+    }
+}

--- a/curvine-common/src/utils/mod.rs
+++ b/curvine-common/src/utils/mod.rs
@@ -20,5 +20,7 @@ pub use self::serde_utils::SerdeUtils;
 
 pub mod display;
 mod rpc_utils;
-
 pub use self::rpc_utils::RpcUtils;
+
+mod common_utils;
+pub use self::common_utils::CommonUtils;

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -1032,7 +1032,7 @@ impl fs::FileSystem for CurvineFileSystem {
             )
         }
 
-        let status = match self.fs.fuse_mkdir(&path, opts.build()).await {
+        let status = match self.fs.mkdir_with_opts(&path, opts.build()).await {
             Ok(status) => match status {
                 Some(v) => v,
                 None => self.fs.get_status(&path).await?,

--- a/curvine-server/src/master/fs/master_filesystem.rs
+++ b/curvine-server/src/master/fs/master_filesystem.rs
@@ -127,18 +127,6 @@ impl MasterFilesystem {
         let mut fs_dir = self.fs_dir.write();
         let inp = Self::resolve_path(&fs_dir, path.as_ref())?;
 
-        if !inp.is_empty_dir() && !recursive {
-            return err_ext!(FsError::dir_not_empty(inp.path()));
-        }
-
-        if inp.is_root() {
-            return err_box!("The root is not allowed to be deleted");
-        }
-
-        if inp.is_empty() || inp.get_last_inode().is_none() {
-            return err_box!("Failed to remove {} because it does not exist", inp.path());
-        }
-
         let delete_result = fs_dir.delete(&inp, recursive)?;
 
         let mut worker_manager = self.worker_manager.write();

--- a/curvine-server/src/master/job/job_manager.rs
+++ b/curvine-server/src/master/job/job_manager.rs
@@ -26,9 +26,9 @@ use curvine_common::state::{
 use curvine_common::FsResult;
 use log::{info, warn};
 use orpc::common::LocalTime;
-use orpc::err_box;
 use orpc::runtime::{LoopTask, RpcRuntime, Runtime};
 use orpc::sync::channel::BlockingChannel;
+use orpc::{err_box, err_ext};
 use std::sync::Arc;
 
 /// Load the Task Manager
@@ -95,7 +95,7 @@ impl JobManager {
                 progress: job.progress.clone(),
             })
         } else {
-            err_box!("Not fond job {}", job_id)
+            err_ext!(FsError::job_not_found(job_id))
         }
     }
 

--- a/curvine-server/src/master/job/job_runner.rs
+++ b/curvine-server/src/master/job/job_runner.rs
@@ -22,10 +22,11 @@ use curvine_common::fs::{FileSystem, Path};
 use curvine_common::state::{
     FileStatus, JobTaskState, LoadJobCommand, LoadJobResult, LoadTaskInfo, MountInfo, WorkerAddress,
 };
+use curvine_common::utils::CommonUtils;
 use curvine_common::FsResult;
 use futures::future;
 use log::{error, info, warn};
-use orpc::common::{ByteUnit, FastHashMap, FastHashSet, LocalTime, Utils};
+use orpc::common::{ByteUnit, FastHashMap, FastHashSet, LocalTime};
 use orpc::err_box;
 use std::collections::LinkedList;
 use std::sync::Arc;
@@ -50,10 +51,6 @@ impl LoadJobRunner {
             factory,
             job_max_files,
         }
-    }
-
-    fn create_job_id(source: impl AsRef<str>) -> String {
-        format!("job_{}", Utils::md5(source))
     }
 
     pub fn choose_worker(&self, block_size: i64) -> FsResult<WorkerAddress> {
@@ -118,7 +115,7 @@ impl LoadJobRunner {
             mnt.get_cv_path(&source_path)?
         };
 
-        let job_id = Self::create_job_id(source_path.full_path());
+        let job_id = CommonUtils::create_job_id(source_path.full_path());
         let result = LoadJobResult {
             job_id: job_id.clone(),
             target_path: target_path.clone_uri(),

--- a/curvine-ufs/src/opendal.rs
+++ b/curvine-ufs/src/opendal.rs
@@ -703,11 +703,11 @@ impl FileSystem<OpendalWriter, OpendalReader> for OpendalFileSystem {
     }
 
     /// OpenDal only supports overwrite, so the overwrite parameter is ignored here.
-    async fn create(&self, path: &Path, _overwrite: bool) -> FsResult<OpendalWriter> {
+    async fn create(&self, path: &Path, overwrite: bool) -> FsResult<OpendalWriter> {
         let object_path = self.get_object_path(path)?;
 
         let exist = self.get_object_status(&object_path).await?.is_some();
-        if !exist {
+        if !exist || overwrite {
             // If no data is written to OpenDal, no file will be created.
             // This does not conform to POSIX semantics, so an empty file is created.
             self.operator


### PR DESCRIPTION
# Fix Metadata Inconsistency Issue in Write Cache Mode

## Core Changes Explanation

### 1. **Rename Operation Improvements**

**Problem**: In write-through mode, executing rename before data synchronization completes may lead to data loss or inconsistency.

**Solution**:

```rust
// Wait for sync job to complete before renaming in UFS
if mount.info.is_write_through() {
    self.wait_job_complete(src, "rename").await?;
}
```

**Key Improvements**:
- **Sync Wait Mechanism**: For write-through modes, rename operations now wait for data sync jobs to complete
- **Rationale**: Ensures all data has been fully written to UFS, preventing data loss that could occur if renaming while data is still being synced
- **Cache Cleanup**: After rename, the file's mtime changes, invalidating cached data, so the old path's cache is deleted

---

### 2. **Delete Operation Improvements**

**Problem**: Delete logic wasn't robust enough; cache cleanup failures could interrupt operations.

**Solution**:

```rust
// Delete from UFS first
mount.ufs.delete(&ufs_path, recursive).await?;

// Then delete cache (failure doesn't affect main flow)
if let Err(e) = self.cv.delete(path, recursive).await {
    if !matches!(e, FsError::FileNotFound(_)) {
        warn!("failed to delete cache for {}: {}", path, e);
    }
};
```

**Key Improvements**:
- **Operation Order Adjustment**: Delete UFS data first, then cache (previously cache then UFS)
- **Fault Tolerance**: Cache deletion failures only log warnings without affecting the overall operation
- **Error Handling Optimization**: Removed duplicate pre-checks from server-side delete operations, unified in `fs_dir.rs`

**Server-side Metadata Delete Improvements**:
- Removed 12 lines of redundant pre-check code in `master_filesystem.rs`
- Centralized all validation logic in the `delete` method of `fs_dir.rs`
- Uses standard error types `FsError::file_not_found()` and `FsError::dir_not_empty()`

---

### 3. **Mkdir (Create Directory) Operation Improvements**

**Problem**: When mount point directories exist in UFS, the cache layer lacks corresponding directory metadata, causing inconsistency.

**Solution**:

```rust
// When directory exists in UFS, also create it in cache layer
if !flag {
    err_ext!(FsError::file_exists(ufs_path.path()))
} else {
    match self.cv.mkdir_with_opts(path, opts).await {
        Ok(status) => Ok(Some(status)),
        Err(e) => {
            warn!("failed to create directory in cache for {}, ignoring: {}", path, e);
            Ok(None)  // Cache creation failure doesn't affect main operation
        }
    }
}
```

**Key Improvements**:
- **Metadata Synchronization**: When UFS directory exists, simultaneously create corresponding directory metadata in cache layer
- **Fault Tolerance**: Cache layer directory creation failures only log warnings without affecting main flow
- **API Refactoring**: Renamed `fuse_mkdir` to `mkdir_with_opts` for clearer interface
- **Unified Handling**: mkdir operations now uniformly handled through `mkdir_with_opts`, enhancing consistency

---

### 4. **Job Wait Mechanism Improvements**

Added `wait_job_complete` method to wait for data sync jobs to complete:

```rust
pub async fn wait_job_complete(&self, path: &Path, mark: &str) -> FsResult<()> {
    let job_id = CommonUtils::create_job_id(path.full_path());
    let res = client.wait_job_complete(job_id, mark).await;
    match res {
        Ok(_) | Err(FsError::JobNotFound(_)) => Ok(()),  // Job not found is also success
        Err(e) => Err(e),
    }
}
```

**Key Features**:
- Supports timeout control and retry mechanism
- Exponential backoff polling intervals
- Periodic progress logging
- New `JobNotFound` error type, treats non-existent jobs as success

---

## Code Statistics

- **Files Modified**: 15 files
- **Lines Added**: +205
- **Lines Deleted**: -112
- **Net Change**: +93 lines

---

## Summary

The core objective of this fix is to **resolve metadata inconsistency issues in write cache mode**, primarily through:

1. **Rename**: Added sync wait mechanism to ensure data integrity before renaming
2. **Delete**: Adjusted operation order, enhanced fault tolerance, unified error handling
3. **Mkdir**: Ensures directory metadata synchronization between cache layer and UFS

All changes follow the principle of **"main flow priority, cache failure degradation"**, improving system robustness and data consistency.

---

## Testing Recommendations

- Test concurrent write scenarios in write cache mode
- Verify metadata synchronization correctness between client and server
- Test error handling and recovery mechanisms in edge cases
- Validate rename operations with active sync jobs
- Test delete operations with cache inconsistencies

