### PR TITLE
build(fuse): support static compilation for curvine-fuse

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ license = "Apache-2.0"
 
 [workspace.dependencies]
 orpc = { path = "orpc" }
-curvine-common = { path = "curvine-common" }
+curvine-common = { path = "curvine-common", default-features = false }
 curvine-client = { path = "curvine-client" }
 curvine-libsdk = { path = "curvine-libsdk" }
 curvine-server = { path = "curvine-server" }

--- a/curvine-client/Cargo.toml
+++ b/curvine-client/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 
 [dependencies]
 orpc = { workspace = true }
-curvine-common = { workspace = true }
+curvine-common = { workspace = true, default-features = false }
 curvine-ufs = { workspace = true, optional = true }
 once_cell = { workspace = true }
 hyper = { workspace = true }

--- a/curvine-common/Cargo.toml
+++ b/curvine-common/Cargo.toml
@@ -11,7 +11,7 @@ orpc = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 log = { workspace = true }
-raft = { workspace = true }
+raft = { workspace = true, optional = true }
 prost = { workspace = true }
 prost-build = { workspace = true }
 serde = { workspace = true }
@@ -28,7 +28,7 @@ percent-encoding = "2.3"
 bincode = { workspace = true }
 thiserror = { workspace = true }
 crc32fast = { workspace = true }
-rocksdb = { workspace = true }
+rocksdb = { workspace = true, optional = true }
 byteorder = { workspace = true }
 flate2 = { workspace = true }
 dashmap = { workspace = true }
@@ -46,7 +46,8 @@ tracing = { workspace = true }
 bitflags = { workspace = true }
 
 [features]
-default = []
+default = ["raft"]
+raft = ["dep:raft", "dep:rocksdb"]
 
 [build-dependencies]
 prost-build = { workspace = true }

--- a/curvine-common/src/conf/cluster_conf.rs
+++ b/curvine-common/src/conf/cluster_conf.rs
@@ -14,6 +14,7 @@
 
 use crate::conf::CliConf;
 use crate::conf::{ClientConf, FuseConf, JobConf, JournalConf, MasterConf, WorkerConf};
+#[cfg(feature = "raft")]
 use crate::rocksdb::DBConf;
 use crate::version;
 use log::info;
@@ -239,6 +240,7 @@ impl ClusterConf {
     }
 
     // Get the rocksdb configuration used to obtain metadata
+    #[cfg(feature = "raft")]
     pub fn meta_rocks_conf(&self) -> DBConf {
         DBConf::new(&self.master.meta_dir)
             .set_compress_type(&self.master.meta_compression_type)

--- a/curvine-common/src/conf/journal_conf.rs
+++ b/curvine-common/src/conf/journal_conf.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::conf::ClusterConf;
-use crate::raft::RaftPeer;
+use crate::conf::RaftPeer;
 use orpc::client::ClientConf;
 use orpc::common::Utils;
 use orpc::io::net::{InetAddr, NetUtils};
@@ -153,6 +153,7 @@ impl JournalConf {
         }
     }
 
