### PR TITLE
chore: cherry-picks 12 commits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1171,6 +1171,9 @@ name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "bitpacking"
@@ -2039,6 +2042,7 @@ dependencies = [
  "axum",
  "bindgen",
  "bitflags 2.10.0",
+ "bytes",
  "clap",
  "curvine-client",
  "curvine-common",
@@ -6091,6 +6095,7 @@ dependencies = [
  "nix",
  "num_enum",
  "once_cell",
+ "parking_lot",
  "pin-project-lite",
  "pkg-config",
  "prometheus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,7 @@ bitvec = "1.0.1"
 config = "0.13.4"
 tempfile = "3.21.0"
 md-5 = "0.10.6"
-bitflags = "2.10.0"
+bitflags = { version = "2.10.0", features = ["serde"] }
 glob = "0.3"
 lru = "0.16.1"
 

--- a/build/build.sh
+++ b/build/build.sh
@@ -318,7 +318,7 @@ fi
 
 build_curvine_libsdk() {
   local sdk_feature="$1"
-  local sdk_cmd="cargo build $PROFILE -p curvine-libsdk --no-default-features --features curvine-common/${ALLOC},${sdk_feature}"
+  local sdk_cmd="cargo build $PROFILE -p curvine-libsdk --no-default-features --features curvine-common/system,${sdk_feature}"
   echo "Building curvine-libsdk with feature: ${sdk_feature}"
   echo "Build command: ${sdk_cmd}"
   eval "$sdk_cmd"

--- a/build/static-link-wrapper.sh
+++ b/build/static-link-wrapper.sh
@@ -1,13 +1,23 @@
 #!/bin/bash
-# Linker wrapper that forces -lstdc++, -lgcc_s, and -lz to link statically.
-# Needed because crate build scripts (e.g. librocksdb-sys) emit
-# `cargo:rustc-link-lib=stdc++` which lands in the -Bdynamic section.
+# Cargo linker wrapper. When CURVINE_STATIC_LINK=1, forces -lstdc++, -lgcc_s,
+# and -lz to link statically. Needed because crate build scripts (e.g.
+# librocksdb-sys) emit `cargo:rustc-link-lib=stdc++` which lands in the
+# -Bdynamic section.
 #
 # NOTE: gcc/clang support comma-separated `-Wl,...` lists. This wrapper
 # emits `-Wl,-Bstatic` / `-Wl,-Bdynamic` as separate args around the
 # affected libraries to preserve the intended linker mode transitions.
+#
+# Usage:
+#   CURVINE_STATIC_LINK=1 cargo build --release
+#
+# Without the variable (default), arguments are passed through unchanged.
 
 set -euo pipefail
+
+if [ "${CURVINE_STATIC_LINK:-0}" != "1" ]; then
+    exec "${CC:-cc}" "$@"
+fi
 
 NEWARGS=()
 for arg in "$@"; do

--- a/curvine-client/src/file/fs_reader.rs
+++ b/curvine-client/src/file/fs_reader.rs
@@ -16,7 +16,7 @@ use crate::file::{FsContext, FsReaderBuffer, ReadDetector};
 use curvine_common::fs::{Path, Reader};
 use curvine_common::state::{FileBlocks, FileStatus};
 use curvine_common::FsResult;
-use log::info;
+use log::debug;
 use orpc::common::{ByteUnit, TimeSpent};
 use orpc::err_box;
 use orpc::sys::DataSlice;
@@ -41,7 +41,7 @@ impl FsReader {
 
         let read_detector = ReadDetector::with_conf(conf, len);
 
-        info!(
+        debug!(
             "Create reader, path={}, len={}, blocks={}, chunk_size={}, chunk_number={}, read_parallel={}, slice_size={}, read_ahead={}-{}",
             &file_blocks.status.path,
             ByteUnit::byte_to_string(len as u64),
@@ -132,6 +132,6 @@ impl Reader for FsReader {
 
 impl Drop for FsReader {
     fn drop(&mut self) {
-        info!("Close reader, path={}", self.path())
+        debug!("Close reader, path={}", self.path())
     }
 }

--- a/curvine-client/src/file/fs_writer.rs
+++ b/curvine-client/src/file/fs_writer.rs
@@ -17,7 +17,7 @@ use bytes::BytesMut;
 use curvine_common::fs::{Path, Writer};
 use curvine_common::state::{FileAllocOpts, FileBlocks, FileStatus};
 use curvine_common::FsResult;
-use log::{debug, info};
+use log::debug;
 use orpc::common::{ByteUnit, TimeSpent};
 use orpc::sys::DataSlice;
 use orpc::{err_box, ternary};
@@ -39,7 +39,7 @@ impl FsWriter {
         let chunk_num = fs_context.write_chunk_num();
         let pos = ternary!(append, status.len, 0);
 
-        info!(
+        debug!(
             "Create writer, path={}, pos={}, len = {}, block_size={}, chunk_size={}, chunk_number={}, replicas={}",
             &status.path,
             pos,
@@ -158,6 +158,6 @@ impl Writer for FsWriter {
 
 impl Drop for FsWriter {
     fn drop(&mut self) {
-        info!("Close writer, path={}", self.path())
+        debug!("Close writer, path={}", self.path())
     }
 }

--- a/curvine-client/src/unified/unified_filesystem.rs
+++ b/curvine-client/src/unified/unified_filesystem.rs
@@ -253,7 +253,7 @@ impl UnifiedFileSystem {
                 .await?
             {
                 CacheValidity::Valid => {
-                    blocks.status.mtime = blocks.status.storage_policy.ufs_mtime;
+                    blocks.status.apply_ufs_fields();
                     let cv_reader = FsReader::new(cv_path.clone(), self.cv.fs_context(), blocks)?;
                     Ok(Some(FallbackFsReader::new(
                         cv_reader,
@@ -626,7 +626,7 @@ impl FileSystem<UnifiedWriter, UnifiedReader> for UnifiedFileSystem {
             Some((ufs_path, mnt)) => match self.cv.get_status(path).await {
                 Ok(mut v) => match self.check_cache_validity(&v, &ufs_path, &mnt).await? {
                     CacheValidity::Valid => {
-                        v.mtime = v.storage_policy.ufs_mtime;
+                        v.apply_ufs_fields();
                         Ok(v)
                     }
                     CacheValidity::Invalid(Some(ufs_status)) => Ok(ufs_status),

--- a/curvine-client/src/unified/unified_filesystem.rs
+++ b/curvine-client/src/unified/unified_filesystem.rs
@@ -27,10 +27,12 @@ use curvine_common::state::{
 };
 use curvine_common::utils::CommonUtils;
 use curvine_common::FsResult;
-use log::{error, info, warn};
+use log::{debug, error, info, warn};
 use orpc::common::TimeSpent;
 use orpc::runtime::{RpcRuntime, Runtime};
 use orpc::{err_box, err_ext};
+use std::borrow::Cow;
+use std::future::Future;
 use std::sync::Arc;
 
 #[allow(clippy::large_enum_variant)]
@@ -46,6 +48,7 @@ pub struct UnifiedFileSystem {
     mount_cache: Arc<MountCache>,
     enable_unified: bool,
     enable_read_ufs: bool,
+    audit_logging_enabled: bool,
     metrics: &'static ClientMetrics,
 }
 
@@ -54,6 +57,7 @@ impl UnifiedFileSystem {
         let update_interval = conf.client.mount_update_ttl;
         let enable_unified = conf.client.enable_unified_fs;
         let enable_read_ufs = conf.client.enable_rust_read_ufs;
+        let audit_logging_enabled = conf.client.audit_logging_enabled;
 
         let cv = CurvineFileSystem::with_rt(conf, rt.clone())?;
         let fs = UnifiedFileSystem {
@@ -61,10 +65,58 @@ impl UnifiedFileSystem {
             mount_cache: Arc::new(MountCache::new(update_interval.as_millis() as u64)),
             enable_unified,
             enable_read_ufs,
+            audit_logging_enabled,
             metrics: FsContext::get_metrics(),
         };
 
         Ok(fs)
+    }
+
+    fn audit<T>(
+        &self,
+        cmd: &str,
+        src: &str,
+        dst: &str,
+        res: FsResult<T>,
+        used_us: u64,
+    ) -> FsResult<T> {
+        if self.audit_logging_enabled {
+            let err_suffix: Cow<'_, str> = match &res {
+                Err(e) => Cow::Owned(format!(" err={:?}", e.kind())),
+                Ok(_) => Cow::Borrowed(""),
+            };
+            info!(
+                target: "audit",
+                "cmd={} ok={} src={} dst={} usedUs={}{}",
+                cmd,
+                res.is_ok(),
+                src,
+                dst,
+                used_us,
+                err_suffix,
+            );
+        }
+
+        res
+    }
+
+    fn op_metric(&self, cmd: &str, used_us: u64) {
+        self.metrics
+            .metadata_operation_duration
+            .with_label_values(&[cmd])
+            .observe(used_us as f64);
+    }
+
+    async fn track<F, T>(&self, cmd: &str, src: &str, dst: &str, fut: F) -> FsResult<T>
+    where
+        F: Future<Output = FsResult<T>>,
+    {
+        let spent = TimeSpent::new();
+        let res = fut.await;
+        let used_us = spent.used_us();
+
+        self.op_metric(cmd, used_us);
+        self.audit(cmd, src, dst, res, used_us)
     }
 
     pub fn conf(&self) -> &ClusterConf {
@@ -113,23 +165,32 @@ impl UnifiedFileSystem {
     }
 
     pub async fn get_master_info(&self) -> FsResult<MasterInfo> {
-        self.cv.get_master_info().await
+        let fut = async { self.cv.get_master_info().await };
+        self.track("GetMasterInfo", "", "", fut).await
     }
 
     pub async fn get_master_info_bytes(&self) -> FsResult<BytesMut> {
-        self.cv.get_master_info_bytes().await
+        let fut = async { self.cv.get_master_info_bytes().await };
+        self.track("GetMasterInfo", "", "", fut).await
     }
 
     pub async fn mount(&self, ufs_path: &Path, cv_path: &Path, opts: MountOptions) -> FsResult<()> {
-        self.cv.mount(ufs_path, cv_path, opts).await?;
-        self.mount_cache.check_update(self, true).await?;
-        Ok(())
+        let fut = async {
+            self.cv.mount(ufs_path, cv_path, opts).await?;
+            self.mount_cache.check_update(self, true).await?;
+            Ok(())
+        };
+        self.track("Mount", cv_path.path(), ufs_path.full_path(), fut)
+            .await
     }
 
     pub async fn umount(&self, cv_path: &Path) -> FsResult<()> {
-        self.cv.umount(cv_path).await?;
-        self.mount_cache.remove(cv_path);
-        Ok(())
+        let fut = async {
+            self.cv.umount(cv_path).await?;
+            self.mount_cache.remove(cv_path);
+            Ok(())
+        };
+        self.track("Umount", cv_path.path(), "", fut).await
     }
 
     pub async fn toggle_path(&self, path: &Path, check_cache: bool) -> FsResult<Option<Path>> {
@@ -153,15 +214,18 @@ impl UnifiedFileSystem {
     }
 
     pub async fn get_mount_info(&self, path: &Path) -> FsResult<Option<MountInfo>> {
-        self.cv.get_mount_info(path).await
+        let fut = async { self.cv.get_mount_info(path).await };
+        self.track("GetMountInfo", path.path(), "", fut).await
     }
 
     pub async fn get_mount_info_bytes(&self, path: &Path) -> FsResult<BytesMut> {
-        self.cv.get_mount_info_bytes(path).await
+        let fut = async { self.cv.get_mount_info_bytes(path).await };
+        self.track("GetMountInfo", path.path(), "", fut).await
     }
 
     pub async fn get_mount_table(&self) -> FsResult<Vec<MountInfo>> {
-        self.cv.get_mount_table().await
+        let fut = async { self.cv.get_mount_table().await };
+        self.track("GetMountTable", "", "", fut).await
     }
 
     pub fn clone_runtime(&self) -> Arc<Runtime> {
@@ -169,33 +233,46 @@ impl UnifiedFileSystem {
     }
 
     pub async fn free(&self, path: &Path, recursive: bool) -> FsResult<FreeResult> {
-        match self.get_mount(path).await? {
-            None => err_box!(
-                "the current path is not mounted to ufs, so the `free` command cannot be executed."
-            ),
-            Some(_) => self.cv.free(path, recursive).await,
-        }
+        let fut = async {
+            match self.get_mount(path).await? {
+                None => err_box!(
+                    "the current path is not mounted to ufs, so the `free` command cannot be executed."
+                ),
+                Some(_) => self.cv.free(path, recursive).await,
+            }
+        };
+        self.track("Free", path.path(), "", fut).await
     }
 
     pub async fn symlink(&self, target: &str, link: &Path, force: bool) -> FsResult<()> {
-        match self.get_mount_checked(link).await? {
-            None => self.cv.symlink(target, link, force).await,
-            Some(_) => err_ext!(FsError::unsupported("symlink")),
-        }
+        let fut = async {
+            match self.get_mount_checked(link).await? {
+                None => self.cv.symlink(target, link, force).await,
+                Some(_) => err_ext!(FsError::unsupported("symlink")),
+            }
+        };
+        self.track("Symlink", target, link.path(), fut).await
     }
 
     pub async fn link(&self, src_path: &Path, dst_path: &Path) -> FsResult<()> {
-        match self.get_mount_checked(src_path).await? {
-            None => self.cv.link(src_path, dst_path).await,
-            Some(_) => err_ext!(FsError::unsupported("link")),
-        }
+        let fut = async {
+            match self.get_mount_checked(src_path).await? {
+                None => self.cv.link(src_path, dst_path).await,
+                Some(_) => err_ext!(FsError::unsupported("link")),
+            }
+        };
+        self.track("Link", src_path.path(), dst_path.path(), fut)
+            .await
     }
 
     pub async fn resize(&self, path: &Path, opts: FileAllocOpts) -> FsResult<()> {
-        match self.get_mount_checked(path).await? {
-            None => self.cv.resize(path, opts).await,
-            Some(_) => err_ext!(FsError::unsupported("resize")),
-        }
+        let fut = async {
+            match self.get_mount_checked(path).await? {
+                None => self.cv.resize(path, opts).await,
+                Some(_) => err_ext!(FsError::unsupported("resize")),
+            }
+        };
+        self.track("Resize", path.path(), "", fut).await
     }
 
     async fn check_cache_validity(
@@ -269,16 +346,35 @@ impl UnifiedFileSystem {
     pub fn async_cache(&self, source_path: &Path) -> FsResult<()> {
         let client = JobMasterClient::new(self.fs_client());
         let source_path = source_path.clone_uri();
+        let log = self.audit_logging_enabled;
+        let metrics = self.metrics;
 
         self.fs_context().rt().spawn(async move {
+            let time = TimeSpent::new();
             let command = LoadJobCommand::builder(source_path.clone()).build();
             let res = client.submit_load_job(command).await;
+
+            let used_us = time.used_us();
+            metrics
+                .metadata_operation_duration
+                .with_label_values(&["SubmitJob"])
+                .observe(used_us as f64);
+
             match res {
                 Err(e) => warn!("submit async cache error for {}: {}", source_path, e),
-                Ok(res) => info!(
-                    "submit async cache successfully for {}, job id {}, target_path {}",
-                    source_path, res.job_id, res.target_path
-                ),
+                Ok(res) => {
+                    if log {
+                        info!(
+                            target: "audit",
+                            "cmd={} ok={} src={} dst={} usedUs={}",
+                            "SubmitJob",
+                            true,
+                            source_path,
+                            res.target_path,
+                           used_us
+                        );
+                    }
+                }
             }
         });
 
@@ -365,48 +461,61 @@ impl UnifiedFileSystem {
         opts: CreateFileOpts,
         flags: OpenFlags,
     ) -> FsResult<UnifiedWriter> {
-        match self.get_mount(path).await? {
-            None => {
-                let writer = self.cv.open_with_opts(path, opts, flags).await?;
-                Ok(UnifiedWriter::Cv(writer))
-            }
+        let time = TimeSpent::new();
+        let mut write_path = path.path().to_owned();
 
-            Some((_, mount)) if mount.info.is_fs_mode() => {
-                let opts = mount.info.merge_create_opts(opts);
-                let mut writer = self.cv.open_with_opts(path, opts.clone(), flags).await?;
-                if writer.file_blocks().data_exists() || flags.overwrite() {
-                    Ok(UnifiedWriter::Cv(writer))
-                } else {
-                    writer.complete().await?;
-
-                    info!(
-                        "copying data from UFS to CV, path={}, len={}",
-                        path,
-                        writer.status().len
-                    );
-                    self.copy_ufs_file(path, &mount, opts.clone(), writer.status().len)
-                        .await?;
-
+        let fut = async {
+            match self.get_mount(path).await? {
+                None => {
                     let writer = self.cv.open_with_opts(path, opts, flags).await?;
                     Ok(UnifiedWriter::Cv(writer))
                 }
-            }
 
-            Some((ufs_path, mount)) => {
-                if let Err(e) = self.cv.delete(path, false).await {
-                    if !matches!(e, FsError::FileNotFound(_)) {
-                        warn!("failed to delete cache for {}: {}", path, e);
+                Some((_, mount)) if mount.info.is_fs_mode() => {
+                    let opts = mount.info.merge_create_opts(opts);
+                    let mut writer = self.cv.open_with_opts(path, opts.clone(), flags).await?;
+                    if writer.file_blocks().data_exists() || flags.overwrite() {
+                        Ok(UnifiedWriter::Cv(writer))
+                    } else {
+                        writer.complete().await?;
+
+                        info!(
+                            "copying data from UFS to CV, path={}, len={}",
+                            path,
+                            writer.status().len
+                        );
+                        self.copy_ufs_file(path, &mount, opts.clone(), writer.status().len)
+                            .await?;
+
+                        let writer = self.cv.open_with_opts(path, opts, flags).await?;
+                        Ok(UnifiedWriter::Cv(writer))
                     }
                 }
 
-                let writer = if flags.append() {
-                    mount.ufs.append(&ufs_path).await?
-                } else {
-                    mount.ufs.create(&ufs_path, flags.overwrite()).await?
-                };
-                Ok(writer)
+                Some((ufs_path, mount)) => {
+                    if let Err(e) = self.cv.delete(path, false).await {
+                        if !matches!(e, FsError::FileNotFound(_)) {
+                            warn!("failed to delete cache for {}: {}", path, e);
+                        }
+                    }
+
+                    write_path = ufs_path.full_path().to_owned();
+                    if flags.append() {
+                        mount.ufs.append(&ufs_path).await
+                    } else {
+                        mount.ufs.create(&ufs_path, flags.overwrite()).await
+                    }
+                }
             }
-        }
+        };
+
+        let res = fut.await;
+
+        let used_us = time.used_us();
+        self.op_metric("Open", used_us);
+
+        let cmd = format!("Open:{}", flags.access_mark());
+        self.audit(&cmd, &write_path, "", res, used_us)
     }
 
     pub async fn mkdir_with_opts(
@@ -414,21 +523,21 @@ impl UnifiedFileSystem {
         path: &Path,
         opts: MkdirOpts,
     ) -> FsResult<Option<FileStatus>> {
-        match self.get_mount_checked(path).await? {
-            None => {
-                let status = self.cv.mkdir_with_opts(path, opts).await?;
-                Ok(Some(status))
-            }
+        let fut = async {
+            match self.get_mount_checked(path).await? {
+                None => Ok(Some(self.cv.mkdir_with_opts(path, opts).await?)),
 
-            Some((ufs_path, mount)) => {
-                let flag = mount.ufs.mkdir(&ufs_path, opts.create_parent).await?;
-                if !flag {
-                    err_ext!(FsError::file_exists(ufs_path.path()))
-                } else {
-                    Ok(None)
+                Some((ufs_path, mount)) => {
+                    let flag = mount.ufs.mkdir(&ufs_path, opts.create_parent).await?;
+                    if !flag {
+                        err_ext!(FsError::file_exists(ufs_path.path()))
+                    } else {
+                        Ok(None)
+                    }
                 }
             }
-        }
+        };
+        self.track("Mkdir", path.path(), "", fut).await
     }
 
     pub async fn fuse_set_attr(
@@ -436,28 +545,37 @@ impl UnifiedFileSystem {
         path: &Path,
         opts: SetAttrOpts,
     ) -> FsResult<Option<FileStatus>> {
-        match self.get_mount_checked(path).await? {
-            None => {
-                let status = self.cv.set_attr(path, opts).await?;
-                Ok(Some(status))
-            }
+        let fut = async {
+            match self.get_mount_checked(path).await? {
+                None => {
+                    let status = self.cv.set_attr(path, opts).await?;
+                    Ok(Some(status))
+                }
 
-            Some(_) => Ok(None),
-        }
+                Some(_) => Ok(None),
+            }
+        };
+        self.track("SetAttr", path.path(), "", fut).await
     }
 
     pub async fn get_lock(&self, path: &Path, lock: FileLock) -> FsResult<Option<FileLock>> {
-        match self.get_mount_checked(path).await? {
-            None => self.cv.get_lock(path, lock).await,
-            Some(_) => err_ext!(FsError::unsupported("get_lock")),
-        }
+        let fut = async {
+            match self.get_mount_checked(path).await? {
+                None => self.cv.get_lock(path, lock).await,
+                Some(_) => err_ext!(FsError::unsupported("get_lock")),
+            }
+        };
+        self.track("GetLock", path.path(), "", fut).await
     }
 
     pub async fn set_lock(&self, path: &Path, lock: FileLock) -> FsResult<Option<FileLock>> {
-        match self.get_mount_checked(path).await? {
-            None => self.cv.set_lock(path, lock).await,
-            Some(_) => err_ext!(FsError::unsupported("set_lock")),
-        }
+        let fut = async {
+            match self.get_mount_checked(path).await? {
+                None => self.cv.set_lock(path, lock).await,
+                Some(_) => err_ext!(FsError::unsupported("set_lock")),
+            }
+        };
+        self.track("SetLock", path.path(), "", fut).await
     }
 }
 
@@ -467,11 +585,6 @@ impl FileSystem<UnifiedWriter, UnifiedReader> for UnifiedFileSystem {
     }
 
     async fn mkdir(&self, path: &Path, create_parent: bool) -> FsResult<bool> {
-        let _timer = TimeSpent::timer_counter_vec(
-            Arc::new(FsContext::get_metrics().metadata_operation_duration.clone()),
-            vec!["mkdir".to_string()],
-        );
-
         let opts = MkdirOptsBuilder::with_conf(&self.cv.conf().client)
             .create_parent(create_parent)
             .build();
@@ -483,11 +596,6 @@ impl FileSystem<UnifiedWriter, UnifiedReader> for UnifiedFileSystem {
     }
 
     async fn create(&self, path: &Path, overwrite: bool) -> FsResult<UnifiedWriter> {
-        let _timer = TimeSpent::timer_counter_vec(
-            Arc::new(FsContext::get_metrics().metadata_operation_duration.clone()),
-            vec!["create".to_string()],
-        );
-
         let flags = OpenFlags::new_write_only()
             .set_create(true)
             .set_overwrite(overwrite);
@@ -502,214 +610,211 @@ impl FileSystem<UnifiedWriter, UnifiedReader> for UnifiedFileSystem {
     }
 
     async fn exists(&self, path: &Path) -> FsResult<bool> {
-        let _timer = TimeSpent::timer_counter_vec(
-            Arc::new(FsContext::get_metrics().metadata_operation_duration.clone()),
-            vec!["exists".to_string()],
-        );
-        match self.get_mount_checked(path).await? {
-            None => self.cv.exists(path).await,
-            Some((ufs_path, mount)) => mount.ufs.exists(&ufs_path).await,
-        }
+        let fut = async {
+            match self.get_mount_checked(path).await? {
+                None => self.cv.exists(path).await,
+                Some((ufs_path, mount)) => mount.ufs.exists(&ufs_path).await,
+            }
+        };
+        self.track("Exists", path.path(), "", fut).await
     }
 
     async fn open(&self, path: &Path) -> FsResult<UnifiedReader> {
-        let (ufs_path, mount) = match self.get_mount(path).await? {
-            None => {
-                let reader = UnifiedReader::Cv(self.cv.open(path).await?);
-                return if reader.status().is_expired() {
-                    return err_ext!(FsError::file_expired(path.path()));
+        let time = TimeSpent::new();
+        let mut read_path = path.path().to_owned();
+
+        let fut = async {
+            let (ufs_path, mount) = match self.get_mount(path).await? {
+                None => {
+                    let reader = UnifiedReader::Cv(self.cv.open(path).await?);
+                    return if reader.status().is_expired() {
+                        err_ext!(FsError::file_expired(path.path()))
+                    } else {
+                        Ok(reader)
+                    };
+                }
+                Some(v) => v,
+            };
+
+            if let Some(reader) = self.get_cv_reader(path, &ufs_path, &mount).await? {
+                debug!(
+                    "read from Curvine(cache), ufs path {}, cv path: {}",
+                    ufs_path, path
+                );
+
+                self.metrics
+                    .mount_cache_hits
+                    .with_label_values(&[mount.mount_id()])
+                    .inc();
+
+                Ok(UnifiedReader::Fallback(reader))
+            } else {
+                self.metrics
+                    .mount_cache_misses
+                    .with_label_values(&[mount.mount_id()])
+                    .inc();
+
+                if mount.info.auto_cache() {
+                    self.async_cache(&ufs_path)?;
+                }
+
+                read_path = ufs_path.full_path().to_owned();
+                // Reading from ufs
+                if self.enable_read_ufs {
+                    debug!("read from ufs, ufs path {}, cv path: {}", ufs_path, path);
+                    mount.ufs.open(&ufs_path).await
                 } else {
-                    Ok(reader)
-                };
+                    err_ext!(FsError::unsupported_ufs_read(path.path()))
+                }
             }
-            Some(v) => v,
         };
 
-        if let Some(reader) = self.get_cv_reader(path, &ufs_path, &mount).await? {
-            info!(
-                "read from Curvine(cache), ufs path {}, cv path: {}",
-                ufs_path, path
-            );
+        let res = fut.await;
 
-            self.metrics
-                .mount_cache_hits
-                .with_label_values(&[mount.mount_id()])
-                .inc();
+        let used_us = time.used_us();
+        self.op_metric("Open", used_us);
 
-            Ok(UnifiedReader::Fallback(reader))
-        } else {
-            self.metrics
-                .mount_cache_misses
-                .with_label_values(&[mount.mount_id()])
-                .inc();
-
-            if mount.info.auto_cache() {
-                self.async_cache(&ufs_path)?;
-            }
-
-            // Reading from ufs
-            if self.enable_read_ufs {
-                info!("read from ufs, ufs path {}, cv path: {}", ufs_path, path);
-                mount.ufs.open(&ufs_path).await
-            } else {
-                err_ext!(FsError::unsupported_ufs_read(path.path()))
-            }
-        }
+        self.audit("Open:R", &read_path, "", res, used_us)
     }
 
     async fn rename(&self, src: &Path, dst: &Path) -> FsResult<bool> {
-        let _timer = TimeSpent::timer_counter_vec(
-            Arc::new(FsContext::get_metrics().metadata_operation_duration.clone()),
-            vec!["rename".to_string()],
-        );
+        let fut = async {
+            match self.get_mount_checked(src).await? {
+                None => self.cv.rename(src, dst).await,
+                Some((src_ufs, mount)) => {
+                    let dst_ufs = mount.get_ufs_path(dst)?;
+                    let res = mount.ufs.rename(&src_ufs, &dst_ufs).await?;
 
-        match self.get_mount_checked(src).await? {
-            None => self.cv.rename(src, dst).await,
-            Some((src_ufs, mount)) => {
-                let dst_ufs = mount.get_ufs_path(dst)?;
-                let res = mount.ufs.rename(&src_ufs, &dst_ufs).await?;
-
-                // After rename, the file's mtime changes, making the cached data invalid
-                if let Err(e) = self.cv.delete(src, true).await {
-                    if !matches!(e, FsError::FileNotFound(_)) {
-                        warn!("failed to delete cache for {}: {}", src, e);
+                    // After rename, the file's mtime changes, making the cached data invalid
+                    if let Err(e) = self.cv.delete(src, true).await {
+                        if !matches!(e, FsError::FileNotFound(_)) {
+                            warn!("failed to delete cache for {}: {}", src, e);
+                        }
                     }
-                }
 
-                Ok(res)
+                    Ok(res)
+                }
             }
-        }
+        };
+        self.track("Rename", src.path(), dst.path(), fut).await
     }
 
     async fn delete(&self, path: &Path, recursive: bool) -> FsResult<()> {
-        let _timer = TimeSpent::timer_counter_vec(
-            Arc::new(FsContext::get_metrics().metadata_operation_duration.clone()),
-            vec!["delete".to_string()],
-        );
-
-        match self.get_mount_checked(path).await? {
-            None => self.cv.delete(path, recursive).await,
-            Some((ufs_path, mount)) => {
-                if path.path() == mount.info.cv_path {
-                    return err_box!(
-                        "cannot delete mount point root: cv_path={}, ufs_path={}",
-                        mount.info.cv_path,
-                        mount.info.ufs_path
-                    );
-                }
-
-                mount.ufs.delete(&ufs_path, recursive).await?;
-
-                // delete cache
-                if let Err(e) = self.cv.delete(path, recursive).await {
-                    if !matches!(e, FsError::FileNotFound(_)) {
-                        warn!("failed to delete cache for {}: {}", path, e);
+        let fut = async {
+            match self.get_mount_checked(path).await? {
+                None => self.cv.delete(path, recursive).await,
+                Some((ufs_path, mount)) => {
+                    if path.path() == mount.info.cv_path {
+                        return err_box!(
+                            "cannot delete mount point root: cv_path={}, ufs_path={}",
+                            mount.info.cv_path,
+                            mount.info.ufs_path
+                        );
                     }
-                };
 
-                Ok(())
+                    mount.ufs.delete(&ufs_path, recursive).await?;
+
+                    // delete cache
+                    if let Err(e) = self.cv.delete(path, recursive).await {
+                        if !matches!(e, FsError::FileNotFound(_)) {
+                            warn!("failed to delete cache for {}: {}", path, e);
+                        }
+                    };
+
+                    Ok(())
+                }
             }
-        }
+        };
+        self.track("Delete", path.path(), "", fut).await
     }
 
     async fn get_status(&self, path: &Path) -> FsResult<FileStatus> {
-        let _timer = TimeSpent::timer_counter_vec(
-            Arc::new(FsContext::get_metrics().metadata_operation_duration.clone()),
-            vec!["get_status".to_string()],
-        );
+        let fut = async {
+            match self.get_mount(path).await? {
+                None => self.cv.get_status(path).await,
 
-        match self.get_mount(path).await? {
-            None => self.cv.get_status(path).await,
+                Some((_, mnt)) if mnt.info.is_fs_mode() => self.cv.get_status(path).await,
 
-            Some((_, mnt)) if mnt.info.is_fs_mode() => self.cv.get_status(path).await,
+                Some((ufs_path, mnt)) => match self.cv.get_status(path).await {
+                    Ok(mut v) => match self.check_cache_validity(&v, &ufs_path, &mnt).await? {
+                        CacheValidity::Valid => {
+                            v.apply_ufs_fields();
+                            Ok(v)
+                        }
+                        CacheValidity::Invalid(Some(ufs_status)) => Ok(ufs_status),
+                        CacheValidity::Invalid(None) => mnt.ufs.get_status(&ufs_path).await,
+                    },
 
-            Some((ufs_path, mnt)) => match self.cv.get_status(path).await {
-                Ok(mut v) => match self.check_cache_validity(&v, &ufs_path, &mnt).await? {
-                    CacheValidity::Valid => {
-                        v.apply_ufs_fields();
-                        Ok(v)
+                    Err(e) => {
+                        if !matches!(e, FsError::FileNotFound(_) | FsError::Expired(_)) {
+                            warn!("failed to get status file {}: {}", path, e);
+                        };
+                        mnt.ufs.get_status(&ufs_path).await
                     }
-                    CacheValidity::Invalid(Some(ufs_status)) => Ok(ufs_status),
-                    CacheValidity::Invalid(None) => mnt.ufs.get_status(&ufs_path).await,
                 },
-
-                Err(e) => {
-                    if !matches!(e, FsError::FileNotFound(_) | FsError::Expired(_)) {
-                        warn!("failed to get status file {}: {}", path, e);
-                    };
-                    mnt.ufs.get_status(&ufs_path).await
-                }
-            },
-        }
+            }
+        };
+        self.track("GetStatus", path.path(), "", fut).await
     }
 
     async fn list_status(&self, path: &Path) -> FsResult<Vec<FileStatus>> {
-        let _timer = TimeSpent::timer_counter_vec(
-            Arc::new(FsContext::get_metrics().metadata_operation_duration.clone()),
-            vec!["list_status".to_string()],
-        );
-
-        match self.get_mount_checked(path).await? {
-            None => self.cv.list_status(path).await,
-            Some((ufs_path, mount)) => mount.ufs.list_status(&ufs_path).await,
-        }
+        let fut = async {
+            match self.get_mount_checked(path).await? {
+                None => self.cv.list_status(path).await,
+                Some((ufs_path, mount)) => mount.ufs.list_status(&ufs_path).await,
+            }
+        };
+        self.track("ListStatus", path.path(), "", fut).await
     }
 
     async fn list_status_bytes(&self, path: &Path) -> FsResult<BytesMut> {
-        let _timer = TimeSpent::timer_counter_vec(
-            Arc::new(FsContext::get_metrics().metadata_operation_duration.clone()),
-            vec!["list_status".to_string()],
-        );
-
-        match self.get_mount_checked(path).await? {
-            None => self.cv.list_status_bytes(path).await,
-            Some((ufs_path, mount)) => mount.ufs.list_status_bytes(&ufs_path).await,
-        }
+        let fut = async {
+            match self.get_mount_checked(path).await? {
+                None => self.cv.list_status_bytes(path).await,
+                Some((ufs_path, mount)) => mount.ufs.list_status_bytes(&ufs_path).await,
+            }
+        };
+        self.track("ListStatus", path.path(), "", fut).await
     }
 
     async fn list_options(&self, path: &Path, options: ListOptions) -> FsResult<Vec<FileStatus>> {
-        let _timer = TimeSpent::timer_counter_vec(
-            Arc::new(FsContext::get_metrics().metadata_operation_duration.clone()),
-            vec!["list_options".to_string()],
-        );
-
-        match self.get_mount_checked(path).await? {
-            None => self.cv.list_options(path, options).await,
-            Some((ufs_path, mount)) => mount.ufs.list_options(&ufs_path, options).await,
-        }
+        let fut = async {
+            match self.get_mount_checked(path).await? {
+                None => self.cv.list_options(path, options).await,
+                Some((ufs_path, mount)) => mount.ufs.list_options(&ufs_path, options).await,
+            }
+        };
+        self.track("ListOptions", path.path(), "", fut).await
     }
 
     async fn list_options_bytes(&self, path: &Path, options: ListOptions) -> FsResult<BytesMut> {
-        let _timer = TimeSpent::timer_counter_vec(
-            Arc::new(FsContext::get_metrics().metadata_operation_duration.clone()),
-            vec!["list_options".to_string()],
-        );
-
-        match self.get_mount_checked(path).await? {
-            None => self.cv.list_options_bytes(path, options).await,
-            Some((ufs_path, mount)) => mount.ufs.list_options_bytes(&ufs_path, options).await,
-        }
+        let fut = async {
+            match self.get_mount_checked(path).await? {
+                None => self.cv.list_options_bytes(path, options).await,
+                Some((ufs_path, mount)) => mount.ufs.list_options_bytes(&ufs_path, options).await,
+            }
+        };
+        self.track("ListOptions", path.path(), "", fut).await
     }
 
     async fn list_stream(&self, path: &Path, options: ListOptions) -> FsResult<ListStream> {
-        match self.get_mount_checked(path).await? {
-            None => self.cv.list_stream(path, options).await,
-            Some((ufs_path, mount)) => mount.ufs.list_stream(&ufs_path, options).await,
-        }
+        let fut = async {
+            match self.get_mount_checked(path).await? {
+                None => self.cv.list_stream(path, options).await,
+                Some((ufs_path, mount)) => mount.ufs.list_stream(&ufs_path, options).await,
+            }
+        };
+        self.track("ListStream", path.path(), "", fut).await
     }
 
     async fn set_attr(&self, path: &Path, opts: SetAttrOpts) -> FsResult<()> {
-        let _timer = TimeSpent::timer_counter_vec(
-            Arc::new(FsContext::get_metrics().metadata_operation_duration.clone()),
-            vec!["set_attr".to_string()],
-        );
-
-        match self.get_mount_checked(path).await? {
-            None => {
+        let fut = async {
+            if self.get_mount_checked(path).await?.is_none() {
                 self.cv.set_attr(path, opts).await?;
-                Ok(())
             }
-            Some((_, _)) => Ok(()), // ignore setting attr on ufs mount paths
-        }
+            // ignore setting attr on ufs mount paths
+            Ok(())
+        };
+        self.track("SetAttr", path.path(), "", fut).await
     }
 }

--- a/curvine-common/src/conf/client_conf.rs
+++ b/curvine-common/src/conf/client_conf.rs
@@ -146,6 +146,10 @@ pub struct ClientConf {
     // If the cache misses, determine whether to allow Curvine to directly read data from the unified file system (UFS).
     pub enable_rust_read_ufs: bool,
 
+    // Whether to enable client-side audit logging for UnifiedFileSystem operations.
+    // The log target is "audit" and records: cmd, ok, src, dst, usedUs.
+    pub audit_logging_enabled: bool,
+
     // Mount information update interval
     #[serde(skip)]
     pub mount_update_ttl: Duration,
@@ -375,6 +379,8 @@ impl Default for ClientConf {
 
             enable_unified_fs: true,
             enable_rust_read_ufs: true,
+
+            audit_logging_enabled: true,
 
             mount_update_ttl: Default::default(),
             mount_update_ttl_str: "10s".to_string(),

--- a/curvine-common/src/conf/client_conf.rs
+++ b/curvine-common/src/conf/client_conf.rs
@@ -119,7 +119,7 @@ pub struct ClientConf {
     pub data_timeout_ms: u64,
     pub pipeline_timeout_ms: u64,
 
-    // After testing 3 connections, the best performance can be achieved, so the default value is 1.
+    // After testing 3 connections, the best performance can be achieved, so the default value is 3.
     pub master_conn_pool_size: usize,
 
     // Whether to enable pre-reading
@@ -362,7 +362,7 @@ impl Default for ClientConf {
             rpc_timeout_ms: 120 * 1000,
             data_timeout_ms: 120 * 1000,
             pipeline_timeout_ms: 120 * 1000,
-            master_conn_pool_size: 1,
+            master_conn_pool_size: 3,
 
             enable_read_ahead: true,
             read_ahead_len: 0,

--- a/curvine-common/src/conf/fuse_conf.rs
+++ b/curvine-common/src/conf/fuse_conf.rs
@@ -28,6 +28,8 @@ pub struct FuseConf {
     // Whether to output the request response log.
     pub debug: bool,
 
+    pub audit_logging_enabled: bool,
+
     pub io_threads: usize,
 
     pub worker_threads: usize,
@@ -269,6 +271,7 @@ impl Default for FuseConf {
     fn default() -> Self {
         let mut conf = Self {
             debug: false,
+            audit_logging_enabled: false,
 
             io_threads: 32,
             worker_threads: Utils::worker_threads(32),

--- a/curvine-common/src/conf/journal_conf.rs
+++ b/curvine-common/src/conf/journal_conf.rs
@@ -203,7 +203,7 @@ impl JournalConf {
 
 impl Default for JournalConf {
     fn default() -> Self {
-        let journal_dir = Utils::test_sub_dir("journal");
+        let journal_dir = format!("testing/journal-{}", Utils::rand_id());
         let journal_addrs = vec![RaftPeer::new(
             1,
             ClusterConf::DEFAULT_HOSTNAME,

--- a/curvine-common/src/error/fs_error.rs
+++ b/curvine-common/src/error/fs_error.rs
@@ -346,7 +346,21 @@ impl From<RaftError> for FsError {
 
 impl From<std::io::Error> for FsError {
     fn from(value: io::Error) -> Self {
-        Self::IO(ErrorImpl::with_source(value))
+        match value.kind() {
+            io::ErrorKind::NotFound => {
+                Self::FileNotFound(ErrorImpl::with_source(value.to_string().into()))
+            }
+            io::ErrorKind::AlreadyExists => {
+                Self::FileAlreadyExists(ErrorImpl::with_source(value.to_string().into()))
+            }
+            io::ErrorKind::DirectoryNotEmpty => {
+                Self::DirNotEmpty(ErrorImpl::with_source(value.to_string().into()))
+            }
+            io::ErrorKind::Unsupported => {
+                Self::Unsupported(ErrorImpl::with_source(value.to_string().into()))
+            }
+            _ => Self::IO(ErrorImpl::with_source(value)),
+        }
     }
 }
 

--- a/curvine-common/src/lib.rs
+++ b/curvine-common/src/lib.rs
@@ -36,3 +36,5 @@ pub mod proto {
 pub type FsResult<T> = Result<T, FsError>;
 
 pub const FILE_BUFFER_SIZE: usize = 128 * 1024;
+
+pub const UFS_INODE_ID: i64 = 0;

--- a/curvine-common/src/rocksdb/db_conf.rs
+++ b/curvine-common/src/rocksdb/db_conf.rs
@@ -379,7 +379,7 @@ impl DBConf {
 
 impl Default for DBConf {
     fn default() -> Self {
-        let dir = Utils::test_sub_dir(format!("testing/db-{}", Utils::rand_id()));
+        let dir = format!("testing/db-{}", Utils::rand_id());
         let base_dir = dir.as_str();
         Self {
             base_dir: base_dir.to_string(),

--- a/curvine-common/src/state/file_status.rs
+++ b/curvine-common/src/state/file_status.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::state::{FileType, StoragePolicy, TtlAction};
+use crate::UFS_INODE_ID;
 use orpc::common::LocalTime;
 use orpc::ternary;
 use serde::{Deserialize, Serialize};
@@ -120,5 +121,12 @@ impl FileStatus {
         } else {
             false
         }
+    }
+
+    /// After cache validity: set visible `mtime` from `storage_policy.ufs_mtime` and clear `id`
+    /// for the UFS-backed read path.
+    pub fn apply_ufs_fields(&mut self) {
+        self.mtime = self.storage_policy.ufs_mtime;
+        self.id = UFS_INODE_ID;
     }
 }

--- a/curvine-common/src/state/file_status.rs
+++ b/curvine-common/src/state/file_status.rs
@@ -102,6 +102,10 @@ impl FileStatus {
     /// Returns true if CV data is valid and usable: CV exists, not expired, UFS exists;
     /// when `ufs_status` is provided, also checks len and mtime match UFS.
     pub fn cv_valid(&self, ufs_status: Option<&FileStatus>) -> bool {
+        if self.storage_policy.ufs_mtime == 0 {
+            return false;
+        }
+
         if !self.cv_exists() {
             return false;
         }

--- a/curvine-common/src/state/job.rs
+++ b/curvine-common/src/state/job.rs
@@ -50,8 +50,19 @@ impl JobTaskState {
             JobTaskState::Completed | JobTaskState::Failed | JobTaskState::Canceled
         )
     }
+
+    pub fn is_running(&self) -> bool {
+        matches!(self, JobTaskState::Pending | JobTaskState::Loading)
+    }
 }
 
+/// Outcome of a load submit or status query: `job_id` / `target_path` identify the
+/// job; `state` is the current phase.
+///
+/// **Callers must not assume this struct always reflects the latest
+/// [`LoadJobCommand`]:** concurrent submits for the same path are defined by the
+/// server as **first submitter wins**; a later `Ok` may describe the in-flight job
+/// only (paths and state), not the superseded request’s options.
 #[derive(Debug, Clone)]
 pub struct LoadJobResult {
     pub job_id: String,

--- a/curvine-common/src/state/open_flags.rs
+++ b/curvine-common/src/state/open_flags.rs
@@ -13,10 +13,11 @@
 // limitations under the License.
 
 use bitflags::bitflags;
+use serde::{Deserialize, Serialize};
 
 bitflags! {
     /// Open file flags (equivalent to Go's syscall.O_* flags)
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize)]
     pub struct OpenFlags: u32 {
         // Access mode flags (must specify one)
         /// Read-only mode

--- a/curvine-common/src/state/opts.rs
+++ b/curvine-common/src/state/opts.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct CreateFileOpts {
     pub create_parent: bool,
     pub replicas: u16,

--- a/curvine-common/src/state/result.rs
+++ b/curvine-common/src/state/result.rs
@@ -23,9 +23,9 @@ pub struct FreeResult {
 }
 
 impl FreeResult {
-    pub fn add(&mut self, file_len: i64, blocks: HashMap<i64, Vec<BlockLocation>>) {
+    pub fn add(&mut self, bytes: i64, blocks: HashMap<i64, Vec<BlockLocation>>) {
         self.inodes += 1;
-        self.bytes += file_len;
+        self.bytes += bytes;
         self.blocks.extend(blocks);
     }
 }

--- a/curvine-common/src/state/storage_policy.rs
+++ b/curvine-common/src/state/storage_policy.rs
@@ -78,11 +78,22 @@ impl StoragePolicy {
     }
 
     pub fn free(&mut self) -> bool {
-        if self.both_exists() && self.ttl_action != TtlAction::None {
-            self.state = StorageState::Ufs;
-            true
-        } else {
-            false
+        match self.ttl_action {
+            TtlAction::Free if self.both_exists() => {
+                self.state = StorageState::Ufs;
+                true
+            }
+
+            TtlAction::Delete => {
+                if self.both_exists() {
+                    self.state = StorageState::Ufs;
+                }
+
+                self.ufs_mtime = 0;
+                true
+            }
+
+            _ => false,
         }
     }
 

--- a/curvine-fuse/src/bin/curvine-fuse.rs
+++ b/curvine-fuse/src/bin/curvine-fuse.rs
@@ -48,15 +48,18 @@ fn main() -> CommonResult<()> {
 
     let fuse_rt = rt.clone();
 
-    rt.spawn(async move {
-        if let Err(e) = WebServer::start(cluster_conf.fuse.web_port).await {
-            tracing::error!("Failed to start metrics server: {}", e);
-        }
-    });
-
     rt.block_on(async move {
         let fs = CurvineFileSystem::new(cluster_conf, fuse_rt.clone()).unwrap();
         let conf = fs.conf().clone();
+
+        let node_state = fs.state().clone();
+        let web_port = conf.web_port;
+        fuse_rt.spawn(async move {
+            if let Err(e) = WebServer::start(web_port, node_state).await {
+                log::error!("Failed to start metrics server: {}", e);
+            }
+        });
+
         let mut session = FuseSession::new(fuse_rt.clone(), fs, conf).await.unwrap();
         session.run().await
     })?;

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -38,15 +38,17 @@ use tokio_util::bytes::BytesMut;
 
 pub struct CurvineFileSystem {
     fs: UnifiedFileSystem,
-    state: NodeState,
+    state: Arc<NodeState>,
     conf: FuseConf,
 }
 
 impl CurvineFileSystem {
     pub fn new(conf: ClusterConf, rt: Arc<Runtime>) -> FuseResult<Self> {
+        FuseMetrics::ensure_init()?;
+
         let fuse_conf = conf.fuse.clone();
         let fs = UnifiedFileSystem::with_rt(conf, rt)?;
-        let state = NodeState::new(fs.clone());
+        let state = Arc::new(NodeState::new(fs.clone()));
 
         let fuse_fs = Self {
             fs,
@@ -55,6 +57,10 @@ impl CurvineFileSystem {
         };
 
         Ok(fuse_fs)
+    }
+
+    pub fn state(&self) -> &Arc<NodeState> {
+        &self.state
     }
 
     fn fill_open_flags(conf: &FuseConf, v: u32) -> u32 {

--- a/curvine-fuse/src/fs/state/node_state.rs
+++ b/curvine-fuse/src/fs/state/node_state.rs
@@ -18,7 +18,8 @@ use crate::fs::state::{NodeAttr, NodeMap};
 use crate::fs::{CurvineFileSystem, FuseReader, FuseWriter};
 use crate::raw::fuse_abi::{fuse_attr, fuse_forget_one};
 use crate::{
-    err_fuse, FuseResult, FUSE_CURRENT_DIR, FUSE_PARENT_DIR, STATE_FILE_MAGIC, STATE_FILE_VERSION,
+    err_fuse, FuseMetrics, FuseResult, FUSE_CURRENT_DIR, FUSE_PARENT_DIR, STATE_FILE_MAGIC,
+    STATE_FILE_VERSION,
 };
 use curvine_client::file::FsReader;
 use curvine_client::unified::{UnifiedFileSystem, UnifiedReader};
@@ -526,6 +527,22 @@ impl NodeState {
         lock.values()
             .flat_map(|v| v.values().cloned())
             .collect::<Vec<_>>()
+    }
+
+    pub fn file_handles_len(&self) -> usize {
+        let lock = self.handles.read();
+        lock.values().map(|m| m.len()).sum()
+    }
+
+    pub fn dir_handles_len(&self) -> usize {
+        let lock = self.dir_handles.read();
+        lock.values().map(|m| m.len()).sum()
+    }
+
+    pub fn set_metrics(&self, m: &FuseMetrics) {
+        m.inode_num.set(self.node_read().nodes_len() as i64);
+        m.file_handle_num.set(self.file_handles_len() as i64);
+        m.dir_handle_num.set(self.dir_handles_len() as i64);
     }
 
     pub async fn persist(&self, writer: &mut StateWriter) -> FuseResult<()> {

--- a/curvine-fuse/src/fuse_metrics.rs
+++ b/curvine-fuse/src/fuse_metrics.rs
@@ -1,0 +1,47 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use once_cell::sync::OnceCell;
+
+use orpc::common::{Gauge, Metrics as m};
+use orpc::CommonResult;
+
+static FUSE_METRICS: OnceCell<FuseMetrics> = OnceCell::new();
+
+pub struct FuseMetrics {
+    pub inode_num: Gauge,
+    pub file_handle_num: Gauge,
+    pub dir_handle_num: Gauge,
+}
+
+impl FuseMetrics {
+    pub fn ensure_init() -> CommonResult<()> {
+        FUSE_METRICS.get_or_try_init(Self::new)?;
+        Ok(())
+    }
+
+    pub fn get() -> &'static Self {
+        FUSE_METRICS
+            .get()
+            .expect("FuseMetrics not initialized; call ensure_init from CurvineFileSystem::new")
+    }
+
+    fn new() -> CommonResult<Self> {
+        Ok(Self {
+            inode_num: m::new_gauge("inode_num", "FUSE inode count in dcache")?,
+            file_handle_num: m::new_gauge("file_handle_num", "FUSE open file handle count")?,
+            dir_handle_num: m::new_gauge("dir_handle_num", "FUSE open directory handle count")?,
+        })
+    }
+}

--- a/curvine-fuse/src/lib.rs
+++ b/curvine-fuse/src/lib.rs
@@ -24,8 +24,10 @@ pub mod session;
 pub mod web_server;
 
 mod fuse_error;
-
 pub use self::fuse_error::FuseError;
+
+pub mod fuse_metrics;
+pub use self::fuse_metrics::FuseMetrics;
 
 mod fuse_utils;
 pub use self::fuse_utils::FuseUtils;

--- a/curvine-fuse/src/session/channel/fuse_receiver.rs
+++ b/curvine-fuse/src/session/channel/fuse_receiver.rs
@@ -42,10 +42,12 @@ pub struct FuseReceiver<T> {
     buf: BytesMut,
     fuse_len: usize,
     debug: bool,
+    audit_logging_enabled: bool,
     pending_requests: Arc<FastDashMap<u64, Arc<Notify>>>,
 }
 
 impl<T: FileSystem> FuseReceiver<T> {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         fs: Arc<T>,
         rt: Arc<Runtime>,
@@ -53,6 +55,7 @@ impl<T: FileSystem> FuseReceiver<T> {
         sender: AsyncSender<FuseTask>,
         buf_size: usize,
         debug: bool,
+        audit_logging_enabled: bool,
         pending_requests: Arc<FastDashMap<u64, Arc<Notify>>>,
     ) -> IOResult<Self> {
         let pipe2 = Pipe2::new(PipeFd::new(buf_size, false, false)?)?;
@@ -67,6 +70,7 @@ impl<T: FileSystem> FuseReceiver<T> {
             buf,
             fuse_len: buf_size,
             debug,
+            audit_logging_enabled,
             pending_requests,
         };
 
@@ -120,6 +124,20 @@ impl<T: FileSystem> FuseReceiver<T> {
         FuseResponse::new(unique, self.sender.clone(), self.debug)
     }
 
+    fn audit(&self, req: &FuseRequest) {
+        if !self.audit_logging_enabled {
+            return;
+        }
+        let ino = req.get_header().map(|h| h.nodeid).unwrap_or(0);
+        info!(
+            target: "audit",
+            "unique={} ino={} opcode={:?}",
+            req.unique(),
+            ino,
+            req.opcode(),
+        );
+    }
+
     pub async fn send_stream(&self, req: FuseRequest) -> FuseResult<()> {
         let operator = req.parse_operator()?;
         let rep = self.new_replay(req.unique());
@@ -167,10 +185,11 @@ impl<T: FileSystem> FuseReceiver<T> {
                                     error!("failed to dispatch stream request: {}", e);
                                 }
                             } else {
+                                self.audit(&req);
+
                                 let reply = self.new_replay(req.unique());
                                 let fs = self.fs.clone();
                                 let pending_requests = self.pending_requests.clone();
-
                                 self.rt.spawn(async move {
                                     if let Err(e) = Self::dispatch_meta_interrupt(fs, pending_requests, req, reply).await {
                                         error!("failed to dispatch meta request: {}", e);

--- a/curvine-fuse/src/session/channel/mod.rs
+++ b/curvine-fuse/src/session/channel/mod.rs
@@ -53,6 +53,7 @@ impl<T: FileSystem> FuseChannel<T> {
                 tx,
                 buf_size,
                 conf.debug,
+                conf.audit_logging_enabled,
                 pending_requests.clone(),
             )?;
 

--- a/curvine-fuse/src/web_server.rs
+++ b/curvine-fuse/src/web_server.rs
@@ -1,15 +1,20 @@
+use crate::fs::state::NodeState;
+use crate::FuseMetrics;
+use axum::extract::State;
 use axum::routing::get;
 use axum::Router;
-use curvine_client::file::FsContext;
+use orpc::common::Metrics;
 use std::net::SocketAddr;
+use std::sync::Arc;
 
 pub struct WebServer;
 
 impl WebServer {
-    pub async fn start(port: u16) -> orpc::CommonResult<()> {
+    pub async fn start(port: u16, state: Arc<NodeState>) -> orpc::CommonResult<()> {
         let app = Router::new()
             .route("/metrics", get(metrics_handler))
-            .route("/healthz", get(|| async { "ok" }));
+            .route("/healthz", get(|| async { "ok" }))
+            .with_state(state);
 
         let addr = SocketAddr::from(([0, 0, 0, 0], port));
         log::info!("FUSE metrics server listening on {}", addr);
@@ -20,8 +25,8 @@ impl WebServer {
     }
 }
 
-async fn metrics_handler() -> String {
-    FsContext::get_metrics()
-        .text_output()
-        .unwrap_or_else(|e| format!("Error: {}", e))
+async fn metrics_handler(State(state): State<Arc<NodeState>>) -> String {
+    let fuse_metrics = FuseMetrics::get();
+    state.set_metrics(fuse_metrics);
+    Metrics::text_output().unwrap_or_else(|e| format!("Error: {}", e))
 }

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineFileSystem.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineFileSystem.java
@@ -25,7 +25,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.conf.StorageSize;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FSInputStream;
@@ -91,9 +90,6 @@ public class CurvineFileSystem extends FileSystem {
     private URI uri;
     private String cacheKey;  // Key used for mount cache lookup
 
-    private int writeChunkSize;
-    private int writeChunkNum;
-
     public final static String SCHEME = "cv";
 
     @Override
@@ -150,10 +146,6 @@ public class CurvineFileSystem extends FileSystem {
         
         this.cacheKey = filesystemConf.master_addrs;
         this.libFs = getOrCreateMount(filesystemConf);
-
-        StorageSize size = StorageSize.parse(filesystemConf.write_chunk_size);
-        this.writeChunkSize = (int) size.getUnit().toBytes(size.getValue());
-        this.writeChunkNum = filesystemConf.write_chunk_num;
     }
     
     /**
@@ -215,7 +207,7 @@ public class CurvineFileSystem extends FileSystem {
             statistics.incrementWriteOps(1);
         }
         long nativeHandle = this.libFs.create(formatPath(path), overwrite);
-        CurvineOutputStream output = new CurvineOutputStream(libFs, nativeHandle, 0, writeChunkSize, writeChunkNum);
+        CurvineOutputStream output = new CurvineOutputStream(libFs, nativeHandle, 0);
         return new FSDataOutputStream(output, statistics);
     }
 
@@ -227,7 +219,7 @@ public class CurvineFileSystem extends FileSystem {
 
         long[] tmp = new long[] {0};
         long nativeHandle = this.libFs.append(formatPath(path), tmp);
-        CurvineOutputStream output = new CurvineOutputStream(libFs, nativeHandle, tmp[0], writeChunkSize, writeChunkNum);
+        CurvineOutputStream output = new CurvineOutputStream(libFs, nativeHandle, tmp[0]);
         return new FSDataOutputStream(output, statistics, output.pos());
     }
 

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineFsMount.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineFsMount.java
@@ -15,11 +15,9 @@
 package io.curvine;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.Optional;
 
 import io.curvine.exception.CurvineException;
-import sun.nio.ch.DirectBuffer;
 
 public class CurvineFsMount {
     private final long nativeHandle;
@@ -66,9 +64,12 @@ public class CurvineFsMount {
         return handle;
     }
 
-    public void write(long writerHandle, ByteBuffer buffer) throws IOException {
-        long res = CurvineNative.write(writerHandle, ((DirectBuffer) buffer).address(), buffer.position());
-        checkError(res);
+    public void allocChunk(long writerHandle, long[] tmp) throws IOException {
+        checkError(CurvineNative.allocChunk(writerHandle, tmp));
+    }
+
+    public void write(long writerHandle, long address, int len, long[] tmp) throws IOException {
+        checkError(CurvineNative.write(writerHandle, address, len, tmp));
     }
 
     public void flush(long writerHandle) throws IOException {

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineNative.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineNative.java
@@ -14,6 +14,7 @@
 
 package io.curvine;
 
+import java.nio.Buffer;
 import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -31,8 +32,8 @@ import java.util.regex.Pattern;
 public class CurvineNative {
     public static final Logger LOGGER = LoggerFactory.getLogger(CurvineNative.class);
     private static final Constructor<?> DBB_CONSTRUCTOR;
+    private static final Field DBB_ADDRESS;
     private static final File WORKDIR;
-
 
     public static final String LIBRARY_PATH = "java.library.path";
     public static final String NATIVE_WORKDIR = "curvine.native.workdir";
@@ -55,6 +56,11 @@ public class CurvineNative {
             Field cleanerField = cls.getDeclaredField("cleaner");
             cleanerField.setAccessible(true);
             DBB_CONSTRUCTOR = constructor;
+
+            Field unsafeField = Buffer.class.getDeclaredField("address");
+            unsafeField.setAccessible(true);
+            DBB_ADDRESS = unsafeField;
+
             WORKDIR = getWorkerDir();
         } catch (ClassNotFoundException | NoSuchMethodException | NoSuchFieldException e) {
             throw new IllegalStateException(e);
@@ -67,6 +73,17 @@ public class CurvineNative {
     static ByteBuffer createBuffer(long[] tmp) throws IOException {
         try {
             return (ByteBuffer) DBB_CONSTRUCTOR.newInstance(tmp[0], (int) tmp[1]);
+        } catch (Exception e) {
+            throw new IOException(e);
+        }
+    }
+
+    public static long getAddress(ByteBuffer buf) throws IOException {
+        if (!buf.isDirect()) {
+            throw new IllegalArgumentException("only direct buffer");
+        }
+        try {
+            return DBB_ADDRESS.getLong(buf);
         } catch (Exception e) {
             throw new IOException(e);
         }
@@ -280,7 +297,9 @@ public class CurvineNative {
 
     public static native long append(long fs, String path, long[] tmp) throws IOException;
 
-    public static native long write(long nativeHandle, long address, int len) throws IOException;
+    public static native long allocChunk(long nativeHandle, long[] tmp) throws IOException;
+
+    public static native long write(long nativeHandle, long address, int len, long[] tmp) throws IOException;
 
     public static native long flush(long nativeHandle) throws IOException;
 

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineOutputStream.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineOutputStream.java
@@ -28,28 +28,17 @@ public class CurvineOutputStream extends OutputStream implements Syncable {
     private final CurvineFsMount libFs;
     private boolean closed;
 
-    private ByteBuffer[] buffer;
+    private ByteBuffer buffer;
 
-    private final int chunkSize;
-    private final int chunkNum;
+    private final long[] tmp = new long[] {0, 0};
 
     private long pos = 0;
 
-    private int bufIndex = 0;
-
-    public CurvineOutputStream(
-            CurvineFsMount libFs,
-            long nativeHandle,
-            long pos,
-            int chunk_size,
-            int chunk_num
-    ) {
+    public CurvineOutputStream(CurvineFsMount libFs, long nativeHandle, long pos) {
         this.libFs = libFs;
         this.nativeHandle = nativeHandle;
         this.oneByte = new byte[1];
         this.pos = pos;
-        this.chunkSize = chunk_size;
-        this.chunkNum = chunk_num;
     }
 
     private void checkClosed() throws IOException {
@@ -71,26 +60,6 @@ public class CurvineOutputStream extends OutputStream implements Syncable {
         write(buf, 0, buf.length);
     }
 
-    protected ByteBuffer getBuffer() throws IOException {
-        if (buffer == null) {
-            buffer = createBufferArray(chunkSize, chunkNum);
-        }
-
-        if (!buffer[bufIndex].hasRemaining()) {
-            flushBuffer();
-
-            // select next buffer
-            if (bufIndex == buffer.length - 1) {
-                libFs.flush(nativeHandle);
-                bufIndex = 0;
-            } else {
-                bufIndex++;
-            }
-            buffer[bufIndex].clear();
-        }
-        return buffer[bufIndex];
-    }
-
     @Override
     public void write(@Nonnull byte[] buf, int offset, int length) throws IOException {
         checkClosed();
@@ -103,26 +72,40 @@ public class CurvineOutputStream extends OutputStream implements Syncable {
         }
 
         while (length > 0) {
-            ByteBuffer curBuf = getBuffer();
-            int writeLen = Math.min(length, curBuf.remaining());
-            curBuf.put(buf, offset, writeLen);
+            ensureWritableBuffer();
+
+            int writeLen = Math.min(length, buffer.remaining());
+            buffer.put(buf, offset, writeLen);
             offset += writeLen;
             length -= writeLen;
             pos += writeLen;
         }
     }
 
-
     private void flushBuffer() throws IOException {
-        if (buffer != null && buffer[bufIndex].position() > 0) {
-            libFs.write(nativeHandle, buffer[bufIndex]);
-            // Clear buffer after writing to prevent duplicate writes
-            buffer[bufIndex].clear();
+        if (buffer != null && buffer.position() > 0) {
+            libFs.write(nativeHandle, CurvineNative.getAddress(buffer), buffer.position(), tmp);
+            buffer = CurvineNative.createBuffer(tmp);
+        }
+    }
+
+    private void ensureWritableBuffer() throws IOException {
+        if (buffer == null) {
+            libFs.allocChunk(nativeHandle, tmp);
+            buffer = CurvineNative.createBuffer(tmp);
+        }
+
+        if (!buffer.hasRemaining()) {
+            flushBuffer();
+            if (buffer == null || !buffer.hasRemaining()) {
+                throw new IOException("write buffer has no remaining capacity after flush");
+            }
         }
     }
 
     @Override
     public void flush() throws IOException {
+        checkClosed();
         flushBuffer();
         libFs.flush(nativeHandle);
     }
@@ -157,28 +140,5 @@ public class CurvineOutputStream extends OutputStream implements Syncable {
         // HDFS protocol requires hsync() to guarantee data durability
         // Flush all buffered data to ensure persistence
         flush();
-    }
-
-    private static ByteBuffer[] createBufferArray(int chunkSize, int chunkNum) {
-        if (chunkSize <= 0 || chunkNum <= 0) {
-            throw new IllegalArgumentException("chunkSize and chunkNum must be positive");
-        }
-
-        ByteBuffer sourceBuffer = CurvineNative.createBuffer(chunkSize * chunkNum);
-        ByteBuffer[] chunks = new ByteBuffer[chunkNum];
-
-        sourceBuffer.position(0);
-        sourceBuffer.limit(sourceBuffer.capacity());
-        for (int i = 0; i < chunkNum; i++) {
-            int startPos = i * chunkSize;
-            int endPos = startPos + chunkSize;
-
-            sourceBuffer.position(startPos);
-            sourceBuffer.limit(endPos);
-
-            chunks[i] = sourceBuffer.slice();
-        }
-
-        return chunks;
     }
 }

--- a/curvine-libsdk/java/src/main/java/io/curvine/FilesystemConf.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/FilesystemConf.java
@@ -64,7 +64,7 @@ public class FilesystemConf {
     public long data_timeout_ms = 120 * 1000;
 
     // Number of fs master connections.
-    public int master_conn_pool_size = 1;
+    public int master_conn_pool_size = 3;
 
     // Whether to enable pre-reading, it only controls whether short-circuit read and write, and whether it is turned on.
     public boolean enable_read_ahead = true;

--- a/curvine-libsdk/src/java/java_abi.rs
+++ b/curvine-libsdk/src/java/java_abi.rs
@@ -19,8 +19,7 @@ use crate::{java_err, java_err2, LibFsReader, LibFsWriter};
 use jni::objects::{JLongArray, JObject, JString};
 use jni::sys::{jarray, jboolean, jint, jlong};
 use jni::JNIEnv;
-use orpc::sys::DataSlice;
-use orpc::sys::{FFIUtils, RawVec};
+use orpc::sys::FFIUtils;
 
 // It's too troublesome to parse object members by jni. Here the configuration will be passed through the json string.
 #[no_mangle]
@@ -64,20 +63,37 @@ pub unsafe extern "C" fn Java_io_curvine_CurvineNative_append(
     FFIUtils::into_raw_ptr(writer)
 }
 
+#[no_mangle]
+pub unsafe extern "C" fn Java_io_curvine_CurvineNative_allocChunk(
+    mut env: JNIEnv,
+    _this: JObject,
+    writer_ptr: *mut LibFsWriter,
+    tmp: JLongArray,
+) -> jlong {
+    let writer = &mut *writer_ptr;
+
+    let chunk = java_err!(env, writer.alloc_chunk());
+    let arr = [chunk.as_ptr() as jlong, chunk.len() as jlong];
+    env.set_long_array_region(tmp, 0, &arr).unwrap();
+
+    SUCCESS
+}
+
 // Write data.Java passes the direct buffer memory address and length.
 #[no_mangle]
 pub unsafe extern "C" fn Java_io_curvine_CurvineNative_write(
     mut env: JNIEnv,
     _this: JObject,
     writer_ptr: *mut LibFsWriter,
-    buf: jlong,
+    address: jlong,
     len: jint,
+    tmp: JLongArray,
 ) -> jlong {
     let writer = &mut *writer_ptr;
 
-    let raw_vec = RawVec::from_raw(buf as *mut u8, len as usize);
-    let buf = DataSlice::MemSlice(raw_vec);
-    java_err!(env, writer.write(buf));
+    let chunk = java_err!(env, writer.write_v2(address, len));
+    let arr = [chunk.as_ptr() as jlong, chunk.len() as jlong];
+    env.set_long_array_region(tmp, 0, &arr).unwrap();
 
     SUCCESS
 }

--- a/curvine-libsdk/src/lib_filesystem.rs
+++ b/curvine-libsdk/src/lib_filesystem.rs
@@ -82,13 +82,13 @@ impl LibFilesystem {
         let writer = self
             .rt
             .block_on(async { self.inner.create(&path, overwrite).await })?;
-        Ok(LibFsWriter::new(self.rt.clone(), writer))
+        Ok(LibFsWriter::new(self.rt.clone(), writer, self.inner.conf()))
     }
 
     pub fn append(&self, path: impl AsRef<str>) -> FsResult<LibFsWriter> {
         let path = Path::from_str(path)?;
         let writer = self.rt.block_on(async { self.inner.append(&path).await })?;
-        Ok(LibFsWriter::new(self.rt.clone(), writer))
+        Ok(LibFsWriter::new(self.rt.clone(), writer, self.inner.conf()))
     }
 
     pub fn get_master_info(&self) -> FsResult<BytesMut> {

--- a/curvine-libsdk/src/lib_fs_writer.rs
+++ b/curvine-libsdk/src/lib_fs_writer.rs
@@ -12,10 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use bytes::BytesMut;
 use curvine_client::unified::UnifiedWriter;
+use curvine_common::conf::ClusterConf;
 use curvine_common::fs::{Path, Writer};
 use curvine_common::state::FileStatus;
 use curvine_common::FsResult;
+use orpc::err_box;
+use orpc::handler::FrameBuf;
 use orpc::runtime::{RpcRuntime, Runtime};
 use orpc::sys::DataSlice;
 use std::sync::Arc;
@@ -23,15 +27,55 @@ use std::sync::Arc;
 pub struct LibFsWriter {
     pub(crate) rt: Arc<Runtime>,
     pub(crate) inner: UnifiedWriter,
+    pub(crate) buf: FrameBuf,
+    pub(crate) chunk_size: usize,
+    pub(crate) cur_chunk: Option<BytesMut>,
 }
 
 impl LibFsWriter {
-    pub fn new(rt: Arc<Runtime>, writer: UnifiedWriter) -> Self {
-        Self { rt, inner: writer }
+    pub fn new(rt: Arc<Runtime>, writer: UnifiedWriter, conf: &ClusterConf) -> Self {
+        Self {
+            rt,
+            inner: writer,
+            buf: FrameBuf::new(conf.client.write_chunk_size * conf.client.write_chunk_num),
+            chunk_size: conf.client.write_chunk_size,
+            cur_chunk: None,
+        }
     }
 
     pub fn write(&mut self, buf: DataSlice) -> FsResult<()> {
         self.inner.blocking_write(&self.rt, buf)
+    }
+
+    pub fn alloc_chunk(&mut self) -> FsResult<&[u8]> {
+        if self.cur_chunk.is_some() {
+            return err_box!("chunk already allocated");
+        }
+        let chunk = self.buf.take_exact(self.chunk_size);
+        Ok(self.cur_chunk.insert(chunk))
+    }
+
+    pub fn write_v2(&mut self, addr: i64, len: i32) -> FsResult<&[u8]> {
+        let Some(mut chunk) = self.cur_chunk.take() else {
+            return err_box!("no chunk allocated; call alloc_chunk first");
+        };
+
+        if chunk.as_ptr() as i64 != addr {
+            self.cur_chunk = Some(chunk);
+            return err_box!("write address does not match allocated chunk");
+        }
+
+        if len < 0 || len as usize > chunk.capacity() {
+            self.cur_chunk.replace(chunk);
+            return err_box!("invalid write length: {}", len);
+        }
+        unsafe {
+            chunk.set_len(len as usize);
+        }
+        self.inner
+            .blocking_write(&self.rt, DataSlice::buffer(chunk))?;
+
+        self.alloc_chunk()
     }
 
     pub fn flush(&mut self) -> FsResult<()> {
@@ -39,6 +83,7 @@ impl LibFsWriter {
     }
 
     pub fn complete(&mut self) -> FsResult<()> {
+        let _ = self.cur_chunk.take();
         self.rt.block_on(self.inner.complete())
     }
 

--- a/curvine-server/src/master/job/job_manager.rs
+++ b/curvine-server/src/master/job/job_manager.rs
@@ -95,16 +95,16 @@ impl JobManager {
 
     async fn wait_job_complete0(&self, job_id: impl AsRef<str>) -> FsResult<JobStatus> {
         let job_id = job_id.as_ref();
+
+        let mut listener = match self.jobs.get(job_id) {
+            Some(job) => job.new_listener(),
+            None => return err_ext!(FsError::job_not_found(job_id)),
+        };
+
         let status = self.get_job_status(job_id)?;
         if status.state.is_finish() {
             return Ok(status);
         }
-
-        let mut listener = if let Some(job) = self.jobs.get(job_id) {
-            job.new_listener()
-        } else {
-            return err_ext!(FsError::job_not_found(job_id));
-        };
 
         loop {
             let next_state = JobTaskState::from(listener.next_state().await?);
@@ -153,6 +153,9 @@ impl JobManager {
         &self.rt
     }
 
+    /// See `LoadJobRunner::submit_load_task` for the concurrency contract: concurrent
+    /// submits for the same path while a load is running return the **existing** run’s
+    /// result; the new command’s options are not applied (first submitter wins).
     pub async fn submit_load_job(&self, command: LoadJobCommand) -> FsResult<LoadJobResult> {
         let source_path = Path::from_str(&command.source_path)?;
 

--- a/curvine-server/src/master/job/job_runner.rs
+++ b/curvine-server/src/master/job/job_runner.rs
@@ -25,6 +25,7 @@ use curvine_common::state::{
 };
 use curvine_common::utils::CommonUtils;
 use curvine_common::FsResult;
+use dashmap::mapref::entry::Entry;
 use futures::future;
 use log::{debug, error, info, warn};
 use orpc::common::{ByteUnit, FastHashMap, FastHashSet, LocalTime};
@@ -65,37 +66,63 @@ impl LoadJobRunner {
         }
     }
 
-    /// Returns true if we should skip submitting the load task (data already synced or job in progress).
     async fn check_job_exists(
         &self,
-        job_id: &str,
+        job: &JobContext,
         mnt: &MountValue,
         source_path: &Path,
         target_path: &Path,
-    ) -> FsResult<bool> {
-        // Job in progress: skip submit
-        if let Some(job) = self.jobs.get(job_id) {
-            let state: JobTaskState = job.state.state();
-            if state == JobTaskState::Pending || state == JobTaskState::Loading {
-                return Ok(true);
+    ) -> FsResult<Option<LoadJobResult>> {
+        if let Some(exist_job) = self.jobs.get(&job.info.job_id) {
+            let state: JobTaskState = exist_job.state.state();
+            if state.is_running() {
+                return Ok(Some(LoadJobResult::with_state(&exist_job.info, state)));
             }
         }
 
-        // Skip based on data state (even when job is None, e.g. after job cleanup)
+        // Data-state fast-path. Applies whether the slot was vacant or held
+        // a terminal ctx — e.g. after JobCleanupTask, after master restart +
+        // journal replay, or after an earlier run completed the sync.
+        //
+        // Only UFS→CV imports can be fast-skipped here; CV sources always
+        // need an explicit export task.
         if source_path.is_cv() {
-            Ok(false)
-        } else if let Ok(cv_status) = self.master_fs.file_status(target_path.path()) {
-            if cv_status.cv_valid(None) {
-                let source_status = mnt.ufs.get_status(source_path).await?;
-                Ok(cv_status.cv_valid(Some(&source_status)))
-            } else {
-                Ok(false)
-            }
+            return Ok(None);
+        }
+
+        // Target not present in Curvine yet — must load.
+        let cv_status = match self.master_fs.file_status(target_path.path()) {
+            Ok(cv_status) => cv_status,
+            Err(FsError::FileNotFound(_)) => return Ok(None),
+            Err(err) => return Err(err),
+        };
+
+        // Cached target exists but its own metadata says it isn't usable — must reload.
+        if !cv_status.cv_valid(None) {
+            return Ok(None);
+        }
+
+        // Target looks valid locally; confirm against UFS source before skipping.
+        let source_status = mnt.ufs.get_status(source_path).await?;
+        if cv_status.cv_valid(Some(&source_status)) {
+            Ok(Some(LoadJobResult::with_state(
+                &job.info,
+                JobTaskState::Completed,
+            )))
         } else {
-            Ok(false)
+            Ok(None)
         }
     }
 
+    /// Submits a load job for the given source path (and mount).
+    ///
+    /// **Concurrency:** The job id is derived from the source path. If two clients
+    /// submit for the same path while a job is already **running**, the call
+    /// returns success with the **in-flight** job’s state and `LoadJobResult` built
+    /// from that job’s `LoadJobInfo`; the later request’s `LoadJobCommand` options
+    /// (replicas, overwrite, etc.) are **not** applied. **First submitter wins** for
+    /// that path. Use `JobManager::get_job_status` to inspect the job that is
+    /// actually running (including its resolved options).
     pub async fn submit_load_task(
         &self,
         command: LoadJobCommand,
@@ -115,8 +142,8 @@ impl LoadJobRunner {
         );
 
         let mnt_value = self.factory.get_mnt(&mnt)?;
-        if self
-            .check_job_exists(&job_id, &mnt_value, &source_path, &target_path)
+        if let Some(res) = self
+            .check_job_exists(&job_context, &mnt_value, &source_path, &target_path)
             .await?
         {
             info!(
@@ -124,20 +151,8 @@ impl LoadJobRunner {
                 job_id,
                 source_path.full_path()
             );
-            return if let Some(existing_ctx) = self.jobs.get(&job_id) {
-                Ok(LoadJobResult::with_state(
-                    &existing_ctx.info,
-                    existing_ctx.state.state(),
-                ))
-            } else {
-                Ok(LoadJobResult::with_state(
-                    &job_context.info,
-                    JobTaskState::Completed,
-                ))
-            };
+            return Ok(res);
         }
-
-        self.jobs.remove(&job_id);
 
         debug!(
             "submitting load job {}: {} -> {}",
@@ -146,35 +161,63 @@ impl LoadJobRunner {
             target_path.full_path()
         );
 
-        let res = self
+        let total_size = self
             .create_all_tasks(&mut job_context, &source_path, &mnt)
-            .await;
+            .await?;
 
-        match res {
-            Err(e) => {
-                warn!("create load job {} failed: {}", job_id, e);
-                Err(e)
+        info!(
+            "load job {} submitted: {} -> {}, tasks {}, total_size {}",
+            job_id,
+            source_path.full_path(),
+            target_path.full_path(),
+            job_context.tasks.len(),
+            ByteUnit::byte_to_string(total_size as u64)
+        );
+
+        let tasks = job_context.tasks.clone();
+        let res = LoadJobResult::with_job(&job_context.info);
+
+        // Install / replace the ctx into the store atomically. We branch into:
+        //   - Vacant: first submitter, install and dispatch.
+        //   - Occupied + running: another submitter won the race; return that job’s
+        //     state (this request’s command is not applied—see `submit_load_task` doc).
+        //   - Occupied + terminal: previous run finished/failed/canceled and
+        //     hasn't been cleaned up yet. Replace with the new ctx and dispatch.
+        match self.jobs.entry(job_id.clone()) {
+            Entry::Occupied(mut e) => {
+                let state: JobTaskState = e.get().state.state();
+                if state.is_running() {
+                    let existing = e.get();
+                    debug!(
+                        "job {} race-lost on entry: another submitter is dispatching (state={:?})",
+                        job_id, state
+                    );
+                    return Ok(LoadJobResult::with_state(&existing.info, state));
+                }
+                info!(
+                    "job {} previous run in terminal state {:?}, replacing",
+                    job_id, state
+                );
+                e.insert(job_context);
             }
 
-            Ok(size) => {
-                info!(
-                    "load job {} submitted: {} -> {}, tasks {}, total_size {}",
-                    job_id,
-                    source_path.full_path(),
-                    target_path.full_path(),
-                    job_context.tasks.len(),
-                    ByteUnit::byte_to_string(size as u64)
-                );
-
-                let tasks = job_context.tasks.clone();
-                let res = LoadJobResult::with_job(&job_context.info);
-                self.jobs.insert(job_id, job_context);
-                // @todo Whether to cancel some tasks that may have been dispatched.
-                self.submit_all_task(tasks).await?;
-
-                Ok(res)
+            Entry::Vacant(e) => {
+                e.insert(job_context);
             }
         }
+
+        if let Err(err) = self.submit_all_task(tasks).await {
+            warn!("dispatch load job {} failed: {}", job_id, err);
+            // @todo Cancel sub-tasks that may have already been dispatched.
+            self.jobs.update_state(
+                &job_id,
+                JobTaskState::Failed,
+                format!("dispatch failed: {}", err),
+            );
+            return Err(err);
+        }
+
+        Ok(res)
     }
 
     async fn submit_all_task(&self, tasks: FastHashMap<String, TaskDetail>) -> FsResult<()> {

--- a/curvine-server/src/master/master_handler.rs
+++ b/curvine-server/src/master/master_handler.rs
@@ -144,7 +144,7 @@ impl MasterHandler {
 
         let opts = ProtoUtils::create_opts_from_pb(header.opts);
         let flags = OpenFlags::new(header.flags);
-        let audit_path = format!("[{}]{}", flags.access_mark(), header.path);
+        let audit_path = format!("{}:{}", flags.access_mark(), header.path);
         ctx.set_audit(Some(audit_path), None);
 
         let file_blocks = self.open_file0(ctx.msg.req_id(), header.path, opts, flags)?;
@@ -304,9 +304,9 @@ impl MasterHandler {
         let req: CompleteFileRequest = ctx.parse_header()?;
 
         let audit_path = if req.only_flush {
-            format!("[flush]{}", req.path)
+            format!("flush:{}", req.path)
         } else {
-            format!("[close]{}", req.path)
+            format!("close:{}", req.path)
         };
         ctx.set_audit(Some(audit_path), None);
 
@@ -725,7 +725,7 @@ impl MessageHandler for MasterHandler {
         // Record request processing time and audit log
         let used_us = ctx.spent.used_us();
         if self.audit_logging_enabled {
-            ctx.audit_log(response.is_ok(), used_us, self.conn_state.as_ref());
+            ctx.audit_log(&response, used_us, self.conn_state.as_ref());
         }
 
         let code_label = format!("{:?}", ctx.code);

--- a/curvine-server/src/master/meta/fs_dir.rs
+++ b/curvine-server/src/master/meta/fs_dir.rs
@@ -272,9 +272,9 @@ impl FsDir {
 
                 File(f) => {
                     let locs = f.get_locs(&self.store)?;
-                    let len = f.len;
+                    let bytes = f.get_locs_bytes(&locs);
                     if f.free(mtime) {
-                        free_res.add(len, locs);
+                        free_res.add(bytes, locs);
                         change_inodes.push(inode.as_ref().clone());
                     }
                 }

--- a/curvine-server/src/master/meta/inode/inode_file.rs
+++ b/curvine-server/src/master/meta/inode/inode_file.rs
@@ -510,6 +510,16 @@ impl InodeFile {
         Ok(res)
     }
 
+    pub fn get_locs_bytes(&self, locs: &HashMap<i64, Vec<BlockLocation>>) -> i64 {
+        let mut bytes = 0;
+        for block in &self.blocks {
+            if let Some(locs) = locs.get(&block.id) {
+                bytes += (locs.len() as i64) * (block.len as i64);
+            }
+        }
+        bytes
+    }
+
     pub fn ufs_exists(&self) -> bool {
         self.storage_policy.ufs_exists()
     }

--- a/curvine-server/src/master/rpc_context.rs
+++ b/curvine-server/src/master/rpc_context.rs
@@ -21,6 +21,7 @@ use orpc::io::net::ConnState;
 use orpc::message::{Builder, Message};
 use orpc::CommonResult;
 use prost::Message as PMessage;
+use std::borrow::Cow;
 
 pub struct RpcContext<'a> {
     pub msg: &'a Message,
@@ -69,7 +70,7 @@ impl<'a> RpcContext<'a> {
         Ok(rep_msg)
     }
 
-    pub fn audit_log(&self, succeeded: bool, used_us: u64, conn_state: Option<&ConnState>) {
+    pub fn audit_log<T>(&self, res: &FsResult<T>, used_us: u64, conn_state: Option<&ConnState>) {
         if matches!(
             self.code,
             RpcCode::WorkerHeartbeat | RpcCode::WorkerBlockReport | RpcCode::GetMountTable
@@ -77,21 +78,26 @@ impl<'a> RpcContext<'a> {
             return;
         }
 
-        let src = match &self.audit_src {
-            None => "",
-            Some(v) => v,
-        };
-        let dst = match &self.audit_dst {
-            None => "",
-            Some(v) => v,
-        };
+        let src = self.audit_src.as_deref().unwrap_or("");
+        let dst = self.audit_dst.as_deref().unwrap_or("");
+        let ip = conn_state
+            .map(|s| s.remote_addr.hostname.as_str())
+            .unwrap_or("");
 
-        let ip = match conn_state {
-            None => "",
-            Some(v) => &v.remote_addr.hostname,
+        let err_suffix: Cow<'_, str> = match res.as_ref() {
+            Err(e) => Cow::Owned(format!(" err={:?}", e.kind())),
+            Ok(_) => Cow::Borrowed(""),
         };
-
-        info!(target: "audit", "cmd={:?} succeeded={} ip={} src={} dst={} executionTimeUs={}",
-            self.code, succeeded, ip, src, dst, used_us);
+        info!(
+            target: "audit",
+            "cmd={} ok={} ip={} src={} dst={} usedUs={}{}",
+            self.code,
+            res.is_ok(),
+            ip,
+            src,
+            dst,
+            used_us,
+            err_suffix,
+        );
     }
 }

--- a/curvine-server/src/worker/task/task_manager.rs
+++ b/curvine-server/src/worker/task/task_manager.rs
@@ -14,12 +14,13 @@
 
 use crate::common::UfsFactory;
 use crate::worker::task::load_task_runner::LoadTaskRunner;
-use crate::worker::task::TaskStore;
+use crate::worker::task::{TaskContext, TaskStore};
 use curvine_client::file::{CurvineFileSystem, FsContext};
 use curvine_common::conf::ClusterConf;
-use curvine_common::state::LoadTaskInfo;
+use curvine_common::state::{JobTaskState, LoadTaskInfo};
 use curvine_common::FsResult;
-use log::debug;
+use dashmap::mapref::entry::Entry;
+use log::{debug, info, warn};
 use orpc::runtime::{RpcRuntime, Runtime};
 use std::sync::Arc;
 use tokio::sync::Semaphore;
@@ -112,20 +113,44 @@ impl TaskManager {
     ///
     /// # Behavior
     ///
-    /// 1. Checks if task already exists (idempotent operation)
-    /// 2. Creates task context and stores it in TaskStore
-    /// 3. Spawns async task that:
-    ///    - Acquires semaphore permit (blocks if limit reached)
-    ///    - Executes LoadTaskRunner.run()
-    ///    - Automatically releases permit on completion
-    ///    - Removes task from store
+    /// 1. If a task with the same `task_id` is already in the store, it is
+    ///    treated as **superseded**: its `TaskContext` is flipped to
+    ///    `Canceled` (the running `LoadTaskRunner` observes this at the
+    ///    next chunk boundary via `TaskContext::is_cancel`) and the map
+    ///    entry is replaced with a fresh context in a single shard-locked
+    ///    operation. This is intentional: silently de-duping would leave
+    ///    the new dispatcher's `JobContext` without a reporter and the
+    ///    master would hang until `ufs_copy_timeout`.
+    /// 2. If no task exists for the `task_id`, the new context is inserted.
+    /// 3. Spawns an async task that:
+    ///    - Acquires a semaphore permit (blocks if limit reached)
+    ///    - Executes `LoadTaskRunner::run`
+    ///    - Automatically releases the permit on completion
+    ///    - Removes the map entry **only if it still points at its own
+    ///      context** (a later `submit_task` may have superseded it)
     pub fn submit_task(&self, task: LoadTaskInfo) -> FsResult<()> {
         let task_id = task.task_id.clone();
-        if self.tasks.contains(&task_id) {
-            return Ok(());
-        }
+        let context = Arc::new(TaskContext::new(task));
 
-        let context = self.tasks.insert(task);
+        match self.tasks.entry(task_id.clone()) {
+            Entry::Occupied(mut occ) => {
+                let old = occ.insert(context.clone());
+                old.update_state(JobTaskState::Canceled, "superseded by new submit");
+                warn!(
+                    "cancel duplicate task {} (source_path={})",
+                    old.info.task_id, old.info.source_path
+                );
+            }
+
+            Entry::Vacant(vac) => {
+                vac.insert(context.clone());
+            }
+        }
+        info!(
+            "submit task {} {}",
+            context.info.task_id, context.info.source_path
+        );
+
         let runner = LoadTaskRunner::new(
             context.clone(),
             self.fs.clone(),
@@ -134,15 +159,13 @@ impl TaskManager {
             self.task_timeout_ms,
         );
 
-        debug!("submit task {}", task_id);
-
         let tasks = self.tasks.clone();
         let semaphore = self.worker_task_semaphore.clone();
+        let context_this = context.clone();
 
         // Spawn task with concurrency control
         self.rt.spawn(async move {
-            let _permit = semaphore.acquire().await;
-            match _permit {
+            match semaphore.acquire().await {
                 Ok(permit) => {
                     runner.run().await;
                     drop(permit);
@@ -152,7 +175,7 @@ impl TaskManager {
                 }
             }
 
-            let _ = tasks.remove(&task_id);
+            let _ = tasks.remove_if(&task_id, |_, ctx| Arc::ptr_eq(ctx, &context_this));
         });
 
         Ok(())

--- a/curvine-server/src/worker/task/task_store.rs
+++ b/curvine-server/src/worker/task/task_store.rs
@@ -78,3 +78,81 @@ impl Deref for TaskStore {
         &self.tasks
     }
 }
+
+#[cfg(test)]
+mod supersede_tests {
+    use super::TaskStore;
+    use crate::worker::task::TaskContext;
+    use curvine_common::state::WorkerAddress;
+    use curvine_common::state::{
+        JobTaskState, LoadJobInfo, LoadTaskInfo, MountInfo, StorageType, TtlAction,
+    };
+    use dashmap::mapref::entry::Entry;
+    use std::sync::Arc;
+
+    fn load_task(task_id: &str, job_id: &str) -> LoadTaskInfo {
+        let job = LoadJobInfo {
+            job_id: job_id.to_string(),
+            source_path: "s".to_string(),
+            target_path: "t".to_string(),
+            block_size: 4096,
+            replicas: 1,
+            storage_type: StorageType::default(),
+            ttl_ms: 0,
+            ttl_action: TtlAction::default(),
+            mount_info: MountInfo::default(),
+            create_time: 0,
+            overwrite: None,
+        };
+        LoadTaskInfo {
+            job,
+            task_id: task_id.to_string(),
+            worker: WorkerAddress::default(),
+            source_path: "s".to_string(),
+            target_path: "t".to_string(),
+            create_time: 0,
+        }
+    }
+
+    /// Mirrors `TaskManager::submit_task`: supersede replaces the map entry; only
+    /// `remove_if` matching the **current** `Arc` may delete (guards spawn epilogue).
+    #[test]
+    fn supersede_marks_old_canceled_remove_if_only_evicts_matching_runner() {
+        let store = TaskStore::new();
+        let tid = "same_task_id".to_string();
+
+        let first = Arc::new(TaskContext::new(load_task(&tid, "job_a")));
+        match store.entry(tid.clone()) {
+            Entry::Vacant(v) => {
+                v.insert(first.clone());
+            }
+            Entry::Occupied(_) => panic!("expected vacant"),
+        }
+
+        let second = Arc::new(TaskContext::new(load_task(&tid, "job_a")));
+        match store.entry(tid.clone()) {
+            Entry::Occupied(mut occ) => {
+                let old = occ.insert(second.clone());
+                assert!(Arc::ptr_eq(&old, &first));
+                old.update_state(JobTaskState::Canceled, "superseded by new submit");
+            }
+            Entry::Vacant(_) => panic!("expected occupied"),
+        }
+
+        assert_eq!(first.get_state(), JobTaskState::Canceled);
+        // Do not hold a `get()` Ref across `remove_if` on the same key (deadlocks: read vs write on one shard).
+        assert!(Arc::ptr_eq(&*store.get(&tid).expect("slot"), &second));
+
+        // Stale runner would call `remove_if` with `first`; must not clear the slot.
+        assert!(store
+            .remove_if(&tid, |_, ctx| Arc::ptr_eq(ctx, &first))
+            .is_none());
+        assert!(store.get(&tid).is_some());
+
+        // Current runner removes with `second`.
+        assert!(store
+            .remove_if(&tid, |_, ctx| Arc::ptr_eq(ctx, &second))
+            .is_some());
+        assert!(store.get(&tid).is_none());
+    }
+}

--- a/orpc/Cargo.toml
+++ b/orpc/Cargo.toml
@@ -44,6 +44,7 @@ fxhash = { workspace = true }
 moka = { workspace = true }
 md-5 = { workspace = true }
 nix = { workspace = true }
+parking_lot = { workspace = true }
 
 [features]
 spdk = []

--- a/orpc/src/sync/mod.rs
+++ b/orpc/src/sync/mod.rs
@@ -43,3 +43,6 @@ pub use self::mutex_hash_map::MutexHashMap;
 
 mod rw_lock_hash_map;
 pub use self::rw_lock_hash_map::RwLockHashMap;
+
+mod mutex;
+pub use self::mutex::*;

--- a/orpc/src/sync/mutex.rs
+++ b/orpc/src/sync/mutex.rs
@@ -1,0 +1,80 @@
+//  Copyright 2025 OPPO.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+use parking_lot::{Mutex, RwLock};
+use std::ops::Deref;
+
+pub struct FastMutex<T>(Mutex<T>);
+
+impl<T> FastMutex<T> {
+    pub fn new(t: T) -> Self {
+        FastMutex(Mutex::new(t))
+    }
+}
+
+impl<T> Deref for FastMutex<T> {
+    type Target = Mutex<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+pub struct FastRwLock<T>(RwLock<T>);
+
+impl<T> FastRwLock<T> {
+    pub fn new(t: T) -> Self {
+        FastRwLock(RwLock::new(t))
+    }
+}
+
+impl<T> Deref for FastRwLock<T> {
+    type Target = RwLock<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+pub struct AsyncMutex<T>(tokio::sync::Mutex<T>);
+
+impl<T> AsyncMutex<T> {
+    pub fn new(t: T) -> Self {
+        AsyncMutex(tokio::sync::Mutex::new(t))
+    }
+}
+
+impl<T> Deref for AsyncMutex<T> {
+    type Target = tokio::sync::Mutex<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+pub struct AsyncRwLock<T>(tokio::sync::RwLock<T>);
+
+impl<T> AsyncRwLock<T> {
+    pub fn new(t: T) -> Self {
+        AsyncRwLock(tokio::sync::RwLock::new(t))
+    }
+}
+
+impl<T> Deref for AsyncRwLock<T> {
+    type Target = tokio::sync::RwLock<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}


### PR DESCRIPTION
## Summary

This PR cherry-picks 12 commits that improve stability, correctness, observability, and SDK/build behavior across server, fuse, common, and libsdk modules.

### 1) Server/job reliability and race-condition fixes
- Fix duplicate sync-task handling by replacing existing task contexts instead of silently de-duping.
- Harden load-job lifecycle handling to avoid race conditions during submission/status transitions.
- Ensure terminal job states are not missed in wait paths by creating listeners before status checks.

### 2) FUSE correctness and metrics
- Fix inode identity issues in cache mode for UFS-backed entries (avoid inode `0` collision behavior).
- Ensure `FileStatus.id` tracks dcache inode consistently.
- Add `FuseMetrics` and refresh FUSE gauges from `NodeState` on `/metrics` scrape.

### 3) Common/metadata correctness
- Map `std::io::ErrorKind` to dedicated `FsError` variants so errno translation is preserved (e.g. `ENOENT`, `EEXIST`, `ENOTEMPTY`, `ENOSYS` instead of generic `EIO`).
- Improve free semantics:
  - report freed **physical bytes** (replicas × block size) rather than logical file length,
  - align behavior with TTL actions,
  - treat invalid `ufs_mtime` as invalid CV data to avoid stale reads.

### 4) Audit and diagnostics
- Introduce a unified per-operation audit logging path across client, fuse, and master.
- Add component-level switches and route logs through dedicated `target: "audit"` for traceability.

### 5) Performance and SDK behavior
- Increase default master connection pool size from 1 to 3 (Rust client and Java SDK config defaults).
- Add ORPC sync mutex wrappers and serde support for open/create options.
- Rework Java `CurvineOutputStream` write path to use Rust-owned chunks (`allocChunk`/`write_v2`) to reduce extra metadata RPC overhead and simplify buffering.

### 6) Build/config safety
- Gate static linker wrapper behavior behind `CURVINE_STATIC_LINK=1` to avoid forcing static-link rewriting by default.
- Build JNI `curvine-libsdk` with system allocator to avoid JVM static TLS block failures from jemalloc-linked cdylib.
- Remove side effects (`mkdir`) from `DBConf` and `JournalConf` defaults.

## Why

These changes collectively target production pain points:
- race conditions and duplicate task corner cases,
- filesystem error-code correctness,
- stale/incorrect metadata identity in FUSE,
- incomplete audit traceability,
- JNI runtime compatibility risks,
- and default performance bottlenecks.
