### PR TITLE
feat(meta): refactor InodeView with named wrappers; expand RocksDB me…

### DIFF
--- a/curvine-common/src/rocksdb/db_engine.rs
+++ b/curvine-common/src/rocksdb/db_engine.rs
@@ -17,7 +17,9 @@ use log::{info, warn};
 use orpc::common::{FileUtils, Utils};
 use orpc::{err_box, try_err, CommonResult};
 use rocksdb::checkpoint::Checkpoint;
+use rocksdb::properties;
 use rocksdb::*;
+use std::collections::HashMap;
 
 pub type KVBytes = (Box<[u8]>, Box<[u8]>);
 
@@ -313,28 +315,141 @@ impl DBEngine {
         format!("{}/ck-{}", self.conf.checkpoint_dir, id)
     }
 
-    pub fn get_rocksdb_memory(&self) -> CommonResult<Vec<(String, u64)>> {
-        let mut memory_info = Vec::with_capacity(4);
+    /// RocksDB statistics (memory, compaction/flush pressure, snapshots, versions), as `HashMap<metric key, value>`.
+    ///
+    /// **Key naming** (`.` in property names becomes `_`)
+    /// - **DB scope**: `db_{name.replace('.', '_')}`, e.g. `db_rocksdb_block-cache-usage`.
+    /// - **CF scope**: `cf_{cf_name}_{name.replace('.', '_')}`, e.g. `cf_inodes_rocksdb_cur-size-all-mem-tables`.
+    ///
+    /// **`db_*` vs real “whole DB” semantics**
+    ///
+    /// Values under `db_*` are read with `DB::property_int_value` (RocksDB C API **without** a column-family
+    /// handle). For several int properties—including `rocksdb.size-all-mem-tables` and
+    /// `rocksdb.estimate-table-readers-mem`—that path reports metrics for the **default column family only**,
+    /// **not** the sum over all column families. Example: `db_rocksdb_size-all-mem-tables` can be tiny while
+    /// `cf_inodes_rocksdb_size-all-mem-tables` is large. For **memtable** and **table-reader** totals on a
+    /// multi-CF database, **sum the corresponding `cf_*` keys** across your column families (and do **not**
+    /// add those `db_*` keys on top).
+    ///
+    /// **Shared block cache** properties (`block-cache-*`) are typically **DB-wide**; `db_*` is appropriate there.
+    ///
+    /// **Units** (properties not listed below are usually **bytes**)
+    /// - **Counts**: `rocksdb.num-immutable-mem-table`, `rocksdb.num-snapshots`, `rocksdb.num-live-versions`,
+    ///   `rocksdb.num-running-flushes`, `rocksdb.num-running-compactions`.
+    /// - **0/1 flags**: `rocksdb.compaction-pending`, `rocksdb.mem-table-flush-pending`.
+    /// - **Time**: `rocksdb.oldest-snapshot-time` is **Unix seconds** (may be 0 when no snapshot, depending on RocksDB version).
+    ///
+    /// **DB-level metrics (via `property_int_value`; mostly shared cache + process-wide counters)**
+    ///
+    /// | Property suffix | Meaning |
+    /// |-----------------|---------|
+    /// | `rocksdb.block-cache-capacity` | Block cache **configured capacity** (bytes), not current usage. |
+    /// | `rocksdb.block-cache-usage` | Block cache **current usage** (bytes), hot read-path cache. |
+    /// | `rocksdb.block-cache-pinned-usage` | Bytes of **pinned** entries in the block cache. |
+    /// | `rocksdb.size-all-mem-tables` | **Default CF only** when exposed as `db_*` (see note above); memtable bytes for that CF. |
+    /// | `rocksdb.estimate-table-readers-mem` | **Default CF only** when exposed as `db_*`; use `cf_*` sum for all CFs. |
+    ///
+    /// **DB-level metrics (compaction / flush in flight)**
+    ///
+    /// | Property suffix | Meaning |
+    /// |-----------------|---------|
+    /// | `rocksdb.num-running-flushes` | Number of **flushes** currently running. |
+    /// | `rocksdb.num-running-compactions` | Number of **compactions** currently running. |
+    ///
+    /// **DB-level metrics (snapshots, whole DB)**
+    ///
+    /// | Property suffix | Meaning |
+    /// |-----------------|---------|
+    /// | `rocksdb.num-snapshots` | Unreleased **Snapshot** count (holding snapshots pins old SSTs). |
+    /// | `rocksdb.oldest-snapshot-time` | **Unix timestamp (seconds)** of the oldest snapshot. |
+    ///
+    /// **CF-level metrics (per column family)**
+    ///
+    /// | Property suffix | Meaning |
+    /// |-----------------|---------|
+    /// | `rocksdb.cur-size-all-mem-tables` | This CF: active + unflushed immutable memtables (bytes). |
+    /// | `rocksdb.cur-size-active-mem-table` | This CF: **active** memtable size (bytes). |
+    /// | `rocksdb.size-all-mem-tables` | This CF: memtable size including pinned immutable (bytes). |
+    /// | `rocksdb.num-immutable-mem-table` | This CF: count of unflushed **immutable** memtables (not bytes). |
+    /// | `rocksdb.estimate-table-readers-mem` | This CF: estimated table reader memory (bytes). |
+    ///
+    /// **CF-level metrics (compaction / flush pressure)**
+    ///
+    /// | Property suffix | Meaning |
+    /// |-----------------|---------|
+    /// | `rocksdb.compaction-pending` | Whether compaction is pending (**0/1**). |
+    /// | `rocksdb.mem-table-flush-pending` | Whether memtable flush is pending (**0/1**). |
+    /// | `rocksdb.estimate-pending-compaction-bytes` | Estimated bytes to rewrite for pending compaction (level-style, **bytes**). |
+    ///
+    /// **CF-level metrics (versions / long-lived readers)**
+    ///
+    /// | Property suffix | Meaning |
+    /// |-----------------|---------|
+    /// | `rocksdb.num-live-versions` | Number of **live Version** structs; high values often correlate with unreleased iterators, snapshots, or unfinished compactions. |
+    ///
+    /// **Approximate “RocksDB internal accounted memory” (bytes, not process RSS)**
+    ///
+    /// Use **three parts** (do **not** use `db_rocksdb_size-all-mem-tables` / `db_rocksdb_estimate-table-readers-mem`
+    /// for multi-CF totals—they track **default CF only**; see `db_*` note above):
+    ///
+    /// 1. **Block cache (once, DB-wide):** `db_rocksdb_block-cache-usage`.
+    /// 2. **Memtables (sum all CFs):** add every `cf_{cf}_rocksdb_size-all-mem-tables` (same property as
+    ///    `rocksdb.size-all-mem-tables` per column family).
+    /// 3. **Table readers (sum all CFs):** add every `cf_{cf}_rocksdb_estimate-table-readers-mem`.
+    ///
+    /// **Do not** add `block-cache-pinned-usage` on top of `block-cache-usage` (pinned is usually part of usage);
+    /// **do not** treat `block-cache-capacity` as used bytes. **Do not** add both `db_*` and `cf_*` memtable
+    /// or table-reader figures for the same scope.
+    ///
+    /// This sum is a coarse RocksDB-internal estimate; it **excludes** WAL, OS page cache, etc., and **does not equal** process memory in `top`/`ps`.
+    pub fn get_rocksdb_metrics(&self) -> CommonResult<HashMap<String, u64>> {
+        let mut info = HashMap::new();
 
-        let properties = [
-            ("rocksdb.cur-size-all-mem-tables", "mem-tables"),
-            ("rocksdb.block-cache-usage", "block-cache"),
-            ("rocksdb.block-cache-pinned-usage", "block-cache-pinned"),
-            ("rocksdb.estimate-table-readers-mem", "table-readers"),
+        // DB scope: block cache; default-CF memtable/table-reader ints (see doc); flush/compaction; snapshots.
+        let db_keys = vec![
+            properties::BLOCK_CACHE_CAPACITY,
+            properties::BLOCK_CACHE_USAGE,
+            properties::BLOCK_CACHE_PINNED_USAGE,
+            properties::SIZE_ALL_MEM_TABLES,
+            properties::ESTIMATE_TABLE_READERS_MEM,
+            properties::NUM_RUNNING_FLUSHES,
+            properties::NUM_RUNNING_COMPACTIONS,
+            properties::NUM_SNAPSHOTS,
+            properties::OLDEST_SNAPSHOT_TIME,
+        ];
+        for key in db_keys {
+            if let Some(value) = self.db.property_int_value(key)? {
+                info.insert(format!("db_{}", key.as_str().replace(".", "_")), value);
+            }
+        }
+
+        // CF scope: memtables, immutables, table readers; compaction/flush backlog; live versions.
+        let cf_keys = vec![
+            properties::CUR_SIZE_ALL_MEM_TABLES,
+            properties::CUR_SIZE_ACTIVE_MEM_TABLE,
+            properties::SIZE_ALL_MEM_TABLES,
+            properties::NUM_IMMUTABLE_MEM_TABLE,
+            properties::ESTIMATE_TABLE_READERS_MEM,
+            properties::COMPACTION_PENDING,
+            properties::MEM_TABLE_FLUSH_PENDING,
+            properties::ESTIMATE_PENDING_COMPACTION_BYTES,
+            properties::NUM_LIVE_VERSIONS,
         ];
 
-        for (property, name) in properties {
-            if let Some(value) = self.db.property_value(property)? {
-                match value.parse::<u64>() {
-                    Ok(size) => memory_info.push((name.to_string(), size)),
-                    Err(e) => {
-                        log::error!("Failed to parse property value: {}", e);
+        for cf_name in &self.conf.family_list {
+            if let Some(cf) = self.db.cf_handle(cf_name) {
+                for &key in &cf_keys {
+                    if let Some(value) = self.db.property_int_value_cf(cf, key)? {
+                        info.insert(
+                            format!("cf_{}_{}", cf_name, key.as_str().replace(".", "_")),
+                            value,
+                        );
                     }
                 }
             }
         }
 
-        Ok(memory_info)
+        Ok(info)
     }
 
     pub fn conf(&self) -> &DBConf {

--- a/curvine-server/src/master/journal/journal_loader.rs
+++ b/curvine-server/src/master/journal/journal_loader.rs
@@ -15,8 +15,8 @@
 #![allow(clippy::needless_range_loop)]
 
 use crate::master::journal::*;
-use crate::master::meta::inode::InodePath;
-use crate::master::meta::inode::InodeView::{Dir, File};
+use crate::master::meta::inode::InodeView::File;
+use crate::master::meta::inode::{InodePath, InodeView};
 use crate::master::{JobManager, Master, MasterMetrics, MountManager, SyncFsDir};
 use curvine_common::conf::JournalConf;
 use curvine_common::error::FsError;
@@ -465,7 +465,7 @@ impl JournalLoader {
         let mut fs_dir = self.fs_dir.write();
         let inp = InodePath::resolve(fs_dir.root_ptr(), entry.path, &fs_dir.store)?;
         let name = inp.name().to_string();
-        let _ = fs_dir.add_last_inode(inp, Dir(name, entry.dir))?;
+        let _ = fs_dir.add_last_inode(inp, InodeView::new_dir(name, entry.dir))?;
         Ok(())
     }
 
@@ -478,7 +478,7 @@ impl JournalLoader {
             return Ok(());
         }
         let name = inp.name().to_string();
-        let _ = fs_dir.add_last_inode(inp, File(name, entry.file))?;
+        let _ = fs_dir.add_last_inode(inp, InodeView::new_file(name, entry.file))?;
         Ok(())
     }
 
@@ -666,7 +666,7 @@ impl JournalLoader {
         };
 
         if let Some(mut inode_ptr) = old_path.get_last_inode() {
-            if let File(_, _) = inode_ptr.as_mut() {
+            if let File(_) = inode_ptr.as_mut() {
                 inode_ptr.incr_nlink();
             }
         }

--- a/curvine-server/src/master/master_metrics.rs
+++ b/curvine-server/src/master/master_metrics.rs
@@ -46,7 +46,7 @@ pub struct MasterMetrics {
     pub(crate) journal_ufs_applied: Gauge,
 
     pub(crate) used_memory_bytes: Gauge,
-    pub(crate) rocksdb_used_memory_bytes: GaugeVec,
+    pub(crate) rocksdb_metrics: GaugeVec,
 
     pub(crate) inode_dir_num: Gauge,
     pub(crate) inode_file_num: Gauge,
@@ -111,11 +111,7 @@ impl MasterMetrics {
             )?,
 
             used_memory_bytes: m::new_gauge("used_memory_bytes", "Total memory used")?,
-            rocksdb_used_memory_bytes: m::new_gauge_vec(
-                "rocksdb_used_memory_bytes",
-                "RocksDB memory usage in bytes",
-                &["tag"],
-            )?,
+            rocksdb_metrics: m::new_gauge_vec("rocksdb_metrics", "RocksDB metrics", &["tag"])?,
 
             inode_dir_num: m::new_gauge("inode_dir_num", "Total dir")?,
 
@@ -179,13 +175,13 @@ impl MasterMetrics {
         }
 
         let fs_dir = fs.fs_dir.read();
-        if let Ok(memory_info) = fs_dir.get_rocks_store().get_rocksdb_memory() {
-            for (component, size) in memory_info {
-                self.rocksdb_used_memory_bytes
-                    .with_label_values(&[&component])
-                    .set(size as i64);
-            }
+        let rocksdb_metrics = fs_dir.get_rocks_store().get_rocksdb_metrics()?;
+        for (key, value) in rocksdb_metrics {
+            self.rocksdb_metrics
+                .with_label_values(&[&key])
+                .set(value as i64);
         }
+
         let ttl_list = fs_dir.get_ttl_bucket_list();
         drop(fs_dir);
         self.ttl_bucket_len.set(ttl_list.buckets_len() as i64);

--- a/curvine-server/src/master/meta/fs_dir.rs
+++ b/curvine-server/src/master/meta/fs_dir.rs
@@ -73,7 +73,7 @@ impl FsDir {
 
     // Create root directory
     pub fn create_root() -> InodeView {
-        Dir(ROOT_INODE_NAME.to_string(), InodeDir::new(ROOT_INODE_ID, 0))
+        InodeView::new_dir(ROOT_INODE_NAME.to_string(), InodeDir::new(ROOT_INODE_ID, 0))
     }
 
     pub fn root_ptr(&self) -> InodePtr {
@@ -125,7 +125,7 @@ impl FsDir {
 
         let dir = InodeDir::with_opts(self.next_inode_id()?, LocalTime::mills() as i64, opts);
 
-        inp = self.add_last_inode(inp, Dir(name.clone(), dir.clone()))?;
+        inp = self.add_last_inode(inp, InodeView::new_dir(name.clone(), dir.clone()))?;
 
         let parent_path = inp.get_valid_parent_path();
         self.journal_writer.log_mkdir(self, &parent_path, &dir)?;
@@ -194,11 +194,11 @@ impl FsDir {
         parent.update_mtime(mtime);
 
         let del_res = match child {
-            File(_, file) => {
-                if file.nlink() > 1 {
+            File(f) => {
+                if f.nlink() > 1 {
                     let target_inode = target.clone();
-                    if let File(_, ref mut target_file) = target_inode.as_mut() {
-                        target_file.decrement_nlink();
+                    if let File(ref mut nf) = target_inode.as_mut() {
+                        nf.decrement_nlink();
                     }
                     self.store.apply_unlink(parent.as_ref(), child)?
                 } else {
@@ -206,13 +206,13 @@ impl FsDir {
                     self.store.apply_delete(parent.as_ref(), child)?
                 }
             }
-            FileEntry(_, inode_id) => {
+            FileEntry(e) => {
                 // This is a link entry, just remove the directory entry
                 // The actual inode's nlink count should be decremented
                 self.store
-                    .apply_unlink_file_entry(parent.as_ref(), child, *inode_id)?
+                    .apply_unlink_file_entry(parent.as_ref(), child, e.id)?
             }
-            Dir(_, _) => {
+            Dir(_) => {
                 parent.dec_nlink();
                 // Directories are always deleted
                 self.store.apply_delete(parent.as_ref(), child)?
@@ -256,24 +256,24 @@ impl FsDir {
         stack.push_back(inode);
         while let Some(inode) = stack.pop_front() {
             match inode.as_mut() {
-                FileEntry(name, id) => {
-                    if let Some(store_inode) = self.store.get_inode(*id, Some(name))? {
+                FileEntry(e) => {
+                    if let Some(store_inode) = self.store.get_inode(e.id, Some(&e.name))? {
                         stack.push_back(InodePtr::from_owned(store_inode));
                     }
                 }
 
-                Dir(_, dir) => {
+                Dir(d) => {
                     if recursive {
-                        for child in dir.children_iter() {
+                        for child in d.children_iter() {
                             stack.push_back(InodePtr::from_ref(child));
                         }
                     }
                 }
 
-                File(_, file) => {
-                    let locs = file.get_locs(&self.store)?;
-                    let len = file.len;
-                    if file.free(mtime) {
+                File(f) => {
+                    let locs = f.get_locs(&self.store)?;
+                    let len = f.len;
+                    if f.free(mtime) {
                         free_res.add(len, locs);
                         change_inodes.push(inode.as_ref().clone());
                     }
@@ -387,7 +387,7 @@ impl FsDir {
 
         // Create an inode file node.
         let file = InodeFile::with_opts(self.next_inode_id()?, LocalTime::mills() as i64, opts);
-        inp = self.add_last_inode(inp, File(name, file))?;
+        inp = self.add_last_inode(inp, InodeView::new_file(name, file))?;
         self.journal_writer.log_create_file(self, &inp)?;
 
         Ok(inp)
@@ -454,15 +454,15 @@ impl FsDir {
 
         let mut res = Vec::with_capacity(1.max(inode.child_len()));
         match inode.as_ref() {
-            File(_, _) => res.push(inode.to_file_status(inp.path())),
+            File(_) => res.push(inode.to_file_status(inp.path())),
 
-            Dir(_, d) => {
+            Dir(d) => {
                 for item in d.children_iter() {
                     let child_path = inp.child_path(item.name());
                     match item {
                         File(..) | Dir(..) => res.push(item.to_file_status(&child_path)),
-                        FileEntry(name, id) => {
-                            let inode_opt = self.store.get_inode(*id, Some(name))?;
+                        FileEntry(e) => {
+                            let inode_opt = self.store.get_inode(e.id, Some(&e.name))?;
                             if let Some(inode_view) = inode_opt {
                                 res.push(inode_view.to_file_status(&child_path));
                             }
@@ -471,8 +471,8 @@ impl FsDir {
                 }
             }
 
-            FileEntry(name, id) => {
-                let inode_opt = self.store.get_inode(*id, Some(name))?;
+            FileEntry(e) => {
+                let inode_opt = self.store.get_inode(e.id, Some(&e.name))?;
                 match inode_opt {
                     Some(inode_view) => res.push(inode_view.to_file_status(inp.path())),
                     None => return err_box!("File {} not exists", inp.path()),
@@ -502,12 +502,12 @@ impl FsDir {
         };
 
         match inode.as_ref() {
-            File(_, _) => {
+            File(_) => {
                 let status = inode.to_file_status(inp.path());
                 Ok(Self::list_single_file(status, opts))
             }
 
-            Dir(_, d) => {
+            Dir(d) => {
                 let children = d.list_options(opts);
                 let mut res = Vec::with_capacity(children.len());
 
@@ -517,8 +517,8 @@ impl FsDir {
                     match item {
                         File(..) | Dir(..) => res.push(item.to_file_status(&child_path)),
 
-                        FileEntry(name, id) => {
-                            let inode_opt = self.store.get_inode(*id, Some(name))?;
+                        FileEntry(e) => {
+                            let inode_opt = self.store.get_inode(e.id, Some(&e.name))?;
                             if let Some(inode_view) = inode_opt {
                                 res.push(inode_view.to_file_status(&child_path));
                             }
@@ -528,8 +528,8 @@ impl FsDir {
                 Ok(res)
             }
 
-            FileEntry(name, id) => {
-                let inode_opt = self.store.get_inode(*id, Some(name))?;
+            FileEntry(e) => {
+                let inode_opt = self.store.get_inode(e.id, Some(&e.name))?;
                 match inode_opt {
                     Some(inode_view) => {
                         let status = inode_view.to_file_status(inp.path());
@@ -882,19 +882,19 @@ impl FsDir {
             }
 
             match cur_inode.as_mut() {
-                Dir(_, dir) if opts.recursive => {
+                Dir(dir) if opts.recursive => {
                     for child in dir.children_iter() {
                         stack.push_back(InodePtr::from_ref(child));
                     }
                 }
 
-                FileEntry(name, id) => {
-                    if let Some(store_inode) = self.store.get_inode(*id, Some(name))? {
+                FileEntry(e) => {
+                    if let Some(store_inode) = self.store.get_inode(e.id, Some(&e.name))? {
                         stack.push_back(InodePtr::from_owned(store_inode));
                     } else {
                         warn!(
                             "unprotected_set_attr: missing inode {} for FileEntry '{}'",
-                            id, name
+                            e.id, e.name
                         );
                     }
                 }
@@ -951,11 +951,11 @@ impl FsDir {
         let is_add = old_inode.is_none();
         let new_inode_ptr = match old_inode {
             Some(v) => {
-                let _ = mem::replace(v.as_mut(), File(name, new_inode));
+                let _ = mem::replace(v.as_mut(), InodeView::new_file(name, new_inode));
                 v
             }
             None => {
-                let added = parent.add_child(File(name, new_inode))?;
+                let added = parent.add_child(InodeView::new_file(name, new_inode))?;
                 link.append(added.clone())?;
                 added
             }
@@ -973,22 +973,22 @@ impl FsDir {
         // Get the original inode ID and update nlink in memory if it's a direct File
         let (original_inode_id, mut original_inode_ptr) = match src_path.get_last_inode() {
             Some(inode) => match inode.as_ref() {
-                File(_, file) => {
+                File(file) => {
                     // Check if it's a regular file (not a directory or symlink)
                     if file.file_type != curvine_common::state::FileType::File {
                         return err_ext!(FsError::common("Cannot create link to non-regular file"));
                     }
                     (file.id, Some(inode.clone()))
                 }
-                FileEntry(_, inode_id) => (*inode_id, None), // FileEntry already points to an inode
-                Dir(_, _) => return err_ext!(FsError::common("Cannot create link to directory")),
+                FileEntry(e) => (e.id, None), // FileEntry already points to an inode
+                Dir(_) => return err_ext!(FsError::common("Cannot create link to directory")),
             },
             None => return err_ext!(FsError::file_not_found(src_path.path())),
         };
 
         // If we have the original inode in memory, increment its nlink count
         if let Some(ref mut inode_ptr) = original_inode_ptr {
-            if let File(_, _) = inode_ptr.as_mut() {
+            if let File(_) = inode_ptr.as_mut() {
                 inode_ptr.incr_nlink();
             }
         }
@@ -1026,7 +1026,7 @@ impl FsDir {
 
         // Create a FileEntry that points to the original inode
         let name = new_path.name().to_string();
-        let file_entry = FileEntry(name.clone(), original_inode_id);
+        let file_entry = InodeView::new_entry(name.clone(), original_inode_id);
 
         // Update parent directory
         parent.update_mtime(op_ms as i64);

--- a/curvine-server/src/master/meta/inode/inode_dir.rs
+++ b/curvine-server/src/master/meta/inode/inode_dir.rs
@@ -14,7 +14,6 @@
 
 use crate::master::meta::feature::{AclFeature, DirFeature};
 use crate::master::meta::inode::inodes_children::InodeChildren;
-use crate::master::meta::inode::InodeView::{Dir, File};
 use crate::master::meta::inode::{
     ChildrenIter, Inode, InodeFile, InodePtr, InodeView, EMPTY_PARENT_ID,
 };
@@ -129,11 +128,11 @@ impl InodeDir {
     }
 
     pub fn add_file_child(&mut self, name: &str, file: InodeFile) -> CommonResult<InodePtr> {
-        self.add_child(File(name.to_string(), file))
+        self.add_child(InodeView::new_file(name.to_string(), file))
     }
 
     pub fn add_dir_child(&mut self, name: &str, dir: InodeDir) -> CommonResult<InodePtr> {
-        self.add_child(Dir(name.to_string(), dir))
+        self.add_child(InodeView::new_dir(name.to_string(), dir))
     }
 }
 

--- a/curvine-server/src/master/meta/inode/inode_path.rs
+++ b/curvine-server/src/master/meta/inode/inode_path.rs
@@ -22,7 +22,6 @@ use orpc::{err_box, try_option, CommonResult};
 use std::collections::{HashMap, VecDeque};
 use std::fmt;
 
-#[derive(Clone)]
 pub struct InodePath {
     path: String,
     name: String,
@@ -51,11 +50,11 @@ impl InodePath {
             //make sure resolved_inode is not a FileEntry
             //if it is a FileEntry, load the complete file data from store
             let resolved_inode = match cur_inode.as_ref() {
-                FileEntry(name, id) => {
+                FileEntry(f) => {
                     // If it is a FileEntry, load the complete object from store
-                    match store.get_inode(*id, Some(name))? {
+                    match store.get_inode(f.id(), Some(f.name()))? {
                         Some(full_inode) => InodePtr::from_owned(full_inode),
-                        None => return err_box!("Failed to load inode {} from store", id),
+                        None => return err_box!("Failed to load inode {} from store", f.id()),
                     }
                 }
                 _ => cur_inode.clone(),
@@ -70,7 +69,7 @@ impl InodePath {
             index += 1;
             let child_name: &str = components[index].as_str();
             match cur_inode.as_mut() {
-                Dir(_, d) => {
+                Dir(d) => {
                     if let Some(child) = d.get_child_ptr(child_name) {
                         cur_inode = child;
                     } else {
@@ -79,10 +78,7 @@ impl InodePath {
                     }
                 }
 
-                File(_, _) | FileEntry(_, _) => {
-                    // File or FileEntry nodes cannot have children, stop path resolution
-                    break;
-                }
+                _ => break,
             }
         }
 
@@ -110,8 +106,8 @@ impl InodePath {
         // Leaf
         match curr_node.as_ref() {
             File(..) | Dir(..) => path_inodes_rebuild.push(curr_node.clone()),
-            FileEntry(name, id) => {
-                let resolved_leaf_node = match store.get_inode(*id, Some(name))? {
+            FileEntry(e) => {
+                let resolved_leaf_node = match store.get_inode(e.id(), Some(e.name()))? {
                     Some(full_inode) => InodePtr::from_owned(full_inode),
                     None => {
                         return err_box!(
@@ -211,7 +207,7 @@ impl InodePath {
             }
 
             // Expand to next level
-            if let Dir(_, d) = curr_node.as_mut() {
+            if let Dir(d) = curr_node.as_mut() {
                 let next_name = components.get(curr_index as usize + 1).map(|s| s.as_str());
                 if let Some(child_name_str) = next_name {
                     // Check the child node name is a glob pattern or not

--- a/curvine-server/src/master/meta/inode/inode_view.rs
+++ b/curvine-server/src/master/meta/inode/inode_view.rs
@@ -27,22 +27,103 @@ use orpc::{err_box, CommonResult};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, LinkedList};
 use std::fmt::{Debug, Formatter};
+use std::ops::{Deref, DerefMut};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NamedFile {
+    pub name: String,
+    pub file: InodeFile,
+}
+
+impl NamedFile {
+    pub fn new(name: String, file: InodeFile) -> Self {
+        NamedFile { name, file }
+    }
+}
+
+impl Deref for NamedFile {
+    type Target = InodeFile;
+
+    fn deref(&self) -> &Self::Target {
+        &self.file
+    }
+}
+
+impl DerefMut for NamedFile {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.file
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NamedDir {
+    pub name: String,
+    pub dir: InodeDir,
+}
+
+impl NamedDir {
+    pub fn new(name: String, dir: InodeDir) -> Self {
+        NamedDir { name, dir }
+    }
+}
+
+impl Deref for NamedDir {
+    type Target = InodeDir;
+
+    fn deref(&self) -> &Self::Target {
+        &self.dir
+    }
+}
+
+impl DerefMut for NamedDir {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.dir
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NamedEntry {
+    pub name: String,
+    pub id: i64,
+}
+
+impl NamedEntry {
+    pub fn new(name: String, id: i64) -> Self {
+        NamedEntry { name, id }
+    }
+
+    pub fn id(&self) -> i64 {
+        self.id
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
 
 #[derive(Serialize, Deserialize)]
 #[repr(i8)]
 pub enum InodeView {
-    File(String, InodeFile) = 1,
-    Dir(String, InodeDir) = 2,
-    FileEntry(String, i64) = 3,
+    File(Box<NamedFile>) = 1,
+    Dir(Box<NamedDir>) = 2,
+    FileEntry(Box<NamedEntry>) = 3,
 }
 
 impl InodeView {
+    pub fn new_dir(name: String, dir: InodeDir) -> Self {
+        Dir(Box::new(NamedDir::new(name, dir)))
+    }
+
+    pub fn new_file(name: String, file: InodeFile) -> Self {
+        File(Box::new(NamedFile::new(name, file)))
+    }
+
+    pub fn new_entry(name: String, id: i64) -> Self {
+        FileEntry(Box::new(NamedEntry::new(name, id)))
+    }
+
     pub fn is_dir(&self) -> bool {
-        match self {
-            File(_, _) => false,
-            Dir(_, _) => true,
-            _ => false,
-        }
+        matches!(self, Dir(_))
     }
 
     pub fn is_file(&self) -> bool {
@@ -50,26 +131,26 @@ impl InodeView {
     }
 
     pub fn is_file_entry(&self) -> bool {
-        matches!(self, FileEntry(_, _))
+        matches!(self, FileEntry(_))
     }
 
     pub fn is_link(&self) -> bool {
-        matches!(self, File(_, v) if v.file_type == FileType::Link)
+        matches!(self, File(v) if v.file_type == FileType::Link)
     }
 
     pub fn id(&self) -> i64 {
         match self {
-            File(_, f) => f.id(),
-            Dir(_, d) => d.id(),
-            FileEntry(_, id) => *id,
+            File(f) => f.id(),
+            Dir(d) => d.id(),
+            FileEntry(e) => e.id,
         }
     }
 
     pub fn name(&self) -> &str {
         match self {
-            File(name, _) => name,
-            Dir(name, _) => name,
-            FileEntry(name, _) => name,
+            File(f) => &f.name,
+            Dir(d) => &d.name,
+            FileEntry(e) => &e.name,
         }
     }
 
@@ -97,24 +178,24 @@ impl InodeView {
 
     pub fn get_child(&self, name: &str) -> Option<&InodeView> {
         match self {
-            File(_, _) => None,
-            Dir(_, d) => d.get_child(name),
-            FileEntry(..) => None,
+            File(_) => None,
+            Dir(d) => d.get_child(name),
+            FileEntry(_) => None,
         }
     }
 
     pub fn get_child_ptr(&mut self, name: &str) -> Option<InodePtr> {
         match self {
-            File(_, _) => None,
-            Dir(_, d) => d.get_child_ptr(name),
-            FileEntry(..) => None,
+            File(_) => None,
+            Dir(d) => d.get_child_ptr(name),
+            FileEntry(_) => None,
         }
     }
 
     // Test and print for use. Memory copying occurs.
     pub fn children(&self) -> Vec<&InodeView> {
         let mut vec = Vec::with_capacity(8);
-        if let Dir(_, d) = self {
+        if let Dir(d) = self {
             for item in d.children_iter() {
                 vec.push(item)
             }
@@ -125,8 +206,8 @@ impl InodeView {
 
     pub fn child_len(&self) -> usize {
         match self {
-            File(_, _) => 0,
-            Dir(_, d) => d.children_iter().len(),
+            File(_) => 0,
+            Dir(d) => d.children_iter().len(),
             FileEntry(..) => 0,
         }
     }
@@ -134,36 +215,36 @@ impl InodeView {
     // Add child nodes.
     pub fn add_child(&mut self, child: InodeView) -> CommonResult<InodePtr> {
         match self {
-            File(name, _) => err_box!("Path not a dir: {}", name),
-            Dir(_, d) => d.add_child(child),
+            File(f) => err_box!("Path not a dir: {}", f.name),
+            Dir(d) => d.add_child(child),
             _ => err_box!("Inode type error: {}", self.name()),
         }
     }
 
     pub fn delete_child(&mut self, id: i64, name: &str) -> CommonResult<InodeView> {
         match self {
-            File(name, _) => err_box!("Path not a dir: {}", name),
-            Dir(_, d) => d.delete_child(id, name),
+            File(f) => err_box!("Path not a dir: {}", f.name),
+            Dir(d) => d.delete_child(id, name),
             _ => err_box!("Inode type error: {}", self.name()),
         }
     }
 
     pub fn mtime(&self) -> i64 {
         match self {
-            File(_, f) => f.mtime(),
-            Dir(_, d) => d.mtime(),
+            File(f) => f.mtime(),
+            Dir(d) => d.mtime(),
             FileEntry(..) => 0,
         }
     }
 
     pub fn update_mtime(&mut self, time: i64) {
         match self {
-            File(_, ref mut f) => {
+            File(f) => {
                 if time > f.mtime {
                     f.mtime = time
                 }
             }
-            Dir(_, ref mut d) => {
+            Dir(d) => {
                 if time > d.mtime {
                     d.mtime = time
                 }
@@ -174,20 +255,20 @@ impl InodeView {
 
     pub fn incr_nlink(&mut self) {
         match self {
-            File(_, f) => f.nlink += 1,
-            Dir(_, d) => d.nlink += 1,
+            File(f) => f.nlink += 1,
+            Dir(d) => d.nlink += 1,
             FileEntry(..) => (),
         }
     }
 
     pub fn dec_nlink(&mut self) {
         match self {
-            File(_, f) => {
+            File(f) => {
                 if f.nlink > 0 {
                     f.nlink -= 1
                 }
             }
-            Dir(_, d) => {
+            Dir(d) => {
                 if d.nlink > 0 {
                     d.nlink -= 1
                 }
@@ -198,64 +279,64 @@ impl InodeView {
 
     pub fn set_parent_id(&mut self, parent_id: i64) {
         match self {
-            File(_, f) => f.parent_id = parent_id,
-            Dir(_, d) => d.parent_id = parent_id,
+            File(f) => f.parent_id = parent_id,
+            Dir(d) => d.parent_id = parent_id,
             FileEntry(..) => (),
         }
     }
 
     pub fn change_name(&mut self, new_name: String) {
         match self {
-            File(name, _) => *name = new_name,
-            Dir(name, _) => *name = new_name,
-            FileEntry(name, _) => *name = new_name,
+            File(f) => f.name = new_name,
+            Dir(d) => d.name = new_name,
+            FileEntry(e) => e.name = new_name,
         }
     }
 
     pub fn atime(&self) -> i64 {
         match self {
-            File(_, f) => f.atime(),
-            Dir(_, d) => d.atime(),
+            File(f) => f.atime(),
+            Dir(d) => d.atime(),
             FileEntry(..) => 0,
         }
     }
 
     pub fn as_dir_mut(&mut self) -> CommonResult<&mut InodeDir> {
         match self {
-            File(_, _) => err_box!("Not a dir"),
-            Dir(_, ref mut d) => Ok(d),
+            File(_) => err_box!("Not a dir"),
+            Dir(d) => Ok(d),
             _ => err_box!("Inode type error: {}", self.name()),
         }
     }
 
     pub fn as_dir_ref(&self) -> CommonResult<&InodeDir> {
         match self {
-            File(_, _) => err_box!("Not a dir"),
-            Dir(_, ref d) => Ok(d),
+            File(_) => err_box!("Not a dir"),
+            Dir(d) => Ok(d),
             _ => err_box!("Inode type error: {}", self.name()),
         }
     }
 
     pub fn as_file_ref(&self) -> CommonResult<&InodeFile> {
         match self {
-            File(_, f) => Ok(f),
-            Dir(_, _) => err_box!("Not a file"),
+            File(f) => Ok(f),
+            Dir(_) => err_box!("Not a file"),
             _ => err_box!("Inode type error: {}", self.name()),
         }
     }
 
     pub fn as_file_mut(&mut self) -> CommonResult<&mut InodeFile> {
         match self {
-            File(_, ref mut f) => Ok(f),
-            Dir(_, _) => err_box!("Not a file"),
+            File(f) => Ok(f),
+            Dir(_) => err_box!("Not a file"),
             _ => err_box!("FileEntry is cannot be mutated: {}", self.name()),
         }
     }
 
     pub fn acl(&self) -> &AclFeature {
         match self {
-            File(_, f) => &f.features.acl,
-            Dir(_, d) => &d.features.acl,
+            File(f) => &f.features.acl,
+            Dir(d) => &d.features.acl,
             FileEntry(..) => {
                 panic!("FileEntry does not support ACL access")
             }
@@ -264,8 +345,8 @@ impl InodeView {
 
     pub fn acl_mut(&mut self) -> &mut AclFeature {
         match self {
-            File(_, f) => &mut f.features.acl,
-            Dir(_, d) => &mut d.features.acl,
+            File(f) => &mut f.features.acl,
+            Dir(d) => &mut d.features.acl,
             FileEntry(..) => {
                 panic!("FileEntry does not support mutable ACL access")
             }
@@ -274,8 +355,8 @@ impl InodeView {
 
     pub fn storage_policy(&self) -> &StoragePolicy {
         match self {
-            File(_, f) => &f.storage_policy,
-            Dir(_, d) => &d.storage_policy,
+            File(f) => &f.storage_policy,
+            Dir(d) => &d.storage_policy,
             FileEntry(..) => {
                 panic!("FileEntry does not support storage policy access")
             }
@@ -284,8 +365,8 @@ impl InodeView {
 
     pub fn storage_policy_mut(&mut self) -> &mut StoragePolicy {
         match self {
-            File(_, f) => &mut f.storage_policy,
-            Dir(_, d) => &mut d.storage_policy,
+            File(f) => &mut f.storage_policy,
+            Dir(d) => &mut d.storage_policy,
             FileEntry(..) => {
                 panic!("FileEntry does not support mutable storage policy access")
             }
@@ -312,8 +393,8 @@ impl InodeView {
 
     pub fn x_attr(&self) -> &HashMap<String, Vec<u8>> {
         match self {
-            File(_, f) => &f.features.x_attr,
-            Dir(_, d) => &d.features.x_attr,
+            File(f) => &f.features.x_attr,
+            Dir(d) => &d.features.x_attr,
             FileEntry(..) => {
                 panic!("FileEntry does not support x_attr access")
             }
@@ -322,8 +403,8 @@ impl InodeView {
 
     pub fn x_attr_mut(&mut self) -> &mut HashMap<String, Vec<u8>> {
         match self {
-            File(_, f) => &mut f.features.x_attr,
-            Dir(_, d) => &mut d.features.x_attr,
+            File(f) => &mut f.features.x_attr,
+            Dir(d) => &mut d.features.x_attr,
             FileEntry(..) => {
                 panic!("FileEntry does not support mutable x_attr access")
             }
@@ -332,9 +413,9 @@ impl InodeView {
 
     pub fn nlink(&self) -> u32 {
         match self {
-            File(_, f) => f.nlink(),
-            Dir(_, d) => d.nlink(),
-            FileEntry(_, _) => {
+            File(f) => f.nlink(),
+            Dir(d) => d.nlink(),
+            FileEntry(_) => {
                 panic!("FileEntry does not support nlink")
             }
         }
@@ -360,16 +441,16 @@ impl InodeView {
         // Handle time modifications
         if let Some(atime) = opts.atime {
             match self {
-                File(_, f) => f.atime = atime,
-                Dir(_, d) => d.atime = atime,
+                File(f) => f.atime = atime,
+                Dir(d) => d.atime = atime,
                 _ => (),
             }
         }
 
         if let Some(mtime) = opts.mtime {
             match self {
-                File(_, f) => f.mtime = mtime,
-                Dir(_, d) => d.mtime = mtime,
+                File(f) => f.mtime = mtime,
+                Dir(d) => d.mtime = mtime,
                 _ => (),
             }
         }
@@ -424,7 +505,7 @@ impl InodeView {
         };
 
         match self {
-            File(_, f) => {
+            File(f) => {
                 status.is_complete = f.is_complete();
                 status.len = f.len;
                 status.replicas = f.replicas as i32;
@@ -435,14 +516,14 @@ impl InodeView {
                 status.target = f.target.clone();
             }
 
-            Dir(_, d) => {
+            Dir(d) => {
                 status.file_type = FileType::Dir;
                 status.len = d.children_len() as i64;
                 status.x_attr = d.features.x_attr.clone();
                 status.storage_policy = d.storage_policy.clone();
             }
 
-            FileEntry(_, _inode_id) => {
+            FileEntry(_) => {
                 panic!("FileEntry does not support to_file_status");
             }
         }
@@ -515,9 +596,9 @@ impl InodeView {
 impl Clone for InodeView {
     fn clone(&self) -> Self {
         match self {
-            File(name, f) => File(name.clone(), f.clone()),
-            Dir(name, d) => Dir(name.clone(), d.clone()),
-            FileEntry(name, id) => FileEntry(name.clone(), *id),
+            File(f) => File(f.clone()),
+            Dir(d) => Dir(d.clone()),
+            FileEntry(e) => FileEntry(e.clone()),
         }
     }
 }
@@ -525,9 +606,9 @@ impl Clone for InodeView {
 impl Debug for InodeView {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            File(name, x) => write!(f, "File(name={}, x={:?})", name, x),
-            Dir(name, x) => write!(f, "Dir(name={}, x={:?})", name, x),
-            FileEntry(name, id) => write!(f, "FileEntry(name={}, id={})", name, id),
+            File(v) => write!(f, "File(name={}, x={:?})", v.name, v.file),
+            Dir(v) => write!(f, "Dir(name={}, x={:?})", v.name, v.dir),
+            FileEntry(v) => write!(f, "FileEntry(name={}, id={})", v.name, v.id),
         }
     }
 }

--- a/curvine-server/src/master/meta/inode/inodes_children.rs
+++ b/curvine-server/src/master/meta/inode/inodes_children.rs
@@ -175,7 +175,7 @@ impl InodeChildren {
                 Entry::Vacant(v) => {
                     if inode.is_file() {
                         // Store lightweight FileEntry in map
-                        v.insert(Box::new(InodeView::FileEntry(
+                        v.insert(Box::new(InodeView::new_entry(
                             inode.name().to_string(),
                             inode.id(),
                         )));

--- a/curvine-server/src/master/meta/inode/ttl/ttl_bucket.rs
+++ b/curvine-server/src/master/meta/inode/ttl/ttl_bucket.rs
@@ -207,11 +207,11 @@ mod tests {
         let mut f = InodeFile::new(id, mtime);
         f.storage_policy.ttl_ms = ttl_ms;
         f.storage_policy.ttl_action = TtlAction::Delete;
-        InodeView::File("t".to_string(), f)
+        InodeView::new_file("t".to_string(), f)
     }
 
     fn file_no_ttl(id: i64, mtime: i64) -> InodeView {
-        InodeView::File("t".to_string(), InodeFile::new(id, mtime))
+        InodeView::new_file("t".to_string(), InodeFile::new(id, mtime))
     }
 
     #[test]

--- a/curvine-server/src/master/meta/inode/ttl/ttl_executor.rs
+++ b/curvine-server/src/master/meta/inode/ttl/ttl_executor.rs
@@ -61,27 +61,27 @@ impl InodeTtlExecutor {
         let fs_dir_guard = fs_dir.read();
         if let Ok(Some(inode_view)) = fs_dir_guard.store.get_inode(inode_id, None) {
             match &inode_view {
-                InodeView::File(name, file) => {
-                    let parent_path = self.build_path_recursive(file.parent_id())?;
+                InodeView::File(f) => {
+                    let parent_path = self.build_path_recursive(f.parent_id())?;
                     let file_path = if parent_path == "/" {
-                        format!("/{}", name)
+                        format!("/{}", f.name)
                     } else {
-                        format!("{}/{}", parent_path, name)
+                        format!("{}/{}", parent_path, f.name)
                     };
                     return Ok(file_path);
                 }
-                InodeView::Dir(name, dir) => {
-                    let parent_path = self.build_path_recursive(dir.parent_id())?;
+                InodeView::Dir(d) => {
+                    let parent_path = self.build_path_recursive(d.parent_id())?;
                     let dir_path = if parent_path == "/" {
-                        format!("/{}", name)
+                        format!("/{}", d.name)
                     } else {
-                        format!("{}/{}", parent_path, name)
+                        format!("{}/{}", parent_path, d.name)
                     };
                     return Ok(dir_path);
                 }
-                InodeView::FileEntry(name, _) => {
+                InodeView::FileEntry(e) => {
                     // For empty files, we can't determine parent_id, so return a basic path
-                    return Ok(format!("/{}", name));
+                    return Ok(format!("/{}", e.name));
                 }
             }
         }

--- a/curvine-server/src/master/meta/store/inode_store.rs
+++ b/curvine-server/src/master/meta/store/inode_store.rs
@@ -23,7 +23,6 @@ use orpc::common::{FileUtils, Utils};
 use orpc::{err_box, try_err, CommonResult};
 use std::collections::{HashMap, LinkedList};
 use std::sync::Arc;
-
 // Currently, only RockSDB is supported.
 // Note: InodeStore is intentionally NOT Clone.
 // Cloning InodeStore increases Arc<RocksInodeStore> refcount, which prevents
@@ -60,10 +59,10 @@ impl InodeStore {
         self.ttl_bucket_list.add(child);
 
         match child {
-            InodeView::File(_, _) => self.fs_stats.increment_file_count(),
-            InodeView::Dir(_, dir) => {
+            InodeView::File(_) => self.fs_stats.increment_file_count(),
+            InodeView::Dir(d) => {
                 // Don't count root directory
-                if dir.id != ROOT_INODE_ID {
+                if d.id != ROOT_INODE_ID {
                     self.fs_stats.increment_dir_count();
                 }
             }
@@ -89,7 +88,7 @@ impl InodeStore {
             del_res.inodes += 1;
 
             match &inode {
-                InodeView::Dir(_, dir) => {
+                InodeView::Dir(dir) => {
                     batch.delete_inode(inode.id())?;
                     self.ttl_bucket_list.remove(&inode);
 
@@ -267,7 +266,7 @@ impl InodeStore {
     ) -> CommonResult<()> {
         if let Some(mut inode_view) = self.get_inode(inode_id, None)? {
             match &mut inode_view {
-                InodeView::File(_, _) => {
+                InodeView::File(_) => {
                     inode_view.incr_nlink();
                     batch.write_inode(&inode_view)?;
                 }
@@ -296,7 +295,7 @@ impl InodeStore {
 
         // Decrement nlink count of the file being unlinked.
         // If nlink reaches 0 the inode is also deleted and del_res.blocks will be populated.
-        let del_res = if let InodeView::File(_, _) = child {
+        let del_res = if let InodeView::File(_) = child {
             self.decrement_inode_nlink(child.id(), &mut batch)?
         } else {
             DeleteResult::new()
@@ -344,13 +343,13 @@ impl InodeStore {
         // Load the inode from storage
         if let Some(mut inode_view) = self.get_inode(inode_id, None)? {
             match &mut inode_view {
-                InodeView::File(_, file) => {
-                    let remaining_links = file.decrement_nlink();
+                InodeView::File(f) => {
+                    let remaining_links = f.decrement_nlink();
                     if remaining_links == 0 {
                         batch.delete_inode(inode_id)?;
 
                         // Collect block info
-                        del_res.blocks.extend(file.get_locs(self)?);
+                        del_res.blocks.extend(f.get_locs(self)?);
 
                         self.ttl_bucket_list.remove(&inode_view);
                     } else {
@@ -387,7 +386,7 @@ impl InodeStore {
         stack.push_back((
             root.as_ptr(),
             ROOT_INODE_ID,
-            InodeView::FileEntry(String::new(), ROOT_INODE_ID),
+            InodeView::new_entry(String::new(), ROOT_INODE_ID),
         ));
         let mut last_inode_id = ROOT_INODE_ID;
         let mut file_count = 0i64;
@@ -411,7 +410,7 @@ impl InodeStore {
                 };
                 self.ttl_bucket_list.add(&store_inode);
 
-                let inode = if matches!(store_inode, InodeView::Dir(_, _)) {
+                let inode = if matches!(store_inode, InodeView::Dir(_)) {
                     store_inode
                 } else {
                     file_entry
@@ -419,8 +418,8 @@ impl InodeStore {
 
                 // Count files and directories during tree reconstruction
                 match &inode {
-                    InodeView::File(_, _) => file_count += 1,
-                    InodeView::Dir(_, dir) => {
+                    InodeView::File(_) => file_count += 1,
+                    InodeView::Dir(dir) => {
                         // Don't count root directory
                         if dir.id != ROOT_INODE_ID {
                             dir_count += 1;
@@ -441,7 +440,7 @@ impl InodeStore {
                     let (key, value) = try_err!(item);
                     let (_, child_name) = RocksUtils::i64_str_from_bytes(&key).unwrap();
                     let child_id = RocksUtils::i64_from_bytes(&value)?;
-                    let file_entry = InodeView::FileEntry(child_name.to_string(), child_id);
+                    let file_entry = InodeView::new_entry(child_name.to_string(), child_id);
 
                     stack.push_back((next_parent.clone(), child_id, file_entry))
                 }
@@ -570,5 +569,13 @@ impl InodeStore {
 
     pub fn apply_set_locks(&self, id: i64, lock: &[FileLock]) -> CommonResult<()> {
         self.store.set_locks(id, lock)
+    }
+
+    pub fn get_rocksdb_metrics(&self) -> CommonResult<HashMap<String, u64>> {
+        self.store.get_rocksdb_metrics()
+    }
+
+    pub fn store(&self) -> &RocksInodeStore {
+        &self.store
     }
 }

--- a/curvine-server/src/master/meta/store/rocks_inode_store.rs
+++ b/curvine-server/src/master/meta/store/rocks_inode_store.rs
@@ -19,6 +19,7 @@ use curvine_common::state::{BlockLocation, FileLock, MountInfo};
 use curvine_common::utils::SerdeUtils as Serde;
 use orpc::CommonResult;
 use rocksdb::{DBIteratorWithThreadMode, WriteBatchWithTransaction, DB};
+use std::collections::HashMap;
 
 pub struct RocksInodeStore {
     pub(crate) db: DBEngine,
@@ -204,8 +205,8 @@ impl RocksInodeStore {
         }
     }
 
-    pub fn get_rocksdb_memory(&self) -> CommonResult<Vec<(String, u64)>> {
-        self.db.get_rocksdb_memory()
+    pub fn get_rocksdb_metrics(&self) -> CommonResult<HashMap<String, u64>> {
+        self.db.get_rocksdb_metrics()
     }
 }
 

--- a/curvine-server/src/master/quota/quota_manager.rs
+++ b/curvine-server/src/master/quota/quota_manager.rs
@@ -157,7 +157,7 @@ impl QuotaManager {
                     .iter()
                     .filter_map(|&inode_id| fs_guard.store.get_inode(inode_id, None).ok().flatten())
                     .map(|inode_view| match &inode_view {
-                        InodeView::File(_, f) => f.len.max(0),
+                        InodeView::File(f) => f.len.max(0),
                         _ => 0,
                     })
                     .sum::<i64>();
@@ -229,7 +229,7 @@ impl QuotaManager {
                         .ok()
                         .flatten()
                         .and_then(|inode_view| match &inode_view {
-                            InodeView::File(_, f) => Some((inode_id, f.len.max(0))),
+                            InodeView::File(f) => Some((inode_id, f.len.max(0))),
                             _ => None,
                         })
                 })


### PR DESCRIPTION
## Summary
Refactors the master metadata `InodeView` representation to use explicit `NamedFile`, `NamedDir`, and `NamedEntry` types (boxed inside the enum), with `Deref`/`DerefMut` to the underlying `InodeFile` / `InodeDir`. Call sites across the filesystem layer, journal replay, inode path resolution, TTL, quota, and the inode store are updated to match the new shape.
Also replaces coarse RocksDB “memory components” reporting with a richer **`HashMap<String, u64>`** of DB- and column-family–scoped integer properties (`get_rocksdb_metrics`), documents semantics (especially default-CF vs multi-CF `db_*` keys), and wires master Prometheus metrics to the new gauge family **`rocksdb_metrics`**.
Adds **`find_inode(parent, name)`** on the Rocks-backed store (edge lookup + inode load) and exposes **`InodeStore::store()`** for direct access where needed.
## Motivation
- Clearer ownership and naming for inode tree nodes; smaller, consistent construction via `InodeView::new_*`.
- Better observability: export many RocksDB internal counters (memtables, block cache, compactions, snapshots, etc.) instead of a handful of synthetic memory tags.
## Changes
### `curvine-common`
- **`DBEngine`**: `get_rocksdb_memory()` → **`get_rocksdb_metrics()`** returning `HashMap<String, u64>` with documented key naming (`db_*`, `cf_{cf}_*`) and guidance for multi-CF totals.
### `curvine-server`
- **`InodeView`**: new wrapper structs, constructors, pattern-match updates throughout.
- **`FsDir`**, **`InodePath`**, **`InodeDir`**, **`inodes_children`**, **`journal_loader`**, **`ttl_*`**, **`quota_manager`**: adapt to new enum and helpers.
- **`RocksInodeStore` / `InodeStore`**: `get_rocksdb_metrics`, **`find_inode`**, **`InodeStore::store()`**.
- **`MasterMetrics`**: `rocksdb_used_memory_bytes` → **`rocksdb_metrics`** (`GaugeVec` keyed by metric name).
## Breaking changes
1. **Serialization**: `InodeView`’s serde/binary layout changes. **Existing persisted inode data may not deserialize** without a migration or compatibility layer.
2. **Metrics**: Prometheus metric name and labels change (`rocksdb_used_memory_bytes` → `rocksdb_metrics`; label values are full metric keys from the map).