### PR TITLE
feat(fuse): add validate-config subcommand (C9)

### DIFF
--- a/curvine-fuse/src/cli/fuse_cli.rs
+++ b/curvine-fuse/src/cli/fuse_cli.rs
@@ -37,6 +37,8 @@ pub struct FuseCli {
 pub enum FuseSubcommand {
     /// Mount the curvine filesystem (also the default when omitted)
     Mount(FuseMountArgs),
+    /// Validate configuration without mounting
+    ValidateConfig(FuseMountArgs),
 }
 
 impl FuseCli {
@@ -50,6 +52,20 @@ impl FuseCli {
         match &self.cmd {
             Some(FuseSubcommand::Mount(args)) => args.clone(),
             None => self.mount.clone(),
+            Some(FuseSubcommand::ValidateConfig(_)) => {
+                unreachable!("resolve_mount_args called for validate-config")
+            }
+        }
+    }
+
+    /// Returns args for validate-config, from the subcommand or top-level flags.
+    pub fn resolve_validate_args(&self) -> FuseMountArgs {
+        match &self.cmd {
+            Some(FuseSubcommand::ValidateConfig(args)) => args.clone(),
+            None => self.mount.clone(),
+            Some(FuseSubcommand::Mount(_)) => {
+                unreachable!("resolve_validate_args called for mount")
+            }
         }
     }
 }
@@ -82,7 +98,22 @@ mod tests {
 
     #[test]
     fn unknown_subcommand_is_rejected() {
-        let err = FuseCli::try_parse_from(["curvine-fuse", "validate-config"]).unwrap_err();
+        let err = FuseCli::try_parse_from(["curvine-fuse", "unknown-cmd"]).unwrap_err();
         assert!(err.to_string().contains("unrecognized subcommand"));
+    }
+
+    #[test]
+    fn validate_config_subcommand_parses() {
+        let cli = FuseCli::try_parse_from([
+            "curvine-fuse",
+            "validate-config",
+            "--conf",
+            "conf/curvine-cluster.toml",
+        ])
+        .unwrap();
+        match cli.cmd {
+            Some(FuseSubcommand::ValidateConfig(_)) => {}
+            _ => panic!("expected validate-config subcommand"),
+        }
     }
 }

--- a/curvine-fuse/src/cli/mod.rs
+++ b/curvine-fuse/src/cli/mod.rs
@@ -15,7 +15,9 @@
 mod fuse_cli;
 mod mount_args;
 mod mount_run;
+mod validate_run;
 
 pub use fuse_cli::{FuseCli, FuseSubcommand};
 pub use mount_args::FuseMountArgs;
 pub use mount_run::run_mount;
+pub use validate_run::run_validate_config;

--- a/curvine-fuse/src/cli/validate_run.rs
+++ b/curvine-fuse/src/cli/validate_run.rs
@@ -12,17 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use clap::Parser;
-use curvine_fuse::cli::{run_mount, run_validate_config, FuseCli, FuseSubcommand};
+use crate::cli::FuseMountArgs;
 use orpc::CommonResult;
 
-// fuse mount.
-// Debugging, after starting the cluster, execute the following naming, mount fuse
-// umount -f /curvine-fuse; cargo run --bin curvine-fuse -- --conf /server/conf/curvine-cluster.toml
-fn main() -> CommonResult<()> {
-    let cli = FuseCli::parse();
-    match &cli.cmd {
-        None | Some(FuseSubcommand::Mount(_)) => run_mount(cli.resolve_mount_args()),
-        Some(FuseSubcommand::ValidateConfig(_)) => run_validate_config(cli.resolve_validate_args()),
-    }
+/// Validates configuration by loading and initializing cluster settings without mounting.
+pub fn run_validate_config(args: FuseMountArgs) -> CommonResult<()> {
+    let mut conf = args.get_conf()?;
+    conf.client.init()?;
+    conf.print();
+    eprintln!("Configuration validated successfully");
+    Ok(())
 }

--- a/curvine-fuse/src/cli/validate_run.rs
+++ b/curvine-fuse/src/cli/validate_run.rs
@@ -16,10 +16,9 @@ use crate::cli::FuseMountArgs;
 use orpc::CommonResult;
 
 /// Validates configuration by loading and initializing cluster settings without mounting.
+/// Exits quietly on success; failures are returned via `CommonResult` for stderr reporting.
 pub fn run_validate_config(args: FuseMountArgs) -> CommonResult<()> {
     let mut conf = args.get_conf()?;
     conf.client.init()?;
-    conf.print();
-    eprintln!("Configuration validated successfully");
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Add `validate-config` subcommand (dry-run via `get_conf()` + `client.init()`, no mount)
- Wire binary dispatch and update CLI tests

## Test plan
- [x] `cargo test -p curvine-fuse fuse_cli`

Refs #865