### PR TITLE
fix(server): only bump inode_file_num on symlink add, not force update

### DIFF
--- a/curvine-server/src/master/meta/fs_dir.rs
+++ b/curvine-server/src/master/meta/fs_dir.rs
@@ -948,6 +948,7 @@ impl FsDir {
 
         let name = link.name().to_string();
         parent.update_mtime(new_inode.mtime);
+        let is_add = old_inode.is_none();
         let new_inode_ptr = match old_inode {
             Some(v) => {
                 let _ = mem::replace(v.as_mut(), File(name, new_inode));
@@ -961,7 +962,7 @@ impl FsDir {
         };
 
         self.store
-            .apply_symlink(parent.as_ref(), new_inode_ptr.as_ref())?;
+            .apply_symlink(parent.as_ref(), new_inode_ptr.as_ref(), is_add)?;
         Ok(link)
     }
 

--- a/curvine-server/src/master/meta/store/inode_store.rs
+++ b/curvine-server/src/master/meta/store/inode_store.rs
@@ -213,9 +213,9 @@ impl InodeStore {
         Ok(())
     }
 
-    /// Persists a symlink inode and its directory edge.
-    /// `is_add`: new symlink at `link` (adds a dentry); bump live file count.
-    /// `!is_add`: update-in-place (`symlink` with `force=true` over an existing symlink); file count unchanged.
+    /// Persists a symlink inode and its directory edge under `parent`.
+    /// `is_add`: create a new symlink dentry (adds a directory entry); bump live file count.
+    /// `!is_add`: update an existing symlink dentry in place; file count unchanged.
     pub fn apply_symlink(
         &self,
         parent: &InodeView,

--- a/curvine-server/src/master/meta/store/inode_store.rs
+++ b/curvine-server/src/master/meta/store/inode_store.rs
@@ -213,7 +213,15 @@ impl InodeStore {
         Ok(())
     }
 
-    pub fn apply_symlink(&self, parent: &InodeView, new_inode: &InodeView) -> CommonResult<()> {
+    /// Persists a symlink inode and its directory edge.
+    /// `is_add`: new symlink at `link` (adds a dentry); bump live file count.
+    /// `!is_add`: update-in-place (`symlink` with `force=true` over an existing symlink); file count unchanged.
+    pub fn apply_symlink(
+        &self,
+        parent: &InodeView,
+        new_inode: &InodeView,
+        is_add: bool,
+    ) -> CommonResult<()> {
         let mut batch = self.store.new_batch();
 
         batch.write_inode(parent)?;
@@ -222,7 +230,9 @@ impl InodeStore {
 
         batch.commit()?;
 
-        self.fs_stats.increment_file_count();
+        if is_add {
+            self.fs_stats.increment_file_count();
+        }
 
         Ok(())
     }

--- a/curvine-server/tests/master_fs_test.rs
+++ b/curvine-server/tests/master_fs_test.rs
@@ -35,8 +35,19 @@ use orpc::message::Builder;
 use orpc::runtime::{AsyncRuntime, RpcRuntime};
 use orpc::CommonResult;
 use raft::eraftpb::Entry;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
+
+// Master metrics gauges are process-wide; tests that assert inode_file_num / inode_dir_num must
+// not run in parallel with each other or counts race with other tests' format/init.
+static INODE_COUNT_METRICS_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+fn inode_count_metrics_test_lock() -> std::sync::MutexGuard<'static, ()> {
+    INODE_COUNT_METRICS_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap()
+}
 
 // Use a lightweight filesystem-only setup for tests that do not need the full
 // journal runtime lifecycle.
@@ -951,6 +962,7 @@ fn test_idempotent_unmount() -> CommonResult<()> {
 
 #[test]
 fn test_inode_file_num_stays_non_negative_for_symlink_create_delete() -> CommonResult<()> {
+    let _lock = inode_count_metrics_test_lock();
     let fs = new_fs(true, "inode-file-num-symlink");
 
     let (dir_count, file_count) = file_counts(&fs);
@@ -983,7 +995,29 @@ fn test_inode_file_num_stays_non_negative_for_symlink_create_delete() -> CommonR
 }
 
 #[test]
+fn test_inode_file_num_stable_on_forced_symlink_rewrite() -> CommonResult<()> {
+    let _lock = inode_count_metrics_test_lock();
+    let fs = new_fs(true, "inode-file-num-symlink-force");
+
+    fs.mkdir("/dir", false)?;
+    fs.symlink("/target-a", "/dir/link", false, 0o777)?;
+    let file_count_after_first = file_counts(&fs).1;
+
+    fs.symlink("/target-b", "/dir/link", true, 0o777)?;
+    fs.symlink("/target-c", "/dir/link", true, 0o777)?;
+    let file_count_after_rewrites = file_counts(&fs).1;
+
+    assert_eq!(
+        file_count_after_first, file_count_after_rewrites,
+        "force symlink replace must not inflate inode_file_num (was {}, after rewrites {})",
+        file_count_after_first, file_count_after_rewrites
+    );
+    Ok(())
+}
+
+#[test]
 fn test_inode_file_num_stays_non_negative_when_renaming_over_symlink() -> CommonResult<()> {
+    let _lock = inode_count_metrics_test_lock();
     let fs = new_fs(true, "inode-file-num-rename-over-link");
 
     fs.mkdir("/dir", false)?;


### PR DESCRIPTION
## Problem
PR #764 added `inode_file_num` updates for symlink create/delete. Review noted that `apply_symlink` ran for both new symlinks and `force=true` replacements of an existing symlink; the latter must not increase the live file count.

## Design
Thread an `is_add` flag into `apply_symlink`: `true` when `unprotected_symlink` adds a new dentry, `false` when replacing a symlink in place. Add a regression test and serialize the inode counter assertions in `master_fs_test` because master metrics gauges are process-wide.

## Key Changes
- `InodeStore::apply_symlink(..., is_add)`; increment stats only when `is_add`.
- `FsDir::unprotected_symlink` passes `is_add = old_inode.is_none()`.
- New test `test_inode_file_num_stable_on_forced_symlink_rewrite`; mutex for related inode count tests.

Follow-up to #764 review discussion.