### PR TITLE
chore(agents): add cross-platform cv-* agent skills

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -1,0 +1,55 @@
+# Curvine Agent Configuration
+
+Cross-platform AI agent config hub. **`.agents/` is the single canonical source**; agent tools read it via symlinks.
+
+## Layout
+
+```text
+.agents/
+  README.md
+  skills/             # project skills (shared)
+  rules/              # cross-agent workflow rules
+```
+
+Only **`cv-*` skills** are tracked in git. Other skills (e.g. local `mermaid`) may exist under `.agents/skills/` but are gitignored.
+
+## Agent skill paths
+
+| Agent | Project path | Invocation |
+| ----- | ------------ | ---------- |
+| Claude Code | `.claude/skills/` → `.agents/skills/` | `/cv-create-pr` |
+| Cursor | `.cursor/skills/` → `.agents/skills/` | auto-discover |
+| Codex | `.agents/skills/` (native) | `/skills` |
+| GitHub Copilot | `.github/skills/` → `.agents/skills/` | `/cv-create-pr` |
+
+Edit versioned skills only under `.agents/skills/cv-*/`.
+
+## Symlinks
+
+```bash
+ln -sfn ../.agents/skills .github/skills
+rm -rf .cursor/skills && ln -sfn ../.agents/skills .cursor/skills
+rm -rf .claude/skills && ln -sfn ../.agents/skills .claude/skills
+```
+
+## Versioned skills (`cv-` prefix)
+
+| Skill | Stage |
+| ----- | ----- |
+| `cv-add-skills` | Meta — add/update cv skills |
+| `cv-tasks-breakdown` | Plan → small tasks + sub-issues |
+| `cv-create-issue` | File GitHub issue |
+| `cv-handle-issue` | Fix issue (plan first, then code) |
+| `cv-create-pr` | Create / update PR |
+| `cv-review-pr` | Handle review comments |
+| `cv-run-workflow` | Dispatch GitHub Actions |
+| `cv-csi-test` | CSI driver integration testing |
+
+## Rules
+
+- Cursor auto-rules: `.cursor/rules/` (`.mdc`)
+- Shared rules: `.agents/rules/`
+
+## AGENTS.md
+
+Root `AGENTS.md` lists all versioned `cv-*` skills in `<available_skills>`. Use `cv-add-skills` when adding or updating skills.

--- a/.agents/rules/README.md
+++ b/.agents/rules/README.md
@@ -1,0 +1,19 @@
+# Curvine Agent Rules
+
+Cross-agent workflow rules. Cursor-specific rules live in `.cursor/rules/` (`.mdc`).
+
+## Workflow skills
+
+| Step | Skill |
+| ---- | ----- |
+| Add / update cv skill | `cv-add-skills` |
+| Decompose plan | `cv-tasks-breakdown` |
+| Create issue | `cv-create-issue` |
+| Fix issue | `cv-handle-issue` |
+| Create / update PR | `cv-create-pr` |
+| Review comments | `cv-review-pr` |
+| Run CI workflow | `cv-run-workflow` |
+
+## Issue → PR flow
+
+See [workflow.md](workflow.md).

--- a/.agents/rules/workflow.md
+++ b/.agents/rules/workflow.md
@@ -1,0 +1,42 @@
+# Curvine workflow rules
+
+Referenced by `cv-*` skills.
+
+## Issue
+
+- Follow `.github/ISSUE_TEMPLATE/` format
+- Feature issues require **Goal**, **Not Goal**, **Test Plan** sections
+- Sub-tasks: title `[SUB]`, body links `Parent: #<n>`
+
+## Implementation
+
+- `cv-handle-issue`: no coding until user approves the plan
+- Large change (> ~500 lines): use `cv-tasks-breakdown` + sub-issues
+- `make format` before every commit
+- Each task must have test coverage
+
+## PR title
+
+```
+<type>(<module>): <description> (#<issueNumber>)
+```
+
+Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `ci`, `build`, `revert`
+
+## PR body sections
+
+1. **Summary**
+2. **Issue Describe / Design** (root cause / repro / fix for bugs)
+3. **Changes** (table: module, change, impact)
+4. **Test verified** (table: case, result, notes)
+5. **Dependencies** (related PRs / issues)
+
+## Review
+
+- Analyze every comment ID before coding
+- Present accept/reject table; wait for user approval
+- Reply in English; resolve fixed threads on GitHub
+
+## CI
+
+- Workflow changes: validate via `cv-run-workflow` on a feature branch

--- a/.agents/skills/cv-add-skills/SKILL.md
+++ b/.agents/skills/cv-add-skills/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: cv-add-skills
+description: Add or update Curvine cv-* project skills under .agents/skills/, following naming and layout conventions, and sync the AGENTS.md registry. Use when creating a new cv skill, updating an existing cv skill structure, or registering skills after changes.
+---
+
+# cv-add-skills
+
+Canonical guide for adding or updating versioned `cv-*` skills in the Curvine repository.
+
+## When to Use
+
+- User asks to add / create a new Curvine project skill
+- User asks to update structure or conventions of an existing `cv-*` skill
+- A new `cv-*` skill was added but `AGENTS.md` registry is out of date
+- Onboarding: understand how Curvine skills are organized
+
+Read [references/structure.md](references/structure.md) and [references/registry.md](references/registry.md) before editing.
+
+## Organization Overview
+
+```text
+.agents/                          # canonical agent config (git tracked)
+  README.md
+  skills/
+    cv-<name>/                      # only cv-* skills are versioned
+      SKILL.md                      # required entrypoint
+      references/                   # optional deep docs
+      scripts/                      # optional executables
+      assets/                       # optional templates
+  rules/
+    workflow.md                     # shared workflow rules
+
+AGENTS.md                           # skill registry (<available_skills>)
+.gitignore                          # .agents/skills/* + !.agents/skills/cv-*/
+
+# symlinks (not copies)
+.github/skills  -> ../.agents/skills
+.cursor/skills  -> ../.agents/skills
+.claude/skills  -> ../.agents/skills
+```
+
+**Rules:**
+
+| Rule | Detail |
+| ---- | ------ |
+| Prefix | All versioned skills **must** start with `cv-` |
+| Location | Edit only `.agents/skills/cv-<name>/` |
+| Language | `description` and body in **English** |
+| Git | Only `cv-*` dirs are tracked; other local skills are gitignored |
+| Registry | Every `cv-*` skill **must** appear in `AGENTS.md` |
+
+## Add a New cv Skill
+
+### Step 1: Validate name
+
+- Format: `cv-<kebab-case>` (e.g. `cv-create-pr`, `cv-csi-test`)
+- Must not collide with existing dirs under `.agents/skills/`
+- Prefer verb-noun matching workflow stage (create / handle / review / run / add)
+
+### Step 2: Create directory
+
+```bash
+SKILL="cv-<name>"
+mkdir -p ".agents/skills/${SKILL}/references"
+```
+
+Copy template if helpful:
+
+```bash
+cp assets/skill-template/SKILL.md ".agents/skills/${SKILL}/SKILL.md"
+```
+
+### Step 3: Write SKILL.md
+
+Required frontmatter:
+
+```yaml
+---
+name: cv-<name>          # must match directory name
+description: <capability in one sentence>. Use when <specific triggers>.
+---
+```
+
+Body guidelines:
+
+- `## When to Use` — bullet triggers
+- Step-by-step workflow with runnable commands
+- Link related cv skills: `[cv-create-pr](../cv-create-pr/SKILL.md)`
+- Keep SKILL.md lean; move long docs to `references/`
+- Align with `.agents/rules/workflow.md` where applicable
+
+### Step 4: Register in AGENTS.md
+
+Inside `<!-- SKILLS_TABLE_START -->` … `<!-- SKILLS_TABLE_END -->`, add:
+
+```xml
+<skill>
+<name>cv-<name></name>
+<description><same as SKILL.md frontmatter description></description>
+<location>project</location>
+</skill>
+```
+
+Keep entries sorted alphabetically by `<name>`.
+
+### Step 5: Update .agents/README.md
+
+Add one row to the versioned skills table.
+
+### Step 6: Verify symlinks
+
+```bash
+ln -sfn ../.agents/skills .github/skills
+ln -sfn ../.agents/skills .cursor/skills
+ln -sfn ../.agents/skills .claude/skills
+ls -la .github/skills .cursor/skills .claude/skills
+```
+
+### Step 7: Self-check
+
+- [ ] Directory is `.agents/skills/cv-<name>/`
+- [ ] `name` in frontmatter matches directory
+- [ ] `description` is English, ≤ 1024 chars, includes "Use when"
+- [ ] `AGENTS.md` entry added/updated
+- [ ] `.agents/README.md` table updated
+- [ ] No files written under symlink paths directly
+- [ ] Skill not gitignored (`git check-ignore -v .agents/skills/cv-<name>/SKILL.md` → no match)
+
+## Update an Existing cv Skill
+
+1. Edit files under `.agents/skills/cv-<name>/` only
+2. If `description` changes → sync `AGENTS.md` `<description>` block
+3. If skill renamed → rename directory, update all cross-links, update registry, remove old registry entry
+4. Do not change `cv-` prefix or move skill outside `.agents/skills/`
+
+## Do Not
+
+- Add non-`cv-` skills to git (they belong in user global skills or local gitignored dirs)
+- Edit skills inside `.cursor/skills/` or `.claude/skills/` directly (symlinks)
+- Skip `AGENTS.md` registration
+- Use Chinese in `description` (body may reference Chinese project docs paths when needed)
+- Create standalone setup scripts in the repo for skill management
+
+## Current cv Skills (maintain this list when adding)
+
+| Skill | Stage |
+| ----- | ----- |
+| `cv-add-skills` | Meta — add/update skills |
+| `cv-create-issue` | Issue |
+| `cv-create-pr` | PR |
+| `cv-csi-test` | Testing |
+| `cv-handle-issue` | Issue |
+| `cv-review-pr` | PR |
+| `cv-run-workflow` | CI |
+| `cv-tasks-breakdown` | Planning |
+
+## Related
+
+- Workflow rules → `.agents/rules/workflow.md`
+- Registry format detail → [references/registry.md](references/registry.md)
+- Directory layout detail → [references/structure.md](references/structure.md)

