### PR TITLE
fix(fuse): use FUSE_BUFFER_HEADER_SIZE for buffer size calculation

### DIFF
--- a/curvine-fuse/src/fuse_utils.rs
+++ b/curvine-fuse/src/fuse_utils.rs
@@ -116,7 +116,7 @@ impl FuseUtils {
     // In fuse 2, this default size is 132kb (128 + 4)
     pub fn get_fuse_buf_size() -> usize {
         let page_size = sys::get_pagesize().unwrap_or(FUSE_DEFAULT_PAGE_SIZE);
-        FUSE_MAX_MAX_PAGES * page_size + FUSE_IN_HEADER_LEN
+        FUSE_MAX_MAX_PAGES * page_size + FUSE_BUFFER_HEADER_SIZE
     }
 
     fn fuse_dev_ioc_clone() -> u64 {


### PR DESCRIPTION
## Summary

Fix `get_fuse_buf_size()` to use `FUSE_BUFFER_HEADER_SIZE` (4096) instead of `FUSE_IN_HEADER_LEN` (40) when computing the receive buffer size.

## Motivation

The receive buffer size is calculated as:

```
bufsize = FUSE_MAX_MAX_PAGES * page_size + <header_reserve>
```

And `max_write` is derived as:

```
max_write = bufsize - FUSE_BUFFER_HEADER_SIZE
```

Previously, `get_fuse_buf_size()` added `FUSE_IN_HEADER_LEN` (40 bytes) as the header reserve, but `max_write` subtracted `FUSE_BUFFER_HEADER_SIZE` (4096 bytes). This asymmetry resulted in:

- `bufsize` = 256 × 4096 + 40 = 1,048,616
- `max_write` = 1,048,616 − 4096 = **1,044,520** (not page-aligned, not 1 MiB)

## Fix

Use `FUSE_BUFFER_HEADER_SIZE` (4096) consistently in both the buffer allocation and `max_write` derivation:

- `bufsize` = 256 × 4096 + 4096 = 1,052,672
- `max_write` = 1,052,672 − 4096 = **1,048,576 = 1 MiB** ✓

This matches libfuse3 behavior (`fuse_session_new()` uses the same formula).

## Benefits

- **Correct max_write**: yields a clean 1 MiB, page-aligned value
- **Consistent with libfuse3**: same buffer sizing logic as the reference implementation
- **Sufficient header headroom**: a full page (4096) accommodates any opcode header (the largest is ~128 bytes), rather than the tight 40-byte margin before
- **Better splice/zero-copy alignment**: page-aligned boundaries benefit DMA and zero-copy I/O paths

## Test plan

- Verified `max_write` is reported as 1,048,576 in INIT response
- Confirmed no regression in sequential/random write workloads