### PR TITLE
build(docker): narrow runtime image build scope

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -290,8 +290,8 @@ mkdir -p "$DIST_DIR"/lib
 mkdir -p "$DIST_DIR"/tests
 
 
-# Copy configuration files and bin
-cp "$FS_HOME"/etc/* "$DIST_DIR"/conf
+# Copy configuration files and directories.
+cp -R "$FS_HOME"/etc/. "$DIST_DIR"/conf/
 
 cp "$FS_HOME"/build/bin/* "$DIST_DIR"/bin
 chmod +x "$DIST_DIR"/bin/*

--- a/curvine-docker/deploy/Dockerfile_rocky9
+++ b/curvine-docker/deploy/Dockerfile_rocky9
@@ -77,7 +77,7 @@ ENTRYPOINT []
 # Examples:
 #   -p core --ufs opendal-s3 --spdk-rdma                   # Core + S3 + SPDK-RDMA
 #   -p server -p client -p tests --ufs opendal-s3 --spdk   # Bench + SPDK-TCP only
-ARG BUILD_ARGS="--skip-java-sdk --ufs opendal-s3 --ufs opendal-oss --ufs opendal-azblob --ufs opendal-gcs --ufs opendal-hdfs-native --ufs oss-hdfs --spdk-rdma"
+ARG BUILD_ARGS="-p server -p client -p cli -p fuse -p web --skip-java-sdk --skip-python-sdk --ufs opendal-s3 --ufs opendal-oss --ufs opendal-azblob --ufs opendal-gcs --ufs opendal-hdfs-native --ufs oss-hdfs --spdk-rdma"
 
 # Copy and apply build configurations
 COPY curvine-docker/deploy/config /build-config/config
@@ -95,35 +95,14 @@ WORKDIR /workspace
 ENV SPDK_DIR=/opt/spdk
 ENV PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig
 
-# 6. Pre-install WebUI dependencies and fix vue-cli-service module resolution
-RUN if [ -d "/workspace/curvine-web/webui" ]; then \
-        echo "Pre-installing WebUI dependencies..."; \
-        cd /workspace/curvine-web/webui && \
-        npm install --legacy-peer-deps && \
-        echo "npm install completed" && \
-        # Fix: vue-cli-service wrapper script expects node_modules/package.json
-        # Create symlink to @vue/cli-service/package.json
-        ln -s @vue/cli-service/package.json node_modules/package.json && \
-        echo "Created symlink: node_modules/package.json -> @vue/cli-service/package.json" && \
-        ls -la node_modules/package.json; \
-    fi
-
-# 7. Patch build.sh to use direct vue-cli-service.js call
-RUN if [ -f "/workspace/build/build.sh" ]; then \
-        echo "Patching build.sh to fix vue-cli-service wrapper script issue..."; \
-        sed -i 's/npm run build/node node_modules\/@vue\/cli-service\/bin\/vue-cli-service.js build/g' /workspace/build/build.sh && \
-        echo "Patch applied" && \
-        grep -n "vue-cli-service" /workspace/build/build.sh || true; \
-    fi
-
-# 8. Build the project from source
+# 6. Build the runtime project from source.
 RUN echo "Building Curvine from source..." && \
     export CURVINE_HOME=/workspace && \
     # Use workspace tmp directory instead of /tmp to avoid "no space left on device"
     mkdir -p /workspace/tmp && \
     export TMPDIR=/workspace/tmp && \
     echo "Using TMPDIR=$TMPDIR for compilation temporary files" && \
-    echo "Running 'make all --skip-java-sdk' with retry mechanism..." && \
+    echo "Running runtime build with retry mechanism: make all ARGS=\"${BUILD_ARGS}\"" && \
     # Build with retry mechanism
     for attempt in 1 2 3; do \
         echo "Build attempt $attempt..." && \

--- a/curvine-docker/deploy/Dockerfile_ubuntu24
+++ b/curvine-docker/deploy/Dockerfile_ubuntu24
@@ -116,6 +116,10 @@ RUN ARCH=$(uname -m) && \
 
 ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 
+# Runtime image only needs master/worker runtime binaries, CLI/FUSE helpers, and WebUI.
+# Override with --build-arg BUILD_ARGS="..." when building SDKs, WebUI, tests, or alternate UFS sets.
+ARG BUILD_ARGS="-p server -p client -p cli -p fuse -p web --skip-java-sdk --skip-python-sdk --ufs opendal-s3 --ufs opendal-oss --ufs opendal-azblob --ufs opendal-gcs --ufs opendal-hdfs --ufs opendal-webhdfs --ufs oss-hdfs"
+
 # Copy and build source code if building from source
 COPY . /workspace/
 WORKDIR /workspace
@@ -133,28 +137,7 @@ RUN ARCH=$(uname -m) && \
     esac && \
     echo "JAVA_HOME set to: ${JAVA_HOME}"
 
-# 7. Pre-install WebUI dependencies and fix vue-cli-service module resolution
-RUN if [ -d "/workspace/curvine-web/webui" ]; then \
-        echo "Pre-installing WebUI dependencies..."; \
-        cd /workspace/curvine-web/webui && \
-        npm install --legacy-peer-deps && \
-        echo "npm install completed" && \
-        # Fix: vue-cli-service wrapper script expects node_modules/package.json
-        # Create symlink to @vue/cli-service/package.json
-        ln -s @vue/cli-service/package.json node_modules/package.json && \
-        echo "Created symlink: node_modules/package.json -> @vue/cli-service/package.json" && \
-        ls -la node_modules/package.json; \
-    fi
-
-# 8. Patch build.sh to use direct vue-cli-service.js call
-RUN if [ -f "/workspace/build/build.sh" ]; then \
-        echo "Patching build.sh to fix vue-cli-service wrapper script issue..."; \
-        sed -i 's/npm run build/node node_modules\/@vue\/cli-service\/bin\/vue-cli-service.js build/g' /workspace/build/build.sh && \
-        echo "Patch applied" && \
-        grep -n "vue-cli-service" /workspace/build/build.sh || true; \
-    fi
-
-# 9. Build the project from source with all UFS support
+# 7. Build the runtime project from source with UFS support.
 RUN echo "Building Curvine from source..." && \
     # Set JAVA_HOME for current architecture
     ARCH=$(uname -m) && \
@@ -175,11 +158,11 @@ RUN echo "Building Curvine from source..." && \
     mkdir -p /workspace/tmp && \
     export TMPDIR=/workspace/tmp && \
     echo "Using TMPDIR=$TMPDIR for compilation temporary files" && \
-    echo "Running 'make all' with --skip-java-sdk and all UFS support..." && \
-    # Build with retry mechanism and all UFS support
+    echo "Running runtime build with retry mechanism: make all ARGS=\"${BUILD_ARGS}\"" && \
+    # Build with retry mechanism and runtime UFS support
     for attempt in 1 2 3; do \
         echo "Build attempt $attempt..." && \
-        if make all ARGS='--skip-java-sdk --ufs opendal-s3 --ufs opendal-oss --ufs opendal-azblob --ufs opendal-gcs --ufs opendal-hdfs --ufs opendal-webhdfs --ufs oss-hdfs'; then \
+        if make all ARGS="${BUILD_ARGS}"; then \
             echo "✓ Build succeeded with all UFS support" && \
             break; \
         else \
@@ -291,4 +274,3 @@ EXPOSE 8995 8996 8997 9000 9001
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["master", "start"]
-


### PR DESCRIPTION
# Summary

Split out the Docker/runtime build changes from PR #1005. This PR narrows runtime image builds to Curvine runtime binaries and copies the complete `etc/` directory into the distribution.

# Issue Describe / Design

Related to #984 and #1005 split work.

Root cause / motivation:
- Runtime images do not need SDK build targets by default.
- Dockerfiles carried local WebUI patch steps that are better avoided in the image build.
- `build.sh` copied only top-level files from `etc/`, which can miss nested config directories.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `build/build.sh` | Copy `etc/` recursively into dist conf | Preserves nested config files/directories |
| `curvine-docker/deploy/Dockerfile_rocky9` | Build runtime packages via `BUILD_ARGS`; remove WebUI patch workaround | Runtime image build is narrower by default |
| `curvine-docker/deploy/Dockerfile_ubuntu24` | Add configurable `BUILD_ARGS`; remove WebUI patch workaround | Runtime image build is narrower by default |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `bash -n build/build.sh` | PASS | Shell syntax check |
| `git diff --cached --check` | PASS | No whitespace errors before commit |

# Dependencies

- Related PRs: #1005
- Related issues: #984
- Blocks / blocked by: None