### PR TITLE
build(deps): bump num-bigint-dig to 0.8.6 for rustc future compat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2042,7 +2042,6 @@ dependencies = [
  "axum",
  "bindgen",
  "bitflags 2.10.0",
- "bytes",
  "clap",
  "curvine-client",
  "curvine-common",
@@ -5805,11 +5804,10 @@ dependencies = [
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
 dependencies = [
- "byteorder",
  "lazy_static",
  "libm",
  "num-integer",


### PR DESCRIPTION
## Problem
Cargo builds emit a future-incompat warning for `num-bigint-dig v0.8.4` (private `vec!` macro usage). This dependency is pulled in transitively via `opendal -> reqsign -> rsa` and will become a hard error in a future Rust release.

## Design
Bump the locked transitive dependency to `num-bigint-dig v0.8.6`, which fixes the macro visibility issue while staying compatible with `rsa v0.9.8`.

## Key Changes
- Update `Cargo.lock` to pin `num-bigint-dig` from `0.8.4` to `0.8.6`
