### PR TITLE
feat: sync UFS mtime/len on create for mount resync

### DIFF
--- a/curvine-cli/src/cmds/mount.rs
+++ b/curvine-cli/src/cmds/mount.rs
@@ -17,9 +17,7 @@ use clap::Parser;
 use curvine_client::unified::{UfsFileSystem, UnifiedFileSystem};
 use curvine_common::error::{ErrorKind, FsError};
 use curvine_common::fs::{FileSystem, Path};
-use curvine_common::state::{
-    MountOptions, Provider, SetAttrOptsBuilder, StorageType, TtlAction, WriteType,
-};
+use curvine_common::state::{MountOptions, Provider, StorageType, TtlAction, WriteType};
 use curvine_common::utils::ProtoUtils;
 use orpc::common::{ByteUnit, DurationUnit};
 use orpc::{err_box, CommonResult};
@@ -405,6 +403,7 @@ impl MountCommand {
 
                 stats.scanned += 1;
                 let ufs_mtime = ufs_entry.mtime;
+                let ufs_len = ufs_entry.len;
                 let cv_path = mount.get_cv_path(&ufs_path)?;
                 let cv_key = cv_path.full_path().to_string();
 
@@ -461,32 +460,10 @@ impl MountCommand {
                     continue;
                 }
 
-                let mut create_opts = mount.get_create_opts(&fs.conf().client);
-                create_opts.storage_policy.ufs_mtime = ufs_mtime;
-
-                if let Err(e) = client.create_with_opts(&cv_path, create_opts, true).await {
+                let create_opts = mount.get_sync_opts(&fs.conf().client, ufs_mtime, ufs_len);
+                if let Err(e) = client.create_with_opts(&cv_path, create_opts, false).await {
                     stats.failed += 1;
                     eprintln!("[resync] failed to create {}: {}", cv_path, e);
-                    progress.tick(&stats, queue.len());
-                    continue;
-                }
-
-                // Complete as an empty metadata placeholder.
-                if let Err(e) = client.complete_file(&cv_path, 0, Vec::new(), false).await {
-                    stats.failed += 1;
-                    eprintln!("[resync] failed to complete {}: {}", cv_path, e);
-                    progress.tick(&stats, queue.len());
-                    continue;
-                }
-
-                let attr_opts = SetAttrOptsBuilder::new()
-                    .mtime(ufs_mtime)
-                    .ufs_mtime(ufs_mtime)
-                    .build();
-
-                if let Err(e) = client.set_attr(&cv_path, attr_opts).await {
-                    stats.failed += 1;
-                    eprintln!("[resync] failed to set attr {}: {}", cv_path, e);
                     progress.tick(&stats, queue.len());
                     continue;
                 }

--- a/curvine-common/proto/master.proto
+++ b/curvine-common/proto/master.proto
@@ -41,6 +41,8 @@ message CreateFileOptsProto {
     required uint32 mode = 9;
     required string owner = 10;
     required string group = 11;
+    required bool sync_ufs_meta = 12 [default = false];
+    required int64 ufs_len = 13 [default = 0];
 }
 
 // Create a file.

--- a/curvine-common/src/state/mount.rs
+++ b/curvine-common/src/state/mount.rs
@@ -114,19 +114,20 @@ impl MountInfo {
     }
 
     pub fn get_create_opts(&self, conf: &ClientConf) -> CreateFileOpts {
-        CreateFileOptsBuilder::new()
-            .create_parent(true)
-            .replicas(self.replicas.unwrap_or(conf.replicas))
-            .block_size(self.block_size.unwrap_or(conf.block_size))
-            .storage_type(self.storage_type.unwrap_or(conf.storage_type))
-            .ttl_ms(self.ttl_ms)
-            .ttl_action(self.ttl_action)
-            .build()
+        let opts = CreateFileOptsBuilder::with_conf(conf).build();
+        self.merge_create_opts(opts)
+    }
+
+    pub fn get_sync_opts(&self, conf: &ClientConf, ufs_mtime: i64, ufs_len: i64) -> CreateFileOpts {
+        let opts = CreateFileOptsBuilder::with_conf(conf)
+            .ufs_mtime_len(ufs_mtime, ufs_len)
+            .build();
+        self.merge_create_opts(opts)
     }
 
     pub fn merge_create_opts(&self, opts: CreateFileOpts) -> CreateFileOpts {
         CreateFileOpts {
-            create_parent: opts.create_parent,
+            create_parent: true,
             replicas: self.replicas.unwrap_or(opts.replicas as i32) as u16,
             block_size: self.block_size.unwrap_or(opts.block_size),
             file_type: opts.file_type,
@@ -137,12 +138,15 @@ impl MountInfo {
                 storage_type: self
                     .storage_type
                     .unwrap_or(opts.storage_policy.storage_type),
-                ..opts.storage_policy
+                ufs_mtime: opts.storage_policy.ufs_mtime,
+                ..Default::default()
             },
             mode: opts.mode,
             client_name: opts.client_name,
             owner: opts.owner,
             group: opts.group,
+            sync_ufs_meta: opts.sync_ufs_meta,
+            ufs_len: opts.ufs_len,
         }
     }
 

--- a/curvine-common/src/state/opts.rs
+++ b/curvine-common/src/state/opts.rs
@@ -31,6 +31,8 @@ pub struct CreateFileOpts {
     pub client_name: String,
     pub owner: String,
     pub group: String,
+    pub sync_ufs_meta: bool,
+    pub ufs_len: i64,
 }
 
 impl CreateFileOpts {
@@ -46,6 +48,8 @@ impl CreateFileOpts {
             mode: ClientConf::DEFAULT_FILE_SYSTEM_MODE,
             owner: "".to_string(),
             group: "".to_string(),
+            sync_ufs_meta: false,
+            ufs_len: 0,
         }
     }
 
@@ -73,6 +77,8 @@ pub struct CreateFileOptsBuilder {
     client_name: Option<String>,
     pub owner: String,
     pub group: String,
+    sync_ufs_meta: bool,
+    ufs_len: i64,
 }
 
 impl Default for CreateFileOptsBuilder {
@@ -94,6 +100,8 @@ impl CreateFileOptsBuilder {
             client_name: None,
             owner: "".to_string(),
             group: "".to_string(),
+            sync_ufs_meta: false,
+            ufs_len: 0,
         }
     }
 
@@ -114,6 +122,8 @@ impl CreateFileOptsBuilder {
             client_name: None,
             owner: "".to_string(),
             group: "".to_string(),
+            sync_ufs_meta: false,
+            ufs_len: 0,
         }
     }
 
@@ -157,8 +167,10 @@ impl CreateFileOptsBuilder {
         self
     }
 
-    pub fn ufs_mtime(mut self, mtime: i64) -> Self {
+    pub fn ufs_mtime_len(mut self, mtime: i64, len: i64) -> Self {
+        self.sync_ufs_meta = true;
         self.storage_policy.ufs_mtime = mtime;
+        self.ufs_len = len;
         self
     }
 
@@ -201,6 +213,8 @@ impl CreateFileOptsBuilder {
             client_name: self.client_name.unwrap_or_default(),
             owner: self.owner,
             group: self.group,
+            sync_ufs_meta: self.sync_ufs_meta,
+            ufs_len: self.ufs_len,
         }
     }
 }

