### PR TITLE
docs: add gitvote conf info

### DIFF
--- a/.gitvote.yml
+++ b/.gitvote.yml
@@ -1,0 +1,13 @@
+# .gitvote.yml example
+# Voting duration. For example, 72h means 72 hours. Units 'd' (days) and 'm' (minutes) are also supported.
+duration: 30d
+
+# Defines which users' votes are binding.
+# 'all' means every user who votes via comments counts; you can also specify specific users or teams.
+binding: all
+
+# Conditions required for a vote to pass.
+# For example: at least 2 in-favor votes, with in-favor votes outnumbering against votes.
+pass:
+  at-least: 5
+  with-majority: true


### PR DESCRIPTION
## Summary
- Add `.gitvote.yml` at the repository root to enable [GitVote](https://github.com/gitvote-io/gitvote) for community-driven voting on issues / PRs.
- Defaults: 30-day voting window, all comment voters are binding, vote passes with at least 5 in-favor votes and a majority.

## Test plan
- [ ] Verify the GitVote GitHub App picks up the new config on PRs / issues.
- [ ] Confirm the configured threshold (`at-least: 5`, `with-majority: true`) matches the project governance expectations before merging.


Made with [Cursor](https://cursor.com)