### PR TITLE
fix(server): reject extreme truncate sizes to prevent master crash

### DIFF
--- a/curvine-common/src/error/fs_error.rs
+++ b/curvine-common/src/error/fs_error.rs
@@ -236,6 +236,15 @@ impl FsError {
         Self::FileAlreadyExists(ErrorImpl::with_source(msg.into()))
     }
 
+    pub fn file_too_large(len: i64) -> Self {
+        let msg = format!(
+            "file size {} exceeds maximum supported size {}",
+            len,
+            crate::MAX_FILE_SIZE
+        );
+        Self::InvalidFileSize(ErrorImpl::with_source(msg.into()))
+    }
+
     pub fn parent_not_dir(path: impl AsRef<str>) -> Self {
         let msg = format!("{} is not a directory", path.as_ref());
         Self::ParentNotDir(ErrorImpl::with_source(msg.into()))

--- a/curvine-common/src/lib.rs
+++ b/curvine-common/src/lib.rs
@@ -37,4 +37,7 @@ pub type FsResult<T> = Result<T, FsError>;
 
 pub const FILE_BUFFER_SIZE: usize = 128 * 1024;
 
+/// Maximum supported file size (1 PiB).
+pub const MAX_FILE_SIZE: i64 = 1 << 50;
+
 pub const UFS_INODE_ID: i64 = 0;

--- a/curvine-common/src/state/file_alloc.rs
+++ b/curvine-common/src/state/file_alloc.rs
@@ -12,9 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::error::FsError;
 use crate::FsResult;
+use crate::MAX_FILE_SIZE;
 use bitflags::bitflags;
-use orpc::err_box;
+use orpc::{err_box, err_ext};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 bitflags! {
@@ -123,6 +125,11 @@ impl FileAllocOpts {
             return err_box!("len must be >= 0 for allocate operation, got {}", self.len);
         }
 
+        let changes_file_size = self.truncate || !self.mode.contains(FileAllocMode::KEEP_SIZE);
+        if changes_file_size && self.len > MAX_FILE_SIZE {
+            return err_ext!(FsError::file_too_large(self.len));
+        }
+
         if !self.truncate {
             let allowed_flags =
                 FileAllocMode::DEFAULT | FileAllocMode::ZERO_RANGE | FileAllocMode::KEEP_SIZE;
@@ -143,5 +150,35 @@ impl FileAllocOpts {
             len,
             ..self.clone()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::FsError;
+
+    #[test]
+    fn validate_rejects_extreme_truncate_size() {
+        let opts = FileAllocOpts::with_truncate(1 << 60);
+        let err = opts.validate().unwrap_err();
+        assert!(matches!(err, FsError::InvalidFileSize(_)));
+    }
+
+    #[test]
+    fn validate_allows_max_supported_size() {
+        let opts = FileAllocOpts::with_truncate(MAX_FILE_SIZE);
+        assert!(opts.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_skips_size_check_for_keep_size_allocate() {
+        let opts = FileAllocOpts {
+            truncate: false,
+            off: 0,
+            len: 1 << 60,
+            mode: FileAllocMode::KEEP_SIZE,
+        };
+        assert!(opts.validate().is_ok());
     }
 }

--- a/curvine-common/src/state/file_alloc.rs
+++ b/curvine-common/src/state/file_alloc.rs
@@ -122,11 +122,10 @@ impl FileAllocOpts {
         }
 
         if self.len < 0 {
-            return err_box!("len must be >= 0 for allocate operation, got {}", self.len);
+            return err_box!("len must be >= 0, got {}", self.len);
         }
 
-        let changes_file_size = self.truncate || !self.mode.contains(FileAllocMode::KEEP_SIZE);
-        if changes_file_size && self.len > MAX_FILE_SIZE {
+        if self.len > MAX_FILE_SIZE {
             return err_ext!(FsError::file_too_large(self.len));
         }
 
@@ -172,13 +171,14 @@ mod tests {
     }
 
     #[test]
-    fn validate_skips_size_check_for_keep_size_allocate() {
+    fn validate_rejects_extreme_size_for_keep_size_allocate() {
         let opts = FileAllocOpts {
             truncate: false,
             off: 0,
             len: 1 << 60,
             mode: FileAllocMode::KEEP_SIZE,
         };
-        assert!(opts.validate().is_ok());
+        let err = opts.validate().unwrap_err();
+        assert!(matches!(err, FsError::InvalidFileSize(_)));
     }
 }

--- a/curvine-fuse/src/fuse_error.rs
+++ b/curvine-fuse/src/fuse_error.rs
@@ -80,6 +80,7 @@ impl From<FsError> for FuseError {
             FsError::ParentNotDir(_) => Some(libc::ENOTDIR),
             FsError::NotADirectory(_) => Some(libc::ENOTDIR),
             FsError::InvalidPath(_) => Some(libc::EINVAL),
+            FsError::InvalidFileSize(_) => Some(libc::EFBIG),
             FsError::InvalidArgument(_) => Some(libc::EINVAL),
             FsError::DiskOutOfSpace(_) => Some(libc::ENOSPC),
             FsError::Timeout(_) => Some(libc::ETIMEDOUT),
@@ -155,13 +156,22 @@ pub(crate) fn errno_label(errno: i32) -> &'static str {
         libc::ENOMEM => "ENOMEM",
         libc::EBUSY => "EBUSY",
         libc::ENAMETOOLONG => "ENAMETOOLONG",
+        libc::EFBIG => "EFBIG",
         _ => "OTHER",
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::errno_label;
+    use super::{errno_label, FuseError};
+    use curvine_common::error::FsError;
+
+    #[test]
+    fn invalid_file_size_maps_to_efbig() {
+        let err: FuseError = FsError::file_too_large(1 << 60).into();
+        assert_eq!(err.errno, libc::EFBIG);
+        assert_eq!(errno_label(err.errno), "EFBIG");
+    }
 
     #[test]
     fn errno_label_maps_the_closed_set() {
@@ -191,6 +201,7 @@ mod tests {
             (libc::ENOMEM, "ENOMEM"),
             (libc::EBUSY, "EBUSY"),
             (libc::ENAMETOOLONG, "ENAMETOOLONG"),
+            (libc::EFBIG, "EFBIG"),
         ];
         for (e, expected) in table {
             assert_eq!(errno_label(e), expected, "label mismatch for errno {}", e);

--- a/curvine-server/src/master/meta/inode/inode_file.rs
+++ b/curvine-server/src/master/meta/inode/inode_file.rs
@@ -16,14 +16,13 @@ use crate::master::meta::feature::{AclFeature, FileFeature, WriteFeature};
 use crate::master::meta::inode::{Inode, EMPTY_PARENT_ID};
 use crate::master::meta::store::InodeStore;
 use crate::master::meta::{BlockMeta, InodeId};
-use curvine_common::error::FsError;
 use curvine_common::state::{
     BlockLocation, CommitBlock, CreateFileOpts, ExtendedBlock, FileAllocOpts, FileType,
     StoragePolicy,
 };
 use curvine_common::FsResult;
 use orpc::common::LocalTime;
-use orpc::{err_box, err_ext, CommonResult};
+use orpc::{err_box, CommonResult};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt::Debug;
@@ -392,9 +391,7 @@ impl InodeFile {
     /// # Returns
     /// * `Vec<BlockMeta>` - Blocks that were removed during truncation (empty if extended or unchanged)
     pub fn resize(&mut self, opts: FileAllocOpts) -> FsResult<Vec<BlockMeta>> {
-        if opts.len > curvine_common::MAX_FILE_SIZE {
-            return err_ext!(FsError::file_too_large(opts.len));
-        }
+        opts.validate()?;
 
         if self.len == opts.len {
             Ok(vec![])

--- a/curvine-server/src/master/meta/inode/inode_file.rs
+++ b/curvine-server/src/master/meta/inode/inode_file.rs
@@ -16,13 +16,14 @@ use crate::master::meta::feature::{AclFeature, FileFeature, WriteFeature};
 use crate::master::meta::inode::{Inode, EMPTY_PARENT_ID};
 use crate::master::meta::store::InodeStore;
 use crate::master::meta::{BlockMeta, InodeId};
+use curvine_common::error::FsError;
 use curvine_common::state::{
     BlockLocation, CommitBlock, CreateFileOpts, ExtendedBlock, FileAllocOpts, FileType,
     StoragePolicy,
 };
 use curvine_common::FsResult;
 use orpc::common::LocalTime;
-use orpc::{err_box, CommonResult};
+use orpc::{err_box, err_ext, CommonResult};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt::Debug;
@@ -391,6 +392,10 @@ impl InodeFile {
     /// # Returns
     /// * `Vec<BlockMeta>` - Blocks that were removed during truncation (empty if extended or unchanged)
     pub fn resize(&mut self, opts: FileAllocOpts) -> FsResult<Vec<BlockMeta>> {
+        if opts.len > curvine_common::MAX_FILE_SIZE {
+            return err_ext!(FsError::file_too_large(opts.len));
+        }
+
         if self.len == opts.len {
             Ok(vec![])
         } else if opts.len < self.len {

--- a/curvine-server/tests/master_fs_test.rs
+++ b/curvine-server/tests/master_fs_test.rs
@@ -23,7 +23,7 @@ use curvine_common::raft::storage::{AppStorage, ApplyMsg};
 use curvine_common::raft::RaftPeer;
 use curvine_common::state::MountOptions;
 use curvine_common::state::{
-    BlockLocation, ClientAddress, CommitBlock, CreateFileOpts, WorkerInfo,
+    BlockLocation, ClientAddress, CommitBlock, CreateFileOpts, FileAllocOpts, WorkerInfo,
 };
 use curvine_common::state::{OpenFlags, RenameFlags, SetAttrOptsBuilder};
 use curvine_common::utils::SerdeUtils;
@@ -1353,4 +1353,19 @@ fn test_idempotent_set_locks() -> CommonResult<()> {
     replay_all_then_duplicate_last(&js, &loader)?;
     assert_eq!(fs.sum_hash(), fs2.sum_hash());
     Ok(())
+}
+
+#[test]
+fn resize_rejects_extreme_file_size() {
+    let _serial = master_fs_test_serial();
+    let fs = new_fs(true, "resize-extreme");
+    fs.create("/extreme.log", true).unwrap();
+
+    let err = fs
+        .resize("/extreme.log", FileAllocOpts::with_truncate(1_i64 << 60))
+        .unwrap_err();
+    assert!(matches!(err, FsError::InvalidFileSize(_)));
+
+    let status = fs.file_status("/extreme.log").unwrap();
+    assert_eq!(status.len, 0);
 }


### PR DESCRIPTION
## Problem
Truncating a file to an extremely large size (e.g. 1 EiB) caused the Master to enter an unbounded block allocation loop in `InodeFile::extend`, making the cluster unresponsive. FUSE returned `EIO` instead of a proper file-size error.

Fixes #915

## Design
Introduce a shared 1 PiB (`MAX_FILE_SIZE`) limit validated in `FileAllocOpts` before resize reaches Master metadata. Map `InvalidFileSize` to POSIX `EFBIG` at the FUSE layer, and keep a defensive check in `InodeFile::resize` as a last resort.

## Key Changes
- Add `MAX_FILE_SIZE` and `FsError::file_too_large()` in `curvine-common`
- Reject oversized resize/truncate in `FileAllocOpts::validate()`
- Map `InvalidFileSize` to `EFBIG` in `curvine-fuse`
- Add defensive size guard in `InodeFile::resize`
- Add unit and master integration tests

## Test plan
- [x] `cargo test -p curvine-common validate_rejects_extreme`
- [x] `cargo test -p curvine-fuse invalid_file_size_maps_to_efbig`
- [x] `cargo test -p curvine-server resize_rejects_extreme_file_size`
