### PR TITLE
feat(fallback): make UFS fallback mode-aware for FsMode vs CacheMode

### DIFF
--- a/curvine-client/src/unified/fallback_fs_reader.rs
+++ b/curvine-client/src/unified/fallback_fs_reader.rs
@@ -49,7 +49,7 @@ pub struct FallbackFsReader {
     ufs_reader: Option<UfsReader>,
     ufs_path: Path,
     ufs_fs: UfsFileSystem,
-    /// True when the mount is FsMode. Controls whether the snapshot consistency check 
+    /// True when the mount is FsMode. Controls whether the snapshot consistency check
     /// gates the fallback to UFS. CacheMode (false) reads S3 directly without validation.
     is_fs_mode: bool,
 }

--- a/curvine-client/src/unified/fallback_fs_reader.rs
+++ b/curvine-client/src/unified/fallback_fs_reader.rs
@@ -30,8 +30,16 @@ use orpc::sys::DataSlice;
 /// - `cv_reader` is always present and maintains all internal state (pos, chunk, etc.).
 /// - `ufs_reader` is created lazily on the first worker failure; once set, all
 ///   subsequent reads go through UFS (no retry back to Curvine).
-/// - Before falling back, `validate_ufs_consistency` is called to ensure the UFS
-///   data matches the snapshot recorded in Curvine metadata (`ufs_mtime`, `len`).
+/// - Before falling back, consistency handling depends on the mount's write type:
+///   - **FsMode** (Curvine is the authority, UFS is a flushed copy): `validate_ufs_consistency`
+///     ensures the UFS data matches the snapshot recorded in Curvine metadata
+///     (`ufs_mtime`, `len`). A mismatch means the UFS copy is untrustworthy (incomplete
+///     flush or externally modified) and fallback is refused.
+///   - **CacheMode** (UFS/S3 is the authority, Curvine is a read-through cache): nothing is
+///     validated. We read S3 directly at the current `pos`. If S3 is still readable there,
+///     that is the authoritative data and we serve it. If S3 was deleted or shrunk so that
+///     `pos` no longer exists, the underlying `open_ufs`/`seek` fails and the error
+///     propagates — we do not clamp the seek or paper over an out-of-range position.
 pub struct FallbackFsReader {
     /// Wraps the Curvine reader. Always present as the metadata authority (status, len).
     cv_reader: FsReader,
@@ -41,15 +49,24 @@ pub struct FallbackFsReader {
     ufs_reader: Option<UfsReader>,
     ufs_path: Path,
     ufs_fs: UfsFileSystem,
+    /// True when the mount is FsMode. Controls whether the snapshot consistency check 
+    /// gates the fallback to UFS. CacheMode (false) reads S3 directly without validation.
+    is_fs_mode: bool,
 }
 
 impl FallbackFsReader {
-    pub fn new(cv_reader: FsReader, ufs_path: Path, ufs_fs: UfsFileSystem) -> Self {
+    pub fn new(
+        cv_reader: FsReader,
+        ufs_path: Path,
+        ufs_fs: UfsFileSystem,
+        is_fs_mode: bool,
+    ) -> Self {
         Self {
             cv_reader,
             ufs_reader: None,
             ufs_path,
             ufs_fs,
+            is_fs_mode,
         }
     }
 
@@ -156,14 +173,27 @@ impl Reader for FallbackFsReader {
             Err(e) if is_worker_err(&e) => {
                 let pos = self.cv_reader.pos();
                 warn!(
-                    "Curvine worker error at pos {} for {}, validating UFS consistency before fallback: {}",
+                    "Curvine worker error at pos {} for {} (fs_mode={}), falling back to UFS: {}",
                     pos,
                     self.cv_reader.path(),
+                    self.is_fs_mode,
                     e
                 );
 
-                // Refuse to fall back if UFS data cannot be trusted.
-                self.validate_ufs_consistency().await?;
+                // FsMode: Curvine is authoritative and UFS is only a flushed copy, so
+                // refuse to fall back if the UFS data cannot be trusted (mtime/len drift
+                // means an incomplete flush or external modification).
+                //
+                // CacheMode: S3/UFS is authoritative — there is nothing to validate.
+                // We just read S3 directly. If S3 is still readable at `pos`, that is
+                // the authoritative data and we serve it. If S3 was deleted or shrunk
+                // so that `pos` no longer exists, the read fails naturally below
+                // (open_ufs stat -> NotFound, or seek -> "Invalid seek position") and
+                // that error propagates to the caller. We deliberately do NOT clamp the
+                // seek or pre-check consistency.
+                if self.is_fs_mode {
+                    self.validate_ufs_consistency().await?;
+                }
 
                 let mut ufs: UfsReader = self.ufs_fs.open_ufs(&self.ufs_path).await?;
                 ufs.seek(pos).await?;

--- a/curvine-client/src/unified/fallback_fs_reader.rs
+++ b/curvine-client/src/unified/fallback_fs_reader.rs
@@ -128,7 +128,14 @@ impl Reader for FallbackFsReader {
     }
 
     fn len(&self) -> i64 {
-        self.cv_reader.len()
+        match &self.ufs_reader {
+            // CacheMode has fallen back to S3, which is authoritative: report its
+            // live length so len()-based callers (e.g. read_as_string) see the
+            // current object size, not the stale cached Curvine length.
+            Some(u) if !self.is_fs_mode => u.len(),
+            // FsMode (or no fallback yet): Curvine remains the metadata authority.
+            _ => self.cv_reader.len(),
+        }
     }
 
     // pos/chunk/chunk_size delegate to whichever reader is currently active.

--- a/curvine-client/src/unified/unified_filesystem.rs
+++ b/curvine-client/src/unified/unified_filesystem.rs
@@ -318,6 +318,7 @@ impl UnifiedFileSystem {
                     cv_reader,
                     ufs_path.clone(),
                     mount.ufs.clone(),
+                    mount.info.is_fs_mode(),
                 )))
             } else if blocks.ufs_exists() {
                 Ok(None)
@@ -336,6 +337,7 @@ impl UnifiedFileSystem {
                         cv_reader,
                         ufs_path.clone(),
                         mount.ufs.clone(),
+                        mount.info.is_fs_mode(),
                     )))
                 }
                 CacheValidity::Invalid(_) => Ok(None),

