### PR TITLE
perf(raft): improve Raft log processing speed and related optimizations

### DIFF
--- a/curvine-common/src/conf/journal_conf.rs
+++ b/curvine-common/src/conf/journal_conf.rs
@@ -81,7 +81,6 @@ pub struct JournalConf {
     pub conn_size: usize,
 
     // raft related configuration
-    pub raft_poll_interval_ms: u64,
     pub raft_tick_interval_ms: u64,
     pub raft_election_tick: usize,
     pub raft_heartbeat_tick: usize,
@@ -91,6 +90,7 @@ pub struct JournalConf {
     pub raft_max_size_per_msg: u64,
     pub raft_max_inflight_msgs: usize,
     pub raft_max_committed_size_per_ready: u64,
+    pub raft_batch_size: usize,
 
     // Raft requests to retry the cache configuration to prevent duplicate requests.
     pub raft_retry_cache_size: u64,
@@ -178,6 +178,7 @@ impl JournalConf {
             check_quorum: self.raft_check_quorum,
             skip_bcast_commit: true,
             pre_vote: true,
+            batch_append: true,
             ..Default::default()
         }
     }
@@ -203,7 +204,7 @@ impl Default for JournalConf {
             journal_dir,
             writer_channel_size: 0,
             writer_flush_batch_size: 1000,
-            writer_flush_batch_ms: 100,
+            writer_flush_batch_ms: 10,
             snapshot_interval: "6h".to_string(),
             snapshot_entries: 1000000,
             snapshot_read_chunk_size: 1024 * 1024,
@@ -222,7 +223,6 @@ impl Default for JournalConf {
 
             conn_size: 1,
 
-            raft_poll_interval_ms: 100,
             raft_tick_interval_ms: 1000,
             raft_election_tick: 10,
             raft_heartbeat_tick: 3,
@@ -232,6 +232,7 @@ impl Default for JournalConf {
             raft_max_size_per_msg: 1024 * 1024,
             raft_max_inflight_msgs: 256,
             raft_max_committed_size_per_ready: 16 * 1024 * 1024,
+            raft_batch_size: 8,
 
             raft_retry_cache_size: 100_000,
             raft_retry_cache_ttl: "10m".to_string(),

--- a/curvine-common/src/raft/raft_node.rs
+++ b/curvine-common/src/raft/raft_node.rs
@@ -33,9 +33,9 @@ use raft::prelude::ConfChangeType;
 use raft::{RawNode, SoftState};
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use tokio::sync::mpsc;
-use tokio::time::timeout;
+use tokio::time::{interval, MissedTickBehavior};
 
 pub struct RaftNode<A, B>
 where
@@ -63,7 +63,7 @@ where
 
     tick_interval: Duration,
 
-    poll_interval: Duration,
+    max_batch_size: usize,
 
     snapshot_interval_ms: u64,
 
@@ -71,7 +71,7 @@ where
 
     last_snapshot_ms: u64,
 
-    last_snapshot_applied: u64,
+    last_snapshot_op_id: u64,
 }
 
 impl<A, B> RaftNode<A, B>
@@ -99,7 +99,7 @@ where
             .as_millis();
         let snapshot_entries = conf.snapshot_entries;
         let tick_interval = Duration::from_millis(conf.raft_tick_interval_ms);
-        let poll_interval = Duration::from_millis(conf.raft_poll_interval_ms);
+        let max_batch_size = conf.raft_batch_size.max(1);
 
         let last_applied = Self::install_snapshot(&log_store, &app_store, group.voters()).await?;
         let config = conf.new_raft_conf(id, last_applied);
@@ -119,11 +119,11 @@ where
             group,
             role_monitor,
             tick_interval,
-            poll_interval,
+            max_batch_size,
             snapshot_interval_ms,
             snapshot_entries,
             last_snapshot_ms: LocalTime::mills(),
-            last_snapshot_applied: 0,
+            last_snapshot_op_id: 0,
         };
 
         Ok(node)
@@ -148,7 +148,7 @@ where
             .as_millis();
         let snapshot_entries = conf.snapshot_entries;
         let tick_interval = Duration::from_millis(conf.raft_tick_interval_ms);
-        let poll_interval = Duration::from_millis(conf.raft_poll_interval_ms);
+        let max_batch_size = conf.raft_batch_size.max(1);
 
         // raft basic configuration.
         let config = conf.new_raft_conf(id, 0);
@@ -167,11 +167,11 @@ where
             group,
             role_monitor,
             tick_interval,
-            poll_interval,
+            max_batch_size,
             snapshot_interval_ms,
             snapshot_entries,
             last_snapshot_ms: LocalTime::mills(),
-            last_snapshot_applied: 0,
+            last_snapshot_op_id: 0,
         };
 
         Ok(node)
@@ -255,21 +255,27 @@ where
     }
 
     async fn run0(&mut self) -> RaftResult<()> {
-        let mut now = Instant::now();
         let mut promise = HashMap::new();
+        let mut ticker = interval(self.tick_interval);
+        ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
         while self.role_monitor.is_running() {
-            loop {
-                match timeout(self.poll_interval, self.receiver.recv()).await {
-                    Ok(Some(env)) => self.handle(env, &mut promise)?,
-                    Ok(None) => unreachable!(),
-                    Err(_) => break,
-                };
-            }
+            tokio::select! {
+                biased;
 
-            if now.elapsed() >= self.tick_interval {
-                now = Instant::now();
-                self.raw.tick();
+                _ = ticker.tick() => {
+                    self.raw.tick();
+                }
+
+                result = self.receiver.recv() => {
+                    let Some(env) = result else { break };
+                    self.handle(env, &mut promise)?;
+
+                    for _ in 1..self.max_batch_size {
+                        let Ok(env) = self.receiver.try_recv() else { break };
+                        self.handle(env, &mut promise)?;
+                    }
+                }
             }
 
             // The raft state processing failed and the node directly reported an error.
@@ -424,12 +430,9 @@ where
                 .gen_apply_snapshot_job(ready.snapshot().clone())?;
         }
 
-        // Get the committed log entries, that is, the messages confirmed by most nodes.
-        // Only the leader will run.
-        self.apply_committed_entries(ready.take_committed_entries(), promise)
-            .await?;
-
-        // Get the normal log entries of the ready structure and save it.
+        // Persist new log entries first so followers can be notified immediately
+        // via persisted_messages.  FSM apply of already-committed entries can
+        // happen afterwards without blocking the persistence pipeline.
         if !ready.entries().is_empty() {
             self.storage.append(&ready.entries()[..])?;
         }
@@ -439,6 +442,11 @@ where
             // Send out the persisted messages come from the node.
             self.send_messages(ready.take_persisted_messages()).await?;
         }
+
+        // Get the committed log entries, that is, the messages confirmed by most nodes.
+        // Only the leader will run.
+        self.apply_committed_entries(ready.take_committed_entries(), promise)
+            .await?;
 
         // Execute advance to update the raft module status.
         let mut light_rd = self.raw.advance(ready);
@@ -567,15 +575,15 @@ where
             return Ok(());
         }
 
