### PR TITLE
feat(common): add auto-cache submit backpressure config

### DIFF
--- a/curvine-common/src/conf/client_conf.rs
+++ b/curvine-common/src/conf/client_conf.rs
@@ -18,7 +18,7 @@ use curvine_common_macros::ClientCliArgs;
 use orpc::client::ClientConf as RpcConf;
 use orpc::common::{ByteUnit, DurationUnit, Utils};
 use orpc::io::net::InetAddr;
-use orpc::CommonResult;
+use orpc::{err_box, CommonResult};
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
@@ -121,6 +121,22 @@ pub struct ClientConf {
     /// Same as auto_cache_ttl, but as Option<String> type, it is convenient to use in the API
     #[client_cli(skip)]
     pub default_cache_ttl: Option<String>,
+
+    /// Maximum number of auto-cache submit requests waiting in the client process.
+    #[client_cli]
+    pub auto_cache_submit_queue_size: usize,
+
+    /// Maximum retries when the master rejects auto-cache submit due to resource pressure.
+    #[client_cli]
+    pub auto_cache_submit_retry_max: u32,
+
+    /// Initial retry sleep for auto-cache submit resource pressure.
+    #[client_cli]
+    pub auto_cache_submit_retry_min_sleep_ms: u64,
+
+    /// Maximum retry sleep for auto-cache submit resource pressure.
+    #[client_cli]
+    pub auto_cache_submit_retry_max_sleep_ms: u64,
 
     // Set up the customer service retry policy
     #[client_cli]
@@ -292,12 +308,28 @@ impl ClientConf {
 
     pub const DEFAULT_MAX_READ_PARALLEL: i64 = 8;
 
+    pub const DEFAULT_AUTO_CACHE_SUBMIT_QUEUE_SIZE: usize = 1024;
+    pub const DEFAULT_AUTO_CACHE_SUBMIT_RETRY_MAX: u32 = 3;
+    pub const DEFAULT_AUTO_CACHE_SUBMIT_RETRY_MIN_SLEEP_MS: u64 = 100;
+    pub const DEFAULT_AUTO_CACHE_SUBMIT_RETRY_MAX_SLEEP_MS: u64 = 2_000;
+
     pub fn init(&mut self) -> CommonResult<()> {
         if self.read_parallel <= 0 {
             self.read_parallel = Self::DEFAULT_READ_PARALLEL;
         }
         if self.max_read_parallel <= 0 {
             self.max_read_parallel = Self::DEFAULT_MAX_READ_PARALLEL;
+        }
+        if self.auto_cache_submit_queue_size == 0 {
+            return err_box!("client.auto_cache_submit_queue_size must be > 0");
+        }
+        if self.auto_cache_submit_retry_min_sleep_ms == 0 {
+            return err_box!("client.auto_cache_submit_retry_min_sleep_ms must be > 0");
+        }
+        if self.auto_cache_submit_retry_max_sleep_ms < self.auto_cache_submit_retry_min_sleep_ms {
+            return err_box!(
+                "client.auto_cache_submit_retry_max_sleep_ms must be >= client.auto_cache_submit_retry_min_sleep_ms"
+            );
         }
 
         self.block_size = ByteUnit::from_str(&self.block_size_str)?.as_byte() as i64;
@@ -422,6 +454,12 @@ impl Default for ClientConf {
             auto_cache_enabled: false,
             auto_cache_ttl: "7d".to_string(),
             default_cache_ttl: Some("7d".to_string()),
+            auto_cache_submit_queue_size: Self::DEFAULT_AUTO_CACHE_SUBMIT_QUEUE_SIZE,
+            auto_cache_submit_retry_max: Self::DEFAULT_AUTO_CACHE_SUBMIT_RETRY_MAX,
+            auto_cache_submit_retry_min_sleep_ms:
+                Self::DEFAULT_AUTO_CACHE_SUBMIT_RETRY_MIN_SLEEP_MS,
+            auto_cache_submit_retry_max_sleep_ms:
+                Self::DEFAULT_AUTO_CACHE_SUBMIT_RETRY_MAX_SLEEP_MS,
 
             conn_retry_max_duration_ms: 60 * 1000,
             conn_retry_min_sleep_ms: 100,

--- a/curvine-common/tests/client_conf_cli_test.rs
+++ b/curvine-common/tests/client_conf_cli_test.rs
@@ -83,6 +83,42 @@ fn normalizes_non_positive_read_parallel_settings_to_defaults() {
 }
 
 #[test]
+fn validates_auto_cache_submit_backpressure_conf() {
+    let mut conf = ClientConf::default();
+    assert_eq!(
+        conf.auto_cache_submit_queue_size,
+        ClientConf::DEFAULT_AUTO_CACHE_SUBMIT_QUEUE_SIZE
+    );
+    assert_eq!(
+        conf.auto_cache_submit_retry_max,
+        ClientConf::DEFAULT_AUTO_CACHE_SUBMIT_RETRY_MAX
+    );
+
+    conf.auto_cache_submit_queue_size = 0;
+    let err = conf.init().unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("client.auto_cache_submit_queue_size must be > 0"),
+        "unexpected error: {}",
+        err
+    );
+
+    let mut conf = ClientConf {
+        auto_cache_submit_retry_min_sleep_ms: 200,
+        auto_cache_submit_retry_max_sleep_ms: 100,
+        ..Default::default()
+    };
+    let err = conf.init().unwrap_err();
+    assert!(
+        err.to_string().contains(
+            "client.auto_cache_submit_retry_max_sleep_ms must be >= client.auto_cache_submit_retry_min_sleep_ms"
+        ),
+        "unexpected error: {}",
+        err
+    );
+}
+
+#[test]
 fn parses_c4_chunk_unified_fs_and_audit_flags() {
     let parsed = CliHarness::try_parse_from([
         "curvine-fuse",


### PR DESCRIPTION
# Summary

Add client-side auto-cache submit backpressure configuration fields and validation.

# Issue Describe / Design

Root cause: client-side retry/queue behavior for auto-cache submit needs explicit local capacity and retry timing. Without named config fields, the client implementation would have to hard-code queue size and backoff policy.

Fix approach: add `ClientConf` fields for local submit queue size, retry count, retry min sleep, and retry max sleep. Defaults keep existing client startup compatible, and `init()` rejects impossible values such as zero queue size or max sleep lower than min sleep.

This PR only adds config. It does not change auto-cache submit behavior by itself.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-common/src/conf/client_conf.rs` | Add auto-cache submit queue/retry config with defaults and validation | No behavior change until client code consumes these fields |
| `curvine-common/tests/client_conf_cli_test.rs` | Add validation coverage | Test-only |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo fmt --check` | PASS | |
| `cargo test -p curvine-common --test client_conf_cli_test validates_auto_cache_submit_backpressure_conf` | PASS | |
| `cargo clippy -p curvine-common --all-targets --jobs 2 -- --deny=warnings --allow clippy::uninlined-format-args` | PASS | |
| `git diff --check` | PASS | |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None
