### PR TITLE
feat(benchmark): add metadata stress manifests and benchmark README

### DIFF
--- a/curvine-tests/benchmark/README.md
+++ b/curvine-tests/benchmark/README.md
@@ -1,0 +1,251 @@
+# Curvine benchmark workloads
+
+Kubernetes manifests under `master-stress/` run **client-side workloads** against a Curvine cluster: each Pod starts one or more `curvine-fuse` processes and runs a bash script on the mount points. They are intended for **lab / staging** use; tune replicas, resources, and env vars before production-like clusters.
+
+### Files and intent (read this first)
+
+| Manifest | Purpose |
+|----------|---------|
+| `deployment-metadata-stable.yaml` | **Master / FUSE connection stress and metadata stability:** merged workload combining many mounts, **mixed POSIX operations** (bulk files, rename, hard/sym links, directory rename, mkdir/rmdir), and repeatable FUSE metadata exercises. Stages feature **deletes** to keep the tree churning (not growing forever), plus validation of **correctness and stability** of metadata paths (rename, links, readdir, etc.) under load. Use to test both connectivity/scale and diverse metadata semantics. |
+| `deployment-metadata-stress.yaml` | **Metadata pressure / capacity:** only **`mkdir` + file create** under `.metadata-stress/`, **no** workload-level `rm`/`rmdir`. Goal is to **continuously add** directories and files (`batch-0`, `batch-1`, …) and stress **metadata volume**, master/RocksDB, and inode-related limits. |
+
+**Apply rule:** `deployment.yaml` and `deployment-metadata-stable.yaml` both define the **same Kubernetes resource names** (e.g. StatefulSet `curvine-master-stress`, ConfigMap `curvine-stress-scripts`). Apply **only one** of them in a given namespace. `deployment-metadata-stress.yaml` uses a **different** app name and can coexist if namespaces or names differ.
+
+**Namespace:** examples below use `curvine-system` where listed; your copy of a manifest may use `default` or another namespace—check `metadata.namespace` before `kubectl apply`.
+
+**Prerequisites:**
+
+- Curvine masters reachable from the cluster; set `Secret` key `master-addrs` (comma-separated `host:port`).
+- Nodes can schedule **privileged** Pods with `hostPath` `/dev/fuse` and `SYS_ADMIN` (same pattern as CSI / FUSE tests).
+- Image default: `ghcr.io/curvineio/curvine-csi:latest` (contains `curvine-fuse`, `curvine-cli`). Override in the StatefulSet if needed.
+
+---
+
+## 1. Master connection stress (`master-stress/deployment.yaml`)
+
+### Scenario
+
+- **Goal:** Stress **master connectivity and many FUSE mounts** with a **mixed POSIX workload** (create, list, stat, rename, hard/sym links, directory rename, mkdir/rmdir).
+- **Behavior:** Each Pod runs `NUM_MOUNTS` independent `curvine-fuse` instances (`/fuse-mnts/curvine-fuse1` … `N`), each backed by a distinct remote fs-path.
+- **Remote layout:** `STRESS_REMOTE_ROOT` / `${POD_NAME}` / `{i}` (default root: `/curvine-master-stress`).
+- **Lifecycle:** By default, on start the entrypoint runs `curvine-cli fs rm --recursive` for **this Pod’s prefix only**, then `fs mkdir --parents` for each mount root. The workload loop **removes** files/dirs after each stage so the tree stays churning rather than growing without bound.
+
+### When to use
+
+- Validating stability under **many FUSE processes** talking to the same masters.
+- Exercising **metadata + rename + link** code paths repeatedly.
+- Measuring behavior with **`INTERVAL_SEC`** throttling between operations.
+
+### Deploy / observe
+
+```bash
+kubectl apply -f master-stress/deployment.yaml
+kubectl -n curvine-system get pods -l app=curvine-master-stress
+kubectl -n curvine-system logs -f statefulset/curvine-master-stress
+```
+
+### Main environment variables
+
+| Variable | Role |
+|----------|------|
+| `NUM_MOUNTS` | Number of FUSE instances per Pod (default `100` in script if unset; manifest often relies on default). |
+| `STRESS_BULK_FILE_COUNT` | Serial bulk file create / ls / stat / rm count per loop iteration. |
+| `INTERVAL_SEC` | Sleep between operations (fractional allowed). |
+| `FUSE_WEB_PORT_BASE` | Base port for fuse web UI per mount (`+ i`). |
+| `STRESS_REMOTE_ROOT` | Remote parent path for this stress run. |
+| `SKIP_REMOTE_POD_CLEANUP` | `1` = skip `fs rm` on this Pod’s prefix at start. |
+| `SKIP_REMOTE_MKDIR` | `1` = skip CLI mkdir (paths must already exist). |
+| `FUSE_USE_DEFAULT_OPTS` | `1` = use curvine-fuse default FUSE options. |
+
+Uncomment and set these under the StatefulSet `env:` section as needed.
+
+### Demo-style load (qualitative)
+
+The script runs **one infinite loop per mount**. Each loop issues a **serial** sequence of operations separated by `INTERVAL_SEC` (default `1` s if unset in the manifest). Rough structure per worker per iteration:
+
+| Phase | Controlled by | What happens (high level) |
+|-------|----------------|---------------------------|
+| Bulk files | `STRESS_BULK_FILE_COUNT` = B | B writes → ls → du → B × stat → B × rm |
+| Rename | — | write → ls → stat → du → mv → ls → stat → rm |
+| Links | — | write → hardlink → symlink → ls → stat → readlink → du → rm × 3 |
+| Dir rename | — | mkdir → write → du → stat → mv dir → ls → du → rm file → rmdir |
+| mkdir/rmdir | — | mkdir → rmdir |
+
+**Order-of-magnitude:** one loop is on the order of **3B + ~30** separate steps, each followed by `INTERVAL_SEC` sleep (so wall time grows linearly with B and `INTERVAL_SEC`). With **`NUM_MOUNTS` = N**, you have **N workers** doing that in parallel on **N** remote subtrees (`…/${POD_NAME}/1..N`), so aggregate master/FUSE load scales about **× N**.
+
+**Example:** `NUM_MOUNTS=100`, `STRESS_BULK_FILE_COUNT=10`, `INTERVAL_SEC=1` → each worker ~60 sleeps per loop → **~60 s** per loop per mount if every step succeeds; 100 mounts hammer the cluster concurrently.
+
+### Resource names
+
+- StatefulSet / Service: `curvine-master-stress`
+- ConfigMap: `curvine-stress-scripts`
+- Secret: `curvine-stress-master` (`master-addrs`)
+
+---
+
+## 2. Metadata stability (`master-stress/deployment-metadata-stable.yaml`)
+
+### Scenario
+
+- **Goal:** **Metadata stability** testing—repeatedly drive **many different FUSE-facing operations** (bulk create/stat/rm, file rename, hard and symbolic links, directory rename, mkdir/rmdir) so Curvine’s metadata handling is exercised under a realistic **mix** of syscalls, not a single opcode.
+- **Relationship to §1:** This file is the **same pattern as the original `deployment.yaml`** workload (same script shape and resource names). Keep it when you want a manifest **explicitly dedicated** to stability runs, or when your repo pins different images/env per profile. Behavior, env vars, and deploy commands match §1 unless you edited the YAML.
+- **Not for capacity burn-down:** The loop **deletes** after each stage; inode count on the remote tree does **not** monotonically grow like the stress manifest.
+
+### Deploy / observe
+
+Same labels and object names as §1 (`curvine-master-stress`). Use the same `kubectl` commands as §1 but point at this file:
+
+```bash
+kubectl apply -f master-stress/deployment-metadata-stable.yaml
+kubectl -n curvine-system get pods -l app=curvine-master-stress
+kubectl -n curvine-system logs -f statefulset/curvine-master-stress
+```
+
+(Adjust `-n` to match `metadata.namespace` in your file.)
+
+See §1 for environment variables, demo load table, and resource names.
+
+---
+
+## 3. Metadata pressure / growth (`master-stress/deployment-metadata-stress.yaml`)
+
+### Scenario
+
+- **Goal:** **Pressure** test—push **file and directory inode / metadata growth** toward cluster limits by **continuously creating** objects (no workload `rm` / `rmdir`).
+- **Behavior:** Same FUSE bootstrap pattern, but workers only **`mkdir` + small files** under `.metadata-stress/`, in repeating **`batch-0`, `batch-1`, …** trees.
+- **Remote layout:** `STRESS_REMOTE_ROOT` / `${POD_NAME}` / `{i}` (default root: `/curvine-metadata-stress` — different from master-stress to avoid sharing the same remote tree).
+
+### When to use
+
+- Capacity planning: **metadata volume**, master/RocksDB pressure, or inode-related limits.
+- Long runs with `SKIP_REMOTE_POD_CLEANUP=1` to **accumulate** objects across restarts (use with care).
+
+### Deploy / observe
+
+```bash
+kubectl apply -f master-stress/deployment-metadata-stress.yaml
+kubectl -n curvine-system get pods -l app=curvine-metadata-stress
+kubectl -n curvine-system logs -f statefulset/curvine-metadata-stress
+```
+
+### Tree parameters (`META_*`)
+
+Let **D** = `META_DIR_DEPTH`, **F** = `META_FANOUT`, **K** = `META_FILES_PER_DIR`.
+
+- **`META_DIR_DEPTH` (D):** From each `batch-*` root, how many **levels** of “fanout expansion” to apply before reaching leaf directories. `D=0` means no subdirectories under `batch-*`, only `K` files there.
+- **`META_FANOUT` (F):** For each directory while `depth > 0`, create **F** child directories, then recurse with `depth - 1`. Child names are `dir-<globalCounter>` for uniqueness.
+- **`META_FILES_PER_DIR` (K):** After children are processed, create **K** files in **every** directory that participates in the recursion (including `batch-*` and internal nodes). Use **`META_WRITE_FILE_DATA`**: `0` (default) = empty file via `touch`; `1` = one-byte payload via `echo "m" > file` (exercises data path slightly).
+
+**File count per batch (exact for this script):**  
+`N_files = K × N_dirs`.  
+`N_dirs` counts the `batch-*` directory plus every `dir-*` mkdir under it for that batch.
+
+#### Formulas for `N_dirs` (one `batch-*` tree)
+
+Let **D** = `META_DIR_DEPTH`, **F** = `META_FANOUT`, **K** = `META_FILES_PER_DIR`.
+
+| Case | Condition | `N_dirs` | `N_files` |
+|------|-----------|----------|-----------|
+| Flat batch | `D = 0` | `1` | `K` |
+| Fanout tree | `D ≥ 1` and `F ≥ 2` | `1 + F + F² + … + F^D = (F^{D+1} − 1) / (F − 1)` | `K × N_dirs` |
+| Single chain | `D ≥ 1` and `F = 1` | `1 + D` (root + one child per level) | `K × (1 + D)` |
+| No fanout | `D ≥ 1` and `F = 0` | `1` (no subdirs created; files only under `batch-*`) | `K` |
+
+Then **each completed batch** adds **`N_dirs` directories** and **`N_files` files** on that mount (plus the next `batch-(n+1)` repeats).
+
+**`META_BATCH_COUNT` (default `0`):** `0` = unlimited batches. If **B ≥ 1**, each mount’s worker builds **`batch-0` … `batch-(B−1)`** (exactly **B** trees), then exits. Per mount, cumulative dirs ≈ **`B × N_dirs`** and files ≈ **`B × N_files`** (each `batch-*` is one top-level dir per tree). With **`NUM_MOUNTS` = M**, multiply those totals by **M** (each mount has its own counter). After all workers finish, the entrypoint runs **`sleep infinity`** so the Pod stays **Running** for logs and inspection; delete the Pod or send SIGTERM to stop. With **unlimited** batches, aggregate growth per “one batch round” across mounts is still about **× M** vs a single mount (workers are not synchronized).
+
+#### Worked examples (per mount, one batch)
+
+| D | F | K | `N_dirs` (calculation) | `N_files` |
+|---|---|---|-------------------------|-----------|
+| 2 | 4 | 20 | `1+4+16 = 21` | `21×20 = 420` |
+| 0 | * | 50 | `1` | `50` |
+| 1 | 10 | 100 | `1+10 = 11` | `1100` |
+| 3 | 2 | 5 | `1+2+4+8 = 15` | `75` |
+| 4 | 2 | 1 | `1+2+4+8+16 = 31` | `31` |
+| 5 | 1 | 20 | `1+5 = 6` | `120` |
+| 2 | 0 | 30 | `1` | `30` |
+| 3 | 3 | 10 | `1+3+9+27 = 40` | `400` |
+
+**Large-tree warning:** e.g. `D=4`, `F=10` → `N_dirs = 11111`, and with `K=20` → **222220 files per batch** on that mount alone. Increase **D/F/K** gradually.
+
+**Other knobs:**
+
+| Variable | Role |
+|----------|------|
+| `META_OP_PAUSE_SEC` | Sleep after each mkdir or file create (throttle master; fractional OK). |
+| `META_BATCH_PAUSE_SEC` | Sleep after finishing one full `batch-*` tree. |
+| `META_BATCH_COUNT` | `0` = unlimited; `B ≥ 1` = run **B** batches (`batch-0` … `batch-B−1`) per mount, then worker exits; entrypoint then idles (`sleep infinity`). |
+| `META_WRITE_FILE_DATA` | `0` = `touch` (empty file); `1` = `echo "m"` (minimal write). |
+| `META_STOP_ON_ERROR` | `1` = exit worker on first failure (easier to capture limit errors). |
+| `NUM_MOUNTS` | Parallel FUSE workers (default `1` in metadata script). |
+
+**Caution:** `F` and `D` together grow **roughly like F^D** directories per batch. Increase gradually to avoid OOM or overwhelming the master.
+
+### Resource names
+
+- StatefulSet / Service: `curvine-metadata-stress`
+- ConfigMap: `curvine-metadata-stress-scripts`
+- Secret: `curvine-stress-master` (same name as master-stress; `kubectl apply` merges if already present)
+
+---
+
+## Comparison (at a glance)
+
+```mermaid
+%%{init: {"theme": "dark", "themeVariables": {"primaryColor": "#334155", "primaryTextColor": "#f1f5f9", "lineColor": "#94a3b8"}}}%%
+flowchart TB
+  subgraph MS[deployment.yaml — connection stress]
+    A1[Many curvine-fuse mounts]
+    A2[Mixed POSIX: bulk rename links dir mv]
+    A3[Deletes between stages / bounded tree]
+  end
+  subgraph ST[deployment-metadata-stable.yaml — stability]
+    S1[Same mixed POSIX loop as §1]
+    S2[Diverse metadata paths under load]
+  end
+  subgraph MD[deployment-metadata-stress.yaml — pressure]
+    B1[mkdir + file create only]
+    B2[batch trees / META_* tuning]
+    B3[No workload deletes / growth]
+  end
+```
+
+| Aspect | `deployment.yaml` | `deployment-metadata-stable.yaml` | `deployment-metadata-stress.yaml` |
+|--------|---------------------|-----------------------------------|-----------------------------------|
+| Primary intent | Many mounts + master/FUSE churn | **Metadata stability** (mixed ops, same family as §1) | **Metadata pressure** (monotonic growth) |
+| FUSE operations | Mixed POSIX + deletes each round | Same idea as §1 | mkdir + create files only |
+| Namespace growth | Churn (rm between stages) | Churn (rm between stages) | Grows until limits / manual cleanup |
+| Default remote root | `/curvine-master-stress` | Same as §1 unless changed | `/curvine-metadata-stress` |
+| Key tuning | `NUM_MOUNTS`, `INTERVAL_SEC`, `STRESS_BULK_FILE_COUNT` | Same as §1 | `META_DIR_DEPTH`, `META_FANOUT`, `META_FILES_PER_DIR`, `META_WRITE_FILE_DATA`, `META_BATCH_COUNT`, pauses |
+| K8s name clash with §1 | — | **Yes** (do not apply both) | **No** (different StatefulSet name) |
+
+---
+
+## Example use cases
+
+1. **Smoke (connection or stability):** Apply `deployment.yaml` or `deployment-metadata-stable.yaml` with defaults; confirm Pod Running and logs show mount OK + worker loops.
+2. **High mount count (§1 or §2):** Set `NUM_MOUNTS` to 50–200 (watch CPU/memory and master QPS).
+3. **Metadata stability soak:** Run `deployment-metadata-stable.yaml` (or `deployment.yaml`) for hours/days with tuned `INTERVAL_SEC` to watch for leaks, stuck mounts, or RPC errors across rename/link/readdir paths.
+4. **Slower, gentler master load:** Increase `INTERVAL_SEC` (§1/§2) or `META_OP_PAUSE_SEC` (§3).
+5. **Metadata pressure, small tree:** `deployment-metadata-stress.yaml` with `META_DIR_DEPTH=0`, `META_FILES_PER_DIR=1000`, many batches over time.
+6. **Deep narrow tree (§3):** `META_DIR_DEPTH=5`, `META_FANOUT=1`, moderate `META_FILES_PER_DIR`.
+7. **Wide shallow tree (§3):** `META_DIR_DEPTH=2`, `META_FANOUT=10`, small `META_FILES_PER_DIR` first.
+8. **Accumulate across Pod restarts:** `SKIP_REMOTE_POD_CLEANUP=1` on metadata **stress** (§3); disk/metadata usage grows; plan cleanup separately.
+9. **Fail fast at limit (§3):** `META_STOP_ON_ERROR=1` when probing inode or space ceilings.
+10. **Isolate from another run:** Change `STRESS_REMOTE_ROOT` so two StatefulSets do not share the same remote prefix.
+11. **Multi-replica:** Increase StatefulSet `replicas` only after checking anti-affinity and node capacity (each replica is another full stress Pod).
+
+---
+
+## Cleanup
+
+```bash
+kubectl delete -f master-stress/deployment.yaml
+# Only if you applied it (not alongside deployment.yaml):
+kubectl delete -f master-stress/deployment-metadata-stable.yaml
+kubectl delete -f master-stress/deployment-metadata-stress.yaml
+```
+
+Remote paths are **not** deleted by these commands; use `curvine-cli fs rm --recursive <path>` (or your ops procedure) if you need to reclaim cluster metadata/storage.

