### PR TITLE
fix(fuse): prevent pipe poisoning from short splice transfers

### DIFF
--- a/curvine-common/src/conf/fuse_conf.rs
+++ b/curvine-common/src/conf/fuse_conf.rs
@@ -189,6 +189,13 @@ pub struct FuseConf {
 
     pub list_limit: usize,
 
+    /// Whether to use splice (zero-copy) for FUSE data transfer.
+    /// When enabled, the receiver uses splice(/dev/fuse → pipe → buf) and the
+    /// sender uses vmsplice + splice (pipe → /dev/fuse) for large responses.
+    /// When disabled, both use plain read/writev (extra memory copy but no
+    /// pipe management overhead). Default: true.
+    pub enable_splice: bool,
+
     pub log: LogConf,
 }
 
@@ -365,6 +372,7 @@ impl Default for FuseConf {
             meta_cache_ttl_duration: Default::default(),
 
             list_limit: 1000,
+            enable_splice: true,
             log: LogConf::default(),
         };
 

--- a/curvine-fuse/src/session/channel/fuse_receiver.rs
+++ b/curvine-fuse/src/session/channel/fuse_receiver.rs
@@ -29,7 +29,7 @@ use orpc::runtime::{RpcRuntime, Runtime};
 use orpc::sync::channel::AsyncSender;
 use orpc::sync::FastDashMap;
 use orpc::sys::pipe::{AsyncFd, Pipe2, PipeFd};
-use orpc::{err_box, sys};
+use orpc::{err_box, sys, try_option_ref};
 use std::sync::Arc;
 use tokio::sync::{watch, Notify};
 use tokio_util::bytes::BytesMut;
