### PR TITLE
refactor(worker): introduce BlockLayout and BlockMetaStore

### DIFF
--- a/curvine-server/src/worker/block/block_store.rs
+++ b/curvine-server/src/worker/block/block_store.rs
@@ -13,12 +13,11 @@
 // limitations under the License.
 
 use crate::worker::block::BlockMeta;
-use crate::worker::storage::{BlockDataset, Dataset};
+use crate::worker::storage::{BlockDataset, BlockLayout, Dataset};
 use curvine_common::conf::ClusterConf;
-use curvine_common::state::{ExtendedBlock, StorageInfo, StorageType};
+use curvine_common::state::{ExtendedBlock, StorageInfo};
 use log::error;
-use orpc::common::FileUtils;
-use orpc::{err_box, CommonResult};
+use orpc::CommonResult;
 use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 #[derive(Clone)]
@@ -97,39 +96,16 @@ impl BlockStore {
 
     // Asynchronously delete block.
     pub fn async_remove_block(&self, id: i64) -> CommonResult<BlockMeta> {
-        // Delete the original data.
-        let mut state = self.write()?;
-        let meta = state.block_map.remove(&id);
-
-        let meta = match meta {
-            None => return err_box!("Not found block {}", id),
-            Some(v) => v,
+        let (meta, layout) = {
+            let mut state = self.write()?;
+            let (meta, layout) = state.remove_block_state_by_id(id)?;
+            state.decrement_blocks_to_delete();
+            (meta, layout)
         };
-        state.decrement_blocks_to_delete();
-        let dir_id = meta.dir_id();
-        let is_spdk = meta.storage_type() == StorageType::SpdkDisk;
 
-        // SPDK: free bdev offset + persist metadata while holding write lock.
-        if is_spdk {
-            if let Ok(dir) = state.find_dir(dir_id) {
-                dir.state.offset_alloc.free(id);
-            }
-            state.spdk_delete(id, StorageType::SpdkDisk);
-        }
-        drop(state);
-
-        // Delete the file.
-        // SPDK blocks have no filesystem file — skip deletion.
-        if !is_spdk {
-            FileUtils::delete_path(meta.get_block_path()?, false)?;
-        }
-
-        // Update disk space.
+        layout.deallocate(&meta)?;
         let state = self.read()?;
-        let dir = state.find_dir(meta.dir_id())?;
-        dir.release_space(meta.is_final(), meta.actual_len);
-        drop(state);
-
+        state.release_block_space(&meta)?;
         Ok(meta)
     }
 

--- a/curvine-server/src/worker/storage/layout/bdev_layout.rs
+++ b/curvine-server/src/worker/storage/layout/bdev_layout.rs
@@ -1,0 +1,105 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::worker::block::{BlockMeta, BlockState};
+use crate::worker::storage::layout::BlockLayout;
+use crate::worker::storage::{SpdkMetaStore, VfsDir};
+use curvine_common::state::ExtendedBlock;
+use log::{info, warn};
+use orpc::CommonResult;
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct BdevLayout {
+    spdk_meta: Option<Arc<SpdkMetaStore>>,
+}
+
+impl BdevLayout {
+    pub fn new(spdk_meta: Option<Arc<SpdkMetaStore>>) -> Self {
+        Self { spdk_meta }
+    }
+}
+
+impl BlockLayout for BdevLayout {
+    fn allocate(&self, dir: &VfsDir, block: &ExtendedBlock) -> CommonResult<BlockMeta> {
+        let mut meta = BlockMeta::with_tmp(block, dir);
+        let offset = dir
+            .state
+            .offset_alloc
+            .allocate(block.id, block.len)
+            .map_err(|e| {
+                orpc::err_msg!(format!(
+                    "Failed to allocate bdev offset for block {}: {}",
+                    block.id, e
+                ))
+            })?;
+        meta.bdev_offset = offset;
+        Ok(meta)
+    }
+
+    fn finalize(&self, meta: &BlockMeta, committed_len: i64) -> CommonResult<BlockMeta> {
+        Ok(BlockMeta::with_final_spdk(meta, committed_len))
+    }
+
+    fn scan(&self, dir: &VfsDir) -> CommonResult<Vec<BlockMeta>> {
+        let Some(store) = self.spdk_meta.as_ref() else {
+            warn!("SPDK dir {} has no meta store - starting empty", dir.id());
+            return Ok(vec![]);
+        };
+
+        // TODO: pre-filter by dir_id in the meta store to avoid scan_all() per SPDK dir.
+        let all_records = store.scan_all()?;
+        let all_records_len = all_records.len();
+        let mut alloc_entries = Vec::new();
+        let mut blocks = Vec::new();
+        for record in all_records {
+            if record.dir_id != dir.id() {
+                continue;
+            }
+
+            alloc_entries.push((record.block_id, record.offset, record.size));
+            let state = if record.finalized {
+                BlockState::Finalized
+            } else {
+                BlockState::Recovering
+            };
+            blocks.push(BlockMeta {
+                id: record.block_id,
+                len: record.len,
+                state,
+                dir: dir.state.clone(),
+                actual_len: record.len,
+                bdev_offset: record.offset,
+            });
+        }
+        dir.state.offset_alloc.restore(&alloc_entries);
+
+        info!(
+            "Restored {} SPDK blocks for dir {} from RocksDB (skipped {} from other dirs)",
+            blocks.len(),
+            dir.id(),
+            all_records_len - blocks.len(),
+        );
+        Ok(blocks)
+    }
+
+    fn release(&self, meta: &BlockMeta) -> CommonResult<()> {
+        meta.dir.offset_alloc.free(meta.id());
+        Ok(())
+    }
+
+    fn deallocate(&self, _meta: &BlockMeta) -> CommonResult<()> {
+        Ok(())
+    }
+}

--- a/curvine-server/src/worker/storage/layout/bdev_layout.rs
+++ b/curvine-server/src/worker/storage/layout/bdev_layout.rs
@@ -99,6 +99,7 @@ impl BlockLayout for BdevLayout {
         Ok(())
     }
 
+    // SPDK blocks have no filesystem file; offset release happens in release().
     fn deallocate(&self, _meta: &BlockMeta) -> CommonResult<()> {
         Ok(())
     }

--- a/curvine-server/src/worker/storage/layout/file_layout.rs
+++ b/curvine-server/src/worker/storage/layout/file_layout.rs
@@ -55,6 +55,7 @@ impl BlockLayout for FileLayout {
         Ok(blocks)
     }
 
+    // Filesystem blocks own no under-lock state; offset/file teardown is in deallocate().
     fn release(&self, _meta: &BlockMeta) -> CommonResult<()> {
         Ok(())
     }

--- a/curvine-server/src/worker/storage/layout/file_layout.rs
+++ b/curvine-server/src/worker/storage/layout/file_layout.rs
@@ -18,7 +18,7 @@ use crate::worker::storage::VfsDir;
 use curvine_common::state::ExtendedBlock;
 use orpc::common::FileUtils;
 use orpc::CommonResult;
-use std::fs::{self, File};
+use std::fs::File;
 
 #[derive(Clone, Copy)]
 pub struct FileLayout;
@@ -60,7 +60,7 @@ impl BlockLayout for FileLayout {
     }
 
     fn deallocate(&self, meta: &BlockMeta) -> CommonResult<()> {
-        fs::remove_file(meta.get_block_path()?)?;
+        FileUtils::delete_path(meta.get_block_path()?, false)?;
         Ok(())
     }
 }

--- a/curvine-server/src/worker/storage/layout/file_layout.rs
+++ b/curvine-server/src/worker/storage/layout/file_layout.rs
@@ -1,0 +1,66 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::worker::block::{BlockMeta, BlockState};
+use crate::worker::storage::layout::BlockLayout;
+use crate::worker::storage::VfsDir;
+use curvine_common::state::ExtendedBlock;
+use orpc::common::FileUtils;
+use orpc::CommonResult;
+use std::fs::{self, File};
+
+#[derive(Clone, Copy)]
+pub struct FileLayout;
+
+impl BlockLayout for FileLayout {
+    fn allocate(&self, dir: &VfsDir, block: &ExtendedBlock) -> CommonResult<BlockMeta> {
+        let meta = BlockMeta::with_tmp(block, dir);
+        let file = meta.get_block_path()?;
+        File::create(file)?;
+        Ok(meta)
+    }
+
+    fn finalize(&self, meta: &BlockMeta, _committed_len: i64) -> CommonResult<BlockMeta> {
+        BlockMeta::with_final(meta)
+    }
+
+    fn scan(&self, dir: &VfsDir) -> CommonResult<Vec<BlockMeta>> {
+        let active_dir = FileUtils::list_files(&dir.active_dir, true)?;
+        let staging_dir = FileUtils::list_files(&dir.staging_dir, true)?;
+
+        let mut blocks = vec![];
+        for file in active_dir {
+            if let Ok(meta) = BlockMeta::from_file(&file, BlockState::Finalized, dir) {
+                blocks.push(meta);
+            }
+        }
+
+        for file in staging_dir {
+            if let Ok(meta) = BlockMeta::from_file(&file, BlockState::Recovering, dir) {
+                blocks.push(meta);
+            }
+        }
+
+        Ok(blocks)
+    }
+
+    fn release(&self, _meta: &BlockMeta) -> CommonResult<()> {
+        Ok(())
+    }
+
+    fn deallocate(&self, meta: &BlockMeta) -> CommonResult<()> {
+        fs::remove_file(meta.get_block_path()?)?;
+        Ok(())
+    }
+}

--- a/curvine-server/src/worker/storage/layout/mod.rs
+++ b/curvine-server/src/worker/storage/layout/mod.rs
@@ -1,0 +1,114 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod bdev_layout;
+mod file_layout;
+
+pub use self::bdev_layout::BdevLayout;
+pub use self::file_layout::FileLayout;
+
+use crate::worker::block::BlockMeta;
+use crate::worker::storage::{SpdkMetaStore, VfsDir};
+use curvine_common::state::{ExtendedBlock, StorageType};
+use orpc::CommonResult;
+use std::sync::Arc;
+
+pub trait BlockLayout {
+    fn allocate(&self, dir: &VfsDir, block: &ExtendedBlock) -> CommonResult<BlockMeta>;
+
+    fn finalize(&self, meta: &BlockMeta, committed_len: i64) -> CommonResult<BlockMeta>;
+
+    fn scan(&self, dir: &VfsDir) -> CommonResult<Vec<BlockMeta>>;
+
+    /// Release layout-owned state while the dataset lock is still held.
+    fn release(&self, meta: &BlockMeta) -> CommonResult<()>;
+
+    /// Remove backing resources. Callers may run this outside the dataset lock.
+    fn deallocate(&self, meta: &BlockMeta) -> CommonResult<()>;
+}
+
+#[derive(Clone)]
+pub enum BlockLayoutKind {
+    File(FileLayout),
+    Bdev(BdevLayout),
+}
+
+impl BlockLayoutKind {
+    fn file() -> Self {
+        Self::File(FileLayout)
+    }
+
+    fn bdev(spdk_meta: Option<Arc<SpdkMetaStore>>) -> Self {
+        Self::Bdev(BdevLayout::new(spdk_meta))
+    }
+}
+
+#[derive(Clone)]
+pub struct BlockLayouts {
+    file: BlockLayoutKind,
+    bdev: BlockLayoutKind,
+}
+
+impl BlockLayouts {
+    pub fn new(spdk_meta: Option<Arc<SpdkMetaStore>>) -> Self {
+        Self {
+            file: BlockLayoutKind::file(),
+            bdev: BlockLayoutKind::bdev(spdk_meta),
+        }
+    }
+
+    pub fn get(&self, storage_type: StorageType) -> &BlockLayoutKind {
+        match storage_type {
+            StorageType::SpdkDisk => &self.bdev,
+            _ => &self.file,
+        }
+    }
+}
+
+impl BlockLayout for BlockLayoutKind {
+    fn allocate(&self, dir: &VfsDir, block: &ExtendedBlock) -> CommonResult<BlockMeta> {
+        match self {
+            Self::File(layout) => layout.allocate(dir, block),
+            Self::Bdev(layout) => layout.allocate(dir, block),
+        }
+    }
+
+    fn finalize(&self, meta: &BlockMeta, committed_len: i64) -> CommonResult<BlockMeta> {
+        match self {
+            Self::File(layout) => layout.finalize(meta, committed_len),
+            Self::Bdev(layout) => layout.finalize(meta, committed_len),
+        }
+    }
+
+    fn scan(&self, dir: &VfsDir) -> CommonResult<Vec<BlockMeta>> {
+        match self {
+            Self::File(layout) => layout.scan(dir),
+            Self::Bdev(layout) => layout.scan(dir),
+        }
+    }
+
+    fn release(&self, meta: &BlockMeta) -> CommonResult<()> {
+        match self {
+            Self::File(layout) => layout.release(meta),
+            Self::Bdev(layout) => layout.release(meta),
+        }
+    }
+
+    fn deallocate(&self, meta: &BlockMeta) -> CommonResult<()> {
+        match self {
+            Self::File(layout) => layout.deallocate(meta),
+            Self::Bdev(layout) => layout.deallocate(meta),
+        }
+    }
+}

--- a/curvine-server/src/worker/storage/meta_store/mem_meta_store.rs
+++ b/curvine-server/src/worker/storage/meta_store/mem_meta_store.rs
@@ -1,0 +1,52 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::worker::block::BlockMeta;
+use std::collections::HashMap;
+
+#[derive(Default)]
+pub struct MemMetaStore {
+    blocks: HashMap<i64, BlockMeta>,
+}
+
+impl MemMetaStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn get(&self, id: i64) -> Option<&BlockMeta> {
+        self.blocks.get(&id)
+    }
+
+    pub fn put(&mut self, meta: BlockMeta) -> Option<BlockMeta> {
+        self.blocks.insert(meta.id(), meta)
+    }
+
+    pub fn remove(&mut self, id: i64) -> Option<BlockMeta> {
+        self.blocks.remove(&id)
+    }
+
+    pub fn block_count(&self) -> usize {
+        self.blocks.len()
+    }
+
+    pub fn values(&self) -> impl Iterator<Item = &BlockMeta> {
+        self.blocks.values()
+    }
+
+    #[cfg(test)]
+    pub fn contains_key(&self, id: i64) -> bool {
+        self.blocks.contains_key(&id)
+    }
+}

