### PR TITLE
feat(curvine-cli): auto sync metadata from ufs when mount

### DIFF
--- a/build/tests/resync_e2e.sh
+++ b/build/tests/resync_e2e.sh
@@ -12,9 +12,14 @@ BUCKET="${BUCKET:-miniocluster}"
 UFS_PREFIX="${UFS_PREFIX:-curvine-test}"
 CV_PATH="${CV_PATH:-/miniocluster/curvine-test}"
 S3_ENDPOINT_URL="${S3_ENDPOINT_URL:-http://127.0.0.1:9009}"
+S3_REGION="${S3_REGION:-cn-beigjing}"
 S3_ACCESS_KEY="${S3_ACCESS_KEY:-minio}"
 S3_SECRET_KEY="${S3_SECRET_KEY:-minio123}"
 S3_FORCE_PATH_STYLE="${S3_FORCE_PATH_STYLE:-true}"
+STRESS_FILE_COUNT="${STRESS_FILE_COUNT:-10000}"
+STRESS_MIN_FILES=1000
+STRESS_MIN_DIRS=100
+STRESS_UPLOAD_JOBS="${STRESS_UPLOAD_JOBS:-16}"
 
 run_cv() {
   "$CV_BIN" --conf "$CV_CONF" "$@"
@@ -44,6 +49,157 @@ assert_not_contains() {
   fi
 }
 
+get_last_resync_metric() {
+  local text="$1"
+  local key="$2"
+  echo "$text" | awk -v k="$key" '
+    /resync summary:/ {
+      for (i = 1; i <= NF; i++) {
+        gsub(",", "", $i)
+        split($i, kv, "=")
+        if (kv[1] == k) {
+          val = kv[2]
+        }
+      }
+    }
+    END {
+      if (val != "") {
+        print val
+      }
+    }
+  '
+}
+
+cleanup_ufs_prefix() {
+  local prefix="$1"
+  mc rm --recursive --force "$MC_ALIAS/$BUCKET/$prefix" >/dev/null 2>&1 || true
+}
+
+cleanup_mount_and_ufs() {
+  local cv_path="$1"
+  local ufs_prefix="$2"
+  run_cv umount "$cv_path" >/dev/null 2>&1 || true
+  cleanup_ufs_prefix "$ufs_prefix"
+}
+
+cleanup_cv_test_path() {
+  local cv_path="$1"
+  local entry
+
+  while read -r entry; do
+    [[ -z "$entry" ]] && continue
+    run_cv fs rm -r "$entry" >/dev/null 2>&1 || true
+  done < <(run_cv fs ls --cache-only -C "$cv_path/" 2>/dev/null || true)
+}
+
+cleanup_base_test_data() {
+  cleanup_ufs_prefix "$UFS_PREFIX"
+  cleanup_cv_test_path "$CV_PATH"
+}
+
+cleanup_previous_test_prefixes() {
+  local raw_name prefix
+  while read -r _ _ _ raw_name; do
+    [[ -z "$raw_name" ]] && continue
+    prefix="${raw_name%/}"
+    case "$prefix" in
+      "$UFS_PREFIX"-auto-*|"$UFS_PREFIX"-*-stress|"$UFS_PREFIX"-cache-mode)
+        cleanup_ufs_prefix "$prefix"
+        ;;
+    esac
+  done < <(mc ls "$MC_ALIAS/$BUCKET" 2>/dev/null || true)
+}
+
+upload_stress_dir_files() {
+  local prefix="$1"
+  local path="$2"
+  local start_idx="$3"
+  local files_in_dir="$4"
+  local seed_file="$5"
+  local idx dst
+
+  for idx in $(seq "$start_idx" $((start_idx + files_in_dir - 1))); do
+    dst="$MC_ALIAS/$BUCKET/$prefix/$path/f-$idx.txt"
+    mc cp "$seed_file" "$dst" >/dev/null
+  done
+}
+
+create_nested_stress_files() {
+  local prefix="$1"
+  local count="$2"
+  local seed_file="$3"
+  local target_dirs base_files remainder
+  local dir_idx depth file_idx created_files
+  local files_in_dir part p path
+  local -a dir_paths
+  local -a batch_pids
+
+  if ((count < STRESS_MIN_FILES)); then
+    fail "STRESS_FILE_COUNT must be >= $STRESS_MIN_FILES, got $count"
+  fi
+
+  # Compute directory distribution first:
+  # - keep at least 100 subdirectories
+  # - spread files across directories to avoid single-dir hot spot
+  target_dirs=$((count / 50))
+  if ((target_dirs < STRESS_MIN_DIRS)); then
+    target_dirs=$STRESS_MIN_DIRS
+  fi
+  if ((target_dirs > count)); then
+    target_dirs=$count
+  fi
+
+  base_files=$((count / target_dirs))
+  remainder=$((count % target_dirs))
+
+  dir_paths=()
+  for dir_idx in $(seq 1 "$target_dirs"); do
+    depth=$((3 + (dir_idx % 3)))
+    path="d1-$dir_idx"
+    for part in $(seq 2 "$depth"); do
+      p=$(((dir_idx * 17 + part * 13) % 127))
+      path="${path}/d${part}-${p}"
+    done
+    dir_paths+=("$path")
+  done
+
+  log "stress distribution: files=$count dirs=$target_dirs depth=3~5 base_files_per_dir=$base_files remainder=$remainder"
+  log "stress upload jobs: $STRESS_UPLOAD_JOBS"
+
+  batch_pids=()
+  created_files=0
+  file_idx=1
+  for dir_idx in $(seq 1 "$target_dirs"); do
+    files_in_dir=$base_files
+    if ((dir_idx <= remainder)); then
+      files_in_dir=$((files_in_dir + 1))
+    fi
+
+    path="${dir_paths[$((dir_idx - 1))]}"
+    upload_stress_dir_files "$prefix" "$path" "$file_idx" "$files_in_dir" "$seed_file" &
+    batch_pids+=("$!")
+    file_idx=$((file_idx + files_in_dir))
+    created_files=$((created_files + files_in_dir))
+
+    if ((${#batch_pids[@]} >= STRESS_UPLOAD_JOBS)); then
+      for pid in "${batch_pids[@]}"; do
+        wait "$pid" || fail "parallel stress upload failed for prefix $prefix"
+      done
+      batch_pids=()
+      log "created $created_files/$count stress files under $prefix"
+    fi
+  done
+
+  for pid in "${batch_pids[@]}"; do
+    wait "$pid" || fail "parallel stress upload failed for prefix $prefix"
+  done
+  log "created $created_files/$count stress files under $prefix"
+
+  if ((created_files != count)); then
+    fail "stress file creation mismatch: created $created_files expected $count"
+  fi
+}
+
 need_cmd mc
 need_cmd "$CV_BIN"
 
@@ -51,10 +207,17 @@ log "using CV_BIN=$CV_BIN"
 log "using CV_CONF=$CV_CONF"
 log "using MC_ALIAS=$MC_ALIAS BUCKET=$BUCKET UFS_PREFIX=$UFS_PREFIX"
 log "using S3_ENDPOINT_URL=$S3_ENDPOINT_URL S3_FORCE_PATH_STYLE=$S3_FORCE_PATH_STYLE"
+log "using STRESS_FILE_COUNT=$STRESS_FILE_COUNT"
+log "using STRESS_UPLOAD_JOBS=$STRESS_UPLOAD_JOBS"
+log "cleaning previous test prefixes in s3"
+cleanup_previous_test_prefixes
+log "cleaning previous base test data in ufs and curvine"
+cleanup_base_test_data
 
 if ! run_cv mount | grep -q "$CV_PATH"; then
   log "mount not found, creating mount for $CV_PATH"
   run_cv mount "s3://$BUCKET/$UFS_PREFIX" "$CV_PATH" \
+    --config s3.region_name="$S3_REGION" \
     --config s3.endpoint_url="$S3_ENDPOINT_URL" \
     --config s3.credentials.access="$S3_ACCESS_KEY" \
     --config s3.credentials.secret="$S3_SECRET_KEY" \
@@ -62,7 +225,7 @@ if ! run_cv mount | grep -q "$CV_PATH"; then
 fi
 
 TMP_DIR="$(mktemp -d)"
-trap 'rm -rf "$TMP_DIR"' EXIT
+trap 'cleanup_base_test_data; rm -rf "$TMP_DIR"' EXIT
 
 echo "a1" > "$TMP_DIR/a.txt"
 echo "b1" > "$TMP_DIR/b.txt"
@@ -73,6 +236,7 @@ b_mc_path="$MC_ALIAS/$BUCKET/$UFS_PREFIX/dir1/b.txt"
 c_mc_path="$MC_ALIAS/$BUCKET/$UFS_PREFIX/dir1/dir2/c.txt"
 
 log "uploading layered test files to UFS"
+cleanup_ufs_prefix "$UFS_PREFIX"
 mc cp "$TMP_DIR/a.txt" "$a_mc_path" >/dev/null
 mc cp "$TMP_DIR/b.txt" "$b_mc_path" >/dev/null
 mc cp "$TMP_DIR/c.txt" "$c_mc_path" >/dev/null
@@ -92,6 +256,8 @@ echo "$out_b"
 assert_contains "$out_b" "skip \(same mtime\)" "expected same-mtime skips"
 
 log "scenario C: cv ufs_mtime=0 -> skip"
+# Ensure source object exists in UFS so ufs_time=0 skip assertion is stable.
+mc cp "$TMP_DIR/a.txt" "$a_mc_path" >/dev/null
 run_cv fs rm --cache-only "$CV_PATH/a.txt" >/dev/null || true
 run_cv fs touch --cache-only "$CV_PATH/a.txt" >/dev/null
 out_c="$(run_cv mount resync "$CV_PATH" --verbose 2>&1)"
@@ -111,6 +277,7 @@ assert_contains "$stat_b" "ufs_mtime: [1-9][0-9]+" "expected non-zero ufs_mtime 
 # Scenario E: resync on cache_mode mount must fail with clear error
 CACHE_MODE_CV_PATH="${CV_PATH}-cache-mode"
 CACHE_MODE_UFS_PREFIX="${UFS_PREFIX}-cache-mode"
+cleanup_mount_and_ufs "$CACHE_MODE_CV_PATH" "$CACHE_MODE_UFS_PREFIX"
 if run_cv mount | grep -q "$CACHE_MODE_CV_PATH"; then
   run_cv umount "$CACHE_MODE_CV_PATH" >/dev/null 2>&1 || true
 fi
@@ -125,7 +292,74 @@ run_cv mount "s3://$BUCKET/$CACHE_MODE_UFS_PREFIX" "$CACHE_MODE_CV_PATH" \
 out_resync_reject="$(run_cv mount resync "$CACHE_MODE_CV_PATH" 2>&1)" || true
 assert_contains "$out_resync_reject" "resync is only allowed for fs_mode" "resync on cache_mode mount must report fs_mode-only error"
 assert_contains "$out_resync_reject" "cache_mode" "error message must mention current write_type cache_mode"
-run_cv umount "$CACHE_MODE_CV_PATH" >/dev/null 2>&1 || true
+cleanup_mount_and_ufs "$CACHE_MODE_CV_PATH" "$CACHE_MODE_UFS_PREFIX"
 log "scenario E: resync correctly rejected for cache_mode mount"
+
+# Scenario F: first mount auto-resync should create nested CV dirs and avoid list-status errors.
+AUTO_TAG="$(date +%s)-$$"
+AUTO_UFS_PREFIX="${UFS_PREFIX}-auto-${AUTO_TAG}"
+AUTO_CV_PATH="${CV_PATH}-auto-${AUTO_TAG}"
+cleanup_mount_and_ufs "$AUTO_CV_PATH" "$AUTO_UFS_PREFIX"
+auto_a_mc_path="$MC_ALIAS/$BUCKET/$AUTO_UFS_PREFIX/dir_auto/a.txt"
+auto_b_mc_path="$MC_ALIAS/$BUCKET/$AUTO_UFS_PREFIX/dir_auto/dir2/b.txt"
+echo "auto-a" > "$TMP_DIR/auto-a.txt"
+echo "auto-b" > "$TMP_DIR/auto-b.txt"
+mc cp "$TMP_DIR/auto-a.txt" "$auto_a_mc_path" >/dev/null
+mc cp "$TMP_DIR/auto-b.txt" "$auto_b_mc_path" >/dev/null
+log "scenario F: first mount auto-resync should not fail on missing cv dirs"
+out_f="$(run_cv mount "s3://$BUCKET/$AUTO_UFS_PREFIX" "$AUTO_CV_PATH" \
+  --config s3.endpoint_url="$S3_ENDPOINT_URL" \
+  --config s3.credentials.access="$S3_ACCESS_KEY" \
+  --config s3.credentials.secret="$S3_SECRET_KEY" \
+  --config s3.force.path.style="$S3_FORCE_PATH_STYLE" 2>&1)"
+echo "$out_f"
+assert_contains "$out_f" "first mount detected, start resync" "expected auto resync on first mount"
+assert_not_contains "$out_f" "failed to list cv dir" "auto-resync should create missing cv dirs before listing"
+assert_not_contains "$out_f" "resync summary:.*failed=[1-9][0-9]*" "auto-resync should not report failures for missing cv dirs"
+cleanup_mount_and_ufs "$AUTO_CV_PATH" "$AUTO_UFS_PREFIX"
+
+# Scenario G: stress test with 10000 nested files and verify metadata sync.
+STRESS_TAG="$(date +%s)-$$-stress"
+STRESS_UFS_PREFIX="${UFS_PREFIX}-${STRESS_TAG}"
+STRESS_CV_PATH="${CV_PATH}-${STRESS_TAG}"
+cleanup_mount_and_ufs "$STRESS_CV_PATH" "$STRESS_UFS_PREFIX"
+echo "stress-seed" > "$TMP_DIR/stress-seed.txt"
+log "scenario G: creating $STRESS_FILE_COUNT nested files in UFS for stress test"
+create_nested_stress_files "$STRESS_UFS_PREFIX" "$STRESS_FILE_COUNT" "$TMP_DIR/stress-seed.txt"
+log "scenario G: mount and trigger auto resync for stress path"
+out_g_mount="$(run_cv mount "s3://$BUCKET/$STRESS_UFS_PREFIX" "$STRESS_CV_PATH" \
+  --config s3.endpoint_url="$S3_ENDPOINT_URL" \
+  --config s3.credentials.access="$S3_ACCESS_KEY" \
+  --config s3.credentials.secret="$S3_SECRET_KEY" \
+  --config s3.force.path.style="$S3_FORCE_PATH_STYLE" 2>&1)"
+echo "$out_g_mount"
+assert_contains "$out_g_mount" "first mount detected, start resync" "stress mount should trigger auto resync"
+assert_not_contains "$out_g_mount" "resync summary:.*failed=[1-9][0-9]*" "stress auto-resync should finish without failures"
+stress_scanned="$(get_last_resync_metric "$out_g_mount" "scanned")"
+stress_recreated="$(get_last_resync_metric "$out_g_mount" "recreated")"
+stress_skip_same="$(get_last_resync_metric "$out_g_mount" "skip_same_mtime")"
+stress_skip_zero="$(get_last_resync_metric "$out_g_mount" "skip_ufs_time_zero")"
+if [[ -z "$stress_scanned" || -z "$stress_recreated" || -z "$stress_skip_same" || -z "$stress_skip_zero" ]]; then
+  fail "cannot parse stress resync summary from mount output"
+fi
+if ((stress_scanned != STRESS_FILE_COUNT)); then
+  fail "stress scanned mismatch: got $stress_scanned expected $STRESS_FILE_COUNT"
+fi
+if ((stress_recreated != STRESS_FILE_COUNT)); then
+  fail "stress recreated mismatch: got $stress_recreated expected $STRESS_FILE_COUNT"
+fi
+if ((stress_skip_same != 0 || stress_skip_zero != 0)); then
+  fail "stress skip mismatch: skip_same_mtime=$stress_skip_same skip_ufs_time_zero=$stress_skip_zero expected 0"
+fi
+
+log "scenario G: verify synced metadata count == $STRESS_FILE_COUNT"
+stress_listing="$(run_cv fs ls --cache-only -C -R "$STRESS_CV_PATH" 2>&1)"
+stress_file_count="$(echo "$stress_listing" | grep -cE "/f-[0-9]+\\.txt$")"
+if ((stress_file_count != STRESS_FILE_COUNT)); then
+  fail "stress sync file count mismatch: got $stress_file_count expected $STRESS_FILE_COUNT"
+fi
+cleanup_mount_and_ufs "$STRESS_CV_PATH" "$STRESS_UFS_PREFIX"
+cleanup_previous_test_prefixes
+cleanup_base_test_data
 
 pass "all resync scenarios passed"

--- a/build/tests/resync_e2e.sh
+++ b/build/tests/resync_e2e.sh
@@ -12,7 +12,7 @@ BUCKET="${BUCKET:-miniocluster}"
 UFS_PREFIX="${UFS_PREFIX:-curvine-test}"
 CV_PATH="${CV_PATH:-/miniocluster/curvine-test}"
 S3_ENDPOINT_URL="${S3_ENDPOINT_URL:-http://127.0.0.1:9009}"
-S3_REGION="${S3_REGION:-cn-beigjing}"
+S3_REGION="${S3_REGION:-cn-beijing}"
 S3_ACCESS_KEY="${S3_ACCESS_KEY:-minio}"
 S3_SECRET_KEY="${S3_SECRET_KEY:-minio123}"
 S3_FORCE_PATH_STYLE="${S3_FORCE_PATH_STYLE:-true}"
@@ -225,7 +225,7 @@ if ! run_cv mount | grep -q "$CV_PATH"; then
 fi
 
 TMP_DIR="$(mktemp -d)"
-trap 'cleanup_base_test_data; rm -rf "$TMP_DIR"' EXIT
+trap 'cleanup_previous_test_prefixes; cleanup_base_test_data; rm -rf "$TMP_DIR"' EXIT
 
 echo "a1" > "$TMP_DIR/a.txt"
 echo "b1" > "$TMP_DIR/b.txt"
@@ -284,6 +284,7 @@ fi
 log "creating cache_mode mount at $CACHE_MODE_CV_PATH for resync rejection test"
 run_cv mount "s3://$BUCKET/$CACHE_MODE_UFS_PREFIX" "$CACHE_MODE_CV_PATH" \
   --write-type cache_mode \
+  --config s3.region_name="$S3_REGION" \
   --config s3.endpoint_url="$S3_ENDPOINT_URL" \
   --config s3.credentials.access="$S3_ACCESS_KEY" \
   --config s3.credentials.secret="$S3_SECRET_KEY" \
@@ -308,6 +309,7 @@ mc cp "$TMP_DIR/auto-a.txt" "$auto_a_mc_path" >/dev/null
 mc cp "$TMP_DIR/auto-b.txt" "$auto_b_mc_path" >/dev/null
 log "scenario F: first mount auto-resync should not fail on missing cv dirs"
 out_f="$(run_cv mount "s3://$BUCKET/$AUTO_UFS_PREFIX" "$AUTO_CV_PATH" \
+  --config s3.region_name="$S3_REGION" \
   --config s3.endpoint_url="$S3_ENDPOINT_URL" \
   --config s3.credentials.access="$S3_ACCESS_KEY" \
   --config s3.credentials.secret="$S3_SECRET_KEY" \
@@ -328,6 +330,7 @@ log "scenario G: creating $STRESS_FILE_COUNT nested files in UFS for stress test
 create_nested_stress_files "$STRESS_UFS_PREFIX" "$STRESS_FILE_COUNT" "$TMP_DIR/stress-seed.txt"
 log "scenario G: mount and trigger auto resync for stress path"
 out_g_mount="$(run_cv mount "s3://$BUCKET/$STRESS_UFS_PREFIX" "$STRESS_CV_PATH" \
+  --config s3.region_name="$S3_REGION" \
   --config s3.endpoint_url="$S3_ENDPOINT_URL" \
   --config s3.credentials.access="$S3_ACCESS_KEY" \
   --config s3.credentials.secret="$S3_SECRET_KEY" \

--- a/curvine-cli/src/cmds/mount.rs
+++ b/curvine-cli/src/cmds/mount.rs
@@ -15,7 +15,7 @@
 use crate::util::*;
 use clap::Parser;
 use curvine_client::unified::{UfsFileSystem, UnifiedFileSystem};
-use curvine_common::error::FsError;
+use curvine_common::error::{ErrorKind, FsError};
 use curvine_common::fs::{FileSystem, Path};
 use curvine_common::state::{
     MountOptions, Provider, SetAttrOptsBuilder, StorageType, TtlAction, WriteType,
@@ -150,9 +150,7 @@ impl ResyncProgress {
 }
 
 fn is_cv_dir_missing(err: &FsError) -> bool {
-    matches!(err, FsError::FileNotFound(_) | FsError::Expired(_))
-        || err.to_string().contains("not exists")
-        || err.to_string().contains("not found")
+    matches!(err.kind(), ErrorKind::FileNotFound | ErrorKind::Expired)
 }
 
 impl MountCommand {

--- a/curvine-cli/src/cmds/mount.rs
+++ b/curvine-cli/src/cmds/mount.rs
@@ -24,6 +24,8 @@ use curvine_common::utils::ProtoUtils;
 use orpc::common::{ByteUnit, DurationUnit};
 use orpc::{err_box, CommonResult};
 use std::collections::{HashMap, VecDeque};
+use std::io::{self, Write};
+use std::time::{Duration, Instant};
 
 #[derive(Parser, Debug)]
 pub struct MountCommand {
@@ -93,6 +95,64 @@ struct ResyncStats {
     skip_ufs_time_zero: usize,
     recreated: usize,
     failed: usize,
+}
+
+struct ResyncProgress {
+    label: String,
+    start: Instant,
+    last_print: Instant,
+    interval: Duration,
+}
+
+impl ResyncProgress {
+    fn new(label: impl Into<String>) -> Self {
+        let now = Instant::now();
+        Self {
+            label: label.into(),
+            start: now,
+            last_print: now.checked_sub(Duration::from_millis(500)).unwrap_or(now),
+            interval: Duration::from_millis(500),
+        }
+    }
+
+    fn tick(&mut self, stats: &ResyncStats, pending_dirs: usize) {
+        let now = Instant::now();
+        if now.duration_since(self.last_print) < self.interval {
+            return;
+        }
+        self.last_print = now;
+        self.render(stats, pending_dirs, false);
+    }
+
+    fn finish(&mut self, stats: &ResyncStats) {
+        self.render(stats, 0, true);
+    }
+
+    fn render(&self, stats: &ResyncStats, pending_dirs: usize, done: bool) {
+        let elapsed = self.start.elapsed().as_secs_f32();
+        let status = if done { "done" } else { "running" };
+        eprint!(
+            "\r[resync:{}] status={} elapsed={:.1}s scanned={} recreated={} skipped={} failed={} pending_dirs={}",
+            self.label,
+            status,
+            elapsed,
+            stats.scanned,
+            stats.recreated,
+            stats.skip_same_mtime + stats.skip_ufs_time_zero,
+            stats.failed,
+            pending_dirs
+        );
+        let _ = io::stderr().flush();
+        if done {
+            eprintln!();
+        }
+    }
+}
+
+fn is_cv_dir_missing(err: &FsError) -> bool {
+    matches!(err, FsError::FileNotFound(_) | FsError::Expired(_))
+        || err.to_string().contains("not exists")
+        || err.to_string().contains("not found")
 }
 
 impl MountCommand {
@@ -236,6 +296,9 @@ impl MountCommand {
         }
 
         let mnt_opts = self.to_mnt_opts()?;
+        let should_auto_resync = !self.update
+            && matches!(mnt_opts.write_type, WriteType::FsMode)
+            && fs.fs_client().get_mount_info(&cv_path).await?.is_none();
 
         let ufs = UfsFileSystem::new(
             &ufs_path,
@@ -249,20 +312,32 @@ impl MountCommand {
 
         handle_rpc_result(fs.mount(&ufs_path, &cv_path, mnt_opts)).await;
         println!("│ ✅️ mount success.");
+        if should_auto_resync {
+            println!("│ 🔄 first mount detected, start resync...");
+            self.run_resync(&fs, &cv_path, "auto").await?;
+        }
         Ok(())
     }
 
     async fn execute_resync(&self, fs: UnifiedFileSystem) -> CommonResult<()> {
-        let cv_root = Path::from_str(&self.cv_path)?;
-        if !cv_root.is_cv() {
+        let cv_path = Path::from_str(&self.cv_path)?;
+        if !cv_path.is_cv() {
             return err_box!("resync requires a curvine path, got: {}", self.cv_path);
         }
+        self.run_resync(&fs, &cv_path, "manual").await
+    }
 
+    async fn run_resync(
+        &self,
+        fs: &UnifiedFileSystem,
+        cv_path: &Path,
+        trigger: &str,
+    ) -> CommonResult<()> {
         let client = fs.fs_client();
 
-        let mount = match client.get_mount_info(&cv_root).await? {
+        let mount = match client.get_mount_info(cv_path).await? {
             Some(v) => v,
-            None => return err_box!("mount info not found for {}", self.cv_path),
+            None => return err_box!("mount info not found for {}", cv_path),
         };
 
         if !mount.is_fs_mode() {
@@ -274,7 +349,7 @@ impl MountCommand {
                 "resync is only allowed for fs_mode mount; mount point \"{}\" (requested path \"{}\") has write_type \"{}\". \
                 Create the mount with --write-type fs_mode to use resync.",
                 mount.cv_path,
-                self.cv_path,
+                cv_path,
                 write_type_str
             );
         }
@@ -284,6 +359,8 @@ impl MountCommand {
 
         let mut stats = ResyncStats::default();
         let mut queue = VecDeque::from([ufs_root.clone()]);
+        let mut progress = ResyncProgress::new(trigger);
+        progress.tick(&stats, queue.len());
 
         while let Some(ufs_dir) = queue.pop_front() {
             let ufs_entries = match ufs.list_status(&ufs_dir).await {
@@ -291,17 +368,26 @@ impl MountCommand {
                 Err(e) => {
                     stats.failed += 1;
                     eprintln!("[resync] failed to list ufs dir {}: {}", ufs_dir, e);
+                    progress.tick(&stats, queue.len());
                     continue;
                 }
             };
 
             let cv_dir = mount.get_cv_path(&ufs_dir)?;
+            if let Err(e) = fs.cv().mkdir(&cv_dir, true).await {
+                stats.failed += 1;
+                eprintln!("[resync] failed to create cv dir {}: {}", cv_dir, e);
+                progress.tick(&stats, queue.len());
+                continue;
+            }
+
             let cv_entries = match fs.cv().list_status(&cv_dir).await {
                 Ok(v) => v,
-                Err(FsError::FileNotFound(_) | FsError::Expired(_)) => vec![],
+                Err(e) if is_cv_dir_missing(&e) => vec![],
                 Err(e) => {
                     stats.failed += 1;
                     eprintln!("[resync] failed to list cv dir {}: {}", cv_dir, e);
+                    progress.tick(&stats, queue.len());
                     continue;
                 }
             };
@@ -315,6 +401,7 @@ impl MountCommand {
                 let ufs_path = Path::from_str(ufs_entry.path)?;
                 if ufs_entry.is_dir {
                     queue.push_back(ufs_path);
+                    progress.tick(&stats, queue.len());
                     continue;
                 }
 
@@ -331,6 +418,7 @@ impl MountCommand {
                         if self.verbose {
                             println!("[resync] skip (ufs_time=0): {}", cv_path);
                         }
+                        progress.tick(&stats, queue.len());
                         continue;
                     }
 
@@ -339,6 +427,7 @@ impl MountCommand {
                         if self.verbose {
                             println!("[resync] skip (same mtime): {}", cv_path);
                         }
+                        progress.tick(&stats, queue.len());
                         continue;
                     }
 
@@ -351,12 +440,14 @@ impl MountCommand {
 
                     if self.dry_run {
                         stats.recreated += 1;
+                        progress.tick(&stats, queue.len());
                         continue;
                     }
 
                     if let Err(e) = client.delete(&cv_path, false).await {
                         stats.failed += 1;
                         eprintln!("[resync] failed to delete {}: {}", cv_path, e);
+                        progress.tick(&stats, queue.len());
                         continue;
                     }
                 } else if self.verbose || self.dry_run {
@@ -368,6 +459,7 @@ impl MountCommand {
 
                 if self.dry_run {
                     stats.recreated += 1;
+                    progress.tick(&stats, queue.len());
                     continue;
                 }
 
@@ -377,6 +469,7 @@ impl MountCommand {
                 if let Err(e) = client.create_with_opts(&cv_path, create_opts, true).await {
                     stats.failed += 1;
                     eprintln!("[resync] failed to create {}: {}", cv_path, e);
+                    progress.tick(&stats, queue.len());
                     continue;
                 }
 
@@ -384,6 +477,7 @@ impl MountCommand {
                 if let Err(e) = client.complete_file(&cv_path, 0, Vec::new(), false).await {
                     stats.failed += 1;
                     eprintln!("[resync] failed to complete {}: {}", cv_path, e);
+                    progress.tick(&stats, queue.len());
                     continue;
                 }
 
@@ -395,13 +489,16 @@ impl MountCommand {
                 if let Err(e) = client.set_attr(&cv_path, attr_opts).await {
                     stats.failed += 1;
                     eprintln!("[resync] failed to set attr {}: {}", cv_path, e);
+                    progress.tick(&stats, queue.len());
                     continue;
                 }
 
                 stats.recreated += 1;
+                progress.tick(&stats, queue.len());
             }
         }
 
+        progress.finish(&stats);
         println!(
             "resync summary: scanned={}, skip_same_mtime={}, skip_ufs_time_zero={}, recreated={}, failed={}",
             stats.scanned,


### PR DESCRIPTION
## Problem
Mount resync on fs_mode lacked first-mount auto synchronization and had weak visibility for long sync runs. Existing e2e coverage was also too shallow for nested/batch metadata synchronization.

## Design
Unify manual and auto resync into one reusable flow with in-place progress reporting. Ensure missing Curvine directories are created during traversal, and harden e2e with high-volume nested data plus strict post-sync assertions and cleanup.

## Key Changes
- Add reusable resync execution path used by both `mount resync` and first `mount` auto-resync in fs_mode.
- Add dynamic progress output (`running/done`, elapsed, scanned/recreated/skipped/failed, pending dirs).
- Create missing Curvine directories during resync traversal to avoid list failures on new UFS directories.
- Expand `build/tests/resync_e2e.sh` with nested stress distribution (3-5 levels, >=100 dirs, >=1000 files), parallel upload, strict summary/count checks, and proactive/after-run cleanup for both UFS and Curvine test data.

Made with [Cursor](https://cursor.com)