### PR TITLE
docs(csi): refresh examples for parameterized mount model (C18)

### DIFF
--- a/curvine-csi/deploy/clusterrolebinding.yaml
+++ b/curvine-csi/deploy/clusterrolebinding.yaml
@@ -9,7 +9,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: curvine-csi-node-sa
-    namespace: curvine-system
+    namespace: curvine
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -22,4 +22,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: curvine-csi-controller-sa
-    namespace: curvine-system
+    namespace: curvine

--- a/curvine-csi/deploy/daemonset.yaml
+++ b/curvine-csi/deploy/daemonset.yaml
@@ -2,7 +2,7 @@ kind: DaemonSet
 apiVersion: apps/v1
 metadata:
   name: curvine-csi-node
-  namespace: curvine-system
+  namespace: curvine
 spec:
   selector:
     matchLabels:
@@ -155,4 +155,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: curvine-csi-node-sa
-    namespace: curvine-system
+    namespace: curvine

--- a/curvine-csi/deploy/deployment.yaml
+++ b/curvine-csi/deploy/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: curvine-csi-controller
   name: curvine-csi-controller
-  namespace: curvine-system
+  namespace: curvine
 spec:
   replicas: 1
   selector:

--- a/curvine-csi/deploy/namespace.yaml
+++ b/curvine-csi/deploy/namespace.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: curvine-system
+  name: curvine
   labels:
-    name: curvine-system
+    name: curvine
     app.kubernetes.io/name: curvine-csi
     app.kubernetes.io/component: storage

--- a/curvine-csi/deploy/serviceaccount.yaml
+++ b/curvine-csi/deploy/serviceaccount.yaml
@@ -2,10 +2,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: curvine-csi-controller-sa
-  namespace: curvine-system
+  namespace: curvine
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: curvine-csi-node-sa
-  namespace: curvine-system
+  namespace: curvine

--- a/curvine-csi/examples/deployment-curvine.yaml
+++ b/curvine-csi/examples/deployment-curvine.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: curvine-shared-pvc
-  namespace: curvine-system
+  namespace: curvine
 spec:
   accessModes:
     - ReadWriteMany
@@ -16,7 +16,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: curvine-test-deployment
-  namespace: curvine-system
+  namespace: curvine
   labels:
     app: curvine-test
 spec:

--- a/curvine-csi/examples/deployment-curvine.yaml
+++ b/curvine-csi/examples/deployment-curvine.yaml
@@ -1,3 +1,4 @@
+# Deployment with a shared ReadWriteMany PVC (all replicas mount the same volume).
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -48,4 +49,3 @@ spec:
         - name: curvine-storage
           persistentVolumeClaim:
             claimName: curvine-shared-pvc
-

--- a/curvine-csi/examples/pod-curvine.yaml
+++ b/curvine-csi/examples/pod-curvine.yaml
@@ -1,8 +1,9 @@
+# Single-pod example using dynamically provisioned PVC curvine-pvc.
 apiVersion: v1
 kind: Pod
 metadata:
   name: curvine-test-pod
-  namespace: curvine
+  namespace: curvine-system
   labels:
     app: curvine-test
 spec:
@@ -11,7 +12,7 @@ spec:
       image: nginx:stable-alpine
       ports:
         - containerPort: 80
-          name: "http-server"
+          name: http-server
       volumeMounts:
         - mountPath: "/data"
           name: curvine-storage

--- a/curvine-csi/examples/pod-curvine.yaml
+++ b/curvine-csi/examples/pod-curvine.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: curvine-test-pod
-  namespace: curvine-system
+  namespace: curvine
   labels:
     app: curvine-test
 spec:

--- a/curvine-csi/examples/pv-curvine.yaml
+++ b/curvine-csi/examples/pv-curvine.yaml
@@ -1,16 +1,19 @@
 # Static PersistentVolume example.
 #