--- a/curvine-tests/tests/fallback_read_test.rs
+++ b/curvine-tests/tests/fallback_read_test.rs
@@ -30,9 +30,13 @@
 //! | ID     | Scenario                                                          |
 //! |--------|-------------------------------------------------------------------|
 //! | TC-11b | Worker failure during read -> fallback to UFS transparently       |
-//! | TC-12  | Worker failure when ufs_mtime mismatches -> returns error         |
-//! | TC-13  | Worker failure when ufs_mtime=0 (not flushed) -> returns error    |
+//! | TC-12  | FsMode worker failure + ufs_mtime mismatch -> returns error        |
+//! | TC-13  | FsMode worker failure + ufs_mtime=0 (not flushed) -> returns error |
 //! | TC-14  | seek() after fallback to UFS -> continues from new position       |
+//! | TC-17  | CacheMode worker failure, pos==0 -> reads current S3 (incl. shrunk)|
+//! | TC-18  | CacheMode worker failure, S3 shrunk past pos -> seek error         |
+//! | TC-19  | CacheMode worker failure, S3 unchanged -> fallback reads value    |
+//! | TC-20  | CacheMode worker failure, S3 grown -> reads current (longer) S3   |
 
 use bytes::BytesMut;
 use curvine_client::file::FsReader;
@@ -95,6 +99,60 @@ async fn mount_fs_mode(fs: &UnifiedFileSystem, mount_dir: &str) {
     fs.mount(&ufs_path, &cv_path, opts).await.unwrap();
 }
 
