### PR TITLE
feat(orpc): detect ArcRwLock reentry in debug builds (#1011)

### DIFF
--- a/orpc/src/sync/lock.rs
+++ b/orpc/src/sync/lock.rs
@@ -52,7 +52,7 @@ mod reentry_guard {
     }
 
     pub(super) fn unmark_held(id: u64) {
-        HELD_LOCKS.with(|held| {
+        let _ = HELD_LOCKS.try_with(|held| {
             let mut held = held.borrow_mut();
             if let Some(pos) = held.iter().rposition(|x| *x == id) {
                 held.remove(pos);

--- a/orpc/src/sync/lock.rs
+++ b/orpc/src/sync/lock.rs
@@ -12,28 +12,104 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
 use std::sync::{Arc, Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
-pub struct ArcRwLock<T>(Arc<RwLock<T>>);
+// The reentrancy guard only exists in debug builds. `std::sync::RwLock` is
+// writer-preferring on Linux: once a writer is queued, a new `read()` blocks.
+// A thread that already holds a read guard and re-acquires the same lock can
+// deadlock. Release builds pay zero cost; debug/test builds panic loudly at the
+// reentrant acquisition instead of silently wedging the whole lock.
+#[cfg(debug_assertions)]
+mod reentry_guard {
+    use std::cell::RefCell;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static LOCK_ID_SEQ: AtomicU64 = AtomicU64::new(1);
+
+    thread_local! {
+        static HELD_LOCKS: RefCell<Vec<u64>> = const { RefCell::new(Vec::new()) };
+    }
+
+    pub(super) fn next_id() -> u64 {
+        LOCK_ID_SEQ.fetch_add(1, Ordering::Relaxed)
+    }
+
+    pub(super) fn assert_not_reentrant(id: u64, kind: &str) {
+        HELD_LOCKS.with(|held| {
+            if held.borrow().contains(&id) {
+                panic!(
+                    "ArcRwLock reentrant {kind} on lock {id}: current thread already holds a \
+                     guard. std::sync::RwLock is writer-preferring, so a reentrant acquire can \
+                     deadlock when a writer is queued. Resolve the path/data before re-locking."
+                );
+            }
+        });
+    }
+
+    pub(super) fn mark_held(id: u64) {
+        HELD_LOCKS.with(|held| held.borrow_mut().push(id));
+    }
+
+    pub(super) fn unmark_held(id: u64) {
+        HELD_LOCKS.with(|held| {
+            let mut held = held.borrow_mut();
+            if let Some(pos) = held.iter().rposition(|x| *x == id) {
+                held.remove(pos);
+            }
+        });
+    }
+}
+
+pub struct ArcRwLock<T> {
+    inner: Arc<RwLock<T>>,
+    #[cfg(debug_assertions)]
+    id: u64,
+}
 
 impl<T> ArcRwLock<T> {
     pub fn new(s: T) -> Self {
-        Self(Arc::new(RwLock::new(s)))
+        Self {
+            inner: Arc::new(RwLock::new(s)),
+            #[cfg(debug_assertions)]
+            id: reentry_guard::next_id(),
+        }
     }
 
-    pub fn read(&self) -> RwLockReadGuard<'_, T> {
-        self.0.read().unwrap()
+    pub fn read(&self) -> ArcRwLockReadGuard<'_, T> {
+        #[cfg(debug_assertions)]
+        reentry_guard::assert_not_reentrant(self.id, "read");
+        let guard = self.inner.read().unwrap();
+        #[cfg(debug_assertions)]
+        reentry_guard::mark_held(self.id);
+        ArcRwLockReadGuard {
+            guard,
+            #[cfg(debug_assertions)]
+            id: self.id,
+        }
     }
 
-    pub fn write(&self) -> RwLockWriteGuard<'_, T> {
-        self.0.write().unwrap()
+    pub fn write(&self) -> ArcRwLockWriteGuard<'_, T> {
+        #[cfg(debug_assertions)]
+        reentry_guard::assert_not_reentrant(self.id, "write");
+        let guard = self.inner.write().unwrap();
+        #[cfg(debug_assertions)]
+        reentry_guard::mark_held(self.id);
+        ArcRwLockWriteGuard {
+            guard,
+            #[cfg(debug_assertions)]
+            id: self.id,
+        }
     }
 }
 
 impl<T> Clone for ArcRwLock<T> {
     fn clone(&self) -> Self {
-        Self(self.0.clone())
+        Self {
+            inner: self.inner.clone(),
+            #[cfg(debug_assertions)]
+            id: self.id,
+        }
     }
 }
 
@@ -41,7 +117,55 @@ impl<T> Deref for ArcRwLock<T> {
     type Target = RwLock<T>;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        &self.inner
+    }
+}
+
+pub struct ArcRwLockReadGuard<'a, T> {
+    guard: RwLockReadGuard<'a, T>,
+    #[cfg(debug_assertions)]
+    id: u64,
+}
+
+impl<T> Deref for ArcRwLockReadGuard<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.guard
+    }
+}
+
+impl<T> Drop for ArcRwLockReadGuard<'_, T> {
+    fn drop(&mut self) {
+        #[cfg(debug_assertions)]
+        reentry_guard::unmark_held(self.id);
+    }
+}
+
+pub struct ArcRwLockWriteGuard<'a, T> {
+    guard: RwLockWriteGuard<'a, T>,
+    #[cfg(debug_assertions)]
+    id: u64,
+}
+
+impl<T> Deref for ArcRwLockWriteGuard<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.guard
+    }
+}
+
+impl<T> DerefMut for ArcRwLockWriteGuard<'_, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.guard
+    }
+}
+
+impl<T> Drop for ArcRwLockWriteGuard<'_, T> {
+    fn drop(&mut self) {
+        #[cfg(debug_assertions)]
+        reentry_guard::unmark_held(self.id);
     }
 }
 