--- a/curvine-server/src/worker/storage/meta_store/mod.rs
+++ b/curvine-server/src/worker/storage/meta_store/mod.rs
@@ -1,0 +1,32 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod mem_meta_store;
+mod vfs_meta_store;
+
+pub use self::mem_meta_store::MemMetaStore;
+pub use self::vfs_meta_store::VfsMetaStore;
+
+use crate::worker::block::BlockMeta;
+use orpc::CommonResult;
+
+/// Persistent side-car store for block metadata records.
+///
+/// The in-memory index remains owned by `VfsMetaStore`; this trait is the narrow
+/// adapter used for stores such as the current SPDK RocksDB records.
+pub trait BlockMetaStore: Send + Sync {
+    fn put_block_meta(&self, meta: &BlockMeta) -> CommonResult<()>;
+
+    fn remove_block_meta(&self, meta: &BlockMeta) -> CommonResult<()>;
+}

--- a/curvine-server/src/worker/storage/meta_store/vfs_meta_store.rs
+++ b/curvine-server/src/worker/storage/meta_store/vfs_meta_store.rs
@@ -1,0 +1,88 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::worker::block::BlockMeta;
+use crate::worker::storage::meta_store::{BlockMetaStore, MemMetaStore};
+use crate::worker::storage::SpdkMetaStore;
+use curvine_common::state::StorageType;
+use log::warn;
+use std::sync::Arc;
+
+pub struct VfsMetaStore {
+    mem: MemMetaStore,
+    spdk: Option<Arc<SpdkMetaStore>>,
+}
+
+impl VfsMetaStore {
+    pub fn new(spdk: Option<Arc<SpdkMetaStore>>) -> Self {
+        Self {
+            mem: MemMetaStore::new(),
+            spdk,
+        }
+    }
+
+    pub fn get(&self, id: i64) -> Option<&BlockMeta> {
+        self.mem.get(id)
+    }
+
+    pub fn put(&mut self, meta: BlockMeta) -> Option<BlockMeta> {
+        self.persist_spdk_put(&meta);
+        self.mem.put(meta)
+    }
+
+    pub fn remove(&mut self, id: i64) -> Option<BlockMeta> {
+        let meta = self.mem.remove(id);
+        if let Some(meta) = meta.as_ref() {
+            self.persist_spdk_remove(meta);
+        }
+        meta
+    }
+
+    pub fn block_count(&self) -> usize {
+        self.mem.block_count()
+    }
+
+    pub fn all_blocks(&self) -> Vec<BlockMeta> {
+        self.mem.values().cloned().collect()
+    }
+
+    #[cfg(test)]
+    pub fn contains_key(&self, id: i64) -> bool {
+        self.mem.contains_key(id)
+    }
+
+    fn persist_spdk_put(&self, meta: &BlockMeta) {
+        if meta.storage_type() != StorageType::SpdkDisk {
+            return;
+        }
+
+        if let Some(store) = self.spdk.as_ref() {
+            if let Err(e) = store.put_block_meta(meta) {
+                warn!("SpdkMetaStore put failed for block {}: {}", meta.id(), e);
+            }
+        }
+    }
+
+    fn persist_spdk_remove(&self, meta: &BlockMeta) {
+        if meta.storage_type() != StorageType::SpdkDisk {
+            return;
+        }
+
+        if let Some(store) = self.spdk.as_ref() {
+            if let Err(e) = store.remove_block_meta(meta) {
+                warn!("SpdkMetaStore delete failed for block {}: {}", meta.id(), e);
+            }
+        }
+    }
+}

