### PR TITLE
feat(master): resolve file inodes by ID for add_block and complete_file

### DIFF
--- a/curvine-client/src/file/fs_client.rs
+++ b/curvine-client/src/file/fs_client.rs
@@ -276,6 +276,30 @@ impl FsClient {
         file_len: i64,
         last_block: Option<ExtendedBlock>,
     ) -> FsResult<LocatedBlock> {
+        self.add_block0(path, None, commit_blocks, file_len, last_block)
+            .await
+    }
+
+    pub async fn add_block_by_id(
+        &self,
+        path: &Path,
+        id: i64,
+        commit_blocks: Vec<CommitBlock>,
+        file_len: i64,
+        last_block: Option<ExtendedBlock>,
+    ) -> FsResult<LocatedBlock> {
+        self.add_block0(path, Some(id), commit_blocks, file_len, last_block)
+            .await
+    }
+
+    async fn add_block0(
+        &self,
+        path: &Path,
+        inode_id: Option<i64>,
+        commit_blocks: Vec<CommitBlock>,
+        file_len: i64,
+        last_block: Option<ExtendedBlock>,
+    ) -> FsResult<LocatedBlock> {
         let commit_blocks = commit_blocks
             .into_iter()
             .map(|v| ProtoUtils::commit_block_to_pb(v.clone()))
@@ -289,6 +313,7 @@ impl FsClient {
             client_address: self.context.client_addr_pb(),
             file_len,
             last_block: last_block.map(ProtoUtils::extend_block_to_pb),
+            inode_id,
         };
 
         let rep_header = self.rpc(RpcCode::AddBlock, header).await?;
@@ -309,6 +334,7 @@ impl FsClient {
                     client_address: self.context.client_addr_pb(),
                     file_len: 0,
                     last_block: None,
+                    inode_id: None,
                 }
             })
             .collect();
@@ -323,10 +349,35 @@ impl FsClient {
             .map(ProtoUtils::located_block_from_pb)
             .collect())
     }
-    // File writing is completed.
+
     pub async fn complete_file(
         &self,
         path: &Path,
+        len: i64,
+        commit_blocks: impl IntoIterator<Item = CommitBlock>,
+        only_flush: bool,
+    ) -> FsResult<Option<FileBlocks>> {
+        self.complete_file0(path, None, len, commit_blocks, only_flush)
+            .await
+    }
+
+    pub async fn complete_file_by_id(
+        &self,
+        path: &Path,
+        inode_id: i64,
+        len: i64,
+        commit_blocks: impl IntoIterator<Item = CommitBlock>,
+        only_flush: bool,
+    ) -> FsResult<Option<FileBlocks>> {
+        self.complete_file0(path, Some(inode_id), len, commit_blocks, only_flush)
+            .await
+    }
+
+    // File writing is completed.
+    async fn complete_file0(
+        &self,
+        path: &Path,
+        inode_id: Option<i64>,
         len: i64,
         commit_blocks: impl IntoIterator<Item = CommitBlock>,
         only_flush: bool,
@@ -342,6 +393,7 @@ impl FsClient {
             client_name: self.context().clone_client_name(),
             commit_blocks,
             only_flush,
+            inode_id,
         };
 
         let rep: CompleteFileResponse = self.rpc(RpcCode::CompleteFile, header).await?;
@@ -366,6 +418,7 @@ impl FsClient {
                     client_name,
                     commit_blocks,
                     only_flush,
+                    inode_id: None,
                 }
             })
             .collect();

--- a/curvine-client/src/file/fs_writer_base.rs
+++ b/curvine-client/src/file/fs_writer_base.rs
@@ -180,7 +180,13 @@ impl FsWriterBase {
 
         let commits_blocks = self.file_blocks.take_commit_blocks();
         self.fs_client
-            .complete_file(&self.path, self.len, commits_blocks, only_flush)
+            .complete_file_by_id(
+                &self.path,
+                self.file_blocks.status.id,
+                self.len,
+                commits_blocks,
+                only_flush,
+            )
             .await
     }
 
