### PR TITLE
feat(client): handle write when data exists only in UFS (#680)

### DIFF
--- a/curvine-client/src/file/fs_writer.rs
+++ b/curvine-client/src/file/fs_writer.rs
@@ -69,6 +69,10 @@ impl FsWriter {
     pub fn append(fs_context: Arc<FsContext>, path: Path, file_blocks: FileBlocks) -> Self {
         Self::new(fs_context, path, file_blocks, true)
     }
+
+    pub fn file_blocks(&self) -> &FileBlocks {
+        self.inner.file_blocks()
+    }
 }
 
 impl Writer for FsWriter {

--- a/curvine-client/src/file/fs_writer_buffer.rs
+++ b/curvine-client/src/file/fs_writer_buffer.rs
@@ -104,7 +104,7 @@ impl BufferChannel {
 // Reader with buffer.
 pub struct FsWriterBuffer {
     path: Path,
-    status: FileStatus,
+    file_blocks: FileBlocks,
     writer: BufferChannel,
     pos: i64,
 }
@@ -113,7 +113,7 @@ impl FsWriterBuffer {
     pub fn new(writer: FsWriterBase, chunk_num: usize) -> Self {
         let err_monitor = Arc::new(ErrorMonitor::new());
         let path = writer.path().clone();
-        let status = writer.status().clone();
+        let file_blocks = writer.file_blocks();
         let pos = writer.pos();
 
         let (chunk_sender, chunk_receiver) = AsyncChannel::new(chunk_num).split();
@@ -140,7 +140,7 @@ impl FsWriterBuffer {
 
         Self {
             path,
-            status,
+            file_blocks,
             writer,
             pos,
         }
@@ -155,7 +155,11 @@ impl FsWriterBuffer {
     }
 
     pub fn status(&self) -> &FileStatus {
-        &self.status
+        &self.file_blocks.status
+    }
+
+    pub fn file_blocks(&self) -> &FileBlocks {
+        &self.file_blocks
     }
 
     pub fn pos(&self) -> i64 {

--- a/curvine-client/src/unified/unified_filesystem.rs
+++ b/curvine-client/src/unified/unified_filesystem.rs
@@ -19,7 +19,7 @@ use crate::ClientMetrics;
 use bytes::BytesMut;
 use curvine_common::conf::ClusterConf;
 use curvine_common::error::FsError;
-use curvine_common::fs::{FileSystem, Path};
+use curvine_common::fs::{FileSystem, Path, Reader, Writer};
 use curvine_common::state::{
     CreateFileOpts, FileAllocOpts, FileLock, FileStatus, JobStatus, LoadJobCommand, LoadJobResult,
     MasterInfo, MkdirOpts, MkdirOptsBuilder, MountInfo, MountOptions, OpenFlags, SetAttrOpts,
@@ -306,16 +306,80 @@ impl UnifiedFileSystem {
         self.enable_unified = false
     }
 
+    pub async fn copy_ufs_file(
+        &self,
+        path: &Path,
+        mnt: &MountValue,
+        opts: CreateFileOpts,
+        cv_len: i64,
+    ) -> FsResult<()> {
+        let ufs_path = mnt.get_ufs_path(path)?;
+        let mut reader = mnt.ufs.open(&ufs_path).await?;
+        if reader.len() != cv_len {
+            return err_box!(
+                "file length mismatch: cv_path={:?}, ufs_path={:?}, ufs_len={}, cv_len={}",
+                path,
+                ufs_path,
+                reader.len(),
+                cv_len
+            );
+        }
+
+        let flags = OpenFlags::new_create().set_overwrite(true);
+        let mut writer = self.cv.open_with_opts(path, opts, flags).await?;
+
+        loop {
+            let data = reader.async_read(None).await?;
+            if data.is_empty() {
+                break;
+            }
+            writer.async_write(data).await?;
+        }
+        reader.complete().await?;
+        writer.complete().await?;
+
+        Ok(())
+    }
+
+    pub async fn open_for_write(&self, path: &Path) -> FsResult<UnifiedWriter> {
+        let opts = self.cv().create_opts_builder().create_parent(true).build();
+        let flags = OpenFlags::new_write_only().set_create(true);
+        self.open_with_opts(path, opts, flags).await
+    }
+
     pub async fn open_with_opts(
         &self,
         path: &Path,
         opts: CreateFileOpts,
         flags: OpenFlags,
     ) -> FsResult<UnifiedWriter> {
-        match self.get_mount_checked(path).await? {
+        match self.get_mount(path).await? {
             None => {
                 let writer = self.cv.open_with_opts(path, opts, flags).await?;
                 Ok(UnifiedWriter::Cv(writer))
+            }
+
+            Some((_, mount)) if mount.info.is_fs_mode() => {
+                let mut writer = self.cv.open_with_opts(path, opts.clone(), flags).await?;
+                if writer.file_blocks().cv_exists()
+                    || flags.overwrite()
+                    || !writer.status().ufs_exists()
+                {
+                    Ok(UnifiedWriter::Cv(writer))
+                } else {
+                    writer.complete().await?;
+
+                    info!(
+                        "copying data from UFS to CV, path={}, len={}",
+                        path,
+                        writer.status().len
+                    );
+                    self.copy_ufs_file(path, &mount, opts.clone(), writer.status().len)
+                        .await?;
+
+                    let writer = self.cv.open_with_opts(path, opts, flags).await?;
+                    Ok(UnifiedWriter::Cv(writer))
+                }
             }
 
             Some((ufs_path, mount)) => {
@@ -412,10 +476,9 @@ impl FileSystem<UnifiedWriter, UnifiedReader> for UnifiedFileSystem {
     }
 
     async fn append(&self, path: &Path) -> FsResult<UnifiedWriter> {
-        match self.get_mount_checked(path).await? {
-            None => Ok(UnifiedWriter::Cv(self.cv.append(path).await?)),
-            Some((ufs_path, mount)) => mount.ufs.append(&ufs_path).await,
-        }
+        let flags = OpenFlags::new_append().set_create(true);
+        let opts = self.cv.create_opts_builder().build();
+        self.open_with_opts(path, opts, flags).await
     }
 
     async fn exists(&self, path: &Path) -> FsResult<bool> {

--- a/curvine-common/src/state/block_info.rs
+++ b/curvine-common/src/state/block_info.rs
@@ -164,7 +164,7 @@ impl FileBlocks {
     }
 
     pub fn cv_exists(&self) -> bool {
-        !self.block_locs.is_empty()
+        self.len > 0 && !self.block_locs.is_empty()
     }
 }
 

--- a/curvine-server/src/master/meta/inode/inode_file.rs
+++ b/curvine-server/src/master/meta/inode/inode_file.rs
@@ -163,7 +163,11 @@ impl InodeFile {
     }
 
     pub fn compute_len(&self) -> i64 {
-        self.blocks.iter().map(|x| x.len as i64).sum()
+        if self.cv_exists() {
+            self.blocks.iter().map(|x| x.len as i64).sum()
+        } else {
+            self.len
+        }
     }
 
     pub fn commit_len(&self, last: Option<&CommitBlock>) -> i64 {
@@ -504,6 +508,10 @@ impl InodeFile {
 
     pub fn ufs_exists(&self) -> bool {
         self.storage_policy.ufs_mtime > 0
+    }
+
+    pub fn cv_exists(&self) -> bool {
+        self.len > 0 && !self.blocks.is_empty()
     }
 }
 

--- a/curvine-tests/tests/write_cache_test.rs
+++ b/curvine-tests/tests/write_cache_test.rs
@@ -23,6 +23,7 @@ use orpc::sys::DataSlice;
 use std::env;
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::time::sleep;
 
 fn get_fs() -> UnifiedFileSystem {
     // Check if UFS configuration is available, if not, skip the test
@@ -204,6 +205,123 @@ fn test_fs_mode_free() {
 
         let reader = fs.open(&path).await.unwrap();
         assert!(!matches!(reader, UnifiedReader::Cv(_)));
+    });
+}
+
+async fn prepare_fs_mode_file_then_free(fs: &UnifiedFileSystem, path: &Path, data: &str) {
+    let mut writer = fs.create(path, true).await.unwrap();
+    writer.write_string(data).await.unwrap();
+    writer.complete().await.unwrap();
+    let _ = fs.open(path).await.unwrap();
+    fs.wait_job_complete(path, false).await.unwrap();
+    fs.free(path).await.unwrap();
+}
+
+#[test]
+fn test_fs_mode_ufs_write_overwrite() {
+    let fs = get_fs();
+    let rt = fs.clone_runtime();
+    rt.block_on(async move {
+        mount(&fs, WriteType::FsMode).await;
+        let base = format!("/write_cache_{:?}", WriteType::FsMode);
+        let path =
+            Path::from_str(format!("{}/test_fs_mode_ufs_write_overwrite.log", base)).unwrap();
+
+        let data_initial = Utils::rand_str(1024);
+        prepare_fs_mode_file_then_free(&fs, &path, &data_initial).await;
+
+        let data_overwrite = Utils::rand_str(2048);
+        let mut writer = fs.create(&path, true).await.unwrap();
+        writer.write_string(&data_overwrite).await.unwrap();
+        writer.complete().await.unwrap();
+
+        let reader = fs.open(&path).await.unwrap();
+        assert!(
+            matches!(reader, UnifiedReader::Cv(_)),
+            "read should return CV reader after overwrite and sync"
+        );
+
+        verify_read_data(&fs, &path, data_overwrite.as_bytes()).await;
+
+        sleep(Duration::from_secs(3)).await;
+        verify_cv_ufs_consistency(&fs, &path).await;
+    });
+}
+
+#[test]
+fn test_fs_mode_ufs_write_append() {
+    let fs = get_fs();
+    let rt = fs.clone_runtime();
+    rt.block_on(async move {
+        mount(&fs, WriteType::FsMode).await;
+        let base = format!("/write_cache_{:?}", WriteType::FsMode);
+        let path = Path::from_str(format!("{}/test_fs_mode_ufs_write_append.log", base)).unwrap();
+
+        let data_initial = Utils::rand_str(1024);
+        prepare_fs_mode_file_then_free(&fs, &path, &data_initial).await;
+
+        let data_append_extra = Utils::rand_str(512);
+        let mut writer = fs.append(&path).await.unwrap();
+        writer.write_string(&data_append_extra).await.unwrap();
+        writer.complete().await.unwrap();
+
+        let reader = fs.open(&path).await.unwrap();
+        assert!(
+            matches!(reader, UnifiedReader::Cv(_)),
+            "read should return CV reader after append and sync"
+        );
+        let expected_append = format!("{}{}", data_initial, data_append_extra);
+
+        verify_read_data(&fs, &path, expected_append.as_bytes()).await;
+
+        sleep(Duration::from_secs(3)).await;
+        verify_cv_ufs_consistency(&fs, &path).await;
+    });
+}
+
+#[test]
+fn test_fs_mode_ufs_write_random() {
+    let fs = get_fs();
+    let rt = fs.clone_runtime();
+    rt.block_on(async move {
+        mount(&fs, WriteType::FsMode).await;
+        let base = format!("/write_cache_{:?}", WriteType::FsMode);
+        let path = Path::from_str(format!("{}/test_fs_mode_ufs_write_random.log", base)).unwrap();
+
+        let data_initial = Utils::rand_str(1024);
+        prepare_fs_mode_file_then_free(&fs, &path, &data_initial).await;
+
+        let chunk_size = 64 * 1024;
+        let total_size = 256 * 1024;
+        let num_chunks = total_size / chunk_size;
+        let mut writer = fs.open_for_write(&path).await.unwrap();
+        let mut expected = vec![0u8; total_size];
+        for _ in 0..num_chunks {
+            let data_str = Utils::rand_str(chunk_size);
+            let data = DataSlice::from_str(data_str.clone()).freeze();
+            let write_pos = writer.pos() as usize;
+            writer.async_write(data.clone()).await.unwrap();
+            expected[write_pos..write_pos + chunk_size].copy_from_slice(data_str.as_bytes());
+        }
+        let random_pos = (num_chunks / 2 * chunk_size) as i64;
+        writer.seek(random_pos).await.unwrap();
+        let random_chunk = Utils::rand_str(chunk_size);
+        let random_data = DataSlice::from_str(random_chunk.clone()).freeze();
+        let write_pos = writer.pos() as usize;
+        writer.async_write(random_data).await.unwrap();
+        expected[write_pos..write_pos + chunk_size].copy_from_slice(random_chunk.as_bytes());
+        writer.complete().await.unwrap();
+        fs.wait_job_complete(&path, false).await.unwrap();
+        let reader = fs.open(&path).await.unwrap();
+        assert!(
+            matches!(reader, UnifiedReader::Cv(_)),
+            "read should return CV reader after random write and sync"
+        );
+
+        verify_read_data(&fs, &path, &expected).await;
+
+        sleep(Duration::from_secs(3)).await;
+        verify_cv_ufs_consistency(&fs, &path).await;
     });
 }
 


### PR DESCRIPTION
- In fs_mode mount, open_for_write: if CV has no blocks (data only in UFS), copy from UFS to CV via copy_ufs_file() then open writer; add copy_ufs_file, open_for_write
- cv_exists(): require len>0 and non-empty blocks (block_info + InodeFile); InodeFile.compute_len() use self.len when !cv_exists()
- FsWriter/FsWriterBuffer: expose file_blocks() for cv_exists check
- append() use open_with_opts so UFS-only path is handled
- Tests: test_fs_mode_ufs_write_overwrite, test_fs_mode_ufs_write_append, test_fs_mode_ufs_write_random (prepare+free then overwrite/append/random write)