### PR TITLE
fix(master): refuse empty non-format startup

### DIFF
--- a/curvine-server/src/master/journal/journal_system.rs
+++ b/curvine-server/src/master/journal/journal_system.rs
@@ -29,11 +29,14 @@ use curvine_common::raft::storage::{AppStorage, LogStorage, RocksLogStorage};
 use curvine_common::raft::{RaftClient, RaftResult, RoleMonitor, RoleStateListener};
 use curvine_common::FsResult;
 use orpc::common::FileUtils;
+use orpc::err_box;
 use orpc::runtime::{RpcRuntime, Runtime};
 use orpc::sync::StateCtl;
 use prost::Message;
 use raft::eraftpb::Entry;
 use raft::Storage;
+use std::fs;
+use std::path::Path;
 use std::sync::Arc;
 
 // Send and replay metadata operation logs based on raft.
@@ -141,8 +144,54 @@ impl JournalSystem {
         })
     }
 
+    fn require_existing_master_data(conf: &ClusterConf) -> FsResult<()> {
+        if conf.format_master || conf.journal.journal_addrs.len() > 1 {
+            return Ok(());
+        }
+
+        let meta_db_conf = conf.db_conf();
+        let journal_db_conf = conf.journal.db_conf();
+        let mut invalid_dirs = Vec::new();
+
+        if !Self::looks_like_rocksdb_data_dir(&meta_db_conf.data_dir) {
+            invalid_dirs.push(format!("meta={}", meta_db_conf.data_dir));
+        }
+        if !Self::looks_like_rocksdb_data_dir(&journal_db_conf.data_dir) {
+            invalid_dirs.push(format!("journal={}", journal_db_conf.data_dir));
+        }
+
+        if invalid_dirs.is_empty() {
+            return Ok(());
+        }
+
+        err_box!(
+            "format_master=false requires existing RocksDB data directories for single-master startup; missing, empty, or unreadable: {}",
+            invalid_dirs.join(", ")
+        )
+    }
+
+    fn looks_like_rocksdb_data_dir(path: &str) -> bool {
+        let path = Path::new(path);
+        if !path.is_dir() || !path.join("CURRENT").is_file() {
+            return false;
+        }
+
+        fs::read_dir(path)
+            .map(|entries| {
+                entries.filter_map(Result::ok).any(|entry| {
+                    entry
+                        .file_name()
+                        .to_str()
+                        .is_some_and(|name| name.starts_with("MANIFEST-"))
+                })
+            })
+            .unwrap_or(false)
+    }
+
     pub fn from_conf(conf: &ClusterConf) -> FsResult<Self> {
         // When the journal system is used, please note that it is separate from the fs system.
+        Self::require_existing_master_data(conf)?;
+
         let rt = conf.journal.create_runtime();
 
         let log_store = RocksLogStorage::from_conf(&conf.journal, conf.format_master);

--- a/curvine-server/tests/master_fs_test.rs
+++ b/curvine-server/tests/master_fs_test.rs
@@ -20,6 +20,7 @@ use curvine_common::proto::{
     CreateFileRequest, DeleteRequest, MkdirOptsProto, MkdirRequest, RenameRequest,
 };
 use curvine_common::raft::storage::{AppStorage, ApplyMsg};
+use curvine_common::raft::RaftPeer;
 use curvine_common::state::MountOptions;
 use curvine_common::state::{
     BlockLocation, ClientAddress, CommitBlock, CreateFileOpts, WorkerInfo,
@@ -34,7 +35,7 @@ use orpc::common::LocalTime;
 use orpc::common::Utils;
 use orpc::message::Builder;
 use orpc::runtime::{AsyncRuntime, RpcRuntime};
-use orpc::CommonResult;
+use orpc::{err_box, CommonResult};
 use raft::eraftpb::Entry;
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
@@ -265,6 +266,83 @@ fn test_filesystem_metadata_restore_with_full_journal_system_reopen() -> CommonR
     assert_eq!(hash1, fs.sum_hash());
 
     drop(fs);
+    js.shutdown();
+
+    Ok(())
+}
+
+#[test]
+fn test_journal_system_refuses_non_format_start_with_empty_master_dirs() -> CommonResult<()> {
+    let _serial = master_fs_test_serial();
+    Master::init_test_metrics();
+    let name = format!("empty-non-format-{}", Utils::rand_str(6));
+    let mut conf = ClusterConf {
+        format_master: false,
+        testing: true,
+        master: MasterConf {
+            meta_dir: Utils::test_sub_dir(format!("master-fs-test/meta-{}", name)),
+            ..Default::default()
+        },
+        journal: JournalConf {
+            enable: false,
+            journal_dir: Utils::test_sub_dir(format!("master-fs-test/journal-{}", name)),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let _ = std::fs::remove_dir_all(&conf.master.meta_dir);
+    let _ = std::fs::remove_dir_all(&conf.journal.journal_dir);
+    std::fs::create_dir_all(&conf.master.meta_dir)?;
+    std::fs::create_dir_all(&conf.journal.journal_dir)?;
+    conf.format_master = false;
+
+    let err = match JournalSystem::from_conf(&conf) {
+        Ok(js) => {
+            js.shutdown();
+            return err_box!("format_master=false initialized empty master data directories");
+        }
+        Err(e) => e,
+    };
+    let err_msg = err.to_string();
+    assert!(
+        err_msg.contains("format_master=false")
+            && err_msg.contains("missing, empty, or unreadable"),
+        "unexpected error: {}",
+        err_msg
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_journal_system_allows_empty_non_format_start_for_multi_master() -> CommonResult<()> {
+    let _serial = master_fs_test_serial();
+    Master::init_test_metrics();
+    let name = format!("empty-non-format-ha-{}", Utils::rand_str(6));
+    let mut conf = ClusterConf {
+        format_master: false,
+        testing: true,
+        master: MasterConf {
+            meta_dir: Utils::test_sub_dir(format!("master-fs-test/meta-{}", name)),
+            ..Default::default()
+        },
+        journal: JournalConf {
+            enable: false,
+            journal_dir: Utils::test_sub_dir(format!("master-fs-test/journal-{}", name)),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    conf.journal.journal_addrs = vec![
+        RaftPeer::new(1, "localhost", conf.journal.rpc_port),
+        RaftPeer::new(2, "localhost", conf.journal.rpc_port + 1),
+    ];
+    let _ = std::fs::remove_dir_all(&conf.master.meta_dir);
+    let _ = std::fs::remove_dir_all(&conf.journal.journal_dir);
+    std::fs::create_dir_all(&conf.master.meta_dir)?;
+    std::fs::create_dir_all(&conf.journal.journal_dir)?;
+
+    let js = JournalSystem::from_conf(&conf)?;
     js.shutdown();
 
     Ok(())


### PR DESCRIPTION
## Problem

`JournalSystem::from_conf()` allowed `format_master=false` startup even when the configured meta and journal RocksDB data directories were empty or missing. RocksDB is configured with `create_if_missing(true)`, so an empty Kubernetes hostPath can be initialized as a blank master state instead of failing fast. This is unsafe for a StatefulSet rescheduled to a node without the original local data.

## Fix

- Add a preflight check for `format_master=false` before opening the journal system.
- Require both meta and journal RocksDB data directories to look like existing RocksDB databases by checking for `CURRENT` and `MANIFEST-*`.
- Return a clear error that lists the missing or empty paths.
- Keep explicit `format_master=true` initialization unchanged.

## Verification

- Reproduced the previous behavior with a failing test: `format_master=false initialized empty master data directories`.
- `cargo test -p curvine-server --test master_fs_test test_journal_system_refuses_non_format_start_with_empty_master_dirs -- --nocapture`
- `cargo test -p curvine-server --test master_fs_test -- --nocapture`
- `cargo test -p curvine-server --test journal_test -- --nocapture`
- `git diff --check`