### PR TITLE
feat(fuse): add configurable permission check and refactor permission…

### DIFF
--- a/curvine-common/src/conf/fuse_conf.rs
+++ b/curvine-common/src/conf/fuse_conf.rs
@@ -131,6 +131,8 @@ pub struct FuseConf {
 
     pub non_seekable: bool,
 
+    pub check_permission: bool,
+
     pub state_dir: String,
 
     /// The following are some time types, which are initialized only after init is called.
@@ -302,6 +304,7 @@ impl Default for FuseConf {
             write_back_cache: false,
             cache_readdir: false,
             non_seekable: false,
+            check_permission: true,
 
             state_dir: std::env::temp_dir().to_string_lossy().to_string(),
 


### PR DESCRIPTION
… validation

- Add check_permission flag in FuseConf to enable/disable permission checks
- Refactor permission checking logic into check_permissions_for_path method
- Replace duplicate permission check code in lookup, access, and open_dir
- Root user (uid=0) and disabled permission check bypass validation
- Default check_permission is true to maintain POSIX compliance