### PR TITLE
feat(master): implement ListOptions RPC and directory listing (#737)

### DIFF
--- a/curvine-common/src/fs/rpc_code.rs
+++ b/curvine-common/src/fs/rpc_code.rs
@@ -48,6 +48,7 @@ pub enum RpcCode {
     AddBlocksBatch = 24,
     CompleteFilesBatch = 25,
     Free = 26,
+    ListOptions = 27,
 
     // manager interface.
     Mount = 30,

--- a/curvine-common/src/state/opts.rs
+++ b/curvine-common/src/state/opts.rs
@@ -18,6 +18,7 @@ use orpc::common::ByteUnit;
 use orpc::sys;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::fmt;
 
 #[derive(Debug, Clone)]
 pub struct CreateFileOpts {
@@ -528,6 +529,17 @@ impl ListOptions {
         Self {
             limit: Some(limit),
             start_after: None,
+        }
+    }
+}
+
+impl fmt::Display for ListOptions {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match (&self.limit, &self.start_after) {
+            (Some(l), Some(s)) => write!(f, "{}-{}", l, s),
+            (Some(l), None) => write!(f, "{}-none", l),
+            (None, Some(s)) => write!(f, "none-{}", s),
+            (None, None) => Ok(()),
         }
     }
 }

--- a/curvine-server/src/master/fs/master_filesystem.rs
+++ b/curvine-server/src/master/fs/master_filesystem.rs
@@ -353,6 +353,22 @@ impl MasterFilesystem {
         }
     }
 
+    pub fn list_options<T: AsRef<str>>(
+        &self,
+        path: T,
+        opts: ListOptions,
+    ) -> FsResult<Vec<FileStatus>> {
+        let path = path.as_ref();
+        let fs_dir = self.fs_dir.read();
+        let (is_glob_pattern, _) = parse_glob_pattern(path);
+        if is_glob_pattern {
+            err_box!("list_options does not support glob pattern, path {}", path)
+        } else {
+            let inp = Self::resolve_path(&fs_dir, path)?;
+            fs_dir.list_options(&inp, &opts)
+        }
+    }
+
     fn resolve_path(fs_dir: &FsDir, path: &str) -> CommonResult<InodePath> {
         InodePath::resolve(fs_dir.root_ptr(), path, &fs_dir.store)
     }

--- a/curvine-server/src/master/master_handler.rs
+++ b/curvine-server/src/master/master_handler.rs
@@ -614,6 +614,24 @@ impl MasterHandler {
         };
         ctx.response(rep_header)
     }
