### PR TITLE
feat(csi): validator cleanup and validate-config integration (C15-C17)

### DIFF
--- a/curvine-csi/Dockerfile
+++ b/curvine-csi/Dockerfile
@@ -115,6 +115,7 @@ RUN mkdir -p /opt/curvine
 COPY --from=builder /build-output/lib/curvine-cli /opt/curvine/
 COPY --from=builder /build-output/lib/curvine-fuse /opt/curvine/
 COPY --from=builder /build-output/bin/csi /opt/curvine/
+COPY --from=builder /build-output/conf/ /opt/curvine/conf/
 
 # Make binaries executable
 RUN chmod +x /opt/curvine/curvine-cli && \

--- a/curvine-csi/pkg/csi/controller.go
+++ b/curvine-csi/pkg/csi/controller.go
@@ -82,6 +82,13 @@ func (d *controllerService) CreateVolume(ctx context.Context, request *csi.Creat
 		return nil, err
 	}
 
+	validateCtx, cancel := context.WithTimeout(ctx, fuseValidateTimeout())
+	defer cancel()
+	if err := ValidateFuseParameters(validateCtx, params.MasterAddrs, params.FSPath, params.Passthrough); err != nil {
+		klog.Errorf("RequestID: %s, validate-config failed: %v", requestID, err)
+		return nil, status.Errorf(codes.InvalidArgument, "invalid StorageClass parameters: %v", err)
+	}
+
 	// Generate VolumeHandle: {cluster-id}@{fs-path}@{pv-name}
 	pvName := request.Name
 	volumeHandle := GenerateVolumeHandle(params.MasterAddrs, params.FSPath, pvName)

--- a/curvine-csi/pkg/csi/controller.go
+++ b/curvine-csi/pkg/csi/controller.go
@@ -86,7 +86,7 @@ func (d *controllerService) CreateVolume(ctx context.Context, request *csi.Creat
 	defer cancel()
 	if err := ValidateFuseParameters(validateCtx, params.MasterAddrs, params.FSPath, params.Passthrough); err != nil {
 		klog.Errorf("RequestID: %s, validate-config failed: %v", requestID, err)
-		return nil, status.Errorf(codes.InvalidArgument, "invalid StorageClass parameters: %v", err)
+		return nil, StatusFromValidateConfigError(err)
 	}
 
 	// Generate VolumeHandle: {cluster-id}@{fs-path}@{pv-name}

--- a/curvine-csi/pkg/csi/fuse_validate.go
+++ b/curvine-csi/pkg/csi/fuse_validate.go
@@ -17,16 +17,29 @@ package csi
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"strings"
 	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 const (
 	defaultFuseConfPath = "/opt/curvine/conf/curvine-cluster.toml"
 )
+
+// ValidateConfigError indicates validate-config rejected the supplied parameters.
+type ValidateConfigError struct {
+	Stderr string
+}
+
+func (e *ValidateConfigError) Error() string {
+	return e.Stderr
+}
 
 // ResolveFuseBinaryPath returns the curvine-fuse binary path from env or driver defaults.
 func ResolveFuseBinaryPath() string {
@@ -65,7 +78,9 @@ func ValidateFuseParameters(ctx context.Context, masterAddrs, fsPath string, pas
 	})
 }
 
