### PR TITLE
fix(fuse): remove send_inode_out calls in flush/complete to prevent d…

### DIFF
--- a/curvine-fuse/src/fs/fuse_writer.rs
+++ b/curvine-fuse/src/fs/fuse_writer.rs
@@ -45,7 +45,7 @@ pub struct FuseWriter {
 }
 
 impl FuseWriter {
-    pub fn new(conf: &FuseConf, rt: Arc<Runtime>, writer: UnifiedWriter, ino: u64) -> Self {
+    pub fn new(conf: &FuseConf, rt: Arc<Runtime>, writer: UnifiedWriter) -> Self {
         let is_ufs = !writer.path().is_cv();
         let path = writer.path().clone();
         let err_monitor = Arc::new(ErrorMonitor::new());
@@ -55,7 +55,7 @@ impl FuseWriter {
         let monitor = err_monitor.clone();
 
         rt.spawn(async move {
-            let res = Self::writer_future(writer, receiver, ino).await;
+            let res = Self::writer_future(writer, receiver).await;
             match res {
                 Ok(_) => (),
 
@@ -130,7 +130,6 @@ impl FuseWriter {
     async fn writer_future(
         mut writer: UnifiedWriter,
         mut req_receiver: AsyncReceiver<WriteTask>,
-        ino: u64,
     ) -> FsResult<()> {
         while let Some(task) = req_receiver.recv().await {
             match task {
@@ -149,7 +148,6 @@ impl FuseWriter {
                 WriteTask::Flush(tx, reply) => {
                     let res = writer.flush().await;
                     if let Some(reply) = reply {
-                        reply.send_inode_out(ino, 0, -1).await?;
                         reply.send_rep(res).await?;
                     }
                     tx.send(1)?;
@@ -158,7 +156,6 @@ impl FuseWriter {
                 WriteTask::Complete(tx, reply) => {
                     let res = writer.complete().await;
                     if let Some(reply) = reply {
-                        reply.send_inode_out(ino, 0, -1).await?;
                         reply.send_rep(res).await?;
                     }
                     tx.send(1)?;

--- a/curvine-fuse/src/fs/state/node_state.rs
+++ b/curvine-fuse/src/fs/state/node_state.rs
@@ -216,7 +216,7 @@ impl NodeState {
         }
 
         let writer = self.fs.open_with_opts(path, opts, flags).await?;
-        let writer = FuseWriter::new(&self.conf, self.fs.clone_runtime(), writer, ino);
+        let writer = FuseWriter::new(&self.conf, self.fs.clone_runtime(), writer);
         Ok(Arc::new(Mutex::new(writer)))
     }
 


### PR DESCRIPTION
# PR Description: Fix FUSE Kernel Deadlock in Writer Flush/Complete Operations

## Problem

The system was experiencing kernel deadlocks when opening files for write operations. The kernel stack trace showed:

```
[ 4056.706605] INFO: task curvine-fuse:29748 blocked for more than 122 seconds.
[ 4056.706769]       Not tainted 6.8.0-90-generic #91~22.04.1-Ubuntu
[ 4056.706873] "echo 0 > /proc/sys/kernel/hung_task_timeout_secs" disables this message.
[ 4056.706903] task:curvine-fuse    state:D stack:0     pid:29748 tgid:29742 ppid:1414   flags:0x00004006
[ 4056.706906] Call Trace:
[ 4056.706908]  <TASK>
[ 4056.706912]  __schedule+0x27c/0x6a0
[ 4056.706919]  schedule+0x33/0x110
[ 4056.706920]  io_schedule+0x46/0x80
[ 4056.706922]  folio_wait_bit_common+0x136/0x330
[ 4056.706926]  ? __pfx_wake_page_function+0x10/0x10
[ 4056.706927]  __folio_lock+0x17/0x30
[ 4056.706928]  invalidate_inode_pages2_range+0x1d2/0x4f0
[ 4056.706933]  fuse_reverse_inval_inode+0x99/0xd0
[ 4056.706935]  fuse_notify+0x16f/0x2d0
[ 4056.706938]  ? fuse_copy_do+0x67/0xb0
[ 4056.706939]  fuse_dev_do_write+0x2d9/0x4c0
[ 4056.706941]  ? kvmalloc_node+0x24/0x100
[ 4056.706943]  fuse_dev_splice_write+0x2d1/0x3f0
[ 4056.706945]  do_splice+0x1bf/0x510
[ 4056.706947]  __do_splice+0x200/0x230
[ 4056.706949]  __x64_sys_splice+0xc3/0x150
[ 4056.706950]  x64_sys_call+0xd9d/0x2480
[ 4056.706952]  do_syscall_64+0x81/0x170
[ 4056.706955]  ? select_idle_sibling+0x45/0x880
[ 4056.706972]  ? arch_exit_to_user_mode_prepare.constprop.0+0x1a/0xe0
[ 4056.706974]  ? x2apic_send_IPI+0x5d/0x90
[ 4056.706996]  ? native_send_call_func_single_ipi+0x13/0x20
[ 4056.706998]  ? __smp_call_single_queue+0xfa/0x180
[ 4056.707014]  ? ttwu_queue_wakelist+0x135/0x1c0
[ 4056.707022]  ? try_to_wake_up+0x1c1/0x610
[ 4056.707024]  ? wake_up_q+0x50/0xa0
[ 4056.707025]  ? futex_wake+0x167/0x190
[ 4056.707027]  ? do_futex+0x128/0x230
[ 4056.707028]  ? __x64_sys_futex+0x95/0x200
[ 4056.707029]  ? arch_exit_to_user_mode_prepare.constprop.0+0x1a/0xe0
[ 4056.707030]  ? syscall_exit_to_user_mode+0x43/0x1e0
[ 4056.707032]  ? do_syscall_64+0x8d/0x170
[ 4056.707034]  ? arch_exit_to_user_mode_prepare.constprop.0+0x1a/0xe0
[ 4056.707035]  ? syscall_exit_to_user_mode+0x43/0x1e0
[ 4056.707037]  ? do_syscall_64+0x8d/0x170
[ 4056.707038]  ? do_syscall_64+0x8d/0x170
[ 4056.707039]  ? do_syscall_64+0x8d/0x170
[ 4056.707041]  ? clear_bhb_loop+0x15/0x70
[ 4056.707043]  ? clear_bhb_loop+0x15/0x70
[ 4056.707044]  ? clear_bhb_loop+0x15/0x70
[ 4056.707045]  entry_SYSCALL_64_after_hwframe+0x78/0x80
[ 4056.707046] RIP: 0033:0x7a7dca7260c5
[ 4056.707053] RSP: 002b:00007a7dc9e0e770 EFLAGS: 00000293 ORIG_RAX: 0000000000000113
[ 4056.707061] RAX: ffffffffffffffda RBX: 00005c0254ede4b0 RCX: 00007a7dca7260c5
[ 4056.707069] RDX: 000000000000000b RSI: 0000000000000000 RDI: 000000000000000c
[ 4056.707070] RBP: 00007a7dc9e13690 R08: 0000000000000028 R09: 0000000000000003
[ 4056.707071] R10: 0000000000000000 R11: 0000000000000293 R12: 0000000000000000
[ 4056.707071] R13: 0000000000000002 R14: 00007a7dcac43000 R15: 00005c0254f08220
[ 4056.707072]  </TASK>

```

The kernel was blocked trying to send `FUSE_NOTIFY_INVAL_INODE` notifications to userspace, waiting for page locks (folio locks).

## Root Cause

The deadlock was caused by calling `send_inode_out()` in `flush` and `complete` operations within the writer backend task (`writer_future`). This created a circular wait scenario:

1. **Userspace backend task** calls `send_inode_out()` → writes to FUSE device (sends `FUSE_NOTIFY_INVAL_INODE` notification)
2. **Kernel** is simultaneously trying to send `FUSE_NOTIFY_INVAL_INODE` notification to userspace
3. **Userspace backend task** gets blocked on the write operation, cannot read kernel notification
4. **Kernel** gets blocked waiting for userspace to read its notification
5. **Deadlock occurs**

The FUSE device is bidirectional - both kernel and userspace can write to it. When both sides try to write simultaneously and wait for the other to read, a deadlock occurs.

## Solution

Removed the `send_inode_out()` calls from `flush` and `complete` operations because:

1. **Not necessary**: Kernel will query file status when needed via `getattr` operations
2. **No proactive notification needed**: These operations don't require immediate cache invalidation
3. **Eliminates deadlock risk**: Removing the notification calls breaks the circular wait

## Changes

- Removed `reply.send_inode_out(ino, 0, -1).await?;` calls from `WriteTask::Flush` handler
- Removed `reply.send_inode_out(ino, 0, -1).await?;` calls from `WriteTask::Complete` handler
- Removed unused `ino` parameter from `writer_future()` function
- Removed unused `ino` parameter from `FuseWriter::new()` function

## Testing

- Verified that file write operations no longer cause kernel deadlocks
- Confirmed that file status is still correctly updated and accessible via `getattr`
- Tested flush and complete operations work correctly without the notification calls

## Impact

- **Positive**: Eliminates kernel deadlock when opening files for write
- **No negative impact**: File status updates still work correctly, kernel queries status when needed

## Related Issues

Fixes kernel deadlock reported in kernel logs:
```
INFO: task curvine-fuse:29748 blocked for more than 122 seconds.
```

