### PR TITLE
feat(cli ): mount resync ufs metadata

### DIFF
--- a/build/tests/resync_e2e.sh
+++ b/build/tests/resync_e2e.sh
@@ -76,7 +76,7 @@ mc cp "$TMP_DIR/b.txt" "$b_mc_path" >/dev/null
 mc cp "$TMP_DIR/c.txt" "$c_mc_path" >/dev/null
 
 log "scenario A: initial resync"
-out_a="$(run_cv mount resync "$CV_PATH" --recursive --verbose 2>&1)"
+out_a="$(run_cv mount resync "$CV_PATH" --verbose 2>&1)"
 echo "$out_a"
 assert_not_contains "$out_a" "sender dropped|buffer writer error| ERROR " "resync output contains unexpected ERROR"
 
@@ -85,21 +85,21 @@ assert_contains "$cache_ls" "a.txt" "cache-only should include a.txt"
 assert_contains "$cache_ls" "b.txt|dir1" "cache-only should include nested entries"
 
 log "scenario B: same mtime -> skip"
-out_b="$(run_cv mount resync "$CV_PATH" --recursive --verbose 2>&1)"
+out_b="$(run_cv mount resync "$CV_PATH" --verbose 2>&1)"
 echo "$out_b"
 assert_contains "$out_b" "skip \(same mtime\)" "expected same-mtime skips"
 
 log "scenario C: cv ufs_mtime=0 -> skip"
 run_cv fs rm --cache-only "$CV_PATH/a.txt" >/dev/null || true
 run_cv fs touch --cache-only "$CV_PATH/a.txt" >/dev/null
-out_c="$(run_cv mount resync "$CV_PATH" --recursive --verbose 2>&1)"
+out_c="$(run_cv mount resync "$CV_PATH" --verbose 2>&1)"
 echo "$out_c"
 assert_contains "$out_c" "skip \(ufs_time=0\): $CV_PATH/a.txt" "expected ufs_time=0 skip for a.txt"
 
 log "scenario D: mtime mismatch -> recreate"
 echo "b2-mod" > "$TMP_DIR/b.txt"
 mc cp "$TMP_DIR/b.txt" "$b_mc_path" >/dev/null
-out_d="$(run_cv mount resync "$CV_PATH" --recursive --verbose 2>&1)"
+out_d="$(run_cv mount resync "$CV_PATH" --verbose 2>&1)"
 echo "$out_d"
 assert_contains "$out_d" "recreate $CV_PATH/dir1/b.txt" "expected recreate for dir1/b.txt"
 

