### PR TITLE
feat(csi): wire fuse_cli passthrough and remove whitelist (C13)

### DIFF
--- a/curvine-csi/pkg/csi/fuse_cli.go
+++ b/curvine-csi/pkg/csi/fuse_cli.go
@@ -113,11 +113,12 @@ type FuseExecArgsInput struct {
 	MasterAddrs string
 	FSPath      string
 	MountKey    string
+	// MntPath, when set, is used as --mnt-path instead of ComputeFuseMntPath(MountKey).
+	MntPath     string
 	Passthrough map[string]string
 }
 
 // BuildFuseExecArgs builds argv for curvine-fuse mount or validate-config.
-// Not wired into node/fuse_manager until a later commit.
 func BuildFuseExecArgs(in FuseExecArgsInput) []string {
 	args := make([]string, 0, 8+len(in.Passthrough)*2)
 	if in.Subcommand != "" {
@@ -132,7 +133,10 @@ func BuildFuseExecArgs(in FuseExecArgsInput) []string {
 	if in.FSPath != "" {
 		args = append(args, "--fs-path", in.FSPath)
 	}
-	if in.MountKey != "" {
+	switch {
+	case in.MntPath != "":
+		args = append(args, "--mnt-path", in.MntPath)
+	case in.MountKey != "":
 		args = append(args, "--mnt-path", ComputeFuseMntPath(in.MountKey))
 	}
 	args = appendPassthroughArgs(args, in.Passthrough)

--- a/curvine-csi/pkg/csi/fuse_cli_test.go
+++ b/curvine-csi/pkg/csi/fuse_cli_test.go
@@ -80,6 +80,26 @@ func TestBuildFuseExecArgs(t *testing.T) {
 	}
 }
 
+func TestBuildFuseExecArgsExplicitMntPath(t *testing.T) {
+	explicit := "/custom/mnt/path"
+	in := FuseExecArgsInput{
+		MountKey: "ignored-key",
+		MntPath:  explicit,
+		Passthrough: map[string]string{
+			"io-threads": "4",
+		},
+	}
+
+	got := BuildFuseExecArgs(in)
+	want := []string{
+		"--mnt-path", explicit,
+		"--io-threads", "4",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("BuildFuseExecArgs() = %#v, want %#v", got, want)
+	}
+}
+
 func TestIsRejectedVolumeParameterKey(t *testing.T) {
 	if !IsRejectedVolumeParameterKey("mnt-path") {
 		t.Fatal("expected mnt-path to be rejected")

--- a/curvine-csi/pkg/csi/fuse_manager.go
+++ b/curvine-csi/pkg/csi/fuse_manager.go
@@ -163,27 +163,18 @@ func (fm *FuseManager) StartFuseProcess(ctx context.Context, mntPath, clusterID,
 
 	// Build FUSE command
 	fuseBinaryPath := "/opt/curvine/curvine-fuse"
+	fuseArgv := BuildFuseExecArgs(FuseExecArgsInput{
+		MasterAddrs: masterAddrs,
+		FSPath:      fsPath,
+		MntPath:     mntPath,
+		Passthrough: fuseParams,
+	})
 	args := []string{fuseBinaryPath}
-
-	// Add debug flag if FUSE_DEBUG_ENABLED is set
 	if debugEnabled := os.Getenv("FUSE_DEBUG_ENABLED"); debugEnabled == "true" || debugEnabled == "1" {
 		args = append(args, "-d")
 		klog.Infof("FUSE debug mode enabled for %s", key)
 	}
-
-	// Add master-addrs
-	if masterAddrs != "" {
-		args = append(args, "--master-addrs", masterAddrs)
-	}
-
-	// Add paths
-	args = append(args, "--fs-path", fsPath)
-	args = append(args, "--mnt-path", mntPath)
-
-	// Add FUSE parameters
-	for key, value := range fuseParams {
-		args = append(args, fmt.Sprintf("--%s", key), value)
-	}
+	args = append(args, fuseArgv...)
 
 	// Use background context for FUSE process, as it should run independently
 	// of the request context. The request context may be cancelled after the

--- a/curvine-csi/pkg/csi/node.go
+++ b/curvine-csi/pkg/csi/node.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"sort"
 	"strings"
 	"time"
 
@@ -132,13 +131,13 @@ func (n *nodeService) NodeStageVolume(ctx context.Context, request *csi.NodeStag
 	clusterID := GenerateClusterID(masterAddrs)
 
 	// Collect FUSE parameters from VolumeContext or PublishContext
-	fuseParams := collectFuseParams(volumeContext, publishContext)
+	fuseParams := CollectPassthroughParams(volumeContext, publishContext)
 
 	// Generate mnt-path based on mount-key (master-addrs + fs-path + fuse-params)
 	// Including fuse params ensures that StorageClasses with the same cluster endpoint
 	// and fs-path but different FUSE parameters each get their own mount point and FUSE process.
 	mountKey := GenerateMountKeyWithFuseParams(masterAddrs, fsPathToMount, fuseParams)
-	mntPath := fmt.Sprintf("/var/lib/kubelet/plugins/kubernetes.io/csi/curvine/%s/fuse-mount", mountKey)
+	mntPath := ComputeFuseMntPath(mountKey)
 	klog.Infof("RequestID: %s, Generated mnt-path: %s (mount-key: %s, cluster-id: %s, master-addrs: %s, fs-path: %s)",
 		requestID, mntPath, mountKey, clusterID, masterAddrs, fsPathToMount)
 
@@ -312,8 +311,9 @@ func (n *nodeService) NodePublishVolume(ctx context.Context, request *csi.NodePu
 
 	// Generate cluster-id and mnt-path (same as NodeStageVolume)
 	clusterID := GenerateClusterID(masterAddrs)
-	mountKey := GenerateMountKey(masterAddrs, fsPath)
-	mntPath := fmt.Sprintf("/var/lib/kubelet/plugins/kubernetes.io/csi/curvine/%s/fuse-mount", mountKey)
+	fuseParams := CollectPassthroughParams(volumeContext, publishContext)
+	mountKey := GenerateMountKeyWithFuseParams(masterAddrs, fsPath, fuseParams)
+	mntPath := ComputeFuseMntPath(mountKey)
 
 	// Ensure shared mount point is ready (call NodeStageVolume logic if needed)
 	klog.Infof("RequestID: %s, Checking mount state for mntPath: %s, clusterID: %s, curvine-path: %s",
@@ -643,111 +643,3 @@ func buildMountOptions(request *csi.NodePublishVolumeRequest, requestID string) 
 	return ""
 }
 
-// supportedFuseParams maps the CLI flag name (as used by curvine-fuse) to its value
-// type. This is the single source of truth for which StorageClass / PV parameters
-// are recognised and forwarded to the curvine-fuse process.
-var supportedFuseParams = map[string]string{
-	// Threading & mount-point settings
-	"mnt-number":          "usize",
-	"io-threads":          "usize",
-	"worker-threads":      "usize",
-	"mnt-per-task":        "usize",
-	"clone-fd":            "bool",
-	"fuse-channel-size":   "usize",
-	"stream-channel-size": "usize",
-	// I/O behaviour
-	"direct-io":        "bool",
-	"write-back-cache": "bool",
-	"non-seekable":     "bool",
-	"cache-readdir":    "bool",
-	// Timeout settings
-	"entry-timeout":    "f64",
-	"attr-timeout":     "f64",
-	"negative-timeout": "f64",
-	"ac-attr-timeout":  "f64",
-	// Performance settings
-	"max-background":       "uint16",
-	"congestion-threshold": "uint16",
-	// Node cache
-	"node-cache-size":    "uint64",
-	"node-cache-timeout": "string",
-	// Metadata cache
-	"enable-meta-cache":   "bool",
-	"meta-cache-capacity": "uint64",
-	"meta-cache-ttl":      "string",
-	// Miscellaneous
-	"read-dir-fill-ino": "bool",
-	"remember":          "bool",
-	"check-permission":  "bool",
-	"list-limit":        "usize",
-	"web-port":          "uint16",
-}
-
-// collectFuseParams gathers FUSE parameters that are present in either
-// volumeContext or publishContext (volumeContext takes precedence) and
-// returns them as a map of CLI-flag-name → value.
-func collectFuseParams(volumeContext, publishContext map[string]string) map[string]string {
-	params := make(map[string]string)
-	for key := range supportedFuseParams {
-		if v, ok := volumeContext[key]; ok && v != "" {
-			params[key] = v
-		} else if v, ok := publishContext[key]; ok && v != "" {
-			params[key] = v
-		}
-	}
-	return params
-}
-
-// appendFuseParameters adds all supported fuse parameters from publishContext
-func appendFuseParameters(args []string, publishContext map[string]string, requestID string) []string {
-	// Collect keys and sort them so the argument order is deterministic across calls,
-	// matching the behaviour of buildFuseArgs in standalone_manager.go.
-	keys := make([]string, 0, len(supportedFuseParams))
-	for key := range supportedFuseParams {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-
-	for _, key := range keys {
-		paramType := supportedFuseParams[key]
-		value, ok := publishContext[key]
-		if !ok || value == "" {
-			continue
-		}
-
-		// Validate parameter value
-		if !isValidParameterValue(value, paramType, requestID, key) {
-			continue
-		}
-
-		// Add parameter to command args
-		args = append(args, "--"+key, value)
-		klog.Infof("RequestID: %s, Added fuse parameter: --%s=%s", requestID, key, value)
-	}
-
-	return args
-}
-
-func isValidParameterValue(value, paramType, requestID, paramName string) bool {
-	if value == "" {
-		klog.Warningf("RequestID: %s, Empty value for parameter %s", requestID, paramName)
-		return false
-	}
-
-	switch paramType {
-	case "bool":
-		if value != "true" && value != "false" {
-			klog.Warningf("RequestID: %s, Invalid boolean value '%s' for parameter %s", requestID, value, paramName)
-			return false
-		}
-	case "string":
-		return true
-	case "uint16", "usize", "uint64", "f64":
-		return true
-	default:
-		klog.Warningf("RequestID: %s, Unknown parameter type %s for parameter %s", requestID, paramType, paramName)
-		return false
-	}
-
-	return true
-}

--- a/curvine-csi/pkg/csi/node_standalone.go
+++ b/curvine-csi/pkg/csi/node_standalone.go
@@ -137,7 +137,7 @@ func (n *nodeServiceStandalone) NodeStageVolume(ctx context.Context, request *cs
 	clusterID := GenerateClusterID(masterAddrs)
 
 	// Collect FUSE parameters from VolumeContext or PublishContext
-	fuseParams := collectFuseParams(volumeContext, publishContext)
+	fuseParams := CollectPassthroughParams(volumeContext, publishContext)
 
 	// Generate mount-key from master-addrs + fs-path + fuse-params
 	// Including fuse params ensures that StorageClasses with the same cluster endpoint
@@ -297,7 +297,7 @@ func (n *nodeServiceStandalone) NodePublishVolume(ctx context.Context, request *
 	clusterID := GenerateClusterID(masterAddrs)
 
 	// Collect FUSE parameters from VolumeContext or PublishContext
-	fuseParams := collectFuseParams(volumeContext, publishContext)
+	fuseParams := CollectPassthroughParams(volumeContext, publishContext)
 
 	// Generate mount-key from master-addrs + fs-path + fuse-params
 	// Including fuse params ensures that StorageClasses with the same cluster endpoint

--- a/curvine-csi/pkg/csi/standalone_manager.go
+++ b/curvine-csi/pkg/csi/standalone_manager.go
@@ -14,7 +14,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -629,20 +628,12 @@ func mountPropagationBidirectionalPtr() *corev1.MountPropagationMode {
 // FUSE parameters supplied via opts.FuseParams.
 // Keys are sorted to ensure deterministic argument ordering across pod restarts.
 func buildFuseArgs(opts *StandaloneOptions) []string {
-	args := []string{
-		"--master-addrs", opts.MasterAddrs,
-		"--fs-path", opts.FSPath,
-		"--mnt-path", StandaloneMountPath,
-	}
-	keys := make([]string, 0, len(opts.FuseParams))
-	for key := range opts.FuseParams {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-	for _, key := range keys {
-		args = append(args, "--"+key, opts.FuseParams[key])
-	}
-	return args
+	return BuildFuseExecArgs(FuseExecArgsInput{
+		MasterAddrs: opts.MasterAddrs,
+		FSPath:      opts.FSPath,
+		MntPath:     StandaloneMountPath,
+		Passthrough: opts.FuseParams,
+	})
 }
 
 // DeleteStandalone deletes the Standalone for the given mount key on this node


### PR DESCRIPTION
## Problem

C12 landed in #864. CSI still needs wiring: replace `supportedFuseParams` whitelist
with passthrough helpers.

## Design

- Replace `collectFuseParams` with `CollectPassthroughParams`.
- Build argv via `BuildFuseExecArgs` in node, fuse_manager, and standalone paths.
- Remove whitelist map and CSI-side type validation (fuse/clap owns validation).
- Use `ComputeFuseMntPath` consistently.

## Key Changes

- Wire `fuse_manager.go`, `node.go`, `node_standalone.go`, `standalone_manager.go`.
- Delete `supportedFuseParams`, `collectFuseParams`, `appendFuseParameters`,
  `isValidParameterValue`.
- Extend `FuseExecArgsInput` with explicit `MntPath`.

## Expected Outcome

- Passthrough keys from SC/PV reach `curvine-fuse` without CSI whitelist updates.
- Unblocks C14 (reject user `mnt-path` in validator).

## Base

Rebased onto latest `main` (767e9ea), including merged #864.

## Test Plan

- [ ] `go test ./pkg/csi/ -run 'ComputeFuse|CollectPassthrough|BuildFuse' -count=1`
- [ ] Smoke NodeStage with extra SC parameters (manual)

Refs #865