### PR TITLE
fix(orpc): skip logger init when tracing subscriber already set (#967)

### DIFF
--- a/orpc/src/common/logger.rs
+++ b/orpc/src/common/logger.rs
@@ -20,6 +20,7 @@ use std::collections::HashSet;
 use std::io;
 use std::str::FromStr;
 use std::sync::Arc;
+use tracing::dispatcher;
 use tracing::Level;
 use tracing_appender::non_blocking::{NonBlocking, WorkerGuard};
 use tracing_subscriber::filter::{filter_fn, LevelFilter};
@@ -78,17 +79,26 @@ impl Logger {
     pub const TARGET_STDERR: &'static str = "stderr";
 
     pub fn new(conf: LogConf) -> Self {
+        if dispatcher::has_been_set() {
+            Self::log_skip_existing_subscriber();
+            return Logger { inner: vec![] };
+        }
+
         if !conf.targets.is_empty() {
             Self::init_with_target(conf)
         } else {
             let level = Level::from_str(&conf.level).unwrap_or(Level::INFO);
             let (writer, guard) = Self::create_writer(&conf);
-            tracing_subscriber::fmt()
-                .with_max_level(level)
-                .with_ansi(false)
-                .event_format(LogFormatter::new(&conf))
-                .with_writer(writer)
-                .init();
+            if !Self::try_install(|| {
+                tracing_subscriber::fmt()
+                    .with_max_level(level)
+                    .with_ansi(false)
+                    .event_format(LogFormatter::new(&conf))
+                    .with_writer(writer)
+                    .try_init()
+            }) {
+                return Logger { inner: vec![] };
+            }
             Logger { inner: vec![guard] }
         }
     }
@@ -170,11 +180,35 @@ impl Logger {
         // Global level filter: sets MAX_LEVEL_HINT so tracing callsite macros
         // skip disabled events before constructing them, consistent with the
         // simple path's .with_max_level(level).
-        tracing_subscriber::registry()
-            .with(layers)
-            .with(LevelFilter::from_level(level))
-            .init();
+        if !Self::try_install(|| {
+            tracing_subscriber::registry()
+                .with(layers)
+                .with(LevelFilter::from_level(level))
+                .try_init()
+        }) {
+            return Logger { inner: vec![] };
+        }
         Logger { inner: guards }
+    }
+
+    /// Installs a global tracing subscriber when none is set yet.
+    ///
+    /// Returns `false` when installation fails (e.g. a race with another initializer).
+    fn try_install<E>(install: impl FnOnce() -> Result<(), E>) -> bool {
+        match install() {
+            Ok(()) => true,
+            Err(_) => {
+                Self::log_skip_existing_subscriber();
+                false
+            }
+        }
+    }
+
+    fn log_skip_existing_subscriber() {
+        tracing::warn!(
+            target: "orpc::logger",
+            "global tracing subscriber already set; skipping Curvine logger initialization"
+        );
     }
 
     pub fn default() {

--- a/orpc/tests/logger_test.rs
+++ b/orpc/tests/logger_test.rs
@@ -1,0 +1,25 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use orpc::common::{LogConf, Logger};
+
+#[test]
+fn logger_init_does_not_panic_when_global_subscriber_already_set() {
+    let _ = tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::ERROR)
+        .with_test_writer()
+        .try_init();
+
+    Logger::init(LogConf::default());
+}

--- a/orpc/tests/logger_test.rs
+++ b/orpc/tests/logger_test.rs
@@ -13,13 +13,20 @@
 // limitations under the License.
 
 use orpc::common::{LogConf, Logger};
+use tracing::dispatcher;
 
 #[test]
 fn logger_init_does_not_panic_when_global_subscriber_already_set() {
-    let _ = tracing_subscriber::fmt()
+    let init_result = tracing_subscriber::fmt()
         .with_max_level(tracing::Level::ERROR)
         .with_test_writer()
         .try_init();
+
+    assert!(
+        init_result.is_ok() || dispatcher::has_been_set(),
+        "expected global tracing subscriber to be installed"
+    );
+    assert!(dispatcher::has_been_set());
 
     Logger::init(LogConf::default());
 }


### PR DESCRIPTION
## Summary

- Fix panic when `curvine-libsdk` is embedded in a host application that has already installed a global `tracing` subscriber
- `Logger::init` now checks `tracing::dispatcher::has_been_set()` and uses `try_init()` instead of `init()`, gracefully deferring to the host logging configuration

## Issue/Design

Fixes #967

When `hottable` (or other services) integrate `curvine-libsdk` with `curvine.mode=sdk`, the host typically initializes its own tracing subscriber first (log path, level, format, desensitization, appenders). Previously, `Session::from_cluster_conf` called `Logger::init`, which panicked with `SetGlobalDefaultError`.

Design: fix at the `orpc::Logger` layer so all callers (libsdk, cli, server, fuse) benefit. Standalone binaries are unchanged when no subscriber is set.

## Changes

| File | Change |
|------|--------|
| `orpc/src/common/logger.rs` | Early `has_been_set()` check; replace `.init()` with `.try_init()` on both simple and multi-target paths |
| `orpc/tests/logger_test.rs` | Integration test: pre-install subscriber, then `Logger::init` must not panic |

## Test verified

- [x] `cargo test -p orpc logger_init_does_not_panic_when_global_subscriber_already_set -- --test-threads=1`
- [x] `cargo test -p orpc` (51 tests pass)
- [x] `cargo clippy -p orpc -- -D warnings`

## Dependencies

None