--- a/curvine-server/src/worker/storage/mod.rs
+++ b/curvine-server/src/worker/storage/mod.rs
@@ -33,6 +33,12 @@ pub use self::dir_state::{DirState, DEFAULT_BLOCK_ALIGN};
 mod spdk_meta_store;
 pub use self::spdk_meta_store::SpdkMetaStore;
 
+mod meta_store;
+pub use self::meta_store::*;
+
+mod layout;
+pub use self::layout::*;
+
 mod vfs_dataset;
 pub use self::vfs_dataset::VfsDataset;
 

--- a/curvine-server/src/worker/storage/spdk_meta_store.rs
+++ b/curvine-server/src/worker/storage/spdk_meta_store.rs
@@ -1,4 +1,6 @@
 //! RocksDB-backed SPDK block metadata.
+use crate::worker::block::BlockMeta;
+use crate::worker::storage::meta_store::BlockMetaStore;
 /// Key: block_id (8B). Value: dir_id(4B) | offset(8B) | size(8B) | len(8B) | finalized(1B) = 29B.
 /// O(1) per block
 use byteorder::{BigEndian, ByteOrder};
@@ -121,6 +123,29 @@ impl SpdkMetaStore {
             len: BigEndian::read_i64(&bytes[20..28]),
             finalized: bytes[28] != 0,
         })
