### PR TITLE
fix(server): exit master on WebServer port bind conflict

### DIFF
--- a/curvine-server/src/master/master_server.rs
+++ b/curvine-server/src/master/master_server.rs
@@ -200,7 +200,12 @@ impl Master {
         rpc_status.wait_running().await.unwrap();
 
         // step3: Start the web server
-        self.web_server.start();
+        let web_name = self.web_server.server_name().to_string();
+        let web_addr = self.web_server.bind_addr().clone();
+        let mut web_status = self.web_server.start();
+        WebServer::<MasterService>::wait_bind(&mut web_status, &web_name, &web_addr)
+            .await
+            .unwrap();
 
         // step4: Start master actor
         self.actor.start();

--- a/curvine-server/src/master/master_server.rs
+++ b/curvine-server/src/master/master_server.rs
@@ -201,9 +201,9 @@ impl Master {
 
         // step3: Start the web server
         let web_name = self.web_server.server_name().to_string();
-        let web_addr = self.web_server.bind_addr().clone();
+        let bind_addr = self.web_server.resolve_bind_addr();
         let mut web_status = self.web_server.start();
-        WebServer::<MasterService>::wait_bind(&mut web_status, &web_name, &web_addr)
+        WebServer::<MasterService>::wait_bind(&mut web_status, &web_name, &bind_addr)
             .await
             .unwrap();
 

--- a/curvine-server/src/worker/worker_server.rs
+++ b/curvine-server/src/worker/worker_server.rs
@@ -239,7 +239,12 @@ impl Worker {
         rpc_status.wait_running().await.unwrap();
 
         // step 4: Start the web server
-        self.web_server.start();
+        let web_name = self.web_server.server_name().to_string();
+        let web_addr = self.web_server.bind_addr().clone();
+        let mut web_status = self.web_server.start();
+        WebServer::<WorkerService>::wait_bind(&mut web_status, &web_name, &web_addr)
+            .await
+            .unwrap();
 
         // step 5: Start block heartbeat check service
         thread::spawn(move || self.block_actor.start())

--- a/curvine-server/src/worker/worker_server.rs
+++ b/curvine-server/src/worker/worker_server.rs
@@ -240,9 +240,9 @@ impl Worker {
 
         // step 4: Start the web server
         let web_name = self.web_server.server_name().to_string();
-        let web_addr = self.web_server.bind_addr().clone();
+        let bind_addr = self.web_server.resolve_bind_addr();
         let mut web_status = self.web_server.start();
-        WebServer::<WorkerService>::wait_bind(&mut web_status, &web_name, &web_addr)
+        WebServer::<WorkerService>::wait_bind(&mut web_status, &web_name, &bind_addr)
             .await
             .unwrap();
 

--- a/curvine-web/src/server/web_server.rs
+++ b/curvine-web/src/server/web_server.rs
@@ -22,7 +22,7 @@ use axum::Json;
 use log::{error, info};
 use orpc::io::net::{InetAddr, NetUtils};
 use orpc::runtime::{RpcRuntime, Runtime};
-use orpc::server::ServerConf;
+use orpc::server::{ServerConf, ServerMonitor, ServerStateListener};
 use orpc::CommonResult;
 use serde_json::json;
 use tokio::net::TcpListener;
@@ -44,6 +44,7 @@ pub struct WebServer<S> {
     service: S,
     conf: ServerConf,
     address: InetAddr,
+    monitor: ServerMonitor,
 }
 
 impl<S> WebServer<S>
@@ -59,6 +60,7 @@ where
             service,
             conf,
             address,
+            monitor: ServerMonitor::new(),
         }
     }
 
@@ -69,24 +71,79 @@ where
             service,
             conf,
             address,
+            monitor: ServerMonitor::new(),
         }
+    }
+
+    pub fn bind_port(&self) -> u16 {
+        self.address.port
+    }
+
+    pub fn server_name(&self) -> &str {
+        &self.conf.name
+    }
+
+    pub fn bind_addr(&self) -> &InetAddr {
+        &self.address
     }
 
     pub fn block_on_start(&self) {
         self.rt.block_on(async {
             if let Err(e) = self.run().await {
-                error!("WebServer connect error: {}", e);
+                error!(
+                    "WebServer [{}] failed to bind address {} (port {}): {}",
+                    self.conf.name,
+                    self.get_bind_addr(),
+                    self.address.port,
+                    e
+                );
             }
         });
     }
 
