### PR TITLE
fix(fuse): route path truncate through active writer

### DIFF
--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -572,6 +572,8 @@ impl CurvineFileSystem {
             } else {
                 return err_fuse!(libc::EACCES);
             }
+        } else if let Some(writer) = self.state.find_writer(&ino) {
+            writer.lock().await.resize(opts).await?;
         } else {
             self.fs.resize(path, opts).await?;
         };


### PR DESCRIPTION
## Summary

Fix FUSE read failures after truncating an open file by path and then reading from the same open handle.

When a file was opened with O_RDWR, written sparsely, truncated through truncate(path, size), and then read again through the same fd, Curvine could return EIO instead of EOF. The truncate operation updated backend metadata, but bypassed the active FUSE writer for the inode, leaving the open handle’s reader/writer state stale.

## Minimal Reproducer

```c
#include <errno.h>
#include <fcntl.h>
#include <stdio.h>
#include <string.h>
#include <unistd.h>

int main(int argc, char **argv) {
    char buf[2048];
    char path[4096];

    if (argc != 2) {
        fprintf(stderr, "usage: %s <mount-dir>\n", argv[0]);
        return 2;
    }

    snprintf(path, sizeof(path), "%s/path_truncate_open_read.dat", argv[1]);

    unlink(path);

    int fd = open(path, O_RDWR | O_CREAT | O_TRUNC, 0666);
    if (fd < 0) {
        perror("open");
        return 1;
    }

    memset(buf, 0x11, sizeof(buf));
    if (lseek(fd, 0, SEEK_SET) < 0 ||
        write(fd, buf, sizeof(buf)) != (ssize_t)sizeof(buf)) {
        perror("write first chunk");
        return 1;
    }

    memset(buf, 0x22, sizeof(buf));
    if (lseek(fd, 8192, SEEK_SET) < 0 ||
        write(fd, buf, sizeof(buf)) != (ssize_t)sizeof(buf)) {
        perror("write sparse chunk");
        return 1;
    }

    if (fsync(fd) != 0) {
        perror("fsync");
        return 1;
    }

    if (truncate(path, 2048) != 0) {
        perror("truncate(path)");
        return 1;
    }

    if (lseek(fd, 4096, SEEK_SET) < 0) {
        perror("lseek after truncate");
        return 1;
    }

    ssize_t n = read(fd, buf, sizeof(buf));
    if (n < 0) {
        fprintf(stderr, "read after truncate failed errno=%d\n", errno);
        perror("read");
        return 1;
    }

    if (n != 0) {
        fprintf(stderr, "expected EOF after truncate, got read=%zd\n", n);
        return 1;
    }

    close(fd);
    unlink(path);

    return 0;
}
```

Run it on a Curvine FUSE mount:

gcc /tmp/path_truncate_open_read.c -o /tmp/path_truncate_open_read /tmp/path_truncate_open_read /curvine-fuse

Before the fix, it failed at the read after path-based truncate:

read after truncate failed errno=5
read: Input/output error

## Root Cause

Path-based truncate requests do not carry the active file handle, so the FUSE resize path used the backend resize path directly.

That meant:

1. The backend file length was updated correctly.
2. The inode still had an open FuseWriter.
3. The same open fd still had stale reader state with the old file length and block metadata.
4. A later read on that fd tried to read using stale block information and failed with EIO.

## Changes

- When resize/truncate is requested without a file handle, first check whether the inode has an active writer.
- If an active writer exists, route the resize through that writer instead of bypassing it.
- This keeps truncate ordered with pending writes and lets the existing reader refresh logic rebuild reader state from updated metadata.

## Verification

- Minimal C reproducer passes after the fix.
- cargo fmt --check passes.