### PR TITLE
fix(fuse): force kernel to invalidate attr cache when file is modifie…

### DIFF
--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -856,9 +856,19 @@ impl fs::FileSystem for CurvineFileSystem {
         let mut fuse_attr = Self::status_to_attr(&self.conf, &status)?;
         fuse_attr.ino = op.header.nodeid;
 
+        let keep_cache = self.state.should_keep_cache(op.header.nodeid, &status)?;
+        let (attr_valid, attr_valid_nsec) = if keep_cache {
+            (
+                self.conf.attr_ttl.as_secs(),
+                self.conf.attr_ttl.subsec_nanos(),
+            )
+        } else {
+            (0, 0)
+        };
+
         let attr = fuse_attr_out {
-            attr_valid: self.conf.attr_ttl.as_secs(),
-            attr_valid_nsec: self.conf.attr_ttl.subsec_nanos(),
+            attr_valid,
+            attr_valid_nsec,
             dummy: 0,
             attr: fuse_attr,
         };


### PR DESCRIPTION
# PR Description: Fix Java transferTo Reading Zero-Length Data Due to Stale Kernel Attr Cache

## Problem

Java NIO `transferTo` was reading zero-length data when copying files through FUSE mount point. The issue occurred because the kernel cached stale file attributes (size=0) for 1 second, even after the file was written and flushed.

### Root Cause

```
Timeline:
T0: File created, size=0
  ↓ getattr() → returns size=0, attr_valid=1 second
  ↓ Kernel caches: size=0, valid for 1 second

T1: Write data, flush completes, size=117 bytes
  ↓ But kernel cache still valid (0.5 seconds remaining)

T2: Java transferTo reads file
  ↓ Kernel queries attr (getattr)
  ↓ Checks cache: attr_valid still valid (0.5 seconds)
  ↓ Returns cached size=0 ❌
  ↓ transferTo thinks file is empty, reads zero bytes
```

### Why Flush Doesn't Auto-Invalidate Attr Cache

- FUSE `flush` operation only flushes data to backend
- Kernel's attr cache is based on TTL (attr_ttl=1 second), independent of data flush
- FUSE protocol doesn't automatically invalidate attr cache on flush

## Solution

Detect file modifications in `getattr` operation and force kernel to invalidate cache by setting `attr_valid=0` when file is modified.

### Implementation

1. **Reuse existing logic**: Use `should_keep_cache()` method which already detects file changes by comparing `mtime` and `len`
2. **Set attr_valid=0**: When `keep_cache=false` (file was modified), set `attr_valid=0` to force kernel cache invalidation
3. **Normal TTL otherwise**: When `keep_cache=true` (file unchanged), use normal TTL

### Code Changes

```rust
// curvine-fuse/src/fs/curvine_file_system.rs

async fn get_attr(&self, op: GetAttr<'_>) -> FuseResult<fuse_attr_out> {
    let path = self.state.get_path(op.header.nodeid)?;
    let status = self.get_cached_status(&path).await?;
    
    let mut fuse_attr = Self::status_to_attr(&self.conf, &status)?;
    fuse_attr.ino = op.header.nodeid;
    
    // Detect if file was modified
    let keep_cache = self.state.should_keep_cache(op.header.nodeid, &status)?;
    let (attr_valid, attr_valid_nsec) = if keep_cache {
        // File unchanged → use normal TTL
        (self.conf.attr_ttl.as_secs(), self.conf.attr_ttl.subsec_nanos())
    } else {
        // File modified → force kernel to invalidate cache
        (0, 0)
    };
    
    let attr = fuse_attr_out {
        attr_valid,
        attr_valid_nsec,
        dummy: 0,
        attr: fuse_attr,
    };
    Ok(attr)
}
```

### How It Works

```
Fixed Timeline:
T0: File created, size=0
  ↓ getattr() → returns size=0, attr_valid=1 second
  ↓ Kernel caches: size=0, node.mtime=0, node.len=0

T1: Write data, flush completes, size=117 bytes
  ↓ invalidate_cache() → invalidates userspace cache

T2: Java transferTo reads file
  ↓ Kernel queries attr (getattr)
  ↓ get_cached_status() → gets latest status (size=117)
  ↓ should_keep_cache() detects:
     - status.mtime != node.mtime ✅ (file modified)
     - status.len != node.len ✅ (117 != 0)
     - Returns false
  ↓ Sets attr_valid=0 ✅
  ↓ Kernel receives attr_valid=0
  ↓ Kernel: doesn't cache, uses returned attr (size=117) ✅
  ↓ transferTo reads correct size=117
```

## Why This Approach

### Advantages

1. **Safe**: Passive invalidation avoids potential deadlock (unlike `send_inode_out()`)
2. **Automatic**: Detects file changes by comparing mtime and len
3. **Efficient**: Reuses existing `should_keep_cache()` logic
4. **Consistent**: Same logic used in `open` operation

### Comparison with Active Notification

| Approach | Pros | Cons |
|----------|------|------|
| `send_inode_out()` active notification | Immediate cache invalidation | Potential deadlock risk |
| `attr_valid=0` passive invalidation | Safe, no deadlock | Requires next getattr query |

For `transferTo` scenario, passive invalidation is sufficient because:
- `transferTo` queries `getattr` before reading
- Setting `attr_valid=0` ensures kernel uses fresh data immediately
- No need for active notification

## Testing

- ✅ Verified transferTo now reads correct file size after flush
- ✅ Verified normal file operations still use TTL caching
- ✅ Verified no deadlock issues

## Related Issues

Fixes: Java transferTo reading zero-length data due to stale kernel attr cache

## References

- FUSE attr cache TTL mechanism
- Linux kernel fuse_getattr implementation
- Java NIO transferTo behavior

