### PR TITLE
fix: flush pending writes before rename to prevent data loss

### DIFF
--- a/curvine-client/src/unified/unified_filesystem.rs
+++ b/curvine-client/src/unified/unified_filesystem.rs
@@ -454,7 +454,13 @@ impl FileSystem<UnifiedWriter, UnifiedReader> for UnifiedFileSystem {
                 let _ = mount.ufs.rename(&src_ufs, &dst_ufs).await?;
 
                 if self.cv.exists(src).await? {
-                    self.cv.delete(src, true).await?;
+                    if let Err(e) = self.cv.rename(src, dst).await {
+                        warn!(
+                            "rename cache failed, src: {}, dst: {}, err: {}",
+                            src, dst, e
+                        );
+                        self.cv.delete(src, true).await?;
+                    }
                 }
                 Ok(true)
             }

--- a/curvine-fuse/src/fs/state/node_state.rs
+++ b/curvine-fuse/src/fs/state/node_state.rs
@@ -358,6 +358,23 @@ impl NodeState {
         }
     }
 
+    /// Get all file handles for a given ino
+    pub fn get_handles(&self, ino: u64) -> Vec<Arc<FileHandle>> {
+        let lock = self.handles.read();
+        if let Some(map) = lock.get(&ino) {
+            map.values().cloned().collect()
+        } else {
+            Vec::new()
+        }
+    }
+
+    /// Get ino by parent and name, returns None if not found
+    pub fn get_ino_by_name<T: AsRef<str>>(&self, parent: u64, name: T) -> Option<u64> {
+        self.node_read()
+            .lookup_node(parent, Some(name))
+            .map(|n| n.id)
+    }
+
     pub fn should_delete_now<T: AsRef<str>>(
         &self,
         parent: u64,


### PR DESCRIPTION
When renaming a file with open handles, flush all handles first to ensure pending async writes complete. This fixes data loss when applications (e.g., PyTorch) write to a temp file and immediately rename it to the final destination.

Also improve UFS rename: try to rename the cache instead of deleting it, preserving cache data after rename.