+
+    pub fn list_options(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+        let header: ListOptionsRequest = ctx.parse_header()?;
+        if header.options.limit.unwrap_or(0) < 0 {
+            return err_box!("list options limit must be greater than 0");
+        }
+        let opts = ProtoUtils::list_options_from_pb(header.options);
+        let audit_path = format!("{}[{}]", header.path, opts);
+        ctx.set_audit(Some(audit_path), None);
+
+        let list = self.fs.list_options(&header.path, opts)?;
+        let res = list
+            .into_iter()
+            .map(ProtoUtils::file_status_to_pb)
+            .collect();
+        let rep_header = ListOptionsResponse { statuses: res };
+        ctx.response(rep_header)
+    }
 }
 
 impl MessageHandler for MasterHandler {
@@ -654,6 +672,7 @@ impl MessageHandler for MasterHandler {
             RpcCode::Free => self.retry_check_free(ctx),
             RpcCode::Rename => self.retry_check_rename(ctx),
             RpcCode::ListStatus => self.list_status(ctx),
+            RpcCode::ListOptions => self.list_options(ctx),
             RpcCode::GetBlockLocations => self.get_block_locations(ctx),
             RpcCode::SetAttr => self.set_attr_retry_check(ctx),
             RpcCode::Symlink => self.symlink_retry_check(ctx),

--- a/curvine-server/src/master/meta/fs_dir.rs
+++ b/curvine-server/src/master/meta/fs_dir.rs
@@ -24,7 +24,7 @@ use curvine_common::conf::ClusterConf;
 use curvine_common::error::FsError;
 use curvine_common::state::{
     BlockLocation, CommitBlock, CreateFileOpts, ExtendedBlock, FileAllocOpts, FileLock, FileStatus,
-    FreeResult, MkdirOpts, MountInfo, RenameFlags, SetAttrOpts, WorkerAddress,
+    FreeResult, ListOptions, MkdirOpts, MountInfo, RenameFlags, SetAttrOpts, WorkerAddress,
 };
 use curvine_common::FsResult;
 use log::{debug, info, warn};
@@ -481,6 +481,46 @@ impl FsDir {
         }
 
         Ok(res)
+    }
+
+    pub fn list_options(&self, inp: &InodePath, opts: &ListOptions) -> FsResult<Vec<FileStatus>> {
+        let inode = match inp.get_last_inode() {
+            Some(v) => v,
+            None => return err_box!("File {} not exists", inp.path()),
+        };
+
+        match inode.as_ref() {
+            File(_, _) => Ok(vec![inode.to_file_status(inp.path())]),
+
+            Dir(_, d) => {
+                let children = d.list_options(opts);
+                let mut res = Vec::with_capacity(children.len());
+
+                for item in children {
+                    let child_path = inp.child_path(item.name());
+
+                    match item {
+                        File(..) | Dir(..) => res.push(item.to_file_status(&child_path)),
+
+                        FileEntry(name, id) => {
+                            let inode_opt = self.store.get_inode(*id, Some(name))?;
+                            if let Some(inode_view) = inode_opt {
+                                res.push(inode_view.to_file_status(&child_path));
+                            }
+                        }
+                    }
+                }
+                Ok(res)
+            }
+
+            FileEntry(name, id) => {
+                let inode_opt = self.store.get_inode(*id, Some(name))?;
+                match inode_opt {
+                    Some(inode_view) => Ok(vec![inode_view.to_file_status(inp.path())]),
+                    None => err_box!("File {} not exists", inp.path()),
+                }
+            }
+        }
     }
 
     pub fn acquire_new_block(

--- a/curvine-server/src/master/meta/inode/inode_dir.rs
+++ b/curvine-server/src/master/meta/inode/inode_dir.rs
@@ -18,7 +18,7 @@ use crate::master::meta::inode::InodeView::{Dir, File};
 use crate::master::meta::inode::{
     ChildrenIter, Inode, InodeFile, InodePtr, InodeView, EMPTY_PARENT_ID,
 };
-use curvine_common::state::{MkdirOpts, StoragePolicy};
+use curvine_common::state::{ListOptions, MkdirOpts, StoragePolicy};
 use glob::Pattern;
 use orpc::CommonResult;
 use serde::{Deserialize, Serialize};
@@ -114,6 +114,10 @@ impl InodeDir {
 
     pub fn children_iter(&self) -> ChildrenIter<'_> {
         self.children.iter()
+    }
+
+    pub fn list_options(&self, options: &ListOptions) -> Vec<&InodeView> {
+        self.children.list_options(options)
     }
 
     pub fn children_vec(&self) -> Vec<InodeView> {

--- a/curvine-server/src/master/meta/inode/inodes_children.rs
+++ b/curvine-server/src/master/meta/inode/inodes_children.rs
@@ -13,10 +13,12 @@
 // limitations under the License.
 
 use crate::master::meta::inode::{InodePtr, InodeView};
+use curvine_common::state::ListOptions;
 use glob::Pattern;
 use orpc::{err_box, CommonResult};
 use std::collections::btree_map::{Entry, Values};
 use std::collections::BTreeMap;
+use std::ops::Bound;
 use std::slice::Iter;
 use std::vec;
 
@@ -119,6 +121,33 @@ impl InodeChildren {
                 } else {
                     Ok(*r)
                 }
+            }
+        }
+    }
+
+    pub fn list_options(&self, opts: &ListOptions) -> Vec<&InodeView> {
+        match self {
+            InodeChildren::List(list) => {
+                let start = opts
+                    .start_after
+                    .as_ref()
+                    .map(|a| match Self::search_by_name(list, a) {
+                        Ok(i) => i + 1,
+                        Err(i) => i,
+                    })
+                    .unwrap_or(0);
+                let slice = &list[start..];
+                let n = opts.limit.unwrap_or(slice.len());
+                slice.iter().take(n).map(|b| b.as_ref()).collect()
+            }
+
+            InodeChildren::Map(map) => {
+                let range = opts.start_after.as_ref().map_or(
+                    map.range::<str, _>((Bound::Unbounded, Bound::Unbounded)),
+                    |a| map.range::<str, _>((Bound::Excluded(a.as_str()), Bound::Unbounded)),
+                );
+                let n = opts.limit.unwrap_or(usize::MAX);
+                range.take(n).map(|(_, v)| v.as_ref()).collect()
             }
         }
     }


### PR DESCRIPTION
### Summary

- Introduce **`RpcCode::ListOptions`** and handle it in **`MasterHandler`**, returning protobuf file statuses from **`ListOptionsRequest` / `ListOptionsResponse`**.
- Add **`MasterFilesystem::list_options`**: resolves the path, rejects **glob patterns**, and delegates to **`FsDir::list_options`**.
- Implement **`FsDir::list_options`**: for files, directories, and lazy **`FileEntry`** inodes, builds **`FileStatus`** results with correct child paths.
- Add **`InodeDir::list_options`** and **`InodeChildren::list_options`**: apply **`ListOptions`** (**`start_after`**, **`limit`**) for both **`List`** and **`Map`** child storage layouts.

### Motivation

Clients need a server-side listing path that supports **cursor-style continuation** (`start_after`) and **bounded page size** (`limit`), aligned with unified list/stream options, without loading entire directories in one shot when a limit is set.

### Behavior notes

- **Glob paths** are rejected at `list_options` on the master filesystem layer (clear error instead of ambiguous semantics).
- **`limit: None`** means “no explicit cap” in the list-backed branch (take up to remaining slice length); map-backed branch uses an unbounded upper range bound with a practical take cap.
