### PR TITLE
feat(fs): define list_stream/list_options interfaces and implement se…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -831,6 +831,7 @@ dependencies = [
 name = "curvine-client"
 version = "0.2.0"
 dependencies = [
+ "async-stream",
  "bytes",
  "curvine-common",
  "curvine-tracing-appender",
@@ -859,6 +860,7 @@ name = "curvine-common"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "async-stream",
  "axum 0.7.9",
  "bincode",
  "bitflags 2.10.0",
@@ -869,6 +871,7 @@ dependencies = [
  "crossbeam",
  "dashmap",
  "flate2",
+ "futures",
  "hyper 1.7.0",
  "indexmap 2.11.0",
  "linked-hash-map",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ curvine-s3-gateway = { path = "curvine-s3-gateway" }
 libc = "0.2.167"
 tokio = { version = "1.42.0", features = ["full"] }
 futures = "0.3.31"
+async-stream = "0.3.6"
 tokio-util = { version = "0.7.12", features = ["full"] }
 bytes = "1.9.0"
 serde = { version = "1.0.215", features = ["derive"] }

--- a/curvine-client/Cargo.toml
+++ b/curvine-client/Cargo.toml
@@ -24,6 +24,7 @@ pin-project-lite = { workspace = true }
 serde_json = { workspace = true }
 dashmap = { workspace = true }
 futures = { workspace = true }
+async-stream = { workspace = true }
 moka = { workspace = true }
 fxhash = { workspace = true }
 prometheus = { workspace = true }

--- a/curvine-client/src/unified/macros.rs
+++ b/curvine-client/src/unified/macros.rs
@@ -470,6 +470,32 @@ macro_rules! impl_filesystem_for_enum {
                 }
             }
 
+            async fn list_options(
+                &self,
+                path: &::curvine_common::fs::Path,
+                opts: ::curvine_common::state::ListOptions,
+            ) -> ::curvine_common::FsResult<Vec<::curvine_common::state::FileStatus>> {
+                match self {
+                    $(
+                        $(#[$cfg])*
+                        Self::$variant(inner) => inner.list_options(path, opts).await,
+                    )+
+                }
+            }
+
+            fn list_stream<'a>(
+                &'a self,
+                path: &'a::curvine_common::fs::Path,
+                opts: ::curvine_common::state::ListOptions,
+            ) -> ::std::pin::Pin<Box<dyn ::futures::Stream<Item = ::curvine_common::FsResult<::curvine_common::state::FileStatus>> + 'a>> {
+                match self {
+                    $(
+                        $(#[$cfg])*
+                        Self::$variant(inner) => inner.list_stream(path, opts),
+                    )+
+                }
+            }
+
             async fn set_attr(
                 &self,
                 path: &::curvine_common::fs::Path,

--- a/curvine-common/Cargo.toml
+++ b/curvine-common/Cargo.toml
@@ -9,6 +9,8 @@ license.workspace = true
 [dependencies]
 orpc = { workspace = true }
 tokio = { workspace = true }
+futures = { workspace = true }
+async-stream =  { workspace = true }
 tokio-util = { workspace = true }
 log = { workspace = true }
 raft = { workspace = true }

--- a/curvine-common/proto/common.proto
+++ b/curvine-common/proto/common.proto
@@ -201,3 +201,7 @@ message FreeResultProto {
     required int64 bytes = 3;
 }
 
+message ListOptionsProto {
+  optional int32 limit = 1;
+  optional string start_after = 2;
+}

--- a/curvine-common/proto/master.proto
+++ b/curvine-common/proto/master.proto
@@ -331,3 +331,12 @@ message SetLockRequest {
 message SetLockResponse {
     optional FileLockProto conflict = 1;
 }
+
+message ListOptionsRequest {
+    required string path = 1;
+    required ListOptionsProto options = 2;
+}
+
+message ListOptionsResponse {
+    repeated FileStatusProto statuses = 1;
+}

--- a/curvine-common/src/fs/filesystem.rs
+++ b/curvine-common/src/fs/filesystem.rs
@@ -14,11 +14,15 @@
 
 use crate::fs::{FsKind, Path};
 use crate::proto::{GetFileStatusResponse, ListStatusResponse};
-use crate::state::{FileStatus, SetAttrOpts};
+use crate::state::{FileStatus, ListOptions, SetAttrOpts};
 use crate::utils::ProtoUtils;
 use crate::FsResult;
+use async_stream::stream;
+use futures::stream::Stream;
+use orpc::err_box;
 use prost::bytes::BytesMut;
 use std::future::Future;
+use std::pin::Pin;
 
 pub trait FileSystem<Writer, Reader> {
     fn fs_kind(&self) -> FsKind;
@@ -65,4 +69,72 @@ pub trait FileSystem<Writer, Reader> {
     }
 
     fn set_attr(&self, path: &Path, opts: SetAttrOpts) -> impl Future<Output = FsResult<()>>;
+
+    fn list_options(
+        &self,
+        _path: &Path,
+        _opts: ListOptions,
+    ) -> impl Future<Output = FsResult<Vec<FileStatus>>> + Send {
+        async move { err_box!("not supported list_options") }
+    }
+
+    fn list_options_bytes(
+        &self,
+        path: &Path,
+        opts: ListOptions,
+    ) -> impl Future<Output = FsResult<BytesMut>> {
+        async move {
+            let statuses = self
+                .list_options(path, opts)
+                .await?
+                .into_iter()
+                .map(ProtoUtils::file_status_to_pb)
+                .collect();
+
+            let rep = ListStatusResponse { statuses };
+            Ok(ProtoUtils::encode(rep)?)
+        }
+    }
+
+    fn list_stream<'a>(
+        &'a self,
+        path: &'a Path,
+        options: ListOptions,
+    ) -> Pin<Box<dyn Stream<Item = FsResult<FileStatus>> + 'a>> {
+        let stream = stream! {
+            let (limit, mut start_after) = (options.limit, options.start_after);
+            loop {
+                let opts = ListOptions {
+                    limit,
+                    start_after: start_after.clone(),
+                };
+                let list = match self.list_options(path, opts).await {
+                    Ok(p) => p,
+                    Err(e) => {
+                        yield Err(e);
+                        break;
+                    }
+                };
+
+                if list.is_empty() {
+                    break;
+                }
+
+                let n = list.len();
+                let last_name = list.last().map(|s| s.name.clone());
+                for status in list {
+                    yield Ok(status);
+                }
+
+                if let Some(l) = limit {
+                    if n < l {
+                        break;
+                    }
+                }
+                start_after = last_name;
+            }
+        };
+
+        Box::pin(stream)
+    }
 }

--- a/curvine-common/src/fs/rpc_code.rs
+++ b/curvine-common/src/fs/rpc_code.rs
@@ -48,6 +48,7 @@ pub enum RpcCode {
     AddBlocksBatch = 24,
     CompleteFilesBatch = 25,
     Free = 26,
+    ListOptions = 27,
 
     // manager interface.
     Mount = 30,

--- a/curvine-common/src/state/opts.rs
+++ b/curvine-common/src/state/opts.rs
@@ -509,3 +509,25 @@ impl SetAttrOptsBuilder {
         }
     }
 }
+
+#[derive(Debug, Clone, Default)]
+pub struct ListOptions {
+    pub limit: Option<usize>,
+    pub start_after: Option<String>,
+}
+
+impl ListOptions {
+    pub fn from_status(limit: usize, status: &FileStatus) -> Self {
+        Self {
+            limit: Some(limit),
+            start_after: Some(status.name.to_owned()),
+        }
+    }
+
+    pub fn with_limit(limit: usize) -> Self {
+        Self {
+            limit: Some(limit),
+            start_after: None,
+        }
+    }
+}

--- a/curvine-common/src/utils/proto_utils.rs
+++ b/curvine-common/src/utils/proto_utils.rs
@@ -526,6 +526,20 @@ impl ProtoUtils {
         }
     }
 
