### PR TITLE
fix(raft): keep node alive on malformed requests

### DIFF
--- a/curvine-common/src/raft/raft_node.rs
+++ b/curvine-common/src/raft/raft_node.rs
@@ -20,13 +20,12 @@ use crate::raft::raft_error::RaftError;
 use crate::raft::storage::{AppStorage, ApplyMsg, LogStorage, PeerStorage};
 use crate::raft::*;
 use crate::utils::SerdeUtils;
-use log::{error, info, warn};
+use log::{debug, error, info, warn};
 use orpc::client::dispatch::{Callback, Envelope};
 use orpc::common::{DurationUnit, LocalTime, TimeSpent};
 use orpc::io::net::InetAddr;
 use orpc::message::{Builder, RefMessage, ResponseStatus};
 use orpc::runtime::{RpcRuntime, Runtime};
-use orpc::try_err;
 use prost::Message as PMessage;
 use raft::eraftpb::{ConfChange, Entry, EntryType, MessageType, Snapshot};
 use raft::prelude::ConfChangeType;
@@ -296,12 +295,37 @@ where
         Ok(())
     }
 
+    fn send_request_error(env: Envelope, error: RaftError) -> RaftResult<()> {
+        warn!(
+            "raft request {:?} failed: {}",
+            RaftCode::from(env.msg.code()),
+            error
+        );
+        let msg = Ok(env.msg.error_ext(&error));
+        env.send_with_log(msg);
+        Ok(())
+    }
+
+    fn send_malformed_request_error(env: Envelope, error: RaftError) -> RaftResult<()> {
+        debug!(
+            "malformed raft request {:?}: {}",
+            RaftCode::from(env.msg.code()),
+            error
+        );
+        let msg = Ok(env.msg.error_ext(&error));
+        env.send_with_log(msg);
+        Ok(())
+    }
+
     fn handle_conf_change(
         &mut self,
         env: Envelope,
         promise: &mut HashMap<i64, Callback>,
     ) -> RaftResult<()> {
-        let header: ConfChangeRequest = env.msg.parse_header()?;
+        let header: ConfChangeRequest = match env.msg.parse_header() {
+            Ok(header) => header,
+            Err(e) => return Self::send_malformed_request_error(env, e.into()),
+        };
         let mut change: ConfChange = header.change;
 
         if !self.is_leader() {
@@ -312,7 +336,9 @@ where
             }
 
             let context = SerdeUtils::serialize(&env.msg.req_id())?;
-            self.raw.propose_conf_change(context, change)?;
+            if let Err(e) = self.raw.propose_conf_change(context, change) {
+                return Self::send_request_error(env, e.into());
+            }
             promise.insert(env.msg.req_id(), env.cb);
         }
 
@@ -321,9 +347,14 @@ where
 
     // Handle raft internal messages, such as elections, heartbeats, voting, etc.
     fn handle_raft(&mut self, env: Envelope) -> RaftResult<()> {
-        let raft: RaftRequest = try_err!(env.msg.parse_header());
+        let raft: RaftRequest = match env.msg.parse_header() {
+            Ok(raft) => raft,
+            Err(e) => return Self::send_malformed_request_error(env, e.into()),
+        };
 
-        self.raw.step(raft.message)?;
+        if let Err(e) = self.raw.step(raft.message) {
+            return Self::send_request_error(env, e.into());
+        }
         let rep_msg = Builder::success(&env.msg)
             .proto_header(RaftResponse::default())
             .build();
@@ -341,9 +372,14 @@ where
         }
 
         let before_index = self.raw.raft.raft_log.last_index() + 1;
-        let header: ProposeRequest = env.msg.parse_header()?;
+        let header: ProposeRequest = match env.msg.parse_header() {
+            Ok(header) => header,
+            Err(e) => return Self::send_malformed_request_error(env, e.into()),
+        };
         let context = SerdeUtils::serialize(&env.msg.req_id())?;
