### PR TITLE
fix(master): bootstrap empty non-format data dirs

### DIFF
--- a/build/bin/local-cluster.sh
+++ b/build/bin/local-cluster.sh
@@ -72,6 +72,84 @@ check_service_status() {
     fi
 }
 
+read_rpc_port() {
+    local section=$1
+    local default_port=$2
+    local conf_file="${CURVINE_CONF_FILE:-$CURVINE_HOME/conf/curvine-cluster.toml}"
+
+    if [ ! -f "$conf_file" ]; then
+        echo "$default_port"
+        return
+    fi
+
+    awk -v section="[$section]" -v default_port="$default_port" '
+        /^[[:space:]]*\[/ {
+            line = $0
+            sub(/[[:space:]]*#.*/, "", line)
+            gsub(/[[:space:]]/, "", line)
+            in_section = (line == section)
+        }
+        in_section && /^[[:space:]]*rpc_port[[:space:]]*=/ {
+            line = $0
+            sub(/[[:space:]]*#.*/, "", line)
+            sub(/^[^=]*=/, "", line)
+            gsub(/[[:space:]"]/, "", line)
+            if (line != "") {
+                print line
+                found = 1
+                exit
+            }
+        }
+        END {
+            if (!found) {
+                print default_port
+            }
+        }
+    ' "$conf_file"
+}
+
+wait_service_ready() {
+    local service=$1
+    local port=$2
+    local timeout=${3:-60}
+    local elapsed=0
+    local pid_file="$CURVINE_HOME/${service}.pid"
+
+    print_info "Waiting for $service RPC port $port to become ready..."
+    while [ $elapsed -lt $timeout ]; do
+        if [ -f "$pid_file" ]; then
+            local pid=$(cat "$pid_file")
+            if ! kill -0 "$pid" > /dev/null 2>&1; then
+                print_error "$service exited before RPC port $port became ready"
+                tail -80 "$LOG_DIR/${service}.out" 2>/dev/null || true
+                return 1
+            fi
+        fi
+
+        if command -v nc >/dev/null 2>&1; then
+            if nc -z 127.0.0.1 "$port" >/dev/null 2>&1; then
+                print_info "$service RPC port $port is ready"
+                return 0
+            fi
+        elif command -v ss >/dev/null 2>&1; then
+            if ss -ltn "( sport = :$port )" | grep -q ":$port"; then
+                print_info "$service RPC port $port is ready"
+                return 0
+            fi
+        else
+            print_warn "Neither nc nor ss is available; only process start was verified"
+            return 0
+        fi
+
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+
+    print_error "$service RPC port $port was not ready after ${timeout}s"
+    tail -80 "$LOG_DIR/${service}.out" 2>/dev/null || true
+    return 1
+}
+
 # Start all services
 start_all() {
     print_info "Starting Curvine local cluster..."
@@ -93,12 +171,16 @@ start_all() {
         return 1
     fi
     
-    # Start each service
-    for service in "${SERVICES[@]}"; do
-        print_info "Starting $service..."
-        "$BIN_DIR/curvine-${service}.sh" start
-        sleep 2
-    done
+    local master_port=$(read_rpc_port "master" 8995)
+    local worker_port=$(read_rpc_port "worker" 8997)
+
+    print_info "Starting master..."
+    "$BIN_DIR/curvine-master.sh" start
+    wait_service_ready "master" "$master_port" 180 || return 1
+
+    print_info "Starting worker..."
+    "$BIN_DIR/curvine-worker.sh" start
+    wait_service_ready "worker" "$worker_port" 60 || return 1
     
     print_info "All services started. Use 'status' to check cluster status."
 }

--- a/build/bin/restart-all.sh
+++ b/build/bin/restart-all.sh
@@ -20,6 +20,42 @@ BIN_DIR="$(cd "`dirname "$0"`"; pwd)"
 
 # Close all services and restart.
 
+read_rpc_port() {
+    local section=$1
+    local default_port=$2
+    local conf_file="${CURVINE_CONF_FILE:-${BIN_DIR}/../conf/curvine-cluster.toml}"
+
+    if [ ! -f "$conf_file" ]; then
+        echo "$default_port"
+        return
+    fi
+
+    awk -v section="[$section]" -v default_port="$default_port" '
+        /^[[:space:]]*\[/ {
+            line = $0
+            sub(/[[:space:]]*#.*/, "", line)
+            gsub(/[[:space:]]/, "", line)
+            in_section = (line == section)
+        }
+        in_section && /^[[:space:]]*rpc_port[[:space:]]*=/ {
+            line = $0
+            sub(/[[:space:]]*#.*/, "", line)
+            sub(/^[^=]*=/, "", line)
+            gsub(/[[:space:]"]/, "", line)
+            if (line != "") {
+                print line
+                found = 1
+                exit
+            }
+        }
+        END {
+            if (!found) {
+                print default_port
+            }
+        }
+    ' "$conf_file"
+}
+
 # Function to wait for a process to start
 wait_for_process() {
     local service_name=$1
@@ -40,19 +76,63 @@ wait_for_process() {
     return 1
 }
 
+wait_for_port() {
+    local service_name=$1
+    local port=$2
+    local timeout=${3:-60}
+    local count=0
+
+    echo "Waiting for $service_name RPC port $port..."
+    while [ $count -lt $timeout ]; do
+        if command -v nc >/dev/null 2>&1; then
+            if nc -z 127.0.0.1 "$port" >/dev/null 2>&1; then
+                echo "$service_name RPC port $port is ready"
+                return 0
+            fi
+        elif command -v ss >/dev/null 2>&1; then
+            if ss -ltn "( sport = :$port )" | grep -q ":$port"; then
+                echo "$service_name RPC port $port is ready"
+                return 0
+            fi
+        else
+            echo "Warning: neither nc nor ss is available; only process start was verified"
+            return 0
+        fi
+
+        if ! ps -ef | grep "curvine" | grep "$service_name" | grep -v grep > /dev/null; then
+            echo "Error: $service_name exited before RPC port $port became ready"
+            tail -80 "${BIN_DIR}/../logs/${service_name}.out" 2>/dev/null || true
+            return 1
+        fi
+
+        sleep 1
+        count=$((count + 1))
+    done
+
+    echo "Error: $service_name RPC port $port did not become ready within $timeout seconds"
+    tail -80 "${BIN_DIR}/../logs/${service_name}.out" 2>/dev/null || true
+    return 1
+}
+
 umount -l /curvine-fuse
 pkill -9 -f "curvine"
 
 # Wait a moment for processes to be killed
 sleep 3
 
+MASTER_PORT=$(read_rpc_port "master" 8995)
+WORKER_PORT=$(read_rpc_port "worker" 8997)
+
 # Start master and worker services
 ${BIN_DIR}/curvine-master.sh start
+wait_for_process "master" || exit 1
+wait_for_port "master" "$MASTER_PORT" 180 || exit 1
+
 ${BIN_DIR}/curvine-worker.sh start
 
 # Wait for master and worker to start
-wait_for_process "master"
-wait_for_process "worker"
+wait_for_process "worker" || exit 1
+wait_for_port "worker" "$WORKER_PORT" 60 || exit 1
 
 # Start fuse service
 ${BIN_DIR}/curvine-fuse.sh start

--- a/curvine-common/src/rocksdb/db_engine.rs
+++ b/curvine-common/src/rocksdb/db_engine.rs
@@ -254,9 +254,7 @@ impl DBEngine {
             info!("Delete(format) exists db path {:?}", base_dir)
         }
 
-        if FileUtils::exists(base_dir) {
-            FileUtils::create_dir(base_dir, true)?;
-        }
+        FileUtils::create_dir(base_dir, true)?;
 
         Ok(())
     }

--- a/curvine-common/tests/rocks_db_test.rs
+++ b/curvine-common/tests/rocks_db_test.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use curvine_common::rocksdb::{DBConf, DBEngine, RocksIterator, RocksUtils};
-use orpc::common::FileUtils;
+use orpc::common::{FileUtils, Utils};
 use orpc::CommonResult;
 
 // Rocksdb database core function test
@@ -27,6 +27,22 @@ fn test_rocksdb_scan_and_range_operations() {
 
     scan_test1(&db, "scan1").unwrap();
     scan_test2(&db, "scan2").unwrap();
+}
+
+#[test]
+fn test_rocksdb_non_format_creates_missing_base_dir() -> CommonResult<()> {
+    let base_dir = Utils::test_sub_dir(format!("rocks_non_format_missing_{}", Utils::rand_str(6)));
+    FileUtils::delete_path(&base_dir, true)?;
+
+    let conf = DBConf::new(&base_dir);
+    let db = DBEngine::new(conf.clone(), false)?;
+    db.put("k".as_bytes(), "v")?;
+
+    assert!(std::path::Path::new(&conf.data_dir)
+        .join("CURRENT")
+        .is_file());
+
+    Ok(())
 }
 
 #[test]

--- a/curvine-server/src/master/journal/journal_system.rs
+++ b/curvine-server/src/master/journal/journal_system.rs
@@ -61,6 +61,13 @@ struct FsInitParts {
     job_manager: Arc<JobManager>,
 }
 
+#[derive(Debug, Eq, PartialEq)]
+enum MasterDataDirState {
+    RocksDb,
+    CleanEmpty,
+    Invalid,
+}
+
 impl JournalSystem {
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -151,23 +158,84 @@ impl JournalSystem {
 
         let meta_db_conf = conf.db_conf();
         let journal_db_conf = conf.journal.db_conf();
-        let mut invalid_dirs = Vec::new();
+        let meta_state =
+            Self::classify_master_data_dir(&meta_db_conf.base_dir, &meta_db_conf.data_dir);
+        let journal_state =
+            Self::classify_master_data_dir(&journal_db_conf.base_dir, &journal_db_conf.data_dir);
 
-        if !Self::looks_like_rocksdb_data_dir(&meta_db_conf.data_dir) {
-            invalid_dirs.push(format!("meta={}", meta_db_conf.data_dir));
-        }
-        if !Self::looks_like_rocksdb_data_dir(&journal_db_conf.data_dir) {
-            invalid_dirs.push(format!("journal={}", journal_db_conf.data_dir));
-        }
-
-        if invalid_dirs.is_empty() {
+        if meta_state == MasterDataDirState::RocksDb && journal_state == MasterDataDirState::RocksDb
+        {
             return Ok(());
         }
 
+        if meta_state == MasterDataDirState::CleanEmpty
+            && journal_state == MasterDataDirState::CleanEmpty
+        {
+            FileUtils::create_dir(&meta_db_conf.base_dir, true)?;
+            FileUtils::create_dir(&journal_db_conf.base_dir, true)?;
+            return Ok(());
+        }
+
+        let mut invalid_dirs = Vec::new();
+
+        if meta_state != MasterDataDirState::RocksDb {
+            invalid_dirs.push(format!("meta={}", meta_db_conf.data_dir));
+        }
+        if journal_state != MasterDataDirState::RocksDb {
+            invalid_dirs.push(format!("journal={}", journal_db_conf.data_dir));
+        }
+
         err_box!(
-            "format_master=false requires existing RocksDB data directories before master startup; missing, empty, or unreadable: {}. For a fresh cluster, bootstrap with format_master=true. For replacing an HA master, preseed a consistent meta and journal copy before starting the pod",
+            "format_master=false found inconsistent or invalid master data directories: {}. Meta and journal must either both be valid RocksDB stores or both be missing/clean empty; non-empty non-RocksDB directories are refused. For replacing an HA master, preseed a consistent meta and journal copy before starting the pod",
             invalid_dirs.join(", ")
         )
+    }
+
+    fn classify_master_data_dir(base_dir: &str, data_dir: &str) -> MasterDataDirState {
+        if Self::looks_like_rocksdb_data_dir(data_dir) {
+            return MasterDataDirState::RocksDb;
+        }
+
+        let base_path = Path::new(base_dir);
+        if !base_path.exists() {
+            return MasterDataDirState::CleanEmpty;
+        }
+        if !base_path.is_dir() {
+            return MasterDataDirState::Invalid;
+        }
+
+        let data_path = Path::new(data_dir);
+        if Self::is_clean_empty_master_base(base_path, data_path) {
+            MasterDataDirState::CleanEmpty
+        } else {
+            MasterDataDirState::Invalid
+        }
+    }
+
+    fn is_clean_empty_master_base(base_path: &Path, data_path: &Path) -> bool {
+        let Ok(entries) = fs::read_dir(base_path) else {
+            return false;
+        };
+
+        for entry in entries {
+            let Ok(entry) = entry else {
+                return false;
+            };
+
+            let path = entry.path();
+            if path != data_path || !Self::is_empty_dir(&path) {
+                return false;
+            }
+        }
+
+        true
+    }
+
+    fn is_empty_dir(path: &Path) -> bool {
+        path.is_dir()
+            && fs::read_dir(path)
+                .map(|mut entries| entries.next().is_none())
+                .unwrap_or(false)
     }
 
     fn looks_like_rocksdb_data_dir(path: &str) -> bool {
@@ -336,5 +404,88 @@ impl JournalSystem {
         let data = SnapshotData::decode(snapshot.get_data())?;
         self.rt
             .block_on(self.raft_journal.app_store().apply_snapshot(data))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use curvine_common::conf::{JournalConf, MasterConf};
+    use curvine_common::raft::RaftPeer;
+    use orpc::common::Utils;
+
+    fn non_format_master_conf(name: &str, multi_master: bool) -> ClusterConf {
+        let mut journal = JournalConf::with_test();
+        journal.enable = false;
+        journal.journal_dir = Utils::test_sub_dir(format!("master-journal-test/journal-{}", name));
+        if multi_master {
+            journal
+                .journal_addrs
+                .push(RaftPeer::new(2, "localhost", journal.rpc_port + 1));
+        }
+
+        ClusterConf {
+            format_master: false,
+            testing: true,
+            master: MasterConf {
+                meta_dir: Utils::test_sub_dir(format!("master-journal-test/meta-{}", name)),
+                ..Default::default()
+            },
+            journal,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn require_existing_master_data_allows_clean_empty_non_format_dirs() -> FsResult<()> {
+        for multi_master in [false, true] {
+            let name = format!(
+                "clean-empty-non-format-{}-{}",
+                if multi_master { "ha" } else { "single" },
+                Utils::rand_str(6)
+            );
+            let conf = non_format_master_conf(&name, multi_master);
+            let _ = fs::remove_dir_all(&conf.master.meta_dir);
+            let _ = fs::remove_dir_all(&conf.journal.journal_dir);
+
+            JournalSystem::require_existing_master_data(&conf)?;
+
+            assert!(Path::new(&conf.master.meta_dir).is_dir());
+            assert!(Path::new(&conf.journal.journal_dir).is_dir());
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn require_existing_master_data_refuses_dirty_non_format_dirs() -> FsResult<()> {
+        for multi_master in [false, true] {
+            let name = format!(
+                "dirty-non-format-{}-{}",
+                if multi_master { "ha" } else { "single" },
+                Utils::rand_str(6)
+            );
+            let conf = non_format_master_conf(&name, multi_master);
+            let _ = fs::remove_dir_all(&conf.master.meta_dir);
+            let _ = fs::remove_dir_all(&conf.journal.journal_dir);
+            fs::create_dir_all(&conf.master.meta_dir)?;
+            fs::create_dir_all(&conf.journal.journal_dir)?;
+            fs::write(
+                Path::new(&conf.journal.journal_dir).join("orphaned-file"),
+                "not rocksdb",
+            )?;
+
+            let err = JournalSystem::require_existing_master_data(&conf)
+                .expect_err("dirty master data directory must be refused");
+            let err_msg = err.to_string();
+            assert!(
+                err_msg.contains("format_master=false")
+                    && err_msg.contains("inconsistent or invalid master data directories"),
+                "unexpected error: {}",
+                err_msg
+            );
+        }
+
+        Ok(())
     }
 }

--- a/curvine-server/tests/master_fs_test.rs
+++ b/curvine-server/tests/master_fs_test.rs
@@ -20,7 +20,6 @@ use curvine_common::proto::{
     CreateFileRequest, DeleteRequest, MkdirOptsProto, MkdirRequest, RenameRequest,
 };
 use curvine_common::raft::storage::{AppStorage, ApplyMsg};
-use curvine_common::raft::RaftPeer;
 use curvine_common::state::MountOptions;
 use curvine_common::state::{
     BlockLocation, ClientAddress, CommitBlock, CreateFileOpts, FileAllocOpts, WorkerInfo,
@@ -35,7 +34,7 @@ use orpc::common::LocalTime;
 use orpc::common::Utils;
 use orpc::message::Builder;
 use orpc::runtime::{AsyncRuntime, RpcRuntime};
-use orpc::{err_box, CommonResult};
+use orpc::CommonResult;
 use raft::eraftpb::Entry;
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
@@ -267,96 +266,6 @@ fn test_filesystem_metadata_restore_with_full_journal_system_reopen() -> CommonR
 
     drop(fs);
     js.shutdown();
-
-    Ok(())
-}
-
-#[test]
-fn test_journal_system_refuses_non_format_start_with_empty_master_dirs() -> CommonResult<()> {
-    let _serial = master_fs_test_serial();
-    Master::init_test_metrics();
-    let name = format!("empty-non-format-{}", Utils::rand_str(6));
-    let mut conf = ClusterConf {
-        format_master: false,
-        testing: true,
-        master: MasterConf {
-            meta_dir: Utils::test_sub_dir(format!("master-fs-test/meta-{}", name)),
-            ..Default::default()
-        },
-        journal: JournalConf {
-            enable: false,
-            journal_dir: Utils::test_sub_dir(format!("master-fs-test/journal-{}", name)),
-            ..Default::default()
-        },
-        ..Default::default()
-    };
-    let _ = std::fs::remove_dir_all(&conf.master.meta_dir);
-    let _ = std::fs::remove_dir_all(&conf.journal.journal_dir);
-    std::fs::create_dir_all(&conf.master.meta_dir)?;
-    std::fs::create_dir_all(&conf.journal.journal_dir)?;
-    conf.format_master = false;
-
-    let err = match JournalSystem::from_conf(&conf) {
-        Ok(js) => {
-            js.shutdown();
-            return err_box!("format_master=false initialized empty master data directories");
-        }
-        Err(e) => e,
-    };
-    let err_msg = err.to_string();
-    assert!(
-        err_msg.contains("format_master=false")
-            && err_msg.contains("missing, empty, or unreadable"),
-        "unexpected error: {}",
-        err_msg
-    );
-
-    Ok(())
-}
-
-#[test]
-fn test_journal_system_refuses_empty_non_format_start_for_multi_master() -> CommonResult<()> {
-    let _serial = master_fs_test_serial();
-    Master::init_test_metrics();
-    let name = format!("empty-non-format-ha-{}", Utils::rand_str(6));
-    let mut conf = ClusterConf {
-        format_master: false,
-        testing: true,
-        master: MasterConf {
-            meta_dir: Utils::test_sub_dir(format!("master-fs-test/meta-{}", name)),
-            ..Default::default()
-        },
-        journal: JournalConf {
-            enable: false,
-            journal_dir: Utils::test_sub_dir(format!("master-fs-test/journal-{}", name)),
-            ..Default::default()
-        },
-        ..Default::default()
-    };
-    conf.journal.journal_addrs = vec![
-        RaftPeer::new(1, "localhost", conf.journal.rpc_port),
-        RaftPeer::new(2, "localhost", conf.journal.rpc_port + 1),
-    ];
-    let _ = std::fs::remove_dir_all(&conf.master.meta_dir);
-    let _ = std::fs::remove_dir_all(&conf.journal.journal_dir);
-    std::fs::create_dir_all(&conf.master.meta_dir)?;
-    std::fs::create_dir_all(&conf.journal.journal_dir)?;
-
-    let err = match JournalSystem::from_conf(&conf) {
-        Ok(js) => {
-            js.shutdown();
-            return err_box!("format_master=false initialized empty HA master data directories");
-        }
-        Err(e) => e,
-    };
-    let err_msg = err.to_string();
-    assert!(
-        err_msg.contains("format_master=false")
-            && err_msg.contains("before master startup")
-            && err_msg.contains("preseed a consistent meta and journal copy"),
-        "unexpected error: {}",
-        err_msg
-    );
 
     Ok(())
 }


### PR DESCRIPTION
## Background

Curvine local scripts and Helm-style fresh deployments commonly start a new cluster with `format_master=false`. That setting means: do not delete existing master metadata on startup. It does not mean the metadata directories must already contain a RocksDB database when the cluster is brand new.

Before the recent guard was added, this worked because RocksDB was opened with `create_if_missing=true`. A fresh cluster could start with missing or empty `meta` and `journal` directories, and RocksDB created `meta/data` and `journal/data` during startup.

PR #942 tightened the `format_master=false` path to protect HA replacement cases. That safety check required both master metadata directories to already look like valid RocksDB stores. The check prevented unsafe empty replacement, but it also broke the fresh-cluster case: a new single-master or new HA cluster has no RocksDB files yet, so startup failed before RocksDB could create them.

The user-visible error was:

```text
format_master=false requires existing RocksDB data directories for single-master startup; missing, empty, or unreadable: meta=..., journal=...
```

## Root Cause

The bug is not simply that a directory is missing. The bug is that the startup logic treated two different states as the same state:

- a clean fresh cluster, where both `meta` and `journal` are missing or empty;
- a bad or partial master state, where only one side exists, or a directory contains non-RocksDB files.

The first state is safe to bootstrap. The second state is unsafe. For example, if `journal/data` already has a `CURRENT` and `MANIFEST-*` but `meta/data` is missing, startup cannot infer whether this is a half-written previous startup, an operator mistake, or a damaged volume. Auto-creating the missing side would hide an inconsistent master state.

There was also a separate startup-script race. `local-cluster.sh` and `restart-all.sh` started the worker after checking that the master process existed. But the master process is not ready until it finishes RocksDB initialization, joins/elects Raft, and opens the RPC port. On a slow disk, the worker can start while port `8995` is still closed and fail to connect.

## Fix

This PR separates clean bootstrap from unsafe state.

For `format_master=false`, master startup now accepts only these states:

1. both `meta/data` and `journal/data` are valid RocksDB stores;
2. both master base directories are missing or clean empty directories.

It rejects mixed or dirty states:

- one side is RocksDB and the other side is missing or empty;
- either base directory contains unrelated files;
- either base path exists but is not a directory;
- a `data` directory exists but does not look like RocksDB.

For the clean bootstrap case, the code creates the `meta` and `journal` base directories and lets RocksDB create the actual DB files. `DBEngine` now always creates the base directory before opening RocksDB, even when `format=false`, so `create_if_missing=true` has a valid parent path to work with.

The local scripts now wait for the configured RPC ports instead of sleeping for a fixed time:

- wait for master RPC before starting worker;
- wait for worker RPC before reporting the cluster ready;
- read `rpc_port` from `curvine-cluster.toml`, falling back to `8995` and `8997`;
- print the service log tail when readiness times out.

## Why Not Just Create Missing Directories Unconditionally

Creating directories is correct only when both master metadata roots are clean. If one side already contains RocksDB and the other side is missing, unconditional creation would convert an inconsistent state into a seemingly valid startup path. That is dangerous for HA replacement and for partial bootstrap after a killed startup.

So the rule is:

- clean + clean: bootstrap;
- RocksDB + RocksDB: reopen;
- anything mixed or dirty: fail loudly.

This preserves the old fresh-cluster behavior without weakening the safety check added for HA replacement.

## Changed Files

- `curvine-common/src/rocksdb/db_engine.rs`
  - create the RocksDB base directory before open, regardless of `format`.
- `curvine-server/src/master/journal/journal_system.rs`
  - classify master metadata directories as `RocksDb`, `CleanEmpty`, or `Invalid`;
  - allow clean empty bootstrap;
  - reject mixed or dirty metadata states.
- `build/bin/local-cluster.sh`
  - wait for master and worker RPC readiness.
- `build/bin/restart-all.sh`
  - wait for master RPC before starting worker;
  - wait for worker RPC before starting fuse.
- tests
  - cover non-format RocksDB base-dir creation;
  - cover clean-empty and dirty non-format master directory classification.

## Verification

Ran formatting and static checks:

```bash
cargo fmt
git diff --check
cargo clippy --all-targets --jobs 4 -- --deny warnings --allow clippy::uninlined-format-args
```

Ran targeted tests:

```bash
cargo test -p curvine-server --lib master::journal::journal_system::tests:: -- --nocapture
# 2 passed, 71 filtered out

cargo test -p curvine-common --test rocks_db_test test_rocksdb_non_format_creates_missing_base_dir -- --nocapture
# 1 passed, 3 filtered out
```

Built the dist used for e2e:

```bash
build/build.sh -d -p server -p cli --alloc system --skip-java-sdk --skip-python-sdk
```

Ran e2e with a clean `/tmp` data root and default `format_master=false`:

- `local-cluster.sh start` brought up master and worker;
- master RPC port `8995` became ready before worker start;
- worker RPC port `8997` became ready before status reported success;
- RocksDB files were created under both metadata roots:
  - `journal/data/CURRENT`
  - `journal/data/MANIFEST-000005`
  - `meta/data/CURRENT`
  - `meta/data/MANIFEST-000005`
- `cv fs mkdir /e2e` succeeded;
- `cv fs ls /` listed `/e2e`.

I also verified cleanup afterward: no local `curvine-server` master/worker process remained, and the temporary dist config was restored.
