### PR TITLE
perf(client): refresh mount cache in background off the hot path

### DIFF
--- a/curvine-client/src/unified/mount_cache.rs
+++ b/curvine-client/src/unified/mount_cache.rs
@@ -66,10 +66,12 @@ use crate::unified::{UfsFileSystem, UnifiedFileSystem};
 use curvine_common::fs::Path;
 use curvine_common::state::MountInfo;
 use curvine_common::FsResult;
-use log::debug;
+use log::{debug, warn};
 use orpc::common::{FastHashMap, LocalTime};
+use orpc::runtime::RpcRuntime;
 use orpc::sync::AtomicCounter;
 use orpc::CommonResult;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use tokio::sync::Mutex;
 
@@ -168,6 +170,9 @@ pub struct MountCache {
     last_update: AtomicCounter,
     /// Single-flight lock: only one task performs full refresh when TTL expires.
     refresh_lock: Mutex<()>,
+    /// True while a background refresh has been scheduled but not yet finished.
+    /// Used to avoid spawning more than one concurrent background refresh task.
+    refreshing: AtomicBool,
 }
 
 impl MountCache {
@@ -177,6 +182,7 @@ impl MountCache {
             update_interval,
             last_update: AtomicCounter::new(0),
             refresh_lock: Mutex::new(()),
+            refreshing: AtomicBool::new(false),
         }
     }
 
@@ -184,16 +190,15 @@ impl MountCache {
         LocalTime::mills() > self.update_interval + self.last_update.get()
     }
 