-    pub fn start(self) {
+    pub fn start(self) -> ServerStateListener {
         let rt = self.rt.clone();
+        let listener = self.monitor.new_listener();
         rt.spawn(async move {
-            if let Err(e) = self.run().await {
-                error!("WebServer connect error: {}", e);
-            }
+            Self::start0(self).await;
         });
+        listener
+    }
+
+    pub async fn wait_bind(
+        listener: &mut ServerStateListener,
+        name: &str,
+        address: &InetAddr,
+    ) -> CommonResult<()> {
+        use orpc::err_box;
+
+        let port = address.port;
+        match listener.wait_startup().await {
+            Ok(()) => Ok(()),
+            Err(_) => err_box!(
+                "WebServer [{}] failed to bind address {} (port {}); the port may already be in use",
+                name,
+                address,
+                port
+            ),
+        }
+    }
+
+    async fn start0(server: Self) {
+        let bind_addr = server.get_bind_addr();
+        if let Err(e) = server.run().await {
+            error!(
+                "WebServer [{}] failed to bind address {} (port {}): {}",
+                server.conf.name, bind_addr, server.address.port, e
+            );
+        }
+
+        server.monitor.advance_shutdown();
+        server.monitor.advance_stop();
+
+        // Drop the server (and possibly its dedicated runtime) outside the async context
+        // to avoid Tokio panics when WebServer::new() owns the only runtime reference.
+        tokio::task::spawn_blocking(move || drop(server)).await.ok();
     }
 
     fn get_bind_addr(&self) -> String {
@@ -109,6 +166,8 @@ where
             "WebServer [{}] start successfully, bind address: {}",
             self.conf.name, self.address,
         );
+        self.monitor.advance_running();
+
         let webui_path = Path::new(WEBUI_DIR);
         let serve_dir = ServeDir::new(webui_path)
             .not_found_service(ServeFile::new(webui_path.join("index.html")));
@@ -152,13 +211,7 @@ fn test() {
     let mut conf = ServerConf::with_hostname("127.0.0.1", 9000);
     conf.name = "test".to_string();
     let web = WebServer::new(conf, service);
+    let _listener = web.start();
 
-    // Start server in background instead of blocking
-    web.start();
-
-    // Wait a short time for server to start
     thread::sleep(Duration::from_millis(500));
-
-    // Test completes - server continues running in background but test doesn't block
-    // The server will be cleaned up when the runtime shuts down
 }

--- a/curvine-web/src/server/web_server.rs
+++ b/curvine-web/src/server/web_server.rs
@@ -87,14 +87,17 @@ where
         &self.address
     }
 
