### PR TITLE
refactor(common): remove circular dependency between conf and raft mo…

### DIFF
--- a/curvine-common/src/raft/raft_peer.rs
+++ b/curvine-common/src/raft/raft_peer.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::conf::JournalConf;
 use crate::raft::NodeId;
 use orpc::common::Utils;
 use orpc::io::net::InetAddr;
@@ -40,10 +39,6 @@ impl RaftPeer {
     pub fn from_addr<T: AsRef<str>>(hostname: T, port: u16) -> Self {
         let id = Self::create_id(format!("{}{}", hostname.as_ref(), port));
         Self::new(id, hostname, port)
-    }
-
-    pub fn from_conf(conf: &JournalConf) -> Self {
-        Self::from_addr(conf.hostname.clone(), conf.rpc_port)
     }
 
     fn create_id<T: AsRef<str>>(address: T) -> NodeId {


### PR DESCRIPTION
…dules

There was a circular dependency between the `conf` and `raft` modules:
- `conf/journal_conf.rs` imports `raft::RaftPeer` (for `journal_addrs` field)
- `raft/raft_peer.rs` imports `conf::JournalConf` (for `from_conf` method)

This creates a bidirectional dependency:

    conf::JournalConf ←→ raft::RaftPeer

While Rust allows such dependencies within the same crate, circular dependencies are an anti-pattern that leads to:
- High coupling between modules
- Unclear module responsibilities
- Increased maintenance burden
- Potential issues with future refactoring

Remove the unused `RaftPeer::from_conf()` method and its import of `JournalConf`. Analysis shows this method was never called anywhere in the codebase.

After this change, the dependency becomes unidirectional:

    conf::JournalConf → raft::RaftPeer (conf depends on raft)

Other raft module files still depend on `JournalConf` as input parameters, which is a normal unidirectional dependency (configuration flows into the raft module).

- Remove `use crate::conf::JournalConf;` from raft_peer.rs
- Remove `RaftPeer::from_conf()` method (unused)

- No breaking changes (removed method was unused)
- Cleaner module architecture with unidirectional dependencies
- Easier to understand and maintain module boundaries