--- a/.agents/skills/cv-add-skills/assets/skill-template/SKILL.md
+++ b/.agents/skills/cv-add-skills/assets/skill-template/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: cv-<name>
+description: <One sentence: what this skill does>. Use when <comma-separated triggers>.
+---
+
+# cv-<name>
+
+<One paragraph overview.>
+
+## When to Use
+
+- Trigger 1
+- Trigger 2
+
+## Step 1: <title>
+
+<Instructions>
+
+```bash
+# example command
+```
+
+## Related
+
+- [cv-add-skills](../cv-add-skills/SKILL.md) — skill conventions
+- [cv-create-pr](../cv-create-pr/SKILL.md) — if this skill hands off to PR
+
+## Checklist
+
+- [ ] Item 1

--- a/.agents/skills/cv-add-skills/references/registry.md
+++ b/.agents/skills/cv-add-skills/references/registry.md
@@ -1,0 +1,75 @@
+# AGENTS.md Registry
+
+## Location
+
+Repository root: `AGENTS.md`
+
+Markers (do not remove):
+
+```xml
+<!-- SKILLS_TABLE_START -->
+...
+<!-- SKILLS_TABLE_END -->
+```
+
+## Entry template
+
+```xml
+<skill>
+<name>cv-<name></name>
+<description><English description matching SKILL.md frontmatter></description>
+<location>project</location>
+</skill>
+```
+
+## Usage block (do not narrow to block global skills)
+
+The `<usage>` section clarifies:
+
+- **Project workflow** → prefer `cv-*` in `<available_skills>`
+- **User global skills** → still available via agent tool (e.g. `~/.cursor/skills/`)
+- **Do not** invent unlisted project skills
+
+## Maintenance checklist
+
+When adding `cv-new-skill`:
+
+1. Create `.agents/skills/cv-new-skill/SKILL.md`
+2. Append `<skill>` block inside `<available_skills>`
+3. Sort entries alphabetically by name
+4. Verify `description` matches frontmatter exactly
+5. Update `.agents/README.md` skills table
+6. Update skill list in `cv-add-skills/SKILL.md` if maintained there
+
+When updating description only:
+
+1. Edit frontmatter in `SKILL.md`
+2. Edit matching `<description>` in `AGENTS.md`
+3. No directory rename needed
+
+When renaming `cv-old` → `cv-new`:
+
+1. `git mv .agents/skills/cv-old .agents/skills/cv-new`
+2. Update `name:` in frontmatter
+3. Replace registry entry (remove old, add new)
+4. `rg 'cv-old' .agents/skills/` — fix cross-links
+
+## Validation
+
+```bash
+# should NOT be ignored
+git check-ignore -v .agents/skills/cv-add-skills/SKILL.md
+
+# should be ignored (local-only skill example)
+git check-ignore -v .agents/skills/mermaid/SKILL.md
+```
+
+## Invocation hint for agents
+
+Agents read skills via:
+
+```text
+.agents/skills/<skill-name>/SKILL.md
+```
+
+Not via `openskills` unless user environment configures it.

--- a/.agents/skills/cv-add-skills/references/structure.md
+++ b/.agents/skills/cv-add-skills/references/structure.md
@@ -1,0 +1,75 @@
+# Curvine cv-* Skill Structure
+
+## Canonical layout
+
+```text
+.agents/skills/cv-<name>/
+  SKILL.md              # required — entrypoint + YAML frontmatter
+  references/           # optional — loaded on demand
+    *.md
+  scripts/              # optional — bash/python helpers
+    *
+  assets/               # optional — templates, not loaded into context
+    *
+```
+
+## Cross-platform visibility
+
+| Agent | Reads from |
+| ----- | ---------- |
+| Codex | `.agents/skills/` directly |
+| Cursor | `.cursor/skills/` → symlink |
+| Claude Code | `.claude/skills/` → symlink |
+| GitHub Copilot | `.github/skills/` → symlink |
+
+Single source of truth: **`.agents/skills/cv-*/`**
+
+## Git tracking
+
+`.gitignore`:
+
+```gitignore
+.agents/skills/*
+!.agents/skills/cv-*/
+```
+
+- `cv-*` → committed
+- anything else under `.agents/skills/` → local only (e.g. `mermaid/`)
+
+## Naming
+
+| Item | Convention | Example |
+| ---- | ---------- | ------- |
+| Directory | `cv-` + kebab-case | `cv-create-pr` |
+| Frontmatter `name` | same as directory | `cv-create-pr` |
+| Reference files | kebab-case.md | `workflow-catalog.md` |
+| Scripts | snake_case or kebab | `test-suite.sh` |
+
+## SKILL.md sections (recommended)
+
+1. Title (`# cv-<name>`)
+2. `## When to Use`
+3. Workflow steps (`## Step N:` or `### Step N:`)
+4. `## Related` — links to other cv skills
+5. Optional `## Checklist` / `## Rules` / `## Do Not`
+
+## Cross-linking
+
+Use relative paths between cv skills:
+
+```markdown
+See [cv-create-pr](../cv-create-pr/SKILL.md)
+```
+
+## Workflow skill chain
+
+```text
+cv-tasks-breakdown → cv-create-issue (sub-issues)
+cv-create-issue → cv-handle-issue
+cv-handle-issue → cv-tasks-breakdown (large scope)
+cv-handle-issue → cv-create-pr
+cv-create-pr → cv-review-pr
+cv-run-workflow → cv-create-pr (for workflow YAML changes)
+```
+
+New skills should declare where they fit in this chain.

