### PR TITLE
fix: ufs rename and delete behavior; feat: load job state, FsKind, path helpers

### DIFF
--- a/curvine-client/src/rpc/job_master_client.rs
+++ b/curvine-client/src/rpc/job_master_client.rs
@@ -64,6 +64,7 @@ impl JobMasterClient {
         Ok(LoadJobResult {
             job_id: rep.job_id,
             target_path: rep.target_path,
+            state: JobTaskState::from(rep.state as i8),
         })
     }
 
@@ -137,7 +138,10 @@ impl JobMasterClient {
                             return Err(err);
                         } else {
                             time::sleep(conf.sync_check_interval_min).await;
-                            continue;
+                            JobStatus {
+                                job_id: job_id.to_string(),
+                                ..Default::default()
+                            }
                         }
                     }
                     _ => return Err(err),

--- a/curvine-client/src/unified/macros.rs
+++ b/curvine-client/src/unified/macros.rs
@@ -340,6 +340,15 @@ macro_rules! impl_filesystem_for_enum {
                 $crate::unified::UnifiedReader,
             > for $enum_name
         {
+            fn fs_kind(&self) -> ::curvine_common::fs::FsKind {
+                match self {
+                    $(
+                        $(#[$cfg])*
+                        Self::$variant(inner) => inner.fs_kind(),
+                    )+
+                }
+            }
+
             async fn mkdir(
                 &self,
                 path: &::curvine_common::fs::Path,

--- a/curvine-client/src/unified/mod.rs
+++ b/curvine-client/src/unified/mod.rs
@@ -27,9 +27,6 @@ use curvine_ufs::opendal::*;
 #[cfg(feature = "oss-hdfs")]
 use curvine_ufs::oss_hdfs::*;
 
-// Storage schemes
-pub const S3_SCHEME: &str = "s3";
-
 pub mod macros;
 
 mod unified_filesystem;

--- a/curvine-client/src/unified/unified_filesystem.rs
+++ b/curvine-client/src/unified/unified_filesystem.rs
@@ -19,7 +19,7 @@ use crate::ClientMetrics;
 use bytes::BytesMut;
 use curvine_common::conf::ClusterConf;
 use curvine_common::error::FsError;
-use curvine_common::fs::{FileSystem, Path, Reader, Writer};
+use curvine_common::fs::{FileSystem, FsKind, Path, Reader, Writer};
 use curvine_common::state::{
     CreateFileOpts, FileAllocOpts, FileLock, FileStatus, JobStatus, LoadJobCommand, MasterInfo,
     MkdirOpts, MkdirOptsBuilder, MountInfo, MountOptions, OpenFlags, SetAttrOpts,
@@ -213,7 +213,7 @@ impl UnifiedFileSystem {
             return Ok(CacheValidity::Invalid(None));
         }
 
-        if !cv_status.is_complete() {
+        if !cv_status.is_complete() || !cv_status.ufs_exists() {
             return Ok(CacheValidity::Invalid(None));
         }
 
@@ -302,8 +302,20 @@ impl UnifiedFileSystem {
     }
 
     pub async fn wait_job_complete(&self, path: &Path, fail_if_not_found: bool) -> FsResult<()> {
+        if !path.is_cv() {
+            return err_box!("the current file {} is not a cache file", path);
+        }
+        let (ufs_path, mnt) = match self.get_mount(path).await? {
+            Some((ufs_path, mnt)) => (ufs_path, mnt),
+            None => return err_box!("the current file {} is not mounted to ufs", path),
+        };
+
+        let job_id = if mnt.info.is_fs_mode() {
+            CommonUtils::create_job_id(path.full_path())
+        } else {
+            CommonUtils::create_job_id(ufs_path.full_path())
+        };
         let client = JobMasterClient::new(self.fs_client());
-        let job_id = CommonUtils::create_job_id(path.full_path());
         client.wait_job_complete(job_id, fail_if_not_found).await
     }
 
@@ -376,10 +388,7 @@ impl UnifiedFileSystem {
 
             Some((_, mount)) if mount.info.is_fs_mode() => {
                 let mut writer = self.cv.open_with_opts(path, opts.clone(), flags).await?;
-                if writer.file_blocks().cv_exists()
-                    || flags.overwrite()
-                    || !writer.status().ufs_exists()
-                {
+                if writer.file_blocks().cv_exists() || flags.overwrite() {
                     Ok(UnifiedWriter::Cv(writer))
                 } else {
                     writer.complete().await?;
@@ -467,6 +476,10 @@ impl UnifiedFileSystem {
 }
 
 impl FileSystem<UnifiedWriter, UnifiedReader> for UnifiedFileSystem {
+    fn fs_kind(&self) -> FsKind {
+        FsKind::Cv
+    }
+
     async fn mkdir(&self, path: &Path, create_parent: bool) -> FsResult<bool> {
         let _timer = TimeSpent::timer_counter_vec(
             Arc::new(FsContext::get_metrics().metadata_operation_duration.clone()),

--- a/curvine-common/proto/job.proto
+++ b/curvine-common/proto/job.proto
@@ -40,6 +40,7 @@ message SubmitJobRequest {
 message SubmitJobResponse {
   required string job_id = 1;
   required string target_path = 2;
+  required JobTaskStateProto state = 3;
 }
 
 // Cancel the job request

--- a/curvine-common/src/error/fs_error.rs
+++ b/curvine-common/src/error/fs_error.rs
@@ -175,6 +175,10 @@ impl FsError {
         Self::Common(ErrorImpl::with_source(str.into()))
     }
 
+    pub fn from_error<E: std::error::Error>(e: E) -> Self {
+        Self::Common(ErrorImpl::with_source(e.to_string().into()))
+    }
+
     pub fn not_leader_master(code: RpcCode, client_ip: &str) -> Self {
         let error = format!(
             "Not a leader master, code={:?}, client_ip={}",

--- a/curvine-common/src/fs/filesystem.rs
+++ b/curvine-common/src/fs/filesystem.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::fs::Path;
+use crate::fs::{FsKind, Path};
 use crate::proto::{GetFileStatusResponse, ListStatusResponse};
 use crate::state::{FileStatus, SetAttrOpts};
 use crate::utils::ProtoUtils;
@@ -21,6 +21,8 @@ use prost::bytes::BytesMut;
 use std::future::Future;
 
 pub trait FileSystem<Writer, Reader> {
+    fn fs_kind(&self) -> FsKind;
+
     fn mkdir(&self, path: &Path, create_parent: bool) -> impl Future<Output = FsResult<bool>>;
 
     fn create(&self, path: &Path, overwrite: bool) -> impl Future<Output = FsResult<Writer>>;

--- a/curvine-common/src/fs/fs_kind.rs
+++ b/curvine-common/src/fs/fs_kind.rs
@@ -1,0 +1,89 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Identifies the kind of filesystem / storage for a path (e.g. cv, s3, oss).
+#[repr(i8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FsKind {
+    Cv,
+    S3,
+    Oss,
+    OssHdfs,
+    Hdfs,
+    Gcs,
+    Azblob,
+    Cos,
+    Unknown,
+}
+
+impl FsKind {
+    // Scheme string constants for each filesystem kind.
+    pub const SCHEME_CV: &'static str = "cv";
+    pub const SCHEME_S3: &'static str = "s3";
+    pub const SCHEME_S3A: &'static str = "s3a";
+    pub const SCHEME_OSS: &'static str = "oss";
+    pub const SCHEME_HDFS: &'static str = "hdfs";
+    pub const SCHEME_GCS: &'static str = "gcs";
+    pub const SCHEME_GS: &'static str = "gs";
+    pub const SCHEME_AZBLOB: &'static str = "azblob";
+    pub const SCHEME_COS: &'static str = "cos";
+    pub const SCHEME_UNKNOWN: &'static str = "unknown";
+
+    /// Returns the filesystem kind for the given scheme string (e.g. from `Path::scheme()`).
+    pub fn from_scheme(scheme: &str) -> Self {
+        let lower = scheme.to_lowercase();
+        match lower.as_str() {
+            Self::SCHEME_CV => Self::Cv,
+            Self::SCHEME_S3 | Self::SCHEME_S3A => Self::S3,
+            Self::SCHEME_OSS => Self::Oss,
+            Self::SCHEME_HDFS => Self::Hdfs,
+            Self::SCHEME_GCS | Self::SCHEME_GS => Self::Gcs,
+            Self::SCHEME_AZBLOB => Self::Azblob,
+            Self::SCHEME_COS => Self::Cos,
+            _ => Self::Unknown,
+        }
+    }
+
+    /// Returns the kind when the path may have no scheme (treated as Cv).
+    pub fn from_scheme_opt(scheme: Option<&str>) -> Self {
+        match scheme {
+            None => Self::Cv,
+            Some(s) => Self::from_scheme(s),
+        }
+    }
+
+    /// Returns true if this is Curvine native / local.
+    pub fn is_cv(self) -> bool {
+        self == Self::Cv
+    }
+
+    /// Returns the canonical scheme string (e.g. for display).
+    pub fn as_scheme_str(self) -> &'static str {
+        match self {
+            Self::Cv => Self::SCHEME_CV,
+            Self::S3 => Self::SCHEME_S3,
+            Self::Oss => Self::SCHEME_OSS,
+            Self::OssHdfs => Self::SCHEME_OSS,
+            Self::Hdfs => Self::SCHEME_HDFS,
+            Self::Gcs => Self::SCHEME_GCS,
+            Self::Azblob => Self::SCHEME_AZBLOB,
+            Self::Cos => Self::SCHEME_COS,
+            Self::Unknown => Self::SCHEME_UNKNOWN,
+        }
+    }
+
+    pub fn support_rename(&self) -> bool {
+        matches!(self, Self::Cv | Self::Hdfs | Self::OssHdfs)
+    }
+}

--- a/curvine-common/src/fs/mod.rs
+++ b/curvine-common/src/fs/mod.rs
@@ -15,6 +15,9 @@
 mod path;
 pub use self::path::Path;
 
+mod fs_kind;
+pub use self::fs_kind::FsKind;
+
 mod rpc_code;
 pub use self::rpc_code::RpcCode;
 

--- a/curvine-common/src/fs/path.rs
+++ b/curvine-common/src/fs/path.rs
@@ -261,6 +261,11 @@ impl Path {
     pub fn clone_display_path(&self) -> String {
         self.display_path().to_string()
     }
+
+    pub fn likely_file(&self) -> bool {
+        let name = self.name();
+        !name.is_empty() && name.contains('.') && !name.starts_with('.')
+    }
 }
 
 impl Display for Path {

--- a/curvine-common/src/fs/writer.rs
+++ b/curvine-common/src/fs/writer.rs
@@ -37,7 +37,7 @@ pub trait Writer {
     fn flush_chunk(&mut self) -> impl Future<Output = FsResult<i64>> {
         async move {
             if !self.chunk_mut().is_empty() {
-                let chunk = DataSlice::Bytes(self.chunk_mut().split().freeze());
+                let chunk = DataSlice::Buffer(self.chunk_mut().split());
                 self.write_chunk(chunk).await
             } else {
                 Ok(0)

--- a/curvine-common/src/state/job.rs
+++ b/curvine-common/src/state/job.rs
@@ -30,10 +30,11 @@ use serde::{Deserialize, Serialize};
     FromPrimitive,
     Serialize,
     Deserialize,
+    Default,
 )]
 #[repr(i8)]
 pub enum JobTaskState {
-    #[num_enum(default)]
+    #[default]
     UNKNOWN = 0,
     Pending = 1,
     Loading = 2,
@@ -51,9 +52,29 @@ impl JobTaskState {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct LoadJobResult {
     pub job_id: String,
     pub target_path: String,
+    pub state: JobTaskState,
+}
+
+impl LoadJobResult {
+    pub fn with_job(job: &LoadJobInfo) -> Self {
+        Self {
+            job_id: job.job_id.to_owned(),
+            target_path: job.target_path.to_owned(),
+            state: JobTaskState::Pending,
+        }
+    }
+
+    pub fn with_state(job: &LoadJobInfo, state: JobTaskState) -> Self {
+        Self {
+            job_id: job.job_id.to_owned(),
+            target_path: job.target_path.to_owned(),
+            state,
+        }
+    }
 }
 
 #[derive(
@@ -76,6 +97,7 @@ pub enum JobTaskType {
     Load = 1,
 }
 
+#[derive(Default)]
 pub struct JobStatus {
     pub job_id: String,
     pub state: JobTaskState,

--- a/curvine-server/src/master/job/job_handler.rs
+++ b/curvine-server/src/master/job/job_handler.rs
@@ -53,6 +53,7 @@ impl JobHandler {
         let response = SubmitJobResponse {
             job_id: res.job_id,
             target_path: res.target_path,
+            state: res.state as i32,
         };
 
         ctx.response(response)

--- a/curvine-server/src/master/job/job_runner.rs
+++ b/curvine-server/src/master/job/job_runner.rs
@@ -83,15 +83,7 @@ impl LoadJobRunner {
 
         // Skip based on data state (even when job is None, e.g. after job cleanup)
         if source_path.is_cv() {
-            // cv -> ufs: if CV's ufs_mtime already set, data already copied to UFS, skip
-            let source_status = self.master_fs.file_status(source_path.path())?;
-            if source_status.is_dir {
-                Ok(false)
-            } else if source_status.ufs_exists() {
-                Ok(true)
-            } else {
-                Ok(false)
-            }
+            Ok(false)
         } else {
             // ufs -> cv: if CV exists and ufs_mtime matches UFS mtime, data already synced, skip
             let source_status = mnt.ufs.get_status(source_path).await?;
@@ -120,10 +112,6 @@ impl LoadJobRunner {
         let target_path = mnt.toggle_path(&source_path)?;
 
         let job_id = CommonUtils::create_job_id(source_path.full_path());
-        let result = LoadJobResult {
-            job_id: job_id.clone(),
-            target_path: target_path.clone_uri(),
-        };
         let mut job_context = JobContext::with_conf(
             &command,
             job_id.clone(),
@@ -138,15 +126,22 @@ impl LoadJobRunner {
             .check_job_exists(&job_id, &mnt_value, &source_path, &target_path)
             .await?
         {
-            debug!(
+            info!(
                 "skip load job {}: source_path {} already loaded or in progress",
                 job_id,
                 source_path.full_path()
             );
-
-            job_context.update_state(JobTaskState::Completed, "exists tasks");
-            self.jobs.insert(job_id, job_context);
-            return Ok(result);
+            return if let Some(existing_ctx) = self.jobs.get(&job_id) {
+                Ok(LoadJobResult::with_state(
+                    &existing_ctx.info,
+                    existing_ctx.state.state(),
+                ))
+            } else {
+                Ok(LoadJobResult::with_state(
+                    &job_context.info,
+                    JobTaskState::Completed,
+                ))
+            };
         }
 
         self.jobs.remove(&job_id);
@@ -179,11 +174,12 @@ impl LoadJobRunner {
                 );
 
                 let tasks = job_context.tasks.clone();
+                let res = LoadJobResult::with_job(&job_context.info);
                 self.jobs.insert(job_id, job_context);
                 // @todo Whether to cancel some tasks that may have been dispatched.
                 self.submit_all_task(tasks).await?;
 
-                Ok(result)
+                Ok(res)
             }
         }
     }

--- a/curvine-server/src/master/journal/journal_loader.rs
+++ b/curvine-server/src/master/journal/journal_loader.rs
@@ -163,6 +163,15 @@ impl JournalLoader {
             return Ok(());
         }
 
+        let cur = self.get_fsm_state();
+        if entry.index <= cur.applied.index {
+            info!(
+                "skip entry index {}, term {}, fsm_state {:?}",
+                entry.index, entry.term, cur
+            );
+            return Ok(());
+        }
+
         let batch: JournalBatch = SerdeUtils::deserialize(&entry.data)?;
         let batch_len = batch.len();
         let mut snapshot = None;

--- a/curvine-server/src/master/journal/ufs_loader.rs
+++ b/curvine-server/src/master/journal/ufs_loader.rs
@@ -22,7 +22,7 @@ use curvine_common::error::FsError;
 use curvine_common::fs::{FileSystem, Path};
 use curvine_common::state::{JobTaskState, LoadJobCommand};
 use curvine_common::FsResult;
-use log::warn;
+use log::{info, warn};
 use orpc::common::DurationUnit;
 use orpc::{err_box, CommonResult};
 use std::sync::Arc;
@@ -53,6 +53,14 @@ impl UfsLoader {
         }
     }
 
+    fn get_mnt(&self, path: &Path) -> FsResult<Option<(Path, Arc<MountValue>)>> {
+        match self.job_manager.get_mnt(path)? {
+            Some((path, mnt)) if mnt.info.is_fs_mode() => Ok(Some((path, mnt))),
+
+            _ => Ok(None),
+        }
+    }
+
     pub async fn submit_load_task(&self, path: &Path, mnt: &MountValue) -> FsResult<()> {
         let command = LoadJobCommand::builder(path.clone_uri()).build();
         let runner = self.job_manager.create_runner();
@@ -60,13 +68,17 @@ impl UfsLoader {
             Ok(res) => res,
             Err(e) => {
                 return if matches!(e, FsError::FileNotFound(_)) {
-                    // File may have been renamed
+                    info!("file {} not found, skipping load job", path.full_path());
                     Ok(())
                 } else {
                     err_box!("load job failed: {}", e)
                 };
             }
         };
+
+        if matches!(res.state, JobTaskState::Completed) {
+            return Ok(());
+        }
 
         let status = self
             .job_manager
@@ -95,7 +107,7 @@ impl UfsLoader {
 
     pub async fn mkdir(&self, e: &MkdirEntry) -> CommonResult<()> {
         let path = Path::from_str(&e.path)?;
-        if let Some((ufs_path, mnt)) = self.job_manager.get_mnt(&path)? {
+        if let Some((ufs_path, mnt)) = self.get_mnt(&path)? {
             mnt.ufs.mkdir(&ufs_path, false).await?;
             Ok(())
         } else {
@@ -109,8 +121,9 @@ impl UfsLoader {
         }
 
         let path = Path::from_str(&e.path)?;
-        if let Some((_, mnt)) = self.job_manager.get_mnt(&path)? {
-            self.submit_load_task(&path, &mnt).await.map_err(Into::into)
+        if let Some((_, mnt)) = self.get_mnt(&path)? {
+            self.submit_load_task(&path, &mnt).await?;
+            Ok(())
         } else {
             Ok(())
         }
@@ -119,13 +132,21 @@ impl UfsLoader {
     pub async fn rename(&self, e: &RenameEntry) -> CommonResult<()> {
         let src = Path::from_str(&e.src)?;
         let dst = Path::from_str(&e.dst)?;
-        if let Some((src_ufs_path, mnt)) = self.job_manager.get_mnt(&src)? {
-            if mnt.ufs.exists(&src_ufs_path).await? {
-                mnt.ufs.delete(&src_ufs_path, true).await?;
-            } else {
+        if let Some((src_ufs_path, mnt)) = self.get_mnt(&src)? {
+            if !mnt.ufs.exists(&src_ufs_path).await? {
                 warn!("rename: src file not exists: {}", src_ufs_path);
+                return Ok(());
             }
-            self.submit_load_task(&dst, &mnt).await.map_err(Into::into)
+
+            let src_dst_path = mnt.info.get_ufs_path(&dst)?;
+            if mnt.ufs.fs_kind().support_rename() {
+                mnt.ufs.rename(&src_ufs_path, &src_dst_path).await?;
+                Ok(())
+            } else {
+                mnt.ufs.delete(&src_ufs_path, true).await?;
+                self.submit_load_task(&dst, &mnt).await?;
+                Ok(())
+            }
         } else {
             Ok(())
         }
@@ -133,7 +154,7 @@ impl UfsLoader {
 
     pub async fn delete(&self, e: &DeleteEntry) -> CommonResult<()> {
         let path = Path::from_str(&e.path)?;
-        if let Some((ufs_path, mnt)) = self.job_manager.get_mnt(&path)? {
+        if let Some((ufs_path, mnt)) = self.get_mnt(&path)? {
             if mnt.ufs.exists(&ufs_path).await? {
                 mnt.ufs.delete(&ufs_path, true).await?;
             } else {

--- a/curvine-server/src/master/master_handler.rs
+++ b/curvine-server/src/master/master_handler.rs
@@ -718,13 +718,18 @@ impl MessageHandler for MasterHandler {
             return Err(FsError::not_leader_master(ctx.code, self.client_ip()));
         }
 
-        match code {
+        let res = match code {
             RpcCode::SubmitJob => self.job_handler.submit_load_job(ctx).await,
             RpcCode::GetJobStatus => self.job_handler.get_load_status(ctx),
             RpcCode::CancelJob => self.job_handler.cancel_job(ctx).await,
             RpcCode::ReportTask => self.job_handler.task_report(ctx),
 
             v => err_box!("unsupported operation {:?}", v),
+        };
+
+        match res {
+            Ok(v) => Ok(v),
+            Err(e) => Ok(msg.error_ext(&e)),
         }
     }
 }

--- a/curvine-server/src/master/meta/inode/inode_file.rs
+++ b/curvine-server/src/master/meta/inode/inode_file.rs
@@ -86,10 +86,7 @@ impl InodeFile {
             block_size: opts.block_size as u32,
             replicas: opts.replicas as u8,
 
-            storage_policy: StoragePolicy {
-                ufs_mtime: 0,
-                ..opts.storage_policy
-            },
+            storage_policy: opts.storage_policy,
             features: FileFeature {
                 x_attr: Default::default(),
                 file_write: None,
@@ -209,6 +206,7 @@ impl InodeFile {
 
     pub fn reopen(&mut self, client_name: impl AsRef<str>) -> Option<ExtendedBlock> {
         self.features.set_writing(client_name.as_ref().to_string());
+        self.invalid_cache();
         if let Some(last_block) = self.get_block_mut(-1) {
             let blk = ExtendedBlock {
                 id: last_block.id,
@@ -315,12 +313,6 @@ impl InodeFile {
         client_name: impl AsRef<str>,
         only_flush: bool,
     ) -> FsResult<()> {
-        // If commit_blocks contains data, it means the curvine file has been updated.
-        // The corresponding ufs_mtime is set to 0, indicating that the relationship with ufs has been severed.
-        if !commit_blocks.is_empty() {
-            self.storage_policy.ufs_mtime = 0
-        }
-
         for block in commit_blocks {
             let meta = self.search_block_mut_check(block.block_id)?;
             meta.commit(block);
@@ -393,9 +385,11 @@ impl InodeFile {
             Ok(vec![])
         } else if opts.len < self.len {
             let del_blocks = self.truncate(opts);
+            self.invalid_cache();
             Ok(del_blocks)
         } else {
             self.extend(opts)?;
+            self.invalid_cache();
             Ok(vec![])
         }
     }
@@ -512,6 +506,10 @@ impl InodeFile {
 
     pub fn cv_exists(&self) -> bool {
         self.len > 0 && !self.blocks.is_empty()
+    }
+
+    pub fn invalid_cache(&mut self) {
+        self.storage_policy.ufs_mtime = 0;
     }
 }
 

--- a/curvine-server/src/worker/task/load_task_runner.rs
+++ b/curvine-server/src/worker/task/load_task_runner.rs
@@ -18,7 +18,7 @@ use curvine_client::file::CurvineFileSystem;
 use curvine_client::rpc::JobMasterClient;
 use curvine_client::unified::{UfsFileSystem, UnifiedReader, UnifiedWriter};
 use curvine_common::fs::{FileSystem, Path, Reader, Writer};
-use curvine_common::state::{CreateFileOptsBuilder, JobTaskState, SetAttrOptsBuilder};
+use curvine_common::state::{CreateFileOptsBuilder, FileStatus, JobTaskState, SetAttrOptsBuilder};
 use curvine_common::FsResult;
 use log::{error, info, warn};
 use orpc::common::{LocalTime, TimeSpent};
@@ -159,7 +159,7 @@ impl LoadTaskRunner {
         let reader = self.open_unified(&source_path).await?;
 
         // Create writer (automatically selects filesystem based on scheme)
-        let writer = self.create_unified(&target_path).await?;
+        let writer = self.create_unified(&target_path, reader.status()).await?;
 
         Ok((reader, writer))
     }
@@ -175,15 +175,17 @@ impl LoadTaskRunner {
         }
     }
 
-    async fn create_unified(&self, path: &Path) -> FsResult<UnifiedWriter> {
+    async fn create_unified(
+        &self,
+        path: &Path,
+        read_status: &FileStatus,
+    ) -> FsResult<UnifiedWriter> {
         if path.is_cv() {
             // Curvine path - get source mtime for UFS→Curvine import
             let source_path = Path::from_str(&self.task.info.source_path)?;
             let source_mtime = if !source_path.is_cv() {
                 // Import from UFS, get source mtime
-                let ufs = self.get_ufs()?;
-                let source_status = ufs.get_status(&source_path).await?;
-                source_status.mtime
+                read_status.mtime
             } else {
                 // Curvine→Curvine (not supported yet), use 0
                 0

--- a/curvine-tests/tests/write_cache_test.rs
+++ b/curvine-tests/tests/write_cache_test.rs
@@ -37,7 +37,8 @@ fn get_fs() -> UnifiedFileSystem {
         panic!("UFS_TEST_PATH is not set")
     }
 
-    let testing = Testing::default();
+    let testing = Testing::builder().workers(1).build().unwrap();
+    testing.start_cluster().unwrap();
     let rt = Arc::new(AsyncRuntime::single());
     testing.get_unified_fs_with_rt(rt.clone()).unwrap()
 }
@@ -95,8 +96,7 @@ async fn test_cache_read(fs: &UnifiedFileSystem, path: &Path) {
 
     let str1 = reader1.read_as_string().await.unwrap();
 
-    let (ufs_path, _) = fs.get_mount(path).await.unwrap().unwrap();
-    fs.wait_job_complete(&ufs_path, false).await.unwrap();
+    fs.wait_job_complete(path, false).await.unwrap();
 
     let mut reader2 = fs.open(path).await.unwrap();
     assert!(
@@ -124,6 +124,7 @@ fn test_fs_mode() {
         let mut writer = fs.create(&path, true).await.unwrap();
         writer.write_string(Utils::rand_str(1024)).await.unwrap();
         writer.complete().await.unwrap();
+        fs.wait_job_complete(&path, false).await.unwrap();
 
         let dst_path = format!("/write_cache_{:?}/meta_rename.log", WriteType::FsMode).into();
         fs.rename(&path, &dst_path).await.unwrap();
@@ -193,8 +194,7 @@ fn test_fs_mode_free() {
         writer.complete().await.unwrap();
 
         let _ = fs.open(&path).await.unwrap();
-        let (ufs_path, _) = fs.get_mount(&path).await.unwrap().unwrap();
-        fs.wait_job_complete(&ufs_path, false).await.unwrap();
+        fs.wait_job_complete(&path, false).await.unwrap();
 
         fs.free(&path).await.unwrap();
 

--- a/curvine-ufs/src/opendal.rs
+++ b/curvine-ufs/src/opendal.rs
@@ -18,21 +18,20 @@ use crate::OssHdfsConf;
 use crate::{err_ufs, FOLDER_SUFFIX};
 use bytes::BytesMut;
 use curvine_common::error::FsError;
-use curvine_common::fs::{FileSystem, Path, Reader, Writer};
+use curvine_common::fs::{FileSystem, FsKind, Path, Reader, Writer};
 use curvine_common::state::{FileStatus, FileType, SetAttrOpts};
 use curvine_common::FsResult;
 use futures::StreamExt;
+use opendal::options::ListOptions;
 use opendal::services::*;
 use opendal::{
     layers::{LoggingLayer, RetryLayer, TimeoutLayer},
-    Metadata, Operator,
+    ErrorKind, Metadata, Operator,
 };
 use orpc::sys::DataSlice;
 use orpc::{err_box, err_ext, try_option_mut};
 use std::collections::HashMap;
 use std::time::Duration;
-
-pub const HDFS_SCHEMA: &str = "hdfs";
 
 /// OpenDAL Reader implementation
 pub struct OpendalReader {
@@ -102,7 +101,7 @@ impl Reader for OpendalReader {
             if let Some(chunk_result) = stream.next().await {
                 match chunk_result {
                     Ok(chunk) => Ok(DataSlice::Bytes(chunk)),
-                    Err(e) => Err(FsError::common(format!("Failed to read chunk: {}", e))),
+                    Err(e) => err_box!("Failed to read chunk: {}", e),
                 }
             } else {
                 Ok(DataSlice::Empty)
@@ -114,42 +113,19 @@ impl Reader for OpendalReader {
 
     async fn seek(&mut self, pos: i64) -> FsResult<()> {
         if pos < 0 || pos > self.length {
-            return Err(FsError::common("Invalid seek position"));
+            return err_box!("Invalid seek position");
         }
 
-        // If seeking backward or forward significantly, reset the stream
-        if pos < self.pos || pos > self.pos + (self.chunk_size as i64 * 2) {
-            self.byte_stream = None;
-            self.chunk = DataSlice::Empty;
+        if pos == self.pos {
+            return Ok(());
+        }
 
-            // Create new stream starting from the seek position
-            let reader = self
-                .operator
-                .reader_with(&self.object_path)
-                .chunk(self.chunk_size)
-                .await
-                .map_err(|e| FsError::common(format!("Failed to create reader: {}", e)))?;
-
-            self.byte_stream = Some(
-                reader
-                    .into_bytes_stream(pos as u64..self.length as u64)
-                    .await
-                    .map_err(|e| FsError::common(format!("Failed to create stream: {}", e)))?,
-            );
+        let to_skip = pos - self.pos;
+        if to_skip >= 0 && to_skip <= self.chunk.len() as i64 {
+            self.chunk.advance(to_skip as usize);
         } else {
-            // Skip forward in the current stream
-            while self.pos < pos {
-                let skip_bytes = (pos - self.pos).min(self.chunk_size as i64) as usize;
-                if self.chunk.is_empty() {
-                    self.chunk = self.read_chunk0().await?;
-                }
-                if self.chunk.is_empty() {
-                    break;
-                }
-                let actual_skip = skip_bytes.min(self.chunk.len());
-                self.chunk.advance(actual_skip);
-                self.pos += actual_skip as i64;
-            }
+            self.chunk.clear();
+            self.byte_stream = None;
         }
 
         self.pos = pos;
@@ -210,8 +186,8 @@ impl Writer for OpendalWriter {
             );
         }
 
-        let data = bytes::Bytes::copy_from_slice(chunk.as_slice());
-        let len = data.len() as i64;
+        let data = chunk.to_bytes();
+        let len = data.len();
 
         let writer = try_option_mut!(self.writer);
         writer
@@ -219,7 +195,7 @@ impl Writer for OpendalWriter {
             .await
             .map_err(|e| FsError::common(format!("Failed to write: {}", e)))?;
 
-        Ok(len)
+        Ok(len as i64)
     }
 
     async fn flush(&mut self) -> FsResult<()> {
@@ -499,7 +475,7 @@ impl OpendalFileSystem {
                 Self::add_stability_layers(base_op, &conf)?
             }
 
-            #[cfg(feature = "opendal-hdfs-native")]
+            #[cfg(all(feature = "opendal-hdfs-native", not(feature = "opendal-hdfs")))]
             "hdfs" => Self::create_hdfs_native_operator(&bucket_or_container, &conf)?,
 
             _ => {
@@ -647,7 +623,7 @@ impl OpendalFileSystem {
         match self.operator.stat(object_path).await {
             Ok(m) => Ok(Some(m)),
             Err(e) => {
-                if e.kind() == opendal::ErrorKind::NotFound {
+                if e.kind() == ErrorKind::NotFound {
                     Ok(None)
                 } else {
                     err_box!(format!("failed to stat: {}", e))
@@ -657,20 +633,10 @@ impl OpendalFileSystem {
     }
 
     pub async fn get_file_status(&self, path: &Path) -> FsResult<Option<FileStatus>> {
-        let path_str = path.full_path();
-
-        let likely_dir = if path_str.ends_with('/') {
-            true
-        } else {
-            let name = path.name();
-            let has_extension = name.contains('.') && !name.starts_with('.');
-            !has_extension
-        };
-
-        let (first_path, second_path) = if likely_dir {
-            (self.get_dir_path(path)?, self.get_object_path(path)?)
-        } else {
+        let (first_path, second_path) = if path.likely_file() {
             (self.get_object_path(path)?, self.get_dir_path(path)?)
+        } else {
+            (self.get_dir_path(path)?, self.get_object_path(path)?)
         };
 
         let mut metadata = self.get_object_status(&first_path).await?;
@@ -684,6 +650,10 @@ impl OpendalFileSystem {
 }
 
 impl FileSystem<OpendalWriter, OpendalReader> for OpendalFileSystem {
+    fn fs_kind(&self) -> FsKind {
+        FsKind::from_scheme(&self.scheme)
+    }
+
     // Creates a directory; the directory must end with "/".
     // OpenDal always creates directories recursively.
     async fn mkdir(&self, path: &Path, _create_parent: bool) -> FsResult<bool> {
@@ -697,12 +667,18 @@ impl FileSystem<OpendalWriter, OpendalReader> for OpendalFileSystem {
         Ok(true)
     }
 
-    /// OpenDal only supports overwrite, so the overwrite parameter is ignored here.
+    /// Create a new file or open for overwrite. When overwrite is false and the path exists, returns file_exists.
+    /// Empty file is written only when the path does not exist (POSIX-like); when overwrite is true we defer to the first write.
     async fn create(&self, path: &Path, overwrite: bool) -> FsResult<OpendalWriter> {
         let object_path = self.get_object_path(path)?;
 
         let exist = self.get_object_status(&object_path).await?.is_some();
-        if !exist || overwrite {
+
+        if exist && !overwrite {
+            return err_ext!(FsError::file_exists(path.full_path()));
+        }
+
+        if !exist {
             // If no data is written to OpenDal, no file will be created.
             // This does not conform to POSIX semantics, so an empty file is created.
             self.operator
@@ -731,8 +707,9 @@ impl FileSystem<OpendalWriter, OpendalReader> for OpendalFileSystem {
     }
 
     async fn append(&self, path: &Path) -> FsResult<OpendalWriter> {
-        // OpenDAL doesn't support append for most backends
-        // For now, return an error
+        // Most OpenDAL backends do not support true append; large files return unsupported.
+        // For small files we return a Writer with existing content in chunk, but write_chunk uses operator.writer() which overwrites instead of appending,
+        // so the current behavior is semantically wrong and only safe for "read existing, do not write"; real append would need read-all + concat + write in complete().
         let object_path = self.get_object_path(path)?;
         let status = self.get_file_status(path).await?;
 
@@ -797,58 +774,95 @@ impl FileSystem<OpendalWriter, OpendalReader> for OpendalFileSystem {
     }
 
     async fn rename(&self, src: &Path, dst: &Path) -> FsResult<bool> {
-        let src_path = self.get_object_path(src)?;
-        let dst_path = self.get_object_path(dst)?;
-
-        // Try direct rename first
-        match self.operator.rename(&src_path, &dst_path).await {
-            Ok(_) => Ok(true),
-            Err(e) if e.kind() == opendal::ErrorKind::Unsupported => {
-                self.operator
-                    .copy(&src_path, &dst_path)
-                    .await
-                    .map_err(|e| {
-                        FsError::common(format!("failed to copy source file for rename: {}", e))
-                    })?;
-
-                // Delete source file
-                self.operator.delete(&src_path).await.map_err(|e| {
-                    FsError::common(format!("failed to delete source file after rename: {}", e))
-                })?;
-
-                Ok(true)
-            }
-
-            Err(e) => Err(FsError::common(format!("failed to rename: {}", e))),
+        if dst.is_root() {
+            return err_box!("cannot rename to root directory");
         }
+
+        if src.full_path() == dst.full_path() {
+            return Ok(false);
+        }
+
+        let Some(src_status) = self.get_file_status(src).await? else {
+            return err_ext!(FsError::file_not_found(src.full_path()));
+        };
+
+        if src_status.is_dir {
+            let src_path = self.get_dir_path(src)?;
+            let dst_path = self.get_dir_path(dst)?;
+            if let Err(e) = self.operator.rename(&src_path, &dst_path).await {
+                if matches!(e.kind(), ErrorKind::Unsupported | ErrorKind::IsADirectory) {
+                    return err_ext!(FsError::unsupported(
+                        "rename directory on this backend (e.g. S3)"
+                    ));
+                }
+                return Err(FsError::from_error(e));
+            }
+        } else {
+            let src_path = self.get_object_path(src)?;
+            let dst_path = self.get_object_path(dst)?;
+            if let Err(e) = self.operator.rename(&src_path, &dst_path).await {
+                if e.kind() == ErrorKind::Unsupported {
+                    self.operator
+                        .copy(&src_path, &dst_path)
+                        .await
+                        .map_err(FsError::from_error)?;
+                    self.operator
+                        .delete(&src_path)
+                        .await
+                        .map_err(FsError::from_error)?;
+                } else {
+                    return Err(FsError::from_error(e));
+                }
+            }
+        }
+
+        Ok(true)
     }
 
     async fn delete(&self, path: &Path, recursive: bool) -> FsResult<()> {
-        let object_path = self.get_object_path(path)?;
+        if path.is_root() {
+            return err_box!("cannot delete root directory");
+        }
 
-        if recursive {
-            // Check if it's a directory
-            match self.operator.stat(&object_path).await {
-                Ok(metadata) if metadata.is_dir() => self.operator.remove_all(&object_path).await,
-                _ => self.operator.delete(&object_path).await,
+        let Some(status) = self.get_file_status(path).await? else {
+            return err_ext!(FsError::file_not_found(path.full_path()));
+        };
+
+        if status.is_dir {
+            let dir_path = self.get_dir_path(path)?;
+            if recursive {
+                self.operator
+                    .remove_all(&dir_path)
+                    .await
+                    .map_err(FsError::from_error)?;
+            } else {
+                let opts = ListOptions {
+                    limit: Some(2),
+                    ..Default::default()
+                };
+                let mut list = self
+                    .operator
+                    .lister_options(&dir_path, opts)
+                    .await
+                    .map_err(FsError::from_error)?;
+
+                if let Some(result) = list.next().await {
+                    // Propagate any error from listing instead of treating it as a non-empty directory.
+                    result.map_err(FsError::from_error)?;
+                    // If we successfully retrieved an entry, the directory is not empty.
+                    return err_ext!(FsError::dir_not_empty(path.full_path()));
+                }
+                self.operator
+                    .delete(&dir_path)
+                    .await
+                    .map_err(FsError::from_error)?;
             }
-            .map_err(|e| FsError::common(format!("Failed to delete recursive: {}", e)))?;
         } else {
-            // Try to delete as file first
+            let object_path = self.get_object_path(path)?;
             self.operator
                 .delete(&object_path)
                 .await
-                .map_err(|e| FsError::common(format!("Failed to delete file: {}", e)))?;
-
-            // Also try to delete as directory marker (with suffix)
-            // S3 delete is idempotent, so it's safe to try deleting the marker even if it doesn't exist
-            // or if we just deleted a file.
-            let dir_path = self.get_dir_path(path)?;
-            if dir_path != object_path {
-                self.operator.delete(&dir_path).await.map_err(|e| {
-                    FsError::common(format!("Failed to delete directory marker: {}", e))
-                })?;
-            }
+                .map_err(FsError::from_error)?;
         }
 
         Ok(())

--- a/curvine-ufs/src/oss_hdfs/oss_hdfs_filesystem.rs
+++ b/curvine-ufs/src/oss_hdfs/oss_hdfs_filesystem.rs
@@ -15,7 +15,7 @@
 use bytes::BytesMut;
 use curvine_common::conf::UfsConf;
 use curvine_common::error::FsError;
-use curvine_common::fs::{FileSystem, Path};
+use curvine_common::fs::{FileSystem, FsKind, Path};
 use curvine_common::state::{FileStatus, FileType, SetAttrOpts};
 use curvine_common::FsResult;
 use orpc::common::LocalTime;
@@ -341,6 +341,10 @@ impl OssHdfsFileSystem {
 }
 
 impl FileSystem<OssHdfsWriter, OssHdfsReader> for OssHdfsFileSystem {
+    fn fs_kind(&self) -> FsKind {
+        FsKind::OssHdfs
+    }
+
     async fn mkdir(&self, path: &Path, create_parent: bool) -> FsResult<bool> {
         let path_cstr = self.path_to_cstring(path)?;
         let ctx = Box::new(CallbackCtx::<(JindoStatus, Option<String>)>::default());

--- a/orpc/src/sys/data_slice.rs
+++ b/orpc/src/sys/data_slice.rs
@@ -225,6 +225,16 @@ impl DataSlice {
             Bytes(s) => s.as_ptr(),
         }
     }
+
+    pub fn to_bytes(self) -> TBytes {
+        match self {
+            Empty => TBytes::new(),
+            Bytes(bytes) => bytes,
+            Buffer(buf) => buf.freeze(),
+            MemSlice(buf) => TBytes::copy_from_slice(buf.as_slice()),
+            IOSlice(buf) => TBytes::copy_from_slice(buf.as_slice()),
+        }
+    }
 }
 
 impl Clone for DataSlice {


### PR DESCRIPTION
### 1. Load Job API and State

- **Proto** (`curvine-common/proto/job.proto`): `SubmitJobResponse` includes `required JobTaskStateProto state = 3`.
- **curvine-common** (`state/job.rs`): `LoadJobResult` has `state: JobTaskState`; `with_job(job)` (Pending) and `with_complete(job)` (Completed).
- **curvine-server** (`job_runner.rs`): On skip return `LoadJobResult::with_complete` without inserting into job store; on submit return `LoadJobResult::with_job` after insert.
- **curvine-server** (`job_handler.rs`): Map `res.state` into response.
- **curvine-client** (`job_master_client.rs`): Set `state: JobTaskState::from(rep.state as i8)` in `LoadJobResult`.

### 2. FsKind and FileSystem Trait

- **curvine-common** (`fs/fs_kind.rs`): Enum `FsKind` (Cv, S3, Oss, OssHdfs, Hdfs, Gcs, Azblob, Cos, Unknown) with `from_scheme`, `from_scheme_opt`, `is_cv`, `as_scheme_str`, `support_rename()` (Cv, Hdfs, OssHdfs).
- **curvine-common** (`fs/filesystem.rs`): `FileSystem` has `fn fs_kind(&self) -> FsKind`.
- **curvine-common** (`fs/path.rs`): `Path::likely_file()` for path-looking-like-file heuristic.
- **curvine-client** (`unified/`): `fs_kind()` on unified FS and macro-generated variants; remove `S3_SCHEME`.
- **curvine-ufs** (`opendal.rs`, `oss_hdfs_filesystem.rs`): `fs_kind()` and `support_rename()` where needed.

### 3. Rename and delete fixes (UFS loader + OpenDAL)

#### Rename

- **curvine-server** (`journal/ufs_loader.rs`):
  - **Fix**: Rename no longer only deletes the source. Logic is now:
    1. If source does not exist on UFS, log and return (no delete, no load).
    2. If backend **supports rename** (`fs_kind().support_rename()`): call `mnt.ufs.rename(&src_ufs_path, &src_dst_path)` so the object is moved on UFS and CV metadata can point at the new path.
    3. If backend **does not support rename** (e.g. S3): delete source on UFS, then submit load task for destination so data is re-loaded from CV to the new UFS path — CV and UFS stay consistent.
  - Avoids incorrect “delete only” or wrong order that could lose data or leave CV/UFS out of sync.
- **curvine-ufs** (`opendal.rs`): `rename()` tries native `operator.rename`; for files, on `ErrorKind::Unsupported` falls back to copy then delete. For directories, unsupported rename returns a clear unsupported error.

#### Delete

- **curvine-ufs** (`opendal.rs`):
  - **Fix**: Non-recursive directory delete now **checks that the directory is empty** before calling `operator.delete`:
    - Uses `lister_options(&dir_path, ListOptions { limit: Some(2), .. })` to list up to two entries.
    - If any entry is returned (after propagating list errors), returns `FsError::dir_not_empty(path)` and does **not** delete.
    - Only if the directory is empty, calls `operator.delete(&dir_path)`.
  - Prevents deleting non-empty directories on backends that would otherwise allow it or fail in an unclear way.

### 4. UfsLoader (other) and OpenDAL (other)

- **curvine-server** (`journal/ufs_loader.rs`): If `res.state == JobTaskState::Completed` after submit, return without waiting.

**OpenDAL (curvine-ufs) — other changes:**
- **Reader**: Simpler seek (advance within chunk or reset stream).
- **get_file_status**: Try file then dir (or vice versa) via `likely_file()`.
- **Error handling**: `FsError::from_error`, `err_box!`, `ErrorKind::NotFound`.

### 5. Writer and DataSlice

- **curvine-common** (`fs/writer.rs`): Default `flush_chunk` uses `DataSlice::Buffer(self.chunk_mut().split())`.
- **orpc** (`sys/data_slice.rs`): `DataSlice::Buffer(BytesMut)` variant.

### 6. Cache Validity and UnifiedFileSystem

- **curvine-client** (`unified_filesystem.rs`): Cache validity checks `ufs_exists()`; `fs_kind()` returns `FsKind::Cv`.

### 7. Journal and Master

- **curvine-server** (`journal/journal_loader.rs`): Skip applying entry if `entry.index <= cur.applied.index` (avoid duplicate apply).
- **curvine-server** (`master/master_handler.rs`): Job RPC branch returns `Ok(msg.error_ext(&e))` on error so client gets error payload instead of connection error.

### 8. InodeFile (curvine-server)

- **curvine-server** (`master/meta/inode/inode_file.rs`): Use `opts.storage_policy` as-is when creating file. Add `invalid_cache()` (sets `storage_policy.ufs_mtime = 0`). Call `invalid_cache()` in `reopen`, `truncate`, and `set_attr` (len change). Remove clearing `ufs_mtime` in `commit_blocks`.

### 9. LoadTaskRunner (curvine-server worker)

- **curvine-server** (`worker/task/load_task_runner.rs`): `create_unified` now takes `read_status: &FileStatus`; call site passes `reader.status()` so target creation can use source metadata.