### PR TITLE
fix(master): repair orphan inode edges on restore

### DIFF
--- a/curvine-server/src/master/meta/store/inode_store.rs
+++ b/curvine-server/src/master/meta/store/inode_store.rs
@@ -423,23 +423,27 @@ impl InodeStore {
         let mut has_repairs = false;
         while let Some((mut parent, child_id, file_entry)) = stack.pop_front() {
             last_inode_id = last_inode_id.max(child_id);
+            let parent_id = parent.id();
+            let edge_name = file_entry.name().to_string();
 
             let next_parent = if child_id != ROOT_INODE_ID {
                 let mut store_inode = match self.store.get_inode(child_id)? {
                     Some(v) => v,
                     None => {
                         // Orphaned edge: inode was deleted but edge was not cleaned up
-                        // (can happen after a crash between two non-atomic batch commits).
-                        // Skip this entry to keep the tree consistent.
+                        // by older buggy metadata updates. Drop the edge durably so
+                        // recovery does not keep replaying the same broken namespace entry.
                         log::warn!(
-                            "create_tree: orphaned edge detected, child_id={} has no inode, skipping",
+                            "create_tree: orphaned edge detected, parent_id={}, edge_name='{}', child_id={} has no inode, dropping edge",
+                            parent_id,
+                            edge_name,
                             child_id
                         );
+                        repair_batch.delete_child(parent_id, &edge_name)?;
+                        has_repairs = true;
                         continue;
                     }
                 };
-                let parent_id = parent.id();
-                let edge_name = file_entry.name().to_string();
 
                 let inode = match store_inode {
                     InodeView::Dir(_) => {

--- a/curvine-server/tests/inode_test.rs
+++ b/curvine-server/tests/inode_test.rs
@@ -14,9 +14,14 @@
 
 use curvine_common::rocksdb::DBConf;
 use curvine_common::state::BlockLocation;
+use curvine_server::master::meta::inode::ttl::TtlBucketList;
 use curvine_server::master::meta::inode::{InodeDir, InodeFile, InodeView, ROOT_INODE_ID};
-use curvine_server::master::meta::store::RocksInodeStore;
+use curvine_server::master::meta::store::{InodeStore, RocksInodeStore};
+use curvine_server::master::meta::FsDir;
+use curvine_server::master::Master;
+use orpc::common::Utils;
 use orpc::CommonResult;
+use std::sync::Arc;
 
 #[test]
 fn test_inode_dir_add_children_and_sort_alphabetically() {
@@ -87,6 +92,38 @@ fn test_rocks_inode_store_add_delete_child_and_iterator() -> CommonResult<()> {
     }
     println!("vec = {:?}", vec);
     assert_eq!(vec, vec![2, 3]);
+
+    Ok(())
+}
+
+#[test]
+fn test_inode_store_create_tree_removes_orphan_edges() -> CommonResult<()> {
+    Master::init_test_metrics();
+
+    let conf = DBConf::new(Utils::test_sub_dir(format!(
+        "inode-test/orphan-edge-{}",
+        Utils::rand_str(6)
+    )));
+    {
+        let rocks = RocksInodeStore::new(conf.clone(), true)?;
+        let store = InodeStore::new(rocks, Arc::new(TtlBucketList::new(60_000)));
+        let root = FsDir::create_root();
+        let missing_inode_id = 2001;
+
+        {
+            let mut batch = store.new_batch();
+            batch.write_inode(&root)?;
+            batch.add_child(ROOT_INODE_ID, "missing", missing_inode_id)?;
+            batch.commit()?;
+        }
+
+        let (_, restored) = store.create_tree()?;
+        assert!(restored.get_child("missing").is_none());
+    }
+
+    let rocks = RocksInodeStore::new(conf, false)?;
+    let edge_count = rocks.edges_iter(ROOT_INODE_ID)?.count();
+    assert_eq!(edge_count, 0);
 
     Ok(())
 }


### PR DESCRIPTION
## Problem
A dirty RocksDB namespace can contain a directory edge whose child inode no longer exists. Before this fix, restore skipped the bad edge in memory but left it in RocksDB, so the same broken edge could be encountered again on the next restart.

## Solution
During tree reconstruction, detect an edge pointing to a missing inode and delete that edge in the repair batch. The restored namespace no longer contains the orphan, and the repair is durable.

## Test Plan
- `cargo fmt --check`
- `CARGO_TARGET_DIR=/tmp/curvine-pr-split-target cargo clippy -p curvine-common -p curvine-server -p curvine-ufs --all-targets --jobs 2 -- --deny=warnings --allow clippy::uninlined-format-args`
- `CARGO_TARGET_DIR=/tmp/curvine-pr-split-target cargo test -p curvine-server --test inode_test test_inode_store_create_tree_removes_orphan_edges --jobs 2 -- --nocapture`
