### PR TITLE
fix: export renamed fs-mode files when ufs source is missing (#844)

### DIFF
--- a/curvine-server/src/master/journal/ufs_loader.rs
+++ b/curvine-server/src/master/journal/ufs_loader.rs
@@ -139,7 +139,10 @@ impl UfsLoader {
                     src_ufs_path,
                     dst.full_path()
                 );
-                self.submit_load_task(&dst, &mnt).await?;
+                if let Some((_, dst_mnt)) = self.get_mnt(&dst)? {
+                    // Keep journal apply aligned with fs_mode's durable export contract.
+                    self.submit_load_task(&dst, &dst_mnt).await?;
+                }
                 return Ok(());
             }
 

--- a/curvine-server/src/master/journal/ufs_loader.rs
+++ b/curvine-server/src/master/journal/ufs_loader.rs
@@ -134,7 +134,12 @@ impl UfsLoader {
         let dst = Path::from_str(&e.dst)?;
         if let Some((src_ufs_path, mnt)) = self.get_mnt(&src)? {
             if !mnt.ufs.exists(&src_ufs_path).await? {
-                warn!("rename: src file not exists: {}", src_ufs_path);
+                warn!(
+                    "rename: src file not exists: {}, loading dst {}",
+                    src_ufs_path,
+                    dst.full_path()
+                );
+                self.submit_load_task(&dst, &mnt).await?;
                 return Ok(());
             }
 


### PR DESCRIPTION
## Summary

- export the renamed destination path when fs_mode rename sees that the UFS source path is missing
- keep the change scoped to UfsLoader rename handling

## Root Cause

StarRocks writes segment files through a temporary path and then renames it to the final .dat path. The fs_mode auto-export path may try to export the temporary path after it has already been renamed. When UfsLoader handled the rename journal entry, it returned early if the UFS source path did not exist, leaving the final Curvine file without a UFS copy.

## Fix

When the UFS source path is missing during fs_mode rename handling, submit a load task for the destination path instead of silently skipping the entry. This exports the final visible path to UFS.

Fixes #844

## Validation

- cargo fmt
- cargo fmt --check
- cargo clippy --all-targets --jobs 2 -- --deny=warnings --allow clippy::uninlined-format-args
- git diff --check