### PR TITLE
feat(server): add UfsLoader to sync journal metadata to UFS (#680)

### DIFF
--- a/curvine-server/src/master/journal/journal_loader.rs
+++ b/curvine-server/src/master/journal/journal_loader.rs
@@ -17,7 +17,7 @@
 use crate::master::journal::*;
 use crate::master::meta::inode::InodePath;
 use crate::master::meta::inode::InodeView::{Dir, File};
-use crate::master::{MountManager, SyncFsDir};
+use crate::master::{JobManager, MountManager, SyncFsDir};
 use curvine_common::conf::JournalConf;
 use curvine_common::proto::raft::SnapshotData;
 use curvine_common::raft::storage::AppStorage;
@@ -37,16 +37,24 @@ use std::{fs, mem};
 pub struct JournalLoader {
     fs_dir: SyncFsDir,
     mnt_mgr: Arc<MountManager>,
+    ufs_loader: UfsLoader,
     seq_id: Arc<AtomicCounter>,
     retain_checkpoint_num: usize,
     ignore_replay_error: bool,
 }
 
 impl JournalLoader {
-    pub fn new(fs_dir: SyncFsDir, mnt_mgr: Arc<MountManager>, conf: &JournalConf) -> Self {
+    pub fn new(
+        fs_dir: SyncFsDir,
+        mnt_mgr: Arc<MountManager>,
+        conf: &JournalConf,
+        job_manager: Arc<JobManager>,
+    ) -> Self {
+        let ufs_loader = UfsLoader::new(job_manager);
         Self {
             fs_dir,
             mnt_mgr,
+            ufs_loader,
             seq_id: Arc::new(AtomicCounter::new(0)),
             retain_checkpoint_num: 3.max(conf.retain_checkpoint_num),
             ignore_replay_error: conf.ignore_replay_error,
@@ -259,7 +267,7 @@ impl JournalLoader {
         Ok(())
     }
 
-    fn apply0(&self, is_leader: bool, message: &[u8]) -> RaftResult<()> {
+    async fn apply0(&self, is_leader: bool, message: &[u8]) -> RaftResult<()> {
         // The raft log has logs that do not contain referenced data.
         if message.is_empty() {
             return Ok(());
@@ -269,7 +277,9 @@ impl JournalLoader {
 
         // The leader node ignores all logs because they have been applied to the master node before synchronization via raft.
         if is_leader {
-            self.seq_id.set(batch.seq_id + 1);
+            let seq_id = batch.seq_id + 1;
+            self.ufs_loader.apply_batch(batch).await?;
+            self.seq_id.set(seq_id);
             return Ok(());
         }
 
@@ -293,7 +303,7 @@ impl JournalLoader {
 
 impl AppStorage for JournalLoader {
     async fn apply(&self, is_leader: bool, message: &[u8]) -> RaftResult<()> {
-        match self.apply0(is_leader, message) {
+        match self.apply0(is_leader, message).await {
             Ok(_) => Ok(()),
 
             Err(e) => {

--- a/curvine-server/src/master/journal/journal_system.rs
+++ b/curvine-server/src/master/journal/journal_system.rs
@@ -137,7 +137,12 @@ impl JournalSystem {
         let raft_journal = MetaRaftJournal::new(
             rt.clone(),
             log_store,
-            JournalLoader::new(fs_dir.clone(), mount_manager.clone(), &conf.journal),
+            JournalLoader::new(
+                fs_dir.clone(),
+                mount_manager.clone(),
+                &conf.journal,
+                job_manager.clone(),
+            ),
             conf.journal.clone(),
             role_monitor,
         );

--- a/curvine-server/src/master/journal/mod.rs
+++ b/curvine-server/src/master/journal/mod.rs
@@ -26,3 +26,6 @@ pub use self::journal_system::JournalSystem;
 
 mod sender_task;
 pub use self::sender_task::SenderTask;
+
+mod ufs_loader;
+pub use self::ufs_loader::UfsLoader;

--- a/curvine-server/src/master/journal/ufs_loader.rs
+++ b/curvine-server/src/master/journal/ufs_loader.rs
@@ -1,0 +1,123 @@
+//  Copyright 2025 OPPO.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+use crate::master::journal::{
+    CompleteFileEntry, DeleteEntry, JournalBatch, JournalEntry, MkdirEntry, RenameEntry,
+};
+use crate::master::JobManager;
+use curvine_client::unified::MountValue;
+use curvine_common::error::FsError;
+use curvine_common::fs::{FileSystem, Path};
+use curvine_common::state::LoadJobCommand;
+use curvine_common::FsResult;
+use log::warn;
+use orpc::{err_box, CommonResult};
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct UfsLoader {
+    job_manager: Arc<JobManager>,
+}
+
+impl UfsLoader {
+    pub fn new(job_manager: Arc<JobManager>) -> Self {
+        Self { job_manager }
+    }
+
+    pub async fn apply_batch(&self, batch: JournalBatch) -> CommonResult<()> {
+        for entry in batch.batch {
+            self.apply_entry(&entry).await?;
+        }
+        Ok(())
+    }
+
+    pub async fn submit_load_task(&self, path: &Path, mnt: &MountValue) -> FsResult<()> {
+        let command = LoadJobCommand::builder(path.clone_uri()).build();
+        let runner = self.job_manager.create_runner();
+        let _ = match runner.submit_load_task(command, mnt.info.clone()).await {
+            Ok(res) => res,
+            Err(e) => {
+                return if matches!(e, FsError::FileNotFound(_)) {
+                    // File may have been renamed
+                    Ok(())
+                } else {
+                    err_box!("load job failed: {}", e)
+                };
+            }
+        };
+        Ok(())
+    }
+
+    pub async fn apply_entry(&self, entry: &JournalEntry) -> FsResult<()> {
+        match entry {
+            JournalEntry::Mkdir(e) => self.mkdir(e).await,
+            JournalEntry::CompleteFile(e) => self.complete_file(e).await,
+            JournalEntry::Rename(e) => self.rename(e).await,
+            JournalEntry::Delete(e) => self.delete(e).await,
+            _ => Ok(()),
+        }
+    }
+
+    pub async fn mkdir(&self, e: &MkdirEntry) -> FsResult<()> {
+        let path = Path::from_str(&e.path)?;
+        if let Some((ufs_path, mnt)) = self.job_manager.get_mnt(&path)? {
+            mnt.ufs.mkdir(&ufs_path, false).await?;
+            Ok(())
+        } else {
+            Ok(())
+        }
+    }
+
+    pub async fn complete_file(&self, e: &CompleteFileEntry) -> FsResult<()> {
+        if !e.file.is_complete() {
+            return Ok(());
+        }
+
+        let path = Path::from_str(&e.path)?;
+        if let Some((_, mnt)) = self.job_manager.get_mnt(&path)? {
+            self.submit_load_task(&path, &mnt).await
+        } else {
+            Ok(())
+        }
+    }
+
+    pub async fn rename(&self, e: &RenameEntry) -> FsResult<()> {
+        let src = Path::from_str(&e.src)?;
+        let dst = Path::from_str(&e.dst)?;
+        if let Some((src_ufs_path, mnt)) = self.job_manager.get_mnt(&src)? {
+            if mnt.ufs.exists(&src_ufs_path).await? {
+                mnt.ufs.delete(&src_ufs_path, true).await?;
+            } else {
+                warn!("rename: src file not exists: {}", src_ufs_path);
+            }
+            self.submit_load_task(&dst, &mnt).await
+        } else {
+            Ok(())
+        }
+    }
+
+    pub async fn delete(&self, e: &DeleteEntry) -> FsResult<()> {
+        let path = Path::from_str(&e.path)?;
+        if let Some((ufs_path, mnt)) = self.job_manager.get_mnt(&path)? {
+            if mnt.ufs.exists(&ufs_path).await? {
+                mnt.ufs.delete(&ufs_path, true).await?;
+            } else {
+                warn!("delete: src file not exists: {}", ufs_path);
+            }
+            Ok(())
+        } else {
+            Ok(())
+        }
+    }
+}

--- a/curvine-server/src/master/meta/inode/inode_file.rs
+++ b/curvine-server/src/master/meta/inode/inode_file.rs
@@ -302,6 +302,12 @@ impl InodeFile {
         client_name: impl AsRef<str>,
         only_flush: bool,
     ) -> FsResult<()> {
+        // If commit_blocks contains data, it means the curvine file has been updated.
+        // The corresponding ufs_mtime is set to 0, indicating that the relationship with ufs has been severed.
+        if !commit_blocks.is_empty() {
+            self.storage_policy.ufs_mtime = 0
+        }
+
         for block in commit_blocks {
             let meta = self.search_block_mut_check(block.block_id)?;
             meta.commit(block);

--- a/curvine-server/tests/journal_test.rs
+++ b/curvine-server/tests/journal_test.rs
@@ -56,7 +56,12 @@ fn test_journal_replay_consistency_between_leader_and_follower() -> CommonResult
     let follower_journal_system = JournalSystem::from_conf(&conf)?;
     let fs_follower = MasterFilesystem::with_js(&conf, &follower_journal_system);
     let mnt_mgr2 = follower_journal_system.mount_manager();
-    let journal_loader = JournalLoader::new(fs_follower.fs_dir(), mnt_mgr2.clone(), &conf.journal);
+    let journal_loader = JournalLoader::new(
+        fs_follower.fs_dir(),
+        mnt_mgr2.clone(),
+        &conf.journal,
+        follower_journal_system.job_manager(),
+    );
 
     let entries = journal_system.fs().fs_dir.read().take_entries();
     info!("entries size {}", entries.len());

--- a/curvine-tests/tests/write_cache_test.rs
+++ b/curvine-tests/tests/write_cache_test.rs
@@ -13,18 +13,18 @@
 // limitations under the License.
 
 use bytes::BytesMut;
-use curvine_client::unified::UnifiedFileSystem;
+use curvine_client::unified::{UfsFileSystem, UnifiedFileSystem, UnifiedReader};
 use curvine_common::fs::{FileSystem, Path, Reader, Writer};
-use curvine_common::state::{MountOptionsBuilder, WriteType};
+use curvine_common::state::{MountOptionsBuilder, MountType, WriteType};
 use curvine_tests::Testing;
 use orpc::common::Utils;
 use orpc::runtime::{AsyncRuntime, RpcRuntime};
 use orpc::sys::DataSlice;
 use std::env;
 use std::sync::Arc;
+use std::time::Duration;
 
-#[test]
-fn test_mount_write_cache() {
+fn get_fs() -> UnifiedFileSystem {
     // Check if UFS configuration is available, if not, skip the test
     if env::var("UFS_TEST_PATH").is_err() {
         println!("⚠️  UFS_TEST_PATH is not set, skipping test");
@@ -33,31 +33,125 @@ fn test_mount_write_cache() {
         );
         println!("   Example: export UFS_TEST_PATH=hdfs://127.0.0.1:9000");
         println!("   Example: export UFS_TEST_PROPERTIES=\"hdfs.namenode=hdfs://127.0.0.1:9000,hdfs.user=root\"");
-        return;
+        panic!("UFS_TEST_PATH is not set")
     }
 
     let testing = Testing::default();
     let rt = Arc::new(AsyncRuntime::single());
-    let fs = testing.get_unified_fs_with_rt(rt.clone()).unwrap();
-
+    testing.get_unified_fs_with_rt(rt.clone()).unwrap()
+}
+#[test]
+fn test_cache_mode() {
+    let fs = get_fs();
+    let rt = fs.clone_runtime();
     rt.block_on(async move {
         mount(&fs, WriteType::CacheMode).await;
-        mount(&fs, WriteType::FsMode).await;
 
-        write(&fs, WriteType::CacheMode, false).await;
-        write(&fs, WriteType::FsMode, false).await;
-    })
+        let path = format!("/write_cache_{:?}/test.log", WriteType::CacheMode).into();
+
+        // Test 1: verify data write is correct
+        write(&fs, &path, false).await;
+
+        // Test 2: resubmit async task (skipped if data already synced); then check UFS mtime unchanged
+        let (ufs_path, mnt) = fs.get_mount(&path).await.unwrap().unwrap();
+        let ufs_reader_before = mnt.ufs.open(&ufs_path).await.unwrap();
+        let mtime_before = ufs_reader_before.status().mtime;
+        drop(ufs_reader_before);
+
+        fs.async_cache(&path).await.unwrap();
+        fs.wait_job_complete(&path, false).await.unwrap();
+
+        let ufs_reader_after = mnt.ufs.open(&ufs_path).await.unwrap();
+        let mtime_after = ufs_reader_after.status().mtime;
+        drop(ufs_reader_after);
+        assert_eq!(
+            mtime_before, mtime_after,
+            "resubmit should skip, UFS mtime should be unchanged ({} vs {})",
+            mtime_before, mtime_after
+        );
+
+        // Test 3: read cache test
+        let path = format!("/write_cache_{:?}/read_cache.log", WriteType::CacheMode).into();
+
+        // Write file to UFS, then test read
+        let mut writer = fs.create(&path, true).await.unwrap();
+        writer.write_string(Utils::rand_str(1024)).await.unwrap();
+        writer.complete().await.unwrap();
+        test_cache_read(&fs, &path).await;
+
+        // Delete curvine file to simulate expiry
+        fs.cv().delete(&path, false).await.unwrap();
+        test_cache_read(&fs, &path).await;
+    });
 }
 
-async fn write(fs: &UnifiedFileSystem, write_type: WriteType, random_write: bool) {
+async fn test_cache_read(fs: &UnifiedFileSystem, path: &Path) {
+    let mut reader1 = fs.open(path).await.unwrap();
+    assert!(
+        !matches!(reader1, UnifiedReader::Cv(_)),
+        "first read should be from ufs"
+    );
+
+    let str1 = reader1.read_as_string().await.unwrap();
+
+    let (ufs_path, _) = fs.get_mount(path).await.unwrap().unwrap();
+    fs.wait_job_complete(&ufs_path, false).await.unwrap();
+
+    let mut reader2 = fs.open(path).await.unwrap();
+    assert!(
+        matches!(reader2, UnifiedReader::Cv(_)),
+        "second read should be from curvine"
+    );
+
+    let str2 = reader2.read_as_string().await.unwrap();
+    assert_eq!(str1, str2);
+}
+
+#[test]
+fn test_fs_mode() {
+    let fs = get_fs();
+    let rt = fs.clone_runtime();
+    rt.block_on(async move {
+        mount(&fs, WriteType::FsMode).await;
+        let path = format!("/write_cache_{:?}/test.log", WriteType::FsMode).into();
+        write(&fs, &path, false).await;
+
+        let (_, mnt) = fs.get_mount(&path).await.unwrap().unwrap();
+
+        // Test rename
+        let path = format!("/write_cache_{:?}/meta.log", WriteType::FsMode).into();
+        let mut writer = fs.create(&path, true).await.unwrap();
+        writer.write_string(Utils::rand_str(1024)).await.unwrap();
+        writer.complete().await.unwrap();
+
+        let dst_path = format!("/write_cache_{:?}/meta_rename.log", WriteType::FsMode).into();
+        fs.rename(&path, &dst_path).await.unwrap();
+
+        tokio::time::sleep(Duration::from_secs(5)).await;
+
+        // Check UFS file
+        let ufs_path = mnt.get_ufs_path(&dst_path).unwrap();
+        let mut reader1 = mnt.ufs.open(&ufs_path).await.unwrap();
+        let str1 = reader1.read_as_string().await.unwrap();
+
+        let mut reader2 = fs.open(&dst_path).await.unwrap();
+        let str2 = reader2.read_as_string().await.unwrap();
+
+        assert_eq!(str1, str2);
+
+        // Test delete
+        fs.delete(&dst_path, false).await.unwrap();
+        tokio::time::sleep(Duration::from_secs(5)).await;
+        assert!(!mnt.ufs.exists(&ufs_path).await.unwrap());
+    });
+}
+
+async fn write(fs: &UnifiedFileSystem, path: &Path, random_write: bool) {
     let chunk_size = 64 * 1024;
     let total_size = 1024 * 1024;
     let num_chunks = total_size / chunk_size;
 
-    let dir = format!("write_cache_{:?}", write_type);
-    let path = Path::from_str(format!("/{}/test.log", dir)).unwrap();
-    let mut writer = fs.create(&path, true).await.unwrap();
-
+    let mut writer = fs.create(path, true).await.unwrap();
     let mut written_data = vec![0u8; total_size];
 
     // Sequential write all chunks
@@ -85,17 +179,14 @@ async fn write(fs: &UnifiedFileSystem, write_type: WriteType, random_write: bool
 
     writer.complete().await.unwrap();
 
-    verify_read_data(fs, &path, &written_data, write_type).await;
+    verify_read_data(fs, path, &written_data).await;
 
-    verify_cv_ufs_consistency(fs, &path).await;
+    fs.wait_job_complete(path, false).await.unwrap();
+
+    verify_cv_ufs_consistency(fs, path).await;
 }
 
-async fn verify_read_data(
-    fs: &UnifiedFileSystem,
-    path: &Path,
-    expected_data: &[u8],
-    _write_type: WriteType,
-) {
+async fn verify_read_data(fs: &UnifiedFileSystem, path: &Path, expected_data: &[u8]) {
     let mut reader = fs.open(path).await.unwrap();
 
     let mut read_data = BytesMut::zeroed(reader.len() as usize);
@@ -149,6 +240,13 @@ async fn mount(fs: &UnifiedFileSystem, write_type: WriteType) {
         }
     }
 
-    let opts = opts_builder.build();
-    fs.mount(&ufs_path, &cv_path, opts).await.unwrap();
+    let opts = opts_builder.mount_type(MountType::Orch).build();
+    let ufs = UfsFileSystem::new(&ufs_path, opts.add_properties.clone(), None).unwrap();
+    if ufs.exists(&ufs_path).await.unwrap() {
+        ufs.delete(&ufs_path, true).await.unwrap();
+    }
+
+    ufs.mkdir(&ufs_path, true).await.unwrap();
+
+    fs.mount(&ufs_path, &cv_path, opts.clone()).await.unwrap();
 }


### PR DESCRIPTION
## Summary

1. **Integrate UfsLoader with JournalLoader**: When the leader applies a journal batch, it now calls `UfsLoader::apply_batch` so metadata operations (mkdir, complete_file, rename, delete) are mirrored to UFS and load tasks are submitted for completed files.
2. **InodeFile**: On `complete()` with non-empty commit_blocks, set `ufs_mtime = 0` so the Curvine file is no longer considered tied to UFS (CV was updated).
3. **write_cache_test**: Restructure around CacheMode and FsMode: shared `get_fs()`, dedicated `test_cache_mode` and `test_fs_mode`, read-cache and rename/delete scenarios; mount uses `MountType::Orch` and clears UFS path when present.

## Changes

### 1. JournalLoader + UfsLoader

- **JournalLoader**:
  - Constructor: `new(fs_dir, mnt_mgr, conf, job_manager)`; creates `UfsLoader::new(job_manager)` and stores it.
  - **apply0**: Now `async`. On leader path, after `seq_id.set(batch.seq_id + 1)`, calls **`self.ufs_loader.apply_batch(batch).await?`** so each journal batch is replayed to UFS on the leader.
  - **apply**: Awaits `apply0(...).await`.
- **JournalSystem**: Builds `JournalLoader::new(..., job_manager.clone())`.
- **mod.rs**: `mod ufs_loader; pub use self::ufs_loader::UfsLoader;`.

### 2. InodeFile (`inode_file.rs`)

- In **complete()**, before processing commit_blocks: if `!commit_blocks.is_empty()`, set **`self.storage_policy.ufs_mtime = 0`** so the inode no longer tracks a UFS mtime (Curvine file was written and is no longer in sync with UFS by mtime).

### 3. journal_test

- **JournalLoader::new** is called with **`follower_journal_system.job_manager()`** so the test loader has a JobManager when replaying.

### 4. write_cache_test

- **get_fs()**: Centralized UFS env setup; returns `UnifiedFileSystem` or panics if `UFS_TEST_PATH` is not set.
- **test_cache_mode**:
  - Mount CacheMode; write to a path; resubmit async_cache and assert UFS mtime unchanged; read-cache test (create file, test_cache_read, delete CV file, test_cache_read again).
- **test_cache_read**: First open (UFS), wait_job_complete(ufs_path), second open (CV), assert content equal.
- **test_fs_mode**: Mount FsMode; write; rename test (create, rename, sleep 5s, check UFS content, delete, assert UFS gone).
- **write(path, random_write)**: Takes `path` and `random_write`; after verify_read_data calls `wait_job_complete(path, false)` and verify_cv_ufs_consistency.
- **verify_read_data**: No longer takes write_type.
- **mount()**: Uses `MountType::Orch` in opts; after mount, creates `UfsFileSystem` and deletes the UFS path if it exists (clean slate).

## Motivation

- **Leader UFS sync**: Replaying journal batches to UFS on the leader (via UfsLoader) keeps UFS metadata and load tasks in sync with Curvine metadata.
- **ufs_mtime semantics**: Clearing ufs_mtime when CV data is committed avoids treating the file as UFS-backed when it has been overwritten in Curvine.
- **Tests**: Clear split between CacheMode and FsMode and a shared get_fs() make write_cache tests easier to run and extend.
