### PR TITLE
refactor(ttl): simplify bucket-based TTL pipeline and expiration sema…

### DIFF
--- a/curvine-common/src/state/file_status.rs
+++ b/curvine-common/src/state/file_status.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::state::{FileType, StoragePolicy};
+use crate::state::{FileType, StoragePolicy, TtlAction};
 use orpc::common::LocalTime;
 use orpc::ternary;
 use serde::{Deserialize, Serialize};
@@ -73,8 +73,12 @@ impl FileStatus {
     }
 
     pub fn is_expired(&self) -> bool {
-        self.storage_policy.ttl_ms != 0
-            && LocalTime::mills() as i64 > self.atime + self.storage_policy.ttl_ms
+        let sp = &self.storage_policy;
+        if sp.ttl_action != TtlAction::None && sp.ttl_ms > 0 {
+            LocalTime::mills() as i64 > self.mtime.saturating_add(sp.ttl_ms)
+        } else {
+            false
+        }
     }
 
     // Check if this file has hard links (nlink > 1 and is a regular file)

--- a/curvine-server/src/master/fs/master_actor.rs
+++ b/curvine-server/src/master/fs/master_actor.rs
@@ -12,15 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::common::UfsFactory;
 use crate::master::fs::heartbeat_checker::HeartbeatChecker;
 use crate::master::fs::master_filesystem::MasterFilesystem;
-use crate::master::job::JobManager;
-use crate::master::meta::inode::ttl::ttl_manager::InodeTtlManager;
-use crate::master::meta::inode::ttl::ttl_scheduler::TtlHeartbeatChecker;
-use crate::master::meta::inode::ttl_executor::InodeTtlExecutor;
-use crate::master::meta::inode::ttl_scheduler::TtlHeartbeatConfig;
-use crate::master::mount::MountManager;
+use crate::master::meta::inode::ttl::TtlHeartbeatChecker;
+use crate::master::meta::inode::ttl::TtlHeartbeatConfig;
+use crate::master::meta::inode::ttl::{InodeTtlExecutor, InodeTtlManager};
 use crate::master::quota::QuotaManager;
 use crate::master::replication::master_replication_manager::MasterReplicationManager;
 use crate::master::MasterMonitor;
@@ -67,12 +63,7 @@ impl MasterActor {
         .unwrap();
     }
 
