### PR TITLE
build: add linker wrapper to statically link libstdc++, libgcc_s, and libz on Linux

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,13 @@
 [env]
 #RUST_TEST_NOCAPTURE = "1"
 
+[target.x86_64-unknown-linux-gnu]
+# Use a linker wrapper to statically link libstdc++.
+# librocksdb-sys emits `cargo:rustc-link-lib=stdc++` which gets placed in
+# the -Wl,-Bdynamic section before RUSTFLAGS can intercept it. The wrapper
+# script replaces every -lstdc++ with -Wl,-Bstatic,-lstdc++,-Wl,-Bdynamic.
+linker = "build/static-link-wrapper.sh"
+
 [target.x86_64-apple-darwin]
 rustflags = [
     "-C", "link-arg=-undefined",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,10 +2,11 @@
 #RUST_TEST_NOCAPTURE = "1"
 
 [target.x86_64-unknown-linux-gnu]
-# Use a linker wrapper to statically link libstdc++.
+# Use a linker wrapper to statically link libstdc++, libgcc_s, and libz.
 # librocksdb-sys emits `cargo:rustc-link-lib=stdc++` which gets placed in
 # the -Wl,-Bdynamic section before RUSTFLAGS can intercept it. The wrapper
-# script replaces every -lstdc++ with -Wl,-Bstatic,-lstdc++,-Wl,-Bdynamic.
+# script rewrites each matching linker arg (e.g. `-lstdc++`) as separate
+# args: `-Wl,-Bstatic` `-lstdc++` `-Wl,-Bdynamic`.
 linker = "build/static-link-wrapper.sh"
 
 [target.x86_64-apple-darwin]

--- a/build/static-link-wrapper.sh
+++ b/build/static-link-wrapper.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Linker wrapper that forces -lstdc++, -lgcc_s, and -lz to link statically.
+# Needed because crate build scripts (e.g. librocksdb-sys) emit
+# `cargo:rustc-link-lib=stdc++` which lands in the -Bdynamic section.
+#
+# NOTE: each -Wl flag must be a separate arg; do NOT merge into one
+# comma-separated string or gcc will pass a literal "-Wl," to the linker.
+
+set -euo pipefail
+
+NEWARGS=()
+for arg in "$@"; do
+    if [ "$arg" = "-lstdc++" ]; then
+        NEWARGS+=("-Wl,-Bstatic" "-lstdc++" "-Wl,-Bdynamic")
+    elif [ "$arg" = "-lgcc_s" ]; then
+        NEWARGS+=("-Wl,-Bstatic" "-lgcc_eh" "-lgcc" "-Wl,-Bdynamic")
+    elif [ "$arg" = "-lz" ]; then
+        NEWARGS+=("-Wl,-Bstatic" "-lz" "-Wl,-Bdynamic")
+    else
+        NEWARGS+=("$arg")
+    fi
+done
+
+exec "${CC:-cc}" "${NEWARGS[@]}"

--- a/build/static-link-wrapper.sh
+++ b/build/static-link-wrapper.sh
@@ -3,8 +3,9 @@
 # Needed because crate build scripts (e.g. librocksdb-sys) emit
 # `cargo:rustc-link-lib=stdc++` which lands in the -Bdynamic section.
 #
-# NOTE: each -Wl flag must be a separate arg; do NOT merge into one
-# comma-separated string or gcc will pass a literal "-Wl," to the linker.
+# NOTE: gcc/clang support comma-separated `-Wl,...` lists. This wrapper
+# emits `-Wl,-Bstatic` / `-Wl,-Bdynamic` as separate args around the
+# affected libraries to preserve the intended linker mode transitions.
 
 set -euo pipefail
 

--- a/build/static-link-wrapper.sh
+++ b/build/static-link-wrapper.sh
@@ -14,6 +14,9 @@ for arg in "$@"; do
     if [ "$arg" = "-lstdc++" ]; then
         NEWARGS+=("-Wl,-Bstatic" "-lstdc++" "-Wl,-Bdynamic")
     elif [ "$arg" = "-lgcc_s" ]; then
+        # libgcc_s.so provides both the GCC runtime helpers and the EH
+        # (exception-handling) unwinder. GCC does not ship a libgcc_s.a;
+        # the static equivalents are libgcc.a (runtime) + libgcc_eh.a (EH).
         NEWARGS+=("-Wl,-Bstatic" "-lgcc_eh" "-lgcc" "-Wl,-Bdynamic")
     elif [ "$arg" = "-lz" ]; then
         NEWARGS+=("-Wl,-Bstatic" "-lz" "-Wl,-Bdynamic")

--- a/curvine-docker/compile/Dockerfile_rocky9
+++ b/curvine-docker/compile/Dockerfile_rocky9
@@ -25,6 +25,8 @@ RUN dnf install -y \
     java-1.8.0-openjdk-devel \
     openssl-devel \
     zlib-devel \
+    libstdc++-static \
+    zlib-static \
     && dnf clean all
 
 # Set JAVA_HOME for JNI support (required for opendal-hdfs feature)

--- a/curvine-docker/compile/Dockerfile_rocky9_cached
+++ b/curvine-docker/compile/Dockerfile_rocky9_cached
@@ -25,6 +25,8 @@ RUN dnf install -y \
     java-1.8.0-openjdk-devel \
     openssl-devel \
     zlib-devel \
+    libstdc++-static \
+    zlib-static \
     && dnf clean all
 
 # 1.1. Install Node.js 22 LTS from NodeSource repository (ensures npm >= 9.0.0 and compatibility)


### PR DESCRIPTION
## Summary
- Add a linker wrapper script (`build/static-link-wrapper.sh`) that forces `libstdc++`, `libgcc_s`, and `libz` to link statically on Linux x86_64
- Configure Cargo to use the wrapper via `.cargo/config.toml`

## Motivation

`librocksdb-sys` emits `cargo:rustc-link-lib=stdc++` in its build script, which causes the linker to place `-lstdc++` in the `-Wl,-Bdynamic` section. This happens before `RUSTFLAGS` can intercept it, making it impossible to force static linking through normal Cargo configuration.

This is problematic for deployment on systems where `libstdc++.so`, `libgcc_s.so`, or `libz.so` may not be available or may be a different version, leading to runtime failures.

## Approach

A thin shell wrapper (`build/static-link-wrapper.sh`) intercepts linker arguments and replaces:
- `-lstdc++` → `-Wl,-Bstatic -lstdc++ -Wl,-Bdynamic`
- `-lgcc_s` → `-Wl,-Bstatic -lgcc_eh -lgcc -Wl,-Bdynamic`
- `-lz` → `-Wl,-Bstatic -lz -Wl,-Bdynamic`

This ensures these libraries are statically linked while keeping all other libraries dynamically linked as usual.

## Test plan
- [x] Build on x86_64 Linux and verify with `ldd` that the output binary has no dynamic dependency on `libstdc++`, `libgcc_s`, or `libz`
- [x] Build on macOS to confirm the wrapper is not used and existing behavior is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)