+/// Mount `mount_dir` in CacheMode (UFS/S3 is authoritative, Curvine is a read cache).
+async fn mount_cache_mode(fs: &UnifiedFileSystem, mount_dir: &str) {
+    let ufs_base = env::var("UFS_TEST_PATH").unwrap();
+    let ufs_path = Path::from_str(format!("{}/{}", ufs_base, mount_dir)).unwrap();
+    let cv_path = Path::from_str(format!("/{}", mount_dir)).unwrap();
+
+    if fs.get_mount(&cv_path).await.unwrap().is_some() {
+        return;
+    }
+
+    let mut opts_builder = MountOptionsBuilder::new().write_type(WriteType::CacheMode);
+    if let Ok(props_str) = env::var("UFS_TEST_PROPERTIES") {
+        for pair in props_str.split(',') {
+            if let Some((k, v)) = pair.split_once('=') {
+                opts_builder = opts_builder.add_property(k.trim(), v.trim());
+            }
+        }
+    }
+    let opts = opts_builder.build();
+
+    let ufs = UfsFileSystem::new(&ufs_path, opts.add_properties.clone(), None).unwrap();
+    if ufs.exists(&ufs_path).await.unwrap() {
+        ufs.delete(&ufs_path, true).await.unwrap();
+    }
+    ufs.mkdir(&ufs_path, true).await.unwrap();
+    fs.mount(&ufs_path, &cv_path, opts).await.unwrap();
+}
+
+/// Write `data` directly into the CacheMode UFS (S3), then warm the Curvine cache
+/// by submitting a load job, so a subsequent read can hit Curvine blocks. Returns
+/// the cv path. This mirrors the cache_mode lifecycle: write goes straight to S3,
+/// the cache is populated asynchronously by a LoadJob.
+async fn write_ufs_and_warm_cache(
+    fs: &UnifiedFileSystem,
+    mount_dir: &str,
+    name: &str,
+    data: &str,
+) -> Path {
+    let cv_path = Path::from_str(format!("/{}/{}", mount_dir, name)).unwrap();
+    let (ufs_path, mount) = fs.get_mount(&cv_path).await.unwrap().unwrap();
+
+    let mut w = mount.ufs.create(&ufs_path, true).await.unwrap();
+    w.write(data.as_bytes()).await.unwrap();
+    w.complete().await.unwrap();
+
+    // Warm the Curvine cache from S3 and wait for the load job to finish.
+    // async_cache takes the ufs path (server derives job_id from it in CacheMode),
+    // but wait_job_complete requires the cv path (it checks path.is_cv() and derives
+    // the ufs path internally). Passing ufs_path here fails with "not a cache file".
+    fs.async_cache(&ufs_path).unwrap();
+    fs.wait_job_complete(&cv_path, false).await.unwrap();
+    cv_path
+}
+
 /// Write `data` to Curvine FsMode and wait for it to flush to UFS.
 async fn write_and_flush(fs: &UnifiedFileSystem, mount_dir: &str, name: &str, data: &str) -> Path {
     let cv_path = Path::from_str(format!("/{}/{}", mount_dir, name)).unwrap();
@@ -143,7 +201,12 @@ async fn build_reader_with_unreachable_worker(
 
     let cv_reader = FsReader::new(cv_path.clone(), fs.cv().fs_context(), blocks).unwrap();
     let (ufs_path, mount) = fs.get_mount(cv_path).await.unwrap().unwrap();
-    FallbackFsReader::new(cv_reader, ufs_path, mount.ufs.clone())
+    FallbackFsReader::new(
+        cv_reader,
+        ufs_path,
+        mount.ufs.clone(),
+        mount.info.is_fs_mode(),
+    )
 }
 
 // ---- TC-10: FsMode open returns Fallback -----------------------------------
@@ -295,8 +358,10 @@ fn test_tc11b_worker_failure_falls_back_to_ufs() {
     });
 }
 
-/// TC-12: Worker failure when `ufs_mtime` differs from actual UFS mtime
+/// TC-12: FsMode worker failure when `ufs_mtime` differs from actual UFS mtime
 /// -> `read_chunk0` must return an error (no silent fallback with stale data).
