### PR TITLE
refactor(client): simplify write types to CacheMode and FsMode only

### DIFF
--- a/curvine-cli/src/cmds/mount.rs
+++ b/curvine-cli/src/cmds/mount.rs
@@ -50,13 +50,6 @@ pub struct MountCommand {
     #[arg(long, default_value = "7d")]
     ttl_ms: String,
 
-    #[arg(
-        long,
-        default_value = "delete",
-        help = "TTL expiration action when file expires:\n  none - No action\n  delete - Delete file\n  persist - Export to UFS (skip if exists), keep CV cache\n  evict - Export to UFS (skip if exists), delete CV cache\n  flush - Force export to UFS (overwrite), delete CV cache"
-    )]
-    ttl_action: String,
-
     #[arg(long)]
     replicas: Option<i32>,
 
@@ -68,8 +61,8 @@ pub struct MountCommand {
 
     #[arg(
         long,
-        default_value = "async_through",
-        help = "Write type: cache, through, async_through, cache_through"
+        default_value = "fs_mode",
+        help = "Write type: cache_mode, fs_mode"
     )]
     write_type: String,
 
@@ -243,17 +236,24 @@ impl MountCommand {
     }
 
     pub fn to_mnt_opts(&self) -> CommonResult<MountOptions> {
+        let write_type = WriteType::try_from(self.write_type.as_str())?;
         let mnt_type = MountType::try_from(self.mnt_type.as_str())?;
         let consistency_strategy =
             ConsistencyStrategy::try_from(self.consistency_strategy.as_str())?;
         let ttl_ms = DurationUnit::from_str(self.ttl_ms.as_str())?.as_millis() as i64;
-        let ttl_action = TtlAction::try_from(self.ttl_action.as_str())?;
         let conf_map = self.get_config_map()?;
+
+        let ttl_action = if matches!(write_type, WriteType::FsMode) {
+            TtlAction::Flush
+        } else {
+            TtlAction::Delete
+        };
 
         let mut opts = MountOptions::builder()
             .update(self.update)
             .set_properties(conf_map)
             .mount_type(mnt_type)
+            .write_type(write_type)
             .consistency_strategy(consistency_strategy)
             .ttl_ms(ttl_ms)
             .ttl_action(ttl_action);
@@ -267,9 +267,6 @@ impl MountCommand {
         if let Some(storage_type) = self.storage_type.as_ref() {
             opts = opts.storage_type(StorageType::try_from(storage_type.as_str())?);
         }
-
-        let write_type = WriteType::try_from(self.write_type.as_str())?;
-        opts = opts.write_type(write_type);
 
         if let Some(provider_str) = self.provider.as_ref() {
             let provider = Provider::try_from(provider_str.as_str())?;

--- a/curvine-common/proto/common.proto
+++ b/curvine-common/proto/common.proto
@@ -24,10 +24,8 @@ enum TtlActionProto {
 }
 
 enum WriteTypeProto {
-    WRITE_TYPE_PROTO_CACHE = 0;
-    WRITE_TYPE_PROTO_THROUGH = 1;
-    WRITE_TYPE_PROTO_ASYNC_THROUGH = 2;
-    WRITE_TYPE_PROTO_CACHE_THROUGH = 3;
+    WRITE_TYPE_PROTO_CACHE_MODE = 0;
+    WRITE_TYPE_PROTO_FS_MODE = 1;
 }
 
 // Define file type

--- a/curvine-common/src/fs/writer.rs
+++ b/curvine-common/src/fs/writer.rs
@@ -114,4 +114,8 @@ pub trait Writer {
     fn resize(&mut self, _opts: FileAllocOpts) -> impl Future<Output = FsResult<()>> {
         async move { err_box!("Not support") }
     }
+
+    fn write_string(&mut self, content: impl AsRef<str>) -> impl Future<Output = FsResult<()>> {
+        async move { self.write(content.as_ref().as_bytes()).await }
+    }
 }

--- a/curvine-common/src/state/block_info.rs
+++ b/curvine-common/src/state/block_info.rs
@@ -163,19 +163,8 @@ impl FileBlocks {
         Self { status, block_locs }
     }
 
-    // According to the file reading location, get the block that needs to be read and the offset in the block.
-    pub fn get_read_block(&self, file_pos: i64) -> FsResult<(i64, LocatedBlock)> {
-        let mut start_pos = 0;
-        for block in &self.block_locs {
-            let end_pos = start_pos + block.block.len;
-            if file_pos >= start_pos && file_pos < end_pos {
-                let block_off = file_pos - start_pos;
-                return Ok((block_off, block.clone()));
-            }
-            start_pos = end_pos;
-        }
-
-        err_box!("Not found block for pos {}", file_pos)
+    pub fn cv_exists(&self) -> bool {
+        !self.block_locs.is_empty()
     }
 }
 

--- a/curvine-common/src/state/file_status.rs
+++ b/curvine-common/src/state/file_status.rs
@@ -82,12 +82,11 @@ impl FileStatus {
         !self.is_dir && self.nlink > 1 && self.id > 0
     }
 
-    /// Returns true if the file exists only in Curvine and not in UFS
-    pub fn is_cv_only(&self) -> bool {
-        self.storage_policy.ufs_mtime == 0
-    }
-
     pub fn is_complete(&self) -> bool {
         self.is_complete
+    }
+
+    pub fn ufs_exists(&self) -> bool {
+        self.storage_policy.ufs_mtime > 0
     }
 }

--- a/curvine-common/src/utils/display.rs
+++ b/curvine-common/src/utils/display.rs
@@ -24,10 +24,8 @@ use std::fmt::Display;
 /// Convert WriteTypeProto to a readable string
 fn write_type_to_str(write_type: WriteTypeProto) -> &'static str {
     match write_type {
-        WriteTypeProto::Cache => "cache",
-        WriteTypeProto::Through => "through",
-        WriteTypeProto::AsyncThrough => "async_through",
-        WriteTypeProto::CacheThrough => "cache_through",
+        WriteTypeProto::CacheMode => "cache_mode",
+        WriteTypeProto::FsMode => "fs_mode",
     }
 }
 

--- a/curvine-tests/tests/ufs_test.rs
+++ b/curvine-tests/tests/ufs_test.rs
@@ -176,7 +176,7 @@ async fn mount_storage(fs: &UnifiedFileSystem, config: &TestConfig) -> CommonRes
     let opts = MountOptions::builder()
         .set_properties(config.properties.clone())
         .mount_type(MountType::Orch)
-        .write_type(WriteType::Through)
+        .write_type(WriteType::CacheMode)
         .build();
 
     let ufs_path: Path = Path::from_str(&config.ufs_path).unwrap();

--- a/curvine-tests/tests/write_cache_test.rs
+++ b/curvine-tests/tests/write_cache_test.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use bytes::BytesMut;
-use curvine_client::unified::{UnifiedFileSystem, UnifiedReader, UnifiedWriter};
+use curvine_client::unified::UnifiedFileSystem;
 use curvine_common::fs::{FileSystem, Path, Reader, Writer};
 use curvine_common::state::{MountOptionsBuilder, WriteType};
 use curvine_tests::Testing;
@@ -41,19 +41,11 @@ fn test_mount_write_cache() {
     let fs = testing.get_unified_fs_with_rt(rt.clone()).unwrap();
 
     rt.block_on(async move {
-        mount(&fs, WriteType::Cache).await;
-        mount(&fs, WriteType::Through).await;
-        mount(&fs, WriteType::CacheThrough).await;
-        mount(&fs, WriteType::AsyncThrough).await;
+        mount(&fs, WriteType::CacheMode).await;
+        mount(&fs, WriteType::FsMode).await;
 
-        write(&fs, WriteType::Cache, false).await;
-        write(&fs, WriteType::Through, false).await;
-        write(&fs, WriteType::CacheThrough, false).await;
-        write(&fs, WriteType::CacheThrough, true).await;
-        write(&fs, WriteType::AsyncThrough, false).await;
-        write(&fs, WriteType::AsyncThrough, true).await;
-        write(&fs, WriteType::CacheThrough, true).await;
-        write(&fs, WriteType::AsyncThrough, true).await;
+        write(&fs, WriteType::CacheMode, false).await;
+        write(&fs, WriteType::FsMode, false).await;
     })
 }
 
@@ -93,17 +85,6 @@ async fn write(fs: &UnifiedFileSystem, write_type: WriteType, random_write: bool
 
     writer.complete().await.unwrap();
 
-    // If async write, wait for job to complete
-    if matches!(write_type, WriteType::AsyncThrough) {
-        match &writer {
-            UnifiedWriter::CacheSync(r) => {
-                r.wait_job_complete().await.unwrap();
-            }
-
-            _ => panic!("Invalid writer type"),
-        };
-    }
-
     verify_read_data(fs, &path, &written_data, write_type).await;
 
     verify_cv_ufs_consistency(fs, &path).await;
@@ -113,20 +94,9 @@ async fn verify_read_data(
     fs: &UnifiedFileSystem,
     path: &Path,
     expected_data: &[u8],
-    write_type: WriteType,
+    _write_type: WriteType,
 ) {
     let mut reader = fs.open(path).await.unwrap();
-
-    // Check reader type
-    match write_type {
-        WriteType::Cache | WriteType::CacheThrough | WriteType::AsyncThrough => {
-            assert!(matches!(reader, UnifiedReader::Cv(_)));
-        }
-
-        WriteType::Through => {
-            assert!(matches!(reader, UnifiedReader::Opendal(_)));
-        }
-    }
 
     let mut read_data = BytesMut::zeroed(reader.len() as usize);
     reader.read_full(&mut read_data).await.unwrap();
@@ -141,9 +111,6 @@ async fn verify_read_data(
 
 async fn verify_cv_ufs_consistency(fs: &UnifiedFileSystem, path: &Path) {
     let (ufs_path, mnt) = fs.get_mount(path).await.unwrap().unwrap();
-    if matches!(mnt.info.write_type, WriteType::Cache | WriteType::Through) {
-        return;
-    }
 
     let mut cv_reader = fs.cv().open(path).await.unwrap();
     let mut ufs_reader = mnt.ufs.open(&ufs_path).await.unwrap();


### PR DESCRIPTION
## Summary

Unify the previous four write types (Cache, Through, AsyncThrough, CacheThrough) into two modes: **CacheMode** and **FsMode**. This reduces complexity in the unified client and CLI while keeping the main use cases: writing through to UFS only (CacheMode) and writing to Curvine with optional sync to UFS (FsMode).

## Write type semantics

| Write type   | Behavior |
|-------------|----------|
| **CacheMode** | Write goes directly to the underlying storage (UFS), bypassing Curvine cache. |
| **FsMode**    | Write goes to Curvine (cache) only. Data can be synced to UFS later (e.g. on close/complete or via async cache job). |

- **CLI**: `--write-type` accepts only `cache_mode` and `fs_mode` (default `fs_mode`).
- **TTL action**: No longer a separate CLI flag. It is derived from write type: **FsMode** → `Flush`, otherwise `Delete`. Mount must have a non-zero TTL.

## Changes

### Client & CLI

- **curvine-cli (mount)**  
  - Removed `--ttl-action`. TTL action is set from write type; TTL must be non-zero.
  - `--write-type` default `fs_mode`, help text updated to the two options.

- **job_master_client**  
  - `wait_job_complete(job_id, mark)` → `wait_job_complete(job_id, fail_if_not_found: bool)`.
  - If `get_job_status` returns `JobNotFound`: when `fail_if_not_found` is true, return `Err`; when false, sleep and retry (keeps waiting).

- **cache_sync_writer**  
  - Removed the check that write type must be AsyncThrough or CacheThrough.
  - Calls `wait_job_complete(..., true)`.
  - FsMode: wait for job complete on close (sync-to-UFS behavior).

- **unified_filesystem**  
  - `CacheValidity::Invalid` no longer carries `Option<FileStatus>`.
  - New `get_mount_checked(path)`: returns `Some(mount)` only for cache-mode mounts; used for symlink/link and other ops that should run only on cache mounts.
  - Create/open and cache validity logic simplified for the two write types.

### Common (state, proto, traits)

- **WriteType enum**: Only `CacheMode` and `FsMode`; proto and display helpers updated.
- **MountInfo**: `is_cache_mode()`, `is_fs_mode()`; removed `is_write_through`, `has_ufs_data`.
- **MountOptionsBuilder**: Default write type `CacheMode`.
- **FileBlocks**: `cv_exists()` added; `get_read_block()` removed.
- **FileStatus**: `ufs_exists()` added; `is_cv_only()` removed.
- **Writer trait**: Default `write_string()` implementation added.

### Tests

- **write_cache_test**: Only mounts and writes for CacheMode and FsMode; removed multi-mode matrix and async wait logic tied to old write types.
- **ufs_test**: Uses `WriteType::CacheMode` instead of `Through`.

## Motivation

- Fewer write types make the API and CLI easier to understand and maintain.
- Clear split: “write to UFS only” (CacheMode) vs “write to Curvine, maybe sync to UFS” (FsMode).
- `fail_if_not_found` on `wait_job_complete` makes “must exist” vs “poll until found” explicit and avoids overloading a string `mark`.

## Files changed

| Area        | Files |
|------------|--------|
| CLI        | `curvine-cli/src/cmds/mount.rs` |
| Client     | `curvine-client/src/rpc/job_master_client.rs`, `unified/cache_sync_writer.rs`, `unified/unified_filesystem.rs` |
| Common     | `curvine-common/proto/common.proto`, `src/fs/writer.rs`, `state/block_info.rs`, `state/file_status.rs`, `state/mount.rs`, `utils/display.rs` |
| Tests      | `curvine-tests/tests/ufs_test.rs`, `write_cache_test.rs` |

## Breaking changes

- **WriteType**: Old variants (Cache, Through, AsyncThrough, CacheThrough) and CLI values (`cache`, `through`, `async_through`, `cache_through`) are removed. Callers must switch to **CacheMode** / **FsMode** and `cache_mode` / `fs_mode`.
- **wait_job_complete**: Second argument is now `fail_if_not_found: bool` instead of `mark: &str`.
- **Mount**: `ttl_action` is no longer a CLI option; it is derived from write type. TTL must be set (non-zero).
- **MountInfo**: `is_write_through()` and `has_ufs_data()` removed; use `is_cache_mode()` / `is_fs_mode()` and logic as needed.
- **FileBlocks**: `get_read_block()` removed; **FileStatus**: `is_cv_only()` removed; use `cv_exists()` / `ufs_exists()` where applicable.
