### PR TITLE
feat(fluid): adapt cache runtime integration

### DIFF
--- a/.github/workflows/build-fluid-image.yml
+++ b/.github/workflows/build-fluid-image.yml
@@ -135,7 +135,7 @@ jobs:
       - name: Build and push Fluid image for ${{ matrix.arch }}
         uses: docker/build-push-action@v5
         with:
-          context: .
+          context: ./curvine-docker/fluid
           file: ./curvine-docker/fluid/Dockerfile
           platforms: linux/${{ matrix.arch }}
           push: ${{ needs.prepare.outputs.push_image == 'true' }}
@@ -280,4 +280,3 @@ jobs:
           else
             echo "**Note:** Image was built but not pushed (push_image=false)" >> $GITHUB_STEP_SUMMARY
           fi
-

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ ifeq ($(IS_UBUNTU),1)
   SHELL_CMD := bash
 endif
 
+FLUID_IMAGE ?= curvine-fluid:latest
+FLUID_BASE_IMAGE_TAG ?= latest
+
 # Default target - show help
 help:
 	@echo "Curvine Build System - Available Commands:"
@@ -36,6 +39,7 @@ help:
 	@echo ""
 	@echo "Fluid (Kubernetes):"
 	@echo "  make docker-build-fluid          - Build unified Fluid Docker image (supports both cache-runtime and thin-runtime)"
+	@echo "                                    FLUID_IMAGE=curvine-fluid:latest FLUID_BASE_IMAGE_TAG=latest"
 	@echo ""
 	@echo "CSI (Container Storage Interface):"
 	@echo "  make curvine-csi                 - Build curvine-csi Docker image"
@@ -125,34 +129,34 @@ docker-compile:
 	docker run --rm --entrypoint="" -v $(PWD):/workspace -w /workspace curvine/curvine-compile:build-cached bash -c "make all"
 
 # 7.1. Build Fluid CacheRuntime Docker image
-docker-build-fluid-cache:
-	@echo "Building Fluid CacheRuntime Docker image..."
-	@bash curvine-docker/fluid/cache-runtime/build-image.sh
+docker-build-fluid-cache: docker-build-fluid
 
 # 7.2. Build Fluid ThinRuntime Docker image
-docker-build-fluid-thin:
-	@echo "Building Fluid ThinRuntime Docker image..."
-	@bash curvine-docker/fluid/thin-runtime/build-image.sh
+docker-build-fluid-thin: docker-build-fluid
 
 # 7.3. Build unified Fluid Docker image
 docker-build-fluid:
 	@echo "Building unified Fluid Docker image..."
 	@echo "This image supports both cache-runtime and thin-runtime modes"
-	@if ! docker image inspect ghcr.io/curvineio/curvine:latest >/dev/null 2>&1; then \
-		echo "Warning: Base image ghcr.io/curvineio/curvine:latest not found locally."; \
+	@if ! docker image inspect ghcr.io/curvineio/curvine:$(FLUID_BASE_IMAGE_TAG) >/dev/null 2>&1; then \
+		echo "Warning: Base image ghcr.io/curvineio/curvine:$(FLUID_BASE_IMAGE_TAG) not found locally."; \
 		echo "Attempting to pull from registry..."; \
-		docker pull ghcr.io/curvineio/curvine:latest || \
+		docker pull ghcr.io/curvineio/curvine:$(FLUID_BASE_IMAGE_TAG) || \
 		(echo "Error: Failed to pull base image. Please build it first with 'make docker-build' or pull from registry." && exit 1); \
 	fi
-	@cd curvine-docker/fluid && docker build -f Dockerfile -t curvine-fluid:latest .
-	@echo "✓ Unified Fluid Docker image built successfully: curvine-fluid:latest"
+	@docker build \
+		--build-arg BASE_IMAGE_TAG=$(FLUID_BASE_IMAGE_TAG) \
+		-f curvine-docker/fluid/Dockerfile \
+		-t $(FLUID_IMAGE) \
+		curvine-docker/fluid
+	@echo "✓ Unified Fluid Docker image built successfully: $(FLUID_IMAGE)"
 	@echo ""
 	@echo "Usage examples:"
 	@echo "  # CacheRuntime mode:"
-	@echo "  docker run -e FLUID_RUNTIME_COMPONENT_TYPE=master curvine-fluid:latest master start"
+	@echo "  docker run -e FLUID_RUNTIME_COMPONENT_TYPE=master $(FLUID_IMAGE) master start"
 	@echo ""
 	@echo "  # ThinRuntime mode:"
-	@echo "  docker run curvine-fluid:latest fluid-thin-runtime"
+	@echo "  docker run $(FLUID_IMAGE) fluid-thin-runtime"
 
 # 8. CSI (Container Storage Interface) target
 .PHONY: curvine-csi

--- a/curvine-docker/fluid/Dockerfile
+++ b/curvine-docker/fluid/Dockerfile
@@ -1,5 +1,6 @@
 ARG BASE_IMAGE_TAG=latest
 FROM ghcr.io/curvineio/curvine:${BASE_IMAGE_TAG}
+ARG BASE_IMAGE_TAG
 
 # Add metadata labels
 ARG REPO_URL=https://github.com/curvineio/curvine
@@ -8,30 +9,14 @@ LABEL org.opencontainers.image.description="Curvine Fluid Runtime Image (support
 LABEL org.opencontainers.image.base.name="ghcr.io/curvineio/curvine"
 LABEL org.opencontainers.image.base.tag="${BASE_IMAGE_TAG}"
 
