### PR TITLE
fix(mount): preserve default TTL for legacy mount requests

### DIFF
--- a/curvine-cli/src/cmds/mount.rs
+++ b/curvine-cli/src/cmds/mount.rs
@@ -18,6 +18,7 @@ use curvine_client::unified::{UfsFileSystem, UnifiedFileSystem};
 use curvine_common::fs::{FileSystem, Path};
 use curvine_common::state::{
     ConsistencyStrategy, MountOptions, MountType, Provider, StorageType, TtlAction, WriteType,
+    DEFAULT_MOUNT_TTL_ACTION_STR, DEFAULT_MOUNT_TTL_STR,
 };
 use curvine_common::utils::ProtoUtils;
 use orpc::common::{ByteUnit, DurationUnit};
@@ -47,12 +48,12 @@ pub struct MountCommand {
     #[arg(long, default_value = "none")]
     consistency_strategy: String,
 
-    #[arg(long, default_value = "7d")]
+    #[arg(long, default_value_t = DEFAULT_MOUNT_TTL_STR.to_string())]
     ttl_ms: String,
 
     #[arg(
         long,
-        default_value = "delete",
+        default_value_t = DEFAULT_MOUNT_TTL_ACTION_STR.to_string(),
         help = "TTL expiration action when file expires:\n  none - No action\n  delete - Delete file\n  persist - Export to UFS (skip if exists), keep CV cache\n  evict - Export to UFS (skip if exists), delete CV cache\n  flush - Force export to UFS (overwrite), delete CV cache"
     )]
     ttl_action: String,

--- a/curvine-common/src/conf/client_conf.rs
+++ b/curvine-common/src/conf/client_conf.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::conf::ClusterConf;
+use crate::state::DEFAULT_MOUNT_TTL_STR;
 use crate::state::{StorageType, TtlAction};
 use orpc::client::ClientConf as RpcConf;
 use orpc::common::{ByteUnit, DurationUnit, Utils};