-        self.raw.propose(context, header.data)?;
+        if let Err(e) = self.raw.propose(context, header.data) {
+            return Self::send_request_error(env, e.into());
+        }
 
         let after_index = self.raw.raft.raft_log.last_index() + 1;
         if before_index == after_index {

--- a/curvine-common/tests/raft_node_test.rs
+++ b/curvine-common/tests/raft_node_test.rs
@@ -19,15 +19,19 @@ use curvine_common::proto::raft::{FsmState, SnapshotData};
 use curvine_common::raft::storage::{
     AppStorage, HashAppStorage, LogStorage, MemLogStorage, RocksLogStorage,
 };
-use curvine_common::raft::{RaftClient, RaftError, RaftJournal, RaftResult, RoleMonitor};
+use curvine_common::raft::{RaftClient, RaftCode, RaftError, RaftJournal, RaftResult, RoleMonitor};
 use curvine_common::utils::SerdeUtils;
-use orpc::common::{Logger, Utils};
+use orpc::client::{ClientConf, RpcClient};
+use orpc::common::{FileUtils, Logger, Utils};
+use orpc::message::{Builder, ResponseStatus};
 use orpc::runtime::{RpcRuntime, Runtime};
 use orpc::CommonResult;
+use prost::bytes::BytesMut;
 use prost::Message;
 use raft::eraftpb::{ConfState, Entry, HardState, Snapshot};
 use raft::{GetEntriesContext, RaftState, StateRole, Storage, StorageError};
 use std::sync::Arc;
+use std::sync::{Mutex, RwLock};
 
 // Single-node memory storage test.
 // #[test]
@@ -120,7 +124,6 @@ where
 
     Ok(app_store)
 }
-
 #[derive(Clone, Default)]
 struct FailingSnapshotAppStorage;
 
