### PR TITLE
fix(unified): prevent hydrate/load jobs from overriding in-flight mount writes

### DIFF
--- a/curvine-client/src/rpc/job_master_client.rs
+++ b/curvine-client/src/rpc/job_master_client.rs
@@ -48,8 +48,28 @@ impl JobMasterClient {
     }
 
     pub async fn submit_load(&self, path: impl AsRef<str>) -> FsResult<LoadJobResult> {
-        self.submit_load_job(LoadJobCommand::builder(path.as_ref()).build())
+        self.submit_publish(path).await
+    }
+
+    pub async fn submit_publish(&self, path: impl AsRef<str>) -> FsResult<LoadJobResult> {
+        self.submit_load_job(LoadJobCommand::publish_builder(path.as_ref()).build())
             .await
+    }
+
+    pub async fn submit_hydrate(
+        &self,
+        path: impl AsRef<str>,
+        expected_target_mtime: Option<i64>,
+        expected_target_missing: bool,
+    ) -> FsResult<LoadJobResult> {
+        let mut builder = LoadJobCommand::hydrate_builder(path.as_ref());
+        if let Some(mtime) = expected_target_mtime {
+            builder = builder.expected_target_mtime(mtime);
+        }
+        if expected_target_missing {
+            builder = builder.expected_target_missing(true);
+        }
+        self.submit_load_job(builder.build()).await
     }
 
     // Submit loading task

--- a/curvine-client/src/unified/cache_sync_writer.rs
+++ b/curvine-client/src/unified/cache_sync_writer.rs
@@ -105,7 +105,7 @@ impl Writer for CacheSyncWriter {
         if self.job_res.is_none() && !self.has_random_access {
             let job_res = self
                 .job_client
-                .submit_load(self.inner.path().clone_uri())
+                .submit_publish(self.inner.path().clone_uri())
                 .await?;
             info!(
                 "submit(init) job successfully for {}, job id {}, target_path {}",
@@ -127,7 +127,10 @@ impl Writer for CacheSyncWriter {
         self.inner.complete().await?;
 
         if self.job_res.is_none() {
-            let job_res = self.job_client.submit_load(self.path().clone_uri()).await?;
+            let job_res = self
+                .job_client
+                .submit_publish(self.path().clone_uri())
+                .await?;
             info!(
                 "resubmit job successfully for {}, job id {}, target_path {}",
                 self.path(),

--- a/curvine-server/src/master/job/job_context.rs
+++ b/curvine-server/src/master/job/job_context.rs
@@ -84,6 +84,8 @@ impl JobContext {
             mount_info: mnt.clone(),
             create_time: LocalTime::mills() as i64,
             overwrite: job_conf.overwrite,
+            expected_target_mtime: job_conf.expected_target_mtime,
+            expected_target_missing: job_conf.expected_target_missing,
         };
 
         JobContext {

--- a/curvine-server/src/master/meta/inode/ttl/ttl_executor.rs
+++ b/curvine-server/src/master/meta/inode/ttl/ttl_executor.rs
@@ -331,6 +331,8 @@ impl InodeTtlExecutor {
             storage_type: None,
             ttl_ms: None,
             ttl_action: None,
+            expected_target_mtime: None,
+            expected_target_missing: None,
         };
 
         let job_result = self.job_manager.submit_load_job(command).map_err(|e| {


### PR DESCRIPTION
## Summary
This PR hardens mount read/write concurrency by preventing `ufs -> cv` hydrate jobs from overriding metadata for files that are currently being written through mount paths.

## Root Cause
The previous flow reused one `load` command for two opposite directions:
- publish: `cv -> ufs`
- hydrate: `ufs -> cv`

During read-miss auto-cache, hydrate jobs could be submitted while a write-through session on the same mount path was still in progress. In that window, hydrate execution could race with the writer lifecycle and overwrite/truncate the target CV metadata state.

## What Changed
### 1. Clarify job semantics in API
- Added explicit APIs in client:
  - `submit_publish(...)` for `cv -> ufs`
  - `submit_hydrate(...)` for `ufs -> cv`
- Kept `submit_load(...)` as backward-compatible alias to publish behavior.

### 2. Add hydrate snapshot guard fields
- Extended `LoadJobCommand` / `LoadJobInfo` with:
  - `expected_target_mtime`
  - `expected_target_missing`
- Auto-cache now submits hydrate with expected target snapshot and `overwrite=false`.

### 3. Master-side hydrate admission control
- Explicitly detect hydrate direction (`ufs -> cv`).
- Reject hydrate when:
  - active load jobs already touch the same CV path, or
  - target CV metadata is incomplete, or
  - target metadata no longer matches expected snapshot.

### 4. Worker-side execution fence
- Before creating hydrate target on CV, worker re-checks:
  - expected snapshot matches
  - target is not incomplete
- This closes the time window between master admission and worker execution.

### 5. Compatibility updates
- TTL export path initializes new optional fields as `None`.
- Existing builder semantics are preserved for backward compatibility.

## Why This Is Safe and Fast
- New checks are metadata-level comparisons only.
- Active job scan happens only on hydrate submission path.
- No data-plane copy path changes.

## Validation
- `cargo clippy --all-targets --jobs 2 -- --deny=warnings --allow clippy::uninlined-format-args`
- `RUSTC_WRAPPER= cargo check -p curvine-common -p curvine-client -p curvine-server`
- `RUSTC_WRAPPER= cargo test -p curvine-common state::job::tests:: -- --nocapture`
- `RUSTC_WRAPPER= cargo test -p curvine-server master::job::job_runner::tests:: -- --nocapture`
- `RUSTC_WRAPPER= cargo test -p curvine-client unified::unified_filesystem::tests:: -- --nocapture`
- `RUSTC_WRAPPER= cargo test -p curvine-tests --test write_cache_test test_mount_write_cache -- --nocapture` (skips when `UFS_TEST_PATH` is not configured)

## Files
- `curvine-client/src/rpc/job_master_client.rs`
- `curvine-client/src/unified/cache_sync_writer.rs`
- `curvine-client/src/unified/unified_filesystem.rs`
- `curvine-common/src/state/job.rs`
- `curvine-server/src/master/job/job_context.rs`
- `curvine-server/src/master/job/job_runner.rs`
- `curvine-server/src/worker/task/load_task_runner.rs`
- `curvine-server/src/master/meta/inode/ttl/ttl_executor.rs`
