### PR TITLE
fix(master): harden load jobs after auto-cache isolation (#984)

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -290,8 +290,8 @@ mkdir -p "$DIST_DIR"/lib
 mkdir -p "$DIST_DIR"/tests
 
 
-# Copy configuration files and bin
-cp "$FS_HOME"/etc/* "$DIST_DIR"/conf
+# Copy configuration files and directories.
+cp -R "$FS_HOME"/etc/. "$DIST_DIR"/conf/
 
 cp "$FS_HOME"/build/bin/* "$DIST_DIR"/bin
 chmod +x "$DIST_DIR"/bin/*

--- a/curvine-client/src/unified/unified_filesystem.rs
+++ b/curvine-client/src/unified/unified_filesystem.rs
@@ -30,16 +30,184 @@ use curvine_common::FsResult;
 use log::{debug, error, info, warn};
 use orpc::common::TimeSpent;
 use orpc::runtime::{RpcRuntime, Runtime};
+use orpc::sync::channel::{AsyncChannel, AsyncReceiver, AsyncSender};
 use orpc::{err_box, err_ext};
 use std::borrow::Cow;
+use std::collections::HashSet;
 use std::future::Future;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex as StdMutex};
+use std::time::Duration;
+use tokio::time;
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone)]
 enum CacheValidity {
     Valid,
     Invalid(Option<FileStatus>),
+}
+
+struct AsyncCacheSubmitter {
+    sender: AsyncSender<String>,
+    pending: Arc<StdMutex<HashSet<String>>>,
+}
+
+impl AsyncCacheSubmitter {
+    fn new(
+        fs_client: Arc<FsClient>,
+        rt: Arc<Runtime>,
+        conf: &ClusterConf,
+        metrics: &'static ClientMetrics,
+        audit_logging_enabled: bool,
+    ) -> Self {
+        let (sender, receiver) =
+            AsyncChannel::new(conf.client.auto_cache_submit_queue_size).split();
+        let pending = Arc::new(StdMutex::new(HashSet::new()));
+
+        Self::spawn_worker(
+            rt,
+            receiver,
+            fs_client,
+            pending.clone(),
+            AsyncCacheRetryPolicy {
+                max_retries: conf.client.auto_cache_submit_retry_max,
+                min_sleep: Duration::from_millis(conf.client.auto_cache_submit_retry_min_sleep_ms),
+                max_sleep: Duration::from_millis(conf.client.auto_cache_submit_retry_max_sleep_ms),
+            },
+            metrics,
+            audit_logging_enabled,
+        );
+
+        Self { sender, pending }
+    }
+
+    fn enqueue(&self, source_path: String) {
+        if !Self::insert_pending(&self.pending, source_path.clone()) {
+            debug!("async cache submit already queued for {}", source_path);
+            return;
+        }
+
+        match self.sender.try_reserve() {
+            Ok(Some(permit)) => permit.send(source_path),
+            Ok(None) => {
+                Self::remove_pending(&self.pending, &source_path);
+                warn!("async cache submit queue is full, drop {}", source_path);
+            }
+            Err(err) => {
+                Self::remove_pending(&self.pending, &source_path);
+                warn!(
+                    "async cache submit queue is closed for {}: {}",
+                    source_path, err
+                );
+            }
+        }
+    }
+
+    fn spawn_worker(
+        rt: Arc<Runtime>,
+        mut receiver: AsyncReceiver<String>,
+        fs_client: Arc<FsClient>,
+        pending: Arc<StdMutex<HashSet<String>>>,
+        retry_policy: AsyncCacheRetryPolicy,
+        metrics: &'static ClientMetrics,
+        audit_logging_enabled: bool,
+    ) {
+        rt.spawn(async move {
+            let client = JobMasterClient::new(fs_client);
+            while let Some(source_path) = receiver.recv().await {
+                Self::submit_with_retry(
+                    &client,
+                    source_path.clone(),
+                    retry_policy,
+                    metrics,
+                    audit_logging_enabled,
+                )
+                .await;
+                Self::remove_pending(&pending, &source_path);
+            }
+        });
+    }
+
+    async fn submit_with_retry(
+        client: &JobMasterClient,
+        source_path: String,
+        retry_policy: AsyncCacheRetryPolicy,
+        metrics: &'static ClientMetrics,
+        audit_logging_enabled: bool,
+    ) {
+        let mut retries = 0;
+        let mut sleep_time = retry_policy.min_sleep;
+
+        loop {
+            let time = TimeSpent::new();
+            let command = LoadJobCommand::builder(source_path.clone()).build();
+            let res = client.submit_load_job(command).await;
+            let used_us = time.used_us();
+
+            metrics
+                .metadata_operation_duration
+                .with_label_values(&["SubmitJob"])
+                .observe(used_us as f64);
+
+            match res {
+                Ok(res) => {
+                    if audit_logging_enabled {
+                        info!(
+                            target: "audit",
+                            "cmd={} ok={} src={} dst={} usedUs={}",
+                            "SubmitJob",
+                            true,
+                            source_path,
+                            res.target_path,
+                            used_us
+                        );
+                    }
+                    return;
+                }
+                Err(err)
+                    if matches!(err, FsError::ResourceExhausted(_))
+                        && retries < retry_policy.max_retries =>
+                {
+                    retries += 1;
+                    warn!(
+                        "async cache submit resource exhausted for {}, retry {}/{} after {:?}: {}",
+                        source_path, retries, retry_policy.max_retries, sleep_time, err
+                    );
+                    time::sleep(sleep_time).await;
+                    sleep_time = retry_policy.max_sleep.min(sleep_time + sleep_time);
+                }
+                Err(err) => {
+                    warn!("submit async cache error for {}: {}", source_path, err);
+                    return;
+                }
+            }
+        }
+    }
+
+    fn insert_pending(pending: &StdMutex<HashSet<String>>, source_path: String) -> bool {
+        match pending.lock() {
+            Ok(mut pending) => pending.insert(source_path),
+            Err(err) => {
+                warn!("async cache pending set poisoned: {}", err);
+                false
+            }
+        }
+    }
+
+    fn remove_pending(pending: &StdMutex<HashSet<String>>, source_path: &str) {
+        match pending.lock() {
+            Ok(mut pending) => {
+                pending.remove(source_path);
+            }
+            Err(err) => warn!("async cache pending set poisoned: {}", err),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct AsyncCacheRetryPolicy {
+    max_retries: u32,
+    min_sleep: Duration,
+    max_sleep: Duration,
 }
 
 #[derive(Clone)]
@@ -49,6 +217,7 @@ pub struct UnifiedFileSystem {
     enable_unified: bool,
     enable_read_ufs: bool,
     audit_logging_enabled: bool,
+    async_cache_submitter: Arc<AsyncCacheSubmitter>,
     metrics: &'static ClientMetrics,
 }
 
@@ -60,13 +229,22 @@ impl UnifiedFileSystem {
         let audit_logging_enabled = conf.client.audit_logging_enabled;
 
         let cv = CurvineFileSystem::with_rt(conf, rt.clone())?;
+        let metrics = FsContext::get_metrics();
+        let async_cache_submitter = Arc::new(AsyncCacheSubmitter::new(
+            cv.fs_client(),
+            rt,
+            cv.conf(),
+            metrics,
+            audit_logging_enabled,
+        ));
         let fs = UnifiedFileSystem {
             cv,
             mount_cache: Arc::new(MountCache::new(update_interval.as_millis() as u64)),
             enable_unified,
             enable_read_ufs,
             audit_logging_enabled,
-            metrics: FsContext::get_metrics(),
+            async_cache_submitter,
+            metrics,
         };
 
         Ok(fs)
@@ -374,44 +552,23 @@ impl UnifiedFileSystem {
     }
 
     pub fn async_cache(&self, source_path: &Path) -> FsResult<()> {
-        let client = JobMasterClient::new(self.fs_client());
-        let source_path = source_path.clone_uri();
-        let log = self.audit_logging_enabled;
-        let metrics = self.metrics;
-
-        self.fs_context().rt().spawn(async move {
-            let time = TimeSpent::new();
-            let command = LoadJobCommand::builder(source_path.clone()).build();
-            let res = client.submit_load_job(command).await;
-
-            let used_us = time.used_us();
-            metrics
-                .metadata_operation_duration
-                .with_label_values(&["SubmitJob"])
-                .observe(used_us as f64);
-
-            match res {
-                Err(e) => warn!("submit async cache error for {}: {}", source_path, e),
-                Ok(res) => {
-                    if log {
-                        info!(
-                            target: "audit",
-                            "cmd={} ok={} src={} dst={} usedUs={}",
-                            "SubmitJob",
-                            true,
-                            source_path,
-                            res.target_path,
-                           used_us
-                        );
-                    }
-                }
-            }
-        });
-
+        self.async_cache_submitter.enqueue(source_path.clone_uri());
         Ok(())
     }
 
     pub async fn wait_job_complete(&self, path: &Path, fail_if_not_found: bool) -> FsResult<()> {
+        let job_id = self.load_job_id_for_path(path).await?;
+        let client = JobMasterClient::new(self.fs_client());
+        client.wait_job_complete(job_id, fail_if_not_found).await
+    }
+
+    pub async fn get_job_status(&self, path: &Path) -> FsResult<JobStatus> {
+        let client = JobMasterClient::new(self.fs_client());
+        let job_id = self.load_job_id_for_path(path).await?;
+        client.get_job_status(job_id).await
+    }
+
+    async fn load_job_id_for_path(&self, path: &Path) -> FsResult<String> {
         if !path.is_cv() {
             return err_box!("the current file {} is not a cache file", path);
         }
@@ -420,19 +577,17 @@ impl UnifiedFileSystem {
             None => return err_box!("the current file {} is not mounted to ufs", path),
         };
 
-        let job_id = if mnt.info.is_fs_mode() {
-            CommonUtils::create_job_id(path.full_path())
+        let source = if mnt.info.is_fs_mode() {
+            match self.cv.get_status(path).await {
+                Ok(status) if status.storage_policy.ufs_only() => ufs_path.full_path(),
+                Ok(_) | Err(FsError::FileNotFound(_)) => path.full_path(),
+                Err(err) => return Err(err),
+            }
         } else {
-            CommonUtils::create_job_id(ufs_path.full_path())
+            ufs_path.full_path()
         };
-        let client = JobMasterClient::new(self.fs_client());
-        client.wait_job_complete(job_id, fail_if_not_found).await
-    }
 
-    pub async fn get_job_status(&self, path: &Path) -> FsResult<JobStatus> {
-        let client = JobMasterClient::new(self.fs_client());
-        let job_id = CommonUtils::create_job_id(path.full_path());
-        client.get_job_status(job_id).await
+        Ok(CommonUtils::create_job_id(source))
     }
 
     pub async fn cleanup(&self) {
@@ -689,16 +844,26 @@ impl FileSystem<UnifiedWriter, UnifiedReader> for UnifiedFileSystem {
                     .with_label_values(&[mount.mount_id()])
                     .inc();
 
-                if mount.info.auto_cache() {
-                    self.async_cache(&ufs_path)?;
-                }
-
                 read_path = ufs_path.full_path().to_owned();
                 // Reading from ufs
                 if self.enable_read_ufs {
                     debug!("read from ufs, ufs path {}, cv path: {}", ufs_path, path);
-                    mount.ufs.open(&ufs_path).await
+                    if mount.info.auto_cache() {
+                        let status = mount.ufs.get_status(&ufs_path).await?;
+                        if status.is_dir {
+                            return err_ext!(FsError::is_a_directory(ufs_path.path()));
+                        }
+                    }
+                    let reader = mount.ufs.open(&ufs_path).await?;
+                    if mount.info.auto_cache() {
+                        self.async_cache(&ufs_path)?;
+                    }
+                    Ok(reader)
                 } else {
+                    if mount.info.auto_cache() {
+                        mount.ufs.get_status(&ufs_path).await?;
+                        self.async_cache(&ufs_path)?;
+                    }
                     err_ext!(FsError::unsupported_ufs_read(path.path()))
                 }
             }

--- a/curvine-common/src/conf/client_conf.rs
+++ b/curvine-common/src/conf/client_conf.rs
@@ -18,7 +18,7 @@ use curvine_common_macros::ClientCliArgs;
 use orpc::client::ClientConf as RpcConf;
 use orpc::common::{ByteUnit, DurationUnit, Utils};
 use orpc::io::net::InetAddr;
-use orpc::CommonResult;
+use orpc::{err_box, CommonResult};
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
@@ -121,6 +121,22 @@ pub struct ClientConf {
     /// Same as auto_cache_ttl, but as Option<String> type, it is convenient to use in the API
     #[client_cli(skip)]
     pub default_cache_ttl: Option<String>,
+
+    /// Maximum number of auto-cache submit requests waiting in the client process.
+    #[client_cli]
+    pub auto_cache_submit_queue_size: usize,
+
+    /// Maximum retries when the master rejects auto-cache submit due to resource pressure.
+    #[client_cli]
+    pub auto_cache_submit_retry_max: u32,
+
+    /// Initial retry sleep for auto-cache submit resource pressure.
+    #[client_cli]
+    pub auto_cache_submit_retry_min_sleep_ms: u64,
+
+    /// Maximum retry sleep for auto-cache submit resource pressure.
+    #[client_cli]
+    pub auto_cache_submit_retry_max_sleep_ms: u64,
 
     // Set up the customer service retry policy
     #[client_cli]
@@ -292,12 +308,28 @@ impl ClientConf {
 
     pub const DEFAULT_MAX_READ_PARALLEL: i64 = 8;
 
+    pub const DEFAULT_AUTO_CACHE_SUBMIT_QUEUE_SIZE: usize = 1024;
+    pub const DEFAULT_AUTO_CACHE_SUBMIT_RETRY_MAX: u32 = 3;
+    pub const DEFAULT_AUTO_CACHE_SUBMIT_RETRY_MIN_SLEEP_MS: u64 = 100;
+    pub const DEFAULT_AUTO_CACHE_SUBMIT_RETRY_MAX_SLEEP_MS: u64 = 2_000;
+
     pub fn init(&mut self) -> CommonResult<()> {
         if self.read_parallel <= 0 {
             self.read_parallel = Self::DEFAULT_READ_PARALLEL;
         }
         if self.max_read_parallel <= 0 {
             self.max_read_parallel = Self::DEFAULT_MAX_READ_PARALLEL;
+        }
+        if self.auto_cache_submit_queue_size == 0 {
+            return err_box!("client.auto_cache_submit_queue_size must be > 0");
+        }
+        if self.auto_cache_submit_retry_min_sleep_ms == 0 {
+            return err_box!("client.auto_cache_submit_retry_min_sleep_ms must be > 0");
+        }
+        if self.auto_cache_submit_retry_max_sleep_ms < self.auto_cache_submit_retry_min_sleep_ms {
+            return err_box!(
+                "client.auto_cache_submit_retry_max_sleep_ms must be >= client.auto_cache_submit_retry_min_sleep_ms"
+            );
         }
 
         self.block_size = ByteUnit::from_str(&self.block_size_str)?.as_byte() as i64;
@@ -422,6 +454,12 @@ impl Default for ClientConf {
             auto_cache_enabled: false,
             auto_cache_ttl: "7d".to_string(),
             default_cache_ttl: Some("7d".to_string()),
+            auto_cache_submit_queue_size: Self::DEFAULT_AUTO_CACHE_SUBMIT_QUEUE_SIZE,
+            auto_cache_submit_retry_max: Self::DEFAULT_AUTO_CACHE_SUBMIT_RETRY_MAX,
+            auto_cache_submit_retry_min_sleep_ms:
+                Self::DEFAULT_AUTO_CACHE_SUBMIT_RETRY_MIN_SLEEP_MS,
+            auto_cache_submit_retry_max_sleep_ms:
+                Self::DEFAULT_AUTO_CACHE_SUBMIT_RETRY_MAX_SLEEP_MS,
 
             conn_retry_max_duration_ms: 60 * 1000,
             conn_retry_min_sleep_ms: 100,

--- a/curvine-common/src/conf/job_conf.rs
+++ b/curvine-common/src/conf/job_conf.rs
@@ -40,6 +40,24 @@ pub struct JobConf {
     // Maximum concurrent master-side load job planning tasks
     pub master_max_concurrent_load_jobs: usize,
 
+    // Maximum master-side load jobs allowed to wait in the background FIFO queue
+    pub master_max_background_load_jobs: usize,
+
+    // Maximum load job submit requests allowed to wait before background admission.
+    pub master_max_pending_load_job_submits: usize,
+
+    // Runtime threads reserved for master-side load job planning
+    pub master_load_job_runtime_threads: usize,
+
+    // Blocking threads reserved for master-side load job planning
+    pub master_load_job_blocking_threads: usize,
+
+    // Time to reuse a deterministic source-not-found load failure before retrying UFS.
+    #[serde(skip)]
+    pub master_failed_load_job_retry_interval: Duration,
+    #[serde(alias = "master_failed_load_job_retry_interval")]
+    pub master_failed_load_job_retry_interval_str: String,
+
     // Maximum execution time allowed for a task.
     #[serde(skip)]
     pub task_timeout: Duration,
@@ -61,6 +79,11 @@ impl JobConf {
     pub const DEFAULT_JOB_CLEANUP_TTL_STR: &'static str = "10m";
     pub const DEFAULT_JOB_MAX_FILES: usize = 100000;
     pub const DEFAULT_MASTER_MAX_CONCURRENT_LOAD_JOBS: usize = 16;
+    pub const DEFAULT_MASTER_MAX_BACKGROUND_LOAD_JOBS: usize = 1024;
+    pub const DEFAULT_MASTER_MAX_PENDING_LOAD_JOB_SUBMITS: usize = 4096;
+    pub const DEFAULT_MASTER_LOAD_JOB_RUNTIME_THREADS: usize = 4;
+    pub const DEFAULT_MASTER_LOAD_JOB_BLOCKING_THREADS: usize = 16;
+    pub const DEFAULT_MASTER_FAILED_LOAD_JOB_RETRY_INTERVAL: &'static str = "30s";
     pub const DEFAULT_TASK_TIMEOUT: &'static str = "1h";
     pub const DEFAULT_TASK_REPORT_INTERVAL: &'static str = "10s";
     pub const DEFAULT_WORKER_MAX_CONCURRENT_TASKS: usize = 100;
@@ -71,8 +94,22 @@ impl JobConf {
         self.task_timeout = DurationUnit::from_str(&self.task_timeout_str)?.as_duration();
         self.task_report_interval =
             DurationUnit::from_str(&self.task_report_interval_str)?.as_duration();
+        self.master_failed_load_job_retry_interval =
+            DurationUnit::from_str(&self.master_failed_load_job_retry_interval_str)?.as_duration();
         if self.master_max_concurrent_load_jobs == 0 {
             return err_box!("job.master_max_concurrent_load_jobs must be > 0");
+        }
+        if self.master_max_background_load_jobs == 0 {
+            return err_box!("job.master_max_background_load_jobs must be > 0");
+        }
+        if self.master_max_pending_load_job_submits == 0 {
+            return err_box!("job.master_max_pending_load_job_submits must be > 0");
+        }
+        if self.master_load_job_runtime_threads == 0 {
+            return err_box!("job.master_load_job_runtime_threads must be > 0");
+        }
+        if self.master_load_job_blocking_threads == 0 {
+            return err_box!("job.master_load_job_blocking_threads must be > 0");
         }
 
         Ok(())
@@ -89,6 +126,13 @@ impl Default for JobConf {
 
             job_max_files: Self::DEFAULT_JOB_MAX_FILES,
             master_max_concurrent_load_jobs: Self::DEFAULT_MASTER_MAX_CONCURRENT_LOAD_JOBS,
+            master_max_background_load_jobs: Self::DEFAULT_MASTER_MAX_BACKGROUND_LOAD_JOBS,
+            master_max_pending_load_job_submits: Self::DEFAULT_MASTER_MAX_PENDING_LOAD_JOB_SUBMITS,
+            master_load_job_runtime_threads: Self::DEFAULT_MASTER_LOAD_JOB_RUNTIME_THREADS,
+            master_load_job_blocking_threads: Self::DEFAULT_MASTER_LOAD_JOB_BLOCKING_THREADS,
+            master_failed_load_job_retry_interval: Default::default(),
+            master_failed_load_job_retry_interval_str:
+                Self::DEFAULT_MASTER_FAILED_LOAD_JOB_RETRY_INTERVAL.to_string(),
 
             task_timeout: Default::default(),
             task_timeout_str: Self::DEFAULT_TASK_TIMEOUT.to_string(),

--- a/curvine-common/src/error/fs_error.rs
+++ b/curvine-common/src/error/fs_error.rs
@@ -64,6 +64,7 @@ pub enum ErrorKind {
     NotADirectory = 27,
     InvalidArgument = 28,
     BlockNotFound = 29,
+    ResourceExhausted = 30,
 
     #[num_enum(default)]
     Common = 10000,
@@ -184,6 +185,10 @@ pub enum FsError {
     #[error("{0}")]
     JobNotFound(ErrorImpl<StringError>),
 
+    // The server or client side resource limit was reached.
+    #[error("{0}")]
+    ResourceExhausted(ErrorImpl<StringError>),
+
     // Other errors that are not defined.
     #[error("{0}")]
     Common(ErrorImpl<StringError>),
@@ -239,6 +244,10 @@ impl FsError {
     pub fn job_not_found(job_id: impl AsRef<str>) -> Self {
         let msg = format!("Job {} not found", job_id.as_ref());
         Self::JobNotFound(ErrorImpl::with_source(msg.into()))
+    }
+
+    pub fn resource_exhausted(msg: impl Into<String>) -> Self {
+        Self::ResourceExhausted(ErrorImpl::with_source(msg.into().into()))
     }
 
     pub fn file_exists(path: impl AsRef<str>) -> Self {
@@ -370,6 +379,7 @@ impl FsError {
             FsError::Pipeline(_) => ErrorKind::Pipeline,
             FsError::MinReplicasNotMet(_) => ErrorKind::MinReplicasNotMet,
             FsError::JobNotFound(_) => ErrorKind::JobNotFound,
+            FsError::ResourceExhausted(_) => ErrorKind::ResourceExhausted,
             FsError::Common(_) => ErrorKind::Common,
         }
     }
@@ -516,6 +526,7 @@ impl ErrorExt for FsError {
             FsError::Pipeline(e) => FsError::Pipeline(e.ctx(ctx)),
             FsError::MinReplicasNotMet(e) => FsError::MinReplicasNotMet(e.ctx(ctx)),
             FsError::JobNotFound(e) => FsError::JobNotFound(e.ctx(ctx)),
+            FsError::ResourceExhausted(e) => FsError::ResourceExhausted(e.ctx(ctx)),
             FsError::Common(e) => FsError::Common(e.ctx(ctx)),
         }
     }
@@ -551,6 +562,7 @@ impl ErrorExt for FsError {
             FsError::Pipeline(e) => e.encode(ErrorKind::Pipeline),
             FsError::MinReplicasNotMet(e) => e.encode(ErrorKind::MinReplicasNotMet),
             FsError::JobNotFound(e) => e.encode(ErrorKind::JobNotFound),
+            FsError::ResourceExhausted(e) => e.encode(ErrorKind::ResourceExhausted),
             FsError::Common(e) => e.encode(ErrorKind::Common),
         }
     }
@@ -589,6 +601,7 @@ impl ErrorExt for FsError {
             ErrorKind::Pipeline => FsError::Pipeline(de.into_string()),
             ErrorKind::MinReplicasNotMet => FsError::MinReplicasNotMet(de.into_string()),
             ErrorKind::JobNotFound => FsError::JobNotFound(de.into_string()),
+            ErrorKind::ResourceExhausted => FsError::ResourceExhausted(de.into_string()),
             ErrorKind::Common => FsError::Common(de.into_string()),
         }
     }

--- a/curvine-common/tests/client_conf_cli_test.rs
+++ b/curvine-common/tests/client_conf_cli_test.rs
@@ -83,6 +83,42 @@ fn normalizes_non_positive_read_parallel_settings_to_defaults() {
 }
 
 #[test]
+fn validates_auto_cache_submit_backpressure_conf() {
+    let mut conf = ClientConf::default();
+    assert_eq!(
+        conf.auto_cache_submit_queue_size,
+        ClientConf::DEFAULT_AUTO_CACHE_SUBMIT_QUEUE_SIZE
+    );
+    assert_eq!(
+        conf.auto_cache_submit_retry_max,
+        ClientConf::DEFAULT_AUTO_CACHE_SUBMIT_RETRY_MAX
+    );
+
+    conf.auto_cache_submit_queue_size = 0;
+    let err = conf.init().unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("client.auto_cache_submit_queue_size must be > 0"),
+        "unexpected error: {}",
+        err
+    );
+
+    let mut conf = ClientConf {
+        auto_cache_submit_retry_min_sleep_ms: 200,
+        auto_cache_submit_retry_max_sleep_ms: 100,
+        ..Default::default()
+    };
+    let err = conf.init().unwrap_err();
+    assert!(
+        err.to_string().contains(
+            "client.auto_cache_submit_retry_max_sleep_ms must be >= client.auto_cache_submit_retry_min_sleep_ms"
+        ),
+        "unexpected error: {}",
+        err
+    );
+}
+
+#[test]
 fn parses_c4_chunk_unified_fs_and_audit_flags() {
     let parsed = CliHarness::try_parse_from([
         "curvine-fuse",

--- a/curvine-common/tests/fs_error_test.rs
+++ b/curvine-common/tests/fs_error_test.rs
@@ -16,3 +16,22 @@ fn block_not_found_round_trips_with_structured_kind() {
         other => panic!("expected BlockNotFound, got {:?}", other),
     }
 }
+
+#[test]
+fn resource_exhausted_round_trips_with_structured_kind() {
+    let error = FsError::resource_exhausted("master load job queue is full; retry later");
+    assert!(matches!(error.kind(), ErrorKind::ResourceExhausted));
+
+    let decoded = FsError::decode(error.encode());
+    assert!(matches!(decoded.kind(), ErrorKind::ResourceExhausted));
+
+    match decoded {
+        FsError::ResourceExhausted(error) => {
+            assert_eq!(
+                error.source.to_string(),
+                "master load job queue is full; retry later"
+            );
+        }
+        other => panic!("expected ResourceExhausted, got {:?}", other),
+    }
+}

--- a/curvine-common/tests/job_conf_test.rs
+++ b/curvine-common/tests/job_conf_test.rs
@@ -1,0 +1,98 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use curvine_common::conf::JobConf;
+
+#[test]
+fn default_master_load_job_runtime_conf_is_valid() {
+    let mut conf = JobConf::default();
+
+    conf.init().expect("default job conf should be valid");
+
+    assert_eq!(
+        conf.master_load_job_runtime_threads,
+        JobConf::DEFAULT_MASTER_LOAD_JOB_RUNTIME_THREADS
+    );
+    assert_eq!(
+        conf.master_load_job_blocking_threads,
+        JobConf::DEFAULT_MASTER_LOAD_JOB_BLOCKING_THREADS
+    );
+    assert_eq!(
+        conf.master_max_pending_load_job_submits,
+        JobConf::DEFAULT_MASTER_MAX_PENDING_LOAD_JOB_SUBMITS
+    );
+    assert_eq!(
+        conf.master_failed_load_job_retry_interval_str,
+        JobConf::DEFAULT_MASTER_FAILED_LOAD_JOB_RETRY_INTERVAL
+    );
+}
+
+#[test]
+fn master_load_job_runtime_conf_rejects_zero_threads() {
+    let mut conf = JobConf {
+        master_max_background_load_jobs: 0,
+        ..Default::default()
+    };
+    let err = conf
+        .init()
+        .expect_err("zero background queue capacity must be rejected");
+    assert!(
+        err.to_string()
+            .contains("job.master_max_background_load_jobs must be > 0"),
+        "unexpected error: {}",
+        err
+    );
+
+    let mut conf = JobConf {
+        master_load_job_runtime_threads: 0,
+        ..Default::default()
+    };
+    let err = conf
+        .init()
+        .expect_err("zero runtime threads must be rejected");
+    assert!(
+        err.to_string()
+            .contains("job.master_load_job_runtime_threads must be > 0"),
+        "unexpected error: {}",
+        err
+    );
+
+    let mut conf = JobConf {
+        master_load_job_blocking_threads: 0,
+        ..Default::default()
+    };
+    let err = conf
+        .init()
+        .expect_err("zero blocking threads must be rejected");
+    assert!(
+        err.to_string()
+            .contains("job.master_load_job_blocking_threads must be > 0"),
+        "unexpected error: {}",
+        err
+    );
+
+    let mut conf = JobConf {
+        master_max_pending_load_job_submits: 0,
+        ..Default::default()
+    };
+    let err = conf
+        .init()
+        .expect_err("zero submit queue capacity must be rejected");
+    assert!(
+        err.to_string()
+            .contains("job.master_max_pending_load_job_submits must be > 0"),
+        "unexpected error: {}",
+        err
+    );
+}

--- a/curvine-docker/deploy/Dockerfile_rocky9
+++ b/curvine-docker/deploy/Dockerfile_rocky9
@@ -77,7 +77,7 @@ ENTRYPOINT []
 # Examples:
 #   -p core --ufs opendal-s3 --spdk-rdma                   # Core + S3 + SPDK-RDMA
 #   -p server -p client -p tests --ufs opendal-s3 --spdk   # Bench + SPDK-TCP only
-ARG BUILD_ARGS="--skip-java-sdk --ufs opendal-s3 --ufs opendal-oss --ufs opendal-azblob --ufs opendal-gcs --ufs opendal-hdfs-native --ufs oss-hdfs --spdk-rdma"
+ARG BUILD_ARGS="-p server -p client -p cli -p fuse -p web --skip-java-sdk --skip-python-sdk --ufs opendal-s3 --ufs opendal-oss --ufs opendal-azblob --ufs opendal-gcs --ufs opendal-hdfs-native --ufs oss-hdfs --spdk-rdma"
 
 # Copy and apply build configurations
 COPY curvine-docker/deploy/config /build-config/config
@@ -95,35 +95,14 @@ WORKDIR /workspace
 ENV SPDK_DIR=/opt/spdk
 ENV PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig
 
-# 6. Pre-install WebUI dependencies and fix vue-cli-service module resolution
-RUN if [ -d "/workspace/curvine-web/webui" ]; then \
-        echo "Pre-installing WebUI dependencies..."; \
-        cd /workspace/curvine-web/webui && \
-        npm install --legacy-peer-deps && \
-        echo "npm install completed" && \
-        # Fix: vue-cli-service wrapper script expects node_modules/package.json
-        # Create symlink to @vue/cli-service/package.json
-        ln -s @vue/cli-service/package.json node_modules/package.json && \
-        echo "Created symlink: node_modules/package.json -> @vue/cli-service/package.json" && \
-        ls -la node_modules/package.json; \
-    fi
-
-# 7. Patch build.sh to use direct vue-cli-service.js call
-RUN if [ -f "/workspace/build/build.sh" ]; then \
-        echo "Patching build.sh to fix vue-cli-service wrapper script issue..."; \
-        sed -i 's/npm run build/node node_modules\/@vue\/cli-service\/bin\/vue-cli-service.js build/g' /workspace/build/build.sh && \
-        echo "Patch applied" && \
-        grep -n "vue-cli-service" /workspace/build/build.sh || true; \
-    fi
-
-# 8. Build the project from source
+# 6. Build the runtime project from source.
 RUN echo "Building Curvine from source..." && \
     export CURVINE_HOME=/workspace && \
     # Use workspace tmp directory instead of /tmp to avoid "no space left on device"
     mkdir -p /workspace/tmp && \
     export TMPDIR=/workspace/tmp && \
     echo "Using TMPDIR=$TMPDIR for compilation temporary files" && \
-    echo "Running 'make all --skip-java-sdk' with retry mechanism..." && \
+    echo "Running runtime build with retry mechanism: make all ARGS=\"${BUILD_ARGS}\"" && \
     # Build with retry mechanism
     for attempt in 1 2 3; do \
         echo "Build attempt $attempt..." && \

--- a/curvine-docker/deploy/Dockerfile_ubuntu24
+++ b/curvine-docker/deploy/Dockerfile_ubuntu24
@@ -116,6 +116,10 @@ RUN ARCH=$(uname -m) && \
 
 ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 
+# Runtime image only needs master/worker runtime binaries, CLI/FUSE helpers, and WebUI.
+# Override with --build-arg BUILD_ARGS="..." when building SDKs, WebUI, tests, or alternate UFS sets.
+ARG BUILD_ARGS="-p server -p client -p cli -p fuse -p web --skip-java-sdk --skip-python-sdk --ufs opendal-s3 --ufs opendal-oss --ufs opendal-azblob --ufs opendal-gcs --ufs opendal-hdfs --ufs opendal-webhdfs --ufs oss-hdfs"
+
 # Copy and build source code if building from source
 COPY . /workspace/
 WORKDIR /workspace
@@ -133,28 +137,7 @@ RUN ARCH=$(uname -m) && \
     esac && \
     echo "JAVA_HOME set to: ${JAVA_HOME}"
 
-# 7. Pre-install WebUI dependencies and fix vue-cli-service module resolution
-RUN if [ -d "/workspace/curvine-web/webui" ]; then \
-        echo "Pre-installing WebUI dependencies..."; \
-        cd /workspace/curvine-web/webui && \
-        npm install --legacy-peer-deps && \
-        echo "npm install completed" && \
-        # Fix: vue-cli-service wrapper script expects node_modules/package.json
-        # Create symlink to @vue/cli-service/package.json
-        ln -s @vue/cli-service/package.json node_modules/package.json && \
-        echo "Created symlink: node_modules/package.json -> @vue/cli-service/package.json" && \
-        ls -la node_modules/package.json; \
-    fi
-
-# 8. Patch build.sh to use direct vue-cli-service.js call
-RUN if [ -f "/workspace/build/build.sh" ]; then \
-        echo "Patching build.sh to fix vue-cli-service wrapper script issue..."; \
-        sed -i 's/npm run build/node node_modules\/@vue\/cli-service\/bin\/vue-cli-service.js build/g' /workspace/build/build.sh && \
-        echo "Patch applied" && \
-        grep -n "vue-cli-service" /workspace/build/build.sh || true; \
-    fi
-
-# 9. Build the project from source with all UFS support
+# 7. Build the runtime project from source with UFS support.
 RUN echo "Building Curvine from source..." && \
     # Set JAVA_HOME for current architecture
     ARCH=$(uname -m) && \
@@ -175,11 +158,11 @@ RUN echo "Building Curvine from source..." && \
     mkdir -p /workspace/tmp && \
     export TMPDIR=/workspace/tmp && \
     echo "Using TMPDIR=$TMPDIR for compilation temporary files" && \
-    echo "Running 'make all' with --skip-java-sdk and all UFS support..." && \
-    # Build with retry mechanism and all UFS support
+    echo "Running runtime build with retry mechanism: make all ARGS=\"${BUILD_ARGS}\"" && \
+    # Build with retry mechanism and runtime UFS support
     for attempt in 1 2 3; do \
         echo "Build attempt $attempt..." && \
-        if make all ARGS='--skip-java-sdk --ufs opendal-s3 --ufs opendal-oss --ufs opendal-azblob --ufs opendal-gcs --ufs opendal-hdfs --ufs opendal-webhdfs --ufs oss-hdfs'; then \
+        if make all ARGS="${BUILD_ARGS}"; then \
             echo "✓ Build succeeded with all UFS support" && \
             break; \
         else \
@@ -291,4 +274,3 @@ EXPOSE 8995 8996 8997 9000 9001
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["master", "start"]
-

--- a/curvine-server/src/master/fs/heartbeat_checker.rs
+++ b/curvine-server/src/master/fs/heartbeat_checker.rs
@@ -64,6 +64,8 @@ impl LoopTask for HeartbeatChecker {
             return Ok(());
         }
 
+        let mut blacklisted_workers = Vec::new();
+        let mut removed_workers = Vec::new();
         {
             let mut wm = self.fs.worker_manager.write();
             let workers = wm.get_last_heartbeat();
@@ -72,42 +74,52 @@ impl LoopTask for HeartbeatChecker {
             for (id, last_update) in workers {
                 if now > last_update + self.worker_blacklist_ms {
                     // Worker blacklist timeout
-                    let worker = wm.add_blacklist_worker(id);
-                    warn!(
-                        "Worker {:?} has no heartbeat for more than {} ms and will be blacklisted",
-                        worker, self.worker_blacklist_ms
-                    );
+                    if let Some(worker) = wm.add_blacklist_worker(id) {
+                        blacklisted_workers.push((id, worker.address, worker.last_update));
+                    }
                 }
 
                 if now > last_update + self.worker_lost_ms {
                     // Heartbeat timeout
-                    let removed = wm.remove_expired_worker(id);
-                    warn!(
-                        "Worker {:?} has no heartbeat for more than {} ms and will be removed",
-                        removed, self.worker_lost_ms
-                    );
-                    // Asynchronously delete all block location data.
-                    let fs = self.fs.clone();
-                    let rm = self.replication_manager.clone();
-                    let res = self.executor.spawn(move || {
-                        let spend = TimeSpent::new();
-                        let block_ids = try_log!(fs.delete_locations(id), vec![]);
-                        let block_num = block_ids.len();
-                        if let Err(e) = rm.report_under_replicated_blocks(id, block_ids) {
-                            error!(
-                                "Errors on reporting under-replicated {} blocks. err: {:?}",
-                                block_num, e
-                            );
-                        }
-                        info!(
-                            "Delete worker {} all locations used {} ms",
-                            id,
-                            spend.used_ms()
-                        );
-                    });
-                    let _ = try_log!(res);
+                    if let Some(worker) = wm.remove_expired_worker(id) {
+                        removed_workers.push((id, worker.address, worker.last_update));
+                    }
                 }
             }
+        }
+
+        for (id, address, last_update) in blacklisted_workers {
+            warn!(
+                "Worker {} ({}) last heartbeat {} has exceeded blacklist timeout {} ms",
+                id, address, last_update, self.worker_blacklist_ms
+            );
+        }
+
+        for (id, address, last_update) in removed_workers {
+            warn!(
+                "Worker {} ({}) last heartbeat {} has exceeded lost timeout {} ms and will be removed",
+                id, address, last_update, self.worker_lost_ms
+            );
+            // Asynchronously delete all block location data.
+            let fs = self.fs.clone();
+            let rm = self.replication_manager.clone();
+            let res = self.executor.spawn(move || {
+                let spend = TimeSpent::new();
+                let block_ids = try_log!(fs.delete_locations(id), vec![]);
+                let block_num = block_ids.len();
+                if let Err(e) = rm.report_under_replicated_blocks(id, block_ids) {
+                    error!(
+                        "Errors on reporting under-replicated {} blocks. err: {:?}",
+                        block_num, e
+                    );
+                }
+                info!(
+                    "Delete worker {} all locations used {} ms",
+                    id,
+                    spend.used_ms()
+                );
+            });
+            let _ = try_log!(res);
         }
 
         if let Ok(info) = self.fs.master_info() {

--- a/curvine-server/src/master/fs/master_filesystem.rs
+++ b/curvine-server/src/master/fs/master_filesystem.rs
@@ -25,8 +25,9 @@ use curvine_common::conf::{ClusterConf, MasterConf};
 use curvine_common::error::FsError;
 use curvine_common::state::*;
 use curvine_common::FsResult;
-use log::warn;
+use log::{error, info, warn};
 use orpc::common::LocalTime;
+use orpc::runtime::GroupExecutor;
 use orpc::sync::ArcRwLock;
 use orpc::{err_box, err_ext, try_option, CommonResult};
 use parking_lot::Mutex;
@@ -40,12 +41,36 @@ pub struct MasterFilesystem {
     pub master_monitor: MasterMonitor,
     pub conf: Arc<MasterConf>,
     full_block_reports: Arc<Mutex<HashMap<u32, FullBlockReportState>>>,
+    full_block_reconciles: Arc<Mutex<HashMap<u32, FullBlockReconcileState>>>,
 }
 
 struct FullBlockReportState {
     total_len: u64,
     update_time_ms: u64,
     reported_blocks: HashSet<i64>,
+}
+
+struct FullBlockReconcileState {
+    running: bool,
+    generation: u64,
+    pending: Option<FullBlockReconcileJob>,
+}
+
+struct FullBlockReconcileJob {
+    generation: u64,
+    reported_blocks: HashSet<i64>,
+}
+
+pub struct BlockReportResult {
+    pub worker_id: u32,
+    pub full_reported_blocks: Option<HashSet<i64>>,
+    pub delete_blocks: Vec<i64>,
+}
+
+pub(crate) enum BlockInodeState {
+    File,
+    Missing,
+    NotFile,
 }
 
 const FULL_BLOCK_REPORT_TTL_MS: u64 = 60 * 60 * 1000;
@@ -63,6 +88,7 @@ impl MasterFilesystem {
             master_monitor,
             conf: Arc::new(conf.master.clone()),
             full_block_reports: Default::default(),
+            full_block_reconciles: Default::default(),
         }
     }
 
@@ -73,6 +99,7 @@ impl MasterFilesystem {
             master_monitor: js.master_monitor(),
             conf: Arc::new(conf.master.clone()),
             full_block_reports: Default::default(),
+            full_block_reconciles: Default::default(),
         }
     }
 
@@ -717,9 +744,9 @@ impl MasterFilesystem {
         fs_dir.restore_from_rocksdb()
     }
 
-    fn block_exists(&self, id: i64) -> FsResult<bool> {
+    fn block_inode_state(&self, id: i64) -> FsResult<BlockInodeState> {
         let fs_dir = self.fs_dir.read();
-        fs_dir.block_exists(id)
+        fs_dir.block_inode_state(id)
     }
 
     fn collect_full_block_report(&self, list: &BlockReportList) -> Option<HashSet<i64>> {
@@ -769,32 +796,72 @@ impl MasterFilesystem {
 
     pub fn reset_full_block_report(&self, worker_id: u32) {
         self.full_block_reports.lock().remove(&worker_id);
+        self.invalidate_full_block_reconcile(worker_id);
+    }
+
+    fn invalidate_full_block_reconcile(&self, worker_id: u32) {
+        let mut reconciles = self.full_block_reconciles.lock();
+        if let Some(state) = reconciles.get_mut(&worker_id) {
+            state.generation = state.generation.saturating_add(1);
+            state.pending = None;
+            if !state.running {
+                reconciles.remove(&worker_id);
+            }
+        }
     }
 
     /// Process block reports
-    pub fn block_report(&self, list: BlockReportList) -> FsResult<Vec<i64>> {
+    pub fn block_report(&self, list: BlockReportList) -> FsResult<BlockReportResult> {
         // @todo check cluster.
+        let invalidate_full_reconcile = !list.full_report
+            && list.blocks.iter().any(|block| {
+                matches!(
+                    block.status,
+                    BlockReportStatus::Finalized | BlockReportStatus::Writing
+                )
+            });
+        if invalidate_full_reconcile {
+            self.invalidate_full_block_reconcile(list.worker_id);
+        }
         let full_reported_blocks = self.collect_full_block_report(&list);
         if list.blocks.is_empty() && full_reported_blocks.is_none() {
-            return Ok(Vec::new());
+            return Ok(BlockReportResult {
+                worker_id: list.worker_id,
+                full_reported_blocks,
+                delete_blocks: Vec::new(),
+            });
         }
 
         //(Whether to increase, block id, block location)
         let mut checked = Vec::with_capacity(list.blocks.len());
+        let mut delete_blocks = Vec::new();
+        let mut missing_blocks = 0usize;
+        let mut not_file_blocks = 0usize;
         for item in list.blocks {
             match item.status {
                 BlockReportStatus::Finalized | BlockReportStatus::Writing => {
-                    let exists = match self.block_exists(item.id) {
-                        Ok(v) => v,
-                        Err(e) => {
-                            warn!("block_report {item:?}: {e}");
-                            continue;
+                    match self.block_inode_state(item.id)? {
+                        BlockInodeState::File => checked.push((item, Some(BlockInodeState::File))),
+                        BlockInodeState::Missing => {
+                            missing_blocks += 1;
+                            delete_blocks.push(item.id);
+                            checked.push((item, Some(BlockInodeState::Missing)));
                         }
-                    };
-                    checked.push((item, Some(exists)));
+                        BlockInodeState::NotFile => {
+                            not_file_blocks += 1;
+                            delete_blocks.push(item.id);
+                            checked.push((item, Some(BlockInodeState::NotFile)));
+                        }
+                    }
                 }
                 BlockReportStatus::Deleted => checked.push((item, None)),
             }
+        }
+        if missing_blocks > 0 || not_file_blocks > 0 {
+            warn!(
+                "block_report worker {} found {} missing-inode and {} non-file-inode blocks; scheduling worker deletion",
+                list.worker_id, missing_blocks, not_file_blocks
+            );
         }
 
         let mut batch: Vec<(bool, i64, BlockLocation)> = vec![];
@@ -803,21 +870,27 @@ impl MasterFilesystem {
             let loc = BlockLocation::new(list.worker_id, item.storage_type);
             match item.status {
                 BlockReportStatus::Finalized | BlockReportStatus::Writing => {
-                    let exists = match exists {
+                    let state = match exists {
                         Some(v) => v,
                         None => {
                             warn!(
-                                "block_report invariant violated: missing existence flag for block {}",
+                                "block_report invariant violated: missing inode state for block {}",
                                 item.id
                             );
                             continue;
                         }
                     };
 
-                    if exists {
-                        batch.push((true, item.id, loc));
-                    } else {
-                        wm.remove_block(list.worker_id, item.id);
+                    match state {
+                        BlockInodeState::File => batch.push((true, item.id, loc)),
+                        BlockInodeState::Missing => {
+                            batch.push((false, item.id, loc));
+                            wm.remove_block(list.worker_id, item.id);
+                        }
+                        BlockInodeState::NotFile => {
+                            batch.push((false, item.id, loc));
+                            wm.remove_block(list.worker_id, item.id);
+                        }
                     }
                 }
                 BlockReportStatus::Deleted => {
@@ -828,29 +901,163 @@ impl MasterFilesystem {
         }
         drop(wm);
 
-        let mut stale_block_ids = Vec::new();
         let mut fs_dir = self.fs_dir.write();
-        if let Some(reported_blocks) = full_reported_blocks {
-            let existing_blocks = fs_dir.get_worker_block_ids(list.worker_id)?;
-            for block_id in existing_blocks {
-                if !reported_blocks.contains(&block_id) {
-                    batch.push((false, block_id, BlockLocation::with_id(list.worker_id)));
-                    stale_block_ids.push(block_id);
+        fs_dir.block_report(batch)?;
+
+        Ok(BlockReportResult {
+            worker_id: list.worker_id,
+            full_reported_blocks,
+            delete_blocks,
+        })
+    }
+
+    pub fn submit_full_block_reconcile(
+        &self,
+        executor: Arc<GroupExecutor>,
+        worker_id: u32,
+        reported_blocks: HashSet<i64>,
+        replication_handler: Option<
+            crate::master::replication::master_replication_handler::MasterReplicationHandler,
+        >,
+    ) -> FsResult<()> {
+        let should_spawn = {
+            let mut reconciles = self.full_block_reconciles.lock();
+            let state = reconciles
+                .entry(worker_id)
+                .or_insert_with(|| FullBlockReconcileState {
+                    running: false,
+                    generation: 0,
+                    pending: None,
+                });
+            state.generation = state.generation.saturating_add(1);
+            let generation = state.generation;
+            state.pending = Some(FullBlockReconcileJob {
+                generation,
+                reported_blocks,
+            });
+            if state.running {
+                false
+            } else {
+                state.running = true;
+                true
+            }
+        };
+
+        if !should_spawn {
+            return Ok(());
+        }
+
+        let fs = self.clone();
+        let res = executor.fixed_try_spawn(worker_id as i64, move || {
+            fs.run_full_block_reconcile(worker_id, replication_handler);
+        });
+        if let Err(e) = &res {
+            let mut reconciles = self.full_block_reconciles.lock();
+            reconciles.remove(&worker_id);
+            error!("submit full block report reconcile for worker {worker_id} failed: {e}");
+        }
+        res?;
+        Ok(())
+    }
+
+    fn run_full_block_reconcile(
+        &self,
+        worker_id: u32,
+        replication_handler: Option<
+            crate::master::replication::master_replication_handler::MasterReplicationHandler,
+        >,
+    ) {
+        loop {
+            let job = {
+                let mut reconciles = self.full_block_reconciles.lock();
+                match reconciles.get_mut(&worker_id) {
+                    Some(state) => match state.pending.take() {
+                        Some(v) => v,
+                        None => {
+                            reconciles.remove(&worker_id);
+                            return;
+                        }
+                    },
+                    None => return,
+                }
+            };
+
+            if !self.is_full_block_reconcile_current(worker_id, job.generation) {
+                info!(
+                    "skip stale full block report reconcile for worker {}, generation {}",
+                    worker_id, job.generation
+                );
+                continue;
+            }
+
+            match self.reconcile_full_block_report(worker_id, job.generation, job.reported_blocks) {
+                Ok(stale_block_ids) => {
+                    let stale_block_count = stale_block_ids.len();
+                    if stale_block_count > 0 {
+                        info!(
+                            "full block report reconciled {} stale block locations for worker {}",
+                            stale_block_count, worker_id
+                        );
+                        if let Some(replication_handler) = &replication_handler {
+                            if let Err(e) = replication_handler
+                                .report_under_replicated_blocks(worker_id, stale_block_ids)
+                            {
+                                error!(
+                                    "Errors on reporting under-replicated {} blocks from full block report reconciliation. err: {:?}",
+                                    stale_block_count, e
+                                );
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    error!(
+                        "full block report reconcile for worker {} failed: {}",
+                        worker_id, e
+                    );
                 }
             }
         }
+    }
 
-        fs_dir.block_report(batch)?;
-
-        if !stale_block_ids.is_empty() {
-            warn!(
-                "full block report reconciled {} stale block locations for worker {}",
-                stale_block_ids.len(),
-                list.worker_id
-            );
+    fn reconcile_full_block_report(
+        &self,
+        worker_id: u32,
+        generation: u64,
+        reported_blocks: HashSet<i64>,
+    ) -> FsResult<Vec<i64>> {
+        let mut stale_block_ids = Vec::new();
+        let mut batch = Vec::new();
+        let existing_blocks = {
+            let fs_dir = self.fs_dir.read();
+            fs_dir.get_worker_block_ids(worker_id)?
+        };
+        for block_id in existing_blocks {
+            if !reported_blocks.contains(&block_id) {
+                batch.push((false, block_id, BlockLocation::with_id(worker_id)));
+                stale_block_ids.push(block_id);
+            }
         }
-
+        if !batch.is_empty() {
+            if !self.is_full_block_reconcile_current(worker_id, generation) {
+                info!(
+                    "skip stale full block report reconcile apply for worker {}, generation {}",
+                    worker_id, generation
+                );
+                return Ok(Vec::new());
+            }
+            let mut fs_dir = self.fs_dir.write();
+            fs_dir.block_report(batch)?;
+        }
         Ok(stale_block_ids)
+    }
+
+    fn is_full_block_reconcile_current(&self, worker_id: u32, generation: u64) -> bool {
+        let reconciles = self.full_block_reconciles.lock();
+        reconciles
+            .get(&worker_id)
+            .map(|state| state.generation == generation)
+            .unwrap_or(false)
     }
 
     pub fn delete_locations(&self, worker_id: u32) -> FsResult<Vec<i64>> {

--- a/curvine-server/src/master/fs/mod.rs
+++ b/curvine-server/src/master/fs/mod.rs
@@ -25,6 +25,7 @@ mod fs_retry_cache;
 pub use self::fs_retry_cache::*;
 
 mod master_filesystem;
+pub(crate) use self::master_filesystem::BlockInodeState;
 pub use self::master_filesystem::MasterFilesystem;
 
 mod delete_result;

--- a/curvine-server/src/master/fs/worker_manager.rs
+++ b/curvine-server/src/master/fs/worker_manager.rs
@@ -135,12 +135,12 @@ impl WorkerManager {
 
     pub fn add_blacklist_worker(&mut self, id: u32) -> Option<WorkerInfo> {
         match self.worker_map.workers.get_mut(&id) {
-            Some(v) => {
+            Some(v) if v.status != WorkerStatus::Blacklist => {
                 v.status = WorkerStatus::Blacklist;
                 Some(v.clone())
             }
 
-            None => None,
+            _ => None,
         }
     }
 

--- a/curvine-server/src/master/job/job_manager.rs
+++ b/curvine-server/src/master/job/job_manager.rs
@@ -14,7 +14,10 @@
 
 use crate::common::UfsFactory;
 use crate::master::fs::MasterFilesystem;
-use crate::master::{JobStore, LoadJobRunner, MountManager};
+use crate::master::job::job_runner::{
+    LoadJobPrepareResult, QueuedLoadJob, QueuedLoadJobValidation,
+};
+use crate::master::{JobStore, LoadJobRunner, Master, MasterMetrics, MountManager};
 use core::time::Duration;
 use curvine_client::unified::MountValue;
 use curvine_common::conf::ClusterConf;
@@ -28,24 +31,153 @@ use curvine_common::FsResult;
 use log::{debug, info, warn};
 use orpc::common::LocalTime;
 use orpc::runtime::{LoopTask, RpcRuntime, Runtime};
+use orpc::sync::channel::{AsyncChannel, AsyncReceiver, AsyncSender};
 use orpc::sync::AtomicCounter;
 use orpc::{err_box, err_ext, CommonResult};
-use std::sync::Arc;
-use tokio::sync::Semaphore;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Weak};
+use tokio::sync::{watch, Mutex};
 use tokio::time::timeout;
 
-/// Load the Task Manager
+struct QueuedLoadJobRequest {
+    job_id: String,
+    queued: QueuedLoadJob,
+}
+
+#[derive(Clone)]
+struct LoadJobWorkerContext {
+    jobs: JobStore,
+    master_fs: MasterFilesystem,
+    factory: Weak<UfsFactory>,
+    job_max_files: usize,
+    run_seq: Arc<AtomicCounter>,
+    shutdown_rx: watch::Receiver<bool>,
+    metrics: Option<&'static MasterMetrics>,
+}
+
+#[derive(Clone)]
+struct LoadJobSubmitContext {
+    jobs: JobStore,
+    master_fs: MasterFilesystem,
+    factory: Weak<UfsFactory>,
+    job_max_files: usize,
+    run_seq: Arc<AtomicCounter>,
+    load_job_sender: AsyncSender<QueuedLoadJobRequest>,
+    shutdown: Arc<AtomicBool>,
+    metrics: Option<&'static MasterMetrics>,
+}
+
+impl LoadJobWorkerContext {
+    fn create_runner(&self) -> Option<LoadJobRunner> {
+        self.factory.upgrade().map(|factory| {
+            LoadJobRunner::new(
+                self.jobs.clone(),
+                self.master_fs.clone(),
+                factory,
+                self.job_max_files,
+                self.run_seq.clone(),
+            )
+        })
+    }
+}
+
+impl LoadJobSubmitContext {
+    fn create_runner(&self) -> Option<LoadJobRunner> {
+        self.factory.upgrade().map(|factory| {
+            LoadJobRunner::new(
+                self.jobs.clone(),
+                self.master_fs.clone(),
+                factory,
+                self.job_max_files,
+                self.run_seq.clone(),
+            )
+        })
+    }
+
+    async fn forward_queued_load_job(&self, request: QueuedLoadJobRequest) {
+        let job_id = request.job_id.clone();
+        let run_id = request.queued.run_id;
+        if self.shutdown.load(Ordering::SeqCst) {
+            self.fail_queued_load_job(job_id, run_id, "load job manager is shutting down");
+            return;
+        }
+
+        let Some(runner) = self.create_runner() else {
+            self.fail_queued_load_job(job_id, run_id, "load job manager is shutting down");
+            return;
+        };
+        let validation = runner.validate_queued_source(&request.queued).await;
+        tokio::task::block_in_place(move || drop(runner));
+        match validation {
+            Ok(QueuedLoadJobValidation::Ready) => {}
+            Ok(QueuedLoadJobValidation::Failed) => {
+                self.finish_queued_load_job(true);
+                return;
+            }
+            Ok(QueuedLoadJobValidation::Stale) => {
+                self.finish_queued_load_job(false);
+                return;
+            }
+            Err(err) => {
+                warn!(
+                    "queued load job {} source validation failed: {}",
+                    job_id, err
+                );
+                self.finish_queued_load_job(true);
+                return;
+            }
+        }
+
+        if self.shutdown.load(Ordering::SeqCst) {
+            self.fail_queued_load_job(job_id, run_id, "load job manager is shutting down");
+            return;
+        }
+
+        if let Err(err) = self.load_job_sender.send(request).await {
+            self.fail_queued_load_job(job_id, run_id, format!("queue load job failed: {}", err));
+        }
+    }
+
+    fn fail_queued_load_job(&self, job_id: String, run_id: u64, message: impl Into<String>) {
+        let message = message.into();
+        warn!("queued load job {} skipped: {}", job_id, message);
+        self.jobs
+            .update_state_if_run(&job_id, run_id, JobTaskState::Failed, message);
+        if let Some(metrics) = self.metrics {
+            metrics.load_job_queue_len.dec();
+            metrics.load_job_failure_count.inc();
+        }
+    }
+
+    fn finish_queued_load_job(&self, failed: bool) {
+        if let Some(metrics) = self.metrics {
+            metrics.load_job_queue_len.dec();
+            if failed {
+                metrics.load_job_failure_count.inc();
+            }
+        }
+    }
+}
+
+/// Load job manager
 pub struct JobManager {
     rt: Arc<Runtime>,
+    // Soft-isolates load planning from the master RPC/Raft runtime. Process-level
+    // resources are still shared, so queue and concurrency limits remain required.
+    background_rt: Arc<Runtime>,
     jobs: JobStore,
     master_fs: MasterFilesystem,
     factory: Arc<UfsFactory>,
     mount_manager: Arc<MountManager>,
     job_life_ttl: Duration,
     job_cleanup_ttl: Duration,
+    failed_retry_interval: Duration,
     job_max_files: usize,
     run_seq: Arc<AtomicCounter>,
-    load_job_semaphore: Arc<Semaphore>,
+    submit_job_sender: AsyncSender<QueuedLoadJobRequest>,
+    shutdown: Arc<AtomicBool>,
+    shutdown_tx: watch::Sender<bool>,
+    metrics: Option<&'static MasterMetrics>,
 }
 
 impl JobManager {
@@ -55,20 +187,187 @@ impl JobManager {
         rt: Arc<Runtime>,
         conf: &ClusterConf,
     ) -> Self {
-        let factory = Arc::new(UfsFactory::with_rt(&conf.client, rt.clone()));
+        let background_rt = Arc::new(Runtime::new(
+            "master-load-job",
+            conf.job.master_load_job_runtime_threads,
+            conf.job.master_load_job_blocking_threads,
+        ));
+        let factory = Arc::new(UfsFactory::with_rt(&conf.client, background_rt.clone()));
+        let jobs = JobStore::new();
+        let run_seq = Arc::new(AtomicCounter::new(0));
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let metrics = Master::get_metrics().ok();
+        let (submit_job_sender, submit_job_receiver) =
+            AsyncChannel::new(conf.job.master_max_pending_load_job_submits).split();
+        let (load_job_sender, load_job_receiver) =
+            AsyncChannel::new(conf.job.master_max_background_load_jobs).split();
+        let load_job_worker_num = conf.job.master_max_concurrent_load_jobs;
+        let submit_worker_num = conf.job.master_load_job_runtime_threads;
+
+        Self::spawn_submit_workers(
+            background_rt.clone(),
+            submit_job_receiver,
+            submit_worker_num,
+            LoadJobSubmitContext {
+                jobs: jobs.clone(),
+                master_fs: master_fs.clone(),
+                factory: Arc::downgrade(&factory),
+                job_max_files: conf.job.job_max_files,
+                run_seq: run_seq.clone(),
+                load_job_sender: load_job_sender.clone(),
+                shutdown: shutdown.clone(),
+                metrics,
+            },
+        );
+
+        Self::spawn_load_job_workers(
+            background_rt.clone(),
+            load_job_receiver,
+            load_job_worker_num,
+            LoadJobWorkerContext {
+                jobs: jobs.clone(),
+                master_fs: master_fs.clone(),
+                factory: Arc::downgrade(&factory),
+                job_max_files: conf.job.job_max_files,
+                run_seq: run_seq.clone(),
+                shutdown_rx,
+                metrics,
+            },
+        );
 
         Self {
             rt,
-            jobs: JobStore::new(),
+            background_rt,
+            jobs,
             master_fs,
             factory,
             mount_manager,
             job_life_ttl: conf.job.job_life_ttl,
             job_cleanup_ttl: conf.job.job_cleanup_ttl,
+            failed_retry_interval: conf.job.master_failed_load_job_retry_interval,
             job_max_files: conf.job.job_max_files,
-            run_seq: Arc::new(AtomicCounter::new(0)),
-            load_job_semaphore: Arc::new(Semaphore::new(conf.job.master_max_concurrent_load_jobs)),
+            run_seq,
+            submit_job_sender,
+            shutdown,
+            shutdown_tx,
+            metrics,
         }
+    }
+
+    fn spawn_submit_workers(
+        rt: Arc<Runtime>,
+        receiver: AsyncReceiver<QueuedLoadJobRequest>,
+        workers: usize,
+        context: LoadJobSubmitContext,
+    ) {
+        let receiver = Arc::new(Mutex::new(receiver));
+
+        for _ in 0..workers {
+            let receiver = receiver.clone();
+            let context = context.clone();
+            rt.spawn(async move {
+                loop {
+                    let request = {
+                        let mut receiver = receiver.lock().await;
+                        receiver.recv().await
+                    };
+                    let Some(request) = request else {
+                        break;
+                    };
+                    context.forward_queued_load_job(request).await;
+                }
+            });
+        }
+    }
+
+    fn spawn_load_job_workers(
+        rt: Arc<Runtime>,
+        receiver: AsyncReceiver<QueuedLoadJobRequest>,
+        workers: usize,
+        context: LoadJobWorkerContext,
+    ) {
+        let receiver = Arc::new(Mutex::new(receiver));
+
+        for _ in 0..workers {
+            let receiver = receiver.clone();
+            let context = context.clone();
+            rt.spawn(async move {
+                let mut shutdown_rx = context.shutdown_rx.clone();
+                loop {
+                    let request = {
+                        let mut receiver = receiver.lock().await;
+                        if *shutdown_rx.borrow() {
+                            match receiver.try_recv() {
+                                Ok(Some(request)) => Some(request),
+                                Ok(None) => None,
+                                Err(err) => {
+                                    debug!("load job receiver closed during shutdown: {}", err);
+                                    None
+                                }
+                            }
+                        } else {
+                            tokio::select! {
+                                request = receiver.recv() => request,
+                                changed = shutdown_rx.changed() => {
+                                    if changed.is_err() {
+                                        None
+                                    } else {
+                                        match receiver.try_recv() {
+                                            Ok(Some(request)) => Some(request),
+                                            Ok(None) => None,
+                                            Err(err) => {
+                                                debug!("load job receiver closed during shutdown: {}", err);
+                                                None
+                                            }
+                                        }
+                                    }
+                                },
+                            }
+                        }
+                    };
+                    let Some(request) = request else {
+                        break;
+                    };
+                    let QueuedLoadJobRequest { job_id, queued } = request;
+                    if let Some(metrics) = context.metrics {
+                        metrics.load_job_queue_len.dec();
+                        metrics.load_job_running_num.inc();
+                    }
+                    match context.create_runner() {
+                        Some(runner) => {
+                            let result = runner.run_queued_load_job(queued).await;
+                            tokio::task::block_in_place(move || drop(runner));
+                            if let Err(err) = result {
+                                warn!("async load job {} failed: {}", job_id, err);
+                                if let Some(metrics) = context.metrics {
+                                    metrics.load_job_failure_count.inc();
+                                }
+                            }
+                        }
+                        None => {
+                            let message = "load job manager is shutting down";
+                            warn!("async load job {} skipped: {}", job_id, message);
+                            let _ =
+                                context
+                                    .jobs
+                                    .update_state(&job_id, JobTaskState::Failed, message);
+                            if let Some(metrics) = context.metrics {
+                                metrics.load_job_failure_count.inc();
+                            }
+                        }
+                    }
+                    if let Some(metrics) = context.metrics {
+                        metrics.load_job_running_num.dec();
+                    }
+                }
+            });
+        }
+    }
+
+    pub fn shutdown(&self) {
+        self.shutdown.store(true, Ordering::SeqCst);
+        let _ = self.shutdown_tx.send(true);
     }
 
     /// Start the job manager
@@ -164,15 +463,19 @@ impl JobManager {
         &self.rt
     }
 
-    /// See `LoadJobRunner::submit_load_task` for the concurrency contract: concurrent
-    /// submits for the same path while a load is running return the **existing** run’s
-    /// result; the new command’s options are not applied (first submitter wins).
-    pub async fn submit_load_job(&self, command: LoadJobCommand) -> FsResult<LoadJobResult> {
-        let source_path = Path::from_str(&command.source_path)?;
+    pub fn background_rt(&self) -> &Runtime {
+        &self.background_rt
+    }
 
-        // Check mount info for both UFS and CV paths
-        // - For UFS path: Import (UFS → Curvine)
-        // - For CV path: Export (Curvine → UFS), requires mount info to determine target UFS
+    /// See `LoadJobRunner::submit_load_task` for the concurrency contract: concurrent
+    /// submits for the same path while a load is running return the **existing** run's
+    /// result; the new command's options are not applied (first submitter wins).
+    pub async fn submit_load_job(&self, command: LoadJobCommand) -> FsResult<LoadJobResult> {
+        if self.shutdown.load(Ordering::SeqCst) {
+            return err_box!("load job manager is shutting down");
+        }
+
+        let source_path = Path::from_str(&command.source_path)?;
         let mnt = if let Some(mnt) = self.mount_manager.get_mount_info(&source_path)? {
             mnt
         } else {
@@ -180,35 +483,39 @@ impl JobManager {
         };
 
         let job_runner = self.create_runner();
-        let (res, queued) = job_runner.enqueue_load_job(command, mnt)?;
+        if let Some(res) = job_runner.running_job_result_for_command(&command, &mnt)? {
+            if let Some(metrics) = self.metrics {
+                metrics.load_job_duplicate_count.inc();
+            }
+            return Ok(res);
+        }
 
+        let prepared = match job_runner.admit_load_job(command, mnt, self.failed_retry_interval)? {
+            LoadJobPrepareResult::Done(result) => return Ok(result),
+            LoadJobPrepareResult::Ready(prepared) => prepared,
+        };
+
+        let channel_permit = match self.submit_job_sender.try_reserve()? {
+            Some(permit) => permit,
+            None => {
+                return Err(FsError::resource_exhausted(
+                    "master load job submit queue is full; retry later",
+                ))
+            }
+        };
+
+        let (res, queued) = job_runner.commit_prepared_load_job(prepared)?;
         if let Some(queued) = queued {
-            let runner = self.create_runner();
             let job_id = res.job_id.clone();
-            let semaphore = self.load_job_semaphore.clone();
-            let jobs = self.jobs.clone();
-            self.rt.spawn(async move {
-                let _permit = match semaphore.acquire_owned().await {
-                    Ok(permit) => permit,
-                    Err(err) => {
-                        warn!(
-                            "async load job {} failed to acquire permit: {}",
-                            job_id, err
-                        );
-                        jobs.update_state_if_run(
-                            &queued.job_id,
-                            queued.run_id,
-                            JobTaskState::Failed,
-                            format!("async load job failed to acquire permit: {}", err),
-                        );
-                        return;
-                    }
-                };
-
-                if let Err(err) = runner.run_queued_load_job(queued).await {
-                    warn!("async load job {} failed: {}", job_id, err);
-                }
-            });
+            let request = QueuedLoadJobRequest {
+                job_id: job_id.clone(),
+                queued,
+            };
+            if let Some(metrics) = self.metrics {
+                metrics.load_job_queue_len.inc();
+                metrics.load_job_enqueue_count.inc();
+            }
+            channel_permit.send(request);
         }
 
         Ok(res)
@@ -257,6 +564,10 @@ impl JobManager {
 
     pub fn jobs(&self) -> &JobStore {
         &self.jobs
+    }
+
+    pub fn master_fs(&self) -> &MasterFilesystem {
+        &self.master_fs
     }
 
     pub fn factory(&self) -> &Arc<UfsFactory> {

--- a/curvine-server/src/master/job/job_runner.rs
+++ b/curvine-server/src/master/job/job_runner.rs
@@ -33,7 +33,9 @@ use orpc::common::{ByteUnit, FastHashMap, FastHashSet, LocalTime};
 use orpc::err_box;
 use orpc::sync::AtomicCounter;
 use std::collections::LinkedList;
+use std::fmt::Display;
 use std::sync::Arc;
+use std::time::Duration;
 
 pub struct LoadJobRunner {
     jobs: JobStore,
@@ -54,8 +56,30 @@ struct PlannedLoadJob {
     total_size: i64,
 }
 
+#[derive(Clone, Copy)]
+enum CvSourceMode {
+    LoadUfsOnlyFromUfs,
+    ExportCurvineToUfs,
+}
+
+pub(crate) enum LoadJobPrepareResult {
+    Ready(Box<PreparedLoadJob>),
+    Done(LoadJobResult),
+}
+
+pub(crate) enum QueuedLoadJobValidation {
+    Ready,
+    Failed,
+    Stale,
+}
+
+pub(crate) struct PreparedLoadJob {
+    job_context: JobContext,
+}
+
 impl LoadJobRunner {
     const RUN_ID_SEQ_MOD: u64 = 1_000_000;
+    const SOURCE_NOT_FOUND_PREFIX: &'static str = "source file not found";
 
     pub fn new(
         jobs: JobStore,
@@ -88,9 +112,30 @@ impl LoadJobRunner {
         &self,
         command: &LoadJobCommand,
         mnt: &MountInfo,
+        cv_source_mode: CvSourceMode,
     ) -> FsResult<(JobContext, Path, Path)> {
-        let source_path = Path::from_str(&command.source_path)?;
-        let target_path = mnt.toggle_path(&source_path)?;
+        let command_source = Path::from_str(&command.source_path)?;
+        let load_cv_from_ufs = if !command_source.is_cv() {
+            false
+        } else {
+            match cv_source_mode {
+                CvSourceMode::LoadUfsOnlyFromUfs => {
+                    match self.master_fs.file_status(command_source.path()) {
+                        Ok(status) => status.storage_policy.ufs_only(),
+                        Err(FsError::FileNotFound(_)) => false,
+                        Err(err) => return Err(err),
+                    }
+                }
+                CvSourceMode::ExportCurvineToUfs => false,
+            }
+        };
+
+        let (source_path, target_path) = if load_cv_from_ufs {
+            (mnt.get_ufs_path(&command_source)?, command_source)
+        } else {
+            let target_path = mnt.toggle_path(&command_source)?;
+            (command_source, target_path)
+        };
         let job_id = CommonUtils::create_job_id(source_path.full_path());
         let run_id = self.next_run_id();
         let job_context = JobContext::with_conf(
@@ -121,6 +166,98 @@ impl LoadJobRunner {
                 None
             }
         })
+    }
+
+    fn reusable_job_result(
+        &self,
+        job_id: &str,
+        failed_retry_interval: Duration,
+    ) -> Option<LoadJobResult> {
+        self.jobs.get(job_id).and_then(|exist_job| {
+            let state: JobTaskState = exist_job.state.state();
+            if state.is_running() {
+                debug!(
+                    "job {} already running during admission (state={:?})",
+                    job_id, state
+                );
+                return Some(LoadJobResult::with_state(&exist_job.info, state));
+            }
+            if let Some(result) =
+                self.reusable_source_not_found_result(&exist_job, failed_retry_interval)
+            {
+                debug!(
+                    "job {} reuses recent source-not-found failure during retry interval",
+                    job_id
+                );
+                return Some(result);
+            }
+            None
+        })
+    }
+
+    fn reusable_source_not_found_result(
+        &self,
+        job: &JobContext,
+        retry_interval: Duration,
+    ) -> Option<LoadJobResult> {
+        let state: JobTaskState = job.state.state();
+        if state != JobTaskState::Failed {
+            return None;
+        }
+        if !job
+            .progress
+            .message
+            .starts_with(Self::SOURCE_NOT_FOUND_PREFIX)
+        {
+            return None;
+        }
+        let update_time = job.progress.update_time;
+        if update_time <= 0 {
+            return None;
+        }
+        let now = LocalTime::mills() as i64;
+        let retry_interval_ms = retry_interval.as_millis() as i64;
+        if retry_interval_ms > 0 && now.saturating_sub(update_time) <= retry_interval_ms {
+            Some(LoadJobResult::with_state(&job.info, state))
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn running_job_result_for_command(
+        &self,
+        command: &LoadJobCommand,
+        mnt: &MountInfo,
+    ) -> FsResult<Option<LoadJobResult>> {
+        let (_, source_path, _) =
+            self.build_job_context(command, mnt, CvSourceMode::LoadUfsOnlyFromUfs)?;
+        let job_id = CommonUtils::create_job_id(source_path.full_path());
+        Ok(self.running_job_result(&job_id))
+    }
+
+    pub(crate) fn admit_load_job(
+        &self,
+        command: LoadJobCommand,
+        mnt: MountInfo,
+        failed_retry_interval: Duration,
+    ) -> FsResult<LoadJobPrepareResult> {
+        let (job_context, source_path, target_path) =
+            self.build_job_context(&command, &mnt, CvSourceMode::LoadUfsOnlyFromUfs)?;
+        let job_id = job_context.info.job_id.clone();
+
+        if let Some(result) = self.reusable_job_result(&job_id, failed_retry_interval) {
+            return Ok(LoadJobPrepareResult::Done(result));
+        }
+
+        debug!(
+            "admitted load job {}: {} -> {}",
+            job_id,
+            source_path.full_path(),
+            target_path.full_path()
+        );
+        Ok(LoadJobPrepareResult::Ready(Box::new(PreparedLoadJob {
+            job_context,
+        })))
     }
 
     async fn check_already_loaded(
@@ -156,14 +293,83 @@ impl LoadJobRunner {
         Ok(cv_status.cv_valid(Some(&source_status)))
     }
 
-    pub(crate) fn enqueue_load_job(
+    async fn check_source_root_exists(&self, source_path: &Path, mnt: &MountInfo) -> FsResult<()> {
+        if source_path.is_cv() {
+            self.master_fs.file_status(source_path.path())?;
+        } else {
+            let ufs = self.factory.get_ufs(mnt)?;
+            ufs.get_status(source_path).await?;
+        }
+        Ok(())
+    }
+
+    fn fail_source_not_found(
         &self,
-        command: LoadJobCommand,
-        mnt: MountInfo,
+        queued: &QueuedLoadJob,
+        source_path: &Path,
+        err: impl Display,
+    ) -> bool {
+        self.jobs.update_state_if_run(
+            &queued.job_id,
+            queued.run_id,
+            JobTaskState::Failed,
+            format!(
+                "{}: {} ({})",
+                Self::SOURCE_NOT_FOUND_PREFIX,
+                source_path.full_path(),
+                err
+            ),
+        )
+    }
+
+    fn fail_source_check(&self, queued: &QueuedLoadJob, err: impl Display) -> bool {
+        self.jobs.update_state_if_run(
+            &queued.job_id,
+            queued.run_id,
+            JobTaskState::Failed,
+            format!("check source file failed: {}", err),
+        )
+    }
+
+    pub(crate) async fn validate_queued_source(
+        &self,
+        queued: &QueuedLoadJob,
+    ) -> FsResult<QueuedLoadJobValidation> {
+        let job_info = match self.current_job_info(queued) {
+            Some(job_info) => job_info,
+            None => return Ok(QueuedLoadJobValidation::Stale),
+        };
+        let source_path = Path::from_str(&job_info.source_path)?;
+        let mnt = job_info.mount_info;
+
+        match self.check_source_root_exists(&source_path, &mnt).await {
+            Ok(()) => Ok(QueuedLoadJobValidation::Ready),
+            Err(FsError::FileNotFound(err)) => {
+                if self.fail_source_not_found(queued, &source_path, err) {
+                    Ok(QueuedLoadJobValidation::Failed)
+                } else {
+                    Ok(QueuedLoadJobValidation::Stale)
+                }
+            }
+            Err(err) => {
+                if self.fail_source_check(queued, &err) {
+                    Err(err)
+                } else {
+                    Ok(QueuedLoadJobValidation::Stale)
+                }
+            }
+        }
+    }
+
+    pub(crate) fn commit_prepared_load_job(
+        &self,
+        prepared: Box<PreparedLoadJob>,
     ) -> FsResult<(LoadJobResult, Option<QueuedLoadJob>)> {
-        let (job_context, source_path, target_path) = self.build_job_context(&command, &mnt)?;
+        let PreparedLoadJob { job_context } = *prepared;
         let job_id = job_context.info.job_id.clone();
         let run_id = job_context.run_id;
+        let source_path = job_context.info.source_path.clone();
+        let target_path = job_context.info.target_path.clone();
 
         match self.jobs.entry(job_id.clone()) {
             Entry::Occupied(mut e) => {
@@ -171,7 +377,7 @@ impl LoadJobRunner {
                 if state.is_running() {
                     let existing = e.get();
                     debug!(
-                        "job {} already running during enqueue (state={:?})",
+                        "job {} already running during commit (state={:?})",
                         job_id, state
                     );
                     return Ok((LoadJobResult::with_state(&existing.info, state), None));
@@ -190,9 +396,7 @@ impl LoadJobRunner {
 
         debug!(
             "queued load job {}: {} -> {}",
-            job_id,
-            source_path.full_path(),
-            target_path.full_path()
+            job_id, source_path, target_path
         );
 
         let job = match self.jobs.get(&job_id) {
@@ -205,7 +409,7 @@ impl LoadJobRunner {
         ))
     }
 
-    /// Submits a load job for the given source path (and mount).
+    /// Submits a load/import job for the given source path (and mount).
     ///
     /// **Concurrency:** The job id is derived from the source path. If two clients
     /// submit for the same path while a job is already **running**, the call
@@ -219,7 +423,32 @@ impl LoadJobRunner {
         command: LoadJobCommand,
         mnt: MountInfo,
     ) -> FsResult<LoadJobResult> {
-        let (mut job_context, source_path, target_path) = self.build_job_context(&command, &mnt)?;
+        self.submit_direct_task(command, mnt, CvSourceMode::LoadUfsOnlyFromUfs, "load")
+            .await
+    }
+
+    /// Submits a durable export job used by fs_mode journal replay.
+    ///
+    /// CV source paths stay CV sources here. This preserves the journal contract:
+    /// committed Curvine data is copied back to the mounted UFS.
+    pub async fn submit_export_task(
+        &self,
+        command: LoadJobCommand,
+        mnt: MountInfo,
+    ) -> FsResult<LoadJobResult> {
+        self.submit_direct_task(command, mnt, CvSourceMode::ExportCurvineToUfs, "export")
+            .await
+    }
+
+    async fn submit_direct_task(
+        &self,
+        command: LoadJobCommand,
+        mnt: MountInfo,
+        cv_source_mode: CvSourceMode,
+        job_kind: &str,
+    ) -> FsResult<LoadJobResult> {
+        let (mut job_context, source_path, target_path) =
+            self.build_job_context(&command, &mnt, cv_source_mode)?;
         let job_id = job_context.info.job_id.clone();
         let run_id = job_context.run_id;
 
@@ -233,7 +462,8 @@ impl LoadJobRunner {
             .await?
         {
             info!(
-                "skip load job {}: source_path {} already loaded or in progress",
+                "skip {} job {}: source_path {} already loaded or in progress",
+                job_kind,
                 job_id,
                 source_path.full_path()
             );
@@ -244,7 +474,8 @@ impl LoadJobRunner {
         }
 
         debug!(
-            "submitting load job {}: {} -> {}",
+            "submitting {} job {}: {} -> {}",
+            job_kind,
             job_id,
             source_path.full_path(),
             target_path.full_path()
@@ -256,7 +487,8 @@ impl LoadJobRunner {
         let total_size = planned.total_size;
         if planned.tasks.is_empty() {
             info!(
-                "load job {} has no tasks: {} -> {}",
+                "{} job {} has no tasks: {} -> {}",
+                job_kind,
                 job_id,
                 source_path.full_path(),
                 target_path.full_path()
@@ -272,7 +504,8 @@ impl LoadJobRunner {
         }
 
         info!(
-            "load job {} submitted: {} -> {}, tasks {}, total_size {}",
+            "{} job {} submitted: {} -> {}, tasks {}, total_size {}",
+            job_kind,
             job_id,
             source_path.full_path(),
             target_path.full_path(),
@@ -285,7 +518,7 @@ impl LoadJobRunner {
         // Install / replace the ctx into the store atomically. We branch into:
         //   - Vacant: first submitter, install and dispatch.
         //   - Occupied + running: another submitter won the race; return that job’s
-        //     state (this request’s command is not applied—see `submit_load_task` doc).
+        //     state (this request's command options are not applied).
         //   - Occupied + terminal: previous run finished/failed/canceled and
         //     hasn't been cleaned up yet. Replace with the new ctx and dispatch.
         match self.jobs.entry(job_id.clone()) {
@@ -312,7 +545,7 @@ impl LoadJobRunner {
         }
 
         if let Err(err) = self.submit_all_task(tasks).await {
-            warn!("dispatch load job {} failed: {}", job_id, err);
+            warn!("dispatch {} job {} failed: {}", job_kind, job_id, err);
             // @todo Cancel sub-tasks that may have already been dispatched.
             if let Err(update_err) = self.jobs.update_state(
                 &job_id,
@@ -320,8 +553,8 @@ impl LoadJobRunner {
                 format!("dispatch failed: {}", err),
             ) {
                 error!(
-                    "failed to mark load job {} as failed after dispatch error: {}",
-                    job_id, update_err
+                    "failed to mark {} job {} as failed after dispatch error: {}",
+                    job_kind, job_id, update_err
                 );
             }
             return Err(err);
@@ -357,6 +590,10 @@ impl LoadJobRunner {
             .await
         {
             Ok(already_loaded) => already_loaded,
+            Err(FsError::FileNotFound(err)) => {
+                self.fail_source_not_found(&queued, &source_path, &err);
+                return Err(FsError::FileNotFound(err));
+            }
             Err(err) => {
                 self.jobs.update_state_if_run(
                     &queued.job_id,
@@ -388,6 +625,10 @@ impl LoadJobRunner {
             .await
         {
             Ok(planned) => planned,
+            Err(FsError::FileNotFound(err)) => {
+                self.fail_source_not_found(&queued, &source_path, &err);
+                return Err(FsError::FileNotFound(err));
+            }
             Err(err) => {
                 self.jobs.update_state_if_run(
                     &queued.job_id,

--- a/curvine-server/src/master/journal/ufs_loader.rs
+++ b/curvine-server/src/master/journal/ufs_loader.rs
@@ -80,17 +80,17 @@ impl UfsLoader {
         }
     }
 
-    pub async fn submit_load_task(&self, path: &Path, mnt: &MountValue) -> FsResult<()> {
+    pub async fn submit_export_task(&self, path: &Path, mnt: &MountValue) -> FsResult<()> {
         let command = LoadJobCommand::builder(path.clone_uri()).build();
         let runner = self.job_manager.create_runner();
-        let res = match runner.submit_load_task(command, mnt.info.clone()).await {
+        let res = match runner.submit_export_task(command, mnt.info.clone()).await {
             Ok(res) => res,
             Err(e) => {
                 return if matches!(e, FsError::FileNotFound(_)) {
-                    info!("file {} not found, skipping load job", path.full_path());
+                    info!("file {} not found, skipping export job", path.full_path());
                     Ok(())
                 } else {
-                    err_box!("load job failed: {}", e)
+                    err_box!("export job failed: {}", e)
                 };
             }
         };
@@ -107,7 +107,7 @@ impl UfsLoader {
             Ok(())
         } else {
             err_box!(
-                "load job failed: {} {}",
+                "export job failed: {} {}",
                 status.state,
                 status.progress.message
             )
@@ -141,7 +141,7 @@ impl UfsLoader {
 
         let path = Path::from_str(&e.path)?;
         if let Some((_, mnt)) = self.get_mnt(&path)? {
-            self.submit_load_task(&path, &mnt).await?;
+            self.submit_export_task(&path, &mnt).await?;
             Ok(())
         } else {
             Ok(())
@@ -154,13 +154,13 @@ impl UfsLoader {
         if let Some((src_ufs_path, mnt)) = self.get_mnt(&src)? {
             if !mnt.ufs.exists(&src_ufs_path).await? {
                 warn!(
-                    "rename: src file not exists: {}, loading dst {}",
+                    "rename: src file not exists: {}, exporting dst {}",
                     src_ufs_path,
                     dst.full_path()
                 );
                 if let Some((_, dst_mnt)) = self.get_mnt(&dst)? {
                     // Keep journal apply aligned with fs_mode's durable export contract.
-                    self.submit_load_task(&dst, &dst_mnt).await?;
+                    self.submit_export_task(&dst, &dst_mnt).await?;
                 }
                 return Ok(());
             }
@@ -181,7 +181,7 @@ impl UfsLoader {
                 Ok(())
             } else {
                 mnt.ufs.delete(&src_ufs_path, true).await?;
-                self.submit_load_task(&dst, &mnt).await?;
+                self.submit_export_task(&dst, &mnt).await?;
                 Ok(())
             }
         } else {

--- a/curvine-server/src/master/master_handler.rs
+++ b/curvine-server/src/master/master_handler.rs
@@ -24,16 +24,18 @@ use curvine_common::fs::Path;
 use curvine_common::fs::RpcCode;
 use curvine_common::proto::*;
 use curvine_common::state::{
-    CreateFileOpts, FileBlocks, FileStatus, FreeResult, HeartbeatStatus, OpenFlags, RenameFlags,
+    CreateFileOpts, DeleteBlockCmd, FileBlocks, FileStatus, FreeResult, HeartbeatStatus,
+    ListOptions, MasterInfo, OpenFlags, RenameFlags, WorkerCommand,
 };
 use curvine_common::utils::ProtoUtils;
 use curvine_common::FsResult;
-use log::error;
 use orpc::err_box;
 use orpc::handler::{FrameBuf, MessageHandler};
 use orpc::io::net::ConnState;
 use orpc::message::Message;
+use orpc::runtime::GroupExecutor;
 use std::sync::Arc;
+use tokio::sync::{oneshot, Semaphore};
 
 pub struct MasterHandler {
     pub(crate) fs: MasterFilesystem,
@@ -43,6 +45,13 @@ pub struct MasterHandler {
     pub(crate) conn_state: Option<ConnState>,
     pub(crate) job_handler: JobHandler,
     pub(crate) mount_manager: Arc<MountManager>,
+    pub(crate) heartbeat_rpc_executor: Arc<GroupExecutor>,
+    pub(crate) block_report_rpc_executor: Arc<GroupExecutor>,
+    pub(crate) block_report_reconcile_executor: Arc<GroupExecutor>,
+    pub(crate) control_rpc_executor: Arc<GroupExecutor>,
+    pub(crate) list_rpc_executor: Arc<GroupExecutor>,
+    pub(crate) get_block_locations_rpc_executor: Arc<GroupExecutor>,
+    pub(crate) get_block_locations_limiter: Arc<Semaphore>,
     pub(crate) replication_handler: Option<MasterReplicationHandler>,
     pub(crate) buf: FrameBuf,
 }
@@ -56,6 +65,13 @@ impl MasterHandler {
         conn_state: Option<ConnState>,
         mount_manager: Arc<MountManager>,
         job_handler: JobHandler,
+        heartbeat_rpc_executor: Arc<GroupExecutor>,
+        block_report_rpc_executor: Arc<GroupExecutor>,
+        block_report_reconcile_executor: Arc<GroupExecutor>,
+        control_rpc_executor: Arc<GroupExecutor>,
+        list_rpc_executor: Arc<GroupExecutor>,
+        get_block_locations_rpc_executor: Arc<GroupExecutor>,
+        get_block_locations_limiter: Arc<Semaphore>,
         replication_manager: Arc<MasterReplicationManager>,
         metrics: &'static MasterMetrics,
     ) -> Self {
@@ -67,6 +83,13 @@ impl MasterHandler {
             conn_state,
             mount_manager,
             job_handler,
+            heartbeat_rpc_executor,
+            block_report_rpc_executor,
+            block_report_reconcile_executor,
+            control_rpc_executor,
+            list_rpc_executor,
+            get_block_locations_rpc_executor,
+            get_block_locations_limiter,
             replication_handler: Some(MasterReplicationHandler::new(replication_manager)),
             buf: FrameBuf::new(conf.master.buffer_size),
         }
@@ -276,6 +299,10 @@ impl MasterHandler {
         ctx.response_buf(rep_header, &mut self.buf)
     }
 
+    fn process_list_status(fs: MasterFilesystem, path: String) -> FsResult<Vec<FileStatus>> {
+        fs.list_status(&path)
+    }
+
     // The add block internally determines whether it is a retry request.
     pub fn add_block(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let req: AddBlockRequest = ctx.parse_header()?;
@@ -417,12 +444,24 @@ impl MasterHandler {
     pub fn get_block_locations(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let req: GetBlockLocationsRequest = ctx.parse_header()?;
         ctx.set_audit(Some(req.path.to_string()), None);
+        let _permit = self
+            .get_block_locations_limiter
+            .try_acquire()
+            .map_err(|_| {
+                FsError::resource_exhausted(
+                    "master GetBlockLocations concurrency limit exceeded; retry later",
+                )
+            })?;
 
         let blocks = self.fs.get_block_locations(req.path)?;
         let rep_header = GetBlockLocationsResponse {
             blocks: ProtoUtils::file_blocks_to_pb(blocks),
         };
         ctx.response_buf(rep_header, &mut self.buf)
+    }
+
+    fn process_get_block_locations(fs: MasterFilesystem, path: String) -> FsResult<FileBlocks> {
+        fs.get_block_locations(path)
     }
 
     pub fn get_master_info(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
@@ -433,24 +472,13 @@ impl MasterHandler {
         ctx.response_buf(rep_header, &mut self.buf)
     }
 
+    fn process_get_master_info(fs: MasterFilesystem) -> FsResult<MasterInfo> {
+        fs.master_info()
+    }
+
     pub fn worker_heartbeat(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let header: WorkerHeartbeatRequest = ctx.parse_header()?;
-        let status = HeartbeatStatus::from(header.status);
-        let address = ProtoUtils::worker_address_from_pb(&header.address);
-        if matches!(status, HeartbeatStatus::Start) {
-            self.fs.reset_full_block_report(address.worker_id);
-        }
-
-        let mut wm = self.fs.worker_manager.write();
-
-        let cmds = wm.heartbeat(
-            &header.cluster_id,
-            status,
-            address,
-            ProtoUtils::storage_info_list_from_pb(header.storages),
-        )?;
-        drop(wm);
-
+        let cmds = Self::process_worker_heartbeat(self.fs.clone(), header)?;
         let rep_header = WorkerHeartbeatResponse {
             cmds: ProtoUtils::worker_cmd_to_pb(cmds),
         };
@@ -459,25 +487,73 @@ impl MasterHandler {
 
     pub fn block_report(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let header: BlockReportListRequest = ctx.parse_header()?;
-        let list = ProtoUtils::block_report_list_from_pb(header);
-        let worker_id = list.worker_id;
-        let stale_block_ids = self.fs.block_report(list)?;
-        let stale_block_count = stale_block_ids.len();
-        if stale_block_count > 0 {
-            if let Some(replication_handler) = &self.replication_handler {
-                if let Err(e) =
-                    replication_handler.report_under_replicated_blocks(worker_id, stale_block_ids)
-                {
-                    error!(
-                        "Errors on reporting under-replicated {} blocks from full block report reconciliation. err: {:?}",
-                        stale_block_count, e
-                    );
-                }
-            }
+        let cmds = Self::process_block_report(
+            self.fs.clone(),
+            self.block_report_reconcile_executor.clone(),
+            self.replication_handler.clone(),
+            header,
+        )?;
+        let rep_header = BlockReportListResponse {
+            cmds: ProtoUtils::worker_cmd_to_pb(cmds),
+        };
+        ctx.response_buf(rep_header, &mut self.buf)
+    }
+
+    fn process_worker_heartbeat(
+        fs: MasterFilesystem,
+        header: WorkerHeartbeatRequest,
+    ) -> FsResult<Vec<WorkerCommand>> {
+        let status = HeartbeatStatus::from(header.status);
+        let address = ProtoUtils::worker_address_from_pb(&header.address);
+        if matches!(status, HeartbeatStatus::Start) {
+            fs.reset_full_block_report(address.worker_id);
         }
 
-        let rep_header = BlockReportListResponse::default();
-        ctx.response_buf(rep_header, &mut self.buf)
+        let mut wm = fs.worker_manager.write();
+        let cmds = wm.heartbeat(
+            &header.cluster_id,
+            status,
+            address,
+            ProtoUtils::storage_info_list_from_pb(header.storages),
+        )?;
+        Ok(cmds)
+    }
+
+    fn process_block_report(
+        fs: MasterFilesystem,
+        reconcile_executor: Arc<GroupExecutor>,
+        replication_handler: Option<MasterReplicationHandler>,
+        header: BlockReportListRequest,
+    ) -> FsResult<Vec<WorkerCommand>> {
+        let list = ProtoUtils::block_report_list_from_pb(header);
+        let result = fs.block_report(list)?;
+        if let Some(reported_blocks) = result.full_reported_blocks {
+            fs.submit_full_block_reconcile(
+                reconcile_executor,
+                result.worker_id,
+                reported_blocks,
+                replication_handler,
+            )?;
+        }
+        if result.delete_blocks.is_empty() {
+            Ok(Vec::new())
+        } else {
+            Ok(vec![WorkerCommand::DeleteBlock(DeleteBlockCmd {
+                blocks: result.delete_blocks,
+            })])
+        }
+    }
+
+    async fn run_master_rpc_task<T, F>(executor: Arc<GroupExecutor>, task: F) -> FsResult<T>
+    where
+        T: Send + 'static,
+        F: FnOnce() -> FsResult<T> + Send + 'static,
+    {
+        let (tx, rx) = oneshot::channel();
+        executor.try_spawn(move || {
+            let _ = tx.send(task());
+        })?;
+        rx.await?
     }
 
     fn client_ip(&self) -> &str {
@@ -676,6 +752,115 @@ impl MasterHandler {
         let rep_header = ListOptionsResponse { statuses: res };
         ctx.response_buf(rep_header, &mut self.buf)
     }
+
+    fn process_list_options(
+        fs: MasterFilesystem,
+        path: String,
+        opts: ListOptions,
+    ) -> FsResult<Vec<FileStatus>> {
+        fs.list_options(&path, opts)
+    }
+
+    async fn async_get_block_locations(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+        let req: GetBlockLocationsRequest = ctx.parse_header()?;
+        ctx.set_audit(Some(req.path.to_string()), None);
+        let permit = self
+            .get_block_locations_limiter
+            .clone()
+            .try_acquire_owned()
+            .map_err(|_| {
+                FsError::resource_exhausted(
+                    "master GetBlockLocations concurrency limit exceeded; retry later",
+                )
+            })?;
+        let fs = self.fs.clone();
+        let blocks =
+            Self::run_master_rpc_task(self.get_block_locations_rpc_executor.clone(), move || {
+                let _permit = permit;
+                Self::process_get_block_locations(fs, req.path)
+            })
+            .await?;
+        let rep_header = GetBlockLocationsResponse {
+            blocks: ProtoUtils::file_blocks_to_pb(blocks),
+        };
+        ctx.response_buf(rep_header, &mut self.buf)
+    }
+
+    async fn async_get_master_info(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+        let _: GetMasterInfoRequest = ctx.parse_header()?;
+        let fs = self.fs.clone();
+        let info = Self::run_master_rpc_task(self.control_rpc_executor.clone(), move || {
+            Self::process_get_master_info(fs)
+        })
+        .await?;
+        let rep_header = ProtoUtils::master_info_to_pb(info);
+        ctx.response_buf(rep_header, &mut self.buf)
+    }
+
+    async fn async_list_status(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+        let header: ListStatusRequest = ctx.parse_header()?;
+        ctx.set_audit(Some(header.path.to_string()), None);
+        let fs = self.fs.clone();
+        let list = Self::run_master_rpc_task(self.list_rpc_executor.clone(), move || {
+            Self::process_list_status(fs, header.path)
+        })
+        .await?;
+        let statuses = list
+            .into_iter()
+            .map(ProtoUtils::file_status_to_pb)
+            .collect();
+        ctx.response_buf(ListStatusResponse { statuses }, &mut self.buf)
+    }
+
+    async fn async_list_options(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+        let header: ListOptionsRequest = ctx.parse_header()?;
+        if header.options.limit.unwrap_or(0) < 0 {
+            return err_box!("list options limit must be greater than 0");
+        }
+        let opts = ProtoUtils::list_options_from_pb(header.options);
+        let audit_path = format!("{}[{}]", header.path, opts);
+        ctx.set_audit(Some(audit_path), None);
+        let fs = self.fs.clone();
+        let list = Self::run_master_rpc_task(self.list_rpc_executor.clone(), move || {
+            Self::process_list_options(fs, header.path, opts)
+        })
+        .await?;
+        let statuses = list
+            .into_iter()
+            .map(ProtoUtils::file_status_to_pb)
+            .collect();
+        ctx.response_buf(ListOptionsResponse { statuses }, &mut self.buf)
+    }
+
+    async fn async_worker_heartbeat(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+        let header: WorkerHeartbeatRequest = ctx.parse_header()?;
+        let fs = self.fs.clone();
+        let cmds = Self::run_master_rpc_task(self.heartbeat_rpc_executor.clone(), move || {
+            Self::process_worker_heartbeat(fs, header)
+        })
+        .await?;
+        let rep_header = WorkerHeartbeatResponse {
+            cmds: ProtoUtils::worker_cmd_to_pb(cmds),
+        };
+        ctx.response_buf(rep_header, &mut self.buf)
+    }
+
+    async fn async_worker_block_report(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+        let header: BlockReportListRequest = ctx.parse_header()?;
+        let fs = self.fs.clone();
+        let reconcile_executor = self.block_report_reconcile_executor.clone();
+        let replication_handler = self.replication_handler.clone();
+        let cmds = Self::run_master_rpc_task(self.block_report_rpc_executor.clone(), move || {
+            Self::process_block_report(fs, reconcile_executor, replication_handler, header)
+        })
+        .await?;
+        ctx.response_buf(
+            BlockReportListResponse {
+                cmds: ProtoUtils::worker_cmd_to_pb(cmds),
+            },
+            &mut self.buf,
+        )
+    }
 }
 
 impl MessageHandler for MasterHandler {
@@ -685,7 +870,16 @@ impl MessageHandler for MasterHandler {
         let code = RpcCode::from(msg.code());
         !matches!(
             code,
-            RpcCode::SubmitJob | RpcCode::GetJobStatus | RpcCode::CancelJob | RpcCode::ReportTask
+            RpcCode::SubmitJob
+                | RpcCode::GetJobStatus
+                | RpcCode::CancelJob
+                | RpcCode::ReportTask
+                | RpcCode::GetBlockLocations
+                | RpcCode::GetMasterInfo
+                | RpcCode::ListStatus
+                | RpcCode::ListOptions
+                | RpcCode::WorkerHeartbeat
+                | RpcCode::WorkerBlockReport
         )
     }
 
@@ -780,7 +974,7 @@ impl MessageHandler for MasterHandler {
 
         // Check whether the master is active
         if !self.fs.master_monitor.is_active() {
-            return Err(FsError::not_leader_master(ctx.code, self.client_ip()));
+            return Ok(msg.error_ext(&FsError::not_leader_master(ctx.code, self.client_ip())));
         }
 
         let res = match code {
@@ -788,9 +982,30 @@ impl MessageHandler for MasterHandler {
             RpcCode::GetJobStatus => self.job_handler.get_load_status(ctx, &mut self.buf),
             RpcCode::CancelJob => self.job_handler.cancel_job(ctx, &mut self.buf).await,
             RpcCode::ReportTask => self.job_handler.task_report(ctx, &mut self.buf),
+            RpcCode::GetBlockLocations => self.async_get_block_locations(ctx).await,
+            RpcCode::GetMasterInfo => self.async_get_master_info(ctx).await,
+            RpcCode::ListStatus => self.async_list_status(ctx).await,
+            RpcCode::ListOptions => self.async_list_options(ctx).await,
+            RpcCode::WorkerHeartbeat => self.async_worker_heartbeat(ctx).await,
+            RpcCode::WorkerBlockReport => self.async_worker_block_report(ctx).await,
 
             v => err_box!("unsupported operation {:?}", v),
         };
+
+        if ctx.code == RpcCode::GetBlockLocations {
+            let used_us = ctx.spent.used_us();
+            if self.audit_logging_enabled {
+                ctx.audit_log(&res, used_us, self.conn_state.as_ref());
+            }
+
+            let code_label = format!("{:?}", ctx.code);
+            self.metrics.rpc_request_total_time.inc_by(used_us as i64);
+            self.metrics.rpc_request_total_count.inc();
+            self.metrics
+                .operation_duration
+                .with_label_values(&[&code_label])
+                .observe(used_us as f64);
+        }
 
         match res {
             Ok(v) => Ok(v),

--- a/curvine-server/src/master/master_metrics.rs
+++ b/curvine-server/src/master/master_metrics.rs
@@ -67,6 +67,12 @@ pub struct MasterMetrics {
     pub(crate) ttl_bucket_len: Gauge,
     pub(crate) ttl_total_inodes: Gauge,
     pub(crate) ttl_skipped_inodes: Counter,
+
+    pub(crate) load_job_queue_len: Gauge,
+    pub(crate) load_job_running_num: Gauge,
+    pub(crate) load_job_enqueue_count: Counter,
+    pub(crate) load_job_duplicate_count: Counter,
+    pub(crate) load_job_failure_count: Counter,
 }
 
 impl MasterMetrics {
@@ -160,6 +166,26 @@ impl MasterMetrics {
             ttl_skipped_inodes: m::new_counter(
                 "ttl_skipped_inodes",
                 "Total number of inodes skipped while updating TTL buckets",
+            )?,
+            load_job_queue_len: m::new_gauge(
+                "load_job_queue_len",
+                "Number of master load jobs waiting in the FIFO queue",
+            )?,
+            load_job_running_num: m::new_gauge(
+                "load_job_running_num",
+                "Number of master load jobs currently being planned",
+            )?,
+            load_job_enqueue_count: m::new_counter(
+                "load_job_enqueue_count",
+                "Total number of master load jobs enqueued",
+            )?,
+            load_job_duplicate_count: m::new_counter(
+                "load_job_duplicate_count",
+                "Total number of duplicate master load job submissions",
+            )?,
+            load_job_failure_count: m::new_counter(
+                "load_job_failure_count",
+                "Total number of master load jobs that failed in background planning",
             )?,
         };
 

--- a/curvine-server/src/master/master_server.rs
+++ b/curvine-server/src/master/master_server.rs
@@ -22,9 +22,10 @@ use log::error;
 use orpc::common::{LocalTime, Logger};
 use orpc::handler::HandlerService;
 use orpc::io::net::ConnState;
-use orpc::runtime::{RpcRuntime, Runtime};
+use orpc::runtime::{GroupExecutor, RpcRuntime, Runtime};
 use orpc::server::{RpcServer, ServerStateListener};
 use orpc::{err_box, CommonResult};
+use tokio::sync::Semaphore;
 
 use crate::master::fs::{FsRetryCache, MasterActor, MasterFilesystem};
 use crate::master::journal::JournalSystem;
@@ -44,6 +45,13 @@ pub struct MasterService {
     mount_manager: Arc<MountManager>,
     job_manager: Arc<JobManager>,
     rt: Arc<Runtime>,
+    heartbeat_rpc_executor: Arc<GroupExecutor>,
+    block_report_rpc_executor: Arc<GroupExecutor>,
+    block_report_reconcile_executor: Arc<GroupExecutor>,
+    control_rpc_executor: Arc<GroupExecutor>,
+    list_rpc_executor: Arc<GroupExecutor>,
+    get_block_locations_rpc_executor: Arc<GroupExecutor>,
+    get_block_locations_limiter: Arc<Semaphore>,
     replication_manager: Arc<MasterReplicationManager>,
     metrics: &'static MasterMetrics,
 }
@@ -57,6 +65,13 @@ impl MasterService {
         mount_manager: Arc<MountManager>,
         job_manager: Arc<JobManager>,
         rt: Arc<Runtime>,
+        heartbeat_rpc_executor: Arc<GroupExecutor>,
+        block_report_rpc_executor: Arc<GroupExecutor>,
+        block_report_reconcile_executor: Arc<GroupExecutor>,
+        control_rpc_executor: Arc<GroupExecutor>,
+        list_rpc_executor: Arc<GroupExecutor>,
+        get_block_locations_rpc_executor: Arc<GroupExecutor>,
+        get_block_locations_limiter: Arc<Semaphore>,
         replication_manager: Arc<MasterReplicationManager>,
         metrics: &'static MasterMetrics,
     ) -> Self {
@@ -67,6 +82,13 @@ impl MasterService {
             mount_manager,
             job_manager,
             rt,
+            heartbeat_rpc_executor,
+            block_report_rpc_executor,
+            block_report_reconcile_executor,
+            control_rpc_executor,
+            list_rpc_executor,
+            get_block_locations_rpc_executor,
+            get_block_locations_limiter,
             replication_manager,
             metrics,
         }
@@ -104,6 +126,13 @@ impl HandlerService for MasterService {
             client_state,
             self.mount_manager.clone(),
             JobHandler::new(self.job_manager.clone()),
+            self.heartbeat_rpc_executor.clone(),
+            self.block_report_rpc_executor.clone(),
+            self.block_report_reconcile_executor.clone(),
+            self.control_rpc_executor.clone(),
+            self.list_rpc_executor.clone(),
+            self.get_block_locations_rpc_executor.clone(),
+            self.get_block_locations_limiter.clone(),
             self.replication_manager.clone(),
             self.metrics,
         )
@@ -149,6 +178,21 @@ impl Master {
         let job_manager = journal_system.job_manager();
 
         let rt = Arc::new(conf.master_server_conf().create_runtime());
+        let heartbeat_rpc_executor = Arc::new(GroupExecutor::new("master-heartbeat-rpc", 2, 1024));
+        let block_report_rpc_executor =
+            Arc::new(GroupExecutor::new("master-block-report-rpc", 2, 128));
+        let block_report_reconcile_executor =
+            Arc::new(GroupExecutor::new("master-block-report-reconcile", 2, 128));
+        let control_rpc_executor = Arc::new(GroupExecutor::new("master-control-rpc", 2, 1024));
+        let list_rpc_executor = Arc::new(GroupExecutor::new("master-list-rpc", 2, 128));
+        let get_block_locations_rpc_executor = Arc::new(GroupExecutor::new(
+            "master-get-block-locations-rpc",
+            conf.master.worker_threads.saturating_sub(4).max(1),
+            conf.master.worker_threads.saturating_mul(2).max(1),
+        ));
+        let get_block_locations_limiter = Arc::new(Semaphore::new(
+            conf.master.worker_threads.saturating_sub(4).max(1),
+        ));
 
         let replication_manager = MasterReplicationManager::new(&fs, &conf, &rt, &worker_manager)?;
 
@@ -169,12 +213,21 @@ impl Master {
             mount_manager.clone(),
             job_manager.clone(),
             rt.clone(),
+            heartbeat_rpc_executor,
+            block_report_rpc_executor,
+            block_report_reconcile_executor,
+            control_rpc_executor,
+            list_rpc_executor,
+            get_block_locations_rpc_executor,
+            get_block_locations_limiter,
             replication_manager.clone(),
             metrics,
         );
 
         let rpc_conf = conf.master_server_conf();
         let rpc_server = RpcServer::with_rt(rt.clone(), rpc_conf, service.clone());
+        let shutdown_job_manager = job_manager.clone();
+        rpc_server.add_shutdown_hook(move || shutdown_job_manager.shutdown());
 
         // step4: Create a web server
         let web_conf = conf.master_web_conf();

--- a/curvine-server/src/master/meta/fs_dir.rs
+++ b/curvine-server/src/master/meta/fs_dir.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::master::fs::DeleteResult;
+use crate::master::fs::{BlockInodeState, DeleteResult};
 use crate::master::journal::{JournalEntry, JournalWriter};
 use crate::master::meta::inode::ttl::TtlBucketList;
 use crate::master::meta::inode::InodeView::{Dir, File, FileEntry};
@@ -625,23 +625,19 @@ impl FsDir {
         Ok(status)
     }
 
-    // Determine whether the current block has been deleted.
-    //Judge whether the block's inode exists. Block will only be deleted if the inode is deleted. All this judgment is not problematic.
-    pub fn block_exists(&self, block_id: i64) -> FsResult<bool> {
+    // Determine whether a reported block still belongs to a file inode.
+    pub(crate) fn block_inode_state(&self, block_id: i64) -> FsResult<BlockInodeState> {
         let file_id = InodeId::get_id(block_id);
         let inode = self.store.get_inode(file_id, None)?;
         match inode {
-            None => Ok(false),
+            None => Ok(BlockInodeState::Missing),
+            Some(v) if v.is_file() => Ok(BlockInodeState::File),
             Some(v) => {
-                if v.is_file() {
-                    Ok(true)
-                } else {
-                    err_box!(
-                        "block_id {} resolves to inode {:?} which is not a file",
-                        block_id,
-                        v
-                    )
-                }
+                warn!(
+                    "block_id {} resolves to inode {:?} which is not a file",
+                    block_id, v
+                );
+                Ok(BlockInodeState::NotFile)
             }
         }
     }

--- a/curvine-server/src/worker/block/block_actor.rs
+++ b/curvine-server/src/worker/block/block_actor.rs
@@ -15,14 +15,19 @@
 use crate::worker::block::{BlockStore, HeartbeatTask, MasterClient};
 use curvine_client::file::FsContext;
 use curvine_common::conf::ClusterConf;
+use curvine_common::error::FsError;
 use curvine_common::executor::ScheduledExecutor;
 use curvine_common::state::{BlockReportInfo, HeartbeatStatus, WorkerAddress};
+use curvine_common::utils::ProtoUtils;
+use curvine_common::FsResult;
 use dashmap::DashMap;
-use log::info;
+use log::{error, info};
 use orpc::common::TimeSpent;
-use orpc::runtime::{GroupExecutor, Runtime};
+use orpc::runtime::{GroupExecutor, LoopTask, Runtime};
+use orpc::server::ServerState;
 use orpc::sync::StateCtl;
 use orpc::CommonResult;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 /// Worker block management role.
@@ -85,14 +90,6 @@ impl BlockActor {
         self.register()?;
         info!("worker register success");
 
-        let spend = TimeSpent::new();
-        let total_len = self.full_block_report()?;
-        info!(
-            "worker block report success, total blocks {}, used {} ms",
-            total_len,
-            spend.used_ms()
-        );
-
         Self::start_heartbeat(
             self.executor.clone(),
             self.worker_ctl.clone(),
@@ -101,6 +98,7 @@ impl BlockActor {
             self.report_blocks.clone(),
             self.heartbeat_interval_ms,
         )?;
+        self.start_full_block_report_retry()?;
         Ok(())
     }
 
@@ -115,20 +113,43 @@ impl BlockActor {
     pub fn full_block_report(&self) -> CommonResult<usize> {
         let blocks = self.store.all_blocks()?;
         if blocks.is_empty() {
-            let _ = self.client.full_block_report(0, &[])?;
+            let response = self.client.full_block_report(0, &[])?;
+            let cmds = ProtoUtils::worker_cmd_from_pb(response.cmds);
+            HeartbeatTask::delete_block_task(
+                self.executor.clone(),
+                self.store.clone(),
+                cmds,
+                self.report_blocks.clone(),
+            );
             return Ok(0);
         }
 
         let mut off = 0;
         while off < blocks.len() {
             let end = (off + self.block_report_limit).min(blocks.len());
-            let _ = self
+            let response = self
                 .client
                 .full_block_report(blocks.len(), &blocks[off..end])?;
+            let cmds = ProtoUtils::worker_cmd_from_pb(response.cmds);
+            HeartbeatTask::delete_block_task(
+                self.executor.clone(),
+                self.store.clone(),
+                cmds,
+                self.report_blocks.clone(),
+            );
             off = end;
         }
 
         Ok(blocks.len())
+    }
+
+    fn start_full_block_report_retry(&self) -> CommonResult<()> {
+        let scheduler =
+            ScheduledExecutor::new("worker-full-block-report", self.heartbeat_interval_ms);
+        scheduler.start(FullBlockReportTask {
+            actor: self.clone(),
+            complete: Arc::new(AtomicBool::new(false)),
+        })
     }
 
     pub fn start_heartbeat(
@@ -147,9 +168,42 @@ impl BlockActor {
             client,
             store,
             report_blocks,
+            report_in_flight: Arc::new(AtomicBool::new(false)),
         };
 
         scheduler.start(task)?;
         Ok(())
+    }
+}
+
+struct FullBlockReportTask {
+    actor: BlockActor,
+    complete: Arc<AtomicBool>,
+}
+
+impl LoopTask for FullBlockReportTask {
+    type Error = FsError;
+
+    fn run(&self) -> FsResult<()> {
+        let spend = TimeSpent::new();
+        match self.actor.full_block_report() {
+            Ok(total_len) => {
+                info!(
+                    "worker block report success, total blocks {}, used {} ms",
+                    total_len,
+                    spend.used_ms()
+                );
+                self.complete.store(true, Ordering::Release);
+            }
+            Err(e) => {
+                error!("worker full block report failed: {}; will retry", e);
+            }
+        }
+        Ok(())
+    }
+
+    fn terminate(&self) -> bool {
+        self.complete.load(Ordering::Acquire)
+            || self.actor.worker_ctl.state::<ServerState>() == ServerState::Stop
     }
 }

--- a/curvine-server/src/worker/block/heartbeat_task.rs
+++ b/curvine-server/src/worker/block/heartbeat_task.rs
@@ -24,7 +24,8 @@ use orpc::runtime::{GroupExecutor, LoopTask};
 use orpc::server::ServerState;
 use orpc::sync::StateCtl;
 use orpc::try_log;
-use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 
 pub struct HeartbeatTask {
     pub(crate) executor: Arc<GroupExecutor>,
@@ -32,11 +33,12 @@ pub struct HeartbeatTask {
     pub(crate) client: MasterClient,
     pub(crate) store: BlockStore,
     pub(crate) report_blocks: Arc<DashMap<i64, BlockReportInfo>>,
+    pub(crate) report_in_flight: Arc<AtomicBool>,
 }
 
 impl HeartbeatTask {
     // Asynchronously delete the block file.
-    fn delete_block_task(
+    pub(crate) fn delete_block_task(
         executor: Arc<GroupExecutor>,
         store: BlockStore,
         cmds: Vec<WorkerCommand>,
@@ -96,8 +98,59 @@ impl HeartbeatTask {
     }
 
     pub fn put_missing_report(&self, blocks: Vec<BlockReportInfo>) {
+        Self::put_report_blocks(self.report_blocks.clone(), blocks);
+    }
+
+    fn put_report_blocks(
+        report_blocks: Arc<DashMap<i64, BlockReportInfo>>,
+        blocks: Vec<BlockReportInfo>,
+    ) {
         for block in blocks {
-            self.report_blocks.insert(block.id, block);
+            report_blocks.insert(block.id, block);
+        }
+    }
+
+    fn submit_block_report(&self, report_blocks: Vec<BlockReportInfo>) {
+        if self.report_in_flight.swap(true, Ordering::AcqRel) {
+            self.put_missing_report(report_blocks);
+            return;
+        }
+
+        let client = self.client.clone();
+        let executor = self.executor.clone();
+        let store = self.store.clone();
+        let pending_reports = self.report_blocks.clone();
+        let report_in_flight = self.report_in_flight.clone();
+        let task_reports = Arc::new(Mutex::new(Some(report_blocks)));
+        let task_reports_for_task = task_reports.clone();
+        let res = self.executor.try_spawn(move || {
+            let reports = task_reports_for_task
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .take()
+                .unwrap_or_default();
+            match client.incr_block_report(&reports) {
+                Ok(v) => {
+                    let cmds = ProtoUtils::worker_cmd_from_pb(v.cmds);
+                    Self::delete_block_task(executor, store, cmds, pending_reports);
+                }
+                Err(e) => {
+                    error!("report blocks {}", e);
+                    Self::put_report_blocks(pending_reports, reports);
+                }
+            }
+            report_in_flight.store(false, Ordering::Release);
+        });
+
+        if let Err(e) = res {
+            error!("submit block report task failed {}", e);
+            let reports = task_reports
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .take()
+                .unwrap_or_default();
+            self.put_missing_report(reports);
+            self.report_in_flight.store(false, Ordering::Release);
         }
     }
 }
@@ -139,17 +192,7 @@ impl LoopTask for HeartbeatTask {
             return Ok(());
         }
 
-        let res = self.client.incr_block_report(&report_blocks);
-        match res {
-            Ok(_cmds) => {
-                // @todo handles cmds returned by master.
-            }
-
-            Err(e) => {
-                error!("report blocks {}", e);
-                self.put_missing_report(report_blocks)
-            }
-        }
+        self.submit_block_report(report_blocks);
 
         Ok(())
     }

--- a/curvine-server/tests/load_job_submit_test.rs
+++ b/curvine-server/tests/load_job_submit_test.rs
@@ -15,8 +15,9 @@
 use curvine_common::conf::{ClientConf, ClusterConf, JournalConf, MasterConf};
 use curvine_common::state::{
     JobTaskProgress, JobTaskState, LoadJobCommand, LoadJobInfo, LoadTaskInfo, MountInfo,
-    MountOptions, StorageType, TtlAction, WorkerAddress, WorkerInfo,
+    MountOptions, OpenFlags, StorageType, TtlAction, WorkerAddress, WorkerInfo,
 };
+use curvine_common::utils::CommonUtils;
 use curvine_server::master::fs::MasterFilesystem;
 use curvine_server::master::journal::JournalSystem;
 use curvine_server::master::{JobContext, JobManager, JobStore, Master};
@@ -28,10 +29,17 @@ use std::sync::Arc;
 use std::time::Duration;
 
 fn new_job_manager(name: &str) -> CommonResult<(Arc<JobManager>, Arc<Runtime>, String)> {
+    new_job_manager_with_conf(name, |_| {})
+}
+
+fn new_job_manager_with_conf(
+    name: &str,
+    configure: impl FnOnce(&mut ClusterConf),
+) -> CommonResult<(Arc<JobManager>, Arc<Runtime>, String)> {
     Master::init_test_metrics();
     let test_name = format!("{}-{}", name, Utils::rand_id());
 
-    let conf = ClusterConf {
+    let mut conf = ClusterConf {
         format_master: true,
         testing: true,
         master: MasterConf {
@@ -45,6 +53,8 @@ fn new_job_manager(name: &str) -> CommonResult<(Arc<JobManager>, Arc<Runtime>, S
         },
         ..Default::default()
     };
+    configure(&mut conf);
+    conf.job.init()?;
 
     let journal_system = JournalSystem::from_conf(&conf)?;
     let master_fs = MasterFilesystem::with_js(&conf, &journal_system);
@@ -92,23 +102,24 @@ fn load_task(task_id: &str, job_id: &str) -> LoadTaskInfo {
 }
 
 #[test]
-fn submit_load_job_returns_before_ufs_planning() -> CommonResult<()> {
+fn submit_load_job_returns_pending_before_missing_source_check() -> CommonResult<()> {
     let (job_manager, rt, missing_source) = new_job_manager("async-missing-source")?;
+    let source = missing_source.clone();
 
-    rt.block_on(async move {
+    rt.block_on(async {
         let result = job_manager
-            .submit_load_job(LoadJobCommand::builder(missing_source).build())
+            .submit_load_job(LoadJobCommand::builder(source).build())
             .await?;
 
         assert!(!result.job_id.is_empty());
         assert_eq!(result.state, JobTaskState::Pending);
-
-        for _ in 0..50 {
+        for _ in 0..100 {
             let status = job_manager.get_job_status(&result.job_id)?;
             if status.state == JobTaskState::Failed {
                 assert!(
-                    !status.progress.message.is_empty(),
-                    "failed job should keep a diagnostic message"
+                    status.progress.message.contains("source file not found"),
+                    "failed job should keep a source-not-found diagnostic: {}",
+                    status.progress.message
                 );
                 assert!(
                     status.progress.update_time > 0,
@@ -122,9 +133,364 @@ fn submit_load_job_returns_before_ufs_planning() -> CommonResult<()> {
 
         let status = job_manager.get_job_status(&result.job_id)?;
         panic!(
-            "load job did not fail in background, state={:?}, message={}",
+            "missing source load did not fail, state={:?}, message={}",
             status.state, status.progress.message
         );
+    })
+}
+
+#[test]
+fn missing_source_load_failure_is_reused_during_retry_interval() -> CommonResult<()> {
+    let (job_manager, rt, missing_source) =
+        new_job_manager_with_conf("missing-source-cooldown", |conf| {
+            conf.job.master_failed_load_job_retry_interval_str = "1h".to_string();
+        })?;
+    let source = missing_source.clone();
+
+    rt.block_on(async {
+        let first = job_manager
+            .submit_load_job(LoadJobCommand::builder(source.clone()).build())
+            .await?;
+
+        let mut failed_status = None;
+        for _ in 0..100 {
+            let status = job_manager.get_job_status(&first.job_id)?;
+            if status.state == JobTaskState::Failed {
+                failed_status = Some(status);
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        let failed_status = match failed_status {
+            Some(status) => status,
+            None => {
+                let status = job_manager.get_job_status(&first.job_id)?;
+                panic!(
+                    "missing source load did not fail during cooldown test, state={:?}, message={}",
+                    status.state, status.progress.message
+                );
+            }
+        };
+        assert!(
+            failed_status
+                .progress
+                .message
+                .contains("source file not found"),
+            "unexpected failed message: {}",
+            failed_status.progress.message
+        );
+
+        let duplicate = job_manager
+            .submit_load_job(LoadJobCommand::builder(source).build())
+            .await?;
+
+        assert_eq!(duplicate.job_id, first.job_id);
+        assert_eq!(duplicate.state, JobTaskState::Failed);
+        let status_after_duplicate = job_manager.get_job_status(&first.job_id)?;
+        assert_eq!(status_after_duplicate.state, JobTaskState::Failed);
+        assert_eq!(
+            status_after_duplicate.progress.update_time, failed_status.progress.update_time,
+            "duplicate submit should not replace the failed job during cooldown"
+        );
+
+        Ok(())
+    })
+}
+
+#[test]
+fn job_manager_uses_dedicated_background_runtime() -> CommonResult<()> {
+    let (job_manager, _rt, _missing_source) = new_job_manager("background-runtime")?;
+
+    assert_eq!(job_manager.rt().thread_name(), "single");
+    assert_eq!(job_manager.background_rt().thread_name(), "master-load-job");
+    assert_eq!(
+        job_manager.background_rt().io_threads(),
+        curvine_common::conf::JobConf::DEFAULT_MASTER_LOAD_JOB_RUNTIME_THREADS
+    );
+    assert_eq!(
+        job_manager.background_rt().worker_threads(),
+        curvine_common::conf::JobConf::DEFAULT_MASTER_LOAD_JOB_BLOCKING_THREADS
+    );
+    Ok(())
+}
+
+#[test]
+fn submit_load_job_reuses_pending_job_for_same_path() -> CommonResult<()> {
+    let (job_manager, rt, missing_source) = new_job_manager("pending-dedupe")?;
+    let source_path = curvine_common::fs::Path::from_str(&missing_source)?;
+    let (_, mount) = job_manager
+        .get_mnt(&source_path)?
+        .expect("test source should match mount");
+    let target_path = mount.info.toggle_path(&source_path)?;
+    let command = LoadJobCommand::builder(missing_source.clone()).build();
+    let job_id = CommonUtils::create_job_id(source_path.full_path());
+    let pending = JobContext::with_conf(
+        &command,
+        job_id.clone(),
+        source_path.clone_uri(),
+        target_path.clone_uri(),
+        &mount.info,
+        &ClientConf::default(),
+        1,
+    );
+    job_manager.jobs().insert(job_id.clone(), pending);
+
+    rt.block_on(async {
+        let duplicate = job_manager.submit_load_job(command).await?;
+
+        assert_eq!(duplicate.job_id, job_id);
+        assert_eq!(duplicate.target_path, target_path.clone_uri());
+        assert_eq!(duplicate.state, JobTaskState::Pending);
+        Ok(())
+    })
+}
+
+#[test]
+fn submit_load_job_rejects_after_shutdown_without_creating_job() -> CommonResult<()> {
+    let (job_manager, rt, missing_source) = new_job_manager("shutdown-no-half-job")?;
+    job_manager.shutdown();
+    let source = missing_source.clone();
+    let source_path = curvine_common::fs::Path::from_str(&source)?;
+    let job_id = CommonUtils::create_job_id(source_path.full_path());
+
+    rt.block_on(async {
+        let err = job_manager
+            .submit_load_job(LoadJobCommand::builder(source).build())
+            .await
+            .expect_err("submit should fail after shutdown before creating a job");
+
+        assert!(
+            err.to_string()
+                .contains("load job manager is shutting down"),
+            "unexpected error: {}",
+            err
+        );
+        assert!(
+            job_manager.jobs().get(&job_id).is_none(),
+            "failed admission must not leave a half-created job"
+        );
+        Ok(())
+    })
+}
+
+#[test]
+fn fs_mode_cv_path_load_uses_ufs_source_when_metadata_is_ufs_only() -> CommonResult<()> {
+    let (job_manager, rt, missing_source) = new_job_manager("fs-cv-load-ufs-only")?;
+    let source = missing_source.replace("/missing-file", "/ufs-only-file");
+    let local_source = source
+        .strip_prefix("file://")
+        .expect("test UFS path uses file scheme");
+    if let Some(parent) = std::path::Path::new(local_source).parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(local_source, b"load-data")?;
+
+    let cv_path = "/mnt/ufs-only-file";
+    let source_path = curvine_common::fs::Path::from_str(&source)?;
+    let (_, mount) = job_manager
+        .get_mnt(&source_path)?
+        .expect("test source should match mount");
+    let sync_opts = mount.info.get_sync_opts(&ClientConf::default(), 1, 9);
+    job_manager
+        .master_fs()
+        .create_with_opts(cv_path, sync_opts, OpenFlags::new_create())?;
+    let expected_job_id = CommonUtils::create_job_id(&source);
+
+    rt.block_on(async {
+        let result = job_manager
+            .submit_load_job(LoadJobCommand::builder(cv_path).build())
+            .await?;
+
+        assert_eq!(result.job_id, expected_job_id);
+        assert_eq!(result.target_path, cv_path);
+
+        let status = job_manager.get_job_status(&result.job_id)?;
+        assert_eq!(status.source_path, source);
+        assert_eq!(status.target_path, cv_path);
+        Ok(())
+    })
+}
+
+#[test]
+fn fs_mode_cv_path_load_keeps_cv_source_when_cv_data_exists() -> CommonResult<()> {
+    let (job_manager, rt, _missing_source) = new_job_manager("fs-cv-load-export")?;
+    let cv_path = "/mnt/cv-file";
+    let create_opts = curvine_common::state::CreateFileOptsBuilder::new()
+        .create_parent(true)
+        .build();
+    job_manager
+        .master_fs()
+        .create_with_opts(cv_path, create_opts, OpenFlags::new_create())?;
+    let expected_target = job_manager
+        .get_mnt(&curvine_common::fs::Path::from_str(cv_path)?)?
+        .expect("test CV path should match mount")
+        .0
+        .clone_uri();
+    let expected_job_id = CommonUtils::create_job_id(cv_path);
+
+    rt.block_on(async {
+        let result = job_manager
+            .submit_load_job(LoadJobCommand::builder(cv_path).build())
+            .await?;
+
+        assert_eq!(result.job_id, expected_job_id);
+        assert_eq!(result.target_path, expected_target);
+
+        let status = job_manager.get_job_status(&result.job_id)?;
+        assert_eq!(status.source_path, cv_path);
+        assert_eq!(status.target_path, expected_target);
+        Ok(())
+    })
+}
+
+#[test]
+fn direct_load_task_uses_ufs_source_when_cv_metadata_is_ufs_only() -> CommonResult<()> {
+    let (job_manager, rt, missing_source) = new_job_manager("direct-load-ufs-only")?;
+    let source = missing_source.replace("/missing-file", "/direct-ufs-only-file");
+    let local_source = source
+        .strip_prefix("file://")
+        .expect("test UFS path uses file scheme");
+    if let Some(parent) = std::path::Path::new(local_source).parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(local_source, b"load-data")?;
+
+    let cv_path = "/mnt/direct-ufs-only-file";
+    let source_path = curvine_common::fs::Path::from_str(&source)?;
+    let (_, mount) = job_manager
+        .get_mnt(&source_path)?
+        .expect("test source should match mount");
+    let sync_opts = mount.info.get_sync_opts(&ClientConf::default(), 1, 9);
+    job_manager
+        .master_fs()
+        .create_with_opts(cv_path, sync_opts, OpenFlags::new_create())?;
+
+    let command = LoadJobCommand::builder(cv_path).build();
+    let expected_job_id = CommonUtils::create_job_id(&source);
+    let running = JobContext::with_conf(
+        &command,
+        expected_job_id.clone(),
+        source.clone(),
+        cv_path.to_string(),
+        &mount.info,
+        &ClientConf::default(),
+        1,
+    );
+    job_manager.jobs().insert(expected_job_id.clone(), running);
+
+    rt.block_on(async {
+        let result = job_manager
+            .create_runner()
+            .submit_load_task(command, mount.info.clone())
+            .await?;
+
+        assert_eq!(result.job_id, expected_job_id);
+        assert_eq!(result.target_path, cv_path);
+
+        let status = job_manager.get_job_status(&result.job_id)?;
+        assert_eq!(status.source_path, source);
+        assert_eq!(status.target_path, cv_path);
+        Ok(())
+    })
+}
+
+#[test]
+fn direct_export_task_keeps_cv_source_for_fs_mode_journal_sync() -> CommonResult<()> {
+    let (job_manager, rt, _missing_source) = new_job_manager("direct-export")?;
+    let cv_path = "/mnt/export-file";
+    let create_opts = curvine_common::state::CreateFileOptsBuilder::new()
+        .create_parent(true)
+        .build();
+    job_manager
+        .master_fs()
+        .create_with_opts(cv_path, create_opts, OpenFlags::new_create())?;
+    let expected_target = job_manager
+        .get_mnt(&curvine_common::fs::Path::from_str(cv_path)?)?
+        .expect("test CV path should match mount")
+        .0
+        .clone_uri();
+    let (_, mount) = job_manager
+        .get_mnt(&curvine_common::fs::Path::from_str(cv_path)?)?
+        .expect("test CV path should match mount");
+
+    let command = LoadJobCommand::builder(cv_path).build();
+    let expected_job_id = CommonUtils::create_job_id(cv_path);
+    let running = JobContext::with_conf(
+        &command,
+        expected_job_id.clone(),
+        cv_path.to_string(),
+        expected_target.clone(),
+        &mount.info,
+        &ClientConf::default(),
+        1,
+    );
+    job_manager.jobs().insert(expected_job_id.clone(), running);
+
+    rt.block_on(async {
+        let result = job_manager
+            .create_runner()
+            .submit_export_task(command, mount.info.clone())
+            .await?;
+
+        assert_eq!(result.job_id, expected_job_id);
+        assert_eq!(result.target_path, expected_target);
+
+        let status = job_manager.get_job_status(&result.job_id)?;
+        assert_eq!(status.source_path, cv_path);
+        assert_eq!(status.target_path, expected_target);
+        Ok(())
+    })
+}
+
+#[test]
+fn load_job_worker_survives_idle_before_submit() -> CommonResult<()> {
+    let (job_manager, rt, missing_source) = new_job_manager_with_conf("idle-worker", |conf| {
+        conf.job.master_max_concurrent_load_jobs = 1;
+    })?;
+
+    rt.block_on(async {
+        let result = job_manager
+            .submit_load_job(LoadJobCommand::builder(missing_source).build())
+            .await?;
+
+        for _ in 0..50 {
+            let status = job_manager.get_job_status(&result.job_id)?;
+            if status.state == JobTaskState::Failed {
+                assert!(
+                    !status.progress.message.is_empty(),
+                    "failed job should keep a diagnostic message"
+                );
+                return Ok(());
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        let status = job_manager.get_job_status(&result.job_id)?;
+        panic!(
+            "idle worker did not process load job, state={:?}, message={}",
+            status.state, status.progress.message
+        );
+    })
+}
+
+#[test]
+fn submit_load_job_rejects_after_shutdown() -> CommonResult<()> {
+    let (job_manager, rt, missing_source) = new_job_manager("shutdown-reject")?;
+
+    job_manager.shutdown();
+
+    rt.block_on(async {
+        let err = job_manager
+            .submit_load_job(LoadJobCommand::builder(missing_source).build())
+            .await
+            .expect_err("submit should fail after shutdown");
+        assert!(
+            err.to_string()
+                .contains("load job manager is shutting down"),
+            "unexpected shutdown error: {}",
+            err
+        );
+        Ok(())
     })
 }
 
@@ -136,10 +502,11 @@ fn empty_directory_load_completes_without_worker_reports() -> CommonResult<()> {
         .strip_prefix("file://")
         .expect("test UFS path uses file scheme");
     std::fs::create_dir_all(local_source)?;
+    let source_path = source.clone();
 
-    rt.block_on(async move {
+    rt.block_on(async {
         let result = job_manager
-            .submit_load_job(LoadJobCommand::builder(source).build())
+            .submit_load_job(LoadJobCommand::builder(source_path).build())
             .await?;
 
         assert!(!result.job_id.is_empty());

--- a/curvine-server/tests/master_fs_test.rs
+++ b/curvine-server/tests/master_fs_test.rs
@@ -17,27 +17,37 @@ use curvine_common::error::FsError;
 use curvine_common::fs::CurvineURI;
 use curvine_common::fs::RpcCode;
 use curvine_common::proto::{
-    CreateFileRequest, DeleteRequest, MkdirOptsProto, MkdirRequest, RenameRequest,
+    CreateFileRequest, DeleteRequest, GetBlockLocationsRequest, MkdirOptsProto, MkdirRequest,
+    RenameRequest,
 };
 use curvine_common::raft::storage::{AppStorage, ApplyMsg};
+use curvine_common::raft::RoleState;
 use curvine_common::state::MountOptions;
 use curvine_common::state::{
-    BlockLocation, ClientAddress, CommitBlock, CreateFileOpts, FileAllocOpts, WorkerInfo,
+    BlockLocation, BlockReportInfo, BlockReportList, BlockReportStatus, ClientAddress, CommitBlock,
+    CreateFileOpts, FileAllocOpts, HeartbeatStatus, StorageType, WorkerAddress, WorkerCommand,
+    WorkerInfo,
 };
 use curvine_common::state::{OpenFlags, RenameFlags, SetAttrOptsBuilder};
 use curvine_common::utils::SerdeUtils;
 use curvine_server::master::fs::{FsRetryCache, MasterFilesystem, OperationStatus};
 use curvine_server::master::journal::{JournalBatch, JournalEntry, JournalLoader, JournalSystem};
+use curvine_server::master::meta::InodeId;
 use curvine_server::master::replication::master_replication_manager::MasterReplicationManager;
-use curvine_server::master::{JobHandler, JobManager, Master, MasterHandler, RpcContext};
+use curvine_server::master::{
+    JobHandler, JobManager, Master, MasterHandler, MasterMonitor, RpcContext,
+};
 use orpc::common::LocalTime;
 use orpc::common::Utils;
-use orpc::message::Builder;
-use orpc::runtime::{AsyncRuntime, RpcRuntime};
+use orpc::handler::MessageHandler;
+use orpc::message::{Builder, ResponseStatus};
+use orpc::runtime::{AsyncRuntime, GroupExecutor, RpcRuntime};
+use orpc::sync::StateCtl;
 use orpc::CommonResult;
 use raft::eraftpb::Entry;
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
+use tokio::sync::Semaphore;
 
 // Master metrics gauges are process-wide; master_fs_test cases must not run in parallel or
 // inode_file_num / inode_dir_num race with other tests' format/init.
@@ -145,16 +155,32 @@ fn file_counts(fs: &MasterFilesystem) -> (i64, i64) {
 }
 
 fn new_handler() -> MasterHandler {
+    new_handler_with_role_and_read_limit(RoleState::Leader, 8)
+}
+
+fn new_active_handler_with_read_limit(read_limit: usize) -> MasterHandler {
+    new_handler_with_role_and_read_limit(RoleState::Leader, read_limit)
+}
+
+fn new_handler_with_role_and_read_limit(role: RoleState, read_limit: usize) -> MasterHandler {
     Master::init_test_metrics();
 
     let mut conf = ClusterConf::format();
     conf.journal.enable = false;
+    let suffix = Utils::rand_str(6);
 
-    conf.master.meta_dir = Utils::test_sub_dir("master-fs-test/meta-retry");
-    conf.journal.journal_dir = Utils::test_sub_dir("master-fs-test/journal-retry");
+    conf.master.meta_dir = Utils::test_sub_dir(format!("master-fs-test/meta-handler-{suffix}"));
+    conf.journal.journal_dir =
+        Utils::test_sub_dir(format!("master-fs-test/journal-handler-{suffix}"));
 
     let journal_system = JournalSystem::from_conf(&conf).unwrap();
-    let fs = MasterFilesystem::with_js(&conf, &journal_system);
+    let raw_fs = MasterFilesystem::with_js(&conf, &journal_system);
+    let fs = MasterFilesystem::new(
+        &conf,
+        raw_fs.fs_dir.clone(),
+        raw_fs.worker_manager.clone(),
+        MasterMonitor::new(StateCtl::new(role.into()), StateCtl::new(0)),
+    );
     fs.add_test_worker(WorkerInfo::default());
     let retry_cache = FsRetryCache::with_conf(&conf.master)
         .expect("test master retry cache configuration should be valid");
@@ -177,9 +203,108 @@ fn new_handler() -> MasterHandler {
         None,
         mount_manager,
         JobHandler::new(job_manager),
+        Arc::new(GroupExecutor::new("test-heartbeat-rpc", 1, 8)),
+        Arc::new(GroupExecutor::new("test-block-report-rpc", 1, 8)),
+        Arc::new(GroupExecutor::new("test-block-report-reconcile", 1, 8)),
+        Arc::new(GroupExecutor::new("test-control-rpc", 1, 8)),
+        Arc::new(GroupExecutor::new("test-list-rpc", 1, 8)),
+        Arc::new(GroupExecutor::new("test-get-block-locations-rpc", 1, 8)),
+        Arc::new(Semaphore::new(read_limit)),
         replication_manager,
         Master::get_metrics().expect("test master metrics should initialize"),
     )
+}
+
+#[test]
+fn worker_reports_do_not_share_master_sync_blocking_pool() {
+    let _serial = master_fs_test_serial();
+    let handler = new_handler();
+
+    let submit_job = Builder::new_rpc(RpcCode::SubmitJob).build();
+    let get_block_locations = Builder::new_rpc(RpcCode::GetBlockLocations).build();
+    let get_master_info = Builder::new_rpc(RpcCode::GetMasterInfo).build();
+    let list_status = Builder::new_rpc(RpcCode::ListStatus).build();
+    let list_options = Builder::new_rpc(RpcCode::ListOptions).build();
+    let heartbeat = Builder::new_rpc(RpcCode::WorkerHeartbeat).build();
+    let block_report = Builder::new_rpc(RpcCode::WorkerBlockReport).build();
+
+    assert!(
+        !handler.is_sync(&submit_job),
+        "SubmitJob must use async admission instead of the master sync blocking pool"
+    );
+    assert!(
+        !handler.is_sync(&get_block_locations),
+        "GetBlockLocations must use the dedicated read executor instead of the master sync blocking pool"
+    );
+    assert!(
+        !handler.is_sync(&get_master_info),
+        "GetMasterInfo must use the control executor instead of the master sync blocking pool"
+    );
+    assert!(
+        !handler.is_sync(&list_status),
+        "ListStatus must use the control executor instead of the master sync blocking pool"
+    );
+    assert!(
+        !handler.is_sync(&list_options),
+        "ListOptions must use the control executor instead of the master sync blocking pool"
+    );
+    assert!(
+        !handler.is_sync(&heartbeat),
+        "WorkerHeartbeat must use the dedicated heartbeat executor instead of the master sync blocking pool"
+    );
+    assert!(
+        !handler.is_sync(&block_report),
+        "WorkerBlockReport must use the dedicated block-report executor instead of the master sync blocking pool"
+    );
+}
+
+#[test]
+fn get_block_locations_limit_returns_rpc_error_response() {
+    let _serial = master_fs_test_serial();
+    let mut handler = new_active_handler_with_read_limit(0);
+    assert!(handler.clone_fs().master_monitor.is_active());
+    let request = Builder::new_rpc(RpcCode::GetBlockLocations)
+        .proto_header(GetBlockLocationsRequest {
+            path: "/busy-file".to_string(),
+        })
+        .build();
+
+    let runtime = AsyncRuntime::single();
+    let response = runtime.block_on(handler.async_handle(request)).expect(
+        "async handler should return an RPC error response instead of closing the connection",
+    );
+
+    assert_eq!(response.response_status(), ResponseStatus::Error);
+    assert!(
+        response
+            .to_error_msg()
+            .contains("GetBlockLocations concurrency limit exceeded"),
+        "unexpected error response: {}",
+        response.to_error_msg()
+    );
+}
+
+#[test]
+fn async_rpc_to_standby_returns_rpc_error_response() {
+    let _serial = master_fs_test_serial();
+    let mut handler = new_handler_with_role_and_read_limit(RoleState::Follower, 8);
+    let request = Builder::new_rpc(RpcCode::GetBlockLocations)
+        .proto_header(GetBlockLocationsRequest {
+            path: "/standby-file".to_string(),
+        })
+        .build();
+
+    let runtime = AsyncRuntime::single();
+    let response = runtime.block_on(handler.async_handle(request)).expect(
+        "async handler should return a not-leader RPC error response instead of closing the connection",
+    );
+
+    assert_eq!(response.response_status(), ResponseStatus::Error);
+    assert!(
+        response.to_error_msg().contains("Not a leader master"),
+        "unexpected error response: {}",
+        response.to_error_msg()
+    );
 }
 
 #[test]
@@ -194,6 +319,46 @@ fn test_master_filesystem_core_operations() -> CommonResult<()> {
     get_file_info(&fs)?;
     list_status(&fs)?;
     state(&fs)?;
+
+    Ok(())
+}
+
+#[test]
+fn block_report_for_non_file_inode_schedules_worker_delete() -> CommonResult<()> {
+    let _serial = master_fs_test_serial();
+    let fs = new_fs(true, "block-report-non-file");
+    fs.mkdir("/dir-block", true)?;
+    let dir_status = fs.file_status("/dir-block")?;
+    let block_id = InodeId::create_block_id(dir_status.id, 0)?;
+
+    let result = fs.block_report(BlockReportList {
+        cluster_id: "curvine".into(),
+        worker_id: 100,
+        full_report: false,
+        total_len: 1,
+        blocks: vec![BlockReportInfo::new(
+            block_id,
+            BlockReportStatus::Finalized,
+            StorageType::Disk,
+            1,
+        )],
+    })?;
+
+    assert_eq!(result.delete_blocks, vec![block_id]);
+
+    let cmds = fs.worker_manager.write().heartbeat(
+        "curvine",
+        HeartbeatStatus::Running,
+        WorkerAddress {
+            worker_id: 100,
+            ..Default::default()
+        },
+        vec![],
+    )?;
+    assert!(cmds.iter().any(|cmd| matches!(
+        cmd,
+        WorkerCommand::DeleteBlock(delete) if delete.blocks.contains(&block_id)
+    )));
 
     Ok(())
 }

--- a/curvine-tests/tests/write_cache_test.rs
+++ b/curvine-tests/tests/write_cache_test.rs
@@ -13,26 +13,56 @@
 // limitations under the License.
 
 use bytes::BytesMut;
+use curvine_client::rpc::JobMasterClient;
 use curvine_client::unified::{UfsFileSystem, UnifiedFileSystem, UnifiedReader};
+use curvine_common::conf::ClusterConf;
 use curvine_common::fs::{FileSystem, Path, Reader, RpcCode, Writer};
-use curvine_common::state::{MountOptionsBuilder, WriteType};
+use curvine_common::state::{AccessMode, MountOptionsBuilder, WriteType};
+use curvine_common::utils::CommonUtils;
 use curvine_tests::Testing;
 use orpc::common::Utils;
 use orpc::runtime::{AsyncRuntime, RpcRuntime};
 use orpc::sys::DataSlice;
 use std::env;
+use std::ops::Deref;
 use std::sync::Arc;
 use std::time::Duration;
-fn get_fs() -> UnifiedFileSystem {
-    let testing = Testing::builder().workers(1).build().unwrap();
-    // Check if UFS configuration is available, if not, skip the test
-    if env::var("UFS_TEST_PATH").is_err() {
-        env::set_var("UFS_TEST_PATH", testing.ufs_path.clone());
+
+struct TestFs {
+    fs: UnifiedFileSystem,
+    ufs_path: String,
+}
+
+impl Deref for TestFs {
+    type Target = UnifiedFileSystem;
+
+    fn deref(&self) -> &Self::Target {
+        &self.fs
     }
+}
+
+fn get_fs() -> TestFs {
+    get_fs_with_conf(|_| {})
+}
+
+fn get_fs_with_conf<F>(configure: F) -> TestFs
+where
+    F: Fn(&mut ClusterConf) + Send + Sync + 'static,
+{
+    let testing = Testing::builder()
+        .workers(1)
+        .mutate_conf(configure)
+        .build()
+        .unwrap();
+    let ufs_base = env::var("UFS_TEST_PATH").unwrap_or_else(|_| testing.ufs_path.clone());
+    let ufs_path = format!("{}/{}", ufs_base.trim_end_matches('/'), Utils::rand_str(8));
 
     testing.start_cluster().unwrap();
     let rt = Arc::new(AsyncRuntime::single());
-    testing.get_unified_fs_with_rt(rt.clone()).unwrap()
+    TestFs {
+        fs: testing.get_unified_fs_with_rt(rt.clone()).unwrap(),
+        ufs_path,
+    }
 }
 
 #[test]
@@ -84,6 +114,69 @@ fn test_cache_mode() {
     });
 }
 
+#[test]
+fn test_cache_mode_missing_ufs_open_does_not_submit_load_job() {
+    let fs = get_fs();
+    let rt = fs.clone_runtime();
+    rt.block_on(async move {
+        mount(&fs, WriteType::CacheMode).await;
+
+        let path = Path::from_str(format!(
+            "/write_cache_{:?}/missing-meta-file",
+            WriteType::CacheMode
+        ))
+        .unwrap();
+        let (ufs_path, _) = fs
+            .get_mount(&path, RpcCode::GetMountInfo)
+            .await
+            .unwrap()
+            .unwrap();
+        let job_id = CommonUtils::create_job_id(ufs_path.full_path());
+
+        let err = match fs.open(&path).await {
+            Ok(_) => panic!("missing UFS source should fail open"),
+            Err(err) => err,
+        };
+        assert!(!err.to_string().is_empty());
+
+        assert_job_stays_missing(&fs, &job_id).await;
+    });
+}
+
+#[test]
+fn test_cache_mode_auto_cache_submits_when_ufs_read_disabled() {
+    let fs = get_fs_with_conf(|conf| {
+        conf.client.enable_rust_read_ufs = false;
+    });
+    let rt = fs.clone_runtime();
+    rt.block_on(async move {
+        mount(&fs, WriteType::CacheMode).await;
+
+        let path = Path::from_str(format!(
+            "/write_cache_{:?}/read-disabled-cache-miss.log",
+            WriteType::CacheMode
+        ))
+        .unwrap();
+        let data = Utils::rand_str(1024);
+        let mut writer = fs.create(&path, true).await.unwrap();
+        writer.write_string(&data).await.unwrap();
+        writer.complete().await.unwrap();
+
+        let err = match fs.open(&path).await {
+            Ok(_) => panic!("cache miss should not read UFS directly when UFS read is disabled"),
+            Err(err) => err,
+        };
+        assert!(
+            matches!(err, curvine_common::error::FsError::UnsupportedUfsRead(_)),
+            "unexpected open error: {}",
+            err
+        );
+
+        fs.wait_job_complete(&path, false).await.unwrap();
+        verify_read_data(&fs, &path, data.as_bytes()).await;
+    });
+}
+
 async fn test_cache_read(fs: &UnifiedFileSystem, path: &Path) {
     let mut reader1 = fs.open(path).await.unwrap();
     assert!(
@@ -95,12 +188,19 @@ async fn test_cache_read(fs: &UnifiedFileSystem, path: &Path) {
 
     fs.wait_job_complete(path, false).await.unwrap();
 
-    let mut reader2 = fs.open(path).await.unwrap();
-    assert!(
-        matches!(reader2, UnifiedReader::Fallback(_)),
-        "second read should be from curvine via FallbackFsReader"
-    );
+    let mut w = awaitility::at_most(Duration::from_secs(60));
+    w.poll_interval(Duration::from_millis(100));
+    w.until_async(|| async {
+        match fs.open(path).await {
+            Ok(reader) => matches!(reader, UnifiedReader::Fallback(_)),
+            Err(_) => false,
+        }
+    })
+    .await;
+    w.result()
+        .expect("second read should be from curvine via FallbackFsReader");
 
+    let mut reader2 = fs.open(path).await.unwrap();
     let str2 = reader2.read_as_string().await.unwrap();
     assert_eq!(str1, str2);
 }
@@ -246,6 +346,44 @@ fn test_fs_mode_ufs_write_overwrite() {
         // Wait until CV and UFS are fully consistent instead of a fixed sleep,
         // as UFS sync jobs may take longer under parallel test load.
         wait_for_cv_ufs_consistency(&fs, &path).await;
+    });
+}
+
+#[test]
+fn test_fs_mode_ufs_only_wait_uses_ufs_job_id() {
+    let fs = get_fs();
+    let rt = fs.clone_runtime();
+    rt.block_on(async move {
+        mount(&fs, WriteType::FsMode).await;
+
+        let path = Path::from_str(format!(
+            "/write_cache_{:?}/ufs_only_wait_job.log",
+            WriteType::FsMode
+        ))
+        .unwrap();
+        let data = Utils::rand_str(1024);
+        let (ufs_path, mnt) = fs
+            .get_mount(&path, RpcCode::GetMountInfo)
+            .await
+            .unwrap()
+            .unwrap();
+        let mut ufs_writer = mnt.ufs.create(&ufs_path, true).await.unwrap();
+        ufs_writer.write_string(&data).await.unwrap();
+        ufs_writer.complete().await.unwrap();
+        let ufs_status = mnt.ufs.get_status(&ufs_path).await.unwrap();
+        let sync_opts = mnt
+            .info
+            .get_sync_opts(&fs.conf().client, ufs_status.mtime, ufs_status.len);
+        let writer = fs
+            .cv()
+            .create_with_opts(&path, sync_opts, true)
+            .await
+            .unwrap();
+        drop(writer);
+
+        fs.async_cache(&path).unwrap();
+        fs.wait_job_complete(&path, false).await.unwrap();
+        verify_read_data(&fs, &path, data.as_bytes()).await;
     });
 }
 
@@ -430,11 +568,33 @@ async fn wait_for_cv_ufs_consistency(fs: &UnifiedFileSystem, path: &Path) {
         .expect("timed out waiting for CV and UFS to match after journal/UFS apply");
 }
 
-async fn mount(fs: &UnifiedFileSystem, write_type: WriteType) {
-    let ufs_base = env::var("UFS_TEST_PATH").unwrap();
+async fn assert_job_stays_missing(fs: &UnifiedFileSystem, job_id: &str) {
+    let client = JobMasterClient::new(fs.fs_client());
+    let deadline = tokio::time::Instant::now() + Duration::from_millis(500);
 
+    loop {
+        match client.get_job_status(job_id).await {
+            Ok(status) => panic!(
+                "missing UFS open must not submit an auto-cache load job: job_id={}, state={:?}, message={}",
+                status.job_id, status.state, status.progress.message
+            ),
+            Err(curvine_common::error::FsError::JobNotFound(_)) => {}
+            Err(err) => panic!("unexpected job status error: {}", err),
+        }
+
+        if tokio::time::Instant::now() >= deadline {
+            break;
+        }
+
+        // Negative async assertion: fail immediately if the background submit appears
+        // during the observation window.
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+async fn mount(fs: &TestFs, write_type: WriteType) {
     let dir = format!("write_cache_{:?}", write_type);
-    let ufs_path = Path::from_str(format!("{}/{}", ufs_base, dir)).unwrap();
+    let ufs_path = Path::from_str(format!("{}/{}", fs.ufs_path, dir)).unwrap();
     let cv_path = Path::from_str(format!("/{}", dir)).unwrap();
 
     if fs
@@ -446,7 +606,9 @@ async fn mount(fs: &UnifiedFileSystem, write_type: WriteType) {
         return;
     }
 
-    let mut opts_builder = MountOptionsBuilder::new().write_type(write_type);
+    let mut opts_builder = MountOptionsBuilder::new()
+        .write_type(write_type)
+        .access_mode(AccessMode::ReadWrite);
 
     // Add properties from environment variable if set
     if let Ok(props_str) = env::var("UFS_TEST_PROPERTIES") {

--- a/orpc/src/handler/stream_handler.rs
+++ b/orpc/src/handler/stream_handler.rs
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::err_box;
 use crate::handler::{Frame, MessageHandler};
 use crate::io::IOResult;
-use crate::message::Message;
+use crate::message::{Builder, Message};
 use crate::runtime::{RpcRuntime, Runtime};
 use crate::server::ServerConf;
 use crate::sys::RawPtr;
@@ -86,9 +85,19 @@ impl<F: Frame, M: MessageHandler> StreamHandler<F, M> {
                 })
                 .await?
         } else {
+            let error_response_base = Builder::new()
+                .code(request.code())
+                .request(request.request_status())
+                .req_id(request.req_id())
+                .seq_id(request.seq_id())
+                .build();
+            let req_id = request.req_id();
             match self.handler.as_mut().async_handle(request).await {
                 Ok(v) => v,
-                Err(e) => return err_box!("{}", e),
+                Err(e) => {
+                    debug!("handler request {} error: {}", req_id, e);
+                    error_response_base.error_ext(&e)
+                }
             }
         };
 

--- a/orpc/src/runtime/group_executor.rs
+++ b/orpc/src/runtime/group_executor.rs
@@ -63,6 +63,13 @@ impl GroupExecutor {
         self.get_robin_thread().spawn(task)
     }
 
+    pub fn try_spawn<F>(&self, task: F) -> CommonResult<()>
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        self.get_robin_thread().try_spawn(task)
+    }
+
     pub fn spawn_blocking<F, R>(&self, task: F) -> CommonResult<R>
     where
         F: FnOnce() -> R + Send + 'static,
@@ -76,6 +83,13 @@ impl GroupExecutor {
         F: FnOnce() + Send + 'static,
     {
         self.get_fix_thread(id).spawn(task)
+    }
+
+    pub fn fixed_try_spawn<F>(&self, id: i64, task: F) -> CommonResult<()>
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        self.get_fix_thread(id).try_spawn(task)
     }
 
     pub fn fixed_spawn_blocking<F, R>(&self, id: i64, task: F) -> CommonResult<R>

--- a/orpc/src/runtime/single_executor.rs
+++ b/orpc/src/runtime/single_executor.rs
@@ -15,7 +15,7 @@
 use crate::{err_box, try_err, try_log, CommonResult};
 use log::{error, warn};
 use std::sync::atomic::{AtomicU8, Ordering};
-use std::sync::mpsc::{Receiver, RecvTimeoutError, SyncSender};
+use std::sync::mpsc::{Receiver, RecvTimeoutError, SyncSender, TrySendError};
 use std::sync::{mpsc, Arc};
 use std::thread;
 use std::thread::JoinHandle;
@@ -57,6 +57,21 @@ impl SingleExecutor {
     {
         try_err!(self.sender.send(Box::new(task)));
         Ok(())
+    }
+
+    pub fn try_spawn<F>(&self, task: F) -> CommonResult<()>
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        match self.sender.try_send(Box::new(task)) {
+            Ok(()) => Ok(()),
+            Err(TrySendError::Full(_)) => {
+                err_box!("executor {} queue is full", self.name)
+            }
+            Err(TrySendError::Disconnected(_)) => {
+                err_box!("executor {} has stopped", self.name)
+            }
+        }
     }
 
     pub fn spawn_blocking<F, R>(&self, task: F) -> CommonResult<R>

--- a/orpc/tests/stream_handler_test.rs
+++ b/orpc/tests/stream_handler_test.rs
@@ -1,0 +1,82 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use orpc::error::CommonErrorExt;
+use orpc::handler::{Frame, MessageHandler, StreamHandler};
+use orpc::io::net::ConnState;
+use orpc::io::IOResult;
+use orpc::message::{BoxMessage, Builder, Message, RefMessage, RequestStatus};
+use orpc::runtime::{RpcRuntime, Runtime};
+use orpc::server::ServerConf;
+use std::sync::Arc;
+
+struct MemoryFrame {
+    sent: Vec<BoxMessage>,
+}
+
+impl Frame for MemoryFrame {
+    async fn send(&mut self, message: impl RefMessage) -> IOResult<()> {
+        self.sent.push(message.into_box());
+        Ok(())
+    }
+
+    async fn receive(&mut self) -> IOResult<Message> {
+        Ok(Message::empty())
+    }
+
+    fn new_conn_state(&self) -> ConnState {
+        ConnState::default()
+    }
+}
+
+struct AsyncErrorHandler;
+
+impl MessageHandler for AsyncErrorHandler {
+    type Error = CommonErrorExt;
+
+    fn is_sync(&self, _msg: &Message) -> bool {
+        false
+    }
+
+    fn handle(&mut self, _msg: &Message) -> Result<Message, Self::Error> {
+        unreachable!("test handler only uses async_handle")
+    }
+
+    async fn async_handle(&mut self, _msg: Message) -> Result<Message, Self::Error> {
+        Err(CommonErrorExt::from("async handler failed".to_string()))
+    }
+}
+
+#[test]
+fn async_handler_error_is_sent_as_response() {
+    let rt = Arc::new(Runtime::current_thread("stream-handler-test"));
+    let conf = ServerConf::with_hostname("127.0.0.1", 0);
+    let frame = MemoryFrame { sent: Vec::new() };
+    let handler = AsyncErrorHandler;
+    let mut stream_handler = StreamHandler::new(rt.clone(), frame, handler, &conf);
+    let request = Builder::new()
+        .code(1)
+        .request(RequestStatus::Open)
+        .req_id(1)
+        .build();
+
+    rt.block_on(stream_handler.call(request))
+        .expect("async handler error should not close the stream");
+
+    let sent = &stream_handler.frame_mut().sent;
+    assert_eq!(sent.len(), 1);
+    assert!(!sent[0].is_success());
+    let err = sent[0].check_error_ext::<CommonErrorExt>().unwrap_err();
+    assert!(err.to_string().contains("async handler failed"));
+}


### PR DESCRIPTION
# Summary

This PR is a hotfix follow-up to #998 for #984. It hardens load/auto-cache submission end to end: master-side load planning runs behind an isolated bounded queue, queue pressure is returned as a structured `ResourceExhausted` error, and clients use their own bounded auto-cache submit queue with retry instead of spawning unbounded submit RPCs.

# Issue Describe / Design

Related to #984. Follow-up to #998.

Root cause:
- #998 moved auto-cache load planning off the submit RPC path, but background load work still needed a bounded pressure point and a structured queue-full signal.
- The client auto-cache path submitted one async task per cache miss. When the master queue was full, the failure was only a stringly `Common` error, so the client could not make a stable retry decision.
- Public `cv load` on a CV path had ambiguous direction: UFS-only metadata should hydrate Curvine from the mounted UFS source, while a CV path that already has Curvine data should keep exporting/flushing Curvine data to UFS.
- When direct UFS reads were disabled, valid auto-cache opportunities could be skipped before the load job was submitted.

Reproduction steps:
- Drive many cache misses or `cv load` requests while master-side load planning is saturated.
- Observe that queue-full rejection is not distinguishable by error kind and client auto-cache has no local queue/retry policy.
- Mount an external UFS path in FsMode, sync UFS-only metadata, then run `cv load -w <cv-path>`.
- Disable direct UFS reads and open a valid auto-cache miss.

Fix approach:
- Add a dedicated `master-load-job` runtime plus bounded FIFO queue for master-side load planning.
- Return `FsError::ResourceExhausted` when the master load-job queue is full.
- Add a client-side bounded auto-cache submit queue with local pending-path dedupe and finite retry on `ResourceExhausted`.
- Preserve duplicate-job semantics and add explicit shutdown handling for queued master workers.
- Select CV-path load direction from real Curvine metadata: UFS-only metadata imports from UFS, existing Curvine data exports to UFS.
- Keep submit/wait/get-status job-id derivation consistent for UFS-only metadata.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-server/src/master/job/job_manager.rs` | Add dedicated load-job runtime, bounded FIFO queue, shutdown handling, duplicate detection before enqueue, queue metrics, and structured `ResourceExhausted` for queue-full. | Load planning is isolated from master RPC/Raft runtime; queue overflow is now machine-readable and retryable by clients. |
| `curvine-client/src/unified/unified_filesystem.rs` | Replace one-spawn-per-cache-miss submit with a bounded client auto-cache submit queue, pending-path dedupe, and finite retry on `ResourceExhausted`. | Auto-cache remains best-effort and no longer floods master submit RPCs under cache-miss pressure. |
| `curvine-common/src/error/fs_error.rs` | Add `ResourceExhausted` error kind and RPC encode/decode support. | Clients can distinguish resource pressure from generic failures without string matching. |
| `curvine-common/src/conf/client_conf.rs` | Add validated client auto-cache submit queue/retry defaults. | New defaults: queue 1024, retry max 3, retry sleep 100ms to 2000ms. |
| `curvine-server/src/master/job/job_runner.rs` | Split public CV-path load direction from internal replay/export tasks. | CV paths with UFS-only metadata hydrate from UFS; CV paths with Curvine data keep the original export behavior. |
| `curvine-client/src/unified/unified_filesystem.rs` | Submit auto-cache for valid UFS sources even when direct UFS reads are disabled; unify load job id selection for wait/status. | Auto-cache remains effective when UFS direct read is disabled, while missing UFS sources do not create background jobs. |
| `curvine-common/src/conf/job_conf.rs` | Add validated defaults for master load-job queue and runtime sizing. | New defaults: queue 1024, runtime threads 4, blocking threads 16. |
| `curvine-server/src/master/master_metrics.rs` | Add master load-job queue/enqueue/duplicate/running/failure metrics. | Operational visibility improves without changing client API. |
| `curvine-server/src/master/master_server.rs` | Shutdown the job manager with the master server. | Avoids leaving load-job workers alive during master shutdown. |
| Tests | Add focused coverage for config, error encoding, queue behavior, runtime isolation, duplicate submits, shutdown, CV-path direction, auto-cache, and FsMode UFS-only wait. | Test-only. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo fmt --check` | PASS | |
| `git diff --check` | PASS | |
| `git diff --cached --check` | PASS | |
| `cargo test -p curvine-common --test fs_error_test -- --nocapture` | PASS | 2 passed. |
| `cargo test -p curvine-common --test client_conf_cli_test -- --nocapture` | PASS | 15 passed. |
| `cargo test -p curvine-server --test load_job_submit_test -- --nocapture` | PASS | 12 passed. |
| `cargo test -p curvine-tests --test write_cache_test -- --nocapture` | PASS | 10 passed. |
| `cargo test -p curvine-client --tests -- --nocapture` | PASS | 54 passed. |
| `cargo clippy -p curvine-client -p curvine-common -p curvine-server -p curvine-tests --all-targets -- --deny=warnings --allow clippy::uninlined-format-args` | PASS | No issues found. |
| Local S3 mount/load E2E | PASS | Mounted S3, ran `cv load -w` on a probe file, verified completed load and no master/worker error logs during the check. |

# Dependencies

- Related PRs: #998
- Related issues: #984
- Blocks / blocked by: None
