### PR TITLE
feat(spdk): add orphan lifecycle and reclaim stale

### DIFF
--- a/orpc/src/io/spdk_env.rs
+++ b/orpc/src/io/spdk_env.rs
@@ -1187,7 +1187,7 @@ mod test {
 
         #[test]
         fn validate_rejects_low_keep_alive() {
-            let mut conf = SpdkConf {
+            let conf = SpdkConf {
                 enabled: true,
                 poll_interval_ms: 100,
                 targets: vec![NvmeTarget {
@@ -1209,7 +1209,7 @@ mod test {
 
         #[test]
         fn validate_accepts_high_keep_alive() {
-            let mut conf = SpdkConf {
+            let conf = SpdkConf {
                 enabled: true,
                 poll_interval_ms: 100,
                 targets: vec![NvmeTarget {
@@ -1227,7 +1227,7 @@ mod test {
 
         #[test]
         fn validate_rejects_inherited_low_keep_alive() {
-            let mut conf = SpdkConf {
+            let conf = SpdkConf {
                 enabled: true,
                 poll_interval_ms: 100,
                 keep_alive_timeout_ms: 50, // global is too low

--- a/orpc/src/io/spdk_poller.rs
+++ b/orpc/src/io/spdk_poller.rs
@@ -640,6 +640,12 @@ unsafe extern "C" fn poller_callback(cb_arg: *mut c_void, status: i32) {
     let ctx = Box::from_raw(cb_arg as *mut CallbackCtx);
 
     let qs = &mut *(ctx.qpair_state as *mut QpairState);
+
+    // Defensive guard against UB underflow on empty pending.
+    if qs.pending.is_empty() {
+        return;
+    }
+
     let idx = ctx.pending_idx;
     let last = qs.pending.len() - 1;
     if idx != last {
@@ -650,8 +656,10 @@ unsafe extern "C" fn poller_callback(cb_arg: *mut c_void, status: i32) {
         qs.pending.pop();
     }
 
-    ctx.bdev_inflight.fetch_sub(1, Ordering::Release);
-    ctx.completion.complete(status);
+    // Guard against double-decrement on repeated complete()
+    if ctx.completion.complete(status) {
+        ctx.bdev_inflight.fetch_sub(1, Ordering::Release);
+    }
 }
 
 impl Drop for SpdkPoller {
@@ -755,5 +763,38 @@ mod test {
                 unsafe { drop(Box::from_raw(cb_ptr as *mut CallbackCtx)) };
             }
         }
+    }
+
+    #[test]
+    fn poller_callback_empty_pending_returns_early() {
+        let inflight = Arc::new(AtomicUsize::new(1));
+        let completion = IoCompletion::new();
+        let qs = Box::new(QpairState {
+            dead: Arc::new(AtomicBool::new(false)),
+            pending: Vec::new(),
+        });
+        let ctx = Box::into_raw(Box::new(CallbackCtx {
+            completion: completion.clone(),
+            async_ctx: unsafe { std::mem::zeroed() },
+            bdev_inflight: inflight.clone(),
+            qpair_state: &*qs as *const QpairState as *mut QpairState,
+            pending_idx: 0,
+        }));
+
+        unsafe { poller_callback(ctx as *mut c_void, 0) };
+
+        assert!(qs.pending.is_empty());
+        assert_eq!(inflight.load(Ordering::Acquire), 1);
+        assert_eq!(completion.wait(1), -libc::ETIMEDOUT);
+    }
+
+    #[test]
+    fn complete_second_call_does_not_decrement_inflight() {
+        let completion = IoCompletion::new();
+        assert!(completion.complete(42));
+        assert_eq!(completion.wait(0), 42);
+
+        assert!(!completion.complete(99));
+        assert_eq!(completion.wait(0), 42);
     }
 }

--- a/orpc/src/io/spdk_poller.rs
+++ b/orpc/src/io/spdk_poller.rs
@@ -679,26 +679,25 @@ struct CallbackCtx {
 unsafe extern "C" fn poller_callback(cb_arg: *mut c_void, status: i32) {
     let ctx = &*(cb_arg as *mut CallbackCtx);
 
-    let qs = &mut *(ctx.qpair_state as *mut QpairState);
-
-    // Defensive guard against UB underflow on empty pending.
-    if qs.pending.is_empty() {
-        return;
-    }
-
-    let idx = ctx.pending_idx;
-    let last = qs.pending.len() - 1;
-    if idx != last {
-        let last_ptr = qs.pending[last];
-        qs.pending.swap_remove(idx);
-        (*last_ptr).pending_idx = idx;
-    } else {
-        qs.pending.pop();
-    }
-
-    // Guard against double-decrement on repeated complete()
     if ctx.completion.complete(status) {
+        let qs = &mut *(ctx.qpair_state as *mut QpairState);
+
+        // Defensive: skip swap_remove if pending is empty (underflow guard).
+        if !qs.pending.is_empty() {
+            let idx = ctx.pending_idx;
+            let last = qs.pending.len() - 1;
+            if idx != last {
+                let last_ptr = qs.pending[last];
+                qs.pending.swap_remove(idx);
+                (*last_ptr).pending_idx = idx;
+            } else {
+                qs.pending.pop();
+            }
+        }
+
         ctx.bdev_inflight.fetch_sub(1, Ordering::Release);
+        // Free the CallbackCtx now that accounting is done.
+        drop(Box::from_raw(cb_arg as *mut CallbackCtx));
     }
 }
 
@@ -846,30 +845,6 @@ mod test {
         // Post-check: already removed, position() returns None (skips cleanup).
         let pos = qs.pending.iter().position(|&p| p == cb_ctx_ptr);
         assert!(pos.is_none());
-    }
-
-    #[test]
-    fn poller_callback_empty_pending_returns_early() {
-        let inflight = Arc::new(AtomicUsize::new(1));
-        let completion = IoCompletion::new();
-        let qs = Box::new(QpairState {
-            dead: Arc::new(AtomicBool::new(false)),
-            pending: Vec::new(),
-            stale: Vec::new(),
-        });
-        let ctx = Box::into_raw(Box::new(CallbackCtx {
-            completion: completion.clone(),
-            async_ctx: unsafe { std::mem::zeroed() },
-            bdev_inflight: inflight.clone(),
-            qpair_state: &*qs as *const QpairState as *mut QpairState,
-            pending_idx: 0,
-        }));
-
-        unsafe { poller_callback(ctx as *mut c_void, 0) };
-
-        assert!(qs.pending.is_empty());
-        assert_eq!(inflight.load(Ordering::Acquire), 1);
-        assert_eq!(completion.wait(1), -libc::ETIMEDOUT);
     }
 
     #[test]

--- a/orpc/src/io/spdk_poller.rs
+++ b/orpc/src/io/spdk_poller.rs
@@ -527,7 +527,7 @@ impl SpdkPoller {
         }
 
         // Pre-push: poller_callback needs the entry in pending if SPDK completes synchronously during the submit call.
-        qs.pending.push(cb_ctx_ptr);
+        unsafe { (*qs_ptr).pending.push(cb_ctx_ptr) };
 
         let rc = match &req.op {
             IoOp::Read {
@@ -573,14 +573,17 @@ impl SpdkPoller {
         if rc != 0 {
             // If callback fired during submit and removed this entry from
             // pending via swap_remove, position() returns None - skip.
-            if let Some(pos) = qs.pending.iter().position(|&p| p == cb_ctx_ptr) {
-                qs.pending.swap_remove(pos);
-                if pos < qs.pending.len() {
-                    unsafe { (*qs.pending[pos]).pending_idx = pos };
+            unsafe {
+                if let Some(pos) = (*qs_ptr).pending.iter().position(|&p| p == cb_ctx_ptr) {
+                    (*qs_ptr).pending.swap_remove(pos);
+                    if pos < (*qs_ptr).pending.len() {
+                        (*(&mut (*qs_ptr).pending)[pos]).pending_idx = pos;
+                    }
+                    drop(Box::from_raw(cb_ctx_ptr));
+                    if req.completion.complete(rc) {
+                        req.bdev_inflight.fetch_sub(1, Ordering::Release);
+                    }
                 }
-                unsafe { drop(Box::from_raw(cb_ctx_ptr)) };
-                req.bdev_inflight.fetch_sub(1, Ordering::Release);
-                req.completion.complete(rc);
             }
             return;
         }

--- a/orpc/src/io/spdk_poller.rs
+++ b/orpc/src/io/spdk_poller.rs
@@ -716,7 +716,6 @@ mod test {
 
     #[test]
     fn force_complete_reclaims_callback_ctx() {
-        // Allocate CallbackCtx as submit_one does, one per simulated I/O.
         let completion_1 = IoCompletion::new();
         let inflight_1 = Arc::new(AtomicUsize::new(1));
         let completion_2 = IoCompletion::new();
@@ -724,7 +723,6 @@ mod test {
         let completion_3 = IoCompletion::new();
         let inflight_3 = Arc::new(AtomicUsize::new(1));
 
-        // Create QpairState for DEAD qpair.
         let dead_flag = Arc::new(AtomicBool::new(false));
         let mut qs_dead = Box::new(QpairState {
             dead: dead_flag.clone(),
@@ -732,7 +730,6 @@ mod test {
             stale: Vec::new(),
         });
 
-        // Allocate and push 2 CallbackCtx entries into DEAD's pending Vec.
         let ctx_1 = Box::into_raw(Box::new(CallbackCtx {
             completion: completion_1.clone(),
             async_ctx: unsafe { std::mem::zeroed() },
@@ -751,7 +748,6 @@ mod test {
         }));
         qs_dead.pending.push(ctx_2);
 
-        // Create QpairState for LIVE qpair (control — should be untouched).
         let live_flag = Arc::new(AtomicBool::new(false));
         let mut qs_live = Box::new(QpairState {
             dead: live_flag,
@@ -768,45 +764,29 @@ mod test {
         }));
         qs_live.pending.push(ctx_3);
 
-        // Build dead_qpairs map.
         let mut dead_qpairs: HashMap<usize, Box<QpairState>> = HashMap::new();
         dead_qpairs.insert(DEAD, qs_dead);
         dead_qpairs.insert(LIVE, qs_live);
 
-        // Act.
         SpdkPoller::force_complete_qpair(DEAD, &mut dead_qpairs);
 
-        // Assert: DEAD entries completed with -EIO.
         assert_eq!(completion_1.wait(0), -libc::EIO);
         assert_eq!(completion_2.wait(0), -libc::EIO);
-
-        // Assert: LIVE entry NOT completed (timeout with 1ms).
         assert_eq!(completion_3.wait(1000), -libc::ETIMEDOUT);
-
-        // Assert: DEAD entries' bdev_inflight decremented.
         assert_eq!(inflight_1.load(Ordering::Acquire), 0);
         assert_eq!(inflight_2.load(Ordering::Acquire), 0);
-
-        // Assert: LIVE entry's bdev_inflight unchanged.
         assert_eq!(inflight_3.load(Ordering::Acquire), 1);
-
-        // Assert: DEAD stays in dead_qpairs with entries in stale.
         assert!(dead_qpairs.contains_key(&DEAD));
         assert_eq!(dead_qpairs[&DEAD].stale.len(), 2);
         assert_eq!(dead_qpairs[&DEAD].pending.len(), 0);
         assert!(dead_flag.load(Ordering::Acquire));
 
-        // Reclaim stale entries (frees CallbackCtx, signals already done).
         if let Some(qs) = dead_qpairs.get_mut(&DEAD) {
             qs.reclaim_stale();
         }
         dead_qpairs.remove(&DEAD);
 
-        // Assert: LIVE still present and untouched.
         assert!(dead_qpairs.contains_key(&LIVE));
-
-        // Clean up LIVE entry (force_complete did not touch it).
-        // The raw pointer in qs_live.pending must be reclaimed.
         if let Some(qs) = dead_qpairs.get_mut(&LIVE) {
             for cb_ptr in qs.pending.drain(..) {
                 unsafe { drop(Box::from_raw(cb_ptr as *mut CallbackCtx)) };
@@ -814,9 +794,61 @@ mod test {
         }
     }
 
+    #[test]
+    fn pre_push_entry_removed_by_callback_skips_cleanup() {
+        let inflight = Arc::new(AtomicUsize::new(1));
+        let completion = IoCompletion::new();
+
+        let qs = Box::new(QpairState {
+            dead: Arc::new(AtomicBool::new(false)),
+            pending: Vec::new(),
+            stale: Vec::new(),
+        });
+        let qs_ptr = &*qs as *const QpairState as *mut QpairState;
+
+        let cb_ctx = Box::new(CallbackCtx {
+            completion: completion.clone(),
+            async_ctx: unsafe { std::mem::zeroed() },
+            bdev_inflight: inflight.clone(),
+            qpair_state: qs_ptr,
+            pending_idx: 0,
+        });
+        let cb_ctx_ptr = Box::into_raw(cb_ctx);
+        unsafe { (*qs_ptr).pending.push(cb_ctx_ptr) };
+        assert_eq!(unsafe { (*qs_ptr).pending.len() }, 1);
+
+        unsafe { poller_callback(cb_ctx_ptr as *mut c_void, -libc::EIO) };
+        assert!(unsafe { (*qs_ptr).pending.is_empty() });
+
+        let pos = unsafe { (*qs_ptr).pending.iter().position(|&p| p == cb_ctx_ptr) };
+        assert!(pos.is_none());
+    }
 
     #[test]
-    fn complete_second_call_does_not_decrement_inflight() {
+    fn poller_callback_empty_pending_skips_swap_remove_only() {
+        let inflight = Arc::new(AtomicUsize::new(1));
+        let completion = IoCompletion::new();
+        let qs = Box::new(QpairState {
+            dead: Arc::new(AtomicBool::new(false)),
+            pending: Vec::new(),
+            stale: Vec::new(),
+        });
+
+        let ctx = Box::into_raw(Box::new(CallbackCtx {
+            completion: completion.clone(),
+            async_ctx: unsafe { std::mem::zeroed() },
+            bdev_inflight: inflight.clone(),
+            qpair_state: &*qs as *const QpairState as *mut QpairState,
+            pending_idx: 0,
+        }));
+        unsafe { poller_callback(ctx as *mut c_void, 0) };
+
+        assert_eq!(completion.wait(0), 0, "completion signaled");
+        assert_eq!(inflight.load(Ordering::Acquire), 0, "inflight decremented");
+    }
+
+    #[test]
+    fn complete_is_idempotent_first_call_wins() {
         let completion = IoCompletion::new();
         assert!(completion.complete(42));
         assert_eq!(completion.wait(0), 42);
@@ -835,12 +867,10 @@ mod test {
             stale: Vec::new(),
         });
 
-        // Simulate force_complete_qpair signaling first.
         assert!(completion.complete(42));
         inflight.fetch_sub(1, Ordering::Release);
         assert_eq!(inflight.load(Ordering::Acquire), 0);
 
-        // Now poller_callback fires on the same ctx.
         let ctx = Box::into_raw(Box::new(CallbackCtx {
             completion: completion.clone(),
             async_ctx: unsafe { std::mem::zeroed() },
@@ -850,7 +880,6 @@ mod test {
         }));
         qs.pending.push(ctx);
 
-        // complete() returns false -> fetch_sub skipped.
         unsafe { poller_callback(ctx as *mut c_void, 99) };
 
         assert_eq!(completion.wait(0), 42, "first signal wins");
@@ -858,28 +887,13 @@ mod test {
     }
 
     #[test]
-    fn poller_callback_empty_pending_skips_swap_remove_only() {
-        let inflight = Arc::new(AtomicUsize::new(1));
+    fn complete_second_call_does_not_decrement_inflight() {
         let completion = IoCompletion::new();
-        let qs = Box::new(QpairState {
-            dead: Arc::new(AtomicBool::new(false)),
-            pending: Vec::new(),
-            stale: Vec::new(),
-        });
+        assert!(completion.complete(42));
+        assert_eq!(completion.wait(0), 42);
 
-        // complete() returns true with empty pending: underflow guard skips swap_remove,
-        // but fetch_sub and free still run.
-        let ctx = Box::into_raw(Box::new(CallbackCtx {
-            completion: completion.clone(),
-            async_ctx: unsafe { std::mem::zeroed() },
-            bdev_inflight: inflight.clone(),
-            qpair_state: &*qs as *const QpairState as *mut QpairState,
-            pending_idx: 0,
-        }));
-        unsafe { poller_callback(ctx as *mut c_void, 0) };
-
-        assert_eq!(completion.wait(0), 0, "completion signaled");
-        assert_eq!(inflight.load(Ordering::Acquire), 0, "inflight decremented");
+        assert!(!completion.complete(99));
+        assert_eq!(completion.wait(0), 42);
     }
 
     #[test]
@@ -902,7 +916,6 @@ mod test {
         let cb_ctx_ptr = Box::into_raw(cb_ctx);
         qs.pending.push(cb_ctx_ptr);
 
-        // Simulate rc != 0 path: entry still in pending -> position() finds it.
         if let Some(pos) = qs.pending.iter().position(|&p| p == cb_ctx_ptr) {
             qs.pending.swap_remove(pos);
             if pos < qs.pending.len() {
@@ -938,15 +951,12 @@ mod test {
         let cb_ctx_ptr = Box::into_raw(cb_ctx);
         qs.pending.push(cb_ctx_ptr);
 
-        // Simulate callback firing during submit via the real callback.
         unsafe { poller_callback(cb_ctx_ptr as *mut c_void, 0) };
         assert!(qs.pending.is_empty());
 
-        // Simulate rc != 0 path: position() returns None -> skip.
         let found = qs.pending.iter().position(|&p| p == cb_ctx_ptr);
         assert!(found.is_none());
 
-        // Completion and inflight unchanged from callback.
         assert_eq!(completion.wait(0), 0);
         assert_eq!(inflight.load(Ordering::Acquire), 0);
     }
@@ -981,7 +991,6 @@ mod test {
         }));
         qs.pending.push(ctx_1);
 
-        // Simulate rc != 0 for ctx_0 (position 0 → swap with last = ctx_1).
         if let Some(pos) = qs.pending.iter().position(|&p| p == ctx_0) {
             qs.pending.swap_remove(pos);
             if pos < qs.pending.len() {
@@ -992,17 +1001,14 @@ mod test {
             completion_0.complete(-libc::EIO);
         }
 
-        // ctx_0 freed and cleaned up.
         assert_eq!(qs.pending.len(), 1);
         assert_eq!(completion_0.wait(0), -libc::EIO);
         assert_eq!(inflight_0.load(Ordering::Acquire), 0);
 
-        // ctx_1 still alive, reindexed to 0.
         assert_eq!(unsafe { (*qs.pending[0]).pending_idx }, 0);
         assert_eq!(completion_1.wait(1), -libc::ETIMEDOUT);
         assert_eq!(inflight_1.load(Ordering::Acquire), 1);
 
-        // Clean up ctx_1.
         unsafe { drop(Box::from_raw(ctx_1)) };
     }
 
@@ -1016,11 +1022,9 @@ mod test {
             stale: Vec::new(),
         });
 
-        // Simulate force_complete signaling first.
         assert!(completion.complete(-libc::EIO));
         assert_eq!(inflight.load(Ordering::Acquire), 0);
 
-        // Now simulate the late SPDK callback.
         let ctx = Box::into_raw(Box::new(CallbackCtx {
             completion: completion.clone(),
             async_ctx: unsafe { std::mem::zeroed() },
@@ -1030,12 +1034,9 @@ mod test {
         }));
         unsafe { poller_callback(ctx as *mut c_void, 0) };
 
-        // Completion unchanged (still -EIO from force_complete).
         assert_eq!(completion.wait(0), -libc::EIO);
-        // Inflight unchanged (force_complete already decremented).
         assert_eq!(inflight.load(Ordering::Acquire), 0);
 
-        // Late path doesn't free — reclaim manually.
         unsafe { drop(Box::from_raw(ctx)) };
     }
 
@@ -1064,61 +1065,16 @@ mod test {
 
         SpdkPoller::force_complete_qpair(0xDEAD, &mut dead_qpairs);
 
-        // QpairState stays alive with entry in stale.
         assert!(dead_qpairs.contains_key(&0xDEAD));
         assert_eq!(dead_qpairs[&0xDEAD].stale.len(), 1);
         assert_eq!(dead_qpairs[&0xDEAD].pending.len(), 0);
         assert!(dead_flag.load(Ordering::Acquire));
 
-        // reclaim_stale frees the stale CallbackCtx.
         if let Some(qs) = dead_qpairs.get_mut(&0xDEAD) {
             qs.reclaim_stale();
         }
         assert_eq!(dead_qpairs[&0xDEAD].stale.len(), 0);
         assert_eq!(completion.wait(0), -libc::EIO);
         assert_eq!(inflight.load(Ordering::Acquire), 0);
-    }
-
-    #[test]
-    fn pre_push_entry_removed_by_callback_skips_cleanup() {
-        // Pre-push: entry added before SPDK submit call.
-        let inflight = Arc::new(AtomicUsize::new(1));
-        let completion = IoCompletion::new();
-
-        let qs = Box::new(QpairState {
-            dead: Arc::new(AtomicBool::new(false)),
-            pending: Vec::new(),
-            stale: Vec::new(),
-        });
-        let qs_ptr = &*qs as *const QpairState as *mut QpairState;
-
-        let cb_ctx = Box::new(CallbackCtx {
-            completion: completion.clone(),
-            async_ctx: unsafe { std::mem::zeroed() },
-            bdev_inflight: inflight.clone(),
-            qpair_state: qs_ptr,
-            pending_idx: 0,
-        });
-        let cb_ctx_ptr = Box::into_raw(cb_ctx);
-        unsafe { (*qs_ptr).pending.push(cb_ctx_ptr) };
-        assert_eq!(unsafe { (*qs_ptr).pending.len() }, 1);
-
-        // Sync callback: poller_callback removes entry from pending.
-        unsafe { poller_callback(cb_ctx_ptr as *mut c_void, -libc::EIO) };
-        assert!(unsafe { (*qs_ptr).pending.is_empty() });
-
-        // Post-check: already removed, position() returns None (skips cleanup).
-        let pos = unsafe { (*qs_ptr).pending.iter().position(|&p| p == cb_ctx_ptr) };
-        assert!(pos.is_none());
-    }
-
-    #[test]
-    fn complete_is_idempotent_first_call_wins() {
-        let completion = IoCompletion::new();
-        assert!(completion.complete(42));
-        assert_eq!(completion.wait(0), 42);
-
-        assert!(!completion.complete(99));
-        assert_eq!(completion.wait(0), 42);
     }
 }

--- a/orpc/src/io/spdk_poller.rs
+++ b/orpc/src/io/spdk_poller.rs
@@ -911,16 +911,6 @@ mod test {
     }
 
     #[test]
-    fn complete_second_call_does_not_decrement_inflight() {
-        let completion = IoCompletion::new();
-        assert!(completion.complete(42));
-        assert_eq!(completion.wait(0), 42);
-
-        assert!(!completion.complete(99));
-        assert_eq!(completion.wait(0), 42);
-    }
-
-    #[test]
     fn submit_one_rc_error_cleans_up_pending_entry() {
         // Pre-push: entry added before SPDK submit call.
         let inflight = Arc::new(AtomicUsize::new(1));

--- a/orpc/src/io/spdk_poller.rs
+++ b/orpc/src/io/spdk_poller.rs
@@ -526,6 +526,9 @@ impl SpdkPoller {
             );
         }
 
+        // Pre-push: poller_callback needs the entry in pending if SPDK completes synchronously during the submit call.
+        qs.pending.push(cb_ctx_ptr);
+
         let rc = match &req.op {
             IoOp::Read {
                 ns,
@@ -568,15 +571,19 @@ impl SpdkPoller {
         };
 
         if rc != 0 {
-            // Submission failed - reclaim allocation and complete with error
-            unsafe { drop(Box::from_raw(cb_ctx_ptr)) };
-            req.bdev_inflight.fetch_sub(1, Ordering::Release);
-            req.completion.complete(rc);
+            // If callback fired during submit and removed this entry from
+            // pending via swap_remove, position() returns None - skip.
+            if let Some(pos) = qs.pending.iter().position(|&p| p == cb_ctx_ptr) {
+                qs.pending.swap_remove(pos);
+                if pos < qs.pending.len() {
+                    unsafe { (*qs.pending[pos]).pending_idx = pos };
+                }
+                unsafe { drop(Box::from_raw(cb_ctx_ptr)) };
+                req.bdev_inflight.fetch_sub(1, Ordering::Release);
+                req.completion.complete(rc);
+            }
             return;
         }
-
-        qs.pending.push(cb_ctx_ptr);
-
         // Track active qpair
         if !active_qpairs.contains(&qpair) {
             active_qpairs.push(qpair);
@@ -640,6 +647,12 @@ unsafe extern "C" fn poller_callback(cb_arg: *mut c_void, status: i32) {
     let ctx = Box::from_raw(cb_arg as *mut CallbackCtx);
 
     let qs = &mut *(ctx.qpair_state as *mut QpairState);
+
+    // Defensive guard against UB underflow on empty pending.
+    if qs.pending.is_empty() {
+        return;
+    }
+
     let idx = ctx.pending_idx;
     let last = qs.pending.len() - 1;
     if idx != last {
@@ -650,8 +663,10 @@ unsafe extern "C" fn poller_callback(cb_arg: *mut c_void, status: i32) {
         qs.pending.pop();
     }
 
-    ctx.bdev_inflight.fetch_sub(1, Ordering::Release);
-    ctx.completion.complete(status);
+    // Guard against double-decrement on repeated complete()
+    if ctx.completion.complete(status) {
+        ctx.bdev_inflight.fetch_sub(1, Ordering::Release);
+    }
 }
 
 impl Drop for SpdkPoller {
@@ -755,5 +770,70 @@ mod test {
                 unsafe { drop(Box::from_raw(cb_ptr as *mut CallbackCtx)) };
             }
         }
+    }
+
+    #[test]
+    fn pre_push_entry_removed_by_callback_skips_cleanup() {
+        // Pre-push: entry added before SPDK submit call.
+        let inflight = Arc::new(AtomicUsize::new(1));
+        let completion = IoCompletion::new();
+
+        let mut qs = Box::new(QpairState {
+            dead: Arc::new(AtomicBool::new(false)),
+            pending: Vec::new(),
+        });
+        let qs_ptr = &*qs as *const QpairState as *mut QpairState;
+
+        let cb_ctx = Box::new(CallbackCtx {
+            completion: completion.clone(),
+            async_ctx: unsafe { std::mem::zeroed() },
+            bdev_inflight: inflight.clone(),
+            qpair_state: qs_ptr,
+            pending_idx: 0,
+        });
+        let cb_ctx_ptr = Box::into_raw(cb_ctx);
+        qs.pending.push(cb_ctx_ptr);
+        assert_eq!(qs.pending.len(), 1);
+
+        // Sync callback: poller_callback removes entry from pending.
+        unsafe { poller_callback(cb_ctx_ptr as *mut c_void, -libc::EIO) };
+        assert!(qs.pending.is_empty());
+
+        // Post-check: already removed, position() returns None (skips cleanup).
+        let pos = qs.pending.iter().position(|&p| p == cb_ctx_ptr);
+        assert!(pos.is_none());
+    }
+
+    #[test]
+    fn poller_callback_empty_pending_returns_early() {
+        let inflight = Arc::new(AtomicUsize::new(1));
+        let completion = IoCompletion::new();
+        let qs = Box::new(QpairState {
+            dead: Arc::new(AtomicBool::new(false)),
+            pending: Vec::new(),
+        });
+        let ctx = Box::into_raw(Box::new(CallbackCtx {
+            completion: completion.clone(),
+            async_ctx: unsafe { std::mem::zeroed() },
+            bdev_inflight: inflight.clone(),
+            qpair_state: &*qs as *const QpairState as *mut QpairState,
+            pending_idx: 0,
+        }));
+
+        unsafe { poller_callback(ctx as *mut c_void, 0) };
+
+        assert!(qs.pending.is_empty());
+        assert_eq!(inflight.load(Ordering::Acquire), 1);
+        assert_eq!(completion.wait(1), -libc::ETIMEDOUT);
+    }
+
+    #[test]
+    fn complete_second_call_does_not_decrement_inflight() {
+        let completion = IoCompletion::new();
+        assert!(completion.complete(42));
+        assert_eq!(completion.wait(0), 42);
+
+        assert!(!completion.complete(99));
+        assert_eq!(completion.wait(0), 42);
     }
 }

--- a/orpc/src/io/spdk_poller.rs
+++ b/orpc/src/io/spdk_poller.rs
@@ -841,7 +841,6 @@ mod test {
         assert_eq!(completion.wait(0), 42);
     }
 
-
     #[test]
     fn complete_is_idempotent_first_call_wins() {
         let completion = IoCompletion::new();

--- a/orpc/src/io/spdk_poller.rs
+++ b/orpc/src/io/spdk_poller.rs
@@ -716,6 +716,7 @@ mod test {
 
     #[test]
     fn force_complete_reclaims_callback_ctx() {
+        // Allocate CallbackCtx as submit_one does, one per simulated I/O.
         let completion_1 = IoCompletion::new();
         let inflight_1 = Arc::new(AtomicUsize::new(1));
         let completion_2 = IoCompletion::new();
@@ -723,6 +724,7 @@ mod test {
         let completion_3 = IoCompletion::new();
         let inflight_3 = Arc::new(AtomicUsize::new(1));
 
+        // Create QpairState for DEAD qpair.
         let dead_flag = Arc::new(AtomicBool::new(false));
         let mut qs_dead = Box::new(QpairState {
             dead: dead_flag.clone(),
@@ -730,6 +732,7 @@ mod test {
             stale: Vec::new(),
         });
 
+        // Allocate and push 2 CallbackCtx entries into DEAD's pending Vec.
         let ctx_1 = Box::into_raw(Box::new(CallbackCtx {
             completion: completion_1.clone(),
             async_ctx: unsafe { std::mem::zeroed() },
@@ -748,6 +751,7 @@ mod test {
         }));
         qs_dead.pending.push(ctx_2);
 
+        // Create QpairState for LIVE qpair (control — should be untouched).
         let live_flag = Arc::new(AtomicBool::new(false));
         let mut qs_live = Box::new(QpairState {
             dead: live_flag,
@@ -764,29 +768,40 @@ mod test {
         }));
         qs_live.pending.push(ctx_3);
 
+        // Build dead_qpairs map.
         let mut dead_qpairs: HashMap<usize, Box<QpairState>> = HashMap::new();
         dead_qpairs.insert(DEAD, qs_dead);
         dead_qpairs.insert(LIVE, qs_live);
 
+        // Act.
         SpdkPoller::force_complete_qpair(DEAD, &mut dead_qpairs);
 
+        // Assert: DEAD entries completed with -EIO.
         assert_eq!(completion_1.wait(0), -libc::EIO);
         assert_eq!(completion_2.wait(0), -libc::EIO);
+        // Assert: LIVE entry NOT completed (timeout with 1ms).
         assert_eq!(completion_3.wait(1000), -libc::ETIMEDOUT);
+        // Assert: DEAD entries' bdev_inflight decremented.
         assert_eq!(inflight_1.load(Ordering::Acquire), 0);
         assert_eq!(inflight_2.load(Ordering::Acquire), 0);
+        // Assert: LIVE entry's bdev_inflight unchanged.
         assert_eq!(inflight_3.load(Ordering::Acquire), 1);
+        // Assert: DEAD stays in dead_qpairs with entries in stale.
         assert!(dead_qpairs.contains_key(&DEAD));
         assert_eq!(dead_qpairs[&DEAD].stale.len(), 2);
         assert_eq!(dead_qpairs[&DEAD].pending.len(), 0);
         assert!(dead_flag.load(Ordering::Acquire));
 
+        // Reclaim stale entries (frees CallbackCtx, signals already done).
         if let Some(qs) = dead_qpairs.get_mut(&DEAD) {
             qs.reclaim_stale();
         }
         dead_qpairs.remove(&DEAD);
 
+        // Assert: LIVE still present and untouched.
         assert!(dead_qpairs.contains_key(&LIVE));
+        // Clean up LIVE entry (force_complete did not touch it).
+        // The raw pointer in qs_live.pending must be reclaimed.
         if let Some(qs) = dead_qpairs.get_mut(&LIVE) {
             for cb_ptr in qs.pending.drain(..) {
                 unsafe { drop(Box::from_raw(cb_ptr as *mut CallbackCtx)) };
@@ -867,6 +882,7 @@ mod test {
             stale: Vec::new(),
         });
 
+        // Simulate force_complete_qpair signaling first.
         assert!(completion.complete(42));
         inflight.fetch_sub(1, Ordering::Release);
         assert_eq!(inflight.load(Ordering::Acquire), 0);
@@ -880,6 +896,7 @@ mod test {
         }));
         qs.pending.push(ctx);
 
+        // complete() returns false -> fetch_sub skipped.
         unsafe { poller_callback(ctx as *mut c_void, 99) };
 
         assert_eq!(completion.wait(0), 42, "first signal wins");
@@ -898,6 +915,7 @@ mod test {
 
     #[test]
     fn submit_one_rc_error_cleans_up_pending_entry() {
+        // Pre-push: entry added before SPDK submit call.
         let inflight = Arc::new(AtomicUsize::new(1));
         let completion = IoCompletion::new();
         let mut qs = Box::new(QpairState {
@@ -916,6 +934,7 @@ mod test {
         let cb_ctx_ptr = Box::into_raw(cb_ctx);
         qs.pending.push(cb_ctx_ptr);
 
+        // Simulate rc != 0 path: entry still in pending -> position() finds it.
         if let Some(pos) = qs.pending.iter().position(|&p| p == cb_ctx_ptr) {
             qs.pending.swap_remove(pos);
             if pos < qs.pending.len() {
@@ -933,6 +952,7 @@ mod test {
 
     #[test]
     fn submit_one_rc_error_callback_already_removed_entry() {
+        // Sync callback: poller_callback removes entry from pending.
         let inflight = Arc::new(AtomicUsize::new(1));
         let completion = IoCompletion::new();
         let mut qs = Box::new(QpairState {
@@ -951,12 +971,15 @@ mod test {
         let cb_ctx_ptr = Box::into_raw(cb_ctx);
         qs.pending.push(cb_ctx_ptr);
 
+        // Simulate callback firing during submit via the real callback.
         unsafe { poller_callback(cb_ctx_ptr as *mut c_void, 0) };
         assert!(qs.pending.is_empty());
 
+        // Simulate rc != 0 path: position() returns None -> skip.
         let found = qs.pending.iter().position(|&p| p == cb_ctx_ptr);
         assert!(found.is_none());
 
+        // Completion and inflight unchanged from callback.
         assert_eq!(completion.wait(0), 0);
         assert_eq!(inflight.load(Ordering::Acquire), 0);
     }
@@ -991,6 +1014,7 @@ mod test {
         }));
         qs.pending.push(ctx_1);
 
+        // Simulate rc != 0 for ctx_0 (position 0 → swap with last = ctx_1).
         if let Some(pos) = qs.pending.iter().position(|&p| p == ctx_0) {
             qs.pending.swap_remove(pos);
             if pos < qs.pending.len() {
@@ -1022,9 +1046,11 @@ mod test {
             stale: Vec::new(),
         });
 
+        // Simulate force_complete signaling first.
         assert!(completion.complete(-libc::EIO));
         assert_eq!(inflight.load(Ordering::Acquire), 0);
 
+        // Now simulate the late SPDK callback.
         let ctx = Box::into_raw(Box::new(CallbackCtx {
             completion: completion.clone(),
             async_ctx: unsafe { std::mem::zeroed() },
@@ -1034,9 +1060,12 @@ mod test {
         }));
         unsafe { poller_callback(ctx as *mut c_void, 0) };
 
+        // Completion unchanged (still -EIO from force_complete).
         assert_eq!(completion.wait(0), -libc::EIO);
+        // Inflight unchanged (force_complete already decremented).
         assert_eq!(inflight.load(Ordering::Acquire), 0);
 
+        // Late path doesn't free — reclaim manually.
         unsafe { drop(Box::from_raw(ctx)) };
     }
 
@@ -1065,11 +1094,13 @@ mod test {
 
         SpdkPoller::force_complete_qpair(0xDEAD, &mut dead_qpairs);
 
+        // QpairState stays alive with entry in stale.
         assert!(dead_qpairs.contains_key(&0xDEAD));
         assert_eq!(dead_qpairs[&0xDEAD].stale.len(), 1);
         assert_eq!(dead_qpairs[&0xDEAD].pending.len(), 0);
         assert!(dead_flag.load(Ordering::Acquire));
 
+        // reclaim_stale frees the stale CallbackCtx.
         if let Some(qs) = dead_qpairs.get_mut(&0xDEAD) {
             qs.reclaim_stale();
         }

--- a/orpc/src/io/spdk_poller.rs
+++ b/orpc/src/io/spdk_poller.rs
@@ -779,11 +779,14 @@ mod test {
         // Assert: DEAD entries completed with -EIO.
         assert_eq!(completion_1.wait(0), -libc::EIO);
         assert_eq!(completion_2.wait(0), -libc::EIO);
+
         // Assert: LIVE entry NOT completed (timeout with 1ms).
         assert_eq!(completion_3.wait(1000), -libc::ETIMEDOUT);
+
         // Assert: DEAD entries' bdev_inflight decremented.
         assert_eq!(inflight_1.load(Ordering::Acquire), 0);
         assert_eq!(inflight_2.load(Ordering::Acquire), 0);
+
         // Assert: LIVE entry's bdev_inflight unchanged.
         assert_eq!(inflight_3.load(Ordering::Acquire), 1);
         // Assert: DEAD stays in dead_qpairs with entries in stale.
@@ -851,7 +854,6 @@ mod test {
             pending: Vec::new(),
             stale: Vec::new(),
         });
-
         let ctx = Box::into_raw(Box::new(CallbackCtx {
             completion: completion.clone(),
             async_ctx: unsafe { std::mem::zeroed() },
@@ -859,6 +861,7 @@ mod test {
             qpair_state: &*qs as *const QpairState as *mut QpairState,
             pending_idx: 0,
         }));
+
         unsafe { poller_callback(ctx as *mut c_void, 0) };
 
         assert_eq!(completion.wait(0), 0, "completion signaled");

--- a/orpc/src/io/spdk_poller.rs
+++ b/orpc/src/io/spdk_poller.rs
@@ -823,6 +823,7 @@ mod test {
         let mut qs = Box::new(QpairState {
             dead: Arc::new(AtomicBool::new(false)),
             pending: Vec::new(),
+            stale: Vec::new(),
         });
         let qs_ptr = &*qs as *const QpairState as *mut QpairState;
 
@@ -847,26 +848,13 @@ mod test {
     }
 
     #[test]
-    fn poller_callback_empty_pending_returns_early() {
-        let inflight = Arc::new(AtomicUsize::new(1));
+    fn complete_second_call_does_not_decrement_inflight() {
         let completion = IoCompletion::new();
-        let qs = Box::new(QpairState {
-            dead: Arc::new(AtomicBool::new(false)),
-            pending: Vec::new(),
-        });
-        let ctx = Box::into_raw(Box::new(CallbackCtx {
-            completion: completion.clone(),
-            async_ctx: unsafe { std::mem::zeroed() },
-            bdev_inflight: inflight.clone(),
-            qpair_state: &*qs as *const QpairState as *mut QpairState,
-            pending_idx: 0,
-        }));
+        assert!(completion.complete(42));
+        assert_eq!(completion.wait(0), 42);
 
-        unsafe { poller_callback(ctx as *mut c_void, 0) };
-
-        assert!(qs.pending.is_empty());
-        assert_eq!(inflight.load(Ordering::Acquire), 1);
-        assert_eq!(completion.wait(1), -libc::ETIMEDOUT);
+        assert!(!completion.complete(99));
+        assert_eq!(completion.wait(0), 42);
     }
 
     #[test]
@@ -886,6 +874,7 @@ mod test {
         let mut qs = Box::new(QpairState {
             dead: Arc::new(AtomicBool::new(false)),
             pending: Vec::new(),
+            stale: Vec::new(),
         });
 
         // Simulate force_complete_qpair signaling first.
@@ -908,16 +897,6 @@ mod test {
 
         assert_eq!(completion.wait(0), 42, "first signal wins");
         assert_eq!(inflight.load(Ordering::Acquire), 0, "no double-decrement");
-    }
-
-    #[test]
-    fn complete_second_call_does_not_decrement_inflight() {
-        let completion = IoCompletion::new();
-        assert!(completion.complete(42));
-        assert_eq!(completion.wait(0), 42);
-
-        assert!(!completion.complete(99));
-        assert_eq!(completion.wait(0), 42);
     }
 
     #[test]

--- a/orpc/src/io/spdk_poller.rs
+++ b/orpc/src/io/spdk_poller.rs
@@ -1085,9 +1085,10 @@ mod test {
         let inflight = Arc::new(AtomicUsize::new(1));
         let completion = IoCompletion::new();
 
-        let mut qs = Box::new(QpairState {
+        let qs = Box::new(QpairState {
             dead: Arc::new(AtomicBool::new(false)),
             pending: Vec::new(),
+            stale: Vec::new(),
         });
         let qs_ptr = &*qs as *const QpairState as *mut QpairState;
 
@@ -1109,29 +1110,6 @@ mod test {
         // Post-check: already removed, position() returns None (skips cleanup).
         let pos = unsafe { (*qs_ptr).pending.iter().position(|&p| p == cb_ctx_ptr) };
         assert!(pos.is_none());
-    }
-
-    #[test]
-    fn poller_callback_empty_pending_returns_early() {
-        let inflight = Arc::new(AtomicUsize::new(1));
-        let completion = IoCompletion::new();
-        let qs = Box::new(QpairState {
-            dead: Arc::new(AtomicBool::new(false)),
-            pending: Vec::new(),
-        });
-        let ctx = Box::into_raw(Box::new(CallbackCtx {
-            completion: completion.clone(),
-            async_ctx: unsafe { std::mem::zeroed() },
-            bdev_inflight: inflight.clone(),
-            qpair_state: &*qs as *const QpairState as *mut QpairState,
-            pending_idx: 0,
-        }));
-
-        unsafe { poller_callback(ctx as *mut c_void, 0) };
-
-        assert!(qs.pending.is_empty());
-        assert_eq!(inflight.load(Ordering::Acquire), 1);
-        assert_eq!(completion.wait(1), -libc::ETIMEDOUT);
     }
 
     #[test]

--- a/orpc/src/io/spdk_poller.rs
+++ b/orpc/src/io/spdk_poller.rs
@@ -118,10 +118,10 @@ pub struct IoRequest {
     pub op: IoOp,
     pub completion: Arc<IoCompletion>,
     /// Per-bdev in-flight counter. Decremented on completion.
-    pub bdev_inflight: std::sync::Arc<AtomicUsize>,
+    pub bdev_inflight: Arc<AtomicUsize>,
     /// Per-qpair dead flag. Set by the poller when qpair poll fails;
     /// checked by the bdev to fail subsequent I/Os fast.
-    pub qpair_dead: std::sync::Arc<AtomicBool>,
+    pub qpair_dead: Arc<AtomicBool>,
 }
 
 // SAFETY: exclusive ownership - blocks until completion.
@@ -454,6 +454,11 @@ impl SpdkPoller {
             }
         }
 
+        // Free any stale entries before thread exit.
+        for (_, qs) in dead_qpairs.iter_mut() {
+            qs.reclaim_stale();
+        }
+        dead_qpairs.clear();
         info!("SPDK poller thread exiting");
     }
 
@@ -466,6 +471,9 @@ impl SpdkPoller {
         if let IoOp::UnregisterQpair { qpair, ack } = &req.op {
             active_qpairs.retain(|&qp| qp != *qpair);
             let key = *qpair as usize;
+            if let Some(qs) = dead_qpairs.get_mut(&key) {
+                qs.reclaim_stale();
+            }
             dead_qpairs.remove(&key);
             let _ = ack.send(());
         }
@@ -494,6 +502,7 @@ impl SpdkPoller {
             Box::new(QpairState {
                 dead: req.qpair_dead.clone(),
                 pending: Vec::with_capacity(io_queue_depth),
+                stale: Vec::new(),
             })
         });
 
@@ -525,6 +534,9 @@ impl SpdkPoller {
                 cb_ctx_ptr as *mut c_void,
             );
         }
+
+        // Pre-push: poller_callback needs the entry in pending if SPDK completes synchronously during the submit call.
+        qs.pending.push(cb_ctx_ptr);
 
         let rc = match &req.op {
             IoOp::Read {
@@ -568,10 +580,17 @@ impl SpdkPoller {
         };
 
         if rc != 0 {
-            // Submission failed - reclaim allocation and complete with error
-            unsafe { drop(Box::from_raw(cb_ctx_ptr)) };
-            req.bdev_inflight.fetch_sub(1, Ordering::Release);
-            req.completion.complete(rc);
+            // If callback fired during submit and removed this entry from
+            // pending via swap_remove, position() returns None - skip.
+            if let Some(pos) = qs.pending.iter().position(|&p| p == cb_ctx_ptr) {
+                qs.pending.swap_remove(pos);
+                if pos < qs.pending.len() {
+                    unsafe { (*qs.pending[pos]).pending_idx = pos };
+                }
+                unsafe { drop(Box::from_raw(cb_ctx_ptr)) };
+                req.bdev_inflight.fetch_sub(1, Ordering::Release);
+                req.completion.complete(rc);
+            }
             return;
         }
 
@@ -591,11 +610,16 @@ impl SpdkPoller {
             let pending = std::mem::take(&mut qs.pending);
             let count = pending.len();
             for cb_ptr in &pending {
-                let ctx = unsafe { Box::from_raw(*cb_ptr as *mut CallbackCtx) };
-                if ctx.completion.complete(-libc::EIO) {
-                    ctx.bdev_inflight.fetch_sub(1, Ordering::Release);
+                // Signal but DON'T free - keep alive for late callbacks.
+                let ctx = *cb_ptr as *mut CallbackCtx;
+                unsafe {
+                    if (*ctx).completion.complete(-libc::EIO) {
+                        (*ctx).bdev_inflight.fetch_sub(1, Ordering::Release);
+                    }
                 }
             }
+            // Move to stale so reclaim_stale can free them later.
+            qs.stale.extend(pending);
             if count > 0 {
                 error!(
                     "Force-completed {} outstanding I/O(s) on failed qpair 0x{:x} with EIO",
@@ -603,7 +627,7 @@ impl SpdkPoller {
                 );
             }
         }
-        dead_qpairs.remove(&key);
+        // Keep QpairState alive for late callbacks. reclaim_stale frees stale entries.
     }
 
     /// Process admin completions on all controllers to service keep-alive.
@@ -617,11 +641,22 @@ impl SpdkPoller {
     }
 }
 
-/// Per-qpair state tracked on the poller thread. Holds the dead flag and
-/// a Vec of all in-flight CallbackCtx pointers for force-completion.
+/// Per-qpair state tracked on the poller thread. Holds the dead flag,
+/// in-flight I/Os (pending), and force-completed entries kept alive for
+/// late SPDK callbacks (stale).
 struct QpairState {
     dead: Arc<AtomicBool>,
     pending: Vec<*mut CallbackCtx>,
+    /// Force-completed entries kept alive for late callbacks. Freed by reclaim_stale().
+    stale: Vec<*mut CallbackCtx>,
+}
+
+impl QpairState {
+    fn reclaim_stale(&mut self) {
+        for ptr in self.stale.drain(..) {
+            unsafe { drop(Box::from_raw(ptr as *mut CallbackCtx)) };
+        }
+    }
 }
 
 /// C callback context. Heap-allocated for SPDK to hold pointer.
@@ -635,11 +670,22 @@ struct CallbackCtx {
     pending_idx: usize,
 }
 
-/// C callback invoked by SPDK when NVMe command completes.
+/// SPDK NVMe completion callback.
+///
+/// **Hot path** — first completion, qpair_state alive. Remove from pending, decrement inflight,
+///   then free the CallbackCtx.
+/// **Late path** — completion already signaled by force_complete, qpair_state may be freed.
+///   Don't free — entry is in QpairState::stale and will be freed by reclaim_stale.
 unsafe extern "C" fn poller_callback(cb_arg: *mut c_void, status: i32) {
-    let ctx = Box::from_raw(cb_arg as *mut CallbackCtx);
+    let ctx = &*(cb_arg as *mut CallbackCtx);
 
     let qs = &mut *(ctx.qpair_state as *mut QpairState);
+
+    // Defensive guard against UB underflow on empty pending.
+    if qs.pending.is_empty() {
+        return;
+    }
+
     let idx = ctx.pending_idx;
     let last = qs.pending.len() - 1;
     if idx != last {
@@ -650,8 +696,10 @@ unsafe extern "C" fn poller_callback(cb_arg: *mut c_void, status: i32) {
         qs.pending.pop();
     }
 
-    ctx.bdev_inflight.fetch_sub(1, Ordering::Release);
-    ctx.completion.complete(status);
+    // Guard against double-decrement on repeated complete()
+    if ctx.completion.complete(status) {
+        ctx.bdev_inflight.fetch_sub(1, Ordering::Release);
+    }
 }
 
 impl Drop for SpdkPoller {
@@ -682,6 +730,7 @@ mod test {
         let mut qs_dead = Box::new(QpairState {
             dead: dead_flag.clone(),
             pending: Vec::new(),
+            stale: Vec::new(),
         });
 
         // Allocate and push 2 CallbackCtx entries into DEAD's pending Vec.
@@ -708,6 +757,7 @@ mod test {
         let mut qs_live = Box::new(QpairState {
             dead: live_flag,
             pending: Vec::new(),
+            stale: Vec::new(),
         });
 
         let ctx_3 = Box::into_raw(Box::new(CallbackCtx {
@@ -741,11 +791,19 @@ mod test {
         // Assert: LIVE entry's bdev_inflight unchanged.
         assert_eq!(inflight_3.load(Ordering::Acquire), 1);
 
-        // Assert: dead flag set.
+        // Assert: DEAD stays in dead_qpairs with entries in stale.
+        assert!(dead_qpairs.contains_key(&DEAD));
+        assert_eq!(dead_qpairs[&DEAD].stale.len(), 2);
+        assert_eq!(dead_qpairs[&DEAD].pending.len(), 0);
         assert!(dead_flag.load(Ordering::Acquire));
 
-        // Assert: DEAD removed from dead_qpairs, LIVE still present.
-        assert!(!dead_qpairs.contains_key(&DEAD));
+        // Reclaim stale entries (frees CallbackCtx, signals already done).
+        if let Some(qs) = dead_qpairs.get_mut(&DEAD) {
+            qs.reclaim_stale();
+        }
+        dead_qpairs.remove(&DEAD);
+
+        // Assert: LIVE still present and untouched.
         assert!(dead_qpairs.contains_key(&LIVE));
 
         // Clean up LIVE entry (force_complete did not touch it).
@@ -755,5 +813,269 @@ mod test {
                 unsafe { drop(Box::from_raw(cb_ptr as *mut CallbackCtx)) };
             }
         }
+    }
+
+    #[test]
+    fn pre_push_entry_removed_by_callback_skips_cleanup() {
+        // Pre-push: entry added before SPDK submit call.
+        let inflight = Arc::new(AtomicUsize::new(1));
+        let completion = IoCompletion::new();
+
+        let mut qs = Box::new(QpairState {
+            dead: Arc::new(AtomicBool::new(false)),
+            pending: Vec::new(),
+            stale: Vec::new(),
+        });
+        let qs_ptr = &*qs as *const QpairState as *mut QpairState;
+
+        let cb_ctx = Box::new(CallbackCtx {
+            completion: completion.clone(),
+            async_ctx: unsafe { std::mem::zeroed() },
+            bdev_inflight: inflight.clone(),
+            qpair_state: qs_ptr,
+            pending_idx: 0,
+        });
+        let cb_ctx_ptr = Box::into_raw(cb_ctx);
+        qs.pending.push(cb_ctx_ptr);
+        assert_eq!(qs.pending.len(), 1);
+
+        // Sync callback: poller_callback removes entry from pending.
+        unsafe { poller_callback(cb_ctx_ptr as *mut c_void, -libc::EIO) };
+        assert!(qs.pending.is_empty());
+
+        // Post-check: already removed, position() returns None (skips cleanup).
+        let pos = qs.pending.iter().position(|&p| p == cb_ctx_ptr);
+        assert!(pos.is_none());
+    }
+
+    #[test]
+    fn poller_callback_empty_pending_returns_early() {
+        let inflight = Arc::new(AtomicUsize::new(1));
+        let completion = IoCompletion::new();
+        let qs = Box::new(QpairState {
+            dead: Arc::new(AtomicBool::new(false)),
+            pending: Vec::new(),
+            stale: Vec::new(),
+        });
+        let ctx = Box::into_raw(Box::new(CallbackCtx {
+            completion: completion.clone(),
+            async_ctx: unsafe { std::mem::zeroed() },
+            bdev_inflight: inflight.clone(),
+            qpair_state: &*qs as *const QpairState as *mut QpairState,
+            pending_idx: 0,
+        }));
+
+        unsafe { poller_callback(ctx as *mut c_void, 0) };
+
+        assert!(qs.pending.is_empty());
+        assert_eq!(inflight.load(Ordering::Acquire), 1);
+        assert_eq!(completion.wait(1), -libc::ETIMEDOUT);
+    }
+
+    #[test]
+    fn complete_second_call_does_not_decrement_inflight() {
+        let completion = IoCompletion::new();
+        assert!(completion.complete(42));
+        assert_eq!(completion.wait(0), 42);
+
+        assert!(!completion.complete(99));
+        assert_eq!(completion.wait(0), 42);
+    }
+
+    #[test]
+    fn submit_one_rc_error_cleans_up_pending_entry() {
+        let inflight = Arc::new(AtomicUsize::new(1));
+        let completion = IoCompletion::new();
+        let mut qs = Box::new(QpairState {
+            dead: Arc::new(AtomicBool::new(false)),
+            pending: Vec::new(),
+            stale: Vec::new(),
+        });
+
+        let cb_ctx = Box::new(CallbackCtx {
+            completion: completion.clone(),
+            async_ctx: unsafe { std::mem::zeroed() },
+            bdev_inflight: inflight.clone(),
+            qpair_state: &mut *qs as *mut QpairState,
+            pending_idx: 0,
+        });
+        let cb_ctx_ptr = Box::into_raw(cb_ctx);
+        qs.pending.push(cb_ctx_ptr);
+
+        // Simulate rc != 0 path: entry still in pending -> position() finds it.
+        if let Some(pos) = qs.pending.iter().position(|&p| p == cb_ctx_ptr) {
+            qs.pending.swap_remove(pos);
+            if pos < qs.pending.len() {
+                unsafe { (*qs.pending[pos]).pending_idx = pos };
+            }
+            unsafe { drop(Box::from_raw(cb_ctx_ptr)) };
+            inflight.fetch_sub(1, Ordering::Release);
+            completion.complete(-libc::ENOMEM);
+        }
+
+        assert!(qs.pending.is_empty());
+        assert_eq!(inflight.load(Ordering::Acquire), 0);
+        assert_eq!(completion.wait(0), -libc::ENOMEM);
+    }
+
+    #[test]
+    fn submit_one_rc_error_callback_already_removed_entry() {
+        let inflight = Arc::new(AtomicUsize::new(1));
+        let completion = IoCompletion::new();
+        let mut qs = Box::new(QpairState {
+            dead: Arc::new(AtomicBool::new(false)),
+            pending: Vec::new(),
+            stale: Vec::new(),
+        });
+
+        let cb_ctx = Box::new(CallbackCtx {
+            completion: completion.clone(),
+            async_ctx: unsafe { std::mem::zeroed() },
+            bdev_inflight: inflight.clone(),
+            qpair_state: &mut *qs as *mut QpairState,
+            pending_idx: 0,
+        });
+        let cb_ctx_ptr = Box::into_raw(cb_ctx);
+        qs.pending.push(cb_ctx_ptr);
+
+        // Simulate callback firing during submit via the real callback.
+        unsafe { poller_callback(cb_ctx_ptr as *mut c_void, 0) };
+        assert!(qs.pending.is_empty());
+
+        // Simulate rc != 0 path: position() returns None -> skip.
+        let found = qs.pending.iter().position(|&p| p == cb_ctx_ptr);
+        assert!(found.is_none());
+
+        // Completion and inflight unchanged from callback.
+        assert_eq!(completion.wait(0), 0);
+        assert_eq!(inflight.load(Ordering::Acquire), 0);
+    }
+
+    #[test]
+    fn submit_one_rc_error_reindexes_on_swap_remove() {
+        let inflight_0 = Arc::new(AtomicUsize::new(1));
+        let completion_0 = IoCompletion::new();
+        let inflight_1 = Arc::new(AtomicUsize::new(1));
+        let completion_1 = IoCompletion::new();
+        let mut qs = Box::new(QpairState {
+            dead: Arc::new(AtomicBool::new(false)),
+            pending: Vec::new(),
+            stale: Vec::new(),
+        });
+
+        let ctx_0 = Box::into_raw(Box::new(CallbackCtx {
+            completion: completion_0.clone(),
+            async_ctx: unsafe { std::mem::zeroed() },
+            bdev_inflight: inflight_0.clone(),
+            qpair_state: &mut *qs as *mut QpairState,
+            pending_idx: 0,
+        }));
+        qs.pending.push(ctx_0);
+
+        let ctx_1 = Box::into_raw(Box::new(CallbackCtx {
+            completion: completion_1.clone(),
+            async_ctx: unsafe { std::mem::zeroed() },
+            bdev_inflight: inflight_1.clone(),
+            qpair_state: &mut *qs as *mut QpairState,
+            pending_idx: 1,
+        }));
+        qs.pending.push(ctx_1);
+
+        // Simulate rc != 0 for ctx_0 (position 0 → swap with last = ctx_1).
+        if let Some(pos) = qs.pending.iter().position(|&p| p == ctx_0) {
+            qs.pending.swap_remove(pos);
+            if pos < qs.pending.len() {
+                unsafe { (*qs.pending[pos]).pending_idx = pos };
+            }
+            unsafe { drop(Box::from_raw(ctx_0)) };
+            inflight_0.fetch_sub(1, Ordering::Release);
+            completion_0.complete(-libc::EIO);
+        }
+
+        // ctx_0 freed and cleaned up.
+        assert_eq!(qs.pending.len(), 1);
+        assert_eq!(completion_0.wait(0), -libc::EIO);
+        assert_eq!(inflight_0.load(Ordering::Acquire), 0);
+
+        // ctx_1 still alive, reindexed to 0.
+        assert_eq!(unsafe { (*qs.pending[0]).pending_idx }, 0);
+        assert_eq!(completion_1.wait(1), -libc::ETIMEDOUT);
+        assert_eq!(inflight_1.load(Ordering::Acquire), 1);
+
+        // Clean up ctx_1.
+        unsafe { drop(Box::from_raw(ctx_1)) };
+    }
+
+    #[test]
+    fn poller_callback_late_path_does_not_double_signal() {
+        let inflight = Arc::new(AtomicUsize::new(0));
+        let completion = IoCompletion::new();
+        let qs = Box::new(QpairState {
+            dead: Arc::new(AtomicBool::new(false)),
+            pending: Vec::new(),
+            stale: Vec::new(),
+        });
+
+        // Simulate force_complete signaling first.
+        assert!(completion.complete(-libc::EIO));
+        assert_eq!(inflight.load(Ordering::Acquire), 0);
+
+        // Now simulate the late SPDK callback.
+        let ctx = Box::into_raw(Box::new(CallbackCtx {
+            completion: completion.clone(),
+            async_ctx: unsafe { std::mem::zeroed() },
+            bdev_inflight: inflight.clone(),
+            qpair_state: &*qs as *const QpairState as *mut QpairState,
+            pending_idx: 0,
+        }));
+        unsafe { poller_callback(ctx as *mut c_void, 0) };
+
+        // Completion unchanged (still -EIO from force_complete).
+        assert_eq!(completion.wait(0), -libc::EIO);
+        // Inflight unchanged (force_complete already decremented).
+        assert_eq!(inflight.load(Ordering::Acquire), 0);
+
+        // Late path doesn't free — reclaim manually.
+        unsafe { drop(Box::from_raw(ctx)) };
+    }
+
+    #[test]
+    fn force_complete_into_stale_reclaimable() {
+        let completion = IoCompletion::new();
+        let inflight = Arc::new(AtomicUsize::new(1));
+        let dead_flag = Arc::new(AtomicBool::new(false));
+        let mut qs = Box::new(QpairState {
+            dead: dead_flag.clone(),
+            pending: Vec::new(),
+            stale: Vec::new(),
+        });
+
+        let ctx = Box::into_raw(Box::new(CallbackCtx {
+            completion: completion.clone(),
+            async_ctx: unsafe { std::mem::zeroed() },
+            bdev_inflight: inflight.clone(),
+            qpair_state: &mut *qs as *mut QpairState,
+            pending_idx: 0,
+        }));
+        qs.pending.push(ctx);
+
+        let mut dead_qpairs: HashMap<usize, Box<QpairState>> = HashMap::new();
+        dead_qpairs.insert(0xDEAD, qs);
+
+        SpdkPoller::force_complete_qpair(0xDEAD, &mut dead_qpairs);
+
+        // QpairState stays alive with entry in stale.
+        assert!(dead_qpairs.contains_key(&0xDEAD));
+        assert_eq!(dead_qpairs[&0xDEAD].stale.len(), 1);
+        assert_eq!(dead_qpairs[&0xDEAD].pending.len(), 0);
+        assert!(dead_flag.load(Ordering::Acquire));
+
+        // reclaim_stale frees the stale CallbackCtx.
+        if let Some(qs) = dead_qpairs.get_mut(&0xDEAD) {
+            qs.reclaim_stale();
+        }
+        assert_eq!(dead_qpairs[&0xDEAD].stale.len(), 0);
+        assert_eq!(completion.wait(0), -libc::EIO);
+        assert_eq!(inflight.load(Ordering::Acquire), 0);
     }
 }

--- a/orpc/src/io/spdk_poller.rs
+++ b/orpc/src/io/spdk_poller.rs
@@ -641,7 +641,8 @@ unsafe extern "C" fn poller_callback(cb_arg: *mut c_void, status: i32) {
 
     let qs = &mut *(ctx.qpair_state as *mut QpairState);
 
-    // Defensive guard against UB underflow on empty pending.
+    // Underflow guard only (runs after Box::from_raw + deref, not a UAF guard).
+    // TODO: add orphan lifecycle for late-callback safety.
     if qs.pending.is_empty() {
         return;
     }

--- a/orpc/src/io/spdk_poller.rs
+++ b/orpc/src/io/spdk_poller.rs
@@ -795,15 +795,15 @@ mod test {
             pending_idx: 0,
         });
         let cb_ctx_ptr = Box::into_raw(cb_ctx);
-        qs.pending.push(cb_ctx_ptr);
-        assert_eq!(qs.pending.len(), 1);
+        unsafe { (*qs_ptr).pending.push(cb_ctx_ptr) };
+        assert_eq!(unsafe { (*qs_ptr).pending.len() }, 1);
 
         // Sync callback: poller_callback removes entry from pending.
         unsafe { poller_callback(cb_ctx_ptr as *mut c_void, -libc::EIO) };
-        assert!(qs.pending.is_empty());
+        assert!(unsafe { (*qs_ptr).pending.is_empty() });
 
         // Post-check: already removed, position() returns None (skips cleanup).
-        let pos = qs.pending.iter().position(|&p| p == cb_ctx_ptr);
+        let pos = unsafe { (*qs_ptr).pending.iter().position(|&p| p == cb_ctx_ptr) };
         assert!(pos.is_none());
     }
 

--- a/orpc/src/io/spdk_poller.rs
+++ b/orpc/src/io/spdk_poller.rs
@@ -900,6 +900,31 @@ mod test {
     }
 
     #[test]
+    fn poller_callback_empty_pending_skips_swap_remove_only() {
+        let inflight = Arc::new(AtomicUsize::new(1));
+        let completion = IoCompletion::new();
+        let qs = Box::new(QpairState {
+            dead: Arc::new(AtomicBool::new(false)),
+            pending: Vec::new(),
+            stale: Vec::new(),
+        });
+
+        // complete() returns true with empty pending: underflow guard skips swap_remove,
+        // but fetch_sub and free still run.
+        let ctx = Box::into_raw(Box::new(CallbackCtx {
+            completion: completion.clone(),
+            async_ctx: unsafe { std::mem::zeroed() },
+            bdev_inflight: inflight.clone(),
+            qpair_state: &*qs as *const QpairState as *mut QpairState,
+            pending_idx: 0,
+        }));
+        unsafe { poller_callback(ctx as *mut c_void, 0) };
+
+        assert_eq!(completion.wait(0), 0, "completion signaled");
+        assert_eq!(inflight.load(Ordering::Acquire), 0, "inflight decremented");
+    }
+
+    #[test]
     fn submit_one_rc_error_cleans_up_pending_entry() {
         let inflight = Arc::new(AtomicUsize::new(1));
         let completion = IoCompletion::new();

--- a/orpc/src/io/spdk_poller.rs
+++ b/orpc/src/io/spdk_poller.rs
@@ -790,12 +790,43 @@ mod test {
     }
 
     #[test]
-    fn complete_second_call_does_not_decrement_inflight() {
+    fn complete_is_idempotent_first_call_wins() {
         let completion = IoCompletion::new();
         assert!(completion.complete(42));
         assert_eq!(completion.wait(0), 42);
 
         assert!(!completion.complete(99));
         assert_eq!(completion.wait(0), 42);
+    }
+
+    #[test]
+    fn poller_callback_fetch_sub_guard_runs_once() {
+        let completion = IoCompletion::new();
+        let inflight = Arc::new(AtomicUsize::new(1));
+        let mut qs = Box::new(QpairState {
+            dead: Arc::new(AtomicBool::new(false)),
+            pending: Vec::new(),
+        });
+
+        // Simulate force_complete_qpair signaling first.
+        assert!(completion.complete(42));
+        inflight.fetch_sub(1, Ordering::Release);
+        assert_eq!(inflight.load(Ordering::Acquire), 0);
+
+        // Now poller_callback fires on the same ctx.
+        let ctx = Box::into_raw(Box::new(CallbackCtx {
+            completion: completion.clone(),
+            async_ctx: unsafe { std::mem::zeroed() },
+            bdev_inflight: inflight.clone(),
+            qpair_state: &mut *qs as *mut QpairState,
+            pending_idx: 0,
+        }));
+        qs.pending.push(ctx);
+
+        // complete() returns false -> fetch_sub skipped.
+        unsafe { poller_callback(ctx as *mut c_void, 99) };
+
+        assert_eq!(completion.wait(0), 42, "first signal wins");
+        assert_eq!(inflight.load(Ordering::Acquire), 0, "no double-decrement");
     }
 }

--- a/orpc/src/io/spdk_poller.rs
+++ b/orpc/src/io/spdk_poller.rs
@@ -811,6 +811,7 @@ mod test {
 
     #[test]
     fn pre_push_entry_removed_by_callback_skips_cleanup() {
+        // Pre-push: entry added before SPDK submit call.
         let inflight = Arc::new(AtomicUsize::new(1));
         let completion = IoCompletion::new();
 
@@ -832,9 +833,11 @@ mod test {
         unsafe { (*qs_ptr).pending.push(cb_ctx_ptr) };
         assert_eq!(unsafe { (*qs_ptr).pending.len() }, 1);
 
+        // Sync callback: poller_callback removes entry from pending.
         unsafe { poller_callback(cb_ctx_ptr as *mut c_void, -libc::EIO) };
         assert!(unsafe { (*qs_ptr).pending.is_empty() });
 
+        // Post-check: already removed, position() returns None (skips cleanup).
         let pos = unsafe { (*qs_ptr).pending.iter().position(|&p| p == cb_ctx_ptr) };
         assert!(pos.is_none());
     }
@@ -887,6 +890,7 @@ mod test {
         inflight.fetch_sub(1, Ordering::Release);
         assert_eq!(inflight.load(Ordering::Acquire), 0);
 
+        // Now poller_callback fires on the same ctx.
         let ctx = Box::into_raw(Box::new(CallbackCtx {
             completion: completion.clone(),
             async_ctx: unsafe { std::mem::zeroed() },


### PR DESCRIPTION
# Description
- Add orphan lifecycle for late SPDK callbacks. When `force_complete_qpair` signals all outstanding I/Os as failed, the `CallbackCtx` entries are kept alive (moved to `stale`) instead of freed, so the late SPDK callback can safely find its context without a use-after-free. `reclaim_stale()` drains and frees entries at shutdown or qpair unregister.
- Resolves part of [issue-710](https://github.com/CurvineIO/curvine/issues/710)
- Based on the change of [pr-1000](https://github.com/CurvineIO/curvine/pull/1000)
# Key Changes
- `orpc/src/io/spdk_poller.rs`: `QpairState` gains `stale: Vec<*mut CallbackCtx>` field and `reclaim_stale()` method that drains and frees stale entries.
- `force_complete_qpair`: Signals completion in-place without taking ownership. Entries moved from `pending` to `stale` (no longer freed immediately). The `QpairState` itself stays in `dead_qpairs` to keep ctx pointers valid for the late SPDK callback.
- `poller_callback`: Restructured with `complete()` as the outer discriminator. Hot path (`complete()` returns true): removes from pending via swap_remove/pop, signals, decrements inflight, then frees the `CallbackCtx` via `drop(Box::from_raw(...))`. Late path (already signaled by force_complete): entire body skipped - entry lives on in `stale` and is freed by `reclaim_stale()`.
- Shutdown + unregister paths: Call `reclaim_stale()` before `dead_qpairs.clear()` or `.remove()`.
- Minor cleanup: Shorten `std::sync::Arc<AtomicUsize>` to `Arc<AtomicUsize>` in `IoRequest` and `CallbackCtx`.
- `submit_one`: Accesses `pending` through raw pointer (`(*qs_ptr).pending`) instead of `&mut` to avoid aliasing UB with poller_callback reentry.
- Add correctness tests:
    + `force_complete_into_stale_reclaimable`:  Verifies `force_complete_qpair` moves entries to `stale`, keeps `QpairState` alive, and `reclaim_stale` frees them correctly.
    + update `poller_callback_empty_pending_returns_early` to `poller_callback_empty_pending_skips_swap_remove_only`: Underflow guard skips swap_remove when pending is empty, but fetch_sub and free still run on the hot path.
    + `poller_callback_late_path_does_not_double_signal`: Late callback after `force_complete` does not re-signal or double-decrement inflight.
    + Updated `force_complete_reclaims_callback_ctx` test: Now verifies stale lifecycle instead of immediate cleanup.
- update from mutable to immutable variables to avoid warning:
    +  pre_push_entry_removed_by_callback_skips_cleanup
    + poller_callback_empty_pending_skips_swap_remove_only
    + validate_rejects_low_keep_alive
    + validate_accepts_high_keep_alive
    + validate_rejects_inherited_low_keep_alive
# Impact
- Prevents use-after-free when SPDK fires a completion callback after the qpair has already been force-completed.
- Enables safe deferred cleanup of orphaned callbacks without leaking.

# Future Work
4. **Decouple dead flags** — Remove `qpair_dead` from `IoRequest`
5. **Derive qpair activeness** — from `pending` state, remove `active_qpairs` Vec
6. **Deferred qpair cleanup** — Strategy for clean deferred removal 
7. **Unregister ctrlr + detach target** — Complete controller teardown