### PR TITLE
feat(common): expose RPC retry and timeout client CLI flags (C5)

### DIFF
--- a/curvine-common/src/conf/client_conf.rs
+++ b/curvine-common/src/conf/client_conf.rs
@@ -115,25 +115,37 @@ pub struct ClientConf {
     pub default_cache_ttl: Option<String>,
 
     // Set up the customer service retry policy
+    #[client_cli]
     pub conn_retry_max_duration_ms: u64,
+    #[client_cli]
     pub conn_retry_min_sleep_ms: u64,
+    #[client_cli]
     pub conn_retry_max_sleep_ms: u64,
 
     // rpc requests retry policy.
+    #[client_cli]
     pub rpc_retry_max_duration_ms: u64,
+    #[client_cli]
     pub rpc_retry_min_sleep_ms: u64,
+    #[client_cli]
     pub rpc_retry_max_sleep_ms: u64,
 
     // Whether to close the idle rpc connection.
+    #[client_cli]
     pub rpc_close_idle: bool,
 
     //Configuration of timeout for a request.
+    #[client_cli]
     pub conn_timeout_ms: u64,
+    #[client_cli]
     pub rpc_timeout_ms: u64,
+    #[client_cli]
     pub data_timeout_ms: u64,
+    #[client_cli]
     pub pipeline_timeout_ms: u64,
 
     // After testing 3 connections, the best performance can be achieved, so the default value is 3.
+    #[client_cli]
     pub master_conn_pool_size: usize,
 
     // Whether to enable pre-reading

--- a/curvine-common/src/conf/client_conf.rs
+++ b/curvine-common/src/conf/client_conf.rs
@@ -141,7 +141,6 @@ pub struct ClientConf {
     pub rpc_timeout_ms: u64,
     #[client_cli]
     pub data_timeout_ms: u64,
-    #[client_cli]
     pub pipeline_timeout_ms: u64,
 
     // After testing 3 connections, the best performance can be achieved, so the default value is 3.

--- a/curvine-common/tests/client_conf_cli_test.rs
+++ b/curvine-common/tests/client_conf_cli_test.rs
@@ -108,10 +108,24 @@ fn apply_to_updates_c4_fields() {
 fn parses_c5_rpc_retry_and_timeout_flags() {
     let parsed = CliHarness::try_parse_from([
         "curvine-fuse",
+        "--client.conn-retry-max-duration-ms",
+        "120000",
+        "--client.conn-retry-min-sleep-ms",
+        "100",
+        "--client.conn-retry-max-sleep-ms",
+        "2000",
+        "--client.rpc-retry-max-duration-ms",
+        "180000",
+        "--client.rpc-retry-min-sleep-ms",
+        "200",
+        "--client.rpc-retry-max-sleep-ms",
+        "10000",
         "--client.rpc-timeout-ms",
         "60000",
         "--client.conn-timeout-ms",
         "30000",
+        "--client.data-timeout-ms",
+        "90000",
         "--client.rpc-close-idle",
         "false",
         "--client.master-conn-pool-size",
@@ -119,8 +133,15 @@ fn parses_c5_rpc_retry_and_timeout_flags() {
     ])
     .unwrap();
 
-    assert_eq!(parsed.overrides.rpc_timeout_ms, Some(60000));
-    assert_eq!(parsed.overrides.conn_timeout_ms, Some(30000));
+    assert_eq!(parsed.overrides.conn_retry_max_duration_ms, Some(120_000));
+    assert_eq!(parsed.overrides.conn_retry_min_sleep_ms, Some(100));
+    assert_eq!(parsed.overrides.conn_retry_max_sleep_ms, Some(2_000));
+    assert_eq!(parsed.overrides.rpc_retry_max_duration_ms, Some(180_000));
+    assert_eq!(parsed.overrides.rpc_retry_min_sleep_ms, Some(200));
+    assert_eq!(parsed.overrides.rpc_retry_max_sleep_ms, Some(10_000));
+    assert_eq!(parsed.overrides.rpc_timeout_ms, Some(60_000));
+    assert_eq!(parsed.overrides.conn_timeout_ms, Some(30_000));
+    assert_eq!(parsed.overrides.data_timeout_ms, Some(90_000));
     assert_eq!(parsed.overrides.rpc_close_idle, Some(false));
     assert_eq!(parsed.overrides.master_conn_pool_size, Some(5));
 }
@@ -132,7 +153,6 @@ fn apply_to_updates_c5_fields() {
         conn_retry_max_duration_ms: Some(120_000),
         rpc_retry_min_sleep_ms: Some(200),
         data_timeout_ms: Some(90_000),
-        pipeline_timeout_ms: Some(90_000),
         ..Default::default()
     };
     overrides.apply_to(&mut conf).unwrap();
@@ -140,7 +160,13 @@ fn apply_to_updates_c5_fields() {
     assert_eq!(conf.conn_retry_max_duration_ms, 120_000);
     assert_eq!(conf.rpc_retry_min_sleep_ms, 200);
     assert_eq!(conf.data_timeout_ms, 90_000);
-    assert_eq!(conf.pipeline_timeout_ms, 90_000);
+}
+
+#[test]
+fn rejects_pipeline_timeout_ms_until_wired_to_rpc_conf() {
+    let err = CliHarness::try_parse_from(["curvine-fuse", "--client.pipeline-timeout-ms", "90000"])
+        .unwrap_err();
+    assert!(err.to_string().contains("pipeline-timeout-ms"));
 }
 
 #[test]

--- a/curvine-common/tests/client_conf_cli_test.rs
+++ b/curvine-common/tests/client_conf_cli_test.rs
@@ -105,6 +105,45 @@ fn apply_to_updates_c4_fields() {
 }
 
 #[test]
+fn parses_c5_rpc_retry_and_timeout_flags() {
+    let parsed = CliHarness::try_parse_from([
+        "curvine-fuse",
+        "--client.rpc-timeout-ms",
+        "60000",
+        "--client.conn-timeout-ms",
+        "30000",
+        "--client.rpc-close-idle",
+        "false",
+        "--client.master-conn-pool-size",
+        "5",
+    ])
+    .unwrap();
+
+    assert_eq!(parsed.overrides.rpc_timeout_ms, Some(60000));
+    assert_eq!(parsed.overrides.conn_timeout_ms, Some(30000));
+    assert_eq!(parsed.overrides.rpc_close_idle, Some(false));
+    assert_eq!(parsed.overrides.master_conn_pool_size, Some(5));
+}
+
+#[test]
+fn apply_to_updates_c5_fields() {
+    let mut conf = ClientConf::default();
+    let overrides = ClientConfCliOverrides {
+        conn_retry_max_duration_ms: Some(120_000),
+        rpc_retry_min_sleep_ms: Some(200),
+        data_timeout_ms: Some(90_000),
+        pipeline_timeout_ms: Some(90_000),
+        ..Default::default()
+    };
+    overrides.apply_to(&mut conf).unwrap();
+
+    assert_eq!(conf.conn_retry_max_duration_ms, 120_000);
+    assert_eq!(conf.rpc_retry_min_sleep_ms, 200);
+    assert_eq!(conf.data_timeout_ms, 90_000);
+    assert_eq!(conf.pipeline_timeout_ms, 90_000);
+}
+
+#[test]
 fn rejects_unannotated_field_in_opt_in_mode() {
     let err =
         CliHarness::try_parse_from(["curvine-fuse", "--client.hostname", "host1"]).unwrap_err();


### PR DESCRIPTION
## Summary

Continues #865 Track B (C5): expose RPC/retry/timeout `ClientConf` fields via `#[client_cli]` under `opt_in`.

- Connection retry: `conn_retry_*`
- RPC retry: `rpc_retry_*`, `rpc_close_idle`
- Timeouts: `conn_timeout_ms`, `rpc_timeout_ms`, `data_timeout_ms`, `pipeline_timeout_ms`
- `master_conn_pool_size`

## Test plan

- [x] `make format`
- [x] `cargo test -p curvine-common --test client_conf_cli_test --release`
- [ ] CI green

Refs #865
