### PR TITLE
fix: show leader address in raft state log (#507)

### DIFF
--- a/curvine-common/src/raft/raft_group.rs
+++ b/curvine-common/src/raft/raft_group.rs
@@ -52,6 +52,16 @@ impl RaftGroup {
         }
     }
 
+    pub fn get_addr_only_string(&self, id: u64) -> String {
+        if id == 0 {
+            return "unknown".to_string();
+        }
+        match self.peers.get(&id) {
+            None => format!("{}", id),
+            Some(v) => format!("{}:{}", v.hostname, v.port),
+        }
+    }
+
     pub fn voters(&self) -> Vec<u64> {
         self.peers.iter().map(|x| *x.0).collect()
     }
@@ -119,5 +129,34 @@ impl RaftGroup {
 
     pub fn remove(&mut self, id: &NodeId) {
         self.peers.remove(id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_addr_only_string_returns_address_when_peer_exists() {
+        let mut peers = HashMap::new();
+        peers.insert(1, RaftPeer::new(1, "master-1", 8996));
+
+        let group = RaftGroup::new("test", peers);
+
+        assert_eq!("master-1:8996", group.get_addr_only_string(1));
+    }
+
+    #[test]
+    fn get_addr_only_string_falls_back_to_id_when_peer_is_unknown() {
+        let group = RaftGroup::new("test", HashMap::new());
+
+        assert_eq!("2", group.get_addr_only_string(2));
+    }
+
+    #[test]
+    fn get_addr_only_string_returns_unknown_for_zero_leader_id() {
+        let group = RaftGroup::new("test", HashMap::new());
+
+        assert_eq!("unknown", group.get_addr_only_string(0));
     }
 }

--- a/curvine-common/src/raft/raft_node.rs
+++ b/curvine-common/src/raft/raft_node.rs
@@ -466,8 +466,8 @@ where
 
         if let Some(ss) = soft_state {
             info!(
-                "raft state change, current leader {}, node {}",
-                self.group.get_addr_string(self.leader()),
+                "raft state change, current leader address {}, node {}",
+                self.group.get_addr_only_string(self.leader()),
                 self.group.get_addr_string(self.id()),
             );
 


### PR DESCRIPTION
## Summary
- Update the Raft SoftState state-change runtime log to show the leader master address without the node id.
- Add an address-only formatter for Raft peers with unit coverage for known and unknown peer ids.

## Context
Maintainer confirmed the target log site in #507: https://github.com/CurvineIO/curvine/issues/507#issuecomment-4467573435

Closes #507.

## Tests
- `cargo fmt --check`
- `cargo test -p curvine-common raft_group -- --nocapture`
- `npm run commitlint`
- `cargo clippy -p curvine-common --all-targets -- --deny warnings --allow clippy::uninlined-format-args`
