### PR TITLE
feat(fs): add list stream interface and protocol support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -831,6 +831,7 @@ dependencies = [
 name = "curvine-client"
 version = "0.2.0"
 dependencies = [
+ "async-stream",
  "bytes",
  "curvine-common",
  "curvine-tracing-appender",
@@ -859,6 +860,7 @@ name = "curvine-common"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "async-stream",
  "axum 0.7.9",
  "bincode",
  "bitflags 2.10.0",
@@ -869,6 +871,7 @@ dependencies = [
  "crossbeam",
  "dashmap",
  "flate2",
+ "futures",
  "hyper 1.7.0",
  "indexmap 2.11.0",
  "linked-hash-map",
@@ -908,6 +911,7 @@ dependencies = [
  "curvine-common",
  "curvine-tracing-appender",
  "dashmap",
+ "futures",
  "fxhash",
  "libc",
  "log",
@@ -1051,6 +1055,7 @@ dependencies = [
  "curvine-server",
  "curvine-tracing-appender",
  "curvine-ufs",
+ "futures",
  "log",
  "once_cell",
  "orpc",
@@ -1077,6 +1082,7 @@ name = "curvine-ufs"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "async-stream",
  "async-trait",
  "bytes",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ curvine-s3-gateway = { path = "curvine-s3-gateway" }
 libc = "0.2.167"
 tokio = { version = "1.42.0", features = ["full"] }
 futures = "0.3.31"
+async-stream = "0.3.6"
 tokio-util = { version = "0.7.12", features = ["full"] }
 bytes = "1.9.0"
 serde = { version = "1.0.215", features = ["derive"] }

--- a/curvine-client/Cargo.toml
+++ b/curvine-client/Cargo.toml
@@ -24,6 +24,7 @@ pin-project-lite = { workspace = true }
 serde_json = { workspace = true }
 dashmap = { workspace = true }
 futures = { workspace = true }
+async-stream = { workspace = true }
 moka = { workspace = true }
 fxhash = { workspace = true }
 prometheus = { workspace = true }

--- a/curvine-client/src/unified/macros.rs
+++ b/curvine-client/src/unified/macros.rs
@@ -470,6 +470,32 @@ macro_rules! impl_filesystem_for_enum {
                 }
             }
 
+            async fn list_options(
+                &self,
+                path: &::curvine_common::fs::Path,
+                opts: ::curvine_common::state::ListOptions,
+            ) -> ::curvine_common::FsResult<Vec<::curvine_common::state::FileStatus>> {
+                match self {
+                    $(
+                        $(#[$cfg])*
+                        Self::$variant(inner) => inner.list_options(path, opts).await,
+                    )+
+                }
+            }
+
+            async fn list_stream(
+                &self,
+                path: &::curvine_common::fs::Path,
+                opts: ::curvine_common::state::ListOptions,
+            ) -> ::curvine_common::FsResult<::curvine_common::fs::ListStream> {
+                match self {
+                    $(
+                        $(#[$cfg])*
+                        Self::$variant(inner) => inner.list_stream(path, opts).await,
+                    )+
+                }
+            }
+
             async fn set_attr(
                 &self,
                 path: &::curvine_common::fs::Path,

--- a/curvine-common/Cargo.toml
+++ b/curvine-common/Cargo.toml
@@ -9,6 +9,8 @@ license.workspace = true
 [dependencies]
 orpc = { workspace = true }
 tokio = { workspace = true }
+futures = { workspace = true }
+async-stream =  { workspace = true }
 tokio-util = { workspace = true }
 log = { workspace = true }
 raft = { workspace = true }

--- a/curvine-common/proto/common.proto
+++ b/curvine-common/proto/common.proto
@@ -201,3 +201,7 @@ message FreeResultProto {
     required int64 bytes = 3;
 }
 
+message ListOptionsProto {
+    optional int32 limit = 1;
+    optional string start_after = 2;
+}

--- a/curvine-common/proto/master.proto
+++ b/curvine-common/proto/master.proto
@@ -331,3 +331,12 @@ message SetLockRequest {
 message SetLockResponse {
     optional FileLockProto conflict = 1;
 }
+
+message ListOptionsRequest {
+    required string path = 1;
+    required ListOptionsProto options = 2;
+}
+
+message ListOptionsResponse {
+    repeated FileStatusProto statuses = 1;
+}

--- a/curvine-common/src/fs/filesystem.rs
+++ b/curvine-common/src/fs/filesystem.rs
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::fs::{FsKind, Path};
-use crate::proto::{GetFileStatusResponse, ListStatusResponse};
-use crate::state::{FileStatus, SetAttrOpts};
+use crate::fs::{FsKind, ListStream, Path};
+use crate::proto::{GetFileStatusResponse, ListOptionsResponse, ListStatusResponse};
+use crate::state::{FileStatus, ListOptions, SetAttrOpts};
 use crate::utils::ProtoUtils;
 use crate::FsResult;
+use orpc::err_box;
 use prost::bytes::BytesMut;
 use std::future::Future;
 
@@ -65,4 +66,38 @@ pub trait FileSystem<Writer, Reader> {
     }
 
     fn set_attr(&self, path: &Path, opts: SetAttrOpts) -> impl Future<Output = FsResult<()>>;
+
+    fn list_options(
+        &self,
+        _path: &Path,
+        _opts: ListOptions,
+    ) -> impl Future<Output = FsResult<Vec<FileStatus>>> + Send {
+        async move { err_box!("not supported list_options") }
+    }
+
+    fn list_options_bytes(
+        &self,
+        path: &Path,
+        opts: ListOptions,
+    ) -> impl Future<Output = FsResult<BytesMut>> {
+        async move {
+            let statuses = self
+                .list_options(path, opts)
+                .await?
+                .into_iter()
+                .map(ProtoUtils::file_status_to_pb)
+                .collect();
+
+            let rep = ListOptionsResponse { statuses };
+            Ok(ProtoUtils::encode(rep)?)
+        }
+    }
+
+    fn list_stream(
+        &self,
+        _path: &Path,
+        _options: ListOptions,
+    ) -> impl Future<Output = FsResult<ListStream>> {
+        async move { err_box!("not supported list_stream") }
+    }
 }

--- a/curvine-common/src/fs/list_stream.rs
+++ b/curvine-common/src/fs/list_stream.rs
@@ -1,0 +1,60 @@
+//  Copyright 2025 OPPO.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+use std::pin::Pin;
+
+use crate::state::FileStatus;
+use crate::FsResult;
+use futures::stream::{self, Stream, StreamExt};
+
+pub struct ListStream {
+    inner: Pin<Box<dyn Stream<Item = FsResult<FileStatus>> + Send + 'static>>,
+}
+
+impl ListStream {
+    pub fn new(inner: impl Stream<Item = FsResult<FileStatus>> + Send + 'static) -> Self {
+        ListStream {
+            inner: Box::pin(inner),
+        }
+    }
+
+    pub fn from_vec(list: Vec<FileStatus>) -> Self {
+        Self::new(stream::iter(list.into_iter().map(Ok)))
+    }
+
+    pub async fn collect(&mut self) -> FsResult<Vec<FileStatus>> {
+        let mut vec = Vec::new();
+        while let Some(item) = self.next().await {
+            vec.push(item?);
+        }
+        Ok(vec)
+    }
+}
+
+impl From<Vec<FileStatus>> for ListStream {
+    fn from(list: Vec<FileStatus>) -> Self {
+        Self::from_vec(list)
+    }
+}
+
+impl Stream for ListStream {
+    type Item = FsResult<FileStatus>;
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        self.inner.as_mut().poll_next(cx)
+    }
+}

--- a/curvine-common/src/fs/mod.rs
+++ b/curvine-common/src/fs/mod.rs
@@ -36,5 +36,8 @@ pub use self::meta_cache::MetaCache;
 mod state_file;
 pub use self::state_file::*;
 
+mod list_stream;
+pub use self::list_stream::ListStream;
+
 // CurvineURI is used in the Curvine system to describe paths, including external storage
 pub type CurvineURI = Path;

--- a/curvine-common/src/state/opts.rs
+++ b/curvine-common/src/state/opts.rs
@@ -509,3 +509,25 @@ impl SetAttrOptsBuilder {
         }
     }
 }
+
+#[derive(Debug, Clone, Default)]
+pub struct ListOptions {
+    pub limit: Option<usize>,
+    pub start_after: Option<String>,
+}
+
+impl ListOptions {
+    pub fn from_status(limit: usize, status: &FileStatus) -> Self {
+        Self {
+            limit: Some(limit),
+            start_after: Some(status.name.to_owned()),
+        }
+    }
+
+    pub fn with_limit(limit: usize) -> Self {
+        Self {
+            limit: Some(limit),
+            start_after: None,
+        }
+    }
+}

--- a/curvine-common/src/utils/proto_utils.rs
+++ b/curvine-common/src/utils/proto_utils.rs
@@ -526,6 +526,20 @@ impl ProtoUtils {
         }
     }
 
+    pub fn list_options_from_pb(opts: ListOptionsProto) -> ListOptions {
+        ListOptions {
+            limit: opts.limit.map(|v| v as usize),
+            start_after: opts.start_after,
+        }
+    }
+
+    pub fn list_options_to_pb(opts: ListOptions) -> ListOptionsProto {
+        ListOptionsProto {
+            limit: opts.limit.map(|v| v as i32),
+            start_after: opts.start_after,
+        }
+    }
+
     pub fn mount_info_to_pb(info: MountInfo) -> MountInfoProto {
         MountInfoProto {
             cv_path: info.cv_path,


### PR DESCRIPTION
### Summary
- Add a new `ListStream` abstraction in `curvine-common` for streaming file list results.
- Extend protobuf definitions and utility conversions to support list-stream related fields.
- Update client/common integration points (macros, modules, and options) to consume the new interface.
- Refresh workspace dependency manifests/lockfile for the new additions.

### Why
This change establishes a dedicated stream-based listing contract, reducing coupling between listing producers and consumers and preparing the codebase for consistent, paginated, and extensible unified listing behavior.