### PR TITLE
feat(master): add Free RPC to release Curvine cache after UFS sync (#…

### DIFF
--- a/curvine-client/src/file/curvine_filesystem.rs
+++ b/curvine-client/src/file/curvine_filesystem.rs
@@ -189,6 +189,10 @@ impl CurvineFileSystem {
         self.fs_client.delete(path, recursive).await
     }
 
+    pub async fn free(&self, path: &Path) -> FsResult<()> {
+        self.fs_client.free(path).await
+    }
+
     pub async fn get_status(&self, path: &Path) -> FsResult<FileStatus> {
         self.fs_client.file_status(path).await
     }

--- a/curvine-client/src/file/fs_client.rs
+++ b/curvine-client/src/file/fs_client.rs
@@ -169,6 +169,15 @@ impl FsClient {
         Ok(())
     }
 
+    pub async fn free(&self, path: &Path) -> FsResult<()> {
+        let header = FreeRequest {
+            path: path.encode(),
+        };
+
+        let _: FreeResponse = self.rpc(RpcCode::Free, header).await?;
+        Ok(())
+    }
+
     pub async fn rename(&self, src: &Path, dst: &Path) -> FsResult<bool> {
         let header = RenameRequest {
             src: src.encode(),

--- a/curvine-client/src/unified/unified_filesystem.rs
+++ b/curvine-client/src/unified/unified_filesystem.rs
@@ -168,10 +168,19 @@ impl UnifiedFileSystem {
         self.cv.clone_runtime()
     }
 
-    // If the path lies outside the mount point, the operation behaves as a full delete.
-    // If it's within the mount point, only the associated cache files will be removed. (ufs will be ignored)
-    pub async fn free(&self, path: &Path, recursive: bool) -> FsResult<()> {
-        self.cv.delete(path, recursive).await
+    pub async fn free(&self, path: &Path) -> FsResult<()> {
+        match self.get_mount(path).await? {
+            None => err_box!(
+                "the current file is not mounted to ufs, so the `free` command cannot be executed."
+            ),
+            Some((_, mnt)) => {
+                if mnt.info.is_fs_mode() {
+                    self.cv.free(path).await
+                } else {
+                    self.cv.delete(path, false).await
+                }
+            }
+        }
     }
 
     pub async fn symlink(&self, target: &str, link: &Path, force: bool) -> FsResult<()> {

--- a/curvine-common/proto/master.proto
+++ b/curvine-common/proto/master.proto
@@ -89,6 +89,12 @@ message DeleteRequest {
 
 message DeleteResponse {}
 
+message FreeRequest {
+    required string path = 1;
+}
+
+message FreeResponse {}
+
 message GetFileStatusRequest {
     required string path = 1;
 }

--- a/curvine-common/src/fs/rpc_code.rs
+++ b/curvine-common/src/fs/rpc_code.rs
@@ -47,6 +47,7 @@ pub enum RpcCode {
     CreateFilesBatch = 23,
     AddBlocksBatch = 24,
     CompleteFilesBatch = 25,
+    Free = 26,
 
     // manager interface.
     Mount = 30,

--- a/curvine-server/src/master/fs/master_filesystem.rs
+++ b/curvine-server/src/master/fs/master_filesystem.rs
@@ -135,6 +135,19 @@ impl MasterFilesystem {
         Ok(true)
     }
 
+    pub fn free<T: AsRef<str>>(&self, path: T) -> FsResult<()> {
+        let mut fs_dir = self.fs_dir.write();
+        let inp = Self::resolve_path(&fs_dir, path.as_ref())?;
+
+        let free_res = fs_dir.free(&inp)?;
+        drop(fs_dir);
+
+        let mut worker_manager = self.worker_manager.write();
+        worker_manager.remove_blocks(&free_res);
+
+        Ok(())
+    }
+
     pub fn rename<T: AsRef<str>>(&self, src: T, dst: T, flags: RenameFlags) -> FsResult<bool> {
         let src = src.as_ref();
         let dst = dst.as_ref();

--- a/curvine-server/src/master/journal/entry.rs
+++ b/curvine-server/src/master/journal/entry.rs
@@ -126,6 +126,13 @@ pub struct SetLocksEntry {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct FreeEntry {
+    pub(crate) op_ms: u64,
+    pub(crate) path: String,
+    pub(crate) mtime: i64,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
 pub enum JournalEntry {
     Mkdir(MkdirEntry),
     CreateFile(CreateFileEntry),
@@ -141,6 +148,7 @@ pub enum JournalEntry {
     Symlink(SymlinkEntry),
     Link(LinkEntry),
     SetLocks(SetLocksEntry),
+    Free(FreeEntry),
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]

--- a/curvine-server/src/master/journal/journal_loader.rs
+++ b/curvine-server/src/master/journal/journal_loader.rs
@@ -78,6 +78,8 @@ impl JournalLoader {
 
             JournalEntry::Delete(e) => self.delete(e),
 
+            JournalEntry::Free(e) => self.free(e),
+
             JournalEntry::ReopenFile(e) => self.reopen_file(e),
 
             JournalEntry::Mount(e) => self.mount(e),
@@ -187,6 +189,13 @@ impl JournalLoader {
         let mut fs_dir = self.fs_dir.write();
         let inp = InodePath::resolve(fs_dir.root_ptr(), entry.path, &fs_dir.store)?;
         fs_dir.unprotected_delete(&inp, entry.mtime)?;
+        Ok(())
+    }
+
+    pub fn free(&self, entry: FreeEntry) -> CommonResult<()> {
+        let mut fs_dir = self.fs_dir.write();
+        let inp = InodePath::resolve(fs_dir.root_ptr(), entry.path, &fs_dir.store)?;
+        fs_dir.unprotected_free(&inp, entry.mtime)?;
         Ok(())
     }
 

--- a/curvine-server/src/master/journal/journal_writer.rs
+++ b/curvine-server/src/master/journal/journal_writer.rs
@@ -191,6 +191,15 @@ impl JournalWriter {
         self.send(JournalEntry::Delete(entry))
     }
 
+    pub fn log_free<P: AsRef<str>>(&self, op_ms: u64, path: P, mtime: i64) -> FsResult<()> {
+        let entry = FreeEntry {
+            op_ms,
+            path: path.as_ref().to_string(),
+            mtime,
+        };
+        self.send(JournalEntry::Free(entry))
+    }
+
     pub fn log_mount(&self, op_ms: u64, info: MountInfo) -> FsResult<()> {
         let entry = MountEntry { op_ms, info };
 

--- a/curvine-server/src/master/master_handler.rs
+++ b/curvine-server/src/master/master_handler.rs
@@ -211,6 +211,23 @@ impl MasterHandler {
         ctx.response(rep_header)
     }
 
+    pub fn retry_check_free(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+        let header: FreeRequest = ctx.parse_header()?;
+        ctx.set_audit(Some(header.path.to_string()), None);
+
+        self.free0(ctx.msg.req_id(), header)?;
+        ctx.response(FreeResponse::default())
+    }
+
+    pub fn free0(&self, req_id: i64, header: FreeRequest) -> FsResult<()> {
+        if self.check_is_retry(req_id)? {
+            return Ok(());
+        }
+
+        let res = self.fs.free(&header.path);
+        self.set_req_cache(req_id, res)
+    }
+
     pub fn rename0(&mut self, req_id: i64, header: RenameRequest) -> FsResult<bool> {
         if self.check_is_retry(req_id)? {
             return Ok(true);
@@ -617,6 +634,7 @@ impl MessageHandler for MasterHandler {
             RpcCode::CompleteFilesBatch => self.complete_files_batch(ctx),
             RpcCode::Exists => self.exists(ctx),
             RpcCode::Delete => self.retry_check_delete(ctx),
+            RpcCode::Free => self.retry_check_free(ctx),
             RpcCode::Rename => self.retry_check_rename(ctx),
             RpcCode::ListStatus => self.list_status(ctx),
             RpcCode::GetBlockLocations => self.get_block_locations(ctx),

--- a/curvine-server/src/master/meta/fs_dir.rs
+++ b/curvine-server/src/master/meta/fs_dir.rs
@@ -218,6 +218,45 @@ impl FsDir {
         Ok(del_res)
     }
 
+    pub fn free(&mut self, inp: &InodePath) -> FsResult<DeleteResult> {
+        let op_ms = LocalTime::mills();
+
+        let del_res = self.unprotected_free(inp, op_ms as i64)?;
+        self.journal_writer
+            .log_free(op_ms, inp.path(), op_ms as i64)?;
+
+        Ok(del_res)
+    }
+
+    pub(crate) fn unprotected_free(
+        &mut self,
+        inp: &InodePath,
+        mtime: i64,
+    ) -> FsResult<DeleteResult> {
+        let mut inode = match inp.get_last_inode() {
+            Some(v) => v,
+            None => return err_ext!(FsError::file_not_found(inp.path())),
+        };
+        let file = inode.as_file_mut()?;
+        if !file.ufs_exists() {
+            return err_box!("path {} data not synchronized to ufs", inp.path());
+        }
+
+        if file.blocks.is_empty() {
+            return Ok(DeleteResult::default());
+        }
+
+        let del_res = DeleteResult {
+            inodes: 0,
+            blocks: file.get_locs(&self.store)?,
+        };
+
+        file.free(mtime);
+        self.store.apply_free(&[&inode])?;
+
+        Ok(del_res)
+    }
+
     pub fn rename(
         &mut self,
         src_inp: &InodePath,

--- a/curvine-server/src/master/meta/inode/inode_file.rs
+++ b/curvine-server/src/master/meta/inode/inode_file.rs
@@ -14,14 +14,17 @@
 
 use crate::master::meta::feature::{AclFeature, FileFeature, WriteFeature};
 use crate::master::meta::inode::{Inode, EMPTY_PARENT_ID};
+use crate::master::meta::store::InodeStore;
 use crate::master::meta::{BlockMeta, InodeId};
 use curvine_common::state::{
-    CommitBlock, CreateFileOpts, ExtendedBlock, FileAllocOpts, FileType, StoragePolicy,
+    BlockLocation, CommitBlock, CreateFileOpts, ExtendedBlock, FileAllocOpts, FileType,
+    StoragePolicy,
 };
 use curvine_common::FsResult;
 use orpc::common::LocalTime;
 use orpc::{err_box, CommonResult};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::fmt::Debug;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -83,7 +86,10 @@ impl InodeFile {
             block_size: opts.block_size as u32,
             replicas: opts.replicas as u8,
 
-            storage_policy: opts.storage_policy,
+            storage_policy: StoragePolicy {
+                ufs_mtime: 0,
+                ..opts.storage_policy
+            },
             features: FileFeature {
                 x_attr: Default::default(),
                 file_write: None,
@@ -260,7 +266,10 @@ impl InodeFile {
         // Update file metadata with new options
         self.replicas = opts.replicas as u8;
         self.block_size = opts.block_size as u32;
-        self.storage_policy = opts.storage_policy;
+        self.storage_policy = StoragePolicy {
+            ufs_mtime: 0,
+            ..opts.storage_policy
+        };
         self.mtime = mtime;
 
         // Reset file writing state for new write operation
@@ -328,6 +337,11 @@ impl InodeFile {
             self.features.complete_write(client_name);
         }
         Ok(())
+    }
+
+    pub fn free(&mut self, mtime: i64) {
+        self.mtime = mtime;
+        self.blocks.clear();
     }
 
     /// Search for block by file position
@@ -470,6 +484,26 @@ impl InodeFile {
 
         self.len = expect_len;
         del_blocks
+    }
+
+    pub fn get_locs(&self, store: &InodeStore) -> CommonResult<HashMap<i64, Vec<BlockLocation>>> {
+        let mut res = HashMap::new();
+        for meta in &self.blocks {
+            if let Some(locs) = &meta.locs {
+                res.insert(meta.id, locs.clone());
+            } else {
+                let locs = store.get_locations(meta.id)?;
+                if !locs.is_empty() {
+                    res.insert(meta.id, locs);
+                }
+            }
+        }
+
+        Ok(res)
+    }
+
+    pub fn ufs_exists(&self) -> bool {
+        self.storage_policy.ufs_mtime > 0
     }
 }
 

--- a/curvine-server/src/master/meta/store/inode_store.rs
+++ b/curvine-server/src/master/meta/store/inode_store.rs
@@ -134,6 +134,15 @@ impl InodeStore {
         Ok(del_res)
     }
 
+    pub fn apply_free(&self, inodes: &[&InodeView]) -> CommonResult<()> {
+        let mut batch = self.store.new_batch();
+        for inode in inodes {
+            batch.write_inode(inode)?;
+        }
+        batch.commit()?;
+        Ok(())
+    }
+
     pub fn apply_rename(
         &self,
         src_parent: &InodeView,
@@ -356,16 +365,7 @@ impl InodeStore {
                         batch.delete_inode(inode_id)?;
 
                         // Collect block info
-                        for meta in &file.blocks {
-                            if let Some(locs) = &meta.locs {
-                                del_res.blocks.insert(meta.id, locs.clone());
-                            } else {
-                                let locs = self.store.get_locations(meta.id)?;
-                                if !locs.is_empty() {
-                                    del_res.blocks.insert(meta.id, locs);
-                                }
-                            }
-                        }
+                        del_res.blocks.extend(file.get_locs(self)?);
 
                         // Remove from TTL
                         if let Err(e) = self.ttl_bucket_list.remove_inode(inode_id as u64) {

--- a/curvine-tests/tests/write_cache_test.rs
+++ b/curvine-tests/tests/write_cache_test.rs
@@ -146,6 +146,67 @@ fn test_fs_mode() {
     });
 }
 
+#[test]
+fn test_cache_mode_free() {
+    let fs = get_fs();
+    let rt = fs.clone_runtime();
+    rt.block_on(async move {
+        mount(&fs, WriteType::CacheMode).await;
+
+        let data = Utils::rand_str(1024);
+
+        let path = format!(
+            "/write_cache_{:?}/test_cache_mode_free.log",
+            WriteType::CacheMode
+        )
+        .into();
+        let mut writer = fs.create(&path, true).await.unwrap();
+        writer.write_string(data).await.unwrap();
+        writer.complete().await.unwrap();
+
+        let _ = fs.open(&path).await.unwrap();
+        fs.wait_job_complete(&path, false).await.unwrap();
+
+        fs.free(&path).await.unwrap();
+
+        // Check cache file exists
+        assert!(!fs.cv().exists(&path).await.unwrap());
+
+        let reader = fs.open(&path).await.unwrap();
+        assert!(!matches!(reader, UnifiedReader::Cv(_)));
+    });
+}
+
+#[test]
+fn test_fs_mode_free() {
+    let fs = get_fs();
+    let rt = fs.clone_runtime();
+    rt.block_on(async move {
+        mount(&fs, WriteType::FsMode).await;
+
+        let data = Utils::rand_str(1024);
+
+        let path = format!("/write_cache_{:?}/test_fs_mode_free.log", WriteType::FsMode).into();
+        let mut writer = fs.create(&path, true).await.unwrap();
+        writer.write_string(&data).await.unwrap();
+        writer.complete().await.unwrap();
+
+        let _ = fs.open(&path).await.unwrap();
+        let (ufs_path, _) = fs.get_mount(&path).await.unwrap().unwrap();
+        fs.wait_job_complete(&ufs_path, false).await.unwrap();
+
+        fs.free(&path).await.unwrap();
+
+        let file_blocks = fs.cv().get_block_locations(&path).await.unwrap();
+        println!("test_fs_mode_free status {:?}", file_blocks);
+        assert_eq!(file_blocks.len, data.len() as i64);
+        assert_eq!(file_blocks.block_locs.len(), 0);
+
+        let reader = fs.open(&path).await.unwrap();
+        assert!(!matches!(reader, UnifiedReader::Cv(_)));
+    });
+}
+
 async fn write(fs: &UnifiedFileSystem, path: &Path, random_write: bool) {
     let chunk_size = 64 * 1024;
     let total_size = 1024 * 1024;
@@ -228,6 +289,10 @@ async fn mount(fs: &UnifiedFileSystem, write_type: WriteType) {
     let dir = format!("write_cache_{:?}", write_type);
     let ufs_path = Path::from_str(format!("{}/{}", ufs_base, dir)).unwrap();
     let cv_path = Path::from_str(format!("/{}", dir)).unwrap();
+
+    if fs.get_mount(&cv_path).await.unwrap().is_some() {
+        return;
+    }
 
     let mut opts_builder = MountOptionsBuilder::new().write_type(write_type);
 


### PR DESCRIPTION
## Description

### Summary

This PR adds a **Free** RPC that allows releasing Curvine’s cached block metadata and local cache for a path **after** its data has been synchronized to UFS. This supports reclaiming space and simplifying metadata once a file is safely stored in UFS.

### Changes

- **Proto & RPC**
  - `curvine-common/proto/master.proto`: add `FreeRequest` (path) and `FreeResponse`.
  - `curvine-common/src/fs/rpc_code.rs`: add `Free` RPC code.
  - `curvine-server/src/master/master_handler.rs`: add `retry_check_free` / `free0` and dispatch for `RpcCode::Free`.

- **Journal**
  - `curvine-server/src/master/journal/entry.rs`: add `FreeEntry` (op_ms, path, mtime) and `JournalEntry::Free`.
  - `journal_writer`: `log_free`; `journal_loader`: apply Free entry on replay.

- **Master metadata**
  - `curvine-server/src/master/meta/fs_dir.rs`: `free(inp)` and `unprotected_free(inp, mtime)` — ensure file has been synced to UFS (`ufs_exists`), then clear blocks and persist via journal.
  - `curvine-server/src/master/meta/inode/inode_file.rs`: `free(mtime)` (clear blocks, set mtime), `get_locs(store)` for block locations, `ufs_exists()` (based on `storage_policy.ufs_mtime > 0`).
  - `curvine-server/src/master/meta/store/inode_store.rs`: `apply_free` for persisting freed inodes.
  - `curvine-server/src/master/fs/master_filesystem.rs`: expose `free(&path)` to handler.

- **Client**
  - `curvine-client`: add `free(path)` in `curvine_filesystem`, `fs_client`, and `unified_filesystem`.

- **Tests**
  - `curvine-tests/tests/write_cache_test.rs`: add `test_cache_mode_free` and `test_fs_mode_free` (write → sync to UFS → free → assert cache/block state and read-from-UFS behavior). Minor mount helper change to skip if already mounted.

### Behavior

- **Precondition**: Free is only allowed when the file has been synced to UFS (`ufs_exists()`), otherwise an error is returned.
- **Effect**: In-memory and persisted file inode has its block list cleared and mtime updated; journal records the Free for replay.
- **Use case**: After async cache sync or fs_mode write, call `free(path)` to drop Curvine cache and block metadata so space can be reclaimed while the file remains in UFS.

### Testing

- New tests: `test_cache_mode_free`, `test_fs_mode_free` in `write_cache_test` (require `UFS_TEST_PATH` etc.).
- Existing write_cache tests unchanged; mount helper avoids duplicate mount when path already mounted.
