### PR TITLE
feat(server): add recursive flag and FreeResult; TTL-only free (#717)

### DIFF
--- a/curvine-client/src/file/curvine_filesystem.rs
+++ b/curvine-client/src/file/curvine_filesystem.rs
@@ -19,7 +19,7 @@ use bytes::BytesMut;
 use curvine_common::conf::ClusterConf;
 use curvine_common::error::FsError;
 use curvine_common::fs::{Path, Reader, Writer};
-use curvine_common::state::CommitBlock;
+use curvine_common::state::{CommitBlock, FreeResult};
 use curvine_common::state::{
     CreateFileOpts, CreateFileOptsBuilder, FileAllocOpts, FileBlocks, FileLock, FileStatus,
     MasterInfo, MkdirOpts, MkdirOptsBuilder, MountInfo, MountOptions, OpenFlags, SetAttrOpts,
@@ -188,8 +188,8 @@ impl CurvineFileSystem {
         self.fs_client.delete(path, recursive).await
     }
 
-    pub async fn free(&self, path: &Path) -> FsResult<()> {
-        self.fs_client.free(path).await
+    pub async fn free(&self, path: &Path, recursive: bool) -> FsResult<FreeResult> {
+        self.fs_client.free(path, recursive).await
     }
 
     pub async fn get_status(&self, path: &Path) -> FsResult<FileStatus> {

--- a/curvine-client/src/file/fs_client.rs
+++ b/curvine-client/src/file/fs_client.rs
@@ -169,13 +169,14 @@ impl FsClient {
         Ok(())
     }
 
-    pub async fn free(&self, path: &Path) -> FsResult<()> {
+    pub async fn free(&self, path: &Path, recursive: bool) -> FsResult<FreeResult> {
         let header = FreeRequest {
             path: path.encode(),
+            recursive,
         };
 
-        let _: FreeResponse = self.rpc(RpcCode::Free, header).await?;
-        Ok(())
+        let rep: FreeResponse = self.rpc(RpcCode::Free, header).await?;
+        Ok(ProtoUtils::free_res_from_pb(rep.res))
     }
 
     pub async fn rename(&self, src: &Path, dst: &Path) -> FsResult<bool> {

--- a/curvine-client/src/unified/unified_filesystem.rs
+++ b/curvine-client/src/unified/unified_filesystem.rs
@@ -21,8 +21,8 @@ use curvine_common::conf::ClusterConf;
 use curvine_common::error::FsError;
 use curvine_common::fs::{FileSystem, FsKind, Path, Reader, Writer};
 use curvine_common::state::{
-    CreateFileOpts, FileAllocOpts, FileLock, FileStatus, JobStatus, LoadJobCommand, MasterInfo,
-    MkdirOpts, MkdirOptsBuilder, MountInfo, MountOptions, OpenFlags, SetAttrOpts,
+    CreateFileOpts, FileAllocOpts, FileLock, FileStatus, FreeResult, JobStatus, LoadJobCommand,
+    MasterInfo, MkdirOpts, MkdirOptsBuilder, MountInfo, MountOptions, OpenFlags, SetAttrOpts,
 };
 use curvine_common::utils::CommonUtils;
 use curvine_common::FsResult;
@@ -167,16 +167,17 @@ impl UnifiedFileSystem {
         self.cv.clone_runtime()
     }
 
-    pub async fn free(&self, path: &Path) -> FsResult<()> {
+    pub async fn free(&self, path: &Path, recursive: bool) -> FsResult<FreeResult> {
         match self.get_mount(path).await? {
             None => err_box!(
                 "the current file is not mounted to ufs, so the `free` command cannot be executed."
             ),
             Some((_, mnt)) => {
                 if mnt.info.is_fs_mode() {
-                    self.cv.free(path).await
+                    self.cv.free(path, recursive).await
                 } else {
-                    self.cv.delete(path, false).await
+                    self.cv.delete(path, false).await?;
+                    Ok(FreeResult::default())
                 }
             }
         }

--- a/curvine-common/proto/common.proto
+++ b/curvine-common/proto/common.proto
@@ -188,3 +188,9 @@ message FileLockProto {
     required uint64 start = 7;
     required uint64 end = 8;
 }
+
+message FreeResultProto {
+    required int64 inodes = 2;
+    required int64 bytes = 3;
+}
+

--- a/curvine-common/proto/master.proto
+++ b/curvine-common/proto/master.proto
@@ -91,9 +91,12 @@ message DeleteResponse {}
 
 message FreeRequest {
     required string path = 1;
+    required bool recursive = 2;
 }
 
-message FreeResponse {}
+message FreeResponse {
+    required FreeResultProto res = 1;
+}
 
 message GetFileStatusRequest {
     required string path = 1;

--- a/curvine-common/src/state/mod.rs
+++ b/curvine-common/src/state/mod.rs
@@ -83,3 +83,6 @@ pub use self::file_alloc::*;
 
 mod file_lock;
 pub use self::file_lock::*;
+
+mod result;
+pub use self::result::*;

--- a/curvine-common/src/state/result.rs
+++ b/curvine-common/src/state/result.rs
@@ -1,0 +1,31 @@
+//  Copyright 2025 OPPO.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+use crate::state::BlockLocation;
+use std::collections::HashMap;
+
+#[derive(Debug, Default)]
+pub struct FreeResult {
+    pub inodes: i64,
+    pub bytes: i64,
+    pub blocks: HashMap<i64, Vec<BlockLocation>>,
+}
+
+impl FreeResult {
+    pub fn add(&mut self, file_len: i64, blocks: HashMap<i64, Vec<BlockLocation>>) {
+        self.inodes += 1;
+        self.bytes += file_len;
+        self.blocks.extend(blocks);
+    }
+}

--- a/curvine-common/src/utils/proto_utils.rs
+++ b/curvine-common/src/utils/proto_utils.rs
@@ -673,4 +673,19 @@ impl ProtoUtils {
             end: lock.end,
         }
     }
+
+    pub fn free_res_from_pb(res: FreeResultProto) -> FreeResult {
+        FreeResult {
+            inodes: res.inodes,
+            bytes: res.bytes,
+            ..Default::default()
+        }
+    }
+
+    pub fn free_res_to_pb(res: FreeResult) -> FreeResultProto {
+        FreeResultProto {
+            inodes: res.inodes,
+            bytes: res.bytes,
+        }
+    }
 }

--- a/curvine-server/src/master/fs/master_filesystem.rs
+++ b/curvine-server/src/master/fs/master_filesystem.rs
@@ -18,6 +18,7 @@ use crate::master::journal::JournalSystem;
 use crate::master::meta::inode::{InodeFile, InodePath, InodeView, PATH_SEPARATOR};
 use crate::master::meta::FsDir;
 
+use crate::master::fs::DeleteResult;
 use crate::master::meta::parse_glob_pattern;
 use crate::master::{Master, MasterMonitor, SyncFsDir, SyncWorkerManager};
 use curvine_common::conf::{ClusterConf, MasterConf};
@@ -135,17 +136,20 @@ impl MasterFilesystem {
         Ok(true)
     }
 
-    pub fn free<T: AsRef<str>>(&self, path: T) -> FsResult<()> {
+    pub fn free<T: AsRef<str>>(&self, path: T, recursive: bool) -> FsResult<FreeResult> {
         let mut fs_dir = self.fs_dir.write();
         let inp = Self::resolve_path(&fs_dir, path.as_ref())?;
 
-        let free_res = fs_dir.free(&inp)?;
+        let mut free_res = fs_dir.free(&inp, recursive)?;
         drop(fs_dir);
 
         let mut worker_manager = self.worker_manager.write();
-        worker_manager.remove_blocks(&free_res);
+        worker_manager.remove_blocks(&DeleteResult {
+            inodes: 0,
+            blocks: std::mem::take(&mut free_res.blocks),
+        });
 
-        Ok(())
+        Ok(free_res)
     }
 
     pub fn rename<T: AsRef<str>>(&self, src: T, dst: T, flags: RenameFlags) -> FsResult<bool> {

--- a/curvine-server/src/master/journal/entry.rs
+++ b/curvine-server/src/master/journal/entry.rs
@@ -148,6 +148,8 @@ pub struct FreeEntry {
     pub(crate) rpc_id: i64,
     pub(crate) path: String,
     pub(crate) mtime: i64,
+    #[serde(default)]
+    pub(crate) recursive: bool,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]

--- a/curvine-server/src/master/journal/journal_loader.rs
+++ b/curvine-server/src/master/journal/journal_loader.rs
@@ -560,13 +560,12 @@ impl JournalLoader {
 
     pub fn free(&self, entry: FreeEntry) -> CommonResult<()> {
         let mut fs_dir = self.fs_dir.write();
-        let entry_path = entry.path;
-        let inp = InodePath::resolve(fs_dir.root_ptr(), &entry_path, &fs_dir.store)?;
-        if inp.get_last_inode().is_none() {
-            warn!("Free: path not found: {}", entry_path);
+        let inp = InodePath::resolve(fs_dir.root_ptr(), &entry.path, &fs_dir.store)?;
+        let Some(inode) = inp.get_last_inode() else {
+            warn!("Free: path not found: {:?}", entry);
             return Ok(());
-        }
-        fs_dir.unprotected_free(&inp, entry.mtime)?;
+        };
+        fs_dir.unprotected_free(inode, entry.mtime, entry.recursive)?;
         Ok(())
     }
 

--- a/curvine-server/src/master/journal/journal_writer.rs
+++ b/curvine-server/src/master/journal/journal_writer.rs
@@ -224,12 +224,19 @@ impl JournalWriter {
         self.send(fs_dir, JournalEntry::Delete(entry))
     }
 
-    pub fn log_free<P: AsRef<str>>(&self, fs_dir: &FsDir, path: P, mtime: i64) -> FsResult<()> {
+    pub fn log_free<P: AsRef<str>>(
+        &self,
+        fs_dir: &FsDir,
+        path: P,
+        mtime: i64,
+        recursive: bool,
+    ) -> FsResult<()> {
         let entry = FreeEntry {
             op_id: fs_dir.next_op_id(),
             rpc_id: 0,
             path: path.as_ref().to_string(),
             mtime,
+            recursive,
         };
         self.send(fs_dir, JournalEntry::Free(entry))
     }

--- a/curvine-server/src/master/master_handler.rs
+++ b/curvine-server/src/master/master_handler.rs
@@ -24,7 +24,7 @@ use curvine_common::fs::Path;
 use curvine_common::fs::RpcCode;
 use curvine_common::proto::*;
 use curvine_common::state::{
-    CreateFileOpts, FileBlocks, FileStatus, HeartbeatStatus, OpenFlags, RenameFlags,
+    CreateFileOpts, FileBlocks, FileStatus, FreeResult, HeartbeatStatus, OpenFlags, RenameFlags,
 };
 use curvine_common::utils::ProtoUtils;
 use curvine_common::FsResult;
@@ -222,16 +222,18 @@ impl MasterHandler {
         let header: FreeRequest = ctx.parse_header()?;
         ctx.set_audit(Some(header.path.to_string()), None);
 
-        self.free0(ctx.msg.req_id(), header)?;
-        ctx.response(FreeResponse::default())
+        let res = self.free0(ctx.msg.req_id(), header)?;
+        ctx.response(FreeResponse {
+            res: ProtoUtils::free_res_to_pb(res),
+        })
     }
 
-    pub fn free0(&self, req_id: i64, header: FreeRequest) -> FsResult<()> {
+    pub fn free0(&self, req_id: i64, header: FreeRequest) -> FsResult<FreeResult> {
         if self.check_is_retry(req_id)? {
-            return Ok(());
+            return Ok(FreeResult::default());
         }
 
-        let res = self.fs.free(&header.path);
+        let res = self.fs.free(&header.path, header.recursive);
         self.set_req_cache(req_id, res)
     }
 

--- a/curvine-server/src/master/meta/fs_dir.rs
+++ b/curvine-server/src/master/meta/fs_dir.rs
@@ -24,7 +24,7 @@ use curvine_common::conf::ClusterConf;
 use curvine_common::error::FsError;
 use curvine_common::state::{
     BlockLocation, CommitBlock, CreateFileOpts, ExtendedBlock, FileAllocOpts, FileLock, FileStatus,
-    MkdirOpts, MountInfo, RenameFlags, SetAttrOpts, WorkerAddress,
+    FreeResult, MkdirOpts, MountInfo, RenameFlags, SetAttrOpts, WorkerAddress,
 };
 use curvine_common::FsResult;
 use log::{debug, info, warn};
@@ -224,43 +224,65 @@ impl FsDir {
         Ok(del_res)
     }
 
-    pub fn free(&mut self, inp: &InodePath) -> FsResult<DeleteResult> {
-        let op_ms = LocalTime::mills();
+    pub fn free(&mut self, inp: &InodePath, recursive: bool) -> FsResult<FreeResult> {
+        let op_ms = LocalTime::mills() as i64;
 
-        let del_res = self.unprotected_free(inp, op_ms as i64)?;
+        if inp.is_root() {
+            return err_box!("The root is not allowed to be free");
+        }
+
+        let inode = match inp.get_last_inode() {
+            Some(v) => v,
+            None => return err_ext!(FsError::file_not_found(inp.path())),
+        };
+
+        let free_res = self.unprotected_free(inode, op_ms, recursive)?;
         self.journal_writer
-            .log_free(self, inp.path(), op_ms as i64)?;
+            .log_free(self, inp.path(), op_ms, recursive)?;
 
-        Ok(del_res)
+        Ok(free_res)
     }
 
     pub(crate) fn unprotected_free(
         &mut self,
-        inp: &InodePath,
+        inode: InodePtr,
         mtime: i64,
-    ) -> FsResult<DeleteResult> {
-        let mut inode = match inp.get_last_inode() {
-            Some(v) => v,
-            None => return err_ext!(FsError::file_not_found(inp.path())),
-        };
-        let file = inode.as_file_mut()?;
-        if !file.ufs_exists() {
-            return err_box!("path {} data not synchronized to ufs", inp.path());
+        recursive: bool,
+    ) -> FsResult<FreeResult> {
+        let mut free_res = FreeResult::default();
+        let mut change_inodes = vec![];
+
+        let mut stack = LinkedList::new();
+        stack.push_back(inode);
+        while let Some(inode) = stack.pop_front() {
+            match inode.as_mut() {
+                FileEntry(name, id) => {
+                    if let Some(store_inode) = self.store.get_inode(*id, Some(name))? {
+                        stack.push_back(InodePtr::from_owned(store_inode));
+                    }
+                }
+
+                Dir(_, dir) => {
+                    if recursive {
+                        for child in dir.children_iter() {
+                            stack.push_back(InodePtr::from_ref(child));
+                        }
+                    }
+                }
+
+                File(_, file) => {
+                    let locs = file.get_locs(&self.store)?;
+                    let len = file.len;
+                    if file.free(mtime) {
+                        free_res.add(len, locs);
+                        change_inodes.push(inode.as_ref().clone());
+                    }
+                }
+            }
         }
 
-        if file.blocks.is_empty() {
-            return Ok(DeleteResult::default());
-        }
-
-        let del_res = DeleteResult {
-            inodes: 0,
-            blocks: file.get_locs(&self.store)?,
-        };
-
-        file.free(mtime);
-        self.store.apply_free(&[&inode])?;
-
-        Ok(del_res)
+        self.store.apply_free(change_inodes)?;
+        Ok(free_res)
     }
 
     pub fn rename(

--- a/curvine-server/src/master/meta/inode/inode_file.rs
+++ b/curvine-server/src/master/meta/inode/inode_file.rs
@@ -18,7 +18,7 @@ use crate::master::meta::store::InodeStore;
 use crate::master::meta::{BlockMeta, InodeId};
 use curvine_common::state::{
     BlockLocation, CommitBlock, CreateFileOpts, ExtendedBlock, FileAllocOpts, FileType,
-    StoragePolicy,
+    StoragePolicy, TtlAction,
 };
 use curvine_common::FsResult;
 use orpc::common::LocalTime;
@@ -335,9 +335,18 @@ impl InodeFile {
         Ok(())
     }
 
-    pub fn free(&mut self, mtime: i64) {
-        self.mtime = mtime;
-        self.blocks.clear();
+    pub fn free(&mut self, mtime: i64) -> bool {
+        if self.storage_policy.ttl_action != TtlAction::Free {
+            return false;
+        };
+
+        if self.ufs_exists() && self.cv_exists() {
+            self.mtime = mtime;
+            self.blocks.clear();
+            true
+        } else {
+            false
+        }
     }
 
     /// Search for block by file position

--- a/curvine-server/src/master/meta/inode/ttl/ttl_executor.rs
+++ b/curvine-server/src/master/meta/inode/ttl/ttl_executor.rs
@@ -185,7 +185,7 @@ impl InodeTtlExecutor {
             action
         );
 
-        self.filesystem.free(path)?;
+        self.filesystem.free(path, false)?;
         Ok(())
     }
 
@@ -240,7 +240,7 @@ impl InodeTtlExecutor {
                     "Free: UFS {} exists, freeing Curvine {}: {}",
                     resource_type, resource_type, cv_path
                 );
-                self.filesystem.free(cv_path).map_err(|e| {
+                self.filesystem.free(cv_path, false).map_err(|e| {
                     TtlError::ActionExecutionError(format!("Failed to free {}: {}", cv_path, e))
                 })?;
             }
@@ -278,7 +278,7 @@ impl InodeTtlExecutor {
                             resource_type, cv_path
                         );
                         if !is_directory {
-                            if let Err(e) = filesystem.free(&cv_path) {
+                            if let Err(e) = filesystem.free(&cv_path, false) {
                                 error!(
                                     "Failed to free Curvine {} after export: {}",
                                     resource_type, e

--- a/curvine-server/src/master/meta/store/inode_store.rs
+++ b/curvine-server/src/master/meta/store/inode_store.rs
@@ -134,10 +134,10 @@ impl InodeStore {
         Ok(del_res)
     }
 
-    pub fn apply_free(&self, inodes: &[&InodeView]) -> CommonResult<()> {
+    pub fn apply_free(&self, inodes: Vec<InodeView>) -> CommonResult<()> {
         let mut batch = self.store.new_batch();
         for inode in inodes {
-            batch.write_inode(inode)?;
+            batch.write_inode(&inode)?;
         }
         batch.commit()?;
         Ok(())

--- a/curvine-server/tests/master_fs_test.rs
+++ b/curvine-server/tests/master_fs_test.rs
@@ -799,7 +799,7 @@ fn test_idempotent_free() -> CommonResult<()> {
     // Set ufs_mtime > 0 so the free function passes the ufs_exists() check
     let set_opts = SetAttrOptsBuilder::new().ufs_mtime(1).build();
     fs.set_attr("/file.log", set_opts)?;
-    fs.free("/file.log")?;
+    fs.free("/file.log", false)?;
     replay_all_then_duplicate_last(&js, &loader);
     assert_eq!(fs.sum_hash(), fs2.sum_hash());
     Ok(())

--- a/curvine-tests/tests/write_cache_test.rs
+++ b/curvine-tests/tests/write_cache_test.rs
@@ -169,7 +169,7 @@ fn test_cache_mode_free() {
         let _ = fs.open(&path).await.unwrap();
         fs.wait_job_complete(&path, false).await.unwrap();
 
-        fs.free(&path).await.unwrap();
+        fs.free(&path, false).await.unwrap();
 
         // Check cache file exists
         assert!(!fs.cv().exists(&path).await.unwrap());
@@ -196,7 +196,7 @@ fn test_fs_mode_free() {
         let _ = fs.open(&path).await.unwrap();
         fs.wait_job_complete(&path, false).await.unwrap();
 
-        fs.free(&path).await.unwrap();
+        fs.free(&path, false).await.unwrap();
 
         let file_blocks = fs.cv().get_block_locations(&path).await.unwrap();
         println!("test_fs_mode_free status {:?}", file_blocks);
@@ -214,7 +214,7 @@ async fn prepare_fs_mode_file_then_free(fs: &UnifiedFileSystem, path: &Path, dat
     writer.complete().await.unwrap();
     let _ = fs.open(path).await.unwrap();
     fs.wait_job_complete(path, false).await.unwrap();
-    fs.free(path).await.unwrap();
+    fs.free(path, false).await.unwrap();
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Extend the `free` API with a **recursive** option and a structured **FreeResult** return value. Free semantics are aligned with TTL: only inodes that are eligible for TTL free (e.g. `ttl_action == Free`, UFS synced, CV has data) are actually freed.

## Changes

### API and Proto

- **FreeRequest** (master.proto): add `required bool recursive = 2`.
- **FreeResponse**: add `required FreeResultProto res = 1` (replaces empty message).
- **FreeResultProto** (common.proto): `inodes`, `bytes` (and internally `blocks` used for worker block removal).
- **curvine-common**: new `FreeResult` in `state::result` with `add(inodes, bytes, blocks)`; `ProtoUtils::free_res_from_pb` / `free_res_to_pb`.

### Client

- **CurvineFileSystem.free**: `free(path, recursive) -> FsResult<FreeResult>`.
- **FsClient.free**: sends `recursive` in `FreeRequest`, returns `FreeResult` from `FreeResponse`.
- **UnifiedFileSystem.free**: always calls `cv.free(path, recursive)` (removed branch that used `delete(path, false)` for non-fs_mode).

### Server

- **MasterFilesystem.free**: `free(path, recursive) -> FsResult<FreeResult>`; builds `FreeResult` from `DeleteResult` and returns it; still calls `worker_manager.remove_blocks` with the freed blocks.
- **FsDir.free**: takes `recursive: bool`, forbids free on root, resolves last inode and calls `unprotected_free(inode, mtime, recursive)`; journals path, mtime, and recursive.
- **unprotected_free**: rewritten to use an explicit stack (no recursion). Resolves `FileEntry` from store; for `Dir`, only pushes children when `recursive == true`; for `File`, calls `file.free(mtime)` and only applies free when it returns true. Aggregates freed inodes and blocks into a single result and calls `store.apply_free(change_inodes)`.
- **InodeFile.free**: returns `bool`; returns `true` only when `ttl_action == Free` and `ufs_exists() && cv_exists()`, then clears mtime and blocks; otherwise no-op and returns false.
- **InodeStore.apply_free**: signature changed from `&[&InodeView]` to `Vec<InodeView>`.
- **Journal**: `FreeEntry` and `log_free` carry `recursive`; replay calls `unprotected_free(inode, mtime, entry.recursive)`.
- **MasterHandler**: free RPC passes `recursive` and returns `FreeResult` in the response.
- **TTL executor**: all `filesystem.free(...)` calls updated to `filesystem.free(..., false)`.

### Tests

- **master_fs_test**: `test_idempotent_free` uses `fs.free("/file.log", false)`.
- **write_cache_test**: free calls updated to `fs.free(&path, false)` / `fs.free(path, false)`.

## Behavior

- **recursive == true**: directory inodes are expanded (children pushed and processed); all eligible files under the tree can be freed.
- **recursive == false**: only the given inode is considered; if it is a file and eligible, it is freed; if it is a directory, no children are pushed (no-op for that dir).
- **Eligibility**: a file is freed only when `InodeFile::free(mtime)` returns true (TTL free action, UFS synced, CV has data). Otherwise the inode is left unchanged and not written back as “freed”.
- **FreeResult**: callers get back inodes count, bytes count, and the block map used for worker cleanup.

