### PR TITLE
docs(fuse): add Grafana dashboard for fuse metrics

### DIFF
--- a/etc/grafana/README.md
+++ b/etc/grafana/README.md
@@ -1,0 +1,177 @@
+# Curvine FUSE Metrics — Grafana Dashboard
+
+A DevOps troubleshooting dashboard for the `curvine-fuse` client, covering all
+`curvine_fuse_*` Prometheus metrics. The dashboard is organized as a **triage
+path** (not by metric family): first locate impact and the bottleneck stage,
+then drill into the domain rows.
+
+- Dashboard model: [`curvine-fuse-dashboard.json`](./curvine-fuse-dashboard.json)
+- Pure JSON — importing it changes nothing on the Rust side.
+
+## Import
+
+1. In Grafana: **Dashboards → New → Import** → upload `curvine-fuse-dashboard.json`.
+2. Select your Prometheus datasource for the `Datasource` variable.
+3. **First step after import: confirm the `Job` variable.** It defaults to a
+   regex `/.*curvine.*fuse.*/` over `label_values(up, job)`. If your Prometheus
+   job name for the fuse target differs, edit the `job` variable's regex (or
+   value) so it matches only curvine-fuse targets — otherwise the availability
+   panels will show unrelated targets while the business panels show no data.
+
+### Prometheus scrape setup
+
+Point Prometheus at each fuse process's `/metrics` endpoint. There is **no
+per-mount label** — multiple fuse instances/mounts are distinguished only by the
+Prometheus `instance` label. The dashboard uses `$__rate_interval`, so it adapts
+to your scrape interval automatically; a scrape interval of 10–30s pairs well
+with the default `30s` refresh and `now-1h` time range.
+
+## Template variables
+
+| Variable | Type | Notes |
+|---|---|---|
+| `$datasource` | datasource | Prometheus |
+| `$job` | query `label_values(up, job)` | regex-constrained to curvine-fuse; sourced from `up` (not a business metric) so **down targets stay visible** |
+| `$instance` | query `label_values(up{job=~"$job"}, instance)` | multi + All (All value `.*`) |
+| `$opcode` | custom, **single-select** | 34 handled request ops; query uses `opcode="$opcode"` |
+| `$kind` | custom `metadata,stream` | multi + All; query uses `kind=~"$kind"` |
+| `$io_type` | custom `read,write` | Stream IO only; multi + All; `io_type=~"$io_type"` |
+| `$lifecycle_io_type` | custom `flush,fsync,release` | Lifecycle only — **separate from `$io_type`**; `io_type=~"$lifecycle_io_type"` |
+| `$path_type` | custom `curvine,ufs,fallback,local,unknown` | multi + All; `path_type=~"$path_type"` |
+
+`$opcode` is a **static** list: it must be updated by hand when
+`curvine-fuse/src/session/channel/fuse_receiver.rs` gains or loses a dispatch
+arm. It covers only the 34 handled data/metadata/stream request ops. **`Init`
+and `Interrupt` are handled control ops** (they appear in `requests_total` but
+are excluded from the drilldown — see the *Control requests* panel in the
+Framework row). Unsupported ops (`Ioctl`/`Lseek`/`Rename2`/`BMap`/`Poll`/…) are
+observed via the *Unsupported top-N* panel in the Framework row.
+
+## Reading the dashboard
+
+### Availability: three states, don't conflate
+
+- `up==0` and business panels show No data → **process/scrape target
+  unreachable** (`kernel_fd_health` is absent). This is **not** QPS=0.
+- `up==1 && QPS==0` → reachable but currently **idle** (normal).
+- `up==1 && kernel_fd_health==0` → reachable but the **FUSE fd/session is
+  unhealthy**.
+
+The two Overview stats show these as **fleet counts, not per-instance tiles**, so
+their size stays fixed no matter how many instances `$instance` selects:
+
+- **Availability (up)** → `UP` (targets with `up==1`) + `DOWN` (`up==0`) counts;
+  `DOWN>0` turns red. `count(...) or vector(0)` keeps the all-healthy case at `0`,
+  not No data.
+- **Kernel fd health** → `HEALTHY` + `UNHEALTHY` counts over **reachable**
+  instances; `UNHEALTHY>0` turns red. A down process (`up==0`) exports no
+  `kernel_fd_health`, so it is in **neither** count — read this together with the
+  Availability `DOWN` count.
+
+Which specific instance is down/unhealthy is in the **Per-instance overview**
+table (it lists `up` and `kernel_fd_health` per instance).
+
+### No data ≠ broken
+
+Top-N error/event tables show **No data** when there were no such events in the
+range — that is expected, not a broken panel. The Overview error-total stats are
+zero-filled so "no errors" reads as `0`, not No data. Ratio panels (non-success,
+cache hit rate) are zero-filled too.
+
+### Histograms lag — use gauges as leading signals
+
+**All `*_duration_us` histograms are completion-based**: a request/stage is only
+observed *after* it finishes. Work currently stuck in a queue, a backend call,
+the reply channel, or a kernel write is **not yet counted**, so p99 can stay flat
+(or samples drop) during a stall. Under async/backpressure scenarios the leading
+signals are the inflight/queue gauges: `active_requests`, `reply_queue_depth`,
+`meta_task_inflight`, `stream_io_inflight`, `stream_lifecycle_inflight`,
+`stream_write_queue_depth`, `setlkw_inflight`.
+
+### Two errno conventions (do not mix)
+
+- `errors_total{errno}` and `response_write_errors_total{errno}` use **uppercase**
+  POSIX names (`ENOENT`, `EIO`, …, `OTHER`).
+- `receive_errors_total{errno}` uses **lowercase** splice names
+  (`enoent`, `eintr`, `eagain`, `enodev`, `other`).
+
+### Other easy-to-misread semantics
+
+- `path_type=fallback` means a **fallback-capable handle**, not a read that
+  actually fell back to UFS. Don't treat fallback latency/bytes as real
+  UFS-fallback IO.
+- `receive_loop_wait_duration_us` **includes idle wait** — a high p99 under low
+  traffic is normal, not slow requests.
+- `operation_duration_us` is the **metadata dispatch scope** (includes reply
+  enqueue, excludes interrupted SETLKW); it is not the end-to-end
+  `request_duration_us`. **Do not subtract the two** to localize latency.
+- `stream_lifecycle_requests_total` has **no status** label → no lifecycle error
+  rate (its result mixes backend and reply-enqueue errors).
+- `readdir_entries` observes only the **success** child; it is a per-syscall
+  batch size, not total directory size.
+- `decode_errors_total{phase="decode"}` is **terminal** (receiver died → restart
+  signal), not a rate to threshold; `phase="parse"` is recurring/recoverable.
+- `stage_duration_us` has **no `opcode` label** (framework horizontal overview,
+  by kind); per-op latency is in the Operation drilldown row.
+
+### Aggregation rules
+
+- `kernel_fd_health` → `min by(instance)` (never sum).
+- Queues / inflight → `sum by(instance)` (plus `kind`/`io_type` where the metric
+  carries it, in the Bottleneck Locator).
+- `{inode,file_handle,dir_handle}_count` → kept **per-instance**, not summed
+  across instances.
+
+## DevOps Triage Matrix
+
+Enter from a **symptom**; the row tells you where to look and what to do next.
+(Remember: p99 histograms lag — check inflight/queue gauges first under
+backpressure.)
+
+| Symptom | Look at | Likely cause | Next step |
+|---|---|---|---|
+| `up==0` | Overview Availability | scrape/process down | check process/port/deployment (business No data ≠ QPS=0) |
+| `up==1 && kernel_fd_health==0` | Overview Availability | FUSE fd/session unhealthy | check mount/kernel fd/session log + recent shutdown reason |
+| request p99 high & `meta_spawn` stage high | Locator + Framework | metadata task scheduling / runtime pressure | check `meta_task_inflight` |
+| request p99 high & `operation` stage high | Metadata + Cache | metadata backend/cache/readdir | op drilldown + cache/readdir + backend side |
+| request p99 high & `stream_io` stage high | Stream IO | backend read/write slow | io_type/path_type/status/throughput |
+| `active_requests` high but stage p99 flat | Locator + queues | concurrency accumulation / downstream wait (p99 lag) | inspect queues/inflight + op mix |
+| write latency high & `stream_write_queue_depth` high | Stream IO | writer queue backlog | write QPS/bytes/lifecycle flush/release |
+| `reply_write` p99 high & `response_write_errors_total` present | Reply | kernel fd write slow/failing | write errors by errno + kernel fd health |
+| `reply_queue_depth` high & `reply_write` rate flat | Reply | sender not draining / downstream write stuck | reply_queue_depth trend + downstream write |
+| `reply_enqueue_errors_total` present | Reply | request never reached the sender | enqueue failures by reason |
+| `reply_write` p99 high but `reply_queue_depth` low | Reply | single slow kernel write, no backlog | write latency distribution |
+| non-success ratio high & errno top-N present | Overview / Operation | FS operation error | errno/op/status (`errors_total`) |
+| `unsupported_total` high | Framework → Unsupported top-N | kernel sent an unimplemented op | opcode/reason, confirm compatibility |
+| `setlkw_wait`/`setlkw_inflight` high | Metadata | lock wait or SETLKW reply backpressure | setlkw duration/inflight + interrupted |
+| cache hit rate low | Cache & readdir | metadata cache miss/invalidation | invalidation reason/top op |
+
+## Scope boundary
+
+This dashboard localizes bottlenecks to the **fuse-local链路 only**. When it
+shows a domain is slow, the next hop is a different system:
+
+- `operation_duration_us` high → fuse metadata dispatch/backend call is slow
+  overall → look at Curvine metadata/backend side.
+- `io_duration_us` high → fuse read/write backend call is slow → look at Curvine
+  client/server/storage/network metrics.
+- `path_type=fallback` is not a real UFS-fallback outcome (see above).
+
+The dashboard does not decompose Curvine master/worker/server internals.
+
+## Tables and implementation limits
+
+Multi-query tables (`Per-instance overview`, `Top opcode p99`, `Metadata op
+hotspots`, `read/write comparison`) use Grafana transforms (`joinByField` on a
+single key, or `merge` for the `(io_type,path_type)` comparison) to render one
+row per key. `io_dispatch_duration_us` and `stream_io_inflight` carry only
+`io_type` (no `path_type`), so they are shown in a companion panel next to the
+`read/write comparison` table rather than force-joined into it. If a table ever
+renders as multiple frames in your Grafana version, fall back to the individual
+per-metric panels in the same row to continue troubleshooting.
+
+## Enhancements (optional, not required for v1)
+
+Data links / variable interlinking (click an instance → set `$instance`, click
+an opcode → set `$opcode`) are enhancements; panel descriptions already state the
+next variable to switch. They can be added after the core dashboard is in use.

