### PR TITLE
fix(fuse): avoid reusing completed writer after truncate

### DIFF
--- a/curvine-client/src/file/fs_writer.rs
+++ b/curvine-client/src/file/fs_writer.rs
@@ -151,8 +151,11 @@ impl Writer for FsWriter {
     }
 
     async fn resize(&mut self, opts: FileAllocOpts) -> FsResult<()> {
+        let len = opts.len;
         self.flush_chunk().await?;
-        self.inner.resize(opts).await
+        self.inner.resize(opts).await?;
+        self.pos = self.pos.min(len);
+        Ok(())
     }
 }
 

--- a/curvine-client/src/file/fs_writer_base.rs
+++ b/curvine-client/src/file/fs_writer_base.rs
@@ -339,6 +339,7 @@ impl FsWriterBase {
         }
 
         // Step 4: Reset writer state
+        self.pos = self.pos.min(len);
         self.len = len;
         self.file_blocks = file_blocks;
 

--- a/curvine-client/src/file/fs_writer_buffer.rs
+++ b/curvine-client/src/file/fs_writer_buffer.rs
@@ -88,14 +88,14 @@ impl BufferChannel {
         fun.await.map_err(|e| self.check_error(e))
     }
 
-    async fn resize(&mut self, opts: FileAllocOpts) -> FsResult<()> {
+    async fn resize(&mut self, opts: FileAllocOpts) -> FsResult<FileBlocks> {
         let fun = async {
             let (tx, rx) = CallChannel::channel();
             self.task_sender
                 .send(WriterTask::Resize((opts, tx)))
                 .await?;
-            rx.receive().await?;
-            Ok::<(), IOError>(())
+            let file_blocks = rx.receive().await?;
+            Ok::<FileBlocks, IOError>(file_blocks)
         };
         fun.await.map_err(|e| self.check_error(e))
     }
@@ -195,7 +195,10 @@ impl FsWriterBuffer {
     }
 
     pub async fn resize(&mut self, opts: FileAllocOpts) -> FsResult<()> {
-        self.writer.resize(opts).await
+        let file_blocks = self.writer.resize(opts).await?;
+        self.pos = self.pos.min(file_blocks.len);
+        self.file_blocks = file_blocks;
+        Ok(())
     }
 
     async fn write_future(

--- a/curvine-fuse/src/fs/fuse_writer.rs
+++ b/curvine-fuse/src/fs/fuse_writer.rs
@@ -126,15 +126,14 @@ impl FuseWriter {
     }
 
     pub async fn complete(&mut self, reply: Option<FuseResponse>) -> FsResult<()> {
+        self.completed = true;
         let fun = async {
             let (rx, tx) = CallChannel::channel();
             self.sender.send(WriteTask::Complete(rx, reply)).await?;
             tx.receive().await?;
             Ok::<(), FsError>(())
         };
-        fun.await.map_err(|e| self.check_error(e))?;
-        self.completed = true;
-        Ok(())
+        fun.await.map_err(|e| self.check_error(e))
     }
 
     pub async fn resize(&mut self, opts: FileAllocOpts) -> FsResult<()> {

--- a/curvine-fuse/src/fs/fuse_writer.rs
+++ b/curvine-fuse/src/fs/fuse_writer.rs
@@ -44,6 +44,7 @@ pub struct FuseWriter {
     is_ufs: bool,
     len: Arc<Mutex<i64>>,
     write_ver: AtomicCounter,
+    completed: bool,
 }
 
 impl FuseWriter {
@@ -79,6 +80,7 @@ impl FuseWriter {
             is_ufs,
             len,
             write_ver,
+            completed: false,
         }
     }
 
@@ -95,6 +97,10 @@ impl FuseWriter {
 
     pub fn is_ufs(&self) -> bool {
         self.is_ufs
+    }
+
+    pub fn is_completed(&self) -> bool {
+        self.completed
     }
 
     fn check_error(&self, e: FsError) -> FsError {
@@ -126,10 +132,13 @@ impl FuseWriter {
             tx.receive().await?;
             Ok::<(), FsError>(())
         };
-        fun.await.map_err(|e| self.check_error(e))
+        fun.await.map_err(|e| self.check_error(e))?;
+        self.completed = true;
+        Ok(())
     }
 
     pub async fn resize(&mut self, opts: FileAllocOpts) -> FsResult<()> {
+        let len = opts.len;
         let fun = async {
             let (rx, tx) = CallChannel::channel();
             self.sender.send(WriteTask::Resize(rx, opts)).await?;
@@ -137,7 +146,10 @@ impl FuseWriter {
             Ok::<(), FsError>(())
         };
         self.write_ver.incr();
-        fun.await.map_err(|e| self.check_error(e))
+        fun.await.map_err(|e| self.check_error(e))?;
+        let mut lock = self.len.lock().unwrap();
+        *lock = len;
+        Ok(())
     }
 
     pub fn len(&self) -> i64 {

--- a/curvine-fuse/src/fs/state/node_state.rs
+++ b/curvine-fuse/src/fs/state/node_state.rs
@@ -380,37 +380,118 @@ impl NodeState {
             return err_fuse!(libc::EINVAL, "Invalid flags: {:?}", flags);
         };
 
-        let mut lock = self.handles.write();
-
-        // Check if writer already exists to prevent duplicate creation
-        let check_writer = if let Some(writer) = writer {
-            if let Some(exist_writer) = Self::find_writer0(&lock, &ino) {
-                if exist_writer
-                    .try_lock()
-                    .map(|writer| !writer.is_completed())
-                    .unwrap_or(false)
-                {
-                    Some(exist_writer)
-                } else {
-                    Some(writer)
-                }
-            } else {
-                Some(writer)
-            }
-        } else {
-            None
-        };
-
-        let handle = Arc::new(FileHandle::new(
-            ino,
-            self.next_fh(),
-            reader,
-            check_writer,
-            status,
-        ));
-        Self::insert_file_handle_locked(&mut lock, handle.ino, handle.fh, handle.clone());
+        let handle = self
+            .insert_handle_with_writer(ino, reader, writer, status)
+            .await;
 
         Ok(handle)
+    }
+
+    async fn insert_handle_with_writer(
+        &self,
+        ino: u64,
+        reader: Option<RawPtr<FuseReader>>,
+        writer: Option<Arc<Mutex<FuseWriter>>>,
+        status: FileStatus,
+    ) -> Arc<FileHandle> {
+        let mut candidate_writer = writer;
+        let mut ignored_completed: Vec<Arc<Mutex<FuseWriter>>> = vec![];
+        let mut reader = Some(reader);
+        let mut status = Some(status);
+
+        loop {
+            let writer = match candidate_writer.take() {
+                Some(writer) => writer,
+                None => {
+                    let handle = Arc::new(FileHandle::new(
+                        ino,
+                        self.next_fh(),
+                        reader.take().unwrap(),
+                        None,
+                        status.take().unwrap(),
+                    ));
+                    let mut lock = self.handles.write();
+                    Self::insert_file_handle_locked(
+                        &mut lock,
+                        handle.ino,
+                        handle.fh,
+                        handle.clone(),
+                    );
+                    return handle;
+                }
+            };
+
+            let exist_writer = self.find_writer_excluding(ino, &ignored_completed);
+
+            let Some(exist_writer) = exist_writer else {
+                let handle = Arc::new(FileHandle::new(
+                    ino,
+                    self.next_fh(),
+                    reader.take().unwrap(),
+                    Some(writer),
+                    status.take().unwrap(),
+                ));
+                let mut lock = self.handles.write();
+                Self::insert_file_handle_locked(&mut lock, handle.ino, handle.fh, handle.clone());
+                return handle;
+            };
+
+            let exist_guard = exist_writer.lock().await;
+            if exist_guard.is_completed() {
+                drop(exist_guard);
+                ignored_completed.push(exist_writer);
+                candidate_writer = Some(writer);
+                continue;
+            }
+
+            {
+                let mut lock = self.handles.write();
+                let still_exists = lock.get(&ino).is_some_and(|handles| {
+                    handles
+                        .values()
+                        .filter_map(|handle| handle.writer.as_ref())
+                        .any(|writer| Arc::ptr_eq(writer, &exist_writer))
+                });
+                if still_exists {
+                    let handle = Arc::new(FileHandle::new(
+                        ino,
+                        self.next_fh(),
+                        reader.take().unwrap(),
+                        Some(exist_writer.clone()),
+                        status.take().unwrap(),
+                    ));
+                    Self::insert_file_handle_locked(
+                        &mut lock,
+                        handle.ino,
+                        handle.fh,
+                        handle.clone(),
+                    );
+                    return handle;
+                }
+            };
+
+            drop(exist_guard);
+            candidate_writer = Some(writer);
+        }
+    }
+
+    fn find_writer_excluding(
+        &self,
+        ino: u64,
+        ignored_writers: &[Arc<Mutex<FuseWriter>>],
+    ) -> Option<Arc<Mutex<FuseWriter>>> {
+        let lock = self.handles.read();
+        lock.get(&ino).and_then(|handles| {
+            handles
+                .values()
+                .filter_map(|handle| handle.writer.as_ref())
+                .find(|writer| {
+                    !ignored_writers
+                        .iter()
+                        .any(|ignored| Arc::ptr_eq(ignored, writer))
+                })
+                .cloned()
+        })
     }
 
     /// Runtime chokepoint for inserting a file handle while holding the write

--- a/curvine-fuse/src/fs/state/node_state.rs
+++ b/curvine-fuse/src/fs/state/node_state.rs
@@ -385,7 +385,15 @@ impl NodeState {
         // Check if writer already exists to prevent duplicate creation
         let check_writer = if let Some(writer) = writer {
             if let Some(exist_writer) = Self::find_writer0(&lock, &ino) {
-                Some(exist_writer)
+                if exist_writer
+                    .try_lock()
+                    .map(|writer| !writer.is_completed())
+                    .unwrap_or(false)
+                {
+                    Some(exist_writer)
+                } else {
+                    Some(writer)
+                }
             } else {
                 Some(writer)
             }

--- a/curvine-fuse/src/fs/state/node_state.rs
+++ b/curvine-fuse/src/fs/state/node_state.rs
@@ -265,7 +265,9 @@ impl NodeState {
         };
 
         if let Some(writer) = exists_writer {
-            return Ok(writer);
+            if !writer.lock().await.is_completed() {
+                return Ok(writer);
+            }
         }
 
         let writer = self.fs.open_with_opts(path, opts, flags).await?;


### PR DESCRIPTION
## Summary

Fix FUSE write failures after truncating a file and then reopening it for more writes.

A workload can repeatedly open a file, append data, truncate it to a smaller size, close it, then reopen and continue writing from the new EOF. Before this change, the truncate path updated file metadata successfully, but the FUSE/client writer state could remain stale or reuse a completed writer. The next write then failed with `EIO`, with logs showing `channel closed`.

## Minimal Reproducer

```c
#include <fcntl.h>
#include <unistd.h>
#include <string.h>
#include <stdio.h>
#include <errno.h>

int main(int argc, char **argv) {
    if (argc < 2) {
        fprintf(stderr, "usage: %s <file>\n", argv[0]);
        return 1;
    }

    char buf[20480];
    memset(buf, 'a', sizeof(buf));

    for (int i = 1; i <= 20; i++) {
        int fd = open(argv[1], O_RDWR | O_CREAT | O_SYNC, 0777);
        if (fd < 0) { perror("open"); return 1; }

        if (lseek(fd, 0, SEEK_END) < 0) { perror("lseek"); return 2; }

        ssize_t n = write(fd, buf, sizeof(buf));
        if (n != sizeof(buf)) {
            fprintf(stderr, "iter=%d write ret=%zd errno=%d\n", i, n, errno);
            perror("write");
            return 3;
        }

        if (i % 10 == 0) {
            off_t cur = lseek(fd, 0, SEEK_CUR);
            off_t new_size = cur - 20480;
            if (new_size < 0) new_size = 0;

            if (ftruncate(fd, new_size) != 0) {
                fprintf(stderr, "iter=%d truncate to %lld failed errno=%d\n",
                        i, (long long)new_size, errno);
                perror("ftruncate");
                return 4;
            }
        }

        close(fd);
    }

    return 0;
}
```

Run it on a Curvine FUSE mount:

gcc /tmp/cv_gf30_mini.c -o /tmp/cv_gf30_mini
rm -f /curvine-fuse/cv_gf30_mini
/tmp/cv_gf30_mini /curvine-fuse/cv_gf30_mini

Before the fix, it failed at iteration 11:

iter=11 write ret=-1 errno=5
write: Input/output error

## Root Cause

Two writer state issues were involved:

1. Resize/truncate updated the file length, but writer positions in the layered client writers were not clamped to the new file length.
2. NodeState::new_writer() reused an existing FuseWriter for the inode even after that writer had already been completed on release(). Reusing this completed writer caused subsequent writes to send through a closed channel.

A representative debug log showed:

FuseWriter write failed path=/cv_gf30_mini off=184320 len=20480 writer_pos=184320 writer_len=184320 err=IO([]channel closed)

## Changes

- Clamp writer position after resize in:
    - FsWriterBase
    - FsWriterBuffer
    - FsWriter

- Refresh FsWriterBuffer cached FileBlocks after resize.
- Track completed state in FuseWriter.
- Avoid reusing completed FuseWriter instances in NodeState::new_writer().
- Update FUSE writer length cache after resize.

## Verification

- Minimal C reproducer passes after the fix.
- cargo fmt --check passes.