### PR TITLE
feat(fuse): flatten ClientConf CLI overrides at top level (C11)

### DIFF
--- a/curvine-common/macros/src/client_cli.rs
+++ b/curvine-common/macros/src/client_cli.rs
@@ -67,12 +67,13 @@ fn derive_client_cli_args_impl(input: &DeriveInput) -> syn::Result<TokenStream2>
             .expect("named field must have an identifier");
         validate_cli_field_type(field)?;
         let long = cli_long_name(field, &container)?;
+        let arg_id = cli_arg_id(ident, &container);
         let field_is_option = unwrap_option_type(&field.ty).is_some();
         let inner_ty = unwrap_option_type(&field.ty).unwrap_or(&field.ty);
         let ty = quote! { Option<#inner_ty> };
 
         override_fields.push(quote! {
-            #[arg(long = #long)]
+            #[arg(long = #long, id = #arg_id)]
             pub #ident: #ty,
         });
         apply_stmts.push(apply_override_stmt(ident, inner_ty, field_is_option)?);
@@ -256,6 +257,14 @@ fn cli_long_name(field: &Field, container: &ContainerConfig) -> syn::Result<Stri
         Ok(format!("{prefix}.{kebab}"))
     } else {
         Ok(kebab)
+    }
+}
+
+fn cli_arg_id(ident: &syn::Ident, container: &ContainerConfig) -> String {
+    if let Some(prefix) = &container.prefix {
+        format!("{prefix}_{ident}")
+    } else {
+        ident.to_string()
     }
 }
 

--- a/curvine-common/tests/client_conf_cli_test.rs
+++ b/curvine-common/tests/client_conf_cli_test.rs
@@ -218,6 +218,35 @@ fn apply_to_updates_c6_fields() {
 }
 
 #[test]
