### PR TITLE
feat(fuse): add list-config-flags subcommand (C10)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2073,6 +2073,7 @@ dependencies = [
  "pin-project-lite",
  "pkg-config",
  "serde",
+ "serde_json",
  "smallvec",
  "thiserror 1.0.69",
  "tokio",

--- a/curvine-fuse/Cargo.toml
+++ b/curvine-fuse/Cargo.toml
@@ -32,6 +32,7 @@ tracing = { workspace = true }
 tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 futures = { workspace = true }
 
 [features]

--- a/curvine-fuse/src/bin/curvine-fuse.rs
+++ b/curvine-fuse/src/bin/curvine-fuse.rs
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 use clap::Parser;
-use curvine_fuse::cli::{run_mount, run_validate_config, FuseCli, FuseSubcommand};
+use curvine_fuse::cli::{
+    run_list_config_flags, run_mount, run_validate_config, FuseCli, FuseSubcommand,
+};
 use orpc::CommonResult;
 
 // fuse mount.
@@ -24,5 +26,6 @@ fn main() -> CommonResult<()> {
     match &cli.cmd {
         None | Some(FuseSubcommand::Mount(_)) => run_mount(cli.resolve_mount_args()),
         Some(FuseSubcommand::ValidateConfig(_)) => run_validate_config(cli.resolve_validate_args()),
+        Some(FuseSubcommand::ListConfigFlags(args)) => run_list_config_flags(args.clone()),
     }
 }

--- a/curvine-fuse/src/cli/fuse_cli.rs
+++ b/curvine-fuse/src/cli/fuse_cli.rs
@@ -12,10 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use curvine_common::version;
 
 use crate::cli::mount_args::FuseMountArgs;
+
+/// Output format for `list-config-flags`.
+#[derive(Debug, Clone, Copy, Default, ValueEnum, PartialEq, Eq)]
+pub enum ListConfigFormat {
+    #[default]
+    Json,
+}
+
+/// Arguments for the `list-config-flags` subcommand.
+#[derive(Debug, Parser, Clone)]
+pub struct ListConfigFlagsArgs {
+    #[arg(long, value_enum, default_value_t = ListConfigFormat::Json)]
+    pub format: ListConfigFormat,
+}
 
 /// Top-level curvine-fuse CLI. Mount is the default when no subcommand is given.
 #[derive(Debug, Parser, Clone)]
@@ -39,6 +53,8 @@ pub enum FuseSubcommand {
     Mount(FuseMountArgs),
     /// Validate configuration without mounting
     ValidateConfig(FuseMountArgs),
+    /// List mount-related CLI flags as JSON for docs and CI
+    ListConfigFlags(ListConfigFlagsArgs),
 }
 
 impl FuseCli {
@@ -55,6 +71,9 @@ impl FuseCli {
             Some(FuseSubcommand::ValidateConfig(_)) => {
                 unreachable!("resolve_mount_args called for validate-config")
             }
+            Some(FuseSubcommand::ListConfigFlags(_)) => {
+                unreachable!("resolve_mount_args called for list-config-flags")
+            }
         }
     }
 
@@ -65,6 +84,9 @@ impl FuseCli {
             None => self.mount.clone(),
             Some(FuseSubcommand::Mount(_)) => {
                 unreachable!("resolve_validate_args called for mount")
+            }
+            Some(FuseSubcommand::ListConfigFlags(_)) => {
+                unreachable!("resolve_validate_args called for list-config-flags")
             }
         }
     }
@@ -114,6 +136,30 @@ mod tests {
         match cli.cmd {
             Some(FuseSubcommand::ValidateConfig(_)) => {}
             _ => panic!("expected validate-config subcommand"),
+        }
+    }
+
+    #[test]
+    fn list_config_flags_subcommand_parses() {
+        let cli = FuseCli::try_parse_from(["curvine-fuse", "list-config-flags"]).unwrap();
+        match cli.cmd {
+            Some(FuseSubcommand::ListConfigFlags(args)) => {
+                assert_eq!(args.format, ListConfigFormat::Json);
+            }
+            _ => panic!("expected list-config-flags subcommand"),
+        }
+    }
+
+    #[test]
+    fn list_config_flags_accepts_format_json() {
+        let cli =
+            FuseCli::try_parse_from(["curvine-fuse", "list-config-flags", "--format", "json"])
+                .unwrap();
+        match cli.cmd {
+            Some(FuseSubcommand::ListConfigFlags(args)) => {
+                assert_eq!(args.format, ListConfigFormat::Json);
+            }
+            _ => panic!("expected list-config-flags subcommand"),
         }
     }
 }