+    }
+}
+
+impl BlockMetaStore for SpdkMetaStore {
+    fn put_block_meta(&self, meta: &BlockMeta) -> CommonResult<()> {
+        let alloc_size = meta
+            .dir
+            .offset_alloc
+            .get_entry(meta.id())
+            .map_or(meta.actual_len, |(_, size)| size);
+
+        self.put(
+            meta.id(),
+            meta.dir_id(),
+            meta.bdev_offset,
+            alloc_size,
+            meta.len(),
+            meta.is_final(),
+        )
+    }
+
+    fn remove_block_meta(&self, meta: &BlockMeta) -> CommonResult<()> {
+        self.delete(meta.id())
     }
 }
 #[cfg(test)]

--- a/curvine-server/src/worker/storage/vfs_dataset.rs
+++ b/curvine-server/src/worker/storage/vfs_dataset.rs
@@ -13,15 +13,17 @@
 // limitations under the License.
 
 use crate::worker::block::{BlockMeta, BlockState};
-use crate::worker::storage::{Dataset, DirList, SpdkMetaStore, StorageVersion, VfsDir};
+use crate::worker::storage::{
+    BlockLayout, BlockLayoutKind, BlockLayouts, Dataset, DirList, SpdkMetaStore, StorageVersion,
+    VfsDir, VfsMetaStore,
+};
 use curvine_common::conf::{ClusterConf, WorkerDataDir};
 use curvine_common::state::{ExtendedBlock, StorageType};
 use indexmap::map::Values;
-use log::{info, warn};
+use log::info;
 use orpc::common::{ByteUnit, FileUtils, LocalTime, TimeSpent};
-use orpc::{err_box, try_err, CommonResult};
+use orpc::{err_box, CommonResult};
 use std::collections::HashMap;