--- a/.agents/skills/cv-create-issue/SKILL.md
+++ b/.agents/skills/cv-create-issue/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: cv-create-issue
+description: Create a GitHub issue for Curvine using repository templates, with extended Goal/Not Goal/Test Plan sections for features. Use when user asks to create an issue, report a serious bug found during testing, or when agent should suggest filing an issue for the current problem.
+---
+
+# cv-create-issue
+
+Create structured GitHub issues that follow `.github/ISSUE_TEMPLATE/` and Curvine conventions.
+
+## When to Use
+
+- User explicitly asks to create / file / open an issue
+- A **serious bug** is found during testing (data loss, crash, security, CI breakage)
+- Agent detects an unresolved problem worth tracking — **ask user** whether to file an issue
+
+## Step 1: Classify
+
+| Type | Template | Label | Title prefix |
+| ---- | -------- | ----- | ------------ |
+| Bug | `bug_report.md` | `bug` | `[BUG]:` |
+| Feature | `feature_request.md` | `enhancement` | `[FEATURE]` |
+
+Search for duplicates first:
+
+```bash
+gh issue list --search "<keywords>" --state open --limit 10
+```
+
+## Step 2: Draft Body
+
+### Bug (follow template)
+
+Required sections from `.github/ISSUE_TEMPLATE/bug_report.md`:
+
+- **Describe the bug**
+- **To Reproduce** (numbered steps)
+- **Expected behavior**
+- **OS Version** (OS, Curvine version/branch, relevant config)
+- **Additional context** (logs, screenshots)
+
+### Feature (template + extensions)
+
+Base sections from `.github/ISSUE_TEMPLATE/feature_request.md`:
+
+- **Is your feature request related to a problem?**
+- **Describe the solution you'd like**
+- **Describe alternatives you've considered**
+- **Additional context**
+
+**Required extra sections for Feature issues:**
+
+```markdown
+# Goal
+
+Design scope: list sub-requirements and the problem each solves.
+
+| Sub-requirement | Problem solved |
+| --------------- | -------------- |
+| ... | ... |
+
+# Not Goal
+
+Modules, features, or boundaries this issue must **not** touch.
+
+- ...
+
+# Test Plan
+
+| Test case | Test objective | Modules involved |
+| --------- | -------------- | ---------------- |
+| ... | ... | ... |
+```
+
+## Step 3: Confirm with User
+
+Show title + full body preview. Wait for approval before `gh issue create`.
+
+## Step 4: Create
+
+```bash
+# Bug
+gh issue create \
+  --title "[BUG]: <summary>" \
+  --label bug \
+  --body "$(cat <<'EOF'
+...
+EOF
+)"
+
+# Feature
+gh issue create \
+  --title "[FEATURE] <summary>" \
+  --label enhancement \
+  --body "$(cat <<'EOF'
+...
+EOF
+)"
+```
+
+## Step 5: Output
+
+Return issue number, URL, and suggested next step:
+
+- Bug fix → [cv-handle-issue](../cv-handle-issue/SKILL.md)
+- Large feature → [cv-tasks-breakdown](../cv-tasks-breakdown/SKILL.md)
+
+## Rules
+
+- Body in English unless user requests otherwise
+- One issue per topic
+- For sub-tasks of a parent issue, prefix title with `[SUB]` and link `Parent: #<n>` in body

