### PR TITLE
feat(common,orpc,build): optional allocators and FrameBuf for RPC reads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,6 +876,7 @@ dependencies = [
  "indexmap 2.11.0",
  "linked-hash-map",
  "log",
+ "mimalloc",
  "mini-moka",
  "num_enum",
  "once_cell",
@@ -892,6 +893,9 @@ dependencies = [
  "slog",
  "slog-stdlog",
  "thiserror 1.0.69",
+ "tikv-jemalloc-ctl",
+ "tikv-jemalloc-sys",
+ "tikv-jemallocator",
  "tokio",
  "tokio-util",
  "toml",
@@ -2296,6 +2300,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2460,6 +2474,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -2817,6 +2840,12 @@ dependencies = [
  "smallvec",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pbkdf2"
@@ -4365,6 +4394,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tikv-jemalloc-ctl"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "661f1f6a57b3a36dc9174a2c10f19513b4866816e13425d3e418b11cc37bc24c"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,3 +125,8 @@ md-5 = "0.10.6"
 bitflags = "2.10.0"
 glob = "0.3"
 lru = "0.16.1"
+
+mimalloc = "0.1.48"
+tikv-jemallocator = { version = "0.6.1", features = ["stats", "unprefixed_malloc_on_supported_platforms"] }
+tikv-jemalloc-ctl = { version = "0.6.1"}
+tikv-jemalloc-sys = { version = "0.6.1", features = ["stats"] }

--- a/build/build.sh
+++ b/build/build.sh
@@ -137,12 +137,13 @@ DIST_ZIP=curvine-${CURVINE_VERSION}-${ARCH_NAME}-${OS_VERSION}.zip
 PROFILE="--release"
 declare -a PACKAGES=("all")  # Default to build all packages
 declare -a UFS_TYPES=("opendal-s3")  # Default UFS type
-declare -a EXTRA_FEATURES=()  # Extra features to add
+declare -a EXTRA_FEATURES=()  # From -f only; --alloc is merged into FEATURES later
+ALLOC=jemalloc
 CRATE_ZIP=""
 SKIP_JAVA_SDK=0  # Flag to skip Java SDK compilation
 
 # Parse command line arguments
-TEMP=$(getopt -o p:u:f:dzhv --long package:,ufs:,features:,debug,zip,skip-java-sdk,help -n "$0" -- "$@")
+TEMP=$(getopt -o p:u:f:a:dzhv --long package:,ufs:,features:,alloc:,debug,zip,skip-java-sdk,help -n "$0" -- "$@")
 if [ $? != 0 ] ; then print_help ; exit 1 ; fi
 
 eval set -- "$TEMP"
@@ -167,6 +168,10 @@ while true ; do
       for feature in "${FEATURE_ARRAY[@]}"; do
         EXTRA_FEATURES+=("$feature")
       done
+      shift 2
+      ;;
+    -a|--alloc)
+      ALLOC="$2"
       shift 2
       ;;
     -d|--debug)
@@ -453,9 +458,12 @@ if [ ${#EXTRA_FEATURES[@]} -gt 0 ]; then
   done
 fi
 
+# Append --alloc as a workspace feature: curvine-common/{jemalloc|mimalloc} → cargo --features
+FEATURES+=("curvine-common/${ALLOC}")
+
 # Add features to command if any
 if [ ${#FEATURES[@]} -gt 0 ]; then
-  # Join features with comma
+  # Join features with comma for --features
   IFS=, eval 'FEATURE_LIST="${FEATURES[*]}"'
   cmd="$cmd --no-default-features --features $FEATURE_LIST"
 fi

--- a/curvine-client/src/file/curvine_filesystem.rs
+++ b/curvine-client/src/file/curvine_filesystem.rs
@@ -17,6 +17,7 @@ use crate::file::{FsClient, FsContext, FsReader, FsWriter, FsWriterBase};
 use crate::ClientMetrics;
 use async_stream::stream;
 use bytes::BytesMut;
+use curvine_common::alloc::allocator_type_name;
 use curvine_common::conf::ClusterConf;
 use curvine_common::error::FsError;
 use curvine_common::fs::{FileSystem, FsKind, ListStream, Path, Reader, Writer};
@@ -56,9 +57,10 @@ impl CurvineFileSystem {
 
         let c = &fs.conf().client;
         info!(
-            "Create new filesystem, git version: {}, masters: {}, threads: {}-{}, \
+            "Create new filesystem, git version: {}, allocator: {}, masters: {}, threads: {}-{}, \
             buffer(rw): {}-{}, conn timeout(ms): {}-{}, rpc timeout(ms): {}-{}, data timeout(ms): {}",
             GIT_VERSION,
+            allocator_type_name(),
             fs.conf().masters_string(),
             rt.io_threads(),
             rt.worker_threads(),

--- a/curvine-common/Cargo.toml
+++ b/curvine-common/Cargo.toml
@@ -47,8 +47,24 @@ anyhow = { workspace = true }
 tracing = { workspace = true }
 bitflags = { workspace = true }
 
+mimalloc = { workspace = true, optional = true }
+
+[target.'cfg(unix)'.dependencies]
+tikv-jemallocator = { workspace = true, optional = true }
+tikv-jemalloc-ctl = { workspace = true, optional = true }
+tikv-jemalloc-sys = { workspace = true, optional = true }
+
 [features]
-default = []
+jemalloc = [
+    "dep:tikv-jemallocator",
+    "dep:tikv-jemalloc-ctl",
+    "dep:tikv-jemalloc-sys",
+]
+mimalloc = ["dep:mimalloc"]
+system = []
 
 [build-dependencies]
 prost-build = { workspace = true }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }

--- a/curvine-common/src/alloc/jemalloc.rs
+++ b/curvine-common/src/alloc/jemalloc.rs
@@ -1,0 +1,19 @@
+//  Copyright 2025 OPPO.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+pub type Allocator = tikv_jemallocator::Jemalloc;
+
+pub const fn allocator() -> Allocator {
+    tikv_jemallocator::Jemalloc
+}

--- a/curvine-common/src/alloc/mimalloc.rs
+++ b/curvine-common/src/alloc/mimalloc.rs
@@ -1,0 +1,19 @@
+//  Copyright 2025 OPPO.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+pub type Allocator = mimalloc::MiMalloc;
+
+pub const fn allocator() -> Allocator {
+    mimalloc::MiMalloc
+}

--- a/curvine-common/src/alloc/mod.rs
+++ b/curvine-common/src/alloc/mod.rs
@@ -1,0 +1,38 @@
+//  Copyright 2025 OPPO.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+//! Global allocator for crates that link `curvine-common`. Feature `mimalloc` wins over `jemalloc`.
+//! `jemalloc` is Unix-only; other targets fall back to the system allocator.
+
+#[cfg(all(unix, not(fuzzing), feature = "jemalloc"))]
+#[path = "jemalloc.rs"]
+mod imp;
+
+#[cfg(all(unix, not(fuzzing), feature = "mimalloc"))]
+#[path = "mimalloc.rs"]
+mod imp;
+
+#[cfg(not(all(unix, not(fuzzing), any(feature = "jemalloc", feature = "mimalloc"))))]
+#[path = "system.rs"]
+mod imp;
+
+pub use self::imp::*;
+
+#[global_allocator]
+static ALLOC: Allocator = allocator();
+
+#[inline]
+pub fn allocator_type_name() -> &'static str {
+    std::any::type_name::<Allocator>()
+}

--- a/curvine-common/src/alloc/system.rs
+++ b/curvine-common/src/alloc/system.rs
@@ -1,0 +1,18 @@
+//  Copyright 2025 OPPO.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+pub type Allocator = std::alloc::System;
+pub const fn allocator() -> Allocator {
+    std::alloc::System
+}

--- a/curvine-common/src/conf/cluster_conf.rs
+++ b/curvine-common/src/conf/cluster_conf.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::alloc::allocator_type_name;
 use crate::conf::CliConf;
 use crate::conf::{ClientConf, FuseConf, JobConf, JournalConf, MasterConf, WorkerConf};
 use crate::rocksdb::DBConf;
@@ -265,6 +266,7 @@ impl ClusterConf {
 
     pub fn print(&self) {
         let conf = self.to_pretty_toml().unwrap();
+        info!("allocator: {}", allocator_type_name());
         info!("git version: {}", version::GIT_VERSION);
         info!("cluster conf start: \n{}\n", conf);
     }

--- a/curvine-common/src/conf/master_conf.rs
+++ b/curvine-common/src/conf/master_conf.rs
@@ -130,6 +130,8 @@ pub struct MasterConf {
     pub lock_expire_time: String,
     #[serde(skip)]
     pub lock_expire_time_unit: DurationUnit,
+
+    pub buffer_size: usize,
 }
 
 impl MasterConf {
@@ -303,6 +305,8 @@ impl Default for MasterConf {
 
             lock_expire_time: "5m".to_string(),
             lock_expire_time_unit: Default::default(),
+
+            buffer_size: 128 * 1024,
         };
 
         conf.init().unwrap();

--- a/curvine-common/src/error/fs_error.rs
+++ b/curvine-common/src/error/fs_error.rs
@@ -405,6 +405,12 @@ impl From<Elapsed> for FsError {
     }
 }
 
+impl From<EncodeError> for FsError {
+    fn from(value: EncodeError) -> Self {
+        Self::PBEncode(ErrorImpl::with_source(value))
+    }
+}
+
 impl ErrorExt for FsError {
     fn ctx(self, ctx: impl Into<String>) -> Self {
         match self {

--- a/curvine-common/src/lib.rs
+++ b/curvine-common/src/lib.rs
@@ -14,6 +14,7 @@
 
 use crate::error::FsError;
 
+pub mod alloc;
 pub mod conf;
 pub mod error;
 pub mod executor;

--- a/orpc/src/handler/frame_buf.rs
+++ b/orpc/src/handler/frame_buf.rs
@@ -1,0 +1,98 @@
+//  Copyright 2025 OPPO.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+use std::ops::{Deref, DerefMut};
+
+use bytes::BytesMut;
+
+/// Reusable [`BytesMut`] wrapper for per-frame reads and protocol encoding on the write side.
+///
+/// [`take_exact`](Self::take_exact) may retain spare capacity after [`BytesMut::split_to`]; when
+/// the tail’s capacity exceeds `buf_size * MAX_FACTOR`, the tail is discarded to cap growth.
+///
+/// # `buf_size` and zero
+///
+/// `buf_size` is the baseline used for that shrink threshold (and e.g. [`RpcFrame::into_tokio_frame`](crate::handler::RpcFrame::into_tokio_frame) capacity).
+/// If `buf_size` is `0`, it is replaced with [`DEFAULT_BUF_SIZE`] (8 KiB) so shrink logic and
+/// downstream sizing behave sensibly instead of treating every non‑empty tail as over‑capacity.
+pub struct FrameBuf {
+    inner: BytesMut,
+    buf_size: usize,
+}
+
+impl FrameBuf {
+    pub const MAX_FACTOR: usize = 4;
+
+    /// Default effective `buf_size` when the caller passes `0` ([`new`](Self::new)).
+    pub const DEFAULT_BUF_SIZE: usize = 8 * 1024;
+
+    /// Creates an empty buffer. If `buf_size` is `0`, uses [`DEFAULT_BUF_SIZE`] (8 KiB).
+    pub fn new(buf_size: usize) -> Self {
+        let buf_size = if buf_size == 0 {
+            Self::DEFAULT_BUF_SIZE
+        } else {
+            buf_size
+        };
+        Self {
+            inner: BytesMut::new(),
+            buf_size,
+        }
+    }
+
+    /// Effective baseline size (after applying the `0` → 8 KiB default in [`new`](Self::new)).
+    pub fn buf_size(&self) -> usize {
+        self.buf_size
+    }
+
+    pub fn take_exact(&mut self, len: usize) -> BytesMut {
+        self.inner.reserve(len);
+        unsafe {
+            self.inner.set_len(len);
+        }
+        let buf = self.inner.split_to(len);
+
+        if self.inner.capacity() > self.buf_size.saturating_mul(Self::MAX_FACTOR) {
+            self.inner = BytesMut::new();
+        }
+
+        buf
+    }
+
+    pub fn into_inner(self) -> BytesMut {
+        self.inner
+    }
+}
+
+impl Clone for FrameBuf {
+    fn clone(&self) -> Self {
+        Self {
+            inner: BytesMut::new(),
+            buf_size: self.buf_size,
+        }
+    }
+}
+
+impl Deref for FrameBuf {
+    type Target = BytesMut;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl DerefMut for FrameBuf {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}

--- a/orpc/src/handler/mod.rs
+++ b/orpc/src/handler/mod.rs
@@ -35,3 +35,6 @@ pub use self::read_frame::ReadFrame;
 
 mod frame;
 pub use self::frame::Frame;
+
+mod frame_buf;
+pub use self::frame_buf::FrameBuf;

--- a/orpc/src/handler/read_frame.rs
+++ b/orpc/src/handler/read_frame.rs
@@ -12,34 +12,38 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::handler::rpc_frame::FrameSate;
-use crate::io::IOResult;
-use crate::message;
-use crate::message::Message;
-use crate::sys::DataSlice;
-use bytes::BytesMut;
 use std::mem;
+
+use bytes::BytesMut;
 use tokio::io::{AsyncReadExt, ReadHalf};
 use tokio::net::TcpStream;
 
+use crate::handler::rpc_frame::FrameSate;
+use crate::handler::FrameBuf;
+use crate::io::IOResult;
+use crate::message::Message;
+use crate::sys::DataSlice;
+use crate::{err_box, message};
+
 pub struct ReadFrame {
     io: ReadHalf<TcpStream>,
-    buf: BytesMut,
+    buf: FrameBuf,
 }
 
 impl ReadFrame {
-    pub(crate) fn new(io: ReadHalf<TcpStream>, buf: BytesMut) -> Self {
+    pub(crate) fn new(io: ReadHalf<TcpStream>, buf: FrameBuf) -> Self {
         Self { io, buf }
     }
 
     // Read data of the specified length.
     pub async fn read_full(&mut self, len: i32) -> IOResult<BytesMut> {
-        let len = len as usize;
-        self.buf.reserve(len);
-        unsafe {
-            self.buf.set_len(len);
+        if len == 0 {
+            return Ok(BytesMut::new());
+        } else if len < 0 {
+            return err_box!("Invalid length {}", len);
         }
-        let mut buf = self.buf.split_to(len);
+
+        let mut buf = self.buf.take_exact(len as usize);
         self.io.read_exact(&mut buf).await?;
         Ok(buf)
     }

--- a/orpc/src/handler/rpc_frame.rs
+++ b/orpc/src/handler/rpc_frame.rs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::handler::{Frame, ReadFrame, RpcCodec, WriteFrame};
+use crate::handler::{Frame, FrameBuf, ReadFrame, RpcCodec, WriteFrame};
 use crate::io::net::ConnState;
 use crate::io::IOResult;
 use crate::message::{Message, Protocol, RefMessage};
 use crate::server::ServerConf;
 use crate::sys::{DataSlice, RawIOSlice};
-use crate::{message, sys};
+use crate::{err_box, message, sys};
 use bytes::BytesMut;
 use std::mem;
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
@@ -37,7 +37,7 @@ pub enum FrameSate {
 /// Custom data frame resolution
 pub struct RpcFrame {
     io: TcpStream,
-    buf: BytesMut,
+    buf: FrameBuf,
     enable_splice: bool,
 }
 
@@ -51,7 +51,7 @@ impl RpcFrame {
 
         RpcFrame {
             io,
-            buf: BytesMut::with_capacity(buffer_size),
+            buf: FrameBuf::new(buffer_size),
             enable_splice,
         }
     }
@@ -66,11 +66,13 @@ impl RpcFrame {
 
     // Read data of the specified length.
     pub async fn read_full(&mut self, len: i32) -> IOResult<BytesMut> {
-        self.buf.reserve(len as usize);
-        unsafe {
-            self.buf.set_len(len as usize);
+        if len == 0 {
+            return Ok(BytesMut::new());
+        } else if len < 0 {
+            return err_box!("Invalid length {}", len);
         }
-        let mut buf = self.buf.split_to(len as usize);
+
+        let mut buf = self.buf.take_exact(len as usize);
         self.io.read_exact(&mut buf).await?;
         Ok(buf)
     }
@@ -181,12 +183,12 @@ impl RpcFrame {
     }
 
     pub fn into_tokio_frame(self) -> Framed<TcpStream, RpcCodec> {
-        Framed::with_capacity(self.io, RpcCodec::new(), self.buf.capacity())
+        Framed::with_capacity(self.io, RpcCodec::new(), self.buf.buf_size())
     }
 
     pub fn split(self) -> (ReadFrame, WriteFrame) {
         let (read, write) = tokio::io::split(self.io);
-        let read_frame = ReadFrame::new(read, BytesMut::with_capacity(self.buf.capacity()));
+        let read_frame = ReadFrame::new(read, self.buf.clone());
         let write_frame = WriteFrame::new(write, self.buf);
         (read_frame, write_frame)
     }

--- a/orpc/src/handler/write_frame.rs
+++ b/orpc/src/handler/write_frame.rs
@@ -12,19 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::io::IOResult;
-use crate::message::Message;
-use bytes::BytesMut;
 use tokio::io::{AsyncWriteExt, WriteHalf};
 use tokio::net::TcpStream;
 
+use crate::handler::FrameBuf;
+use crate::io::IOResult;
+use crate::message::Message;
+
 pub struct WriteFrame {
     io: WriteHalf<TcpStream>,
-    buf: BytesMut,
+    buf: FrameBuf,
 }
 
 impl WriteFrame {
-    pub(crate) fn new(io: WriteHalf<TcpStream>, buf: BytesMut) -> Self {
+    pub(crate) fn new(io: WriteHalf<TcpStream>, buf: FrameBuf) -> Self {
         Self { io, buf }
     }
 


### PR DESCRIPTION
## Summary

Reduces steady-state memory pressure from RPC read buffering by centralizing `BytesMut` reuse in a new **`FrameBuf`** type, and adds **optional global allocators** (`jemalloc` on Unix, `mimalloc`) selectable at build time via `curvine-common` features and `build.sh`.

## Motivation

- Per-connection `BytesMut` + `split_to` can leave a large **spare tail capacity**, which scales badly with concurrency.
- Production builds often want **jemalloc/mimalloc** instead of the system allocator for allocator contention and RSS behavior.

## Changes

### `orpc`

- New **`FrameBuf`**: `take_exact(len)` uses `reserve` / `set_len` / `split_to`, then drops the tail when `tail.capacity() > buf_size * 4` to cap retained capacity.
- **`buf_size == 0`** is normalized to **8 KiB** for shrink thresholds and `Framed` capacity (`into_tokio_frame`).
- **`RpcFrame`**, **`ReadFrame`**, **`WriteFrame`**: use `FrameBuf` instead of raw `BytesMut`; `read_full` returns early for `len <= 0`.
- **`split`**: read half gets `FrameBuf::clone()` (fresh inner buffer + same baseline size); write half keeps the original buffer for encoding.

### `curvine-common`

- New **`alloc`** module: `#[global_allocator]`, optional **`jemalloc`** (Unix-only deps under `target.'cfg(unix)'.dependencies`), optional **`mimalloc`**, **`system`** feature placeholder, **`allocator_type_name()`** via `type_name::<Allocator>()`.
- **`[lints.rust]`**: `check-cfg` for `fuzzing` to avoid `unexpected_cfgs` noise.
- **`ClusterConf::print`**: logs active allocator type.
- **`MasterConf`**: new **`buffer_size`** field, default **128 KiB**.
- **`FsError`**: **`From<EncodeError>`** impl.
- **`lib.rs`**: export `alloc`.

### `curvine-client`

- Startup log line includes **`allocator_type_name()`** next to git version / masters / thread counts.

### Workspace / build

- Root **`Cargo.toml`**: workspace entries for allocator crates.
- **`build/build.sh`**: **`-a` / `--alloc`** (default **`jemalloc`**); value is appended as **`curvine-common/${ALLOC}`** into the feature list passed to `cargo --features` (with existing UFS / `-f` flow).
- **`Cargo.lock`**: updated for new dependencies.

## How to test

- [ ] `cargo check --workspace` (with and without `curvine-common` allocator features).
- [ ] `./build/build.sh` default and `./build/build.sh --alloc mimalloc` (or your package/UFS flags).
- [ ] RPC smoke / integration: read/write paths, `RpcFrame::split`, `into_tokio_frame`.
- [ ] Confirm allocator string appears in client FS log and `ClusterConf::print` output.

## Ops / rollout

- Builds that use `--no-default-features` now rely on **`build.sh`** (or callers) to still pass **`curvine-common/jemalloc`** or **`mimalloc`** if you want a non-system allocator; default script behavior keeps **`jemalloc`**.
- **`MasterConf.buffer_size`**: ensure config/TOML migration if existing deployments omit the field (serde default applies for new field if optional in your schema).

## Risk / notes

- **`#[global_allocator]`** in `curvine-common`: the final binary must not register a second global allocator.
- Allocator choice affects **RSS / P99 latency**; validate under your load model.