-# Static PV volumeAttributes use curvine-path (full path to mount) instead of fs-path.
+# Static PV volumeAttributes:
+#   curvine-path — required subpath bind-mounted into the pod
+#   fs-path      — optional; path passed to curvine-fuse (defaults to "/" if unset)
 # NodeStageVolume runs curvine-fuse validate-config before mounting.
 #
 # Reserved volume attribute keys:
-#   master-addrs, curvine-path, path-type, author
+#   master-addrs, fs-path, curvine-path, path-type, author
 # Rejected keys: mnt-path (computed by CSI)
 # Passthrough: any other non-empty key → curvine-fuse CLI flag (see storage-class.yaml)
 #
 # FUSE process sharing:
-#   PVs share one FUSE pod when master-addrs, curvine-path (used as fuse fs-path),
-#   and passthrough parameters match.
+#   PVs share one FUSE pod when master-addrs, fs-path (defaults to "/"), and
+#   passthrough parameters match. curvine-path only selects the bind-mount subpath
+#   inside the pod unless fs-path is explicitly set to a different fuse root.
 #
 apiVersion: v1
 kind: PersistentVolume

--- a/curvine-csi/examples/pv-curvine.yaml
+++ b/curvine-csi/examples/pv-curvine.yaml
@@ -1,3 +1,17 @@
+# Static PersistentVolume example.
+#
+# Static PV volumeAttributes use curvine-path (full path to mount) instead of fs-path.
+# NodeStageVolume runs curvine-fuse validate-config before mounting.
+#
+# Reserved volume attribute keys:
+#   master-addrs, curvine-path, path-type, author
+# Rejected keys: mnt-path (computed by CSI)
+# Passthrough: any other non-empty key → curvine-fuse CLI flag (see storage-class.yaml)
+#
+# FUSE process sharing:
+#   PVs share one FUSE pod when master-addrs, curvine-path (used as fuse fs-path),
+#   and passthrough parameters match.
+#
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -13,32 +27,15 @@ spec:
   persistentVolumeReclaimPolicy: Retain
   csi:
     driver: curvine
-    # For static PV, volumeHandle can be any unique string
+    # Any unique string for static PVs
     volumeHandle: "my-existing-volume"
     volumeAttributes:
-      # Required: Curvine cluster master addresses
+      # Required
       master-addrs: "m0:8995,m1:8995,m2:8995"
-      # Required: Complete path in curvine filesystem to mount
-      # This path will be mounted directly by FUSE
+      # Required: existing path in the Curvine filesystem
       curvine-path: "/my-existing-data"
-      # Optional: Path creation strategy
-      # "Directory" - path must exist (recommended for existing data)
-      # "DirectoryOrCreate" - create if not exist
+      # Optional (default: Directory)
       path-type: "Directory"
-      # Optional: FUSE parameters
+      # Optional passthrough examples:
       # io-threads: "4"
-      # worker-threads: "8"
-      
-# Static PV Configuration Notes:
-# - volumeHandle: Any unique string (e.g., "my-volume-1")
-# - curvine-path: Complete path in curvine filesystem to mount
-# - FUSE mounts curvine-path directly to local mount point
-# - Recommended: Use "Retain" policy to prevent accidental deletion
-# 
-# Sharing FUSE Process:
-# - Multiple PVs with same master-addrs + curvine-path will share one FUSE process
-# - Different curvine-path will have independent FUSE process
-# 
-# Example:
-# PV1 (curvine-path="/shared") + PV2 (curvine-path="/shared") → Share FUSE
-# PV3 (curvine-path="/data") → Independent FUSE
+      # client.umask: "022"

--- a/curvine-csi/examples/pvc-curvine.yaml
+++ b/curvine-csi/examples/pvc-curvine.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: curvine-pvc
-  namespace: curvine-system
+  namespace: curvine
 spec:
   storageClassName: curvine-sc
   accessModes:

