### PR TITLE
refactor(client): improve cache consistency and optimize job submissi…

### DIFF
--- a/curvine-server/src/master/fs/master_filesystem.rs
+++ b/curvine-server/src/master/fs/master_filesystem.rs
@@ -539,7 +539,10 @@ impl MasterFilesystem {
         let path = path.as_ref();
         let inp = Self::resolve_path(&fs_dir, path)?;
 
-        let inode = try_option!(inp.get_last_inode(), "File {} not exists", path);
+        let inode = match inp.get_last_inode() {
+            Some(v) => v,
+            None => return err_ext!(FsError::file_not_found(path)),
+        };
         let file = inode.as_file_ref()?;
         let block_locs = self.get_block_locs(path, &fs_dir, file)?;
         let locate_blocks = FileBlocks {


### PR DESCRIPTION
…on (##635)

  validation logic between get_cv_reader and get_status
- Fix data consistency issue: ensure both get_cv_reader and get_status use the same cache validity check logic
- Delay job submission in CacheSyncWriter: move from constructor to write_chunk to avoid submitting job when writer is created but not used
- Change job_res to Option<LoadJobResult> to handle lazy job submission
- Fix open_with_opts: only create UFS file when overwrite flag is set
- Improve error handling in master_filesystem for file not found cases