### PR TITLE
fix(orpc): return async handler errors as responses

### DIFF
--- a/orpc/src/handler/stream_handler.rs
+++ b/orpc/src/handler/stream_handler.rs
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::err_box;
 use crate::handler::{Frame, MessageHandler};
 use crate::io::IOResult;
-use crate::message::Message;
+use crate::message::{Builder, Message};
 use crate::runtime::{RpcRuntime, Runtime};
 use crate::server::ServerConf;
 use crate::sys::RawPtr;
@@ -86,9 +85,19 @@ impl<F: Frame, M: MessageHandler> StreamHandler<F, M> {
                 })
                 .await?
         } else {
+            let error_response_base = Builder::new()
+                .code(request.code())
+                .request(request.request_status())
+                .req_id(request.req_id())
+                .seq_id(request.seq_id())
+                .build();
+            let req_id = request.req_id();
             match self.handler.as_mut().async_handle(request).await {
                 Ok(v) => v,
-                Err(e) => return err_box!("{}", e),
+                Err(e) => {
+                    debug!("handler request {} error: {}", req_id, e);
+                    error_response_base.error_ext(&e)
+                }
             }
         };
 

--- a/orpc/src/handler/stream_handler.rs
+++ b/orpc/src/handler/stream_handler.rs
@@ -85,17 +85,20 @@ impl<F: Frame, M: MessageHandler> StreamHandler<F, M> {
                 })
                 .await?
         } else {
-            let error_response_base = Builder::new()
-                .code(request.code())
-                .request(request.request_status())
-                .req_id(request.req_id())
-                .seq_id(request.seq_id())
-                .build();
+            let code = request.code();
+            let request_status = request.request_status();
             let req_id = request.req_id();
+            let seq_id = request.seq_id();
             match self.handler.as_mut().async_handle(request).await {
                 Ok(v) => v,
                 Err(e) => {
                     debug!("handler request {} error: {}", req_id, e);
+                    let error_response_base = Builder::new()
+                        .code(code)
+                        .request(request_status)
+                        .req_id(req_id)
+                        .seq_id(seq_id)
+                        .build();
                     error_response_base.error_ext(&e)
                 }
             }

--- a/orpc/tests/stream_handler_test.rs
+++ b/orpc/tests/stream_handler_test.rs
@@ -1,0 +1,82 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use orpc::error::CommonErrorExt;
+use orpc::handler::{Frame, MessageHandler, StreamHandler};
+use orpc::io::net::ConnState;
+use orpc::io::IOResult;
+use orpc::message::{BoxMessage, Builder, Message, RefMessage, RequestStatus};
+use orpc::runtime::{RpcRuntime, Runtime};
+use orpc::server::ServerConf;
+use std::sync::Arc;
+
+struct MemoryFrame {
+    sent: Vec<BoxMessage>,
+}
+
+impl Frame for MemoryFrame {
+    async fn send(&mut self, message: impl RefMessage) -> IOResult<()> {
+        self.sent.push(message.into_box());
+        Ok(())
+    }
+
+    async fn receive(&mut self) -> IOResult<Message> {
+        Ok(Message::empty())
+    }
+
+    fn new_conn_state(&self) -> ConnState {
+        ConnState::default()
+    }
+}
+
+struct AsyncErrorHandler;
+
+impl MessageHandler for AsyncErrorHandler {
+    type Error = CommonErrorExt;
+
+    fn is_sync(&self, _msg: &Message) -> bool {
+        false
+    }
+
+    fn handle(&mut self, _msg: &Message) -> Result<Message, Self::Error> {
+        unreachable!("test handler only uses async_handle")
+    }
+
+    async fn async_handle(&mut self, _msg: Message) -> Result<Message, Self::Error> {
+        Err(CommonErrorExt::from("async handler failed".to_string()))
+    }
+}
+
+#[test]
+fn async_handler_error_is_sent_as_response() {
+    let rt = Arc::new(Runtime::current_thread("stream-handler-test"));
+    let conf = ServerConf::with_hostname("127.0.0.1", 0);
+    let frame = MemoryFrame { sent: Vec::new() };
+    let handler = AsyncErrorHandler;
+    let mut stream_handler = StreamHandler::new(rt.clone(), frame, handler, &conf);
+    let request = Builder::new()
+        .code(1)
+        .request(RequestStatus::Open)
+        .req_id(1)
+        .build();
+
+    rt.block_on(stream_handler.call(request))
+        .expect("async handler error should not close the stream");
+
+    let sent = &stream_handler.frame_mut().sent;
+    assert_eq!(sent.len(), 1);
+    assert!(!sent[0].is_success());
+    let err = sent[0].check_error_ext::<CommonErrorExt>().unwrap_err();
+    assert!(err.to_string().contains("async handler failed"));
+}


### PR DESCRIPTION
# Summary

Return async `MessageHandler` failures as normal RPC error responses instead of turning them into stream-level errors.

# Issue Describe / Design

Root cause: `StreamHandler::call` already converts sync handler errors into response messages, but the async path returned `Err(...)` directly. That closed or failed the stream and prevented the caller from receiving the standard RPC error payload.

Reproduction steps: install an async handler that returns an error and call `StreamHandler::call`. Before this fix, `call` returned an error and sent no response. After this fix, `call` succeeds at the transport level and sends one failed response message.

Fix approach: build the response header before moving the request into `async_handle`, then encode async handler errors with `error_ext`, matching the sync path.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `orpc/src/handler/stream_handler.rs` | Convert async handler errors to RPC error responses | Async business errors reach clients as structured responses instead of closing the stream |
| `orpc/tests/stream_handler_test.rs` | Add regression coverage for async handler errors | Test-only |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo fmt --check` | PASS | |
| `cargo test -p orpc --test stream_handler_test` | PASS | |
| `cargo clippy -p orpc --all-targets --jobs 2 -- --deny=warnings --allow clippy::uninlined-format-args` | PASS | |
| `git diff --check` | PASS | |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None
