### PR TITLE
feat(fuse): phase 0 metrics enabling primitives (#897)

### DIFF
--- a/curvine-fuse/src/fuse_error.rs
+++ b/curvine-fuse/src/fuse_error.rs
@@ -112,3 +112,90 @@ impl From<std::io::Error> for FuseError {
         Self::new(libc::EIO, value.into())
     }
 }
+
+/// Maps an errno integer to a stable, low-cardinality symbolic `&'static str`
+/// label, suitable for the `errno` label on error metrics. Zero-allocation: the
+/// metrics hot path must never format the raw integer or a libc-locale string.
+///
+/// The table is the closed set of errnos actually produced in the FUSE layer
+/// (verified against `libc::E*` usage across `curvine-fuse/src/` plus the
+/// `FsError -> errno` mapping above). Any errno outside the table collapses to
+/// `"OTHER"`; if a new errno starts being produced, add it here and to the
+/// design doc's label table together.
+// Phase 0 enabling primitive: defined here, wired to call sites in Phase 1.
+#[allow(dead_code)]
+pub(crate) fn errno_label(errno: i32) -> &'static str {
+    match errno {
+        libc::ENOENT => "ENOENT",
+        libc::EIO => "EIO",
+        libc::EINTR => "EINTR",
+        libc::ENOSYS => "ENOSYS",
+        libc::EAGAIN => "EAGAIN",
+        libc::EACCES => "EACCES",
+        libc::EBADF => "EBADF",
+        libc::EINVAL => "EINVAL",
+        libc::EPERM => "EPERM",
+        libc::EOPNOTSUPP => "EOPNOTSUPP",
+        libc::EEXIST => "EEXIST",
+        libc::ENOTDIR => "ENOTDIR",
+        libc::EISDIR => "EISDIR",
+        libc::ENOTEMPTY => "ENOTEMPTY",
+        libc::ETIMEDOUT => "ETIMEDOUT",
+        libc::ENOSPC => "ENOSPC",
+        libc::ETXTBSY => "ETXTBSY",
+        libc::EPROTO => "EPROTO",
+        libc::ERANGE => "ERANGE",
+        libc::ENODATA => "ENODATA",
+        libc::ENOMEM => "ENOMEM",
+        libc::EBUSY => "EBUSY",
+        libc::ENAMETOOLONG => "ENAMETOOLONG",
+        _ => "OTHER",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::errno_label;
+
+    #[test]
+    fn errno_label_maps_the_closed_set() {
+        // Full (errno, expected-label) table. Any accidental relabeling must
+        // update this table and the design doc's errno Label rules together.
+        let table = [
+            (libc::ENOENT, "ENOENT"),
+            (libc::EIO, "EIO"),
+            (libc::EINTR, "EINTR"),
+            (libc::ENOSYS, "ENOSYS"),
+            (libc::EAGAIN, "EAGAIN"),
+            (libc::EACCES, "EACCES"),
+            (libc::EBADF, "EBADF"),
+            (libc::EINVAL, "EINVAL"),
+            (libc::EPERM, "EPERM"),
+            (libc::EOPNOTSUPP, "EOPNOTSUPP"),
+            (libc::EEXIST, "EEXIST"),
+            (libc::ENOTDIR, "ENOTDIR"),
+            (libc::EISDIR, "EISDIR"),
+            (libc::ENOTEMPTY, "ENOTEMPTY"),
+            (libc::ETIMEDOUT, "ETIMEDOUT"),
+            (libc::ENOSPC, "ENOSPC"),
+            (libc::ETXTBSY, "ETXTBSY"),
+            (libc::EPROTO, "EPROTO"),
+            (libc::ERANGE, "ERANGE"),
+            (libc::ENODATA, "ENODATA"),
+            (libc::ENOMEM, "ENOMEM"),
+            (libc::EBUSY, "EBUSY"),
+            (libc::ENAMETOOLONG, "ENAMETOOLONG"),
+        ];
+        for (e, expected) in table {
+            assert_eq!(errno_label(e), expected, "label mismatch for errno {}", e);
+        }
+    }
+
+    #[test]
+    fn unmapped_errno_falls_back_to_other() {
+        // An errno not in the table (e.g. ELOOP) collapses to OTHER.
+        assert_eq!(errno_label(libc::ELOOP), "OTHER");
+        assert_eq!(errno_label(0), "OTHER");
+        assert_eq!(errno_label(99999), "OTHER");
+    }
+}