--- a/.agents/skills/cv-create-pr/SKILL.md
+++ b/.agents/skills/cv-create-pr/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: cv-create-pr
+description: Create or update a Curvine pull request with standardized title and body sections (Summary, Issue/Design, Changes table, Test verified, Dependencies). Use when user asks to create, submit, update, or push a PR.
+---
+
+# cv-create-pr
+
+Create or update a PR with Curvine title and body conventions.
+
+## When to Use
+
+- User asks to create / submit / open a PR
+- User asks to update PR title or body
+- After `cv-handle-issue` or task commits are ready to publish
+
+## Pre-flight
+
+```bash
+make format
+git status
+git diff
+```
+
+Only stage files changed in the current task/session. Confirm with user before commit.
+
+## PR Title Format
+
+```
+<type>(<module>): <description> (#<issueNumber>)
+```
+
+**Example:** `feat(fuse): add new compression algorithm (#123)`
+
+**Supported types:** `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `ci`, `build`, `revert`
+
+Show title preview and get user approval.
+
+## Commit Before PR
+
+```bash
+git add <confirmed-files>
+git commit -m "$(cat <<'EOF'
+<type>(<module>): <subject>
+
+<optional body>
+EOF
+)"
+git push -u origin HEAD
+```
+
+## PR Body Template
+
+All PR bodies in **English**. Use this structure:
+
+```markdown
+# Summary
+
+<1-3 sentences: what this PR does and why>
+
+# Issue Describe / Design
+
+Closes #<issueNumber> (or "Related to #<n>")
+
+For **bug fixes**, include:
+- Root cause
+- Reproduction steps
+- Fix approach
+
+For **features**, include:
+- Design decisions and trade-offs
+- Link to parent issue / sub-issues if applicable
+
+# Changes
+
+| Module / File | Change | Impact on existing behavior |
+| ------------- | ------ | --------------------------- |
+| `path/to/file` | ... | None / behavior change: ... |
+
+# Test verified
+
+| Test case | Result | Notes |
+| --------- | ------ | ----- |
+| `cargo test -p ...` | PASS | |
+| ... | | |
+
+# Dependencies
+
+- Related PRs: #<n> or None
+- Related issues: #<n> or None
+- Blocks / blocked by: or None
+```
+
+Do **not** include tool watermarks (e.g. "Made with Cursor").
+
+## Create PR
+
+Preview full title + body; wait for user approval.
+
+```bash
+gh pr create \
+  --title "<type>(<module>): <description> (#<issueNumber>)" \
+  --body "$(cat <<'EOF'
+# Summary
+...
+EOF
+)"
+```
+
+Default: **draft** unless user says `ready`:
+
+```bash
+gh pr create --draft --title "..." --body "..."
+```
+
+## Update Existing PR
+
+```bash
+gh pr edit <number> \
+  --title "<type>(<module>): <description> (#<issueNumber>)" \
+  --body "$(cat <<'EOF'
+...
+EOF
+)"
+```
+
+Or update current branch PR:
+
+```bash
+gh pr view --json number
+gh pr edit <number> --title "..." --body "..."
+```
+
+## Checklist
+
+- [ ] `make format` passed
+- [ ] Tests run and recorded in **Test verified**
+- [ ] Title matches format with issue number
+- [ ] Changes table covers key modules
+- [ ] User approved commit and PR content
+
+## Related
+
+- Review feedback → [cv-review-pr](../cv-review-pr/SKILL.md)
+- Fix issue workflow → [cv-handle-issue](../cv-handle-issue/SKILL.md)

--- a/.agents/skills/cv-csi-test/SKILL.md
+++ b/.agents/skills/cv-csi-test/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: cv-csi-test
+description: End-to-end Curvine CSI driver testing guide for Kubernetes deployment, StorageClass and MountPod setup, resilience scenarios, volume expansion, and scripted test suites. Use when validating CSI code changes, running integration tests, debugging mount failures, or verifying MountPod recovery after node or CSI restarts.
+---
+
+# cv-csi-test
+
+This skill provides comprehensive guidance for testing Curvine CSI driver, including component deployment, test pod configuration, and complete testing workflows.
+
+## Quick Start
+
+### 1. Deploy Components
+
+Deploy in order:
+```bash
+kubectl apply -f curvine-csi/deploy/namespace.yaml
+kubectl apply -f curvine-csi/deploy/serviceaccount.yaml
+kubectl apply -f curvine-csi/deploy/clusterrole.yaml
+kubectl apply -f curvine-csi/deploy/clusterrolebinding.yaml
+kubectl apply -f curvine-csi/deploy/csidriver.yaml
+kubectl apply -f curvine-csi/deploy/daemonset-mountpod.yaml  # MountPod mode (recommended)
+kubectl apply -f curvine-csi/examples/storage-class.yaml
+```
+
+### 2. Verify Deployment
+
+```bash
+kubectl get pods -n curvine-system -l app=curvine-csi-node
+kubectl get csidriver curvine
+kubectl get storageclass curvine-sc
+```
+
+### 3. Run Basic Test
+
+```bash
+kubectl apply -f curvine-csi/examples/pvc-curvine.yaml
+kubectl apply -f curvine-csi/examples/pod-curvine.yaml
+kubectl exec curvine-test-pod -n curvine-system -- sh -c 'echo "Test" > /usr/share/nginx/html/test.txt'
+kubectl exec curvine-test-pod -n curvine-system -- cat /usr/share/nginx/html/test.txt
+```
+
+## Core Workflow
+
+### Phase 1: Build and Deploy
+
+1. **Build CSI Binary**
+   ```bash
+   cd curvine-csi
+   CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/csi .
+   ```
+
+2. **Build Docker Image**
+   ```bash
+   mkdir -p /tmp/csi-build && cp bin/csi /tmp/csi-build/
+   cat > /tmp/csi-build/Dockerfile << 'EOF'
+   FROM ghcr.io/curvineio/curvine-csi:latest
+   COPY csi /opt/curvine/csi
+   RUN chmod +x /opt/curvine/csi
+   EOF
+   cd /tmp/csi-build && docker build -t curvine-csi:latest .
+   docker tag curvine-csi:latest 10.119.43.210:5000/curvine-csi:latest
+   docker push 10.119.43.210:5000/curvine-csi:latest
+   ```
+
+3. **Deploy Components** (see Quick Start)
+
+### Phase 2: Basic Functionality Tests
+
+#### Test 1: Create PVC and Pod
+```bash
+kubectl apply -f curvine-csi/examples/pvc-curvine.yaml
+kubectl wait --for=condition=Bound pvc/curvine-pvc -n curvine-system --timeout=60s
+kubectl apply -f curvine-csi/examples/pod-curvine.yaml
+kubectl wait --for=condition=Ready pod/curvine-test-pod -n curvine-system --timeout=60s
+```
+
+#### Test 2: Write and Read Data
+```bash
+kubectl exec curvine-test-pod -n curvine-system -- \
+  sh -c 'echo "Hello Curvine CSI" > /usr/share/nginx/html/test.txt'
+kubectl exec curvine-test-pod -n curvine-system -- \
+  cat /usr/share/nginx/html/test.txt
+```
+
+#### Test 3: Multi-Pod Shared Access
+```bash
+kubectl apply -f curvine-csi/examples/deployment-curvine.yaml
+kubectl wait --for=condition=Ready pod -l app=curvine-test -n curvine-system --timeout=60s
+# Write from pod 1, read from pod 2
+```
+
+### Phase 3: Resilience Tests
+
+#### Test 4: CSI Node Pod Restart (MountPod Mode)
+```bash
+# Write data before restart
+kubectl exec curvine-test-pod -n curvine-system -- \
+  sh -c 'echo "Before restart: $(date)" > /usr/share/nginx/html/restart-test.txt'
+
+# Restart CSI Node Pod
+kubectl delete pod -l app=curvine-csi-node -n curvine-system
+kubectl wait --for=condition=Ready pod -l app=curvine-csi-node -n curvine-system --timeout=60s
+
+# Verify MountPod still exists
+kubectl get pods -n curvine-system | grep curvine-mountpod
+
+# Read data after restart (should still be accessible)
+kubectl exec curvine-test-pod -n curvine-system -- \
+  cat /usr/share/nginx/html/restart-test.txt
+```
+
+#### Test 5: MountPod Recovery
+```bash
+kubectl get pods -n curvine-system | grep curvine-mountpod
+kubectl logs -n curvine-system -l app=curvine-mountpod --tail=50
+```
+
+#### Test 6: Pod Deletion and Cleanup
+```bash
+kubectl delete pod curvine-test-pod -n curvine-system
+kubectl wait --for=delete pod/curvine-test-pod -n curvine-system --timeout=30s
+kubectl delete pvc curvine-pvc -n curvine-system
+```
+
+## Test Pods
+
+### Simple Test Pod
+- File: `curvine-csi/examples/pod-curvine.yaml`
+- Single pod with nginx, mounts PVC
+
+### Multi-Pod Deployment
+- File: `curvine-csi/examples/deployment-curvine.yaml`
+- 3 replicas sharing same PVC
+
+### StatefulSet
+- File: `curvine-csi/examples/statefulset-curvine.yaml`
+- For stateful workloads
+
+## Components Reference
+
+See `references/components.md` for detailed component descriptions:
+- Namespace, ServiceAccounts, RBAC
+- CSIDriver, Controller, Node Plugin
+- StorageClass configuration
+
+## Troubleshooting
+
+### Common Issues
+
+**PVC Stuck in Pending**
+```bash
+kubectl describe pvc curvine-pvc -n curvine-system
+kubectl logs -n curvine-system -l app=curvine-csi-controller --tail=100
+```
+
+**Pod Cannot Mount Volume**
+```bash
+kubectl logs -n curvine-system -l app=curvine-csi-node --tail=100
+kubectl get pods -n curvine-system | grep curvine-mountpod
+kubectl logs -n curvine-system -l app=curvine-mountpod --tail=100
+```
+
+**MountPod Not Created**
+```bash
+kubectl logs -n curvine-system -l app=curvine-csi-node --tail=100 | grep -i mountpod
+kubectl auth can-i create pods --as=system:serviceaccount:curvine-system:curvine-csi-node-sa
+kubectl get configmap -n curvine-system | grep curvine-mountpod
+```
+
+**Pod Deletion Hangs**
+```bash
+kubectl get pv -o json | jq '.items[] | select(.spec.csi.driver=="curvine") | {name: .metadata.name, finalizers: .metadata.finalizers}'
+# Manual cleanup if needed:
+kubectl patch pv <pv-name> -p '{"metadata":{"finalizers":[]}}' --type=merge
+```
+
+## Test Scripts
+
+See `scripts/test-suite.sh` for automated test script template.
+
+## Verification Checklist
+
+- [ ] CSI Node Pods running on all nodes
+- [ ] MountPods created for each Curvine cluster
+- [ ] CSIDriver registered
+- [ ] StorageClass available
+- [ ] PVC creation succeeds
+- [ ] Pod can mount volume
+- [ ] Data write/read works
+- [ ] Multiple pods can share same volume
+- [ ] CSI restart doesn't affect mounted volumes (MountPod mode)
+
+## 注意事项
+如果遇到Pod Terminating，最多等待2min，就要停止等待，并仔细检查pod删除卡主的原因，如果无法修复，可以采用--force的方式确保安全删除。
+- 测试集群的master addr为10.119.43.210:8995, 且只有一个。 
+- 测试之前需要将gchr镜像替换为10.119.43.210:5000/curvine-csi,  测试完成后总是要恢复为原始镜像。

--- a/.agents/skills/cv-csi-test/references/components.md
+++ b/.agents/skills/cv-csi-test/references/components.md
@@ -1,0 +1,144 @@
+# CSI Components Reference
+
+## Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    Kubernetes Node                          │
+├─────────────────────────────────────────────────────────────┤
+│  ┌──────────────────┐    ┌──────────────────────────────┐  │
+│  │  CSI Node Pod    │    │      MountPod                │  │
+│  │  (可重启)         │    │  (独立运行，持久化FUSE)       │  │
+│  │                  │    │                              │  │
+│  │  - NodeService   │    │  - curvine-fuse 进程         │  │
+│  │  - MountPodMgr   │───▶│  - 挂载点: /mnt/curvine      │  │
+│  │                  │    │  - HostPath: Bidirectional   │  │
+│  └──────────────────┘    └──────────────────────────────┘  │
+│           │                         │                       │
+│           ▼                         ▼                       │
+│  ┌──────────────────────────────────────────────────────┐  │
+│  │              Host Mount Namespace                     │  │
+│  │     /var/lib/kubelet/plugins/kubernetes.io/csi/...   │  │
+│  └──────────────────────────────────────────────────────┘  │
+│                          │                                  │
+│                          ▼                                  │
+│  ┌──────────────────────────────────────────────────────┐  │
+│  │              Application Pod                          │  │
+│  │     Bind Mount from host → /usr/share/nginx/html     │  │
+│  └──────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Prerequisites
+
+### Namespace
+```yaml
+# File: curvine-csi/deploy/namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: curvine-system
+```
+
+### ServiceAccounts
+```yaml
+# File: curvine-csi/deploy/serviceaccount.yaml
+# Creates:
+# - curvine-csi-controller-sa
+# - curvine-csi-node-sa
+```
+
+### RBAC
+- Files: `curvine-csi/deploy/clusterrole.yaml`, `clusterrolebinding.yaml`
+- MountPod mode also includes RBAC in `daemonset-mountpod.yaml`
+
+## Core Components
+
+### CSIDriver
+```yaml
+# File: curvine-csi/deploy/csidriver.yaml
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: curvine
+spec:
+  attachRequired: false
+  podInfoOnMount: false
+```
+
+### CSI Controller (Optional)
+- File: `curvine-csi/deploy/deployment.yaml`
+- For dynamic provisioning
+- Includes csi-provisioner sidecar
+
+### CSI Node Plugin
+Two modes available:
+
+**MountPod Mode (Recommended)**
+- File: `curvine-csi/deploy/daemonset-mountpod.yaml`
+- FUSE runs in separate MountPod
+- Enables smooth CSI restart
+- Environment variables:
+  ```yaml
+  env:
+    - name: USE_MOUNT_POD
+      value: "true"
+    - name: MOUNT_POD_IMAGE
+      value: "10.119.43.210:5000/curvine-csi:latest"
+  ```
+
+**Traditional Mode**
+- File: `curvine-csi/deploy/daemonset.yaml`
+- FUSE runs in CSI container
+- Simpler but loses mounts on restart
+
+## Storage Configuration
+
+### StorageClass
+```yaml
+# File: curvine-csi/examples/storage-class.yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: curvine-sc
+provisioner: curvine
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+allowVolumeExpansion: true
+parameters:
+  master-addrs: "m0:8995,m1:8995,m2:8995"  # Required
+  fs-path: "/test-data"                      # Required
+  path-type: "DirectoryOrCreate"            # Optional
+```
+
+**Parameters:**
+- `master-addrs`: Curvine master addresses (required)
+- `fs-path`: Filesystem path prefix for dynamic PVs (required)
+- `path-type`: "DirectoryOrCreate" or "Directory" (optional, default: "Directory")
+
+**Path Generation:**
+```
+实际挂载路径 = fs-path + "/" + pv-name
+示例: "/test-data/pvc-1234-5678-abcd"
+```
+
+## MountPod Details
+
+### MountPod Lifecycle
+1. Created during NodeStageVolume
+2. One MountPod per Curvine cluster (master-addrs + fs-path)
+3. State persisted in ConfigMap
+4. Survives CSI Node Pod restart
+5. Deleted when refCount=0 in NodeUnstageVolume
+
+### MountPod Configuration
+- `hostNetwork: true`
+- `hostPID: true`
+- `MountPropagation: Bidirectional`
+- Mount point: `/mnt/curvine`
+- Host path: `/var/lib/kubelet/plugins/curvine/<cluster-id>`
+
+### MountPod Health Checks
+- ReadinessProbe: `mountpoint -q /mnt/curvine`
+- LivenessProbe: `mountpoint -q /mnt/curvine`
+

--- a/.agents/skills/cv-csi-test/scripts/test-suite.sh
+++ b/.agents/skills/cv-csi-test/scripts/test-suite.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+set -e
+
+NAMESPACE="curvine-system"
+TEST_POD="curvine-test-pod"
+TEST_PVC="curvine-pvc"
+
+echo "=== CSI Test Suite ==="
+
+# Cleanup function
+cleanup() {
+    echo "Cleaning up..."
+    kubectl delete pod $TEST_POD -n $NAMESPACE --ignore-not-found=true
+    kubectl delete pvc $TEST_PVC -n $NAMESPACE --ignore-not-found=true
+}
+
+trap cleanup EXIT
+
+# Test 1: Create PVC
+echo "Test 1: Creating PVC..."
+kubectl apply -f curvine-csi/examples/pvc-curvine.yaml
+kubectl wait --for=condition=Bound pvc/$TEST_PVC -n $NAMESPACE --timeout=60s
+echo "✓ PVC created and bound"
+
+# Test 2: Create Pod
+echo "Test 2: Creating test pod..."
+kubectl apply -f curvine-csi/examples/pod-curvine.yaml
+kubectl wait --for=condition=Ready pod/$TEST_POD -n $NAMESPACE --timeout=60s
+echo "✓ Pod created and ready"
+
+# Test 3: Write data
+echo "Test 3: Writing test data..."
+kubectl exec $TEST_POD -n $NAMESPACE -- \
+  sh -c 'echo "CSI Test: $(date)" > /usr/share/nginx/html/test.txt'
+echo "✓ Data written"
+
+# Test 4: Read data
+echo "Test 4: Reading test data..."
+DATA=$(kubectl exec $TEST_POD -n $NAMESPACE -- cat /usr/share/nginx/html/test.txt)
+echo "✓ Data read: $DATA"
+
+# Test 5: Restart CSI Node Pod (MountPod mode)
+if kubectl get pods -n $NAMESPACE -l app=curvine-csi-node --no-headers | grep -q Running; then
+    echo "Test 5: Restarting CSI Node Pod..."
+    kubectl delete pod -l app=curvine-csi-node -n $NAMESPACE
+    kubectl wait --for=condition=Ready pod -l app=curvine-csi-node -n $NAMESPACE --timeout=60s
+    
+    # Verify data still accessible
+    DATA_AFTER=$(kubectl exec $TEST_POD -n $NAMESPACE -- cat /usr/share/nginx/html/test.txt)
+    if [ "$DATA" == "$DATA_AFTER" ]; then
+        echo "✓ Data persisted after CSI restart"
+    else
+        echo "✗ Data mismatch after restart"
+        exit 1
+    fi
+fi
+
+echo "=== All Tests Passed ==="
+

--- a/.agents/skills/cv-handle-issue/SKILL.md
+++ b/.agents/skills/cv-handle-issue/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: cv-handle-issue
+description: Fix a Curvine GitHub issue from analysis through plan approval to implementation, routing large features to cv-tasks-breakdown. Use when user asks to fix, resolve, or implement a specific issue URL or issue number.
+---
+
+# cv-handle-issue
+
+End-to-end issue resolution with explicit user approval before coding.
+
+## When to Use
+
+- User provides an **issue URL or issue number** and asks to fix / implement / resolve it
+
+## Prerequisites
+
+- Valid issue reference (URL or `#<number>`)
+- `gh auth status` OK
+
+## Step 1: Read Issue
+
+```bash
+gh issue view <NUMBER> --json number,title,body,labels,state,url
+```
+
+Extract:
+
+- Bug vs feature (labels, title prefix)
+- Goal / Not Goal / Test Plan sections (if present)
+- Acceptance criteria and reproduction steps
+
+If issue is **closed** or scope is unclear, stop and ask user.
+
+## Step 2: Analyze
+
+Summarize for the user:
+
+| Item | Content |
+| ---- | ------- |
+| Type | bug / feature |
+| Problem | What is wrong or what is requested |
+| Affected modules | From issue body + codebase exploration |
+| Risks | Breaking changes, concurrency, compatibility |
+| Test strategy | Existing tests + new cases needed |
+
+Use deepwiki / codegraph as needed for CurvineIO/curvine.
+
+## Step 3: Propose Plan (No Coding Yet)
+
+Present a plan:
+
+```markdown
+## Proposed Approach
+
+1. ...
+2. ...
+
+## Files to touch (estimate)
+- `path/...` — ...
+
+## Test plan
+- ...
+
+## Estimated size
+~<N> lines / <M> files
+```
+
+### Size routing
+
+| Estimate | Next step |
+| -------- | --------- |
+| ≤ ~500 lines | Continue with this skill after user approval |
+| > ~500 lines or multi-module feature | Use [cv-tasks-breakdown](../cv-tasks-breakdown/SKILL.md); create sub-issues |
+
+**Do not write code until the user explicitly approves the plan.**
+
+Iterate on the plan until approval. For ambiguous requirements, ask clarifying questions.
+
+## Step 4: Branch
+
+After approval:
+
+```bash
+git fetch origin
+git checkout main && git pull origin main
+git checkout -b fix/<NUMBER>-<short-slug>   # or feat/...
+```
+
+## Step 5: Implement
+
+- Minimal scope aligned with approved plan
+- Follow `.cursor/rules/std-common/ai-workflow.mdc`
+- Add/update tests per plan
+- Run `make format` and relevant tests before commit
+
+If using task breakdown, complete **one task / one commit** at a time.
+
+## Step 6: Handoff to PR
+
+When implementation and tests pass, use [cv-create-pr](../cv-create-pr/SKILL.md):
+
+- PR title: `<type>(<module>): <description> (#<NUMBER>)`
+- Fill all PR body sections including **Test verified**
+
+## Rules
+
+- **No coding without explicit user approval** on the plan
+- Code change target: **≤ ~500 lines** per issue unless broken down via `cv-tasks-breakdown`
+- Large features → sub-issues + task breakdown, not one monolithic PR
+
+## Related
+
+- Break down large work → [cv-tasks-breakdown](../cv-tasks-breakdown/SKILL.md)
+- File new issue → [cv-create-issue](../cv-create-issue/SKILL.md)
+- Submit PR → [cv-create-pr](../cv-create-pr/SKILL.md)
+- Review feedback → [cv-review-pr](../cv-review-pr/SKILL.md)

