### PR TITLE
fix(master): make full block reports authoritative

### DIFF
--- a/curvine-common/src/error/fs_error.rs
+++ b/curvine-common/src/error/fs_error.rs
@@ -63,6 +63,7 @@ pub enum ErrorKind {
     IsADirectory = 26,
     NotADirectory = 27,
     InvalidArgument = 28,
+    BlockNotFound = 29,
 
     #[num_enum(default)]
     Common = 10000,
@@ -134,6 +135,10 @@ pub enum FsError {
     // Block exception
     #[error("{0}")]
     BlockInfo(ErrorImpl<StringError>),
+
+    // Block data does not exist.
+    #[error("{0}")]
+    BlockNotFound(ErrorImpl<StringError>),
 
     // The lease written to the client service is incorrect.
     #[error("{0}")]
@@ -214,6 +219,11 @@ impl FsError {
     pub fn file_not_found(path: impl AsRef<str>) -> Self {
         let msg = format!("File {} not found", path.as_ref());
         Self::FileNotFound(ErrorImpl::with_source(msg.into()))
+    }
+
+    pub fn block_not_found(block_id: i64) -> Self {
+        let msg = format!("Block {} not found", block_id);
+        Self::BlockNotFound(ErrorImpl::with_source(msg.into()))
     }
 
     pub fn file_expired(path: impl AsRef<str>) -> Self {
@@ -347,6 +357,7 @@ impl FsError {
             FsError::AbnormalData(_) => ErrorKind::AbnormalData,
             FsError::BlockIsWriting(_) => ErrorKind::BlockIsWriting,
             FsError::BlockInfo(_) => ErrorKind::BlockInfo,
+            FsError::BlockNotFound(_) => ErrorKind::BlockNotFound,
             FsError::Lease(_) => ErrorKind::Lease,
             FsError::InvalidPath(_) => ErrorKind::InvalidPath,
             FsError::InvalidArgument(_) => ErrorKind::InvalidArgument,
@@ -492,6 +503,7 @@ impl ErrorExt for FsError {
             FsError::AbnormalData(e) => FsError::AbnormalData(e.ctx(ctx)),
             FsError::BlockIsWriting(e) => FsError::BlockIsWriting(e.ctx(ctx)),
             FsError::BlockInfo(e) => FsError::BlockInfo(e.ctx(ctx)),
+            FsError::BlockNotFound(e) => FsError::BlockNotFound(e.ctx(ctx)),
             FsError::Lease(e) => FsError::Lease(e.ctx(ctx)),
             FsError::InvalidPath(e) => FsError::InvalidPath(e.ctx(ctx)),
             FsError::InvalidArgument(e) => FsError::InvalidArgument(e.ctx(ctx)),
@@ -526,6 +538,7 @@ impl ErrorExt for FsError {
             FsError::AbnormalData(e) => e.encode(ErrorKind::AbnormalData),
             FsError::BlockIsWriting(e) => e.encode(ErrorKind::BlockIsWriting),
             FsError::BlockInfo(e) => e.encode(ErrorKind::BlockInfo),
+            FsError::BlockNotFound(e) => e.encode(ErrorKind::BlockNotFound),
             FsError::Lease(e) => e.encode(ErrorKind::Lease),
             FsError::InvalidPath(e) => e.encode(ErrorKind::InvalidPath),
             FsError::InvalidArgument(e) => e.encode(ErrorKind::InvalidArgument),
@@ -563,6 +576,7 @@ impl ErrorExt for FsError {
             ErrorKind::AbnormalData => FsError::AbnormalData(de.into_string()),
             ErrorKind::BlockIsWriting => FsError::BlockIsWriting(de.into_string()),
             ErrorKind::BlockInfo => FsError::BlockInfo(de.into_string()),
+            ErrorKind::BlockNotFound => FsError::BlockNotFound(de.into_string()),
             ErrorKind::Lease => FsError::Lease(de.into_string()),
             ErrorKind::InvalidPath => FsError::InvalidPath(de.into_string()),
             ErrorKind::InvalidArgument => FsError::InvalidArgument(de.into_string()),

--- a/curvine-common/tests/fs_error_test.rs
+++ b/curvine-common/tests/fs_error_test.rs
@@ -1,0 +1,18 @@
+use curvine_common::error::{ErrorKind, FsError};
+use orpc::error::ErrorExt;
+
+#[test]
+fn block_not_found_round_trips_with_structured_kind() {
+    let error = FsError::block_not_found(42);
+    assert!(matches!(error.kind(), ErrorKind::BlockNotFound));
+
+    let decoded = FsError::decode(error.encode());
+    assert!(matches!(decoded.kind(), ErrorKind::BlockNotFound));
+
+    match decoded {
+        FsError::BlockNotFound(error) => {
+            assert_eq!(error.source.to_string(), "Block 42 not found");
+        }
+        other => panic!("expected BlockNotFound, got {:?}", other),
+    }
+}

--- a/curvine-server/src/master/fs/master_filesystem.rs
+++ b/curvine-server/src/master/fs/master_filesystem.rs
@@ -26,8 +26,11 @@ use curvine_common::error::FsError;
 use curvine_common::state::*;
 use curvine_common::FsResult;
 use log::warn;
+use orpc::common::LocalTime;
 use orpc::sync::ArcRwLock;
 use orpc::{err_box, err_ext, try_option, CommonResult};
+use parking_lot::Mutex;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 #[derive(Clone)]
@@ -36,7 +39,16 @@ pub struct MasterFilesystem {
     pub worker_manager: SyncWorkerManager,
     pub master_monitor: MasterMonitor,
     pub conf: Arc<MasterConf>,
+    full_block_reports: Arc<Mutex<HashMap<u32, FullBlockReportState>>>,
 }
+
+struct FullBlockReportState {
+    total_len: u64,
+    update_time_ms: u64,
+    reported_blocks: HashSet<i64>,
+}
+
+const FULL_BLOCK_REPORT_TTL_MS: u64 = 60 * 60 * 1000;
 
 impl MasterFilesystem {
     pub fn new(
@@ -50,6 +62,7 @@ impl MasterFilesystem {
             worker_manager,
             master_monitor,
             conf: Arc::new(conf.master.clone()),
+            full_block_reports: Default::default(),
         }
     }
 
@@ -59,6 +72,7 @@ impl MasterFilesystem {
             worker_manager: js.worker_manager(),
             master_monitor: js.master_monitor(),
             conf: Arc::new(conf.master.clone()),
+            full_block_reports: Default::default(),
         }
     }
 
@@ -673,11 +687,61 @@ impl MasterFilesystem {
         fs_dir.block_exists(id)
     }
 
+    fn collect_full_block_report(&self, list: &BlockReportList) -> Option<HashSet<i64>> {
+        if !list.full_report {
+            return None;
+        }
+
+        let now = LocalTime::mills();
+        let mut reports = self.full_block_reports.lock();
+        reports.retain(|_, report| {
+            now.saturating_sub(report.update_time_ms) <= FULL_BLOCK_REPORT_TTL_MS
+        });
+        let report = reports
+            .entry(list.worker_id)
+            .or_insert_with(|| FullBlockReportState {
+                total_len: list.total_len,
+                update_time_ms: now,
+                reported_blocks: HashSet::with_capacity(list.total_len as usize),
+            });
+
+        if report.total_len != list.total_len {
+            warn!(
+                "full block report for worker {} restarted because total_len changed from {} to {}; discarding {} accumulated block ids",
+                list.worker_id,
+                report.total_len,
+                list.total_len,
+                report.reported_blocks.len()
+            );
+            report.total_len = list.total_len;
+            report.reported_blocks.clear();
+            report.reported_blocks.reserve(list.total_len as usize);
+        }
+        report.update_time_ms = now;
+
+        for block in &list.blocks {
+            report.reported_blocks.insert(block.id);
+        }
+
+        if report.reported_blocks.len() as u64 >= report.total_len {
+            reports
+                .remove(&list.worker_id)
+                .map(|report| report.reported_blocks)
+        } else {
+            None
+        }
+    }
+
+    pub fn reset_full_block_report(&self, worker_id: u32) {
+        self.full_block_reports.lock().remove(&worker_id);
+    }
+
     /// Process block reports
-    pub fn block_report(&self, list: BlockReportList) -> FsResult<()> {
+    pub fn block_report(&self, list: BlockReportList) -> FsResult<Vec<i64>> {
         // @todo check cluster.
-        if list.blocks.is_empty() {
-            return Ok(());
+        let full_reported_blocks = self.collect_full_block_report(&list);
+        if list.blocks.is_empty() && full_reported_blocks.is_none() {
+            return Ok(Vec::new());
         }
 
         //(Whether to increase, block id, block location)
@@ -729,8 +793,29 @@ impl MasterFilesystem {
         }
         drop(wm);
 
+        let mut stale_block_ids = Vec::new();
         let mut fs_dir = self.fs_dir.write();
-        fs_dir.block_report(batch)
+        if let Some(reported_blocks) = full_reported_blocks {
+            let existing_blocks = fs_dir.get_worker_block_ids(list.worker_id)?;
+            for block_id in existing_blocks {
+                if !reported_blocks.contains(&block_id) {
+                    batch.push((false, block_id, BlockLocation::with_id(list.worker_id)));
+                    stale_block_ids.push(block_id);
+                }
+            }
+        }
+
+        fs_dir.block_report(batch)?;
+
+        if !stale_block_ids.is_empty() {
+            warn!(
+                "full block report reconciled {} stale block locations for worker {}",
+                stale_block_ids.len(),
+                list.worker_id
+            );
+        }
+
+        Ok(stale_block_ids)
     }
 
     pub fn delete_locations(&self, worker_id: u32) -> FsResult<Vec<i64>> {

--- a/curvine-server/src/master/master_handler.rs
+++ b/curvine-server/src/master/master_handler.rs
@@ -28,6 +28,7 @@ use curvine_common::state::{
 };
 use curvine_common::utils::ProtoUtils;
 use curvine_common::FsResult;
+use log::error;
 use orpc::err_box;
 use orpc::handler::{FrameBuf, MessageHandler};
 use orpc::io::net::ConnState;
@@ -427,12 +428,18 @@ impl MasterHandler {
 
     pub fn worker_heartbeat(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let header: WorkerHeartbeatRequest = ctx.parse_header()?;
+        let status = HeartbeatStatus::from(header.status);
+        let address = ProtoUtils::worker_address_from_pb(&header.address);
+        if matches!(status, HeartbeatStatus::Start) {
+            self.fs.reset_full_block_report(address.worker_id);
+        }
+
         let mut wm = self.fs.worker_manager.write();
 
         let cmds = wm.heartbeat(
             &header.cluster_id,
-            HeartbeatStatus::from(header.status),
-            ProtoUtils::worker_address_from_pb(&header.address),
+            status,
+            address,
             ProtoUtils::storage_info_list_from_pb(header.storages),
         )?;
         drop(wm);
@@ -446,7 +453,21 @@ impl MasterHandler {
     pub fn block_report(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let header: BlockReportListRequest = ctx.parse_header()?;
         let list = ProtoUtils::block_report_list_from_pb(header);
-        self.fs.block_report(list)?;
+        let worker_id = list.worker_id;
+        let stale_block_ids = self.fs.block_report(list)?;
+        let stale_block_count = stale_block_ids.len();
+        if stale_block_count > 0 {
+            if let Some(replication_handler) = &self.replication_handler {
+                if let Err(e) =
+                    replication_handler.report_under_replicated_blocks(worker_id, stale_block_ids)
+                {
+                    error!(
+                        "Errors on reporting under-replicated {} blocks from full block report reconciliation. err: {:?}",
+                        stale_block_count, e
+                    );
+                }
+            }
+        }
 
         let rep_header = BlockReportListResponse::default();
         ctx.response_buf(rep_header, &mut self.buf)

--- a/curvine-server/src/master/meta/fs_dir.rs
+++ b/curvine-server/src/master/meta/fs_dir.rs
@@ -790,6 +790,10 @@ impl FsDir {
         Ok(block_ids)
     }
 
+    pub fn get_worker_block_ids(&self, worker_id: u32) -> FsResult<Vec<i64>> {
+        Ok(self.store.store.get_block_ids(worker_id)?)
+    }
+
     // for testing
     pub fn take_entries(&self) -> Vec<JournalEntry> {
         self.journal_writer.take_entries()

--- a/curvine-server/src/master/replication/master_replication_handler.rs
+++ b/curvine-server/src/master/replication/master_replication_handler.rs
@@ -22,6 +22,7 @@ use log::warn;
 use orpc::error::ErrorImpl;
 use orpc::handler::MessageHandler;
 use orpc::message::Message;
+use orpc::CommonResult;
 use std::sync::Arc;
 
 #[derive(Clone)]
@@ -32,6 +33,15 @@ pub struct MasterReplicationHandler {
 impl MasterReplicationHandler {
     pub fn new(manager: Arc<MasterReplicationManager>) -> Self {
         Self { manager }
+    }
+
+    pub fn report_under_replicated_blocks(
+        &self,
+        worker_id: u32,
+        block_ids: Vec<i64>,
+    ) -> CommonResult<()> {
+        self.manager
+            .report_under_replicated_blocks(worker_id, block_ids)
     }
 
     pub fn report_replication_result(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {

--- a/curvine-server/src/worker/block/block_actor.rs
+++ b/curvine-server/src/worker/block/block_actor.rs
@@ -113,6 +113,10 @@ impl BlockActor {
 
     pub fn full_block_report(&self) -> CommonResult<usize> {
         let blocks = self.store.all_blocks();
+        if blocks.is_empty() {
+            let _ = self.client.full_block_report(0, &[])?;
+            return Ok(0);
+        }
 
         let mut off = 0;
         while off < blocks.len() {

--- a/curvine-server/src/worker/handler/read_handler.rs
+++ b/curvine-server/src/worker/handler/read_handler.rs
@@ -21,6 +21,7 @@ use curvine_common::state::StorageType;
 use curvine_common::FsResult;
 use log::{info, warn};
 use orpc::common::{ByteUnit, TimeSpent};
+use orpc::error::ErrorExt;
 use orpc::handler::MessageHandler;
 use orpc::io::{BlockDevice, BlockIO};
 use orpc::message::{Builder, Message, RequestStatus};
@@ -59,7 +60,10 @@ impl ReadHandler {
 
     pub fn open(&mut self, msg: &Message) -> FsResult<Message> {
         let mut context = ReadContext::from_req(msg)?;
-        let meta = self.store.get_block(context.block_id)?;
+        let meta = self.store.get_block(context.block_id).map_err(|e| {
+            FsError::block_not_found(context.block_id)
+                .ctx(format!("worker block store lookup failed: {}", e))
+        })?;
 
         if context.off > meta.len {
             return err_box!(


### PR DESCRIPTION
## Problem
After worker local storage is replaced or lost, master can keep stale block locations because a full block report only adds reported blocks and an empty worker report is ignored. Reads can then be routed to blocks that no longer exist on that worker.

## Solution
Aggregate chunked full block reports per worker and treat the completed report as the worker's authoritative block set. Remove master-side locations that are absent from the full report, reset partial reports when a worker restarts, accept empty full reports, and return a structured `BlockNotFound` when a worker no longer has a block.

## Test Plan
- `cargo fmt --check`
- `CARGO_TARGET_DIR=/tmp/curvine-pr-split-target cargo clippy -p curvine-common -p curvine-server -p curvine-ufs --all-targets --jobs 2 -- --deny=warnings --allow clippy::uninlined-format-args`
- `CARGO_TARGET_DIR=/tmp/curvine-pr-split-target cargo test -p curvine-common --test fs_error_test block_not_found_round_trips_with_structured_kind --jobs 2 -- --nocapture`
