### PR TITLE
docs: add dev container proxy example

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,33 @@
+# Dev Container
+
+This directory contains Dev Container configuration for local development.
+
+## Files
+
+- `devcontainer.json`: active local Dev Container config
+- `devcontainer.json.example`: example config with proxy settings
+
+## Usage
+
+1. Copy the example file:
+   - `cp .devcontainer/devcontainer.json.example .devcontainer/devcontainer.json`
+2. Adjust proxy settings in `containerEnv` if needed.
+3. Reopen the project in the Dev Container.
+
+## Proxy settings
+
+The example includes these environment variables:
+
+- `HTTP_PROXY`: HTTP proxy address
+- `HTTPS_PROXY`: HTTPS proxy address
+- `ALL_PROXY`: SOCKS proxy address for tools that support it
+- `NO_PROXY`: hosts that should bypass the proxy
+
+Default example values:
+
+- `HTTP_PROXY=http://host.docker.internal:7890`
+- `HTTPS_PROXY=http://host.docker.internal:7890`
+- `ALL_PROXY=socks5://host.docker.internal:7891`
+- `NO_PROXY=localhost,127.0.0.1,host.docker.internal`
+
+`host.docker.internal` lets the container access a proxy running on the host machine. Update ports and values to match your local environment.

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -30,4 +30,4 @@ Default example values:
 - `ALL_PROXY=socks5://host.docker.internal:7891`
 - `NO_PROXY=localhost,127.0.0.1,host.docker.internal`
 
-`host.docker.internal` lets the container access a proxy running on the host machine. Update ports and values to match your local environment.
+On Docker Desktop (macOS/Windows), `host.docker.internal` lets the container access a proxy running on the host machine. On many Linux Docker setups you may need to add `host.docker.internal` yourself (for example with `"runArgs": ["--add-host=host.docker.internal:host-gateway"]`) or use the Docker host IP instead. Update ports, hostnames, and values to match your local environment.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,38 @@
+{
+  "name": "curvine-dev",
+  "image": "ghcr.io/curvineio/curvine-compile:rocky9",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
+  "workspaceFolder": "/workspace",
+  "remoteUser": "root",
+  "init": true,
+  "overrideCommand": true,
+  "updateRemoteUserUID": false,
+  "mounts": [
+    "source=curvine-cargo-cache,target=/root/.cargo,type=volume",
+    "source=curvine-m2-cache,target=/root/.m2,type=volume",
+    "source=curvine-npm-cache,target=/root/.npm,type=volume"
+  ],
+  "postCreateCommand": "git config --global --add safe.directory /workspace && cd /workspace/curvine-web/webui && npm install",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "rust-lang.rust-analyzer",
+        "vadimcn.vscode-lldb",
+        "tamasfe.even-better-toml",
+        "ms-python.python",
+        "golang.go",
+        "dbaeumer.vscode-eslint",
+        "Vue.volar"
+      ],
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash",
+        "editor.formatOnSave": true,
+        "rust-analyzer.check.command": "clippy",
+        "rust-analyzer.cargo.features": "all",
+        "[rust]": {
+          "editor.defaultFormatter": "rust-lang.rust-analyzer"
+        }
+      }
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json.example
+++ b/.devcontainer/devcontainer.json.example
@@ -1,0 +1,44 @@
+{
+  "name": "curvine-dev",
+  "image": "ghcr.io/curvineio/curvine-compile:rocky9",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
+  "workspaceFolder": "/workspace",
+  "remoteUser": "root",
+  "init": true,
+  "overrideCommand": true,
+  "updateRemoteUserUID": false,
+  "mounts": [
+    "source=curvine-cargo-cache,target=/root/.cargo,type=volume",
+    "source=curvine-m2-cache,target=/root/.m2,type=volume",
+    "source=curvine-npm-cache,target=/root/.npm,type=volume"
+  ],
+  "containerEnv": {
+    "HTTP_PROXY": "http://host.docker.internal:7890",
+    "HTTPS_PROXY": "http://host.docker.internal:7890",
+    "ALL_PROXY": "socks5://host.docker.internal:7891",
+    "NO_PROXY": "localhost,127.0.0.1,host.docker.internal"
+  },
+  "postCreateCommand": "git config --global --add safe.directory /workspace && cd /workspace/curvine-web/webui && npm install",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "rust-lang.rust-analyzer",
+        "vadimcn.vscode-lldb",
+        "tamasfe.even-better-toml",
+        "ms-python.python",
+        "golang.go",
+        "dbaeumer.vscode-eslint",
+        "Vue.volar"
+      ],
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash",
+        "editor.formatOnSave": true,
+        "rust-analyzer.check.command": "clippy",
+        "rust-analyzer.cargo.features": "all",
+        "[rust]": {
+          "editor.defaultFormatter": "rust-lang.rust-analyzer"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `.devcontainer/devcontainer.json.example` with proxy-related environment variables
- add `.devcontainer/README.md` describing how to copy and customize the example locally
- keep proxy guidance out of the main project README and scoped to Dev Container docs