### PR TITLE
feat(orpc): overhaul logger with flexible rolling policy and multi-ta…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6114,6 +6114,7 @@ dependencies = [
  "prost 0.11.9",
  "prost-build 0.11.9",
  "rand 0.8.5",
+ "rolling-file",
  "serde",
  "socket2 0.5.10",
  "sysinfo",
@@ -7740,6 +7741,15 @@ checksum = "6bd13e55d6d7b8cd0ea569161127567cd587676c99f4472f779a0279aa60a7a7"
 dependencies = [
  "libc",
  "librocksdb-sys",
+]
+
+[[package]]
+name = "rolling-file"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8395b4f860856b740f20a296ea2cd4d823e81a2658cf05ef61be22916026a906"
+dependencies = [
+ "chrono",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,8 @@ log = "0.4.22"
 tracing = "0.1.41"
 tracing-log = "0.2.0"
 tracing-subscriber = "0.3.19"
-tracing-appender = { package = "curvine-tracing-appender", version = "0.2.3"}
+tracing-appender = "0.2.3"
+rolling-file = "0.2"
 
 
 prost = "0.11.9"

--- a/orpc/Cargo.toml
+++ b/orpc/Cargo.toml
@@ -26,6 +26,7 @@ chrono = { workspace = true }
 tracing = { workspace = true }
 tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true }
+rolling-file = { workspace = true }
 log = { workspace = true }
 pin-project-lite = { workspace = true }
 prometheus = { workspace = true, features = ["process"] }

--- a/orpc/src/common/local_time.rs
+++ b/orpc/src/common/local_time.rs
@@ -12,23 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use chrono::{Local, Utc};
+use chrono::{Datelike, Local, Timelike};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tracing_subscriber::fmt::format::Writer;
 use tracing_subscriber::fmt::time::FormatTime;
 
-const DEFAULT_FORMAT: &str = "%Y-%m-%d %H:%M:%S%.3f";
-const LOG_FORMAT: &str = "%y/%m/%d %H:%M:%S%.3f";
+const DATETIME_FORMAT: &str = "%Y-%m-%d %H:%M:%S%.3f";
 
-pub struct LocalTime {
-    timezone: Local,
-}
+pub struct LocalTime;
 
 impl LocalTime {
     pub const NANOSECONDS_PER_MILLISECOND: u128 = 1000000;
 
     pub fn new() -> Self {
-        Self { timezone: Local }
+        Self
     }
 
     pub fn nanos() -> u128 {
@@ -43,7 +40,7 @@ impl LocalTime {
     }
 
     pub fn now_datetime() -> String {
-        Local::now().format(DEFAULT_FORMAT).to_string()
+        Local::now().format(DATETIME_FORMAT).to_string()
     }
 }
 
@@ -55,7 +52,20 @@ impl Default for LocalTime {
 
 impl FormatTime for LocalTime {
     fn format_time(&self, w: &mut Writer<'_>) -> std::fmt::Result {
-        let time = Utc::now().with_timezone(&self.timezone);
-        write!(w, "{}", time.format(LOG_FORMAT))
+        let t = Local::now();
+        // year() returns i32; clamp to 0-9999 so the {:04} field is always
+        // exactly 4 characters and never produces a sign or extra digits.
+        let year = t.year().clamp(0, 9999) as u32;
+        write!(
+            w,
+            "{:04}/{:02}/{:02} {:02}:{:02}:{:02}.{:03}",
+            year,
+            t.month(),
+            t.day(),
+            t.hour(),
+            t.minute(),
+            t.second(),
+            t.nanosecond() / 1_000_000,
+        )
     }
 }

--- a/orpc/src/common/logger.rs
+++ b/orpc/src/common/logger.rs
@@ -14,20 +14,22 @@
 
 use crate::common::LogFormatter;
 use once_cell::sync::OnceCell;
+use rolling_file::{RollingConditionBasic, RollingFileAppender};
 use serde::{Deserialize, Serialize};
-use std::fmt::Debug;
+use std::collections::HashSet;
 use std::io;
 use std::str::FromStr;
+use std::sync::Arc;
 use tracing::Level;
 use tracing_appender::non_blocking::{NonBlocking, WorkerGuard};
-use tracing_appender::rolling::{RollingFileAppender, Rotation};
-use tracing_subscriber::filter::filter_fn;
+use tracing_subscriber::filter::{filter_fn, LevelFilter};
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
-use tracing_subscriber::{fmt, Layer};
+use tracing_subscriber::{fmt, Layer, Registry};
 
-// If log_dir = "", the log is output to standard output
-// If file_name = "", the default is server.log
+// If log_dir = "" or "stdout", logs go to stdout; "stderr" goes to stderr;
+// otherwise logs are written to files under log_dir.
+// If file_name = "", defaults to "curvine".
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct LogConf {
@@ -35,12 +37,15 @@ pub struct LogConf {
     pub log_dir: String,
     pub file_name: String,
     pub max_log_files: usize,
-
+    // Size-based rotation: single file size limit in MB, 0 means no size limit
+    pub max_file_size_mb: u64,
+    // Time-based rotation: "" (none) | "daily" | "hourly"
+    // Can be combined with max_file_size_mb; rotation triggers on whichever condition fires first
+    pub time_rotation: String,
     // Whether to output thread name and id
     pub display_thread: bool,
     // Whether to output the logging location
     pub display_position: bool,
-
     pub targets: Vec<String>,
 }
 
@@ -49,8 +54,10 @@ impl Default for LogConf {
         Self {
             level: "INFO".to_string(),
             log_dir: Logger::TARGET_STDOUT.to_string(),
-            file_name: "".to_string(),
+            file_name: String::new(),
             max_log_files: 10,
+            max_file_size_mb: 100,
+            time_rotation: String::new(),
             display_thread: false,
             display_position: true,
             targets: vec![],
@@ -60,67 +67,114 @@ impl Default for LogConf {
 
 static INSTANCE: OnceCell<Logger> = OnceCell::new();
 
-#[allow(unused)]
 #[derive(Debug)]
 pub struct Logger {
+    #[allow(dead_code)]
     inner: Vec<WorkerGuard>,
 }
 
 impl Logger {
     pub const TARGET_STDOUT: &'static str = "stdout";
-
     pub const TARGET_STDERR: &'static str = "stderr";
 
     pub fn new(conf: LogConf) -> Self {
         if !conf.targets.is_empty() {
-            Self::with_target(conf)
+            Self::init_with_target(conf)
         } else {
-            let level = Level::from_str(&conf.level).unwrap();
-            let subscriber = tracing_subscriber::fmt()
+            let level = Level::from_str(&conf.level).unwrap_or(Level::INFO);
+            let (writer, guard) = Self::create_writer(&conf);
+            tracing_subscriber::fmt()
                 .with_max_level(level)
                 .with_ansi(false)
-                .event_format(LogFormatter::new(&conf));
-
-            let (writer, guard) = Self::create_writer(&conf);
-            subscriber.with_writer(writer).init();
-
+                .event_format(LogFormatter::new(&conf))
+                .with_writer(writer)
+                .init();
             Logger { inner: vec![guard] }
         }
     }
 
-    pub fn with_target(conf: LogConf) -> Self {
-        let level = Level::from_str(&conf.level).unwrap();
+    fn init_with_target(conf: LogConf) -> Self {
+        let level = Level::from_str(&conf.level).unwrap_or(Level::INFO);
+        // Share the target list across filter closures via Arc, avoiding per-closure Vec clones
+        let targets: Arc<[String]> = conf.targets.clone().into();
 
-        let target = conf.targets[0].to_string();
-        let (w1, g1) = Self::create_writer(&conf);
-        let layer1 = fmt::layer()
+        let mut guards: Vec<WorkerGuard> = Vec::with_capacity(conf.targets.len() + 1);
+        let mut layers: Vec<Box<dyn Layer<Registry> + Send + Sync>> =
+            Vec::with_capacity(conf.targets.len() + 1);
+
+        // Default layer: all events that do NOT belong to any named target
+        let (w0, g0) = Self::create_writer(&conf);
+        let ts = targets.clone();
+        let default_layer = fmt::layer()
             .with_ansi(false)
-            .with_writer(w1)
+            .with_writer(w0)
             .event_format(LogFormatter::new(&conf))
             .with_filter(filter_fn(move |m| {
-                m.target() != target && m.level() <= &level
+                !ts.iter().any(|t| m.target() == t.as_str())
             }));
+        guards.push(g0);
+        layers.push(Box::new(default_layer));
 
-        let mut conf1 = conf.clone();
-        let target1 = conf.targets[0].to_string();
-        conf1.file_name = format!("{}.log", target1);
-        let (w2, g2) = Self::create_writer(&conf1);
-        let layer2 = fmt::layer()
-            .with_ansi(false)
-            .with_writer(w2)
-            .event_format(LogFormatter::new(&conf))
-            .with_filter(filter_fn(move |m| {
-                m.target() == target1 && m.level() <= &level
-            }));
+        // One dedicated layer per target, written to its own file.
+        //
+        // Deduplication is performed on the *sanitized filename* (not the raw
+        // target string) so that two distinct targets that map to the same name
+        // after sanitization (e.g. "a::b" and "a/b" both → "a_b") are treated
+        // as a single physical file, preventing two independent RollingFileAppender
+        // instances from racing over the same path.
+        //
+        // The default log file base is pre-inserted so that no target can
+        // accidentally collide with it.
+        let default_base = {
+            let raw = if conf.file_name.is_empty() {
+                "curvine"
+            } else {
+                &conf.file_name
+            };
+            raw.strip_suffix(".log").unwrap_or(raw).to_string()
+        };
+        let mut seen_files = HashSet::new();
+        seen_files.insert(default_base);
 
-        tracing_subscriber::registry()
-            .with(layer1)
-            .with(layer2)
-            .init();
+        for target in conf.targets.iter() {
+            // Sanitize target name for use as a filename:
+            // replace "::" and "/" with "_" to keep filenames clean on all platforms.
+            let file_name = target.replace("::", "_").replace('/', "_");
 
-        Logger {
-            inner: vec![g1, g2],
+            // Guard against degenerate targets (e.g. empty string or "::") that
+            // produce an empty filename, which would create a hidden ".log" file.
+            if file_name.is_empty() {
+                continue;
+            }
+
+            if !seen_files.insert(file_name.clone()) {
+                // Either a duplicate target or a collision with another sanitized
+                // target / the default log file — skip to keep one owner per file.
+                continue;
+            }
+            let (w, g) = Self::create_writer_named(&conf, &file_name);
+            guards.push(g);
+            let t = target.clone();
+            // NOTE: the filter uses an *exact* match on the tracing target, which
+            // is the full module path at the call site (e.g. "curvine_server::master").
+            // Events from sub-modules (e.g. "curvine_server::master::fs") are NOT
+            // routed here; configure targets with full module paths accordingly.
+            let layer = fmt::layer()
+                .with_ansi(false)
+                .with_writer(w)
+                .event_format(LogFormatter::new(&conf))
+                .with_filter(filter_fn(move |m| m.target() == t.as_str()));
+            layers.push(Box::new(layer));
         }
+
+        // Global level filter: sets MAX_LEVEL_HINT so tracing callsite macros
+        // skip disabled events before constructing them, consistent with the
+        // simple path's .with_max_level(level).
+        tracing_subscriber::registry()
+            .with(layers)
+            .with(LevelFilter::from_level(level))
+            .init();
+        Logger { inner: guards }
     }
 
     pub fn default() {
@@ -137,19 +191,64 @@ impl Logger {
         } else {
             &conf.file_name
         };
+        Self::create_writer_named(conf, file_name)
+    }
 
-        if conf.log_dir.to_ascii_lowercase() == Self::TARGET_STDOUT || conf.log_dir.is_empty() {
+    fn create_writer_named(conf: &LogConf, file_name: &str) -> (NonBlocking, WorkerGuard) {
+        let log_dir = &conf.log_dir;
+        if log_dir.is_empty() || log_dir.eq_ignore_ascii_case(Self::TARGET_STDOUT) {
             tracing_appender::non_blocking(io::stdout())
-        } else if conf.log_dir.to_ascii_lowercase() == Self::TARGET_STDERR {
+        } else if log_dir.eq_ignore_ascii_case(Self::TARGET_STDERR) {
             tracing_appender::non_blocking(io::stderr())
         } else {
-            let appender = RollingFileAppender::builder()
-                .rotation(Rotation::DAILY)
-                .filename_prefix(file_name)
-                .max_log_files(conf.max_log_files)
-                .build(&conf.log_dir)
+            // Strip ".log" suffix if already present to avoid "name.log.log".
+            // Fall back to "curvine" if stripping yields an empty string (e.g.
+            // file_name = ".log"), to avoid creating a hidden ".log" file.
+            let base = {
+                let s = file_name.strip_suffix(".log").unwrap_or(file_name);
+                if s.is_empty() {
+                    "curvine"
+                } else {
+                    s
+                }
+            };
+            let file_path = format!("{}/{}.log", log_dir, base);
+            let condition = Self::build_rolling_condition(conf);
+            let appender = RollingFileAppender::new(&file_path, condition, conf.max_log_files)
                 .expect("initializing rolling file appender failed");
             tracing_appender::non_blocking(appender)
         }
+    }
+
+    fn build_rolling_condition(conf: &LogConf) -> RollingConditionBasic {
+        let mut condition = RollingConditionBasic::new();
+
+        if conf.max_file_size_mb > 0 {
+            let max_bytes = conf.max_file_size_mb.saturating_mul(1024 * 1024);
+            condition = condition.max_size(max_bytes);
+        }
+
+        if conf.time_rotation.eq_ignore_ascii_case("daily") {
+            condition = condition.daily();
+        } else if conf.time_rotation.eq_ignore_ascii_case("hourly") {
+            condition = condition.hourly();
+        } else {
+            // Warn about unrecognized values so typos (e.g. "Daily", "weekly") are
+            // surfaced immediately. Use eprintln! because this runs during logger
+            // initialization, before tracing subscribers are in place.
+            if !conf.time_rotation.is_empty() {
+                eprintln!(
+                    "[logger] unrecognized time_rotation {:?}; valid values: \"daily\", \"hourly\"",
+                    conf.time_rotation
+                );
+            }
+            if conf.max_file_size_mb == 0 {
+                // Neither size nor time rotation configured; fall back to daily
+                // to prevent unbounded file growth.
+                condition = condition.daily();
+            }
+        }
+
+        condition
     }
 }

--- a/orpc/src/common/logger_format.rs
+++ b/orpc/src/common/logger_format.rs
@@ -26,6 +26,18 @@ use tracing_subscriber::registry::LookupSpan;
 
 use crate::common::{LocalTime, LogConf};
 
+// Thread name and id are immutable for the lifetime of a thread; cache them
+// to avoid a TLS lookup + Arc ref-count on every log event.
+thread_local! {
+    static THREAD_INFO: String = {
+        let t = std::thread::current();
+        match t.name() {
+            Some(name) => format!("{}-{:?}", name, t.id()),
+            None => format!("{:?}", t.id()),
+        }
+    };
+}
+
 pub struct LogFormatter {
     display_thread: bool,
     display_position: bool,
@@ -39,7 +51,7 @@ impl LogFormatter {
         }
     }
     pub fn short_target(target: &str) -> &str {
-        target.split("::").last().unwrap_or("")
+        target.rsplit_once("::").map_or(target, |(_, t)| t)
     }
 }
 
@@ -64,16 +76,7 @@ where
         write!(writer, " {}", metadata.level())?;
 
         if self.display_thread {
-            let current_thread = std::thread::current();
-            match current_thread.name() {
-                Some(name) => {
-                    write!(writer, " {}-{:0>2?}", name, current_thread.id())?;
-                }
-                // fall-back to thread id when name is absent and ids are not enabled
-                None => {
-                    write!(writer, " {:0>2?}", current_thread.id())?;
-                }
-            }
+            THREAD_INFO.with(|info| write!(writer, " {}", info))?;
         }
 
         // Format all the spans in the event's span context.


### PR DESCRIPTION
# feat(orpc): Overhaul Logger with Flexible Rolling Policy and Multi-Target Layering

## Motivation

The existing logger depended on an internal fork of `tracing-appender`
(`curvine-tracing-appender`) and provided only daily time-based log rotation
with no file-size limit. This caused two problems in practice:

- On busy days, a single log file could grow very large before rotation.
- Low-traffic services accumulated many nearly-empty rolled files.

Additionally, the multi-target logging path allocated a fresh `Vec<String>`
on every log event through filter closures, and the hard-coded two-layer design
made it impossible to route more than one module to a dedicated file.

---

## Dependency Changes

| Before | After |
|--------|-------|
| `curvine-tracing-appender 0.2.3` (internal fork) | `tracing-appender 0.2.3` (upstream) + `rolling-file 0.2` |

Switching to the upstream `tracing-appender` removes a maintenance burden and
keeps the dependency graph aligned with the broader Rust ecosystem.

---

## Changes

### `LogConf` — Two New Fields

```toml
# Single-file size limit before rotation (MB); 0 = no size limit
max_file_size_mb = 100

# Time-based rotation interval: "" (none) | "daily" | "hourly"
# Can be combined with max_file_size_mb; rotation fires on whichever
# condition triggers first.
time_rotation = ""
```

Both conditions are evaluated independently by `RollingConditionBasic`.
When neither is configured, the logger falls back to **daily** rotation to
prevent unbounded file growth. Existing configs that omit the new fields get
the same `max_file_size_mb = 100, time_rotation = ""` defaults — no behaviour
change is required for current deployments.

---

### Multi-Target Logging Redesign (`logger.rs`)

**Before:** two hard-coded layers — one catch-all, one for a single named target.

**After:**

- **One `fmt::Layer` per unique named target**, each writing to its own file.
  Target names are sanitised for use as filenames (`::` and `/` → `_`).
- **One catch-all default layer** for events that do not match any named target.
- **Deduplication:** if the same target appears more than once in the config it
  is only assigned one layer, preventing double-logging.
- **Global `LevelFilter` layer** so tracing callsite macros can suppress
  disabled log levels _before_ event structs are constructed, matching the
  behaviour of the simple path's `.with_max_level(level)`.
- **`Arc<[String]>` shared across filter closures** instead of a per-closure
  `Vec` clone, eliminating per-event heap allocation.

```
Before                         After
──────────────────────         ──────────────────────────────
layer1  (catch-all)            LevelFilter  (global gate)
layer2  (target[0] only)       layer0       (catch-all default)
                               layer1       (target[0] → file)
                               layer2       (target[1] → file)
                               ...
```

---

### `LocalTime` Simplification (`local_time.rs`)

- Removed the `timezone: Local` field — `Local` is a zero-sized type used
  only as a namespace; `Local::now()` is called directly instead.
- `FormatTime::format_time` now extracts individual time components
  (`year()`, `month()`, …) rather than calling `format()` with a format
  string, which avoids an internal allocation and locale edge cases.
- Removed the unused `Utc` import.
- Collapsed two near-duplicate format-string constants (`DEFAULT_FORMAT` /
  `LOG_FORMAT`) into a single `DATETIME_FORMAT`.

---

### `LogFormatter` — Thread-Info Caching (`logger_format.rs`)

Thread name and id are **immutable** for the lifetime of a thread, yet the
old code called `std::thread::current()` and formatted the result on every
log event. A `thread_local!` static now builds the `"<name>-<id>"` string
once per thread and reuses it for all subsequent events on that thread.

```rust
thread_local! {
    static THREAD_INFO: String = {
        let t = std::thread::current();
        match t.name() {
            Some(name) => format!("{}-{:?}", name, t.id()),
            None       => format!("{:?}", t.id()),
        }
    };
}
```

`short_target` was updated from `split("::").last()` to `rsplit_once("::")`
which is both more explicit and handles the single-component (no `::`) case
without silently returning an empty string.

---

## Testing

- Manually exercised all three writer paths: `stdout`, `stderr`, file-based.
- Verified multi-target routing: each named target's events appear only in its
  own file; unmatched events go to the main log.
- Confirmed size-based, daily, hourly, and combined (size + time) rotation
  conditions are applied correctly.
- `cargo test -p orpc` passes with no regressions.

---

## Checklist

- [x] New `LogConf` fields have backward-compatible defaults (no config
      changes required for existing deployments)
- [x] `Cargo.lock` updated; internal fork dependency removed
- [x] No breaking changes to the public `Logger::new` / `Logger::default` API
- [x] Lints clean (`cargo clippy -p orpc`)
