### PR TITLE
build(spdk): move SPDK build into compile image

### DIFF
--- a/.github/workflows/build-compile-image.yml
+++ b/.github/workflows/build-compile-image.yml
@@ -144,12 +144,14 @@ jobs:
       - name: Create and push multi-arch manifest for ${{ matrix.tag }}
         run: |
           # Create manifest for GHCR
+          docker manifest rm ghcr.io/curvineio/curvine-compile:${{ matrix.tag }} || true
           docker manifest create ghcr.io/curvineio/curvine-compile:${{ matrix.tag }} \
             ghcr.io/curvineio/curvine-compile:${{ matrix.tag }}-amd64 \
             ghcr.io/curvineio/curvine-compile:${{ matrix.tag }}-arm64
           docker manifest push ghcr.io/curvineio/curvine-compile:${{ matrix.tag }}
           
           # Create manifest for Docker Hub
+          docker manifest rm curvine/curvine-compile:${{ matrix.tag }} || true
           docker manifest create curvine/curvine-compile:${{ matrix.tag }} \
             curvine/curvine-compile:${{ matrix.tag }}-amd64 \
             curvine/curvine-compile:${{ matrix.tag }}-arm64

--- a/.github/workflows/build-compile-image.yml
+++ b/.github/workflows/build-compile-image.yml
@@ -37,19 +37,6 @@ jobs:
             tag: rocky9
             arch: arm64
             runner: ubuntu-24.04-arm
-          # Rocky Linux 9 (cached)
-          - build_type: rocky9_cached
-            dockerfile: Dockerfile_rocky9_cached
-            context: .
-            tag: rocky9_cached
-            arch: amd64
-            runner: ubuntu-latest
-          - build_type: rocky9_cached
-            dockerfile: Dockerfile_rocky9_cached
-            context: .
-            tag: rocky9_cached
-            arch: arm64
-            runner: ubuntu-24.04-arm
           # Ubuntu 22.04
           - build_type: ubuntu22.04
             dockerfile: Dockerfile_ubuntu22
@@ -94,9 +81,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      
       - name: Login to GitHub Container Registry
         if: inputs.push_image == true
         uses: docker/login-action@v3
@@ -112,19 +96,19 @@ jobs:
           username: curvine
           password: ${{ secrets.PAT_DOCKERIO_TOKEN }}
       
-      - name: Build and push compile image for ${{ matrix.build_type }} (${{ matrix.arch }})
-        uses: docker/build-push-action@v5
-        with:
-          context: ${{ matrix.context }}
-          file: ./curvine-docker/compile/${{ matrix.dockerfile }}
-          platforms: linux/${{ matrix.arch }}
-          push: ${{ inputs.push_image }}
-          tags: |
-            ghcr.io/curvineio/curvine-compile:${{ matrix.tag }}-${{ matrix.arch }}
-            curvine/curvine-compile:${{ matrix.tag }}-${{ matrix.arch }}
-          cache-from: type=gha,scope=compile-${{ matrix.build_type }}-${{ matrix.arch }}
-          # Transient GHA cache API errors (e.g. 502) must not fail the job after image build/push succeeds.
-          cache-to: type=gha,mode=max,scope=compile-${{ matrix.build_type }}-${{ matrix.arch }},ignore-error=true
+      - name: Build compile image for ${{ matrix.build_type }} (${{ matrix.arch }})
+        run: |
+          docker build \
+            -f ./curvine-docker/compile/${{ matrix.dockerfile }} \
+            -t ghcr.io/curvineio/curvine-compile:${{ matrix.tag }}-${{ matrix.arch }} \
+            -t curvine/curvine-compile:${{ matrix.tag }}-${{ matrix.arch }} \
+            ${{ matrix.context }}
+
+      - name: Push compile image for ${{ matrix.build_type }} (${{ matrix.arch }})
+        if: inputs.push_image == true
+        run: |
+          docker push ghcr.io/curvineio/curvine-compile:${{ matrix.tag }}-${{ matrix.arch }}
+          docker push curvine/curvine-compile:${{ matrix.tag }}-${{ matrix.arch }}
       
       - name: Build summary for ${{ matrix.build_type }} (${{ matrix.arch }})
         run: |
@@ -140,14 +124,10 @@ jobs:
       matrix:
         include:
           - tag: rocky9
