### PR TITLE
fix: improve snapshot restore safety, Raft hard-state durability, and…

### DIFF
--- a/curvine-common/src/raft/raft_node.rs
+++ b/curvine-common/src/raft/raft_node.rs
@@ -183,6 +183,8 @@ where
         app_store: &B,
         voters: Vec<u64>,
     ) -> RaftResult<u64> {
+        info!("init raft state: {:?}", log_store.initial_state()?);
+
         let spend = TimeSpent::new();
 
         match log_store.latest_snapshot()? {

--- a/curvine-common/src/raft/storage/rocks_storage_core.rs
+++ b/curvine-common/src/raft/storage/rocks_storage_core.rs
@@ -105,13 +105,21 @@ impl RocksStorageCore {
 
     pub fn set_hard_state(&mut self, hs: HardState) -> RaftResult<()> {
         self.raft_state.hard_state = hs.clone();
-        self.db
-            .put_cf(Self::CF_META, Self::STATE_KEY, hs.encode_to_vec())?;
+
+        let mut batch = StoreWriteBatch::new(&self.db);
+        batch.set_state(&hs)?;
+        batch.commit()?;
+
         Ok(())
     }
 
     pub fn set_hard_state_commit(&mut self, commit: u64) -> RaftResult<()> {
         self.mut_hard_state().set_commit(commit);
+
+        let mut batch = StoreWriteBatch::new(&self.db);
+        batch.set_state(&self.raft_state.hard_state)?;
+        batch.commit()?;
+
         Ok(())
     }
 
@@ -414,7 +422,16 @@ impl<'a> StoreWriteBatch<'a> {
         Ok(())
     }
 
+    fn set_state(&mut self, state: &HardState) -> CommonResult<()> {
+        self.0.put_cf(
+            RocksStorageCore::CF_META,
+            RocksStorageCore::STATE_KEY,
+            state.encode_to_vec(),
+        )?;
+        Ok(())
+    }
+
     fn commit(self) -> CommonResult<()> {
-        self.0.commit()
+        self.0.commit_sync()
     }
 }

--- a/curvine-common/src/rocksdb/db_engine.rs
+++ b/curvine-common/src/rocksdb/db_engine.rs
@@ -55,21 +55,23 @@ impl DBEngine {
     }
 
     pub fn restore<T: AsRef<str>>(&mut self, checkpoint: T) -> CommonResult<()> {
-        let db_path = &self.conf.data_dir;
+        let db_path = self.conf.data_dir.clone();
         let db_opt = self.conf.create_db_opt();
         let cfs = self.conf.create_cf_opt();
+        let checkpoint = checkpoint.as_ref();
 
-        //The database points to a temporary directory.
+        // The database points to a temporary directory while we prepare the restore.
         let tmp_path = Utils::temp_file();
         self.db = try_err!(DB::open(&db_opt, &tmp_path));
+        // Remove the original database directory before linking the checkpoint.
+        FileUtils::delete_path(&db_path, true)?;
 
-        // Delete the original file and move the checkpoint to the data directory.
-        FileUtils::delete_path(db_path, true)?;
-        FileUtils::rename(checkpoint.as_ref(), db_path)?;
+        try_err!(RocksUtils::link_dir(checkpoint, &db_path));
+        self.db = try_err!(DB::open_cf_with_opts(&db_opt, &db_path, cfs));
 
-        // Retry instantiating db and delete the temporary directory.
-        self.db = try_err!(DB::open_cf_with_opts(&db_opt, db_path, cfs));
-        let _ = FileUtils::delete_path(tmp_path, true);
+        // Now that self.db points to the restored DB and the temporary DB handle is dropped,
+        // it is safe to delete the temporary directory. Propagate any deletion error.
+        FileUtils::delete_path(&tmp_path, true)?;
 
         Ok(())
     }
@@ -204,6 +206,8 @@ impl DBEngine {
 
     // Create a checkpoint.
     pub fn create_checkpoint(&self, id: u64) -> CommonResult<String> {
+        self.flush(true)?;
+
         let checkpoint_path = self.get_checkpoint_path(id);
         let existed = FileUtils::exists(&checkpoint_path);
 
@@ -246,13 +250,23 @@ impl DBEngine {
         &self.db
     }
 
-    pub fn flush(&self) -> CommonResult<()> {
-        self.db.flush()?;
+    pub fn flush_mem(&self, sync: bool) -> CommonResult<()> {
+        let mut opts = FlushOptions::default();
+        opts.set_wait(sync);
+        self.db.flush_opt(&opts)?;
         Ok(())
     }
 
     pub fn flush_wal(&self, sync: bool) -> CommonResult<()> {
         self.db.flush_wal(sync)?;
+        Ok(())
+    }
+
+    pub fn flush(&self, sync: bool) -> CommonResult<()> {
+        self.flush_mem(sync)?;
+        if !self.conf.disable_wal {
+            self.flush_wal(sync)?;
+        }
         Ok(())
     }
 

--- a/curvine-common/src/rocksdb/rocks_utils.rs
+++ b/curvine-common/src/rocksdb/rocks_utils.rs
@@ -13,8 +13,10 @@
 // limitations under the License.
 
 use byteorder::{BigEndian, ByteOrder};
+use orpc::io::IOResult;
 use orpc::{err_box, CommonResult};
 use prost::bytes::BufMut;
+use std::fs;
 
 // A utility class that converts some types to bytes.
 pub struct RocksUtils;
@@ -180,6 +182,35 @@ impl RocksUtils {
 
         end
     }
+
+    pub fn link_dir<P: AsRef<std::path::Path>>(src: P, dst: P) -> IOResult<()> {
+        let src = src.as_ref();
+        let dst = dst.as_ref();
+        if !dst.exists() {
+            fs::create_dir_all(dst)?;
+        }
+
+        for entry in fs::read_dir(src)? {
+            let entry = entry?;
+            let src_path = entry.path();
+            let dst_path = dst.join(entry.file_name());
+            if src_path.is_dir() {
+                Self::link_dir(&src_path, &dst_path)?;
+            } else if Self::is_sst_file(&src_path) {
+                fs::hard_link(&src_path, &dst_path)?;
+            } else {
+                fs::copy(&src_path, &dst_path)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn is_sst_file(path: &std::path::Path) -> bool {
+        matches!(
+            path.extension().and_then(|e: &std::ffi::OsStr| e.to_str()),
+            Some("sst") | Some("ldb")
+        )
+    }
 }
 
 #[cfg(test)]
@@ -233,5 +264,126 @@ mod tests {
         let (c_id, c_name) = RocksUtils::i64_str_from_bytes(&bytes).unwrap();
         assert_eq!(id, c_id);
         assert_eq!(name, c_name);
+    }
+
+    mod tests_link_dir {
+        use super::*;
+        use std::fs;
+        use std::io::Write;
+        #[cfg(unix)]
+        use std::os::unix::fs::MetadataExt;
+        use std::path::{Path, PathBuf};
+        fn unique_test_dir(name: &str) -> PathBuf {
+            let mut dir = std::env::temp_dir();
+            // Use high-resolution time and thread id to avoid collisions without extra deps.
+            let nanos = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let tid = format!("{:?}", std::thread::current().id());
+            dir.push(format!("rocks_utils_{}_{}_{}", name, nanos, tid));
+            dir
+        }
+        fn write_file(path: &Path, contents: &str) {
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).unwrap();
+            }
+            let mut file = fs::File::create(path).unwrap();
+            file.write_all(contents.as_bytes()).unwrap();
+        }
+        #[test]
+        fn link_dir_hardlinks_sst_and_ldb_and_copies_other_files() {
+            let src_root = unique_test_dir("src");
+            let dst_root = unique_test_dir("dst");
+            // Build source directory structure.
+            let sst_file = src_root.join("file1.sst");
+            let ldb_file = src_root.join("file2.ldb");
+            let txt_file = src_root.join("other.txt");
+            let nested_dir = src_root.join("nested");
+            let nested_sst = nested_dir.join("nested.sst");
+            let nested_txt = nested_dir.join("nested.txt");
+            write_file(&sst_file, "sst data");
+            write_file(&ldb_file, "ldb data");
+            write_file(&txt_file, "text data");
+            write_file(&nested_sst, "nested sst");
+            write_file(&nested_txt, "nested text");
+            fs::create_dir_all(&dst_root).unwrap();
+            // Exercise link_dir.
+            RocksUtils::link_dir(&src_root, &dst_root).unwrap();
+            // Destination paths.
+            let dst_sst = dst_root.join("file1.sst");
+            let dst_ldb = dst_root.join("file2.ldb");
+            let dst_txt = dst_root.join("other.txt");
+            let dst_nested_dir = dst_root.join("nested");
+            let dst_nested_sst = dst_nested_dir.join("nested.sst");
+            let dst_nested_txt = dst_nested_dir.join("nested.txt");
+            // Ensure all files and dirs exist.
+            assert!(dst_root.is_dir());
+            assert!(dst_sst.is_file());
+            assert!(dst_ldb.is_file());
+            assert!(dst_txt.is_file());
+            assert!(dst_nested_dir.is_dir());
+            assert!(dst_nested_sst.is_file());
+            assert!(dst_nested_txt.is_file());
+            // Helper to read all bytes and compare contents.
+            fn assert_same_contents(a: &Path, b: &Path) {
+                let ca = fs::read(a).unwrap();
+                let cb = fs::read(b).unwrap();
+                assert_eq!(ca, cb, "file contents differ for {:?} and {:?}", a, b);
+            }
+            assert_same_contents(&sst_file, &dst_sst);
+            assert_same_contents(&ldb_file, &dst_ldb);
+            assert_same_contents(&txt_file, &dst_txt);
+            assert_same_contents(&nested_sst, &dst_nested_sst);
+            assert_same_contents(&nested_txt, &dst_nested_txt);
+            // On Unix, verify hard links for .sst/.ldb and copies for others using inode/link count.
+            #[cfg(unix)]
+            {
+                fn assert_hard_link(src: &Path, dst: &Path) {
+                    let m_src = fs::metadata(src).unwrap();
+                    let m_dst = fs::metadata(dst).unwrap();
+                    assert_eq!(
+                        m_src.ino(),
+                        m_dst.ino(),
+                        "expected hard link between {:?} and {:?}",
+                        src,
+                        dst
+                    );
+                    assert!(
+                        m_src.nlink() >= 2,
+                        "expected src link count >= 2 for {:?}",
+                        src
+                    );
+                    assert!(
+                        m_dst.nlink() >= 2,
+                        "expected dst link count >= 2 for {:?}",
+                        dst
+                    );
+                }
+                fn assert_copied(src: &Path, dst: &Path) {
+                    let m_src = fs::metadata(src).unwrap();
+                    let m_dst = fs::metadata(dst).unwrap();
+                    // Same size but different inode indicates copy (not hard link).
+                    assert_eq!(
+                        m_src.len(),
+                        m_dst.len(),
+                        "expected same length for copied files"
+                    );
+                    assert_ne!(
+                        m_src.ino(),
+                        m_dst.ino(),
+                        "expected different inodes for copied files"
+                    );
+                }
+                assert_hard_link(&sst_file, &dst_sst);
+                assert_hard_link(&ldb_file, &dst_ldb);
+                assert_hard_link(&nested_sst, &dst_nested_sst);
+                assert_copied(&txt_file, &dst_txt);
+                assert_copied(&nested_txt, &dst_nested_txt);
+            }
+            // Cleanup.
+            let _ = fs::remove_dir_all(&src_root);
+            let _ = fs::remove_dir_all(&dst_root);
+        }
     }
 }

--- a/curvine-common/src/rocksdb/write_batch.rs
+++ b/curvine-common/src/rocksdb/write_batch.rs
@@ -52,9 +52,13 @@ impl<'a> WriteBatch<'a> {
         self.db.write_batch(self.batch)
     }
 
-    pub fn commit_wal(self, sync: bool) -> CommonResult<()> {
+    pub fn commit_flush(self, sync: bool) -> CommonResult<()> {
         self.db.write_batch(self.batch)?;
-        self.db.flush_wal(sync)?;
+        self.db.flush(sync)?;
         Ok(())
+    }
+
+    pub fn commit_sync(self) -> CommonResult<()> {
+        self.commit_flush(true)
     }
 }

--- a/curvine-server/src/master/journal/journal_loader.rs
+++ b/curvine-server/src/master/journal/journal_loader.rs
@@ -646,26 +646,37 @@ impl JournalLoader {
 
     // Clean up expired checkpoints.
     pub fn purge_checkpoint(&self, current_ck: impl AsRef<str>) -> CommonResult<()> {
-        let ck_dir = match Path::new(current_ck.as_ref()).parent() {
+        let current_ck = current_ck.as_ref();
+        let ck_dir = match Path::new(current_ck).parent() {
             None => return Ok(()),
             Some(v) => v,
+        };
+
+        let current_mtime = match Path::new(current_ck).metadata() {
+            Ok(meta) => FileUtils::mtime(&meta)?,
+            Err(_) => return Ok(()),
         };
 
         let mut vec = vec![];
         for entry in fs::read_dir(ck_dir)? {
             let entry = entry?;
             let meta = entry.metadata()?;
-            vec.push((FileUtils::mtime(&meta)?, entry.path()));
+            let mtime = FileUtils::mtime(&meta)?;
+            if mtime < current_mtime {
+                vec.push((mtime, entry.path()));
+            }
         }
 
-        // Sort by modification time
+        // Sort oldest-first and keep at most (retain_checkpoint_num - 1) older
+        // checkpoints so that together with current_ck the total is retain_checkpoint_num.
         vec.sort_by_key(|x| x.0);
-        let del_num = vec.len().saturating_sub(self.retain_checkpoint_num);
+        let keep = self.retain_checkpoint_num.saturating_sub(1);
+        let del_num = vec.len().saturating_sub(keep);
 
         for i in 0..del_num {
             let path = vec[i].1.as_path();
             FileUtils::delete_path(path, true)?;
-            info!("delete expired checkpoint, dir: {}", path.to_string_lossy())
+            info!("delete expired checkpoint: {}", path.to_string_lossy());
         }
 
         Ok(())

--- a/curvine-server/src/master/meta/fs_dir.rs
+++ b/curvine-server/src/master/meta/fs_dir.rs
@@ -27,7 +27,7 @@ use curvine_common::state::{
     MkdirOpts, MountInfo, RenameFlags, SetAttrOpts, WorkerAddress,
 };
 use curvine_common::FsResult;
-use log::{info, warn};
+use log::{debug, info, warn};
 use orpc::common::{LocalTime, TimeSpent};
 use orpc::sync::AtomicCounter;
 use orpc::{err_box, err_ext, try_option, CommonResult};
@@ -94,7 +94,9 @@ impl FsDir {
     }
 
     pub fn update_op_id(&self, op_id: u64) {
-        self.op_id.set(op_id);
+        if op_id > self.op_id.get() {
+            self.op_id.set(op_id);
+        }
     }
 
     pub fn get_ttl_bucket_list(&self) -> Arc<TtlBucketList> {
@@ -362,7 +364,7 @@ impl FsDir {
         let name = inp.name().to_string();
 
         // Create an inode file node.
-        let file = InodeFile::with_opts(self.inode_id.next()?, LocalTime::mills() as i64, opts);
+        let file = InodeFile::with_opts(self.next_inode_id()?, LocalTime::mills() as i64, opts);
         inp = self.add_last_inode(inp, File(name, file))?;
         self.journal_writer.log_create_file(self, &inp)?;
 
@@ -582,9 +584,9 @@ impl FsDir {
                     Ok(true)
                 } else {
                     err_box!(
-                        "block_id {} resolves to inode_id {} which is not a file",
+                        "block_id {} resolves to inode {:?} which is not a file",
                         block_id,
-                        file_id
+                        v
                     )
                 }
             }
@@ -676,7 +678,7 @@ impl FsDir {
         let mut spend = TimeSpent::new();
         let path = path.as_ref();
 
-        // Set to other values ​​first to facilitate memory recycling.
+        // Set to other value first to facilitate memory recycling.
         self.root_dir = Self::create_root();
 
         // Reset rocksdb
@@ -691,10 +693,10 @@ impl FsDir {
         let time2 = spend.used_ms();
 
         info!(
-            "Restore from {}, restore rocksdb used {} ms, \
+            "restore from {}, restore rocksdb used {} ms, \
         build in-memory directory tree used {} ms, \
-        statistics updated during tree reconstruction",
-            path, time1, time2
+        statistics updated during tree reconstruction, last_inode_id {}",
+            path, time1, time2, last_inode_id
         );
         Ok(())
     }
@@ -985,7 +987,7 @@ impl FsDir {
             return Ok(DeleteResult::new());
         }
         let del_blocks = file.resize(opts.clone())?;
-        info!("resize file {} success, opts: {:?}", inp.path(), opts);
+        debug!("resize file {} success, opts: {:?}", inp.path(), opts);
 
         file.complete(file.len, &[], "", true)?;
         let mut del_res = DeleteResult::new();

--- a/curvine-server/src/master/meta/inode/inodes_children.rs
+++ b/curvine-server/src/master/meta/inode/inodes_children.rs
@@ -153,8 +153,8 @@ impl InodeChildren {
                         // But return owned pointer to complete object
                         Ok(InodePtr::from_owned(*inode))
                     } else {
-                        // Directory directly stores complete object and returns its reference
-                        let inserted = v.insert(inode.clone());
+                        // Directory: move ownership into the map and return a reference.
+                        let inserted = v.insert(inode);
                         Ok(InodePtr::from_ref(inserted.as_ref()))
                     }
                 }

--- a/curvine-server/src/master/meta/store/inode_store.rs
+++ b/curvine-server/src/master/meta/store/inode_store.rs
@@ -20,7 +20,7 @@ use crate::master::meta::{FileSystemStats, FsDir, LockMeta};
 use curvine_common::rocksdb::{DBConf, RocksUtils};
 use curvine_common::state::{BlockLocation, CommitBlock, FileLock, MountInfo};
 use orpc::common::{FileUtils, Utils};
-use orpc::{err_box, try_err, try_option, CommonResult};
+use orpc::{err_box, try_err, CommonResult};
 use std::collections::{HashMap, LinkedList};
 use std::sync::Arc;
 
@@ -116,7 +116,7 @@ impl InodeStore {
 
                 _ => {
                     deleted_files += 1;
-                    let res = self.decrement_inode_nlink(inode.id())?;
+                    let res = self.decrement_inode_nlink(inode.id(), &mut batch)?;
                     del_res.blocks.extend(res.blocks);
                 }
             }
@@ -264,8 +264,8 @@ impl InodeStore {
         //link is a edge, link to same inode
         batch.add_child(parent.id(), new_entry.name(), original_inode_id)?;
 
-        // Increment nlink count of the original inode
-        self.increment_inode_nlink(original_inode_id)?;
+        // Increment nlink count of the original inode (in the same batch for atomicity)
+        self.increment_inode_nlink(original_inode_id, &mut batch)?;
 
         batch.commit()?;
 
@@ -274,14 +274,16 @@ impl InodeStore {
         Ok(())
     }
 
-    fn increment_inode_nlink(&self, inode_id: i64) -> CommonResult<()> {
+    fn increment_inode_nlink(
+        &self,
+        inode_id: i64,
+        batch: &mut InodeWriteBatch<'_>,
+    ) -> CommonResult<()> {
         if let Some(mut inode_view) = self.get_inode(inode_id, None)? {
             match &mut inode_view {
                 InodeView::File(_, _) => {
                     inode_view.incr_nlink();
-                    let mut batch = self.store.new_batch();
                     batch.write_inode(&inode_view)?;
-                    batch.commit()?;
                 }
                 _ => {
                     return err_box!("Cannot increment nlink for non-file inode {}", inode_id);
@@ -306,21 +308,19 @@ impl InodeStore {
         // Remove the child from the parent's children list
         batch.delete_child(parent.id(), child.name())?;
 
-        // Decrement nlink count of the file being unlinked
-        if let InodeView::File(_, _) = child {
-            self.decrement_inode_nlink(child.id())?;
-        }
+        // Decrement nlink count of the file being unlinked.
+        // If nlink reaches 0 the inode is also deleted and del_res.blocks will be populated.
+        let del_res = if let InodeView::File(_, _) = child {
+            self.decrement_inode_nlink(child.id(), &mut batch)?
+        } else {
+            DeleteResult::new()
+        };
 
         batch.commit()?;
 
         self.fs_stats.decrement_file_count();
 
-        // Create a delete result indicating only the directory entry was removed
-        // For unlink operations, we don't delete blocks since the inode still exists
-        Ok(DeleteResult {
-            inodes: 0,                  // No inodes actually deleted
-            blocks: Default::default(), // No blocks deleted for unlink
-        })
+        Ok(del_res)
     }
 
     pub fn apply_unlink_file_entry(
@@ -337,29 +337,28 @@ impl InodeStore {
         // Remove the FileEntry from the parent's children list
         batch.delete_child(parent.id(), child.name())?;
 
-        // Decrement nlink count of the original inode
-        self.decrement_inode_nlink(inode_id)?;
+        // Decrement nlink count of the original inode.
+        // If nlink reaches 0 the inode is also deleted and del_res.blocks will be populated.
+        let del_res = self.decrement_inode_nlink(inode_id, &mut batch)?;
 
         batch.commit()?;
 
         self.fs_stats.decrement_file_count();
 
-        // Create a delete result indicating only the directory entry was removed
-        Ok(DeleteResult {
-            inodes: 0,                  // No inodes actually deleted
-            blocks: Default::default(), // No blocks deleted for unlink
-        })
+        Ok(del_res)
     }
 
     // Helper method to decrement nlink count of an inode
-    fn decrement_inode_nlink(&self, inode_id: i64) -> CommonResult<DeleteResult> {
+    fn decrement_inode_nlink(
+        &self,
+        inode_id: i64,
+        batch: &mut InodeWriteBatch<'_>,
+    ) -> CommonResult<DeleteResult> {
         let mut del_res = DeleteResult::new();
         // Load the inode from storage
         if let Some(mut inode_view) = self.get_inode(inode_id, None)? {
             match &mut inode_view {
                 InodeView::File(_, file) => {
-                    let mut batch = self.store.new_batch();
-
                     let remaining_links = file.decrement_nlink();
                     if remaining_links == 0 {
                         batch.delete_inode(inode_id)?;
@@ -375,7 +374,6 @@ impl InodeStore {
                         // Write the updated inode back to storage
                         batch.write_inode(&inode_view)?;
                     }
-                    batch.commit()?;
                 }
                 _ => {
                     return err_box!("Cannot decrement nlink for non-file inode {}", inode_id);
@@ -395,7 +393,13 @@ impl InodeStore {
 
     // Restore to a directory tree from rocksdb
     pub fn create_tree(&self) -> CommonResult<(i64, InodeView)> {
-        let mut root = FsDir::create_root();
+        // Load root metadata from DB to preserve mtime, nlink, and other attributes
+        // that have been updated since the root was first created.
+        let mut root = self
+            .store
+            .get_inode(ROOT_INODE_ID)?
+            .unwrap_or_else(FsDir::create_root);
+
         let mut stack = LinkedList::new();
         stack.push_back((
             root.as_ptr(),
@@ -409,7 +413,19 @@ impl InodeStore {
             last_inode_id = last_inode_id.max(child_id);
 
             let next_parent = if child_id != ROOT_INODE_ID {
-                let store_inode = try_option!(self.store.get_inode(child_id)?);
+                let store_inode = match self.store.get_inode(child_id)? {
+                    Some(v) => v,
+                    None => {
+                        // Orphaned edge: inode was deleted but edge was not cleaned up
+                        // (can happen after a crash between two non-atomic batch commits).
+                        // Skip this entry to keep the tree consistent.
+                        log::warn!(
+                            "create_tree: orphaned edge detected, child_id={} has no inode, skipping",
+                            child_id
+                        );
+                        continue;
+                    }
+                };
                 let inode = if matches!(store_inode, InodeView::Dir(_, _)) {
                     store_inode
                 } else {

--- a/curvine-server/src/worker/handler/write_handler.rs
+++ b/curvine-server/src/worker/handler/write_handler.rs
@@ -75,9 +75,11 @@ impl WriteHandler {
 
         if opts.len != file.len() {
             return err_box!(
-                "invalid resize operation: resize {} != actual {}",
+                "invalid resize file {} operation: resize {} != actual {}, opts={:?}",
+                file.path(),
                 opts.len,
-                file.len()
+                file.len(),
+                opts
             );
         }
 


### PR DESCRIPTION
### Summary

This PR addresses several correctness and durability issues discovered during
follower snapshot recovery testing. The changes fall into four areas:

1. **RocksDB snapshot restore** (`db_engine.rs`, `rocks_utils.rs`)
2. **Raft hard-state durability** (`rocks_storage_core.rs`, `write_batch.rs`)
3. **Checkpoint lifecycle safety** (`journal_loader.rs`)
4. **Inode nlink atomicity** (`inode_store.rs`)

---

### 1. RocksDB snapshot restore (`db_engine.rs`, `rocks_utils.rs`)

**Problem:**  
The previous `restore` implementation used `FileUtils::rename` to move the
checkpoint directory into the data path. This had two issues:
- The original checkpoint was destroyed, making it unavailable for future use.
- The old `DB` handle still held a RocksDB `LOCK` file on the data directory,
  causing `rename` or `delete` to fail or leave the DB in an inconsistent state
  on some platforms.

**Fix:**
- Added `RocksUtils::link_dir`: recursively hard-links `.sst`/`.ldb` files and
  copies all other files. Hard links share the same inode, so the checkpoint data
  remains intact while the restored DB directory gets its own independent copy.
- In `DBEngine::restore`, the old DB handle is now replaced with a throw-away DB
  opened at a temporary path *before* any filesystem operations. This releases the
  `LOCK` on the real data directory so `delete_path` succeeds. The temporary DB is
  cleaned up after the restored DB is opened successfully.
- Added an explicit `flush(true)` call at the start of `create_checkpoint` to
  ensure all memtable data is flushed to SST files before the checkpoint is taken.

```
restore flow:
  1. open tmp DB  →  old DB handle dropped, LOCK released
  2. delete_path(db_path)
  3. RocksUtils::link_dir(checkpoint → db_path)
  4. open real DB at db_path
  5. delete tmp DB directory
```

---

### 2. Raft hard-state durability (`rocks_storage_core.rs`, `write_batch.rs`)

**Problem:**  
`set_hard_state_commit` only updated the in-memory `hard_state.commit` field; it
never wrote to RocksDB. After a crash and restart the commit index was lost,
causing the node to replay already-committed entries or diverge from peers.

Additionally, `StoreWriteBatch::commit` called `commit()` (no fsync), so even
`set_hard_state` writes could be lost on a power failure.

**Fix:**
- `set_hard_state_commit` now persists the full `HardState` to RocksDB via
  `StoreWriteBatch`, identical to `set_hard_state`.
- `StoreWriteBatch::commit` is changed to `commit_sync` which calls
  `commit_flush(true)` – this flushes both the write batch and the WAL with
  `sync = true`, guaranteeing the write reaches durable storage before returning.
- `WriteBatch::commit_wal` renamed to `commit_flush` for clarity; a new
  `commit_sync` convenience method is added.

---

### 3. Checkpoint lifecycle safety (`journal_loader.rs`)

**Problem:**  
`purge_checkpoint` iterated *all* subdirectories of the checkpoint parent and
applied the `retain_checkpoint_num` limit to the sorted list. When
`retain_checkpoint_num = 1`, this could delete the very checkpoint that was just
passed as `current_ck`, causing a `No such file or directory` panic when the
follower tried to open it immediately after.

**Fix:**  
Before building the candidate list, read `current_ck`'s modification time.
Only directories with `mtime < current_mtime` are candidates for deletion.
The retention limit is applied as `retain_checkpoint_num - 1` older checkpoints
(plus `current_ck` itself = `retain_checkpoint_num` total). This guarantees the
active checkpoint is never touched.

---

### 4. Inode nlink atomicity (`inode_store.rs`)

**Problem:**  
`increment_inode_nlink` and `decrement_inode_nlink` each created their own
`InodeWriteBatch` and committed it independently. When called from `create_link`
or `unlink`, the edge mutation (add/delete child) and the nlink update were in
separate batches, so a crash between them could leave the filesystem in an
inconsistent state (edge present but nlink not updated, or vice-versa).

Additionally, `unlink` always returned an empty `DeleteResult`; if `decrement_nlink`
reduced the count to zero (inode deletion), the associated block list was silently
discarded.

**Fix:**
- Both helpers now accept an external `batch: &mut InodeWriteBatch<'_>` parameter.
  Callers pass their own batch so the nlink change is written in the same atomic
  commit as the edge operation.
- `unlink` and `apply_unlink_file_entry` now forward the `DeleteResult` returned
  by `decrement_inode_nlink` so block cleanup is correctly propagated to callers.

---

### Other minor fixes

| File | Change |
|------|--------|
| `raft_node.rs` | Log initial Raft state on startup for easier diagnostics |
| `fs_dir.rs` | `update_op_id` is now monotonic (only advances, never decreases) |
| `fs_dir.rs` | Use `next_inode_id()` helper consistently in `create_file` |
| `write_handler.rs` | Include file path and `opts` detail in resize error message |

---

### Test Plan

- [x] Leader creates snapshot, follower recovers from it – no panic, no orphaned-edge warnings
- [x] `purge_checkpoint` with `retain_checkpoint_num=1` no longer deletes the active checkpoint
- [x] Hard-link restore preserves the source checkpoint directory
- [x] `create_link` + crash recovery: nlink and edge are consistent after replay
- [x] `unlink` last hard-link: block list is returned to the caller for cleanup
