### PR TITLE
feat(client): add FallbackFsReader for UFS fallback in FsMode

### DIFF
--- a/curvine-client/src/unified/fallback_fs_reader.rs
+++ b/curvine-client/src/unified/fallback_fs_reader.rs
@@ -1,0 +1,311 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::file::FsReader;
+use crate::unified::{UfsFileSystem, UfsReader};
+use curvine_common::error::FsError;
+use curvine_common::fs::{FileSystem, Path, Reader};
+use curvine_common::state::{FileBlocks, FileStatus};
+use curvine_common::FsResult;
+use log::warn;
+use orpc::err_box;
+use orpc::sys::DataSlice;
+
+/// A wrapper around `FsReader` that transparently falls back to UFS when Curvine
+/// becomes unavailable (master down at open time handled externally, worker down
+/// during read handled here).
+///
+/// Design:
+/// - `cv_reader` is always present and maintains all internal state (pos, chunk, etc.).
+/// - `ufs_reader` is created lazily on the first worker failure; once set, all
+///   subsequent reads go through UFS (no retry back to Curvine).
+/// - Before falling back, `validate_ufs_consistency` is called to ensure the UFS
+///   data matches the snapshot recorded in Curvine metadata (`ufs_mtime`, `len`).
+pub struct FallbackFsReader {
+    /// Wraps the Curvine reader. Always present as the metadata authority (status, len).
+    cv_reader: FsReader,
+    /// Created lazily on first worker error. None = reading from Curvine.
+    /// Uses UfsReader (not UnifiedReader) to avoid a recursive type/async-fn cycle:
+    /// UnifiedReader::Fallback(FallbackFsReader) -> UfsReader (no Fallback variant).
+    ufs_reader: Option<UfsReader>,
+    ufs_path: Path,
+    ufs_fs: UfsFileSystem,
+}
+
+impl FallbackFsReader {
+    pub fn new(cv_reader: FsReader, ufs_path: Path, ufs_fs: UfsFileSystem) -> Self {
+        Self {
+            cv_reader,
+            ufs_reader: None,
+            ufs_path,
+            ufs_fs,
+        }
+    }
+
+    /// Expose Curvine block metadata for callers that need cache hints.
+    pub fn file_blocks(&self) -> &FileBlocks {
+        self.cv_reader.file_blocks()
+    }
+
+    /// Validates that the UFS data matches what Curvine recorded when it last flushed.
+    /// Returns an error if UFS data cannot be trusted (modified externally or never flushed).
+    async fn validate_ufs_consistency(&self) -> FsResult<()> {
+        let cv_status = self.cv_reader.status();
+        let cv_ufs_mtime = cv_status.storage_policy.ufs_mtime;
+        let cv_len = cv_status.len;
+        let ufs_status = self.ufs_fs.get_status(&self.ufs_path).await?;
+
+        if let Err(e) =
+            check_ufs_consistency(cv_ufs_mtime, cv_len, ufs_status.mtime, ufs_status.len)
+        {
+            return err_box!("UFS data inconsistent for {}: {}", self.ufs_path, e);
+        }
+
+        Ok(())
+    }
+}
+
+/// Returns true for errors caused by a worker being unavailable (IO, pipeline, timeout).
+/// These trigger a UFS fallback. Other error kinds (e.g. NotLeaderMaster) are not
+/// worker errors — the RPC layer handles master failover via retry.
+pub(crate) fn is_worker_err(e: &FsError) -> bool {
+    if matches!(
+        e,
+        FsError::IO(_) | FsError::Pipeline(_) | FsError::Timeout(_)
+    ) {
+        return true;
+    }
+
+    // In some read paths, connection-level worker failures are wrapped as Common.
+    // Treat well-known transport failure signatures as worker failures too.
+    if matches!(e, FsError::Common(_)) {
+        let msg = e.to_string().to_lowercase();
+        return msg.contains("connection refused")
+            || msg.contains("connection reset")
+            || msg.contains("early eof")
+            || msg.contains("broken pipe")
+            || msg.contains("sender dropped");
+    }
+
+    false
+}
+
+/// Shared consistency check logic used by runtime path and tests.
+pub(crate) fn check_ufs_consistency(
+    cv_ufs_mtime: i64,
+    cv_len: i64,
+    ufs_mtime: i64,
+    ufs_len: i64,
+) -> FsResult<()> {
+    if cv_ufs_mtime == 0 {
+        return err_box!("data has not been flushed to UFS yet (ufs_mtime=0)");
+    }
+    if cv_ufs_mtime != ufs_mtime || cv_len != ufs_len {
+        return err_box!(
+            "UFS data inconsistent: cv_ufs_mtime={}, ufs_mtime={}, cv_len={}, ufs_len={}",
+            cv_ufs_mtime,
+            ufs_mtime,
+            cv_len,
+            ufs_len
+        );
+    }
+    Ok(())
+}
+
+impl Reader for FallbackFsReader {
+    // Always from cv_reader — Curvine is the metadata authority in FsMode.
+    fn status(&self) -> &FileStatus {
+        self.cv_reader.status()
+    }
+
+    fn path(&self) -> &Path {
+        self.cv_reader.path()
+    }
+
+    fn len(&self) -> i64 {
+        self.cv_reader.len()
+    }
+
+    // pos/chunk/chunk_size delegate to whichever reader is currently active.
+    fn pos(&self) -> i64 {
+        match &self.ufs_reader {
+            Some(u) => u.pos(),
+            None => self.cv_reader.pos(),
+        }
+    }
+
+    fn pos_mut(&mut self) -> &mut i64 {
+        match &mut self.ufs_reader {
+            Some(u) => u.pos_mut(),
+            None => self.cv_reader.pos_mut(),
+        }
+    }
+
+    fn chunk_mut(&mut self) -> &mut DataSlice {
+        match &mut self.ufs_reader {
+            Some(u) => u.chunk_mut(),
+            None => self.cv_reader.chunk_mut(),
+        }
+    }
+
+    fn chunk_size(&self) -> usize {
+        match &self.ufs_reader {
+            Some(u) => u.chunk_size(),
+            None => self.cv_reader.chunk_size(),
+        }
+    }
+
+    async fn read_chunk0(&mut self) -> FsResult<DataSlice> {
+        // Already fallen back to UFS — read directly, no retry to Curvine.
+        if let Some(ufs) = &mut self.ufs_reader {
+            return ufs.read_chunk0().await;
+        }
+
+        // Try reading from Curvine.
+        match self.cv_reader.read_chunk0().await {
+            Ok(data) => Ok(data),
+
+            Err(e) if is_worker_err(&e) => {
+                let pos = self.cv_reader.pos();
+                warn!(
+                    "Curvine worker error at pos {} for {}, validating UFS consistency before fallback: {}",
+                    pos,
+                    self.cv_reader.path(),
+                    e
+                );
+
+                // Refuse to fall back if UFS data cannot be trusted.
+                self.validate_ufs_consistency().await?;
+
+                let mut ufs: UfsReader = self.ufs_fs.open_ufs(&self.ufs_path).await?;
+                ufs.seek(pos).await?;
+                let data = ufs.read_chunk0().await?;
+                self.ufs_reader = Some(ufs);
+                Ok(data)
+            }
+
+            Err(e) => Err(e),
+        }
+    }
+
+    async fn seek(&mut self, pos: i64) -> FsResult<()> {
+        match &mut self.ufs_reader {
+            Some(ufs) => ufs.seek(pos).await,
+            None => self.cv_reader.seek(pos).await,
+        }
+    }
+
+    async fn complete(&mut self) -> FsResult<()> {
+        if let Some(mut ufs) = self.ufs_reader.take() {
+            // Best-effort cleanup; the worker may already be down.
+            let _ = ufs.complete().await;
+        }
+        // Always release cv_reader connections (block handles, cached readers).
+        self.cv_reader.complete().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use curvine_common::error::FsError;
+    use orpc::error::ErrorImpl;
+    use std::io;
+    use std::time::Duration;
+
+    // --- TC-1 to TC-5: is_worker_err classification ---
+
+    #[test]
+    fn test_is_worker_err_io() {
+        let e = FsError::IO(ErrorImpl::with_source(io::Error::new(
+            io::ErrorKind::ConnectionReset,
+            "connection reset",
+        )));
+        assert!(is_worker_err(&e));
+    }
+
+    #[test]
+    fn test_is_worker_err_pipeline() {
+        // Uses the public constructor to avoid touching ErrorImpl internals.
+        let e = FsError::pipeline_error(42, "worker unreachable");
+        assert!(is_worker_err(&e));
+    }
+
+    #[tokio::test]
+    async fn test_is_worker_err_timeout() {
+        // Elapsed can only be created via an actual tokio timeout.
+        let elapsed = tokio::time::timeout(Duration::from_nanos(1), std::future::pending::<()>())
+            .await
+            .unwrap_err();
+        let e = FsError::Timeout(ErrorImpl::with_source(elapsed));
+        assert!(is_worker_err(&e));
+    }
+
+    #[test]
+    fn test_is_worker_err_not_leader_master() {
+        // Master failover is handled by RPC retry, not UFS fallback.
+        let e = FsError::not_leader("not leader");
+        assert!(!is_worker_err(&e));
+    }
+
+    #[test]
+    fn test_is_worker_err_file_not_found() {
+        let e = FsError::file_not_found("/test/path");
+        assert!(!is_worker_err(&e));
+    }
+
+    #[test]
+    fn test_is_worker_err_common_connection_refused() {
+        let e = FsError::common("Connection refused (os error 111)");
+        assert!(is_worker_err(&e));
+    }
+
+    // --- TC-6 to TC-9: check_ufs_consistency pure function ---
+
+    #[test]
+    fn test_ufs_consistency_mtime_zero() {
+        // Data has never been flushed to UFS — cannot fall back.
+        let result = check_ufs_consistency(0, 100, 0, 100);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("ufs_mtime=0"));
+    }
+
+    #[test]
+    fn test_ufs_consistency_mtime_mismatch() {
+        // UFS was modified externally after Curvine last flushed.
+        let result = check_ufs_consistency(1000, 100, 2000, 100);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("cv_ufs_mtime=1000"));
+        assert!(msg.contains("ufs_mtime=2000"));
+    }
+
+    #[test]
+    fn test_ufs_consistency_len_mismatch() {
+        // mtime matches but file length differs — still inconsistent.
+        let result = check_ufs_consistency(1000, 100, 1000, 150);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("cv_len=100"));
+        assert!(msg.contains("ufs_len=150"));
+    }
+
+    #[test]
+    fn test_ufs_consistency_all_match() {
+        // Both mtime and len match — safe to fall back.
+        let result = check_ufs_consistency(1000, 100, 1000, 100);
+        assert!(result.is_ok());
+    }
+}

