### PR TITLE
refactor: introduce StorageState (Cv/Ufs/Both) for fs_mode and cache_…

### DIFF
--- a/curvine-client/src/file/curvine_filesystem.rs
+++ b/curvine-client/src/file/curvine_filesystem.rs
@@ -30,8 +30,8 @@ use curvine_common::FsResult;
 use log::info;
 use log::warn;
 use orpc::client::ClientConf;
+use orpc::err_box;
 use orpc::runtime::{RpcRuntime, Runtime};
-use orpc::{err_box, err_ext};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::timeout;
@@ -136,21 +136,8 @@ impl CurvineFileSystem {
         self.fs_client.exists(path).await
     }
 
-    fn check_read_status(path: &Path, file_blocks: &FileBlocks) -> FsResult<()> {
-        // if !file_blocks.status.is_complete {
-        //     return err_box!("Cannot read from {} because it is incomplete.", path);
-        // }
-
-        if file_blocks.status.is_expired() {
-            return err_ext!(FsError::file_expired(path.path()));
-        }
-
-        Ok(())
-    }
-
     pub async fn open(&self, path: &Path) -> FsResult<FsReader> {
         let file_blocks = self.fs_client.get_block_locations(path).await?;
-        Self::check_read_status(path, &file_blocks)?;
 
         let reader = FsReader::new(path.clone(), self.fs_context.clone(), file_blocks)?;
         Ok(reader)

--- a/curvine-client/src/unified/fallback_fs_reader.rs
+++ b/curvine-client/src/unified/fallback_fs_reader.rs
@@ -62,14 +62,13 @@ impl FallbackFsReader {
     /// Returns an error if UFS data cannot be trusted (modified externally or never flushed).
     async fn validate_ufs_consistency(&self) -> FsResult<()> {
         let cv_status = self.cv_reader.status();
-        let cv_ufs_mtime = cv_status.storage_policy.ufs_mtime;
-        let cv_len = cv_status.len;
         let ufs_status = self.ufs_fs.get_status(&self.ufs_path).await?;
 
-        if let Err(e) =
-            check_ufs_consistency(cv_ufs_mtime, cv_len, ufs_status.mtime, ufs_status.len)
-        {
-            return err_box!("UFS data inconsistent for {}: {}", self.ufs_path, e);
+        if !cv_status.ufs_valid(&ufs_status) {
+            return err_box!(
+                "UFS data inconsistent for {}: CV and UFS len/mtime do not match or CV not valid",
+                self.ufs_path
+            );
         }
 
         Ok(())
@@ -99,28 +98,6 @@ pub(crate) fn is_worker_err(e: &FsError) -> bool {
     }
 
     false
-}
-
-/// Shared consistency check logic used by runtime path and tests.
-pub(crate) fn check_ufs_consistency(
-    cv_ufs_mtime: i64,
-    cv_len: i64,
-    ufs_mtime: i64,
-    ufs_len: i64,
-) -> FsResult<()> {
-    if cv_ufs_mtime == 0 {
-        return err_box!("data has not been flushed to UFS yet (ufs_mtime=0)");
-    }
-    if cv_ufs_mtime != ufs_mtime || cv_len != ufs_len {
-        return err_box!(
-            "UFS data inconsistent: cv_ufs_mtime={}, ufs_mtime={}, cv_len={}, ufs_len={}",
-            cv_ufs_mtime,
-            ufs_mtime,
-            cv_len,
-            ufs_len
-        );
-    }
-    Ok(())
 }
 
 impl Reader for FallbackFsReader {
@@ -269,43 +246,5 @@ mod tests {
     fn test_is_worker_err_common_connection_refused() {
         let e = FsError::common("Connection refused (os error 111)");
         assert!(is_worker_err(&e));
-    }
-
-    // --- TC-6 to TC-9: check_ufs_consistency pure function ---
-
-    #[test]
-    fn test_ufs_consistency_mtime_zero() {
-        // Data has never been flushed to UFS — cannot fall back.
-        let result = check_ufs_consistency(0, 100, 0, 100);
-        assert!(result.is_err());
-        let msg = result.unwrap_err().to_string();
-        assert!(msg.contains("ufs_mtime=0"));
-    }
-
-    #[test]
-    fn test_ufs_consistency_mtime_mismatch() {
-        // UFS was modified externally after Curvine last flushed.
-        let result = check_ufs_consistency(1000, 100, 2000, 100);
-        assert!(result.is_err());
-        let msg = result.unwrap_err().to_string();
-        assert!(msg.contains("cv_ufs_mtime=1000"));
-        assert!(msg.contains("ufs_mtime=2000"));
-    }
-
-    #[test]
-    fn test_ufs_consistency_len_mismatch() {
-        // mtime matches but file length differs — still inconsistent.
-        let result = check_ufs_consistency(1000, 100, 1000, 150);
-        assert!(result.is_err());
-        let msg = result.unwrap_err().to_string();
-        assert!(msg.contains("cv_len=100"));
-        assert!(msg.contains("ufs_len=150"));
-    }
-
-    #[test]
-    fn test_ufs_consistency_all_match() {
-        // Both mtime and len match — safe to fall back.
-        let result = check_ufs_consistency(1000, 100, 1000, 100);
-        assert!(result.is_ok());
     }
 }

--- a/curvine-client/src/unified/unified_filesystem.rs
+++ b/curvine-client/src/unified/unified_filesystem.rs
@@ -203,26 +203,17 @@ impl UnifiedFileSystem {
         ufs_path: &Path,
         mount: &MountValue,
     ) -> FsResult<CacheValidity> {
-        if cv_status.is_expired() {
-            return Ok(CacheValidity::Invalid(None));
-        }
-
-        if !cv_status.is_complete() || !cv_status.ufs_exists() {
-            return Ok(CacheValidity::Invalid(None));
-        }
-
-        if !mount.info.read_verify_ufs {
-            return Ok(CacheValidity::Valid);
-        }
-
-        let ufs_status = mount.ufs.get_status(ufs_path).await?;
-        if cv_status.len == ufs_status.len
-            && cv_status.storage_policy.ufs_mtime != 0
-            && cv_status.storage_policy.ufs_mtime == ufs_status.mtime
-        {
+        if mount.info.read_verify_ufs {
+            let ufs_status = mount.ufs.get_status(ufs_path).await?;
+            if cv_status.cv_valid(Some(&ufs_status)) {
+                Ok(CacheValidity::Valid)
+            } else {
+                Ok(CacheValidity::Invalid(Some(ufs_status)))
+            }
+        } else if cv_status.cv_valid(None) {
             Ok(CacheValidity::Valid)
         } else {
-            Ok(CacheValidity::Invalid(Some(ufs_status)))
+            Ok(CacheValidity::Invalid(None))
         }
     }
 
@@ -256,18 +247,12 @@ impl UnifiedFileSystem {
                 err_box!("path {} data lost", cv_path)
             }
         } else {
-            if !blocks.cv_exists() {
-                return Ok(None);
-            }
-
             match self
                 .check_cache_validity(&blocks.status, ufs_path, mount)
                 .await?
             {
                 CacheValidity::Valid => {
-                    if blocks.status.ufs_exists() {
-                        blocks.status.mtime = blocks.status.storage_policy.ufs_mtime;
-                    }
+                    blocks.status.mtime = blocks.status.storage_policy.ufs_mtime;
                     let cv_reader = FsReader::new(cv_path.clone(), self.cv.fs_context(), blocks)?;
                     Ok(Some(FallbackFsReader::new(
                         cv_reader,
@@ -338,6 +323,7 @@ impl UnifiedFileSystem {
         opts: CreateFileOpts,
         cv_len: i64,
     ) -> FsResult<()> {
+        let opts = mnt.info.merge_create_opts(opts);
         let ufs_path = mnt.get_ufs_path(path)?;
         let mut reader = mnt.ufs.open(&ufs_path).await?;
         if reader.len() != cv_len {
@@ -385,8 +371,9 @@ impl UnifiedFileSystem {
             }
 
             Some((_, mount)) if mount.info.is_fs_mode() => {
+                let opts = mount.info.merge_create_opts(opts);
                 let mut writer = self.cv.open_with_opts(path, opts.clone(), flags).await?;
-                if writer.file_blocks().cv_exists() || flags.overwrite() {
+                if writer.file_blocks().data_exists() || flags.overwrite() {
                     Ok(UnifiedWriter::Cv(writer))
                 } else {
                     writer.complete().await?;
@@ -526,7 +513,14 @@ impl FileSystem<UnifiedWriter, UnifiedReader> for UnifiedFileSystem {
 
     async fn open(&self, path: &Path) -> FsResult<UnifiedReader> {
         let (ufs_path, mount) = match self.get_mount(path).await? {
-            None => return Ok(UnifiedReader::Cv(self.cv.open(path).await?)),
+            None => {
+                let reader = UnifiedReader::Cv(self.cv.open(path).await?);
+                return if reader.status().is_expired() {
+                    return err_ext!(FsError::file_expired(path.path()));
+                } else {
+                    Ok(reader)
+                };
+            }
             Some(v) => v,
         };
 
@@ -631,9 +625,7 @@ impl FileSystem<UnifiedWriter, UnifiedReader> for UnifiedFileSystem {
             Some((ufs_path, mnt)) => match self.cv.get_status(path).await {
                 Ok(mut v) => match self.check_cache_validity(&v, &ufs_path, &mnt).await? {
                     CacheValidity::Valid => {
-                        if v.ufs_exists() {
-                            v.mtime = v.storage_policy.ufs_mtime;
-                        }
+                        v.mtime = v.storage_policy.ufs_mtime;
                         Ok(v)
                     }
                     CacheValidity::Invalid(Some(ufs_status)) => Ok(ufs_status),

--- a/curvine-common/proto/common.proto
+++ b/curvine-common/proto/common.proto
@@ -36,12 +36,19 @@ enum FileTypeProto {
     FILE_TYPE_PROTO_OBJECT = 5;
 }
 
+enum StorageStateProto {
+    STORAGE_STATE_PROTO_CV = 1;
+    STORAGE_STATE_PROTO_UFS = 2;
+    STORAGE_STATE_PROTO_BOTH = 3;
+}
+
 // File storage policy
 message StoragePolicyProto {
     required StorageTypeProto storage_type = 1 [default = STORAGE_TYPE_PROTO_DISK];
     required int64 ttl_ms = 2 [default = 0];
     required TtlActionProto ttl_action = 3 [default = TTL_ACTION_PROTO_NONE];
     required int64 ufs_mtime = 4;
+    required StorageStateProto state = 5 [default = STORAGE_STATE_PROTO_CV];
 }
 
 message FileStatusProto {

--- a/curvine-common/src/state/block_info.rs
+++ b/curvine-common/src/state/block_info.rs
@@ -163,11 +163,11 @@ impl FileBlocks {
         Self { status, block_locs }
     }
 
-    pub fn cv_exists(&self) -> bool {
-        if self.len <= 0 {
+    pub fn data_exists(&self) -> bool {
+        if self.len == 0 {
             true
         } else {
-            !self.block_locs.is_empty()
+            self.cv_exists() && !self.block_locs.is_empty()
         }
     }
 }

--- a/curvine-common/src/state/file_status.rs
+++ b/curvine-common/src/state/file_status.rs
@@ -87,6 +87,34 @@ impl FileStatus {
     }
 
     pub fn ufs_exists(&self) -> bool {
-        self.storage_policy.ufs_mtime > 0
+        self.storage_policy.ufs_exists()
+    }
+
+    pub fn cv_exists(&self) -> bool {
+        self.storage_policy.cv_exists()
+    }
+
+    /// Returns true if CV data is valid and usable: CV exists, not expired, UFS exists;
+    /// when `ufs_status` is provided, also checks len and mtime match UFS.
+    pub fn cv_valid(&self, ufs_status: Option<&FileStatus>) -> bool {
+        if !self.cv_exists() {
+            return false;
+        }
+        if self.is_expired() || !self.ufs_exists() {
+            return false;
+        }
+        if let Some(ufs_status) = ufs_status {
+            self.len == ufs_status.len && self.storage_policy.ufs_mtime == ufs_status.mtime
+        } else {
+            true
+        }
+    }
+
+    pub fn ufs_valid(&self, ufs_status: &FileStatus) -> bool {
+        if self.ufs_exists() {
+            self.len == ufs_status.len && self.storage_policy.ufs_mtime == ufs_status.mtime
+        } else {
+            false
+        }
     }
 }

--- a/curvine-common/src/state/mount.rs
+++ b/curvine-common/src/state/mount.rs
@@ -14,7 +14,7 @@
 
 use crate::conf::ClientConf;
 use crate::fs::Path;
-use crate::state::{CreateFileOpts, CreateFileOptsBuilder, StorageType, TtlAction};
+use crate::state::{CreateFileOpts, CreateFileOptsBuilder, StoragePolicy, StorageType, TtlAction};
 use num_enum::{FromPrimitive, IntoPrimitive};
 use orpc::common::DurationUnit;
 use orpc::{err_box, CommonError, CommonResult};
@@ -124,6 +124,28 @@ impl MountInfo {
             .build()
     }
 
+    pub fn merge_create_opts(&self, opts: CreateFileOpts) -> CreateFileOpts {
+        CreateFileOpts {
+            create_parent: opts.create_parent,
+            replicas: self.replicas.unwrap_or(opts.replicas as i32) as u16,
+            block_size: self.block_size.unwrap_or(opts.block_size),
+            file_type: opts.file_type,
+            x_attr: opts.x_attr,
+            storage_policy: StoragePolicy {
+                ttl_ms: self.ttl_ms,
+                ttl_action: self.ttl_action,
+                storage_type: self
+                    .storage_type
+                    .unwrap_or(opts.storage_policy.storage_type),
+                ..opts.storage_policy
+            },
+            mode: opts.mode,
+            client_name: opts.client_name,
+            owner: opts.owner,
+            group: opts.group,
+        }
+    }
+
     pub fn is_cache_mode(&self) -> bool {
         self.write_type == WriteType::CacheMode
     }
@@ -182,13 +204,18 @@ impl MountOptions {
     }
 
     pub fn to_info(self, mount_id: u32, cv_path: &str, ufs_path: &str) -> MountInfo {
+        let ttl_action = match self.write_type {
+            WriteType::CacheMode => TtlAction::Delete,
+            WriteType::FsMode => TtlAction::Free,
+        };
+
         MountInfo {
             cv_path: cv_path.to_string(),
             ufs_path: ufs_path.to_string(),
             mount_id,
             properties: self.add_properties,
             ttl_ms: self.ttl_ms.unwrap_or(0),
-            ttl_action: self.ttl_action.unwrap_or(TtlAction::None),
+            ttl_action,
             read_verify_ufs: self.read_verify_ufs,
             storage_type: self.storage_type,
             block_size: self.block_size,

--- a/curvine-common/src/state/storage_policy.rs
+++ b/curvine-common/src/state/storage_policy.rs
@@ -13,9 +13,29 @@
 // limitations under the License.
 
 use crate::state::{StorageType, TtlAction};
-
-// File storage policy.
+use num_enum::{FromPrimitive, IntoPrimitive};
 use serde::{Deserialize, Serialize};
+
+#[repr(i8)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    IntoPrimitive,
+    FromPrimitive,
+    Eq,
+    Default,
+    Hash,
+)]
+pub enum StorageState {
+    #[default]
+    Cv = 1,
+    Ufs = 2,
+    Both = 3,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StoragePolicy {
@@ -23,6 +43,67 @@ pub struct StoragePolicy {
     pub ttl_ms: i64,
     pub ttl_action: TtlAction,
     pub ufs_mtime: i64,
+    pub state: StorageState,
+}
+
+impl StoragePolicy {
+    pub fn with_cv(new_policy: StoragePolicy) -> Self {
+        Self {
+            ufs_mtime: 0,
+            state: StorageState::Cv,
+            ..new_policy
+        }
+    }
+
+    pub fn overwrite(&mut self, new_policy: StoragePolicy) {
+        self.storage_type = new_policy.storage_type;
+        self.ttl_ms = new_policy.ttl_ms;
+        self.ttl_action = new_policy.ttl_action;
+
+        self.detach_ufs();
+    }
+
+    /// On write: detach from UFS (close link); state→Cv, ufs_mtime=0.
+    pub fn detach_ufs(&mut self) {
+        self.state = StorageState::Cv;
+        self.ufs_mtime = 0;
+    }
+
+    pub fn free(&mut self) -> bool {
+        if self.both_exists() && self.ttl_action != TtlAction::None {
+            self.state = StorageState::Ufs;
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn save_ufs(&mut self, ufs_mtime: i64) {
+        if ufs_mtime > 0 {
+            self.ufs_mtime = ufs_mtime;
+            self.state = StorageState::Both;
+        }
+    }
+
+    pub fn ufs_exists(&self) -> bool {
+        matches!(self.state, StorageState::Ufs | StorageState::Both)
+    }
+
+    pub fn cv_exists(&self) -> bool {
+        matches!(self.state, StorageState::Cv | StorageState::Both)
+    }
+
+    pub fn ufs_only(&self) -> bool {
+        self.state == StorageState::Ufs
+    }
+
+    pub fn cv_only(&self) -> bool {
+        self.state == StorageState::Cv
+    }
+
+    pub fn both_exists(&self) -> bool {
+        self.state == StorageState::Both
+    }
 }
 
 impl Default for StoragePolicy {
@@ -32,6 +113,7 @@ impl Default for StoragePolicy {
             ttl_ms: 0,
             ttl_action: TtlAction::None,
             ufs_mtime: 0,
+            state: StorageState::Cv,
         }
     }
 }

--- a/curvine-common/src/utils/proto_utils.rs
+++ b/curvine-common/src/utils/proto_utils.rs
@@ -200,6 +200,7 @@ impl ProtoUtils {
             ttl_ms: policy.ttl_ms,
             ttl_action: policy.ttl_action.into(),
             ufs_mtime: policy.ufs_mtime,
+            state: policy.state as i32,
         }
     }
 
@@ -209,6 +210,7 @@ impl ProtoUtils {
             ttl_ms: policy.ttl_ms,
             ttl_action: TtlAction::from(policy.ttl_action),
             ufs_mtime: policy.ufs_mtime,
+            state: StorageState::from(policy.state as i8),
         }
     }
 

--- a/curvine-server/src/master/job/job_runner.rs
+++ b/curvine-server/src/master/job/job_runner.rs
@@ -84,22 +84,15 @@ impl LoadJobRunner {
         // Skip based on data state (even when job is None, e.g. after job cleanup)
         if source_path.is_cv() {
             Ok(false)
-        } else {
-            // ufs -> cv: if CV exists and ufs_mtime matches UFS mtime, data already synced, skip
-            let source_status = mnt.ufs.get_status(source_path).await?;
-            if source_status.is_dir {
-                Ok(false)
-            } else if let Ok(cv_status) = self.master_fs.file_status(target_path.path()) {
-                if cv_status.is_expired() || !cv_status.is_complete {
-                    Ok(false)
-                } else {
-                    Ok(source_status.len == cv_status.len
-                        && cv_status.storage_policy.ufs_mtime != 0
-                        && cv_status.storage_policy.ufs_mtime == source_status.mtime)
-                }
+        } else if let Ok(cv_status) = self.master_fs.file_status(target_path.path()) {
+            if cv_status.cv_valid(None) {
+                let source_status = mnt.ufs.get_status(source_path).await?;
+                Ok(cv_status.cv_valid(Some(&source_status)))
             } else {
                 Ok(false)
             }
+        } else {
+            Ok(false)
         }
     }
 

--- a/curvine-server/src/master/meta/inode/inode_file.rs
+++ b/curvine-server/src/master/meta/inode/inode_file.rs
@@ -18,7 +18,7 @@ use crate::master::meta::store::InodeStore;
 use crate::master::meta::{BlockMeta, InodeId};
 use curvine_common::state::{
     BlockLocation, CommitBlock, CreateFileOpts, ExtendedBlock, FileAllocOpts, FileType,
-    StoragePolicy, TtlAction,
+    StoragePolicy,
 };
 use curvine_common::FsResult;
 use orpc::common::LocalTime;
@@ -86,7 +86,7 @@ impl InodeFile {
             block_size: opts.block_size as u32,
             replicas: opts.replicas as u8,
 
-            storage_policy: opts.storage_policy,
+            storage_policy: StoragePolicy::with_cv(opts.storage_policy),
             features: FileFeature {
                 x_attr: Default::default(),
                 file_write: None,
@@ -160,7 +160,7 @@ impl InodeFile {
     }
 
     pub fn compute_len(&self) -> i64 {
-        if self.cv_exists() {
+        if self.data_exists() {
             self.blocks.iter().map(|x| x.len as i64).sum()
         } else {
             self.len
@@ -206,7 +206,7 @@ impl InodeFile {
 
     pub fn reopen(&mut self, client_name: impl AsRef<str>) -> Option<ExtendedBlock> {
         self.features.set_writing(client_name.as_ref().to_string());
-        self.invalid_cache();
+        self.storage_policy.detach_ufs();
         if let Some(last_block) = self.get_block_mut(-1) {
             let blk = ExtendedBlock {
                 id: last_block.id,
@@ -268,10 +268,7 @@ impl InodeFile {
         // Update file metadata with new options
         self.replicas = opts.replicas as u8;
         self.block_size = opts.block_size as u32;
-        self.storage_policy = StoragePolicy {
-            ufs_mtime: 0,
-            ..opts.storage_policy
-        };
+        self.storage_policy.overwrite(opts.storage_policy);
         self.mtime = mtime;
 
         // Reset file writing state for new write operation
@@ -336,11 +333,7 @@ impl InodeFile {
     }
 
     pub fn free(&mut self, mtime: i64) -> bool {
-        if self.storage_policy.ttl_action == TtlAction::None {
-            return false;
-        };
-
-        if self.ufs_exists() && self.cv_exists() {
+        if self.storage_policy.free() {
             self.mtime = mtime;
             self.blocks.clear();
             true
@@ -394,11 +387,11 @@ impl InodeFile {
             Ok(vec![])
         } else if opts.len < self.len {
             let del_blocks = self.truncate(opts);
-            self.invalid_cache();
+            self.storage_policy.detach_ufs();
             Ok(del_blocks)
         } else {
             self.extend(opts)?;
-            self.invalid_cache();
+            self.storage_policy.detach_ufs();
             Ok(vec![])
         }
     }
@@ -510,15 +503,19 @@ impl InodeFile {
     }
 
     pub fn ufs_exists(&self) -> bool {
-        self.storage_policy.ufs_mtime > 0
+        self.storage_policy.ufs_exists()
     }
 
     pub fn cv_exists(&self) -> bool {
-        self.len > 0 && !self.blocks.is_empty()
+        self.storage_policy.cv_exists()
     }
 
-    pub fn invalid_cache(&mut self) {
-        self.storage_policy.ufs_mtime = 0;
+    pub fn data_exists(&self) -> bool {
+        if self.len == 0 {
+            true
+        } else {
+            self.cv_exists() && !self.blocks.is_empty()
+        }
     }
 }
 

--- a/curvine-server/src/master/meta/inode/inode_view.rs
+++ b/curvine-server/src/master/meta/inode/inode_view.rs
@@ -380,7 +380,9 @@ impl InodeView {
         }
 
         if let Some(ufs_mtime) = opts.ufs_mtime {
-            self.storage_policy_mut().ufs_mtime = ufs_mtime;
+            if self.is_file() {
+                self.storage_policy_mut().save_ufs(ufs_mtime);
+            }
         }
     }
 

--- a/curvine-server/src/worker/task/load_task_runner.rs
+++ b/curvine-server/src/worker/task/load_task_runner.rs
@@ -18,7 +18,7 @@ use curvine_client::file::CurvineFileSystem;
 use curvine_client::rpc::JobMasterClient;
 use curvine_client::unified::{UfsFileSystem, UnifiedReader, UnifiedWriter};
 use curvine_common::fs::{FileSystem, Path, Reader, Writer};
-use curvine_common::state::{CreateFileOptsBuilder, FileStatus, JobTaskState, SetAttrOptsBuilder};
+use curvine_common::state::{CreateFileOptsBuilder, JobTaskState, SetAttrOptsBuilder};
 use curvine_common::FsResult;
 use log::{error, info, warn};
 use orpc::common::{LocalTime, TimeSpent};
@@ -121,19 +121,17 @@ impl LoadTaskRunner {
         writer.complete().await?;
         reader.complete().await?;
 
-        // cv -> ufs
-        let ufs_mtime = if reader.path().is_cv() && !writer.path().is_cv() {
-            let ufs_status = self.get_ufs()?.get_status(writer.path()).await?;
-
-            let attr_opts = SetAttrOptsBuilder::new()
-                .ufs_mtime(ufs_status.mtime)
-                .build();
-
-            self.fs.set_attr(reader.path(), attr_opts).await?;
-            ufs_status.mtime
+        let (cv_path, ufs_mtime) = if writer.path().is_cv() {
+            // ufs -> cv
+            (writer.path(), reader.status().mtime)
         } else {
-            reader.status().storage_policy.ufs_mtime
+            // cv -> ufs
+            let ufs_status = self.get_ufs()?.get_status(writer.path()).await?;
+            (reader.path(), ufs_status.mtime)
         };
+
+        let attr_opts = SetAttrOptsBuilder::new().ufs_mtime(ufs_mtime).build();
+        self.fs.set_attr(cv_path, attr_opts).await?;
 
         self.update_progress(writer.pos(), reader.len(), true).await;
 
@@ -159,7 +157,7 @@ impl LoadTaskRunner {
         let reader = self.open_unified(&source_path).await?;
 
         // Create writer (automatically selects filesystem based on scheme)
-        let writer = self.create_unified(&target_path, reader.status()).await?;
+        let writer = self.create_unified(&target_path).await?;
 
         Ok((reader, writer))
     }
@@ -175,22 +173,8 @@ impl LoadTaskRunner {
         }
     }
 
-    async fn create_unified(
-        &self,
-        path: &Path,
-        read_status: &FileStatus,
-    ) -> FsResult<UnifiedWriter> {
+    async fn create_unified(&self, path: &Path) -> FsResult<UnifiedWriter> {
         if path.is_cv() {
-            // Curvine path - get source mtime for UFS→Curvine import
-            let source_path = Path::from_str(&self.task.info.source_path)?;
-            let source_mtime = if !source_path.is_cv() {
-                // Import from UFS, get source mtime
-                read_status.mtime
-            } else {
-                // Curvine→Curvine (not supported yet), use 0
-                0
-            };
-
             let opts = CreateFileOptsBuilder::new()
                 .create_parent(true)
                 .replicas(self.task.info.job.replicas)
@@ -198,7 +182,6 @@ impl LoadTaskRunner {
                 .storage_type(self.task.info.job.storage_type)
                 .ttl_ms(self.task.info.job.ttl_ms)
                 .ttl_action(self.task.info.job.ttl_action)
-                .ufs_mtime(source_mtime)
                 .build();
 
             let overwrite = self.task.info.job.overwrite.unwrap_or(false);


### PR DESCRIPTION
## Summary

**Core change:** introduce explicit **StorageState** (Cv, Ufs, Both) in `StoragePolicy` so "where data lives" is no longer inferred from `ufs_mtime` alone. This underpins both **fs_mode** (unified FS read/write and cache validity) and **cache_mode** (TTL eviction and load jobs): validity checks, `free()`, and post-copy metadata all use state. Additionally, mount TTL/storage options are merged into create options so fs_mode writes get the correct policy.

## Why introduce StorageState

Previously, "whether data exists in UFS" was inferred only from `ufs_mtime > 0`. That was ambiguous and led to bugs:

- **Reopen / truncate / overwrite**: We set `ufs_mtime = 0` to mean "cache invalid", but there was no explicit notion of "CV-only" vs "synced with UFS". TTL `free()` and cache validity logic had to guess from a single field.
- **After load job**: Both UFS→CV and CV→UFS need to record that the CV file is now in sync with UFS (`ufs_mtime` set). Without a clear state, it was easy to miss updating the right side or to apply TTL incorrectly.
- **free() semantics**: We only want to free CV blocks (and drop to "UFS-only") when data actually exists in both places and TTL allows it. Inferring "both exist" from `ufs_mtime > 0` plus block presence was fragile.

**StorageState** makes the lifecycle explicit:

| State   | Meaning |
|--------|---------|
| **Cv**  | Data exists only in Curvine (e.g. just written, or after reopen/truncate; not yet synced to UFS). |
| **Ufs** | Data exists only in UFS (e.g. after TTL `free()` evicted CV cache). |
| **Both**| Data is present in both CV and UFS and considered in sync (`ufs_mtime` valid). |

Transitions:

- **detach_ufs()**: On write start, reopen, truncate → state = Cv, ufs_mtime = 0.
- **save_ufs(ufs_mtime)**: After a copy (load job or sync) completes → state = Both, ufs_mtime set.
- **free()**: If state is Both and ttl_action allows → state = Ufs, CV blocks freed.

So `ufs_exists()` / `cv_exists()` / `both_exists()` are derived from state instead of heuristics, and TTL assignment on fs_mode writes is fixed by merging mount options and updating state only at well-defined points (create, copy completion, free).

## Changes

### curvine-common

- **Proto**
  - Add `StorageStateProto` (Cv / Ufs / Both) and `state` field to `StoragePolicyProto` (default Cv).
- **StoragePolicy**
  - Introduce `StorageState` (Cv, Ufs, Both) and store it in `StoragePolicy`; see **Why introduce StorageState** above.
  - Add `with_cv(policy)` for new files (state=Cv, ufs_mtime=0).
  - Add `detach_ufs()` (state→Cv, ufs_mtime=0), `save_ufs(ufs_mtime)` (state→Both when mtime>0), `overwrite(new_policy)` (merge and detach_ufs).
  - Add `ufs_exists()` / `cv_exists()` / `both_exists()` based on state; `free()` uses state and ttl_action.
- **FileStatus**
  - `ufs_exists()` / `cv_exists()` delegate to `storage_policy`.
  - Add `cv_valid(ufs_status)` for cache validity: CV exists, not expired, UFS exists; if `ufs_status` is provided, also checks len and mtime match.
- **MountInfo**
  - Add `merge_create_opts(opts)`: merge mount’s ttl_ms, ttl_action, storage_type, replicas, block_size into `CreateFileOpts` so fs_mode writes get correct TTL/storage attributes.
- **FileBlocks**
  - Rename `cv_exists()` → `data_exists()`: for len==0 returns true; otherwise `cv_exists() && !block_locs.is_empty()`.

### curvine-client

- **CurvineFileSystem**
  - Remove `check_read_status` from `open()` (no read-side expired check before opening).
- **UnifiedFileSystem**
  - **Cache validity**: Use `cv_status.cv_valid(ufs_status)`; only run UFS verification when `read_verify_ufs`; otherwise use `cv_valid(None)`.
  - **Read path**: When valid, set `mtime = storage_policy.ufs_mtime` once; remove redundant `cv_exists` / `ufs_exists` branches.
  - **fs_mode create**: Call `mount.info.merge_create_opts(opts)` so TTL and storage options from the mount are applied on create; use `data_exists()` instead of `cv_exists()` for the writer branch.
  - **copy_from_ufs**: Apply `merge_create_opts` so target file gets mount TTL/storage.

### curvine-server

- **InodeFile**
  - New files use `StoragePolicy::with_cv(opts.storage_policy)`.
  - Replace `invalid_cache()` with `storage_policy.detach_ufs()`; replace direct `ufs_mtime = 0` with `storage_policy.overwrite()` where appropriate.
  - `reopen` / truncate / set_attr use `detach_ufs`; `free()` delegates to `storage_policy.free()`.
  - `ufs_exists()` / `cv_exists()` delegate to `storage_policy`; add `data_exists()` (same semantics as `FileBlocks`).
- **InodeView (set_attr)**
  - When setting `ufs_mtime`, call `storage_policy.save_ufs(ufs_mtime)` for files so state becomes Both.
  - Remove atime handling from set_attr.
- **FsDir (set_attr)**
  - Clearer error when set_attr is used on unresolved FileEntry; clone `child_opts` once; log warning when FileEntry inode is missing.
- **LoadTaskRunner**
  - After copy (both UFS→CV and CV→UFS), set `ufs_mtime` on the CV path via `set_attr` so storage state is updated correctly.
  - `create_unified(path)` no longer takes `read_status`; remove `ufs_mtime` from CreateFileOptsBuilder (state is updated after copy).

### Other

- **curvine-cli/stat**: Indentation fix.
- **rust-toolchain.toml**: Comment out explicit channel (optional / env-specific).

## Testing

- Verify fs_mode write: new file gets mount TTL and storage policy.
- Verify load job (UFS→CV and CV→UFS): after copy, CV inode has correct `ufs_mtime` and state (Both).
- Verify cache validity and read path use `cv_valid` and single mtime assignment.

## Issue

Fixes #719 (incorrect TTL attribute assignment on file writes in fs_mode).

---