--- a/curvine-csi/examples/pvc-curvine.yaml
+++ b/curvine-csi/examples/pvc-curvine.yaml
@@ -1,8 +1,10 @@
+# Dynamic PVC: provisioned by curvine-sc StorageClass.
+# After binding, the PV mounts /test-data/<pvc-name> on the Curvine cluster.
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: curvine-pvc
-  namespace: curvine
+  namespace: curvine-system
 spec:
   storageClassName: curvine-sc
   accessModes:

--- a/curvine-csi/examples/pvc-static.yaml
+++ b/curvine-csi/examples/pvc-static.yaml
@@ -1,3 +1,4 @@
+# Static PVC: binds to pre-created PV curvine-pv by name.
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -11,4 +12,3 @@ spec:
     requests:
       storage: 5Gi
   volumeName: curvine-pv
-

--- a/curvine-csi/examples/pvc-static.yaml
+++ b/curvine-csi/examples/pvc-static.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: curvine-pvc-static
-  namespace: curvine-system
+  namespace: curvine
 spec:
   storageClassName: curvine-sc
   accessModes:

--- a/curvine-csi/examples/statefulset-curvine.yaml
+++ b/curvine-csi/examples/statefulset-curvine.yaml
@@ -1,3 +1,7 @@
+# StatefulSet with per-pod PVCs (volumeClaimTemplates).
+# Each pod gets data-<ordinal> PVC; dynamic provisioning creates a unique
+# Curvine path under fs-path for every PVC (see storage-class.yaml).
+# ReadWriteOnce is intentional: one pod per dedicated volume.
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -55,4 +59,3 @@ spec:
   ports:
     - port: 80
       name: http
-

--- a/curvine-csi/examples/statefulset-curvine.yaml
+++ b/curvine-csi/examples/statefulset-curvine.yaml
@@ -6,7 +6,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: curvine-statefulset
-  namespace: curvine-system
+  namespace: curvine
 spec:
   serviceName: curvine-service
   replicas: 3
@@ -51,7 +51,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: curvine-service
-  namespace: curvine-system
+  namespace: curvine
 spec:
   clusterIP: None
   selector:

--- a/curvine-csi/examples/storage-class.yaml
+++ b/curvine-csi/examples/storage-class.yaml
@@ -14,9 +14,10 @@
 #   before the PV is created.
 #
 # FUSE process sharing (mount key):
-#   Volumes share one standalone FUSE pod when master-addrs, the fs-path passed
-#   to fuse (for dynamic PVs: fs-path + pv-name), and passthrough parameters
-#   are identical. Different passthrough values get separate FUSE pods.
+#   Volumes share one standalone FUSE pod when master-addrs, the StorageClass
+#   fs-path prefix passed to curvine-fuse, and passthrough parameters are identical.
+#   For dynamic PVs, curvine-path (= fs-path + "/" + pv-name) is only the bind-mount
+#   subpath inside the pod; it does not change the FUSE mount key.
 #
 apiVersion: storage.k8s.io/v1
 kind: StorageClass

--- a/curvine-csi/examples/storage-class.yaml
+++ b/curvine-csi/examples/storage-class.yaml
@@ -1,3 +1,23 @@
+# Curvine CSI StorageClass example (dynamic provisioning).
+#
+# Parameter model (see epic #865):
+#   Reserved (handled by CSI, not forwarded as generic CLI flags):
+#     master-addrs, fs-path, path-type
+#   Rejected in StorageClass / PV parameters:
+#     mnt-path  (computed internally by the CSI node plugin)
+#   Passthrough (any other non-empty key → curvine-fuse --key value):
+#     FUSE mount flags, e.g. io-threads, entry-timeout
+#     ClientConf overrides with client.* prefix, e.g. client.block-size, client.umask
+#
+# Validation:
+#   CreateVolume runs curvine-fuse validate-config with the resolved parameters
+#   before the PV is created.
+#
+# FUSE process sharing (mount key):
+#   Volumes share one standalone FUSE pod when master-addrs, the fs-path passed
+#   to fuse (for dynamic PVs: fs-path + pv-name), and passthrough parameters
+#   are identical. Different passthrough values get separate FUSE pods.
+#
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -7,23 +27,19 @@ reclaimPolicy: Delete
 volumeBindingMode: Immediate
 allowVolumeExpansion: true
 parameters:
