### PR TITLE
fix(fuse): refresh inode size after write for POSIX visibility

### DIFF
--- a/build/tests/fuse-test.sh
+++ b/build/tests/fuse-test.sh
@@ -58,6 +58,7 @@ This script tests basic filesystem operations including:
   - Symbolic and hard links
   - File permissions (chmod, chown, chgrp)
   - Sed in-place editing
+  - Pwrite visibility (file size and content after pwrite)
 
 For FIO performance tests, use fio-test.sh instead.
 
@@ -1245,6 +1246,50 @@ test_fuse_reload() {
     fi
 }
 
+# Test 17: Pwrite visibility test
+test_pwrite_visibility() {
+    CURRENT_TEST_GROUP="Test 17: Pwrite Visibility"
+    print_header "$CURRENT_TEST_GROUP"
+
+    if ! command -v python3 >/dev/null 2>&1 && ! command -v python >/dev/null 2>&1; then
+        print_info "Python not available, skipping pwrite visibility test"
+        return
+    fi
+
+    local python_cmd
+    python_cmd=$(command -v python3 2>/dev/null || command -v python)
+    local test_script="$SCRIPT_DIR/scripts/visibility_test.py"
+
+    if [ ! -f "$test_script" ]; then
+        print_info "Pwrite visibility test script not found: $test_script"
+        print_info "Skipping pwrite visibility test"
+        return
+    fi
+
+    print_test "Testing file size and content visibility after pwrite"
+    TOTAL_TESTS=$((TOTAL_TESTS + 1))
+
+    local start_time
+    start_time=$(date +%s)
+    local result=0
+
+    if $python_cmd "$test_script" --dir "$TEST_DIR" 2>&1; then
+        result=0
+    else
+        result=$?
+    fi
+
+    local end_time
+    end_time=$(date +%s)
+    local elapsed=$((end_time - start_time))
+
+    if [ $result -eq 0 ]; then
+        print_success "Pwrite visibility test completed successfully in ${elapsed}s"
+    else
+        handle_error "Pwrite visibility test failed" "python $test_script --dir $TEST_DIR"
+    fi
+}
+
 # Test 16: Git clone operations
 test_git_clone() {
     CURRENT_TEST_GROUP="Test 16: Git Clone Operations"
@@ -1393,6 +1438,7 @@ main() {
     test_delayed_delete
     test_python_high_frequency_write
     test_fuse_reload
+    test_pwrite_visibility
     test_git_clone
 
     print_info "All test functions completed"

--- a/build/tests/scripts/visibility_test.py
+++ b/build/tests/scripts/visibility_test.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Visibility test for file size and content after pwrite.
+
+Usage:
+    python3 visibility_test.py --dir /curvine-fuse
+"""
+
+import argparse
+import os
+import sys
+
+WRITE_SIZE = 1024
+DEFAULT_DIR = "/curvine-fuse"
+TEST_FILE = "visibility-test"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Visibility test for file size and content after pwrite",
+    )
+    parser.add_argument("--dir", default=DEFAULT_DIR, help="Directory for test files")
+    args = parser.parse_args()
+
+    path = os.path.join(os.path.abspath(args.dir), TEST_FILE)
+    data = b"A" * WRITE_SIZE
+
+    try:
+        os.unlink(path)
+    except FileNotFoundError:
+        pass
+
+    fd = os.open(path, os.O_RDWR | os.O_CREAT | os.O_TRUNC, 0o644)
+    try:
+        if os.pwrite(fd, data, 0) != WRITE_SIZE:
+            print("ERROR: pwrite short write", file=sys.stderr)
+            return 1
+
+        size = os.fstat(fd).st_size
+        print(f"size={size} (expect {WRITE_SIZE})")
+        if size != WRITE_SIZE:
+            print("ERROR: size mismatch", file=sys.stderr)
+            return 1
+
+        read_buf = os.pread(fd, WRITE_SIZE, 0)
+        if read_buf != data:
+            print("ERROR: read content mismatch", file=sys.stderr)
+            return 1
+
+        print("PASS")
+        return 0
+    finally:
+        os.close(fd)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -668,16 +668,9 @@ impl fs::FileSystem for CurvineFileSystem {
         let res = self.lookup_status(parent, name.as_deref(), &status);
 
         let entry = match res {
-            Ok(attr) => {
-                let mut entry = Self::create_entry_out(&self.conf, attr);
-                let keep_attr = self.state.should_keep_attr(entry.nodeid, &status)?;
-                if !keep_attr {
-                    entry.entry_valid = 0;
-                    entry.attr_valid = 0;
-                    entry.entry_valid_nsec = 0;
-                    entry.attr_valid_nsec = 0;
-                }
-                entry
+            Ok(mut attr) => {
+                self.state.update_writer_len(&mut attr).await;
+                Self::create_entry_out(&self.conf, attr)
             }
 
             Err(e) if e.errno == libc::ENOENT && !self.conf.negative_ttl.is_zero() => {
@@ -879,20 +872,11 @@ impl fs::FileSystem for CurvineFileSystem {
 
         let mut fuse_attr = Self::status_to_attr(&self.conf, &status)?;
         fuse_attr.ino = op.header.nodeid;
-
-        let keep_cache = self.state.should_keep_attr(op.header.nodeid, &status)?;
-        let (attr_valid, attr_valid_nsec) = if keep_cache {
-            (
-                self.conf.attr_ttl.as_secs(),
-                self.conf.attr_ttl.subsec_nanos(),
-            )
-        } else {
-            (0, 0)
-        };
+        self.state.update_writer_len(&mut fuse_attr).await;
 
         let attr = fuse_attr_out {
-            attr_valid,
-            attr_valid_nsec,
+            attr_valid: self.conf.attr_ttl.as_secs(),
+            attr_valid_nsec: self.conf.attr_ttl.subsec_nanos(),
             dummy: 0,
             attr: fuse_attr,
         };
@@ -1131,7 +1115,7 @@ impl fs::FileSystem for CurvineFileSystem {
         } else {
             let keep_cache = self
                 .state
-                .should_keep_cache(op.header.nodeid, handle.status())?;
+                .should_keep_cache(op.header.nodeid, handle.status());
             if keep_cache {
                 open_flags |= FUSE_FOPEN_KEEP_CACHE;
             } else {

--- a/curvine-fuse/src/fs/fuse_writer.rs
+++ b/curvine-fuse/src/fs/fuse_writer.rs
@@ -26,7 +26,7 @@ use orpc::runtime::{RpcRuntime, Runtime};
 use orpc::sync::channel::{AsyncChannel, AsyncReceiver, AsyncSender, CallChannel, CallSender};
 use orpc::sync::ErrorMonitor;
 use orpc::sys::DataSlice;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use tokio_util::bytes::Bytes;
 
 enum WriteTask {
@@ -42,6 +42,7 @@ pub struct FuseWriter {
     err_monitor: Arc<ErrorMonitor<FsError>>,
     status: FileStatus,
     is_ufs: bool,
+    len: Arc<Mutex<i64>>,
 }
 
 impl FuseWriter {
@@ -53,9 +54,11 @@ impl FuseWriter {
 
         let status = writer.status().clone();
         let monitor = err_monitor.clone();
+        let len = Arc::new(Mutex::new(status.len));
 
+        let len1 = len.clone();
         rt.spawn(async move {
-            let res = Self::writer_future(writer, receiver).await;
+            let res = Self::writer_future(writer, receiver, len1).await;
             match res {
                 Ok(_) => (),
 
@@ -72,6 +75,7 @@ impl FuseWriter {
             err_monitor,
             status,
             is_ufs,
+            len,
         }
     }
 
@@ -127,9 +131,18 @@ impl FuseWriter {
         fun.await.map_err(|e| self.check_error(e))
     }
 
+    pub fn len(&self) -> i64 {
+        *self.len.lock().unwrap()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     async fn writer_future(
         mut writer: UnifiedWriter,
         mut req_receiver: AsyncReceiver<WriteTask>,
+        file_len: Arc<Mutex<i64>>,
     ) -> FsResult<()> {
         while let Some(task) = req_receiver.recv().await {
             match task {
@@ -142,6 +155,12 @@ impl FuseWriter {
                             size: len as u32,
                             padding: 0,
                         });
+
+                    if res.is_ok() {
+                        let mut lock = file_len.lock().unwrap();
+                        *lock = lock.max(off + len as i64);
+                    }
+
                     reply.send_rep(res).await?;
                 }
 

--- a/curvine-fuse/src/fs/state/node_state.rs
+++ b/curvine-fuse/src/fs/state/node_state.rs
@@ -89,48 +89,38 @@ impl NodeState {
         self.node_read().get_check(id).cloned()
     }
 
-    /// Update node cache state and return cache validity info.
-    ///
-    /// Returns (is_first_access, is_changed) where:
-    /// - is_first_access: true if this is the first access (cache_valid was false)
-    /// - is_changed: true if file mtime or len has changed
-    ///
-    /// Usage patterns:
-    /// 1. For page cache (should_keep_cache):
-    ///    - Cache is valid if: is_first_access || !is_changed
-    ///    - First access OR unchanged mtime/len → cache is valid
-    ///    - We don't use kernel notification (FUSE_NOTIFY_INVAL_INODE) as it causes deadlocks in practice
-    ///
-    /// 2. For attr cache (should_keep_attr):
-    ///    - Cache is valid if: !is_first_access || !is_changed
-    ///    - Non-first access OR unchanged mtime/len → cache is valid
-    ///    - First access AND changed → cache is invalid (returns false)
-    ///    - Note: Non-first access always keeps cache (returns true), but mtime/len changes invalidate it
-    ///    - This helps prevent reading outdated attributes in time-sensitive scenarios (e.g., git clone)
-    ///    - The logic ensures that once a file is accessed, subsequent lookups with unchanged attributes
-    ///      can use cached values, but any change to mtime/len will force cache invalidation
-    fn update_cache_state(&self, id: u64, status: &FileStatus) -> FuseResult<(bool, bool)> {
+    fn update_cache_state(&self, id: u64, status: &FileStatus) -> bool {
         let mut lock = self.node_write();
-        let attr = lock.get_mut_check(id)?;
+        let Some(attr) = lock.get_mut(id) else {
+            return false;
+        };
 
-        let is_first_access = !attr.cache_valid;
         let is_changed = status.mtime != attr.mtime || status.len != attr.len;
 
         attr.cache_valid = true;
         attr.mtime = status.mtime;
         attr.len = status.len;
 
-        Ok((is_first_access, is_changed))
+        is_changed
     }
 
-    pub fn should_keep_cache(&self, id: u64, status: &FileStatus) -> FuseResult<bool> {
-        let (is_first_access, is_changed) = self.update_cache_state(id, status)?;
-        Ok(is_first_access || !is_changed)
+    pub fn should_keep_cache(&self, id: u64, status: &FileStatus) -> bool {
+        let is_changed = self.update_cache_state(id, status);
+        !is_changed
     }
 
-    pub fn should_keep_attr(&self, id: u64, status: &FileStatus) -> FuseResult<bool> {
-        let (is_first_access, is_changed) = self.update_cache_state(id, status)?;
-        Ok(!is_first_access || !is_changed)
+    pub async fn update_writer_len(&self, attr: &mut fuse_attr) {
+        if let Some(len) = self.get_writer_len(attr.ino).await {
+            attr.size = attr.size.max(len)
+        }
+    }
+
+    pub async fn get_writer_len(&self, ino: u64) -> Option<u64> {
+        if let Some(writer) = self.find_writer(&ino) {
+            return Some(writer.lock().await.len() as u64);
+        }
+
+        None
     }
 
     pub fn get_path_common<T: AsRef<str>>(&self, parent: u64, name: Option<T>) -> FuseResult<Path> {


### PR DESCRIPTION
## Summary

Fixes [#837](https://github.com/CurvineIO/curvine/issues/837): after `pwrite()` on a Curvine FUSE mount, `fstat()` / `pread()` on the same fd could observe a stale file size (often `0`) until `fsync()`, `close`, or another attribute refresh.

- Track the current write extent in `FuseWriter` and expose it through `update_writer_len()` on `lookup` / `getattr`.
- Refresh `fuse_attr.size` from the active writer before returning attributes to the kernel.
- Simplify `NodeState` cache helpers: drop `should_keep_attr` zero-TTL workaround; keep page-cache decisions based on metadata change detection.
- Add `build/tests/scripts/visibility_test.py` and run it from `fuse-test.sh` (Test 17: Pwrite Visibility).

## Problem

Per [issue #837](https://github.com/CurvineIO/curvine/issues/837), a successful `pwrite()` did not update the kernel-side inode size. Subsequent `fstat()`, `lseek(SEEK_END)`, `read()`, and `pread()` on the same fd could see the pre-write size until one of:

- `fsync(fd)`
- `ftruncate()`
- close + re-open (`FUSE_LOOKUP`)
- dropping kernel caches

This breaks POSIX read-after-write visibility (size and reads should reflect the write without an intermediate `fsync`).

Root causes called out in the issue:

1. `fuse_write_out` carries only byte count (no piggybacked `fuse_attr`).
2. No `FUSE_NOTIFY_INVAL_INODE` after write.
3. Daemon meta cache invalidation was delayed until flush/fsync/close.

## Solution

| Area | Change |
|------|--------|
| `fuse_writer.rs` | Maintain `len` updated on each successful write; expose `len()` for in-flight size. |
| `node_state.rs` | Add `update_writer_len()` / `get_writer_len()`; simplify `should_keep_cache()`. |
| `curvine_file_system.rs` | Apply `update_writer_len()` on lookup/getattr; use consistent `attr_ttl` on getattr. |
| Tests | `visibility_test.py`: `pwrite` 1024 B → `fstat` size check → `pread` content check; integrated into `fuse-test.sh`. |

After the fix, post-`pwrite` `fstat()` and `pread()` on the same fd should see the updated size and data immediately.

## Test plan

- [ ] On a Curvine FUSE mount: `python3 build/tests/scripts/visibility_test.py --dir /curvine-fuse/fuse-test` → `PASS`
- [ ] Run `./build/tests/fuse-test.sh` and confirm **Test 17: Pwrite Visibility** passes
- [ ] Reproduce issue #837 C cases (optional): `fstat` after `pwrite` without `fsync` should report `4096`, not `0`
- [ ] Smoke: `lookup` / `getattr` / `open` on files with active writers; no regressions in git-clone or reload tests