--- a/curvine-fuse/src/cli/list_config_run.rs
+++ b/curvine-fuse/src/cli/list_config_run.rs
@@ -19,11 +19,8 @@ use serde::Serialize;
 use std::collections::BTreeMap;
 
 #[derive(Debug, Serialize, PartialEq, Eq)]
-pub struct CliFlagRecord {
-    pub id: String,
+struct CliFlagRecord {
     pub long: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub short: Option<char>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub help: Option<String>,
     pub required: bool,
@@ -31,8 +28,7 @@ pub struct CliFlagRecord {
 }
 
 #[derive(Debug, Serialize, PartialEq, Eq)]
-pub struct CliFlagsDocument {
-    pub format: String,
+struct CliFlagsDocument {
     pub version: String,
     pub flags: Vec<CliFlagRecord>,
 }
@@ -48,16 +44,13 @@ pub fn run_list_config_flags(args: ListConfigFlagsArgs) -> CommonResult<()> {
     }
 }
 
-pub fn export_cli_flags_json() -> CommonResult<CliFlagsDocument> {
+fn export_cli_flags_json() -> CommonResult<CliFlagsDocument> {
+    let cmd = FuseCli::command();
     let mut by_long = BTreeMap::new();
-    collect_flags(&FuseCli::command(), &mut by_long);
+    collect_flags(&cmd, &mut by_long);
 
     Ok(CliFlagsDocument {
-        format: "json".to_string(),
-        version: FuseCli::command()
-            .get_version()
-            .unwrap_or_default()
-            .to_string(),
+        version: cmd.get_version().unwrap_or_default().to_string(),
         flags: by_long.into_values().collect(),
     })
 }
@@ -72,8 +65,15 @@ fn collect_flags(cmd: &clap::Command, out: &mut BTreeMap<String, CliFlagRecord>)
         }
     }
     for sub in cmd.get_subcommands() {
+        if should_skip_subcommand(sub.get_name()) {
+            continue;
+        }
         collect_flags(sub, out);
     }
+}
+
+fn should_skip_subcommand(name: &str) -> bool {
+    matches!(name, "list-config-flags" | "help")
 }
 
 fn should_skip_arg(arg: &Arg) -> bool {
@@ -84,9 +84,7 @@ fn should_skip_arg(arg: &Arg) -> bool {
 fn flag_record_from_arg(arg: &Arg) -> Option<CliFlagRecord> {
     let long = arg.get_long()?.to_string();
     Some(CliFlagRecord {
-        id: arg.get_id().as_str().to_string(),
         long,
-        short: arg.get_short(),
         help: arg.get_help().map(|h| h.to_string()),
         required: arg.is_required_set(),
         takes_value: arg.get_action().takes_values(),
@@ -120,5 +118,12 @@ mod tests {
         let mut sorted = longs.clone();
         sorted.sort_unstable();
         assert_eq!(longs, sorted);
+    }
+
+    #[test]
+    fn export_omits_list_config_flags_subcommand_args() {
+        let doc = export_cli_flags_json().unwrap();
+        let longs: Vec<_> = doc.flags.iter().map(|f| f.long.as_str()).collect();
+        assert!(!longs.contains(&"format"));
     }
 }

--- a/curvine-fuse/src/cli/list_config_run.rs
+++ b/curvine-fuse/src/cli/list_config_run.rs
@@ -1,0 +1,124 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::cli::fuse_cli::{FuseCli, ListConfigFlagsArgs, ListConfigFormat};
+use clap::{Arg, CommandFactory};
+use orpc::CommonResult;
+use serde::Serialize;
+use std::collections::BTreeMap;
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct CliFlagRecord {
+    pub id: String,
+    pub long: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub short: Option<char>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub help: Option<String>,
+    pub required: bool,
+    pub takes_value: bool,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct CliFlagsDocument {
+    pub format: String,
+    pub version: String,
+    pub flags: Vec<CliFlagRecord>,
+}
+
+/// Exports curvine-fuse CLI flags as JSON for docs/CI (CSI does not embed this at runtime).
+pub fn run_list_config_flags(args: ListConfigFlagsArgs) -> CommonResult<()> {
+    match args.format {
+        ListConfigFormat::Json => {
+            let document = export_cli_flags_json()?;
+            println!("{}", serde_json::to_string_pretty(&document)?);
+            Ok(())
+        }
+    }
+}
+
+pub fn export_cli_flags_json() -> CommonResult<CliFlagsDocument> {
+    let mut by_long = BTreeMap::new();
+    collect_flags(&FuseCli::command(), &mut by_long);
+
+    Ok(CliFlagsDocument {
+        format: "json".to_string(),
+        version: FuseCli::command()
+            .get_version()
+            .unwrap_or_default()
+            .to_string(),
+        flags: by_long.into_values().collect(),
+    })
+}
+
+fn collect_flags(cmd: &clap::Command, out: &mut BTreeMap<String, CliFlagRecord>) {
+    for arg in cmd.get_arguments() {
+        if should_skip_arg(arg) {
+            continue;
+        }
+        if let Some(record) = flag_record_from_arg(arg) {
+            out.entry(record.long.clone()).or_insert(record);
+        }
+    }
+    for sub in cmd.get_subcommands() {
+        collect_flags(sub, out);
+    }
+}
+
+fn should_skip_arg(arg: &Arg) -> bool {
+    let id = arg.get_id().as_str();
+    matches!(id, "help" | "version")
+}
+
+fn flag_record_from_arg(arg: &Arg) -> Option<CliFlagRecord> {
+    let long = arg.get_long()?.to_string();
+    Some(CliFlagRecord {
+        id: arg.get_id().as_str().to_string(),
+        long,
+        short: arg.get_short(),
+        help: arg.get_help().map(|h| h.to_string()),
+        required: arg.is_required_set(),
+        takes_value: arg.get_action().takes_values(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn export_includes_fuse_mount_flags() {
+        let doc = export_cli_flags_json().unwrap();
+        let longs: Vec<_> = doc.flags.iter().map(|f| f.long.as_str()).collect();
+        assert!(longs.contains(&"io-threads"));
+        assert!(longs.contains(&"conf"));
+        assert!(longs.contains(&"master-addrs"));
+    }
+
+    #[test]
+    fn export_deduplicates_shared_mount_flags() {
+        let doc = export_cli_flags_json().unwrap();
+        let io_threads = doc.flags.iter().filter(|f| f.long == "io-threads").count();
+        assert_eq!(io_threads, 1);
+    }
+
+    #[test]
+    fn export_is_sorted_by_long_name() {
+        let doc = export_cli_flags_json().unwrap();
+        let longs: Vec<_> = doc.flags.iter().map(|f| f.long.as_str()).collect();
+        let mut sorted = longs.clone();
+        sorted.sort_unstable();
+        assert_eq!(longs, sorted);
+    }
+}

--- a/curvine-fuse/src/cli/mod.rs
+++ b/curvine-fuse/src/cli/mod.rs
@@ -13,11 +13,15 @@
 // limitations under the License.
 
 mod fuse_cli;
+mod list_config_run;
 mod mount_args;
 mod mount_run;
 mod validate_run;
 
-pub use fuse_cli::{FuseCli, FuseSubcommand};
+pub use fuse_cli::{FuseCli, FuseSubcommand, ListConfigFlagsArgs, ListConfigFormat};
+pub use list_config_run::{
+    export_cli_flags_json, run_list_config_flags, CliFlagRecord, CliFlagsDocument,
+};
 pub use mount_args::FuseMountArgs;
 pub use mount_run::run_mount;
 pub use validate_run::run_validate_config;

--- a/curvine-fuse/src/cli/mod.rs
+++ b/curvine-fuse/src/cli/mod.rs
@@ -19,9 +19,7 @@ mod mount_run;
 mod validate_run;
 
 pub use fuse_cli::{FuseCli, FuseSubcommand, ListConfigFlagsArgs, ListConfigFormat};
-pub use list_config_run::{
-    export_cli_flags_json, run_list_config_flags, CliFlagRecord, CliFlagsDocument,
-};
+pub use list_config_run::run_list_config_flags;
 pub use mount_args::FuseMountArgs;
 pub use mount_run::run_mount;
 pub use validate_run::run_validate_config;


### PR DESCRIPTION
## Summary

Implements #865 Track C (C10): `curvine-fuse list-config-flags --format json` exports mount-related CLI flags from `FuseCli` via clap `CommandFactory`.

**JSON schema:** `{ "version": "...", "flags": [{ "long", "help", "required", "takes_value" }] }`

- Sorted, deduplicated mount flags only (skips `list-config-flags` / `help` subcommand args)
- For docs/CI only; CSI does not embed at runtime
- `--client.*` flags will appear automatically after **C11** flattens `ClientCliOverrides`

## Test plan

- [x] `make format`
- [x] `cargo test -p curvine-fuse --release`
- [ ] CI green

Refs #865