-  # Required: Curvine cluster connection information
-  master-addrs: "m0:8995,m1:8995,m2:8995"  # Master node addresses, format: host:port,host:port
-  
-  # Required: Filesystem path prefix for dynamic PV
-  # Each dynamic PV will create: fs-path + pv-name
-  # Example: fs-path="/" → creates "/pvc-xxx"
-  #          fs-path="/test-data" → creates "/test-data/pvc-xxx"
+  # Required: Curvine master addresses (host:port,host:port,...)
+  master-addrs: "m0:8995,m1:8995,m2:8995"
+
+  # Required for dynamic provisioning: directory prefix on the Curvine filesystem.
+  # Each PV mounts fs-path + "/" + pv-name, e.g. fs-path="/test-data" → "/test-data/pvc-xxx"
   fs-path: "/test-data"
-  
-  # Optional: Path creation strategy
-  path-type: "DirectoryOrCreate"  # "DirectoryOrCreate" or "Directory" (default: "Directory")
-  
-  # Optional: FUSE parameters
+
+  # Optional: path creation strategy (default: Directory)
+  path-type: "DirectoryOrCreate"  # or "Directory"
+
+  # Optional passthrough examples (uncomment to override defaults):
   # io-threads: "4"
   # worker-threads: "8"
-  
-# How it works:
-# - Each PV gets curvine-path = fs-path + pv-name
-# - FUSE mounts curvine-path directly to local mount point
-# - PVs with same master-addrs + curvine-path share FUSE process
+  # entry-timeout: "1.0"
+  # client.block-size: "128MB"
+  # client.umask: "022"  # octal notation; also accepts 0o22

--- a/curvine-csi/pkg/csi/config.go
+++ b/curvine-csi/pkg/csi/config.go
@@ -45,7 +45,7 @@ func DefaultConfig() *Config {
 		RetryCount:          3,
 		RetryInterval:       2,
 		CommandTimeout:      30,
-		KubernetesNamespace: "curvine-system",
+		KubernetesNamespace: "curvine",
 	}
 }
 