@@ -143,6 +146,68 @@ impl AppStorage for FailingSnapshotAppStorage {
 
     async fn apply_snapshot(&self, _: SnapshotData) -> RaftResult<()> {
         Err(RaftError::other("injected snapshot restore failure".into()))
+    }
+
+    fn snapshot_dir(&self, _: u64) -> RaftResult<String> {
+        Ok(String::new())
+    }
+}
+
+#[derive(Clone, Default)]
+struct TestKvAppStorage {
+    map: Arc<RwLock<std::collections::HashMap<String, String>>>,
+    fsm_state: Arc<Mutex<FsmState>>,
+}
+
+impl TestKvAppStorage {
+    fn get(&self, key: &str) -> Option<String> {
+        self.map.read().unwrap().get(key).cloned()
+    }
+}
+
+impl AppStorage for TestKvAppStorage {
+    async fn apply(&self, _: bool, msg: curvine_common::raft::storage::ApplyMsg) -> RaftResult<()> {
+        match msg {
+            curvine_common::raft::storage::ApplyMsg::Entry(entry) => {
+                let pair: (String, String) = SerdeUtils::deserialize(&entry.data)?;
+                self.map.write().unwrap().insert(pair.0, pair.1);
+                self.fsm_state.lock().unwrap().applied =
+                    curvine_common::proto::raft::AppliedIndex {
+                        term: entry.term,
+                        index: entry.index,
+                        op_id: 0,
+                        rpc_id: 0,
+                    };
+            }
+            curvine_common::raft::storage::ApplyMsg::Scan(applied) => {
+                self.fsm_state.lock().unwrap().applied = applied;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn get_fsm_state(&self) -> FsmState {
+        self.fsm_state.lock().unwrap().clone()
+    }
+
+    async fn role_change(&self, _: StateRole) -> RaftResult<()> {
+        Ok(())
+    }
+
+    async fn create_snapshot(&self) -> RaftResult<SnapshotData> {
+        Ok(SnapshotData {
+            snapshot_id: self.get_fsm_state().applied.index,
+            node_id: 0,
+            create_time: 0,
+            bytes_data: Some(Vec::new()),
+            files_data: None,
+            fsm_state: self.get_fsm_state(),
+        })
+    }
+
+    async fn apply_snapshot(&self, _: SnapshotData) -> RaftResult<()> {
+        Ok(())
     }
 
     fn snapshot_dir(&self, _: u64) -> RaftResult<String> {
@@ -219,6 +284,48 @@ impl Storage for NoSnapshotLogStorage {
             StorageError::SnapshotTemporarilyUnavailable,
         ))
     }
+}
+
+#[test]
+fn malformed_propose_request_does_not_stop_raft_node() -> CommonResult<()> {
+    Logger::default();
+
+    let mut conf = JournalConf::with_test();
+    conf.journal_dir = format!("../testing/malformed-propose-{}", Utils::rand_id());
+    FileUtils::delete_path(&conf.journal_dir, true)?;
+
+    let rt = conf.create_runtime();
+    let store = TestKvAppStorage::default();
+    let raft = RaftJournal::new(
+        rt.clone(),
+        RocksLogStorage::from_conf(&conf, true),
+        store.clone(),
+        conf.clone(),
+        RoleMonitor::new(),
+    );
+    let mut listener = rt.block_on(raft.run())?;
+    rt.block_on(listener.wait_leader())?;
+
+    let client = RaftClient::from_conf(rt.clone(), &conf);
+    let malformed_header = SerdeUtils::serialize(&("bad".to_string(), "payload".to_string()))?;
+    let malformed_req = Builder::new_rpc(RaftCode::Propose)
+        .header(BytesMut::from(&malformed_header[..]))
+        .build();
+    let raw_client = rt.block_on(RpcClient::new(
+        false,
+        rt.clone(),
+        &conf.local_addr(),
+        &ClientConf::default(),
+    ))?;
+    let malformed_rep = rt.block_on(raw_client.rpc(malformed_req))?;
+    assert_eq!(malformed_rep.response_status(), ResponseStatus::Error);
+
+    rt.block_on(send_pair(rt.clone(), &conf, "name", "curvine"))?;
+    Utils::sleep(1000);
+    assert_eq!(store.get("name"), Some("curvine".to_string()));
+    FileUtils::delete_path(&conf.journal_dir, true)?;
+
+    Ok(())
 }
 
 #[test]


### PR DESCRIPTION
## Summary

This PR prevents a malformed Raft RPC request from stopping the whole Raft node task.

The change is intentionally narrow: request-level failures now return an RPC error to the caller, while local consistency failures in `on_ready`, log persistence, state-machine apply, and snapshot handling still stop the Raft node.

## Problem

A Curvine master can stay `Running` and pass the TCP probe while its Raft task has already exited.

In the production incident, the leader logged a protobuf decode error while handling a `Propose` request. After that, port `8996` still accepted connections, but the Raft receiver was gone. Peers then kept getting `channel closed`, no new leader could be elected, and normal `cv` commands failed with `Not a leader master`.

The failure mode is:

1. A bad or incompatible request reaches the Raft RPC port.
2. `RaftNode::handle_*` returns an error for that single request.
3. The error bubbles out of `RaftNode::run0`.
4. `RaftNode::run` logs `raft node stop` and advances the role state to `Exit`.
5. The RPC server process keeps running, so Kubernetes still sees the master pod as healthy.
6. The cluster loses Raft quorum behavior until the master pods are restarted.

Restarting the pods recreates the Raft task, but it does not close the bug. The same request path can kill the node again.

## Root Cause

`handle_raft`, `handle_propose`, and `handle_conf_change` treated malformed request data and raft-rs request admission errors as fatal node errors. These are not local storage or state-machine failures; they belong to the current RPC request.

A request decode failure should produce an error response for that request. It should not stop election, heartbeats, or future proposals.

## Solution

This PR adds request-level error handling in the Raft request handlers:

- `handle_raft`
  - returns an RPC error for malformed `RaftRequest`
  - returns an RPC error if `raw.step` rejects the message
- `handle_propose`
  - returns an RPC error for malformed `ProposeRequest`
  - returns an RPC error if `raw.propose` rejects the proposal
- `handle_conf_change`
  - returns an RPC error for malformed `ConfChangeRequest`
  - returns an RPC error if `raw.propose_conf_change` rejects the change

These paths log a warning and reply through the original RPC callback. The Raft event loop then continues.

## What This Does Not Change

This PR does not hide real local consistency failures.

Errors from ready handling, hard-state persistence, log append, committed entry apply, snapshot restore, and snapshot creation still propagate out of `run0`. Those errors can mean the local node state is unsafe to continue from, so fail-fast remains the correct behavior.

## Performance

The normal path only replaces `?` with explicit `match` / `if let Err` handling around operations that already returned `Result`.

There is no new lock, retry loop, network call, allocation-heavy path, or background task for successful requests. The extra warning log and error response only run on failure paths.

## Tests

Added a regression test that:

1. Starts a single-node Raft journal.
2. Waits until it becomes leader.
3. Sends a malformed `Propose` request whose header is not a `ProposeRequest` protobuf.
4. Verifies the malformed request returns an RPC error.
5. Sends a normal proposal afterward.
6. Verifies the normal proposal still commits.

Tested locally:

```bash
cargo fmt --check
cargo test -p curvine-common --test raft_node_test -- --nocapture
```

Result:

```text
cargo test: 2 passed
```