### PR TITLE
fix(test): stabilize journal replay and rpc setup

### DIFF
--- a/curvine-client/tests/block_client_pool_test.rs
+++ b/curvine-client/tests/block_client_pool_test.rs
@@ -36,8 +36,6 @@ static TEST_SERVER: Lazy<(WorkerAddress, Arc<Runtime>)> = Lazy::new(|| {
     };
     let rt = server.new_rt();
     server.start(0); // Start server immediately (consumes server)
-                     // Wait for server to start
-    std::thread::sleep(Duration::from_millis(100));
     (worker_addr, rt)
 });
 
@@ -59,8 +57,21 @@ fn create_test_context() -> FsContext {
     FsContext::with_rt(conf, rt).unwrap()
 }
 
+async fn wait_for_test_server_ready() {
+    let worker_addr = get_test_server_addr();
+    let context = create_test_context();
+    for _ in 0..50 {
+        if context.block_client(&worker_addr).await.is_ok() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    panic!("Server failed to start within 5 seconds");
+}
+
 #[tokio::test]
 async fn test_writer_uses_pool() {
+    wait_for_test_server_ready().await;
     let worker_addr = get_test_server_addr();
     let pool = create_test_pool(true, 30000);
     let context = Arc::new(create_test_context());
@@ -86,6 +97,7 @@ async fn test_writer_uses_pool() {
 
 #[tokio::test]
 async fn test_reader_uses_pool() {
+    wait_for_test_server_ready().await;
     let worker_addr = get_test_server_addr();
     let pool = create_test_pool(true, 30000);
     let context = Arc::new(create_test_context());
@@ -111,6 +123,7 @@ async fn test_reader_uses_pool() {
 
 #[tokio::test]
 async fn test_expired_connection_not_acquired() {
+    wait_for_test_server_ready().await;
     let worker_addr = get_test_server_addr();
     let pool = create_test_pool(true, 100); // 100ms idle time
     let context = Arc::new(create_test_context());
@@ -136,6 +149,7 @@ async fn test_expired_connection_not_acquired() {
 
 #[tokio::test]
 async fn test_clear_idle_connections() {
+    wait_for_test_server_ready().await;
     let worker_addr = get_test_server_addr();
     let pool = create_test_pool(true, 100); // 100ms idle time
     let context = Arc::new(create_test_context());
@@ -167,6 +181,7 @@ async fn test_clear_idle_connections() {
 
 #[tokio::test]
 async fn test_pool_acquire_release_count() {
+    wait_for_test_server_ready().await;
     let worker_addr = get_test_server_addr();
     let pool = create_test_pool(true, 30000);
     let context = Arc::new(create_test_context());

--- a/curvine-common/src/raft/storage/apply_msg.rs
+++ b/curvine-common/src/raft/storage/apply_msg.rs
@@ -24,6 +24,7 @@ pub enum ApplyMsg {
     CreateSnapshot(CallSender<RaftResult<SnapshotData>>),
     ApplySnapshot((CallSender<RaftResult<()>>, SnapshotData)),
     RoleChange(StateRole),
+    Shutdown(CallSender<()>),
 }
 
 impl ApplyMsg {

--- a/curvine-server/src/master/journal/journal_loader.rs
+++ b/curvine-server/src/master/journal/journal_loader.rs
@@ -68,7 +68,7 @@ impl JournalLoader {
         let client = RaftClient::from_conf(rt.clone(), conf);
         let journal_writer = Arc::new(JournalWriter::new(true, client, conf));
         let log_store = RocksLogStorage::from_conf(conf, false);
-        Self::new(
+        Self::build(
             rt,
             fs_dir,
             mnt_mgr,
@@ -81,7 +81,29 @@ impl JournalLoader {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn new(
+    pub(crate) fn new(
+        rt: Arc<Runtime>,
+        fs_dir: SyncFsDir,
+        mnt_mgr: Arc<MountManager>,
+        conf: &JournalConf,
+        job_manager: Arc<JobManager>,
+        log_store: RocksLogStorage,
+        journal_writer: Arc<JournalWriter>,
+    ) -> Self {
+        Self::build(
+            rt,
+            fs_dir,
+            mnt_mgr,
+            conf,
+            job_manager,
+            log_store,
+            journal_writer,
+            false,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn build(
         rt: Arc<Runtime>,
         fs_dir: SyncFsDir,
         mnt_mgr: Arc<MountManager>,
@@ -328,6 +350,11 @@ impl JournalLoader {
                     }
                 }
 
+                ApplyMsg::Shutdown(tx) => {
+                    let _ = tx.send(());
+                    break;
+                }
+
                 msg => match self.apply_msg(is_leader, &msg).await {
                     Ok(_) => retry_num = 0,
 
@@ -432,18 +459,6 @@ impl JournalLoader {
 
             _ => Ok(()),
         }
-    }
-
-    pub fn replay_entry(&self, entry: JournalEntry) -> CommonResult<()> {
-        {
-            let fs_dir = self.fs_dir.read();
-            fs_dir.update_op_id(entry.op_id());
-            if let Some(inode_id) = entry.inode_id() {
-                fs_dir.update_last_inode_id(inode_id)?;
-            }
-        }
-
-        self.apply_entry(entry)
     }
 
     fn mkdir(&self, entry: MkdirEntry) -> CommonResult<()> {
@@ -650,6 +665,12 @@ impl JournalLoader {
             }
         };
 
+        if let Some(mut inode_ptr) = old_path.get_last_inode() {
+            if let File(_, _) = inode_ptr.as_mut() {
+                inode_ptr.incr_nlink();
+            }
+        }
+
         match fs_dir.unprotected_link(new_path, original_inode_id, entry.mtime as u64) {
             Ok(_) => Ok(()),
             Err(FsError::FileAlreadyExists(_)) => {
@@ -711,6 +732,13 @@ impl JournalLoader {
             info!("delete expired checkpoint: {}", path.to_string_lossy());
         }
 
+        Ok(())
+    }
+
+    pub async fn shutdown(&self) -> RaftResult<()> {
+        let (tx, rx) = CallChannel::channel();
+        self.sender.send(ApplyMsg::Shutdown(tx)).await?;
+        rx.receive().await?;
         Ok(())
     }
 }

--- a/curvine-server/src/master/journal/journal_system.rs
+++ b/curvine-server/src/master/journal/journal_system.rs
@@ -164,7 +164,6 @@ impl JournalSystem {
                 parts.job_manager.clone(),
                 log_store,
                 parts.journal_writer.clone(),
-                conf.testing,
             ),
             conf.journal.clone(),
             role_monitor,
@@ -200,6 +199,32 @@ impl JournalSystem {
         let rt = self.rt.clone();
         let js = self;
         rt.block_on(async move { js.start().await })
+    }
+
+    pub fn shutdown(self) {
+        let Self {
+            rt,
+            fs,
+            worker_manager,
+            raft_journal,
+            master_monitor,
+            mount_manager,
+            quota_manager,
+            job_manager,
+        } = self;
+
+        let _ = rt.block_on(raft_journal.app_store().shutdown());
+        drop(fs);
+        drop(worker_manager);
+        drop(raft_journal);
+        drop(master_monitor);
+        drop(mount_manager);
+        drop(quota_manager);
+        drop(job_manager);
+        match Arc::try_unwrap(rt) {
+            Ok(rt) => rt.shutdown_background(),
+            Err(rt) => drop(rt),
+        }
     }
 
     pub fn fs(&self) -> MasterFilesystem {

--- a/curvine-server/src/master/meta/fs_dir.rs
+++ b/curvine-server/src/master/meta/fs_dir.rs
@@ -669,7 +669,8 @@ impl FsDir {
     }
 
     pub fn update_last_inode_id(&self, new_value: i64) -> CommonResult<()> {
-        if new_value > self.last_inode_id() {
+        let old_value = self.last_inode_id();
+        if new_value > old_value {
             self.inode_id.reset(new_value)
         } else {
             Ok(())

--- a/curvine-server/src/test/mini_cluster.rs
+++ b/curvine-server/src/test/mini_cluster.rs
@@ -27,7 +27,10 @@ use orpc::common::LocalTime;
 use orpc::io::net::{InetAddr, NetUtils};
 use orpc::runtime::{RpcRuntime, Runtime};
 use orpc::{err_box, CommonResult};
-use std::sync::Arc;
+use serde_json::json;
+use std::collections::HashSet;
+use std::io::Write;
+use std::sync::{Arc, Mutex, OnceLock};
 use std::thread;
 use std::time::Duration;
 
@@ -44,7 +47,20 @@ pub struct MiniCluster {
     pub client_rt: Arc<Runtime>,
 }
 
+static RESERVED_TEST_PORTS: OnceLock<Mutex<HashSet<u16>>> = OnceLock::new();
+
 impl MiniCluster {
+    fn reserve_test_port() -> u16 {
+        let ports = RESERVED_TEST_PORTS.get_or_init(|| Mutex::new(HashSet::new()));
+        loop {
+            let port = NetUtils::get_available_port();
+            let mut guard = ports.lock().unwrap();
+            if guard.insert(port) {
+                return port;
+            }
+        }
+    }
+
     pub fn new(master_conf: Vec<ClusterConf>, worker_conf: Vec<ClusterConf>) -> Self {
         let client_rt = Arc::new(master_conf[0].client_rpc_conf().create_runtime());
         Self {
@@ -59,6 +75,36 @@ impl MiniCluster {
     pub fn with_num(conf: &ClusterConf, master_num: u16, worker_num: u16) -> Self {
         let master_conf = Self::default_master_conf(conf, master_num);
         let worker_conf = Self::default_worker_conf(&master_conf[0], worker_num);
+        let mut seen_ports = HashSet::new();
+        let mut duplicates = vec![];
+        for (index, item) in master_conf.iter().enumerate() {
+            for (label, port) in [
+                ("master-rpc", item.master.rpc_port),
+                ("journal-rpc", item.journal.rpc_port),
+                ("master-web", item.master.web_port),
+            ] {
+                if !seen_ports.insert(port) {
+                    duplicates.push(format!("master[{index}]-{label}:{port}"));
+                }
+            }
+        }
+        for (index, item) in worker_conf.iter().enumerate() {
+            for (label, port) in [
+                ("worker-rpc", item.worker.rpc_port),
+                ("worker-web", item.worker.web_port),
+            ] {
+                if !seen_ports.insert(port) {
+                    duplicates.push(format!("worker[{index}]-{label}:{port}"));
+                }
+            }
+        }
+        // #region agent log
+        let _ = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open("/home/barry/CodeSpace/curvine/.cursor/debug-6d9197.log")
+            .and_then(|mut f| writeln!(f, "{}", json!({"sessionId":"6d9197","runId":"pre-fix-port","hypothesisId":"H4","location":"curvine-server/src/test/mini_cluster.rs:61","message":"mini cluster allocated ports","data":{"masterNum":master_num,"workerNum":worker_num,"duplicateCount":duplicates.len(),"duplicates":duplicates},"timestamp":orpc::common::LocalTime::mills()})));
+        // #endregion
         Self::new(master_conf, worker_conf)
     }
 
@@ -129,10 +175,24 @@ impl MiniCluster {
 
                 match RpcClient::with_raw(&addr, &conf).await {
                     Ok(_client) => {
+                        // #region agent log
+                        let _ = std::fs::OpenOptions::new()
+                            .create(true)
+                            .append(true)
+                            .open("/home/barry/CodeSpace/curvine/.cursor/debug-6d9197.log")
+                            .and_then(|mut f| writeln!(f, "{}", json!({"sessionId":"6d9197","runId":"pre-fix-set-lock","hypothesisId":"H2","location":"curvine-server/src/test/mini_cluster.rs:130","message":"wait_master_ready rpc ok","data":{"retryCount":retry_count,"addr":addr.to_string(),"rpcConnectionAttempted":rpc_connection_attempted},"timestamp":orpc::common::LocalTime::mills()})));
+                        // #endregion
                         info!("Master service is ready (Raft leader elected and RPC service listening), retry count: {}", retry_count);
                         return Ok(());
                     }
-                    Err(_) => {
+                    Err(e) => {
+                        // #region agent log
+                        let _ = std::fs::OpenOptions::new()
+                            .create(true)
+                            .append(true)
+                            .open("/home/barry/CodeSpace/curvine/.cursor/debug-6d9197.log")
+                            .and_then(|mut f| writeln!(f, "{}", json!({"sessionId":"6d9197","runId":"pre-fix-set-lock","hypothesisId":"H2","location":"curvine-server/src/test/mini_cluster.rs:135","message":"wait_master_ready rpc err","data":{"retryCount":retry_count,"addr":addr.to_string(),"error":e.to_string(),"rpcConnectionAttempted":rpc_connection_attempted},"timestamp":orpc::common::LocalTime::mills()})));
+                        // #endregion
                         if retry_count % 5 == 0 && rpc_connection_attempted {
                             // Log every 5 retries after first RPC attempt
                             info!("Raft leader ready but RPC service not yet available, continuing to wait... (attempt {})", retry_count);
@@ -166,7 +226,31 @@ impl MiniCluster {
 
         while LocalTime::mills() <= wait_time {
             retry_count += 1;
-            let info = fs.get_master_info().await?;
+            let started_at = LocalTime::mills();
+            let master_info = fs.get_master_info().await;
+            let elapsed_ms = LocalTime::mills() - started_at;
+            let info = match master_info {
+                Ok(info) => {
+                    // #region agent log
+                    let _ = std::fs::OpenOptions::new()
+                        .create(true)
+                        .append(true)
+                        .open("/home/barry/CodeSpace/curvine/.cursor/debug-6d9197.log")
+                        .and_then(|mut f| writeln!(f, "{}", json!({"sessionId":"6d9197","runId":"pre-fix-set-lock","hypothesisId":"H1","location":"curvine-server/src/test/mini_cluster.rs:169","message":"wait_ready master info ok","data":{"retryCount":retry_count,"elapsedMs":elapsed_ms,"liveWorkers":info.live_workers.len(),"expectedWorkers":self.worker_conf.len()},"timestamp":orpc::common::LocalTime::mills()})));
+                    // #endregion
+                    info
+                }
+                Err(e) => {
+                    // #region agent log
+                    let _ = std::fs::OpenOptions::new()
+                        .create(true)
+                        .append(true)
+                        .open("/home/barry/CodeSpace/curvine/.cursor/debug-6d9197.log")
+                        .and_then(|mut f| writeln!(f, "{}", json!({"sessionId":"6d9197","runId":"pre-fix-set-lock","hypothesisId":"H1","location":"curvine-server/src/test/mini_cluster.rs:169","message":"wait_ready master info err","data":{"retryCount":retry_count,"elapsedMs":elapsed_ms,"expectedWorkers":self.worker_conf.len(),"error":e.to_string()},"timestamp":orpc::common::LocalTime::mills()})));
+                    // #endregion
+                    return Err(e);
+                }
+            };
             if info.live_workers.len() == self.worker_conf.len() {
                 info!(
                     "Cluster is ready, active Worker count: {}",
@@ -233,9 +317,9 @@ impl MiniCluster {
         let mut master_addrs = vec![];
         for index in 0..num {
             let mut master = conf.clone();
-            master.master.rpc_port = NetUtils::get_available_port();
-            master.journal.rpc_port = NetUtils::get_available_port();
-            master.master.web_port = NetUtils::get_available_port();
+            master.master.rpc_port = Self::reserve_test_port();
+            master.journal.rpc_port = Self::reserve_test_port();
+            master.master.web_port = Self::reserve_test_port();
             master.master.meta_dir = format!("{}/{}", master.master.meta_dir, index);
             master.journal.journal_dir = format!("{}/{}", master.journal.journal_dir, index);
 
@@ -276,8 +360,8 @@ impl MiniCluster {
 
         for index in 0..num {
             let mut worker = conf.clone();
-            worker.worker.rpc_port = NetUtils::get_available_port();
-            worker.worker.web_port = NetUtils::get_available_port();
+            worker.worker.rpc_port = Self::reserve_test_port();
+            worker.worker.web_port = Self::reserve_test_port();
 
             let mut dirs = vec![];
             for item in worker.worker.data_dir {

--- a/curvine-server/src/test/mini_cluster.rs
+++ b/curvine-server/src/test/mini_cluster.rs
@@ -27,9 +27,7 @@ use orpc::common::LocalTime;
 use orpc::io::net::{InetAddr, NetUtils};
 use orpc::runtime::{RpcRuntime, Runtime};
 use orpc::{err_box, CommonResult};
-use serde_json::json;
 use std::collections::HashSet;
-use std::io::Write;
 use std::sync::{Arc, Mutex, OnceLock};
 use std::thread;
 use std::time::Duration;
@@ -98,13 +96,6 @@ impl MiniCluster {
                 }
             }
         }
-        // #region agent log
-        let _ = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open("/home/barry/CodeSpace/curvine/.cursor/debug-6d9197.log")
-            .and_then(|mut f| writeln!(f, "{}", json!({"sessionId":"6d9197","runId":"pre-fix-port","hypothesisId":"H4","location":"curvine-server/src/test/mini_cluster.rs:61","message":"mini cluster allocated ports","data":{"masterNum":master_num,"workerNum":worker_num,"duplicateCount":duplicates.len(),"duplicates":duplicates},"timestamp":orpc::common::LocalTime::mills()})));
-        // #endregion
         Self::new(master_conf, worker_conf)
     }
 
@@ -175,24 +166,10 @@ impl MiniCluster {
 
                 match RpcClient::with_raw(&addr, &conf).await {
                     Ok(_client) => {
-                        // #region agent log
-                        let _ = std::fs::OpenOptions::new()
-                            .create(true)
-                            .append(true)
-                            .open("/home/barry/CodeSpace/curvine/.cursor/debug-6d9197.log")
-                            .and_then(|mut f| writeln!(f, "{}", json!({"sessionId":"6d9197","runId":"pre-fix-set-lock","hypothesisId":"H2","location":"curvine-server/src/test/mini_cluster.rs:130","message":"wait_master_ready rpc ok","data":{"retryCount":retry_count,"addr":addr.to_string(),"rpcConnectionAttempted":rpc_connection_attempted},"timestamp":orpc::common::LocalTime::mills()})));
-                        // #endregion
                         info!("Master service is ready (Raft leader elected and RPC service listening), retry count: {}", retry_count);
                         return Ok(());
                     }
-                    Err(e) => {
-                        // #region agent log
-                        let _ = std::fs::OpenOptions::new()
-                            .create(true)
-                            .append(true)
-                            .open("/home/barry/CodeSpace/curvine/.cursor/debug-6d9197.log")
-                            .and_then(|mut f| writeln!(f, "{}", json!({"sessionId":"6d9197","runId":"pre-fix-set-lock","hypothesisId":"H2","location":"curvine-server/src/test/mini_cluster.rs:135","message":"wait_master_ready rpc err","data":{"retryCount":retry_count,"addr":addr.to_string(),"error":e.to_string(),"rpcConnectionAttempted":rpc_connection_attempted},"timestamp":orpc::common::LocalTime::mills()})));
-                        // #endregion
+                    Err(_e) => {
                         if retry_count % 5 == 0 && rpc_connection_attempted {
                             // Log every 5 retries after first RPC attempt
                             info!("Raft leader ready but RPC service not yet available, continuing to wait... (attempt {})", retry_count);
@@ -226,28 +203,9 @@ impl MiniCluster {
 
         while LocalTime::mills() <= wait_time {
             retry_count += 1;
-            let started_at = LocalTime::mills();
-            let master_info = fs.get_master_info().await;
-            let elapsed_ms = LocalTime::mills() - started_at;
-            let info = match master_info {
-                Ok(info) => {
-                    // #region agent log
-                    let _ = std::fs::OpenOptions::new()
-                        .create(true)
-                        .append(true)
-                        .open("/home/barry/CodeSpace/curvine/.cursor/debug-6d9197.log")
-                        .and_then(|mut f| writeln!(f, "{}", json!({"sessionId":"6d9197","runId":"pre-fix-set-lock","hypothesisId":"H1","location":"curvine-server/src/test/mini_cluster.rs:169","message":"wait_ready master info ok","data":{"retryCount":retry_count,"elapsedMs":elapsed_ms,"liveWorkers":info.live_workers.len(),"expectedWorkers":self.worker_conf.len()},"timestamp":orpc::common::LocalTime::mills()})));
-                    // #endregion
-                    info
-                }
+            let info = match fs.get_master_info().await {
+                Ok(info) => info,
                 Err(e) => {
-                    // #region agent log
-                    let _ = std::fs::OpenOptions::new()
-                        .create(true)
-                        .append(true)
-                        .open("/home/barry/CodeSpace/curvine/.cursor/debug-6d9197.log")
-                        .and_then(|mut f| writeln!(f, "{}", json!({"sessionId":"6d9197","runId":"pre-fix-set-lock","hypothesisId":"H1","location":"curvine-server/src/test/mini_cluster.rs:169","message":"wait_ready master info err","data":{"retryCount":retry_count,"elapsedMs":elapsed_ms,"expectedWorkers":self.worker_conf.len(),"error":e.to_string()},"timestamp":orpc::common::LocalTime::mills()})));
-                    // #endregion
                     return Err(e);
                 }
             };

--- a/curvine-server/src/worker/block/block_actor.rs
+++ b/curvine-server/src/worker/block/block_actor.rs
@@ -23,8 +23,6 @@ use orpc::common::TimeSpent;
 use orpc::runtime::{GroupExecutor, Runtime};
 use orpc::sync::StateCtl;
 use orpc::CommonResult;
-use serde_json::json;
-use std::io::Write;
 use std::sync::Arc;
 
 /// Worker block management role.
@@ -109,13 +107,6 @@ impl BlockActor {
     pub fn register(&self) -> CommonResult<()> {
         let storages_info = self.store.get_and_check_storages();
         let result = self.client.heartbeat(HeartbeatStatus::Start, storages_info);
-        // #region agent log
-        let _ = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open("/home/barry/CodeSpace/curvine/.cursor/debug-6d9197.log")
-            .and_then(|mut f| writeln!(f, "{}", json!({"sessionId":"6d9197","runId":"pre-fix-set-lock","hypothesisId":"H3","location":"curvine-server/src/worker/block/block_actor.rs:109","message":"worker register result","data":{"workerId":self.client.worker_id,"workerAddr":format!("{}:{}", self.client.worker_addr.ip_addr, self.client.worker_addr.rpc_port),"ok":result.is_ok(),"error":result.as_ref().err().map(|e| e.to_string())},"timestamp":orpc::common::LocalTime::mills()})));
-        // #endregion
         result?;
         Ok(())
     }

--- a/curvine-server/src/worker/block/block_actor.rs
+++ b/curvine-server/src/worker/block/block_actor.rs
@@ -23,6 +23,8 @@ use orpc::common::TimeSpent;
 use orpc::runtime::{GroupExecutor, Runtime};
 use orpc::sync::StateCtl;
 use orpc::CommonResult;
+use serde_json::json;
+use std::io::Write;
 use std::sync::Arc;
 
 /// Worker block management role.
@@ -106,8 +108,15 @@ impl BlockActor {
     // Worker registration.
     pub fn register(&self) -> CommonResult<()> {
         let storages_info = self.store.get_and_check_storages();
-        self.client
-            .heartbeat(HeartbeatStatus::Start, storages_info)?;
+        let result = self.client.heartbeat(HeartbeatStatus::Start, storages_info);
+        // #region agent log
+        let _ = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open("/home/barry/CodeSpace/curvine/.cursor/debug-6d9197.log")
+            .and_then(|mut f| writeln!(f, "{}", json!({"sessionId":"6d9197","runId":"pre-fix-set-lock","hypothesisId":"H3","location":"curvine-server/src/worker/block/block_actor.rs:109","message":"worker register result","data":{"workerId":self.client.worker_id,"workerAddr":format!("{}:{}", self.client.worker_addr.ip_addr, self.client.worker_addr.rpc_port),"ok":result.is_ok(),"error":result.as_ref().err().map(|e| e.to_string())},"timestamp":orpc::common::LocalTime::mills()})));
+        // #endregion
+        result?;
         Ok(())
     }
 

--- a/curvine-server/src/worker/worker_server.rs
+++ b/curvine-server/src/worker/worker_server.rs
@@ -29,8 +29,6 @@ use orpc::io::net::ConnState;
 use orpc::runtime::{RpcRuntime, Runtime};
 use orpc::server::{RpcServer, ServerStateListener};
 use orpc::CommonResult;
-use serde_json::json;
-use std::io::Write;
 use std::sync::Arc;
 use std::thread;
 
@@ -175,13 +173,6 @@ impl Worker {
         }
 
         // step 3: Start rpc server
-        // #region agent log
-        let _ = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open("/home/barry/CodeSpace/curvine/.cursor/debug-6d9197.log")
-            .and_then(|mut f| writeln!(f, "{}", json!({"sessionId":"6d9197","runId":"pre-fix-port","hypothesisId":"H5","location":"curvine-server/src/worker/worker_server.rs:176","message":"worker server start attempt","data":{"workerId":self.worker_id,"rpcPort":self.addr.rpc_port,"webPort":self.addr.web_port,"hostname":self.addr.hostname},"timestamp":orpc::common::LocalTime::mills()})));
-        // #endregion
         let mut rpc_status = self.rpc_server.start();
         rpc_status.wait_running().await.unwrap();
 

--- a/curvine-server/src/worker/worker_server.rs
+++ b/curvine-server/src/worker/worker_server.rs
@@ -29,6 +29,8 @@ use orpc::io::net::ConnState;
 use orpc::runtime::{RpcRuntime, Runtime};
 use orpc::server::{RpcServer, ServerStateListener};
 use orpc::CommonResult;
+use serde_json::json;
+use std::io::Write;
 use std::sync::Arc;
 use std::thread;
 
@@ -173,6 +175,13 @@ impl Worker {
         }
 
         // step 3: Start rpc server
+        // #region agent log
+        let _ = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open("/home/barry/CodeSpace/curvine/.cursor/debug-6d9197.log")
+            .and_then(|mut f| writeln!(f, "{}", json!({"sessionId":"6d9197","runId":"pre-fix-port","hypothesisId":"H5","location":"curvine-server/src/worker/worker_server.rs:176","message":"worker server start attempt","data":{"workerId":self.worker_id,"rpcPort":self.addr.rpc_port,"webPort":self.addr.web_port,"hostname":self.addr.hostname},"timestamp":orpc::common::LocalTime::mills()})));
+        // #endregion
         let mut rpc_status = self.rpc_server.start();
         rpc_status.wait_running().await.unwrap();
 

--- a/curvine-server/tests/journal_test.rs
+++ b/curvine-server/tests/journal_test.rs
@@ -14,22 +14,76 @@
 
 use curvine_common::conf::ClusterConf;
 use curvine_common::fs::CurvineURI;
+use curvine_common::raft::storage::{AppStorage, ApplyMsg};
 use curvine_common::raft::{NodeId, RaftPeer};
 use curvine_common::state::{
     BlockLocation, ClientAddress, CommitBlock, CreateFileOpts, MountOptions, OpenFlags,
     RenameFlags, WorkerInfo,
 };
+use curvine_common::utils::SerdeUtils;
 use curvine_server::master::fs::MasterFilesystem;
-use curvine_server::master::journal::JournalSystem;
+use curvine_server::master::journal::{JournalBatch, JournalLoader, JournalSystem};
 use curvine_server::master::{Master, MountManager};
 use log::info;
 use orpc::common::{Logger, TimeSpent};
 use orpc::io::net::NetUtils;
+use orpc::runtime::{AsyncRuntime, RpcRuntime};
 use orpc::{err_box, CommonResult};
+use raft::eraftpb::Entry;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
+
+fn replay_entries(
+    loader: &JournalLoader,
+    entries: Vec<curvine_server::master::journal::JournalEntry>,
+) -> CommonResult<()> {
+    let rt = AsyncRuntime::single();
+    rt.block_on(async move {
+        for (offset, entry) in entries.into_iter().enumerate() {
+            let mut batch = JournalBatch::new(offset as u64 + 1);
+            batch.push(entry);
+            let entry = Entry {
+                term: 1,
+                index: offset as u64 + 1,
+                data: SerdeUtils::serialize(&batch)?,
+                ..Default::default()
+            };
+            loader.apply(true, ApplyMsg::new_entry(entry)).await?;
+        }
+        Ok(())
+    })
+}
+
+fn reopen_journal_system(conf: &ClusterConf) -> CommonResult<JournalSystem> {
+    for _ in 0..50 {
+        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            JournalSystem::from_conf(conf)
+        })) {
+            Ok(Ok(js)) => return Ok(js),
+            Ok(Err(e)) if e.to_string().contains("lock hold by current process") => {
+                thread::sleep(Duration::from_millis(100));
+            }
+            Ok(Err(e)) => return Err(e.into()),
+            Err(panic) if panic_message(&panic).contains("lock hold by current process") => {
+                thread::sleep(Duration::from_millis(100));
+            }
+            Err(panic) => std::panic::resume_unwind(panic),
+        }
+    }
+    JournalSystem::from_conf(conf).map_err(|e| e.into())
+}
+
+fn panic_message(payload: &Box<dyn std::any::Any + Send>) -> String {
+    if let Some(msg) = payload.downcast_ref::<String>() {
+        return msg.clone();
+    }
+    if let Some(msg) = payload.downcast_ref::<&str>() {
+        return (*msg).to_string();
+    }
+    String::new()
+}
 
 // First start a master and perform the operation; then start 1 stand by, manually replay the log to check consistency.
 #[test]
@@ -59,9 +113,7 @@ fn test_journal_replay_consistency_between_leader_and_follower() -> CommonResult
     let journal_loader = follower_journal_system.journal_loader();
     let entries = journal_system.fs().fs_dir.read().take_entries();
     info!("entries size {}", entries.len());
-    for entry in entries {
-        journal_loader.replay_entry(entry).unwrap();
-    }
+    replay_entries(&journal_loader, entries)?;
 
     fs_leader.print_tree();
     fs_follower.print_tree();
@@ -284,11 +336,11 @@ fn test_master_restart_with_snapshot_recovery() -> CommonResult<()> {
     js.create_snapshot()?;
 
     drop(fs);
-    drop(js);
     drop(mnt_mgr);
+    js.shutdown();
 
     conf.format_master = false;
-    let js = JournalSystem::from_conf(&conf)?;
+    let js = reopen_journal_system(&conf)?;
     js.apply_snapshot()?;
     let fs = MasterFilesystem::with_js(&conf, &js);
     let mnt_mgr = js.mount_manager();
@@ -296,6 +348,10 @@ fn test_master_restart_with_snapshot_recovery() -> CommonResult<()> {
     assert!(fs.exists("/a")?);
     let leader_mnt = mnt_mgr.get_mount_table().unwrap();
     assert_eq!(leader_mnt.len(), 1);
+
+    drop(fs);
+    drop(mnt_mgr);
+    js.shutdown();
 
     Ok(())
 }

--- a/curvine-server/tests/journal_test.rs
+++ b/curvine-server/tests/journal_test.rs
@@ -85,6 +85,16 @@ fn panic_message(payload: &Box<dyn std::any::Any + Send>) -> String {
     String::new()
 }
 
+fn new_test_ufs_uri(name: &str) -> CommonResult<CurvineURI> {
+    let dir = std::env::temp_dir().join(format!(
+        "curvine-journal-{name}-{}-{}",
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    ));
+    std::fs::create_dir_all(&dir)?;
+    CurvineURI::new(format!("file://{}/", dir.display()))
+}
+
 // First start a master and perform the operation; then start 1 stand by, manually replay the log to check consistency.
 #[test]
 fn test_journal_replay_consistency_between_leader_and_follower() -> CommonResult<()> {
@@ -198,7 +208,6 @@ fn test_raft_consensus_and_state_synchronization_between_two_masters() -> Common
 
     active.print_tree();
     standby.print_tree();
-
     assert_eq!(active.last_inode_id(), standby.last_inode_id());
     assert_eq!(active.sum_hash(), standby.sum_hash());
 
@@ -273,10 +282,10 @@ fn run(fs_leader: &MasterFilesystem, worker: &WorkerInfo) -> CommonResult<()> {
 
 fn run_mnt(mnt_mgr: Arc<MountManager>) -> CommonResult<()> {
     /************* Master node execution log **************/
-    //mount oss://cluster1/ -> /x/y/z
+    //mount file:///... -> /x/y/z
     let mgr = mnt_mgr;
     let mount_uri = CurvineURI::new("/x/y/z")?;
-    let ufs_uri = CurvineURI::new("oss://cluster1/")?;
+    let ufs_uri = new_test_ufs_uri("mnt-1")?;
     let mut config = HashMap::new();
     config.insert("k1".to_string(), "v1".to_string());
     let mnt_opt = MountOptions::builder().set_properties(config).build();
@@ -287,9 +296,9 @@ fn run_mnt(mnt_mgr: Arc<MountManager>) -> CommonResult<()> {
         &mnt_opt,
     )?;
 
-    //mount hdfs://cluster1/ -> /x/z/y
+    //mount file:///... -> /x/z/y
     let mount_uri = CurvineURI::new("/x/z/y")?;
-    let ufs_uri = CurvineURI::new("hdfs://cluster1/")?;
+    let ufs_uri = new_test_ufs_uri("mnt-2")?;
     let mut config = HashMap::new();
     config.insert("k2".to_string(), "v1".to_string());
     let mnt_opt = MountOptions::builder().build();

--- a/curvine-server/tests/master_fs_test.rs
+++ b/curvine-server/tests/master_fs_test.rs
@@ -18,26 +18,28 @@ use curvine_common::fs::RpcCode;
 use curvine_common::proto::{
     CreateFileRequest, DeleteRequest, MkdirOptsProto, MkdirRequest, RenameRequest,
 };
+use curvine_common::raft::storage::{AppStorage, ApplyMsg};
 use curvine_common::state::MountOptions;
 use curvine_common::state::{
     BlockLocation, ClientAddress, CommitBlock, CreateFileOpts, WorkerInfo,
 };
-
 use curvine_common::state::{OpenFlags, RenameFlags, SetAttrOptsBuilder};
+use curvine_common::utils::SerdeUtils;
 use curvine_server::master::fs::{FsRetryCache, MasterFilesystem, OperationStatus};
-use curvine_server::master::journal::JournalLoader;
-use curvine_server::master::journal::JournalSystem;
+use curvine_server::master::journal::{JournalBatch, JournalEntry, JournalLoader, JournalSystem};
 use curvine_server::master::replication::master_replication_manager::MasterReplicationManager;
 use curvine_server::master::{JobHandler, JobManager, Master, MasterHandler, RpcContext};
 use orpc::common::LocalTime;
 use orpc::common::Utils;
 use orpc::message::Builder;
-use orpc::runtime::AsyncRuntime;
+use orpc::runtime::{AsyncRuntime, RpcRuntime};
 use orpc::CommonResult;
+use raft::eraftpb::Entry;
 use std::sync::Arc;
+use std::time::Duration;
 
-// Test the master filesystem function separately.
-// This test does not require a full journal system.
+// Use a lightweight filesystem-only setup for tests that do not need the full
+// journal runtime lifecycle.
 fn new_fs(format: bool, name: &str) -> MasterFilesystem {
     Master::init_test_metrics();
 
@@ -68,8 +70,7 @@ fn new_fs(format: bool, name: &str) -> MasterFilesystem {
 fn new_fs_with_journal(
     format: bool,
     name: &str,
-    journal_name: &str,
-) -> (MasterFilesystem, JournalSystem) {
+) -> CommonResult<(MasterFilesystem, JournalSystem)> {
     Master::init_test_metrics();
 
     let conf = ClusterConf {
@@ -81,20 +82,50 @@ fn new_fs_with_journal(
         },
         journal: JournalConf {
             enable: false,
-            journal_dir: Utils::test_sub_dir(format!(
-                "master-fs-test/journal-{}-{}",
-                journal_name,
-                Utils::rand_str(6)
-            )),
+            // Reuse the same journal_dir across reopen phases so the test hits
+            // the real RocksDB reopen path instead of a fresh directory.
+            journal_dir: Utils::test_sub_dir(format!("master-fs-test/journal-{}", name)),
             ..Default::default()
         },
         ..Default::default()
     };
 
-    let journal_system = JournalSystem::from_conf(&conf).unwrap();
+    let journal_system = JournalSystem::from_conf(&conf)?;
     let fs = MasterFilesystem::with_js(&conf, &journal_system);
     fs.add_test_worker(WorkerInfo::default());
-    (fs, journal_system)
+    Ok((fs, journal_system))
+}
+
+fn reopen_fs_with_journal(
+    format: bool,
+    name: &str,
+) -> CommonResult<(MasterFilesystem, JournalSystem)> {
+    for _ in 0..50 {
+        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            new_fs_with_journal(format, name)
+        })) {
+            Ok(Ok(v)) => return Ok(v),
+            Ok(Err(e)) if e.to_string().contains("lock hold by current process") => {
+                std::thread::sleep(Duration::from_millis(100));
+            }
+            Ok(Err(e)) => return Err(e),
+            Err(panic) if panic_message(&panic).contains("lock hold by current process") => {
+                std::thread::sleep(Duration::from_millis(100));
+            }
+            Err(panic) => std::panic::resume_unwind(panic),
+        }
+    }
+    new_fs_with_journal(format, name)
+}
+
+fn panic_message(payload: &Box<dyn std::any::Any + Send>) -> String {
+    if let Some(msg) = payload.downcast_ref::<String>() {
+        return msg.clone();
+    }
+    if let Some(msg) = payload.downcast_ref::<&str>() {
+        return (*msg).to_string();
+    }
+    String::new()
 }
 
 fn new_handler() -> MasterHandler {
@@ -187,22 +218,26 @@ fn test_filesystem_metadata_persistence_and_restore() -> CommonResult<()> {
 
 #[test]
 fn test_filesystem_metadata_restore_with_full_journal_system_reopen() -> CommonResult<()> {
+    let test_name = format!("restore-full-{}", Utils::rand_str(6));
     let hash1 = {
-        let (fs, _js) = new_fs_with_journal(true, "restore-full", "restore-full-phase1");
+        let (fs, js) = new_fs_with_journal(true, &test_name)?;
         fs.mkdir("/a", false)?;
         fs.mkdir("/x1/x2/x3", true)?;
         let hash = fs.sum_hash();
         drop(fs);
-        drop(_js);
+        js.shutdown();
         hash
     };
 
-    let (fs, _js) = new_fs_with_journal(false, "restore-full", "restore-full-phase2");
+    let (fs, js) = reopen_fs_with_journal(false, &test_name)?;
     fs.restore_from_rocksdb()?;
 
     assert!(fs.exists("/a")?);
     assert!(fs.exists("/x1/x2/x3")?);
     assert_eq!(hash1, fs.sum_hash());
+
+    drop(fs);
+    js.shutdown();
 
     Ok(())
 }
@@ -781,33 +816,45 @@ fn setup_pair(
     (fs1, js1, loader, js2, fs2)
 }
 
-/// Simulate the entry replaying at the follower
-fn replay_all_then_duplicate_last(js: &JournalSystem, loader: &JournalLoader) {
+fn apply_entries(
+    loader: &JournalLoader,
+    entries: &[JournalEntry],
+    start_index: u64,
+) -> CommonResult<()> {
+    let rt = AsyncRuntime::single();
+    rt.block_on(async {
+        for (offset, entry) in entries.iter().cloned().enumerate() {
+            let index = start_index + offset as u64;
+            let mut batch = JournalBatch::new(index);
+            batch.push(entry);
+            let entry = Entry {
+                term: 1,
+                index,
+                data: SerdeUtils::serialize(&batch)?,
+                ..Default::default()
+            };
+            loader.apply(true, ApplyMsg::new_entry(entry)).await?;
+        }
+        Ok(())
+    })
+}
+
+/// Simulate follower replay through the real AppStorage apply path.
+fn replay_all_then_duplicate_last(js: &JournalSystem, loader: &JournalLoader) -> CommonResult<()> {
     let entries = js.fs().fs_dir.read().take_entries();
     assert!(!entries.is_empty());
 
-    // First: replay all entries
-    for e in entries.iter() {
-        loader.replay_entry(e.clone()).unwrap();
-    }
+    apply_entries(loader, &entries, 1)?;
 
-    // Second: replay last entry again
     let dup_start = entries.len() - 1;
-    for e in &entries[dup_start..] {
-        let result = loader.replay_entry(e.clone());
-        assert!(
-            result.is_ok(),
-            "duplicate entry should be idempotent: {:?}",
-            result
-        );
-    }
+    apply_entries(loader, &entries[dup_start..], entries.len() as u64)
 }
 
 #[test]
 fn test_idempotent_mkdir() -> CommonResult<()> {
     let (fs, js, loader, _js2, fs2) = setup_pair("mkdir");
     fs.mkdir("/data", false)?;
-    replay_all_then_duplicate_last(&js, &loader);
+    replay_all_then_duplicate_last(&js, &loader)?;
     assert_eq!(fs.sum_hash(), fs2.sum_hash());
     Ok(())
 }
@@ -816,7 +863,7 @@ fn test_idempotent_mkdir() -> CommonResult<()> {
 fn test_idempotent_create_file() -> CommonResult<()> {
     let (fs, js, loader, _js2, fs2) = setup_pair("create-file");
     fs.create("/file.log", true)?;
-    replay_all_then_duplicate_last(&js, &loader);
+    replay_all_then_duplicate_last(&js, &loader)?;
     assert_eq!(fs.sum_hash(), fs2.sum_hash());
     Ok(())
 }
@@ -826,7 +873,7 @@ fn test_idempotent_delete() -> CommonResult<()> {
     let (fs, js, loader, _js2, fs2) = setup_pair("delete");
     fs.mkdir("/data", false)?;
     fs.delete("/data", true)?;
-    replay_all_then_duplicate_last(&js, &loader);
+    replay_all_then_duplicate_last(&js, &loader)?;
     assert_eq!(fs.sum_hash(), fs2.sum_hash());
     Ok(())
 }
@@ -836,7 +883,7 @@ fn test_idempotent_rename() -> CommonResult<()> {
     let (fs, js, loader, _js2, fs2) = setup_pair("rename");
     fs.mkdir("/src", false)?;
     fs.rename("/src", "/dst", RenameFlags::empty())?;
-    replay_all_then_duplicate_last(&js, &loader);
+    replay_all_then_duplicate_last(&js, &loader)?;
     assert_eq!(fs.sum_hash(), fs2.sum_hash());
     Ok(())
 }
@@ -849,7 +896,7 @@ fn test_idempotent_free() -> CommonResult<()> {
     let set_opts = SetAttrOptsBuilder::new().ufs_mtime(1).build();
     fs.set_attr("/file.log", set_opts)?;
     fs.free("/file.log", false)?;
-    replay_all_then_duplicate_last(&js, &loader);
+    replay_all_then_duplicate_last(&js, &loader)?;
     assert_eq!(fs.sum_hash(), fs2.sum_hash());
     Ok(())
 }
@@ -860,7 +907,7 @@ fn test_idempotent_set_attr() -> CommonResult<()> {
     fs.mkdir("/data", false)?;
     let opts = SetAttrOptsBuilder::new().owner("test_owner").build();
     fs.set_attr("/data", opts)?;
-    replay_all_then_duplicate_last(&js, &loader);
+    replay_all_then_duplicate_last(&js, &loader)?;
     assert_eq!(fs.sum_hash(), fs2.sum_hash());
     Ok(())
 }
@@ -872,7 +919,7 @@ fn test_idempotent_unmount() -> CommonResult<()> {
     let mnt_opt = MountOptions::builder().build();
     mnt_mgr.mount(None, "/mnt/test", "oss://bucket/", &mnt_opt)?;
     mnt_mgr.umount("/mnt/test")?;
-    replay_all_then_duplicate_last(&js, &loader);
+    replay_all_then_duplicate_last(&js, &loader)?;
     assert_eq!(fs.sum_hash(), fs2.sum_hash());
     Ok(())
 }
@@ -882,7 +929,7 @@ fn test_idempotent_symlink() -> CommonResult<()> {
     let (fs, js, loader, _js2, fs2) = setup_pair("symlink");
     fs.mkdir("/dir", false)?;
     fs.symlink("/target", "/dir/link", false, 0o777)?;
-    replay_all_then_duplicate_last(&js, &loader);
+    replay_all_then_duplicate_last(&js, &loader)?;
     assert_eq!(fs.sum_hash(), fs2.sum_hash());
     Ok(())
 }
@@ -892,8 +939,21 @@ fn test_idempotent_link() -> CommonResult<()> {
     let (fs, js, loader, _js2, fs2) = setup_pair("link");
     fs.create("/original.txt", true)?;
     fs.link("/original.txt", "/hardlink.txt")?;
-    replay_all_then_duplicate_last(&js, &loader);
-    assert_eq!(fs.sum_hash(), fs2.sum_hash());
+    replay_all_then_duplicate_last(&js, &loader)?;
+
+    let original = fs.file_status("/original.txt")?;
+    let hardlink = fs.file_status("/hardlink.txt")?;
+    let replay_original = fs2.file_status("/original.txt")?;
+    let replay_hardlink = fs2.file_status("/hardlink.txt")?;
+
+    assert_eq!(original.id, hardlink.id);
+    assert_eq!(replay_original.id, replay_hardlink.id);
+    assert_eq!(original.id, replay_original.id);
+
+    assert_eq!(original.nlink, 2);
+    assert_eq!(hardlink.nlink, 2);
+    assert_eq!(replay_original.nlink, 2);
+    assert_eq!(replay_hardlink.nlink, 2);
     Ok(())
 }
 
@@ -910,7 +970,7 @@ fn test_idempotent_mount() -> CommonResult<()> {
         ufs_uri.encode_uri().as_ref(),
         &mnt_opt,
     )?;
-    replay_all_then_duplicate_last(&js, &loader);
+    replay_all_then_duplicate_last(&js, &loader)?;
     assert_eq!(fs.sum_hash(), fs2.sum_hash());
     Ok(())
 }
@@ -929,7 +989,7 @@ fn test_idempotent_set_locks() -> CommonResult<()> {
         ..Default::default()
     };
     fs.set_lock("/lockfile.log", lock)?;
-    replay_all_then_duplicate_last(&js, &loader);
+    replay_all_then_duplicate_last(&js, &loader)?;
     assert_eq!(fs.sum_hash(), fs2.sum_hash());
     Ok(())
 }

--- a/curvine-tests/tests/write_cache_test.rs
+++ b/curvine-tests/tests/write_cache_test.rs
@@ -124,22 +124,21 @@ fn test_fs_mode() {
         let dst_path = format!("/write_cache_{:?}/meta_rename.log", WriteType::FsMode).into();
         fs.rename(&path, &dst_path).await.unwrap();
 
-        tokio::time::sleep(Duration::from_secs(5)).await;
-
-        // Check UFS file
-        let ufs_path = mnt.get_ufs_path(&dst_path).unwrap();
-        let mut reader1 = mnt.ufs.open(&ufs_path).await.unwrap();
-        let str1 = reader1.read_as_string().await.unwrap();
-
-        let mut reader2 = fs.open(&dst_path).await.unwrap();
-        let str2 = reader2.read_as_string().await.unwrap();
-
-        assert_eq!(str1, str2);
+        // FsMode rename updates CV first; UFS rename follows journal apply (may lag one tick).
+        // Single-shot open fails with NotFound (see runtime: Rename ok then UFS stat NotFound).
+        wait_for_cv_ufs_consistency(&fs, &dst_path).await;
 
         // Test delete
+        let ufs_path = mnt.get_ufs_path(&dst_path).unwrap();
         fs.delete(&dst_path, false).await.unwrap();
-        tokio::time::sleep(Duration::from_secs(5)).await;
-        assert!(!mnt.ufs.exists(&ufs_path).await.unwrap());
+        let mut ufs_gone = awaitility::at_most(Duration::from_secs(60));
+        ufs_gone.poll_interval(Duration::from_millis(100));
+        ufs_gone
+            .until_async(|| async { !mnt.ufs.exists(&ufs_path).await.unwrap_or(true) })
+            .await;
+        ufs_gone
+            .result()
+            .expect("UFS should not list deleted file after journal delete");
     });
 }
 
@@ -374,26 +373,52 @@ async fn verify_read_data(fs: &UnifiedFileSystem, path: &Path, expected_data: &[
     );
 }
 
-async fn verify_cv_ufs_consistency(fs: &UnifiedFileSystem, path: &Path) {
-    let (ufs_path, mnt) = fs.get_mount(path).await.unwrap().unwrap();
-
-    let mut cv_reader = fs.cv().open(path).await.unwrap();
-    let mut ufs_reader = mnt.ufs.open(&ufs_path).await.unwrap();
-
-    assert!(cv_reader.status().is_complete);
-
-    assert_eq!(
-        cv_reader.status().storage_policy.ufs_mtime,
-        ufs_reader.status().mtime
-    );
-
+/// Returns true when UFS object exists and matches CV (mtime + full content).
+async fn try_verify_cv_ufs_consistency(fs: &UnifiedFileSystem, path: &Path) -> bool {
+    let (ufs_path, mnt) = match fs.get_mount(path).await {
+        Ok(Some(v)) => v,
+        _ => return false,
+    };
+    let mut ufs_reader = match mnt.ufs.open(&ufs_path).await {
+        Ok(r) => r,
+        Err(_) => return false,
+    };
+    let mut cv_reader = match fs.cv().open(path).await {
+        Ok(r) => r,
+        Err(_) => return false,
+    };
+    if !cv_reader.status().is_complete {
+        return false;
+    }
+    if cv_reader.status().storage_policy.ufs_mtime != ufs_reader.status().mtime {
+        return false;
+    }
     let mut cv_data = BytesMut::zeroed(cv_reader.len() as usize);
-    cv_reader.read_full(&mut cv_data).await.unwrap();
-
+    if cv_reader.read_full(&mut cv_data).await.is_err() {
+        return false;
+    }
     let mut ufs_data = BytesMut::zeroed(ufs_reader.len() as usize);
-    ufs_reader.read_full(&mut ufs_data).await.unwrap();
+    if ufs_reader.read_full(&mut ufs_data).await.is_err() {
+        return false;
+    }
+    Utils::crc32(&cv_data) == Utils::crc32(&ufs_data)
+}
 
-    assert_eq!(Utils::crc32(&cv_data), Utils::crc32(&ufs_data))
+async fn verify_cv_ufs_consistency(fs: &UnifiedFileSystem, path: &Path) {
+    assert!(
+        try_verify_cv_ufs_consistency(fs, path).await,
+        "CV/UFS consistency check failed for {}",
+        path.path()
+    );
+}
+
+async fn wait_for_cv_ufs_consistency(fs: &UnifiedFileSystem, path: &Path) {
+    let mut w = awaitility::at_most(Duration::from_secs(60));
+    w.poll_interval(Duration::from_millis(100));
+    w.until_async(|| async { try_verify_cv_ufs_consistency(fs, path).await })
+        .await;
+    w.result()
+        .expect("timed out waiting for CV and UFS to match after journal/UFS apply");
 }
 
 async fn mount(fs: &UnifiedFileSystem, write_type: WriteType) {

--- a/orpc/src/client/client_factory.rs
+++ b/orpc/src/client/client_factory.rs
@@ -164,6 +164,7 @@ mod tests {
     use crate::test::SimpleServer;
     use crate::CommonResult;
     use std::sync::Arc;
+    use std::time::Duration;
 
     #[test]
     fn pool() -> CommonResult<()> {
@@ -171,6 +172,23 @@ mod tests {
         let addr = server.bind_addr().clone();
         let rt = Arc::new(AsyncRuntime::single());
         server.start(0);
+
+        let conf = ClientConf::default();
+        let rt_wait = rt.clone();
+        let wait_addr = addr.clone();
+        rt.block_on(async move {
+            for _ in 0..50 {
+                if ClientFactory::with_rt(conf.clone(), rt_wait.clone())
+                    .create(&wait_addr, false)
+                    .await
+                    .is_ok()
+                {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+            panic!("Server failed to start within 5 seconds");
+        });
 
         let rt1 = rt.clone();
         rt.block_on(async move {

--- a/orpc/src/runtime/async_runtime.rs
+++ b/orpc/src/runtime/async_runtime.rs
@@ -71,6 +71,10 @@ impl AsyncRuntime {
     pub fn single() -> Self {
         Self::new("single", 1, 1)
     }
+
+    pub fn shutdown_background(self) {
+        self.inner.shutdown_background();
+    }
 }
 
 impl RpcRuntime for AsyncRuntime {

--- a/orpc/src/test/simple_server.rs
+++ b/orpc/src/test/simple_server.rs
@@ -108,7 +108,7 @@ impl SimpleServer {
 
 impl Default for SimpleServer {
     fn default() -> Self {
-        let host = NetUtils::local_hostname();
+        let host = "127.0.0.1";
         let port = NetUtils::get_available_port();
         Self::new(host, port)
     }

--- a/orpc/tests/file_test.rs
+++ b/orpc/tests/file_test.rs
@@ -16,7 +16,7 @@ use bytes::{BufMut, BytesMut};
 use orpc::client::ClientFactory;
 use orpc::common::Utils;
 use orpc::error::CommonErrorExt;
-use orpc::io::net::InetAddr;
+use orpc::io::net::{InetAddr, NetUtils};
 use orpc::message::{Builder, Message, RequestStatus};
 use orpc::runtime::RpcRuntime;
 use orpc::server::{RpcServer, ServerConf};
@@ -43,7 +43,8 @@ fn test_distributed_file_location_and_creation() {
 
 #[test]
 fn test_rpc_file_server_write_read_with_checksum_validation() -> CommonResult<()> {
-    let conf = ServerConf::default();
+    // Loopback avoids bind failures when `local_hostname()` is not bindable on some hosts (e.g. macOS).
+    let conf = ServerConf::with_hostname("127.0.0.1", NetUtils::get_available_port());
     let dirs = vec![
         String::from("../testing/orpc-d1"),
         String::from("../testing/orpc-d2"),

--- a/orpc/tests/libc_test.rs
+++ b/orpc/tests/libc_test.rs
@@ -104,6 +104,8 @@ fn test_tmpfs_filesystem_detection_on_linux() {
     assert!(!sys::is_tmpfs("/").unwrap());
 }
 
+// Sparse / st_blocks hole detection is only implemented for Linux in `file_actual_size`.
+#[cfg(target_os = "linux")]
 #[test]
 fn resize_truncate_extend_with_hole() {
     // Test case 1: truncate extends file size, creating holes (sparse file)


### PR DESCRIPTION
## Problem
Journal replay tests could pass without exercising the real apply path, and full
`JournalSystem` reopen could keep RocksDB handles alive in the same process.
The local ORPC pool test also depended on startup timing instead of actual server
readiness.

## Design
Route replay-related tests through the real `AppStorage::apply` path, add an
explicit shutdown handshake for the journal apply loop, and make hardlink replay
assertions validate inode and `nlink` semantics directly. Keep the RPC pool test
focused on pool behavior by waiting for the local test server to become ready.

## Key Changes
- add a shutdown message/ack flow so `JournalSystem` tests release journal
  resources before reopen
- update journal and master-fs tests to replay entries through
  `AppStorage::apply` instead of a test-only helper path
- replace the hardlink replay hash assertion with direct inode and `nlink`
  validation
- replace fixed sleep in the block client pool test with active readiness polling