-RUN if [ -f /etc/redhat-release ]; then \
-        dnf install -y python3 python3-yaml python3-toml zlib libstdc++ && \
-        dnf clean all && \
-        rm -rf /var/cache/dnf/*; \
-    else \
-        apt-get update && \
-        apt-get install -y --no-install-recommends \
-            python3 \
-            python3-yaml \
-            python3-toml \
-            zlib1g \
-            libstdc++6 && \
-        apt-get clean && \
-        rm -rf /var/lib/apt/lists/* && \
-        rm -rf /var/cache/apt/*; \
-    fi
-
 COPY generate_config.py /app/curvine/
 COPY config-parse.py /app/curvine/
+COPY mountUfs.sh /app/curvine/
 COPY entrypoint.sh /entrypoint.sh
 
 RUN chmod +x /app/curvine/generate_config.py \
     && chmod +x /app/curvine/config-parse.py \
+    && chmod +x /app/curvine/mountUfs.sh \
     && chmod +x /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]
-

--- a/curvine-docker/fluid/cache-runtime/curvine-cache-runtime-class.yaml
+++ b/curvine-docker/fluid/cache-runtime/curvine-cache-runtime-class.yaml
@@ -2,59 +2,93 @@ apiVersion: data.fluid.io/v1alpha1
 kind: CacheRuntimeClass
 metadata:
   name: curvine
-fileSystemType: fuse
+fileSystemType: curvinefs
 topology:
   master:
-    workloadType:
-      apiVersion: apps/v1
-      kind: StatefulSet
     service:
       headless: {}
-    dependencies:
-      encryptOption: {}
-    podTemplateSpec:
+    executionEntries:
+      mountUFS:
+        command:
+        - bash
+        - -c
+        - /app/curvine/mountUfs.sh
+        timeout: 120
+    template:
       spec:
         restartPolicy: Always
         containers:
         - name: master
-          image: ghcr.io/curvineio/curvine-fluid:latest
+          image: curvine-fluid:latest
+          command:
+          - /entrypoint.sh
           args:
           - master
+          - start
           imagePullPolicy: IfNotPresent
+          readinessProbe:
+            tcpSocket:
+              port: 8995
+            initialDelaySeconds: 35
+            periodSeconds: 5
+            failureThreshold: 12
+          env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          volumeMounts:
+          - name: curvine-logs
+            mountPath: /app/curvine/logs
+          - name: curvine-master-data
+            mountPath: /app/curvine/data
   worker:
-    workloadType:
-      apiVersion: apps/v1
-      kind: StatefulSet
     service:
       headless: {}
-    dependencies: {}
-    podTemplateSpec:
+    template:
       spec:
         restartPolicy: Always
         containers:
         - name: worker
-          image: ghcr.io/curvineio/curvine-fluid:latest
+          image: curvine-fluid:latest
+          command:
+          - /entrypoint.sh
           args:
           - worker
+          - start
           imagePullPolicy: IfNotPresent
+          readinessProbe:
+            tcpSocket:
+              port: 8997
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 12
+          env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          volumeMounts:
+          - name: curvine-logs
+            mountPath: /app/curvine/logs
+          - name: curvine-cache
+            mountPath: /app/curvine/data
   client:
-    workloadType:
-      apiVersion: apps/v1
-      kind: DaemonSet
-    dependencies:
-      encryptOption: {}
-    podTemplateSpec:
+    template:
       spec:
         restartPolicy: Always
         containers:
         - name: client
-          image: ghcr.io/curvineio/curvine-fluid:latest
+          image: curvine-fluid:latest
+          command:
+          - /entrypoint.sh
+          args:
+          - client
+          - start
+          imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
             runAsUser: 0
-          args:
-          - client
-          imagePullPolicy: IfNotPresent
           lifecycle:
             preStop:
               exec:
@@ -62,16 +96,7 @@ topology:
                 - /bin/sh
                 - -c
                 - |
-                  echo "PreStop: Cleaning up FUSE mount..."
-                  target_path="${CURVINE_TARGET_PATH:-${FLUID_RUNTIME_MOUNT_PATH}}"
-                  if [ -z "$target_path" ]; then
-                    echo "WARNING: Neither CURVINE_TARGET_PATH nor FLUID_RUNTIME_MOUNT_PATH is set, skipping unmount"
-                    exit 0
-                  fi
-                  if mountpoint -q "$target_path" 2>/dev/null; then
-                    echo "Unmounting $target_path"
+                  target_path="${CURVINE_TARGET_PATH:-${FLUID_RUNTIME_MOUNT_PATH:-}}"
+                  if [ -n "$target_path" ] && mountpoint -q "$target_path" 2>/dev/null; then
                     fusermount -u "$target_path" 2>/dev/null || umount -f "$target_path" 2>/dev/null || true
-                  else
-                    echo "Mount point $target_path is not mounted, skipping"
                   fi
-                  echo "PreStop: Cleanup completed"

--- a/curvine-docker/fluid/cache-runtime/curvine-dataset.yaml
+++ b/curvine-docker/fluid/cache-runtime/curvine-dataset.yaml
@@ -9,10 +9,8 @@ spec:
   accessModes:
   - ReadWriteMany
   mounts:
-  - name: demo
+  - name: curvine
     mountPoint: "curvine:///data"
-    options:
-      cluster_id: "curvine-demo"
 ---
 apiVersion: data.fluid.io/v1alpha1
 kind: CacheRuntime
@@ -21,86 +19,66 @@ metadata:
   namespace: default
 spec:
   runtimeClassName: curvine
-  
   volumes:
   - name: curvine-logs
     emptyDir: {}
   - name: curvine-cache
     emptyDir: {}
-  - name: curvine-meta
+  - name: curvine-master-data
     emptyDir: {}
-  - name: curvine-journal
-    emptyDir: {}
-  
   master:
+    replicas: 1
     options:
-      format_master: "false"
-      io_close_idle: "false"
+      format_master: "true"
       rpc_port: "8995"
       journal_port: "8996"
       web_port: "9000"
-      meta_dir: "/opt/curvine/data/meta"
-      journal_dir: "/opt/curvine/data/journal"
-      meta_disable_wal: "false"
-      meta_compression_type: "lz4"
-      meta_write_buffer_size: "64MB"
-    replicas: 3
+      meta_dir: "/app/curvine/data/meta"
+      journal_dir: "/app/curvine/data/journal"
     volumeMounts:
     - name: curvine-logs
-      mountPath: /opt/curvine/logs
-    - name: curvine-meta
-      mountPath: /opt/curvine/data/meta
-    - name: curvine-journal
-      mountPath: /opt/curvine/data/journal
+      mountPath: /app/curvine/logs
+    - name: curvine-master-data
+      mountPath: /app/curvine/data
     resources:
       requests:
-        memory: "256Mi"
-        cpu: "100m"
+        cpu: 100m
+        memory: 256Mi
       limits:
-        memory: "1Gi"
-        cpu: "500m"
-  
+        cpu: 500m
+        memory: 1Gi
   worker:
+    replicas: 1
     options:
-      format_worker: "false"
+      format_worker: "true"
       rpc_port: "8997"
       web_port: "9001"
-      dir_reserved: "5GB"
-      data_dir: "/opt/curvine/data"
-    replicas: 1
+      dir_reserved: "0"
     volumeMounts:
     - name: curvine-logs
-      mountPath: /opt/curvine/logs
+      mountPath: /app/curvine/logs
     - name: curvine-cache
-      mountPath: /opt/curvine/data
-    resources:
-      requests:
-        memory: "512Mi"
-        cpu: "200m"
-      limits:
-        memory: "2Gi"
-        cpu: "1000m"
+      mountPath: /app/curvine/data
     tieredStore:
       levels:
-      - quota: 5Gi
-        low: "0.5"
+      - low: "0.5"
         high: "0.8"
-        path: "/opt/curvine/data"
-        medium:
-          inline:
-            emptyDir: {}
-  
-  client:
-    options:
-      debug: "true"
-      log_level: "info"
-      rpc_timeout_ms: "60000"
-      data_timeout_ms: "60000"
-      rpc_close_idle: "false"
+        emptyDir:
+          quota: 5Gi
     resources:
       requests:
-        memory: "128Mi"
-        cpu: "50m"
+        cpu: 200m
+        memory: 512Mi
       limits:
-        memory: "512Mi"
-        cpu: "200m"
+        cpu: "1"
+        memory: 2Gi
+  client:
+    options:
+      debug: "false"
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        cpu: 200m
+        memory: 512Mi

--- a/curvine-docker/fluid/entrypoint.sh
+++ b/curvine-docker/fluid/entrypoint.sh
@@ -33,6 +33,7 @@ CURVINE_LOG_DIR="${CURVINE_HOME}/logs"
 
 FLUID_MODE=false
 FLUID_RUNTIME_TYPE_ENV="${FLUID_RUNTIME_TYPE:-}"
+FLUID_RUNTIME_TYPE=""
 
 if [ -n "$FLUID_RUNTIME_TYPE_ENV" ]; then
     FLUID_MODE=true
@@ -61,6 +62,16 @@ echo "SERVER_TYPE: $SERVER_TYPE, ACTION_TYPE: $ACTION_TYPE"
 
 set_hosts() {
     :
+}
+
+load_curvine_env() {
+    if [ -f "$CURVINE_HOME/conf/curvine-env.sh" ]; then
+        echo "Loading curvine environment variables..."
+        local original_home="$CURVINE_HOME"
+        source "$CURVINE_HOME/conf/curvine-env.sh"
+        export CURVINE_HOME="$original_home"
+        export CURVINE_CONF_FILE="${CURVINE_CONF_DIR}/curvine-cluster.toml"
+    fi
 }
 
 parse_fluid_config() {
@@ -167,72 +178,19 @@ setup_environment() {
 start_service() {
   local SERVICE_NAME=$1
 
-  if [ -z "$CURVINE_CONF_FILE" ]; then
+  if [ -z "${CURVINE_CONF_FILE:-}" ]; then
     export CURVINE_CONF_FILE=${CURVINE_HOME}/conf/curvine-cluster.toml
   fi
 
-  local LOG_DIR=${CURVINE_HOME}/logs
-  local OUT_FILE=${LOG_DIR}/${SERVICE_NAME}.out
-  mkdir -p "${LOG_DIR}"
+  mkdir -p "${CURVINE_HOME}/logs"
 
   cd "${CURVINE_HOME}"
 
   echo "Starting ${SERVICE_NAME} service..."
 
-  "${CURVINE_HOME}/lib/curvine-server" \
+  exec "${CURVINE_HOME}/lib/curvine-server" \
     --service "${SERVICE_NAME}" \
-    --conf "${CURVINE_CONF_FILE}" \
-    >> "${OUT_FILE}" 2>&1 &
-
-  local SERVER_PID=$!
-  sleep 3
-
-  if ! kill -0 "${SERVER_PID}" 2>/dev/null; then
-    wait "${SERVER_PID}" 2>/dev/null
-    local EXIT_CODE=$?
-    echo "${SERVICE_NAME} start fail - process exited during startup with code ${EXIT_CODE}"
-    if [ -f "${OUT_FILE}" ]; then
-      echo "Last 20 lines of output:"
-      tail -n 20 "${OUT_FILE}"
-    fi
-    exit 1
-  fi
-
-  local ACTUAL_PID
-  ACTUAL_PID=$(pgrep -n -f "${CURVINE_HOME}/lib/curvine-server[[:space:]].*--service[[:space:]]${SERVICE_NAME}" || true)
-  if [[ -n "${ACTUAL_PID}" ]] && kill -0 "${ACTUAL_PID}" 2>/dev/null; then
-    echo "${SERVICE_NAME} start success, pid=${ACTUAL_PID}"
-
-    local LOG_DATE=$(date +%Y-%m-%d)
-    local LOG_FILE="${LOG_DIR}/${SERVICE_NAME}.log.${LOG_DATE}"
-    
-    sleep 2
-    
-    if [ -f "${LOG_FILE}" ]; then
-      tail -f "${LOG_FILE}" &
-      local TAIL_PID=$!
-    else
-      tail -f "${OUT_FILE}" &
-      local TAIL_PID=$!
-    fi
-
-    wait "${SERVER_PID}"
-    local EXIT_CODE=$?
-    echo "${SERVICE_NAME} process exited with code ${EXIT_CODE}"
-    
-    if [ -n "${TAIL_PID}" ]; then
-      kill "${TAIL_PID}" 2>/dev/null || true
-    fi
-    
-    exit "${EXIT_CODE}"
-  else
-    echo "${SERVICE_NAME} start fail - process not found after startup check"
-    if [ -f "${OUT_FILE}" ]; then
-      echo "Last 20 lines of output:"
-      tail -n 20 "${OUT_FILE}"
-    fi
-    exit 1
-  fi
+    --conf "${CURVINE_CONF_FILE}"
 }
 
 start_curvine_component() {
@@ -244,12 +202,7 @@ start_curvine_component() {
     case "$component" in
         master)
             echo "Starting Curvine Master in Fluid cache-runtime mode..."
-            if [ -f "$CURVINE_HOME/conf/curvine-env.sh" ]; then
-                echo "Loading curvine environment variables..."
-                local original_home="$CURVINE_HOME"
-                source "$CURVINE_HOME/conf/curvine-env.sh"
-                export CURVINE_HOME="$original_home"
-            fi
+            load_curvine_env
             
             local pod_name="${HOSTNAME:-$(hostname)}"
             local namespace="${FLUID_DATASET_NAMESPACE:-default}"
@@ -263,12 +216,7 @@ start_curvine_component() {
         
         worker)
             echo "Starting Curvine Worker in Fluid cache-runtime mode..."
-            if [ -f "$CURVINE_HOME/conf/curvine-env.sh" ]; then
-                echo "Loading curvine environment variables..."
-                local original_home="$CURVINE_HOME"
-                source "$CURVINE_HOME/conf/curvine-env.sh"
-                export CURVINE_HOME="$original_home"
-            fi
+            load_curvine_env
             
             if [ -n "$CURVINE_MASTER_HOSTNAME" ]; then
                 echo "WARN: Ignoring CURVINE_MASTER_HOSTNAME in worker: $CURVINE_MASTER_HOSTNAME"
@@ -276,7 +224,8 @@ start_curvine_component() {
             
             local pod_name="${HOSTNAME:-$(hostname)}"
             local namespace="${FLUID_DATASET_NAMESPACE:-default}"
-            local worker_service="${CURVINE_WORKER_SERVICE:-$(echo $CURVINE_MASTER_SERVICE | sed 's/master/worker/')}"
+            local master_service="${CURVINE_MASTER_SERVICE:-curvine-master}"
+            local worker_service="${CURVINE_WORKER_SERVICE:-$(echo "$master_service" | sed 's/master/worker/')}"
             local worker_fqdn="${pod_name}.${worker_service}.${namespace}.svc.cluster.local"
             export CURVINE_WORKER_HOSTNAME="$worker_fqdn"
             echo "Set CURVINE_WORKER_HOSTNAME to: $CURVINE_WORKER_HOSTNAME"
@@ -300,8 +249,8 @@ start_curvine_component() {
             rm -rf "$target_path"/.* 2>/dev/null || true
             
             exec "$CURVINE_HOME/lib/curvine-fuse" \
-                --conf="$config_file" \
-                --mnt-path="$target_path"
+                --conf "$config_file" \
+                --mnt-path "$target_path"
             ;;
         
         *)

--- a/curvine-docker/fluid/generate_config.py
+++ b/curvine-docker/fluid/generate_config.py
@@ -2,18 +2,25 @@
 import os
 import sys
 import json
-import toml
 from copy import deepcopy
+
+TOP_LEVEL_KEYS = {'format_master', 'format_worker', 'testing', 'cluster_id'}
+INTEGER_OPTION_KEYS = {'rpc_port', 'web_port', 'journal_port', 'raft_port'}
+SECTION_ALIASES = {
+    'journal_port': ('journal', 'rpc_port'),
+    'journal_dir': ('journal', 'journal_dir'),
+    'master_hostname': ('master', 'hostname'),
+    'worker_hostname': ('worker', 'hostname'),
+}
 
 def generate_curvine_config():
     """Generate Curvine configuration from Fluid runtime config"""
     curvine_home = os.environ.get('CURVINE_HOME', '/app/curvine')
     config_path = os.environ.get('FLUID_RUNTIME_CONFIG_PATH', '/etc/fluid/config/config.json')
     config_file = os.environ.get('CURVINE_CONF_DIR', f'{curvine_home}/conf') + '/curvine-cluster.toml'
+    os.makedirs(os.path.dirname(config_file), exist_ok=True)
     data_dir = os.environ.get('CURVINE_DATA_DIR', f'{curvine_home}/data')
     log_dir = os.environ.get('CURVINE_LOG_DIR', f'{curvine_home}/logs')
-    cluster_id = os.environ.get('CURVINE_DATASET_NAME', 'curvine')
-
     try:
         if not os.path.exists(config_path):
             raise FileNotFoundError(f"Fluid config file not found: {config_path}")
@@ -39,19 +46,22 @@ def generate_curvine_config():
             
             if not isinstance(fluid_config, dict):
                 raise ValueError(f"Expected dict, got {type(fluid_config)}")
+
+        cluster_id = _cluster_id(fluid_config)
         
         default_config = {}
         if os.path.exists(config_file):
             with open(config_file, 'r') as f:
-                default_config = toml.load(f)
+                default_config = _load_existing_toml(f)
         
         current_hostname = os.environ.get('HOSTNAME', 'localhost')
         component_type = _determine_component_type(current_hostname)
         namespace = os.environ.get('FLUID_DATASET_NAMESPACE', 'default')
         
-        topology = fluid_config.get('topology', {})
-        master_service = topology.get('master', {}).get('service', {}).get('name', '')
-        worker_service = topology.get('worker', {}).get('service', {}).get('name', '')
+        master_runtime = _component_config(fluid_config, 'master')
+        worker_runtime = _component_config(fluid_config, 'worker')
+        master_service = _service_name(master_runtime)
+        worker_service = _service_name(worker_runtime)
         
         journal_addrs = _generate_journal_addrs(fluid_config, master_service, namespace)
         
@@ -64,7 +74,7 @@ def generate_curvine_config():
         _set_target_path(merged_config, fluid_config)
         
         with open(config_file, 'w') as f:
-            toml.dump(merged_config, f)
+            f.write(_to_toml(merged_config))
         
         _export_environment_variables(component_type, master_service, worker_service, 
                                     journal_addrs, fluid_config)
@@ -74,6 +84,115 @@ def generate_curvine_config():
         import traceback
         traceback.print_exc(file=sys.stderr)
         sys.exit(1)
+
+def _load_existing_toml(file_obj):
+    try:
+        import toml  # type: ignore
+        return toml.load(file_obj)
+    except Exception:
+        return {}
+
+def _toml_quote(value):
+    return '"' + str(value).replace('\\', '\\\\').replace('"', '\\"') + '"'
+
+def _toml_scalar(value):
+    if isinstance(value, bool):
+        return 'true' if value else 'false'
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float):
+        return str(value)
+    return _toml_quote(value)
+
+def _toml_array(value):
+    if not value:
+        return '[]'
+    if all(isinstance(item, dict) for item in value):
+        rendered = []
+        for item in value:
+            parts = [f"{key} = {_toml_scalar(val)}" for key, val in item.items()]
+            rendered.append("{ " + ", ".join(parts) + " }")
+        return "[\n    " + ",\n    ".join(rendered) + "\n]"
+    return "[" + ", ".join(_toml_scalar(item) for item in value) + "]"
+
+def _to_toml(data):
+    lines = []
+
+    def emit_value(key, value):
+        if isinstance(value, list):
+            lines.append(f"{key} = {_toml_array(value)}")
+        else:
+            lines.append(f"{key} = {_toml_scalar(value)}")
+
+    for key, value in data.items():
+        if not isinstance(value, dict):
+            emit_value(key, value)
+    if lines:
+        lines.append("")
+
+    for section, values in data.items():
+        if not isinstance(values, dict):
+            continue
+        lines.append(f"[{section}]")
+        for key, value in values.items():
+            if isinstance(value, dict):
+                continue
+            emit_value(key, value)
+        for subsection, subvalues in values.items():
+            if not isinstance(subvalues, dict):
+                continue
+            lines.append("")
+            lines.append(f"[{section}.{subsection}]")
+            for key, value in subvalues.items():
+                emit_value(key, value)
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+def _component_config(fluid_config, component_name):
+    """Return component config from either the latest top-level shape or old topology shape."""
+    component = fluid_config.get(component_name, {})
+    if component:
+        return component
+    return fluid_config.get('topology', {}).get(component_name, {})
+
+def _cluster_id(fluid_config):
+    dataset_name = os.environ.get('FLUID_DATASET_NAME') or os.environ.get('CURVINE_DATASET_NAME')
+    if dataset_name:
+        return dataset_name
+    mounts = fluid_config.get('mounts') or []
+    if mounts:
+        cluster_id = (mounts[0].get('options') or {}).get('cluster_id')
+        if cluster_id:
+            return cluster_id
+    return 'curvine'
+
+def _service_name(component_config):
+    service = component_config.get('service', {})
+    if isinstance(service, dict):
+        return service.get('name', '') or service.get('serviceName', '')
+    return ''
+
+def _runtime_name(fluid_config, master_service):
+    master_config = _component_config(fluid_config, 'master')
+    if master_config.get('name'):
+        return master_config['name'].rsplit('-master', 1)[0]
+
+    topology_master = fluid_config.get('topology', {}).get('master', {})
+    master_pods = topology_master.get('podConfigs', [])
+    if master_pods:
+        first_pod = master_pods[0].get('podName', '')
+        if first_pod and '-master-' in first_pod:
+            return first_pod.split('-master-')[0]
+
+    if master_service and '-master' in master_service:
+        service_prefix = master_service
+        if service_prefix.startswith('svc-'):
+            service_prefix = service_prefix[len('svc-'):]
+        return service_prefix.rsplit('-master', 1)[0]
+
+    dataset_name = os.environ.get('FLUID_DATASET_NAME')
+    return dataset_name or 'curvine'
 
 def _determine_component_type(hostname):
     """Determine component type from hostname"""
@@ -90,16 +209,13 @@ def _determine_component_type(hostname):
 def _generate_journal_addrs(fluid_config, master_service, namespace):
     """Generate journal addresses for master cluster"""
     journal_port = 8996
+    master_config = _component_config(fluid_config, 'master')
+    master_options = master_config.get('options', {})
+    journal_port = int(master_options.get('journal_port') or master_options.get('raft_port') or journal_port)
     journal_addrs = []
     
     topology = fluid_config.get('topology', {})
     master_pods = topology.get('master', {}).get('podConfigs', [])
-    
-    runtime_name = 'curvine'
-    if master_pods:
-        first_pod = master_pods[0].get('podName', '')
-        if first_pod and '-master-' in first_pod:
-            runtime_name = first_pod.split('-master-')[0]
     
     for i, pod in enumerate(master_pods):
         pod_name = pod.get('podName', '')
@@ -109,17 +225,17 @@ def _generate_journal_addrs(fluid_config, master_service, namespace):
     
     if not journal_addrs:
         namespace = os.environ.get('FLUID_DATASET_NAMESPACE', namespace or 'default')
+        runtime_name = _runtime_name(fluid_config, master_service)
+        replicas = int(master_config.get('replicas') or 1)
         if master_service and namespace:
-            if '-master' in master_service:
-                runtime_name = master_service.rsplit('-master', 1)[0]
-                master_pod_name = f"{runtime_name}-master-0"
-            else:
-                master_pod_name = f"{master_service}-0"
-            hostname = f"{master_pod_name}.{master_service}.{namespace}.svc.cluster.local"
+            for i in range(replicas):
+                master_pod_name = f"{runtime_name}-master-{i}"
+                hostname = f"{master_pod_name}.{master_service}.{namespace}.svc.cluster.local"
+                journal_addrs.append({"id": i + 1, "hostname": hostname, "port": journal_port})
         else:
             hostname = 'localhost'
-        journal_addrs.append({"id": 1, "hostname": hostname, "port": journal_port})
-        print(f"WARNING: No master pods found in topology, using default journal address: {hostname}:{journal_port}", file=sys.stderr)
+            journal_addrs.append({"id": 1, "hostname": hostname, "port": journal_port})
+        print(f"WARNING: No master pods found in topology, using generated journal address list: {journal_addrs}", file=sys.stderr)
     
     journal_addrs.sort(key=lambda x: x['hostname'])
     for i, addr in enumerate(journal_addrs):
@@ -133,32 +249,48 @@ def _build_base_config(default_config, cluster_id, data_dir, log_dir):
     merged_config['cluster_id'] = cluster_id
     
     # Initialize sections
-    for section in ['master', 'journal', 'worker', 'client', 'fuse']:
+    for section in ['master', 'journal', 'worker', 'client', 'fuse', 'log']:
         if section not in merged_config:
             merged_config[section] = {}
+    if 'rpc_port' not in merged_config['master']:
+        merged_config['master']['rpc_port'] = 8995
+    if 'web_port' not in merged_config['master']:
+        merged_config['master']['web_port'] = 9000
+    if 'rpc_port' not in merged_config['journal']:
+        merged_config['journal']['rpc_port'] = 8996
+    if 'rpc_port' not in merged_config['worker']:
+        merged_config['worker']['rpc_port'] = 8997
+    if 'web_port' not in merged_config['worker']:
+        merged_config['worker']['web_port'] = 9001
     
     # Update directories
-    if merged_config['master'].get('meta_dir', '').startswith('testing/'):
+    if not merged_config['master'].get('meta_dir') or merged_config['master'].get('meta_dir', '').startswith('testing/'):
         merged_config['master']['meta_dir'] = f"{data_dir}/meta"
     
-    if merged_config['journal'].get('journal_dir', '').startswith('testing/'):
+    if not merged_config['journal'].get('journal_dir') or merged_config['journal'].get('journal_dir', '').startswith('testing/'):
         merged_config['journal']['journal_dir'] = f"{data_dir}/journal"
     
     # Update log directories
     for component in ['master', 'worker']:
-        if component in merged_config and 'log' in merged_config[component]:
-            log_config = merged_config[component]['log']
-            if isinstance(log_config, dict) and log_config.get('log_dir') == 'stdout':
-                log_config['log_dir'] = log_dir
+        if 'log' not in merged_config[component] or not isinstance(merged_config[component].get('log'), dict):
+            merged_config[component]['log'] = {}
+        log_config = merged_config[component]['log']
+        if not log_config.get('log_dir') or log_config.get('log_dir') == 'stdout':
+            log_config['log_dir'] = log_dir
+        if not log_config.get('file_name'):
+            log_config['file_name'] = f"{component}.log"
+
+    if not merged_config['log'].get('log_dir'):
+        merged_config['log']['log_dir'] = log_dir
+    if not merged_config['log'].get('file_name'):
+        merged_config['log']['file_name'] = "curvine.log"
     
     return merged_config
 
 def _merge_fluid_options(merged_config, fluid_config):
     """Merge Fluid component options into configuration"""
-    TOP_LEVEL_KEYS = {'format_master', 'format_worker', 'testing', 'cluster_id'}
-    
     def merge_component_options(component_name):
-        component_config = fluid_config.get(component_name, {})
+        component_config = _component_config(fluid_config, component_name)
         options = component_config.get('options', {})
         
         if component_name not in merged_config:
@@ -168,11 +300,16 @@ def _merge_fluid_options(merged_config, fluid_config):
             if isinstance(value, str):
                 if value.lower() in ['true', 'false']:
                     value = value.lower() == 'true'
-                elif value.isdigit():
+                elif key in INTEGER_OPTION_KEYS and value.isdigit():
                     value = int(value)
             
             if key in TOP_LEVEL_KEYS:
                 merged_config[key] = value
+            elif key in SECTION_ALIASES:
+                section, alias_key = SECTION_ALIASES[key]
+                if section not in merged_config:
+                    merged_config[section] = {}
+                merged_config[section][alias_key] = value
             else:
                 merged_config[component_name][key] = value
     
@@ -185,7 +322,10 @@ def _set_hostnames_and_journal(merged_config, component_type, current_hostname,
     merged_config['journal']['journal_addrs'] = journal_addrs
     
     if component_type == 'master':
-        if journal_addrs:
+        match = next((addr for addr in journal_addrs if addr['hostname'].startswith(f"{current_hostname}.")), None)
+        if match:
+            master_fqdn = match['hostname']
+        elif journal_addrs:
             master_fqdn = journal_addrs[0]['hostname']
         elif master_service and current_hostname != 'localhost':
             master_fqdn = f"{current_hostname}.{master_service}.{namespace}.svc.cluster.local"
@@ -206,7 +346,7 @@ def _set_hostnames_and_journal(merged_config, component_type, current_hostname,
 
 def _set_cache_paths(merged_config, fluid_config):
     """Set cache paths from tieredStore configuration"""
-    worker_config = fluid_config.get('worker', {})
+    worker_config = _component_config(fluid_config, 'worker')
     
     if 'data_dir' in worker_config.get('options', {}):
         data_dir = worker_config['options']['data_dir']
@@ -218,27 +358,42 @@ def _set_cache_paths(merged_config, fluid_config):
         else:
             merged_config['worker']['data_dir'] = [str(data_dir)]
     else:
-        tiered_store = worker_config.get('tieredStore', [])
+        tiered_store = worker_config.get('tieredStoreLevels') or worker_config.get('tieredStore', [])
+        if isinstance(tiered_store, dict):
+            tiered_store = tiered_store.get('levels', [])
         
         if tiered_store and len(tiered_store) > 0:
             data_dirs = []
             for level in tiered_store:
-                path = level.get('path', '/cache-data')
+                mount_paths = level.get('mountPaths') or [level.get('path', '/cache-data')]
+                medium_type = level.get('mediumType')
                 medium = level.get('medium', {})
-                if 'emptyDir' in medium and medium['emptyDir'].get('medium') == 'Memory':
-                    storage_type = 'MEM'
-                else:
-                    storage_type = 'SSD'
-                
-                quota = level.get('quota', '')
-                if quota:
-                    data_dirs.append(f"[{storage_type}:{quota}]{path}")
-                else:
-                    data_dirs.append(f"[{storage_type}]{path}")
+                if not medium_type:
+                    if 'emptyDir' in level:
+                        medium_type = 'HDD'
+                    elif 'emptyDir' in medium and medium['emptyDir'].get('medium') == 'Memory':
+                        medium_type = 'MEM'
+                    else:
+                        medium_type = 'SSD'
+
+                quotas = level.get('quotas') or [level.get('quota') or level.get('emptyDir', {}).get('quota', '')]
+                for index, path in enumerate(mount_paths):
+                    quota = quotas[index] if index < len(quotas) else ''
+                    quota = _normalize_capacity(quota)
+                    if quota:
+                        data_dirs.append(f"[{medium_type}:{quota}]{path}")
+                    else:
+                        data_dirs.append(f"[{medium_type}]{path}")
             
             merged_config['worker']['data_dir'] = data_dirs if data_dirs else [f"[SSD]/cache-data"]
         else:
             merged_config['worker']['data_dir'] = [f"[SSD]/cache-data"]
+
+def _normalize_capacity(value):
+    if value is None:
+        return ''
+    value = str(value)
+    return value.replace('Ki', 'KB').replace('Mi', 'MB').replace('Gi', 'GB').replace('Ti', 'TB')
         
 def _set_client_endpoints(merged_config, journal_addrs):
     """Set client master endpoints"""
@@ -256,23 +411,24 @@ def _set_client_endpoints(merged_config, journal_addrs):
         
 def _set_target_path(merged_config, fluid_config):
     """Set FUSE target path"""
-    client_config = fluid_config.get('client', {})
-    target_path = client_config.get('targetPath', '/runtime-mnt/cache/default/curvine-demo/fuse')
+    client_config = _component_config(fluid_config, 'client')
+    target_path = fluid_config.get('targetPath') or client_config.get('targetPath', '/runtime-mnt/cache/default/curvine-demo/fuse')
     merged_config['fuse']['mnt_path'] = target_path
         
 def _export_environment_variables(component_type, master_service, worker_service, 
                                 journal_addrs, fluid_config):
     """Export environment variables for entrypoint script"""
-    client_config = fluid_config.get('client', {})
-    target_path = client_config.get('targetPath', '/runtime-mnt/cache/default/curvine-demo/fuse')
+    client_config = _component_config(fluid_config, 'client')
+    target_path = fluid_config.get('targetPath') or client_config.get('targetPath', '/runtime-mnt/cache/default/curvine-demo/fuse')
     print(f'export CURVINE_TARGET_PATH="{target_path}"')
     
     if component_type == 'master':
+        current_hostname = os.environ.get('HOSTNAME', 'localhost')
+        match = next((addr for addr in journal_addrs if addr['hostname'].startswith(f"{current_hostname}.")), None)
         if journal_addrs:
-            master_fqdn = journal_addrs[0]['hostname']
+            master_fqdn = (match or journal_addrs[0])['hostname']
             print(f'export CURVINE_MASTER_HOSTNAME="{master_fqdn}"')
         else:
-            current_hostname = os.environ.get('HOSTNAME', 'localhost')
             namespace = os.environ.get('FLUID_DATASET_NAMESPACE', 'default')
             if master_service and current_hostname != 'localhost':
                 master_fqdn = f"{current_hostname}.{master_service}.{namespace}.svc.cluster.local"

--- a/curvine-docker/fluid/mountUfs.sh
+++ b/curvine-docker/fluid/mountUfs.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONFIG_PATH="${FLUID_RUNTIME_CONFIG_PATH:-/etc/fluid/config/config.json}"
+CURVINE_HOME="${CURVINE_HOME:-/app/curvine}"
+CURVINE_CONF_FILE="${CURVINE_CONF_FILE:-${CURVINE_HOME}/conf/curvine-cluster.toml}"
+CV_BIN="${CURVINE_CLI:-${CURVINE_HOME}/bin/cv}"
+
+log() {
+  echo "$@" >&2
+}
+
+if [ ! -f "$CONFIG_PATH" ]; then
+  log "Fluid runtime config not found: $CONFIG_PATH"
+  printf '{"mounted":[]}\n'
+  exit 0
+fi
+
+python3 - "$CONFIG_PATH" "$CV_BIN" "$CURVINE_CONF_FILE" <<'PY'
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+config_path, cv_bin, conf_file = sys.argv[1:4]
+
+
+def eprint(*args):
+    print(*args, file=sys.stderr)
+
+
+def load_config(path):
+    with open(path, "r", encoding="utf-8") as f:
+        content = f.read().strip()
+    if not content:
+        return {}
+    data = json.loads(content)
+    if isinstance(data, str):
+        data = json.loads(data)
+    if not isinstance(data, dict):
+        raise ValueError(f"runtime config must be a JSON object, got {type(data).__name__}")
+    return data
+
+
+def read_secret(value):
+    if value and os.path.isfile(value):
+        with open(value, "r", encoding="utf-8") as f:
+            return f.read().strip()
+    return value
+
+
+def options_for_mount(mount):
+    options = dict(mount.get("options") or {})
+    encrypt_options = mount.get("encryptOptions") or {}
+
+    if isinstance(encrypt_options, list):
+        for item in encrypt_options:
+            name = item.get("name")
+            value_from = item.get("valueFrom") or {}
+            secret_key_ref = value_from.get("secretKeyRef") or {}
+            if name and secret_key_ref.get("path"):
+                encrypt_options[name] = secret_key_ref["path"]
+    if isinstance(encrypt_options, dict):
+        for key, value in encrypt_options.items():
+            options[key] = read_secret(value)
+
+    params = []
+    key_map = {
+        "endpoint_url": "s3.endpoint_url",
+        "region_name": "s3.region_name",
+        "path_style": "s3.force.path.style",
+        "access": "s3.credentials.access",
+        "secret": "s3.credentials.secret",
+        "access-key": "s3.credentials.access",
+        "secret-key": "s3.credentials.secret",
+    }
+    for key, conf_key in key_map.items():
+        value = options.get(key)
+        if value:
+            params.extend(["-c", f"{conf_key}={value}"])
+    return params
+
+
+def cv_path_for_mount(mount):
+    path = mount.get("path")
+    if path:
+        return path if path.startswith("/") else f"/{path}"
+    name = mount.get("name")
+    if name:
+        return name if str(name).startswith("/") else f"/{name}"
+    mount_point = mount.get("mountPoint") or ""
+    if "://" in mount_point:
+        suffix = mount_point.split("://", 1)[1].split("/", 1)
+        if len(suffix) == 2 and suffix[1]:
+            return f"/{suffix[1].strip('/')}"
+    return "/"
+
+
+def is_curvine_native_mount(mount_point):
+    return str(mount_point).startswith(("curvine://", "curvinefs://"))
+
+
+def run_cv(args):
+    cmd = [cv_bin, *args, "--conf", conf_file]
+    eprint("Running:", " ".join(cmd))
+    return subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+
+
+def parse_mounted_paths(output):
+    paths = []
+    for line in output.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("|"):
+            continue
+        cols = [col.strip() for col in stripped.strip("|").split("|")]
+        if len(cols) < 2 or cols[0] == "ID" or cols[1] == "Curvine Path":
+            continue
+        if cols[1]:
+            paths.append(cols[1])
+    return paths
+
+
+config = load_config(config_path)
+mounts = config.get("mounts") or []
+mounted = []
+
+if not shutil.which(cv_bin) and not os.path.exists(cv_bin):
+    for mount in mounts:
+        mount_point = mount.get("mountPoint")
+        if mount_point:
+            if is_curvine_native_mount(mount_point):
+                mounted.append(cv_path_for_mount(mount))
+            else:
+                mounted.append(mount_point)
+    print(json.dumps({"mounted": mounted}, separators=(",", ":")))
+    sys.exit(0)
+
+for mount in mounts:
+    mount_point = mount.get("mountPoint")
+    if not mount_point:
+        eprint("Skipping mount without mountPoint:", mount)
+        continue
+    cv_path = cv_path_for_mount(mount)
+    if is_curvine_native_mount(mount_point):
+        eprint(f"Skipping native Curvine mountPoint {mount_point}; reporting {cv_path}")
+        mounted.append(cv_path)
+        continue
+    params = options_for_mount(mount)
+
+    current = run_cv(["mount"])
+    if current.returncode == 0 and (mount_point in current.stdout or cv_path in current.stdout):
+        mounted.append(cv_path)
+        continue
+
+    command = [
+        "mount",
+        mount_point,
+        cv_path,
+        "--check-path-consist",
+        "false",
+        *params,
+    ]
+    result = run_cv(command)
+    if result.returncode != 0:
+        eprint(result.stdout)
+        eprint(result.stderr)
+        raise SystemExit(result.returncode)
+    mounted.append(cv_path)
+
+current = run_cv(["mount"])
+if current.returncode == 0:
+    mounted = parse_mounted_paths(current.stdout) or mounted
+elif current.stderr:
+    eprint(current.stderr)
+
+print(json.dumps({"mounted": mounted}, separators=(",", ":")))
+PY


### PR DESCRIPTION
## Background

Fluid has moved Curvine integration to the generic CacheRuntime flow. The old Docker material under `curvine-docker/fluid` assumed the older runtime config shape and did not provide a `MountUFS` entry that matches the current Fluid contract.

This PR keeps the diff focused on the adapter code and the core cache-runtime manifests needed for Fluid `1.1.0-alpha.9`.

## What Changed

### RuntimeConfig parsing

- Updated `curvine-docker/fluid/generate_config.py` to parse both the current top-level Fluid RuntimeConfig shape and the older `topology` shape.
- Added support for:
  - `master.service.name` and generated journal addresses
  - `worker.tieredStoreLevels` cache paths and quota conversion
  - top-level `targetPath` as the FUSE mount path
  - component `options` merging into Curvine TOML sections
  - `FLUID_DATASET_NAME` as the default cluster id
- Kept `dir_reserved` as a string while converting only port-like values to integers.
- Kept TOML rendering self-contained so the runtime image does not need extra Python TOML packages.

### MountUFS integration

- Added `curvine-docker/fluid/mountUfs.sh`.
- The script reads `FLUID_RUNTIME_CONFIG_PATH`, handles Fluid `encryptOptions` secret file paths, maps S3 options into Curvine `cv mount -c ...` options, and prints only Fluid-compatible JSON on stdout.
- Native Curvine mounts such as `curvine:///data` are treated as no-op mounts and reported as mounted Curvine paths.

### Runtime entrypoint and image

- Fixed cache-runtime startup under `set -u`.
- Preserved the Curvine image environment while forcing Fluid-generated config paths back to `/app/curvine`.
- Runs Curvine master and worker in the foreground so Kubernetes gets the real process status and logs.
- Simplified the Fluid Dockerfile to copy adapter scripts on top of the Curvine runtime image.

### Core cache-runtime manifests

- Reworked `CacheRuntimeClass` to use the current Fluid generic CacheRuntime `template` and `executionEntries.mountUFS` structure.
- Added master and worker readiness probes.
- Updated the example Dataset/CacheRuntime to use the new parser and mount flow.

### Build flow

- Fixed `.github/workflows/build-fluid-image.yml` so the Docker build context matches the Fluid Dockerfile layout.
- Added configurable Makefile variables:
  - `FLUID_IMAGE`, default `curvine-fluid:latest`
  - `FLUID_BASE_IMAGE_TAG`, default `latest`
- Redirected the old `docker-build-fluid-cache` and `docker-build-fluid-thin` Makefile targets to the unified Fluid image build instead of missing scripts.

## Local Verification

Commands run:

```bash
bash -n curvine-docker/fluid/entrypoint.sh curvine-docker/fluid/mountUfs.sh
python3 -m py_compile curvine-docker/fluid/generate_config.py curvine-docker/fluid/config-parse.py
make docker-build-fluid
kubectl apply --dry-run=client \
  -f curvine-docker/fluid/cache-runtime/curvine-cache-runtime-class.yaml \
  -f curvine-docker/fluid/cache-runtime/curvine-dataset.yaml
```

Local image built:

```text
curvine-fluid:latest
sha256:023a7fc17fbf956684713838e171042db1cbf5d3c47b9297202de3e331aaec4f
```

I also verified the adapter locally against Fluid chart `1.1.0-alpha.9` before trimming the PR diff to core files. Both native Curvine and S3-backed cache-runtime flows reached Ready locally:

```text
curvine-demo master=Ready worker=Ready client=Ready
curvine-s3-demo master=Ready worker=Ready client=Ready
```

The S3 local run confirmed `MountUFS` registered `/minio -> s3://test/` and the Fluid PVC could read from UFS and write/read Curvine cache data.

## Compatibility Notes

- The parser keeps compatibility with the old `topology` RuntimeConfig shape while supporting the current generic CacheRuntime shape.
- `MountUFS` keeps logs on stderr and writes only the final JSON object to stdout, as required by Fluid.
- Curvine `fs_mode` writes to Curvine cache, not back to the UFS. The local S3 verification covered UFS read and cache write/read behavior, not write-through.

## References

- Fluid generic CacheRuntime integration doc: https://github.com/fluid-cloudnative/fluid/blob/master/docs/zh/dev/generic_cache_runtime_integration.md
- Fluid Curvine e2e example: https://github.com/fluid-cloudnative/fluid/blob/master/test/gha-e2e/curvine/cacheruntimeclass.yaml
- Fluid chart release used for local testing: https://github.com/fluid-cloudnative/charts/releases/tag/helm-chart-fluid-1.1.0-alpha.9