--- a/curvine-common/src/state/storage_policy.rs
+++ b/curvine-common/src/state/storage_policy.rs
@@ -55,6 +55,14 @@ impl StoragePolicy {
         }
     }
 
+    pub fn with_ufs(new_policy: StoragePolicy) -> Self {
+        Self {
+            ufs_mtime: new_policy.ufs_mtime,
+            state: StorageState::Ufs,
+            ..new_policy
+        }
+    }
+
     pub fn overwrite(&mut self, new_policy: StoragePolicy) {
         self.storage_type = new_policy.storage_type;
         self.ttl_ms = new_policy.ttl_ms;

--- a/curvine-common/src/utils/proto_utils.rs
+++ b/curvine-common/src/utils/proto_utils.rs
@@ -482,6 +482,8 @@ impl ProtoUtils {
             mode: opts.mode,
             owner: opts.owner,
             group: opts.group,
+            sync_ufs_meta: opts.sync_ufs_meta,
+            ufs_len: opts.ufs_len,
         }
     }
 
@@ -497,6 +499,8 @@ impl ProtoUtils {
             client_name: opts.client_name,
             owner: opts.owner,
             group: opts.group,
+            sync_ufs_meta: opts.sync_ufs_meta,
+            ufs_len: opts.ufs_len,
         }
     }
 

