### PR TITLE
fix(fuse): restore mmap/read coherence by not forcing direct_io on ca…

### DIFF
--- a/build/tests/fuse-test.sh
+++ b/build/tests/fuse-test.sh
@@ -59,6 +59,7 @@ This script tests basic filesystem operations including:
   - File permissions (chmod, chown, chgrp)
   - Sed in-place editing
   - Pwrite visibility (file size and content after pwrite)
+  - Mmap read/write (MAP_SHARED mmap ↔ pread coherence, issue #850)
 
 For FIO performance tests, use fio-test.sh instead.
 
@@ -181,6 +182,76 @@ init_test_env() {
     fi
     
     print_info "Test environment initialized successfully"
+}
+
+# Resolve python3/python executable path.
+# Prints the command on success; returns 1 if Python is unavailable.
+get_python_cmd() {
+    if command -v python3 >/dev/null 2>&1; then
+        echo "python3"
+        return 0
+    fi
+    if command -v python >/dev/null 2>&1; then
+        echo "python"
+        return 0
+    fi
+    return 1
+}
+
+# Run a Python test script from build/tests/scripts/.
+#
+# Usage:
+#   run_python_script_test "Test description" script.py [script args...]
+#
+# Returns:
+#   0 - passed or skipped (Python or script unavailable)
+#   1 - failed
+run_python_script_test() {
+    local test_name="$1"
+    local script_name="$2"
+    shift 2
+
+    local python_cmd
+    if ! python_cmd=$(get_python_cmd); then
+        print_info "Python not available, skipping $test_name"
+        return 0
+    fi
+
+    local test_script="$SCRIPT_DIR/scripts/$script_name"
+    if [ ! -f "$test_script" ]; then
+        print_info "Test script not found: $test_script"
+        print_info "Skipping $test_name"
+        return 0
+    fi
+
+    print_test "$test_name"
+    TOTAL_TESTS=$((TOTAL_TESTS + 1))
+
+    local start_time end_time elapsed result=0
+    start_time=$(date +%s)
+
+    local cmd="$python_cmd $test_script"
+    if [ $# -gt 0 ]; then
+        cmd="$cmd $*"
+    fi
+    print_command "$cmd"
+
+    if $python_cmd "$test_script" "$@" 2>&1; then
+        result=0
+    else
+        result=$?
+    fi
+
+    end_time=$(date +%s)
+    elapsed=$((end_time - start_time))
+
+    if [ $result -eq 0 ]; then
+        print_success "$test_name completed successfully in ${elapsed}s"
+        return 0
+    fi
+
+    handle_error "$test_name failed" "$cmd"
+    return 1
 }
 
 # Test 1: Basic file operations
@@ -903,15 +974,10 @@ test_file_locks() {
     fi
 
     # Test 4: POSIX lock (fcntl) - using Python if available
-    if command -v python3 >/dev/null 2>&1 || command -v python >/dev/null 2>&1; then
+    local python_cmd
+    if python_cmd=$(get_python_cmd); then
         print_test "Testing POSIX lock (fcntl) with Python"
         TOTAL_TESTS=$((TOTAL_TESTS + 1))
-        local python_cmd=""
-        if command -v python3 >/dev/null 2>&1; then
-            python_cmd="python3"
-        else
-            python_cmd="python"
-        fi
 
         local lock_script_file=$(mktemp)
         cat > "$lock_script_file" << 'PYTHON_EOF'
@@ -1110,12 +1176,11 @@ test_python_high_frequency_write() {
     CURRENT_TEST_GROUP="Test 14: Python High-Frequency Write"
     print_header "$CURRENT_TEST_GROUP"
 
-    if ! command -v python3 >/dev/null 2>&1 && ! command -v python >/dev/null 2>&1; then
+    local python_cmd
+    if ! python_cmd=$(get_python_cmd); then
         print_info "Python not available, skipping high-frequency write test"
         return
     fi
-
-    local python_cmd=$(command -v python3 2>/dev/null || command -v python)
     local test_file="$TEST_DIR/python-high-freq.txt"
     local iterations=20
     
@@ -1209,85 +1274,7 @@ PYTHON_SCRIPT
 test_fuse_reload() {
     CURRENT_TEST_GROUP="Test 15: FUSE Hot Reload"
     print_header "$CURRENT_TEST_GROUP"
-
-    if ! command -v python3 >/dev/null 2>&1 && ! command -v python >/dev/null 2>&1; then
-        print_info "Python not available, skipping FUSE reload test"
-        return
-    fi
-
-    local python_cmd=$(command -v python3 2>/dev/null || command -v python)
-    local test_script="$SCRIPT_DIR/scripts/fuse_reload_test.py"
-    
-    if [ ! -f "$test_script" ]; then
-        print_info "FUSE reload test script not found: $test_script"
-        print_info "Skipping FUSE reload test"
-        return
-    fi
-
-    print_test "Testing FUSE hot reload functionality"
-    TOTAL_TESTS=$((TOTAL_TESTS + 1))
-
-    local start_time=$(date +%s)
-    
-    # Run the Python test script
-    if $python_cmd "$test_script" 2>&1; then
-        local result=0
-    else
-        local result=$?
-    fi
-    
-    local end_time=$(date +%s)
-    local elapsed=$((end_time - start_time))
-
-    if [ $result -eq 0 ]; then
-        print_success "FUSE reload test completed successfully in ${elapsed}s"
-    else
-        handle_error "FUSE reload test failed" "python $test_script"
-    fi
-}
-
-# Test 17: Pwrite visibility test
-test_pwrite_visibility() {
-    CURRENT_TEST_GROUP="Test 17: Pwrite Visibility"
-    print_header "$CURRENT_TEST_GROUP"
-
-    if ! command -v python3 >/dev/null 2>&1 && ! command -v python >/dev/null 2>&1; then
-        print_info "Python not available, skipping pwrite visibility test"
-        return
-    fi
-
-    local python_cmd
-    python_cmd=$(command -v python3 2>/dev/null || command -v python)
-    local test_script="$SCRIPT_DIR/scripts/visibility_test.py"
-
-    if [ ! -f "$test_script" ]; then
-        print_info "Pwrite visibility test script not found: $test_script"
-        print_info "Skipping pwrite visibility test"
-        return
-    fi
-
-    print_test "Testing file size and content visibility after pwrite"
-    TOTAL_TESTS=$((TOTAL_TESTS + 1))
-
-    local start_time
-    start_time=$(date +%s)
-    local result=0
-
-    if $python_cmd "$test_script" --dir "$TEST_DIR" 2>&1; then
-        result=0
-    else
-        result=$?
-    fi
-
-    local end_time
-    end_time=$(date +%s)
-    local elapsed=$((end_time - start_time))
-
-    if [ $result -eq 0 ]; then
-        print_success "Pwrite visibility test completed successfully in ${elapsed}s"
-    else
-        handle_error "Pwrite visibility test failed" "python $test_script --dir $TEST_DIR"
-    fi
+    run_python_script_test "Testing FUSE hot reload functionality" "fuse_reload_test.py"
 }
 
 # Test 16: Git clone operations
@@ -1335,6 +1322,22 @@ test_git_clone() {
     else
         handle_error "Failed to clone repository" "$cmd"
     fi
+}
+
+# Test 17: Mmap read/write test
+test_mmap() {
+    CURRENT_TEST_GROUP="Test 17: Mmap Read/Write"
+    print_header "$CURRENT_TEST_GROUP"
+    run_python_script_test \
+        "Testing MAP_SHARED mmap write visible to pread after cache-miss open" \
+        "mmap_test.py" --dir "$TEST_DIR"
+}
+
+# Test 18: Pwrite visibility test
+test_pwrite_visibility() {
+    CURRENT_TEST_GROUP="Test 18: Pwrite Visibility"
+    print_header "$CURRENT_TEST_GROUP"
+    run_python_script_test "Testing file size and content visibility after pwrite" "visibility_test.py" --dir "$TEST_DIR"
 }
 
 # Print final report
@@ -1438,8 +1441,9 @@ main() {
     test_delayed_delete
     test_python_high_frequency_write
     test_fuse_reload
-    test_pwrite_visibility
     test_git_clone
+    test_mmap
+    test_pwrite_visibility
 
     print_info "All test functions completed"
 

--- a/build/tests/scripts/mmap_test.py
+++ b/build/tests/scripts/mmap_test.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+#  // Copyright 2025 OPPO.
+#  //
+#  // Licensed under the Apache License, Version 2.0 (the "License");
+#  // you may not use this file except in compliance with the License.
+#  // You may obtain a copy of the License at
+#  //
+#  //     http://www.apache.org/licenses/LICENSE-2.0
+#  //
+#  // Unless required by applicable law or agreed to in writing, software
+#  // distributed under the License is distributed on an "AS IS" BASIS,
+#  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  // See the License for the specific language governing permissions and
+#  // limitations under the License.
+
+"""
+Regression test for Curvine FUSE mmap/read coherence (issue #850).
+
+Exercises the open() cache-miss path (keep_cache == false) where the daemon
+must not force DIRECT_IO, then verifies MAP_SHARED mmap writes are immediately
+visible to pread() on the same fd and persist after close/reopen.
+
+Usage:
+    python3 mmap_test.py --dir /curvine-fuse/fuse-test
+    python3 mmap_test.py --dir /curvine-fuse/fuse-test --stress
+"""
+
+from __future__ import annotations
+
+import argparse
+import mmap
+import multiprocessing as mp
+import os
+import sys
+
+DEFAULT_DIR = "/curvine-fuse/fuse-test"
+TEST_FILE = "test-mmap-file"
+PAGE = 4096
+FILE_SIZE = PAGE * 2
+MARKER = b"M" * PAGE
+STRESS_SIZE = 1 << 20
+STRESS_WORKERS = 4
+STRESS_ROUNDS = 100
+
+
+def setup_file(file_path: str, size: int) -> None:
+    os.makedirs(os.path.dirname(file_path), exist_ok=True)
+    fd = os.open(file_path, os.O_RDWR | os.O_CREAT | os.O_TRUNC, 0o644)
+    try:
+        os.ftruncate(fd, size)
+        zero = bytes(PAGE)
+        for off in range(0, size, PAGE):
+            os.pwrite(fd, zero, off)
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def force_cache_miss(file_path: str) -> None:
+    """Warm daemon metadata cache, then change backend metadata before reopen."""
+    fd = os.open(file_path, os.O_RDONLY)
+    try:
+        os.pread(fd, 1, 0)
+    finally:
+        os.close(fd)
+
+    fd = os.open(file_path, os.O_RDWR)
+    try:
+        end = os.fstat(fd).st_size
+        os.pwrite(fd, b"\x01", end)
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def test_mmap_pread_coherence(file_path: str) -> int:
+    setup_file(file_path, FILE_SIZE)
+    force_cache_miss(file_path)
+
+    fd = os.open(file_path, os.O_RDWR)
+    try:
+        mm = mmap.mmap(fd, PAGE, access=mmap.ACCESS_WRITE)
+        try:
+            mm.seek(0)
+            mm.write(MARKER)
+            # Do not msync/flush — POSIX requires pread to see mmap writes.
+
+            rbuf = os.pread(fd, PAGE, 0)
+            if rbuf != MARKER:
+                print(
+                    "FAIL: mmap write not visible to pread on same fd "
+                    f"(expected {MARKER[:8]!r}..., got {rbuf[:8]!r}...)",
+                    file=sys.stderr,
+                )
+                return 1
+            print("PASS: mmap write visible to pread on same fd (cache-miss open)")
+        finally:
+            mm.close()
+    finally:
+        os.close(fd)
+
+    fd = os.open(file_path, os.O_RDONLY)
+    try:
+        rbuf = os.pread(fd, PAGE, 0)
+        if rbuf != MARKER:
+            print(
+                "FAIL: mmap write not persisted after close/reopen "
+                f"(expected {MARKER[:8]!r}..., got {rbuf[:8]!r}...)",
+                file=sys.stderr,
+            )
+            return 1
+        print("PASS: mmap write persisted after close/reopen")
+    finally:
+        os.close(fd)
+
+    return 0
+
+
+def _stress_worker(file_path: str, worker_id: int, rounds: int) -> None:
+    fd = os.open(file_path, os.O_RDWR)
+    try:
+        mm = mmap.mmap(fd, STRESS_SIZE, access=mmap.ACCESS_WRITE)
+        try:
+            marker = ord("A") + worker_id
+            block = bytes([marker]) * PAGE
+            region = STRESS_SIZE // STRESS_WORKERS
+
+            for r in range(rounds):
+                off = (worker_id * region) + ((r * PAGE) % region)
+                mm.seek(off)
+                mm.write(block)
+
+                rbuf = os.pread(fd, PAGE, off)
+                if len(rbuf) != PAGE:
+                    print(
+                        f"worker={worker_id} round={r} off={off} pread short n={len(rbuf)}",
+                        file=sys.stderr,
+                    )
+                    sys.exit(2)
+
+                for i, b in enumerate(rbuf):
+                    if b != marker:
+                        print(
+                            f"worker={worker_id} round={r} off={off} byte {i}: "
+                            f"mmap-wrote='{chr(marker)}' pread-got=0x{b:02x}",
+                            file=sys.stderr,
+                        )
+                        sys.exit(2)
+        finally:
+            mm.close()
+    finally:
+        os.close(fd)
+
+
+def test_mmap_pread_stress(file_path: str, workers: int, rounds: int) -> int:
+    setup_file(file_path, STRESS_SIZE)
+    force_cache_miss(file_path)
+
+    procs: list[mp.Process] = []
+    for w in range(workers):
+        p = mp.Process(target=_stress_worker, args=(file_path, w, rounds))
+        p.start()
+        procs.append(p)
+
+    fail = 0
+    for p in procs:
+        p.join()
+        if p.exitcode != 0:
+            print(f"worker exit status={p.exitcode}", file=sys.stderr)
+            fail += 1
+
+    if fail == 0:
+        print(f"PASS: {workers} workers x {rounds} rounds mmap/pread stress test")
+        return 0
+
+    print(
+        f"FAIL: {fail}/{workers} workers reported mmap/read inconsistency",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Regression test for Curvine FUSE mmap/read coherence (#850)",
+    )
+    parser.add_argument("--dir", default=DEFAULT_DIR, help="Directory for test files")
+    parser.add_argument(
+        "--stress",
+        action="store_true",
+        help="Run concurrent mmap+pread stress test (issue #850 reproducer)",
+    )
+    parser.add_argument("--workers", type=int, default=STRESS_WORKERS)
+    parser.add_argument("--rounds", type=int, default=STRESS_ROUNDS)
+    args = parser.parse_args()
+
+    file_path = os.path.join(os.path.abspath(args.dir), TEST_FILE)
+
+    try:
+        os.unlink(file_path)
+    except FileNotFoundError:
+        pass
+
+    if args.stress:
+        rc = test_mmap_pread_stress(file_path, args.workers, args.rounds)
+    else:
+        rc = test_mmap_pread_coherence(file_path)
+
+    try:
+        os.unlink(file_path)
+    except FileNotFoundError:
+        pass
+
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/curvine-common/src/conf/fuse_conf.rs
+++ b/curvine-common/src/conf/fuse_conf.rs
@@ -132,6 +132,13 @@ pub struct FuseConf {
 
     pub cache_readdir: bool,
 
+    /// When metadata indicates a cache miss on open, use direct I/O instead of
+    /// dropping the kernel page cache. Default false preserves mmap/read coherence
+    /// (#850); set true to restore the pre-fix behavior for strict remote-read
+    /// freshness (log tailers, multi-writer pipelines). May break MAP_SHARED ↔
+    /// pread coherence when enabled.
+    pub direct_io_on_cache_miss: bool,
+
     pub non_seekable: bool,
 
     pub check_permission: bool,
@@ -309,6 +316,7 @@ impl Default for FuseConf {
             direct_io: false,
             write_back_cache: false,
             cache_readdir: false,
+            direct_io_on_cache_miss: false,
             non_seekable: false,
             check_permission: true,
 

--- a/curvine-fuse/src/bin/curvine-fuse.rs
+++ b/curvine-fuse/src/bin/curvine-fuse.rs
@@ -126,6 +126,12 @@ pub struct FuseArgs {
     #[arg(long, help = "Cache readdir results (optional)")]
     pub cache_readdir: Option<bool>,
 
+    #[arg(
+        long,
+        help = "Use direct I/O on open when local metadata indicates a cache miss (optional, default: false)"
+    )]
+    pub direct_io_on_cache_miss: Option<bool>,
+
     // Timeout settings
     #[arg(long, help = "Entry timeout in seconds (optional)")]
     pub entry_timeout: Option<f64>,
@@ -256,6 +262,10 @@ impl FuseArgs {
 
         if let Some(cache_readdir) = self.cache_readdir {
             conf.fuse.cache_readdir = cache_readdir;
+        }
+
+        if let Some(direct_io_on_cache_miss) = self.direct_io_on_cache_miss {
+            conf.fuse.direct_io_on_cache_miss = direct_io_on_cache_miss;
         }
 
         if let Some(entry_timeout) = self.entry_timeout {

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -1124,9 +1124,20 @@ impl fs::FileSystem for CurvineFileSystem {
                 .should_keep_cache(op.header.nodeid, handle.status());
             if keep_cache {
                 open_flags |= FUSE_FOPEN_KEEP_CACHE;
-            } else {
+            } else if self.conf.direct_io_on_cache_miss {
                 open_flags |= FUSE_FOPEN_DIRECT_IO;
+            } else {
+                warn!(
+                    "open ino={}: metadata cache miss (mtime/len changed), likely updated by \
+                     another client or concurrent writer; omitting KEEP_CACHE so the kernel \
+                     drops stale pages",
+                    op.header.nodeid
+                );
             }
+            // Do not send FUSE_NOTIFY_INVAL_INODE here: synchronous invalidation
+            // during open can deadlock when the kernel holds page locks on this inode.
+            // Remote updates may still appear stale until attr cache expires (default 1s);
+            // use attr_ttl=0, direct_io, or direct_io_on_cache_miss for stronger consistency.
         }
 
         let entry = fuse_open_out {


### PR DESCRIPTION
## Summary

Fixes [#850](https://github.com/CurvineIO/curvine/issues/850): `MAP_SHARED` mmap writes were not consistently visible to subsequent `pread()` / `read()` on the same file.

The root cause was in the FUSE `open` handler. When local metadata indicated the file had changed (`keep_cache == false`), the daemon responded with `FUSE_FOPEN_DIRECT_IO`. That forced the buffered I/O path to bypass the kernel page cache, while `MAP_SHARED` mmap writes still updated cached pages. The two paths were no longer unified, violating the POSIX coherence contract between mmap and read.

This PR removes the `FUSE_FOPEN_DIRECT_IO` fallback on cache miss. When the cache should be invalidated, we simply omit `FUSE_FOPEN_KEEP_CACHE` and let the kernel discard stale pages on open. We also document why synchronous `FUSE_NOTIFY_INVAL_INODE` must not be sent from the open path (kernel deadlock risk).

## Changes

- **`curvine-fuse/src/fs/curvine_file_system.rs`**
  - Stop setting `FUSE_FOPEN_DIRECT_IO` when `keep_cache` is false.
  - Rely on omitting `FUSE_FOPEN_KEEP_CACHE` for kernel-side page cache invalidation.
  - Add comments explaining deadlock and consistency trade-offs.

- **`build/tests/scripts/mmap_test.py`**
  - Add a basic mmap write + read-back regression test (mmap and file handle).

- **`build/tests/fuse-test.sh`**
  - Wire mmap test into the FUSE test suite (Test 17).
  - Introduce `get_python_cmd()` and `run_python_script_test()` to deduplicate Python test execution.

## Root Cause

| Path | Before (cache miss) | After |
|------|---------------------|-------|
| `mmap(MAP_SHARED)` write | Kernel page cache | Kernel page cache |
| `pread()` / `read()` | Direct I/O (no page cache) | Buffered I/O (page cache) |

Because mmap and buffered reads no longer shared the same cache layer, bytes written via mmap could appear as stale zeros when read back via `pread`.

## Test Plan

- [ ] Run the issue #850 reproducer on a Curvine FUSE mount:
  ```bash
  gcc -O0 -Wall repro_mmap_pread.c -o /tmp/repro_mmap_pread
  for i in 1 2 3 4 5; do /tmp/repro_mmap_pread; done