### PR TITLE
feat: enable worker-side pipeline write handling and status reporting

### DIFF
--- a/curvine-client/src/block/block_writer_remote.rs
+++ b/curvine-client/src/block/block_writer_remote.rs
@@ -39,6 +39,16 @@ impl BlockWriterRemote {
         worker_address: WorkerAddress,
         pos: i64,
     ) -> FsResult<Self> {
+        Self::new_with_pipeline(fs_context, block, worker_address, pos, Vec::new()).await
+    }
+
+    pub async fn new_with_pipeline(
+        fs_context: &FsContext,
+        block: ExtendedBlock,
+        worker_address: WorkerAddress,
+        pos: i64,
+        pipeline_stream: Vec<WorkerAddress>,
+    ) -> FsResult<Self> {
         let req_id = Utils::req_id();
         let seq_id = 0;
         let block_size = fs_context.block_size();
@@ -53,7 +63,7 @@ impl BlockWriterRemote {
                 seq_id,
                 fs_context.write_chunk_size() as i32,
                 false,
-                Vec::new(),
+                pipeline_stream,
             )
             .await?;
 

--- a/curvine-common/src/conf/client_conf.rs
+++ b/curvine-common/src/conf/client_conf.rs
@@ -119,6 +119,8 @@ pub struct ClientConf {
     pub data_timeout_ms: u64,
     pub pipeline_timeout_ms: u64,
 
+    pub enable_pipeline_write: bool,
+
     // Number of fs master connections.
     // After testing 3 connections, the best performance can be achieved, so the default value is 3.
     pub master_conn_pool_size: usize,
@@ -363,6 +365,7 @@ impl Default for ClientConf {
             rpc_timeout_ms: 120 * 1000,
             data_timeout_ms: 120 * 1000,
             pipeline_timeout_ms: 120 * 1000,
+            enable_pipeline_write: false,
             master_conn_pool_size: 1,
 
             enable_read_ahead: true,

--- a/curvine-common/src/conf/worker_conf.rs
+++ b/curvine-common/src/conf/worker_conf.rs
@@ -159,6 +159,10 @@ pub struct WorkerConf {
 
     // Enable S3 gateway alongside worker
     pub enable_s3_gateway: bool,
+
+    pub pipeline_queue_size: usize,
+
+    pub pipeline_write_delay_ms: u64,
 }
 
 impl WorkerConf {
@@ -203,6 +207,8 @@ impl Default for WorkerConf {
             block_replication_concurrency_limit: 100,
             block_replication_chunk_size: 1024 * 1024,
             enable_s3_gateway: false,
+            pipeline_queue_size: 0,
+            pipeline_write_delay_ms: 0,
         }
     }
 }

--- a/curvine-server/src/worker/handler/block_handler.rs
+++ b/curvine-server/src/worker/handler/block_handler.rs
@@ -13,50 +13,109 @@
 // limitations under the License.
 
 use crate::worker::block::BlockStore;
-use crate::worker::handler::BlockHandler::{BatchWriter, Reader, Writer};
-use crate::worker::handler::{BatchWriteHandler, ReadHandler, WriteHandler};
+use crate::worker::handler::BlockHandler::{BatchWriter, PipelineWriter, Reader, Writer};
+use crate::worker::handler::WriteContext;
+use crate::worker::handler::{BatchWriteHandler, PipelineWriteHandler, ReadHandler, WriteHandler};
+use curvine_client::file::FsContext;
 use curvine_common::error::FsError;
 use curvine_common::fs::RpcCode;
 use curvine_common::FsResult;
+use log::warn;
+use orpc::error::ErrorExt;
 use orpc::handler::MessageHandler;
-use orpc::message::Message;
+use orpc::message::RequestStatus as ProtoRequestStatus;
+use orpc::message::{Builder, Message, ResponseStatus};
 use orpc::{err_box, CommonResult};
+use std::sync::Arc;
 
 pub enum BlockHandler {
     Writer(WriteHandler),
+    PipelineWriter(PipelineWriteHandler),
     Reader(ReadHandler),
     BatchWriter(BatchWriteHandler),
 }
 
 impl BlockHandler {
-    pub fn new(code: RpcCode, store: BlockStore) -> CommonResult<Self> {
-        let handler = match code {
-            RpcCode::WriteBlock => Writer(WriteHandler::new(store)),
+    pub fn new(msg: &Message, store: BlockStore, fs_context: Arc<FsContext>) -> CommonResult<Self> {
+        let code = RpcCode::from(msg.code());
+        if code != RpcCode::WriteBlock {
+            let handler = match code {
+                RpcCode::ReadBlock => Reader(ReadHandler::new(store)),
+                RpcCode::WriteBlocksBatch => BatchWriter(BatchWriteHandler::new(store, fs_context)),
+                code => return err_box!("Unsupported request type: {:?}", code),
+            };
+            return Ok(handler);
+        }
 
-            RpcCode::ReadBlock => Reader(ReadHandler::new(store)),
+        if msg.request_status() == ProtoRequestStatus::Open {
+            let ctx = WriteContext::from_req(msg)?;
+            let pipeline_enabled = fs_context.cluster_conf().client.enable_pipeline_write;
+            if ctx.has_pipeline_stream() && pipeline_enabled {
+                let queue_size = fs_context.cluster_conf().worker.pipeline_queue_size;
+                let pipeline_write_delay_ms =
+                    fs_context.cluster_conf().worker.pipeline_write_delay_ms;
+                return Ok(PipelineWriter(PipelineWriteHandler::new(
+                    store,
+                    fs_context,
+                    crate::worker::Worker::get_metrics(),
+                    queue_size,
+                    pipeline_write_delay_ms,
+                )));
+            }
+            if ctx.has_pipeline_stream() && !pipeline_enabled {
+                warn!(
+                    "BlockHandler::new_with_request: pipeline_stream ignored because pipeline write is disabled, block_id={}",
+                    ctx.block.id
+                );
+            }
+        }
 
-            RpcCode::WriteBlocksBatch => BatchWriter(BatchWriteHandler::new(store)),
-
-            code => return err_box!("Unsupported request type: {:?}", code),
-        };
-
-        Ok(handler)
+        Ok(Writer(WriteHandler::new(store)))
     }
 }
 
 impl MessageHandler for BlockHandler {
     type Error = FsError;
 
+    fn is_sync(&self, msg: &Message) -> bool {
+        match self {
+            Writer(h) => h.is_sync(msg),
+            PipelineWriter(h) => h.is_sync(msg),
+            Reader(_) => true,
+            BatchWriter(_) => true,
+        }
+    }
+
     fn handle(&mut self, msg: &Message) -> FsResult<Message> {
-        let response = match self {
+        let result = match self {
             Writer(h) => h.handle(msg),
+            PipelineWriter(h) => h.handle(msg),
             Reader(h) => h.handle(msg),
             BatchWriter(h) => h.handle(msg),
         };
+        result.or_else(|e| Ok(msg.error_ext(&e)))
+    }
 
-        match response {
-            Ok(v) => Ok(v),
-            Err(e) => Ok(msg.error_ext(&e)),
-        }
+    async fn async_handle(&mut self, msg: Message) -> FsResult<Message> {
+        let error_ctx = (msg.code(), msg.request_status(), msg.req_id(), msg.seq_id());
+
+        let result = match self {
+            Writer(h) => h.async_handle(msg).await,
+            PipelineWriter(h) => h.async_handle(msg).await,
+            Reader(h) => h.async_handle(msg).await,
+            BatchWriter(h) => h.async_handle(msg).await,
+        };
+
+        result.or_else(|e| {
+            let err_msg = Builder::new()
+                .code(error_ctx.0)
+                .request(error_ctx.1)
+                .response(ResponseStatus::Error)
+                .req_id(error_ctx.2)
+                .seq_id(error_ctx.3)
+                .data(orpc::sys::DataSlice::Buffer(e.encode()))
+                .build();
+            Ok(err_msg)
+        })
     }
 }

--- a/curvine-server/src/worker/handler/mod.rs
+++ b/curvine-server/src/worker/handler/mod.rs
@@ -18,6 +18,12 @@ pub use self::worker_handler::WorkerHandler;
 mod write_handler;
 pub use self::write_handler::WriteHandler;
 
+mod pipeline_writer;
+pub use self::pipeline_writer::{ClientPipelineForwarder, PipelineStream};
+
+mod pipeline_write_handler;
+pub use self::pipeline_write_handler::PipelineWriteHandler;
+
 mod batch_write_handler;
 pub use self::batch_write_handler::BatchWriteHandler;
 

--- a/curvine-server/src/worker/handler/pipeline_write_handler.rs
+++ b/curvine-server/src/worker/handler/pipeline_write_handler.rs
@@ -1,0 +1,428 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::worker::block::BlockStore;
+use crate::worker::handler::pipeline_writer::{ClientPipelineForwarder, PipelineStream};
+use crate::worker::handler::WriteContext;
+use crate::worker::handler::WriteHandler;
+use crate::worker::WorkerMetrics;
+use curvine_client::file::FsContext;
+use curvine_common::error::FsError;
+use curvine_common::proto::{BlockWriteResponse, DataHeaderProto, PipelineStatus};
+use curvine_common::state::{ExtendedBlock, WorkerAddress};
+use curvine_common::FsResult;
+use log::{debug, info, warn};
+use orpc::common::{ByteUnit, TimeSpent};
+use orpc::io::LocalFile;
+use orpc::message::{Builder, Message, RequestStatus};
+use orpc::{err_box, ternary, try_option_mut};
+use std::collections::HashSet;
+use std::mem;
+use std::sync::Arc;
+use tokio::time::{sleep, Duration};
+
+pub struct PipelineWriteHandler {
+    store: BlockStore,
+    context: Option<WriteContext>,
+    file: Option<LocalFile>,
+    is_commit: bool,
+    io_slow_us: u64,
+    pipeline_write_delay_ms: u64,
+    metrics: &'static WorkerMetrics,
+    pipeline_stream: Option<PipelineStream>,
+    forwarder: ClientPipelineForwarder,
+    last_processed_seq: i32,
+    processed_seq_ids: HashSet<(i64, i32)>,
+    had_pipeline_stream: bool,
+}
+
+impl PipelineWriteHandler {
+    pub fn new(
+        store: BlockStore,
+        fs_context: Arc<FsContext>,
+        metrics: &'static WorkerMetrics,
+        queue_size: usize,
+        pipeline_write_delay_ms: u64,
+    ) -> Self {
+        Self {
+            store,
+            context: None,
+            file: None,
+            is_commit: false,
+            io_slow_us: 0,
+            pipeline_write_delay_ms,
+            metrics,
+            pipeline_stream: None,
+            forwarder: ClientPipelineForwarder::new(fs_context, queue_size),
+            last_processed_seq: -1,
+            processed_seq_ids: HashSet::new(),
+            had_pipeline_stream: false,
+        }
+    }
+
+    pub fn set_io_slow_us(&mut self, io_slow_us: u64) {
+        self.io_slow_us = io_slow_us;
+    }
+
+    pub fn is_sync(&self, msg: &Message) -> bool {
+        if msg.request_status() == RequestStatus::Open {
+            match WriteContext::from_req(msg) {
+                Ok(ctx) => {
+                    let has_pipeline_stream = ctx.has_pipeline_stream();
+                    let result = !has_pipeline_stream;
+                    if has_pipeline_stream && result {
+                        warn!(
+                            "PipelineWriteHandler::is_sync: has_pipeline_stream=true but sync=true! block_id={}",
+                            ctx.block.id
+                        );
+                    }
+                    return result;
+                }
+                Err(e) => {
+                    warn!(
+                        "PipelineWriteHandler::is_sync: failed to parse WriteContext: {}",
+                        e
+                    );
+                }
+            }
+        }
+        !self.had_pipeline_stream
+    }
+
+    pub async fn async_handle(&mut self, msg: Message) -> FsResult<Message> {
+        let request_status = msg.request_status();
+        match request_status {
+            RequestStatus::Open => self.async_open(&msg).await,
+            RequestStatus::Running => self.async_write(msg).await,
+            RequestStatus::Complete => self.async_complete(&msg, true).await,
+            RequestStatus::Cancel => self.async_complete(&msg, false).await,
+            _ => err_box!("Unsupported request type"),
+        }
+    }
+
+    pub async fn async_open(&mut self, msg: &Message) -> FsResult<Message> {
+        let context = WriteContext::from_req(msg)?;
+
+        debug!(
+            "PipelineWriteHandler::async_open: block_id={}, pipeline_stream_count={}",
+            context.block.id,
+            context.pipeline_stream.len()
+        );
+
+        if context.off > context.block_size {
+            return err_box!(
+                "Invalid write offset: {}, block size: {}",
+                context.off,
+                context.block_size
+            );
+        }
+
+        let open_block = ExtendedBlock {
+            len: context.block_size,
+            ..context.block.clone()
+        };
+
+        let meta = self.store.open_block(&open_block)?;
+        let mut file = meta.create_writer(context.off, false)?;
+        WriteHandler::resize(&mut file, &context)?;
+
+        let (label, path, file) = if context.short_circuit {
+            ("local", file.path().to_string(), None)
+        } else {
+            ("remote", file.path().to_string(), Some(file))
+        };
+
+        let mut pipeline_status = PipelineStatus {
+            success: true,
+            established_count: 1,
+            failed_worker: None,
+            error_message: None,
+        };
+
+        if context.has_pipeline_stream() {
+            self.metrics.pipeline_establish_total.inc();
+            match self.establish_pipeline_stream(&context).await {
+                Ok(pipeline_stream) => {
+                    pipeline_status.established_count += pipeline_stream.established_count();
+                    self.pipeline_stream = Some(pipeline_stream);
+                    self.had_pipeline_stream = true;
+                    info!(
+                        "PipelineWriteHandler::async_open: Pipeline established, block_id={}, workers={}",
+                        context.block.id, pipeline_status.established_count
+                    );
+                }
+                Err(e) => {
+                    pipeline_status.success = false;
+                    self.metrics.pipeline_establish_failed.inc();
+                    pipeline_status.failed_worker = context.pipeline_stream.first().map(|w| {
+                        curvine_common::proto::WorkerAddressProto {
+                            worker_id: w.worker_id,
+                            hostname: w.hostname.clone(),
+                            ip_addr: w.ip_addr.clone(),
+                            rpc_port: w.rpc_port,
+                            web_port: w.web_port,
+                        }
+                    });
+                    pipeline_status.error_message = Some(e.to_string());
+                    warn!(
+                        "PipelineWriteHandler::async_open: Pipeline establishment failed, block_id={}, error={}",
+                        context.block.id,
+                        e
+                    );
+                }
+            }
+        }
+
+        let log_msg = format!(
+            "Write {}-block start req_id: {}, path: {:?}, chunk_size: {}, off: {}, block_size: {}, pipeline_established: {}",
+            label,
+            context.req_id,
+            path,
+            context.chunk_size,
+            context.off,
+            ByteUnit::byte_to_string(context.block_size as u64),
+            pipeline_status.established_count
+        );
+
+        let response = BlockWriteResponse {
+            id: meta.id,
+            path: ternary!(context.short_circuit, Some(path), None),
+            off: context.off,
+            block_size: context.block_size,
+            storage_type: meta.storage_type().into(),
+            pipeline_status: Some(pipeline_status),
+        };
+
+        let _ = mem::replace(&mut self.file, file);
+        let _ = self.context.replace(context);
+
+        self.metrics.write_blocks.with_label_values(&[label]).inc();
+
+        info!("{}", log_msg);
+        Ok(Builder::success(msg).proto_header(response).build())
+    }
+
+    pub async fn async_write(&mut self, mut msg: Message) -> FsResult<Message> {
+        let seq_id = msg.seq_id();
+        let req_id = msg.req_id();
+        if seq_id >= 0
+            && (self.is_duplicate_request(seq_id)
+                || self.processed_seq_ids.contains(&(req_id, seq_id)))
+        {
+            return Ok(msg.success());
+        }
+
+        let context = try_option_mut!(self.context);
+        Self::check_context(context, &msg)?;
+
+        if msg.header_len() > 0 {
+            let header: DataHeaderProto = msg.parse_header()?;
+            if !header.flush {
+                if header.offset < 0 || header.offset >= context.block_size {
+                    return err_box!(
+                        "Invalid seek offset: {}, block length: {}",
+                        header.offset,
+                        context.block_size
+                    );
+                }
+                if let Some(file) = &mut self.file {
+                    file.seek(header.offset)?;
+                }
+            }
+        }
+
+        let data_len = msg.data_len() as i64;
+        if data_len > 0 {
+            if self.pipeline_write_delay_ms > 0 && self.pipeline_stream.is_some() {
+                sleep(Duration::from_millis(self.pipeline_write_delay_ms)).await;
+            }
+            let block_size = context.block_size;
+            let file_pos = self.file.as_ref().map(|f| f.pos()).unwrap_or(0);
+
+            if file_pos + data_len > block_size {
+                return err_box!(
+                    "Write range [{}, {}) exceeds block size {}",
+                    file_pos,
+                    file_pos + data_len,
+                    block_size
+                );
+            }
+
+            let data = std::mem::replace(&mut msg.data, orpc::sys::DataSlice::Empty).freeze();
+            let io_slow_us = self.io_slow_us;
+
+            let local_write_future = {
+                if let Some(file) = self.file.take() {
+                    let data_clone = data.clone();
+                    Some(tokio::task::spawn_blocking(move || {
+                        let mut file = file;
+                        let spend = TimeSpent::new();
+                        let result = file.write_region(&data_clone);
+                        let used = spend.used_us();
+                        let path = file.path().to_string();
+                        (file, result, used, path)
+                    }))
+                } else {
+                    None
+                }
+            };
+
+            let forward_future = async {
+                if let Some(ref mut pipeline_stream) = self.pipeline_stream {
+                    pipeline_stream.write(data.clone()).await
+                } else {
+                    Ok(())
+                }
+            };
+
+            let (local_result, forward_result) = if let Some(local_future) = local_write_future {
+                let (local_res, forward_res) = tokio::join!(local_future, forward_future);
+                (Some(local_res), forward_res)
+            } else {
+                (None, forward_future.await)
+            };
+
+            if let Some(local_res) = local_result {
+                let (file, write_result, used, path) = local_res
+                    .map_err(|e| FsError::from(format!("spawn_blocking failed: {}", e)))?;
+                self.file = Some(file);
+                write_result?;
+
+                if used >= io_slow_us {
+                    warn!(
+                        "Slow write data from disk cost: {}us (threshold={}us), path: {}",
+                        used, io_slow_us, path
+                    );
+                }
+                self.metrics.write_time_us.inc_by(used as i64);
+            }
+
+            forward_result?;
+
+            self.metrics.write_bytes.inc_by(data_len);
+            self.metrics.write_count.inc();
+        }
+
+        self.update_last_seq(seq_id);
+        if seq_id >= 0 {
+            self.processed_seq_ids.insert((req_id, seq_id));
+        }
+        Ok(msg.success())
+    }
+
+    pub async fn async_complete(&mut self, msg: &Message, commit: bool) -> FsResult<Message> {
+        if self.is_commit {
+            return if !msg.data.is_empty() {
+                err_box!("The block has been committed and data cannot be written anymore.")
+            } else {
+                Ok(msg.success())
+            };
+        }
+
+        if let Some(context) = self.context.take() {
+            Self::check_context(&context, msg)?;
+        }
+        let context = WriteContext::from_req(msg)?;
+
+        let file = self.file.take();
+        if let Some(mut file) = file {
+            file.flush()?;
+            drop(file);
+        }
+
+        if context.block.len > context.block_size {
+            return err_box!(
+                "Invalid write offset: {}, block size: {}",
+                context.block.len,
+                context.block_size
+            );
+        }
+
+        if let Some(mut pipeline_stream) = self.pipeline_stream.take() {
+            pipeline_stream.complete(commit).await?;
+        }
+
+        self.commit_block(&context.block, commit)?;
+        self.is_commit = true;
+        self.processed_seq_ids.clear();
+
+        info!(
+            "write block end for req_id {}, is commit: {}, off: {}, len: {}",
+            msg.req_id(),
+            commit,
+            context.off,
+            context.block.len
+        );
+
+        Ok(msg.success())
+    }
+
+    fn is_duplicate_request(&self, seq_id: i32) -> bool {
+        seq_id >= 0 && seq_id <= self.last_processed_seq
+    }
+
+    fn update_last_seq(&mut self, seq_id: i32) {
+        if seq_id > self.last_processed_seq {
+            self.last_processed_seq = seq_id;
+        }
+    }
+
+    fn commit_block(&self, block: &ExtendedBlock, commit: bool) -> FsResult<()> {
+        if commit {
+            self.store.finalize_block(block)?;
+        } else {
+            self.store.abort_block(block)?;
+        }
+        Ok(())
+    }
+
+    fn check_context(context: &WriteContext, msg: &Message) -> FsResult<()> {
+        if msg.req_id() != context.req_id {
+            return err_box!(
+                "Invalid request id: current req_id {}, expected {}",
+                msg.req_id(),
+                context.req_id
+            );
+        }
+        Ok(())
+    }
+
+    async fn establish_pipeline_stream(&self, ctx: &WriteContext) -> FsResult<PipelineStream> {
+        let next_worker = ctx
+            .pipeline_stream
+            .first()
+            .ok_or_else(|| FsError::common("No pipeline stream worker specified"))?;
+        let remaining: Vec<WorkerAddress> = ctx.pipeline_stream[1..].to_vec();
+
+        info!(
+            "PipelineWriteHandler::establish_pipeline_stream: block_id={}, next_worker={}, remaining_count={}, remaining_workers={:?}",
+            ctx.block.id,
+            next_worker.worker_id,
+            remaining.len(),
+            remaining.iter().map(|w| w.worker_id).collect::<Vec<_>>()
+        );
+
+        let pipeline_stream = self.forwarder.connect(ctx).await?;
+
+        info!(
+            "PipelineWriteHandler::establish_pipeline_stream: SUCCESS block_id={}, next_worker={}",
+            ctx.block.id, next_worker.worker_id
+        );
+
+        Ok(pipeline_stream)
+    }
+
+    pub fn handle(&mut self, _msg: &Message) -> FsResult<Message> {
+        err_box!("PipelineWriteHandler only supports async_handle")
+    }
+}

--- a/curvine-server/src/worker/handler/pipeline_writer.rs
+++ b/curvine-server/src/worker/handler/pipeline_writer.rs
@@ -1,0 +1,215 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::worker::handler::WriteContext;
+use curvine_client::block::BlockWriterRemote;
+use curvine_client::file::FsContext;
+use curvine_common::error::FsError;
+use curvine_common::state::WorkerAddress;
+use curvine_common::FsResult;
+use orpc::sync::channel::{AsyncChannel, AsyncReceiver, AsyncSender, CallChannel, CallSender};
+use orpc::sync::ErrorMonitor;
+use orpc::sys::DataSlice;
+use std::sync::Arc;
+
+pub struct ClientPipelineForwarder {
+    fs_context: Arc<FsContext>,
+    queue_size: usize,
+}
+
+impl ClientPipelineForwarder {
+    pub fn new(fs_context: Arc<FsContext>, queue_size: usize) -> Self {
+        Self {
+            fs_context,
+            queue_size,
+        }
+    }
+
+    pub async fn connect(&self, ctx: &WriteContext) -> FsResult<PipelineStream> {
+        let next_worker = ctx
+            .pipeline_stream
+            .first()
+            .ok_or_else(|| FsError::common("No pipeline stream worker specified"))?;
+        let remaining: Vec<WorkerAddress> = ctx.pipeline_stream[1..].to_vec();
+
+        let writer = BlockWriterRemote::new(
+            &self.fs_context,
+            ctx.block.clone(),
+            next_worker.clone(),
+            ctx.off,
+        )
+        .await?;
+
+        Ok(PipelineStream::new(writer, remaining, self.queue_size))
+    }
+}
+
+enum PipelineTask {
+    Complete((bool, CallSender<i8>)),
+}
+
+struct PipelineChannel {
+    worker_id: u32,
+    data_sender: AsyncSender<DataSlice>,
+    task_sender: AsyncSender<PipelineTask>,
+    err_monitor: Arc<ErrorMonitor<FsError>>,
+}
+
+impl PipelineChannel {
+    fn new(writer: BlockWriterRemote, queue_size: usize) -> Self {
+        let worker_id = writer.worker_address().worker_id;
+        let (data_sender, data_receiver) = AsyncChannel::new(queue_size).split();
+        let (task_sender, task_receiver) = AsyncChannel::new(2).split();
+        let err_monitor = Arc::new(ErrorMonitor::new());
+        let monitor = err_monitor.clone();
+
+        tokio::spawn(async move {
+            let res = pipeline_writer_task(writer, data_receiver, task_receiver).await;
+            if let Err(e) = res {
+                monitor.set_error(e);
+            }
+        });
+
+        Self {
+            worker_id,
+            data_sender,
+            task_sender,
+            err_monitor,
+        }
+    }
+
+    fn wrap_error(&self, err: FsError) -> FsError {
+        FsError::pipeline_error(self.worker_id, err.to_string())
+    }
+
+    fn check_error(&self, err: FsError) -> FsError {
+        self.wrap_error(self.err_monitor.take_error().unwrap_or(err))
+    }
+
+    async fn write(&mut self, data: DataSlice) -> FsResult<()> {
+        self.err_monitor
+            .check_error()
+            .map_err(|e| self.wrap_error(e))?;
+        self.data_sender
+            .send(data)
+            .await
+            .map_err(|e| self.check_error(e.into()))?;
+        self.err_monitor
+            .check_error()
+            .map_err(|e| self.wrap_error(e))?;
+        Ok(())
+    }
+
+    async fn complete(&mut self, commit: bool) -> FsResult<()> {
+        let (tx, rx) = CallChannel::channel();
+        self.task_sender
+            .send(PipelineTask::Complete((commit, tx)))
+            .await
+            .map_err(|e| self.check_error(e.into()))?;
+        rx.receive().await.map_err(|e| self.check_error(e.into()))?;
+        self.err_monitor
+            .check_error()
+            .map_err(|e| self.wrap_error(e))?;
+        Ok(())
+    }
+}
+
+pub struct PipelineStream {
+    writer: Option<PipelineChannel>,
+    remaining_pipeline_stream: Vec<WorkerAddress>,
+}
+
+impl PipelineStream {
+    fn new(
+        writer: BlockWriterRemote,
+        remaining_pipeline_stream: Vec<WorkerAddress>,
+        queue_size: usize,
+    ) -> Self {
+        Self {
+            writer: Some(PipelineChannel::new(writer, queue_size)),
+            remaining_pipeline_stream,
+        }
+    }
+
+    pub fn established_count(&self) -> i32 {
+        self.remaining_pipeline_stream.len() as i32 + 1
+    }
+
+    pub async fn write(&mut self, data: DataSlice) -> FsResult<()> {
+        match self.writer.as_mut() {
+            Some(writer) => writer.write(data).await,
+            None => Ok(()),
+        }
+    }
+
+    pub async fn complete(&mut self, commit: bool) -> FsResult<()> {
+        match self.writer.as_mut() {
+            Some(writer) => writer.complete(commit).await,
+            None => Ok(()),
+        }
+    }
+}
+
+impl Drop for PipelineStream {
+    fn drop(&mut self) {
+        if let Some(mut writer) = self.writer.take() {
+            tokio::spawn(async move {
+                let _ = writer.complete(false).await;
+            });
+        }
+    }
+}
+
+async fn pipeline_writer_task(
+    mut writer: BlockWriterRemote,
+    mut data_receiver: AsyncReceiver<DataSlice>,
+    mut task_receiver: AsyncReceiver<PipelineTask>,
+) -> FsResult<()> {
+    loop {
+        let task = tokio::select! {
+            biased;
+
+            ctrl = task_receiver.recv_check() => {
+                ctrl.map(SelectTask::Control)?
+            }
+
+            data = data_receiver.recv_check() => {
+                data.map(SelectTask::Data)?
+            }
+        };
+
+        match task {
+            SelectTask::Data(chunk) => {
+                writer.write(chunk).await?;
+            }
+
+            SelectTask::Control(PipelineTask::Complete((commit, tx))) => {
+                while let Some(chunk) = data_receiver.try_recv()? {
+                    writer.write(chunk).await?;
+                }
+                if commit {
+                    writer.complete().await?;
+                } else {
+                    writer.cancel().await?;
+                }
+                tx.send(1)?;
+                return Ok(());
+            }
+        }
+    }
+}
+
+enum SelectTask {
+    Control(PipelineTask),
+    Data(DataSlice),
+}

--- a/curvine-server/src/worker/worker_metrics.rs
+++ b/curvine-server/src/worker/worker_metrics.rs
@@ -26,6 +26,8 @@ pub struct WorkerMetrics {
     pub(crate) write_time_us: Counter,
     pub(crate) write_count: Counter,
     pub(crate) write_blocks: CounterVec,
+    pub(crate) pipeline_establish_total: Counter,
+    pub(crate) pipeline_establish_failed: Counter,
 
     pub(crate) read_bytes: Counter,
     pub(crate) read_time_us: Counter,
@@ -52,6 +54,14 @@ impl WorkerMetrics {
             write_time_us: m::new_counter("write_time_us", "Microseconds spent writing")?,
             write_count: m::new_counter("write_count", "Number of writes")?,
             write_blocks: m::new_counter_vec("write_blocks", "write_blocks", &["type"])?,
+            pipeline_establish_total: m::new_counter(
+                "pipeline_establish_total",
+                "Total pipeline establishment attempts",
+            )?,
+            pipeline_establish_failed: m::new_counter(
+                "pipeline_establish_failed",
+                "Failed pipeline establishment attempts",
+            )?,
 
             read_bytes: m::new_counter("read_bytes", "worker read total bytes")?,
             read_time_us: m::new_counter("read_time_us", "Microseconds spent read")?,

--- a/curvine-server/src/worker/worker_server.rs
+++ b/curvine-server/src/worker/worker_server.rs
@@ -83,6 +83,7 @@ impl HandlerService for WorkerService {
             task_manager: self.task_manager.clone(),
             rt: self.rt.clone(),
             replication_handler: WorkerReplicationHandler::new(&self.replication_manager),
+            fs_context: self.task_manager.get_fs_context(),
         }
     }
 }

--- a/curvine-server/tests/worker_test.rs
+++ b/curvine-server/tests/worker_test.rs
@@ -66,7 +66,7 @@ fn block_write(id: i64, conf: &ClusterConf) -> CommonResult<u64> {
         short_circuit: false,
         client_name: "test".to_string(),
         chunk_size: CHUNK_SIZE,
-        pipeline_stream: Vec::new(),
+        pipeline_stream: vec![],
     };
 
     let req_id = Utils::req_id();


### PR DESCRIPTION
 enable worker-side pipeline write handling and status reporting with a temporary single-hop writer fallback for build isolation.
 
Core Functionality:
 - Worker-side support for pipeline writes: Parsing `pipeline_stream`, establishing downstream links, and sending back pipeline status.
- Extended write links: `WriteHandler` adds asynchronous pipeline establishment, forwarding, and failure handling.
- Enhanced monitoring and testing: Updates worker metrics and worker_test.