### PR TITLE
refactor(server): replace Persist/Evict/Flush with single Free action…

### DIFF
--- a/curvine-cli/src/cmds/mount.rs
+++ b/curvine-cli/src/cmds/mount.rs
@@ -420,7 +420,7 @@ impl MountCommand {
         let conf_map = self.get_config_map()?;
 
         let ttl_action = if matches!(write_type, WriteType::FsMode) {
-            TtlAction::Flush
+            TtlAction::Free
         } else {
             TtlAction::Delete
         };

--- a/curvine-common/proto/common.proto
+++ b/curvine-common/proto/common.proto
@@ -18,9 +18,7 @@ enum StorageTypeProto {
 enum TtlActionProto {
     TTL_ACTION_PROTO_NONE = 0;
     TTL_ACTION_PROTO_DELETE = 1;
-    TTL_ACTION_PROTO_PERSIST = 2;
-    TTL_ACTION_PROTO_EVICT = 3;
-    TTL_ACTION_PROTO_FLUSH = 4;
+    TTL_ACTION_PROTO_FREE = 2;
 }
 
 enum WriteTypeProto {

--- a/curvine-common/src/state/ttl_action.rs
+++ b/curvine-common/src/state/ttl_action.rs
@@ -34,9 +34,7 @@ pub enum TtlAction {
     #[default]
     None = 0,
     Delete = 1,
-    Persist = 2,
-    Evict = 3,
-    Flush = 4,
+    Free = 2,
 }
 
 impl TryFrom<&str> for TtlAction {
@@ -46,9 +44,7 @@ impl TryFrom<&str> for TtlAction {
         let action = match value.to_uppercase().as_str() {
             "NONE" => TtlAction::None,
             "DELETE" => TtlAction::Delete,
-            "PERSIST" => TtlAction::Persist,
-            "EVICT" => TtlAction::Evict,
-            "FLUSH" => TtlAction::Flush,
+            "FREE" => TtlAction::Free,
             _ => return err_box!("invalid ttl action: {}", value),
         };
 

--- a/curvine-common/src/utils/display.rs
+++ b/curvine-common/src/utils/display.rs
@@ -45,9 +45,7 @@ fn ttl_action_to_str(ttl_action: TtlActionProto) -> &'static str {
     match ttl_action {
         TtlActionProto::None => "none",
         TtlActionProto::Delete => "delete",
-        TtlActionProto::Persist => "persist",
-        TtlActionProto::Evict => "evict",
-        TtlActionProto::Flush => "flush",
+        TtlActionProto::Free => "free",
     }
 }
 

--- a/curvine-s3-gateway/src/utils/s3_utils.rs
+++ b/curvine-s3-gateway/src/utils/s3_utils.rs
@@ -145,9 +145,7 @@ pub fn fill_ttl_info(head: &mut HeadObjectResult, file_status: &FileStatus) {
         head.expiration = Some(
             match file_status.storage_policy.ttl_action {
                 TtlAction::Delete => "expiry-date=\"{}\" rule-id=\"ttl-delete\"",
-                TtlAction::Persist => "expiry-date=\"{}\" rule-id=\"ttl-persist\"",
-                TtlAction::Evict => "expiry-date=\"{}\" rule-id=\"ttl-evict\"",
-                TtlAction::Flush => "expiry-date=\"{}\" rule-id=\"ttl-flush\"",
+                TtlAction::Free => "expiry-date=\"{}\" rule-id=\"ttl-free\"",
                 _ => "rule-id=\"no-expiry\"",
             }
             .to_string(),

--- a/curvine-server/src/master/meta/inode/ttl/ttl_checker.rs
+++ b/curvine-server/src/master/meta/inode/ttl/ttl_checker.rs
@@ -211,23 +211,18 @@ impl InodeTtlChecker {
                     result.failed_cleanups = 1;
                 }
             },
-            TtlAction::Persist | TtlAction::Evict | TtlAction::Flush => {
-                match self.action_executor.free_inode(inode_id) {
-                    Ok(()) => {
-                        info!(
-                            "Successfully executed {:?} action for inode {}",
-                            action, inode_id
-                        );
-                        result.successful_frees.push(inode_id);
-                        result.successful_cleanups = 1;
-                    }
-                    Err(e) => {
-                        error!("{:?} action failed for inode {}: {}", action, inode_id, e);
-                        result.failed_inodes.push(inode_id);
-                        result.failed_cleanups = 1;
-                    }
+            TtlAction::Free => match self.action_executor.free_inode(inode_id) {
+                Ok(()) => {
+                    info!("Successfully executed Free action for inode {}", inode_id);
+                    result.successful_frees.push(inode_id);
+                    result.successful_cleanups = 1;
                 }
-            }
+                Err(e) => {
+                    error!("Free action failed for inode {}: {}", inode_id, e);
+                    result.failed_inodes.push(inode_id);
+                    result.failed_cleanups = 1;
+                }
+            },
             TtlAction::None => {
                 warn!("No ttl action defined for inode {}, skipping", inode_id);
                 result.skipped_inodes = 1;

--- a/curvine-server/src/master/meta/inode/ttl/ttl_executor.rs
+++ b/curvine-server/src/master/meta/inode/ttl/ttl_executor.rs
@@ -42,7 +42,7 @@ use std::sync::{Arc, RwLock};
 pub struct InodeTtlExecutor {
     filesystem: MasterFilesystem,
     path_cache: Arc<RwLock<HashMap<u64, String>>>,
-    mount_manager: Arc<MountManager>,
+    pub mount_manager: Arc<MountManager>,
     factory: Arc<UfsFactory>,
     job_manager: Arc<JobManager>,
 }
@@ -64,20 +64,7 @@ impl InodeTtlExecutor {
     }
 
     fn get_inode_path(&self, inode_id: u64) -> TtlResult<String> {
-        if let Ok(cache) = self.path_cache.read() {
-            if let Some(path) = cache.get(&inode_id) {
-                debug!("Cache hit for inode {}: {}", inode_id, path);
-                return Ok(path.clone());
-            }
-        }
-
         let path = self.resolve_inode_path(inode_id as i64)?;
-
-        if let Ok(mut cache) = self.path_cache.write() {
-            cache.insert(inode_id, path.clone());
-            debug!("Cached path for inode {}: {}", inode_id, path);
-        }
-
         Ok(path)
     }
 
@@ -158,7 +145,7 @@ impl InodeTtlExecutor {
     }
 
     pub fn free_inode(&self, inode_id: u64) -> TtlResult<()> {
-        info!("Freeing inode: {}", inode_id);
+        debug!("Freeing inode: {}", inode_id);
 
         let path = self.get_inode_path(inode_id)?;
         let inode = self.get_inode_from_store(inode_id)?.ok_or_else(|| {
@@ -170,9 +157,8 @@ impl InodeTtlExecutor {
                 let action = file.storage_policy.ttl_action;
                 self.free(inode_id, &path, action, false)?;
             }
-            InodeView::Dir(_, dir) => {
-                let action = dir.storage_policy.ttl_action;
-                self.free(inode_id, &path, action, true)?;
+            InodeView::Dir(_, _) => {
+                // pass
             }
             InodeView::FileEntry(..) => {
                 return Err(TtlError::ActionExecutionError(format!(
@@ -187,7 +173,7 @@ impl InodeTtlExecutor {
 
     fn free(
         &self,
-        inode_id: u64,
+        _inode_id: u64,
         path: &str,
         action: TtlAction,
         is_directory: bool,
@@ -199,51 +185,7 @@ impl InodeTtlExecutor {
             action
         );
 
-        let cv_path = Path::from_str(path)
-            .map_err(|e| TtlError::ActionExecutionError(format!("Invalid path {}: {}", path, e)))?;
-
-        let mount_info = self
-            .mount_manager
-            .get_mount_info(&cv_path)
-            .map_err(|e| {
-                TtlError::ActionExecutionError(format!("Failed to get mount info: {}", e))
-            })?
-            .ok_or_else(|| {
-                TtlError::ActionExecutionError(format!("No mount point for path: {}", path))
-            })?;
-
-        let ufs_path = mount_info.get_ufs_path(&cv_path).map_err(|e| {
-            TtlError::ActionExecutionError(format!("Failed to get UFS path: {}", e))
-        })?;
-
-        let ufs_exists = self.check_ufs_exists(&mount_info, &ufs_path)?;
-
-        match (ufs_exists, action) {
-            (true, TtlAction::Persist | TtlAction::Evict) => {
-                info!(
-                    "UFS {} already exists, skipping job: {}",
-                    self.resource_type(is_directory),
-                    ufs_path.full_path()
-                );
-                self.handle_skip_job(inode_id, action, path, is_directory)?;
-            }
-            _ => {
-                info!(
-                    "Submitting export job for {}: {}",
-                    self.resource_type(is_directory),
-                    path
-                );
-                self.submit_export_job(
-                    inode_id,
-                    path,
-                    &ufs_path,
-                    action,
-                    is_directory,
-                    mount_info,
-                )?;
-            }
-        }
-
+        self.filesystem.free(path)?;
         Ok(())
     }
 
@@ -257,7 +199,7 @@ impl InodeTtlExecutor {
         }
     }
 
-    fn check_ufs_exists(
+    pub fn check_ufs_exists(
         &self,
         mount_info: &curvine_common::state::MountInfo,
         ufs_path: &Path,
@@ -283,7 +225,7 @@ impl InodeTtlExecutor {
         Ok(exists)
     }
 
-    fn handle_skip_job(
+    pub fn handle_skip_job(
         &self,
         _inode_id: u64,
         action: TtlAction,
@@ -293,19 +235,13 @@ impl InodeTtlExecutor {
         let resource_type = self.resource_type(is_directory);
 
         match action {
-            TtlAction::Persist => {
+            TtlAction::Free if !is_directory => {
                 info!(
-                    "Persist: UFS {} exists, keeping Curvine {}: {}",
+                    "Free: UFS {} exists, freeing Curvine {}: {}",
                     resource_type, resource_type, cv_path
                 );
-            }
-            TtlAction::Evict => {
-                info!(
-                    "Evict: UFS {} exists, deleting Curvine {}: {}",
-                    resource_type, resource_type, cv_path
-                );
-                self.filesystem.delete(cv_path, is_directory).map_err(|e| {
-                    TtlError::ActionExecutionError(format!("Failed to delete {}: {}", cv_path, e))
+                self.filesystem.free(cv_path).map_err(|e| {
+                    TtlError::ActionExecutionError(format!("Failed to free {}: {}", cv_path, e))
                 })?;
             }
             _ => {}
@@ -313,7 +249,7 @@ impl InodeTtlExecutor {
         Ok(())
     }
 
-    fn submit_export_job(
+    pub fn submit_export_job(
         &self,
         inode_id: u64,
         cv_path: &str,
@@ -325,7 +261,7 @@ impl InodeTtlExecutor {
         let command = LoadJobCommand {
             source_path: cv_path.to_string(),
             target_path: Some(ufs_path.full_path().to_string()),
-            overwrite: Some(matches!(action, TtlAction::Flush)),
+            overwrite: Some(matches!(action, TtlAction::Free)),
             replicas: None,
             block_size: None,
             storage_type: None,
@@ -356,7 +292,7 @@ impl InodeTtlExecutor {
         Ok(())
     }
 
-    fn register_export_callback(
+    pub fn register_export_callback(
         &self,
         job_id: String,
         inode_id: u64,
@@ -379,27 +315,19 @@ impl InodeTtlExecutor {
                     // So we compute it inline (consistent with other methods now using helper)
                     let resource_type = if is_directory { "directory" } else { "file" };
 
-                    match action {
-                        TtlAction::Persist => {
-                            info!(
-                                "Persist completed, keeping Curvine {}: {}",
-                                resource_type, cv_path
-                            );
-                        }
-                        TtlAction::Evict | TtlAction::Flush => {
-                            info!(
-                                "Evict/Flush completed, deleting Curvine {}: {}",
-                                resource_type, cv_path
-                            );
-                            // Use recursive=true for directories, false for files
-                            if let Err(e) = filesystem.delete(&cv_path, is_directory) {
+                    if action == TtlAction::Free {
+                        info!(
+                            "Free completed, freeing Curvine {}: {}",
+                            resource_type, cv_path
+                        );
+                        if !is_directory {
+                            if let Err(e) = filesystem.free(&cv_path) {
                                 error!(
-                                    "Failed to delete Curvine {} after export: {}",
+                                    "Failed to free Curvine {} after export: {}",
                                     resource_type, e
                                 );
                             }
                         }
-                        _ => {}
                     }
                 } else {
                     warn!(

--- a/curvine-tests/tests/ttl_test.rs
+++ b/curvine-tests/tests/ttl_test.rs
@@ -12,10 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use curvine_client::file::{FsClient, FsContext};
+use curvine_client::file::{FsClient, FsContext, FsWriter};
 use curvine_common::conf::ClientConf;
-use curvine_common::fs::Path;
-use curvine_common::state::{CreateFileOptsBuilder, MkdirOptsBuilder, StoragePolicy, TtlAction};
+use curvine_common::fs::{Path, Writer};
+use curvine_common::state::{
+    CreateFileOptsBuilder, FileBlocks, MkdirOptsBuilder, SetAttrOptsBuilder, StoragePolicy,
+    TtlAction,
+};
 use curvine_tests::Testing;
 use log::info;
 use orpc::common::{DurationUnit, LogConf, Logger};
@@ -70,8 +73,11 @@ fn test_ttl_cleanup() -> CommonResult<()> {
         // Test 4: Test TTL cleanup timing
         test_ttl_cleanup_timing(&client, &conf.client).await?;
 
-        // Test 5: Test multiple files cleanupFix TTL test failures and improve test coverage
+        // Test 5: Test multiple files cleanup. Fix TTL test failures and improve test coverage
         test_ttl_multiple_files_cleanup(&client, &conf.client).await?;
+
+        // Test 6: TTL Free
+        test_ttl_free_cleanup(&client, &conf.client).await?;
 
         info!("Inode ttl cleanup test completed successfully");
         Ok(())
@@ -159,6 +165,71 @@ async fn test_ttl_file_cleanup(fs: &FsClient, conf: &ClientConf) -> CommonResult
     assert!(!exists, "File should be deleted after TTL expiration");
     info!("File successfully deleted after TTL expiration");
 
+    Ok(())
+}
+
+/// TTL Free background automatic cleanup: after expiration, free is executed;
+/// data (blocks) are deleted but the file still exists.
+async fn test_ttl_free_cleanup(fs: &FsClient, conf: &ClientConf) -> CommonResult<()> {
+    info!("Testing TTL Free cleanup: data deleted, file still exists");
+
+    let file_path = Path::from("/test_ttl_free.txt");
+    let ttl_ms = 3000u64; // 3 seconds TTL
+    let data = "ttl_free_test_data";
+
+    let opts = CreateFileOptsBuilder::with_conf(conf)
+        .create_parent(true)
+        .ttl_ms(ttl_ms as i64)
+        .ttl_action(TtlAction::Free)
+        .build();
+
+    let status = fs.create_with_opts(&file_path, opts, true).await?;
+    let mut writer = FsWriter::create(
+        fs.context().clone(),
+        file_path.clone(),
+        FileBlocks::new(status, vec![]),
+    );
+    writer.write_string(data).await?;
+    writer.complete().await?;
+    info!("Created file with TTL Free: {}", file_path);
+
+    let set_opts = SetAttrOptsBuilder::new().ufs_mtime(1).build();
+    fs.set_attr(&file_path, set_opts).await?;
+    info!("Set ufs_mtime so Free can run (ufs_exists)");
+
+    assert!(fs.exists(&file_path).await?);
+    let blocks_before = fs.get_block_locations(&file_path).await?;
+    assert!(
+        !blocks_before.block_locs.is_empty(),
+        "file should have blocks before TTL free"
+    );
+
+    info!("Waiting for TTL Free to run (blocks cleared)...");
+    awaitility::at_most(Duration::from_secs(12))
+        .poll_interval(Duration::from_millis(200))
+        .until_async(|| async {
+            let blocks = fs.get_block_locations(&file_path).await.ok();
+            blocks.map(|b| b.block_locs.is_empty()).unwrap_or(false)
+        })
+        .await;
+
+    let blocks_after = fs.get_block_locations(&file_path).await?;
+    assert_eq!(
+        blocks_after.len,
+        data.len() as i64,
+        "file len should be unchanged after free"
+    );
+    assert_eq!(
+        blocks_after.block_locs.len(),
+        0,
+        "all curvine blocks should be deleted"
+    );
+    assert!(
+        fs.exists(&file_path).await?,
+        "file should still exist after free"
+    );
+
+    info!("TTL Free cleanup verified: data deleted, file exists");
     Ok(())
 }
 


### PR DESCRIPTION
… (#680)

- Proto and TtlAction: remove PERSIST, EVICT, FLUSH; add FREE
- TTL checker: only execute free_inode for TtlAction::Free
- TTL executor: free() delegates to filesystem.free(path); remove path cache; dir TTL no-op; handle_skip_job and export callback use free() instead of delete
- Update mount CLI, display, s3_utils for new action name
- Expand ttl_test