### PR TITLE
feat(fuse): stream-based readdir, list_options fixes, and env defaults

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1082,7 +1082,6 @@ name = "curvine-ufs"
 version = "0.2.0"
 dependencies = [
  "anyhow",
- "async-stream",
  "async-trait",
  "bytes",
  "cc",

--- a/curvine-common/src/conf/cluster_conf.rs
+++ b/curvine-common/src/conf/cluster_conf.rs
@@ -69,6 +69,7 @@ impl ClusterConf {
     pub const DEFAULT_WORKER_PORT: u16 = 8997;
     pub const DEFAULT_MASTER_WEB_PORT: u16 = 9000;
     pub const DEFAULT_WORKER_WEB_PORT: u16 = 9001;
+    pub const DEFAULT_FUSE_WEB_PORT: u16 = 9002;
 
     pub const ENV_MASTER_HOSTNAME: &'static str = "CURVINE_MASTER_HOSTNAME";
     pub const ENV_WORKER_HOSTNAME: &'static str = "CURVINE_WORKER_HOSTNAME";

--- a/curvine-common/src/conf/fuse_conf.rs
+++ b/curvine-common/src/conf/fuse_conf.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::conf::ClusterConf;
 use orpc::common::{DurationUnit, FileUtils, LogConf, Utils};
 use orpc::sys::{CString, FFIUtils};
 use orpc::{err_box, sys, try_err, CommonResult};
@@ -151,6 +152,8 @@ pub struct FuseConf {
     #[serde(skip_serializing, skip_deserializing)]
     pub meta_cache_ttl_duration: Duration,
 
+    pub list_limit: usize,
+
     pub log: LogConf,
 }
 
@@ -288,7 +291,7 @@ impl Default for FuseConf {
             ac_attr_timeout: FuseConf::TTR_TIMEOUT,
             ac_attr_timeout_set: FuseConf::TTR_TIMEOUT,
             remember: false,
-            web_port: 9002,
+            web_port: ClusterConf::DEFAULT_FUSE_WEB_PORT,
 
             max_background: 256,
             congestion_threshold: 192,
@@ -314,6 +317,7 @@ impl Default for FuseConf {
             node_cache_ttl: Default::default(),
             meta_cache_ttl_duration: Default::default(),
 
+            list_limit: 1000,
             log: LogConf::default(),
         };
 

--- a/curvine-common/src/fs/list_stream.rs
+++ b/curvine-common/src/fs/list_stream.rs
@@ -33,7 +33,7 @@ impl ListStream {
         Self::new(stream::iter(list.into_iter().map(Ok)))
     }
 
-    pub async fn collect(&mut self) -> FsResult<Vec<FileStatus>> {
+    pub async fn collect_vec(&mut self) -> FsResult<Vec<FileStatus>> {
         let mut vec = Vec::new();
         while let Some(item) = self.next().await {
             vec.push(item?);

--- a/curvine-fuse/Cargo.toml
+++ b/curvine-fuse/Cargo.toml
@@ -32,6 +32,7 @@ tracing = { workspace = true }
 tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true }
 serde = { workspace = true }
+futures = { workspace = true }
 
 [features]
 default = ["fuse3"]

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -254,28 +254,32 @@ impl CurvineFileSystem {
     ) -> FuseResult<FuseDirentList> {
         let handle = self.state.find_dir_handle(header.nodeid, arg.fh)?;
 
-        let mut map = self.state.node_write();
         let mut res = FuseDirentList::new(arg);
-        for (index, status) in handle.get_list(arg.offset as usize) {
-            let attr = if status.name != FUSE_CURRENT_DIR && status.name != FUSE_PARENT_DIR {
-                if self.conf.enable_meta_cache {
-                    let path = Path::from_str(&status.path)?;
-                    self.state.meta_cache().put_status(&path, status.clone());
-                }
-                map.do_lookup(header.nodeid, Some(&status.name), status)?
-            } else {
-                Self::status_to_attr(&self.conf, status)?
-            };
-            let entry = Self::create_entry_out(&self.conf, attr);
+        let mut index = arg.offset;
+        let mut batch = handle.get_batch(arg.offset as usize).await?;
+        {
+            let mut map = self.state.node_write();
+            while let Some(status) = batch.pop_front() {
+                let attr = if status.name != FUSE_CURRENT_DIR && status.name != FUSE_PARENT_DIR {
+                    if self.conf.enable_meta_cache {
+                        let path = Path::from_str(&status.path)?;
+                        self.state.meta_cache().put_status(&path, status.clone());
+                    }
+                    map.do_lookup(header.nodeid, Some(&status.name), &status)?
+                } else {
+                    Self::status_to_attr(&self.conf, &status)?
+                };
 
-            if plus {
-                if !res.add_plus((index + 1) as u64, status, entry) {
+                let entry = Self::create_entry_out(&self.conf, attr);
+                if !res.add_dirent(plus, index, &status, entry) {
+                    batch.push_front(status);
                     break;
                 }
-            } else if !res.add((index + 1) as u64, status, entry) {
-                break;
+                index += 1;
             }
         }
+        handle.set_buf(batch).await?;
+
         Ok(res)
     }
 
@@ -545,7 +549,7 @@ impl CurvineFileSystem {
         Ok(status)
     }
 
-    async fn get_cached_list(&self, path: &Path) -> FuseResult<Vec<FileStatus>> {
+    pub async fn get_cached_list(&self, path: &Path) -> FuseResult<Vec<FileStatus>> {
         if self.conf.enable_meta_cache {
             if let Some(list) = self.state.meta_cache().get_list(path) {
                 return Ok(list);
@@ -994,8 +998,10 @@ impl fs::FileSystem for CurvineFileSystem {
         self.check_permissions(&dir_path, op.header, action.acl_mask())
             .await?;
 
-        let list = self.get_cached_list(&dir_path).await?;
-        let handle = self.state.new_dir_handle(op.header.nodeid, list).await?;
+        let handle = self
+            .state
+            .new_dir_handle(op.header.nodeid, &dir_path)
+            .await?;
         let open_flags = Self::fill_open_flags(&self.conf, op.arg.flags);
         let attr = fuse_open_out {
             fh: handle.fh,

--- a/curvine-fuse/src/fs/state/dir_handle.rs
+++ b/curvine-fuse/src/fs/state/dir_handle.rs
@@ -12,35 +12,100 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use curvine_common::fs::{ListStream, Path};
 use curvine_common::state::FileStatus;
+use curvine_common::FsResult;
+use futures::StreamExt;
+use log::info;
+use orpc::err_box;
 use serde::{Deserialize, Serialize};
+use std::collections::VecDeque;
+use std::mem;
+use tokio::sync::{Mutex, MutexGuard};
 
-#[derive(Debug, Deserialize, Serialize)]
+struct InnerStream {
+    stream: ListStream,
+    buf: VecDeque<FileStatus>,
+    index: usize,
+}
+
+impl InnerStream {
+    pub fn new(stream: ListStream) -> Self {
+        Self {
+            stream,
+            buf: VecDeque::new(),
+            index: 0,
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize)]
 pub struct DirHandle {
     pub ino: u64,
     pub fh: u64,
+    pub path: String,
 
-    list: Vec<FileStatus>,
+    #[serde(skip, default)]
+    stream: Option<Mutex<InnerStream>>,
+    limit: usize,
 }
 
 impl DirHandle {
-    pub fn new(ino: u64, fh: u64, list: Vec<FileStatus>) -> Self {
-        DirHandle { ino, fh, list }
+    pub fn new(ino: u64, fh: u64, path: &Path, limit: usize, stream: ListStream) -> Self {
+        Self {
+            ino,
+            fh,
+            path: path.clone_uri(),
+            stream: Some(Mutex::new(InnerStream::new(stream))),
+            limit,
+        }
     }
 
-    pub fn get_list(&self, skip: usize) -> impl Iterator<Item = (usize, &FileStatus)> {
-        self.list.iter().enumerate().skip(skip)
+    async fn guard(&self) -> FsResult<MutexGuard<'_, InnerStream>> {
+        match self.stream {
+            Some(ref stream) => Ok(stream.lock().await),
+            None => err_box!("path {} list stream not init", self.path),
+        }
     }
 
-    pub fn len(&self) -> usize {
-        self.list.len()
+    pub async fn get_batch(&self, off: usize) -> FsResult<VecDeque<FileStatus>> {
+        let mut guard = self.guard().await?;
+
+        if off > 0 && guard.index == 0 {
+            info!(
+                "readdir {} skipping {} list entries (resume offset / inner index reset)",
+                self.path, off
+            );
+            while guard.index < off {
+                match guard.stream.next().await {
+                    Some(Ok(_)) => guard.index += 1,
+                    Some(Err(e)) => return Err(e),
+                    None => return Ok(VecDeque::new()),
+                }
+            }
+        }
+
+        while guard.buf.len() < self.limit {
+            match guard.stream.next().await {
+                Some(Ok(s)) => {
+                    guard.buf.push_back(s);
+                    guard.index += 1;
+                }
+                Some(Err(e)) => return Err(e),
+                None => break,
+            }
+        }
+
+        Ok(mem::take(&mut guard.buf))
     }
 
-    pub fn is_empty(&self) -> bool {
-        self.list.is_empty()
+    pub async fn set_buf(&self, buf: VecDeque<FileStatus>) -> FsResult<()> {
+        let mut guard = self.guard().await?;
+        guard.buf = buf;
+        Ok(())
     }
 
-    pub fn get_all(&self) -> &[FileStatus] {
-        &self.list
+    pub fn set_stream(&mut self, stream: ListStream) {
+        self.stream.replace(Mutex::new(InnerStream::new(stream)));
     }
 }

--- a/curvine-fuse/src/fs/state/node_state.rs
+++ b/curvine-fuse/src/fs/state/node_state.rs
@@ -15,14 +15,17 @@
 use crate::fs::state::file_handle::FileHandle;
 use crate::fs::state::DirHandle;
 use crate::fs::state::{NodeAttr, NodeMap};
-use crate::fs::{FuseReader, FuseWriter};
+use crate::fs::{CurvineFileSystem, FuseReader, FuseWriter};
 use crate::raw::fuse_abi::{fuse_attr, fuse_forget_one};
-use crate::{err_fuse, FuseResult, STATE_FILE_MAGIC, STATE_FILE_VERSION};
+use crate::{
+    err_fuse, FuseResult, FUSE_CURRENT_DIR, FUSE_PARENT_DIR, STATE_FILE_MAGIC, STATE_FILE_VERSION,
+};
 use curvine_client::file::FsReader;
 use curvine_client::unified::{UnifiedFileSystem, UnifiedReader};
 use curvine_common::conf::{ClientConf, ClusterConf, FuseConf};
-use curvine_common::fs::{FileSystem, MetaCache, Path, StateReader, StateWriter};
-use curvine_common::state::{CreateFileOpts, FileBlocks, FileStatus, OpenFlags};
+use curvine_common::fs::{FileSystem, ListStream, MetaCache, Path, StateReader, StateWriter};
+use curvine_common::state::{CreateFileOpts, FileBlocks, FileStatus, ListOptions, OpenFlags};
+use futures::stream::{self, StreamExt};
 use log::{error, info, warn};
 use orpc::common::FastHashMap;
 use orpc::err_box;
@@ -504,12 +507,15 @@ impl NodeState {
         }
     }
 
-    pub async fn new_dir_handle(
-        &self,
-        ino: u64,
-        list: Vec<FileStatus>,
-    ) -> FuseResult<Arc<DirHandle>> {
-        let handle = Arc::new(DirHandle::new(ino, self.next_fh(), list));
+    pub async fn new_dir_handle(&self, ino: u64, path: &Path) -> FuseResult<Arc<DirHandle>> {
+        let stream = self.list_stream(path).await?;
+        let handle = Arc::new(DirHandle::new(
+            ino,
+            self.next_fh(),
+            path,
+            self.conf.list_limit,
+            stream,
+        ));
         let mut lock = self.dir_handles.write();
         lock.entry(ino)
             .or_default()
@@ -567,6 +573,20 @@ impl NodeState {
         writer.write_len(self.fh_creator.get())?;
 
         Ok(())
+    }
+
+    pub async fn list_stream(&self, path: &Path) -> FuseResult<ListStream> {
+        let inner = self
+            .fs
+            .list_stream(path, ListOptions::with_limit(self.conf.list_limit))
+            .await?;
+
+        let dots = stream::iter([
+            Ok(CurvineFileSystem::new_dot_status(FUSE_CURRENT_DIR)),
+            Ok(CurvineFileSystem::new_dot_status(FUSE_PARENT_DIR)),
+        ]);
+
+        Ok(ListStream::new(dots.chain(inner)))
     }
 
     pub async fn restore(&self, reader: &mut StateReader) -> FuseResult<()> {
@@ -631,7 +651,11 @@ impl NodeState {
         info!("node_state::restore: restoring dir_handles");
         let dir_handles_count = reader.read_len()?;
         for _ in 0..dir_handles_count {
-            let handle = reader.read_struct::<DirHandle>()?;
+            let mut handle = reader.read_struct::<DirHandle>()?;
+            let path = Path::from_str(&handle.path)?;
+            let stream = self.list_stream(&path).await?;
+            handle.set_stream(stream);
+
             self.dir_handles
                 .write()
                 .entry(handle.ino)

--- a/curvine-fuse/src/raw/fuse_dirent_list.rs
+++ b/curvine-fuse/src/raw/fuse_dirent_list.rs
@@ -68,6 +68,20 @@ impl FuseDirentList {
         self.add_buf(&header, name)
     }
 
+    pub fn add_dirent(
+        &mut self,
+        plus: bool,
+        off: u64,
+        status: &FileStatus,
+        entry: fuse_entry_out,
+    ) -> bool {
+        if plus {
+            self.add_plus(off, status, entry)
+        } else {
+            self.add(off, status, entry)
+        }
+    }
+
     /// Add an entry to the buffer and return false if the buff is already full.
     fn add_buf<T>(&mut self, data: &T, name: &[u8]) -> bool {
         let bytes = FuseUtils::struct_as_bytes(data);

--- a/curvine-fuse/src/session/fuse_response.rs
+++ b/curvine-fuse/src/session/fuse_response.rs
@@ -96,6 +96,12 @@ impl FuseResponse {
         self.unique
     }
 
+    fn rep_log(&self, e: &FuseError) {
+        if self.debug || !matches!(e.errno, libc::ENOENT | libc::ENODATA | libc::ENOSYS) {
+            warn!("send_rep unique {}: {}", self.unique, e);
+        }
+    }
+
     pub async fn send_rep<T: Debug, E: Into<FuseError> + Debug>(
         &self,
         res: Result<T, E>,
@@ -116,9 +122,7 @@ impl FuseResponse {
 
             Err(e) => {
                 let e = e.into();
-                if self.debug || (e.errno != libc::ENOENT && e.errno != libc::ENODATA) {
-                    warn!("send_rep unique {}: {:?}", self.unique, e);
-                }
+                self.rep_log(&e);
                 ResponseData::create(self.unique, e.errno, vec![])
             }
         };
@@ -156,9 +160,7 @@ impl FuseResponse {
             }
 
             Err(e) => {
-                if self.debug || (e.errno != libc::ENOENT && e.errno != libc::ENODATA) {
-                    warn!("send_buf unique {}: {}", self.unique, e);
-                }
+                self.rep_log(&e);
                 ResponseData::create(self.unique, e.errno, vec![])
             }
         };
@@ -177,9 +179,7 @@ impl FuseResponse {
             }
 
             Err(e) => {
-                if self.debug || (e.errno != libc::ENOENT && e.errno != libc::ENODATA) {
-                    warn!("send_data unique {}: {}", self.unique, e);
-                }
+                self.rep_log(&e);
                 ResponseData::create(self.unique, e.errno, vec![])
             }
         };

--- a/curvine-fuse/src/web_server.rs
+++ b/curvine-fuse/src/web_server.rs
@@ -1,5 +1,6 @@
 use axum::routing::get;
 use axum::Router;
+use curvine_client::file::FsContext;
 use std::net::SocketAddr;
 
 pub struct WebServer;
@@ -11,7 +12,7 @@ impl WebServer {
             .route("/healthz", get(|| async { "ok" }));
 
         let addr = SocketAddr::from(([0, 0, 0, 0], port));
-        tracing::info!("FUSE metrics server listening on {}", addr);
+        log::info!("FUSE metrics server listening on {}", addr);
 
         let listener = tokio::net::TcpListener::bind(addr).await?;
         axum::serve(listener, app).await?;
@@ -20,5 +21,7 @@ impl WebServer {
 }
 
 async fn metrics_handler() -> String {
-    orpc::common::Metrics::text_output().unwrap_or_else(|e| format!("Error: {}", e))
+    FsContext::get_metrics()
+        .text_output()
+        .unwrap_or_else(|e| format!("Error: {}", e))
 }

--- a/curvine-server/src/master/meta/fs_dir.rs
+++ b/curvine-server/src/master/meta/fs_dir.rs
@@ -483,6 +483,18 @@ impl FsDir {
         Ok(res)
     }
 
+    fn list_single_file(status: FileStatus, opts: &ListOptions) -> Vec<FileStatus> {
+        if matches!(opts.limit, Some(0)) {
+            return vec![];
+        }
+        if let Some(sa) = opts.start_after.as_deref() {
+            if status.name.as_str() <= sa {
+                return vec![];
+            }
+        }
+        vec![status]
+    }
+
     pub fn list_options(&self, inp: &InodePath, opts: &ListOptions) -> FsResult<Vec<FileStatus>> {
         let inode = match inp.get_last_inode() {
             Some(v) => v,
@@ -490,7 +502,10 @@ impl FsDir {
         };
 
         match inode.as_ref() {
-            File(_, _) => Ok(vec![inode.to_file_status(inp.path())]),
+            File(_, _) => {
+                let status = inode.to_file_status(inp.path());
+                Ok(Self::list_single_file(status, opts))
+            }
 
             Dir(_, d) => {
                 let children = d.list_options(opts);
@@ -516,7 +531,10 @@ impl FsDir {
             FileEntry(name, id) => {
                 let inode_opt = self.store.get_inode(*id, Some(name))?;
                 match inode_opt {
-                    Some(inode_view) => Ok(vec![inode_view.to_file_status(inp.path())]),
+                    Some(inode_view) => {
+                        let status = inode_view.to_file_status(inp.path());
+                        Ok(Self::list_single_file(status, opts))
+                    }
                     None => err_box!("File {} not exists", inp.path()),
                 }
             }

--- a/curvine-tests/Cargo.toml
+++ b/curvine-tests/Cargo.toml
@@ -19,12 +19,12 @@ tracing = { workspace = true }
 tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true }
 log = { workspace = true }
+futures = { workspace = true }
 bytes = { workspace = true }
 once_cell = { workspace = true }
 clap = { workspace = true }
 awaitility = "0.4"
 tempfile = { workspace = true }
-futures = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 curvine-fuse = { workspace = true }

--- a/curvine-tests/tests/fs_test.rs
+++ b/curvine-tests/tests/fs_test.rs
@@ -1057,6 +1057,30 @@ fn list_options() {
         let full = fs.list_status(&dir).await.unwrap();
         assert_eq!(full.len(), 5, "full list should have 5 entries");
 
+        // list file
+        let file1 = Path::from_str(format!("/fs_test/list_options/{}.log", 1)).unwrap();
+        let opts = ListOptions {
+            limit: Some(1),
+            start_after: None,
+        };
+        let list = fs.list_options(&file1, opts).await.unwrap();
+        assert_eq!(list.len(), 1);
+
+        let opts = ListOptions {
+            limit: Some(1),
+            start_after: Some("1.log".to_owned()),
+        };
+        let list = fs.list_options(&file1, opts).await.unwrap();
+        assert_eq!(list.len(), 0);
+
+        let opts = ListOptions {
+            limit: Some(1),
+            start_after: None,
+        };
+        let mut list_stream = fs.list_stream(&file1, opts).await.unwrap();
+        let list = list_stream.collect_vec().await.unwrap();
+        assert_eq!(list.len(), 1);
+
         // limit only
         let opts = ListOptions {
             limit: Some(2),

--- a/curvine-tests/tests/fuse_test.rs
+++ b/curvine-tests/tests/fuse_test.rs
@@ -17,7 +17,7 @@
 fn persist_restore() {
     use std::sync::Arc;
 
-    use curvine_common::fs::{Path, StateReader, StateWriter};
+    use curvine_common::fs::{FileSystem, Path, StateReader, StateWriter};
     use curvine_common::state::{CreateFileOptsBuilder, FileStatus, OpenFlags};
     use curvine_fuse::fs::state::NodeState;
     use curvine_fuse::FUSE_ROOT_ID;
@@ -48,18 +48,11 @@ fn persist_restore() {
         let c = state1.do_lookup(b.ino, Some("c"), &status_c).unwrap();
 
         // Create dir_handles
-        let dir_status_list = vec![
-            FileStatus::with_name(10, "file1".to_string(), false),
-            FileStatus::with_name(11, "file2".to_string(), false),
-        ];
-        let dir_handle1 = state1
-            .new_dir_handle(a.ino, dir_status_list.clone())
-            .await
-            .unwrap();
-        let dir_handle2 = state1
-            .new_dir_handle(b.ino, dir_status_list.clone())
-            .await
-            .unwrap();
+        let path_a_dir = Path::from_str("/a").unwrap();
+        let path_b_dir = Path::from_str("/a/b").unwrap();
+        fs1.mkdir(&path_b_dir, true).await.unwrap();
+        let dir_handle1 = state1.new_dir_handle(a.ino, &path_a_dir).await.unwrap();
+        let dir_handle2 = state1.new_dir_handle(b.ino, &path_b_dir).await.unwrap();
 
         // Create file handles
         let path = Path::from_str("/a/1.log").unwrap();
@@ -97,7 +90,6 @@ fn persist_restore() {
         let original_id_creator = state1.node_read().current_id();
         let original_fh_creator = state1.current_fh();
         let original_handle1_status = handle1.status().clone();
-        let _original_dir_handle1_list = dir_handle1.get_all().to_vec();
 
         // Persist state
         let mut writer = StateWriter::new(&test_path).unwrap();
@@ -146,7 +138,7 @@ fn persist_restore() {
             .unwrap();
         assert_eq!(restored_dir_handle1.ino, dir_handle1.ino);
         assert_eq!(restored_dir_handle1.fh, dir_handle1.fh);
-        assert_eq!(restored_dir_handle1.len(), dir_handle1.len());
+        assert_eq!(restored_dir_handle1.path, dir_handle1.path);
 
         let restored_dir_handle2 = state2
             .find_dir_handle(dir_handle2.ino, dir_handle2.fh)

--- a/etc/curvine-env.sh
+++ b/etc/curvine-env.sh
@@ -18,26 +18,17 @@
 
 export CURVINE_HOME="$(cd "$(dirname "$0")"/..; pwd)"
 
-OS_NAME=$(uname)
-# Get the IP address from hostname, taking the last network interface address
-LOCAL_HOSTNAME="$(hostname || echo localhost)"
-
-if [ "$OS_NAME" == "Linux" ]; then
-    LOCAL_IP=$(hostname -I | awk '{print $NF}')
-elif [ "$OS_NAME" == "Darwin" ]; then
-    LOCAL_IP=$(ifconfig | grep "inet " | awk '{print $2}' | grep -v 127.0.0.1 | tail -n 1)
-else
-    echo "Unsupported OS: $OS_NAME"
-    exit 1
-fi
+LOCAL_HOSTNAME=localhost
 
 # master bound host name
-export CURVINE_MASTER_HOSTNAME=${CURVINE_MASTER_HOSTNAME:-$LOCAL_HOSTNAME}
+export CURVINE_MASTER_HOSTNAME=$LOCAL_HOSTNAME
 
 # worker bound host name
-export CURVINE_WORKER_HOSTNAME=${CURVINE_WORKER_HOSTNAME:-$LOCAL_IP}
+export CURVINE_WORKER_HOSTNAME=$LOCAL_HOSTNAME
 
 # The client server hostname is used to determine whether the worker and client are on the same machine.
-export CURVINE_CLIENT_HOSTNAME=${CURVINE_CLIENT_HOSTNAME:-$LOCAL_HOSTNAME}
+export CURVINE_CLIENT_HOSTNAME=$LOCAL_HOSTNAME
 
-export CURVINE_CONF_FILE=${CURVINE_CONF_FILE:-$CURVINE_HOME/conf/curvine-cluster.toml}
+export ORPC_BIND_HOSTNAME=0.0.0.0
+
+export CURVINE_CONF_FILE=$CURVINE_HOME/conf/curvine-cluster.toml


### PR DESCRIPTION
### Summary

- **FUSE `readdir` / `DirHandle`**
  - Directory handles now wrap a **`ListStream`** with an internal **`VecDeque`** buffer and configurable **`list_limit`** (from **`FuseConf`**).
  - **`get_batch(offset)`** fills the buffer from the stream, supports **resume after FUSE offset** when inner index was reset (e.g. restore), and **`set_buf`** returns unconsumed entries when the reply buffer is full.
  - **`opendir`** creates handles via **`NodeState::new_dir_handle(ino, path)`** instead of materializing a full **`Vec<FileStatus>`** up front.

- **State persistence**
  - Serialized **`DirHandle`** stores **`path`**; **`stream`** is skipped and **recreated on `restore`** via **`list_stream(path)`**, keeping behavior consistent after restart.

- **FUSE filesystem glue**
  - **`read_dir_common`** uses **`add_dirent`** (plus/non-plus), **`arg.offset`** as the running cookie, and passes **`&FileStatus`** into lookup helpers where appropriate.
  - **`fuse_dirent_list`**: new **`add_dirent`** helper to branch **`add` / `add_plus`**.

- **Session / observability**
  - **`FuseResponse`**: shared **`rep_log`** for errors; suppress routine noise for **`ENOENT` / `ENODATA` / `ENOSYS`** unless debug is on.
  - **FUSE web server**: expose **`FsContext::get_metrics()`** for **`/metrics`**; use **`log::info`** for bind message.

- **Configuration**
  - **`ClusterConf::DEFAULT_FUSE_WEB_PORT`** (**`9002`**); **`FuseConf`** default **`web_port`** uses it and adds **`list_limit`** (default **1000**).

- **Common / server**
  - **`ListStream::collect`** renamed to **`collect_vec`** to avoid confusion with **`StreamExt::collect`**.
  - **`FsDir::list_options`**: for **file** / **`FileEntry`** targets, apply the same **`start_after`** (exclusive) and **`limit`** semantics as directory children via **`list_single_file`**.

- **Tests**
  - **`fs_test`**: **`list_options` / `list_stream`** on a **file** path (including **`start_after`** empty result).
  - **`fuse_test`**: persist/restore updated for **path-based** **`DirHandle`** (mkdir setup, assert **`path`** instead of list length).

- **Tooling / deps**
  - **`etc/curvine-env.sh`**: fixed **`localhost`** hostnames, set **`ORPC_BIND_HOSTNAME=0.0.0.0`**, drop previous OS-specific IP discovery and **`:-` defaults** for Curvine env vars (stricter, dev-oriented).
  - **`curvine-fuse`**: add **`futures`**; trim unused deps from lockfile where applicable.

### Motivation

Large directories should not require loading the full listing into memory for **`opendir`**. Streaming aligns FUSE with **master/UFS `list_stream`**, improves **offset/cookie** handling for partial **`readdir`** replies, and fixes **pagination edge cases** when **`list_options`** targets a single file.