### PR TITLE
fix: support Curvine LanceDB clone and conditional writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2079,8 +2079,11 @@ dependencies = [
  "curvine-client",
  "curvine-common",
  "futures",
+ "lance",
  "lance-core",
  "lance-io",
+ "lance-namespace",
+ "lance-table",
  "lancedb",
  "md-5",
  "object_store",
@@ -2176,13 +2179,16 @@ dependencies = [
  "curvine-tracing-appender",
  "curvine-ufs",
  "futures",
+ "lance-io",
  "log",
+ "object_store",
  "once_cell",
  "orpc",
  "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]

--- a/curvine-lancedb-rs/Cargo.toml
+++ b/curvine-lancedb-rs/Cargo.toml
@@ -17,8 +17,11 @@ chrono = { workspace = true }
 curvine-client = { workspace = true }
 curvine-common = { workspace = true }
 futures = { workspace = true }
+lance = { version = "4.0.0", default-features = false }
 lance-core = "4.0.0"
 lance-io = "4.0.0"
+lance-namespace = "4.0.0"
+lance-table = "4.0.0"
 lancedb_upstream = { package = "lancedb", version = "0.27.2", default-features = false }
 md-5 = { workspace = true }
 object_store = "0.12.5"

--- a/curvine-lancedb-rs/src/connection.rs
+++ b/curvine-lancedb-rs/src/connection.rs
@@ -13,15 +13,57 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
+use std::ops::Deref;
+use std::path::MAIN_SEPARATOR;
+use std::sync::Arc;
+use std::time::Duration;
 
 use crate::object_store::curvine_session;
 
-pub use lancedb_upstream::connection::{CloneTableBuilder, OpenTableBuilder, TableNamesBuilder};
-pub use lancedb_upstream::connection::{ConnectRequest, Connection, LanceFileVersion};
+use lance::dataset::builder::DatasetBuilder;
+use lance::dataset::refs::Ref;
+use lance::dataset::transaction::{Operation, Transaction};
+use lance::dataset::{CommitBuilder, ReadParams, WriteDestination};
+use lance::io::{ObjectStoreParams, StorageOptionsAccessor};
+use lance::{Dataset, Result as LanceResult};
+use lance_namespace::LanceNamespace;
+use lance_table::io::commit::ConditionalPutCommitHandler;
+use lancedb_upstream::connection::{
+    CloneTableBuilder as UpstreamCloneTableBuilder, ConnectBuilder as UpstreamConnectBuilder,
+};
+use lancedb_upstream::database::{CloneTableRequest, DatabaseOptions};
+use lancedb_upstream::embeddings::EmbeddingRegistry;
+use lancedb_upstream::error::{Error, Result};
+#[cfg(feature = "remote")]
+use lancedb_upstream::remote::ClientConfig;
+use lancedb_upstream::{
+    connect as upstream_connect, connect_namespace as upstream_connect_namespace,
+    Connection as UpstreamConnection, Session, Table,
+};
+use url::Url;
+
+pub use lancedb_upstream::connection::{
+    ConnectRequest, LanceFileVersion, OpenTableBuilder, TableNamesBuilder,
+};
+
+const LANCE_FILE_EXTENSION: &str = "lance";
 
 #[derive(Debug)]
 enum ConnectBuilderInner {
-    Upstream(Box<lancedb_upstream::connection::ConnectBuilder>),
+    Upstream {
+        builder: Box<UpstreamConnectBuilder>,
+        options: ConnectionOptions,
+    },
+}
+
+#[derive(Clone, Debug, Default)]
+struct ConnectionOptions {
+    uri: String,
+    query_string: Option<String>,
+    storage_options: HashMap<String, String>,
+    session: Option<Arc<Session>>,
+    namespace_backed: bool,
 }
 
 #[derive(Debug)]
@@ -29,89 +71,147 @@ pub struct ConnectBuilder {
     inner: ConnectBuilderInner,
 }
 
+#[derive(Clone)]
+pub struct Connection {
+    upstream: UpstreamConnection,
+    options: ConnectionOptions,
+}
+
+pub struct CloneTableBuilder {
+    upstream: UpstreamCloneTableBuilder,
+    connection: Connection,
+    request: CloneTableRequest,
+}
+
 impl ConnectBuilder {
     pub fn new(uri: &str) -> Self {
-        let builder = lancedb_upstream::connect(uri);
+        let builder = upstream_connect(uri);
+        let session = is_curvine_uri(uri).then(curvine_session);
+        let options = ConnectionOptions {
+            uri: normalize_listing_uri(uri).unwrap_or_else(|| uri.to_string()),
+            query_string: listing_query_string(uri),
+            session: session.clone(),
+            ..Default::default()
+        };
         if is_curvine_uri(uri) {
             Self {
-                inner: ConnectBuilderInner::Upstream(Box::new(builder.session(curvine_session()))),
+                inner: ConnectBuilderInner::Upstream {
+                    builder: Box::new(builder.session(session.expect("curvine session is set"))),
+                    options,
+                },
             }
         } else {
             Self {
-                inner: ConnectBuilderInner::Upstream(Box::new(builder)),
+                inner: ConnectBuilderInner::Upstream {
+                    builder: Box::new(builder),
+                    options,
+                },
             }
         }
     }
 
     fn map_upstream(
         self,
-        f: impl FnOnce(
-            lancedb_upstream::connection::ConnectBuilder,
-        ) -> lancedb_upstream::connection::ConnectBuilder,
+        f: impl FnOnce(UpstreamConnectBuilder) -> UpstreamConnectBuilder,
+        update: impl FnOnce(&mut ConnectionOptions),
     ) -> Self {
         match self.inner {
-            ConnectBuilderInner::Upstream(builder) => Self {
-                inner: ConnectBuilderInner::Upstream(Box::new(f(*builder))),
-            },
+            ConnectBuilderInner::Upstream {
+                builder,
+                mut options,
+            } => {
+                update(&mut options);
+                Self {
+                    inner: ConnectBuilderInner::Upstream {
+                        builder: Box::new(f(*builder)),
+                        options,
+                    },
+                }
+            }
         }
     }
 
-    pub fn database_options(
-        self,
-        database_options: &dyn lancedb_upstream::database::DatabaseOptions,
-    ) -> Self {
-        self.map_upstream(|builder| builder.database_options(database_options))
+    pub fn database_options(self, database_options: &dyn DatabaseOptions) -> Self {
+        self.map_upstream(|builder| builder.database_options(database_options), |_| {})
     }
 
-    pub fn embedding_registry(
-        self,
-        registry: std::sync::Arc<dyn lancedb_upstream::embeddings::EmbeddingRegistry>,
-    ) -> Self {
-        self.map_upstream(|builder| builder.embedding_registry(registry))
+    pub fn embedding_registry(self, registry: Arc<dyn EmbeddingRegistry>) -> Self {
+        self.map_upstream(|builder| builder.embedding_registry(registry), |_| {})
     }
 
     pub fn storage_option(self, key: impl Into<String>, value: impl Into<String>) -> Self {
-        self.map_upstream(|builder| builder.storage_option(key, value))
+        let key = key.into();
+        let value = value.into();
+        let upstream_key = key.clone();
+        let upstream_value = value.clone();
+        self.map_upstream(
+            |builder| builder.storage_option(upstream_key, upstream_value),
+            |options| {
+                options.storage_options.insert(key, value);
+            },
+        )
     }
 
     pub fn storage_options(
         self,
         pairs: impl IntoIterator<Item = (impl Into<String>, impl Into<String>)>,
     ) -> Self {
-        self.map_upstream(|builder| builder.storage_options(pairs))
+        let pairs = pairs
+            .into_iter()
+            .map(|(key, value)| (key.into(), value.into()))
+            .collect::<Vec<_>>();
+        let upstream_pairs = pairs.clone();
+        self.map_upstream(
+            |builder| builder.storage_options(upstream_pairs),
+            |options| {
+                options.storage_options.extend(pairs);
+            },
+        )
     }
 
-    pub fn read_consistency_interval(self, read_consistency_interval: std::time::Duration) -> Self {
-        self.map_upstream(|builder| builder.read_consistency_interval(read_consistency_interval))
+    pub fn read_consistency_interval(self, read_consistency_interval: Duration) -> Self {
+        self.map_upstream(
+            |builder| builder.read_consistency_interval(read_consistency_interval),
+            |_| {},
+        )
     }
 
-    pub fn session(self, session: std::sync::Arc<lancedb_upstream::Session>) -> Self {
-        self.map_upstream(|builder| builder.session(session))
+    pub fn session(self, session: Arc<Session>) -> Self {
+        let upstream_session = session.clone();
+        self.map_upstream(
+            |builder| builder.session(upstream_session),
+            |options| {
+                options.session = Some(session);
+            },
+        )
     }
 
     #[cfg(feature = "remote")]
     pub fn api_key(self, api_key: &str) -> Self {
-        self.map_upstream(|builder| builder.api_key(api_key))
+        self.map_upstream(|builder| builder.api_key(api_key), |_| {})
     }
 
     #[cfg(feature = "remote")]
     pub fn region(self, region: &str) -> Self {
-        self.map_upstream(|builder| builder.region(region))
+        self.map_upstream(|builder| builder.region(region), |_| {})
     }
 
     #[cfg(feature = "remote")]
     pub fn host_override(self, host_override: &str) -> Self {
-        self.map_upstream(|builder| builder.host_override(host_override))
+        self.map_upstream(|builder| builder.host_override(host_override), |_| {})
     }
 
     #[cfg(feature = "remote")]
-    pub fn client_config(self, config: lancedb_upstream::remote::ClientConfig) -> Self {
-        self.map_upstream(|builder| builder.client_config(config))
+    pub fn client_config(self, config: ClientConfig) -> Self {
+        self.map_upstream(|builder| builder.client_config(config), |_| {})
     }
 
-    pub async fn execute(self) -> lancedb_upstream::Result<Connection> {
+    pub async fn execute(self) -> Result<Connection> {
         match self.inner {
-            ConnectBuilderInner::Upstream(builder) => builder.execute().await,
+            ConnectBuilderInner::Upstream { builder, options } => {
+                let upstream = builder.execute().await?;
+                Ok(Connection { upstream, options })
+            }
         }
     }
 }
@@ -120,15 +220,247 @@ pub fn connect(uri: &str) -> ConnectBuilder {
     ConnectBuilder::new(uri)
 }
 
+impl Connection {
+    pub fn clone_table(
+        &self,
+        target_table_name: impl Into<String>,
+        source_uri: impl Into<String>,
+    ) -> CloneTableBuilder {
+        let target_table_name = target_table_name.into();
+        let source_uri = source_uri.into();
+        CloneTableBuilder {
+            upstream: self
+                .upstream
+                .clone_table(target_table_name.clone(), source_uri.clone()),
+            connection: self.clone(),
+            request: CloneTableRequest::new(target_table_name, source_uri),
+        }
+    }
+
+    fn should_handle_curvine_clone(&self, request: &CloneTableRequest) -> bool {
+        is_curvine_uri(&self.options.uri)
+            && is_curvine_uri(&request.source_uri)
+            && request.is_shallow
+            && request.target_namespace.is_empty()
+            && request.namespace_client.is_none()
+            && !self.options.namespace_backed
+    }
+
+    async fn clone_curvine_table(&self, request: CloneTableRequest) -> Result<Table> {
+        validate_table_name(&request.target_table_name)?;
+        if request.source_version.is_some() && request.source_tag.is_some() {
+            return Err(Error::InvalidInput {
+                message: "Cannot specify both source_version and source_tag".to_string(),
+            });
+        }
+
+        let session = self.options.session.clone().unwrap_or_else(curvine_session);
+        let storage_params = self.object_store_params();
+        let read_params = ReadParams {
+            store_options: Some(storage_params.clone()),
+            session: Some(session.clone()),
+            ..Default::default()
+        };
+        let mut source_dataset = DatasetBuilder::from_uri(&request.source_uri)
+            .with_read_params(read_params)
+            .load()
+            .await
+            .map_err(Error::from)?;
+
+        let (version_ref, version_number) = match (request.source_version, request.source_tag) {
+            (Some(version), None) => (Ref::Version(None, Some(version)), version),
+            (None, Some(tag)) => {
+                let tag_contents = source_dataset.tags().get(&tag).await.map_err(Error::from)?;
+                (Ref::Tag(tag), tag_contents.version)
+            }
+            (None, None) => {
+                let version = source_dataset.version().version;
+                (Ref::Version(None, Some(version)), version)
+            }
+            (Some(_), Some(_)) => unreachable!("checked above"),
+        };
+        let target_uri = self.table_uri(&request.target_table_name)?;
+        clone_dataset_with_session(
+            &mut source_dataset,
+            &target_uri,
+            version_ref,
+            version_number,
+            storage_params,
+            session,
+        )
+        .await
+        .map_err(Error::from)?;
+
+        self.open_table(request.target_table_name)
+            .storage_options(self.options.storage_options.clone())
+            .execute()
+            .await
+    }
+
+    fn object_store_params(&self) -> ObjectStoreParams {
+        ObjectStoreParams {
+            storage_options_accessor: if self.options.storage_options.is_empty() {
+                None
+            } else {
+                Some(Arc::new(StorageOptionsAccessor::with_static_options(
+                    self.options.storage_options.clone(),
+                )))
+            },
+            ..Default::default()
+        }
+    }
+
+    fn table_uri(&self, name: &str) -> Result<String> {
+        validate_table_name(name)?;
+
+        let mut uri = self.options.uri.clone();
+        if !(uri.ends_with('/') || uri.ends_with('\\')) {
+            if uri.contains("://") {
+                uri.push('/');
+            } else {
+                uri.push(MAIN_SEPARATOR);
+            }
+        }
+        uri.push_str(name);
+        uri.push('.');
+        uri.push_str(LANCE_FILE_EXTENSION);
+        if let Some(query) = &self.options.query_string {
+            uri.push('?');
+            uri.push_str(query);
+        }
+        Ok(uri)
+    }
+}
+
+impl Deref for Connection {
+    type Target = UpstreamConnection;
+
+    fn deref(&self) -> &Self::Target {
+        &self.upstream
+    }
+}
+
+impl Debug for Connection {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        f.debug_struct("Connection")
+            .field("uri", &self.options.uri)
+            .finish()
+    }
+}
+
+impl Display for Connection {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        self.upstream.fmt(f)
+    }
+}
+
+impl CloneTableBuilder {
+    pub fn source_version(mut self, version: u64) -> Self {
+        self.upstream = self.upstream.source_version(version);
+        self.request.source_version = Some(version);
+        self
+    }
+
+    pub fn source_tag(mut self, tag: impl Into<String>) -> Self {
+        let tag = tag.into();
+        self.upstream = self.upstream.source_tag(tag.clone());
+        self.request.source_tag = Some(tag);
+        self
+    }
+
+    pub fn target_namespace(mut self, namespace: Vec<String>) -> Self {
+        self.upstream = self.upstream.target_namespace(namespace.clone());
+        self.request.target_namespace = namespace;
+        self
+    }
+
+    pub fn is_shallow(mut self, is_shallow: bool) -> Self {
+        self.upstream = self.upstream.is_shallow(is_shallow);
+        self.request.is_shallow = is_shallow;
+        self
+    }
+
+    pub fn namespace_client(mut self, client: Arc<dyn LanceNamespace>) -> Self {
+        self.upstream = self.upstream.namespace_client(client.clone());
+        self.request.namespace_client = Some(client);
+        self
+    }
+
+    pub async fn execute(self) -> Result<Table> {
+        if self.connection.should_handle_curvine_clone(&self.request) {
+            self.connection.clone_curvine_table(self.request).await
+        } else {
+            self.upstream.execute().await
+        }
+    }
+}
+
+async fn clone_dataset_with_session(
+    source_dataset: &mut Dataset,
+    target_uri: &str,
+    version: Ref,
+    version_number: u64,
+    storage_params: ObjectStoreParams,
+    session: Arc<Session>,
+) -> LanceResult<Dataset> {
+    let ref_name = match &version {
+        Ref::Version(branch, _) => branch.clone(),
+        Ref::VersionNumber(_) => source_dataset.version().metadata.get("branch").cloned(),
+        Ref::Tag(tag) => source_dataset.tags().get(tag).await?.branch,
+    };
+    let clone_op = Operation::Clone {
+        is_shallow: true,
+        ref_name,
+        ref_version: version_number,
+        ref_path: source_dataset.uri().to_string(),
+        branch_name: None,
+    };
+    let transaction = Transaction::new(version_number, clone_op, None);
+
+    CommitBuilder::new(WriteDestination::Uri(target_uri))
+        .with_store_params(storage_params)
+        .with_object_store(Arc::new(source_dataset.object_store().clone()))
+        .with_commit_handler(Arc::new(ConditionalPutCommitHandler))
+        .with_storage_format(
+            source_dataset
+                .manifest()
+                .data_storage_format
+                .lance_file_version()?,
+        )
+        .with_session(session)
+        .execute(transaction)
+        .await
+}
+
+fn validate_table_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        return Err(Error::InvalidTableName {
+            name: name.to_string(),
+            reason: "Table names cannot be empty strings".to_string(),
+        });
+    }
+    if !name
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '-' || ch == '.')
+    {
+        return Err(Error::InvalidTableName {
+            name: name.to_string(),
+            reason:
+                "Table names can only contain alphanumeric characters, underscores, hyphens, and periods"
+                    .to_string(),
+        });
+    }
+    Ok(())
+}
+
 enum ConnectNamespaceBuilderInner {
     Pending {
         ns_impl: String,
         properties: HashMap<String, String>,
         storage_options: HashMap<String, String>,
-        read_consistency_interval: Option<std::time::Duration>,
-        embedding_registry:
-            Option<std::sync::Arc<dyn lancedb_upstream::embeddings::EmbeddingRegistry>>,
-        session: Option<std::sync::Arc<lancedb_upstream::Session>>,
+        read_consistency_interval: Option<Duration>,
+        embedding_registry: Option<Arc<dyn EmbeddingRegistry>>,
+        session: Option<Arc<Session>>,
         server_side_query: bool,
     },
 }
@@ -137,8 +469,8 @@ pub struct ConnectNamespaceBuilder {
     inner: ConnectNamespaceBuilderInner,
 }
 
-impl std::fmt::Debug for ConnectNamespaceBuilderInner {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Debug for ConnectNamespaceBuilderInner {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
             Self::Pending {
                 ns_impl,
@@ -162,8 +494,8 @@ impl std::fmt::Debug for ConnectNamespaceBuilderInner {
     }
 }
 
-impl std::fmt::Debug for ConnectNamespaceBuilder {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Debug for ConnectNamespaceBuilder {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         f.debug_struct("ConnectNamespaceBuilder")
             .field("inner", &self.inner)
             .finish()
@@ -249,7 +581,7 @@ impl ConnectNamespaceBuilder {
         })
     }
 
-    pub fn read_consistency_interval(self, read_consistency_interval: std::time::Duration) -> Self {
+    pub fn read_consistency_interval(self, read_consistency_interval: Duration) -> Self {
         self.map_upstream(|inner| match inner {
             ConnectNamespaceBuilderInner::Pending {
                 ns_impl,
@@ -271,10 +603,7 @@ impl ConnectNamespaceBuilder {
         })
     }
 
-    pub fn embedding_registry(
-        self,
-        registry: std::sync::Arc<dyn lancedb_upstream::embeddings::EmbeddingRegistry>,
-    ) -> Self {
+    pub fn embedding_registry(self, registry: Arc<dyn EmbeddingRegistry>) -> Self {
         self.map_upstream(|inner| match inner {
             ConnectNamespaceBuilderInner::Pending {
                 ns_impl,
@@ -296,7 +625,7 @@ impl ConnectNamespaceBuilder {
         })
     }
 
-    pub fn session(self, session: std::sync::Arc<lancedb_upstream::Session>) -> Self {
+    pub fn session(self, session: Arc<Session>) -> Self {
         self.map_upstream(|inner| match inner {
             ConnectNamespaceBuilderInner::Pending {
                 ns_impl,
@@ -340,7 +669,7 @@ impl ConnectNamespaceBuilder {
         })
     }
 
-    pub async fn execute(self) -> lancedb_upstream::Result<Connection> {
+    pub async fn execute(self) -> Result<Connection> {
         match self.inner {
             ConnectNamespaceBuilderInner::Pending {
                 ns_impl,
@@ -351,10 +680,19 @@ impl ConnectNamespaceBuilder {
                 session,
                 server_side_query,
             } => {
-                let wants_curvine = find_curvine_uri(&properties).is_some();
-                let mut builder = lancedb_upstream::connect_namespace(&ns_impl, properties);
+                let curvine_uri = find_curvine_uri(&properties);
+                let wants_curvine = curvine_uri.is_some();
+                let mut builder = upstream_connect_namespace(&ns_impl, properties);
+
+                let mut options = ConnectionOptions {
+                    uri: curvine_uri.unwrap_or_default(),
+                    session: session.clone(),
+                    namespace_backed: true,
+                    ..Default::default()
+                };
 
                 for (key, value) in storage_options {
+                    options.storage_options.insert(key.clone(), value.clone());
                     builder = builder.storage_option(key, value);
                 }
 
@@ -369,10 +707,16 @@ impl ConnectNamespaceBuilder {
                 if let Some(session) = session {
                     builder = builder.session(session);
                 } else if wants_curvine {
-                    builder = builder.session(curvine_session());
+                    let session = curvine_session();
+                    options.session = Some(session.clone());
+                    builder = builder.session(session);
                 }
 
-                builder.server_side_query(server_side_query).execute().await
+                let upstream = builder
+                    .server_side_query(server_side_query)
+                    .execute()
+                    .await?;
+                Ok(Connection { upstream, options })
             }
         }
     }
@@ -402,4 +746,16 @@ fn find_curvine_uri(properties: &HashMap<String, String>) -> Option<String> {
         .values()
         .find(|value| is_curvine_uri(value))
         .cloned()
+}
+
+fn normalize_listing_uri(uri: &str) -> Option<String> {
+    let mut url = Url::parse(uri).ok()?;
+    url.set_query(None);
+    Some(url.to_string())
+}
+
+fn listing_query_string(uri: &str) -> Option<String> {
+    Url::parse(uri)
+        .ok()
+        .and_then(|url| url.query().map(ToString::to_string))
 }

--- a/curvine-lancedb-rs/src/object_store.rs
+++ b/curvine-lancedb-rs/src/object_store.rs
@@ -178,6 +178,44 @@ fn resolve_curvine_conf_path(params: &ObjectStoreParams) -> Option<String> {
         .or_else(|| env::var(ClusterConf::ENV_CONF_FILE).ok())
 }
 
+fn curvine_store_identity(
+    url: &Url,
+    storage_options: Option<&HashMap<String, String>>,
+) -> Result<String> {
+    if let Some(conf_path) = storage_options
+        .and_then(|opts| opts.get(CURVINE_CONF_FILE_KEY))
+        .cloned()
+        .or_else(|| env::var(ClusterConf::ENV_CONF_FILE).ok())
+    {
+        let conf = ClusterConf::from(&conf_path).map_err(|e| {
+            LanceError::invalid_input(format!(
+                "Failed to load Curvine configuration from '{}': {e}",
+                conf_path
+            ))
+        })?;
+        return Ok(format!(
+            "masters:{}",
+            conf.master_nodes()
+                .into_iter()
+                .map(|node| node.addr.to_string())
+                .collect::<Vec<_>>()
+                .join(",")
+        ));
+    }
+
+    curvine_absolute_path_str_from_uri(url)
+        .map(|path| format!("uri:{path}"))
+        .map_err(|e| LanceError::invalid_input(format!("Invalid curvine:// URI `{}`: {e}", url)))
+}
+
+fn is_known_internal_dir(path: &CurvinePath) -> bool {
+    let path = path.full_path().trim_end_matches('/').to_string();
+    path == MULTIPART_STAGING_ROOT
+        || path.starts_with(&format!("{MULTIPART_STAGING_ROOT}/"))
+        || path == CONDITIONAL_LOCK_ROOT
+        || path.starts_with(&format!("{CONDITIONAL_LOCK_ROOT}/"))
+}
+
 fn missing_curvine_config_error() -> LanceError {
     LanceError::invalid_input(format!(
         "Missing Curvine cluster configuration: set storage option `{CURVINE_CONF_FILE_KEY}` \
@@ -271,12 +309,8 @@ impl ObjectStoreProvider for CurvineObjectStoreProvider {
         curvine_workspace_root_from_uri(url).map_err(|e| {
             LanceError::invalid_input(format!("Invalid curvine:// URI `{}`: {e}", url))
         })?;
-        let conf_path = storage_options
-            .and_then(|opts| opts.get(CURVINE_CONF_FILE_KEY))
-            .cloned()
-            .or_else(|| env::var(ClusterConf::ENV_CONF_FILE).ok())
-            .ok_or_else(missing_curvine_config_error)?;
-        Ok(format!("{CURVINE_SCHEME}${conf_path}"))
+        let identity = curvine_store_identity(url, storage_options)?;
+        Ok(format!("{CURVINE_SCHEME}${identity}"))
     }
 }
 
@@ -494,9 +528,10 @@ impl ObjectStoreTrait for CurvineObjectStore {
                     store: CURVINE_SCHEME,
                     source: e.to_string().into(),
                 })?;
-                if self.dir_contains_visible_file(&child).await? {
-                    common_prefixes.insert(prefix);
+                if is_known_internal_dir(&child) {
+                    continue;
                 }
+                common_prefixes.insert(prefix);
             } else {
                 objects.push(file_status_to_object_meta(entry_location, status));
             }
@@ -943,38 +978,6 @@ impl CurvineObjectStore {
         }
 
         Ok(())
-    }
-
-    async fn dir_contains_visible_file(&self, dir: &CurvinePath) -> OsResult<bool> {
-        let statuses = self
-            .list_curvine_dir_or_empty(dir, &Path::default())
-            .await?;
-
-        for status in statuses {
-            if status.is_dir {
-                let child = CurvinePath::from_str(&status.path).map_err(|e| OsError::Generic {
-                    store: CURVINE_SCHEME,
-                    source: e.to_string().into(),
-                })?;
-                if self.is_multipart_internal_dir(&child) {
-                    continue;
-                }
-                if Box::pin(self.dir_contains_visible_file(&child)).await? {
-                    return Ok(true);
-                }
-            } else {
-                let path = relative_object_path(&self.context.workspace_root, &status.path)
-                    .map_err(|msg| OsError::Generic {
-                        store: CURVINE_SCHEME,
-                        source: msg.into(),
-                    })?;
-                if !self.is_internal_reserved_location(&path) {
-                    return Ok(true);
-                }
-            }
-        }
-
-        Ok(false)
     }
 
     fn multipart_dir(&self, location: &Path, upload_id: &str) -> OsResult<CurvinePath> {

--- a/curvine-lancedb-rs/src/object_store.rs
+++ b/curvine-lancedb-rs/src/object_store.rs
@@ -26,7 +26,7 @@ use curvine_client::file::CurvineFileSystem;
 use curvine_common::conf::ClusterConf;
 use curvine_common::error::FsError;
 use curvine_common::fs::{Path as CurvinePath, Reader, Writer};
-use curvine_common::state::FileStatus;
+use curvine_common::state::{FileLock, FileStatus, LockFlags, LockType};
 use futures::stream::{self, BoxStream};
 use futures::StreamExt;
 use lance_core::error::Result;
@@ -45,6 +45,7 @@ use object_store::{
     PutOptions, PutPayload, PutResult, Result as OsResult, UploadPart,
 };
 use tokio::sync::Mutex;
+use tokio::time::{sleep, Duration, Instant};
 use url::Url;
 use uuid::Uuid;
 
@@ -54,7 +55,10 @@ pub const CURVINE_CONF_FILE_KEY: &str = "curvine.conf.path";
 
 const COPY_CHUNK_BYTES: usize = 1024 * 1024;
 const MULTIPART_STAGING_ROOT: &str = "/.curvine/lancedb/multipart";
+const CONDITIONAL_LOCK_ROOT: &str = "/.curvine/lancedb/locks";
 const INTERNAL_RESERVED_ROOT: &str = ".curvine";
+const CONDITIONAL_LOCK_RETRY_DELAY: Duration = Duration::from_millis(20);
+const CONDITIONAL_LOCK_WAIT_TIMEOUT: Duration = Duration::from_secs(120);
 
 #[derive(Clone)]
 struct CurvineContext {
@@ -87,8 +91,13 @@ struct CurvineMultipartUpload {
 #[derive(Debug, Clone)]
 struct CompletedPart {
     part_idx: usize,
-    etag: String,
     path: CurvinePath,
+}
+
+#[derive(Debug)]
+struct ConditionalWriteLock {
+    path: CurvinePath,
+    lock: FileLock,
 }
 
 impl Debug for CurvineObjectStore {
@@ -111,10 +120,11 @@ impl Display for CurvineObjectStore {
 
 /// [`ObjectStoreProvider`] for `curvine://` URIs.
 ///
-/// The opening URI is turned into one absolute Curvine workspace path (authority, when present,
-/// is the first path segment: `curvine://tenant/a` → `/tenant/a`). [`ObjectStoreProvider::extract_path`]
-/// applies the same validation and returns an empty [`Path`] because Lance object
-/// keys are relative to that workspace root. See `docs/phase4-curvine-object-store-and-lancedb.md` in this crate.
+/// The store is rooted at Curvine `/`, while [`ObjectStoreProvider::extract_path`]
+/// turns the full URI into a relative Lance object key (for example,
+/// `curvine://tenant/a` -> `tenant/a`, `curvine:///tmp/db` -> `tmp/db`).
+/// This matches Lance's object store contract and lets one Curvine store address
+/// multiple dataset base paths during shallow clone.
 #[derive(Debug, Clone, Default)]
 pub struct CurvineObjectStoreProvider;
 
@@ -146,11 +156,14 @@ impl CurvineObjectStoreProvider {
             ))
         })?;
 
-        let workspace_root = curvine_workspace_root_from_uri(base_path).map_err(|e| {
+        curvine_workspace_root_from_uri(base_path).map_err(|e| {
             LanceError::invalid_input(format!(
                 "Invalid curvine:// workspace URI '{}': {e}",
                 base_path
             ))
+        })?;
+        let workspace_root = CurvinePath::from_str("/").map_err(|e| {
+            LanceError::invalid_input(format!("Failed to initialize Curvine root path: {e}"))
         })?;
 
         Ok(Arc::new(CurvineContext { fs, workspace_root }))
@@ -231,27 +244,39 @@ impl ObjectStoreProvider for CurvineObjectStoreProvider {
         Ok(store)
     }
 
-    /// The opening `curvine://...` URI identifies the workspace root, not an object key.
-    ///
-    /// We therefore validate the URI with the same absolute-path merger used for
-    /// `workspace_root`, and then return an empty relative [`Path`]. All later
-    /// `head/get/put/list/...` calls operate on keys that are relative to that
-    /// workspace root.
+    /// Convert the full `curvine://...` URI into a Lance object key.
     fn extract_path(&self, url: &Url) -> Result<Path> {
-        curvine_workspace_root_from_uri(url).map_err(|e| {
+        if url.host_str() == Some(INTERNAL_RESERVED_ROOT) {
+            return Err(LanceError::invalid_input(format!(
+                "`{INTERNAL_RESERVED_ROOT}` is a reserved Curvine namespace and cannot be used as a curvine:// authority"
+            )));
+        }
+        let absolute = curvine_absolute_path_str_from_uri(url).map_err(|e| {
             LanceError::invalid_input(format!("Invalid curvine:// URI `{}`: {e}", url))
         })?;
-        Ok(Path::default())
+        let relative = absolute.trim_start_matches('/');
+        Path::parse(relative).map_err(|e| {
+            LanceError::invalid_input(format!(
+                "Invalid curvine:// URI path `{}` from `{}`: {e}",
+                absolute, url
+            ))
+        })
     }
 
     fn calculate_object_store_prefix(
         &self,
         url: &Url,
-        _storage_options: Option<&HashMap<String, String>>,
+        storage_options: Option<&HashMap<String, String>>,
     ) -> Result<String> {
-        let host = url.host_str().unwrap_or("");
-        let path = url.path().trim_end_matches('/');
-        Ok(format!("curvine${host}{path}"))
+        curvine_workspace_root_from_uri(url).map_err(|e| {
+            LanceError::invalid_input(format!("Invalid curvine:// URI `{}`: {e}", url))
+        })?;
+        let conf_path = storage_options
+            .and_then(|opts| opts.get(CURVINE_CONF_FILE_KEY))
+            .cloned()
+            .or_else(|| env::var(ClusterConf::ENV_CONF_FILE).ok())
+            .ok_or_else(missing_curvine_config_error)?;
+        Ok(format!("{CURVINE_SCHEME}${conf_path}"))
     }
 }
 
@@ -267,37 +292,13 @@ impl ObjectStoreTrait for CurvineObjectStore {
             return Err(OsError::NotImplemented);
         }
 
-        let path = self.object_path(location)?;
-        let overwrite = match opts.mode {
-            PutMode::Overwrite => true,
-            PutMode::Create => false,
-            PutMode::Update(_) => return Err(OsError::NotImplemented),
-        };
-        let mut writer = self
-            .context
-            .fs
-            .create(&path, overwrite)
-            .await
-            .map_err(|e| fs_error_to_object_store(location, e))?;
-
-        for chunk in payload.iter() {
-            writer
-                .write(chunk)
-                .await
-                .map_err(|e| fs_error_to_object_store(location, e))?;
+        match opts.mode {
+            PutMode::Overwrite => return self.put_overwrite(location, payload).await,
+            PutMode::Create => return self.put_create(location, payload).await,
+            PutMode::Update(update) => {
+                return self.put_update(location, payload, update).await;
+            }
         }
-
-        writer
-            .complete()
-            .await
-            .map_err(|e| fs_error_to_object_store(location, e))?;
-
-        let meta = self.head(location).await?;
-
-        Ok(PutResult {
-            e_tag: meta.e_tag,
-            version: meta.version,
-        })
     }
 
     async fn put_multipart_opts(
@@ -310,7 +311,7 @@ impl ObjectStoreTrait for CurvineObjectStore {
         }
 
         let upload_id = Uuid::new_v4().to_string();
-        let upload_dir = self.multipart_dir(&upload_id)?;
+        let upload_dir = self.multipart_dir(location, &upload_id)?;
         self.context
             .fs
             .mkdir(&upload_dir, true)
@@ -402,12 +403,25 @@ impl ObjectStoreTrait for CurvineObjectStore {
 
     async fn delete(&self, location: &Path) -> OsResult<()> {
         let cv_path = self.object_path(location)?;
-        self.context
-            .fs
-            .delete(&cv_path, false)
-            .await
-            .map_err(|e| fs_error_to_object_store(location, e))?;
-        let _ = self.prune_empty_parents(&cv_path, location).await;
+        let lock = self.acquire_object_write_lock(location).await?;
+        let result = match self.context.fs.get_status(&cv_path).await {
+            Ok(status) if status.is_dir => Ok(()),
+            Ok(_) => self
+                .context
+                .fs
+                .delete(&cv_path, false)
+                .await
+                .map_err(|e| fs_error_to_object_store(location, e)),
+            Err(FsError::FileNotFound(_))
+            | Err(FsError::Expired(_))
+            | Err(FsError::JobNotFound(_)) => Ok(()),
+            Err(e) => Err(fs_error_to_object_store(location, e)),
+        };
+        let _ = self.release_object_write_lock(&lock).await;
+        result?;
+        if !self.is_root_workspace() {
+            let _ = self.prune_empty_parents(&cv_path, location).await;
+        }
         Ok(())
     }
 
@@ -476,7 +490,13 @@ impl ObjectStoreTrait for CurvineObjectStore {
                 if self.is_internal_reserved_location(&prefix) {
                     continue;
                 }
-                common_prefixes.insert(prefix);
+                let child = CurvinePath::from_str(&status.path).map_err(|e| OsError::Generic {
+                    store: CURVINE_SCHEME,
+                    source: e.to_string().into(),
+                })?;
+                if self.dir_contains_visible_file(&child).await? {
+                    common_prefixes.insert(prefix);
+                }
             } else {
                 objects.push(file_status_to_object_meta(entry_location, status));
             }
@@ -493,9 +513,20 @@ impl ObjectStoreTrait for CurvineObjectStore {
     /// is left unchanged (copy, not move).
     async fn copy(&self, from: &Path, to: &Path) -> OsResult<()> {
         let from_cv = self.object_path(from)?;
-        let to_cv = self.object_path(to)?;
         let meta = self.head(from).await?;
         let size = meta.size;
+        let upload_id = Uuid::new_v4().to_string();
+        let staging = self.multipart_final_path(to, &upload_id)?;
+        if let Some(parent) = staging.parent().map_err(|e| OsError::Generic {
+            store: CURVINE_SCHEME,
+            source: e.to_string().into(),
+        })? {
+            self.context
+                .fs
+                .mkdir(&parent, true)
+                .await
+                .map_err(|e| fs_error_to_object_store(to, e))?;
+        }
 
         let mut reader = self
             .context
@@ -507,28 +538,49 @@ impl ObjectStoreTrait for CurvineObjectStore {
         let mut writer = self
             .context
             .fs
-            .create(&to_cv, true)
+            .create(&staging, true)
             .await
             .map_err(|e| fs_error_to_object_store(to, e))?;
 
-        self.stream_copy_contents(from, to, size, &mut reader, &mut writer)
-            .await?;
-        reader
-            .complete()
-            .await
-            .map_err(|e| fs_error_to_object_store(from, e))?;
-        writer
-            .complete()
-            .await
-            .map_err(|e| fs_error_to_object_store(to, e))?;
-        Ok(())
+        let copy_result: OsResult<()> = async {
+            self.stream_copy_contents(from, to, size, &mut reader, &mut writer)
+                .await?;
+            reader
+                .complete()
+                .await
+                .map_err(|e| fs_error_to_object_store(from, e))?;
+            writer
+                .complete()
+                .await
+                .map_err(|e| fs_error_to_object_store(to, e))?;
+            let lock = self.acquire_object_write_lock(to).await?;
+            let replace = self.replace_from_staging(to, &staging).await.map(|_| ());
+            let _ = self.release_object_write_lock(&lock).await;
+            replace
+        }
+        .await;
+        if copy_result.is_err() {
+            let _ = self.context.fs.delete(&staging, false).await;
+        }
+        copy_result
     }
 
     async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> OsResult<()> {
         let from_cv = self.object_path(from)?;
-        let to_cv = self.object_path(to)?;
         let meta = self.head(from).await?;
         let size = meta.size;
+        let upload_id = Uuid::new_v4().to_string();
+        let staging = self.multipart_final_path(to, &upload_id)?;
+        if let Some(parent) = staging.parent().map_err(|e| OsError::Generic {
+            store: CURVINE_SCHEME,
+            source: e.to_string().into(),
+        })? {
+            self.context
+                .fs
+                .mkdir(&parent, true)
+                .await
+                .map_err(|e| fs_error_to_object_store(to, e))?;
+        }
 
         let mut reader = self
             .context
@@ -540,7 +592,7 @@ impl ObjectStoreTrait for CurvineObjectStore {
         let mut writer = self
             .context
             .fs
-            .create(&to_cv, false)
+            .create(&staging, true)
             .await
             .map_err(|e| fs_error_to_object_store(to, e))?;
 
@@ -558,12 +610,24 @@ impl ObjectStoreTrait for CurvineObjectStore {
                 .complete()
                 .await
                 .map_err(|e| fs_error_to_object_store(to, e))?;
-            Ok(())
+            let lock = self.acquire_object_write_lock(to).await?;
+            let replace = match self.head(to).await {
+                Ok(_) => Err(OsError::AlreadyExists {
+                    path: to.to_string(),
+                    source: "object already exists".into(),
+                }),
+                Err(OsError::NotFound { .. }) => {
+                    self.replace_from_staging(to, &staging).await.map(|_| ())
+                }
+                Err(err) => Err(err),
+            };
+            let _ = self.release_object_write_lock(&lock).await;
+            replace
         }
         .await;
 
         if finalize_result.is_err() {
-            let _ = self.context.fs.delete(&to_cv, false).await;
+            let _ = self.context.fs.delete(&staging, false).await;
         }
 
         finalize_result
@@ -571,6 +635,220 @@ impl ObjectStoreTrait for CurvineObjectStore {
 }
 
 impl CurvineObjectStore {
+    async fn put_overwrite(&self, location: &Path, payload: PutPayload) -> OsResult<PutResult> {
+        let staging = self.write_payload_to_staging(location, payload).await?;
+        let lock = self.acquire_object_write_lock(location).await?;
+        let result = self.replace_from_staging(location, &staging).await;
+        let _ = self.release_object_write_lock(&lock).await;
+        if result.is_err() {
+            let _ = self.context.fs.delete(&staging, false).await;
+        }
+        result
+    }
+
+    async fn put_create(&self, location: &Path, payload: PutPayload) -> OsResult<PutResult> {
+        let staging = self.write_payload_to_staging(location, payload).await?;
+        let lock = self.acquire_object_write_lock(location).await?;
+        let result = match self.head(location).await {
+            Ok(_) => Err(OsError::AlreadyExists {
+                path: location.to_string(),
+                source: "object already exists".into(),
+            }),
+            Err(OsError::NotFound { .. }) => self.replace_from_staging(location, &staging).await,
+            Err(err) => Err(err),
+        };
+        let _ = self.release_object_write_lock(&lock).await;
+        if result.is_err() {
+            let _ = self.context.fs.delete(&staging, false).await;
+        }
+        result
+    }
+
+    async fn put_update(
+        &self,
+        location: &Path,
+        payload: PutPayload,
+        update: object_store::UpdateVersion,
+    ) -> OsResult<PutResult> {
+        let expected_etag = update.e_tag.ok_or_else(|| OsError::Generic {
+            store: CURVINE_SCHEME,
+            source: "ETag required for conditional update".into(),
+        })?;
+
+        let staging = self.write_payload_to_staging(location, payload).await?;
+        let lock = self.acquire_object_write_lock(location).await?;
+        let result = async {
+            let current = self.head_for_update(location).await?;
+            ensure_matching_etag(location, current.e_tag.as_deref(), &expected_etag)?;
+            self.replace_from_staging(location, &staging).await
+        }
+        .await;
+        let _ = self.release_object_write_lock(&lock).await;
+        if result.is_err() {
+            let _ = self.context.fs.delete(&staging, false).await;
+        }
+        result
+    }
+
+    async fn write_payload_to_staging(
+        &self,
+        location: &Path,
+        payload: PutPayload,
+    ) -> OsResult<CurvinePath> {
+        let upload_id = Uuid::new_v4().to_string();
+        let staging = self.multipart_final_path(location, &upload_id)?;
+        if let Some(parent) = staging.parent().map_err(|e| OsError::Generic {
+            store: CURVINE_SCHEME,
+            source: e.to_string().into(),
+        })? {
+            self.context
+                .fs
+                .mkdir(&parent, true)
+                .await
+                .map_err(|e| fs_error_to_object_store(location, e))?;
+        }
+
+        let mut writer = self
+            .context
+            .fs
+            .create(&staging, true)
+            .await
+            .map_err(|e| fs_error_to_object_store(location, e))?;
+        let write_result: OsResult<()> = async {
+            for chunk in payload.iter() {
+                writer
+                    .write(chunk)
+                    .await
+                    .map_err(|e| fs_error_to_object_store(location, e))?;
+            }
+            writer
+                .complete()
+                .await
+                .map_err(|e| fs_error_to_object_store(location, e))
+        }
+        .await;
+        match write_result {
+            Ok(()) => Ok(staging),
+            Err(err) => {
+                let _ = self.context.fs.delete(&staging, false).await;
+                Err(err)
+            }
+        }
+    }
+
+    async fn replace_from_staging(
+        &self,
+        location: &Path,
+        staging: &CurvinePath,
+    ) -> OsResult<PutResult> {
+        let dest = self.object_path(location)?;
+        self.prepare_multipart_destination(&dest, location).await?;
+        self.context
+            .fs
+            .rename(staging, &dest)
+            .await
+            .map_err(|e| fs_error_to_object_store(location, e))
+            .and_then(|renamed| {
+                if renamed {
+                    Ok(())
+                } else {
+                    Err(OsError::Generic {
+                        store: CURVINE_SCHEME,
+                        source: "object replacement rename reported no-op".into(),
+                    })
+                }
+            })?;
+
+        let meta = self.head(location).await?;
+        Ok(PutResult {
+            e_tag: meta.e_tag,
+            version: meta.version,
+        })
+    }
+
+    async fn head_for_update(&self, location: &Path) -> OsResult<ObjectMeta> {
+        match self.head(location).await {
+            Ok(meta) => Ok(meta),
+            Err(OsError::NotFound { path, source }) => Err(OsError::Precondition { path, source }),
+            Err(err) => Err(err),
+        }
+    }
+
+    async fn acquire_object_write_lock(&self, location: &Path) -> OsResult<ConditionalWriteLock> {
+        let path = self.object_lock_path(location)?;
+        self.ensure_lock_file(&path, location).await?;
+        let owner_id = conditional_lock_owner();
+        let lock = conditional_write_lock(owner_id);
+        let deadline = Instant::now() + CONDITIONAL_LOCK_WAIT_TIMEOUT;
+        // Curvine locks are advisory. This serializes LanceDB-on-Curvine facade writers;
+        // non-facade Curvine clients still require a future server-side conditional primitive.
+        loop {
+            match self.context.fs.set_lock(&path, lock.clone()).await {
+                Ok(None) => {
+                    return Ok(ConditionalWriteLock {
+                        path,
+                        lock: conditional_unlock(owner_id),
+                    });
+                }
+                Ok(Some(_)) if Instant::now() < deadline => {
+                    sleep(CONDITIONAL_LOCK_RETRY_DELAY).await
+                }
+                Ok(Some(_)) => {
+                    return Err(OsError::Generic {
+                        store: CURVINE_SCHEME,
+                        source: format!(
+                            "Timed out waiting for Curvine object write lock at {}",
+                            path.full_path()
+                        )
+                        .into(),
+                    });
+                }
+                Err(e) => return Err(fs_error_to_object_store(location, e)),
+            }
+        }
+    }
+
+    async fn release_object_write_lock(&self, guard: &ConditionalWriteLock) -> OsResult<()> {
+        self.context
+            .fs
+            .set_lock(&guard.path, guard.lock.clone())
+            .await
+            .map(|_| ())
+            .map_err(|e| fs_error_to_object_store(&Path::default(), e))
+    }
+
+    async fn ensure_lock_file(&self, lock_path: &CurvinePath, location: &Path) -> OsResult<()> {
+        if let Some(parent) = lock_path.parent().map_err(|e| OsError::Generic {
+            store: CURVINE_SCHEME,
+            source: e.to_string().into(),
+        })? {
+            self.context
+                .fs
+                .mkdir(&parent, true)
+                .await
+                .map_err(|e| fs_error_to_object_store(location, e))?;
+        }
+
+        match self.context.fs.create(lock_path, false).await {
+            Ok(mut writer) => writer
+                .complete()
+                .await
+                .map_err(|e| fs_error_to_object_store(location, e)),
+            Err(FsError::FileAlreadyExists(_)) => Ok(()),
+            Err(e) => Err(fs_error_to_object_store(location, e)),
+        }
+    }
+
+    fn object_lock_path(&self, location: &Path) -> OsResult<CurvinePath> {
+        let workspace_id = multipart_staging_id(&self.context.workspace_root, Some(location));
+        CurvinePath::from_str(format!("{CONDITIONAL_LOCK_ROOT}/{workspace_id}")).map_err(|e| {
+            OsError::Generic {
+                store: CURVINE_SCHEME,
+                source: e.to_string().into(),
+            }
+        })
+    }
+
     fn object_path(&self, location: &Path) -> OsResult<CurvinePath> {
         let rel = location.as_ref().trim_start_matches('/');
         if self.is_root_workspace() && is_internal_reserved_relative_path(rel) {
@@ -588,7 +866,9 @@ impl CurvineObjectStore {
             .full_path()
             .trim_end_matches('/');
 
-        let full = if rel.is_empty() {
+        let full = if rel.is_empty() && base.is_empty() {
+            "/".to_string()
+        } else if rel.is_empty() {
             base.to_string()
         } else {
             format!("{base}/{rel}")
@@ -665,8 +945,40 @@ impl CurvineObjectStore {
         Ok(())
     }
 
-    fn multipart_dir(&self, upload_id: &str) -> OsResult<CurvinePath> {
-        let workspace_id = workspace_staging_id(&self.context.workspace_root);
+    async fn dir_contains_visible_file(&self, dir: &CurvinePath) -> OsResult<bool> {
+        let statuses = self
+            .list_curvine_dir_or_empty(dir, &Path::default())
+            .await?;
+
+        for status in statuses {
+            if status.is_dir {
+                let child = CurvinePath::from_str(&status.path).map_err(|e| OsError::Generic {
+                    store: CURVINE_SCHEME,
+                    source: e.to_string().into(),
+                })?;
+                if self.is_multipart_internal_dir(&child) {
+                    continue;
+                }
+                if Box::pin(self.dir_contains_visible_file(&child)).await? {
+                    return Ok(true);
+                }
+            } else {
+                let path = relative_object_path(&self.context.workspace_root, &status.path)
+                    .map_err(|msg| OsError::Generic {
+                        store: CURVINE_SCHEME,
+                        source: msg.into(),
+                    })?;
+                if !self.is_internal_reserved_location(&path) {
+                    return Ok(true);
+                }
+            }
+        }
+
+        Ok(false)
+    }
+
+    fn multipart_dir(&self, location: &Path, upload_id: &str) -> OsResult<CurvinePath> {
+        let workspace_id = multipart_staging_id(&self.context.workspace_root, Some(location));
         CurvinePath::from_str(format!(
             "{}/{}/{}",
             MULTIPART_STAGING_ROOT, workspace_id, upload_id
@@ -677,8 +989,13 @@ impl CurvineObjectStore {
         })
     }
 
-    fn multipart_part_path(&self, upload_id: &str, part_idx: usize) -> OsResult<CurvinePath> {
-        let workspace_id = workspace_staging_id(&self.context.workspace_root);
+    fn multipart_part_path(
+        &self,
+        location: &Path,
+        upload_id: &str,
+        part_idx: usize,
+    ) -> OsResult<CurvinePath> {
+        let workspace_id = multipart_staging_id(&self.context.workspace_root, Some(location));
         CurvinePath::from_str(format!(
             "{}/{}/{}/part-{:08}",
             MULTIPART_STAGING_ROOT, workspace_id, upload_id, part_idx
@@ -689,8 +1006,8 @@ impl CurvineObjectStore {
         })
     }
 
-    fn multipart_final_path(&self, upload_id: &str) -> OsResult<CurvinePath> {
-        let workspace_id = workspace_staging_id(&self.context.workspace_root);
+    fn multipart_final_path(&self, location: &Path, upload_id: &str) -> OsResult<CurvinePath> {
+        let workspace_id = multipart_staging_id(&self.context.workspace_root, Some(location));
         CurvinePath::from_str(format!(
             "{}/{}/{}/final",
             MULTIPART_STAGING_ROOT, workspace_id, upload_id
@@ -701,8 +1018,8 @@ impl CurvineObjectStore {
         })
     }
 
-    async fn cleanup_multipart(&self, upload_id: &str) -> OsResult<()> {
-        let dir = self.multipart_dir(upload_id)?;
+    async fn cleanup_multipart(&self, location: &Path, upload_id: &str) -> OsResult<()> {
+        let dir = self.multipart_dir(location, upload_id)?;
         match self.context.fs.delete(&dir, true).await {
             Ok(_) => Ok(()),
             Err(FsError::FileNotFound(_))
@@ -839,39 +1156,33 @@ impl MultipartUpload for CurvineMultipartUpload {
     fn put_part(&mut self, data: PutPayload) -> UploadPart {
         let store = self.store.clone();
         let upload_id = self.upload_id.clone();
+        let dest = self.dest.clone();
         let part_idx = self.next_part;
         self.next_part += 1;
         let completed_parts = Arc::clone(&self.completed_parts);
 
         Box::pin(async move {
-            let path = store.multipart_part_path(&upload_id, part_idx)?;
+            let path = store.multipart_part_path(&dest, &upload_id, part_idx)?;
             let mut writer = store
                 .context
                 .fs
                 .create(&path, true)
                 .await
-                .map_err(|e| fs_error_to_object_store(&Path::default(), e))?;
+                .map_err(|e| fs_error_to_object_store(&dest, e))?;
 
-            let mut hasher = Md5::new();
             for chunk in data.iter() {
-                hasher.update(chunk);
                 writer
                     .write(chunk)
                     .await
-                    .map_err(|e| fs_error_to_object_store(&Path::default(), e))?;
+                    .map_err(|e| fs_error_to_object_store(&dest, e))?;
             }
             writer
                 .complete()
                 .await
-                .map_err(|e| fs_error_to_object_store(&Path::default(), e))?;
+                .map_err(|e| fs_error_to_object_store(&dest, e))?;
 
-            let etag = format!("\"{:x}\"", hasher.finalize());
             let mut guard = completed_parts.lock().await;
-            guard.push(CompletedPart {
-                part_idx,
-                etag,
-                path,
-            });
+            guard.push(CompletedPart { part_idx, path });
             Ok(())
         })
     }
@@ -880,11 +1191,9 @@ impl MultipartUpload for CurvineMultipartUpload {
         let mut parts = self.completed_parts.lock().await.clone();
         parts.sort_by_key(|p| p.part_idx);
 
-        let dest = self.store.object_path(&self.dest)?;
-        self.store
-            .prepare_multipart_destination(&dest, &self.dest)
-            .await?;
-        let staging_final = self.store.multipart_final_path(&self.upload_id)?;
+        let staging_final = self
+            .store
+            .multipart_final_path(&self.dest, &self.upload_id)?;
         let mut writer = self
             .store
             .context
@@ -893,8 +1202,7 @@ impl MultipartUpload for CurvineMultipartUpload {
             .await
             .map_err(|e| fs_error_to_object_store(&self.dest, e))?;
 
-        let mut etag_inputs = String::new();
-        let write_result: OsResult<()> = async {
+        let write_result: OsResult<PutResult> = async {
             for part in parts {
                 let part_meta = self
                     .store
@@ -923,46 +1231,37 @@ impl MultipartUpload for CurvineMultipartUpload {
                     .complete()
                     .await
                     .map_err(|e| fs_error_to_object_store(&self.dest, e))?;
-                etag_inputs.push_str(&part.etag);
             }
             writer
                 .complete()
                 .await
                 .map_err(|e| fs_error_to_object_store(&self.dest, e))?;
-            self.store
-                .context
-                .fs
-                .rename(&staging_final, &dest)
-                .await
-                .map_err(|e| fs_error_to_object_store(&self.dest, e))
-                .and_then(|renamed| {
-                    if renamed {
-                        Ok(())
-                    } else {
-                        Err(OsError::Generic {
-                            store: CURVINE_SCHEME,
-                            source: "multipart final rename reported no-op".into(),
-                        })
-                    }
-                })?;
-            Ok(())
+            let lock = self.store.acquire_object_write_lock(&self.dest).await?;
+            let replace = self
+                .store
+                .replace_from_staging(&self.dest, &staging_final)
+                .await;
+            let _ = self.store.release_object_write_lock(&lock).await;
+            replace
         }
         .await;
 
         match write_result {
-            Ok(()) => {
-                let _ = self.store.cleanup_multipart(&self.upload_id).await;
-                Ok(PutResult {
-                    e_tag: Some(etag_inputs),
-                    version: None,
-                })
+            Ok(result) => {
+                let _ = self
+                    .store
+                    .cleanup_multipart(&self.dest, &self.upload_id)
+                    .await;
+                Ok(result)
             }
             Err(err) => Err(err),
         }
     }
 
     async fn abort(&mut self) -> OsResult<()> {
-        self.store.cleanup_multipart(&self.upload_id).await
+        self.store
+            .cleanup_multipart(&self.dest, &self.upload_id)
+            .await
     }
 }
 
@@ -1030,11 +1329,54 @@ fn is_internal_reserved_relative_path(rel: &str) -> bool {
     rel == INTERNAL_RESERVED_ROOT || rel.starts_with(&format!("{INTERNAL_RESERVED_ROOT}/"))
 }
 
-fn workspace_staging_id(workspace_root: &CurvinePath) -> String {
-    workspace_root
-        .full_path()
-        .trim_start_matches('/')
-        .replace('/', "__")
+fn ensure_matching_etag(location: &Path, actual: Option<&str>, expected: &str) -> OsResult<()> {
+    match actual {
+        Some(actual) if actual == expected => Ok(()),
+        Some(actual) => Err(OsError::Precondition {
+            path: location.to_string(),
+            source: format!("{actual} does not match {expected}").into(),
+        }),
+        None => Err(OsError::Precondition {
+            path: location.to_string(),
+            source: format!("Object at location {location} has no ETag").into(),
+        }),
+    }
+}
+
+fn conditional_write_lock(owner_id: u64) -> FileLock {
+    conditional_lock(owner_id, LockType::WriteLock)
+}
+
+fn conditional_unlock(owner_id: u64) -> FileLock {
+    conditional_lock(owner_id, LockType::UnLock)
+}
+
+fn conditional_lock_owner() -> u64 {
+    let uuid = Uuid::new_v4();
+    u64::from_le_bytes(uuid.as_bytes()[..8].try_into().unwrap_or_default())
+}
+
+fn conditional_lock(owner_id: u64, lock_type: LockType) -> FileLock {
+    FileLock {
+        client_id: format!("curvine-lancedb:{}", std::process::id()),
+        owner_id,
+        pid: std::process::id(),
+        acquire_time: 0,
+        lock_type,
+        lock_flags: LockFlags::Flock,
+        start: 0,
+        end: u64::MAX,
+    }
+}
+
+fn multipart_staging_id(workspace_root: &CurvinePath, location: Option<&Path>) -> String {
+    let mut hasher = Md5::new();
+    hasher.update(workspace_root.full_path().as_bytes());
+    if let Some(location) = location {
+        hasher.update([0]);
+        hasher.update(location.as_ref().as_bytes());
+    }
+    format!("{:x}", hasher.finalize())
 }
 
 fn fs_error_to_object_store(location: &Path, error: FsError) -> OsError {

--- a/curvine-lancedb-rs/tests/facade_compat.rs
+++ b/curvine-lancedb-rs/tests/facade_compat.rs
@@ -14,13 +14,16 @@
 
 use std::collections::HashMap;
 use std::env;
+use std::io::Write;
 use std::sync::Arc;
 
 use curvine_common::conf::ClusterConf;
 use lancedb::connect;
 use lancedb::connect_namespace;
 use lancedb::error::Error as LanceDbError;
-use lancedb::object_store::{curvine_registry, curvine_session, CurvineObjectStoreProvider};
+use lancedb::object_store::{
+    curvine_registry, curvine_session, CurvineObjectStoreProvider, CURVINE_CONF_FILE_KEY,
+};
 use lancedb::{ObjectStoreProvider, ObjectStoreRegistry, Session};
 use tokio::sync::Mutex;
 use url::Url;
@@ -61,6 +64,52 @@ fn curvine_provider_extracts_lance_relative_base_path() {
         .extract_path(&Url::parse("curvine://tenant/data/db").unwrap())
         .unwrap();
     assert_eq!(path.as_ref(), "tenant/data/db");
+}
+
+#[test]
+fn curvine_provider_prefix_does_not_require_config() {
+    let provider = CurvineObjectStoreProvider::new();
+    let prefix = provider
+        .calculate_object_store_prefix(
+            &Url::parse("curvine://tenant/data/db").unwrap(),
+            Some(&HashMap::new()),
+        )
+        .unwrap();
+
+    assert_eq!(prefix, "curvine$uri:/tenant/data/db");
+}
+
+#[test]
+fn curvine_provider_prefix_uses_cluster_identity_not_raw_conf_path() {
+    let mut conf = tempfile::NamedTempFile::new().unwrap();
+    writeln!(
+        conf,
+        r#"
+[client]
+master_addrs = [
+    {{ hostname = "10.0.0.1", port = 8995 }},
+    {{ hostname = "10.0.0.2", port = 8995 }},
+]
+"#
+    )
+    .unwrap();
+    let conf_path = conf.path().to_string_lossy().to_string();
+    let mut storage_options = HashMap::new();
+    storage_options.insert(CURVINE_CONF_FILE_KEY.to_string(), conf_path.clone());
+
+    let provider = CurvineObjectStoreProvider::new();
+    let prefix = provider
+        .calculate_object_store_prefix(
+            &Url::parse("curvine:///tmp/lancedb/demo").unwrap(),
+            Some(&storage_options),
+        )
+        .unwrap();
+
+    assert_eq!(prefix, "curvine$masters:10.0.0.1:8995,10.0.0.2:8995");
+    assert!(
+        !prefix.contains(&conf_path),
+        "store prefix must not embed raw config path: {prefix}"
+    );
 }
 
 #[tokio::test]

--- a/curvine-lancedb-rs/tests/facade_compat.rs
+++ b/curvine-lancedb-rs/tests/facade_compat.rs
@@ -20,9 +20,10 @@ use curvine_common::conf::ClusterConf;
 use lancedb::connect;
 use lancedb::connect_namespace;
 use lancedb::error::Error as LanceDbError;
-use lancedb::object_store::{curvine_registry, curvine_session};
-use lancedb::{ObjectStoreRegistry, Session};
+use lancedb::object_store::{curvine_registry, curvine_session, CurvineObjectStoreProvider};
+use lancedb::{ObjectStoreProvider, ObjectStoreRegistry, Session};
 use tokio::sync::Mutex;
+use url::Url;
 
 static ENV_MUTEX: Mutex<()> = Mutex::const_new(());
 
@@ -45,6 +46,21 @@ fn curvine_registry_registers_curvine_scheme() {
 fn curvine_session_uses_registry_with_curvine_scheme() {
     let session = curvine_session();
     assert!(session.store_registry().get_provider("curvine").is_some());
+}
+
+#[test]
+fn curvine_provider_extracts_lance_relative_base_path() {
+    let provider = CurvineObjectStoreProvider::new();
+
+    let path = provider
+        .extract_path(&Url::parse("curvine:///tmp/lancedb/demo/table.lance").unwrap())
+        .unwrap();
+    assert_eq!(path.as_ref(), "tmp/lancedb/demo/table.lance");
+
+    let path = provider
+        .extract_path(&Url::parse("curvine://tenant/data/db").unwrap())
+        .unwrap();
+    assert_eq!(path.as_ref(), "tenant/data/db");
 }
 
 #[tokio::test]
@@ -75,6 +91,30 @@ async fn namespace_connect_stays_compatible() {
 
     let names = conn.table_names().execute().await.unwrap();
     assert!(names.is_empty());
+}
+
+#[tokio::test]
+async fn namespace_connect_clone_table_delegates_to_upstream_not_supported() {
+    let tmpdir = tempfile::tempdir().unwrap();
+    let mut properties = HashMap::new();
+    properties.insert(
+        "root".to_string(),
+        tmpdir.path().to_str().unwrap().to_string(),
+    );
+
+    let conn = connect_namespace("dir", properties)
+        .execute()
+        .await
+        .unwrap();
+    let result = conn
+        .clone_table("clone_t", "file:///tmp/source.lance")
+        .execute()
+        .await;
+
+    assert!(
+        matches!(result, Err(LanceDbError::NotSupported { .. })),
+        "namespace connections must preserve upstream clone_table unsupported semantics, got {result:?}"
+    );
 }
 
 #[tokio::test]

--- a/curvine-lancedb-rs/tests/object_store_semantics.rs
+++ b/curvine-lancedb-rs/tests/object_store_semantics.rs
@@ -10,10 +10,9 @@
 //!
 //! Covered operations: `put`, `head`, `get_opts(head=true)`, ranged `get_opts`, overwrite `put`,
 //! `copy` (source retained, destination overwritten when present), `copy_if_not_exists`,
-//! `delete`, recursive `list`, `list_with_delimiter` (directory prefix is not listed as a file
-//! object), and multipart staging invisibility / complete / abort / out-of-order completion /
-//! same-path race behavior. `PutMode::Update` remains intentionally unsupported until Curvine
-//! exposes a real conditional-write primitive beyond weak synthetic e-tags.
+//! conditional `PutMode::Update` with e-tags, `delete`, recursive `list`, `list_with_delimiter`
+//! (directory prefix is not listed as a file object), and multipart staging invisibility /
+//! complete / abort / out-of-order completion / same-path race behavior.
 
 use std::collections::HashMap;
 use std::env;
@@ -258,18 +257,77 @@ async fn curvine_object_store_semantics_live_cluster() {
         )
         .await;
     assert!(matches!(create_again, Err(OsError::AlreadyExists { .. })));
-    let update_attempt = store
+    let updated = store
         .inner
         .put_opts(
             &create_only,
             Vec::from(&b"create-v3"[..]).into(),
+            PutOptions {
+                mode: PutMode::Update(create_res.clone().into()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        store.read_one_all(&create_only).await.unwrap().as_ref(),
+        b"create-v3"
+    );
+    let stale_update = store
+        .inner
+        .put_opts(
+            &create_only,
+            Vec::from(&b"create-stale"[..]).into(),
             PutOptions {
                 mode: PutMode::Update(create_res.into()),
                 ..Default::default()
             },
         )
         .await;
-    assert!(matches!(update_attempt, Err(OsError::NotImplemented)));
+    assert!(matches!(stale_update, Err(OsError::Precondition { .. })));
+    store
+        .inner
+        .put_opts(
+            &create_only,
+            Vec::from(&b"create-v4"[..]).into(),
+            PutOptions {
+                mode: PutMode::Update(updated.clone().into()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        store.read_one_all(&create_only).await.unwrap().as_ref(),
+        b"create-v4"
+    );
+    let version_update = store
+        .inner
+        .put_opts(
+            &create_only,
+            Vec::from(&b"create-version"[..]).into(),
+            PutOptions {
+                mode: PutMode::Update(object_store::UpdateVersion {
+                    e_tag: None,
+                    version: Some("1".to_string()),
+                }),
+                ..Default::default()
+            },
+        )
+        .await;
+    assert!(matches!(version_update, Err(OsError::Generic { .. })));
+    let missing_update = store
+        .inner
+        .put_opts(
+            &Path::parse(format!("{pfx}/missing.bin")).unwrap(),
+            Vec::from(&b"missing"[..]).into(),
+            PutOptions {
+                mode: PutMode::Update(updated.into()),
+                ..Default::default()
+            },
+        )
+        .await;
+    assert!(matches!(missing_update, Err(OsError::Precondition { .. })));
 
     store.put(&key, b"overwrite").await.unwrap();
     let full = store.read_one_all(&key).await.unwrap();
@@ -489,6 +547,34 @@ async fn curvine_object_store_semantics_live_cluster() {
         store.read_one_all(&multipart_key).await.unwrap().as_ref(),
         b"hello multipart",
         "multipart complete must concatenate parts in order"
+    );
+    let mp_update = store
+        .inner
+        .put_opts(
+            &multipart_key,
+            Vec::from(&b"after multipart"[..]).into(),
+            PutOptions {
+                mode: PutMode::Update(mp_res.into()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    assert!(mp_update.e_tag.is_some());
+    assert_eq!(
+        store.read_one_all(&multipart_key).await.unwrap().as_ref(),
+        b"after multipart",
+        "multipart PutResult must be usable as an UpdateVersion"
+    );
+
+    let prefix_only = Path::parse(format!("{pfx}/prefix_only")).unwrap();
+    let prefix_child = Path::parse(format!("{pfx}/prefix_only/child.bin")).unwrap();
+    store.put(&prefix_child, b"child").await.unwrap();
+    store.inner.delete(&prefix_only).await.unwrap();
+    assert_eq!(
+        store.read_one_all(&prefix_child).await.unwrap().as_ref(),
+        b"child",
+        "deleting a directory prefix must not delete child objects"
     );
 
     let multipart_order_key = Path::parse(format!("{pfx}/multipart/out_of_order.bin")).unwrap();

--- a/curvine-tests/Cargo.toml
+++ b/curvine-tests/Cargo.toml
@@ -21,6 +21,8 @@ tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true }
 log = { workspace = true }
 futures = { workspace = true }
+lance-io = "4.0.0"
+object_store = "0.12.5"
 bytes = { workspace = true }
 once_cell = { workspace = true }
 clap = { workspace = true }
@@ -28,6 +30,7 @@ arrow-array = "57.2"
 arrow-schema = "57.2"
 awaitility = "0.4"
 tempfile = { workspace = true }
+url = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 curvine-fuse = { workspace = true }

--- a/curvine-tests/tests/common/mod.rs
+++ b/curvine-tests/tests/common/mod.rs
@@ -1,0 +1,61 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use arrow_array::RecordBatch;
+use curvine_server::test::MiniCluster;
+use curvine_tests::Testing;
+use once_cell::sync::OnceCell;
+use orpc::CommonResult;
+use tokio::runtime::Runtime;
+
+static MINICLUSTER: OnceCell<RunningMinicluster> = OnceCell::new();
+static UNIQUE_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+pub fn unique_ns() -> u128 {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let seq = UNIQUE_COUNTER.fetch_add(1, Ordering::Relaxed) as u128;
+    nanos.saturating_mul(1_000_000) + seq
+}
+
+pub struct RunningMinicluster {
+    pub _testing: Testing,
+    pub _cluster: Arc<MiniCluster>,
+    pub conf_path: String,
+}
+
+fn minicluster() -> CommonResult<&'static RunningMinicluster> {
+    MINICLUSTER.get_or_try_init(|| {
+        // This E2E binary shares one live cluster. Each test must use a unique
+        // workspace root and must not mutate cluster-global state.
+        let testing = Testing::builder().default().workers(3).build()?;
+        let cluster = testing.start_cluster()?;
+        let conf_path = testing.active_conf_path().to_string();
+        Ok(RunningMinicluster {
+            _testing: testing,
+            _cluster: cluster,
+            conf_path,
+        })
+    })
+}
+
+pub fn start_minicluster() -> CommonResult<(&'static RunningMinicluster, Runtime)> {
+    let cluster = minicluster()?;
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| orpc::CommonError::from(e.to_string()))?;
+    Ok((cluster, rt))
+}
+
+pub fn row_count(batches: &[RecordBatch]) -> usize {
+    batches.iter().map(RecordBatch::num_rows).sum()
+}

--- a/curvine-tests/tests/lancedb_object_store_e2e.rs
+++ b/curvine-tests/tests/lancedb_object_store_e2e.rs
@@ -2,39 +2,140 @@
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
+//
+//! Phase 6 — LanceDB on Curvine E2E (ListingDatabase + `curvine://` object store).
+//! 覆盖常用路径与最小向量索引路径；各用例使用独立 `curvine:///tmp/...` workspace，并通过
+//! `storage_option(CURVINE_CONF_FILE_KEY, …)` 注入配置，避免依赖进程级环境变量。
 
-use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
+mod common;
 
-use arrow_array::{Int32Array, RecordBatch};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use arrow_array::cast::AsArray;
+use arrow_array::types::{Float32Type, Float64Type, Int32Type, UInt64Type};
+use arrow_array::Array;
+use arrow_array::{
+    BooleanArray, FixedSizeListArray, Float32Array, Float64Array, Int32Array, Int64Array,
+    RecordBatch, RecordBatchIterator, RecordBatchReader, StringArray,
+};
 use arrow_schema::{DataType, Field, Schema};
-use curvine_tests::Testing;
-use futures::TryStreamExt;
+use common::{row_count, start_minicluster, unique_ns};
+use curvine_common::conf::ClusterConf;
+use futures::{stream::FuturesUnordered, TryStreamExt};
+use lance_io::object_store::{ObjectStoreParams, StorageOptionsAccessor};
 use lancedb::connect;
-use lancedb::query::ExecutableQuery;
+use lancedb::database::{CreateTableMode, ReadConsistency};
+use lancedb::error::Error as LanceDbError;
+use lancedb::expr::{col, lit};
+use lancedb::index::vector::IvfPqIndexBuilder;
+use lancedb::index::{Index, IndexType};
+use lancedb::object_store::{CurvineObjectStoreProvider, CURVINE_CONF_FILE_KEY};
+use lancedb::query::{ExecutableQuery, QueryBase, Select};
+use lancedb::table::{AddDataMode, ColumnAlteration, NewColumnTransform, OptimizeAction};
+use lancedb::{DistanceType, ObjectStoreProvider};
+use object_store::path::Path as ObjectPath;
+use object_store::{Error as ObjectStoreError, ObjectStore, PutMode, PutOptions, UpdateVersion};
 use orpc::{CommonError, CommonResult};
+use std::env;
+use url::Url;
+
+static ENV_MUTATION_LOCK: Mutex<()> = Mutex::new(());
+
+fn int32_values(batch: &RecordBatch, column: &str) -> Vec<Option<i32>> {
+    let array = batch[column].as_primitive::<Int32Type>();
+    (0..array.len())
+        .map(|i| {
+            if array.is_null(i) {
+                None
+            } else {
+                Some(array.value(i))
+            }
+        })
+        .collect()
+}
+
+fn float32_values(batch: &RecordBatch, column: &str) -> Vec<f32> {
+    let array = batch[column].as_primitive::<Float32Type>();
+    (0..array.len()).map(|i| array.value(i)).collect()
+}
+
+fn float64_values(batch: &RecordBatch, column: &str) -> Vec<f64> {
+    let array = batch[column].as_primitive::<Float64Type>();
+    (0..array.len()).map(|i| array.value(i)).collect()
+}
+
+fn bool_values(batch: &RecordBatch, column: &str) -> Vec<bool> {
+    let array = batch[column].as_boolean();
+    (0..array.len()).map(|i| array.value(i)).collect()
+}
+
+fn string_values(batch: &RecordBatch, column: &str) -> Vec<String> {
+    let array = batch[column].as_string::<i32>();
+    (0..array.len())
+        .map(|i| array.value(i).to_string())
+        .collect()
+}
+
+fn uint64_values(batch: &RecordBatch, column: &str) -> Vec<u64> {
+    let array = batch[column].as_primitive::<UInt64Type>();
+    (0..array.len()).map(|i| array.value(i)).collect()
+}
+
+fn id_age_batch(offset: i32, age: i32, rows: i32) -> Box<dyn RecordBatchReader + Send> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("age", DataType::Int32, false),
+    ]));
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(Int32Array::from_iter_values(offset..(offset + rows))),
+            Arc::new(Int32Array::from_iter_values(std::iter::repeat_n(
+                age,
+                rows as usize,
+            ))),
+        ],
+    )
+    .unwrap();
+    Box::new(RecordBatchIterator::new(vec![Ok(batch)], schema))
+}
+
+fn int32_batch(column: &str, values: Vec<i32>) -> RecordBatch {
+    let schema = Arc::new(Schema::new(vec![Field::new(
+        column,
+        DataType::Int32,
+        false,
+    )]));
+    RecordBatch::try_new(schema, vec![Arc::new(Int32Array::from(values))]).unwrap()
+}
+
+fn collect_id_age_rows(batches: &[RecordBatch]) -> Vec<(i32, i32)> {
+    let mut rows = Vec::new();
+    for batch in batches {
+        let ids = int32_values(batch, "id");
+        let ages = int32_values(batch, "age");
+        for row in 0..batch.num_rows() {
+            rows.push((
+                ids[row].expect("id is non-nullable"),
+                ages[row].expect("age is non-nullable"),
+            ));
+        }
+    }
+    rows.sort_unstable();
+    rows
+}
 
 #[test]
-fn lancedb_on_curvine_minicluster_e2e() -> CommonResult<()> {
-    let testing = Testing::builder().default().workers(3).build()?;
-    let _cluster = testing.start_cluster()?;
-    let conf_path = testing.active_conf_path().to_string();
-
-    let unique = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    let table_name = format!("lancedb_e2e_{unique}");
-    let db_uri = format!("curvine:///tmp/{table_name}");
-
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .unwrap();
-    let result: Result<(), CommonError> = rt.block_on(async move {
-        std::env::set_var(curvine_common::conf::ClusterConf::ENV_CONF_FILE, &conf_path);
-
+fn lancedb_on_curvine_minicluster_smoke_extended() -> CommonResult<()> {
+    let (cluster, rt) = start_minicluster()?;
+    let conf = cluster.conf_path.clone();
+    let ns = unique_ns();
+    rt.block_on(async move {
+        let db_uri = format!("curvine:///tmp/lancedb_smoke_{ns}");
         let conn = connect(&db_uri)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
             .execute()
             .await
             .map_err(|e| CommonError::from(e.to_string()))?;
@@ -46,7 +147,8 @@ fn lancedb_on_curvine_minicluster_e2e() -> CommonResult<()> {
         )
         .unwrap();
 
-        conn.create_table(&table_name, batch)
+        conn.create_table("smoke_tbl", batch)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
             .execute()
             .await
             .map_err(|e| CommonError::from(e.to_string()))?;
@@ -56,10 +158,11 @@ fn lancedb_on_curvine_minicluster_e2e() -> CommonResult<()> {
             .execute()
             .await
             .map_err(|e| CommonError::from(e.to_string()))?;
-        assert!(names.contains(&table_name));
+        assert!(names.contains(&"smoke_tbl".to_string()));
 
         let table = conn
-            .open_table(&table_name)
+            .open_table("smoke_tbl")
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
             .execute()
             .await
             .map_err(|e| CommonError::from(e.to_string()))?;
@@ -80,8 +183,7 @@ fn lancedb_on_curvine_minicluster_e2e() -> CommonResult<()> {
             .try_collect()
             .await
             .map_err(|e| CommonError::from(e.to_string()))?;
-        let rows: usize = batches.iter().map(RecordBatch::num_rows).sum();
-        assert_eq!(rows, 3);
+        assert_eq!(row_count(&batches), 3);
 
         let schema = Arc::new(Schema::new(vec![Field::new("v", DataType::Int32, false)]));
         let batch = RecordBatch::try_new(
@@ -102,7 +204,7 @@ fn lancedb_on_curvine_minicluster_e2e() -> CommonResult<()> {
             6
         );
 
-        conn.drop_table(&table_name, &[])
+        conn.drop_table("smoke_tbl", &[])
             .await
             .map_err(|e| CommonError::from(e.to_string()))?;
         let names_after = conn
@@ -110,17 +212,2633 @@ fn lancedb_on_curvine_minicluster_e2e() -> CommonResult<()> {
             .execute()
             .await
             .map_err(|e| CommonError::from(e.to_string()))?;
-        assert!(!names_after.contains(&table_name));
+        assert!(!names_after.contains(&"smoke_tbl".to_string()));
 
-        let reopen = conn.open_table(&table_name).execute().await;
+        let reopen = conn
+            .open_table("smoke_tbl")
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await;
+        assert!(reopen.is_err());
+
+        Ok::<(), CommonError>(())
+    })?;
+    Ok(())
+}
+
+#[test]
+fn lancedb_table_lifecycle_create_list_open_drop_errors() -> CommonResult<()> {
+    let (cluster, rt) = start_minicluster()?;
+    let conf = cluster.conf_path.clone();
+    let ns = unique_ns();
+    rt.block_on(async move {
+        let db_uri = format!("curvine:///tmp/lifecycle_{ns}");
+        let conn = connect(&db_uri)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let schema = Arc::new(Schema::new(vec![Field::new("k", DataType::Int32, false)]));
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(Int32Array::from(vec![1]))])
+            .unwrap();
+
+        conn.create_table("life_t", batch.clone())
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let dup = conn
+            .create_table("life_t", batch.clone())
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await;
         assert!(
-            reopen.is_err(),
-            "open_table should fail after drop_table, got {reopen:?}"
+            matches!(dup, Err(LanceDbError::TableAlreadyExists { .. })),
+            "expected TableAlreadyExists, got {dup:?}"
         );
 
-        Ok(())
-    });
-    result?;
+        let names = conn
+            .table_names()
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert!(names.contains(&"life_t".to_string()));
 
+        let open_bad = conn
+            .open_table("no_such_table")
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await;
+        assert!(
+            matches!(open_bad, Err(LanceDbError::TableNotFound { .. })),
+            "expected TableNotFound, got {open_bad:?}"
+        );
+
+        let drop_bad = conn.drop_table("no_such_table", &[]).await;
+        assert!(
+            drop_bad.is_ok() || matches!(drop_bad, Err(LanceDbError::TableNotFound { .. })),
+            "drop missing table: expected Ok (idempotent) or TableNotFound, got {drop_bad:?}"
+        );
+
+        conn.drop_table("life_t", &[])
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        conn.create_table("life_t", batch)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let t = conn
+            .open_table("life_t")
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(
+            t.count_rows(None)
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            1
+        );
+
+        Ok::<(), CommonError>(())
+    })?;
+    Ok(())
+}
+
+#[test]
+fn lancedb_table_names_create_modes_and_drop_all_tables() -> CommonResult<()> {
+    let (cluster, rt) = start_minicluster()?;
+    let conf = cluster.conf_path.clone();
+    let ns = unique_ns();
+    rt.block_on(async move {
+        let db_uri = format!("curvine:///tmp/table_modes_{ns}");
+        let conn = connect(&db_uri)
+            .read_consistency_interval(Duration::from_secs(0))
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert!(matches!(
+            conn.read_consistency()
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            ReadConsistency::Strong
+        ));
+
+        let schema = Arc::new(Schema::new(vec![Field::new("x", DataType::Int32, false)]));
+        for name in ["tbl_a", "tbl_b", "tbl_c", "tbl_d"] {
+            conn.create_empty_table(name, schema.clone())
+                .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+                .execute()
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?;
+        }
+
+        assert_eq!(
+            conn.table_names()
+                .limit(2)
+                .execute()
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            vec!["tbl_a".to_string(), "tbl_b".to_string()]
+        );
+        assert_eq!(
+            conn.table_names()
+                .start_after("tbl_b")
+                .limit(2)
+                .execute()
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            vec!["tbl_c".to_string(), "tbl_d".to_string()]
+        );
+
+        let existing = conn
+            .create_empty_table("tbl_a", schema.clone())
+            .mode(CreateTableMode::exist_ok(|request| request))
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(
+            existing
+                .count_rows(None)
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            0
+        );
+
+        conn.create_table("tbl_b", int32_batch("x", vec![9, 10]))
+            .mode(CreateTableMode::Overwrite)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let overwritten = conn
+            .open_table("tbl_b")
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(
+            overwritten
+                .count_rows(None)
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            2
+        );
+
+        conn.drop_all_tables(&[])
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert!(conn
+            .table_names()
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .is_empty());
+        let reopened = connect(&db_uri)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert!(reopened
+            .table_names()
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .is_empty());
+
+        Ok::<(), CommonError>(())
+    })?;
+    Ok(())
+}
+
+#[test]
+fn lancedb_clone_table_shallow_clone_roundtrip() -> CommonResult<()> {
+    let (cluster, rt) = start_minicluster()?;
+    let conf = cluster.conf_path.clone();
+    let ns = unique_ns();
+    rt.block_on(async move {
+        let db_uri = format!("curvine:///tmp/clone_{ns}");
+        let conn = connect(&db_uri)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let empty = conn
+            .create_empty_table("empty_t", schema.clone())
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(
+            empty
+                .count_rows(None)
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            0
+        );
+        empty
+            .add(int32_batch("id", vec![1, 2, 3]))
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(
+            empty
+                .count_rows(None)
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            3
+        );
+
+        let source = conn
+            .create_table("source_t", int32_batch("id", vec![10, 20, 30]))
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let source_uri = source
+            .uri()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let cloned = conn
+            .clone_table("clone_t", source_uri)
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(
+            cloned
+                .count_rows(None)
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            3
+        );
+        cloned
+            .add(int32_batch("id", vec![40]))
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(
+            cloned
+                .count_rows(None)
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            4
+        );
+        assert_eq!(
+            source
+                .count_rows(None)
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            3
+        );
+
+        let names = conn
+            .table_names()
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert!(names.contains(&"empty_t".to_string()));
+        assert!(names.contains(&"source_t".to_string()));
+        assert!(names.contains(&"clone_t".to_string()));
+
+        let reopened = connect(&db_uri)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let reopened_clone = reopened
+            .open_table("clone_t")
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(
+            reopened_clone
+                .count_rows(None)
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            4
+        );
+        let reopened_source = reopened
+            .open_table("source_t")
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(
+            reopened_source
+                .count_rows(None)
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            3
+        );
+
+        Ok::<(), CommonError>(())
+    })?;
+    Ok(())
+}
+
+#[test]
+fn lancedb_clone_table_shallow_clone_source_refs() -> CommonResult<()> {
+    let (cluster, rt) = start_minicluster()?;
+    let conf = cluster.conf_path.clone();
+    let ns = unique_ns();
+    rt.block_on(async move {
+        let db_uri = format!("curvine:///tmp/clone_refs_{ns}");
+        let conn = connect(&db_uri)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let source = conn
+            .create_table("source_t", int32_batch("id", vec![1, 2]))
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let v1 = source
+            .version()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        source
+            .add(int32_batch("id", vec![3, 4]))
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let v2 = source
+            .version()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        {
+            let mut tags = source
+                .tags()
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?;
+            tags.create("v1", v1)
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?;
+        }
+        source
+            .add(int32_batch("id", vec![5, 6]))
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(
+            source
+                .count_rows(None)
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            6
+        );
+
+        let source_uri = source
+            .uri()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let cloned_v1 = conn
+            .clone_table("clone_v1", source_uri.clone())
+            .source_version(v1)
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(
+            cloned_v1
+                .count_rows(None)
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            2
+        );
+
+        let cloned_tag = conn
+            .clone_table("clone_tag", source_uri.clone())
+            .source_tag("v1")
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(
+            cloned_tag
+                .count_rows(None)
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            2
+        );
+
+        let cloned_v2 = conn
+            .clone_table("clone_v2", source_uri.clone())
+            .source_version(v2)
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(
+            cloned_v2
+                .count_rows(None)
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            4
+        );
+
+        let both_ref_err = conn
+            .clone_table("clone_both_ref", source_uri)
+            .source_version(v1)
+            .source_tag("v1")
+            .execute()
+            .await;
+        assert!(
+            matches!(both_ref_err, Err(LanceDbError::InvalidInput { .. })),
+            "clone_table with source_version and source_tag should fail before writing target, got {both_ref_err:?}"
+        );
+        let names = conn
+            .table_names()
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert!(!names.contains(&"clone_both_ref".to_string()));
+
+        Ok::<(), CommonError>(())
+    })?;
+    Ok(())
+}
+
+#[test]
+fn lancedb_listing_database_unsupported_clone_and_rename_semantics() -> CommonResult<()> {
+    let (cluster, rt) = start_minicluster()?;
+    let conf = cluster.conf_path.clone();
+    let ns = unique_ns();
+    rt.block_on(async move {
+        let db_uri = format!("curvine:///tmp/unsupported_listing_{ns}");
+        let conn = connect(&db_uri)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let table = conn
+            .create_table("source_t", int32_batch("id", vec![1, 2]))
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let source_uri = table
+            .uri()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let deep_clone = conn
+            .clone_table("deep_clone_t", source_uri.clone())
+            .is_shallow(false)
+            .execute()
+            .await;
+        assert!(
+            matches!(deep_clone, Err(LanceDbError::NotSupported { .. })),
+            "deep clone should be explicitly unsupported by upstream ListingDatabase, got {deep_clone:?}"
+        );
+
+        let namespace_clone = conn
+            .clone_table("namespace_clone_t", source_uri)
+            .target_namespace(vec!["ns".to_string()])
+            .execute()
+            .await;
+        assert!(
+            matches!(namespace_clone, Err(LanceDbError::NotSupported { .. })),
+            "clone into namespace should be explicitly unsupported by upstream ListingDatabase, got {namespace_clone:?}"
+        );
+
+        let rename = conn.rename_table("source_t", "renamed_t", &[], &[]).await;
+        assert!(
+            matches!(rename, Err(LanceDbError::NotSupported { .. })),
+            "rename_table should be explicitly unsupported by LanceDB OSS ListingDatabase, got {rename:?}"
+        );
+        let names = conn
+            .table_names()
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert!(names.contains(&"source_t".to_string()));
+        assert!(!names.contains(&"deep_clone_t".to_string()));
+        assert!(!names.contains(&"namespace_clone_t".to_string()));
+        assert!(!names.contains(&"renamed_t".to_string()));
+
+        Ok::<(), CommonError>(())
+    })?;
+    Ok(())
+}
+
+#[test]
+fn lancedb_write_append_multiple_batches_and_schema_mismatch() -> CommonResult<()> {
+    let (cluster, rt) = start_minicluster()?;
+    let conf = cluster.conf_path.clone();
+    let ns = unique_ns();
+    rt.block_on(async move {
+        let db_uri = format!("curvine:///tmp/write_{ns}");
+        let conn = connect(&db_uri)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let b1 = RecordBatch::try_new(schema.clone(), vec![Arc::new(Int32Array::from(vec![1, 2]))])
+            .unwrap();
+        let b2 = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![3, 4, 5]))],
+        )
+        .unwrap();
+
+        let table = conn
+            .create_table("w_t", b1)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        table
+            .add(b2)
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(
+            table
+                .count_rows(None)
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            5
+        );
+
+        let bad_schema = Arc::new(Schema::new(vec![Field::new(
+            "other",
+            DataType::Int64,
+            false,
+        )]));
+        let bad_batch =
+            RecordBatch::try_new(bad_schema, vec![Arc::new(Int64Array::from(vec![1_i64]))])
+                .unwrap();
+        let bad_add = table.add(bad_batch).execute().await;
+        assert!(
+            bad_add.is_err(),
+            "schema mismatch add should fail: {bad_add:?}"
+        );
+
+        Ok::<(), CommonError>(())
+    })?;
+    Ok(())
+}
+
+#[test]
+fn lancedb_write_empty_initial_table_has_zero_rows() -> CommonResult<()> {
+    let (cluster, rt) = start_minicluster()?;
+    let conf = cluster.conf_path.clone();
+    let ns = unique_ns();
+    rt.block_on(async move {
+        let db_uri = format!("curvine:///tmp/empty_{ns}");
+        let conn = connect(&db_uri)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let empty =
+            RecordBatch::try_new(schema, vec![Arc::new(Int32Array::from(Vec::<i32>::new()))])
+                .unwrap();
+        let r = conn
+            .create_table("empty_t", empty)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(
+            r.count_rows(None)
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            0
+        );
+
+        Ok::<(), CommonError>(())
+    })?;
+    Ok(())
+}
+
+#[test]
+fn lancedb_add_overwrite_replaces_existing_rows() -> CommonResult<()> {
+    let (cluster, rt) = start_minicluster()?;
+    let conf = cluster.conf_path.clone();
+    let ns = unique_ns();
+    rt.block_on(async move {
+        let db_uri = format!("curvine:///tmp/overwrite_{ns}");
+        let conn = connect(&db_uri)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let initial = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )
+        .unwrap();
+        let table = conn
+            .create_table("overwrite_t", initial)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let replacement =
+            RecordBatch::try_new(schema, vec![Arc::new(Int32Array::from(vec![9]))]).unwrap();
+        table
+            .add(replacement)
+            .mode(AddDataMode::Overwrite)
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        assert_eq!(
+            table
+                .count_rows(None)
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            1
+        );
+        let batches: Vec<RecordBatch> = table
+            .query()
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .try_collect()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let ids: Vec<i32> = batches
+            .iter()
+            .flat_map(|batch| int32_values(batch, "id"))
+            .flatten()
+            .collect();
+        assert_eq!(ids, vec![9]);
+
+        Ok::<(), CommonError>(())
+    })?;
+    Ok(())
+}
+
+#[test]
+fn lancedb_update_delete_and_merge_insert_semantics() -> CommonResult<()> {
+    let (cluster, rt) = start_minicluster()?;
+    let conf = cluster.conf_path.clone();
+    let ns = unique_ns();
+    rt.block_on(async move {
+        let db_uri = format!("curvine:///tmp/mutation_{ns}");
+        let conn = connect(&db_uri)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let table = conn
+            .create_table("mutation_t", id_age_batch(0, 0, 10))
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let update = table
+            .update()
+            .only_if("id < 3")
+            .column("age", "age + 10")
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(update.rows_updated, 3);
+        assert!(update.version > 0);
+        assert_eq!(
+            table
+                .count_rows(Some("age = 10".to_string()))
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            3
+        );
+
+        let delete = table
+            .delete("id >= 8")
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(delete.num_deleted_rows, 2);
+        assert_eq!(
+            table
+                .count_rows(None)
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            8
+        );
+
+        let mut insert_only = table.merge_insert(&["id"]);
+        insert_only.when_not_matched_insert_all();
+        let inserted = insert_only
+            .execute(id_age_batch(5, 20, 10))
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(inserted.num_inserted_rows, 7);
+        assert_eq!(inserted.num_updated_rows, 0);
+        assert_eq!(inserted.num_deleted_rows, 0);
+        assert_eq!(
+            table
+                .count_rows(None)
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            15
+        );
+
+        let mut update_only = table.merge_insert(&["id"]);
+        update_only.when_matched_update_all(Some("target.age = 0".to_string()));
+        let updated = update_only
+            .execute(id_age_batch(3, 30, 6))
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(updated.num_updated_rows, 5);
+        assert_eq!(updated.num_inserted_rows, 0);
+        assert_eq!(
+            table
+                .count_rows(Some("age = 30".to_string()))
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            5
+        );
+
+        let mut replace_subset = table.merge_insert(&["id"]);
+        replace_subset
+            .when_matched_update_all(None)
+            .when_not_matched_insert_all()
+            .when_not_matched_by_source_delete(Some("id >= 10".to_string()));
+        let replaced = replace_subset
+            .execute(id_age_batch(10, 40, 2))
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(replaced.num_updated_rows, 2);
+        assert_eq!(replaced.num_deleted_rows, 3);
+        assert_eq!(
+            table
+                .count_rows(Some("id >= 10".to_string()))
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            2
+        );
+        assert_eq!(
+            table
+                .count_rows(Some("age = 40".to_string()))
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            2
+        );
+        let batches: Vec<RecordBatch> = table
+            .query()
+            .select(Select::columns(&["id", "age"]))
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .try_collect()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let rows = collect_id_age_rows(&batches);
+        assert_eq!(rows.len(), 12);
+        assert!(rows.contains(&(0, 10)));
+        assert!(rows.contains(&(3, 30)));
+        assert!(rows.contains(&(10, 40)));
+        assert!(rows.contains(&(11, 40)));
+        assert!(!rows.iter().any(|(id, _)| *id >= 12));
+
+        let reopened = connect(&db_uri)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .open_table("mutation_t")
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(
+            reopened
+                .count_rows(None)
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            12
+        );
+        assert_eq!(
+            reopened
+                .count_rows(Some("age = 40".to_string()))
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            2
+        );
+
+        Ok::<(), CommonError>(())
+    })?;
+    Ok(())
+}
+
+#[test]
+fn curvine_object_store_put_update_conditional_etag_semantics() -> CommonResult<()> {
+    let (cluster, rt) = start_minicluster()?;
+    let conf = cluster.conf_path.clone();
+    let ns = unique_ns();
+    rt.block_on(async move {
+        let mut opts = HashMap::new();
+        opts.insert(CURVINE_CONF_FILE_KEY.to_string(), conf);
+        let params = ObjectStoreParams {
+            storage_options_accessor: Some(Arc::new(StorageOptionsAccessor::with_static_options(
+                opts,
+            ))),
+            ..Default::default()
+        };
+        let provider = CurvineObjectStoreProvider::new();
+        let store = provider
+            .new_store(
+                Url::parse(&format!("curvine:///tmp/put_update_{ns}")).unwrap(),
+                &params,
+            )
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let key = ObjectPath::parse(format!("obj_{ns}.bin")).unwrap();
+        let created = store
+            .inner
+            .put_opts(
+                &key,
+                Vec::from(&b"v1"[..]).into(),
+                PutOptions {
+                    mode: PutMode::Create,
+                    ..Default::default()
+                },
+            )
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert!(created.e_tag.is_some());
+
+        let updated = store
+            .inner
+            .put_opts(
+                &key,
+                Vec::from(&b"v2"[..]).into(),
+                PutOptions {
+                    mode: PutMode::Update(created.clone().into()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_ne!(updated.e_tag, created.e_tag);
+        assert_eq!(
+            store
+                .inner
+                .get(&key)
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?
+                .bytes()
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?
+                .as_ref(),
+            b"v2"
+        );
+
+        let stale = store
+            .inner
+            .put_opts(
+                &key,
+                Vec::from(&b"stale"[..]).into(),
+                PutOptions {
+                    mode: PutMode::Update(created.into()),
+                    ..Default::default()
+                },
+            )
+            .await;
+        assert!(
+            matches!(stale, Err(ObjectStoreError::Precondition { .. })),
+            "stale PutMode::Update must not overwrite the current object, got {stale:?}"
+        );
+        let missing = store
+            .inner
+            .put_opts(
+                &ObjectPath::parse(format!("missing_{ns}.bin")).unwrap(),
+                Vec::from(&b"missing"[..]).into(),
+                PutOptions {
+                    mode: PutMode::Update(updated.clone().into()),
+                    ..Default::default()
+                },
+            )
+            .await;
+        assert!(
+            matches!(missing, Err(ObjectStoreError::Precondition { .. })),
+            "conditional update of a missing object must report Precondition, got {missing:?}"
+        );
+        let version_only = store
+            .inner
+            .put_opts(
+                &key,
+                Vec::from(&b"version-only"[..]).into(),
+                PutOptions {
+                    mode: PutMode::Update(UpdateVersion {
+                        e_tag: None,
+                        version: Some("1".to_string()),
+                    }),
+                    ..Default::default()
+                },
+            )
+            .await;
+        assert!(
+            matches!(version_only, Err(ObjectStoreError::Generic { .. })),
+            "Curvine exposes e_tag but no object version, got {version_only:?}"
+        );
+        assert_eq!(
+            store
+                .inner
+                .get(&key)
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?
+                .bytes()
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?
+                .as_ref(),
+            b"v2"
+        );
+
+        Ok::<(), CommonError>(())
+    })?;
+    Ok(())
+}
+
+#[test]
+fn curvine_object_store_put_update_concurrent_retries_preserve_all_writes() -> CommonResult<()> {
+    let (cluster, rt) = start_minicluster()?;
+    let conf = cluster.conf_path.clone();
+    let ns = unique_ns();
+    rt.block_on(async move {
+        const WORKERS: usize = 5;
+        const INCREMENTS: usize = 10;
+
+        let mut opts = HashMap::new();
+        opts.insert(CURVINE_CONF_FILE_KEY.to_string(), conf);
+        let params = ObjectStoreParams {
+            storage_options_accessor: Some(Arc::new(StorageOptionsAccessor::with_static_options(
+                opts,
+            ))),
+            ..Default::default()
+        };
+        let provider = CurvineObjectStoreProvider::new();
+        let store = provider
+            .new_store(
+                Url::parse(&format!("curvine:///tmp/put_update_race_{ns}")).unwrap(),
+                &params,
+            )
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .inner;
+        let key = ObjectPath::parse(format!("counter_{ns}.txt")).unwrap();
+
+        let mut tasks = (0..WORKERS)
+            .map(|_| {
+                let store = Arc::clone(&store);
+                let key = key.clone();
+                async move {
+                    for _ in 0..INCREMENTS {
+                        loop {
+                            match store.get(&key).await {
+                                Ok(result) => {
+                                    let version = UpdateVersion {
+                                        e_tag: result.meta.e_tag.clone(),
+                                        version: result.meta.version.clone(),
+                                    };
+                                    let bytes = result.bytes().await?;
+                                    let value = std::str::from_utf8(bytes.as_ref())
+                                        .map_err(|source| ObjectStoreError::Generic {
+                                            store: "curvine-test",
+                                            source: Box::new(source),
+                                        })?
+                                        .parse::<usize>()
+                                        .map_err(|source| ObjectStoreError::Generic {
+                                            store: "curvine-test",
+                                            source: Box::new(source),
+                                        })?;
+                                    let next = (value + 1).to_string();
+                                    match store
+                                        .put_opts(
+                                            &key,
+                                            next.into_bytes().into(),
+                                            PutOptions {
+                                                mode: PutMode::Update(version),
+                                                ..Default::default()
+                                            },
+                                        )
+                                        .await
+                                    {
+                                        Ok(_) => break,
+                                        Err(ObjectStoreError::Precondition { .. }) => continue,
+                                        Err(err) => return Err(err),
+                                    }
+                                }
+                                Err(ObjectStoreError::NotFound { .. }) => {
+                                    match store
+                                        .put_opts(
+                                            &key,
+                                            Vec::from(&b"1"[..]).into(),
+                                            PutOptions {
+                                                mode: PutMode::Create,
+                                                ..Default::default()
+                                            },
+                                        )
+                                        .await
+                                    {
+                                        Ok(_) => break,
+                                        Err(ObjectStoreError::AlreadyExists { .. }) => continue,
+                                        Err(err) => return Err(err),
+                                    }
+                                }
+                                Err(err) => return Err(err),
+                            }
+                        }
+                    }
+                    Ok::<(), ObjectStoreError>(())
+                }
+            })
+            .collect::<FuturesUnordered<_>>();
+
+        while tasks
+            .try_next()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .is_some()
+        {}
+
+        let bytes = store
+            .get(&key)
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .bytes()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let final_value = std::str::from_utf8(bytes.as_ref())
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .parse::<usize>()
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(final_value, WORKERS * INCREMENTS);
+
+        Ok::<(), CommonError>(())
+    })?;
+    Ok(())
+}
+
+#[test]
+fn lancedb_stale_table_handle_append_rebases_on_curvine() -> CommonResult<()> {
+    let (cluster, rt) = start_minicluster()?;
+    let conf = cluster.conf_path.clone();
+    let ns = unique_ns();
+    rt.block_on(async move {
+        let db_uri = format!("curvine:///tmp/concurrent_append_{ns}");
+        let conn = connect(&db_uri)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        conn.create_table("append_t", int32_batch("id", vec![0]))
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let t1 = connect(&db_uri)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .open_table("append_t")
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let t2 = connect(&db_uri)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .open_table("append_t")
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let initial_v1 = t1
+            .version()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let initial_v2 = t2
+            .version()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(initial_v1, initial_v2);
+
+        t1.add(int32_batch("id", vec![1]))
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        t2.add(int32_batch("id", vec![2]))
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let reopened = connect(&db_uri)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .open_table("append_t")
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(
+            reopened
+                .count_rows(None)
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            3
+        );
+        let batches: Vec<RecordBatch> = reopened
+            .query()
+            .select(Select::columns(&["id"]))
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .try_collect()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let mut ids = batches
+            .iter()
+            .flat_map(|batch| int32_values(batch, "id"))
+            .flatten()
+            .collect::<Vec<_>>();
+        ids.sort_unstable();
+        assert_eq!(ids, vec![0, 1, 2]);
+
+        Ok::<(), CommonError>(())
+    })?;
+    Ok(())
+}
+
+#[test]
+fn lancedb_query_limit_select_filter() -> CommonResult<()> {
+    let (cluster, rt) = start_minicluster()?;
+    let conf = cluster.conf_path.clone();
+    let ns = unique_ns();
+    rt.block_on(async move {
+        let db_uri = format!("curvine:///tmp/query_{ns}");
+        let conn = connect(&db_uri)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("score", DataType::Int32, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5])),
+                Arc::new(Int32Array::from(vec![10, 20, 30, 40, 50])),
+            ],
+        )
+        .unwrap();
+
+        let table = conn
+            .create_table("q_t", batch)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let stream = table
+            .query()
+            .limit(2)
+            .select(Select::columns(&["id"]))
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let batches: Vec<RecordBatch> = stream
+            .try_collect()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(row_count(&batches), 2);
+        assert!(batches.iter().all(|batch| batch.num_columns() == 1));
+        assert!(batches
+            .iter()
+            .all(|batch| batch.schema().field(0).name() == "id"));
+        let limited_ids: Vec<i32> = batches
+            .iter()
+            .flat_map(|batch| int32_values(batch, "id"))
+            .flatten()
+            .collect();
+        assert_eq!(limited_ids.len(), 2);
+        assert!(limited_ids.iter().all(|id| (1..=5).contains(id)));
+
+        let stream = table
+            .query()
+            .only_if("score >= 30")
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let batches: Vec<RecordBatch> = stream
+            .try_collect()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(row_count(&batches), 3);
+        let mut ids: Vec<i32> = batches
+            .iter()
+            .flat_map(|batch| int32_values(batch, "id"))
+            .flatten()
+            .collect();
+        ids.sort_unstable();
+        assert_eq!(ids, vec![3, 4, 5]);
+
+        Ok::<(), CommonError>(())
+    })?;
+    Ok(())
+}
+
+#[test]
+fn lancedb_query_offset_dynamic_expr_and_plans() -> CommonResult<()> {
+    let (cluster, rt) = start_minicluster()?;
+    let conf = cluster.conf_path.clone();
+    let ns = unique_ns();
+    rt.block_on(async move {
+        let db_uri = format!("curvine:///tmp/query_expr_{ns}");
+        let conn = connect(&db_uri)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("score", DataType::Int32, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from_iter_values(0..6)),
+                Arc::new(Int32Array::from(vec![0, 10, 20, 30, 40, 50])),
+            ],
+        )
+        .unwrap();
+        let table = conn
+            .create_table("query_expr_t", batch)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let full_batches: Vec<RecordBatch> = table
+            .query()
+            .select(Select::columns(&["id"]))
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .try_collect()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let full_ids: Vec<i32> = full_batches
+            .iter()
+            .flat_map(|batch| int32_values(batch, "id"))
+            .flatten()
+            .collect();
+        assert_eq!(full_ids.len(), 6);
+
+        let batches: Vec<RecordBatch> = table
+            .query()
+            .offset(2)
+            .limit(2)
+            .select(Select::columns(&["id"]))
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .try_collect()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(row_count(&batches), 2);
+        let offset_ids: Vec<i32> = batches
+            .iter()
+            .flat_map(|batch| int32_values(batch, "id"))
+            .flatten()
+            .collect();
+        assert_eq!(offset_ids, full_ids[2..4]);
+
+        let batches: Vec<RecordBatch> = table
+            .query()
+            .select(Select::dynamic(&[("double_score", "score * 2")]))
+            .only_if("id >= 3")
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .try_collect()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let mut doubled: Vec<i32> = batches
+            .iter()
+            .flat_map(|batch| int32_values(batch, "double_score"))
+            .flatten()
+            .collect();
+        doubled.sort_unstable();
+        assert_eq!(doubled, vec![60, 80, 100]);
+
+        let batches: Vec<RecordBatch> = table
+            .query()
+            .only_if_expr(col("score").gt(lit(20)))
+            .select(Select::expr_projection(&[
+                ("id", col("id")),
+                ("score_plus_one", col("score") + lit(1)),
+            ]))
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .try_collect()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let mut rows = Vec::new();
+        for batch in &batches {
+            let ids = int32_values(batch, "id");
+            let scores = int32_values(batch, "score_plus_one");
+            for row in 0..batch.num_rows() {
+                rows.push((
+                    ids[row].expect("id is non-nullable"),
+                    scores[row].expect("score_plus_one is non-nullable"),
+                ));
+            }
+        }
+        rows.sort_unstable();
+        assert_eq!(rows, vec![(3, 31), (4, 41), (5, 51)]);
+
+        let plan = table
+            .query()
+            .only_if("score >= 30")
+            .explain_plan(true)
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert!(!plan.trim().is_empty(), "empty explain plan");
+        let analyzed = table
+            .query()
+            .only_if("score >= 30")
+            .analyze_plan()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert!(!analyzed.trim().is_empty(), "empty analyzed plan");
+
+        Ok::<(), CommonError>(())
+    })?;
+    Ok(())
+}
+
+#[test]
+fn lancedb_take_offsets_row_ids_and_table_metadata() -> CommonResult<()> {
+    let (cluster, rt) = start_minicluster()?;
+    let conf = cluster.conf_path.clone();
+    let ns = unique_ns();
+    rt.block_on(async move {
+        let db_uri = format!("curvine:///tmp/take_meta_{ns}");
+        let conn = connect(&db_uri)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let table = conn
+            .create_table("take_t", id_age_batch(0, 7, 6))
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(table.name(), "take_t");
+        assert_eq!(table.namespace(), &[] as &[String]);
+        assert!(table.id().contains("take_t"));
+        assert!(table
+            .uri()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .contains("take_t"));
+        let initial_options = table
+            .initial_storage_options()
+            .await
+            .expect("storage options should be retained");
+        assert_eq!(initial_options.get(CURVINE_CONF_FILE_KEY), Some(&conf));
+        let latest_options = table
+            .latest_storage_options()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .expect("latest storage options should be retained");
+        assert_eq!(latest_options.get(CURVINE_CONF_FILE_KEY), Some(&conf));
+
+        let offset_batches: Vec<RecordBatch> = table
+            .take_offsets(vec![1, 4])
+            .select(Select::columns(&["id"]))
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .try_collect()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let mut offset_ids: Vec<i32> = offset_batches
+            .iter()
+            .flat_map(|batch| int32_values(batch, "id"))
+            .flatten()
+            .collect();
+        offset_ids.sort_unstable();
+        assert_eq!(offset_ids, vec![1, 4]);
+
+        let row_id_batches: Vec<RecordBatch> = table
+            .query()
+            .with_row_id()
+            .select(Select::columns(&["id"]))
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .try_collect()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let mut target_row_ids = Vec::new();
+        for batch in &row_id_batches {
+            let ids = int32_values(batch, "id");
+            let row_ids = uint64_values(batch, "_rowid");
+            for row in 0..batch.num_rows() {
+                if ids[row] == Some(2) || ids[row] == Some(5) {
+                    target_row_ids.push(row_ids[row]);
+                }
+            }
+        }
+        assert_eq!(target_row_ids.len(), 2);
+
+        let taken_by_row_id: Vec<RecordBatch> = table
+            .take_row_ids(target_row_ids)
+            .select(Select::columns(&["id"]))
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .try_collect()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let mut ids: Vec<i32> = taken_by_row_id
+            .iter()
+            .flat_map(|batch| int32_values(batch, "id"))
+            .flatten()
+            .collect();
+        ids.sort_unstable();
+        assert_eq!(ids, vec![2, 5]);
+
+        let stats = table
+            .stats()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(stats.num_rows, 6);
+        assert!(stats.total_bytes > 0);
+        assert_eq!(stats.num_indices, 0);
+
+        Ok::<(), CommonError>(())
+    })?;
+    Ok(())
+}
+
+#[test]
+fn lancedb_schema_mixed_types_roundtrip() -> CommonResult<()> {
+    let (cluster, rt) = start_minicluster()?;
+    let conf = cluster.conf_path.clone();
+    let ns = unique_ns();
+    rt.block_on(async move {
+        let db_uri = format!("curvine:///tmp/mixed_{ns}");
+        let conn = connect(&db_uri)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("label", DataType::Utf8, false),
+            Field::new("f32", DataType::Float32, false),
+            Field::new("f64", DataType::Float64, false),
+            Field::new("flag", DataType::Boolean, false),
+            Field::new("opt_i", DataType::Int32, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2])),
+                Arc::new(StringArray::from(vec!["a", "b"])),
+                Arc::new(Float32Array::from(vec![1.5_f32, 2.5])),
+                Arc::new(Float64Array::from(vec![10.1_f64, 20.2])),
+                Arc::new(BooleanArray::from(vec![true, false])),
+                Arc::new(Int32Array::from(vec![Some(7), None])),
+            ],
+        )
+        .unwrap();
+
+        let table = conn
+            .create_table("mix_t", batch)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let stream = table
+            .query()
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let batches: Vec<RecordBatch> = stream
+            .try_collect()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(row_count(&batches), 2);
+        let mut rows = Vec::new();
+        for batch in &batches {
+            let ids = int32_values(batch, "id");
+            let labels = string_values(batch, "label");
+            let f32s = float32_values(batch, "f32");
+            let f64s = float64_values(batch, "f64");
+            let flags = bool_values(batch, "flag");
+            let opt_is = int32_values(batch, "opt_i");
+            for row in 0..batch.num_rows() {
+                rows.push((
+                    ids[row].expect("id is non-nullable"),
+                    labels[row].clone(),
+                    f32s[row],
+                    f64s[row],
+                    flags[row],
+                    opt_is[row],
+                ));
+            }
+        }
+        rows.sort_by_key(|row| row.0);
+        assert_eq!(
+            rows,
+            vec![
+                (1, "a".to_string(), 1.5_f32, 10.1_f64, true, Some(7)),
+                (2, "b".to_string(), 2.5_f32, 20.2_f64, false, None),
+            ]
+        );
+
+        Ok::<(), CommonError>(())
+    })?;
+    Ok(())
+}
+
+#[test]
+fn lancedb_schema_evolution_and_versions_roundtrip() -> CommonResult<()> {
+    let (cluster, rt) = start_minicluster()?;
+    let conf = cluster.conf_path.clone();
+    let ns = unique_ns();
+    rt.block_on(async move {
+        let db_uri = format!("curvine:///tmp/schema_version_{ns}");
+        let conn = connect(&db_uri)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("score", DataType::Int32, false),
+            Field::new("drop_me", DataType::Int32, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                Arc::new(Int32Array::from(vec![10, 20, 30])),
+                Arc::new(Int32Array::from(vec![100, 200, 300])),
+            ],
+        )
+        .unwrap();
+        let table = conn
+            .create_table("schema_t", batch)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let v1 = table
+            .version()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let add_columns = table
+            .add_columns(
+                NewColumnTransform::SqlExpressions(vec![(
+                    "double_score".into(),
+                    "score * 2".into(),
+                )]),
+                None,
+            )
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert!(add_columns.version > v1);
+
+        let alter_columns = table
+            .alter_columns(&[ColumnAlteration::new("score".into()).rename("renamed_score".into())])
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert!(alter_columns.version > add_columns.version);
+
+        let drop_columns = table
+            .drop_columns(&["drop_me"])
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert!(drop_columns.version > alter_columns.version);
+
+        let schema = table
+            .schema()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert!(schema.field_with_name("renamed_score").is_ok());
+        assert!(schema.field_with_name("double_score").is_ok());
+        assert!(schema.field_with_name("drop_me").is_err());
+
+        let batches: Vec<RecordBatch> = table
+            .query()
+            .select(Select::columns(&["id", "renamed_score", "double_score"]))
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .try_collect()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let mut rows = Vec::new();
+        for batch in &batches {
+            let ids = int32_values(batch, "id");
+            let scores = int32_values(batch, "renamed_score");
+            let doubled = int32_values(batch, "double_score");
+            for row in 0..batch.num_rows() {
+                rows.push((
+                    ids[row].expect("id is non-nullable"),
+                    scores[row].expect("renamed_score is non-nullable"),
+                    doubled[row].expect("double_score is non-nullable"),
+                ));
+            }
+        }
+        rows.sort_unstable();
+        assert_eq!(rows, vec![(1, 10, 20), (2, 20, 40), (3, 30, 60)]);
+
+        let latest = table
+            .version()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let versions = table
+            .list_versions()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert!(versions.len() >= 4);
+        table
+            .checkout(v1)
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(
+            table
+                .count_rows(None)
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            3
+        );
+        let old_schema = table
+            .schema()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert!(old_schema.field_with_name("score").is_ok());
+        assert!(old_schema.field_with_name("double_score").is_err());
+        let checked_out_write = table.update().column("score", "score + 1").execute().await;
+        assert!(
+            checked_out_write.is_err(),
+            "writes should fail while checked out to an old version"
+        );
+
+        table
+            .checkout_latest()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(
+            table
+                .version()
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            latest
+        );
+        table
+            .checkout(v1)
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        table
+            .restore()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert!(
+            table
+                .version()
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?
+                > latest
+        );
+        let restored_schema = table
+            .schema()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert!(restored_schema.field_with_name("score").is_ok());
+        assert!(restored_schema.field_with_name("double_score").is_err());
+        let reopened = connect(&db_uri)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .open_table("schema_t")
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let reopened_schema = reopened
+            .schema()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert!(reopened_schema.field_with_name("score").is_ok());
+        assert!(reopened_schema.field_with_name("double_score").is_err());
+        assert_eq!(
+            reopened
+                .count_rows(None)
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            3
+        );
+
+        Ok::<(), CommonError>(())
+    })?;
+    Ok(())
+}
+
+#[test]
+fn lancedb_tags_checkout_tag_and_reopen_persist() -> CommonResult<()> {
+    let (cluster, rt) = start_minicluster()?;
+    let conf = cluster.conf_path.clone();
+    let ns = unique_ns();
+    rt.block_on(async move {
+        let db_uri = format!("curvine:///tmp/tags_{ns}");
+        let conn = connect(&db_uri)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let table = conn
+            .create_table("tag_t", int32_batch("id", vec![1]))
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let v1 = table
+            .version()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        table
+            .add(int32_batch("id", vec![2]))
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let v2 = table
+            .version()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let mut tags = table
+            .tags()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert!(tags
+            .list()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .is_empty());
+        tags.create("initial", v1)
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        tags.create("latest", v2)
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(
+            tags.get_version("initial")
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            v1
+        );
+        table
+            .add(int32_batch("id", vec![3]))
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let v3 = table
+            .version()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        tags.update("latest", v3)
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        tags.delete("initial")
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let listed = tags
+            .list()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed.get("latest").map(|tag| tag.version), Some(v3));
+        drop(tags);
+
+        table
+            .checkout_tag("latest")
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(
+            table
+                .version()
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            v3
+        );
+        table
+            .checkout(v1)
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(
+            table
+                .count_rows(None)
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            1
+        );
+        table
+            .checkout_latest()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(
+            table
+                .count_rows(None)
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            3
+        );
+
+        let reopened = connect(&db_uri)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .open_table("tag_t")
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let reopened_tags = reopened
+            .tags()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(
+            reopened_tags
+                .get_version("latest")
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            v3
+        );
+
+        Ok::<(), CommonError>(())
+    })?;
+    Ok(())
+}
+
+#[test]
+fn lancedb_native_manifest_config_metadata_and_stats_persist() -> CommonResult<()> {
+    let (cluster, rt) = start_minicluster()?;
+    let conf = cluster.conf_path.clone();
+    let ns = unique_ns();
+    rt.block_on(async move {
+        let db_uri = format!("curvine:///tmp/native_meta_{ns}");
+        let conn = connect(&db_uri)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let table = conn
+            .create_table("native_t", id_age_batch(0, 1, 5))
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        table
+            .delete("id >= 3")
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let native = table.as_native().expect("curvine listing table is native");
+        assert!(native
+            .load_indices()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .is_empty());
+        native
+            .update_config(vec![
+                ("curvine.phase".to_string(), "phase6".to_string()),
+                ("curvine.keep".to_string(), "yes".to_string()),
+            ])
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        native
+            .delete_config_keys(&["curvine.keep"])
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let manifest = native
+            .manifest()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(
+            manifest.config.get("curvine.phase"),
+            Some(&"phase6".to_string())
+        );
+        assert!(!manifest.config.contains_key("curvine.keep"));
+
+        native
+            .replace_schema_metadata(vec![("schema.owner".to_string(), "curvine".to_string())])
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let field_id = native
+            .manifest()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .schema
+            .field("age")
+            .ok_or_else(|| CommonError::from("missing age field"))?
+            .id as u32;
+        let mut field_metadata = HashMap::new();
+        field_metadata.insert("field.role".to_string(), "metric".to_string());
+        native
+            .replace_field_metadata(vec![(field_id, field_metadata)])
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let reopened = connect(&db_uri)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .open_table("native_t")
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let reopened_native = reopened.as_native().expect("reopened table is native");
+        assert_eq!(
+            reopened_native
+                .count_deleted_rows()
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            2
+        );
+        let reopened_manifest = reopened_native
+            .manifest()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(
+            reopened_manifest.config.get("curvine.phase"),
+            Some(&"phase6".to_string())
+        );
+        assert_eq!(
+            reopened_manifest.schema.metadata.get("schema.owner"),
+            Some(&"curvine".to_string())
+        );
+        assert_eq!(
+            reopened_manifest
+                .schema
+                .field("age")
+                .ok_or_else(|| CommonError::from("missing reopened age field"))?
+                .metadata
+                .get("field.role"),
+            Some(&"metric".to_string())
+        );
+
+        Ok::<(), CommonError>(())
+    })?;
+    Ok(())
+}
+
+#[test]
+fn lancedb_drop_recreate_and_listing_clean() -> CommonResult<()> {
+    let (cluster, rt) = start_minicluster()?;
+    let conf = cluster.conf_path.clone();
+    let ns = unique_ns();
+    rt.block_on(async move {
+        let db_uri = format!("curvine:///tmp/droprec_{ns}");
+        let conn = connect(&db_uri)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let schema = Arc::new(Schema::new(vec![Field::new("x", DataType::Int32, false)]));
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(Int32Array::from(vec![1]))])
+            .unwrap();
+
+        conn.create_table("reuse_name", batch.clone())
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        conn.drop_table("reuse_name", &[])
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let names = conn
+            .table_names()
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert!(!names.contains(&"reuse_name".to_string()));
+
+        conn.create_table("reuse_name", batch)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let t = conn
+            .open_table("reuse_name")
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(
+            t.count_rows(None)
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            1
+        );
+
+        Ok::<(), CommonError>(())
+    })?;
+    Ok(())
+}
+
+#[test]
+fn lancedb_two_tables_sequential_writes_isolation() -> CommonResult<()> {
+    let (cluster, rt) = start_minicluster()?;
+    let conf = cluster.conf_path.clone();
+    let ns = unique_ns();
+    rt.block_on(async move {
+        let db_uri = format!("curvine:///tmp/iso_{ns}");
+        let conn = connect(&db_uri)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let s1 = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
+        let s2 = Arc::new(Schema::new(vec![Field::new("b", DataType::Int32, false)]));
+        let b1 =
+            RecordBatch::try_new(s1.clone(), vec![Arc::new(Int32Array::from(vec![1, 2]))]).unwrap();
+        let b2 =
+            RecordBatch::try_new(s2.clone(), vec![Arc::new(Int32Array::from(vec![100]))]).unwrap();
+
+        conn.create_table("t_a", b1)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        conn.create_table("t_b", b2)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let ta = conn
+            .open_table("t_a")
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let tb = conn
+            .open_table("t_b")
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let add_a = RecordBatch::try_new(s1, vec![Arc::new(Int32Array::from(vec![3]))]).unwrap();
+        let add_b = RecordBatch::try_new(s2, vec![Arc::new(Int32Array::from(vec![200]))]).unwrap();
+        ta.add(add_a)
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        tb.add(add_b)
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        assert_eq!(
+            ta.count_rows(None)
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            3
+        );
+        assert_eq!(
+            tb.count_rows(None)
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            2
+        );
+
+        let names = conn
+            .table_names()
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert!(names.contains(&"t_a".to_string()) && names.contains(&"t_b".to_string()));
+
+        conn.drop_table("t_a", &[])
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let tb_only = conn
+            .open_table("t_b")
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(
+            tb_only
+                .count_rows(None)
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            2
+        );
+
+        Ok::<(), CommonError>(())
+    })?;
+    Ok(())
+}
+
+#[test]
+fn lancedb_connect_curvine_without_conf_fails() -> CommonResult<()> {
+    let _guard = ENV_MUTATION_LOCK.lock().expect("poisoned lock");
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| CommonError::from(e.to_string()))?;
+    let ns = unique_ns();
+    let key = ClusterConf::ENV_CONF_FILE;
+    let saved = env::var(key).ok();
+    let _restore = RestoreEnvVar::new(key, saved);
+
+    env::remove_var(key);
+    let err = rt.block_on(async move {
+        connect(&format!("curvine:///tmp/noconf_{ns}"))
+            .execute()
+            .await
+    });
+    assert!(err.is_err(), "expected connect failure without conf");
+
+    Ok(())
+}
+
+struct RestoreEnvVar {
+    key: &'static str,
+    prev: Option<String>,
+}
+
+impl RestoreEnvVar {
+    fn new(key: &'static str, prev: Option<String>) -> Self {
+        Self { key, prev }
+    }
+}
+
+impl Drop for RestoreEnvVar {
+    fn drop(&mut self) {
+        match &self.prev {
+            Some(v) => env::set_var(self.key, v),
+            None => env::remove_var(self.key),
+        }
+    }
+}
+
+#[test]
+fn lancedb_connect_unknown_scheme_fails() -> CommonResult<()> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| CommonError::from(e.to_string()))?;
+    let err = rt.block_on(async {
+        connect("unknown-scheme-xyz://localhost/bucket/db")
+            .execute()
+            .await
+    });
+    assert!(
+        err.is_err(),
+        "expected failure for unknown object store scheme"
+    );
+    Ok(())
+}
+
+#[test]
+fn lancedb_non_root_workspace_allows_dot_curvine_segment() -> CommonResult<()> {
+    let (cluster, rt) = start_minicluster()?;
+    let conf = cluster.conf_path.clone();
+    let ns = unique_ns();
+    rt.block_on(async move {
+        let db_uri = format!("curvine:///tmp/lancedb_dot_curvine_{ns}/.curvine/user_ws");
+        let conn = connect(&db_uri)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let schema = Arc::new(Schema::new(vec![Field::new("z", DataType::Int32, false)]));
+        let name = format!("tbl_under_dot_curvine_{ns}");
+        let batch =
+            RecordBatch::try_new(schema, vec![Arc::new(Int32Array::from(vec![42]))]).unwrap();
+
+        conn.create_table(&name, batch)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let names = conn
+            .table_names()
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert!(names.contains(&name));
+
+        let t = conn
+            .open_table(&name)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(
+            t.count_rows(None)
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            1
+        );
+
+        conn.drop_table(&name, &[])
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        Ok::<(), CommonError>(())
+    })?;
+    Ok(())
+}
+
+#[test]
+fn lancedb_scalar_and_fts_indices_persist_after_reopen() -> CommonResult<()> {
+    let (cluster, rt) = start_minicluster()?;
+    let conf = cluster.conf_path.clone();
+    let ns = unique_ns();
+    rt.block_on(async move {
+        let db_uri = format!("curvine:///tmp/scalar_fts_idx_{ns}");
+        let conn = connect(&db_uri)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let rows = 120;
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("category", DataType::Utf8, true),
+            Field::new("active", DataType::Boolean, true),
+            Field::new("text", DataType::Utf8, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from_iter_values(0..rows)),
+                Arc::new(StringArray::from_iter_values(
+                    (0..rows).map(|row| format!("category_{}", row % 5)),
+                )),
+                Arc::new(BooleanArray::from_iter(
+                    (0..rows).map(|row| Some(row % 2 == 0)),
+                )),
+                Arc::new(StringArray::from_iter_values((0..rows).map(|row| {
+                    match row % 3 {
+                        0 => "cat",
+                        1 => "dog",
+                        _ => "fish",
+                    }
+                }))),
+            ],
+        )
+        .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let table = conn
+            .create_table("idx_t", batch)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        table
+            .create_index(&["id"], Index::Auto)
+            .name("id_btree_idx".to_string())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        table
+            .create_index(&["category"], Index::Bitmap(Default::default()))
+            .name("category_bitmap_idx".to_string())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        table
+            .create_index(&["text"], Index::FTS(Default::default()))
+            .name("text_fts_idx".to_string())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let reopened = connect(&db_uri)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .open_table("idx_t")
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let mut index_configs = reopened
+            .list_indices()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        index_configs.sort_by(|left, right| left.name.cmp(&right.name));
+        assert_eq!(index_configs.len(), 3);
+        assert!(index_configs.iter().any(|index| {
+            index.name == "id_btree_idx"
+                && index.index_type == IndexType::BTree
+                && index.columns == vec!["id".to_string()]
+        }));
+        assert!(index_configs.iter().any(|index| {
+            index.name == "category_bitmap_idx"
+                && index.index_type == IndexType::Bitmap
+                && index.columns == vec!["category".to_string()]
+        }));
+        assert!(index_configs.iter().any(|index| {
+            index.name == "text_fts_idx"
+                && index.index_type == IndexType::FTS
+                && index.columns == vec!["text".to_string()]
+        }));
+
+        for name in ["id_btree_idx", "category_bitmap_idx", "text_fts_idx"] {
+            let stats = reopened
+                .index_stats(name)
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?
+                .unwrap_or_else(|| panic!("missing index stats for {name}"));
+            assert_eq!(stats.num_unindexed_rows, 0);
+        }
+
+        assert_eq!(
+            reopened
+                .count_rows(Some("id >= 10 AND id < 20".to_string()))
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            10
+        );
+        assert_eq!(
+            reopened
+                .count_rows(Some("category = 'category_3'".to_string()))
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            24
+        );
+
+        Ok::<(), CommonError>(())
+    })?;
+    Ok(())
+}
+
+#[test]
+fn lancedb_vector_column_search_create_index_and_query_again() -> CommonResult<()> {
+    let (cluster, rt) = start_minicluster()?;
+    let conf = cluster.conf_path.clone();
+    let ns = unique_ns();
+    rt.block_on(async move {
+        const DIM: i32 = 8;
+        const N: usize = 256;
+        let item = Arc::new(Field::new("item", DataType::Float32, true));
+        let mut flat: Vec<f32> = Vec::with_capacity(N * DIM as usize);
+        for r in 0..N {
+            for c in 0..DIM as usize {
+                flat.push((r as f32) * 0.01 + (c as f32) * 0.001);
+            }
+        }
+        let values = Float32Array::from(flat);
+        let list = FixedSizeListArray::try_new(item.clone(), DIM, Arc::new(values), None)
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("vec", DataType::FixedSizeList(item, DIM), false),
+        ]));
+        let ids = Int32Array::from_iter_values(0..N as i32);
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(ids), Arc::new(list)])
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let db_uri = format!("curvine:///tmp/vec_idx_{ns}");
+        let conn = connect(&db_uri)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let table = conn
+            .create_table("vec_t", batch)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let qv: Vec<f32> = vec![0.0_f32, 0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007];
+        let stream = table
+            .vector_search(qv.clone())
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .limit(10)
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let before: Vec<RecordBatch> = stream
+            .try_collect()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert!(
+            row_count(&before) >= 1,
+            "vector search before index should return rows"
+        );
+        assert_nearest_vector_result(&before)?;
+
+        table
+            .create_index(&["vec"], Index::IvfPq(IvfPqIndexBuilder::default()))
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let index_configs = table
+            .list_indices()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(index_configs.len(), 1);
+        assert_eq!(index_configs[0].columns, vec!["vec".to_string()]);
+
+        let stats = table
+            .index_stats(&index_configs[0].name)
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .expect("created vector index should have stats");
+        assert_eq!(stats.distance_type, Some(DistanceType::L2));
+        let table_stats = table
+            .stats()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(table_stats.num_rows, N);
+        assert_eq!(table_stats.num_indices, 1);
+
+        let more_values =
+            Float32Array::from_iter_values((0..DIM as usize).map(|c| 9.0_f32 + (c as f32) * 0.001));
+        let more_list = FixedSizeListArray::try_new(
+            Arc::new(Field::new("item", DataType::Float32, true)),
+            DIM,
+            Arc::new(more_values),
+            None,
+        )
+        .map_err(|e| CommonError::from(e.to_string()))?;
+        let more = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("id", DataType::Int32, false),
+                Field::new(
+                    "vec",
+                    DataType::FixedSizeList(
+                        Arc::new(Field::new("item", DataType::Float32, true)),
+                        DIM,
+                    ),
+                    false,
+                ),
+            ])),
+            vec![
+                Arc::new(Int32Array::from(vec![N as i32])),
+                Arc::new(more_list),
+            ],
+        )
+        .map_err(|e| CommonError::from(e.to_string()))?;
+        table
+            .add(more)
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let unoptimized = table
+            .index_stats(&index_configs[0].name)
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .expect("index stats should remain available after append");
+        assert!(unoptimized.num_unindexed_rows > 0);
+
+        table
+            .optimize(OptimizeAction::Index(Default::default()))
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let optimized = table
+            .index_stats(&index_configs[0].name)
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .expect("index stats should remain available after optimize");
+        assert_eq!(optimized.num_unindexed_rows, 0);
+        let reopened = connect(&db_uri)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .open_table("vec_t")
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let reopened_indices = reopened
+            .list_indices()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert!(reopened_indices.iter().any(|index| {
+            index.name == index_configs[0].name && index.columns == vec!["vec".to_string()]
+        }));
+        let reopened_stats = reopened
+            .index_stats(&index_configs[0].name)
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .expect("reopened table should see persisted index stats");
+        assert_eq!(reopened_stats.num_unindexed_rows, 0);
+
+        let stream = reopened
+            .vector_search(qv.clone())
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .limit(10)
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let after: Vec<RecordBatch> = stream
+            .try_collect()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert!(
+            row_count(&after) >= 1,
+            "vector search after index should return rows"
+        );
+        assert_nearest_vector_result(&after)?;
+
+        table
+            .drop_index(&index_configs[0].name)
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(
+            table
+                .list_indices()
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?
+                .len(),
+            0
+        );
+
+        Ok::<(), CommonError>(())
+    })?;
+    Ok(())
+}
+
+fn assert_nearest_vector_result(batches: &[RecordBatch]) -> CommonResult<()> {
+    let first = batches
+        .first()
+        .ok_or_else(|| CommonError::from("vector search returned no batches"))?;
+    assert_eq!(
+        int32_values(first, "id").first().copied().flatten(),
+        Some(0)
+    );
+    let distance = float32_values(first, "_distance")
+        .first()
+        .copied()
+        .ok_or_else(|| CommonError::from("vector search returned no distance"))?;
+    assert!(
+        distance.abs() < 1.0e-6,
+        "expected nearest vector distance close to zero, got {distance}"
+    );
     Ok(())
 }


### PR DESCRIPTION
## What changed
- adds Curvine-aware shallow `clone_table` wiring for `curvine://` LanceDB databases
- supports source version and source tag resolution for shallow clone targets
- implements `PutMode::Update` with Curvine-backed conditional write locking and eTag checks
- extends object-store semantic coverage for conditional updates, multipart interactions, and missing-object behavior
- expands minicluster e2e coverage for LanceDB table lifecycle, clone-table flows, schema/version/tag behavior, and object-store conditional writes

## Why
This is PR 4 in the LanceDB on Curvine stack. It builds on PR #823 by adding the LanceDB semantics that require conditional object updates and correct URI/path handling across clone operations.

## Stack
- #799: facade scaffold, merged
- #801: object store/provider/session scaffold, merged
- #823: working Curvine object-store contract
- this PR: shallow clone and conditional write semantics

## Validation
- `cargo fmt --all`
- `cargo clippy -p curvine-lancedb-rs --all-targets --all-features -- -D warnings`
- `cargo test -p curvine-lancedb-rs`
- `cargo clippy -p curvine-tests --test lancedb_object_store_e2e -- -D warnings`