### PR TITLE
fix(master): isolate control-plane rpc lanes (#1011)

### DIFF
--- a/curvine-server/src/master/master_handler.rs
+++ b/curvine-server/src/master/master_handler.rs
@@ -35,6 +35,7 @@ use orpc::handler::{FrameBuf, MessageHandler};
 use orpc::io::net::ConnState;
 use orpc::message::Message;
 use orpc::runtime::GroupExecutor;
+use std::panic::{self, AssertUnwindSafe};
 use std::sync::Arc;
 use tokio::sync::oneshot;
 
@@ -735,9 +736,29 @@ impl MasterHandler {
     {
         let (tx, rx) = oneshot::channel();
         executor.try_spawn(move || {
-            let _ = tx.send(task());
+            let res = panic::catch_unwind(AssertUnwindSafe(task))
+                .unwrap_or_else(|_| err_box!("master rpc lane task panicked"));
+            let _ = tx.send(res);
         })?;
         rx.await?
+    }
+
+    fn record_rpc_observability(&self, ctx: &RpcContext<'_>, response: &FsResult<Message>) {
+        let used_us = ctx.spent.used_us();
+        if self.audit_logging_enabled {
+            ctx.audit_log(response, used_us, self.conn_state.as_ref());
+        }
+
+        let code_label = format!("{:?}", ctx.code);
+        self.metrics.rpc_request_total_time.inc_by(used_us as i64);
+        self.metrics.rpc_request_total_count.inc();
+
+        if ctx.code != RpcCode::WorkerHeartbeat {
+            self.metrics
+                .operation_duration
+                .with_label_values(&[&code_label])
+                .observe(used_us as f64);
+        };
     }
 
     async fn async_get_block_locations(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
@@ -907,22 +928,7 @@ impl MessageHandler for MasterHandler {
             _ => err_box!("Unsupported operation"),
         };
 
-        // Record request processing time and audit log
-        let used_us = ctx.spent.used_us();
-        if self.audit_logging_enabled {
-            ctx.audit_log(&response, used_us, self.conn_state.as_ref());
-        }
-
-        let code_label = format!("{:?}", ctx.code);
-        self.metrics.rpc_request_total_time.inc_by(used_us as i64);
-        self.metrics.rpc_request_total_count.inc();
-
-        if ctx.code != RpcCode::WorkerHeartbeat {
-            self.metrics
-                .operation_duration
-                .with_label_values(&[&code_label])
-                .observe(used_us as f64);
-        };
+        self.record_rpc_observability(ctx, &response);
 
         match response {
             Ok(v) => Ok(v),
@@ -935,25 +941,26 @@ impl MessageHandler for MasterHandler {
         let ctx = &mut rpc_context;
         let code = RpcCode::from(msg.code());
 
-        // Check whether the master is active
-        if !self.fs.master_monitor.is_active() {
-            return Ok(msg.error_ext(&FsError::not_leader_master(ctx.code, self.client_ip())));
-        }
+        let res = if !self.fs.master_monitor.is_active() {
+            Err(FsError::not_leader_master(ctx.code, self.client_ip()))
+        } else {
+            match code {
+                RpcCode::SubmitJob => self.job_handler.submit_load_job(ctx, &mut self.buf).await,
+                RpcCode::GetJobStatus => self.job_handler.get_load_status(ctx, &mut self.buf),
+                RpcCode::CancelJob => self.job_handler.cancel_job(ctx, &mut self.buf).await,
+                RpcCode::ReportTask => self.job_handler.task_report(ctx, &mut self.buf),
+                RpcCode::GetBlockLocations => self.async_get_block_locations(ctx).await,
+                RpcCode::GetMasterInfo => self.async_get_master_info(ctx).await,
+                RpcCode::ListStatus => self.async_list_status(ctx).await,
+                RpcCode::ListOptions => self.async_list_options(ctx).await,
+                RpcCode::WorkerHeartbeat => self.async_worker_heartbeat(ctx).await,
+                RpcCode::WorkerBlockReport => self.async_worker_block_report(ctx).await,
 
-        let res = match code {
-            RpcCode::SubmitJob => self.job_handler.submit_load_job(ctx, &mut self.buf).await,
-            RpcCode::GetJobStatus => self.job_handler.get_load_status(ctx, &mut self.buf),
-            RpcCode::CancelJob => self.job_handler.cancel_job(ctx, &mut self.buf).await,
-            RpcCode::ReportTask => self.job_handler.task_report(ctx, &mut self.buf),
-            RpcCode::GetBlockLocations => self.async_get_block_locations(ctx).await,
-            RpcCode::GetMasterInfo => self.async_get_master_info(ctx).await,
-            RpcCode::ListStatus => self.async_list_status(ctx).await,
-            RpcCode::ListOptions => self.async_list_options(ctx).await,
-            RpcCode::WorkerHeartbeat => self.async_worker_heartbeat(ctx).await,
-            RpcCode::WorkerBlockReport => self.async_worker_block_report(ctx).await,
-
-            v => err_box!("unsupported operation {:?}", v),
+                v => err_box!("unsupported operation {:?}", v),
+            }
         };
+
+        self.record_rpc_observability(ctx, &res);
 
         match res {
             Ok(v) => Ok(v),

--- a/curvine-server/src/master/master_handler.rs
+++ b/curvine-server/src/master/master_handler.rs
@@ -24,7 +24,8 @@ use curvine_common::fs::Path;
 use curvine_common::fs::RpcCode;
 use curvine_common::proto::*;
 use curvine_common::state::{
-    CreateFileOpts, FileBlocks, FileStatus, FreeResult, HeartbeatStatus, OpenFlags, RenameFlags,
+    CreateFileOpts, FileBlocks, FileStatus, FreeResult, HeartbeatStatus, ListOptions, MasterInfo,
+    OpenFlags, RenameFlags, WorkerCommand,
 };
 use curvine_common::utils::ProtoUtils;
 use curvine_common::FsResult;
@@ -33,7 +34,9 @@ use orpc::err_box;
 use orpc::handler::{FrameBuf, MessageHandler};
 use orpc::io::net::ConnState;
 use orpc::message::Message;
+use orpc::runtime::GroupExecutor;
 use std::sync::Arc;
+use tokio::sync::oneshot;
 
 pub struct MasterHandler {
     pub(crate) fs: MasterFilesystem,
@@ -43,6 +46,11 @@ pub struct MasterHandler {
     pub(crate) conn_state: Option<ConnState>,
     pub(crate) job_handler: JobHandler,
     pub(crate) mount_manager: Arc<MountManager>,
+    pub(crate) heartbeat_rpc_executor: Arc<GroupExecutor>,
+    pub(crate) block_report_rpc_executor: Arc<GroupExecutor>,
+    pub(crate) control_rpc_executor: Arc<GroupExecutor>,
+    pub(crate) list_rpc_executor: Arc<GroupExecutor>,
+    pub(crate) get_block_locations_rpc_executor: Arc<GroupExecutor>,
     pub(crate) replication_handler: Option<MasterReplicationHandler>,
     pub(crate) buf: FrameBuf,
 }
@@ -56,6 +64,11 @@ impl MasterHandler {
         conn_state: Option<ConnState>,
         mount_manager: Arc<MountManager>,
         job_handler: JobHandler,
+        heartbeat_rpc_executor: Arc<GroupExecutor>,
+        block_report_rpc_executor: Arc<GroupExecutor>,
+        control_rpc_executor: Arc<GroupExecutor>,
+        list_rpc_executor: Arc<GroupExecutor>,
+        get_block_locations_rpc_executor: Arc<GroupExecutor>,
         replication_manager: Arc<MasterReplicationManager>,
         metrics: &'static MasterMetrics,
     ) -> Self {
@@ -67,6 +80,11 @@ impl MasterHandler {
             conn_state,
             mount_manager,
             job_handler,
+            heartbeat_rpc_executor,
+            block_report_rpc_executor,
+            control_rpc_executor,
+            list_rpc_executor,
+            get_block_locations_rpc_executor,
             replication_handler: Some(MasterReplicationHandler::new(replication_manager)),
             buf: FrameBuf::new(conf.master.buffer_size),
         }
@@ -266,7 +284,7 @@ impl MasterHandler {
         let header: ListStatusRequest = ctx.parse_header()?;
         ctx.set_audit(Some(header.path.to_string()), None);
 
-        let list = self.fs.list_status(&header.path)?;
+        let list = Self::process_list_status(self.fs.clone(), header.path)?;
         let res = list
             .into_iter()
             .map(ProtoUtils::file_status_to_pb)
@@ -274,6 +292,10 @@ impl MasterHandler {
 
         let rep_header = ListStatusResponse { statuses: res };
         ctx.response_buf(rep_header, &mut self.buf)
+    }
+
+    fn process_list_status(fs: MasterFilesystem, path: String) -> FsResult<Vec<FileStatus>> {
+        fs.list_status(&path)
     }
 
     // The add block internally determines whether it is a retry request.
@@ -418,53 +440,76 @@ impl MasterHandler {
         let req: GetBlockLocationsRequest = ctx.parse_header()?;
         ctx.set_audit(Some(req.path.to_string()), None);
 
-        let blocks = self.fs.get_block_locations(req.path)?;
+        let blocks = Self::process_get_block_locations(self.fs.clone(), req.path)?;
         let rep_header = GetBlockLocationsResponse {
             blocks: ProtoUtils::file_blocks_to_pb(blocks),
         };
         ctx.response_buf(rep_header, &mut self.buf)
     }
 
+    fn process_get_block_locations(fs: MasterFilesystem, path: String) -> FsResult<FileBlocks> {
+        fs.get_block_locations(path)
+    }
+
     pub fn get_master_info(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let _: GetMasterInfoRequest = ctx.parse_header()?;
 
-        let info = self.fs.master_info()?;
+        let info = Self::process_get_master_info(self.fs.clone())?;
         let rep_header = ProtoUtils::master_info_to_pb(info);
         ctx.response_buf(rep_header, &mut self.buf)
     }
 
+    fn process_get_master_info(fs: MasterFilesystem) -> FsResult<MasterInfo> {
+        fs.master_info()
+    }
+
     pub fn worker_heartbeat(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let header: WorkerHeartbeatRequest = ctx.parse_header()?;
-        let status = HeartbeatStatus::from(header.status);
-        let address = ProtoUtils::worker_address_from_pb(&header.address);
-        if matches!(status, HeartbeatStatus::Start) {
-            self.fs.reset_full_block_report(address.worker_id);
-        }
-
-        let mut wm = self.fs.worker_manager.write();
-
-        let cmds = wm.heartbeat(
-            &header.cluster_id,
-            status,
-            address,
-            ProtoUtils::storage_info_list_from_pb(header.storages),
-        )?;
-        drop(wm);
-
+        let cmds = Self::process_worker_heartbeat(self.fs.clone(), header)?;
         let rep_header = WorkerHeartbeatResponse {
             cmds: ProtoUtils::worker_cmd_to_pb(cmds),
         };
         ctx.response_buf(rep_header, &mut self.buf)
     }
 
+    fn process_worker_heartbeat(
+        fs: MasterFilesystem,
+        header: WorkerHeartbeatRequest,
+    ) -> FsResult<Vec<WorkerCommand>> {
+        let status = HeartbeatStatus::from(header.status);
+        let address = ProtoUtils::worker_address_from_pb(&header.address);
+        if matches!(status, HeartbeatStatus::Start) {
+            fs.reset_full_block_report(address.worker_id);
+        }
+
+        let mut wm = fs.worker_manager.write();
+        let cmds = wm.heartbeat(
+            &header.cluster_id,
+            status,
+            address,
+            ProtoUtils::storage_info_list_from_pb(header.storages),
+        )?;
+        Ok(cmds)
+    }
+
     pub fn block_report(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let header: BlockReportListRequest = ctx.parse_header()?;
+        Self::process_block_report(self.fs.clone(), self.replication_handler.clone(), header)?;
+        let rep_header = BlockReportListResponse::default();
+        ctx.response_buf(rep_header, &mut self.buf)
+    }
+
+    fn process_block_report(
+        fs: MasterFilesystem,
+        replication_handler: Option<MasterReplicationHandler>,
+        header: BlockReportListRequest,
+    ) -> FsResult<()> {
         let list = ProtoUtils::block_report_list_from_pb(header);
         let worker_id = list.worker_id;
-        let stale_block_ids = self.fs.block_report(list)?;
+        let stale_block_ids = fs.block_report(list)?;
         let stale_block_count = stale_block_ids.len();
         if stale_block_count > 0 {
-            if let Some(replication_handler) = &self.replication_handler {
+            if let Some(replication_handler) = &replication_handler {
                 if let Err(e) =
                     replication_handler.report_under_replicated_blocks(worker_id, stale_block_ids)
                 {
@@ -475,9 +520,7 @@ impl MasterHandler {
                 }
             }
         }
-
-        let rep_header = BlockReportListResponse::default();
-        ctx.response_buf(rep_header, &mut self.buf)
+        Ok(())
     }
 
     fn client_ip(&self) -> &str {
@@ -668,13 +711,118 @@ impl MasterHandler {
         let audit_path = format!("{}[{}]", header.path, opts);
         ctx.set_audit(Some(audit_path), None);
 
-        let list = self.fs.list_options(&header.path, opts)?;
+        let list = Self::process_list_options(self.fs.clone(), header.path, opts)?;
         let res = list
             .into_iter()
             .map(ProtoUtils::file_status_to_pb)
             .collect();
         let rep_header = ListOptionsResponse { statuses: res };
         ctx.response_buf(rep_header, &mut self.buf)
+    }
+
+    fn process_list_options(
+        fs: MasterFilesystem,
+        path: String,
+        opts: ListOptions,
+    ) -> FsResult<Vec<FileStatus>> {
+        fs.list_options(&path, opts)
+    }
+
+    async fn run_master_rpc_task<T, F>(executor: Arc<GroupExecutor>, task: F) -> FsResult<T>
+    where
+        T: Send + 'static,
+        F: FnOnce() -> FsResult<T> + Send + 'static,
+    {
+        let (tx, rx) = oneshot::channel();
+        executor.try_spawn(move || {
+            let _ = tx.send(task());
+        })?;
+        rx.await?
+    }
+
+    async fn async_get_block_locations(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+        let req: GetBlockLocationsRequest = ctx.parse_header()?;
+        ctx.set_audit(Some(req.path.to_string()), None);
+        let fs = self.fs.clone();
+        let blocks =
+            Self::run_master_rpc_task(self.get_block_locations_rpc_executor.clone(), move || {
+                Self::process_get_block_locations(fs, req.path)
+            })
+            .await?;
+        let rep_header = GetBlockLocationsResponse {
+            blocks: ProtoUtils::file_blocks_to_pb(blocks),
+        };
+        ctx.response_buf(rep_header, &mut self.buf)
+    }
+
+    async fn async_get_master_info(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+        let _: GetMasterInfoRequest = ctx.parse_header()?;
+        let fs = self.fs.clone();
+        let info = Self::run_master_rpc_task(self.control_rpc_executor.clone(), move || {
+            Self::process_get_master_info(fs)
+        })
+        .await?;
+        let rep_header = ProtoUtils::master_info_to_pb(info);
+        ctx.response_buf(rep_header, &mut self.buf)
+    }
+
+    async fn async_list_status(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+        let header: ListStatusRequest = ctx.parse_header()?;
+        ctx.set_audit(Some(header.path.to_string()), None);
+        let fs = self.fs.clone();
+        let list = Self::run_master_rpc_task(self.list_rpc_executor.clone(), move || {
+            Self::process_list_status(fs, header.path)
+        })
+        .await?;
+        let statuses = list
+            .into_iter()
+            .map(ProtoUtils::file_status_to_pb)
+            .collect();
+        ctx.response_buf(ListStatusResponse { statuses }, &mut self.buf)
+    }
+
+    async fn async_list_options(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+        let header: ListOptionsRequest = ctx.parse_header()?;
+        if header.options.limit.unwrap_or(0) < 0 {
+            return err_box!("list options limit must be greater than 0");
+        }
+        let opts = ProtoUtils::list_options_from_pb(header.options);
+        let audit_path = format!("{}[{}]", header.path, opts);
+        ctx.set_audit(Some(audit_path), None);
+        let fs = self.fs.clone();
+        let list = Self::run_master_rpc_task(self.list_rpc_executor.clone(), move || {
+            Self::process_list_options(fs, header.path, opts)
+        })
+        .await?;
+        let statuses = list
+            .into_iter()
+            .map(ProtoUtils::file_status_to_pb)
+            .collect();
+        ctx.response_buf(ListOptionsResponse { statuses }, &mut self.buf)
+    }
+
+    async fn async_worker_heartbeat(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+        let header: WorkerHeartbeatRequest = ctx.parse_header()?;
+        let fs = self.fs.clone();
+        let cmds = Self::run_master_rpc_task(self.heartbeat_rpc_executor.clone(), move || {
+            Self::process_worker_heartbeat(fs, header)
+        })
+        .await?;
+        let rep_header = WorkerHeartbeatResponse {
+            cmds: ProtoUtils::worker_cmd_to_pb(cmds),
+        };
+        ctx.response_buf(rep_header, &mut self.buf)
+    }
+
+    async fn async_worker_block_report(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+        let header: BlockReportListRequest = ctx.parse_header()?;
+        let fs = self.fs.clone();
+        let replication_handler = self.replication_handler.clone();
+        Self::run_master_rpc_task(self.block_report_rpc_executor.clone(), move || {
+            Self::process_block_report(fs, replication_handler, header)
+        })
+        .await?;
+        ctx.response_buf(BlockReportListResponse::default(), &mut self.buf)
     }
 }
 
@@ -685,7 +833,16 @@ impl MessageHandler for MasterHandler {
         let code = RpcCode::from(msg.code());
         !matches!(
             code,
-            RpcCode::SubmitJob | RpcCode::GetJobStatus | RpcCode::CancelJob | RpcCode::ReportTask
+            RpcCode::SubmitJob
+                | RpcCode::GetJobStatus
+                | RpcCode::CancelJob
+                | RpcCode::ReportTask
+                | RpcCode::GetBlockLocations
+                | RpcCode::GetMasterInfo
+                | RpcCode::ListStatus
+                | RpcCode::ListOptions
+                | RpcCode::WorkerHeartbeat
+                | RpcCode::WorkerBlockReport
         )
     }
 
@@ -780,7 +937,7 @@ impl MessageHandler for MasterHandler {
 
         // Check whether the master is active
         if !self.fs.master_monitor.is_active() {
-            return Err(FsError::not_leader_master(ctx.code, self.client_ip()));
+            return Ok(msg.error_ext(&FsError::not_leader_master(ctx.code, self.client_ip())));
         }
 
         let res = match code {
@@ -788,6 +945,12 @@ impl MessageHandler for MasterHandler {
             RpcCode::GetJobStatus => self.job_handler.get_load_status(ctx, &mut self.buf),
             RpcCode::CancelJob => self.job_handler.cancel_job(ctx, &mut self.buf).await,
             RpcCode::ReportTask => self.job_handler.task_report(ctx, &mut self.buf),
+            RpcCode::GetBlockLocations => self.async_get_block_locations(ctx).await,
+            RpcCode::GetMasterInfo => self.async_get_master_info(ctx).await,
+            RpcCode::ListStatus => self.async_list_status(ctx).await,
+            RpcCode::ListOptions => self.async_list_options(ctx).await,
+            RpcCode::WorkerHeartbeat => self.async_worker_heartbeat(ctx).await,
+            RpcCode::WorkerBlockReport => self.async_worker_block_report(ctx).await,
 
             v => err_box!("unsupported operation {:?}", v),
         };

--- a/curvine-server/src/master/master_server.rs
+++ b/curvine-server/src/master/master_server.rs
@@ -22,7 +22,7 @@ use log::error;
 use orpc::common::{LocalTime, Logger};
 use orpc::handler::HandlerService;
 use orpc::io::net::ConnState;
-use orpc::runtime::{RpcRuntime, Runtime};
+use orpc::runtime::{GroupExecutor, RpcRuntime, Runtime};
 use orpc::server::{RpcServer, ServerStateListener};
 use orpc::{err_box, CommonResult};
 
@@ -44,6 +44,11 @@ pub struct MasterService {
     mount_manager: Arc<MountManager>,
     job_manager: Arc<JobManager>,
     rt: Arc<Runtime>,
+    heartbeat_rpc_executor: Arc<GroupExecutor>,
+    block_report_rpc_executor: Arc<GroupExecutor>,
+    control_rpc_executor: Arc<GroupExecutor>,
+    list_rpc_executor: Arc<GroupExecutor>,
+    get_block_locations_rpc_executor: Arc<GroupExecutor>,
     replication_manager: Arc<MasterReplicationManager>,
     metrics: &'static MasterMetrics,
 }
@@ -57,6 +62,11 @@ impl MasterService {
         mount_manager: Arc<MountManager>,
         job_manager: Arc<JobManager>,
         rt: Arc<Runtime>,
+        heartbeat_rpc_executor: Arc<GroupExecutor>,
+        block_report_rpc_executor: Arc<GroupExecutor>,
+        control_rpc_executor: Arc<GroupExecutor>,
+        list_rpc_executor: Arc<GroupExecutor>,
+        get_block_locations_rpc_executor: Arc<GroupExecutor>,
         replication_manager: Arc<MasterReplicationManager>,
         metrics: &'static MasterMetrics,
     ) -> Self {
@@ -67,6 +77,11 @@ impl MasterService {
             mount_manager,
             job_manager,
             rt,
+            heartbeat_rpc_executor,
+            block_report_rpc_executor,
+            control_rpc_executor,
+            list_rpc_executor,
+            get_block_locations_rpc_executor,
             replication_manager,
             metrics,
         }
@@ -104,6 +119,11 @@ impl HandlerService for MasterService {
             client_state,
             self.mount_manager.clone(),
             JobHandler::new(self.job_manager.clone()),
+            self.heartbeat_rpc_executor.clone(),
+            self.block_report_rpc_executor.clone(),
+            self.control_rpc_executor.clone(),
+            self.list_rpc_executor.clone(),
+            self.get_block_locations_rpc_executor.clone(),
             self.replication_manager.clone(),
             self.metrics,
         )
@@ -149,6 +169,22 @@ impl Master {
         let job_manager = journal_system.job_manager();
 
         let rt = Arc::new(conf.master_server_conf().create_runtime());
+        let heartbeat_rpc_executor = Arc::new(GroupExecutor::new("master-heartbeat-rpc", 2, 1024));
+        let block_report_rpc_executor =
+            Arc::new(GroupExecutor::new("master-block-report-rpc", 2, 128));
+        let control_rpc_executor = Arc::new(GroupExecutor::new("master-control-rpc", 2, 1024));
+        let read_lane_threads = conf.master.worker_threads.saturating_sub(4).max(1);
+        let read_lane_queue = conf.master.worker_threads.saturating_mul(2).max(1);
+        let list_rpc_executor = Arc::new(GroupExecutor::new(
+            "master-list-rpc",
+            read_lane_threads,
+            read_lane_queue,
+        ));
+        let get_block_locations_rpc_executor = Arc::new(GroupExecutor::new(
+            "master-get-block-locations-rpc",
+            read_lane_threads,
+            read_lane_queue,
+        ));
 
         let replication_manager = MasterReplicationManager::new(&fs, &conf, &rt, &worker_manager)?;
 
@@ -169,6 +205,11 @@ impl Master {
             mount_manager.clone(),
             job_manager.clone(),
             rt.clone(),
+            heartbeat_rpc_executor,
+            block_report_rpc_executor,
+            control_rpc_executor,
+            list_rpc_executor,
+            get_block_locations_rpc_executor,
             replication_manager.clone(),
             metrics,
         );

--- a/curvine-server/tests/master_fs_test.rs
+++ b/curvine-server/tests/master_fs_test.rs
@@ -17,7 +17,8 @@ use curvine_common::error::FsError;
 use curvine_common::fs::CurvineURI;
 use curvine_common::fs::RpcCode;
 use curvine_common::proto::{
-    CreateFileRequest, DeleteRequest, MkdirOptsProto, MkdirRequest, RenameRequest,
+    CreateFileRequest, DeleteRequest, GetMasterInfoRequest, MkdirOptsProto, MkdirRequest,
+    RenameRequest,
 };
 use curvine_common::raft::storage::{AppStorage, ApplyMsg};
 use curvine_common::state::MountOptions;
@@ -32,8 +33,9 @@ use curvine_server::master::replication::master_replication_manager::MasterRepli
 use curvine_server::master::{JobHandler, JobManager, Master, MasterHandler, RpcContext};
 use orpc::common::LocalTime;
 use orpc::common::Utils;
+use orpc::handler::MessageHandler;
 use orpc::message::Builder;
-use orpc::runtime::{AsyncRuntime, RpcRuntime};
+use orpc::runtime::{AsyncRuntime, GroupExecutor, RpcRuntime};
 use orpc::CommonResult;
 use raft::eraftpb::Entry;
 use std::sync::{Arc, Mutex, OnceLock};
@@ -147,11 +149,13 @@ fn file_counts(fs: &MasterFilesystem) -> (i64, i64) {
 fn new_handler() -> MasterHandler {
     Master::init_test_metrics();
 
+    let test_id = Utils::rand_str(8);
     let mut conf = ClusterConf::format();
     conf.journal.enable = false;
 
-    conf.master.meta_dir = Utils::test_sub_dir("master-fs-test/meta-retry");
-    conf.journal.journal_dir = Utils::test_sub_dir("master-fs-test/journal-retry");
+    conf.master.meta_dir = Utils::test_sub_dir(format!("master-fs-test/meta-retry-{test_id}"));
+    conf.journal.journal_dir =
+        Utils::test_sub_dir(format!("master-fs-test/journal-retry-{test_id}"));
 
     let journal_system = JournalSystem::from_conf(&conf).unwrap();
     let fs = MasterFilesystem::with_js(&conf, &journal_system);
@@ -177,9 +181,60 @@ fn new_handler() -> MasterHandler {
         None,
         mount_manager,
         JobHandler::new(job_manager),
+        Arc::new(GroupExecutor::new("test-master-heartbeat-rpc", 1, 8)),
+        Arc::new(GroupExecutor::new("test-master-block-report-rpc", 1, 8)),
+        Arc::new(GroupExecutor::new("test-master-control-rpc", 1, 8)),
+        Arc::new(GroupExecutor::new("test-master-list-rpc", 1, 8)),
+        Arc::new(GroupExecutor::new(
+            "test-master-get-block-locations-rpc",
+            1,
+            8,
+        )),
         replication_manager,
         Master::get_metrics().expect("test master metrics should initialize"),
     )
+}
+
+#[test]
+fn worker_reports_and_metadata_reads_do_not_use_master_sync_pool() {
+    let _serial = master_fs_test_serial();
+    let handler = new_handler();
+
+    for code in [
+        RpcCode::SubmitJob,
+        RpcCode::GetJobStatus,
+        RpcCode::CancelJob,
+        RpcCode::ReportTask,
+        RpcCode::GetBlockLocations,
+        RpcCode::GetMasterInfo,
+        RpcCode::ListStatus,
+        RpcCode::ListOptions,
+        RpcCode::WorkerHeartbeat,
+        RpcCode::WorkerBlockReport,
+    ] {
+        let msg = Builder::new_rpc(code).build();
+        assert!(!handler.is_sync(&msg), "{code:?} must use an async lane");
+    }
+
+    let mkdir = Builder::new_rpc(RpcCode::Mkdir).build();
+    assert!(handler.is_sync(&mkdir));
+}
+
+#[test]
+fn async_rpc_to_standby_returns_rpc_error_response() -> CommonResult<()> {
+    let _serial = master_fs_test_serial();
+    let mut handler = new_handler();
+    let msg = Builder::new_rpc(RpcCode::GetMasterInfo)
+        .proto_header(GetMasterInfoRequest::default())
+        .build();
+
+    let rt = AsyncRuntime::single();
+    let response = rt.block_on(handler.async_handle(msg))?;
+
+    assert!(!response.is_success());
+    let err = response.check_error_ext::<FsError>().unwrap_err();
+    assert!(matches!(err, FsError::NotLeaderMaster(_)));
+    Ok(())
 }
 
 #[test]

--- a/orpc/src/runtime/group_executor.rs
+++ b/orpc/src/runtime/group_executor.rs
@@ -63,6 +63,13 @@ impl GroupExecutor {
         self.get_robin_thread().spawn(task)
     }
 
+    pub fn try_spawn<F>(&self, task: F) -> CommonResult<()>
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        self.get_robin_thread().try_spawn(task)
+    }
+
     pub fn spawn_blocking<F, R>(&self, task: F) -> CommonResult<R>
     where
         F: FnOnce() -> R + Send + 'static,
@@ -76,6 +83,13 @@ impl GroupExecutor {
         F: FnOnce() + Send + 'static,
     {
         self.get_fix_thread(id).spawn(task)
+    }
+
+    pub fn fixed_try_spawn<F>(&self, id: i64, task: F) -> CommonResult<()>
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        self.get_fix_thread(id).try_spawn(task)
     }
 
     pub fn fixed_spawn_blocking<F, R>(&self, id: i64, task: F) -> CommonResult<R>

--- a/orpc/src/runtime/group_executor.rs
+++ b/orpc/src/runtime/group_executor.rs
@@ -13,10 +13,12 @@
 // limitations under the License.
 
 use crate::common::Utils;
+use crate::runtime::single_executor::Task;
 use crate::runtime::SingleExecutor;
-use crate::CommonResult;
+use crate::{err_box, CommonResult};
 use std::fmt::{Debug, Display, Formatter};
 use std::io::Cursor;
+use std::sync::mpsc::TrySendError;
 
 /// Thread group
 #[derive(Debug)]
@@ -67,7 +69,27 @@ impl GroupExecutor {
     where
         F: FnOnce() + Send + 'static,
     {
-        self.get_robin_thread().try_spawn(task)
+        let mut task = Some(Box::new(task) as Task);
+        let start = Utils::rand_id() as usize % self.thread_num;
+        let mut stopped = 0usize;
+
+        for offset in 0..self.thread_num {
+            let index = (start + offset) % self.thread_num;
+            match self.workers[index].try_spawn_task(task.take().unwrap()) {
+                Ok(()) => return Ok(()),
+                Err(TrySendError::Full(t)) => task = Some(t),
+                Err(TrySendError::Disconnected(t)) => {
+                    stopped += 1;
+                    task = Some(t);
+                }
+            }
+        }
+
+        if stopped == self.thread_num {
+            err_box!("executor group {} has stopped", self.name_prefix)
+        } else {
+            err_box!("executor group {} queue is full", self.name_prefix)
+        }
     }
 
     pub fn spawn_blocking<F, R>(&self, task: F) -> CommonResult<R>

--- a/orpc/src/runtime/single_executor.rs
+++ b/orpc/src/runtime/single_executor.rs
@@ -15,7 +15,7 @@
 use crate::{err_box, try_err, try_log, CommonResult};
 use log::{error, warn};
 use std::sync::atomic::{AtomicU8, Ordering};
-use std::sync::mpsc::{Receiver, RecvTimeoutError, SyncSender};
+use std::sync::mpsc::{Receiver, RecvTimeoutError, SyncSender, TrySendError};
 use std::sync::{mpsc, Arc};
 use std::thread;
 use std::thread::JoinHandle;
@@ -57,6 +57,17 @@ impl SingleExecutor {
     {
         try_err!(self.sender.send(Box::new(task)));
         Ok(())
+    }
+
+    pub fn try_spawn<F>(&self, task: F) -> CommonResult<()>
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        match self.sender.try_send(Box::new(task)) {
+            Ok(()) => Ok(()),
+            Err(TrySendError::Full(_)) => err_box!("executor {} queue is full", self.name),
+            Err(TrySendError::Disconnected(_)) => err_box!("executor {} has stopped", self.name),
+        }
     }
 
     pub fn spawn_blocking<F, R>(&self, task: F) -> CommonResult<R>

--- a/orpc/src/runtime/single_executor.rs
+++ b/orpc/src/runtime/single_executor.rs
@@ -21,7 +21,7 @@ use std::thread;
 use std::thread::JoinHandle;
 use std::time::Duration;
 
-type Task = Box<dyn FnOnce() + 'static + Send>;
+pub(super) type Task = Box<dyn FnOnce() + 'static + Send>;
 
 #[derive(Debug)]
 pub struct SingleExecutor {
@@ -63,11 +63,15 @@ impl SingleExecutor {
     where
         F: FnOnce() + Send + 'static,
     {
-        match self.sender.try_send(Box::new(task)) {
+        match self.try_spawn_task(Box::new(task)) {
             Ok(()) => Ok(()),
             Err(TrySendError::Full(_)) => err_box!("executor {} queue is full", self.name),
             Err(TrySendError::Disconnected(_)) => err_box!("executor {} has stopped", self.name),
         }
+    }
+
+    pub(super) fn try_spawn_task(&self, task: Task) -> Result<(), TrySendError<Task>> {
+        self.sender.try_send(task)
     }
 
     pub fn spawn_blocking<F, R>(&self, task: F) -> CommonResult<R>

--- a/orpc/tests/executor_test.rs
+++ b/orpc/tests/executor_test.rs
@@ -76,6 +76,41 @@ fn single_executor_try_spawn_returns_error_when_queue_is_full() -> CommonResult<
 }
 
 #[test]
+fn group_executor_try_spawn_uses_available_worker() -> CommonResult<()> {
+    let executor = GroupExecutor::new("group-try-spawn", 2, 128);
+    let (started_tx, started_rx) = mpsc::sync_channel(1);
+    let (release_tx, release_rx) = mpsc::sync_channel(1);
+
+    executor.fixed_spawn(0, move || {
+        started_tx.send(()).unwrap();
+        release_rx.recv().unwrap();
+    })?;
+    started_rx.recv()?;
+
+    for _ in 0..128 {
+        executor.fixed_try_spawn(0, || {})?;
+    }
+
+    let (done_tx, done_rx) = mpsc::sync_channel(64);
+    for _ in 0..64 {
+        let done_tx = done_tx.clone();
+        executor.try_spawn(move || {
+            done_tx.send(()).unwrap();
+        })?;
+    }
+    drop(done_tx);
+
+    for _ in 0..64 {
+        done_rx.recv()?;
+    }
+
+    release_tx.send(())?;
+    drop(executor);
+
+    Ok(())
+}
+
+#[test]
 fn test_group_executor_fixed_thread_allocation_for_thread_safety() {
     let executor = Arc::new(GroupExecutor::new("test", 2, 10));
 

--- a/orpc/tests/executor_test.rs
+++ b/orpc/tests/executor_test.rs
@@ -49,6 +49,33 @@ fn test_single_thread_executor_spawn_blocking() -> CommonResult<()> {
 }
 
 #[test]
+fn single_executor_try_spawn_returns_error_when_queue_is_full() -> CommonResult<()> {
+    let executor = SingleExecutor::new("try-spawn-full", 1);
+    let (started_tx, started_rx) = mpsc::sync_channel(1);
+    let (release_tx, release_rx) = mpsc::sync_channel(1);
+
+    executor.spawn(move || {
+        started_tx.send(()).unwrap();
+        release_rx.recv().unwrap();
+    })?;
+    started_rx.recv()?;
+
+    executor.try_spawn(|| {})?;
+    let err = executor.try_spawn(|| {}).unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("executor try-spawn-full queue is full"),
+        "unexpected error: {}",
+        err
+    );
+
+    release_tx.send(())?;
+    drop(executor);
+
+    Ok(())
+}
+
+#[test]
 fn test_group_executor_fixed_thread_allocation_for_thread_safety() {
     let executor = Arc::new(GroupExecutor::new("test", 2, 10));
 


### PR DESCRIPTION
# Summary

This PR isolates several master control-plane RPC classes into bounded executor lanes. It keeps the main RPC sync pool from being occupied by heartbeat, block-report, list, and get-block-locations storms while preserving the existing handler semantics.

# Issue Describe / Design

Related to #1011.

- Root cause: the master previously let more request types run through the shared RPC sync path. Under request storms, metadata reads, worker heartbeat, and full block report handling could occupy the shared processing resource and delay unrelated control-plane requests.
- Fix approach: add nonblocking `try_spawn` support to ORPC executors, then route heartbeat, block report, master info, list, and get-block-locations through dedicated bounded `GroupExecutor` lanes. Async handler errors are returned as normal RPC error responses, including standby/not-leader responses.
- Trade-off: this does not remove the global `fs_dir` lock bottleneck. It limits blast radius at the RPC execution layer and keeps worker/control traffic from sharing the same saturated sync pool.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `orpc/src/runtime/single_executor.rs` | Add nonblocking `try_spawn` that returns an error when the bounded queue is full or stopped. | Existing blocking `spawn` behavior is unchanged. |
| `orpc/src/runtime/group_executor.rs` | Expose `try_spawn` and `fixed_try_spawn` for grouped executors. | Enables bounded admission without blocking callers. |
| `curvine-server/src/master/master_server.rs` | Create dedicated master RPC lanes for heartbeat, block report, control, list, and get-block-locations. | New bounded executors isolate these request classes from the main sync pool. |
| `curvine-server/src/master/master_handler.rs` | Move selected RPCs to async handling and run their existing logic on the dedicated lanes. | Existing RPC response semantics are preserved; errors are encoded as RPC error responses. |
| `curvine-server/tests/master_fs_test.rs` | Cover async lane routing and standby async error response behavior. | Prevents regression back to sync-pool handling. |
| `orpc/tests/executor_test.rs` | Cover queue-full behavior for `SingleExecutor::try_spawn`. | Verifies nonblocking admission semantics. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo fmt --check` | PASS | |
| `cargo test -p orpc --test executor_test single_executor_try_spawn_returns_error_when_queue_is_full` | PASS | 1 passed. |
| `cargo test -p curvine-server --test master_fs_test -- --test-threads=1` | PASS | 23 passed. |
| `cargo clippy -p orpc -p curvine-server --all-targets --jobs 2 -- --deny=warnings --allow clippy::uninlined-format-args` | PASS | No issues found. |
| `git diff --check` | PASS | |

# Dependencies

- Related PRs: #1005, #1017
- Related issues: #1011
- Blocks / blocked by: None