+/// This refusal is FsMode-specific: Curvine is authoritative and a UFS mismatch
+/// means the flushed copy is untrustworthy. CacheMode behaves oppositely (TC-17).
 #[test]
 fn test_tc12_worker_failure_ufs_mtime_mismatch_returns_error() {
     let Some(fs) = setup() else {
@@ -373,5 +438,187 @@ fn test_tc14_seek_after_ufs_fallback() {
         let _ = reader.complete().await;
 
         assert_eq!(suffix.as_bytes(), &buf[..]);
+    });
+}
+
+/// # How to run this test (requires a real S3/UFS)
+///
+/// This test is skipped unless `UFS_TEST_PATH` is set. Run it on the dev host
+/// (cluster + S3 connectivity + the `opendal-s3` build feature live there):
+///
+/// ```bash
+/// # 1) Point the test at an S3 base path + connection properties
+/// #    (fill in your own bucket / endpoint / credentials)
+/// export UFS_TEST_PATH="s3://<bucket name>/curvine-fallback-test"
+/// export UFS_TEST_PROPERTIES="s3.endpoint_url=<your s3 endpoint>,s3.region_name=<region>,s3.credentials.access=<your access key>,s3.credentials.secret=<your secret key>,s3.force.path.style=false,s3.list_objects_version=v1"
+///
+/// # 2) Run only this case
+/// cargo test -p curvine-tests --test fallback_read_test \
+///     --features curvine-client/opendal-s3 \
+///     test_tc17_cachemode_worker_failure_pos0_reads_current_s3 \
+///     -- --exact --nocapture
+/// ```
+///
+/// Property keys map to `S3Conf` in curvine-ufs/src/conf.rs. `s3.endpoint_url`
+/// MUST start with http:// or https://. `s3.region_name` is required by the
+/// OpenDAL S3 builder (omitting it fails with "region is missing"). If output
+/// shows "WARNING: UFS_TEST_PATH not set", the env vars did not take effect.
+/// TC-17: CacheMode worker failure at pos == 0 after S3 was changed (shrunk) out-of-band.
+/// CacheMode treats S3 as authoritative and validates nothing; the read starts at pos 0
+/// (always in range) and must return the CURRENT S3 content, not refuse.
+#[test]
+fn test_tc17_cachemode_worker_failure_pos0_reads_current_s3() {
+    let Some(fs) = setup() else {
+        return;
+    };
+    let rt = fs.clone_runtime();
+    rt.block_on(async move {
+        let mount_dir = "fallback_read_tc17";
+        mount_cache_mode(&fs, mount_dir).await;
+
+        // Warm the cache with the original (longer) content.
+        let original = "abcdefghijklmnopqrstuvwxyz";
+        let cv_path = write_ufs_and_warm_cache(&fs, mount_dir, "tc17.log", original).await;
+
+        // Modify S3 out-of-band to SHORTER content (changes mtime AND len).
+        let changed = "abcdefghij";
+        let (ufs_path, mount) = fs.get_mount(&cv_path).await.unwrap().unwrap();
+        let mut w = mount.ufs.create(&ufs_path, true).await.unwrap();
+        w.write(changed.as_bytes()).await.unwrap();
+        w.complete().await.unwrap();
+
+        // Fresh reader at pos == 0; first read triggers fallback. pos 0 is always in
+        // range, so it must succeed and return the current (shrunk) S3 content.
+        let mut reader = build_reader_with_unreachable_worker(&fs, &cv_path).await;
+        let mut buf = BytesMut::zeroed(changed.len());
+        let n = reader
+            .read_full(&mut buf)
+            .await
+            .expect("cache_mode fallback at pos==0 must read current S3, not refuse");
+        let _ = reader.complete().await;
+
+        assert_eq!(
+            &buf[..n],
+            changed.as_bytes(),
+            "cache_mode fallback at pos==0 must return current S3 content"
+        );
+    });
+}
+
+/// TC-18: CacheMode worker failure when S3 was shrunk past the current read position.
+/// CacheMode validates nothing and does NOT clamp the seek: reading from a `pos` that
+/// no longer exists in S3 must surface the underlying seek error, not silently return
+/// EOF. (The caller then knows the object changed and can re-open.)
+#[test]
+fn test_tc18_cachemode_worker_failure_shrunk_past_pos_errors() {
+    let Some(fs) = setup() else {
+        return;
+    };
+    let rt = fs.clone_runtime();
+    rt.block_on(async move {
+        let mount_dir = "fallback_read_tc18";
+        mount_cache_mode(&fs, mount_dir).await;
+
+        let original = "abcdefghijklmnopqrstuvwxyz";
+        let cv_path = write_ufs_and_warm_cache(&fs, mount_dir, "tc18.log", original).await;
+
+        // Shrink S3 out-of-band to a few bytes.
+        let changed = "abcd";
+        let (ufs_path, mount) = fs.get_mount(&cv_path).await.unwrap().unwrap();
+        let mut w = mount.ufs.create(&ufs_path, true).await.unwrap();
+        w.write(changed.as_bytes()).await.unwrap();
+        w.complete().await.unwrap();
+
+        // Position the reader well past the new (shrunk) S3 length before the failing
+        // read. pos_mut delegates to cv_reader while no fallback has happened yet, so
+        // this needs no worker IO.
+        let mut reader = build_reader_with_unreachable_worker(&fs, &cv_path).await;
+        *reader.pos_mut() = 20; // > changed.len()
+
+        let mut buf = BytesMut::zeroed(8);
+        let err = reader.read_full(&mut buf).await.unwrap_err().to_string();
+        assert!(
+            err.contains("Invalid seek position"),
+            "expected seek-out-of-range error (no clamp), got: {err}"
+        );
+    });
+}
+
+/// TC-19: CacheMode worker failure with S3 unchanged -> fallback reads the value.
+/// The happy-path counterpart to TC-17/TC-18: nothing is modified out-of-band, the
+/// Curvine worker is simply unreachable, so the read must transparently fall back to
+/// S3 and return exactly what was written. Verifies fallback works in the common case,
+/// not just under S3 mutation.
+#[test]
+fn test_tc19_cachemode_worker_failure_unchanged_reads_value() {
+    let Some(fs) = setup() else {
+        return;
+    };
+    let rt = fs.clone_runtime();
+    rt.block_on(async move {
+        let mount_dir = "fallback_read_tc19";
+        mount_cache_mode(&fs, mount_dir).await;
+
+        // Write to S3 and warm the cache. S3 is NOT modified afterwards.
+        let original = "abcdefghijklmnopqrstuvwxyz";
+        let cv_path = write_ufs_and_warm_cache(&fs, mount_dir, "tc19.log", original).await;
+
+        // Worker is unreachable; first read triggers fallback to the (unchanged) S3.
+        let mut reader = build_reader_with_unreachable_worker(&fs, &cv_path).await;
+        let mut buf = BytesMut::zeroed(original.len());
+        reader
+            .read_full(&mut buf)
+            .await
+            .expect("cache_mode fallback with unchanged S3 must succeed");
+        let _ = reader.complete().await;
+
+        assert_eq!(
+            &buf[..],
+            original.as_bytes(),
+            "cache_mode fallback must return the original S3 content unchanged"
+        );
+    });
+}
+
+/// TC-20: CacheMode worker failure after S3 was GROWN (lengthened) out-of-band.
+/// The lengthening counterpart to TC-17 (which shrinks). CacheMode validates nothing
+/// and treats S3 as authoritative; reading from pos 0 must fall back and return the
+/// CURRENT, longer S3 content -- not the shorter content that was warmed into cache.
+#[test]
+fn test_tc20_cachemode_worker_failure_grown_reads_current_s3() {
+    let Some(fs) = setup() else {
+        return;
+    };
+    let rt = fs.clone_runtime();
+    rt.block_on(async move {
+        let mount_dir = "fallback_read_tc20";
+        mount_cache_mode(&fs, mount_dir).await;
+
+        // Warm the cache with the original (shorter) content.
+        let original = "abcdefghij";
+        let cv_path = write_ufs_and_warm_cache(&fs, mount_dir, "tc20.log", original).await;
+
+        // Modify S3 out-of-band to LONGER content (changes mtime AND len).
+        let changed = "abcdefghijklmnopqrstuvwxyz";
+        let (ufs_path, mount) = fs.get_mount(&cv_path).await.unwrap().unwrap();
+        let mut w = mount.ufs.create(&ufs_path, true).await.unwrap();
+        w.write(changed.as_bytes()).await.unwrap();
+        w.complete().await.unwrap();
+
+        // Fresh reader at pos == 0; first read triggers fallback. Must succeed and
+        // return the current (grown) S3 content in full.
+        let mut reader = build_reader_with_unreachable_worker(&fs, &cv_path).await;
+        let mut buf = BytesMut::zeroed(changed.len());
+        let n = reader
+            .read_full(&mut buf)
+            .await
+            .expect("cache_mode fallback after S3 grew must read current S3, not refuse");
+        let _ = reader.complete().await;
+
+        assert_eq!(
+            &buf[..n],
+            changed.as_bytes(),
+            "cache_mode fallback must return the grown S3 content in full"
+        );
     });
 }