+    #[cfg(feature = "raft")]
     pub fn new_raft_conf(&self, id: u64, applied: u64) -> raft::Config {
         raft::Config {
             id,

--- a/curvine-common/src/conf/mod.rs
+++ b/curvine-common/src/conf/mod.rs
@@ -30,6 +30,9 @@ pub use self::fuse_conf::FuseConf;
 mod journal_conf;
 pub use self::journal_conf::JournalConf;
 
+mod raft_peer;
+pub use self::raft_peer::{NodeId, RaftPeer};
+
 mod size_string;
 pub use self::size_string::SizeString;
 

--- a/curvine-common/src/conf/raft_peer.rs
+++ b/curvine-common/src/conf/raft_peer.rs
@@ -12,13 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::raft::NodeId;
 use orpc::common::Utils;
 use orpc::io::net::InetAddr;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 
-// Represents a raft address
+/// Node ID type for raft peers
+pub type NodeId = u64;
+
+/// Represents a raft peer address
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(default)]
 pub struct RaftPeer {

--- a/curvine-common/src/error/fs_error.rs
+++ b/curvine-common/src/error/fs_error.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::fs::RpcCode;
+#[cfg(feature = "raft")]
 use crate::raft::RaftError;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
@@ -334,6 +335,7 @@ impl From<CommonError> for FsError {
     }
 }
 
+#[cfg(feature = "raft")]
 impl From<RaftError> for FsError {
     fn from(value: RaftError) -> Self {
         Self::Raft(ErrorImpl::with_source(value.to_string().into()))

--- a/curvine-common/src/executor/mod.rs
+++ b/curvine-common/src/executor/mod.rs
@@ -15,5 +15,7 @@
 mod scheduled_executor;
 pub use self::scheduled_executor::ScheduledExecutor;
 
+#[cfg(feature = "raft")]
 mod event_loop;
+#[cfg(feature = "raft")]
 pub use self::event_loop::EventLoop;

--- a/curvine-common/src/lib.rs
+++ b/curvine-common/src/lib.rs
@@ -18,7 +18,9 @@ pub mod conf;
 pub mod error;
 pub mod executor;
 pub mod fs;
+#[cfg(feature = "raft")]
 pub mod raft;
+#[cfg(feature = "raft")]
 pub mod rocksdb;
 pub mod state;
 pub mod utils;
@@ -27,6 +29,7 @@ pub mod version;
 pub mod proto {
     include!(concat!(env!("OUT_DIR"), "/protos/proto.rs"));
 
+    #[cfg(feature = "raft")]
     pub mod raft {
         include!(concat!(env!("OUT_DIR"), "/protos/raft.rs"));
     }

--- a/curvine-common/src/raft/mod.rs
+++ b/curvine-common/src/raft/mod.rs
@@ -34,8 +34,8 @@ pub use self::raft_journal::RaftJournal;
 mod raft_group;
 pub use self::raft_group::RaftGroup;
 
-mod raft_peer;
-pub use self::raft_peer::RaftPeer;
+// Re-export RaftPeer from conf module for backward compatibility
+pub use crate::conf::{NodeId, RaftPeer};
 
 mod raft_error;
 pub use self::raft_error::RaftError;
@@ -47,8 +47,6 @@ pub mod snapshot;
 
 mod raft_utils;
 pub use self::raft_utils::RaftUtils;
-
-pub type NodeId = u64;
 
 pub type RaftResult<T> = Result<T, RaftError>;
 

--- a/curvine-fuse/Cargo.toml
+++ b/curvine-fuse/Cargo.toml
@@ -7,8 +7,8 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-orpc = { workspace = true}
-curvine-common = { workspace = true }
+orpc = { workspace = true }
+curvine-common = { workspace = true, default-features = false }
 curvine-client = { workspace = true }
 log = { workspace = true }
 clap = { workspace = true }
@@ -37,6 +37,10 @@ serde = { workspace = true }
 default = ["fuse3"]
 fuse2 = []
 fuse3 = []
+# Enable static linking support:
+# - Skips pkg-config FUSE library check in build.rs
+# - Enables file-based user/group lookup instead of NSS in orpc
+static = ["orpc/static"]
 
 [build-dependencies]
 bindgen = { workspace = true }

--- a/curvine-fuse/build.rs
+++ b/curvine-fuse/build.rs
@@ -13,7 +13,10 @@
 // limitations under the License.
 
 fn main() {
-    #[cfg(target_os = "linux")]
+    // Skip FUSE library check when building statically.
+    // curvine-fuse uses pure Rust FUSE implementation with direct syscalls,
+    // it does NOT link against libfuse at runtime.
+    #[cfg(all(target_os = "linux", not(feature = "static")))]
     {
         use pkg_config::Config;
 

--- a/curvine-server/Cargo.toml
+++ b/curvine-server/Cargo.toml
@@ -12,7 +12,7 @@ jni = ["curvine-ufs/jni"]
 
 [dependencies]
 orpc = { workspace = true }
-curvine-common = { workspace = true }
+curvine-common = { workspace = true, features = ["raft"] }
 curvine-client = { workspace = true }
 curvine-ufs = { workspace = true }
 curvine-web = { workspace = true }

--- a/curvine-ufs/Cargo.toml
+++ b/curvine-ufs/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 
 [dependencies]
 orpc = { workspace = true }
-curvine-common = { workspace = true }
+curvine-common = { workspace = true, default-features = false }
 tokio = { workspace = true }
 async-trait = { workspace = true }
 bytes = { workspace = true }

--- a/orpc/Cargo.toml
+++ b/orpc/Cargo.toml
@@ -43,3 +43,9 @@ tracing-log = { workspace = true }
 fxhash = { workspace = true }
 moka = { workspace = true }
 md-5 = { workspace = true }
+
+[features]
+default = []
+# Use direct file parsing instead of NSS for user/group lookups.
+# Required for static linking with glibc to avoid NSS dynamic loading issues.
+static = []


### PR DESCRIPTION
- Add `server` feature to curvine-common to make rocksdb, raft, flate2 optional dependencies (only needed for master/worker nodes)
- Move RaftPeer and NodeId to conf module to avoid circular dependencies
- Add `static` feature to curvine-fuse to skip libfuse pkg-config check
- Fix musl libc compatibility issues in orpc and curvine-fuse:
  - Handle TMPFS_MAGIC type difference (musl: i64, glibc: u64)
  - Handle ioctl request param type difference (musl: i32, glibc: u64)
  - Handle request_code_read! macro return type difference

This enables building a fully static curvine-fuse binary using musl:
  cargo build --release --target x86_64-unknown-linux-musl \
    -p curvine-fuse --features static --no-default-features