### PR TITLE
feat(fuse): add metrics context spine and finish state machine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2072,6 +2072,7 @@ dependencies = [
  "num_enum",
  "once_cell",
  "orpc",
+ "parking_lot",
  "pin-project-lite",
  "pkg-config",
  "serde",

--- a/curvine-fuse/Cargo.toml
+++ b/curvine-fuse/Cargo.toml
@@ -23,6 +23,7 @@ thiserror = { workspace = true }
 trait-variant = { workspace = true }
 nix = { workspace = true }
 once_cell = { workspace = true }
+parking_lot = { workspace = true }
 mini-moka = { workspace = true }
 fxhash = { workspace = true }
 dashmap = { workspace = true }

--- a/curvine-fuse/src/fs/state/file_handle.rs
+++ b/curvine-fuse/src/fs/state/file_handle.rs
@@ -15,6 +15,7 @@
 use crate::fs::operator::{Read, Write};
 use crate::fs::state::NodeState;
 use crate::fs::{FuseReader, FuseWriter};
+use crate::raw::fuse_abi::fuse_write_out;
 use crate::session::FuseResponse;
 use crate::{err_fuse, FuseError, FuseResult};
 use curvine_common::fs::{Path, StateReader, StateWriter};
@@ -96,6 +97,17 @@ impl FileHandle {
 
     pub async fn write(&self, op: Write<'_>, reply: FuseResponse) -> FuseResult<()> {
         if op.data.is_empty() {
+            // A zero-length write is a valid no-op, but it must still send a
+            // reply (size=0) rather than returning silently: silently returning
+            // would leave the request's metrics context un-finished (the guard
+            // would only be released by passive drop, never reaching a terminal
+            // state-machine transition). Reply normally so it finishes like any
+            // other replied request.
+            let res: FuseResult<fuse_write_out> = Ok(fuse_write_out {
+                size: 0,
+                padding: 0,
+            });
+            reply.send_rep(res).await?;
             return Ok(());
         }
 

--- a/curvine-fuse/src/fuse_error.rs
+++ b/curvine-fuse/src/fuse_error.rs
@@ -29,6 +29,12 @@ impl FuseError {
     pub fn new(errno: i32, error: CommonError) -> Self {
         Self { errno, error }
     }
+
+    /// The POSIX errno this error maps to. Used by the metrics finish path to
+    /// stash the errno label source.
+    pub(crate) fn errno(&self) -> i32 {
+        self.errno
+    }
 }
 
 impl From<String> for FuseError {

--- a/curvine-fuse/src/fuse_metrics.rs
+++ b/curvine-fuse/src/fuse_metrics.rs
@@ -132,32 +132,134 @@ impl FuseReqLabels {
     }
 }
 
+/// The terminal status of a FUSE request, used as the `status` label.
+///
+/// Classified by `FuseResponse::send_rep_tagged()` (via `err_status()`) from the
+/// FS-operation result plus an explicit source tag — never from errno alone (see
+/// the metrics design's Status Semantics). Phase 1a-1 computes and stores it as
+/// control flow; the real `requests_total{status}` / duration series read it in
+/// 1a-2.
+#[allow(dead_code)] // status values are read by the request metrics in Phase 1a-2.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FuseReqStatus {
+    Success,
+    Error,
+    Interrupted,
+    Unsupported,
+}
+
+/// Move-only request context created in the receiver right after a request is
+/// decoded. It owns the E2E `ActiveGuard`; dropping the context (or moving the
+/// guard out exactly once) is what keeps `active_requests` correct.
+///
+/// `labels` is `Copy` and travels onto the reply; the guard is move-only and
+/// must not be duplicated. Stored on the `FuseResponse` (inside `FuseRespMetrics`).
+#[allow(dead_code)] // constructed/consumed by the request path wired in Phase 1a.
+#[derive(Debug)]
+pub(crate) struct FuseReqCtx {
+    pub(crate) labels: FuseReqLabels,
+    pub(crate) active: Option<ActiveGuard>,
+}
+
+/// Interior-mutable per-request metrics slot held behind `Arc<Mutex<…>>` on the
+/// `FuseResponse`. The reply path writes it once (taking the guard, stashing
+/// status); the sender reads it once at finish. See the design's
+/// "FuseResponse API strategy" and "finish state machine".
+///
+/// `op_status` / `errno` / `unsupported_reason` are stored **independently of**
+/// `active`, so taking the guard out into the reply task does not clear the
+/// status the operation-duration timer reads later (Phase 1a-2 / Phase 2).
+#[derive(Debug)]
+pub(crate) struct FuseRespMetrics {
+    pub(crate) labels: FuseReqLabels,
+    /// The E2E guard; `take()`n exactly once when the reply is built.
+    pub(crate) active: Option<ActiveGuard>,
+    /// FS-operation result status; set when the reply / no-reply / early-finish
+    /// path classifies the operation result. Read by `operation_duration_us` in
+    /// Phase 1a-2 / Phase 2.
+    #[allow(dead_code)]
+    pub(crate) op_status: Option<FuseReqStatus>,
+    /// Final delivery/result status; read by `request_duration_us` in the
+    /// sender (Phase 1a-2).
+    #[allow(dead_code)]
+    pub(crate) request_status: Option<FuseReqStatus>,
+    /// errno label source for `errors_total` on the **replied** path (set by
+    /// `send_rep`/`send_buf`/`send_data`, Phase 1a-2). Deliberately left at 0 on
+    /// the no-reply path (`finish_no_reply`): `Forget`/`BatchForget` failures do
+    /// not emit an errno-labelled metric (no meaningful errno — design decision),
+    /// so the 0 is never read there.
+    #[allow(dead_code)]
+    pub(crate) errno: i32,
+    /// Set only at the wildcard / `Notimplemented` / trait-default sites; read
+    /// by status classification in Phase 1a-2.
+    #[allow(dead_code)]
+    pub(crate) unsupported_reason: Option<&'static str>,
+    /// Set on the parse-after-ctx early-finish path (`finish_early`); read by
+    /// `decode_errors_total{phase="parse",reason}` in Phase 1a-2. Stored as a
+    /// `&'static str` reason (`short_read`/`invalid_header`/`length_mismatch`/
+    /// `other`) because structural parse failures have no stable OS errno.
+    #[allow(dead_code)]
+    pub(crate) parse_reason: Option<&'static str>,
+    /// State-machine guard: prevents a second reply from double-finishing.
+    pub(crate) finished: bool,
+}
+
+#[allow(dead_code)] // call sites land across Phase 1a.
+impl FuseRespMetrics {
+    pub(crate) fn new(ctx: FuseReqCtx) -> Self {
+        Self {
+            labels: ctx.labels,
+            active: ctx.active,
+            op_status: None,
+            request_status: None,
+            errno: 0,
+            unsupported_reason: None,
+            parse_reason: None,
+            finished: false,
+        }
+    }
+}
+
 /// RAII guard for an in-flight gauge: increments on construction, decrements
 /// exactly once on drop.
 ///
 /// It is `Send` and movable (so it can travel into a spawned task or onto a
 /// reply task), and deliberately **not** `Copy` — a `Copy` guard could
-/// double-decrement. The guard holds its own `Gauge` handle so a single type
-/// can back different scopes (`active_requests`, `stream_io_inflight`,
+/// double-decrement. The guard holds an optional `Gauge` handle so a single
+/// type can back different scopes (`active_requests`, `stream_io_inflight`,
 /// `meta_task_inflight`) just by being constructed from different gauges.
+///
+/// The `None` (no-op) form is what Phase 1a-1 uses: it exercises the full
+/// move-and-drop lifetime — proving single-take / single-drop ownership — while
+/// touching no real gauge. Phase 1a-2 swaps in `new(active_requests_gauge)` so
+/// the same plumbing then drives the real metric.
 // Phase 0 enabling primitive: defined here, wired to call sites in Phase 1.
 #[allow(dead_code)]
 #[derive(Debug)]
 pub(crate) struct ActiveGuard {
-    gauge: Gauge,
+    gauge: Option<Gauge>,
 }
 
 #[allow(dead_code)] // Phase 0 primitive; call sites land in Phase 1.
 impl ActiveGuard {
+    /// A guard backed by a real gauge: increments now, decrements on drop.
     pub(crate) fn new(gauge: Gauge) -> Self {
         gauge.inc();
-        Self { gauge }
+        Self { gauge: Some(gauge) }
+    }
+
+    /// A no-op guard: same move/drop semantics, but touches no gauge. Used in
+    /// Phase 1a-1 to validate ownership before the real gauge is wired (1a-2).
+    pub(crate) fn noop() -> Self {
+        Self { gauge: None }
     }
 }
 
 impl Drop for ActiveGuard {
     fn drop(&mut self) {
-        self.gauge.dec();
+        if let Some(g) = &self.gauge {
+            g.dec();
+        }
     }
 }
 

--- a/curvine-fuse/src/session/channel/fuse_receiver.rs
+++ b/curvine-fuse/src/session/channel/fuse_receiver.rs
@@ -14,6 +14,7 @@
 
 use crate::fs::operator::FuseOperator;
 use crate::fs::FileSystem;
+use crate::fuse_metrics::{ActiveGuard, FuseReqCtx, FuseReqKind, FuseReqLabels};
 use crate::raw::fuse_abi::fuse_out_header;
 use crate::session::{FuseRequest, FuseResponse, FuseTask};
 use crate::{err_fuse, FuseResult, FUSE_IN_HEADER_LEN};
@@ -48,7 +49,7 @@ pub struct FuseReceiver<T> {
 
 impl<T: FileSystem> FuseReceiver<T> {
     #[allow(clippy::too_many_arguments)]
-    pub fn new(
+    pub(crate) fn new(
         fs: Arc<T>,
         rt: Arc<Runtime>,
         kernel_fd: Arc<AsyncFd>,
@@ -120,8 +121,28 @@ impl<T: FileSystem> FuseReceiver<T> {
         Ok(req_buf)
     }
 
-    pub fn new_replay(&self, unique: u64) -> FuseResponse {
-        FuseResponse::new(unique, self.sender.clone(), self.debug)
+    /// Build a reply handle for `unique`. When `labels` is `Some`, a metrics
+    /// context (with a no-op `ActiveGuard` in Phase 1a-1) is created so the
+    /// reply finishes in the sender; when `None`, the legacy disabled path.
+    pub(crate) fn new_reply(&self, unique: u64, labels: Option<FuseReqLabels>) -> FuseResponse {
+        let ctx = labels.map(|labels| FuseReqCtx {
+            labels,
+            active: Some(ActiveGuard::noop()),
+        });
+        FuseResponse::new_reply(unique, self.sender.clone(), self.debug, ctx)
+    }
+
+    /// Derive the copyable metrics labels for a decoded request. Phase 1a-1
+    /// always builds these (metrics machinery is exercised but emits nothing);
+    /// the disabled-mode `None` path arrives with the Phase 1 kill switch.
+    fn req_labels(req: &FuseRequest) -> FuseReqLabels {
+        let kind = if req.is_stream() {
+            FuseReqKind::Stream
+        } else {
+            FuseReqKind::Metadata
+        };
+        let request_bytes = req.get_header().map(|h| h.len).unwrap_or(0);
+        FuseReqLabels::new(req.opcode().as_str(), kind, request_bytes)
     }
 
     fn audit(&self, req: &FuseRequest) {
@@ -139,8 +160,29 @@ impl<T: FileSystem> FuseReceiver<T> {
     }
 
     pub async fn send_stream(&self, req: FuseRequest) -> FuseResult<()> {
-        let operator = req.parse_operator()?;
-        let rep = self.new_replay(req.unique());
+        // Create the metrics context *before* parsing (ctx-before-parse), so a
+        // structural parse failure after this point is a real finish-state-machine
+        // event, consistent with the metadata path.
+        let labels = Self::req_labels(&req);
+        let rep = self.new_reply(req.unique(), Some(labels));
+
+        // A structural parse failure after the ctx exists must finish the context
+        // early (drop the active guard, mark finished) and emit no reply.
+        let operator = match req.parse_operator() {
+            Ok(op) => op,
+            Err(err) => {
+                // Structural parse failure after the ctx exists: no stable errno
+                // for the parse reason, so use the catch-all "other".
+                rep.finish_early(err.errno(), "other");
+                return Err(err);
+            }
+        };
+
+        // Clone shares the same metrics slot; the clone is the error-path reply
+        // so an enqueue/dispatch failure finishes the *original* context once
+        // (single logical finish, guard not double-counted) instead of building a
+        // fresh context.
+        let err_rep = rep.clone();
         let res = match operator {
             FuseOperator::Read(op) => self.fs.read(op, rep).await,
 
@@ -156,7 +198,7 @@ impl<T: FileSystem> FuseReceiver<T> {
         };
 
         if res.is_err() {
-            self.new_replay(req.unique()).send_rep(res).await?;
+            err_rep.send_rep(res).await?;
         }
         Ok(())
     }
@@ -171,12 +213,18 @@ impl<T: FileSystem> FuseReceiver<T> {
                             let req = FuseRequest::from_bytes(buf.freeze())?;
 
                             if self.debug {
-                                let operator = req.parse_operator()?;
+                                // Debug logging must NOT parse the operator here:
+                                // a parse failure would `?`-return out of the
+                                // receiver loop *before* the context is created,
+                                // both terminating the receiver and bypassing the
+                                // dispatch-path `finish_early` cleanup. The
+                                // dispatch path (`dispatch_meta` / `send_stream`)
+                                // is the single parse + cleanup site. Log only the
+                                // fields available without parsing the body.
                                 info!(
-                                    "receive unique: {}, code: {:?}, op: {:?}",
+                                    "receive unique: {}, code: {:?}",
                                     req.unique(),
                                     req.opcode(),
-                                    operator
                                 );
                             }
 
@@ -187,7 +235,8 @@ impl<T: FileSystem> FuseReceiver<T> {
                             } else {
                                 self.audit(&req);
 
-                                let reply = self.new_replay(req.unique());
+                                let labels = Self::req_labels(&req);
+                                let reply = self.new_reply(req.unique(), Some(labels));
                                 let fs = self.fs.clone();
                                 let pending_requests = self.pending_requests.clone();
                                 self.rt.spawn(async move {
@@ -242,7 +291,9 @@ impl<T: FileSystem> FuseReceiver<T> {
             _ = notify.notified() => {
                 pending_requests.remove(&req.unique());
                 let err: FuseResult<()> = err_fuse!(EINTR, "operation interrupted");
-                reply.send_rep(err).await.map_err(|x| x.into())
+                // Source-tagged as interrupted (the SETLKW interrupt-notify path),
+                // not inferred from the EINTR errno.
+                reply.send_rep_tagged(err, None, true).await.map_err(|x| x.into())
             }
         };
 
@@ -255,7 +306,16 @@ impl<T: FileSystem> FuseReceiver<T> {
         req: &FuseRequest,
         reply: &FuseResponse,
     ) -> FuseResult<()> {
-        let operator = req.parse_operator()?;
+        // A structural parse failure happens *after* the ctx was created in the
+        // receiver, so it must finish the context early (drop the active guard,
+        // mark finished) without emitting a request reply.
+        let operator = match req.parse_operator() {
+            Ok(op) => op,
+            Err(err) => {
+                reply.finish_early(err.errno(), "other");
+                return Err(err);
+            }
+        };
 
         let res = match operator {
             FuseOperator::Init(op) => reply.send_rep(fs.init(op).await).await,
@@ -335,9 +395,15 @@ impl<T: FileSystem> FuseReceiver<T> {
             FuseOperator::SetLkW(op) => reply.send_rep(fs.set_lkw(op).await).await,
 
             _ => {
+                // A parsed-but-unhandled opcode (e.g. Rename2, or any
+                // `Notimplemented`): source-tagged as `unimplemented_opcode` so
+                // it classifies as Unsupported, not a backend Error. (Phase 1a-2
+                // reads the tag for `unsupported_total{reason}`.)
                 let err: FuseResult<fuse_out_header> =
                     err_fuse!(libc::ENOSYS, "unsupported operation {:?}", req.opcode());
-                reply.send_rep(err).await
+                reply
+                    .send_rep_tagged(err, Some("unimplemented_opcode"), false)
+                    .await
             }
         };
 

--- a/curvine-fuse/src/session/channel/fuse_sender.rs
+++ b/curvine-fuse/src/session/channel/fuse_sender.rs
@@ -15,7 +15,7 @@
 use crate::fs::FileSystem;
 use crate::session::{FuseTask, ResponseData};
 use crate::FuseResult;
-use log::{error, info, warn};
+use log::{info, warn};
 use orpc::io::IOResult;
 use orpc::runtime::Runtime;
 use orpc::sync::channel::AsyncReceiver;
@@ -37,7 +37,7 @@ pub struct FuseSender<T> {
 }
 
 impl<T: FileSystem> FuseSender<T> {
-    pub fn new(
+    pub(crate) fn new(
         fs: Arc<T>,
         rt: Arc<Runtime>,
         kernel_fd: Arc<AsyncFd>,
@@ -65,6 +65,41 @@ impl<T: FileSystem> FuseSender<T> {
     pub async fn start(mut self) -> FuseResult<()> {
         while let Some(task) = self.receiver.recv().await {
             match task {
+                // A replied request with metrics context. This is the E2E finish
+                // point: after the kernel-fd write, the `active` guard is dropped
+                // (releasing the in-flight count). Phase 1a-1 wires the drop as
+                // control flow only — `active` is a no-op guard until Phase 1a-2
+                // attaches it to the real `active_requests` gauge, and
+                // `labels`/`status`/`errno` are not yet read into any metric.
+                FuseTask::RequestReply {
+                    data,
+                    labels: _labels,
+                    active,
+                    status: _status,
+                    errno: _errno,
+                    unsupported_reason: _unsupported_reason,
+                } => {
+                    let id = data.header.unique;
+                    if let Err(e) = self.send(data).await {
+                        if e.raw_error().raw_os_error() != Some(libc::ENOENT) {
+                            warn!("error send unique {}: {}", id, e);
+                        }
+                    }
+                    // Finish point: drop the in-flight guard after the write.
+                    drop(active);
+                }
+
+                // A kernel notification: same splice, no request guard/finish.
+                FuseTask::NotifyReply { data, code: _code } => {
+                    let id = data.header.unique;
+                    if let Err(e) = self.send(data).await {
+                        if e.raw_error().raw_os_error() != Some(libc::ENOENT) {
+                            warn!("error send notify {}: {}", id, e);
+                        }
+                    }
+                }
+
+                // Legacy fast path (metrics disabled): byte-identical to before.
                 FuseTask::Reply(reply) => {
                     let id = reply.header.unique;
                     if let Err(e) = self.send(reply).await {
@@ -72,10 +107,6 @@ impl<T: FileSystem> FuseSender<T> {
                             warn!("error send unique {}: {}", id, e);
                         }
                     }
-                }
-
-                FuseTask::Request(_) => {
-                    error!("Not support")
                 }
             }
         }

--- a/curvine-fuse/src/session/fuse_response.rs
+++ b/curvine-fuse/src/session/fuse_response.rs
@@ -12,21 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(unused)]
-
+use crate::fuse_metrics::{FuseReqCtx, FuseReqStatus, FuseRespMetrics};
 use crate::raw::fuse_abi::{
     fuse_notify_inval_entry_out, fuse_notify_inval_inode_out, fuse_out_header,
 };
-use crate::session::{FuseNotifyCode, FuseOpCode, FuseTask};
+use crate::session::{FuseNotifyCode, FuseTask};
 use crate::{FuseError, FuseResult, FuseUtils};
-use crate::{FUSE_MAX_NAME_LENGTH, FUSE_NOTIFY_UNIQUE, FUSE_OUT_HEADER_LEN, FUSE_SUCCESS};
+use crate::{FUSE_NOTIFY_UNIQUE, FUSE_OUT_HEADER_LEN, FUSE_SUCCESS};
 use log::{info, warn};
 use orpc::io::IOResult;
 use orpc::sync::channel::AsyncSender;
 use orpc::sys::DataSlice;
 use orpc::ternary;
+use parking_lot::Mutex;
 use std::fmt::Debug;
 use std::io::IoSlice;
+use std::sync::Arc;
 use std::vec;
 use tokio_util::bytes::BytesMut;
 
@@ -77,20 +78,38 @@ impl ResponseData {
     }
 }
 
-// Send fuse response to the mount point
+// Send fuse response to the mount point.
+//
+// `metrics` is the per-request metrics slot (Phase 1a): `Some` when metrics are
+// enabled, `None` for the disabled fast path. It is `Arc<Mutex<…>>` so that
+// cloning a `FuseResponse` (used by `dispatch_meta`, which borrows `&self`)
+// shares the *same* slot — the active guard is taken exactly once regardless of
+// clones. The lock is uncontended (written once on the reply path, read once in
+// the sender) and is never held across an `.await`.
 #[derive(Clone)]
 pub struct FuseResponse {
     pub(crate) unique: u64,
     pub(crate) sender: AsyncSender<FuseTask>,
     pub(crate) debug: bool,
+    pub(crate) metrics: Option<Arc<Mutex<FuseRespMetrics>>>,
 }
 
 impl FuseResponse {
-    pub fn new(unique: u64, sender: AsyncSender<FuseTask>, debug: bool) -> Self {
+    /// Build a reply handle. `ctx = Some(..)` enables metrics (the reply path
+    /// produces `RequestReply`/`NotifyReply` and finishes in the sender);
+    /// `ctx = None` is the disabled fast path (produces the legacy `Reply`).
+    pub(crate) fn new_reply(
+        unique: u64,
+        sender: AsyncSender<FuseTask>,
+        debug: bool,
+        ctx: Option<FuseReqCtx>,
+    ) -> Self {
+        let metrics = ctx.map(|c| Arc::new(Mutex::new(FuseRespMetrics::new(c))));
         Self {
             unique,
             sender,
             debug,
+            metrics,
         }
     }
 
@@ -104,11 +123,180 @@ impl FuseResponse {
         }
     }
 
+    /// Classify a *non-Ok* reply into a `FuseReqStatus` from the explicit
+    /// source tag — **never from errno alone** (a backend `ENOSYS`/`EINTR` with
+    /// no tag stays `Error`). `Unsupported`/`Interrupted` are reached only when
+    /// the caller passes the matching tag (set at the wildcard / `Notimplemented`
+    /// / SETLKW-interrupt sites). Phase 1a-1 wires this as control flow; the
+    /// status-labelled metrics read the stashed value in Phase 1a-2.
+    fn err_status(unsupported_reason: Option<&'static str>, interrupted: bool) -> FuseReqStatus {
+        if unsupported_reason.is_some() {
+            FuseReqStatus::Unsupported
+        } else if interrupted {
+            FuseReqStatus::Interrupted
+        } else {
+            FuseReqStatus::Error
+        }
+    }
+
+    /// Build the reply task and enqueue it. The single finish entry point for a
+    /// replied request:
+    ///
+    /// - metrics enabled: stash status/errno, `take()` the active guard out of
+    ///   the shared slot (move-only, exactly once), mark `finished`, then send a
+    ///   `RequestReply`. All slot access is scoped *before* the `.await` so the
+    ///   `parking_lot` guard is never held across the await. **If the enqueue
+    ///   fails**, the request never reaches the sender, so we re-lock and correct
+    ///   `request_status` to `Error` (the `Pending → FinishedEarly(enqueue err)`
+    ///   transition) while leaving `op_status` as the FS-operation result.
+    /// - metrics disabled: send the legacy `Reply`.
+    ///
+    /// `status`/`errno` are computed by the caller (which still holds the typed
+    /// result); they cannot be derived from the enqueue outcome because a
+    /// successful enqueue of an error frame returns `Ok(())`.
+    async fn finish_request(
+        &self,
+        data: ResponseData,
+        status: FuseReqStatus,
+        errno: i32,
+        unsupported_reason: Option<&'static str>,
+    ) -> IOResult<()> {
+        let slot = match &self.metrics {
+            None => return self.sender.send(FuseTask::Reply(data)).await,
+            Some(slot) => slot,
+        };
+
+        // Extract everything BEFORE the send: the active guard is move-only and
+        // `send` consumes the task (it is not returned on error), so the
+        // guard/labels must leave the slot here.
+        let (labels, active) = {
+            let mut m = slot.lock();
+            if m.finished {
+                // Double reply on an already-finished context: a logic bug.
+                // Never double-count/double-drop — log and no-op in all builds
+                // (this is testable, unlike a debug_assert that would panic the
+                // release-path test).
+                warn!(
+                    "double reply on an already-finished FuseResponse (unique {})",
+                    self.unique
+                );
+                return Ok(());
+            }
+            m.op_status = Some(status);
+            m.request_status = Some(status);
+            m.errno = errno;
+            m.unsupported_reason = unsupported_reason;
+            m.finished = true;
+            let active = m
+                .active
+                .take()
+                .unwrap_or_else(crate::fuse_metrics::ActiveGuard::noop);
+            (m.labels, active)
+        }; // lock dropped here, before the .await below.
+
+        let send_result = self
+            .sender
+            .send(FuseTask::RequestReply {
+                data,
+                labels,
+                active,
+                status,
+                errno,
+                unsupported_reason,
+            })
+            .await;
+
+        if send_result.is_err() {
+            // Enqueue failed: the request never reaches the sender's finish
+            // point. The FS-operation status (`op_status`) is preserved, but the
+            // delivered/result status becomes `Error`. (The guard was moved into
+            // the consumed task and dropped with it.) Phase 1a-2 reads this to
+            // emit `reply_enqueue_errors_total` + `request_duration_us{status=error}`.
+            let mut m = slot.lock();
+            m.request_status = Some(FuseReqStatus::Error);
+        }
+        send_result
+    }
+
+    /// Finish a no-reply request (`Forget` / `BatchForget`). Inspects the
+    /// operation result (so a failing forget is not a phantom success), drops
+    /// the active guard, and sends no task. Non-async: nothing reaches the
+    /// sender. Phase 1a-1 runs the state machine but emits no real metric.
+    ///
+    /// No-reply errors are always classified `Error` (via `err_status` with no
+    /// interrupt tag): `Forget`/`BatchForget` are never interrupted, and the
+    /// `trait_default` unsupported reason is out of scope for Phase 1a-1. If
+    /// Phase 1a-2 needs no-reply `unsupported`, add a source-tag param here.
+    fn finish_no_reply(&self, res: FuseResult<()>) {
+        if let Some(slot) = &self.metrics {
+            let mut m = slot.lock();
+            if m.finished {
+                return;
+            }
+            // No-reply errors are always `Error`: Forget/BatchForget are never
+            // interrupted, and the `trait_default` unsupported reason is out of
+            // scope for Phase 1a-1. Classified explicitly (not via the slot's
+            // `unsupported_reason`) so the code matches the doc comment and does
+            // not depend on prior slot state. If Phase 1a-2 needs no-reply
+            // `unsupported`, add a source-tag parameter here.
+            let status = match &res {
+                Ok(_) => FuseReqStatus::Success,
+                Err(_) => FuseReqStatus::Error,
+            };
+            m.op_status = Some(status);
+            m.request_status = Some(status);
+            m.finished = true;
+            // Drop the guard explicitly (no task carries it on the no-reply path).
+            let _ = m.active.take();
+        }
+    }
+
+    /// Finish a request that errored **before** any reply could be produced —
+    /// e.g. a structural `parse_operator()` failure after the context was
+    /// created. Drops the active guard and marks the slot `finished` so the
+    /// `active_requests` count cannot leak, but enqueues **no** task and emits
+    /// no `requests_total` (the request never dispatched).
+    ///
+    /// `reason` is the `&'static str` parse-failure reason
+    /// (`short_read`/`invalid_header`/`length_mismatch`/`other`) — stashed now,
+    /// read by `decode_errors_total{phase="parse",reason}` in Phase 1a-2. A
+    /// reason rather than an errno is carried because structural parse failures
+    /// have no stable OS errno; `errno` is kept too for diagnostics.
+    pub(crate) fn finish_early(&self, errno: i32, reason: &'static str) {
+        if let Some(slot) = &self.metrics {
+            let mut m = slot.lock();
+            if m.finished {
+                return;
+            }
+            m.op_status = Some(FuseReqStatus::Error);
+            m.request_status = Some(FuseReqStatus::Error);
+            m.errno = errno;
+            m.parse_reason = Some(reason);
+            m.finished = true;
+            let _ = m.active.take();
+        }
+    }
+
     pub async fn send_rep<T: Debug, E: Into<FuseError> + Debug>(
         &self,
         res: Result<T, E>,
     ) -> IOResult<()> {
-        let data = match res {
+        self.send_rep_tagged(res, None, false).await
+    }
+
+    /// Like `send_rep`, but lets the caller attach an explicit status source
+    /// tag for the error case: `unsupported_reason` (a known unsupported path —
+    /// `unknown_opcode`/`unimplemented_opcode`/`trait_default`) or `interrupted`
+    /// (the SETLKW interrupt-notify path). Status is **never** inferred from
+    /// errno; an untagged error is always `Error`. (Phase 1a-1 stashes the tag
+    /// as control flow; `unsupported_total`/`interrupted_total` read it in 1a-2.)
+    pub async fn send_rep_tagged<T: Debug, E: Into<FuseError> + Debug>(
+        &self,
+        res: Result<T, E>,
+        unsupported_reason: Option<&'static str>,
+        interrupted: bool,
+    ) -> IOResult<()> {
+        let (data, status, errno) = match res {
             Ok(v) => {
                 if self.debug {
                     info!("send_rep unique {}, res: {:?}", self.unique, v);
@@ -119,17 +307,28 @@ impl FuseResponse {
                 } else {
                     vec![DataSlice::buffer(FuseUtils::struct_as_buf(&v))]
                 };
-                ResponseData::create(self.unique, FUSE_SUCCESS, data)
+                (
+                    ResponseData::create(self.unique, FUSE_SUCCESS, data),
+                    FuseReqStatus::Success,
+                    0,
+                )
             }
 
             Err(e) => {
                 let e = e.into();
                 self.rep_log(&e);
-                ResponseData::create(self.unique, e.errno, vec![])
+                let errno = e.errno;
+                let status = Self::err_status(unsupported_reason, interrupted);
+                (
+                    ResponseData::create(self.unique, errno, vec![]),
+                    status,
+                    errno,
+                )
             }
         };
 
-        self.sender.send(FuseTask::Reply(data)).await
+        self.finish_request(data, status, errno, unsupported_reason)
+            .await
     }
 
     pub async fn send_notify(&self, code: FuseNotifyCode, data: Vec<DataSlice>) -> IOResult<()> {
@@ -138,47 +337,86 @@ impl FuseResponse {
         }
 
         let data = ResponseData::create(FUSE_NOTIFY_UNIQUE, code.into(), data);
-        self.sender.send(FuseTask::Reply(data)).await
+        // Notifications are not request replies: they never touch the request
+        // metrics slot. When metrics are disabled, fall back to the legacy Reply
+        // so the disabled path is byte-identical.
+        if self.metrics.is_some() {
+            self.sender
+                .send(FuseTask::NotifyReply {
+                    data,
+                    code: code.as_str(),
+                })
+                .await
+        } else {
+            self.sender.send(FuseTask::Reply(data)).await
+        }
     }
 
+    // `send_buf` / `send_data` always classify an error as `Error` and have no
+    // source-tag variant: every current `unsupported`/`interrupted` source goes
+    // through `send_rep_tagged` (dispatch wildcard, SETLKW interrupt). If a
+    // future buffer/data-returning op needs to be tagged unsupported/interrupted,
+    // add `send_buf_tagged` / `send_data_tagged` (or route through a shared
+    // helper) rather than inferring status from errno.
     pub async fn send_buf(&self, res: FuseResult<BytesMut>) -> IOResult<()> {
-        let data = match res {
+        let (data, status, errno) = match res {
             Ok(v) => {
                 if self.debug {
                     info!("send_buf unique {}, data len: {}", self.unique, v.len());
                 }
-                ResponseData::create(self.unique, FUSE_SUCCESS, vec![DataSlice::Buffer(v)])
+                (
+                    ResponseData::create(self.unique, FUSE_SUCCESS, vec![DataSlice::Buffer(v)]),
+                    FuseReqStatus::Success,
+                    0,
+                )
             }
 
             Err(e) => {
                 self.rep_log(&e);
-                ResponseData::create(self.unique, e.errno, vec![])
+                let errno = e.errno;
+                (
+                    ResponseData::create(self.unique, errno, vec![]),
+                    FuseReqStatus::Error,
+                    errno,
+                )
             }
         };
 
-        self.sender.send(FuseTask::Reply(data)).await
+        self.finish_request(data, status, errno, None).await
     }
 
     pub async fn send_data(&self, res: FuseResult<Vec<DataSlice>>) -> IOResult<()> {
-        let data = match res {
+        let (data, status, errno) = match res {
             Ok(v) => {
                 if self.debug {
                     let len = v.iter().map(|x| x.len()).sum::<usize>();
                     info!("send_data unique {}, data len: {}", self.unique, len);
                 }
-                ResponseData::create(self.unique, FUSE_SUCCESS, v)
+                (
+                    ResponseData::create(self.unique, FUSE_SUCCESS, v),
+                    FuseReqStatus::Success,
+                    0,
+                )
             }
 
             Err(e) => {
                 self.rep_log(&e);
-                ResponseData::create(self.unique, e.errno, vec![])
+                let errno = e.errno;
+                (
+                    ResponseData::create(self.unique, errno, vec![]),
+                    FuseReqStatus::Error,
+                    errno,
+                )
             }
         };
 
-        self.sender.send(FuseTask::Reply(data)).await
+        self.finish_request(data, status, errno, None).await
     }
 
-    pub fn send_none(&self, _: FuseResult<()>) -> IOResult<()> {
+    pub fn send_none(&self, res: FuseResult<()>) -> IOResult<()> {
+        // No reply is sent to the kernel for Forget/BatchForget, but the request
+        // context must still be finished (guard dropped, result classified).
+        self.finish_no_reply(res);
         Ok(())
     }
 
@@ -228,5 +466,308 @@ impl FuseResponse {
         ];
         self.send_notify(FuseNotifyCode::FUSE_NOTIFY_INVAL_ENTRY, data)
             .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fuse_metrics::{ActiveGuard, FuseReqKind, FuseReqLabels};
+    use orpc::common::{Gauge, Metrics as m};
+    use orpc::sync::channel::{AsyncChannel, AsyncReceiver};
+
+    // Build a FuseResponse whose active guard is backed by `gauge`, so tests can
+    // assert "guard dropped exactly once" as a concrete `gauge.get()` count.
+    fn reply_with_gauge(unique: u64, gauge: &Gauge) -> (FuseResponse, AsyncReceiver<FuseTask>) {
+        let (tx, rx) = AsyncChannel::new(16).split();
+        let labels = FuseReqLabels::new("Lookup", FuseReqKind::Metadata, 64);
+        let ctx = FuseReqCtx {
+            labels,
+            active: Some(ActiveGuard::new(gauge.clone())), // inc to 1 now
+        };
+        (FuseResponse::new_reply(unique, tx, false, Some(ctx)), rx)
+    }
+
+    fn disabled_reply(unique: u64) -> (FuseResponse, AsyncReceiver<FuseTask>) {
+        let (tx, rx) = AsyncChannel::new(16).split();
+        (FuseResponse::new_reply(unique, tx, false, None), rx)
+    }
+
+    // T1: a normal metadata reply produces a RequestReply, finishes the slot
+    // exactly once, and the active guard is NOT dropped until the task is
+    // (i.e. the count is still 1 while the task is in flight, 0 after).
+    #[tokio::test]
+    async fn t1_request_reply_finishes_once_and_holds_guard_until_task_drops() {
+        let g = m::new_gauge("t1_active", "test").unwrap();
+        let (reply, mut rx) = reply_with_gauge(1, &g);
+        assert_eq!(g.get(), 1, "guard live after ctx creation");
+
+        reply.send_rep::<(), FuseError>(Ok(())).await.unwrap();
+
+        // The slot is finished, and the guard was moved onto the task (still 1).
+        {
+            let slot = reply.metrics.as_ref().unwrap().lock();
+            assert!(slot.finished, "slot marked finished after reply");
+            assert!(
+                slot.active.is_none(),
+                "guard taken out of slot exactly once"
+            );
+        }
+        assert_eq!(g.get(), 1, "guard rides on the task, not yet dropped");
+
+        let task = rx.try_recv().unwrap().expect("a task was enqueued");
+        assert!(
+            matches!(task, FuseTask::RequestReply { .. }),
+            "produced RequestReply"
+        );
+        drop(task); // sender finish: dropping the task drops the guard
+        assert_eq!(g.get(), 0, "guard dropped exactly once at task drop");
+    }
+
+    // T13: a real second reply on an already-finished slot is a no-op — no
+    // second task enqueued, the guard is not double-taken or double-dropped.
+    // (This actually calls send_rep twice, unlike the earlier modelled version.)
+    #[tokio::test]
+    async fn t13_real_double_reply_is_noop() {
+        let g = m::new_gauge("t13_active", "test").unwrap();
+        let (reply, mut rx) = reply_with_gauge(2, &g);
+
+        // First reply: takes the guard, finishes, enqueues a RequestReply.
+        reply.send_rep::<(), FuseError>(Ok(())).await.unwrap();
+        let t1 = rx.try_recv().unwrap().expect("first task");
+        assert!(matches!(t1, FuseTask::RequestReply { .. }));
+        assert_eq!(g.get(), 1, "guard rides on the first task");
+
+        // Second reply: slot already finished → no-op, no second task.
+        reply.send_rep::<(), FuseError>(Ok(())).await.unwrap();
+        assert!(rx.try_recv().unwrap().is_none(), "no second task enqueued");
+
+        drop(t1);
+        assert_eq!(g.get(), 0, "exactly one guard, dropped once");
+    }
+
+    // T6: Forget/BatchForget — finish_no_reply inspects the result, drops the
+    // guard, and enqueues NO task. Run for both Ok and Err.
+    #[tokio::test]
+    async fn t6_no_reply_finishes_without_task_for_ok_and_err() {
+        // Ok case
+        let g_ok = m::new_gauge("t6_ok_active", "test").unwrap();
+        let (reply_ok, mut rx_ok) = reply_with_gauge(3, &g_ok);
+        reply_ok.send_none(Ok(())).unwrap();
+        assert_eq!(g_ok.get(), 0, "no-reply drops the guard");
+        assert!(
+            rx_ok.try_recv().unwrap().is_none(),
+            "no task enqueued on no-reply"
+        );
+        {
+            let slot = reply_ok.metrics.as_ref().unwrap().lock();
+            assert!(slot.finished);
+            assert_eq!(slot.op_status, Some(FuseReqStatus::Success));
+        }
+
+        // Err case — must classify as Error, not a phantom success.
+        let g_err = m::new_gauge("t6_err_active", "test").unwrap();
+        let (reply_err, mut rx_err) = reply_with_gauge(4, &g_err);
+        reply_err.send_none(Err(FuseError::from("boom"))).unwrap();
+        assert_eq!(g_err.get(), 0);
+        assert!(rx_err.try_recv().unwrap().is_none());
+        {
+            let slot = reply_err.metrics.as_ref().unwrap().lock();
+            assert!(slot.finished);
+            assert_eq!(slot.op_status, Some(FuseReqStatus::Error));
+        }
+    }
+
+    // T7: send_rep_then_inval_inode — the request reply finishes once (a
+    // RequestReply), the trailing notification is a NotifyReply that does NOT
+    // re-finish the request slot.
+    #[tokio::test]
+    async fn t7_rep_then_inval_splits_request_and_notify() {
+        let g = m::new_gauge("t7_active", "test").unwrap();
+        let (reply, mut rx) = reply_with_gauge(5, &g);
+
+        reply
+            .send_rep_then_inval_inode::<(), FuseError>(Ok(()), 1, 0, 0)
+            .await
+            .unwrap();
+
+        let first = rx.try_recv().unwrap().expect("request reply");
+        assert!(
+            matches!(first, FuseTask::RequestReply { .. }),
+            "first = RequestReply"
+        );
+        let second = rx.try_recv().unwrap().expect("trailing notify");
+        assert!(
+            matches!(second, FuseTask::NotifyReply { .. }),
+            "second = NotifyReply"
+        );
+
+        // Request slot finished exactly once; notify did not touch it again.
+        {
+            let slot = reply.metrics.as_ref().unwrap().lock();
+            assert!(slot.finished);
+            assert!(slot.active.is_none());
+        }
+        drop(first);
+        assert_eq!(
+            g.get(),
+            0,
+            "request guard dropped once; notify carried none"
+        );
+    }
+
+    // T8: parse-after-ctx early finish — `finish_early` (the API the receiver
+    // calls when `parse_operator()` fails after the ctx exists) drops the guard,
+    // marks finished, and enqueues NO task. No requests_total would be emitted.
+    #[tokio::test]
+    async fn t8_finish_early_drops_guard_no_task() {
+        let g = m::new_gauge("t8_active", "test").unwrap();
+        let (reply, mut rx) = reply_with_gauge(6, &g);
+        reply.finish_early(libc::EINVAL, "other");
+        assert_eq!(g.get(), 0, "guard dropped on early finish (no leak)");
+        assert!(rx.try_recv().unwrap().is_none(), "no request task enqueued");
+        {
+            let slot = reply.metrics.as_ref().unwrap().lock();
+            assert!(slot.finished);
+            assert_eq!(slot.errno, libc::EINVAL, "errno stashed for decode_errors");
+            assert_eq!(
+                slot.parse_reason,
+                Some("other"),
+                "parse reason stashed for 1a-2"
+            );
+            assert_eq!(slot.op_status, Some(FuseReqStatus::Error));
+        }
+    }
+
+    // T11: metrics disabled — produces the legacy Reply, constructs no metrics
+    // slot, and notifications also fall back to Reply.
+    #[tokio::test]
+    async fn t11_disabled_uses_legacy_reply() {
+        let (reply, mut rx) = disabled_reply(7);
+        assert!(reply.metrics.is_none(), "no metrics slot when disabled");
+
+        reply.send_rep::<(), FuseError>(Ok(())).await.unwrap();
+        let task = rx.try_recv().unwrap().expect("a task");
+        assert!(
+            matches!(task, FuseTask::Reply(_)),
+            "disabled path = legacy Reply"
+        );
+
+        reply
+            .send_notify(FuseNotifyCode::FUSE_NOTIFY_INVAL_INODE, vec![])
+            .await
+            .unwrap();
+        let n = rx.try_recv().unwrap().expect("a notify task");
+        assert!(
+            matches!(n, FuseTask::Reply(_)),
+            "disabled notify = legacy Reply"
+        );
+    }
+
+    // Clone shares the single slot: finishing via a clone marks the original.
+    #[tokio::test]
+    async fn t13_clone_shares_one_slot() {
+        let g = m::new_gauge("t13_clone_active", "test").unwrap();
+        let (reply, mut rx) = reply_with_gauge(8, &g);
+        let clone = reply.clone();
+
+        // Finish via the clone.
+        clone.send_rep::<(), FuseError>(Ok(())).await.unwrap();
+
+        // The original sees finished=true and the guard gone — shared slot.
+        {
+            let slot = reply.metrics.as_ref().unwrap().lock();
+            assert!(slot.finished, "clone and original share one slot");
+            assert!(slot.active.is_none());
+        }
+        let task = rx.try_recv().unwrap().expect("one task");
+        drop(task);
+        assert_eq!(g.get(), 0, "single guard, dropped once");
+    }
+
+    // #3: reply enqueue failure splits op_status (FS result) from request_status
+    // (delivery). FS op succeeds but the channel is closed → request_status=Error
+    // while op_status stays Success; guard dropped exactly once (with the
+    // consumed task).
+    #[tokio::test]
+    async fn enqueue_failure_sets_request_status_error_keeps_op_status() {
+        let g = m::new_gauge("enq_fail_active", "test").unwrap();
+        let (reply, rx) = reply_with_gauge(9, &g);
+        drop(rx); // close the channel so send() fails
+
+        let send_result = reply.send_rep::<(), FuseError>(Ok(())).await;
+        assert!(
+            send_result.is_err(),
+            "enqueue must fail on a closed channel"
+        );
+
+        let slot = reply.metrics.as_ref().unwrap().lock();
+        assert!(slot.finished);
+        assert_eq!(
+            slot.op_status,
+            Some(FuseReqStatus::Success),
+            "FS op succeeded"
+        );
+        assert_eq!(
+            slot.request_status,
+            Some(FuseReqStatus::Error),
+            "delivery failed → request_status=Error"
+        );
+        drop(slot);
+        assert_eq!(g.get(), 0, "guard dropped once (with the consumed task)");
+    }
+
+    // #4/#5: status is classified from the explicit source tag, never errno.
+    #[tokio::test]
+    async fn status_classification_from_source_tag_not_errno() {
+        // backend ENOSYS with no tag → Error (not laundered into Unsupported).
+        let g1 = m::new_gauge("tag_backend_enosys", "test").unwrap();
+        let (r1, mut rx1) = reply_with_gauge(10, &g1);
+        let err: FuseResult<()> = Err(FuseError::new(libc::ENOSYS, "backend".into()));
+        r1.send_rep_tagged(err, None, false).await.unwrap();
+        let _ = rx1.try_recv();
+        assert_eq!(
+            r1.metrics.as_ref().unwrap().lock().op_status,
+            Some(FuseReqStatus::Error),
+            "untagged ENOSYS is Error"
+        );
+
+        // tagged unimplemented_opcode → Unsupported.
+        let g2 = m::new_gauge("tag_unimpl", "test").unwrap();
+        let (r2, mut rx2) = reply_with_gauge(11, &g2);
+        let err: FuseResult<()> = Err(FuseError::new(libc::ENOSYS, "unimpl".into()));
+        r2.send_rep_tagged(err, Some("unimplemented_opcode"), false)
+            .await
+            .unwrap();
+        let _ = rx2.try_recv();
+        assert_eq!(
+            r2.metrics.as_ref().unwrap().lock().op_status,
+            Some(FuseReqStatus::Unsupported),
+            "tagged path is Unsupported"
+        );
+
+        // ordinary EINTR with no interrupt tag → Error (not Interrupted).
+        let g3 = m::new_gauge("tag_plain_eintr", "test").unwrap();
+        let (r3, mut rx3) = reply_with_gauge(12, &g3);
+        let err: FuseResult<()> = Err(FuseError::new(libc::EINTR, "plain".into()));
+        r3.send_rep_tagged(err, None, false).await.unwrap();
+        let _ = rx3.try_recv();
+        assert_eq!(
+            r3.metrics.as_ref().unwrap().lock().op_status,
+            Some(FuseReqStatus::Error),
+            "untagged EINTR is Error"
+        );
+
+        // interrupt source tag → Interrupted.
+        let g4 = m::new_gauge("tag_interrupt", "test").unwrap();
+        let (r4, mut rx4) = reply_with_gauge(13, &g4);
+        let err: FuseResult<()> = Err(FuseError::new(libc::EINTR, "setlkw".into()));
+        r4.send_rep_tagged(err, None, true).await.unwrap();
+        let _ = rx4.try_recv();
+        assert_eq!(
+            r4.metrics.as_ref().unwrap().lock().op_status,
+            Some(FuseReqStatus::Interrupted),
+            "interrupt-tagged path is Interrupted"
+        );
     }
 }

--- a/curvine-fuse/src/session/mod.rs
+++ b/curvine-fuse/src/session/mod.rs
@@ -41,7 +41,34 @@ pub use self::fuse_notify_code::FuseNotifyCode;
 
 pub mod bdi;
 
-pub enum FuseTask {
+use crate::fuse_metrics::{ActiveGuard, FuseReqLabels, FuseReqStatus};
+
+pub(crate) enum FuseTask {
+    /// A reply to a real FUSE request with metrics enabled. Owns the move-only
+    /// `ActiveGuard`; the sender finishes the request metrics and drops the
+    /// guard after the kernel-fd write (the E2E finish point).
+    RequestReply {
+        data: ResponseData,
+        labels: FuseReqLabels,
+        active: ActiveGuard,
+        status: FuseReqStatus,
+        errno: i32,
+        /// Source tag for `status == Unsupported` (`unknown_opcode` /
+        /// `unimplemented_opcode` / `trait_default`), carried so Phase 1a-2 can
+        /// emit `unsupported_total{reason}` at the sender finish point without
+        /// reaching back into the metrics slot. `None` for non-unsupported
+        /// replies. (Phase 1a-1 sets it but reads nothing.)
+        unsupported_reason: Option<&'static str>,
+    },
+    /// A kernel notification (cache invalidation). No originating request, so no
+    /// labels/guard; carries its own `FuseNotifyCode::as_str()` code for
+    /// sender-side attribution.
+    NotifyReply {
+        data: ResponseData,
+        code: &'static str,
+    },
+    /// Legacy fast path, used when metrics are disabled: no context, no guard,
+    /// the sender does no request-finish work. Keeps `metrics_enabled=false`
+    /// byte-identical to the pre-metrics behaviour.
     Reply(ResponseData),
-    Request(FuseRequest),
 }


### PR DESCRIPTION
## What

Phase 1a-1 of the curvine-fuse end-to-end metrics work ([design](curvine-fuse-metrics-design.md), [#897](https://github.com/CurvineIO/curvine/issues/897)): the **structural context spine and finish state machine**. This is a **behaviour-preserving** refactor that establishes the per-request metrics context and the sender-side finish point, **without emitting any real metric**. It is intentionally landed before the counters (Phase 1a-2) so the ownership model is validated in isolation.

After this PR the daemon behaves identically — only internal plumbing changed.

## Changes (9 files, +558/-33)

- **`FuseTask` split** into `RequestReply` (owns the move-only `ActiveGuard`, finished in the sender after the kernel-fd write), `NotifyReply` (kernel notifications, carry their own code), and legacy `Reply` (disabled fast path).
- **`Arc<Mutex<FuseRespMetrics>>` slot** on `FuseResponse`: single-take active guard, `finished` flag, `op_status`/`request_status` stored separately, clone shares one slot.
- **Status from an explicit source tag** (`send_rep_tagged`), never from errno: untagged `ENOSYS`/`EINTR` stay `Error`; the dispatch wildcard / `Notimplemented` is `Unsupported`; the SETLKW interrupt path is `Interrupted`.
- **`finish_no_reply`** inspects the `Forget`/`BatchForget` result (a failing forget is `Error`, not a phantom success); **`finish_early`** drops the guard on a parse-after-ctx failure without emitting a request.
- **`send_stream`** creates the ctx before parse and reuses the same slot on the enqueue-failure reply, so failures cannot become zero-latency phantoms.
- **Zero-length write** now sends a `fuse_write_out{size:0}` reply so the request reaches a terminal state instead of hanging the kernel task.
- `ActiveGuard` is a **no-op guard** in 1a-1 (proves move/drop ownership without touching a real gauge); `parking_lot::Mutex` matches orpc; its `MutexGuard` is `!Send` (the workspace does not enable `send_guard`), so a lock-held-across-await fails to compile. (`ActiveGuard` itself is intentionally `Send` — it must travel onto the reply task — and a `guards_are_send` compile-test enforces that.)

## Scope / deferred

- **No real metrics are emitted in this PR.** The `active_requests` gauge, `requests_total`, `request_duration_us`, etc. are wired on top of this proven state machine in **Phase 1a-2** (next PR, stacked on this branch).
- The `metrics_enabled` kill switch also lands in Phase 1a-2 (the design's "kill switch in Phase 1a-1" is deferred one step).

## Tests

7 new ownership/error-path tests in `fuse_response.rs` cover: finish-once, clone/double-reply no-op, no-reply success+error, notify split, parse-after-ctx no-leak, enqueue-failure status split, and source-tag classification.

- `cargo build -p curvine-fuse`: zero warnings
- `cargo test -p curvine-fuse --lib`: 39 passed
- `cargo clippy -p curvine-fuse --all-targets -- --deny=warnings --allow clippy::uninlined-format-args` (matches CI): passes
- End-to-end `fuse-test.sh` mainline passes (the metrics work is validated more fully in 1a-2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

