### PR TITLE
fix(cli): remove redundant conf arg shadowing global config in load subcommands (#1008)

### DIFF
--- a/curvine-cli/src/cmds/load.rs
+++ b/curvine-cli/src/cmds/load.rs
@@ -23,9 +23,6 @@ use orpc::CommonResult;
 pub struct LoadCommand {
     path: String,
 
-    #[arg(long, default_value = "${CURVINE_CONF_FILE}")]
-    conf: String,
-
     /// Watch load job status after submission
     #[arg(long, short = 'w')]
     watch: bool,
@@ -46,12 +43,8 @@ impl LoadCommand {
         println!("{}", rep);
 
         if self.watch {
-            let status_command = LoadStatusCommand::new(
-                rep.job_id.clone(),
-                false,
-                "1s".to_string(),
-                self.conf.clone(),
-            );
+            let status_command =
+                LoadStatusCommand::new(rep.job_id.clone(), false, "1s".to_string());
 
             status_command.execute(client).await?;
         }

--- a/curvine-cli/src/cmds/load_cancel.rs
+++ b/curvine-cli/src/cmds/load_cancel.rs
@@ -21,9 +21,6 @@ use crate::util::*;
 #[derive(Parser, Debug)]
 pub struct CancelLoadCommand {
     job_id: String,
-
-    #[arg(long, default_value = "${CURVINE_CONF_FILE}")]
-    conf: String,
 }
 
 impl CancelLoadCommand {

--- a/curvine-cli/src/cmds/load_status.rs
+++ b/curvine-cli/src/cmds/load_status.rs
@@ -28,18 +28,14 @@ pub struct LoadStatusCommand {
 
     #[arg(long, short = 'w', default_value = "5s")]
     watch: Option<String>,
-
-    #[arg(long, default_value = "${CURVINE_CONF_FILE}")]
-    conf: String,
 }
 
 impl LoadStatusCommand {
-    pub fn new(job_id: String, verbose: bool, watch: String, conf: String) -> Self {
+    pub fn new(job_id: String, verbose: bool, watch: String) -> Self {
         Self {
             job_id,
             verbose,
             watch: Some(watch),
-            conf,
         }
     }
     pub async fn execute(&self, client: JobMasterClient) -> CommonResult<()> {


### PR DESCRIPTION
# Summary

Remove the redundant `--conf` argument from `load`, `load-status`, and `cancel-load` subcommands that shadowed the global `--conf` argument on `CurvineArgs`, causing the CLI to ignore user-provided config files and fall back to the default `localhost:8995` master address.

# Issue Describe / Design

Closes #1008

**Root cause:** `CurvineArgs` in `main.rs` defines a global `--conf` argument (`global = true`). However, the `LoadCommand`, `LoadStatusCommand`, and `CancelLoadCommand` subcommands each also defined their own `--conf` argument with `default_value = "${CURVINE_CONF_FILE}"`. In clap, a subcommand-level argument shadows the global argument. When users passed `--conf /path/to/config` after the subcommand (e.g., `cv load-status <job_id> --conf /path`), the value was captured by the subcommand's `conf` field, while `CurvineArgs.conf` remained `None`. Since `get_conf()` only reads `self.conf` (the global arg), the config file was never loaded, and the CLI fell back to the default configuration with `localhost:8995`.

Additionally, the `default_value = "${CURVINE_CONF_FILE}"` is a literal string — clap does not expand environment variables in `default_value`. The subcommand `conf` fields were dead code, never used for configuration loading.

**Fix approach:** Remove the redundant `conf` field from all affected subcommands so the global `--conf` argument on `CurvineArgs` is the single source of truth. The `get_conf()` method already handles the priority chain: CLI `--conf` -> `CURVINE_CONF_FILE` env var -> default config.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-cli/src/cmds/load_status.rs` | Removed `conf` field and updated `new()` signature | `--conf` now correctly routes to the global argument |
| `curvine-cli/src/cmds/load.rs` | Removed `conf` field and updated `LoadStatusCommand::new()` call | Same as above |
| `curvine-cli/src/cmds/load_cancel.rs` | Removed `conf` field | Same as above |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo check -p curvine-cli` | PASS | Compilation verified |

# Dependencies

- Related issues: #1008
- Related PRs: None
- Blocks / blocked by: None
