### PR TITLE
feat(csi): add fuse_cli passthrough helpers skeleton

### DIFF
--- a/curvine-csi/pkg/csi/fuse_cli.go
+++ b/curvine-csi/pkg/csi/fuse_cli.go
@@ -1,0 +1,162 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package csi
+
+import (
+	"fmt"
+	"sort"
+)
+
+const fuseKubeletPluginBase = "/var/lib/kubelet/plugins/kubernetes.io/csi/curvine"
+
+// reservedVolumeParameterKeys are handled explicitly by the CSI driver and must not
+// be forwarded as generic curvine-fuse CLI flags.
+var reservedVolumeParameterKeys = map[string]struct{}{
+	"master-addrs":  {},
+	"fs-path":       {},
+	"path-type":     {},
+	"curvine-path":  {},
+	"author":        {},
+	"volume-handle": {},
+}
+
+// rejectedVolumeParameterKeys must not appear in StorageClass / PV parameters.
+var rejectedVolumeParameterKeys = map[string]struct{}{
+	"mnt-path": {},
+}
+
+// volumeParameterDenylist blocks keys that are CSI-internal or not valid fuse flags.
+var volumeParameterDenylist = map[string]struct{}{
+	"csi.storage.k8s.io/ephemeral": {},
+	"csi.storage.k8s.io/pod.name":  {},
+	"csi.storage.k8s.io/pod.namespace": {},
+	"csi.storage.k8s.io/pod.uid":   {},
+	"csi.storage.k8s.io/serviceAccount.name": {},
+}
+
+// IsReservedVolumeParameterKey reports whether the key is owned by the CSI driver.
+func IsReservedVolumeParameterKey(key string) bool {
+	_, ok := reservedVolumeParameterKeys[key]
+	return ok
+}
+
+// IsRejectedVolumeParameterKey reports whether the key must be rejected at provision time.
+func IsRejectedVolumeParameterKey(key string) bool {
+	_, ok := rejectedVolumeParameterKeys[key]
+	return ok
+}
+
+// IsDeniedVolumeParameterKey reports whether the key must never be passed to curvine-fuse.
+func IsDeniedVolumeParameterKey(key string) bool {
+	_, ok := volumeParameterDenylist[key]
+	return ok
+}
+
+// MergeVolumeParameters merges volumeContext and publishContext with volumeContext winning.
+func MergeVolumeParameters(volumeContext, publishContext map[string]string) map[string]string {
+	merged := make(map[string]string)
+	for k, v := range publishContext {
+		if v != "" {
+			merged[k] = v
+		}
+	}
+	for k, v := range volumeContext {
+		if v != "" {
+			merged[k] = v
+		}
+	}
+	return merged
+}
+
+// CollectPassthroughParams returns StorageClass/PV keys that should be forwarded to
+// curvine-fuse as --key value pairs (sorted by key).
+func CollectPassthroughParams(volumeContext, publishContext map[string]string) map[string]string {
+	merged := MergeVolumeParameters(volumeContext, publishContext)
+	out := make(map[string]string)
+	for key, value := range merged {
+		if value == "" {
+			continue
+		}
+		if IsReservedVolumeParameterKey(key) || IsRejectedVolumeParameterKey(key) || IsDeniedVolumeParameterKey(key) {
+			continue
+		}
+		out[key] = value
+	}
+	return out
+}
+
+// ComputeFuseMntPath returns the host path where curvine-fuse mounts for a mount key.
+func ComputeFuseMntPath(mountKey string) string {
+	return fmt.Sprintf("%s/%s/fuse-mount", fuseKubeletPluginBase, mountKey)
+}
+
+// FuseExecArgsInput describes inputs for building a curvine-fuse argv slice.
+type FuseExecArgsInput struct {
+	// Subcommand is optional (e.g. "validate-config"). Empty means default mount.
+	Subcommand  string
+	ConfPath    string
+	MasterAddrs string
+	FSPath      string
+	MountKey    string
+	Passthrough map[string]string
+}
+
+// BuildFuseExecArgs builds argv for curvine-fuse mount or validate-config.
+// Not wired into node/fuse_manager until a later commit.
+func BuildFuseExecArgs(in FuseExecArgsInput) []string {
+	args := make([]string, 0, 8+len(in.Passthrough)*2)
+	if in.Subcommand != "" {
+		args = append(args, in.Subcommand)
+	}
+	if in.ConfPath != "" {
+		args = append(args, "--conf", in.ConfPath)
+	}
+	if in.MasterAddrs != "" {
+		args = append(args, "--master-addrs", in.MasterAddrs)
+	}
+	if in.FSPath != "" {
+		args = append(args, "--fs-path", in.FSPath)
+	}
+	if in.MountKey != "" {
+		args = append(args, "--mnt-path", ComputeFuseMntPath(in.MountKey))
+	}
+	args = appendPassthroughArgs(args, in.Passthrough)
+	return args
+}
+
+func appendPassthroughArgs(args []string, passthrough map[string]string) []string {
+	if len(passthrough) == 0 {
+		return args
+	}
+	keys := make([]string, 0, len(passthrough))
+	for key := range passthrough {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		flag := passthroughCLIKey(key)
+		args = append(args, flag, passthrough[key])
+	}
+	return args
+}
+
+// passthroughCLIKey maps a volume parameter key to a curvine-fuse CLI flag name.
+func passthroughCLIKey(key string) string {
+	// client.* keys use the client. prefix on the CLI (e.g. client.block-size).
+	if len(key) > 7 && key[:7] == "client." {
+		return "--" + key
+	}
+	return "--" + key
+}