-          - tag: rocky9_cached
           - tag: ubuntu22.04
           - tag: ubuntu24.04
           - tag: amzn2
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -164,14 +144,16 @@ jobs:
       - name: Create and push multi-arch manifest for ${{ matrix.tag }}
         run: |
           # Create manifest for GHCR
-          docker buildx imagetools create -t ghcr.io/curvineio/curvine-compile:${{ matrix.tag }} \
+          docker manifest create ghcr.io/curvineio/curvine-compile:${{ matrix.tag }} \
             ghcr.io/curvineio/curvine-compile:${{ matrix.tag }}-amd64 \
             ghcr.io/curvineio/curvine-compile:${{ matrix.tag }}-arm64
+          docker manifest push ghcr.io/curvineio/curvine-compile:${{ matrix.tag }}
           
           # Create manifest for Docker Hub
-          docker buildx imagetools create -t curvine/curvine-compile:${{ matrix.tag }} \
+          docker manifest create curvine/curvine-compile:${{ matrix.tag }} \
             curvine/curvine-compile:${{ matrix.tag }}-amd64 \
             curvine/curvine-compile:${{ matrix.tag }}-arm64
+          docker manifest push curvine/curvine-compile:${{ matrix.tag }}
       
       - name: Manifest creation summary for ${{ matrix.tag }}
         run: |
@@ -194,7 +176,7 @@ jobs:
         run: |
           echo "### Compile Image Build Summary 🚀" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Build Types:** rocky9, rocky9_cached, ubuntu22.04, ubuntu24.04, amzn2" >> $GITHUB_STEP_SUMMARY
+          echo "**Build Types:** rocky9, ubuntu22.04, ubuntu24.04, amzn2" >> $GITHUB_STEP_SUMMARY
           echo "**Architectures:** amd64 (native), arm64 (native)" >> $GITHUB_STEP_SUMMARY
           echo "**Build Strategy:** Native runners for each architecture" >> $GITHUB_STEP_SUMMARY
           echo "**Trigger:** workflow_dispatch" >> $GITHUB_STEP_SUMMARY
@@ -203,7 +185,6 @@ jobs:
           if [ "${{ inputs.push_image }}" == "true" ]; then
             echo "**Multi-arch images pushed to:**" >> $GITHUB_STEP_SUMMARY
             echo "- \`ghcr.io/curvineio/curvine-compile:rocky9\`" >> $GITHUB_STEP_SUMMARY
-            echo "- \`ghcr.io/curvineio/curvine-compile:rocky9_cached\`" >> $GITHUB_STEP_SUMMARY
             echo "- \`ghcr.io/curvineio/curvine-compile:ubuntu22.04\`" >> $GITHUB_STEP_SUMMARY
             echo "- \`ghcr.io/curvineio/curvine-compile:ubuntu24.04\`" >> $GITHUB_STEP_SUMMARY
             echo "- \`ghcr.io/curvineio/curvine-compile:amzn2\`" >> $GITHUB_STEP_SUMMARY
@@ -212,8 +193,6 @@ jobs:
             echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
             echo "# Rocky Linux 9 (standard)" >> $GITHUB_STEP_SUMMARY
             echo "docker pull ghcr.io/curvineio/curvine-compile:rocky9" >> $GITHUB_STEP_SUMMARY
-            echo "# Rocky Linux 9 (cached)" >> $GITHUB_STEP_SUMMARY
-            echo "docker pull ghcr.io/curvineio/curvine-compile:rocky9_cached" >> $GITHUB_STEP_SUMMARY
             echo "# Ubuntu 22.04" >> $GITHUB_STEP_SUMMARY
             echo "docker pull ghcr.io/curvineio/curvine-compile:ubuntu22.04" >> $GITHUB_STEP_SUMMARY
             echo "# Ubuntu 24.04" >> $GITHUB_STEP_SUMMARY
@@ -222,7 +201,7 @@ jobs:
             echo "docker pull ghcr.io/curvineio/curvine-compile:amzn2" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "# Verify multi-arch" >> $GITHUB_STEP_SUMMARY
-            echo "docker buildx imagetools inspect ghcr.io/curvineio/curvine-compile:rocky9" >> $GITHUB_STEP_SUMMARY
+            echo "docker manifest inspect ghcr.io/curvineio/curvine-compile:rocky9" >> $GITHUB_STEP_SUMMARY
             echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           else
             echo "**Note:** Images were built but not pushed (push_image=false)" >> $GITHUB_STEP_SUMMARY