--- a/.agents/skills/cv-review-pr/SKILL.md
+++ b/.agents/skills/cv-review-pr/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: cv-review-pr
+description: Review an existing Curvine PR, analyze review comments one by one with an accept/reject table, fix after user approval, update the PR, reply to comments, and resolve threads. Use when user asks to review a PR, handle review comments, or provides a PR URL.
+---
+
+# cv-review-pr
+
+Process PR review comments systematically: analyze → propose → user approves → fix → update PR → reply → resolve.
+
+## When to Use
+
+- User asks to review / address comments on current branch PR
+- User provides a PR URL or PR number
+- User asks to read or respond to review feedback
+
+## Step 1: Locate PR
+
+```bash
+# Current branch
+gh pr view --json number,url,title,headRefName,baseRefName
+
+# By number or URL
+gh pr view <number> --json number,url,title,headRefName,baseRefName
+```
+
+## Step 2: Collect Comments
+
+```bash
+PR=<number>
+
+# Inline review comments
+gh api "repos/{owner}/{repo}/pulls/${PR}/comments?per_page=100"
+
+# Conversation comments
+gh api "repos/{owner}/{repo}/issues/${PR}/comments?per_page=100"
+
+# Review summaries
+gh pr view ${PR} --json reviews
+```
+
+Read **all** comments before proposing changes.
+
+## Step 3: Analysis Table (Mandatory Before Coding)
+
+Output a table for **every** comment ID. Do not post this table to GitHub.
+
+```markdown
+| Comment ID | Title / excerpt | Accept? | Reason |
+| ---------- | --------------- | ------- | ------ |
+| 1234567890 | "use Result instead of unwrap" | Yes | Valid error handling |
+| 1234567891 | "rename to FooBar" | No | Conflicts with existing naming in module X |
+```
+
+Columns:
+
+- **Comment ID** — numeric ID from API
+- **Title / excerpt** — short summary of the comment
+- **Accept?** — `Yes` / `No` / `Partial`
+- **Reason** — technical justification
+
+**Wait for user approval** on this table before making code changes.
+
+## Step 4: Apply Fixes (Accepted Only)
+
+For each accepted comment:
+
+1. Minimal-scope code change
+2. Run relevant tests (`make format` + targeted `cargo test`)
+3. One focused commit per logical fix batch (user may prefer one commit — confirm)
+
+## Step 5: Update PR
+
+Follow [cv-create-pr](../cv-create-pr/SKILL.md) to push and refresh PR body if behavior or test results changed.
+
+## Step 6: Reply to Each Comment (English)
+
+### Inline review comment reply
+
+```bash
+gh api \
+  -X POST \
+  "repos/{owner}/{repo}/pulls/${PR}/comments/<COMMENT_ID>/replies" \
+  -f body='Thanks. Addressed in <commit/ref>: <short description>.'
+```
+
+### Conversation comment
+
+```bash
+gh pr comment ${PR} --body "Thanks for the feedback. ..."
+```
+
+Reply templates:
+
+- **Fixed:** `Thanks. Fixed in <sha>: <what changed>.`
+- **Declined:** `Thanks for the suggestion. Kept current approach because <reason>.`
+- **Already fixed:** `This is addressed in the latest push; no further change needed.`
+
+## Step 7: Resolve Threads
+
+For comments that are fixed, resolve the review thread via GraphQL:
+
+```bash
+# Get thread ID for a comment (GraphQL)
+gh api graphql -f query='
+query($owner:String!, $repo:String!, $pr:Int!) {
+  repository(owner:$owner, name:$repo) {
+    pullRequest(number:$pr) {
+      reviewThreads(first:100) {
+        nodes { id isResolved comments(first:1) { nodes { databaseId } } }
+      }
+    }
+  }
+}' -f owner=CurvineIO -f repo=curvine -F pr=${PR}
+```
+
+Resolve thread:
+
+```bash
+gh api graphql -f query='
+mutation($threadId:ID!) {
+  resolveReviewThread(input: {threadId:$threadId}) {
+    thread { isResolved }
+  }
+}' -f threadId="<THREAD_ID>"
+```
+
+Resolve only threads where the fix is merged in the PR branch and reply is posted.
+
+## Step 8: Checklist
+
+- [ ] Every comment ID in analysis table
+- [ ] User approved accept/reject decisions
+- [ ] Fixes committed and pushed
+- [ ] Each comment replied in English
+- [ ] Fixed threads resolved on GitHub
+
+## Related
+
+- Create / update PR → [cv-create-pr](../cv-create-pr/SKILL.md)

