### PR TITLE
fix(fuse): bump writer version and refresh reader when versions differ

### DIFF
--- a/build/tests/scripts/visibility_test.py
+++ b/build/tests/scripts/visibility_test.py
@@ -2,11 +2,17 @@
 # -*- coding: utf-8 -*-
 
 """
-Visibility test for file size and content after pwrite.
+Visibility tests for pwrite/pread behavior on FUSE mounts.
+
+Includes:
+1) basic file size/content visibility after pwrite
+2) pread visibility strategies after extending pwrite (ported from repro_pread_then_pwrite.py)
 
 Usage:
-    python3 visibility_test.py --dir /curvine-fuse
+    python3 visibility_test.py --dir /curvine-fuse --mode all
 """
+
+from __future__ import annotations
 
 import argparse
 import os
@@ -14,17 +20,26 @@ import sys
 
 WRITE_SIZE = 1024
 DEFAULT_DIR = "/curvine-fuse"
-TEST_FILE = "visibility-test"
+BASIC_TEST_FILE = "visibility-test"
+
+PP_TEST_FILE = "pp.bin"
+# Values from issue #852 repro (repro_pc_boundary.c / repro_pread_then_pwrite.c):
+# first write establishes reader at BUF1_LEN; extending pwrite starts at OFF2
+# with a sparse hole [BUF1_LEN, OFF2).
+BUF1_LEN = 1167
+OFF2 = 1425
+BUF2_LEN = 3882
+EXPECT = OFF2 + BUF2_LEN  # 5307
+
+_EXPECTED_PREAD = (
+    b"A" * BUF1_LEN
+    + b"\x00" * (OFF2 - BUF1_LEN)
+    + b"B" * BUF2_LEN
+)
 
 
-def main() -> int:
-    parser = argparse.ArgumentParser(
-        description="Visibility test for file size and content after pwrite",
-    )
-    parser.add_argument("--dir", default=DEFAULT_DIR, help="Directory for test files")
-    args = parser.parse_args()
-
-    path = os.path.join(os.path.abspath(args.dir), TEST_FILE)
+def run_basic_visibility(base_dir: str) -> int:
+    path = os.path.join(base_dir, BASIC_TEST_FILE)
     data = b"A" * WRITE_SIZE
 
     try:
@@ -39,7 +54,7 @@ def main() -> int:
             return 1
 
         size = os.fstat(fd).st_size
-        print(f"size={size} (expect {WRITE_SIZE})")
+        print(f"[basic] size={size} (expect {WRITE_SIZE})")
         if size != WRITE_SIZE:
             print("ERROR: size mismatch", file=sys.stderr)
             return 1
@@ -49,10 +64,127 @@ def main() -> int:
             print("ERROR: read content mismatch", file=sys.stderr)
             return 1
 
-        print("PASS")
+        print("[basic] PASS")
         return 0
     finally:
         os.close(fd)
