### PR TITLE
fix: use safe Curvine commits and streamed object IO

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2087,6 +2087,8 @@ dependencies = [
  "lancedb",
  "md-5",
  "object_store",
+ "once_cell",
+ "orpc",
  "tempfile",
  "tokio",
  "url",

--- a/curvine-lancedb-rs/Cargo.toml
+++ b/curvine-lancedb-rs/Cargo.toml
@@ -24,7 +24,9 @@ lance-namespace = "4.0.0"
 lance-table = "4.0.0"
 lancedb_upstream = { package = "lancedb", version = "0.27.2", default-features = false }
 md-5 = { workspace = true }
+once_cell = { workspace = true }
 object_store = "0.12.5"
+orpc = { workspace = true }
 tokio = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }

--- a/curvine-lancedb-rs/src/connection.rs
+++ b/curvine-lancedb-rs/src/connection.rs
@@ -19,6 +19,7 @@ use std::path::MAIN_SEPARATOR;
 use std::sync::Arc;
 use std::time::Duration;
 
+use crate::curvine_safe_commit_database::CurvineSafeCommitDatabase;
 use crate::object_store::curvine_session;
 
 use lance::dataset::builder::DatasetBuilder;
@@ -32,8 +33,8 @@ use lance_table::io::commit::ConditionalPutCommitHandler;
 use lancedb_upstream::connection::{
     CloneTableBuilder as UpstreamCloneTableBuilder, ConnectBuilder as UpstreamConnectBuilder,
 };
-use lancedb_upstream::database::{CloneTableRequest, DatabaseOptions};
-use lancedb_upstream::embeddings::EmbeddingRegistry;
+use lancedb_upstream::database::{CloneTableRequest, Database, DatabaseOptions};
+use lancedb_upstream::embeddings::{EmbeddingRegistry, MemoryRegistry};
 use lancedb_upstream::error::{Error, Result};
 #[cfg(feature = "remote")]
 use lancedb_upstream::remote::ClientConfig;
@@ -63,14 +64,18 @@ struct ConnectionOptions {
     query_string: Option<String>,
     storage_options: HashMap<String, String>,
     session: Option<Arc<Session>>,
+    embedding_registry: Option<Arc<dyn EmbeddingRegistry>>,
     namespace_backed: bool,
 }
 
+/// Builder for a LanceDB connection. For `curvine://` URIs, applies a default session and, after
+/// `execute`, may wrap the inner database so `create_table` / `open_table` use a safe commit handler.
 #[derive(Debug)]
 pub struct ConnectBuilder {
     inner: ConnectBuilderInner,
 }
 
