### PR TITLE
feat: in-place mount update, async job API, and UFS load timeout (#680)

### DIFF
--- a/curvine-common/src/conf/journal_conf.rs
+++ b/curvine-common/src/conf/journal_conf.rs
@@ -103,6 +103,10 @@ pub struct JournalConf {
 
     // Whether to ignore errors in the log replay process.
     pub ignore_replay_error: bool,
+
+    // Max timeout for copying data to UFS, expressed as a duration string (e.g. "20m").
+    // Default: 20 minutes.
+    pub ufs_copy_timeout: String,
 }
 
 impl JournalConf {
@@ -229,6 +233,8 @@ impl Default for JournalConf {
 
             retain_checkpoint_num: 3,
             ignore_replay_error: false,
+
+            ufs_copy_timeout: "20m".to_owned(), // 20 minutes
         }
     }
 }

--- a/curvine-common/src/state/job.rs
+++ b/curvine-common/src/state/job.rs
@@ -42,6 +42,15 @@ pub enum JobTaskState {
     Canceled = 5,
 }
 
+impl JobTaskState {
+    pub fn is_finish(&self) -> bool {
+        matches!(
+            self,
+            JobTaskState::Completed | JobTaskState::Failed | JobTaskState::Canceled
+        )
+    }
+}
+
 pub struct LoadJobResult {
     pub job_id: String,
     pub target_path: String,

--- a/curvine-common/src/state/mount.rs
+++ b/curvine-common/src/state/mount.rs
@@ -131,6 +131,33 @@ impl MountInfo {
     pub fn is_fs_mode(&self) -> bool {
         self.write_type == WriteType::FsMode
     }
+
+    pub fn merge_with(self, mnt_opt: MountOptions) -> MountInfo {
+        let mut properties = self.properties;
+
+        for (k, v) in mnt_opt.add_properties {
+            properties.insert(k, v);
+        }
+
+        for k in &mnt_opt.remove_properties {
+            properties.remove(k);
+        }
+
+        MountInfo {
+            cv_path: self.cv_path,
+            ufs_path: self.ufs_path,
+            mount_id: self.mount_id,
+            properties,
+            ttl_ms: mnt_opt.ttl_ms.unwrap_or(self.ttl_ms),
+            ttl_action: mnt_opt.ttl_action.unwrap_or(self.ttl_action),
+            read_verify_ufs: mnt_opt.read_verify_ufs,
+            storage_type: mnt_opt.storage_type.or(self.storage_type),
+            block_size: mnt_opt.block_size.or(self.block_size),
+            replicas: mnt_opt.replicas.or(self.replicas),
+            write_type: self.write_type,
+            provider: mnt_opt.provider.or(self.provider),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/curvine-server/src/master/job/job_context.rs
+++ b/curvine-server/src/master/job/job_context.rs
@@ -21,7 +21,7 @@ use curvine_common::FsResult;
 use log::{info, warn};
 use orpc::common::{ByteUnit, FastHashMap, FastHashSet, LocalTime};
 use orpc::err_box;
-use orpc::sync::StateCtl;
+use orpc::sync::{StateListener, StateMonitor};
 
 #[derive(Debug, Clone)]
 pub struct TaskDetail {
@@ -41,7 +41,7 @@ impl TaskDetail {
 #[derive(Clone)]
 pub struct JobContext {
     pub info: LoadJobInfo,
-    pub state: StateCtl,
+    pub state: StateMonitor,
     pub progress: JobTaskProgress,
     pub assigned_workers: FastHashSet<WorkerAddress>,
     pub tasks: FastHashMap<String, TaskDetail>,
@@ -88,7 +88,7 @@ impl JobContext {
 
         JobContext {
             info: job,
-            state: StateCtl::new(JobTaskState::Pending.into()),
+            state: StateMonitor::new(JobTaskState::Pending.into()),
             progress: Default::default(),
             assigned_workers: Default::default(),
             tasks: Default::default(),
@@ -106,9 +106,13 @@ impl JobContext {
     }
 
     pub fn update_state(&mut self, state: JobTaskState, message: impl Into<String>) {
-        self.state.set_state(state);
+        self.state.advance_state(state, true);
         self.progress.update_time = LocalTime::mills() as i64;
         self.progress.message = message.into();
+    }
+
+    pub fn new_listener(&self) -> StateListener {
+        self.state.new_listener()
     }
 
     pub fn update_progress(

--- a/curvine-server/src/master/job/job_handler.rs
+++ b/curvine-server/src/master/job/job_handler.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use crate::master::{JobManager, RpcContext};
-use curvine_common::fs::RpcCode;
 use curvine_common::proto::{
     CancelJobRequest, CancelJobResponse, GetJobStatusRequest, GetJobStatusResponse,
     SubmitJobRequest, SubmitJobResponse, TaskReportRequest, TaskReportResponse,
@@ -41,7 +40,7 @@ impl JobHandler {
     ///
     /// Handles the submission of a new load job by parsing the request,
     /// validating parameters, and forwarding to the load manager.
-    pub fn submit_load_job(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+    pub async fn submit_load_job(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let req: SubmitJobRequest = ctx.parse_header()?;
         let command: LoadJobCommand = SerdeUtils::deserialize(&req.job_command)?;
         ctx.set_audit(Some(command.source_path.clone()), None);
@@ -50,7 +49,7 @@ impl JobHandler {
             return err_box!("Path cannot be empty");
         }
 
-        let res = self.job_manager.submit_load_job(command)?;
+        let res = self.job_manager.submit_load_job(command).await?;
         let response = SubmitJobResponse {
             job_id: res.job_id,
             target_path: res.target_path,
@@ -83,13 +82,13 @@ impl JobHandler {
     ///
     /// Handles the cancellation of a load job by its ID and returns
     /// the result of the cancellation operation.
-    pub fn cancel_job(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+    pub async fn cancel_job(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let req: CancelJobRequest = ctx.parse_header()?;
 
         let job_id = req.job_id;
         ctx.set_audit(Some(job_id.clone()), None);
 
-        self.job_manager.cancel_job(job_id.clone())?;
+        self.job_manager.cancel_job(job_id.clone()).await?;
 
         ctx.response(CancelJobResponse {})
     }
@@ -111,15 +110,5 @@ impl JobHandler {
         )?;
 
         ctx.response(TaskReportResponse {})
-    }
-
-    pub fn handle(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
-        match ctx.code {
-            RpcCode::SubmitJob => self.submit_load_job(ctx),
-            RpcCode::GetJobStatus => self.get_load_status(ctx),
-            RpcCode::CancelJob => self.cancel_job(ctx),
-            RpcCode::ReportTask => self.task_report(ctx),
-            v => err_box!("Unsupported operation: {:?}", v),
-        }
     }
 }

--- a/curvine-server/src/master/job/job_manager.rs
+++ b/curvine-server/src/master/job/job_manager.rs
@@ -25,12 +25,12 @@ use curvine_common::state::{
     JobStatus, JobTaskProgress, JobTaskState, LoadJobCommand, LoadJobResult,
 };
 use curvine_common::FsResult;
-use log::{info, warn};
+use log::info;
 use orpc::common::LocalTime;
-use orpc::runtime::{LoopTask, RpcRuntime, Runtime};
-use orpc::sync::channel::BlockingChannel;
+use orpc::runtime::{LoopTask, Runtime};
 use orpc::{err_box, err_ext};
 use std::sync::Arc;
+use tokio::time::timeout;
 
 /// Load the Task Manager
 pub struct JobManager {
@@ -85,6 +85,35 @@ impl JobManager {
         self.jobs.update_state(job_id, state, message)
     }
 
+    pub async fn wait_job_complete(
+        &self,
+        job_id: impl AsRef<str>,
+        duration: Duration,
+    ) -> FsResult<JobStatus> {
+        timeout(duration, self.wait_job_complete0(job_id)).await?
+    }
+
+    async fn wait_job_complete0(&self, job_id: impl AsRef<str>) -> FsResult<JobStatus> {
+        let job_id = job_id.as_ref();
+        let status = self.get_job_status(job_id)?;
+        if status.state.is_finish() {
+            return Ok(status);
+        }
+
+        let mut listener = if let Some(job) = self.jobs.get(job_id) {
+            job.new_listener()
+        } else {
+            return err_ext!(FsError::job_not_found(job_id));
+        };
+
+        loop {
+            let next_state = JobTaskState::from(listener.next_state().await?);
+            if next_state.is_finish() {
+                return self.get_job_status(job_id);
+            }
+        }
+    }
+
     pub fn get_job_status(&self, job_id: impl AsRef<str>) -> FsResult<JobStatus> {
         let job_id = job_id.as_ref();
         if let Some(job) = self.jobs.get(job_id) {
@@ -124,7 +153,7 @@ impl JobManager {
         &self.rt
     }
 
-    pub fn submit_load_job(&self, command: LoadJobCommand) -> FsResult<LoadJobResult> {
+    pub async fn submit_load_job(&self, command: LoadJobCommand) -> FsResult<LoadJobResult> {
         let source_path = Path::from_str(&command.source_path)?;
 
         // Check mount info for both UFS and CV paths
@@ -137,20 +166,11 @@ impl JobManager {
         };
 
         let job_runner = self.create_runner();
-
-        let (tx, rx) = BlockingChannel::new(1).split();
-        self.rt.spawn(async move {
-            let res = job_runner.submit_load_task(command, mnt).await;
-            if let Err(e) = tx.send(res) {
-                warn!("send submit_load_job result: {}", e);
-            }
-        });
-
-        rx.recv_check()?
+        job_runner.submit_load_task(command, mnt).await
     }
 
     /// Handle cancellation of tasks
-    pub fn cancel_job(&self, job_id: impl AsRef<str>) -> FsResult<()> {
+    pub async fn cancel_job(&self, job_id: impl AsRef<str>) -> FsResult<()> {
         let job_id = job_id.as_ref();
         let assigned_workers = {
             if let Some(job) = self.jobs.get(job_id) {
@@ -177,12 +197,7 @@ impl JobManager {
         self.update_state(job_id, JobTaskState::Canceled, "Canceling job by user");
 
         let job_runner = self.create_runner();
-        let job_id = job_id.to_string();
-        self.rt.spawn(async move {
-            if let Err(e) = job_runner.cancel_job(&job_id, assigned_workers).await {
-                warn!("Cancel job {} error: {}", job_id, e);
-            }
-        });
+        job_runner.cancel_job(&job_id, assigned_workers).await?;
 
         Ok(())
     }

--- a/curvine-server/src/master/journal/journal_loader.rs
+++ b/curvine-server/src/master/journal/journal_loader.rs
@@ -50,7 +50,7 @@ impl JournalLoader {
         conf: &JournalConf,
         job_manager: Arc<JobManager>,
     ) -> Self {
-        let ufs_loader = UfsLoader::new(job_manager);
+        let ufs_loader = UfsLoader::new(job_manager, conf);
         Self {
             fs_dir,
             mnt_mgr,

--- a/curvine-server/src/master/journal/ufs_loader.rs
+++ b/curvine-server/src/master/journal/ufs_loader.rs
@@ -17,22 +17,40 @@ use crate::master::journal::{
 };
 use crate::master::JobManager;
 use curvine_client::unified::MountValue;
+use curvine_common::conf::JournalConf;
 use curvine_common::error::FsError;
 use curvine_common::fs::{FileSystem, Path};
-use curvine_common::state::LoadJobCommand;
+use curvine_common::state::{JobTaskState, LoadJobCommand};
 use curvine_common::FsResult;
 use log::warn;
+use orpc::common::DurationUnit;
 use orpc::{err_box, CommonResult};
 use std::sync::Arc;
+use std::time::Duration;
 
 #[derive(Clone)]
 pub struct UfsLoader {
     job_manager: Arc<JobManager>,
+    copy_timeout: Duration,
 }
 
 impl UfsLoader {
-    pub fn new(job_manager: Arc<JobManager>) -> Self {
-        Self { job_manager }
+    pub fn new(job_manager: Arc<JobManager>, conf: &JournalConf) -> Self {
+        let copy_timeout = match DurationUnit::from_str(&conf.ufs_copy_timeout) {
+            Ok(unit) => unit.as_duration(),
+            Err(e) => {
+                warn!(
+                    "Invalid ufs_copy_timeout value '{}': {}. Falling back to default 20min",
+                    conf.ufs_copy_timeout, e
+                );
+                Duration::from_secs(20 * 60)
+            }
+        };
+
+        Self {
+            job_manager,
+            copy_timeout,
+        }
     }
 
     pub async fn apply_batch(&self, batch: JournalBatch) -> CommonResult<()> {
@@ -45,7 +63,7 @@ impl UfsLoader {
     pub async fn submit_load_task(&self, path: &Path, mnt: &MountValue) -> FsResult<()> {
         let command = LoadJobCommand::builder(path.clone_uri()).build();
         let runner = self.job_manager.create_runner();
-        let _ = match runner.submit_load_task(command, mnt.info.clone()).await {
+        let res = match runner.submit_load_task(command, mnt.info.clone()).await {
             Ok(res) => res,
             Err(e) => {
                 return if matches!(e, FsError::FileNotFound(_)) {
@@ -56,7 +74,20 @@ impl UfsLoader {
                 };
             }
         };
-        Ok(())
+
+        let status = self
+            .job_manager
+            .wait_job_complete(res.job_id, self.copy_timeout)
+            .await?;
+        if matches!(status.state, JobTaskState::Completed) {
+            Ok(())
+        } else {
+            err_box!(
+                "load job failed: {} {}",
+                status.state,
+                status.progress.message
+            )
+        }
     }
 
     pub async fn apply_entry(&self, entry: &JournalEntry) -> FsResult<()> {

--- a/curvine-server/src/master/master_handler.rs
+++ b/curvine-server/src/master/master_handler.rs
@@ -610,6 +610,14 @@ impl MasterHandler {
 impl MessageHandler for MasterHandler {
     type Error = FsError;
 
+    fn is_sync(&self, msg: &Message) -> bool {
+        let code = RpcCode::from(msg.code());
+        !matches!(
+            code,
+            RpcCode::SubmitJob | RpcCode::GetJobStatus | RpcCode::CancelJob | RpcCode::ReportTask
+        )
+    }
+
     fn handle(&mut self, msg: &Message) -> FsResult<Message> {
         let mut rpc_context = RpcContext::new(msg);
         let ctx = &mut rpc_context;
@@ -658,12 +666,6 @@ impl MessageHandler for MasterHandler {
             RpcCode::WorkerBlockReport => self.block_report(ctx),
             RpcCode::GetMasterInfo => self.get_master_info(ctx),
 
-            // Load task related requests
-            RpcCode::SubmitJob
-            | RpcCode::GetJobStatus
-            | RpcCode::CancelJob
-            | RpcCode::ReportTask => self.job_handler.handle(ctx),
-
             RpcCode::ReportBlockReplicationResult => {
                 if let Some(ref mut replication_service) = self.replication_handler {
                     return replication_service.handle(msg);
@@ -696,6 +698,26 @@ impl MessageHandler for MasterHandler {
         match response {
             Ok(v) => Ok(v),
             Err(e) => Ok(msg.error_ext(&e)),
+        }
+    }
+
+    async fn async_handle(&mut self, msg: Message) -> FsResult<Message> {
+        let mut rpc_context = RpcContext::new(&msg);
+        let ctx = &mut rpc_context;
+        let code = RpcCode::from(msg.code());
+
+        // Check whether the master is active
+        if !self.fs.master_monitor.is_active() {
+            return Err(FsError::not_leader_master(ctx.code, self.client_ip()));
+        }
+
+        match code {
+            RpcCode::SubmitJob => self.job_handler.submit_load_job(ctx).await,
+            RpcCode::GetJobStatus => self.job_handler.get_load_status(ctx),
+            RpcCode::CancelJob => self.job_handler.cancel_job(ctx).await,
+            RpcCode::ReportTask => self.job_handler.task_report(ctx),
+
+            v => err_box!("unsupported operation {:?}", v),
         }
     }
 }

--- a/curvine-server/src/master/meta/inode/ttl/ttl_executor.rs
+++ b/curvine-server/src/master/meta/inode/ttl/ttl_executor.rs
@@ -19,7 +19,7 @@ use crate::master::meta::inode::ttl_types::{TtlError, TtlResult};
 use crate::master::meta::inode::{Inode, InodeView, ROOT_INODE_ID};
 use crate::master::mount::MountManager;
 use curvine_common::fs::{FileSystem, Path};
-use curvine_common::state::{LoadJobCommand, TtlAction};
+use curvine_common::state::TtlAction;
 use log::{debug, error, info, warn};
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
@@ -246,49 +246,6 @@ impl InodeTtlExecutor {
             }
             _ => {}
         }
-        Ok(())
-    }
-
-    pub fn submit_export_job(
-        &self,
-        inode_id: u64,
-        cv_path: &str,
-        ufs_path: &Path,
-        action: TtlAction,
-        is_directory: bool,
-        _mount_info: curvine_common::state::MountInfo,
-    ) -> TtlResult<()> {
-        let command = LoadJobCommand {
-            source_path: cv_path.to_string(),
-            target_path: Some(ufs_path.full_path().to_string()),
-            overwrite: Some(matches!(action, TtlAction::Free)),
-            replicas: None,
-            block_size: None,
-            storage_type: None,
-            ttl_ms: None,
-            ttl_action: None,
-        };
-
-        let job_result = self.job_manager.submit_load_job(command).map_err(|e| {
-            TtlError::ActionExecutionError(format!("Failed to submit export job: {}", e))
-        })?;
-
-        info!(
-            "Export job submitted for {}: job_id={}, inode={}, action={:?}",
-            self.resource_type(is_directory),
-            job_result.job_id,
-            inode_id,
-            action
-        );
-
-        self.register_export_callback(
-            job_result.job_id,
-            inode_id,
-            action,
-            cv_path.to_string(),
-            is_directory,
-        )?;
-
         Ok(())
     }
 

--- a/curvine-server/src/master/mount/mount_manager.rs
+++ b/curvine-server/src/master/mount/mount_manager.rs
@@ -21,7 +21,7 @@ use curvine_common::fs::{self, CurvineURI, Path};
 use curvine_common::state::{MkdirOpts, MountInfo, MountOptions};
 use curvine_common::FsResult;
 use log::info;
-use orpc::{err_box, try_option};
+use orpc::{err_box, err_msg, try_option};
 use std::collections::HashMap;
 
 pub struct MountManager {
@@ -76,28 +76,12 @@ impl MountManager {
             .add_mount(assign_id, mount_path, ufs_path, mnt_opt)
     }
 
-    fn update_mount(
-        &self,
-        mnt_id: Option<u32>,
-        cv_path: &str,
-        ufs_path: &str,
-        mnt_opt: &MountOptions,
-    ) -> FsResult<()> {
-        if !self.mount_table.exists(cv_path) {
-            return err_box!("update mode: mount point {} does not exist", ufs_path);
-        }
+    fn update_mount(&self, cv_path: &str, mnt_opt: &MountOptions) -> FsResult<()> {
+        let path = Path::from_str(cv_path)?;
+        let existing = try_option!(self.get_mount_info(&path)?);
+        let merged = existing.merge_with(mnt_opt.clone());
 
-        self.mount_table.umount(cv_path)?;
-
-        self.create_mount_point(cv_path)?;
-
-        let assign_id = match mnt_id {
-            Some(id) => id,
-            None => self.mount_table.assign_mount_id()?,
-        };
-
-        self.mount_table
-            .add_mount(assign_id, cv_path, ufs_path, mnt_opt)
+        self.mount_table.update_mount(merged)
     }
 
     /// same baseuri of ufs can only mount once
@@ -112,7 +96,7 @@ impl MountManager {
         mnt_opt: &MountOptions,
     ) -> FsResult<()> {
         if mnt_opt.update {
-            return self.update_mount(mnt_id, cv_path, ufs_path, mnt_opt);
+            return self.update_mount(cv_path, mnt_opt);
         }
 
         self.add_mount(mnt_id, cv_path, ufs_path, mnt_opt)

--- a/curvine-server/src/master/mount/mount_table.rs
+++ b/curvine-server/src/master/mount/mount_table.rs
@@ -142,6 +142,19 @@ impl MountTable {
         Ok(())
     }
 
+    pub fn update_mount(&self, info: MountInfo) -> FsResult<()> {
+        let old = self.get_mount_info_by_id(info.mount_id)?;
+        if old.cv_path != info.cv_path || old.ufs_path != info.ufs_path {
+            return err_box!("cannot change mount path");
+        }
+
+        self.unprotected_add_mount(info.clone())?;
+
+        let mut fs_dir = self.fs_dir.write();
+        fs_dir.store_mount(info, true)?;
+        Ok(())
+    }
+
     pub fn assign_mount_id(&self) -> FsResult<u32> {
         let mut rng = rand::thread_rng();
         for _ in 0..10 {

--- a/orpc/src/sync/state_monitor.rs
+++ b/orpc/src/sync/state_monitor.rs
@@ -14,6 +14,7 @@
 
 use crate::{err_box, CommonResult};
 use log::error;
+use std::ops::Deref;
 use std::sync::atomic::{AtomicI8, Ordering};
 use std::sync::Arc;
 use tokio::sync::broadcast;
@@ -128,6 +129,14 @@ impl StateMonitor {
 
     pub fn value(&self) -> i8 {
         self.ctl.value()
+    }
+}
+
+impl Deref for StateMonitor {
+    type Target = StateCtl;
+
+    fn deref(&self) -> &Self::Target {
+        &self.ctl
     }
 }
 


### PR DESCRIPTION
- Mount: add MountInfo::merge_with(MountOptions); update_mount now merges params in-place via MountTable::update_mount(merged) instead of umount+add
- JournalConf: add ufs_copy_timeout (default "20m") for UFS copy max wait
- JobManager: submit_load_job and cancel_job are async; add wait_job_complete with timeout; remove spawn+blocking channel
- UfsLoader: take JournalConf, wait for load job completion with copy_timeout and fail apply_batch if job does not complete successfully
- MasterHandler: route SubmitJob/GetJobStatus/CancelJob/ReportTask to async_handle via is_sync(); implement async_handle for job RPCs
- MountTable: add update_mount(MountInfo) (unprotected_add_mount + store_mount)