### PR TITLE
fix(master): harden metadata replay compatibility for stale journal events

### DIFF
--- a/curvine-common/src/raft/storage/peer_storage.rs
+++ b/curvine-common/src/raft/storage/peer_storage.rs
@@ -213,7 +213,9 @@ where
 
             let snapshot = app_store.create_snapshot(node_id, last_applied)?;
             let snapshot_id = snapshot.snapshot_id;
-            log_store.create_snapshot(snapshot, last_applied)?;
+            // Use latest committed index when materializing raft snapshot metadata.
+            // This avoids binding snapshot data to a stale request index captured earlier.
+            log_store.create_snapshot(snapshot, u64::MAX)?;
             log_store.compact(compact_id)?;
 
             info!(

--- a/curvine-server/src/master/journal/journal_writer.rs
+++ b/curvine-server/src/master/journal/journal_writer.rs
@@ -25,16 +25,23 @@ use log::info;
 use std::sync::mpsc::{Receiver, SendError, Sender, SyncSender};
 use std::sync::{mpsc, Mutex};
 
+#[allow(clippy::large_enum_variant)]
+pub enum JournalEvent {
+    Entry(JournalEntry),
+    // None means success, Some(err) means flush failed.
+    Flush(SyncSender<Option<String>>),
+}
+
 enum SenderAdapter {
-    Bounded(SyncSender<JournalEntry>),
-    UnBounded(Sender<JournalEntry>),
+    Bounded(SyncSender<JournalEvent>),
+    UnBounded(Sender<JournalEvent>),
 }
 
 impl SenderAdapter {
-    fn send(&self, entry: JournalEntry) -> Result<(), SendError<JournalEntry>> {
+    fn send(&self, event: JournalEvent) -> Result<(), SendError<JournalEvent>> {
         match self {
-            SenderAdapter::Bounded(s) => s.send(entry),
-            SenderAdapter::UnBounded(s) => s.send(entry),
+            SenderAdapter::Bounded(s) => s.send(event),
+            SenderAdapter::UnBounded(s) => s.send(event),
         }
     }
 }
@@ -45,7 +52,7 @@ pub struct JournalWriter {
     debug: bool,
     sender: SenderAdapter,
     metrics: &'static MasterMetrics,
-    receiver: Option<Mutex<Receiver<JournalEntry>>>,
+    receiver: Option<Mutex<Receiver<JournalEvent>>>,
 }
 
 impl JournalWriter {
@@ -82,10 +89,30 @@ impl JournalWriter {
         }
 
         if self.enable {
-            self.sender.send(entry)?;
+            self.sender.send(JournalEvent::Entry(entry))?;
             self.metrics.journal_queue_len.inc();
         }
         Ok(())
+    }
+
+    pub fn flush(&self) -> FsResult<()> {
+        if !self.enable {
+            return Ok(());
+        }
+
+        // No sender task exists in testing mode.
+        if self.receiver.is_some() {
+            return Ok(());
+        }
+
+        let (sender, receiver) = mpsc::sync_channel(1);
+        self.sender.send(JournalEvent::Flush(sender))?;
+
+        match receiver.recv() {
+            Ok(None) => Ok(()),
+            Ok(Some(e)) => orpc::err_box!("flush journal failed: {}", e),
+            Err(e) => orpc::err_box!("flush journal failed: {}", e),
+        }
     }
 
     pub fn log_mkdir(&self, op_ms: u64, path: impl AsRef<str>, dir: &InodeDir) -> FsResult<()> {
@@ -249,7 +276,9 @@ impl JournalWriter {
         let mut entries = vec![];
 
         while let Ok(v) = self.receiver.as_ref().unwrap().lock().unwrap().try_recv() {
-            entries.push(v)
+            if let JournalEvent::Entry(entry) = v {
+                entries.push(entry);
+            }
         }
         entries
     }

--- a/curvine-server/src/master/journal/mod.rs
+++ b/curvine-server/src/master/journal/mod.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 mod journal_writer;
-pub use self::journal_writer::JournalWriter;
+pub use self::journal_writer::{JournalEvent, JournalWriter};
 
 mod journal_loader;
 pub use self::journal_loader::JournalLoader;

--- a/curvine-server/src/master/journal/sender_task.rs
+++ b/curvine-server/src/master/journal/sender_task.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::master::journal::{JournalBatch, JournalEntry};
+use crate::master::journal::{JournalBatch, JournalEvent};
 use crate::master::{Master, MasterMetrics};
 use curvine_common::conf::JournalConf;
 use curvine_common::raft::RaftClient;
@@ -49,7 +49,7 @@ impl SenderTask {
     }
 
     // Start a thread to execute sender task
-    pub fn spawn(self, receiver: mpsc::Receiver<JournalEntry>) -> FsResult<()> {
+    pub fn spawn(self, receiver: mpsc::Receiver<JournalEvent>) -> FsResult<()> {
         let poll = Duration::from_millis(self.flush_batch_ms);
         let name = "journal-writer".to_string();
         let task = self;
@@ -62,7 +62,7 @@ impl SenderTask {
     }
 
     fn loop0(
-        receiver: mpsc::Receiver<JournalEntry>,
+        receiver: mpsc::Receiver<JournalEvent>,
         poll: Duration,
         mut task: SenderTask,
     ) -> FsResult<()> {
@@ -77,35 +77,62 @@ impl SenderTask {
         }
     }
 
-    pub fn handle(&mut self, entry: Option<JournalEntry>) -> FsResult<()> {
-        if let Some(v) = entry {
-            self.batch.push(v);
-            self.metrics.journal_queue_len.dec();
-        }
+    fn flush_batch(&mut self) -> FsResult<()> {
+        let spend = TimeSpent::new();
+        let bytes = SerdeUtils::serialize(&self.batch)?;
+        self.client.block_on_send_propose(bytes)?;
 
+        self.metrics.journal_flush_count.inc();
+        self.metrics
+            .journal_flush_time
+            .inc_by(spend.used_us() as i64);
+
+        // Scroll to the next batch.
+        self.batch.next();
+        self.last_flush_ms = LocalTime::mills();
+        Ok(())
+    }
+
+    pub fn handle(&mut self, event: Option<JournalEvent>) -> FsResult<()> {
+        let mut flush_waiter = None;
+        if let Some(v) = event {
+            match v {
+                JournalEvent::Entry(entry) => {
+                    self.batch.push(entry);
+                    self.metrics.journal_queue_len.dec();
+                }
+                JournalEvent::Flush(waiter) => {
+                    flush_waiter = Some(waiter);
+                }
+            }
+        }
         let len = self.batch.len() as u64;
-        if len == 0 {
+        if len == 0 && flush_waiter.is_none() {
             return Ok(());
         }
 
-        if len >= self.flush_batch_size
+        let flush_now = flush_waiter.is_some()
+            || len >= self.flush_batch_size
             || LocalTime::mills() - self.last_flush_ms >= self.flush_batch_ms
-        {
-            let spend = TimeSpent::new();
+            || len == 0;
 
-            let bytes = SerdeUtils::serialize(&self.batch)?;
-            self.client.block_on_send_propose(bytes)?;
-
-            self.metrics.journal_flush_count.inc();
-            self.metrics
-                .journal_flush_time
-                .inc_by(spend.used_us() as i64);
-
-            // Scroll to the next batch.
-            self.batch.next();
-            self.last_flush_ms = LocalTime::mills();
+        if !flush_now {
+            return Ok(());
         }
 
-        Ok(())
+        let flush_result = if len == 0 { Ok(()) } else { self.flush_batch() };
+
+        if let Some(waiter) = flush_waiter {
+            match &flush_result {
+                Ok(_) => {
+                    let _ = waiter.send(None);
+                }
+                Err(e) => {
+                    let _ = waiter.send(Some(e.to_string()));
+                }
+            }
+        }
+
+        flush_result
     }
 }

--- a/curvine-tests/tests/journal_replay_regression_test.rs
+++ b/curvine-tests/tests/journal_replay_regression_test.rs
@@ -1,0 +1,262 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use curvine_common::conf::ClusterConf;
+use curvine_common::state::{BlockLocation, ClientAddress, CommitBlock, WorkerInfo};
+use curvine_server::master::fs::MasterFilesystem;
+use curvine_server::master::journal::{JournalEntry, JournalLoader, JournalSystem};
+use curvine_server::master::Master;
+use orpc::common::{LocalTime, Logger, Utils};
+use orpc::{err_box, CommonResult};
+
+#[test]
+fn test_replay_skips_stale_add_block_after_delete() -> CommonResult<()> {
+    Logger::default();
+    Master::init_test_metrics();
+
+    let mut conf = ClusterConf {
+        testing: true,
+        ..Default::default()
+    };
+
+    let case_name = format!(
+        "curvine-tests-issue-649-{}-{}",
+        LocalTime::mills(),
+        Utils::rand_str(6)
+    );
+    conf.change_test_meta_dir(&case_name);
+
+    let js = JournalSystem::from_conf(&conf)?;
+    let fs = MasterFilesystem::with_js(&conf, &js);
+    fs.add_test_worker(WorkerInfo::default());
+
+    let path = "/issue649-stale-add-block.log";
+    fs.create(path, true)?;
+    fs.add_block(path, ClientAddress::default(), vec![], vec![], 0, None)?;
+    fs.delete(path, true)?;
+
+    let mut create_entry: Option<JournalEntry> = None;
+    let mut delete_entry: Option<JournalEntry> = None;
+    let mut add_block_entry: Option<JournalEntry> = None;
+
+    for entry in js.fs().fs_dir.read().take_entries() {
+        match entry {
+            JournalEntry::CreateFile(_) if create_entry.is_none() => {
+                create_entry = Some(entry);
+            }
+            JournalEntry::Delete(_) if delete_entry.is_none() => {
+                delete_entry = Some(entry);
+            }
+            JournalEntry::AddBlock(_) if add_block_entry.is_none() => {
+                add_block_entry = Some(entry);
+            }
+            _ => {}
+        }
+    }
+
+    let create_entry = match create_entry {
+        Some(entry) => entry,
+        None => return err_box!("missing CreateFile journal entry"),
+    };
+    let delete_entry = match delete_entry {
+        Some(entry) => entry,
+        None => return err_box!("missing Delete journal entry"),
+    };
+    let add_block_entry = match add_block_entry {
+        Some(entry) => entry,
+        None => return err_box!("missing AddBlock journal entry"),
+    };
+
+    let mut replay_conf = conf.clone();
+    replay_conf.change_test_meta_dir(format!("{}-replay", case_name));
+
+    let replay_js = JournalSystem::from_conf(&replay_conf)?;
+    let replay_fs = MasterFilesystem::with_js(&replay_conf, &replay_js);
+    let loader = JournalLoader::new(
+        replay_fs.fs_dir(),
+        replay_js.mount_manager(),
+        &replay_conf.journal,
+    );
+
+    loader.apply_entry(create_entry)?;
+    loader.apply_entry(delete_entry)?;
+
+    // Simulate stale AddBlock log replaying after snapshot state where file was already deleted.
+    let replay_res = loader.apply_entry(add_block_entry);
+    assert!(
+        replay_res.is_ok(),
+        "stale AddBlock should be skipped during replay, got: {:?}",
+        replay_res
+    );
+    assert!(!replay_fs.exists(path)?);
+
+    Ok(())
+}
+
+#[test]
+fn test_replay_skips_stale_complete_file_after_delete() -> CommonResult<()> {
+    Logger::default();
+    Master::init_test_metrics();
+
+    let mut conf = ClusterConf {
+        testing: true,
+        ..Default::default()
+    };
+
+    let case_name = format!(
+        "curvine-tests-issue-649-complete-{}-{}",
+        LocalTime::mills(),
+        Utils::rand_str(6)
+    );
+    conf.change_test_meta_dir(&case_name);
+
+    let js = JournalSystem::from_conf(&conf)?;
+    let fs = MasterFilesystem::with_js(&conf, &js);
+    fs.add_test_worker(WorkerInfo::default());
+
+    let path = "/issue649-stale-complete-file.log";
+    let address = ClientAddress::default();
+    fs.create(path, true)?;
+    let add_block = fs.add_block(path, address.clone(), vec![], vec![], 0, None)?;
+    let commit = CommitBlock {
+        block_id: add_block.block.id,
+        block_len: add_block.block.len,
+        locations: vec![BlockLocation::with_id(add_block.locs[0].worker_id)],
+    };
+    fs.complete_file(
+        path,
+        add_block.block.len,
+        vec![commit],
+        &address.client_name,
+        false,
+    )?;
+    fs.delete(path, true)?;
+
+    let mut create_entry: Option<JournalEntry> = None;
+    let mut delete_entry: Option<JournalEntry> = None;
+    let mut complete_entry: Option<JournalEntry> = None;
+
+    for entry in js.fs().fs_dir.read().take_entries() {
+        match entry {
+            JournalEntry::CreateFile(_) if create_entry.is_none() => {
+                create_entry = Some(entry);
+            }
+            JournalEntry::Delete(_) if delete_entry.is_none() => {
+                delete_entry = Some(entry);
+            }
+            JournalEntry::CompleteFile(_) if complete_entry.is_none() => {
+                complete_entry = Some(entry);
+            }
+            _ => {}
+        }
+    }
+
+    let create_entry = match create_entry {
+        Some(entry) => entry,
+        None => return err_box!("missing CreateFile journal entry"),
+    };
+    let delete_entry = match delete_entry {
+        Some(entry) => entry,
+        None => return err_box!("missing Delete journal entry"),
+    };
+    let complete_entry = match complete_entry {
+        Some(entry) => entry,
+        None => return err_box!("missing CompleteFile journal entry"),
+    };
+
+    let mut replay_conf = conf.clone();
+    replay_conf.change_test_meta_dir(format!("{}-replay", case_name));
+
+    let replay_js = JournalSystem::from_conf(&replay_conf)?;
+    let replay_fs = MasterFilesystem::with_js(&replay_conf, &replay_js);
+    let loader = JournalLoader::new(
+        replay_fs.fs_dir(),
+        replay_js.mount_manager(),
+        &replay_conf.journal,
+    );
+
+    loader.apply_entry(create_entry)?;
+    loader.apply_entry(delete_entry)?;
+
+    // Simulate stale CompleteFile replaying after snapshot state where file was already deleted.
+    let replay_res = loader.apply_entry(complete_entry);
+    assert!(
+        replay_res.is_ok(),
+        "stale CompleteFile should be skipped during replay, got: {:?}",
+        replay_res
+    );
+    assert!(!replay_fs.exists(path)?);
+
+    Ok(())
+}
+
+#[test]
+fn test_replay_skips_stale_delete_when_path_missing() -> CommonResult<()> {
+    Logger::default();
+    Master::init_test_metrics();
+
+    let mut conf = ClusterConf {
+        testing: true,
+        ..Default::default()
+    };
+
+    let case_name = format!(
+        "curvine-tests-issue-649-delete-{}-{}",
+        LocalTime::mills(),
+        Utils::rand_str(6)
+    );
+    conf.change_test_meta_dir(&case_name);
+
+    let js = JournalSystem::from_conf(&conf)?;
+    let fs = MasterFilesystem::with_js(&conf, &js);
+
+    let path = "/issue649-stale-delete.log";
+    fs.create(path, true)?;
+    fs.delete(path, true)?;
+
+    let mut delete_entry: Option<JournalEntry> = None;
+    for entry in js.fs().fs_dir.read().take_entries() {
+        if let JournalEntry::Delete(_) = entry {
+            delete_entry = Some(entry);
+            break;
+        }
+    }
+
+    let delete_entry = match delete_entry {
+        Some(entry) => entry,
+        None => return err_box!("missing Delete journal entry"),
+    };
+
+    let mut replay_conf = conf.clone();
+    replay_conf.change_test_meta_dir(format!("{}-replay", case_name));
+
+    let replay_js = JournalSystem::from_conf(&replay_conf)?;
+    let replay_fs = MasterFilesystem::with_js(&replay_conf, &replay_js);
+    let loader = JournalLoader::new(
+        replay_fs.fs_dir(),
+        replay_js.mount_manager(),
+        &replay_conf.journal,
+    );
+
+    // Simulate stale Delete replaying after snapshot state where path is already absent.
+    let replay_res = loader.apply_entry(delete_entry);
+    assert!(
+        replay_res.is_ok(),
+        "stale Delete should be skipped during replay, got: {:?}",
+        replay_res
+    );
+    assert!(!replay_fs.exists(path)?);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Fix metadata replay compatibility for stale journal events so replay no longer fails when paths/inodes are already absent.
- Add a journal flush barrier before snapshot checkpointing, and bind raft snapshot metadata creation to the latest committed log index.
- Add regression tests in `curvine-tests` that reproduce stale replay ordering (`AddBlock`, `CompleteFile`, `Delete`) and verify replay succeeds.

## Root Cause
- Snapshot/checkpoint could race with asynchronous journal delivery, leaving stale journal events to be replayed against newer snapshot state.
- During replay, stale entries previously hard-failed with `Path not exists`, causing restore/replay failure.

## Changes
- `JournalLoader` now skips stale `AddBlock`, `CompleteFile`, and `Delete` entries when the target path/inode is already missing during replay.
- `JournalWriter`/`SenderTask` introduce a flush event barrier used by snapshot creation to drain queued journal entries before checkpoint.
- Snapshot creation path flushes journal before checkpoint creation.
- `PeerStorage` snapshot metadata creation uses the latest committed index at materialization time (`u64::MAX`) to avoid stale index binding.
- Added `curvine-tests/tests/journal_replay_regression_test.rs` for issue #649 scenarios.

## Performance and Compatibility
- No journal log format change and no RocksDB schema change.
- Flush barrier is only used on snapshot creation path, not on each metadata mutation path.
- Event queue keeps entry payload by value to avoid per-entry heap allocation; local lint allow is scoped to this enum only.

## Test Plan
- `cargo fmt --all`
- `RUSTC_WRAPPER= cargo test -p curvine-tests --test journal_replay_regression_test -- --nocapture`
- `RUSTC_WRAPPER= cargo clippy --all-targets --jobs 2 -- --deny=warnings --allow clippy::uninlined-format-args`