@@ -347,8 +348,8 @@ impl Default for ClientConf {
             ttl_action_str: "none".to_string(),
 
             auto_cache_enabled: false,
-            auto_cache_ttl: "7d".to_string(),
-            default_cache_ttl: Some("7d".to_string()),
+            auto_cache_ttl: DEFAULT_MOUNT_TTL_STR.to_string(),
+            default_cache_ttl: Some(DEFAULT_MOUNT_TTL_STR.to_string()),
 
             conn_retry_max_duration_ms: 60 * 1000,
             conn_retry_min_sleep_ms: 100,

--- a/curvine-common/src/state/mount.rs
+++ b/curvine-common/src/state/mount.rs
@@ -21,6 +21,11 @@ use orpc::{err_box, CommonError, CommonResult};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+pub const DEFAULT_MOUNT_TTL_STR: &str = "7d";
+pub const DEFAULT_MOUNT_TTL_ACTION_STR: &str = "delete";
+pub const DEFAULT_MOUNT_TTL_MS: i64 = 7 * DurationUnit::DAY as i64;
+pub const DEFAULT_MOUNT_TTL_ACTION: TtlAction = TtlAction::Delete;
+
 #[repr(i32)]
 #[derive(
     Debug,
@@ -236,8 +241,8 @@ impl MountOptions {
             ufs_path: ufs_path.to_string(),
             mount_id,
             properties: self.add_properties,
-            ttl_ms: self.ttl_ms.unwrap_or(0),
-            ttl_action: self.ttl_action.unwrap_or(TtlAction::None),
+            ttl_ms: self.ttl_ms.unwrap_or(DEFAULT_MOUNT_TTL_MS),
+            ttl_action: self.ttl_action.unwrap_or(DEFAULT_MOUNT_TTL_ACTION),
             consistency_strategy: self
                 .consistency_strategy
                 .unwrap_or(ConsistencyStrategy::None),
@@ -271,8 +276,8 @@ impl MountOptionsBuilder {
     pub fn new() -> Self {
         Self {
             write_type: WriteType::AsyncThrough,
-            ttl_ms: Some(7 * DurationUnit::DAY as i64),
-            ttl_action: Some(TtlAction::Delete),
+            ttl_ms: Some(DEFAULT_MOUNT_TTL_MS),
+            ttl_action: Some(DEFAULT_MOUNT_TTL_ACTION),
             ..Default::default()
         }
     }

--- a/curvine-common/src/utils/proto_utils.rs
+++ b/curvine-common/src/utils/proto_utils.rs
@@ -577,8 +577,11 @@ impl ProtoUtils {
         MountOptions {
             update: opts.update,
             add_properties: opts.add_properties,
-            ttl_ms: opts.ttl_ms,
-            ttl_action: opts.ttl_action.map(TtlAction::from),
+            ttl_ms: opts.ttl_ms.or(Some(DEFAULT_MOUNT_TTL_MS)),
+            ttl_action: opts
+                .ttl_action
+                .map(TtlAction::from)
+                .or(Some(DEFAULT_MOUNT_TTL_ACTION)),
             consistency_strategy: opts.consistency_strategy.map(ConsistencyStrategy::from),
             storage_type: opts.storage_type.map(StorageType::from),
             block_size: opts.block_size,

--- a/curvine-tests/tests/mount_ttl_compat_test.rs
+++ b/curvine-tests/tests/mount_ttl_compat_test.rs
@@ -1,0 +1,70 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use curvine_common::proto::MountOptionsProto;
+use curvine_common::state::{DEFAULT_MOUNT_TTL_ACTION, DEFAULT_MOUNT_TTL_MS};
+use curvine_common::utils::ProtoUtils;
+use std::collections::HashMap;
+
+#[test]
+fn test_mount_options_proto_without_ttl_uses_default_ttl() {
+    let mut add_properties = HashMap::new();
+    add_properties.insert(
+        "s3.endpoint_url".to_string(),
+        "http://localhost:9000".to_string(),
+    );
+
+    // Simulate an old client payload that does not carry ttl fields.
+    let opts_pb = MountOptionsProto {
+        update: false,
+        add_properties,
+        ttl_ms: None,
+        ttl_action: None,
+        consistency_strategy: None,
+        storage_type: None,
+        block_size: None,
+        replicas: None,
+        mount_type: 0,
+        remove_properties: vec![],
+        write_type: 2,
+        provider: None,
+    };
+
+    let opts = ProtoUtils::mount_options_from_pb(opts_pb);
+    assert_eq!(
+        opts.ttl_ms,
+        Some(DEFAULT_MOUNT_TTL_MS),
+        "pb decode should backfill missing ttl_ms"
+    );
+    assert_eq!(
+        opts.ttl_action,
+        Some(DEFAULT_MOUNT_TTL_ACTION),
+        "pb decode should backfill missing ttl_action"
+    );
+
+    let info = opts.to_info(1, "/mnt/s3", "s3://flink/user");
+
+    assert_eq!(
+        info.ttl_ms, DEFAULT_MOUNT_TTL_MS,
+        "missing ttl_ms should fall back to mount default"
+    );
+    assert_eq!(
+        info.ttl_action, DEFAULT_MOUNT_TTL_ACTION,
+        "missing ttl_action should fall back to mount default"
+    );
+    assert!(
+        info.auto_cache(),
+        "missing ttl should not disable async cache load"
+    );
+}


### PR DESCRIPTION
## Problem
Mount requests coming from legacy clients (or compatibility paths) may omit `ttl_ms` and `ttl_action` in `MountOptionsProto`.

In the previous flow, missing TTL fields were deserialized as `None`, then converted into `MountInfo` as `ttl_ms=0` and `ttl_action=none`. This disabled `auto_cache` and caused read miss paths to fall back to UFS instead of triggering async cache loading.

## Fix Intent
Ensure mount TTL behavior is stable and backward-compatible when optional TTL fields are missing, while keeping default handling centralized to avoid drift across modules.

## Implementation Details
- Added centralized mount default constants in `curvine-common/src/state/mount.rs`:
  - `DEFAULT_MOUNT_TTL_STR` (`7d`)
  - `DEFAULT_MOUNT_TTL_ACTION_STR` (`delete`)
  - `DEFAULT_MOUNT_TTL_MS`
  - `DEFAULT_MOUNT_TTL_ACTION`
- Updated `MountOptionsBuilder::new()` and `MountOptions::to_info()` to use these constants.
- Added compatibility backfill at protobuf decode boundary in `ProtoUtils::mount_options_from_pb()`:
  - missing `ttl_ms` => `DEFAULT_MOUNT_TTL_MS`
  - missing `ttl_action` => `DEFAULT_MOUNT_TTL_ACTION`
- Updated CLI mount defaults to reference shared constants instead of hardcoded literals.
- Updated client config defaults (`auto_cache_ttl`, `default_cache_ttl`) to reference the same shared mount TTL string constant.

## Tests
- Added regression test: `curvine-tests/tests/mount_ttl_compat_test.rs`
  - Reproduces legacy payload with missing TTL fields
  - Verifies decode-layer backfill and final `MountInfo` defaults
  - Verifies `auto_cache()` remains enabled

## Verification
- `RUSTC_WRAPPER= cargo check -p curvine-cli -p curvine-common`
- `RUSTC_WRAPPER= cargo test -p curvine-tests --test mount_ttl_compat_test -- --nocapture`