+
+
+def run_pread_strategy(
+        name: str,
+        file_path: str,
+        *,
+        do_fsync: bool,
+        do_lseek: bool,
+        do_reopen: bool,
+        do_fstat: bool,
+) -> int:
+    try:
+        os.unlink(file_path)
+    except FileNotFoundError:
+        pass
+
+    b1 = b"A" * BUF1_LEN
+    b2 = b"B" * BUF2_LEN
+
+    fd = os.open(file_path, os.O_RDWR | os.O_CREAT, 0o644)
+    try:
+        os.pwrite(fd, b1, 0)
+        os.pread(fd, BUF1_LEN, 0)  # establish page cache
+        os.pwrite(fd, b2, OFF2)  # extending pwrite
+
+        if do_fsync:
+            os.fsync(fd)
+        if do_lseek:
+            os.lseek(fd, 0, os.SEEK_END)
+        if do_fstat:
+            os.fstat(fd)
+        if do_reopen:
+            os.close(fd)
+            fd = -1
+            fd = os.open(file_path, os.O_RDWR)
+
+        data = os.pread(fd, EXPECT, 0)
+        ok = len(data) == EXPECT and data == _EXPECTED_PREAD
+        print(
+            f"[pread] {name}: pread={len(data)} (expect {EXPECT}) "
+            f"{'OK' if ok else 'FAIL'}"
+        )
+        if not ok and len(data) == EXPECT:
+            print("[pread] content mismatch (stale or wrong bytes)", file=sys.stderr)
+        return 0 if ok else 1
+    finally:
+        if fd >= 0:
+            os.close(fd)
+        try:
+            os.unlink(file_path)
+        except FileNotFoundError:
+            pass
+
+
+def run_pread_visibility(base_dir: str) -> int:
+    file_path = os.path.join(base_dir, PP_TEST_FILE)
+    cases = [
+        (
+            "A. baseline (no flush)",
+            dict(do_fsync=False, do_lseek=False, do_reopen=False, do_fstat=False),
+        ),
+        (
+            "B. fsync between",
+            dict(do_fsync=True, do_lseek=False, do_reopen=False, do_fstat=False),
+        ),
+        (
+            "C. lseek SEEK_END between",
+            dict(do_fsync=False, do_lseek=True, do_reopen=False, do_fstat=False),
+        ),
+        (
+            "D. close+reopen between",
+            dict(do_fsync=False, do_lseek=False, do_reopen=True, do_fstat=False),
+        ),
+        (
+            "E. fstat between",
+            dict(do_fsync=False, do_lseek=False, do_reopen=False, do_fstat=True),
+        ),
+        (
+            "F. fsync + lseek + fstat",
+            dict(do_fsync=True, do_lseek=True, do_reopen=False, do_fstat=True),
+        ),
+    ]
+
+    fail = 0
+    for name, kwargs in cases:
+        fail += run_pread_strategy(name, file_path, **kwargs)
+    passed = len(cases) - fail
+    if fail == 0:
+        print(f"[pread] {passed}/{len(cases)} PASS")
+    else:
+        print(f"[pread] {fail}/{len(cases)} FAIL")
+    return 1 if fail else 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Visibility tests for pwrite/pread on FUSE mounts",
+    )
+    parser.add_argument("--dir", default=DEFAULT_DIR, help="Directory for test files")
+    parser.add_argument(
+        "--mode",
+        choices=["basic", "pread", "all"],
+        default="all",
+        help="Select which visibility suite to run",
+    )
+    args = parser.parse_args()
+
+    base_dir = os.path.abspath(args.dir)
+    os.makedirs(base_dir, exist_ok=True)
+
+    fail = 0
+    if args.mode in ("basic", "all"):
+        fail += run_basic_visibility(base_dir)
+    if args.mode in ("pread", "all"):
+        fail += run_pread_visibility(base_dir)
+
+    return 1 if fail else 0
 
 
 if __name__ == "__main__":

--- a/curvine-fuse/src/fs/fuse_writer.rs
+++ b/curvine-fuse/src/fs/fuse_writer.rs
@@ -24,7 +24,7 @@ use curvine_common::FsResult;
 use log::error;
 use orpc::runtime::{RpcRuntime, Runtime};
 use orpc::sync::channel::{AsyncChannel, AsyncReceiver, AsyncSender, CallChannel, CallSender};
-use orpc::sync::ErrorMonitor;
+use orpc::sync::{AtomicCounter, ErrorMonitor};
 use orpc::sys::DataSlice;
 use std::sync::{Arc, Mutex};
 use tokio_util::bytes::Bytes;
