### PR TITLE
fix(master): avoid TTL fs_dir read-lock reentry (#1011)

### DIFF
--- a/curvine-server/src/master/meta/inode/ttl/ttl_executor.rs
+++ b/curvine-server/src/master/meta/inode/ttl/ttl_executor.rs
@@ -72,7 +72,13 @@ impl InodeTtlExecutor {
 
             let inode_view = match fs_dir.store.get_inode(current_id, None)? {
                 Some(inode_view) => inode_view,
-                None => return err_box!("Cannot resolve path for inode {}", inode_id),
+                None => {
+                    return err_box!(
+                        "Cannot resolve path for inode {} (missing ancestor {})",
+                        inode_id,
+                        current_id
+                    );
+                }
             };
 
             match &inode_view {
@@ -90,10 +96,6 @@ impl InodeTtlExecutor {
                     break;
                 }
             }
-        }
-
-        if components.is_empty() {
-            return Ok("/".to_string());
         }
 
         components.reverse();

--- a/curvine-server/src/master/meta/inode/ttl/ttl_executor.rs
+++ b/curvine-server/src/master/meta/inode/ttl/ttl_executor.rs
@@ -14,6 +14,7 @@
 
 use crate::master::fs::MasterFilesystem;
 use crate::master::meta::inode::{Inode, InodeView, ROOT_INODE_ID};
+use crate::master::meta::FsDir;
 use curvine_common::state::TtlAction;
 use curvine_common::FsResult;
 use log::debug;
@@ -49,44 +50,54 @@ impl InodeTtlExecutor {
     }
 
     fn resolve_inode_path(&self, inode_id: i64) -> FsResult<String> {
-        self.build_path_recursive(inode_id)
+        let fs_dir = self.filesystem.fs_dir();
+        let fs_dir_guard = fs_dir.read();
+        Self::build_path_from_store(&fs_dir_guard, inode_id)
     }
 
-    fn build_path_recursive(&self, inode_id: i64) -> FsResult<String> {
+    fn build_path_from_store(fs_dir: &FsDir, inode_id: i64) -> FsResult<String> {
         if inode_id == ROOT_INODE_ID {
             return Ok("/".to_string());
         }
 
-        let fs_dir = self.filesystem.fs_dir();
-        let fs_dir_guard = fs_dir.read();
-        if let Ok(Some(inode_view)) = fs_dir_guard.store.get_inode(inode_id, None) {
+        let mut current_id = inode_id;
+        let mut components = Vec::new();
+        let mut visited = Vec::new();
+
+        while current_id != ROOT_INODE_ID {
+            if visited.contains(&current_id) {
+                return err_box!("Cycle detected while resolving inode path {}", inode_id);
+            }
+            visited.push(current_id);
+
+            let inode_view = match fs_dir.store.get_inode(current_id, None)? {
+                Some(inode_view) => inode_view,
+                None => return err_box!("Cannot resolve path for inode {}", inode_id),
+            };
+
             match &inode_view {
                 InodeView::File(f) => {
-                    let parent_path = self.build_path_recursive(f.parent_id())?;
-                    let file_path = if parent_path == "/" {
-                        format!("/{}", f.name)
-                    } else {
-                        format!("{}/{}", parent_path, f.name)
-                    };
-                    return Ok(file_path);
+                    components.push(f.name.clone());
+                    current_id = f.parent_id();
                 }
                 InodeView::Dir(d) => {
-                    let parent_path = self.build_path_recursive(d.parent_id())?;
-                    let dir_path = if parent_path == "/" {
-                        format!("/{}", d.name)
-                    } else {
-                        format!("{}/{}", parent_path, d.name)
-                    };
-                    return Ok(dir_path);
+                    components.push(d.name.clone());
+                    current_id = d.parent_id();
                 }
                 InodeView::FileEntry(e) => {
-                    // For empty files, we can't determine parent_id, so return a basic path
-                    return Ok(format!("/{}", e.name));
+                    // FileEntry does not carry parent_id, so preserve the previous fallback.
+                    components.push(e.name.clone());
+                    break;
                 }
             }
         }
 
-        err_box!("Cannot resolve path for inode {}", inode_id)
+        if components.is_empty() {
+            return Ok("/".to_string());
+        }
+
+        components.reverse();
+        Ok(format!("/{}", components.join("/")))
     }
 
     pub fn get_inode_from_store(&self, inode_id: i64) -> FsResult<Option<InodeView>> {

--- a/curvine-server/tests/master_fs_test.rs
+++ b/curvine-server/tests/master_fs_test.rs
@@ -22,12 +22,14 @@ use curvine_common::proto::{
 use curvine_common::raft::storage::{AppStorage, ApplyMsg};
 use curvine_common::state::MountOptions;
 use curvine_common::state::{
-    BlockLocation, ClientAddress, CommitBlock, CreateFileOpts, FileAllocOpts, WorkerInfo,
+    BlockLocation, ClientAddress, CommitBlock, CreateFileOpts, CreateFileOptsBuilder,
+    FileAllocOpts, TtlAction, WorkerInfo,
 };
 use curvine_common::state::{OpenFlags, RenameFlags, SetAttrOptsBuilder};
 use curvine_common::utils::SerdeUtils;
 use curvine_server::master::fs::{FsRetryCache, MasterFilesystem, OperationStatus};
 use curvine_server::master::journal::{JournalBatch, JournalEntry, JournalLoader, JournalSystem};
+use curvine_server::master::meta::inode::ttl::InodeTtlExecutor;
 use curvine_server::master::replication::master_replication_manager::MasterReplicationManager;
 use curvine_server::master::{JobHandler, JobManager, Master, MasterHandler, RpcContext};
 use orpc::common::LocalTime;
@@ -194,6 +196,105 @@ fn test_master_filesystem_core_operations() -> CommonResult<()> {
     get_file_info(&fs)?;
     list_status(&fs)?;
     state(&fs)?;
+
+    Ok(())
+}
+
+#[test]
+fn ttl_executor_deletes_nested_expired_inode() -> CommonResult<()> {
+    let _serial = master_fs_test_serial();
+    let fs = new_fs(true, "ttl-executor-nested-delete");
+    let opts = CreateFileOptsBuilder::new()
+        .create_parent(true)
+        .ttl_ms(1)
+        .ttl_action(TtlAction::Delete)
+        .build();
+    let status = fs.create_with_opts(
+        "/ttl/a/b/file.log",
+        opts,
+        OpenFlags::new_create().set_overwrite(true),
+    )?;
+
+    std::thread::sleep(Duration::from_millis(10));
+    let executor = InodeTtlExecutor::with_managers(fs.clone());
+    let (processed, inode) = executor.execute_by_id(status.id)?;
+
+    assert!(
+        processed,
+        "expired inode should be processed by TTL executor"
+    );
+    assert_eq!(inode.id(), status.id);
+    assert!(
+        fs.file_status("/ttl/a/b/file.log").is_err(),
+        "TTL delete should remove the nested file path resolved from inode id"
+    );
+
+    Ok(())
+}
+
+// Regression: TTL path resolution must not re-acquire the fs_dir read lock while
+// already holding it. std::sync::RwLock is writer-preferring, so a reentrant read
+// deadlocks once a writer is queued. This reproduces the 2026-07-08 freeze shape:
+// a deep path resolved under continuous concurrent writers. It must complete
+// within the timeout.
+#[test]
+fn ttl_path_resolution_no_reentrant_deadlock_under_writers() -> CommonResult<()> {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::mpsc;
+
+    let _serial = master_fs_test_serial();
+    let fs = new_fs(true, "ttl-reentrant-deadlock");
+
+    let mut deep_path = String::new();
+    for level in 0..12 {
+        deep_path.push_str(&format!("/d{}", level));
+    }
+    deep_path.push_str("/file.log");
+
+    let opts = CreateFileOptsBuilder::new()
+        .create_parent(true)
+        .ttl_ms(1)
+        .ttl_action(TtlAction::Delete)
+        .build();
+    let status = fs.create_with_opts(
+        &deep_path,
+        opts,
+        OpenFlags::new_create().set_overwrite(true),
+    )?;
+    std::thread::sleep(Duration::from_millis(10));
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let writer_fs = fs.clone();
+    let writer_stop = stop.clone();
+    let writer = std::thread::spawn(move || {
+        let mut i = 0u64;
+        while !writer_stop.load(Ordering::Relaxed) {
+            let _ = writer_fs.mkdir(format!("/writer/{}", i), true);
+            i += 1;
+        }
+    });
+
+    let (tx, rx) = mpsc::channel();
+    let exec_fs = fs.clone();
+    let inode_id = status.id;
+    let resolver = std::thread::spawn(move || {
+        let executor = InodeTtlExecutor::with_managers(exec_fs);
+        let _ = tx.send(executor.execute_by_id(inode_id));
+    });
+
+    let result = rx.recv_timeout(Duration::from_secs(10));
+    stop.store(true, Ordering::Relaxed);
+    let _ = writer.join();
+    let _ = resolver.join();
+
+    let (processed, inode) = result
+        .expect("TTL path resolution deadlocked: no result within 10s under concurrent writers")?;
+    assert!(processed, "expired inode should be processed");
+    assert_eq!(inode.id(), status.id);
+    assert!(
+        fs.file_status(&deep_path).is_err(),
+        "TTL delete should remove the deep path resolved from inode id"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
# Summary

Fixes a master-wide stall caused by TTL path resolution recursively re-acquiring the global `fs_dir` read lock. TTL now resolves an inode path with a single read-lock acquisition and then releases that lock before executing delete/free.

# Issue Describe / Design

Closes #1011.

Root cause:
- `InodeTtlExecutor::build_path_recursive` held `fs_dir.read()` while recursively resolving the parent path.
- `fs_dir` is backed by `std::sync::RwLock`; when a writer is queued, a second read acquisition by the same thread can block.
- Under metadata write pressure, TTL cleanup can self-deadlock while holding the first read guard, blocking later readers and writers behind the global metadata lock.

Reproduction shape:
1. Create a nested expired TTL inode.
2. Keep concurrent metadata writes queued.
3. Run TTL cleanup/path resolution.
4. Old code can block on recursive read-lock acquisition; the fixed code completes.

Fix approach:
- Replace recursive path building with an iterative parent-chain walk under one read guard.
- Preserve the old `FileEntry` fallback behavior.
- Keep delete/free outside the read-lock scope.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-server/src/master/meta/inode/ttl/ttl_executor.rs` | Resolve inode paths iteratively under one `fs_dir` read lock | Removes reentrant lock deadlock risk; TTL delete/free semantics preserved |
| `curvine-server/tests/master_fs_test.rs` | Add nested TTL delete and concurrent-writer regression coverage | Covers the production freeze shape without changing runtime behavior |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo fmt --check` | PASS | |
| `cargo clippy -p curvine-server --all-targets --jobs 2 -- --deny=warnings --allow clippy::uninlined-format-args` | PASS | |
| `cargo test -p curvine-server --test master_fs_test ttl_executor_deletes_nested_expired_inode -- --nocapture --test-threads=1` | PASS | |
| `cargo test -p curvine-server --test master_fs_test ttl_path_resolution_no_reentrant_deadlock_under_writers -- --nocapture --test-threads=1` | PASS | |
| `cargo test -p curvine-server --test master_fs_test -- --test-threads=1` | PASS | 23 passed |
| Production validation | PASS | Active master responded to repeated `cv fs --cache-only stat /`; master/worker pods Ready; no recent critical ERROR/WARN/panic matched |

# Dependencies

- Related PRs: #1005
- Related issues: #1011
- Blocks / blocked by: None