### PR TITLE
fix(csi): improve passthrough filtering and quick local image build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,8 @@ help:
 	@echo ""
 	@echo "CSI (Container Storage Interface):"
 	@echo "  make curvine-csi                 - Build curvine-csi Docker image"
+	@echo "  make curvine-csi-quick           - Quick rebuild CSI + curvine-cli + curvine-fuse (Dockerfile.quick)"
+	@echo "  make curvine-csi-quick-push      - Quick build and push to CSI_QUICK_REGISTRY (default localhost:5000)"
 	@echo ""
 	@echo "SPDK NVMe-oF (Storage Performance Development Kit):"
 	@echo "  make docker-build-spdk-target    - Build SPDK NVMe-oF target Docker image"
@@ -168,28 +170,36 @@ curvine-csi-push: curvine-csi
 	docker push curvineio/curvine-csi:latest
 	@echo "✓ Image pushed successfully: curvineio/curvine-csi:latest"
 
-# Quick iteration build for CSI development (only rebuilds CSI binary)
-# Prerequisite: curvine-csi:latest must exist (run 'make curvine-csi' first)
+# Quick iteration build for CSI development (CSI + curvine-cli + curvine-fuse)
+# Prerequisite: ghcr.io/curvineio/curvine-csi:latest base image (runtime libs only)
 .PHONY: curvine-csi-quick
+# Override for private registry, e.g. make curvine-csi-quick-push CSI_QUICK_REGISTRY=registry.example.com:5000
+CSI_QUICK_REGISTRY ?= localhost:5000
 curvine-csi-quick:
-	@echo "Quick building curvine-csi (CSI binary only)..."
-	@if ! docker image inspect curvine-csi:latest >/dev/null 2>&1; then \
-		echo "Error: Base image curvine-csi:latest not found. Please run 'make curvine-csi' first."; \
+	@echo "Quick building curvine-csi (CSI + curvine-cli + curvine-fuse)..."
+	@if ! docker image inspect ghcr.io/curvineio/curvine-csi:latest >/dev/null 2>&1; then \
+		echo "Error: Base image ghcr.io/curvineio/curvine-csi:latest not found."; \
 		exit 1; \
 	fi
+	@echo "Building curvine-cli and curvine-fuse..."
+	@cargo build --release -p curvine-cli -p curvine-fuse || exit 1
+	@mkdir -p curvine-csi/quick-build
+	@cp target/release/curvine-cli target/release/curvine-fuse curvine-csi/quick-build/
 	@echo "Building CSI binary locally..."
 	@cd curvine-csi && GOPROXY=https://goproxy.cn,direct go build -o csi-binary main.go || exit 1
-	@echo "Building Docker image with new CSI binary..."
+	@echo "Building Docker image with local binaries..."
 	docker build -t curvine-csi:latest -f curvine-csi/Dockerfile.quick .
+	docker tag curvine-csi:latest $(CSI_QUICK_REGISTRY)/curvine-csi:latest
 	@rm -f curvine-csi/csi-binary
+	@rm -rf curvine-csi/quick-build
+	@echo "✓ Quick image: curvine-csi:latest and $(CSI_QUICK_REGISTRY)/curvine-csi:latest"
 
-# Quick iteration build and push
+# Quick iteration build and push to local registry
 .PHONY: curvine-csi-quick-push
 curvine-csi-quick-push: curvine-csi-quick
-	@echo "Tagging and pushing quick-built curvine-csi image to private registry..."
-	docker tag curvine-csi:latest curvineio/curvine-csi:latest
-	docker push curvineio/curvine-csi:latest
-	@echo "✓ Quick-built image pushed successfully: curvineio/curvine-csi:latest"
+	@echo "Pushing quick-built curvine-csi image to $(CSI_QUICK_REGISTRY)..."
+	docker push $(CSI_QUICK_REGISTRY)/curvine-csi:latest
+	@echo "✓ Quick-built image pushed: $(CSI_QUICK_REGISTRY)/curvine-csi:latest"
 
 # 9. SPDK NVMe-oF builds
 .PHONY: docker-build-spdk-target docker-compose-spdk docker-compose-spdk-down