@@ -43,6 +43,7 @@ pub struct FuseWriter {
     status: FileStatus,
     is_ufs: bool,
     len: Arc<Mutex<i64>>,
+    write_ver: AtomicCounter,
 }
 
 impl FuseWriter {
@@ -55,6 +56,7 @@ impl FuseWriter {
         let status = writer.status().clone();
         let monitor = err_monitor.clone();
         let len = Arc::new(Mutex::new(status.len));
+        let write_ver = AtomicCounter::new(0);
 
         let len1 = len.clone();
         rt.spawn(async move {
@@ -76,7 +78,12 @@ impl FuseWriter {
             status,
             is_ufs,
             len,
+            write_ver,
         }
+    }
+
+    pub fn write_ver(&self) -> u64 {
+        self.write_ver.get()
     }
 
     pub fn path(&self) -> &Path {
@@ -95,6 +102,7 @@ impl FuseWriter {
     }
 
     pub async fn write(&mut self, op: Write<'_>, reply: FuseResponse) -> FsResult<()> {
+        self.write_ver.incr();
         self.sender
             .send(WriteTask::Write(op.arg.offset as i64, op.data, reply))
             .await
@@ -128,6 +136,7 @@ impl FuseWriter {
             tx.receive().await?;
             Ok::<(), FsError>(())
         };
+        self.write_ver.incr();
         fun.await.map_err(|e| self.check_error(e))
     }
 

--- a/curvine-fuse/src/fs/state/file_handle.rs
+++ b/curvine-fuse/src/fs/state/file_handle.rs
@@ -20,6 +20,7 @@ use crate::{err_fuse, FuseError, FuseResult};
 use curvine_common::fs::{Path, StateReader, StateWriter};
 use curvine_common::state::{CreateFileOptsBuilder, FileStatus, LockFlags, OpenFlags};
 use orpc::err_box;
+use orpc::sync::AtomicCounter;
 use orpc::sys::RawPtr;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -40,6 +41,8 @@ pub struct FileHandle {
     pub status: FileStatus,
 
     fh_locks: std::sync::Mutex<HandleLock>,
+
+    read_ver: AtomicCounter,
 }
 
 impl FileHandle {
@@ -57,6 +60,7 @@ impl FileHandle {
             writer,
             status,
             fh_locks: std::sync::Mutex::new(HandleLock::default()),
+            read_ver: AtomicCounter::new(0),
         }
     }
 
@@ -71,16 +75,18 @@ impl FileHandle {
             None => return err_fuse!(libc::EIO),
         };
 
-        if op.arg.offset as i64 >= reader.len() {
-            if let Some(writer) = state.find_writer(&op.header.nodeid) {
-                {
-                    writer.lock().await.flush(None).await?;
-                }
-                // TODO: Optimize by adding refresh interface to refresh block list
+        if let Some(lock) = state.find_writer(&self.ino) {
+            let mut writer = lock.lock().await;
+            let write_ver = writer.write_ver();
+            if self.read_ver.get() != write_ver {
+                writer.flush(None).await?;
+                drop(writer);
+
                 let path = reader.path().clone();
-                reader.as_mut().complete(None).await?;
                 let new_reader = state.new_reader(&path).await?;
                 reader.replace(new_reader);
+
+                self.read_ver.set(write_ver);
             }
         }
 
@@ -214,6 +220,7 @@ impl FileHandle {
             writer,
             status,
             fh_locks: std::sync::Mutex::new(locks),
+            read_ver: AtomicCounter::new(0),
         };
         Ok(handle)
     }


### PR DESCRIPTION
## Summary

Fixes [#852](https://github.com/CurvineIO/curvine/issues/852): after `pread()` then an extending `pwrite()` on the same fd, metadata (`fstat`, `lseek`) can show the new size while `pread()` still returns data bounded by the old length until the reader is refreshed (e.g. via `fsync` or reopen).

## Approach

1. **Writer version** — `FuseWriter` maintains `write_ver`, incremented on each `write()` and `resize()`.
2. **Version check on read** — `FileHandle` keeps `read_ver` (last write generation seen for this handle). Before serving a read, compare `read_ver` with the writer's `write_ver`.
3. **Refresh when stale** — If they differ, flush the writer, replace the `FuseReader`, and set `read_ver = write_ver`, then perform the read so data matches the current file state.

The previous logic only refreshed when the read offset was past `reader.len()`, so whole-file or low-offset reads after an extending write never triggered a refresh. Version comparison covers any write since the last read refresh, regardless of read offset.

## Changes

| Area | Change |
|------|--------|
| `fuse_writer.rs` | `write_ver` + `write_ver()`; bump on write/resize |
| `file_handle.rs` | `read_ver`; on read, compare versions → flush + new reader if mismatch |
| `visibility_test.py` | Add `--mode pread\|all` suite (six strategies from issue repro) |

## Test plan

- [ ] `python3 build/tests/scripts/visibility_test.py --dir <mount> --mode all` → `[basic] PASS`, `[pread] 0/6 FAIL`
- [ ] Issue repro `repro_pc_boundary.c`: all five checks pass without `fsync`
- [ ] Regression: normal sequential read/write on same fd

## Related

Closes #852