+    pub fn list_options_from_pb(opts: ListOptionsProto) -> ListOptions {
+        ListOptions {
+            limit: opts.limit.map(|v| v as usize),
+            start_after: opts.start_after,
+        }
+    }
+
+    pub fn list_options_to_pb(opts: ListOptions) -> ListOptionsProto {
+        ListOptionsProto {
+            limit: opts.limit.map(|v| v as i32),
+            start_after: opts.start_after,
+        }
+    }
+
     pub fn mount_info_to_pb(info: MountInfo) -> MountInfoProto {
         MountInfoProto {
             cv_path: info.cv_path,

--- a/curvine-server/src/master/fs/master_filesystem.rs
+++ b/curvine-server/src/master/fs/master_filesystem.rs
@@ -353,6 +353,22 @@ impl MasterFilesystem {
         }
     }
 
+    pub fn list_options<T: AsRef<str>>(
+        &self,
+        path: T,
+        opts: ListOptions,
+    ) -> FsResult<Vec<FileStatus>> {
+        let path = path.as_ref();
+        let fs_dir = self.fs_dir.read();
+        let (is_glob_pattern, _) = parse_glob_pattern(path);
+        if is_glob_pattern {
+            return err_box!("not support glob_pattern, path {}", path);
+        } else {
+            let inp = Self::resolve_path(&fs_dir, path)?;
+            fs_dir.list_options(&inp, &opts)
+        }
+    }
+
     fn resolve_path(fs_dir: &FsDir, path: &str) -> CommonResult<InodePath> {
         InodePath::resolve(fs_dir.root_ptr(), path, &fs_dir.store)
     }

--- a/curvine-server/src/master/master_handler.rs
+++ b/curvine-server/src/master/master_handler.rs
@@ -614,6 +614,20 @@ impl MasterHandler {
         };
         ctx.response(rep_header)
     }
