### PR TITLE
fix: use pre-push + post-check in submit_one to prevent UAF

### DIFF
--- a/orpc/src/io/spdk_poller.rs
+++ b/orpc/src/io/spdk_poller.rs
@@ -640,6 +640,12 @@ unsafe extern "C" fn poller_callback(cb_arg: *mut c_void, status: i32) {
     let ctx = Box::from_raw(cb_arg as *mut CallbackCtx);
 
     let qs = &mut *(ctx.qpair_state as *mut QpairState);
+
+    // Defensive guard against UB underflow on empty pending.
+    if qs.pending.is_empty() {
+        return;
+    }
+
     let idx = ctx.pending_idx;
     let last = qs.pending.len() - 1;
     if idx != last {
@@ -650,8 +656,10 @@ unsafe extern "C" fn poller_callback(cb_arg: *mut c_void, status: i32) {
         qs.pending.pop();
     }
 
-    ctx.bdev_inflight.fetch_sub(1, Ordering::Release);
-    ctx.completion.complete(status);
+    // Guard against double-decrement on repeated complete()
+    if ctx.completion.complete(status) {
+        ctx.bdev_inflight.fetch_sub(1, Ordering::Release);
+    }
 }
 
 impl Drop for SpdkPoller {
@@ -755,5 +763,38 @@ mod test {
                 unsafe { drop(Box::from_raw(cb_ptr as *mut CallbackCtx)) };
             }
         }
+    }
+
+    #[test]
+    fn poller_callback_empty_pending_returns_early() {
+        let inflight = Arc::new(AtomicUsize::new(1));
+        let completion = IoCompletion::new();
+        let qs = Box::new(QpairState {
+            dead: Arc::new(AtomicBool::new(false)),
+            pending: Vec::new(),
+        });
+        let ctx = Box::into_raw(Box::new(CallbackCtx {
+            completion: completion.clone(),
+            async_ctx: unsafe { std::mem::zeroed() },
+            bdev_inflight: inflight.clone(),
+            qpair_state: &*qs as *const QpairState as *mut QpairState,
+            pending_idx: 0,
+        }));
+
+        unsafe { poller_callback(ctx as *mut c_void, 0) };
+
+        assert!(qs.pending.is_empty());
+        assert_eq!(inflight.load(Ordering::Acquire), 1);
+        assert_eq!(completion.wait(1), -libc::ETIMEDOUT);
+    }
+
+    #[test]
+    fn complete_second_call_does_not_decrement_inflight() {
+        let completion = IoCompletion::new();
+        assert!(completion.complete(42));
+        assert_eq!(completion.wait(0), 42);
+
+        assert!(!completion.complete(99));
+        assert_eq!(completion.wait(0), 42);
     }
 }

--- a/orpc/src/io/spdk_poller.rs
+++ b/orpc/src/io/spdk_poller.rs
@@ -832,16 +832,6 @@ mod test {
     }
 
     #[test]
