### PR TITLE
feat(csi): reject user mnt-path on StorageClass and PV (C14)

### DIFF
--- a/curvine-csi/pkg/csi/fuse_cli.go
+++ b/curvine-csi/pkg/csi/fuse_cli.go
@@ -17,6 +17,10 @@ package csi
 import (
 	"fmt"
 	"sort"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"k8s.io/klog"
 )
 
 const fuseKubeletPluginBase = "/var/lib/kubelet/plugins/kubernetes.io/csi/curvine"
@@ -62,6 +66,24 @@ func IsRejectedVolumeParameterKey(key string) bool {
 func IsDeniedVolumeParameterKey(key string) bool {
 	_, ok := volumeParameterDenylist[key]
 	return ok
+}
+
+// RejectDisallowedVolumeParameters rejects user-supplied keys such as mnt-path on PVs
+// and in node volume/publish context before mount-key generation.
+func RejectDisallowedVolumeParameters(volumeContext, publishContext map[string]string, requestID string) error {
+	for key := range volumeContext {
+		if IsRejectedVolumeParameterKey(key) {
+			klog.Errorf("RequestID: %s, Parameter %q is not allowed on StorageClass or PV", requestID, key)
+			return status.Errorf(codes.InvalidArgument, "Parameter %q is not allowed on StorageClass or PV", key)
+		}
+	}
+	for key := range publishContext {
+		if IsRejectedVolumeParameterKey(key) {
+			klog.Errorf("RequestID: %s, Parameter %q is not allowed on StorageClass or PV", requestID, key)
+			return status.Errorf(codes.InvalidArgument, "Parameter %q is not allowed on StorageClass or PV", key)
+		}
+	}
+	return nil
 }
 
 // MergeVolumeParameters merges volumeContext and publishContext with volumeContext winning.

--- a/curvine-csi/pkg/csi/fuse_cli.go
+++ b/curvine-csi/pkg/csi/fuse_cli.go
@@ -33,8 +33,6 @@ var reservedVolumeParameterKeys = map[string]struct{}{
 }
 
 // rejectedVolumeParameterKeys must not appear in StorageClass / PV parameters.
-// Enforcement in validator/node wiring is deferred to C14; until then validator.go may
-// still accept a legacy user-provided mnt-path.
 var rejectedVolumeParameterKeys = map[string]struct{}{
 	"mnt-path": {},
 }

--- a/curvine-csi/pkg/csi/fuse_cli_test.go
+++ b/curvine-csi/pkg/csi/fuse_cli_test.go
@@ -108,3 +108,13 @@ func TestIsRejectedVolumeParameterKey(t *testing.T) {
 		t.Fatal("did not expect io-threads to be rejected")
 	}
 }
+
+func TestRejectDisallowedVolumeParameters(t *testing.T) {
+	volumeContext := map[string]string{
+		"master-addrs": "m1:8995",
+		"mnt-path":     "/custom",
+	}
+	if err := RejectDisallowedVolumeParameters(volumeContext, nil, "req"); err == nil {
+		t.Fatal("expected error for mnt-path in volume context")
+	}
+}

--- a/curvine-csi/pkg/csi/node.go
+++ b/curvine-csi/pkg/csi/node.go
@@ -104,6 +104,10 @@ func (n *nodeService) NodeStageVolume(ctx context.Context, request *csi.NodeStag
 		publishContext = make(map[string]string)
 	}
 
