### PR TITLE
feat(ufs): add mount auto cache and access mode controls

### DIFF
--- a/curvine-cli/src/cmds/mount.rs
+++ b/curvine-cli/src/cmds/mount.rs
@@ -17,7 +17,9 @@ use clap::Parser;
 use curvine_client::unified::{UfsFileSystem, UnifiedFileSystem};
 use curvine_common::error::{ErrorKind, FsError};
 use curvine_common::fs::{FileSystem, Path};
-use curvine_common::state::{MountOptions, Provider, StorageType, TtlAction, WriteType};
+use curvine_common::state::{
+    AccessMode, MountOptions, Provider, StorageType, TtlAction, WriteType,
+};
 use curvine_common::utils::ProtoUtils;
 use orpc::common::{ByteUnit, DurationUnit};
 use orpc::{err_box, CommonResult};
@@ -74,6 +76,18 @@ pub struct MountCommand {
         help = "UFS provider: auto, oss-hdfs, opendal. Controls which implementation to use for the given scheme."
     )]
     provider: Option<String>,
+
+    #[arg(
+        long,
+        help = "Whether to automatically submit a cache job on cache miss or invalid cache. Values: true, false. Default for new mounts: true."
+    )]
+    auto_cache: Option<bool>,
+
+    #[arg(
+        long,
+        help = "Access mode for cache_mode mounts: read_only, read_write. Default for new mounts: read_only."
+    )]
+    access_mode: Option<String>,
 
     #[arg(long, default_value_t = false)]
     check: bool,
