### PR TITLE
fix(client): handle sparse parallel readers for random reads

### DIFF
--- a/curvine-client/src/file/fs_reader_buffer.rs
+++ b/curvine-client/src/file/fs_reader_buffer.rs
@@ -134,6 +134,7 @@ impl ReaderAdapter {
 // Reader with buffer.
 pub struct FsReaderBuffer {
     readers: Vec<ReaderAdapter>,
+    base_reader_index: usize,
     path: Path,
     pos: i64,
     len: i64,
@@ -208,10 +209,12 @@ impl FsReaderBuffer {
             readers.push(reader);
         }
 
+        let base_reader_index = readers.len();
         readers.push(ReaderAdapter::Base(base));
 
         let reader = Self {
             readers,
+            base_reader_index,
             path,
             pos,
             len,
@@ -245,14 +248,42 @@ impl FsReaderBuffer {
         &self.path
     }
 
+    fn select_reader_index(
+        is_random: bool,
+        pos: i64,
+        slice_size: i64,
+        read_parallel: i64,
+        base_reader_index: usize,
+    ) -> Option<usize> {
+        if is_random {
+            return Some(base_reader_index);
+        }
+
+        if slice_size <= 0 || read_parallel <= 0 {
+            return None;
+        }
+
+        Some((pos / slice_size % read_parallel) as usize)
+    }
+
     fn get_reader(&mut self) -> FsResult<&mut ReaderAdapter> {
-        let id = if self.read_detector.is_random() {
-            self.read_detector.read_parallel()
-        } else {
-            self.pos / self.slice_size % self.read_detector.read_parallel()
+        let Some(id) = Self::select_reader_index(
+            self.read_detector.is_random(),
+            self.pos,
+            self.slice_size,
+            self.read_detector.read_parallel(),
+            self.base_reader_index,
+        ) else {
+            return err_box!(
+                "reader is not initialized: pos={}, slice_size={}, read_parallel={}, base_reader_index={}",
+                self.pos,
+                self.slice_size,
+                self.read_detector.read_parallel(),
+                self.base_reader_index
+            );
         };
 
-        match self.readers.get_mut(id as usize) {
+        match self.readers.get_mut(id) {
             Some(v) => Ok(v),
             None => err_box!("reader {} is not initialized", id),
         }
@@ -403,5 +434,48 @@ impl FsReaderBuffer {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use curvine_common::conf::ClusterConf;
+    use curvine_common::state::FileStatus;
+
+    fn sparse_file_blocks(len: i64) -> FileBlocks {
+        FileBlocks::new(
+            FileStatus {
+                id: 1,
+                len,
+                is_complete: true,
+                ..Default::default()
+            },
+            vec![],
+        )
+    }
+
+    #[test]
+    fn test_random_read_uses_base_reader_for_sparse_parallel_slices() {
+        let mut conf = ClusterConf::default();
+        conf.client.read_parallel = 4;
+        conf.client.read_chunk_num = 1;
+        conf.client.read_slice_size_str = "16MB".to_string();
+        conf.client.large_file_size_str = "1GB".to_string();
+        conf.client.init().unwrap();
+
+        let file_len = conf.client.read_slice_size / 2;
+        let file_blocks = sparse_file_blocks(file_len);
+        let path = Path::from_str("/small-file").unwrap();
+        let read_detector = ReadDetector::with_conf(&conf.client, file_len);
+        let fs_context = Arc::new(FsContext::new(conf).unwrap());
+        let rt = fs_context.clone_runtime();
+        let mut reader = FsReaderBuffer::new(path, fs_context, file_blocks, read_detector).unwrap();
+
+        assert_eq!(reader.base_reader_index, 1);
+
+        rt.block_on(reader.seek(file_len)).unwrap();
+        assert!(reader.read_detector.is_random());
+        assert!(reader.get_reader().is_ok());
     }
 }

--- a/curvine-common/src/conf/client_conf.rs
+++ b/curvine-common/src/conf/client_conf.rs
@@ -288,7 +288,18 @@ impl ClientConf {
 
     pub const DEFAULT_CLOSE_TIMEOUT_SECS: u64 = 5;
 
+    pub const DEFAULT_READ_PARALLEL: i64 = 1;
+
+    pub const DEFAULT_MAX_READ_PARALLEL: i64 = 8;
+
     pub fn init(&mut self) -> CommonResult<()> {
+        if self.read_parallel <= 0 {
+            self.read_parallel = Self::DEFAULT_READ_PARALLEL;
+        }
+        if self.max_read_parallel <= 0 {
+            self.max_read_parallel = Self::DEFAULT_MAX_READ_PARALLEL;
+        }
+
         self.block_size = ByteUnit::from_str(&self.block_size_str)?.as_byte() as i64;
 
         self.write_chunk_size = ByteUnit::from_str(&self.write_chunk_size_str)?.as_byte() as usize;
@@ -394,7 +405,7 @@ impl Default for ClientConf {
             read_chunk_size: 0,
             read_chunk_size_str: "128KB".to_owned(),
             read_chunk_num: 8,
-            read_parallel: 1,
+            read_parallel: Self::DEFAULT_READ_PARALLEL,
             read_slice_size: 0,
             read_slice_size_str: "0".to_owned(),
             max_cache_block_handles: 10,
@@ -480,7 +491,7 @@ impl Default for ClientConf {
             enable_smart_prefetch: true,
             large_file_size: 0,
             large_file_size_str: "10GB".to_string(),
-            max_read_parallel: 8,
+            max_read_parallel: Self::DEFAULT_MAX_READ_PARALLEL,
             sequential_read_threshold: 7,
         };
 

--- a/curvine-common/tests/client_conf_cli_test.rs
+++ b/curvine-common/tests/client_conf_cli_test.rs
@@ -64,6 +64,25 @@ fn apply_to_updates_pilot_client_fields() {
 }
 
 #[test]
+fn normalizes_non_positive_read_parallel_settings_to_defaults() {
+    let mut conf = ClientConf {
+        read_parallel: 0,
+        max_read_parallel: 0,
+        ..Default::default()
+    };
+
+    conf.init().unwrap();
+
+    assert_eq!(
+        (conf.read_parallel, conf.max_read_parallel),
+        (
+            ClientConf::DEFAULT_READ_PARALLEL,
+            ClientConf::DEFAULT_MAX_READ_PARALLEL
+        )
+    );
+}
+
+#[test]
 fn parses_c4_chunk_unified_fs_and_audit_flags() {
     let parsed = CliHarness::try_parse_from([
         "curvine-fuse",


### PR DESCRIPTION
## Problem
StarRocks uses positional reads through Curvine. With `fs.cv.read_parallel=4`, small files can create fewer parallel slice readers than the configured parallelism. `FsReaderParallel::create_all()` skips empty slice readers, so a small file may produce only reader `0` plus the full-file base reader.

The random-read path incorrectly used the configured `read_parallel` value as the reader index. For the small-file case above, that asks for reader `4` even though the reader vector only contains `[slice reader 0, base reader]`, causing `reader 4 is not initialized`.

## Fix
- Record the full-file base reader index when `FsReaderBuffer` appends it.
- Route random reads to that base reader instead of deriving an index from configured parallelism.
- Keep sequential reads on the existing slice-based selection path.
- Normalize non-positive `read_parallel` and `max_read_parallel` values to the existing safe defaults during `ClientConf::init()`.
- Include selector inputs in the invalid-reader error path for easier diagnosis.

## Tests
- Added a construction-level regression test for a small file with `read_parallel=4`; it builds the sparse reader layout and verifies the random path resolves through the recorded base reader. I also checked this test against the old read_parallel-as-index logic and it fails there.
- `cargo fmt -p curvine-client -p curvine-common --check`
- `cargo test -p curvine-common --test client_conf_cli_test`
- `cargo test -p curvine-client fs_reader_buffer`
- `cargo test -p curvine-client fs_reader_parallel`
- `cargo clippy -p curvine-client -p curvine-common --all-targets -- -D warnings`