--- a/curvine-csi/.gitignore
+++ b/curvine-csi/.gitignore
@@ -19,3 +19,5 @@ bin/
 *~
 curvine/
 test/
+csi-binary
+quick-build/

--- a/curvine-csi/Dockerfile.quick
+++ b/curvine-csi/Dockerfile.quick
@@ -1,0 +1,16 @@
+# Quick iteration Dockerfile for CSI development
+# Replaces CSI, curvine-cli, and curvine-fuse with locally built binaries.
+# Prerequisites (built by make curvine-csi-quick):
+#   - curvine-csi/csi-binary
+#   - curvine-csi/quick-build/curvine-cli
+#   - curvine-csi/quick-build/curvine-fuse
+# Usage: make curvine-csi-quick
+
+FROM ghcr.io/curvineio/curvine-csi:latest
+
+COPY curvine-csi/csi-binary /opt/curvine/csi
+COPY curvine-csi/quick-build/curvine-cli /opt/curvine/curvine-cli
+COPY curvine-csi/quick-build/curvine-fuse /opt/curvine/curvine-fuse
+
+RUN chmod +x /opt/curvine/csi /opt/curvine/curvine-cli /opt/curvine/curvine-fuse
+

--- a/curvine-csi/pkg/csi/fuse_cli.go
+++ b/curvine-csi/pkg/csi/fuse_cli.go
@@ -17,6 +17,7 @@ package csi
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -64,8 +65,14 @@ func IsRejectedVolumeParameterKey(key string) bool {
 
 // IsDeniedVolumeParameterKey reports whether the key must never be passed to curvine-fuse.
 func IsDeniedVolumeParameterKey(key string) bool {
-	_, ok := volumeParameterDenylist[key]
-	return ok
+	if _, ok := volumeParameterDenylist[key]; ok {
+		return true
+	}
+	// Kubernetes-injected volume context keys (e.g. storage.kubernetes.io/csiProvisionerIdentity).
+	if strings.HasPrefix(key, "csi.storage.k8s.io/") || strings.HasPrefix(key, "storage.kubernetes.io/") {
+		return true
+	}
+	return false
 }
 
 // RejectDisallowedVolumeParameters rejects user-supplied keys such as mnt-path on PVs

--- a/curvine-csi/pkg/csi/fuse_cli_test.go
+++ b/curvine-csi/pkg/csi/fuse_cli_test.go
@@ -109,6 +109,29 @@ func TestIsRejectedVolumeParameterKey(t *testing.T) {
 	}
 }
 
