### PR TITLE
build(spdk): use portable CPU baseline for x86_64

### DIFF
--- a/curvine-docker/compile/Dockerfile_rocky9
+++ b/curvine-docker/compile/Dockerfile_rocky9
@@ -156,11 +156,17 @@ RUN cd /tmp && \
     make install && \
     ldconfig && \
     cd /tmp/spdk-src && \
+    ARCH=$(uname -m) && \
+    case "${ARCH}" in \
+        x86_64) TARGET_ARCH="nehalem" ;; \
+        aarch64) TARGET_ARCH="native" ;; \
+        *) echo "Unsupported architecture: ${ARCH}" && exit 1 ;; \
+    esac && \
     ./configure \
         --disable-tests \
         --with-rdma \
         --without-vfio-user \
-        --target-arch=native \
+        --target-arch=${TARGET_ARCH} \
         --with-shared && \
     make -j$(nproc) && \
     mkdir -p /opt/spdk/build/bin \


### PR DESCRIPTION
# Problem

SPDK compile image is built with `--target-arch=native` on GitHub CI runners (modern x86_64 CPUs). The resulting binary contains CPU-specific instructions like `VPCLMULQDQ` that crash on older CPUs. This affects anyone running the compile image on a machine without those instructions (e.g., VMs, older cloud instances).

# Fix

Add architecture-aware `--target-arch` selection in `curvine-docker/compile/Dockerfile_rocky9`:

- **x86_64** → `nehalem` (Intel Nehalem, 2008) — a widely compatible baseline that runs on virtually any x86_64 CPU
- **aarch64** → `native` — ARM CPUs don't have this compatibility issue; native detection is safe

Follows the same `$(uname -m) && case ... esac` pattern already used elsewhere in this Dockerfile (protoc, JindoSDK, Go installation).

# Testing

Locally rebuilt compile image with the fix and verified `nvmf_tgt` starts without the VPCLMULQDQ error on a Fedora 37 Vagrant VM.

# Impact

- **No more crash** on CPUs without VPCLMULQDQ
- **ARM64** unchanged: stays `native`
- **SPDK `nvmf_tgt`** bottleneck is PCIe/NVMe latency, not CPU math, data path is DMA, not SIMD loops. The perf loss from losing AVX-512/VPCLMULQDQ is negligible for this workload.

- **x86_64 perf regression**: `nehalem` baseline omits newer instructions (VPCLMULQDQ). In practice, the target is network/disk-bound, so this is unlikely to matter.
- **Old GHCR tag still broken**: The `rocky9` multi-arch manifest on GHCR still points to the old `--target-arch=native` build until someone rebuilds and pushes the fixed compile image.
