### PR TITLE
feat(p2p-01): add file version epoch proto foundation (#671)

### DIFF
--- a/curvine-common/proto/common.proto
+++ b/curvine-common/proto/common.proto
@@ -72,7 +72,7 @@ message FileStatusProto {
     required uint32 mode = 17;
     optional string target = 18;
     required uint32 nlink = 19;
-    required int64 version_epoch = 20 [default = 0];
+    optional int64 version_epoch = 20 [default = 0];
 }
 
 // Describe the worker address information.

--- a/curvine-common/proto/common.proto
+++ b/curvine-common/proto/common.proto
@@ -72,6 +72,7 @@ message FileStatusProto {
     required uint32 mode = 17;
     optional string target = 18;
     required uint32 nlink = 19;
+    required int64 version_epoch = 20 [default = 0];
 }
 
 // Describe the worker address information.

--- a/curvine-common/src/state/file_status.rs
+++ b/curvine-common/src/state/file_status.rs
@@ -21,6 +21,7 @@ use std::collections::HashMap;
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct FileStatus {
     pub id: i64,
+    pub version_epoch: i64,
     pub path: String,
     pub name: String,
     pub is_dir: bool,

--- a/curvine-common/src/state/file_status.rs
+++ b/curvine-common/src/state/file_status.rs
@@ -21,6 +21,7 @@ use std::collections::HashMap;
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct FileStatus {
     pub id: i64,
+    #[serde(default)]
     pub version_epoch: i64,
     pub path: String,
     pub name: String,
@@ -121,5 +122,29 @@ impl FileStatus {
         } else {
             false
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+
+    #[test]
+    fn file_status_serde_decodes_legacy_json_without_version_epoch() {
+        let mut json = serde_json::to_value(FileStatus {
+            id: 7,
+            path: "/tmp/a".to_string(),
+            name: "a".to_string(),
+            ..Default::default()
+        })
+        .unwrap();
+
+        if let Value::Object(obj) = &mut json {
+            obj.remove("version_epoch");
+        }
+
+        let decoded: FileStatus = serde_json::from_value(json).unwrap();
+        assert_eq!(decoded.version_epoch, 0);
     }
 }

--- a/curvine-common/src/utils/proto_utils.rs
+++ b/curvine-common/src/utils/proto_utils.rs
@@ -217,7 +217,7 @@ impl ProtoUtils {
     pub fn file_status_to_pb(status: FileStatus) -> FileStatusProto {
         FileStatusProto {
             id: status.id,
-            version_epoch: status.version_epoch,
+            version_epoch: Some(status.version_epoch),
             path: status.path,
             name: status.name,
             is_dir: status.is_dir,
@@ -243,7 +243,7 @@ impl ProtoUtils {
     pub fn file_status_from_pb(status: FileStatusProto) -> FileStatus {
         FileStatus {
             id: status.id,
-            version_epoch: status.version_epoch,
+            version_epoch: status.version_epoch.unwrap_or_default(),
             path: status.path,
             name: status.name,
             is_dir: status.is_dir,
@@ -818,6 +818,20 @@ mod tests {
         let bytes = legacy.encode_to_vec();
         let decoded = FileStatusProto::decode(bytes.as_slice())
             .expect("current proto should decode legacy payload without version_epoch");
+        assert_eq!(decoded.version_epoch, None);
+        assert_eq!(ProtoUtils::file_status_from_pb(decoded).version_epoch, 0);
+    }
+
+    #[test]
+    fn file_status_from_pb_defaults_optional_version_epoch_to_zero() {
+        let mut pb = ProtoUtils::file_status_to_pb(FileStatus {
+            id: 7,
+            path: "/tmp/a".to_string(),
+            name: "a".to_string(),
+            ..Default::default()
+        });
+        pb.version_epoch = None;
+        let decoded = ProtoUtils::file_status_from_pb(pb);
         assert_eq!(decoded.version_epoch, 0);
     }
 }

--- a/curvine-common/src/utils/proto_utils.rs
+++ b/curvine-common/src/utils/proto_utils.rs
@@ -217,6 +217,7 @@ impl ProtoUtils {
     pub fn file_status_to_pb(status: FileStatus) -> FileStatusProto {
         FileStatusProto {
             id: status.id,
+            version_epoch: status.version_epoch,
             path: status.path,
             name: status.name,
             is_dir: status.is_dir,
@@ -242,6 +243,7 @@ impl ProtoUtils {
     pub fn file_status_from_pb(status: FileStatusProto) -> FileStatus {
         FileStatus {
             id: status.id,
+            version_epoch: status.version_epoch,
             path: status.path,
             name: status.name,
             is_dir: status.is_dir,
@@ -707,5 +709,115 @@ impl ProtoUtils {
             inodes: res.inodes,
             bytes: res.bytes,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Clone, PartialEq, Message)]
+    struct LegacyStoragePolicyProto {
+        #[prost(enumeration = "StorageTypeProto", required, tag = "1")]
+        pub storage_type: i32,
+        #[prost(int64, required, tag = "2", default = "0")]
+        pub ttl_ms: i64,
+        #[prost(enumeration = "TtlActionProto", required, tag = "3")]
+        pub ttl_action: i32,
+        #[prost(int64, required, tag = "4")]
+        pub ufs_mtime: i64,
+        #[prost(enumeration = "StorageStateProto", required, tag = "5")]
+        pub state: i32,
+    }
+
+    #[derive(Clone, PartialEq, Message)]
+    struct LegacyFileStatusProto {
+        #[prost(int64, required, tag = "1")]
+        pub id: i64,
+        #[prost(string, required, tag = "2")]
+        pub path: String,
+        #[prost(string, required, tag = "3")]
+        pub name: String,
+        #[prost(bool, required, tag = "4")]
+        pub is_dir: bool,
+        #[prost(int64, required, tag = "5")]
+        pub mtime: i64,
+        #[prost(int64, required, tag = "6")]
+        pub atime: i64,
+        #[prost(int32, required, tag = "7")]
+        pub children_num: i32,
+        #[prost(bool, required, tag = "8", default = "false")]
+        pub is_complete: bool,
+        #[prost(int64, required, tag = "9")]
+        pub len: i64,
+        #[prost(int32, required, tag = "10")]
+        pub replicas: i32,
+        #[prost(int64, required, tag = "11")]
+        pub block_size: i64,
+        #[prost(enumeration = "FileTypeProto", required, tag = "12")]
+        pub file_type: i32,
+        #[prost(map = "string, bytes", tag = "13")]
+        pub x_attr: std::collections::HashMap<String, Vec<u8>>,
+        #[prost(message, required, tag = "14")]
+        pub storage_policy: LegacyStoragePolicyProto,
+        #[prost(string, required, tag = "15")]
+        pub owner: String,
+        #[prost(string, required, tag = "16")]
+        pub group: String,
+        #[prost(uint32, required, tag = "17")]
+        pub mode: u32,
+        #[prost(string, optional, tag = "18")]
+        pub target: Option<String>,
+        #[prost(uint32, required, tag = "19")]
+        pub nlink: u32,
+    }
+
+    #[test]
+    fn file_status_proto_roundtrip_keeps_version_epoch() {
+        let status = FileStatus {
+            id: 7,
+            path: "/tmp/a".to_string(),
+            name: "a".to_string(),
+            version_epoch: 42,
+            ..Default::default()
+        };
+        let pb = ProtoUtils::file_status_to_pb(status.clone());
+        let decoded = ProtoUtils::file_status_from_pb(pb);
+        assert_eq!(decoded.version_epoch, 42);
+    }
+
+    #[test]
+    fn file_status_proto_decodes_legacy_payload_without_version_epoch() {
+        let legacy = LegacyFileStatusProto {
+            id: 7,
+            path: "/tmp/a".to_string(),
+            name: "a".to_string(),
+            is_dir: false,
+            mtime: 11,
+            atime: 12,
+            children_num: 0,
+            is_complete: true,
+            len: 33,
+            replicas: 1,
+            block_size: 128,
+            file_type: FileTypeProto::File as i32,
+            x_attr: Default::default(),
+            storage_policy: LegacyStoragePolicyProto {
+                storage_type: StorageTypeProto::Disk as i32,
+                ttl_ms: 0,
+                ttl_action: TtlActionProto::None as i32,
+                ufs_mtime: 0,
+                state: StorageStateProto::Cv as i32,
+            },
+            owner: "owner".to_string(),
+            group: "group".to_string(),
+            mode: 0o644,
+            target: None,
+            nlink: 1,
+        };
+        let bytes = legacy.encode_to_vec();
+        let decoded = FileStatusProto::decode(bytes.as_slice())
+            .expect("current proto should decode legacy payload without version_epoch");
+        assert_eq!(decoded.version_epoch, 0);
     }
 }

--- a/curvine-server/src/master/meta/inode/inode_file.rs
+++ b/curvine-server/src/master/meta/inode/inode_file.rs
@@ -277,6 +277,7 @@ impl InodeFile {
         // Clear all blocks and reset file size
         self.blocks.clear();
         self.len = 0;
+        self.version_epoch = self.version_epoch.max(0).saturating_add(1);
 
         // Update file metadata with new options
         self.replicas = opts.replicas as u8;
@@ -533,6 +534,23 @@ impl InodeFile {
         } else {
             self.cv_exists() && !self.blocks.is_empty()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::InodeFile;
+    use curvine_common::state::CreateFileOpts;
+
+    #[test]
+    fn overwrite_bumps_version_epoch() {
+        let opts = CreateFileOpts::with_create(false);
+        let mut file = InodeFile::with_opts(7, 100, opts.clone());
+        let initial_epoch = file.version_epoch;
+
+        file.overwrite(opts, 200);
+
+        assert_eq!(file.version_epoch, initial_epoch + 1);
     }
 }
 

--- a/curvine-server/src/master/meta/inode/inode_file.rs
+++ b/curvine-server/src/master/meta/inode/inode_file.rs
@@ -34,6 +34,8 @@ pub struct InodeFile {
     pub(crate) file_type: FileType,
     pub(crate) mtime: i64,
     pub(crate) atime: i64,
+    #[serde(default)]
+    pub(crate) version_epoch: i64,
 
     pub(crate) len: i64,
     pub(crate) block_size: u32,
@@ -61,6 +63,7 @@ impl InodeFile {
             file_type: FileType::File,
             mtime: time,
             atime: time,
+            version_epoch: 1,
             len: 0,
             block_size: 0,
             replicas: 0,
@@ -88,6 +91,7 @@ impl InodeFile {
             file_type: opts.file_type,
             mtime: time,
             atime: time,
+            version_epoch: 1,
             len,
             block_size: opts.block_size as u32,
             replicas: opts.replicas as u8,
@@ -128,6 +132,7 @@ impl InodeFile {
             file_type: FileType::Link,
             mtime: time,
             atime: time,
+            version_epoch: 1,
             len: 0,
             block_size: 0,
             replicas: 0,

--- a/curvine-server/src/master/meta/inode/inode_file.rs
+++ b/curvine-server/src/master/meta/inode/inode_file.rs
@@ -537,23 +537,6 @@ impl InodeFile {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::InodeFile;
-    use curvine_common::state::CreateFileOpts;
-
-    #[test]
-    fn overwrite_bumps_version_epoch() {
-        let opts = CreateFileOpts::with_create(false);
-        let mut file = InodeFile::with_opts(7, 100, opts.clone());
-        let initial_epoch = file.version_epoch;
-
-        file.overwrite(opts, 200);
-
-        assert_eq!(file.version_epoch, initial_epoch + 1);
-    }
-}
-
 impl Inode for InodeFile {
     fn id(&self) -> i64 {
         self.id
@@ -583,5 +566,22 @@ impl Inode for InodeFile {
 impl PartialEq for InodeFile {
     fn eq(&self, other: &Self) -> bool {
         self.id == other.id
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::InodeFile;
+    use curvine_common::state::CreateFileOpts;
+
+    #[test]
+    fn overwrite_bumps_version_epoch() {
+        let opts = CreateFileOpts::with_create(false);
+        let mut file = InodeFile::with_opts(7, 100, opts.clone());
+        let initial_epoch = file.version_epoch;
+
+        file.overwrite(opts, 200);
+
+        assert_eq!(file.version_epoch, initial_epoch + 1);
     }
 }

--- a/curvine-server/src/master/meta/inode/inode_view.rs
+++ b/curvine-server/src/master/meta/inode/inode_view.rs
@@ -403,6 +403,7 @@ impl InodeView {
         let acl = self.acl();
         let mut status = FileStatus {
             id: self.id(),
+            version_epoch: 0,
             path: path.to_owned(),
             name: self.name().to_owned(),
             is_dir: self.is_dir(),
@@ -425,6 +426,7 @@ impl InodeView {
 
         match self {
             File(_, f) => {
+                status.version_epoch = f.version_epoch;
                 status.is_complete = f.is_complete();
                 status.len = f.len;
                 status.replicas = f.replicas as i32;


### PR DESCRIPTION
## Summary
- Add `version_epoch` to shared file metadata used by later P2P read identity.
- Keep legacy `FileStatus` payloads decodable with a default epoch of `0`.

## Design
- Extend the existing `FileStatus` path instead of introducing a parallel P2P-only message.
- Seed inode-side version state now so later cache and transfer keys can stay version-safe.

## Implementation
- Update `common.proto`, `FileStatus`, proto conversions, and inode view/file mappings.
- Add proto compatibility coverage for round-trip and legacy decode behavior.

## Verification
- `cargo test -p curvine-common file_status_proto_roundtrip_keeps_version_epoch`
- `cargo test -p curvine-common file_status_proto_decodes_legacy_payload_without_version_epoch`

