### PR TITLE
fix(server): master_fs_test ut

### DIFF
--- a/curvine-server/src/master/fs/master_filesystem.rs
+++ b/curvine-server/src/master/fs/master_filesystem.rs
@@ -620,6 +620,13 @@ impl MasterFilesystem {
         fs_dir.create_tree()
     }
 
+    // Restore in-memory tree from RocksDB (for testing without Raft).
+    // In production, Raft automatically restores via apply_snapshot().
+    pub fn restore_from_rocksdb(&self) -> CommonResult<()> {
+        let mut fs_dir = self.fs_dir.write();
+        fs_dir.restore_from_rocksdb()
+    }
+
     fn block_exists(&self, id: i64) -> FsResult<bool> {
         let fs_dir = self.fs_dir.read();
         fs_dir.block_exists(id)

--- a/curvine-server/src/master/meta/fs_dir.rs
+++ b/curvine-server/src/master/meta/fs_dir.rs
@@ -624,6 +624,15 @@ impl FsDir {
         self.store.create_tree().map(|x| x.1)
     }
 
+    // Restore in-memory tree from RocksDB without checkpoint (for testing only).
+    // In production, use restore() with checkpoint path via Raft snapshot.
+    pub fn restore_from_rocksdb(&mut self) -> CommonResult<()> {
+        let (last_inode_id, root_dir) = self.store.create_tree()?;
+        self.root_dir = root_dir;
+        self.update_last_inode_id(last_inode_id)?;
+        Ok(())
+    }
+
     pub fn create_checkpoint(&self, id: u64) -> CommonResult<String> {
         self.store.create_checkpoint(id)
     }


### PR DESCRIPTION
In testing mode, fs only init an empty tree,  the journal won't start,  so will not restore file tree.  this case failed cause by #547 