--- a/curvine-fuse/src/fuse_metrics.rs
+++ b/curvine-fuse/src/fuse_metrics.rs
@@ -12,13 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::time::Instant;
+
 use once_cell::sync::OnceCell;
 
-use orpc::common::{Gauge, Metrics as m};
+use orpc::common::{Gauge, Histogram, Metrics as m};
 use orpc::CommonResult;
 
 static FUSE_METRICS: OnceCell<FuseMetrics> = OnceCell::new();
 
+/// Process-global FUSE metrics registry.
+///
+/// The struct is intentionally shaped so that **each implementation phase
+/// registers the concrete metric families it first uses** — it is *not*
+/// front-loaded with every future metric. Adding a later phase's metrics is an
+/// additive change (a new field + a registration line), never a refactor of the
+/// existing fields. This keeps each phase's diff self-contained and avoids
+/// locking metric names / label sets before the code that uses them exists.
+///
+/// Phase 0 registers only the three pre-existing runtime gauges; the helper
+/// types below (`FuseReqLabels`, `ActiveGuard`, `HistogramTimer`) are the
+/// enabling primitives that later phases build on, and carry no call sites yet.
 pub struct FuseMetrics {
     pub inode_num: Gauge,
     pub file_handle_num: Gauge,
@@ -43,5 +57,215 @@ impl FuseMetrics {
             file_handle_num: m::new_gauge("file_handle_num", "FUSE open file handle count")?,
             dir_handle_num: m::new_gauge("dir_handle_num", "FUSE open directory handle count")?,
         })