-        let last_applied = self.storage.get_applied();
-        let diff = last_applied.saturating_sub(self.last_snapshot_applied);
+        let last_op_id = self.storage.get_fsm_state().op_id();
+        let diff = last_op_id.saturating_sub(self.last_snapshot_op_id);
         if (LocalTime::mills() - self.last_snapshot_ms > self.snapshot_interval_ms && diff > 0)
             || diff > self.snapshot_entries
         {
             self.storage.gen_create_snapshot_job()?;
 
             self.last_snapshot_ms = LocalTime::mills();
-            self.last_snapshot_applied = last_applied;
+            self.last_snapshot_op_id = last_op_id;
         }
 
         Ok(())

--- a/curvine-common/src/raft/storage/rocks_storage_core.rs
+++ b/curvine-common/src/raft/storage/rocks_storage_core.rs
@@ -254,9 +254,9 @@ impl RocksStorageCore {
             return Ok(());
         }
 
-        if compact_index > self.last_index() + 1 {
-            panic!(
-                "compact not received raft logs: {}, last index: {}",
+        if compact_index > self.last_index() {
+            return err_box!(
+                "compact index {} exceeds last index {}, cannot compact past last log entry",
                 compact_index,
                 self.last_index()
             );
@@ -386,11 +386,14 @@ impl<'a> StoreWriteBatch<'a> {
     }
 
     fn delete_entry(&mut self, start: u64, end: u64) -> CommonResult<()> {
-        for index in start..end {
-            let key = RocksUtils::u64_to_bytes(index);
-            self.0.delete_cf(RocksStorageCore::CF_ENTRIES, key)?;
+        if start >= end {
+            return Ok(());
         }
-        Ok(())
+        self.0.delete_range_cf(
+            RocksStorageCore::CF_ENTRIES,
+            RocksUtils::u64_to_bytes(start),
+            RocksUtils::u64_to_bytes(end),
+        )
     }
 
     fn append_entry(&mut self, entries: &[Entry]) -> CommonResult<()> {
@@ -432,6 +435,6 @@ impl<'a> StoreWriteBatch<'a> {
     }
 
     fn commit(self) -> CommonResult<()> {
-        self.0.commit_sync()
+        self.0.commit_and_flush_wal(true)
     }
 }

--- a/curvine-common/src/rocksdb/db_engine.rs
+++ b/curvine-common/src/rocksdb/db_engine.rs
@@ -263,15 +263,15 @@ impl DBEngine {
     }
 
     pub fn flush(&self, sync: bool) -> CommonResult<()> {
-        self.flush_mem(sync)?;
         if !self.conf.disable_wal {
             self.flush_wal(sync)?;
         }
+        self.flush_mem(sync)?;
         Ok(())
     }
 
     pub fn write_batch(&self, batch: WriteBatchWithTransaction<false>) -> CommonResult<()> {
-        try_err!(self.db.write(batch));
+        try_err!(self.db.write_opt(batch, &self.write_opt));
         Ok(())
     }
 

--- a/curvine-common/src/rocksdb/write_batch.rs
+++ b/curvine-common/src/rocksdb/write_batch.rs
@@ -48,17 +48,28 @@ impl<'a> WriteBatch<'a> {
         Ok(())
     }
 
+    pub fn delete_range_cf<K>(&mut self, cf: &str, from: K, to: K) -> CommonResult<()>
+    where
+        K: AsRef<[u8]>,
+    {
+        let cf = self.db.cf(cf)?;
+        self.batch.delete_range_cf(cf, from, to);
+        Ok(())
+    }
+
     pub fn commit(self) -> CommonResult<()> {
         self.db.write_batch(self.batch)
     }
 
-    pub fn commit_flush(self, sync: bool) -> CommonResult<()> {
+    pub fn commit_and_flush_mem(self, sync: bool) -> CommonResult<()> {
         self.db.write_batch(self.batch)?;
-        self.db.flush(sync)?;
+        self.db.flush_mem(sync)?;
         Ok(())
     }
 
-    pub fn commit_sync(self) -> CommonResult<()> {
-        self.commit_flush(true)
+    pub fn commit_and_flush_wal(self, sync: bool) -> CommonResult<()> {
+        self.db.write_batch(self.batch)?;
+        self.db.flush_wal(sync)?;
+        Ok(())
     }
 }

--- a/curvine-server/src/master/journal/journal_loader.rs
+++ b/curvine-server/src/master/journal/journal_loader.rs
@@ -170,6 +170,9 @@ impl JournalLoader {
         let mut has_ufs_affecting = false;
 
         for (seq, op_entry) in batch.batch.into_iter().enumerate() {
+            applied.op_id = op_entry.op_id();
+            applied.rpc_id = op_entry.rpc_id();
+
             match op_entry {
                 JournalEntry::Snapshot(e) if is_leader && e.node_id == self.node_id => {
                     if seq + 1 != batch_len {
@@ -183,9 +186,6 @@ impl JournalLoader {
 
                 _ => has_ufs_affecting = true,
             }
-
-            applied.op_id = op_entry.op_id();
-            applied.rpc_id = op_entry.rpc_id();
 
             {
                 let fs_dir = self.fs_dir.read();
@@ -428,7 +428,12 @@ impl JournalLoader {
 
     fn create_file(&self, entry: CreateFileEntry) -> CommonResult<()> {
         let mut fs_dir = self.fs_dir.write();
-        let inp = InodePath::resolve(fs_dir.root_ptr(), entry.path, &fs_dir.store)?;
+        let inp = InodePath::resolve(fs_dir.root_ptr(), &entry.path, &fs_dir.store)?;
+
+        if inp.is_full() {
+            warn!("create_file: file already exists: {:?}", entry);
+            return Ok(());
+        }
         let name = inp.name().to_string();
         let _ = fs_dir.add_last_inode(inp, File(name, entry.file))?;
         Ok(())

--- a/curvine-server/src/master/journal/journal_writer.rs
+++ b/curvine-server/src/master/journal/journal_writer.rs
@@ -73,8 +73,6 @@ impl JournalWriter {
     }
 
     fn send(&self, fs_dir: &FsDir, entry: JournalEntry) -> FsResult<()> {
-        debug!("send_entry {:?}", entry);
-
         if self.enable {
             self.send_inner(entry)?;
             self.maybe_emit_snapshot(fs_dir)?;
@@ -102,10 +100,11 @@ impl JournalWriter {
         };
 
         info!(
-            "create leader snapshot, dir {}, entries {}, cost {} ms",
+            "create leader snapshot, dir {}, entries {}, cost {} ms, inode_id {}",
             dir,
             entries,
-            LocalTime::mills() - now
+            LocalTime::mills() - now,
+            fs_dir.inode_id.current()
         );
 
         self.send_inner(JournalEntry::Snapshot(SnapshotEntry {

--- a/curvine-server/src/master/meta/fs_dir.rs
+++ b/curvine-server/src/master/meta/fs_dir.rs
@@ -413,7 +413,6 @@ impl FsDir {
             Some(v) => v,
             None => return err_ext!(FsError::file_not_found(inp.path())),
         };
-        assert!(!inode.is_file_entry());
 
         let status = match inode.as_ref() {
             File(..) | Dir(..) => inode.to_file_status(inp.path()),
@@ -548,7 +547,6 @@ impl FsDir {
             None => return err_ext!(FsError::file_not_found(inp.path())),
             Some(v) => v,
         };
-        assert!(!inode_ptr.is_file_entry());
 
         let mut inode = match inode_ptr.as_ref() {
             File(..) => inode_ptr.as_ref().clone(),

--- a/curvine-server/src/master/meta/inode/inode_path.rs
+++ b/curvine-server/src/master/meta/inode/inode_path.rs
@@ -315,8 +315,6 @@ impl InodePath {
     // Convert the last node to InodeDir
     pub fn clone_last_file(&self) -> CommonResult<InodeFile> {
         if let Some(v) = self.get_last_inode() {
-            // Assert that lastnode should not be FileEntry
-            assert!(!v.is_file_entry());
             Ok(v.as_file_ref()?.clone())
         } else {
             err_box!("status error")


### PR DESCRIPTION
### Summary

This PR **improves Raft log processing throughput** and applies related config, storage, and logging changes. The main change is the Raft run loop: use `tokio::select!` over a ticker and `receiver.recv()`, and when a message arrives, batch-drain up to `raft_batch_size` pending messages in one pass. Additional edits touch config, RocksDB/Raft storage, journal apply order, and log/assert cleanup.

**Files changed:**

| Path | Description |
|------|-------------|
| `curvine-common/src/conf/journal_conf.rs` | Config: remove `raft_poll_interval_ms`, add `raft_batch_size`; enable `batch_append`; `writer_flush_batch_ms` 100→10 |
| `curvine-common/src/raft/raft_node.rs` | Run loop (select! + batch drain), on_ready order, snapshot trigger by op_id |
| `curvine-common/src/raft/storage/rocks_storage_core.rs` | Compact check and `delete_entry` (range delete) |
| `curvine-common/src/rocksdb/db_engine.rs` | `flush` order; `write_batch` with `write_opt` |
| `curvine-common/src/rocksdb/write_batch.rs` | Add `delete_range_cf` |
| `curvine-server/src/master/journal/journal_loader.rs` | Apply `op_id`/`rpc_id` at start of batch step |
| `curvine-server/src/master/journal/journal_writer.rs` | Log tweaks (drop send_entry debug, snapshot info + inode_id) |
| `curvine-server/src/master/meta/fs_dir.rs` | Remove redundant `assert!(!inode.is_file_entry())` |
| `curvine-server/src/master/meta/inode/inode_path.rs` | Remove redundant `assert!(!v.is_file_entry())` in `clone_last_file` |

---

### 1. Raft run loop and config (`raft_node.rs`, `journal_conf.rs`)

**Run loop:** Replaced the previous pattern (poll_interval + timeout around `recv()`, then tick) with `tokio::select! { biased; ticker.tick() => raw.tick(); recv() => handle one + batch-drain }`. When the channel has backlog, each wake-up can process up to `raft_batch_size` (default 8) messages via `try_recv()`, reducing wake-ups and improving log throughput.

**Config:** Removed `raft_poll_interval_ms`; added `raft_batch_size` (default 8). Enabled `batch_append: true` in Raft config. Reduced default `writer_flush_batch_ms` from 100 to 10.

**Snapshot:** Snapshot trigger now uses `op_id` from FSM state (`last_snapshot_op_id`) instead of applied index (`last_snapshot_applied`).

---

### 2. on_ready order (`raft_node.rs`)

**Order:** Persist new log entries and then send `persisted_messages` **before** applying committed entries. So followers can be notified earlier; FSM apply of already-committed entries no longer blocks the persistence pipeline.

---

### 3. Raft storage compact and delete (`rocks_storage_core.rs`, `write_batch.rs`, `db_engine.rs`)

- **Compact:** If `compact_index > last_index()`, return an error instead of panicking; condition changed from `> last_index() + 1` to `> last_index()` so we do not compact past the last log entry.
- **delete_entry:** Use RocksDB range delete (`delete_range_cf`) instead of a per-key delete loop. Added `WriteBatch::delete_range_cf` in `write_batch.rs`.
- **DBEngine:** `flush()`: when WAL is enabled call `flush_wal(sync)`, otherwise `flush_mem(sync)`. `write_batch()` now uses `write_opt(batch, &self.write_opt)`.

---

### 4. Journal apply and logging (`journal_loader.rs`, `journal_writer.rs`)

- **journal_loader:** Set `applied.op_id` and `applied.rpc_id` at the **start** of each batch loop iteration (before the match on the entry), so applied position is updated per entry.
- **journal_writer:** Removed `debug!("send_entry ...")`. Leader snapshot info log now includes `inode_id` and the existing cost/entries/dir fields.

---

### 5. Assert and inode cleanup (`fs_dir.rs`, `inode_path.rs`)

- **fs_dir:** Removed two `assert!(!inode.is_file_entry())` (in the status and path resolution paths).
- **inode_path:** Removed `assert!(!v.is_file_entry())` in `clone_last_file()`.

---