### PR TITLE
refactor(journal): async apply pipeline and op_id-based deduplication

### DIFF
--- a/curvine-common/src/conf/journal_conf.rs
+++ b/curvine-common/src/conf/journal_conf.rs
@@ -99,6 +99,7 @@ pub struct JournalConf {
     // The number of checkpoints saved.
     pub retain_checkpoint_num: usize,
 
+    pub ignore_reply_error: bool,
     pub cv_error_retry: bool,
     pub ufs_error_retry: bool,
     pub max_retry_num: u64,
@@ -239,6 +240,7 @@ impl Default for JournalConf {
 
             retain_checkpoint_num: 3,
 
+            ignore_reply_error: false,
             ufs_error_retry: true,
             cv_error_retry: false,
             max_retry_num: 1000,

--- a/curvine-common/src/raft/mod.rs
+++ b/curvine-common/src/raft/mod.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::proto::raft::FsmState;
+use crate::proto::raft::{FsmState, SnapshotData};
 use raft::eraftpb;
 
 mod raft_node;
@@ -75,5 +75,14 @@ impl FsmState {
 
     pub fn op_id(&self) -> u64 {
         self.applied.op_id.max(self.ufs_applied.op_id)
+    }
+}
+
+impl SnapshotData {
+    pub fn data_dir(&self) -> String {
+        match &self.files_data {
+            Some(files_data) => files_data.dir.clone(),
+            None => "".to_string(),
+        }
     }
 }

--- a/curvine-common/src/raft/raft_group.rs
+++ b/curvine-common/src/raft/raft_group.rs
@@ -45,6 +45,17 @@ impl RaftGroup {
         Self::new(conf.group_name.as_str(), peers)
     }
 
+    pub fn get_addr_string(&self, id: u64) -> String {
+        match self.peers.get(&id) {
+            None => format!("{}", id),
+            Some(v) => format!("{}", v),
+        }
+    }
+
+    pub fn voters(&self) -> Vec<u64> {
+        self.peers.iter().map(|x| *x.0).collect()
+    }
+
     pub fn from_proto<T: AsRef<str>>(name: T, list: Vec<RaftPeerProto>) -> Self {
         let mut peers = HashMap::new();
         for item in list {

--- a/curvine-common/src/raft/raft_node.rs
+++ b/curvine-common/src/raft/raft_node.rs
@@ -30,7 +30,7 @@ use orpc::try_err;
 use prost::Message as PMessage;
 use raft::eraftpb::{ConfChange, Entry, EntryType, MessageType, Snapshot};
 use raft::prelude::ConfChangeType;
-use raft::RawNode;
+use raft::{RawNode, SoftState};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -92,7 +92,6 @@ where
     ) -> RaftResult<Self> {
         let group = RaftGroup::from_conf(conf);
         let id = group.get_node_id(&conf.local_addr())?;
-        let voters = group.peers.iter().map(|x| *x.0).collect();
 
         let client = RaftClient::new(rt.clone(), &group, conf.new_client_conf());
         let snapshot_interval_ms = DurationUnit::from_str(&conf.snapshot_interval)
@@ -102,7 +101,7 @@ where
         let tick_interval = Duration::from_millis(conf.raft_tick_interval_ms);
         let poll_interval = Duration::from_millis(conf.raft_poll_interval_ms);
 
-        let last_applied = Self::install_snapshot(&log_store, &app_store, voters).await?;
+        let last_applied = Self::install_snapshot(&log_store, &app_store, group.voters()).await?;
         let config = conf.new_raft_conf(id, last_applied);
         config.validate()?;
 
@@ -186,13 +185,13 @@ where
     ) -> RaftResult<u64> {
         let spend = TimeSpent::new();
 
-        let fsm_state: FsmState = match log_store.latest_snapshot()? {
+        match log_store.latest_snapshot()? {
             None => {
                 let mut snapshot = Snapshot::default();
                 snapshot.mut_metadata().mut_conf_state().voters = voters;
 
                 log_store.apply_snapshot(snapshot.clone())?;
-                FsmState::default()
+                app_store.apply_snapshot(SnapshotData::default()).await?;
             }
 
             Some(mut snapshot) => {
@@ -201,21 +200,23 @@ where
                 log_store.apply_snapshot(snapshot.clone())?;
                 // app store app snapshot.
                 let snapshot_data: SnapshotData = SnapshotData::decode(snapshot.get_data())?;
+
                 info!(
-                    "install snapshot start, meta: {:?}, snapshot data {:?}",
-                    snapshot.get_metadata(),
-                    snapshot_data
+                    "install snapshot start, dir: {}, fsm_state {:?}",
+                    snapshot_data.data_dir(),
+                    snapshot_data.fsm_state
                 );
+
                 app_store.apply_snapshot(snapshot_data).await?;
 
-                app_store.get_fsm_state()
+                info!("install snapshot end, cost {} ms", spend.used_ms());
             }
         };
 
+        let fsm_state = app_store.get_fsm_state();
         app_store
             .apply(true, ApplyMsg::new_scan(fsm_state.applied))
             .await?;
-        info!("install snapshot end, cost {} ms", spend.used_ms());
         Ok(app_store.get_fsm_state().applied.index)
     }
 
@@ -404,15 +405,10 @@ where
             store.set_hard_state(hs)?;
         }
 
-        if let Some(ss) = ready.ss() {
-            info!(
-                "Raft soft state change, node id {}, current leader {}",
-                self.id(),
-                self.leader()
-            );
-            self.role_monitor.advance_role(ss);
-            self.storage.role_change(ss.raft_state).await?;
-        }
+        let soft_state = ready.ss().map(|ss| SoftState {
+            leader_id: ss.leader_id,
+            raft_state: ss.raft_state,
+        });
 
         // Get the message that needs to be sent to other nodes.
         // Only the leader call returns true.
@@ -458,9 +454,29 @@ where
 
         self.raw.advance_apply();
 
-        // Determine whether a snapshot is needed.
-        self.apply_create_snapshot()?;
+        if let Some(ss) = soft_state {
+            info!(
+                "raft state change, current leader {}, node {}",
+                self.group.get_addr_string(self.leader()),
+                self.group.get_addr_string(self.id()),
+            );
 
+            self.storage.role_change(ss.raft_state).await?;
+            let to_follower = self.role_monitor.is_leader() && !self.is_leader();
+            if to_follower {
+                Self::install_snapshot(
+                    &self.storage.log_store,
+                    &self.storage.app_store,
+                    self.group.voters(),
+                )
+                .await?;
+            }
+
+            self.role_monitor.advance_role(&ss);
+        } else {
+            // Determine whether a snapshot is needed.
+            self.apply_create_snapshot()?;
+        }
         Ok(())
     }
 

--- a/curvine-common/src/raft/role_monitor.rs
+++ b/curvine-common/src/raft/role_monitor.rs
@@ -55,6 +55,10 @@ impl RoleMonitor {
         }
     }
 
+    pub fn is_leader(&self) -> bool {
+        self.state() == RoleState::Leader
+    }
+
     pub fn advance_exit(&self) {
         self.0.advance_state(RoleState::Exit, true);
     }

--- a/curvine-common/src/raft/storage/apply_msg.rs
+++ b/curvine-common/src/raft/storage/apply_msg.rs
@@ -21,7 +21,8 @@ use raft::StateRole;
 pub enum ApplyMsg {
     Entry(Entry),
     Scan(AppliedIndex),
-    Snapshot(CallSender<RaftResult<SnapshotData>>),
+    CreateSnapshot(CallSender<RaftResult<SnapshotData>>),
+    ApplySnapshot((CallSender<RaftResult<()>>, SnapshotData)),
     RoleChange(StateRole),
 }
 

--- a/curvine-common/src/raft/storage/peer_storage.rs
+++ b/curvine-common/src/raft/storage/peer_storage.rs
@@ -31,8 +31,8 @@ use std::sync::{Arc, Mutex};
 #[derive(Clone)]
 pub struct PeerStorage<A, B> {
     rt: Arc<Runtime>,
-    log_store: A,
-    app_store: B,
+    pub(crate) log_store: A,
+    pub(crate) app_store: B,
     conf: JournalConf,
     executor: Arc<GroupExecutor>,
     snap_state: Arc<Mutex<SnapshotState>>,
@@ -247,8 +247,9 @@ where
             log_store.compact(snap_data.fsm_state.compact())?;
 
             info!(
-                "create new snapshot, snap_data {:?}, used {} ms",
-                snap_data,
+                "create new snapshot, dir {}, fsm_state: {:?}, used {} ms",
+                snap_data.data_dir(),
+                snap_data.fsm_state,
                 cost.used_ms()
             );
             Ok::<(), RaftError>(())

--- a/curvine-server/src/master/journal/entry.rs
+++ b/curvine-server/src/master/journal/entry.rs
@@ -19,28 +19,32 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct MkdirEntry {
-    pub(crate) op_ms: u64,
+    pub(crate) op_id: u64,
+    pub(crate) rpc_id: i64,
     pub(crate) path: String,
     pub(crate) dir: InodeDir,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct CreateFileEntry {
-    pub(crate) op_ms: u64,
+    pub(crate) op_id: u64,
+    pub(crate) rpc_id: i64,
     pub(crate) path: String,
     pub(crate) file: InodeFile,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct ReopenFileEntry {
-    pub(crate) op_ms: u64,
+    pub(crate) op_id: u64,
+    pub(crate) rpc_id: i64,
     pub(crate) path: String,
     pub(crate) file: InodeFile,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct OverWriteFileEntry {
-    pub(crate) op_ms: u64,
+    pub(crate) op_id: u64,
+    pub(crate) rpc_id: i64,
     pub(crate) path: String,
     pub(crate) file: InodeFile,
 }
@@ -48,7 +52,8 @@ pub struct OverWriteFileEntry {
 // Apply for a new block
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct AddBlockEntry {
-    pub(crate) op_ms: u64,
+    pub(crate) op_id: u64,
+    pub(crate) rpc_id: i64,
     pub(crate) path: String,
     pub(crate) blocks: Vec<BlockMeta>,
     pub(crate) commit_block: Vec<CommitBlock>,
@@ -57,7 +62,8 @@ pub struct AddBlockEntry {
 // File writing is completed.
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct CompleteFileEntry {
-    pub(crate) op_ms: u64,
+    pub(crate) op_id: u64,
+    pub(crate) rpc_id: i64,
     pub(crate) path: String,
     pub(crate) file: InodeFile,
     pub(crate) commit_blocks: Vec<CommitBlock>,
@@ -66,16 +72,19 @@ pub struct CompleteFileEntry {
 // Rename
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct RenameEntry {
-    pub(crate) op_ms: u64,
+    pub(crate) op_id: u64,
+    pub(crate) rpc_id: i64,
     pub(crate) src: String,
     pub(crate) dst: String,
     pub(crate) mtime: i64,
     pub(crate) flags: u32,
 }
+
 // delete
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct DeleteEntry {
-    pub(crate) op_ms: u64,
+    pub(crate) op_id: u64,
+    pub(crate) rpc_id: i64,
     pub(crate) path: String,
     pub(crate) mtime: i64,
 }
@@ -83,29 +92,33 @@ pub struct DeleteEntry {
 // mount
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct MountEntry {
-    pub(crate) op_ms: u64,
+    pub(crate) op_id: u64,
+    pub(crate) rpc_id: i64,
     pub(crate) info: MountInfo,
 }
 
 // umount
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct UnMountEntry {
-    pub(crate) op_ms: u64,
+    pub(crate) op_id: u64,
+    pub(crate) rpc_id: i64,
     pub(crate) id: u32,
 }
 
 // set attr
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct SetAttrEntry {
-    pub(crate) op_ms: u64,
+    pub(crate) op_id: u64,
+    pub(crate) rpc_id: i64,
     pub(crate) path: String,
     pub(crate) opts: SetAttrOpts,
 }
 
-// set attr
+// symlink
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct SymlinkEntry {
-    pub(crate) op_ms: u64,
+    pub(crate) op_id: u64,
+    pub(crate) rpc_id: i64,
     pub(crate) link: String,
     pub(crate) new_inode: InodeFile,
     pub(crate) force: bool,
@@ -113,23 +126,44 @@ pub struct SymlinkEntry {
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct LinkEntry {
-    pub(crate) op_ms: u64,
+    pub(crate) op_id: u64,
+    pub(crate) rpc_id: i64,
+    /// Link creation time, used during replay to set inode mtime.
+    pub(crate) mtime: i64,
     pub(crate) src_path: String,
     pub(crate) dst_path: String,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct SetLocksEntry {
-    pub(crate) op_ms: u64,
+    pub(crate) op_id: u64,
+    pub(crate) rpc_id: i64,
     pub(crate) ino: i64,
     pub(crate) locks: Vec<FileLock>,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct FreeEntry {
-    pub(crate) op_ms: u64,
+    pub(crate) op_id: u64,
+    pub(crate) rpc_id: i64,
     pub(crate) path: String,
     pub(crate) mtime: i64,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct UfsAppliedEntry {
+    pub(crate) op_id: u64,
+    pub(crate) rpc_id: i64,
+    pub(crate) term: u64,
+    pub(crate) index: u64,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct SnapshotEntry {
+    pub(crate) op_id: u64,
+    pub(crate) rpc_id: i64,
+    pub(crate) node_id: u64,
+    pub(crate) dir: String,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -149,6 +183,67 @@ pub enum JournalEntry {
     Link(LinkEntry),
     SetLocks(SetLocksEntry),
     Free(FreeEntry),
+    UfsApplied(UfsAppliedEntry),
+    Snapshot(SnapshotEntry),
+}
+
+impl JournalEntry {
+    pub fn op_id(&self) -> u64 {
+        match self {
+            JournalEntry::Mkdir(e) => e.op_id,
+            JournalEntry::CreateFile(e) => e.op_id,
+            JournalEntry::ReopenFile(e) => e.op_id,
+            JournalEntry::OverWriteFile(e) => e.op_id,
+            JournalEntry::AddBlock(e) => e.op_id,
+            JournalEntry::CompleteFile(e) => e.op_id,
+            JournalEntry::Rename(e) => e.op_id,
+            JournalEntry::Delete(e) => e.op_id,
+            JournalEntry::Mount(e) => e.op_id,
+            JournalEntry::UnMount(e) => e.op_id,
+            JournalEntry::SetAttr(e) => e.op_id,
+            JournalEntry::Symlink(e) => e.op_id,
+            JournalEntry::Link(e) => e.op_id,
+            JournalEntry::SetLocks(e) => e.op_id,
+            JournalEntry::Free(e) => e.op_id,
+            JournalEntry::UfsApplied(e) => e.op_id,
+            JournalEntry::Snapshot(e) => e.op_id,
+        }
+    }
+
+    pub fn rpc_id(&self) -> i64 {
+        match self {
+            JournalEntry::Mkdir(e) => e.rpc_id,
+            JournalEntry::CreateFile(e) => e.rpc_id,
+            JournalEntry::ReopenFile(e) => e.rpc_id,
+            JournalEntry::OverWriteFile(e) => e.rpc_id,
+            JournalEntry::AddBlock(e) => e.rpc_id,
+            JournalEntry::CompleteFile(e) => e.rpc_id,
+            JournalEntry::Rename(e) => e.rpc_id,
+            JournalEntry::Delete(e) => e.rpc_id,
+            JournalEntry::Mount(e) => e.rpc_id,
+            JournalEntry::UnMount(e) => e.rpc_id,
+            JournalEntry::SetAttr(e) => e.rpc_id,
+            JournalEntry::Symlink(e) => e.rpc_id,
+            JournalEntry::Link(e) => e.rpc_id,
+            JournalEntry::SetLocks(e) => e.rpc_id,
+            JournalEntry::Free(e) => e.rpc_id,
+            JournalEntry::UfsApplied(e) => e.rpc_id,
+            JournalEntry::Snapshot(e) => e.rpc_id,
+        }
+    }
+
+    pub fn inode_id(&self) -> Option<i64> {
+        match self {
+            JournalEntry::Mkdir(e) => Some(e.dir.id),
+            JournalEntry::CreateFile(e) => Some(e.file.id),
+            JournalEntry::ReopenFile(e) => Some(e.file.id),
+            JournalEntry::OverWriteFile(e) => Some(e.file.id),
+            JournalEntry::CompleteFile(e) => Some(e.file.id),
+            JournalEntry::Symlink(e) => Some(e.new_inode.id),
+            JournalEntry::SetLocks(e) => Some(e.ino),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]

--- a/curvine-server/src/master/journal/journal_loader.rs
+++ b/curvine-server/src/master/journal/journal_loader.rs
@@ -20,51 +20,351 @@ use crate::master::meta::inode::InodeView::{Dir, File};
 use crate::master::{JobManager, MountManager, SyncFsDir};
 use curvine_common::conf::JournalConf;
 use curvine_common::error::FsError;
-use curvine_common::proto::raft::{FsmState, SnapshotData};
-use curvine_common::raft::storage::{AppStorage, ApplyMsg};
-use curvine_common::raft::{RaftResult, RaftUtils};
+use curvine_common::proto::raft::{AppliedIndex, FsmState, SnapshotData};
+use curvine_common::raft::storage::{AppStorage, ApplyMsg, LogStorage, RocksLogStorage};
+use curvine_common::raft::{RaftClient, RaftResult, RaftUtils};
 use curvine_common::state::RenameFlags;
 use curvine_common::utils::SerdeUtils;
 use log::{debug, error, info, warn};
-use orpc::common::FileUtils;
-use orpc::sync::AtomicCounter;
-use orpc::{err_box, try_option, try_option_ref, CommonResult};
+use orpc::common::{FileUtils, LocalTime};
+use orpc::runtime::{RpcRuntime, Runtime};
+use orpc::sync::channel::{AsyncChannel, AsyncReceiver, AsyncSender, CallChannel};
+use orpc::{err_box, CommonResult};
+use raft::eraftpb::Entry;
 use raft::StateRole;
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
 use std::{fs, mem};
 
 // Replay the master metadata operation log.
 #[derive(Clone)]
 pub struct JournalLoader {
+    node_id: u64,
     fs_dir: SyncFsDir,
     mnt_mgr: Arc<MountManager>,
+    journal_writer: Arc<JournalWriter>,
     ufs_loader: UfsLoader,
-    seq_id: Arc<AtomicCounter>,
+    log_store: RocksLogStorage,
+    sender: AsyncSender<ApplyMsg>,
+    fsm_state: Arc<Mutex<FsmState>>,
     retain_checkpoint_num: usize,
-    ignore_replay_error: bool,
+    ignore_reply_error: bool,
+    max_retry_num: u64,
+    batch_size: u64,
+    retry_interval: Duration,
 }
 
 impl JournalLoader {
-    pub fn new(
+    pub fn new_replay_loader(
         fs_dir: SyncFsDir,
         mnt_mgr: Arc<MountManager>,
         conf: &JournalConf,
         job_manager: Arc<JobManager>,
     ) -> Self {
-        let ufs_loader = UfsLoader::new(job_manager, conf);
-        Self {
+        let rt = conf.create_runtime();
+        let client = RaftClient::from_conf(rt.clone(), conf);
+        let journal_writer = Arc::new(JournalWriter::new(true, client, conf));
+        let log_store = RocksLogStorage::from_conf(conf, false);
+        Self::new(
+            rt,
             fs_dir,
             mnt_mgr,
+            conf,
+            job_manager,
+            log_store,
+            journal_writer,
+        )
+    }
+
+    pub fn new(
+        rt: Arc<Runtime>,
+        fs_dir: SyncFsDir,
+        mnt_mgr: Arc<MountManager>,
+        conf: &JournalConf,
+        job_manager: Arc<JobManager>,
+        log_store: RocksLogStorage,
+        journal_writer: Arc<JournalWriter>,
+    ) -> Self {
+        let ufs_loader = UfsLoader::new(job_manager, conf);
+        let (sender, receiver) = AsyncChannel::new(conf.writer_channel_size).split();
+        let loader = Self {
+            node_id: conf.node_id().unwrap(),
+            fs_dir,
+            mnt_mgr,
+            journal_writer,
             ufs_loader,
-            seq_id: Arc::new(AtomicCounter::new(0)),
+            log_store,
+            sender,
+            fsm_state: Arc::new(Mutex::new(FsmState::default())),
             retain_checkpoint_num: 3.max(conf.retain_checkpoint_num),
-            ignore_replay_error: conf.cv_error_retry,
+            ignore_reply_error: conf.ignore_reply_error,
+            max_retry_num: conf.max_retry_num,
+            batch_size: conf.scan_batch_size,
+            retry_interval: Duration::from_secs(conf.retry_interval_secs),
+        };
+
+        let loader1 = loader.clone();
+        rt.spawn(async move {
+            Self::run_apply(loader1, receiver).await;
+        });
+
+        loader
+    }
+
+    fn get_ufs_applied(&self) -> AppliedIndex {
+        self.fsm_state.lock().unwrap().ufs_applied.clone()
+    }
+
+    fn set_follower_applied(&self, applied: AppliedIndex) {
+        self.fsm_state.lock().unwrap().applied = applied;
+    }
+
+    fn set_leader_applied(&self, applied: AppliedIndex) {
+        let mut lock = self.fsm_state.lock().unwrap();
+        lock.ufs_applied = applied.clone();
+        lock.applied = applied;
+    }
+
+    fn build_applied(entry: &Entry) -> AppliedIndex {
+        AppliedIndex {
+            term: entry.term,
+            index: entry.index,
+            ..Default::default()
         }
+    }
+
+    async fn apply0(&self, is_leader: bool, entry: &Entry) -> CommonResult<()> {
+        if entry.data.is_empty() {
+            return Ok(());
+        }
+
+        let batch: JournalBatch = SerdeUtils::deserialize(&entry.data)?;
+        let batch_len = batch.len();
+        let mut snapshot = None;
+        let mut applied = Self::build_applied(entry);
+        let mut has_ufs_affecting = false;
+
+        for (seq, op_entry) in batch.batch.into_iter().enumerate() {
+            match op_entry {
+                JournalEntry::Snapshot(e) if is_leader && e.node_id == self.node_id => {
+                    if seq + 1 != batch_len {
+                        return err_box!("snapshot should be the last entry");
+                    }
+                    snapshot.replace(e);
+                    continue;
+                }
+
+                JournalEntry::UfsApplied(_) => (),
+
+                _ => has_ufs_affecting = true,
+            }
+
+            applied.op_id = op_entry.op_id();
+            applied.rpc_id = op_entry.rpc_id();
+
+            {
+                let fs_dir = self.fs_dir.read();
+                fs_dir.update_op_id(op_entry.op_id());
+                if let Some(inode_id) = op_entry.inode_id() {
+                    fs_dir.update_last_inode_id(inode_id)?;
+                }
+            }
+
+            let res = if is_leader {
+                self.ufs_loader.apply_entry(&op_entry).await
+            } else {
+                self.apply_entry(op_entry.clone())
+            };
+
+            if let Err(e) = res {
+                return err_box!("failed to apply journal: {:?}: {}", op_entry, e);
+            }
+        }
+
+        if is_leader {
+            if has_ufs_affecting {
+                self.journal_writer
+                    .log_ufs_applied(applied.op_id, applied.term, applied.index)?;
+            }
+            self.set_leader_applied(applied);
+        } else {
+            self.set_follower_applied(applied);
+        }
+
+        if let Some(e) = snapshot {
+            let snap_data = self.create_snapshot0(Some(e.dir.to_string()))?;
+
+            self.log_store.create_snapshot(snap_data.clone())?;
+            self.log_store.compact(snap_data.fsm_state.compact())?;
+
+            info!(
+                "create leader snapshot, dir={}, fsm_state={:?}",
+                e.dir, snap_data.fsm_state
+            );
+        }
+
+        Ok(())
+    }
+
+    async fn apply_msg(&self, is_leader: bool, msg: &ApplyMsg) -> CommonResult<()> {
+        match msg {
+            ApplyMsg::Entry(entry) => {
+                self.apply0(is_leader, entry).await?;
+                Ok(())
+            }
+
+            ApplyMsg::Scan(applied_index) => {
+                let mut last_applied = applied_index.index;
+                let commit_index = self.log_store.hard_state().commit;
+                loop {
+                    if last_applied >= commit_index {
+                        return Ok(());
+                    }
+
+                    let high = (last_applied + self.batch_size).min(commit_index + 1);
+                    let list = self.log_store.scan_entries(last_applied + 1, high)?;
+
+                    if list.is_empty() {
+                        return Ok(());
+                    };
+
+                    info!(
+                        "replay-scan, start_index: {}, entries: {}, commit_index: {}",
+                        last_applied + 1,
+                        list.len(),
+                        commit_index
+                    );
+
+                    for entry in list {
+                        self.apply0(is_leader, &entry).await?;
+                        last_applied = entry.index;
+                    }
+                }
+            }
+
+            _ => unreachable!(),
+        }
+    }
+
+    async fn next_apply_msg(
+        &self,
+        receiver: &mut AsyncReceiver<ApplyMsg>,
+        retry_msg: &mut Option<ApplyMsg>,
+    ) -> Option<ApplyMsg> {
+        match retry_msg.take() {
+            Some(msg) => {
+                tokio::time::sleep(self.retry_interval).await;
+                Some(msg)
+            }
+            None => receiver.recv().await,
+        }
+    }
+
+    async fn run_apply(self, mut receiver: AsyncReceiver<ApplyMsg>) {
+        let mut retry_msg: Option<ApplyMsg> = None;
+        let mut retry_num: u64 = 0;
+        let mut is_leader = false;
+
+        loop {
+            let apply_msg = match self.next_apply_msg(&mut receiver, &mut retry_msg).await {
+                Some(v) => v,
+                None => break,
+            };
+
+            match apply_msg {
+                ApplyMsg::CreateSnapshot(tx) => {
+                    if let Err(e) = tx.send(self.create_snapshot0(None)) {
+                        warn!("send create snapshot result failed: {}", e);
+                    }
+                    retry_num = 0;
+                }
+
+                ApplyMsg::ApplySnapshot((tx, snapshot)) => {
+                    if let Err(e) = tx.send(self.apply_snapshot0(snapshot)) {
+                        warn!("send apply snapshot result failed: {}", e);
+                    }
+                    retry_num = 0;
+                }
+
+                ApplyMsg::RoleChange(role) => {
+                    is_leader = role == StateRole::Leader;
+                    if is_leader {
+                        let ufs_applied = self.get_ufs_applied();
+                        info!("role changed to leader, scheduling UFS replay scan from ufs_applied: {:?}", ufs_applied);
+                        retry_msg.replace(ApplyMsg::new_scan(ufs_applied));
+                    }
+                }
+
+                msg => match self.apply_msg(is_leader, &msg).await {
+                    Ok(_) => retry_num = 0,
+
+                    Err(error) => {
+                        if self.ignore_reply_error {
+                            error!("apply entry failed(skip): {}", error);
+                        } else if is_leader {
+                            retry_num += 1;
+
+                            if retry_num >= self.max_retry_num {
+                                panic!("apply entry failed(retry_num={}): {}", retry_num, error);
+                            } else {
+                                error!("apply entry failed(retry_num={}): {}", retry_num, error);
+                            }
+
+                            retry_msg.replace(msg);
+                        } else {
+                            panic!("apply entry failed: {}", error);
+                        }
+                    }
+                },
+            }
+        }
+    }
+
+    fn create_snapshot0(&self, dir_option: Option<String>) -> RaftResult<SnapshotData> {
+        let fsm_state = self.get_fsm_state();
+        let fs_dir = self.fs_dir.read();
+        let dir = match dir_option {
+            Some(dir) => dir,
+            None => fs_dir.create_checkpoint(fsm_state.applied.index)?,
+        };
+
+        let data = RaftUtils::create_file_snapshot(&dir, self.node_id, fsm_state)?;
+
+        if let Err(e) = self.purge_checkpoint(&dir) {
+            warn!("purge checkpoint: {}", e);
+        }
+
+        Ok(data)
+    }
+
+    fn apply_snapshot0(&self, snapshot: SnapshotData) -> RaftResult<()> {
+        let mut fs_dir = self.fs_dir.write();
+        match snapshot.files_data {
+            None => {
+                let dir = fs_dir.get_checkpoint_path(LocalTime::mills());
+                FileUtils::create_dir(&dir, true)?;
+                fs_dir.restore(dir)?;
+                fs_dir.update_op_id(snapshot.fsm_state.op_id());
+            }
+
+            Some(data) => {
+                fs_dir.restore(&data.dir)?;
+                fs_dir.update_op_id(snapshot.fsm_state.op_id());
+            }
+        }
+        drop(fs_dir);
+
+        self.mnt_mgr.restore();
+
+        *self.fsm_state.lock().unwrap() = snapshot.fsm_state;
+
+        Ok(())
     }
 
     pub fn apply_entry(&self, entry: JournalEntry) -> CommonResult<()> {
         debug!("replay entry: {:?}", entry);
+
         match entry {
             JournalEntry::Mkdir(e) => self.mkdir(e),
 
@@ -95,12 +395,15 @@ impl JournalLoader {
             JournalEntry::Link(e) => self.link(e),
 
             JournalEntry::SetLocks(e) => self.set_locks(e),
+
+            JournalEntry::UfsApplied(e) => self.ufs_applied(e),
+
+            _ => Ok(()),
         }
     }
 
     fn mkdir(&self, entry: MkdirEntry) -> CommonResult<()> {
         let mut fs_dir = self.fs_dir.write();
-        fs_dir.update_last_inode_id(entry.dir.id)?;
         let inp = InodePath::resolve(fs_dir.root_ptr(), entry.path, &fs_dir.store)?;
         let name = inp.name().to_string();
         let _ = fs_dir.add_last_inode(inp, Dir(name, entry.dir))?;
@@ -109,7 +412,6 @@ impl JournalLoader {
 
     fn create_file(&self, entry: CreateFileEntry) -> CommonResult<()> {
         let mut fs_dir = self.fs_dir.write();
-        fs_dir.update_last_inode_id(entry.file.id)?;
         let inp = InodePath::resolve(fs_dir.root_ptr(), entry.path, &fs_dir.store)?;
         let name = inp.name().to_string();
         let _ = fs_dir.add_last_inode(inp, File(name, entry.file))?;
@@ -118,9 +420,15 @@ impl JournalLoader {
 
     fn reopen_file(&self, entry: ReopenFileEntry) -> CommonResult<()> {
         let fs_dir = self.fs_dir.write();
-        let inp = InodePath::resolve(fs_dir.root_ptr(), entry.path, &fs_dir.store)?;
+        let inp = InodePath::resolve(fs_dir.root_ptr(), &entry.path, &fs_dir.store)?;
 
-        let mut inode = try_option!(inp.get_last_inode());
+        let mut inode = match inp.get_last_inode() {
+            Some(v) => v,
+            None => {
+                warn!("reopen_file: file not found: {:?}", entry);
+                return Ok(());
+            }
+        };
         let file = inode.as_file_mut()?;
         let _ = mem::replace(file, entry.file);
 
@@ -131,10 +439,15 @@ impl JournalLoader {
 
     fn overwrite_file(&self, entry: OverWriteFileEntry) -> CommonResult<()> {
         let fs_dir = self.fs_dir.write();
-        let inp = InodePath::resolve(fs_dir.root_ptr(), entry.path, &fs_dir.store)?;
+        let inp = InodePath::resolve(fs_dir.root_ptr(), &entry.path, &fs_dir.store)?;
 
-        // For journal replay, we directly update the file with the entry's file data
-        let mut inode = try_option!(inp.get_last_inode());
+        let mut inode = match inp.get_last_inode() {
+            Some(v) => v,
+            None => {
+                warn!("overwrite_file: file not found: {:?}", entry);
+                return Ok(());
+            }
+        };
         let file = inode.as_file_mut()?;
         let _ = mem::replace(file, entry.file);
 
@@ -145,9 +458,15 @@ impl JournalLoader {
 
     fn add_block(&self, entry: AddBlockEntry) -> CommonResult<()> {
         let fs_dir = self.fs_dir.write();
-        let inp = InodePath::resolve(fs_dir.root_ptr(), entry.path, &fs_dir.store)?;
+        let inp = InodePath::resolve(fs_dir.root_ptr(), &entry.path, &fs_dir.store)?;
 
-        let mut inode = try_option!(inp.get_last_inode());
+        let mut inode = match inp.get_last_inode() {
+            Some(v) => v,
+            None => {
+                warn!("add_block: file not found: {:?}", entry);
+                return Ok(());
+            }
+        };
         let file = inode.as_file_mut()?;
         let _ = mem::replace(&mut file.blocks, entry.blocks);
         fs_dir
@@ -159,9 +478,15 @@ impl JournalLoader {
 
     fn complete_file(&self, entry: CompleteFileEntry) -> CommonResult<()> {
         let fs_dir = self.fs_dir.write();
-        let inp = InodePath::resolve(fs_dir.root_ptr(), entry.path, &fs_dir.store)?;
+        let inp = InodePath::resolve(fs_dir.root_ptr(), &entry.path, &fs_dir.store)?;
 
-        let mut inode = try_option!(inp.get_last_inode());
+        let mut inode = match inp.get_last_inode() {
+            Some(v) => v,
+            None => {
+                warn!("complete_file: file not found: {:?}", entry);
+                return Ok(());
+            }
+        };
         let file = inode.as_file_mut()?;
 
         let _ = mem::replace(file, entry.file);
@@ -225,7 +550,7 @@ impl JournalLoader {
 
     pub fn unmount(&self, entry: UnMountEntry) -> CommonResult<()> {
         if !self.mnt_mgr.has_mounted(entry.id) {
-            warn!("Unmount: id already unmounted: {}", entry.id);
+            warn!("Unmount: id already unmounted: {:?}", entry);
             return Ok(());
         }
         self.mnt_mgr.unprotected_umount_by_id(entry.id)?;
@@ -236,12 +561,11 @@ impl JournalLoader {
 
     pub fn set_attr(&self, entry: SetAttrEntry) -> CommonResult<()> {
         let mut fs_dir = self.fs_dir.write();
-        let entry_path = entry.path;
-        let inp = InodePath::resolve(fs_dir.root_ptr(), &entry_path, &fs_dir.store)?;
+        let inp = InodePath::resolve(fs_dir.root_ptr(), &entry.path, &fs_dir.store)?;
         let last_inode = match inp.get_last_inode() {
             Some(v) => v,
             None => {
-                warn!("SetAttr: path not found: {}", entry_path);
+                warn!("SetAttr: path not found: {:?}", entry);
                 return Ok(());
             }
         };
@@ -257,7 +581,7 @@ impl JournalLoader {
         match fs_dir.unprotected_symlink(inp, entry.new_inode, entry.force) {
             Ok(_) => Ok(()),
             Err(FsError::FileAlreadyExists(_)) => {
-                warn!("Symlink: file already exists: {}", link_path);
+                warn!("Symlink: file already exists: {:?}", link_path);
                 Ok(())
             }
             Err(e) => Err(e.into()),
@@ -265,25 +589,23 @@ impl JournalLoader {
     }
 
     pub fn link(&self, entry: LinkEntry) -> CommonResult<()> {
-        let src_path = entry.src_path;
-        let dst_path = entry.dst_path;
         let mut fs_dir = self.fs_dir.write();
-        let old_path = InodePath::resolve(fs_dir.root_ptr(), &src_path, &fs_dir.store)?;
-        let new_path = InodePath::resolve(fs_dir.root_ptr(), &dst_path, &fs_dir.store)?;
+        let old_path = InodePath::resolve(fs_dir.root_ptr(), &entry.src_path, &fs_dir.store)?;
+        let new_path = InodePath::resolve(fs_dir.root_ptr(), &entry.dst_path, &fs_dir.store)?;
 
         // Get the original inode ID
         let original_inode_id = match old_path.get_last_inode() {
             Some(inode) => inode.id(),
             None => {
-                warn!("Link: source path not found: {}", src_path);
+                warn!("Link: source path not found: {:?}", entry);
                 return Ok(());
             }
         };
 
-        match fs_dir.unprotected_link(new_path, original_inode_id, entry.op_ms) {
+        match fs_dir.unprotected_link(new_path, original_inode_id, entry.mtime as u64) {
             Ok(_) => Ok(()),
             Err(FsError::FileAlreadyExists(_)) => {
-                warn!("Link: dst_path already exists: {}", dst_path);
+                warn!("Link: dst_path already exists: {:?}", entry);
                 Ok(())
             }
             Err(e) => Err(e.into()),
@@ -293,6 +615,17 @@ impl JournalLoader {
     pub fn set_locks(&self, entry: SetLocksEntry) -> CommonResult<()> {
         let fs_dir = self.fs_dir.write();
         fs_dir.store.apply_set_locks(entry.ino, &entry.locks)
+    }
+
+    pub fn ufs_applied(&self, entry: UfsAppliedEntry) -> CommonResult<()> {
+        let mut lock = self.fsm_state.lock().unwrap();
+        lock.ufs_applied = AppliedIndex {
+            op_id: entry.op_id,
+            rpc_id: entry.rpc_id,
+            term: entry.term,
+            index: entry.index,
+        };
+        Ok(())
     }
 
     // Clean up expired checkpoints.
@@ -321,89 +654,50 @@ impl JournalLoader {
 
         Ok(())
     }
-
-    async fn apply0(&self, is_leader: bool, message: &[u8]) -> RaftResult<()> {
-        // The raft log has logs that do not contain referenced data.
-        if message.is_empty() {
-            return Ok(());
-        }
-
-        let batch: JournalBatch = SerdeUtils::deserialize(message)?;
-
-        // The leader node ignores all logs because they have been applied to the master node before synchronization via raft.
-        if is_leader {
-            let seq_id = batch.seq_id + 1;
-            self.ufs_loader.apply_batch(batch).await?;
-            self.seq_id.set(seq_id);
-            return Ok(());
-        }
-
-        self.seq_id.incr();
-        for entry in batch.batch {
-            match self.apply_entry(entry.clone()) {
-                Ok(_) => (),
-                Err(e) => {
-                    return err_box!(
-                        "Failed to apply journal entry to master, entry: {:?}: {}",
-                        entry,
-                        e
-                    );
-                }
-            }
-        }
-
-        Ok(())
-    }
 }
 
 impl AppStorage for JournalLoader {
     async fn apply(&self, wait: bool, msg: ApplyMsg) -> RaftResult<()> {
-        match self.apply0(wait, &msg.take_entry().data[..]).await {
-            Ok(_) => Ok(()),
-
-            Err(e) => {
-                if self.ignore_replay_error {
-                    error!("journal apply {}", e);
+        if wait {
+            if let Err(e) = self.apply_msg(false, &msg).await {
+                if self.ignore_reply_error {
+                    error!("apply entry failed: {}", e);
                     Ok(())
                 } else {
-                    Err(e)
+                    Err(e.into())
                 }
+            } else {
+                Ok(())
             }
+        } else {
+            self.sender.send(msg).await?;
+            Ok(())
         }
     }
 
     fn get_fsm_state(&self) -> FsmState {
-        FsmState::default()
+        self.fsm_state.lock().unwrap().clone()
     }
 
-    async fn role_change(&self, _: StateRole) -> RaftResult<()> {
+    async fn role_change(&self, role: StateRole) -> RaftResult<()> {
+        self.sender.send(ApplyMsg::RoleChange(role)).await?;
         Ok(())
     }
 
-    // Call rocksdb's API to create a snapshot.
     async fn create_snapshot(&self) -> RaftResult<SnapshotData> {
-        let fs_dir = self.fs_dir.read();
-        let dir = fs_dir.create_checkpoint(0)?;
-        let data = RaftUtils::create_file_snapshot(&dir, 0, FsmState::default())?;
+        let (tx, rx) = CallChannel::channel();
+        let msg = ApplyMsg::CreateSnapshot(tx);
 
-        // Delete historical snapshots.
-        if let Err(e) = self.purge_checkpoint(&dir) {
-            warn!("purge checkpoint: {}", e);
-        }
-        Ok(data)
+        self.sender.send(msg).await?;
+        rx.receive().await?
     }
 
     async fn apply_snapshot(&self, snapshot: SnapshotData) -> RaftResult<()> {
-        {
-            let mut fs_dir = self.fs_dir.write();
-            let data = try_option_ref!(snapshot.files_data);
-            self.seq_id.set(snapshot.snapshot_id + 1);
-            fs_dir.restore(&data.dir)?;
-        }
-        {
-            self.mnt_mgr.restore();
-        }
-        Ok(())
+        let (tx, rx) = CallChannel::channel();
+        let msg = ApplyMsg::ApplySnapshot((tx, snapshot));
+
+        self.sender.send(msg).await?;
+        rx.receive().await?
     }
 
     fn snapshot_dir(&self, snapshot_id: u64) -> RaftResult<String> {

--- a/curvine-server/src/master/journal/journal_system.rs
+++ b/curvine-server/src/master/journal/journal_system.rs
@@ -28,7 +28,6 @@ use curvine_common::proto::raft::SnapshotData;
 use curvine_common::raft::storage::{AppStorage, LogStorage, RocksLogStorage};
 use curvine_common::raft::{RaftClient, RaftResult, RoleMonitor, RoleStateListener};
 use curvine_common::FsResult;
-use log::info;
 use orpc::common::FileUtils;
 use orpc::runtime::{RpcRuntime, Runtime};
 use orpc::sync::StateCtl;
@@ -81,17 +80,10 @@ impl JournalSystem {
         let worker_manager = SyncWorkerManager::new(WorkerManager::new(conf));
 
         let client = RaftClient::from_conf(rt.clone(), &conf.journal);
-        let journal_writer = JournalWriter::new(conf.testing, client, &conf.journal);
+        let journal_writer = Arc::new(JournalWriter::new(conf.testing, client, &conf.journal));
 
-        // If a snapshot exists in the current system, fs_dir will be restored based on the snapshot.
-        // Here we will first delete the rocksdb data directory, which is to prevent the creation of the memory directory tree twice.
         let db_conf = conf.meta_rocks_conf();
-        if !conf.format_master && log_store.has_snapshot() {
-            info!(
-                "There is a snapshot currently, the original data directory {} will be \
-            deleted and restored based on the snapshot later",
-                db_conf.data_dir
-            );
+        if FileUtils::exists(&db_conf.data_dir) {
             FileUtils::delete_path(&db_conf.data_dir, true)?;
         }
 
@@ -110,7 +102,7 @@ impl JournalSystem {
 
         let fs_dir = SyncFsDir::new(FsDir::new(
             conf,
-            journal_writer,
+            journal_writer.clone(),
             ttl_bucket_list,
             evictor.clone(),
         )?);
@@ -136,12 +128,15 @@ impl JournalSystem {
 
         let raft_journal = MetaRaftJournal::new(
             rt.clone(),
-            log_store,
+            log_store.clone(),
             JournalLoader::new(
+                rt.clone(),
                 fs_dir.clone(),
                 mount_manager.clone(),
                 &conf.journal,
                 job_manager.clone(),
+                log_store,
+                journal_writer.clone(),
             ),
             conf.journal.clone(),
             role_monitor,

--- a/curvine-server/src/master/journal/journal_writer.rs
+++ b/curvine-server/src/master/journal/journal_writer.rs
@@ -16,46 +16,34 @@
 
 use crate::master::journal::*;
 use crate::master::meta::inode::{InodeDir, InodeFile, InodePath};
+use crate::master::meta::FsDir;
 use crate::master::{Master, MasterMetrics};
 use curvine_common::conf::JournalConf;
 use curvine_common::raft::RaftClient;
 use curvine_common::state::{CommitBlock, FileLock, MountInfo, RenameFlags, SetAttrOpts};
 use curvine_common::FsResult;
-use log::debug;
-use std::sync::mpsc::{Receiver, SendError, Sender, SyncSender};
-use std::sync::{mpsc, Mutex};
-
-enum SenderAdapter {
-    Bounded(SyncSender<JournalEntry>),
-    UnBounded(Sender<JournalEntry>),
-}
-
-impl SenderAdapter {
-    fn send(&self, entry: JournalEntry) -> Result<(), SendError<JournalEntry>> {
-        match self {
-            SenderAdapter::Bounded(s) => s.send(entry),
-            SenderAdapter::UnBounded(s) => s.send(entry),
-        }
-    }
-}
+use log::{debug, info};
+use orpc::common::LocalTime;
+use orpc::err_box;
+use orpc::sync::channel::{BlockingChannel, BlockingReceiver, BlockingSender};
+use orpc::sync::AtomicCounter;
+use std::sync::Mutex;
 
 // Write metadata operation logs.
 pub struct JournalWriter {
     enable: bool,
-    sender: SenderAdapter,
+    node_id: u64,
+    sender: BlockingSender<JournalEntry>,
     metrics: &'static MasterMetrics,
-    receiver: Option<Mutex<Receiver<JournalEntry>>>,
+    receiver: Option<Mutex<BlockingReceiver<JournalEntry>>>,
+
+    snapshot_entries: u64,
+    entries_since_snapshot: AtomicCounter,
 }
 
 impl JournalWriter {
     pub fn new(testing: bool, client: RaftClient, conf: &JournalConf) -> Self {
-        let (sender, receiver) = if conf.writer_channel_size == 0 {
-            let (sender, receiver) = mpsc::channel();
-            (SenderAdapter::UnBounded(sender), receiver)
-        } else {
-            let (sender, receiver) = mpsc::sync_channel(conf.writer_channel_size);
-            (SenderAdapter::Bounded(sender), receiver)
-        };
+        let (sender, receiver) = BlockingChannel::new(conf.writer_channel_size).split();
 
         let receiver = if !testing {
             // Start the send log thread.
@@ -68,189 +56,278 @@ impl JournalWriter {
 
         Self {
             enable: conf.enable,
+            node_id: conf.node_id().unwrap(),
             sender,
             metrics: Master::get_metrics(),
             receiver,
+            snapshot_entries: conf.snapshot_entries,
+            entries_since_snapshot: AtomicCounter::new(0),
         }
     }
 
-    fn send(&self, entry: JournalEntry) -> FsResult<()> {
-        debug!("send {:?}", entry);
+    fn send_inner(&self, entry: JournalEntry) -> FsResult<()> {
+        debug!("send_entry {:?}", entry);
+        self.sender.send(entry)?;
+        self.metrics.journal_queue_len.inc();
+        Ok(())
+    }
+
+    fn send(&self, fs_dir: &FsDir, entry: JournalEntry) -> FsResult<()> {
+        debug!("send_entry {:?}", entry);
 
         if self.enable {
-            self.sender.send(entry)?;
-            self.metrics.journal_queue_len.inc();
+            self.send_inner(entry)?;
+            self.maybe_emit_snapshot(fs_dir)?;
         }
         Ok(())
     }
 
-    pub fn log_mkdir(&self, op_ms: u64, path: impl AsRef<str>, dir: &InodeDir) -> FsResult<()> {
+    fn maybe_emit_snapshot(&self, fs_dir: &FsDir) -> FsResult<()> {
+        if self.snapshot_entries == 0 {
+            return Ok(());
+        }
+
+        let entries = self.entries_since_snapshot.add_and_get(1);
+        if entries < self.snapshot_entries {
+            return Ok(());
+        }
+
+        let now = LocalTime::mills();
+        self.entries_since_snapshot.set(0);
+        let dir = match fs_dir.store.create_checkpoint(now) {
+            Ok(d) => d,
+            Err(e) => {
+                return err_box!("leaderSnapshot: create_checkpoint failed: {}", e);
+            }
+        };
+
+        info!(
+            "create leader snapshot, dir {}, entries {}, cost {} ms",
+            dir,
+            entries,
+            LocalTime::mills() - now
+        );
+
+        self.send_inner(JournalEntry::Snapshot(SnapshotEntry {
+            op_id: fs_dir.next_op_id(),
+            rpc_id: 0,
+            node_id: self.node_id,
+            dir,
+        }))?;
+        Ok(())
+    }
+
+    pub fn log_mkdir(&self, fs_dir: &FsDir, path: impl AsRef<str>, dir: &InodeDir) -> FsResult<()> {
         let entry = MkdirEntry {
-            op_ms,
+            op_id: fs_dir.next_op_id(),
+            rpc_id: 0,
             path: path.as_ref().to_string(),
             dir: dir.clone(),
         };
-        self.send(JournalEntry::Mkdir(entry))
+        self.send(fs_dir, JournalEntry::Mkdir(entry))
     }
 
-    pub fn log_create_file(&self, op_ms: u64, inp: &InodePath) -> FsResult<()> {
+    pub fn log_create_file(&self, fs_dir: &FsDir, inp: &InodePath) -> FsResult<()> {
         let entry = CreateFileEntry {
-            op_ms,
+            op_id: fs_dir.next_op_id(),
+            rpc_id: 0,
             path: inp.path().to_string(),
             file: inp.clone_last_file()?,
         };
-        self.send(JournalEntry::CreateFile(entry))
+        self.send(fs_dir, JournalEntry::CreateFile(entry))
     }
 
     pub fn log_reopen_file<P: AsRef<str>>(
         &self,
-        op_ms: u64,
+        fs_dir: &FsDir,
         path: P,
         file: &InodeFile,
     ) -> FsResult<()> {
         let entry = ReopenFileEntry {
-            op_ms,
+            op_id: fs_dir.next_op_id(),
+            rpc_id: 0,
             path: path.as_ref().to_string(),
             file: file.clone(),
         };
-        self.send(JournalEntry::ReopenFile(entry))
+        self.send(fs_dir, JournalEntry::ReopenFile(entry))
     }
 
     pub fn log_add_block<P: AsRef<str>>(
         &self,
-        op_ms: u64,
+        fs_dir: &FsDir,
         path: P,
         file: &InodeFile,
         commit_block: Vec<CommitBlock>,
     ) -> FsResult<()> {
         let entry = AddBlockEntry {
-            op_ms,
+            op_id: fs_dir.next_op_id(),
+            rpc_id: 0,
             path: path.as_ref().to_string(),
             blocks: file.blocks.clone(),
             commit_block,
         };
-
-        self.send(JournalEntry::AddBlock(entry))
+        self.send(fs_dir, JournalEntry::AddBlock(entry))
     }
 
     pub fn log_complete_file<P: AsRef<str>>(
         &self,
-        op_ms: u64,
+        fs_dir: &FsDir,
         path: P,
         file: &InodeFile,
         commit_blocks: Vec<CommitBlock>,
     ) -> FsResult<()> {
         let entry = CompleteFileEntry {
-            op_ms,
+            op_id: fs_dir.next_op_id(),
+            rpc_id: 0,
             path: path.as_ref().to_string(),
             file: file.clone(),
             commit_blocks,
         };
-
-        self.send(JournalEntry::CompleteFile(entry))
+        self.send(fs_dir, JournalEntry::CompleteFile(entry))
     }
 
-    pub fn log_overwrite_file(&self, op_ms: u64, inp: &InodePath) -> FsResult<()> {
+    pub fn log_overwrite_file(&self, fs_dir: &FsDir, inp: &InodePath) -> FsResult<()> {
         let entry = OverWriteFileEntry {
-            op_ms,
+            op_id: fs_dir.next_op_id(),
+            rpc_id: 0,
             path: inp.path().to_string(),
             file: inp.clone_last_file()?,
         };
-        self.send(JournalEntry::OverWriteFile(entry))
+        self.send(fs_dir, JournalEntry::OverWriteFile(entry))
     }
 
     pub fn log_rename<P: AsRef<str>>(
         &self,
-        op_ms: u64,
+        fs_dir: &FsDir,
         src: P,
         dst: P,
         mtime: i64,
         flags: RenameFlags,
     ) -> FsResult<()> {
         let entry = RenameEntry {
-            op_ms,
+            op_id: fs_dir.next_op_id(),
+            rpc_id: 0,
             src: src.as_ref().to_string(),
             dst: dst.as_ref().to_string(),
             mtime,
             flags: flags.value(),
         };
-
-        self.send(JournalEntry::Rename(entry))
+        self.send(fs_dir, JournalEntry::Rename(entry))
     }
 
-    pub fn log_delete<P: AsRef<str>>(&self, op_ms: u64, path: P, mtime: i64) -> FsResult<()> {
+    pub fn log_delete<P: AsRef<str>>(&self, fs_dir: &FsDir, path: P, mtime: i64) -> FsResult<()> {
         let entry = DeleteEntry {
-            op_ms,
+            op_id: fs_dir.next_op_id(),
+            rpc_id: 0,
             path: path.as_ref().to_string(),
             mtime,
         };
-        self.send(JournalEntry::Delete(entry))
+        self.send(fs_dir, JournalEntry::Delete(entry))
     }
 
-    pub fn log_free<P: AsRef<str>>(&self, op_ms: u64, path: P, mtime: i64) -> FsResult<()> {
+    pub fn log_free<P: AsRef<str>>(&self, fs_dir: &FsDir, path: P, mtime: i64) -> FsResult<()> {
         let entry = FreeEntry {
-            op_ms,
+            op_id: fs_dir.next_op_id(),
+            rpc_id: 0,
             path: path.as_ref().to_string(),
             mtime,
         };
-        self.send(JournalEntry::Free(entry))
+        self.send(fs_dir, JournalEntry::Free(entry))
     }
 
-    pub fn log_mount(&self, op_ms: u64, info: MountInfo) -> FsResult<()> {
-        let entry = MountEntry { op_ms, info };
-
-        self.send(JournalEntry::Mount(entry))
+    pub fn log_mount(&self, fs_dir: &FsDir, info: MountInfo) -> FsResult<()> {
+        let entry = MountEntry {
+            op_id: fs_dir.next_op_id(),
+            rpc_id: 0,
+            info,
+        };
+        self.send(fs_dir, JournalEntry::Mount(entry))
     }
 
-    pub fn log_unmount(&self, op_ms: u64, id: u32) -> FsResult<()> {
-        let entry = UnMountEntry { op_ms, id };
-        self.send(JournalEntry::UnMount(entry))
+    pub fn log_unmount(&self, fs_dir: &FsDir, id: u32) -> FsResult<()> {
+        let entry = UnMountEntry {
+            op_id: fs_dir.next_op_id(),
+            rpc_id: 0,
+            id,
+        };
+        self.send(fs_dir, JournalEntry::UnMount(entry))
     }
 
-    pub fn log_set_attr(&self, op_ms: u64, inp: &InodePath, opts: SetAttrOpts) -> FsResult<()> {
+    pub fn log_set_attr(&self, fs_dir: &FsDir, inp: &InodePath, opts: SetAttrOpts) -> FsResult<()> {
         let entry = SetAttrEntry {
-            op_ms,
+            op_id: fs_dir.next_op_id(),
+            rpc_id: 0,
             path: inp.path().to_string(),
             opts,
         };
-        self.send(JournalEntry::SetAttr(entry))
+        self.send(fs_dir, JournalEntry::SetAttr(entry))
     }
 
     pub fn log_symlink<P: AsRef<str>>(
         &self,
-        op_ms: u64,
+        fs_dir: &FsDir,
         link: P,
         new_inode: InodeFile,
         force: bool,
     ) -> FsResult<()> {
         let entry = SymlinkEntry {
-            op_ms,
+            op_id: fs_dir.next_op_id(),
+            rpc_id: 0,
             link: link.as_ref().to_string(),
             new_inode,
             force,
         };
-        self.send(JournalEntry::Symlink(entry))
+        self.send(fs_dir, JournalEntry::Symlink(entry))
     }
 
-    pub fn log_link<P: AsRef<str>>(&self, op_ms: u64, src_path: P, dst_path: P) -> FsResult<()> {
+    pub fn log_link<P: AsRef<str>>(
+        &self,
+        fs_dir: &FsDir,
+        src_path: P,
+        dst_path: P,
+    ) -> FsResult<()> {
         let entry = LinkEntry {
-            op_ms,
+            op_id: fs_dir.next_op_id(),
+            rpc_id: 0,
+            mtime: LocalTime::mills() as i64,
             src_path: src_path.as_ref().to_string(),
             dst_path: dst_path.as_ref().to_string(),
         };
-        self.send(JournalEntry::Link(entry))
+        self.send(fs_dir, JournalEntry::Link(entry))
     }
 
-    pub fn log_set_locks(&self, op_ms: u64, ino: i64, locks: Vec<FileLock>) -> FsResult<()> {
-        let entry = SetLocksEntry { op_ms, ino, locks };
-        self.send(JournalEntry::SetLocks(entry))
+    pub fn log_ufs_applied(&self, op_id: u64, term: u64, index: u64) -> FsResult<()> {
+        if !self.enable {
+            return Ok(());
+        }
+
+        let entry = UfsAppliedEntry {
+            op_id,
+            rpc_id: 0,
+            term,
+            index,
+        };
+        self.metrics.journal_queue_len.inc();
+        self.sender.send(JournalEntry::UfsApplied(entry))?;
+
+        Ok(())
+    }
+
+    pub fn log_set_locks(&self, fs_dir: &FsDir, ino: i64, locks: Vec<FileLock>) -> FsResult<()> {
+        let entry = SetLocksEntry {
+            op_id: fs_dir.next_op_id(),
+            rpc_id: 0,
+            ino,
+            locks,
+        };
+        self.send(fs_dir, JournalEntry::SetLocks(entry))
     }
 
     // for testing
     pub fn take_entries(&self) -> Vec<JournalEntry> {
         let mut entries = vec![];
-
-        while let Ok(v) = self.receiver.as_ref().unwrap().lock().unwrap().try_recv() {
+        let receiver = self.receiver.as_ref().unwrap().lock().unwrap();
+        while let Ok(v) = receiver.recv_check() {
             entries.push(v)
         }
         entries

--- a/curvine-server/src/master/journal/sender_task.rs
+++ b/curvine-server/src/master/journal/sender_task.rs
@@ -20,7 +20,7 @@ use curvine_common::utils::SerdeUtils;
 use curvine_common::FsResult;
 use orpc::common::{LocalTime, TimeSpent};
 use orpc::err_box;
-use std::sync::mpsc;
+use orpc::sync::channel::BlockingReceiver;
 use std::sync::mpsc::RecvTimeoutError;
 use std::thread;
 use std::time::Duration;
@@ -49,7 +49,7 @@ impl SenderTask {
     }
 
     // Start a thread to execute sender task
-    pub fn spawn(self, receiver: mpsc::Receiver<JournalEntry>) -> FsResult<()> {
+    pub fn spawn(self, receiver: BlockingReceiver<JournalEntry>) -> FsResult<()> {
         let poll = Duration::from_millis(self.flush_batch_ms);
         let name = "journal-writer".to_string();
         let task = self;
@@ -62,7 +62,7 @@ impl SenderTask {
     }
 
     fn loop0(
-        receiver: mpsc::Receiver<JournalEntry>,
+        receiver: BlockingReceiver<JournalEntry>,
         poll: Duration,
         mut task: SenderTask,
     ) -> FsResult<()> {
@@ -78,17 +78,22 @@ impl SenderTask {
     }
 
     pub fn handle(&mut self, entry: Option<JournalEntry>) -> FsResult<()> {
-        if let Some(v) = entry {
+        let force = if let Some(v) = entry {
+            let force = matches!(v, JournalEntry::Snapshot(_));
             self.batch.push(v);
             self.metrics.journal_queue_len.dec();
-        }
+            force
+        } else {
+            false
+        };
 
         let len = self.batch.len() as u64;
         if len == 0 {
             return Ok(());
         }
 
-        if len >= self.flush_batch_size
+        if force
+            || len >= self.flush_batch_size
             || LocalTime::mills() - self.last_flush_ms >= self.flush_batch_ms
         {
             let spend = TimeSpent::new();

--- a/curvine-server/src/master/journal/ufs_loader.rs
+++ b/curvine-server/src/master/journal/ufs_loader.rs
@@ -13,7 +13,7 @@
 //  limitations under the License.
 
 use crate::master::journal::{
-    CompleteFileEntry, DeleteEntry, JournalBatch, JournalEntry, MkdirEntry, RenameEntry,
+    CompleteFileEntry, DeleteEntry, JournalEntry, MkdirEntry, RenameEntry,
 };
 use crate::master::JobManager;
 use curvine_client::unified::MountValue;
@@ -53,13 +53,6 @@ impl UfsLoader {
         }
     }
 
-    pub async fn apply_batch(&self, batch: JournalBatch) -> CommonResult<()> {
-        for entry in batch.batch {
-            self.apply_entry(&entry).await?;
-        }
-        Ok(())
-    }
-
     pub async fn submit_load_task(&self, path: &Path, mnt: &MountValue) -> FsResult<()> {
         let command = LoadJobCommand::builder(path.clone_uri()).build();
         let runner = self.job_manager.create_runner();
@@ -90,7 +83,7 @@ impl UfsLoader {
         }
     }
 
-    pub async fn apply_entry(&self, entry: &JournalEntry) -> FsResult<()> {
+    pub async fn apply_entry(&self, entry: &JournalEntry) -> CommonResult<()> {
         match entry {
             JournalEntry::Mkdir(e) => self.mkdir(e).await,
             JournalEntry::CompleteFile(e) => self.complete_file(e).await,
@@ -100,7 +93,7 @@ impl UfsLoader {
         }
     }
 
-    pub async fn mkdir(&self, e: &MkdirEntry) -> FsResult<()> {
+    pub async fn mkdir(&self, e: &MkdirEntry) -> CommonResult<()> {
         let path = Path::from_str(&e.path)?;
         if let Some((ufs_path, mnt)) = self.job_manager.get_mnt(&path)? {
             mnt.ufs.mkdir(&ufs_path, false).await?;
@@ -110,20 +103,20 @@ impl UfsLoader {
         }
     }
 
-    pub async fn complete_file(&self, e: &CompleteFileEntry) -> FsResult<()> {
+    pub async fn complete_file(&self, e: &CompleteFileEntry) -> CommonResult<()> {
         if !e.file.is_complete() {
             return Ok(());
         }
 
         let path = Path::from_str(&e.path)?;
         if let Some((_, mnt)) = self.job_manager.get_mnt(&path)? {
-            self.submit_load_task(&path, &mnt).await
+            self.submit_load_task(&path, &mnt).await.map_err(Into::into)
         } else {
             Ok(())
         }
     }
 
-    pub async fn rename(&self, e: &RenameEntry) -> FsResult<()> {
+    pub async fn rename(&self, e: &RenameEntry) -> CommonResult<()> {
         let src = Path::from_str(&e.src)?;
         let dst = Path::from_str(&e.dst)?;
         if let Some((src_ufs_path, mnt)) = self.job_manager.get_mnt(&src)? {
@@ -132,13 +125,13 @@ impl UfsLoader {
             } else {
                 warn!("rename: src file not exists: {}", src_ufs_path);
             }
-            self.submit_load_task(&dst, &mnt).await
+            self.submit_load_task(&dst, &mnt).await.map_err(Into::into)
         } else {
             Ok(())
         }
     }
 
-    pub async fn delete(&self, e: &DeleteEntry) -> FsResult<()> {
+    pub async fn delete(&self, e: &DeleteEntry) -> CommonResult<()> {
         let path = Path::from_str(&e.path)?;
         if let Some((ufs_path, mnt)) = self.job_manager.get_mnt(&path)? {
             if mnt.ufs.exists(&ufs_path).await? {

--- a/curvine-server/src/master/meta/fs_dir.rs
+++ b/curvine-server/src/master/meta/fs_dir.rs
@@ -29,6 +29,7 @@ use curvine_common::state::{
 use curvine_common::FsResult;
 use log::{info, warn};
 use orpc::common::{LocalTime, TimeSpent};
+use orpc::sync::AtomicCounter;
 use orpc::{err_box, err_ext, try_option, CommonResult};
 use std::collections::{HashMap, LinkedList};
 use std::mem;
@@ -39,14 +40,15 @@ pub struct FsDir {
     pub(crate) root_dir: InodeView,
     pub(crate) inode_id: InodeId,
     pub(crate) store: InodeStore,
-    pub(crate) journal_writer: JournalWriter,
+    pub(crate) journal_writer: Arc<JournalWriter>,
     pub(crate) evictor: Arc<dyn Evictor>,
+    pub(crate) op_id: AtomicCounter,
 }
 
 impl FsDir {
     pub fn new(
         conf: &ClusterConf,
-        journal_writer: JournalWriter,
+        journal_writer: Arc<JournalWriter>,
         ttl_bucket_list: Arc<TtlBucketList>,
         evictor: Arc<dyn Evictor>,
     ) -> FsResult<Self> {
@@ -62,16 +64,12 @@ impl FsDir {
             store: state,
             journal_writer,
             evictor,
+            op_id: AtomicCounter::new(0),
         };
         fs_dir.update_last_inode_id(last_inode_id)?;
 
         Ok(fs_dir)
     }
-
-    // Note: inode_store() method was intentionally removed.
-    // Cloning InodeStore increases Arc<RocksInodeStore> refcount, which prevents
-    // the RocksDB lock from being released during Raft snapshot restore.
-    // Access inode_store via self references instead of cloning.
 
     // Create root directory
     pub fn create_root() -> InodeView {
@@ -91,6 +89,14 @@ impl FsDir {
         Ok(id)
     }
 
+    pub fn next_op_id(&self) -> u64 {
+        self.op_id.next()
+    }
+
+    pub fn update_op_id(&self, op_id: u64) {
+        self.op_id.set(op_id);
+    }
+
     pub fn get_ttl_bucket_list(&self) -> Arc<TtlBucketList> {
         self.store.get_ttl_bucket_list()
     }
@@ -108,8 +114,6 @@ impl FsDir {
     // 1. If all directories on the path already exist, skip and return successful.
     // 2. If the parent directory does not exist, an error is returned.
     fn create_single_dir(&mut self, mut inp: InodePath, opts: MkdirOpts) -> FsResult<InodePath> {
-        let op_ms = LocalTime::mills();
-
         if inp.is_full() || inp.is_root() {
             return Ok(inp);
         }
@@ -122,7 +126,7 @@ impl FsDir {
         inp = self.add_last_inode(inp, Dir(name.clone(), dir.clone()))?;
 
         let parent_path = inp.get_valid_parent_path();
-        self.journal_writer.log_mkdir(op_ms, &parent_path, &dir)?;
+        self.journal_writer.log_mkdir(self, &parent_path, &dir)?;
 
         Ok(inp)
     }
@@ -162,7 +166,7 @@ impl FsDir {
 
         let del_res = self.unprotected_delete(inp, op_ms as i64)?;
         self.journal_writer
-            .log_delete(op_ms, inp.path(), op_ms as i64)?;
+            .log_delete(self, inp.path(), op_ms as i64)?;
 
         Ok(del_res)
     }
@@ -223,7 +227,7 @@ impl FsDir {
 
         let del_res = self.unprotected_free(inp, op_ms as i64)?;
         self.journal_writer
-            .log_free(op_ms, inp.path(), op_ms as i64)?;
+            .log_free(self, inp.path(), op_ms as i64)?;
 
         Ok(del_res)
     }
@@ -266,7 +270,7 @@ impl FsDir {
         let op_ms = LocalTime::mills();
         let res = self.unprotected_rename(src_inp, dst_inp, op_ms as i64, flags)?;
         self.journal_writer.log_rename(
-            op_ms,
+            self,
             src_inp.path(),
             dst_inp.path(),
             op_ms as i64,
@@ -349,7 +353,6 @@ impl FsDir {
     }
 
     pub fn create_file(&mut self, mut inp: InodePath, opts: CreateFileOpts) -> FsResult<InodePath> {
-        let op_ms = LocalTime::mills();
         if inp.get_last_inode().is_some() {
             return err_ext!(FsError::file_exists(inp.path()));
         }
@@ -361,7 +364,7 @@ impl FsDir {
         // Create an inode file node.
         let file = InodeFile::with_opts(self.inode_id.next()?, LocalTime::mills() as i64, opts);
         inp = self.add_last_inode(inp, File(name, file))?;
-        self.journal_writer.log_create_file(op_ms, &inp)?;
+        self.journal_writer.log_create_file(self, &inp)?;
 
         Ok(inp)
     }
@@ -464,7 +467,6 @@ impl FsDir {
         choose_workers: &[WorkerAddress],
         file_len: i64,
     ) -> FsResult<ExtendedBlock> {
-        let op_ms = LocalTime::mills();
         let mut inode = try_option!(inp.get_last_inode());
         let file = inode.as_file_mut()?;
 
@@ -486,12 +488,8 @@ impl FsDir {
 
         // state add block.
         self.store.apply_new_block(inode.as_ref(), &commit_blocks)?;
-        self.journal_writer.log_add_block(
-            op_ms,
-            inp.path(),
-            inode.as_file_ref()?,
-            commit_blocks,
-        )?;
+        self.journal_writer
+            .log_add_block(self, inp.path(), inode.as_file_ref()?, commit_blocks)?;
         Ok(block)
     }
 
@@ -503,7 +501,6 @@ impl FsDir {
         client_name: impl AsRef<str>,
         only_flush: bool,
     ) -> FsResult<bool> {
-        let op_ms = LocalTime::mills();
         let mut inode = try_option!(inp.get_last_inode());
         let file = inode.as_file_mut()?;
         file.complete(len, &commit_block, client_name, only_flush)?;
@@ -513,7 +510,7 @@ impl FsDir {
         self.store
             .apply_complete_file(inode.as_ref(), &commit_block)?;
         self.journal_writer.log_complete_file(
-            op_ms,
+            self,
             inp.path(),
             inode.as_file_ref()?,
             commit_block,
@@ -545,7 +542,6 @@ impl FsDir {
         inp: &InodePath,
         client_name: impl AsRef<str>,
     ) -> FsResult<FileStatus> {
-        let op_ms = LocalTime::mills();
         let inode_ptr = match inp.get_last_inode() {
             None => return err_ext!(FsError::file_not_found(inp.path())),
             Some(v) => v,
@@ -569,7 +565,7 @@ impl FsDir {
 
         self.store.apply_reopen_file(&inode)?;
         self.journal_writer
-            .log_reopen_file(op_ms, inp.path(), inode.as_file_ref()?)?;
+            .log_reopen_file(self, inp.path(), inode.as_file_ref()?)?;
 
         Ok(status)
     }
@@ -628,7 +624,7 @@ impl FsDir {
         }
 
         // Log the operation
-        self.journal_writer.log_overwrite_file(op_ms, inp)?;
+        self.journal_writer.log_overwrite_file(self, inp)?;
 
         Ok(delete_result)
     }
@@ -740,12 +736,10 @@ impl FsDir {
     }
 
     pub fn store_mount(&mut self, info: MountInfo, send_log: bool) -> FsResult<()> {
-        // Create parent directory
-        let op_ms = LocalTime::mills();
         self.store.store.add_mountpoint(info.mount_id, &info)?;
 
         if send_log {
-            self.journal_writer.log_mount(op_ms, info)?;
+            self.journal_writer.log_mount(self, info)?;
         }
 
         Ok(())
@@ -757,10 +751,8 @@ impl FsDir {
     }
 
     pub fn unmount(&mut self, id: u32) -> FsResult<()> {
-        // Create parent directory
-        let op_ms = LocalTime::mills();
         self.store.store.remove_mountpoint(id)?;
-        self.journal_writer.log_unmount(op_ms, id)?;
+        self.journal_writer.log_unmount(self, id)?;
         Ok(())
     }
 
@@ -778,15 +770,13 @@ impl FsDir {
     }
 
     pub fn set_attr(&mut self, inp: InodePath, opts: SetAttrOpts) -> FsResult<FileStatus> {
-        let op_ms = LocalTime::mills();
-
         let inode = match inp.get_last_inode() {
             Some(v) => v,
             None => return err_ext!(FsError::file_not_found(inp.path())),
         };
 
         self.unprotected_set_attr(inode.clone(), opts.clone())?;
-        self.journal_writer.log_set_attr(op_ms, &inp, opts)?;
+        self.journal_writer.log_set_attr(self, &inp, opts)?;
         Ok(inode.to_file_status(inp.path()))
     }
 
@@ -847,7 +837,7 @@ impl FsDir {
 
         let link = self.unprotected_symlink(link, new_inode.clone(), force)?;
         self.journal_writer
-            .log_symlink(op_ms, link.path(), new_inode, force)?;
+            .log_symlink(self, link.path(), new_inode, force)?;
         Ok(())
     }
 
@@ -925,7 +915,7 @@ impl FsDir {
 
         // Log the operation
         self.journal_writer
-            .log_link(op_ms, src_path.path(), &dst_path_str)?;
+            .log_link(self, src_path.path(), &dst_path_str)?;
 
         Ok(())
     }
@@ -985,8 +975,6 @@ impl FsDir {
     /// 3. Collect locations of blocks to be deleted
     /// 4. Persist changes to store and write journal entry
     pub fn resize(&mut self, inp: &InodePath, opts: FileAllocOpts) -> FsResult<DeleteResult> {
-        let op_ms = LocalTime::mills();
-
         let mut inode = match inp.get_last_inode() {
             Some(v) => v,
             None => return err_ext!(FsError::file_not_found(inp.path())),
@@ -1010,7 +998,7 @@ impl FsDir {
 
         self.store.apply_complete_file(inode.as_ref(), &[])?;
         self.journal_writer
-            .log_complete_file(op_ms, inp.path(), inode.as_file_ref()?, vec![])?;
+            .log_complete_file(self, inp.path(), inode.as_file_ref()?, vec![])?;
 
         Ok(del_res)
     }
@@ -1021,8 +1009,6 @@ impl FsDir {
         block_id: i64,
         workers: &[WorkerAddress],
     ) -> FsResult<ExtendedBlock> {
-        let op_ms = LocalTime::mills();
-
         let mut inode = try_option!(inp.get_last_inode());
         let file = inode.as_file_mut()?;
 
@@ -1039,7 +1025,7 @@ impl FsDir {
         if res {
             self.store.apply_new_block(inode.as_ref(), &[])?;
             self.journal_writer
-                .log_add_block(op_ms, inp.path(), inode.as_file_ref()?, vec![])?;
+                .log_add_block(self, inp.path(), inode.as_file_ref()?, vec![])?;
         }
 
         Ok(block)
@@ -1075,7 +1061,6 @@ impl FsDir {
         lock: FileLock,
         expire_ms: u64,
     ) -> FsResult<Option<FileLock>> {
-        let op_ms = LocalTime::mills();
         let inode = match inp.get_last_inode() {
             Some(v) => v,
             None => return err_ext!(FsError::file_not_found(inp.path())),
@@ -1086,8 +1071,7 @@ impl FsDir {
 
         let locks = meta.to_vec();
         self.store.apply_set_locks(inode.id(), &locks)?;
-        self.journal_writer
-            .log_set_locks(op_ms, inode.id(), locks)?;
+        self.journal_writer.log_set_locks(self, inode.id(), locks)?;
 
         Ok(conflict)
     }

--- a/curvine-server/src/master/meta/store/inode_store.rs
+++ b/curvine-server/src/master/meta/store/inode_store.rs
@@ -519,12 +519,6 @@ impl InodeStore {
         // Check if there are other references to the Arc, which would prevent the lock from being released
         let ref_count = Arc::strong_count(&self.store);
         if ref_count > 1 {
-            log::error!(
-                "cannot restore: RocksInodeStore has {} references (expected 1). \
-                Other components are still holding clones of InodeStore, \
-                which prevents RocksDB lock from being released.",
-                ref_count
-            );
             return err_box!(
                 "cannot restore: RocksInodeStore has {} references (expected 1). \
                 Other components are still holding clones of InodeStore, \

--- a/curvine-server/tests/journal_test.rs
+++ b/curvine-server/tests/journal_test.rs
@@ -56,7 +56,7 @@ fn test_journal_replay_consistency_between_leader_and_follower() -> CommonResult
     let follower_journal_system = JournalSystem::from_conf(&conf)?;
     let fs_follower = MasterFilesystem::with_js(&conf, &follower_journal_system);
     let mnt_mgr2 = follower_journal_system.mount_manager();
-    let journal_loader = JournalLoader::new(
+    let journal_loader = JournalLoader::new_replay_loader(
         fs_follower.fs_dir(),
         mnt_mgr2.clone(),
         &conf.journal,

--- a/curvine-server/tests/master_fs_test.rs
+++ b/curvine-server/tests/master_fs_test.rs
@@ -722,7 +722,7 @@ fn setup_pair(
     let js2 = JournalSystem::from_conf(&conf).unwrap();
     let fs2 = MasterFilesystem::with_js(&conf, &js2);
     fs2.add_test_worker(worker);
-    let loader = JournalLoader::new(
+    let loader = JournalLoader::new_replay_loader(
         fs2.fs_dir(),
         js2.mount_manager(),
         &conf.journal,


### PR DESCRIPTION
### Summary

This PR refactors the journal system to decouple log application from the
Raft event loop and establishes a consistent, auditable operation identity
model across all journal entry types.

### Motivation

The previous design had two problems:

1. **Blocking apply**: `JournalLoader.apply()` ran synchronously inside
   `on_ready`, stalling the Raft tick loop on every committed batch and
   causing tail latency spikes under write-heavy workloads.

2. **Coarse op identity**: Entries carried only `op_ms` (wall-clock
   milliseconds), which made deduplication unreliable (clock skew, same-ms
   bursts) and provided no way to correlate a client RPC to its replicated
   log entry.

### Changes

#### `curvine-common`

| File | Change |
|---|---|
| `raft/raft_node.rs` | Defer `SoftState` processing until after `committed_entries` are applied; call `install_snapshot` on leader→follower transition after `role_change` |
| `raft/storage/apply_msg.rs` | Add `ApplyMsg::Scan(AppliedIndex)` variant for startup replay |
| `raft/storage/peer_storage.rs` | Minor cleanup |
| `conf/journal_conf.rs` | Add `scan_batch_size`, `max_retry_num`, `retry_interval_secs`, `ignore_reply_error` fields |

#### `curvine-server` — journal

| File | Change |
|---|---|
| `journal/entry.rs` | Replace `op_ms: u64` with `op_id: u64` + `rpc_id: i64` on every entry struct; add `JournalEntry::op_id()` / `rpc_id()` accessors |
| `journal/journal_loader.rs` | Full rewrite: async channel pipeline, unified `apply0`, batched `Scan` replay, per-role FsmState tracking, leader-triggered snapshot via `SnapshotEntry` |
| `journal/journal_writer.rs` | Switch to `BlockingChannel`; add threshold-based snapshot emission (`snapshot_entries`); `send()` now takes `&FsDir` to emit snapshots inline |
| `journal/journal_system.rs` | Wire new `JournalLoader::new` signature |
| `journal/sender_task.rs` | Minor alignment with new channel types |
| `journal/ufs_loader.rs` | Adapt to `op_id`-based entry accessors |

#### `curvine-server` — meta

| File | Change |
|---|---|
| `meta/fs_dir.rs` | Add `op_id: AtomicCounter`; expose `next_op_id()` / `update_op_id()`; `journal_writer` field is now `Arc<JournalWriter>` |
| `meta/store/inode_store.rs` | Minor cleanup |

### Design: async apply pipeline

```
Raft on_ready
    │
    ├─ persist hard state / send messages  (unchanged)
    │
    └─ sender.send(ApplyMsg::Entry(entry))   ← non-blocking enqueue
            │
            ▼  (dedicated async task)
        run_apply()
            │
            ├─ apply0(is_leader, entry)
            │       ├─ update inode_id counter
            │       ├─ update op_id counter
            │       ├─ leader  → ufs_loader.apply_entry()
            │       └─ follower → apply_entry()
            │
            └─ set_leader_applied / set_follower_applied
```

On startup (or after `install_snapshot`), a single `ApplyMsg::Scan` is
enqueued. `apply_msg` then replays all entries from `last_applied + 1` to
`hard_state.commit` in configurable batches before accepting new entries.