### PR TITLE
feat(common): expose chunk, unified FS, and audit client CLI flags (C4)

### DIFF
--- a/curvine-common/src/conf/client_conf.rs
+++ b/curvine-common/src/conf/client_conf.rs
@@ -49,13 +49,17 @@ pub struct ClientConf {
     #[serde(skip)]
     pub write_chunk_size: usize,
     #[serde(alias = "write_chunk_size")]
+    #[client_cli]
     pub write_chunk_size_str: String,
+    #[client_cli]
     pub write_chunk_num: usize,
 
     #[serde(skip)]
     pub read_chunk_size: usize,
     #[serde(alias = "read_chunk_size")]
+    #[client_cli]
     pub read_chunk_size_str: String,
+    #[client_cli]
     pub read_chunk_num: usize,
 
     // These 2 parameters are used to improve the speed of reading a single file.
@@ -69,11 +73,13 @@ pub struct ClientConf {
     #[serde(skip)]
     pub read_slice_size: i64,
     #[serde(alias = "read_slice_size")]
+    #[client_cli]
     pub read_slice_size_str: String,
 
     // Maximum number of open block handles (readers and writers).
     // When the limit is reached, FIFO eviction will close the oldest (first opened) handle.
     // This limits memory usage and connection count in random read/write scenarios.
+    #[client_cli]
     pub max_cache_block_handles: usize,
 
     #[client_cli]
@@ -149,13 +155,16 @@ pub struct ClientConf {
     pub failed_worker_ttl_str: String,
 
     // Whether to enable the unified file system
+    #[client_cli]
     pub enable_unified_fs: bool,
     // If the cache hits, read data from Curvine.
     // If the cache misses, determine whether to allow Curvine to directly read data from the unified file system (UFS).
+    #[client_cli]
     pub enable_rust_read_ufs: bool,
 
     // Whether to enable client-side audit logging for UnifiedFileSystem operations.
     // The log target is "audit" and records: cmd, ok, src, dst, usedUs.
+    #[client_cli]
     pub audit_logging_enabled: bool,
 
     // Mount information update interval

--- a/curvine-common/tests/client_conf_cli_test.rs
+++ b/curvine-common/tests/client_conf_cli_test.rs
@@ -51,6 +51,7 @@ fn apply_to_updates_pilot_client_fields() {
         block_size_str: Some("64KB".to_string()),
         read_parallel: Some(2),
         short_circuit: Some(false),
+        ..Default::default()
     };
     overrides.apply_to(&mut conf).unwrap();
     conf.init().unwrap();
@@ -60,6 +61,47 @@ fn apply_to_updates_pilot_client_fields() {
     assert_eq!(conf.block_size_str, "64KB");
     assert_eq!(conf.read_parallel, 2);
     assert!(!conf.short_circuit);
+}
+
+#[test]
+fn parses_c4_chunk_unified_fs_and_audit_flags() {
+    let parsed = CliHarness::try_parse_from([
+        "curvine-fuse",
+        "--client.write-chunk-size",
+        "256KB",
+        "--client.read-chunk-num",
+        "4",
+        "--client.enable-unified-fs",
+        "true",
+        "--client.audit-logging-enabled",
+        "false",
+    ])
+    .unwrap();
+
+    assert_eq!(
+        parsed.overrides.write_chunk_size_str.as_deref(),
+        Some("256KB")
+    );
+    assert_eq!(parsed.overrides.read_chunk_num, Some(4));
+    assert_eq!(parsed.overrides.enable_unified_fs, Some(true));
+    assert_eq!(parsed.overrides.audit_logging_enabled, Some(false));
+}
+
+#[test]
+fn apply_to_updates_c4_fields() {
+    let mut conf = ClientConf::default();
+    let overrides = ClientConfCliOverrides {
+        write_chunk_size_str: Some("512KB".to_string()),
+        enable_rust_read_ufs: Some(true),
+        max_cache_block_handles: Some(20),
+        ..Default::default()
+    };
+    overrides.apply_to(&mut conf).unwrap();
+    conf.init().unwrap();
+
+    assert_eq!(conf.write_chunk_size_str, "512KB");
+    assert!(conf.enable_rust_read_ufs);
+    assert_eq!(conf.max_cache_block_handles, 20);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Continues #865 Track B (C4): annotate the next `ClientConf` batch with `#[client_cli]` under `opt_in` rollout.

- Chunk I/O: `write_chunk_size`, `write_chunk_num`, `read_chunk_size`, `read_chunk_num`, `read_slice_size`, `max_cache_block_handles`
- Unified FS: `enable_unified_fs`, `enable_rust_read_ufs`
- Audit: `audit_logging_enabled`

## Test plan

- [x] `make format` (clippy + fmt)
- [x] `cargo test -p curvine-common --test client_conf_cli_test --release`
- [ ] CI green

Refs #865
