### PR TITLE
fix: persist mount metadata across master switch

### DIFF
--- a/curvine-server/src/master/journal/mod.rs
+++ b/curvine-server/src/master/journal/mod.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 mod journal_writer;
-pub use self::journal_writer::JournalWriter;
+pub use self::journal_writer::{JournalEvent, JournalWriter};
 
 mod journal_loader;
 pub use self::journal_loader::JournalLoader;

--- a/curvine-server/src/master/meta/fs_dir.rs
+++ b/curvine-server/src/master/meta/fs_dir.rs
@@ -707,6 +707,7 @@ impl FsDir {
 
         if send_log {
             self.journal_writer.log_mount(op_ms, info)?;
+            self.journal_writer.flush()?;
         }
 
         Ok(())
@@ -722,6 +723,7 @@ impl FsDir {
         let op_ms = LocalTime::mills();
         self.store.store.remove_mountpoint(id)?;
         self.journal_writer.log_unmount(op_ms, id)?;
+        self.journal_writer.flush()?;
         Ok(())
     }
 

--- a/curvine-server/src/master/mount/mount_manager.rs
+++ b/curvine-server/src/master/mount/mount_manager.rs
@@ -83,8 +83,8 @@ impl MountManager {
         ufs_path: &str,
         mnt_opt: &MountOptions,
     ) -> FsResult<()> {
-        if !self.mount_table.exists(cv_path) {
-            return err_box!("update mode: mount point {} does not exist", ufs_path);
+        if !self.mount_table.mount_path_exists(cv_path) {
+            return err_box!("update mode: mount point {} does not exist", cv_path);
         }
 
         self.mount_table.umount(cv_path)?;

--- a/curvine-server/src/master/mount/mount_table.rs
+++ b/curvine-server/src/master/mount/mount_table.rs
@@ -61,40 +61,24 @@ impl MountTable {
         };
 
         let total = mounts.len();
-        info!(
-            "mount restore started: {} entries loaded from metadata store",
-            total
-        );
         if total == 0 {
             info!("mount restore completed: no entries found");
             return;
         }
+        info!(
+            "mount restore started: {} entries loaded from metadata store",
+            total
+        );
 
-        let mut restored = 0usize;
         let mut failed = 0usize;
 
         for mnt in mounts {
-            let mount_id = mnt.mount_id;
-            let cv_path = mnt.cv_path.clone();
-            let ufs_path = mnt.ufs_path.clone();
-
-            match self.unprotected_add_mount(mnt) {
-                Ok(_) => {
-                    restored += 1;
-                    info!(
-                        "mount restore entry succeeded: mount_id={}, cv_path={}, ufs_path={}",
-                        mount_id, cv_path, ufs_path
-                    );
-                }
-                Err(e) => {
-                    failed += 1;
-                    error!(
-                        "mount restore entry failed: mount_id={}, cv_path={}, ufs_path={}, err={}",
-                        mount_id, cv_path, ufs_path, e
-                    );
-                }
+            if let Err(e) = self.unprotected_add_mount(mnt) {
+                failed += 1;
+                error!("mount restore entry failed: err={}", e);
             }
         }
+        let restored = total - failed;
 
         if failed == 0 {
             info!(

--- a/curvine-server/src/test/mini_cluster.rs
+++ b/curvine-server/src/test/mini_cluster.rs
@@ -217,6 +217,13 @@ impl MiniCluster {
             .unwrap()
     }
 
+    pub fn get_standby_master_fs(&self) -> Option<MasterFilesystem> {
+        self.master_entries
+            .iter()
+            .find(|x| !x.0.master_monitor.is_active())
+            .map(|x| x.0.clone())
+    }
+
     pub fn get_active_master_replication_manager(&self) -> Arc<MasterReplicationManager> {
         self.master_entries
             .iter()

--- a/curvine-tests/tests/mount_failover_test.rs
+++ b/curvine-tests/tests/mount_failover_test.rs
@@ -1,0 +1,78 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use curvine_client::file::{FsClient, FsContext};
+use curvine_common::fs::Path;
+use curvine_common::state::MountOptions;
+use curvine_tests::Testing;
+use orpc::common::Logger;
+use orpc::runtime::RpcRuntime;
+use orpc::CommonResult;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+#[test]
+fn test_mount_replicated_to_standby_before_mount_returns() -> CommonResult<()> {
+    Logger::default();
+
+    // Expand journal flush window so replication lag is deterministic if mount does not force a flush.
+    let testing = Testing::builder()
+        .default()
+        .masters(2)
+        .workers(0)
+        .mutate_conf(|conf| {
+            conf.journal.writer_flush_batch_size = 1_000;
+            conf.journal.writer_flush_batch_ms = 60_000;
+            conf.journal.raft_tick_interval_ms = 100;
+        })
+        .build()?;
+
+    let cluster = testing.start_cluster()?;
+    let cluster_conf = testing.get_active_cluster_conf()?;
+    let rt = Arc::new(cluster_conf.client_rpc_conf().create_runtime());
+
+    rt.block_on(async {
+        let fs_context = Arc::new(FsContext::with_rt(cluster_conf.clone(), rt.clone())?);
+        let client = FsClient::new(fs_context);
+
+        let ufs_path = Path::from_str("oss://mount-failover-test/path")?;
+        let cv_path = Path::from_str("/mount-failover-test/path")?;
+        let opts = MountOptions::builder().build();
+
+        client.mount(&ufs_path, &cv_path, opts).await?;
+        Ok::<(), orpc::CommonError>(())
+    })?;
+
+    let standby_fs = cluster
+        .get_standby_master_fs()
+        .expect("expected one standby master in 2-master cluster");
+
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let mut replicated = false;
+    while Instant::now() < deadline {
+        let standby_mounts = standby_fs.fs_dir.read().get_mount_table()?;
+        if standby_mounts.len() == 1 {
+            replicated = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    assert!(
+        replicated,
+        "mount returned success, but standby still has no mount entry within 2s; leader cutover can lose mount info"
+    );
+
+    Ok(())
+}

--- a/curvine-tests/tests/mount_manager_test.rs
+++ b/curvine-tests/tests/mount_manager_test.rs
@@ -1,0 +1,230 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use curvine_common::conf::ClusterConf;
+use curvine_common::fs::Path;
+use curvine_common::state::MountOptions;
+use curvine_server::master::fs::MasterFilesystem;
+use curvine_server::master::journal::JournalSystem;
+use curvine_server::master::{Master, MountManager};
+use orpc::common::Utils;
+use orpc::CommonResult;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+struct MountEnv {
+    _conf: ClusterConf,
+    _js: JournalSystem,
+    _fs: MasterFilesystem,
+    mnt_mgr: Arc<MountManager>,
+}
+
+fn new_mount_env(name: &str, format_master: bool) -> MountEnv {
+    Master::init_test_metrics();
+
+    let mut conf = ClusterConf {
+        testing: true,
+        ..Default::default()
+    };
+    conf.change_test_meta_dir(format!("mount-manager-test/{}", name));
+    conf.format_master = format_master;
+    conf.journal.enable = false;
+
+    let js = JournalSystem::from_conf(&conf).unwrap();
+    let fs = MasterFilesystem::with_js(&conf, &js);
+    let mnt_mgr = js.mount_manager();
+
+    MountEnv {
+        _conf: conf,
+        _js: js,
+        _fs: fs,
+        mnt_mgr,
+    }
+}
+
+#[test]
+fn test_mount_basic_lookup_and_unmount_by_id() -> CommonResult<()> {
+    let env = new_mount_env(&format!("basic-{}", Utils::rand_str(6)), true);
+
+    let mut props = HashMap::new();
+    props.insert("k".to_string(), "v".to_string());
+    let opts = MountOptions::builder().set_properties(props).build();
+
+    env.mnt_mgr
+        .mount(None, "/data", "oss://bucket/data", &opts)?;
+
+    // Explicit mount id path (Some) should also work.
+    let explicit_id = 42_4242_u32;
+    env.mnt_mgr.mount(
+        Some(explicit_id),
+        "/data-explicit",
+        "oss://bucket/explicit",
+        &opts,
+    )?;
+
+    // Existing mount point path should take the "already exists" directory branch.
+    env._fs.mkdir("/pre-created", true)?;
+    env.mnt_mgr
+        .mount(None, "/pre-created", "oss://bucket/pre-created", &opts)?;
+
+    let table = env.mnt_mgr.get_mount_table()?;
+    assert_eq!(table.len(), 3);
+    let mount_id = table
+        .iter()
+        .find(|x| x.cv_path == "/data")
+        .unwrap()
+        .mount_id;
+    let pre_created_id = table
+        .iter()
+        .find(|x| x.cv_path == "/pre-created")
+        .unwrap()
+        .mount_id;
+    assert!(table.iter().any(|x| x.mount_id == explicit_id));
+
+    let cv_child = Path::from_str("/data/a/b.txt")?;
+    let cv_info = env.mnt_mgr.get_mount_info(&cv_child)?.unwrap();
+    assert_eq!(cv_info.cv_path, "/data");
+    assert_eq!(cv_info.ufs_path, "oss://bucket/data");
+
+    let ufs_child = Path::from_str("oss://bucket/data/a/b.txt")?;
+    let ufs_info = env.mnt_mgr.get_mount_info(&ufs_child)?.unwrap();
+    assert_eq!(ufs_info.cv_path, "/data");
+
+    env.mnt_mgr.unmount_by_id(mount_id)?;
+    env.mnt_mgr.unmount_by_id(pre_created_id)?;
+    env.mnt_mgr.unmount_by_id(explicit_id)?;
+    assert!(env.mnt_mgr.get_mount_table()?.is_empty());
+
+    Ok(())
+}
+
+#[test]
+fn test_mount_conflicts_and_duplicate_checks() -> CommonResult<()> {
+    let env = new_mount_env(&format!("conflict-{}", Utils::rand_str(6)), true);
+    let opts = MountOptions::builder().build();
+
+    env.mnt_mgr.mount(None, "/cv/a", "oss://bucket/a", &opts)?;
+
+    // Duplicate UFS path
+    let err = env
+        .mnt_mgr
+        .mount(None, "/cv/other", "oss://bucket/a", &opts)
+        .unwrap_err();
+    assert!(err.to_string().contains("already exists in mount table"));
+
+    // Duplicate CV mount path
+    let err = env
+        .mnt_mgr
+        .mount(None, "/cv/a", "oss://bucket/other", &opts)
+        .unwrap_err();
+    assert!(err.to_string().contains("already exists in mount table"));
+
+    // CV path prefix conflict
+    let err = env
+        .mnt_mgr
+        .mount(None, "/cv/a/sub", "oss://bucket/new", &opts)
+        .unwrap_err();
+    assert!(err.to_string().contains("is a prefix of"));
+
+    // UFS path prefix conflict
+    let err = env
+        .mnt_mgr
+        .mount(None, "/cv/new", "oss://bucket/a/sub", &opts)
+        .unwrap_err();
+    assert!(err.to_string().contains("is a prefix of"));
+
+    Ok(())
+}
+
+#[test]
+fn test_mount_update_mode_overwrites_existing_entry() -> CommonResult<()> {
+    let env = new_mount_env(&format!("update-{}", Utils::rand_str(6)), true);
+
+    let mut props1 = HashMap::new();
+    props1.insert("old".to_string(), "1".to_string());
+    let opts1 = MountOptions::builder().set_properties(props1).build();
+    env.mnt_mgr
+        .mount(None, "/cv/update", "oss://bucket-old/cv/update", &opts1)?;
+
+    // Update non-existing path should fail.
+    let missing_update = MountOptions::builder().update(true).build();
+    let err = env
+        .mnt_mgr
+        .mount(
+            None,
+            "/cv/not-exists",
+            "oss://bucket-new/cv/not-exists",
+            &missing_update,
+        )
+        .unwrap_err();
+    assert!(err.to_string().contains("does not exist"));
+
+    // Update existing path should succeed and replace properties/ufs path.
+    let mut props2 = HashMap::new();
+    props2.insert("new".to_string(), "2".to_string());
+    let update_opts = MountOptions::builder()
+        .update(true)
+        .set_properties(props2)
+        .build();
+
+    let updated_id = 77_7777_u32;
+    env.mnt_mgr.mount(
+        Some(updated_id),
+        "/cv/update",
+        "oss://bucket-new/cv/update",
+        &update_opts,
+    )?;
+
+    let info = env
+        .mnt_mgr
+        .get_mount_info(&Path::from_str("/cv/update/a.txt")?)?
+        .unwrap();
+
+    assert_eq!(info.ufs_path, "oss://bucket-new/cv/update");
+    assert_eq!(info.mount_id, updated_id);
+    assert_eq!(info.properties.get("new"), Some(&"2".to_string()));
+    assert!(!info.properties.contains_key("old"));
+
+    Ok(())
+}
+
+#[test]
+fn test_mount_restore_and_unprotected_paths() -> CommonResult<()> {
+    let name = format!("restore-{}", Utils::rand_str(6));
+
+    {
+        let env = new_mount_env(&name, true);
+        let opts = MountOptions::builder().build();
+        env.mnt_mgr
+            .mount(None, "/restore/x", "oss://restore/x", &opts)?;
+        assert_eq!(env.mnt_mgr.get_mount_table()?.len(), 1);
+    }
+
+    let env2 = new_mount_env(&name, false);
+    assert!(env2.mnt_mgr.get_mount_table()?.is_empty());
+
+    env2.mnt_mgr.restore();
+    let table = env2.mnt_mgr.get_mount_table()?;
+    assert_eq!(table.len(), 1);
+
+    let id = table[0].mount_id;
+    env2.mnt_mgr.unprotected_umount_by_id(id)?;
+    assert!(env2.mnt_mgr.get_mount_table()?.is_empty());
+
+    // Unprotected remove missing id should fail.
+    let err = env2.mnt_mgr.unprotected_umount_by_id(id).unwrap_err();
+    assert!(err.to_string().contains("failed found"));
+
+    Ok(())
+}

--- a/curvine-tests/tests/mount_table_test.rs
+++ b/curvine-tests/tests/mount_table_test.rs
@@ -1,0 +1,144 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use curvine_common::conf::ClusterConf;
+use curvine_common::fs::Path;
+use curvine_common::state::MountOptions;
+use curvine_server::master::fs::MasterFilesystem;
+use curvine_server::master::journal::JournalSystem;
+use curvine_server::master::mount::MountTable;
+use curvine_server::master::Master;
+use orpc::common::Utils;
+use orpc::CommonResult;
+use std::collections::HashMap;
+
+struct TableEnv {
+    _conf: ClusterConf,
+    _js: JournalSystem,
+    table: MountTable,
+}
+
+fn new_table_env(name: &str, format_master: bool) -> TableEnv {
+    Master::init_test_metrics();
+
+    let mut conf = ClusterConf {
+        testing: true,
+        ..Default::default()
+    };
+    conf.change_test_meta_dir(format!("mount-table-test/{}", name));
+    conf.format_master = format_master;
+    conf.journal.enable = false;
+
+    let js = JournalSystem::from_conf(&conf).unwrap();
+    let fs = MasterFilesystem::with_js(&conf, &js);
+    let table = MountTable::new(fs.fs_dir.clone());
+
+    TableEnv {
+        _conf: conf,
+        _js: js,
+        table,
+    }
+}
+
+#[test]
+fn test_mount_table_conflict_lookup_and_error_paths() -> CommonResult<()> {
+    let env = new_table_env(&format!("conflict-{}", Utils::rand_str(6)), true);
+    let opts = MountOptions::builder().build();
+
+    env.table.add_mount(100, "/cv/a", "oss://bucket/a", &opts)?;
+
+    // Existing path is child of incoming path: /cv/a has prefix /cv.
+    let err = env
+        .table
+        .check_conflict("/cv", "oss://bucket-new")
+        .unwrap_err();
+    assert!(err.to_string().contains("is a prefix of"));
+
+    // UFS child conflict: incoming ufs is under existing ufs.
+    let err = env
+        .table
+        .check_conflict("/other/path", "oss://bucket/a/sub")
+        .unwrap_err();
+    assert!(err.to_string().contains("is a prefix of"));
+
+    // UFS parent conflict: existing ufs is under incoming ufs.
+    let err = env
+        .table
+        .check_conflict("/other/path2", "oss://bucket")
+        .unwrap_err();
+    assert!(err.to_string().contains("is a prefix of"));
+
+    // Lookup miss path.
+    let miss = env.table.get_mount_info(&Path::from_str("/not/found")?)?;
+    assert!(miss.is_none());
+
+    // Missing umount path error.
+    let err = env.table.umount("/not/found").unwrap_err();
+    assert!(err.to_string().contains("failed found"));
+
+    // Missing id lookup error.
+    let err = env.table.get_mount_info_by_id(999999).unwrap_err();
+    assert!(err.to_string().contains("failed found"));
+
+    // Ensure assign id fast path is exercised.
+    let assigned = env.table.assign_mount_id()?;
+    assert_ne!(assigned, 0);
+
+    Ok(())
+}
+
+#[test]
+fn test_mount_table_get_ufs_conf_paths() -> CommonResult<()> {
+    let env = new_table_env(&format!("ufs-{}", Utils::rand_str(6)), true);
+
+    let mut props = HashMap::new();
+    props.insert("ak".to_string(), "sk".to_string());
+    props.insert("endpoint".to_string(), "http://example".to_string());
+    let opts = MountOptions::builder().set_properties(props).build();
+
+    env.table.add_mount(200, "/m", "oss://bucket/m", &opts)?;
+
+    let conf = env.table.get_ufs_conf(&"oss://bucket/m".to_string())?;
+    assert_eq!(conf.get("ak"), Some("sk"));
+    assert_eq!(conf.get("endpoint"), Some("http://example"));
+
+    let err = env
+        .table
+        .get_ufs_conf(&"oss://bucket/missing".to_string())
+        .unwrap_err();
+    assert!(err.to_string().contains("failed found"));
+
+    Ok(())
+}
+
+#[test]
+fn test_mount_table_restore_path() -> CommonResult<()> {
+    let name = format!("restore-{}", Utils::rand_str(6));
+
+    {
+        let env = new_table_env(&name, true);
+        let opts = MountOptions::builder().build();
+        env.table
+            .add_mount(300, "/restore/a", "oss://restore/a", &opts)?;
+        assert_eq!(env.table.get_mount_table()?.len(), 1);
+    }
+
+    let env2 = new_table_env(&name, false);
+    assert!(env2.table.get_mount_table()?.is_empty());
+
+    env2.table.restore();
+    assert_eq!(env2.table.get_mount_table()?.len(), 1);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- flush mount/unmount journal entries before returning success to avoid mount metadata loss during leader switch
- fix mount update-mode existence check to use curvine mount-path index
- expose standby master fs in mini cluster test helper for failover assertions
- add mount regression and coverage tests in curvine-tests (failover, mount manager, mount table)

## Verification
- cargo clippy --all-targets --jobs 2 -- --deny=warnings --allow clippy::uninlined-format-args
- cargo test -p curvine-tests --test mount_failover_test --test mount_manager_test --test mount_table_test -- --nocapture