### PR TITLE
fix(worker): truncate old block file when reusing blocks

### DIFF
--- a/curvine-server/src/worker/storage/vfs_dataset.rs
+++ b/curvine-server/src/worker/storage/vfs_dataset.rs
@@ -176,6 +176,10 @@ impl Dataset for VfsDataset {
                     // Create a new block meta, where block.len represents the block size
                     let new_meta = BlockMeta::new(meta.id, block.len, dir);
 
+                    // Truncate the old block file to avoid length mismatch when reusing blocks
+                    let file = new_meta.get_block_path()?;
+                    let _ = try_err!(fs::File::create(file));
+
                     dir.release_space(meta.is_final(), meta.actual_len);
                     dir.reserve_space(false, new_meta.len);
                     self.block_map.insert(new_meta.id(), new_meta.clone());


### PR DESCRIPTION
When a block is reused (open_block with existing block id), only the BlockMeta was updated but the old block file was not truncated. This caused the following issues:

1. Block length mismatch error in finalize_block: expected length (new data size) != actual length (old data remains on disk)
2. Cache task failure with error like: "Block 22229811200 length mismatch, expected: 34556, actual: 41759"
3. Empty cache files (size=0) created because writer was closed before data was written due to task failure
4. Client reads empty/corrupted data, causing image parsing failures

The fix adds File::create() call to truncate the old block file when reusing blocks, making it consistent with create_block() behavior.