--- a/.agents/skills/cv-run-workflow/SKILL.md
+++ b/.agents/skills/cv-run-workflow/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: cv-run-workflow
+description: Trigger GitHub Actions workflows for Curvine when workflow YAML or dependent Dockerfiles change, with support for specifying branch, workflow file, and inputs. Use when user asks to run a workflow, dispatch CI, or test workflow/Dockerfile changes.
+---
+
+# cv-run-workflow
+
+Manually dispatch `.github/workflows/` jobs via `gh workflow run`, with branch and input selection.
+
+## When to Use
+
+- Changes to `.github/workflows/*.yml`
+- Changes to Dockerfiles referenced by workflows (e.g. `curvine-docker/`)
+- User asks to run / trigger / dispatch CI or a specific workflow
+- User invokes `/cv-run-workflow` or `/run-workflow-actions`
+
+## Step 1: Identify Workflow
+
+List available workflows:
+
+```bash
+gh workflow list --repo CurvineIO/curvine
+```
+
+Read the YAML to discover `workflow_dispatch` inputs:
+
+```bash
+# Example: inspect inputs
+head -30 .github/workflows/build-compile-image.yml
+```
+
+Common workflows in this repo:
+
+| Workflow file | Purpose |
+| ------------- | ------- |
+| `build.yml` | Compile and smoke test |
+| `build-compile-image.yml` | Compile Docker images |
+| `build-runtime-image.yml` | Runtime images |
+| `build-tests-image.yml` | Test images |
+| `build-csi-image.yml` | CSI images |
+| `build-fluid-image.yml` | Fluid images |
+| `build-java-sdk.yml` | Java SDK build |
+| `daily-ut-coverage.yml` | UT coverage |
+| `release.yml` | Release |
+| `trigger-helm-release.yml` | Helm release trigger |
+
+## Step 2: Confirm Parameters with User
+
+Before dispatching, confirm:
+
+| Parameter | Description |
+| --------- | ----------- |
+| `workflow` | YAML filename, e.g. `build-compile-image.yml` |
+| `--ref` | Branch or tag to run on |
+| `-f key=value` | `workflow_dispatch` inputs from YAML |
+
+Show the exact command for user approval.
+
+## Step 3: Dispatch
+
+### Generic form
+
+```bash
+gh workflow run <workflow-file> \
+  --repo CurvineIO/curvine \
+  --ref <branch-or-tag> \
+  -f <input_name>=<value>
+```
+
+### Example: compile image (from project convention)
+
+```bash
+gh workflow run build-compile-image.yml \
+  --repo CurvineIO/curvine \
+  --ref build/docker-centos7-compile-image \
+  -f push_image=true
+```
+
+Note: inspect the workflow file for actual input names (`push_image`, `platforms`, etc.) — they vary per workflow.
+
+### Example: build smoke test on a branch
+
+```bash
+gh workflow run build.yml \
+  --repo CurvineIO/curvine \
+  --ref <your-branch>
+```
+
+## Step 4: Monitor Run
+
+```bash
+# Latest run for a workflow
+gh run list --workflow=<workflow-file> --repo CurvineIO/curvine --limit 5
+
+# Watch specific run
+gh run watch <run-id> --repo CurvineIO/curvine
+
+# View logs on failure
+gh run view <run-id> --repo CurvineIO/curvine --log-failed
+```
+
+## Invocation Alias
+
+User may say:
+
+```text
+/run-workflow-actions [compile,deploy] <branch>
+```
+
+Map intent to workflow files:
+
+| Intent keyword | Typical workflow |
+| -------------- | ---------------- |
+| `compile` | `build-compile-image.yml` |
+| `test` / `build` | `build.yml` |
+| `runtime` | `build-runtime-image.yml` |
+| `csi` | `build-csi-image.yml` |
+| `deploy` / `helm` | `trigger-helm-release.yml` |
+| `release` | `release.yml` |
+
+Always verify inputs in the YAML before dispatching.
+
+## Rules
+
+- Default repo: `CurvineIO/curvine` unless user specifies another
+- Never dispatch without user confirmation of branch + inputs
+- After workflow YAML edits, run the affected workflow on a **feature branch** before merging
+- Report run URL and conclusion to user
+
+## Related
+
+- PR for workflow changes → [cv-create-pr](../cv-create-pr/SKILL.md)
+
+See [references/workflow-catalog.md](references/workflow-catalog.md) for workflow file paths.