--- a/curvine-csi/pkg/csi/node.go
+++ b/curvine-csi/pkg/csi/node.go
@@ -55,7 +55,7 @@ func newNodeService(nodeID string) (*nodeService, error) {
 	// Initialize Kubernetes client
 	kubernetesNamespace := os.Getenv("KUBERNETES_NAMESPACE")
 	if kubernetesNamespace == "" {
-		kubernetesNamespace = "curvine-system"
+		kubernetesNamespace = "curvine"
 	}
 	k8sClient, err := NewK8sClient(kubernetesNamespace, nodeID)
 	if err != nil {

--- a/curvine-tests/benchmark/README.md
+++ b/curvine-tests/benchmark/README.md
@@ -11,7 +11,7 @@ Kubernetes manifests under `master-stress/` run **client-side workloads** agains
 
 **Apply rule:** `deployment.yaml` and `deployment-metadata-stable.yaml` both define the **same Kubernetes resource names** (e.g. StatefulSet `curvine-master-stress`, ConfigMap `curvine-stress-scripts`). Apply **only one** of them in a given namespace. `deployment-metadata-stress.yaml` uses a **different** app name and can coexist if namespaces or names differ.
 
-**Namespace:** examples below use `curvine-system` where listed; your copy of a manifest may use `default` or another namespace—check `metadata.namespace` before `kubectl apply`.
+**Namespace:** examples below use `curvine` where listed; your copy of a manifest may use `default` or another namespace—check `metadata.namespace` before `kubectl apply`.
 
 **Prerequisites:**
 
@@ -40,8 +40,8 @@ Kubernetes manifests under `master-stress/` run **client-side workloads** agains
 
 ```bash
 kubectl apply -f master-stress/deployment.yaml
-kubectl -n curvine-system get pods -l app=curvine-master-stress
-kubectl -n curvine-system logs -f statefulset/curvine-master-stress
+kubectl -n curvine get pods -l app=curvine-master-stress
+kubectl -n curvine logs -f statefulset/curvine-master-stress
 ```
 
 ### Main environment variables
@@ -97,8 +97,8 @@ Same labels and object names as §1 (`curvine-master-stress`). Use the same `kub
 
 ```bash
 kubectl apply -f master-stress/deployment-metadata-stable.yaml
-kubectl -n curvine-system get pods -l app=curvine-master-stress
-kubectl -n curvine-system logs -f statefulset/curvine-master-stress
+kubectl -n curvine get pods -l app=curvine-master-stress
+kubectl -n curvine logs -f statefulset/curvine-master-stress
 ```
 
 (Adjust `-n` to match `metadata.namespace` in your file.)
@@ -124,8 +124,8 @@ See §1 for environment variables, demo load table, and resource names.
 
 ```bash
 kubectl apply -f master-stress/deployment-metadata-stress.yaml
-kubectl -n curvine-system get pods -l app=curvine-metadata-stress
-kubectl -n curvine-system logs -f statefulset/curvine-metadata-stress
+kubectl -n curvine get pods -l app=curvine-metadata-stress
+kubectl -n curvine logs -f statefulset/curvine-metadata-stress
 ```
 
 ### Tree parameters (`META_*`)

--- a/curvine-tests/benchmark/master-stress/deployment.yaml
+++ b/curvine-tests/benchmark/master-stress/deployment.yaml
@@ -12,7 +12,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: curvine-stress-master
-  namespace: curvine-system
+  namespace: curvine
 type: Opaque
 stringData:
   master-addrs: "cv-curvine-master-0.cv-curvine-master.default.svc.cluster.local:8995,cv-curvine-master-1.cv-curvine-master.default.svc.cluster.local:8995,cv-curvine-master-2.cv-curvine-master.default.svc.cluster.local:8995"
@@ -21,7 +21,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: curvine-stress-scripts
-  namespace: curvine-system
+  namespace: curvine
 data:
   stress-entrypoint.sh: |
     #!/usr/bin/env bash
@@ -338,7 +338,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: curvine-master-stress
-  namespace: curvine-system
+  namespace: curvine
   labels:
     app: curvine-master-stress
 spec:
@@ -354,7 +354,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: curvine-master-stress
-  namespace: curvine-system 
+  namespace: curvine 
   labels:
     app: curvine-master-stress
 spec:

--- a/curvine-tests/benchmark/master-stress/deployment.yaml
+++ b/curvine-tests/benchmark/master-stress/deployment.yaml
@@ -354,7 +354,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: curvine-master-stress
-  namespace: curvine 
+  namespace: curvine
   labels:
     app: curvine-master-stress
 spec:


### PR DESCRIPTION
## Problem
CSI example YAML comments were outdated: wrong FUSE sharing semantics, no documentation for reserved/passthrough keys, validate-config, or `client.*` parameters. Deploy manifests and CSI defaults still used `curvine-system` instead of the intended `curvine` namespace.

Refs #865 (M6)

## Design
Refresh example inline comments to match the C14–C17 CSI parameter model. Align namespace usage across examples, deploy manifests, benchmark docs, and CSI defaults (`config.go` / `node.go`).

## Key Changes
- Document reserved keys, rejected `mnt-path`, and passthrough → CLI mapping
- Explain validate-config (CreateVolume / NodeStage) and mount-key sharing rules
- Clarify fs-path (fuse root) vs curvine-path (pod bind subpath) in examples
- Add `client.umask` passthrough example; use `curvine` namespace consistently
- Update CSI default namespace to `curvine` when `KUBERNETES_NAMESPACE` is unset