+
+    pub fn list_options(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+        let header: ListOptionsRequest = ctx.parse_header()?;
+        ctx.set_audit(Some(header.path.to_string()), None);
+
+        let opts = ProtoUtils::list_options_from_pb(header.options);
+        let list = self.fs.list_options(&header.path, opts)?;
+        let res = list
+            .into_iter()
+            .map(ProtoUtils::file_status_to_pb)
+            .collect();
+        let rep_header = ListOptionsResponse { statuses: res };
+        ctx.response(rep_header)
+    }
 }
 
 impl MessageHandler for MasterHandler {
@@ -654,6 +668,7 @@ impl MessageHandler for MasterHandler {
             RpcCode::Free => self.retry_check_free(ctx),
             RpcCode::Rename => self.retry_check_rename(ctx),
             RpcCode::ListStatus => self.list_status(ctx),
+            RpcCode::ListOptions => self.list_options(ctx),
             RpcCode::GetBlockLocations => self.get_block_locations(ctx),
             RpcCode::SetAttr => self.set_attr_retry_check(ctx),
             RpcCode::Symlink => self.symlink_retry_check(ctx),

--- a/curvine-server/src/master/meta/fs_dir.rs
+++ b/curvine-server/src/master/meta/fs_dir.rs
@@ -24,7 +24,7 @@ use curvine_common::conf::ClusterConf;
 use curvine_common::error::FsError;
 use curvine_common::state::{
     BlockLocation, CommitBlock, CreateFileOpts, ExtendedBlock, FileAllocOpts, FileLock, FileStatus,
-    FreeResult, MkdirOpts, MountInfo, RenameFlags, SetAttrOpts, WorkerAddress,
+    FreeResult, ListOptions, MkdirOpts, MountInfo, RenameFlags, SetAttrOpts, WorkerAddress,
 };
 use curvine_common::FsResult;
 use log::{debug, info, warn};
@@ -481,6 +481,50 @@ impl FsDir {
         }
 
         Ok(res)
+    }
+
+    pub fn list_options(&self, inp: &InodePath, opts: &ListOptions) -> FsResult<Vec<FileStatus>> {
+        let inode = match inp.get_last_inode() {
+            Some(v) => v,
+            None => return err_box!("File {} not exists", inp.path()),
+        };
+
+        match inode.as_ref() {
+            File(_, _) => Ok(vec![inode.to_file_status(inp.path())]),
+
+            Dir(_, d) => {
+                let children = d.list_options(opts);
+                let mut res = Vec::with_capacity(children.len());
+
+                for item in children {
+                    let child_path = inp.child_path(item.name());
+
+                    match item {
+                        File(..) | Dir(..) => res.push(item.to_file_status(&child_path)),
+
+                        FileEntry(name, id) => {
+                            let inode_opt = self.store.get_inode(*id, Some(name))?;
+                            if let Some(inode_view) = inode_opt {
+                                res.push(inode_view.to_file_status(&child_path));
+                            } else {
+                                // Underlying inode is missing; skip this stale entry to match
+                                // list_status semantics.
+                                continue;
+                            }
+                        }
+                    }
+                }
+                Ok(res)
+            }
+
+            FileEntry(name, id) => {
+                let inode_opt = self.store.get_inode(*id, Some(name))?;
+                match inode_opt {
+                    Some(inode_view) => Ok(vec![inode_view.to_file_status(inp.path())]),
+                    None => err_box!("File {} not exists", inp.path()),
+                }
+            }
+        }
     }
 
     pub fn acquire_new_block(

--- a/curvine-server/src/master/meta/inode/inode_dir.rs
+++ b/curvine-server/src/master/meta/inode/inode_dir.rs
@@ -18,7 +18,7 @@ use crate::master::meta::inode::InodeView::{Dir, File};
 use crate::master::meta::inode::{
     ChildrenIter, Inode, InodeFile, InodePtr, InodeView, EMPTY_PARENT_ID,
 };
-use curvine_common::state::{MkdirOpts, StoragePolicy};
+use curvine_common::state::{ListOptions, MkdirOpts, StoragePolicy};
 use glob::Pattern;
 use orpc::CommonResult;
 use serde::{Deserialize, Serialize};
@@ -114,6 +114,10 @@ impl InodeDir {
 
     pub fn children_iter(&self) -> ChildrenIter<'_> {
         self.children.iter()
+    }
+
+    pub fn list_options(&self, options: &ListOptions) -> Vec<&InodeView> {
+        self.children.list_options(options)
     }
 
     pub fn children_vec(&self) -> Vec<InodeView> {

--- a/curvine-server/src/master/meta/inode/inodes_children.rs
+++ b/curvine-server/src/master/meta/inode/inodes_children.rs
@@ -13,10 +13,12 @@
 // limitations under the License.
 
 use crate::master::meta::inode::{InodePtr, InodeView};
+use curvine_common::state::ListOptions;
 use glob::Pattern;
 use orpc::{err_box, CommonResult};
 use std::collections::btree_map::{Entry, Values};
 use std::collections::BTreeMap;
+use std::ops::Bound;
 use std::slice::Iter;
 use std::vec;
 
@@ -119,6 +121,33 @@ impl InodeChildren {
                 } else {
                     Ok(*r)
                 }
+            }
+        }
+    }
+
+    pub fn list_options(&self, opts: &ListOptions) -> Vec<&InodeView> {
+        match self {
+            InodeChildren::List(list) => {
+                let start = opts
+                    .start_after
+                    .as_ref()
+                    .map(|a| match Self::search_by_name(list, a) {
+                        Ok(i) => i + 1,
+                        Err(i) => i,
+                    })
+                    .unwrap_or(0);
+                let slice = &list[start..];
+                let n = opts.limit.unwrap_or(slice.len());
+                slice.iter().take(n).map(|b| b.as_ref()).collect()
+            }
+
+            InodeChildren::Map(map) => {
+                let range = opts.start_after.as_ref().map_or(
+                    map.range::<str, _>((Bound::Unbounded, Bound::Unbounded)),
+                    |a| map.range::<str, _>((Bound::Excluded(a.as_str()), Bound::Unbounded)),
+                );
+                let n = opts.limit.unwrap_or(usize::MAX);
+                range.take(n).map(|(_, v)| v.as_ref()).collect()
             }
         }
     }


### PR DESCRIPTION

## Summary

- Define and expose filesystem-level `list_stream` and `list_options` interfaces for paginated directory listing.
- Implement server-side `list_options` handling from RPC entry to metadata directory/inode traversal.
- Add pagination semantics (`limit`, `start_after`) and related proto/model conversion support.
- Wire client/unified forwarding so list options requests flow consistently across filesystem backends.

## What is implemented

- **Interface layer**
  - Add `list_options` contract for page-based listing.
  - Add `list_stream` contract for stream-based iteration built on list options semantics.
- **Server layer**
  - Implement master RPC handling for `list_options`.
  - Implement metadata-side listing logic to return ordered, paginated children.
- **Protocol/model layer**
  - Extend proto/state conversion for list options fields (`limit`, `start_after`).

## Why

Large directory listings need predictable pagination and streaming behavior. This change establishes a single contract at the filesystem interface and provides concrete server-side `list_options` behavior to support scalable listing.
