### PR TITLE
fix(client): reject incomplete cache in check_cache_validity

### DIFF
--- a/curvine-client/src/unified/unified_filesystem.rs
+++ b/curvine-client/src/unified/unified_filesystem.rs
@@ -195,6 +195,16 @@ impl UnifiedFileSystem {
             return Ok(CacheValidity::Invalid(None));
         }
 
+        // Cache must be complete to be valid
+        if !cv_status.is_complete() {
+            log::debug!(
+                "check_cache_validity: INVALID - cache not complete, ufs_path={}, cv_len={}",
+                ufs_path,
+                cv_status.len
+            );
+            return Ok(CacheValidity::Invalid(None));
+        }
+
         if cv_status.is_cv_only() || mount.info.consistency_strategy == ConsistencyStrategy::None {
             return Ok(CacheValidity::Valid);
         }

--- a/curvine-common/src/state/file_status.rs
+++ b/curvine-common/src/state/file_status.rs
@@ -86,4 +86,8 @@ impl FileStatus {
     pub fn is_cv_only(&self) -> bool {
         self.storage_policy.ufs_mtime == 0
     }
+
+    pub fn is_complete(&self) -> bool {
+        self.is_complete
+    }
 }


### PR DESCRIPTION
When consistency_strategy=None, check_cache_validity() returned Valid without checking is_complete flag. This caused the following issue:

1. First open() -> CACHE MISS -> read from ufs + submit async cache job
2. Second open() (triggered by PIL or error handling) -> cache file exists but incomplete (is_complete=false, cv_len=0)
3. check_cache_validity() at unified_filesystem.rs:220 returned Valid because consistency_strategy=None, skipping is_complete check
4. Client received empty file, causing "image file is truncated" error

The fix adds is_complete check before the consistency_strategy check, ensuring incomplete cache is always treated as invalid.

Error path:
  open() -> get_cv_reader() -> check_cache_validity()
    -> consistency_strategy=None branch (line 220)
    -> returned Valid without checking is_complete
    -> SUSPICIOUS CACHE HIT warning logged but not blocked
    -> read from Curvine(cache) with len=0