+func TestIsDeniedVolumeParameterKeyKubernetesInternal(t *testing.T) {
+	if !IsDeniedVolumeParameterKey("storage.kubernetes.io/csiProvisionerIdentity") {
+		t.Fatal("expected storage.kubernetes.io/csiProvisionerIdentity to be denied")
+	}
+	if !IsDeniedVolumeParameterKey("csi.storage.k8s.io/pod.name") {
+		t.Fatal("expected csi.storage.k8s.io/pod.name to be denied")
+	}
+	if IsDeniedVolumeParameterKey("io-threads") {
+		t.Fatal("did not expect io-threads to be denied")
+	}
+}
+
+func TestCollectPassthroughParamsFiltersProvisionerIdentity(t *testing.T) {
+	volumeContext := map[string]string{
+		"io-threads": "4",
+		"storage.kubernetes.io/csiProvisionerIdentity": "1781067593753-8639-curvine",
+	}
+	got := CollectPassthroughParams(volumeContext, nil)
+	if len(got) != 1 || got["io-threads"] != "4" {
+		t.Fatalf("CollectPassthroughParams() = %#v, want only io-threads=4", got)
+	}
+}
+
 func TestRejectDisallowedVolumeParameters(t *testing.T) {
 	volumeContext := map[string]string{
 		"master-addrs": "m1:8995",

--- a/curvine-csi/pkg/csi/standalone_manager.go
+++ b/curvine-csi/pkg/csi/standalone_manager.go
@@ -499,7 +499,7 @@ func (m *standaloneMountManagerImpl) buildStandalone(opts *StandaloneOptions, po
 					StartupProbe: &corev1.Probe{
 						ProbeHandler: corev1.ProbeHandler{
 							Exec: &corev1.ExecAction{
-								Command: []string{"mountpoint", "-q", StandaloneMountPath},
+								Command: standaloneFuseMountProbeCommand(),
 							},
 						},
 						InitialDelaySeconds: 1,
@@ -512,7 +512,7 @@ func (m *standaloneMountManagerImpl) buildStandalone(opts *StandaloneOptions, po
 					ReadinessProbe: &corev1.Probe{
 						ProbeHandler: corev1.ProbeHandler{
 							Exec: &corev1.ExecAction{
-								Command: []string{"mountpoint", "-q", StandaloneMountPath},
+								Command: standaloneFuseMountProbeCommand(),
 							},
 						},
 						InitialDelaySeconds: 0,
@@ -525,7 +525,7 @@ func (m *standaloneMountManagerImpl) buildStandalone(opts *StandaloneOptions, po
 					LivenessProbe: &corev1.Probe{
 						ProbeHandler: corev1.ProbeHandler{
 							Exec: &corev1.ExecAction{
-								Command: []string{"mountpoint", "-q", StandaloneMountPath},
+								Command: standaloneFuseMountProbeCommand(),
 							},
 						},
 						InitialDelaySeconds: 0, // StartupProbe handles initial delay
@@ -943,6 +943,15 @@ func (m *standaloneMountManagerImpl) GetState() *StandaloneState {
 	}
 
 	return stateCopy
+}
+
+// standaloneFuseMountProbeCommand returns a probe command that detects curvinefs on
+// StandaloneMountPath without calling mountpoint(1), which can block on FUSE backends.
+func standaloneFuseMountProbeCommand() []string {
+	return []string{
+		"sh", "-c",
+		fmt.Sprintf("grep -qE '^[^ ]+ %s fuse' /proc/mounts", StandaloneMountPath),
+	}
 }
 
 // isMountPoint checks if a path is a mount point


### PR DESCRIPTION
## Problem

CSI parameter passthrough (issue #865) needs two fixes discovered during local
minikube testing: Kubernetes-injected volume context keys were forwarded to
curvine-fuse and crashed standalone pods, and standalone readiness probes using
`mountpoint` blocked indefinitely on curvinefs mounts. Local iteration also
needed a fast path to rebuild CSI with freshly built curvine-cli/curvine-fuse
binaries without a full image build.

## Design

1. Extend `IsDeniedVolumeParameterKey` to reject any `csi.storage.k8s.io/*` and
   `storage.kubernetes.io/*` keys so only user-facing SC/PV parameters reach fuse.
2. Replace standalone startup/readiness/liveness `mountpoint` probes with a
   `/proc/mounts` grep that does not block on FUSE backends.
3. Add `Dockerfile.quick` plus `make curvine-csi-quick` targets to layer local
   CSI/cli/fuse binaries onto the published runtime base image; registry address
   is parameterized via `CSI_QUICK_REGISTRY` (default `localhost:5000`).

## Key Changes

- `curvine-csi/pkg/csi/fuse_cli.go`: prefix denylist for K8s internal volume keys
- `curvine-csi/pkg/csi/fuse_cli_test.go`: unit tests for denylist and passthrough
- `curvine-csi/pkg/csi/standalone_manager.go`: non-blocking FUSE mount probes
- `curvine-csi/Dockerfile.quick`: quick local CSI image build
- `Makefile`: `curvine-csi-quick` / `curvine-csi-quick-push` targets
- `curvine-csi/.gitignore`: ignore `csi-binary` and `quick-build/` artifacts