### PR TITLE
fix(ufs): set default file mode to 0o777 for UFS file status

### DIFF
--- a/curvine-ufs/src/opendal.rs
+++ b/curvine-ufs/src/opendal.rs
@@ -622,6 +622,7 @@ impl OpendalFileSystem {
             replicas: 1,
             block_size: 4 * 1024 * 1024,
             file_type: FileType::File,
+            mode: 0o777,
             ..Default::default()
         }
     }
@@ -647,6 +648,7 @@ impl OpendalFileSystem {
             is_complete: true,
             replicas: 1,
             block_size: 4 * 1024 * 1024,
+            mode: 0o777,
             ..Default::default()
         }
     }

--- a/curvine-ufs/src/oss_hdfs/oss_hdfs_filesystem.rs
+++ b/curvine-ufs/src/oss_hdfs/oss_hdfs_filesystem.rs
@@ -293,6 +293,7 @@ impl OssHdfsFileSystem {
             } else {
                 FileType::File
             },
+            mode: 0o777,
             ..Default::default()
         }
     }


### PR DESCRIPTION
When accessing files from UFS (e.g., S3, OSS) via FUSE mount, the access() system call was failing with EACCES (errno 13), even though ls -l showed correct permissions (0777).

Root cause:
- FileStatus returned by UFS layers used `..Default::default()` which set mode to 0 (u32::default())
- In FUSE's status_to_attr(), there was a fallback: when mode == 0, use FUSE_DEFAULT_MODE (0o777). This made ls -l display correct perms.
- However, check_access_permissions() used raw status.mode directly without this fallback, causing permission checks to fail.

Example log before fix:
  Access check: mode=0, permission_bits=0, mask=4 Read permission check: requested=true, granted=false FuseError { errno: 13, error: "Permission denied" }

Fix:
- Add explicit `mode: 0o777` in FileStatus construction for:
  - opendal.rs: write_status(), read_status()
  - oss_hdfs_filesystem.rs: new_file_status()

Note: file_status_from_info() in oss_hdfs already reads actual permissions from JindoFileInfo, so no change needed there.