### PR TITLE
fix: resolve cv authority paths against mount table (#842)

### DIFF
--- a/curvine-common/src/fs/path.rs
+++ b/curvine-common/src/fs/path.rs
@@ -210,28 +210,32 @@ impl Path {
             return result;
         }
 
-        let mut current_path = match self.scheme() {
-            Some(FsKind::SCHEME_FILE) => {
-                let sp = if self.path.starts_with(Self::SEPARATOR) {
-                    Self::SEPARATOR
-                } else {
-                    ""
-                };
-                format!(
-                    "{}{}{}{}",
-                    FsKind::SCHEME_FILE,
+        let mut current_path = if self.is_cv() {
+            Self::SEPARATOR.to_string()
+        } else {
+            match self.scheme() {
+                Some(FsKind::SCHEME_FILE) => {
+                    let sp = if self.path.starts_with(Self::SEPARATOR) {
+                        Self::SEPARATOR
+                    } else {
+                        ""
+                    };
+                    format!(
+                        "{}{}{}{}",
+                        FsKind::SCHEME_FILE,
+                        Self::SCHEME_DELIMITER,
+                        sp,
+                        self.authority().unwrap_or("")
+                    )
+                }
+                Some(v) => format!(
+                    "{}{}{}",
+                    v,
                     Self::SCHEME_DELIMITER,
-                    sp,
                     self.authority().unwrap_or("")
-                )
+                ),
+                None => Self::SEPARATOR.to_string(),
             }
-            Some(v) => format!(
-                "{}{}{}",
-                v,
-                Self::SCHEME_DELIMITER,
-                self.authority().unwrap_or("")
-            ),
-            None => Self::SEPARATOR.to_string(),
         };
 
         for part in parts {
@@ -370,6 +374,11 @@ mod tests {
     #[test]
     fn get_possible_mounts() -> CommonResult<()> {
         let p1 = Path::from_str("/a/b/c")?;
+        let mnts = p1.get_possible_mounts();
+        println!("{:?}", mnts);
+        assert_eq!(mnts, Vec::from(["/", "/a", "/a/b", "/a/b/c"]));
+
+        let p1 = Path::from_str("cv://curvine-pro/a/b/c")?;
         let mnts = p1.get_possible_mounts();
         println!("{:?}", mnts);
         assert_eq!(mnts, Vec::from(["/", "/a", "/a/b", "/a/b/c"]));

--- a/curvine-common/src/fs/path.rs
+++ b/curvine-common/src/fs/path.rs
@@ -213,8 +213,11 @@ impl Path {
         let mut current_path = if self.is_cv() {
             Self::SEPARATOR.to_string()
         } else {
-            match self.scheme() {
-                Some(FsKind::SCHEME_FILE) => {
+            match self
+                .scheme()
+                .expect("non-CV paths must have a non-CV scheme")
+            {
+                FsKind::SCHEME_FILE => {
                     let sp = if self.path.starts_with(Self::SEPARATOR) {
                         Self::SEPARATOR
                     } else {
@@ -228,13 +231,12 @@ impl Path {
                         self.authority().unwrap_or("")
                     )
                 }
-                Some(v) => format!(
+                v => format!(
                     "{}{}{}",
                     v,
                     Self::SCHEME_DELIMITER,
                     self.authority().unwrap_or("")
                 ),
-                None => Self::SEPARATOR.to_string(),
             }
         };
 

--- a/curvine-common/src/state/mount.rs
+++ b/curvine-common/src/state/mount.rs
@@ -435,6 +435,12 @@ mod tests {
             info.get_ufs_path(&path).unwrap().full_path(),
             "s3://spark/test1/test/dt=2025/1.csv"
         );
+
+        let path = Path::from_str("cv://curvine-pro/spark/test1/test/dt=2025/1.csv").unwrap();
+        assert_eq!(
+            info.get_ufs_path(&path).unwrap().full_path(),
+            "s3://spark/test1/test/dt=2025/1.csv"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- treat cv://authority/... paths as Curvine internal paths when generating mount lookup candidates
- keep non-Curvine schemes such as s3://, file://, oss://, and hdfs:// on the existing scheme://authority candidate path
- add regression coverage for cv://authority mount candidate generation and CV-to-UFS conversion

## Root Cause

Curvine stores CV mount table keys as plain internal paths, for example /acc-hdfs/starrocks. However, Path::get_possible_mounts() generated candidates such as cv://curvine-pro/acc-hdfs/starrocks for cv://authority/... paths. That made mount lookup miss an existing CV mount when callers passed a full Curvine URI.

## Fix

When a path is a Curvine path, including both /path and cv://authority/path forms, mount candidates now start from /. The authority still remains available on the parsed Path, but it is not used as part of the CV mount key.

The non-CV branch now explicitly assumes a non-CV scheme, so schemeless CV paths cannot appear in that branch as dead code.

## Mount Lookup Audit

I checked the other mount-key paths called out in review:

- server-side MountManager/MountTable routes lookups through Path::get_possible_mounts() and then chooses mountpath2id for CV paths, so cv://authority/... is covered by this fix.
- client-side MountCache also iterates Path::get_possible_mounts() and indexes cv_map only for CV paths; CV cache removal uses path.path(), not the raw URI.
- UfsLoader and JobManager::get_mnt() route through MountManager::get_mount_info(), so they inherit the same normalized CV mount lookup.
- curvine-server/src/common/ufs_manager.rs caches by UFS base URI and asks the master for mount info using a UFS Path; it does not derive CV mount keys from cv://authority/... inputs.

Fixes #842

## Validation

- cargo test -p curvine-common fs::path::tests::get_possible_mounts -- --nocapture
- cargo test -p curvine-common state::mount::tests::test_path_cst -- --nocapture
- cargo test -p curvine-common
- cargo fmt
- cargo fmt --check
- cargo clippy --all-targets --jobs 2 -- --deny=warnings --allow clippy::uninlined-format-args
- git diff --check