--- a/.agents/skills/cv-run-workflow/references/workflow-catalog.md
+++ b/.agents/skills/cv-run-workflow/references/workflow-catalog.md
@@ -1,0 +1,19 @@
+# Workflow Catalog
+
+Paths relative to repo root: `.github/workflows/`
+
+| File | Trigger | Notes |
+| ---- | ------- | ----- |
+| `build.yml` | push, PR, `workflow_dispatch` | Main compile + smoke test |
+| `build-compile-image.yml` | `workflow_dispatch` | Matrix: rocky9, ubuntu22.04, ubuntu24.04; inputs: `push_image`, `platforms` |
+| `build-runtime-image.yml` | `workflow_dispatch` | Runtime Docker images |
+| `build-tests-image.yml` | `workflow_dispatch` | curvine-tests image |
+| `build-csi-image.yml` | `workflow_dispatch` | CSI driver image |
+| `build-fluid-image.yml` | `workflow_dispatch` | Fluid integration image |
+| `build-java-sdk.yml` | `workflow_dispatch` | Java SDK |
+| `daily-ut-coverage.yml` | schedule / manual | UT coverage |
+| `release.yml` | `workflow_dispatch` | Release pipeline |
+| `trigger-helm-release.yml` | `workflow_dispatch` | Helm chart release |
+| `pr-title-check.yml` | PR events | Validates PR title format (not manually dispatched) |
+
+Re-read the YAML before dispatch — inputs and matrix change over time.

--- a/.agents/skills/cv-tasks-breakdown/SKILL.md
+++ b/.agents/skills/cv-tasks-breakdown/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: cv-tasks-breakdown
+description: Break a design or implementation plan into small, dependency-ordered tasks with test coverage per task, commit-sized deliverables, and sub-issue tracking. Use when user asks to decompose a plan, split a large feature, create a task breakdown, or prepare incremental commits for a complex change.
+---
+
+# cv-tasks-breakdown
+
+Decompose a plan into small tasks that each land as one commit, keep the codebase working after every task, and track progress via sub-issues when a parent issue exists.
+
+## When to Use
+
+- Large feature or refactor (> ~500 lines expected)
+- User provides a design doc, RFC, or implementation plan
+- `cv-handle-issue` routes here when scope is too large for a single PR
+
+## Core Rules
+
+1. **Explicit dependencies** — every task has clear predecessors; no task starts until deps are done.
+2. **Always shippable** — after each task, existing behavior and new behavior must both work; no broken intermediate states.
+3. **One task ≈ one commit** — minimize diff size per task.
+4. **Repeated touch is OK** — the same module may change in multiple tasks if decomposition requires it.
+5. **Tests per task** — every task lists test case(s) that must pass before the task is considered done.
+
+## Workflow
+
+### Step 1: Understand the Plan
+
+- Read the parent issue, design doc, or user description
+- Identify modules, APIs, data paths, and acceptance criteria
+- Estimate whether any single task would exceed ~300 lines changed
+
+### Step 2: Draft Task List
+
+For each task define:
+
+| Field | Description |
+| ----- | ----------- |
+| Task ID | `T1`, `T2`, … sequential by dependency order |
+| Title | Short verb phrase |
+| Description | What this task delivers |
+| Depends on | Task IDs (empty = no deps) |
+| Test cases | Concrete tests to add or run |
+| Existing behavior impact | What existing functionality is touched |
+| Estimated scope | Files / modules (not line counts unless known) |
+
+### Step 3: Global Preview Table
+
+Present this table to the user **before** any implementation:
+
+```markdown
+## Task Breakdown Preview
+
+| Order | Task | Depends | Description | Test Cases | Existing Behavior Impact |
+| ----- | ---- | ------- | ----------- | ---------- | ------------------------ |
+| 1 | T1: ... | — | ... | `cargo test -p ... test_name` | None |
+| 2 | T2: ... | T1 | ... | ... | ... |
+```
+
+Add a **Commit Sequence Quick Reference** below the table:
+
+```markdown
+## Commit Sequence
+
+1. `T1` → `feat(module): <short subject>`
+2. `T2` → `feat(module): <short subject>`
+```
+
+Commit messages follow project commitlint; PR title uses `cv-create-pr` format when merged.
+
+### Step 4: Dependency Graph
+
+Show a simple mermaid or ASCII dependency graph when ≥ 3 tasks:
+
+```mermaid
+flowchart TD
+  T1 --> T2
+  T1 --> T3
+  T2 --> T4
+  T3 --> T4
+```
+
+### Step 5: Clarify Blockers with User
+
+**Stop and ask the user** when:
+
+- Acceptance criteria are ambiguous
+- Two tasks have circular or unclear dependencies
+- A task cannot be made shippable without a flag / stub / feature gate
+- Test strategy is unknown for a module
+- Scope boundary (Goal vs Not Goal) is unclear
+
+Do **not** start coding during breakdown. Iterate on the table until the user approves.
+
+### Step 6: Sub-Issues (when parent issue exists)
+
+If a parent GitHub issue is linked, create sub-issues via `cv-create-issue` or:
+
+```bash
+gh issue create \
+  --title "[SUB] T1: <title>" \
+  --label enhancement \
+  --body "$(cat <<'EOF'
+Parent: #<PARENT_NUMBER>
+
+## Task
+<description>
+
+## Depends on
+<task IDs or "none">
+
+## Test Cases
+- ...
+
+## Acceptance
+- [ ] Tests pass
+- [ ] No regression in <modules>
+EOF
+)"
+```
+
+Reference parent in body: `Parent: #123`
+
+### Step 7: Handoff
+
+After user approval:
+
+- Implement tasks **one at a time** in dependency order
+- Each task → one commit → verify tests → next task
+- Final PR via [cv-create-pr](../cv-create-pr/SKILL.md)
+
+## Task Sizing Guidelines
+
+| Signal | Action |
+| ------ | ------ |
+| > 500 lines or > 8 files | Split further |
+| Touches public API + impl | Split: types/API first, impl second |
+| Needs migration | Separate migration task with backward compat |
+| Only tests + no prod change | OK as standalone task |
+
+## Anti-Patterns
+
+- Task that leaves `cargo test` or `make format` failing
+- Task with no test coverage plan
+- Task that depends on a later task
+- One giant "implement everything" task
+
+## Related
+
+- Handle issue → [cv-handle-issue](../cv-handle-issue/SKILL.md)
+- Create issue / sub-issue → [cv-create-issue](../cv-create-issue/SKILL.md)
+- Submit work → [cv-create-pr](../cv-create-pr/SKILL.md)
+
+See [references/task-table-template.md](references/task-table-template.md) for a copy-paste template.

