### PR TITLE
feat(meta): batch inode multi-get for directory listing; fix worker S…

### DIFF
--- a/curvine-common/src/rocksdb/db_engine.rs
+++ b/curvine-common/src/rocksdb/db_engine.rs
@@ -113,6 +113,20 @@ impl DBEngine {
         Ok(cf_bytes)
     }
 
+    pub fn batched_multi_get_cf<'a, K, I>(
+        &'a self,
+        cf: &str,
+        keys: I,
+        sorted_input: bool,
+    ) -> CommonResult<Vec<Result<Option<DBPinnableSlice<'a>>, Error>>>
+    where
+        K: AsRef<[u8]> + 'a + ?Sized,
+        I: IntoIterator<Item = &'a K>,
+    {
+        let cf = self.cf(cf)?;
+        Ok(self.db.batched_multi_get_cf(cf, keys, sorted_input))
+    }
+
     pub fn get<K>(&self, key: K) -> CommonResult<Option<Vec<u8>>>
     where
         K: AsRef<[u8]>,

--- a/curvine-server/src/master/fs/state/worker_map.rs
+++ b/curvine-server/src/master/fs/state/worker_map.rs
@@ -38,10 +38,14 @@ impl WorkerMap {
         }
     }
 
-    pub fn insert(&mut self, addr: WorkerAddress, storages: Vec<StorageInfo>) -> FsResult<()> {
-        // Check whether the address and worker id conflict.
+    pub fn remove(&mut self, addr: &WorkerAddress) {
+        self.workers.swap_remove(&addr.worker_id);
+        self.lost_workers.swap_remove(&addr.worker_id);
+    }
+
+    pub fn ensure_worker_id_addr(&self, addr: &WorkerAddress) -> FsResult<()> {
         if let Some(v) = self.workers.get(&addr.worker_id) {
-            if v.address != addr {
+            if v.address != *addr {
                 return err_box!(
                     "worker id addr mismatch,  expected {}, actual: {}",
                     v.address,
@@ -49,6 +53,11 @@ impl WorkerMap {
                 );
             }
         }
+        Ok(())
+    }
+
+    pub fn insert(&mut self, addr: WorkerAddress, storages: Vec<StorageInfo>) -> FsResult<()> {
+        self.ensure_worker_id_addr(&addr)?;
 
         // Register the worker and update the storage information.
         // @todo Heartbeat may be too simple and directly covers historical data.

--- a/curvine-server/src/master/fs/worker_manager.rs
+++ b/curvine-server/src/master/fs/worker_manager.rs
@@ -67,7 +67,13 @@ impl WorkerManager {
         let cmds = match status {
             HeartbeatStatus::Start => {
                 info!("Worker register: {}", addr);
-                vec![]
+                // Enforce the same worker_id ↔ address rule as insert() before remove(): a Start
+                // from a conflicting address must not evict the live registration.
+                self.worker_map.ensure_worker_id_addr(&addr)?;
+                // Same node restarting: clear the slot so we do not treat it as ready or run
+                // Running heartbeat bookkeeping until insert() on the next Running beat.
+                self.worker_map.remove(&addr);
+                return Ok(vec![]);
             }
 
             HeartbeatStatus::Running => self.block_map.handle_heartbeat(addr.worker_id),

--- a/curvine-server/src/master/meta/fs_dir.rs
+++ b/curvine-server/src/master/meta/fs_dir.rs
@@ -452,35 +452,23 @@ impl FsDir {
             None => return err_box!("File {} not exists", inp.path()),
         };
 
-        let mut res = Vec::with_capacity(1.max(inode.child_len()));
         match inode.as_ref() {
-            File(_) => res.push(inode.to_file_status(inp.path())),
+            File(_) => Ok(vec![inode.to_file_status(inp.path())]),
 
             Dir(d) => {
-                for item in d.children_iter() {
-                    let child_path = inp.child_path(item.name());
-                    match item {
-                        File(..) | Dir(..) => res.push(item.to_file_status(&child_path)),
-                        FileEntry(e) => {
-                            let inode_opt = self.store.get_inode(e.id, Some(&e.name))?;
-                            if let Some(inode_view) = inode_opt {
-                                res.push(inode_view.to_file_status(&child_path));
-                            }
-                        }
-                    }
-                }
+                let iter = d.children_iter().collect();
+                let res = self.store.batched_get_inodes(inp, iter)?;
+                Ok(res)
             }
 
             FileEntry(e) => {
                 let inode_opt = self.store.get_inode(e.id, Some(&e.name))?;
                 match inode_opt {
-                    Some(inode_view) => res.push(inode_view.to_file_status(inp.path())),
-                    None => return err_box!("File {} not exists", inp.path()),
+                    Some(inode_view) => Ok(vec![inode_view.to_file_status(inp.path())]),
+                    None => err_box!("File {} not exists", inp.path()),
                 }
             }
         }
-
-        Ok(res)
     }
 
     fn list_single_file(status: FileStatus, opts: &ListOptions) -> Vec<FileStatus> {
@@ -509,22 +497,7 @@ impl FsDir {
 
             Dir(d) => {
                 let children = d.list_options(opts);
-                let mut res = Vec::with_capacity(children.len());
-
-                for item in children {
-                    let child_path = inp.child_path(item.name());
-
-                    match item {
-                        File(..) | Dir(..) => res.push(item.to_file_status(&child_path)),
-
-                        FileEntry(e) => {
-                            let inode_opt = self.store.get_inode(e.id, Some(&e.name))?;
-                            if let Some(inode_view) = inode_opt {
-                                res.push(inode_view.to_file_status(&child_path));
-                            }
-                        }
-                    }
-                }
+                let res = self.store.batched_get_inodes(inp, children)?;
                 Ok(res)
             }
 

--- a/curvine-server/src/master/meta/store/inode_store.rs
+++ b/curvine-server/src/master/meta/store/inode_store.rs
@@ -14,15 +14,17 @@
 
 use crate::master::fs::DeleteResult;
 use crate::master::meta::inode::ttl::TtlBucketList;
-use crate::master::meta::inode::{InodeFile, InodeView, ROOT_INODE_ID};
+use crate::master::meta::inode::{InodeFile, InodePath, InodeView, ROOT_INODE_ID};
 use crate::master::meta::store::{InodeWriteBatch, RocksInodeStore};
 use crate::master::meta::{FileSystemStats, FsDir, LockMeta};
 use curvine_common::rocksdb::{DBConf, RocksUtils};
-use curvine_common::state::{BlockLocation, CommitBlock, FileLock, MountInfo};
+use curvine_common::state::{BlockLocation, CommitBlock, FileLock, FileStatus, MountInfo};
+use curvine_common::utils::SerdeUtils;
 use orpc::common::{FileUtils, Utils};
-use orpc::{err_box, try_err, CommonResult};
+use orpc::{err_box, try_err, try_option, CommonResult};
 use std::collections::{HashMap, LinkedList};
 use std::sync::Arc;
+
 // Currently, only RockSDB is supported.
 // Note: InodeStore is intentionally NOT Clone.
 // Cloning InodeStore increases Arc<RocksInodeStore> refcount, which prevents
@@ -487,6 +489,63 @@ impl InodeStore {
             }
         }
         Ok(inode_view)
+    }
+
+    pub fn batched_get_inodes(
+        &self,
+        inp: &InodePath,
+        list: Vec<&InodeView>,
+    ) -> CommonResult<Vec<FileStatus>> {
+        if list.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let mut out = vec![FileStatus::default(); list.len()];
+        let mut scan_inodes = Vec::with_capacity(list.len());
+
+        for (index, inode) in list.iter().enumerate() {
+            if inode.is_file_entry() {
+                scan_inodes.push((index, RocksUtils::i64_to_bytes(inode.id())));
+            } else {
+                let child_path = inp.child_path(inode.name());
+                out[index] = inode.to_file_status(&child_path);
+            }
+        }
+
+        if scan_inodes.is_empty() {
+            return Ok(out);
+        }
+
+        let keys = scan_inodes.iter().map(|x| &x.1);
+        let batch_res = self.store.batched_multi_get_inodes(keys, false)?;
+        for (i, item) in batch_res.into_iter().enumerate() {
+            let index = try_option!(scan_inodes.get(i)).0;
+            let file_entry = try_option!(list.get(index));
+
+            if let Some(bytes) = try_err!(item) {
+                let mut inode: InodeView = SerdeUtils::deserialize(bytes.as_ref())?;
+                if inode.id() != file_entry.id() {
+                    return err_box!(
+                        "batched_get_inodes: inode id mismatch for key index {} (expected id {}, stored inode id {})",
+                        i,
+                        file_entry.id(),
+                        inode.id()
+                    );
+                }
+
+                inode.change_name(file_entry.name().to_owned());
+                let child_path = inp.child_path(file_entry.name());
+                out[index] = inode.to_file_status(&child_path);
+            } else {
+                return err_box!(
+                    "batched_get_inodes: inode missing in store path {}, id {}",
+                    inp.child_path(file_entry.name()),
+                    file_entry.id()
+                );
+            }
+        }
+
+        Ok(out)
     }
 
     pub fn cf_hash(&self, cf: &str) -> u128 {

--- a/curvine-server/src/master/meta/store/rocks_inode_store.rs
+++ b/curvine-server/src/master/meta/store/rocks_inode_store.rs
@@ -18,7 +18,7 @@ use curvine_common::rocksdb::{DBConf, DBEngine, RocksIterator, RocksUtils};
 use curvine_common::state::{BlockLocation, FileLock, MountInfo};
 use curvine_common::utils::SerdeUtils as Serde;
 use orpc::CommonResult;
-use rocksdb::{DBIteratorWithThreadMode, WriteBatchWithTransaction, DB};
+use rocksdb::{DBIteratorWithThreadMode, DBPinnableSlice, Error, WriteBatchWithTransaction, DB};
 use std::collections::HashMap;
 
 pub struct RocksInodeStore {
@@ -107,6 +107,19 @@ impl RocksInodeStore {
                 Ok(Some(inode))
             }
         }
+    }
+
+    pub fn batched_multi_get_inodes<'a, K, I>(
+        &'a self,
+        keys: I,
+        sorted_input: bool,
+    ) -> CommonResult<Vec<Result<Option<DBPinnableSlice<'a>>, Error>>>
+    where
+        K: AsRef<[u8]> + 'a + ?Sized,
+        I: IntoIterator<Item = &'a K>,
+    {
+        self.db
+            .batched_multi_get_cf(Self::CF_INODES, keys, sorted_input)
     }
 
     pub fn iter_cf<'a: 'b, 'b>(


### PR DESCRIPTION
## Summary
Improves master metadata read path for directory listings by batching `FileEntry` inode loads through RocksDB `batched_multi_get`, and hardens worker registration when a node sends a **Start** heartbeat after restart.
## Performance
**Large directory listing:** For a directory with **~70,000 entries**, end-to-end list latency dropped from **~2s to ~200ms** (order of magnitude improvement), by replacing per-entry `get_inode` calls with a single batched inode multi-get.
## Changes
### Metadata / listing
- **`curvine-common`**: `DBEngine::batched_multi_get_cf` — thin wrapper over `rocksdb::batched_multi_get_cf` for a named column family.
- **`RocksInodeStore`**: `batched_multi_get_inodes` — batch-read inode keys from `CF_INODES`.
- **`InodeStore`**: `batched_get_inodes` — for a list of `InodeView` references under an `InodePath`:
  - Non–`FileEntry` children use in-memory views (unchanged semantics).
  - `FileEntry` children are resolved in one batch; output order matches the input list.
  - Validates stored inode id against the entry id; on missing key returns an explicit error (path + id).
- **`FsDir`**: Replaces per-child `get_inode` loops with `batched_get_inodes` for directory listing paths.
### Worker / heartbeat
- **`WorkerMap::remove`**: Removes a worker from both active and “lost” maps.
- **`WorkerManager`**: On `HeartbeatStatus::Start`, removes any stale map entry and returns immediately so the node is not treated as ready for scheduling or heartbeat bookkeeping until it transitions to **Running** (helps after unexpected restarts when full block reports are slow).
## Motivation
- **Listing**: Many `get_inode` calls per directory are replaced by a single batched read, reducing RocksDB round-trips and latency on large directories.
- **Workers**: Avoid false readiness and timeout behavior while a restarted worker is still registering and reporting blocks.
