### PR TITLE
fix(fuse): complete open handle before unlinking path

### DIFF
--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -1399,7 +1399,17 @@ impl fs::FileSystem for CurvineFileSystem {
         let parent_ino = op.header.nodeid;
 
         let path = self.state.get_path_common(parent_ino, Some(name))?;
-        if self.state.should_delete_now(parent_ino, Some(name))? {
+        let completed_open_handle = if let Some(handle) = self.state.find_open_handle_by_path(&path)
+        {
+            handle.complete(None).await?;
+            true
+        } else {
+            false
+        };
+
+        let delete_now =
+            completed_open_handle || self.state.should_delete_now(parent_ino, Some(name))?;
+        if delete_now {
             self.fs.delete(&path, false).await?;
         }
         self.state.unlink_node(parent_ino, Some(name))?;

--- a/curvine-fuse/src/fs/state/node_state.rs
+++ b/curvine-fuse/src/fs/state/node_state.rs
@@ -678,7 +678,7 @@ impl NodeState {
         }
     }
 
-    fn find_open_handle_by_path(&self, path: &Path) -> Option<Arc<FileHandle>> {
+    pub fn find_open_handle_by_path(&self, path: &Path) -> Option<Arc<FileHandle>> {
         let path = path.full_path();
         let lock = self.handles.read();
         lock.values()


### PR DESCRIPTION
## Summary

Fix a FUSE unlink race where a path could remain visible when it was unlinked immediately after closing an open file.

When a file was closed and then unlinked right away, the kernel could send `unlink` before the FUSE `release` for the closed handle had finished. Before this change, Curvine saw that the file still had an open handle and deferred backend deletion. That left the old backend path visible temporarily.

A subsequent open with create semantics for the same name could then resolve the old file during lookup instead of creating a new file, causing intermittent open failures or stale-path behavior.

## Root Cause

Curvine's unlink path treated an inode with open handles as a delayed-delete case. That preserved the backend path until the final handle was released.

This is unsafe for same-name recreation because POSIX unlink semantics require the directory entry to disappear when `unlink()` returns. Existing open handles may continue to complete their own file state, but they must not keep the unlinked pathname visible or block a new file with the same name.

## Changes

- In FUSE `unlink`, detect an existing open handle for the target path.
- Complete the open handle before deleting the backend path.
- Delete the backend path immediately after the handle is completed.
- Expose `NodeState::find_open_handle_by_path()` so the unlink path can find the active handle by pathname.

## Verification

- Repeated same-name close, unlink, and reopen/create workflow passes after the fix.