+/// Established connection. For `curvine://` listing URIs, the inner database may be wrapped for safe commits.
 #[derive(Clone)]
 pub struct Connection {
     upstream: UpstreamConnection,
@@ -96,7 +101,7 @@ impl ConnectBuilder {
         if is_curvine_uri(uri) {
             Self {
                 inner: ConnectBuilderInner::Upstream {
-                    builder: Box::new(builder.session(session.expect("curvine session is set"))),
+                    builder: Box::new(builder.session(session.unwrap_or_else(curvine_session))),
                     options,
                 },
             }
@@ -136,7 +141,13 @@ impl ConnectBuilder {
     }
 
     pub fn embedding_registry(self, registry: Arc<dyn EmbeddingRegistry>) -> Self {
-        self.map_upstream(|builder| builder.embedding_registry(registry), |_| {})
+        let reg = registry.clone();
+        self.map_upstream(
+            |builder| builder.embedding_registry(reg),
+            |options| {
+                options.embedding_registry = Some(registry);
+            },
+        )
     }
 
     pub fn storage_option(self, key: impl Into<String>, value: impl Into<String>) -> Self {
@@ -210,6 +221,7 @@ impl ConnectBuilder {
         match self.inner {
             ConnectBuilderInner::Upstream { builder, options } => {
                 let upstream = builder.execute().await?;
+                let upstream = wrap_upstream_connection_for_curvine(upstream, &options);
                 Ok(Connection { upstream, options })
             }
         }
@@ -218,6 +230,26 @@ impl ConnectBuilder {
 
 pub fn connect(uri: &str) -> ConnectBuilder {
     ConnectBuilder::new(uri)
+}
+
+fn wrap_upstream_connection_for_curvine(
+    upstream: UpstreamConnection,
+    options: &ConnectionOptions,
+) -> UpstreamConnection {
+    if !is_curvine_uri(&options.uri) {
+        return upstream;
+    }
+    let embedding_registry = options
+        .embedding_registry
+        .clone()
+        .unwrap_or_else(|| Arc::new(MemoryRegistry::new()));
+    let inner_db = upstream.database().clone();
+    let wrapped: Arc<dyn Database> = if options.namespace_backed {
+        Arc::new(CurvineSafeCommitDatabase::new_namespace(inner_db))
+    } else {
+        Arc::new(CurvineSafeCommitDatabase::new(inner_db))
+    };
+    UpstreamConnection::new(wrapped, embedding_registry)
 }
 
 impl Connection {
@@ -248,17 +280,13 @@ impl Connection {
 
     async fn clone_curvine_table(&self, request: CloneTableRequest) -> Result<Table> {
         validate_table_name(&request.target_table_name)?;
-        if request.source_version.is_some() && request.source_tag.is_some() {
-            return Err(Error::InvalidInput {
-                message: "Cannot specify both source_version and source_tag".to_string(),
-            });
-        }
 
         let session = self.options.session.clone().unwrap_or_else(curvine_session);
         let storage_params = self.object_store_params();
         let read_params = ReadParams {
             store_options: Some(storage_params.clone()),
             session: Some(session.clone()),
+            commit_handler: Some(Arc::new(ConditionalPutCommitHandler)),
             ..Default::default()
         };
         let mut source_dataset = DatasetBuilder::from_uri(&request.source_uri)
@@ -277,7 +305,11 @@ impl Connection {
                 let version = source_dataset.version().version;
                 (Ref::Version(None, Some(version)), version)
             }
-            (Some(_), Some(_)) => unreachable!("checked above"),
+            (Some(_), Some(_)) => {
+                return Err(Error::InvalidInput {
+                    message: "Cannot specify both source_version and source_tag".to_string(),
+                });
+            }
         };
         let target_uri = self.table_uri(&request.target_table_name)?;
         clone_dataset_with_session(
@@ -465,6 +497,8 @@ enum ConnectNamespaceBuilderInner {
     },
 }
 
+/// Builder for namespace-backed connections. When `properties` contain a `curvine://` root, behavior
+/// matches `connect` (URI query split, optional default session).
 pub struct ConnectNamespaceBuilder {
     inner: ConnectNamespaceBuilderInner,
 }
@@ -680,14 +714,30 @@ impl ConnectNamespaceBuilder {
                 session,
                 server_side_query,
             } => {
-                let curvine_uri = find_curvine_uri(&properties);
-                let wants_curvine = curvine_uri.is_some();
-                let mut builder = upstream_connect_namespace(&ns_impl, properties);
+                let curvine_root_raw = find_curvine_uri(&properties);
+                let wants_curvine = curvine_root_raw.is_some();
+                let mut properties_for_upstream = properties;
+                for (key, value) in &storage_options {
+                    properties_for_upstream
+                        .entry(format!("storage.{key}"))
+                        .or_insert_with(|| value.clone());
+                }
+                let mut builder = upstream_connect_namespace(&ns_impl, properties_for_upstream);
+
+                let (listing_uri, listing_query) = match curvine_root_raw {
+                    Some(raw) => (
+                        normalize_listing_uri(&raw).unwrap_or_else(|| raw.clone()),
+                        listing_query_string(&raw),
+                    ),
+                    None => (String::new(), None),
+                };
 
                 let mut options = ConnectionOptions {
-                    uri: curvine_uri.unwrap_or_default(),
+                    uri: listing_uri,
+                    query_string: listing_query,
                     session: session.clone(),
                     namespace_backed: true,
+                    embedding_registry: embedding_registry.clone(),
                     ..Default::default()
                 };
 
@@ -716,6 +766,7 @@ impl ConnectNamespaceBuilder {
                     .server_side_query(server_side_query)
                     .execute()
                     .await?;
+                let upstream = wrap_upstream_connection_for_curvine(upstream, &options);
                 Ok(Connection { upstream, options })
             }
         }
@@ -730,7 +781,15 @@ pub fn connect_namespace(
 }
 
 fn is_curvine_uri(uri: &str) -> bool {
-    uri.starts_with("curvine://")
+    let t = uri.trim_start();
+    match Url::parse(t) {
+        Ok(u) => u.scheme().eq_ignore_ascii_case("curvine"),
+        Err(_) => {
+            const PREFIX: &[u8] = b"curvine://";
+            let b = t.as_bytes();
+            b.len() >= PREFIX.len() && b[..PREFIX.len()].eq_ignore_ascii_case(PREFIX)
+        }
+    }
 }
 
 fn find_curvine_uri(properties: &HashMap<String, String>) -> Option<String> {

--- a/curvine-lancedb-rs/src/curvine_safe_commit_database.rs
+++ b/curvine-lancedb-rs/src/curvine_safe_commit_database.rs
@@ -1,0 +1,295 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use lance::dataset::{ReadParams, WriteParams};
+use lance_namespace::models::{
+    CreateNamespaceRequest, CreateNamespaceResponse, DescribeNamespaceRequest,
+    DescribeNamespaceResponse, DescribeTableRequest, DropNamespaceRequest, DropNamespaceResponse,
+    ListNamespacesRequest, ListNamespacesResponse, ListTablesRequest, ListTablesResponse,
+};
+use lance_table::io::commit::{CommitHandler, ConditionalPutCommitHandler};
+use lancedb_upstream::arrow::arrow_schema::SchemaRef;
+use lancedb_upstream::database::{
+    CloneTableRequest, CreateTableMode, CreateTableRequest, Database, OpenTableRequest,
+    ReadConsistency, TableNamesRequest,
+};
+use lancedb_upstream::error::{Error, Result};
+use lancedb_upstream::table::BaseTable;
+
+fn curvine_commit_handler() -> Arc<dyn CommitHandler> {
+    Arc::new(ConditionalPutCommitHandler)
+}
+
+fn ensure_create_request_has_commit_handler(mut req: CreateTableRequest) -> CreateTableRequest {
+    let wp = req
+        .write_options
+        .lance_write_params
+        .get_or_insert_with(WriteParams::default);
+    if wp.commit_handler.is_none() {
+        wp.commit_handler = Some(curvine_commit_handler());
+    }
+    req
+}
+
+fn ensure_open_request_has_commit_handler(mut req: OpenTableRequest) -> OpenTableRequest {
+    match &mut req.lance_read_params {
+        Some(rp) => {
+            if rp.commit_handler.is_none() {
+                rp.commit_handler = Some(curvine_commit_handler());
+            }
+        }
+        None => {
+            let mut rp = ReadParams::default();
+            if let Some(ics) = req.index_cache_size {
+                #[allow(deprecated)]
+                rp.index_cache_size(ics as usize);
+            }
+            rp.commit_handler = Some(curvine_commit_handler());
+            req.lance_read_params = Some(rp);
+        }
+    }
+    req
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum SafeCommitScope {
+    Listing,
+    Namespace,
+}
+
+/// Wraps the upstream database. Before `create_table` / `open_table`, sets `ConditionalPutCommitHandler`
+/// when the request did not set `commit_handler`.
+pub(crate) struct CurvineSafeCommitDatabase {
+    upstream: Arc<dyn Database>,
+    scope: SafeCommitScope,
+}
+
+impl CurvineSafeCommitDatabase {
+    pub(crate) fn new(upstream: Arc<dyn Database>) -> Self {
+        Self {
+            upstream,
+            scope: SafeCommitScope::Listing,
+        }
+    }
+
+    pub(crate) fn new_namespace(upstream: Arc<dyn Database>) -> Self {
+        Self {
+            upstream,
+            scope: SafeCommitScope::Namespace,
+        }
+    }
+
+    async fn open_existing_table_for_create(
+        &self,
+        name: String,
+        namespace: Vec<String>,
+        data_schema: SchemaRef,
+        callback: impl FnOnce(OpenTableRequest) -> OpenTableRequest,
+    ) -> Result<Arc<dyn BaseTable>> {
+        let request = callback(OpenTableRequest {
+            name,
+            namespace,
+            index_cache_size: None,
+            lance_read_params: None,
+            location: None,
+            namespace_client: None,
+            managed_versioning: None,
+        });
+        let table = self.open_table(request).await?;
+        let table_schema = table.schema().await?;
+        if table_schema.as_ref() != data_schema.as_ref() {
+            return Err(Error::Schema {
+                message: "Provided schema does not match existing table schema".to_string(),
+            });
+        }
+        Ok(table)
+    }
+
+    async fn namespace_uses_managed_versioning(&self, req: &OpenTableRequest) -> Result<bool> {
+        let namespace = self.upstream.namespace_client().await?;
+        let mut table_id = req.namespace.clone();
+        table_id.push(req.name.clone());
+        let response = namespace
+            .describe_table(DescribeTableRequest {
+                id: Some(table_id),
+                ..Default::default()
+            })
+            .await
+            .map_err(|source| Error::Runtime {
+                message: format!("Failed to describe namespace table: {source}"),
+            })?;
+        Ok(response.managed_versioning == Some(true))
+    }
+}
+
+impl fmt::Debug for CurvineSafeCommitDatabase {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self.upstream.as_ref(), f)
+    }
+}
+
+impl fmt::Display for CurvineSafeCommitDatabase {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self.upstream.as_ref(), f)
+    }
+}
+
+#[async_trait]
+impl Database for CurvineSafeCommitDatabase {
+    fn uri(&self) -> &str {
+        self.upstream.uri()
+    }
+
+    async fn read_consistency(&self) -> Result<ReadConsistency> {
+        self.upstream.read_consistency().await
+    }
+
+    async fn list_namespaces(
+        &self,
+        request: ListNamespacesRequest,
+    ) -> Result<ListNamespacesResponse> {
+        self.upstream.list_namespaces(request).await
+    }
+
+    async fn create_namespace(
+        &self,
+        request: CreateNamespaceRequest,
+    ) -> Result<CreateNamespaceResponse> {
+        self.upstream.create_namespace(request).await
+    }
+
+    async fn drop_namespace(&self, request: DropNamespaceRequest) -> Result<DropNamespaceResponse> {
+        self.upstream.drop_namespace(request).await
+    }
+
+    async fn describe_namespace(
+        &self,
+        request: DescribeNamespaceRequest,
+    ) -> Result<DescribeNamespaceResponse> {
+        self.upstream.describe_namespace(request).await
+    }
+
+    #[allow(deprecated)]
+    async fn table_names(&self, request: TableNamesRequest) -> Result<Vec<String>> {
+        self.upstream.table_names(request).await
+    }
+
+    async fn list_tables(&self, request: ListTablesRequest) -> Result<ListTablesResponse> {
+        self.upstream.list_tables(request).await
+    }
+
+    async fn create_table(&self, request: CreateTableRequest) -> Result<Arc<dyn BaseTable>> {
+        let CreateTableRequest {
+            name,
+            namespace,
+            data,
+            mode,
+            write_options,
+            location,
+            namespace_client,
+        } = request;
+
+        if let CreateTableMode::ExistOk(callback) = mode {
+            let data_schema = data.schema();
+            let open_result = self
+                .open_existing_table_for_create(
+                    name.clone(),
+                    namespace.clone(),
+                    data_schema,
+                    callback,
+                )
+                .await;
+            return match open_result {
+                Ok(table) => Ok(table),
+                Err(Error::TableNotFound { .. }) => {
+                    let request = CreateTableRequest {
+                        name,
+                        namespace,
+                        data,
+                        mode: CreateTableMode::Create,
+                        write_options,
+                        location,
+                        namespace_client,
+                    };
+                    self.upstream
+                        .create_table(ensure_create_request_has_commit_handler(request))
+                        .await
+                }
+                Err(err) => Err(err),
+            };
+        }
+
+        let request = CreateTableRequest {
+            name,
+            namespace,
+            data,
+            mode,
+            write_options,
+            location,
+            namespace_client,
+        };
+        let request = ensure_create_request_has_commit_handler(request);
+        self.upstream.create_table(request).await
+    }
+
+    async fn clone_table(&self, request: CloneTableRequest) -> Result<Arc<dyn BaseTable>> {
+        self.upstream.clone_table(request).await
+    }
+
+    async fn open_table(&self, request: OpenTableRequest) -> Result<Arc<dyn BaseTable>> {
+        let request = match self.scope {
+            SafeCommitScope::Listing => ensure_open_request_has_commit_handler(request),
+            SafeCommitScope::Namespace => {
+                if self.namespace_uses_managed_versioning(&request).await? {
+                    request
+                } else {
+                    ensure_open_request_has_commit_handler(request)
+                }
+            }
+        };
+        self.upstream.open_table(request).await
+    }
+
+    async fn rename_table(
+        &self,
+        cur_name: &str,
+        new_name: &str,
+        cur_namespace: &[String],
+        new_namespace: &[String],
+    ) -> Result<()> {
+        self.upstream
+            .rename_table(cur_name, new_name, cur_namespace, new_namespace)
+            .await
+    }
+
+    async fn drop_table(&self, name: &str, namespace: &[String]) -> Result<()> {
+        self.upstream.drop_table(name, namespace).await
+    }
+
+    async fn drop_all_tables(&self, namespace: &[String]) -> Result<()> {
+        self.upstream.drop_all_tables(namespace).await
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self.upstream.as_any()
+    }
+
+    async fn namespace_client(&self) -> Result<Arc<dyn lance_namespace::LanceNamespace>> {
+        self.upstream.namespace_client().await
+    }
+}

--- a/curvine-lancedb-rs/src/lib.rs
+++ b/curvine-lancedb-rs/src/lib.rs
@@ -14,6 +14,7 @@
 
 pub use lancedb_upstream::arrow;
 pub mod connection;
+mod curvine_safe_commit_database;
 pub mod error;
 pub mod object_store;
 pub use lancedb_upstream::data;
@@ -32,7 +33,8 @@ pub use lancedb_upstream::table;
 pub use lancedb_upstream::utils;
 
 pub use connection::{
-    connect, connect_namespace, ConnectBuilder, ConnectNamespaceBuilder, Connection,
+    connect, connect_namespace, CloneTableBuilder, ConnectBuilder, ConnectNamespaceBuilder,
+    Connection,
 };
 pub use error::{Error, Result};
 pub use lance_io::object_store::ObjectStoreProvider;

--- a/curvine-lancedb-rs/src/object_store.rs
+++ b/curvine-lancedb-rs/src/object_store.rs
@@ -17,6 +17,7 @@ use std::env;
 use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
 use std::result::Result as StdResult;
 use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
 
 use async_stream::stream;
 use async_trait::async_trait;
@@ -26,7 +27,9 @@ use curvine_client::file::CurvineFileSystem;
 use curvine_common::conf::ClusterConf;
 use curvine_common::error::FsError;
 use curvine_common::fs::{Path as CurvinePath, Reader, Writer};
-use curvine_common::state::{FileLock, FileStatus, LockFlags, LockType};
+use curvine_common::state::{
+    FileLock, FileStatus, LockFlags, LockType, SetAttrOpts, SetAttrOptsBuilder,
+};
 use futures::stream::{self, BoxStream};
 use futures::StreamExt;
 use lance_core::error::Result;
@@ -40,10 +43,12 @@ use lancedb_upstream::Session;
 use md5::{Digest, Md5};
 use object_store::path::Path;
 use object_store::{
-    Attributes, Error as OsError, GetOptions, GetResult, GetResultPayload, ListResult,
+    Attribute, Attributes, Error as OsError, GetOptions, GetResult, GetResultPayload, ListResult,
     MultipartUpload, ObjectMeta, ObjectStore as ObjectStoreTrait, PutMode, PutMultipartOptions,
     PutOptions, PutPayload, PutResult, Result as OsResult, UploadPart,
 };
+use once_cell::sync::Lazy;
+use orpc::sys::DataSlice;
 use tokio::sync::Mutex;
 use tokio::time::{sleep, Duration, Instant};
 use url::Url;
@@ -59,6 +64,11 @@ const CONDITIONAL_LOCK_ROOT: &str = "/.curvine/lancedb/locks";
 const INTERNAL_RESERVED_ROOT: &str = ".curvine";
 const CONDITIONAL_LOCK_RETRY_DELAY: Duration = Duration::from_millis(20);
 const CONDITIONAL_LOCK_WAIT_TIMEOUT: Duration = Duration::from_secs(120);
+const OBJECT_STORE_ATTR_PREFIX: &str = "lancedb.object_store.attr.";
+const OBJECT_STORE_METADATA_ATTR_PREFIX: &str = "lancedb.object_store.attr.metadata.";
+
+static PROCESS_WRITE_LOCKS: Lazy<StdMutex<HashMap<String, Arc<Mutex<()>>>>> =
+    Lazy::new(|| StdMutex::new(HashMap::new()));
 
 #[derive(Clone)]
 struct CurvineContext {
@@ -86,6 +96,7 @@ struct CurvineMultipartUpload {
     dest: Path,
     next_part: usize,
     completed_parts: Arc<Mutex<Vec<CompletedPart>>>,
+    attributes: Attributes,
 }
 
 #[derive(Debug, Clone)]
@@ -322,15 +333,12 @@ impl ObjectStoreTrait for CurvineObjectStore {
         payload: PutPayload,
         opts: PutOptions,
     ) -> OsResult<PutResult> {
-        if !opts.attributes.is_empty() {
-            return Err(OsError::NotImplemented);
-        }
-
+        let attributes = opts.attributes;
         match opts.mode {
-            PutMode::Overwrite => return self.put_overwrite(location, payload).await,
-            PutMode::Create => return self.put_create(location, payload).await,
+            PutMode::Overwrite => return self.put_overwrite(location, payload, attributes).await,
+            PutMode::Create => return self.put_create(location, payload, attributes).await,
             PutMode::Update(update) => {
-                return self.put_update(location, payload, update).await;
+                return self.put_update(location, payload, update, attributes).await;
             }
         }
     }
@@ -340,10 +348,6 @@ impl ObjectStoreTrait for CurvineObjectStore {
         location: &Path,
         opts: PutMultipartOptions,
     ) -> OsResult<Box<dyn MultipartUpload>> {
-        if !opts.attributes.is_empty() {
-            return Err(OsError::NotImplemented);
-        }
-
         let upload_id = Uuid::new_v4().to_string();
         let upload_dir = self.multipart_dir(location, &upload_id)?;
         self.context
@@ -358,28 +362,29 @@ impl ObjectStoreTrait for CurvineObjectStore {
             dest: location.clone(),
             next_part: 0,
             completed_parts: Arc::new(Mutex::new(Vec::new())),
+            attributes: opts.attributes,
         }))
     }
 
     async fn get_opts(&self, location: &Path, options: GetOptions) -> OsResult<GetResult> {
-        if options.version.is_some() {
-            return Err(OsError::NotImplemented);
-        }
-
         if options.head {
             let meta = self.head(location).await?;
+            ensure_current_version(&meta, options.version.as_deref())?;
+            let attributes = self.get_attributes(location).await?;
             options.check_preconditions(&meta)?;
             let stream = stream::once(async move { Ok::<Bytes, OsError>(Bytes::new()) }).boxed();
             return Ok(GetResult {
                 payload: GetResultPayload::Stream(stream),
                 meta,
                 range: 0..0,
-                attributes: Attributes::default(),
+                attributes,
             });
         }
 
         let cv_path = self.object_path(location)?;
         let meta = self.head(location).await?;
+        ensure_current_version(&meta, options.version.as_deref())?;
+        let attributes = self.get_attributes(location).await?;
         options.check_preconditions(&meta)?;
 
         let mut reader = self
@@ -412,7 +417,7 @@ impl ObjectStoreTrait for CurvineObjectStore {
             payload: GetResultPayload::Stream(stream),
             meta,
             range,
-            attributes: Attributes::default(),
+            attributes,
         })
     }
 
@@ -550,6 +555,7 @@ impl ObjectStoreTrait for CurvineObjectStore {
         let from_cv = self.object_path(from)?;
         let meta = self.head(from).await?;
         let size = meta.size;
+        let attributes = self.get_attributes(from).await?;
         let upload_id = Uuid::new_v4().to_string();
         let staging = self.multipart_final_path(to, &upload_id)?;
         if let Some(parent) = staging.parent().map_err(|e| OsError::Generic {
@@ -588,8 +594,13 @@ impl ObjectStoreTrait for CurvineObjectStore {
                 .complete()
                 .await
                 .map_err(|e| fs_error_to_object_store(to, e))?;
+            let process_lock = process_write_lock(&self.context.workspace_root, to);
+            let _process_guard = process_lock.lock().await;
             let lock = self.acquire_object_write_lock(to).await?;
-            let replace = self.replace_from_staging(to, &staging).await.map(|_| ());
+            let replace = self
+                .replace_from_staging(to, &staging, attributes)
+                .await
+                .map(|_| ());
             let _ = self.release_object_write_lock(&lock).await;
             replace
         }
@@ -604,6 +615,7 @@ impl ObjectStoreTrait for CurvineObjectStore {
         let from_cv = self.object_path(from)?;
         let meta = self.head(from).await?;
         let size = meta.size;
+        let attributes = self.get_attributes(from).await?;
         let upload_id = Uuid::new_v4().to_string();
         let staging = self.multipart_final_path(to, &upload_id)?;
         if let Some(parent) = staging.parent().map_err(|e| OsError::Generic {
@@ -645,15 +657,18 @@ impl ObjectStoreTrait for CurvineObjectStore {
                 .complete()
                 .await
                 .map_err(|e| fs_error_to_object_store(to, e))?;
+            let process_lock = process_write_lock(&self.context.workspace_root, to);
+            let _process_guard = process_lock.lock().await;
             let lock = self.acquire_object_write_lock(to).await?;
             let replace = match self.head(to).await {
                 Ok(_) => Err(OsError::AlreadyExists {
                     path: to.to_string(),
                     source: "object already exists".into(),
                 }),
-                Err(OsError::NotFound { .. }) => {
-                    self.replace_from_staging(to, &staging).await.map(|_| ())
-                }
+                Err(OsError::NotFound { .. }) => self
+                    .replace_from_staging(to, &staging, attributes)
+                    .await
+                    .map(|_| ()),
                 Err(err) => Err(err),
             };
             let _ = self.release_object_write_lock(&lock).await;
@@ -667,13 +682,57 @@ impl ObjectStoreTrait for CurvineObjectStore {
 
         finalize_result
     }
+
+    async fn rename_if_not_exists(&self, from: &Path, to: &Path) -> OsResult<()> {
+        let from_cv = self.object_path(from)?;
+        let to_cv = self.object_path(to)?;
+        let process_lock = process_write_lock(&self.context.workspace_root, to);
+        let _process_guard = process_lock.lock().await;
+        let lock = self.acquire_object_write_lock(to).await?;
+        let result = match self.head(to).await {
+            Ok(_) => Err(OsError::AlreadyExists {
+                path: to.to_string(),
+                source: "object already exists".into(),
+            }),
+            Err(OsError::NotFound { .. }) => {
+                self.prepare_multipart_destination(&to_cv, to).await?;
+                self.context
+                    .fs
+                    .rename(&from_cv, &to_cv)
+                    .await
+                    .map_err(|e| fs_error_to_object_store(to, e))
+                    .and_then(|renamed| {
+                        if renamed {
+                            Ok(())
+                        } else {
+                            Err(OsError::Generic {
+                                store: CURVINE_SCHEME,
+                                source: "rename_if_not_exists rename reported no-op".into(),
+                            })
+                        }
+                    })
+            }
+            Err(err) => Err(err),
+        };
+        let _ = self.release_object_write_lock(&lock).await;
+        result
+    }
 }
 
 impl CurvineObjectStore {
-    async fn put_overwrite(&self, location: &Path, payload: PutPayload) -> OsResult<PutResult> {
+    async fn put_overwrite(
+        &self,
+        location: &Path,
+        payload: PutPayload,
+        attributes: Attributes,
+    ) -> OsResult<PutResult> {
         let staging = self.write_payload_to_staging(location, payload).await?;
+        let process_lock = process_write_lock(&self.context.workspace_root, location);
+        let _process_guard = process_lock.lock().await;
         let lock = self.acquire_object_write_lock(location).await?;
-        let result = self.replace_from_staging(location, &staging).await;
+        let result = self
+            .replace_from_staging(location, &staging, attributes)
+            .await;
         let _ = self.release_object_write_lock(&lock).await;
         if result.is_err() {
             let _ = self.context.fs.delete(&staging, false).await;
@@ -681,15 +740,25 @@ impl CurvineObjectStore {
         result
     }
 
-    async fn put_create(&self, location: &Path, payload: PutPayload) -> OsResult<PutResult> {
+    async fn put_create(
+        &self,
+        location: &Path,
+        payload: PutPayload,
+        attributes: Attributes,
+    ) -> OsResult<PutResult> {
         let staging = self.write_payload_to_staging(location, payload).await?;
+        let process_lock = process_write_lock(&self.context.workspace_root, location);
+        let _process_guard = process_lock.lock().await;
         let lock = self.acquire_object_write_lock(location).await?;
         let result = match self.head(location).await {
             Ok(_) => Err(OsError::AlreadyExists {
                 path: location.to_string(),
                 source: "object already exists".into(),
             }),
-            Err(OsError::NotFound { .. }) => self.replace_from_staging(location, &staging).await,
+            Err(OsError::NotFound { .. }) => {
+                self.replace_from_staging(location, &staging, attributes)
+                    .await
+            }
             Err(err) => Err(err),
         };
         let _ = self.release_object_write_lock(&lock).await;
@@ -704,6 +773,7 @@ impl CurvineObjectStore {
         location: &Path,
         payload: PutPayload,
         update: object_store::UpdateVersion,
+        attributes: Attributes,
     ) -> OsResult<PutResult> {
         let expected_etag = update.e_tag.ok_or_else(|| OsError::Generic {
             store: CURVINE_SCHEME,
@@ -711,11 +781,14 @@ impl CurvineObjectStore {
         })?;
 
         let staging = self.write_payload_to_staging(location, payload).await?;
+        let process_lock = process_write_lock(&self.context.workspace_root, location);
+        let _process_guard = process_lock.lock().await;
         let lock = self.acquire_object_write_lock(location).await?;
         let result = async {
             let current = self.head_for_update(location).await?;
             ensure_matching_etag(location, current.e_tag.as_deref(), &expected_etag)?;
-            self.replace_from_staging(location, &staging).await
+            self.replace_from_staging(location, &staging, attributes)
+                .await
         }
         .await;
         let _ = self.release_object_write_lock(&lock).await;
@@ -750,9 +823,9 @@ impl CurvineObjectStore {
             .await
             .map_err(|e| fs_error_to_object_store(location, e))?;
         let write_result: OsResult<()> = async {
-            for chunk in payload.iter() {
+            for chunk in payload {
                 writer
-                    .write(chunk)
+                    .async_write(DataSlice::bytes(chunk))
                     .await
                     .map_err(|e| fs_error_to_object_store(location, e))?;
             }
@@ -775,9 +848,11 @@ impl CurvineObjectStore {
         &self,
         location: &Path,
         staging: &CurvinePath,
+        attributes: Attributes,
     ) -> OsResult<PutResult> {
         let dest = self.object_path(location)?;
         self.prepare_multipart_destination(&dest, location).await?;
+        self.set_attributes(location, staging, &attributes).await?;
         self.context
             .fs
             .rename(staging, &dest)
@@ -793,12 +868,40 @@ impl CurvineObjectStore {
                     })
                 }
             })?;
-
         let meta = self.head(location).await?;
         Ok(PutResult {
             e_tag: meta.e_tag,
             version: meta.version,
         })
+    }
+
+    async fn get_attributes(&self, location: &Path) -> OsResult<Attributes> {
+        let cv_path = self.object_path(location)?;
+        let status = self
+            .context
+            .fs
+            .get_status(&cv_path)
+            .await
+            .map_err(|e| fs_error_to_object_store(location, e))?;
+        Ok(curvine_x_attrs_to_object_attributes(&status.x_attr))
+    }
+
+    async fn set_attributes(
+        &self,
+        location: &Path,
+        staging: &CurvinePath,
+        attributes: &Attributes,
+    ) -> OsResult<()> {
+        let Some(opts) = object_attributes_to_set_attr_opts(attributes)? else {
+            return Ok(());
+        };
+
+        self.context
+            .fs
+            .set_attr(staging, opts)
+            .await
+            .map(|_| ())
+            .map_err(|e| fs_error_to_object_store(location, e))
     }
 
     async fn head_for_update(&self, location: &Path) -> OsResult<ObjectMeta> {
@@ -885,6 +988,23 @@ impl CurvineObjectStore {
     }
 
     fn object_path(&self, location: &Path) -> OsResult<CurvinePath> {
+        if let Some(absolute) = curvine_absolute_path_str_from_object_path(location)? {
+            if self.is_root_workspace()
+                && is_internal_reserved_relative_path(absolute.trim_start_matches('/'))
+            {
+                return Err(OsError::NotSupported {
+                    source: format!(
+                        "`{INTERNAL_RESERVED_ROOT}` is a reserved Curvine namespace for root workspaces"
+                    )
+                    .into(),
+                });
+            }
+            return CurvinePath::from_str(absolute).map_err(|e| OsError::Generic {
+                store: CURVINE_SCHEME,
+                source: e.to_string().into(),
+            });
+        }
+
         let rel = location.as_ref().trim_start_matches('/');
         if self.is_root_workspace() && is_internal_reserved_relative_path(rel) {
             return Err(OsError::NotSupported {
@@ -1114,21 +1234,21 @@ impl CurvineObjectStore {
         writer: &mut impl Writer,
     ) -> OsResult<()> {
         let mut remaining = size as usize;
-        let mut buf = vec![0u8; COPY_CHUNK_BYTES];
         while remaining > 0 {
             let take = remaining.min(COPY_CHUNK_BYTES);
-            let n = reader
-                .read_full(&mut buf[..take])
+            let chunk = reader
+                .async_read(Some(take))
                 .await
                 .map_err(|e| fs_error_to_object_store(from, e))?;
-            if n == 0 {
+            if chunk.is_empty() {
                 break;
             }
+            let len = chunk.len();
             writer
-                .write(&buf[..n])
+                .async_write(chunk)
                 .await
                 .map_err(|e| fs_error_to_object_store(to, e))?;
-            remaining = remaining.saturating_sub(n);
+            remaining = remaining.saturating_sub(len);
         }
 
         Ok(())
@@ -1173,9 +1293,9 @@ impl MultipartUpload for CurvineMultipartUpload {
                 .await
                 .map_err(|e| fs_error_to_object_store(&dest, e))?;
 
-            for chunk in data.iter() {
+            for chunk in data {
                 writer
-                    .write(chunk)
+                    .async_write(DataSlice::bytes(chunk))
                     .await
                     .map_err(|e| fs_error_to_object_store(&dest, e))?;
             }
@@ -1239,10 +1359,12 @@ impl MultipartUpload for CurvineMultipartUpload {
                 .complete()
                 .await
                 .map_err(|e| fs_error_to_object_store(&self.dest, e))?;
+            let process_lock = process_write_lock(&self.store.context.workspace_root, &self.dest);
+            let _process_guard = process_lock.lock().await;
             let lock = self.store.acquire_object_write_lock(&self.dest).await?;
             let replace = self
                 .store
-                .replace_from_staging(&self.dest, &staging_final)
+                .replace_from_staging(&self.dest, &staging_final, self.attributes.clone())
                 .await;
             let _ = self.store.release_object_write_lock(&lock).await;
             replace
@@ -1257,7 +1379,13 @@ impl MultipartUpload for CurvineMultipartUpload {
                     .await;
                 Ok(result)
             }
-            Err(err) => Err(err),
+            Err(err) => {
+                let _ = self
+                    .store
+                    .cleanup_multipart(&self.dest, &self.upload_id)
+                    .await;
+                Err(err)
+            }
         }
     }
 
@@ -1298,24 +1426,129 @@ fn curvine_workspace_root_from_uri(url: &Url) -> StdResult<CurvinePath, String> 
     CurvinePath::from_str(&full).map_err(|e| e.to_string())
 }
 
+fn curvine_absolute_path_str_from_object_path(location: &Path) -> OsResult<Option<String>> {
+    let raw = location.as_ref();
+    let Some(stripped) = raw.strip_prefix("curvine:") else {
+        return Ok(None);
+    };
+
+    let absolute = if let Some(path) = stripped.strip_prefix("///") {
+        format!("/{path}")
+    } else if let Some(path) = stripped.strip_prefix("//") {
+        let mut parts = path.splitn(2, '/');
+        let authority = parts.next().unwrap_or_default();
+        let rest = parts.next().unwrap_or_default();
+        if authority.is_empty() {
+            format!("/{rest}")
+        } else if rest.is_empty() {
+            format!("/{authority}")
+        } else {
+            format!("/{authority}/{rest}")
+        }
+    } else if stripped.starts_with('/') {
+        stripped.to_string()
+    } else {
+        return Err(OsError::Generic {
+            store: CURVINE_SCHEME,
+            source: format!("Invalid Curvine object path `{raw}`").into(),
+        });
+    };
+
+    Ok(Some(absolute))
+}
+
 /// Curvine [`FileStatus`] → [`ObjectMeta`].
 ///
 /// - **size / last_modified**: from `len` and `mtime` (ms since epoch on wire).
-/// - **e_tag**: weak synthetic tag `W/"cv:{inode}:{mtime_ms}"` for stable referential
-///   identity; **not** a content digest. Do not use for byte-accurate conditional semantics
-///   until a content hash is wired through the filesystem.
-/// - **version**: always `None` (no object-version id exposed yet).
+/// - **e_tag / version**: weak synthetic token from Curvine metadata fields currently exposed by
+///   `FileStatus`; **not** a content digest or a server-side generation.
 fn file_status_to_object_meta(location: Path, status: FileStatus) -> ObjectMeta {
     let secs = status.mtime.div_euclid(1000);
     let millis = status.mtime.rem_euclid(1000) as u32;
-    let weak_etag = Some(format!("W/\"cv:{}:{}\"", status.id, status.mtime));
+    let token = Some(curvine_object_version_token(&status));
     ObjectMeta {
         location,
         last_modified: DateTime::<Utc>::from_timestamp(secs, millis * 1_000_000)
             .unwrap_or(DateTime::<Utc>::UNIX_EPOCH),
         size: status.len as u64,
-        e_tag: weak_etag,
-        version: None,
+        e_tag: token.clone(),
+        version: token,
+    }
+}
+
+fn curvine_object_version_token(status: &FileStatus) -> String {
+    format!(
+        "W/\"cv:{}:{}:{}:{}:{}\"",
+        status.id, status.mtime, status.len, status.is_complete, status.nlink
+    )
+}
+
+fn ensure_current_version(meta: &ObjectMeta, requested: Option<&str>) -> OsResult<()> {
+    match (requested, meta.version.as_deref()) {
+        (Some(requested), Some(current)) if requested == current => Ok(()),
+        (Some(_), _) => Err(OsError::NotImplemented),
+        (None, _) => Ok(()),
+    }
+}
+
+fn object_attributes_to_set_attr_opts(attributes: &Attributes) -> OsResult<Option<SetAttrOpts>> {
+    let mut builder = SetAttrOptsBuilder::new();
+    let mut has_attrs = false;
+
+    for (key, value) in attributes {
+        builder = builder.add_x_attr(
+            object_attribute_x_attr_key(key)?,
+            value.as_ref().as_bytes().to_vec(),
+        );
+        has_attrs = true;
+    }
+
+    Ok(has_attrs.then(|| builder.build()))
+}
+
+fn curvine_x_attrs_to_object_attributes(x_attrs: &HashMap<String, Vec<u8>>) -> Attributes {
+    let mut attributes = Attributes::new();
+
+    for (key, value) in x_attrs {
+        let Some(attribute) = x_attr_key_to_object_attribute(key) else {
+            continue;
+        };
+        let Ok(value) = String::from_utf8(value.clone()) else {
+            continue;
+        };
+        attributes.insert(attribute, value.into());
+    }
+
+    attributes
+}
+
+fn object_attribute_x_attr_key(attribute: &Attribute) -> OsResult<String> {
+    let key = match attribute {
+        Attribute::ContentDisposition => format!("{OBJECT_STORE_ATTR_PREFIX}content_disposition"),
+        Attribute::ContentEncoding => format!("{OBJECT_STORE_ATTR_PREFIX}content_encoding"),
+        Attribute::ContentLanguage => format!("{OBJECT_STORE_ATTR_PREFIX}content_language"),
+        Attribute::ContentType => format!("{OBJECT_STORE_ATTR_PREFIX}content_type"),
+        Attribute::CacheControl => format!("{OBJECT_STORE_ATTR_PREFIX}cache_control"),
+        Attribute::StorageClass => format!("{OBJECT_STORE_ATTR_PREFIX}storage_class"),
+        Attribute::Metadata(key) => format!("{OBJECT_STORE_METADATA_ATTR_PREFIX}{key}"),
+        _ => return Err(OsError::NotImplemented),
+    };
+    Ok(key)
+}
+
+fn x_attr_key_to_object_attribute(key: &str) -> Option<Attribute> {
+    if let Some(metadata_key) = key.strip_prefix(OBJECT_STORE_METADATA_ATTR_PREFIX) {
+        return Some(Attribute::Metadata(metadata_key.to_string().into()));
+    }
+
+    match key.strip_prefix(OBJECT_STORE_ATTR_PREFIX)? {
+        "content_disposition" => Some(Attribute::ContentDisposition),
+        "content_encoding" => Some(Attribute::ContentEncoding),
+        "content_language" => Some(Attribute::ContentLanguage),
+        "content_type" => Some(Attribute::ContentType),
+        "cache_control" => Some(Attribute::CacheControl),
+        "storage_class" => Some(Attribute::StorageClass),
+        _ => None,
     }
 }
 
@@ -1357,6 +1590,17 @@ fn conditional_unlock(owner_id: u64) -> FileLock {
 fn conditional_lock_owner() -> u64 {
     let uuid = Uuid::new_v4();
     u64::from_le_bytes(uuid.as_bytes()[..8].try_into().unwrap_or_default())
+}
+
+fn process_write_lock(workspace_root: &CurvinePath, location: &Path) -> Arc<Mutex<()>> {
+    let key = format!("{}:{}", workspace_root.full_path(), location);
+    let mut locks = PROCESS_WRITE_LOCKS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    locks
+        .entry(key)
+        .or_insert_with(|| Arc::new(Mutex::new(())))
+        .clone()
 }
 
 fn conditional_lock(owner_id: u64, lock_type: LockType) -> FileLock {

--- a/curvine-tests/tests/lancedb_object_store_e2e.rs
+++ b/curvine-tests/tests/lancedb_object_store_e2e.rs
@@ -3,9 +3,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 //
-//! Phase 6 — LanceDB on Curvine E2E (ListingDatabase + `curvine://` object store).
-//! 覆盖常用路径与最小向量索引路径；各用例使用独立 `curvine:///tmp/...` workspace，并通过
-//! `storage_option(CURVINE_CONF_FILE_KEY, …)` 注入配置，避免依赖进程级环境变量。
+//! Phase 6 — LanceDB on Curvine E2E (listing database + `curvine://` object store).
+//! Covers common paths and a minimal vector-index path. Each case uses an isolated `curvine:///tmp/...`
+//! workspace and injects config via `storage_option(CURVINE_CONF_FILE_KEY, ...)`, not process env vars.
 
 mod common;
 
@@ -26,6 +26,7 @@ use curvine_common::conf::ClusterConf;
 use futures::{stream::FuturesUnordered, TryStreamExt};
 use lance_io::object_store::{ObjectStoreParams, StorageOptionsAccessor};
 use lancedb::connect;
+use lancedb::connect_namespace;
 use lancedb::database::{CreateTableMode, ReadConsistency};
 use lancedb::error::Error as LanceDbError;
 use lancedb::expr::{col, lit};
@@ -1358,6 +1359,349 @@ fn lancedb_stale_table_handle_append_rebases_on_curvine() -> CommonResult<()> {
             .await
             .map_err(|e| CommonError::from(e.to_string()))?
             .open_table("append_t")
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(
+            reopened
+                .count_rows(None)
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            3
+        );
+        let batches: Vec<RecordBatch> = reopened
+            .query()
+            .select(Select::columns(&["id"]))
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .try_collect()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let mut ids = batches
+            .iter()
+            .flat_map(|batch| int32_values(batch, "id"))
+            .flatten()
+            .collect::<Vec<_>>();
+        ids.sort_unstable();
+        assert_eq!(ids, vec![0, 1, 2]);
+
+        Ok::<(), CommonError>(())
+    })?;
+    Ok(())
+}
+
+#[test]
+fn lancedb_concurrent_append_rebases_on_curvine() -> CommonResult<()> {
+    let (cluster, rt) = start_minicluster()?;
+    let conf = cluster.conf_path.clone();
+    let ns = unique_ns();
+    rt.block_on(async move {
+        let db_uri = format!("curvine:///tmp/concurrent_append_live_{ns}");
+        let conn = connect(&db_uri)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        conn.create_table("append_t", int32_batch("id", vec![0]))
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let t1 = connect(&db_uri)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .open_table("append_t")
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let t2 = connect(&db_uri)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .open_table("append_t")
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let initial_v1 = t1
+            .version()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let initial_v2 = t2
+            .version()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(initial_v1, initial_v2);
+
+        let append1 = t1.add(int32_batch("id", vec![1])).execute();
+        let append2 = t2.add(int32_batch("id", vec![2])).execute();
+        let (r1, r2) = tokio::join!(append1, append2);
+        r1.map_err(|e| CommonError::from(e.to_string()))?;
+        r2.map_err(|e| CommonError::from(e.to_string()))?;
+
+        let reopened = connect(&db_uri)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .open_table("append_t")
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(
+            reopened
+                .count_rows(None)
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            3
+        );
+        let batches: Vec<RecordBatch> = reopened
+            .query()
+            .select(Select::columns(&["id"]))
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .try_collect()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let mut ids = batches
+            .iter()
+            .flat_map(|batch| int32_values(batch, "id"))
+            .flatten()
+            .collect::<Vec<_>>();
+        ids.sort_unstable();
+        assert_eq!(ids, vec![0, 1, 2]);
+
+        Ok::<(), CommonError>(())
+    })?;
+    Ok(())
+}
+
+#[test]
+fn lancedb_connect_namespace_curvine_concurrent_append() -> CommonResult<()> {
+    let (cluster, rt) = start_minicluster()?;
+    let conf = cluster.conf_path.clone();
+    let ns = unique_ns();
+    rt.block_on(async move {
+        let root = format!("curvine:///tmp/ns_cv_append_{ns}");
+        let mut properties = HashMap::new();
+        properties.insert("root".to_string(), root);
+
+        let conn = connect_namespace("dir", properties)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        conn.create_table("ns_append_t", int32_batch("id", vec![0]))
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let t1 = conn
+            .open_table("ns_append_t")
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let t2 = conn
+            .open_table("ns_append_t")
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let append1 = t1.add(int32_batch("id", vec![1])).execute();
+        let append2 = t2.add(int32_batch("id", vec![2])).execute();
+        let (r1, r2) = tokio::join!(append1, append2);
+        r1.map_err(|e| CommonError::from(e.to_string()))?;
+        r2.map_err(|e| CommonError::from(e.to_string()))?;
+
+        let reopened = conn
+            .open_table("ns_append_t")
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(
+            reopened
+                .count_rows(None)
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            3
+        );
+        let batches: Vec<RecordBatch> = reopened
+            .query()
+            .select(Select::columns(&["id"]))
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .try_collect()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let mut ids = batches
+            .iter()
+            .flat_map(|batch| int32_values(batch, "id"))
+            .flatten()
+            .collect::<Vec<_>>();
+        ids.sort_unstable();
+        assert_eq!(ids, vec![0, 1, 2]);
+
+        Ok::<(), CommonError>(())
+    })?;
+    Ok(())
+}
+
+#[test]
+fn lancedb_managed_namespace_curvine_concurrent_append() -> CommonResult<()> {
+    let (cluster, rt) = start_minicluster()?;
+    let conf = cluster.conf_path.clone();
+    let ns = unique_ns();
+    rt.block_on(async move {
+        let root = format!("curvine:///tmp/ns_cv_managed_append_{ns}");
+        let mut properties = HashMap::new();
+        properties.insert("root".to_string(), root);
+        properties.insert(
+            "table_version_tracking_enabled".to_string(),
+            "true".to_string(),
+        );
+
+        let conn = connect_namespace("dir", properties)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        conn.create_table("managed_append_t", int32_batch("id", vec![0]))
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let t1 = conn
+            .open_table("managed_append_t")
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let t2 = conn
+            .open_table("managed_append_t")
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let append1 = t1.add(int32_batch("id", vec![1])).execute();
+        let append2 = t2.add(int32_batch("id", vec![2])).execute();
+        let (r1, r2) = tokio::join!(append1, append2);
+        r1.map_err(|e| CommonError::from(e.to_string()))?;
+        r2.map_err(|e| CommonError::from(e.to_string()))?;
+
+        let reopened = conn
+            .open_table("managed_append_t")
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        assert_eq!(
+            reopened
+                .count_rows(None)
+                .await
+                .map_err(|e| CommonError::from(e.to_string()))?,
+            3
+        );
+        let batches: Vec<RecordBatch> = reopened
+            .query()
+            .select(Select::columns(&["id"]))
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .try_collect()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let mut ids = batches
+            .iter()
+            .flat_map(|batch| int32_values(batch, "id"))
+            .flatten()
+            .collect::<Vec<_>>();
+        ids.sort_unstable();
+        assert_eq!(ids, vec![0, 1, 2]);
+
+        Ok::<(), CommonError>(())
+    })?;
+    Ok(())
+}
+
+#[test]
+fn lancedb_exist_ok_then_concurrent_append_on_curvine() -> CommonResult<()> {
+    let (cluster, rt) = start_minicluster()?;
+    let conf = cluster.conf_path.clone();
+    let ns = unique_ns();
+    rt.block_on(async move {
+        let db_uri = format!("curvine:///tmp/exist_ok_append_{ns}");
+        let conn = connect(&db_uri)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        conn.create_table("exist_t", int32_batch("id", vec![0]))
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let _via_exist = conn
+            .create_empty_table("exist_t", schema.clone())
+            .mode(CreateTableMode::exist_ok(|request| request))
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let t1 = connect(&db_uri)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .open_table("exist_t")
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+        let t2 = connect(&db_uri)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .open_table("exist_t")
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?;
+
+        let append1 = t1.add(int32_batch("id", vec![1])).execute();
+        let append2 = t2.add(int32_batch("id", vec![2])).execute();
+        let (r1, r2) = tokio::join!(append1, append2);
+        r1.map_err(|e| CommonError::from(e.to_string()))?;
+        r2.map_err(|e| CommonError::from(e.to_string()))?;
+
+        let reopened = connect(&db_uri)
+            .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
+            .execute()
+            .await
+            .map_err(|e| CommonError::from(e.to_string()))?
+            .open_table("exist_t")
             .storage_option(CURVINE_CONF_FILE_KEY, conf.as_str())
             .execute()
             .await


### PR DESCRIPTION
This PR is the main-target replacement for the previous stacked PR #825, whose base was the old PR04 branch.

Scope:
- Add the Curvine safe-commit database adapter wiring for LanceDB metadata commits.
- Keep Curvine object writes staged before replacement.
- Stream object IO through Curvine instead of materializing whole payloads.
- Extend the LanceDB-on-Curvine e2e coverage for the safe commit path.

Validation run locally:
- cargo fmt --all --check
- cargo clippy -p curvine-lancedb --all-targets --all-features -- -D warnings
- cargo test -p curvine-lancedb
- cargo clippy -p curvine-tests --test lancedb_object_store_e2e -- -D warnings