--- a/curvine-tests/tests/fallback_read_test.rs
+++ b/curvine-tests/tests/fallback_read_test.rs
@@ -37,6 +37,7 @@
 //! | TC-18  | CacheMode worker failure, S3 shrunk past pos -> seek error         |
 //! | TC-19  | CacheMode worker failure, S3 unchanged -> fallback reads value    |
 //! | TC-20  | CacheMode worker failure, S3 grown -> reads current (longer) S3   |
+//! | TC-21  | CacheMode fallback -> len() reflects current (grown) S3 length    |
 
 use bytes::BytesMut;
 use curvine_client::file::FsReader;
@@ -620,5 +621,44 @@ fn test_tc20_cachemode_worker_failure_grown_reads_current_s3() {
             changed.as_bytes(),
             "cache_mode fallback must return the grown S3 content in full"
         );
+    });
+}
+
+/// TC-21: CacheMode fallback must expose the CURRENT S3 length via len().
+/// Regression guard for the reviewer's note on PR #963: after fallback to S3,
+/// len() must delegate to the active ufs_reader so len()-based callers (e.g.
+/// read_as_string) see the grown object size, not the stale cached length.
+#[test]
+fn test_tc21_cachemode_fallback_len_reflects_current_s3() {
+    let Some(fs) = setup() else {
+        return;
+    };
+    let rt = fs.clone_runtime();
+    rt.block_on(async move {
+        let mount_dir = "fallback_read_tc21";
+        mount_cache_mode(&fs, mount_dir).await;
+
+        // Warm the cache with the original (shorter) content.
+        let original = "abcdefghij";
+        let cv_path = write_ufs_and_warm_cache(&fs, mount_dir, "tc21.log", original).await;
+
+        // Grow S3 out-of-band to a longer object.
+        let changed = "abcdefghijklmnopqrstuvwxyz";
+        let (ufs_path, mount) = fs.get_mount(&cv_path).await.unwrap().unwrap();
+        let mut w = mount.ufs.create(&ufs_path, true).await.unwrap();
+        w.write(changed.as_bytes()).await.unwrap();
+        w.complete().await.unwrap();
+
+        // Trigger fallback with a single read, then check len() reflects the grown S3.
+        let mut reader = build_reader_with_unreachable_worker(&fs, &cv_path).await;
+        let mut probe = BytesMut::zeroed(1);
+        let _ = reader.read(&mut probe).await.unwrap();
+
+        assert_eq!(
+            reader.len(),
+            changed.len() as i64,
+            "after CacheMode fallback, len() must report the current (grown) S3 length"
+        );
+        let _ = reader.complete().await;
     });
 }


