### PR TITLE
feat(raft): introduce AppliedIndex/FsmState proto and async ApplyMsg …

### DIFF
--- a/curvine-common/proto/raft.proto
+++ b/curvine-common/proto/raft.proto
@@ -21,9 +21,21 @@ message SnapshotFileList {
     repeated SnapshotFileInfo files = 2;
 }
 
+message AppliedIndex {
+    required uint64 term = 1;
+    required uint64 index = 2;
+    required uint64 op_id = 3;
+    required int64 rpc_id = 4;
+}
+
+message FsmState {
+    required AppliedIndex applied = 1;
+    required AppliedIndex ufs_applied = 2;
+}
+
 // Describe a snapshot.
 message SnapshotData {
-    // Snapshot id
+    // Snapshot id / applied index of the snapshot.
     required uint64 snapshot_id = 1;
 
     // Which node is the snapshot created.
@@ -35,6 +47,8 @@ message SnapshotData {
     optional bytes bytes_data = 4;
 
     optional SnapshotFileList files_data = 5;
+
+    required FsmState fsm_state = 6;
 }
 
 
@@ -75,12 +89,6 @@ message RaftRequest {
 }
 
 message RaftResponse {
-}
-
-message RaftStateStoreProto {
-    required eraftpb.HardState hard_state = 1;
-    required eraftpb.ConfState conf_state = 2;
-    required eraftpb.SnapshotMetadata snapshot = 3;
 }
 
 // Download snapshot request.

--- a/curvine-common/src/conf/cluster_conf.rs
+++ b/curvine-common/src/conf/cluster_conf.rs
@@ -233,7 +233,14 @@ impl ClusterConf {
 
     // Test and modify the metadata-related path.
     pub fn change_test_meta_dir<T: AsRef<str>>(&mut self, name: T) {
-        let base = Utils::cur_dir_sub(format!("../testing/{}", name.as_ref()));
+        let pid = std::process::id();
+        let rand = Utils::rand_str(6);
+        let base = Utils::cur_dir_sub(format!(
+            "../target/testing/{}_{}_{}",
+            name.as_ref(),
+            pid,
+            rand
+        ));
         self.master.meta_dir = format!("{}/meta", base);
         self.journal.journal_dir = format!("{}/journal", base);
     }

--- a/curvine-common/src/conf/journal_conf.rs
+++ b/curvine-common/src/conf/journal_conf.rs
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 use crate::conf::ClusterConf;
-use crate::raft::RaftPeer;
+use crate::raft::{RaftGroup, RaftPeer};
+use crate::FsResult;
 use orpc::client::ClientConf;
 use orpc::common::Utils;
 use orpc::io::net::{InetAddr, NetUtils};
@@ -42,9 +43,6 @@ pub struct JournalConf {
 
     // raft log storage configuration
     pub journal_dir: String,
-
-    // Write enables debug and will print every log.
-    pub writer_debug: bool,
 
     // The buffer queue size when journal is written, default is 200_000
     // The queue size is high in concurrency, which has a great impact on metadata performance. It can be set to 0 and use an unbounded queue.
@@ -101,8 +99,11 @@ pub struct JournalConf {
     // The number of checkpoints saved.
     pub retain_checkpoint_num: usize,
 
-    // Whether to ignore errors in the log replay process.
-    pub ignore_replay_error: bool,
+    pub cv_error_retry: bool,
+    pub ufs_error_retry: bool,
+    pub max_retry_num: u64,
+    pub scan_batch_size: u64,
+    pub retry_interval_secs: u64,
 
     // Max timeout for copying data to UFS, expressed as a duration string (e.g. "20m").
     // Default: 20 minutes.
@@ -128,6 +129,12 @@ impl JournalConf {
 
     pub fn local_addr(&self) -> InetAddr {
         InetAddr::new(self.hostname.clone(), self.rpc_port)
+    }
+
+    pub fn node_id(&self) -> FsResult<u64> {
+        let group = RaftGroup::from_conf(self);
+        let id = group.get_node_id(&self.local_addr())?;
+        Ok(id)
     }
 
     pub fn new_client_conf(&self) -> ClientConf {
@@ -195,12 +202,11 @@ impl Default for JournalConf {
             message_size: 200,
             journal_addrs,
             journal_dir,
-            writer_debug: false,
             writer_channel_size: 0,
             writer_flush_batch_size: 1000,
             writer_flush_batch_ms: 100,
             snapshot_interval: "6h".to_string(),
-            snapshot_entries: 100_000,
+            snapshot_entries: 1000000,
             snapshot_read_chunk_size: 1024 * 1024,
 
             conn_retry_max_duration_ms: 0,
@@ -232,8 +238,12 @@ impl Default for JournalConf {
             raft_retry_cache_ttl: "10m".to_string(),
 
             retain_checkpoint_num: 3,
-            ignore_replay_error: false,
 
+            ufs_error_retry: true,
+            cv_error_retry: false,
+            max_retry_num: 1000,
+            scan_batch_size: 1000,
+            retry_interval_secs: 10,
             ufs_copy_timeout: "20m".to_owned(), // 20 minutes
         }
     }

--- a/curvine-common/src/raft/mod.rs
+++ b/curvine-common/src/raft/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::proto::raft::FsmState;
 use raft::eraftpb;
 
 mod raft_node;
@@ -60,3 +61,19 @@ pub type LibRaftMessage = eraftpb::Message;
 pub const DEFAULT_LEADER_ID: u64 = 0;
 
 pub const LOG_START_INDEX: u64 = 0;
+
+impl FsmState {
+    pub fn compact(&self) -> u64 {
+        let applied = if self.applied.index <= self.ufs_applied.index {
+            &self.applied
+        } else {
+            &self.ufs_applied
+        };
+
+        applied.index.saturating_sub(1)
+    }
+
+    pub fn op_id(&self) -> u64 {
+        self.applied.op_id.max(self.ufs_applied.op_id)
+    }
+}

--- a/curvine-common/src/raft/raft_utils.rs
+++ b/curvine-common/src/raft/raft_utils.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::proto::raft::{
-    SnapshotData, SnapshotDownloadRequest, SnapshotFileInfo, SnapshotFileList,
+    FsmState, SnapshotData, SnapshotDownloadRequest, SnapshotFileInfo, SnapshotFileList,
 };
 use crate::raft::RaftResult;
 use crate::rocksdb::DBEngine;
@@ -28,7 +28,7 @@ impl RaftUtils {
     pub fn create_file_snapshot(
         dir: impl AsRef<str>,
         node_id: u64,
-        snapshot_id: u64,
+        fsm_state: FsmState,
     ) -> RaftResult<SnapshotData> {
         let dir = dir.as_ref();
         let files = FileUtils::list_files(dir, false)?;
@@ -49,11 +49,12 @@ impl RaftUtils {
         }
 
         let data = SnapshotData {
-            snapshot_id,
+            snapshot_id: fsm_state.applied.index,
             node_id,
             create_time: LocalTime::mills(),
             bytes_data: None,
             files_data: Some(list),
+            fsm_state,
         };
 
         Ok(data)

--- a/curvine-common/src/raft/storage/apply_msg.rs
+++ b/curvine-common/src/raft/storage/apply_msg.rs
@@ -1,0 +1,43 @@
+//  Copyright 2025 OPPO.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+use crate::proto::raft::{AppliedIndex, SnapshotData};
+use crate::raft::RaftResult;
+use orpc::sync::channel::CallSender;
+use raft::eraftpb::Entry;
+use raft::StateRole;
+
+pub enum ApplyMsg {
+    Entry(Entry),
+    Scan(AppliedIndex),
+    Snapshot(CallSender<RaftResult<SnapshotData>>),
+    RoleChange(StateRole),
+}
+
+impl ApplyMsg {
+    pub fn new_entry(entry: Entry) -> Self {
+        ApplyMsg::Entry(entry)
+    }
+
+    pub fn new_scan(applied_index: AppliedIndex) -> ApplyMsg {
+        ApplyMsg::Scan(applied_index)
+    }
+
+    pub fn take_entry(self) -> Entry {
+        match self {
+            ApplyMsg::Entry(entry) => entry,
+            _ => panic!("invalid entry"),
+        }
+    }
+}

--- a/curvine-common/src/raft/storage/hash_app_storage.rs
+++ b/curvine-common/src/raft/storage/hash_app_storage.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::proto::raft::SnapshotData;
+use crate::proto::raft::{FsmState, SnapshotData};
 use crate::raft::storage::AppStorage;
 use crate::raft::{RaftResult, RaftUtils};
 use crate::rocksdb::DBEngine;
@@ -98,6 +98,7 @@ where
             create_time: LocalTime::mills(),
             bytes_data: Some(bytes),
             files_data: None,
+            fsm_state: Default::default(),
         };
         Ok(data)
     }
@@ -174,7 +175,7 @@ where
     fn create_snapshot(&self, node_id: u64, snapshot_id: u64) -> RaftResult<SnapshotData> {
         let db = self.lock()?;
         let dir = db.create_checkpoint(snapshot_id)?;
-        let data = RaftUtils::create_file_snapshot(dir, node_id, snapshot_id)?;
+        let data = RaftUtils::create_file_snapshot(dir, node_id, FsmState::default())?;
         Ok(data)
     }
 

--- a/curvine-common/src/raft/storage/mod.rs
+++ b/curvine-common/src/raft/storage/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod log_storage;
+
 pub use self::log_storage::LogStorage;
 
 mod mem_log_storage;
@@ -32,3 +33,6 @@ pub use self::rocks_log_storage::RocksLogStorage;
 
 mod peer_storage;
 pub use self::peer_storage::PeerStorage;
+
+mod apply_msg;
+pub use self::apply_msg::*;

--- a/curvine-common/src/raft/storage/rocks_storage_core.rs
+++ b/curvine-common/src/raft/storage/rocks_storage_core.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::proto::raft::RaftStateStoreProto;
 use crate::raft::{RaftError, RaftResult, LOG_START_INDEX};
 use crate::rocksdb::{DBConf, DBEngine, RocksUtils, WriteBatch};
 use log::warn;
@@ -111,14 +110,6 @@ impl RocksStorageCore {
 
     pub fn hard_state(&self) -> &HardState {
         &self.raft_state.hard_state
-    }
-
-    pub fn create_proto_state(&self) -> RaftStateStoreProto {
-        RaftStateStoreProto {
-            hard_state: self.raft_state.hard_state.clone(),
-            conf_state: self.raft_state.conf_state.clone(),
-            snapshot: self.snapshot_metadata.clone(),
-        }
     }
 
     pub fn mut_hard_state(&mut self) -> &mut HardState {

--- a/curvine-server/src/master/journal/journal_loader.rs
+++ b/curvine-server/src/master/journal/journal_loader.rs
@@ -20,7 +20,7 @@ use crate::master::meta::inode::InodeView::{Dir, File};
 use crate::master::{JobManager, MountManager, SyncFsDir};
 use curvine_common::conf::JournalConf;
 use curvine_common::error::FsError;
-use curvine_common::proto::raft::SnapshotData;
+use curvine_common::proto::raft::{FsmState, SnapshotData};
 use curvine_common::raft::storage::AppStorage;
 use curvine_common::raft::{RaftResult, RaftUtils};
 use curvine_common::state::RenameFlags;
@@ -57,7 +57,7 @@ impl JournalLoader {
             ufs_loader,
             seq_id: Arc::new(AtomicCounter::new(0)),
             retain_checkpoint_num: 3.max(conf.retain_checkpoint_num),
-            ignore_replay_error: conf.ignore_replay_error,
+            ignore_replay_error: conf.cv_error_retry,
         }
     }
 
@@ -374,7 +374,7 @@ impl AppStorage for JournalLoader {
     fn create_snapshot(&self, node_id: u64, last_applied: u64) -> RaftResult<SnapshotData> {
         let fs_dir = self.fs_dir.read();
         let dir = fs_dir.create_checkpoint(last_applied)?;
-        let data = RaftUtils::create_file_snapshot(&dir, node_id, last_applied)?;
+        let data = RaftUtils::create_file_snapshot(&dir, node_id, FsmState::default())?;
 
         // Delete historical snapshots.
         if let Err(e) = self.purge_checkpoint(&dir) {

--- a/curvine-server/src/master/journal/journal_writer.rs
+++ b/curvine-server/src/master/journal/journal_writer.rs
@@ -21,7 +21,7 @@ use curvine_common::conf::JournalConf;
 use curvine_common::raft::RaftClient;
 use curvine_common::state::{CommitBlock, FileLock, MountInfo, RenameFlags, SetAttrOpts};
 use curvine_common::FsResult;
-use log::info;
+use log::debug;
 use std::sync::mpsc::{Receiver, SendError, Sender, SyncSender};
 use std::sync::{mpsc, Mutex};
 
@@ -42,7 +42,6 @@ impl SenderAdapter {
 // Write metadata operation logs.
 pub struct JournalWriter {
     enable: bool,
-    debug: bool,
     sender: SenderAdapter,
     metrics: &'static MasterMetrics,
     receiver: Option<Mutex<Receiver<JournalEntry>>>,
@@ -69,7 +68,6 @@ impl JournalWriter {
 
         Self {
             enable: conf.enable,
-            debug: conf.writer_debug,
             sender,
             metrics: Master::get_metrics(),
             receiver,
@@ -77,9 +75,7 @@ impl JournalWriter {
     }
 
     fn send(&self, entry: JournalEntry) -> FsResult<()> {
-        if self.debug {
-            info!("send {:?}", entry);
-        }
+        debug!("send {:?}", entry);
 
         if self.enable {
             self.sender.send(entry)?;
@@ -208,9 +204,6 @@ impl JournalWriter {
 
     pub fn log_unmount(&self, op_ms: u64, id: u32) -> FsResult<()> {
         let entry = UnMountEntry { op_ms, id };
-        if self.debug {
-            info!("send {:?}", entry);
-        }
         self.send(JournalEntry::UnMount(entry))
     }
 


### PR DESCRIPTION
## Summary

This PR lays the groundwork for a reliable **leader/follower role-transition** mechanism in the Raft-based master journal layer. The core changes are:

- **`AppliedIndex` / `FsmState` proto** — replaces the bare `snapshot_id: u64` with a structured type that tracks both the metadata-applied index and the UFS-applied index separately. This makes it possible for a newly elected leader to know exactly where to resume UFS replay without re-applying already-committed metadata.
- **`ApplyMsg` abstraction** — a new enum (`Entry`, `Scan`, `Snapshot`, `RoleChange`) passed through an async channel, replacing ad-hoc synchronous calls. This cleanly separates the concerns of log application, snapshot install, and role-change handling.
- **`FsmState` embedded in `SnapshotData`** — snapshots now carry the full FSM state so that a node restoring from snapshot can immediately reconstruct both applied indices without scanning the log.
- **Retry / error policy split** — `ignore_replay_error` is split into `cv_error_retry` (curvine metadata errors) and `ufs_error_retry` (UFS copy errors), each independently configurable, with `max_retry_num`, `scan_batch_size`, and `retry_interval_secs`.