### PR TITLE
refactor(server): job_manager and load-job flow improvements (#680)

### DIFF
--- a/curvine-server/src/master/job/job_manager.rs
+++ b/curvine-server/src/master/job/job_manager.rs
@@ -16,6 +16,7 @@ use crate::common::UfsFactory;
 use crate::master::fs::MasterFilesystem;
 use crate::master::{JobStore, LoadJobRunner, MountManager};
 use core::time::Duration;
+use curvine_client::unified::MountValue;
 use curvine_common::conf::ClusterConf;
 use curvine_common::error::FsError;
 use curvine_common::executor::ScheduledExecutor;
@@ -108,6 +109,21 @@ impl JobManager {
         )
     }
 
+    pub fn get_mnt(&self, path: &Path) -> FsResult<Option<(Path, Arc<MountValue>)>> {
+        if let Some(mnt) = self.mount_manager.get_mount_info(path)? {
+            let mnt_value = self.factory.get_mnt(&mnt)?;
+            let target_path = mnt_value.toggle_path(path)?;
+
+            Ok(Some((target_path, mnt_value)))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub fn rt(&self) -> &Runtime {
+        &self.rt
+    }
+
     pub fn submit_load_job(&self, command: LoadJobCommand) -> FsResult<LoadJobResult> {
         let source_path = Path::from_str(&command.source_path)?;
 
@@ -122,7 +138,7 @@ impl JobManager {
 
         let job_runner = self.create_runner();
 
-        let (tx, mut rx) = BlockingChannel::new(1).split();
+        let (tx, rx) = BlockingChannel::new(1).split();
         self.rt.spawn(async move {
             let res = job_runner.submit_load_task(command, mnt).await;
             if let Err(e) = tx.send(res) {

--- a/curvine-server/src/master/job/job_runner.rs
+++ b/curvine-server/src/master/job/job_runner.rs
@@ -16,11 +16,12 @@ use crate::common::UfsFactory;
 use crate::master::fs::policy::ChooseContext;
 use crate::master::fs::MasterFilesystem;
 use crate::master::{JobContext, JobStore, TaskDetail};
+use curvine_client::unified::MountValue;
 use curvine_common::conf::ClientConf;
 use curvine_common::error::FsError;
 use curvine_common::fs::{FileSystem, Path};
 use curvine_common::state::{
-    FileStatus, JobTaskState, LoadJobCommand, LoadJobResult, LoadTaskInfo, MountInfo, WorkerAddress,
+    JobTaskState, LoadJobCommand, LoadJobResult, LoadTaskInfo, MountInfo, WorkerAddress,
 };
 use curvine_common::utils::CommonUtils;
 use curvine_common::FsResult;
@@ -64,39 +65,49 @@ impl LoadJobRunner {
         }
     }
 
-    fn check_job_exists(
+    /// Returns true if we should skip submitting the load task (data already synced or job in progress).
+    async fn check_job_exists(
         &self,
         job_id: &str,
-        source_status: &FileStatus,
+        mnt: &MountValue,
+        source_path: &Path,
         target_path: &Path,
-    ) -> bool {
-        let job = if let Some(job) = self.jobs.get(job_id) {
-            job
-        } else {
-            return false;
-        };
-
-        let state: JobTaskState = job.state.state();
-        if state == JobTaskState::Pending || state == JobTaskState::Loading {
-            return true;
+    ) -> FsResult<bool> {
+        // Job in progress: skip submit
+        if let Some(job) = self.jobs.get(job_id) {
+            let state: JobTaskState = job.state.state();
+            if state == JobTaskState::Pending || state == JobTaskState::Loading {
+                return Ok(true);
+            }
         }
 
-        if !source_status.is_dir {
-            // Files are generally auto-loaded and executed in parallel.
-            // Validate ufs_mtime to prevent distributing a large number of duplicate tasks.
-            if let Ok(cv_status) = self.master_fs.file_status(target_path.path()) {
-                if cv_status.is_expired() || !cv_status.is_complete {
-                    false
-                } else {
-                    source_status.len == cv_status.len
-                        && cv_status.storage_policy.ufs_mtime != 0
-                        && cv_status.storage_policy.ufs_mtime == source_status.mtime
-                }
+        // Skip based on data state (even when job is None, e.g. after job cleanup)
+        if source_path.is_cv() {
+            // cv -> ufs: if CV's ufs_mtime already set, data already copied to UFS, skip
+            let source_status = self.master_fs.file_status(source_path.path())?;
+            if source_status.is_dir {
+                Ok(false)
+            } else if source_status.ufs_exists() {
+                Ok(true)
             } else {
-                false
+                Ok(false)
             }
         } else {
-            true
+            // ufs -> cv: if CV exists and ufs_mtime matches UFS mtime, data already synced, skip
+            let source_status = mnt.ufs.get_status(source_path).await?;
+            if source_status.is_dir {
+                Ok(false)
+            } else if let Ok(cv_status) = self.master_fs.file_status(target_path.path()) {
+                if cv_status.is_expired() || !cv_status.is_complete {
+                    Ok(false)
+                } else {
+                    Ok(source_status.len == cv_status.len
+                        && cv_status.storage_policy.ufs_mtime != 0
+                        && cv_status.storage_policy.ufs_mtime == source_status.mtime)
+                }
+            } else {
+                Ok(false)
+            }
         }
     }
 
@@ -106,14 +117,7 @@ impl LoadJobRunner {
         mnt: MountInfo,
     ) -> FsResult<LoadJobResult> {
         let source_path = Path::from_str(&command.source_path)?;
-
-        let target_path = if let Some(ref target) = command.target_path {
-            Path::from_str(target)?
-        } else if source_path.is_cv() {
-            mnt.get_ufs_path(&source_path)?
-        } else {
-            mnt.get_cv_path(&source_path)?
-        };
+        let target_path = mnt.toggle_path(&source_path)?;
 
         let job_id = CommonUtils::create_job_id(source_path.full_path());
         let result = LoadJobResult {
@@ -121,14 +125,11 @@ impl LoadJobRunner {
             target_path: target_path.clone_uri(),
         };
 
-        let source_status = if source_path.is_cv() {
-            self.master_fs.file_status(source_path.path())?
-        } else {
-            let ufs = self.factory.get_ufs(&mnt)?;
-            ufs.get_status(&source_path).await?
-        };
-
-        if self.check_job_exists(&job_id, &source_status, &target_path) {
+        let mnt_value = self.factory.get_mnt(&mnt)?;
+        if self
+            .check_job_exists(&job_id, &mnt_value, &source_path, &target_path)
+            .await?
+        {
             info!(
                 "job {}, source_path {} already exists",
                 job_id,
@@ -136,6 +137,8 @@ impl LoadJobRunner {
             );
             return Ok(result);
         }
+
+        self.jobs.remove(&job_id);
 
         info!("Submitting load job {}", job_id);
         let mut job_context = JobContext::with_conf(
@@ -148,7 +151,7 @@ impl LoadJobRunner {
         );
 
         let res = self
-            .create_all_tasks(&mut job_context, source_status, &mnt)
+            .create_all_tasks(&mut job_context, &source_path, &mnt)
             .await;
 
         match res {
@@ -194,9 +197,16 @@ impl LoadJobRunner {
     async fn create_all_tasks(
         &self,
         job: &mut JobContext,
-        source_status: FileStatus,
+        source_path: &Path,
         mnt: &MountInfo,
     ) -> FsResult<i64> {
+        let source_status = if source_path.is_cv() {
+            self.master_fs.file_status(source_path.path())?
+        } else {
+            let ufs = self.factory.get_ufs(mnt)?;
+            ufs.get_status(source_path).await?
+        };
+
         job.update_state(JobTaskState::Pending, "Assigning workers");
         let block_size = job.info.block_size;
 

--- a/curvine-server/src/master/journal/journal_system.rs
+++ b/curvine-server/src/master/journal/journal_system.rs
@@ -20,7 +20,8 @@ use crate::master::quota::eviction::evictor::{Evictor, LFUEvictor, LRUEvictor};
 use crate::master::quota::eviction::types::EvictionPolicy;
 use crate::master::quota::eviction::EvictionConf;
 use crate::master::{
-    MasterMonitor, MetaRaftJournal, MountManager, QuotaManager, SyncFsDir, SyncWorkerManager,
+    JobManager, MasterMonitor, MetaRaftJournal, MountManager, QuotaManager, SyncFsDir,
+    SyncWorkerManager,
 };
 use curvine_common::conf::ClusterConf;
 use curvine_common::proto::raft::SnapshotData;
@@ -45,9 +46,11 @@ pub struct JournalSystem {
     master_monitor: MasterMonitor,
     mount_manager: Arc<MountManager>,
     quota_manager: Arc<QuotaManager>,
+    job_manager: Arc<JobManager>,
 }
 
 impl JournalSystem {
+    #[allow(clippy::too_many_arguments)]
     fn new(
         rt: Arc<Runtime>,
         fs: MasterFilesystem,
@@ -56,6 +59,7 @@ impl JournalSystem {
         master_monitor: MasterMonitor,
         mount_manager: Arc<MountManager>,
         quota_manager: Arc<QuotaManager>,
+        job_manager: Arc<JobManager>,
     ) -> Self {
         Self {
             rt,
@@ -65,6 +69,7 @@ impl JournalSystem {
             master_monitor,
             mount_manager,
             quota_manager,
+            job_manager,
         }
     }
 
@@ -122,6 +127,13 @@ impl JournalSystem {
         let quota_manager =
             QuotaManager::new(eviction_conf, fs.clone(), evictor.clone(), rt.clone());
 
+        let job_manager = Arc::new(JobManager::from_cluster_conf(
+            fs.clone(),
+            mount_manager.clone(),
+            rt.clone(),
+            conf,
+        ));
+
         let raft_journal = MetaRaftJournal::new(
             rt.clone(),
             log_store,
@@ -138,6 +150,7 @@ impl JournalSystem {
             master_monitor,
             mount_manager,
             quota_manager,
+            job_manager,
         );
 
         Ok(js)
@@ -176,6 +189,10 @@ impl JournalSystem {
 
     pub fn quota_manager(&self) -> Arc<QuotaManager> {
         self.quota_manager.clone()
+    }
+
+    pub fn job_manager(&self) -> Arc<JobManager> {
+        self.job_manager.clone()
     }
 
     // Create a snapshot manually, dedicated for testing.

--- a/curvine-server/src/master/master_server.rs
+++ b/curvine-server/src/master/master_server.rs
@@ -141,6 +141,7 @@ impl Master {
         let worker_manager = journal_system.worker_manager();
         let mount_manager = journal_system.mount_manager();
         let quota_manager = journal_system.quota_manager();
+        let job_manager = journal_system.job_manager();
 
         let rt = Arc::new(conf.master_server_conf().create_runtime());
 
@@ -153,13 +154,6 @@ impl Master {
             &replication_manager,
             quota_manager,
         );
-
-        let job_manager = Arc::new(JobManager::from_cluster_conf(
-            fs.clone(),
-            mount_manager.clone(),
-            rt.clone(),
-            &conf,
-        ));
 
         // step3: Create rpc server.
         let retry_cache = FsRetryCache::with_conf(&conf.master);

--- a/curvine-server/src/worker/task/load_task_runner.rs
+++ b/curvine-server/src/worker/task/load_task_runner.rs
@@ -16,7 +16,7 @@ use crate::common::UfsFactory;
 use crate::worker::task::TaskContext;
 use curvine_client::file::CurvineFileSystem;
 use curvine_client::rpc::JobMasterClient;
-use curvine_client::unified::{CacheSyncReader, UfsFileSystem, UnifiedReader, UnifiedWriter};
+use curvine_client::unified::{UfsFileSystem, UnifiedReader, UnifiedWriter};
 use curvine_common::fs::{FileSystem, Path, Reader, Writer};
 use curvine_common::state::{CreateFileOptsBuilder, JobTaskState, SetAttrOptsBuilder};
 use curvine_common::FsResult;
@@ -105,7 +105,8 @@ impl LoadTaskRunner {
 
             if LocalTime::mills() > last_progress_time + self.progress_interval_ms {
                 last_progress_time = LocalTime::mills();
-                self.update_progress(writer.pos(), reader.len()).await;
+                self.update_progress(writer.pos(), reader.len(), false)
+                    .await;
             }
 
             if total_cost_ms > self.task_timeout_ms {
@@ -134,7 +135,7 @@ impl LoadTaskRunner {
             reader.status().storage_policy.ufs_mtime
         };
 
-        self.update_progress(writer.pos(), reader.len()).await;
+        self.update_progress(writer.pos(), reader.len(), true).await;
 
         info!(
             "task {} completed, source_path {}, target_path {}, ufs_mtime:{}, copy bytes {}, read cost {} ms, task cost {} ms",
@@ -165,9 +166,8 @@ impl LoadTaskRunner {
 
     async fn open_unified(&self, path: &Path) -> FsResult<UnifiedReader> {
         if path.is_cv() {
-            // Curvine path
-            let reader = CacheSyncReader::new(&self.fs, path).await?;
-            Ok(UnifiedReader::CacheSync(reader))
+            let reader = self.fs.open(path).await?;
+            Ok(UnifiedReader::Cv(reader))
         } else {
             // UFS path
             let ufs = self.get_ufs()?;
@@ -215,14 +215,22 @@ impl LoadTaskRunner {
         }
     }
 
-    pub async fn update_progress(&self, loaded_size: i64, total_size: i64) {
-        if let Err(e) = self.update_progress0(loaded_size, total_size).await {
+    pub async fn update_progress(&self, loaded_size: i64, total_size: i64, is_last: bool) {
+        if let Err(e) = self
+            .update_progress0(loaded_size, total_size, is_last)
+            .await
+        {
             warn!("update progress failed, err: {:?}", e);
         }
     }
 
-    pub async fn update_progress0(&self, loaded_size: i64, total_size: i64) -> FsResult<()> {
-        let progress = self.task.update_progress(loaded_size, total_size);
+    pub async fn update_progress0(
+        &self,
+        loaded_size: i64,
+        total_size: i64,
+        is_last: bool,
+    ) -> FsResult<()> {
+        let progress = self.task.update_progress(loaded_size, total_size, is_last);
         let task = &self.task;
 
         self.master_client

--- a/curvine-server/src/worker/task/task_context.rs
+++ b/curvine-server/src/worker/task/task_context.rs
@@ -67,14 +67,19 @@ impl TaskContext {
         lock.update_time = LocalTime::mills() as i64;
     }
 
-    pub fn update_progress(&self, loaded_size: i64, total_size: i64) -> JobTaskProgress {
+    pub fn update_progress(
+        &self,
+        loaded_size: i64,
+        total_size: i64,
+        is_last: bool,
+    ) -> JobTaskProgress {
         let mut lock = self.progress.lock().unwrap();
 
         lock.loaded_size = loaded_size;
         lock.total_size = total_size;
         lock.update_time = LocalTime::mills() as i64;
 
-        if loaded_size >= total_size {
+        if is_last {
             lock.message = "task completed successfully".into();
             self.state.set_state(JobTaskState::Completed);
         }


### PR DESCRIPTION
## Summary

Refactors the job manager lifecycle, mount/UFS access, and load-job submission so that:

- **JobManager** is created and owned by **JournalSystem** and exposed to Master (single place of construction).
- **UfsFactory** caches full **MountValue** (including UFS client) and offers `get_mnt()` for code that needs mount context.
- **Load job skip logic** is based on both job state and data state (CV↔UFS sync), and runs async with UFS access where needed.
- **Task progress** reports an explicit `is_last` so the job is only marked Completed after `writer.complete()`, avoiding clients seeing job complete before file `is_complete`.

## Changes

### 1. UfsFactory (`curvine-server/src/common/ufs_factory.rs`)

- Cache type: `UfsFileSystem` → `Arc<MountValue>`.
- **`get_mnt(mnt)`**: returns `Arc<MountValue>` (creates and caches `MountValue::new(mnt)`).
- **`get_ufs(mnt)`**: implemented as `get_mnt(mnt).map(|x| x.ufs.clone())`.

### 2. JobManager (`job_manager.rs`)

- **`get_mnt(path)`**: resolves mount for path, gets `MountValue` from factory, returns `Option<(Path, Arc<MountValue>)>` (UFS path + mount value).
- **`rt()`**: accessor for the runtime.
- **submit_load_job**: channel receiver no longer needs to be `mut`.

### 3. JournalSystem & Master

- **JournalSystem** holds and constructs **JobManager** (via `JobManager::from_cluster_conf`), and exposes **`job_manager()`**.
- **Master** no longer constructs JobManager; it uses **`journal_system.job_manager()`**.

### 4. LoadJobRunner (`job_runner.rs`)

- **`check_job_exists`**:
  - Now **async**, takes `job_id`, `ufs: UfsFileSystem`, `source_path`, `target_path` (no `source_status`).
  - Returns **`FsResult<bool>`**: `true` = skip submit.
  - Skip if job exists and is Pending/Loading.
  - Otherwise skip based on **data state**:
    - **CV → UFS**: use master `file_status(source_path)`; if file and `ufs_exists()` → skip.
    - **UFS → CV**: use `ufs.get_status(source_path)`; if CV exists, not expired, complete, and len + ufs_mtime match → skip.
- **submit_load_task**:
  - Resolves `target_path` from `source_path` (CV ⇒ UFS path, else CV path).
  - Gets UFS once, calls **`check_job_exists(..., ufs, &source_path, &target_path).await?`**.
  - **`self.jobs.remove(&job_id)`** before creating a new job context (avoid stale entry).
- **create_all_tasks**: takes `source_path` and `mnt`; loads **source_status** inside (from master for CV path, from UFS for UFS path).

### 5. LoadTaskRunner & TaskContext

- **LoadTaskRunner**:
  - **open_unified** for Curvine path: use **`self.fs.open(path)`** and **`UnifiedReader::Cv(reader)`** (no CacheSyncReader).
  - **update_progress(loaded_size, total_size, is_last)**:
    - In the copy loop: `update_progress(..., false)`.
    - After `writer.complete()`: `update_progress(..., true)`.
- **TaskContext**: **update_progress(..., is_last)**; sets state to **Completed** only when **`is_last`** (not when `loaded_size >= total_size`), so job completion is not visible before file completion.

### 6. orpc BlockingReceiver (`orpc/src/sync/channel.rs`)

- **`recv()`** and **`recv_check()`** take **`&self`** instead of **`&mut self`**.
- **`recv_timeout(timeout)`** added; returns **`Result<T, RecvTimeoutError>`**.

## Motivation

- **Single JobManager ownership**: JournalSystem creates and holds JobManager; Master only uses it. Simplifies wiring and testing.
- **MountValue cache**: Callers that need both UFS and mount info can use `get_mnt()` and avoid duplicate mount resolution/UFS creation.
- **Data-state skip**: Skip load job when data is already synced (CV↔UFS) even if there is no active job (e.g. after cleanup), reducing duplicate work.
- **Completed only on is_last**: Prevents the job from being reported Completed before `complete_file` is applied, so clients do not see job complete while `is_complete` is still false.
- **BlockingReceiver &self**: Allows sharing the receiver where only blocking recv is needed; **recv_timeout** supports timed wait in sync contexts.

## Files changed

| File | Description |
|------|-------------|
| `curvine-server/src/common/ufs_factory.rs` | MountValue cache, get_mnt/get_ufs |
| `curvine-server/src/master/job/job_manager.rs` | get_mnt, rt; channel rx not mut |
| `curvine-server/src/master/job/job_runner.rs` | check_job_exists async + data-state skip; remove stale job; create_all_tasks by path |
| `curvine-server/src/master/journal/journal_system.rs` | Own JobManager, job_manager() |
| `curvine-server/src/master/master_server.rs` | Get job_manager from JournalSystem |
| `curvine-server/src/worker/task/load_task_runner.rs` | Cv reader, update_progress(is_last) |
| `curvine-server/src/worker/task/task_context.rs` | update_progress(..., is_last), Completed only when is_last |
| `orpc/src/sync/channel.rs` | BlockingReceiver &self, recv_timeout |
