### PR TITLE
fix(server): journal apply index, state listener wait races, and comp…

### DIFF
--- a/curvine-server/src/master/journal/journal_loader.rs
+++ b/curvine-server/src/master/journal/journal_loader.rs
@@ -29,7 +29,7 @@ use log::{debug, error, info, warn};
 use orpc::common::{FileUtils, LocalTime};
 use orpc::runtime::{RpcRuntime, Runtime};
 use orpc::sync::channel::{AsyncChannel, AsyncReceiver, AsyncSender, CallChannel};
-use orpc::{err_box, CommonResult};
+use orpc::{err_box, ternary, CommonResult};
 use raft::eraftpb::Entry;
 use raft::StateRole;
 use std::path::Path;
@@ -193,7 +193,8 @@ impl JournalLoader {
         }
 
         let cur = self.get_fsm_state();
-        if entry.index <= cur.applied.index {
+        let role_applied = ternary!(is_leader, cur.ufs_applied.index, cur.applied.index);
+        if entry.index <= role_applied {
             info!(
                 "skip entry index {}, term {}, fsm_state {:?}",
                 entry.index, entry.term, cur

--- a/curvine-server/src/master/master_handler.rs
+++ b/curvine-server/src/master/master_handler.rs
@@ -302,7 +302,13 @@ impl MasterHandler {
     // Complete_file internally determines whether it is a retry request.
     pub fn complete_file(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let req: CompleteFileRequest = ctx.parse_header()?;
-        ctx.set_audit(Some(req.path.to_string()), None);
+
+        let audit_path = if req.only_flush {
+            format!("[flush]{}", req.path)
+        } else {
+            format!("[close]{}", req.path)
+        };
+        ctx.set_audit(Some(audit_path), None);
 
         let commit_blocks = req
             .commit_blocks

--- a/curvine-server/src/master/meta/inode/ttl/ttl_bucket.rs
+++ b/curvine-server/src/master/meta/inode/ttl/ttl_bucket.rs
@@ -145,7 +145,7 @@ impl TtlBucketList {
             let bucket = self.get_or_create_bucket(expiration_ms);
             bucket.add(inode.id());
 
-            info!(
+            debug!(
                 "added inode {} to sorted TTL bucket list, expires at {}ms",
                 inode.id(),
                 expiration_ms

--- a/orpc/src/sync/state_monitor.rs
+++ b/orpc/src/sync/state_monitor.rs
@@ -92,7 +92,7 @@ impl StateMonitor {
     }
 
     pub fn new_listener(&self) -> StateListener {
-        StateListener::new(self.sender.subscribe())
+        StateListener::new(self.sender.subscribe(), self.ctl.read_only())
     }
 
     pub fn read_ctl(&self) -> StateCtl {
@@ -142,11 +142,16 @@ impl Deref for StateMonitor {
 
 pub struct StateListener {
     receiver: broadcast::Receiver<i8>,
+    ctl: StateCtl,
 }
 
 impl StateListener {
-    pub fn new(receiver: broadcast::Receiver<i8>) -> Self {
-        Self { receiver }
+    pub fn new(receiver: broadcast::Receiver<i8>, ctl: StateCtl) -> Self {
+        Self { receiver, ctl }
+    }
+
+    pub fn current(&self) -> i8 {
+        self.ctl.value()
     }
 
     // Get the next state.
@@ -163,12 +168,16 @@ impl StateListener {
     // Wait for a certain state.
     pub async fn wait_state<T: Into<i8>>(&mut self, target: T) -> CommonResult<()> {
         let target = target.into();
+        if self.ctl.value() == target {
+            return Ok(());
+        }
         loop {
             let cur = self.next_state().await?;
             if cur == target {
                 return Ok(());
-            } else {
-                continue;
+            }
+            if self.ctl.value() == target {
+                return Ok(());
             }
         }
     }
@@ -176,12 +185,16 @@ impl StateListener {
     // Wait for a state of progressive evolution.
     pub async fn wait_progress<T: Into<i8>>(&mut self, target: T) -> CommonResult<()> {
         let target = target.into();
+        if self.ctl.value() >= target {
+            return Ok(());
+        }
         loop {
             let cur = self.next_state().await?;
             if cur >= target {
                 return Ok(());
-            } else {
-                continue;
+            }
+            if self.ctl.value() >= target {
+                return Ok(());
             }
         }
     }


### PR DESCRIPTION
## Summary

This change fixes three operational issues on the master path and one observability nit: journal entry replay uses the correct applied index for the current Raft role, `StateListener` no longer can miss a terminal state if it was reached before the listener subscribes, `complete_file` audit logs distinguish flush vs full close, and noisy TTL registration logs are demoted to debug.

## Motivation

- **Journal replay vs leader / follower FSMs**: The leader tracks UFS-related progress separately; comparing only `cur.applied` can incorrectly skip or replay journal entries. Using `ufs_applied` on the leader and `applied` on followers keeps skip logic aligned with the FSM.
- **State listener races**: A subscriber that calls `wait_state` / `wait_progress` after the state has already advanced could block forever on `next_state` because broadcast channels do not retain past messages. Caching a read-only `StateCtl` on the listener allows an immediate return when the state is already satisfied, and a second check after each notification covers concurrent updates.
- **Auditability**: Distinguishing flush-only and close paths in `complete_file` makes audit logs easier to search and reason about.
- **Log volume**: Per-inode TTL bucket registration was too chatty at info level in production.

## Changes

| Area | Change |
|------|--------|
| `journal_loader.rs` | `entry.index` compared to `cur.ufs_applied.index` when `is_leader`, else `cur.applied.index` |
| `state_monitor.rs` | `StateListener` stores `StateCtl` (read-only); add `current()`; fast path + re-check in `wait_state` / `wait_progress` |
| `master_handler.rs` | Audit string for `complete_file`: `[flush]{path}` vs `[close]{path}` from `only_flush` |
| `ttl_bucket.rs` | `info!` → `debug!` when adding inodes to the TTL list |

## Testing

- [ ] `cargo test` (or the project’s default CI) for `orpc` and `curvine-server` touched crates
- [ ] If applicable: replay journal with leader / follower and confirm entries are not incorrectly skipped
- [ ] Manually: submit load job, confirm `wait_job_complete`-style code paths that use `StateListener` no longer hang when the job is already in a final state