### PR TITLE
fix(client): optimize cache validity check for cv-only files

### DIFF
--- a/curvine-client/src/unified/unified_filesystem.rs
+++ b/curvine-client/src/unified/unified_filesystem.rs
@@ -195,6 +195,10 @@ impl UnifiedFileSystem {
             return Ok(CacheValidity::Invalid(None));
         }
 
+        if cv_status.is_cv_only() {
+            return Ok(CacheValidity::Valid);
+        }
+
         // Cache must be complete to be valid
         if !cv_status.is_complete() {
             log::debug!(
@@ -205,7 +209,7 @@ impl UnifiedFileSystem {
             return Ok(CacheValidity::Invalid(None));
         }
 
-        if cv_status.is_cv_only() || mount.info.consistency_strategy == ConsistencyStrategy::None {
+        if mount.info.consistency_strategy == ConsistencyStrategy::None {
             return Ok(CacheValidity::Valid);
         }
 


### PR DESCRIPTION
- Move is_cv_only() check earlier in check_cache_validity to avoid unnecessary consistency checks for cv-only files
- cv-only files are always valid since they don't exist in UFS, so we can return early without checking completion status