--- a/curvine-docker/compile/Dockerfile_amzn2
+++ b/curvine-docker/compile/Dockerfile_amzn2
@@ -64,8 +64,10 @@ ENV PATH="/app/protoc/bin:${PATH}"
 
 # 4. Install Maven
 RUN cd /app && \
-    MAVEN_VERSION=3.9.15 && \
-    curl -fL -o apache-maven-${MAVEN_VERSION}-bin.tar.gz https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz && \
+    MAVEN_VERSION=3.9.16 && \
+    MAVEN_PACKAGE=apache-maven-${MAVEN_VERSION}-bin.tar.gz && \
+    MAVEN_ARCHIVE_URL=https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/${MAVEN_PACKAGE} && \
+    curl -fL -o ${MAVEN_PACKAGE} ${MAVEN_ARCHIVE_URL} && \
     tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz && \
     mv apache-maven-${MAVEN_VERSION} maven && \
     rm -f *.tar.gz && \

--- a/curvine-docker/compile/Dockerfile_amzn2
+++ b/curvine-docker/compile/Dockerfile_amzn2
@@ -68,7 +68,7 @@ RUN cd /app && \
     MAVEN_PACKAGE=apache-maven-${MAVEN_VERSION}-bin.tar.gz && \
     MAVEN_ARCHIVE_URL=https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/${MAVEN_PACKAGE} && \
     curl -fL -o ${MAVEN_PACKAGE} ${MAVEN_ARCHIVE_URL} && \
-    tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz && \
+    tar -xzf ${MAVEN_PACKAGE} && \
     mv apache-maven-${MAVEN_VERSION} maven && \
     rm -f *.tar.gz && \
     echo "✓ Maven ${MAVEN_VERSION} installed successfully"

--- a/curvine-docker/compile/Dockerfile_rocky9
+++ b/curvine-docker/compile/Dockerfile_rocky9
@@ -97,7 +97,7 @@ RUN cd /app && \
     MAVEN_PACKAGE=apache-maven-${MAVEN_VERSION}-bin.tar.gz && \
     MAVEN_ARCHIVE_URL=https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/${MAVEN_PACKAGE} && \
     curl -fL -o ${MAVEN_PACKAGE} ${MAVEN_ARCHIVE_URL} && \
-    tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz && \
+    tar -xzf ${MAVEN_PACKAGE} && \
     mv apache-maven-${MAVEN_VERSION} maven && \
     rm -f *.tar.gz && \
     echo "✓ Maven ${MAVEN_VERSION} installed successfully"

--- a/curvine-docker/compile/Dockerfile_rocky9
+++ b/curvine-docker/compile/Dockerfile_rocky9
@@ -93,8 +93,10 @@ ENV PATH="/app/protoc/bin:${PATH}"
 
 # 4. Install Maven
 RUN cd /app && \
-    MAVEN_VERSION=3.9.15 && \
-    curl -fL -o apache-maven-${MAVEN_VERSION}-bin.tar.gz https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz && \
+    MAVEN_VERSION=3.9.16 && \
+    MAVEN_PACKAGE=apache-maven-${MAVEN_VERSION}-bin.tar.gz && \
+    MAVEN_ARCHIVE_URL=https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/${MAVEN_PACKAGE} && \
+    curl -fL -o ${MAVEN_PACKAGE} ${MAVEN_ARCHIVE_URL} && \
     tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz && \
     mv apache-maven-${MAVEN_VERSION} maven && \
     rm -f *.tar.gz && \

--- a/curvine-docker/compile/Dockerfile_rocky9
+++ b/curvine-docker/compile/Dockerfile_rocky9
@@ -5,15 +5,25 @@ FROM rockylinux:9
 ARG REPO_URL=https://github.com/curvineio/curvine
 LABEL org.opencontainers.image.source="${REPO_URL}"
 
+ARG SPDK_VERSION=v25.09
+ARG NASM_VERSION=2.16.03
+ARG ISAL_VERSION=v2.31.1
+
 # 1. Install the basic toolchain and dependencies
 # rockylinux:9 ships curl-minimal; installing package "curl" conflicts with it. curl-minimal is enough for HTTPS downloads below.
 RUN dnf install -y dnf-plugins-core && \
     dnf config-manager --set-enabled crb && \
     dnf install -y \
+    epel-release \
     gcc \
     gcc-c++ \
     make \
     pkg-config \