-    fn complete_second_call_does_not_decrement_inflight() {
-        let completion = IoCompletion::new();
-        assert!(completion.complete(42));
-        assert_eq!(completion.wait(0), 42);
-
-        assert!(!completion.complete(99));
-        assert_eq!(completion.wait(0), 42);
-    }
-
-    #[test]
     fn complete_is_idempotent_first_call_wins() {
         let completion = IoCompletion::new();
         assert!(completion.complete(42));

--- a/orpc/src/io/spdk_poller.rs
+++ b/orpc/src/io/spdk_poller.rs
@@ -527,7 +527,7 @@ impl SpdkPoller {
         }
 
         // Pre-push: poller_callback needs the entry in pending if SPDK completes synchronously during the submit call.
-        qs.pending.push(cb_ctx_ptr);
+        unsafe { (*qs_ptr).pending.push(cb_ctx_ptr) };
 
         let rc = match &req.op {
             IoOp::Read {
@@ -573,14 +573,17 @@ impl SpdkPoller {
         if rc != 0 {
             // If callback fired during submit and removed this entry from
             // pending via swap_remove, position() returns None - skip.
-            if let Some(pos) = qs.pending.iter().position(|&p| p == cb_ctx_ptr) {
-                qs.pending.swap_remove(pos);
-                if pos < qs.pending.len() {
-                    unsafe { (*qs.pending[pos]).pending_idx = pos };
+            unsafe {
+                if let Some(pos) = (*qs_ptr).pending.iter().position(|&p| p == cb_ctx_ptr) {
+                    (*qs_ptr).pending.swap_remove(pos);
+                    if pos < (*qs_ptr).pending.len() {
+                        (*(&mut (*qs_ptr).pending)[pos]).pending_idx = pos;
+                    }
+                    drop(Box::from_raw(cb_ctx_ptr));
+                    if req.completion.complete(rc) {
+                        req.bdev_inflight.fetch_sub(1, Ordering::Release);
+                    }
                 }
-                unsafe { drop(Box::from_raw(cb_ctx_ptr)) };
-                req.bdev_inflight.fetch_sub(1, Ordering::Release);
-                req.completion.complete(rc);
             }
             return;
         }

--- a/orpc/src/io/spdk_poller.rs
+++ b/orpc/src/io/spdk_poller.rs
@@ -526,6 +526,9 @@ impl SpdkPoller {
             );
         }
 
+        // Pre-push: poller_callback needs the entry in pending if SPDK completes synchronously during the submit call.
+        qs.pending.push(cb_ctx_ptr);
+
         let rc = match &req.op {
             IoOp::Read {
                 ns,
@@ -568,15 +571,19 @@ impl SpdkPoller {
         };
 
         if rc != 0 {
-            // Submission failed - reclaim allocation and complete with error
-            unsafe { drop(Box::from_raw(cb_ctx_ptr)) };
-            req.bdev_inflight.fetch_sub(1, Ordering::Release);
-            req.completion.complete(rc);
+            // If callback fired during submit and removed this entry from
+            // pending via swap_remove, position() returns None - skip.
+            if let Some(pos) = qs.pending.iter().position(|&p| p == cb_ctx_ptr) {
+                qs.pending.swap_remove(pos);
+                if pos < qs.pending.len() {
+                    unsafe { (*qs.pending[pos]).pending_idx = pos };
+                }
+                unsafe { drop(Box::from_raw(cb_ctx_ptr)) };
+                req.bdev_inflight.fetch_sub(1, Ordering::Release);
+                req.completion.complete(rc);
+            }
             return;
         }
-
-        qs.pending.push(cb_ctx_ptr);
-
         // Track active qpair
         if !active_qpairs.contains(&qpair) {
             active_qpairs.push(qpair);
@@ -640,6 +647,12 @@ unsafe extern "C" fn poller_callback(cb_arg: *mut c_void, status: i32) {
     let ctx = Box::from_raw(cb_arg as *mut CallbackCtx);
 
     let qs = &mut *(ctx.qpair_state as *mut QpairState);
+
+    // Defensive guard against UB underflow on empty pending.
+    if qs.pending.is_empty() {
+        return;
+    }
+
     let idx = ctx.pending_idx;
     let last = qs.pending.len() - 1;
     if idx != last {
@@ -650,8 +663,10 @@ unsafe extern "C" fn poller_callback(cb_arg: *mut c_void, status: i32) {
         qs.pending.pop();
     }
 
-    ctx.bdev_inflight.fetch_sub(1, Ordering::Release);
-    ctx.completion.complete(status);
+    // Guard against double-decrement on repeated complete()
+    if ctx.completion.complete(status) {
+        ctx.bdev_inflight.fetch_sub(1, Ordering::Release);
+    }
 }
 
 impl Drop for SpdkPoller {
@@ -755,5 +770,70 @@ mod test {
                 unsafe { drop(Box::from_raw(cb_ptr as *mut CallbackCtx)) };
             }
         }
+    }
+
+    #[test]
+    fn pre_push_entry_removed_by_callback_skips_cleanup() {
+        // Pre-push: entry added before SPDK submit call.
+        let inflight = Arc::new(AtomicUsize::new(1));
+        let completion = IoCompletion::new();
+
+        let mut qs = Box::new(QpairState {
+            dead: Arc::new(AtomicBool::new(false)),
+            pending: Vec::new(),
+        });
+        let qs_ptr = &*qs as *const QpairState as *mut QpairState;
+
+        let cb_ctx = Box::new(CallbackCtx {
+            completion: completion.clone(),
+            async_ctx: unsafe { std::mem::zeroed() },
+            bdev_inflight: inflight.clone(),
+            qpair_state: qs_ptr,
+            pending_idx: 0,
+        });
+        let cb_ctx_ptr = Box::into_raw(cb_ctx);
+        qs.pending.push(cb_ctx_ptr);
+        assert_eq!(qs.pending.len(), 1);
+
+        // Sync callback: poller_callback removes entry from pending.
+        unsafe { poller_callback(cb_ctx_ptr as *mut c_void, -libc::EIO) };
+        assert!(qs.pending.is_empty());
+
+        // Post-check: already removed, position() returns None (skips cleanup).
+        let pos = qs.pending.iter().position(|&p| p == cb_ctx_ptr);
+        assert!(pos.is_none());
+    }
+
+    #[test]
+    fn poller_callback_empty_pending_returns_early() {
+        let inflight = Arc::new(AtomicUsize::new(1));
+        let completion = IoCompletion::new();
+        let qs = Box::new(QpairState {
+            dead: Arc::new(AtomicBool::new(false)),
+            pending: Vec::new(),
+        });
+        let ctx = Box::into_raw(Box::new(CallbackCtx {
+            completion: completion.clone(),
+            async_ctx: unsafe { std::mem::zeroed() },
+            bdev_inflight: inflight.clone(),
+            qpair_state: &*qs as *const QpairState as *mut QpairState,
+            pending_idx: 0,
+        }));
+
+        unsafe { poller_callback(ctx as *mut c_void, 0) };
+
+        assert!(qs.pending.is_empty());
+        assert_eq!(inflight.load(Ordering::Acquire), 1);
+        assert_eq!(completion.wait(1), -libc::ETIMEDOUT);
+    }
+
+    #[test]
+    fn complete_second_call_does_not_decrement_inflight() {
+        let completion = IoCompletion::new();
+        assert!(completion.complete(42));
+        assert_eq!(completion.wait(0), 42);
+
+        assert!(!completion.complete(99));
+        assert_eq!(completion.wait(0), 42);
     }
 }

--- a/orpc/src/io/spdk_poller.rs
+++ b/orpc/src/io/spdk_poller.rs
@@ -841,7 +841,6 @@ mod test {
         assert_eq!(completion.wait(0), 42);
     }
 
-
     #[test]
     fn complete_is_idempotent_first_call_wins() {
         let completion = IoCompletion::new();

--- a/orpc/src/io/spdk_poller.rs
+++ b/orpc/src/io/spdk_poller.rs
@@ -641,7 +641,8 @@ unsafe extern "C" fn poller_callback(cb_arg: *mut c_void, status: i32) {
 
     let qs = &mut *(ctx.qpair_state as *mut QpairState);
 
-    // Defensive guard against UB underflow on empty pending.
+    // Underflow guard only (runs after Box::from_raw + deref, not a UAF guard).
+    // TODO: add orphan lifecycle for late-callback safety.
     if qs.pending.is_empty() {
         return;
     }

--- a/orpc/src/io/spdk_poller.rs
+++ b/orpc/src/io/spdk_poller.rs
@@ -795,15 +795,15 @@ mod test {
             pending_idx: 0,
         });
         let cb_ctx_ptr = Box::into_raw(cb_ctx);
-        qs.pending.push(cb_ctx_ptr);
-        assert_eq!(qs.pending.len(), 1);
+        unsafe { (*qs_ptr).pending.push(cb_ctx_ptr) };
+        assert_eq!(unsafe { (*qs_ptr).pending.len() }, 1);
 
         // Sync callback: poller_callback removes entry from pending.
         unsafe { poller_callback(cb_ctx_ptr as *mut c_void, -libc::EIO) };
-        assert!(qs.pending.is_empty());
+        assert!(unsafe { (*qs_ptr).pending.is_empty() });
 
         // Post-check: already removed, position() returns None (skips cleanup).
-        let pos = qs.pending.iter().position(|&p| p == cb_ctx_ptr);
+        let pos = unsafe { (*qs_ptr).pending.iter().position(|&p| p == cb_ctx_ptr) };
         assert!(pos.is_none());
     }
 

--- a/orpc/src/io/spdk_poller.rs
+++ b/orpc/src/io/spdk_poller.rs
@@ -790,12 +790,43 @@ mod test {
     }
 
     #[test]
-    fn complete_second_call_does_not_decrement_inflight() {
+    fn complete_is_idempotent_first_call_wins() {
         let completion = IoCompletion::new();
         assert!(completion.complete(42));
         assert_eq!(completion.wait(0), 42);
 
         assert!(!completion.complete(99));
         assert_eq!(completion.wait(0), 42);
+    }
+
+    #[test]
+    fn poller_callback_fetch_sub_guard_runs_once() {
+        let completion = IoCompletion::new();
+        let inflight = Arc::new(AtomicUsize::new(1));
+        let mut qs = Box::new(QpairState {
+            dead: Arc::new(AtomicBool::new(false)),
+            pending: Vec::new(),
+        });
+
+        // Simulate force_complete_qpair signaling first.
+        assert!(completion.complete(42));
+        inflight.fetch_sub(1, Ordering::Release);
+        assert_eq!(inflight.load(Ordering::Acquire), 0);
+
+        // Now poller_callback fires on the same ctx.
+        let ctx = Box::into_raw(Box::new(CallbackCtx {
+            completion: completion.clone(),
+            async_ctx: unsafe { std::mem::zeroed() },
+            bdev_inflight: inflight.clone(),
+            qpair_state: &mut *qs as *mut QpairState,
+            pending_idx: 0,
+        }));
+        qs.pending.push(ctx);
+
+        // complete() returns false -> fetch_sub skipped.
+        unsafe { poller_callback(ctx as *mut c_void, 99) };
+
+        assert_eq!(completion.wait(0), 42, "first signal wins");
+        assert_eq!(inflight.load(Ordering::Acquire), 0, "no double-decrement");
     }
 }


### PR DESCRIPTION
# Description
- Fix a use-after-free in submit_one when SPDK completes I/O synchronously during the submit call.
- Resolves part of [issue-710](https://github.com/CurvineIO/curvine/issues/710)
- Based on the change of [pr-999](https://github.com/CurvineIO/curvine/pull/999)
# Key Changes
- `orpc/src/io/spdk_poller.rs`: Pre-push cb_ctx_ptr to qs.pending before the SPDK submit call, so poller_callback always finds a valid entry. On rc != 0, use position() to check whether the callback already removed the entry; if found, clean up with proper swap_remove + reindex + free + complete. If not found (callback already fired), skip cleanup entirely. 

# Impact
- Eliminates UAF when SPDK fires poller_callback synchronously during submit_one.
- Ensures pending vec and pending_idx invariants are always correct regardless of callback timing

# Future works
2. **Orphan lifecycle** — Add orphan lifecycle and reclaim stale
3. **Late callback safety** — Orphaned lifecycle with poll and sweep for late SPDK callback safety
4. **Decouple dead flags** — Remove `qpair_dead` from `IoRequest`
5. **Derive qpair activeness** — from `pending` state, remove `active_qpairs` Vec
6. **Deferred qpair cleanup** — Strategy for clean deferred removal 
7. **Unregister ctrlr + detach target** — Complete controller teardown