--- a/etc/grafana/curvine-fuse-dashboard.json
+++ b/etc/grafana/curvine-fuse-dashboard.json
@@ -1,0 +1,5016 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Prometheus datasource scraping curvine-fuse /metrics",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "curvine-fuse metrics \u2014 DevOps troubleshooting dashboard. Rows are ordered as a triage path: Overview -> Bottleneck Locator -> Instance Overview -> Operation drilldown -> Reply -> Framework -> Metadata -> Stream IO -> Cache -> State. First three rows are expanded by default. See etc/grafana/README.md for the full DevOps Triage Matrix and semantics. NOTE: all *_duration_us histograms are completion-based and can lag for stuck in-flight work; use inflight/queue gauges as leading signals under async/backpressure scenarios.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "liveNow": false,
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "curvine",
+    "fuse",
+    "metrics"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(up, job)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Job",
+        "multi": false,
+        "name": "job",
+        "options": [],
+        "query": {
+          "query": "label_values(up, job)",
+          "refId": "job"
+        },
+        "refresh": 2,
+        "regex": "/.*curvine.*fuse.*/",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(up{job=~\"$job\"}, instance)",
+        "hide": 0,
+        "includeAll": true,
+        "allValue": ".*",
+        "label": "Instance",
+        "multi": true,
+        "name": "instance",
+        "options": [],
+        "query": {
+          "query": "label_values(up{job=~\"$job\"}, instance)",
+          "refId": "instance"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "Lookup",
+          "value": "Lookup"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "label": "Opcode",
+        "name": "opcode",
+        "description": "Handled data/metadata/stream request ops only (34). Init/Interrupt are control ops (see Framework row); unsupported ops (Ioctl/Lseek/Rename2/...) see Overview Unsupported panel. Static list must be updated by hand when fuse_receiver.rs dispatch arms change.",
+        "options": [],
+        "query": "Lookup,GetAttr,SetAttr,Readlink,Symlink,MkNod,Mkdir,Unlink,RmDir,Rename,Link,Open,Read,Write,StatFs,Release,Fsync,SetXAttr,GetXAttr,ListXAttr,RemoveXAttr,Flush,OpenDir,ReadDir,ReleaseDir,GetLk,SetLk,SetLkW,Access,Create,Forget,BatchForget,FAllocate,ReadDirPlus",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "hide": 0,
+        "includeAll": true,
+        "allValue": ".*",
+        "label": "Kind",
+        "multi": true,
+        "name": "kind",
+        "options": [],
+        "query": "metadata,stream",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "hide": 0,
+        "includeAll": true,
+        "allValue": ".*",
+        "label": "IO type",
+        "multi": true,
+        "name": "io_type",
+        "description": "Stream read/write IO only. flush/fsync/release lifecycle uses $lifecycle_io_type.",
+        "options": [],
+        "query": "read,write",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "hide": 0,
+        "includeAll": true,
+        "allValue": ".*",
+        "label": "Lifecycle IO type",
+        "multi": true,
+        "name": "lifecycle_io_type",
+        "options": [],
+        "query": "flush,fsync,release",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "hide": 0,
+        "includeAll": true,
+        "allValue": ".*",
+        "label": "Path type",
+        "multi": true,
+        "name": "path_type",
+        "description": "path_type=fallback means a fallback-capable handle, NOT a read that actually fell back to UFS.",
+        "options": [],
+        "query": "curvine,ufs,fallback,local,unknown",
+        "skipUrlSync": false,
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Curvine FUSE Metrics",
+  "uid": "curvine-fuse-metrics",
+  "version": 1,
+  "weekStart": "",
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "Overview / Golden Signals",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "panels": []
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Availability (up)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "count(up{job=~\"$job\",instance=~\"$instance\"} == 1) or vector(0)",
+          "refId": "A",
+          "legendFormat": "UP"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "count(up{job=~\"$job\",instance=~\"$instance\"} == 0) or vector(0)",
+          "refId": "B",
+          "legendFormat": "DOWN"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "none",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "DOWN"
+            },
+            "properties": [
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 1
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "textMode": "value_and_name",
+        "orientation": "horizontal"
+      },
+      "description": "Fleet availability counts over the selected $instance set: UP = scrape targets with up==1, DOWN = up==0. Sizes are independent of the number of instances (no per-instance tiles). DOWN>0 turns red. Per-instance detail is in the 'Per-instance overview' table below. Semantics unchanged: up==0 & business panels No data = process/scrape target unreachable (kernel_fd_health absent), NOT QPS=0; up==1 & QPS==0 = reachable but idle; up==1 & kernel_fd_health==0 = reachable but FUSE fd/session unhealthy."
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Kernel fd health",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 4,
+        "y": 1
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "count(curvine_fuse_kernel_fd_health{instance=~\"$instance\"} == 1) or vector(0)",
+          "refId": "A",
+          "legendFormat": "HEALTHY"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "count(curvine_fuse_kernel_fd_health{instance=~\"$instance\"} == 0) or vector(0)",
+          "refId": "B",
+          "legendFormat": "UNHEALTHY"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "none",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "UNHEALTHY"
+            },
+            "properties": [
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 1
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "textMode": "value_and_name",
+        "orientation": "horizontal"
+      },
+      "description": "Fleet FUSE-fd health counts over reachable instances: HEALTHY = kernel_fd_health==1, UNHEALTHY = kernel_fd_health==0 (process reachable but FUSE fd/session unhealthy). UNHEALTHY>0 turns red. NOTE: a down process (up==0) exports no kernel_fd_health, so it appears in NEITHER count — read this together with the Availability DOWN count. Sizes are independent of instance count; per-instance detail is in the 'Per-instance overview' table."
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Total QPS",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 8,
+        "y": 1
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(curvine_fuse_requests_total{instance=~\"$instance\"}[$__rate_interval])) or vector(0)",
+          "refId": "A",
+          "legendFormat": "qps"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "orientation": "auto"
+      },
+      "description": "Zero-filled: a freshly started process with no requests shows 0 (idle), not No data."
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "Request non-success ratio",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "(sum(rate(curvine_fuse_requests_total{instance=~\"$instance\",status!=\"success\"}[$__rate_interval])) or vector(0)) / clamp_min(sum(rate(curvine_fuse_requests_total{instance=~\"$instance\"}[$__rate_interval])) or vector(0),1e-9)",
+          "refId": "A",
+          "legendFormat": "ratio"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1e-07
+              },
+              {
+                "color": "red",
+                "value": 0.05
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "orientation": "auto"
+      },
+      "description": "User-visible final failure SLI. status!=success over all requests. Both numerator and denominator zero-filled so all-success AND freshly-started (no requests) show 0, not No data."
+    },
+    {
+      "id": 6,
+      "type": "stat",
+      "title": "Recent shutdowns by reason",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by(reason)(increase(curvine_fuse_session_shutdown_total{instance=~\"$instance\"}[$__range]))",
+          "refId": "A",
+          "legendFormat": "{{reason}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "orientation": "auto"
+      },
+      "description": "increase over range. reason=completed|run_all_error|run_all_panic|term_signal|fd_watcher. No data means no shutdowns in the selected range (expected in a healthy running cluster)."
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "QPS by kind",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 7
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by(kind)(rate(curvine_fuse_requests_total{instance=~\"$instance\"}[$__rate_interval]))",
+          "refId": "A",
+          "legendFormat": "{{kind}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "description": "No grouped zero-fill (a bare vector(0) would add an unlabeled 0 line). Idle/no-traffic shows No data here; Total QPS carries the idle=0 signal."
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "Request latency by kind (\u00b5s)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 7
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by(le,kind)(rate(curvine_fuse_request_duration_us_bucket{instance=~\"$instance\"}[$__rate_interval])))",
+          "refId": "A",
+          "legendFormat": "p50 {{kind}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum by(le,kind)(rate(curvine_fuse_request_duration_us_bucket{instance=~\"$instance\"}[$__rate_interval])))",
+          "refId": "B",
+          "legendFormat": "p95 {{kind}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by(le,kind)(rate(curvine_fuse_request_duration_us_bucket{instance=~\"$instance\"}[$__rate_interval])))",
+          "refId": "C",
+          "legendFormat": "p99 {{kind}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "unit": "\u00b5s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 9,
+      "type": "stat",
+      "title": "Error totals over range (0 = none)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 7
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(increase(curvine_fuse_errors_total{instance=~\"$instance\"}[$__range])) or vector(0)",
+          "refId": "A",
+          "legendFormat": "FS errno"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(increase(curvine_fuse_response_write_errors_total{instance=~\"$instance\"}[$__range])) or vector(0)",
+          "refId": "B",
+          "legendFormat": "delivery write"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(increase(curvine_fuse_reply_enqueue_errors_total{instance=~\"$instance\"}[$__range])) or vector(0)",
+          "refId": "C",
+          "legendFormat": "reply enqueue"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(increase(curvine_fuse_unsupported_total{instance=~\"$instance\"}[$__range])) or vector(0)",
+          "refId": "D",
+          "legendFormat": "unsupported"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 100
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "orientation": "auto"
+      },
+      "description": "Zero-filled totals for the 4 error classes so 0 shows as 0 (not No data), green; >0 yellow/red. Detailed by-label top-N: FS errno here in Overview; Unsupported in the Framework row; delivery/enqueue in the Reply row."
+    },
+    {
+      "id": 10,
+      "type": "table",
+      "title": "Top opcode p99 (\u00b5s) \u2014 with traffic",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "topk(15, histogram_quantile(0.99, sum by(le,opcode)(rate(curvine_fuse_request_duration_us_bucket{instance=~\"$instance\"}[$__rate_interval]))))",
+          "refId": "A",
+          "legendFormat": "",
+          "format": "table",
+          "instant": true,
+          "range": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by(opcode)(rate(curvine_fuse_requests_total{instance=~\"$instance\"}[$__rate_interval]))",
+          "refId": "B",
+          "legendFormat": "",
+          "format": "table",
+          "instant": true,
+          "range": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by(opcode)(increase(curvine_fuse_requests_total{instance=~\"$instance\",status!=\"success\"}[$__range])) or on(opcode) 0 * sum by(opcode)(increase(curvine_fuse_requests_total{instance=~\"$instance\"}[$__range]))",
+          "refId": "C",
+          "legendFormat": "",
+          "format": "table",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false
+        }
+      },
+      "description": "Low-QPS ops can top p99 on a single slow request. Read p99 with QPS/count; low sample p99 is a hint not an SLA. non-success zero-filled per opcode so all-success shows 0. Next step: set $opcode to drill down.",
+      "transformations": [
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "opcode",
+            "mode": "inner"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "renameByName": {
+              "Value #A": "p99 (\u00b5s)",
+              "Value #B": "QPS",
+              "Value #C": "non-success (range)"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": [],
+            "sort": [
+              {
+                "field": "p99 (\u00b5s)",
+                "desc": true
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "errno top-N (FS operation, uppercase)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 14
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "topk(5, sum by(errno)(rate(curvine_fuse_errors_total{instance=~\"$instance\"}[$__rate_interval])))",
+          "refId": "A",
+          "legendFormat": "{{errno}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "description": "curvine_fuse_errors_total \u2014 FS operation layer, uppercase POSIX errno. No data means no events in selected range. (Unsupported top-N and delivery-failure breakdowns are in the Framework and Reply rows to keep the first screen lean.)"
+    },
+    {
+      "id": 12,
+      "type": "row",
+      "title": "Bottleneck Locator",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 22
+      },
+      "panels": []
+    },
+    {
+      "id": 13,
+      "type": "timeseries",
+      "title": "Stage p99 by stage/kind/status (\u00b5s)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 23
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by(le,stage,kind,status)(rate(curvine_fuse_stage_duration_us_bucket{instance=~\"$instance\"}[$__rate_interval])))",
+          "refId": "A",
+          "legendFormat": "{{stage}}/{{kind}}/{{status}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "unit": "\u00b5s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "description": "stage=reply_write|meta_spawn|operation|stream_io. status kept so error/interrupted/unsupported are not blended. stage_duration_us has NO opcode label (global/by-kind, not per-op). Histograms are completion-based and can lag for stuck in-flight work; use inflight/queue gauges as leading signals under async/backpressure scenarios."
+    },
+    {
+      "id": 14,
+      "type": "timeseries",
+      "title": "Stage sample rate by stage/kind/status",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 23
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by(stage,kind,status)(rate(curvine_fuse_stage_duration_us_count{instance=~\"$instance\"}[$__rate_interval]))",
+          "refId": "A",
+          "legendFormat": "{{stage}}/{{kind}}/{{status}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "description": "Confirms a stage has samples; a high p99 with zero samples is not a bottleneck."
+    },
+    {
+      "id": 15,
+      "type": "table",
+      "title": "Stage non-success samples (range) \u2014 slow AND failing",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 31
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by(stage,kind,status)(increase(curvine_fuse_stage_duration_us_count{instance=~\"$instance\",status!=\"success\"}[$__range]))",
+          "refId": "A",
+          "legendFormat": "",
+          "format": "table",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false
+        }
+      },
+      "description": "STAGE sample non-success count (stage_duration_us_count{status!=success}), NOT request count \u2014 stage_duration_us is a stage view, has no opcode, and not every request emits every stage. For request-level failure see Overview non-success ratio / Metadata non-success. No data means no non-success stage samples in range.",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "renameByName": {
+              "Value": "non-success samples (range)"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": 16,
+      "type": "timeseries",
+      "title": "Saturation: reply_queue_depth",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 0,
+        "y": 37
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by(instance)(curvine_fuse_reply_queue_depth{instance=~\"$instance\"})",
+          "refId": "A",
+          "legendFormat": "{{instance}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 100
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 17,
+      "type": "timeseries",
+      "title": "Saturation: stream_write_queue_depth",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 6,
+        "y": 37
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by(instance)(curvine_fuse_stream_write_queue_depth{instance=~\"$instance\"})",
+          "refId": "A",
+          "legendFormat": "{{instance}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 100
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "description": "Writer-channel backlog: ALL WriteTasks (write/flush/complete/resize), not just FUSE_WRITE; resize can come from metadata paths."
+    },
+    {
+      "id": 18,
+      "type": "timeseries",
+      "title": "Saturation: meta_task_inflight",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 12,
+        "y": 37
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by(instance)(curvine_fuse_meta_task_inflight{instance=~\"$instance\"})",
+          "refId": "A",
+          "legendFormat": "{{instance}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 100
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 19,
+      "type": "timeseries",
+      "title": "Saturation: setlkw_inflight",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 18,
+        "y": 37
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by(instance)(curvine_fuse_setlkw_inflight{instance=~\"$instance\"})",
+          "refId": "A",
+          "legendFormat": "{{instance}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 100
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 20,
+      "type": "timeseries",
+      "title": "active_requests by kind",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 44
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by(instance,kind)(curvine_fuse_active_requests{instance=~\"$instance\"})",
+          "refId": "A",
+          "legendFormat": "{{instance}}/{{kind}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 100
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "description": "Leading signal: high active_requests with flat stage p99 = concurrency accumulation / downstream wait (histogram lag)."
+    },
+    {
+      "id": 21,
+      "type": "timeseries",
+      "title": "stream_io_inflight by io_type",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 44
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by(instance,io_type)(curvine_fuse_stream_io_inflight{instance=~\"$instance\"})",
+          "refId": "A",
+          "legendFormat": "{{instance}}/{{io_type}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 100
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 22,
+      "type": "timeseries",
+      "title": "stream_lifecycle_inflight by io_type",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 44
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by(instance,io_type)(curvine_fuse_stream_lifecycle_inflight{instance=~\"$instance\"})",
+          "refId": "A",
+          "legendFormat": "{{instance}}/{{io_type}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 100
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "description": "flush/fsync/release backlog."
+    },
+    {
+      "id": 23,
+      "type": "row",
+      "title": "Instance Overview",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 51
+      },
+      "panels": []
+    },
+    {
+      "id": 24,
+      "type": "table",
+      "title": "Per-instance overview",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 52
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "up{job=~\"$job\",instance=~\"$instance\"}",
+          "refId": "A",
+          "legendFormat": "",
+          "format": "table",
+          "instant": true,
+          "range": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "min by(instance)(curvine_fuse_kernel_fd_health{instance=~\"$instance\"})",
+          "refId": "B",
+          "legendFormat": "",
+          "format": "table",
+          "instant": true,
+          "range": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by(instance)(rate(curvine_fuse_requests_total{instance=~\"$instance\"}[$__rate_interval])) or on(instance) 0 * up{job=~\"$job\",instance=~\"$instance\"}",
+          "refId": "C",
+          "legendFormat": "",
+          "format": "table",
+          "instant": true,
+          "range": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by(le,instance)(rate(curvine_fuse_request_duration_us_bucket{instance=~\"$instance\"}[$__rate_interval])))",
+          "refId": "D",
+          "legendFormat": "",
+          "format": "table",
+          "instant": true,
+          "range": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "(sum by(instance)(rate(curvine_fuse_requests_total{instance=~\"$instance\",status!=\"success\"}[$__rate_interval])) or on(instance) 0 * up{job=~\"$job\",instance=~\"$instance\"}) / clamp_min(sum by(instance)(rate(curvine_fuse_requests_total{instance=~\"$instance\"}[$__rate_interval])) or on(instance) 0 * up{job=~\"$job\",instance=~\"$instance\"},1e-9)",
+          "refId": "E",
+          "legendFormat": "",
+          "format": "table",
+          "instant": true,
+          "range": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by(instance)(curvine_fuse_active_requests{instance=~\"$instance\"}) or on(instance) 0 * up{job=~\"$job\",instance=~\"$instance\"}",
+          "refId": "F",
+          "legendFormat": "",
+          "format": "table",
+          "instant": true,
+          "range": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by(instance)(curvine_fuse_reply_queue_depth{instance=~\"$instance\"})",
+          "refId": "G",
+          "legendFormat": "",
+          "format": "table",
+          "instant": true,
+          "range": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by(instance)(curvine_fuse_stream_write_queue_depth{instance=~\"$instance\"})",
+          "refId": "H",
+          "legendFormat": "",
+          "format": "table",
+          "instant": true,
+          "range": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by(instance)(curvine_fuse_meta_task_inflight{instance=~\"$instance\"})",
+          "refId": "I",
+          "legendFormat": "",
+          "format": "table",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "up"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "0": {
+                        "text": "DOWN",
+                        "color": "red",
+                        "index": 0
+                      },
+                      "1": {
+                        "text": "UP",
+                        "color": "green",
+                        "index": 1
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "fd_health"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "0": {
+                        "text": "UNHEALTHY",
+                        "color": "red",
+                        "index": 0
+                      },
+                      "1": {
+                        "text": "HEALTHY",
+                        "color": "green",
+                        "index": 1
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "non-success ratio"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percentunit"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 1e-07
+                    },
+                    {
+                      "color": "red",
+                      "value": 0.05
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "req p99 (\u00b5s)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "\u00b5s"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "QPS"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "reqps"
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false
+        }
+      },
+      "description": "All columns filtered by $instance. In All mode this localizes which instance is slow/down/backlogged. Click an instance then set $instance to drill down (data link is an optional enhancement).",
+      "transformations": [
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "instance",
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "renameByName": {
+              "Value #A": "up",
+              "Value #B": "fd_health",
+              "Value #C": "QPS",
+              "Value #D": "req p99 (\u00b5s)",
+              "Value #E": "non-success ratio",
+              "Value #F": "active_requests",
+              "Value #G": "reply_queue",
+              "Value #H": "write_queue",
+              "Value #I": "meta_inflight"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": 25,
+      "type": "row",
+      "title": "Operation drilldown ($opcode)",
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 60
+      },
+      "panels": [
+        {
+          "id": 26,
+          "type": "timeseries",
+          "title": "QPS ($opcode)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 0,
+            "y": 61
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum(rate(curvine_fuse_requests_total{instance=~\"$instance\",opcode=\"$opcode\"}[$__rate_interval])) or vector(0)",
+              "refId": "A",
+              "legendFormat": "qps"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "reqps"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "description": "Zero-filled so selecting an op with no traffic shows 0 (static $opcode is meant to allow no-traffic ops), not No data. $opcode covers 34 handled data/metadata/stream ops. Init/Interrupt -> Framework row Control requests; unsupported ops -> Framework Unsupported top-N."
+        },
+        {
+          "id": 27,
+          "type": "timeseries",
+          "title": "Latency ($opcode) (\u00b5s)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 8,
+            "y": 61
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "histogram_quantile(0.50, sum by(le)(rate(curvine_fuse_request_duration_us_bucket{instance=~\"$instance\",opcode=\"$opcode\"}[$__rate_interval])))",
+              "refId": "A",
+              "legendFormat": "p50"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "histogram_quantile(0.95, sum by(le)(rate(curvine_fuse_request_duration_us_bucket{instance=~\"$instance\",opcode=\"$opcode\"}[$__rate_interval])))",
+              "refId": "B",
+              "legendFormat": "p95"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "histogram_quantile(0.99, sum by(le)(rate(curvine_fuse_request_duration_us_bucket{instance=~\"$instance\",opcode=\"$opcode\"}[$__rate_interval])))",
+              "refId": "C",
+              "legendFormat": "p99"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "\u00b5s"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          }
+        },
+        {
+          "id": 28,
+          "type": "timeseries",
+          "title": "Count by status ($opcode)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 16,
+            "y": 61
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum by(status)(increase(curvine_fuse_requests_total{instance=~\"$instance\",opcode=\"$opcode\"}[$__range]))",
+              "refId": "A",
+              "legendFormat": "{{status}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "description": "Full status set (success/error/interrupted/unsupported), not just success/error."
+        },
+        {
+          "id": 29,
+          "type": "timeseries",
+          "title": "Operation dispatch p99 ($opcode, metadata) (\u00b5s)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 68
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "histogram_quantile(0.99, sum by(le)(rate(curvine_fuse_operation_duration_us_bucket{instance=~\"$instance\",opcode=\"$opcode\"}[$__rate_interval])))",
+              "refId": "A",
+              "legendFormat": "op p99"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "\u00b5s"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "description": "Metadata dispatch scope. Navigation: if $opcode is Read/Write -> Stream IO row (io_type=read|write); if Flush/Fsync/Release -> lifecycle. stage_duration_us cannot be filtered by opcode."
+        },
+        {
+          "id": 30,
+          "type": "timeseries",
+          "title": "Reply write errors ($opcode)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 68
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum by(errno)(rate(curvine_fuse_response_write_errors_total{instance=~\"$instance\",opcode=\"$opcode\"}[$__rate_interval]))",
+              "refId": "A",
+              "legendFormat": "{{errno}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "description": "No data means no response write errors for the selected opcode in range."
+        }
+      ]
+    },
+    {
+      "id": 31,
+      "type": "row",
+      "title": "Reply / Delivery pipeline",
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 75
+      },
+      "panels": [
+        {
+          "id": 32,
+          "type": "timeseries",
+          "title": "Kernel write latency p99 (\u00b5s)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 76
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "histogram_quantile(0.99, sum by(le,opcode)(rate(curvine_fuse_response_write_duration_us_bucket{instance=~\"$instance\"}[$__rate_interval])))",
+              "refId": "A",
+              "legendFormat": "{{opcode}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "\u00b5s"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "description": "Kernel-fd write (splice) latency, observed on success and failure."
+        },
+        {
+          "id": 33,
+          "type": "timeseries",
+          "title": "Kernel write errors by errno",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 76
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum by(errno)(rate(curvine_fuse_response_write_errors_total{instance=~\"$instance\"}[$__rate_interval]))",
+              "refId": "A",
+              "legendFormat": "{{errno}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "description": "Delivery failure in the sender (uppercase errno). No data means no events in selected range."
+        },
+        {
+          "id": 34,
+          "type": "timeseries",
+          "title": "Reply queue depth",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 0,
+            "y": 83
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum by(instance)(curvine_fuse_reply_queue_depth{instance=~\"$instance\"})",
+              "refId": "A",
+              "legendFormat": "{{instance}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "short",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 100
+                  }
+                ]
+              },
+              "color": {
+                "mode": "thresholds"
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "description": "High depth + reply_write rate not rising = sender not draining / downstream write stuck."
+        },
+        {
+          "id": 35,
+          "type": "timeseries",
+          "title": "Reply enqueue failures by reason",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 8,
+            "y": 83
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum by(reason)(rate(curvine_fuse_reply_enqueue_errors_total{instance=~\"$instance\"}[$__rate_interval]))",
+              "refId": "A",
+              "legendFormat": "{{reason}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "description": "Reply-channel enqueue failed; the request never reached the sender. No data means no events in selected range."
+        },
+        {
+          "id": 36,
+          "type": "timeseries",
+          "title": "Response throughput / avg reply size",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 16,
+            "y": 83
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum(rate(curvine_fuse_response_bytes_total{instance=~\"$instance\"}[$__rate_interval]))",
+              "refId": "A",
+              "legendFormat": "throughput B/s"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum(rate(curvine_fuse_response_bytes_total{instance=~\"$instance\"}[$__rate_interval])) / clamp_min(sum(rate(curvine_fuse_response_write_duration_us_count{instance=~\"$instance\"}[$__rate_interval])),1e-9)",
+              "refId": "B",
+              "legendFormat": "avg reply size B"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "Bps"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byFrameRefID",
+                  "options": "B"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "bytes"
+                  }
+                ]
+              }
+            ]
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "description": "Throughput in B/s; avg reply size (B) series overridden to bytes. Avg reply size denominator uses response_write_duration_us_count (actual sender writes), NOT requests_total (which includes no-reply/enqueue failures)."
+        }
+      ]
+    },
+    {
+      "id": 37,
+      "type": "row",
+      "title": "Framework / Receiver / Notify",
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 90
+      },
+      "panels": [
+        {
+          "id": 38,
+          "type": "timeseries",
+          "title": "Receiver loop wait incl. idle (NOT request latency) (\u00b5s)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 91
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "histogram_quantile(0.99, sum by(le)(rate(curvine_fuse_receive_loop_wait_duration_us_bucket{instance=~\"$instance\"}[$__rate_interval])))",
+              "refId": "A",
+              "legendFormat": "p99"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "\u00b5s"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "description": "splice + header parse INCLUDING idle wait. Under low traffic a high p99 is normal idle, not slow requests."
+        },
+        {
+          "id": 39,
+          "type": "timeseries",
+          "title": "Control requests (Init/Interrupt)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 91
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum by(opcode)(rate(curvine_fuse_requests_total{instance=~\"$instance\",opcode=~\"Init|Interrupt\"}[$__rate_interval]))",
+              "refId": "A",
+              "legendFormat": "{{opcode}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "reqps"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "description": "Init/Interrupt are handled control ops (in requests_total), excluded from $opcode drilldown. interrupted_total{opcode} counts the interrupted SetLkW, not FUSE_INTERRUPT."
+        },
+        {
+          "id": 40,
+          "type": "timeseries",
+          "title": "Kernel notify rate by code/status",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 98
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum by(code,status)(rate(curvine_fuse_notify_total{instance=~\"$instance\"}[$__rate_interval]))",
+              "refId": "A",
+              "legendFormat": "{{code}}/{{status}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "description": "status=success|enqueue_failed|write_failed. Notify failures affect kernel invalidation."
+        },
+        {
+          "id": 41,
+          "type": "timeseries",
+          "title": "Notify failures",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 98
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum by(code,status)(rate(curvine_fuse_notify_total{instance=~\"$instance\",status!=\"success\"}[$__rate_interval]))",
+              "refId": "A",
+              "legendFormat": "{{code}}/{{status}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "description": "No data means no notify failures in selected range."
+        },
+        {
+          "id": 42,
+          "type": "timeseries",
+          "title": "Stage p99 by stage/kind (framework overview) (\u00b5s)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 105
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "histogram_quantile(0.99, sum by(le,stage,kind,status)(rate(curvine_fuse_stage_duration_us_bucket{instance=~\"$instance\"}[$__rate_interval])))",
+              "refId": "A",
+              "legendFormat": "{{stage}}/{{kind}}/{{status}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "\u00b5s"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "description": "Framework horizontal overview. response_write/operation/io *_duration_us are the per-domain drilldowns (labels closer to domain). Two views of a stage are overview-vs-detail; do NOT subtract different metrics to localize latency."
+        },
+        {
+          "id": 43,
+          "type": "timeseries",
+          "title": "receive_errors_total by errno/action (lowercase errno)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 105
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum by(errno,action)(rate(curvine_fuse_receive_errors_total{instance=~\"$instance\"}[$__rate_interval]))",
+              "refId": "A",
+              "legendFormat": "{{errno}}/{{action}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "description": "Splice/receive errors before decode. errno is LOWERCASE (enoent/eintr/eagain/enodev/other) \u2014 distinct from errors_total uppercase. action=continue|exit. No data means no events in selected range."
+        },
+        {
+          "id": 44,
+          "type": "timeseries",
+          "title": "Unsupported top-N by opcode/reason",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 112
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "topk(10, sum by(opcode,reason)(rate(curvine_fuse_unsupported_total{instance=~\"$instance\"}[$__rate_interval])))",
+              "refId": "A",
+              "legendFormat": "{{opcode}}/{{reason}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "description": "Only observation point for Ioctl/Lseek/Rename2/FsyncDir/... (kernel ops with no dispatch arm, excluded from $opcode drilldown). reason=unknown_opcode|unimplemented_opcode. No data means no events in selected range."
+        },
+        {
+          "id": 45,
+          "type": "stat",
+          "title": "decode_errors_total (phase=decode is TERMINAL)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 12,
+            "y": 112
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum by(phase,reason)(increase(curvine_fuse_decode_errors_total{instance=~\"$instance\"}[$__range]))",
+              "refId": "A",
+              "legendFormat": "{{phase}}/{{reason}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "unit": "short",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              },
+              "color": {
+                "mode": "thresholds"
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "textMode": "auto",
+            "orientation": "auto"
+          },
+          "description": "phase=parse is recurring/recoverable; phase=decode is TERMINAL (receiver died -> restart signal), not a rate to threshold."
+        },
+        {
+          "id": 46,
+          "type": "timeseries",
+          "title": "meta_task_inflight",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 0,
+            "y": 119
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum by(instance)(curvine_fuse_meta_task_inflight{instance=~\"$instance\"})",
+              "refId": "A",
+              "legendFormat": "{{instance}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "short",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 100
+                  }
+                ]
+              },
+              "color": {
+                "mode": "thresholds"
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          }
+        },
+        {
+          "id": 47,
+          "type": "timeseries",
+          "title": "Metrics scrape self-observation",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 8,
+            "y": 119
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "histogram_quantile(0.99, sum by(le)(rate(curvine_fuse_metrics_scrape_duration_us_bucket{instance=~\"$instance\"}[$__rate_interval])))",
+              "refId": "A",
+              "legendFormat": "scrape p99 \u00b5s"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "max by(instance)(curvine_fuse_metrics_scrape_bytes{instance=~\"$instance\"})",
+              "refId": "B",
+              "legendFormat": "scrape bytes {{instance}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "\u00b5s"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byFrameRefID",
+                  "options": "B"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "bytes"
+                  }
+                ]
+              }
+            ]
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "description": "Last-scrape self-observation. scrape_bytes is last-scrape semantics, not used for instance enumeration. p99 in \u00b5s, bytes series overridden to bytes."
+        }
+      ]
+    },
+    {
+      "id": 48,
+      "type": "row",
+      "title": "Metadata & SETLKW",
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 126
+      },
+      "panels": [
+        {
+          "id": 49,
+          "type": "stat",
+          "title": "Metadata request non-success ratio",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 0,
+            "y": 127
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "(sum(rate(curvine_fuse_requests_total{instance=~\"$instance\",kind=\"metadata\",status!=\"success\"}[$__rate_interval])) or vector(0)) / clamp_min(sum(rate(curvine_fuse_requests_total{instance=~\"$instance\",kind=\"metadata\"}[$__rate_interval])) or vector(0),1e-9)",
+              "refId": "A",
+              "legendFormat": "ratio"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "unit": "percentunit",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 1e-07
+                  },
+                  {
+                    "color": "red",
+                    "value": 0.05
+                  }
+                ]
+              },
+              "color": {
+                "mode": "thresholds"
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "textMode": "auto",
+            "orientation": "auto"
+          },
+          "description": "User-visible metadata failure (authoritative). requests_total{kind=metadata}. Numerator and denominator both zero-filled so no-metadata-traffic (e.g. stream-only or freshly started) shows 0, not No data."
+        },
+        {
+          "id": 50,
+          "type": "timeseries",
+          "title": "Metadata dispatch duration (\u00b5s)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 16,
+            "x": 8,
+            "y": 127
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "histogram_quantile(0.99, sum by(le,opcode)(rate(curvine_fuse_operation_duration_us_bucket{instance=~\"$instance\",kind=\"metadata\"}[$__rate_interval])))",
+              "refId": "A",
+              "legendFormat": "{{opcode}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "\u00b5s"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "description": "operation_duration_us = metadata dispatch scope (incl reply enqueue, interrupted SETLKW excluded). NOT end-to-end; non-success -> use the request ratio panel. Do not subtract vs request_duration."
+        },
+        {
+          "id": 51,
+          "type": "table",
+          "title": "Metadata op hotspots",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 134
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum by(opcode)(rate(curvine_fuse_requests_total{instance=~\"$instance\",kind=\"metadata\"}[$__rate_interval]))",
+              "refId": "A",
+              "legendFormat": "",
+              "format": "table",
+              "instant": true,
+              "range": false
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "histogram_quantile(0.99, sum by(le,opcode)(rate(curvine_fuse_request_duration_us_bucket{instance=~\"$instance\",kind=\"metadata\"}[$__rate_interval])))",
+              "refId": "B",
+              "legendFormat": "",
+              "format": "table",
+              "instant": true,
+              "range": false
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "histogram_quantile(0.99, sum by(le,opcode)(rate(curvine_fuse_operation_duration_us_bucket{instance=~\"$instance\",kind=\"metadata\"}[$__rate_interval])))",
+              "refId": "C",
+              "legendFormat": "",
+              "format": "table",
+              "instant": true,
+              "range": false
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum by(opcode)(increase(curvine_fuse_requests_total{instance=~\"$instance\",kind=\"metadata\",status!=\"success\"}[$__range])) or on(opcode) 0 * sum by(opcode)(increase(curvine_fuse_requests_total{instance=~\"$instance\",kind=\"metadata\"}[$__range]))",
+              "refId": "D",
+              "legendFormat": "",
+              "format": "table",
+              "instant": true,
+              "range": false
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "options": {
+            "showHeader": true,
+            "cellHeight": "sm",
+            "footer": {
+              "show": false
+            }
+          },
+          "description": "Which metadata op is hot/slow. non-success zero-filled per opcode. Pair with Cache & readdir row for Lookup/GetAttr/ReadDir hotspots. Set $opcode to drill down.",
+          "transformations": [
+            {
+              "id": "joinByField",
+              "options": {
+                "byField": "opcode",
+                "mode": "outer"
+              }
+            },
+            {
+              "id": "organize",
+              "options": {
+                "renameByName": {
+                  "Value #A": "QPS",
+                  "Value #B": "req p99 (\u00b5s)",
+                  "Value #C": "op p99 (\u00b5s)",
+                  "Value #D": "non-success (range)"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": 52,
+          "type": "timeseries",
+          "title": "Metadata errno top-N",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 134
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "topk(10, sum by(opcode,errno)(rate(curvine_fuse_errors_total{instance=~\"$instance\",kind=\"metadata\"}[$__rate_interval])))",
+              "refId": "A",
+              "legendFormat": "{{opcode}}/{{errno}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "description": "No data means no events in selected range."
+        },
+        {
+          "id": 53,
+          "type": "timeseries",
+          "title": "SETLKW wait p99 (\u00b5s)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 142
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "histogram_quantile(0.99, sum by(le)(rate(curvine_fuse_setlkw_wait_duration_us_bucket{instance=~\"$instance\"}[$__rate_interval])))",
+              "refId": "A",
+              "legendFormat": "setlkw wait p99"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "\u00b5s"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "description": "setlkw_wait includes reply backpressure, not pure lock wait."
+        },
+        {
+          "id": 54,
+          "type": "timeseries",
+          "title": "SETLKW inflight / interrupted rate",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 142
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum by(instance)(curvine_fuse_setlkw_inflight{instance=~\"$instance\"})",
+              "refId": "A",
+              "legendFormat": "setlkw_inflight {{instance}}"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum by(opcode)(rate(curvine_fuse_interrupted_total{instance=~\"$instance\"}[$__rate_interval]))",
+              "refId": "B",
+              "legendFormat": "interrupted {{opcode}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "short",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 100
+                  }
+                ]
+              },
+              "color": {
+                "mode": "thresholds"
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "description": "setlkw_inflight is a saturation gauge; interrupted_total{opcode} = interrupted SetLkW (not FUSE_INTERRUPT count)."
+        }
+      ]
+    },
+    {
+      "id": 55,
+      "type": "row",
+      "title": "Stream IO / Lifecycle",
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 149
+      },
+      "panels": [
+        {
+          "id": 56,
+          "type": "timeseries",
+          "title": "IO latency p99 (\u00b5s)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 150
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "histogram_quantile(0.99, sum by(le,io_type,path_type,status)(rate(curvine_fuse_io_duration_us_bucket{instance=~\"$instance\",io_type=~\"$io_type\",path_type=~\"$path_type\"}[$__rate_interval])))",
+              "refId": "A",
+              "legendFormat": "{{io_type}}/{{path_type}}/{{status}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "\u00b5s"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "description": "path_type=fallback = fallback-capable handle, NOT a read that actually fell back to UFS. Do not treat fallback latency/bytes as real UFS-fallback IO."
+        },
+        {
+          "id": 57,
+          "type": "timeseries",
+          "title": "IO throughput (success bytes)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 150
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum by(io_type,path_type)(rate(curvine_fuse_io_bytes_total{instance=~\"$instance\",io_type=~\"$io_type\",path_type=~\"$path_type\",status=\"success\"}[$__rate_interval]))",
+              "refId": "A",
+              "legendFormat": "{{io_type}}/{{path_type}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "Bps"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          }
+        },
+        {
+          "id": 58,
+          "type": "timeseries",
+          "title": "IO error rate (io_requests status=error)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 0,
+            "y": 157
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum by(io_type,path_type)(rate(curvine_fuse_io_requests_total{instance=~\"$instance\",io_type=~\"$io_type\",path_type=~\"$path_type\",status=\"error\"}[$__rate_interval])) or on(io_type,path_type) 0 * sum by(io_type,path_type)(rate(curvine_fuse_io_requests_total{instance=~\"$instance\",io_type=~\"$io_type\",path_type=~\"$path_type\"}[$__rate_interval]))",
+              "refId": "A",
+              "legendFormat": "{{io_type}}/{{path_type}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "description": "Errors from io_requests_total{status=error}, not inferred from bytes. Zero-filled per (io_type,path_type) so a success-only path shows 0, not blank."
+        },
+        {
+          "id": 59,
+          "type": "timeseries",
+          "title": "IO size p95 (bytes)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 8,
+            "y": 157
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "histogram_quantile(0.95, sum by(le,io_type,path_type)(rate(curvine_fuse_io_size_bytes_bucket{instance=~\"$instance\",io_type=~\"$io_type\",path_type=~\"$path_type\"}[$__rate_interval])))",
+              "refId": "A",
+              "legendFormat": "{{io_type}}/{{path_type}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "description": "Filtered by $io_type and $path_type (io_size_bytes has both labels), consistent with the rest of Row 5."
+        },
+        {
+          "id": 60,
+          "type": "timeseries",
+          "title": "IO dispatch p99 & stream_io_inflight (by io_type)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 16,
+            "y": 157
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "histogram_quantile(0.99, sum by(le,io_type)(rate(curvine_fuse_io_dispatch_duration_us_bucket{instance=~\"$instance\",io_type=~\"$io_type\"}[$__rate_interval])))",
+              "refId": "A",
+              "legendFormat": "dispatch p99 {{io_type}}"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum by(instance,io_type)(curvine_fuse_stream_io_inflight{instance=~\"$instance\",io_type=~\"$io_type\"})",
+              "refId": "B",
+              "legendFormat": "inflight {{instance}}/{{io_type}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "\u00b5s"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byFrameRefID",
+                  "options": "B"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "short"
+                  }
+                ]
+              }
+            ]
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "description": "Companion to the comparison table for the two io_type-only metrics (no path_type). Dispatch (incl worker dispatch), not pure enqueue; io_type=read|write. dispatch p99 in \u00b5s, inflight series overridden to short."
+        },
+        {
+          "id": 61,
+          "type": "table",
+          "title": "read/write comparison (by io_type/path_type)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 164
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum by(io_type,path_type)(rate(curvine_fuse_io_requests_total{instance=~\"$instance\",io_type=~\"$io_type\",path_type=~\"$path_type\"}[$__rate_interval]))",
+              "refId": "A",
+              "legendFormat": "",
+              "format": "table",
+              "instant": true,
+              "range": false
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum by(io_type,path_type)(rate(curvine_fuse_io_bytes_total{instance=~\"$instance\",io_type=~\"$io_type\",path_type=~\"$path_type\",status=\"success\"}[$__rate_interval]))",
+              "refId": "B",
+              "legendFormat": "",
+              "format": "table",
+              "instant": true,
+              "range": false
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "histogram_quantile(0.99, sum by(le,io_type,path_type)(rate(curvine_fuse_io_duration_us_bucket{instance=~\"$instance\",io_type=~\"$io_type\",path_type=~\"$path_type\"}[$__rate_interval])))",
+              "refId": "C",
+              "legendFormat": "",
+              "format": "table",
+              "instant": true,
+              "range": false
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum by(io_type,path_type)(rate(curvine_fuse_io_requests_total{instance=~\"$instance\",io_type=~\"$io_type\",path_type=~\"$path_type\",status=\"error\"}[$__rate_interval])) or on(io_type,path_type) 0 * sum by(io_type,path_type)(rate(curvine_fuse_io_requests_total{instance=~\"$instance\",io_type=~\"$io_type\",path_type=~\"$path_type\"}[$__rate_interval]))",
+              "refId": "D",
+              "legendFormat": "",
+              "format": "table",
+              "instant": true,
+              "range": false
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "QPS"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "reqps"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "throughput (B/s)"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "Bps"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "backend p99 (\u00b5s)"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "\u00b5s"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "error rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "reqps"
+                  }
+                ]
+              }
+            ]
+          },
+          "options": {
+            "showHeader": true,
+            "cellHeight": "sm",
+            "footer": {
+              "show": false
+            }
+          },
+          "description": "One row per (io_type,path_type) via merge transform: QPS / throughput (Bps, auto-scales to MB/s) / backend p99 / error rate. Dispatch p99 & inflight are io_type-only -> companion panel to the left. fallback = capable handle, not real UFS-fallback.",
+          "transformations": [
+            {
+              "id": "merge",
+              "options": {}
+            },
+            {
+              "id": "organize",
+              "options": {
+                "renameByName": {
+                  "Value #A": "QPS",
+                  "Value #B": "throughput (B/s)",
+                  "Value #C": "backend p99 (\u00b5s)",
+                  "Value #D": "error rate"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": 62,
+          "type": "timeseries",
+          "title": "Stream lifecycle duration p99 (\u00b5s)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 164
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "histogram_quantile(0.99, sum by(le,io_type,path_type)(rate(curvine_fuse_stream_lifecycle_duration_us_bucket{instance=~\"$instance\",io_type=~\"$lifecycle_io_type\"}[$__rate_interval])))",
+              "refId": "A",
+              "legendFormat": "{{io_type}}/{{path_type}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "\u00b5s"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "description": "flush/fsync/release. Uses $lifecycle_io_type (NOT $io_type). No status label -> no lifecycle error rate (result mixes backend + reply-enqueue errors)."
+        },
+        {
+          "id": 63,
+          "type": "timeseries",
+          "title": "Stream lifecycle attempts / inflight",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 172
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum by(io_type,path_type)(rate(curvine_fuse_stream_lifecycle_requests_total{instance=~\"$instance\",io_type=~\"$lifecycle_io_type\"}[$__rate_interval]))",
+              "refId": "A",
+              "legendFormat": "attempts {{io_type}}/{{path_type}}"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum by(instance,io_type)(curvine_fuse_stream_lifecycle_inflight{instance=~\"$instance\",io_type=~\"$lifecycle_io_type\"})",
+              "refId": "B",
+              "legendFormat": "inflight {{instance}}/{{io_type}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "description": "requests_total has no status (attempts only). inflight has io_type but NO path_type."
+        },
+        {
+          "id": 64,
+          "type": "timeseries",
+          "title": "stream_write_queue_depth",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 172
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum by(instance)(curvine_fuse_stream_write_queue_depth{instance=~\"$instance\"})",
+              "refId": "A",
+              "legendFormat": "{{instance}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "short",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 100
+                  }
+                ]
+              },
+              "color": {
+                "mode": "thresholds"
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": 65,
+      "type": "row",
+      "title": "Cache & readdir",
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 179
+      },
+      "panels": [
+        {
+          "id": 66,
+          "type": "timeseries",
+          "title": "user_meta_cache hit rate by cache",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 180
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "(sum by(cache)(rate(curvine_fuse_user_meta_cache_total{instance=~\"$instance\",status=\"hit\"}[$__rate_interval])) or on(cache) 0 * sum by(cache)(rate(curvine_fuse_user_meta_cache_total{instance=~\"$instance\",status=~\"hit|miss\"}[$__rate_interval]))) / clamp_min(sum by(cache)(rate(curvine_fuse_user_meta_cache_total{instance=~\"$instance\",status=~\"hit|miss\"}[$__rate_interval])),1e-9)",
+              "refId": "A",
+              "legendFormat": "{{cache}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "description": "Denominator excludes put (hit|miss only). Zero-filled per cache with 'or on(cache) 0*denom' so all-miss shows 0%, not No data. cache=status|list|blocks."
+        },
+        {
+          "id": 67,
+          "type": "timeseries",
+          "title": "node_cache hit rate by operation",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 180
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "(sum by(operation)(rate(curvine_fuse_node_cache_total{instance=~\"$instance\",status=\"hit\"}[$__rate_interval])) or on(operation) 0 * sum by(operation)(rate(curvine_fuse_node_cache_total{instance=~\"$instance\",status=~\"hit|miss\"}[$__rate_interval]))) / clamp_min(sum by(operation)(rate(curvine_fuse_node_cache_total{instance=~\"$instance\",status=~\"hit|miss\"}[$__rate_interval])),1e-9)",
+              "refId": "A",
+              "legendFormat": "{{operation}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "description": "operation=lookup. Same zero-fill pattern."
+        },
+        {
+          "id": 68,
+          "type": "timeseries",
+          "title": "user_meta_cache put rate",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 0,
+            "y": 187
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum by(cache)(rate(curvine_fuse_user_meta_cache_total{instance=~\"$instance\",status=\"put\"}[$__rate_interval]))",
+              "refId": "A",
+              "legendFormat": "{{cache}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          }
+        },
+        {
+          "id": 69,
+          "type": "timeseries",
+          "title": "Cache invalidations top-N by cache/reason",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 8,
+            "y": 187
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "topk(10, sum by(cache,reason)(rate(curvine_fuse_user_meta_cache_invalidations_total{instance=~\"$instance\"}[$__rate_interval])))",
+              "refId": "A",
+              "legendFormat": "{{cache}}/{{reason}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "description": "No data means no invalidations in selected range."
+        },
+        {
+          "id": 70,
+          "type": "timeseries",
+          "title": "Negative entry vs Lookup ENOENT",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 16,
+            "y": 187
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum(rate(curvine_fuse_negative_entry_returned_total{instance=~\"$instance\"}[$__rate_interval]))",
+              "refId": "A",
+              "legendFormat": "negative_entry"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum(rate(curvine_fuse_errors_total{instance=~\"$instance\",opcode=\"Lookup\",errno=\"ENOENT\"}[$__rate_interval]))",
+              "refId": "B",
+              "legendFormat": "Lookup ENOENT"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "description": "errno is on errors_total (uppercase ENOENT), NOT requests_total."
+        },
+        {
+          "id": 71,
+          "type": "timeseries",
+          "title": "readdir duration p95 by status (\u00b5s)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 194
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "histogram_quantile(0.95, sum by(le,status)(rate(curvine_fuse_readdir_duration_us_bucket{instance=~\"$instance\"}[$__rate_interval])))",
+              "refId": "A",
+              "legendFormat": "{{status}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "\u00b5s"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          }
+        },
+        {
+          "id": 72,
+          "type": "timeseries",
+          "title": "readdir entries distribution (success only)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 194
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "histogram_quantile(0.50, sum by(le)(rate(curvine_fuse_readdir_entries_bucket{instance=~\"$instance\",status=\"success\"}[$__rate_interval])))",
+              "refId": "A",
+              "legendFormat": "p50"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "histogram_quantile(0.95, sum by(le)(rate(curvine_fuse_readdir_entries_bucket{instance=~\"$instance\",status=\"success\"}[$__rate_interval])))",
+              "refId": "B",
+              "legendFormat": "p95"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "description": "Only success child is observed. Per-syscall batch size, not total dir size. Errors -> readdir_duration_us{status=error}."
+        }
+      ]
+    },
+    {
+      "id": 73,
+      "type": "row",
+      "title": "State & session",
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 201
+      },
+      "panels": [
+        {
+          "id": 74,
+          "type": "stat",
+          "title": "State persist/restore by status (range)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 0,
+            "y": 202
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum by(status)(increase(curvine_fuse_state_persist_total{instance=~\"$instance\"}[$__range]))",
+              "refId": "A",
+              "legendFormat": "persist {{status}}"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum by(status)(increase(curvine_fuse_state_restore_total{instance=~\"$instance\"}[$__range]))",
+              "refId": "B",
+              "legendFormat": "restore {{status}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "textMode": "auto",
+            "orientation": "auto"
+          },
+          "description": "Near-zero events: increase over range, not rate. No status-grouped zero-fill (it would inject a label-less 0 series); No data means no persist/restore events in the selected range."
+        },
+        {
+          "id": 75,
+          "type": "timeseries",
+          "title": "State persist stage p99 (\u00b5s)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 8,
+            "y": 202
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "histogram_quantile(0.99, sum by(le,stage,status)(rate(curvine_fuse_state_persist_stage_duration_us_bucket{instance=~\"$instance\"}[$__rate_interval])))",
+              "refId": "A",
+              "legendFormat": "{{stage}}/{{status}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "\u00b5s"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "description": "stage=node_map|file_handles|dir_handles|mount_fds. A missing stage means an earlier stage failed (magic/version header failure leaves only mount_fds)."
+        },
+        {
+          "id": 76,
+          "type": "timeseries",
+          "title": "State restore stage p99 (\u00b5s)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 16,
+            "y": 202
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "histogram_quantile(0.99, sum by(le,stage,status)(rate(curvine_fuse_state_restore_stage_duration_us_bucket{instance=~\"$instance\"}[$__rate_interval])))",
+              "refId": "A",
+              "legendFormat": "{{stage}}/{{status}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "\u00b5s"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          }
+        },
+        {
+          "id": 77,
+          "type": "timeseries",
+          "title": "state_persist_handle_count by kind",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 0,
+            "y": 209
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum by(instance,kind)(curvine_fuse_state_persist_handle_count{instance=~\"$instance\"})",
+              "refId": "A",
+              "legendFormat": "{{instance}}/{{kind}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "description": "Snapshot at persist time. kind=node_map|file_handles|dir_handles."
+        },
+        {
+          "id": 78,
+          "type": "stat",
+          "title": "Session init/shutdown (range)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 8,
+            "y": 209
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum by(result)(increase(curvine_fuse_session_init_total{instance=~\"$instance\"}[$__range]))",
+              "refId": "A",
+              "legendFormat": "init {{result}}"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum by(reason)(increase(curvine_fuse_session_shutdown_total{instance=~\"$instance\"}[$__range]))",
+              "refId": "B",
+              "legendFormat": "shutdown {{reason}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "textMode": "auto",
+            "orientation": "auto"
+          },
+          "description": "Low-freq lifecycle events, increase over range. No status-grouped zero-fill (would inject a label-less 0); No data means no init/shutdown events in the selected range."
+        },
+        {
+          "id": 79,
+          "type": "timeseries",
+          "title": "Namespaced gauges (per-instance, not summed across)",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 16,
+            "x": 0,
+            "y": 216
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "curvine_fuse_inode_count{instance=~\"$instance\"}",
+              "refId": "A",
+              "legendFormat": "inode {{instance}}"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "curvine_fuse_file_handle_count{instance=~\"$instance\"}",
+              "refId": "B",
+              "legendFormat": "file_handle {{instance}}"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "curvine_fuse_dir_handle_count{instance=~\"$instance\"}",
+              "refId": "C",
+              "legendFormat": "dir_handle {{instance}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "description": "Namespaced (not legacy *_num). Kept per-instance, not summed across instances."
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What

Adds a Grafana dashboard (plus README) for the `curvine-fuse` client, covering all `curvine_fuse_*` Prometheus metrics shipped by the fuse metrics work.

- `etc/grafana/curvine-fuse-dashboard.json` — 31 top-level panels across 9 rows.
- `etc/grafana/README.md` — import steps, template variables, reading guide, and a DevOps triage matrix.

**Pure JSON + docs — no Rust-side changes.** Importing it changes nothing on the client.

## Design

Organized as a **triage path**, not by metric family:

`Overview / Golden Signals` → `Bottleneck Locator` → `Per-instance overview` → domain drilldowns (Operation / Reply pipeline / Framework / Metadata & SETLKW / Stream IO / Cache & readdir / State & session).

Notable choices:
- **Three-state availability** (up==0 unreachable vs up==1&&QPS==0 idle vs up==1&&kernel_fd_health==0 unhealthy), documented so they are not conflated.
- **Fleet-count availability stats** — the Overview `Availability` and `Kernel fd health` stats show UP/DOWN and HEALTHY/UNHEALTHY as counts, so their size is independent of how many instances `$instance` selects (no per-instance tile explosion); per-instance detail lives in the Per-instance overview table.
- **Histograms are completion-based and lag** under backpressure — the README calls out the inflight/queue gauges as the leading signals.
- Zero-filled golden-signal ratios so "all healthy / freshly started" reads as `0`, not `No data`.

## Testing

- `jq` validates the dashboard JSON.
- Dashboard metric names / label values were cross-checked against the registered `curvine_fuse_*` metrics and the `opcode`/`kind`/`path_type`/`cache` label constants in the source.
- Imported into a live Grafana (v12.2.1) against a Prometheus scraping a running curvine-fuse; golden-signal queries verified to return expected values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)