### PR TITLE
fix(cli): display file timestamps in local timezone

### DIFF
--- a/curvine-cli/src/cmds/fs/common.rs
+++ b/curvine-cli/src/cmds/fs/common.rs
@@ -65,3 +65,19 @@ pub fn format_size(size: u64) -> String {
         format!("{} B", size)
     }
 }
+
+/// Formats a Unix epoch timestamp in milliseconds using the local timezone.
+pub fn format_epoch_ms_local(timestamp_ms: i64, fmt: &str) -> String {
+    if timestamp_ms <= 0 {
+        return "-".to_string();
+    }
+
+    let Some(datetime) = chrono::DateTime::from_timestamp_millis(timestamp_ms) else {
+        return "-".to_string();
+    };
+
+    datetime
+        .with_timezone(&chrono::Local)
+        .format(fmt)
+        .to_string()
+}

--- a/curvine-cli/src/cmds/fs/ls.rs
+++ b/curvine-cli/src/cmds/fs/ls.rs
@@ -372,9 +372,8 @@ async fn print_file_entry(
 
     // Format time (use access time if requested, otherwise modification time)
     let timestamp = if config.atime { file.atime } else { file.mtime };
-    let datetime = chrono::DateTime::from_timestamp(timestamp / 1000, 0)
-        .unwrap_or_else(|| chrono::DateTime::from_timestamp(0, 0).unwrap());
-    let formatted_time = datetime.format("%Y-%m-%d %H:%M").to_string();
+    let formatted_time =
+        crate::cmds::fs::common::format_epoch_ms_local(timestamp, "%Y-%m-%d %H:%M");
 
     // Format filename (handle non-printable characters)
     let filename = if config.hide_non_printable {

--- a/curvine-cli/src/cmds/fs/stat.rs
+++ b/curvine-cli/src/cmds/fs/stat.rs
@@ -53,16 +53,14 @@ impl StatCommand {
                         println!("Ttl action: {:?}", status.storage_policy.ttl_action);
 
                         // Format modification time
-                        let mtime = chrono::DateTime::from_timestamp(status.mtime / 1000, 0)
-                            .unwrap_or_else(|| chrono::DateTime::from_timestamp(0, 0).unwrap());
-                        let formatted_mtime = mtime.format("%Y-%m-%d %H:%M:%S").to_string();
-
-                        let ufs_mtime = chrono::DateTime::from_timestamp(
-                            status.storage_policy.ufs_mtime / 1000,
-                            0,
-                        )
-                        .unwrap_or_else(|| chrono::DateTime::from_timestamp(0, 0).unwrap());
-                        let formatted_ufs_mtime = ufs_mtime.format("%Y-%m-%d %H:%M:%S").to_string();
+                        let formatted_mtime = crate::cmds::fs::common::format_epoch_ms_local(
+                            status.mtime,
+                            "%Y-%m-%d %H:%M:%S",
+                        );
+                        let formatted_ufs_mtime = crate::cmds::fs::common::format_epoch_ms_local(
+                            status.storage_policy.ufs_mtime,
+                            "%Y-%m-%d %H:%M:%S",
+                        );
 
                         println!("Type: {}", if status.is_dir { "directory" } else { "file" });
                         println!("Modification time: {}", formatted_mtime);


### PR DESCRIPTION
Fixes #802

This changes Curvine CLI ls/stat timestamp formatting to convert epoch milliseconds to the local timezone before display. The stored metadata remains Unix epoch milliseconds.

Note: human-readable timestamps in `cv fs ls` and `cv fs stat` now follow the process local timezone (`TZ` / system zone) instead of rendering as UTC. Non-positive or out-of-range timestamp values are displayed as `-`.