--- a/curvine-csi/pkg/csi/fuse_cli.go
+++ b/curvine-csi/pkg/csi/fuse_cli.go
@@ -33,6 +33,8 @@ var reservedVolumeParameterKeys = map[string]struct{}{
 }
 
 // rejectedVolumeParameterKeys must not appear in StorageClass / PV parameters.
+// Enforcement in validator/node wiring is deferred to C14; until then validator.go may
+// still accept a legacy user-provided mnt-path.
 var rejectedVolumeParameterKeys = map[string]struct{}{
 	"mnt-path": {},
 }
@@ -81,7 +83,8 @@ func MergeVolumeParameters(volumeContext, publishContext map[string]string) map[
 }
 
 // CollectPassthroughParams returns StorageClass/PV keys that should be forwarded to
-// curvine-fuse as --key value pairs (sorted by key).
+// curvine-fuse as --key value pairs. The returned map is unordered; deterministic argv
+// ordering is applied in appendPassthroughArgs when building CLI flags.
 func CollectPassthroughParams(volumeContext, publishContext map[string]string) map[string]string {
 	merged := MergeVolumeParameters(volumeContext, publishContext)
 	out := make(map[string]string)
@@ -154,9 +157,5 @@ func appendPassthroughArgs(args []string, passthrough map[string]string) []strin
 
 // passthroughCLIKey maps a volume parameter key to a curvine-fuse CLI flag name.
 func passthroughCLIKey(key string) string {
-	// client.* keys use the client. prefix on the CLI (e.g. client.block-size).
-	if len(key) > 7 && key[:7] == "client." {
-		return "--" + key
-	}
 	return "--" + key
 }

--- a/curvine-csi/pkg/csi/fuse_cli_test.go
+++ b/curvine-csi/pkg/csi/fuse_cli_test.go
@@ -1,0 +1,90 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package csi
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestComputeFuseMntPath(t *testing.T) {
+	mountKey := "abc123"
+	want := "/var/lib/kubelet/plugins/kubernetes.io/csi/curvine/abc123/fuse-mount"
+	if got := ComputeFuseMntPath(mountKey); got != want {
+		t.Fatalf("ComputeFuseMntPath() = %q, want %q", got, want)
+	}
+}
+
+func TestCollectPassthroughParams(t *testing.T) {
+	volumeContext := map[string]string{
+		"master-addrs":      "m1:8995",
+		"io-threads":        "4",
+		"client.block-size": "65536",
+		"mnt-path":          "/should-not-appear",
+	}
+	publishContext := map[string]string{
+		"entry-timeout": "1.0",
+		"io-threads":      "8",
+	}
+
+	got := CollectPassthroughParams(volumeContext, publishContext)
+	want := map[string]string{
+		"io-threads":        "8",
+		"entry-timeout":     "1.0",
+		"client.block-size": "65536",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("CollectPassthroughParams() = %#v, want %#v", got, want)
+	}
+}
+
+func TestBuildFuseExecArgs(t *testing.T) {
+	in := FuseExecArgsInput{
+		Subcommand:  "validate-config",
+		ConfPath:    "/etc/curvine/cluster.toml",
+		MasterAddrs: "m1:8995",
+		FSPath:      "/data",
+		MountKey:    "mk1",
+		Passthrough: map[string]string{
+			"entry-timeout":     "1.0",
+			"client.block-size": "65536",
+			"io-threads":        "4",
+		},
+	}
+
+	got := BuildFuseExecArgs(in)
+	want := []string{
+		"validate-config",
+		"--conf", "/etc/curvine/cluster.toml",
+		"--master-addrs", "m1:8995",
+		"--fs-path", "/data",
+		"--mnt-path", ComputeFuseMntPath("mk1"),
+		"--client.block-size", "65536",
+		"--entry-timeout", "1.0",
+		"--io-threads", "4",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("BuildFuseExecArgs() = %#v, want %#v", got, want)
+	}
+}
+
+func TestIsRejectedVolumeParameterKey(t *testing.T) {
+	if !IsRejectedVolumeParameterKey("mnt-path") {
+		t.Fatal("expected mnt-path to be rejected")
+	}
+	if IsRejectedVolumeParameterKey("io-threads") {
+		t.Fatal("did not expect io-threads to be rejected")
+	}
+}

--- a/curvine-csi/pkg/csi/fuse_cli_test.go
+++ b/curvine-csi/pkg/csi/fuse_cli_test.go
@@ -41,7 +41,7 @@ func TestCollectPassthroughParams(t *testing.T) {
 
 	got := CollectPassthroughParams(volumeContext, publishContext)
 	want := map[string]string{
-		"io-threads":        "8",
+		"io-threads":        "4",
 		"entry-timeout":     "1.0",
 		"client.block-size": "65536",
 	}


### PR DESCRIPTION
## Problem

CSI maintains fuse parameters via `supportedFuseParams`, which drifts from
`curvine-fuse` CLI flags. The target model is reserved keys + denylist + passthrough
of all other StorageClass/PV keys as `--key value`.

## Design

- Add `fuse_cli.go` as the single CSI argv builder (skeleton only; not wired yet).
- `reservedVolumeParameterKeys`: CSI-owned keys (`master-addrs`, `fs-path`, etc.).
- `rejectedVolumeParameterKeys`: reject `mnt-path` on SC/PV; compute internally via
  `ComputeFuseMntPath`.
- `CollectPassthroughParams`: merge volume/publish context, filter reserved/rejected/denylist.
- `BuildFuseExecArgs`: build mount or `validate-config` argv; map `client.*` to `--client.*`.
- Sort passthrough keys for deterministic argv (tests and mount-key stability).

## Key Changes

- Add `curvine-csi/pkg/csi/fuse_cli.go`.
- Add `curvine-csi/pkg/csi/fuse_cli_test.go`.
- Do **not** change `node.go`, `fuse_manager.go`, or `validator.go` (wiring is C13+).

## Expected Outcome

- `go test ./pkg/csi/ -run 'ComputeFuse|CollectPassthrough|BuildFuse|IsRejected'` passes.
- Runtime CSI behavior unchanged (helpers are not called yet).
- Passthrough rules can be reviewed before replacing the whitelist.

## Test Plan

- [ ] `go test ./pkg/csi/ -run 'ComputeFuse|CollectPassthrough|BuildFuse|IsRejected' -count=1`
- [ ] Confirm node/fuse_manager still use legacy whitelist logic