-// ExecFuseValidateConfig executes curvine-fuse validate-config and returns stderr on failure.
+// ExecFuseValidateConfig executes curvine-fuse validate-config.
+// Non-zero exits are returned as *ValidateConfigError with stderr text; other
+// failures preserve their original error type for gRPC code mapping.
 func ExecFuseValidateConfig(ctx context.Context, in FuseExecArgsInput) error {
 	in.Subcommand = "validate-config"
 	if in.ConfPath == "" {
@@ -79,13 +94,39 @@ func ExecFuseValidateConfig(ctx context.Context, in FuseExecArgsInput) error {
 	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {
-		msg := strings.TrimSpace(stderr.String())
-		if msg == "" {
-			msg = err.Error()
+		stderrMsg := strings.TrimSpace(stderr.String())
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			if stderrMsg == "" {
+				stderrMsg = err.Error()
+			}
+			return &ValidateConfigError{Stderr: stderrMsg}
 		}
-		return fmt.Errorf("%s", msg)
+		if stderrMsg != "" {
+			return fmt.Errorf("%s: %w", stderrMsg, err)
+		}
+		return err
 	}
 	return nil
+}
+
+// StatusFromValidateConfigError maps validate-config failures to gRPC status codes.
+func StatusFromValidateConfigError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	var paramErr *ValidateConfigError
+	if errors.As(err, &paramErr) {
+		return status.Errorf(codes.InvalidArgument, "invalid fuse configuration: %s", paramErr.Stderr)
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return status.Errorf(codes.DeadlineExceeded, "validate-config timed out: %v", err)
+	}
+	if errors.Is(err, context.Canceled) {
+		return status.Errorf(codes.Canceled, "validate-config canceled: %v", err)
+	}
+	return status.Errorf(codes.Internal, "validate-config failed: %v", err)
 }
 
 // fuseValidateTimeout returns the timeout for validate-config subprocess calls.

--- a/curvine-csi/pkg/csi/fuse_validate.go
+++ b/curvine-csi/pkg/csi/fuse_validate.go
@@ -94,6 +94,9 @@ func ExecFuseValidateConfig(ctx context.Context, in FuseExecArgsInput) error {
 	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {
+		if ctxErr := context.Cause(ctx); ctxErr != nil {
+			return ctxErr
+		}
 		stderrMsg := strings.TrimSpace(stderr.String())
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {

--- a/curvine-csi/pkg/csi/fuse_validate.go
+++ b/curvine-csi/pkg/csi/fuse_validate.go
@@ -1,0 +1,98 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package csi
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const (
+	defaultFuseConfPath = "/opt/curvine/conf/curvine-cluster.toml"
+)
+
+// ResolveFuseBinaryPath returns the curvine-fuse binary path from env or driver defaults.
+func ResolveFuseBinaryPath() string {
+	if path := os.Getenv("FUSE_BINARY_PATH"); path != "" {
+		return path
+	}
+	return DefaultConfig().FuseBinaryPath
+}
+
+// ResolveFuseConfPath returns the cluster config path passed to curvine-fuse.
+func ResolveFuseConfPath() string {
+	if path := os.Getenv("FUSE_CONF_PATH"); path != "" {
+		return path
+	}
+	return defaultFuseConfPath
+}
+
+// IsStaticVolumeID reports whether the volume ID does not use the dynamic
+// {cluster-id}@{fs-path}@{pv-name} format produced by CreateVolume.
+func IsStaticVolumeID(volumeID string) bool {
+	_, err := ParseVolumeHandle(volumeID)
+	return err != nil
+}
+
+// ValidateFuseParameters runs curvine-fuse validate-config with the same argv
+// shape used for mount, minus mnt-path (not required for config dry-run).
+func ValidateFuseParameters(ctx context.Context, masterAddrs, fsPath string, passthrough map[string]string) error {
+	if fsPath == "" {
+		fsPath = "/"
+	}
+	return ExecFuseValidateConfig(ctx, FuseExecArgsInput{
+		ConfPath:    ResolveFuseConfPath(),
+		MasterAddrs: masterAddrs,
+		FSPath:      fsPath,
+		Passthrough: passthrough,
+	})
+}
+
+// ExecFuseValidateConfig executes curvine-fuse validate-config and returns stderr on failure.
+func ExecFuseValidateConfig(ctx context.Context, in FuseExecArgsInput) error {
+	in.Subcommand = "validate-config"
+	if in.ConfPath == "" {
+		in.ConfPath = ResolveFuseConfPath()
+	}
+
+	args := BuildFuseExecArgs(in)
+	cmd := exec.CommandContext(ctx, ResolveFuseBinaryPath(), args...)
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		return fmt.Errorf("%s", msg)
+	}
+	return nil
+}
+
+// fuseValidateTimeout returns the timeout for validate-config subprocess calls.
+func fuseValidateTimeout() time.Duration {
+	seconds := DefaultConfig().CommandTimeout
+	if seconds <= 0 {
+		seconds = 30
+	}
+	return time.Duration(seconds) * time.Second
+}

--- a/curvine-csi/pkg/csi/fuse_validate_test.go
+++ b/curvine-csi/pkg/csi/fuse_validate_test.go
@@ -1,0 +1,58 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package csi
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestBuildFuseValidateExecArgs(t *testing.T) {
+	args := BuildFuseExecArgs(FuseExecArgsInput{
+		Subcommand:  "validate-config",
+		ConfPath:    "/opt/curvine/conf/curvine-cluster.toml",
+		MasterAddrs: "m1:8995",
+		FSPath:      "/data",
+		Passthrough: map[string]string{
+			"io-threads":        "4",
+			"client.block-size": "128MB",
+		},
+	})
+	want := []string{
+		"validate-config",
+		"--conf", "/opt/curvine/conf/curvine-cluster.toml",
+		"--master-addrs", "m1:8995",
+		"--fs-path", "/data",
+		"--client.block-size", "128MB",
+		"--io-threads", "4",
+	}
+	if !reflect.DeepEqual(args, want) {
+		t.Fatalf("BuildFuseExecArgs() = %#v, want %#v", args, want)
+	}
+}
+
+func TestResolveFuseBinaryPathDefaults(t *testing.T) {
+	t.Setenv("FUSE_BINARY_PATH", "")
+	if got := ResolveFuseBinaryPath(); got != DefaultConfig().FuseBinaryPath {
+		t.Fatalf("ResolveFuseBinaryPath() = %q, want default %q", got, DefaultConfig().FuseBinaryPath)
+	}
+}
+
+func TestResolveFuseConfPathEnvOverride(t *testing.T) {
+	t.Setenv("FUSE_CONF_PATH", "/custom/conf.toml")
+	if got := ResolveFuseConfPath(); got != "/custom/conf.toml" {
+		t.Fatalf("ResolveFuseConfPath() = %q, want env override", got)
+	}
+}

--- a/curvine-csi/pkg/csi/fuse_validate_test.go
+++ b/curvine-csi/pkg/csi/fuse_validate_test.go
@@ -15,8 +15,14 @@
 package csi
 
 import (
+	"context"
+	"errors"
+	"os/exec"
 	"reflect"
 	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestBuildFuseValidateExecArgs(t *testing.T) {
@@ -54,5 +60,54 @@ func TestResolveFuseConfPathEnvOverride(t *testing.T) {
 	t.Setenv("FUSE_CONF_PATH", "/custom/conf.toml")
 	if got := ResolveFuseConfPath(); got != "/custom/conf.toml" {
 		t.Fatalf("ResolveFuseConfPath() = %q, want env override", got)
+	}
+}
+
+func TestStatusFromValidateConfigErrorMapsExitToInvalidArgument(t *testing.T) {
+	err := StatusFromValidateConfigError(&ValidateConfigError{Stderr: "unknown flag"})
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status, got %v", err)
+	}
+	if st.Code() != codes.InvalidArgument {
+		t.Fatalf("expected InvalidArgument, got %v", st.Code())
+	}
+}
+
+func TestStatusFromValidateConfigErrorMapsDeadlineExceeded(t *testing.T) {
+	err := StatusFromValidateConfigError(context.DeadlineExceeded)
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status, got %v", err)
+	}
+	if st.Code() != codes.DeadlineExceeded {
+		t.Fatalf("expected DeadlineExceeded, got %v", st.Code())
+	}
+}
+
+func TestStatusFromValidateConfigErrorMapsMissingBinaryToInternal(t *testing.T) {
+	err := StatusFromValidateConfigError(&exec.Error{Name: "curvine-fuse", Err: exec.ErrNotFound})
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status, got %v", err)
+	}
+	if st.Code() != codes.Internal {
+		t.Fatalf("expected Internal, got %v", st.Code())
+	}
+}
+
+func TestExecFuseValidateConfigPreservesExitErrorType(t *testing.T) {
+	t.Setenv("FUSE_BINARY_PATH", "/nonexistent/curvine-fuse-binary")
+	ctx := context.Background()
+	err := ExecFuseValidateConfig(ctx, FuseExecArgsInput{
+		MasterAddrs: "m1:8995",
+		FSPath:      "/",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing binary")
+	}
+	var paramErr *ValidateConfigError
+	if errors.As(err, &paramErr) {
+		t.Fatal("expected infrastructure error, not ValidateConfigError")
 	}
 }

--- a/curvine-csi/pkg/csi/fuse_validate_test.go
+++ b/curvine-csi/pkg/csi/fuse_validate_test.go
@@ -20,6 +20,7 @@ import (
 	"os/exec"
 	"reflect"
 	"testing"
+	"time"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -93,6 +94,35 @@ func TestStatusFromValidateConfigErrorMapsMissingBinaryToInternal(t *testing.T) 
 	}
 	if st.Code() != codes.Internal {
 		t.Fatalf("expected Internal, got %v", st.Code())
+	}
+}
+
+func TestExecFuseValidateConfigMapsSubprocessKillToDeadlineExceeded(t *testing.T) {
+	if _, err := exec.LookPath("yes"); err != nil {
+		t.Skip("yes not available")
+	}
+
+	t.Setenv("FUSE_BINARY_PATH", "yes")
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	err := ExecFuseValidateConfig(ctx, FuseExecArgsInput{
+		MasterAddrs: "m1:8995",
+		FSPath:      "/",
+	})
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context.DeadlineExceeded, got %T: %v", err, err)
+	}
+
+	st, ok := status.FromError(StatusFromValidateConfigError(err))
+	if !ok {
+		t.Fatalf("expected gRPC status, got %v", err)
+	}
+	if st.Code() != codes.DeadlineExceeded {
+		t.Fatalf("expected DeadlineExceeded, got %v", st.Code())
 	}
 }
 

--- a/curvine-csi/pkg/csi/node.go
+++ b/curvine-csi/pkg/csi/node.go
@@ -142,7 +142,7 @@ func (n *nodeService) NodeStageVolume(ctx context.Context, request *csi.NodeStag
 		defer cancel()
 		if err := ValidateFuseParameters(validateCtx, masterAddrs, fsPathToMount, fuseParams); err != nil {
 			klog.Errorf("RequestID: %s, validate-config failed for static PV: %v", requestID, err)
-			return nil, status.Errorf(codes.InvalidArgument, "invalid volume parameters: %v", err)
+			return nil, StatusFromValidateConfigError(err)
 		}
 	}
 

--- a/curvine-csi/pkg/csi/node.go
+++ b/curvine-csi/pkg/csi/node.go
@@ -137,6 +137,15 @@ func (n *nodeService) NodeStageVolume(ctx context.Context, request *csi.NodeStag
 	// Collect FUSE parameters from VolumeContext or PublishContext
 	fuseParams := CollectPassthroughParams(volumeContext, publishContext)
 
+	if IsStaticVolumeID(volumeID) {
+		validateCtx, cancel := context.WithTimeout(ctx, fuseValidateTimeout())
+		defer cancel()
+		if err := ValidateFuseParameters(validateCtx, masterAddrs, fsPathToMount, fuseParams); err != nil {
+			klog.Errorf("RequestID: %s, validate-config failed for static PV: %v", requestID, err)
+			return nil, status.Errorf(codes.InvalidArgument, "invalid volume parameters: %v", err)
+		}
+	}
+
 	// Generate mnt-path based on mount-key (master-addrs + fs-path + fuse-params)
 	// Including fuse params ensures that StorageClasses with the same cluster endpoint
 	// and fs-path but different FUSE parameters each get their own mount point and FUSE process.

--- a/curvine-csi/pkg/csi/node_standalone.go
+++ b/curvine-csi/pkg/csi/node_standalone.go
@@ -148,7 +148,7 @@ func (n *nodeServiceStandalone) NodeStageVolume(ctx context.Context, request *cs
 		defer cancel()
 		if err := ValidateFuseParameters(validateCtx, masterAddrs, fsPathToMount, fuseParams); err != nil {
 			klog.Errorf("RequestID: %s, validate-config failed for static PV: %v", requestID, err)
-			return nil, status.Errorf(codes.InvalidArgument, "invalid volume parameters: %v", err)
+			return nil, StatusFromValidateConfigError(err)
 		}
 	}
 

--- a/curvine-csi/pkg/csi/node_standalone.go
+++ b/curvine-csi/pkg/csi/node_standalone.go
@@ -143,6 +143,15 @@ func (n *nodeServiceStandalone) NodeStageVolume(ctx context.Context, request *cs
 	// Collect FUSE parameters from VolumeContext or PublishContext
 	fuseParams := CollectPassthroughParams(volumeContext, publishContext)
 
+	if IsStaticVolumeID(volumeID) {
+		validateCtx, cancel := context.WithTimeout(ctx, fuseValidateTimeout())
+		defer cancel()
+		if err := ValidateFuseParameters(validateCtx, masterAddrs, fsPathToMount, fuseParams); err != nil {
+			klog.Errorf("RequestID: %s, validate-config failed for static PV: %v", requestID, err)
+			return nil, status.Errorf(codes.InvalidArgument, "invalid volume parameters: %v", err)
+		}
+	}
+
 	// Generate mount-key from master-addrs + fs-path + fuse-params
 	// Including fuse params ensures that StorageClasses with the same cluster endpoint
 	// and fs-path but different FUSE parameters each receive their own standalone pod.

--- a/curvine-csi/pkg/csi/validator.go
+++ b/curvine-csi/pkg/csi/validator.go
@@ -53,7 +53,7 @@ func ValidateStorageClassParams(params map[string]string, requestID string) (*St
 		fsPath = "/"
 		klog.Infof("RequestID: %s, fs-path not specified, using default: /", requestID)
 	}
-	if err := ValidatePath(fsPath); err != nil {
+	if err := ValidateFSPath(fsPath); err != nil {
 		klog.Errorf("RequestID: %s, Invalid fs-path: %v", requestID, err)
 		return nil, status.Errorf(codes.InvalidArgument, "Invalid fs-path: %v", err)
 	}
@@ -112,5 +112,16 @@ func ValidateMasterAddrs(masterAddrs string) error {
 		}
 	}
 
+	return nil
+}
+
+// ValidateFSPath validates fs-path for volume handle generation and mount usage.
+func ValidateFSPath(fsPath string) error {
+	if err := ValidatePath(fsPath); err != nil {
+		return err
+	}
+	if strings.Contains(fsPath, VolumeHandleSeparator) {
+		return fmt.Errorf("fs-path must not contain %q", VolumeHandleSeparator)
+	}
 	return nil
 }

--- a/curvine-csi/pkg/csi/validator.go
+++ b/curvine-csi/pkg/csi/validator.go
@@ -24,23 +24,20 @@ import (
 	"k8s.io/klog"
 )
 
-// StorageClassParams represents validated StorageClass parameters
+// StorageClassParams represents validated StorageClass parameters.
 type StorageClassParams struct {
 	MasterAddrs string
-	MntPath     string
 	FSPath      string
 	PathType    string
-	// Optional FUSE parameters
-	FuseParams map[string]string
+	Passthrough map[string]string
 }
 
-// ValidateStorageClassParams validates StorageClass parameters
+// ValidateStorageClassParams validates StorageClass parameters.
 func ValidateStorageClassParams(params map[string]string, requestID string) (*StorageClassParams, error) {
-	validated := &StorageClassParams{
-		FuseParams: make(map[string]string),
+	if err := RejectDisallowedVolumeParameters(params, nil, requestID); err != nil {
+		return nil, err
 	}
 
-	// Validate master-addrs (required) - must validate first as it's needed for mnt-path generation
 	masterAddrs, ok := params["master-addrs"]
 	if !ok || masterAddrs == "" {
 		klog.Errorf("RequestID: %s, Parameter 'master-addrs' is required", requestID)
@@ -50,9 +47,7 @@ func ValidateStorageClassParams(params map[string]string, requestID string) (*St
 		klog.Errorf("RequestID: %s, Invalid master-addrs format: %v", requestID, err)
 		return nil, status.Errorf(codes.InvalidArgument, "Invalid master-addrs format: %v", err)
 	}
-	validated.MasterAddrs = masterAddrs
 
-	// Validate fs-path first (needed for mnt-path generation)
 	fsPath, ok := params["fs-path"]
 	if !ok || fsPath == "" {
 		fsPath = "/"
@@ -62,24 +57,7 @@ func ValidateStorageClassParams(params map[string]string, requestID string) (*St
 		klog.Errorf("RequestID: %s, Invalid fs-path: %v", requestID, err)
 		return nil, status.Errorf(codes.InvalidArgument, "Invalid fs-path: %v", err)
 	}
-	validated.FSPath = fsPath
 
-	fuseParams := CollectPassthroughParams(params, nil)
-	for key := range params {
-		if IsRejectedVolumeParameterKey(key) {
-			klog.Errorf("RequestID: %s, Parameter %q is not allowed on StorageClass or PV", requestID, key)
-			return nil, status.Errorf(codes.InvalidArgument, "Parameter %q is not allowed on StorageClass or PV", key)
-		}
-	}
-
-	mountKey := GenerateMountKeyWithFuseParams(masterAddrs, fsPath, fuseParams)
-	mntPath := ComputeFuseMntPath(mountKey)
-	clusterID := GenerateClusterID(masterAddrs)
-	klog.Infof("RequestID: %s, Auto-generated mnt-path: %s (mount-key: %s, cluster-id: %s, fs-path: %s)",
-		requestID, mntPath, mountKey, clusterID, fsPath)
-	validated.MntPath = mntPath
-
-	// Validate path-type (optional, default to "Directory")
 	pathType, ok := params["path-type"]
 	if !ok || pathType == "" {
 		pathType = "Directory"
@@ -88,16 +66,21 @@ func ValidateStorageClassParams(params map[string]string, requestID string) (*St
 		klog.Errorf("RequestID: %s, Invalid path-type: %s, must be 'Directory' or 'DirectoryOrCreate'", requestID, pathType)
 		return nil, status.Error(codes.InvalidArgument, "path-type must be 'Directory' or 'DirectoryOrCreate'")
 	}
-	validated.PathType = pathType
-	validated.FuseParams = fuseParams
 
-	klog.Infof("RequestID: %s, Validated StorageClass parameters: master-addrs=%s, mnt-path=%s, fs-path=%s, path-type=%s",
-		requestID, validated.MasterAddrs, validated.MntPath, validated.FSPath, validated.PathType)
+	passthrough := CollectPassthroughParams(params, nil)
 
-	return validated, nil
+	klog.Infof("RequestID: %s, Validated StorageClass parameters: master-addrs=%s, fs-path=%s, path-type=%s, passthrough-keys=%d",
+		requestID, masterAddrs, fsPath, pathType, len(passthrough))
+
+	return &StorageClassParams{
+		MasterAddrs: masterAddrs,
+		FSPath:      fsPath,
+		PathType:    pathType,
+		Passthrough: passthrough,
+	}, nil
 }
 
-// ValidateMasterAddrs validates master-addrs format
+// ValidateMasterAddrs validates master-addrs format.
 // Format: host:port,host:port,...
 func ValidateMasterAddrs(masterAddrs string) error {
 	if masterAddrs == "" {
@@ -130,12 +113,4 @@ func ValidateMasterAddrs(masterAddrs string) error {
 	}
 
 	return nil
-}
-
-// ValidateClusterConnection optionally validates cluster connection
-// This is a placeholder for future implementation
-func ValidateClusterConnection(masterAddrs string, requestID string) error {
-	// TODO: Implement actual connection validation if needed
-	// For now, just validate the format
-	return ValidateMasterAddrs(masterAddrs)
 }

--- a/curvine-csi/pkg/csi/validator_test.go
+++ b/curvine-csi/pkg/csi/validator_test.go
@@ -41,7 +41,7 @@ func TestValidateStorageClassParamsRejectsMntPath(t *testing.T) {
 	}
 }
 
-func TestValidateStorageClassParamsGeneratesMntPath(t *testing.T) {
+func TestValidateStorageClassParamsCollectsPassthrough(t *testing.T) {
 	params := map[string]string{
 		"master-addrs": "m1:8995",
 		"fs-path":      "/data",
@@ -52,13 +52,19 @@ func TestValidateStorageClassParamsGeneratesMntPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ValidateStorageClassParams() error = %v", err)
 	}
-	want := ComputeFuseMntPath(GenerateMountKeyWithFuseParams("m1:8995", "/data", map[string]string{
-		"io-threads": "4",
-	}))
-	if got.MntPath != want {
-		t.Fatalf("MntPath = %q, want %q", got.MntPath, want)
+	if got.Passthrough["io-threads"] != "4" {
+		t.Fatalf("Passthrough = %#v, want io-threads=4", got.Passthrough)
 	}
-	if got.FuseParams["io-threads"] != "4" {
-		t.Fatalf("FuseParams = %#v, want io-threads=4 from passthrough", got.FuseParams)
+	if got.MasterAddrs != "m1:8995" || got.FSPath != "/data" {
+		t.Fatalf("unexpected validated params: %#v", got)
+	}
+}
+
+func TestIsStaticVolumeID(t *testing.T) {
+	if !IsStaticVolumeID("my-existing-volume") {
+		t.Fatal("expected unstructured volume handle to be static")
+	}
+	if IsStaticVolumeID(GenerateVolumeHandle("m1:8995", "/data", "pvc-a")) {
+		t.Fatal("expected structured volume handle to be dynamic")
 	}
 }

--- a/curvine-csi/pkg/csi/validator_test.go
+++ b/curvine-csi/pkg/csi/validator_test.go
@@ -60,6 +60,31 @@ func TestValidateStorageClassParamsCollectsPassthrough(t *testing.T) {
 	}
 }
 
+func TestValidateStorageClassParamsRejectsFSPathWithAtSign(t *testing.T) {
+	params := map[string]string{
+		"master-addrs": "m1:8995",
+		"fs-path":      "/bad@path",
+	}
+
+	_, err := ValidateStorageClassParams(params, "test-req")
+	if err == nil {
+		t.Fatal("expected error for fs-path containing @")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.InvalidArgument {
+		t.Fatalf("expected InvalidArgument, got %v", st.Code())
+	}
+}
+
+func TestValidateFSPathRejectsAtSign(t *testing.T) {
+	if err := ValidateFSPath("/data@vol"); err == nil {
+		t.Fatal("expected error for fs-path with @")
+	}
+}
+
 func TestIsStaticVolumeID(t *testing.T) {
 	if !IsStaticVolumeID("my-existing-volume") {
 		t.Fatal("expected unstructured volume handle to be static")


### PR DESCRIPTION
## Problem
After C11/C14, CSI still lacked provision-time fuse parameter validation and
carried dead validator fields (`MntPath`, `ValidateClusterConnection`) from the
pre-passthrough era.

## Design
- **C15**: Slim `ValidateStorageClassParams` to reserved-key checks plus
  `Passthrough`; reject disallowed keys via `RejectDisallowedVolumeParameters`.
- **C16/C17**: Shared `ExecFuseValidateConfig` builds the same argv as mount
  (without `--mnt-path`) and surfaces subprocess stderr on failure.
- Dynamic volumes validate in **CreateVolume**; static PVs validate in
  **NodeStage** when `volumeID` is not a structured handle.

## Key Changes
- Add `fuse_validate.go` with `ValidateFuseParameters` / path resolution helpers
- Remove `StorageClassParams.MntPath` and unused `ValidateClusterConnection`
- Wire validate-config into controller CreateVolume and embedded/standalone NodeStage
- Unit tests for passthrough validation, static volume detection, and argv shape

Refs #865
