### PR TITLE
feat(master): add fs_dir lock stall watchdog (#1011)

### DIFF
--- a/curvine-server/src/master/fs/fs_dir_watchdog.rs
+++ b/curvine-server/src/master/fs/fs_dir_watchdog.rs
@@ -37,6 +37,7 @@ pub struct FsDirWatchdog {
     stall_threshold_ms: i64,
     first_unavailable_ms: AtomicI64,
     stall_reported: AtomicBool,
+    poison_reported: AtomicBool,
 }
 
 impl FsDirWatchdog {
@@ -47,6 +48,16 @@ impl FsDirWatchdog {
             stall_threshold_ms,
             first_unavailable_ms: AtomicI64::new(0),
             stall_reported: AtomicBool::new(false),
+            poison_reported: AtomicBool::new(false),
+        }
+    }
+
+    fn reset_unavailable_state(&self) {
+        self.first_unavailable_ms.store(0, Ordering::SeqCst);
+        self.stall_reported.store(false, Ordering::SeqCst);
+        self.poison_reported.store(false, Ordering::SeqCst);
+        if let Some(metrics) = self.metrics {
+            metrics.fs_dir_stalled.set(0);
         }
     }
 
@@ -54,6 +65,7 @@ impl FsDirWatchdog {
         if let Some(metrics) = self.metrics {
             metrics.fs_dir_probe_acquire_us.set(probe_us);
         }
+        self.poison_reported.store(false, Ordering::SeqCst);
         if self.stall_reported.swap(false, Ordering::SeqCst) {
             let stalled_ms =
                 LocalTime::mills() as i64 - self.first_unavailable_ms.load(Ordering::SeqCst);
@@ -68,7 +80,11 @@ impl FsDirWatchdog {
         self.first_unavailable_ms.store(0, Ordering::SeqCst);
     }
 
-    fn on_unavailable(&self, poisoned: bool) {
+    fn on_unavailable(&self, probe_us: i64, poisoned: bool) {
+        if let Some(metrics) = self.metrics {
+            metrics.fs_dir_probe_acquire_us.set(probe_us);
+        }
+
         let now = LocalTime::mills() as i64;
         let first = self.first_unavailable_ms.load(Ordering::SeqCst);
         let first = if first == 0 {
@@ -79,7 +95,7 @@ impl FsDirWatchdog {
         };
 
         let unavailable_ms = now - first;
-        if poisoned {
+        if poisoned && !self.poison_reported.swap(true, Ordering::SeqCst) {
             error!("fs_dir metadata lock is poisoned; a holder panicked while mutating metadata");
         }
         if unavailable_ms >= self.stall_threshold_ms
@@ -102,17 +118,98 @@ impl LoopTask for FsDirWatchdog {
     type Error = FsError;
 
     fn run(&self) -> FsResult<()> {
+        if !self.fs.master_monitor.is_active() {
+            self.reset_unavailable_state();
+            return Ok(());
+        }
+
         let spent = TimeSpent::new();
         // Non-blocking shared probe. It never blocks the watchdog thread.
         match self.fs.fs_dir().try_read() {
             Ok(_guard) => self.on_available(spent.used_us() as i64),
-            Err(TryLockError::WouldBlock) => self.on_unavailable(false),
-            Err(TryLockError::Poisoned(_)) => self.on_unavailable(true),
+            Err(TryLockError::WouldBlock) => self.on_unavailable(spent.used_us() as i64, false),
+            Err(TryLockError::Poisoned(_)) => self.on_unavailable(spent.used_us() as i64, true),
         }
         Ok(())
     }
 
     fn terminate(&self) -> bool {
-        false
+        self.fs.master_monitor.is_stop()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::master::journal::JournalSystem;
+    use crate::master::Master;
+    use curvine_common::conf::{ClusterConf, JournalConf, MasterConf};
+    use curvine_common::raft::RoleState;
+    use orpc::common::Utils;
+
+    fn test_fs(name: &str) -> MasterFilesystem {
+        Master::init_test_metrics();
+        let conf = ClusterConf {
+            format_master: true,
+            testing: true,
+            master: MasterConf {
+                meta_dir: Utils::test_sub_dir(format!("fs-dir-watchdog/meta-{}", name)),
+                ..Default::default()
+            },
+            journal: JournalConf {
+                enable: false,
+                journal_dir: Utils::test_sub_dir(format!("fs-dir-watchdog/journal-{}", name)),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        JournalSystem::fs_only_for_test(&conf).unwrap()
+    }
+
+    #[test]
+    fn inactive_master_resets_without_probing_lock() {
+        let fs = test_fs("inactive");
+        let fs_dir = fs.fs_dir();
+        let _write_guard = fs_dir.write();
+        let watchdog = FsDirWatchdog::new(fs, 0);
+
+        watchdog.first_unavailable_ms.store(123, Ordering::SeqCst);
+        watchdog.stall_reported.store(true, Ordering::SeqCst);
+        watchdog.poison_reported.store(true, Ordering::SeqCst);
+
+        watchdog.run().unwrap();
+
+        assert_eq!(watchdog.first_unavailable_ms.load(Ordering::SeqCst), 0);
+        assert!(!watchdog.stall_reported.load(Ordering::SeqCst));
+        assert!(!watchdog.poison_reported.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn stopped_master_terminates_watchdog() {
+        let fs = test_fs("stopped");
+        fs.master_monitor.journal_ctl.set_state(RoleState::Exit);
+        let watchdog = FsDirWatchdog::new(fs, 0);
+
+        assert!(watchdog.terminate());
+    }
+
+    #[test]
+    fn active_watchdog_reports_stall_once_and_recovers() {
+        let fs = test_fs("active");
+        fs.master_monitor.journal_ctl.set_state(RoleState::Leader);
+        let fs_dir = fs.fs_dir();
+        let watchdog = FsDirWatchdog::new(fs, 0);
+
+        let write_guard = fs_dir.write();
+        watchdog.run().unwrap();
+
+        assert!(watchdog.first_unavailable_ms.load(Ordering::SeqCst) > 0);
+        assert!(watchdog.stall_reported.load(Ordering::SeqCst));
+
+        drop(write_guard);
+        watchdog.run().unwrap();
+
+        assert_eq!(watchdog.first_unavailable_ms.load(Ordering::SeqCst), 0);
+        assert!(!watchdog.stall_reported.load(Ordering::SeqCst));
     }
 }

--- a/curvine-server/src/master/fs/fs_dir_watchdog.rs
+++ b/curvine-server/src/master/fs/fs_dir_watchdog.rs
@@ -1,0 +1,118 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::master::fs::MasterFilesystem;
+use crate::master::{Master, MasterMetrics};
+use curvine_common::error::FsError;
+use curvine_common::FsResult;
+use log::{error, warn};
+use orpc::common::{LocalTime, TimeSpent};
+use orpc::runtime::LoopTask;
+use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
+use std::sync::TryLockError;
+
+/// Watches the single `fs_dir` metadata lock and surfaces a stall as an
+/// observable signal instead of a silent multi-minute control-plane freeze.
+///
+/// The metadata lock is a single global `std::sync::RwLock` and cannot be
+/// sharded yet. When it wedges (for example a reader that never releases while
+/// writers queue), every metadata RPC blocks with no log or metric. This probe
+/// takes a non-blocking `try_read()` each tick: a lock that stays unacquirable
+/// past the threshold is reported. It never blocks and never aborts the
+/// process; recovery decisions stay with the operator / k8s.
+pub struct FsDirWatchdog {
+    fs: MasterFilesystem,
+    metrics: Option<&'static MasterMetrics>,
+    stall_threshold_ms: i64,
+    first_unavailable_ms: AtomicI64,
+    stall_reported: AtomicBool,
+}
+
+impl FsDirWatchdog {
+    pub fn new(fs: MasterFilesystem, stall_threshold_ms: i64) -> Self {
+        Self {
+            fs,
+            metrics: Master::get_metrics().ok(),
+            stall_threshold_ms,
+            first_unavailable_ms: AtomicI64::new(0),
+            stall_reported: AtomicBool::new(false),
+        }
+    }
+
+    fn on_available(&self, probe_us: i64) {
+        if let Some(metrics) = self.metrics {
+            metrics.fs_dir_probe_acquire_us.set(probe_us);
+        }
+        if self.stall_reported.swap(false, Ordering::SeqCst) {
+            let stalled_ms =
+                LocalTime::mills() as i64 - self.first_unavailable_ms.load(Ordering::SeqCst);
+            warn!(
+                "fs_dir metadata lock recovered after ~{} ms unavailable",
+                stalled_ms
+            );
+            if let Some(metrics) = self.metrics {
+                metrics.fs_dir_stalled.set(0);
+            }
+        }
+        self.first_unavailable_ms.store(0, Ordering::SeqCst);
+    }
+
+    fn on_unavailable(&self, poisoned: bool) {
+        let now = LocalTime::mills() as i64;
+        let first = self.first_unavailable_ms.load(Ordering::SeqCst);
+        let first = if first == 0 {
+            self.first_unavailable_ms.store(now, Ordering::SeqCst);
+            now
+        } else {
+            first
+        };
+
+        let unavailable_ms = now - first;
+        if poisoned {
+            error!("fs_dir metadata lock is poisoned; a holder panicked while mutating metadata");
+        }
+        if unavailable_ms >= self.stall_threshold_ms
+            && !self.stall_reported.swap(true, Ordering::SeqCst)
+        {
+            warn!(
+                "fs_dir metadata lock unacquirable for ~{} ms (threshold {} ms); control plane \
+                 metadata RPCs are likely blocked on the global lock",
+                unavailable_ms, self.stall_threshold_ms
+            );
+            if let Some(metrics) = self.metrics {
+                metrics.fs_dir_stalled.set(1);
+                metrics.fs_dir_stall_total.inc();
+            }
+        }
+    }
+}
+
+impl LoopTask for FsDirWatchdog {
+    type Error = FsError;
+
+    fn run(&self) -> FsResult<()> {
+        let spent = TimeSpent::new();
+        // Non-blocking shared probe. It never blocks the watchdog thread.
+        match self.fs.fs_dir().try_read() {
+            Ok(_guard) => self.on_available(spent.used_us() as i64),
+            Err(TryLockError::WouldBlock) => self.on_unavailable(false),
+            Err(TryLockError::Poisoned(_)) => self.on_unavailable(true),
+        }
+        Ok(())
+    }
+
+    fn terminate(&self) -> bool {
+        false
+    }
+}

--- a/curvine-server/src/master/fs/master_actor.rs
+++ b/curvine-server/src/master/fs/master_actor.rs
@@ -14,6 +14,7 @@
 
 use crate::master::fs::heartbeat_checker::HeartbeatChecker;
 use crate::master::fs::master_filesystem::MasterFilesystem;
+use crate::master::fs::FsDirWatchdog;
 use crate::master::meta::inode::ttl::TtlHeartbeatChecker;
 use crate::master::meta::inode::ttl::TtlHeartbeatConfig;
 use crate::master::meta::inode::ttl::{InodeTtlExecutor, InodeTtlManager};
@@ -35,6 +36,11 @@ pub struct MasterActor {
 }
 
 impl MasterActor {
+    // fs_dir stall watchdog cadence. The threshold is well above any legitimate
+    // brief write burst; a read lock unacquirable this long means a wedge.
+    const FS_DIR_WATCHDOG_INTERVAL_MS: u64 = 1000;
+    const FS_DIR_WATCHDOG_STALL_THRESHOLD_MS: i64 = 15000;
+
     pub fn new(
         fs: MasterFilesystem,
         master_monitor: MasterMonitor,
@@ -60,6 +66,20 @@ impl MasterActor {
             self.replication_manager.clone(),
             self.quota_manager.clone(),
         )?;
+        Self::start_fs_dir_watchdog(self.fs.clone())?;
+        Ok(())
+    }
+
+    fn start_fs_dir_watchdog(fs: MasterFilesystem) -> CommonResult<()> {
+        let scheduler =
+            ScheduledExecutor::new("fs-dir-watchdog", Self::FS_DIR_WATCHDOG_INTERVAL_MS);
+        let watchdog = FsDirWatchdog::new(fs, Self::FS_DIR_WATCHDOG_STALL_THRESHOLD_MS);
+        scheduler.start(watchdog)?;
+        info!(
+            "fs_dir watchdog started, interval {} ms, stall threshold {} ms",
+            Self::FS_DIR_WATCHDOG_INTERVAL_MS,
+            Self::FS_DIR_WATCHDOG_STALL_THRESHOLD_MS
+        );
         Ok(())
     }
 

--- a/curvine-server/src/master/fs/mod.rs
+++ b/curvine-server/src/master/fs/mod.rs
@@ -18,6 +18,9 @@ pub use self::worker_manager::WorkerManager;
 mod heartbeat_checker;
 pub use self::heartbeat_checker::HeartbeatChecker;
 
+mod fs_dir_watchdog;
+pub use self::fs_dir_watchdog::FsDirWatchdog;
+
 mod master_actor;
 pub use self::master_actor::MasterActor;
 

--- a/curvine-server/src/master/master_metrics.rs
+++ b/curvine-server/src/master/master_metrics.rs
@@ -67,6 +67,13 @@ pub struct MasterMetrics {
     pub(crate) ttl_bucket_len: Gauge,
     pub(crate) ttl_total_inodes: Gauge,
     pub(crate) ttl_skipped_inodes: Counter,
+
+    // fs_dir global lock health. The metadata lock cannot be sharded yet, so a
+    // stalled or wedged lock freezes the whole control plane. These give the
+    // stall an observable signal instead of a silent multi-minute freeze.
+    pub(crate) fs_dir_stalled: Gauge,
+    pub(crate) fs_dir_stall_total: Counter,
+    pub(crate) fs_dir_probe_acquire_us: Gauge,
 }
 
 impl MasterMetrics {
@@ -160,6 +167,18 @@ impl MasterMetrics {
             ttl_skipped_inodes: m::new_counter(
                 "ttl_skipped_inodes",
                 "Total number of inodes skipped while updating TTL buckets",
+            )?,
+            fs_dir_stalled: m::new_gauge(
+                "fs_dir_stalled",
+                "1 when the fs_dir metadata lock has been unacquirable beyond the stall threshold",
+            )?,
+            fs_dir_stall_total: m::new_counter(
+                "fs_dir_stall_total",
+                "Total number of fs_dir metadata lock stall episodes detected",
+            )?,
+            fs_dir_probe_acquire_us: m::new_gauge(
+                "fs_dir_probe_acquire_us",
+                "Latency in microseconds of the last fs_dir watchdog read-lock probe",
             )?,
         };
 


### PR DESCRIPTION
# Summary

Add a master-side watchdog for the global `fs_dir` metadata lock. The watchdog probes the lock with non-blocking `try_read()` and exports metrics/logs when the lock stays unavailable beyond the stall threshold.

# Issue Describe / Design

Related to #1011.

Root cause: production file-operation storms can make the master appear dead when all metadata RPCs block behind the single global `fs_dir` lock. Before this change, that condition had no direct master metric or log, so operators only saw secondary symptoms such as heartbeat loss or RPC timeouts.

Fix approach: start a lightweight scheduled task with `MasterActor`. It performs a non-blocking read-lock probe once per second, records probe latency, reports a stall only after 15 seconds, and clears the signal after the lock becomes available again. It never blocks the scheduler, never takes a write lock, and never restarts or aborts the process.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-server/src/master/fs/fs_dir_watchdog.rs` | Add `FsDirWatchdog` loop task using `try_read()` | Adds observability only |
| `curvine-server/src/master/fs/master_actor.rs` | Start the watchdog with the existing scheduled executor | Adds one lightweight background task |
| `curvine-server/src/master/fs/mod.rs` | Register watchdog module | None |
| `curvine-server/src/master/master_metrics.rs` | Add `fs_dir_stalled`, `fs_dir_stall_total`, and `fs_dir_probe_acquire_us` metrics | Adds metrics only |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo fmt --check` | PASS | |
| `cargo clippy -p curvine-server --all-targets --jobs 2 -- --deny=warnings --allow clippy::uninlined-format-args` | PASS | |
| `git diff --check` | PASS | |

# Dependencies

- Related PRs: None
- Related issues: #1011
- Blocks / blocked by: None
