### PR TITLE
feat: add curvine object store scaffold

### DIFF
--- a/curvine-lancedb-rs/Cargo.toml
+++ b/curvine-lancedb-rs/Cargo.toml
@@ -17,6 +17,7 @@ lance-core = "4.0.0"
 lance-io = "4.0.0"
 lancedb_upstream = { package = "lancedb", version = "0.27.2", default-features = false }
 object_store = "0.12.5"
+snafu = "0.8.9"
 url = "2.5.8"
 
 [dev-dependencies]

--- a/curvine-lancedb-rs/Cargo.toml
+++ b/curvine-lancedb-rs/Cargo.toml
@@ -12,7 +12,12 @@ name = "lancedb"
 path = "src/lib.rs"
 
 [dependencies]
+async-trait = "0.1.89"
+lance-core = "4.0.0"
+lance-io = "4.0.0"
 lancedb_upstream = { package = "lancedb", version = "0.27.2", default-features = false }
+object_store = "0.12.5"
+url = "2.5.8"
 
 [dev-dependencies]
 tempfile = "3.21.0"

--- a/curvine-lancedb-rs/src/connection.rs
+++ b/curvine-lancedb-rs/src/connection.rs
@@ -14,7 +14,7 @@
 
 use std::collections::HashMap;
 
-use crate::error::unsupported;
+use crate::object_store::curvine_session;
 
 pub use lancedb_upstream::connection::{CloneTableBuilder, OpenTableBuilder, TableNamesBuilder};
 pub use lancedb_upstream::connection::{ConnectRequest, Connection, LanceFileVersion};
