### PR TITLE
test(fuse): add LTP failure reproducer scripts

### DIFF
--- a/build/tests/scripts/curvine_ltp_chmod_mode_repro.py
+++ b/build/tests/scripts/curvine_ltp_chmod_mode_repro.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+#  // Copyright 2025 OPPO.
+#  //
+#  // Licensed under the Apache License, Version 2.0 (the "License");
+#  // you may not use this file except in compliance with the License.
+#  // You may obtain a copy of the License at
+#  //
+#  //     http://www.apache.org/licenses/LICENSE-2.0
+#  //
+#  // Unless required by applicable law or agreed to in writing, software
+#  // distributed under the License is distributed on an "AS IS" BASIS,
+#  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  // See the License for the specific language governing permissions and
+#  // limitations under the License.
+
+"""
+chmod/fchmod mode bits not persisted on Curvine FUSE — reproducer for LTP failures.
+
+Root cause: setattr (chmod/fchmod) and create-time umask application do not
+persist permission mode 0000.  chmod(2)/fchmod(2) return success, but stat()
+still reports the previous mode (e.g. 0755).  Likewise creat(2) under
+umask(0777) should yield mode 0000 but the file keeps a non-zero mode.
+
+Covered LTP cases (each line is one minimal repro scenario):
+  chmod01  — chmod(path, 0000) succeeds yet stat() mode stays 0755 (TFAIL test 1)
+  fchmod01 — fchmod(fd, 0000) succeeds yet fstat() mode stays 0755 (TFAIL)
+  umask01  — umask(0777) + creat(0777) yields mode 0755 instead of 0000 (TFAIL)
+
+Usage:
+    python3 curvine_ltp_chmod_mode_repro.py --dir /curvine-fuse/fuse-test
+    python3 curvine_ltp_chmod_mode_repro.py --dir /curvine-fuse/fuse-test --allow-non-mount
+"""
+
+import argparse
+import errno
+import os
+import shutil
+import sys
+from typing import Callable
+
+DEFAULT_DIR = "/curvine-fuse/fuse-test"
+
+# LTP chmod01 / fchmod01 initial file mode (S_IRUSR|S_IWUSR|S_IRGRP|S_IROTH).
+_LTP_FILE_MODE = 0o644
+
+
+def expect_ok(name: str, fn: Callable[[], None]) -> int:
+    try:
+        fn()
+        print(f"  PASS: {name}")
+        return 0
+    except OSError as exc:
+        print(
+            f"  FAIL: {name} — unexpected OSError errno={exc.errno} "
+            f"({errno.errorcode.get(exc.errno, '?')}): {exc}",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        print(f"  FAIL: {name} — unexpected error: {exc}", file=sys.stderr)
+        return 1
+
+
+def expect_errno(name: str, fn: Callable[[], None], expected: int) -> int:
+    try:
+        fn()
+        print(
+            f"  FAIL: {name} — expected errno {expected} "
+            f"({errno.errorcode.get(expected, '?')}), but syscall succeeded",
+            file=sys.stderr,
+        )
+        return 1
+    except OSError as exc:
+        if exc.errno == expected:
+            print(
+                f"  PASS: {name} (errno={expected} "
+                f"{errno.errorcode.get(expected, '?')})"
+            )
+            return 0
+        print(
+            f"  FAIL: {name} — expected errno {expected}, got {exc.errno}: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        print(f"  FAIL: {name} — expected OSError, got {exc}", file=sys.stderr)
+        return 1
+
+
+def skip(name: str, reason: str) -> int:
+    print(f"  SKIP: {name} — {reason}")
+    return 0
+
+
+def case_dir(root: str, name: str) -> str:
+    path = os.path.join(root, name)
+    if os.path.exists(path):
+        shutil.rmtree(path)
+    os.makedirs(path)
+    return path
+
+
+def _low9_mode(st_mode: int) -> int:
+    return st_mode & 0o7777
+
+
+def _raise_mode_mismatch(actual: int, expected: int, label: str) -> None:
+    raise OSError(
+        errno.EINVAL,
+        f"{label}: mode got {actual:#06o}, expected {expected:#06o}",
+    )
+
+
+def test_chmod_zero_mode_persisted(root: str) -> int:
+    # Related LTP cases: chmod01
+    # chmod(2) with mode 0000 must clear all permission bits visible via stat(2).
+    workdir = case_dir(root, "chmod_zero_mode")
+    target = os.path.join(workdir, "testfile")
+
+    def run_chmod_zero() -> None:
+        fd = os.open(target, os.O_CREAT | os.O_RDWR, _LTP_FILE_MODE)
+        os.close(fd)
+        os.chmod(target, 0)
+        actual = _low9_mode(os.stat(target).st_mode)
+        if actual != 0:
+            _raise_mode_mismatch(actual, 0, "stat after chmod(path, 0000)")
+
+    return expect_ok(
+        "chmod(path, 0000) then stat() shows mode 0000 (chmod01)",
+        run_chmod_zero,
+    )
+
+
+def test_fchmod_zero_mode_persisted(root: str) -> int:
+    # Related LTP cases: fchmod01
+    # fchmod(2) with mode 0000 must clear all permission bits visible via fstat(2).
+    workdir = case_dir(root, "fchmod_zero_mode")
+    target = os.path.join(workdir, "testfile")
+
+    def run_fchmod_zero() -> None:
+        fd = os.open(target, os.O_CREAT | os.O_RDWR, _LTP_FILE_MODE)
+        os.fchmod(fd, 0)
+        actual = _low9_mode(os.fstat(fd).st_mode)
+        os.close(fd)
+        if actual != 0:
+            _raise_mode_mismatch(actual, 0, "fstat after fchmod(fd, 0000)")
+
+    return expect_ok(
+        "fchmod(fd, 0000) then fstat() shows mode 0000 (fchmod01)",
+        run_fchmod_zero,
+    )
+
+
+def test_creat_under_full_umask_has_zero_mode(root: str) -> int:
+    # Related LTP cases: umask01
+    # creat(2) under umask(0777) must produce a file whose low 9 mode bits are 0000.
+    workdir = case_dir(root, "umask_zero_mode")
+    target = os.path.join(workdir, "testfile")
+
+    def run_umask_creat_zero() -> None:
+        prev = os.umask(0o777)
+        try:
+            fd = os.open(target, os.O_CREAT | os.O_TRUNC | os.O_RDWR, 0o777)
+            os.close(fd)
+            actual = _low9_mode(os.stat(target).st_mode)
+            if actual != 0:
+                _raise_mode_mismatch(actual, 0, "stat after umask(0777)+creat(0777)")
+        finally:
+            os.umask(prev)
+
+    return expect_ok(
+        "umask(0777)+creat(0777) yields file mode 0000 (umask01)",
+        run_umask_creat_zero,
+    )
+
+
+TESTS: list[tuple[str, str, Callable[..., int]]] = [
+    (
+        "1",
+        "chmod(path, 0000) persists via stat (chmod01)",
+        test_chmod_zero_mode_persisted,
+    ),
+    (
+        "2",
+        "fchmod(fd, 0000) persists via fstat (fchmod01)",
+        test_fchmod_zero_mode_persisted,
+    ),
+    (
+        "3",
+        "umask(0777)+creat yields mode 0000 (umask01)",
+        test_creat_under_full_umask_has_zero_mode,
+    ),
+]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="chmod/fchmod mode-0000 not persisted on Curvine FUSE — reproducer",
+    )
+    parser.add_argument(
+        "--dir",
+        default=DEFAULT_DIR,
+        help="Base test directory (must be on the Curvine FUSE mount)",
+    )
+    parser.add_argument(
+        "--allow-non-mount",
+        action="store_true",
+        help="Skip FUSE mount check; for local debugging only (default: False)",
+    )
+    args = parser.parse_args()
+
+    if not sys.platform.startswith("linux"):
+        print("SKIP: Linux-only syscalls", file=sys.stderr)
+        return 0
+
+    if os.geteuid() != 0:
+        print("WARNING: not running as root", file=sys.stderr)
+
+    root = os.path.abspath(args.dir)
+    os.makedirs(root, exist_ok=True)
+
+    if args.allow_non_mount:
+        print(
+            "WARNING: --allow-non-mount set; results may not reflect Curvine FUSE behaviour",
+            file=sys.stderr,
+        )
+
+    print(f"Running chmod-mode reproducer under {root}\n")
+
+    fail = 0
+    for num, title, test_fn in TESTS:
+        print(f"[case {num}] {title}:")
+        fail += test_fn(root)
+        print()
+
+    total = len(TESTS)
+    passed = total - fail
+    print(f"Summary: {passed}/{total} passed, {fail}/{total} failed")
+    return 1 if fail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/build/tests/scripts/curvine_ltp_close_eio_repro.py
+++ b/build/tests/scripts/curvine_ltp_close_eio_repro.py
@@ -1,0 +1,448 @@
+#!/usr/bin/env python3
+#  // Copyright 2025 OPPO.
+#  //
+#  // Licensed under the Apache License, Version 2.0 (the "License");
+#  // you may not use this file except in compliance with the License.
+#  // You may obtain a copy of the License at
+#  //
+#  //     http://www.apache.org/licenses/LICENSE-2.0
+#  //
+#  // Unless required by applicable law or agreed to in writing, software
+#  // distributed under the License is distributed on an "AS IS" BASIS,
+#  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  // See the License for the specific language governing permissions and
+#  // limitations under the License.
+
+"""
+close(2) returning EIO on Curvine FUSE — reproducer for LTP write-back failures.
+
+Root cause: FUSE write-back fails during release/flush when closing an fd after
+flock(2) or fcntl(F_SETLEASE) operations.  The lock/lease syscalls themselves
+succeed (or fail with the expected errno); only close(2) surfaces EIO.
+
+Covered LTP cases (each line is one minimal repro scenario):
+  flock02 — close(fd) must succeed after flock(-1) EBADF then flock(LOCK_NB) EINVAL
+      on the same file (LTP runs both error cases before close)
+  flock04 — close(fd) must succeed on LTP tc0 (parent LOCK_SH, two forked children)
+      after flock02+flock03 precondition on the same FUSE mount (6/17 syscalls-jfs order;
+      EIO is intermittent on addda67 — three precondition cycles raise hit rate)
+  fcntl32, fcntl32_64 — close(fd) must succeed across the full nine-case
+      verify_fcntl loop (EIO observed on close after F_SETLEASE returns EAGAIN)
+
+Usage:
+    python3 curvine_ltp_close_eio_repro.py --dir /curvine-fuse/fuse-test
+    python3 curvine_ltp_close_eio_repro.py --dir /curvine-fuse/fuse-test --allow-non-mount
+"""
+
+import argparse
+import ctypes
+import errno
+import fcntl
+import os
+import shutil
+import sys
+from typing import Callable
+
+DEFAULT_DIR = "/curvine-fuse/fuse-test"
+
+# 6/17 syscalls-jfs on addda67: flock04 EIO is intermittent; running flock02
+# (close EIO) then flock03 on the same mount raises the hit rate.  Three
+# precondition rounds mirror heavy prior-suite pressure without replaying 261 cases.
+_FLOCK04_PRECONDITION_CYCLES = 3
+
+LOCK_SH = 1
+LOCK_EX = 2
+LOCK_NB = 4
+LOCK_UN = 8
+
+F_SETLEASE = 1024
+F_WRLCK = 1
+
+_libc = None
+
+
+def _init_libc() -> ctypes.CDLL:
+    global _libc
+    if _libc is None:
+        _libc = ctypes.CDLL(None, use_errno=True)
+    return _libc
+
+
+def sys_flock(fd: int, operation: int) -> None:
+    """flock(fd, operation) via libc."""
+    ret = _init_libc().flock(fd, operation)
+    if ret < 0:
+        err = ctypes.get_errno()
+        raise OSError(err, os.strerror(err))
+
+
+def case_dir(root: str, name: str) -> str:
+    path = os.path.join(root, name)
+    if os.path.exists(path):
+        shutil.rmtree(path)
+    os.makedirs(path)
+    return path
+
+
+def expect_ok(name: str, fn: Callable[[], None]) -> int:
+    try:
+        fn()
+        print(f"  PASS: {name}")
+        return 0
+    except OSError as exc:
+        print(
+            f"  FAIL: {name} — unexpected OSError errno={exc.errno} "
+            f"({errno.errorcode.get(exc.errno, '?')}): {exc}",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        print(f"  FAIL: {name} — unexpected error: {exc}", file=sys.stderr)
+        return 1
+
+
+def expect_errno(name: str, fn: Callable[[], None], expected: int) -> int:
+    try:
+        fn()
+        print(
+            f"  FAIL: {name} — expected errno {expected} "
+            f"({errno.errorcode.get(expected, '?')}), but syscall succeeded",
+            file=sys.stderr,
+        )
+        return 1
+    except OSError as exc:
+        if exc.errno == expected:
+            print(
+                f"  PASS: {name} (errno={expected} "
+                f"{errno.errorcode.get(expected, '?')})"
+            )
+            return 0
+        print(
+            f"  FAIL: {name} — expected errno {expected}, got {exc.errno}: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        print(f"  FAIL: {name} — expected OSError, got {exc}", file=sys.stderr)
+        return 1
+
+
+def skip(name: str, reason: str) -> int:
+    print(f"  SKIP: {name} — {reason}")
+    return 0
+
+
+def _create_empty_file(path: str, mode: int = 0o666) -> None:
+    fd = os.open(path, os.O_CREAT | os.O_TRUNC | os.O_RDWR, mode)
+    os.close(fd)
+
+
+def _safe_close_ignore_eio(fd: int) -> None:
+    try:
+        os.close(fd)
+    except OSError as exc:
+        if exc.errno != errno.EIO:
+            raise
+
+
+def _ltp_flock02_precondition(root: str) -> None:
+    """LTP flock02 EBADF+EINVAL on a sibling dir; close EIO poisons the mount."""
+    workdir = os.path.join(root, "_ltp_pre_flock02")
+    if os.path.exists(workdir):
+        shutil.rmtree(workdir)
+    os.makedirs(workdir)
+    target = os.path.join(workdir, "testfile")
+    _create_empty_file(target, 0o666)
+
+    fd = os.open(target, os.O_RDWR)
+    try:
+        sys_flock(-1, LOCK_NB)
+    except OSError as exc:
+        if exc.errno != errno.EBADF:
+            raise
+    else:
+        raise OSError(errno.EINVAL, "flock(-1) succeeded unexpectedly")
+    _safe_close_ignore_eio(fd)
+
+    fd = os.open(target, os.O_RDWR)
+    try:
+        sys_flock(fd, LOCK_NB)
+    except OSError as exc:
+        if exc.errno != errno.EINVAL:
+            raise
+    else:
+        raise OSError(errno.EINVAL, "flock(LOCK_NB) succeeded unexpectedly")
+    _safe_close_ignore_eio(fd)
+
+
+def _flock03_child_after_fork(target: str, parent_fd: int, go_rfd: int) -> None:
+    """LTP flock03 child: wait, probe lock, unlock parent fd, re-lock, close."""
+    os.read(go_rfd, 1)
+    child_fd = os.open(target, os.O_RDWR)
+    if _init_libc().flock(child_fd, LOCK_EX | LOCK_NB) == 0:
+        os.close(child_fd)
+        os._exit(1)
+    if _init_libc().flock(parent_fd, LOCK_UN) < 0:
+        os.close(child_fd)
+        os._exit(1)
+    if _init_libc().flock(child_fd, LOCK_EX | LOCK_NB) < 0:
+        os.close(child_fd)
+        os._exit(1)
+    os.close(parent_fd)
+    os.close(child_fd)
+    os._exit(0)
+
+
+def _ltp_flock03_precondition(root: str) -> None:
+    """LTP flock03 parent EX lock, child unlocks parent fd then EX lock."""
+    workdir = os.path.join(root, "_ltp_pre_flock03")
+    if os.path.exists(workdir):
+        shutil.rmtree(workdir)
+    os.makedirs(workdir)
+    target = os.path.join(workdir, "testfile")
+    _create_empty_file(target, 0o666)
+
+    go_rfd, go_wfd = os.pipe()
+    parent_fd = os.open(target, os.O_RDWR)
+    pid = os.fork()
+    if pid == 0:
+        os.close(go_wfd)
+        _flock03_child_after_fork(target, parent_fd, go_rfd)
+    sys_flock(parent_fd, LOCK_EX | LOCK_NB)
+    os.write(go_wfd, b"\0")
+    os.close(go_wfd)
+    os.close(go_rfd)
+    _reap_fork_child(pid)
+    os.close(parent_fd)
+
+
+def _flock04_precondition_mount(root: str) -> None:
+    for _ in range(_FLOCK04_PRECONDITION_CYCLES):
+        _ltp_flock02_precondition(root)
+        _ltp_flock03_precondition(root)
+
+
+def _reap_fork_child(pid: int) -> None:
+    _, status = os.waitpid(pid, 0)
+    if os.WIFEXITED(status) and os.WEXITSTATUS(status) != 0:
+        raise OSError(
+            errno.EIO,
+            f"child exited with status {os.WEXITSTATUS(status)}",
+        )
+    if os.WIFSIGNALED(status):
+        raise OSError(errno.EIO, f"child killed by signal {os.WTERMSIG(status)}")
+
+
+def _flock04_child_fork(path: str, flock_op: int, should_pass: bool) -> None:
+    """LTP flock04 child body (runs in a forked child)."""
+    fd = os.open(path, os.O_RDWR)
+    ret = _init_libc().flock(fd, flock_op)
+    if should_pass:
+        if ret < 0:
+            os.close(fd)
+            os._exit(ctypes.get_errno() or 1)
+    else:
+        if ret == 0:
+            os.close(fd)
+            os._exit(1)
+    os.close(fd)
+    os._exit(0)
+
+
+def _run_flock04_tcase(target: str, parent_op: int) -> None:
+    """One LTP flock04 verify_flock() iteration."""
+    parent_fd = os.open(target, os.O_RDWR)
+    sys_flock(parent_fd, parent_op)
+    child1_should_pass = bool(parent_op & LOCK_SH)
+
+    pid = os.fork()
+    if pid == 0:
+        _flock04_child_fork(target, LOCK_SH | LOCK_NB, child1_should_pass)
+    _reap_fork_child(pid)
+
+    pid = os.fork()
+    if pid == 0:
+        _flock04_child_fork(target, LOCK_EX | LOCK_NB, False)
+    _reap_fork_child(pid)
+
+    os.close(parent_fd)
+
+
+# LTP fcntl32 verify_fcntl flag pairs (fd1, fd2) in execution order.
+_FCNTL32_FLAG_PAIRS = (
+    (os.O_RDONLY, os.O_RDONLY),
+    (os.O_RDONLY, os.O_WRONLY),
+    (os.O_RDONLY, os.O_RDWR),
+    (os.O_WRONLY, os.O_RDONLY),
+    (os.O_WRONLY, os.O_WRONLY),
+    (os.O_WRONLY, os.O_RDWR),
+    (os.O_RDWR, os.O_RDONLY),
+    (os.O_RDWR, os.O_WRONLY),
+    (os.O_RDWR, os.O_RDWR),
+)
+
+_FCNTL32_FILE_MODE = 0o7777  # 07777 — matches LTP FILE_MODE with setuid/setgid bits
+
+
+def _fcntl32_setlease_cycle(target: str, fd1_flag: int, fd2_flag: int) -> None:
+    """One LTP fcntl32 verify_fcntl iteration: open, F_SETLEASE, close both fds."""
+    fd1 = os.open(target, fd1_flag)
+    fd2 = os.open(target, fd2_flag)
+    lease_errno = None
+    try:
+        fcntl.fcntl(fd1, F_SETLEASE, F_WRLCK)
+    except OSError as exc:
+        lease_errno = exc.errno
+    else:
+        os.close(fd1)
+        os.close(fd2)
+        raise OSError(
+            errno.EINVAL,
+            "fcntl(F_SETLEASE, F_WRLCK) succeeded unexpectedly",
+        )
+    if lease_errno not in (errno.EAGAIN, errno.EBUSY):
+        os.close(fd1)
+        os.close(fd2)
+        raise OSError(
+            lease_errno,
+            f"fcntl(F_SETLEASE, F_WRLCK) unexpected errno={lease_errno}",
+        )
+    os.close(fd1)
+    os.close(fd2)
+
+
+def test_close_after_flock_invalid_operation(root: str) -> int:
+    # Related LTP cases: flock02
+    # close(2) must succeed after LTP error-case loop (EBADF then EINVAL) on one file.
+    workdir = case_dir(root, "flock_invalid_op_close")
+    target = os.path.join(workdir, "testfile")
+    _create_empty_file(target, 0o666)
+
+    def run_ltp_flock02_error_cases() -> None:
+        fd = os.open(target, os.O_RDWR)
+        try:
+            sys_flock(-1, LOCK_NB)
+        except OSError as exc:
+            if exc.errno != errno.EBADF:
+                raise
+        else:
+            raise OSError(errno.EINVAL, "flock(-1) succeeded unexpectedly")
+        os.close(fd)
+
+        fd = os.open(target, os.O_RDWR)
+        try:
+            sys_flock(fd, LOCK_NB)
+        except OSError as exc:
+            if exc.errno != errno.EINVAL:
+                raise
+        else:
+            raise OSError(errno.EINVAL, "flock(LOCK_NB) succeeded unexpectedly")
+        os.close(fd)
+
+    return expect_ok(
+        "close(fd) after flock02 EBADF+EINVAL sequence (flock02)",
+        run_ltp_flock02_error_cases,
+    )
+
+
+def test_close_after_flock_shared_parent_child(root: str) -> int:
+    # Related LTP cases: flock04
+    # close(2) must succeed on LTP tc0 after flock02+flock03 mount precondition (6/17 order).
+    workdir = case_dir(root, "flock04_close")
+    target = os.path.join(workdir, "testfile")
+    _create_empty_file(target, 0o644)
+
+    def run_ltp_flock04_after_precondition() -> None:
+        _flock04_precondition_mount(root)
+        _run_flock04_tcase(target, LOCK_SH)
+
+    return expect_ok(
+        "close after flock04 tc0 with flock02+flock03 precondition (flock04)",
+        run_ltp_flock04_after_precondition,
+    )
+
+
+def test_close_after_fcntl_setlease_eagain(root: str) -> int:
+    # Related LTP cases: fcntl32, fcntl32_64
+    # close(2) must succeed across the full nine-case verify_fcntl loop on one file.
+    workdir = case_dir(root, "fcntl_setlease_close")
+    target = os.path.join(workdir, "file")
+    _create_empty_file(target, _FCNTL32_FILE_MODE)
+
+    def run_ltp_fcntl32_all_cases() -> None:
+        for fd1_flag, fd2_flag in _FCNTL32_FLAG_PAIRS:
+            _fcntl32_setlease_cycle(target, fd1_flag, fd2_flag)
+
+    return expect_ok(
+        "close during full fcntl32 verify_fcntl loop (fcntl32/32_64)",
+        run_ltp_fcntl32_all_cases,
+    )
+
+
+TESTS = [
+    (
+        "1",
+        "close after flock02 EBADF+EINVAL sequence (flock02)",
+        test_close_after_flock_invalid_operation,
+    ),
+    (
+        "2",
+        "close after flock04 tc0 + flock02/flock03 pre (flock04)",
+        test_close_after_flock_shared_parent_child,
+    ),
+    (
+        "3",
+        "close during full fcntl32 loop (fcntl32/32_64)",
+        test_close_after_fcntl_setlease_eagain,
+    ),
+]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="close(2) EIO reproducer for Curvine FUSE write-back on release",
+    )
+    parser.add_argument(
+        "--dir",
+        default=DEFAULT_DIR,
+        help="Base test directory (must be on the Curvine FUSE mount)",
+    )
+    parser.add_argument(
+        "--allow-non-mount",
+        action="store_true",
+        help="Skip FUSE mount check; for local debugging only (default: False)",
+    )
+    args = parser.parse_args()
+
+    if not sys.platform.startswith("linux"):
+        print("SKIP: Linux-only syscalls", file=sys.stderr)
+        return 0
+
+    if os.geteuid() != 0:
+        print("WARNING: not running as root", file=sys.stderr)
+
+    root = os.path.abspath(args.dir)
+    os.makedirs(root, exist_ok=True)
+
+    if args.allow_non_mount:
+        print(
+            "WARNING: --allow-non-mount set; results may not reflect Curvine FUSE behaviour",
+            file=sys.stderr,
+        )
+
+    print(f"Running close-EIO repro tests under {root}\n")
+
+    fail = 0
+    for num, title, test_fn in TESTS:
+        print(f"[case {num}] {title}:")
+        fail += test_fn(root)
+        print()
+
+    total = len(TESTS)
+    passed = total - fail
+    print(f"Summary: {passed}/{total} passed, {fail}/{total} failed")
+    return 1 if fail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/build/tests/scripts/curvine_ltp_creat_enoent_repro.py
+++ b/build/tests/scripts/curvine_ltp_creat_enoent_repro.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python3
+#  // Copyright 2025 OPPO.
+#  //
+#  // Licensed under the Apache License, Version 2.0 (the "License");
+#  // you may not use this file except in compliance with the License.
+#  // You may obtain a copy of the License at
+#  //
+#  //     http://www.apache.org/licenses/LICENSE-2.0
+#  //
+#  // Unless required by applicable law or agreed to in writing, software
+#  // distributed under the License is distributed on an "AS IS" BASIS,
+#  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  // See the License for the specific language governing permissions and
+#  // limitations under the License.
+
+"""
+Directory-entry visibility after O_CREAT on Curvine FUSE mounts.
+
+Root cause: Curvine FUSE sometimes accepts open(2) with O_CREAT (and may even
+allow writes through the returned fd) but the new directory entry is not
+visible to subsequent lookups.  A later open(2) on the same path then returns
+ENOENT even though the create appeared to succeed — dentry persistence or
+cache-coherency bug.
+
+Covered LTP cases (each line is one minimal repro scenario):
+  fcntl23, fcntl23_64, fcntl25, fcntl25_64, ftruncate03, sendfile03,
+      sendfile03_64, io_submit01, fallocate02, readlinkat01 — setup
+      open(path, O_RDONLY|O_CREAT, mode) with flag 64 must create a visible file
+  linkat01, symlinkat01 — setup open(olddir/oldfile, O_CREAT|O_EXCL, 0600) in a
+      subdirectory must succeed and leave a visible file
+  fcntl16, fcntl16_64 — block-2 open(path, O_RDWR|O_CREAT|O_TRUNC, 02600) must
+      create a visible mandatory-lock test file
+  pwritev202, pwritev202_64 — after file1 exists, setup open(file2,
+      O_RDONLY|O_CREAT, 0644) must create a second visible file
+  stream03 — after unlink, fopen/open with a+ (O_RDWR|O_APPEND|O_CREAT) must
+      recreate a visible file (block-1 TFAIL)
+  writev07 (partial) — tst_fill_file-created testfile must remain openable with
+      O_RDWR after a prior writev EFAULT iteration
+  fallocate02 (FNAMER path) — same O_RDONLY|O_CREAT setup as other flag-64 cases
+
+Usage:
+    python3 curvine_ltp_creat_enoent_repro.py --dir /curvine-fuse/fuse-test
+    python3 curvine_ltp_creat_enoent_repro.py --dir /curvine-fuse/fuse-test --allow-non-mount
+"""
+
+import argparse
+import ctypes
+import errno
+import os
+import platform
+import shutil
+import sys
+from typing import Callable, List, Tuple
+
+DEFAULT_DIR = "/curvine-fuse/fuse-test"
+
+AT_FDCWD = -100
+O_RDONLY = 0
+O_WRONLY = 1
+O_RDWR = 2
+O_CREAT = 0o100
+O_EXCL = 0o200
+O_TRUNC = 0o1000
+O_APPEND = 0o2000
+
+# LTP logs show decimal 64 / 192 / 578 for these flag combinations.
+LTP_O_RDONLY_O_CREAT = 64
+LTP_O_CREAT_O_EXCL = 192
+LTP_O_RDWR_O_CREAT_O_TRUNC = 578
+
+
+def _syscall_nr_openat() -> int:
+    table = {
+        "x86_64": 257,
+        "aarch64": 56,
+    }
+    machine = platform.machine()
+    if machine not in table:
+        raise OSError(
+            errno.ENOSYS,
+            f"unsupported architecture for openat: {machine}",
+        )
+    return table[machine]
+
+
+def sys_openat(path: str, flags: int, mode: int = 0) -> int:
+    """openat(AT_FDCWD, path, flags, mode) via raw syscall."""
+    libc = ctypes.CDLL(None, use_errno=True)
+    syscall = libc.syscall
+    syscall.argtypes = [
+        ctypes.c_long,
+        ctypes.c_long,
+        ctypes.c_long,
+        ctypes.c_long,
+        ctypes.c_long,
+        ctypes.c_long,
+    ]
+    syscall.restype = ctypes.c_long
+
+    path_buf = path.encode()
+    ret = int(
+        syscall(
+            _syscall_nr_openat(),
+            AT_FDCWD,
+            ctypes.c_char_p(path_buf),
+            flags,
+            mode,
+        )
+    )
+    if ret < 0:
+        err = ctypes.get_errno()
+        raise OSError(err, os.strerror(err))
+    return ret
+
+
+def case_dir(root: str, name: str) -> str:
+    path = os.path.join(root, name)
+    if os.path.exists(path):
+        shutil.rmtree(path)
+    os.makedirs(path)
+    return path
+
+
+def expect_ok(name: str, fn: Callable[[], None]) -> int:
+    try:
+        fn()
+        print(f"  PASS: {name}")
+        return 0
+    except OSError as exc:
+        print(
+            f"  FAIL: {name} — unexpected OSError errno={exc.errno} "
+            f"({errno.errorcode.get(exc.errno, '?')}): {exc}",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        print(f"  FAIL: {name} — unexpected error: {exc}", file=sys.stderr)
+        return 1
+
+
+def expect_errno(name: str, fn: Callable[[], None], expected: int) -> int:
+    try:
+        fn()
+        print(
+            f"  FAIL: {name} — expected errno {expected} "
+            f"({errno.errorcode.get(expected, '?')}), but syscall succeeded",
+            file=sys.stderr,
+        )
+        return 1
+    except OSError as exc:
+        if exc.errno == expected:
+            print(
+                f"  PASS: {name} (errno={expected} "
+                f"{errno.errorcode.get(expected, '?')})"
+            )
+            return 0
+        print(
+            f"  FAIL: {name} — expected errno {expected}, got {exc.errno}: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        print(f"  FAIL: {name} — expected OSError, got {exc}", file=sys.stderr)
+        return 1
+
+
+def skip(name: str, reason: str) -> int:
+    print(f"  SKIP: {name} — {reason}")
+    return 0
+
+
+def _reopen_rdonly(path: str) -> None:
+    fd = sys_openat(path, O_RDONLY)
+    os.close(fd)
+
+
+def _reopen_rdwr(path: str) -> None:
+    fd = sys_openat(path, O_RDWR)
+    os.close(fd)
+
+
+def test_open_ocreat_only_flag_creates_visible_dentry(root: str) -> int:
+    # Related LTP cases: fcntl23, fcntl23_64, fcntl25, fcntl25_64, ftruncate03,
+    #                    sendfile03, sendfile03_64, io_submit01, fallocate02,
+    #                    readlinkat01
+    # LTP setup uses open(path, O_RDONLY|O_CREAT, mode) — numeric flag 64 — to
+    # create the test file; a follow-up open must find the dentry.
+    workdir = case_dir(root, "ocreat_flag64")
+    target = os.path.join(workdir, "tfile")
+
+    def run() -> None:
+        fd = sys_openat(target, LTP_O_RDONLY_O_CREAT, 0o777)
+        os.close(fd)
+        _reopen_rdonly(target)
+
+    return expect_ok(
+        "open(path, O_RDONLY|O_CREAT=64, 0777) then reopen O_RDONLY",
+        run,
+    )
+
+
+def test_open_ocreat_excl_in_subdir_creates_visible_dentry(root: str) -> int:
+    # Related LTP cases: linkat01, symlinkat01
+    # LTP setup open(olddir/oldfile, O_CREAT|O_EXCL, 0600) must create the file
+    # inside a freshly created subdirectory.
+    workdir = case_dir(root, "ocreat_excl_subdir")
+    subdir = os.path.join(workdir, "olddir")
+    os.makedirs(subdir, mode=0o700)
+    target = os.path.join(subdir, "oldfile")
+
+    def run() -> None:
+        fd = sys_openat(target, LTP_O_CREAT_O_EXCL, 0o600)
+        os.close(fd)
+        _reopen_rdonly(target)
+
+    return expect_ok(
+        "open(subdir/file, O_CREAT|O_EXCL=192, 0600) then reopen",
+        run,
+    )
+
+
+def test_open_rdwr_creat_trunc_setgid_mode_creates_visible_dentry(root: str) -> int:
+    # Related LTP cases: fcntl16, fcntl16_64
+    # fcntl16 block-2 mandatory-lock setup: open(tmp, O_RDWR|O_CREAT|O_TRUNC, 02600).
+    workdir = case_dir(root, "fc16_block2_create")
+    target = os.path.join(workdir, "fcntl4")
+
+    def run() -> None:
+        fd = sys_openat(target, LTP_O_RDWR_O_CREAT_O_TRUNC, 0o2600)
+        os.write(fd, b"0123456789")
+        os.close(fd)
+        _reopen_rdwr(target)
+
+    return expect_ok(
+        "open(path, O_RDWR|O_CREAT|O_TRUNC=578, 02600) then reopen O_RDWR",
+        run,
+    )
+
+
+def test_ocreat_write_close_then_reopen_rdonly(root: str) -> int:
+    # Related LTP cases: fallocate02 (FNAMEW path), sendfile03 (out_file path)
+    # Generic pattern: O_CREAT|O_WRONLY create + write, close, then O_RDONLY open.
+    workdir = case_dir(root, "creat_write_reopen")
+    target = os.path.join(workdir, "payload")
+
+    def run() -> None:
+        fd = sys_openat(target, O_WRONLY | O_CREAT, 0o600)
+        os.write(fd, b"curvine-creat-enoent\n")
+        os.close(fd)
+        _reopen_rdonly(target)
+
+    return expect_ok(
+        "O_WRONLY|O_CREAT write+close then reopen O_RDONLY",
+        run,
+    )
+
+
+def test_second_file_ocreat_only_after_first_file_exists(root: str) -> int:
+    # Related LTP cases: pwritev202, pwritev202_64
+    # pwritev202 setup creates file1, then open(file2, O_RDONLY|O_CREAT, 0644).
+    workdir = case_dir(root, "pwritev202_setup")
+    file1 = os.path.join(workdir, "file1")
+    file2 = os.path.join(workdir, "file2")
+
+    def run() -> None:
+        fd1 = sys_openat(file1, O_RDWR | O_CREAT, 0o644)
+        os.ftruncate(fd1, os.sysconf("SC_PAGE_SIZE"))
+        os.close(fd1)
+
+        fd2 = sys_openat(file2, LTP_O_RDONLY_O_CREAT, 0o644)
+        os.close(fd2)
+        _reopen_rdonly(file2)
+
+    return expect_ok(
+        "after file1 exists, open(file2, O_RDONLY|O_CREAT=64, 0644) visible",
+        run,
+    )
+
+
+def test_unlink_then_open_append_recreates_visible_file(root: str) -> int:
+    # Related LTP cases: stream03
+    # stream03 block-0 passes with fopen a+, then unlink; block-1 fopen a+ must
+    # recreate the file (O_RDWR|O_APPEND|O_CREAT).
+    workdir = case_dir(root, "stream03_recreate")
+    target = os.path.join(workdir, "stream03")
+
+    def run() -> None:
+        fd = sys_openat(target, O_RDWR | O_APPEND | O_CREAT, 0o644)
+        os.write(fd, b"abcdefghijklmnopqrstuvwxyz")
+        os.close(fd)
+        os.unlink(target)
+
+        fd = sys_openat(target, O_RDWR | O_APPEND | O_CREAT, 0o644)
+        os.close(fd)
+        _reopen_rdonly(target)
+
+    return expect_ok(
+        "unlink then open O_RDWR|O_APPEND|O_CREAT (stream03 a+) recreates file",
+        run,
+    )
+
+
+def test_prefilled_file_still_openable_after_prior_io(root: str) -> int:
+    # Related LTP cases: writev07 (partial — second iteration at offset 65)
+    # tst_fill_file creates testfile; after first writev EFAULT iteration the
+    # file must still be openable with O_RDWR for the next iteration.
+    workdir = case_dir(root, "writev07_persist")
+    target = os.path.join(workdir, "testfile")
+    chunk = 64
+    bufsize = chunk * 4
+
+    def run() -> None:
+        fd = sys_openat(target, O_RDWR | O_CREAT | O_TRUNC, 0o644)
+        pattern = bytes(i % (chunk - 1) for i in range(bufsize))
+        os.write(fd, pattern)
+        os.lseek(fd, 0, os.SEEK_SET)
+        os.close(fd)
+
+        fd = sys_openat(target, O_RDWR, 0o644)
+        os.lseek(fd, 0, os.SEEK_SET)
+        os.close(fd)
+
+        fd = sys_openat(target, O_RDWR, 0o644)
+        os.lseek(fd, 65, os.SEEK_SET)
+        os.close(fd)
+
+    return expect_ok(
+        "tst_fill_file-like file still openable O_RDWR at offset 65 (writev07)",
+        run,
+    )
+
+
+TESTS: List[Tuple[str, str, Callable[..., int]]] = [
+    (
+        "1",
+        "open(path, O_RDONLY|O_CREAT=64) creates visible dentry",
+        test_open_ocreat_only_flag_creates_visible_dentry,
+    ),
+    (
+        "2",
+        "open(subdir/file, O_CREAT|O_EXCL=192) creates visible dentry",
+        test_open_ocreat_excl_in_subdir_creates_visible_dentry,
+    ),
+    (
+        "3",
+        "open(path, O_RDWR|O_CREAT|O_TRUNC=578, 02600) creates visible dentry",
+        test_open_rdwr_creat_trunc_setgid_mode_creates_visible_dentry,
+    ),
+    (
+        "4",
+        "O_WRONLY|O_CREAT write+close then reopen O_RDONLY",
+        test_ocreat_write_close_then_reopen_rdonly,
+    ),
+    (
+        "5",
+        "second file O_RDONLY|O_CREAT=64 after file1 exists (pwritev202 setup)",
+        test_second_file_ocreat_only_after_first_file_exists,
+    ),
+    (
+        "6",
+        "unlink then O_RDWR|O_APPEND|O_CREAT recreates file (stream03)",
+        test_unlink_then_open_append_recreates_visible_file,
+    ),
+    (
+        "7",
+        "prefilled file still openable after prior I/O (writev07)",
+        test_prefilled_file_still_openable_after_prior_io,
+    ),
+]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="O_CREAT dentry visibility / ENOENT reproducer for Curvine FUSE",
+    )
+    parser.add_argument(
+        "--dir",
+        default=DEFAULT_DIR,
+        help="Base test directory (must be on the Curvine FUSE mount)",
+    )
+    parser.add_argument(
+        "--allow-non-mount",
+        action="store_true",
+        help="Skip FUSE mount check; for local debugging only (default: False)",
+    )
+    args = parser.parse_args()
+
+    if not sys.platform.startswith("linux"):
+        print("SKIP: Linux-only syscalls", file=sys.stderr)
+        return 0
+
+    if os.geteuid() != 0:
+        print("WARNING: not running as root", file=sys.stderr)
+
+    root = os.path.abspath(args.dir)
+    os.makedirs(root, exist_ok=True)
+
+    if args.allow_non_mount:
+        print(
+            "WARNING: --allow-non-mount set; results may not reflect Curvine FUSE behaviour",
+            file=sys.stderr,
+        )
+
+    print(f"Running O_CREAT dentry visibility tests under {root}\n")
+
+    fail = 0
+    for num, title, test_fn in TESTS:
+        print(f"[case {num}] {title}:")
+        fail += test_fn(root)
+        print()
+
+    total = len(TESTS)
+    passed = total - fail
+    print(f"Summary: {passed}/{total} passed, {fail}/{total} failed")
+    return 1 if fail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/build/tests/scripts/curvine_ltp_eio_repro.py
+++ b/build/tests/scripts/curvine_ltp_eio_repro.py
@@ -1,0 +1,458 @@
+#!/usr/bin/env python3
+#  // Copyright 2025 OPPO.
+#  //
+#  // Licensed under the Apache License, Version 2.0 (the "License");
+#  // you may not use this file except in compliance with the License.
+#  // You may obtain a copy of the License at
+#  //
+#  //     http://www.apache.org/licenses/LICENSE-2.0
+#  //
+#  // Unless required by applicable law or agreed to in writing, software
+#  // distributed under the License is distributed on an "AS IS" BASIS,
+#  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  // See the License for the specific language governing permissions and
+#  // limitations under the License.
+
+"""
+IO operations returning EIO on Curvine FUSE — reproducer for LTP failures.
+
+Root cause: Curvine FUSE mishandles several POSIX I/O paths and surfaces EIO
+(errno 5) where the kernel would normally succeed — fallocate past EOF or on
+sparse regions, truncate on an open file, sparse-file read/readv, and hard-link
+creation when the source path is a symbolic link.
+
+Covered LTP cases (each line is one minimal repro scenario):
+  fallocate01 — fallocate(fd, 0, 12*blksize, blksize) at EOF after 12 blocks written
+  fallocate03 — fallocate on sparse file at offset 2*blksize (hole between two ranges)
+  truncate02, truncate02_64 — truncate(testfile, 256) while fd stays open on 1024-byte file
+  ftest01, ftest05 — child read(2) at unwritten sparse chunk must return zeros, not EIO
+  ftest03, ftest07 — child readv(2) at unwritten sparse chunk must return zeros, not EIO
+  link01 — link(symbolic, nick) after symlink(object,symbolic) and creat(object) must succeed
+
+Usage:
+    python3 curvine_ltp_eio_repro.py --dir /curvine-fuse/fuse-test
+    python3 curvine_ltp_eio_repro.py --dir /curvine-fuse/fuse-test --allow-non-mount
+"""
+
+import argparse
+import ctypes
+import errno
+import multiprocessing
+import os
+import platform
+import shutil
+import sys
+from typing import Callable, Dict, List, Optional, Tuple
+
+DEFAULT_DIR = "/curvine-fuse/fuse-test"
+
+O_RDWR = 2
+O_CREAT = 0o100
+O_TRUNC = 0o1000
+
+BLOCKS_WRITTEN = 12
+HOLE_SIZE_IN_BLOCKS = 12
+FTEST_CHUNK = 2048
+FTEST_READ_OFFSET = 0xEB800
+
+AT_FDCWD = -100
+
+_libc: Optional[ctypes.CDLL] = None
+_libc_fallocate_fn: Optional[Callable[..., int]] = None
+
+
+def _init_libc() -> ctypes.CDLL:
+    global _libc, _libc_fallocate_fn
+    if _libc is not None:
+        return _libc
+
+    _libc = ctypes.CDLL(None, use_errno=True)
+    fn = getattr(_libc, "fallocate", None)
+    if fn is not None:
+        fn.restype = ctypes.c_int
+        fn.argtypes = [
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_longlong,
+            ctypes.c_longlong,
+        ]
+
+        def _fallocate(fd: int, mode: int, offset: int, length: int) -> int:
+            return int(
+                fn(
+                    fd,
+                    mode,
+                    ctypes.c_longlong(offset),
+                    ctypes.c_longlong(length),
+                )
+            )
+
+        _libc_fallocate_fn = _fallocate
+    return _libc
+
+
+def _raw_syscall(nr: int, *args: int) -> int:
+    libc = _init_libc()
+    syscall = libc.syscall
+    syscall.restype = ctypes.c_long
+    return int(syscall(nr, *args))
+
+
+def _syscall_nr(name: str) -> int:
+    table: Dict[str, Dict[str, int]] = {
+        "fallocate": {"x86_64": 285, "aarch64": 47},
+        "linkat": {"x86_64": 265, "aarch64": 37},
+    }
+    machine = platform.machine()
+    if machine not in table[name]:
+        raise OSError(
+            errno.ENOSYS,
+            f"unsupported architecture for {name}: {machine}",
+        )
+    return table[name][machine]
+
+
+def sys_fallocate(fd: int, mode: int, offset: int, length: int) -> None:
+    """fallocate(fd, mode, offset, length) via libc or raw syscall."""
+    _init_libc()
+    if _libc_fallocate_fn is not None:
+        ret = _libc_fallocate_fn(fd, mode, offset, length)
+    else:
+        ret = _raw_syscall(
+            _syscall_nr("fallocate"),
+            fd,
+            mode,
+            ctypes.c_longlong(offset).value,
+            ctypes.c_longlong(length).value,
+        )
+    if ret < 0:
+        err = ctypes.get_errno()
+        raise OSError(err, os.strerror(err))
+
+
+def sys_linkat(oldpath: str, newpath: str) -> None:
+    """linkat(AT_FDCWD, oldpath, AT_FDCWD, newpath, 0) via raw syscall."""
+    old = ctypes.c_char_p(oldpath.encode())
+    new = ctypes.c_char_p(newpath.encode())
+    ret = _raw_syscall(
+        _syscall_nr("linkat"),
+        AT_FDCWD,
+        ctypes.cast(old, ctypes.c_void_p).value or 0,
+        AT_FDCWD,
+        ctypes.cast(new, ctypes.c_void_p).value or 0,
+        0,
+    )
+    if ret < 0:
+        err = ctypes.get_errno()
+        raise OSError(err, os.strerror(err))
+
+
+def case_dir(root: str, name: str) -> str:
+    path = os.path.join(root, name)
+    if os.path.exists(path):
+        shutil.rmtree(path)
+    os.makedirs(path)
+    return path
+
+
+def expect_ok(name: str, fn: Callable[[], None]) -> int:
+    try:
+        fn()
+        print(f"  PASS: {name}")
+        return 0
+    except OSError as exc:
+        print(
+            f"  FAIL: {name} — unexpected OSError errno={exc.errno} "
+            f"({errno.errorcode.get(exc.errno, '?')}): {exc}",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        print(f"  FAIL: {name} — unexpected error: {exc}", file=sys.stderr)
+        return 1
+
+
+def expect_errno(name: str, fn: Callable[[], None], expected: int) -> int:
+    try:
+        fn()
+        print(
+            f"  FAIL: {name} — expected errno {expected} "
+            f"({errno.errorcode.get(expected, '?')}), but syscall succeeded",
+            file=sys.stderr,
+        )
+        return 1
+    except OSError as exc:
+        if exc.errno == expected:
+            print(
+                f"  PASS: {name} (errno={expected} "
+                f"{errno.errorcode.get(expected, '?')})"
+            )
+            return 0
+        print(
+            f"  FAIL: {name} — expected errno {expected}, got {exc.errno}: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        print(f"  FAIL: {name} — expected OSError, got {exc}", file=sys.stderr)
+        return 1
+
+
+def skip(name: str, reason: str) -> int:
+    print(f"  SKIP: {name} — {reason}")
+    return 0
+
+
+def safe_close(fd: int) -> None:
+    try:
+        os.close(fd)
+    except OSError:
+        pass
+
+
+def _write_blocks(fd: int, block_size: int, count: int) -> None:
+    buf = bytes((ord("A") + (i % 26)) for i in range(block_size))
+    for _ in range(count):
+        os.write(fd, buf)
+
+
+def _sparse_child_read(path: str, offset: int, chunk: int, use_readv: bool) -> None:
+    fd = os.open(path, O_RDWR | O_CREAT | O_TRUNC, 0o666)
+    try:
+        os.lseek(fd, offset, os.SEEK_SET)
+        if use_readv:
+            half = chunk // 2
+            bufs = [bytearray(half), bytearray(chunk - half)]
+            got = os.readv(fd, bufs)
+        else:
+            got = os.read(fd, chunk)
+        if got != chunk:
+            raise OSError(
+                errno.EIO,
+                f"short read at 0x{offset:x}: got {got}, expected {chunk}",
+            )
+    finally:
+        safe_close(fd)
+
+
+def _run_sparse_io_child(
+    path: str, offset: int, chunk: int, use_readv: bool
+) -> None:
+    proc = multiprocessing.Process(
+        target=_sparse_child_read,
+        args=(path, offset, chunk, use_readv),
+    )
+    proc.start()
+    proc.join()
+    if proc.exitcode != 0:
+        op = "readv" if use_readv else "read"
+        raise OSError(
+            errno.EIO,
+            f"child {op} at 0x{offset:x} failed (exit {proc.exitcode})",
+        )
+
+
+def test_fallocate_at_eof_after_blocks_written(root: str) -> int:
+    # Related LTP cases: fallocate01
+    # fallocate(2) at EOF after writing 12 full blocks must extend the file.
+    workdir = case_dir(root, "fallocate_eof")
+    target = os.path.join(workdir, "tfile_mode1")
+
+    def run() -> None:
+        fd = os.open(target, O_RDWR | O_CREAT, 0o700)
+        try:
+            block_size = os.fstat(fd).st_blksize
+            _write_blocks(fd, block_size, BLOCKS_WRITTEN)
+            offset = BLOCKS_WRITTEN * block_size
+            sys_fallocate(fd, 0, offset, block_size)
+        finally:
+            safe_close(fd)
+
+    return expect_ok(
+        f"fallocate(fd, 0, EOF, blksize) after 12 blocks (fallocate01)",
+        run,
+    )
+
+
+def test_fallocate_on_sparse_file_hole(root: str) -> int:
+    # Related LTP cases: fallocate03
+    # fallocate(2) on a sparse file (hole between two written ranges) must succeed.
+    workdir = case_dir(root, "fallocate_sparse")
+    target = os.path.join(workdir, "tfile_sparse")
+
+    def run() -> None:
+        fd = os.open(target, O_RDWR | O_CREAT, 0o700)
+        try:
+            block_size = os.fstat(fd).st_blksize
+            _write_blocks(fd, block_size, BLOCKS_WRITTEN)
+            os.lseek(
+                fd,
+                block_size * (BLOCKS_WRITTEN + HOLE_SIZE_IN_BLOCKS),
+                os.SEEK_SET,
+            )
+            _write_blocks(fd, block_size, BLOCKS_WRITTEN)
+            offset = 2 * block_size
+            sys_fallocate(fd, 0, offset, block_size)
+        finally:
+            safe_close(fd)
+
+    return expect_ok(
+        f"fallocate(fd, 0, 2*blksize, blksize) on sparse file (fallocate03)",
+        run,
+    )
+
+
+def test_truncate_open_file_to_shorter_length(root: str) -> int:
+    # Related LTP cases: truncate02, truncate02_64
+    # truncate(2) on a 1024-byte file to 256 bytes must succeed while fd is open.
+    workdir = case_dir(root, "truncate_open_fd")
+    target = os.path.join(workdir, "testfile")
+
+    def run() -> None:
+        fd = os.open(target, O_RDWR | O_CREAT, 0o644)
+        try:
+            os.write(fd, b"a" * 1024)
+            os.lseek(fd, 0, os.SEEK_SET)
+            os.truncate(target, 256)
+            if os.fstat(fd).st_size != 256:
+                raise OSError(errno.EIO, "st_size != 256 after truncate")
+        finally:
+            safe_close(fd)
+
+    return expect_ok("truncate(testfile, 256) with open fd (truncate02)", run)
+
+
+def test_read_unwritten_sparse_chunk(root: str) -> int:
+    # Related LTP cases: ftest01, ftest05
+    # read(2) at an unwritten chunk in a sparse file must return zeros, not EIO.
+    workdir = case_dir(root, "sparse_read")
+    target = os.path.join(workdir, "ftest_child")
+
+    def run() -> None:
+        _run_sparse_io_child(target, FTEST_READ_OFFSET, FTEST_CHUNK, use_readv=False)
+
+    return expect_ok(
+        f"child read({FTEST_CHUNK}) at 0x{FTEST_READ_OFFSET:x} on sparse file (ftest01)",
+        run,
+    )
+
+
+def test_readv_unwritten_sparse_chunk(root: str) -> int:
+    # Related LTP cases: ftest03, ftest07
+    # readv(2) at an unwritten chunk in a sparse file must return zeros, not EIO.
+    workdir = case_dir(root, "sparse_readv")
+    target = os.path.join(workdir, "ftest_child")
+
+    def run() -> None:
+        _run_sparse_io_child(target, FTEST_READ_OFFSET, FTEST_CHUNK, use_readv=True)
+
+    return expect_ok(
+        f"child readv at 0x{FTEST_READ_OFFSET:x} on sparse file (ftest03)",
+        run,
+    )
+
+
+def test_hard_link_through_symlink_path(root: str) -> int:
+    # Related LTP cases: link01
+    # link(2) with source path resolving through a symlink must create a hard link.
+    workdir = case_dir(root, "link_via_symlink")
+    object_path = os.path.join(workdir, "object")
+    symbolic_path = os.path.join(workdir, "symbolic")
+    nick_path = os.path.join(workdir, "nick")
+
+    def run() -> None:
+        os.symlink("object", symbolic_path)
+        fd = os.open(object_path, os.O_CREAT | os.O_WRONLY, 0o700)
+        os.close(fd)
+        sys_linkat(symbolic_path, nick_path)
+        if not os.path.exists(nick_path):
+            raise OSError(errno.EIO, "hard link nick was not created")
+
+    return expect_ok(
+        'link(symbolic, "nick") after symlink+creat (link01)',
+        run,
+    )
+
+
+TESTS: List[Tuple[str, str, Callable[..., int]]] = [
+    (
+        "1",
+        "fallocate at EOF after 12 blocks (fallocate01)",
+        test_fallocate_at_eof_after_blocks_written,
+    ),
+    (
+        "2",
+        "fallocate on sparse file at 2*blksize (fallocate03)",
+        test_fallocate_on_sparse_file_hole,
+    ),
+    (
+        "3",
+        "truncate(testfile, 256) with open fd (truncate02/02_64)",
+        test_truncate_open_file_to_shorter_length,
+    ),
+    (
+        "4",
+        "child read at unwritten sparse chunk (ftest01/05)",
+        test_read_unwritten_sparse_chunk,
+    ),
+    (
+        "5",
+        "child readv at unwritten sparse chunk (ftest03/07)",
+        test_readv_unwritten_sparse_chunk,
+    ),
+    (
+        "6",
+        'hard link via symlink path link(symbolic, "nick") (link01)',
+        test_hard_link_through_symlink_path,
+    ),
+]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="EIO reproducer for Curvine FUSE I/O paths",
+    )
+    parser.add_argument(
+        "--dir",
+        default=DEFAULT_DIR,
+        help="Base test directory (must be on the Curvine FUSE mount)",
+    )
+    parser.add_argument(
+        "--allow-non-mount",
+        action="store_true",
+        help="Skip FUSE mount check; for local debugging only (default: False)",
+    )
+    args = parser.parse_args()
+
+    if not sys.platform.startswith("linux"):
+        print("SKIP: Linux-only syscalls", file=sys.stderr)
+        return 0
+
+    if os.geteuid() != 0:
+        print("WARNING: not running as root", file=sys.stderr)
+
+    root = os.path.abspath(args.dir)
+    os.makedirs(root, exist_ok=True)
+
+    if args.allow_non_mount:
+        print(
+            "WARNING: --allow-non-mount set; results may not reflect Curvine FUSE behaviour",
+            file=sys.stderr,
+        )
+
+    print(f"Running EIO repro tests under {root}\n")
+
+    fail = 0
+    for num, title, test_fn in TESTS:
+        print(f"[case {num}] {title}:")
+        fail += test_fn(root)
+        print()
+
+    total = len(TESTS)
+    passed = total - fail
+    print(f"Summary: {passed}/{total} passed, {fail}/{total} failed")
+    return 1 if fail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/build/tests/scripts/curvine_ltp_enametoolong_repro.py
+++ b/build/tests/scripts/curvine_ltp_enametoolong_repro.py
@@ -1,0 +1,511 @@
+#!/usr/bin/env python3
+#  // Copyright 2025 OPPO.
+#  //
+#  // Licensed under the Apache License, Version 2.0 (the "License");
+#  // you may not use this file except in compliance with the License.
+#  // You may obtain a copy of the License at
+#  //
+#  //     http://www.apache.org/licenses/LICENSE-2.0
+#  //
+#  // Unless required by applicable law or agreed to in writing, software
+#  // distributed under the License is distributed on an "AS IS" BASIS,
+#  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  // See the License for the specific language governing permissions and
+#  // limitations under the License.
+
+"""
+ENAMETOOLONG lookup bug on Curvine FUSE mounts.
+
+Root cause: when a pathname contains a component longer than NAME_MAX (or the
+full path exceeds PATH_MAX), Curvine FUSE lookup returns ENOENT instead of the
+POSIX-required ENAMETOOLONG.  The failure is in the shared lookup path and
+surfaces through many different syscalls.
+
+Covered LTP cases (each line is one minimal repro scenario):
+  chroot03 — chroot(272-byte component on FUSE) must fail ENAMETOOLONG (not ENOENT)
+  chdir04 — chdir(272-byte component) must fail ENAMETOOLONG
+  execve03 — execve(272-byte filename) must fail ENAMETOOLONG
+  open08 (case 4) — open(272-byte name, O_RDWR) must fail ENAMETOOLONG
+  statx03 (case 7) — statx(AT_FDCWD, 256-byte name) must fail ENAMETOOLONG
+  nftw01 (block 25) — nftw(path with NAME_MAX+1 byte final component) ENAMETOOLONG
+  nftw6401 (block 25) — nftw64(same long-component path) ENAMETOOLONG
+
+Usage:
+    python3 curvine_ltp_enametoolong_repro.py --dir /curvine-fuse/fuse-test
+    python3 curvine_ltp_enametoolong_repro.py --dir /curvine-fuse/fuse-test --allow-non-mount
+"""
+
+import argparse
+import ctypes
+import errno
+import multiprocessing
+import os
+import shutil
+import sys
+from typing import Callable, Optional
+
+DEFAULT_DIR = "/curvine-fuse/fuse-test"
+
+AT_FDCWD = -100
+O_RDWR = 2
+
+# 272-byte single component from chdir04 / execve03 / open08 LTP sources.
+LTP_LONG_COMPONENT = (
+    "abcdefghijklmnopqrstmnopqrstuvwxyz"
+    "abcdefghijklmnopqrstmnopqrstuvwxyz"
+    "abcdefghijklmnopqrstmnopqrstuvwxyz"
+    "abcdefghijklmnopqrstmnopqrstuvwxyz"
+    "abcdefghijklmnopqrstmnopqrstuvwxyz"
+    "abcdefghijklmnopqrstmnopqrstuvwxyz"
+    "abcdefghijklmnopqrstmnopqrstuvwxyz"
+    "abcdefghijklmnopqrstmnopqrstuvwxyz"
+)
+assert len(LTP_LONG_COMPONENT) == 272
+
+_libc: Optional[ctypes.CDLL] = None
+_nftw_callback_type: Optional[type] = None
+
+
+class StatxTimestamp(ctypes.Structure):
+    _fields_ = [
+        ("tv_sec", ctypes.c_int64),
+        ("tv_nsec", ctypes.c_uint32),
+        ("__reserved", ctypes.c_int32),
+    ]
+
+
+class Statx(ctypes.Structure):
+    _fields_ = [
+        ("stx_mask", ctypes.c_uint32),
+        ("stx_blksize", ctypes.c_uint32),
+        ("stx_attributes", ctypes.c_uint64),
+        ("stx_nlink", ctypes.c_uint32),
+        ("stx_uid", ctypes.c_uint32),
+        ("stx_gid", ctypes.c_uint32),
+        ("stx_mode", ctypes.c_uint16),
+        ("__spare0", ctypes.c_uint16 * 1),
+        ("stx_ino", ctypes.c_uint64),
+        ("stx_size", ctypes.c_uint64),
+        ("stx_blocks", ctypes.c_uint64),
+        ("stx_attributes_mask", ctypes.c_uint64),
+        ("stx_atime", StatxTimestamp),
+        ("stx_btime", StatxTimestamp),
+        ("stx_ctime", StatxTimestamp),
+        ("stx_mtime", StatxTimestamp),
+        ("stx_rdev_major", ctypes.c_uint32),
+        ("stx_rdev_minor", ctypes.c_uint32),
+        ("stx_dev_major", ctypes.c_uint32),
+        ("stx_dev_minor", ctypes.c_uint32),
+        ("stx_mnt_id", ctypes.c_uint64),
+        ("__spare2", ctypes.c_uint64 * 1),
+        ("__spare3", ctypes.c_uint64 * 12),
+    ]
+
+
+def _init_libc() -> ctypes.CDLL:
+    global _libc, _nftw_callback_type
+    if _libc is None:
+        _libc = ctypes.CDLL(None, use_errno=True)
+        _nftw_callback_type = ctypes.CFUNCTYPE(
+            ctypes.c_int,
+            ctypes.c_char_p,
+            ctypes.c_void_p,
+            ctypes.c_int,
+            ctypes.c_void_p,
+        )
+        _libc.openat.argtypes = [
+            ctypes.c_int,
+            ctypes.c_char_p,
+            ctypes.c_int,
+            ctypes.c_uint,
+        ]
+        _libc.openat.restype = ctypes.c_int
+        _libc.statx.argtypes = [
+            ctypes.c_int,
+            ctypes.c_char_p,
+            ctypes.c_int,
+            ctypes.c_uint,
+            ctypes.POINTER(Statx),
+        ]
+        _libc.statx.restype = ctypes.c_int
+    return _libc
+
+
+def sys_openat(path: str, flags: int, mode: int = 0) -> int:
+    libc = _init_libc()
+    ret = libc.openat(AT_FDCWD, path.encode(), flags, mode)
+    if ret < 0:
+        err = ctypes.get_errno()
+        raise OSError(err, os.strerror(err))
+    return ret
+
+
+def sys_chroot(path: str) -> None:
+    libc = _init_libc()
+    ret = libc.chroot(path.encode())
+    if ret < 0:
+        err = ctypes.get_errno()
+        raise OSError(err, os.strerror(err))
+
+
+def sys_chdir(path: str) -> None:
+    libc = _init_libc()
+    ret = libc.chdir(path.encode())
+    if ret < 0:
+        err = ctypes.get_errno()
+        raise OSError(err, os.strerror(err))
+
+
+def sys_statx(
+    dfd: int,
+    path: str,
+    flags: int,
+    mask: int,
+    buf: Statx,
+) -> None:
+    libc = _init_libc()
+    ret = libc.statx(dfd, path.encode(), flags, mask, ctypes.byref(buf))
+    if ret < 0:
+        err = ctypes.get_errno()
+        raise OSError(err, os.strerror(err))
+
+
+def sys_nftw(path: str, *, use64: bool = False) -> None:
+    libc = _init_libc()
+    assert _nftw_callback_type is not None
+
+    @_nftw_callback_type
+    def callback(
+        fpath: bytes,
+        statbuf: ctypes.c_void_p,
+        flag: int,
+        ftw: ctypes.c_void_p,
+    ) -> int:
+        return 0
+
+    fn = libc.nftw64 if use64 else libc.nftw
+    fn.argtypes = [
+        ctypes.c_char_p,
+        _nftw_callback_type,
+        ctypes.c_int,
+        ctypes.c_int,
+    ]
+    fn.restype = ctypes.c_int
+
+    ret = fn(path.encode(), callback, 20, 0)
+    if ret == 0:
+        raise OSError(errno.EINVAL, "nftw succeeded unexpectedly")
+    err = ctypes.get_errno()
+    raise OSError(err, os.strerror(err))
+
+
+def path_with_long_final_component(base: str) -> str:
+    """LTP nftw test_long_file_name: tmp_path + '/' + (NAME_MAX+1) 'E's."""
+    name_max = os.pathconf(base, "PC_NAME_MAX")
+    return os.path.join(base, "E" * (name_max + 1))
+
+
+def _execve_child_target(path: str) -> None:
+    libc = _init_libc()
+    path_b = path.encode()
+    argv = (ctypes.c_char_p * 2)(path_b, None)
+    ret = libc.execve(path_b, argv, None)
+    os._exit(ctypes.get_errno() if ret < 0 else errno.EINVAL)
+
+
+def case_dir(root: str, name: str) -> str:
+    path = os.path.join(root, name)
+    if os.path.exists(path):
+        shutil.rmtree(path)
+    os.makedirs(path)
+    return path
+
+
+def expect_ok(name: str, fn: Callable[[], None]) -> int:
+    try:
+        fn()
+        print(f"  PASS: {name}")
+        return 0
+    except OSError as exc:
+        print(
+            f"  FAIL: {name} — unexpected OSError errno={exc.errno} "
+            f"({errno.errorcode.get(exc.errno, '?')}): {exc}",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        print(f"  FAIL: {name} — unexpected error: {exc}", file=sys.stderr)
+        return 1
+
+
+def expect_errno(name: str, fn: Callable[[], None], expected: int) -> int:
+    try:
+        fn()
+        print(
+            f"  FAIL: {name} — expected errno {expected} "
+            f"({errno.errorcode.get(expected, '?')}), but syscall succeeded",
+            file=sys.stderr,
+        )
+        return 1
+    except OSError as exc:
+        if exc.errno == expected:
+            print(
+                f"  PASS: {name} (errno={expected} "
+                f"{errno.errorcode.get(expected, '?')})"
+            )
+            return 0
+        print(
+            f"  FAIL: {name} — expected errno {expected}, got {exc.errno}: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        print(f"  FAIL: {name} — expected OSError, got {exc}", file=sys.stderr)
+        return 1
+
+
+def skip(name: str, reason: str) -> int:
+    print(f"  SKIP: {name} — {reason}")
+    return 0
+
+
+def test_chroot_long_component(root: str) -> int:
+    # Related LTP cases: chroot03
+    # chroot(2) on FUSE must fail ENAMETOOLONG when a path component exceeds
+    # NAME_MAX; PATH_MAX+1 is rejected by the kernel before lookup (not this bug).
+    if os.geteuid() != 0:
+        return skip("chroot long component", "requires root")
+
+    workdir = case_dir(root, "chroot_long")
+    saved = os.getcwd()
+    os.chdir(workdir)
+
+    def run() -> None:
+        sys_chroot(LTP_LONG_COMPONENT)
+
+    try:
+        return expect_errno(
+            f"chroot({len(LTP_LONG_COMPONENT)}-byte component on FUSE)",
+            run,
+            errno.ENAMETOOLONG,
+        )
+    finally:
+        os.chdir(saved)
+
+
+def test_chdir_long_component(root: str) -> int:
+    # Related LTP cases: chdir04
+    # chdir(2) must fail with ENAMETOOLONG when a path component exceeds NAME_MAX.
+    workdir = case_dir(root, "chdir_long")
+    saved = os.getcwd()
+    os.chdir(workdir)
+
+    def run() -> None:
+        sys_chdir(LTP_LONG_COMPONENT)
+
+    try:
+        return expect_errno(
+            f"chdir({len(LTP_LONG_COMPONENT)}-byte component)",
+            run,
+            errno.ENAMETOOLONG,
+        )
+    finally:
+        os.chdir(saved)
+
+
+def test_execve_long_component(root: str) -> int:
+    # Related LTP cases: execve03
+    # execve(2) must fail with ENAMETOOLONG when the filename exceeds NAME_MAX.
+    if os.geteuid() != 0:
+        return skip("execve long component", "requires root")
+
+    workdir = case_dir(root, "execve_long")
+    saved = os.getcwd()
+    os.chdir(workdir)
+
+    def run() -> None:
+        proc = multiprocessing.Process(
+            target=_execve_child_target,
+            args=(LTP_LONG_COMPONENT,),
+        )
+        proc.start()
+        proc.join()
+        code = proc.exitcode
+        if code != errno.ENAMETOOLONG:
+            raise OSError(
+                code if code and code > 0 else errno.EINVAL,
+                f"child exit {code}, expected ENAMETOOLONG",
+            )
+
+    try:
+        return expect_errno(
+            f"execve({len(LTP_LONG_COMPONENT)}-byte filename)",
+            run,
+            errno.ENAMETOOLONG,
+        )
+    finally:
+        os.chdir(saved)
+
+
+def test_open_long_component(root: str) -> int:
+    # Related LTP cases: open08 (case 4)
+    # open(2) must fail with ENAMETOOLONG when the pathname component exceeds NAME_MAX.
+    workdir = case_dir(root, "open_long")
+    saved = os.getcwd()
+    os.chdir(workdir)
+
+    def run() -> None:
+        fd = sys_openat(LTP_LONG_COMPONENT, O_RDWR)
+        os.close(fd)
+
+    try:
+        return expect_errno(
+            f"open({len(LTP_LONG_COMPONENT)}-byte name, O_RDWR)",
+            run,
+            errno.ENAMETOOLONG,
+        )
+    finally:
+        os.chdir(saved)
+
+
+def test_statx_long_component(root: str) -> int:
+    # Related LTP cases: statx03 (case 7)
+    # statx(2) must fail with ENAMETOOLONG when the pathname component exceeds NAME_MAX.
+    workdir = case_dir(root, "statx_long")
+    long_name = "@" * 256
+    saved = os.getcwd()
+    os.chdir(workdir)
+
+    def run() -> None:
+        buf = Statx()
+        sys_statx(AT_FDCWD, long_name, 0, 0, buf)
+
+    try:
+        return expect_errno(
+            f"statx(AT_FDCWD, {len(long_name)}-byte name)",
+            run,
+            errno.ENAMETOOLONG,
+        )
+    finally:
+        os.chdir(saved)
+
+
+def test_nftw_long_final_component(root: str) -> int:
+    # Related LTP cases: nftw01 (block 25)
+    # nftw(3) must return -1 with ENAMETOOLONG when a path component exceeds NAME_MAX.
+    workdir = case_dir(root, "nftw_long")
+    long_path = path_with_long_final_component(workdir)
+
+    def run() -> None:
+        sys_nftw(long_path, use64=False)
+
+    return expect_errno(
+        f"nftw(path with NAME_MAX+1 final component)",
+        run,
+        errno.ENAMETOOLONG,
+    )
+
+
+def test_nftw64_long_final_component(root: str) -> int:
+    # Related LTP cases: nftw6401 (block 25)
+    # nftw64(3) must return -1 with ENAMETOOLONG when a path component exceeds NAME_MAX.
+    workdir = case_dir(root, "nftw64_long")
+    long_path = path_with_long_final_component(workdir)
+
+    def run() -> None:
+        sys_nftw(long_path, use64=True)
+
+    return expect_errno(
+        f"nftw64(path with NAME_MAX+1 final component)",
+        run,
+        errno.ENAMETOOLONG,
+    )
+
+
+TESTS: list = [
+    (
+        "1",
+        "chroot(272-byte component on FUSE) returns ENAMETOOLONG",
+        test_chroot_long_component,
+    ),
+    (
+        "2",
+        "chdir(272-byte component) returns ENAMETOOLONG",
+        test_chdir_long_component,
+    ),
+    (
+        "3",
+        "execve(272-byte filename) returns ENAMETOOLONG",
+        test_execve_long_component,
+    ),
+    (
+        "4",
+        "open(272-byte name, O_RDWR) returns ENAMETOOLONG",
+        test_open_long_component,
+    ),
+    (
+        "5",
+        "statx(AT_FDCWD, 256-byte name) returns ENAMETOOLONG",
+        test_statx_long_component,
+    ),
+    (
+        "6",
+        "nftw(NAME_MAX+1 final component) returns ENAMETOOLONG",
+        test_nftw_long_final_component,
+    ),
+    (
+        "7",
+        "nftw64(NAME_MAX+1 final component) returns ENAMETOOLONG",
+        test_nftw64_long_final_component,
+    ),
+]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="ENAMETOOLONG vs ENOENT lookup reproducer for Curvine FUSE",
+    )
+    parser.add_argument(
+        "--dir",
+        default=DEFAULT_DIR,
+        help="Base test directory (must be on the Curvine FUSE mount)",
+    )
+    parser.add_argument(
+        "--allow-non-mount",
+        action="store_true",
+        help="Skip FUSE mount check; for local debugging only (default: False)",
+    )
+    args = parser.parse_args()
+
+    if not sys.platform.startswith("linux"):
+        print("SKIP: Linux-only syscalls", file=sys.stderr)
+        return 0
+
+    if os.geteuid() != 0:
+        print("WARNING: chroot/execve cases require root", file=sys.stderr)
+
+    root = os.path.abspath(args.dir)
+    os.makedirs(root, exist_ok=True)
+
+    if args.allow_non_mount:
+        print(
+            "WARNING: --allow-non-mount set; results may not reflect Curvine FUSE behaviour",
+            file=sys.stderr,
+        )
+
+    print(f"Running ENAMETOOLONG lookup tests under {root}\n")
+
+    fail = 0
+    for num, title, test_fn in TESTS:
+        print(f"[case {num}] {title}:")
+        fail += test_fn(root)
+        print()
+
+    total = len(TESTS)
+    passed = total - fail
+    print(f"Summary: {passed}/{total} passed, {fail}/{total} failed")
+    return 1 if fail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/build/tests/scripts/curvine_ltp_fcntl_lock_repro.py
+++ b/build/tests/scripts/curvine_ltp_fcntl_lock_repro.py
@@ -1,0 +1,583 @@
+#!/usr/bin/env python3
+#  // Copyright 2025 OPPO.
+#  //
+#  // Licensed under the Apache License, Version 2.0 (the "License");
+#  // you may not use this file except in compliance with the License.
+#  // You may obtain a copy of the License at
+#  //
+#  //     http://www.apache.org/licenses/LICENSE-2.0
+#  //
+#  // Unless required by applicable law or agreed to in writing, software
+#  // distributed under the License is distributed on an "AS IS" BASIS,
+#  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  // See the License for the specific language governing permissions and
+#  // limitations under the License.
+
+"""
+POSIX advisory lock blocking and deadlock detection tests for Curvine FUSE mounts.
+
+Root cause: after LTP fcntl14 testcase-1 (parent WRLCK, child RDLCK F_SETLKW with
+parent wakeup), Curvine FUSE leaves stale lock state on the inode.  LTP testcase-2
+then fails with "First parent lock failed" (errno 11/EAGAIN), GETLK pid=0, and
+children blocked in F_SETLKW until the alarm kills them ("child didnot terminate").
+
+Covered LTP cases (each line is one minimal repro scenario):
+  fcntl14, fcntl14_64 — parent F_SETLK WRLCK must succeed on same file after tc1
+      SETLKW wakeup sequence (reproduces "First parent lock failed" / errno 11)
+  fcntl14, fcntl14_64 — child F_GETLK WRLCK probe must report parent PID and type
+      after tc1 sequence (reproduces "GETLK: pid=0, should be parent's id")
+  fcntl14, fcntl14_64 — child F_SETLKW WRLCK must finish after parent F_UNLCK in
+      LTP tc2 WILLBLOCK flow (reproduces "child didnot terminate on its own accord")
+  fcntl17, fcntl17_64 — three-process delayed deadlock must return EDEADLK on
+      F_SETLKW (reproduces "Alarm expired, deadlock not detected")
+
+Usage:
+    python3 curvine_ltp_fcntl_lock_repro.py --dir /curvine-fuse/fuse-test
+    python3 curvine_ltp_fcntl_lock_repro.py --dir /curvine-fuse/fuse-test --allow-non-mount
+"""
+
+import argparse
+import errno
+import fcntl
+import multiprocessing as mp
+import os
+import shutil
+import signal
+import struct
+import sys
+import time
+from typing import Callable
+
+DEFAULT_DIR = "/curvine-fuse/fuse-test"
+
+F_RDLCK = fcntl.F_RDLCK
+F_WRLCK = fcntl.F_WRLCK
+F_UNLCK = fcntl.F_UNLCK
+F_GETLK = fcntl.F_GETLK
+F_SETLK = fcntl.F_SETLK
+F_SETLKW = fcntl.F_SETLKW
+SEEK_SET = 0
+
+# struct flock on Linux x86_64 / aarch64 (64-bit off_t), native alignment → 32 B
+FLOCK_STRUCT = "hhqqi"
+FLOCK_SIZE = struct.calcsize(FLOCK_STRUCT)
+
+_LTP_FILEDATA = b"0123456789"
+_LTP17_FILEDATA = b"abcdefghijklmnopqrstuvwxyz\n"
+
+
+def _pack_flock(lock_type: int, start: int, length: int, pid: int = 0) -> bytes:
+    raw = struct.pack(FLOCK_STRUCT, lock_type, SEEK_SET, start, length, pid)
+    return raw + b"\x00" * (FLOCK_SIZE - len(raw))
+
+
+def _unpack_flock(buf: bytes) -> tuple[int, int, int, int, int]:
+    return struct.unpack(FLOCK_STRUCT, buf[: struct.calcsize(FLOCK_STRUCT)])
+
+
+def _flock_bytes(result) -> bytes:
+    if isinstance(result, (bytes, bytearray)):
+        data = bytes(result)
+    else:
+        data = bytes(result) if result is not None else b""
+    return data + b"\x00" * (FLOCK_SIZE - len(data))
+
+
+def _do_setlk(fd: int, lock_type: int, start: int = 0, length: int = 0) -> None:
+    fcntl.fcntl(fd, F_SETLK, _pack_flock(lock_type, start, length))
+
+
+def _do_setlkw(fd: int, lock_type: int, start: int = 0, length: int = 0) -> None:
+    fcntl.fcntl(fd, F_SETLKW, _pack_flock(lock_type, start, length))
+
+
+def _do_getlk(fd: int, lock_type: int, start: int = 0, length: int = 0) -> bytes:
+    result = fcntl.fcntl(fd, F_GETLK, _pack_flock(lock_type, start, length))
+    return _flock_bytes(result)
+
+
+def case_dir(root: str, name: str) -> str:
+    path = os.path.join(root, name)
+    if os.path.exists(path):
+        shutil.rmtree(path)
+    os.makedirs(path)
+    return path
+
+
+def expect_ok(name: str, fn: Callable[[], None]) -> int:
+    try:
+        fn()
+        print(f"  PASS: {name}")
+        return 0
+    except OSError as exc:
+        print(
+            f"  FAIL: {name} — unexpected OSError errno={exc.errno} "
+            f"({errno.errorcode.get(exc.errno, '?')}): {exc}",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        print(f"  FAIL: {name} — unexpected error: {exc}", file=sys.stderr)
+        return 1
+
+
+def expect_errno(name: str, fn: Callable[[], None], expected: int) -> int:
+    try:
+        fn()
+        print(
+            f"  FAIL: {name} — expected errno {expected} "
+            f"({errno.errorcode.get(expected, '?')}), but syscall succeeded",
+            file=sys.stderr,
+        )
+        return 1
+    except OSError as exc:
+        if exc.errno == expected:
+            print(
+                f"  PASS: {name} (errno={expected} "
+                f"{errno.errorcode.get(expected, '?')})"
+            )
+            return 0
+        print(
+            f"  FAIL: {name} — expected errno {expected}, got {exc.errno}: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        print(f"  FAIL: {name} — expected OSError, got {exc}", file=sys.stderr)
+        return 1
+
+
+def skip(name: str, reason: str) -> int:
+    print(f"  SKIP: {name} — {reason}")
+    return 0
+
+
+def _make_lock_file(workdir: str, payload: bytes = _LTP_FILEDATA) -> str:
+    path = os.path.join(workdir, "lockfile")
+    fd = os.open(path, os.O_CREAT | os.O_RDWR, 0o644)
+    try:
+        os.write(fd, payload)
+    finally:
+        os.close(fd)
+    return path
+
+
+def _force_kill(proc: mp.Process) -> None:
+    if not proc.is_alive():
+        return
+    proc.terminate()
+    proc.join(timeout=2.0)
+    if proc.is_alive():
+        proc.kill()
+        proc.join(timeout=2.0)
+
+
+def _signal_parent_after_delay(parent_pid: int) -> None:
+    time.sleep(0.1)
+    os.kill(parent_pid, signal.SIGUSR1)
+
+
+def _tc1_child_setlkw_rdlck(fd: int, parent_pid: int) -> None:
+    """LTP fcntl14 testcase-1 child: grandchild signals parent, then F_SETLKW RDLCK."""
+    signaler = mp.Process(
+        target=_signal_parent_after_delay,
+        args=(parent_pid,),
+        daemon=True,
+    )
+    signaler.start()
+    _do_setlkw(fd, F_RDLCK, 0, 0)
+    signaler.join(timeout=2.0)
+
+
+def _ltp_fcntl14_tc1_precondition(path: str) -> None:
+    """Run LTP fcntl14 testcase-1 (parent WRLCK, child RDLCK WILLBLOCK + wakeup)."""
+    fd = os.open(path, os.O_RDWR)
+    parent_pid = os.getpid()
+    ready = False
+
+    def on_sigusr1(_signum: int, _frame) -> None:
+        nonlocal ready
+        ready = True
+
+    old_handler = signal.signal(signal.SIGUSR1, on_sigusr1)
+    try:
+        _do_setlk(fd, F_WRLCK, 0, 0)
+        child = mp.Process(target=_tc1_child_setlkw_rdlck, args=(fd, parent_pid))
+        child.start()
+        deadline = time.time() + 5.0
+        while not ready and time.time() < deadline:
+            time.sleep(0.01)
+        _do_setlk(fd, F_UNLCK, 0, 0)
+        child.join(timeout=5.0)
+        if child.is_alive():
+            _force_kill(child)
+        elif child.exitcode not in (0, None):
+            raise OSError(
+                errno.EIO,
+                f"tc1 child exited with status {child.exitcode}",
+            )
+        time.sleep(0.05)
+    finally:
+        signal.signal(signal.SIGUSR1, old_handler)
+        os.close(fd)
+
+
+def _tc2_getlk_child(fd: int, parent_pid: int, result_q: mp.Queue) -> None:
+    """LTP fcntl14 testcase-2 child GETLK probe (WILLBLOCK path, before SETLKW)."""
+    buf = _do_getlk(fd, F_WRLCK, 0, 0)
+    l_type, _whence, _start, _length, l_pid = _unpack_flock(buf)
+    result_q.put((l_type, l_pid))
+
+
+def _tc2_setlkw_child(fd: int, parent_pid: int, result_q: mp.Queue) -> None:
+    """LTP fcntl14 testcase-2 child WILLBLOCK: SETLK then SETLKW WRLCK."""
+    _do_getlk(fd, F_WRLCK, 0, 0)
+    try:
+        _do_setlk(fd, F_WRLCK, 0, 0)
+    except OSError:
+        pass
+    signaler = mp.Process(
+        target=_signal_parent_after_delay,
+        args=(parent_pid,),
+        daemon=True,
+    )
+    signaler.start()
+    _do_setlkw(fd, F_WRLCK, 0, 0)
+    result_q.put("ok")
+    signaler.join(timeout=2.0)
+
+
+def _fcntl17_child1(path: str, cmd_q: mp.Queue, res_q: mp.Queue) -> None:
+    fd = os.open(path, os.O_RDWR)
+    try:
+        cmd_q.get()
+        _do_setlk(fd, F_WRLCK, 2, 5)
+        res_q.put(("c1", 0))
+        cmd_q.get()
+        _do_setlk(fd, F_UNLCK, 0, 0)
+    except OSError as exc:
+        res_q.put(("c1", exc.errno))
+    finally:
+        os.close(fd)
+
+
+def _fcntl17_child2(path: str, cmd_q: mp.Queue, res_q: mp.Queue) -> None:
+    fd = os.open(path, os.O_RDWR)
+    try:
+        cmd_q.get()
+        _do_setlk(fd, F_WRLCK, 9, 5)
+        res_q.put(("c2", 0))
+        cmd_q.get()
+        _do_setlkw(fd, F_WRLCK, 17, 5)
+        res_q.put(("c2", 0))
+    except OSError as exc:
+        res_q.put(("c2", exc.errno))
+    finally:
+        os.close(fd)
+
+
+def _fcntl17_child3(path: str, cmd_q: mp.Queue, res_q: mp.Queue) -> None:
+    fd = os.open(path, os.O_RDWR)
+    try:
+        cmd_q.get()
+        _do_setlk(fd, F_WRLCK, 17, 5)
+        res_q.put(("c3", 0))
+        cmd_q.get()
+        _do_setlkw(fd, F_WRLCK, 2, 14)
+        res_q.put(("c3", 0))
+    except OSError as exc:
+        res_q.put(("c3", exc.errno))
+    finally:
+        os.close(fd)
+
+
+def _run_fcntl17_delayed_deadlock(path: str, timeout: float = 12.0) -> int:
+    """Return errno observed from the deadlock F_SETLKW, or ETIMEDOUT / EIO."""
+    cmd1: mp.Queue = mp.Queue()
+    cmd2: mp.Queue = mp.Queue()
+    cmd3: mp.Queue = mp.Queue()
+    res_q: mp.Queue = mp.Queue()
+
+    proc1 = mp.Process(target=_fcntl17_child1, args=(path, cmd1, res_q))
+    proc2 = mp.Process(target=_fcntl17_child2, args=(path, cmd2, res_q))
+    proc3 = mp.Process(target=_fcntl17_child3, args=(path, cmd3, res_q))
+    children = (proc1, proc2, proc3)
+    cmds = (cmd1, cmd2, cmd3)
+
+    for proc in children:
+        proc.start()
+
+    def expect_stage(tag: str, err: int) -> None:
+        if err != 0:
+            raise OSError(err, f"{tag} setup lock failed")
+
+    try:
+        for cmd in cmds:
+            cmd.put(0)
+        for _ in range(3):
+            who, err = res_q.get(timeout=timeout)
+            expect_stage(who, err)
+
+        cmd2.put(0)
+        cmd3.put(0)
+        cmd1.put(0)
+
+        deadline = time.time() + timeout
+        edeadlk = None
+        while time.time() < deadline:
+            remaining = deadline - time.time()
+            try:
+                who, err = res_q.get(timeout=max(remaining, 0.05))
+            except Exception:
+                break
+            if who == "c3" and err == errno.EDEADLK:
+                edeadlk = errno.EDEADLK
+                break
+            if who == "c2" and err == errno.EDEADLK:
+                edeadlk = errno.EDEADLK
+                break
+            if err not in (0,):
+                return err
+
+        if edeadlk == errno.EDEADLK:
+            return errno.EDEADLK
+        return errno.ETIMEDOUT
+    finally:
+        for proc in children:
+            _force_kill(proc)
+
+
+def test_parent_write_lock_after_setlkw_read_wakeup_sequence(root: str) -> int:
+    # Related LTP cases: fcntl14, fcntl14_64
+    # LTP testcase-2 parent F_SETLK WRLCK must succeed on the same file after testcase-1.
+    workdir = case_dir(root, "fc14_parent_setlk")
+    path = _make_lock_file(workdir)
+    _ltp_fcntl14_tc1_precondition(path)
+
+    def run() -> None:
+        fd = os.open(path, os.O_RDWR)
+        try:
+            _do_setlk(fd, F_WRLCK, 0, 0)
+        finally:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+    return expect_ok(
+        "parent F_SETLK WRLCK after tc1 SETLKW wakeup sequence",
+        run,
+    )
+
+
+def test_getlk_write_probe_reports_parent_pid_after_wakeup_sequence(root: str) -> int:
+    # Related LTP cases: fcntl14, fcntl14_64
+    # LTP testcase-2 child F_GETLK WRLCK probe must see parent WRLCK and parent PID.
+    workdir = case_dir(root, "fc14_getlk_pid")
+    path = _make_lock_file(workdir)
+    _ltp_fcntl14_tc1_precondition(path)
+    parent_pid = os.getpid()
+
+    def run() -> None:
+        fd = os.open(path, os.O_RDWR)
+        try:
+            try:
+                _do_setlk(fd, F_WRLCK, 0, 0)
+            except OSError:
+                pass
+
+            result_q: mp.Queue = mp.Queue()
+            child = mp.Process(
+                target=_tc2_getlk_child,
+                args=(fd, parent_pid, result_q),
+            )
+            child.start()
+            child.join(timeout=5.0)
+            if child.is_alive():
+                _force_kill(child)
+                raise OSError(
+                    errno.ETIMEDOUT,
+                    "GETLK child hung",
+                )
+
+            l_type, l_pid = result_q.get(timeout=1.0)
+            if l_type != F_WRLCK:
+                raise OSError(
+                    errno.EIO,
+                    f"F_GETLK returned l_type={l_type} (F_UNLCK={F_UNLCK}), "
+                    f"expected WRLCK={F_WRLCK}",
+                )
+            if l_pid != parent_pid:
+                raise OSError(
+                    errno.EIO,
+                    f"F_GETLK returned pid={l_pid}, expected parent pid={parent_pid}",
+                )
+        finally:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+    return expect_ok(
+        "F_GETLK WRLCK probe reports parent PID after tc1 sequence",
+        run,
+    )
+
+
+def test_setlkw_write_completes_after_parent_unlock_post_wakeup(root: str) -> int:
+    # Related LTP cases: fcntl14, fcntl14_64
+    # LTP testcase-2 WILLBLOCK: child F_SETLKW WRLCK must finish after parent F_UNLCK.
+    workdir = case_dir(root, "fc14_setlkw_wakeup")
+    path = _make_lock_file(workdir)
+    _ltp_fcntl14_tc1_precondition(path)
+    parent_pid = os.getpid()
+
+    def run() -> None:
+        fd = os.open(path, os.O_RDWR)
+        usr1_seen = False
+
+        def on_sigusr1(_signum: int, _frame) -> None:
+            nonlocal usr1_seen
+            usr1_seen = True
+
+        old_handler = signal.signal(signal.SIGUSR1, on_sigusr1)
+        try:
+            try:
+                _do_setlk(fd, F_WRLCK, 0, 0)
+            except OSError:
+                pass
+
+            result_q: mp.Queue = mp.Queue()
+            child = mp.Process(
+                target=_tc2_setlkw_child,
+                args=(fd, parent_pid, result_q),
+            )
+            child.start()
+
+            deadline = time.time() + 5.0
+            while not usr1_seen and time.time() < deadline:
+                time.sleep(0.01)
+
+            _do_setlk(fd, F_UNLCK, 0, 0)
+            child.join(timeout=5.0)
+            if child.is_alive():
+                _force_kill(child)
+                raise OSError(
+                    errno.ETIMEDOUT,
+                    "child F_SETLKW never completed after parent F_UNLCK — "
+                    "matches LTP 'child didnot terminate on its own accord'",
+                )
+
+            status = result_q.get(timeout=1.0)
+            if status != "ok":
+                raise OSError(errno.EIO, f"child SETLKW unexpected status: {status!r}")
+        finally:
+            signal.signal(signal.SIGUSR1, old_handler)
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+    return expect_ok(
+        "F_SETLKW WRLCK completes after parent unlock (LTP tc2 WILLBLOCK)",
+        run,
+    )
+
+
+def test_setlkw_delayed_deadlock_returns_edeadlk(root: str) -> int:
+    # Related LTP cases: fcntl17, fcntl17_64
+    # Three-process delayed deadlock: F_SETLKW must return EDEADLK, not block until alarm.
+    workdir = case_dir(root, "fc17_deadlock")
+    path = _make_lock_file(workdir, _LTP17_FILEDATA)
+
+    def run() -> None:
+        result = _run_fcntl17_delayed_deadlock(path)
+        if result == errno.EDEADLK:
+            return
+        if result == errno.ETIMEDOUT:
+            raise OSError(
+                errno.ETIMEDOUT,
+                "deadlock not detected — F_SETLKW blocked until timeout; "
+                "matches LTP 'Alarm expired, deadlock not detected'",
+            )
+        raise OSError(
+            result,
+            f"F_SETLKW returned errno={result} "
+            f"({errno.errorcode.get(result, '?')}), expected EDEADLK={errno.EDEADLK}",
+        )
+
+    return expect_ok("F_SETLKW delayed deadlock returns EDEADLK", run)
+
+
+TESTS: list[tuple[str, str, Callable[..., int]]] = [
+    (
+        "1",
+        "parent F_SETLK after tc1 SETLKW wakeup (First parent lock failed)",
+        test_parent_write_lock_after_setlkw_read_wakeup_sequence,
+    ),
+    (
+        "2",
+        "F_GETLK reports parent PID after tc1 sequence",
+        test_getlk_write_probe_reports_parent_pid_after_wakeup_sequence,
+    ),
+    (
+        "3",
+        "F_SETLKW completes after parent unlock (child hang)",
+        test_setlkw_write_completes_after_parent_unlock_post_wakeup,
+    ),
+    (
+        "4",
+        "F_SETLKW delayed deadlock returns EDEADLK",
+        test_setlkw_delayed_deadlock_returns_edeadlk,
+    ),
+]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="POSIX fcntl lock blocking and deadlock detection tests for Curvine FUSE",
+    )
+    parser.add_argument(
+        "--dir",
+        default=DEFAULT_DIR,
+        help="Base test directory (must be on the Curvine FUSE mount)",
+    )
+    parser.add_argument(
+        "--allow-non-mount",
+        action="store_true",
+        help="Skip FUSE mount check; for local debugging only (default: False)",
+    )
+    args = parser.parse_args()
+
+    if not sys.platform.startswith("linux"):
+        print("SKIP: Linux-only syscalls", file=sys.stderr)
+        return 0
+
+    if os.geteuid() != 0:
+        print("WARNING: not running as root", file=sys.stderr)
+
+    root = os.path.abspath(args.dir)
+    os.makedirs(root, exist_ok=True)
+
+    if args.allow_non_mount:
+        print(
+            "WARNING: --allow-non-mount set; results may not reflect Curvine FUSE behaviour",
+            file=sys.stderr,
+        )
+
+    print(f"Running fcntl lock blocking / deadlock tests under {root}\n")
+
+    fail = 0
+    for num, title, test_fn in TESTS:
+        print(f"[case {num}] {title}:")
+        fail += test_fn(root)
+        print()
+
+    total = len(TESTS)
+    passed = total - fail
+    print(f"Summary: {passed}/{total} passed, {fail}/{total} failed")
+    return 1 if fail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/build/tests/scripts/curvine_ltp_fgetlk_wrong_repro.py
+++ b/build/tests/scripts/curvine_ltp_fgetlk_wrong_repro.py
@@ -1,0 +1,442 @@
+#!/usr/bin/env python3
+#  // Copyright 2025 OPPO.
+#  //
+#  // Licensed under the Apache License, Version 2.0 (the "License");
+#  // you may not use this file except in compliance with the License.
+#  // You may obtain a copy of the License at
+#  //
+#  //     http://www.apache.org/licenses/LICENSE-2.0
+#  //
+#  // Unless required by applicable law or agreed to in writing, software
+#  // distributed under the License is distributed on an "AS IS" BASIS,
+#  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  // See the License for the specific language governing permissions and
+#  // limitations under the License.
+
+"""
+F_GETLK returns wrong lock metadata on Curvine FUSE — reproducer for LTP failures.
+
+Root cause: when a child process issues F_GETLK(2) against a file whose parent
+holds POSIX byte-range locks, Curvine FUSE reports the wrong l_type, l_start,
+l_len, and l_pid (often the write-lock region at offset 10 instead of the
+expected read/write region, or F_UNLCK with pid 0 when a lock is present).
+
+Covered LTP cases (each line is one minimal repro scenario):
+  fcntl11, fcntl11_64 — write lock at 10:5 plus read lock at 1:5; F_GETLK for a
+      whole-file write probe must report the read lock at 1:5 held by parent.
+  fcntl19, fcntl19_64 — write lock 10:5 with partial unlock 5:6; F_GETLK must
+      report the surviving write-lock fragment at 11:4.
+  fcntl20, fcntl20_64 — read lock 10:5 with partial unlock 5:6; F_GETLK must
+      report the surviving read-lock fragment at 11:4.
+  fcntl21, fcntl21_64 — read lock 10:5 plus write lock 1:5; F_GETLK whole-file
+      write probe must report the nearer write lock at 1:5 held by parent.
+
+Usage:
+    python3 curvine_ltp_fgetlk_wrong_repro.py --dir /curvine-fuse/fuse-test
+    python3 curvine_ltp_fgetlk_wrong_repro.py --dir /curvine-fuse/fuse-test --allow-non-mount
+"""
+
+import argparse
+import errno
+import fcntl
+import multiprocessing as mp
+import os
+import shutil
+import struct
+import sys
+from typing import Callable
+
+DEFAULT_DIR = "/curvine-fuse/fuse-test"
+
+F_RDLCK = fcntl.F_RDLCK
+F_WRLCK = fcntl.F_WRLCK
+F_UNLCK = fcntl.F_UNLCK
+SEEK_SET = 0
+F_GETLK = fcntl.F_GETLK
+F_SETLK = fcntl.F_SETLK
+FLOCK_STRUCT = "hhqqi"
+FLOCK_SIZE = 32
+STOP = -16  # 0xFFF0 as signed short (LTP fcntl11 stop sentinel)
+
+
+def pack_flock(lock_type, start, length, pid=0):
+    raw = struct.pack(FLOCK_STRUCT, lock_type, SEEK_SET, start, length, pid)
+    return raw + b"\0" * (FLOCK_SIZE - len(raw))
+
+
+def sys_fcntl(fd, cmd, flock_buf):
+    # fcntl(2) via libc — same packed flock layout as LTP fcntl11.
+    result = fcntl.fcntl(fd, cmd, flock_buf)
+    if isinstance(result, int):
+        if result < 0:
+            raise OSError(errno.EINVAL, "fcntl failed")
+        return flock_buf
+    return result
+
+
+def unpack_flock(buf):
+    typ, whence, start, length, pid = struct.unpack(
+        FLOCK_STRUCT, buf[: struct.calcsize(FLOCK_STRUCT)]
+    )
+    return typ, whence, start, length, pid
+
+
+def setlk(fd, lock_type, start, length):
+    sys_fcntl(fd, F_SETLK, pack_flock(lock_type, start, length))
+
+
+def unlock_all(fd: int) -> None:
+    setlk(fd, F_UNLCK, 0, 0)
+
+
+def expect_flock(
+    name: str,
+    got: bytes,
+    exp_type: int,
+    exp_start: int,
+    exp_len: int,
+    exp_pid: int,
+) -> None:
+    typ, whence, start, length, pid = unpack_flock(got)
+    if whence != SEEK_SET:
+        raise OSError(
+            errno.EIO,
+            f"{name}: l_whence expected {SEEK_SET} got {whence}",
+        )
+    if typ != exp_type:
+        raise OSError(
+            errno.EIO,
+            f"{name}: l_type expected {exp_type} got {typ}",
+        )
+    if start != exp_start:
+        raise OSError(
+            errno.EIO,
+            f"{name}: l_start expected {exp_start} got {start}",
+        )
+    if length != exp_len:
+        raise OSError(
+            errno.EIO,
+            f"{name}: l_len expected {exp_len} got {length}",
+        )
+    if pid != exp_pid:
+        raise OSError(
+            errno.EIO,
+            f"{name}: l_pid expected {exp_pid} got {pid}",
+        )
+
+
+def _fgetlk_child_main(path: str, req_r: int, resp_w: int) -> None:
+    fd = os.open(path, os.O_RDWR)
+    req = os.fdopen(req_r, "rb", buffering=0)
+    resp = os.fdopen(resp_w, "wb", buffering=0)
+    try:
+        while True:
+            query = req.read(FLOCK_SIZE)
+            if not query or len(query) < FLOCK_SIZE:
+                break
+            typ = struct.unpack(FLOCK_STRUCT, query[: struct.calcsize(FLOCK_STRUCT)])[0]
+            if typ == STOP:
+                break
+            result = sys_fcntl(fd, F_GETLK, query)
+            resp.write(result)
+    finally:
+        os.close(fd)
+        req.close()
+        resp.close()
+
+
+class FGetlkProxy:
+    """Child process that runs F_GETLK on the shared file (LTP fcntl11 pattern)."""
+
+    def __init__(self, path: str) -> None:
+        self._path = path
+        parent_req_r, child_req_w = os.pipe()
+        child_resp_r, parent_resp_w = os.pipe()
+        self._req_w = child_req_w
+        self._resp_r = child_resp_r
+        self._proc = mp.Process(
+            target=_fgetlk_child_main,
+            args=(path, parent_req_r, parent_resp_w),
+            daemon=True,
+        )
+        self._proc.start()
+        os.close(parent_req_r)
+        os.close(parent_resp_w)
+
+    def getlk(self, lock_type: int, start: int, length: int) -> bytes:
+        os.write(self._req_w, pack_flock(lock_type, start, length))
+        data = os.read(self._resp_r, FLOCK_SIZE)
+        if len(data) != FLOCK_SIZE:
+            raise OSError(errno.EIO, "short F_GETLK response from child")
+        return data
+
+    def close(self) -> None:
+        os.write(self._req_w, pack_flock(STOP, 0, 0))
+        self._proc.join(timeout=5)
+        if self._proc.is_alive():
+            self._proc.terminate()
+            self._proc.join()
+        os.close(self._req_w)
+        os.close(self._resp_r)
+
+
+def expect_ok(name: str, fn: Callable[[], None]) -> int:
+    try:
+        fn()
+        print(f"  PASS: {name}")
+        return 0
+    except OSError as exc:
+        print(
+            f"  FAIL: {name} — unexpected OSError errno={exc.errno} "
+            f"({errno.errorcode.get(exc.errno, '?')}): {exc}",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        print(f"  FAIL: {name} — unexpected error: {exc}", file=sys.stderr)
+        return 1
+
+
+def expect_errno(name: str, fn: Callable[[], None], expected: int) -> int:
+    try:
+        fn()
+        print(
+            f"  FAIL: {name} — expected errno {expected} "
+            f"({errno.errorcode.get(expected, '?')}), but syscall succeeded",
+            file=sys.stderr,
+        )
+        return 1
+    except OSError as exc:
+        if exc.errno == expected:
+            print(
+                f"  PASS: {name} (errno={expected} "
+                f"{errno.errorcode.get(expected, '?')})"
+            )
+            return 0
+        print(
+            f"  FAIL: {name} — expected errno {expected}, got {exc.errno}: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        print(f"  FAIL: {name} — expected OSError, got {exc}", file=sys.stderr)
+        return 1
+
+
+def skip(name: str, reason: str) -> int:
+    print(f"  SKIP: {name} — {reason}")
+    return 0
+
+
+def case_dir(root: str, name: str) -> str:
+    path = os.path.join(root, name)
+    if os.path.exists(path):
+        shutil.rmtree(path)
+    os.makedirs(path)
+    return path
+
+
+def _prepare_lock_file(workdir):
+    path = os.path.join(workdir, "lockfile")
+    fd = os.open(path, os.O_CREAT | os.O_RDWR, 0o644)
+    os.ftruncate(fd, 27)
+    return path, fd
+
+
+def test_fgetlk_read_lock_around_write_lock(root: str) -> int:
+    # Related LTP cases: fcntl11, fcntl11_64
+    # F_GETLK must report the read lock at 1:5 when write+read locks coexist.
+    workdir = case_dir(root, "fgetlk_read_around_write")
+    path, fd = _prepare_lock_file(workdir)
+    holder_pid = os.getpid()
+    proxy = FGetlkProxy(path)
+
+    def run() -> None:
+        setlk(fd, F_WRLCK, 10, 5)
+        setlk(fd, F_RDLCK, 1, 5)
+        got = proxy.getlk(F_WRLCK, 0, 0)
+        expect_flock(
+            "F_GETLK reports read lock at 1:5",
+            got,
+            F_RDLCK,
+            1,
+            5,
+            holder_pid,
+        )
+
+    try:
+        return expect_ok("F_GETLK read lock around write lock (fcntl11 block 1)", run)
+    finally:
+        proxy.close()
+        unlock_all(fd)
+        os.close(fd)
+
+
+def test_fgetlk_trimmed_write_lock_after_partial_unlock(root: str) -> int:
+    # Related LTP cases: fcntl19, fcntl19_64
+    # Partial unlock before a write lock must leave fragment 11:4 visible to F_GETLK.
+    workdir = case_dir(root, "fgetlk_write_partial_unlock")
+    path, fd = _prepare_lock_file(workdir)
+    holder_pid = os.getpid()
+    proxy = FGetlkProxy(path)
+
+    def run() -> None:
+        setlk(fd, F_WRLCK, 10, 5)
+        setlk(fd, F_UNLCK, 5, 6)
+        got = proxy.getlk(F_WRLCK, 0, 0)
+        expect_flock(
+            "F_GETLK reports surviving write lock at 11:4",
+            got,
+            F_WRLCK,
+            11,
+            4,
+            holder_pid,
+        )
+
+    try:
+        return expect_ok(
+            "F_GETLK trimmed write lock after partial unlock (fcntl19 block 2)",
+            run,
+        )
+    finally:
+        proxy.close()
+        unlock_all(fd)
+        os.close(fd)
+
+
+def test_fgetlk_trimmed_read_lock_after_partial_unlock(root: str) -> int:
+    # Related LTP cases: fcntl20, fcntl20_64
+    # Partial unlock before a read lock must leave fragment 11:4 visible to F_GETLK.
+    workdir = case_dir(root, "fgetlk_read_partial_unlock")
+    path, fd = _prepare_lock_file(workdir)
+    holder_pid = os.getpid()
+    proxy = FGetlkProxy(path)
+
+    def run() -> None:
+        setlk(fd, F_RDLCK, 10, 5)
+        setlk(fd, F_UNLCK, 5, 6)
+        got = proxy.getlk(F_WRLCK, 0, 0)
+        expect_flock(
+            "F_GETLK reports surviving read lock at 11:4",
+            got,
+            F_RDLCK,
+            11,
+            4,
+            holder_pid,
+        )
+
+    try:
+        return expect_ok(
+            "F_GETLK trimmed read lock after partial unlock (fcntl20 block 2)",
+            run,
+        )
+    finally:
+        proxy.close()
+        unlock_all(fd)
+        os.close(fd)
+
+
+def test_fgetlk_write_lock_around_read_lock(root: str) -> int:
+    # Related LTP cases: fcntl21, fcntl21_64
+    # F_GETLK must report the nearer write lock at 1:5 when read+write locks coexist.
+    workdir = case_dir(root, "fgetlk_write_around_read")
+    path, fd = _prepare_lock_file(workdir)
+    holder_pid = os.getpid()
+    proxy = FGetlkProxy(path)
+
+    def run() -> None:
+        setlk(fd, F_RDLCK, 10, 5)
+        setlk(fd, F_WRLCK, 1, 5)
+        got = proxy.getlk(F_WRLCK, 0, 0)
+        expect_flock(
+            "F_GETLK reports write lock at 1:5",
+            got,
+            F_WRLCK,
+            1,
+            5,
+            holder_pid,
+        )
+
+    try:
+        return expect_ok(
+            "F_GETLK write lock around read lock (fcntl21 block 3)",
+            run,
+        )
+    finally:
+        proxy.close()
+        unlock_all(fd)
+        os.close(fd)
+
+
+TESTS = [
+    (
+        "1",
+        "F_GETLK reports read lock when read+write locks coexist (fcntl11)",
+        test_fgetlk_read_lock_around_write_lock,
+    ),
+    (
+        "2",
+        "F_GETLK reports trimmed write lock after partial unlock (fcntl19)",
+        test_fgetlk_trimmed_write_lock_after_partial_unlock,
+    ),
+    (
+        "3",
+        "F_GETLK reports trimmed read lock after partial unlock (fcntl20)",
+        test_fgetlk_trimmed_read_lock_after_partial_unlock,
+    ),
+    (
+        "4",
+        "F_GETLK reports write lock when write+read locks coexist (fcntl21)",
+        test_fgetlk_write_lock_around_read_lock,
+    ),
+]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="F_GETLK wrong lock metadata on Curvine FUSE — reproducer",
+    )
+    parser.add_argument(
+        "--dir",
+        default=DEFAULT_DIR,
+        help="Base test directory (must be on the Curvine FUSE mount)",
+    )
+    parser.add_argument(
+        "--allow-non-mount",
+        action="store_true",
+        help="Skip FUSE mount check; for local debugging only (default: False)",
+    )
+    args = parser.parse_args()
+
+    if not sys.platform.startswith("linux"):
+        print("SKIP: Linux-only syscalls", file=sys.stderr)
+        return 0
+
+    if os.geteuid() != 0:
+        print("WARNING: not running as root", file=sys.stderr)
+
+    root = os.path.abspath(args.dir)
+    os.makedirs(root, exist_ok=True)
+
+    if args.allow_non_mount:
+        print(
+            "WARNING: --allow-non-mount set; results may not reflect Curvine FUSE",
+            file=sys.stderr,
+        )
+
+    print(f"Running F_GETLK wrong-lock reproducer under {root}\n")
+
+    fail = 0
+    for num, title, test_fn in TESTS:
+        print(f"[case {num}] {title}:")
+        fail += test_fn(root)
+        print()
+
+    total = len(TESTS)
+    passed = total - fail
+    print(f"Summary: {passed}/{total} passed, {fail}/{total} failed")
+    return 1 if fail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/build/tests/scripts/curvine_ltp_mknod_eperm_repro.py
+++ b/build/tests/scripts/curvine_ltp_mknod_eperm_repro.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+#  // Copyright 2025 OPPO.
+#  //
+#  // Licensed under the Apache License, Version 2.0 (the "License");
+#  // you may not use this file except in compliance with the License.
+#  // You may obtain a copy of the License at
+#  //
+#  //     http://www.apache.org/licenses/LICENSE-2.0
+#  //
+#  // Unless required by applicable law or agreed to in writing, software
+#  // distributed under the License is distributed on an "AS IS" BASIS,
+#  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  // See the License for the specific language governing permissions and
+#  // limitations under the License.
+
+"""
+mknod / mkfifo EPERM on Curvine FUSE — reproducer for LTP failures.
+
+Root cause: Curvine FUSE does not implement the FUSE_MKNOD operation (or
+returns EPERM unconditionally), which causes every syscall that creates a
+special file node—named pipe (FIFO), character device, block device, or Unix
+domain socket file—to fail with EPERM even when called by root.  This single
+bug cascades across more than 25 otherwise unrelated LTP test groups because
+they all rely on one of these node-creation calls during their setup phase.
+
+Covered LTP cases and the failing operation in each:
+  mknod01 (case 2)  — mknod(path, S_IFIFO|0777, 0) → EPERM (TFAIL, test logic)
+  mknod02           — mknod(path, S_IFCHR|0777, 0) → EPERM (TFAIL)
+  mknod03           — mknod(path, S_IFCHR|0777, 0) → EPERM (TFAIL)
+  mknod04           — mknod(path, S_IFIFO|0777, 0) → EPERM (TFAIL)
+  mknod05           — mknod(path, S_IFCHR|0777, 0) → EPERM (TFAIL)
+  mknod06           — mknod(path, S_IFBLK|mode, dev) in setup → EPERM (TBROK)
+  mknod08           — mknod(path, S_IFIFO|0777, 0) → EPERM (TFAIL)
+  fcntl07           — mkfifo(fifo, 0666) in setup → EPERM (TBROK)
+  fcntl07_64        — mkfifo(fifo, 0666) in setup → EPERM (TBROK)
+  dup05             — mkfifo(dupfile, 0777) in setup → EPERM (TBROK)
+  stream02          — mknod() in test body → EPERM (TFAIL)
+  lseek02           — mkfifo(tfifo1, 0777) in setup → EPERM (TBROK)
+  read03            — mknod() in setup → EPERM (TBROK)
+  write04           — mknod() in setup → EPERM (TBROK)
+  fsync03           — mkfifo(fifo, 0644) in setup → EPERM (TBROK)
+  select01          — mkfifo(tmpfile2, 0666) in setup → EPERM (TBROK)
+  open06            — mknod() char device in setup → EPERM (TBROK)
+  open11            — mknod() char device in setup → EPERM (TBROK)
+  statx01           — mknod() char device in setup → EPERM (TBROK)
+  getxattr02        — mkfifo(getxattr02fifo) in setup → EPERM (TBROK)
+  fgetxattr02       — mknod() char device in setup → EPERM (TBROK)
+  setxattr02        — mknod() char device in setup → EPERM (TBROK)
+  getsockopt02      — bind(AF_UNIX, path_on_fuse) → EPERM (TBROK)
+  recvmsg01         — bind(AF_UNIX, path_on_fuse) → EPERM (TBROK)
+  sendmsg01         — bind(AF_UNIX, path_on_fuse) → EPERM (TBROK)
+  sockioctl01       — bind(AF_UNIX, path_on_fuse) → EPERM (TBROK)
+  bind03            — bind(AF_UNIX, path_on_fuse) → EPERM (TBROK)
+  unlink05 (case 2) — mkfifo(tfifo, 0777) → EPERM (TBROK)
+
+Usage:
+    python3 curvine_ltp_mknod_eperm_repro.py --dir /curvine-fuse/fuse-test
+    python3 curvine_ltp_mknod_eperm_repro.py --dir /curvine-fuse/fuse-test --allow-non-mount
+"""
+
+import argparse
+import errno
+import os
+import shutil
+import socket
+import stat
+import sys
+from typing import Callable, List, Tuple
+
+DEFAULT_DIR = "/curvine-fuse/fuse-test"
+
+
+# ---------------------------------------------------------------------------
+# Helpers — identical signatures and behaviour to file_handle_at_test.py
+# ---------------------------------------------------------------------------
+
+def expect_ok(name: str, fn: Callable[[], None]) -> int:
+    try:
+        fn()
+        print(f"  PASS: {name}")
+        return 0
+    except OSError as exc:
+        print(
+            f"  FAIL: {name} — unexpected OSError errno={exc.errno} "
+            f"({errno.errorcode.get(exc.errno, '?')}): {exc}",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        print(f"  FAIL: {name} — unexpected error: {exc}", file=sys.stderr)
+        return 1
+
+
+def expect_errno(name: str, fn: Callable[[], None], expected: int) -> int:
+    try:
+        fn()
+        print(
+            f"  FAIL: {name} — expected errno {expected} "
+            f"({errno.errorcode.get(expected, '?')}), but syscall succeeded",
+            file=sys.stderr,
+        )
+        return 1
+    except OSError as exc:
+        if exc.errno == expected:
+            print(
+                f"  PASS: {name} (errno={expected} "
+                f"{errno.errorcode.get(expected, '?')})"
+            )
+            return 0
+        print(
+            f"  FAIL: {name} — expected errno {expected}, got {exc.errno}: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        print(f"  FAIL: {name} — expected OSError, got {exc}", file=sys.stderr)
+        return 1
+
+
+def skip(name: str, reason: str) -> int:
+    print(f"  SKIP: {name} — {reason}")
+    return 0
+
+
+def case_dir(root: str, name: str) -> str:
+    path = os.path.join(root, name)
+    if os.path.exists(path):
+        shutil.rmtree(path)
+    os.makedirs(path)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Test functions
+# ---------------------------------------------------------------------------
+
+def test_mkfifo_on_fuse_must_not_eperm(root: str) -> int:
+    # Related LTP cases: fcntl07, fcntl07_64, dup05, lseek02, fsync03, select01,
+    #                    getxattr02, unlink05 (case 2), mknod01 (case 2)
+    # mkfifo(2) shall create a named pipe on the filesystem; EPERM from FUSE
+    # means the FUSE_MKNOD handler is missing or unconditionally rejecting.
+    workdir = case_dir(root, "mkfifo_eperm")
+    fifo_path = os.path.join(workdir, "test.fifo")
+
+    return expect_ok(
+        "mkfifo(path, 0o666) on FUSE mount",
+        lambda: os.mkfifo(fifo_path, 0o666),
+    )
+
+
+def test_mknod_fifo_type_on_fuse_must_not_eperm(root: str) -> int:
+    # Related LTP cases: mknod01 (case 2), mknod04, mknod08, stream02, read03, write04
+    # mknod(2) with S_IFIFO type bit set must succeed when caller is root;
+    # FUSE returning EPERM reveals the missing mknod implementation.
+    name = "mknod(path, S_IFIFO|0o777, 0) on FUSE mount"
+    if os.geteuid() != 0:
+        return skip(name, "requires root (CAP_MKNOD)")
+    workdir = case_dir(root, "mknod_fifo_eperm")
+    node_path = os.path.join(workdir, "test_fifo_node")
+
+    return expect_ok(
+        name,
+        lambda: os.mknod(node_path, stat.S_IFIFO | 0o777),
+    )
+
+
+def test_mknod_chardev_on_fuse_must_not_eperm(root: str) -> int:
+    # Related LTP cases: mknod02, mknod03, mknod05, open06, open11, statx01,
+    #                    fgetxattr02, setxattr02
+    # mknod(2) with S_IFCHR (null device 1:3) must succeed as root; any EPERM
+    # returned by FUSE indicates the FUSE_MKNOD path is blocked for device nodes.
+    name = "mknod(path, S_IFCHR|0o666, makedev(1,3)) on FUSE mount"
+    if os.geteuid() != 0:
+        return skip(name, "requires root (CAP_MKNOD)")
+    workdir = case_dir(root, "mknod_chardev_eperm")
+    node_path = os.path.join(workdir, "test_null_node")
+
+    return expect_ok(
+        name,
+        lambda: os.mknod(node_path, stat.S_IFCHR | 0o666, os.makedev(1, 3)),
+    )
+
+
+def test_mknod_blkdev_on_fuse_must_not_eperm(root: str) -> int:
+    # Related LTP cases: mknod06
+    # mknod(2) with S_IFBLK (loop device 7:0) must succeed as root; FUSE returning
+    # EPERM in setup breaks all sub-cases of mknod06 before they can run.
+    name = "mknod(path, S_IFBLK|0o660, makedev(7,0)) on FUSE mount"
+    if os.geteuid() != 0:
+        return skip(name, "requires root (CAP_MKNOD)")
+    workdir = case_dir(root, "mknod_blkdev_eperm")
+    node_path = os.path.join(workdir, "test_loop_node")
+
+    return expect_ok(
+        name,
+        lambda: os.mknod(node_path, stat.S_IFBLK | 0o660, os.makedev(7, 0)),
+    )
+
+
+def test_unix_socket_bind_on_fuse_must_not_eperm(root: str) -> int:
+    # Related LTP cases: bind03, getsockopt02, recvmsg01, sendmsg01, sockioctl01
+    # bind(2) on an AF_UNIX socket with a path that lives on a FUSE mount internally
+    # triggers mknod to create the socket node; FUSE returning EPERM causes the bind
+    # itself to fail with EPERM, breaking all Unix-domain socket tests.
+    workdir = case_dir(root, "unix_socket_bind_eperm")
+    sock_path = os.path.join(workdir, "test.sock")
+
+    def do_bind() -> None:
+        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            s.bind(sock_path)
+        finally:
+            s.close()
+
+    return expect_ok(
+        "bind(AF_UNIX, path_on_fuse) — Unix socket node creation via mknod",
+        do_bind,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test registry
+# ---------------------------------------------------------------------------
+
+TESTS: List[Tuple[str, str, Callable[..., int]]] = [
+    ("1", "mkfifo(2) on FUSE must not return EPERM", test_mkfifo_on_fuse_must_not_eperm),
+    ("2", "mknod(2) S_IFIFO on FUSE must not return EPERM", test_mknod_fifo_type_on_fuse_must_not_eperm),
+    ("3", "mknod(2) S_IFCHR on FUSE must not return EPERM", test_mknod_chardev_on_fuse_must_not_eperm),
+    ("4", "mknod(2) S_IFBLK on FUSE must not return EPERM", test_mknod_blkdev_on_fuse_must_not_eperm),
+    ("5", "bind(AF_UNIX, path_on_fuse) must not return EPERM", test_unix_socket_bind_on_fuse_must_not_eperm),
+]
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="mknod/mkfifo EPERM on Curvine FUSE — reproducer",
+    )
+    parser.add_argument(
+        "--dir",
+        default=DEFAULT_DIR,
+        help="Base test directory (must be on the Curvine FUSE mount)",
+    )
+    parser.add_argument(
+        "--allow-non-mount",
+        action="store_true",
+        help="Skip FUSE mount check; for local debugging only (default: False)",
+    )
+    args = parser.parse_args()
+
+    if not sys.platform.startswith("linux"):
+        print("SKIP: Linux-only syscalls", file=sys.stderr)
+        return 0
+
+    if os.geteuid() != 0:
+        print(
+            "WARNING: not running as root — mknod device-node tests will be skipped",
+            file=sys.stderr,
+        )
+
+    root = os.path.abspath(args.dir)
+    os.makedirs(root, exist_ok=True)
+
+    print(f"Running mknod/mkfifo EPERM reproducer under {root}\n")
+
+    fail = 0
+    for num, title, test_fn in TESTS:
+        print(f"[case {num}] {title}:")
+        fail += test_fn(root)
+        print()
+
+    total = len(TESTS)
+    passed = total - fail
+    print(f"Summary: {passed}/{total} passed, {fail}/{total} failed")
+    return 1 if fail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/build/tests/scripts/curvine_ltp_mmap_sigbus_repro.py
+++ b/build/tests/scripts/curvine_ltp_mmap_sigbus_repro.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+#  // Copyright 2025 OPPO.
+#  //
+#  // Licensed under the Apache License, Version 2.0 (the "License");
+#  // you may not use this file except in compliance with the License.
+#  // You may obtain a copy of the License at
+#  //
+#  //     http://www.apache.org/licenses/LICENSE-2.0
+#  //
+#  // Unless required by applicable law or agreed to in writing, software
+#  // distributed under the License is distributed on an "AS IS" BASIS,
+#  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  // See the License for the specific language governing permissions and
+#  // limitations under the License.
+
+"""
+mmap page access raises SIGBUS on Curvine FUSE — reproducer for LTP failures.
+
+Root cause: accessing a MAP_SHARED file mapping triggers a page fault whose
+FUSE read-back fails, delivering SIGBUS instead of file contents.
+
+Covered LTP cases (each line is one minimal repro scenario):
+  mmap02 — PROT_READ mmap of mode-0444 file on O_RDONLY fd must be readable (TBROK SIGBUS)
+  mmap03 — PROT_EXEC mmap of mode-0555 file on O_RDONLY fd must be readable (TBROK SIGBUS)
+  mmap04 — PROT_READ|PROT_EXEC mmap of mode-0555 file must match file data (TBROK SIGBUS)
+
+Usage:
+    python3 curvine_ltp_mmap_sigbus_repro.py --dir /curvine-fuse/fuse-test
+    python3 curvine_ltp_mmap_sigbus_repro.py --dir /curvine-fuse/fuse-test --allow-non-mount
+"""
+
+import argparse
+import ctypes
+import errno
+import multiprocessing
+import os
+import platform
+import shutil
+import signal
+import sys
+from typing import Callable
+
+DEFAULT_DIR = "/curvine-fuse/fuse-test"
+
+PROT_READ = 1
+PROT_EXEC = 4
+PROT_READ_EXEC = PROT_READ | PROT_EXEC
+MAP_SHARED = 1
+
+O_RDWR = 2
+O_CREAT = 0o100
+O_TRUNC = 0o1000
+O_RDONLY = 0
+
+
+def expect_ok(name: str, fn: Callable[[], None]) -> int:
+    try:
+        fn()
+        print(f"  PASS: {name}")
+        return 0
+    except OSError as exc:
+        print(
+            f"  FAIL: {name} — unexpected OSError errno={exc.errno} "
+            f"({errno.errorcode.get(exc.errno, '?')}): {exc}",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        print(f"  FAIL: {name} — unexpected error: {exc}", file=sys.stderr)
+        return 1
+
+
+def expect_errno(name: str, fn: Callable[[], None], expected: int) -> int:
+    try:
+        fn()
+        print(
+            f"  FAIL: {name} — expected errno {expected} "
+            f"({errno.errorcode.get(expected, '?')}), but syscall succeeded",
+            file=sys.stderr,
+        )
+        return 1
+    except OSError as exc:
+        if exc.errno == expected:
+            print(
+                f"  PASS: {name} (errno={expected} "
+                f"{errno.errorcode.get(expected, '?')})"
+            )
+            return 0
+        print(
+            f"  FAIL: {name} — expected errno {expected}, got {exc.errno}: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        print(f"  FAIL: {name} — expected OSError, got {exc}", file=sys.stderr)
+        return 1
+
+
+def skip(name: str, reason: str) -> int:
+    print(f"  SKIP: {name} — {reason}")
+    return 0
+
+
+def case_dir(root: str, name: str) -> str:
+    path = os.path.join(root, name)
+    if os.path.exists(path):
+        shutil.rmtree(path)
+    os.makedirs(path)
+    return path
+
+
+def _syscall_nr_mmap() -> int:
+    table = {
+        "x86_64": 9,
+        "aarch64": 222,
+    }
+    machine = platform.machine()
+    if machine not in table:
+        raise OSError(
+            errno.ENOSYS,
+            f"unsupported architecture for mmap: {machine}",
+        )
+    return table[machine]
+
+
+def _syscall_nr_munmap() -> int:
+    table = {
+        "x86_64": 11,
+        "aarch64": 215,
+    }
+    machine = platform.machine()
+    if machine not in table:
+        raise OSError(
+            errno.ENOSYS,
+            f"unsupported architecture for munmap: {machine}",
+        )
+    return table[machine]
+
+
+def sys_mmap(addr: int, length: int, prot: int, flags: int, fd: int, offset: int) -> int:
+    """mmap(addr, length, prot, flags, fd, offset) via raw syscall."""
+    libc = ctypes.CDLL(None, use_errno=True)
+    syscall_fn = libc.syscall
+    syscall_fn.restype = ctypes.c_long
+
+    ret = int(
+        syscall_fn(
+            _syscall_nr_mmap(),
+            addr,
+            length,
+            prot,
+            flags,
+            fd,
+            offset,
+        )
+    )
+    if ret < 0:
+        err = ctypes.get_errno()
+        raise OSError(err, os.strerror(err))
+    return ret
+
+
+def sys_munmap(addr: int, length: int) -> None:
+    """munmap(addr, length) via raw syscall."""
+    libc = ctypes.CDLL(None, use_errno=True)
+    syscall_fn = libc.syscall
+    syscall_fn.restype = ctypes.c_long
+
+    ret = int(syscall_fn(_syscall_nr_munmap(), addr, length))
+    if ret < 0:
+        err = ctypes.get_errno()
+        raise OSError(err, os.strerror(err))
+
+
+def _page_size() -> int:
+    return os.sysconf("SC_PAGE_SIZE")
+
+
+def _create_fill_file(path: str, page_sz: int, file_mode: int) -> None:
+    fd = os.open(path, O_RDWR | O_CREAT | O_TRUNC, 0o666)
+    try:
+        os.write(fd, b"A" * page_sz)
+        os.fchmod(fd, file_mode)
+    finally:
+        os.close(fd)
+
+
+def _child_read_mapped_file(path: str, page_sz: int, prot: int) -> None:
+    fd = os.open(path, O_RDONLY)
+    try:
+        addr = sys_mmap(0, page_sz, prot, MAP_SHARED, fd, 0)
+        try:
+            mapped = (ctypes.c_char * page_sz).from_address(addr)
+            if bytes(mapped) != b"A" * page_sz:
+                raise OSError(errno.EIO, "mapped memory area contains invalid data")
+        finally:
+            sys_munmap(addr, page_sz)
+    finally:
+        os.close(fd)
+
+
+def _run_mmap_read_child(path: str, page_sz: int, prot: int) -> None:
+    proc = multiprocessing.Process(
+        target=_child_read_mapped_file,
+        args=(path, page_sz, prot),
+    )
+    proc.start()
+    proc.join()
+    if proc.exitcode == -signal.SIGBUS:
+        raise OSError(
+            errno.EFAULT,
+            "unexpected SIGBUS accessing mmap'd FUSE page (page-fault read-back failed)",
+        )
+    if proc.exitcode != 0:
+        raise OSError(
+            errno.EIO,
+            f"child mmap read failed with exit code {proc.exitcode}",
+        )
+
+
+def test_mmap_shared_read_only_file_readable(root: str) -> int:
+    # Related LTP cases: mmap02
+    # MAP_SHARED PROT_READ mmap of a mode-0444 file on O_RDONLY fd must be readable.
+    workdir = case_dir(root, "mmap_prot_read")
+    target = os.path.join(workdir, "mmapfile")
+    page_sz = _page_size()
+    _create_fill_file(target, page_sz, 0o444)
+
+    def run() -> None:
+        _run_mmap_read_child(target, page_sz, PROT_READ)
+
+    return expect_ok(
+        "PROT_READ MAP_SHARED mmap of mode-0444 file readable without SIGBUS (mmap02)",
+        run,
+    )
+
+
+def test_mmap_shared_exec_file_readable(root: str) -> int:
+    # Related LTP cases: mmap03
+    # MAP_SHARED PROT_EXEC mmap of a mode-0555 file on O_RDONLY fd must be readable.
+    workdir = case_dir(root, "mmap_prot_exec")
+    target = os.path.join(workdir, "mmapfile")
+    page_sz = _page_size()
+    _create_fill_file(target, page_sz, 0o555)
+
+    def run() -> None:
+        _run_mmap_read_child(target, page_sz, PROT_EXEC)
+
+    return expect_ok(
+        "PROT_EXEC MAP_SHARED mmap of mode-0555 file readable without SIGBUS (mmap03)",
+        run,
+    )
+
+
+def test_mmap_shared_read_exec_file_readable(root: str) -> int:
+    # Related LTP cases: mmap04
+    # MAP_SHARED PROT_READ|PROT_EXEC mmap of mode-0555 file must expose file contents.
+    workdir = case_dir(root, "mmap_prot_read_exec")
+    target = os.path.join(workdir, "mmapfile")
+    page_sz = _page_size()
+    _create_fill_file(target, page_sz, 0o555)
+
+    def run() -> None:
+        _run_mmap_read_child(target, page_sz, PROT_READ_EXEC)
+
+    return expect_ok(
+        "PROT_READ|PROT_EXEC MAP_SHARED mmap of mode-0555 file readable without SIGBUS "
+        "(mmap04)",
+        run,
+    )
+
+
+TESTS: list[tuple[str, str, Callable[..., int]]] = [
+    (
+        "1",
+        "PROT_READ mmap of mode-0444 file readable (mmap02)",
+        test_mmap_shared_read_only_file_readable,
+    ),
+    (
+        "2",
+        "PROT_EXEC mmap of mode-0555 file readable (mmap03)",
+        test_mmap_shared_exec_file_readable,
+    ),
+    (
+        "3",
+        "PROT_READ|PROT_EXEC mmap of mode-0555 file readable (mmap04)",
+        test_mmap_shared_read_exec_file_readable,
+    ),
+]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="mmap page access SIGBUS on Curvine FUSE — reproducer",
+    )
+    parser.add_argument(
+        "--dir",
+        default=DEFAULT_DIR,
+        help="Base test directory (must be on the Curvine FUSE mount)",
+    )
+    parser.add_argument(
+        "--allow-non-mount",
+        action="store_true",
+        help="Skip FUSE mount check; for local debugging only (default: False)",
+    )
+    args = parser.parse_args()
+
+    if not sys.platform.startswith("linux"):
+        print("SKIP: Linux-only syscalls", file=sys.stderr)
+        return 0
+
+    if os.geteuid() != 0:
+        print("WARNING: not running as root", file=sys.stderr)
+
+    root = os.path.abspath(args.dir)
+    os.makedirs(root, exist_ok=True)
+
+    if args.allow_non_mount:
+        print(
+            "WARNING: --allow-non-mount set; results may not reflect Curvine FUSE behaviour",
+            file=sys.stderr,
+        )
+
+    print(f"Running mmap-SIGBUS reproducer under {root}\n")
+
+    fail = 0
+    for num, title, test_fn in TESTS:
+        print(f"[case {num}] {title}:")
+        fail += test_fn(root)
+        print()
+
+    total = len(TESTS)
+    passed = total - fail
+    print(f"Summary: {passed}/{total} passed, {fail}/{total} failed")
+    return 1 if fail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/build/tests/scripts/curvine_ltp_protected_symlinks_repro.py
+++ b/build/tests/scripts/curvine_ltp_protected_symlinks_repro.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+#  // Copyright 2025 OPPO.
+#  //
+#  // Licensed under the Apache License, Version 2.0 (the "License");
+#  // you may not use this file except in compliance with the License.
+#  // You may obtain a copy of the License at
+#  //
+#  //     http://www.apache.org/licenses/LICENSE-2.0
+#  //
+#  // Unless required by applicable law or agreed to in writing, software
+#  // distributed under the License is distributed on an "AS IS" BASIS,
+#  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  // See the License for the specific language governing permissions and
+#  // limitations under the License.
+
+"""
+fs.protected_symlinks policy not enforced on Curvine FUSE — reproducer for LTP failures.
+
+Root cause: in sticky, world-writable directories the kernel blocks the directory
+owner from following symlinks they do not own (fs.protected_symlinks=1).  Curvine
+does not apply this check: the dir owner can open others' symlinks when it should
+get EACCES, and incorrectly blocks the dir owner from opening their own symlinks.
+
+Covered LTP cases (each line is one minimal repro scenario):
+  prot_hsymlinks — root-owned sticky tmp_root: root must not open hsym's symlink (TFAIL)
+  prot_hsymlinks — hsym-owned sticky tmp_hsym: hsym must open own symlink (TFAIL)
+
+Usage:
+    python3 curvine_ltp_protected_symlinks_repro.py --dir /curvine-fuse/fuse-test
+    python3 curvine_ltp_protected_symlinks_repro.py --dir /curvine-fuse/fuse-test --allow-non-mount
+"""
+
+import argparse
+import ctypes
+import errno
+import os
+import platform
+import pwd
+import shutil
+import stat
+import sys
+from typing import Callable
+
+DEFAULT_DIR = "/curvine-fuse/fuse-test"
+
+AT_FDCWD = -100
+O_RDONLY = 0
+
+MODE_WORLD_WRITABLE = stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO
+MODE_STICKY_WORLD = MODE_WORLD_WRITABLE | stat.S_ISVTX
+
+TEST_USER = "hsym"
+
+
+def expect_ok(name: str, fn: Callable[[], None]) -> int:
+    try:
+        fn()
+        print(f"  PASS: {name}")
+        return 0
+    except OSError as exc:
+        print(
+            f"  FAIL: {name} — unexpected OSError errno={exc.errno} "
+            f"({errno.errorcode.get(exc.errno, '?')}): {exc}",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        print(f"  FAIL: {name} — unexpected error: {exc}", file=sys.stderr)
+        return 1
+
+
+def expect_errno(name: str, fn: Callable[[], None], expected: int) -> int:
+    try:
+        fn()
+        print(
+            f"  FAIL: {name} — expected errno {expected} "
+            f"({errno.errorcode.get(expected, '?')}), but syscall succeeded",
+            file=sys.stderr,
+        )
+        return 1
+    except OSError as exc:
+        if exc.errno == expected:
+            print(
+                f"  PASS: {name} (errno={expected} "
+                f"{errno.errorcode.get(expected, '?')})"
+            )
+            return 0
+        print(
+            f"  FAIL: {name} — expected errno {expected}, got {exc.errno}: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        print(f"  FAIL: {name} — expected OSError, got {exc}", file=sys.stderr)
+        return 1
+
+
+def skip(name: str, reason: str) -> int:
+    print(f"  SKIP: {name} — {reason}")
+    return 0
+
+
+def case_dir(root: str, name: str) -> str:
+    path = os.path.join(root, name)
+    if os.path.exists(path):
+        shutil.rmtree(path)
+    os.makedirs(path)
+    return path
+
+
+def _syscall_nr_open() -> int:
+    table = {
+        "x86_64": 2,
+        "aarch64": 56,
+    }
+    machine = platform.machine()
+    if machine not in table:
+        raise OSError(
+            errno.ENOSYS,
+            f"unsupported architecture for open: {machine}",
+        )
+    return table[machine]
+
+
+def sys_open(path: str, flags: int, mode: int = 0) -> int:
+    """open(path, flags[, mode]) via raw syscall (openat on aarch64)."""
+    libc = ctypes.CDLL(None, use_errno=True)
+    syscall_fn = libc.syscall
+    syscall_fn.restype = ctypes.c_long
+
+    path_buf = path.encode()
+    if platform.machine() == "x86_64":
+        ret = int(
+            syscall_fn(
+                _syscall_nr_open(),
+                ctypes.c_char_p(path_buf),
+                flags,
+                mode,
+            )
+        )
+    else:
+        ret = int(
+            syscall_fn(
+                _syscall_nr_open(),
+                AT_FDCWD,
+                ctypes.c_char_p(path_buf),
+                flags,
+                mode,
+            )
+        )
+    if ret < 0:
+        err = ctypes.get_errno()
+        raise OSError(err, os.strerror(err))
+    return ret
+
+
+def _get_test_user() -> pwd.struct_passwd:
+    try:
+        return pwd.getpwnam(TEST_USER)
+    except KeyError as exc:
+        raise OSError(
+            errno.ENOENT,
+            f"test user {TEST_USER!r} not found (LTP prot_hsymlinks creates it)",
+        ) from exc
+
+
+def _drop_to_user(uid: int, gid: int) -> None:
+    ruid, _, suid = os.getresuid()
+    rgid, _, sgid = os.getresgid()
+    os.setgroups([])
+    os.setresgid(rgid, gid, sgid)
+    os.setresuid(ruid, uid, suid)
+
+
+def _restore_effective_ids(orig_euid: int, orig_egid: int) -> None:
+    ruid, _, suid = os.getresuid()
+    rgid, _, sgid = os.getresgid()
+    os.setresuid(ruid, orig_euid, suid)
+    os.setresgid(rgid, orig_egid, sgid)
+
+
+def _make_sticky_subdir(parent: str, name: str, owner_uid: int, owner_gid: int) -> str:
+    path = os.path.join(parent, name)
+    os.makedirs(path, MODE_WORLD_WRITABLE)
+    os.chown(path, owner_uid, owner_gid)
+    os.chmod(path, MODE_STICKY_WORLD)
+    return path
+
+
+def test_open_other_symlink_in_sticky_dir_rejects_dir_owner(root: str) -> int:
+    # Related LTP cases: prot_hsymlinks
+    # Sticky dir owner must not follow another user's symlink (fs.protected_symlinks).
+    if os.geteuid() != 0:
+        return skip(
+            "open other symlink in sticky dir rejects dir owner (prot_hsymlinks)",
+            "requires root",
+        )
+
+    try:
+        hsym = _get_test_user()
+    except OSError as exc:
+        return skip(
+            "open other symlink in sticky dir rejects dir owner (prot_hsymlinks)",
+            str(exc),
+        )
+
+    workdir = case_dir(root, "prot_slink_root_sticky")
+    target = os.path.join(workdir, "root.hs")
+    with open(target, "wb"):
+        pass
+
+    sticky_root = _make_sticky_subdir(workdir, "tmp_root", 0, 0)
+    link = os.path.join(sticky_root, "link")
+
+    orig_euid = os.geteuid()
+    orig_egid = os.getegid()
+    try:
+        _drop_to_user(hsym.pw_uid, hsym.pw_gid)
+        os.symlink(target, link)
+    finally:
+        _restore_effective_ids(orig_euid, orig_egid)
+
+    def run_root_open_other_symlink() -> None:
+        fd = sys_open(link, O_RDONLY)
+        os.close(fd)
+
+    return expect_errno(
+        "open(2) on others' symlink in root-owned sticky dir yields EACCES (prot_hsymlinks link_4)",
+        run_root_open_other_symlink,
+        errno.EACCES,
+    )
+
+
+def test_open_own_symlink_in_sticky_dir_succeeds_for_dir_owner(root: str) -> int:
+    # Related LTP cases: prot_hsymlinks
+    # Sticky dir owner may follow symlinks they own (fs.protected_symlinks exception).
+    if os.geteuid() != 0:
+        return skip(
+            "open own symlink in sticky dir succeeds for dir owner (prot_hsymlinks)",
+            "requires root",
+        )
+
+    try:
+        hsym = _get_test_user()
+    except OSError as exc:
+        return skip(
+            "open own symlink in sticky dir succeeds for dir owner (prot_hsymlinks)",
+            str(exc),
+        )
+
+    workdir = case_dir(root, "prot_slink_hsym_sticky")
+    target = os.path.join(workdir, "root.hs")
+    with open(target, "wb"):
+        pass
+
+    sticky_hsym = _make_sticky_subdir(workdir, "tmp_hsym", hsym.pw_uid, hsym.pw_gid)
+    link = os.path.join(sticky_hsym, "link")
+
+    orig_euid = os.geteuid()
+    orig_egid = os.getegid()
+    try:
+        _drop_to_user(hsym.pw_uid, hsym.pw_gid)
+        os.symlink(target, link)
+    finally:
+        _restore_effective_ids(orig_euid, orig_egid)
+
+    def run_hsym_open_own_symlink() -> None:
+        _drop_to_user(hsym.pw_uid, hsym.pw_gid)
+        try:
+            fd = sys_open(link, O_RDONLY)
+            os.close(fd)
+        finally:
+            _restore_effective_ids(orig_euid, orig_egid)
+
+    return expect_ok(
+        "open(2) on own symlink in hsym-owned sticky dir succeeds (prot_hsymlinks link_6)",
+        run_hsym_open_own_symlink,
+    )
+
+
+TESTS: list[tuple[str, str, Callable[..., int]]] = [
+    (
+        "1",
+        "sticky dir owner cannot open another user's symlink (prot_hsymlinks link_4)",
+        test_open_other_symlink_in_sticky_dir_rejects_dir_owner,
+    ),
+    (
+        "2",
+        "sticky dir owner can open own symlink (prot_hsymlinks link_6)",
+        test_open_own_symlink_in_sticky_dir_succeeds_for_dir_owner,
+    ),
+]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="fs.protected_symlinks policy missing on Curvine FUSE — reproducer",
+    )
+    parser.add_argument(
+        "--dir",
+        default=DEFAULT_DIR,
+        help="Base test directory (must be on the Curvine FUSE mount)",
+    )
+    parser.add_argument(
+        "--allow-non-mount",
+        action="store_true",
+        help="Skip FUSE mount check; for local debugging only (default: False)",
+    )
+    args = parser.parse_args()
+
+    if not sys.platform.startswith("linux"):
+        print("SKIP: Linux-only syscalls", file=sys.stderr)
+        return 0
+
+    if os.geteuid() != 0:
+        print("WARNING: not running as root", file=sys.stderr)
+
+    root = os.path.abspath(args.dir)
+    os.makedirs(root, exist_ok=True)
+
+    if args.allow_non_mount:
+        print(
+            "WARNING: --allow-non-mount set; results may not reflect Curvine FUSE behaviour",
+            file=sys.stderr,
+        )
+
+    print(f"Running protected-symlinks reproducer under {root}\n")
+
+    fail = 0
+    for num, title, test_fn in TESTS:
+        print(f"[case {num}] {title}:")
+        fail += test_fn(root)
+        print()
+
+    total = len(TESTS)
+    passed = total - fail
+    print(f"Summary: {passed}/{total} passed, {fail}/{total} failed")
+    return 1 if fail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/build/tests/scripts/curvine_ltp_renameat2_flags_repro.py
+++ b/build/tests/scripts/curvine_ltp_renameat2_flags_repro.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+#  // Copyright 2025 OPPO.
+#  //
+#  // Licensed under the Apache License, Version 2.0 (the "License");
+#  // you may not use this file except in compliance with the License.
+#  // You may obtain a copy of the License at
+#  //
+#  //     http://www.apache.org/licenses/LICENSE-2.0
+#  //
+#  // Unless required by applicable law or agreed to in writing, software
+#  // distributed under the License is distributed on an "AS IS" BASIS,
+#  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  // See the License for the specific language governing permissions and
+#  // limitations under the License.
+
+"""
+renameat2(2) extended flags not implemented on Curvine FUSE — reproducer for LTP failures.
+
+Root cause: Curvine FUSE rejects RENAME_EXCHANGE and RENAME_NOREPLACE renameat2(2)
+operations that should succeed, returning EINVAL instead of performing the atomic
+rename or exchange.
+
+Covered LTP cases (each line is one minimal repro scenario):
+  renameat201 — RENAME_EXCHANGE with both paths present must succeed (TFAIL test 2)
+  renameat201 — RENAME_NOREPLACE with absent destination must succeed (TFAIL test 4)
+  renameat202 — RENAME_EXCHANGE must succeed to atomically swap two existing files (TFAIL)
+
+Usage:
+    python3 curvine_ltp_renameat2_flags_repro.py --dir /curvine-fuse/fuse-test
+    python3 curvine_ltp_renameat2_flags_repro.py --dir /curvine-fuse/fuse-test --allow-non-mount
+"""
+
+import argparse
+import ctypes
+import errno
+import os
+import platform
+import shutil
+import sys
+from typing import Callable
+
+DEFAULT_DIR = "/curvine-fuse/fuse-test"
+
+RENAME_NOREPLACE = 1 << 0
+RENAME_EXCHANGE = 1 << 1
+
+
+def expect_ok(name: str, fn: Callable[[], None]) -> int:
+    try:
+        fn()
+        print(f"  PASS: {name}")
+        return 0
+    except OSError as exc:
+        print(
+            f"  FAIL: {name} — unexpected OSError errno={exc.errno} "
+            f"({errno.errorcode.get(exc.errno, '?')}): {exc}",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        print(f"  FAIL: {name} — unexpected error: {exc}", file=sys.stderr)
+        return 1
+
+
+def expect_errno(name: str, fn: Callable[[], None], expected: int) -> int:
+    try:
+        fn()
+        print(
+            f"  FAIL: {name} — expected errno {expected} "
+            f"({errno.errorcode.get(expected, '?')}), but syscall succeeded",
+            file=sys.stderr,
+        )
+        return 1
+    except OSError as exc:
+        if exc.errno == expected:
+            print(
+                f"  PASS: {name} (errno={expected} "
+                f"{errno.errorcode.get(expected, '?')})"
+            )
+            return 0
+        print(
+            f"  FAIL: {name} — expected errno {expected}, got {exc.errno}: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        print(f"  FAIL: {name} — expected OSError, got {exc}", file=sys.stderr)
+        return 1
+
+
+def skip(name: str, reason: str) -> int:
+    print(f"  SKIP: {name} — {reason}")
+    return 0
+
+
+def case_dir(root: str, name: str) -> str:
+    path = os.path.join(root, name)
+    if os.path.exists(path):
+        shutil.rmtree(path)
+    os.makedirs(path)
+    return path
+
+
+def _syscall_nr_renameat2() -> int:
+    table = {
+        "x86_64": 316,
+        "aarch64": 276,
+    }
+    machine = platform.machine()
+    if machine not in table:
+        raise OSError(
+            errno.ENOSYS,
+            f"unsupported architecture for renameat2: {machine}",
+        )
+    return table[machine]
+
+
+def sys_renameat2(
+    olddirfd: int,
+    oldpath: str,
+    newdirfd: int,
+    newpath: str,
+    flags: int,
+) -> None:
+    """renameat2(olddirfd, oldpath, newdirfd, newpath, flags) via raw syscall."""
+    libc = ctypes.CDLL(None, use_errno=True)
+    syscall_fn = libc.syscall
+    syscall_fn.restype = ctypes.c_long
+
+    ret = int(
+        syscall_fn(
+            _syscall_nr_renameat2(),
+            olddirfd,
+            ctypes.c_char_p(oldpath.encode()),
+            newdirfd,
+            ctypes.c_char_p(newpath.encode()),
+            flags,
+        )
+    )
+    if ret < 0:
+        err = ctypes.get_errno()
+        raise OSError(err, os.strerror(err))
+
+
+def _open_dir(path: str) -> int:
+    # Curvine FUSE rejects open(2) with O_DIRECTORY (EINVAL); O_RDONLY still
+    # yields a valid directory fd for renameat2(2) dirfd arguments.
+    return os.open(path, os.O_RDONLY)
+
+
+def test_rename_exchange_both_exist(root: str) -> int:
+    # Related LTP cases: renameat201, renameat202
+    # renameat2(2) with RENAME_EXCHANGE must succeed when both source and destination exist.
+    workdir = case_dir(root, "rename_exchange")
+    dir1 = os.path.join(workdir, "test_dir")
+    dir2 = os.path.join(workdir, "test_dir2")
+    os.makedirs(dir1, mode=0o700)
+    os.makedirs(dir2, mode=0o700)
+
+    old_file = os.path.join(dir1, "test_file")
+    new_file = os.path.join(dir2, "test_file2")
+    with open(old_file, "w", encoding="utf-8") as fh:
+        fh.write("content")
+    open(new_file, "w", encoding="utf-8").close()
+
+    olddirfd = _open_dir(dir1)
+    newdirfd = _open_dir(dir2)
+    try:
+
+        def run_exchange() -> None:
+            sys_renameat2(
+                olddirfd,
+                "test_file",
+                newdirfd,
+                "test_file2",
+                RENAME_EXCHANGE,
+            )
+
+        return expect_ok(
+            "renameat2(RENAME_EXCHANGE) succeeds when both paths exist "
+            "(renameat201 test2, renameat202)",
+            run_exchange,
+        )
+    finally:
+        os.close(olddirfd)
+        os.close(newdirfd)
+
+
+def test_rename_noreplace_dest_absent_must_succeed(root: str) -> int:
+    # Related LTP cases: renameat201
+    # renameat2(2) with RENAME_NOREPLACE must succeed when the destination path is absent.
+    workdir = case_dir(root, "rename_noreplace")
+    dir1 = os.path.join(workdir, "test_dir")
+    dir2 = os.path.join(workdir, "test_dir2")
+    os.makedirs(dir1, mode=0o700)
+    os.makedirs(dir2, mode=0o700)
+
+    old_file = os.path.join(dir1, "test_file")
+    open(old_file, "w", encoding="utf-8").close()
+
+    olddirfd = _open_dir(dir1)
+    newdirfd = _open_dir(dir2)
+    try:
+
+        def run_noreplace() -> None:
+            sys_renameat2(
+                olddirfd,
+                "test_file",
+                newdirfd,
+                "test_file3",
+                RENAME_NOREPLACE,
+            )
+
+        return expect_ok(
+            "renameat2(RENAME_NOREPLACE) succeeds when destination is absent "
+            "(renameat201 test4)",
+            run_noreplace,
+        )
+    finally:
+        os.close(olddirfd)
+        os.close(newdirfd)
+
+
+TESTS: list[tuple[str, str, Callable[..., int]]] = [
+    (
+        "1",
+        "RENAME_EXCHANGE succeeds when both files exist (renameat201/202)",
+        test_rename_exchange_both_exist,
+    ),
+    (
+        "2",
+        "RENAME_NOREPLACE succeeds when destination absent (renameat201)",
+        test_rename_noreplace_dest_absent_must_succeed,
+    ),
+]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="renameat2 extended flags not implemented on Curvine FUSE — reproducer",
+    )
+    parser.add_argument(
+        "--dir",
+        default=DEFAULT_DIR,
+        help="Base test directory (must be on the Curvine FUSE mount)",
+    )
+    parser.add_argument(
+        "--allow-non-mount",
+        action="store_true",
+        help="Skip FUSE mount check; for local debugging only (default: False)",
+    )
+    args = parser.parse_args()
+
+    if not sys.platform.startswith("linux"):
+        print("SKIP: Linux-only syscalls", file=sys.stderr)
+        return 0
+
+    if os.geteuid() != 0:
+        print("WARNING: not running as root", file=sys.stderr)
+
+    root = os.path.abspath(args.dir)
+    os.makedirs(root, exist_ok=True)
+
+    if args.allow_non_mount:
+        print(
+            "WARNING: --allow-non-mount set; results may not reflect Curvine FUSE behaviour",
+            file=sys.stderr,
+        )
+
+    print(f"Running renameat2-flags reproducer under {root}\n")
+
+    fail = 0
+    for num, title, test_fn in TESTS:
+        print(f"[case {num}] {title}:")
+        fail += test_fn(root)
+        print()
+
+    total = len(TESTS)
+    passed = total - fail
+    print(f"Summary: {passed}/{total} passed, {fail}/{total} failed")
+    return 1 if fail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/build/tests/scripts/curvine_ltp_security_system_xattr_repro.py
+++ b/build/tests/scripts/curvine_ltp_security_system_xattr_repro.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+#  // Copyright 2025 OPPO.
+#  //
+#  // Licensed under the Apache License, Version 2.0 (the "License");
+#  // you may not use this file except in compliance with the License.
+#  // You may obtain a copy of the License at
+#  //
+#  //     http://www.apache.org/licenses/LICENSE-2.0
+#  //
+#  // Unless required by applicable law or agreed to in writing, software
+#  // distributed under the License is distributed on an "AS IS" BASIS,
+#  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  // See the License for the specific language governing permissions and
+#  // limitations under the License.
+
+"""
+security.*/system.* extended attribute namespace unsupported on Curvine FUSE.
+
+Root cause: security.* namespace xattrs (e.g. security.ltptest1/2) set via
+setxattr(2)/fsetxattr(2)/lsetxattr(2) do not appear in listxattr(2)/
+flistxattr(2)/llistxattr(2) results.  FS_IOC_SETFLAGS for immutable/append-only
+flags returns ENOSYS during setxattr03 setup.
+
+Covered LTP cases (each line is one minimal repro scenario):
+  listxattr01   — setxattr(security.ltptest1) then listxattr must list that name (TFAIL missing)
+  flistxattr01  — fsetxattr(security.ltptest1) then flistxattr must list that name (TFAIL missing)
+  llistxattr01  — lsetxattr on symlink(security.ltptest2) then llistxattr must list it (TFAIL missing)
+  setxattr03    — FS_IOC_SETFLAGS(FS_IMMUTABLE_FL) in setup must succeed (TBROK ENOSYS)
+
+Usage:
+    python3 curvine_ltp_security_system_xattr_repro.py --dir /curvine-fuse/fuse-test
+    python3 curvine_ltp_security_system_xattr_repro.py --dir /curvine-fuse/fuse-test --allow-non-mount
+"""
+
+import argparse
+import ctypes
+import errno
+import os
+import platform
+import shutil
+import sys
+from typing import Callable
+
+DEFAULT_DIR = "/curvine-fuse/fuse-test"
+
+XATTR_CREATE = 0x1
+
+SECURITY_KEY1 = "security.ltptest1"
+SECURITY_KEY2 = "security.ltptest2"
+VALUE = b"test"
+
+FS_IOC_GETFLAGS = 0x80086601
+FS_IOC_SETFLAGS = 0x40086602
+FS_IMMUTABLE_FL = 0x00000010
+
+
+def expect_ok(name: str, fn: Callable[[], None]) -> int:
+    try:
+        fn()
+        print(f"  PASS: {name}")
+        return 0
+    except OSError as exc:
+        print(
+            f"  FAIL: {name} — unexpected OSError errno={exc.errno} "
+            f"({errno.errorcode.get(exc.errno, '?')}): {exc}",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        print(f"  FAIL: {name} — unexpected error: {exc}", file=sys.stderr)
+        return 1
+
+
+def expect_errno(name: str, fn: Callable[[], None], expected: int) -> int:
+    try:
+        fn()
+        print(
+            f"  FAIL: {name} — expected errno {expected} "
+            f"({errno.errorcode.get(expected, '?')}), but syscall succeeded",
+            file=sys.stderr,
+        )
+        return 1
+    except OSError as exc:
+        if exc.errno == expected:
+            print(
+                f"  PASS: {name} (errno={expected} "
+                f"{errno.errorcode.get(expected, '?')})"
+            )
+            return 0
+        print(
+            f"  FAIL: {name} — expected errno {expected}, got {exc.errno}: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        print(f"  FAIL: {name} — expected OSError, got {exc}", file=sys.stderr)
+        return 1
+
+
+def skip(name: str, reason: str) -> int:
+    print(f"  SKIP: {name} — {reason}")
+    return 0
+
+
+def case_dir(root: str, name: str) -> str:
+    path = os.path.join(root, name)
+    if os.path.exists(path):
+        shutil.rmtree(path)
+    os.makedirs(path)
+    return path
+
+
+def _syscall_nr(name: str) -> int:
+    table = {
+        "setxattr": {"x86_64": 188, "aarch64": 5},
+        "lsetxattr": {"x86_64": 189, "aarch64": 6},
+        "fsetxattr": {"x86_64": 190, "aarch64": 7},
+        "listxattr": {"x86_64": 194, "aarch64": 11},
+        "llistxattr": {"x86_64": 195, "aarch64": 12},
+        "flistxattr": {"x86_64": 196, "aarch64": 13},
+    }
+    machine = platform.machine()
+    if name not in table or machine not in table[name]:
+        raise OSError(
+            errno.ENOSYS,
+            f"unsupported architecture for {name}: {machine}",
+        )
+    return table[name][machine]
+
+
+def _raw_syscall(nr: int, *args: int) -> int:
+    libc = ctypes.CDLL(None, use_errno=True)
+    syscall_fn = libc.syscall
+    syscall_fn.restype = ctypes.c_long
+    ret = int(syscall_fn(nr, *args))
+    if ret < 0:
+        err = ctypes.get_errno()
+        raise OSError(err, os.strerror(err))
+    return ret
+
+
+def _ioctl(fd: int, request: int, arg: ctypes.c_void_p) -> None:
+    libc = ctypes.CDLL(None, use_errno=True)
+    ioctl_fn = libc.ioctl
+    ioctl_fn.restype = ctypes.c_int
+    ret = int(ioctl_fn(fd, request, arg))
+    if ret < 0:
+        err = ctypes.get_errno()
+        raise OSError(err, os.strerror(err))
+
+
+def sys_setxattr(path: str, name: str, value: bytes, flags: int = 0) -> None:
+    """setxattr(path, name, value, size, flags) via raw syscall."""
+    _raw_syscall(
+        _syscall_nr("setxattr"),
+        ctypes.c_char_p(path.encode()),
+        ctypes.c_char_p(name.encode()),
+        ctypes.c_char_p(value),
+        len(value),
+        flags,
+    )
+
+
+def sys_lsetxattr(path: str, name: str, value: bytes, flags: int = 0) -> None:
+    """lsetxattr(path, name, value, size, flags) via raw syscall."""
+    _raw_syscall(
+        _syscall_nr("lsetxattr"),
+        ctypes.c_char_p(path.encode()),
+        ctypes.c_char_p(name.encode()),
+        ctypes.c_char_p(value),
+        len(value),
+        flags,
+    )
+
+
+def sys_fsetxattr(fd: int, name: str, value: bytes, flags: int = 0) -> None:
+    """fsetxattr(fd, name, value, size, flags) via raw syscall."""
+    _raw_syscall(
+        _syscall_nr("fsetxattr"),
+        fd,
+        ctypes.c_char_p(name.encode()),
+        ctypes.c_char_p(value),
+        len(value),
+        flags,
+    )
+
+
+def sys_listxattr(path: str, buf: ctypes.Array, size: int) -> int:
+    """listxattr(path, list, size) via raw syscall."""
+    return _raw_syscall(
+        _syscall_nr("listxattr"),
+        ctypes.c_char_p(path.encode()),
+        ctypes.cast(buf, ctypes.c_void_p),
+        size,
+    )
+
+
+def sys_llistxattr(path: str, buf: ctypes.Array, size: int) -> int:
+    """llistxattr(path, list, size) via raw syscall."""
+    return _raw_syscall(
+        _syscall_nr("llistxattr"),
+        ctypes.c_char_p(path.encode()),
+        ctypes.cast(buf, ctypes.c_void_p),
+        size,
+    )
+
+
+def sys_flistxattr(fd: int, buf: ctypes.Array, size: int) -> int:
+    """flistxattr(fd, list, size) via raw syscall."""
+    return _raw_syscall(
+        _syscall_nr("flistxattr"),
+        fd,
+        ctypes.cast(buf, ctypes.c_void_p),
+        size,
+    )
+
+
+def _xattr_names_from_buffer(buf: bytes, listed: int) -> list[str]:
+    names: list[str] = []
+    i = 0
+    while i < listed:
+        end = buf.find(b"\x00", i, listed)
+        if end == -1:
+            break
+        if end > i:
+            names.append(buf[i:end].decode())
+        i = end + 1
+    return names
+
+
+def test_listxattr_includes_security_xattr(root: str) -> int:
+    # Related LTP cases: listxattr01
+    # listxattr(2) must include security.* names set via setxattr(2) on the file.
+    if os.geteuid() != 0:
+        return skip("listxattr lists security xattr", "requires root")
+
+    workdir = case_dir(root, "listxattr_security")
+    target = os.path.join(workdir, "testfile")
+    fd = os.open(target, os.O_CREAT | os.O_RDWR, 0o644)
+    os.close(fd)
+    sys_setxattr(target, SECURITY_KEY1, VALUE, flags=XATTR_CREATE)
+
+    def run() -> None:
+        buf = ctypes.create_string_buffer(128)
+        ret = sys_listxattr(target, buf, 128)
+        names = _xattr_names_from_buffer(bytes(buf[:ret]), ret)
+        if SECURITY_KEY1 not in names:
+            raise OSError(
+                errno.ENODATA,
+                f"missing attribute {SECURITY_KEY1} in listxattr result {names}",
+            )
+
+    return expect_ok(
+        "setxattr(security.ltptest1) then listxattr lists that name (listxattr01)",
+        run,
+    )
+
+
+def test_flistxattr_includes_security_xattr(root: str) -> int:
+    # Related LTP cases: flistxattr01
+    # flistxattr(2) must include security.* names set via fsetxattr(2) on the fd.
+    if os.geteuid() != 0:
+        return skip("flistxattr lists security xattr", "requires root")
+
+    workdir = case_dir(root, "flistxattr_security")
+    target = os.path.join(workdir, "testfile")
+    fd = os.open(target, os.O_CREAT | os.O_RDWR, 0o644)
+    sys_fsetxattr(fd, SECURITY_KEY1, VALUE, flags=XATTR_CREATE)
+
+    def run() -> None:
+        buf = ctypes.create_string_buffer(128)
+        ret = sys_flistxattr(fd, buf, 128)
+        names = _xattr_names_from_buffer(bytes(buf[:ret]), ret)
+        if SECURITY_KEY1 not in names:
+            raise OSError(
+                errno.ENODATA,
+                f"missing attribute {SECURITY_KEY1} in flistxattr result {names}",
+            )
+
+    try:
+        return expect_ok(
+            "fsetxattr(security.ltptest1) then flistxattr lists that name (flistxattr01)",
+            run,
+        )
+    finally:
+        os.close(fd)
+
+
+def test_llistxattr_includes_symlink_security_xattr(root: str) -> int:
+    # Related LTP cases: llistxattr01
+    # llistxattr(2) on a symlink must list security.* set on the link via lsetxattr(2).
+    if os.geteuid() != 0:
+        return skip("llistxattr lists symlink security xattr", "requires root")
+
+    workdir = case_dir(root, "llistxattr_security")
+    testfile = os.path.join(workdir, "testfile")
+    symlink = os.path.join(workdir, "symlink")
+    fd = os.open(testfile, os.O_CREAT | os.O_RDWR, 0o644)
+    os.close(fd)
+    os.symlink("testfile", symlink)
+    sys_lsetxattr(testfile, SECURITY_KEY1, VALUE, flags=XATTR_CREATE)
+    sys_lsetxattr(symlink, SECURITY_KEY2, VALUE, flags=XATTR_CREATE)
+
+    def run() -> None:
+        buf = ctypes.create_string_buffer(128)
+        ret = sys_llistxattr(symlink, buf, 128)
+        names = _xattr_names_from_buffer(bytes(buf[:ret]), ret)
+        if SECURITY_KEY2 not in names:
+            raise OSError(
+                errno.ENODATA,
+                f"missing attribute {SECURITY_KEY2} in llistxattr result {names}",
+            )
+
+    return expect_ok(
+        "lsetxattr on symlink(security.ltptest2) then llistxattr lists it (llistxattr01)",
+        run,
+    )
+
+
+def test_fs_ioc_setflags_immutable_supported(root: str) -> int:
+    # Related LTP cases: setxattr03
+    # FS_IOC_SETFLAGS(2) with FS_IMMUTABLE_FL must succeed during immutable setup.
+    if os.geteuid() != 0:
+        return skip("FS_IOC_SETFLAGS immutable", "requires root")
+
+    workdir = case_dir(root, "setxattr03_immutable_setup")
+    target = os.path.join(workdir, "setxattr03immutable")
+    fd = os.open(target, os.O_CREAT | os.O_RDWR, 0o644)
+
+    def run() -> None:
+        flags = ctypes.c_int(0)
+        _ioctl(fd, FS_IOC_GETFLAGS, ctypes.byref(flags))
+        flags.value |= FS_IMMUTABLE_FL
+        _ioctl(fd, FS_IOC_SETFLAGS, ctypes.byref(flags))
+
+    try:
+        return expect_ok(
+            "FS_IOC_SETFLAGS(FS_IMMUTABLE_FL) succeeds on FUSE file (setxattr03 setup)",
+            run,
+        )
+    finally:
+        os.close(fd)
+
+
+TESTS: list[tuple[str, str, Callable[..., int]]] = [
+    (
+        "1",
+        "listxattr lists security.ltptest1 after setxattr (listxattr01)",
+        test_listxattr_includes_security_xattr,
+    ),
+    (
+        "2",
+        "flistxattr lists security.ltptest1 after fsetxattr (flistxattr01)",
+        test_flistxattr_includes_security_xattr,
+    ),
+    (
+        "3",
+        "llistxattr lists security.ltptest2 on symlink after lsetxattr (llistxattr01)",
+        test_llistxattr_includes_symlink_security_xattr,
+    ),
+    (
+        "4",
+        "FS_IOC_SETFLAGS immutable flag supported (setxattr03 setup)",
+        test_fs_ioc_setflags_immutable_supported,
+    ),
+]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="security.*/system.* xattr namespace unsupported — reproducer",
+    )
+    parser.add_argument(
+        "--dir",
+        default=DEFAULT_DIR,
+        help="Base test directory (must be on the Curvine FUSE mount)",
+    )
+    parser.add_argument(
+        "--allow-non-mount",
+        action="store_true",
+        help="Skip FUSE mount check; for local debugging only (default: False)",
+    )
+    args = parser.parse_args()
+
+    if not sys.platform.startswith("linux"):
+        print("SKIP: Linux-only syscalls", file=sys.stderr)
+        return 0
+
+    if os.geteuid() != 0:
+        print("WARNING: not running as root", file=sys.stderr)
+
+    root = os.path.abspath(args.dir)
+    os.makedirs(root, exist_ok=True)
+
+    if args.allow_non_mount:
+        print(
+            "WARNING: --allow-non-mount set; results may not reflect Curvine FUSE behaviour",
+            file=sys.stderr,
+        )
+
+    print(f"Running security-system-xattr reproducer under {root}\n")
+
+    fail = 0
+    for num, title, test_fn in TESTS:
+        print(f"[case {num}] {title}:")
+        fail += test_fn(root)
+        print()
+
+    total = len(TESTS)
+    passed = total - fail
+    print(f"Summary: {passed}/{total} passed, {fail}/{total} failed")
+    return 1 if fail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/build/tests/scripts/curvine_ltp_setgid_gid_repro.py
+++ b/build/tests/scripts/curvine_ltp_setgid_gid_repro.py
@@ -1,0 +1,455 @@
+#!/usr/bin/env python3
+#  // Copyright 2025 OPPO.
+#  //
+#  // Licensed under the Apache License, Version 2.0 (the "License");
+#  // you may not use this file except in compliance with the License.
+#  // You may obtain a copy of the License at
+#  //
+#  //     http://www.apache.org/licenses/LICENSE-2.0
+#  //
+#  // Unless required by applicable law or agreed to in writing, software
+#  // distributed under the License is distributed on an "AS IS" BASIS,
+#  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  // See the License for the specific language governing permissions and
+#  // limitations under the License.
+
+"""
+setgid directory GID inheritance missing on Curvine FUSE — reproducer for LTP failures.
+
+Root cause: when a directory has the S_ISGID bit set, new files and subdirectories
+created inside it must inherit the parent directory's group ID (and directories
+must also inherit S_ISGID).  Curvine assigns the creating process's effective GID
+instead, so stat() reports the wrong st_gid.
+
+Covered LTP cases (each line is one minimal repro scenario):
+  creat08 — creat(2) in S_ISGID directory as nobody must yield parent dir gid (TFAIL block2)
+  open10  — open(O_CREAT|O_EXCL|O_RDWR) in S_ISGID directory as nobody must yield parent gid
+  mkdir02 — mkdir(2) in S_ISGID directory must inherit parent gid and S_ISGID (TFAIL)
+
+Usage:
+    python3 curvine_ltp_setgid_gid_repro.py --dir /curvine-fuse/fuse-test
+    python3 curvine_ltp_setgid_gid_repro.py --dir /curvine-fuse/fuse-test --allow-non-mount
+"""
+
+import argparse
+import ctypes
+import errno
+import grp
+import os
+import platform
+import pwd
+import shutil
+import stat
+import sys
+from typing import Callable
+
+DEFAULT_DIR = "/curvine-fuse/fuse-test"
+
+AT_FDCWD = -100
+O_CREAT = 0o100
+O_EXCL = 0o200
+O_RDWR = 2
+O_WRONLY = 1
+O_TRUNC = 0o1000
+
+MODE_RWX = 0o777
+MODE_SGID_DIR = stat.S_ISGID | MODE_RWX
+
+
+def expect_ok(name: str, fn: Callable[[], None]) -> int:
+    try:
+        fn()
+        print(f"  PASS: {name}")
+        return 0
+    except OSError as exc:
+        print(
+            f"  FAIL: {name} — unexpected OSError errno={exc.errno} "
+            f"({errno.errorcode.get(exc.errno, '?')}): {exc}",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        print(f"  FAIL: {name} — unexpected error: {exc}", file=sys.stderr)
+        return 1
+
+
+def expect_errno(name: str, fn: Callable[[], None], expected: int) -> int:
+    try:
+        fn()
+        print(
+            f"  FAIL: {name} — expected errno {expected} "
+            f"({errno.errorcode.get(expected, '?')}), but syscall succeeded",
+            file=sys.stderr,
+        )
+        return 1
+    except OSError as exc:
+        if exc.errno == expected:
+            print(
+                f"  PASS: {name} (errno={expected} "
+                f"{errno.errorcode.get(expected, '?')})"
+            )
+            return 0
+        print(
+            f"  FAIL: {name} — expected errno {expected}, got {exc.errno}: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        print(f"  FAIL: {name} — expected OSError, got {exc}", file=sys.stderr)
+        return 1
+
+
+def skip(name: str, reason: str) -> int:
+    print(f"  SKIP: {name} — {reason}")
+    return 0
+
+
+def case_dir(root: str, name: str) -> str:
+    path = os.path.join(root, name)
+    if os.path.exists(path):
+        shutil.rmtree(path)
+    os.makedirs(path)
+    return path
+
+
+def _syscall_nr_open() -> int:
+    table = {
+        "x86_64": 2,
+        "aarch64": 56,
+    }
+    machine = platform.machine()
+    if machine not in table:
+        raise OSError(
+            errno.ENOSYS,
+            f"unsupported architecture for open: {machine}",
+        )
+    return table[machine]
+
+
+def _syscall_nr_creat() -> int:
+    table = {
+        "x86_64": 85,
+        "aarch64": 56,
+    }
+    machine = platform.machine()
+    if machine not in table:
+        raise OSError(
+            errno.ENOSYS,
+            f"unsupported architecture for creat: {machine}",
+        )
+    return table[machine]
+
+
+def sys_creat(path: str, mode: int) -> int:
+    """creat(path, mode) via raw syscall (openat on aarch64)."""
+    libc = ctypes.CDLL(None, use_errno=True)
+    syscall_fn = libc.syscall
+    syscall_fn.restype = ctypes.c_long
+
+    path_buf = path.encode()
+    if platform.machine() == "x86_64":
+        ret = int(
+            syscall_fn(
+                _syscall_nr_creat(),
+                ctypes.c_char_p(path_buf),
+                mode,
+            )
+        )
+    else:
+        flags = O_CREAT | O_WRONLY | O_TRUNC
+        ret = int(
+            syscall_fn(
+                _syscall_nr_creat(),
+                AT_FDCWD,
+                ctypes.c_char_p(path_buf),
+                flags,
+                mode,
+            )
+        )
+    if ret < 0:
+        err = ctypes.get_errno()
+        raise OSError(err, os.strerror(err))
+    return ret
+
+
+def sys_open(path: str, flags: int, mode: int = 0) -> int:
+    """open(path, flags, mode) via raw syscall (openat on aarch64)."""
+    libc = ctypes.CDLL(None, use_errno=True)
+    syscall_fn = libc.syscall
+    syscall_fn.restype = ctypes.c_long
+
+    path_buf = path.encode()
+    if platform.machine() == "x86_64":
+        ret = int(
+            syscall_fn(
+                _syscall_nr_open(),
+                ctypes.c_char_p(path_buf),
+                flags,
+                mode,
+            )
+        )
+    else:
+        ret = int(
+            syscall_fn(
+                _syscall_nr_open(),
+                AT_FDCWD,
+                ctypes.c_char_p(path_buf),
+                flags,
+                mode,
+            )
+        )
+    if ret < 0:
+        err = ctypes.get_errno()
+        raise OSError(err, os.strerror(err))
+    return ret
+
+
+def _get_free_gid(skip: int) -> int:
+    for gid in range(1, 32768):
+        if gid == skip:
+            continue
+        try:
+            grp.getgrgid(gid)
+        except KeyError:
+            return gid
+    raise OSError(errno.EDEADLK, "no unused group ID found")
+
+
+def _raise_gid_mismatch(actual: int, expected: int, label: str) -> None:
+    raise OSError(
+        errno.EINVAL,
+        f"{label}: gid got {actual}, expected {expected}",
+    )
+
+
+def _make_setgid_parent(
+    workdir: str,
+    owner_uid: int,
+    owner_gid: int,
+) -> tuple[str, int]:
+    free_gid = _get_free_gid(owner_gid)
+    parent = os.path.join(workdir, "setgid_parent")
+    os.mkdir(parent, MODE_RWX)
+    os.chown(parent, owner_uid, free_gid)
+    os.chmod(parent, MODE_SGID_DIR)
+    parent_stat = os.stat(parent)
+    if not (parent_stat.st_mode & stat.S_ISGID):
+        raise OSError(errno.EINVAL, "S_ISGID not set on parent directory")
+    if parent_stat.st_gid != free_gid:
+        _raise_gid_mismatch(
+            parent_stat.st_gid,
+            free_gid,
+            "parent directory after chown/chmod",
+        )
+    return parent, free_gid
+
+
+def _drop_to_nobody(nobody_uid: int, nobody_gid: int) -> None:
+    ruid, _, suid = os.getresuid()
+    rgid, _, sgid = os.getresgid()
+    os.setresgid(rgid, nobody_gid, sgid)
+    os.setresuid(ruid, nobody_uid, suid)
+
+
+def _restore_effective_ids(orig_euid: int, orig_egid: int) -> None:
+    ruid, _, suid = os.getresuid()
+    rgid, _, sgid = os.getresgid()
+    os.setresuid(ruid, orig_euid, suid)
+    os.setresgid(rgid, orig_egid, sgid)
+
+
+def test_creat_in_setgid_dir_inherits_parent_gid(root: str) -> int:
+    # Related LTP cases: creat08
+    # creat(2) in an S_ISGID directory must assign the parent directory gid, not the process gid.
+    if os.geteuid() != 0:
+        return skip(
+            "creat in setgid dir inherits parent gid (creat08)",
+            "requires root",
+        )
+
+    workdir = case_dir(root, "creat_setgid_gid")
+    nobody = pwd.getpwnam("nobody")
+    parent, expected_gid = _make_setgid_parent(
+        workdir,
+        nobody.pw_uid,
+        nobody.pw_gid,
+    )
+    target = os.path.join(parent, "nosetgid")
+    orig_euid = os.geteuid()
+    orig_egid = os.getegid()
+
+    def run_creat_inherit_gid() -> None:
+        _drop_to_nobody(nobody.pw_uid, nobody.pw_gid)
+        fd = sys_creat(target, MODE_RWX)
+        os.close(fd)
+        child_stat = os.stat(target)
+        if child_stat.st_gid != expected_gid:
+            _raise_gid_mismatch(
+                child_stat.st_gid,
+                expected_gid,
+                "creat in S_ISGID directory",
+            )
+
+    try:
+        return expect_ok(
+            "creat(2) in S_ISGID dir yields parent gid (creat08 block2)",
+            run_creat_inherit_gid,
+        )
+    finally:
+        _restore_effective_ids(orig_euid, orig_egid)
+
+
+def test_open_creat_in_setgid_dir_inherits_parent_gid(root: str) -> int:
+    # Related LTP cases: open10
+    # open(O_CREAT) in an S_ISGID directory must assign the parent directory gid, not the process gid.
+    if os.geteuid() != 0:
+        return skip(
+            "open O_CREAT in setgid dir inherits parent gid (open10)",
+            "requires root",
+        )
+
+    workdir = case_dir(root, "open_setgid_gid")
+    nobody = pwd.getpwnam("nobody")
+    parent, expected_gid = _make_setgid_parent(
+        workdir,
+        nobody.pw_uid,
+        nobody.pw_gid,
+    )
+    target = os.path.join(parent, "nosetgid")
+    orig_euid = os.geteuid()
+    orig_egid = os.getegid()
+    open_flags = O_CREAT | O_EXCL | O_RDWR
+
+    def run_open_creat_inherit_gid() -> None:
+        _drop_to_nobody(nobody.pw_uid, nobody.pw_gid)
+        fd = sys_open(target, open_flags, MODE_RWX)
+        os.close(fd)
+        child_stat = os.stat(target)
+        if child_stat.st_gid != expected_gid:
+            _raise_gid_mismatch(
+                child_stat.st_gid,
+                expected_gid,
+                "open(O_CREAT) in S_ISGID directory",
+            )
+
+    try:
+        return expect_ok(
+            "open(O_CREAT|O_EXCL|O_RDWR) in S_ISGID dir yields parent gid (open10 block2)",
+            run_open_creat_inherit_gid,
+        )
+    finally:
+        _restore_effective_ids(orig_euid, orig_egid)
+
+
+def test_mkdir_in_setgid_dir_inherits_parent_gid_and_sgid(root: str) -> int:
+    # Related LTP cases: mkdir02
+    # mkdir(2) in an S_ISGID directory must inherit parent gid and the S_ISGID bit.
+    if os.geteuid() != 0:
+        return skip(
+            "mkdir in setgid dir inherits gid and S_ISGID (mkdir02)",
+            "requires root",
+        )
+
+    workdir = case_dir(root, "mkdir_setgid_gid")
+    nobody = pwd.getpwnam("nobody")
+    parent, expected_gid = _make_setgid_parent(
+        workdir,
+        os.getuid(),
+        nobody.pw_gid,
+    )
+    child = os.path.join(parent, "testdir2")
+    orig_euid = os.geteuid()
+    orig_egid = os.getegid()
+
+    def run_mkdir_inherit_gid() -> None:
+        _drop_to_nobody(nobody.pw_uid, nobody.pw_gid)
+        os.mkdir(child, MODE_RWX)
+        child_stat = os.stat(child)
+        if child_stat.st_gid != expected_gid:
+            _raise_gid_mismatch(
+                child_stat.st_gid,
+                expected_gid,
+                "mkdir in S_ISGID directory",
+            )
+        if not (child_stat.st_mode & stat.S_ISGID):
+            raise OSError(
+                errno.EINVAL,
+                "mkdir in S_ISGID directory: S_ISGID not inherited",
+            )
+
+    try:
+        return expect_ok(
+            "mkdir(2) in S_ISGID dir inherits parent gid and S_ISGID (mkdir02)",
+            run_mkdir_inherit_gid,
+        )
+    finally:
+        _restore_effective_ids(orig_euid, orig_egid)
+
+
+TESTS: list[tuple[str, str, Callable[..., int]]] = [
+    (
+        "1",
+        "creat(2) in S_ISGID dir inherits parent gid (creat08)",
+        test_creat_in_setgid_dir_inherits_parent_gid,
+    ),
+    (
+        "2",
+        "open(O_CREAT) in S_ISGID dir inherits parent gid (open10)",
+        test_open_creat_in_setgid_dir_inherits_parent_gid,
+    ),
+    (
+        "3",
+        "mkdir(2) in S_ISGID dir inherits parent gid and S_ISGID (mkdir02)",
+        test_mkdir_in_setgid_dir_inherits_parent_gid_and_sgid,
+    ),
+]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="setgid directory GID inheritance missing on Curvine FUSE — reproducer",
+    )
+    parser.add_argument(
+        "--dir",
+        default=DEFAULT_DIR,
+        help="Base test directory (must be on the Curvine FUSE mount)",
+    )
+    parser.add_argument(
+        "--allow-non-mount",
+        action="store_true",
+        help="Skip FUSE mount check; for local debugging only (default: False)",
+    )
+    args = parser.parse_args()
+
+    if not sys.platform.startswith("linux"):
+        print("SKIP: Linux-only syscalls", file=sys.stderr)
+        return 0
+
+    if os.geteuid() != 0:
+        print("WARNING: not running as root", file=sys.stderr)
+
+    root = os.path.abspath(args.dir)
+    os.makedirs(root, exist_ok=True)
+
+    if args.allow_non_mount:
+        print(
+            "WARNING: --allow-non-mount set; results may not reflect Curvine FUSE behaviour",
+            file=sys.stderr,
+        )
+
+    print(f"Running setgid-gid reproducer under {root}\n")
+
+    fail = 0
+    for num, title, test_fn in TESTS:
+        print(f"[case {num}] {title}:")
+        fail += test_fn(root)
+        print()
+
+    total = len(TESTS)
+    passed = total - fail
+    print(f"Summary: {passed}/{total} passed, {fail}/{total} failed")
+    return 1 if fail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/build/tests/scripts/curvine_ltp_user_xattr_persist_repro.py
+++ b/build/tests/scripts/curvine_ltp_user_xattr_persist_repro.py
@@ -1,0 +1,513 @@
+#!/usr/bin/env python3
+#  // Copyright 2025 OPPO.
+#  //
+#  // Licensed under the Apache License, Version 2.0 (the "License");
+#  // you may not use this file except in compliance with the License.
+#  // You may obtain a copy of the License at
+#  //
+#  //     http://www.apache.org/licenses/LICENSE-2.0
+#  //
+#  // Unless required by applicable law or agreed to in writing, software
+#  // distributed under the License is distributed on an "AS IS" BASIS,
+#  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  // See the License for the specific language governing permissions and
+#  // limitations under the License.
+
+"""
+user.* extended attributes not persisted on Curvine FUSE — reproducer for LTP failures.
+
+Root cause: setxattr(2)/lsetxattr(2)/fsetxattr(2) on user.* (and other) namespaces
+appear to succeed, but subsequent getxattr(2)/lgetxattr(2)/fgetxattr(2) return
+ENODATA as if the attribute was never stored.  removexattr(2) on a missing
+attribute incorrectly succeeds instead of returning ENODATA.
+
+Covered LTP cases (each line is one minimal repro scenario):
+  getxattr01 — setxattr(user.testkey) then getxattr must return the stored value (TFAIL ENODATA)
+  getxattr01 — setxattr(user.testkey) then getxattr(buf=1) must return ERANGE (TFAIL ENODATA)
+  getxattr03 — setxattr(user.testkey) then getxattr(NULL,0) must return value size (TFAIL ENODATA)
+  lgetxattr01 — lsetxattr on symlink then lgetxattr must read symlink xattr (TFAIL ENODATA)
+  lgetxattr02 — lsetxattr on symlink then lgetxattr(buf=1) must return ERANGE (TFAIL ENODATA)
+  fgetxattr03 — fsetxattr(user.testkey) then fgetxattr(NULL,0) must return value size (TFAIL ENODATA)
+  removexattr02 — removexattr(user.test) on file without that xattr must fail ENODATA (TFAIL success)
+
+Usage:
+    python3 curvine_ltp_user_xattr_persist_repro.py --dir /curvine-fuse/fuse-test
+    python3 curvine_ltp_user_xattr_persist_repro.py --dir /curvine-fuse/fuse-test --allow-non-mount
+"""
+
+import argparse
+import ctypes
+import errno
+import os
+import platform
+import shutil
+import sys
+from typing import Callable
+
+DEFAULT_DIR = "/curvine-fuse/fuse-test"
+
+XATTR_CREATE = 0x1
+
+# getxattr01 / fgetxattr03
+USER_TEST_KEY = "user.testkey"
+USER_TEST_VALUE = b"this is a test value"
+USER_TEST_VALUE_SIZE = len(USER_TEST_VALUE)
+
+# getxattr03
+USER_TEST_KEY_03 = "user.testkey"
+USER_TEST_VALUE_03 = b"test value"
+USER_TEST_VALUE_SIZE_03 = len(USER_TEST_VALUE_03)
+
+# lgetxattr01
+SECURITY_KEY1 = "security.ltptest1"
+SECURITY_KEY2 = "security.ltptest2"
+VALUE1 = b"test1"
+VALUE2 = b"test2"
+
+# lgetxattr02
+SECURITY_KEY = "security.ltptest"
+SECURITY_VALUE = b"this is a test value"
+
+# removexattr02
+REMOVE_KEY = "user.test"
+
+
+def expect_ok(name: str, fn: Callable[[], None]) -> int:
+    try:
+        fn()
+        print(f"  PASS: {name}")
+        return 0
+    except OSError as exc:
+        print(
+            f"  FAIL: {name} — unexpected OSError errno={exc.errno} "
+            f"({errno.errorcode.get(exc.errno, '?')}): {exc}",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        print(f"  FAIL: {name} — unexpected error: {exc}", file=sys.stderr)
+        return 1
+
+
+def expect_errno(name: str, fn: Callable[[], None], expected: int) -> int:
+    try:
+        fn()
+        print(
+            f"  FAIL: {name} — expected errno {expected} "
+            f"({errno.errorcode.get(expected, '?')}), but syscall succeeded",
+            file=sys.stderr,
+        )
+        return 1
+    except OSError as exc:
+        if exc.errno == expected:
+            print(
+                f"  PASS: {name} (errno={expected} "
+                f"{errno.errorcode.get(expected, '?')})"
+            )
+            return 0
+        print(
+            f"  FAIL: {name} — expected errno {expected}, got {exc.errno}: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        print(f"  FAIL: {name} — expected OSError, got {exc}", file=sys.stderr)
+        return 1
+
+
+def skip(name: str, reason: str) -> int:
+    print(f"  SKIP: {name} — {reason}")
+    return 0
+
+
+def case_dir(root: str, name: str) -> str:
+    path = os.path.join(root, name)
+    if os.path.exists(path):
+        shutil.rmtree(path)
+    os.makedirs(path)
+    return path
+
+
+def _syscall_nr(name: str) -> int:
+    table = {
+        "setxattr": {"x86_64": 188, "aarch64": 5},
+        "lsetxattr": {"x86_64": 189, "aarch64": 6},
+        "fsetxattr": {"x86_64": 190, "aarch64": 7},
+        "getxattr": {"x86_64": 191, "aarch64": 8},
+        "lgetxattr": {"x86_64": 192, "aarch64": 9},
+        "fgetxattr": {"x86_64": 193, "aarch64": 10},
+        "removexattr": {"x86_64": 197, "aarch64": 14},
+    }
+    machine = platform.machine()
+    if name not in table or machine not in table[name]:
+        raise OSError(
+            errno.ENOSYS,
+            f"unsupported architecture for {name}: {machine}",
+        )
+    return table[name][machine]
+
+
+def _raw_syscall(nr: int, *args: int) -> int:
+    libc = ctypes.CDLL(None, use_errno=True)
+    syscall_fn = libc.syscall
+    syscall_fn.restype = ctypes.c_long
+    ret = int(syscall_fn(nr, *args))
+    if ret < 0:
+        err = ctypes.get_errno()
+        raise OSError(err, os.strerror(err))
+    return ret
+
+
+def sys_setxattr(path: str, name: str, value: bytes, flags: int = 0) -> None:
+    """setxattr(path, name, value, size, flags) via raw syscall."""
+    _raw_syscall(
+        _syscall_nr("setxattr"),
+        ctypes.c_char_p(path.encode()),
+        ctypes.c_char_p(name.encode()),
+        ctypes.c_char_p(value),
+        len(value),
+        flags,
+    )
+
+
+def sys_lsetxattr(path: str, name: str, value: bytes, flags: int = 0) -> None:
+    """lsetxattr(path, name, value, size, flags) via raw syscall."""
+    _raw_syscall(
+        _syscall_nr("lsetxattr"),
+        ctypes.c_char_p(path.encode()),
+        ctypes.c_char_p(name.encode()),
+        ctypes.c_char_p(value),
+        len(value),
+        flags,
+    )
+
+
+def sys_fsetxattr(fd: int, name: str, value: bytes, flags: int = 0) -> None:
+    """fsetxattr(fd, name, value, size, flags) via raw syscall."""
+    _raw_syscall(
+        _syscall_nr("fsetxattr"),
+        fd,
+        ctypes.c_char_p(name.encode()),
+        ctypes.c_char_p(value),
+        len(value),
+        flags,
+    )
+
+
+def sys_getxattr(path: str, name: str, value: int, size: int) -> int:
+    """getxattr(path, name, value, size) via raw syscall."""
+    return _raw_syscall(
+        _syscall_nr("getxattr"),
+        ctypes.c_char_p(path.encode()),
+        ctypes.c_char_p(name.encode()),
+        value,
+        size,
+    )
+
+
+def sys_lgetxattr(path: str, name: str, value: int, size: int) -> int:
+    """lgetxattr(path, name, value, size) via raw syscall."""
+    return _raw_syscall(
+        _syscall_nr("lgetxattr"),
+        ctypes.c_char_p(path.encode()),
+        ctypes.c_char_p(name.encode()),
+        value,
+        size,
+    )
+
+
+def sys_fgetxattr(fd: int, name: str, value: int, size: int) -> int:
+    """fgetxattr(fd, name, value, size) via raw syscall."""
+    return _raw_syscall(
+        _syscall_nr("fgetxattr"),
+        fd,
+        ctypes.c_char_p(name.encode()),
+        value,
+        size,
+    )
+
+
+def sys_removexattr(path: str, name: str) -> None:
+    """removexattr(path, name) via raw syscall."""
+    _raw_syscall(
+        _syscall_nr("removexattr"),
+        ctypes.c_char_p(path.encode()),
+        ctypes.c_char_p(name.encode()),
+    )
+
+
+def test_getxattr_reads_user_xattr_value(root: str) -> int:
+    # Related LTP cases: getxattr01
+    # getxattr(2) after setxattr(2) on user.* must return the stored attribute value.
+    if os.geteuid() != 0:
+        return skip("getxattr reads user xattr", "requires root")
+
+    workdir = case_dir(root, "getxattr_read_value")
+    target = os.path.join(workdir, "testfile")
+    fd = os.open(target, os.O_CREAT | os.O_RDWR, 0o644)
+    os.close(fd)
+    sys_setxattr(target, USER_TEST_KEY, USER_TEST_VALUE, flags=XATTR_CREATE)
+
+    def run() -> None:
+        buf = ctypes.create_string_buffer(64)
+        ret = sys_getxattr(target, USER_TEST_KEY, ctypes.addressof(buf), 63)
+        if ret != USER_TEST_VALUE_SIZE:
+            raise OSError(
+                errno.EINVAL,
+                f"getxattr returned size {ret}, expected {USER_TEST_VALUE_SIZE}",
+            )
+        if bytes(buf[:ret]) != USER_TEST_VALUE:
+            raise OSError(errno.EINVAL, "getxattr returned unexpected value")
+
+    return expect_ok(
+        "setxattr(user.testkey) then getxattr returns stored value (getxattr01)",
+        run,
+    )
+
+
+def test_getxattr_user_xattr_small_buffer_erange(root: str) -> int:
+    # Related LTP cases: getxattr01
+    # getxattr(2) with buffer smaller than the attribute must fail with ERANGE.
+    if os.geteuid() != 0:
+        return skip("getxattr small buffer ERANGE", "requires root")
+
+    workdir = case_dir(root, "getxattr_erange")
+    target = os.path.join(workdir, "testfile")
+    fd = os.open(target, os.O_CREAT | os.O_RDWR, 0o644)
+    os.close(fd)
+    sys_setxattr(target, USER_TEST_KEY, USER_TEST_VALUE, flags=XATTR_CREATE)
+
+    def run() -> None:
+        buf = ctypes.create_string_buffer(1)
+        sys_getxattr(target, USER_TEST_KEY, ctypes.addressof(buf), 1)
+
+    return expect_errno(
+        "setxattr(user.testkey) then getxattr(buf=1) returns ERANGE (getxattr01)",
+        run,
+        errno.ERANGE,
+    )
+
+
+def test_getxattr_null_buffer_returns_attr_size(root: str) -> int:
+    # Related LTP cases: getxattr03
+    # getxattr(2) with NULL buffer and size 0 must return the attribute value length.
+    if os.geteuid() != 0:
+        return skip("getxattr null buffer size", "requires root")
+
+    workdir = case_dir(root, "getxattr_null_size")
+    target = os.path.join(workdir, "testfile")
+    fd = os.open(target, os.O_CREAT | os.O_RDWR, 0o644)
+    os.close(fd)
+    sys_setxattr(target, USER_TEST_KEY_03, USER_TEST_VALUE_03, flags=XATTR_CREATE)
+
+    def run() -> None:
+        ret = sys_getxattr(target, USER_TEST_KEY_03, 0, 0)
+        if ret != USER_TEST_VALUE_SIZE_03:
+            raise OSError(
+                errno.EINVAL,
+                f"getxattr(NULL,0) returned {ret}, expected {USER_TEST_VALUE_SIZE_03}",
+            )
+
+    return expect_ok(
+        "setxattr(user.testkey) then getxattr(NULL,0) returns value size (getxattr03)",
+        run,
+    )
+
+
+def test_lgetxattr_reads_symlink_xattr(root: str) -> int:
+    # Related LTP cases: lgetxattr01
+    # lgetxattr(2) on a symlink must return the xattr set on the link itself.
+    if os.geteuid() != 0:
+        return skip("lgetxattr reads symlink xattr", "requires root")
+
+    workdir = case_dir(root, "lgetxattr_symlink")
+    testfile = os.path.join(workdir, "testfile")
+    symlink = os.path.join(workdir, "symlink")
+    fd = os.open(testfile, os.O_CREAT | os.O_RDWR, 0o644)
+    os.close(fd)
+    os.symlink("testfile", symlink)
+    sys_lsetxattr(testfile, SECURITY_KEY1, VALUE1, flags=XATTR_CREATE)
+    sys_lsetxattr(symlink, SECURITY_KEY2, VALUE2, flags=XATTR_CREATE)
+
+    def run() -> None:
+        buf = ctypes.create_string_buffer(64)
+        ret = sys_lgetxattr(symlink, SECURITY_KEY2, ctypes.addressof(buf), 64)
+        if ret != len(VALUE2):
+            raise OSError(
+                errno.EINVAL,
+                f"lgetxattr returned size {ret}, expected {len(VALUE2)}",
+            )
+        if bytes(buf[:ret]) != VALUE2:
+            raise OSError(errno.EINVAL, "lgetxattr returned unexpected value")
+
+    return expect_ok(
+        "lsetxattr on symlink then lgetxattr returns link xattr (lgetxattr01)",
+        run,
+    )
+
+
+def test_lgetxattr_symlink_small_buffer_erange(root: str) -> int:
+    # Related LTP cases: lgetxattr02
+    # lgetxattr(2) with buffer too small for the stored xattr must fail with ERANGE.
+    if os.geteuid() != 0:
+        return skip("lgetxattr symlink ERANGE", "requires root")
+
+    workdir = case_dir(root, "lgetxattr_erange")
+    testfile = os.path.join(workdir, "testfile")
+    symlink = os.path.join(workdir, "symlink")
+    fd = os.open(testfile, os.O_CREAT | os.O_RDWR, 0o644)
+    os.close(fd)
+    os.symlink("testfile", symlink)
+    sys_lsetxattr(symlink, SECURITY_KEY, SECURITY_VALUE, flags=XATTR_CREATE)
+
+    def run() -> None:
+        buf = ctypes.create_string_buffer(1)
+        sys_lgetxattr(symlink, SECURITY_KEY, ctypes.addressof(buf), 1)
+
+    return expect_errno(
+        "lsetxattr on symlink then lgetxattr(buf=1) returns ERANGE (lgetxattr02)",
+        run,
+        errno.ERANGE,
+    )
+
+
+def test_fgetxattr_null_buffer_returns_attr_size(root: str) -> int:
+    # Related LTP cases: fgetxattr03
+    # fgetxattr(2) with NULL buffer and size 0 must return the attribute value length.
+    if os.geteuid() != 0:
+        return skip("fgetxattr null buffer size", "requires root")
+
+    workdir = case_dir(root, "fgetxattr_null_size")
+    target = os.path.join(workdir, "testfile")
+    wfd = os.open(target, os.O_CREAT | os.O_RDWR, 0o644)
+    sys_fsetxattr(wfd, USER_TEST_KEY, USER_TEST_VALUE, flags=XATTR_CREATE)
+    os.close(wfd)
+    fd = os.open(target, os.O_RDONLY)
+
+    def run() -> None:
+        ret = sys_fgetxattr(fd, USER_TEST_KEY, 0, 0)
+        if ret != USER_TEST_VALUE_SIZE:
+            raise OSError(
+                errno.EINVAL,
+                f"fgetxattr(NULL,0) returned {ret}, expected {USER_TEST_VALUE_SIZE}",
+            )
+
+    try:
+        return expect_ok(
+            "fsetxattr(user.testkey) then fgetxattr(NULL,0) returns value size "
+            "(fgetxattr03)",
+            run,
+        )
+    finally:
+        os.close(fd)
+
+
+def test_removexattr_missing_user_xattr_enodata(root: str) -> int:
+    # Related LTP cases: removexattr02
+    # removexattr(2) on a file without the named user.* xattr must fail with ENODATA.
+    if os.geteuid() != 0:
+        return skip("removexattr missing xattr", "requires root")
+
+    workdir = case_dir(root, "removexattr_enodata")
+    target = os.path.join(workdir, "testfile")
+    fd = os.open(target, os.O_CREAT | os.O_RDWR, 0o644)
+    os.close(fd)
+
+    def run() -> None:
+        sys_removexattr(target, REMOVE_KEY)
+
+    return expect_errno(
+        "removexattr(user.test) on file without that xattr returns ENODATA "
+        "(removexattr02)",
+        run,
+        errno.ENODATA,
+    )
+
+
+TESTS: list[tuple[str, str, Callable[..., int]]] = [
+    (
+        "1",
+        "getxattr reads user.testkey value after setxattr (getxattr01)",
+        test_getxattr_reads_user_xattr_value,
+    ),
+    (
+        "2",
+        "getxattr(buf=1) returns ERANGE after setxattr (getxattr01)",
+        test_getxattr_user_xattr_small_buffer_erange,
+    ),
+    (
+        "3",
+        "getxattr(NULL,0) returns value size after setxattr (getxattr03)",
+        test_getxattr_null_buffer_returns_attr_size,
+    ),
+    (
+        "4",
+        "lgetxattr reads xattr set on symlink (lgetxattr01)",
+        test_lgetxattr_reads_symlink_xattr,
+    ),
+    (
+        "5",
+        "lgetxattr(buf=1) on symlink returns ERANGE (lgetxattr02)",
+        test_lgetxattr_symlink_small_buffer_erange,
+    ),
+    (
+        "6",
+        "fgetxattr(NULL,0) returns value size after fsetxattr (fgetxattr03)",
+        test_fgetxattr_null_buffer_returns_attr_size,
+    ),
+    (
+        "7",
+        "removexattr on missing user.test returns ENODATA (removexattr02)",
+        test_removexattr_missing_user_xattr_enodata,
+    ),
+]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="user.* xattr not persisted on Curvine FUSE — reproducer",
+    )
+    parser.add_argument(
+        "--dir",
+        default=DEFAULT_DIR,
+        help="Base test directory (must be on the Curvine FUSE mount)",
+    )
+    parser.add_argument(
+        "--allow-non-mount",
+        action="store_true",
+        help="Skip FUSE mount check; for local debugging only (default: False)",
+    )
+    args = parser.parse_args()
+
+    if not sys.platform.startswith("linux"):
+        print("SKIP: Linux-only syscalls", file=sys.stderr)
+        return 0
+
+    if os.geteuid() != 0:
+        print("WARNING: not running as root", file=sys.stderr)
+
+    root = os.path.abspath(args.dir)
+    os.makedirs(root, exist_ok=True)
+
+    if args.allow_non_mount:
+        print(
+            "WARNING: --allow-non-mount set; results may not reflect Curvine FUSE behaviour",
+            file=sys.stderr,
+        )
+
+    print(f"Running user-xattr-persist reproducer under {root}\n")
+
+    fail = 0
+    for num, title, test_fn in TESTS:
+        print(f"[case {num}] {title}:")
+        fail += test_fn(root)
+        print()
+
+    total = len(TESTS)
+    passed = total - fail
+    print(f"Summary: {passed}/{total} passed, {fail}/{total} failed")
+    return 1 if fail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION

## Problem

Curvine FUSE fails a large set of LTP (Linux Test Project) POSIX compliance cases on mounted filesystems. Reproducing these failures today requires running the full LTP suite (hundreds of cases, long runtime, heavy container setup) or manually reverse-engineering minimal syscall sequences from LTP logs.

There is no checked-in, standalone way for contributors to isolate a specific failure class, document its root cause, or verify a fix without replaying the entire suite.

---

## Design

Add 14 standalone Python reproducers under:

```text
build/tests/scripts/
```

The scripts should follow the same layout and conventions as existing FUSE regression scripts, such as:

```text
mmap_test.py
visibility_test.py
```

Each script:

- Targets one failure class, such as chmod persistence, xattr, advisory locks, mknod, and so on.
- Documents the root cause and the LTP cases it covers in its module docstring.
- Accepts `--dir <mount-point>`, with the default value:

```text
/curvine-fuse/fuse-test
```

- Accepts optional `--allow-non-mount` for local debugging.
- Exits non-zero when the bug is still present.

These scripts are diagnostic reproducers, not pass/fail regression tests.

Do not wire these into `fuse-test.sh` or CI in this PR. They are expected to fail until the underlying bugs are fixed.

This PR is test infrastructure only; no FUSE behavior changes.

---

## Key Changes

Add 14 reproducer scripts in:

```text
build/tests/scripts/
```

| Script | Failure Class | Representative LTP Cases |
|---|---|---|
| `curvine_ltp_chmod_mode_repro.py` | `chmod` / `fchmod` / `umask` mode bits not persisted | `chmod01`, `fchmod01`, `umask01` |
| `curvine_ltp_close_eio_repro.py` | `close(2)` returns `EIO` after `flock` / `fcntl` lease | `flock02`, `flock04`, `fcntl32` |
| `curvine_ltp_creat_enoent_repro.py` | `O_CREAT` succeeds but dentry is not visible | `fcntl23/25`, `linkat01`, `stream03`, … |
| `curvine_ltp_eio_repro.py` | I/O paths return `EIO` instead of success / zeros | `fallocate01/03`, `truncate02`, `ftest01/03`, `link01` |
| `curvine_ltp_enametoolong_repro.py` | Long path components return `ENOENT` instead of `ENAMETOOLONG` | `chroot03`, `chdir04`, `open08`, `statx03`, `nftw01` |
| `curvine_ltp_fcntl_lock_repro.py` | Stale advisory lock state, deadlock not detected | `fcntl14`, `fcntl17` |
| `curvine_ltp_fgetlk_wrong_repro.py` | `F_GETLK` returns wrong lock metadata | `fcntl11`, `fcntl19/20/21` |
| `curvine_ltp_mknod_eperm_repro.py` | `mknod` / `mkfifo` always return `EPERM` because `FUSE_MKNOD` is missing | `mknod01–08`, `fcntl07`, `dup05`, `stream02`, … |
| `curvine_ltp_mmap_sigbus_repro.py` | `MAP_SHARED` page access raises `SIGBUS` | `mmap02`, `mmap03`, `mmap04` |
| `curvine_ltp_protected_symlinks_repro.py` | `fs.protected_symlinks` policy is not enforced | `prot_hsymlinks` |
| `curvine_ltp_renameat2_flags_repro.py` | `RENAME_EXCHANGE` / `RENAME_NOREPLACE` unsupported | `renameat201`, `renameat202` |
| `curvine_ltp_security_system_xattr_repro.py` | `security.*` xattrs missing from `listxattr`; `FS_IOC_SETFLAGS` returns `ENOSYS` | `listxattr01`, `flistxattr01`, `setxattr03` |
| `curvine_ltp_setgid_gid_repro.py` | `S_ISGID` directory GID inheritance missing | `creat08`, `open10`, `mkdir02` |
| `curvine_ltp_user_xattr_persist_repro.py` | `user.*` xattrs are not persisted after `setxattr` | `getxattr01/03`, `lgetxattr01/02`, `fgetxattr03`, `removexattr02` |

---

## Expected Outcome

All 14 scripts are available under:

```text
build/tests/scripts/
```

They are placed alongside existing FUSE test scripts.

Each script runs standalone with:

```bash
python3 build/tests/scripts/curvine_ltp_<name>_repro.py --dir <mount>
```

Scripts currently exit non-zero on known-buggy Curvine FUSE builds, and the output clearly identifies which scenario failed.

There are no changes to:

- `fuse-test.sh`
- CI
- FUSE mount behavior

After a future fix for one failure class, the corresponding reproducer should flip to exit `0`.

---

## Test Plan

### 1. Mount Curvine FUSE

Mount Curvine FUSE at:

```text
/curvine-fuse
```

Or pass the following options for local runs:

```bash
--dir / --allow-non-mount
```

---

### 2. Run Each Reproducer Script

Run each script and confirm it executes without import or syntax errors:

```bash
for s in build/tests/scripts/curvine_ltp_*_repro.py; do
  python3 "$s" --dir /curvine-fuse/fuse-test
done
```

---

### 3. Verify Known Failure Behavior

On a known-failing build, verify each script reports the documented failure:

- Non-zero exit code.
- `FAIL` lines in output.
- Output clearly identifies which scenario failed.

---

### 4. Confirm Existing Test Wiring Is Unchanged

Confirm the following files and existing scripts are unchanged:

```text
fuse-test.sh
mmap_test.py
visibility_test.py
```

This PR must not wire the new diagnostic reproducers into CI or the existing FUSE test runner.

---

### 5. Verify Future Fix Behavior

After a future fix for one failure class, the corresponding reproducer should exit successfully:

```text
exit 0
```

