### PR TITLE
fix(client): handle channel close gracefully in FsWriterBuffer write_…

### DIFF
--- a/curvine-client/src/file/fs_writer_buffer.rs
+++ b/curvine-client/src/file/fs_writer_buffer.rs
@@ -211,12 +211,18 @@ impl FsWriterBuffer {
             let select_task = tokio::select! {
                 biased;
 
-                chunk = chunk_receiver.recv_check() => {
-                   SelectTask::Data(chunk?)
+                chunk = chunk_receiver.recv() => {
+                   let Some(chunk) = chunk else {
+                        return Ok(())
+                    };
+                   SelectTask::Data(chunk)
                 }
 
-                task = task_receiver.recv_check() => {
-                    SelectTask::Control(task?)
+                task = task_receiver.recv() => {
+                    let Some(task) = task else {
+                        return Ok(())
+                    };
+                    SelectTask::Control(task)
                 }
             };
 


### PR DESCRIPTION
FsWriterBuffer::write_future` uses a `tokio::select!` loop to
receive either data chunks (`chunk_receiver`) or control tasks
(`task_receiver`) from two channels. Previously, both receivers
called `recv_check()`, which converts a `None` (sender dropped /
channel closed) into an `IOResult<T>` error with the message
"the sender dropped".

This is problematic because a closed channel is the **normal
shutdown path** — when `FsWriterBuffer` is dropped, its senders are
dropped and the channels close. The old code treated this as an
error, causing spurious error propagation and potentially confusing
error logs during clean shutdown.

This change switches both receivers to `recv()` (which returns
`Option<T>`) and explicitly handles `None` by returning `Ok(())`,
treating channel closure as a graceful termination.