--- a/build/tests/resync_e2e.sh
+++ b/build/tests/resync_e2e.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# E2E test for: `cv mount resync`
+CV_BIN="${CV_BIN:-/data/CodeSpace/curvine/build/dist/bin/cv}"
+CV_CONF="${CV_CONF:-/data/CodeSpace/curvine/build/dist/conf/curvine-cluster.toml}"
+MC_ALIAS="${MC_ALIAS:-local}"
+BUCKET="${BUCKET:-miniocluster}"
+UFS_PREFIX="${UFS_PREFIX:-curvine-test}"
+CV_PATH="${CV_PATH:-/miniocluster/curvine-test}"
+
+run_cv() {
+  "$CV_BIN" --conf "$CV_CONF" "$@"
+}
+
+log() { echo "[resync-e2e] $*"; }
+pass() { echo "[PASS] $*"; }
+fail() { echo "[FAIL] $*"; exit 1; }
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "command not found: $1"
+}
+
+assert_contains() {
+  local text="$1"
+  local pattern="$2"
+  local msg="$3"
+  echo "$text" | grep -qE "$pattern" || fail "$msg"
+}
+
+assert_not_contains() {
+  local text="$1"
+  local pattern="$2"
+  local msg="$3"
+  if echo "$text" | grep -qE "$pattern"; then
+    fail "$msg"
+  fi
+}
+
+need_cmd mc
+need_cmd "$CV_BIN"
+
+log "using CV_BIN=$CV_BIN"
+log "using CV_CONF=$CV_CONF"
+log "using MC_ALIAS=$MC_ALIAS BUCKET=$BUCKET UFS_PREFIX=$UFS_PREFIX"
+
+if ! run_cv mount | grep -q "$CV_PATH"; then
+  log "mount not found, creating mount for $CV_PATH"
+  run_cv mount "s3://$BUCKET/$UFS_PREFIX" "$CV_PATH" \
+    --config s3.endpoint_url=http://127.0.0.1:9009 \
+    --config s3.credentials.access=minio \
+    --config s3.credentials.secret=minio123 \
+    --config s3.force.path.style=true
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+echo "a1" > "$TMP_DIR/a.txt"
+echo "b1" > "$TMP_DIR/b.txt"
+echo "c1" > "$TMP_DIR/c.txt"
+
+a_mc_path="$MC_ALIAS/$BUCKET/$UFS_PREFIX/a.txt"
+b_mc_path="$MC_ALIAS/$BUCKET/$UFS_PREFIX/dir1/b.txt"
+c_mc_path="$MC_ALIAS/$BUCKET/$UFS_PREFIX/dir1/dir2/c.txt"
+
+log "uploading layered test files to UFS"
+mc cp "$TMP_DIR/a.txt" "$a_mc_path" >/dev/null
+mc cp "$TMP_DIR/b.txt" "$b_mc_path" >/dev/null
+mc cp "$TMP_DIR/c.txt" "$c_mc_path" >/dev/null
+
+log "scenario A: initial resync"
+out_a="$(run_cv mount resync "$CV_PATH" --recursive --verbose 2>&1)"
+echo "$out_a"
+assert_not_contains "$out_a" "sender dropped|buffer writer error| ERROR " "resync output contains unexpected ERROR"
+
+cache_ls="$(run_cv fs ls --cache-only "$CV_PATH/" 2>&1)"
+assert_contains "$cache_ls" "a.txt" "cache-only should include a.txt"
+assert_contains "$cache_ls" "b.txt|dir1" "cache-only should include nested entries"
+
+log "scenario B: same mtime -> skip"
+out_b="$(run_cv mount resync "$CV_PATH" --recursive --verbose 2>&1)"
+echo "$out_b"
+assert_contains "$out_b" "skip \(same mtime\)" "expected same-mtime skips"
+
+log "scenario C: cv ufs_mtime=0 -> skip"
+run_cv fs rm --cache-only "$CV_PATH/a.txt" >/dev/null || true
+run_cv fs touch --cache-only "$CV_PATH/a.txt" >/dev/null
+out_c="$(run_cv mount resync "$CV_PATH" --recursive --verbose 2>&1)"
+echo "$out_c"
+assert_contains "$out_c" "skip \(ufs_time=0\): $CV_PATH/a.txt" "expected ufs_time=0 skip for a.txt"
+
+log "scenario D: mtime mismatch -> recreate"
+echo "b2-mod" > "$TMP_DIR/b.txt"
+mc cp "$TMP_DIR/b.txt" "$b_mc_path" >/dev/null
+out_d="$(run_cv mount resync "$CV_PATH" --recursive --verbose 2>&1)"
+echo "$out_d"
+assert_contains "$out_d" "recreate $CV_PATH/dir1/b.txt" "expected recreate for dir1/b.txt"
+
+stat_b="$(run_cv fs stat --cache-only "$CV_PATH/dir1/b.txt" 2>&1)"
+assert_contains "$stat_b" "ufs_mtime: [1-9][0-9]+" "expected non-zero ufs_mtime in cache-only stat"
+
+pass "all resync scenarios passed"

--- a/build/tests/resync_e2e.sh
+++ b/build/tests/resync_e2e.sh
@@ -9,6 +9,10 @@ MC_ALIAS="${MC_ALIAS:-local}"
 BUCKET="${BUCKET:-miniocluster}"
 UFS_PREFIX="${UFS_PREFIX:-curvine-test}"
 CV_PATH="${CV_PATH:-/miniocluster/curvine-test}"
