### PR TITLE
fix(test): fix parallel test flakiness caused by TOCTOU port races and Raft sync lag

### DIFF
--- a/curvine-server/src/test/mini_cluster.rs
+++ b/curvine-server/src/test/mini_cluster.rs
@@ -51,11 +51,15 @@ impl MiniCluster {
     fn reserve_test_port() -> u16 {
         let ports = RESERVED_TEST_PORTS.get_or_init(|| Mutex::new(HashSet::new()));
         loop {
-            let port = NetUtils::get_available_port();
+            // hold_available_port keeps the socket bound until RpcServer::run() calls
+            // take_held_listener, preventing TOCTOU races across parallel nextest processes.
+            let port = NetUtils::hold_available_port();
             let mut guard = ports.lock().unwrap();
             if guard.insert(port) {
                 return port;
             }
+            // Duplicate within this process: release the held listener and retry.
+            NetUtils::take_held_listener(port);
         }
     }
 

--- a/curvine-server/tests/journal_test.rs
+++ b/curvine-server/tests/journal_test.rs
@@ -145,8 +145,10 @@ fn test_raft_consensus_and_state_synchronization_between_two_masters() -> Common
     Logger::default();
     Master::init_test_metrics();
 
-    let port1 = NetUtils::get_available_port();
-    let port2 = NetUtils::get_available_port();
+    // hold_available_port keeps each socket bound until the Raft server claims it,
+    // preventing TOCTOU races when nextest runs tests in parallel.
+    let port1 = NetUtils::hold_available_port();
+    let port2 = NetUtils::hold_available_port();
 
     let mut conf = ClusterConf::default();
     conf.journal.writer_flush_batch_size = 1;
@@ -204,12 +206,29 @@ fn test_raft_consensus_and_state_synchronization_between_two_masters() -> Common
     run(&active, &worker)?;
     run_mnt(mnt_mgr.clone())?;
 
-    thread::sleep(Duration::from_secs(30));
-
-    active.print_tree();
-    standby.print_tree();
-    assert_eq!(active.last_inode_id(), standby.last_inode_id());
-    assert_eq!(active.sum_hash(), standby.sum_hash());
+    // Poll until the standby's filesystem state AND mount table converge with
+    // the active node, rather than using a fixed sleep that may be insufficient
+    // under load. Both inode state and mount table are replicated via separate
+    // Raft log entries, so we must wait for all of them to be applied.
+    let deadline = std::time::Instant::now() + Duration::from_secs(60);
+    loop {
+        let leader_mnt = mnt_mgr1.get_mount_table().unwrap_or_default();
+        let follower_mnt = mnt_mgr2.get_mount_table().unwrap_or_default();
+        if active.last_inode_id() == standby.last_inode_id()
+            && active.sum_hash() == standby.sum_hash()
+            && leader_mnt.len() == follower_mnt.len()
+        {
+            break;
+        }
+        if std::time::Instant::now() >= deadline {
+            active.print_tree();
+            standby.print_tree();
+            assert_eq!(active.last_inode_id(), standby.last_inode_id());
+            assert_eq!(active.sum_hash(), standby.sum_hash());
+            break;
+        }
+        thread::sleep(Duration::from_millis(200));
+    }
 
     let leader_mnt = mnt_mgr1.get_mount_table().unwrap();
     let follower_mnt = mnt_mgr2.get_mount_table().unwrap();

--- a/curvine-server/tests/worker_test.rs
+++ b/curvine-server/tests/worker_test.rs
@@ -34,8 +34,10 @@ const LOOP_NUM: i32 = 100;
 // Test the worker interface function.
 fn start_worker() -> ClusterConf {
     let mut conf = ClusterConf::default();
-    conf.worker.rpc_port = NetUtils::get_available_port();
-    conf.worker.web_port = NetUtils::get_available_port();
+    // Use hold_available_port so the socket stays bound until RpcServer::run() claims it,
+    // preventing TOCTOU races when nextest runs tests in parallel.
+    conf.worker.rpc_port = NetUtils::hold_available_port();
+    conf.worker.web_port = NetUtils::hold_available_port();
     conf.worker.data_dir = vec!["[MEM:10MB]../testing/worker-test".to_owned()];
     conf.client.init().unwrap();
 

--- a/curvine-tests/tests/write_cache_test.rs
+++ b/curvine-tests/tests/write_cache_test.rs
@@ -23,8 +23,6 @@ use orpc::sys::DataSlice;
 use std::env;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::time::sleep;
-
 fn get_fs() -> UnifiedFileSystem {
     let testing = Testing::builder().workers(1).build().unwrap();
     // Check if UFS configuration is available, if not, skip the test
@@ -237,8 +235,9 @@ fn test_fs_mode_ufs_write_overwrite() {
 
         verify_read_data(&fs, &path, data_overwrite.as_bytes()).await;
 
-        sleep(Duration::from_secs(3)).await;
-        verify_cv_ufs_consistency(&fs, &path).await;
+        // Wait until CV and UFS are fully consistent instead of a fixed sleep,
+        // as UFS sync jobs may take longer under parallel test load.
+        wait_for_cv_ufs_consistency(&fs, &path).await;
     });
 }
 
@@ -268,8 +267,9 @@ fn test_fs_mode_ufs_write_append() {
 
         verify_read_data(&fs, &path, expected_append.as_bytes()).await;
 
-        sleep(Duration::from_secs(3)).await;
-        verify_cv_ufs_consistency(&fs, &path).await;
+        // Wait until CV and UFS are fully consistent instead of a fixed sleep,
+        // as UFS sync jobs may take longer under parallel test load.
+        wait_for_cv_ufs_consistency(&fs, &path).await;
     });
 }
 