-    pub fn start_ttl_scheduler(
-        &mut self,
-        mount_manager: Arc<MountManager>,
-        factory: Arc<UfsFactory>,
-        job_manager: Arc<JobManager>,
-    ) -> CommonResult<()> {
+    pub fn start_ttl_scheduler(&mut self) -> CommonResult<()> {
         info!("Starting inode ttl scheduler.");
 
         let ttl_bucket_list = {
@@ -81,20 +72,13 @@ impl MasterActor {
             fs_dir.get_ttl_bucket_list()
         };
 
-        let ttl_manager = InodeTtlManager::new(
-            self.fs.clone(),
-            ttl_bucket_list,
-            mount_manager.clone(),
-            factory.clone(),
-            job_manager.clone(),
-        )?;
+        let ttl_manager = InodeTtlManager::new(self.fs.clone(), ttl_bucket_list)?;
 
         let ttl_manager_arc = Arc::new(ttl_manager);
 
         self.start_ttl_heartbeat_checker(ttl_manager_arc)?;
 
-        let ttl_executor =
-            InodeTtlExecutor::with_managers(self.fs.clone(), mount_manager, factory, job_manager);
+        let ttl_executor = InodeTtlExecutor::with_managers(self.fs.clone());
         self.quota_manager.set_ttl_executor(ttl_executor);
         info!("QuotaManager TTL executor initialized.");
 
@@ -117,7 +101,10 @@ impl MasterActor {
             self.fs.conf.ttl_checker_interval_ms(),
         );
         scheduler.start(heartbeat_checker)?;
-        info!("Inode ttl checker started");
+        info!(
+            "Inode ttl checker started, interval: {} ms",
+            self.fs.conf.ttl_checker_interval_ms()
+        );
         Ok(())
     }
 

--- a/curvine-server/src/master/journal/journal_system.rs
+++ b/curvine-server/src/master/journal/journal_system.rs
@@ -14,7 +14,7 @@
 
 use crate::master::fs::{MasterFilesystem, WorkerManager};
 use crate::master::journal::{JournalLoader, JournalWriter};
-use crate::master::meta::inode::ttl::ttl_bucket::TtlBucketList;
+use crate::master::meta::inode::ttl::TtlBucketList;
 use crate::master::meta::FsDir;
 use crate::master::quota::eviction::evictor::{Evictor, LFUEvictor, LRUEvictor};
 use crate::master::quota::eviction::types::EvictionPolicy;
@@ -91,7 +91,9 @@ impl JournalSystem {
         let client = RaftClient::from_conf(rt.clone(), &conf.journal);
         let journal_writer = Arc::new(JournalWriter::new(conf.testing, client, &conf.journal));
 
-        let ttl_bucket_list = Arc::new(TtlBucketList::new(conf.master.ttl_bucket_interval_ms()));
+        let ttl_bucket_list = Arc::new(TtlBucketList::new(
+            conf.master.ttl_bucket_interval_ms() as i64
+        ));
         let eviction_conf = EvictionConf::from_conf(conf);
         let evictor: Arc<dyn Evictor> = match eviction_conf.policy {
             EvictionPolicy::Lru => Arc::new(LRUEvictor::new(eviction_conf.clone())),
@@ -120,6 +122,7 @@ impl JournalSystem {
             rt.clone(),
             conf.testing,
         );
+
         let job_manager = Arc::new(JobManager::from_cluster_conf(
             fs.clone(),
             mount_manager.clone(),

--- a/curvine-server/src/master/master_metrics.rs
+++ b/curvine-server/src/master/master_metrics.rs
@@ -15,6 +15,7 @@
 #![allow(unused)]
 
 use crate::master::fs::MasterFilesystem;
+use crate::master::meta::inode::ttl::TtlBucket;
 use crate::master::Master;
 use curvine_common::state::MetricValue;
 use log::{debug, info, warn};
@@ -62,6 +63,9 @@ pub struct MasterMetrics {
     pub(crate) eviction_trigger_count: Counter,
     pub(crate) eviction_files_deleted: Counter,
     pub(crate) eviction_bytes_freed: Counter,
+
+    pub(crate) ttl_bucket_len: Gauge,
+    pub(crate) ttl_total_inodes: Gauge,
 }
 
 impl MasterMetrics {
@@ -154,6 +158,8 @@ impl MasterMetrics {
                 "eviction_bytes_freed",
                 "Total bytes freed by eviction",
             )?,
+            ttl_bucket_len: m::new_gauge("ttl_bucket_len", "Number of TTL buckets")?,
+            ttl_total_inodes: m::new_gauge("ttl_total_inodes", "Total number of inodes")?,
         };
 
         Ok(wm)
@@ -180,6 +186,10 @@ impl MasterMetrics {
                     .set(size as i64);
             }
         }
+        let ttl_list = fs_dir.get_ttl_bucket_list();
+        drop(fs_dir);
+        self.ttl_bucket_len.set(ttl_list.buckets_len() as i64);
+        self.ttl_total_inodes.set(ttl_list.total_inodes() as i64);
 
         self.worker_num
             .with_label_values(&["live"])

--- a/curvine-server/src/master/master_server.rs
+++ b/curvine-server/src/master/master_server.rs
@@ -212,11 +212,7 @@ impl Master {
         self.job_manager.start();
 
         // step6: Start TTL scheduler (requires mount_manager and job_manager)
-        if let Err(e) = self.actor.start_ttl_scheduler(
-            self.mount_manager.clone(),
-            self.job_manager.factory().clone(),
-            self.job_manager.clone(),
-        ) {
+        if let Err(e) = self.actor.start_ttl_scheduler() {
             error!("Failed to start inode ttl scheduler: {}", e);
         }
 

--- a/curvine-server/src/master/meta/fs_dir.rs
+++ b/curvine-server/src/master/meta/fs_dir.rs
@@ -14,7 +14,7 @@
 
 use crate::master::fs::DeleteResult;
 use crate::master::journal::{JournalEntry, JournalWriter};
-use crate::master::meta::inode::ttl::ttl_bucket::TtlBucketList;
+use crate::master::meta::inode::ttl::TtlBucketList;
 use crate::master::meta::inode::InodeView::{Dir, File, FileEntry};
 use crate::master::meta::inode::*;
 use crate::master::meta::store::{InodeStore, RocksInodeStore};

--- a/curvine-server/src/master/meta/inode/inode_view.rs
+++ b/curvine-server/src/master/meta/inode/inode_view.rs
@@ -15,15 +15,14 @@
 #![allow(clippy::large_enum_variant)]
 
 use crate::master::meta::feature::AclFeature;
-use crate::master::meta::inode::ttl_types::TtlConfig;
 use crate::master::meta::inode::InodeView::{Dir, File, FileEntry};
 use crate::master::meta::inode::{
     Inode, InodeDir, InodeFile, InodePtr, PATH_SEPARATOR, ROOT_INODE_ID,
 };
 use core::panic;
-use curvine_common::state::{FileStatus, FileType, SetAttrOpts, StoragePolicy};
+use curvine_common::state::{FileStatus, FileType, SetAttrOpts, StoragePolicy, TtlAction};
 use curvine_common::utils::SerdeUtils;
-use orpc::common::Utils;
+use orpc::common::{LocalTime, Utils};
 use orpc::{err_box, CommonResult};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, LinkedList};
@@ -65,13 +64,7 @@ impl InodeView {
             FileEntry(_, id) => *id,
         }
     }
-    pub fn ttl_config(&self) -> Option<TtlConfig> {
-        match self {
-            File(_, f) => TtlConfig::from_storage_policy(&f.storage_policy),
-            Dir(_, d) => TtlConfig::from_storage_policy(&d.storage_policy),
-            FileEntry(_, _) => None,
-        }
-    }
+
     pub fn name(&self) -> &str {
         match self {
             File(name, _) => name,
@@ -299,6 +292,24 @@ impl InodeView {
         }
     }
 
+    pub fn expiration_ms(&self) -> Option<i64> {
+        let sp = self.storage_policy();
+        if sp.ttl_ms > 0 && sp.ttl_action != TtlAction::None {
+            Some(self.mtime().saturating_add(sp.ttl_ms))
+        } else {
+            None
+        }
+    }
+
+    pub fn is_expired(&self) -> bool {
+        let sp = self.storage_policy();
+        if sp.ttl_action != TtlAction::None && sp.ttl_ms > 0 {
+            LocalTime::mills() as i64 > self.mtime().saturating_add(sp.ttl_ms)
+        } else {
+            false
+        }
+    }
+
     pub fn x_attr(&self) -> &HashMap<String, Vec<u8>> {
         match self {
             File(_, f) => &f.features.x_attr,
@@ -368,7 +379,9 @@ impl InodeView {
         }
 
         if let Some(ttl_action) = opts.ttl_action {
-            self.storage_policy_mut().ttl_action = ttl_action;
+            if self.storage_policy_mut().ttl_action != TtlAction::Free {
+                self.storage_policy_mut().ttl_action = ttl_action;
+            }
         }
 
         for attr in opts.add_x_attr {

--- a/curvine-server/src/master/meta/inode/mod.rs
+++ b/curvine-server/src/master/meta/inode/mod.rs
@@ -30,7 +30,6 @@ mod inodes_children;
 pub use self::inodes_children::*;
 
 pub mod ttl;
-pub(crate) use self::ttl::*;
 
 pub const ROOT_INODE_ID: i64 = 1000;
 

--- a/curvine-server/src/master/meta/inode/ttl/mod.rs
+++ b/curvine-server/src/master/meta/inode/ttl/mod.rs
@@ -1,6 +1,31 @@
-pub(crate) mod ttl_bucket;
-pub(crate) mod ttl_checker;
-pub(crate) mod ttl_executor;
-pub(crate) mod ttl_manager;
-pub(crate) mod ttl_scheduler;
-pub(crate) mod ttl_types;
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod ttl_bucket;
+pub use self::ttl_bucket::*;
+
+mod ttl_checker;
+pub use self::ttl_checker::*;
+
+mod ttl_executor;
+pub use self::ttl_executor::*;
+
+mod ttl_manager;
+pub use self::ttl_manager::*;
+
+mod ttl_scheduler;
+pub use self::ttl_scheduler::*;
+
+mod ttl_types;
+pub use self::ttl_types::*;

--- a/curvine-server/src/master/meta/inode/ttl/ttl_bucket.rs
+++ b/curvine-server/src/master/meta/inode/ttl/ttl_bucket.rs
@@ -12,80 +12,50 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::master::meta::inode::ttl::ttl_types::TtlResult;
-use dashmap::DashMap;
+use crate::master::meta::inode::InodeView;
 use log::{debug, info, warn};
-use parking_lot::RwLock;
-use std::collections::{BTreeMap, HashMap};
+use orpc::common::FastHashSet;
+use parking_lot::Mutex;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
-// TTL Bucket Management Module
-//
-// This module provides time-based bucket management for TTL (Time-To-Live) operations.
-// It organizes inodes into time intervals for efficient batch processing of expired items.
-//
-// Key Features:
-// - Time-based bucket organization with configurable intervals
-// - Efficient O(log n) bucket lookup using BTreeMap for sorted storage
-// - Thread-safe operations with concurrent access support
-// - Automatic cleanup of empty expired buckets
-// - Fast inode-to-bucket mapping for quick removal operations
-// - Statistics collection for monitoring and debugging
-
-#[derive(Debug)]
 pub struct TtlBucket {
-    /// Start time of the interval (aligned to bucket boundaries) in milliseconds since epoch
-    pub interval_start_ms: u64,
-    /// Interval duration in milliseconds
-    pub interval_duration_ms: u64,
-    /// Map of inode ID to retry count (memory efficient)
-    pub inode_retries: RwLock<HashMap<u64, u32>>,
+    pub interval_start_ms: i64,
+    pub interval_duration_ms: i64,
+    pub inodes: Mutex<FastHashSet<i64>>,
 }
+
 impl TtlBucket {
-    pub fn new(interval_start_ms: u64, interval_duration_ms: u64) -> Self {
+    pub fn new(interval_start_ms: i64, interval_duration_ms: i64) -> Self {
         Self {
             interval_start_ms,
             interval_duration_ms,
-            inode_retries: RwLock::new(HashMap::new()),
+            inodes: Mutex::new(FastHashSet::new()),
         }
     }
 
-    pub fn get_interval_end_ms(&self) -> u64 {
+    pub fn get_interval_end_ms(&self) -> i64 {
         self.interval_start_ms + self.interval_duration_ms
     }
 
-    pub fn add_inode(&self, inode_id: u64, retry_count: u32) {
-        self.inode_retries.write().insert(inode_id, retry_count);
+    pub fn add(&self, inode_id: i64) {
+        self.inodes.lock().insert(inode_id);
     }
 
-    pub fn remove_inode(&self, inode_id: u64) -> Option<u32> {
-        self.inode_retries.write().remove(&inode_id)
+    pub fn remove(&self, inode_id: i64) -> bool {
+        self.inodes.lock().remove(&inode_id)
     }
 
-    pub fn is_expired_at(&self, current_time_ms: u64) -> bool {
+    pub fn is_expired_at(&self, current_time_ms: i64) -> bool {
         self.get_interval_end_ms() <= current_time_ms
     }
 
     pub fn len(&self) -> usize {
-        self.inode_retries.read().len()
+        self.inodes.lock().len()
     }
 
     pub fn is_empty(&self) -> bool {
         self.len() == 0
-    }
-
-    pub fn for_each_inode<F: FnMut(u64, u32)>(&self, mut f: F) {
-        // Take a lightweight snapshot of (inode_id, retry_count) pairs, then release the lock
-        let snapshot: Vec<(u64, u32)> = self
-            .inode_retries
-            .read()
-            .iter()
-            .map(|(inode_id, retry_count)| (*inode_id, *retry_count))
-            .collect();
-        // Process without holding the read lock to avoid lock upgrade issues
-        for (inode_id, retry_count) in snapshot {
-            f(inode_id, retry_count);
-        }
     }
 }
 impl PartialEq for TtlBucket {
@@ -107,166 +77,219 @@ impl Ord for TtlBucket {
     }
 }
 
-#[derive(Debug)]
 pub struct TtlBucketList {
     /// Sorted bucket mapping: interval_start_ms -> TtlBucket (sorted by time)
-    buckets: Arc<RwLock<BTreeMap<u64, Arc<TtlBucket>>>>,
-    /// Hash index for fast access (inode_id -> interval_start_ms)
-    inode_to_bucket_index: Arc<DashMap<u64, u64>>,
+    buckets: Arc<Mutex<BTreeMap<i64, Arc<TtlBucket>>>>,
     /// Interval duration for each bucket in milliseconds
-    interval_duration_ms: u64,
-    /// Total number of inodes across all buckets
-    total_inodes: Arc<std::sync::atomic::AtomicU64>,
+    interval_duration_ms: i64,
 }
+
 impl TtlBucketList {
-    pub fn new(interval_duration_ms: u64) -> Self {
+    pub fn new(interval_duration_ms: i64) -> Self {
+        if interval_duration_ms <= 0 {
+            panic!("interval_duration_ms must be positive");
+        }
+
         info!(
             "Creating TTL bucket list with sorted storage, interval duration: {}ms",
             interval_duration_ms
         );
         Self {
-            buckets: Arc::new(RwLock::new(BTreeMap::new())),
-            inode_to_bucket_index: Arc::new(DashMap::new()),
+            buckets: Arc::new(Mutex::new(BTreeMap::new())),
             interval_duration_ms,
-            total_inodes: Arc::new(std::sync::atomic::AtomicU64::new(0)),
         }
     }
 
     pub fn total_inodes(&self) -> u64 {
-        self.total_inodes.load(std::sync::atomic::Ordering::Relaxed)
+        self.buckets
+            .lock()
+            .values()
+            .map(|bucket| bucket.len() as u64)
+            .sum()
     }
 
     pub fn buckets_len(&self) -> usize {
-        self.buckets.read().len()
+        self.buckets.lock().len()
     }
 
-    fn get_bucket_interval_start(&self, timestamp_ms: u64) -> u64 {
+    fn get_bucket_interval_start(&self, timestamp_ms: i64) -> i64 {
         (timestamp_ms / self.interval_duration_ms) * self.interval_duration_ms
     }
 
-    fn get_or_create_bucket(&self, timestamp_ms: u64) -> TtlResult<Arc<TtlBucket>> {
-        let interval_start = self.get_bucket_interval_start(timestamp_ms);
-
-        if let Some(bucket) = self.buckets.read().get(&interval_start) {
-            return Ok(bucket.clone());
-        }
-
-        let mut buckets = self.buckets.write();
-        if let Some(bucket) = buckets.get(&interval_start) {
-            return Ok(bucket.clone());
-        }
-
-        debug!(
-            "Creating new TTL bucket for interval starting at {}ms",
-            interval_start
-        );
-        let new_bucket = Arc::new(TtlBucket::new(interval_start, self.interval_duration_ms));
-        buckets.insert(interval_start, new_bucket.clone());
-
-        Ok(new_bucket)
-    }
-
-    pub fn add_inode(&self, inode_id: u64, expiration_ms: u64) -> TtlResult<()> {
+    fn get_or_create_bucket(&self, expiration_ms: i64) -> Arc<TtlBucket> {
         let interval_start = self.get_bucket_interval_start(expiration_ms);
-        let bucket = self.get_or_create_bucket(expiration_ms)?;
-
-        bucket.add_inode(inode_id, 0);
-        self.inode_to_bucket_index.insert(inode_id, interval_start);
-        self.total_inodes
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-
-        debug!(
-            "Added inode {} to sorted TTL bucket list, expires at {}ms",
-            inode_id, expiration_ms
-        );
-        Ok(())
+        let mut binding = self.buckets.lock();
+        binding
+            .entry(interval_start)
+            .or_insert_with(|| {
+                debug!(
+                    "creating new TTL bucket for interval starting at {}ms",
+                    interval_start
+                );
+                Arc::new(TtlBucket::new(interval_start, self.interval_duration_ms))
+            })
+            .clone()
     }
 
-    pub fn remove_inode(&self, inode_id: u64) -> TtlResult<Option<u32>> {
-        let interval_start = match self.inode_to_bucket_index.get(&inode_id) {
-            Some(entry) => *entry.value(),
-            None => return Ok(None), // Inode not found
-        };
+    pub fn add(&self, inode: &InodeView) {
+        if inode.is_file_entry() {
+            warn!(
+                "ttl_bucket: skip add for unresolved FileEntry (inode_id={}, name='{}'); TTL index needs a resolved inode",
+                inode.id(),
+                inode.name()
+            );
+            return;
+        }
 
-        if let Some(bucket) = self.buckets.read().get(&interval_start) {
-            let result = bucket.remove_inode(inode_id);
-            if result.is_some() {
-                // Remove from index
-                self.inode_to_bucket_index.remove(&inode_id);
+        if let Some(expiration_ms) = inode.expiration_ms() {
+            let bucket = self.get_or_create_bucket(expiration_ms);
+            bucket.add(inode.id());
 
-                // Update total count
-                self.total_inodes
-                    .fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+            info!(
+                "added inode {} to sorted TTL bucket list, expires at {}ms",
+                inode.id(),
+                expiration_ms
+            );
+        }
+    }
 
-                debug!("Removed inode {} from sorted TTL bucket list", inode_id);
+    pub fn remove(&self, inode: &InodeView) -> bool {
+        if inode.is_file_entry() {
+            warn!(
+                "ttl_bucket: skip remove for unresolved FileEntry (inode_id={}, name='{}')",
+                inode.id(),
+                inode.name()
+            );
+            return false;
+        }
+
+        if let Some(expiration_ms) = inode.expiration_ms() {
+            let interval_start = self.get_bucket_interval_start(expiration_ms);
+            if let Some(bucket) = self.buckets.lock().get(&interval_start) {
+                let res = bucket.remove(inode.id());
+                debug!("removed inode {} from sorted TTL bucket list", inode.id());
+                res
+            } else {
+                false
             }
-            Ok(result)
         } else {
-            Ok(None)
+            false
         }
     }
 
-    /// Reschedule an inode into a future bucket at the provided timestamp (ms).
-    /// This keeps total_inodes unchanged.
-    pub fn reschedule_inode(
-        &self,
-        inode_id: u64,
-        retry_count: u32,
-        next_timestamp_ms: u64,
-    ) -> TtlResult<()> {
-        // Find current bucket via index (if any) and remove it
-        if let Some(cur) = self.inode_to_bucket_index.get(&inode_id) {
-            let cur_start = *cur.value();
-            if let Some(bucket) = self.buckets.read().get(&cur_start) {
-                let _ = bucket.remove_inode(inode_id);
-            }
-        }
-
-        // Insert into new bucket and update index; total_inodes unchanged
-        let new_bucket = self.get_or_create_bucket(next_timestamp_ms)?;
-        let new_start = self.get_bucket_interval_start(next_timestamp_ms);
-        new_bucket.add_inode(inode_id, retry_count);
-        self.inode_to_bucket_index.insert(inode_id, new_start);
-        Ok(())
-    }
-
-    pub fn get_expired_buckets_at(&self, current_time_ms: u64) -> Vec<Arc<TtlBucket>> {
-        // Any bucket with start <= current - interval_duration has end <= current ⇒ expired
+    // Any bucket with start <= current - interval_duration has end <= current ⇒ expired
+    pub fn get_expired_buckets_at(&self, current_time_ms: i64) -> Vec<Arc<TtlBucket>> {
         let max_expired_start = current_time_ms.saturating_sub(self.interval_duration_ms);
 
-        self.buckets
-            .read()
-            .range(..=max_expired_start)
-            .map(|(_, bucket)| bucket.clone())
-            .collect()
+        let mut map = self.buckets.lock();
+
+        let keys: Vec<i64> = map.range(..=max_expired_start).map(|(k, _)| *k).collect();
+
+        let mut buckets = Vec::with_capacity(keys.len());
+        for k in keys {
+            if let Some(bucket) = map.remove(&k) {
+                buckets.push(bucket);
+            }
+        }
+        buckets
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::master::meta::inode::{InodeFile, InodeView};
+    use curvine_common::state::TtlAction;
+
+    const INTERVAL_MS: i64 = 1000;
+
+    fn file_with_ttl(id: i64, mtime: i64, ttl_ms: i64) -> InodeView {
+        let mut f = InodeFile::new(id, mtime);
+        f.storage_policy.ttl_ms = ttl_ms;
+        f.storage_policy.ttl_action = TtlAction::Delete;
+        InodeView::File("t".to_string(), f)
     }
 
-    /// Remove an empty bucket from the bucket list
-    pub fn remove_empty_bucket(&self, bucket: &TtlBucket) -> TtlResult<bool> {
-        // Double-check that the bucket is actually empty before attempting removal
-        if !bucket.is_empty() {
-            warn!(
-                "Attempted to remove non-empty bucket with interval_start_ms={}, {} inodes remaining",
-                bucket.interval_start_ms,
-                bucket.len()
-            );
-            return Ok(false);
-        }
+    fn file_no_ttl(id: i64, mtime: i64) -> InodeView {
+        InodeView::File("t".to_string(), InodeFile::new(id, mtime))
+    }
 
-        // Remove the bucket directly using its interval_start_ms
-        let removed = self.buckets.write().remove(&bucket.interval_start_ms);
-        if removed.is_some() {
-            debug!(
-                "Removed empty TTL bucket with interval_start_ms={}",
-                bucket.interval_start_ms
-            );
-            Ok(true)
-        } else {
-            debug!(
-                "Bucket with interval_start_ms={} not found for removal",
-                bucket.interval_start_ms
-            );
-            Ok(false)
-        }
+    #[test]
+    fn add_skips_when_ttl_disabled() {
+        let list = TtlBucketList::new(INTERVAL_MS);
+        list.add(&file_no_ttl(1, 0));
+        assert_eq!(list.total_inodes(), 0);
+        assert_eq!(list.buckets_len(), 0);
+    }
+
+    #[test]
+    fn add_places_inode_in_quantized_bucket() {
+        let list = TtlBucketList::new(INTERVAL_MS);
+        // expiration = mtime + ttl_ms = 100 + 500 = 600 -> interval_start 0
+        list.add(&file_with_ttl(42, 100, 500));
+        assert_eq!(list.total_inodes(), 1);
+        assert_eq!(list.buckets_len(), 1);
+    }
+
+    #[test]
+    fn add_same_interval_merges_into_one_bucket() {
+        let list = TtlBucketList::new(INTERVAL_MS);
+        list.add(&file_with_ttl(1, 0, 400)); // exp 400 -> start 0
+        list.add(&file_with_ttl(2, 50, 350)); // exp 400 -> start 0
+        assert_eq!(list.total_inodes(), 2);
+        assert_eq!(list.buckets_len(), 1);
+    }
+
+    #[test]
+    fn add_different_intervals_use_multiple_buckets() {
+        let list = TtlBucketList::new(INTERVAL_MS);
+        list.add(&file_with_ttl(1, 0, 500)); // exp 500 -> start 0
+        list.add(&file_with_ttl(2, 500, 1000)); // exp 1500 -> start 1000
+        assert_eq!(list.total_inodes(), 2);
+        assert_eq!(list.buckets_len(), 2);
+    }
+
+    #[test]
+    fn remove_drops_inode_from_bucket() {
+        let list = TtlBucketList::new(INTERVAL_MS);
+        let f = file_with_ttl(7, 0, 100);
+        list.add(&f);
+        assert_eq!(list.total_inodes(), 1);
+        assert!(list.remove(&f));
+        assert_eq!(list.total_inodes(), 0);
+    }
+
+    #[test]
+    fn remove_unknown_returns_false() {
+        let list = TtlBucketList::new(INTERVAL_MS);
+        let f = file_with_ttl(9, 0, 100);
+        assert!(!list.remove(&f));
+    }
+
+    #[test]
+    fn get_expired_buckets_at_drains_and_matches_time_rule() {
+        let list = TtlBucketList::new(INTERVAL_MS);
+        list.add(&file_with_ttl(1, 0, 500)); // exp 500, bucket [0, INTERVAL_MS)
+
+        let now = 2000_i64;
+        let drained = list.get_expired_buckets_at(now);
+        assert_eq!(drained.len(), 1);
+        let b = &drained[0];
+        assert_eq!(b.interval_start_ms, 0);
+        assert!(b.is_expired_at(now));
+        assert_eq!(b.len(), 1);
+        assert_eq!(list.buckets_len(), 0);
+    }
+
+    #[test]
+    fn get_expired_buckets_at_empty_when_not_yet_expired() {
+        let list = TtlBucketList::new(INTERVAL_MS);
+        // exp = 0 + 10_000 = 10_000 -> interval_start 10_000
+        list.add(&file_with_ttl(1, 0, 10_000));
+
+        let drained = list.get_expired_buckets_at(5000);
+        assert!(drained.is_empty());
+        assert_eq!(list.buckets_len(), 1);
+        assert_eq!(list.total_inodes(), 1);
     }
 }

--- a/curvine-server/src/master/meta/inode/ttl/ttl_checker.rs
+++ b/curvine-server/src/master/meta/inode/ttl/ttl_checker.rs
@@ -14,15 +14,11 @@
 
 use crate::master::meta::inode::ttl::ttl_bucket::TtlBucket;
 use crate::master::meta::inode::ttl::ttl_bucket::TtlBucketList;
-use crate::master::meta::inode::ttl::ttl_executor::InodeTtlExecutor;
-use crate::master::meta::inode::ttl::ttl_types::{
-    TtlAction, TtlCleanupConfig, TtlCleanupResult, TtlResult,
-};
-use crate::master::meta::inode::InodeView;
-use curvine_common::state::StoragePolicy;
-use log::{debug, error, info, warn};
+use crate::master::meta::inode::ttl::InodeTtlExecutor;
+use curvine_common::FsResult;
+use log::{debug, info, warn};
+use orpc::common::LocalTime;
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 // TTL Checker Module
 //
@@ -39,209 +35,58 @@ use std::time::{SystemTime, UNIX_EPOCH};
 pub struct InodeTtlChecker {
     bucket_list: Arc<TtlBucketList>,
     action_executor: InodeTtlExecutor,
-    config: TtlCleanupConfig,
 }
 
 impl InodeTtlChecker {
     /// Create checker with external bucket list (for integration with InodeStore)
     pub fn new(
         action_executor: InodeTtlExecutor,
-        config: TtlCleanupConfig,
         bucket_list: Arc<TtlBucketList>,
-    ) -> TtlResult<Self> {
-        config.validate()?;
-        info!(
-            "Created inode ttl checker with external bucket list, config: {:?}",
-            config
-        );
+    ) -> FsResult<Self> {
         Ok(Self {
-            bucket_list,
             action_executor,
-            config,
+            bucket_list,
         })
     }
 
-    pub fn cleanup_once(&self) -> TtlResult<TtlCleanupResult> {
-        let start_time = SystemTime::now();
-        let mut result = TtlCleanupResult::new();
-        let current_time_ms = start_time
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as u64;
-
-        let expired_buckets = self.bucket_list.get_expired_buckets_at(current_time_ms);
+    pub fn cleanup_once(&self) -> FsResult<i64> {
+        let start_time = LocalTime::mills() as i64;
+        let expired_buckets = self.bucket_list.get_expired_buckets_at(start_time);
 
         if expired_buckets.is_empty() {
-            debug!("No expired buckets found");
-            return Ok(result);
+            debug!("no expired buckets found");
+            return Ok(0);
         }
 
-        info!("Found {} expired buckets to process", expired_buckets.len());
+        info!("found {} expired buckets to process", expired_buckets.len());
 
+        let mut total_processed = 0i64;
         for bucket in expired_buckets {
-            let bucket_result = self.process_expired_bucket(&bucket, current_time_ms)?;
-            result.merge(bucket_result);
+            self.process_expired_bucket(&bucket)?;
+            total_processed += bucket.len() as i64;
         }
 
-        let duration = start_time.elapsed().unwrap_or_default();
-        debug!(
-            "Inode ttl cleanup completed: {} processed in {}ms",
-            result.total_processed(),
-            duration.as_millis()
-        );
-
-        Ok(result)
+        Ok(total_processed)
     }
 
-    fn process_expired_bucket(
-        &self,
-        bucket: &TtlBucket,
-        current_time_ms: u64,
-    ) -> TtlResult<TtlCleanupResult> {
-        let mut result = TtlCleanupResult::new();
-
-        // Iterate entries without long-held locks using for_each_inode snapshot
-        bucket.for_each_inode(|inode_id, retry_count| {
-            if self.should_stop_retry(retry_count) {
-                warn!("Stopping retry for inode {} due to max attempts", inode_id);
-                // Count as processed even if we stop retrying
-                result.failed_inodes.push(inode_id);
-                result.failed_cleanups += 1;
-                result.total_processed += 1;
-                let _ = bucket.remove_inode(inode_id);
-                return;
-            }
-
-            let action_result = self.execute_ttl_action(inode_id);
-            result.merge(action_result);
-
-            if result.successful_deletes.contains(&inode_id)
-                || result.successful_frees.contains(&inode_id)
-            {
-                let _ = bucket.remove_inode(inode_id);
-            } else if result.failed_inodes.contains(&inode_id) {
-                // Exponential backoff with jitter and reschedule into a future bucket
-                let updated_retry = retry_count.saturating_add(1);
-
-                if self.should_stop_retry(updated_retry) {
-                    warn!("Max retries reached for inode {}, giving up", inode_id);
-                    let _ = bucket.remove_inode(inode_id);
-                } else {
-                    let next_ts =
-                        self.compute_next_retry_ms(current_time_ms, inode_id, updated_retry);
-                    let _ = self
-                        .bucket_list
-                        .reschedule_inode(inode_id, updated_retry, next_ts);
-                    result.retry_inodes.push(inode_id);
-                    info!(
-                        "Scheduled retry for inode {} (attempt {}/{}) at {}",
-                        inode_id, updated_retry, self.config.max_retry_count, next_ts
+    fn process_expired_bucket(&self, bucket: &TtlBucket) -> FsResult<()> {
+        let inode_ids: Vec<i64> = bucket.inodes.lock().iter().copied().collect();
+        for inode_id in inode_ids {
+            match self.action_executor.execute_by_id(inode_id) {
+                Err(e) => {
+                    warn!(
+                        "error processing inode {}: {} (dropped from TTL scan until re-indexed)",
+                        inode_id, e
                     );
                 }
-            }
-        });
-
-        // After processing all inodes, check if bucket is now empty and remove it
-        if bucket.is_empty() {
-            let _ = self.bucket_list.remove_empty_bucket(bucket);
-        } else {
-            debug!(
-                "Bucket processing completed, {} inodes remaining for retry",
-                bucket.len()
-            );
-        }
-
-        Ok(result)
-    }
-
-    fn should_stop_retry(&self, retry_count: u32) -> bool {
-        if retry_count >= self.config.max_retry_count {
-            debug!(
-                "Retry count limit reached: {}/{}",
-                retry_count, self.config.max_retry_count
-            );
-            return true;
-        }
-        false
-    }
-
-    fn execute_ttl_action(&self, inode_id: u64) -> TtlCleanupResult {
-        let mut result = TtlCleanupResult::new();
-        result.total_processed = 1;
-
-        let inode_view = match self.action_executor.get_inode_from_store(inode_id) {
-            Ok(Some(view)) => view,
-            Ok(None) => {
-                error!("Inode {} not found in store", inode_id);
-                result.failed_inodes.push(inode_id);
-                result.failed_cleanups = 1;
-                return result;
-            }
-            Err(e) => {
-                error!("Failed to get inode {} from store: {}", inode_id, e);
-                result.failed_inodes.push(inode_id);
-                result.failed_cleanups = 1;
-                return result;
-            }
-        };
-
-        let storage_policy = match &inode_view {
-            InodeView::File(_, file) => &file.storage_policy,
-            InodeView::Dir(_, dir) => &dir.storage_policy,
-            InodeView::FileEntry(..) => &StoragePolicy::default(),
-        };
-
-        let action = &storage_policy.ttl_action;
-
-        debug!(
-            "Executing ttl action {:?} for inode {} based on StoragePolicy",
-            action, inode_id
-        );
-
-        match action {
-            TtlAction::Delete => match self.action_executor.delete_inode(inode_id) {
-                Ok(()) => {
-                    debug!("Successfully executed DELETE action for inode {}", inode_id);
-                    result.successful_deletes.push(inode_id);
-                    result.successful_cleanups = 1;
+                Ok((false, inode)) => {
+                    self.bucket_list.add(&inode);
                 }
-                Err(e) => {
-                    error!("Delete failed for inode {}: {}", inode_id, e);
-                    result.failed_inodes.push(inode_id);
-                    result.failed_cleanups = 1;
-                }
-            },
-            TtlAction::Free => match self.action_executor.free_inode(inode_id) {
-                Ok(()) => {
-                    info!("Successfully executed Free action for inode {}", inode_id);
-                    result.successful_frees.push(inode_id);
-                    result.successful_cleanups = 1;
-                }
-                Err(e) => {
-                    error!("Free action failed for inode {}: {}", inode_id, e);
-                    result.failed_inodes.push(inode_id);
-                    result.failed_cleanups = 1;
-                }
-            },
-            TtlAction::None => {
-                warn!("No ttl action defined for inode {}, skipping", inode_id);
-                result.skipped_inodes = 1;
+
+                _ => (),
             }
         }
 
-        result
-    }
-
-    fn compute_next_retry_ms(&self, current_time_ms: u64, inode_id: u64, retry_count: u32) -> u64 {
-        let base = self.config.retry_interval_ms.max(1);
-        let pow = retry_count.min(16); // cap to avoid overflow
-        let mut backoff = base.saturating_mul(1u64 << pow);
-        backoff = backoff.min(self.config.max_retry_duration_ms);
-
-        let basis = inode_id.rotate_left(pow) ^ current_time_ms;
-        let jitter_pct: i64 = (basis % 21) as i64 - 10; // [-10, +10]
-        let jitter_ms = ((backoff as i128 * jitter_pct as i128) / 100) as i64;
-        let adjusted = (backoff as i64 + jitter_ms).max(0) as u64;
-        current_time_ms.saturating_add(adjusted)
+        Ok(())
     }
 }

--- a/curvine-server/src/master/meta/inode/ttl/ttl_executor.rs
+++ b/curvine-server/src/master/meta/inode/ttl/ttl_executor.rs
@@ -12,17 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::common::UfsFactory;
 use crate::master::fs::MasterFilesystem;
-use crate::master::job::JobManager;
-use crate::master::meta::inode::ttl_types::{TtlError, TtlResult};
 use crate::master::meta::inode::{Inode, InodeView, ROOT_INODE_ID};
-use crate::master::mount::MountManager;
-use curvine_common::fs::{FileSystem, Path};
 use curvine_common::state::TtlAction;
-use log::{debug, error, info, warn};
-use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
+use curvine_common::FsResult;
+use log::debug;
+use orpc::err_box;
 
 // TTL Executor Module
 //
@@ -41,38 +36,23 @@ use std::sync::{Arc, RwLock};
 #[derive(Clone)]
 pub struct InodeTtlExecutor {
     filesystem: MasterFilesystem,
-    path_cache: Arc<RwLock<HashMap<u64, String>>>,
-    pub mount_manager: Arc<MountManager>,
-    factory: Arc<UfsFactory>,
-    job_manager: Arc<JobManager>,
 }
 
 impl InodeTtlExecutor {
-    pub fn with_managers(
-        filesystem: MasterFilesystem,
-        mount_manager: Arc<MountManager>,
-        factory: Arc<UfsFactory>,
-        job_manager: Arc<JobManager>,
-    ) -> Self {
-        Self {
-            filesystem,
-            path_cache: Arc::new(RwLock::new(HashMap::new())),
-            mount_manager,
-            factory,
-            job_manager,
-        }
+    pub fn with_managers(filesystem: MasterFilesystem) -> Self {
+        Self { filesystem }
     }
 
-    fn get_inode_path(&self, inode_id: u64) -> TtlResult<String> {
-        let path = self.resolve_inode_path(inode_id as i64)?;
+    fn get_inode_path(&self, inode_id: i64) -> FsResult<String> {
+        let path = self.resolve_inode_path(inode_id)?;
         Ok(path)
     }
 
-    fn resolve_inode_path(&self, inode_id: i64) -> TtlResult<String> {
+    fn resolve_inode_path(&self, inode_id: i64) -> FsResult<String> {
         self.build_path_recursive(inode_id)
     }
 
-    fn build_path_recursive(&self, inode_id: i64) -> TtlResult<String> {
+    fn build_path_recursive(&self, inode_id: i64) -> FsResult<String> {
         if inode_id == ROOT_INODE_ID {
             return Ok("/".to_string());
         }
@@ -106,195 +86,48 @@ impl InodeTtlExecutor {
             }
         }
 
-        Err(TtlError::ServiceError(format!(
-            "Cannot resolve path for inode {}",
-            inode_id
-        )))
+        err_box!("Cannot resolve path for inode {}", inode_id)
     }
 
-    pub fn get_inode_from_store(&self, inode_id: u64) -> TtlResult<Option<InodeView>> {
+    pub fn get_inode_from_store(&self, inode_id: i64) -> FsResult<Option<InodeView>> {
         let fs_dir = self.filesystem.fs_dir();
         let fs_dir_guard = fs_dir.read();
-        fs_dir_guard
-            .store
-            .get_inode(inode_id as i64, None)
-            .map_err(|e| TtlError::ServiceError(format!("Failed to get inode from store: {}", e)))
+        let inode = fs_dir_guard.store.get_inode(inode_id, None)?;
+        Ok(inode)
     }
 
-    pub fn delete_inode(&self, inode_id: u64) -> TtlResult<()> {
-        debug!("Deleting inode: {}", inode_id);
-        let path = self.get_inode_path(inode_id)?;
-        match self.filesystem.delete(&path, true) {
-            Ok(_) => {
-                info!("Successfully deleted file(dir): {}", path);
-
-                if let Ok(mut cache) = self.path_cache.write() {
-                    cache.remove(&inode_id);
-                }
-
-                Ok(())
-            }
-            Err(e) => {
-                error!("Failed to delete file {}: {}", path, e);
-                Err(TtlError::ActionExecutionError(format!(
-                    "Delete failed: {}",
-                    e
-                )))
-            }
-        }
-    }
-
-    pub fn free_inode(&self, inode_id: u64) -> TtlResult<()> {
-        debug!("Freeing inode: {}", inode_id);
-
-        let path = self.get_inode_path(inode_id)?;
-        let inode = self.get_inode_from_store(inode_id)?.ok_or_else(|| {
-            TtlError::ActionExecutionError(format!("Inode {} not found", inode_id))
-        })?;
-
-        match inode {
-            InodeView::File(_, file) => {
-                let action = file.storage_policy.ttl_action;
-                self.free(inode_id, &path, action, false)?;
-            }
-            InodeView::Dir(_, _) => {
-                // pass
-            }
-            InodeView::FileEntry(..) => {
-                return Err(TtlError::ActionExecutionError(format!(
-                    "Cannot free empty file: {}",
-                    path
-                )));
-            }
-        }
-
-        Ok(())
-    }
-
-    fn free(
-        &self,
-        _inode_id: u64,
-        path: &str,
-        action: TtlAction,
-        is_directory: bool,
-    ) -> TtlResult<()> {
-        info!(
-            "Freeing {}: {}, action={:?}",
-            self.resource_type(is_directory),
-            path,
-            action
-        );
-
-        self.filesystem.free(path, false)?;
-        Ok(())
-    }
-
-    // Helper: Get resource type string (eliminates repetition)
-    #[inline]
-    fn resource_type(&self, is_directory: bool) -> &'static str {
-        if is_directory {
-            "directory"
+    pub fn execute_by_id(&self, inode_id: i64) -> FsResult<(bool, InodeView)> {
+        let inode = if let Some(inode) = self.get_inode_from_store(inode_id)? {
+            inode
         } else {
-            "file"
+            return err_box!("Inode {} not found", inode_id);
+        };
+
+        if !inode.is_expired() {
+            return Ok((false, inode));
         }
-    }
 
-    pub fn check_ufs_exists(
-        &self,
-        mount_info: &curvine_common::state::MountInfo,
-        ufs_path: &Path,
-    ) -> TtlResult<bool> {
-        let handle = tokio::runtime::Handle::current();
+        let action = inode.storage_policy().ttl_action;
 
-        let ufs_path_clone = ufs_path.clone();
-        let mount_info_clone = mount_info.clone();
-        let factory = self.factory.clone();
-
-        let exists = handle.block_on(async move {
-            let ufs = factory
-                .get_ufs(&mount_info_clone)
-                .map_err(|e| TtlError::ServiceError(format!("Failed to get UFS: {}", e)))?;
-
-            let result: Result<bool, TtlError> = match ufs.get_status(&ufs_path_clone).await {
-                Ok(_) => Ok(true),
-                Err(_) => Ok(false),
-            };
-            result
-        })?;
-
-        Ok(exists)
-    }
-
-    pub fn handle_skip_job(
-        &self,
-        _inode_id: u64,
-        action: TtlAction,
-        cv_path: &str,
-        is_directory: bool,
-    ) -> TtlResult<()> {
-        let resource_type = self.resource_type(is_directory);
-
-        match action {
-            TtlAction::Free if !is_directory => {
-                info!(
-                    "Free: UFS {} exists, freeing Curvine {}: {}",
-                    resource_type, resource_type, cv_path
-                );
-                self.filesystem.free(cv_path, false).map_err(|e| {
-                    TtlError::ActionExecutionError(format!("Failed to free {}: {}", cv_path, e))
-                })?;
-            }
-            _ => {}
-        }
-        Ok(())
-    }
-
-    pub fn register_export_callback(
-        &self,
-        job_id: String,
-        inode_id: u64,
-        action: TtlAction,
-        cv_path: String,
-        is_directory: bool,
-    ) -> TtlResult<()> {
-        let filesystem = self.filesystem.clone();
-
-        self.job_manager.jobs().register_completion_callback(
-            job_id.clone(),
-            move |job_id_str, _old_state, new_state, job_ctx| {
-                if new_state == curvine_common::state::JobTaskState::Completed {
-                    info!(
-                        "Export job {} completed successfully for inode {}",
-                        job_id_str, inode_id
-                    );
-
-                    // Note: resource_type is captured from closure, but we can't call self here
-                    // So we compute it inline (consistent with other methods now using helper)
-                    let resource_type = if is_directory { "directory" } else { "file" };
-
-                    if action == TtlAction::Free {
-                        info!(
-                            "Free completed, freeing Curvine {}: {}",
-                            resource_type, cv_path
-                        );
-                        if !is_directory {
-                            if let Err(e) = filesystem.free(&cv_path, false) {
-                                error!(
-                                    "Failed to free Curvine {} after export: {}",
-                                    resource_type, e
-                                );
-                            }
-                        }
-                    }
-                } else {
-                    warn!(
-                        "Export job {} failed: {}",
-                        job_id_str, job_ctx.progress.message
-                    );
-                }
-            },
+        debug!(
+            "Executing ttl action {:?} for inode {} based on StoragePolicy",
+            action, inode_id
         );
 
-        Ok(())
+        let path = self.get_inode_path(inode_id)?;
+        match action {
+            TtlAction::Delete => {
+                self.filesystem.delete(&path, true)?;
+                debug!("ttl delete {} {:?}", path, inode);
+                Ok((true, inode))
+            }
+            TtlAction::Free => {
+                self.filesystem.free(&path, true)?;
+                debug!("ttl free {} {:?}", path, inode);
+                Ok((true, inode))
+            }
+
+            _ => Ok((true, inode)),
+        }
     }
 }

--- a/curvine-server/src/master/meta/inode/ttl/ttl_manager.rs
+++ b/curvine-server/src/master/meta/inode/ttl/ttl_manager.rs
@@ -12,17 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::common::UfsFactory;
 use crate::master::fs::MasterFilesystem;
-use crate::master::job::JobManager;
-use crate::master::meta::inode::ttl::ttl_bucket::TtlBucketList;
-use crate::master::meta::inode::ttl::ttl_checker::InodeTtlChecker;
-use crate::master::meta::inode::ttl::ttl_executor::InodeTtlExecutor;
-use crate::master::meta::inode::ttl::ttl_types::{TtlCleanupConfig, TtlCleanupResult, TtlResult};
-use crate::master::mount::MountManager;
-use log::{debug, error};
+use crate::master::meta::inode::ttl::TtlBucketList;
+use crate::master::meta::inode::ttl::TtlResult;
+use crate::master::meta::inode::ttl::{InodeTtlChecker, InodeTtlExecutor};
+use curvine_common::FsResult;
+use log::{error, info};
+use orpc::common::TimeSpent;
 use std::sync::Arc;
-use std::time::Instant;
 
 // TTL Manager Module
 //
@@ -40,59 +37,32 @@ pub struct InodeTtlManager {
 }
 
 impl InodeTtlManager {
-    pub fn new(
-        filesystem: MasterFilesystem,
-        bucket_list: Arc<TtlBucketList>,
-        mount_manager: Arc<MountManager>,
-        factory: Arc<UfsFactory>,
-        job_manager: Arc<JobManager>,
-    ) -> TtlResult<Self> {
-        let ttl_executor = InodeTtlExecutor::with_managers(
-            filesystem.clone(),
-            mount_manager,
-            factory,
-            job_manager,
-        );
+    pub fn new(filesystem: MasterFilesystem, bucket_list: Arc<TtlBucketList>) -> TtlResult<Self> {
+        let ttl_executor = InodeTtlExecutor::with_managers(filesystem.clone());
 
-        // Create cleanup configuration directly from master config
-        let cleanup_config = TtlCleanupConfig {
-            check_interval_ms: filesystem.conf.ttl_checker_interval_ms(),
-            bucket_interval_ms: filesystem.conf.ttl_bucket_interval_ms(),
-            max_retry_count: filesystem.conf.ttl_checker_retry_attempts,
-            max_retry_duration_ms: filesystem.conf.ttl_max_retry_duration_ms(),
-            retry_interval_ms: filesystem.conf.ttl_retry_interval_ms(),
-        };
-
-        let checker = Arc::new(InodeTtlChecker::new(
-            ttl_executor,
-            cleanup_config,
-            bucket_list,
-        )?);
+        let checker = Arc::new(InodeTtlChecker::new(ttl_executor, bucket_list)?);
 
         let manager = Self { checker };
         Ok(manager)
     }
 
-    pub fn cleanup(&self) -> TtlResult<TtlCleanupResult> {
-        let start_time = Instant::now();
+    pub fn cleanup(&self) -> FsResult<i64> {
+        let spend = TimeSpent::new();
 
         match self.checker.cleanup_once() {
-            Ok(result) => {
-                let duration = start_time.elapsed();
-
-                debug!(
-                    "Inode ttl cleanup completed: processed {} items in {}ms",
-                    result.total_processed,
-                    duration.as_millis()
+            Ok(total_processed) => {
+                info!(
+                    "inode ttl cleanup completed: processed {} items in {} ms",
+                    total_processed,
+                    spend.used_ms()
                 );
 
-                Ok(result)
+                Ok(total_processed)
             }
             Err(e) => {
-                let duration = start_time.elapsed();
                 error!(
-                    "Inode ttl cleanup failed after {}ms: {}",
-                    duration.as_millis(),
+                    "inode ttl cleanup failed after {}ms: {}",
+                    spend.used_ms(),
                     e
                 );
                 Err(e)

--- a/curvine-server/src/master/meta/inode/ttl/ttl_scheduler.rs
+++ b/curvine-server/src/master/meta/inode/ttl/ttl_scheduler.rs
@@ -13,11 +13,12 @@
 // limitations under the License.
 
 use crate::master::meta::inode::ttl::ttl_manager::InodeTtlManager;
+use curvine_common::error::FsError;
 use log::{error, info};
+use orpc::common::TimeSpent;
 use orpc::runtime::LoopTask;
-use std::sync::atomic::AtomicU64;
+use orpc::sync::AtomicCounter;
 use std::sync::Arc;
-use std::time::Instant;
 // TTL Scheduler Module
 //
 // This module provides the scheduling infrastructure for TTL operations.
@@ -35,7 +36,7 @@ use std::time::Instant;
 pub struct TtlHeartbeatChecker {
     ttl_manager: Arc<InodeTtlManager>,
     config: TtlHeartbeatConfig,
-    execution_count: Arc<AtomicU64>,
+    execution_count: Arc<AtomicCounter>,
 }
 
 impl TtlHeartbeatChecker {
@@ -43,7 +44,7 @@ impl TtlHeartbeatChecker {
         Self {
             ttl_manager,
             config,
-            execution_count: Arc::new(AtomicU64::new(0)),
+            execution_count: Arc::new(AtomicCounter::new(0)),
         }
     }
     pub fn get_task_name(&self) -> &str {
@@ -70,13 +71,10 @@ impl Default for TtlHeartbeatConfig {
 }
 
 impl LoopTask for TtlHeartbeatChecker {
-    type Error = curvine_common::error::FsError;
+    type Error = FsError;
     fn run(&self) -> Result<(), Self::Error> {
-        let execution_start = Instant::now();
-        let execution_id = self
-            .execution_count
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            + 1;
+        let spend = TimeSpent::new();
+        let execution_id = self.execution_count.add_and_get(1);
 
         info!(
             "Starting inode ttl clean execution #{} for task '{}'",
@@ -84,48 +82,25 @@ impl LoopTask for TtlHeartbeatChecker {
             self.get_task_name()
         );
 
-        let _task_name = &self.config.task_name;
-        let _timeout = self.config.timeout_ms;
-
         let result = self.ttl_manager.cleanup();
-        let execution_time = execution_start.elapsed();
-
-        if execution_time.as_millis() as u64 > self.get_timeout_ms() {
+        let used_ms = spend.used_ms();
+        if used_ms > self.get_timeout_ms() {
             error!(
                 "Inode ttl execution #{} for task '{}' exceeded timeout of {}ms (actual: {}ms)",
                 execution_id,
                 self.get_task_name(),
                 self.get_timeout_ms(),
-                execution_time.as_millis()
+                used_ms
             );
         }
-
-        match result {
-            Ok(cleanup_result) => {
-                info!(
-                    "Inode ttl #{} for task '{}' completed successfully in {}ms. Results: total_processed={}, successful={}, failed={}",
-                    execution_id,
-                    self.get_task_name(),
-                    execution_time.as_millis(),
-                    cleanup_result.total_processed,
-                    cleanup_result.successful_cleanups,
-                    cleanup_result.failed_cleanups
-                );
-                Ok(())
-            }
-            Err(e) => {
-                error!(
-                    "Inode ttl execution #{} for task '{}' failed after {}ms: {}",
-                    execution_id,
-                    self.get_task_name(),
-                    execution_time.as_millis(),
-                    e
-                );
-                Err(curvine_common::error::FsError::common(format!("TTL heartbeat execution failed: execution_id={}, task_name={}, duration={}ms, error={}",
-                                                                   execution_id, self.get_task_name(), execution_time.as_millis(), e)))
-            }
+        if let Err(e) = result {
+            error!("TTL heartbeat execution failed: execution_id={}, task_name={}, duration={}ms, error={}",
+                execution_id, self.get_task_name(), used_ms, e);
         }
+
+        Ok(())
     }
+
     fn terminate(&self) -> bool {
         // TTL manager is always ready after creation, so we never terminate
         // unless the entire system is shutting down

--- a/curvine-server/src/master/meta/store/inode_store.rs
+++ b/curvine-server/src/master/meta/store/inode_store.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::master::fs::DeleteResult;
-use crate::master::meta::inode::ttl::ttl_bucket::TtlBucketList;
+use crate::master::meta::inode::ttl::TtlBucketList;
 use crate::master::meta::inode::{InodeFile, InodeView, ROOT_INODE_ID};
 use crate::master::meta::store::{InodeWriteBatch, RocksInodeStore};
 use crate::master::meta::{FileSystemStats, FsDir, LockMeta};
@@ -57,17 +57,7 @@ impl InodeStore {
 
         batch.commit()?;
 
-        if let Some(ttl_config) = child.ttl_config() {
-            let expiration_ms = ttl_config.expiry_time_ms();
-            let inode_id = child.id() as u64;
-            if let Err(e) = self.ttl_bucket_list.add_inode(inode_id, expiration_ms) {
-                log::warn!(
-                    "Direct ttl registration failed for inode {}: {}",
-                    child.id(),
-                    e
-                );
-            }
-        }
+        self.ttl_bucket_list.add(child);
 
         match child {
             InodeView::File(_, _) => self.fs_stats.increment_file_count(),
@@ -98,13 +88,11 @@ impl InodeStore {
             batch.delete_child(parent_id, inode.name())?;
             del_res.inodes += 1;
 
-            if let Err(e) = self.ttl_bucket_list.remove_inode(inode.id() as u64) {
-                log::warn!("Direct ttl removal failed for inode {}: {}", inode.id(), e);
-            }
-
             match &inode {
                 InodeView::Dir(_, dir) => {
                     batch.delete_inode(inode.id())?;
+                    self.ttl_bucket_list.remove(&inode);
+
                     // Don't count root directory
                     if dir.id != ROOT_INODE_ID {
                         deleted_dirs += 1;
@@ -218,23 +206,9 @@ impl InodeStore {
         let mut batch = self.store.new_batch();
         for inode in &inodes {
             batch.write_inode(inode)?;
+            self.ttl_bucket_list.add(inode);
         }
         batch.commit()?;
-
-        for inode in &inodes {
-            let inode_id = inode.id() as u64;
-            let _ = self.ttl_bucket_list.remove_inode(inode_id);
-            if let Some(ttl_config) = inode.ttl_config() {
-                let expiration_ms = ttl_config.expiry_time_ms();
-                if let Err(e) = self.ttl_bucket_list.add_inode(inode_id, expiration_ms) {
-                    log::warn!(
-                        "Direct ttl re-registration failed for inode {}: {}",
-                        inode_id,
-                        e
-                    );
-                }
-            }
-        }
 
         Ok(())
     }
@@ -366,10 +340,7 @@ impl InodeStore {
                         // Collect block info
                         del_res.blocks.extend(file.get_locs(self)?);
 
-                        // Remove from TTL
-                        if let Err(e) = self.ttl_bucket_list.remove_inode(inode_id as u64) {
-                            log::warn!("Direct ttl removal failed for inode {}: {}", inode_id, e);
-                        }
+                        self.ttl_bucket_list.remove(&inode_view);
                     } else {
                         // Write the updated inode back to storage
                         batch.write_inode(&inode_view)?;
@@ -426,6 +397,8 @@ impl InodeStore {
                         continue;
                     }
                 };
+                self.ttl_bucket_list.add(&store_inode);
+
                 let inode = if matches!(store_inode, InodeView::Dir(_, _)) {
                     store_inode
                 } else {
@@ -459,17 +432,6 @@ impl InodeStore {
                     let file_entry = InodeView::FileEntry(child_name.to_string(), child_id);
 
                     stack.push_back((next_parent.clone(), child_id, file_entry))
-                }
-                if let Some(ttl_config) = next_parent.ttl_config() {
-                    let inode_id = next_parent.id() as u64;
-                    let expiration_ms = ttl_config.expiry_time_ms();
-                    if let Err(e) = self.ttl_bucket_list.add_inode(inode_id, expiration_ms) {
-                        log::warn!(
-                            "Direct ttl registration failed during tree creation for inode {}: {}",
-                            next_parent.id(),
-                            e
-                        );
-                    }
                 }
             }
         }

--- a/curvine-server/src/master/quota/quota_manager.rs
+++ b/curvine-server/src/master/quota/quota_manager.rs
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 
 use crate::master::fs::MasterFilesystem;
-use crate::master::meta::inode::ttl_executor::InodeTtlExecutor;
+use crate::master::meta::inode::ttl::InodeTtlExecutor;
 use crate::master::meta::inode::InodeView;
 use crate::master::quota::eviction::evictor::Evictor;
 use crate::master::quota::eviction::types::EvictPlan;
@@ -206,7 +206,7 @@ impl QuotaManager {
         })
     }
 
-    fn execute_eviction(&self, mode: EvictionMode, inode_ids: &[i64]) {
+    fn execute_eviction(&self, _mode: EvictionMode, inode_ids: &[i64]) {
         let ttl_executor_guard = self.ttl_executor.read();
         let Some(ttl_executor) = ttl_executor_guard.as_ref() else {
             log::warn!("cluster-evict: ttl_executor not initialized, skipping eviction");
@@ -236,16 +236,12 @@ impl QuotaManager {
                 .collect()
         };
 
-        for (inode_id_i64, file_size) in file_sizes {
-            let inode_id = inode_id_i64 as u64;
-            let res = match mode {
-                EvictionMode::FreeFile => ttl_executor.free_inode(inode_id),
-                EvictionMode::DeleteFile => ttl_executor.delete_inode(inode_id),
-            };
+        for (inode_id, file_size) in file_sizes {
+            let res = ttl_executor.execute_by_id(inode_id);
 
             match res {
                 Ok(_) => {
-                    successfully_evicted.push(inode_id_i64);
+                    successfully_evicted.push(inode_id);
                     total_bytes_freed += file_size;
                 }
                 Err(e) => {

--- a/curvine-tests/tests/ttl_test.rs
+++ b/curvine-tests/tests/ttl_test.rs
@@ -54,7 +54,6 @@ fn test_ttl_cleanup() -> CommonResult<()> {
     testing.start_cluster()?;
 
     let conf = testing.get_active_cluster_conf()?;
-    println!("conf: {:?}", conf);
     let rt = Arc::new(conf.client_rpc_conf().create_runtime());
     let fs_context = Arc::new(FsContext::with_rt(conf.clone(), rt.clone())?);
     let client = FsClient::new(fs_context);

--- a/etc/curvine-cluster.toml
+++ b/etc/curvine-cluster.toml
@@ -11,14 +11,6 @@ format_worker = false
 meta_dir = "testing/meta"
 log = { level = "info", log_dir = "stdout", file_name = "master.log" }
 
-# TTL (Time-To-Live) configuration
-ttl_checker_interval = "1h"        # TTL checker execution interval
-ttl_checker_retry_attempts = 3     # Maximum retry attempts for failed TTL operations
-ttl_bucket_interval = "1h"         # TTL bucket time interval
-ttl_max_retry_duration = "30m"     # Maximum duration for retrying failed operations
-ttl_retry_interval = "5s"          # Interval between retry attempts
-
-
 
 # masta ha raft configuration.
 [journal]


### PR DESCRIPTION
## Summary

This change simplifies the master TTL pipeline by moving from a retry-heavy, multi-manager TTL implementation to a lean bucket-indexed model centered on inode metadata (`mtime + ttl_ms`). It unifies imports and module exports, reduces coupling with mount/UFS/job components, and makes TTL cleanup behavior easier to reason about and observe.

## What changed

### 1) TTL data model and expiration semantics

- `FileStatus::is_expired` now follows storage-policy semantics consistently:
  - requires `ttl_action != None`
  - requires `ttl_ms > 0`
  - compares `now` against `mtime + ttl_ms` (instead of `atime + ttl_ms`)
- `InodeView` now owns expiration helpers directly:
  - `expiration_ms()`
  - `is_expired()`
- Legacy `ttl_config()` usage was removed from inode flow.

### 2) TTL bucket implementation rewrite

- `TtlBucketList` was rewritten around:
  - `BTreeMap<interval_start_ms, Arc<TtlBucket>>`
  - per-bucket inode set (`FastHashSet`) with `Mutex`
- Added/standardized bucket operations:
  - `add(&InodeView)`
  - `remove(&InodeView)`
  - `get_expired_buckets_at(now)`
  - `buckets_len()` / `total_inodes()`
- Expired buckets are drained by key range and removed from the map in one pass.
- Added unit tests for basic add/remove/find/drain behavior in `ttl_bucket.rs`.

### 3) TTL checker / executor / manager simplification

- `InodeTtlChecker` now uses a straightforward execution loop over expired buckets and inode ids.
- Removed old retry/backoff result-aggregation complexity.
- `InodeTtlExecutor` API is simplified to `execute_by_id(inode_id)`:
  - load inode
  - check `is_expired()`
  - run action (`Delete` / `Free`)
- `InodeTtlManager` now wires only filesystem + bucket list and reports concise cleanup stats.

### 4) Wiring and module boundary cleanup

- TTL modules are now re-exported cleanly from `ttl/mod.rs`.
- Call sites switched from deep paths to unified TTL exports.
- `MasterActor::start_ttl_scheduler` no longer requires mount/factory/job manager dependencies.
- `MasterServer` start sequence updated accordingly.

### 5) Metrics and observability

- Added master metrics:
  - `ttl_bucket_len`
  - `ttl_total_inodes`
- Exposed TTL bucket state in periodic master metrics collection.

### 6) Store integration updates

- `InodeStore` now directly uses `ttl_bucket_list.add/remove` in inode lifecycle paths
  (create, set_attr, delete/decrement link, tree load), replacing older direct ttl-config registration logic.

### 7) Misc cleanup

- Removed stale debug print from `ttl_test.rs`.
- Removed obsolete TTL config block from `etc/curvine-cluster.toml`.

## Behavioral impact

- TTL expiration now consistently tracks **modification time** (`mtime`) based policy.
- TTL cleanup path is simpler and less coupled, which should reduce operational complexity.
- Retry/backoff orchestration from the previous TTL checker model is no longer part of this flow.