### PR TITLE
fix(ufs): create missing parents during load replay

### DIFF
--- a/curvine-server/src/master/journal/ufs_loader.rs
+++ b/curvine-server/src/master/journal/ufs_loader.rs
@@ -61,6 +61,25 @@ impl UfsLoader {
         }
     }
 
+    async fn mkdir_parent(&self, path: &Path, mnt: &MountValue) -> FsResult<()> {
+        if let Some(parent) = mnt.info.get_ufs_path(path)?.parent()? {
+            mnt.ufs.mkdir(&parent, true).await?;
+        }
+        Ok(())
+    }
+
+    async fn mkdir_with_parent_retry(&self, path: &Path, mnt: &MountValue) -> FsResult<bool> {
+        let ufs_path = mnt.info.get_ufs_path(path)?;
+        match mnt.ufs.mkdir(&ufs_path, false).await {
+            Ok(created) => Ok(created),
+            Err(FsError::FileNotFound(_)) => {
+                self.mkdir_parent(path, mnt).await?;
+                mnt.ufs.mkdir(&ufs_path, false).await
+            }
+            Err(e) => Err(e),
+        }
+    }
+
     pub async fn submit_load_task(&self, path: &Path, mnt: &MountValue) -> FsResult<()> {
         let command = LoadJobCommand::builder(path.clone_uri()).build();
         let runner = self.job_manager.create_runner();
@@ -107,8 +126,8 @@ impl UfsLoader {
 
     pub async fn mkdir(&self, e: &MkdirEntry) -> CommonResult<()> {
         let path = Path::from_str(&e.path)?;
-        if let Some((ufs_path, mnt)) = self.get_mnt(&path)? {
-            mnt.ufs.mkdir(&ufs_path, false).await?;
+        if let Some((_, mnt)) = self.get_mnt(&path)? {
+            self.mkdir_with_parent_retry(&path, &mnt).await?;
             Ok(())
         } else {
             Ok(())
@@ -148,7 +167,17 @@ impl UfsLoader {
 
             let src_dst_path = mnt.info.get_ufs_path(&dst)?;
             if mnt.ufs.fs_kind().support_rename() {
-                mnt.ufs.rename(&src_ufs_path, &src_dst_path).await?;
+                match mnt.ufs.rename(&src_ufs_path, &src_dst_path).await {
+                    Ok(_) => {}
+                    Err(e @ FsError::FileNotFound(_)) => {
+                        if !mnt.ufs.exists(&src_ufs_path).await? {
+                            return Err(e.into());
+                        }
+                        self.mkdir_parent(&dst, &mnt).await?;
+                        mnt.ufs.rename(&src_ufs_path, &src_dst_path).await?;
+                    }
+                    Err(e) => return Err(e.into()),
+                }
                 Ok(())
             } else {
                 mnt.ufs.delete(&src_ufs_path, true).await?;

--- a/curvine-server/src/worker/task/load_task_runner.rs
+++ b/curvine-server/src/worker/task/load_task_runner.rs
@@ -17,6 +17,7 @@ use crate::worker::task::TaskContext;
 use curvine_client::file::CurvineFileSystem;
 use curvine_client::rpc::JobMasterClient;
 use curvine_client::unified::{UfsFileSystem, UnifiedReader, UnifiedWriter};
+use curvine_common::error::FsError;
 use curvine_common::fs::{FileSystem, Path, Reader, Writer};
 use curvine_common::state::{CreateFileOptsBuilder, JobTaskState, SetAttrOptsBuilder};
 use curvine_common::FsResult;
@@ -196,7 +197,16 @@ impl LoadTaskRunner {
                 return err_box!("File exists and overwrite=false");
             }
 
-            ufs.create(path, overwrite).await
+            match ufs.create(path, overwrite).await {
+                Ok(writer) => Ok(writer),
+                Err(FsError::FileNotFound(_)) => {
+                    if let Some(parent) = path.parent()? {
+                        ufs.mkdir(&parent, true).await?;
+                    }
+                    ufs.create(path, overwrite).await
+                }
+                Err(e) => Err(e),
+            }
         }
     }
 

--- a/curvine-server/tests/journal_test.rs
+++ b/curvine-server/tests/journal_test.rs
@@ -18,11 +18,13 @@ use curvine_common::raft::storage::{AppStorage, ApplyMsg};
 use curvine_common::raft::{NodeId, RaftPeer};
 use curvine_common::state::{
     BlockLocation, ClientAddress, CommitBlock, CreateFileOpts, MountOptions, OpenFlags,
-    RenameFlags, WorkerInfo,
+    RenameFlags, WorkerInfo, WriteType,
 };
 use curvine_common::utils::SerdeUtils;
 use curvine_server::master::fs::MasterFilesystem;
-use curvine_server::master::journal::{JournalBatch, JournalLoader, JournalSystem};
+use curvine_server::master::journal::{
+    JournalBatch, JournalEntry, JournalLoader, JournalSystem, UfsLoader,
+};
 use curvine_server::master::{Master, MountManager};
 use log::info;
 use orpc::common::{Logger, TimeSpent};
@@ -331,6 +333,71 @@ fn run_mnt(mnt_mgr: Arc<MountManager>) -> CommonResult<()> {
     // umount
     let mount_uri = CurvineURI::new("/x/z/y")?;
     mgr.umount(mount_uri.path())?;
+
+    Ok(())
+}
+
+#[test]
+fn test_ufs_loader_mkdir_recreates_missing_ufs_parent() -> CommonResult<()> {
+    Master::init_test_metrics();
+
+    let mut conf = ClusterConf {
+        testing: true,
+        ..Default::default()
+    };
+    conf.change_test_meta_dir(format!(
+        "ufs-loader-mkdir-parent-{}",
+        orpc::common::LocalTime::mills()
+    ));
+
+    let journal_system = JournalSystem::from_conf(&conf)?;
+    let fs = MasterFilesystem::with_js(&conf, &journal_system);
+    let mount_manager = journal_system.mount_manager();
+
+    let ufs_dir = std::env::temp_dir().join(format!(
+        "curvine-ufs-loader-mkdir-{}-{}",
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    ));
+    let _ = std::fs::remove_dir_all(&ufs_dir);
+    std::fs::create_dir_all(&ufs_dir)?;
+
+    let mount_opts = MountOptions::builder()
+        .write_type(WriteType::FsMode)
+        .build();
+    mount_manager.mount(
+        None,
+        "/mnt",
+        format!("file://{}/", ufs_dir.display()).as_ref(),
+        &mount_opts,
+    )?;
+
+    fs.mkdir("/mnt/db/table", true)?;
+    journal_system.fs().fs_dir.read().take_entries();
+
+    fs.mkdir("/mnt/db/table/log", false)?;
+    let mkdir_entry = match journal_system
+        .fs()
+        .fs_dir
+        .read()
+        .take_entries()
+        .into_iter()
+        .find_map(|entry| match entry {
+            JournalEntry::Mkdir(e) => Some(e),
+            _ => None,
+        }) {
+        Some(entry) => entry,
+        None => return err_box!("missing mkdir journal entry"),
+    };
+
+    assert!(!ufs_dir.join("db/table").exists());
+
+    let loader = UfsLoader::new(journal_system.job_manager(), &conf.journal);
+    let rt = AsyncRuntime::single();
+    rt.block_on(async { loader.mkdir(&mkdir_entry).await })?;
+
+    assert!(ufs_dir.join("db/table/log").is_dir());
+    let _ = std::fs::remove_dir_all(&ufs_dir);
 
     Ok(())
 }

--- a/curvine-ufs/ffi/jindosdk_ffi.cpp
+++ b/curvine-ufs/ffi/jindosdk_ffi.cpp
@@ -43,7 +43,8 @@ thread_local std::string g_last_error;
 static inline JindoStatus map_error_code_to_status(int32_t code) {
     // Best-effort mapping for a few common error codes.
     // See /usr/local/include/jindosdk/jdo_error.h for the full list.
-    if (code == 3001 /* JDO_FILE_NOT_FOUND_ERROR */) {
+    if (code == 3001 /* JDO_FILE_NOT_FOUND_ERROR */
+        || code == 30001 /* JDO_PARENT_NOT_FOUND_ERROR */) {
         return JINDO_STATUS_FILE_NOT_FOUND;
     }
     return JINDO_STATUS_ERROR;


### PR DESCRIPTION
## Problem
FS-mode UFS compensation can fail when the target parent directory is missing. That is a deterministic namespace gap, not a data-corruption signal, so failing the whole load or replay path leaves the system unable to recover by itself.

## Solution
When mkdir, rename, or load-task create receives `FsError::FileNotFound` for a missing parent, create the parent directory recursively and retry the original operation once. Also map Jindo parent-not-found to `FileNotFound` so the same branch works for OSS-HDFS.

## Test Plan
- `cargo fmt --check`
- `CARGO_TARGET_DIR=/tmp/curvine-pr-split-target cargo clippy -p curvine-common -p curvine-server -p curvine-ufs --all-targets --jobs 2 -- --deny=warnings --allow clippy::uninlined-format-args`
- `CARGO_TARGET_DIR=/tmp/curvine-pr-split-target cargo test -p curvine-server --test journal_test test_ufs_loader_mkdir_recreates_missing_ufs_parent --jobs 2 -- --nocapture`