+    numactl-devel \
+    libuuid-devel \
+    rdma-core-devel \
+    libibverbs-devel \
+    librdmacm-devel \
     fuse3 \
     fuse3-devel \
     clang \
@@ -120,6 +130,62 @@ RUN cd /opt && \
 ENV JINDOSDK_HOME=/opt/jindosdk
 ENV LD_LIBRARY_PATH="${JINDOSDK_HOME}/lib"
 
+# 4.2. Build SPDK once in the compile image. Runtime and test images consume
+# /opt/spdk from this image instead of rebuilding SPDK in deploy Dockerfiles.
+RUN cd /tmp && \
+    git clone --depth 1 --branch "$SPDK_VERSION" --single-branch https://github.com/spdk/spdk.git spdk-src && \
+    cd spdk-src && \
+    git submodule update --init --depth 1 && \
+    dnf config-manager --set-disabled devel 2>/dev/null || true && \
+    scripts/pkgdep.sh --rdma && \
+    dnf clean all && \
+    curl -sL https://www.nasm.us/pub/nasm/releasebuilds/$NASM_VERSION/nasm-$NASM_VERSION.tar.gz | \
+        tar -xz -C /tmp && \
+    cd /tmp/nasm-$NASM_VERSION && \
+    ./configure && \
+    make -j$(nproc) && \
+    make install && \
+    cd /tmp && \
+    git clone --depth 1 --branch $ISAL_VERSION https://github.com/intel/isa-l.git isa-l-src && \
+    cd isa-l-src && \
+    ./autogen.sh && \
+    ./configure && \
+    make -j$(nproc) && \
+    make install && \
+    ldconfig && \
+    cd /tmp/spdk-src && \
+    ./configure \
+        --disable-tests \
+        --with-rdma \
+        --without-vfio-user \
+        --target-arch=native \
+        --with-shared && \
+    make -j$(nproc) && \
+    mkdir -p /opt/spdk/build/bin \
+             /opt/spdk/build/lib \
+             /opt/spdk/dpdk/build/lib \
+             /opt/spdk/include/spdk \
+             /opt/spdk/dpdk/build/include \
+             /opt/spdk/isa-l/.libs \
+             /opt/spdk/isa-l-crypto/.libs && \
+    cp build/bin/nvmf_tgt /opt/spdk/build/bin/ && \
+    cp build/lib/libspdk*.so* /opt/spdk/build/lib/ && \
+    cp build/lib/libspdk*.a /opt/spdk/build/lib/ && \
+    cp dpdk/build/lib/librte_*.so* /opt/spdk/dpdk/build/lib/ && \
+    cp dpdk/build/lib/librte_*.a /opt/spdk/dpdk/build/lib/ && \
+    cp -r include/spdk/*.h /opt/spdk/include/spdk/ && \
+    cp -r dpdk/build/include/* /opt/spdk/dpdk/build/include/ && \
+    cp -r scripts /opt/spdk/scripts && \
+    cp -r python /opt/spdk/python && \
+    cp isa-l/.libs/libisal* /opt/spdk/isa-l/.libs/ && \
+    cp isa-l-crypto/.libs/libisal* /opt/spdk/isa-l-crypto/.libs/ && \
+    ldconfig && \
+    rm -rf /tmp/spdk-src /tmp/nasm-$NASM_VERSION /tmp/isa-l-src
+
+ENV SPDK_DIR=/opt/spdk
+ENV PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig
+ENV LD_LIBRARY_PATH="/opt/spdk/build/lib:/opt/spdk/dpdk/build/lib:/opt/spdk/isa-l/.libs:/opt/spdk/isa-l-crypto/.libs:${JINDOSDK_HOME}/lib"
+
 # 5. Install Go toolchain with multi-arch support
 RUN ARCH=$(uname -m) && \
     case "${ARCH}" in \
@@ -162,6 +228,8 @@ WORKDIR /workspace
 # Verify toolchains. Do not `npm install -g npm@latest`: it replaces distro npm and can leave broken deps (e.g. MODULE_NOT_FOUND promise-retry).
 RUN rustc --version && cargo --version && protoc --version && mvn --version && node --version && \
     npm --version && \
+    test -f /opt/spdk/build/lib/libspdk_nvme.a && \
+    test -f /opt/spdk/build/bin/nvmf_tgt && \
     go version
 
 # Use ENTRYPOINT to ensure environment is loaded

--- a/curvine-docker/compile/Dockerfile_rocky9_cached
+++ b/curvine-docker/compile/Dockerfile_rocky9_cached
@@ -77,8 +77,10 @@ ENV PATH="/app/protoc/bin:${PATH}"
 
 # 4. Install Maven
 RUN cd /app && \
-    MAVEN_VERSION=3.9.15 && \
-    curl -fL -o apache-maven-${MAVEN_VERSION}-bin.tar.gz https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz && \
+    MAVEN_VERSION=3.9.16 && \
+    MAVEN_PACKAGE=apache-maven-${MAVEN_VERSION}-bin.tar.gz && \
+    MAVEN_ARCHIVE_URL=https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/${MAVEN_PACKAGE} && \
+    curl -fL -o ${MAVEN_PACKAGE} ${MAVEN_ARCHIVE_URL} && \
     tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz && \
     mv apache-maven-${MAVEN_VERSION} maven && \
     rm -f *.tar.gz && \

--- a/curvine-docker/compile/Dockerfile_rocky9_cached
+++ b/curvine-docker/compile/Dockerfile_rocky9_cached
@@ -81,7 +81,7 @@ RUN cd /app && \
     MAVEN_PACKAGE=apache-maven-${MAVEN_VERSION}-bin.tar.gz && \
     MAVEN_ARCHIVE_URL=https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/${MAVEN_PACKAGE} && \
     curl -fL -o ${MAVEN_PACKAGE} ${MAVEN_ARCHIVE_URL} && \
-    tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz && \
+    tar -xzf ${MAVEN_PACKAGE} && \
     mv apache-maven-${MAVEN_VERSION} maven && \
     rm -f *.tar.gz && \
     echo "✓ Maven ${MAVEN_VERSION} installed successfully"

--- a/curvine-docker/compile/Dockerfile_ubuntu22
+++ b/curvine-docker/compile/Dockerfile_ubuntu22
@@ -102,7 +102,7 @@ RUN cd /app && \
     MAVEN_PACKAGE=apache-maven-${MAVEN_VERSION}-bin.tar.gz && \
     MAVEN_ARCHIVE_URL=https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/${MAVEN_PACKAGE} && \
     curl -fL -o ${MAVEN_PACKAGE} ${MAVEN_ARCHIVE_URL} && \
-    tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz && \
+    tar -xzf ${MAVEN_PACKAGE} && \
     mv apache-maven-${MAVEN_VERSION} maven && \
     rm -f *.tar.gz && \
     echo "✓ Maven ${MAVEN_VERSION} installed successfully"

--- a/curvine-docker/compile/Dockerfile_ubuntu22
+++ b/curvine-docker/compile/Dockerfile_ubuntu22
@@ -98,8 +98,10 @@ ENV PATH="/app/protoc/bin:${PATH}"
 
 # 4. Install Maven
 RUN cd /app && \
-    MAVEN_VERSION=3.9.15 && \
-    curl -fL -o apache-maven-${MAVEN_VERSION}-bin.tar.gz https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz && \
+    MAVEN_VERSION=3.9.16 && \
+    MAVEN_PACKAGE=apache-maven-${MAVEN_VERSION}-bin.tar.gz && \
+    MAVEN_ARCHIVE_URL=https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/${MAVEN_PACKAGE} && \
+    curl -fL -o ${MAVEN_PACKAGE} ${MAVEN_ARCHIVE_URL} && \
     tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz && \
     mv apache-maven-${MAVEN_VERSION} maven && \
     rm -f *.tar.gz && \

--- a/curvine-docker/compile/Dockerfile_ubuntu24
+++ b/curvine-docker/compile/Dockerfile_ubuntu24
@@ -102,7 +102,7 @@ RUN cd /app && \
     MAVEN_PACKAGE=apache-maven-${MAVEN_VERSION}-bin.tar.gz && \
     MAVEN_ARCHIVE_URL=https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/${MAVEN_PACKAGE} && \
     curl -fL -o ${MAVEN_PACKAGE} ${MAVEN_ARCHIVE_URL} && \
-    tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz && \
+    tar -xzf ${MAVEN_PACKAGE} && \
     mv apache-maven-${MAVEN_VERSION} maven && \
     rm -f *.tar.gz && \
     echo "✓ Maven ${MAVEN_VERSION} installed successfully"

--- a/curvine-docker/compile/Dockerfile_ubuntu24
+++ b/curvine-docker/compile/Dockerfile_ubuntu24
@@ -98,8 +98,10 @@ ENV PATH="/app/protoc/bin:${PATH}"
 
 # 4. Install Maven
 RUN cd /app && \
-    MAVEN_VERSION=3.9.15 && \
-    curl -fL -o apache-maven-${MAVEN_VERSION}-bin.tar.gz https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz && \
+    MAVEN_VERSION=3.9.16 && \
+    MAVEN_PACKAGE=apache-maven-${MAVEN_VERSION}-bin.tar.gz && \
+    MAVEN_ARCHIVE_URL=https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/${MAVEN_PACKAGE} && \
+    curl -fL -o ${MAVEN_PACKAGE} ${MAVEN_ARCHIVE_URL} && \
     tar -xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz && \
     mv apache-maven-${MAVEN_VERSION} maven && \
     rm -f *.tar.gz && \

--- a/curvine-docker/deploy/Dockerfile_rocky9
+++ b/curvine-docker/deploy/Dockerfile_rocky9
@@ -1,5 +1,5 @@
 # ============================================================
-# EPEL + CRB (shared by spdk-deps and spdk-full)
+# EPEL + CRB (runtime base)
 # ============================================================
 FROM rockylinux:9 AS epel-base
 
@@ -21,86 +21,12 @@ RUN --mount=type=cache,sharing=locked,target=/var/cache/dnf \
     && dnf clean all
 
 # ============================================================
-# Stage 0: Install dependencies & clone SPDK
+# SPDK artifacts come from the compile image
 # ============================================================
-FROM epel-base AS spdk-deps
-
-ARG SPDK_VERSION=v25.09
-ARG NASM_VERSION=2.16.03
-ARG ISAL_VERSION=v2.31.1
-
-RUN --mount=type=cache,sharing=locked,target=/var/cache/dnf \
-    dnf install -y git && \
-    dnf clean all
-
-# Clone SPDK
-RUN git clone --depth 1 --branch "$SPDK_VERSION" --single-branch https://github.com/spdk/spdk.git /spdk
-WORKDIR /spdk
-RUN git submodule update --init --depth 1
-
-# Install SPDK build deps
-RUN --mount=type=cache,sharing=locked,target=/var/cache/dnf \
-    dnf config-manager --set-disabled devel 2>/dev/null || true && \
-    scripts/pkgdep.sh --rdma && \
-    dnf clean all
-
-# Build nasm from source (needed by ISA-L, not available in EPEL 9 for aarch64)
-RUN curl -sL https://www.nasm.us/pub/nasm/releasebuilds/$NASM_VERSION/nasm-$NASM_VERSION.tar.gz | \
-    tar -xz -C /tmp && \
-    cd /tmp/nasm-$NASM_VERSION && \
-    ./configure && \
-    make -j$(nproc) && \
-    make install && \
-    rm -rf /tmp/nasm-$NASM_VERSION
-
-# Build isa-l from source (needed by SPDK, not available in all Rocky 9 arches)
-RUN cd /tmp && \
-    git clone --depth 1 --branch $ISAL_VERSION https://github.com/intel/isa-l.git isa-l-src && \
-    cd isa-l-src && \
-    ./autogen.sh && \
-    ./configure && \
-    make -j$(nproc) && \
-    make install && \
-    ldconfig && \
-    cd / && rm -rf /tmp/isa-l-src
+FROM ghcr.io/curvineio/curvine-compile:rocky9 AS spdk-artifacts
 
 # ============================================================
-# Stage 1: Build SPDK
-# ============================================================
-FROM spdk-deps AS spdk-build
-
-ARG SPDK_VERSION
-WORKDIR /spdk
-
-RUN ./configure \
-    --disable-tests \
-    --with-rdma \
-    --without-vfio-user \
-    --target-arch=native \
-    --with-shared && \
-    make -j$(nproc) && \
-    mkdir -p /opt/spdk/build/bin \
-             /opt/spdk/build/lib \
-             /opt/spdk/dpdk/build/lib \
-             /opt/spdk/include/spdk \
-             /opt/spdk/dpdk/build/include \
-             /opt/spdk/isa-l/.libs \
-             /opt/spdk/isa-l-crypto/.libs && \
-    cp build/bin/nvmf_tgt /opt/spdk/build/bin/ && \
-    cp build/lib/libspdk*.so* /opt/spdk/build/lib/ && \
-    cp build/lib/libspdk*.a /opt/spdk/build/lib/ && \
-    cp dpdk/build/lib/librte_*.so* /opt/spdk/dpdk/build/lib/ && \
-    cp dpdk/build/lib/librte_*.a /opt/spdk/dpdk/build/lib/ && \
-    cp -r include/spdk/*.h /opt/spdk/include/spdk/ && \
-    cp -r dpdk/build/include/* /opt/spdk/dpdk/build/include/ && \
-    cp -r scripts /opt/spdk/scripts && \
-    cp -r python /opt/spdk/python && \
-    cp isa-l/.libs/libisal* /opt/spdk/isa-l/.libs/ && \
-    cp isa-l-crypto/.libs/libisal* /opt/spdk/isa-l-crypto/.libs/ && \
-    ldconfig
-
-# ============================================================
-# Stage 2: Full runtime for NVMe-oF Target nodes
+# Full runtime for NVMe-oF Target nodes
 # ============================================================
 FROM runtime-base AS spdk-full
 
@@ -109,7 +35,7 @@ RUN --mount=type=cache,sharing=locked,target=/var/cache/dnf \
     ncurses-libs kmod pciutils libffi fuse3-libs \
     && dnf clean all
 
-COPY --from=spdk-build /opt/spdk /opt/spdk
+COPY --from=spdk-artifacts /opt/spdk /opt/spdk
 
 RUN ldconfig && \
     mkdir -p /var/log/spdk /var/run/spdk
@@ -165,19 +91,9 @@ ENV PATH="/root/.cargo/bin:/app/protoc/bin:/app/maven/bin:${PATH}"
 COPY . /workspace/
 WORKDIR /workspace
 
-# Copy SPDK build artifacts for NVMe-oF initiator support
-COPY --from=spdk-build /opt/spdk /opt/spdk
+# SPDK build artifacts are provided by the compile image.
 ENV SPDK_DIR=/opt/spdk
 ENV PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig
-
-# Install SPDK linking dependencies (static .a libs)
-RUN --mount=type=cache,sharing=locked,target=/var/cache/dnf \
-    dnf install -y epel-release && \
-    dnf install -y numactl-devel libuuid-devel rdma-core-devel \
-    libibverbs-devel librdmacm-devel && \
-    cp /opt/spdk/isa-l/.libs/*.so* /usr/lib64/ && \
-    cp /opt/spdk/isa-l-crypto/.libs/*.so* /usr/lib64/ && \
-    ldconfig
 
 # 6. Pre-install WebUI dependencies and fix vue-cli-service module resolution
 RUN if [ -d "/workspace/curvine-web/webui" ]; then \
@@ -257,9 +173,9 @@ RUN --mount=type=cache,sharing=locked,target=/var/cache/dnf \
     fuse3 zlib libstdc++ nvme-cli \
     && dnf clean all && rm -rf /var/cache/dnf/*
 
-# Copy ISA-L shared libs for SPDK initiator (built from source, not in EPEL)
-COPY --from=spdk-build /opt/spdk/isa-l/.libs/libisal* /usr/lib64/
-COPY --from=spdk-build /opt/spdk/isa-l-crypto/.libs/libisal* /usr/lib64/
+# Copy ISA-L shared libs for SPDK initiator (built into the compile image)
+COPY --from=builder /opt/spdk/isa-l/.libs/libisal* /usr/lib64/
+COPY --from=builder /opt/spdk/isa-l-crypto/.libs/libisal* /usr/lib64/
 RUN ldconfig
 
 # Copy JindoSDK from builder stage for OSS-HDFS support


### PR DESCRIPTION
## Problem
SPDK was built inside the runtime Dockerfile, which made runtime image builds slow and mixed compile-time dependencies into deploy image responsibilities.

## Design
Move SPDK artifact creation into the Rocky9 compile image and have deploy images consume those prebuilt artifacts. Update compile image workflows to use native Docker builds on architecture-specific runners instead of buildx.

## Key Changes
- Build and expose `/opt/spdk` from the Rocky9 compile image.
- Remove SPDK clone/build stages from the Rocky9 deploy Dockerfile.
- Pin Maven downloads to Apache archive and remove the unused rocky9_cached compile workflow variant.
- Replace buildx-based compile image workflow steps with `docker build`, `docker push`, and `docker manifest`.