+	if err := RejectDisallowedVolumeParameters(volumeContext, publishContext, requestID); err != nil {
+		return nil, err
+	}
+
 	// Get required parameters
 	masterAddrs := volumeContext["master-addrs"]
 	if masterAddrs == "" {

--- a/curvine-csi/pkg/csi/node_standalone.go
+++ b/curvine-csi/pkg/csi/node_standalone.go
@@ -111,6 +111,10 @@ func (n *nodeServiceStandalone) NodeStageVolume(ctx context.Context, request *cs
 		publishContext = make(map[string]string)
 	}
 
+	if err := RejectDisallowedVolumeParameters(volumeContext, publishContext, requestID); err != nil {
+		return nil, err
+	}
+
 	// Get required parameters
 	masterAddrs := volumeContext["master-addrs"]
 	if masterAddrs == "" {

--- a/curvine-csi/pkg/csi/validator.go
+++ b/curvine-csi/pkg/csi/validator.go
@@ -89,22 +89,7 @@ func ValidateStorageClassParams(params map[string]string, requestID string) (*St
 		return nil, status.Error(codes.InvalidArgument, "path-type must be 'Directory' or 'DirectoryOrCreate'")
 	}
 	validated.PathType = pathType
-
-	// Collect optional FUSE parameters
-	fuseParamKeys := []string{
-		"io-threads", "worker-threads", "mnt-per-task", "clone-fd",
-		"fuse-channel-size", "stream-channel-size", "auto-cache",
-		"direct-io", "kernel-cache", "cache-readdir", "entry-timeout",
-		"attr-timeout", "negative-timeout", "max-background",
-		"congestion-threshold", "node-cache-size", "node-cache-timeout",
-		"master-hostname", "master-rpc-port", "master-web-port", "mnt-number",
-	}
-
-	for _, key := range fuseParamKeys {
-		if value, ok := params[key]; ok && value != "" {
-			validated.FuseParams[key] = value
-		}
-	}
+	validated.FuseParams = fuseParams
 
 	klog.Infof("RequestID: %s, Validated StorageClass parameters: master-addrs=%s, mnt-path=%s, fs-path=%s, path-type=%s",
 		requestID, validated.MasterAddrs, validated.MntPath, validated.FSPath, validated.PathType)

--- a/curvine-csi/pkg/csi/validator.go
+++ b/curvine-csi/pkg/csi/validator.go
@@ -64,27 +64,19 @@ func ValidateStorageClassParams(params map[string]string, requestID string) (*St
 	}
 	validated.FSPath = fsPath
 
-	// Generate mnt-path automatically (mnt-path parameter is now optional and internal)
-	// If mnt-path is provided (legacy support), use it; otherwise generate it
-	mntPath, ok := params["mnt-path"]
-	if !ok || mntPath == "" {
-		// Auto-generate mnt-path based on mount-key (master-addrs + fs-path)
-		// This ensures different StorageClasses with same master-addrs but different fs-path get different mount points
-		// Format: /var/lib/kubelet/plugins/kubernetes.io/csi/curvine/{mount-key}/fuse-mount
-		mountKey := GenerateMountKey(masterAddrs, fsPath)
-		clusterID := GenerateClusterID(masterAddrs) // Keep for logging
-		mntPath = fmt.Sprintf("/var/lib/kubelet/plugins/kubernetes.io/csi/curvine/%s/fuse-mount", mountKey)
-		klog.Infof("RequestID: %s, Auto-generated mnt-path: %s (mount-key: %s, cluster-id: %s, fs-path: %s)",
-			requestID, mntPath, mountKey, clusterID, fsPath)
-	} else {
-		// User provided mnt-path (legacy mode)
-		klog.Warningf("RequestID: %s, Using user-provided mnt-path: %s (deprecated, will auto-generate in future)",
-			requestID, mntPath)
-		if err := ValidatePath(mntPath); err != nil {
-			klog.Errorf("RequestID: %s, Invalid mnt-path: %v", requestID, err)
-			return nil, status.Errorf(codes.InvalidArgument, "Invalid mnt-path: %v", err)
+	fuseParams := CollectPassthroughParams(params, nil)
+	for key := range params {
+		if IsRejectedVolumeParameterKey(key) {
+			klog.Errorf("RequestID: %s, Parameter %q is not allowed on StorageClass or PV", requestID, key)
+			return nil, status.Errorf(codes.InvalidArgument, "Parameter %q is not allowed on StorageClass or PV", key)
 		}
 	}
+
+	mountKey := GenerateMountKeyWithFuseParams(masterAddrs, fsPath, fuseParams)
+	mntPath := ComputeFuseMntPath(mountKey)
+	clusterID := GenerateClusterID(masterAddrs)
+	klog.Infof("RequestID: %s, Auto-generated mnt-path: %s (mount-key: %s, cluster-id: %s, fs-path: %s)",
+		requestID, mntPath, mountKey, clusterID, fsPath)
 	validated.MntPath = mntPath
 
 	// Validate path-type (optional, default to "Directory")

--- a/curvine-csi/pkg/csi/validator_test.go
+++ b/curvine-csi/pkg/csi/validator_test.go
@@ -1,0 +1,61 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package csi
+
+import (
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestValidateStorageClassParamsRejectsMntPath(t *testing.T) {
+	params := map[string]string{
+		"master-addrs": "m1:8995",
+		"fs-path":      "/data",
+		"mnt-path":     "/custom/mnt",
+	}
+
+	_, err := ValidateStorageClassParams(params, "test-req")
+	if err == nil {
+		t.Fatal("expected error for user-provided mnt-path")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.InvalidArgument {
+		t.Fatalf("expected InvalidArgument, got %v", st.Code())
+	}
+}
+
+func TestValidateStorageClassParamsGeneratesMntPath(t *testing.T) {
+	params := map[string]string{
+		"master-addrs": "m1:8995",
+		"fs-path":      "/data",
+		"io-threads":   "4",
+	}
+
+	got, err := ValidateStorageClassParams(params, "test-req")
+	if err != nil {
+		t.Fatalf("ValidateStorageClassParams() error = %v", err)
+	}
+	want := ComputeFuseMntPath(GenerateMountKeyWithFuseParams("m1:8995", "/data", map[string]string{
+		"io-threads": "4",
+	}))
+	if got.MntPath != want {
+		t.Fatalf("MntPath = %q, want %q", got.MntPath, want)
+	}
+}

--- a/curvine-csi/pkg/csi/validator_test.go
+++ b/curvine-csi/pkg/csi/validator_test.go
@@ -58,4 +58,7 @@ func TestValidateStorageClassParamsGeneratesMntPath(t *testing.T) {
 	if got.MntPath != want {
 		t.Fatalf("MntPath = %q, want %q", got.MntPath, want)
 	}
+	if got.FuseParams["io-threads"] != "4" {
+		t.Fatalf("FuseParams = %#v, want io-threads=4 from passthrough", got.FuseParams)
+	}
 }


### PR DESCRIPTION
## Summary
- Reject `mnt-path` on SC/PV at validation time
- Always compute mount path via `GenerateMountKeyWithFuseParams` + `ComputeFuseMntPath`
- Add validator unit tests

## Test plan
- [ ] `go test ./curvine-csi/pkg/csi/ -run ValidateStorageClass -count=1`

Refs #865