### PR TITLE
fix(server): propagate startup failures in mini cluster

### DIFF
--- a/curvine-client/src/block/batch_block_writer_local.rs
+++ b/curvine-client/src/block/batch_block_writer_local.rs
@@ -1,3 +1,4 @@
+use crate::block::BlockClient;
 use crate::file::FsContext;
 use curvine_common::error::FsError;
 use curvine_common::fs::Path;
@@ -12,12 +13,13 @@ use std::sync::Arc;
 
 pub struct BatchBlockWriterLocal {
     rt: Arc<Runtime>,
-    fs_context: Arc<FsContext>,
     blocks: Vec<ExtendedBlock>,
     worker_address: WorkerAddress,
+    client: BlockClient,
     files: Vec<RawPtr<LocalFile>>,
     block_size: i64,
     pos: i64,
+    req_id: i64,
 }
 
 impl BatchBlockWriterLocal {
@@ -54,12 +56,13 @@ impl BatchBlockWriterLocal {
 
         Ok(Self {
             rt: fs_context.clone_runtime(),
-            fs_context,
             blocks,
             worker_address,
+            client,
             files,
             block_size,
             pos: 0,
+            req_id,
         })
     }
 
@@ -67,13 +70,12 @@ impl BatchBlockWriterLocal {
     pub async fn complete(&mut self) -> FsResult<()> {
         // flush before commit
         self.flush().await?;
-        let client = self.fs_context.block_client(&self.worker_address).await?;
-        client
+        self.client
             .write_commit_batch(
                 &self.blocks,
                 self.pos,
                 self.block_size,
-                Utils::req_id(),
+                self.req_id,
                 0,
                 false,
             )

--- a/curvine-common/src/raft/raft_node.rs
+++ b/curvine-common/src/raft/raft_node.rs
@@ -634,26 +634,42 @@ where
             if entry.get_data().is_empty() {
                 continue;
             }
-            let req_id: i64 = SerdeUtils::deserialize(entry.get_context())?;
 
-            let rep_msg = if let EntryType::EntryConfChange = entry.get_entry_type() {
+            let is_conf_change = matches!(entry.get_entry_type(), EntryType::EntryConfChange);
+            let should_respond = self.is_leader();
+            let (entry_index, entry_term, entry_context) = if should_respond {
+                (entry.index, entry.term, Some(entry.get_context().to_vec()))
+            } else {
+                (0, 0, None)
+            };
+            let rep_msg = if is_conf_change {
                 let rep = self.apply_config_change(&entry)?;
                 Builder::new_rpc(RaftCode::ConfChange)
                     .response(ResponseStatus::Success)
-                    .req_id(req_id)
                     .proto_header(rep)
-                    .build()
             } else {
                 let rep = self.apply_propose(entry).await?;
                 Builder::new_rpc(RaftCode::Propose)
                     .response(ResponseStatus::Success)
-                    .req_id(req_id)
                     .proto_header(rep)
-                    .build()
             };
 
             // Followers only need to replay the message and do not need to respond to the customer service.
-            if self.is_leader() {
+            if should_respond {
+                let Some(entry_context) = entry_context else {
+                    continue;
+                };
+                let req_id: i64 = match SerdeUtils::deserialize(&entry_context) {
+                    Ok(req_id) => req_id,
+                    Err(e) => {
+                        warn!(
+                            "failed to decode raft entry context for response, index {}, term {}: {}",
+                            entry_index, entry_term, e
+                        );
+                        continue;
+                    }
+                };
+                let rep_msg = rep_msg.req_id(req_id).build();
                 match client_send.remove(&req_id) {
                     Some(sender) => {
                         if sender.send(Ok(rep_msg)).is_err() {

--- a/curvine-common/src/state/mount.rs
+++ b/curvine-common/src/state/mount.rs
@@ -15,11 +15,13 @@
 use crate::conf::ClientConf;
 use crate::fs::Path;
 use crate::state::{CreateFileOpts, CreateFileOptsBuilder, StoragePolicy, StorageType, TtlAction};
+use bincode::Options;
 use num_enum::{FromPrimitive, IntoPrimitive};
 use orpc::common::DurationUnit;
 use orpc::{err_box, CommonError, CommonResult};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::io::ErrorKind;
 
 #[repr(i32)]
 #[derive(
@@ -116,7 +118,66 @@ pub struct MountInfo {
     pub access_mode: AccessMode,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+struct LegacyMountInfo {
+    cv_path: String,
+    ufs_path: String,
+    mount_id: u32,
+    properties: HashMap<String, String>,
+    ttl_ms: i64,
+    ttl_action: TtlAction,
+    read_verify_ufs: bool,
+    storage_type: Option<StorageType>,
+    block_size: Option<i64>,
+    replicas: Option<i32>,
+    write_type: WriteType,
+    provider: Option<Provider>,
+}
+
+impl From<LegacyMountInfo> for MountInfo {
+    fn from(info: LegacyMountInfo) -> Self {
+        Self {
+            cv_path: info.cv_path,
+            ufs_path: info.ufs_path,
+            mount_id: info.mount_id,
+            properties: info.properties,
+            ttl_ms: info.ttl_ms,
+            ttl_action: info.ttl_action,
+            read_verify_ufs: info.read_verify_ufs,
+            storage_type: info.storage_type,
+            block_size: info.block_size,
+            replicas: info.replicas,
+            write_type: info.write_type,
+            provider: info.provider,
+            auto_cache: true,
+            access_mode: AccessMode::ReadOnly,
+        }
+    }
+}
+
 impl MountInfo {
+    pub fn decode_persisted(bytes: &[u8]) -> CommonResult<Self> {
+        match bincode::deserialize::<Self>(bytes) {
+            Ok(info) => Ok(info),
+            Err(e) if Self::is_unexpected_eof(&e) => {
+                let legacy: LegacyMountInfo = bincode::DefaultOptions::new()
+                    .with_fixint_encoding()
+                    .reject_trailing_bytes()
+                    .deserialize(bytes)
+                    .map_err(|_| e)?;
+                Ok(legacy.into())
+            }
+            Err(e) => err_box!(e),
+        }
+    }
+
+    fn is_unexpected_eof(err: &bincode::Error) -> bool {
+        matches!(
+            err.as_ref(),
+            bincode::ErrorKind::Io(e) if e.kind() == ErrorKind::UnexpectedEof
+        )
+    }
+
     pub fn auto_cache(&self) -> bool {
         self.auto_cache && self.ttl_ms > 0
     }

--- a/curvine-common/tests/mount_info_compat_test.rs
+++ b/curvine-common/tests/mount_info_compat_test.rs
@@ -1,0 +1,104 @@
+use curvine_common::state::{AccessMode, MountInfo, Provider, StorageType, TtlAction, WriteType};
+use serde::Serialize;
+use std::collections::HashMap;
+
+#[derive(Debug, Serialize)]
+struct LegacyMountInfo {
+    cv_path: String,
+    ufs_path: String,
+    mount_id: u32,
+    properties: HashMap<String, String>,
+    ttl_ms: i64,
+    ttl_action: TtlAction,
+    read_verify_ufs: bool,
+    storage_type: Option<StorageType>,
+    block_size: Option<i64>,
+    replicas: Option<i32>,
+    write_type: WriteType,
+    provider: Option<Provider>,
+}
+
+fn legacy_mount_info() -> LegacyMountInfo {
+    let mut properties = HashMap::new();
+    properties.insert("k".to_string(), "v".to_string());
+
+    LegacyMountInfo {
+        cv_path: "/acc-hdfs".to_string(),
+        ufs_path: "oss://bucket/prefix".to_string(),
+        mount_id: 7,
+        properties,
+        ttl_ms: 86_400_000,
+        ttl_action: TtlAction::Delete,
+        read_verify_ufs: true,
+        storage_type: Some(StorageType::Disk),
+        block_size: Some(134_217_728),
+        replicas: Some(3),
+        write_type: WriteType::CacheMode,
+        provider: Some(Provider::OssHdfs),
+    }
+}
+
+fn current_mount_info() -> MountInfo {
+    let info = legacy_mount_info();
+    MountInfo {
+        cv_path: info.cv_path,
+        ufs_path: info.ufs_path,
+        mount_id: info.mount_id,
+        properties: info.properties,
+        ttl_ms: info.ttl_ms,
+        ttl_action: info.ttl_action,
+        read_verify_ufs: info.read_verify_ufs,
+        storage_type: info.storage_type,
+        block_size: info.block_size,
+        replicas: info.replicas,
+        write_type: info.write_type,
+        provider: info.provider,
+        auto_cache: true,
+        access_mode: AccessMode::ReadOnly,
+    }
+}
+
+#[test]
+fn decode_persisted_mount_info_accepts_legacy_bytes() {
+    let bytes = bincode::serialize(&legacy_mount_info()).unwrap();
+    let decoded = MountInfo::decode_persisted(&bytes).unwrap();
+
+    assert_eq!(decoded.cv_path, "/acc-hdfs");
+    assert_eq!(decoded.ufs_path, "oss://bucket/prefix");
+    assert_eq!(decoded.mount_id, 7);
+    assert_eq!(decoded.properties.get("k").map(String::as_str), Some("v"));
+    assert_eq!(decoded.ttl_ms, 86_400_000);
+    assert_eq!(decoded.ttl_action, TtlAction::Delete);
+    assert!(decoded.read_verify_ufs);
+    assert_eq!(decoded.storage_type, Some(StorageType::Disk));
+    assert_eq!(decoded.block_size, Some(134_217_728));
+    assert_eq!(decoded.replicas, Some(3));
+    assert_eq!(decoded.write_type, WriteType::CacheMode);
+    assert_eq!(decoded.provider, Some(Provider::OssHdfs));
+    assert!(decoded.auto_cache);
+    assert_eq!(decoded.access_mode, AccessMode::ReadOnly);
+}
+
+#[test]
+fn decode_persisted_mount_info_keeps_current_fields() {
+    let mut current = current_mount_info();
+    current.auto_cache = false;
+    current.access_mode = AccessMode::ReadWrite;
+
+    let bytes = bincode::serialize(&current).unwrap();
+    let decoded = MountInfo::decode_persisted(&bytes).unwrap();
+
+    assert!(!decoded.auto_cache);
+    assert_eq!(decoded.access_mode, AccessMode::ReadWrite);
+    assert_eq!(decoded.cv_path, current.cv_path);
+    assert_eq!(decoded.ufs_path, current.ufs_path);
+    assert_eq!(decoded.mount_id, current.mount_id);
+}
+
+#[test]
+fn decode_persisted_mount_info_rejects_trailing_legacy_bytes() {
+    let mut bytes = bincode::serialize(&legacy_mount_info()).unwrap();
+    bytes.push(1);
+
+    assert!(MountInfo::decode_persisted(&bytes).is_err());
+}

--- a/curvine-server/src/bin/curvine-server.rs
+++ b/curvine-server/src/bin/curvine-server.rs
@@ -43,7 +43,7 @@ fn main() -> CommonResult<()> {
 
         ServiceType::Worker => {
             let worker = Worker::with_conf(conf)?;
-            worker.block_on_start();
+            worker.block_on_start()?;
         }
     }
 

--- a/curvine-server/src/bin/curvine-server.rs
+++ b/curvine-server/src/bin/curvine-server.rs
@@ -38,7 +38,7 @@ fn main() -> CommonResult<()> {
         ServiceType::Master => {
             conf.check_master_hostname()?;
             let master = Master::with_conf(conf)?;
-            master.block_on_start();
+            master.block_on_start()?;
         }
 
         ServiceType::Worker => {

--- a/curvine-server/src/master/fs/fs_retry_cache.rs
+++ b/curvine-server/src/master/fs/fs_retry_cache.rs
@@ -19,6 +19,7 @@ use mini_moka::sync::{Cache, CacheBuilder};
 use num_enum::{FromPrimitive, IntoPrimitive};
 use orpc::common::DurationUnit;
 use orpc::err_ext;
+use orpc::error::ErrorExt;
 use std::ops::Deref;
 use std::sync::Arc;
 use std::time::Duration;
@@ -45,15 +46,21 @@ impl FsRetryCache {
         Self(Arc::new(cache))
     }
 
-    pub fn with_conf(conf: &MasterConf) -> Option<FsRetryCache> {
+    pub fn with_conf(conf: &MasterConf) -> FsResult<Option<FsRetryCache>> {
         if conf.retry_cache_enable {
             let ttl = DurationUnit::from_str(&conf.retry_cache_ttl)
-                .unwrap()
+                .map_err(FsError::from)
+                .map_err(|e| {
+                    e.ctx(format!(
+                        "invalid master retry_cache_ttl: {}",
+                        conf.retry_cache_ttl
+                    ))
+                })?
                 .as_duration();
             let cache = Self::new(conf.retry_cache_size, ttl);
-            Some(cache)
+            Ok(Some(cache))
         } else {
-            None
+            Ok(None)
         }
     }
 

--- a/curvine-server/src/master/fs/master_actor.rs
+++ b/curvine-server/src/master/fs/master_actor.rs
@@ -51,7 +51,7 @@ impl MasterActor {
         }
     }
 
-    pub fn start(&mut self) {
+    pub fn start(&mut self) -> CommonResult<()> {
         info!("start master actor");
         Self::start_heartbeat_checker(
             self.fs.clone(),
@@ -59,8 +59,8 @@ impl MasterActor {
             self.executor.clone(),
             self.replication_manager.clone(),
             self.quota_manager.clone(),
-        )
-        .unwrap();
+        )?;
+        Ok(())
     }
 
     pub fn start_ttl_scheduler(&mut self) -> CommonResult<()> {

--- a/curvine-server/src/master/fs/master_filesystem.rs
+++ b/curvine-server/src/master/fs/master_filesystem.rs
@@ -114,7 +114,7 @@ impl MasterFilesystem {
             if opts.create_parent {
                 if let Some(last_inode) = inp.get_last_inode() {
                     if last_inode.is_dir() {
-                        let status = last_inode.to_file_status(inp.path());
+                        let status = last_inode.to_file_status(inp.path())?;
                         return Ok(status);
                     }
                 }
@@ -128,8 +128,12 @@ impl MasterFilesystem {
         }
 
         let inp = fs_dir.mkdir(inp, opts)?;
-        let last = try_option!(inp.get_last_inode());
-        let status = last.to_file_status(inp.path());
+        let last = try_option!(
+            inp.get_last_inode(),
+            "Path {} has no inode after mkdir",
+            inp.path()
+        );
+        let status = last.to_file_status(inp.path())?;
         Ok(status)
     }
 
@@ -442,7 +446,7 @@ impl MasterFilesystem {
     ) -> FsResult<Vec<WorkerAddress>> {
         let wm = self.worker_manager.read();
 
-        let mut inode = try_option!(inp.get_last_inode());
+        let mut inode = try_option!(inp.get_last_inode(), "File {} not exists", inp.path());
         let file = inode.as_file_mut()?;
         let validate_block = Self::validate_add_block(file, &client_addr, None)?;
 
@@ -526,7 +530,7 @@ impl MasterFilesystem {
         fs_dir.complete_file(&inp, len, commit_blocks, client_name, only_flush)?;
         if only_flush {
             let locs = self.get_block_locs(path, &fs_dir, file)?;
-            let status = inode.to_file_status(path);
+            let status = inode.to_file_status(path)?;
             Ok(Some(FileBlocks::new(status, locs)))
         } else {
             Ok(None)
@@ -542,7 +546,7 @@ impl MasterFilesystem {
         let inode = try_option!(inp.get_last_inode(), "File {} not exists", path);
         let file = inode.as_file_ref()?;
         let blocks = self.get_block_locs(path, fs_dir, file)?;
-        Ok(FileBlocks::new(inode.to_file_status(path), blocks))
+        Ok(FileBlocks::new(inode.to_file_status(path)?, blocks))
     }
 
     fn get_block_locs(
@@ -598,7 +602,7 @@ impl MasterFilesystem {
         let file = inode.as_file_ref()?;
         let block_locs = self.get_block_locs(path, &fs_dir, file)?;
         let locate_blocks = FileBlocks {
-            status: inode.to_file_status(path),
+            status: inode.to_file_status(path)?,
             block_locs,
         };
 
@@ -606,7 +610,7 @@ impl MasterFilesystem {
     }
 
     pub fn master_info(&self) -> FsResult<MasterInfo> {
-        let metrics = Master::get_metrics();
+        let metrics = Master::get_metrics()?;
         let mut info = MasterInfo {
             inode_dir_num: metrics.inode_dir_num.get(),
             inode_file_num: metrics.inode_file_num.get(),
@@ -654,7 +658,7 @@ impl MasterFilesystem {
         wm.add_test_worker(worker);
     }
 
-    pub fn sum_hash(&self) -> u128 {
+    pub fn sum_hash(&self) -> CommonResult<u128> {
         let fs_dir = self.fs_dir.read();
         fs_dir.sum_hash()
     }
@@ -915,14 +919,5 @@ impl MasterFilesystem {
         let inp = Self::resolve_path(&fs_dir, path)?;
 
         fs_dir.set_lock(inp, lock, self.conf.lock_expire_time_ms())
-    }
-}
-
-impl Default for MasterFilesystem {
-    fn default() -> Self {
-        let conf = ClusterConf::format();
-        let journal_system = JournalSystem::from_conf(&conf)
-            .expect("Failed to initialize JournalSystem from default ClusterConf");
-        journal_system.fs()
     }
 }

--- a/curvine-server/src/master/fs/policy/robin_worker_policy.rs
+++ b/curvine-server/src/master/fs/policy/robin_worker_policy.rs
@@ -16,7 +16,7 @@ use crate::master::fs::policy::{ChooseContext, WorkerPolicy};
 use curvine_common::state::{WorkerAddress, WorkerInfo};
 use indexmap::IndexMap;
 use orpc::sync::AtomicLen;
-use orpc::{err_box, try_option, CommonResult};
+use orpc::{err_box, CommonResult};
 
 // Poll selector.
 pub struct RobinWorkerPolicy {
@@ -55,7 +55,13 @@ impl WorkerPolicy for RobinWorkerPolicy {
         let mut res = vec![];
 
         while res.len() < ctx.replicas as usize {
-            let (id, worker) = try_option!(workers.get_index(index));
+            let Some((id, worker)) = workers.get_index(index) else {
+                return err_box!(
+                    "worker selection index {} out of range, workers={}",
+                    index,
+                    workers.len()
+                );
+            };
 
             if !ctx.exclude_workers.contains(id)
                 && worker.available > ctx.block_size

--- a/curvine-server/src/master/fs/worker_manager.rs
+++ b/curvine-server/src/master/fs/worker_manager.rs
@@ -36,16 +36,16 @@ pub struct WorkerManager {
 }
 
 impl WorkerManager {
-    pub fn new(conf: &ClusterConf) -> Self {
-        let worker_policy = WorkerPolicyAdapter::from_conf(conf).unwrap();
+    pub fn new(conf: &ClusterConf) -> FsResult<Self> {
+        let worker_policy = WorkerPolicyAdapter::from_conf(conf)?;
 
-        Self {
+        Ok(Self {
             worker_map: WorkerMap::new(),
             block_map: BlockMap::new(),
             worker_policy,
             cluster_id: conf.cluster_id.to_string(),
             conf: conf.clone(),
-        }
+        })
     }
 
     pub fn heartbeat(
@@ -264,12 +264,5 @@ impl Display for WorkerManager {
         }
 
         write!(f, "{}", str)
-    }
-}
-
-impl Default for WorkerManager {
-    fn default() -> Self {
-        let conf = ClusterConf::default();
-        Self::new(&conf)
     }
 }

--- a/curvine-server/src/master/job/job_manager.rs
+++ b/curvine-server/src/master/job/job_manager.rs
@@ -28,7 +28,7 @@ use curvine_common::FsResult;
 use log::{debug, info};
 use orpc::common::LocalTime;
 use orpc::runtime::{LoopTask, Runtime};
-use orpc::{err_box, err_ext};
+use orpc::{err_box, err_ext, CommonResult};
 use std::sync::Arc;
 use tokio::time::timeout;
 
@@ -66,22 +66,26 @@ impl JobManager {
     }
 
     /// Start the job manager
-    pub fn start(&self) {
+    pub fn start(&self) -> CommonResult<()> {
         let cleanup_interval = self.job_cleanup_ttl.as_millis() as u64;
         let ttl_ms = self.job_life_ttl.as_millis() as i64;
 
         let executor = ScheduledExecutor::new("job_cleanup", cleanup_interval);
-        executor
-            .start(JobCleanupTask {
-                jobs: self.jobs.clone(),
-                ttl_ms,
-            })
-            .unwrap();
+        executor.start(JobCleanupTask {
+            jobs: self.jobs.clone(),
+            ttl_ms,
+        })?;
 
         info!("JobManager started");
+        Ok(())
     }
 
-    fn update_state(&self, job_id: &str, state: JobTaskState, message: impl Into<String>) {
+    fn update_state(
+        &self,
+        job_id: &str,
+        state: JobTaskState,
+        message: impl Into<String>,
+    ) -> FsResult<()> {
         self.jobs.update_state(job_id, state, message)
     }
 
@@ -187,7 +191,7 @@ impl JobManager {
                         "job {} is already in final state {:?}, source_path: {}, target_path: {}",
                         job_id, state, job.info.source_path, job.info.target_path
                     );
-                    self.update_state(job_id, JobTaskState::Canceled, "Canceling job by user");
+                    self.update_state(job_id, JobTaskState::Canceled, "Canceling job by user")?;
                     return Ok(());
                 }
 
@@ -197,7 +201,7 @@ impl JobManager {
             }
         };
 
-        self.update_state(job_id, JobTaskState::Canceled, "Canceling job by user");
+        self.update_state(job_id, JobTaskState::Canceled, "Canceling job by user")?;
 
         let job_runner = self.create_runner();
         job_runner.cancel_job(&job_id, assigned_workers).await?;

--- a/curvine-server/src/master/job/job_runner.rs
+++ b/curvine-server/src/master/job/job_runner.rs
@@ -209,11 +209,16 @@ impl LoadJobRunner {
         if let Err(err) = self.submit_all_task(tasks).await {
             warn!("dispatch load job {} failed: {}", job_id, err);
             // @todo Cancel sub-tasks that may have already been dispatched.
-            self.jobs.update_state(
+            if let Err(update_err) = self.jobs.update_state(
                 &job_id,
                 JobTaskState::Failed,
                 format!("dispatch failed: {}", err),
-            );
+            ) {
+                error!(
+                    "failed to mark load job {} as failed after dispatch error: {}",
+                    job_id, update_err
+                );
+            }
             return Err(err);
         }
 
@@ -343,11 +348,16 @@ impl LoadJobRunner {
 
             if let Err(e) = res {
                 error!("failed to send cancel request to worker {}: {}", worker, e);
-                self.jobs.update_state(
+                if let Err(update_err) = self.jobs.update_state(
                     job_id,
                     JobTaskState::Canceled,
                     format!("failed to send cancel request to worker {}: {}", worker, e),
-                );
+                ) {
+                    error!(
+                        "failed to mark load job {} as canceled after worker cancel error: {}",
+                        job_id, update_err
+                    );
+                }
             }
         }
 

--- a/curvine-server/src/master/job/job_store.rs
+++ b/curvine-server/src/master/job/job_store.rs
@@ -73,18 +73,22 @@ impl JobStore {
         }
     }
 
-    pub fn register_callback(&self, job_id: String, callback: JobCallback) {
-        let mut callbacks = self.callbacks.write().unwrap();
+    pub fn register_callback(&self, job_id: String, callback: JobCallback) -> FsResult<()> {
+        let mut callbacks = match self.callbacks.write() {
+            Ok(callbacks) => callbacks,
+            Err(e) => return err_box!("failed to register job callback for {}: {}", job_id, e),
+        };
         callbacks.entry(job_id).or_default().push(callback);
+        Ok(())
     }
 
-    pub fn register_completion_callback<F>(&self, job_id: String, callback: F)
+    pub fn register_completion_callback<F>(&self, job_id: String, callback: F) -> FsResult<()>
     where
         F: Fn(&str, JobTaskState, JobTaskState, &JobContext) + Send + Sync + 'static,
     {
         let cb = JobCallback::new(callback)
             .with_filter(vec![JobTaskState::Completed, JobTaskState::Failed]);
-        self.register_callback(job_id, cb);
+        self.register_callback(job_id, cb)
     }
 
     fn trigger_callbacks(
@@ -93,8 +97,11 @@ impl JobStore {
         old_state: JobTaskState,
         new_state: JobTaskState,
         job: &JobContext,
-    ) {
-        let callbacks_guard = self.callbacks.read().unwrap();
+    ) -> FsResult<()> {
+        let callbacks_guard = match self.callbacks.read() {
+            Ok(callbacks) => callbacks,
+            Err(e) => return err_box!("failed to trigger job callbacks for {}: {}", job_id, e),
+        };
         if let Some(callbacks) = callbacks_guard.get(job_id) {
             for cb in callbacks {
                 if cb.should_trigger(new_state) {
@@ -102,6 +109,7 @@ impl JobStore {
                 }
             }
         }
+        Ok(())
     }
 
     pub fn update_progress(
@@ -130,13 +138,18 @@ impl JobStore {
             let job_clone = (*job).clone();
             drop(job);
 
-            self.trigger_callbacks(&job_id_owned, old_state, new_state, &job_clone);
+            self.trigger_callbacks(&job_id_owned, old_state, new_state, &job_clone)?;
         }
 
         Ok(())
     }
 
-    pub fn update_state(&self, job_id: &str, state: JobTaskState, message: impl Into<String>) {
+    pub fn update_state(
+        &self,
+        job_id: &str,
+        state: JobTaskState,
+        message: impl Into<String>,
+    ) -> FsResult<()> {
         if let Some(mut job) = self.jobs.get_mut(job_id) {
             let old_state: JobTaskState = job.state.state();
             job.update_state(state, message);
@@ -146,14 +159,19 @@ impl JobStore {
                 let job_clone = (*job).clone();
                 drop(job);
 
-                self.trigger_callbacks(job_id, old_state, new_state, &job_clone);
+                self.trigger_callbacks(job_id, old_state, new_state, &job_clone)?;
             }
         }
+        Ok(())
     }
 
-    pub fn remove_callbacks(&self, job_id: &str) {
-        let mut callbacks = self.callbacks.write().unwrap();
+    pub fn remove_callbacks(&self, job_id: &str) -> FsResult<()> {
+        let mut callbacks = match self.callbacks.write() {
+            Ok(callbacks) => callbacks,
+            Err(e) => return err_box!("failed to remove job callbacks for {}: {}", job_id, e),
+        };
         callbacks.remove(job_id);
+        Ok(())
     }
 }
 

--- a/curvine-server/src/master/journal/journal_loader.rs
+++ b/curvine-server/src/master/journal/journal_loader.rs
@@ -33,7 +33,7 @@ use orpc::{err_box, ternary, CommonResult};
 use raft::eraftpb::Entry;
 use raft::StateRole;
 use std::path::Path;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::Duration;
 use std::{fs, mem};
 
@@ -64,10 +64,10 @@ impl JournalLoader {
         mnt_mgr: Arc<MountManager>,
         conf: &JournalConf,
         job_manager: Arc<JobManager>,
-    ) -> Self {
+    ) -> CommonResult<Self> {
         let rt = conf.create_runtime();
         let client = RaftClient::from_conf(rt.clone(), conf);
-        let journal_writer = Arc::new(JournalWriter::new(true, client, conf));
+        let journal_writer = Arc::new(JournalWriter::new(true, client, conf)?);
         let log_store = RocksLogStorage::from_conf(conf, false);
         Self::build(
             rt,
@@ -90,7 +90,7 @@ impl JournalLoader {
         job_manager: Arc<JobManager>,
         log_store: RocksLogStorage,
         journal_writer: Arc<JournalWriter>,
-    ) -> Self {
+    ) -> CommonResult<Self> {
         Self::build(
             rt,
             fs_dir,
@@ -113,11 +113,11 @@ impl JournalLoader {
         log_store: RocksLogStorage,
         journal_writer: Arc<JournalWriter>,
         testing: bool,
-    ) -> Self {
+    ) -> CommonResult<Self> {
         let ufs_loader = UfsLoader::new(job_manager, conf);
         let (sender, receiver) = AsyncChannel::new(conf.writer_channel_size).split();
         let loader = Self {
-            node_id: conf.node_id().unwrap(),
+            node_id: conf.node_id()?,
             fs_dir,
             mnt_mgr,
             journal_writer,
@@ -131,7 +131,7 @@ impl JournalLoader {
             skip_failed_ufs_replay_after_retry: conf.skip_failed_ufs_replay_after_retry,
             batch_size: conf.scan_batch_size,
             retry_interval: Duration::from_secs(conf.retry_interval_secs),
-            metrics: Master::get_metrics(),
+            metrics: Master::get_metrics()?,
             has_apply_worker: !testing,
         };
 
@@ -142,11 +142,30 @@ impl JournalLoader {
             });
         }
 
-        loader
+        Ok(loader)
     }
 
-    fn get_ufs_applied(&self) -> AppliedIndex {
-        self.fsm_state.lock().unwrap().ufs_applied.clone()
+    fn fsm_state(&self) -> CommonResult<MutexGuard<'_, FsmState>> {
+        match self.fsm_state.lock() {
+            Ok(state) => Ok(state),
+            Err(e) => err_box!("fsm_state lock poisoned: {}", e),
+        }
+    }
+
+    fn fsm_state_snapshot(&self) -> CommonResult<FsmState> {
+        Ok(self.fsm_state()?.clone())
+    }
+
+    fn get_ufs_applied(&self) -> CommonResult<AppliedIndex> {
+        Ok(self.fsm_state()?.ufs_applied.clone())
+    }
+
+    fn abort_on_fatal_apply_error(message: impl AsRef<str>) -> ! {
+        error!(
+            "fatal journal apply error: {}; aborting master to avoid serving inconsistent metadata",
+            message.as_ref()
+        );
+        std::process::abort();
     }
 
     fn set_applied(
@@ -160,7 +179,7 @@ impl JournalLoader {
                 .log_ufs_applied(applied.op_id, applied.term, applied.index)?;
         }
 
-        let mut state = self.fsm_state.lock().unwrap();
+        let mut state = self.fsm_state()?;
         if is_leader {
             state.ufs_applied = applied.clone();
             state.applied = applied;
@@ -199,7 +218,7 @@ impl JournalLoader {
             return Ok(());
         }
 
-        let cur = self.get_fsm_state();
+        let cur = self.fsm_state_snapshot()?;
         let role_applied = ternary!(is_leader, cur.ufs_applied.index, cur.applied.index);
         if entry.index <= role_applied {
             info!(
@@ -292,7 +311,7 @@ impl JournalLoader {
             ApplyMsg::Scan(applied_index) => {
                 let mut last_applied = applied_index.index;
                 if is_leader && skip_ufs_error {
-                    last_applied = last_applied.max(self.get_fsm_state().ufs_applied.index);
+                    last_applied = last_applied.max(self.fsm_state_snapshot()?.ufs_applied.index);
                 }
 
                 let commit_index = self.log_store.hard_state().commit;
@@ -325,7 +344,7 @@ impl JournalLoader {
                 }
             }
 
-            _ => unreachable!(),
+            _ => err_box!("unsupported apply message in journal loader apply_msg"),
         }
     }
 
@@ -372,7 +391,15 @@ impl JournalLoader {
                 ApplyMsg::RoleChange(role) => {
                     is_leader = role == StateRole::Leader;
                     if is_leader {
-                        let ufs_applied = self.get_ufs_applied();
+                        let ufs_applied = match self.get_ufs_applied() {
+                            Ok(ufs_applied) => ufs_applied,
+                            Err(e) => {
+                                Self::abort_on_fatal_apply_error(format!(
+                                    "failed to read fsm_state after leader role change: {}",
+                                    e
+                                ));
+                            }
+                        };
                         info!("role changed to leader, scheduling UFS replay scan from ufs_applied: {:?}", ufs_applied);
                         retry_msg.replace(ApplyMsg::new_scan(ufs_applied));
                     }
@@ -402,27 +429,30 @@ impl JournalLoader {
                                     if let Err(skip_error) =
                                         self.apply_msg(is_leader, &msg, true).await
                                     {
-                                        panic!(
+                                        Self::abort_on_fatal_apply_error(format!(
                                             "apply entry failed while skipping failed UFS replay: {}",
                                             skip_error
-                                        );
+                                        ));
                                     }
                                     retry_num = 0;
                                     if continue_scan {
                                         retry_msg.replace(msg);
                                     }
                                 } else {
-                                    panic!(
+                                    Self::abort_on_fatal_apply_error(format!(
                                         "apply entry failed(retry_num={}): {}",
                                         retry_num, error
-                                    );
+                                    ));
                                 }
                             } else {
                                 error!("apply entry failed(retry_num={}): {}", retry_num, error);
                                 retry_msg.replace(msg);
                             }
                         } else {
-                            panic!("apply entry failed: {}", error);
+                            Self::abort_on_fatal_apply_error(format!(
+                                "apply entry failed on follower: {}",
+                                error
+                            ));
                         }
                     }
                 },
@@ -431,7 +461,7 @@ impl JournalLoader {
     }
 
     fn create_snapshot0(&self, dir_option: Option<String>) -> RaftResult<SnapshotData> {
-        let fsm_state = self.get_fsm_state();
+        let fsm_state = self.fsm_state_snapshot()?;
         let fs_dir = self.fs_dir.read();
         let dir = match dir_option {
             Some(dir) => dir,
@@ -487,10 +517,10 @@ impl JournalLoader {
         let restore_ms = spend.used_ms();
         spend.reset();
 
-        self.mnt_mgr.restore();
+        self.mnt_mgr.restore_best_effort();
         let mount_ms = spend.used_ms();
 
-        *self.fsm_state.lock().unwrap() = snapshot.fsm_state;
+        *self.fsm_state()? = snapshot.fsm_state;
 
         info!(
             "apply_snapshot: fs_dir_restore={} ms, mount_restore={} ms, total={} ms",
@@ -693,7 +723,7 @@ impl JournalLoader {
     }
 
     pub fn unmount(&self, entry: UnMountEntry) -> CommonResult<()> {
-        if !self.mnt_mgr.has_mounted(entry.id) {
+        if !self.mnt_mgr.has_mounted(entry.id)? {
             warn!("Unmount: id already unmounted: {:?}", entry);
             return Ok(());
         }
@@ -768,7 +798,7 @@ impl JournalLoader {
     }
 
     pub fn ufs_applied(&self, entry: UfsAppliedEntry) -> CommonResult<()> {
-        let mut lock = self.fsm_state.lock().unwrap();
+        let mut lock = self.fsm_state()?;
         lock.ufs_applied = AppliedIndex {
             op_id: entry.op_id,
             rpc_id: entry.rpc_id,
@@ -807,8 +837,8 @@ impl JournalLoader {
         let keep = self.retain_checkpoint_num.saturating_sub(1);
         let del_num = vec.len().saturating_sub(keep);
 
-        for i in 0..del_num {
-            let path = vec[i].1.as_path();
+        for (_, path) in vec.iter().take(del_num) {
+            let path = path.as_path();
             FileUtils::delete_path(path, true)?;
             info!("delete expired checkpoint: {}", path.to_string_lossy());
         }
@@ -844,7 +874,13 @@ impl AppStorage for JournalLoader {
     }
 
     fn get_fsm_state(&self) -> FsmState {
-        self.fsm_state.lock().unwrap().clone()
+        match self.fsm_state.lock() {
+            Ok(state) => state.clone(),
+            Err(e) => {
+                error!("fatal fsm_state lock poisoned: {}", e);
+                std::process::abort();
+            }
+        }
     }
 
     async fn role_change(&self, role: StateRole) -> RaftResult<()> {

--- a/curvine-server/src/master/journal/journal_system.rs
+++ b/curvine-server/src/master/journal/journal_system.rs
@@ -97,13 +97,13 @@ impl JournalSystem {
         rt: Arc<Runtime>,
         master_monitor: MasterMonitor,
     ) -> FsResult<FsInitParts> {
-        let worker_manager = SyncWorkerManager::new(WorkerManager::new(conf));
+        let worker_manager = SyncWorkerManager::new(WorkerManager::new(conf)?);
         let client = RaftClient::from_conf(rt.clone(), &conf.journal);
-        let journal_writer = Arc::new(JournalWriter::new(conf.testing, client, &conf.journal));
+        let journal_writer = Arc::new(JournalWriter::new(conf.testing, client, &conf.journal)?);
 
         let ttl_bucket_list = Arc::new(TtlBucketList::new(
             conf.master.ttl_bucket_interval_ms() as i64
-        ));
+        )?);
         let eviction_conf = EvictionConf::from_conf(conf);
         let evictor: Arc<dyn Evictor> = match eviction_conf.policy {
             EvictionPolicy::Lru => Arc::new(LRUEvictor::new(eviction_conf.clone())),
@@ -284,7 +284,7 @@ impl JournalSystem {
                 parts.job_manager.clone(),
                 log_store,
                 parts.journal_writer.clone(),
-            ),
+            )?,
             conf.journal.clone(),
             role_monitor,
         );

--- a/curvine-server/src/master/journal/journal_writer.rs
+++ b/curvine-server/src/master/journal/journal_writer.rs
@@ -42,27 +42,29 @@ pub struct JournalWriter {
 }
 
 impl JournalWriter {
-    pub fn new(testing: bool, client: RaftClient, conf: &JournalConf) -> Self {
+    pub fn new(testing: bool, client: RaftClient, conf: &JournalConf) -> FsResult<Self> {
+        let node_id = conf.node_id()?;
+        let metrics = Master::get_metrics()?;
         let (sender, receiver) = BlockingChannel::new(conf.writer_channel_size).split();
 
         let receiver = if !testing {
             // Start the send log thread.
-            let task = SenderTask::new(client, conf, 0);
-            task.spawn(receiver).unwrap();
+            let task = SenderTask::new(client, conf, 0)?;
+            task.spawn(receiver)?;
             None
         } else {
             Some(Mutex::new(receiver))
         };
 
-        Self {
+        Ok(Self {
             enable: conf.enable,
-            node_id: conf.node_id().unwrap(),
+            node_id,
             sender,
-            metrics: Master::get_metrics(),
+            metrics,
             receiver,
             snapshot_entries: conf.snapshot_entries,
             entries_since_snapshot: AtomicCounter::new(0),
-        }
+        })
     }
 
     fn send_inner(&self, entry: JournalEntry) -> FsResult<()> {
@@ -332,7 +334,16 @@ impl JournalWriter {
     // for testing
     pub fn take_entries(&self) -> Vec<JournalEntry> {
         let mut entries = vec![];
-        let receiver = self.receiver.as_ref().unwrap().lock().unwrap();
+        let Some(receiver) = self.receiver.as_ref() else {
+            return entries;
+        };
+        let receiver = match receiver.lock() {
+            Ok(receiver) => receiver,
+            Err(e) => {
+                log::error!("failed to take journal entries: {}", e);
+                return entries;
+            }
+        };
         while let Ok(v) = receiver.try_recv() {
             entries.push(v);
         }

--- a/curvine-server/src/master/journal/sender_task.rs
+++ b/curvine-server/src/master/journal/sender_task.rs
@@ -19,8 +19,8 @@ use curvine_common::raft::RaftClient;
 use curvine_common::utils::SerdeUtils;
 use curvine_common::FsResult;
 use orpc::common::{LocalTime, TimeSpent};
-use orpc::err_box;
 use orpc::sync::channel::BlockingReceiver;
+use orpc::CommonResult;
 use std::sync::mpsc::RecvTimeoutError;
 use std::thread;
 use std::time::Duration;
@@ -35,17 +35,17 @@ pub struct SenderTask {
 }
 
 impl SenderTask {
-    pub fn new(client: RaftClient, conf: &JournalConf, batch_seq_id: u64) -> Self {
+    pub fn new(client: RaftClient, conf: &JournalConf, batch_seq_id: u64) -> CommonResult<Self> {
         let sender = Self {
             client,
             batch: JournalBatch::new(batch_seq_id),
             flush_batch_ms: conf.writer_flush_batch_ms,
             flush_batch_size: conf.writer_flush_batch_size,
             last_flush_ms: LocalTime::mills(),
-            metrics: Master::get_metrics(),
+            metrics: Master::get_metrics()?,
         };
 
-        sender
+        Ok(sender)
     }
 
     // Start a thread to execute sender task
@@ -55,7 +55,8 @@ impl SenderTask {
         let task = self;
         thread::Builder::new().name(name.clone()).spawn(move || {
             if let Err(e) = Self::loop0(receiver, poll, task) {
-                panic!("thread {} stop: {:?}", name, e);
+                log::error!("thread {} stop: {:?}; aborting master", name, e);
+                std::process::abort();
             }
         })?;
         Ok(())
@@ -71,7 +72,10 @@ impl SenderTask {
             let event = match receiver.recv_timeout(poll) {
                 Ok(v) => Some(v),
                 Err(RecvTimeoutError::Timeout) => None,
-                Err(e) => return err_box!("event loop: {}", e),
+                Err(RecvTimeoutError::Disconnected) => {
+                    task.flush_pending()?;
+                    return Ok(());
+                }
             };
             task.handle(event)?;
         }
@@ -92,24 +96,35 @@ impl SenderTask {
             return Ok(());
         }
 
-        if force
-            || len >= self.flush_batch_size
-            || LocalTime::mills() - self.last_flush_ms >= self.flush_batch_ms
-        {
-            let spend = TimeSpent::new();
-
-            let bytes = SerdeUtils::serialize(&self.batch)?;
-            self.client.block_on_send_propose(bytes)?;
-
-            self.metrics.journal_flush_count.inc();
-            self.metrics
-                .journal_flush_time
-                .inc_by(spend.used_us() as i64);
-
-            // Scroll to the next batch.
-            self.batch.next();
-            self.last_flush_ms = LocalTime::mills();
+        if force || len >= self.flush_batch_size || self.flush_interval_elapsed() {
+            self.flush_pending()?;
         }
+
+        Ok(())
+    }
+
+    fn flush_interval_elapsed(&self) -> bool {
+        LocalTime::mills() - self.last_flush_ms >= self.flush_batch_ms
+    }
+
+    fn flush_pending(&mut self) -> FsResult<()> {
+        if self.batch.is_empty() {
+            return Ok(());
+        }
+
+        let spend = TimeSpent::new();
+
+        let bytes = SerdeUtils::serialize(&self.batch)?;
+        self.client.block_on_send_propose(bytes)?;
+
+        self.metrics.journal_flush_count.inc();
+        self.metrics
+            .journal_flush_time
+            .inc_by(spend.used_us() as i64);
+
+        // Scroll to the next batch.
+        self.batch.next();
+        self.last_flush_ms = LocalTime::mills();
 
         Ok(())
     }

--- a/curvine-server/src/master/master_handler.rs
+++ b/curvine-server/src/master/master_handler.rs
@@ -57,11 +57,12 @@ impl MasterHandler {
         mount_manager: Arc<MountManager>,
         job_handler: JobHandler,
         replication_manager: Arc<MasterReplicationManager>,
+        metrics: &'static MasterMetrics,
     ) -> Self {
         Self {
             fs,
             retry_cache,
-            metrics: Master::get_metrics(),
+            metrics,
             audit_logging_enabled: conf.master.audit_logging_enabled,
             conn_state,
             mount_manager,
@@ -572,7 +573,7 @@ impl MasterHandler {
         let header: MetricsReportRequest = ctx.parse_header()?;
 
         let metrics = ProtoUtils::metrics_report_from_pb(header.metrics);
-        Master::get_metrics().metrics_report(metrics)?;
+        Master::get_metrics()?.metrics_report(metrics)?;
 
         ctx.response_buf(MetricsReportResponse {}, &mut self.buf)
     }

--- a/curvine-server/src/master/master_server.rs
+++ b/curvine-server/src/master/master_server.rs
@@ -45,9 +45,11 @@ pub struct MasterService {
     job_manager: Arc<JobManager>,
     rt: Arc<Runtime>,
     replication_manager: Arc<MasterReplicationManager>,
+    metrics: &'static MasterMetrics,
 }
 
 impl MasterService {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         conf: ClusterConf,
         fs: MasterFilesystem,
@@ -56,6 +58,7 @@ impl MasterService {
         job_manager: Arc<JobManager>,
         rt: Arc<Runtime>,
         replication_manager: Arc<MasterReplicationManager>,
+        metrics: &'static MasterMetrics,
     ) -> Self {
         Self {
             conf,
@@ -65,6 +68,7 @@ impl MasterService {
             job_manager,
             rt,
             replication_manager,
+            metrics,
         }
     }
 
@@ -101,6 +105,7 @@ impl HandlerService for MasterService {
             self.mount_manager.clone(),
             JobHandler::new(self.job_manager.clone()),
             self.replication_manager.clone(),
+            self.metrics,
         )
     }
 }
@@ -109,15 +114,15 @@ impl WebHandlerService for MasterService {
     type Item = MasterRouterHandler;
 
     fn get_handler(&self) -> Self::Item {
-        MasterRouterHandler::new(self.conf.clone(), self.fs.clone())
+        MasterRouterHandler::new(self.conf.clone(), self.fs.clone(), self.metrics)
     }
 }
 
 pub struct Master {
     pub start_time: u64,
-    rpc_server: RpcServer<MasterService>,
-    web_server: WebServer<MasterService>,
-    journal_system: JournalSystem,
+    rpc_server: Option<RpcServer<MasterService>>,
+    web_server: Option<WebServer<MasterService>>,
+    journal_system: Option<JournalSystem>,
     actor: MasterActor,
     mount_manager: Arc<MountManager>,
     job_manager: Arc<JobManager>,
@@ -132,7 +137,7 @@ impl Master {
         }
 
         Logger::init(log);
-        MASTER_METRICS.get_or_init(|| MasterMetrics::new().unwrap());
+        let metrics = MASTER_METRICS.get_or_try_init(MasterMetrics::new)?;
         conf.print();
 
         // step1: Create a journal system, the journal system determines how to create a fs dir.
@@ -145,7 +150,7 @@ impl Master {
 
         let rt = Arc::new(conf.master_server_conf().create_runtime());
 
-        let replication_manager = MasterReplicationManager::new(&fs, &conf, &rt, &worker_manager);
+        let replication_manager = MasterReplicationManager::new(&fs, &conf, &rt, &worker_manager)?;
 
         let actor = MasterActor::new(
             fs.clone(),
@@ -156,7 +161,7 @@ impl Master {
         );
 
         // step3: Create rpc server.
-        let retry_cache = FsRetryCache::with_conf(&conf.master);
+        let retry_cache = FsRetryCache::with_conf(&conf.master)?;
         let service = MasterService::new(
             conf.clone(),
             fs,
@@ -165,6 +170,7 @@ impl Master {
             job_manager.clone(),
             rt.clone(),
             replication_manager.clone(),
+            metrics,
         );
 
         let rpc_conf = conf.master_server_conf();
@@ -176,9 +182,9 @@ impl Master {
 
         Ok(Self {
             start_time: LocalTime::mills(),
-            rpc_server,
-            web_server,
-            journal_system,
+            rpc_server: Some(rpc_server),
+            web_server: Some(web_server),
+            journal_system: Some(journal_system),
             actor,
             mount_manager,
             job_manager,
@@ -190,61 +196,77 @@ impl Master {
         Self::new(conf)
     }
 
-    pub async fn start(mut self) -> ServerStateListener {
+    pub async fn start(&mut self) -> CommonResult<ServerStateListener> {
         // step 1: Start journal_system, raft server and raft node will be started internally
-        let mut listener = self.journal_system.start().await.unwrap();
-        listener.wait_role().await.unwrap();
+        let journal_system = self
+            .journal_system
+            .take()
+            .expect("master journal system must be initialized before startup");
+        let mut listener = journal_system.start().await?;
+        listener.wait_role().await?;
 
         // step 2: Start rpc server
-        let mut rpc_status = self.rpc_server.start();
-        rpc_status.wait_running().await.unwrap();
+        let rpc_server = self
+            .rpc_server
+            .take()
+            .expect("master rpc server must be initialized before startup");
+        let mut rpc_status = rpc_server.start();
+        rpc_status.wait_running().await?;
 
         // step3: Start the web server
-        let web_name = self.web_server.server_name().to_string();
-        let bind_addr = self.web_server.resolve_bind_addr();
-        let mut web_status = self.web_server.start();
-        WebServer::<MasterService>::wait_bind(&mut web_status, &web_name, &bind_addr)
-            .await
-            .unwrap();
+        let web_server = self
+            .web_server
+            .take()
+            .expect("master web server must be initialized before startup");
+        let web_name = web_server.server_name().to_string();
+        let bind_addr = web_server.resolve_bind_addr();
+        let mut web_status = web_server.start();
+        WebServer::<MasterService>::wait_bind(&mut web_status, &web_name, &bind_addr).await?;
 
         // step4: Start master actor
-        self.actor.start();
+        self.actor.start()?;
 
         // reload mount info
-        self.mount_manager.restore();
+        self.mount_manager.restore_best_effort();
 
         // step5: Start job manager
-        self.job_manager.start();
+        self.job_manager.start()?;
 
         // step6: Start TTL scheduler (requires mount_manager and job_manager)
         if let Err(e) = self.actor.start_ttl_scheduler() {
             error!("Failed to start inode ttl scheduler: {}", e);
         }
 
-        rpc_status
+        Ok(rpc_status)
     }
 
-    pub fn block_on_start(self) {
-        let rt = self.rpc_server.clone_rt();
-        rt.block_on(async move {
-            let mut status = self.start().await;
-            status.wait_stop().await.unwrap();
-        });
+    pub fn block_on_start(mut self) -> CommonResult<()> {
+        let rt = self
+            .rpc_server
+            .as_ref()
+            .expect("master rpc server must be initialized before startup")
+            .clone_rt();
+        let mut status = rt.block_on(async { self.start().await })?;
+        rt.block_on(async { status.wait_stop().await })
     }
 
-    pub fn get_metrics<'a>() -> &'a MasterMetrics {
-        MASTER_METRICS.get().expect("Master get metrics error!")
+    pub fn get_metrics<'a>() -> CommonResult<&'a MasterMetrics> {
+        MASTER_METRICS.get_or_try_init(MasterMetrics::new)
     }
 
     // Instantiate metrics during testing
     pub fn init_test_metrics() {
-        let metrics = MasterMetrics::new().unwrap();
-        MASTER_METRICS.get_or_init(|| metrics);
+        let _ = Self::get_metrics();
     }
 
     // for test
     pub fn get_fs(&self) -> MasterFilesystem {
-        self.rpc_server.service().fs.clone()
+        self.rpc_server
+            .as_ref()
+            .expect("master rpc server must be initialized")
+            .service()
+            .fs
+            .clone()
     }
 
     // for test
@@ -253,6 +275,9 @@ impl Master {
     }
 
     pub fn service(&self) -> &MasterService {
-        self.rpc_server.service()
+        self.rpc_server
+            .as_ref()
+            .expect("master rpc server must be initialized")
+            .service()
     }
 }

--- a/curvine-server/src/master/meta/fs_dir.rs
+++ b/curvine-server/src/master/meta/fs_dir.rs
@@ -55,7 +55,7 @@ impl FsDir {
         let db_conf = conf.db_conf();
 
         let store = RocksInodeStore::new(db_conf, conf.format_master)?;
-        let state = InodeStore::new(store, ttl_bucket_list);
+        let state = InodeStore::new(store, ttl_bucket_list)?;
         let (last_inode_id, root_dir) = state.create_blank_tree()?;
 
         let fs_dir = Self {
@@ -443,7 +443,7 @@ impl FsDir {
         };
 
         let status = match inode.as_ref() {
-            File(..) | Dir(..) => inode.to_file_status(inp.path()),
+            File(..) | Dir(..) => inode.to_file_status(inp.path())?,
             FileEntry(..) => {
                 return err_box!("FileEntry is not supported");
             }
@@ -459,7 +459,7 @@ impl FsDir {
         };
 
         match inode.as_ref() {
-            File(_) => Ok(vec![inode.to_file_status(inp.path())]),
+            File(_) => Ok(vec![inode.to_file_status(inp.path())?]),
 
             Dir(d) => {
                 let iter = d.children_iter().collect();
@@ -470,7 +470,7 @@ impl FsDir {
             FileEntry(e) => {
                 let inode_opt = self.store.get_inode(e.id, Some(&e.name))?;
                 match inode_opt {
-                    Some(inode_view) => Ok(vec![inode_view.to_file_status(inp.path())]),
+                    Some(inode_view) => Ok(vec![inode_view.to_file_status(inp.path())?]),
                     None => err_ext!(FsError::file_not_found(inp.path())),
                 }
             }
@@ -497,7 +497,7 @@ impl FsDir {
 
         match inode.as_ref() {
             File(_) => {
-                let status = inode.to_file_status(inp.path());
+                let status = inode.to_file_status(inp.path())?;
                 Ok(Self::list_single_file(status, opts))
             }
 
@@ -511,7 +511,7 @@ impl FsDir {
                 let inode_opt = self.store.get_inode(e.id, Some(&e.name))?;
                 match inode_opt {
                     Some(inode_view) => {
-                        let status = inode_view.to_file_status(inp.path());
+                        let status = inode_view.to_file_status(inp.path())?;
                         Ok(Self::list_single_file(status, opts))
                     }
                     None => err_ext!(FsError::file_not_found(inp.path())),
@@ -527,7 +527,7 @@ impl FsDir {
         choose_workers: &[WorkerAddress],
         file_len: i64,
     ) -> FsResult<ExtendedBlock> {
-        let mut inode = try_option!(inp.get_last_inode());
+        let mut inode = try_option!(inp.get_last_inode(), "File {} not exists", inp.path());
         let file = inode.as_file_mut()?;
 
         let new_block_id = file.next_block_id()?;
@@ -561,7 +561,7 @@ impl FsDir {
         client_name: impl AsRef<str>,
         only_flush: bool,
     ) -> FsResult<bool> {
-        let mut inode = try_option!(inp.get_last_inode());
+        let mut inode = try_option!(inp.get_last_inode(), "File {} not exists", inp.path());
         let file = inode.as_file_mut()?;
         file.complete(len, &commit_block, client_name, only_flush)?;
 
@@ -620,7 +620,7 @@ impl FsDir {
 
         let file = inode.as_file_mut()?;
         let _ = file.reopen(client_name);
-        let status = inode.to_file_status(inp.path());
+        let status = inode.to_file_status(inp.path())?;
 
         self.store.apply_reopen_file(&inode)?;
         self.journal_writer
@@ -692,13 +692,13 @@ impl FsDir {
         self.root_dir.print_tree()
     }
 
-    pub fn sum_hash(&self) -> u128 {
-        let mut tree_hash = self.root_dir.sum_hash();
-        tree_hash += self.store.cf_hash(RocksInodeStore::CF_INODES);
-        tree_hash += self.store.cf_hash(RocksInodeStore::CF_EDGES);
-        tree_hash += self.store.cf_hash(RocksInodeStore::CF_LOCATION);
-        tree_hash += self.store.cf_hash(RocksInodeStore::CF_BLOCK);
-        tree_hash
+    pub fn sum_hash(&self) -> CommonResult<u128> {
+        let mut tree_hash = self.root_dir.sum_hash()?;
+        tree_hash += self.store.cf_hash(RocksInodeStore::CF_INODES)?;
+        tree_hash += self.store.cf_hash(RocksInodeStore::CF_EDGES)?;
+        tree_hash += self.store.cf_hash(RocksInodeStore::CF_LOCATION)?;
+        tree_hash += self.store.cf_hash(RocksInodeStore::CF_BLOCK)?;
+        Ok(tree_hash)
     }
 
     pub fn last_inode_id(&self) -> i64 {
@@ -841,7 +841,7 @@ impl FsDir {
 
         self.unprotected_set_attr(inode.clone(), opts.clone())?;
         self.journal_writer.log_set_attr(self, &inp, opts)?;
-        Ok(inode.to_file_status(inp.path()))
+        Ok(inode.to_file_status(inp.path())?)
     }
 
     pub fn unprotected_set_attr(&mut self, inode: InodePtr, opts: SetAttrOpts) -> FsResult<()> {
@@ -860,7 +860,7 @@ impl FsDir {
                 } else {
                     opts.clone()
                 };
-                cur_inode.as_mut().set_attr(set_opts);
+                cur_inode.as_mut().set_attr(set_opts)?;
                 change_inodes.push(cur_inode.as_ref().clone());
             }
 
@@ -1076,7 +1076,7 @@ impl FsDir {
         block_id: i64,
         workers: &[WorkerAddress],
     ) -> FsResult<ExtendedBlock> {
-        let mut inode = try_option!(inp.get_last_inode());
+        let mut inode = try_option!(inp.get_last_inode(), "File {} not exists", inp.path());
         let file = inode.as_file_mut()?;
 
         let block = file.search_block_mut_check(block_id)?;

--- a/curvine-server/src/master/meta/fs_stats.rs
+++ b/curvine-server/src/master/meta/fs_stats.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::master::{Master, MasterMetrics};
+use orpc::CommonResult;
 
 /// File system statistics tracker for maintaining real-time counts
 /// of files and directories without expensive traversal operations.
@@ -22,10 +23,10 @@ pub struct FileSystemStats {
 }
 
 impl FileSystemStats {
-    pub fn new() -> Self {
-        Self {
-            metrics: Master::get_metrics(),
-        }
+    pub fn new() -> CommonResult<Self> {
+        Ok(Self {
+            metrics: Master::get_metrics()?,
+        })
     }
 
     pub fn increment_file_count(&self) {
@@ -58,11 +59,5 @@ impl FileSystemStats {
     pub fn set_counts(&self, file_count: i64, dir_count: i64) {
         self.metrics.inode_file_num.set(file_count);
         self.metrics.inode_dir_num.set(dir_count);
-    }
-}
-
-impl Default for FileSystemStats {
-    fn default() -> Self {
-        Self::new()
     }
 }

--- a/curvine-server/src/master/meta/inode/inode_path.rs
+++ b/curvine-server/src/master/meta/inode/inode_path.rs
@@ -36,7 +36,11 @@ impl InodePath {
         store: &InodeStore,
     ) -> CommonResult<Self> {
         let components = InodeView::path_components(path.as_ref())?;
-        let name = try_option!(components.last());
+        let name = try_option!(
+            components.last(),
+            "Path {} has no components",
+            path.as_ref()
+        );
 
         if name.is_empty() {
             return err_box!("Path {} is invalid", path.as_ref());
@@ -213,9 +217,10 @@ impl InodePath {
                     // Check the child node name is a glob pattern or not
                     let (is_glob_pattern, glob_pattern) = parse_glob_pattern(child_name_str);
                     if is_glob_pattern {
-                        if let Some(children) =
-                            d.get_child_ptr_by_glob_pattern(&glob_pattern.unwrap())
-                        {
+                        let Some(glob_pattern) = glob_pattern else {
+                            return err_box!("invalid glob pattern: {}", child_name_str);
+                        };
+                        if let Some(children) = d.get_child_ptr_by_glob_pattern(&glob_pattern) {
                             for child_ptr in children.iter() {
                                 parent_map.insert(
                                     child_ptr.as_ref().id(),

--- a/curvine-server/src/master/meta/inode/inode_view.rs
+++ b/curvine-server/src/master/meta/inode/inode_view.rs
@@ -19,7 +19,6 @@ use crate::master::meta::inode::InodeView::{Dir, File, FileEntry};
 use crate::master::meta::inode::{
     Inode, InodeDir, InodeFile, InodePtr, PATH_SEPARATOR, ROOT_INODE_ID,
 };
-use core::panic;
 use curvine_common::state::{FileStatus, FileType, SetAttrOpts, StoragePolicy, TtlAction};
 use curvine_common::utils::SerdeUtils;
 use orpc::common::{LocalTime, Utils};
@@ -333,91 +332,82 @@ impl InodeView {
         }
     }
 
-    pub fn acl(&self) -> &AclFeature {
+    pub fn acl(&self) -> CommonResult<&AclFeature> {
         match self {
-            File(f) => &f.features.acl,
-            Dir(d) => &d.features.acl,
+            File(f) => Ok(&f.features.acl),
+            Dir(d) => Ok(&d.features.acl),
+            FileEntry(..) => err_box!("FileEntry does not support ACL access: {}", self.name()),
+        }
+    }
+
+    pub fn acl_mut(&mut self) -> CommonResult<&mut AclFeature> {
+        match self {
+            File(f) => Ok(&mut f.features.acl),
+            Dir(d) => Ok(&mut d.features.acl),
+            FileEntry(..) => err_box!("FileEntry does not support mutable ACL access"),
+        }
+    }
+
+    pub fn storage_policy(&self) -> CommonResult<&StoragePolicy> {
+        match self {
+            File(f) => Ok(&f.storage_policy),
+            Dir(d) => Ok(&d.storage_policy),
             FileEntry(..) => {
-                panic!("FileEntry does not support ACL access")
+                err_box!(
+                    "FileEntry does not support storage policy access: {}",
+                    self.name()
+                )
             }
         }
     }
 
-    pub fn acl_mut(&mut self) -> &mut AclFeature {
+    pub fn storage_policy_mut(&mut self) -> CommonResult<&mut StoragePolicy> {
         match self {
-            File(f) => &mut f.features.acl,
-            Dir(d) => &mut d.features.acl,
-            FileEntry(..) => {
-                panic!("FileEntry does not support mutable ACL access")
-            }
+            File(f) => Ok(&mut f.storage_policy),
+            Dir(d) => Ok(&mut d.storage_policy),
+            FileEntry(..) => err_box!("FileEntry does not support mutable storage policy access"),
         }
     }
 
-    pub fn storage_policy(&self) -> &StoragePolicy {
-        match self {
-            File(f) => &f.storage_policy,
-            Dir(d) => &d.storage_policy,
-            FileEntry(..) => {
-                panic!("FileEntry does not support storage policy access")
-            }
-        }
-    }
-
-    pub fn storage_policy_mut(&mut self) -> &mut StoragePolicy {
-        match self {
-            File(f) => &mut f.storage_policy,
-            Dir(d) => &mut d.storage_policy,
-            FileEntry(..) => {
-                panic!("FileEntry does not support mutable storage policy access")
-            }
-        }
-    }
-
-    pub fn expiration_ms(&self) -> Option<i64> {
-        let sp = self.storage_policy();
+    pub fn expiration_ms(&self) -> CommonResult<Option<i64>> {
+        let sp = self.storage_policy()?;
         if sp.ttl_ms > 0 && sp.ttl_action != TtlAction::None {
-            Some(self.mtime().saturating_add(sp.ttl_ms))
+            Ok(Some(self.mtime().saturating_add(sp.ttl_ms)))
         } else {
-            None
+            Ok(None)
         }
     }
 
-    pub fn is_expired(&self) -> bool {
-        let sp = self.storage_policy();
+    pub fn is_expired(&self) -> CommonResult<bool> {
+        let sp = self.storage_policy()?;
         if sp.ttl_action != TtlAction::None && sp.ttl_ms > 0 {
-            LocalTime::mills() as i64 > self.mtime().saturating_add(sp.ttl_ms)
+            Ok(LocalTime::mills() as i64 > self.mtime().saturating_add(sp.ttl_ms))
         } else {
-            false
+            Ok(false)
         }
     }
 
-    pub fn x_attr(&self) -> &HashMap<String, Vec<u8>> {
+    pub fn x_attr(&self) -> CommonResult<&HashMap<String, Vec<u8>>> {
         match self {
-            File(f) => &f.features.x_attr,
-            Dir(d) => &d.features.x_attr,
-            FileEntry(..) => {
-                panic!("FileEntry does not support x_attr access")
-            }
+            File(f) => Ok(&f.features.x_attr),
+            Dir(d) => Ok(&d.features.x_attr),
+            FileEntry(..) => err_box!("FileEntry does not support x_attr access: {}", self.name()),
         }
     }
 
-    pub fn x_attr_mut(&mut self) -> &mut HashMap<String, Vec<u8>> {
+    pub fn x_attr_mut(&mut self) -> CommonResult<&mut HashMap<String, Vec<u8>>> {
         match self {
-            File(f) => &mut f.features.x_attr,
-            Dir(d) => &mut d.features.x_attr,
-            FileEntry(..) => {
-                panic!("FileEntry does not support mutable x_attr access")
-            }
+            File(f) => Ok(&mut f.features.x_attr),
+            Dir(d) => Ok(&mut d.features.x_attr),
+            FileEntry(..) => err_box!("FileEntry does not support mutable x_attr access"),
         }
     }
 
-    pub fn nlink(&self) -> u32 {
+    pub fn nlink(&self) -> CommonResult<u32> {
         match self {
-            File(f) => f.nlink(),
-            Dir(d) => d.nlink(),
-            FileEntry(_) => {
-                panic!("FileEntry does not support nlink")
-            }
+            File(f) => Ok(f.nlink()),
+            Dir(d) => Ok(d.nlink()),
+            FileEntry(_) => err_box!("FileEntry does not support nlink: {}", self.name()),
         }
     }
 
@@ -425,17 +415,17 @@ impl InodeView {
         InodePtr::from_ref(self)
     }
 
-    pub fn set_attr(&mut self, opts: SetAttrOpts) {
+    pub fn set_attr(&mut self, opts: SetAttrOpts) -> CommonResult<()> {
         if let Some(owner) = opts.owner {
-            self.acl_mut().owner = owner;
+            self.acl_mut()?.owner = owner;
         }
 
         if let Some(group) = opts.group {
-            self.acl_mut().group = group;
+            self.acl_mut()?.group = group;
         }
 
         if let Some(mode) = opts.mode {
-            self.acl_mut().mode = mode;
+            self.acl_mut()?.mode = mode;
         }
 
         // Handle time modifications
@@ -456,79 +446,87 @@ impl InodeView {
         }
 
         if let Some(ttl_ms) = opts.ttl_ms {
-            self.storage_policy_mut().ttl_ms = ttl_ms;
+            self.storage_policy_mut()?.ttl_ms = ttl_ms;
         }
 
         if let Some(ttl_action) = opts.ttl_action {
-            if self.storage_policy_mut().ttl_action != TtlAction::Free {
-                self.storage_policy_mut().ttl_action = ttl_action;
+            let storage_policy = self.storage_policy_mut()?;
+            if storage_policy.ttl_action != TtlAction::Free {
+                storage_policy.ttl_action = ttl_action;
             }
         }
 
         for attr in opts.add_x_attr {
-            self.x_attr_mut().insert(attr.0, attr.1);
+            self.x_attr_mut()?.insert(attr.0, attr.1);
         }
 
         for key in opts.remove_x_attr {
-            let _ = self.x_attr_mut().remove(&key);
+            let _ = self.x_attr_mut()?.remove(&key);
         }
 
         if let Some(ufs_mtime) = opts.ufs_mtime {
             if self.is_file() {
-                self.storage_policy_mut().save_ufs(ufs_mtime);
+                self.storage_policy_mut()?.save_ufs(ufs_mtime);
             }
         }
+
+        Ok(())
     }
 
-    pub fn to_file_status(&self, path: &str) -> FileStatus {
-        let acl = self.acl();
-        let mut status = FileStatus {
-            id: self.id(),
-            path: path.to_owned(),
-            name: self.name().to_owned(),
-            is_dir: self.is_dir(),
-            mtime: self.mtime(),
-            atime: self.atime(),
-            children_num: self.child_len() as i32,
-            is_complete: false,
-            len: 0,
-            replicas: 0,
-            block_size: 0,
-            file_type: FileType::File,
-            x_attr: Default::default(),
-            storage_policy: Default::default(),
-            owner: acl.owner.to_owned(),
-            group: acl.group.to_owned(),
-            mode: acl.mode,
-            nlink: self.nlink(),
-            target: None,
-        };
-
+    pub fn to_file_status(&self, path: &str) -> CommonResult<FileStatus> {
         match self {
             File(f) => {
-                status.is_complete = f.is_complete();
-                status.len = f.len;
-                status.replicas = f.replicas as i32;
-                status.block_size = f.block_size as i64;
-                status.file_type = f.file_type;
-                status.x_attr = f.features.x_attr.clone();
-                status.storage_policy = f.storage_policy.clone();
-                status.target = f.target.clone();
+                let acl = &f.features.acl;
+                Ok(FileStatus {
+                    id: self.id(),
+                    path: path.to_owned(),
+                    name: self.name().to_owned(),
+                    is_dir: false,
+                    mtime: self.mtime(),
+                    atime: self.atime(),
+                    children_num: 0,
+                    is_complete: f.is_complete(),
+                    len: f.len,
+                    replicas: f.replicas as i32,
+                    block_size: f.block_size as i64,
+                    file_type: f.file_type,
+                    x_attr: f.features.x_attr.clone(),
+                    storage_policy: f.storage_policy.clone(),
+                    owner: acl.owner.to_owned(),
+                    group: acl.group.to_owned(),
+                    mode: acl.mode,
+                    nlink: f.nlink(),
+                    target: f.target.clone(),
+                })
             }
 
             Dir(d) => {
-                status.file_type = FileType::Dir;
-                status.len = d.children_len() as i64;
-                status.x_attr = d.features.x_attr.clone();
-                status.storage_policy = d.storage_policy.clone();
+                let acl = &d.features.acl;
+                Ok(FileStatus {
+                    id: self.id(),
+                    path: path.to_owned(),
+                    name: self.name().to_owned(),
+                    is_dir: true,
+                    mtime: self.mtime(),
+                    atime: self.atime(),
+                    children_num: self.child_len() as i32,
+                    is_complete: false,
+                    len: d.children_len() as i64,
+                    replicas: 0,
+                    block_size: 0,
+                    file_type: FileType::Dir,
+                    x_attr: d.features.x_attr.clone(),
+                    storage_policy: d.storage_policy.clone(),
+                    owner: acl.owner.to_owned(),
+                    group: acl.group.to_owned(),
+                    mode: acl.mode,
+                    nlink: d.nlink(),
+                    target: None,
+                })
             }
 
-            FileEntry(_) => {
-                panic!("FileEntry does not support to_file_status");
-            }
+            FileEntry(_) => err_box!("FileEntry does not support to_file_status: {}", self.name()),
         }
-
-        status
     }
 
     /// Print directory structure, output is the same as the linux tree command
@@ -570,17 +568,15 @@ impl InodeView {
         }
     }
 
-    pub fn sum_hash(&self) -> u128 {
+    pub fn sum_hash(&self) -> CommonResult<u128> {
         let mut res: u128 = 0;
         let mut stack = LinkedList::new();
         stack.push_back(self);
 
         while let Some(v) = stack.pop_front() {
-            let bytes = SerdeUtils::serialize(&v).unwrap();
+            let bytes = SerdeUtils::serialize(&v)?;
             if !v.is_root() {
                 let hash = Utils::crc32(&bytes) as u128;
-                // let inode: InodeView = SerdeUtils::deserialize(&bytes).unwrap();
-                // info!("id = {}[{}], detail = {:?}", inode.id(), hash, inode);
                 res += hash
             }
 
@@ -589,7 +585,7 @@ impl InodeView {
             }
         }
 
-        res
+        Ok(res)
     }
 }
 

--- a/curvine-server/src/master/meta/inode/ttl/ttl_bucket.rs
+++ b/curvine-server/src/master/meta/inode/ttl/ttl_bucket.rs
@@ -15,6 +15,7 @@
 use crate::master::meta::inode::InodeView;
 use log::{debug, info, warn};
 use orpc::common::FastHashSet;
+use orpc::{err_box, CommonResult};
 use parking_lot::Mutex;
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -85,19 +86,22 @@ pub struct TtlBucketList {
 }
 
 impl TtlBucketList {
-    pub fn new(interval_duration_ms: i64) -> Self {
+    pub fn new(interval_duration_ms: i64) -> CommonResult<Self> {
         if interval_duration_ms <= 0 {
-            panic!("interval_duration_ms must be positive");
+            return err_box!(
+                "ttl bucket interval_duration_ms must be positive, actual {}",
+                interval_duration_ms
+            );
         }
 
         info!(
             "Creating TTL bucket list with sorted storage, interval duration: {}ms",
             interval_duration_ms
         );
-        Self {
+        Ok(Self {
             buckets: Arc::new(Mutex::new(BTreeMap::new())),
             interval_duration_ms,
-        }
+        })
     }
 
     pub fn total_inodes(&self) -> u64 {
@@ -141,7 +145,15 @@ impl TtlBucketList {
             return;
         }
 
-        if let Some(expiration_ms) = inode.expiration_ms() {
+        let expiration_ms = match inode.expiration_ms() {
+            Ok(Some(expiration_ms)) => expiration_ms,
+            Ok(None) => return,
+            Err(e) => {
+                warn!("ttl_bucket: skip add for inode {}: {}", inode.id(), e);
+                return;
+            }
+        };
+        {
             let bucket = self.get_or_create_bucket(expiration_ms);
             bucket.add(inode.id());
 
@@ -163,15 +175,19 @@ impl TtlBucketList {
             return false;
         }
 
-        if let Some(expiration_ms) = inode.expiration_ms() {
-            let interval_start = self.get_bucket_interval_start(expiration_ms);
-            if let Some(bucket) = self.buckets.lock().get(&interval_start) {
-                let res = bucket.remove(inode.id());
-                debug!("removed inode {} from sorted TTL bucket list", inode.id());
-                res
-            } else {
-                false
+        let expiration_ms = match inode.expiration_ms() {
+            Ok(Some(expiration_ms)) => expiration_ms,
+            Ok(None) => return false,
+            Err(e) => {
+                warn!("ttl_bucket: skip remove for inode {}: {}", inode.id(), e);
+                return false;
             }
+        };
+        let interval_start = self.get_bucket_interval_start(expiration_ms);
+        if let Some(bucket) = self.buckets.lock().get(&interval_start) {
+            let res = bucket.remove(inode.id());
+            debug!("removed inode {} from sorted TTL bucket list", inode.id());
+            res
         } else {
             false
         }
@@ -214,9 +230,13 @@ mod tests {
         InodeView::new_file("t".to_string(), InodeFile::new(id, mtime))
     }
 
+    fn ttl_bucket_list() -> TtlBucketList {
+        TtlBucketList::new(INTERVAL_MS).expect("valid ttl bucket interval")
+    }
+
     #[test]
     fn add_skips_when_ttl_disabled() {
-        let list = TtlBucketList::new(INTERVAL_MS);
+        let list = ttl_bucket_list();
         list.add(&file_no_ttl(1, 0));
         assert_eq!(list.total_inodes(), 0);
         assert_eq!(list.buckets_len(), 0);
@@ -224,7 +244,7 @@ mod tests {
 
     #[test]
     fn add_places_inode_in_quantized_bucket() {
-        let list = TtlBucketList::new(INTERVAL_MS);
+        let list = ttl_bucket_list();
         // expiration = mtime + ttl_ms = 100 + 500 = 600 -> interval_start 0
         list.add(&file_with_ttl(42, 100, 500));
         assert_eq!(list.total_inodes(), 1);
@@ -233,7 +253,7 @@ mod tests {
 
     #[test]
     fn add_same_interval_merges_into_one_bucket() {
-        let list = TtlBucketList::new(INTERVAL_MS);
+        let list = ttl_bucket_list();
         list.add(&file_with_ttl(1, 0, 400)); // exp 400 -> start 0
         list.add(&file_with_ttl(2, 50, 350)); // exp 400 -> start 0
         assert_eq!(list.total_inodes(), 2);
@@ -242,7 +262,7 @@ mod tests {
 
     #[test]
     fn add_different_intervals_use_multiple_buckets() {
-        let list = TtlBucketList::new(INTERVAL_MS);
+        let list = ttl_bucket_list();
         list.add(&file_with_ttl(1, 0, 500)); // exp 500 -> start 0
         list.add(&file_with_ttl(2, 500, 1000)); // exp 1500 -> start 1000
         assert_eq!(list.total_inodes(), 2);
@@ -251,7 +271,7 @@ mod tests {
 
     #[test]
     fn remove_drops_inode_from_bucket() {
-        let list = TtlBucketList::new(INTERVAL_MS);
+        let list = ttl_bucket_list();
         let f = file_with_ttl(7, 0, 100);
         list.add(&f);
         assert_eq!(list.total_inodes(), 1);
@@ -261,14 +281,14 @@ mod tests {
 
     #[test]
     fn remove_unknown_returns_false() {
-        let list = TtlBucketList::new(INTERVAL_MS);
+        let list = ttl_bucket_list();
         let f = file_with_ttl(9, 0, 100);
         assert!(!list.remove(&f));
     }
 
     #[test]
     fn get_expired_buckets_at_drains_and_matches_time_rule() {
-        let list = TtlBucketList::new(INTERVAL_MS);
+        let list = ttl_bucket_list();
         list.add(&file_with_ttl(1, 0, 500)); // exp 500, bucket [0, INTERVAL_MS)
 
         let now = 2000_i64;
@@ -283,7 +303,7 @@ mod tests {
 
     #[test]
     fn get_expired_buckets_at_empty_when_not_yet_expired() {
-        let list = TtlBucketList::new(INTERVAL_MS);
+        let list = ttl_bucket_list();
         // exp = 0 + 10_000 = 10_000 -> interval_start 10_000
         list.add(&file_with_ttl(1, 0, 10_000));
 

--- a/curvine-server/src/master/meta/inode/ttl/ttl_executor.rs
+++ b/curvine-server/src/master/meta/inode/ttl/ttl_executor.rs
@@ -103,11 +103,11 @@ impl InodeTtlExecutor {
             return err_box!("Inode {} not found", inode_id);
         };
 
-        if !inode.is_expired() {
+        if !inode.is_expired()? {
             return Ok((false, inode));
         }
 
-        let action = inode.storage_policy().ttl_action;
+        let action = inode.storage_policy()?.ttl_action;
 
         debug!(
             "Executing ttl action {:?} for inode {} based on StoragePolicy",

--- a/curvine-server/src/master/meta/store/inode_store.rs
+++ b/curvine-server/src/master/meta/store/inode_store.rs
@@ -101,12 +101,12 @@ pub struct InodeStore {
 }
 
 impl InodeStore {
-    pub fn new(store: RocksInodeStore, ttl_bucket_list: Arc<TtlBucketList>) -> Self {
-        InodeStore {
+    pub fn new(store: RocksInodeStore, ttl_bucket_list: Arc<TtlBucketList>) -> CommonResult<Self> {
+        Ok(InodeStore {
             store: Arc::new(store),
-            fs_stats: Arc::new(FileSystemStats::new()),
+            fs_stats: Arc::new(FileSystemStats::new()?),
             ttl_bucket_list,
-        }
+        })
     }
 
     pub fn get_ttl_bucket_list(&self) -> Arc<TtlBucketList> {
@@ -492,7 +492,7 @@ impl InodeStore {
         let edges_iter = self.store.bulk_scan_edges()?;
         for item in edges_iter {
             let (key, value) = try_err!(item);
-            let (parent_id, child_name) = RocksUtils::i64_str_from_bytes(&key).unwrap();
+            let (parent_id, child_name) = RocksUtils::i64_str_from_bytes(&key)?;
             let child_id = RocksUtils::i64_from_bytes(&value)?;
             edges
                 .entry(parent_id)
@@ -620,8 +620,7 @@ impl InodeStore {
                 // Check for duplicate directory edge BEFORE removing from inodes.
                 // A directory can only have one parent; if we've already seen this
                 // directory id, the current edge is a duplicate and must be deleted.
-                if dir_edges.contains_key(child_id) {
-                    let (old_parent_id, old_name) = dir_edges.get(child_id).unwrap();
+                if let Some((old_parent_id, old_name)) = dir_edges.get(child_id) {
                     log::warn!(
                         "create_tree: directory inode {} has multiple parent edges: keeping parent {} name '{}', dropping parent {} name '{}'",
                         child_id, old_parent_id, old_name, parent_id, edge_name
@@ -770,7 +769,7 @@ impl InodeStore {
                 scan_inodes.push((index, RocksUtils::i64_to_bytes(inode.id())));
             } else {
                 let child_path = inp.child_path(inode.name());
-                out[index] = inode.to_file_status(&child_path);
+                out[index] = inode.to_file_status(&child_path)?;
             }
         }
 
@@ -781,8 +780,18 @@ impl InodeStore {
         let keys = scan_inodes.iter().map(|x| &x.1);
         let batch_res = self.store.batched_multi_get_inodes(keys, false)?;
         for (i, item) in batch_res.into_iter().enumerate() {
-            let index = try_option!(scan_inodes.get(i)).0;
-            let file_entry = try_option!(list.get(index));
+            let index = try_option!(
+                scan_inodes.get(i),
+                "batched_get_inodes: missing scan entry for batch result index {}",
+                i
+            )
+            .0;
+            let file_entry = try_option!(
+                list.get(index),
+                "batched_get_inodes: file entry index {} out of range, list len {}",
+                index,
+                list.len()
+            );
 
             if let Some(bytes) = try_err!(item) {
                 let mut inode: InodeView = SerdeUtils::deserialize(bytes.as_ref())?;
@@ -797,7 +806,7 @@ impl InodeStore {
 
                 inode.change_name(file_entry.name().to_owned());
                 let child_path = inp.child_path(file_entry.name());
-                out[index] = inode.to_file_status(&child_path);
+                out[index] = inode.to_file_status(&child_path)?;
             } else {
                 return err_box!(
                     "batched_get_inodes: inode missing in store path {}, id {}",
@@ -810,15 +819,15 @@ impl InodeStore {
         Ok(out)
     }
 
-    pub fn cf_hash(&self, cf: &str) -> u128 {
-        let iter = self.store.iter_cf(cf).unwrap();
+    pub fn cf_hash(&self, cf: &str) -> CommonResult<u128> {
+        let iter = self.store.iter_cf(cf)?;
         let mut hash = 0;
         for inode in iter {
-            let kv = inode.unwrap();
+            let kv = inode?;
             hash += Utils::crc32(kv.0.as_ref()) as u128;
             hash += Utils::crc32(kv.1.as_ref()) as u128;
         }
-        hash
+        Ok(hash)
     }
 
     pub fn create_checkpoint(&self, id: u64) -> CommonResult<String> {
@@ -916,7 +925,7 @@ mod tests {
             Utils::rand_str(6)
         )));
         let rocks = RocksInodeStore::new(conf, true)?;
-        Ok(InodeStore::new(rocks, Arc::new(TtlBucketList::new(60_000))))
+        InodeStore::new(rocks, Arc::new(TtlBucketList::new(60_000)?))
     }
 
     #[test]

--- a/curvine-server/src/master/meta/store/rocks_inode_store.rs
+++ b/curvine-server/src/master/meta/store/rocks_inode_store.rs
@@ -174,7 +174,7 @@ impl RocksInodeStore {
 
     pub fn add_mountpoint(&self, id: u32, entry: &MountInfo) -> CommonResult<()> {
         let key = RocksUtils::u8_u32_to_bytes(Self::PREFIX_MOUNT, id);
-        let value = Serde::serialize(entry).unwrap();
+        let value = Serde::serialize(entry)?;
         self.db.put_cf(Self::CF_COMMON, key, value)
     }
 
@@ -192,7 +192,7 @@ impl RocksInodeStore {
             None => Ok(None),
 
             Some(v) => {
-                let info: MountInfo = Serde::deserialize(&v)?;
+                let info = MountInfo::decode_persisted(&v)?;
                 Ok(Some(info))
             }
         }
@@ -203,7 +203,7 @@ impl RocksInodeStore {
         let mut vec = Vec::with_capacity(8);
         for item in iter {
             let bytes = item?;
-            let mnt = Serde::deserialize::<MountInfo>(&bytes.1)?;
+            let mnt = MountInfo::decode_persisted(&bytes.1)?;
             vec.push(mnt);
         }
 
@@ -250,7 +250,10 @@ impl Iterator for InodeChildrenIter<'_> {
                 Err(e) => Some(Err(e.into())),
 
                 Ok(bytes) => {
-                    let id = RocksUtils::i64_from_bytes(&bytes.1).unwrap();
+                    let id = match RocksUtils::i64_from_bytes(&bytes.1) {
+                        Ok(id) => id,
+                        Err(e) => return Some(Err(e)),
+                    };
                     Some(Ok(id))
                 }
             }

--- a/curvine-server/src/master/mount/mount_manager.rs
+++ b/curvine-server/src/master/mount/mount_manager.rs
@@ -21,7 +21,7 @@ use curvine_common::fs::{self, CurvineURI, Path};
 use curvine_common::state::{MkdirOpts, MountInfo, MountOptions};
 use curvine_common::FsResult;
 use log::info;
-use orpc::{err_box, err_msg, try_option};
+use orpc::err_box;
 use std::collections::HashMap;
 
 pub struct MountManager {
@@ -39,8 +39,12 @@ impl MountManager {
     }
 
     /// recovery mount points from store
-    pub fn restore(&self) {
-        self.mount_table.restore();
+    pub fn restore(&self) -> FsResult<()> {
+        self.mount_table.restore()
+    }
+
+    pub fn restore_best_effort(&self) {
+        self.mount_table.restore_best_effort()
     }
 
     fn create_mount_point(&self, mount_path: &str) -> FsResult<bool> {
@@ -78,7 +82,9 @@ impl MountManager {
 
     fn update_mount(&self, cv_path: &str, mnt_opt: &MountOptions) -> FsResult<()> {
         let path = Path::from_str(cv_path)?;
-        let existing = try_option!(self.get_mount_info(&path)?);
+        let Some(existing) = self.get_mount_info(&path)? else {
+            return err_box!("mount point {} not found for update", cv_path);
+        };
         let merged = existing.merge_with(mnt_opt.clone());
 
         self.mount_table.update_mount(merged)
@@ -119,7 +125,7 @@ impl MountManager {
         self.mount_table.unprotected_umount_by_id(id)
     }
 
-    pub fn has_mounted(&self, id: u32) -> bool {
+    pub fn has_mounted(&self, id: u32) -> FsResult<bool> {
         self.mount_table.has_mounted(id)
     }
 

--- a/curvine-server/src/master/mount/mount_table.rs
+++ b/curvine-server/src/master/mount/mount_table.rs
@@ -17,12 +17,12 @@ use curvine_common::conf::{UfsConf, UfsConfBuilder};
 use curvine_common::fs::Path;
 use curvine_common::state::{MountInfo, MountOptions};
 use curvine_common::FsResult;
-use log::info;
-use orpc::{err_box, try_option};
+use log::{info, warn};
+use orpc::err_box;
 use rand::Rng;
 use std::collections::HashMap;
 use std::convert::Into;
-use std::sync::RwLock;
+use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 pub struct MountTableInner {
     ufs2mountid: HashMap<String, u32>,
@@ -47,29 +47,84 @@ impl MountTable {
         }
     }
 
+    fn read_inner(&self) -> FsResult<RwLockReadGuard<'_, MountTableInner>> {
+        match self.inner.read() {
+            Ok(inner) => Ok(inner),
+            Err(e) => err_box!("mount table read lock poisoned: {}", e),
+        }
+    }
+
+    fn write_inner(&self) -> FsResult<RwLockWriteGuard<'_, MountTableInner>> {
+        match self.inner.write() {
+            Ok(inner) => Ok(inner),
+            Err(e) => err_box!("mount table write lock poisoned: {}", e),
+        }
+    }
+
     //for new master node
-    pub fn restore(&self) {
-        if let Ok(mounts) = self.fs_dir.read().get_mount_table() {
-            for mnt in mounts {
-                self.unprotected_add_mount(mnt).unwrap();
+    pub fn restore(&self) -> FsResult<()> {
+        let mounts = self.fs_dir.read().get_mount_table()?;
+        self.replace_with_mounts(mounts)
+    }
+
+    pub fn restore_best_effort(&self) {
+        match self.fs_dir.read().get_mount_table() {
+            Ok(mounts) => {
+                if let Err(e) = self.replace_with_mounts(mounts) {
+                    warn!("failed to restore mount table: {}", e);
+                }
+            }
+            Err(e) => {
+                warn!("failed to restore mount table: {}", e);
             }
         }
     }
 
+    fn replace_with_mounts(&self, mounts: Vec<MountInfo>) -> FsResult<()> {
+        let mut restored = MountTableInner {
+            ufs2mountid: HashMap::new(),
+            mountid2entry: HashMap::new(),
+            mountpath2id: HashMap::new(),
+        };
+
+        for mnt in mounts {
+            if restored
+                .ufs2mountid
+                .insert(mnt.ufs_path.to_string(), mnt.mount_id)
+                .is_some()
+            {
+                return err_box!("duplicate restored UFS mount path {}", mnt.ufs_path);
+            }
+            if restored
+                .mountpath2id
+                .insert(mnt.cv_path.to_string(), mnt.mount_id)
+                .is_some()
+            {
+                return err_box!("duplicate restored CV mount path {}", mnt.cv_path);
+            }
+            if restored.mountid2entry.insert(mnt.mount_id, mnt).is_some() {
+                return err_box!("duplicate restored mount id");
+            }
+        }
+
+        *self.write_inner()? = restored;
+        Ok(())
+    }
+
     // ufs maybe mounted already or has prefix overlap with existing mounts
-    pub fn exists(&self, ufs_path: &str) -> bool {
-        let inner = self.inner.read().unwrap();
+    pub fn exists(&self, ufs_path: &str) -> FsResult<bool> {
+        let inner = self.read_inner()?;
 
         // full match check
         if inner.ufs2mountid.contains_key(ufs_path) {
-            return true;
+            return Ok(true);
         }
 
-        false
+        Ok(false)
     }
 
     pub fn check_conflict(&self, cv_path: &str, ufs_path: &str) -> FsResult<()> {
-        let inner = self.inner.read().unwrap();
+        let inner = self.read_inner()?;
         for info in inner.mountid2entry.values() {
             if Path::has_prefix(cv_path, &info.cv_path) {
                 return err_box!("mount point {} is a prefix of {}", info.cv_path, cv_path);
@@ -91,21 +146,21 @@ impl MountTable {
     }
 
     // mountid maybe occupied
-    pub fn has_mounted(&self, mount_id: u32) -> bool {
-        let inner = self.inner.read().unwrap();
-        inner.mountid2entry.contains_key(&mount_id)
+    pub fn has_mounted(&self, mount_id: u32) -> FsResult<bool> {
+        let inner = self.read_inner()?;
+        Ok(inner.mountid2entry.contains_key(&mount_id))
     }
 
     // mount_path maybe mounted by other ufs
-    fn mount_point_inuse(&self, cv_path: &str) -> bool {
-        let inner = self.inner.read().unwrap();
-        inner.mountpath2id.contains_key(cv_path)
+    fn mount_point_inuse(&self, cv_path: &str) -> FsResult<bool> {
+        let inner = self.read_inner()?;
+        Ok(inner.mountpath2id.contains_key(cv_path))
     }
 
     pub fn unprotected_add_mount(&self, info: MountInfo) -> FsResult<()> {
         info!("add mount: {:?}", info);
 
-        let mut inner = self.inner.write().unwrap();
+        let mut inner = self.write_inner()?;
         inner
             .ufs2mountid
             .insert(info.ufs_path.to_string(), info.mount_id);
@@ -124,11 +179,11 @@ impl MountTable {
         ufs_path: &str,
         mnt_opt: &MountOptions,
     ) -> FsResult<()> {
-        if self.exists(ufs_path) {
+        if self.exists(ufs_path)? {
             return err_box!("{} already exists in mount table", ufs_path);
         }
 
-        if self.mount_point_inuse(cv_path) {
+        if self.mount_point_inuse(cv_path)? {
             return err_box!("{} already exists in mount table", cv_path);
         }
 
@@ -159,7 +214,7 @@ impl MountTable {
         let mut rng = rand::thread_rng();
         for _ in 0..10 {
             let new_id = rng.gen::<u32>();
-            if !self.has_mounted(new_id) {
+            if !self.has_mounted(new_id)? {
                 return Ok(new_id);
             }
         }
@@ -168,7 +223,7 @@ impl MountTable {
     }
 
     pub fn umount(&self, mount_path: &str) -> FsResult<()> {
-        let mut inner = self.inner.write().unwrap();
+        let mut inner = self.write_inner()?;
 
         let mount_id = match inner.mountpath2id.get(mount_path) {
             Some(&id) => id,
@@ -192,7 +247,7 @@ impl MountTable {
 
     /// use ufs_uri to find ufs config
     pub fn get_ufs_conf(&self, ufs_path: &String) -> FsResult<UfsConf> {
-        let inner = self.inner.read().unwrap();
+        let inner = self.read_inner()?;
 
         let mount_id = match inner.ufs2mountid.get(ufs_path) {
             Some(&id) => id,
@@ -215,7 +270,7 @@ impl MountTable {
     pub fn get_mount_info(&self, path: &Path) -> FsResult<Option<MountInfo>> {
         let list = path.get_possible_mounts();
         let is_cv = path.is_cv();
-        let inner = self.inner.read().unwrap();
+        let inner = self.read_inner()?;
 
         for mnt in list {
             let option_id = if is_cv {
@@ -224,7 +279,13 @@ impl MountTable {
                 inner.ufs2mountid.get(&mnt)
             };
             if let Some(id) = option_id {
-                let entry = try_option!(inner.mountid2entry.get(id));
+                let Some(entry) = inner.mountid2entry.get(id) else {
+                    return err_box!(
+                        "mount table corrupt: path {} references missing mount id {}",
+                        mnt,
+                        id
+                    );
+                };
                 return Ok(Some(entry.clone()));
             }
         }
@@ -233,7 +294,7 @@ impl MountTable {
     }
 
     pub fn get_mount_info_by_id(&self, mount_id: u32) -> FsResult<MountInfo> {
-        let inner = self.inner.read().unwrap();
+        let inner = self.read_inner()?;
         let entry = match inner.mountid2entry.get(&mount_id) {
             Some(entry) => entry.clone(),
             None => return err_box!("failed found {} entry", mount_id),
@@ -242,13 +303,13 @@ impl MountTable {
     }
 
     pub fn get_mount_table(&self) -> FsResult<Vec<MountInfo>> {
-        let inner = self.inner.read().unwrap();
+        let inner = self.read_inner()?;
         let table = inner.mountid2entry.values().cloned().collect();
         Ok(table)
     }
 
     pub fn unprotected_umount_by_id(&self, mount_id: u32) -> FsResult<()> {
-        let mut inner = self.inner.write().unwrap();
+        let mut inner = self.write_inner()?;
 
         let info = match inner.mountid2entry.remove(&mount_id) {
             Some(entry) => entry,

--- a/curvine-server/src/master/quota/eviction/evictor.rs
+++ b/curvine-server/src/master/quota/eviction/evictor.rs
@@ -18,6 +18,14 @@ use std::sync::Mutex;
 use crate::master::quota::eviction::lfu;
 use crate::master::quota::eviction::types::EvictionConf;
 
+const DEFAULT_EVICTION_CACHE_CAPACITY: usize = 5_000_000;
+
+fn eviction_cache_capacity(configured_capacity: usize) -> NonZeroUsize {
+    NonZeroUsize::new(configured_capacity).unwrap_or_else(|| {
+        NonZeroUsize::new(DEFAULT_EVICTION_CACHE_CAPACITY).unwrap_or(NonZeroUsize::MIN)
+    })
+}
+
 pub trait Evictor: Send + Sync {
     fn on_access(&self, inode_id: i64);
     fn select_victims(&self, limit: usize) -> Vec<i64>;
@@ -32,8 +40,7 @@ pub struct LRUEvictor {
 
 impl LRUEvictor {
     pub fn new(conf: EvictionConf) -> Self {
-        let capacity = NonZeroUsize::new(conf.capacity)
-            .unwrap_or_else(|| NonZeroUsize::new(5_000_000).unwrap());
+        let capacity = eviction_cache_capacity(conf.capacity);
 
         Self {
             caches: Mutex::new(lru::LruCache::new(capacity)),
@@ -98,8 +105,7 @@ pub struct LFUEvictor {
 
 impl LFUEvictor {
     pub fn new(conf: EvictionConf) -> Self {
-        let capacity = NonZeroUsize::new(conf.capacity)
-            .unwrap_or_else(|| NonZeroUsize::new(5_000_000).unwrap());
+        let capacity = eviction_cache_capacity(conf.capacity);
 
         Self {
             caches: Mutex::new(lfu::LFUCache::new(capacity.get())),

--- a/curvine-server/src/master/quota/quota_manager.rs
+++ b/curvine-server/src/master/quota/quota_manager.rs
@@ -88,7 +88,13 @@ impl QuotaManager {
         }
 
         // Update LRU cache size metric
-        let metrics = Master::get_metrics();
+        let metrics = match Master::get_metrics() {
+            Ok(metrics) => metrics,
+            Err(e) => {
+                log::warn!("cluster-evict: master metrics unavailable: {}", e);
+                return;
+            }
+        };
         metrics
             .eviction_lru_cache_size
             .set(self.evictor.cache_size() as i64);
@@ -213,7 +219,13 @@ impl QuotaManager {
             return;
         };
 
-        let metrics = Master::get_metrics();
+        let metrics = match Master::get_metrics() {
+            Ok(metrics) => metrics,
+            Err(e) => {
+                log::warn!("cluster-evict: master metrics unavailable: {}", e);
+                return;
+            }
+        };
         let mut successfully_evicted = Vec::with_capacity(inode_ids.len());
         let mut total_bytes_freed = 0_i64;
 

--- a/curvine-server/src/master/replication/master_replication_manager.rs
+++ b/curvine-server/src/master/replication/master_replication_manager.rs
@@ -64,7 +64,7 @@ impl MasterReplicationManager {
         conf: &ClusterConf,
         rt: &Arc<AsyncRuntime>,
         worker_manager: &SyncWorkerManager,
-    ) -> Arc<Self> {
+    ) -> CommonResult<Arc<Self>> {
         let async_runtime = rt.clone();
         let semaphore = Semaphore::new(conf.master.block_replication_concurrency_limit);
         let (send, recv) = tokio::sync::mpsc::channel(Semaphore::MAX_PERMITS);
@@ -77,13 +77,13 @@ impl MasterReplicationManager {
             inflight_blocks: Default::default(),
             worker_client_factory: Arc::new(Default::default()),
             replication_enabled: conf.master.block_replication_enabled,
-            metrics: Master::get_metrics(),
+            metrics: Master::get_metrics()?,
         };
         let manager = Arc::new(manager);
         Self::handle(async_runtime, manager.clone(), recv);
 
         info!("Master replication manager is initialized");
-        manager
+        Ok(manager)
     }
 
     fn handle(async_runtime: Arc<AsyncRuntime>, me: Arc<Self>, mut recv: Receiver<BlockId>) {
@@ -91,13 +91,13 @@ impl MasterReplicationManager {
         async_runtime.spawn(async move {
             let manager = fork;
             while let Some(block_id) = recv.recv().await {
-                // todo: graceful handle the acquire error
-                let permit = manager
-                    .replication_semaphore
-                    .clone()
-                    .acquire_owned()
-                    .await
-                    .unwrap();
+                let permit = match manager.replication_semaphore.clone().acquire_owned().await {
+                    Ok(permit) => permit,
+                    Err(e) => {
+                        error!("Block replication loop stopped: semaphore closed: {}", e);
+                        break;
+                    }
+                };
                 if let Err(e) = manager.replicate_block(block_id, permit).await {
                     error!("Failed to replicate block: {}. err: {}", block_id, e);
                 }
@@ -118,10 +118,16 @@ impl MasterReplicationManager {
     fn assign(&self, exclusive_worker_ids: Vec<WorkerId>) -> CommonResult<WorkerAddress> {
         let worker_manager = self.worker_manager.read();
         let mut assignment = worker_manager.choose_workers(1, exclusive_worker_ids)?;
-        let worker_id = try_option!(assignment.pop()).worker_id;
-        let worker_addr = try_option!(worker_manager.get_worker(worker_id))
-            .address
-            .clone();
+        let Some(worker_id) = assignment.pop().map(|worker| worker.worker_id) else {
+            return err_box!("no target worker selected for block replication");
+        };
+        let Some(worker) = worker_manager.get_worker(worker_id) else {
+            return err_box!(
+                "selected replication target worker {} no longer exists",
+                worker_id
+            );
+        };
+        let worker_addr = worker.address.clone();
         Ok(worker_addr)
     }
 

--- a/curvine-server/src/master/router_handler.rs
+++ b/curvine-server/src/master/router_handler.rs
@@ -28,35 +28,36 @@ use orpc::common::LocalTime;
 use orpc::err_box;
 
 use crate::master::fs::MasterFilesystem;
-use crate::master::Master;
+use crate::master::MasterMetrics;
 
 #[derive(Clone)]
 pub struct MasterRouterHandler {
     fs: MasterFilesystem,
     conf: ClusterConf,
     start_time: String,
+    metrics: &'static MasterMetrics,
 }
 
 impl MasterRouterHandler {
-    pub fn new(conf: ClusterConf, fs: MasterFilesystem) -> Self {
+    pub fn new(conf: ClusterConf, fs: MasterFilesystem, metrics: &'static MasterMetrics) -> Self {
         Self {
             fs,
             conf,
             start_time: LocalTime::now_datetime(),
+            metrics,
         }
     }
 }
 
-fn get_report(fs: MasterFilesystem) -> HashMap<String, String> {
-    let metrics = Master::get_metrics();
-    let output = metrics.text_output(fs).unwrap();
+fn get_report(fs: MasterFilesystem, metrics: &MasterMetrics) -> FsResult<HashMap<String, String>> {
+    let output = metrics.text_output(fs)?;
     let report = output
         .lines()
         .filter(|line| !line.starts_with("#"))
-        .map(|line| {
+        .filter_map(|line| {
             let mut parts = line.split_whitespace();
-            let name = parts.next().unwrap();
-            let value = parts.next().unwrap();
+            let name = parts.next()?;
+            let value = parts.next()?;
             let value = match name {
                 "capacity" | "available" | "fs_used" => {
                     let v = value.parse::<f64>().unwrap_or(0.0);
@@ -66,26 +67,26 @@ fn get_report(fs: MasterFilesystem) -> HashMap<String, String> {
                 _ => value.to_string(),
             };
             let name = name.to_string();
-            (name, value)
+            Some((name, value))
         })
         .collect();
-    report
+    Ok(report)
 }
 
-async fn metrics(Extension(instance): Extension<Arc<MasterRouterHandler>>) -> String {
-    let metrics = Master::get_metrics();
-    metrics.text_output(instance.fs.clone()).unwrap()
+async fn metrics(Extension(instance): Extension<Arc<MasterRouterHandler>>) -> FsResult<String> {
+    Ok(instance.metrics.text_output(instance.fs.clone())?)
 }
 
-async fn report(Extension(instance): Extension<Arc<MasterRouterHandler>>) -> String {
-    let report = get_report(instance.fs.clone());
-    let available = &report.get("available").unwrap();
-    let capacity = &report.get("capacity").unwrap();
-    let fs_used = &report.get("fs_used").unwrap();
-    let dir_total = &report.get("inode_dir_num").unwrap();
-    let files_total = &report.get("inode_file_num").unwrap();
-    let live_workers = &report.get("live_workers").unwrap();
-    let lost_workers = &report.get("lost_workers").unwrap();
+async fn report(Extension(instance): Extension<Arc<MasterRouterHandler>>) -> FsResult<String> {
+    let report = get_report(instance.fs.clone(), instance.metrics)?;
+    let metric = |key: &str| report.get(key).map(String::as_str).unwrap_or("N/A");
+    let available = metric("available");
+    let capacity = metric("capacity");
+    let fs_used = metric("fs_used");
+    let dir_total = metric("inode_dir_num");
+    let files_total = metric("inode_file_num");
+    let live_workers = metric("live_workers");
+    let lost_workers = metric("lost_workers");
 
     let result = format!(
         r#"Curvine cluster summary:
@@ -98,7 +99,7 @@ async fn report(Extension(instance): Extension<Arc<MasterRouterHandler>>) -> Str
     lost_workers: {lost_workers}
     "#
     );
-    result
+    Ok(result)
 }
 
 async fn overview(
@@ -107,7 +108,7 @@ async fn overview(
     let fs = &instance.fs;
     let conf = &instance.conf;
     let start_time = &instance.start_time;
-    let master_info = fs.master_info().unwrap();
+    let master_info = fs.master_info()?;
 
     let (files_total, dir_total) = {
         let (f, d) = fs.get_file_counts();
@@ -167,7 +168,10 @@ async fn block_locations(
     Query(params): Query<HashMap<String, String>>,
 ) -> FsResult<Json<FileBlocks>> {
     let fs = &instance.fs;
-    let path = params.get("path").expect("not found path");
+    let path = match params.get("path") {
+        Some(path) => path,
+        None => return err_box!("missing required query parameter: path"),
+    };
     let files = fs.get_block_locations(path)?;
     Ok(Json(files))
 }

--- a/curvine-server/src/worker/block/block_actor.rs
+++ b/curvine-server/src/worker/block/block_actor.rs
@@ -29,6 +29,7 @@ use std::sync::Arc;
 /// 1. Register worker with master
 /// 2. Report block information to the master
 /// 3. Accept the master's instructions and delete the block data.
+#[derive(Clone)]
 pub struct BlockActor {
     pub(crate) client: MasterClient,
     store: BlockStore,
@@ -51,13 +52,13 @@ impl BlockActor {
         worker_addr: WorkerAddress,
         store: BlockStore,
         worker_ctl: StateCtl,
-    ) -> BlockActor {
-        let context = FsContext::with_rt(conf.clone(), rt).unwrap();
+    ) -> CommonResult<BlockActor> {
+        let context = FsContext::with_rt(conf.clone(), rt)?;
         let context = Arc::new(context);
         let client = MasterClient::new(
             context.clone(),
-            store.cluster_id(),
-            store.worker_id(),
+            store.cluster_id()?,
+            store.worker_id()?,
             worker_addr,
         );
         let executor = GroupExecutor::new(
@@ -67,7 +68,7 @@ impl BlockActor {
         );
         let heartbeat_interval_ms = conf.master.heartbeat_interval_ms();
         let block_report_limit = conf.master.block_report_limit;
-        Self {
+        Ok(Self {
             client,
             store,
             executor: Arc::new(executor),
@@ -75,17 +76,17 @@ impl BlockActor {
             worker_ctl,
             block_report_limit,
             report_blocks: Arc::new(DashMap::new()),
-        }
+        })
     }
 
-    pub fn start(self) {
+    pub fn start(self) -> CommonResult<()> {
         info!("start block actor");
 
-        self.register().unwrap();
+        self.register()?;
         info!("worker register success");
 
         let spend = TimeSpent::new();
-        let total_len = self.full_block_report().unwrap();
+        let total_len = self.full_block_report()?;
         info!(
             "worker block report success, total blocks {}, used {} ms",
             total_len,
@@ -99,20 +100,20 @@ impl BlockActor {
             self.store.clone(),
             self.report_blocks.clone(),
             self.heartbeat_interval_ms,
-        )
-        .unwrap();
+        )?;
+        Ok(())
     }
 
     // Worker registration.
     pub fn register(&self) -> CommonResult<()> {
-        let storages_info = self.store.get_and_check_storages();
+        let storages_info = self.store.get_and_check_storages()?;
         let result = self.client.heartbeat(HeartbeatStatus::Start, storages_info);
         result?;
         Ok(())
     }
 
     pub fn full_block_report(&self) -> CommonResult<usize> {
-        let blocks = self.store.all_blocks();
+        let blocks = self.store.all_blocks()?;
         if blocks.is_empty() {
             let _ = self.client.full_block_report(0, &[])?;
             return Ok(0);

--- a/curvine-server/src/worker/block/block_meta.rs
+++ b/curvine-server/src/worker/block/block_meta.rs
@@ -14,7 +14,6 @@
 
 use crate::worker::storage::{DirState, VfsDir, ACTIVE_DIR, STAGING_DIR};
 use curvine_common::state::{ExtendedBlock, StorageType};
-use once_cell::sync::Lazy;
 use orpc::common::{ByteUnit, FileUtils};
 use orpc::io::{BlockDevice, IOResult, LocalFile};
 
@@ -24,13 +23,10 @@ use log::info;
 use orpc::io::SpdkBdev;
 
 use orpc::{err_box, sys, try_err, CommonResult};
-use regex::Regex;
 use std::fmt::Formatter;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::{fmt, fs};
-
-static FILE_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"^blk_(\w+)$").unwrap());
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[repr(i8)]
@@ -46,16 +42,11 @@ impl BlockState {
     }
 
     pub fn check_file(file: &str) -> Option<i64> {
-        match FILE_REGEX.captures(file) {
-            None => None,
-            Some(v) => {
-                let id = match v.get(1) {
-                    None => return None,
-                    Some(v) => v.as_str().parse::<i64>().unwrap(),
-                };
-                Some(id)
-            }
+        let id = file.strip_prefix("blk_")?;
+        if id.is_empty() || !id.bytes().all(|b| b.is_ascii_digit()) {
+            return None;
         }
+        id.parse::<i64>().ok()
     }
 }
 

--- a/curvine-server/src/worker/block/block_store.rs
+++ b/curvine-server/src/worker/block/block_store.rs
@@ -36,49 +36,61 @@ impl BlockStore {
         Ok(block_store)
     }
 
-    pub(crate) fn write(&self) -> RwLockWriteGuard<'_, BlockDataset> {
-        self.state.write().unwrap()
+    pub(crate) fn write(&self) -> CommonResult<RwLockWriteGuard<'_, BlockDataset>> {
+        match self.state.write() {
+            Ok(state) => Ok(state),
+            Err(e) => {
+                log::error!("fatal block store write lock poisoned: {}", e);
+                std::process::abort();
+            }
+        }
     }
 
-    pub(crate) fn read(&self) -> RwLockReadGuard<'_, BlockDataset> {
-        self.state.read().unwrap()
+    pub(crate) fn read(&self) -> CommonResult<RwLockReadGuard<'_, BlockDataset>> {
+        match self.state.read() {
+            Ok(state) => Ok(state),
+            Err(e) => {
+                log::error!("fatal block store read lock poisoned: {}", e);
+                std::process::abort();
+            }
+        }
     }
 
     pub fn open_block(&self, block: &ExtendedBlock) -> CommonResult<BlockMeta> {
-        self.write().open_block(block)
+        self.write()?.open_block(block)
     }
 
     pub fn finalize_block(&self, block: &ExtendedBlock) -> CommonResult<BlockMeta> {
-        self.write().finalize_block(block)
+        self.write()?.finalize_block(block)
     }
 
     pub fn abort_block(&self, block: &ExtendedBlock) -> CommonResult<()> {
-        self.write().abort_block(block)
+        self.write()?.abort_block(block)
     }
 
     pub fn get_block(&self, id: i64) -> CommonResult<BlockMeta> {
-        let state = self.read();
+        let state = self.read()?;
         let b = state.get_block_check(id)?;
         Ok(b.clone())
     }
 
-    pub fn worker_id(&self) -> u32 {
-        let state = self.read();
-        state.worker_id()
+    pub fn worker_id(&self) -> CommonResult<u32> {
+        let state = self.read()?;
+        Ok(state.worker_id())
     }
 
-    pub fn cluster_id(&self) -> String {
-        let state = self.read();
-        state.cluster_id().to_string()
+    pub fn cluster_id(&self) -> CommonResult<String> {
+        let state = self.read()?;
+        Ok(state.cluster_id().to_string())
     }
 
-    pub fn all_blocks(&self) -> Vec<BlockMeta> {
-        let state = self.read();
-        state.all_blocks()
+    pub fn all_blocks(&self) -> CommonResult<Vec<BlockMeta>> {
+        let state = self.read()?;
+        Ok(state.all_blocks())
     }
 
     pub fn remove_block(&self, id: i64) -> CommonResult<()> {
-        let mut state = self.write();
+        let mut state = self.write()?;
         let block = ExtendedBlock::with_id(id);
         state.remove_block(&block)
     }
@@ -86,7 +98,7 @@ impl BlockStore {
     // Asynchronously delete block.
     pub fn async_remove_block(&self, id: i64) -> CommonResult<BlockMeta> {
         // Delete the original data.
-        let mut state = self.write();
+        let mut state = self.write()?;
         let meta = state.block_map.remove(&id);
 
         let meta = match meta {
@@ -113,7 +125,7 @@ impl BlockStore {
         }
 
         // Update disk space.
-        let state = self.read();
+        let state = self.read()?;
         let dir = state.find_dir(meta.dir_id())?;
         dir.release_space(meta.is_final(), meta.actual_len);
         drop(state);
@@ -124,8 +136,8 @@ impl BlockStore {
     // Get all storage information and check whether the storage directory is normal.
     // If the directory is not normal, the storage will be marked as failed.
     // This method is called by the heartbeat thread and returns all storage information, including failed storage.
-    pub fn get_and_check_storages(&self) -> Vec<StorageInfo> {
-        let state = self.read();
+    pub fn get_and_check_storages(&self) -> CommonResult<Vec<StorageInfo>> {
+        let state = self.read()?;
         let mut vec = vec![];
         for item in state.dir_iter() {
             let failed = match item.check_dir() {
@@ -152,6 +164,6 @@ impl BlockStore {
             vec.push(info);
         }
 
-        vec
+        Ok(vec)
     }
 }

--- a/curvine-server/src/worker/block/heartbeat_task.rs
+++ b/curvine-server/src/worker/block/heartbeat_task.rs
@@ -50,9 +50,12 @@ impl HeartbeatTask {
                             continue;
                         }
 
+                        if let Err(e) = store
+                            .write()
+                            .map(|state| state.increment_blocks_to_delete())
                         {
-                            let state = store.write();
-                            state.increment_blocks_to_delete();
+                            error!("failed to mark block {} deleting: {}", block, e);
+                            continue;
                         }
 
                         // Whether or not it is successfully deleted, it is marked as deleted
@@ -104,7 +107,13 @@ impl LoopTask for HeartbeatTask {
 
     fn run(&self) -> FsResult<()> {
         // Perform heartbeat sending.
-        let info = self.store.get_and_check_storages();
+        let info = match self.store.get_and_check_storages() {
+            Ok(info) => info,
+            Err(e) => {
+                error!("collect worker storage info failed {}", e);
+                return Ok(());
+            }
+        };
         let res = self.client.heartbeat(HeartbeatStatus::Running, info);
         match res {
             Ok(v) => {

--- a/curvine-server/src/worker/handler/batch_write_handler.rs
+++ b/curvine-server/src/worker/handler/batch_write_handler.rs
@@ -19,10 +19,9 @@ use curvine_common::error::FsError;
 use curvine_common::fs::RpcCode;
 use curvine_common::proto::{
     BlockWriteRequest, BlockWriteResponse, BlocksBatchCommitRequest, BlocksBatchCommitResponse,
-    BlocksBatchWriteRequest, BlocksBatchWriteResponse, FilesBatchWriteRequest,
+    BlocksBatchWriteRequest, BlocksBatchWriteResponse, DataHeaderProto, FilesBatchWriteRequest,
     FilesBatchWriteResponse,
 };
-use curvine_common::state::ExtendedBlock;
 use curvine_common::utils::ProtoUtils;
 use curvine_common::FsResult;
 use orpc::err_box;
@@ -30,56 +29,58 @@ use orpc::handler::MessageHandler;
 use orpc::io::{BlockDevice, BlockIO};
 use orpc::message::{Builder, Message, RequestStatus};
 use orpc::sys::DataSlice;
+use orpc::CommonResult;
 
 pub struct BatchWriteHandler {
     pub(crate) store: BlockStore,
     pub(crate) context: Option<Vec<WriteContext>>,
-    pub(crate) file: Option<Vec<BlockDevice>>,
+    pub(crate) file: Option<Vec<Option<BlockDevice>>>,
     pub(crate) is_commit: bool,
     pub(crate) write_handler: WriteHandler,
 }
 
 impl BatchWriteHandler {
-    pub fn new(store: BlockStore) -> Self {
+    pub fn new(store: BlockStore) -> CommonResult<Self> {
         let store_clone = store.clone();
-        Self {
+        Ok(Self {
             store,
             context: None,
             file: None,
             is_commit: false,
-            write_handler: WriteHandler::new(store_clone),
-        }
+            write_handler: WriteHandler::new(store_clone)?,
+        })
     }
 
-    fn check_context(context: &WriteContext, msg: &Message) -> FsResult<()> {
-        if context.req_id != msg.req_id() {
+    fn check_context(context: &WriteContext, expected_req_id: i64) -> FsResult<()> {
+        if context.req_id != expected_req_id {
             return err_box!(
                 "Request id mismatch, expected {}, actual {}",
                 context.req_id,
-                msg.req_id()
+                expected_req_id
             );
         }
         Ok(())
     }
 
-    fn commit_block(&self, block: &ExtendedBlock, commit: bool) -> FsResult<()> {
-        if commit {
-            self.store.finalize_block(block)?;
-        } else {
-            self.store.abort_block(block)?;
+    fn abort_open_contexts(store: &BlockStore, contexts: &[WriteContext]) {
+        for context in contexts {
+            if let Err(e) = store.abort_block(&context.block) {
+                log::warn!(
+                    "failed to abort batch-opened block {} after open error: {}",
+                    context.block.id,
+                    e
+                );
+            }
         }
-        Ok(())
     }
 
     pub fn open_batch(&mut self, msg: &Message) -> FsResult<Message> {
         let header: BlocksBatchWriteRequest = msg.parse_header()?;
         let mut responses = Vec::with_capacity(header.blocks.len());
+        let mut files = Vec::with_capacity(header.blocks.len());
+        let mut contexts = Vec::with_capacity(header.blocks.len());
 
-        // Initialize ONCE with capacity
-        self.file = Some(Vec::with_capacity(header.blocks.len()));
-        self.context = Some(Vec::with_capacity(header.blocks.len()));
-
-        for (i, block_proto) in header.blocks.into_iter().enumerate() {
+        for (i, block_proto) in header.blocks.iter().cloned().enumerate() {
             let unique_req_id = msg.req_id() + i as i64;
             // Create a single BlockWriteRequest from the block
             let header = BlockWriteRequest {
@@ -101,18 +102,42 @@ impl BatchWriteHandler {
                 .proto_header(header)
                 .build();
 
-            let response = self.write_handler.open(&single_msg_req)?;
-            let block_response: BlockWriteResponse = response.parse_header()?;
-            responses.push(block_response);
+            let response = match self.write_handler.open(&single_msg_req) {
+                Ok(response) => response,
+                Err(e) => {
+                    Self::abort_open_contexts(&self.store, &contexts);
+                    return Err(e);
+                }
+            };
 
             // Extract file and context from handler and store in batch vectors
-            if let Some(file) = self.write_handler.file.take() {
-                self.file.as_mut().unwrap().push(file);
-            }
-            if let Some(context) = self.write_handler.context.take() {
-                self.context.as_mut().unwrap().push(context);
-            }
+            let Some(context) = self.write_handler.context.take() else {
+                Self::abort_open_contexts(&self.store, &contexts);
+                return err_box!(
+                    "batch open did not create write context for block index {}",
+                    i
+                );
+            };
+            let block_response: BlockWriteResponse = match response.parse_header() {
+                Ok(response) => response,
+                Err(e) => {
+                    if let Err(abort_err) = self.store.abort_block(&context.block) {
+                        log::warn!(
+                            "failed to abort batch-opened block {} after response parse error: {}",
+                            context.block.id,
+                            abort_err
+                        );
+                    }
+                    Self::abort_open_contexts(&self.store, &contexts);
+                    return Err(e.into());
+                }
+            };
+            responses.push(block_response);
+            files.push(self.write_handler.file.take());
+            contexts.push(context);
         }
+        self.file = Some(files);
+        self.context = Some(contexts);
         let batch_response = BlocksBatchWriteResponse { responses };
 
         Ok(Builder::success(msg).proto_header(batch_response).build())
@@ -131,45 +156,68 @@ impl BatchWriteHandler {
             };
         }
 
-        // Process each block independently
+        let Some(contexts) = self.context.as_ref() else {
+            return err_box!("batch commit without open context");
+        };
+        let Some(files) = self.file.as_mut() else {
+            return err_box!("batch commit without open files");
+        };
+        if contexts.len() != header.blocks.len() || files.len() != header.blocks.len() {
+            return err_box!(
+                "batch commit block count mismatch: blocks={}, contexts={}, files={}",
+                header.blocks.len(),
+                contexts.len(),
+                files.len()
+            );
+        }
+
+        let mut commit_blocks = Vec::with_capacity(header.blocks.len());
         for (i, block_proto) in header.blocks.into_iter().enumerate() {
-            if let Some(context) = self.context.take() {
-                if context.len() > 1 {
-                    Self::check_context(&context[i], msg)?;
-                }
-            }
-
-            // Flush and close the file (same as complete)
-            let file = self.file.take();
-            if let Some(mut file) = file {
-                if file.len() > 1 {
-                    file[i].flush()?;
-                    drop(file);
-                }
-            }
-
-            // Create context manually for each block from block_proto
-            let unique_req_id = msg.req_id() + i as i64;
-            let context = WriteContext {
-                block: ProtoUtils::extend_block_from_pb(block_proto),
-                req_id: unique_req_id,
-                chunk_size: header.block_size as i32,
-                short_circuit: false,
-                off: header.off,
-                block_size: header.block_size,
+            let Some(context) = contexts.get(i) else {
+                return err_box!("missing batch write context at index {}", i);
             };
+            let expected_req_id = msg.req_id() + i as i64;
+            Self::check_context(context, expected_req_id)?;
 
-            // Validate block length (same as complete)
-            if context.block.len > context.block_size {
+            let block = ProtoUtils::extend_block_from_pb(block_proto);
+            if block.id != context.block.id
+                || block.storage_type != context.block.storage_type
+                || block.file_type != context.block.file_type
+            {
+                return err_box!(
+                    "batch commit block mismatch at index {}: opened={:?}, committed={:?}",
+                    i,
+                    context.block,
+                    block
+                );
+            }
+            if block.len > context.block_size {
                 return err_box!(
                     "Invalid write offset: {}, block size: {}",
-                    context.block.len,
+                    block.len,
                     context.block_size
                 );
             }
+            commit_blocks.push(block);
+        }
 
-            // Commit the block
-            self.commit_block(&context.block, commit)?;
+        for file in files.iter_mut() {
+            if let Some(file) = file.as_mut() {
+                file.flush()?;
+            }
+        }
+        for file in files.iter_mut() {
+            if let Some(file) = file.take() {
+                drop(file);
+            }
+        }
+
+        for block in commit_blocks {
+            if commit {
+                self.store.finalize_block(&block)?;
+            } else {
+                self.store.abort_block(&block)?;
+            }
             results.push(true);
         }
         self.is_commit = true;
@@ -180,14 +228,30 @@ impl BatchWriteHandler {
 
     pub fn write_batch(&mut self, msg: &Message) -> FsResult<Message> {
         let header: FilesBatchWriteRequest = msg.parse_header()?;
-        let mut results = Vec::new();
 
         // Use drain to extract elements while preserving the vector's allocated memory
-        let files_vec = self.file.as_mut().unwrap();
-        let contexts_vec = self.context.as_mut().unwrap();
+        let Some(files_vec) = self.file.as_mut() else {
+            return err_box!("batch write without open files");
+        };
+        let Some(contexts_vec) = self.context.as_mut() else {
+            return err_box!("batch write without open context");
+        };
+        if header.files.len() != files_vec.len() || header.files.len() != contexts_vec.len() {
+            return err_box!(
+                "batch write file count mismatch: request={}, files={}, contexts={}",
+                header.files.len(),
+                files_vec.len(),
+                contexts_vec.len()
+            );
+        }
+        if files_vec.iter().any(Option::is_none) {
+            return err_box!(
+                "batch remote write received running data for short-circuit batch writer"
+            );
+        }
 
-        let files_drain: Vec<_> = std::mem::take(files_vec);
-        let contexts_drain: Vec<_> = std::mem::take(contexts_vec);
+        let files_drain = std::mem::take(files_vec);
+        let contexts_drain = std::mem::take(contexts_vec);
 
         // Process each file in order
         let mut files_iter = files_drain.into_iter();
@@ -208,27 +272,86 @@ impl BatchWriteHandler {
                 .build();
 
             // Get the next file and context from iterators (preserves original order)
-            let file = files_iter.next().unwrap();
-            let context = contexts_iter.next().unwrap();
+            let Some(file) = files_iter.next() else {
+                return err_box!("missing batch write file at index {}", i);
+            };
+            let Some(file) = file else {
+                return err_box!("batch remote write missing file state at index {}", i);
+            };
+            let Some(context) = contexts_iter.next() else {
+                return err_box!("missing batch write context at index {}", i);
+            };
 
             self.write_handler.file = Some(file);
             self.write_handler.context = Some(context);
 
-            let response = self.write_handler.write(&single_msg);
+            if let Err(e) = self.write_handler.write(&single_msg) {
+                let Some(file) = self.write_handler.file.take() else {
+                    return err_box!(
+                        "batch write lost file state after write error at index {}",
+                        i
+                    );
+                };
+                let Some(context) = self.write_handler.context.take() else {
+                    return err_box!(
+                        "batch write lost context state after write error at index {}",
+                        i
+                    );
+                };
+                files_vec.push(Some(file));
+                contexts_vec.push(context);
+                files_vec.extend(files_iter);
+                contexts_vec.extend(contexts_iter);
+                return Err(e);
+            }
 
             // Collect processed file and context back into the original vectors
-            let file = self.write_handler.file.take().unwrap();
-            let context = self.write_handler.context.take().unwrap();
+            let Some(file) = self.write_handler.file.take() else {
+                return err_box!("batch write lost file state at index {}", i);
+            };
+            let Some(context) = self.write_handler.context.take() else {
+                return err_box!("batch write lost context state at index {}", i);
+            };
 
             // Push back to reuse the pre-allocated capacity from open_batch
-            files_vec.push(file);
+            files_vec.push(Some(file));
             contexts_vec.push(context);
-
-            results.push(response.is_ok());
         }
 
-        let batch_response = FilesBatchWriteResponse { results };
+        let batch_response = FilesBatchWriteResponse {
+            results: vec![true; header.files.len()],
+        };
         Ok(Builder::success(msg).proto_header(batch_response).build())
+    }
+
+    pub fn flush_batch(&mut self, msg: &Message) -> FsResult<Message> {
+        let header: DataHeaderProto = msg.parse_header()?;
+        if !header.flush {
+            return err_box!("batch writer received non-flush WriteBlock running request");
+        }
+
+        let Some(files) = self.file.as_mut() else {
+            return err_box!("batch flush without open files");
+        };
+        let Some(contexts) = self.context.as_ref() else {
+            return err_box!("batch flush without open context");
+        };
+        if files.len() != contexts.len() {
+            return err_box!(
+                "batch flush state mismatch: files={}, contexts={}",
+                files.len(),
+                contexts.len()
+            );
+        }
+        for (i, (file, context)) in files.iter_mut().zip(contexts.iter()).enumerate() {
+            let expected_req_id = msg.req_id() + i as i64;
+            Self::check_context(context, expected_req_id)?;
+            if let Some(file) = file.as_mut() {
+                file.flush()?;
+            }
+        }
+
+        Ok(msg.success())
     }
 }
 
@@ -239,6 +362,9 @@ impl MessageHandler for BatchWriteHandler {
         match request_status {
             // batch operations
             RequestStatus::Open => self.open_batch(msg),
+            RequestStatus::Running if RpcCode::from(msg.code()) == RpcCode::WriteBlock => {
+                self.flush_batch(msg)
+            }
             RequestStatus::Running => self.write_batch(msg),
             RequestStatus::Complete => self.complete_batch(msg, true),
             RequestStatus::Cancel => self.complete_batch(msg, false),

--- a/curvine-server/src/worker/handler/block_handler.rs
+++ b/curvine-server/src/worker/handler/block_handler.rs
@@ -31,11 +31,11 @@ pub enum BlockHandler {
 impl BlockHandler {
     pub fn new(code: RpcCode, store: BlockStore) -> CommonResult<Self> {
         let handler = match code {
-            RpcCode::WriteBlock => Writer(WriteHandler::new(store)),
+            RpcCode::WriteBlock => Writer(WriteHandler::new(store)?),
 
-            RpcCode::ReadBlock => Reader(ReadHandler::new(store)),
+            RpcCode::ReadBlock => Reader(ReadHandler::new(store)?),
 
-            RpcCode::WriteBlocksBatch => BatchWriter(BatchWriteHandler::new(store)),
+            RpcCode::WriteBlocksBatch => BatchWriter(BatchWriteHandler::new(store)?),
 
             code => return err_box!("Unsupported request type: {:?}", code),
         };

--- a/curvine-server/src/worker/handler/read_handler.rs
+++ b/curvine-server/src/worker/handler/read_handler.rs
@@ -26,7 +26,7 @@ use orpc::handler::MessageHandler;
 use orpc::io::{BlockDevice, BlockIO};
 use orpc::message::{Builder, Message, RequestStatus};
 use orpc::sys::{CacheManager, ReadAheadTask};
-use orpc::{err_box, ternary, try_option_mut};
+use orpc::{err_box, ternary, try_option_mut, CommonResult};
 use std::mem;
 
 pub struct ReadHandler {
@@ -43,10 +43,10 @@ pub struct ReadHandler {
 impl ReadHandler {
     pub const MAX_READ_AHEAD: i64 = 16 * 1024 * 1024;
 
-    pub fn new(store: BlockStore) -> Self {
-        let metrics = Worker::get_metrics();
-        let conf = Worker::get_conf();
-        Self {
+    pub fn new(store: BlockStore) -> CommonResult<Self> {
+        let metrics = Worker::get_metrics()?;
+        let conf = Worker::get_conf()?;
+        Ok(Self {
             store,
             os_cache: CacheManager::with_place(),
             context: None,
@@ -55,7 +55,7 @@ impl ReadHandler {
             io_slow_us: conf.worker.io_slow_us(),
             enable_send_file: conf.worker.enable_send_file,
             metrics,
-        }
+        })
     }
 
     pub fn open(&mut self, msg: &Message) -> FsResult<Message> {

--- a/curvine-server/src/worker/handler/router_handler.rs
+++ b/curvine-server/src/worker/handler/router_handler.rs
@@ -15,15 +15,16 @@
 use axum::routing::get;
 use axum::Router;
 
+use curvine_common::FsResult;
 use curvine_web::router::RouterHandler;
 
 use crate::worker::Worker;
 
 pub struct WorkerRouterHandler;
 
-async fn metrics() -> String {
-    let metrics = Worker::get_metrics();
-    metrics.text_output().unwrap()
+async fn metrics() -> FsResult<String> {
+    let metrics = Worker::get_metrics()?;
+    Ok(metrics.text_output()?)
 }
 
 impl RouterHandler for WorkerRouterHandler {

--- a/curvine-server/src/worker/handler/worker_handler.rs
+++ b/curvine-server/src/worker/handler/worker_handler.rs
@@ -24,7 +24,7 @@ use curvine_common::utils::SerdeUtils;
 use curvine_common::FsResult;
 use orpc::err_box;
 use orpc::handler::MessageHandler;
-use orpc::message::{Builder, Message, RequestStatus};
+use orpc::message::{Builder, Message, RequestStatus, ResponseStatus};
 use orpc::runtime::Runtime;
 use std::sync::Arc;
 
@@ -52,10 +52,14 @@ impl MessageHandler for WorkerHandler {
                 let h = self.get_handler(msg)?;
                 let res = h.handle(msg);
 
-                if matches!(
-                    msg.request_status(),
-                    RequestStatus::Cancel | RequestStatus::Complete
-                ) {
+                if res
+                    .as_ref()
+                    .is_ok_and(|msg| msg.response_status() == ResponseStatus::Success)
+                    && matches!(
+                        msg.request_status(),
+                        RequestStatus::Cancel | RequestStatus::Complete
+                    )
+                {
                     let _ = self.handler.take();
                 };
 
@@ -69,9 +73,13 @@ impl WorkerHandler {
     fn get_handler(&mut self, msg: &Message) -> FsResult<&mut BlockHandler> {
         let code = RpcCode::from(msg.code());
 
-        let need_new_handler = self.handler.is_none()
-            || !matches!(msg.request_status(), RequestStatus::Running)
-            || !Self::handler_matches_code(&self.handler, code);
+        let need_new_handler = match msg.request_status() {
+            RequestStatus::Open => true,
+            RequestStatus::Running | RequestStatus::Complete | RequestStatus::Cancel => {
+                self.handler.is_none() || !Self::handler_matches_code(&self.handler, code)
+            }
+            _ => self.handler.is_none() || !Self::handler_matches_code(&self.handler, code),
+        };
 
         if need_new_handler {
             let handler = BlockHandler::new(code, self.store.clone())?;
@@ -94,6 +102,7 @@ impl WorkerHandler {
                     Some(BlockHandler::BatchWriter(_)),
                     RpcCode::WriteBlocksBatch
                 )
+                | (Some(BlockHandler::BatchWriter(_)), RpcCode::WriteBlock)
         )
     }
 

--- a/curvine-server/src/worker/handler/write_handler.rs
+++ b/curvine-server/src/worker/handler/write_handler.rs
@@ -24,7 +24,7 @@ use orpc::common::{ByteUnit, TimeSpent};
 use orpc::handler::MessageHandler;
 use orpc::io::{BlockDevice, BlockIO};
 use orpc::message::{Builder, Message, RequestStatus};
-use orpc::{err_box, ternary, try_option_mut};
+use orpc::{err_box, ternary, try_option_mut, CommonResult};
 use std::mem;
 
 pub struct WriteHandler {
@@ -37,17 +37,17 @@ pub struct WriteHandler {
 }
 
 impl WriteHandler {
-    pub fn new(store: BlockStore) -> Self {
-        let conf = Worker::get_conf();
-        let metrics = Worker::get_metrics();
-        Self {
+    pub fn new(store: BlockStore) -> CommonResult<Self> {
+        let conf = Worker::get_conf()?;
+        let metrics = Worker::get_metrics()?;
+        Ok(Self {
             store,
             context: None,
             file: None,
             is_commit: false,
             io_slow_us: conf.worker.io_slow_us(),
             metrics,
-        }
+        })
     }
 
     pub fn resize(file: &mut BlockDevice, ctx: &WriteContext) -> FsResult<()> {
@@ -103,9 +103,31 @@ impl WriteHandler {
         };
 
         let meta = self.store.open_block(&open_block)?;
-        let mut file = meta.create_writer(context.off, false)?;
+        let mut file = match meta.create_writer(context.off, false) {
+            Ok(file) => file,
+            Err(e) => {
+                if let Err(abort_err) = self.store.abort_block(&context.block) {
+                    log::warn!(
+                        "failed to abort block {} after create_writer error: {}",
+                        context.block.id,
+                        abort_err
+                    );
+                }
+                return Err(e.into());
+            }
+        };
         // check file resize
-        Self::resize(&mut file, &context)?;
+        if let Err(e) = Self::resize(&mut file, &context) {
+            drop(file);
+            if let Err(abort_err) = self.store.abort_block(&context.block) {
+                log::warn!(
+                    "failed to abort block {} after resize error: {}",
+                    context.block.id,
+                    abort_err
+                );
+            }
+            return Err(e);
+        }
 
         let is_short_circuit = context.short_circuit && file.supports_short_circuit();
         let (label, path, file) = if is_short_circuit {

--- a/curvine-server/src/worker/replication/worker_replication_manager.rs
+++ b/curvine-server/src/worker/replication/worker_replication_manager.rs
@@ -24,7 +24,7 @@ use log::{error, info};
 use once_cell::sync::OnceCell;
 use orpc::io::BlockIO;
 use orpc::runtime::{AsyncRuntime, RpcRuntime};
-use orpc::{err_box, try_option, CommonResult};
+use orpc::{err_box, CommonResult};
 use std::sync::Arc;
 use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::sync::Semaphore;
@@ -92,7 +92,12 @@ impl WorkerReplicationManager {
         job: &ReplicationJob,
         err_msg: Option<String>,
     ) -> CommonResult<ReportBlockReplicationResponse> {
-        let storage_type = try_option!(job.storage_type);
+        let Some(storage_type) = job.storage_type else {
+            return err_box!(
+                "missing storage type when reporting replication result for block {}",
+                job.block_id
+            );
+        };
         let request = ReportBlockReplicationRequest {
             block_id: job.block_id,
             storage_type: storage_type.into(),
@@ -100,7 +105,9 @@ impl WorkerReplicationManager {
             message: err_msg,
         };
 
-        let master_client = try_option!(self.master_client.get());
+        let Some(master_client) = self.master_client.get() else {
+            return err_box!("master client is not initialized for worker replication reporting");
+        };
 
         let response: ReportBlockReplicationResponse = master_client
             .fs_client
@@ -110,12 +117,10 @@ impl WorkerReplicationManager {
     }
 
     async fn replicate_block(&self, job: &mut ReplicationJob) -> CommonResult<()> {
-        let _permit = self
-            .replication_semaphore
-            .clone()
-            .acquire_owned()
-            .await
-            .unwrap();
+        let _permit = match self.replication_semaphore.clone().acquire_owned().await {
+            Ok(permit) => permit,
+            Err(e) => return err_box!("replication semaphore closed: {}", e),
+        };
         let block_meta = self.block_store.get_block(job.block_id)?;
         if block_meta.state != BlockState::Finalized {
             return err_box!("Block: {} is not finalized", job.block_id);
@@ -127,7 +132,7 @@ impl WorkerReplicationManager {
         info!(
             "Replicating block_id: {} from {} to {}",
             job.block_id,
-            self.block_store.worker_id(),
+            self.block_store.worker_id()?,
             job.target_worker_addr.worker_id
         );
         let mut writer = BlockWriterRemote::new(

--- a/curvine-server/src/worker/storage/dir_list.rs
+++ b/curvine-server/src/worker/storage/dir_list.rs
@@ -18,7 +18,7 @@ use indexmap::map::Values;
 use indexmap::IndexMap;
 use log::{info, warn};
 use orpc::common::ByteUnit;
-use orpc::CommonResult;
+use orpc::{err_box, CommonResult};
 use std::ops::Index;
 
 // Directory list.
@@ -28,19 +28,19 @@ pub struct DirList {
 }
 
 impl DirList {
-    pub fn new(list: Vec<VfsDir>) -> Self {
+    pub fn new(list: Vec<VfsDir>) -> CommonResult<Self> {
         let mut dirs = IndexMap::new();
         for dir in list {
             if dirs.contains_key(&dir.id()) {
-                panic!("Storage ID hash conflict")
+                return err_box!("Storage ID hash conflict for dir {}", dir.id());
             }
             dirs.insert(dir.id(), dir);
         }
 
-        Self {
+        Ok(Self {
             dirs,
             chooser: ChoosingPolicy::Robin(RobinChoosingPolicy::new()),
-        }
+        })
     }
 
     pub fn len(&self) -> usize {
@@ -171,7 +171,7 @@ mod tests {
             VfsDir::from_dir(id, dirs[2].clone())?,
         ];
 
-        let mut list = DirList::new(vfs_dir);
+        let mut list = DirList::new(vfs_dir)?;
 
         let mem = list.choose_dir_with_str(StorageType::Mem, "5MB")?;
         println!("choose mem: {:?}", mem.base_path());

--- a/curvine-server/src/worker/storage/dir_state.rs
+++ b/curvine-server/src/worker/storage/dir_state.rs
@@ -15,7 +15,7 @@
 use curvine_common::state::StorageType;
 use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
-use std::sync::Mutex;
+use std::sync::{Mutex, MutexGuard};
 
 #[derive(Debug, Default)]
 pub struct DirState {
@@ -88,10 +88,21 @@ impl BdevOffsetAllocator {
             }),
         }
     }
+
+    fn lock_inner(&self) -> MutexGuard<'_, OffsetAllocInner> {
+        match self.inner.lock() {
+            Ok(inner) => inner,
+            Err(e) => {
+                log::error!("fatal bdev offset allocator lock poisoned: {}", e);
+                std::process::abort();
+            }
+        }
+    }
+
     /// Allocate bytes for block_id. Returns bdev offset (aligned to block size).
     /// First checks the free-list (first-fit), then falls back to bump cursor.
     pub fn allocate(&self, block_id: i64, size: i64) -> Result<i64, String> {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.lock_inner();
         if inner.map.contains_key(&block_id) {
             return Err(format!(
                 "block {} already allocated at offset {}",
@@ -131,17 +142,17 @@ impl BdevOffsetAllocator {
     }
     /// Get offset for allocated block.
     pub fn get(&self, block_id: i64) -> Option<i64> {
-        let inner = self.inner.lock().unwrap();
+        let inner = self.lock_inner();
         inner.map.get(&block_id).map(|&(off, _)| off)
     }
     /// Get (offset, size) for allocated block.
     pub fn get_entry(&self, block_id: i64) -> Option<(i64, i64)> {
-        let inner = self.inner.lock().unwrap();
+        let inner = self.lock_inner();
         inner.map.get(&block_id).copied()
     }
     /// Remove mapping and return space to the free-list with coalescing.
     pub fn free(&self, block_id: i64) {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.lock_inner();
         let (offset, size) = match inner.map.remove(&block_id) {
             Some(v) => v,
             None => return,
@@ -180,12 +191,12 @@ impl BdevOffsetAllocator {
     }
     /// Number of allocated blocks.
     pub fn allocated_count(&self) -> usize {
-        let inner = self.inner.lock().unwrap();
+        let inner = self.lock_inner();
         inner.map.len()
     }
     /// Current cursor (next free offset).
     pub fn cursor(&self) -> i64 {
-        let inner = self.inner.lock().unwrap();
+        let inner = self.lock_inner();
         inner.cursor
     }
 }
@@ -198,7 +209,7 @@ impl Default for BdevOffsetAllocator {
 impl BdevOffsetAllocator {
     /// Export state for persistence: Vec<(block_id, offset, size)>.
     pub fn snapshot(&self) -> Vec<(i64, i64, i64)> {
-        let inner = self.inner.lock().unwrap();
+        let inner = self.lock_inner();
         inner
             .map
             .iter()
@@ -209,7 +220,7 @@ impl BdevOffsetAllocator {
     /// Restore from snapshot. Rebuilds map, cursor = max(offset + size), and reconstructs
     /// the free-list from gaps between allocated blocks within [0, cursor).
     pub fn restore(&self, entries: &[(i64, i64, i64)]) {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.lock_inner();
         inner.map.clear();
         inner.free_list.clear();
         inner.cursor = 0;
@@ -234,33 +245,33 @@ impl BdevOffsetAllocator {
 
     /// Alignment value used by this allocator.
     pub fn align(&self) -> i64 {
-        let inner = self.inner.lock().unwrap();
+        let inner = self.lock_inner();
         inner.align
     }
 
     /// Size of the free-list (number of free ranges).
     pub fn free_list_size(&self) -> usize {
-        let inner = self.inner.lock().unwrap();
+        let inner = self.lock_inner();
         inner.free_list.len()
     }
 
     /// Total free bytes in the free-list.
     pub fn free_list_bytes(&self) -> i64 {
-        let inner = self.inner.lock().unwrap();
+        let inner = self.lock_inner();
         inner.free_list.iter().map(|(_, &v)| v).sum()
     }
 
     #[cfg(test)]
     /// Expose free-list entries for test introspection.
     pub fn free_list_entries(&self) -> Vec<(i64, i64)> {
-        let inner = self.inner.lock().unwrap();
+        let inner = self.lock_inner();
         inner.free_list.iter().map(|(&k, &v)| (k, v)).collect()
     }
 }
 
 impl std::fmt::Debug for BdevOffsetAllocator {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let inner = self.inner.lock().unwrap();
+        let inner = self.lock_inner();
         f.debug_struct("BdevOffsetAllocator")
             .field("cursor", &inner.cursor)
             .field("capacity", &inner.capacity)

--- a/curvine-server/src/worker/storage/vfs_dataset.rs
+++ b/curvine-server/src/worker/storage/vfs_dataset.rs
@@ -38,7 +38,11 @@ pub struct VfsDataset {
 }
 
 impl VfsDataset {
-    fn new(cluster_id: &str, dir_list: DirList, spdk_meta: Option<Arc<SpdkMetaStore>>) -> Self {
+    fn new(
+        cluster_id: &str,
+        dir_list: DirList,
+        spdk_meta: Option<Arc<SpdkMetaStore>>,
+    ) -> CommonResult<Self> {
         let worker_id = match dir_list.get_dir_index(0) {
             None => 0,
             Some(v) => v.version().worker_id,
@@ -53,12 +57,12 @@ impl VfsDataset {
             num_blocks_to_delete: AtomicUsize::new(0),
             spdk_meta,
         };
-        ds.initialize();
-        ds
+        ds.initialize()?;
+        Ok(ds)
     }
 
     pub fn from_conf(cluster_id: &str, conf: &ClusterConf) -> CommonResult<Self> {
-        let mut dir_list = DirList::new(vec![]);
+        let mut dir_list = DirList::new(vec![])?;
         let dir_reserved = ByteUnit::from_str(&conf.worker.dir_reserved)?.as_byte();
 
         let mut worker_id: Option<u32> = None;
@@ -121,7 +125,7 @@ impl VfsDataset {
             None
         };
 
-        Ok(Self::new(cluster_id, dir_list, spdk_meta))
+        Self::new(cluster_id, dir_list, spdk_meta)
     }
 
     // Initialize.
@@ -129,20 +133,20 @@ impl VfsDataset {
     // 2. Block is added to block_map.
     // 3. Update capacity usage.
     // TODO: pre-filter to avoid scan_all() per SPDK dir
-    fn initialize(&mut self) {
+    fn initialize(&mut self) -> CommonResult<()> {
         let spent = TimeSpent::new();
         for dir in self.dir_list.dir_iter() {
             let blocks = if dir.storage_type() == StorageType::SpdkDisk {
                 // SPDK dirs: restore from RocksDB
                 match &self.spdk_meta {
-                    Some(store) => dir.scan_spdk_blocks(store).unwrap(),
+                    Some(store) => dir.scan_spdk_blocks(store)?,
                     None => {
                         warn!("SPDK dir {} has no meta store — starting empty", dir.id());
                         vec![]
                     }
                 }
             } else {
-                dir.scan_blocks().unwrap()
+                dir.scan_blocks()?
             };
             for block in blocks {
                 dir.reserve_space(true, block.len);
@@ -154,6 +158,7 @@ impl VfsDataset {
             spent.used_ms(),
             self.block_map.len()
         );
+        Ok(())
     }
 
     pub fn find_dir(&self, id: u32) -> CommonResult<&VfsDir> {
@@ -309,6 +314,17 @@ impl Dataset for VfsDataset {
 
     fn finalize_block(&mut self, block: &ExtendedBlock) -> CommonResult<BlockMeta> {
         let meta = self.get_block_check(block.id)?;
+        if meta.state() == &BlockState::Finalized {
+            if meta.len() == block.len {
+                return Ok(meta.clone());
+            }
+            return err_box!(
+                "finalized block {} length mismatch, expected: {}, actual: {}",
+                meta.id(),
+                block.len,
+                meta.len()
+            );
+        }
         if meta.state() != &BlockState::Writing {
             return err_box!(
                 "block {} status incorrect, expected {:?}, actual: {:?}",
@@ -339,7 +355,7 @@ impl Dataset for VfsDataset {
 
     fn abort_block(&mut self, block: &ExtendedBlock) -> CommonResult<()> {
         let meta = match self.block_map.remove(&block.id) {
-            None => return err_box!("block {} not exists", block.id),
+            None => return Ok(()),
             Some(v) => v,
         };
 
@@ -427,9 +443,9 @@ mod test {
         }
     }
 
-    fn spdk_dataset() -> VfsDataset {
+    fn spdk_dataset() -> CommonResult<VfsDataset> {
         let st = spdk_state(1);
-        VfsDataset::new("t", DirList::new(vec![spdk_dir(st)]), None)
+        VfsDataset::new("t", DirList::new(vec![spdk_dir(st)])?, None)
     }
 
     #[test]
@@ -475,7 +491,7 @@ mod test {
     #[test]
     fn abort_spdk() -> CommonResult<()> {
         let st = spdk_state(1);
-        let mut ds = VfsDataset::new("t", DirList::new(vec![spdk_dir(st.clone())]), None);
+        let mut ds = VfsDataset::new("t", DirList::new(vec![spdk_dir(st.clone())])?, None)?;
         let meta = BlockMeta {
             id: 1,
             len: 4096,
@@ -498,7 +514,7 @@ mod test {
     }
     #[test]
     fn spdk_create_abort_reuse_offset() -> CommonResult<()> {
-        let mut ds = spdk_dataset();
+        let mut ds = spdk_dataset()?;
         let block1 = ExtendedBlock::new(1, 4096, StorageType::SpdkDisk, FileType::File);
         let meta1 = ds.open_block(&block1)?;
         assert_eq!(meta1.bdev_offset, 0, "first block should get offset 0");
@@ -517,7 +533,7 @@ mod test {
     }
     #[test]
     fn spdk_create_abort_interleaved() -> CommonResult<()> {
-        let mut ds = spdk_dataset();
+        let mut ds = spdk_dataset()?;
         let b1 = ExtendedBlock::new(1, 4096, StorageType::SpdkDisk, FileType::File);
         let b2 = ExtendedBlock::new(2, 4096, StorageType::SpdkDisk, FileType::File);
         let b3 = ExtendedBlock::new(3, 4096, StorageType::SpdkDisk, FileType::File);
@@ -551,7 +567,7 @@ mod test {
     #[test]
     fn spdk_restore_free_list() -> CommonResult<()> {
         let st = spdk_state(1);
-        let mut ds = VfsDataset::new("t", DirList::new(vec![spdk_dir(st.clone())]), None);
+        let mut ds = VfsDataset::new("t", DirList::new(vec![spdk_dir(st.clone())])?, None)?;
         let b1 = ExtendedBlock::new(1, 4096, StorageType::SpdkDisk, FileType::File);
         let b2 = ExtendedBlock::new(2, 4096, StorageType::SpdkDisk, FileType::File);
         let b3 = ExtendedBlock::new(3, 4096, StorageType::SpdkDisk, FileType::File);

--- a/curvine-server/src/worker/task/task_context.rs
+++ b/curvine-server/src/worker/task/task_context.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Mutex;
+use std::sync::{Mutex, MutexGuard};
 
 use curvine_common::state::{JobTaskProgress, JobTaskState, LoadTaskInfo};
 use orpc::common::LocalTime;
@@ -37,8 +37,18 @@ impl TaskContext {
         self.state.state()
     }
 
+    fn progress(&self) -> MutexGuard<'_, JobTaskProgress> {
+        match self.progress.lock() {
+            Ok(progress) => progress,
+            Err(e) => {
+                log::error!("fatal task progress lock poisoned: {}", e);
+                std::process::abort();
+            }
+        }
+    }
+
     pub fn set_failed(&self, message: impl Into<String>) -> JobTaskProgress {
-        let mut lock = self.progress.lock().unwrap();
+        let mut lock = self.progress();
         self.state.set_state(JobTaskState::Failed);
         lock.message = message.into();
         lock.update_time = LocalTime::mills() as i64;
@@ -61,7 +71,7 @@ impl TaskContext {
     }
 
     pub fn update_state(&self, state: JobTaskState, message: impl Into<String>) {
-        let mut lock = self.progress.lock().unwrap();
+        let mut lock = self.progress();
         self.state.set_state(state);
         lock.message = message.into();
         lock.update_time = LocalTime::mills() as i64;
@@ -73,7 +83,7 @@ impl TaskContext {
         total_size: i64,
         is_last: bool,
     ) -> JobTaskProgress {
-        let mut lock = self.progress.lock().unwrap();
+        let mut lock = self.progress();
 
         lock.loaded_size = loaded_size;
         lock.total_size = total_size;

--- a/curvine-server/src/worker/worker_metrics.rs
+++ b/curvine-server/src/worker/worker_metrics.rs
@@ -76,7 +76,7 @@ impl WorkerMetrics {
     }
 
     pub fn text_output(&self) -> CommonResult<String> {
-        let state = self.store.read();
+        let state = self.store.read()?;
 
         self.capacity.set(state.capacity());
         self.available.set(state.available());

--- a/curvine-server/src/worker/worker_server.rs
+++ b/curvine-server/src/worker/worker_server.rs
@@ -24,13 +24,14 @@ use curvine_web::server::{WebHandlerService, WebServer};
 use log::info;
 use once_cell::sync::OnceCell;
 use orpc::common::{LocalTime, Logger};
+use orpc::error::StringError;
 use orpc::handler::HandlerService;
 use orpc::io::net::ConnState;
 #[cfg(feature = "spdk")]
 use orpc::io::spdk_env::SpdkEnv;
 use orpc::runtime::{RpcRuntime, Runtime};
 use orpc::server::{RpcServer, ServerStateListener};
-use orpc::CommonResult;
+use orpc::{CommonError, CommonResult};
 use std::sync::Arc;
 use std::thread;
 
@@ -102,8 +103,8 @@ pub struct Worker {
     pub start_ms: u64,
     pub worker_id: u32,
     pub addr: WorkerAddress,
-    rpc_server: RpcServer<WorkerService>,
-    web_server: WebServer<WorkerService>,
+    rpc_server: Option<RpcServer<WorkerService>>,
+    web_server: Option<WebServer<WorkerService>>,
     block_actor: BlockActor,
 }
 
@@ -177,10 +178,10 @@ impl Worker {
 
         let rt = Arc::new(conf.worker_server_conf().create_runtime());
         let service: WorkerService = WorkerService::with_conf(&conf, rt.clone())?;
-        let worker_id = service.store.worker_id();
+        let worker_id = service.store.worker_id()?;
 
         CLUSTER_CONF.get_or_init(|| conf.clone());
-        WORKER_METRICS.get_or_init(|| WorkerMetrics::new(service.store.clone()).unwrap());
+        WORKER_METRICS.get_or_try_init(|| WorkerMetrics::new(service.store.clone()))?;
         conf.print();
 
         let block_store = service.store.clone();
@@ -202,7 +203,7 @@ impl Worker {
             addr.clone(),
             block_store.clone(),
             rpc_server.new_state_ctl(),
-        );
+        )?;
 
         let master_client = block_actor.client.clone();
         service
@@ -225,58 +226,82 @@ impl Worker {
             start_ms: LocalTime::mills(),
             worker_id,
             addr,
-            rpc_server,
-            web_server,
+            rpc_server: Some(rpc_server),
+            web_server: Some(web_server),
             block_actor,
         };
 
         Ok(worker)
     }
 
-    pub async fn start(self) -> ServerStateListener {
+    pub async fn start(&mut self) -> CommonResult<ServerStateListener> {
         // step 3: Start rpc server
-        let mut rpc_status = self.rpc_server.start();
-        rpc_status.wait_running().await.unwrap();
+        let rpc_server = self
+            .rpc_server
+            .take()
+            .expect("worker rpc server must be initialized before startup");
+        let mut rpc_status = rpc_server.start();
+        rpc_status.wait_running().await?;
 
         // step 4: Start the web server
-        let web_name = self.web_server.server_name().to_string();
-        let bind_addr = self.web_server.resolve_bind_addr();
-        let mut web_status = self.web_server.start();
-        WebServer::<WorkerService>::wait_bind(&mut web_status, &web_name, &bind_addr)
-            .await
-            .unwrap();
+        let web_server = self
+            .web_server
+            .take()
+            .expect("worker web server must be initialized before startup");
+        let web_name = web_server.server_name().to_string();
+        let bind_addr = web_server.resolve_bind_addr();
+        let mut web_status = web_server.start();
+        WebServer::<WorkerService>::wait_bind(&mut web_status, &web_name, &bind_addr).await?;
 
         // step 5: Start block heartbeat check service
-        thread::spawn(move || self.block_actor.start())
+        let block_actor = self.block_actor.clone();
+        thread::spawn(move || block_actor.start())
             .join()
-            .unwrap();
+            .map_err(|_| {
+                CommonError::from(StringError::from(
+                    "worker block actor startup thread panicked",
+                ))
+            })
+            .and_then(|result| result)?;
 
-        rpc_status
+        Ok(rpc_status)
     }
 
-    pub fn block_on_start(self) {
-        let rt = self.rpc_server.clone_rt();
+    pub fn block_on_start(mut self) -> CommonResult<()> {
+        let rt = self
+            .rpc_server
+            .as_ref()
+            .expect("worker rpc server must be initialized before startup")
+            .clone_rt();
 
-        rt.block_on(async move {
-            let mut rpc_status = self.start().await;
-            rpc_status.wait_stop().await.unwrap();
-        })
+        let mut rpc_status = rt.block_on(async { self.start().await })?;
+        rt.block_on(async { rpc_status.wait_stop().await })
     }
 
     // Start a standalone worker.
     pub fn start_standalone(&self) {
-        self.rpc_server.block_on_start();
+        self.rpc_server
+            .as_ref()
+            .expect("worker rpc server must be initialized")
+            .block_on_start();
     }
 
-    pub fn get_conf<'a>() -> &'a ClusterConf {
-        CLUSTER_CONF.get().expect("Worker get conf error!")
+    pub fn get_conf<'a>() -> CommonResult<&'a ClusterConf> {
+        CLUSTER_CONF
+            .get()
+            .ok_or_else(|| orpc::CommonError::from("worker cluster config is not initialized"))
     }
 
-    pub fn get_metrics<'a>() -> &'a WorkerMetrics {
-        WORKER_METRICS.get().expect("Worker get metrics error!")
+    pub fn get_metrics<'a>() -> CommonResult<&'a WorkerMetrics> {
+        WORKER_METRICS
+            .get()
+            .ok_or_else(|| orpc::CommonError::from("worker metrics are not initialized"))
     }
 
     pub fn service(&self) -> &WorkerService {
-        self.rpc_server.service()
+        self.rpc_server
+            .as_ref()
+            .expect("worker rpc server must be initialized")
+            .service()
     }
 }

--- a/curvine-server/tests/inode_test.rs
+++ b/curvine-server/tests/inode_test.rs
@@ -106,7 +106,10 @@ fn test_inode_store_create_tree_removes_orphan_edges() -> CommonResult<()> {
     )));
     {
         let rocks = RocksInodeStore::new(conf.clone(), true)?;
-        let store = InodeStore::new(rocks, Arc::new(TtlBucketList::new(60_000)));
+        let store = InodeStore::new(
+            rocks,
+            Arc::new(TtlBucketList::new(60_000).expect("valid ttl bucket interval")),
+        )?;
         let root = FsDir::create_root();
         let missing_inode_id = 2001;
 

--- a/curvine-server/tests/journal_test.rs
+++ b/curvine-server/tests/journal_test.rs
@@ -130,7 +130,7 @@ fn test_journal_replay_consistency_between_leader_and_follower() -> CommonResult
     fs_leader.print_tree();
     fs_follower.print_tree();
     assert_eq!(fs_leader.last_inode_id(), fs_follower.last_inode_id());
-    assert_eq!(fs_leader.sum_hash(), fs_follower.sum_hash());
+    assert_eq!(fs_leader.sum_hash()?, fs_follower.sum_hash()?);
 
     let leader_mnt = mnt_mgr1.get_mount_table().unwrap();
     let follower_mnt = mnt_mgr2.get_mount_table().unwrap();
@@ -156,6 +156,7 @@ fn test_raft_consensus_and_state_synchronization_between_two_masters() -> Common
     conf.journal.writer_flush_batch_size = 1;
     conf.journal.writer_flush_batch_ms = 10;
     conf.journal.raft_tick_interval_ms = 100;
+    conf.journal.raft_check_quorum = false;
     conf.journal.journal_addrs = vec![
         RaftPeer::new(port1 as NodeId, &conf.master.hostname, port1),
         RaftPeer::new(port2 as NodeId, &conf.master.hostname, port2),
@@ -212,12 +213,16 @@ fn test_raft_consensus_and_state_synchronization_between_two_masters() -> Common
     // the active node, rather than using a fixed sleep that may be insufficient
     // under load. Both inode state and mount table are replicated via separate
     // Raft log entries, so we must wait for all of them to be applied.
-    let deadline = std::time::Instant::now() + Duration::from_secs(60);
+    let deadline = std::time::Instant::now() + Duration::from_secs(180);
     loop {
         let leader_mnt = mnt_mgr1.get_mount_table().unwrap_or_default();
         let follower_mnt = mnt_mgr2.get_mount_table().unwrap_or_default();
+        let hash_converged = match (active.sum_hash(), standby.sum_hash()) {
+            (Ok(active_hash), Ok(standby_hash)) => active_hash == standby_hash,
+            _ => false,
+        };
         if active.last_inode_id() == standby.last_inode_id()
-            && active.sum_hash() == standby.sum_hash()
+            && hash_converged
             && leader_mnt.len() == follower_mnt.len()
         {
             break;
@@ -226,7 +231,7 @@ fn test_raft_consensus_and_state_synchronization_between_two_masters() -> Common
             active.print_tree();
             standby.print_tree();
             assert_eq!(active.last_inode_id(), standby.last_inode_id());
-            assert_eq!(active.sum_hash(), standby.sum_hash());
+            assert_eq!(active.sum_hash()?, standby.sum_hash()?);
             break;
         }
         thread::sleep(Duration::from_millis(200));

--- a/curvine-server/tests/master_fs_test.rs
+++ b/curvine-server/tests/master_fs_test.rs
@@ -156,12 +156,14 @@ fn new_handler() -> MasterHandler {
     let journal_system = JournalSystem::from_conf(&conf).unwrap();
     let fs = MasterFilesystem::with_js(&conf, &journal_system);
     fs.add_test_worker(WorkerInfo::default());
-    let retry_cache = FsRetryCache::with_conf(&conf.master);
+    let retry_cache = FsRetryCache::with_conf(&conf.master)
+        .expect("test master retry cache configuration should be valid");
 
     let mount_manager = journal_system.mount_manager();
     let rt = Arc::new(AsyncRuntime::single());
     let replication_manager =
-        MasterReplicationManager::new(&fs, &conf, &rt, &journal_system.worker_manager());
+        MasterReplicationManager::new(&fs, &conf, &rt, &journal_system.worker_manager())
+            .expect("test master replication manager should initialize");
     let job_manager = Arc::new(JobManager::from_cluster_conf(
         fs.clone(),
         mount_manager.clone(),
@@ -176,6 +178,7 @@ fn new_handler() -> MasterHandler {
         mount_manager,
         JobHandler::new(job_manager),
         replication_manager,
+        Master::get_metrics().expect("test master metrics should initialize"),
     )
 }
 
@@ -226,7 +229,7 @@ fn test_filesystem_metadata_persistence_and_restore() -> CommonResult<()> {
         let fs = new_fs(true, "restore");
         fs.mkdir("/a", false)?;
         fs.mkdir("/x1/x2/x3", true)?;
-        let hash = fs.sum_hash();
+        let hash = fs.sum_hash()?;
         drop(fs);
         hash
     }; // Scope ensures all resources are dropped before reopening DB
@@ -237,7 +240,7 @@ fn test_filesystem_metadata_persistence_and_restore() -> CommonResult<()> {
 
     assert!(fs.exists("/a")?);
     assert!(fs.exists("/x1/x2/x3")?);
-    let hash2 = fs.sum_hash();
+    let hash2 = fs.sum_hash()?;
     assert_eq!(hash1, hash2);
 
     Ok(())
@@ -251,7 +254,7 @@ fn test_filesystem_metadata_restore_with_full_journal_system_reopen() -> CommonR
         let (fs, js) = new_fs_with_journal(true, &test_name)?;
         fs.mkdir("/a", false)?;
         fs.mkdir("/x1/x2/x3", true)?;
-        let hash = fs.sum_hash();
+        let hash = fs.sum_hash()?;
         drop(fs);
         js.shutdown();
         hash
@@ -262,7 +265,7 @@ fn test_filesystem_metadata_restore_with_full_journal_system_reopen() -> CommonR
 
     assert!(fs.exists("/a")?);
     assert!(fs.exists("/x1/x2/x3")?);
-    assert_eq!(hash1, fs.sum_hash());
+    assert_eq!(hash1, fs.sum_hash()?);
 
     drop(fs);
     js.shutdown();
@@ -715,11 +718,11 @@ fn state(fs: &MasterFilesystem) -> CommonResult<()> {
 
     fs.print_tree();
     let fs_dir = fs.fs_dir.read();
-    let mem_hash = fs_dir.root_dir().sum_hash();
+    let mem_hash = fs_dir.root_dir().sum_hash()?;
 
     let state_tree = fs_dir.create_tree()?;
     state_tree.print_tree();
-    let state_hash = state_tree.sum_hash();
+    let state_hash = state_tree.sum_hash()?;
 
     println!("mem_hash = {}, state_hash = {}", mem_hash, state_hash);
     assert_eq!(mem_hash, state_hash);
@@ -991,7 +994,7 @@ fn test_idempotent_mkdir() -> CommonResult<()> {
     let (fs, js, loader, _js2, fs2) = setup_pair("mkdir");
     fs.mkdir("/data", false)?;
     replay_all_then_duplicate_last(&js, &loader)?;
-    assert_eq!(fs.sum_hash(), fs2.sum_hash());
+    assert_eq!(fs.sum_hash()?, fs2.sum_hash()?);
     Ok(())
 }
 
@@ -1001,7 +1004,7 @@ fn test_idempotent_create_file() -> CommonResult<()> {
     let (fs, js, loader, _js2, fs2) = setup_pair("create-file");
     fs.create("/file.log", true)?;
     replay_all_then_duplicate_last(&js, &loader)?;
-    assert_eq!(fs.sum_hash(), fs2.sum_hash());
+    assert_eq!(fs.sum_hash()?, fs2.sum_hash()?);
     Ok(())
 }
 
@@ -1033,7 +1036,7 @@ fn test_idempotent_delete() -> CommonResult<()> {
         "follower file counts must stay non-negative: {:?}",
         follower_counts
     );
-    assert_eq!(fs.sum_hash(), fs2.sum_hash());
+    assert_eq!(fs.sum_hash()?, fs2.sum_hash()?);
     Ok(())
 }
 
@@ -1044,7 +1047,7 @@ fn test_idempotent_rename() -> CommonResult<()> {
     fs.mkdir("/src", false)?;
     fs.rename("/src", "/dst", RenameFlags::empty())?;
     replay_all_then_duplicate_last(&js, &loader)?;
-    assert_eq!(fs.sum_hash(), fs2.sum_hash());
+    assert_eq!(fs.sum_hash()?, fs2.sum_hash()?);
     Ok(())
 }
 
@@ -1058,7 +1061,7 @@ fn test_idempotent_free() -> CommonResult<()> {
     fs.set_attr("/file.log", set_opts)?;
     fs.free("/file.log", false)?;
     replay_all_then_duplicate_last(&js, &loader)?;
-    assert_eq!(fs.sum_hash(), fs2.sum_hash());
+    assert_eq!(fs.sum_hash()?, fs2.sum_hash()?);
     Ok(())
 }
 
@@ -1070,7 +1073,7 @@ fn test_idempotent_set_attr() -> CommonResult<()> {
     let opts = SetAttrOptsBuilder::new().owner("test_owner").build();
     fs.set_attr("/data", opts)?;
     replay_all_then_duplicate_last(&js, &loader)?;
-    assert_eq!(fs.sum_hash(), fs2.sum_hash());
+    assert_eq!(fs.sum_hash()?, fs2.sum_hash()?);
     Ok(())
 }
 
@@ -1083,7 +1086,7 @@ fn test_idempotent_unmount() -> CommonResult<()> {
     mnt_mgr.mount(None, "/mnt/test", "oss://bucket/", &mnt_opt)?;
     mnt_mgr.umount("/mnt/test")?;
     replay_all_then_duplicate_last(&js, &loader)?;
-    assert_eq!(fs.sum_hash(), fs2.sum_hash());
+    assert_eq!(fs.sum_hash()?, fs2.sum_hash()?);
     Ok(())
 }
 
@@ -1190,7 +1193,7 @@ fn test_idempotent_symlink() -> CommonResult<()> {
         "follower file counts must stay non-negative: {:?}",
         follower_counts
     );
-    assert_eq!(fs.sum_hash(), fs2.sum_hash());
+    assert_eq!(fs.sum_hash()?, fs2.sum_hash()?);
     Ok(())
 }
 
@@ -1268,7 +1271,7 @@ fn test_idempotent_mount() -> CommonResult<()> {
         &mnt_opt,
     )?;
     replay_all_then_duplicate_last(&js, &loader)?;
-    assert_eq!(fs.sum_hash(), fs2.sum_hash());
+    assert_eq!(fs.sum_hash()?, fs2.sum_hash()?);
     Ok(())
 }
 
@@ -1288,7 +1291,7 @@ fn test_idempotent_set_locks() -> CommonResult<()> {
     };
     fs.set_lock("/lockfile.log", lock)?;
     replay_all_then_duplicate_last(&js, &loader)?;
-    assert_eq!(fs.sum_hash(), fs2.sum_hash());
+    assert_eq!(fs.sum_hash()?, fs2.sum_hash()?);
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- propagate mini-cluster master and worker startup failures from spawned threads
- abort test process on startup failure instead of silently losing the error in a detached thread

## Stack

Base PR branch: `jlon/fix-worker-recoverable-errors`.

## Verification

- GitHub CI: Compile and Smoke Test
