### PR TITLE
refactor(fuse): replace inline cache cleanup with a scheduled Cleaner…

### DIFF
--- a/curvine-common/src/conf/fuse_conf.rs
+++ b/curvine-common/src/conf/fuse_conf.rs
@@ -304,7 +304,7 @@ impl Default for FuseConf {
             meta_cache_ttl: "120s".to_string(),
 
             node_cache_size: 200000,
-            node_cache_timeout: "24h".to_string(),
+            node_cache_timeout: "1h".to_string(),
 
             direct_io: false,
             write_back_cache: false,

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::fs::operator::*;
-use crate::fs::state::{FileHandle, NodeState};
+use crate::fs::state::{CleanerTask, FileHandle, NodeState};
 use crate::raw::fuse_abi::*;
 use crate::raw::FuseDirentList;
 use crate::session::{FuseBuf, FuseResponse};
@@ -49,6 +49,8 @@ impl CurvineFileSystem {
         let fuse_conf = conf.fuse.clone();
         let fs = UnifiedFileSystem::with_rt(conf, rt)?;
         let state = Arc::new(NodeState::new(fs.clone()));
+
+        CleanerTask::start(fuse_conf.node_cache_ttl.as_millis() as u64, state.clone())?;
 
         let fuse_fs = Self {
             fs,

--- a/curvine-fuse/src/fs/state/cleaner_task.rs
+++ b/curvine-fuse/src/fs/state/cleaner_task.rs
@@ -1,0 +1,55 @@
+//  Copyright 2025 OPPO.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+use crate::fs::state::NodeState;
+use crate::{FuseError, FuseResult};
+use curvine_common::executor::ScheduledExecutor;
+use orpc::runtime::LoopTask;
+use std::sync::{Arc, Weak};
+
+pub struct CleanerTask {
+    state: Weak<NodeState>,
+}
+
+impl CleanerTask {
+    pub fn start(interval_ms: u64, state: Arc<NodeState>) -> FuseResult<()> {
+        if interval_ms == 0 {
+            return Ok(());
+        }
+
+        let task = CleanerTask {
+            state: Arc::downgrade(&state),
+        };
+
+        let interval_ms = (interval_ms / 2).max(1);
+        let executor = ScheduledExecutor::new("dcache-cleaner", interval_ms);
+        executor.start(task)?;
+        Ok(())
+    }
+}
+
+impl LoopTask for CleanerTask {
+    type Error = FuseError;
+
+    fn run(&self) -> Result<(), Self::Error> {
+        match self.state.upgrade() {
+            Some(state) => state.clear(),
+            None => Ok(()),
+        }
+    }
+
+    fn terminate(&self) -> bool {
+        self.state.strong_count() == 0
+    }
+}

--- a/curvine-fuse/src/fs/state/mod.rs
+++ b/curvine-fuse/src/fs/state/mod.rs
@@ -26,3 +26,6 @@ pub use self::file_handle::FileHandle;
 
 mod dir_handle;
 pub use self::dir_handle::DirHandle;
+
+mod cleaner_task;
+pub use self::cleaner_task::CleanerTask;

--- a/curvine-fuse/src/fs/state/node_map.rs
+++ b/curvine-fuse/src/fs/state/node_map.rs
@@ -35,7 +35,6 @@ pub struct NodeMap {
     pending_deletes: FastHashSet<u64>,
     id_creator: AtomicCounter,
     cache_ttl: u64,
-    last_clean: u64,
     conf: FuseConf,
 }
 
@@ -50,7 +49,6 @@ impl NodeMap {
             pending_deletes: FastHashSet::default(),
             id_creator: AtomicCounter::new(FUSE_ROOT_ID),
             cache_ttl: conf.node_cache_ttl.as_millis() as u64,
-            last_clean: LocalTime::mills(),
             conf: conf.clone(),
         }
     }
@@ -162,8 +160,6 @@ impl NodeMap {
         parent: u64,
         name: Option<T>,
     ) -> FuseResult<&mut NodeAttr> {
-        self.clean_cache();
-
         let ino = match self.lookup_node(parent, name.as_ref()) {
             Some(v) => v.id,
 
@@ -431,10 +427,6 @@ impl NodeMap {
 
     pub fn clean_cache(&mut self) {
         let now = LocalTime::mills();
-        if self.last_clean + self.cache_ttl > now {
-            return;
-        }
-
         let expired_nodes: Vec<_> = self
             .nodes
             .iter()
@@ -450,7 +442,6 @@ impl NodeMap {
             }
         }
 
-        self.last_clean = now;
         info!(
             "Clean node cache, total nodes {}, delete nodes {}, cost {} ms",
             self.nodes.len(),

--- a/curvine-fuse/src/fs/state/node_state.rs
+++ b/curvine-fuse/src/fs/state/node_state.rs
@@ -105,6 +105,11 @@ impl NodeState {
         is_changed
     }
 
+    pub fn clear(&self) -> FuseResult<()> {
+        self.node_write().clean_cache();
+        Ok(())
+    }
+
     pub fn should_keep_cache(&self, id: u64, status: &FileStatus) -> bool {
         let is_changed = self.update_cache_state(id, status);
         !is_changed


### PR DESCRIPTION
## Summary

Cache eviction for FUSE inode entries (`NodeMap`) was previously triggered
inline inside `find_node()`, guarded by an internal `last_clean` timestamp.
This approach couples cache maintenance to the lookup hot path and makes the
eviction interval depend on lookup traffic rather than real time.

This change extracts the cleanup into `CleanerTask`, a `LoopTask` backed by
`ScheduledExecutor`, which runs `NodeState::clear()` at a fixed interval
(`node_cache_ttl / 2`). The throttle field is removed from `NodeMap` and the
`clean_cache()` call is dropped from `find_node()`.

## Changes

### 1. New `CleanerTask` (`state/cleaner_task.rs`)

Implements `LoopTask` for `FuseError`. `CleanerTask::start()` takes the
`node_cache_ttl` in milliseconds, halves it (minimum 1 ms), creates a named
`ScheduledExecutor("dcache-cleaner")`, and starts the task. Each tick calls
`NodeState::clear()`.

### 2. `NodeState::clear()` (`state/node_state.rs`)

New public method that acquires a write lock on `NodeMap` and calls
`clean_cache()`. Provides a clean boundary between the task layer and the
state internals.

### 3. Remove throttle from `NodeMap` (`state/node_map.rs`)

- Removed `last_clean: u64` field and its initializer.
- Removed the early-return guard `if self.last_clean + self.cache_ttl > now` from `clean_cache()`.
- Removed `self.clean_cache()` call from `find_node()`.

The interval is now enforced externally by `ScheduledExecutor`, so no
in-band throttling is needed.

### 4. Start `CleanerTask` on startup (`curvine_file_system.rs`)

`CurvineFileSystem::new()` calls `CleanerTask::start(fuse_conf.node_cache_ttl, state.clone())`
immediately after `NodeState` is created.

### 5. Export via `state/mod.rs`

`CleanerTask` is re-exported from `crate::fs::state` so the file system
constructor can import it alongside `NodeState`.

## Before / After

| Aspect | Before | After |
|--------|--------|-------|
| Cleanup trigger | Inline in `find_node()` hot path | Background `ScheduledExecutor` tick |
| Throttle | `last_clean` field + time check in `NodeMap` | `ScheduledExecutor` interval |
| `find_node()` cost | Acquires write lock + scans nodes periodically | No cleanup overhead |
| Eviction frequency | Depends on lookup traffic | Fixed at `node_cache_ttl / 2` |

## Files Changed

| File | Change |
|------|--------|
| `curvine-fuse/src/fs/state/cleaner_task.rs` | New — background cleanup task |
| `curvine-fuse/src/fs/state/mod.rs` | Export `CleanerTask` |
| `curvine-fuse/src/fs/state/node_state.rs` | Add `clear()` entry point |
| `curvine-fuse/src/fs/state/node_map.rs` | Remove `last_clean` throttle and inline call |
| `curvine-fuse/src/fs/curvine_file_system.rs` | Start `CleanerTask` on construction |