### PR TITLE
fix: use err_ext! for file_not_found errors in fs_dir (#796)

### DIFF
--- a/curvine-lancedb-rs/src/python/py_connect.rs
+++ b/curvine-lancedb-rs/src/python/py_connect.rs
@@ -23,7 +23,11 @@ impl PyConnectBuilder {
 
 #[pymethods]
 impl PyConnectBuilder {
-    fn storage_option(mut slf: PyRefMut<Self>, key: String, value: String) -> PyResult<PyRefMut<Self>> {
+    fn storage_option(
+        mut slf: PyRefMut<Self>,
+        key: String,
+        value: String,
+    ) -> PyResult<PyRefMut<Self>> {
         let builder = slf.inner.take().ok_or_else(already_consumed_err)?;
         slf.inner = Some(builder.storage_option(key, value));
         Ok(slf)

--- a/curvine-lancedb-rs/src/python/py_connection.rs
+++ b/curvine-lancedb-rs/src/python/py_connection.rs
@@ -21,7 +21,11 @@ impl PyConnection {
     fn table_names<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let conn = self.inner.upstream.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let names = conn.table_names().execute().await.map_err(error::to_py_err)?;
+            let names = conn
+                .table_names()
+                .execute()
+                .await
+                .map_err(error::to_py_err)?;
             Ok(names)
         })
     }

--- a/curvine-lancedb-rs/src/python/py_query.rs
+++ b/curvine-lancedb-rs/src/python/py_query.rs
@@ -18,9 +18,7 @@ pub struct PyQuery {
 
 impl PyQuery {
     pub fn new(query: UpstreamQuery) -> Self {
-        Self {
-            inner: Some(query),
-        }
+        Self { inner: Some(query) }
     }
 }
 
@@ -75,9 +73,7 @@ pub struct PyVectorQuery {
 
 impl PyVectorQuery {
     pub fn new(query: UpstreamVectorQuery) -> Self {
-        Self {
-            inner: Some(query),
-        }
+        Self { inner: Some(query) }
     }
 }
 

--- a/curvine-lancedb-rs/src/python/py_table.rs
+++ b/curvine-lancedb-rs/src/python/py_table.rs
@@ -23,13 +23,14 @@ impl PyTable {
     }
 
     #[pyo3(signature = (filter=None))]
-    fn count_rows<'py>(&self, py: Python<'py>, filter: Option<String>) -> PyResult<Bound<'py, PyAny>> {
+    fn count_rows<'py>(
+        &self,
+        py: Python<'py>,
+        filter: Option<String>,
+    ) -> PyResult<Bound<'py, PyAny>> {
         let table = self.inner.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let count = table
-                .count_rows(filter)
-                .await
-                .map_err(error::to_py_err)?;
+            let count = table.count_rows(filter).await.map_err(error::to_py_err)?;
             Ok(count)
         })
     }
@@ -38,11 +39,7 @@ impl PyTable {
         let table = self.inner.clone();
         let batch = arrow_bridge::record_batch_from_pyarrow(py, data)?;
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            table
-                .add(batch)
-                .execute()
-                .await
-                .map_err(error::to_py_err)?;
+            table.add(batch).execute().await.map_err(error::to_py_err)?;
             Ok(())
         })
     }
@@ -51,10 +48,7 @@ impl PyTable {
         let table = self.inner.clone();
         let predicate = predicate.to_string();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            table
-                .delete(&predicate)
-                .await
-                .map_err(error::to_py_err)?;
+            table.delete(&predicate).await.map_err(error::to_py_err)?;
             Ok(())
         })
     }

--- a/curvine-server/src/master/meta/fs_dir.rs
+++ b/curvine-server/src/master/meta/fs_dir.rs
@@ -449,7 +449,7 @@ impl FsDir {
     pub fn list_status(&self, inp: &InodePath) -> FsResult<Vec<FileStatus>> {
         let inode = match inp.get_last_inode() {
             Some(v) => v,
-            None => return Err(FsError::file_not_found(inp.path())),
+            None => return err_ext!(FsError::file_not_found(inp.path())),
         };
 
         match inode.as_ref() {
@@ -465,7 +465,7 @@ impl FsDir {
                 let inode_opt = self.store.get_inode(e.id, Some(&e.name))?;
                 match inode_opt {
                     Some(inode_view) => Ok(vec![inode_view.to_file_status(inp.path())]),
-                    None => Err(FsError::file_not_found(inp.path())),
+                    None => err_ext!(FsError::file_not_found(inp.path())),
                 }
             }
         }
@@ -486,7 +486,7 @@ impl FsDir {
     pub fn list_options(&self, inp: &InodePath, opts: &ListOptions) -> FsResult<Vec<FileStatus>> {
         let inode = match inp.get_last_inode() {
             Some(v) => v,
-            None => return Err(FsError::file_not_found(inp.path())),
+            None => return err_ext!(FsError::file_not_found(inp.path())),
         };
 
         match inode.as_ref() {
@@ -508,7 +508,7 @@ impl FsDir {
                         let status = inode_view.to_file_status(inp.path());
                         Ok(Self::list_single_file(status, opts))
                     }
-                    None => Err(FsError::file_not_found(inp.path())),
+                    None => err_ext!(FsError::file_not_found(inp.path())),
                 }
             }
         }


### PR DESCRIPTION
## Summary

Wrap `FsError::file_not_found` with `err_ext!` in `list_status` and `list_options` to include source location (file:line) in error messages, consistent with other error sites in `fs_dir.rs`.

Related: #796

## Changes

- `fs_dir.rs`: 4 places where `Err(FsError::file_not_found(...))` → `err_ext!(FsError::file_not_found(...))`
  - `list_status` (line 452, 468)
  - `list_options` (line 489, 511)

## Test plan

- [x] `cargo check -p curvine-server` passes
- [x] Curvine integration test passes with live cluster
- [x] All 15 Python SDK tests pass