### PR TITLE
feat(client): add ListOptions RPC, list_stream, and FileSystem wiring

### DIFF
--- a/curvine-client/src/file/curvine_filesystem.rs
+++ b/curvine-client/src/file/curvine_filesystem.rs
@@ -15,11 +15,12 @@
 use crate::block::BatchBlockWriter;
 use crate::file::{FsClient, FsContext, FsReader, FsWriter, FsWriterBase};
 use crate::ClientMetrics;
+use async_stream::stream;
 use bytes::BytesMut;
 use curvine_common::conf::ClusterConf;
 use curvine_common::error::FsError;
-use curvine_common::fs::{Path, Reader, Writer};
-use curvine_common::state::{CommitBlock, FreeResult};
+use curvine_common::fs::{FileSystem, FsKind, ListStream, Path, Reader, Writer};
+use curvine_common::state::{CommitBlock, FreeResult, ListOptions};
 use curvine_common::state::{
     CreateFileOpts, CreateFileOptsBuilder, FileAllocOpts, FileBlocks, FileLock, FileStatus,
     MasterInfo, MkdirOpts, MkdirOptsBuilder, MountInfo, MountOptions, OpenFlags, SetAttrOpts,
@@ -193,6 +194,55 @@ impl CurvineFileSystem {
 
     pub async fn list_status_bytes(&self, path: &Path) -> FsResult<BytesMut> {
         self.fs_client.list_status_bytes(path).await
+    }
+
+    pub async fn list_options(&self, path: &Path, opts: ListOptions) -> FsResult<Vec<FileStatus>> {
+        self.fs_client.list_options(path, opts).await
+    }
+
+    pub async fn list_stream(&self, path: &Path, options: ListOptions) -> FsResult<ListStream> {
+        let fs = self.clone();
+        let path = path.clone();
+        let (limit, mut start_after) = (options.limit, options.start_after);
+
+        let stream = stream! {
+            loop {
+                let options = ListOptions {
+                    limit,
+                    start_after: start_after.clone(),
+                };
+                let list = match fs.list_options(&path, options).await {
+                    Ok(p) => p,
+                    Err(e) => {
+                        yield Err(e);
+                        break;
+                    }
+                };
+
+                if list.is_empty() {
+                    break;
+                }
+
+                let n = list.len();
+                let last_name = list.last().map(|s| s.name.clone());
+                for status in list {
+                    yield Ok(status);
+                }
+
+                if let Some(l) = limit {
+                    if n < l {
+                        break;
+                    }
+                }
+                start_after = last_name;
+            }
+        };
+
+        Ok(ListStream::new(stream))
+    }
+
+    pub async fn list_options_bytes(&self, path: &Path, opts: ListOptions) -> FsResult<BytesMut> {
+        self.fs_client.list_options_bytes(path, opts).await
     }
 
     pub async fn list_files(&self, path: &Path) -> FsResult<Vec<FileStatus>> {
@@ -423,5 +473,72 @@ impl CurvineFileSystem {
             .complete_files_batch(complete_requests)
             .await?;
         Ok(())
+    }
+}
+
+impl FileSystem<FsWriter, FsReader> for CurvineFileSystem {
+    fn fs_kind(&self) -> FsKind {
+        FsKind::Cv
+    }
+
+    async fn mkdir(&self, path: &Path, create_parent: bool) -> FsResult<bool> {
+        self.mkdir(path, create_parent).await
+    }
+
+    async fn create(&self, path: &Path, overwrite: bool) -> FsResult<FsWriter> {
+        self.create(path, overwrite).await
+    }
+
+    async fn append(&self, path: &Path) -> FsResult<FsWriter> {
+        self.append(path).await
+    }
+
+    async fn exists(&self, path: &Path) -> FsResult<bool> {
+        self.exists(path).await
+    }
+
+    async fn open(&self, path: &Path) -> FsResult<FsReader> {
+        self.open(path).await
+    }
+
+    async fn rename(&self, src: &Path, dst: &Path) -> FsResult<bool> {
+        self.rename(src, dst).await
+    }
+
+    async fn delete(&self, path: &Path, recursive: bool) -> FsResult<()> {
+        self.delete(path, recursive).await
+    }
+
+    async fn get_status(&self, path: &Path) -> FsResult<FileStatus> {
+        self.get_status(path).await
+    }
+
+    async fn get_status_bytes(&self, path: &Path) -> FsResult<BytesMut> {
+        self.get_status_bytes(path).await
+    }
+
+    async fn list_status(&self, path: &Path) -> FsResult<Vec<FileStatus>> {
+        self.list_status(path).await
+    }
+
+    async fn list_status_bytes(&self, path: &Path) -> FsResult<BytesMut> {
+        self.list_status_bytes(path).await
+    }
+
+    async fn set_attr(&self, path: &Path, opts: SetAttrOpts) -> FsResult<()> {
+        self.set_attr(path, opts).await?;
+        Ok(())
+    }
+
+    async fn list_options(&self, path: &Path, opts: ListOptions) -> FsResult<Vec<FileStatus>> {
+        self.list_options(path, opts).await
+    }
+
+    async fn list_options_bytes(&self, path: &Path, opts: ListOptions) -> FsResult<BytesMut> {
+        self.list_options_bytes(path, opts).await
+    }
+
+    async fn list_stream(&self, path: &Path, opts: ListOptions) -> FsResult<ListStream> {
+        self.list_stream(path, opts).await
     }
 }

--- a/curvine-client/src/file/fs_client.rs
+++ b/curvine-client/src/file/fs_client.rs
@@ -207,6 +207,40 @@ impl FsClient {
         Ok(res)
     }
 
+    pub async fn list_options(
+        &self,
+        path: &Path,
+        options: ListOptions,
+    ) -> FsResult<Vec<FileStatus>> {
+        let header = ListOptionsRequest {
+            path: path.encode(),
+            options: ProtoUtils::list_options_to_pb(options),
+        };
+
+        let rep_header: ListOptionsResponse = self.rpc(RpcCode::ListOptions, header).await?;
+
+        let res = rep_header
+            .statuses
+            .into_iter()
+            .map(ProtoUtils::file_status_from_pb)
+            .collect();
+
+        Ok(res)
+    }
+
+    pub async fn list_options_bytes(
+        &self,
+        path: &Path,
+        options: ListOptions,
+    ) -> FsResult<BytesMut> {
+        let header = ListOptionsRequest {
+            path: path.encode(),
+            options: ProtoUtils::list_options_to_pb(options),
+        };
+
+        self.rpc_bytes(RpcCode::ListOptions, header).await
+    }
+
     pub async fn list_status_bytes(&self, path: &Path) -> FsResult<BytesMut> {
         let header = ListStatusRequest {
             path: path.encode(),

--- a/curvine-client/src/unified/unified_filesystem.rs
+++ b/curvine-client/src/unified/unified_filesystem.rs
@@ -19,10 +19,11 @@ use crate::ClientMetrics;
 use bytes::BytesMut;
 use curvine_common::conf::ClusterConf;
 use curvine_common::error::FsError;
-use curvine_common::fs::{FileSystem, FsKind, Path, Reader, Writer};
+use curvine_common::fs::{FileSystem, FsKind, ListStream, Path, Reader, Writer};
 use curvine_common::state::{
-    CreateFileOpts, FileAllocOpts, FileLock, FileStatus, FreeResult, JobStatus, LoadJobCommand,
-    MasterInfo, MkdirOpts, MkdirOptsBuilder, MountInfo, MountOptions, OpenFlags, SetAttrOpts,
+    CreateFileOpts, FileAllocOpts, FileLock, FileStatus, FreeResult, JobStatus, ListOptions,
+    LoadJobCommand, MasterInfo, MkdirOpts, MkdirOptsBuilder, MountInfo, MountOptions, OpenFlags,
+    SetAttrOpts,
 };
 use curvine_common::utils::CommonUtils;
 use curvine_common::FsResult;
@@ -663,6 +664,37 @@ impl FileSystem<UnifiedWriter, UnifiedReader> for UnifiedFileSystem {
         match self.get_mount_checked(path).await? {
             None => self.cv.list_status_bytes(path).await,
             Some((ufs_path, mount)) => mount.ufs.list_status_bytes(&ufs_path).await,
+        }
+    }
+
+    async fn list_options(&self, path: &Path, options: ListOptions) -> FsResult<Vec<FileStatus>> {
+        let _timer = TimeSpent::timer_counter_vec(
+            Arc::new(FsContext::get_metrics().metadata_operation_duration.clone()),
+            vec!["list_options".to_string()],
+        );
+
+        match self.get_mount_checked(path).await? {
+            None => self.cv.list_options(path, options).await,
+            Some((ufs_path, mount)) => mount.ufs.list_options(&ufs_path, options).await,
+        }
+    }
+
+    async fn list_options_bytes(&self, path: &Path, options: ListOptions) -> FsResult<BytesMut> {
+        let _timer = TimeSpent::timer_counter_vec(
+            Arc::new(FsContext::get_metrics().metadata_operation_duration.clone()),
+            vec!["list_options".to_string()],
+        );
+
+        match self.get_mount_checked(path).await? {
+            None => self.cv.list_options_bytes(path, options).await,
+            Some((ufs_path, mount)) => mount.ufs.list_options_bytes(&ufs_path, options).await,
+        }
+    }
+
+    async fn list_stream(&self, path: &Path, options: ListOptions) -> FsResult<ListStream> {
+        match self.get_mount_checked(path).await? {
+            None => self.cv.list_stream(path, options).await,
+            Some((ufs_path, mount)) => mount.ufs.list_stream(&ufs_path, options).await,
         }
     }
 

--- a/curvine-tests/Cargo.toml
+++ b/curvine-tests/Cargo.toml
@@ -24,6 +24,7 @@ once_cell = { workspace = true }
 clap = { workspace = true }
 awaitility = "0.4"
 tempfile = { workspace = true }
+futures = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 curvine-fuse = { workspace = true }

--- a/curvine-tests/tests/fs_test.rs
+++ b/curvine-tests/tests/fs_test.rs
@@ -18,11 +18,13 @@ use curvine_client::ClientMetrics;
 use curvine_common::conf::ClusterConf;
 use curvine_common::fs::{Path, Reader, Writer};
 use curvine_common::state::{
-    CreateFileOptsBuilder, MkdirOptsBuilder, SetAttrOptsBuilder, StorageState, TtlAction,
+    CreateFileOptsBuilder, ListOptions, MkdirOptsBuilder, SetAttrOptsBuilder, StorageState,
+    TtlAction,
 };
 use curvine_common::state::{FileLock, LockFlags, LockType};
 use curvine_common::FsResult;
 use curvine_tests::Testing;
+use futures::stream::StreamExt;
 use log::info;
 use orpc::common::LocalTime;
 use orpc::runtime::{AsyncRuntime, RpcRuntime};
@@ -1038,5 +1040,105 @@ fn sync_ufs_file() {
         assert_eq!(stats.len, ufs_len);
         assert_eq!(stats.storage_policy.ufs_mtime, ufs_mtime);
         assert_eq!(stats.storage_policy.state, StorageState::Ufs);
+    });
+}
+
+#[test]
+fn list_options() {
+    let testing = Testing::default();
+    let fs = testing.get_fs(None, None).unwrap();
+    fs.clone_runtime().block_on(async move {
+        for i in 0..5 {
+            let path = Path::from_str(format!("/fs_test/list_options/{}.log", i)).unwrap();
+            let _ = fs.create(&path, true).await.unwrap();
+        }
+
+        let dir = Path::from_str("/fs_test/list_options").unwrap();
+        let full = fs.list_status(&dir).await.unwrap();
+        assert_eq!(full.len(), 5, "full list should have 5 entries");
+
+        // limit only
+        let opts = ListOptions {
+            limit: Some(2),
+            start_after: None,
+        };
+        let list = fs.list_options(&dir, opts).await.unwrap();
+        assert_eq!(list.len(), 2, "limit=2 should return 2 entries");
+        assert_eq!(list[0].name, "0.log");
+        assert_eq!(list[1].name, "1.log");
+
+        // start_after only (exclusive)
+        let opts = ListOptions {
+            limit: None,
+            start_after: Some("1.log".to_string()),
+        };
+        let list = fs.list_options(&dir, opts).await.unwrap();
+        assert_eq!(
+            list.len(),
+            3,
+            "start_after 1.log should return 3 entries (2,3,4)"
+        );
+        assert_eq!(list[0].name, "2.log");
+        assert_eq!(list[1].name, "3.log");
+        assert_eq!(list[2].name, "4.log");
+
+        // limit + start_after
+        let opts = ListOptions {
+            limit: Some(2),
+            start_after: Some("1.log".to_string()),
+        };
+        let list = fs.list_options(&dir, opts).await.unwrap();
+        assert_eq!(list.len(), 2, "limit=2 after 1.log should return 2 entries");
+        assert_eq!(list[0].name, "2.log");
+        assert_eq!(list[1].name, "3.log");
+
+        // from_status style pagination: first page
+        let first = &full[0];
+        let opts = ListOptions::from_status(2, first);
+        let page1 = fs.list_options(&dir, opts).await.unwrap();
+        assert_eq!(page1.len(), 2);
+        assert_eq!(page1[0].name, "1.log");
+        assert_eq!(page1[1].name, "2.log");
+
+        // list_stream(page_size): assembles ListOptions per page until directory exhausted
+        let mut stream = fs
+            .list_stream(&dir, ListOptions::with_limit(2))
+            .await
+            .unwrap();
+        let mut names = Vec::new();
+        while let Some(item) = stream.next().await {
+            names.push(item.unwrap().name);
+        }
+        assert_eq!(
+            names,
+            vec![
+                "0.log".to_string(),
+                "1.log".to_string(),
+                "2.log".to_string(),
+                "3.log".to_string(),
+                "4.log".to_string(),
+            ]
+        );
+    });
+}
+
+#[test]
+fn list_stream_matches_list_options_empty_dir() {
+    let testing = Testing::default();
+    let fs = testing.get_fs(None, None).unwrap();
+    fs.clone_runtime().block_on(async move {
+        let dir = Path::from_str("/fs_test/list_stream_empty").unwrap();
+        let _ = fs.delete(&dir, true).await;
+        fs.mkdir(&dir, true).await.unwrap();
+
+        let opts = ListOptions::default();
+        let list = fs.list_options(&dir, opts).await.unwrap();
+        assert!(list.is_empty());
+
+        let mut stream = fs
+            .list_stream(&dir, ListOptions::with_limit(64))
+            .await
+            .unwrap();
+        assert!(stream.next().await.is_none());
     });
 }

--- a/curvine-tests/tests/ufs_test.rs
+++ b/curvine-tests/tests/ufs_test.rs
@@ -61,8 +61,9 @@
 
 use curvine_client::unified::UnifiedFileSystem;
 use curvine_common::fs::{FileSystem, Path, Reader, Writer};
-use curvine_common::state::{MountOptions, WriteType};
+use curvine_common::state::{ListOptions, MountOptions, WriteType};
 use curvine_tests::Testing;
+use futures::StreamExt;
 use orpc::runtime::{AsyncRuntime, RpcRuntime};
 use orpc::CommonResult;
 use std::collections::HashMap;
@@ -147,6 +148,7 @@ fn ufs_test() -> CommonResult<()> {
         test_exists(&fs, &config_clone).await?;
         test_get_status(&fs, &config_clone).await?;
         test_list_status(&fs, &config_clone).await?;
+        test_list_stream(&fs, &config_clone).await?;
 
         // 4. Test file write operations
         println!("\n=== Testing File Write Operations ===");
@@ -307,6 +309,67 @@ async fn test_list_status(fs: &UnifiedFileSystem, config: &TestConfig) -> Common
     let dir_names: Vec<&str> = statuses.iter().map(|s| s.name.as_str()).collect();
     assert!(dir_names.contains(&"dir1"), "dir1 should be in the list");
     assert!(dir_names.contains(&"dir2"), "dir2 should be in the list");
+
+    Ok(())
+}
+
+async fn test_list_stream(fs: &UnifiedFileSystem, config: &TestConfig) -> CommonResult<()> {
+    let base_dir = config.test_base_dir();
+
+    let nonempty: Path = format!("{}/ufs_list_stream_nonempty", base_dir).into();
+    if fs.exists(&nonempty).await? {
+        fs.delete(&nonempty, true).await?;
+    }
+    fs.mkdir(&nonempty, true).await?;
+    for i in 0..5 {
+        let path: Path = format!("{}/ufs_list_stream_nonempty/{}.log", base_dir, i).into();
+        let _ = fs.create(&path, true).await?;
+    }
+
+    let mut stream = fs
+        .list_stream(&nonempty, ListOptions::with_limit(2))
+        .await?;
+    let mut names = Vec::new();
+    while let Some(item) = stream.next().await {
+        names.push(item.unwrap().name);
+    }
+    assert_eq!(
+        names,
+        vec![
+            "0.log".to_string(),
+            "1.log".to_string(),
+            "2.log".to_string(),
+            "3.log".to_string(),
+            "4.log".to_string(),
+        ]
+    );
+    println!(
+        "✓ list_stream paged walk matches full list order under {}",
+        nonempty
+    );
+
+    // Empty directory
+    let empty_dir: Path = format!("{}/ufs_list_stream_empty", base_dir).into();
+    if fs.exists(&empty_dir).await? {
+        fs.delete(&empty_dir, true).await?;
+    }
+    fs.mkdir(&empty_dir, true).await?;
+    let opts = ListOptions::default();
+    assert!(fs
+        .list_stream(&empty_dir, opts)
+        .await?
+        .next()
+        .await
+        .is_none());
+
+    let mut lister = fs
+        .list_stream(&empty_dir, ListOptions::with_limit(2))
+        .await?;
+    assert!(lister.next().await.is_none());
+    println!(
+        "✓ list_stream on empty directory yields no items under {}",
+        empty_dir
+    );
 
     Ok(())
 }

--- a/curvine-ufs/src/opendal.rs
+++ b/curvine-ufs/src/opendal.rs
@@ -18,11 +18,12 @@ use crate::OssHdfsConf;
 use crate::{err_ufs, FOLDER_SUFFIX};
 use bytes::BytesMut;
 use curvine_common::error::FsError;
-use curvine_common::fs::{FileSystem, FsKind, Path, Reader, Writer};
-use curvine_common::state::{FileStatus, FileType, SetAttrOpts};
+use curvine_common::fs::{FileSystem, FsKind, ListStream, Path, Reader, Writer};
+use curvine_common::state::{FileStatus, FileType, ListOptions, SetAttrOpts};
 use curvine_common::FsResult;
+use futures::future::ready;
+use futures::stream::TryStreamExt;
 use futures::StreamExt;
-use opendal::options::ListOptions;
 use opendal::services::*;
 use opendal::{
     layers::{LoggingLayer, RetryLayer, TimeoutLayer},
@@ -845,7 +846,7 @@ impl FileSystem<OpendalWriter, OpendalReader> for OpendalFileSystem {
                     .await
                     .map_err(FsError::from_error)?;
             } else {
-                let opts = ListOptions {
+                let opts = opendal::options::ListOptions {
                     limit: Some(2),
                     ..Default::default()
                 };
@@ -917,5 +918,47 @@ impl FileSystem<OpendalWriter, OpendalReader> for OpendalFileSystem {
 
     async fn set_attr(&self, _path: &Path, _opts: SetAttrOpts) -> FsResult<()> {
         err_ufs!("SetAttr operation is not supported by OpenDAL file system")
+    }
+
+    async fn list_stream(&self, path: &Path, opts: ListOptions) -> FsResult<ListStream> {
+        let fs = self.clone();
+        let path = path.clone();
+        let dir_path = fs.get_dir_path(&path)?;
+        let opts = opendal::options::ListOptions {
+            limit: opts.limit,
+            start_after: opts.start_after.map(|x| format!("{}{}", dir_path, x)),
+            ..Default::default()
+        };
+
+        let lister = fs
+            .operator
+            .lister_options(&dir_path, opts)
+            .await
+            .map_err(FsError::from_error)?;
+
+        let stream = lister
+            .map_err(FsError::from_error)
+            .try_filter_map(move |entry| {
+                let raw_path = format!(
+                    "{}://{}/{}",
+                    fs.scheme,
+                    fs.bucket_or_container,
+                    entry.path().trim_end_matches('/')
+                );
+
+                let entry_path = match Path::from_str(raw_path) {
+                    Ok(v) => v,
+                    Err(e) => return ready(Err(FsError::from(e))),
+                };
+
+                if entry_path.path() == path.path() {
+                    ready(Ok(None))
+                } else {
+                    let metadata = entry.metadata();
+                    ready(Ok(Some(Self::read_status(&entry_path, metadata))))
+                }
+            });
+
+        Ok(ListStream::new(stream))
     }
 }


### PR DESCRIPTION
## PR description

### Summary

- **`FsClient` / `CurvineFileSystem`**
  - Add **`list_options`** and **`list_options_bytes`** using `RpcCode::ListOptions` with protobuf request/response conversion.
  - Add **`list_stream`**: async stream that repeatedly calls **`list_options`** with the same `limit`, advancing **`start_after`** from the last entry name until a short page or empty result ends iteration.
  - Implement **`FileSystem<FsWriter, FsReader>`** for **`CurvineFileSystem`** (including the new listing APIs) so the client matches the common **`FileSystem`** trait surface.

- **`UnifiedFileSystem`**
  - Implement **`list_options`**, **`list_options_bytes`**, and **`list_stream`**, dispatching to **`CurvineFileSystem`** or the mounted UFS backend according to path resolution (with metrics on the typed list paths).

- **`curvine-ufs` (`OpendalFileSystem`)**
  - Implement **`list_stream`** using OpenDAL **`lister_options`**, mapping `ListOptions` into OpenDAL list options (including `start_after` prefixed with the directory object path) and filtering out the synthetic “self” directory entry when it matches the listed path.

- **`curvine-common`**
  - Small adjustment in **`list_stream`** (supporting the new usage pattern).

- **Tests**
  - **`fs_test`**: coverage for **`list_options`** (`limit`, `start_after`, combined) and **`list_stream`** pagination vs full directory order; empty-directory **`list_stream`** behavior.
  - **`ufs_test`**: **`list_stream`** over unified UFS-backed paths (non-empty and empty dirs).

### Motivation

Expose **paginated directory listing** and a **streaming list API** consistently across Curvine (RPC), unified layout (mount-aware), and OpenDAL-backed UFS, so upper layers (e.g. FUSE, tests, tools) can use **`FileSystem::list_stream`** / **`list_options`** without ad hoc pagination logic.

### Test plan

- `cargo test -p curvine-tests --test fs_test` (or run the new list tests selectively).
- `cargo test -p curvine-tests --test ufs_test` (or run UFS list_stream coverage).
- `cargo check -p curvine-client -p curvine-ufs -p curvine-common`.
