### PR TITLE
feat(ci): dispatch curvine-helm release after image publish

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -40,3 +40,25 @@
 1. 首次使用时，需要确保 GitHub 仓库有权限访问 GitHub Container Registry
 2. 如果修改了 Docker 镜像的配置，需要重新构建并推送镜像
 3. Clippy 检查级别设置为 "deny"，可以在工作流文件中修改
+
+## 3. 触发 Helm Chart 发版 (trigger-helm-release.yml)
+
+当 `curvine` 推送 `v*` tag 后，此工作流会:
+
+1. 等待 runtime 和 CSI 镜像构建完成
+2. 校验 GHCR 中对应 tag 的镜像已发布
+3. 向 `CurvineIO/curvine-helm` 发送 `repository_dispatch` 事件 (`curvine-release`)
+
+`curvine-helm` 收到事件后会自动在 `main` 上创建同名 tag，并触发 chart 打包。
+
+### 前置配置
+
+在 `CurvineIO/curvine` 仓库 Settings -> Secrets and variables -> Actions 中添加:
+
+| Secret | 说明 |
+| --- | --- |
+| `CURVINE_HELM_DISPATCH_TOKEN` | 对 `curvine-helm` 有读写权限的 PAT，用于跨仓库 dispatch |
+
+### 手动重试
+
+Actions -> `Trigger Helm Release` -> Run workflow，填写 tag（如 `v0.3.0`）。

--- a/.github/workflows/trigger-helm-release.yml
+++ b/.github/workflows/trigger-helm-release.yml
@@ -1,0 +1,142 @@
+name: Trigger Helm Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to sync to curvine-helm (e.g. v0.3.0)'
+        required: true
+        type: string
+      commit_sha:
+        description: 'Curvine commit SHA for the release (optional)'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: trigger-helm-release-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  trigger-helm-release:
+    name: Wait for images and dispatch helm release
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - name: Resolve release metadata
+        id: meta
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ inputs.tag }}"
+            SHA="${{ inputs.commit_sha }}"
+            if [ -z "$SHA" ]; then
+              SHA="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${TAG}" --jq '.sha')"
+            fi
+          else
+            TAG="${GITHUB_REF#refs/tags/}"
+            SHA="${GITHUB_SHA}"
+          fi
+
+          if [[ ! "$TAG" =~ ^v ]]; then
+            echo "::error::Release tag must start with v, got: $TAG"
+            exit 1
+          fi
+
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "Release tag: $TAG"
+          echo "Source commit: $SHA"
+
+      - name: Wait for runtime and CSI image workflows
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          SHA="${{ steps.meta.outputs.sha }}"
+          WORKFLOWS=(
+            "build-runtime-image.yml"
+            "build-csi-image.yml"
+          )
+          DEADLINE=$((SECONDS + 7200))
+
+          wait_for_workflow() {
+            local workflow_file="$1"
+            local status conclusion
+
+            while [ "$SECONDS" -lt "$DEADLINE" ]; do
+              read -r status conclusion < <(
+                gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/${workflow_file}/runs" \
+                  -f head_sha="$SHA" \
+                  -f event=push \
+                  -f per_page=1 \
+                  --jq '.workflow_runs[0] | "\(.status) \(.conclusion // "null")"' \
+                  | awk '{print $1, $2}'
+              )
+
+              if [ -z "${status:-}" ] || [ "$status" = "null" ]; then
+                echo "Waiting for ${workflow_file} to start..."
+                sleep 30
+                continue
+              fi
+
+              if [ "$status" = "completed" ]; then
+                if [ "$conclusion" = "success" ]; then
+                  echo "${workflow_file} completed successfully"
+                  return 0
+                fi
+
+                echo "::error::${workflow_file} completed with conclusion: ${conclusion}"
+                return 1
+              fi
+
+              echo "${workflow_file} status: ${status}"
+              sleep 30
+            done
+
+            echo "::error::Timed out waiting for ${workflow_file}"
+            return 1
+          }
+
+          for workflow in "${WORKFLOWS[@]}"; do
+            wait_for_workflow "$workflow"
+          done
+
+      - name: Verify release images in GHCR
+        run: |
+          set -euo pipefail
+          TAG="${{ steps.meta.outputs.tag }}"
+
+          for image in ghcr.io/curvineio/curvine ghcr.io/curvineio/curvine-csi; do
+            echo "Inspecting ${image}:${TAG}"
+            docker buildx imagetools inspect "${image}:${TAG}"
+          done
+
+      - name: Dispatch curvine-helm release
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.CURVINE_HELM_DISPATCH_TOKEN }}
+          repository: CurvineIO/curvine-helm
+          event-type: curvine-release
+          client-payload: >-
+            {
+              "tag": "${{ steps.meta.outputs.tag }}",
+              "sha": "${{ steps.meta.outputs.sha }}",
+              "repository": "${{ github.repository }}"
+            }
+
+      - name: Dispatch summary
+        run: |
+          {
+            echo "## Helm Release Dispatch"
+            echo "- **Tag**: ${{ steps.meta.outputs.tag }}"
+            echo "- **Source commit**: ${{ steps.meta.outputs.sha }}"
+            echo "- **Target repository**: CurvineIO/curvine-helm"
+            echo "- **Event**: curvine-release"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- Add `trigger-helm-release.yml` to wait for runtime and CSI image workflows on `v*` tags
- Verify `ghcr.io/curvineio/curvine` and `ghcr.io/curvineio/curvine-csi` manifests exist
- Dispatch `curvine-release` to `CurvineIO/curvine-helm` via `repository_dispatch`

## Setup required
Add repository secret `CURVINE_HELM_DISPATCH_TOKEN` in `CurvineIO/curvine`:
- PAT with `contents: write` on `CurvineIO/curvine-helm`

## Test plan
- [x] Merge paired PR in `curvine-helm` (https://github.com/CurvineIO/curvine-helm/pull/41)
- [x] Configure `CURVINE_HELM_DISPATCH_TOKEN`
- [x] Push a test `v*` tag or manually run `Trigger Helm Release`
- [ ] Verify `curvine-helm` creates matching tag and packages charts