### PR TITLE
feat: add pipeline replication protocol and errors

### DIFF
--- a/curvine-client/src/block/block_client.rs
+++ b/curvine-client/src/block/block_client.rs
@@ -103,7 +103,12 @@ impl BlockClient {
         seq_id: i32,
         chunk_size: i32,
         short_circuit: bool,
+        pipeline_stream: Vec<WorkerAddress>,
     ) -> FsResult<CreateBlockContext> {
+        let pipeline_stream = pipeline_stream
+            .iter()
+            .map(ProtoUtils::worker_address_to_pb)
+            .collect();
         let header = BlockWriteRequest {
             block: ProtoUtils::extend_block_to_pb(blk.clone()),
             off,
@@ -111,6 +116,7 @@ impl BlockClient {
             short_circuit,
             client_name: self.client_name.to_string(),
             chunk_size,
+            pipeline_stream,
         };
 
         let msg = Builder::new()

--- a/curvine-client/src/block/block_writer_local.rs
+++ b/curvine-client/src/block/block_writer_local.rs
@@ -55,6 +55,7 @@ impl BlockWriterLocal {
                 seq_id,
                 fs_context.write_chunk_size() as i32,
                 true,
+                Vec::new(),
             )
             .await?;
 

--- a/curvine-client/src/block/block_writer_remote.rs
+++ b/curvine-client/src/block/block_writer_remote.rs
@@ -53,6 +53,7 @@ impl BlockWriterRemote {
                 seq_id,
                 fs_context.write_chunk_size() as i32,
                 false,
+                Vec::new(),
             )
             .await?;
 

--- a/curvine-common/proto/master.proto
+++ b/curvine-common/proto/master.proto
@@ -150,6 +150,24 @@ message AddBlocksBatchResponse {
     repeated LocatedBlockProto blocks = 1;  
 }
 
+message RequestReplacementWorkerRequest {
+    required int64 block_id = 1;
+    repeated uint32 exclude_workers = 2;
+}
+
+message RequestReplacementWorkerResponse {
+    required WorkerAddressProto worker = 1;
+}
+
+message ReportUnderReplicatedBlocksRequest {
+    repeated int64 block_ids = 1;
+}
+
+message ReportUnderReplicatedBlocksResponse {
+    required bool success = 1;
+    optional string message = 2;
+}
+
 // File writing is completed.
 message CompleteFileRequest {
     required string path = 1;

--- a/curvine-common/proto/worker.proto
+++ b/curvine-common/proto/worker.proto
@@ -16,6 +16,14 @@ message BlockWriteRequest {
     required bool short_circuit = 4 [default = false];
     required string client_name = 5 [default = ""];
     required int32 chunk_size = 6;
+    repeated WorkerAddressProto pipeline_stream = 7;
+}
+
+message PipelineStatus {
+    required bool success = 1;
+    required int32 established_count = 2;
+    optional WorkerAddressProto failed_worker = 3;
+    optional string error_message = 4;
 }
 
 message BlockWriteResponse {
@@ -24,6 +32,7 @@ message BlockWriteResponse {
     required int64 off = 3;
     required int64 block_size = 4;
     required StorageTypeProto storage_type = 5;
+    optional PipelineStatus pipeline_status = 6;
 }
 
 message BlockReadRequest {

--- a/curvine-common/src/conf/client_conf.rs
+++ b/curvine-common/src/conf/client_conf.rs
@@ -117,6 +117,7 @@ pub struct ClientConf {
     pub conn_timeout_ms: u64,
     pub rpc_timeout_ms: u64,
     pub data_timeout_ms: u64,
+    pub pipeline_timeout_ms: u64,
 
     // Number of fs master connections.
     // After testing 3 connections, the best performance can be achieved, so the default value is 3.
@@ -361,6 +362,7 @@ impl Default for ClientConf {
             conn_timeout_ms: 30 * 1000,
             rpc_timeout_ms: 120 * 1000,
             data_timeout_ms: 120 * 1000,
+            pipeline_timeout_ms: 120 * 1000,
             master_conn_pool_size: 1,
 
             enable_read_ahead: true,

--- a/curvine-common/src/conf/master_conf.rs
+++ b/curvine-common/src/conf/master_conf.rs
@@ -87,6 +87,9 @@ pub struct MasterConf {
     // Block replication
     pub block_replication_enabled: bool,
     pub block_replication_concurrency_limit: usize,
+    pub block_replication_retry_interval: String,
+    #[serde(skip)]
+    pub block_replication_retry_interval_unit: DurationUnit,
 
     pub log: LogConf,
 
@@ -145,6 +148,8 @@ impl MasterConf {
         self.ttl_bucket_interval_unit = DurationUnit::from_str(&self.ttl_bucket_interval)?;
         self.ttl_max_retry_duration_unit = DurationUnit::from_str(&self.ttl_max_retry_duration)?;
         self.ttl_retry_interval_unit = DurationUnit::from_str(&self.ttl_retry_interval)?;
+        self.block_replication_retry_interval_unit =
+            DurationUnit::from_str(&self.block_replication_retry_interval)?;
 
         // Initialize lock expiration time
         self.lock_expire_time_unit = DurationUnit::from_str(&self.lock_expire_time)?;
@@ -190,6 +195,10 @@ impl MasterConf {
 
     pub fn ttl_retry_interval_ms(&self) -> u64 {
         self.ttl_retry_interval_unit.as_millis()
+    }
+
+    pub fn block_replication_retry_interval_ms(&self) -> u64 {
+        self.block_replication_retry_interval_unit.as_millis()
     }
 
     pub fn lock_expire_time_ms(&self) -> u64 {
@@ -264,6 +273,8 @@ impl Default for MasterConf {
 
             block_replication_enabled: false,
             block_replication_concurrency_limit: 1000,
+            block_replication_retry_interval: "5s".to_string(),
+            block_replication_retry_interval_unit: Default::default(),
             log: Default::default(),
 
             ttl_checker_retry_attempts: 3,

--- a/curvine-common/src/fs/rpc_code.rs
+++ b/curvine-common/src/fs/rpc_code.rs
@@ -65,6 +65,8 @@ pub enum RpcCode {
 
     SubmitBlockReplicationJob = 42,
     ReportBlockReplicationResult = 43,
+    RequestReplacementWorker = 44,
+    ReportUnderReplicatedBlocks = 45,
 
     MetricsReport = 60,
 

--- a/curvine-common/tests/proto_pipeline_test.rs
+++ b/curvine-common/tests/proto_pipeline_test.rs
@@ -1,0 +1,186 @@
+#[cfg(test)]
+mod tests {
+    use curvine_common::proto::{
+        BlockWriteRequest, BlockWriteResponse, ExtendedBlockProto, PipelineStatus,
+        StorageTypeProto, WorkerAddressProto,
+    };
+    use prost::Message;
+
+    fn create_test_block() -> ExtendedBlockProto {
+        ExtendedBlockProto {
+            id: 12345,
+            block_size: 1024 * 1024,
+            storage_type: StorageTypeProto::Disk as i32,
+            file_type: 1,
+            alloc_opts: None,
+        }
+    }
+
+    fn create_test_worker_address(worker_id: u32) -> WorkerAddressProto {
+        WorkerAddressProto {
+            worker_id,
+            hostname: format!("worker-{}", worker_id),
+            ip_addr: format!("192.168.1.{}", worker_id),
+            rpc_port: 9000 + worker_id,
+            web_port: 8000 + worker_id,
+        }
+    }
+
+    #[test]
+    fn test_block_write_request_round_trip_without_pipeline_stream() {
+        let request = BlockWriteRequest {
+            block: create_test_block(),
+            off: 0,
+            block_size: 64 * 1024 * 1024,
+            short_circuit: false,
+            client_name: "test-client".to_string(),
+            chunk_size: 1024 * 1024,
+            pipeline_stream: vec![],
+        };
+
+        let encoded = request.encode_to_vec();
+        let decoded = BlockWriteRequest::decode(encoded.as_slice()).unwrap();
+
+        assert_eq!(decoded.block.id, request.block.id);
+        assert_eq!(decoded.off, request.off);
+        assert_eq!(decoded.block_size, request.block_size);
+        assert_eq!(decoded.short_circuit, request.short_circuit);
+        assert_eq!(decoded.client_name, request.client_name);
+        assert_eq!(decoded.chunk_size, request.chunk_size);
+        assert!(decoded.pipeline_stream.is_empty());
+    }
+
+    #[test]
+    fn test_block_write_request_round_trip_with_pipeline_stream() {
+        let pipeline_stream = vec![create_test_worker_address(2), create_test_worker_address(3)];
+
+        let request = BlockWriteRequest {
+            block: create_test_block(),
+            off: 0,
+            block_size: 64 * 1024 * 1024,
+            short_circuit: false,
+            client_name: "test-client".to_string(),
+            chunk_size: 1024 * 1024,
+            pipeline_stream: pipeline_stream.clone(),
+        };
+
+        let encoded = request.encode_to_vec();
+        let decoded = BlockWriteRequest::decode(encoded.as_slice()).unwrap();
+
+        assert_eq!(decoded.pipeline_stream.len(), 2);
+        assert_eq!(decoded.pipeline_stream[0].worker_id, 2);
+        assert_eq!(decoded.pipeline_stream[1].worker_id, 3);
+        assert_eq!(decoded.pipeline_stream[0].ip_addr, "192.168.1.2");
+        assert_eq!(decoded.pipeline_stream[1].ip_addr, "192.168.1.3");
+    }
+
+    #[test]
+    fn test_pipeline_status_round_trip_success() {
+        let status = PipelineStatus {
+            success: true,
+            established_count: 3,
+            failed_worker: None,
+            error_message: None,
+        };
+
+        let encoded = status.encode_to_vec();
+        let decoded = PipelineStatus::decode(encoded.as_slice()).unwrap();
+
+        assert!(decoded.success);
+        assert_eq!(decoded.established_count, 3);
+        assert!(decoded.failed_worker.is_none());
+        assert!(decoded.error_message.is_none());
+    }
+
+    #[test]
+    fn test_pipeline_status_round_trip_failure() {
+        let failed_worker = create_test_worker_address(2);
+        let status = PipelineStatus {
+            success: false,
+            established_count: 1,
+            failed_worker: Some(failed_worker),
+            error_message: Some("Connection refused".to_string()),
+        };
+
+        let encoded = status.encode_to_vec();
+        let decoded = PipelineStatus::decode(encoded.as_slice()).unwrap();
+
+        assert!(!decoded.success);
+        assert_eq!(decoded.established_count, 1);
+        assert!(decoded.failed_worker.is_some());
+        assert_eq!(decoded.failed_worker.as_ref().unwrap().worker_id, 2);
+        assert_eq!(
+            decoded.error_message.as_ref().unwrap(),
+            "Connection refused"
+        );
+    }
+
+    #[test]
+    fn test_block_write_response_round_trip_without_pipeline_status() {
+        let response = BlockWriteResponse {
+            id: 12345,
+            path: Some("/data/block/12345".to_string()),
+            off: 0,
+            block_size: 64 * 1024 * 1024,
+            storage_type: StorageTypeProto::Disk as i32,
+            pipeline_status: None,
+        };
+
+        let encoded = response.encode_to_vec();
+        let decoded = BlockWriteResponse::decode(encoded.as_slice()).unwrap();
+
+        assert_eq!(decoded.id, response.id);
+        assert_eq!(decoded.path, response.path);
+        assert_eq!(decoded.off, response.off);
+        assert_eq!(decoded.block_size, response.block_size);
+        assert_eq!(decoded.storage_type, response.storage_type);
+        assert!(decoded.pipeline_status.is_none());
+    }
+
+    #[test]
+    fn test_block_write_response_round_trip_with_pipeline_status() {
+        let status = PipelineStatus {
+            success: true,
+            established_count: 3,
+            failed_worker: None,
+            error_message: None,
+        };
+
+        let response = BlockWriteResponse {
+            id: 12345,
+            path: None,
+            off: 0,
+            block_size: 64 * 1024 * 1024,
+            storage_type: StorageTypeProto::Disk as i32,
+            pipeline_status: Some(status),
+        };
+
+        let encoded = response.encode_to_vec();
+        let decoded = BlockWriteResponse::decode(encoded.as_slice()).unwrap();
+
+        assert!(decoded.pipeline_status.is_some());
+        let decoded_status = decoded.pipeline_status.unwrap();
+        assert!(decoded_status.success);
+        assert_eq!(decoded_status.established_count, 3);
+    }
+
+    #[test]
+    fn test_default_values() {
+        let request = BlockWriteRequest {
+            block: create_test_block(),
+            off: 0,
+            block_size: 64 * 1024 * 1024,
+            short_circuit: false,
+            client_name: String::new(),
+            chunk_size: 0,
+            pipeline_stream: vec![],
+        };
+
+        let encoded = request.encode_to_vec();
+        let decoded = BlockWriteRequest::decode(encoded.as_slice()).unwrap();
+
+        assert!(!decoded.short_circuit);
+        assert!(decoded.client_name.is_empty());
+        assert!(decoded.pipeline_stream.is_empty());
+    }
+}

--- a/curvine-server/src/worker/handler/batch_write_handler.rs
+++ b/curvine-server/src/worker/handler/batch_write_handler.rs
@@ -89,6 +89,7 @@ impl BatchWriteHandler {
                 short_circuit: header.short_circuit,
                 client_name: header.client_name.clone(),
                 chunk_size: header.chunk_size,
+                pipeline_stream: Vec::new(),
             };
 
             // Create single request message for each block

--- a/curvine-server/src/worker/handler/write_handler.rs
+++ b/curvine-server/src/worker/handler/write_handler.rs
@@ -126,6 +126,7 @@ impl WriteHandler {
             off: context.off,
             block_size: context.block_size,
             storage_type: meta.storage_type().into(),
+            pipeline_status: None,
         };
 
         let _ = mem::replace(&mut self.file, file);

--- a/curvine-server/tests/worker_test.rs
+++ b/curvine-server/tests/worker_test.rs
@@ -66,6 +66,7 @@ fn block_write(id: i64, conf: &ClusterConf) -> CommonResult<u64> {
         short_circuit: false,
         client_name: "test".to_string(),
         chunk_size: CHUNK_SIZE,
+        pipeline_stream: Vec::new(),
     };
 
     let req_id = Utils::req_id();


### PR DESCRIPTION
introduce the protocol, config, and error foundations required for pipeline replication, so later client/worker/master changes can rely on stable RPC messages and error types