### PR DESCRIPTION
## What

`FallbackFsReader` now carries an `is_fs_mode` flag so worker-failure fallback respects the (opposite) authority direction of the two mount modes.

- **FsMode**: Curvine is authoritative and UFS is only a flushed copy. `validate_ufs_consistency` still gates the fallback and refuses it when the UFS copy has drifted (mtime/len mismatch = incomplete flush or external modification).
- **CacheMode**: S3/UFS is authoritative and Curvine is a read-through cache. Nothing is validated; S3 is read directly at the current `pos`. A still-readable object is served as the current data. A deleted or shrunk-past-`pos` object surfaces the natural `open_ufs`/`seek` error instead of being papered over as a clean EOF. We deliberately do not clamp the seek or pre-check consistency.

Call sites pass `mount.info.is_fs_mode()` instead of a hardcoded bool.

## Tests

New CacheMode fallback integration tests (require `UFS_TEST_PATH`, gated behind a real S3/UFS):

- **TC-17**: S3 shrunk out-of-band, pos 0 -> reads current (shorter) S3 content
- **TC-18**: S3 shrunk past the read pos -> surfaces `Invalid seek position` error (no clamp)
- **TC-19**: S3 unchanged, worker down -> transparent fallback returns the value
- **TC-20**: S3 grown out-of-band, pos 0 -> reads current (longer) S3 content in full

All four pass against a real S3 backend.