### PR TITLE
fix: align TtlActionProto with TtlAction enum and update file expirat…

### DIFF
--- a/curvine-common/proto/common.proto
+++ b/curvine-common/proto/common.proto
@@ -17,9 +17,10 @@ enum StorageTypeProto {
 // ttl Expiry Strategy.
 enum TtlActionProto {
     TTL_ACTION_PROTO_NONE = 0;
-    TTL_ACTION_PROTO_MOVE = 1;
-    TTL_ACTION_PROTO_UFS = 2;
-    TTL_ACTION_PROTO_DELETE = 3;
+    TTL_ACTION_PROTO_DELETE = 1;
+    TTL_ACTION_PROTO_PERSIST = 2;
+    TTL_ACTION_PROTO_EVICT = 3;
+    TTL_ACTION_PROTO_FLUSH = 4;
 }
 
 enum WriteTypeProto {

--- a/curvine-common/src/state/file_status.rs
+++ b/curvine-common/src/state/file_status.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::state::{FileType, StoragePolicy, TtlAction};
+use crate::state::{FileType, StoragePolicy};
 use orpc::common::LocalTime;
 use orpc::ternary;
 use serde::{Deserialize, Serialize};
@@ -73,7 +73,7 @@ impl FileStatus {
     }
 
     pub fn is_expired(&self) -> bool {
-        self.storage_policy.ttl_action == TtlAction::Delete
+        self.storage_policy.ttl_ms != 0
             && LocalTime::mills() as i64 > self.atime + self.storage_policy.ttl_ms
     }
 

--- a/curvine-common/src/utils/display.rs
+++ b/curvine-common/src/utils/display.rs
@@ -63,9 +63,10 @@ fn storage_type_to_str(storage_type: Option<i32>) -> &'static str {
 fn ttl_action_to_str(ttl_action: TtlActionProto) -> &'static str {
     match ttl_action {
         TtlActionProto::None => "none",
-        TtlActionProto::Move => "move",
-        TtlActionProto::Ufs => "ufs",
         TtlActionProto::Delete => "delete",
+        TtlActionProto::Persist => "persist",
+        TtlActionProto::Evict => "evict",
+        TtlActionProto::Flush => "flush",
     }
 }
 


### PR DESCRIPTION
…ion logic

- Update TtlActionProto enum in common.proto to match Rust TtlAction:
  * Replace MOVE/UFS/DELETE with DELETE/PERSIST/EVICT/FLUSH
  * Ensure enum values match between proto and Rust (0-4)
- Modify FileStatus::is_expired() to check ttl_ms != 0 instead of checking ttl_action == Delete, making expiration logic more general