+fn client_cli_flags_parse_alongside_mount_io_threads() {
+    #[derive(Debug, Parser)]
+    struct MountLikeArgs {
+        #[arg(long)]
+        pub io_threads: Option<usize>,
+    }
+
+    #[derive(Debug, Parser)]
+    struct FlattenHarness {
+        #[command(flatten)]
+        mount: MountLikeArgs,
+        #[command(flatten)]
+        client: ClientConfCliOverrides,
+    }
+
+    let parsed = FlattenHarness::try_parse_from([
+        "curvine-fuse",
+        "--io-threads",
+        "4",
+        "--client.io-threads",
+        "9",
+    ])
+    .unwrap();
+
+    assert_eq!(parsed.mount.io_threads, Some(4));
+    assert_eq!(parsed.client.io_threads, Some(9));
+}
+
+#[test]
 fn rejects_skipped_client_cli_fields() {
     let err = CliHarness::try_parse_from(["curvine-fuse", "--client.default-cache-ttl", "7d"])
         .unwrap_err();

--- a/curvine-fuse/src/bin/curvine-fuse.rs
+++ b/curvine-fuse/src/bin/curvine-fuse.rs
@@ -24,8 +24,8 @@ use orpc::CommonResult;
 fn main() -> CommonResult<()> {
     let cli = FuseCli::parse();
     match &cli.cmd {
-        None | Some(FuseSubcommand::Mount(_)) => run_mount(cli.resolve_mount_args()),
-        Some(FuseSubcommand::ValidateConfig(_)) => run_validate_config(cli.resolve_validate_args()),
+        None | Some(FuseSubcommand::Mount(_)) => run_mount(cli.resolve_runtime_args()),
+        Some(FuseSubcommand::ValidateConfig(_)) => run_validate_config(cli.resolve_runtime_args()),
         Some(FuseSubcommand::ListConfigFlags(args)) => run_list_config_flags(args.clone()),
     }
 }

--- a/curvine-fuse/src/cli/fuse_cli.rs
+++ b/curvine-fuse/src/cli/fuse_cli.rs
@@ -13,9 +13,10 @@
 // limitations under the License.
 
 use clap::{Parser, Subcommand, ValueEnum};
+use curvine_common::conf::ClientConfCliOverrides;
 use curvine_common::version;
 
-use crate::cli::mount_args::FuseMountArgs;
+use crate::cli::mount_args::{FuseMountArgs, FuseRuntimeArgs};
 
 /// Output format for `list-config-flags`.
 #[derive(Debug, Clone, Copy, Default, ValueEnum, PartialEq, Eq)]
@@ -45,14 +46,17 @@ pub struct FuseCli {
 
     #[command(flatten)]
     pub mount: FuseMountArgs,
+
+    #[command(flatten)]
+    pub client: ClientConfCliOverrides,
 }
 
 #[derive(Debug, Clone, Subcommand)]
 pub enum FuseSubcommand {
     /// Mount the curvine filesystem (also the default when omitted)
-    Mount(FuseMountArgs),
+    Mount(FuseRuntimeArgs),
     /// Validate configuration without mounting
-    ValidateConfig(FuseMountArgs),
+    ValidateConfig(FuseRuntimeArgs),
     /// List mount-related CLI flags as JSON for docs and CI
     ListConfigFlags(ListConfigFlagsArgs),
 }
@@ -63,30 +67,18 @@ impl FuseCli {
         matches!(self.cmd, None | Some(FuseSubcommand::Mount(_)))
     }
 
-    /// Returns mount args from the subcommand when present, otherwise top-level flags.
-    pub fn resolve_mount_args(&self) -> FuseMountArgs {
+    /// Returns runtime args from the subcommand when present, otherwise top-level flags.
+    pub fn resolve_runtime_args(&self) -> FuseRuntimeArgs {
         match &self.cmd {
-            Some(FuseSubcommand::Mount(args)) => args.clone(),
-            None => self.mount.clone(),
-            Some(FuseSubcommand::ValidateConfig(_)) => {
-                unreachable!("resolve_mount_args called for validate-config")
+            Some(FuseSubcommand::Mount(args)) | Some(FuseSubcommand::ValidateConfig(args)) => {
+                args.clone()
             }
+            None => FuseRuntimeArgs {
+                mount: self.mount.clone(),
+                client: self.client.clone(),
+            },
             Some(FuseSubcommand::ListConfigFlags(_)) => {
-                unreachable!("resolve_mount_args called for list-config-flags")
-            }
-        }
-    }
-
-    /// Returns args for validate-config, from the subcommand or top-level flags.
-    pub fn resolve_validate_args(&self) -> FuseMountArgs {
-        match &self.cmd {
-            Some(FuseSubcommand::ValidateConfig(args)) => args.clone(),
-            None => self.mount.clone(),
-            Some(FuseSubcommand::Mount(_)) => {
-                unreachable!("resolve_validate_args called for mount")
-            }
-            Some(FuseSubcommand::ListConfigFlags(_)) => {
-                unreachable!("resolve_validate_args called for list-config-flags")
+                unreachable!("resolve_runtime_args called for list-config-flags")
             }
         }
     }
@@ -100,15 +92,69 @@ mod tests {
     fn bare_invocation_preserves_top_level_flags() {
         let cli = FuseCli::try_parse_from(["curvine-fuse", "--io-threads", "4"]).unwrap();
         assert!(cli.cmd.is_none());
-        let args = cli.resolve_mount_args();
-        assert_eq!(args.io_threads, Some(4));
+        let args = cli.resolve_runtime_args();
+        assert_eq!(args.mount.io_threads, Some(4));
+    }
+
+    #[test]
+    fn client_overrides_parse_in_isolation() {
+        #[derive(Parser)]
+        struct Harness {
+            #[command(flatten)]
+            client: ClientConfCliOverrides,
+        }
+        let parsed = Harness::try_parse_from(["curvine-fuse", "--client.io-threads", "9"]).unwrap();
+        assert_eq!(parsed.client.io_threads, Some(9));
+    }
+
+    #[test]
+    fn bare_invocation_parses_client_cli_flags() {
+        let cli = FuseCli::try_parse_from([
+            "curvine-fuse",
+            "--client.io-threads=9",
+            "--client.block-size=64KB",
+        ])
+        .unwrap();
+        assert_eq!(cli.client.io_threads, Some(9));
+        assert_eq!(cli.client.block_size_str.as_deref(), Some("64KB"));
+        let args = cli.resolve_runtime_args();
+        assert_eq!(args.client.io_threads, Some(9));
+        assert_eq!(args.client.block_size_str.as_deref(), Some("64KB"));
+    }
+
+    #[test]
+    fn validate_config_subcommand_parses_client_flags() {
+        let cli = FuseCli::try_parse_from([
+            "curvine-fuse",
+            "validate-config",
+            "--conf",
+            "conf/curvine-cluster.toml",
+            "--client.read-parallel",
+            "3",
+        ])
+        .unwrap();
+        match cli.cmd {
+            Some(FuseSubcommand::ValidateConfig(args)) => {
+                assert_eq!(args.client.read_parallel, Some(3));
+            }
+            _ => panic!("expected validate-config subcommand"),
+        }
+    }
+
+    #[test]
+    fn runtime_args_apply_client_overrides_to_conf() {
+        let args = FuseCli::try_parse_from(["curvine-fuse", "--client.io-threads", "12"])
+            .unwrap()
+            .resolve_runtime_args();
+        let conf = args.get_conf().unwrap();
+        assert_eq!(conf.client.io_threads, 12);
     }
 
     #[test]
     fn mount_subcommand_preserves_flags() {
         let cli = FuseCli::try_parse_from(["curvine-fuse", "mount", "--io-threads", "8"]).unwrap();
-        let args = cli.resolve_mount_args();
-        assert_eq!(args.io_threads, Some(8));
+        let args = cli.resolve_runtime_args();
+        assert_eq!(args.mount.io_threads, Some(8));
     }
 
     #[test]

--- a/curvine-fuse/src/cli/list_config_run.rs
+++ b/curvine-fuse/src/cli/list_config_run.rs
@@ -121,6 +121,13 @@ mod tests {
     }
 
     #[test]
+    fn export_includes_client_cli_flags() {
+        let doc = export_cli_flags_json().unwrap();
+        let longs: Vec<_> = doc.flags.iter().map(|f| f.long.as_str()).collect();
+        assert!(longs.iter().any(|long| long.starts_with("client.")));
+    }
+
+    #[test]
     fn export_omits_list_config_flags_subcommand_args() {
         let doc = export_cli_flags_json().unwrap();
         let longs: Vec<_> = doc.flags.iter().map(|f| f.long.as_str()).collect();

--- a/curvine-fuse/src/cli/mod.rs
+++ b/curvine-fuse/src/cli/mod.rs
@@ -20,6 +20,6 @@ mod validate_run;
 
 pub use fuse_cli::{FuseCli, FuseSubcommand, ListConfigFlagsArgs, ListConfigFormat};
 pub use list_config_run::run_list_config_flags;
-pub use mount_args::FuseMountArgs;
+pub use mount_args::{FuseMountArgs, FuseRuntimeArgs};
 pub use mount_run::run_mount;
 pub use validate_run::run_validate_config;

--- a/curvine-fuse/src/cli/mount_args.rs
+++ b/curvine-fuse/src/cli/mount_args.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use clap::Parser;
-use curvine_common::conf::ClusterConf;
+use curvine_common::conf::{ClientConfCliOverrides, ClusterConf};
 use curvine_common::version;
 use orpc::io::net::InetAddr;
 use orpc::{err_box, CommonResult};
@@ -145,6 +145,26 @@ pub struct FuseMountArgs {
         help = "Maximum number of entries returned per directory listing (optional)"
     )]
     pub list_limit: Option<usize>,
+}
+
+/// Mount CLI flags plus generated `ClientConf` overrides (`--client.*`).
+#[derive(Debug, Parser, Clone)]
+pub struct FuseRuntimeArgs {
+    #[command(flatten)]
+    pub mount: FuseMountArgs,
+
+    #[command(flatten)]
+    pub client: ClientConfCliOverrides,
+}
+
+impl FuseRuntimeArgs {
+    /// Loads cluster config from mount flags and applies `--client.*` overrides.
+    pub fn get_conf(&self) -> CommonResult<ClusterConf> {
+        let mut conf = self.mount.get_conf()?;
+        self.client.apply_to(&mut conf.client)?;
+        conf.client.init()?;
+        Ok(conf)
+    }
 }
 
 impl FuseMountArgs {

--- a/curvine-fuse/src/cli/mount_run.rs
+++ b/curvine-fuse/src/cli/mount_run.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::cli::FuseMountArgs;
+use crate::cli::FuseRuntimeArgs;
 use crate::fs::CurvineFileSystem;
 use crate::session::FuseSession;
 use crate::web_server::WebServer;
@@ -22,7 +22,7 @@ use orpc::CommonResult;
 use std::sync::Arc;
 
 /// Runs the default mount command using the given CLI arguments.
-pub fn run_mount(args: FuseMountArgs) -> CommonResult<()> {
+pub fn run_mount(args: FuseRuntimeArgs) -> CommonResult<()> {
     println!("fuse args {:?}", args);
 
     unsafe {

--- a/curvine-fuse/src/cli/mount_run.rs
+++ b/curvine-fuse/src/cli/mount_run.rs
@@ -23,8 +23,6 @@ use std::sync::Arc;
 
 /// Runs the default mount command using the given CLI arguments.
 pub fn run_mount(args: FuseRuntimeArgs) -> CommonResult<()> {
-    println!("fuse args {:?}", args);
-
     unsafe {
         libc::signal(libc::SIGPIPE, libc::SIG_IGN);
     }

--- a/curvine-fuse/src/cli/validate_run.rs
+++ b/curvine-fuse/src/cli/validate_run.rs
@@ -12,13 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::cli::FuseMountArgs;
+use crate::cli::FuseRuntimeArgs;
 use orpc::CommonResult;
 
 /// Validates configuration by loading and initializing cluster settings without mounting.
 /// Exits quietly on success; failures are returned via `CommonResult` for stderr reporting.
-pub fn run_validate_config(args: FuseMountArgs) -> CommonResult<()> {
-    let mut conf = args.get_conf()?;
-    conf.client.init()?;
+pub fn run_validate_config(args: FuseRuntimeArgs) -> CommonResult<()> {
+    let _conf = args.get_conf()?;
     Ok(())
 }

--- a/curvine-fuse/src/cli/validate_run.rs
+++ b/curvine-fuse/src/cli/validate_run.rs
@@ -18,6 +18,6 @@ use orpc::CommonResult;
 /// Validates configuration by loading and initializing cluster settings without mounting.
 /// Exits quietly on success; failures are returned via `CommonResult` for stderr reporting.
 pub fn run_validate_config(args: FuseRuntimeArgs) -> CommonResult<()> {
-    let _conf = args.get_conf()?;
+    args.get_conf()?;
     Ok(())
 }


### PR DESCRIPTION
## Problem
C11 requires `--client.*` flags on top-level `curvine-fuse -h` and wiring through
`get_conf()`. After C6, client overrides only worked on subcommands or in
isolation; bare invocations like `--client.io-threads` did not apply.

## Design
Introduce `FuseRuntimeArgs` (mount + client flatten) for mount/validate-config
flows and flatten `ClientConfCliOverrides` at the top-level `FuseCli` as well.
Assign unique clap arg ids (`client_io_threads`, etc.) for prefixed client
flags so they do not collide with mount flags that share field names.

## Key Changes
- Add `FuseRuntimeArgs` and route mount/validate through `get_conf()` with
  `client.apply_to()` + `client.init()`
- Flatten `ClientConfCliOverrides` on `FuseCli` for default mount invocations
- Fix `ClientCliArgs` macro to emit `id = client_<field>` for prefixed flags
- Add regression tests for flatten id collision and fuse CLI parsing

Refs #865
