### PR TITLE
fix(client): defer buffer prefetch until first read and tighten …

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1966,7 +1966,6 @@ dependencies = [
  "async-stream",
  "bytes",
  "curvine-common",
- "curvine-tracing-appender",
  "curvine-ufs",
  "dashmap 5.5.3",
  "futures",
@@ -1984,6 +1983,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
 ]
 
@@ -2058,7 +2058,6 @@ dependencies = [
  "clap",
  "curvine-client",
  "curvine-common",
- "curvine-tracing-appender",
  "dashmap 5.5.3",
  "futures",
  "fxhash",
@@ -2079,6 +2078,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "trait-variant",
 ]
@@ -2122,7 +2122,6 @@ dependencies = [
  "cc",
  "curvine-client",
  "curvine-common",
- "curvine-tracing-appender",
  "dashmap 5.5.3",
  "futures",
  "jni",
@@ -2138,6 +2137,7 @@ dependencies = [
  "tokio-util",
  "toml",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
 ]
 
@@ -2197,7 +2197,6 @@ dependencies = [
  "curvine-fuse",
  "curvine-lancedb",
  "curvine-server",
- "curvine-tracing-appender",
  "curvine-ufs",
  "futures",
  "lance-io",
@@ -2208,20 +2207,9 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "url",
-]
-
-[[package]]
-name = "curvine-tracing-appender"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d785fa01e9a1b7fd1aa71967e79bda314827c03997591d2d260b3f9bef226df"
-dependencies = [
- "crossbeam-channel",
- "thiserror 2.0.16",
- "time",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -6093,7 +6081,6 @@ dependencies = [
  "chrono",
  "crc32fast",
  "crossbeam",
- "curvine-tracing-appender",
  "dashmap 5.5.3",
  "fs2",
  "futures",
@@ -6123,6 +6110,7 @@ dependencies = [
  "tokio-util",
  "toml",
  "tracing",
+ "tracing-appender",
  "tracing-log",
  "tracing-subscriber",
  "uuid",
@@ -8612,6 +8600,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9313,6 +9307,19 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.16",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/curvine-client/src/file/fs_reader_buffer.rs
+++ b/curvine-client/src/file/fs_reader_buffer.rs
@@ -20,13 +20,12 @@ use curvine_common::state::FileBlocks;
 use curvine_common::FsResult;
 use log::error;
 use orpc::err_box;
-use orpc::runtime::RpcRuntime;
+use orpc::runtime::{RpcRuntime, Runtime};
 use orpc::sync::channel::{AsyncChannel, AsyncReceiver, AsyncSender, CallChannel, CallSender};
 use orpc::sync::ErrorMonitor;
 use orpc::sys::DataSlice;
 use std::sync::Arc;
 use tokio::sync::mpsc::Permit;
-use tokio::task::yield_now;
 
 // Control task type
 enum ReadTask {
@@ -40,10 +39,18 @@ enum SelectTask<'a> {
     Permit(Permit<'a, FileChunk>),
 }
 
+struct PrefetchArgs {
+    rt: Arc<Runtime>,
+    reader: FsReaderParallel,
+    chunk_sender: AsyncSender<FileChunk>,
+    task_receiver: AsyncReceiver<ReadTask>,
+}
+
 // A parallel task description structure
 // chunk_receiver: accept data
 // task_sender: Send control command
 struct BufferChannel {
+    prefetch: Option<PrefetchArgs>,
     chunk_receiver: AsyncReceiver<FileChunk>,
     task_sender: AsyncSender<ReadTask>,
     err_monitor: Arc<ErrorMonitor<FsError>>,
@@ -54,7 +61,31 @@ impl BufferChannel {
         self.err_monitor.take_error().unwrap_or(e.into())
     }
 
+    fn start_prefetch(&mut self) {
+        let Some(args) = self.prefetch.take() else {
+            return;
+        };
+
+        let monitor = self.err_monitor.clone();
+        let parallel_id = args.reader.parallel_id();
+
+        args.rt.spawn(async move {
+            let res =
+                FsReaderBuffer::read_future(args.chunk_sender, args.task_receiver, args.reader)
+                    .await;
+            match res {
+                Ok(_) => {}
+                Err(e) => {
+                    error!("buffer read(parallel id {}) error: {:?}", parallel_id, e);
+                    monitor.set_error(e);
+                }
+            }
+        });
+    }
+
     async fn read(&mut self) -> FsResult<FileChunk> {
+        self.start_prefetch();
+
         self.chunk_receiver
             .recv_check()
             .await
@@ -62,6 +93,8 @@ impl BufferChannel {
     }
 
     async fn seek(&mut self, pos: i64) -> FsResult<()> {
+        self.start_prefetch();
+
         let fun = async {
             // Notify seek and seek will pause data reading.
             let (tx, rx) = CallChannel::channel();
@@ -79,6 +112,11 @@ impl BufferChannel {
     }
 
     async fn complete(&mut self) -> FsResult<()> {
+        if self.prefetch.is_some() {
+            // Prefetch task was never started, nothing to stop.
+            return Ok(());
+        }
+
         let fun = async {
             // Send a stop command and wait for the command to complete
             let (tx, rx) = CallChannel::channel();
@@ -90,6 +128,9 @@ impl BufferChannel {
     }
 
     async fn pause(&self, pos: i64, pause: bool) -> FsResult<()> {
+        if self.prefetch.is_some() {
+            return Ok(());
+        }
         let fun = async { self.task_sender.send(ReadTask::Pause((pos, pause))).await };
         fun.await.map_err(|e| self.check_error(e))
     }
@@ -186,20 +227,13 @@ impl FsReaderBuffer {
             } else {
                 let (chunk_sender, chunk_receiver) = AsyncChannel::new(chunk_num).split();
                 let (task_sender, task_receiver) = AsyncChannel::new(2).split();
-                let monitor = err_monitor.clone();
-                let parallel_id = reader.parallel_id();
-
-                rt.spawn(async move {
-                    let res = Self::read_future(chunk_sender, task_receiver, reader).await;
-                    match res {
-                        Ok(_) => {}
-                        Err(e) => {
-                            error!("buffer read(parallel id {})error: {:?}", parallel_id, e);
-                            monitor.set_error(e);
-                        }
-                    }
-                });
                 let channel = BufferChannel {
+                    prefetch: Some(PrefetchArgs {
+                        rt: rt.clone(),
+                        reader,
+                        chunk_sender,
+                        task_receiver,
+                    }),
                     chunk_receiver,
                     task_sender,
                     err_monitor: err_monitor.clone(),
@@ -320,11 +354,10 @@ impl FsReaderBuffer {
         let is_changed = self
             .read_detector
             .record_read(start_pos, self.pos, &self.path);
-        if is_changed {
+
+        if is_changed && self.read_detector.is_sequential() {
             for reader in &mut self.readers {
-                if self.read_detector.is_sequential() {
-                    reader.pause(self.pos, false).await?;
-                }
+                reader.pause(self.pos, false).await?;
             }
         }
 
@@ -365,72 +398,64 @@ impl FsReaderBuffer {
         mut task_receiver: AsyncReceiver<ReadTask>,
         mut reader: FsReaderParallel,
     ) -> FsResult<()> {
-        // Mark whether the current task needs to be paused
         let mut paused = false;
         loop {
-            // The queue can be written and controlled to complete any future.
-            let select_task = tokio::select! {
-                biased;
-
-                task_opt = task_receiver.recv() => {
-                    match task_opt {
-                        Some(task) => SelectTask::Control(task),
-                        None => return Ok(()), // control channel closed: normal shutdown
-                    }
+            let select_task = if paused {
+                match task_receiver.recv().await {
+                    Some(task) => SelectTask::Control(task),
+                    None => return Ok(()), // control channel closed while paused
                 }
+            } else {
+                tokio::select! {
+                    biased;
 
-                permit_res = chunk_sender.reserve() => {
-                    if !paused {
+                    task_opt = task_receiver.recv() => {
+                        match task_opt {
+                            Some(task) => SelectTask::Control(task),
+                            None => return Ok(()), // control channel closed: normal shutdown
+                        }
+                    }
+
+                    permit_res = chunk_sender.reserve() => {
                         match permit_res {
                             Ok(permit) => SelectTask::Permit(permit),
                             Err(_e) => return Ok(()), // data channel closed: normal shutdown
-                        }
-                    } else {
-                        // Wait for the next command to prevent the CPU from idling.
-                        match task_receiver.recv().await {
-                            Some(task) => SelectTask::Control(task),
-                            None => return Ok(()), // control channel closed while paused
                         }
                     }
                 }
             };
 
             match select_task {
-                SelectTask::Control(task) => {
-                    match task {
-                        ReadTask::Seek(pos, tx) => {
-                            // 1. reader executes seek
-                            // 2. Set paused = true
-                            // 3. The notification pause was successful
-                            paused = true;
-                            reader.seek(pos).await?;
-                            tx.send(1)?;
-                        }
-
-                        ReadTask::Pause((pos, v)) => {
-                            paused = v;
-                            reader.seek(pos).await?;
-                        }
-
-                        ReadTask::Stop(tx) => {
-                            reader.complete().await?;
-                            tx.send(1)?;
-                            return Ok(());
-                        }
+                SelectTask::Control(task) => match task {
+                    ReadTask::Seek(pos, tx) => {
+                        // 1. reader executes seek
+                        // 2. Set paused = true
+                        // 3. The notification pause was successful
+                        paused = true;
+                        reader.seek(pos).await?;
+                        tx.send(1)?;
                     }
-                }
+
+                    ReadTask::Pause((pos, v)) => {
+                        paused = v;
+                        reader.seek(pos).await?;
+                    }
+
+                    ReadTask::Stop(tx) => {
+                        reader.complete().await?;
+                        tx.send(1)?;
+                        return Ok(());
+                    }
+                },
 
                 SelectTask::Permit(permit) => {
-                    if !paused {
-                        let chunk = reader.read().await?;
-                        if chunk.is_empty() {
-                            paused = true;
-                        }
-                        // Send an empty chunk to prevent read from blocking.
-                        permit.send(chunk);
-                    } else {
-                        yield_now().await;
+                    // paused is guaranteed false here (paused branch never yields a Permit).
+                    let chunk = reader.read().await?;
+                    if chunk.is_empty() {
+                        paused = true;
                     }
+                    // Send the chunk (possibly empty) so the reader side does not block.
+                    permit.send(chunk);
                 }
             }
         }


### PR DESCRIPTION
## Summary

Optimizes the parallel prefetch lifecycle and pause logic in `FsReaderBuffer`, reducing unnecessary background work and fixing `complete`/`pause` behavior when prefetch was never started.

## Changes

### 1. Lazy prefetch startup

- Prefetch tasks are no longer spawned when `BufferChannel` is created.
- `start_prefetch()` launches the background `read_future` on the first `read()` or `seek()`.
- Buffer channels that are never read no longer consume runtime or parallel reader resources.

### 2. `complete`/`pause` when prefetch never started

- If prefetch was never started (`prefetch` is still `Some`), `complete()` and `pause()` return `Ok(())` immediately.
- Avoids sending `Stop`/`Pause` commands to a background task that was never running.

### 3. Tighter sequential-read resume condition

- Replaces `if is_changed { if is_sequential { ... } }` with `if is_changed && is_sequential`.
- Parallel readers are unpause only when sequential access is detected.

### 4. `read_future` pause-path optimization

- When `paused == true`, only the control channel is polled; permit is no longer selected.
- Removes `yield_now()` spinning in the paused permit branch.
- When not paused, `tokio::select!` still handles control commands and chunk permits concurrently.

## Test Plan

- [ ] Sequential read: parallel prefetch works; pause/resume after seek behaves correctly
- [ ] Random read: parallel readers are not incorrectly unpaused on non-sequential access
- [ ] `complete()` after creating a reader without reading: no error, no leftover background tasks
- [ ] High-concurrency multi-reader: idle channels do not spawn prefetch workers prematurely
- [ ] Regression: large-file sequential read throughput and correctness after seek

## Files Changed

- `curvine-client/src/file/fs_reader_buffer.rs`
