### PR TITLE
fix(master): fail queued load jobs fast when source is missing

### DIFF
--- a/curvine-server/src/master/job/job_runner.rs
+++ b/curvine-server/src/master/job/job_runner.rs
@@ -56,6 +56,7 @@ struct PlannedLoadJob {
 
 impl LoadJobRunner {
     const RUN_ID_SEQ_MOD: u64 = 1_000_000;
+    const SOURCE_NOT_FOUND_PREFIX: &'static str = "source file not found";
 
     pub fn new(
         jobs: JobStore,
@@ -154,6 +155,34 @@ impl LoadJobRunner {
         // Target looks valid locally; confirm against UFS source before skipping.
         let source_status = mnt.ufs.get_status(source_path).await?;
         Ok(cv_status.cv_valid(Some(&source_status)))
+    }
+
+    async fn check_source_root_exists(&self, source_path: &Path, mnt: &MountValue) -> FsResult<()> {
+        if source_path.is_cv() {
+            self.master_fs.file_status(source_path.path())?;
+        } else {
+            mnt.ufs.get_status(source_path).await?;
+        }
+        Ok(())
+    }
+
+    fn fail_source_not_found(
+        &self,
+        queued: &QueuedLoadJob,
+        source_path: &Path,
+        err: impl std::fmt::Display,
+    ) -> bool {
+        self.jobs.update_state_if_run(
+            &queued.job_id,
+            queued.run_id,
+            JobTaskState::Failed,
+            format!(
+                "{}: {} ({})",
+                Self::SOURCE_NOT_FOUND_PREFIX,
+                source_path.full_path(),
+                err
+            ),
+        )
     }
 
     pub(crate) fn enqueue_load_job(
@@ -351,6 +380,26 @@ impl LoadJobRunner {
                 return Err(err);
             }
         };
+
+        match self
+            .check_source_root_exists(&source_path, &mnt_value)
+            .await
+        {
+            Ok(()) => {}
+            Err(FsError::FileNotFound(err)) => {
+                self.fail_source_not_found(&queued, &source_path, err);
+                return Ok(());
+            }
+            Err(err) => {
+                self.jobs.update_state_if_run(
+                    &queued.job_id,
+                    queued.run_id,
+                    JobTaskState::Failed,
+                    format!("check source file failed: {}", err),
+                );
+                return Err(err);
+            }
+        }
 
         let already_loaded = match self
             .check_already_loaded(&mnt_value, &source_path, &target_path)

--- a/curvine-server/tests/load_job_submit_test.rs
+++ b/curvine-server/tests/load_job_submit_test.rs
@@ -107,8 +107,9 @@ fn submit_load_job_returns_before_ufs_planning() -> CommonResult<()> {
             let status = job_manager.get_job_status(&result.job_id)?;
             if status.state == JobTaskState::Failed {
                 assert!(
-                    !status.progress.message.is_empty(),
-                    "failed job should keep a diagnostic message"
+                    status.progress.message.contains("source file not found"),
+                    "failed job should keep a source-not-found diagnostic: {}",
+                    status.progress.message
                 );
                 assert!(
                     status.progress.update_time > 0,


### PR DESCRIPTION
# Summary

Fail queued load jobs immediately when the source path is missing.

# Issue Describe / Design

Root cause: for missing UFS/CV sources, the queued load path could continue into cache validation and recursive planning before discovering the same `FileNotFound`. Under a load-job storm, these deterministic invalid jobs still consume the load-job execution path longer than necessary.

Reproduction steps: submit a load job for a mounted file path that does not exist. The job returns `Pending` first, then should quickly become `Failed` with a source-not-found diagnostic. This PR makes that failure happen before cache checks, directory traversal, task planning, or worker dispatch.

Fix approach: add a source-root existence check at the start of `run_queued_load_job`. `FileNotFound` is converted into a failed job state with a stable `source file not found` message and returns `Ok(())` so the background worker consumes the invalid job without noisy retry semantics. Non-FileNotFound source check errors still fail the job and return the error.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-server/src/master/job/job_runner.rs` | Check queued load source before cache validation/planning | Missing sources fail faster; valid source and empty-directory load semantics are unchanged |
| `curvine-server/tests/load_job_submit_test.rs` | Assert source-not-found diagnostic for missing source | Test-only |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo fmt --check` | PASS | |
| `cargo test -p curvine-server --test load_job_submit_test submit_load_job_returns_before_ufs_planning` | PASS | |
| `cargo test -p curvine-server --test load_job_submit_test empty_directory_load_completes_without_worker_reports` | PASS | verifies directories are not treated as missing files |
| `cargo clippy -p curvine-server --all-targets --jobs 2 -- --deny=warnings --allow clippy::uninlined-format-args` | PASS | |
| `git diff --check` | PASS | |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None
