### PR TITLE
fix: apply set_attr on InodeView clone to prevent race conditions

### DIFF
--- a/curvine-server/src/master/meta/fs_dir.rs
+++ b/curvine-server/src/master/meta/fs_dir.rs
@@ -755,11 +755,11 @@ impl FsDir {
         let child_opts = opts.child_opts();
         let recursive = opts.recursive;
         let parent_inode_id = inode.id();
-        let mut change_inodes: Vec<InodePtr> = vec![];
+        let mut change_inodes: Vec<InodeView> = vec![];
 
         // set current inode
         inode.as_mut().set_attr(opts);
-        change_inodes.push(inode.clone());
+        change_inodes.push(inode.as_ref().clone());
 
         // recursive set child inode
         if recursive {
@@ -768,7 +768,7 @@ impl FsDir {
             while let Some(cur_inode) = stack.pop_front() {
                 if cur_inode.id() != parent_inode_id {
                     cur_inode.as_mut().set_attr(child_opts.clone());
-                    change_inodes.push(cur_inode.clone());
+                    change_inodes.push(cur_inode.as_ref().clone());
                 }
 
                 //children may be FileEntry, so we need to load complete data from store

--- a/curvine-server/src/master/meta/store/inode_store.rs
+++ b/curvine-server/src/master/meta/store/inode_store.rs
@@ -14,7 +14,7 @@
 
 use crate::master::fs::DeleteResult;
 use crate::master::meta::inode::ttl::ttl_bucket::TtlBucketList;
-use crate::master::meta::inode::{InodeFile, InodePtr, InodeView, ROOT_INODE_ID};
+use crate::master::meta::inode::{InodeFile, InodeView, ROOT_INODE_ID};
 use crate::master::meta::store::{InodeWriteBatch, RocksInodeStore};
 use crate::master::meta::{FileSystemStats, FsDir, LockMeta};
 use curvine_common::rocksdb::{DBConf, RocksUtils};
@@ -205,10 +205,10 @@ impl InodeStore {
         batch.commit()
     }
 
-    pub fn apply_set_attr(&self, inodes: Vec<InodePtr>) -> CommonResult<()> {
+    pub fn apply_set_attr(&self, inodes: Vec<InodeView>) -> CommonResult<()> {
         let mut batch = self.store.new_batch();
         for inode in &inodes {
-            batch.write_inode(inode.as_ref())?;
+            batch.write_inode(inode)?;
         }
         batch.commit()?;
 


### PR DESCRIPTION
# Description:

**Crash** in `test_filesystem_end_to_end_operations_on_cluster`:
```
unsafe precondition(s) violated: slice::from_raw_parts requires the pointer to be aligned and non-null  
```


The crash occurs due to a **race condition** in `FsDir::unprotected_set_attr()` when `recursive=true`. The function collects `InodePtr` references (borrowed pointers) into a vector, then passes them to `InodeStore::apply_set_attr()` for serialization to RocksDB while other threads concurrently modify the inode view.

# Resolve for the issue: [#643](https://github.com/CurvineIO/curvine/issues/643)

# Solution
Create cloned `InodeView`s and pass them to `InodeStore::apply_set_attr()`.

# Changes
1. Update `InodeStore::apply_set_attr()` parameters from `Vec<InodePtr>` to `Vec<InodeView>`