--- a/curvine-client/src/unified/mod.rs
+++ b/curvine-client/src/unified/mod.rs
@@ -15,7 +15,7 @@
 use crate::file::{FsReader, FsWriter};
 use crate::impl_filesystem_for_enum;
 use crate::{impl_reader_for_enum, impl_writer_for_enum};
-use curvine_common::fs::Path;
+use curvine_common::fs::{FileSystem, Path};
 use curvine_common::state::{MountInfo, Provider};
 use curvine_common::FsResult;
 use orpc::err_box;
@@ -43,6 +43,9 @@ pub use self::cache_sync_writer::CacheSyncWriter;
 
 mod cache_sync_reader;
 pub use self::cache_sync_reader::CacheSyncReader;
+
+mod fallback_fs_reader;
+pub use self::fallback_fs_reader::FallbackFsReader;
 
 #[allow(clippy::large_enum_variant)]
 pub enum UnifiedWriter {
@@ -77,6 +80,8 @@ pub enum UnifiedReader {
 
     CacheSync(CacheSyncReader),
 
+    Fallback(FallbackFsReader),
+
     #[cfg(feature = "opendal")]
     Opendal(OpendalReader),
 
@@ -90,6 +95,30 @@ impl_reader_for_enum! {
 
         CacheSync(CacheSyncReader),
 
+        Fallback(FallbackFsReader),
+
+        #[cfg(feature = "opendal")]
+        Opendal(OpendalReader),
+
+        #[cfg(feature = "oss-hdfs")]
+        OssHdfs(OssHdfsReader),
+    }
+}
+
+/// A non-recursive UFS-only reader used inside FallbackFsReader.
+/// Unlike UnifiedReader, this never contains FallbackFsReader, which
+/// breaks the recursive type/async-fn cycle.
+#[allow(clippy::large_enum_variant)]
+pub enum UfsReader {
+    #[cfg(feature = "opendal")]
+    Opendal(OpendalReader),
+
+    #[cfg(feature = "oss-hdfs")]
+    OssHdfs(OssHdfsReader),
+}
+
+impl_reader_for_enum! {
+    enum UfsReader {
         #[cfg(feature = "opendal")]
         Opendal(OpendalReader),
 
@@ -231,5 +260,17 @@ impl UfsFileSystem {
     pub fn with_mount(mnt: &MountInfo) -> FsResult<Self> {
         let path = Path::from_str(&mnt.ufs_path)?;
         Self::new(&path, mnt.properties.clone(), mnt.provider)
+    }
+
+    /// Opens a UFS reader without wrapping it in UnifiedReader.
+    /// Used by FallbackFsReader to avoid a recursive type cycle.
+    pub async fn open_ufs(&self, path: &Path) -> FsResult<UfsReader> {
+        match self {
+            #[cfg(feature = "opendal")]
+            UfsFileSystem::Opendal(fs) => Ok(UfsReader::Opendal(fs.open(path).await?)),
+
+            #[cfg(feature = "oss-hdfs")]
+            UfsFileSystem::OssHdfs(fs) => Ok(UfsReader::OssHdfs(fs.open(path).await?)),
+        }
     }
 }

--- a/curvine-client/src/unified/unified_filesystem.rs
+++ b/curvine-client/src/unified/unified_filesystem.rs
@@ -14,7 +14,7 @@
 
 use crate::file::{CurvineFileSystem, FsClient, FsContext, FsReader};
 use crate::rpc::JobMasterClient;
-use crate::unified::{MountCache, MountValue, UnifiedReader, UnifiedWriter};
+use crate::unified::{FallbackFsReader, MountCache, MountValue, UnifiedReader, UnifiedWriter};
 use crate::ClientMetrics;
 use bytes::BytesMut;
 use curvine_common::conf::ClusterConf;
@@ -237,7 +237,7 @@ impl UnifiedFileSystem {
         cv_path: &Path,
         ufs_path: &Path,
         mount: &MountValue,
-    ) -> FsResult<Option<FsReader>> {
+    ) -> FsResult<Option<FallbackFsReader>> {
         let mut blocks = match self.cv.get_block_locations(cv_path).await {
             Ok(blocks) => blocks,
             Err(e) => {
@@ -250,12 +250,12 @@ impl UnifiedFileSystem {
 
         if mount.info.is_fs_mode() {
             if blocks.cv_exists() {
-                let cv_reader = Some(FsReader::new(
-                    cv_path.clone(),
-                    self.cv.fs_context(),
-                    blocks,
-                )?);
-                Ok(cv_reader)
+                let cv_reader = FsReader::new(cv_path.clone(), self.cv.fs_context(), blocks)?;
+                Ok(Some(FallbackFsReader::new(
+                    cv_reader,
+                    ufs_path.clone(),
+                    mount.ufs.clone(),
+                )))
             } else if blocks.ufs_exists() {
                 Ok(None)
             } else {
@@ -270,12 +270,12 @@ impl UnifiedFileSystem {
                     if blocks.status.ufs_exists() {
                         blocks.status.mtime = blocks.status.storage_policy.ufs_mtime;
                     }
-                    let cv_reader = Some(FsReader::new(
-                        cv_path.clone(),
-                        self.cv.fs_context(),
-                        blocks,
-                    )?);
-                    Ok(cv_reader)
+                    let cv_reader = FsReader::new(cv_path.clone(), self.cv.fs_context(), blocks)?;
+                    Ok(Some(FallbackFsReader::new(
+                        cv_reader,
+                        ufs_path.clone(),
+                        mount.ufs.clone(),
+                    )))
                 }
                 CacheValidity::Invalid(_) => Ok(None),
             }
@@ -530,7 +530,7 @@ impl FileSystem<UnifiedWriter, UnifiedReader> for UnifiedFileSystem {
                 .with_label_values(&[mount.mount_id()])
                 .inc();
 
-            Ok(UnifiedReader::Cv(reader))
+            Ok(UnifiedReader::Fallback(reader))
         } else {
             self.metrics
                 .mount_cache_misses

--- a/curvine-fuse/src/fs/state/node_state.rs
+++ b/curvine-fuse/src/fs/state/node_state.rs
@@ -283,10 +283,17 @@ impl NodeState {
                 let reader = self.fs.open(path).await?;
 
                 if self.conf.enable_meta_cache {
-                    if let UnifiedReader::Cv(cv_reader) = &reader {
-                        self.meta_cache
-                            .put_open(path, cv_reader.file_blocks().clone());
-                    }
+                    match &reader {
+                        UnifiedReader::Cv(cv_reader) => {
+                            self.meta_cache
+                                .put_open(path, cv_reader.file_blocks().clone());
+                        }
+                        UnifiedReader::Fallback(fallback_reader) => {
+                            self.meta_cache
+                                .put_open(path, fallback_reader.file_blocks().clone());
+                        }
+                        _ => {}
+                    };
                 }
 
                 reader

--- a/curvine-tests/tests/fallback_read_test.rs
+++ b/curvine-tests/tests/fallback_read_test.rs
@@ -1,0 +1,377 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Integration tests for `FallbackFsReader`.
+//!
+//! # Test Plan
+//!
+//! ## Runnable (requires UFS_TEST_PATH env var)
+//!
+//! | ID     | Scenario                                                          |
+//! |--------|-------------------------------------------------------------------|
+//! | TC-10  | FsMode open() returns UnifiedReader::Fallback                     |
+//! | TC-11a | FallbackFsReader reads correct data (normal path, no failure)     |
+//! | TC-15  | seek() then read via FallbackFsReader returns correct slice       |
+//! | TC-16  | read_full() returns all data intact                               |
+//!
+//! ## Require worker-kill infrastructure (skipped with #[ignore])
+//!
+//! | ID     | Scenario                                                          |
+//! |--------|-------------------------------------------------------------------|
+//! | TC-11b | Worker failure during read -> fallback to UFS transparently       |
+//! | TC-12  | Worker failure when ufs_mtime mismatches -> returns error         |
+//! | TC-13  | Worker failure when ufs_mtime=0 (not flushed) -> returns error    |
+//! | TC-14  | seek() after fallback to UFS -> continues from new position       |
+
+use bytes::BytesMut;
+use curvine_client::file::FsReader;
+use curvine_client::unified::{FallbackFsReader, UfsFileSystem, UnifiedFileSystem, UnifiedReader};
+use curvine_common::fs::{FileSystem, Path, Reader, Writer};
+use curvine_common::state::{MountOptionsBuilder, WriteType};
+use curvine_tests::Testing;
+use orpc::common::Utils;
+use orpc::runtime::{AsyncRuntime, RpcRuntime};
+use std::env;
+use std::sync::Arc;
+use std::sync::OnceLock;
+
+// ---- helpers ---------------------------------------------------------------
+
+fn setup() -> Option<UnifiedFileSystem> {
+    let ufs_path = env::var("UFS_TEST_PATH").unwrap_or_default();
+    if ufs_path.is_empty() {
+        println!("WARNING: UFS_TEST_PATH not set or empty, skipping fallback_read tests");
+        return None;
+    }
+    let testing = shared_testing();
+    let rt = Arc::new(AsyncRuntime::single());
+    Some(testing.get_unified_fs_with_rt(rt).unwrap())
+}
+
+fn shared_testing() -> &'static Testing {
+    static TESTING: OnceLock<Testing> = OnceLock::new();
+    TESTING.get_or_init(|| {
+        let testing = Testing::builder().workers(3).build().unwrap();
+        testing.start_cluster().unwrap();
+        testing
+    })
+}
+
+async fn mount_fs_mode(fs: &UnifiedFileSystem, mount_dir: &str) {
+    let ufs_base = env::var("UFS_TEST_PATH").unwrap();
+    let ufs_path = Path::from_str(format!("{}/{}", ufs_base, mount_dir)).unwrap();
+    let cv_path = Path::from_str(format!("/{}", mount_dir)).unwrap();
+
+    if fs.get_mount(&cv_path).await.unwrap().is_some() {
+        return;
+    }
+
+    let mut opts_builder = MountOptionsBuilder::new().write_type(WriteType::FsMode);
+    if let Ok(props_str) = env::var("UFS_TEST_PROPERTIES") {
+        for pair in props_str.split(',') {
+            if let Some((k, v)) = pair.split_once('=') {
+                opts_builder = opts_builder.add_property(k.trim(), v.trim());
+            }
+        }
+    }
+    let opts = opts_builder.build();
+
+    let ufs = UfsFileSystem::new(&ufs_path, opts.add_properties.clone(), None).unwrap();
+    if ufs.exists(&ufs_path).await.unwrap() {
+        ufs.delete(&ufs_path, true).await.unwrap();
+    }
+    ufs.mkdir(&ufs_path, true).await.unwrap();
+    fs.mount(&ufs_path, &cv_path, opts).await.unwrap();
+}
+
+/// Write `data` to Curvine FsMode and wait for it to flush to UFS.
+async fn write_and_flush(fs: &UnifiedFileSystem, mount_dir: &str, name: &str, data: &str) -> Path {
+    let cv_path = Path::from_str(format!("/{}/{}", mount_dir, name)).unwrap();
+    let mut w = fs.create(&cv_path, true).await.unwrap();
+    w.write(data.as_bytes()).await.unwrap();
+    w.complete().await.unwrap();
+
+    // Submit load/export job explicitly, then wait for completion by cv path job id.
+    fs.async_cache(&cv_path).unwrap();
+    fs.wait_job_complete(&cv_path, false).await.unwrap();
+    cv_path
+}
+
+/// Write data but do not flush to UFS, so `ufs_mtime` stays 0.
+async fn write_without_flush(
+    fs: &UnifiedFileSystem,
+    mount_dir: &str,
+    name: &str,
+    data: &str,
+) -> Path {
+    let cv_path = Path::from_str(format!("/{}/{}", mount_dir, name)).unwrap();
+    let mut w = fs.create(&cv_path, true).await.unwrap();
+    w.write(data.as_bytes()).await.unwrap();
+    w.complete().await.unwrap();
+    cv_path
+}
+
+/// Build a `FallbackFsReader` whose internal Curvine block locations point to an
+/// unreachable worker endpoint, to deterministically trigger worker read errors.
+async fn build_reader_with_unreachable_worker(
+    fs: &UnifiedFileSystem,
+    cv_path: &Path,
+) -> FallbackFsReader {
+    let mut blocks = fs.cv().get_block_locations(cv_path).await.unwrap();
+    for (i, located) in blocks.block_locs.iter_mut().enumerate() {
+        for (j, worker) in located.locs.iter_mut().enumerate() {
+            // IMPORTANT:
+            // WorkerAddress hash/eq uses worker_id only. We must also mutate worker_id
+            // to avoid reusing an existing pooled connection for the original worker.
+            worker.worker_id = 4_000_000_000u32.saturating_sub((i * 100 + j) as u32);
+            worker.hostname = "127.0.0.1".to_string();
+            worker.ip_addr = "127.0.0.1".to_string();
+            worker.rpc_port = 1;
+        }
+    }
+
+    let cv_reader = FsReader::new(cv_path.clone(), fs.cv().fs_context(), blocks).unwrap();
+    let (ufs_path, mount) = fs.get_mount(cv_path).await.unwrap().unwrap();
+    FallbackFsReader::new(cv_reader, ufs_path, mount.ufs.clone())
+}
+
+// ---- TC-10: FsMode open returns Fallback -----------------------------------
+
+/// TC-10: `open()` on an FsMode path with cached data must return
+/// `UnifiedReader::Fallback`, not `UnifiedReader::Cv`.
+#[test]
+fn test_tc10_fsmode_open_returns_fallback() {
+    let Some(fs) = setup() else {
+        return;
+    };
+    let rt = fs.clone_runtime();
+    rt.block_on(async move {
+        let mount_dir = "fallback_read_tc10";
+        mount_fs_mode(&fs, mount_dir).await;
+        let cv_path = write_and_flush(&fs, mount_dir, "tc10.log", "hello fallback").await;
+
+        let reader = fs.open(&cv_path).await.unwrap();
+        assert!(
+            matches!(reader, UnifiedReader::Fallback(_)),
+            "FsMode with cached blocks must return UnifiedReader::Fallback"
+        );
+    });
+}
+
+// ---- TC-11a: FallbackFsReader reads correct data (normal path) -------------
+
+/// TC-11a: Data read through `FallbackFsReader` (Curvine path, no failure)
+/// must match what was written.
+#[test]
+fn test_tc11a_fallback_reader_reads_correct_data() {
+    let Some(fs) = setup() else {
+        return;
+    };
+    let rt = fs.clone_runtime();
+    rt.block_on(async move {
+        let mount_dir = "fallback_read_tc11a";
+        mount_fs_mode(&fs, mount_dir).await;
+        let data = Utils::rand_str(4 * 1024);
+        let cv_path = write_and_flush(&fs, mount_dir, "tc11a.log", &data).await;
+
+        let mut reader = fs.open(&cv_path).await.unwrap();
+        assert!(matches!(reader, UnifiedReader::Fallback(_)));
+
+        let mut buf = BytesMut::zeroed(data.len());
+        reader.read_full(&mut buf).await.unwrap();
+        reader.complete().await.unwrap();
+
+        assert_eq!(
+            data.as_bytes(),
+            &buf[..],
+            "data read via FallbackFsReader does not match written data"
+        );
+    });
+}
+
+// ---- TC-15: seek + read via FallbackFsReader --------------------------------
+
+/// TC-15: After `seek()` to an offset, reading must return only the bytes from
+/// that offset onward.
+#[test]
+fn test_tc15_fallback_reader_seek_and_read() {
+    let Some(fs) = setup() else {
+        return;
+    };
+    let rt = fs.clone_runtime();
+    rt.block_on(async move {
+        let mount_dir = "fallback_read_tc15";
+        mount_fs_mode(&fs, mount_dir).await;
+
+        let prefix = "PREFIX_DATA_";
+        let suffix = Utils::rand_str(512);
+        let data = format!("{}{}", prefix, suffix);
+        let cv_path = write_and_flush(&fs, mount_dir, "tc15.log", &data).await;
+
+        let mut reader = fs.open(&cv_path).await.unwrap();
+        assert!(matches!(reader, UnifiedReader::Fallback(_)));
+
+        let seek_pos = prefix.len() as i64;
+        reader.seek(seek_pos).await.unwrap();
+
+        let remaining = data.len() - prefix.len();
+        let mut buf = BytesMut::zeroed(remaining);
+        reader.read_full(&mut buf).await.unwrap();
+        reader.complete().await.unwrap();
+
+        assert_eq!(
+            suffix.as_bytes(),
+            &buf[..],
+            "seek + read via FallbackFsReader returned wrong bytes"
+        );
+    });
+}
+
+// ---- TC-16: read_full returns all data -------------------------------------
+
+/// TC-16: `read_full()` across a 256 KiB file via `FallbackFsReader` must
+/// return all data with a matching checksum.
+#[test]
+fn test_tc16_fallback_reader_multi_chunk_read() {
+    let Some(fs) = setup() else {
+        return;
+    };
+    let rt = fs.clone_runtime();
+    rt.block_on(async move {
+        let mount_dir = "fallback_read_tc16";
+        mount_fs_mode(&fs, mount_dir).await;
+
+        let data = Utils::rand_str(256 * 1024);
+        let cv_path = write_and_flush(&fs, mount_dir, "tc16.log", &data).await;
+
+        let mut reader = fs.open(&cv_path).await.unwrap();
+        assert!(matches!(reader, UnifiedReader::Fallback(_)));
+
+        let mut buf = BytesMut::zeroed(data.len());
+        reader.read_full(&mut buf).await.unwrap();
+        reader.complete().await.unwrap();
+
+        assert_eq!(
+            Utils::crc32(data.as_bytes()),
+            Utils::crc32(&buf),
+            "CRC32 mismatch on multi-chunk read via FallbackFsReader"
+        );
+    });
+}
+
+// ---- TC-11b / TC-12 / TC-13 / TC-14: worker-failure paths ------------------
+
+/// TC-11b: Simulate worker failure during read and verify transparent fallback
+/// to UFS returns the correct data.
+#[test]
+fn test_tc11b_worker_failure_falls_back_to_ufs() {
+    let Some(fs) = setup() else {
+        return;
+    };
+    let rt = fs.clone_runtime();
+    rt.block_on(async move {
+        let mount_dir = "fallback_read_tc11b";
+        mount_fs_mode(&fs, mount_dir).await;
+        let data = Utils::rand_str(16 * 1024);
+        let cv_path = write_and_flush(&fs, mount_dir, "tc11b.log", &data).await;
+
+        let mut reader = build_reader_with_unreachable_worker(&fs, &cv_path).await;
+        let mut buf = BytesMut::zeroed(data.len());
+        reader.read_full(&mut buf).await.unwrap();
+        let _ = reader.complete().await;
+
+        assert_eq!(data.as_bytes(), &buf[..]);
+    });
+}
+
+/// TC-12: Worker failure when `ufs_mtime` differs from actual UFS mtime
+/// -> `read_chunk0` must return an error (no silent fallback with stale data).
+#[test]
+fn test_tc12_worker_failure_ufs_mtime_mismatch_returns_error() {
+    let Some(fs) = setup() else {
+        return;
+    };
+    let rt = fs.clone_runtime();
+    rt.block_on(async move {
+        let mount_dir = "fallback_read_tc12";
+        mount_fs_mode(&fs, mount_dir).await;
+        let cv_path = write_and_flush(&fs, mount_dir, "tc12.log", "original-data").await;
+
+        // Overwrite UFS file to change mtime/len and create metadata mismatch.
+        let (ufs_path, mount) = fs.get_mount(&cv_path).await.unwrap().unwrap();
+        let mut ufs_writer = mount.ufs.create(&ufs_path, true).await.unwrap();
+        ufs_writer.write(b"changed-in-ufs").await.unwrap();
+        ufs_writer.complete().await.unwrap();
+
+        let mut reader = build_reader_with_unreachable_worker(&fs, &cv_path).await;
+        let mut buf = BytesMut::zeroed(32);
+        let err = reader.read(&mut buf).await.unwrap_err().to_string();
+        assert!(err.contains("UFS data inconsistent"));
+    });
+}
+
+/// TC-13: Worker failure when `ufs_mtime == 0` (never flushed to UFS)
+/// -> `read_chunk0` must return an error.
+#[test]
+fn test_tc13_worker_failure_ufs_not_flushed_returns_error() {
+    let Some(fs) = setup() else {
+        return;
+    };
+    let rt = fs.clone_runtime();
+    rt.block_on(async move {
+        let mount_dir = "fallback_read_tc13";
+        mount_fs_mode(&fs, mount_dir).await;
+        let cv_path = write_without_flush(&fs, mount_dir, "tc13.log", "not-flushed").await;
+
+        let mut reader = build_reader_with_unreachable_worker(&fs, &cv_path).await;
+        let mut buf = BytesMut::zeroed(32);
+        let err = reader.read(&mut buf).await.unwrap_err().to_string();
+        assert!(err.contains("not been flushed"));
+    });
+}
+
+/// TC-14: After falling back to UFS, `seek()` to a new position then read
+/// must return data from the new offset, not the original fallback position.
+#[test]
+fn test_tc14_seek_after_ufs_fallback() {
+    let Some(fs) = setup() else {
+        return;
+    };
+    let rt = fs.clone_runtime();
+    rt.block_on(async move {
+        let mount_dir = "fallback_read_tc14";
+        mount_fs_mode(&fs, mount_dir).await;
+        let prefix = "PREFIX-";
+        let middle = Utils::rand_str(128);
+        let suffix = Utils::rand_str(256);
+        let data = format!("{}{}{}", prefix, middle, suffix);
+        let cv_path = write_and_flush(&fs, mount_dir, "tc14.log", &data).await;
+
+        let mut reader = build_reader_with_unreachable_worker(&fs, &cv_path).await;
+
+        // First read triggers fallback from Curvine to UFS.
+        let mut first = BytesMut::zeroed(8);
+        let n = reader.read(&mut first).await.unwrap();
+        assert!(n > 0);
+
+        // Seek after fallback and verify the returned slice.
+        let seek_pos = (prefix.len() + middle.len()) as i64;
+        reader.seek(seek_pos).await.unwrap();
+        let mut buf = BytesMut::zeroed(suffix.len());
+        reader.read_full(&mut buf).await.unwrap();
+        let _ = reader.complete().await;
+
+        assert_eq!(suffix.as_bytes(), &buf[..]);
+    });
+}

--- a/curvine-tests/tests/write_cache_test.rs
+++ b/curvine-tests/tests/write_cache_test.rs
@@ -100,8 +100,8 @@ async fn test_cache_read(fs: &UnifiedFileSystem, path: &Path) {
 
     let mut reader2 = fs.open(path).await.unwrap();
     assert!(
-        matches!(reader2, UnifiedReader::Cv(_)),
-        "second read should be from curvine"
+        matches!(reader2, UnifiedReader::Fallback(_)),
+        "second read should be from curvine via FallbackFsReader"
     );
 
     let str2 = reader2.read_as_string().await.unwrap();
@@ -237,8 +237,8 @@ fn test_fs_mode_ufs_write_overwrite() {
 
         let reader = fs.open(&path).await.unwrap();
         assert!(
-            matches!(reader, UnifiedReader::Cv(_)),
-            "read should return CV reader after overwrite and sync"
+            matches!(reader, UnifiedReader::Fallback(_)),
+            "read should return Fallback reader after overwrite and sync"
         );
 
         verify_read_data(&fs, &path, data_overwrite.as_bytes()).await;
@@ -267,8 +267,8 @@ fn test_fs_mode_ufs_write_append() {
 
         let reader = fs.open(&path).await.unwrap();
         assert!(
-            matches!(reader, UnifiedReader::Cv(_)),
-            "read should return CV reader after append and sync"
+            matches!(reader, UnifiedReader::Fallback(_)),
+            "read should return Fallback reader after append and sync"
         );
         let expected_append = format!("{}{}", data_initial, data_append_extra);
 
@@ -314,8 +314,8 @@ fn test_fs_mode_ufs_write_random() {
         fs.wait_job_complete(&path, false).await.unwrap();
         let reader = fs.open(&path).await.unwrap();
         assert!(
-            matches!(reader, UnifiedReader::Cv(_)),
-            "read should return CV reader after random write and sync"
+            matches!(reader, UnifiedReader::Fallback(_)),
+            "read should return Fallback reader after random write and sync"
         );
 
         verify_read_data(&fs, &path, &expected).await;


### PR DESCRIPTION
## Problem
In FsMode, reads fail when Curvine master is unavailable or when a worker serving file blocks
becomes unhealthy. The client needs a transparent fallback path to UFS read.

## Design
Introduce `FallbackFsReader` as a wrapper around `FsReader` that holds UFS context.
On worker-related read errors (IO/Pipeline/Timeout), validate UFS consistency using
`ufs_mtime` and `len`, then switch permanently to UFS for subsequent reads.

## Key Changes
- Added `fallback_fs_reader.rs`: implements `FallbackFsReader`, worker-error classification,
  lazy UFS reader creation, and UFS metadata consistency validation before fallback
- Updated `mod.rs`: added `UnifiedReader::Fallback`, introduced `UfsReader` and
  `UfsFileSystem::open_ufs()` to break recursive type/async cycles
- Updated `unified_filesystem.rs`: `get_cv_reader` now returns `Option<FallbackFsReader>`;
  FsMode open path now returns `UnifiedReader::Fallback`
- Added `fallback_read_test.rs`: integration test coverage for TC-10/11a/15/16, with
  worker-kill dependent cases (TC-11b/12/13/14) marked as ignored
- Updated `write_cache_test.rs`: assertions now expect `Fallback` instead of `Cv`