-    pub async fn check_update(&self, fs: &UnifiedFileSystem, force: bool) -> FsResult<()> {
-        if !self.need_update() && !force {
-            return Ok(());
-        }
+    /// Whether the cache has ever been successfully populated. `last_update` is
+    /// 0 until the first successful refresh sets it to a real wall-clock millis.
+    fn is_initialized(&self) -> bool {
+        self.last_update.get() != 0
+    }
 
-        let _guard = self.refresh_lock.lock().await;
-        if !self.need_update() && !force {
-            return Ok(());
-        }
-
+    /// Performs the actual full refresh of the mount table from the master.
+    /// Guarded by `refresh_lock` so only one refresh runs at a time.
+    async fn do_refresh(&self, fs: &UnifiedFileSystem) -> FsResult<()> {
         let mounts = fs.get_mount_table().await?;
         let mut state = self.mounts.write().unwrap();
 
@@ -207,14 +212,88 @@ impl MountCache {
         Ok(())
     }
 
+    /// Synchronous refresh: blocks until the mount table is up to date.
+    /// Used when the caller must observe the latest state immediately
+    /// (e.g. right after a `mount` call). `force` bypasses the TTL check.
+    pub async fn check_update(&self, fs: &UnifiedFileSystem, force: bool) -> FsResult<()> {
+        if !self.need_update() && !force {
+            return Ok(());
+        }
+
+        let _guard = self.refresh_lock.lock().await;
+        if !self.need_update() && !force {
+            return Ok(());
+        }
+
+        self.do_refresh(fs).await
+    }
+
+    /// Non-blocking refresh trigger: if the cache is stale, spawn a background
+    /// task to refresh it and return immediately, letting the caller keep using
+    /// the current (possibly stale) snapshot.
+    ///
+    /// At most one background refresh runs at a time: the `refreshing` flag is
+    /// claimed via compare_exchange, and a duplicate trigger is a no-op until the
+    /// in-flight task clears it. The task takes ownership of cloned handles
+    /// (`Arc<MountCache>` and `UnifiedFileSystem`), so it can outlive the current
+    /// request.
+    fn trigger_async_update(self: &Arc<Self>, fs: &UnifiedFileSystem) {
+        if !self.need_update() {
+            return;
+        }
+
+        // Ensure at most one background refresh is in flight. compare_exchange
+        // returning Err means another task already set the flag and will publish
+        // a fresh snapshot soon, so this call becomes a no-op.
+        if self
+            .refreshing
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+
+        let cache = self.clone();
+        let fs = fs.clone();
+        let rt = fs.clone_runtime();
+        rt.spawn(async move {
+            // Hold the single-flight lock for the whole refresh so the semantics
+            // match the synchronous path and double-refresh is impossible.
+            let _guard = cache.refresh_lock.lock().await;
+            if cache.need_update() {
+                if let Err(e) = cache.do_refresh(&fs).await {
+                    warn!("background mount cache refresh failed: {:?}", e);
+                }
+            }
+            // Always clear the flag, even on error, so a future stale read can
+            // schedule another refresh attempt.
+            cache.refreshing.store(false, Ordering::Release);
+        });
+    }
+
     /// Finds mount point for a path using hierarchical lookup.
     /// Returns the most specific mount that contains the given path.
+    ///
+    /// Refresh policy:
+    /// - On cold start (cache never populated) the first call refreshes
+    ///   synchronously so a freshly-created client observes the correct mount
+    ///   table instead of an empty one.
+    /// - Once populated, a stale cache triggers a background refresh that is NOT
+    ///   awaited: the lookup proceeds against the current snapshot so the caller
+    ///   is never blocked on a master round-trip. The refreshed table becomes
+    ///   visible to subsequent calls.
     pub async fn get_mount(
-        &self,
+        self: &Arc<Self>,
         fs: &UnifiedFileSystem,
         path: &Path,
     ) -> FsResult<Option<Arc<MountValue>>> {
-        self.check_update(fs, false).await?;
+        if self.is_initialized() {
+            self.trigger_async_update(fs);
+        } else {
+            // First access: block once to populate the cache. check_update is
+            // single-flight, so concurrent first callers share one refresh.
+            self.check_update(fs, false).await?;
+        }
 
         let state = self.mounts.read().unwrap();
         if state.is_empty() {

--- a/curvine-client/src/unified/mount_cache.rs
+++ b/curvine-client/src/unified/mount_cache.rs
@@ -166,7 +166,7 @@ impl InnerMap {
 
 /// RAII guard that clears the `refreshing` flag on drop. This guarantees the
 /// flag is released on *every* exit path of the background task — normal
-/// completion, early return, and panic-unwind alike. 
+/// completion, early return, and panic-unwind alike.
 struct RefreshingGuard<'a> {
     flag: &'a AtomicBool,
 }

--- a/curvine-client/src/unified/mount_cache.rs
+++ b/curvine-client/src/unified/mount_cache.rs
@@ -164,6 +164,19 @@ impl InnerMap {
     }
 }
 
+/// RAII guard that clears the `refreshing` flag on drop. This guarantees the
+/// flag is released on *every* exit path of the background task — normal
+/// completion, early return, and panic-unwind alike. 
+struct RefreshingGuard<'a> {
+    flag: &'a AtomicBool,
+}
+
+impl Drop for RefreshingGuard<'_> {
+    fn drop(&mut self) {
+        self.flag.store(false, Ordering::Release);
+    }
+}
+
 pub struct MountCache {
     mounts: RwLock<InnerMap>,
     update_interval: u64,
@@ -257,6 +270,15 @@ impl MountCache {
         let fs = fs.clone();
         let rt = fs.clone_runtime();
         rt.spawn(async move {
+            // Take ownership of the claimed `refreshing` flag via an RAII guard
+            // so it is cleared on every exit path — including a panic in
+            // `do_refresh` (e.g. a poisoned RwLock) — not just on the normal
+            // tail. Without this, a panic here would leak the flag and wedge all
+            // future refreshes. Created before the lock so it covers the whole
+            // task body.
+            let _refreshing = RefreshingGuard {
+                flag: &cache.refreshing,
+            };
             // Hold the single-flight lock for the whole refresh so the semantics
             // match the synchronous path and double-refresh is impossible.
             let _guard = cache.refresh_lock.lock().await;
@@ -265,9 +287,6 @@ impl MountCache {
                     warn!("background mount cache refresh failed: {:?}", e);
                 }
             }
-            // Always clear the flag, even on error, so a future stale read can
-            // schedule another refresh attempt.
-            cache.refreshing.store(false, Ordering::Release);
         });
     }
 


### PR DESCRIPTION
Fixes **Defect 2** of #920 (`cache_mode` mount cannot fall back to S3 when the Master is down).

## Problem

`MountCache::get_mount()` previously called `check_update()` on every lookup, which forced a synchronous `get_mount_table()` RPC to the master whenever the cache TTL expired. Since every filesystem operation (open/rename/mkdir/read/write/stat…) resolves its mount point through `get_mount()` first, each TTL boundary stalled the next incoming request on a master round-trip — the cache periodically inserted a synchronous RPC into the hot path it was supposed to accelerate.

As described in **Defect 2** of #920, this is also a correctness problem when the Master is down: on the first lookup after TTL expiry, the fatal `?` on `get_mount_table().await?` propagates the error up through `get_mount` → `get_status` **before** the existing S3 fallback is ever reached, so a `cache_mode` `stat` returns EIO even though the object is intact in S3.

## Change

Decouple refresh from read so a failed/slow mount-table refresh can no longer block the lookup (and therefore can no longer block the downstream S3 fallback):

- **Cold start** (cache never populated): refresh synchronously so a fresh client never observes an empty mount table.
- **Warm path** (populated but stale): spawn a background refresh task and serve the current (stale-while-error) snapshot immediately; the caller never blocks on, nor fails on, the master. The refreshed table becomes visible to subsequent calls.

This addresses Defect 2's failure mode by moving the refresh out of the hot path entirely: a refresh RPC failure is now logged and retried in the background instead of being propagated fatally to the caller, so the post-TTL `stat` proceeds against the stale mount table and reaches the S3 fallback.

`is_initialized()` distinguishes the two states by reusing the existing `last_update` field (0 ⇔ never refreshed) — no new state introduced.

## Concurrency

- A `refreshing` `AtomicBool`, claimed via `compare_exchange`, ensures **at most one** background refresh task is in flight (throttles spawns). The flag is **always** cleared — even on error or skip — so a failed refresh self-heals on the next stale read.
- The existing `refresh_lock` `Mutex` still serializes the refresh body, shared by the sync and async paths, with a double-checked `need_update`.
- Mount-table visibility is guaranteed by the `RwLock`, **not** by the control flag; `refreshing` is purely a spawn-throttling signal.

## API

`get_mount()`'s receiver becomes `self: &Arc<Self>` so the background task can take an owned handle (`self.clone()`). Callers already hold `Arc<MountCache>`, so **no call sites change**.

## Scope

This PR covers **Defect 2** only. **Defect 1** (mount-point ancestors take the `None` branch in `get_status`, which has no S3 fallback) is independent and is not addressed here.

## Test

`cargo build -p curvine-client` passes with no errors or warnings.