@@ -227,7 +233,13 @@ impl FsWriterBase {
                         let last_block = self.file_blocks.last_block();
                         let lb = self
                             .fs_client
-                            .add_block(&self.path, commit_blocks, self.len, last_block)
+                            .add_block_by_id(
+                                &self.path,
+                                self.file_blocks.status.id,
+                                commit_blocks,
+                                self.len,
+                                last_block,
+                            )
                             .await?;
                         self.file_blocks.add_block(lb.clone())?;
                         let writer =

--- a/curvine-common/proto/master.proto
+++ b/curvine-common/proto/master.proto
@@ -146,6 +146,7 @@ message AddBlockRequest {
     required ClientAddressProto client_address = 5;
     required int64 file_len = 6;
     optional ExtendedBlockProto last_block = 7;
+    optional int64 inode_id = 8;
 }
 
 message AddBlockResponse {
@@ -186,6 +187,7 @@ message CompleteFileRequest {
     required string client_name = 3;
     repeated CommitBlockProto commit_blocks = 4;
     required bool only_flush = 5 [default = false];
+    optional int64 inode_id = 6;
 }
 
 message CompleteFileResponse {

--- a/curvine-server/src/master/fs/master_filesystem.rs
+++ b/curvine-server/src/master/fs/master_filesystem.rs
@@ -15,7 +15,7 @@
 use crate::master::fs::context::ValidateAddBlock;
 use crate::master::fs::policy::ChooseContext;
 use crate::master::journal::JournalSystem;
-use crate::master::meta::inode::{InodeFile, InodePath, InodeView, PATH_SEPARATOR};
+use crate::master::meta::inode::{InodeFile, InodePath, InodePtr, InodeView, PATH_SEPARATOR};
 use crate::master::meta::FsDir;
 
 use crate::master::fs::DeleteResult;
@@ -440,12 +440,19 @@ impl MasterFilesystem {
         client_addr: ClientAddress,
         exclude_workers: Vec<u32>,
     ) -> FsResult<Vec<WorkerAddress>> {
-        let wm = self.worker_manager.read();
-
         let mut inode = try_option!(inp.get_last_inode());
         let file = inode.as_file_mut()?;
-        let validate_block = Self::validate_add_block(file, &client_addr, None)?;
+        self.choose_worker_for_file(file, client_addr, exclude_workers)
+    }
 
+    pub fn choose_worker_for_file(
+        &self,
+        file: &InodeFile,
+        client_addr: ClientAddress,
+        exclude_workers: Vec<u32>,
+    ) -> FsResult<Vec<WorkerAddress>> {
+        let wm = self.worker_manager.read();
+        let validate_block = Self::validate_add_block(file, &client_addr, None)?;
         let choose_ctx = ChooseContext::with_block(validate_block, exclude_workers);
         Ok(wm.choose_worker(choose_ctx)?)
     }
@@ -461,10 +468,33 @@ impl MasterFilesystem {
             .create_locate_block(path, block, locs)
     }
 
+    pub fn resolve_file_inode(
+        fs_dir: &FsDir,
+        path: &str,
+        inode_id: Option<i64>,
+    ) -> FsResult<InodePtr> {
+        match inode_id {
+            Some(v) if v > 0 => match fs_dir.store.get_inode(v, None)? {
+                Some(view) => Ok(InodePtr::from_owned(view)),
+                None => err_box!("File inode {} not exists", v),
+            },
+
+            _ => {
+                let inp = Self::resolve_path(fs_dir, path)?;
+                match inp.task_last() {
+                    Some(ptr) => Ok(ptr),
+                    None => err_box!("File {} not exists", path),
+                }
+            }
+        }
+    }
+
     /// Document application to allocate a new block.
+    #[allow(clippy::too_many_arguments)]
     pub fn add_block<T: AsRef<str>>(
         &self,
         path: T,
+        inode_id: Option<i64>,
         client_addr: ClientAddress,
         commit_blocks: Vec<CommitBlock>,
         exclude_workers: Vec<u32>,
@@ -473,11 +503,7 @@ impl MasterFilesystem {
     ) -> FsResult<LocatedBlock> {
         let path = path.as_ref();
         let mut fs_dir = self.fs_dir.write();
-        let inp = Self::resolve_path(&fs_dir, path)?;
-        let inode = match inp.get_last_inode() {
-            Some(v) => v,
-            None => return err_box!("File {} not exists", inp.path()),
-        };
+        let inode = Self::resolve_file_inode(&fs_dir, path, inode_id)?;
         let file = inode.as_file_ref()?;
 
         // File allows concurrent writes, 'previous' is the previous block,
@@ -496,8 +522,9 @@ impl MasterFilesystem {
             return self.create_locate_block(path, extend_block, &locs);
         }
 
-        let choose_workers = self.choose_worker(&inp, client_addr, exclude_workers)?;
-        let block = fs_dir.acquire_new_block(&inp, commit_blocks, &choose_workers, file_len)?;
+        let choose_workers = self.choose_worker_for_file(file, client_addr, exclude_workers)?;
+        let block =
+            fs_dir.acquire_new_block(path, inode, commit_blocks, &choose_workers, file_len)?;
         let located = LocatedBlock {
             block,
             locs: choose_workers,
@@ -509,6 +536,7 @@ impl MasterFilesystem {
     pub fn complete_file<T: AsRef<str>>(
         &self,
         path: T,
+        inode_id: Option<i64>,
         len: i64,
         commit_blocks: Vec<CommitBlock>,
         client_name: T,
@@ -516,15 +544,18 @@ impl MasterFilesystem {
     ) -> FsResult<Option<FileBlocks>> {
         let path = path.as_ref();
         let mut fs_dir = self.fs_dir.write();
-        let inp = Self::resolve_path(&fs_dir, path)?;
+        let mut inode = Self::resolve_file_inode(&fs_dir, path, inode_id)?;
+        fs_dir.complete_file(
+            path,
+            &mut inode,
+            len,
+            commit_blocks,
+            client_name,
+            only_flush,
+        )?;
 
-        let inode = match inp.get_last_inode() {
-            None => return err_box!("File does not exist: {}", inp.path()),
-            Some(v) => v,
-        };
-        let file = inode.as_file_ref()?;
-        fs_dir.complete_file(&inp, len, commit_blocks, client_name, only_flush)?;
         if only_flush {
+            let file = inode.as_file_ref()?;
             let locs = self.get_block_locs(path, &fs_dir, file)?;
             let status = inode.to_file_status(path);
             Ok(Some(FileBlocks::new(status, locs)))

--- a/curvine-server/src/master/journal/journal_loader.rs
+++ b/curvine-server/src/master/journal/journal_loader.rs
@@ -14,9 +14,11 @@
 
 #![allow(clippy::needless_range_loop)]
 
+use crate::master::fs::MasterFilesystem;
 use crate::master::journal::*;
 use crate::master::meta::inode::InodeView::File;
 use crate::master::meta::inode::{InodePath, InodeView};
+use crate::master::meta::InodeId;
 use crate::master::{JobManager, Master, MasterMetrics, MountManager, SyncFsDir};
 use curvine_common::conf::JournalConf;
 use curvine_common::error::FsError;
@@ -603,12 +605,13 @@ impl JournalLoader {
 
     fn add_block(&self, entry: AddBlockEntry) -> CommonResult<()> {
         let fs_dir = self.fs_dir.write();
-        let inp = InodePath::resolve(fs_dir.root_ptr(), &entry.path, &fs_dir.store)?;
 
-        let mut inode = match inp.get_last_inode() {
-            Some(v) => v,
-            None => {
-                warn!("add_block: file not found: {:?}", entry);
+        let inode_id = entry.blocks.first().map(|v| InodeId::get_id(v.id));
+
+        let mut inode = match MasterFilesystem::resolve_file_inode(&fs_dir, &entry.path, inode_id) {
+            Ok(v) => v,
+            Err(e) => {
+                warn!("add_block: file not found: {:?} {}", entry, e);
                 return Ok(());
             }
         };
@@ -623,15 +626,15 @@ impl JournalLoader {
 
     fn complete_file(&self, entry: CompleteFileEntry) -> CommonResult<()> {
         let fs_dir = self.fs_dir.write();
-        let inp = InodePath::resolve(fs_dir.root_ptr(), &entry.path, &fs_dir.store)?;
 
-        let mut inode = match inp.get_last_inode() {
-            Some(v) => v,
-            None => {
-                warn!("complete_file: file not found: {:?}", entry);
-                return Ok(());
-            }
-        };
+        let mut inode =
+            match MasterFilesystem::resolve_file_inode(&fs_dir, &entry.path, Some(entry.file.id)) {
+                Ok(v) => v,
+                Err(e) => {
+                    warn!("complete_file: file not found: {:?} {}", entry, e);
+                    return Ok(());
+                }
+            };
         let file = inode.as_file_mut()?;
 
         let _ = mem::replace(file, entry.file);

--- a/curvine-server/src/master/master_handler.rs
+++ b/curvine-server/src/master/master_handler.rs
@@ -288,13 +288,15 @@ impl MasterHandler {
             .map(ProtoUtils::commit_block_from_pb)
             .collect();
 
+        let last_block = req.last_block.map(ProtoUtils::extend_block_from_pb);
         let located_block = self.fs.add_block(
             path,
+            req.inode_id,
             client_addr,
             commit_blocks,
             req.exclude_workers,
             req.file_len,
-            req.last_block.map(ProtoUtils::extend_block_from_pb),
+            last_block,
         )?;
         let rep_header = ProtoUtils::located_block_to_pb(located_block);
         ctx.response_buf(rep_header, &mut self.buf)
@@ -318,6 +320,7 @@ impl MasterHandler {
             .collect();
         let file_blocks = self.fs.complete_file(
             req.path,
+            req.inode_id,
             req.len,
             commit_blocks,
             req.client_name,
@@ -365,13 +368,15 @@ impl MasterHandler {
                 .map(ProtoUtils::commit_block_from_pb)
                 .collect();
 
+            let last_block = req.last_block.map(ProtoUtils::extend_block_from_pb);
             let located_block = self.fs.add_block(
                 path,
+                req.inode_id,
                 client_addr,
                 commit_blocks,
                 req.exclude_workers,
                 req.file_len,
-                req.last_block.map(ProtoUtils::extend_block_from_pb),
+                last_block,
             )?;
             results.push(ProtoUtils::located_block_to_pb(located_block));
         }
@@ -394,6 +399,7 @@ impl MasterHandler {
                 .fs
                 .complete_file(
                     req.path,
+                    req.inode_id,
                     req.len,
                     commit_blocks,
                     req.client_name,

--- a/curvine-server/src/master/meta/fs_dir.rs
+++ b/curvine-server/src/master/meta/fs_dir.rs
@@ -522,12 +522,12 @@ impl FsDir {
 
     pub fn acquire_new_block(
         &mut self,
-        inp: &InodePath,
+        path: impl AsRef<str>,
+        mut inode: InodePtr,
         commit_blocks: Vec<CommitBlock>,
         choose_workers: &[WorkerAddress],
         file_len: i64,
     ) -> FsResult<ExtendedBlock> {
-        let mut inode = try_option!(inp.get_last_inode());
         let file = inode.as_file_mut()?;
 
         let new_block_id = file.next_block_id()?;
@@ -549,19 +549,19 @@ impl FsDir {
         // state add block.
         self.store.apply_new_block(inode.as_ref(), &commit_blocks)?;
         self.journal_writer
-            .log_add_block(self, inp.path(), inode.as_file_ref()?, commit_blocks)?;
+            .log_add_block(self, path, inode.as_file_ref()?, commit_blocks)?;
         Ok(block)
     }
 
     pub fn complete_file(
         &mut self,
-        inp: &InodePath,
+        path: impl AsRef<str>,
+        inode: &mut InodePtr,
         len: i64,
         commit_block: Vec<CommitBlock>,
         client_name: impl AsRef<str>,
         only_flush: bool,
     ) -> FsResult<bool> {
-        let mut inode = try_option!(inp.get_last_inode());
         let file = inode.as_file_mut()?;
         file.complete(len, &commit_block, client_name, only_flush)?;
 
@@ -569,12 +569,8 @@ impl FsDir {
 
         self.store
             .apply_complete_file(inode.as_ref(), &commit_block)?;
-        self.journal_writer.log_complete_file(
-            self,
-            inp.path(),
-            inode.as_file_ref()?,
-            commit_block,
-        )?;
+        self.journal_writer
+            .log_complete_file(self, path, inode.as_file_ref()?, commit_block)?;
 
         Ok(true)
     }

--- a/curvine-server/src/master/meta/inode/inode_path.rs
+++ b/curvine-server/src/master/meta/inode/inode_path.rs
@@ -371,9 +371,13 @@ impl InodePath {
         }
     }
 
-    // Delete the last 1 inodes.
-    pub fn delete_last(&mut self) {
-        self.inodes.pop();
+    // Return the last inode only if the path was fully resolved.
+    pub fn task_last(mut self) -> Option<InodePtr> {
+        if self.inodes.len() == self.components.len() {
+            self.inodes.pop()
+        } else {
+            None
+        }
     }
 }
 

--- a/curvine-server/tests/journal_test.rs
+++ b/curvine-server/tests/journal_test.rs
@@ -255,7 +255,8 @@ fn run(fs_leader: &MasterFilesystem, worker: &WorkerInfo) -> CommonResult<()> {
     let status = fs_leader.create("/journal/b/test.log", true)?;
 
     // Assign block
-    let block = fs_leader.add_block(&status.path, address.clone(), vec![], vec![], 0, None)?;
+    let block =
+        fs_leader.add_block(&status.path, None, address.clone(), vec![], vec![], 0, None)?;
 
     // Complete the file.
     let commit = CommitBlock {
@@ -263,7 +264,14 @@ fn run(fs_leader: &MasterFilesystem, worker: &WorkerInfo) -> CommonResult<()> {
         block_len: 10,
         locations: vec![BlockLocation::with_id(worker.worker_id())],
     };
-    fs_leader.complete_file(&status.path, 10, vec![commit], &address.client_name, false)?;
+    fs_leader.complete_file(
+        &status.path,
+        None,
+        10,
+        vec![commit],
+        &address.client_name,
+        false,
+    )?;
 
     // File renaming
     fs_leader.rename(
@@ -278,13 +286,13 @@ fn run(fs_leader: &MasterFilesystem, worker: &WorkerInfo) -> CommonResult<()> {
     let path = "/journal/append.log";
     fs_leader.create(path, true)?;
 
-    let block = fs_leader.add_block(path, address.clone(), vec![], vec![], 0, None)?;
+    let block = fs_leader.add_block(path, None, address.clone(), vec![], vec![], 0, None)?;
     let commit = CommitBlock {
         block_id: block.block.id,
         block_len: 10,
         locations: vec![BlockLocation::with_id(worker.worker_id())],
     };
-    fs_leader.complete_file(path, 10, vec![commit], "", false)?;
+    fs_leader.complete_file(path, None, 10, vec![commit], "", false)?;
 
     let commit = CommitBlock {
         block_id: block.block.id,
@@ -296,7 +304,7 @@ fn run(fs_leader: &MasterFilesystem, worker: &WorkerInfo) -> CommonResult<()> {
         CreateFileOpts::with_create(true),
         OpenFlags::new_create(),
     )?;
-    fs_leader.complete_file(path, 13, vec![commit], "", false)?;
+    fs_leader.complete_file(path, None, 13, vec![commit], "", false)?;
 
     Ok(())
 }

--- a/curvine-server/tests/lock_order_deadlock_stress_test.rs
+++ b/curvine-server/tests/lock_order_deadlock_stress_test.rs
@@ -67,6 +67,7 @@ fn stress_add_block_vs_block_report_no_hang() {
         for i in 0..loops {
             let res = fs_a.add_block(
                 "/deadlock/file.log",
+                None,
                 client.clone(),
                 vec![],
                 vec![],
@@ -167,6 +168,7 @@ fn sanity_single_thread_paths_progress() {
     for i in 0..500 {
         let _ = fs.add_block(
             "/deadlock/file.log",
+            None,
             client.clone(),
             vec![],
             vec![],

--- a/curvine-server/tests/master_fs_test.rs
+++ b/curvine-server/tests/master_fs_test.rs
@@ -764,10 +764,10 @@ fn add_block_retry(fs: &MasterFilesystem) -> CommonResult<()> {
     let status = fs.create(path, false).unwrap();
 
     let b1 = fs
-        .add_block(path, addr.clone(), vec![], vec![], 0, None)
+        .add_block(path, None, addr.clone(), vec![], vec![], 0, None)
         .unwrap();
     let b2 = fs
-        .add_block(path, addr.clone(), vec![], vec![], 0, None)
+        .add_block(path, None, addr.clone(), vec![], vec![], 0, None)
         .unwrap();
 
     assert_eq!(b1.block.id, b2.block.id);
@@ -792,6 +792,7 @@ fn add_block_retry(fs: &MasterFilesystem) -> CommonResult<()> {
     let b1 = fs
         .add_block(
             path,
+            None,
             addr.clone(),
             vec![commit.clone()],
             vec![],
@@ -802,6 +803,7 @@ fn add_block_retry(fs: &MasterFilesystem) -> CommonResult<()> {
     let b2 = fs
         .add_block(
             path,
+            None,
             addr.clone(),
             vec![commit],
             vec![],
@@ -823,7 +825,7 @@ fn complete_file_retry(fs: &MasterFilesystem) -> CommonResult<()> {
     let addr = ClientAddress::default();
     fs.create(path, false)?;
 
-    let b1 = fs.add_block(path, addr.clone(), vec![], vec![], 0, None)?;
+    let b1 = fs.add_block(path, None, addr.clone(), vec![], vec![], 0, None)?;
 
     let commit = CommitBlock {
         block_id: b1.block.id,
@@ -836,6 +838,7 @@ fn complete_file_retry(fs: &MasterFilesystem) -> CommonResult<()> {
 
     let f1 = fs.complete_file(
         path,
+        None,
         b1.block.len,
         vec![commit.clone()],
         &addr.client_name,
@@ -845,6 +848,7 @@ fn complete_file_retry(fs: &MasterFilesystem) -> CommonResult<()> {
 
     let f2 = fs.complete_file(
         path,
+        None,
         b1.block.len,
         vec![commit.clone()],
         &addr.client_name,

--- a/curvine-server/tests/resize_lock_scope_test.rs
+++ b/curvine-server/tests/resize_lock_scope_test.rs
@@ -43,7 +43,7 @@ fn resize_does_not_hold_fs_lock_while_waiting_worker_manager() {
         ip_addr: "127.0.0.1".into(),
         port: 0,
     };
-    fs.add_block("/resize/file.log", client, vec![], vec![], 0, None)
+    fs.add_block("/resize/file.log", None, client, vec![], vec![], 0, None)
         .unwrap();
 
     let fs = Arc::new(fs);

--- a/curvine-tests/tests/fs_test.rs
+++ b/curvine-tests/tests/fs_test.rs
@@ -100,6 +100,9 @@ fn run_filesystem_end_to_end_operations_on_cluster(
         rename2(&fs).await?;
         println!("rename2 done");
 
+        open_file_rename_read_write(&fs).await?;
+        println!("open_file_rename_read_write done");
+
         set_attr_non_recursive(&fs).await?;
         println!("set_attr_non_recursive done");
 
@@ -410,14 +413,54 @@ async fn rename2(fs: &CurvineFileSystem) -> CommonResult<()> {
     let _ = fs.rename(&src, &dst).await?;
 
     assert!(!(fs.exists(&src).await?));
+    assert!(fs.exists(&dst).await?);
     assert!(
-        fs.exists(&Path::from_str("/fs_test/rename2/rename2.log")?)
+        !fs.exists(&Path::from_str("/fs_test/rename2/rename2.log")?)
             .await?
     );
 
     let res = fs.list_status(&dst).await?;
     println!("{:?}", res);
-    assert_eq!(res.len(), 1);
+    assert_eq!(res.len(), 0);
+
+    Ok(())
+}
+
+async fn open_file_rename_read_write(fs: &CurvineFileSystem) -> CommonResult<()> {
+    let src = Path::from_str("/fs_test/open_rename/write.log")?;
+    let dst = Path::from_str("/fs_test/open_rename/write_renamed.log")?;
+
+    let mut writer = fs.create(&src, true).await?;
+    writer.write("before-".as_bytes()).await?;
+    fs.rename(&src, &dst).await?;
+
+    assert!(!fs.exists(&src).await?);
+    assert!(fs.exists(&dst).await?);
+
+    writer.write("after".as_bytes()).await?;
+    writer.complete().await?;
+
+    let status = fs.get_status(&dst).await?;
+    assert_eq!(status.len, "before-after".len() as i64);
+    assert_eq!(fs.read_string(&dst).await?, "before-after");
+    assert!(fs.open(&src).await.is_err());
+
+    let read_src = Path::from_str("/fs_test/open_rename/read.log")?;
+    let read_dst = Path::from_str("/fs_test/open_rename/read_renamed.log")?;
+    fs.write_string(&read_src, "read-before-rename").await?;
+
+    let mut reader = fs.open(&read_src).await?;
+    fs.rename(&read_src, &read_dst).await?;
+
+    assert!(!fs.exists(&read_src).await?);
+    assert!(fs.exists(&read_dst).await?);
+
+    let mut buffer = BytesMut::zeroed("read-before-rename".len());
+    let bytes_read = reader.read_full(&mut buffer).await?;
+    reader.complete().await?;
+    buffer.truncate(bytes_read);
+    assert_eq!(String::from_utf8(buffer.to_vec())?, "read-before-rename");
+    assert_eq!(fs.read_string(&read_dst).await?, "read-before-rename");
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Previously, `add_block` and `complete_file` on the master side resolved the
target file exclusively by **path**. When a file was renamed while a writer
or reader still held it open, subsequent block allocations or file
completion calls would fail because the original path no longer existed.

This change introduces an **inode ID** field on both `AddBlockRequest` and
`CompleteFileRequest`. The client now passes the inode ID (obtained at file
creation time) along with every `add_block` and `complete_file` RPC. The
master resolves the inode by ID when available, falling back to path-based
resolution only when no ID is supplied. This makes file operations resilient
to renames that happen mid-write or mid-read.

## Changes

### 1. Protocol changes (`master.proto`)

Added `optional int64 inode_id` to both request messages:

```proto
message AddBlockRequest {
    ...
    optional int64 inode_id = 8;
}

message CompleteFileRequest {
    ...
    optional int64 inode_id = 6;
}
```

### 2. Client API (`fs_client.rs`)

- Refactored `add_block` into a private `add_block0` that accepts
  `Option<i64>` for the inode ID.
- Added public `add_block_by_id` which passes `Some(id)`.
- Applied the same pattern to `complete_file` / `complete_file_by_id` /
  `complete_file0`.

### 3. Writer (`fs_writer_base.rs`)

`FsWriterBase` now calls `add_block_by_id` and `complete_file_by_id`,
passing `self.file_blocks.status.id` as the inode ID. This ensures that
block allocation and file completion are bound to the inode, not the path.

### 4. Master filesystem (`master_filesystem.rs`)

- **`resolve_file_inode`** — new helper that resolves an inode by ID
  (`fs_dir.store.get_inode`) when `inode_id > 0`, otherwise falls back to
  path-based resolution via `resolve_path` + `task_last`.
- `add_block` and `complete_file` now accept `inode_id: Option<i64>` and
  delegate inode resolution to `resolve_file_inode`.
- Extracted `choose_worker_for_file` from `choose_worker` so worker selection
  can operate directly on an `InodeFile` without an `InodePath`.

### 5. Journal replay (`journal_loader.rs`)

Updated `add_block` and `complete_file` journal replay to use
`resolve_file_inode`. For `add_block` the inode ID is derived from the
first block's ID (`InodeId::get_id`); for `complete_file` the entry's
`file.id` is used directly.

### 6. FsDir (`fs_dir.rs`)

`acquire_new_block` and `complete_file` now accept `path: impl AsRef<str>`
and an `InodePtr` directly, removing the dependency on `InodePath` inside
these methods.

### 7. InodePath (`inode_path.rs`)

Replaced `delete_last` with `task_last`, which consumes `self` and returns
the last `InodePtr` **only if the path was fully resolved** (i.e.
`inodes.len() == components.len()`). This prevents accidentally returning a
parent inode when the target does not exist.

### 8. Master handler (`master_handler.rs`)

All `add_block` and `complete_file` call sites (single and batch) now
forward `req.inode_id` to the filesystem layer.

### 9. Tests (`fs_test.rs`)

- **`open_file_rename_read_write`** — new end-to-end test:
  - Create a file, write data, rename it, then write more data and complete.
    Verify the renamed file contains all data and the old path is gone.
  - Write a file, open a reader, rename the file, then read from the open
    reader. Verify the data is intact and the new path is readable.
- **`rename2`** — fixed assertions that were previously incorrect (the
  source file should not exist after rename, and the child file under the
  old path should also not exist).

## Files Changed

| File | Change |
|------|--------|
| `curvine-common/proto/master.proto` | Add `inode_id` field to `AddBlockRequest` and `CompleteFileRequest` |
| `curvine-client/src/file/fs_client.rs` | Add `add_block_by_id` / `complete_file_by_id`; refactor internals |
| `curvine-client/src/file/fs_writer_base.rs` | Use `*_by_id` variants with the file's inode ID |
| `curvine-server/src/master/fs/master_filesystem.rs` | Add `resolve_file_inode`; thread `inode_id` through `add_block` / `complete_file` |
| `curvine-server/src/master/journal/journal_loader.rs` | Use `resolve_file_inode` in journal replay |
| `curvine-server/src/master/master_handler.rs` | Forward `req.inode_id` at all call sites |
| `curvine-server/src/master/meta/fs_dir.rs` | Accept `path` + `InodePtr` directly instead of `InodePath` |
| `curvine-server/src/master/meta/inode/inode_path.rs` | Replace `delete_last` with safer `task_last` |
| `curvine-tests/tests/fs_test.rs` | Add rename-during-IO test; fix `rename2` assertions |

## Test Plan

- [ ] Run the new `open_file_rename_read_write` test: verify data integrity after rename-during-write and rename-during-read
- [ ] Run the updated `rename2` test: verify source path is gone and destination is correct
- [ ] Verify existing add_block / complete_file calls without `inode_id` still work (backward-compatible path fallback)
- [ ] Verify journal replay correctly resolves inodes by ID after a rename
