### PR TITLE
feat(fuse): add mount subcommand via FuseCli (C8)

### DIFF
--- a/curvine-fuse/src/bin/curvine-fuse.rs
+++ b/curvine-fuse/src/bin/curvine-fuse.rs
@@ -13,54 +13,17 @@
 // limitations under the License.
 
 use clap::Parser;
-use curvine_fuse::cli::FuseMountArgs;
-use curvine_fuse::fs::CurvineFileSystem;
-use curvine_fuse::session::FuseSession;
-use curvine_fuse::web_server::WebServer;
-use orpc::common::Logger;
-use orpc::runtime::{AsyncRuntime, RpcRuntime};
-use orpc::CommonResult;
-use std::sync::Arc;
+use curvine_fuse::cli::{run_mount, FuseCli};
+use orpc::{err_box, CommonResult};
 
 // fuse mount.
 // Debugging, after starting the cluster, execute the following naming, mount fuse
 // umount -f /curvine-fuse; cargo run --bin curvine-fuse -- --conf /server/conf/curvine-cluster.toml
 fn main() -> CommonResult<()> {
-    let args = FuseMountArgs::parse();
-    println!("fuse args {:?}", args);
-
-    // Ignore SIGPIPE to prevent unexpected termination when peer closes
-    unsafe {
-        libc::signal(libc::SIGPIPE, libc::SIG_IGN);
+    let cli = FuseCli::parse();
+    if cli.runs_mount() {
+        run_mount(cli.resolve_mount_args())
+    } else {
+        err_box!("unsupported curvine-fuse subcommand")
     }
-
-    let cluster_conf = args.get_conf()?;
-    Logger::init(cluster_conf.fuse.log.clone());
-    cluster_conf.print();
-
-    let rt = Arc::new(AsyncRuntime::new(
-        "curvine-fuse",
-        cluster_conf.fuse.io_threads,
-        cluster_conf.fuse.worker_threads,
-    ));
-
-    let fuse_rt = rt.clone();
-
-    rt.block_on(async move {
-        let fs = CurvineFileSystem::new(cluster_conf, fuse_rt.clone()).unwrap();
-        let conf = fs.conf().clone();
-
-        let node_state = fs.state().clone();
-        let web_port = conf.web_port;
-        fuse_rt.spawn(async move {
-            if let Err(e) = WebServer::start(web_port, node_state).await {
-                log::error!("Failed to start metrics server: {}", e);
-            }
-        });
-
-        let mut session = FuseSession::new(fuse_rt.clone(), fs, conf).await.unwrap();
-        session.run().await
-    })?;
-
-    Ok(())
 }

--- a/curvine-fuse/src/cli/fuse_cli.rs
+++ b/curvine-fuse/src/cli/fuse_cli.rs
@@ -1,0 +1,88 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use clap::{Parser, Subcommand};
+use curvine_common::version;
+
+use crate::cli::mount_args::FuseMountArgs;
+
+/// Top-level curvine-fuse CLI. Mount is the default when no subcommand is given.
+#[derive(Debug, Parser, Clone)]
+#[command(
+    name = "curvine-fuse",
+    version = version::VERSION,
+    subcommand_required = false,
+    args_conflicts_with_subcommands = true
+)]
+pub struct FuseCli {
+    #[command(subcommand)]
+    pub cmd: Option<FuseSubcommand>,
+
+    #[command(flatten)]
+    pub mount: FuseMountArgs,
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum FuseSubcommand {
+    /// Mount the curvine filesystem (also the default when omitted)
+    Mount(FuseMountArgs),
+}
+
+impl FuseCli {
+    /// Returns true when the parsed invocation should run the mount flow.
+    pub fn runs_mount(&self) -> bool {
+        matches!(self.cmd, None | Some(FuseSubcommand::Mount(_)))
+    }
+
+    /// Returns mount args from the subcommand when present, otherwise top-level flags.
+    pub fn resolve_mount_args(&self) -> FuseMountArgs {
+        match &self.cmd {
+            Some(FuseSubcommand::Mount(args)) => args.clone(),
+            None => self.mount.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bare_invocation_preserves_top_level_flags() {
+        let cli = FuseCli::try_parse_from(["curvine-fuse", "--io-threads", "4"]).unwrap();
+        assert!(cli.cmd.is_none());
+        let args = cli.resolve_mount_args();
+        assert_eq!(args.io_threads, Some(4));
+    }
+
+    #[test]
+    fn mount_subcommand_preserves_flags() {
+        let cli = FuseCli::try_parse_from(["curvine-fuse", "mount", "--io-threads", "8"]).unwrap();
+        let args = cli.resolve_mount_args();
+        assert_eq!(args.io_threads, Some(8));
+    }
+
+    #[test]
+    fn mixed_top_level_flags_and_subcommand_is_rejected() {
+        let err =
+            FuseCli::try_parse_from(["curvine-fuse", "--io-threads", "4", "mount"]).unwrap_err();
+        assert!(err.to_string().contains("cannot be used with"));
+    }
+
+    #[test]
+    fn unknown_subcommand_is_rejected() {
+        let err = FuseCli::try_parse_from(["curvine-fuse", "validate-config"]).unwrap_err();
+        assert!(err.to_string().contains("unrecognized subcommand"));
+    }
+}

--- a/curvine-fuse/src/cli/mod.rs
+++ b/curvine-fuse/src/cli/mod.rs
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod fuse_cli;
 mod mount_args;
+mod mount_run;
 
+pub use fuse_cli::{FuseCli, FuseSubcommand};
 pub use mount_args::FuseMountArgs;
+pub use mount_run::run_mount;

--- a/curvine-fuse/src/cli/mount_run.rs
+++ b/curvine-fuse/src/cli/mount_run.rs
@@ -1,0 +1,61 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::cli::FuseMountArgs;
+use crate::fs::CurvineFileSystem;
+use crate::session::FuseSession;
+use crate::web_server::WebServer;
+use orpc::common::Logger;
+use orpc::runtime::{AsyncRuntime, RpcRuntime};
+use orpc::CommonResult;
+use std::sync::Arc;
+
+/// Runs the default mount command using the given CLI arguments.
+pub fn run_mount(args: FuseMountArgs) -> CommonResult<()> {
+    println!("fuse args {:?}", args);
+
+    unsafe {
+        libc::signal(libc::SIGPIPE, libc::SIG_IGN);
+    }
+
+    let cluster_conf = args.get_conf()?;
+    Logger::init(cluster_conf.fuse.log.clone());
+    cluster_conf.print();
+
+    let rt = Arc::new(AsyncRuntime::new(
+        "curvine-fuse",
+        cluster_conf.fuse.io_threads,
+        cluster_conf.fuse.worker_threads,
+    ));
+
+    let fuse_rt = rt.clone();
+
+    rt.block_on(async move {
+        let fs = CurvineFileSystem::new(cluster_conf, fuse_rt.clone()).unwrap();
+        let conf = fs.conf().clone();
+
+        let node_state = fs.state().clone();
+        let web_port = conf.web_port;
+        fuse_rt.spawn(async move {
+            if let Err(e) = WebServer::start(web_port, node_state).await {
+                log::error!("Failed to start metrics server: {}", e);
+            }
+        });
+
+        let mut session = FuseSession::new(fuse_rt.clone(), fs, conf).await.unwrap();
+        session.run().await
+    })?;
+
+    Ok(())
+}


### PR DESCRIPTION
## Problem

C7 landed in #863. Next step is a top-level `FuseCli` entrypoint so C9/C10 can add
more subcommands without growing the binary.

## Design

- Introduce `FuseCli` with optional `mount` subcommand.
- Keep backward compatibility: bare `curvine-fuse --conf ...` still runs mount.
- `Mount(FuseMountArgs)` accepts flags after `mount`; `resolve_mount_args` picks subcommand vs top-level.
- `args_conflicts_with_subcommands = true` rejects mixed top-level flags + subcommand.
- Move mount runtime into `cli::run_mount`.

## Key Changes

- Add `curvine-fuse/src/cli/fuse_cli.rs`, `mount_run.rs`.
- Update `curvine-fuse` binary to parse `FuseCli` and call `run_mount`.
- Add `fuse_cli` unit tests for parsing precedence/validation.

## Review follow-ups (szbr9486)

- Mixed `--flag ... mount` now hard-errors via clap instead of silently dropping flags.
- Unit tests lock bare/subcommand/mixed/unknown-subcommand behavior.

## Base

Rebased onto latest `main`, including merged #863.

## Test Plan

- [x] `cargo check -p curvine-fuse`
- [x] `cargo test -p curvine-fuse fuse_cli`

Refs #865