@@ -43,7 +43,7 @@ pub struct FuseReceiver<T> {
     fs: Arc<T>,
     rt: Arc<Runtime>,
     sender: AsyncSender<FuseTask>,
-    pipe2: Pipe2,
+    pipe2: Option<Pipe2>,
     buf: BytesMut,
     fuse_len: usize,
     debug: bool,
@@ -64,8 +64,13 @@ impl<T: FileSystem> FuseReceiver<T> {
         audit_logging_enabled: bool,
         metrics_enabled: bool,
         pending_requests: Arc<FastDashMap<u64, Arc<Notify>>>,
+        enable_splice: bool,
     ) -> IOResult<Self> {
-        let pipe2 = Pipe2::new(PipeFd::new(buf_size, false, false)?)?;
+        let pipe2 = if enable_splice {
+            Some(Pipe2::new(PipeFd::new(buf_size, false, false)?)?)
+        } else {
+            None
+        };
         let buf = BytesMut::zeroed(buf_size);
 
         let client = Self {
@@ -87,32 +92,43 @@ impl<T: FileSystem> FuseReceiver<T> {
 
     // Read a data from fuse.
     pub async fn receive(&mut self) -> IOResult<BytesMut> {
-        self.splice().await
+        if self.pipe2.is_some() {
+            self.splice().await
+        } else {
+            self.read().await
+        }
     }
 
-    // Use libc::read to read data, test it, and there are multiple memory copies.
+    // Use libc::read to read data directly into the buffer (no splice).
     pub async fn read(&mut self) -> IOResult<BytesMut> {
+        self.buf.reserve(self.fuse_len);
+        unsafe {
+            self.buf.set_len(self.fuse_len);
+        }
+
         let len = self
             .kernel_fd
             .async_read(|fd| sys::read(fd.fd(), &mut self.buf))
-            .await
-            .unwrap();
-        Ok(BytesMut::from(&self.buf[..len as usize]))
+            .await?;
+        let len = len as usize;
+        if len < FUSE_IN_HEADER_LEN {
+            return err_box!("short read on fuse device");
+        }
+
+        Ok(self.buf.split_to(len))
     }
 
     pub async fn splice(&mut self) -> IOResult<BytesMut> {
-        let write_len = self
-            .pipe2
-            .write_io(&self.kernel_fd, None, self.fuse_len)
-            .await
-            .unwrap();
+        let pipe2 = try_option_ref!(self.pipe2);
+
+        let write_len = pipe2.write_io(&self.kernel_fd, None, self.fuse_len).await?;
 
         self.buf.reserve(write_len);
         unsafe {
             self.buf.set_len(write_len);
         }
 
-        let read_len = self.pipe2.read_buf(&mut self.buf[..write_len]).await?;
+        let read_len = pipe2.read_buf(&mut self.buf[..write_len]).await?;
         if write_len != read_len {
             return err_box!(
                 "splice read and write lengths are inconsistent, write len {}, read len {}",
@@ -124,8 +140,7 @@ impl<T: FileSystem> FuseReceiver<T> {
             return err_box!("short read on fuse device");
         };
 
-        let req_buf = self.buf.split_to(read_len);
-        Ok(req_buf)
+        Ok(self.buf.split_to(read_len))
     }
 
     /// Build a reply handle for `unique`. When `labels` is `Some`, a metrics

--- a/curvine-fuse/src/session/channel/fuse_sender.rs
+++ b/curvine-fuse/src/session/channel/fuse_sender.rs
@@ -24,8 +24,13 @@ use orpc::io::IOResult;
 use orpc::runtime::Runtime;
 use orpc::sync::channel::AsyncReceiver;
 use orpc::sys::pipe::{AsyncFd, Pipe2, PipeFd};
-use orpc::{err_box, sys};
+use orpc::{err_box, sys, try_option_ref};
 use std::sync::Arc;
+
+/// Responses smaller than this threshold use writev (1 syscall) instead of
+/// vmsplice + splice (2 syscalls).  The zero-copy benefit of splice only
+/// outweighs the extra syscall for larger payloads.
+const SPLICE_THRESHOLD: usize = 8192;
 
 /// FuseSender
 /// Reads data from queue and writes to fuse fd.
@@ -36,7 +41,7 @@ pub struct FuseSender<T> {
     rt: Arc<Runtime>,
     kernel_fd: Arc<AsyncFd>,
     receiver: AsyncReceiver<FuseTask>,
-    pipe2: Pipe2,
+    pipe2: Option<Pipe2>,
     debug: bool,
 }
 
@@ -48,8 +53,13 @@ impl<T: FileSystem> FuseSender<T> {
         receiver: AsyncReceiver<FuseTask>,
         buf_size: usize,
         debug: bool,
+        enable_splice: bool,
     ) -> IOResult<Self> {
-        let pipe2 = Pipe2::new(PipeFd::new(buf_size, false, false)?)?;
+        let pipe2 = if enable_splice {
+            Some(Pipe2::new(PipeFd::new(buf_size, false, false)?)?)
+        } else {
+            None
+        };
         let fuse_rx = Self {
             fs,
             rt,
@@ -178,33 +188,73 @@ impl<T: FileSystem> FuseSender<T> {
     }
 
     // Send response data to fuse.
+    // Small responses use writev (1 syscall); large responses use splice
+    // (vmsplice + splice, 2 syscalls but zero-copy).
     pub async fn send(&mut self, rep: ResponseData) -> IOResult<()> {
         if self.debug {
             info!("reply {:?}", rep.header);
         }
-        self.splice(rep).await
+
+        let len = rep.header.len as usize;
+        if self.pipe2.is_some() && len >= SPLICE_THRESHOLD {
+            self.splice(rep).await
+        } else {
+            self.write(rep).await
+        }
     }
 
     pub async fn write(&mut self, rep: ResponseData) -> IOResult<()> {
-        let (_, iovec) = rep.as_iovec()?;
-        self.kernel_fd
+        let (len, iovec) = rep.as_iovec()?;
+        let written = self
+            .kernel_fd
             .async_write(|fd| sys::writev(fd.fd(), &iovec))
             .await?;
+        if written as usize != len {
+            return err_box!("short writev: wrote {} of {}", written, len);
+        }
         Ok(())
     }
 
-    async fn splice(&mut self, rep: ResponseData) -> IOResult<()> {
+    async fn splice(&self, rep: ResponseData) -> IOResult<()> {
+        let pipe2 = try_option_ref!(self.pipe2);
+
         let (len, iovec) = rep.as_iovec()?;
-        let write_len = self.pipe2.write_iov(&iovec).await?;
-        if write_len != len {
-            return err_box!("io return value error, res: {}, expect: {}", write_len, len);
+        if let Err(e) = pipe2.write_iov(len, &iovec).await {
+            Self::drain_pipe(pipe2);
+            return Err(e);
         }
 
-        let read_len = self.pipe2.read_io(&self.kernel_fd, len).await?;
-        if read_len != len {
-            err_box!("io return value error, res: {}, expect: {}", read_len, len)
-        } else {
-            Ok(())
+        if let Err(e) = pipe2.read_io(&self.kernel_fd, len).await {
+            Self::drain_pipe(pipe2);
+            return Err(e);
+        }
+
+        Ok(())
+    }
+
+    /// Drain any residual bytes left in the pipe after a failed transfer.
+    /// This prevents the pipe from being permanently poisoned (issue #965):
+    /// without draining, stale bytes at the head of the FIFO would corrupt
+    /// every subsequent response.
+    ///
+    /// EINTR is retried so that a signal during draining cannot leave the
+    /// pipe partially filled.  The loop stops when the non-blocking pipe
+    /// reports EAGAIN/EWOULDBLOCK (empty) or on EOF/any other error.
+    fn drain_pipe(pipe2: &Pipe2) {
+        let fd = pipe2.read_raw_fd();
+        let mut buf = [0u8; 8192];
+        loop {
+            match sys::read(fd, &mut buf) {
+                Ok(n) if n > 0 => continue,
+                Ok(_) => break, // EOF
+                Err(e) => {
+                    if e.raw_error().raw_os_error() == Some(libc::EINTR) {
+                        continue; // interrupted; retry
+                    }
+                    // EAGAIN/EWOULDBLOCK: pipe is empty; any other error: stop.
+                    break;
+                }
+            }
         }
     }
 }

--- a/curvine-fuse/src/session/channel/mod.rs
+++ b/curvine-fuse/src/session/channel/mod.rs
@@ -14,7 +14,7 @@
 
 use crate::fs::FileSystem;
 use crate::session::FuseMnt;
-use crate::{FuseResult, FuseUtils};
+use crate::{FuseResult, FuseUtils, FUSE_BUFFER_HEADER_SIZE};
 use curvine_common::conf::FuseConf;
 use orpc::runtime::Runtime;
 use orpc::sync::channel::AsyncChannel;
@@ -34,7 +34,9 @@ pub struct FuseChannel<T> {
 
 impl<T: FileSystem> FuseChannel<T> {
     pub fn new(fs: Arc<T>, rt: Arc<Runtime>, mnt: &FuseMnt, conf: &FuseConf) -> FuseResult<Self> {
-        let buf_size = FuseUtils::get_fuse_buf_size();
+        let max_readahead = conf.max_readahead_kb.unwrap_or(0).saturating_mul(1024);
+        let buf_size =
+            FuseUtils::get_fuse_buf_size().max(max_readahead as usize + FUSE_BUFFER_HEADER_SIZE);
 
         let mut receivers = Vec::with_capacity(conf.mnt_per_task);
         let mut senders = Vec::with_capacity(conf.mnt_per_task);
@@ -43,8 +45,15 @@ impl<T: FileSystem> FuseChannel<T> {
             let (tx, rx) = AsyncChannel::new(conf.fuse_channel_size).split();
             let fd = mnt.create_async_task_fd(conf.clone_fd)?;
 
-            let sender =
-                FuseSender::new(fs.clone(), rt.clone(), fd.clone(), rx, buf_size, conf.debug)?;
+            let sender = FuseSender::new(
+                fs.clone(),
+                rt.clone(),
+                fd.clone(),
+                rx,
+                buf_size,
+                conf.debug,
+                conf.enable_splice,
+            )?;
 
             let receiver = FuseReceiver::new(
                 fs.clone(),
@@ -56,6 +65,7 @@ impl<T: FileSystem> FuseChannel<T> {
                 conf.audit_logging_enabled,
                 conf.metrics_enabled,
                 pending_requests.clone(),
+                conf.enable_splice,
             )?;
 
             senders.push(sender);

--- a/orpc/src/sys/pipe/pipe2.rs
+++ b/orpc/src/sys/pipe/pipe2.rs
@@ -94,22 +94,59 @@ impl Pipe2 {
         Ok(res as usize)
     }
 
-    // Write IoSlice data into the pipeline, iov -> pipe writer
-    pub async fn write_iov(&self, iov: &[IoSlice<'_>]) -> IOResult<usize> {
-        let res = self
-            .writer
-            .async_write(|fd| sys::vm_splice(fd.fd(), iov))
-            .await?;
-        Ok(res as usize)
+    // Write IoSlice data into the pipeline, iov -> pipe writer.
+    pub async fn write_iov(&self, len: usize, iov: &[IoSlice<'_>]) -> IOResult<()> {
+        if len > self.buf_size {
+            return err_box!(
+                "write_iov: data size {} exceeds pipe buffer size {}",
+                len,
+                self.buf_size
+            );
+        }
+
+        let mut written = 0;
+        while written < len {
+            let res = if written == 0 {
+                self.writer
+                    .async_write(|fd| sys::vm_splice(fd.fd(), iov))
+                    .await?
+            } else {
+                let cur_iov = Self::skip_iov_bytes(iov, written);
+                self.writer
+                    .async_write(|fd| sys::vm_splice(fd.fd(), &cur_iov))
+                    .await?
+            };
+            if res == 0 {
+                return err_box!("vmsplice returned 0");
+            }
+            written += res as usize;
+        }
+        Ok(())
     }
 
-    // Read data in the pipeline, write to the io object, pipe reader -> fd out
-    pub async fn read_io(&self, fd_out: &AsyncFd, len: usize) -> IOResult<usize> {
+    // Read data in the pipeline, write to the io object, pipe reader -> fd out.
+    // Loops to completion: a partial splice (short transfer under SPLICE_F_NONBLOCK)
+    // is retried until all bytes are transferred, preventing pipe poisoning (issue #965).
+    pub async fn read_io(&self, fd_out: &AsyncFd, len: usize) -> IOResult<()> {
+        if len > self.buf_size {
+            return err_box!(
+                "read_io: request size {} exceeds pipe buffer size {}",
+                len,
+                self.buf_size
+            );
+        }
         let fd_in = self.reader.raw_fd();
-        let res = fd_out
-            .async_write(|fd| sys::splice(fd_in, None, fd.fd(), None, len))
-            .await?;
-        Ok(res as usize)
+        let mut remaining = len;
+        while remaining > 0 {
+            let res = fd_out
+                .async_write(|fd| sys::splice(fd_in, None, fd.fd(), None, remaining))
+                .await?;
+            if res == 0 {
+                return err_box!("splice returned 0");
+            }
+            remaining -= res as usize;
+        }
+        Ok(())
     }
 
     // Read the data of the pipeline into buf, pipe read -> buf
@@ -127,6 +164,23 @@ impl Pipe2 {
 
     pub fn take_fd(&mut self) -> PipeFd {
         self.pipe_fd.take().unwrap()
+    }
+
+    /// Build a new iovec that skips the first `offset` bytes from `iov`.
+    /// Used by `write_iov` to resume a partially completed vmsplice transfer.
+    fn skip_iov_bytes<'a>(iov: &'a [IoSlice<'a>], mut offset: usize) -> Vec<IoSlice<'a>> {
+        let mut result = Vec::with_capacity(iov.len());
+        for slice in iov {
+            if offset == 0 {
+                result.push(IoSlice::new(&slice[..]));
+            } else if slice.len() <= offset {
+                offset -= slice.len();
+            } else {
+                result.push(IoSlice::new(&slice[offset..]));
+                offset = 0;
+            }
+        }
+        result
     }
 }
 


### PR DESCRIPTION
### Summary

Fixes #965.

A single short (partial) `splice`/`vmsplice` transfer under `SPLICE_F_NONBLOCK` could permanently poison the FuseSender's long-lived, reused pipe. The residual bytes left in the FIFO would either starve the pipe (every subsequent `write_iov` short-writes) or corrupt responses (stale bytes spliced ahead of the real data). Once poisoned, all requests on that sender were never answered, causing the FUSE mount to hang in D state with ~100+ backlogged requests.

### Root Cause

1. `Pipe2::write_iov` and `Pipe2::read_io` issued a **single** `vmsplice`/`splice` syscall and returned the raw byte count. Under `SPLICE_F_NONBLOCK`, the kernel may transfer fewer bytes than requested (short transfer). The caller treated `transferred != expected` as an error and returned early — but the bytes already pushed into the pipe were **left there**.

2. The pipe is a FIFO reused across requests. Residual bytes from a failed transfer:
   - **Space starvation**: occupy pipe capacity, causing every subsequent `write_iov` to short-write → error → more residual bytes → pipe eventually fills → sender parks on `writable().await` forever.
   - **Corruption**: stale bytes at the FIFO head get spliced into `/dev/fuse` ahead of the next response, causing protocol-level misalignment.

3. The sender's error path only logged a `warn!` and continued to the next task — the pipe was never drained or rebuilt.

### Changes

| File | Change |
|------|--------|
| `orpc/src/sys/pipe/pipe2.rs` | `write_iov` and `read_io` now loop to completion; added `skip_iov_bytes` to resume partial vmsplice from the correct offset; added buffer-size validation |
| `curvine-fuse/src/session/channel/fuse_sender.rs` | Added `drain_pipe()` to clear residual bytes on splice error; `pipe2` is now `Option<Pipe2>`; small responses (< 8 KB) use `writev` instead of splice; `write()` checks for short writev |
| `curvine-fuse/src/session/channel/fuse_receiver.rs` | `pipe2` is now `Option<Pipe2>`; `receive()` chooses between `splice()` and `read()`; `read()` uses proper error handling instead of `.unwrap()` |
| `curvine-fuse/src/session/channel/mod.rs` | Pass `enable_splice` config to sender/receiver; `buf_size` now accounts for `max_readahead_kb` |
| `curvine-common/src/conf/fuse_conf.rs` | New `enable_splice: bool` config (default: `true`) |

### How the Fix Works

**1. Loop-to-completion (primary defense)**

`Pipe2::write_iov` and `Pipe2::read_io` now loop until all requested bytes are transferred:

```rust
// write_iov: vmsplice loop
let mut written = 0;
while written < len {
    let cur_iov = Self::skip_iov_bytes(iov, written);
    let res = self.writer.async_write(|fd| sys::vm_splice(fd.fd(), &cur_iov)).await?;
    if res == 0 { return err_box!("vmsplice returned 0"); }
    written += res as usize;
}

// read_io: splice loop
let mut remaining = len;
while remaining > 0 {
    let res = fd_out.async_write(|fd| sys::splice(fd_in, None, fd.fd(), None, remaining)).await?;
    if res == 0 { return err_box!("splice returned 0"); }
    remaining -= res as usize;
}
```

A partial transfer under `SPLICE_F_NONBLOCK` is treated as "continue" — the loop resumes from the partial offset (`skip_iov_bytes` for vmsplice, `remaining` counter for splice). This eliminates the condition that created residual bytes in the first place.

**2. drain_pipe (safety net)**

If a splice ultimately fails (e.g. I/O error, broken pipe), `drain_pipe` reads and discards any residual bytes from the pipe before the sender continues:

```rust
fn drain_pipe(pipe2: &Pipe2) {
    let fd = pipe2.read_raw_fd();
    let mut buf = [0u8; 8192];
    loop {
        match sys::read(fd, &mut buf) {
            Ok(n) if n > 0 => continue,
            _ => break,
        }
    }
}
```

This ensures that even if the completion loop itself fails, the pipe is clean for the next response.

**3. Small-response writev fast path**

Responses smaller than 8 KB now use `writev` (1 syscall) instead of `vmsplice + splice` (2 syscalls). This eliminates pipe involvement entirely for small metadata responses, reducing both latency and the surface area for pipe poisoning.

**4. enable_splice runtime switch**

A new `fuse.enable_splice` config (default: `true`) allows disabling splice entirely as a fallback. When disabled, both receiver and sender use plain `read`/`writev` — extra memory copy but zero pipe management overhead.

### Test Plan

- [ ] Compile and run existing FUSE tests
- [ ] Mount with `enable_splice=true`, run `fio` sequential read/write (128 KB block) — verify no hangs
- [ ] Mount with `enable_splice=false`, run same workload — verify fallback path works
- [ ] Stress test: concurrent `ls`, `cat`, `dd` on the same mount for 10+ minutes — verify no D-state hangs
- [ ] Verify small metadata responses (e.g. `stat`, `lookup`) use writev path (check logs with `debug=true`)
- [ ] Verify large data responses still use splice path

### Issue Reference

Closes #965