--- a/orpc/tests/arc_rw_lock_test.rs
+++ b/orpc/tests/arc_rw_lock_test.rs
@@ -1,0 +1,49 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use orpc::sync::ArcRwLock;
+
+#[test]
+#[should_panic(expected = "ArcRwLock reentrant read")]
+fn arc_rw_lock_reentrant_read_panics_in_debug_builds() {
+    let lock = ArcRwLock::new(1);
+    let _read_guard = lock.read();
+
+    let _reentrant = lock.read();
+}
+
+#[test]
+#[should_panic(expected = "ArcRwLock reentrant read")]
+fn arc_rw_lock_read_while_holding_write_panics_in_debug_builds() {
+    let lock = ArcRwLock::new(1);
+    let _write_guard = lock.write();
+
+    let _reentrant = lock.read();
+}
+
+#[test]
+fn arc_rw_lock_can_reacquire_after_guard_drop() {
+    let lock = ArcRwLock::new(1);
+    {
+        let read_guard = lock.read();
+        assert_eq!(*read_guard, 1);
+    }
+
+    let mut write_guard = lock.write();
+    *write_guard = 2;
+    drop(write_guard);
+
+    let read_guard = lock.read();
+    assert_eq!(*read_guard, 2);
+}


### PR DESCRIPTION
# Summary

Add debug-build reentrant-acquire detection for `ArcRwLock`.

# Issue Describe / Design

Related to #1011.

Root cause: `std::sync::RwLock` can deadlock when a thread that already holds a guard re-acquires the same lock after a writer is queued. This is exactly the kind of mistake that can turn the master metadata lock into a silent control-plane stall during tests or debug builds.

Fix approach: assign each `ArcRwLock` a debug-only id and track currently held lock ids in thread-local state. `read()` and `write()` panic in debug/test builds if the current thread already holds a guard for the same lock. Release builds do not maintain this state. The wrapper guards implement `Deref`/`DerefMut`, and `curvine-server` clippy verifies existing master call sites still compile.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `orpc/src/sync/lock.rs` | Add debug-only reentry tracking and wrapper guards for `ArcRwLock` | Release behavior unchanged; debug/test builds fail fast on same-thread reentry |
| `orpc/tests/arc_rw_lock_test.rs` | Add reentry and reacquire-after-drop coverage | Test-only |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo fmt --check` | PASS | |
| `cargo test -p orpc --test arc_rw_lock_test` | PASS | |
| `cargo clippy -p orpc --all-targets --jobs 2 -- --deny=warnings --allow clippy::uninlined-format-args` | PASS | |
| `cargo clippy -p curvine-server --all-targets --jobs 2 -- --deny=warnings --allow clippy::uninlined-format-args` | PASS | verifies master callers compile with wrapper guards |
| `git diff --check` | PASS | |

# Dependencies

- Related PRs: None
- Related issues: #1011
- Blocks / blocked by: None