--- a/.agents/skills/cv-tasks-breakdown/references/task-table-template.md
+++ b/.agents/skills/cv-tasks-breakdown/references/task-table-template.md
@@ -1,0 +1,32 @@
+# Task Breakdown Template
+
+Copy and fill for each breakdown session.
+
+## Context
+
+- Parent issue: #<number> or N/A
+- Plan source: <link or summary>
+- Goal: <one paragraph>
+
+## Global Preview
+
+| Order | Task | Depends | Description | Test Cases | Existing Behavior Impact |
+| ----- | ---- | ------- | ----------- | ---------- | ------------------------ |
+| 1 | T1 | — | | | |
+| 2 | T2 | T1 | | | |
+
+## Commit Sequence
+
+| # | Task | Suggested commit message |
+| - | ---- | ------------------------ |
+| 1 | T1 | `feat(scope): ...` |
+| 2 | T2 | `feat(scope): ...` |
+
+## Open Questions
+
+- [ ] ...
+
+## User Approval
+
+- [ ] Preview table approved
+- [ ] Sub-issues created (if applicable)

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.cursor/skills
+++ b/.cursor/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.github/skills
+++ b/.github/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,9 @@ yarn.lock
 .metals
 .scala-build
 .cursorrules
-.cursor
+.cursor/*
+!.cursor/skills
+!.github/skills
 # Scala/Metals related files (not needed for Rust project)
 .metals/
 .scala-build/
@@ -42,7 +44,8 @@ yarn.lock
 curvine-libsdk/java/target/
 .staging/
 .summary/
-.claude/
+.claude/*
+!.claude/skills
 # Repo-root design notes (keep local); allow per-crate docs/ (e.g. curvine-lancedb-rs/docs).
 /docs
 
@@ -50,3 +53,7 @@ __pycache__
 
 # Regression test results (build-server / curvine-tests)
 curvine-tests/regression_result
+
+# Agent skills: only cv-* are tracked in repo; other local skills stay untracked
+.agents/skills/*
+!.agents/skills/cv-*/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,78 @@
+
+
+<skills_system priority="1">
+
+## Available Skills
+
+<!-- SKILLS_TABLE_START -->
+<usage>
+When users ask you to perform tasks, check if any of the available skills below can help complete the task more effectively. Skills provide specialized capabilities and domain knowledge.
+
+How to use skills:
+- Read the skill file at `.agents/skills/<skill-name>/SKILL.md`
+- Base directory provided in output for resolving bundled resources (references/, scripts/, assets/)
+
+Usage notes:
+- For Curvine project workflow tasks, prefer the cv-* skills listed in <available_skills> below
+- User-installed global skills (e.g. ~/.cursor/skills/, ~/.claude/skills/) remain available when the agent tool exposes them
+- Do not invent or invoke project skills that are not listed in <available_skills>
+- Do not invoke a skill that is already loaded in your context
+- Each skill invocation is stateless
+- Canonical project skill location: `.agents/skills/` (symlinked from `.cursor/skills`, `.claude/skills`, `.github/skills`)
+- Only `cv-*` skills are versioned in this repository
+</usage>
+
+<available_skills>
+
+<skill>
+<name>cv-add-skills</name>
+<description>Add or update Curvine cv-* project skills under .agents/skills/, following naming and layout conventions, and sync the AGENTS.md registry. Use when creating a new cv skill, updating an existing cv skill structure, or registering skills after changes.</description>
+<location>project</location>
+</skill>
+
+<skill>
+<name>cv-create-issue</name>
+<description>Create a GitHub issue for Curvine using repository templates, with extended Goal/Not Goal/Test Plan sections for features. Use when user asks to create an issue, report a serious bug found during testing, or when agent should suggest filing an issue for the current problem.</description>
+<location>project</location>
+</skill>
+
+<skill>
+<name>cv-create-pr</name>
+<description>Create or update a Curvine pull request with standardized title and body sections (Summary, Issue/Design, Changes table, Test verified, Dependencies). Use when user asks to create, submit, update, or push a PR.</description>
+<location>project</location>
+</skill>
+
+<skill>
+<name>cv-csi-test</name>
+<description>End-to-end Curvine CSI driver testing guide for Kubernetes deployment, StorageClass and MountPod setup, resilience scenarios, volume expansion, and scripted test suites. Use when validating CSI code changes, running integration tests, debugging mount failures, or verifying MountPod recovery after node or CSI restarts.</description>
+<location>project</location>
+</skill>
+
+<skill>
+<name>cv-handle-issue</name>
+<description>Fix a Curvine GitHub issue from analysis through plan approval to implementation, routing large features to cv-tasks-breakdown. Use when user asks to fix, resolve, or implement a specific issue URL or issue number.</description>
+<location>project</location>
+</skill>
+
+<skill>
+<name>cv-review-pr</name>
+<description>Review an existing Curvine PR, analyze review comments one by one with an accept/reject table, fix after user approval, update the PR, reply to comments, and resolve threads. Use when user asks to review a PR, handle review comments, or provides a PR URL.</description>
+<location>project</location>
+</skill>
+
+<skill>
+<name>cv-run-workflow</name>
+<description>Trigger GitHub Actions workflows for Curvine when workflow YAML or dependent Dockerfiles change, with support for specifying branch, workflow file, and inputs. Use when user asks to run a workflow, dispatch CI, or test workflow/Dockerfile changes.</description>
+<location>project</location>
+</skill>
+
+<skill>
+<name>cv-tasks-breakdown</name>
+<description>Break a design or implementation plan into small, dependency-ordered tasks with test coverage per task, commit-sized deliverables, and sub-issue tracking. Use when user asks to decompose a plan, split a large feature, create a task breakdown, or prepare incremental commits for a complex change.</description>
+<location>project</location>
+</skill>
+
+</available_skills>
+<!-- SKILLS_TABLE_END -->
+
+</skills_system>


### PR DESCRIPTION
# Summary

Add a cross-platform agent skills system for Curvine with `.agents/` as the canonical source. Versioned `cv-*` skills cover the full dev workflow (issue, task breakdown, PR, review, CI, CSI testing, and skill authoring). Agent tools read skills via symlinks from `.cursor/`, `.claude/`, and `.github/`.

# Issue Describe / Design

No linked issue.

Design decisions:
- **Single canonical path**: `.agents/skills/cv-*/` — edit once, all agents see it via symlinks
- **`cv-` prefix**: only `cv-*` skills are git-tracked; local non-cv skills stay gitignored
- **`AGENTS.md` registry**: lists project skills; global user skills remain available per agent tool
- **Meta skill `cv-add-skills`**: documents conventions for adding/updating cv skills and syncing the registry

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `.agents/` | New canonical agent config (skills + rules) | None — additive |
| `.agents/skills/cv-*` | 8 workflow skills | None — additive |
| `AGENTS.md` | Skill registry for project cv-* skills | None — additive |
| `.gitignore` | Track only `cv-*` under `.agents/skills/`; allow skill symlinks | None |
| `.github/skills`, `.cursor/skills`, `.claude/skills` | Symlinks → `.agents/skills` | None — additive |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `git check-ignore .agents/skills/cv-add-skills/SKILL.md` | PASS | cv-* not ignored |
| `git check-ignore .agents/skills/mermaid/SKILL.md` | PASS | non-cv skill ignored |
| Symlink resolution `.cursor/skills/cv-create-pr/SKILL.md` | PASS | Readable via symlink |
| `make format` | SKIP | No Rust files changed |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None