+    }
+}
+
+/// Monotonic time source for durations.
+///
+/// `orpc::common::LocalTime::nanos()` is wall-clock (`SystemTime::now()`) and
+/// must **not** be used for latency: an NTP step or suspend/resume can produce
+/// skewed or negative deltas. All FUSE duration metrics use `std::time::Instant`
+/// instead, accessed through this single helper so the choice is centralized.
+// Phase 0 enabling primitive: defined here, wired to call sites in Phase 1.
+#[allow(dead_code)]
+#[inline]
+pub(crate) fn mono_now() -> Instant {
+    Instant::now()
+}
+
+/// The kind of a FUSE request, used as the `kind` label.
+///
+/// There is deliberately no `NoReply` variant: `Forget` / `BatchForget` are
+/// `Metadata` and are distinguished by a separate `reply_type` label where it
+/// matters (added in a later phase).
+// Phase 0 enabling primitive: defined here, wired to call sites in Phase 1.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FuseReqKind {
+    Metadata,
+    Stream,
+}
+
+#[allow(dead_code)] // Phase 0 primitive; call sites land in Phase 1.
+impl FuseReqKind {
+    /// Low-cardinality `&'static str` label. Zero-allocation.
+    pub(crate) fn as_str(&self) -> &'static str {
+        match self {
+            FuseReqKind::Metadata => "metadata",
+            FuseReqKind::Stream => "stream",
+        }
+    }
+}
+
+/// The cheap, copyable label set carried alongside a request from decode to the
+/// sender finish point. Holds only `&'static str` and integers plus a monotonic
+/// `start` — no heap formatting, so it is `Copy` and free to clone onto a reply
+/// task.
+///
+/// The move-only request context that *owns* the in-flight guard (`FuseReqCtx`)
+/// is defined where it is used (Phase 1a-1); these labels are the part that
+/// travels onto the reply.
+// Phase 0 enabling primitive: defined here, wired to call sites in Phase 1.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct FuseReqLabels {
+    pub(crate) opcode: &'static str,
+    pub(crate) kind: FuseReqKind,
+    pub(crate) start: Instant,
+    pub(crate) request_bytes: u32,
+}
+
+#[allow(dead_code)] // Phase 0 primitive; call sites land in Phase 1.
+impl FuseReqLabels {
+    pub(crate) fn new(opcode: &'static str, kind: FuseReqKind, request_bytes: u32) -> Self {
+        Self {
+            opcode,
+            kind,
+            start: mono_now(),
+            request_bytes,
+        }
+    }
+
+    /// Microseconds elapsed since `start`, using the monotonic clock.
+    pub(crate) fn elapsed_us(&self) -> u64 {
+        self.start.elapsed().as_micros() as u64
+    }
+}
+
+/// RAII guard for an in-flight gauge: increments on construction, decrements
+/// exactly once on drop.
+///
+/// It is `Send` and movable (so it can travel into a spawned task or onto a
+/// reply task), and deliberately **not** `Copy` — a `Copy` guard could
+/// double-decrement. The guard holds its own `Gauge` handle so a single type
+/// can back different scopes (`active_requests`, `stream_io_inflight`,
+/// `meta_task_inflight`) just by being constructed from different gauges.
+// Phase 0 enabling primitive: defined here, wired to call sites in Phase 1.
+#[allow(dead_code)]
+#[derive(Debug)]
+pub(crate) struct ActiveGuard {
+    gauge: Gauge,
+}
+
+#[allow(dead_code)] // Phase 0 primitive; call sites land in Phase 1.
+impl ActiveGuard {
+    pub(crate) fn new(gauge: Gauge) -> Self {
+        gauge.inc();
+        Self { gauge }
+    }
+}
+
+impl Drop for ActiveGuard {
+    fn drop(&mut self) {
+        self.gauge.dec();
+    }
+}
+
+/// Zero-allocation RAII timer for a histogram.
+///
+/// Holds an already-resolved `Histogram` (e.g. obtained once via
+/// `HistogramVec::with_label_values(...)` and stored), so its `drop` is a single
+/// `observe()` with **no allocation and no per-call label-map probe**. This is
+/// the hot-path replacement for `orpc`'s `MetricTimerVec`, which re-allocates a
+/// `Vec<&str>` on every drop and must not be used per request.
+///
+/// Durations are measured with the monotonic clock (`Instant`).
+// Phase 0 enabling primitive: defined here, wired to call sites in Phase 1.
+#[allow(dead_code)]
+#[derive(Debug)]
+pub(crate) struct HistogramTimer {
+    start: Instant,
+    hist: Histogram,
+}
+
+#[allow(dead_code)] // Phase 0 primitive; call sites land in Phase 1.
+impl HistogramTimer {
+    pub(crate) fn new(hist: Histogram) -> Self {
+        Self {
+            start: mono_now(),
+            hist,
+        }
+    }
+}
+
+impl Drop for HistogramTimer {
+    fn drop(&mut self) {
+        // Observe in microseconds, matching the `_us` metric convention.
+        self.hist.observe(self.start.elapsed().as_micros() as f64);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use orpc::common::Metrics as m;
+
+    // Compile-time guarantee that the guards/timer are `Send`. They must travel
+    // into spawned tasks and onto reply tasks (Phase 1a); if a future field
+    // change made them `!Send`, this fails to compile here rather than silently
+    // at the first cross-task move.
+    #[test]
+    fn guards_are_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<ActiveGuard>();
+        assert_send::<HistogramTimer>();
+        assert_send::<FuseReqLabels>();
+    }
+
+    #[test]
+    fn req_kind_labels() {
+        assert_eq!(FuseReqKind::Metadata.as_str(), "metadata");
+        assert_eq!(FuseReqKind::Stream.as_str(), "stream");
+    }
+
+    #[test]
+    fn req_labels_are_copy_and_measure_monotonically() {
+        let labels = FuseReqLabels::new("Lookup", FuseReqKind::Metadata, 64);
+        // FuseReqLabels is Copy: using it after a copy must still compile/work.
+        let copied = labels;
+        assert_eq!(copied.opcode, "Lookup");
+        assert_eq!(copied.kind, FuseReqKind::Metadata);
+        assert_eq!(copied.request_bytes, 64);
+        // elapsed_us is monotonic and never panics.
+        let _ = labels.elapsed_us();
+    }
+
+    #[test]
+    fn active_guard_inc_dec_balances() {
+        let g = m::new_gauge("test_active_guard_gauge", "test gauge").unwrap();
+        assert_eq!(g.get(), 0);
+        {
+            let _guard = ActiveGuard::new(g.clone());
+            assert_eq!(g.get(), 1);
+            {
+                let _g2 = ActiveGuard::new(g.clone());
+                assert_eq!(g.get(), 2);
+            }
+            assert_eq!(g.get(), 1);
+        }
+        assert_eq!(g.get(), 0);
+    }
+
+    #[test]
+    fn active_guard_moves_without_double_decrement() {
+        let g = m::new_gauge("test_active_guard_move_gauge", "test gauge").unwrap();
+        let guard = ActiveGuard::new(g.clone());
+        assert_eq!(g.get(), 1);
+        // Moving the guard must not change the count.
+        let moved = guard;
+        assert_eq!(g.get(), 1);
+        drop(moved);
+        // Dropped exactly once.
+        assert_eq!(g.get(), 0);
+    }
+
+    #[test]
+    fn histogram_timer_observes_on_drop() {
+        let h = m::new_histogram("test_histogram_timer", "test histogram").unwrap();
+        assert_eq!(h.get_sample_count(), 0);
+        {
+            let _t = HistogramTimer::new(h.clone());
+        }
+        assert_eq!(h.get_sample_count(), 1);
     }
 }