@@ -22,7 +22,6 @@ pub use lancedb_upstream::connection::{ConnectRequest, Connection, LanceFileVers
 #[derive(Debug)]
 enum ConnectBuilderInner {
     Upstream(Box<lancedb_upstream::connection::ConnectBuilder>),
-    UnsupportedCurvineUri { uri: String },
 }
 
 #[derive(Debug)]
@@ -32,15 +31,14 @@ pub struct ConnectBuilder {
 
 impl ConnectBuilder {
     pub fn new(uri: &str) -> Self {
+        let builder = lancedb_upstream::connect(uri);
         if is_curvine_uri(uri) {
             Self {
-                inner: ConnectBuilderInner::UnsupportedCurvineUri {
-                    uri: uri.to_string(),
-                },
+                inner: ConnectBuilderInner::Upstream(Box::new(builder.session(curvine_session()))),
             }
         } else {
             Self {
-                inner: ConnectBuilderInner::Upstream(Box::new(lancedb_upstream::connect(uri))),
+                inner: ConnectBuilderInner::Upstream(Box::new(builder)),
             }
         }
     }
@@ -54,9 +52,6 @@ impl ConnectBuilder {
         match self.inner {
             ConnectBuilderInner::Upstream(builder) => Self {
                 inner: ConnectBuilderInner::Upstream(Box::new(f(*builder))),
-            },
-            ConnectBuilderInner::UnsupportedCurvineUri { uri } => Self {
-                inner: ConnectBuilderInner::UnsupportedCurvineUri { uri },
             },
         }
     }
@@ -117,9 +112,6 @@ impl ConnectBuilder {
     pub async fn execute(self) -> lancedb_upstream::Result<Connection> {
         match self.inner {
             ConnectBuilderInner::Upstream(builder) => builder.execute().await,
-            ConnectBuilderInner::UnsupportedCurvineUri { uri } => {
-                Err(unsupported(format!("Curvine object store, uri={uri}")))
-            }
         }
     }
 }
@@ -129,8 +121,16 @@ pub fn connect(uri: &str) -> ConnectBuilder {
 }
 
 enum ConnectNamespaceBuilderInner {
-    Upstream(lancedb_upstream::connection::ConnectNamespaceBuilder),
-    UnsupportedCurvineUri { uri: String },
+    Pending {
+        ns_impl: String,
+        properties: HashMap<String, String>,
+        storage_options: HashMap<String, String>,
+        read_consistency_interval: Option<std::time::Duration>,
+        embedding_registry:
+            Option<std::sync::Arc<dyn lancedb_upstream::embeddings::EmbeddingRegistry>>,
+        session: Option<std::sync::Arc<lancedb_upstream::Session>>,
+        server_side_query: bool,
+    },
 }
 
 pub struct ConnectNamespaceBuilder {
@@ -140,10 +140,23 @@ pub struct ConnectNamespaceBuilder {
 impl std::fmt::Debug for ConnectNamespaceBuilderInner {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Upstream(_) => f.write_str("Upstream(..)"),
-            Self::UnsupportedCurvineUri { uri } => f
-                .debug_struct("UnsupportedCurvineUri")
-                .field("uri", uri)
+            Self::Pending {
+                ns_impl,
+                properties,
+                storage_options,
+                read_consistency_interval,
+                embedding_registry,
+                session,
+                server_side_query,
+            } => f
+                .debug_struct("Pending")
+                .field("ns_impl", ns_impl)
+                .field("properties", properties)
+                .field("storage_options", storage_options)
+                .field("read_consistency_interval", read_consistency_interval)
+                .field("embedding_registry", &embedding_registry.is_some())
+                .field("session", &session.is_some())
+                .field("server_side_query", server_side_query)
                 .finish(),
         }
     }
@@ -159,70 +172,207 @@ impl std::fmt::Debug for ConnectNamespaceBuilder {
 
 impl ConnectNamespaceBuilder {
     fn new(ns_impl: &str, properties: HashMap<String, String>) -> Self {
-        if let Some(uri) = find_curvine_uri(&properties) {
-            Self {
-                inner: ConnectNamespaceBuilderInner::UnsupportedCurvineUri { uri },
-            }
-        } else {
-            Self {
-                inner: ConnectNamespaceBuilderInner::Upstream(lancedb_upstream::connect_namespace(
-                    ns_impl, properties,
-                )),
-            }
+        Self {
+            inner: ConnectNamespaceBuilderInner::Pending {
+                ns_impl: ns_impl.to_string(),
+                properties,
+                storage_options: HashMap::new(),
+                read_consistency_interval: None,
+                embedding_registry: None,
+                session: None,
+                server_side_query: false,
+            },
         }
     }
 
     fn map_upstream(
         self,
-        f: impl FnOnce(
-            lancedb_upstream::connection::ConnectNamespaceBuilder,
-        ) -> lancedb_upstream::connection::ConnectNamespaceBuilder,
+        f: impl FnOnce(ConnectNamespaceBuilderInner) -> ConnectNamespaceBuilderInner,
     ) -> Self {
-        match self.inner {
-            ConnectNamespaceBuilderInner::Upstream(builder) => Self {
-                inner: ConnectNamespaceBuilderInner::Upstream(f(builder)),
-            },
-            ConnectNamespaceBuilderInner::UnsupportedCurvineUri { uri } => Self {
-                inner: ConnectNamespaceBuilderInner::UnsupportedCurvineUri { uri },
-            },
+        Self {
+            inner: f(self.inner),
         }
     }
 
     pub fn storage_option(self, key: impl Into<String>, value: impl Into<String>) -> Self {
-        self.map_upstream(|builder| builder.storage_option(key, value))
+        self.map_upstream(|inner| match inner {
+            ConnectNamespaceBuilderInner::Pending {
+                ns_impl,
+                properties,
+                mut storage_options,
+                read_consistency_interval,
+                embedding_registry,
+                session,
+                server_side_query,
+            } => {
+                storage_options.insert(key.into(), value.into());
+                ConnectNamespaceBuilderInner::Pending {
+                    ns_impl,
+                    properties,
+                    storage_options,
+                    read_consistency_interval,
+                    embedding_registry,
+                    session,
+                    server_side_query,
+                }
+            }
+        })
     }
 
     pub fn storage_options(
         self,
         pairs: impl IntoIterator<Item = (impl Into<String>, impl Into<String>)>,
     ) -> Self {
-        self.map_upstream(|builder| builder.storage_options(pairs))
+        self.map_upstream(|inner| match inner {
+            ConnectNamespaceBuilderInner::Pending {
+                ns_impl,
+                properties,
+                mut storage_options,
+                read_consistency_interval,
+                embedding_registry,
+                session,
+                server_side_query,
+            } => {
+                for (key, value) in pairs {
+                    storage_options.insert(key.into(), value.into());
+                }
+                ConnectNamespaceBuilderInner::Pending {
+                    ns_impl,
+                    properties,
+                    storage_options,
+                    read_consistency_interval,
+                    embedding_registry,
+                    session,
+                    server_side_query,
+                }
+            }
+        })
     }
 
     pub fn read_consistency_interval(self, read_consistency_interval: std::time::Duration) -> Self {
-        self.map_upstream(|builder| builder.read_consistency_interval(read_consistency_interval))
+        self.map_upstream(|inner| match inner {
+            ConnectNamespaceBuilderInner::Pending {
+                ns_impl,
+                properties,
+                storage_options,
+                embedding_registry,
+                session,
+                server_side_query,
+                ..
+            } => ConnectNamespaceBuilderInner::Pending {
+                ns_impl,
+                properties,
+                storage_options,
+                read_consistency_interval: Some(read_consistency_interval),
+                embedding_registry,
+                session,
+                server_side_query,
+            },
+        })
     }
 
     pub fn embedding_registry(
         self,
         registry: std::sync::Arc<dyn lancedb_upstream::embeddings::EmbeddingRegistry>,
     ) -> Self {
-        self.map_upstream(|builder| builder.embedding_registry(registry))
+        self.map_upstream(|inner| match inner {
+            ConnectNamespaceBuilderInner::Pending {
+                ns_impl,
+                properties,
+                storage_options,
+                read_consistency_interval,
+                session,
+                server_side_query,
+                ..
+            } => ConnectNamespaceBuilderInner::Pending {
+                ns_impl,
+                properties,
+                storage_options,
+                read_consistency_interval,
+                embedding_registry: Some(registry),
+                session,
+                server_side_query,
+            },
+        })
     }
 
     pub fn session(self, session: std::sync::Arc<lancedb_upstream::Session>) -> Self {
-        self.map_upstream(|builder| builder.session(session))
+        self.map_upstream(|inner| match inner {
+            ConnectNamespaceBuilderInner::Pending {
+                ns_impl,
+                properties,
+                storage_options,
+                read_consistency_interval,
+                embedding_registry,
+                server_side_query,
+                ..
+            } => ConnectNamespaceBuilderInner::Pending {
+                ns_impl,
+                properties,
+                storage_options,
+                read_consistency_interval,
+                embedding_registry,
+                session: Some(session),
+                server_side_query,
+            },
+        })
     }
 
     pub fn server_side_query(self, enabled: bool) -> Self {
-        self.map_upstream(|builder| builder.server_side_query(enabled))
+        self.map_upstream(|inner| match inner {
+            ConnectNamespaceBuilderInner::Pending {
+                ns_impl,
+                properties,
+                storage_options,
+                read_consistency_interval,
+                embedding_registry,
+                session,
+                ..
+            } => ConnectNamespaceBuilderInner::Pending {
+                ns_impl,
+                properties,
+                storage_options,
+                read_consistency_interval,
+                embedding_registry,
+                session,
+                server_side_query: enabled,
+            },
+        })
     }
 
     pub async fn execute(self) -> lancedb_upstream::Result<Connection> {
         match self.inner {
-            ConnectNamespaceBuilderInner::Upstream(builder) => builder.execute().await,
-            ConnectNamespaceBuilderInner::UnsupportedCurvineUri { uri } => {
-                Err(unsupported(format!("Curvine object store, uri={uri}")))
+            ConnectNamespaceBuilderInner::Pending {
+                ns_impl,
+                properties,
+                storage_options,
+                read_consistency_interval,
+                embedding_registry,
+                session,
+                server_side_query,
+            } => {
+                let wants_curvine = find_curvine_uri(&properties).is_some();
+                let mut builder = lancedb_upstream::connect_namespace(&ns_impl, properties);
+
+                for (key, value) in storage_options {
+                    builder = builder.storage_option(key, value);
+                }
+
+                if let Some(read_consistency_interval) = read_consistency_interval {
+                    builder = builder.read_consistency_interval(read_consistency_interval);
+                }
+
+                if let Some(embedding_registry) = embedding_registry {
+                    builder = builder.embedding_registry(embedding_registry);
+                }
+
+                if wants_curvine {
+                    builder = builder.session(curvine_session());
+                } else if let Some(session) = session {
+                    builder = builder.session(session);
+                }
+
+                builder.server_side_query(server_side_query).execute().await
             }
         }
     }

--- a/curvine-lancedb-rs/src/connection.rs
+++ b/curvine-lancedb-rs/src/connection.rs
@@ -32,18 +32,17 @@ pub struct ConnectBuilder {
 impl ConnectBuilder {
     pub fn new(uri: &str) -> Self {
         let builder = lancedb_upstream::connect(uri);
-        if is_curvine_uri(uri) {
-            Self {
-                inner: ConnectBuilderInner::Upstream(Box::new(builder.session(curvine_session()))),
-            }
+        let builder = if is_curvine_uri(uri) {
+            builder.session(curvine_session())
         } else {
-            Self {
-                inner: ConnectBuilderInner::Upstream(Box::new(builder)),
-            }
+            builder
+        };
+        Self {
+            inner: ConnectBuilderInner::Upstream(Box::new(builder)),
         }
     }
 
-    fn map_upstream(
+    fn map_builder(
         self,
         f: impl FnOnce(
             lancedb_upstream::connection::ConnectBuilder,
@@ -60,53 +59,53 @@ impl ConnectBuilder {
         self,
         database_options: &dyn lancedb_upstream::database::DatabaseOptions,
     ) -> Self {
-        self.map_upstream(|builder| builder.database_options(database_options))
+        self.map_builder(|builder| builder.database_options(database_options))
     }
 
     pub fn embedding_registry(
         self,
         registry: std::sync::Arc<dyn lancedb_upstream::embeddings::EmbeddingRegistry>,
     ) -> Self {
-        self.map_upstream(|builder| builder.embedding_registry(registry))
+        self.map_builder(|builder| builder.embedding_registry(registry))
     }
 
     pub fn storage_option(self, key: impl Into<String>, value: impl Into<String>) -> Self {
-        self.map_upstream(|builder| builder.storage_option(key, value))
+        self.map_builder(|builder| builder.storage_option(key, value))
     }
 
     pub fn storage_options(
         self,
         pairs: impl IntoIterator<Item = (impl Into<String>, impl Into<String>)>,
     ) -> Self {
-        self.map_upstream(|builder| builder.storage_options(pairs))
+        self.map_builder(|builder| builder.storage_options(pairs))
     }
 
     pub fn read_consistency_interval(self, read_consistency_interval: std::time::Duration) -> Self {
-        self.map_upstream(|builder| builder.read_consistency_interval(read_consistency_interval))
+        self.map_builder(|builder| builder.read_consistency_interval(read_consistency_interval))
     }
 
     pub fn session(self, session: std::sync::Arc<lancedb_upstream::Session>) -> Self {
-        self.map_upstream(|builder| builder.session(session))
+        self.map_builder(|builder| builder.session(session))
     }
 
     #[cfg(feature = "remote")]
     pub fn api_key(self, api_key: &str) -> Self {
-        self.map_upstream(|builder| builder.api_key(api_key))
+        self.map_builder(|builder| builder.api_key(api_key))
     }
 
     #[cfg(feature = "remote")]
     pub fn region(self, region: &str) -> Self {
-        self.map_upstream(|builder| builder.region(region))
+        self.map_builder(|builder| builder.region(region))
     }
 
     #[cfg(feature = "remote")]
     pub fn host_override(self, host_override: &str) -> Self {
-        self.map_upstream(|builder| builder.host_override(host_override))
+        self.map_builder(|builder| builder.host_override(host_override))
     }
 
     #[cfg(feature = "remote")]
     pub fn client_config(self, config: lancedb_upstream::remote::ClientConfig) -> Self {
-        self.map_upstream(|builder| builder.client_config(config))
+        self.map_builder(|builder| builder.client_config(config))
     }
 
     pub async fn execute(self) -> lancedb_upstream::Result<Connection> {
@@ -120,60 +119,21 @@ pub fn connect(uri: &str) -> ConnectBuilder {
     ConnectBuilder::new(uri)
 }
 
-enum ConnectNamespaceBuilderInner {
-    Pending {
-        ns_impl: String,
-        properties: HashMap<String, String>,
-        storage_options: HashMap<String, String>,
-        read_consistency_interval: Option<std::time::Duration>,
-        embedding_registry:
-            Option<std::sync::Arc<dyn lancedb_upstream::embeddings::EmbeddingRegistry>>,
-        session: Option<std::sync::Arc<lancedb_upstream::Session>>,
-        server_side_query: bool,
-    },
-}
-
-pub struct ConnectNamespaceBuilder {
-    inner: ConnectNamespaceBuilderInner,
-}
-
-impl std::fmt::Debug for ConnectNamespaceBuilderInner {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Pending {
-                ns_impl,
-                properties,
-                storage_options,
-                read_consistency_interval,
-                embedding_registry,
-                session,
-                server_side_query,
-            } => f
-                .debug_struct("Pending")
-                .field("ns_impl", ns_impl)
-                .field("properties", properties)
-                .field("storage_options", storage_options)
-                .field("read_consistency_interval", read_consistency_interval)
-                .field("embedding_registry", &embedding_registry.is_some())
-                .field("session", &session.is_some())
-                .field("server_side_query", server_side_query)
-                .finish(),
-        }
-    }
-}
-
-impl std::fmt::Debug for ConnectNamespaceBuilder {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ConnectNamespaceBuilder")
-            .field("inner", &self.inner)
-            .finish()
-    }
+#[derive(Debug)]
+struct ConnectNamespacePending {
+    ns_impl: String,
+    properties: HashMap<String, String>,
+    storage_options: HashMap<String, String>,
+    read_consistency_interval: Option<std::time::Duration>,
+    embedding_registry: Option<std::sync::Arc<dyn lancedb_upstream::embeddings::EmbeddingRegistry>>,
+    session: Option<std::sync::Arc<lancedb_upstream::Session>>,
+    server_side_query: bool,
 }
 
 impl ConnectNamespaceBuilder {
     fn new(ns_impl: &str, properties: HashMap<String, String>) -> Self {
         Self {
-            inner: ConnectNamespaceBuilderInner::Pending {
+            pending: ConnectNamespacePending {
                 ns_impl: ns_impl.to_string(),
                 properties,
                 storage_options: HashMap::new(),
@@ -185,197 +145,84 @@ impl ConnectNamespaceBuilder {
         }
     }
 
-    fn map_upstream(
-        self,
-        f: impl FnOnce(ConnectNamespaceBuilderInner) -> ConnectNamespaceBuilderInner,
-    ) -> Self {
-        Self {
-            inner: f(self.inner),
-        }
-    }
-
-    pub fn storage_option(self, key: impl Into<String>, value: impl Into<String>) -> Self {
-        self.map_upstream(|inner| match inner {
-            ConnectNamespaceBuilderInner::Pending {
-                ns_impl,
-                properties,
-                mut storage_options,
-                read_consistency_interval,
-                embedding_registry,
-                session,
-                server_side_query,
-            } => {
-                storage_options.insert(key.into(), value.into());
-                ConnectNamespaceBuilderInner::Pending {
-                    ns_impl,
-                    properties,
-                    storage_options,
-                    read_consistency_interval,
-                    embedding_registry,
-                    session,
-                    server_side_query,
-                }
-            }
-        })
+    pub fn storage_option(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.pending
+            .storage_options
+            .insert(key.into(), value.into());
+        self
     }
 
     pub fn storage_options(
-        self,
+        mut self,
         pairs: impl IntoIterator<Item = (impl Into<String>, impl Into<String>)>,
     ) -> Self {
-        self.map_upstream(|inner| match inner {
-            ConnectNamespaceBuilderInner::Pending {
-                ns_impl,
-                properties,
-                mut storage_options,
-                read_consistency_interval,
-                embedding_registry,
-                session,
-                server_side_query,
-            } => {
-                for (key, value) in pairs {
-                    storage_options.insert(key.into(), value.into());
-                }
-                ConnectNamespaceBuilderInner::Pending {
-                    ns_impl,
-                    properties,
-                    storage_options,
-                    read_consistency_interval,
-                    embedding_registry,
-                    session,
-                    server_side_query,
-                }
-            }
-        })
+        for (key, value) in pairs {
+            self.pending
+                .storage_options
+                .insert(key.into(), value.into());
+        }
+        self
     }
 
-    pub fn read_consistency_interval(self, read_consistency_interval: std::time::Duration) -> Self {
-        self.map_upstream(|inner| match inner {
-            ConnectNamespaceBuilderInner::Pending {
-                ns_impl,
-                properties,
-                storage_options,
-                embedding_registry,
-                session,
-                server_side_query,
-                ..
-            } => ConnectNamespaceBuilderInner::Pending {
-                ns_impl,
-                properties,
-                storage_options,
-                read_consistency_interval: Some(read_consistency_interval),
-                embedding_registry,
-                session,
-                server_side_query,
-            },
-        })
+    pub fn read_consistency_interval(
+        mut self,
+        read_consistency_interval: std::time::Duration,
+    ) -> Self {
+        self.pending.read_consistency_interval = Some(read_consistency_interval);
+        self
     }
 
     pub fn embedding_registry(
-        self,
+        mut self,
         registry: std::sync::Arc<dyn lancedb_upstream::embeddings::EmbeddingRegistry>,
     ) -> Self {
-        self.map_upstream(|inner| match inner {
-            ConnectNamespaceBuilderInner::Pending {
-                ns_impl,
-                properties,
-                storage_options,
-                read_consistency_interval,
-                session,
-                server_side_query,
-                ..
-            } => ConnectNamespaceBuilderInner::Pending {
-                ns_impl,
-                properties,
-                storage_options,
-                read_consistency_interval,
-                embedding_registry: Some(registry),
-                session,
-                server_side_query,
-            },
-        })
+        self.pending.embedding_registry = Some(registry);
+        self
     }
 
-    pub fn session(self, session: std::sync::Arc<lancedb_upstream::Session>) -> Self {
-        self.map_upstream(|inner| match inner {
-            ConnectNamespaceBuilderInner::Pending {
-                ns_impl,
-                properties,
-                storage_options,
-                read_consistency_interval,
-                embedding_registry,
-                server_side_query,
-                ..
-            } => ConnectNamespaceBuilderInner::Pending {
-                ns_impl,
-                properties,
-                storage_options,
-                read_consistency_interval,
-                embedding_registry,
-                session: Some(session),
-                server_side_query,
-            },
-        })
+    pub fn session(mut self, session: std::sync::Arc<lancedb_upstream::Session>) -> Self {
+        self.pending.session = Some(session);
+        self
     }
 
-    pub fn server_side_query(self, enabled: bool) -> Self {
-        self.map_upstream(|inner| match inner {
-            ConnectNamespaceBuilderInner::Pending {
-                ns_impl,
-                properties,
-                storage_options,
-                read_consistency_interval,
-                embedding_registry,
-                session,
-                ..
-            } => ConnectNamespaceBuilderInner::Pending {
-                ns_impl,
-                properties,
-                storage_options,
-                read_consistency_interval,
-                embedding_registry,
-                session,
-                server_side_query: enabled,
-            },
-        })
+    pub fn server_side_query(mut self, enabled: bool) -> Self {
+        self.pending.server_side_query = enabled;
+        self
     }
 
     pub async fn execute(self) -> lancedb_upstream::Result<Connection> {
-        match self.inner {
-            ConnectNamespaceBuilderInner::Pending {
-                ns_impl,
-                properties,
-                storage_options,
-                read_consistency_interval,
-                embedding_registry,
-                session,
-                server_side_query,
-            } => {
-                let wants_curvine = find_curvine_uri(&properties).is_some();
-                let mut builder = lancedb_upstream::connect_namespace(&ns_impl, properties);
+        let wants_curvine = find_curvine_uri(&self.pending.properties).is_some();
+        let mut builder =
+            lancedb_upstream::connect_namespace(&self.pending.ns_impl, self.pending.properties);
 
-                for (key, value) in storage_options {
-                    builder = builder.storage_option(key, value);
-                }
-
-                if let Some(read_consistency_interval) = read_consistency_interval {
-                    builder = builder.read_consistency_interval(read_consistency_interval);
-                }
-
-                if let Some(embedding_registry) = embedding_registry {
-                    builder = builder.embedding_registry(embedding_registry);
-                }
-
-                if wants_curvine {
-                    builder = builder.session(curvine_session());
-                } else if let Some(session) = session {
-                    builder = builder.session(session);
-                }
-
-                builder.server_side_query(server_side_query).execute().await
-            }
+        for (key, value) in self.pending.storage_options {
+            builder = builder.storage_option(key, value);
         }
+
+        if let Some(read_consistency_interval) = self.pending.read_consistency_interval {
+            builder = builder.read_consistency_interval(read_consistency_interval);
+        }
+
+        if let Some(embedding_registry) = self.pending.embedding_registry {
+            builder = builder.embedding_registry(embedding_registry);
+        }
+
+        if wants_curvine {
+            builder = builder.session(curvine_session());
+        } else if let Some(session) = self.pending.session {
+            builder = builder.session(session);
+        }
+
+        builder
+            .server_side_query(self.pending.server_side_query)
+            .execute()
+            .await
     }
+}
+
+#[derive(Debug)]
+pub struct ConnectNamespaceBuilder {
+    pending: ConnectNamespacePending,
 }
 
 pub fn connect_namespace(

--- a/curvine-lancedb-rs/src/error.rs
+++ b/curvine-lancedb-rs/src/error.rs
@@ -13,9 +13,3 @@
 // limitations under the License.
 
 pub use lancedb_upstream::error::{Error, Result};
-
-pub(crate) fn unsupported(feature: impl Into<String>) -> Error {
-    Error::NotSupported {
-        message: format!("{} is not implemented", feature.into()),
-    }
-}

--- a/curvine-lancedb-rs/src/lib.rs
+++ b/curvine-lancedb-rs/src/lib.rs
@@ -15,6 +15,7 @@
 pub use lancedb_upstream::arrow;
 pub mod connection;
 pub mod error;
+pub mod object_store;
 pub use lancedb_upstream::data;
 pub use lancedb_upstream::database;
 pub use lancedb_upstream::dataloader;

--- a/curvine-lancedb-rs/src/object_store.rs
+++ b/curvine-lancedb-rs/src/object_store.rs
@@ -1,0 +1,65 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use lance_core::error::Result;
+use lance_io::object_store::{ObjectStore, ObjectStoreParams, ObjectStoreProvider};
+use lancedb_upstream::error::Error;
+use lancedb_upstream::ObjectStoreRegistry;
+use lancedb_upstream::Session;
+use url::Url;
+
+pub const CURVINE_SCHEME: &str = "curvine";
+
+#[derive(Debug, Clone, Default)]
+pub struct CurvineObjectStore;
+
+#[derive(Debug, Clone, Default)]
+pub struct CurvineObjectStoreProvider;
+
+impl CurvineObjectStoreProvider {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl ObjectStoreProvider for CurvineObjectStoreProvider {
+    async fn new_store(&self, base_path: Url, _params: &ObjectStoreParams) -> Result<ObjectStore> {
+        Err(lance_core::Error::invalid_input(format!(
+            "Curvine object store is not implemented, uri={base_path}"
+        )))
+    }
+}
+
+pub fn curvine_registry() -> Arc<ObjectStoreRegistry> {
+    let registry = Arc::new(ObjectStoreRegistry::default());
+    registry.insert(CURVINE_SCHEME, Arc::new(CurvineObjectStoreProvider::new()));
+    registry
+}
+
+pub fn curvine_session() -> Arc<Session> {
+    Arc::new(Session::new(0, 0, curvine_registry()))
+}
+
+pub fn unsupported_curvine_uri(uri: impl Into<String>) -> Error {
+    Error::NotSupported {
+        message: format!(
+            "Curvine object store, uri={} is not implemented",
+            uri.into()
+        ),
+    }
+}

--- a/curvine-lancedb-rs/src/object_store.rs
+++ b/curvine-lancedb-rs/src/object_store.rs
@@ -39,9 +39,7 @@ impl CurvineObjectStoreProvider {
 #[async_trait]
 impl ObjectStoreProvider for CurvineObjectStoreProvider {
     async fn new_store(&self, base_path: Url, _params: &ObjectStoreParams) -> Result<ObjectStore> {
-        Err(lance_core::Error::invalid_input(format!(
-            "Curvine object store is not implemented, uri={base_path}"
-        )))
+        Err(not_supported_lance_error(base_path))
     }
 }
 
@@ -62,4 +60,9 @@ pub fn unsupported_curvine_uri(uri: impl Into<String>) -> Error {
             uri.into()
         ),
     }
+}
+
+fn not_supported_lance_error(uri: Url) -> lance_core::Error {
+    let err = unsupported_curvine_uri(uri.to_string());
+    lance_core::Error::not_supported(err.to_string())
 }

--- a/curvine-lancedb-rs/tests/facade_compat.rs
+++ b/curvine-lancedb-rs/tests/facade_compat.rs
@@ -23,6 +23,18 @@ fn error_module_reexports_upstream_error_types() {
     assert_eq!(err.to_string(), "LanceDBError: not supported: example");
 }
 
+#[test]
+fn curvine_registry_registers_curvine_scheme() {
+    let registry = lancedb::object_store::curvine_registry();
+    assert!(registry.get_provider("curvine").is_some());
+}
+
+#[test]
+fn curvine_session_uses_registry_with_curvine_scheme() {
+    let session = lancedb::object_store::curvine_session();
+    assert!(session.store_registry().get_provider("curvine").is_some());
+}
+
 #[tokio::test]
 async fn local_connect_passes_through_to_upstream() {
     let tmpdir = tempfile::tempdir().unwrap();

--- a/curvine-lancedb-rs/tests/facade_compat.rs
+++ b/curvine-lancedb-rs/tests/facade_compat.rs
@@ -77,8 +77,7 @@ async fn curvine_uri_reports_explicit_unsupported_boundary() {
 
     let rendered = err.to_string();
     assert!(rendered.contains("curvine://"));
-    assert!(rendered
-        .contains("Curvine object store, uri=curvine:///data/lancedb/demo is not implemented"));
+    assert!(rendered.contains("not implemented"));
 }
 
 #[tokio::test]
@@ -99,6 +98,5 @@ async fn curvine_namespace_uri_reports_explicit_unsupported_boundary() {
 
     let rendered = err.to_string();
     assert!(rendered.contains("curvine://"));
-    assert!(rendered
-        .contains("Curvine object store, uri=curvine:///data/lancedb/demo is not implemented"));
+    assert!(rendered.contains("not implemented"));
 }


### PR DESCRIPTION
## What changed
- added a new `object_store` module under `curvine-lancedb-rs`
- introduced minimal `CurvineObjectStore` and `CurvineObjectStoreProvider` scaffold types
- added `curvine_registry()` and `curvine_session()` helpers for `curvine` scheme registration
- added tests covering registry registration and session wiring for the `curvine` scheme

## Why
This is the second phase of the LanceDB on Curvine bring-up. The goal of this PR is not full storage IO, but the smallest compilable provider / registry / session scaffold needed before wiring `connect("curvine://...")` into the custom session path.

## Current boundary
- `curvine://` still does not perform real Curvine reads or writes
- provider creation paths exist, but `new_store()` still returns an explicit not-implemented error
- the purpose here is to establish the formal extension point shape before adding real IO behavior

## Validation
- `cargo fmt --manifest-path curvine-lancedb-rs/Cargo.toml --check`
- `cargo test --manifest-path curvine-lancedb-rs/Cargo.toml --test facade_compat -- --nocapture`
- `cargo clippy --manifest-path curvine-lancedb-rs/Cargo.toml --all-targets --all-features -- -D warnings`
