### PR TITLE
ci(release): fix Rocky9 release build for opendal-hdfs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,17 @@ jobs:
     name: Build for Rocky Linux 9
     runs-on: ubuntu-latest
     container:
-      image: curvine/curvine-compile:latest
+      image: ghcr.io/curvineio/curvine-compile:rocky9
 
     steps:
     - uses: actions/checkout@v4
+
+    # hdfs-sys (opendal-hdfs) uses java-locator which shells out to `which`
+    - name: Ensure which is available for hdfs-sys build
+      run: |
+        if ! command -v which >/dev/null 2>&1; then
+          dnf install -y which
+        fi
 
     - name: Cache cargo registry
       uses: actions/cache@v3

--- a/curvine-csi/Dockerfile
+++ b/curvine-csi/Dockerfile
@@ -41,10 +41,10 @@ RUN echo "Building Curvine from source..." && \
     mkdir -p /workspace/tmp && \
     export TMPDIR=/workspace/tmp && \
     echo "Using TMPDIR=$TMPDIR for compilation temporary files" && \
-    echo "Running 'make all' with --skip-java-sdk (CSI doesn't need Java SDK)..." && \
+    echo "Running 'make all' with --skip-java-sdk --skip-python-sdk (CSI doesn't need Java/Python SDKs)..." && \
     for attempt in 1 2 3; do \
         echo "Build attempt $attempt..." && \
-        if make all ARGS='--skip-java-sdk --ufs opendal-s3 --ufs opendal-oss --ufs opendal-azblob --ufs opendal-gcs --ufs opendal-hdfs-native --ufs oss-hdfs'; then \
+        if make all ARGS='--skip-java-sdk --skip-python-sdk --ufs opendal-s3 --ufs opendal-oss --ufs opendal-azblob --ufs opendal-gcs --ufs opendal-hdfs-native --ufs oss-hdfs'; then \
             echo "✓ Build succeeded" && \
             break; \
         else \

--- a/curvine-docker/compile/Dockerfile_rocky9
+++ b/curvine-docker/compile/Dockerfile_rocky9
@@ -27,6 +27,7 @@ RUN dnf install -y dnf-plugins-core && \
     python3 \
     python3-pip \
     java-1.8.0-openjdk-devel \
+    which \
     openssl-devel \
     libstdc++-devel \
     libstdc++-static \

--- a/curvine-docker/compile/Dockerfile_rocky9_cached
+++ b/curvine-docker/compile/Dockerfile_rocky9_cached
@@ -27,6 +27,7 @@ RUN dnf install -y dnf-plugins-core && \
     python3 \
     python3-pip \
     java-1.8.0-openjdk-devel \
+    which \
     openssl-devel \
     libstdc++-devel \
     libstdc++-static \


### PR DESCRIPTION
## Summary

- Install `which` in Rocky9 compile Dockerfiles (`hdfs-sys` / `java-locator` dependency)
- Point Release workflow at `ghcr.io/curvineio/curvine-compile:rocky9`
- Add a CI step to `dnf install which` when the image lacks it (unblocks v0.2.0 without waiting for a new compile image)

Fixes failed Release run for tag `v0.2.0`:
https://github.com/CurvineIO/curvine/actions/runs/26028203048

## Test plan

- [ ] Merge PR
- [ ] Move `v0.2.0` tag to merge commit and push tag to re-trigger Release workflow
- [ ] Confirm `Build for Rocky Linux 9` passes and GitHub Release assets are published

Made with [Cursor](https://cursor.com)