+    pub fn resolve_bind_addr(&self) -> String {
+        self.get_bind_addr()
+    }
+
     pub fn block_on_start(&self) {
         self.rt.block_on(async {
             if let Err(e) = self.run().await {
                 error!(
-                    "WebServer [{}] failed to bind address {} (port {}): {}",
+                    "WebServer [{}] exited with error on address {}: {}",
                     self.conf.name,
                     self.get_bind_addr(),
-                    self.address.port,
                     e
                 );
             }
@@ -113,28 +116,46 @@ where
     pub async fn wait_bind(
         listener: &mut ServerStateListener,
         name: &str,
-        address: &InetAddr,
+        bind_addr: &str,
     ) -> CommonResult<()> {
         use orpc::err_box;
 
-        let port = address.port;
         match listener.wait_startup().await {
             Ok(()) => Ok(()),
             Err(_) => err_box!(
-                "WebServer [{}] failed to bind address {} (port {}); the port may already be in use",
+                "WebServer [{}] failed to start on address {}",
                 name,
-                address,
-                port
+                bind_addr
             ),
         }
     }
 
     async fn start0(server: Self) {
         let bind_addr = server.get_bind_addr();
-        if let Err(e) = server.run().await {
+        let listener = match server.bind_listener().await {
+            Ok(listener) => listener,
+            Err(e) => {
+                error!(
+                    "WebServer [{}] failed to bind address {}: {}",
+                    server.conf.name, bind_addr, e
+                );
+                server.monitor.advance_shutdown();
+                server.monitor.advance_stop();
+                tokio::task::spawn_blocking(move || drop(server)).await.ok();
+                return;
+            }
+        };
+
+        info!(
+            "WebServer [{}] start successfully, bind address: {}",
+            server.conf.name, bind_addr
+        );
+        server.monitor.advance_running();
+
+        if let Err(e) = server.serve_listener(listener).await {
             error!(
-                "WebServer [{}] failed to bind address {} (port {}): {}",
-                server.conf.name, bind_addr, server.address.port, e
+                "WebServer [{}] exited with error on address {}: {}",
+                server.conf.name, bind_addr, e
             );
         }
 
@@ -151,23 +172,20 @@ where
         format!("{}:{}", hostname, self.address.port)
     }
 
-    pub async fn run(&self) -> CommonResult<()> {
+    async fn bind_listener(&self) -> CommonResult<TcpListener> {
         // Prefer a pre-bound listener from the test port reservation map.
         // This eliminates the TOCTOU race between port discovery and actual bind
         // when parallel test processes (cargo nextest) run simultaneously.
-        let listener = match NetUtils::take_held_listener(self.address.port) {
+        match NetUtils::take_held_listener(self.address.port) {
             Some(std_listener) => {
                 std_listener.set_nonblocking(true)?;
-                TcpListener::from_std(std_listener)?
+                Ok(TcpListener::from_std(std_listener)?)
             }
-            None => TcpListener::bind(self.get_bind_addr()).await?,
-        };
-        info!(
-            "WebServer [{}] start successfully, bind address: {}",
-            self.conf.name, self.address,
-        );
-        self.monitor.advance_running();
+            None => Ok(TcpListener::bind(self.get_bind_addr()).await?),
+        }
+    }
 
+    async fn serve_listener(&self, listener: TcpListener) -> CommonResult<()> {
         let webui_path = Path::new(WEBUI_DIR);
         let serve_dir = ServeDir::new(webui_path)
             .not_found_service(ServeFile::new(webui_path.join("index.html")));
@@ -188,6 +206,17 @@ where
             );
         axum::serve(listener, app).await?;
         Ok(())
+    }
+
+    pub async fn run(&self) -> CommonResult<()> {
+        let bind_addr = self.get_bind_addr();
+        let listener = self.bind_listener().await?;
+        info!(
+            "WebServer [{}] start successfully, bind address: {}",
+            self.conf.name, bind_addr
+        );
+        self.monitor.advance_running();
+        self.serve_listener(listener).await
     }
 }
 

--- a/orpc/src/server/server_monitor.rs
+++ b/orpc/src/server/server_monitor.rs
@@ -81,4 +81,66 @@ impl ServerStateListener {
     pub async fn wait_stop(&mut self) -> CommonResult<()> {
         self.0.wait_state(ServerState::Stop).await
     }
+
+    /// Wait until the server reaches Running, or fail fast if it shuts down before binding.
+    pub async fn wait_startup(&mut self) -> CommonResult<()> {
+        use crate::err_box;
+
+        let running = ServerState::Running.into();
+        let shutdown = ServerState::Shutdown.into();
+
+        if self.0.current() == running {
+            return Ok(());
+        }
+        if self.0.current() >= shutdown {
+            return err_box!("server failed to start");
+        }
+
+        loop {
+            let state = self.0.next_state().await?;
+            if state == running {
+                return Ok(());
+            }
+            if state >= shutdown {
+                return err_box!("server failed to start");
+            }
+            if self.0.current() == running {
+                return Ok(());
+            }
+            if self.0.current() >= shutdown {
+                return err_box!("server failed to start");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::{AsyncRuntime, RpcRuntime};
+
+    #[test]
+    fn wait_startup_fails_when_shutdown_before_running() {
+        let monitor = ServerMonitor::new();
+        let mut listener = monitor.new_listener();
+        let rt = AsyncRuntime::single();
+
+        rt.block_on(async {
+            monitor.advance_shutdown();
+            monitor.advance_stop();
+            assert!(listener.wait_startup().await.is_err());
+        });
+    }
+
+    #[test]
+    fn wait_startup_succeeds_when_running() {
+        let monitor = ServerMonitor::new();
+        let mut listener = monitor.new_listener();
+        let rt = AsyncRuntime::single();
+
+        rt.block_on(async {
+            monitor.advance_running();
+            listener.wait_startup().await.unwrap();
+        });
+    }
 }


### PR DESCRIPTION
## Problem
When the Master or Worker WebServer fails to bind its port (e.g. `Address already in use`), the process continued starting JobManager, inode TTL scheduler, and other components instead of exiting. Fixes #937.
## Design
Mirror RpcServer lifecycle with `ServerMonitor` on WebServer, and gate Master/Worker startup on a successful web bind via `wait_bind()`. Fix `wait_startup()` so `Shutdown` is not mistaken for `Running` (`>= Running` was true for state 2). Keep WebServer on its own runtime via `WebServer::new()` as before.
## Key Changes
- Add `ServerMonitor` to `WebServer`; `start()` returns `ServerStateListener`
- Master/Worker await web bind before starting downstream components
- Add `ServerStateListener::wait_startup()` with correct Running vs Shutdown handling
- Improve bind-failure logs with server name, address, and port
- Drop dedicated WebServer runtime via `spawn_blocking` to avoid Tokio panic on failure path