### PR TITLE
refactor(raft): modernize AppStorage/LogStorage traits and async appl…

### DIFF
--- a/curvine-common/src/raft/raft_node.rs
+++ b/curvine-common/src/raft/raft_node.rs
@@ -17,7 +17,7 @@
 use crate::conf::JournalConf;
 use crate::proto::raft::*;
 use crate::raft::raft_error::RaftError;
-use crate::raft::storage::{AppStorage, LogStorage, PeerStorage};
+use crate::raft::storage::{AppStorage, ApplyMsg, LogStorage, PeerStorage};
 use crate::raft::*;
 use crate::utils::SerdeUtils;
 use log::{error, info, warn};
@@ -71,10 +71,7 @@ where
 
     last_snapshot_ms: u64,
 
-    last_snapshot_index: u64,
-
-    // Index of each node commit
-    commit_info: HashMap<NodeId, u64>,
+    last_snapshot_applied: u64,
 }
 
 impl<A, B> RaftNode<A, B>
@@ -109,7 +106,7 @@ where
         let config = conf.new_raft_conf(id, last_applied);
         config.validate()?;
 
-        let storage = PeerStorage::new(log_store, app_store, client.clone(), conf);
+        let storage = PeerStorage::new(rt.clone(), log_store, app_store, client.clone(), conf);
         let raw = RawNode::new(&config, storage.clone(), logger)?;
         // raw.raft.become_candidate();
 
@@ -127,8 +124,7 @@ where
             snapshot_interval_ms,
             snapshot_entries,
             last_snapshot_ms: LocalTime::mills(),
-            last_snapshot_index: 0,
-            commit_info: Default::default(),
+            last_snapshot_applied: 0,
         };
 
         Ok(node)
@@ -160,7 +156,7 @@ where
         config.validate()?;
 
         client.join_cluster(id, &conf.local_addr()).await?;
-        let storage = PeerStorage::new(log_store, app_store, client.clone(), conf);
+        let storage = PeerStorage::new(rt.clone(), log_store, app_store, client.clone(), conf);
         let raw = RawNode::new(&config, storage.clone(), logger)?;
         let node = Self {
             rt,
@@ -176,8 +172,7 @@ where
             snapshot_interval_ms,
             snapshot_entries,
             last_snapshot_ms: LocalTime::mills(),
-            last_snapshot_index: 0,
-            commit_info: Default::default(),
+            last_snapshot_applied: 0,
         };
 
         Ok(node)