--- a/curvine-server/src/master/journal/ufs_loader.rs
+++ b/curvine-server/src/master/journal/ufs_loader.rs
@@ -116,7 +116,7 @@ impl UfsLoader {
     }
 
     pub async fn complete_file(&self, e: &CompleteFileEntry) -> CommonResult<()> {
-        if !e.file.is_complete() {
+        if !e.file.is_complete() || e.file.ufs_only() {
             return Ok(());
         }
 

--- a/curvine-server/src/master/meta/inode/inode_file.rs
+++ b/curvine-server/src/master/meta/inode/inode_file.rs
@@ -77,16 +77,22 @@ impl InodeFile {
     }
 
     pub fn with_opts(id: i64, time: i64, opts: CreateFileOpts) -> InodeFile {
+        let (len, storage_policy) = if opts.sync_ufs_meta {
+            (opts.ufs_len, StoragePolicy::with_ufs(opts.storage_policy))
+        } else {
+            (0, StoragePolicy::with_cv(opts.storage_policy))
+        };
+
         let mut file = Self {
             id,
             file_type: opts.file_type,
             mtime: time,
             atime: time,
-            len: 0,
+            len,
             block_size: opts.block_size as u32,
             replicas: opts.replicas as u8,
 
-            storage_policy: StoragePolicy::with_cv(opts.storage_policy),
+            storage_policy,
             features: FileFeature {
                 x_attr: Default::default(),
                 file_write: None,
@@ -104,7 +110,9 @@ impl InodeFile {
             parent_id: EMPTY_PARENT_ID,
         };
 
-        file.features.set_writing(opts.client_name);
+        if !opts.sync_ufs_meta {
+            file.features.set_writing(opts.client_name);
+        }
         if !opts.x_attr.is_empty() {
             file.features.set_attrs(opts.x_attr);
         }
@@ -504,6 +512,10 @@ impl InodeFile {
 
     pub fn ufs_exists(&self) -> bool {
         self.storage_policy.ufs_exists()
+    }
+
+    pub fn ufs_only(&self) -> bool {
+        self.storage_policy.ufs_only()
     }
 
     pub fn cv_exists(&self) -> bool {

--- a/curvine-tests/tests/fs_test.rs
+++ b/curvine-tests/tests/fs_test.rs
@@ -18,12 +18,13 @@ use curvine_client::ClientMetrics;
 use curvine_common::conf::ClusterConf;
 use curvine_common::fs::{Path, Reader, Writer};
 use curvine_common::state::{
-    CreateFileOptsBuilder, MkdirOptsBuilder, SetAttrOptsBuilder, TtlAction,
+    CreateFileOptsBuilder, MkdirOptsBuilder, SetAttrOptsBuilder, StorageState, TtlAction,
 };
 use curvine_common::state::{FileLock, LockFlags, LockType};
 use curvine_common::FsResult;
 use curvine_tests::Testing;
 use log::info;
+use orpc::common::LocalTime;
 use orpc::runtime::{AsyncRuntime, RpcRuntime};
 use orpc::CommonResult;
 use std::sync::Arc;
@@ -1016,4 +1017,26 @@ fn get_lock() {
         // Cleanup
         info!("=== get_lock test completed ===");
     })
+}
+
+#[test]
+fn sync_ufs_file() {
+    let testing = Testing::default();
+    let fs = testing.get_fs(None, None).unwrap();
+    fs.clone_runtime().block_on(async move {
+        let (ufs_mtime, ufs_len) = (LocalTime::mills() as i64, 1024);
+        let opts = CreateFileOptsBuilder::with_conf(&fs.conf().client)
+            .ufs_mtime_len(ufs_mtime, ufs_len)
+            .build();
+
+        let path = "/sync_ufs_file.log".into();
+        let mut file = fs.create_with_opts(&path, opts, false).await.unwrap();
+        file.complete().await.unwrap();
+
+        let stats = fs.get_status(&path).await.unwrap();
+        info!("stats: {:?}", stats);
+        assert_eq!(stats.len, ufs_len);
+        assert_eq!(stats.storage_policy.ufs_mtime, ufs_mtime);
+        assert_eq!(stats.storage_policy.state, StorageState::Ufs);
+    });
 }


### PR DESCRIPTION
## Summary

Introduces a **single-path create** for Curvine files that should mirror UFS metadata (mtime + length) without an extra `complete(0)` + `set_attr` round trip. Used by **CLI mount resync** when recreating missing CV entries from UFS listings. The server creates **UFS-only** placeholder inodes (`StorageState::Ufs`) with the correct logical length and `ufs_mtime` when `sync_ufs_meta` is set.

## Motivation

Previously, resync did: `create_with_opts` → `complete_file(0)` → `set_attr(mtime, ufs_mtime)`. That was fragile and easy to get out of sync with storage policy state. Creating with explicit UFS sync flags lets the master apply **one** consistent inode shape.

## Changes

### curvine-common

- **`CreateFileOpts` / `CreateFileOptsProto`**: Add `sync_ufs_meta: bool` and `ufs_len: i64` (proto fields 12–13). Wire through `ProtoUtils` conversions.
- **`CreateFileOptsBuilder`**: Add `ufs_mtime_len(mtime, len)` — sets `sync_ufs_meta = true`, `storage_policy.ufs_mtime`, and `ufs_len`. (Replaces the old `ufs_mtime`-only builder usage for sync flows.)
- **`MountInfo`**:
  - `get_create_opts`: build from `CreateFileOptsBuilder::with_conf(conf)` then `merge_create_opts`.
  - **`get_sync_opts(conf, ufs_mtime, ufs_len)`**: for resync — builds opts with `ufs_mtime_len` and merges mount TTL/storage/replicas/block_size.
  - **`merge_create_opts`**: Preserve `ufs_mtime` / `sync_ufs_meta` / `ufs_len` from merged opts; adjust `storage_policy` merge so mount-level fields still apply.
- **`StoragePolicy::with_ufs`**: New helper — copies policy with `state = Ufs` and the given `ufs_mtime` (for UFS-backed placeholder files).

### curvine-server

- **`InodeFile::with_opts`**: If `opts.sync_ufs_meta`, set `len = opts.ufs_len`, `storage_policy = StoragePolicy::with_ufs(...)`, and **do not** call `set_writing` (no open write session for a pure UFS sync stub).
- **`InodeFile::ufs_only()`**: Delegates to `storage_policy.ufs_only()`.
- **`UfsLoader::complete_file`**: Early-return when file is incomplete **or** `ufs_only()` — UFS-only placeholders skip the normal CV complete path.

### curvine-cli

- **Mount resync**: Read `ufs_len` from UFS entries; use `mount.get_sync_opts(...)` for `create_with_opts`; remove post-create `complete_file(0)` and `set_attr` for that path.

### curvine-tests

- **`sync_ufs_file`**: Integration test — `create_with_opts` + `ufs_mtime_len`, `complete()`, then assert `len`, `ufs_mtime`, and `StorageState::Ufs` on status.

## Testing

- `cargo test -p curvine-tests sync_ufs_file` (or full `fs_test` as appropriate).
- Manual: run mount resync against a tree with missing CV files and verify metadata without duplicate RPCs.