-use std::fs;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
@@ -30,11 +32,9 @@ pub struct VfsDataset {
     worker_id: u32,
     ctime: u64,
     dir_list: DirList,
-    pub(crate) block_map: HashMap<i64, BlockMeta>,
+    meta: VfsMetaStore,
+    layouts: BlockLayouts,
     num_blocks_to_delete: AtomicUsize,
-    /// RocksDB-backed store for SPDK block metadata. `None` when no SPDK
-    /// directories are configured.
-    spdk_meta: Option<Arc<SpdkMetaStore>>,
 }
 
 impl VfsDataset {
@@ -53,9 +53,9 @@ impl VfsDataset {
             worker_id,
             ctime: LocalTime::mills(),
             dir_list,
-            block_map: HashMap::new(),
+            meta: VfsMetaStore::new(spdk_meta.clone()),
+            layouts: BlockLayouts::new(spdk_meta),
             num_blocks_to_delete: AtomicUsize::new(0),
-            spdk_meta,
         };
         ds.initialize()?;
         Ok(ds)
@@ -130,33 +130,23 @@ impl VfsDataset {
 
     // Initialize.
     // 1. Scan all blocks in the directory (filesystem or RocksDB for SPDK)
-    // 2. Block is added to block_map.
+    // 2. Block is added to meta store.
     // 3. Update capacity usage.
     // TODO: pre-filter to avoid scan_all() per SPDK dir
     fn initialize(&mut self) -> CommonResult<()> {
         let spent = TimeSpent::new();
         for dir in self.dir_list.dir_iter() {
-            let blocks = if dir.storage_type() == StorageType::SpdkDisk {
-                // SPDK dirs: restore from RocksDB
-                match &self.spdk_meta {
-                    Some(store) => dir.scan_spdk_blocks(store)?,
-                    None => {
-                        warn!("SPDK dir {} has no meta store — starting empty", dir.id());
-                        vec![]
-                    }
-                }
-            } else {
-                dir.scan_blocks()?
-            };
+            let layout = self.layouts.get(dir.storage_type());
+            let blocks = layout.scan(dir)?;
             for block in blocks {
                 dir.reserve_space(true, block.len);
-                self.block_map.insert(block.id, block);
+                self.meta.put(block);
             }
         }
         info!(
             "Dataset initialize, used {} ms, total block {}",
             spent.used_ms(),
-            self.block_map.len()
+            self.meta.block_count()
         );
         Ok(())
     }
@@ -187,46 +177,7 @@ impl VfsDataset {
     }
 
     pub fn all_blocks(&self) -> Vec<BlockMeta> {
-        let mut vec = vec![];
-        for meta in self.block_map.values() {
-            vec.push(meta.clone());
-        }
-        vec
-    }
-    /// Persist one SPDK block's metadata to RocksDB. No-op if no SPDK store.
-    fn spdk_put(&self, meta: &BlockMeta) {
-        if meta.storage_type() != StorageType::SpdkDisk {
-            return;
-        }
-        if let Some(ref store) = self.spdk_meta {
-            let alloc_size = meta
-                .dir
-                .offset_alloc
-                .get_entry(meta.id)
-                .map_or(meta.actual_len, |(_, sz)| sz);
-            if let Err(e) = store.put(
-                meta.id,
-                meta.dir_id(),
-                meta.bdev_offset,
-                alloc_size,
-                meta.len,
-                meta.is_final(),
-            ) {
-                warn!("SpdkMetaStore put failed for block {}: {}", meta.id, e);
-            }
-        }
-    }
-
-    /// Remove one SPDK block's metadata from RocksDB. No-op if no SPDK store.
-    pub(crate) fn spdk_delete(&self, block_id: i64, storage_type: StorageType) {
-        if storage_type != StorageType::SpdkDisk {
-            return;
-        }
-        if let Some(ref store) = self.spdk_meta {
-            if let Err(e) = store.delete(block_id) {
-                warn!("SpdkMetaStore delete failed for block {}: {}", block_id, e);
-            }
-        }
+        self.meta.all_blocks()
     }
 
     #[cfg(test)]
@@ -239,6 +190,37 @@ impl VfsDataset {
             .dir_iter()
             .find(|d| d.id() == dir_id)
             .map(|d| &d.state.offset_alloc)
+    }
+
+    pub(crate) fn remove_block_state_by_id(
+        &mut self,
+        id: i64,
+    ) -> CommonResult<(BlockMeta, BlockLayoutKind)> {
+        let meta = match self.meta.remove(id) {
+            None => return err_box!("Not found block {}", id),
+            Some(meta) => meta,
+        };
+
+        let layout = self.layouts.get(meta.storage_type());
+        if meta.storage_type() == StorageType::SpdkDisk {
+            self.find_dir(meta.dir_id())?;
+        }
+        layout.release(&meta)?;
+
+        Ok((meta, layout.clone()))
+    }
+
+    pub(crate) fn release_block_space(&self, meta: &BlockMeta) -> CommonResult<()> {
+        let dir = self.find_dir(meta.dir_id())?;
+        dir.release_space(meta.is_final(), meta.actual_len);
+        Ok(())
+    }
+
+    pub(crate) fn remove_block_by_id(&mut self, id: i64) -> CommonResult<BlockMeta> {
+        let (meta, layout) = self.remove_block_state_by_id(id)?;
+        layout.deallocate(&meta)?;
+        self.release_block_space(&meta)?;
+        Ok(meta)
     }
 }
 
@@ -256,7 +238,7 @@ impl Dataset for VfsDataset {
     }
 
     fn num_blocks(&self) -> usize {
-        self.block_map.len()
+        self.meta.block_count()
     }
 
     fn num_blocks_to_delete(&self) -> usize {
@@ -272,11 +254,11 @@ impl Dataset for VfsDataset {
     }
 
     fn get_block(&self, id: i64) -> Option<&BlockMeta> {
-        self.block_map.get(&id)
+        self.meta.get(id)
     }
 
     fn open_block(&mut self, block: &ExtendedBlock) -> CommonResult<BlockMeta> {
-        match self.block_map.get(&block.id) {
+        match self.meta.get(block.id).cloned() {
             Some(meta) => {
                 if meta.is_active() {
                     let dir = self.find_dir(meta.dir_id())?;
@@ -286,8 +268,7 @@ impl Dataset for VfsDataset {
 
                     dir.release_space(meta.is_final(), meta.actual_len);
                     dir.reserve_space(false, new_meta.len);
-                    self.block_map.insert(new_meta.id(), new_meta.clone());
-                    self.spdk_put(&new_meta);
+                    self.meta.put(new_meta.clone());
 
                     Ok(new_meta)
                 } else {
@@ -301,11 +282,11 @@ impl Dataset for VfsDataset {
 
             None => {
                 let dir = self.dir_list.choose_dir(block)?;
-                let meta = dir.create_block(block)?;
+                let layout = self.layouts.get(dir.storage_type());
+                let meta = layout.allocate(dir, block)?;
 
-                self.block_map.insert(meta.id(), meta.clone());
+                self.meta.put(meta.clone());
                 dir.reserve_space(false, block.len);
-                self.spdk_put(&meta);
 
                 Ok(meta)
             }
@@ -313,66 +294,56 @@ impl Dataset for VfsDataset {
     }
 
     fn finalize_block(&mut self, block: &ExtendedBlock) -> CommonResult<BlockMeta> {
-        let meta = self.get_block_check(block.id)?;
-        if meta.state() == &BlockState::Finalized {
-            if meta.len() == block.len {
-                return Ok(meta.clone());
+        // Keep the meta borrow scoped before mutating the meta store and dir accounting.
+        let (dir_id, actual_len, final_meta) = {
+            let meta = self.get_block_check(block.id)?;
+            if meta.state() == &BlockState::Finalized {
+                if meta.len() == block.len {
+                    return Ok(meta.clone());
+                }
+                return err_box!(
+                    "finalized block {} length mismatch, expected: {}, actual: {}",
+                    meta.id(),
+                    block.len,
+                    meta.len()
+                );
             }
-            return err_box!(
-                "finalized block {} length mismatch, expected: {}, actual: {}",
-                meta.id(),
-                block.len,
-                meta.len()
-            );
-        }
-        if meta.state() != &BlockState::Writing {
-            return err_box!(
-                "block {} status incorrect, expected {:?}, actual: {:?}",
-                meta.id(),
-                BlockState::Writing,
-                meta.state()
-            );
-        }
+            if meta.state() != &BlockState::Writing {
+                return err_box!(
+                    "block {} status incorrect, expected {:?}, actual: {:?}",
+                    meta.id(),
+                    BlockState::Writing,
+                    meta.state()
+                );
+            }
 
-        let dir = self.find_dir(meta.dir_id())?;
-        let final_meta = dir.finalize_block(meta, block.len)?;
-        if block.len != final_meta.len() {
-            return err_box!(
-                "Block {} length mismatch, expected: {}, actual: {}",
-                meta.id(),
-                block.len,
-                final_meta.len()
-            );
-        }
+            let layout = self.layouts.get(meta.storage_type());
+            let final_meta = layout.finalize(meta, block.len)?;
+            if block.len != final_meta.len() {
+                return err_box!(
+                    "Block {} length mismatch, expected: {}, actual: {}",
+                    meta.id(),
+                    block.len,
+                    final_meta.len()
+                );
+            }
 
-        dir.release_space(false, meta.actual_len);
+            (meta.dir_id(), meta.actual_len, final_meta)
+        };
+
+        let dir = self.find_dir(dir_id)?;
+        dir.release_space(false, actual_len);
         dir.reserve_space(true, final_meta.actual_len);
-        self.block_map.insert(final_meta.id(), final_meta.clone());
-        self.spdk_put(&final_meta);
+        self.meta.put(final_meta.clone());
 
         Ok(final_meta)
     }
 
     fn abort_block(&mut self, block: &ExtendedBlock) -> CommonResult<()> {
-        let meta = match self.block_map.remove(&block.id) {
-            None => return Ok(()),
-            Some(v) => v,
-        };
-
-        let dir_id = meta.dir_id();
-        let is_spdk = meta.storage_type() == StorageType::SpdkDisk;
-        // SPDK: no filesystem file - nothing to delete.
-        if !is_spdk {
-            let file = meta.get_block_path()?;
-            try_err!(fs::remove_file(file));
+        if self.meta.get(block.id).is_none() {
+            return Ok(());
         }
-        let dir = self.find_dir(dir_id)?;
-
-        if is_spdk {
-            self.spdk_delete(block.id, meta.storage_type());
-            dir.state.offset_alloc.free(block.id);
-        }
-        dir.release_space(meta.is_final(), meta.actual_len);
+        self.remove_block_by_id(block.id)?;
         Ok(())
     }
 
@@ -383,8 +354,6 @@ impl Dataset for VfsDataset {
 
 #[cfg(test)]
 mod test {
-    use crate::worker::block::BlockMeta;
-    use crate::worker::block::BlockState;
     use crate::worker::storage::{Dataset, DirList, DirState, StorageVersion, VfsDataset, VfsDir};
     use curvine_common::conf::{ClusterConf, WorkerConf};
     use curvine_common::state::{ExtendedBlock, FileType, StorageType};
@@ -485,31 +454,16 @@ mod test {
         }
         drop(ds);
         let ds = create_data_set(false, "init");
-        assert_eq!(ds.block_map.len(), 11);
+        assert_eq!(ds.num_blocks(), 11);
         Ok(())
     }
     #[test]
     fn abort_spdk() -> CommonResult<()> {
-        let st = spdk_state(1);
-        let mut ds = VfsDataset::new("t", DirList::new(vec![spdk_dir(st.clone())])?, None)?;
-        let meta = BlockMeta {
-            id: 1,
-            len: 4096,
-            state: BlockState::Writing,
-            dir: st,
-            actual_len: 4096,
-            bdev_offset: 0,
-        };
-        ds.block_map.insert(1, meta);
-        let ok = ds
-            .abort_block(&ExtendedBlock::new(
-                1,
-                4096,
-                StorageType::SpdkDisk,
-                FileType::File,
-            ))
-            .is_ok();
-        assert!(ok && !ds.block_map.contains_key(&1));
+        let mut ds = spdk_dataset()?;
+        let block = ExtendedBlock::new(1, 4096, StorageType::SpdkDisk, FileType::File);
+        ds.open_block(&block)?;
+        let ok = ds.abort_block(&block).is_ok();
+        assert!(ok && ds.get_block(1).is_none());
         Ok(())
     }
     #[test]
@@ -521,7 +475,7 @@ mod test {
         assert_eq!(ds.offset_alloc_for_dir(1).unwrap().allocated_count(), 1);
 
         ds.abort_block(&block1)?;
-        assert!(!ds.block_map.contains_key(&1));
+        assert!(ds.get_block(1).is_none());
         assert_eq!(ds.offset_alloc_for_dir(1).unwrap().free_list_size(), 1);
 
         let block2 = ExtendedBlock::new(2, 4096, StorageType::SpdkDisk, FileType::File);

--- a/curvine-server/src/worker/storage/vfs_dataset.rs
+++ b/curvine-server/src/worker/storage/vfs_dataset.rs
@@ -202,10 +202,9 @@ impl VfsDataset {
         };
 
         let layout = self.layouts.get(meta.storage_type());
-        if meta.storage_type() == StorageType::SpdkDisk {
-            self.find_dir(meta.dir_id())?;
+        if self.find_dir(meta.dir_id()).is_ok() {
+            layout.release(&meta)?;
         }
-        layout.release(&meta)?;
 
         Ok((meta, layout.clone()))
     }

--- a/curvine-server/src/worker/storage/vfs_dir.rs
+++ b/curvine-server/src/worker/storage/vfs_dir.rs
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::worker::block::{BlockMeta, BlockState};
 use crate::worker::storage::{
     DirState, StorageVersion, ACTIVE_DIR, DEFAULT_BLOCK_ALIGN, STAGING_DIR,
 };
 use curvine_common::conf::WorkerDataDir;
-use curvine_common::state::{ExtendedBlock, StorageType};
+use curvine_common::state::StorageType;
 use log::*;
 use orpc::common::{ByteUnit, FileUtils};
 #[cfg(feature = "spdk")]
@@ -25,9 +24,8 @@ use orpc::io::spdk_env::SpdkEnv;
 use orpc::io::LocalFile;
 use orpc::sync::AtomicLong;
 use orpc::sys::FsStats;
-use orpc::{try_err, CommonResult};
+use orpc::CommonResult;
 use std::fmt::{Debug, Formatter};
-use std::fs::File;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -304,115 +302,6 @@ impl VfsDir {
         }
     }
 
-    pub fn create_block(&self, block: &ExtendedBlock) -> CommonResult<BlockMeta> {
-        let mut meta = BlockMeta::with_tmp(block, self);
-        if self.storage_type == StorageType::SpdkDisk {
-            // Allocate a non-overlapping offset range on the bdev for this block.
-            let offset = self
-                .state
-                .offset_alloc
-                .allocate(block.id, block.len)
-                .map_err(|e| {
-                    orpc::err_msg!(format!(
-                        "Failed to allocate bdev offset for block {}: {}",
-                        block.id, e
-                    ))
-                })?;
-            meta.bdev_offset = offset;
-        } else {
-            let file = meta.get_block_path()?;
-            let _ = try_err!(File::create(file));
-        }
-        Ok(meta)
-    }
-
-    pub fn finalize_block(&self, meta: &BlockMeta, committed_len: i64) -> CommonResult<BlockMeta> {
-        if self.storage_type == StorageType::SpdkDisk {
-            // SPDK: skip metadata stat (use in-memory BlockMeta)
-            return Ok(BlockMeta::with_final_spdk(meta, committed_len));
-        }
-        let final_meta = BlockMeta::with_final(meta)?;
-        Ok(final_meta)
-    }
-
-    // Scan all blocks in the directory
-    pub fn scan_blocks(&self) -> CommonResult<Vec<BlockMeta>> {
-        // SPDK bdevs don't store blocks on the filesystem — nothing to scan
-        if self.storage_type == StorageType::SpdkDisk {
-            // SPDK: loaded via scan_spdk_blocks() in VfsDataset
-            return Ok(vec![]);
-        }
-        let active_dir = FileUtils::list_files(&self.active_dir, true)?;
-        let staging_dir = FileUtils::list_files(&self.staging_dir, true)?;
-
-        let mut vec = vec![];
-        for file in active_dir {
-            if let Ok(v) = BlockMeta::from_file(&file, BlockState::Finalized, self) {
-                vec.push(v);
-            }
-        }
-
-        for file in staging_dir {
-            if let Ok(v) = BlockMeta::from_file(&file, BlockState::Recovering, self) {
-                vec.push(v);
-            }
-        }
-
-        Ok(vec)
-    }
-
-    /// Restore SPDK block metadata from RocksDB on restart.
-    /// Called during dataset initialization for SPDK directories.
-    /// - Loads all block records from RocksDB
-    /// - Filters to this directory's dir_id
-    /// - Restores the offset allocator state
-    /// - Returns blocks as BlockMeta (non-finalized blocks become Recovering state)
-    pub fn scan_spdk_blocks(&self, store: &super::SpdkMetaStore) -> CommonResult<Vec<BlockMeta>> {
-        let all_records = store.scan_all()?;
-        let all_records_len = all_records.len();
-        // Filter to only records belonging to this directory.
-        let records: Vec<_> = all_records
-            .into_iter()
-            .filter(|r| r.dir_id == self.id())
-            .collect();
-
-        // Restore the offset allocator from the saved entries.
-        let alloc_entries: Vec<(i64, i64, i64)> = records
-            .iter()
-            .map(|r| (r.block_id, r.offset, r.size))
-            .collect();
-        self.state.offset_alloc.restore(&alloc_entries);
-
-        // Reconstruct BlockMeta for each saved block.
-        let mut blocks = Vec::with_capacity(records.len());
-        for rec in &records {
-            let state = if rec.finalized {
-                BlockState::Finalized
-            } else {
-                // Non-finalized blocks found after restart are treated as
-                // recovering — the write was interrupted.
-                BlockState::Recovering
-            };
-            let block = BlockMeta {
-                id: rec.block_id,
-                len: rec.len,
-                state,
-                dir: self.state.clone(),
-                actual_len: rec.len,
-                bdev_offset: rec.offset,
-            };
-            blocks.push(block);
-        }
-
-        info!(
-            "Restored {} SPDK blocks for dir {} from RocksDB (skipped {} from other dirs)",
-            blocks.len(),
-            self.id(),
-            all_records_len - blocks.len(),
-        );
-        Ok(blocks)
-    }
-
     pub fn check_dir(&self) -> CommonResult<()> {
         if self.storage_type == StorageType::SpdkDisk {
             return Ok(());
@@ -463,9 +352,11 @@ impl Debug for VfsDir {
 #[cfg(all(test, feature = "spdk"))]
 mod test {
     use super::*;
+    use crate::worker::block::{BlockMeta, BlockState};
     use crate::worker::storage::vfs_dir::VfsDir;
-    use crate::worker::storage::StorageVersion;
-    use crate::worker::storage::DEFAULT_BLOCK_ALIGN;
+    use crate::worker::storage::{
+        BdevLayout, BlockLayout, FileLayout, StorageVersion, DEFAULT_BLOCK_ALIGN,
+    };
     use curvine_common::conf::WorkerDataDir;
     use curvine_common::state::{ExtendedBlock, StorageType};
     use orpc::common::{ByteUnit, FileUtils};
@@ -545,7 +436,8 @@ mod test {
 
         // add tmp block
         let block = ExtendedBlock::with_size_str(1122, "10MB", StorageType::Mem)?;
-        let tmp = dir.create_block(&block)?;
+        let layout = FileLayout;
+        let tmp = layout.allocate(&dir, &block)?;
         dir.reserve_space(false, block.len);
 
         let tmp_file = tmp.get_block_path()?;
@@ -564,7 +456,7 @@ mod test {
 
         // commit block
         // commit block (committed_len = 1MB, the actual data written)
-        let final1 = dir.finalize_block(&tmp, ByteUnit::MB as i64)?;
+        let final1 = layout.finalize(&tmp, ByteUnit::MB as i64)?;
         let file = final1.get_block_path()?;
         dir.release_space(false, block.len);
         dir.reserve_space(false, final1.len);
@@ -581,9 +473,8 @@ mod test {
     // SPDK: finalize_block skips path.metadata()
     #[test]
     fn finalize_block_spdk() -> CommonResult<()> {
-        use crate::worker::block::{BlockMeta, BlockState};
         let st = spdk_state("/spdk/final", 1 << 30);
-        let dir = spdk_dir("/spdk/final", st.clone(), 1 << 30);
+        let _dir = spdk_dir("/spdk/final", st.clone(), 1 << 30);
         let meta = BlockMeta {
             id: 1,
             len: 4096,
@@ -592,7 +483,8 @@ mod test {
             actual_len: 4096,
             bdev_offset: 0,
         };
-        let r = dir.finalize_block(&meta, 2048)?;
+        let layout = BdevLayout::new(None);
+        let r = layout.finalize(&meta, 2048)?;
         assert_eq!(r.len, 2048);
         Ok(())
     }


### PR DESCRIPTION
# Summary

This PR introduces two new abstraction boundaries for the worker block storage path: `BlockLayout` (encapsulates filesystem vs SPDK block lifecycle operations) and `BlockMetaStore` (provides a unified metadata store interface for the in-memory index and optional SPDK RocksDB persistence). The goal is to isolate SPDK-specific branching from `BlockStore`, `VfsDataset`, and `VfsDir` so that future storage layouts or metadata backends can be added safely.

# Issue Describe / Design

- **Root cause:** The worker block path did not have a real abstraction boundary. `VfsDir` mixed media accounting with block lifecycle work such as allocate, finalize, scan, and remove. `VfsDataset` owned both the live block map and SPDK RocksDB persistence details, so callers still had to understand SPDK-specific metadata. As SPDK support grew, `StorageType::SpdkDisk` branches spread through the worker storage path, making future layouts or worker-side metadata stores hard to add safely.
- **Fix approach:**
  - Add `BlockLayout` trait with `FileLayout` (filesystem blocks) and `BdevLayout` (SPDK blocks) implementations for the block lifecycle operations covered by this first PR.
  - Add `BlockLayouts` as the dataset-local registry that maps `StorageType` to the correct layout without passing SPDK state through non-SPDK paths.
  - Add `BlockMetaStore` trait plus `MemMetaStore` (in-memory index) and `VfsMetaStore` (in-memory + SPDK persistence coordinator), and adapt `SpdkMetaStore` to the new metadata-store boundary while preserving the existing 29-byte RocksDB value format.
  - Move filesystem block lifecycle code out of `VfsDir` into `FileLayout`.
  - Move SPDK allocation, restore, and deallocation lifecycle code into `BdevLayout`.
  - Route `BlockStore::async_remove_block` through `VfsDataset` instead of directly manipulating storage internals.
- **Design decisions:**
  - `VfsDataset` remains the orchestrator for block lifecycle consistency.
  - `VfsDir` is reduced toward media state, capacity accounting, and health checks.
  - `VfsMetaStore` coordinates the in-memory index with optional SPDK persistence, so callers do not need to branch on SPDK metadata details.
  - The handler data path is intentionally unchanged in this PR: `BlockMeta::create_reader/create_writer` and the handler-owned `BlockDevice` flow stay as-is.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-server/src/worker/block/block_store.rs` | Route `async_remove_block` through `VfsDataset` instead of manipulating storage internals | None |
| `curvine-server/src/worker/storage/layout/mod.rs` | Add `BlockLayout` trait, `BlockLayoutKind` enum, and `BlockLayouts` registry | New module |
| `curvine-server/src/worker/storage/layout/file_layout.rs` | `FileLayout`: allocate/finalize/scan/release/deallocate for filesystem blocks | New module |
| `curvine-server/src/worker/storage/layout/bdev_layout.rs` | `BdevLayout`: allocate/finalize/scan/release/deallocate for SPDK blocks | New module |
| `curvine-server/src/worker/storage/meta_store/mod.rs` | Add `BlockMetaStore` trait | New module |
| `curvine-server/src/worker/storage/meta_store/mem_meta_store.rs` | `MemMetaStore`: in-memory block index | New module |
| `curvine-server/src/worker/storage/meta_store/vfs_meta_store.rs` | `VfsMetaStore`: coordinates in-memory index with SPDK persistence | New module |
| `curvine-server/src/worker/storage/spdk_meta_store.rs` | Implement `BlockMetaStore` trait, preserving 29-byte RocksDB value format | None |
| `curvine-server/src/worker/storage/vfs_dataset.rs` | Replace `block_map` + `spdk_meta` with `VfsMetaStore`, delegate lifecycle to `BlockLayouts`, add `remove_block_state_by_id`/`release_block_space`/`remove_block_by_id` | None |
| `curvine-server/src/worker/storage/vfs_dir.rs` | Remove `create_block`, `finalize_block`, `scan_blocks`, `scan_spdk_blocks` (moved to layouts) | None |
| `curvine-server/src/worker/storage/mod.rs` | Export `meta_store` and `layout` modules | None |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo fmt --check` | PASS | |
| `git diff --check` | PASS | |
| `cargo test -p curvine-server` | PASS | |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None