@@ -191,13 +186,13 @@ where
     ) -> RaftResult<u64> {
         let spend = TimeSpent::new();
 
-        let snapshot = match log_store.latest_snapshot()? {
+        let fsm_state: FsmState = match log_store.latest_snapshot()? {
             None => {
                 let mut snapshot = Snapshot::default();
                 snapshot.mut_metadata().mut_conf_state().voters = voters;
 
                 log_store.apply_snapshot(snapshot.clone())?;
-                snapshot
+                FsmState::default()
             }
 
             Some(mut snapshot) => {
@@ -205,49 +200,23 @@ where
                 // log store application snapshot.
                 log_store.apply_snapshot(snapshot.clone())?;
                 // app store app snapshot.
-                let snapshot_data = SnapshotData::decode(snapshot.get_data())?;
+                let snapshot_data: SnapshotData = SnapshotData::decode(snapshot.get_data())?;
                 info!(
                     "install snapshot start, meta: {:?}, snapshot data {:?}",
                     snapshot.get_metadata(),
                     snapshot_data
                 );
-                app_store.apply_snapshot(&snapshot_data)?;
+                app_store.apply_snapshot(snapshot_data).await?;
 
-                snapshot
+                app_store.get_fsm_state()
             }
         };
 
-        // Replay the log after the snapshot.
-        let mut last_applied = snapshot.metadata.as_ref().map(|x| x.index).unwrap_or(0);
-        let mut reply_state = log_store.initial_state()?.hard_state;
-        loop {
-            let entries = log_store.scan_entries(last_applied + 1, last_applied + 1000)?;
-            if entries.is_empty() {
-                break;
-            }
-            info!(
-                "install snapshot replay log, start_index: {}, entries: {}",
-                last_applied + 1,
-                entries.len()
-            );
-
-            for entry in &entries {
-                app_store.apply(false, &entry.data).await?;
-            }
-
-            let last_entry = entries.last().unwrap();
-            last_applied = last_entry.index;
-
-            // After log replay, set index and term.
-            reply_state.commit = last_entry.index;
-            reply_state.term = last_entry.term;
-        }
-
-        // Modify hard_state after log replay
-        log_store.set_hard_state(&reply_state)?;
-
+        app_store
+            .apply(true, ApplyMsg::new_scan(fsm_state.applied))
+            .await?;
         info!("install snapshot end, cost {} ms", spend.used_ms());
-        Ok(last_applied)
+        Ok(app_store.get_fsm_state().applied.index)
     }
 
     pub fn is_leader(&self) -> bool {
@@ -344,8 +313,7 @@ where
     // Handle raft internal messages, such as elections, heartbeats, voting, etc.
     fn handle_raft(&mut self, env: Envelope) -> RaftResult<()> {
         let raft: RaftRequest = try_err!(env.msg.parse_header());
-        self.commit_info
-            .insert(raft.message.from, raft.message.commit);
+
         self.raw.step(raft.message)?;
         let rep_msg = Builder::success(&env.msg)
             .proto_header(RaftResponse::default())
@@ -430,6 +398,22 @@ where
         // Get the ready structure.
         let mut ready = self.raw.ready();
 
+        // If hard state changes, it needs to be saved.
+        if let Some(hs) = ready.hs() {
+            let store = self.raw.mut_store();
+            store.set_hard_state(hs)?;
+        }
+
+        if let Some(ss) = ready.ss() {
+            info!(
+                "Raft soft state change, node id {}, current leader {}",
+                self.id(),
+                self.leader()
+            );
+            self.role_monitor.advance_role(ss);
+            self.storage.role_change(ss.raft_state).await?;
+        }
+
         // Get the message that needs to be sent to other nodes.
         // Only the leader call returns true.
         if !ready.messages().is_empty() {
@@ -444,28 +428,12 @@ where
 
         // Get the committed log entries, that is, the messages confirmed by most nodes.
         // Only the leader will run.
-        let mut apply_res = self
-            .apply_committed_entries(ready.take_committed_entries(), promise)
-            .await;
+        self.apply_committed_entries(ready.take_committed_entries(), promise)
+            .await?;
 
         // Get the normal log entries of the ready structure and save it.
         if !ready.entries().is_empty() {
             self.storage.append(&ready.entries()[..])?;
-        }
-
-        // If hard state changes, it needs to be saved.
-        if let Some(hs) = ready.hs() {
-            let store = self.raw.mut_store();
-            store.set_hard_state(hs)?;
-        }
-
-        if let Some(ss) = ready.ss() {
-            info!(
-                "Raft soft state change, node id {}, current leader {}",
-                self.id(),
-                self.leader()
-            );
-            self.role_monitor.advance_role(ss);
         }
 
         // Get the message that the leader has fallen into the disk and send these messages to other nodes.
@@ -485,26 +453,10 @@ where
         self.send_messages(light_rd.take_messages()).await?;
 
         // The advance interface will return a new committed entries.
-        if apply_res.is_ok() {
-            apply_res = self
-                .apply_committed_entries(light_rd.take_committed_entries(), promise)
-                .await;
-        }
+        self.apply_committed_entries(light_rd.take_committed_entries(), promise)
+            .await?;
 
-        match apply_res {
-            Err(e) => {
-                if self.is_leader() {
-                    // The leader replays the UFS logs. If it fails, it logs a warning and doesn't execute `advance_apply`
-                    // in this run. The committed entries remain committed and will be re-applied on the next `on_ready`.
-                    // `advance_apply` is only called after a successful apply, which ensures idempotency across retries.
-                    warn!("apply_committed_entries err {}", e)
-                } else {
-                    return Err(e);
-                }
-            }
-
-            Ok(()) => self.raw.advance_apply(),
-        }
+        self.raw.advance_apply();
 
         // Determine whether a snapshot is needed.
         self.apply_create_snapshot()?;
@@ -584,37 +536,28 @@ where
         Ok(ConfChangeResponse::default())
     }
 
-    async fn apply_propose(&mut self, entry: &Entry) -> RaftResult<ProposeResponse> {
+    async fn apply_propose(&mut self, entry: Entry) -> RaftResult<ProposeResponse> {
         self.storage
-            .apply_propose(self.is_leader(), &entry.data)
+            .apply_propose(false, ApplyMsg::new_entry(entry))
             .await?;
         Ok(ProposeResponse::default())
     }
 
     // Whether you need to create a new snapshot.
     fn apply_create_snapshot(&mut self) -> RaftResult<()> {
-        if !self.storage.can_generate_snapshot() {
+        if self.is_leader() || !self.storage.can_generate_snapshot() {
             return Ok(());
         }
 
-        let last_applied = self.raw.raft.raft_log.applied;
-        let diff = last_applied - self.last_snapshot_index;
-
+        let last_applied = self.storage.get_applied();
+        let diff = last_applied.saturating_sub(self.last_snapshot_applied);
         if (LocalTime::mills() - self.last_snapshot_ms > self.snapshot_interval_ms && diff > 0)
             || diff > self.snapshot_entries
         {
-            if self.is_leader() {
-                self.commit_info
-                    .insert(self.id(), self.raw.raft.raft_log.committed);
-            }
-
-            let raw_compact = *(self.commit_info.values().min().unwrap_or(&0));
-            let compact_id = raw_compact.min(last_applied);
-            self.storage
-                .gen_create_snapshot_job(self.id(), last_applied, compact_id)?;
+            self.storage.gen_create_snapshot_job()?;
 
             self.last_snapshot_ms = LocalTime::mills();
-            self.last_snapshot_index = last_applied;
+            self.last_snapshot_applied = last_applied;
         }
 
         Ok(())
@@ -639,7 +582,7 @@ where
                     .proto_header(rep)
                     .build()
             } else {
-                let rep = self.apply_propose(&entry).await?;
+                let rep = self.apply_propose(entry).await?;
                 Builder::new_rpc(RaftCode::Propose)
                     .response(ResponseStatus::Success)
                     .req_id(req_id)

--- a/curvine-common/src/raft/storage/app_storage.rs
+++ b/curvine-common/src/raft/storage/app_storage.rs
@@ -12,19 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::proto::raft::SnapshotData;
-use crate::raft::RaftResult;
 use std::future::Future;
+
+use raft::StateRole;
+
+use crate::proto::raft::{FsmState, SnapshotData};
+use crate::raft::storage::ApplyMsg;
+use crate::raft::RaftResult;
 
 /// Application layer storage.
 /// Replay raft log
 pub trait AppStorage: Clone + Send + Sync + 'static {
-    fn apply(&self, is_leader: bool, message: &[u8])
+    fn apply(&self, wait: bool, msg: ApplyMsg) -> impl Future<Output = RaftResult<()>> + Send;
+
+    fn get_fsm_state(&self) -> FsmState;
+
+    fn role_change(&self, role: StateRole) -> impl Future<Output = RaftResult<()>> + Send;
+
+    fn create_snapshot(&self) -> impl Future<Output = RaftResult<SnapshotData>> + Send;
+
+    fn apply_snapshot(&self, snapshot: SnapshotData)
         -> impl Future<Output = RaftResult<()>> + Send;
-
-    fn create_snapshot(&self, node_id: u64, last_applied: u64) -> RaftResult<SnapshotData>;
-
-    fn apply_snapshot(&self, snapshot: &SnapshotData) -> RaftResult<()>;
 
     // Get the snapshot to save the directory.
     fn snapshot_dir(&self, snapshot_id: u64) -> RaftResult<String>;

--- a/curvine-common/src/raft/storage/hash_app_storage.rs
+++ b/curvine-common/src/raft/storage/hash_app_storage.rs
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::proto::raft::{FsmState, SnapshotData};
-use crate::raft::storage::AppStorage;
+use crate::proto::raft::{AppliedIndex, FsmState, SnapshotData};
+use crate::raft::storage::{AppStorage, ApplyMsg};
 use crate::raft::{RaftResult, RaftUtils};
 use crate::rocksdb::DBEngine;
 use crate::utils::SerdeUtils;
 use orpc::common::LocalTime;
 use orpc::{try_err, try_option_ref, CommonResult};
+use raft::StateRole;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::collections::HashMap;
@@ -29,6 +30,7 @@ use std::sync::{Arc, Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuar
 #[derive(Clone)]
 pub struct HashAppStorage<K, V> {
     map: Arc<RwLock<HashMap<K, V>>>,
+    fsm_state: Arc<Mutex<FsmState>>,
 }
 
 impl<K, V> Default for HashAppStorage<K, V>
@@ -49,6 +51,7 @@ where
     pub fn new() -> Self {
         Self {
             map: Arc::new(RwLock::new(HashMap::new())),
+            fsm_state: Arc::new(Mutex::new(FsmState::default())),
         }
     }
 
@@ -82,32 +85,52 @@ where
     K: DeserializeOwned + Sized + Serialize + Clone + Hash + Eq + Send + Sync + 'static,
     V: DeserializeOwned + Sized + Serialize + Clone + Send + Sync + 'static,
 {
-    async fn apply(&self, _: bool, message: &[u8]) -> RaftResult<()> {
+    async fn apply(&self, _: bool, msg: ApplyMsg) -> RaftResult<()> {
+        let entry = msg.take_entry();
         let mut map = self.write()?;
-        let pairs: (K, V) = SerdeUtils::deserialize(message)?;
+        let pairs: (K, V) = SerdeUtils::deserialize(&entry.data)?;
         map.insert(pairs.0, pairs.1);
+
+        self.fsm_state.lock().unwrap().applied = AppliedIndex {
+            term: entry.term,
+            index: entry.index,
+            op_id: 0,
+            rpc_id: 0,
+        };
+
         Ok(())
     }
 
-    fn create_snapshot(&self, node_id: u64, snapshot_id: u64) -> RaftResult<SnapshotData> {
+    fn get_fsm_state(&self) -> FsmState {
+        self.fsm_state.lock().unwrap().clone()
+    }
+
+    async fn role_change(&self, _: StateRole) -> RaftResult<()> {
+        Ok(())
+    }
+
+    async fn create_snapshot(&self) -> RaftResult<SnapshotData> {
         let map = self.read()?;
+        let fsm_state = self.get_fsm_state();
         let bytes = SerdeUtils::serialize(&*map)?;
         let data = SnapshotData {
-            snapshot_id,
-            node_id,
+            snapshot_id: fsm_state.applied.index,
+            node_id: 0,
             create_time: LocalTime::mills(),
             bytes_data: Some(bytes),
             files_data: None,
-            fsm_state: Default::default(),
+            fsm_state,
         };
+
         Ok(data)
     }
 
-    fn apply_snapshot(&self, data: &SnapshotData) -> RaftResult<()> {
-        let data = try_option_ref!(data.bytes_data);
+    async fn apply_snapshot(&self, snapshot: SnapshotData) -> RaftResult<()> {
+        let data = try_option_ref!(snapshot.bytes_data);
         let new: HashMap<K, V> = SerdeUtils::deserialize(data)?;
         let mut map = self.write()?;
         let _ = std::mem::replace(&mut *map, new);
+        *self.fsm_state.lock().unwrap() = snapshot.fsm_state;
         Ok(())
     }
 
@@ -119,6 +142,7 @@ where
 #[derive(Clone)]
 pub struct RocksAppStorage<K, V> {
     db: Arc<Mutex<DBEngine>>,
+    fsm_state: Arc<Mutex<FsmState>>,
     _k: PhantomData<K>,
     _v: PhantomData<V>,
 }
@@ -132,6 +156,7 @@ where
         let db = DBEngine::from_dir(dir, true).unwrap();
         Self {
             db: Arc::new(Mutex::new(db)),
+            fsm_state: Arc::new(Mutex::new(FsmState::default())),
             _k: Default::default(),
             _v: Default::default(),
         }
@@ -162,27 +187,47 @@ where
     K: Serialize + DeserializeOwned + Clone + Sync + Send + 'static,
     V: Serialize + DeserializeOwned + Clone + Sync + Send + 'static,
 {
-    async fn apply(&self, _: bool, message: &[u8]) -> RaftResult<()> {
+    async fn apply(&self, _: bool, msg: ApplyMsg) -> RaftResult<()> {
+        let entry = msg.take_entry();
         let db = self.lock()?;
-        let pairs: (K, V) = SerdeUtils::deserialize(message)?;
+        let pairs: (K, V) = SerdeUtils::deserialize(&entry.data)?;
         let k = SerdeUtils::serialize(&pairs.0)?;
         let v = SerdeUtils::serialize(&pairs.1)?;
         db.put(k, v)?;
+
+        self.fsm_state.lock().unwrap().applied = AppliedIndex {
+            term: entry.term,
+            index: entry.index,
+            op_id: 0,
+            rpc_id: 0,
+        };
+
+        Ok(())
+    }
+
+    fn get_fsm_state(&self) -> FsmState {
+        self.fsm_state.lock().unwrap().clone()
+    }
+
+    async fn role_change(&self, _role: StateRole) -> RaftResult<()> {
         Ok(())
     }
 
     // Create a snapshot.
-    fn create_snapshot(&self, node_id: u64, snapshot_id: u64) -> RaftResult<SnapshotData> {
+    async fn create_snapshot(&self) -> RaftResult<SnapshotData> {
         let db = self.lock()?;
-        let dir = db.create_checkpoint(snapshot_id)?;
-        let data = RaftUtils::create_file_snapshot(dir, node_id, FsmState::default())?;
+        let fsm_state = self.get_fsm_state();
+        let dir = db.create_checkpoint(fsm_state.applied.index)?;
+        let data = RaftUtils::create_file_snapshot(dir, 0, fsm_state)?;
         Ok(data)
     }
 
-    fn apply_snapshot(&self, data: &SnapshotData) -> RaftResult<()> {
+    async fn apply_snapshot(&self, data: SnapshotData) -> RaftResult<()> {
         let mut db = self.lock()?;
         let files = try_option_ref!(data.files_data);
-        RaftUtils::apply_rocks_snapshot(&mut db, files)
+        RaftUtils::apply_rocks_snapshot(&mut db, files)?;
+        *self.fsm_state.lock().unwrap() = data.fsm_state;
+        Ok(())
     }
 
     fn snapshot_dir(&self, snapshot_id: u64) -> RaftResult<String> {

--- a/curvine-common/src/raft/storage/log_storage.rs
+++ b/curvine-common/src/raft/storage/log_storage.rs
@@ -46,7 +46,7 @@ pub trait LogStorage: Storage + Clone + Send + Sync + 'static {
     fn set_conf_state(&self, conf_state: &ConfState) -> RaftResult<()>;
 
     /// Create a new snapshot.
-    fn create_snapshot(&self, data: SnapshotData, request_index: u64) -> RaftResult<()>;
+    fn create_snapshot(&self, data: SnapshotData) -> RaftResult<()>;
 
     /// The state machine used to apply snapshots to nodes.
     /// When the node needs to restore state from the snapshot, it calls this method.

--- a/curvine-common/src/raft/storage/mem_log_storage.rs
+++ b/curvine-common/src/raft/storage/mem_log_storage.rs
@@ -72,8 +72,8 @@ impl LogStorage for MemLogStorage {
         Ok(())
     }
 
-    fn create_snapshot(&self, data: SnapshotData, request_index: u64) -> RaftResult<()> {
-        let mut snapshot = self.core.snapshot(request_index, 0)?;
+    fn create_snapshot(&self, data: SnapshotData) -> RaftResult<()> {
+        let mut snapshot = self.core.snapshot(data.fsm_state.applied.index, 0)?;
         snapshot.set_data(data.encode_to_vec());
 
         let mut sn = self.snapshot.lock().unwrap();

--- a/curvine-common/src/raft/storage/peer_storage.rs
+++ b/curvine-common/src/raft/storage/peer_storage.rs
@@ -13,23 +13,24 @@
 // limitations under the License.
 
 use crate::conf::JournalConf;
-use crate::proto::raft::SnapshotData;
+use crate::proto::raft::{FsmState, SnapshotData};
 use crate::raft::snapshot::{DownloadJob, SnapshotState};
-use crate::raft::storage::{AppStorage, LogStorage};
+use crate::raft::storage::{AppStorage, ApplyMsg, LogStorage};
 use crate::raft::{LibRaftResult, RaftClient, RaftError, RaftResult};
 use log::{error, info, warn};
 use orpc::common::{TimeSpent, Utils};
 use orpc::err_box;
-use orpc::runtime::{GroupExecutor, JobCtl, JobState};
+use orpc::runtime::{GroupExecutor, JobCtl, JobState, RpcRuntime, Runtime};
 use prost::Message;
 use raft::eraftpb::{ConfState, Entry, HardState, Snapshot};
-use raft::{GetEntriesContext, RaftState, Storage};
+use raft::{GetEntriesContext, RaftState, StateRole, Storage};
 use std::sync::{Arc, Mutex};
 
 // raft log packaging class
 // Unify the access interfaces of app_store and log_store. Convenient to code use.
 #[derive(Clone)]
 pub struct PeerStorage<A, B> {
+    rt: Arc<Runtime>,
     log_store: A,
     app_store: B,
     conf: JournalConf,
@@ -43,10 +44,17 @@ where
     A: LogStorage,
     B: AppStorage,
 {
-    pub fn new(log_store: A, app_store: B, client: RaftClient, conf: &JournalConf) -> Self {
+    pub fn new(
+        rt: Arc<Runtime>,
+        log_store: A,
+        app_store: B,
+        client: RaftClient,
+        conf: &JournalConf,
+    ) -> Self {
         let executor = GroupExecutor::new("raft-job-executor", conf.worker_threads, 10);
 
         Self {
+            rt,
             log_store,
             app_store,
             conf: conf.clone(),
@@ -64,6 +72,14 @@ where
         self.log_store.set_entries(entries)
     }
 
+    pub fn get_fsm_state(&self) -> FsmState {
+        self.app_store.get_fsm_state()
+    }
+
+    pub fn get_applied(&self) -> u64 {
+        self.get_fsm_state().applied.index
+    }
+
     pub fn set_hard_state(&self, hard_state: &HardState) -> RaftResult<()> {
         self.log_store.set_hard_state(hard_state)
     }
@@ -76,8 +92,13 @@ where
         self.log_store.set_conf_state(conf_state)
     }
 
-    pub async fn apply_propose(&self, is_leader: bool, data: &[u8]) -> RaftResult<()> {
-        self.app_store.apply(is_leader, data).await
+    pub async fn apply_propose(&self, wait: bool, apply_msg: ApplyMsg) -> RaftResult<()> {
+        self.app_store.apply(wait, apply_msg).await
+    }
+
+    /// Scan log entries in [low, high). Used to get committed-but-not-applied entries for replay.
+    pub fn scan_entries(&self, low: u64, high: u64) -> RaftResult<Vec<Entry>> {
+        self.log_store.scan_entries(low, high)
     }
 
     fn check_snapshot_state(&self) -> SnapshotState {
@@ -137,6 +158,10 @@ where
         }
     }
 
+    pub async fn role_change(&self, role: StateRole) -> RaftResult<()> {
+        self.app_store.role_change(role).await
+    }
+
     pub fn gen_apply_snapshot_job(&self, snapshot: Snapshot) -> RaftResult<()> {
         if self.is_snapshot_applying() {
             return err_box!("Currently applying snapshot");
@@ -144,6 +169,7 @@ where
 
         let log_store = self.log_store.clone();
         let app_store = self.app_store.clone();
+        let rt = self.rt.clone();
 
         let job_ctl = JobCtl::new();
         let mut snap_state = self.snap_state.lock().unwrap();
@@ -153,16 +179,22 @@ where
         let conf = self.conf.clone();
         let executor = self.executor.clone();
         let job = move || {
-            let mut data = SnapshotData::decode(snapshot.get_data())?;
+            let mut snap_data = SnapshotData::decode(snapshot.get_data())?;
             let mut spend = TimeSpent::new();
 
             // Start downloading the snapshot.
-            match data.files_data {
+            match snap_data.files_data {
                 None => panic!("Not found snapshot data"),
                 Some(ref mut files) => {
                     let dir = app_store.snapshot_dir(Utils::rand_id())?;
-                    let mut download_job =
-                        DownloadJob::new(executor, data.node_id, dir, files.clone(), &conf, client);
+                    let mut download_job = DownloadJob::new(
+                        executor,
+                        snap_data.node_id,
+                        dir,
+                        files.clone(),
+                        &conf,
+                        client,
+                    );
 
                     // Modify the data in the local directory.
                     files.dir = download_job.run()?;
@@ -170,9 +202,6 @@ where
             }
             let download_ms = spend.used_ms();
             spend.reset();
-
-            // Install snapshot.
-            let snapshot_meta = snapshot.metadata.clone();
 
             if let Err(e) = log_store.apply_snapshot(snapshot) {
                 return if e.is_snapshot_out_of_date() {
@@ -183,12 +212,12 @@ where
                 };
             }
 
-            app_store.apply_snapshot(&data)?;
+            rt.block_on(app_store.apply_snapshot(snap_data.clone()))?;
             let apply_ms = spend.used_ms();
 
             info!(
-                "Apply snapshot, meta: {:?}, download used {} ms, apply used {} ms",
-                snapshot_meta, download_ms, apply_ms
+                "Apply snapshot, snap_data: {:?}, download used {} ms, apply used {} ms",
+                snap_data, download_ms, apply_ms
             );
 
             Ok::<(), RaftError>(())
@@ -197,18 +226,14 @@ where
         self.spawn_job(job, job_ctl)
     }
 
-    pub fn gen_create_snapshot_job(
-        &self,
-        node_id: u64,
-        last_applied: u64,
-        compact_id: u64,
-    ) -> RaftResult<()> {
+    pub fn gen_create_snapshot_job(&self) -> RaftResult<()> {
         if !self.can_generate_snapshot() {
             return err_box!("Currently creating snapshot");
         }
 
         let log_store = self.log_store.clone();
         let app_store = self.app_store.clone();
+        let rt = self.rt.clone();
 
         let job_ctl = JobCtl::new();
         let mut snap_state = self.snap_state.lock().unwrap();
@@ -217,16 +242,13 @@ where
         let job = move || {
             let cost = TimeSpent::new();
 
-            let snapshot = app_store.create_snapshot(node_id, last_applied)?;
-            let snapshot_id = snapshot.snapshot_id;
-            log_store.create_snapshot(snapshot, last_applied)?;
-            log_store.compact(compact_id)?;
+            let snap_data = rt.block_on(app_store.create_snapshot())?;
+            log_store.create_snapshot(snap_data.clone())?;
+            log_store.compact(snap_data.fsm_state.compact())?;
 
             info!(
-                "Create new snapshot, snapshot_id {}, last_applied {}, compact_id {}, used {} ms",
-                snapshot_id,
-                last_applied,
-                compact_id,
+                "create new snapshot, snap_data {:?}, used {} ms",
+                snap_data,
                 cost.used_ms()
             );
             Ok::<(), RaftError>(())

--- a/curvine-common/src/raft/storage/rocks_log_storage.rs
+++ b/curvine-common/src/raft/storage/rocks_log_storage.rs
@@ -16,7 +16,6 @@ use crate::conf::JournalConf;
 use crate::proto::raft::SnapshotData;
 use crate::raft::storage::{LogStorage, RocksStorageCore};
 use crate::raft::{LibRaftResult, RaftError, RaftResult};
-use prost::Message;
 use raft::eraftpb::{ConfState, Entry, HardState, Snapshot};
 use raft::util::limit_size;
 use raft::{GetEntriesContext, RaftState, Storage};
@@ -58,6 +57,10 @@ impl RocksLogStorage {
     pub fn clone_store(&self) -> Arc<RwLock<RocksStorageCore>> {
         self.core.clone()
     }
+
+    pub fn hard_state(&self) -> HardState {
+        self.core.read().unwrap().hard_state().clone()
+    }
 }
 
 impl LogStorage for RocksLogStorage {
@@ -91,9 +94,9 @@ impl LogStorage for RocksLogStorage {
         store.set_conf_state(conf_state.clone())
     }
 
-    fn create_snapshot(&self, data: SnapshotData, request_index: u64) -> RaftResult<()> {
+    fn create_snapshot(&self, data: SnapshotData) -> RaftResult<()> {
         let store = self.read();
-        let _ = store.create_snapshot(data.encode_to_vec(), request_index)?;
+        let _ = store.create_snapshot(data)?;
         Ok(())
     }
 

--- a/curvine-common/src/raft/storage/rocks_storage_core.rs
+++ b/curvine-common/src/raft/storage/rocks_storage_core.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::proto::raft::SnapshotData;
 use crate::raft::{RaftError, RaftResult, LOG_START_INDEX};
 use crate::rocksdb::{DBConf, DBEngine, RocksUtils, WriteBatch};
 use log::warn;
@@ -40,6 +41,7 @@ impl RocksStorageCore {
     pub const SNAP_KEY: &'static [u8] = &[0x01u8];
     // Save index range。
     pub const INDEX_KEY: &'static [u8] = &[0x02u8];
+    pub const STATE_KEY: &'static [u8] = &[0x03u8];
 
     pub fn new<T: AsRef<str>>(dir: T, format: bool) -> Self {
         let conf = DBConf::new(dir)
@@ -59,10 +61,13 @@ impl RocksStorageCore {
             get_entries_context: None,
         };
 
-        // Readfirst_index，last_index
         if let Some((first, last)) = core.get_index_range().unwrap() {
             core.first_index = Some(first);
             core.last_index = Some(last);
+        }
+
+        if let Some(data) = core.db.get_cf(Self::CF_META, Self::STATE_KEY).unwrap() {
+            core.raft_state.hard_state = HardState::decode(data.as_ref()).unwrap_or_default();
         }
 
         core
@@ -99,7 +104,9 @@ impl RocksStorageCore {
     }
 
     pub fn set_hard_state(&mut self, hs: HardState) -> RaftResult<()> {
-        self.raft_state.hard_state = hs;
+        self.raft_state.hard_state = hs.clone();
+        self.db
+            .put_cf(Self::CF_META, Self::STATE_KEY, hs.encode_to_vec())?;
         Ok(())
     }
 
@@ -159,27 +166,39 @@ impl RocksStorageCore {
 
         self.snapshot_metadata = meta.clone();
         self.raft_state.hard_state.term = cmp::max(self.raft_state.hard_state.term, meta.term);
-        self.raft_state.hard_state.commit = index;
+        self.raft_state.hard_state.commit = cmp::max(self.raft_state.hard_state.commit, index);
         self.raft_state.conf_state = meta.get_conf_state().clone();
 
         Ok(())
     }
 
-    pub fn create_snapshot(&self, data: Vec<u8>, request_index: u64) -> RaftResult<Snapshot> {
+    pub fn create_snapshot(&self, data: SnapshotData) -> RaftResult<Snapshot> {
+        let request_index = data.fsm_state.applied.index;
+
         let mut snapshot = Snapshot::default();
-        snapshot.set_data(data);
+        snapshot.set_data(data.encode_to_vec());
         let meta = snapshot.mut_metadata();
-        meta.index = self.raft_state.hard_state.commit.min(request_index);
+
+        if request_index > self.raft_state.hard_state.commit {
+            return err_box!(
+                "snapshot temporarily unavailable: request_index {}, hard_state {:?}",
+                request_index,
+                self.raft_state.hard_state
+            );
+        }
+
+        meta.index = request_index;
         meta.term = match meta.index.cmp(&self.snapshot_metadata.index) {
             cmp::Ordering::Equal => self.snapshot_metadata.term,
             cmp::Ordering::Greater => {
-                let entry = self.get_check(meta.index).unwrap();
+                let entry = self.get_check(meta.index)?;
                 entry.term
             }
             cmp::Ordering::Less => {
-                panic!(
+                return err_box!(
                     "commit {} < snapshot_metadata.index {}",
-                    meta.index, self.snapshot_metadata.index
+                    meta.index,
+                    self.snapshot_metadata.index
                 );
             }
         };

--- a/curvine-common/tests/raft_node_test.rs
+++ b/curvine-common/tests/raft_node_test.rs
@@ -76,7 +76,7 @@ fn rocks_snap_test() -> CommonResult<()> {
     let snap = core.write().unwrap().last_snapshot()?;
     let store_snap: HashAppStorage<String, String> = HashAppStorage::new();
     let data: SnapshotData = SnapshotData::decode(snap.get_data())?;
-    store_snap.apply_snapshot(&data)?;
+    rt.block_on(store_snap.apply_snapshot(data))?;
     assert_eq!(store_snap.len(), 10);
 
     Ok(())

--- a/curvine-server/src/master/journal/journal_loader.rs
+++ b/curvine-server/src/master/journal/journal_loader.rs
@@ -21,7 +21,7 @@ use crate::master::{JobManager, MountManager, SyncFsDir};
 use curvine_common::conf::JournalConf;
 use curvine_common::error::FsError;
 use curvine_common::proto::raft::{FsmState, SnapshotData};
-use curvine_common::raft::storage::AppStorage;
+use curvine_common::raft::storage::{AppStorage, ApplyMsg};
 use curvine_common::raft::{RaftResult, RaftUtils};
 use curvine_common::state::RenameFlags;
 use curvine_common::utils::SerdeUtils;
@@ -29,9 +29,11 @@ use log::{debug, error, info, warn};
 use orpc::common::FileUtils;
 use orpc::sync::AtomicCounter;
 use orpc::{err_box, try_option, try_option_ref, CommonResult};
+use raft::StateRole;
 use std::path::Path;
 use std::sync::Arc;
 use std::{fs, mem};
+
 // Replay the master metadata operation log.
 #[derive(Clone)]
 pub struct JournalLoader {
@@ -355,8 +357,8 @@ impl JournalLoader {
 }
 
 impl AppStorage for JournalLoader {
-    async fn apply(&self, is_leader: bool, message: &[u8]) -> RaftResult<()> {
-        match self.apply0(is_leader, message).await {
+    async fn apply(&self, wait: bool, msg: ApplyMsg) -> RaftResult<()> {
+        match self.apply0(wait, &msg.take_entry().data[..]).await {
             Ok(_) => Ok(()),
 
             Err(e) => {
@@ -370,11 +372,19 @@ impl AppStorage for JournalLoader {
         }
     }
 
+    fn get_fsm_state(&self) -> FsmState {
+        FsmState::default()
+    }
+
+    async fn role_change(&self, _: StateRole) -> RaftResult<()> {
+        Ok(())
+    }
+
     // Call rocksdb's API to create a snapshot.
-    fn create_snapshot(&self, node_id: u64, last_applied: u64) -> RaftResult<SnapshotData> {
+    async fn create_snapshot(&self) -> RaftResult<SnapshotData> {
         let fs_dir = self.fs_dir.read();
-        let dir = fs_dir.create_checkpoint(last_applied)?;
-        let data = RaftUtils::create_file_snapshot(&dir, node_id, FsmState::default())?;
+        let dir = fs_dir.create_checkpoint(0)?;
+        let data = RaftUtils::create_file_snapshot(&dir, 0, FsmState::default())?;
 
         // Delete historical snapshots.
         if let Err(e) = self.purge_checkpoint(&dir) {
@@ -383,7 +393,7 @@ impl AppStorage for JournalLoader {
         Ok(data)
     }
 
-    fn apply_snapshot(&self, snapshot: &SnapshotData) -> RaftResult<()> {
+    async fn apply_snapshot(&self, snapshot: SnapshotData) -> RaftResult<()> {
         {
             let mut fs_dir = self.fs_dir.write();
             let data = try_option_ref!(snapshot.files_data);

--- a/curvine-server/src/master/journal/journal_system.rs
+++ b/curvine-server/src/master/journal/journal_system.rs
@@ -202,7 +202,9 @@ impl JournalSystem {
 
     // Create a snapshot manually, dedicated for testing.
     pub fn create_snapshot(&self) -> RaftResult<()> {
-        let data = self.raft_journal.app_store().create_snapshot(1, 1)?;
+        let data = self
+            .rt
+            .block_on(self.raft_journal.app_store().create_snapshot())?;
 
         // The test will not generate a raft log. Please modify the status here.
         let entry = Entry {
@@ -213,13 +215,14 @@ impl JournalSystem {
         self.raft_journal.log_store().append(&[entry])?;
         self.raft_journal.log_store().set_hard_state_commit(1)?;
 
-        self.raft_journal.log_store().create_snapshot(data, 0)
+        self.raft_journal.log_store().create_snapshot(data)
     }
 
     // Manually apply a snapshot, dedicated for testing.
     pub fn apply_snapshot(&self) -> RaftResult<()> {
         let snapshot = self.raft_journal.log_store().snapshot(0, 0)?;
         let data = SnapshotData::decode(snapshot.get_data())?;
-        self.raft_journal.app_store().apply_snapshot(&data)
+        self.rt
+            .block_on(self.raft_journal.app_store().apply_snapshot(data))
     }
 }


### PR DESCRIPTION
### Summary

This PR refactors the Raft storage layer (`AppStorage`, `LogStorage`,
`PeerStorage`, `RaftNode`) to establish a cleaner, fully-async contract
between the Raft consensus engine and the application state machine
(`JournalLoader`).

The main motivation is to unblock follow-on work such as:

- Leader/follower role-change callbacks (needed to fix inode_id drift
  after a leader switch — see related issue)
- Structured apply messages (`ApplyMsg`) carrying typed metadata rather
  than raw byte slices
- FSM state (`FsmState`) as a first-class concept surfaced through the
  trait boundary

### Changes

#### `AppStorage` trait (`app_storage.rs`)

| Before | After |
|---|---|
| `apply(is_leader: bool, message: &[u8])` | `apply(wait: bool, msg: ApplyMsg)` |
| `create_snapshot(node_id, last_applied) -> SnapshotData` | `async create_snapshot() -> SnapshotData` |
| `apply_snapshot(&SnapshotData)` | `async apply_snapshot(SnapshotData)` |
| *(absent)* | `get_fsm_state() -> FsmState` |
| *(absent)* | `async role_change(StateRole)` |

#### `PeerStorage` (`peer_storage.rs`)

- Added `rt: Arc<Runtime>` field so background snapshot jobs can call
  `rt.block_on(...)` on async app-store methods.
- Added `role_change()`, `scan_entries()`, `get_fsm_state()`,
  `get_applied()` delegation helpers.
- Simplified `gen_create_snapshot_job`: no longer requires the caller to
  pass `node_id`, `last_applied`, and `compact_id`; the snapshot job
  derives those from `FsmState`.
- Updated `gen_apply_snapshot_job` to call the new async
  `apply_snapshot` via `rt.block_on`.

#### `RaftNode` (`raft_node.rs`)

- Removed the `commit_info: HashMap<NodeId, u64>` tracking map (was
  unused after prior cleanup).
- Renamed `last_snapshot_index` → `last_snapshot_applied` for clarity.
- `install_snapshot` now calls the async `apply_snapshot` and reads
  `get_fsm_state()` to determine the last applied index, replacing the
  previous approach of reading snapshot metadata directly.
- `apply_create_snapshot` no longer manually assembles snapshot
  parameters; delegates entirely to `gen_create_snapshot_job`.
- Propagates `rt` into `PeerStorage::new`.

#### `LogStorage` (`log_storage.rs` / `rocks_log_storage.rs`)

- `create_snapshot` now takes `SnapshotData` directly instead of
  `(SnapshotData, last_applied)`.

#### `JournalLoader` (`journal_loader.rs`)

- Implements the new trait methods (`get_fsm_state`, `role_change`).
- `apply` now unpacks `ApplyMsg` to extract the raw entry bytes,
  preserving existing replay logic.
- `create_snapshot` / `apply_snapshot` updated to match the new async
  signatures.
