### PR TITLE
fix(fuse): improve FUSE cache invalidation and remove unused reply pa…

### DIFF
--- a/curvine-fuse/src/fs/file_system.rs
+++ b/curvine-fuse/src/fs/file_system.rs
@@ -97,11 +97,7 @@ pub trait FileSystem: Send + Sync + 'static {
         async move { err_fuse!(libc::ENOSYS, "{:?}", op) }
     }
 
-    fn open(
-        &self,
-        op: Open<'_>,
-        _reply: &FuseResponse,
-    ) -> impl Future<Output = FuseResult<fuse_open_out>> + Send {
+    fn open(&self, op: Open<'_>) -> impl Future<Output = FuseResult<fuse_open_out>> + Send {
         async move { err_fuse!(libc::ENOSYS, "{:?}", op) }
     }
 

--- a/curvine-fuse/src/session/channel/fuse_receiver.rs
+++ b/curvine-fuse/src/session/channel/fuse_receiver.rs
@@ -279,7 +279,7 @@ impl<T: FileSystem> FuseReceiver<T> {
 
             FuseOperator::Forget(op) => reply.send_none(fs.forget(op).await),
 
-            FuseOperator::Open(op) => reply.send_rep(fs.open(op, reply).await).await,
+            FuseOperator::Open(op) => reply.send_rep(fs.open(op).await).await,
 
             FuseOperator::MkNod(op) => reply.send_rep(fs.mk_nod(op).await).await,
 


### PR DESCRIPTION
…rameter

- Add should_keep_attr check in lookup to invalidate cache when file changes
- Remove unused reply parameter from open method
- Remove send_inode_out notification in open (rely on TTL-based expiration)
- Add should_keep_attr method to check if attribute cache should be kept
- Set entry_valid and attr_valid to 0 in lookup when file has changed"