### PR TITLE
fix(raft): return candidate init errors

### DIFF
--- a/curvine-common/src/raft/raft_journal.rs
+++ b/curvine-common/src/raft/raft_journal.rs
@@ -82,8 +82,7 @@ where
             sender,
             &self.logger,
         )
-        .await
-        .unwrap();
+        .await?;
 
         Self::start(server, node).await
     }

--- a/curvine-common/tests/raft_node_test.rs
+++ b/curvine-common/tests/raft_node_test.rs
@@ -15,16 +15,18 @@
 #![allow(unused)]
 
 use curvine_common::conf::JournalConf;
-use curvine_common::proto::raft::SnapshotData;
+use curvine_common::proto::raft::{FsmState, SnapshotData};
 use curvine_common::raft::storage::{
     AppStorage, HashAppStorage, LogStorage, MemLogStorage, RocksLogStorage,
 };
-use curvine_common::raft::{RaftClient, RaftJournal, RoleMonitor};
+use curvine_common::raft::{RaftClient, RaftError, RaftJournal, RaftResult, RoleMonitor};
 use curvine_common::utils::SerdeUtils;
 use orpc::common::{Logger, Utils};
 use orpc::runtime::{RpcRuntime, Runtime};
 use orpc::CommonResult;
 use prost::Message;
+use raft::eraftpb::{ConfState, Entry, HardState, Snapshot};
+use raft::{GetEntriesContext, RaftState, StateRole, Storage, StorageError};
 use std::sync::Arc;
 
 // Single-node memory storage test.
@@ -117,4 +119,135 @@ where
     });
 
     Ok(app_store)
+}
+
+#[derive(Clone, Default)]
+struct FailingSnapshotAppStorage;
+
+impl AppStorage for FailingSnapshotAppStorage {
+    async fn apply(&self, _: bool, _: curvine_common::raft::storage::ApplyMsg) -> RaftResult<()> {
+        Ok(())
+    }
+
+    fn get_fsm_state(&self) -> FsmState {
+        FsmState::default()
+    }
+
+    async fn role_change(&self, _: StateRole) -> RaftResult<()> {
+        Ok(())
+    }
+
+    async fn create_snapshot(&self) -> RaftResult<SnapshotData> {
+        Ok(SnapshotData::default())
+    }
+
+    async fn apply_snapshot(&self, _: SnapshotData) -> RaftResult<()> {
+        Err(RaftError::other("injected snapshot restore failure".into()))
+    }
+
+    fn snapshot_dir(&self, _: u64) -> RaftResult<String> {
+        Ok(String::new())
+    }
+}
+
+#[derive(Clone, Default)]
+struct NoSnapshotLogStorage;
+
+impl LogStorage for NoSnapshotLogStorage {
+    fn append(&self, _: &[Entry]) -> RaftResult<()> {
+        Ok(())
+    }
+
+    fn scan_entries(&self, _: u64, _: u64) -> RaftResult<Vec<Entry>> {
+        Ok(vec![])
+    }
+
+    fn set_hard_state(&self, _: &HardState) -> RaftResult<()> {
+        Ok(())
+    }
+
+    fn set_hard_state_commit(&self, _: u64) -> RaftResult<()> {
+        Ok(())
+    }
+
+    fn set_conf_state(&self, _: &ConfState) -> RaftResult<()> {
+        Ok(())
+    }
+
+    fn create_snapshot(&self, _: SnapshotData) -> RaftResult<()> {
+        Ok(())
+    }
+
+    fn apply_snapshot(&self, _: Snapshot) -> RaftResult<()> {
+        Ok(())
+    }
+
+    fn compact(&self, _: u64) -> RaftResult<()> {
+        Ok(())
+    }
+}
+
+impl Storage for NoSnapshotLogStorage {
+    fn initial_state(&self) -> raft::Result<RaftState> {
+        Ok(RaftState::default())
+    }
+
+    fn entries(
+        &self,
+        _: u64,
+        _: u64,
+        _: impl Into<Option<u64>>,
+        _: GetEntriesContext,
+    ) -> raft::Result<Vec<Entry>> {
+        Ok(vec![])
+    }
+
+    fn term(&self, _: u64) -> raft::Result<u64> {
+        Ok(0)
+    }
+
+    fn first_index(&self) -> raft::Result<u64> {
+        Ok(1)
+    }
+
+    fn last_index(&self) -> raft::Result<u64> {
+        Ok(0)
+    }
+
+    fn snapshot(&self, _: u64, _: u64) -> raft::Result<Snapshot> {
+        Err(raft::Error::Store(
+            StorageError::SnapshotTemporarilyUnavailable,
+        ))
+    }
+}
+
+#[test]
+fn run_candidate_returns_snapshot_restore_error_without_panicking() -> CommonResult<()> {
+    Logger::default();
+
+    let conf = JournalConf::with_test();
+    let rt = conf.create_runtime();
+    let raft = RaftJournal::new(
+        rt.clone(),
+        NoSnapshotLogStorage,
+        FailingSnapshotAppStorage,
+        conf,
+        RoleMonitor::new(),
+    );
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        rt.block_on(raft.run_candidate())
+    }));
+
+    let err = match result.expect("run_candidate should return an error instead of panicking") {
+        Ok(_) => panic!("snapshot restore failure should be returned to the caller"),
+        Err(err) => err,
+    };
+    assert!(
+        err.to_string()
+            .contains("injected snapshot restore failure"),
+        "unexpected error: {err}"
+    );
+
+    Ok(())
 }


### PR DESCRIPTION
## Problem

`RaftJournal::run_candidate()` used `unwrap()` on `RaftNode::new_candidate(...)`. If candidate startup failed while restoring snapshot state, the master process panicked instead of returning a typed error with context. That made recovery failures harder to diagnose and turned recoverable initialization errors into CrashLoopBackOff panics.

## Fix

- Replace the `unwrap()` with `?` so candidate initialization errors are returned to the caller.
- Add a regression test with injected snapshot restore failure to prove `run_candidate()` returns the error instead of panicking.

## Verification

- `cargo test -p curvine-common --test raft_node_test run_candidate_returns_snapshot_restore_error_without_panicking -- --nocapture`
- `cargo test -p curvine-common --test raft_node_test -- --nocapture`