--- a/curvine-fuse/src/session/fuse_notify_code.rs
+++ b/curvine-fuse/src/session/fuse_notify_code.rs
@@ -30,3 +30,58 @@ pub enum FuseNotifyCode {
     FUSE_NOTIFY_INC_EPOCH = 8,
     FUSE_NOTIFY_CODE_MAX = 9,
 }
+
+impl FuseNotifyCode {
+    /// Returns a stable, low-cardinality `&'static str` name for this notify
+    /// code, suitable for the `code` label on `notify_total`. Zero-allocation.
+    ///
+    /// The label set is the closed enum defined in the metrics design's Label
+    /// rules: `inval_inode | inval_entry | delete | store | retrieve | poll |
+    /// other`. Notify codes outside that set (`unknown`, `resend`, `inc_epoch`,
+    /// `code_max`) collapse to `other` so the `notify_total{code}` series stays
+    /// bounded to exactly the documented values. If a new code needs its own
+    /// label, add it here and to the design doc's Label rules together.
+    // Phase 0 enabling primitive: defined here, wired to call sites in Phase 1.
+    #[allow(dead_code)]
+    pub(crate) fn as_str(&self) -> &'static str {
+        match self {
+            FuseNotifyCode::FUSE_NOTIFY_INVAL_INODE => "inval_inode",
+            FuseNotifyCode::FUSE_NOTIFY_INVAL_ENTRY => "inval_entry",
+            FuseNotifyCode::FUSE_NOTIFY_DELETE => "delete",
+            FuseNotifyCode::FUSE_NOTIFY_STORE => "store",
+            FuseNotifyCode::FUSE_NOTIFY_RETRIEVE => "retrieve",
+            FuseNotifyCode::FUSE_NOTIFY_POLL => "poll",
+            FuseNotifyCode::FUSE_NOTIFY_UNKNOWN
+            | FuseNotifyCode::FUSE_NOTIFY_RESEND
+            | FuseNotifyCode::FUSE_NOTIFY_INC_EPOCH
+            | FuseNotifyCode::FUSE_NOTIFY_CODE_MAX => "other",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FuseNotifyCode;
+
+    #[test]
+    fn as_str_matches_the_closed_label_set() {
+        // Full (variant, expected-label) table. Any accidental relabeling must
+        // update this table and the design doc's Label rules together. Codes
+        // outside the documented set fold to "other".
+        let table = [
+            (FuseNotifyCode::FUSE_NOTIFY_UNKNOWN, "other"),
+            (FuseNotifyCode::FUSE_NOTIFY_POLL, "poll"),
+            (FuseNotifyCode::FUSE_NOTIFY_INVAL_INODE, "inval_inode"),
+            (FuseNotifyCode::FUSE_NOTIFY_INVAL_ENTRY, "inval_entry"),
+            (FuseNotifyCode::FUSE_NOTIFY_STORE, "store"),
+            (FuseNotifyCode::FUSE_NOTIFY_RETRIEVE, "retrieve"),
+            (FuseNotifyCode::FUSE_NOTIFY_DELETE, "delete"),
+            (FuseNotifyCode::FUSE_NOTIFY_RESEND, "other"),
+            (FuseNotifyCode::FUSE_NOTIFY_INC_EPOCH, "other"),
+            (FuseNotifyCode::FUSE_NOTIFY_CODE_MAX, "other"),
+        ];
+        for (code, expected) in table {
+            assert_eq!(code.as_str(), expected, "label mismatch for {:?}", code);
+        }
+    }
+}

--- a/curvine-fuse/src/session/fuse_op_code.rs
+++ b/curvine-fuse/src/session/fuse_op_code.rs
@@ -68,3 +68,128 @@ pub enum FuseOpCode {
 
     CUSE_INIT = 4096,
 }
+
+impl FuseOpCode {
+    /// Returns a stable, low-cardinality `&'static str` name for this opcode,
+    /// suitable for use as a metric label. Zero-allocation: the metrics hot
+    /// path must never `format!("{:?}", op)`.
+    ///
+    /// Names are short CamelCase (e.g. `Lookup`, `GetAttr`, `Read`) matching
+    /// the `opcode` label convention in the FUSE metrics design.
+    // Phase 0 enabling primitive: defined here, wired to call sites in Phase 1.
+    #[allow(dead_code)]
+    pub(crate) fn as_str(&self) -> &'static str {
+        match self {
+            FuseOpCode::NOT_SUPPORTED => "NotSupported",
+            FuseOpCode::FUSE_LOOKUP => "Lookup",
+            FuseOpCode::FUSE_FORGET => "Forget",
+            FuseOpCode::FUSE_GETATTR => "GetAttr",
+            FuseOpCode::FUSE_SETATTR => "SetAttr",
+            FuseOpCode::FUSE_READLINK => "Readlink",
+            FuseOpCode::FUSE_SYMLINK => "Symlink",
+            FuseOpCode::FUSE_MKNOD => "MkNod",
+            FuseOpCode::FUSE_MKDIR => "Mkdir",
+            FuseOpCode::FUSE_UNLINK => "Unlink",
+            FuseOpCode::FUSE_RMDIR => "RmDir",
+            FuseOpCode::FUSE_RENAME => "Rename",
+            FuseOpCode::FUSE_LINK => "Link",
+            FuseOpCode::FUSE_OPEN => "Open",
+            FuseOpCode::FUSE_READ => "Read",
+            FuseOpCode::FUSE_WRITE => "Write",
+            FuseOpCode::FUSE_STATFS => "StatFs",
+            FuseOpCode::FUSE_RELEASE => "Release",
+            FuseOpCode::FUSE_FSYNC => "Fsync",
+            FuseOpCode::FUSE_SETXATTR => "SetXAttr",
+            FuseOpCode::FUSE_GETXATTR => "GetXAttr",
+            FuseOpCode::FUSE_LISTXATTR => "ListXAttr",
+            FuseOpCode::FUSE_REMOVEXATTR => "RemoveXAttr",
+            FuseOpCode::FUSE_FLUSH => "Flush",
+            FuseOpCode::FUSE_INIT => "Init",
+            FuseOpCode::FUSE_OPENDIR => "OpenDir",
+            FuseOpCode::FUSE_READDIR => "ReadDir",
+            FuseOpCode::FUSE_RELEASEDIR => "ReleaseDir",
+            FuseOpCode::FUSE_FSYNCDIR => "FsyncDir",
+            FuseOpCode::FUSE_GETLK => "GetLk",
+            FuseOpCode::FUSE_SETLK => "SetLk",
+            FuseOpCode::FUSE_SETLKW => "SetLkW",
+            FuseOpCode::FUSE_ACCESS => "Access",
+            FuseOpCode::FUSE_CREATE => "Create",
+            FuseOpCode::FUSE_INTERRUPT => "Interrupt",
+            FuseOpCode::FUSE_BMAP => "BMap",
+            FuseOpCode::FUSE_DESTROY => "Destroy",
+            FuseOpCode::FUSE_IOCTL => "Ioctl",
+            FuseOpCode::FUSE_POLL => "Poll",
+            FuseOpCode::FUSE_NOTIFY_REPLY => "NotifyReply",
+            FuseOpCode::FUSE_BATCH_FORGET => "BatchForget",
+            FuseOpCode::FUSE_FALLOCATE => "FAllocate",
+            FuseOpCode::FUSE_READDIRPLUS => "ReadDirPlus",
+            FuseOpCode::FUSE_RENAME2 => "Rename2",
+            FuseOpCode::FUSE_LSEEK => "Lseek",
+            FuseOpCode::CUSE_INIT => "CuseInit",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FuseOpCode;
+
+    #[test]
+    fn as_str_matches_the_full_label_table() {
+        // Full (variant, expected-label) table covering every enum variant.
+        // Any accidental relabeling must update this table (and the design
+        // doc's `opcode` label convention) together, so a Prometheus series
+        // name can never drift silently.
+        let table = [
+            (FuseOpCode::NOT_SUPPORTED, "NotSupported"),
+            (FuseOpCode::FUSE_LOOKUP, "Lookup"),
+            (FuseOpCode::FUSE_FORGET, "Forget"),
+            (FuseOpCode::FUSE_GETATTR, "GetAttr"),
+            (FuseOpCode::FUSE_SETATTR, "SetAttr"),
+            (FuseOpCode::FUSE_READLINK, "Readlink"),
+            (FuseOpCode::FUSE_SYMLINK, "Symlink"),
+            (FuseOpCode::FUSE_MKNOD, "MkNod"),
+            (FuseOpCode::FUSE_MKDIR, "Mkdir"),
+            (FuseOpCode::FUSE_UNLINK, "Unlink"),
+            (FuseOpCode::FUSE_RMDIR, "RmDir"),
+            (FuseOpCode::FUSE_RENAME, "Rename"),
+            (FuseOpCode::FUSE_LINK, "Link"),
+            (FuseOpCode::FUSE_OPEN, "Open"),
+            (FuseOpCode::FUSE_READ, "Read"),
+            (FuseOpCode::FUSE_WRITE, "Write"),
+            (FuseOpCode::FUSE_STATFS, "StatFs"),
+            (FuseOpCode::FUSE_RELEASE, "Release"),
+            (FuseOpCode::FUSE_FSYNC, "Fsync"),
+            (FuseOpCode::FUSE_SETXATTR, "SetXAttr"),
+            (FuseOpCode::FUSE_GETXATTR, "GetXAttr"),
+            (FuseOpCode::FUSE_LISTXATTR, "ListXAttr"),
+            (FuseOpCode::FUSE_REMOVEXATTR, "RemoveXAttr"),
+            (FuseOpCode::FUSE_FLUSH, "Flush"),
+            (FuseOpCode::FUSE_INIT, "Init"),
+            (FuseOpCode::FUSE_OPENDIR, "OpenDir"),
+            (FuseOpCode::FUSE_READDIR, "ReadDir"),
+            (FuseOpCode::FUSE_RELEASEDIR, "ReleaseDir"),
+            (FuseOpCode::FUSE_FSYNCDIR, "FsyncDir"),
+            (FuseOpCode::FUSE_GETLK, "GetLk"),
+            (FuseOpCode::FUSE_SETLK, "SetLk"),
+            (FuseOpCode::FUSE_SETLKW, "SetLkW"),
+            (FuseOpCode::FUSE_ACCESS, "Access"),
+            (FuseOpCode::FUSE_CREATE, "Create"),
+            (FuseOpCode::FUSE_INTERRUPT, "Interrupt"),
+            (FuseOpCode::FUSE_BMAP, "BMap"),
+            (FuseOpCode::FUSE_DESTROY, "Destroy"),
+            (FuseOpCode::FUSE_IOCTL, "Ioctl"),
+            (FuseOpCode::FUSE_POLL, "Poll"),
+            (FuseOpCode::FUSE_NOTIFY_REPLY, "NotifyReply"),
+            (FuseOpCode::FUSE_BATCH_FORGET, "BatchForget"),
+            (FuseOpCode::FUSE_FALLOCATE, "FAllocate"),
+            (FuseOpCode::FUSE_READDIRPLUS, "ReadDirPlus"),
+            (FuseOpCode::FUSE_RENAME2, "Rename2"),
+            (FuseOpCode::FUSE_LSEEK, "Lseek"),
+            (FuseOpCode::CUSE_INIT, "CuseInit"),
+        ];
+        for (op, expected) in table {
+            assert_eq!(op.as_str(), expected, "label mismatch for {:?}", op);
+        }
+    }
+}


### PR DESCRIPTION
First implementation step of the curvine-fuse end-to-end metrics design
(proposal in `curvine-fuse-metrics-design.md`). Phase 0 adds low-overhead,
zero-call-site primitives that later phases build on. **No business behavior
change** — nothing is wired into the request path yet.

## What's included

- `FuseOpCode::as_str()` / `FuseNotifyCode::as_str()`: stable, zero-allocation
  `&'static str` labels for the `opcode` / notify `code` metric labels. Notify
  codes fold to the documented closed set
  (`inval_inode|inval_entry|delete|store|retrieve|poll|other`).
- `errno_label()`: maps the closed set of errnos produced in the FUSE layer
  (incl. `EBUSY` / `ENAMETOOLONG`) to symbolic labels, `OTHER` as catch-all.
- Monotonic clock (`mono_now` via `std::time::Instant`): durations must not use
  the wall-clock `LocalTime::nanos()`.
- `FuseReqLabels` (Copy) + `FuseReqKind`: the copyable label set later carried
  on replies.
- `ActiveGuard`: RAII in-flight gauge guard (Send, movable, not Copy — no
  double-decrement). `HistogramTimer`: zero-allocation drop-to-observe timer.
- `FuseMetrics` documented to register metric families per phase (additive),
  not front-loaded.

## Notes for review

- All new items are `pub(crate)` and `#[allow(dead_code)]` until Phase 1 wires
  the call sites — the allows double as a Phase 1 removal checklist.
- Tests use full `(value, expected-label)` tables for every opcode / notify code
  / errno, plus a compile-time `Send` assertion for the guards, so a label can't
  drift silently.

## Verification

- `cargo build` / `cargo test` / `cargo clippy --all-targets --deny=warnings`
  all clean on `curvine-fuse`.
- Brought up a local master + worker + fuse cluster and confirmed basic POSIX
  operations and the main-line `fuse-test.sh` cases pass.

Related issue: #897