### PR TITLE
perf(fuse): reuse parent_path in lookup to avoid redundant node tree traversal

### DIFF
--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -659,7 +659,7 @@ impl fs::FileSystem for CurvineFileSystem {
         self.check_permissions(&parent_path, op.header, libc::X_OK as u32)
             .await?;
 
-        // Get the path(reuse parent_path instead of traversing the node tree again).
+        // Reuse parent_path instead of traversing the node tree again.
         let path = match name.as_deref() {
             Some(n) => Path::from_str(format!("{}/{}", parent_path.full_path(), n))?,
             None => parent_path.clone(),

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -659,8 +659,11 @@ impl fs::FileSystem for CurvineFileSystem {
         self.check_permissions(&parent_path, op.header, libc::X_OK as u32)
             .await?;
 
-        // Get the path.
-        let path = self.state.get_path_common(parent, name.as_deref())?;
+        // Get the path(reuse parent_path instead of traversing the node tree again).
+        let path = match name.as_deref() {
+            Some(n) => Path::from_str(format!("{}/{}", parent_path.full_path(), n))?,
+            None => parent_path.clone(),
+        };
         let status = self.get_cached_status(&path).await?;
         let res = self.lookup_status(parent, name.as_deref(), &status);
 


### PR DESCRIPTION
## Summary

- Optimize `lookup()` in `curvine_file_system.rs` by reusing the already-resolved `parent_path` instead of calling `get_path_common()` which redundantly traverses the node tree from parent to root a second time.

## Motivation

In the current implementation, `lookup()` calls `get_path(parent)` to obtain `parent_path` for permission checking, and then immediately calls `get_path_common(parent, name)` to resolve the child path. `get_path_common` internally traverses from `parent` up to root again (via `try_get_path`), performing N HashMap lookups, a VecDeque allocation, string concatenation, and `convert_to_cv_path` — all of which duplicates the work already done by `get_path(parent)`.

Since `lookup` is one of the hottest FUSE operations (called for every path component resolution), this redundant traversal adds up, especially for deep directory trees.

## Approach

Since `parent_path` is already available and fully resolved (including `convert_to_cv_path`), we construct the child path by simply appending `"/" + name` to `parent_path.full_path()` via `Path::from_str`, avoiding the second tree traversal entirely.

## Behavioral note

The old code re-walked the inode tree **after** the `check_permissions().await?` await point, so a concurrent rename/move of `parent` landing in that narrow window would have been reflected in the resolved `path`. After this change, `path` is reconstructed from the `parent_path` snapshot captured **before** the await, so the same race would yield the pre-rename path.

This is arguably the more consistent behavior — the entire `lookup` operation now works against a single path snapshot, and the subsequent `status`/`attr` reads are guaranteed to match the resolved `path`. Existing `cargo test -p curvine-fuse` tests do not rely on the re-traversal behavior.

## Test plan

- [x] `cargo check -p curvine-fuse` passes
- [x] `cargo test -p curvine-fuse` passes
- [x] `cargo test -p curvine-common` passes

Closes #792