### PR TITLE
refactor(fuse): single cache with Arc fields and moka atomic upsert

### DIFF
--- a/curvine-client/src/file/fs_reader.rs
+++ b/curvine-client/src/file/fs_reader.rs
@@ -30,7 +30,7 @@ pub struct FsReader {
     chunk_size: usize,
     pos: i64,
     len: i64,
-    status: FileStatus,
+    file_blocks: FileBlocks,
 }
 
 impl FsReader {
@@ -38,7 +38,6 @@ impl FsReader {
         let chunk_size = fs_context.read_chunk_size();
         let len = file_blocks.status.len;
         let conf = &fs_context.conf.client;
-        let status = file_blocks.status.clone();
 
         let read_detector = ReadDetector::with_conf(conf, len);
 
@@ -55,22 +54,26 @@ impl FsReader {
             conf.read_ahead_len
         );
 
-        let inner = FsReaderBuffer::new(path, fs_context, file_blocks, read_detector)?;
+        let inner = FsReaderBuffer::new(path, fs_context, file_blocks.clone(), read_detector)?;
         let reader = Self {
             inner,
             chunk: DataSlice::Empty,
             chunk_size,
             pos: 0,
             len,
-            status,
+            file_blocks,
         };
         Ok(reader)
+    }
+
+    pub fn file_blocks(&self) -> &FileBlocks {
+        &self.file_blocks
     }
 }
 
 impl Reader for FsReader {
     fn status(&self) -> &FileStatus {
-        &self.status
+        &self.file_blocks.status
     }
 
     fn path(&self) -> &Path {

--- a/curvine-common/src/conf/client_conf.rs
+++ b/curvine-common/src/conf/client_conf.rs
@@ -363,7 +363,7 @@ impl Default for ClientConf {
             rpc_timeout_ms: 120 * 1000,
             data_timeout_ms: 120 * 1000,
             pipeline_timeout_ms: 120 * 1000,
-            master_conn_pool_size: 1,
+            master_conn_pool_size: 3,
 
             enable_read_ahead: true,
             read_ahead_len: 0,

--- a/curvine-common/src/fs/meta_cache.rs
+++ b/curvine-common/src/fs/meta_cache.rs
@@ -15,72 +15,134 @@
 use crate::fs::Path;
 use crate::state::{FileBlocks, FileStatus};
 use orpc::sync::FastSyncCache;
+use std::sync::Arc;
 use std::time::Duration;
 
+#[derive(Default)]
+struct CacheValue {
+    list: Option<Arc<Vec<FileStatus>>>,
+    status: Option<Arc<FileStatus>>,
+    blocks: Option<Arc<FileBlocks>>,
+}
+
 pub struct MetaCache {
-    list_cache: FastSyncCache<String, Vec<FileStatus>>,
-    status_cache: FastSyncCache<String, FileStatus>,
-    open_cache: FastSyncCache<String, FileBlocks>,
+    inner: FastSyncCache<String, Arc<CacheValue>>,
 }
 
 impl MetaCache {
     pub fn new(capacity: u64, ttl: Duration) -> Self {
         Self {
-            list_cache: FastSyncCache::new(capacity, ttl),
-            status_cache: FastSyncCache::new(capacity, ttl),
-            open_cache: FastSyncCache::new(capacity, ttl),
+            inner: FastSyncCache::new(capacity, ttl),
         }
     }
 
     pub fn get_list(&self, path: &Path) -> Option<Vec<FileStatus>> {
-        self.list_cache.get(path.full_path())
+        self.inner
+            .get(path.full_path())
+            .and_then(|v| v.list.as_ref().map(|a| (**a).clone()))
     }
 
     pub fn get_status(&self, path: &Path) -> Option<FileStatus> {
-        self.status_cache.get(path.full_path())
+        self.inner
+            .get(path.full_path())
+            .and_then(|v| v.status.as_ref().map(|a| (**a).clone()))
     }
 
     pub fn get_blocks(&self, path: &Path) -> Option<FileBlocks> {
-        self.open_cache.get(path.full_path())
+        self.inner
+            .get(path.full_path())
+            .and_then(|v| v.blocks.as_ref().map(|a| (**a).clone()))
     }
 
     pub fn get_open(&self, path: &Path) -> Option<FileBlocks> {
-        self.open_cache.get(path.full_path())
+        self.inner
+            .get(path.full_path())
+            .and_then(|v| v.blocks.as_ref().map(|a| (**a).clone()))
     }
 
     pub fn put_list(&self, path: &Path, list: Vec<FileStatus>) {
-        self.list_cache.insert(path.clone_uri(), list);
+        self.inner
+            .entry(path.clone_uri())
+            .and_upsert_with(|maybe_entry| {
+                let prev = maybe_entry.map(|e| e.into_value());
+                Arc::new(CacheValue {
+                    list: Some(Arc::new(list)),
+                    status: prev.as_ref().and_then(|v| v.status.clone()),
+                    blocks: prev.as_ref().and_then(|v| v.blocks.clone()),
+                })
+            });
     }
 
     pub fn put_status(&self, path: &Path, status: FileStatus) {
-        self.status_cache.insert(path.clone_uri(), status);
+        self.inner
+            .entry(path.clone_uri())
+            .and_upsert_with(|maybe_entry| {
+                let prev = maybe_entry.map(|e| e.into_value());
+                Arc::new(CacheValue {
+                    list: prev.as_ref().and_then(|v| v.list.clone()),
+                    status: Some(Arc::new(status)),
+                    blocks: prev.as_ref().and_then(|v| v.blocks.clone()),
+                })
+            });
     }
 
     pub fn put_open(&self, path: &Path, blocks: FileBlocks) {
-        self.open_cache.insert(path.clone_uri(), blocks);
+        self.inner
+            .entry(path.clone_uri())
+            .and_upsert_with(|maybe_entry| {
+                let prev = maybe_entry.map(|e| e.into_value());
+                Arc::new(CacheValue {
+                    list: prev.as_ref().and_then(|v| v.list.clone()),
+                    status: prev.as_ref().and_then(|v| v.status.clone()),
+                    blocks: Some(Arc::new(blocks)),
+                })
+            });
     }
 
     pub fn invalidate(&self, path: &Path) {
-        self.list_cache.invalidate(path.full_path());
-        self.status_cache.invalidate(path.full_path());
-        self.open_cache.invalidate(path.full_path());
+        self.inner.invalidate(path.full_path());
     }
 
     pub fn invalidate_list(&self, path: &Path) {
-        self.list_cache.invalidate(path.full_path());
+        self.inner
+            .entry(path.clone_uri())
+            .and_upsert_with(|maybe_entry| {
+                let prev = maybe_entry.map(|e| e.into_value());
+                Arc::new(CacheValue {
+                    list: None,
+                    status: prev.as_ref().and_then(|v| v.status.clone()),
+                    blocks: prev.as_ref().and_then(|v| v.blocks.clone()),
+                })
+            });
     }
 
     pub fn invalidate_status(&self, path: &Path) {
-        self.status_cache.invalidate(path.full_path());
+        self.inner
+            .entry(path.clone_uri())
+            .and_upsert_with(|maybe_entry| {
+                let prev = maybe_entry.map(|e| e.into_value());
+                Arc::new(CacheValue {
+                    list: prev.as_ref().and_then(|v| v.list.clone()),
+                    status: None,
+                    blocks: prev.as_ref().and_then(|v| v.blocks.clone()),
+                })
+            });
     }
 
     pub fn invalidate_open(&self, path: &Path) {
-        self.open_cache.invalidate(path.full_path());
+        self.inner
+            .entry(path.clone_uri())
+            .and_upsert_with(|maybe_entry| {
+                let prev = maybe_entry.map(|e| e.into_value());
+                Arc::new(CacheValue {
+                    list: prev.as_ref().and_then(|v| v.list.clone()),
+                    status: prev.as_ref().and_then(|v| v.status.clone()),
+                    blocks: None,
+                })
+            });
     }
 
     pub fn clear(&self) {
-        self.list_cache.invalidate_all();
-        self.status_cache.invalidate_all();
-        self.open_cache.invalidate_all();
+        self.inner.invalidate_all();
     }
 }

--- a/curvine-fuse/src/fs/state/node_state.rs
+++ b/curvine-fuse/src/fs/state/node_state.rs
@@ -18,10 +18,11 @@ use crate::fs::state::{NodeAttr, NodeMap};
 use crate::fs::{FuseReader, FuseWriter};
 use crate::raw::fuse_abi::{fuse_attr, fuse_forget_one};
 use crate::{err_fuse, FuseResult, STATE_FILE_MAGIC, STATE_FILE_VERSION};
-use curvine_client::unified::UnifiedFileSystem;
+use curvine_client::file::FsReader;
+use curvine_client::unified::{UnifiedFileSystem, UnifiedReader};
 use curvine_common::conf::{ClientConf, ClusterConf, FuseConf};
 use curvine_common::fs::{FileSystem, MetaCache, Path, StateReader, StateWriter};
-use curvine_common::state::{CreateFileOpts, FileStatus, OpenFlags};
+use curvine_common::state::{CreateFileOpts, FileBlocks, FileStatus, OpenFlags};
 use log::{error, info, warn};
 use orpc::common::FastHashMap;
 use orpc::err_box;
@@ -263,8 +264,35 @@ impl NodeState {
         Ok(Arc::new(Mutex::new(writer)))
     }
 
+    fn get_cached_blocks(&self, path: &Path) -> Option<FileBlocks> {
+        if self.conf.enable_meta_cache {
+            self.meta_cache.get_blocks(path)
+        } else {
+            None
+        }
+    }
+
     pub async fn new_reader(&self, path: &Path) -> FuseResult<FuseReader> {
-        let reader = self.fs.open(path).await?;
+        let reader = match self.get_cached_blocks(path) {
+            Some(blocks) => {
+                let reader = FsReader::new(path.clone(), self.fs.fs_context().clone(), blocks)?;
+                UnifiedReader::Cv(reader)
+            }
+
+            None => {
+                let reader = self.fs.open(path).await?;
+
+                if self.conf.enable_meta_cache {
+                    if let UnifiedReader::Cv(cv_reader) = &reader {
+                        self.meta_cache
+                            .put_open(path, cv_reader.file_blocks().clone());
+                    }
+                }
+
+                reader
+            }
+        };
+
         let reader = FuseReader::new(&self.conf, self.fs.clone_runtime(), reader);
         Ok(reader)
     }


### PR DESCRIPTION
- meta_cache: use single FastSyncCache<String, Arc<CacheValue>>; wrap list/status/blocks in Arc so merge only does Arc::clone; use entry().and_upsert_with() for atomic read-modify-write (moka key-level lock), remove custom stripe lock
- node_state: pass path to put_open in new_reader, use if let for Cv branch