### PR TITLE
fix(master): decouple auto-cache planning from submit RPC (#984)

### DIFF
--- a/curvine-common/src/conf/job_conf.rs
+++ b/curvine-common/src/conf/job_conf.rs
@@ -14,6 +14,7 @@
 
 use crate::FsResult;
 use orpc::common::DurationUnit;
+use orpc::err_box;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
@@ -36,6 +37,9 @@ pub struct JobConf {
     // Maximum number of files allowed to be loaded by a job
     pub job_max_files: usize,
 
+    // Maximum concurrent master-side load job planning tasks
+    pub master_max_concurrent_load_jobs: usize,
+
     // Maximum execution time allowed for a task.
     #[serde(skip)]
     pub task_timeout: Duration,
@@ -56,6 +60,7 @@ impl JobConf {
     pub const DEFAULT_JOB_LIFE_TTL: &'static str = "24h";
     pub const DEFAULT_JOB_CLEANUP_TTL_STR: &'static str = "10m";
     pub const DEFAULT_JOB_MAX_FILES: usize = 100000;
+    pub const DEFAULT_MASTER_MAX_CONCURRENT_LOAD_JOBS: usize = 16;
     pub const DEFAULT_TASK_TIMEOUT: &'static str = "1h";
     pub const DEFAULT_TASK_REPORT_INTERVAL: &'static str = "10s";
     pub const DEFAULT_WORKER_MAX_CONCURRENT_TASKS: usize = 100;
@@ -66,6 +71,9 @@ impl JobConf {
         self.task_timeout = DurationUnit::from_str(&self.task_timeout_str)?.as_duration();
         self.task_report_interval =
             DurationUnit::from_str(&self.task_report_interval_str)?.as_duration();
+        if self.master_max_concurrent_load_jobs == 0 {
+            return err_box!("job.master_max_concurrent_load_jobs must be > 0");
+        }
 
         Ok(())
     }
@@ -80,6 +88,7 @@ impl Default for JobConf {
             job_cleanup_ttl_str: Self::DEFAULT_JOB_CLEANUP_TTL_STR.to_string(),
 
             job_max_files: Self::DEFAULT_JOB_MAX_FILES,
+            master_max_concurrent_load_jobs: Self::DEFAULT_MASTER_MAX_CONCURRENT_LOAD_JOBS,
 
             task_timeout: Default::default(),
             task_timeout_str: Self::DEFAULT_TASK_TIMEOUT.to_string(),

--- a/curvine-server/src/master/job/job_context.rs
+++ b/curvine-server/src/master/job/job_context.rs
@@ -41,6 +41,7 @@ impl TaskDetail {
 #[derive(Clone)]
 pub struct JobContext {
     pub info: LoadJobInfo,
+    pub run_id: u64,
     pub state: StateMonitor,
     pub progress: JobTaskProgress,
     pub assigned_workers: FastHashSet<WorkerAddress>,
@@ -55,6 +56,7 @@ impl JobContext {
         target_path: String,
         mnt: &MountInfo,
         client_conf: &ClientConf,
+        run_id: u64,
     ) -> Self {
         let replicas = job_conf
             .replicas
@@ -88,6 +90,7 @@ impl JobContext {
 
         JobContext {
             info: job,
+            run_id,
             state: StateMonitor::new(JobTaskState::Pending.into()),
             progress: Default::default(),
             assigned_workers: Default::default(),
@@ -103,6 +106,15 @@ impl JobContext {
         self.assigned_workers.insert(task.worker.clone());
         self.tasks
             .insert(task.task_id.clone(), TaskDetail::new(task));
+    }
+
+    pub fn add_task_detail(&mut self, task_id: String, detail: TaskDetail) {
+        self.update_state(
+            JobTaskState::Loading,
+            format!("Assigned to worker {}", detail.task.worker),
+        );
+        self.assigned_workers.insert(detail.task.worker.clone());
+        self.tasks.insert(task_id, detail);
     }
 
     pub fn update_state(&mut self, state: JobTaskState, message: impl Into<String>) {

--- a/curvine-server/src/master/job/job_manager.rs
+++ b/curvine-server/src/master/job/job_manager.rs
@@ -25,11 +25,13 @@ use curvine_common::state::{
     JobStatus, JobTaskProgress, JobTaskState, LoadJobCommand, LoadJobResult,
 };
 use curvine_common::FsResult;
-use log::{debug, info};
+use log::{debug, info, warn};
 use orpc::common::LocalTime;
-use orpc::runtime::{LoopTask, Runtime};
+use orpc::runtime::{LoopTask, RpcRuntime, Runtime};
+use orpc::sync::AtomicCounter;
 use orpc::{err_box, err_ext, CommonResult};
 use std::sync::Arc;
+use tokio::sync::Semaphore;
 use tokio::time::timeout;
 
 /// Load the Task Manager
@@ -42,6 +44,8 @@ pub struct JobManager {
     job_life_ttl: Duration,
     job_cleanup_ttl: Duration,
     job_max_files: usize,
+    run_seq: Arc<AtomicCounter>,
+    load_job_semaphore: Arc<Semaphore>,
 }
 
 impl JobManager {
@@ -62,6 +66,8 @@ impl JobManager {
             job_life_ttl: conf.job.job_life_ttl,
             job_cleanup_ttl: conf.job.job_cleanup_ttl,
             job_max_files: conf.job.job_max_files,
+            run_seq: Arc::new(AtomicCounter::new(0)),
+            load_job_semaphore: Arc::new(Semaphore::new(conf.job.master_max_concurrent_load_jobs)),
         }
     }
 
@@ -139,6 +145,7 @@ impl JobManager {
             self.master_fs.clone(),
             self.factory.clone(),
             self.job_max_files,
+            self.run_seq.clone(),
         )
     }
 
@@ -173,7 +180,38 @@ impl JobManager {
         };
 
         let job_runner = self.create_runner();
-        job_runner.submit_load_task(command, mnt).await
+        let (res, queued) = job_runner.enqueue_load_job(command, mnt)?;
+
+        if let Some(queued) = queued {
+            let runner = self.create_runner();
+            let job_id = res.job_id.clone();
+            let semaphore = self.load_job_semaphore.clone();
+            let jobs = self.jobs.clone();
+            self.rt.spawn(async move {
+                let _permit = match semaphore.acquire_owned().await {
+                    Ok(permit) => permit,
+                    Err(err) => {
+                        warn!(
+                            "async load job {} failed to acquire permit: {}",
+                            job_id, err
+                        );
+                        jobs.update_state_if_run(
+                            &queued.job_id,
+                            queued.run_id,
+                            JobTaskState::Failed,
+                            format!("async load job failed to acquire permit: {}", err),
+                        );
+                        return;
+                    }
+                };
+
+                if let Err(err) = runner.run_queued_load_job(queued).await {
+                    warn!("async load job {} failed: {}", job_id, err);
+                }
+            });
+        }
+
+        Ok(res)
     }
 
     /// Handle cancellation of tasks
@@ -191,7 +229,6 @@ impl JobManager {
                         "job {} is already in final state {:?}, source_path: {}, target_path: {}",
                         job_id, state, job.info.source_path, job.info.target_path
                     );
-                    self.update_state(job_id, JobTaskState::Canceled, "Canceling job by user")?;
                     return Ok(());
                 }
 

--- a/curvine-server/src/master/job/job_runner.rs
+++ b/curvine-server/src/master/job/job_runner.rs
@@ -21,7 +21,8 @@ use curvine_common::conf::ClientConf;
 use curvine_common::error::FsError;
 use curvine_common::fs::{FileSystem, Path};
 use curvine_common::state::{
-    JobTaskState, LoadJobCommand, LoadJobResult, LoadTaskInfo, MountInfo, WorkerAddress,
+    JobTaskState, LoadJobCommand, LoadJobInfo, LoadJobResult, LoadTaskInfo, MountInfo,
+    WorkerAddress,
 };
 use curvine_common::utils::CommonUtils;
 use curvine_common::FsResult;
@@ -30,6 +31,7 @@ use futures::future;
 use log::{debug, error, info, warn};
 use orpc::common::{ByteUnit, FastHashMap, FastHashSet, LocalTime};
 use orpc::err_box;
+use orpc::sync::AtomicCounter;
 use std::collections::LinkedList;
 use std::sync::Arc;
 
@@ -38,20 +40,36 @@ pub struct LoadJobRunner {
     master_fs: MasterFilesystem,
     factory: Arc<UfsFactory>,
     job_max_files: usize,
+    run_seq: Arc<AtomicCounter>,
+}
+
+#[derive(Clone)]
+pub(crate) struct QueuedLoadJob {
+    pub(crate) job_id: String,
+    pub(crate) run_id: u64,
+}
+
+struct PlannedLoadJob {
+    tasks: FastHashMap<String, TaskDetail>,
+    total_size: i64,
 }
 
 impl LoadJobRunner {
+    const RUN_ID_SEQ_MOD: u64 = 1_000_000;
+
     pub fn new(
         jobs: JobStore,
         master_fs: MasterFilesystem,
         factory: Arc<UfsFactory>,
         job_max_files: usize,
+        run_seq: Arc<AtomicCounter>,
     ) -> Self {
         Self {
             jobs,
             master_fs,
             factory,
             job_max_files,
+            run_seq,
         }
     }
 
@@ -66,20 +84,51 @@ impl LoadJobRunner {
         }
     }
 
-    async fn check_job_exists(
+    fn build_job_context(
         &self,
-        job: &JobContext,
+        command: &LoadJobCommand,
+        mnt: &MountInfo,
+    ) -> FsResult<(JobContext, Path, Path)> {
+        let source_path = Path::from_str(&command.source_path)?;
+        let target_path = mnt.toggle_path(&source_path)?;
+        let job_id = CommonUtils::create_job_id(source_path.full_path());
+        let run_id = self.next_run_id();
+        let job_context = JobContext::with_conf(
+            command,
+            job_id,
+            source_path.clone_uri(),
+            target_path.clone_uri(),
+            mnt,
+            &ClientConf::default(),
+            run_id,
+        );
+
+        Ok((job_context, source_path, target_path))
+    }
+
+    fn next_run_id(&self) -> u64 {
+        LocalTime::mills()
+            .saturating_mul(Self::RUN_ID_SEQ_MOD)
+            .saturating_add(self.run_seq.next() % Self::RUN_ID_SEQ_MOD)
+    }
+
+    fn running_job_result(&self, job_id: &str) -> Option<LoadJobResult> {
+        self.jobs.get(job_id).and_then(|exist_job| {
+            let state: JobTaskState = exist_job.state.state();
+            if state.is_running() {
+                Some(LoadJobResult::with_state(&exist_job.info, state))
+            } else {
+                None
+            }
+        })
+    }
+
+    async fn check_already_loaded(
+        &self,
         mnt: &MountValue,
         source_path: &Path,
         target_path: &Path,
-    ) -> FsResult<Option<LoadJobResult>> {
-        if let Some(exist_job) = self.jobs.get(&job.info.job_id) {
-            let state: JobTaskState = exist_job.state.state();
-            if state.is_running() {
-                return Ok(Some(LoadJobResult::with_state(&exist_job.info, state)));
-            }
-        }
-
+    ) -> FsResult<bool> {
         // Data-state fast-path. Applies whether the slot was vacant or held
         // a terminal ctx — e.g. after JobCleanupTask, after master restart +
         // journal replay, or after an earlier run completed the sync.
@@ -87,31 +136,73 @@ impl LoadJobRunner {
         // Only UFS→CV imports can be fast-skipped here; CV sources always
         // need an explicit export task.
         if source_path.is_cv() {
-            return Ok(None);
+            return Ok(false);
         }
 
         // Target not present in Curvine yet — must load.
         let cv_status = match self.master_fs.file_status(target_path.path()) {
             Ok(cv_status) => cv_status,
-            Err(FsError::FileNotFound(_)) => return Ok(None),
+            Err(FsError::FileNotFound(_)) => return Ok(false),
             Err(err) => return Err(err),
         };
 
         // Cached target exists but its own metadata says it isn't usable — must reload.
         if !cv_status.cv_valid(None) {
-            return Ok(None);
+            return Ok(false);
         }
 
         // Target looks valid locally; confirm against UFS source before skipping.
         let source_status = mnt.ufs.get_status(source_path).await?;
-        if cv_status.cv_valid(Some(&source_status)) {
-            Ok(Some(LoadJobResult::with_state(
-                &job.info,
-                JobTaskState::Completed,
-            )))
-        } else {
-            Ok(None)
+        Ok(cv_status.cv_valid(Some(&source_status)))
+    }
+
+    pub(crate) fn enqueue_load_job(
+        &self,
+        command: LoadJobCommand,
+        mnt: MountInfo,
+    ) -> FsResult<(LoadJobResult, Option<QueuedLoadJob>)> {
+        let (job_context, source_path, target_path) = self.build_job_context(&command, &mnt)?;
+        let job_id = job_context.info.job_id.clone();
+        let run_id = job_context.run_id;
+
+        match self.jobs.entry(job_id.clone()) {
+            Entry::Occupied(mut e) => {
+                let state: JobTaskState = e.get().state.state();
+                if state.is_running() {
+                    let existing = e.get();
+                    debug!(
+                        "job {} already running during enqueue (state={:?})",
+                        job_id, state
+                    );
+                    return Ok((LoadJobResult::with_state(&existing.info, state), None));
+                }
+                info!(
+                    "job {} previous run in terminal state {:?}, replacing",
+                    job_id, state
+                );
+                e.insert(job_context);
+            }
+
+            Entry::Vacant(e) => {
+                e.insert(job_context);
+            }
         }
+
+        debug!(
+            "queued load job {}: {} -> {}",
+            job_id,
+            source_path.full_path(),
+            target_path.full_path()
+        );
+
+        let job = match self.jobs.get(&job_id) {
+            Some(job) => job,
+            None => return err_box!("queued job {} missing after insert", job_id),
+        };
+        Ok((
+            LoadJobResult::with_job(&job.info),
+            Some(QueuedLoadJob { job_id, run_id }),
+        ))
     }
 
     /// Submits a load job for the given source path (and mount).
@@ -128,22 +219,17 @@ impl LoadJobRunner {
         command: LoadJobCommand,
         mnt: MountInfo,
     ) -> FsResult<LoadJobResult> {
-        let source_path = Path::from_str(&command.source_path)?;
-        let target_path = mnt.toggle_path(&source_path)?;
+        let (mut job_context, source_path, target_path) = self.build_job_context(&command, &mnt)?;
+        let job_id = job_context.info.job_id.clone();
+        let run_id = job_context.run_id;
 
-        let job_id = CommonUtils::create_job_id(source_path.full_path());
-        let mut job_context = JobContext::with_conf(
-            &command,
-            job_id.clone(),
-            source_path.clone_uri(),
-            target_path.clone_uri(),
-            &mnt,
-            &ClientConf::default(),
-        );
+        if let Some(res) = self.running_job_result(&job_id) {
+            return Ok(res);
+        }
 
         let mnt_value = self.factory.get_mnt(&mnt)?;
-        if let Some(res) = self
-            .check_job_exists(&job_context, &mnt_value, &source_path, &target_path)
+        if self
+            .check_already_loaded(&mnt_value, &source_path, &target_path)
             .await?
         {
             info!(
@@ -151,7 +237,10 @@ impl LoadJobRunner {
                 job_id,
                 source_path.full_path()
             );
-            return Ok(res);
+            return Ok(LoadJobResult::with_state(
+                &job_context.info,
+                JobTaskState::Completed,
+            ));
         }
 
         debug!(
@@ -161,9 +250,26 @@ impl LoadJobRunner {
             target_path.full_path()
         );
 
-        let total_size = self
-            .create_all_tasks(&mut job_context, &source_path, &mnt)
+        let planned = self
+            .create_all_tasks(&job_context.info, &source_path, &mnt, run_id)
             .await?;
+        let total_size = planned.total_size;
+        if planned.tasks.is_empty() {
+            info!(
+                "load job {} has no tasks: {} -> {}",
+                job_id,
+                source_path.full_path(),
+                target_path.full_path()
+            );
+            return Ok(LoadJobResult::with_state(
+                &job_context.info,
+                JobTaskState::Completed,
+            ));
+        }
+        let tasks = planned.tasks.clone();
+        for (task_id, detail) in planned.tasks.take() {
+            job_context.add_task_detail(task_id, detail);
+        }
 
         info!(
             "load job {} submitted: {} -> {}, tasks {}, total_size {}",
@@ -174,7 +280,6 @@ impl LoadJobRunner {
             ByteUnit::byte_to_string(total_size as u64)
         );
 
-        let tasks = job_context.tasks.clone();
         let res = LoadJobResult::with_job(&job_context.info);
 
         // Install / replace the ctx into the store atomically. We branch into:
@@ -225,6 +330,174 @@ impl LoadJobRunner {
         Ok(res)
     }
 
+    pub(crate) async fn run_queued_load_job(&self, queued: QueuedLoadJob) -> FsResult<()> {
+        let job_info = match self.current_job_info(&queued) {
+            Some(job_info) => job_info,
+            None => return Ok(()),
+        };
+
+        let source_path = Path::from_str(&job_info.source_path)?;
+        let target_path = Path::from_str(&job_info.target_path)?;
+        let mnt = job_info.mount_info.clone();
+        let mnt_value = match self.factory.get_mnt(&mnt) {
+            Ok(mnt_value) => mnt_value,
+            Err(err) => {
+                self.jobs.update_state_if_run(
+                    &queued.job_id,
+                    queued.run_id,
+                    JobTaskState::Failed,
+                    format!("prepare UFS failed: {}", err),
+                );
+                return Err(err);
+            }
+        };
+
+        let already_loaded = match self
+            .check_already_loaded(&mnt_value, &source_path, &target_path)
+            .await
+        {
+            Ok(already_loaded) => already_loaded,
+            Err(err) => {
+                self.jobs.update_state_if_run(
+                    &queued.job_id,
+                    queued.run_id,
+                    JobTaskState::Failed,
+                    format!("check cached file failed: {}", err),
+                );
+                return Err(err);
+            }
+        };
+        if already_loaded {
+            info!(
+                "queued load job {} already loaded: {} -> {}",
+                queued.job_id,
+                source_path.full_path(),
+                target_path.full_path()
+            );
+            self.jobs.update_state_if_run(
+                &queued.job_id,
+                queued.run_id,
+                JobTaskState::Completed,
+                "Already loaded",
+            );
+            return Ok(());
+        }
+
+        let planned = match self
+            .create_all_tasks(&job_info, &source_path, &mnt, queued.run_id)
+            .await
+        {
+            Ok(planned) => planned,
+            Err(err) => {
+                self.jobs.update_state_if_run(
+                    &queued.job_id,
+                    queued.run_id,
+                    JobTaskState::Failed,
+                    format!("plan load job failed: {}", err),
+                );
+                return Err(err);
+            }
+        };
+        let total_size = planned.total_size;
+        let task_count = planned.tasks.len();
+        if task_count == 0 {
+            info!(
+                "queued load job {} has no tasks: {} -> {}",
+                queued.job_id,
+                source_path.full_path(),
+                target_path.full_path()
+            );
+            self.jobs.update_state_if_run(
+                &queued.job_id,
+                queued.run_id,
+                JobTaskState::Completed,
+                "No load tasks to dispatch",
+            );
+            return Ok(());
+        }
+        let tasks = planned.tasks.clone();
+        let assigned_workers = Self::assigned_workers(&tasks);
+
+        if !self.install_plan_if_current(&queued, planned) {
+            debug!(
+                "skip dispatch for stale queued load job {} run {}",
+                queued.job_id, queued.run_id
+            );
+            return Ok(());
+        }
+
+        info!(
+            "queued load job {} planned: {} -> {}, tasks {}, total_size {}",
+            queued.job_id,
+            source_path.full_path(),
+            target_path.full_path(),
+            task_count,
+            ByteUnit::byte_to_string(total_size as u64)
+        );
+
+        if !self.is_current_running(&queued) {
+            return Ok(());
+        }
+
+        if let Err(err) = self.submit_all_task(tasks).await {
+            warn!("dispatch load job {} failed: {}", queued.job_id, err);
+            let failed_current_run = self.jobs.update_state_if_run(
+                &queued.job_id,
+                queued.run_id,
+                JobTaskState::Failed,
+                format!("dispatch failed: {}", err),
+            );
+            if failed_current_run {
+                self.cancel_workers_best_effort(&queued.job_id, &assigned_workers)
+                    .await;
+            }
+            return Err(err);
+        }
+
+        Ok(())
+    }
+
+    fn assigned_workers(tasks: &FastHashMap<String, TaskDetail>) -> FastHashSet<WorkerAddress> {
+        let mut workers = FastHashSet::default();
+        for detail in tasks.values() {
+            workers.insert(detail.task.worker.clone());
+        }
+        workers
+    }
+
+    fn current_job_info(&self, queued: &QueuedLoadJob) -> Option<LoadJobInfo> {
+        self.jobs.get(&queued.job_id).and_then(|job| {
+            let state: JobTaskState = job.state.state();
+            if job.run_id == queued.run_id && state.is_running() {
+                Some(job.info.clone())
+            } else {
+                None
+            }
+        })
+    }
+
+    fn is_current_running(&self, queued: &QueuedLoadJob) -> bool {
+        self.current_job_info(queued).is_some()
+    }
+
+    fn install_plan_if_current(&self, queued: &QueuedLoadJob, planned: PlannedLoadJob) -> bool {
+        let mut job = match self.jobs.get_mut(&queued.job_id) {
+            Some(job) => job,
+            None => return false,
+        };
+
+        let state: JobTaskState = job.state.state();
+        if job.run_id != queued.run_id || !state.is_running() {
+            return false;
+        }
+
+        for (task_id, detail) in planned.tasks.take() {
+            job.add_task_detail(task_id, detail);
+        }
+
+        true
+    }
+
     async fn submit_all_task(&self, tasks: FastHashMap<String, TaskDetail>) -> FsResult<()> {
         let submit_futures: Vec<_> = tasks
             .take()
@@ -244,10 +517,11 @@ impl LoadJobRunner {
 
     async fn create_all_tasks(
         &self,
-        job: &mut JobContext,
+        job: &LoadJobInfo,
         source_path: &Path,
         mnt: &MountInfo,
-    ) -> FsResult<i64> {
+        run_id: u64,
+    ) -> FsResult<PlannedLoadJob> {
         let source_status = if source_path.is_cv() {
             self.master_fs.file_status(source_path.path())?
         } else {
@@ -255,16 +529,16 @@ impl LoadJobRunner {
             ufs.get_status(source_path).await?
         };
 
-        job.update_state(JobTaskState::Pending, "Assigning workers");
-        let block_size = job.info.block_size;
+        let block_size = job.block_size;
 
         let mut total_size = 0;
+        let mut tasks = FastHashMap::new();
         let mut stack = LinkedList::new();
         let mut task_index = 0;
         stack.push_back(source_status);
 
         // Get target base path for direction detection
-        let target_base = Path::from_str(&job.info.target_path)?;
+        let target_base = Path::from_str(&job.target_path)?;
 
         while let Some(status) = stack.pop_front() {
             if status.is_dir {
@@ -303,26 +577,22 @@ impl LoadJobRunner {
                     );
                 };
 
-                let task_id = format!("{}_task_{}", job.info.job_id, task_index);
+                let task_id = format!("{}_run_{}_task_{}", job.job_id, run_id, task_index);
                 task_index += 1;
                 total_size += status.len;
 
                 let task = LoadTaskInfo {
-                    job: job.info.clone(),
+                    job: job.clone(),
                     task_id: task_id.clone(),
                     worker: worker.clone(),
                     source_path: source_path.clone_uri(),
                     target_path: target_path.clone_uri(),
                     create_time: LocalTime::mills() as i64,
                 };
-                job.add_task(task.clone());
+                tasks.insert(task_id.clone(), TaskDetail::new(task));
 
-                if job.tasks.len() > self.job_max_files {
-                    return err_box!(
-                        "Job {} files exceeds {}",
-                        job.info.job_id,
-                        self.job_max_files
-                    );
+                if tasks.len() > self.job_max_files {
+                    return err_box!("Job {} files exceeds {}", job.job_id, self.job_max_files);
                 }
                 debug!(
                     "created sub-task {} ({} -> {})",
@@ -333,7 +603,7 @@ impl LoadJobRunner {
             }
         }
 
-        Ok(total_size)
+        Ok(PlannedLoadJob { tasks, total_size })
     }
 
     pub async fn cancel_job(
@@ -362,5 +632,31 @@ impl LoadJobRunner {
         }
 
         Ok(())
+    }
+
+    async fn cancel_workers_best_effort(
+        &self,
+        job_id: &str,
+        assigned_workers: &FastHashSet<WorkerAddress>,
+    ) {
+        for worker in assigned_workers.iter() {
+            let client = match self.factory.get_worker_client(worker).await {
+                Ok(client) => client,
+                Err(err) => {
+                    error!(
+                        "failed to create cancel client for worker {}: {}",
+                        worker, err
+                    );
+                    continue;
+                }
+            };
+
+            if let Err(err) = client.cancel_job(job_id).await {
+                error!(
+                    "failed to send cancel request to worker {}: {}",
+                    worker, err
+                );
+            }
+        }
     }
 }

--- a/curvine-server/src/master/job/job_store.rs
+++ b/curvine-server/src/master/job/job_store.rs
@@ -15,6 +15,7 @@
 use crate::master::JobContext;
 use curvine_common::state::{JobTaskProgress, JobTaskState};
 use curvine_common::FsResult;
+use log::{debug, error};
 use orpc::err_box;
 use orpc::sync::FastDashMap;
 use std::collections::HashMap;
@@ -128,6 +129,21 @@ impl JobStore {
         };
 
         let old_state: JobTaskState = job.state.state();
+        if old_state.is_finish() {
+            debug!(
+                "ignore task report for terminal job {}, task {}, state {:?}",
+                job_id, task_id, old_state
+            );
+            return Ok(());
+        }
+
+        if !job.tasks.contains_key(task_id) {
+            debug!(
+                "ignore stale task report for job {}, unknown task {}",
+                job_id, task_id
+            );
+            return Ok(());
+        }
 
         job.update_progress(task_id, progress)?;
 
@@ -163,6 +179,41 @@ impl JobStore {
             }
         }
         Ok(())
+    }
+
+    pub fn update_state_if_run(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        state: JobTaskState,
+        message: impl Into<String>,
+    ) -> bool {
+        let mut job = match self.jobs.get_mut(job_id) {
+            Some(job) => job,
+            None => return false,
+        };
+
+        let old_state: JobTaskState = job.state.state();
+        if job.run_id != run_id || !old_state.is_running() {
+            return false;
+        }
+
+        job.update_state(state, message);
+        let new_state = state;
+
+        if old_state != new_state {
+            let job_clone = (*job).clone();
+            drop(job);
+
+            if let Err(err) = self.trigger_callbacks(job_id, old_state, new_state, &job_clone) {
+                error!(
+                    "failed to trigger job callbacks for {} after run-scoped state update: {}",
+                    job_id, err
+                );
+            }
+        }
+
+        true
     }
 
     pub fn remove_callbacks(&self, job_id: &str) -> FsResult<()> {

--- a/curvine-server/src/worker/task/load_task_runner.rs
+++ b/curvine-server/src/worker/task/load_task_runner.rs
@@ -79,10 +79,18 @@ impl LoadTaskRunner {
     }
 
     async fn run0(&self) -> FsResult<()> {
+        if self.task.is_cancel() {
+            info!("task {} was cancelled", self.task.info.task_id);
+            return Ok(());
+        }
         self.task
             .update_state(JobTaskState::Loading, "Task started");
 
         let (mut reader, mut writer) = self.create_stream().await?;
+        if self.task.is_cancel() {
+            info!("task {} was cancelled", self.task.info.task_id);
+            return Ok(());
+        }
         let mut last_progress_time = LocalTime::mills();
         let mut read_cost_ms = 0;
         let mut total_cost_ms = 0;
@@ -90,7 +98,7 @@ impl LoadTaskRunner {
         loop {
             if self.task.is_cancel() {
                 info!("task {} was cancelled", self.task.info.task_id);
-                break;
+                return Ok(());
             }
 
             let spend = TimeSpent::new();

--- a/curvine-server/src/worker/task/task_context.rs
+++ b/curvine-server/src/worker/task/task_context.rs
@@ -72,6 +72,11 @@ impl TaskContext {
 
     pub fn update_state(&self, state: JobTaskState, message: impl Into<String>) {
         let mut lock = self.progress();
+        if self.state.state::<JobTaskState>() == JobTaskState::Canceled
+            && state != JobTaskState::Canceled
+        {
+            return;
+        }
         self.state.set_state(state);
         lock.message = message.into();
         lock.update_time = LocalTime::mills() as i64;
@@ -84,6 +89,15 @@ impl TaskContext {
         is_last: bool,
     ) -> JobTaskProgress {
         let mut lock = self.progress();
+        if self.state.state::<JobTaskState>() == JobTaskState::Canceled {
+            return JobTaskProgress {
+                state: JobTaskState::Canceled,
+                total_size: lock.total_size,
+                loaded_size: lock.loaded_size,
+                update_time: lock.update_time,
+                message: lock.message.clone(),
+            };
+        }
 
         lock.loaded_size = loaded_size;
         lock.total_size = total_size;

--- a/curvine-server/src/worker/task/task_store.rs
+++ b/curvine-server/src/worker/task/task_store.rs
@@ -15,7 +15,7 @@
 use std::ops::Deref;
 use std::sync::Arc;
 
-use curvine_common::state::LoadTaskInfo;
+use curvine_common::state::{JobTaskState, LoadTaskInfo};
 use orpc::sync::FastDashMap;
 
 use crate::worker::task::TaskContext;
@@ -60,6 +60,7 @@ impl TaskStore {
     pub fn cancel(&self, job_id: impl AsRef<str>) -> Vec<Arc<TaskContext>> {
         let all_tasks = self.get_all_tasks(job_id);
         for context in all_tasks.iter() {
+            context.update_state(JobTaskState::Canceled, "canceled by master");
             let _ = self.tasks.remove(&context.info.task_id);
         }
 

--- a/curvine-server/tests/load_job_submit_test.rs
+++ b/curvine-server/tests/load_job_submit_test.rs
@@ -1,0 +1,265 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use curvine_common::conf::{ClientConf, ClusterConf, JournalConf, MasterConf};
+use curvine_common::state::{
+    JobTaskProgress, JobTaskState, LoadJobCommand, LoadJobInfo, LoadTaskInfo, MountInfo,
+    MountOptions, StorageType, TtlAction, WorkerAddress, WorkerInfo,
+};
+use curvine_server::master::fs::MasterFilesystem;
+use curvine_server::master::journal::JournalSystem;
+use curvine_server::master::{JobContext, JobManager, JobStore, Master};
+use curvine_server::worker::task::{TaskContext, TaskStore};
+use orpc::common::Utils;
+use orpc::runtime::{AsyncRuntime, RpcRuntime, Runtime};
+use orpc::CommonResult;
+use std::sync::Arc;
+use std::time::Duration;
+
+fn new_job_manager(name: &str) -> CommonResult<(Arc<JobManager>, Arc<Runtime>, String)> {
+    Master::init_test_metrics();
+    let test_name = format!("{}-{}", name, Utils::rand_id());
+
+    let conf = ClusterConf {
+        format_master: true,
+        testing: true,
+        master: MasterConf {
+            meta_dir: Utils::test_sub_dir(format!("load-job-submit/meta-{}", test_name)),
+            ..Default::default()
+        },
+        journal: JournalConf {
+            enable: false,
+            journal_dir: Utils::test_sub_dir(format!("load-job-submit/journal-{}", test_name)),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let journal_system = JournalSystem::from_conf(&conf)?;
+    let master_fs = MasterFilesystem::with_js(&conf, &journal_system);
+    master_fs.add_test_worker(WorkerInfo::default());
+
+    let mount_manager = journal_system.mount_manager();
+    let rt = Arc::new(AsyncRuntime::single());
+    let job_manager = Arc::new(JobManager::from_cluster_conf(
+        master_fs,
+        mount_manager.clone(),
+        rt.clone(),
+        &conf,
+    ));
+
+    let ufs_root_dir = Utils::test_sub_dir(format!("load-job-submit/ufs-{}", test_name));
+    let ufs_root = format!("file://{}", ufs_root_dir);
+    mount_manager.mount(None, "/mnt", &ufs_root, &MountOptions::builder().build())?;
+
+    Ok((job_manager, rt, format!("{}/missing-file", ufs_root)))
+}
+
+fn load_task(task_id: &str, job_id: &str) -> LoadTaskInfo {
+    let job = LoadJobInfo {
+        job_id: job_id.to_string(),
+        source_path: "file://source".to_string(),
+        target_path: "/mnt/source".to_string(),
+        replicas: 1,
+        block_size: 4096,
+        storage_type: StorageType::default(),
+        ttl_ms: 0,
+        ttl_action: TtlAction::default(),
+        mount_info: MountInfo::default(),
+        create_time: 0,
+        overwrite: None,
+    };
+
+    LoadTaskInfo {
+        job,
+        task_id: task_id.to_string(),
+        worker: WorkerAddress::default(),
+        source_path: "file://source".to_string(),
+        target_path: "/mnt/source".to_string(),
+        create_time: 0,
+    }
+}
+
+#[test]
+fn submit_load_job_returns_before_ufs_planning() -> CommonResult<()> {
+    let (job_manager, rt, missing_source) = new_job_manager("async-missing-source")?;
+
+    rt.block_on(async move {
+        let result = job_manager
+            .submit_load_job(LoadJobCommand::builder(missing_source).build())
+            .await?;
+
+        assert!(!result.job_id.is_empty());
+        assert_eq!(result.state, JobTaskState::Pending);
+
+        for _ in 0..50 {
+            let status = job_manager.get_job_status(&result.job_id)?;
+            if status.state == JobTaskState::Failed {
+                assert!(
+                    !status.progress.message.is_empty(),
+                    "failed job should keep a diagnostic message"
+                );
+                assert!(
+                    status.progress.update_time > 0,
+                    "failed job should update progress timestamp: {}",
+                    status.progress.update_time
+                );
+                return Ok(());
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        let status = job_manager.get_job_status(&result.job_id)?;
+        panic!(
+            "load job did not fail in background, state={:?}, message={}",
+            status.state, status.progress.message
+        );
+    })
+}
+
+#[test]
+fn empty_directory_load_completes_without_worker_reports() -> CommonResult<()> {
+    let (job_manager, rt, missing_source) = new_job_manager("async-empty-dir")?;
+    let source = missing_source.replace("/missing-file", "/empty-dir");
+    let local_source = source
+        .strip_prefix("file://")
+        .expect("test UFS path uses file scheme");
+    std::fs::create_dir_all(local_source)?;
+
+    rt.block_on(async move {
+        let result = job_manager
+            .submit_load_job(LoadJobCommand::builder(source).build())
+            .await?;
+
+        assert!(!result.job_id.is_empty());
+        assert_eq!(result.state, JobTaskState::Pending);
+
+        for _ in 0..50 {
+            let status = job_manager.get_job_status(&result.job_id)?;
+            if status.state == JobTaskState::Completed {
+                assert_eq!(status.progress.message, "No load tasks to dispatch");
+                return Ok(());
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        let status = job_manager.get_job_status(&result.job_id)?;
+        panic!(
+            "empty directory load did not complete, state={:?}, message={}",
+            status.state, status.progress.message
+        );
+    })
+}
+
+#[test]
+fn late_task_report_does_not_change_terminal_job_state() -> CommonResult<()> {
+    let job_id = "job-terminal";
+    let task_id = "job-terminal_run_1_task_0";
+    let command = LoadJobCommand::builder("file://source").build();
+    let mount = MountInfo::default();
+    let mut job = JobContext::with_conf(
+        &command,
+        job_id.to_string(),
+        "file://source".to_string(),
+        "/mnt/source".to_string(),
+        &mount,
+        &ClientConf::default(),
+        1,
+    );
+    job.add_task(load_task(task_id, job_id));
+
+    let store = JobStore::new();
+    store.insert(job_id.to_string(), job);
+    store.update_state(job_id, JobTaskState::Failed, "dispatch failed")?;
+
+    store.update_progress(
+        job_id,
+        task_id,
+        JobTaskProgress {
+            state: JobTaskState::Completed,
+            loaded_size: 1,
+            total_size: 1,
+            update_time: 1,
+            message: "late completed report".to_string(),
+        },
+    )?;
+
+    let job = store.get(job_id).expect("job exists");
+    assert_eq!(job.state.state::<JobTaskState>(), JobTaskState::Failed);
+    assert_eq!(job.progress.message, "dispatch failed");
+    Ok(())
+}
+
+#[test]
+fn stale_task_report_for_running_job_is_ignored() -> CommonResult<()> {
+    let job_id = "job-running-stale-report";
+    let current_task_id = "job-running-stale-report_run_2_task_0";
+    let stale_task_id = "job-running-stale-report_run_1_task_0";
+    let command = LoadJobCommand::builder("file://source").build();
+    let mount = MountInfo::default();
+    let mut job = JobContext::with_conf(
+        &command,
+        job_id.to_string(),
+        "file://source".to_string(),
+        "/mnt/source".to_string(),
+        &mount,
+        &ClientConf::default(),
+        2,
+    );
+    job.add_task(load_task(current_task_id, job_id));
+
+    let store = JobStore::new();
+    store.insert(job_id.to_string(), job);
+
+    store.update_progress(
+        job_id,
+        stale_task_id,
+        JobTaskProgress {
+            state: JobTaskState::Completed,
+            loaded_size: 1,
+            total_size: 1,
+            update_time: 1,
+            message: "stale completed report".to_string(),
+        },
+    )?;
+
+    let job = store.get(job_id).expect("job exists");
+    assert_eq!(job.state.state::<JobTaskState>(), JobTaskState::Loading);
+    assert_eq!(job.tasks.len(), 1);
+    assert!(job.tasks.contains_key(current_task_id));
+    Ok(())
+}
+
+#[test]
+fn worker_cancel_marks_running_context_canceled() {
+    let store = TaskStore::new();
+    let context = store.insert(load_task("task-cancel", "job-cancel"));
+
+    let canceled = store.cancel("job-cancel");
+
+    assert_eq!(canceled.len(), 1);
+    assert_eq!(context.get_state(), JobTaskState::Canceled);
+    assert!(store.get("task-cancel").is_none());
+}
+
+#[test]
+fn canceled_worker_context_ignores_late_completion_progress() {
+    let context = TaskContext::new(load_task("task-cancel-progress", "job-cancel-progress"));
+    context.update_state(JobTaskState::Canceled, "canceled by master");
+
+    let progress = context.update_progress(1, 1, true);
+
+    assert_eq!(progress.state, JobTaskState::Canceled);
+    assert_eq!(context.get_state(), JobTaskState::Canceled);
+}


### PR DESCRIPTION
# Summary

This PR fixes the auto-cache metadata latency regression reported in #984 by making master `SubmitJob` return after enqueueing the load job instead of synchronously planning it against UFS. UFS status/list planning now runs in bounded background execution, so slow S3/HDFS calls no longer occupy the master RPC critical path for metadata requests.

# Issue Describe / Design

Closes #984

## Root cause

When `auto_cache` is enabled, cache misses trigger `async_cache`, which submits `SubmitJob` RPCs to the master. Before this change, `JobManager::submit_load_job` synchronously called `LoadJobRunner::submit_load_task`, and that path performed UFS work such as `get_status` / recursive task planning before returning.

That made each `SubmitJob` RPC potentially wait on slow S3/HDFS I/O. Because clients share the master connection pool for `SubmitJob`, `GetStatus`, `ListStatus`, and other metadata RPCs, bursts of auto-cache submits caused head-of-line blocking and degraded unrelated metadata operations.

## Reproduction condition

1. Mount a remote UFS path with `auto_cache` enabled.
2. Trigger many first-time reads/cache misses under that mount.
3. Observe a burst of `SubmitJob` RPCs.
4. Metadata RPC latency rises because master-side submit handling waits on UFS planning.

## Fix approach

- Keep the `SubmitJob` RPC path lightweight: validate path/mount, install a `Pending` job in `JobStore`, return `LoadJobResult` immediately.
- Move UFS cache validation, recursive planning, and worker dispatch into `run_queued_load_job` on the master runtime.
- Add `job.master_max_concurrent_load_jobs` with default `16` to bound concurrent master-side UFS planning. Extra accepted jobs wait for permits; they are not dropped.
- Keep the internal `LoadJobRunner::submit_load_task` path synchronous for journal/UFS replay callers that rely on planning and dispatch being complete before returning.
- Add run-scoped task IDs so stale worker reports from an older run cannot update a replaced job. The run id uses timestamp high bits plus local sequence low bits to avoid restart-local id reuse.
- Make terminal job states stable: late worker reports are ignored after `Completed`, `Failed`, or `Canceled`.
- Close cancel/dispatch races by marking worker task contexts as canceled and preventing canceled contexts from being revived by late progress.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-server/src/master/job/job_manager.rs` | Enqueue load jobs in `submit_load_job`, spawn bounded background planning with a semaphore. | `SubmitJob` returns faster; accepted jobs continue asynchronously. |
| `curvine-common/src/conf/job_conf.rs` | Add `job.master_max_concurrent_load_jobs`, default `16`, reject `0`. | New tunable for master-side load planning concurrency. |
| `curvine-server/src/master/job/job_runner.rs` | Split enqueue/planning paths, preserve synchronous `submit_load_task`, add queued background execution, run-scoped task IDs, and best-effort cancel after races/failures. | Removes UFS I/O from RPC critical path while preserving internal synchronous callers. |
| `curvine-server/src/master/job/job_context.rs` | Track `run_id` and allow installing pre-planned task details. | Supports stale report isolation and async planning. |
| `curvine-server/src/master/job/job_store.rs` | Add run-guarded state updates and ignore progress reports for terminal jobs. | Prevents stale background work or late worker reports from corrupting terminal/replaced jobs. |
| `curvine-server/src/worker/task/*` | Ensure cancel marks task contexts and canceled tasks cannot be completed by late progress. | Makes cancel effective for running load tasks. |
| `curvine-server/tests/load_job_submit_test.rs` | Add regression coverage for async submit return, background planning failure, zero-task completion, stale task reports, terminal late reports, and worker cancel stability. | Covers the key behavior and race protections for this fix. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo fmt --check` | PASS | Formatting check. |
| `cargo test -p curvine-server --test load_job_submit_test -- --nocapture` | PASS | 6 tests passed. |
| `CARGO_TARGET_DIR=/tmp/curvine-998-target cargo test -p curvine-server --test load_job_submit_test -- --nocapture` | PASS | 6 tests passed with an isolated target dir. |
| `CARGO_TARGET_DIR=/tmp/curvine-998-target cargo clippy -p curvine-common -p curvine-server --all-targets --jobs 2 -- --deny=warnings --allow clippy::uninlined-format-args` | PASS | No warnings. |
| `git diff --check` | PASS | No whitespace errors. |
| Three independent sub-agent reviews | PASS | Issue-fit, state-machine/race, and performance/config reviews all returned Ready after fixes. |

# Dependencies

- Related PRs: None
- Related issues: #984
- Blocks / blocked by: None