### PR TITLE
feat(metrics): expose journal Raft progress metrics and reduce log noise

### DIFF
--- a/curvine-common/src/conf/journal_conf.rs
+++ b/curvine-common/src/conf/journal_conf.rs
@@ -100,8 +100,6 @@ pub struct JournalConf {
     pub retain_checkpoint_num: usize,
 
     pub ignore_reply_error: bool,
-    pub cv_error_retry: bool,
-    pub ufs_error_retry: bool,
     pub max_retry_num: u64,
     pub scan_batch_size: u64,
     pub retry_interval_secs: u64,
@@ -241,8 +239,6 @@ impl Default for JournalConf {
             retain_checkpoint_num: 3,
 
             ignore_reply_error: false,
-            ufs_error_retry: true,
-            cv_error_retry: false,
             max_retry_num: 1000,
             scan_batch_size: 1000,
             retry_interval_secs: 10,

--- a/curvine-server/src/master/job/job_manager.rs
+++ b/curvine-server/src/master/job/job_manager.rs
@@ -25,7 +25,7 @@ use curvine_common::state::{
     JobStatus, JobTaskProgress, JobTaskState, LoadJobCommand, LoadJobResult,
 };
 use curvine_common::FsResult;
-use log::info;
+use log::{debug, info};
 use orpc::common::LocalTime;
 use orpc::runtime::{LoopTask, Runtime};
 use orpc::{err_box, err_ext};
@@ -241,7 +241,7 @@ impl LoopTask for JobCleanupTask {
 
         for job_id in jobs_to_remove {
             if let Some(v) = self.jobs.remove(&job_id) {
-                info!("Removing expired job: {:?}", v.1.info);
+                debug!("Removing expired job: {:?}", v.1.info);
             }
         }
 

--- a/curvine-server/src/master/job/job_runner.rs
+++ b/curvine-server/src/master/job/job_runner.rs
@@ -26,7 +26,7 @@ use curvine_common::state::{
 use curvine_common::utils::CommonUtils;
 use curvine_common::FsResult;
 use futures::future;
-use log::{error, info, warn};
+use log::{debug, error, info, warn};
 use orpc::common::{ByteUnit, FastHashMap, FastHashSet, LocalTime};
 use orpc::err_box;
 use std::collections::LinkedList;
@@ -124,23 +124,6 @@ impl LoadJobRunner {
             job_id: job_id.clone(),
             target_path: target_path.clone_uri(),
         };
-
-        let mnt_value = self.factory.get_mnt(&mnt)?;
-        if self
-            .check_job_exists(&job_id, &mnt_value, &source_path, &target_path)
-            .await?
-        {
-            info!(
-                "job {}, source_path {} already exists",
-                job_id,
-                source_path.full_path()
-            );
-            return Ok(result);
-        }
-
-        self.jobs.remove(&job_id);
-
-        info!("Submitting load job {}", job_id);
         let mut job_context = JobContext::with_conf(
             &command,
             job_id.clone(),
@@ -150,20 +133,47 @@ impl LoadJobRunner {
             &ClientConf::default(),
         );
 
+        let mnt_value = self.factory.get_mnt(&mnt)?;
+        if self
+            .check_job_exists(&job_id, &mnt_value, &source_path, &target_path)
+            .await?
+        {
+            debug!(
+                "skip load job {}: source_path {} already loaded or in progress",
+                job_id,
+                source_path.full_path()
+            );
+
+            job_context.update_state(JobTaskState::Completed, "exists tasks");
+            self.jobs.insert(job_id, job_context);
+            return Ok(result);
+        }
+
+        self.jobs.remove(&job_id);
+
+        debug!(
+            "submitting load job {}: {} -> {}",
+            job_id,
+            source_path.full_path(),
+            target_path.full_path()
+        );
+
         let res = self
             .create_all_tasks(&mut job_context, &source_path, &mnt)
             .await;
 
         match res {
             Err(e) => {
-                warn!("Create load job {} failed: {}", job_id, e);
+                warn!("create load job {} failed: {}", job_id, e);
                 Err(e)
             }
 
             Ok(size) => {
                 info!(
-                    "Submit load job {} success, tasks {}, total_size {}",
+                    "load job {} submitted: {} -> {}, tasks {}, total_size {}",
                     job_id,
+                    source_path.full_path(),
+                    target_path.full_path(),
                     job_context.tasks.len(),
                     ByteUnit::byte_to_string(size as u64)
                 );
@@ -183,9 +193,10 @@ impl LoadJobRunner {
             .take()
             .into_iter()
             .map(|(id, task)| async move {
-                let client = self.factory.get_worker_client(&task.task.worker).await?;
+                let worker = task.task.worker.clone();
+                let client = self.factory.get_worker_client(&worker).await?;
                 client.submit_load_task(task.task).await?;
-                info!("Submit sub-task {}", id);
+                debug!("dispatched sub-task {} to worker {}", id, worker);
                 Ok::<(), FsError>(())
             })
             .collect();
@@ -276,7 +287,12 @@ impl LoadJobRunner {
                         self.job_max_files
                     );
                 }
-                info!("Added sub-task {}", task_id);
+                debug!(
+                    "created sub-task {} ({} -> {})",
+                    task_id,
+                    source_path.full_path(),
+                    target_path.full_path()
+                );
             }
         }
 
@@ -294,17 +310,11 @@ impl LoadJobRunner {
             let res = client.cancel_job(job_id).await;
 
             if let Err(e) = res {
-                error!(
-                    "Failed to send cancel load request to worker{}: {}",
-                    worker, e
-                );
+                error!("failed to send cancel request to worker {}: {}", worker, e);
                 self.jobs.update_state(
                     job_id,
                     JobTaskState::Canceled,
-                    format!(
-                        "Failed to send cancel load request to worker {}: {}",
-                        worker, e
-                    ),
+                    format!("failed to send cancel request to worker {}: {}", worker, e),
                 );
             }
         }

--- a/curvine-server/src/master/journal/journal_loader.rs
+++ b/curvine-server/src/master/journal/journal_loader.rs
@@ -17,7 +17,7 @@
 use crate::master::journal::*;
 use crate::master::meta::inode::InodePath;
 use crate::master::meta::inode::InodeView::{Dir, File};
-use crate::master::{JobManager, MountManager, SyncFsDir};
+use crate::master::{JobManager, Master, MasterMetrics, MountManager, SyncFsDir};
 use curvine_common::conf::JournalConf;
 use curvine_common::error::FsError;
 use curvine_common::proto::raft::{AppliedIndex, FsmState, SnapshotData};
@@ -53,6 +53,7 @@ pub struct JournalLoader {
     max_retry_num: u64,
     batch_size: u64,
     retry_interval: Duration,
+    metrics: &'static MasterMetrics,
 }
 
 impl JournalLoader {
@@ -102,6 +103,7 @@ impl JournalLoader {
             max_retry_num: conf.max_retry_num,
             batch_size: conf.scan_batch_size,
             retry_interval: Duration::from_secs(conf.retry_interval_secs),
+            metrics: Master::get_metrics(),
         };
 
         let loader1 = loader.clone();
@@ -116,14 +118,36 @@ impl JournalLoader {
         self.fsm_state.lock().unwrap().ufs_applied.clone()
     }
 
-    fn set_follower_applied(&self, applied: AppliedIndex) {
-        self.fsm_state.lock().unwrap().applied = applied;
-    }
+    fn set_applied(
+        &self,
+        is_leader: bool,
+        applied: AppliedIndex,
+        has_ufs_affecting: bool,
+    ) -> CommonResult<()> {
+        if is_leader && has_ufs_affecting {
+            self.journal_writer
+                .log_ufs_applied(applied.op_id, applied.term, applied.index)?;
+        }
 
-    fn set_leader_applied(&self, applied: AppliedIndex) {
-        let mut lock = self.fsm_state.lock().unwrap();
-        lock.ufs_applied = applied.clone();
-        lock.applied = applied;
+        let mut state = self.fsm_state.lock().unwrap();
+        if is_leader {
+            state.ufs_applied = applied.clone();
+            state.applied = applied;
+        } else {
+            state.applied = applied;
+        }
+
+        self.metrics.journal_applied.set(state.applied.index as i64);
+        self.metrics
+            .journal_ufs_applied
+            .set(state.ufs_applied.index as i64);
+        drop(state);
+
+        let state = self.log_store.hard_state();
+        self.metrics.journal_committed.set(state.commit as i64);
+        self.metrics.journal_term.set(state.term as i64);
+
+        Ok(())
     }
 
     fn build_applied(entry: &Entry) -> AppliedIndex {
@@ -182,15 +206,7 @@ impl JournalLoader {
             }
         }
 
-        if is_leader {
-            if has_ufs_affecting {
-                self.journal_writer
-                    .log_ufs_applied(applied.op_id, applied.term, applied.index)?;
-            }
-            self.set_leader_applied(applied);
-        } else {
-            self.set_follower_applied(applied);
-        }
+        self.set_applied(is_leader, applied, has_ufs_affecting)?;
 
         if let Some(e) = snapshot {
             let snap_data = self.create_snapshot0(Some(e.dir.to_string()))?;

--- a/curvine-server/src/master/master_metrics.rs
+++ b/curvine-server/src/master/master_metrics.rs
@@ -39,6 +39,10 @@ pub struct MasterMetrics {
     pub(crate) journal_queue_len: Gauge,
     pub(crate) journal_flush_count: Counter,
     pub(crate) journal_flush_time: Counter,
+    pub(crate) journal_committed: Gauge,
+    pub(crate) journal_term: Gauge,
+    pub(crate) journal_applied: Gauge,
+    pub(crate) journal_ufs_applied: Gauge,
 
     pub(crate) used_memory_bytes: Gauge,
     pub(crate) rocksdb_used_memory_bytes: GaugeVec,
@@ -88,6 +92,19 @@ impl MasterMetrics {
                 "Number of flushes of log entries",
             )?,
             journal_flush_time: m::new_counter("journal_flush_time", "Log entry flush time")?,
+            journal_committed: m::new_gauge(
+                "journal_committed",
+                "Raft commit index of the journal",
+            )?,
+            journal_term: m::new_gauge("journal_term", "Current Raft term of the journal")?,
+            journal_applied: m::new_gauge(
+                "journal_applied",
+                "Last applied index of the journal state machine",
+            )?,
+            journal_ufs_applied: m::new_gauge(
+                "journal_ufs_applied",
+                "Last UFS-applied index of the journal state machine",
+            )?,
 
             used_memory_bytes: m::new_gauge("used_memory_bytes", "Total memory used")?,
             rocksdb_used_memory_bytes: m::new_gauge_vec(

--- a/curvine-server/src/worker/task/task_manager.rs
+++ b/curvine-server/src/worker/task/task_manager.rs
@@ -19,7 +19,7 @@ use curvine_client::file::{CurvineFileSystem, FsContext};
 use curvine_common::conf::ClusterConf;
 use curvine_common::state::LoadTaskInfo;
 use curvine_common::FsResult;
-use log::info;
+use log::debug;
 use orpc::runtime::{RpcRuntime, Runtime};
 use std::sync::Arc;
 use tokio::sync::Semaphore;
@@ -134,7 +134,7 @@ impl TaskManager {
             self.task_timeout_ms,
         );
 
-        info!("submit task {}", task_id);
+        debug!("submit task {}", task_id);
 
         let tasks = self.tasks.clone();
         let semaphore = self.worker_task_semaphore.clone();
@@ -162,7 +162,7 @@ impl TaskManager {
         let job_id = job_id.as_ref();
         let all_task = self.tasks.cancel(job_id);
 
-        info!(
+        debug!(
             "Successfully canceled {} tasks for job {}",
             all_task.len(),
             job_id


### PR DESCRIPTION
### Summary

- **Observability**: four new Prometheus-style gauges give operators
  real-time visibility into the journal's Raft commit/term/applied progress
  without having to grep logs.
- **Code quality**: the two `set_leader_applied` / `set_follower_applied`
  helpers are collapsed into one `set_applied` that always emits metrics,
  removing a class of "metrics not updated on follower" bugs.
- **Log hygiene**: ~8 `info!` call sites in the data-path are downgraded
  to `debug!`, shrinking production log volume significantly.

### Changes

#### `curvine-server`

| File | Change |
|---|---|
| `master/master_metrics.rs` | Add `journal_committed`, `journal_term`, `journal_applied`, `journal_ufs_applied` gauge fields and their initialization |
| `master/journal/journal_loader.rs` | Replace `set_leader_applied` + `set_follower_applied` with unified `set_applied(is_leader, applied, has_ufs_affecting)`; emit all four metrics on every call |
| `master/job/job_runner.rs` | Downgrade routine log lines to `debug`; add source/target paths to the submit-success log; fix worker-field move in `submit_all_task`; persist job context on early-return path |
| `master/job/job_manager.rs` | Downgrade expired-job removal log to `debug` |
| `worker/task/task_manager.rs` | Downgrade task submit/cancel logs to `debug` |

### Metrics Reference

| Metric | Type | Description |
|---|---|---|
| `journal_committed` | Gauge | Raft hard-state commit index |
| `journal_term` | Gauge | Current Raft term |
| `journal_applied` | Gauge | Last index applied to the state machine |
| `journal_ufs_applied` | Gauge | Last index whose UFS side-effects were applied (leader only) |
