### PR TITLE
fix(ufs): normalize not-found errors

### DIFF
--- a/curvine-ufs/ffi/jindosdk_ffi.cpp
+++ b/curvine-ufs/ffi/jindosdk_ffi.cpp
@@ -302,10 +302,6 @@ void jindo_internal_bool_to_status_cb(JdoHandleCtx_t ctx, bool ok, void* ud) {
     if (code != 0 || !ok) {
         err = jdo_getHandleCtxErrorMsg(ctx);
         st = map_error_code_to_status(code);
-        if (st == JINDO_STATUS_FILE_NOT_FOUND) {
-            // For status-only operations we don't distinguish NotFound.
-            st = JINDO_STATUS_ERROR;
-        }
     }
 
     if (c && c->cb) {
@@ -656,10 +652,6 @@ void jindo_internal_list_dir_cb(JdoHandleCtx_t ctx, JdoListDirResult_t list_resu
     if (code != 0 || !list_result) {
         err = jdo_getHandleCtxErrorMsg(ctx);
         st = map_error_code_to_status(code);
-        if (st == JINDO_STATUS_FILE_NOT_FOUND) {
-            // listDir: treat not-found as error (matches common fs semantics for listing a missing directory)
-            st = JINDO_STATUS_ERROR;
-        }
         if (!list_result && code == 0) {
             st = JINDO_STATUS_ERROR;
         }
@@ -789,7 +781,6 @@ void jindo_internal_content_summary_cb(JdoHandleCtx_t ctx, JdoContentSummary_t s
     if (code != 0 || !summary) {
         err = jdo_getHandleCtxErrorMsg(ctx);
         st = map_error_code_to_status(code);
-        if (st == JINDO_STATUS_FILE_NOT_FOUND) st = JINDO_STATUS_ERROR;
         if (!summary && code == 0) st = JINDO_STATUS_ERROR;
     }
 
@@ -1001,7 +992,6 @@ static void jindo_internal_open_io_cb(JdoHandleCtx_t ctx, JdoIOContext_t io_ctx,
     if (code != 0 || !io_ctx) {
         err = jdo_getHandleCtxErrorMsg(ctx);
         JindoStatus st = map_error_code_to_status(code);
-        if (st == JINDO_STATUS_FILE_NOT_FOUND) st = JINDO_STATUS_ERROR;
 
         if (is_writer) {
             auto* c = reinterpret_cast<AsyncOpenWriterCtx*>(ud);
@@ -1274,8 +1264,6 @@ static void jindo_internal_i64_cb(JdoHandleCtx_t ctx, int64_t value, void* ud) {
     if (code != 0) {
         err = jdo_getHandleCtxErrorMsg(ctx);
         st = map_error_code_to_status(code);
-        if (st == JINDO_STATUS_FILE_NOT_FOUND) st = JINDO_STATUS_ERROR;
-        if (st == JINDO_STATUS_ERROR) st = JINDO_STATUS_ERROR;
     }
 
     if (c && c->cb) c->cb(st, value, err, c->userdata);
@@ -1515,8 +1503,6 @@ JindoStatus jindo_reader_seek_async(JindoReaderHandle reader, int64_t offset, Ji
             if (code != 0 || value < 0) {
                 err = jdo_getHandleCtxErrorMsg(ctx);
                 st = map_error_code_to_status(code);
-                if (st == JINDO_STATUS_FILE_NOT_FOUND) st = JINDO_STATUS_ERROR;
-                st = JINDO_STATUS_ERROR;
             }
 
             if (c && c->cb) c->cb(st, err, c->userdata);

--- a/curvine-ufs/src/opendal.rs
+++ b/curvine-ufs/src/opendal.rs
@@ -29,10 +29,38 @@ use opendal::{
     layers::{LoggingLayer, RetryLayer, TimeoutLayer},
     ErrorKind, Metadata, Operator,
 };
+use orpc::error::ErrorExt;
 use orpc::sys::DataSlice;
 use orpc::{err_box, err_ext, try_option_mut};
 use std::collections::HashMap;
 use std::time::Duration;
+
+fn storage_error(
+    operation: impl AsRef<str>,
+    path: impl AsRef<str>,
+    e: impl std::fmt::Display,
+    not_found: bool,
+) -> FsError {
+    if not_found {
+        FsError::file_not_found(path.as_ref()).ctx(format!("{}: {}", operation.as_ref(), e))
+    } else {
+        FsError::common(format!("{} {}: {}", operation.as_ref(), path.as_ref(), e))
+    }
+}
+
+fn opendal_error(operation: impl AsRef<str>, path: impl AsRef<str>, e: opendal::Error) -> FsError {
+    let not_found = e.kind() == ErrorKind::NotFound;
+    storage_error(operation, path, e, not_found)
+}
+
+fn opendal_io_error(
+    operation: impl AsRef<str>,
+    path: impl AsRef<str>,
+    e: std::io::Error,
+) -> FsError {
+    let not_found = e.kind() == std::io::ErrorKind::NotFound;
+    storage_error(operation, path, e, not_found)
+}
 
 /// OpenDAL Reader implementation
 pub struct OpendalReader {
@@ -88,13 +116,13 @@ impl Reader for OpendalReader {
                 .reader_with(&self.object_path)
                 .chunk(self.chunk_size)
                 .await
-                .map_err(|e| FsError::common(format!("Failed to create reader: {}", e)))?;
+                .map_err(|e| opendal_error("Failed to create reader", &self.object_path, e))?;
 
             self.byte_stream = Some(
                 reader
                     .into_bytes_stream(self.pos as u64..self.length as u64)
                     .await
-                    .map_err(|e| FsError::common(format!("Failed to create stream: {}", e)))?,
+                    .map_err(|e| opendal_error("Failed to create stream", &self.object_path, e))?,
             );
         }
 
@@ -102,7 +130,11 @@ impl Reader for OpendalReader {
             if let Some(chunk_result) = stream.next().await {
                 match chunk_result {
                     Ok(chunk) => Ok(DataSlice::Bytes(chunk)),
-                    Err(e) => err_box!("Failed to read chunk: {}", e),
+                    Err(e) => Err(opendal_io_error(
+                        "Failed to read chunk",
+                        &self.object_path,
+                        e,
+                    )),
                 }
             } else {
                 Ok(DataSlice::Empty)
@@ -183,7 +215,7 @@ impl Writer for OpendalWriter {
                 self.operator
                     .writer(&self.object_path)
                     .await
-                    .map_err(|e| FsError::common(format!("Failed to create writer: {}", e)))?,
+                    .map_err(|e| opendal_error("Failed to create writer", &self.object_path, e))?,
             );
         }
 
@@ -194,7 +226,7 @@ impl Writer for OpendalWriter {
         writer
             .write(data)
             .await
-            .map_err(|e| FsError::common(format!("Failed to write: {}", e)))?;
+            .map_err(|e| opendal_error("Failed to write", &self.object_path, e))?;
 
         Ok(len as i64)
     }
@@ -211,7 +243,7 @@ impl Writer for OpendalWriter {
             writer
                 .close()
                 .await
-                .map_err(|e| FsError::common(format!("Failed to close writer: {}", e)))?;
+                .map_err(|e| opendal_error("Failed to close writer", &self.object_path, e))?;
         }
 
         Ok(())
@@ -697,7 +729,7 @@ impl FileSystem<OpendalWriter, OpendalReader> for OpendalFileSystem {
         self.operator
             .create_dir(&object_path)
             .await
-            .map_err(|e| FsError::common(format!("Failed to create directory: {}", e)))?;
+            .map_err(|e| opendal_error("Failed to create directory", &object_path, e))?;
 
         Ok(true)
     }
@@ -719,13 +751,7 @@ impl FileSystem<OpendalWriter, OpendalReader> for OpendalFileSystem {
             self.operator
                 .write(&object_path, opendal::Buffer::new())
                 .await
-                .map_err(|e| {
-                    FsError::common(format!(
-                        "Failed to create empty file {}: {}",
-                        path.full_path(),
-                        e
-                    ))
-                })?;
+                .map_err(|e| opendal_error("Failed to create empty file", path.full_path(), e))?;
         }
 
         let status = Self::write_status(path);
@@ -753,11 +779,11 @@ impl FileSystem<OpendalWriter, OpendalReader> for OpendalFileSystem {
             Some(s) => {
                 if s.len < 8 * 1024 * 1024 {
                     let chunk = self.operator.read(&object_path).await.map_err(|e| {
-                        FsError::common(format!(
-                            "Failed to read existing file {} for append: {}",
+                        opendal_error(
+                            "Failed to read existing file for append",
                             path.full_path(),
-                            e
-                        ))
+                            e,
+                        )
                     })?;
                     return Ok(OpendalWriter {
                         operator: self.operator.clone(),
@@ -792,7 +818,7 @@ impl FileSystem<OpendalWriter, OpendalReader> for OpendalFileSystem {
             .operator
             .stat(&object_path)
             .await
-            .map_err(|e| FsError::common(format!("Failed to stat file: {}", e)))?;
+            .map_err(|e| opendal_error("Failed to stat file", &object_path, e))?;
         let status = Self::read_status(path, &metadata);
 
         Ok(OpendalReader {
@@ -830,7 +856,7 @@ impl FileSystem<OpendalWriter, OpendalReader> for OpendalFileSystem {
                         "rename directory on this backend (e.g. S3)"
                     ));
                 }
-                return Err(FsError::from_error(e));
+                return Err(opendal_error("Failed to rename directory", &src_path, e));
             }
         } else {
             let src_path = self.get_object_path(src)?;
@@ -840,13 +866,12 @@ impl FileSystem<OpendalWriter, OpendalReader> for OpendalFileSystem {
                     self.operator
                         .copy(&src_path, &dst_path)
                         .await
-                        .map_err(FsError::from_error)?;
-                    self.operator
-                        .delete(&src_path)
-                        .await
-                        .map_err(FsError::from_error)?;
+                        .map_err(|e| opendal_error("Failed to copy for rename", &src_path, e))?;
+                    self.operator.delete(&src_path).await.map_err(|e| {
+                        opendal_error("Failed to delete source for rename", &src_path, e)
+                    })?;
                 } else {
-                    return Err(FsError::from_error(e));
+                    return Err(opendal_error("Failed to rename file", &src_path, e));
                 }
             }
         }
@@ -869,7 +894,7 @@ impl FileSystem<OpendalWriter, OpendalReader> for OpendalFileSystem {
                 self.operator
                     .remove_all(&dir_path)
                     .await
-                    .map_err(FsError::from_error)?;
+                    .map_err(|e| opendal_error("Failed to remove directory", &dir_path, e))?;
             } else {
                 let opts = opendal::options::ListOptions {
                     limit: Some(2),
@@ -879,25 +904,27 @@ impl FileSystem<OpendalWriter, OpendalReader> for OpendalFileSystem {
                     .operator
                     .lister_options(&dir_path, opts)
                     .await
-                    .map_err(FsError::from_error)?;
+                    .map_err(|e| opendal_error("Failed to list directory", &dir_path, e))?;
 
                 if let Some(result) = list.next().await {
                     // Propagate any error from listing instead of treating it as a non-empty directory.
-                    result.map_err(FsError::from_error)?;
+                    result.map_err(|e| {
+                        opendal_error("Failed to list directory entry", &dir_path, e)
+                    })?;
                     // If we successfully retrieved an entry, the directory is not empty.
                     return err_ext!(FsError::dir_not_empty(path.full_path()));
                 }
                 self.operator
                     .delete(&dir_path)
                     .await
-                    .map_err(FsError::from_error)?;
+                    .map_err(|e| opendal_error("Failed to delete directory", &dir_path, e))?;
             }
         } else {
             let object_path = self.get_object_path(path)?;
             self.operator
                 .delete(&object_path)
                 .await
-                .map_err(FsError::from_error)?;
+                .map_err(|e| opendal_error("Failed to delete file", &object_path, e))?;
         }
 
         Ok(())
@@ -917,7 +944,7 @@ impl FileSystem<OpendalWriter, OpendalReader> for OpendalFileSystem {
             .operator
             .list(&dir_path)
             .await
-            .map_err(|e| FsError::common(format!("Failed to list directory: {}", e)))?;
+            .map_err(|e| opendal_error("Failed to list directory", &dir_path, e))?;
 
         let mut statuses = Vec::new();
         for entry in list_result {
@@ -959,10 +986,10 @@ impl FileSystem<OpendalWriter, OpendalReader> for OpendalFileSystem {
             .operator
             .lister_options(&dir_path, opts)
             .await
-            .map_err(FsError::from_error)?;
+            .map_err(|e| opendal_error("Failed to list directory", &dir_path, e))?;
 
         let stream = lister
-            .map_err(FsError::from_error)
+            .map_err(move |e| opendal_error("Failed to list directory entry", &dir_path, e))
             .try_filter_map(move |entry| {
                 let raw_path = format!(
                     "{}://{}/{}",

--- a/curvine-ufs/src/oss_hdfs/mod.rs
+++ b/curvine-ufs/src/oss_hdfs/mod.rs
@@ -18,8 +18,33 @@ mod oss_hdfs_filesystem;
 mod oss_hdfs_reader;
 mod oss_hdfs_writer;
 
+use curvine_common::error::FsError;
+use curvine_common::FsResult;
+use orpc::error::ErrorExt;
+
+use self::ffi::{jindo_last_error, JindoStatus};
+
 pub use self::oss_hdfs_filesystem::OssHdfsFileSystem;
 pub use self::oss_hdfs_reader::OssHdfsReader;
 pub use self::oss_hdfs_writer::OssHdfsWriter;
 
 pub const SCHEME: &str = "oss";
+
+pub(crate) fn jindo_error(status: JindoStatus, operation: &str, err: Option<String>) -> FsError {
+    let detail = err.unwrap_or_else(jindo_last_error);
+    match status {
+        JindoStatus::FileNotFound => FsError::file_not_found(detail).ctx(operation),
+        _ => FsError::common(format!("{}: {}", operation, detail)),
+    }
+}
+
+pub(crate) fn check_jindo_status(
+    status: JindoStatus,
+    operation: &str,
+    err: Option<String>,
+) -> FsResult<()> {
+    match status {
+        JindoStatus::Ok => Ok(()),
+        _ => Err(jindo_error(status, operation, err)),
+    }
+}

--- a/curvine-ufs/src/oss_hdfs/oss_hdfs_filesystem.rs
+++ b/curvine-ufs/src/oss_hdfs/oss_hdfs_filesystem.rs
@@ -30,7 +30,7 @@ use crate::conf::OssHdfsConf;
 use crate::err_ufs;
 use crate::oss_hdfs::callback_ctx::{err_from_c, CallbackCtx};
 use crate::oss_hdfs::ffi::*;
-use crate::oss_hdfs::{OssHdfsReader, OssHdfsWriter, SCHEME};
+use crate::oss_hdfs::{check_jindo_status, OssHdfsReader, OssHdfsWriter, SCHEME};
 use std::ffi::NulError;
 
 // Helper to convert CString errors
@@ -252,10 +252,7 @@ impl OssHdfsFileSystem {
     }
 
     fn check_status(status: JindoStatus, operation: &str) -> FsResult<()> {
-        if status != JindoStatus::Ok {
-            return err_ufs!("{}: {}", operation, jindo_last_error());
-        }
-        Ok(())
+        check_jindo_status(status, operation, None)
     }
 
     fn check_status_with_err(
@@ -263,13 +260,7 @@ impl OssHdfsFileSystem {
         operation: &str,
         err: Option<String>,
     ) -> FsResult<()> {
-        if status != JindoStatus::Ok {
-            if let Some(e) = err {
-                return err_ufs!("{}: {}", operation, e);
-            }
-            return err_ufs!("{}: {}", operation, jindo_last_error());
-        }
-        Ok(())
+        check_jindo_status(status, operation, err)
     }
 
     fn new_file_status(
@@ -563,12 +554,17 @@ impl FileSystem<OssHdfsWriter, OssHdfsReader> for OssHdfsFileSystem {
             let start_status = self.with_fs_handle(|fs_handle| unsafe {
                 jindo_filesystem_exists_async(fs_handle, path_cstr.as_ptr(), Some(cb), userdata)
             })?;
-            if start_status != JindoStatus::Ok {
-                Self::check_status(start_status, "Failed to start async exists")?;
+            match start_status {
+                JindoStatus::Ok => {}
+                JindoStatus::FileNotFound => return Ok(false),
+                _ => Self::check_status(start_status, "Failed to start async exists")?,
             }
         }
 
         let (status, exists, err) = ctx.wait().await?;
+        if status == JindoStatus::FileNotFound {
+            return Ok(false);
+        }
         Self::check_status_with_err(status, "Failed to check existence", err)?;
 
         Ok(exists)
@@ -763,12 +759,8 @@ impl FileSystem<OssHdfsWriter, OssHdfsReader> for OssHdfsFileSystem {
                     jindo_free(info_ptr as *mut c_void);
                 }
             }
-            return if status == JindoStatus::FileNotFound {
-                Err(FsError::common("File not found"))
-            } else {
-                Self::check_status_with_err(status, "Failed to get file info", err)?;
-                unreachable!("check_status_with_err returns Err on non-OK status");
-            };
+            Self::check_status_with_err(status, "Failed to get file info", err)?;
+            unreachable!("check_status_with_err returns Err on non-OK status");
         }
 
         if info_ptr.is_null() {

--- a/curvine-ufs/src/oss_hdfs/oss_hdfs_reader.rs
+++ b/curvine-ufs/src/oss_hdfs/oss_hdfs_reader.rs
@@ -22,6 +22,7 @@ use std::os::raw::c_void;
 
 use crate::oss_hdfs::callback_ctx::{I64CallbackCtx, StatusCallbackCtx};
 use crate::oss_hdfs::ffi::*;
+use crate::oss_hdfs::{check_jindo_status, jindo_error};
 
 // Extension methods for OSS-HDFS Reader
 impl OssHdfsReader {
@@ -87,19 +88,14 @@ impl OssHdfsReader {
             };
             if start_status != JindoStatus::Ok {
                 buffer.clear();
-                let err_msg = jindo_last_error();
-                return Err(FsError::common(format!(
-                    "Failed to start pread: {}",
-                    err_msg
-                )));
+                check_jindo_status(start_status, "Failed to start pread", None)?;
             }
         }
 
         let (status, actual_read, err) = ctx.wait().await?;
         if status != JindoStatus::Ok {
             buffer.clear();
-            let err_msg = err.unwrap_or_else(jindo_last_error);
-            return Err(FsError::common(format!("Failed to pread: {}", err_msg)));
+            check_jindo_status(status, "Failed to pread", err)?;
         }
 
         let actual_read = usize::try_from(actual_read.max(0)).unwrap_or(0);
@@ -128,18 +124,13 @@ impl OssHdfsReader {
             let start_status =
                 unsafe { jindo_reader_tell_async(handle.as_raw(), Some(cb), userdata) };
             if start_status != JindoStatus::Ok {
-                let err_msg = jindo_last_error();
-                return Err(FsError::common(format!(
-                    "Failed to start tell: {}",
-                    err_msg
-                )));
+                check_jindo_status(start_status, "Failed to start tell", None)?;
             }
         }
 
         let (status, offset, err) = ctx.wait().await?;
         if status != JindoStatus::Ok {
-            let err_msg = err.unwrap_or_else(jindo_last_error);
-            return Err(FsError::common(format!("Failed to tell: {}", err_msg)));
+            check_jindo_status(status, "Failed to tell", err)?;
         }
         Ok(offset)
     }
@@ -280,11 +271,7 @@ impl Reader for OssHdfsReader {
                 };
                 if start_status != JindoStatus::Ok {
                     buffer.clear();
-                    let err_msg = jindo_last_error();
-                    return Err(FsError::common(format!(
-                        "Failed to start read: {}",
-                        err_msg
-                    )));
+                    check_jindo_status(start_status, "Failed to start read", None)?;
                 }
             }
 
@@ -294,8 +281,7 @@ impl Reader for OssHdfsReader {
                     buffer.clear();
                     return Ok(DataSlice::Buffer(buffer));
                 }
-                let err_msg = err.unwrap_or_else(jindo_last_error);
-                return Err(FsError::common(format!("Failed to read: {}", err_msg)));
+                return Err(jindo_error(status, "Failed to read", err));
             }
 
             let actual_read = usize::try_from(actual_read.max(0)).unwrap_or(0);
@@ -353,18 +339,13 @@ impl Reader for OssHdfsReader {
                 let start_status =
                     unsafe { jindo_reader_seek_async(handle.as_raw(), pos, Some(cb), userdata) };
                 if start_status != JindoStatus::Ok {
-                    let err_msg = jindo_last_error();
-                    return Err(FsError::common(format!(
-                        "Failed to start seek: {}",
-                        err_msg
-                    )));
+                    check_jindo_status(start_status, "Failed to start seek", None)?;
                 }
             }
 
             let (status, err) = self.status_ctx.wait().await?;
             if status != JindoStatus::Ok {
-                let err_msg = err.unwrap_or_else(jindo_last_error);
-                return Err(FsError::common(format!("Failed to seek: {}", err_msg)));
+                check_jindo_status(status, "Failed to seek", err)?;
             }
         } // handle is dropped here, releasing the borrow
 
@@ -396,22 +377,14 @@ impl Reader for OssHdfsReader {
                 unsafe {
                     jindo_reader_free(handle.as_raw());
                 }
-                let err_msg = jindo_last_error();
-                return Err(FsError::common(format!(
-                    "Failed to start close reader: {}",
-                    err_msg
-                )));
+                check_jindo_status(start_status, "Failed to start close reader", None)?;
             }
 
             let (status, err) = self.status_ctx.wait().await?;
             unsafe { jindo_reader_free(handle.as_raw()) };
 
             if status != JindoStatus::Ok {
-                let err_msg = err.unwrap_or_else(jindo_last_error);
-                return Err(FsError::common(format!(
-                    "Failed to close reader: {}",
-                    err_msg
-                )));
+                check_jindo_status(status, "Failed to close reader", err)?;
             }
         }
         Ok(())

--- a/curvine-ufs/src/oss_hdfs/oss_hdfs_writer.rs
+++ b/curvine-ufs/src/oss_hdfs/oss_hdfs_writer.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::oss_hdfs::callback_ctx::{I64CallbackCtx, StatusCallbackCtx};
+use crate::oss_hdfs::check_jindo_status;
 use crate::oss_hdfs::ffi::*;
 use bytes::BytesMut;
 use curvine_common::error::FsError;
@@ -58,17 +59,13 @@ impl OssHdfsWriter {
             let start_status =
                 unsafe { jindo_writer_tell_async(handle.as_raw(), Some(cb), userdata) };
             if start_status != JindoStatus::Ok {
-                return Err(FsError::common(format!(
-                    "Failed to start tell: {}",
-                    jindo_last_error()
-                )));
+                check_jindo_status(start_status, "Failed to start tell", None)?;
             }
         }
 
         let (status, offset, err) = self.tell_ctx.wait().await?;
         if status != JindoStatus::Ok {
-            let msg = err.unwrap_or_else(jindo_last_error);
-            return Err(FsError::common(format!("Failed to tell: {}", msg)));
+            check_jindo_status(status, "Failed to tell", err)?;
         }
         Ok(offset)
     }
@@ -161,18 +158,13 @@ impl Writer for OssHdfsWriter {
                 jindo_writer_write_async(handle.as_raw(), data_ptr, data_len, Some(cb), userdata)
             };
             if start_status != JindoStatus::Ok {
-                let err_msg = jindo_last_error();
-                return Err(FsError::common(format!(
-                    "Failed to start write: {}",
-                    err_msg
-                )));
+                check_jindo_status(start_status, "Failed to start write", None)?;
             }
         }
 
         let (status, written, err) = self.write_ctx.wait().await?;
         if status != JindoStatus::Ok {
-            let err_msg = err.unwrap_or_else(jindo_last_error);
-            return Err(FsError::common(format!("Failed to write: {}", err_msg)));
+            check_jindo_status(status, "Failed to write", err)?;
         }
         if written != len {
             return Err(FsError::common(format!(
@@ -203,18 +195,13 @@ impl Writer for OssHdfsWriter {
             let start_status =
                 unsafe { jindo_writer_flush_async(handle.as_raw(), Some(cb), userdata) };
             if start_status != JindoStatus::Ok {
-                let err_msg = jindo_last_error();
-                return Err(FsError::common(format!(
-                    "Failed to start flush: {}",
-                    err_msg
-                )));
+                check_jindo_status(start_status, "Failed to start flush", None)?;
             }
         }
 
         let (status, err) = self.status_ctx.wait().await?;
         if status != JindoStatus::Ok {
-            let err_msg = err.unwrap_or_else(jindo_last_error);
-            return Err(FsError::common(format!("Failed to flush: {}", err_msg)));
+            check_jindo_status(status, "Failed to flush", err)?;
         }
         Ok(())
     }
@@ -241,11 +228,7 @@ impl Writer for OssHdfsWriter {
                 unsafe {
                     jindo_writer_free(handle.as_raw());
                 }
-                let err_msg = jindo_last_error();
-                return Err(FsError::common(format!(
-                    "Failed to start close writer: {}",
-                    err_msg
-                )));
+                check_jindo_status(start_status, "Failed to start close writer", None)?;
             }
 
             let (status, err) = self.status_ctx.wait().await?;
@@ -253,11 +236,7 @@ impl Writer for OssHdfsWriter {
             unsafe { jindo_writer_free(handle.as_raw()) };
 
             if status != JindoStatus::Ok {
-                let err_msg = err.unwrap_or_else(jindo_last_error);
-                return Err(FsError::common(format!(
-                    "Failed to close writer: {}",
-                    err_msg
-                )));
+                check_jindo_status(status, "Failed to close writer", err)?;
             }
         }
         Ok(())


### PR DESCRIPTION
## Problem
UFS backends could turn a real missing file or directory into a generic error. Existing master and worker code already has `FsError::FileNotFound` handling, but it could not run when the adapter hid the error kind.

## Solution
Map OpenDAL and OSS-HDFS/Jindo not-found results to `FsError::FileNotFound` instead of stringly generic errors. Keep other failures as ordinary errors.

## Test Plan
- `cargo fmt --check`
- `CARGO_TARGET_DIR=/tmp/curvine-pr-split-target cargo clippy -p curvine-common -p curvine-server -p curvine-ufs --all-targets --jobs 2 -- --deny=warnings --allow clippy::uninlined-format-args`
- `CARGO_TARGET_DIR=/tmp/curvine-pr-split-target cargo test -p curvine-ufs --all-targets --jobs 2`
