### PR TITLE
fix(common): add resource exhausted fs error

### DIFF
--- a/curvine-common/src/error/fs_error.rs
+++ b/curvine-common/src/error/fs_error.rs
@@ -64,6 +64,7 @@ pub enum ErrorKind {
     NotADirectory = 27,
     InvalidArgument = 28,
     BlockNotFound = 29,
+    ResourceExhausted = 30,
 
     #[num_enum(default)]
     Common = 10000,
@@ -184,6 +185,10 @@ pub enum FsError {
     #[error("{0}")]
     JobNotFound(ErrorImpl<StringError>),
 
+    // The server or client side resource limit was reached.
+    #[error("{0}")]
+    ResourceExhausted(ErrorImpl<StringError>),
+
     // Other errors that are not defined.
     #[error("{0}")]
     Common(ErrorImpl<StringError>),
@@ -224,6 +229,10 @@ impl FsError {
     pub fn block_not_found(block_id: i64) -> Self {
         let msg = format!("Block {} not found", block_id);
         Self::BlockNotFound(ErrorImpl::with_source(msg.into()))
+    }
+
+    pub fn resource_exhausted(msg: impl Into<String>) -> Self {
+        Self::ResourceExhausted(ErrorImpl::with_source(msg.into().into()))
     }
 
     pub fn file_expired(path: impl AsRef<str>) -> Self {
@@ -370,6 +379,7 @@ impl FsError {
             FsError::Pipeline(_) => ErrorKind::Pipeline,
             FsError::MinReplicasNotMet(_) => ErrorKind::MinReplicasNotMet,
             FsError::JobNotFound(_) => ErrorKind::JobNotFound,
+            FsError::ResourceExhausted(_) => ErrorKind::ResourceExhausted,
             FsError::Common(_) => ErrorKind::Common,
         }
     }
@@ -516,6 +526,7 @@ impl ErrorExt for FsError {
             FsError::Pipeline(e) => FsError::Pipeline(e.ctx(ctx)),
             FsError::MinReplicasNotMet(e) => FsError::MinReplicasNotMet(e.ctx(ctx)),
             FsError::JobNotFound(e) => FsError::JobNotFound(e.ctx(ctx)),
+            FsError::ResourceExhausted(e) => FsError::ResourceExhausted(e.ctx(ctx)),
             FsError::Common(e) => FsError::Common(e.ctx(ctx)),
         }
     }
@@ -551,6 +562,7 @@ impl ErrorExt for FsError {
             FsError::Pipeline(e) => e.encode(ErrorKind::Pipeline),
             FsError::MinReplicasNotMet(e) => e.encode(ErrorKind::MinReplicasNotMet),
             FsError::JobNotFound(e) => e.encode(ErrorKind::JobNotFound),
+            FsError::ResourceExhausted(e) => e.encode(ErrorKind::ResourceExhausted),
             FsError::Common(e) => e.encode(ErrorKind::Common),
         }
     }
@@ -589,6 +601,7 @@ impl ErrorExt for FsError {
             ErrorKind::Pipeline => FsError::Pipeline(de.into_string()),
             ErrorKind::MinReplicasNotMet => FsError::MinReplicasNotMet(de.into_string()),
             ErrorKind::JobNotFound => FsError::JobNotFound(de.into_string()),
+            ErrorKind::ResourceExhausted => FsError::ResourceExhausted(de.into_string()),
             ErrorKind::Common => FsError::Common(de.into_string()),
         }
     }

--- a/curvine-common/tests/fs_error_test.rs
+++ b/curvine-common/tests/fs_error_test.rs
@@ -16,3 +16,22 @@ fn block_not_found_round_trips_with_structured_kind() {
         other => panic!("expected BlockNotFound, got {:?}", other),
     }
 }
+
+#[test]
+fn resource_exhausted_round_trips_with_structured_kind() {
+    let error = FsError::resource_exhausted("master load job queue is full; retry later");
+    assert!(matches!(error.kind(), ErrorKind::ResourceExhausted));
+
+    let decoded = FsError::decode(error.encode());
+    assert!(matches!(decoded.kind(), ErrorKind::ResourceExhausted));
+
+    match decoded {
+        FsError::ResourceExhausted(error) => {
+            assert_eq!(
+                error.source.to_string(),
+                "master load job queue is full; retry later"
+            );
+        }
+        other => panic!("expected ResourceExhausted, got {:?}", other),
+    }
+}


### PR DESCRIPTION
# Summary

Add a structured `FsError::ResourceExhausted` error kind for server/client backpressure and resource-limit failures.

# Issue Describe / Design

Root cause: queue-full and resource-pressure paths need a stable error kind so callers can retry or throttle without parsing error strings. `FsError` did not have such a kind, so these failures would have to fall back to `Common` or ad-hoc text matching.

Fix approach: add `ErrorKind::ResourceExhausted`, `FsError::ResourceExhausted`, a helper constructor, and encode/decode/ctx mapping. This PR only adds the common error type; it does not change any master or client behavior by itself.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-common/src/error/fs_error.rs` | Add structured `ResourceExhausted` kind and mapping | Existing errors are unchanged |
| `curvine-common/tests/fs_error_test.rs` | Add round-trip encoding test | Test-only |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo fmt --check` | PASS | |
| `cargo test -p curvine-common --test fs_error_test` | PASS | |
| `cargo clippy -p curvine-common --all-targets --jobs 2 -- --deny=warnings --allow clippy::uninlined-format-args` | PASS | |
| `git diff --check` | PASS | |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None
