### PR TITLE
refactor(common): make AppStorage::apply async

### DIFF
--- a/curvine-common/src/raft/storage/app_storage.rs
+++ b/curvine-common/src/raft/storage/app_storage.rs
@@ -14,11 +14,13 @@
 
 use crate::proto::raft::SnapshotData;
 use crate::raft::RaftResult;
+use std::future::Future;
 
 /// Application layer storage.
 /// Replay raft log
 pub trait AppStorage: Clone + Send + Sync + 'static {
-    fn apply(&self, is_leader: bool, message: &[u8]) -> RaftResult<()>;
+    fn apply(&self, is_leader: bool, message: &[u8])
+        -> impl Future<Output = RaftResult<()>> + Send;
 
     fn create_snapshot(&self, node_id: u64, last_applied: u64) -> RaftResult<SnapshotData>;
 

--- a/curvine-common/src/raft/storage/hash_app_storage.rs
+++ b/curvine-common/src/raft/storage/hash_app_storage.rs
@@ -82,7 +82,7 @@ where
     K: DeserializeOwned + Sized + Serialize + Clone + Hash + Eq + Send + Sync + 'static,
     V: DeserializeOwned + Sized + Serialize + Clone + Send + Sync + 'static,
 {
-    fn apply(&self, _: bool, message: &[u8]) -> RaftResult<()> {
+    async fn apply(&self, _: bool, message: &[u8]) -> RaftResult<()> {
         let mut map = self.write()?;
         let pairs: (K, V) = SerdeUtils::deserialize(message)?;
         map.insert(pairs.0, pairs.1);
@@ -161,7 +161,7 @@ where
     K: Serialize + DeserializeOwned + Clone + Sync + Send + 'static,
     V: Serialize + DeserializeOwned + Clone + Sync + Send + 'static,
 {
-    fn apply(&self, _: bool, message: &[u8]) -> RaftResult<()> {
+    async fn apply(&self, _: bool, message: &[u8]) -> RaftResult<()> {
         let db = self.lock()?;
         let pairs: (K, V) = SerdeUtils::deserialize(message)?;
         let k = SerdeUtils::serialize(&pairs.0)?;

--- a/curvine-server/src/master/journal/journal_loader.rs
+++ b/curvine-server/src/master/journal/journal_loader.rs
@@ -292,7 +292,7 @@ impl JournalLoader {
 }
 
 impl AppStorage for JournalLoader {
-    fn apply(&self, is_leader: bool, message: &[u8]) -> RaftResult<()> {
+    async fn apply(&self, is_leader: bool, message: &[u8]) -> RaftResult<()> {
         match self.apply0(is_leader, message) {
             Ok(_) => Ok(()),
 


### PR DESCRIPTION
## Summary

Convert `AppStorage::apply` from a synchronous method to an async one so that application-layer log replay (e.g. UFS/journal) can run asynchronously without blocking the Raft reactor. This avoids blocking the event loop when apply involves I/O or other async work.

## Changes

### 1. **AppStorage trait** (`curvine-common/src/raft/storage/app_storage.rs`)

- `apply(is_leader, message)` now returns `impl Future<Output = RaftResult<()>> + Send` instead of `RaftResult<()>`.

### 2. **Implementations**

- **HashAppStorage** (`hash_app_storage.rs`): `apply` is implemented as `async fn apply(...)`.
- **PeerStorage** (`peer_storage.rs`):
  - `apply_propose` is now `async` and awaits `app_store.apply(...)`.
  - `snap_state` is changed from `RefCell<SnapshotState>` to `Arc<Mutex<SnapshotState>>` so that the storage remains `Send` when used in async contexts.
  - `check_snapshot_state` now returns `SnapshotState` and is used by `can_generate_snapshot` and `is_snapshot_applying` without double-borrow.

### 3. **RaftNode** (`curvine-common/src/raft/raft_node.rs`)

- **install_snapshot**: Made `async`; replays snapshot entries with `app_store.apply(...).await?`.
- **apply_propose**: Made `async`; calls `storage.apply_propose(...).await?`.
- **apply_committed_entries**: Made `async`; applies entries and uses `apply_propose(...).await` for each.
- **on_ready**:
  - Runs both batches of committed entries in sequence: if the first `apply_committed_entries` succeeds, the second is run; then `advance_apply` is called once.
  - **Leader apply failure**: On apply error, the leader only logs a warning and does not call `advance_apply`, so the same entries can be retried on the next run (idempotent replay). This keeps Curvine usable when UFS is down and allows replay after UFS recovers.
  - **Follower**: Apply failure still returns `Err` and does not advance.
- **compact_id**: Capped by `last_applied` when generating snapshot jobs (`compact_id = raw_compact.min(last_applied)`).

## Motivation

- **Non-blocking apply**: Async apply allows the Raft core to stay responsive when application replay does I/O (e.g. UFS or journal).
- **Leader resilience**: Leader apply failures (e.g. UFS unavailable) no longer fail the whole ready handling; the leader keeps making progress and retries apply later.
- **Send + async**: Using `Arc<Mutex<...>>` for shared state in `PeerStorage` keeps the type `Send` and safe to use across async boundaries.

