### PR TITLE
fix(master): separate load and export path direction

### DIFF
--- a/curvine-server/src/master/job/job_manager.rs
+++ b/curvine-server/src/master/job/job_manager.rs
@@ -170,9 +170,9 @@ impl JobManager {
     pub async fn submit_load_job(&self, command: LoadJobCommand) -> FsResult<LoadJobResult> {
         let source_path = Path::from_str(&command.source_path)?;
 
-        // Check mount info for both UFS and CV paths
-        // - For UFS path: Import (UFS → Curvine)
-        // - For CV path: Export (Curvine → UFS), requires mount info to determine target UFS
+        // Check mount info for both UFS and CV paths. Public load jobs import
+        // from UFS into Curvine; CV paths are accepted only when existing
+        // metadata marks them as UFS-only.
         let mnt = if let Some(mnt) = self.mount_manager.get_mount_info(&source_path)? {
             mnt
         } else {

--- a/curvine-server/src/master/job/job_runner.rs
+++ b/curvine-server/src/master/job/job_runner.rs
@@ -97,26 +97,31 @@ impl LoadJobRunner {
         cv_source_mode: CvSourceMode,
     ) -> FsResult<(JobContext, Path, Path)> {
         let command_source = Path::from_str(&command.source_path)?;
-        let load_cv_from_ufs = if !command_source.is_cv() {
-            false
-        } else {
-            match cv_source_mode {
-                CvSourceMode::LoadUfsOnlyFromUfs => {
-                    match self.master_fs.file_status(command_source.path()) {
-                        Ok(status) => status.storage_policy.ufs_only(),
-                        Err(FsError::FileNotFound(_)) => false,
-                        Err(err) => return Err(err),
-                    }
-                }
-                CvSourceMode::ExportCurvineToUfs => false,
+        let (source_path, target_path) = match (cv_source_mode, command_source.is_cv()) {
+            (CvSourceMode::LoadUfsOnlyFromUfs, false) => {
+                let target_path = mnt.get_cv_path(&command_source)?;
+                (command_source, target_path)
             }
-        };
-
-        let (source_path, target_path) = if load_cv_from_ufs {
-            (mnt.get_ufs_path(&command_source)?, command_source)
-        } else {
-            let target_path = mnt.toggle_path(&command_source)?;
-            (command_source, target_path)
+            (CvSourceMode::LoadUfsOnlyFromUfs, true) => {
+                let status = self.master_fs.file_status(command_source.path())?;
+                if !status.storage_policy.ufs_only() {
+                    return err_box!(
+                        "load job for CV path {} requires UFS-only metadata",
+                        command_source.full_path()
+                    );
+                }
+                (mnt.get_ufs_path(&command_source)?, command_source)
+            }
+            (CvSourceMode::ExportCurvineToUfs, true) => {
+                let target_path = mnt.get_ufs_path(&command_source)?;
+                (command_source, target_path)
+            }
+            (CvSourceMode::ExportCurvineToUfs, false) => {
+                return err_box!(
+                    "export job source path {} must be a CV path",
+                    command_source.full_path()
+                );
+            }
         };
         let job_id = CommonUtils::create_job_id(source_path.full_path());
         let run_id = self.next_run_id();

--- a/curvine-server/src/master/job/job_runner.rs
+++ b/curvine-server/src/master/job/job_runner.rs
@@ -54,6 +54,12 @@ struct PlannedLoadJob {
     total_size: i64,
 }
 
+#[derive(Clone, Copy)]
+enum CvSourceMode {
+    LoadUfsOnlyFromUfs,
+    ExportCurvineToUfs,
+}
+
 impl LoadJobRunner {
     const RUN_ID_SEQ_MOD: u64 = 1_000_000;
 
@@ -88,9 +94,30 @@ impl LoadJobRunner {
         &self,
         command: &LoadJobCommand,
         mnt: &MountInfo,
+        cv_source_mode: CvSourceMode,
     ) -> FsResult<(JobContext, Path, Path)> {
-        let source_path = Path::from_str(&command.source_path)?;
-        let target_path = mnt.toggle_path(&source_path)?;
+        let command_source = Path::from_str(&command.source_path)?;
+        let load_cv_from_ufs = if !command_source.is_cv() {
+            false
+        } else {
+            match cv_source_mode {
+                CvSourceMode::LoadUfsOnlyFromUfs => {
+                    match self.master_fs.file_status(command_source.path()) {
+                        Ok(status) => status.storage_policy.ufs_only(),
+                        Err(FsError::FileNotFound(_)) => false,
+                        Err(err) => return Err(err),
+                    }
+                }
+                CvSourceMode::ExportCurvineToUfs => false,
+            }
+        };
+
+        let (source_path, target_path) = if load_cv_from_ufs {
+            (mnt.get_ufs_path(&command_source)?, command_source)
+        } else {
+            let target_path = mnt.toggle_path(&command_source)?;
+            (command_source, target_path)
+        };
         let job_id = CommonUtils::create_job_id(source_path.full_path());
         let run_id = self.next_run_id();
         let job_context = JobContext::with_conf(
@@ -161,7 +188,8 @@ impl LoadJobRunner {
         command: LoadJobCommand,
         mnt: MountInfo,
     ) -> FsResult<(LoadJobResult, Option<QueuedLoadJob>)> {
-        let (job_context, source_path, target_path) = self.build_job_context(&command, &mnt)?;
+        let (job_context, source_path, target_path) =
+            self.build_job_context(&command, &mnt, CvSourceMode::LoadUfsOnlyFromUfs)?;
         let job_id = job_context.info.job_id.clone();
         let run_id = job_context.run_id;
 
@@ -219,7 +247,32 @@ impl LoadJobRunner {
         command: LoadJobCommand,
         mnt: MountInfo,
     ) -> FsResult<LoadJobResult> {
-        let (mut job_context, source_path, target_path) = self.build_job_context(&command, &mnt)?;
+        self.submit_direct_task(command, mnt, CvSourceMode::LoadUfsOnlyFromUfs, "load")
+            .await
+    }
+
+    /// Submits a durable export job used by fs_mode journal replay.
+    ///
+    /// CV source paths stay CV sources here. This preserves the journal contract:
+    /// committed Curvine data is copied back to the mounted UFS.
+    pub async fn submit_export_task(
+        &self,
+        command: LoadJobCommand,
+        mnt: MountInfo,
+    ) -> FsResult<LoadJobResult> {
+        self.submit_direct_task(command, mnt, CvSourceMode::ExportCurvineToUfs, "export")
+            .await
+    }
+
+    async fn submit_direct_task(
+        &self,
+        command: LoadJobCommand,
+        mnt: MountInfo,
+        cv_source_mode: CvSourceMode,
+        job_kind: &str,
+    ) -> FsResult<LoadJobResult> {
+        let (mut job_context, source_path, target_path) =
+            self.build_job_context(&command, &mnt, cv_source_mode)?;
         let job_id = job_context.info.job_id.clone();
         let run_id = job_context.run_id;
 
@@ -233,7 +286,8 @@ impl LoadJobRunner {
             .await?
         {
             info!(
-                "skip load job {}: source_path {} already loaded or in progress",
+                "skip {} job {}: source_path {} already loaded or in progress",
+                job_kind,
                 job_id,
                 source_path.full_path()
             );
@@ -244,7 +298,8 @@ impl LoadJobRunner {
         }
 
         debug!(
-            "submitting load job {}: {} -> {}",
+            "submitting {} job {}: {} -> {}",
+            job_kind,
             job_id,
             source_path.full_path(),
             target_path.full_path()
@@ -256,7 +311,8 @@ impl LoadJobRunner {
         let total_size = planned.total_size;
         if planned.tasks.is_empty() {
             info!(
-                "load job {} has no tasks: {} -> {}",
+                "{} job {} has no tasks: {} -> {}",
+                job_kind,
                 job_id,
                 source_path.full_path(),
                 target_path.full_path()
@@ -272,7 +328,8 @@ impl LoadJobRunner {
         }
 
         info!(
-            "load job {} submitted: {} -> {}, tasks {}, total_size {}",
+            "{} job {} submitted: {} -> {}, tasks {}, total_size {}",
+            job_kind,
             job_id,
             source_path.full_path(),
             target_path.full_path(),
@@ -285,7 +342,7 @@ impl LoadJobRunner {
         // Install / replace the ctx into the store atomically. We branch into:
         //   - Vacant: first submitter, install and dispatch.
         //   - Occupied + running: another submitter won the race; return that job’s
-        //     state (this request’s command is not applied—see `submit_load_task` doc).
+        //     state (this request's command options are not applied).
         //   - Occupied + terminal: previous run finished/failed/canceled and
         //     hasn't been cleaned up yet. Replace with the new ctx and dispatch.
         match self.jobs.entry(job_id.clone()) {
@@ -312,7 +369,7 @@ impl LoadJobRunner {
         }
 
         if let Err(err) = self.submit_all_task(tasks).await {
-            warn!("dispatch load job {} failed: {}", job_id, err);
+            warn!("dispatch {} job {} failed: {}", job_kind, job_id, err);
             // @todo Cancel sub-tasks that may have already been dispatched.
             if let Err(update_err) = self.jobs.update_state(
                 &job_id,
@@ -320,8 +377,8 @@ impl LoadJobRunner {
                 format!("dispatch failed: {}", err),
             ) {
                 error!(
-                    "failed to mark load job {} as failed after dispatch error: {}",
-                    job_id, update_err
+                    "failed to mark {} job {} as failed after dispatch error: {}",
+                    job_kind, job_id, update_err
                 );
             }
             return Err(err);

--- a/curvine-server/src/master/journal/ufs_loader.rs
+++ b/curvine-server/src/master/journal/ufs_loader.rs
@@ -80,17 +80,17 @@ impl UfsLoader {
         }
     }
 
-    pub async fn submit_load_task(&self, path: &Path, mnt: &MountValue) -> FsResult<()> {
+    pub async fn submit_export_task(&self, path: &Path, mnt: &MountValue) -> FsResult<()> {
         let command = LoadJobCommand::builder(path.clone_uri()).build();
         let runner = self.job_manager.create_runner();
-        let res = match runner.submit_load_task(command, mnt.info.clone()).await {
+        let res = match runner.submit_export_task(command, mnt.info.clone()).await {
             Ok(res) => res,
             Err(e) => {
                 return if matches!(e, FsError::FileNotFound(_)) {
-                    info!("file {} not found, skipping load job", path.full_path());
+                    info!("file {} not found, skipping export job", path.full_path());
                     Ok(())
                 } else {
-                    err_box!("load job failed: {}", e)
+                    err_box!("export job failed: {}", e)
                 };
             }
         };
@@ -107,7 +107,7 @@ impl UfsLoader {
             Ok(())
         } else {
             err_box!(
-                "load job failed: {} {}",
+                "export job failed: {} {}",
                 status.state,
                 status.progress.message
             )
@@ -141,7 +141,7 @@ impl UfsLoader {
 
         let path = Path::from_str(&e.path)?;
         if let Some((_, mnt)) = self.get_mnt(&path)? {
-            self.submit_load_task(&path, &mnt).await?;
+            self.submit_export_task(&path, &mnt).await?;
             Ok(())
         } else {
             Ok(())
@@ -154,13 +154,13 @@ impl UfsLoader {
         if let Some((src_ufs_path, mnt)) = self.get_mnt(&src)? {
             if !mnt.ufs.exists(&src_ufs_path).await? {
                 warn!(
-                    "rename: src file not exists: {}, loading dst {}",
+                    "rename: src file not exists: {}, exporting dst {}",
                     src_ufs_path,
                     dst.full_path()
                 );
                 if let Some((_, dst_mnt)) = self.get_mnt(&dst)? {
                     // Keep journal apply aligned with fs_mode's durable export contract.
-                    self.submit_load_task(&dst, &dst_mnt).await?;
+                    self.submit_export_task(&dst, &dst_mnt).await?;
                 }
                 return Ok(());
             }
@@ -181,7 +181,7 @@ impl UfsLoader {
                 Ok(())
             } else {
                 mnt.ufs.delete(&src_ufs_path, true).await?;
-                self.submit_load_task(&dst, &mnt).await?;
+                self.submit_export_task(&dst, &mnt).await?;
                 Ok(())
             }
         } else {

--- a/curvine-server/tests/load_job_submit_test.rs
+++ b/curvine-server/tests/load_job_submit_test.rs
@@ -15,8 +15,9 @@
 use curvine_common::conf::{ClientConf, ClusterConf, JournalConf, MasterConf};
 use curvine_common::state::{
     JobTaskProgress, JobTaskState, LoadJobCommand, LoadJobInfo, LoadTaskInfo, MountInfo,
-    MountOptions, StorageType, TtlAction, WorkerAddress, WorkerInfo,
+    MountOptions, OpenFlags, StorageType, TtlAction, WorkerAddress, WorkerInfo,
 };
+use curvine_common::utils::CommonUtils;
 use curvine_server::master::fs::MasterFilesystem;
 use curvine_server::master::journal::JournalSystem;
 use curvine_server::master::{JobContext, JobManager, JobStore, Master};
@@ -28,6 +29,13 @@ use std::sync::Arc;
 use std::time::Duration;
 
 fn new_job_manager(name: &str) -> CommonResult<(Arc<JobManager>, Arc<Runtime>, String)> {
+    let (job_manager, rt, missing_source, _) = new_job_manager_with_fs(name)?;
+    Ok((job_manager, rt, missing_source))
+}
+
+fn new_job_manager_with_fs(
+    name: &str,
+) -> CommonResult<(Arc<JobManager>, Arc<Runtime>, String, MasterFilesystem)> {
     Master::init_test_metrics();
     let test_name = format!("{}-{}", name, Utils::rand_id());
 
@@ -49,6 +57,7 @@ fn new_job_manager(name: &str) -> CommonResult<(Arc<JobManager>, Arc<Runtime>, S
     let journal_system = JournalSystem::from_conf(&conf)?;
     let master_fs = MasterFilesystem::with_js(&conf, &journal_system);
     master_fs.add_test_worker(WorkerInfo::default());
+    let master_fs_ref = master_fs.clone();
 
     let mount_manager = journal_system.mount_manager();
     let rt = Arc::new(AsyncRuntime::single());
@@ -63,7 +72,12 @@ fn new_job_manager(name: &str) -> CommonResult<(Arc<JobManager>, Arc<Runtime>, S
     let ufs_root = format!("file://{}", ufs_root_dir);
     mount_manager.mount(None, "/mnt", &ufs_root, &MountOptions::builder().build())?;
 
-    Ok((job_manager, rt, format!("{}/missing-file", ufs_root)))
+    Ok((
+        job_manager,
+        rt,
+        format!("{}/missing-file", ufs_root),
+        master_fs_ref,
+    ))
 }
 
 fn load_task(task_id: &str, job_id: &str) -> LoadTaskInfo {
@@ -125,6 +139,89 @@ fn submit_load_job_returns_before_ufs_planning() -> CommonResult<()> {
             "load job did not fail in background, state={:?}, message={}",
             status.state, status.progress.message
         );
+    })
+}
+
+#[test]
+fn fs_mode_cv_path_load_uses_ufs_source_when_metadata_is_ufs_only() -> CommonResult<()> {
+    let (job_manager, rt, missing_source, master_fs) =
+        new_job_manager_with_fs("fs-cv-load-ufs-only")?;
+    let source = missing_source.replace("/missing-file", "/ufs-only-file");
+    let local_source = source
+        .strip_prefix("file://")
+        .expect("test UFS path uses file scheme");
+    if let Some(parent) = std::path::Path::new(local_source).parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(local_source, b"load-data")?;
+
+    let cv_path = "/mnt/ufs-only-file";
+    let source_path = curvine_common::fs::Path::from_str(&source)?;
+    let (_, mount) = job_manager
+        .get_mnt(&source_path)?
+        .expect("test source should match mount");
+    let sync_opts = mount.info.get_sync_opts(&ClientConf::default(), 1, 9);
+    master_fs.create_with_opts(cv_path, sync_opts, OpenFlags::new_create())?;
+    let expected_job_id = CommonUtils::create_job_id(&source);
+
+    rt.block_on(async {
+        let result = job_manager
+            .submit_load_job(LoadJobCommand::builder(cv_path).build())
+            .await?;
+
+        assert_eq!(result.job_id, expected_job_id);
+        assert_eq!(result.target_path, cv_path);
+
+        let status = job_manager.get_job_status(&result.job_id)?;
+        assert_eq!(status.source_path, source);
+        assert_eq!(status.target_path, cv_path);
+        Ok(())
+    })
+}
+
+#[test]
+fn direct_export_task_keeps_cv_source_for_fs_mode_journal_sync() -> CommonResult<()> {
+    let (job_manager, rt, _missing_source, master_fs) = new_job_manager_with_fs("direct-export")?;
+    let cv_path = "/mnt/export-file";
+    let create_opts = curvine_common::state::CreateFileOptsBuilder::new()
+        .create_parent(true)
+        .build();
+    master_fs.create_with_opts(cv_path, create_opts, OpenFlags::new_create())?;
+    let expected_target = job_manager
+        .get_mnt(&curvine_common::fs::Path::from_str(cv_path)?)?
+        .expect("test CV path should match mount")
+        .0
+        .clone_uri();
+    let (_, mount) = job_manager
+        .get_mnt(&curvine_common::fs::Path::from_str(cv_path)?)?
+        .expect("test CV path should match mount");
+
+    let command = LoadJobCommand::builder(cv_path).build();
+    let expected_job_id = CommonUtils::create_job_id(cv_path);
+    let running = JobContext::with_conf(
+        &command,
+        expected_job_id.clone(),
+        cv_path.to_string(),
+        expected_target.clone(),
+        &mount.info,
+        &ClientConf::default(),
+        1,
+    );
+    job_manager.jobs().insert(expected_job_id.clone(), running);
+
+    rt.block_on(async {
+        let result = job_manager
+            .create_runner()
+            .submit_export_task(command, mount.info.clone())
+            .await?;
+
+        assert_eq!(result.job_id, expected_job_id);
+        assert_eq!(result.target_path, expected_target);
+
+        let status = job_manager.get_job_status(&result.job_id)?;
+        assert_eq!(status.source_path, cv_path);
+        assert_eq!(status.target_path, expected_target);
+        Ok(())
     })
 }
 

--- a/curvine-server/tests/load_job_submit_test.rs
+++ b/curvine-server/tests/load_job_submit_test.rs
@@ -180,13 +180,34 @@ fn fs_mode_cv_path_load_uses_ufs_source_when_metadata_is_ufs_only() -> CommonRes
 }
 
 #[test]
-fn direct_export_task_keeps_cv_source_for_fs_mode_journal_sync() -> CommonResult<()> {
-    let (job_manager, rt, _missing_source, master_fs) = new_job_manager_with_fs("direct-export")?;
-    let cv_path = "/mnt/export-file";
+fn cv_path_load_without_ufs_only_metadata_is_rejected() -> CommonResult<()> {
+    let (job_manager, rt, _missing_source, master_fs) =
+        new_job_manager_with_fs("cv-load-rejects-export")?;
+    let cv_path = "/mnt/native-file";
     let create_opts = curvine_common::state::CreateFileOptsBuilder::new()
         .create_parent(true)
         .build();
     master_fs.create_with_opts(cv_path, create_opts, OpenFlags::new_create())?;
+
+    rt.block_on(async {
+        let err = job_manager
+            .submit_load_job(LoadJobCommand::builder(cv_path).build())
+            .await
+            .expect_err("ordinary CV load should not fall back to CV-to-UFS export");
+        assert!(
+            err.to_string().contains("requires UFS-only metadata"),
+            "unexpected error: {}",
+            err
+        );
+        Ok(())
+    })
+}
+
+#[test]
+fn direct_export_task_keeps_cv_source_for_fs_mode_journal_sync() -> CommonResult<()> {
+    let (job_manager, rt, _missing_source, master_fs) = new_job_manager_with_fs("direct-export")?;
+    let cv_path = "/mnt/export-dir";
+    master_fs.mkdir(cv_path, true)?;
     let expected_target = job_manager
         .get_mnt(&curvine_common::fs::Path::from_str(cv_path)?)?
         .expect("test CV path should match mount")
@@ -198,16 +219,6 @@ fn direct_export_task_keeps_cv_source_for_fs_mode_journal_sync() -> CommonResult
 
     let command = LoadJobCommand::builder(cv_path).build();
     let expected_job_id = CommonUtils::create_job_id(cv_path);
-    let running = JobContext::with_conf(
-        &command,
-        expected_job_id.clone(),
-        cv_path.to_string(),
-        expected_target.clone(),
-        &mount.info,
-        &ClientConf::default(),
-        1,
-    );
-    job_manager.jobs().insert(expected_job_id.clone(), running);
 
     rt.block_on(async {
         let result = job_manager
@@ -217,10 +228,7 @@ fn direct_export_task_keeps_cv_source_for_fs_mode_journal_sync() -> CommonResult
 
         assert_eq!(result.job_id, expected_job_id);
         assert_eq!(result.target_path, expected_target);
-
-        let status = job_manager.get_job_status(&result.job_id)?;
-        assert_eq!(status.source_path, cv_path);
-        assert_eq!(status.target_path, expected_target);
+        assert_eq!(result.state, JobTaskState::Completed);
         Ok(())
     })
 }


### PR DESCRIPTION
# Summary

Separate client load/import path resolution from fs_mode journal export path resolution.

# Issue Describe / Design

Root cause: `LoadJobRunner` used one `build_job_context` path toggle for both user load requests and fs_mode journal replay. That is wrong for CV paths whose metadata is `ufs_only`: a user load for that CV path should read the mounted UFS source and populate Curvine, while journal replay must export committed Curvine data back to UFS.

Reproduction steps: create a mounted CV path with UFS-only metadata, then submit a load command using the CV path. Before this fix, the job id and source path are derived from the CV path and the runner treats the operation like a CV-to-UFS export. After this fix, the job id/source are derived from the mounted UFS path and the target stays the CV path. A separate export regression covers journal replay semantics.

Fix approach: make the direction explicit with two modes: `LoadUfsOnlyFromUfs` for normal load/import and `ExportCurvineToUfs` for fs_mode journal replay. `UfsLoader` now calls `submit_export_task` so replay is not affected by the load/import UFS-only fallback.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-server/src/master/job/job_runner.rs` | Add explicit load/export CV source modes and `submit_export_task` | CV UFS-only load uses UFS source; journal export remains CV source |
| `curvine-server/src/master/journal/ufs_loader.rs` | Call `submit_export_task` for fs_mode replay | Preserves durable CV-to-UFS replay semantics |
| `curvine-server/tests/load_job_submit_test.rs` | Add regression tests for UFS-only load and journal export direction | Test-only |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo fmt --check` | PASS | |
| `cargo test -p curvine-server --test load_job_submit_test fs_mode_cv_path_load_uses_ufs_source_when_metadata_is_ufs_only` | PASS | |
| `cargo test -p curvine-server --test load_job_submit_test direct_export_task_keeps_cv_source_for_fs_mode_journal_sync` | PASS | |
| `cargo clippy -p curvine-server --all-targets --jobs 2 -- --deny=warnings --allow clippy::uninlined-format-args` | PASS | |
| `git diff --check` | PASS | |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None