+S3_ENDPOINT_URL="${S3_ENDPOINT_URL:-http://127.0.0.1:9009}"
+S3_ACCESS_KEY="${S3_ACCESS_KEY:-minio}"
+S3_SECRET_KEY="${S3_SECRET_KEY:-minio123}"
+S3_FORCE_PATH_STYLE="${S3_FORCE_PATH_STYLE:-true}"
 
 run_cv() {
   "$CV_BIN" --conf "$CV_CONF" "$@"
@@ -44,14 +48,15 @@ need_cmd "$CV_BIN"
 log "using CV_BIN=$CV_BIN"
 log "using CV_CONF=$CV_CONF"
 log "using MC_ALIAS=$MC_ALIAS BUCKET=$BUCKET UFS_PREFIX=$UFS_PREFIX"
+log "using S3_ENDPOINT_URL=$S3_ENDPOINT_URL S3_FORCE_PATH_STYLE=$S3_FORCE_PATH_STYLE"
 
 if ! run_cv mount | grep -q "$CV_PATH"; then
   log "mount not found, creating mount for $CV_PATH"
   run_cv mount "s3://$BUCKET/$UFS_PREFIX" "$CV_PATH" \
-    --config s3.endpoint_url=http://127.0.0.1:9009 \
-    --config s3.credentials.access=minio \
-    --config s3.credentials.secret=minio123 \
-    --config s3.force.path.style=true
+    --config s3.endpoint_url="$S3_ENDPOINT_URL" \
+    --config s3.credentials.access="$S3_ACCESS_KEY" \
+    --config s3.credentials.secret="$S3_SECRET_KEY" \
+    --config s3.force.path.style="$S3_FORCE_PATH_STYLE"
 fi
 
 TMP_DIR="$(mktemp -d)"

--- a/build/tests/resync_e2e.sh
+++ b/build/tests/resync_e2e.sh
@@ -3,8 +3,10 @@
 set -euo pipefail
 
 # E2E test for: `cv mount resync`
-CV_BIN="${CV_BIN:-/data/CodeSpace/curvine/build/dist/bin/cv}"
-CV_CONF="${CV_CONF:-/data/CodeSpace/curvine/build/dist/conf/curvine-cluster.toml}"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/../.." >/dev/null 2>&1 && pwd)"
+CV_BIN="${CV_BIN:-$REPO_ROOT/build/dist/bin/cv}"
+CV_CONF="${CV_CONF:-$REPO_ROOT/build/dist/conf/curvine-cluster.toml}"
 MC_ALIAS="${MC_ALIAS:-local}"
 BUCKET="${BUCKET:-miniocluster}"
 UFS_PREFIX="${UFS_PREFIX:-curvine-test}"

--- a/curvine-cli/src/cmds/mount.rs
+++ b/curvine-cli/src/cmds/mount.rs
@@ -89,8 +89,12 @@ pub struct MountCommand {
     dry_run: bool,
 
     /// Traverse directories recursively in resync mode
-    #[arg(long, default_value_t = false)]
+    #[arg(long, default_value_t = true)]
     recursive: bool,
+
+    /// Disable recursive traversal in resync mode
+    #[arg(long, default_value_t = false)]
+    no_recursive: bool,
 
     #[arg(long, default_value_t = false)]
     verbose: bool,
@@ -271,6 +275,8 @@ impl MountCommand {
         let ufs_root = Path::from_str(&mount.ufs_path)?;
         let ufs = UfsFileSystem::new(&ufs_root, mount.properties.clone(), mount.provider)?;
 
+        let effective_recursive = self.recursive && !self.no_recursive;
+
         let mut stats = ResyncStats::default();
         let mut queue = VecDeque::from([ufs_root.clone()]);
 
@@ -287,7 +293,7 @@ impl MountCommand {
             for entry in entries {
                 let ufs_path = Path::from_str(entry.path)?;
                 if entry.is_dir {
-                    if self.recursive {
+                    if effective_recursive {
                         queue.push_back(ufs_path);
                     }
                     continue;

--- a/curvine-cli/src/cmds/mount.rs
+++ b/curvine-cli/src/cmds/mount.rs
@@ -84,7 +84,7 @@ pub struct MountCommand {
     #[arg(long, default_value_t = false)]
     check: bool,
 
-    /// Metadata-only resync mode: `curvine mount resync <cv_path>`
+    /// Perform a dry run: scan and report differences without create/delete/set_attr changes.
     #[arg(long, default_value_t = false)]
     dry_run: bool,
 
@@ -98,7 +98,6 @@ struct ResyncStats {
     skip_same_mtime: usize,
     skip_ufs_time_zero: usize,
     recreated: usize,
-    ufs_missing: usize,
     failed: usize,
 }
 
@@ -381,12 +380,11 @@ impl MountCommand {
         }
 
         println!(
-            "resync summary: scanned={}, skip_same_mtime={}, skip_ufs_time_zero={}, recreated={}, ufs_missing={}, failed={}",
+            "resync summary: scanned={}, skip_same_mtime={}, skip_ufs_time_zero={}, recreated={}, failed={}",
             stats.scanned,
             stats.skip_same_mtime,
             stats.skip_ufs_time_zero,
             stats.recreated,
-            stats.ufs_missing,
             stats.failed
         );
 

--- a/curvine-cli/src/cmds/mount.rs
+++ b/curvine-cli/src/cmds/mount.rs
@@ -364,6 +364,13 @@ impl MountCommand {
                     continue;
                 }
 
+                // Complete as an empty metadata placeholder.
+                if let Err(e) = client.complete_file(&cv_path, 0, Vec::new(), false).await {
+                    stats.failed += 1;
+                    eprintln!("[resync] failed to complete {}: {}", cv_path, e);
+                    continue;
+                }
+
                 let attr_opts = SetAttrOptsBuilder::new()
                     .mtime(ufs_mtime)
                     .ufs_mtime(ufs_mtime)

--- a/curvine-cli/src/cmds/mount.rs
+++ b/curvine-cli/src/cmds/mount.rs
@@ -88,14 +88,6 @@ pub struct MountCommand {
     #[arg(long, default_value_t = false)]
     dry_run: bool,
 
-    /// Traverse directories recursively in resync mode
-    #[arg(long, default_value_t = true)]
-    recursive: bool,
-
-    /// Disable recursive traversal in resync mode
-    #[arg(long, default_value_t = false)]
-    no_recursive: bool,
-
     #[arg(long, default_value_t = false)]
     verbose: bool,
 }
@@ -275,8 +267,6 @@ impl MountCommand {
         let ufs_root = Path::from_str(&mount.ufs_path)?;
         let ufs = UfsFileSystem::new(&ufs_root, mount.properties.clone(), mount.provider)?;
 
-        let effective_recursive = self.recursive && !self.no_recursive;
-
         let mut stats = ResyncStats::default();
         let mut queue = VecDeque::from([ufs_root.clone()]);
 
@@ -293,9 +283,7 @@ impl MountCommand {
             for entry in entries {
                 let ufs_path = Path::from_str(entry.path)?;
                 if entry.is_dir {
-                    if effective_recursive {
-                        queue.push_back(ufs_path);
-                    }
+                    queue.push_back(ufs_path);
                     continue;
                 }
 

--- a/curvine-cli/src/cmds/mount.rs
+++ b/curvine-cli/src/cmds/mount.rs
@@ -17,12 +17,13 @@ use clap::Parser;
 use curvine_client::unified::{UfsFileSystem, UnifiedFileSystem};
 use curvine_common::fs::{FileSystem, Path};
 use curvine_common::state::{
-    ConsistencyStrategy, MountOptions, MountType, Provider, StorageType, TtlAction, WriteType,
+    ConsistencyStrategy, MountOptions, MountType, Provider, SetAttrOptsBuilder, StorageType,
+    TtlAction, WriteType,
 };
 use curvine_common::utils::ProtoUtils;
 use orpc::common::{ByteUnit, DurationUnit};
 use orpc::{err_box, CommonResult};
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 
 #[derive(Parser, Debug)]
 pub struct MountCommand {
@@ -81,10 +82,35 @@ pub struct MountCommand {
 
     #[arg(long, default_value_t = false)]
     check: bool,
+
+    /// Metadata-only resync mode: `curvine mount resync <cv_path>`
+    #[arg(long, default_value_t = false)]
+    dry_run: bool,
+
+    /// Traverse directories recursively in resync mode
+    #[arg(long, default_value_t = false)]
+    recursive: bool,
+
+    #[arg(long, default_value_t = false)]
+    verbose: bool,
+}
+
+#[derive(Default)]
+struct ResyncStats {
+    scanned: usize,
+    skip_same_mtime: usize,
+    skip_ufs_time_zero: usize,
+    recreated: usize,
+    ufs_missing: usize,
+    failed: usize,
 }
 
 impl MountCommand {
     pub async fn execute(&self, fs: UnifiedFileSystem) -> CommonResult<()> {
+        if self.ufs_path.trim() == "resync" {
+            return self.execute_resync(fs).await;
+        }
+
         // If no path argument is given, all mount points are listed.
         if self.ufs_path.trim().is_empty() && self.cv_path.trim().is_empty() {
             let rep = handle_rpc_result(fs.fs_client().get_mount_table()).await;
@@ -225,6 +251,136 @@ impl MountCommand {
 
         handle_rpc_result(fs.mount(&ufs_path, &cv_path, mnt_opts)).await;
         println!("│ ✅️ mount success.");
+        Ok(())
+    }
+
+    async fn execute_resync(&self, fs: UnifiedFileSystem) -> CommonResult<()> {
+        let cv_root = Path::from_str(&self.cv_path)?;
+        if !cv_root.is_cv() {
+            return err_box!("resync requires a curvine path, got: {}", self.cv_path);
+        }
+
+        let mount = match fs.fs_client().get_mount_info(&cv_root).await? {
+            Some(v) => v,
+            None => return err_box!("mount info not found for {}", self.cv_path),
+        };
+
+        let ufs_root = Path::from_str(&mount.ufs_path)?;
+        let ufs = UfsFileSystem::new(&ufs_root, mount.properties.clone(), mount.provider)?;
+
+        let mut stats = ResyncStats::default();
+        let mut queue = VecDeque::from([cv_root.clone()]);
+
+        while let Some(path) = queue.pop_front() {
+            let status = match fs.cv().get_status(&path).await {
+                Ok(v) => v,
+                Err(e) => {
+                    stats.failed += 1;
+                    eprintln!("[resync] failed to get cv status {}: {}", path, e);
+                    continue;
+                }
+            };
+
+            if status.is_dir {
+                if self.recursive || path == cv_root {
+                    let children = match fs.cv().list_status(&path).await {
+                        Ok(v) => v,
+                        Err(e) => {
+                            stats.failed += 1;
+                            eprintln!("[resync] failed to list {}: {}", path, e);
+                            continue;
+                        }
+                    };
+
+                    for child in children {
+                        queue.push_back(Path::from_str(child.path)?);
+                    }
+                }
+                continue;
+            }
+
+            stats.scanned += 1;
+            let cv_ufs_mtime = status.storage_policy.ufs_mtime;
+
+            if cv_ufs_mtime == 0 {
+                stats.skip_ufs_time_zero += 1;
+                if self.verbose {
+                    println!("[resync] skip (ufs_time=0): {}", path);
+                }
+                continue;
+            }
+
+            let ufs_path = mount.get_ufs_path(&path)?;
+            let ufs_status = match ufs.get_status(&ufs_path).await {
+                Ok(v) => v,
+                Err(e) => {
+                    stats.ufs_missing += 1;
+                    if self.verbose {
+                        eprintln!("[resync] ufs missing or unavailable {}: {}", ufs_path, e);
+                    }
+                    continue;
+                }
+            };
+
+            if cv_ufs_mtime == ufs_status.mtime {
+                stats.skip_same_mtime += 1;
+                if self.verbose {
+                    println!("[resync] skip (same mtime): {}", path);
+                }
+                continue;
+            }
+
+            if self.verbose || self.dry_run {
+                println!(
+                    "[resync] recreate {} (cv_ufs_mtime={}, ufs_mtime={})",
+                    path, cv_ufs_mtime, ufs_status.mtime
+                );
+            }
+
+            if self.dry_run {
+                stats.recreated += 1;
+                continue;
+            }
+
+            if let Err(e) = fs.cv().delete(&path, false).await {
+                stats.failed += 1;
+                eprintln!("[resync] failed to delete {}: {}", path, e);
+                continue;
+            }
+
+            let mut create_opts = mount.get_create_opts(&fs.conf().client);
+            create_opts.storage_policy.ufs_mtime = ufs_status.mtime;
+
+            if let Err(e) = fs.cv().create_with_opts(&path, create_opts, true).await {
+                stats.failed += 1;
+                eprintln!("[resync] failed to create {}: {}", path, e);
+                continue;
+            }
+
+            let attr_opts = SetAttrOptsBuilder::new()
+                .mtime(ufs_status.mtime)
+                .ufs_mtime(ufs_status.mtime)
+                .build();
+
+            if let Err(e) = fs.cv().set_attr(&path, attr_opts).await {
+                stats.failed += 1;
+                eprintln!("[resync] failed to set attr {}: {}", path, e);
+                continue;
+            }
+
+            stats.recreated += 1;
+        }
+
+        println!(
+            "resync summary: scanned={}, skip_same_mtime={}, skip_ufs_time_zero={}, recreated={}, ufs_missing={}, failed={}",
+            stats.scanned,
+            stats.skip_same_mtime,
+            stats.skip_ufs_time_zero,
+            stats.recreated,
+            stats.ufs_missing,
+            stats.failed
+        );
+
         Ok(())
     }
 


### PR DESCRIPTION
### Summary
This PR adds `cv mount resync <cv_mount_path>` to sync **UFS metadata only** into Curvine cache metadata for mounted paths (no data copy/load).

### Behavior
For each file discovered from UFS (always recursive):
- `cv.ufs_mtime == ufs.mtime` -> skip
- `cv.ufs_mtime == 0` -> skip
- both exist and mtime differs -> delete + recreate Curvine metadata entry
- UFS exists but CV missing -> create metadata entry

### Notes
- Uses direct `fs_client` metadata operations to persist `ufs_mtime` correctly.
- Added E2E script: `build/tests/resync_e2e.sh` (layered paths + all rule scenarios), with S3/MinIO config driven by env vars.