### PR TITLE
fix(fuse): ensure handle is always removed on release and guard write…

### DIFF
--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -1239,14 +1239,16 @@ impl fs::FileSystem for CurvineFileSystem {
 
     async fn release(&self, op: Release<'_>, reply: FuseResponse) -> FuseResult<()> {
         let ino = op.header.nodeid;
-        let handle = match self.state.remove_handle(ino, op.arg.fh) {
-            Some(handle) => handle,
-            None => return err_fuse!(libc::EBADF),
-        };
+        let handle = self.state.find_handle(ino, op.arg.fh)?;
 
-        self.fs_unlock(&handle, LockFlags::Flock).await?;
-        self.fs_unlock(&handle, LockFlags::Plock).await?;
-        let complete_result = handle.complete(Some(reply)).await;
+        let complete_result = self
+            .fs_unlock(&handle, LockFlags::Flock)
+            .await
+            .and(self.fs_unlock(&handle, LockFlags::Plock).await)
+            .and(handle.complete(Some(reply)).await);
+
+        self.state.remove_handle(ino, op.arg.fh);
+        complete_result?;
 
         if !self.state.has_open_handles(ino) && self.state.remove_pending_delete(ino) {
             let path = Path::from_str(&handle.status.path)?;
@@ -1264,7 +1266,7 @@ impl fs::FileSystem for CurvineFileSystem {
             self.invalidate_cache(&path)?;
         }
 
-        complete_result
+        Ok(())
     }
 
     async fn forget(&self, op: Forget<'_>) -> FuseResult<()> {

--- a/curvine-fuse/src/fs/fuse_writer.rs
+++ b/curvine-fuse/src/fs/fuse_writer.rs
@@ -153,6 +153,7 @@ impl FuseWriter {
         mut req_receiver: AsyncReceiver<WriteTask>,
         file_len: Arc<Mutex<i64>>,
     ) -> FsResult<()> {
+        let mut complete = false;
         while let Some(task) = req_receiver.recv().await {
             match task {
                 WriteTask::Write(off, data, reply) => {
@@ -182,7 +183,16 @@ impl FuseWriter {
                 }
 
                 WriteTask::Complete(tx, reply) => {
-                    let res = writer.complete().await;
+                    let res = if !complete {
+                        let res = writer.complete().await;
+                        if res.is_ok() {
+                            complete = true;
+                        }
+                        res
+                    } else {
+                        Ok(())
+                    };
+
                     if let Some(reply) = reply {
                         reply.send_rep(res).await?;
                     }

--- a/curvine-fuse/src/fs/state/node_state.rs
+++ b/curvine-fuse/src/fs/state/node_state.rs
@@ -298,6 +298,13 @@ impl NodeState {
         Ok(reader)
     }
 
+    pub async fn complete_writer(&self, ino: u64) -> FuseResult<()> {
+        if let Some(existing_writer) = self.find_writer(&ino) {
+            existing_writer.lock().await.complete(None).await?;
+        }
+        Ok(())
+    }
+
     pub async fn new_handle(
         &self,
         ino: u64,


### PR DESCRIPTION
## Summary

Three related fixes for correctness around file handle lifecycle and writer
completion:

1. **`release()` handle leak** — the old code called `remove_handle()` first
   and returned early on error, so if `fs_unlock` or `complete` failed, the
   handle was already gone from the map but the underlying writer/reader was
   never finalized.

2. **`FuseWriter` double-complete** — when a file handle is closed multiple
   times (e.g. from a retry or an explicit flush followed by release), the
   underlying writer's `complete()` was called twice, potentially causing a
   double-free or protocol error with the storage backend.

3. **`complete_writer` helper** — provides a single entry point to flush an
   in-flight writer for a given inode before a rename or unlink, without
   requiring the caller to locate and manage the handle directly.

## Changes

### 1. Fix `release()` cleanup order (`curvine_file_system.rs`)

**Before:**
```rust
let handle = match self.state.remove_handle(ino, op.arg.fh) { ... };
self.fs_unlock(&handle, LockFlags::Flock).await?;   // early return on error
self.fs_unlock(&handle, LockFlags::Plock).await?;   // skipped if above fails
let complete_result = handle.complete(Some(reply)).await;
// handle already removed; complete_result returned at end
```

**After:**
```rust
let handle = self.state.find_handle(ino, op.arg.fh)?;   // borrow, not remove

let complete_result = self
    .fs_unlock(&handle, LockFlags::Flock).await
    .and(self.fs_unlock(&handle, LockFlags::Plock).await)
    .and(handle.complete(Some(reply)).await);

self.state.remove_handle(ino, op.arg.fh);   // always runs
complete_result?;
```

`find_handle` borrows without removing, so the handle remains accessible to
all three steps. `remove_handle` is called unconditionally afterwards,
guaranteeing cleanup. Errors from all three steps are chained with `.and()`
so the first failure is propagated after cleanup.

### 2. Guard `FuseWriter` against double-complete (`fuse_writer.rs`)

Added a `complete: bool` flag to the write loop. On the first
`WriteTask::Complete`, the underlying writer's `complete()` is called and
`complete` is set to `true`. Subsequent `Complete` tasks return `Ok(())` immediately,
preventing a second call to the storage backend.

### 3. Add `NodeState::complete_writer` helper (`node_state.rs`)

```rust
pub async fn complete_writer(&self, ino: u64) -> FuseResult<()> {
    if let Some(existing_writer) = self.find_writer(&ino) {
        existing_writer.complete(None).await?;
    }
    Ok(())
}
```

Allows callers (e.g. rename pre-flush) to complete an open writer for an
inode without holding a file handle reference.

## Files Changed

| File | Change |
|------|--------|
| `curvine-fuse/src/fs/curvine_file_system.rs` | Fix `release()` cleanup order and error propagation |
| `curvine-fuse/src/fs/fuse_writer.rs` | Guard writer `complete` against duplicate calls |
| `curvine-fuse/src/fs/state/node_state.rs` | Add `complete_writer` helper |