@@ -532,6 +546,15 @@ impl MountCommand {
         if let Some(provider_str) = self.provider.as_ref() {
             let provider = Provider::try_from(provider_str.as_str())?;
             opts = opts.provider(provider);
+        }
+
+        if let Some(auto_cache) = self.auto_cache {
+            opts = opts.auto_cache(auto_cache);
+        }
+
+        if let Some(access_mode_str) = self.access_mode.as_ref() {
+            let access_mode = AccessMode::try_from(access_mode_str.as_str())?;
+            opts = opts.access_mode(access_mode);
         }
 
         Ok(opts.build())

--- a/curvine-client/src/unified/unified_filesystem.rs
+++ b/curvine-client/src/unified/unified_filesystem.rs
@@ -19,7 +19,7 @@ use crate::ClientMetrics;
 use bytes::BytesMut;
 use curvine_common::conf::ClusterConf;
 use curvine_common::error::FsError;
-use curvine_common::fs::{FileSystem, FsKind, ListStream, Path, Reader, Writer};
+use curvine_common::fs::{FileSystem, FsKind, ListStream, Path, Reader, RpcCode, Writer};
 use curvine_common::state::{
     CreateFileOpts, FileAllocOpts, FileLock, FileStatus, FreeResult, JobStatus, ListOptions,
     LoadJobCommand, MasterInfo, MkdirOpts, MkdirOptsBuilder, MountInfo, MountOptions, OpenFlags,
@@ -135,8 +135,12 @@ impl UnifiedFileSystem {
         self.cv.fs_client()
     }
 
-    // Check if the path is a mount point, if so, return the mount point information
-    pub async fn get_mount(&self, path: &Path) -> FsResult<Option<(Path, Arc<MountValue>)>> {
+    // Check if the path is a mount point, if so, return the mount point information.
+    pub async fn get_mount(
+        &self,
+        path: &Path,
+        rpc_code: RpcCode,
+    ) -> FsResult<Option<(Path, Arc<MountValue>)>> {
         if !path.is_cv() {
             return err_box!("path is not curvine path");
         }
@@ -147,6 +151,13 @@ impl UnifiedFileSystem {
 
         let state = self.mount_cache.get_mount(self, path).await?;
         if let Some(mnt) = state {
+            if mnt.info.is_read_only_cache_mode() && Self::is_mount_write_rpc(rpc_code) {
+                return err_ext!(FsError::unsupported(format!(
+                    "{} on read_only cache_mode mount {}",
+                    rpc_code, path
+                )));
+            }
+
             let ufs_path = mnt.get_ufs_path(path)?;
             Ok(Some((ufs_path, mnt)))
         } else {
@@ -154,11 +165,28 @@ impl UnifiedFileSystem {
         }
     }
 
+    fn is_mount_write_rpc(rpc_code: RpcCode) -> bool {
+        matches!(
+            rpc_code,
+            RpcCode::Mkdir
+                | RpcCode::Delete
+                | RpcCode::CreateFile
+                | RpcCode::AppendFile
+                | RpcCode::Rename
+                | RpcCode::SetAttr
+                | RpcCode::Symlink
+                | RpcCode::Link
+                | RpcCode::ResizeFile
+                | RpcCode::SetLock
+        )
+    }
+
     pub async fn get_mount_checked(
         &self,
         path: &Path,
+        rpc_code: RpcCode,
     ) -> FsResult<Option<(Path, Arc<MountValue>)>> {
-        match self.get_mount(path).await? {
+        match self.get_mount(path, rpc_code).await? {
             Some(v) if v.1.info.is_cache_mode() => Ok(Some(v)),
             _ => Ok(None),
         }
@@ -234,7 +262,7 @@ impl UnifiedFileSystem {
 
     pub async fn free(&self, path: &Path, recursive: bool) -> FsResult<FreeResult> {
         let fut = async {
-            match self.get_mount(path).await? {
+            match self.get_mount(path, RpcCode::Free).await? {
                 None => err_box!(
                     "the current path is not mounted to ufs, so the `free` command cannot be executed."
                 ),
@@ -246,7 +274,7 @@ impl UnifiedFileSystem {
 
     pub async fn symlink(&self, target: &str, link: &Path, force: bool) -> FsResult<()> {
         let fut = async {
-            match self.get_mount_checked(link).await? {
+            match self.get_mount_checked(link, RpcCode::Symlink).await? {
                 None => self.cv.symlink(target, link, force).await,
                 Some(_) => err_ext!(FsError::unsupported("symlink")),
             }
@@ -256,7 +284,7 @@ impl UnifiedFileSystem {
 
     pub async fn link(&self, src_path: &Path, dst_path: &Path) -> FsResult<()> {
         let fut = async {
-            match self.get_mount_checked(src_path).await? {
+            match self.get_mount_checked(src_path, RpcCode::Link).await? {
                 None => self.cv.link(src_path, dst_path).await,
                 Some(_) => err_ext!(FsError::unsupported("link")),
             }
@@ -267,7 +295,7 @@ impl UnifiedFileSystem {
 
     pub async fn resize(&self, path: &Path, opts: FileAllocOpts) -> FsResult<()> {
         let fut = async {
-            match self.get_mount_checked(path).await? {
+            match self.get_mount_checked(path, RpcCode::ResizeFile).await? {
                 None => self.cv.resize(path, opts).await,
                 Some(_) => err_ext!(FsError::unsupported("resize")),
             }
@@ -387,7 +415,7 @@ impl UnifiedFileSystem {
         if !path.is_cv() {
             return err_box!("the current file {} is not a cache file", path);
         }
-        let (ufs_path, mnt) = match self.get_mount(path).await? {
+        let (ufs_path, mnt) = match self.get_mount(path, RpcCode::GetJobStatus).await? {
             Some((ufs_path, mnt)) => (ufs_path, mnt),
             None => return err_box!("the current file {} is not mounted to ufs", path),
         };
@@ -467,7 +495,12 @@ impl UnifiedFileSystem {
         let mut write_path = path.path().to_owned();
 
         let fut = async {
-            match self.get_mount(path).await? {
+            let rpc_code = if flags.read_only() {
+                RpcCode::OpenFile
+            } else {
+                RpcCode::CreateFile
+            };
+            match self.get_mount(path, rpc_code).await? {
                 None => {
                     let writer = self.cv.open_with_opts(path, opts, flags).await?;
                     Ok(UnifiedWriter::Cv(writer))
@@ -526,7 +559,7 @@ impl UnifiedFileSystem {
         opts: MkdirOpts,
     ) -> FsResult<Option<FileStatus>> {
         let fut = async {
-            match self.get_mount_checked(path).await? {
+            match self.get_mount_checked(path, RpcCode::Mkdir).await? {
                 None => Ok(Some(self.cv.mkdir_with_opts(path, opts).await?)),
 
                 Some((ufs_path, mount)) => {
@@ -548,7 +581,7 @@ impl UnifiedFileSystem {
         opts: SetAttrOpts,
     ) -> FsResult<Option<FileStatus>> {
         let fut = async {
-            match self.get_mount_checked(path).await? {
+            match self.get_mount_checked(path, RpcCode::SetAttr).await? {
                 None => {
                     let status = self.cv.set_attr(path, opts).await?;
                     Ok(Some(status))
@@ -562,7 +595,7 @@ impl UnifiedFileSystem {
 
     pub async fn get_lock(&self, path: &Path, lock: FileLock) -> FsResult<Option<FileLock>> {
         let fut = async {
-            match self.get_mount_checked(path).await? {
+            match self.get_mount_checked(path, RpcCode::GetLock).await? {
                 None => self.cv.get_lock(path, lock).await,
                 Some(_) => err_ext!(FsError::unsupported("get_lock")),
             }
@@ -572,7 +605,7 @@ impl UnifiedFileSystem {
 
     pub async fn set_lock(&self, path: &Path, lock: FileLock) -> FsResult<Option<FileLock>> {
         let fut = async {
-            match self.get_mount_checked(path).await? {
+            match self.get_mount_checked(path, RpcCode::SetLock).await? {
                 None => self.cv.set_lock(path, lock).await,
                 Some(_) => err_ext!(FsError::unsupported("set_lock")),
             }
@@ -613,7 +646,7 @@ impl FileSystem<UnifiedWriter, UnifiedReader> for UnifiedFileSystem {
 
     async fn exists(&self, path: &Path) -> FsResult<bool> {
         let fut = async {
-            match self.get_mount_checked(path).await? {
+            match self.get_mount_checked(path, RpcCode::Exists).await? {
                 None => self.cv.exists(path).await,
                 Some((ufs_path, mount)) => mount.ufs.exists(&ufs_path).await,
             }
@@ -626,7 +659,7 @@ impl FileSystem<UnifiedWriter, UnifiedReader> for UnifiedFileSystem {
         let mut read_path = path.path().to_owned();
 
         let fut = async {
-            let (ufs_path, mount) = match self.get_mount(path).await? {
+            let (ufs_path, mount) = match self.get_mount(path, RpcCode::OpenFile).await? {
                 None => {
                     let reader = UnifiedReader::Cv(self.cv.open(path).await?);
                     return if reader.status().is_expired() {
@@ -681,7 +714,8 @@ impl FileSystem<UnifiedWriter, UnifiedReader> for UnifiedFileSystem {
 
     async fn rename(&self, src: &Path, dst: &Path) -> FsResult<bool> {
         let fut = async {
-            match self.get_mount_checked(src).await? {
+            let _ = self.get_mount_checked(dst, RpcCode::Rename).await?;
+            match self.get_mount_checked(src, RpcCode::Rename).await? {
                 None => self.cv.rename(src, dst).await,
                 Some((src_ufs, mount)) => {
                     let dst_ufs = mount.get_ufs_path(dst)?;
@@ -703,7 +737,7 @@ impl FileSystem<UnifiedWriter, UnifiedReader> for UnifiedFileSystem {
 
     async fn delete(&self, path: &Path, recursive: bool) -> FsResult<()> {
         let fut = async {
-            match self.get_mount_checked(path).await? {
+            match self.get_mount_checked(path, RpcCode::Delete).await? {
                 None => self.cv.delete(path, recursive).await,
                 Some((ufs_path, mount)) => {
                     if path.path() == mount.info.cv_path {
@@ -732,7 +766,7 @@ impl FileSystem<UnifiedWriter, UnifiedReader> for UnifiedFileSystem {
 
     async fn get_status(&self, path: &Path) -> FsResult<FileStatus> {
         let fut = async {
-            match self.get_mount(path).await? {
+            match self.get_mount(path, RpcCode::FileStatus).await? {
                 None => self.cv.get_status(path).await,
 
                 Some((_, mnt)) if mnt.info.is_fs_mode() => self.cv.get_status(path).await,
@@ -761,7 +795,7 @@ impl FileSystem<UnifiedWriter, UnifiedReader> for UnifiedFileSystem {
 
     async fn list_status(&self, path: &Path) -> FsResult<Vec<FileStatus>> {
         let fut = async {
-            match self.get_mount_checked(path).await? {
+            match self.get_mount_checked(path, RpcCode::ListStatus).await? {
                 None => self.cv.list_status(path).await,
                 Some((ufs_path, mount)) => mount.ufs.list_status(&ufs_path).await,
             }
@@ -771,7 +805,7 @@ impl FileSystem<UnifiedWriter, UnifiedReader> for UnifiedFileSystem {
 
     async fn list_status_bytes(&self, path: &Path) -> FsResult<BytesMut> {
         let fut = async {
-            match self.get_mount_checked(path).await? {
+            match self.get_mount_checked(path, RpcCode::ListStatus).await? {
                 None => self.cv.list_status_bytes(path).await,
                 Some((ufs_path, mount)) => mount.ufs.list_status_bytes(&ufs_path).await,
             }
@@ -781,7 +815,7 @@ impl FileSystem<UnifiedWriter, UnifiedReader> for UnifiedFileSystem {
 
     async fn list_options(&self, path: &Path, options: ListOptions) -> FsResult<Vec<FileStatus>> {
         let fut = async {
-            match self.get_mount_checked(path).await? {
+            match self.get_mount_checked(path, RpcCode::ListOptions).await? {
                 None => self.cv.list_options(path, options).await,
                 Some((ufs_path, mount)) => mount.ufs.list_options(&ufs_path, options).await,
             }
@@ -791,7 +825,7 @@ impl FileSystem<UnifiedWriter, UnifiedReader> for UnifiedFileSystem {
 
     async fn list_options_bytes(&self, path: &Path, options: ListOptions) -> FsResult<BytesMut> {
         let fut = async {
-            match self.get_mount_checked(path).await? {
+            match self.get_mount_checked(path, RpcCode::ListOptions).await? {
                 None => self.cv.list_options_bytes(path, options).await,
                 Some((ufs_path, mount)) => mount.ufs.list_options_bytes(&ufs_path, options).await,
             }
@@ -801,7 +835,7 @@ impl FileSystem<UnifiedWriter, UnifiedReader> for UnifiedFileSystem {
 
     async fn list_stream(&self, path: &Path, options: ListOptions) -> FsResult<ListStream> {
         let fut = async {
-            match self.get_mount_checked(path).await? {
+            match self.get_mount_checked(path, RpcCode::ListOptions).await? {
                 None => self.cv.list_stream(path, options).await,
                 Some((ufs_path, mount)) => mount.ufs.list_stream(&ufs_path, options).await,
             }
@@ -811,7 +845,11 @@ impl FileSystem<UnifiedWriter, UnifiedReader> for UnifiedFileSystem {
 
     async fn set_attr(&self, path: &Path, opts: SetAttrOpts) -> FsResult<()> {
         let fut = async {
-            if self.get_mount_checked(path).await?.is_none() {
+            if self
+                .get_mount_checked(path, RpcCode::SetAttr)
+                .await?
+                .is_none()
+            {
                 self.cv.set_attr(path, opts).await?;
             }
             // ignore setting attr on ufs mount paths

--- a/curvine-common/proto/mount.proto
+++ b/curvine-common/proto/mount.proto
@@ -20,6 +20,8 @@ message MountInfoProto {
     optional int32 replicas = 10;
     required WriteTypeProto write_type = 11;
     optional ProviderProto provider = 12;
+    optional bool auto_cache = 13 [default = true];
+    optional AccessModeProto access_mode = 14 [default = ACCESS_MODE_PROTO_READ_ONLY];
 }
 
 message MountOptionsProto {
@@ -34,12 +36,19 @@ message MountOptionsProto {
     repeated string remove_properties = 10;
     required WriteTypeProto write_type = 11;
     optional ProviderProto provider = 12;
+    optional bool auto_cache = 13;
+    optional AccessModeProto access_mode = 14;
 }
 
 enum ProviderProto {
     PROVIDER_PROTO_AUTO = 0;
     PROVIDER_PROTO_OSS_HDFS = 1;
     PROVIDER_PROTO_OPENDAL = 2;
+}
+
+enum AccessModeProto {
+    ACCESS_MODE_PROTO_READ_ONLY = 0;
+    ACCESS_MODE_PROTO_READ_WRITE = 1;
 }
 
 message MountRequest {

--- a/curvine-common/src/state/mount.rs
+++ b/curvine-common/src/state/mount.rs
@@ -57,6 +57,46 @@ impl TryFrom<&str> for Provider {
     }
 }
 
+#[repr(i32)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    FromPrimitive,
+    IntoPrimitive,
+    Default,
+    Deserialize,
+    Serialize,
+)]
+pub enum AccessMode {
+    #[default]
+    ReadOnly = 0,
+    ReadWrite = 1,
+}
+
+impl AccessMode {
+    pub fn is_read_only(&self) -> bool {
+        matches!(self, AccessMode::ReadOnly)
+    }
+}
+
+impl TryFrom<&str> for AccessMode {
+    type Error = CommonError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        let mode = match value.to_lowercase().as_str() {
+            "read_only" => AccessMode::ReadOnly,
+            "read_write" => AccessMode::ReadWrite,
+            _ => return err_box!("invalid access mode: {}", value),
+        };
+
+        Ok(mode)
+    }
+}
+
 /// Mount information structure
 #[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq, Default)]
 pub struct MountInfo {
@@ -72,11 +112,13 @@ pub struct MountInfo {
     pub replicas: Option<i32>,
     pub write_type: WriteType,
     pub provider: Option<Provider>,
+    pub auto_cache: bool,
+    pub access_mode: AccessMode,
 }
 
 impl MountInfo {
     pub fn auto_cache(&self) -> bool {
-        self.ttl_ms > 0
+        self.auto_cache && self.ttl_ms > 0
     }
 
     pub fn get_ttl(&self) -> Option<String> {
@@ -158,6 +200,10 @@ impl MountInfo {
         self.write_type == WriteType::FsMode
     }
 
+    pub fn is_read_only_cache_mode(&self) -> bool {
+        self.is_cache_mode() && self.access_mode.is_read_only()
+    }
+
     pub fn merge_with(self, mnt_opt: MountOptions) -> MountInfo {
         let mut properties = self.properties;
 
@@ -182,6 +228,8 @@ impl MountInfo {
             replicas: mnt_opt.replicas.or(self.replicas),
             write_type: self.write_type,
             provider: mnt_opt.provider.or(self.provider),
+            auto_cache: mnt_opt.auto_cache.unwrap_or(self.auto_cache),
+            access_mode: mnt_opt.access_mode.unwrap_or(self.access_mode),
         }
     }
 }
@@ -199,6 +247,8 @@ pub struct MountOptions {
     pub remove_properties: Vec<String>,
     pub write_type: WriteType,
     pub provider: Option<Provider>,
+    pub auto_cache: Option<bool>,
+    pub access_mode: Option<AccessMode>,
 }
 
 impl MountOptions {
@@ -226,6 +276,8 @@ impl MountOptions {
             replicas: self.replicas,
             write_type: self.write_type,
             provider: self.provider,
+            auto_cache: self.auto_cache.unwrap_or(true),
+            access_mode: self.access_mode.unwrap_or_default(),
         }
     }
 }
@@ -243,6 +295,8 @@ pub struct MountOptionsBuilder {
     remove_properties: Vec<String>,
     write_type: WriteType,
     provider: Option<Provider>,
+    auto_cache: Option<bool>,
+    access_mode: Option<AccessMode>,
 }
 
 impl MountOptionsBuilder {
@@ -251,6 +305,8 @@ impl MountOptionsBuilder {
             write_type: WriteType::CacheMode,
             ttl_ms: Some(7 * DurationUnit::DAY as i64),
             ttl_action: Some(TtlAction::Delete),
+            auto_cache: Some(true),
+            access_mode: Some(AccessMode::ReadOnly),
             ..Default::default()
         }
     }
@@ -324,6 +380,16 @@ impl MountOptionsBuilder {
         self
     }
 
+    pub fn auto_cache(mut self, auto_cache: bool) -> Self {
+        self.auto_cache = Some(auto_cache);
+        self
+    }
+
+    pub fn access_mode(mut self, access_mode: AccessMode) -> Self {
+        self.access_mode = Some(access_mode);
+        self
+    }
+
     pub fn build(self) -> MountOptions {
         MountOptions {
             update: self.update,
@@ -337,6 +403,8 @@ impl MountOptionsBuilder {
             remove_properties: self.remove_properties,
             write_type: self.write_type,
             provider: self.provider,
+            auto_cache: self.auto_cache,
+            access_mode: self.access_mode,
         }
     }
 }
@@ -381,7 +449,51 @@ impl TryFrom<&str> for WriteType {
 #[cfg(test)]
 mod tests {
     use crate::fs::Path;
-    use crate::state::{MountInfo, WriteType};
+    use crate::state::{AccessMode, MountInfo, MountOptions, WriteType};
+
+    #[test]
+    fn test_access_mode_parse() {
+        assert_eq!(
+            AccessMode::try_from("read_only").unwrap(),
+            AccessMode::ReadOnly
+        );
+        assert_eq!(
+            AccessMode::try_from("read_write").unwrap(),
+            AccessMode::ReadWrite
+        );
+        assert!(AccessMode::try_from("invalid").is_err());
+    }
+
+    #[test]
+    fn test_mount_options_default_auto_cache_and_access_mode() {
+        let info = MountOptions::builder().build().to_info(1, "/mnt", "s3://b");
+        assert!(info.auto_cache);
+        assert_eq!(info.access_mode, AccessMode::ReadOnly);
+    }
+
+    #[test]
+    fn test_mount_info_merge_auto_cache_and_access_mode() {
+        let info = MountInfo {
+            cv_path: "/mnt".to_string(),
+            ufs_path: "s3://b".to_string(),
+            auto_cache: true,
+            access_mode: AccessMode::ReadOnly,
+            ..Default::default()
+        };
+
+        let unchanged = info.clone().merge_with(MountOptions::builder().build());
+        assert!(unchanged.auto_cache);
+        assert_eq!(unchanged.access_mode, AccessMode::ReadOnly);
+
+        let updated = info.merge_with(
+            MountOptions::builder()
+                .auto_cache(false)
+                .access_mode(AccessMode::ReadWrite)
+                .build(),
+        );
+        assert!(!updated.auto_cache);
+        assert_eq!(updated.access_mode, AccessMode::ReadWrite);
+    }
 
     #[test]
     fn test_is_fs_mode_resync_guard() {
@@ -390,6 +502,7 @@ mod tests {
             cv_path: "/mnt/fs".to_string(),
             ufs_path: "s3://b/k".to_string(),
             write_type: WriteType::FsMode,
+            auto_cache: true,
             ..Default::default()
         };
         assert!(fs_mode_mount.is_fs_mode());
@@ -399,6 +512,7 @@ mod tests {
             cv_path: "/mnt/cache".to_string(),
             ufs_path: "s3://b/k".to_string(),
             write_type: WriteType::CacheMode,
+            auto_cache: true,
             ..Default::default()
         };
         assert!(!cache_mode_mount.is_fs_mode());

--- a/curvine-common/src/utils/display.rs
+++ b/curvine-common/src/utils/display.rs
@@ -60,6 +60,13 @@ fn provider_to_str(provider: Option<i32>) -> &'static str {
     }
 }
 
+fn access_mode_to_str(access_mode: Option<i32>) -> &'static str {
+    match access_mode {
+        Some(1) => "read_write",
+        _ => "read_only",
+    }
+}
+
 /// Configuration options for progress display
 pub struct ProgressDisplayOptions {
     /// Progress bar width
@@ -253,6 +260,8 @@ impl Display for GetMountTableResponse {
         let mut ufs_width = 8; // "UFS Path"
         let mut write_type_width = 10; // "Write Type"
         let mut read_verify_ufs_width = 14; // "Read Verify UFS"
+        let mut auto_cache_width = 10; // "Auto Cache"
+        let mut access_mode_width = 11; // "Access Mode"
         let mut storage_width = 7; // "Storage"
         let mut ttl_action_width = 10; // "TTL Action"
         let mut provider_width = 8; // "Provider"
@@ -264,6 +273,15 @@ impl Display for GetMountTableResponse {
             write_type_width = write_type_width.max(write_type_to_str(mnt.write_type()).len());
             read_verify_ufs_width =
                 read_verify_ufs_width.max(if mnt.read_verify_ufs { "yes" } else { "no" }.len());
+            auto_cache_width = auto_cache_width.max(
+                if mnt.auto_cache.unwrap_or(true) {
+                    "yes"
+                } else {
+                    "no"
+                }
+                .len(),
+            );
+            access_mode_width = access_mode_width.max(access_mode_to_str(mnt.access_mode).len());
             storage_width = storage_width.max(storage_type_to_str(mnt.storage_type).len());
             ttl_action_width = ttl_action_width.max(ttl_action_to_str(mnt.ttl_action()).len());
             provider_width = provider_width.max(provider_to_str(mnt.provider).len());
@@ -275,6 +293,8 @@ impl Display for GetMountTableResponse {
         ufs_width += 2;
         write_type_width += 2;
         read_verify_ufs_width += 2;
+        auto_cache_width += 2;
+        access_mode_width += 2;
         storage_width += 2;
         ttl_action_width += 2;
         provider_width += 2;
@@ -289,6 +309,8 @@ impl Display for GetMountTableResponse {
         write!(f, "{:-^width$}+", "", width = ufs_width)?;
         write!(f, "{:-^width$}+", "", width = write_type_width)?;
         write!(f, "{:-^width$}+", "", width = read_verify_ufs_width)?;
+        write!(f, "{:-^width$}+", "", width = auto_cache_width)?;
+        write!(f, "{:-^width$}+", "", width = access_mode_width)?;
         write!(f, "{:-^width$}+", "", width = storage_width)?;
         write!(f, "{:-^width$}+", "", width = ttl_action_width)?;
         writeln!(f, "{:-^width$}+", "", width = provider_width)?;
@@ -310,6 +332,18 @@ impl Display for GetMountTableResponse {
             "Read Verify UFS",
             width = read_verify_ufs_width - 1
         )?;
+        write!(
+            f,
+            " {:<width$}|",
+            "Auto Cache",
+            width = auto_cache_width - 1
+        )?;
+        write!(
+            f,
+            " {:<width$}|",
+            "Access Mode",
+            width = access_mode_width - 1
+        )?;
         write!(f, " {:<width$}|", "Storage", width = storage_width - 1)?;
         write!(
             f,
@@ -326,6 +360,8 @@ impl Display for GetMountTableResponse {
         write!(f, "{:-^width$}+", "", width = ufs_width)?;
         write!(f, "{:-^width$}+", "", width = write_type_width)?;
         write!(f, "{:-^width$}+", "", width = read_verify_ufs_width)?;
+        write!(f, "{:-^width$}+", "", width = auto_cache_width)?;
+        write!(f, "{:-^width$}+", "", width = access_mode_width)?;
         write!(f, "{:-^width$}+", "", width = storage_width)?;
         write!(f, "{:-^width$}+", "", width = ttl_action_width)?;
         writeln!(f, "{:-^width$}+", "", width = provider_width)?;
@@ -347,6 +383,22 @@ impl Display for GetMountTableResponse {
                 " {:<width$}|",
                 if mnt.read_verify_ufs { "yes" } else { "no" },
                 width = read_verify_ufs_width - 1
+            )?;
+            write!(
+                f,
+                " {:<width$}|",
+                if mnt.auto_cache.unwrap_or(true) {
+                    "yes"
+                } else {
+                    "no"
+                },
+                width = auto_cache_width - 1
+            )?;
+            write!(
+                f,
+                " {:<width$}|",
+                access_mode_to_str(mnt.access_mode),
+                width = access_mode_width - 1
             )?;
             write!(
                 f,
@@ -375,6 +427,8 @@ impl Display for GetMountTableResponse {
         write!(f, "{:-^width$}+", "", width = ufs_width)?;
         write!(f, "{:-^width$}+", "", width = write_type_width)?;
         write!(f, "{:-^width$}+", "", width = read_verify_ufs_width)?;
+        write!(f, "{:-^width$}+", "", width = auto_cache_width)?;
+        write!(f, "{:-^width$}+", "", width = access_mode_width)?;
         write!(f, "{:-^width$}+", "", width = storage_width)?;
         write!(f, "{:-^width$}+", "", width = ttl_action_width)?;
         writeln!(f, "{:-^width$}+", "", width = provider_width)?;

--- a/curvine-common/src/utils/proto_utils.rs
+++ b/curvine-common/src/utils/proto_utils.rs
@@ -554,6 +554,8 @@ impl ProtoUtils {
             replicas: info.replicas,
             write_type: info.write_type.into(),
             provider: info.provider.map(|v| v.into()),
+            auto_cache: Some(info.auto_cache),
+            access_mode: Some(info.access_mode.into()),
         }
     }
 
@@ -571,6 +573,8 @@ impl ProtoUtils {
             replicas: info.replicas,
             write_type: WriteType::from(info.write_type),
             provider: info.provider.map(|x| x.into()),
+            auto_cache: info.auto_cache.unwrap_or(true),
+            access_mode: info.access_mode.map(AccessMode::from).unwrap_or_default(),
         }
     }
 
@@ -587,6 +591,8 @@ impl ProtoUtils {
             remove_properties: opts.remove_properties,
             write_type: opts.write_type.into(),
             provider: opts.provider.map(|v| v.into()),
+            auto_cache: opts.auto_cache,
+            access_mode: opts.access_mode.map(|v| v.into()),
         }
     }
 
@@ -603,6 +609,8 @@ impl ProtoUtils {
             remove_properties: opts.remove_properties,
             write_type: opts.write_type.into(),
             provider: opts.provider.map(Provider::from),
+            auto_cache: opts.auto_cache,
+            access_mode: opts.access_mode.map(AccessMode::from),
         }
     }
 
@@ -707,5 +715,43 @@ impl ProtoUtils {
             inodes: res.inodes,
             bytes: res.bytes,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::state::{AccessMode, MountInfo, MountOptions};
+    use crate::utils::ProtoUtils;
+
+    #[test]
+    fn test_mount_info_proto_round_trip_auto_cache_and_access_mode() {
+        let info = MountInfo {
+            cv_path: "/mnt".to_string(),
+            ufs_path: "s3://bucket".to_string(),
+            mount_id: 7,
+            auto_cache: false,
+            access_mode: AccessMode::ReadWrite,
+            ..Default::default()
+        };
+
+        let pb = ProtoUtils::mount_info_to_pb(info);
+        let round_trip = ProtoUtils::mount_info_from_pb(pb);
+
+        assert!(!round_trip.auto_cache);
+        assert_eq!(round_trip.access_mode, AccessMode::ReadWrite);
+    }
+
+    #[test]
+    fn test_mount_options_proto_round_trip_auto_cache_and_access_mode() {
+        let opts = MountOptions::builder()
+            .auto_cache(false)
+            .access_mode(AccessMode::ReadWrite)
+            .build();
+
+        let pb = ProtoUtils::mount_options_to_pb(opts);
+        let round_trip = ProtoUtils::mount_options_from_pb(pb);
+
+        assert_eq!(round_trip.auto_cache, Some(false));
+        assert_eq!(round_trip.access_mode, Some(AccessMode::ReadWrite));
     }
 }

--- a/curvine-tests/tests/fallback_read_test.rs
+++ b/curvine-tests/tests/fallback_read_test.rs
@@ -42,7 +42,7 @@
 use bytes::BytesMut;
 use curvine_client::file::FsReader;
 use curvine_client::unified::{FallbackFsReader, UfsFileSystem, UnifiedFileSystem, UnifiedReader};
-use curvine_common::fs::{FileSystem, Path, Reader, Writer};
+use curvine_common::fs::{FileSystem, Path, Reader, RpcCode, Writer};
 use curvine_common::state::{MountOptionsBuilder, WriteType};
 use curvine_tests::Testing;
 use orpc::common::Utils;
@@ -78,7 +78,12 @@ async fn mount_fs_mode(fs: &UnifiedFileSystem, mount_dir: &str) {
     let ufs_path = Path::from_str(format!("{}/{}", ufs_base, mount_dir)).unwrap();
     let cv_path = Path::from_str(format!("/{}", mount_dir)).unwrap();
 
-    if fs.get_mount(&cv_path).await.unwrap().is_some() {
+    if fs
+        .get_mount(&cv_path, RpcCode::GetMountInfo)
+        .await
+        .unwrap()
+        .is_some()
+    {
         return;
     }
 
@@ -106,7 +111,12 @@ async fn mount_cache_mode(fs: &UnifiedFileSystem, mount_dir: &str) {
     let ufs_path = Path::from_str(format!("{}/{}", ufs_base, mount_dir)).unwrap();
     let cv_path = Path::from_str(format!("/{}", mount_dir)).unwrap();
 
-    if fs.get_mount(&cv_path).await.unwrap().is_some() {
+    if fs
+        .get_mount(&cv_path, RpcCode::GetMountInfo)
+        .await
+        .unwrap()
+        .is_some()
+    {
         return;
     }
 
@@ -139,7 +149,11 @@ async fn write_ufs_and_warm_cache(
     data: &str,
 ) -> Path {
     let cv_path = Path::from_str(format!("/{}/{}", mount_dir, name)).unwrap();
-    let (ufs_path, mount) = fs.get_mount(&cv_path).await.unwrap().unwrap();
+    let (ufs_path, mount) = fs
+        .get_mount(&cv_path, RpcCode::GetMountInfo)
+        .await
+        .unwrap()
+        .unwrap();
 
     let mut w = mount.ufs.create(&ufs_path, true).await.unwrap();
     w.write(data.as_bytes()).await.unwrap();
@@ -201,7 +215,11 @@ async fn build_reader_with_unreachable_worker(
     }
 
     let cv_reader = FsReader::new(cv_path.clone(), fs.cv().fs_context(), blocks).unwrap();
-    let (ufs_path, mount) = fs.get_mount(cv_path).await.unwrap().unwrap();
+    let (ufs_path, mount) = fs
+        .get_mount(cv_path, RpcCode::GetMountInfo)
+        .await
+        .unwrap()
+        .unwrap();
     FallbackFsReader::new(
         cv_reader,
         ufs_path,
@@ -375,7 +393,11 @@ fn test_tc12_worker_failure_ufs_mtime_mismatch_returns_error() {
         let cv_path = write_and_flush(&fs, mount_dir, "tc12.log", "original-data").await;
 
         // Overwrite UFS file to change mtime/len and create metadata mismatch.
-        let (ufs_path, mount) = fs.get_mount(&cv_path).await.unwrap().unwrap();
+        let (ufs_path, mount) = fs
+            .get_mount(&cv_path, RpcCode::GetMountInfo)
+            .await
+            .unwrap()
+            .unwrap();
         let mut ufs_writer = mount.ufs.create(&ufs_path, true).await.unwrap();
         ufs_writer.write(b"changed-in-ufs").await.unwrap();
         ufs_writer.complete().await.unwrap();
@@ -483,7 +505,11 @@ fn test_tc17_cachemode_worker_failure_pos0_reads_current_s3() {
 
         // Modify S3 out-of-band to SHORTER content (changes mtime AND len).
         let changed = "abcdefghij";
-        let (ufs_path, mount) = fs.get_mount(&cv_path).await.unwrap().unwrap();
+        let (ufs_path, mount) = fs
+            .get_mount(&cv_path, RpcCode::GetMountInfo)
+            .await
+            .unwrap()
+            .unwrap();
         let mut w = mount.ufs.create(&ufs_path, true).await.unwrap();
         w.write(changed.as_bytes()).await.unwrap();
         w.complete().await.unwrap();
@@ -525,7 +551,11 @@ fn test_tc18_cachemode_worker_failure_shrunk_past_pos_errors() {
 
         // Shrink S3 out-of-band to a few bytes.
         let changed = "abcd";
-        let (ufs_path, mount) = fs.get_mount(&cv_path).await.unwrap().unwrap();
+        let (ufs_path, mount) = fs
+            .get_mount(&cv_path, RpcCode::GetMountInfo)
+            .await
+            .unwrap()
+            .unwrap();
         let mut w = mount.ufs.create(&ufs_path, true).await.unwrap();
         w.write(changed.as_bytes()).await.unwrap();
         w.complete().await.unwrap();
@@ -601,7 +631,11 @@ fn test_tc20_cachemode_worker_failure_grown_reads_current_s3() {
 
         // Modify S3 out-of-band to LONGER content (changes mtime AND len).
         let changed = "abcdefghijklmnopqrstuvwxyz";
-        let (ufs_path, mount) = fs.get_mount(&cv_path).await.unwrap().unwrap();
+        let (ufs_path, mount) = fs
+            .get_mount(&cv_path, RpcCode::GetMountInfo)
+            .await
+            .unwrap()
+            .unwrap();
         let mut w = mount.ufs.create(&ufs_path, true).await.unwrap();
         w.write(changed.as_bytes()).await.unwrap();
         w.complete().await.unwrap();
@@ -644,7 +678,11 @@ fn test_tc21_cachemode_fallback_len_reflects_current_s3() {
 
         // Grow S3 out-of-band to a longer object.
         let changed = "abcdefghijklmnopqrstuvwxyz";
-        let (ufs_path, mount) = fs.get_mount(&cv_path).await.unwrap().unwrap();
+        let (ufs_path, mount) = fs
+            .get_mount(&cv_path, RpcCode::GetMountInfo)
+            .await
+            .unwrap()
+            .unwrap();
         let mut w = mount.ufs.create(&ufs_path, true).await.unwrap();
         w.write(changed.as_bytes()).await.unwrap();
         w.complete().await.unwrap();

--- a/curvine-tests/tests/write_cache_test.rs
+++ b/curvine-tests/tests/write_cache_test.rs
@@ -14,7 +14,7 @@
 
 use bytes::BytesMut;
 use curvine_client::unified::{UfsFileSystem, UnifiedFileSystem, UnifiedReader};
-use curvine_common::fs::{FileSystem, Path, Reader, Writer};
+use curvine_common::fs::{FileSystem, Path, Reader, RpcCode, Writer};
 use curvine_common::state::{MountOptionsBuilder, WriteType};
 use curvine_tests::Testing;
 use orpc::common::Utils;
@@ -48,7 +48,11 @@ fn test_cache_mode() {
         write(&fs, &path, false).await;
 
         // Test 2: resubmit async task (skipped if data already synced); then check UFS mtime unchanged
-        let (ufs_path, mnt) = fs.get_mount(&path).await.unwrap().unwrap();
+        let (ufs_path, mnt) = fs
+            .get_mount(&path, RpcCode::GetMountInfo)
+            .await
+            .unwrap()
+            .unwrap();
         let ufs_reader_before = mnt.ufs.open(&ufs_path).await.unwrap();
         let mtime_before = ufs_reader_before.status().mtime;
         drop(ufs_reader_before);
@@ -110,7 +114,11 @@ fn test_fs_mode() {
         let path = format!("/write_cache_{:?}/test.log", WriteType::FsMode).into();
         write(&fs, &path, false).await;
 
-        let (_, mnt) = fs.get_mount(&path).await.unwrap().unwrap();
+        let (_, mnt) = fs
+            .get_mount(&path, RpcCode::GetMountInfo)
+            .await
+            .unwrap()
+            .unwrap();
 
         // Test rename
         let path = format!("/write_cache_{:?}/meta.log", WriteType::FsMode).into();
@@ -376,7 +384,7 @@ async fn verify_read_data(fs: &UnifiedFileSystem, path: &Path, expected_data: &[
 
 /// Returns true when UFS object exists and matches CV (mtime + full content).
 async fn try_verify_cv_ufs_consistency(fs: &UnifiedFileSystem, path: &Path) -> bool {
-    let (ufs_path, mnt) = match fs.get_mount(path).await {
+    let (ufs_path, mnt) = match fs.get_mount(path, RpcCode::GetMountInfo).await {
         Ok(Some(v)) => v,
         _ => return false,
     };
@@ -429,7 +437,12 @@ async fn mount(fs: &UnifiedFileSystem, write_type: WriteType) {
     let ufs_path = Path::from_str(format!("{}/{}", ufs_base, dir)).unwrap();
     let cv_path = Path::from_str(format!("/{}", dir)).unwrap();
 
-    if fs.get_mount(&cv_path).await.unwrap().is_some() {
+    if fs
+        .get_mount(&cv_path, RpcCode::GetMountInfo)
+        .await
+        .unwrap()
+        .is_some()
+    {
         return;
     }
 


### PR DESCRIPTION
## Summary

- Add `auto_cache` mount option to control whether cache-miss or invalid-cache reads automatically submit cache jobs.
- Add `access_mode` mount option with `read_only` and `read_write` values.
- Apply `read_only` enforcement only to `cache_mode` mounts; `fs_mode` behavior remains unchanged.
- Surface the new options through mount proto conversion, CLI mount arguments, and mount table display.

## Behavior

- `auto_cache` defaults to `true`.
- `access_mode` defaults to `read_only`.
- `cache_mode + read_only` rejects non-query operations such as create, append, mkdir, rename, delete, set_attr, free, link, symlink, resize, and set_lock.
- `cache_mode + read_write` preserves existing UFS write behavior.
- `fs_mode` ignores `access_mode` and keeps writing to Curvine cache.
- Manual `curvine load` is not blocked by `access_mode`.

## Validation

- Ran `cargo fmt`.
- Ran `cargo test -p curvine-common mount`.
- Client compile/check was started but interrupted before completion.