### PR TITLE
feat(fuse): add namespaced inode/handle count gauges (phase 3b-1)

### DIFF
--- a/curvine-fuse/src/fs/state/node_map.rs
+++ b/curvine-fuse/src/fs/state/node_map.rs
@@ -55,7 +55,10 @@ impl NodeMap {
         // production mount. Assumes one FUSE mount / one NodeState per process
         // (the CLI builds a single CurvineFileSystem); multi-mount would need a
         // per-state aggregator instead.
-        FuseMetrics::with(|m| m.inode_num.set(1));
+        FuseMetrics::with(|m| {
+            m.inode_num.set(1);
+            m.inode_count.set(1);
+        });
         Self {
             nodes,
             names: FastHashMap::default(),
@@ -83,7 +86,10 @@ impl NodeMap {
     fn insert_node(&mut self, id: u64, node: NodeAttr) -> Option<NodeAttr> {
         let prev = self.nodes.insert(id, node);
         if prev.is_none() {
-            FuseMetrics::with(|m| m.inode_num.inc());
+            FuseMetrics::with(|m| {
+                m.inode_num.inc();
+                m.inode_count.inc();
+            });
         }
         prev
     }
@@ -95,7 +101,10 @@ impl NodeMap {
     fn remove_node(&mut self, id: u64) -> Option<NodeAttr> {
         let removed = self.nodes.remove(&id);
         if removed.is_some() {
-            FuseMetrics::with(|m| m.inode_num.dec());
+            FuseMetrics::with(|m| {
+                m.inode_num.dec();
+                m.inode_count.dec();
+            });
         }
         removed
     }
@@ -370,7 +379,13 @@ impl NodeMap {
         if let Some(exists_node) = self.lookup_node(new_id, Some(new_name)).cloned() {
             self.delete_name(&exists_node)?;
             if exists_node.should_unref() {
-                self.nodes.remove(&exists_node.id);
+                // Go through the remove_node chokepoint (not a bare
+                // `self.nodes.remove`) so both the legacy `inode_num` and the
+                // namespaced `inode_count` gauges decrement with the live map.
+                // The name mapping was already cleared by `delete_name` above,
+                // so we must NOT call `delete_node` here (that would re-run
+                // delete_name / parent-ref changes) — only the inode removal.
+                self.remove_node(exists_node.id);
             }
         }
 
@@ -595,7 +610,11 @@ impl NodeMap {
         // Single inode_num set from the live map count — runs on success and on
         // every early-return above (the closure captured `&mut self`, so reading
         // `self.nodes.len()` here is fine and reflects whatever was loaded).
-        FuseMetrics::with(|m| Self::sync_inode_gauge(&m.inode_num, self.nodes.len()));
+        FuseMetrics::with(|m| {
+            let live = self.nodes.len();
+            Self::sync_inode_gauge(&m.inode_num, live);
+            Self::sync_inode_gauge(&m.inode_count, live);
+        });
         result
     }
 
@@ -707,6 +726,44 @@ mod tests {
         );
         // The inode survives under its new parent, same id.
         assert!(map.get(src).is_some(), "renamed inode keeps its id");
+    }
+
+    #[test]
+    fn rename_overwrite_unreffed_target_drops_one_inode() {
+        // rename onto an EXISTING target whose `should_unref()` is true must
+        // remove the target inode through the `remove_node` chokepoint, so the
+        // live count drops by exactly one (and, in production, both the legacy
+        // `inode_num` and the namespaced `inode_count` gauges decrement). This is
+        // the path that previously did a bare `self.nodes.remove`, drifting the
+        // gauges. We assert on `nodes_len()` (the value the gauges track) rather
+        // than the process-global gauge, to stay parallel-test safe.
+        let mut map = test_map();
+        let src = map.find_node(FUSE_ROOT_ID, Some("src")).unwrap().id;
+        let target = map.find_node(FUSE_ROOT_ID, Some("target")).unwrap().id;
+
+        // Make the target collectible: drop its lookup to 0 (find_node set it to
+        // 1) so `should_unref()` (n_lookup==0 && ref_ctr==0 && !root) holds.
+        map.get_mut(target).unwrap().sub_lookup(1);
+        assert!(
+            map.get(target).unwrap().should_unref(),
+            "target must be unref-able to exercise the remove branch"
+        );
+
+        let before = map.nodes_len();
+        map.rename_node(FUSE_ROOT_ID, "src", FUSE_ROOT_ID, "target")
+            .unwrap();
+
+        assert_eq!(
+            map.nodes_len(),
+            before - 1,
+            "overwriting an unreffed target removes exactly one inode"
+        );
+        // The overwritten target id is gone; the source inode took its name.
+        assert!(
+            map.get(target).is_none(),
+            "overwritten target inode removed"
+        );
+        assert!(map.get(src).is_some(), "source inode survives the rename");
     }
 
     #[test]

--- a/curvine-fuse/src/fs/state/node_state.rs
+++ b/curvine-fuse/src/fs/state/node_state.rs
@@ -514,7 +514,9 @@ impl NodeState {
         handle: Arc<FileHandle>,
     ) {
         if Self::map_insert_handle(lock, ino, fh, handle) {
-            FuseMetrics::with(|m| m.file_handle_num.inc());
+            FuseMetrics::with(|m| {
+                Self::inc_gauges_lockstep(&m.file_handle_num, &m.file_handle_count)
+            });
         }
     }
 
@@ -529,7 +531,9 @@ impl NodeState {
     ) -> Option<Arc<FileHandle>> {
         let (handle, removed) = Self::map_remove_handle(lock, ino, fh);
         if removed {
-            FuseMetrics::with(|m| m.file_handle_num.dec());
+            FuseMetrics::with(|m| {
+                Self::dec_gauges_lockstep(&m.file_handle_num, &m.file_handle_count)
+            });
         }
         handle
     }
@@ -694,7 +698,9 @@ impl NodeState {
         handle: Arc<DirHandle>,
     ) {
         if Self::map_insert_handle(lock, ino, fh, handle) {
-            FuseMetrics::with(|m| m.dir_handle_num.inc());
+            FuseMetrics::with(|m| {
+                Self::inc_gauges_lockstep(&m.dir_handle_num, &m.dir_handle_count)
+            });
         }
     }
 
@@ -707,7 +713,9 @@ impl NodeState {
     ) -> Option<Arc<DirHandle>> {
         let (handle, removed) = Self::map_remove_handle(lock, ino, fh);
         if removed {
-            FuseMetrics::with(|m| m.dir_handle_num.dec());
+            FuseMetrics::with(|m| {
+                Self::dec_gauges_lockstep(&m.dir_handle_num, &m.dir_handle_count)
+            });
         }
         handle
     }
@@ -917,12 +925,11 @@ impl NodeState {
         // covering the Ok path and every early-? above. inode_num is not touched
         // here (NodeMap::restore already owns it).
         FuseMetrics::with(|m| {
-            Self::sync_handle_gauges(
-                &m.file_handle_num,
-                self.file_handles_len(),
-                &m.dir_handle_num,
-                self.dir_handles_len(),
-            )
+            let file_len = self.file_handles_len();
+            let dir_len = self.dir_handles_len();
+            Self::sync_handle_gauges(&m.file_handle_num, file_len, &m.dir_handle_num, dir_len);
+            // Phase 3b-1: namespaced aliases set from the same live counts.
+            Self::sync_handle_gauges(&m.file_handle_count, file_len, &m.dir_handle_count, dir_len);
         });
 
         if result.is_ok() {
@@ -945,6 +952,23 @@ impl NodeState {
     ) {
         file_gauge.set(file_len as i64);
         dir_gauge.set(dir_len as i64);
+    }
+
+    /// Increment a legacy gauge and its Phase 3b-1 namespaced alias in lockstep.
+    /// Extracted as a `&Gauge` taker (like [`Self::sync_handle_gauges`]) so the
+    /// "legacy and alias move together" invariant is unit-testable against
+    /// injected, isolated gauges — the process-global handle gauges are written
+    /// by parallel tests, so a direct assertion on them would be flaky. Both are
+    /// single atomic adds, safe to call inside the in-lock `FuseMetrics::with`.
+    fn inc_gauges_lockstep(legacy: &orpc::common::Gauge, alias: &orpc::common::Gauge) {
+        legacy.inc();
+        alias.inc();
+    }
+
+    /// Decrement counterpart of [`Self::inc_gauges_lockstep`].
+    fn dec_gauges_lockstep(legacy: &orpc::common::Gauge, alias: &orpc::common::Gauge) {
+        legacy.dec();
+        alias.dec();
     }
 }
 
@@ -1102,6 +1126,9 @@ mod test {
         let mx = crate::FuseMetrics::get();
 
         // --- file handle: inc/dec file_handle_num, must not touch dir_handle_num ---
+        // (Namespaced-alias lockstep is proven separately against injected,
+        // isolated gauges in `inc_dec_gauges_lockstep_move_both_together`, to keep
+        // this process-global-gauge test free of extra flaky absolute assertions.)
         let mut file_map: FastHashMap<u64, FastHashMap<u64, Arc<FileHandle>>> =
             FastHashMap::default();
         let file_before = mx.file_handle_num.get();
@@ -1151,6 +1178,33 @@ mod test {
             dir_before,
             "removing the fh must dec dir_handle_num back"
         );
+    }
+
+    // Phase 3b-1: prove the legacy gauge and its namespaced alias move together
+    // on inc/dec, against INJECTED isolated gauges (not the process-global ones),
+    // so the assertion is exact yet parallel-test safe (the production chokepoints
+    // call these same helpers inside their `FuseMetrics::with` closure).
+    #[test]
+    fn inc_dec_gauges_lockstep_move_both_together() {
+        let legacy = orpc::common::Metrics::new_gauge(
+            "test_lockstep_legacy_gauge_unique",
+            "isolated legacy gauge",
+        )
+        .unwrap();
+        let alias = orpc::common::Metrics::new_gauge(
+            "test_lockstep_alias_gauge_unique",
+            "isolated alias gauge",
+        )
+        .unwrap();
+
+        NodeState::inc_gauges_lockstep(&legacy, &alias);
+        NodeState::inc_gauges_lockstep(&legacy, &alias);
+        assert_eq!(legacy.get(), 2, "legacy inc'd twice");
+        assert_eq!(alias.get(), 2, "alias must track legacy on inc");
+
+        NodeState::dec_gauges_lockstep(&legacy, &alias);
+        assert_eq!(legacy.get(), 1, "legacy dec'd once");
+        assert_eq!(alias.get(), 1, "alias must track legacy on dec");
     }
 
     // The restore handle finalizer feeds file_handles_len()/dir_handles_len() to

--- a/curvine-fuse/src/fuse_metrics.rs
+++ b/curvine-fuse/src/fuse_metrics.rs
@@ -162,6 +162,15 @@ pub struct FuseMetrics {
     pub file_handle_num: Gauge,
     pub dir_handle_num: Gauge,
 
+    // --- Phase 3b-1: namespaced aliases of the legacy gauges above ---
+    // Event-driven at the same insert/remove/restore sites, kept exactly in
+    // lockstep with their legacy counterparts (updated inside the same
+    // `FuseMetrics::with` closure). The legacy `*_num` gauges are deprecated and
+    // will be removed two minor releases after dashboards migrate to these.
+    pub inode_count: Gauge,
+    pub file_handle_count: Gauge,
+    pub dir_handle_count: Gauge,
+
     // --- Phase 1a-2: end-to-end request metrics ---
     /// E2E in-flight requests, driven by `ActiveGuard`: incremented at ctx
     /// creation, decremented at the sender/no-reply finish. `kind`.
@@ -318,13 +327,17 @@ impl FuseMetrics {
     /// no-op when not (instead of `get()`'s panic).
     ///
     /// This is the access path for the **legacy compatibility gauges**
-    /// (`inode_num` / `file_handle_num` / `dir_handle_num`), which are updated
-    /// unconditionally at their inode/handle mutation sites (Phase 1b-2 made
-    /// them event-driven and removed the scrape-time `set_metrics()` refresh).
-    /// Those sites live in `NodeState`/`NodeMap`, whose unit tests construct
-    /// state with a bare `NodeState::new` and never call `ensure_init()`;
-    /// routing every legacy-gauge write through `with()` keeps them from
-    /// panicking on the uninitialized singleton.
+    /// (`inode_num` / `file_handle_num` / `dir_handle_num`) **and their Phase 3b-1
+    /// namespaced aliases** (`curvine_fuse_{inode,file_handle,dir_handle}_count`),
+    /// which are updated unconditionally at their inode/handle mutation sites
+    /// (Phase 1b-2 made them event-driven and removed the scrape-time
+    /// `set_metrics()` refresh; 3b-1 added the aliases in lockstep at the same
+    /// sites). Those sites live in `NodeState`/`NodeMap`, whose unit tests
+    /// construct state with a bare `NodeState::new` and never call
+    /// `ensure_init()`; routing every gauge write through `with()` keeps them
+    /// from panicking on the uninitialized singleton. The aliases MUST use this
+    /// same `with()` path — do NOT switch them to `FuseMetrics::get()`, which
+    /// would reintroduce that panic on the bare-`NodeState` test paths.
     ///
     /// The uninit branch is a deliberate, silent no-op — NOT a `debug_assert!`.
     /// Tests run in debug with a process-global `OnceCell` whose init order
@@ -345,6 +358,20 @@ impl FuseMetrics {
             inode_num: m::new_gauge("inode_num", "FUSE inode count in dcache")?,
             file_handle_num: m::new_gauge("file_handle_num", "FUSE open file handle count")?,
             dir_handle_num: m::new_gauge("dir_handle_num", "FUSE open directory handle count")?,
+
+            // Phase 3b-1: namespaced aliases (same values, event-driven in lockstep).
+            inode_count: m::new_gauge(
+                "curvine_fuse_inode_count",
+                "FUSE inode count in dcache (namespaced alias of inode_num)",
+            )?,
+            file_handle_count: m::new_gauge(
+                "curvine_fuse_file_handle_count",
+                "FUSE open file handle count (namespaced alias of file_handle_num)",
+            )?,
+            dir_handle_count: m::new_gauge(
+                "curvine_fuse_dir_handle_count",
+                "FUSE open directory handle count (namespaced alias of dir_handle_num)",
+            )?,
 
             active_requests: m::new_gauge_vec(
                 "curvine_fuse_active_requests",


### PR DESCRIPTION
## Summary

Phase 3b-1 of the curvine-fuse Prometheus metrics work (stacked after Phase 2b #954, now merged). Adds three **namespaced** gauges as aliases of the legacy `inode_num`/`file_handle_num`/`dir_handle_num` so dashboards can migrate off the un-namespaced names:

- `curvine_fuse_inode_count`
- `curvine_fuse_file_handle_count`
- `curvine_fuse_dir_handle_count`

## Design

- **Zero behaviour change**: the new gauges are event-driven at the exact same insert/remove/restore-finalizer sites as the legacy `*_num` gauges, updated inside the **same `FuseMetrics::with` closure**, so legacy and alias stay in lockstep. The legacy gauges are deprecated and slated for removal two minor releases after dashboards migrate (per the metrics design doc).
- Keeps the in-lock single-atomic-op rule — no `*Vec` label lookup / allocation / registry traversal under the node-map / handle write locks.
- Also fixes a pre-existing inode-gauge drift: `NodeMap::rename_node` overwriting an unref-able target did a bare `self.nodes.remove`, bypassing the `remove_node` chokepoint, so neither `inode_num` nor `inode_count` decremented while the live map shrank. Routed through `remove_node` (the name mapping was already cleared by `delete_name`, so `delete_node` is intentionally not used).

## Testing

- `cargo fmt -p curvine-fuse --check`: clean.
- `cargo clippy -p curvine-fuse --all-targets -- --deny=warnings --allow clippy::uninlined-format-args`: 0.
- `cargo test -p curvine-fuse --lib`: 153 passed.
- New tests: `rename_overwrite_unreffed_target_drops_one_inode` (live-count predicate, parallel-safe); `inc_dec_gauges_lockstep_move_both_together` (injected isolated gauges, exact lockstep without touching the process-global singletons).

🤖 Generated with [Claude Code](https://claude.com/claude-code)