@@ -314,8 +314,9 @@ fn test_fs_mode_ufs_write_random() {
 
         verify_read_data(&fs, &path, &expected).await;
 
-        sleep(Duration::from_secs(3)).await;
-        verify_cv_ufs_consistency(&fs, &path).await;
+        // Wait until CV and UFS are fully consistent instead of a fixed sleep,
+        // as UFS sync jobs may take longer under parallel test load.
+        wait_for_cv_ufs_consistency(&fs, &path).await;
     });
 }
 

--- a/curvine-web/src/server/web_server.rs
+++ b/curvine-web/src/server/web_server.rs
@@ -20,7 +20,7 @@ use axum::error_handling::HandleErrorLayer;
 use axum::http::StatusCode;
 use axum::Json;
 use log::{error, info};
-use orpc::io::net::InetAddr;
+use orpc::io::net::{InetAddr, NetUtils};
 use orpc::runtime::{RpcRuntime, Runtime};
 use orpc::server::ServerConf;
 use orpc::CommonResult;
@@ -95,7 +95,16 @@ where
     }
 
     pub async fn run(&self) -> CommonResult<()> {
-        let listener = TcpListener::bind(self.get_bind_addr()).await?;
+        // Prefer a pre-bound listener from the test port reservation map.
+        // This eliminates the TOCTOU race between port discovery and actual bind
+        // when parallel test processes (cargo nextest) run simultaneously.
+        let listener = match NetUtils::take_held_listener(self.address.port) {
+            Some(std_listener) => {
+                std_listener.set_nonblocking(true)?;
+                TcpListener::from_std(std_listener)?
+            }
+            None => TcpListener::bind(self.get_bind_addr()).await?,
+        };
         info!(
             "WebServer [{}] start successfully, bind address: {}",
             self.conf.name, self.address,

--- a/orpc/src/io/net/net_utils.rs
+++ b/orpc/src/io/net/net_utils.rs
@@ -14,19 +14,46 @@
 
 use crate::io::IOResult;
 use crate::{try_err, try_option};
-use std::net::ToSocketAddrs;
+use std::collections::HashMap;
+use std::net::{TcpListener, ToSocketAddrs};
+use std::sync::{Mutex, OnceLock};
 use sysinfo::System;
+
+// Process-global map of pre-bound listeners for test port reservation.
+// Keeps sockets alive between port selection and server startup, preventing
+// TOCTOU races when multiple test processes run in parallel (e.g. cargo nextest).
+static HELD_LISTENERS: OnceLock<Mutex<HashMap<u16, TcpListener>>> = OnceLock::new();
 
 pub struct NetUtils;
 
 impl NetUtils {
     // Get a system-available port.
     pub fn get_available_port() -> u16 {
-        std::net::TcpListener::bind("0.0.0.0:0")
+        TcpListener::bind("0.0.0.0:0")
             .unwrap()
             .local_addr()
             .unwrap()
             .port()
+    }
+
+    // Bind to an available port and hold the socket open in a global map.
+    // The port stays reserved until `take_held_listener` is called, eliminating
+    // the TOCTOU race between port discovery and actual server bind.
+    // Use this in test infrastructure instead of `get_available_port`.
+    pub fn hold_available_port() -> u16 {
+        let listener = TcpListener::bind("0.0.0.0:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let map = HELD_LISTENERS.get_or_init(|| Mutex::new(HashMap::new()));
+        map.lock().unwrap().insert(port, listener);
+        port
+    }
+
+    // Remove and return the held TcpListener for a port.
+    // Called by the server runtime when it is ready to accept connections.
+    pub fn take_held_listener(port: u16) -> Option<TcpListener> {
+        HELD_LISTENERS
+            .get()
+            .and_then(|map| map.lock().unwrap().remove(&port))
     }
 
     pub fn local_hostname() -> String {

--- a/orpc/src/server/rpc_server.rs
+++ b/orpc/src/server/rpc_server.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::handler::{HandlerService, MessageHandler, RpcFrame};
-use crate::io::net::InetAddr;
+use crate::io::net::{InetAddr, NetUtils};
 use crate::runtime::{RpcRuntime, Runtime};
 use crate::server::{ServerConf, ServerMonitor, ServerStateListener};
 use crate::sync::StateCtl;
@@ -139,7 +139,16 @@ where
 
     pub async fn run(&self) -> CommonResult<()> {
         let bind_addr = self.get_bind_addr();
-        let listener = TcpListener::bind(&bind_addr).await?;
+        // Prefer a pre-bound listener from the test port reservation map.
+        // This eliminates the TOCTOU race between port discovery and actual bind
+        // when parallel test processes (cargo nextest) run simultaneously.
+        let listener = match NetUtils::take_held_listener(self.addr.port) {
+            Some(std_listener) => {
+                std_listener.set_nonblocking(true)?;
+                TcpListener::from_std(std_listener)?
+            }
+            None => TcpListener::bind(&bind_addr).await?,
+        };
         info!(
             "Rpc server [{}] start successfully, bind address: {}, hostname: {}, thread_name: {}, io threads: {}, worker threads: {}",
             self.conf.name,

--- a/orpc/src/test/simple_server.rs
+++ b/orpc/src/test/simple_server.rs
@@ -109,7 +109,9 @@ impl SimpleServer {
 impl Default for SimpleServer {
     fn default() -> Self {
         let host = "127.0.0.1";
-        let port = NetUtils::get_available_port();
+        // hold_available_port keeps the socket bound until RpcServer claims it,
+        // preventing TOCTOU races when nextest runs tests in parallel.
+        let port = NetUtils::hold_available_port();
         Self::new(host, port)
     }
 }

--- a/orpc/tests/file_test.rs
+++ b/orpc/tests/file_test.rs
@@ -44,7 +44,9 @@ fn test_distributed_file_location_and_creation() {
 #[test]
 fn test_rpc_file_server_write_read_with_checksum_validation() -> CommonResult<()> {
     // Loopback avoids bind failures when `local_hostname()` is not bindable on some hosts (e.g. macOS).
-    let conf = ServerConf::with_hostname("127.0.0.1", NetUtils::get_available_port());
+    // hold_available_port keeps the socket bound until RpcServer claims it,
+    // preventing TOCTOU races when nextest runs tests in parallel.
+    let conf = ServerConf::with_hostname("127.0.0.1", NetUtils::hold_available_port());
     let dirs = vec![
         String::from("../testing/orpc-d1"),
         String::from("../testing/orpc-d2"),


### PR DESCRIPTION
## Problem
`cargo nextest run` runs tests in parallel processes. Tests that allocate
ports via `get_available_port()` suffered TOCTOU races: the port was released
between discovery and the server's bind, allowing another parallel process to
claim it. Additionally, `journal_test` failed intermittently because the polling
loop only waited for inode state convergence, not mount table convergence.

## Design
Introduce a port-holding mechanism (`hold_available_port` / `take_held_listener`)
that keeps a `TcpListener` bound in a process-global map until the server
explicitly claims it. Servers (`RpcServer`, `WebServer`) check this map first
before falling back to a fresh bind. For timing-sensitive assertions, replace
fixed sleeps with polling loops that wait for the actual condition to be true.

## Key Changes
- `net_utils.rs`: add `hold_available_port()` and `take_held_listener()` backed
  by a `OnceLock<Mutex<HashMap<u16, TcpListener>>>`
- `rpc_server.rs`, `web_server.rs`: use `take_held_listener` in `run()` to claim
  pre-reserved ports atomically
- `mini_cluster.rs`, `worker_test.rs`, `file_test.rs`, `simple_server.rs`:
  replace `get_available_port()` with `hold_available_port()`
- `write_cache_test.rs`: replace `sleep(3s) + verify` with
  `wait_for_cv_ufs_consistency()` polling (up to 60s)
- `journal_test.rs`: extend convergence poll to also wait for mount table
  length equality between leader and follower before asserting