--- a/curvine-tests/benchmark/master-stress/deployment-metadata-stable.yaml
+++ b/curvine-tests/benchmark/master-stress/deployment-metadata-stable.yaml
@@ -1,0 +1,494 @@
+# Master connection stress: StatefulSet (Parallel) + headless Service + ConfigMap.
+# FUSE mount points: /fuse-mnts/curvine-fuse1 .. N (writable emptyDir; not under read-only /).
+# Host /dev/fuse is mounted into the pod (many minimal images lack a working FUSE char dev).
+# Remote layout: STRESS_REMOTE_ROOT (default /curvine-master-stress) / ${POD_NAME} / {i} — one subtree per Pod.
+# On start: curvine-cli fs rm -r ${STRESS_REMOTE_ROOT}/${POD_NAME} (unless SKIP_REMOTE_POD_CLEANUP=1), then mkdir each leaf.
+# Pod anti-affinity: at most one stress pod per node (replicas > node count => Pending).
+# All resources in namespace curvine (create ns first: kubectl create namespace curvine).
+# Edit image if needed; default master-addrs in Secret. kubectl apply -f deployment.yaml
+#
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: curvine-stress-master
+  namespace: default
+type: Opaque
+stringData:
+  master-addrs: "cv-curvine-master-0.cv-curvine-master.default.svc.cluster.local:8995,cv-curvine-master-1.cv-curvine-master.default.svc.cluster.local:8995,cv-curvine-master-2.cv-curvine-master.default.svc.cluster.local:8995"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: curvine-stress-scripts
+  namespace: default
+data:
+  stress-entrypoint.sh: |
+    #!/usr/bin/env bash
+    #
+    # Curvine master connection stress: N independent curvine-fuse processes, each with
+    # its own mnt-path and fs-path; each stage ends with RM (after rename / after links / after dir mv).
+    #
+    # Env: MASTER_ADDRS (required), POD_NAME, NUM_MOUNTS, INTERVAL_SEC, FUSE_WEB_PORT_BASE,
+    #      INTERVAL_SEC (default 1) — sleep after every operation; fractional seconds OK (e.g. 0.1).
+    #      MNT_ROOT (default /fuse-mnts) — must be writable (emptyDir).
+    #      STRESS_REMOTE_ROOT (default /curvine-master-stress) — shared parent; each pod uses .../${POD_NAME}/.
+    #      SKIP_REMOTE_POD_CLEANUP=1 — do not fs rm -r ${STRESS_REMOTE_ROOT}/${POD_NAME} on start.
+    #      FUSE_USE_DEFAULT_OPTS=1 — use curvine-fuse built-in fuse opts (includes allow_other).
+    #      SKIP_REMOTE_MKDIR=1 — skip curvine-cli mkdir (paths must already exist on cluster).
+    #      CURVINE_CLI — path to curvine-cli binary (default: PATH or /opt/curvine/curvine-cli).
+    #      STRESS_BULK_FILE_COUNT (default 1) — serial bulk-N.dat create → ls/du → stat each → rm each per round.
+    #
+    set -u
+
+    : "${MASTER_ADDRS:?MASTER_ADDRS must be set (e.g. m1:8995,m2:8995)}"
+
+    POD_NAME="${POD_NAME:-$(hostname)}"
+    NUM_MOUNTS="${NUM_MOUNTS:-100}"
+    INTERVAL_SEC="${INTERVAL_SEC:-1}"
+    FUSE_WEB_PORT_BASE="${FUSE_WEB_PORT_BASE:-28000}"
+    MNT_ROOT="${MNT_ROOT:-/fuse-mnts}"
+    STRESS_REMOTE_ROOT="${STRESS_REMOTE_ROOT:-/curvine-master-stress}"
+    case "${STRESS_REMOTE_ROOT}" in
+      /*) ;;
+      *) STRESS_REMOTE_ROOT="/${STRESS_REMOTE_ROOT}" ;;
+    esac
+    if [ "${STRESS_REMOTE_ROOT}" = "/" ]; then
+      echo "ERROR: STRESS_REMOTE_ROOT must not be /" >&2
+      exit 1
+    fi
+    REMOTE_POD_PREFIX="${STRESS_REMOTE_ROOT}/${POD_NAME}"
+
+    if ! [[ "${NUM_MOUNTS}" =~ ^[0-9]+$ ]] || [ "${NUM_MOUNTS}" -lt 1 ]; then
+      echo "NUM_MOUNTS must be a positive integer" >&2
+      exit 1
+    fi
+
+    STRESS_BULK_FILE_COUNT="${STRESS_BULK_FILE_COUNT:-1}"
+    if ! [[ "${STRESS_BULK_FILE_COUNT}" =~ ^[0-9]+$ ]] || [ "${STRESS_BULK_FILE_COUNT}" -lt 1 ]; then
+      echo "STRESS_BULK_FILE_COUNT must be a positive integer (default 1)" >&2
+      exit 1
+    fi
+
+    mkdir -p "${MNT_ROOT}" || {
+      echo "ERROR: cannot create writable MNT_ROOT=${MNT_ROOT} (read-only root? mount emptyDir here)" >&2
+      exit 1
+    }
+    echo "[bootstrap] MNT_ROOT=${MNT_ROOT} REMOTE_POD_PREFIX=${REMOTE_POD_PREFIX} NUM_MOUNTS=${NUM_MOUNTS} STRESS_BULK_FILE_COUNT=${STRESS_BULK_FILE_COUNT}"
+
+    if [ ! -c /dev/fuse ]; then
+      echo "ERROR: /dev/fuse is missing or not a character device. Mount host /dev/fuse (see manifest volumes)." >&2
+      ls -la /dev 2>&1 | head -n 40 >&2 || true
+      exit 1
+    fi
+    echo "[bootstrap] $(ls -l /dev/fuse)"
+
+    if ! command -v fusermount3 >/dev/null 2>&1 && ! command -v fusermount >/dev/null 2>&1; then
+      echo "WARN: neither fusermount3 nor fusermount found in PATH; auto_unmount may misbehave" >&2
+    fi
+
+    # Drop allow_other for single-user container mounts; avoids fuse.conf edge cases.
+    CURVINE_FUSE_EXTRA=(--options async --options auto_unmount)
+    if [ "${FUSE_USE_DEFAULT_OPTS:-0}" = 1 ]; then
+      CURVINE_FUSE_EXTRA=()
+    fi
+
+    if [ "${FUSE_USE_DEFAULT_OPTS:-0}" = 1 ] && [ -f /etc/fuse.conf ] && ! grep -qE '^[[:space:]]*user_allow_other' /etc/fuse.conf 2>/dev/null; then
+      echo 'user_allow_other' >>/etc/fuse.conf
+    fi
+
+    resolve_curvine_cli() {
+      if [ -n "${CURVINE_CLI:-}" ] && [ -x "${CURVINE_CLI}" ]; then
+        echo "${CURVINE_CLI}"
+        return 0
+      fi
+      if command -v curvine-cli >/dev/null 2>&1; then
+        command -v curvine-cli
+        return 0
+      fi
+      if [ -x /opt/curvine/curvine-cli ]; then
+        echo /opt/curvine/curvine-cli
+        return 0
+      fi
+      return 1
+    }
+
+    # Remote fs-path roots must exist; otherwise FUSE mount succeeds but stat/ls on the mount
+    # shows d????????? and "cannot access" (no valid root inode metadata).
+    REMOTE_CLI_NEEDED=0
+    if [ "${SKIP_REMOTE_POD_CLEANUP:-0}" != 1 ]; then
+      REMOTE_CLI_NEEDED=1
+    fi
+    if [ "${SKIP_REMOTE_MKDIR:-0}" != 1 ]; then
+      REMOTE_CLI_NEEDED=1
+    fi
+
+    CLI_BIN=""
+    if [ "${REMOTE_CLI_NEEDED}" = 1 ]; then
+      if ! CLI_BIN="$(resolve_curvine_cli)"; then
+        echo "ERROR: curvine-cli not found. Set CURVINE_CLI, or set SKIP_REMOTE_POD_CLEANUP=1 and SKIP_REMOTE_MKDIR=1." >&2
+        exit 1
+      fi
+    fi
+
+    if [ "${SKIP_REMOTE_POD_CLEANUP:-0}" != 1 ] && [ -n "${CLI_BIN}" ]; then
+      echo "[bootstrap] remote cleanup (this pod only): fs rm --recursive ${REMOTE_POD_PREFIX}"
+      "${CLI_BIN}" --master-addrs "${MASTER_ADDRS}" fs rm "${REMOTE_POD_PREFIX}" --recursive || true
+    fi
+
+    if [ "${SKIP_REMOTE_MKDIR:-0}" != 1 ]; then
+      echo "[bootstrap] creating remote fs-path roots under ${REMOTE_POD_PREFIX} via ${CLI_BIN}"
+      for i in $(seq 1 "${NUM_MOUNTS}"); do
+        fs_path="${REMOTE_POD_PREFIX}/${i}"
+        echo "[bootstrap] remote mkdir ${fs_path}"
+        if ! "${CLI_BIN}" --master-addrs "${MASTER_ADDRS}" fs mkdir "${fs_path}" --parents; then
+          echo "ERROR: curvine-cli mkdir failed for ${fs_path}" >&2
+          exit 1
+        fi
+      done
+    else
+      echo "[bootstrap] SKIP_REMOTE_MKDIR=1 — ensure ${REMOTE_POD_PREFIX}/1..N exist on Curvine"
+    fi
+
+    declare -a FUSE_PIDS=()
+    declare -a WORKER_PIDS=()
+
+    cleanup() {
+      echo "Stopping workers and fuse processes..."
+      for pid in "${WORKER_PIDS[@]:-}"; do
+        kill "${pid}" 2>/dev/null || true
+      done
+      for pid in "${FUSE_PIDS[@]:-}"; do
+        kill "${pid}" 2>/dev/null || true
+      done
+      wait 2>/dev/null || true
+    }
+
+    trap cleanup SIGTERM SIGINT EXIT
+
+    wait_mount_ready() {
+      local idx="$1"
+      local mnt_path="$2"
+      local logf="/tmp/fuse-${idx}.log"
+      local deadline=$((SECONDS + 180))
+      while [ "${SECONDS}" -lt "${deadline}" ]; do
+        if mountpoint -q "${mnt_path}" 2>/dev/null; then
+          echo "[fuse ${idx}] mount OK ${mnt_path}"
+          return 0
+        fi
+        if ! kill -0 "${FUSE_PIDS[$((idx - 1))]}" 2>/dev/null; then
+          echo "[fuse ${idx}] process exited before mount; log tail:" >&2
+          tail -n 120 "${logf}" >&2 || true
+          return 1
+        fi
+        sleep 0.5
+      done
+      echo "Timeout waiting for mount at ${mnt_path}" >&2
+      echo "=== fuse-${idx}.log (last 120 lines) ===" >&2
+      tail -n 120 "${logf}" >&2 || true
+      return 1
+    }
+
+    echo "Starting ${NUM_MOUNTS} curvine-fuse instances for pod=${POD_NAME}"
+
+    for i in $(seq 1 "${NUM_MOUNTS}"); do
+      mnt_path="${MNT_ROOT}/curvine-fuse${i}"
+      fs_path="${REMOTE_POD_PREFIX}/${i}"
+      web_port=$((FUSE_WEB_PORT_BASE + i))
+      mkdir -p "${mnt_path}" || {
+        echo "ERROR: mkdir failed for ${mnt_path}" >&2
+        exit 1
+      }
+      logf="/tmp/fuse-${i}.log"
+      echo "[fuse ${i}] start mnt_path=${mnt_path} fs_path=${fs_path} web_port=${web_port}"
+      curvine-fuse \
+        --mnt-path "${mnt_path}" \
+        --fs-path "${fs_path}" \
+        --master-addrs "${MASTER_ADDRS}" \
+        --web-port "${web_port}" \
+        "${CURVINE_FUSE_EXTRA[@]}" >>"${logf}" 2>&1 &
+      FUSE_PIDS+=($!)
+    done
+
+    sleep 5
+
+    for i in $(seq 1 "${NUM_MOUNTS}"); do
+      wait_mount_ready "${i}" "${MNT_ROOT}/curvine-fuse${i}" || exit 1
+    done
+
+    echo "All mounts are up; starting workload loops (INTERVAL_SEC=${INTERVAL_SEC} between ops)"
+
+    run_worker() {
+      local id="$1"
+      local base="${MNT_ROOT}/curvine-fuse${id}/.stress-workload"
+      mkdir -p "${base}" || {
+        echo "[worker ${id}] ERROR mkdir ${base}" >&2
+        return 1
+      }
+      while true; do
+        rm -f "${base}/blob.dat" "${base}/blob_named.dat" "${base}/link_src.dat" "${base}/link_hard.dat" "${base}/link_sym.dat" 2>/dev/null || true
+        rm -f "${base}"/bulk-*.dat 2>/dev/null || true
+        rm -rf "${base}/mvdir" "${base}/mvdir2" "${base}/subdir" 2>/dev/null || true
+
+        # --- bulk files (serial): sleep after each create, ls, du, each stat, each rm ---
+        echo "[worker ${id}] BULK create ${STRESS_BULK_FILE_COUNT} file(s) under ${base}"
+        n=1
+        while [ "${n}" -le "${STRESS_BULK_FILE_COUNT}" ]; do
+          echo "[worker ${id}] BULK PUT ${base}/bulk-${n}.dat"
+          echo "bulk-${id}-${n}-$(date +%s%N)" >"${base}/bulk-${n}.dat" || echo "[worker ${id}] WARN bulk write failed n=${n}" >&2
+          sleep "${INTERVAL_SEC}"
+          n=$((n + 1))
+        done
+
+        echo "[worker ${id}] BULK LS ${base}"
+        ls -la "${base}" || true
+        sleep "${INTERVAL_SEC}"
+
+        echo "[worker ${id}] BULK DU ${base}"
+        du -sh "${base}" 2>/dev/null || du -sk "${base}" 2>/dev/null || true
+        sleep "${INTERVAL_SEC}"
+
+        n=1
+        while [ "${n}" -le "${STRESS_BULK_FILE_COUNT}" ]; do
+          echo "[worker ${id}] BULK STAT ${base}/bulk-${n}.dat"
+          stat "${base}/bulk-${n}.dat" || true
+          sleep "${INTERVAL_SEC}"
+          n=$((n + 1))
+        done
+
+        n=1
+        while [ "${n}" -le "${STRESS_BULK_FILE_COUNT}" ]; do
+          echo "[worker ${id}] BULK RM ${base}/bulk-${n}.dat"
+          rm -f "${base}/bulk-${n}.dat" || true
+          sleep "${INTERVAL_SEC}"
+          n=$((n + 1))
+        done
+
+        # --- file rename; then delete so this stage leaves no file ---
+        echo "[worker ${id}] PUT ${base}/blob.dat"
+        echo "stress-${id}-$(date +%s%N)" >"${base}/blob.dat" || echo "[worker ${id}] WARN write failed" >&2
+        sleep "${INTERVAL_SEC}"
+
+        echo "[worker ${id}] LS ${base}"
+        ls -la "${base}" || echo "[worker ${id}] WARN ls failed" >&2
+        sleep "${INTERVAL_SEC}"
+
+        echo "[worker ${id}] STAT ${base}/blob.dat"
+        stat "${base}/blob.dat" || echo "[worker ${id}] WARN stat failed" >&2
+        sleep "${INTERVAL_SEC}"
+
+        echo "[worker ${id}] DU ${base}"
+        du -sh "${base}" 2>/dev/null || du -sk "${base}" 2>/dev/null || echo "[worker ${id}] WARN du failed" >&2
+        sleep "${INTERVAL_SEC}"
+
+        echo "[worker ${id}] MV rename blob.dat -> blob_named.dat"
+        mv -f "${base}/blob.dat" "${base}/blob_named.dat" || echo "[worker ${id}] WARN mv file failed" >&2
+        sleep "${INTERVAL_SEC}"
+
+        echo "[worker ${id}] LS ${base} (after rename)"
+        ls -la "${base}" || true
+        sleep "${INTERVAL_SEC}"
+
+        echo "[worker ${id}] STAT ${base}/blob_named.dat"
+        stat "${base}/blob_named.dat" || true
+        sleep "${INTERVAL_SEC}"
+
+        echo "[worker ${id}] RM (after rename) blob_named.dat"
+        rm -f "${base}/blob_named.dat" || true
+        sleep "${INTERVAL_SEC}"
+
+        # --- links on a fresh file; then delete all names so this stage is clean ---
+        echo "[worker ${id}] PUT ${base}/link_src.dat"
+        echo "link-${id}-$(date +%s%N)" >"${base}/link_src.dat" || echo "[worker ${id}] WARN write link_src failed" >&2
+        sleep "${INTERVAL_SEC}"
+
+        echo "[worker ${id}] LN hard link_src.dat -> link_hard.dat"
+        ln "${base}/link_src.dat" "${base}/link_hard.dat" || echo "[worker ${id}] WARN hardlink failed" >&2
+        sleep "${INTERVAL_SEC}"
+
+        echo "[worker ${id}] LN -s link_src.dat -> link_sym.dat"
+        ln -sf link_src.dat "${base}/link_sym.dat" || echo "[worker ${id}] WARN symlink failed" >&2
+        sleep "${INTERVAL_SEC}"
+
+        echo "[worker ${id}] LS ${base} (after links)"
+        ls -la "${base}" || true
+        sleep "${INTERVAL_SEC}"
+
+        echo "[worker ${id}] STAT ${base}/link_sym.dat"
+        stat "${base}/link_sym.dat" || true
+        sleep "${INTERVAL_SEC}"
+
+        echo "[worker ${id}] READLINK ${base}/link_sym.dat"
+        readlink "${base}/link_sym.dat" || readlink -f "${base}/link_sym.dat" || true
+        sleep "${INTERVAL_SEC}"
+
+        echo "[worker ${id}] DU ${base} (with links)"
+        du -sh "${base}" 2>/dev/null || du -sk "${base}" 2>/dev/null || true
+        sleep "${INTERVAL_SEC}"
+
+        echo "[worker ${id}] RM (after links) link_hard.dat link_sym.dat link_src.dat"
+        rm -f "${base}/link_hard.dat" "${base}/link_sym.dat" "${base}/link_src.dat" || true
+        sleep "${INTERVAL_SEC}"
+
+        echo "[worker ${id}] MKDIR ${base}/mvdir + inner.txt"
+        mkdir -p "${base}/mvdir" || echo "[worker ${id}] WARN mkdir mvdir failed" >&2
+        echo "nested-${id}" >"${base}/mvdir/inner.txt" || true
+        sleep "${INTERVAL_SEC}"
+
+        echo "[worker ${id}] DU ${base}/mvdir"
+        du -sh "${base}/mvdir" 2>/dev/null || true
+        sleep "${INTERVAL_SEC}"
+
+        echo "[worker ${id}] STAT ${base}/mvdir/inner.txt"
+        stat "${base}/mvdir/inner.txt" || true
+        sleep "${INTERVAL_SEC}"
+
+        echo "[worker ${id}] MV rename dir mvdir -> mvdir2"
+        mv -f "${base}/mvdir" "${base}/mvdir2" || echo "[worker ${id}] WARN mv dir failed" >&2
+        sleep "${INTERVAL_SEC}"
+
+        echo "[worker ${id}] LS ${base}/mvdir2"
+        ls -la "${base}/mvdir2" || true
+        sleep "${INTERVAL_SEC}"
+
+        echo "[worker ${id}] DU ${base}/mvdir2"
+        du -sh "${base}/mvdir2" 2>/dev/null || true
+        sleep "${INTERVAL_SEC}"
+
+        echo "[worker ${id}] RM (after dir rename) inner.txt + rmdir mvdir2"
+        rm -f "${base}/mvdir2/inner.txt" || true
+        rmdir "${base}/mvdir2" 2>/dev/null || rm -rf "${base}/mvdir2" || true
+        sleep "${INTERVAL_SEC}"
+
+        echo "[worker ${id}] MKDIR ${base}/subdir"
+        mkdir -p "${base}/subdir" || echo "[worker ${id}] WARN mkdir subdir failed" >&2
+        sleep "${INTERVAL_SEC}"
+        echo "[worker ${id}] RMDIR ${base}/subdir"
+        rmdir "${base}/subdir" 2>/dev/null || true
+        sleep "${INTERVAL_SEC}"
+      done
+    }
+
+    for i in $(seq 1 "${NUM_MOUNTS}"); do
+      run_worker "${i}" &
+      WORKER_PIDS+=($!)
+    done
+
+    echo "Stress running; forward SIGTERM to stop."
+    wait
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: curvine-master-stress
+  namespace: default
+  labels:
+    app: curvine-master-stress
+spec:
+  clusterIP: None
+  selector:
+    app: curvine-master-stress
+  ports:
+    - port: 9999
+      name: noop
+      targetPort: 9999
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: curvine-master-stress
+  namespace: default 
+  labels:
+    app: curvine-master-stress
+spec:
+  serviceName: curvine-master-stress
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      app: curvine-master-stress
+  template:
+    metadata:
+      labels:
+        app: curvine-master-stress
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - curvine-master-stress
+              topologyKey: kubernetes.io/hostname
+      containers:
+        - name: stress
+          image: ghcr.io/curvineio/curvine-csi:latest
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+            capabilities:
+              add:
+                - SYS_ADMIN
+          command: ["/bin/bash", "/scripts/stress-entrypoint.sh"]
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MASTER_ADDRS
+              valueFrom:
+                secretKeyRef:
+                  name: curvine-stress-master
+                  key: master-addrs
+            # - name: NUM_MOUNTS
+            #   value: "100"
+            # - name: STRESS_BULK_FILE_COUNT
+            #   value: "1"
+            # - name: INTERVAL_SEC
+            #   value: "1"
+            # - name: FUSE_WEB_PORT_BASE
+            #   value: "28000"
+            # - name: MNT_ROOT
+            #   value: "/fuse-mnts"
+            # - name: FUSE_USE_DEFAULT_OPTS
+            #   value: "1"
+            # - name: SKIP_REMOTE_MKDIR
+            #   value: "1"
+            # - name: CURVINE_CLI
+            #   value: "/opt/curvine/curvine-cli"
+            # - name: STRESS_REMOTE_ROOT
+            #   value: "/curvine-master-stress"
+            # - name: SKIP_REMOTE_POD_CLEANUP
+            #   value: "1"
+          volumeMounts:
+            - name: dev-fuse
+              mountPath: /dev/fuse
+            - name: stress-scripts
+              mountPath: /scripts
+              readOnly: true
+            - name: fuse-mnt-root
+              mountPath: /fuse-mnts
+            - name: fuse-tmp
+              mountPath: /tmp
+          resources:
+            requests:
+              cpu: "2"
+              memory: 4Gi
+            limits:
+              cpu: "8"
+              memory: 16Gi
+      volumes:
+        - name: dev-fuse
+          hostPath:
+            path: /dev/fuse
+            type: CharDevice
+        - name: stress-scripts
+          configMap:
+            name: curvine-stress-scripts
+            defaultMode: 0755
+        - name: fuse-mnt-root
+          emptyDir: {}
+        - name: fuse-tmp
+          emptyDir: {}

--- a/curvine-tests/benchmark/master-stress/deployment-metadata-stress.yaml
+++ b/curvine-tests/benchmark/master-stress/deployment-metadata-stress.yaml
@@ -1,0 +1,454 @@
+# Curvine metadata ceiling stress: StatefulSet + headless Service + ConfigMap.
+# Same FUSE/bootstrap model as deployment.yaml, but workload only creates dirs/files (no rm/rmdir).
+#
+# Remote layout: STRESS_REMOTE_ROOT (default /curvine-metadata-stress) / ${POD_NAME} / {mountIndex}
+# Workload root per mount: .../mount/.metadata-stress/
+# Each batch: .../batch-<n>/ with a tree controlled by META_* env vars.
+#
+# Tree model (per batch directory):
+#   META_DIR_DEPTH: how many levels of subdirectories to create below the batch root.
+#     0 = no subdirs; only META_FILES_PER_DIR files in the batch folder.
+#   META_FANOUT: when depth > 0, create this many child directories under each directory,
+#     then recurse with depth-1. Child dir names are dir-<globalCounter> for uniqueness.
+#   META_FILES_PER_DIR: after processing children (if any), create this many tiny files
+#     in the current directory (names f-<globalCounter>).
+#
+# Growth per batch (approximate, fanout F, depth D, files K per dir):
+#   Dir count ~= sum_{i=0..D} F^i = (F^(D+1)-1)/(F-1) for F>1; D+1 for F=1; 1 for D=0.
+#   File count ~= K * (that dir count). Use small defaults first; huge F^D can stall the pod.
+#
+# Env (worker / metadata):
+#   META_DIR_DEPTH (default 2), META_FANOUT (default 4), META_FILES_PER_DIR (default 20)
+#   META_BATCH_PAUSE_SEC (default 0) — sleep after each full batch tree
+#   META_BATCH_COUNT (default 0) — if >= 1, run exactly that many batches per worker (batch-0 .. batch-(N-1)) then exit;
+#     0 = unlimited batches. After all workers finish, entrypoint sleeps forever so the Pod stays up (delete pod to stop).
+#   META_OP_PAUSE_SEC (default 0) — sleep after each mkdir/file op (throttle master); fractional OK
+#   META_WRITE_FILE_DATA (default 0) — 0: empty files via touch; 1: write one byte via echo "m" > file
+#   META_STOP_ON_ERROR (default 0) — set to 1 to exit worker on first mkdir/file failure
+#
+# Shared with master-stress deployment:
+#   MASTER_ADDRS, POD_NAME, NUM_MOUNTS, MNT_ROOT, STRESS_REMOTE_ROOT, FUSE_WEB_PORT_BASE,
+#   SKIP_REMOTE_POD_CLEANUP, SKIP_REMOTE_MKDIR, FUSE_USE_DEFAULT_OPTS, CURVINE_CLI, INTERVAL_SEC
+#   (INTERVAL_SEC is kept for compatibility; metadata workload prefers META_* pauses.)
+#
+# All resources in namespace default (adjust if needed). kubectl apply -f deployment-metadata-stress.yaml
+#
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: curvine-stress-master
+  namespace: default
+type: Opaque
+stringData:
+  master-addrs: "cv-curvine-master-0.cv-curvine-master.default.svc.cluster.local:8995,cv-curvine-master-1.cv-curvine-master.default.svc.cluster.local:8995,cv-curvine-master-2.cv-curvine-master.default.svc.cluster.local:8995"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: curvine-metadata-stress-scripts
+  namespace: default
+data:
+  metadata-stress-entrypoint.sh: |
+    #!/usr/bin/env bash
+    #
+    # Metadata stress: monotonically create directories and files under FUSE mounts (no deletes).
+    #
+    set -u
+
+    : "${MASTER_ADDRS:?MASTER_ADDRS must be set (e.g. m1:8995,m2:8995)}"
+
+    POD_NAME="${POD_NAME:-$(hostname)}"
+    NUM_MOUNTS="${NUM_MOUNTS:-1}"
+    FUSE_WEB_PORT_BASE="${FUSE_WEB_PORT_BASE:-29000}"
+    MNT_ROOT="${MNT_ROOT:-/fuse-mnts}"
+    STRESS_REMOTE_ROOT="${STRESS_REMOTE_ROOT:-/curvine-metadata-stress}"
+    case "${STRESS_REMOTE_ROOT}" in
+      /*) ;;
+      *) STRESS_REMOTE_ROOT="/${STRESS_REMOTE_ROOT}" ;;
+    esac
+    if [ "${STRESS_REMOTE_ROOT}" = "/" ]; then
+      echo "ERROR: STRESS_REMOTE_ROOT must not be /" >&2
+      exit 1
+    fi
+    REMOTE_POD_PREFIX="${STRESS_REMOTE_ROOT}/${POD_NAME}"
+
+    META_DIR_DEPTH="${META_DIR_DEPTH:-2}"
+    META_FANOUT="${META_FANOUT:-4}"
+    META_FILES_PER_DIR="${META_FILES_PER_DIR:-20}"
+    META_BATCH_PAUSE_SEC="${META_BATCH_PAUSE_SEC:-0}"
+    META_BATCH_COUNT="${META_BATCH_COUNT:-0}"
+    META_OP_PAUSE_SEC="${META_OP_PAUSE_SEC:-0}"
+    META_STOP_ON_ERROR="${META_STOP_ON_ERROR:-0}"
+    META_WRITE_FILE_DATA="${META_WRITE_FILE_DATA:-0}"
+
+    if ! [[ "${NUM_MOUNTS}" =~ ^[0-9]+$ ]] || [ "${NUM_MOUNTS}" -lt 1 ]; then
+      echo "NUM_MOUNTS must be a positive integer" >&2
+      exit 1
+    fi
+    for v in META_DIR_DEPTH META_FANOUT META_FILES_PER_DIR META_BATCH_COUNT; do
+      val="${!v}"
+      if ! [[ "${val}" =~ ^[0-9]+$ ]]; then
+        echo "${v} must be a non-negative integer" >&2
+        exit 1
+      fi
+    done
+    if [ "${META_WRITE_FILE_DATA}" != "0" ] && [ "${META_WRITE_FILE_DATA}" != "1" ]; then
+      echo "META_WRITE_FILE_DATA must be 0 or 1" >&2
+      exit 1
+    fi
+
+    mkdir -p "${MNT_ROOT}" || {
+      echo "ERROR: cannot create writable MNT_ROOT=${MNT_ROOT}" >&2
+      exit 1
+    }
+    echo "[bootstrap] metadata-stress MNT_ROOT=${MNT_ROOT} REMOTE_POD_PREFIX=${REMOTE_POD_PREFIX} NUM_MOUNTS=${NUM_MOUNTS}"
+    echo "[bootstrap] META_DIR_DEPTH=${META_DIR_DEPTH} META_FANOUT=${META_FANOUT} META_FILES_PER_DIR=${META_FILES_PER_DIR} META_BATCH_COUNT=${META_BATCH_COUNT} META_WRITE_FILE_DATA=${META_WRITE_FILE_DATA}"
+
+    if [ ! -c /dev/fuse ]; then
+      echo "ERROR: /dev/fuse is missing or not a character device." >&2
+      exit 1
+    fi
+
+    CURVINE_FUSE_EXTRA=(--options async --options auto_unmount)
+    if [ "${FUSE_USE_DEFAULT_OPTS:-0}" = 1 ]; then
+      CURVINE_FUSE_EXTRA=()
+    fi
+    if [ "${FUSE_USE_DEFAULT_OPTS:-0}" = 1 ] && [ -f /etc/fuse.conf ] && ! grep -qE '^[[:space:]]*user_allow_other' /etc/fuse.conf 2>/dev/null; then
+      echo 'user_allow_other' >>/etc/fuse.conf
+    fi
+
+    resolve_curvine_cli() {
+      if [ -n "${CURVINE_CLI:-}" ] && [ -x "${CURVINE_CLI}" ]; then
+        echo "${CURVINE_CLI}"
+        return 0
+      fi
+      if command -v curvine-cli >/dev/null 2>&1; then
+        command -v curvine-cli
+        return 0
+      fi
+      if [ -x /opt/curvine/curvine-cli ]; then
+        echo /opt/curvine/curvine-cli
+        return 0
+      fi
+      return 1
+    }
+
+    REMOTE_CLI_NEEDED=0
+    if [ "${SKIP_REMOTE_POD_CLEANUP:-0}" != 1 ]; then
+      REMOTE_CLI_NEEDED=1
+    fi
+    if [ "${SKIP_REMOTE_MKDIR:-0}" != 1 ]; then
+      REMOTE_CLI_NEEDED=1
+    fi
+
+    CLI_BIN=""
+    if [ "${REMOTE_CLI_NEEDED}" = 1 ]; then
+      if ! CLI_BIN="$(resolve_curvine_cli)"; then
+        echo "ERROR: curvine-cli not found." >&2
+        exit 1
+      fi
+    fi
+
+    if [ "${SKIP_REMOTE_POD_CLEANUP:-0}" != 1 ] && [ -n "${CLI_BIN}" ]; then
+      echo "[bootstrap] remote cleanup (this pod only): fs rm --recursive ${REMOTE_POD_PREFIX}"
+      "${CLI_BIN}" --master-addrs "${MASTER_ADDRS}" fs rm "${REMOTE_POD_PREFIX}" --recursive || true
+    fi
+
+    if [ "${SKIP_REMOTE_MKDIR:-0}" != 1 ]; then
+      echo "[bootstrap] creating remote fs-path roots under ${REMOTE_POD_PREFIX}"
+      for i in $(seq 1 "${NUM_MOUNTS}"); do
+        fs_path="${REMOTE_POD_PREFIX}/${i}"
+        if ! "${CLI_BIN}" --master-addrs "${MASTER_ADDRS}" fs mkdir "${fs_path}" --parents; then
+          echo "ERROR: curvine-cli mkdir failed for ${fs_path}" >&2
+          exit 1
+        fi
+      done
+    else
+      echo "[bootstrap] SKIP_REMOTE_MKDIR=1 — ensure ${REMOTE_POD_PREFIX}/1..N exist"
+    fi
+
+    declare -a FUSE_PIDS=()
+    declare -a WORKER_PIDS=()
+
+    cleanup() {
+      echo "Stopping workers and fuse processes..."
+      for pid in "${WORKER_PIDS[@]:-}"; do
+        kill "${pid}" 2>/dev/null || true
+      done
+      for pid in "${FUSE_PIDS[@]:-}"; do
+        kill "${pid}" 2>/dev/null || true
+      done
+      wait 2>/dev/null || true
+    }
+
+    trap cleanup SIGTERM SIGINT EXIT
+
+    wait_mount_ready() {
+      local idx="$1"
+      local mnt_path="$2"
+      local logf="/tmp/fuse-md-${idx}.log"
+      local deadline=$((SECONDS + 180))
+      while [ "${SECONDS}" -lt "${deadline}" ]; do
+        if mountpoint -q "${mnt_path}" 2>/dev/null; then
+          echo "[fuse ${idx}] mount OK ${mnt_path}"
+          return 0
+        fi
+        if ! kill -0 "${FUSE_PIDS[$((idx - 1))]}" 2>/dev/null; then
+          echo "[fuse ${idx}] process exited before mount; log tail:" >&2
+          tail -n 120 "${logf}" >&2 || true
+          return 1
+        fi
+        sleep 0.5
+      done
+      echo "Timeout waiting for mount at ${mnt_path}" >&2
+      tail -n 120 "${logf}" >&2 || true
+      return 1
+    }
+
+    for i in $(seq 1 "${NUM_MOUNTS}"); do
+      mnt_path="${MNT_ROOT}/curvine-fuse${i}"
+      fs_path="${REMOTE_POD_PREFIX}/${i}"
+      web_port=$((FUSE_WEB_PORT_BASE + i))
+      mkdir -p "${mnt_path}" || exit 1
+      logf="/tmp/fuse-md-${i}.log"
+      echo "[fuse ${i}] start mnt_path=${mnt_path} fs_path=${fs_path} web_port=${web_port}"
+      curvine-fuse \
+        --mnt-path "${mnt_path}" \
+        --fs-path "${fs_path}" \
+        --master-addrs "${MASTER_ADDRS}" \
+        --web-port "${web_port}" \
+        "${CURVINE_FUSE_EXTRA[@]}" >>"${logf}" 2>&1 &
+      FUSE_PIDS+=($!)
+    done
+
+    sleep 5
+
+    for i in $(seq 1 "${NUM_MOUNTS}"); do
+      wait_mount_ready "${i}" "${MNT_ROOT}/curvine-fuse${i}" || exit 1
+    done
+
+    meta_op_pause() {
+      # sleep accepts fractional seconds; sleep 0 is a no-op
+      sleep "${META_OP_PAUSE_SEC}" 2>/dev/null || true
+    }
+
+    fail_or_warn() {
+      local msg="$1"
+      if [ "${META_STOP_ON_ERROR}" = 1 ]; then
+        echo "ERROR: ${msg}" >&2
+        exit 1
+      fi
+      echo "WARN: ${msg}" >&2
+    }
+
+    run_worker() {
+      local id="$1"
+      local base="${MNT_ROOT}/curvine-fuse${id}/.metadata-stress"
+      mkdir -p "${base}" || {
+        echo "[worker ${id}] ERROR mkdir ${base}" >&2
+        return 1
+      }
+
+      local GLOBAL_DIR_COUNTER=0
+      local GLOBAL_FILE_COUNTER=0
+      local batch=0
+
+      create_files_in_dir() {
+        local d="$1"
+        local wid="$2"
+        local n
+        n=1
+        while [ "${n}" -le "${META_FILES_PER_DIR}" ]; do
+          GLOBAL_FILE_COUNTER=$((GLOBAL_FILE_COUNTER + 1))
+          local fp="${d}/f-${GLOBAL_FILE_COUNTER}"
+          if [ "${META_WRITE_FILE_DATA}" = 1 ]; then
+            if ! echo "m" >"${fp}"; then
+              fail_or_warn "[worker ${wid}] write failed ${fp}"
+            fi
+          else
+            if ! touch "${fp}"; then
+              fail_or_warn "[worker ${wid}] touch failed ${fp}"
+            fi
+          fi
+          meta_op_pause
+          n=$((n + 1))
+        done
+      }
+
+      build_tree() {
+        local d="$1"
+        local depth="$2"
+        local wid="$3"
+        if [ "${depth}" -eq 0 ]; then
+          create_files_in_dir "${d}" "${wid}"
+          return 0
+        fi
+        local j=1
+        while [ "${j}" -le "${META_FANOUT}" ]; do
+          GLOBAL_DIR_COUNTER=$((GLOBAL_DIR_COUNTER + 1))
+          local child="${d}/dir-${GLOBAL_DIR_COUNTER}"
+          if ! mkdir -p "${child}"; then
+            fail_or_warn "[worker ${wid}] mkdir failed ${child}"
+          fi
+          meta_op_pause
+          build_tree "${child}" $((depth - 1)) "${wid}" || return 1
+          j=$((j + 1))
+        done
+        create_files_in_dir "${d}" "${wid}"
+      }
+
+      echo "[worker ${id}] metadata stress loop (no deletes); base=${base}"
+      while true; do
+        local root="${base}/batch-${batch}"
+        if ! mkdir -p "${root}"; then
+          fail_or_warn "[worker ${id}] mkdir failed ${root}"
+        fi
+        meta_op_pause
+        echo "[worker ${id}] batch ${batch} tree root=${root}"
+        build_tree "${root}" "${META_DIR_DEPTH}" "${id}" || true
+        batch=$((batch + 1))
+        sleep "${META_BATCH_PAUSE_SEC}" 2>/dev/null || true
+        if [ "${META_BATCH_COUNT}" -ge 1 ] && [ "${batch}" -ge "${META_BATCH_COUNT}" ]; then
+          echo "[worker ${id}] finished ${META_BATCH_COUNT} batch(es), exiting"
+          return 0
+        fi
+      done
+    }
+
+    echo "All mounts up; starting metadata workers"
+    for i in $(seq 1 "${NUM_MOUNTS}"); do
+      run_worker "${i}" &
+      WORKER_PIDS+=($!)
+    done
+
+    echo "Metadata stress running; SIGTERM to stop."
+    wait
+    echo "[entrypoint] all metadata workers exited"
+    if [ "${META_BATCH_COUNT}" -ge 1 ]; then
+      echo "[entrypoint] META_BATCH_COUNT=${META_BATCH_COUNT} done; holding pod (sleep infinity). Delete pod or send SIGTERM to stop."
+      sleep infinity
+    fi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: curvine-metadata-stress
+  namespace: default
+  labels:
+    app: curvine-metadata-stress
+spec:
+  clusterIP: None
+  selector:
+    app: curvine-metadata-stress
+  ports:
+    - port: 9999
+      name: noop
+      targetPort: 9999
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: curvine-metadata-stress
+  namespace: default
+  labels:
+    app: curvine-metadata-stress
+spec:
+  serviceName: curvine-metadata-stress
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      app: curvine-metadata-stress
+  template:
+    metadata:
+      labels:
+        app: curvine-metadata-stress
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - curvine-metadata-stress
+              topologyKey: kubernetes.io/hostname
+      containers:
+        - name: stress
+          image: ghcr.io/curvineio/curvine-csi:latest
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+            capabilities:
+              add:
+                - SYS_ADMIN
+          command: ["/bin/bash", "/scripts/metadata-stress-entrypoint.sh"]
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MASTER_ADDRS
+              valueFrom:
+                secretKeyRef:
+                  name: curvine-stress-master
+                  key: master-addrs
+            # Recommended: start with small tree; increase META_FANOUT / META_DIR_DEPTH gradually.
+            - name: NUM_MOUNTS
+              value: "1"
+            - name: META_DIR_DEPTH
+              value: "2"
+            - name: META_FANOUT
+              value: "4"
+            - name: META_FILES_PER_DIR
+              value: "20"
+            - name: META_OP_PAUSE_SEC
+              value: "0"
+            - name: META_BATCH_PAUSE_SEC
+              value: "0"
+            - name: META_BATCH_COUNT
+              value: "0"
+            - name: META_WRITE_FILE_DATA
+              value: "0"
+            # - name: META_STOP_ON_ERROR
+            #   value: "0"
+            # - name: FUSE_WEB_PORT_BASE
+            #   value: "29000"
+            # - name: STRESS_REMOTE_ROOT
+            #   value: "/curvine-metadata-stress"
+            # - name: SKIP_REMOTE_POD_CLEANUP
+            #   value: "1"
+            # - name: SKIP_REMOTE_MKDIR
+            #   value: "1"
+          volumeMounts:
+            - name: dev-fuse
+              mountPath: /dev/fuse
+            - name: metadata-stress-scripts
+              mountPath: /scripts
+              readOnly: true
+            - name: fuse-mnt-root
+              mountPath: /fuse-mnts
+            - name: fuse-tmp
+              mountPath: /tmp
+          resources:
+            requests:
+              cpu: "2"
+              memory: 4Gi
+            limits:
+              cpu: "8"
+              memory: 16Gi
+      volumes:
+        - name: dev-fuse
+          hostPath:
+            path: /dev/fuse
+            type: CharDevice
+        - name: metadata-stress-scripts
+          configMap:
+            name: curvine-metadata-stress-scripts
+            defaultMode: 0755
+        - name: fuse-mnt-root
+          emptyDir: {}
+        - name: fuse-tmp
+          emptyDir: {}


### PR DESCRIPTION
## Problem
Benchmark lacked documented Kubernetes workloads to distinguish metadata stability testing (mixed FUSE POSIX operations) from metadata pressure testing (monotonic file/dir growth).

## Design
Add two StatefulSet manifests under `curvine-tests/benchmark/master-stress/` plus a README that explains scenarios, env vars, formulas for `META_*` tree sizing, and apply/cleanup notes.

## Key Changes
- `deployment-metadata-stable.yaml`: mixed POSIX loop for metadata stability (same resource pattern as existing master-stress).
- `deployment-metadata-stress.yaml`: configurable tree growth (`META_DIR_DEPTH`, `META_FANOUT`, `META_FILES_PER_DIR`, `META_BATCH_COUNT`, `META_WRITE_FILE_DATA`, pauses).
- `README.md`: file intent table, deploy steps, comparison, and example use cases.

Made with [Cursor](https://cursor.com)