### PR TITLE
fix(fs): simplify free path and fix TTL free condition

### DIFF
--- a/curvine-client/src/unified/unified_filesystem.rs
+++ b/curvine-client/src/unified/unified_filesystem.rs
@@ -170,16 +170,9 @@ impl UnifiedFileSystem {
     pub async fn free(&self, path: &Path, recursive: bool) -> FsResult<FreeResult> {
         match self.get_mount(path).await? {
             None => err_box!(
-                "the current file is not mounted to ufs, so the `free` command cannot be executed."
+                "the current path is not mounted to ufs, so the `free` command cannot be executed."
             ),
-            Some((_, mnt)) => {
-                if mnt.info.is_fs_mode() {
-                    self.cv.free(path, recursive).await
-                } else {
-                    self.cv.delete(path, false).await?;
-                    Ok(FreeResult::default())
-                }
-            }
+            Some(_) => self.cv.free(path, recursive).await,
         }
     }
 
@@ -263,6 +256,10 @@ impl UnifiedFileSystem {
                 err_box!("path {} data lost", cv_path)
             }
         } else {
+            if !blocks.cv_exists() {
+                return Ok(None);
+            }
+
             match self
                 .check_cache_validity(&blocks.status, ufs_path, mount)
                 .await?

--- a/curvine-common/src/state/block_info.rs
+++ b/curvine-common/src/state/block_info.rs
@@ -164,7 +164,11 @@ impl FileBlocks {
     }
 
     pub fn cv_exists(&self) -> bool {
-        self.len > 0 && !self.block_locs.is_empty()
+        if self.len <= 0 {
+            true
+        } else {
+            !self.block_locs.is_empty()
+        }
     }
 }
 

--- a/curvine-server/src/master/meta/inode/inode_file.rs
+++ b/curvine-server/src/master/meta/inode/inode_file.rs
@@ -336,7 +336,7 @@ impl InodeFile {
     }
 
     pub fn free(&mut self, mtime: i64) -> bool {
-        if self.storage_policy.ttl_action != TtlAction::Free {
+        if self.storage_policy.ttl_action == TtlAction::None {
             return false;
         };
 

--- a/curvine-tests/tests/write_cache_test.rs
+++ b/curvine-tests/tests/write_cache_test.rs
@@ -172,7 +172,7 @@ fn test_cache_mode_free() {
         fs.free(&path, false).await.unwrap();
 
         // Check cache file exists
-        assert!(!fs.cv().exists(&path).await.unwrap());
+        assert!(fs.cv().exists(&path).await.unwrap());
 
         let reader = fs.open(&path).await.unwrap();
         assert!(!matches!(reader, UnifiedReader::Cv(_)));


### PR DESCRIPTION
- UnifiedFileSystem::free: always use cv.free, remove mount/ufs branch
- Skip cache validity check when blocks.cv_exists() is false
- InodeFile::free: only skip when ttl_action is None (#close 717)