### PR TITLE
fix(orpc): keep serving on accept errors; tune client defaults; audit…

### DIFF
--- a/curvine-client/src/unified/unified_filesystem.rs
+++ b/curvine-client/src/unified/unified_filesystem.rs
@@ -491,7 +491,7 @@ impl FileSystem<UnifiedWriter, UnifiedReader> for UnifiedFileSystem {
         let flags = OpenFlags::new_write_only()
             .set_create(true)
             .set_overwrite(overwrite);
-        let opts = self.cv.create_opts_builder().build();
+        let opts = self.cv.create_opts_builder().create_parent(true).build();
         self.open_with_opts(path, opts, flags).await
     }
 

--- a/curvine-common/src/conf/client_conf.rs
+++ b/curvine-common/src/conf/client_conf.rs
@@ -119,8 +119,7 @@ pub struct ClientConf {
     pub data_timeout_ms: u64,
     pub pipeline_timeout_ms: u64,
 
-    // Number of fs master connections.
-    // After testing 3 connections, the best performance can be achieved, so the default value is 3.
+    // After testing 3 connections, the best performance can be achieved, so the default value is 1.
     pub master_conn_pool_size: usize,
 
     // Whether to enable pre-reading
@@ -222,7 +221,7 @@ impl ClientConf {
 
     pub const DEFAULT_FILE_SYSTEM_MODE: u32 = 0o777;
 
-    pub const DEFAULT_CLEAN_TASK_INTERVAL_STR: &'static str = "10s";
+    pub const DEFAULT_CLEAN_TASK_INTERVAL_STR: &'static str = "60s";
 
     pub const DEFAULT_CLOSE_TIMEOUT_SECS: u64 = 5;
 
@@ -363,7 +362,7 @@ impl Default for ClientConf {
             rpc_timeout_ms: 120 * 1000,
             data_timeout_ms: 120 * 1000,
             pipeline_timeout_ms: 120 * 1000,
-            master_conn_pool_size: 3,
+            master_conn_pool_size: 1,
 
             enable_read_ahead: true,
             read_ahead_len: 0,

--- a/curvine-server/src/master/master_handler.rs
+++ b/curvine-server/src/master/master_handler.rs
@@ -506,6 +506,8 @@ impl MasterHandler {
         }
 
         let header: SetAttrRequest = ctx.parse_header()?;
+        ctx.set_audit(Some(header.path.to_string()), None);
+
         let opts = ProtoUtils::set_attr_opts_from_pb(header.opts);
         let status = self.fs.set_attr(header.path, opts)?;
 

--- a/curvine-server/src/master/rpc_context.rs
+++ b/curvine-server/src/master/rpc_context.rs
@@ -56,7 +56,10 @@ impl<'a> RpcContext<'a> {
     }
 
     pub fn audit_log(&self, succeeded: bool, used_us: u64, conn_state: Option<&ConnState>) {
-        if self.code == RpcCode::WorkerHeartbeat || self.code == RpcCode::WorkerBlockReport {
+        if matches!(
+            self.code,
+            RpcCode::WorkerHeartbeat | RpcCode::WorkerBlockReport | RpcCode::GetMountTable
+        ) {
             return;
         }
 

--- a/orpc/src/server/rpc_server.rs
+++ b/orpc/src/server/rpc_server.rs
@@ -161,7 +161,19 @@ where
         self.monitor.advance_running();
 
         loop {
-            let (stream, client_addr) = listener.accept().await?;
+            let (stream, client_addr) = match listener.accept().await {
+                Ok(conn) => conn,
+                Err(e) => {
+                    error!(
+                        "accept error on {}: {}. Possible system resource exhaustion; \
+                        please check open file descriptors/handles limits, \
+                        ephemeral port range and usage, process/thread limits, and OS socket backlog limits",
+                        bind_addr,
+                        e
+                    );
+                    continue;
+                }
+            };
 
             // Set the tcp parameter through socket2.
             let sock_ref = SockRef::from(&stream);


### PR DESCRIPTION
### Summary

- **`orpc` / `RpcServer`**
  - On `listener.accept()` failure, emit a structured **`error!`** including **`bind_addr`**, hinting at **FD/handle limits**, **ephemeral ports**, **process/thread limits**, and **socket backlog** issues, then **`continue`** the accept loop instead of failing the whole server task.

- **`curvine-client` / `UnifiedFileSystem`**
  - **`create()`** now builds create options with **`create_parent(true)`** so parent directories are created when missing (aligned with typical “create file” expectations).

- **`curvine-common` / `ClientConf`**
  - Default **`master_conn_pool_size`**: **3 → 1** (comment updated accordingly).
  - Default clean task interval string: **10s → 60s**.

- **`curvine-server` / master**
  - **`set_attr`**: set RPC audit context using the request path.
  - **Audit logging**: additionally skip high-frequency **`GetMountTable`** RPCs (similar to heartbeat-style noise suppression).

### Motivation

Improve production robustness when transient accept errors occur; reduce noisy audit logs; align client defaults with observed behavior; make unified `create()` more ergonomic for nested paths.


