### PR TITLE
fix(master): shorten heartbeat worker lock scope (#1011)

### DIFF
--- a/curvine-server/src/master/fs/heartbeat_checker.rs
+++ b/curvine-server/src/master/fs/heartbeat_checker.rs
@@ -64,6 +64,8 @@ impl LoopTask for HeartbeatChecker {
             return Ok(());
         }
 
+        let mut blacklisted_workers = Vec::new();
+        let mut removed_workers = Vec::new();
         {
             let mut wm = self.fs.worker_manager.write();
             let workers = wm.get_last_heartbeat();
@@ -72,42 +74,52 @@ impl LoopTask for HeartbeatChecker {
             for (id, last_update) in workers {
                 if now > last_update + self.worker_blacklist_ms {
                     // Worker blacklist timeout
-                    let worker = wm.add_blacklist_worker(id);
-                    warn!(
-                        "Worker {:?} has no heartbeat for more than {} ms and will be blacklisted",
-                        worker, self.worker_blacklist_ms
-                    );
+                    if let Some(worker) = wm.add_blacklist_worker(id) {
+                        blacklisted_workers.push((id, worker.address, worker.last_update));
+                    }
                 }
 
                 if now > last_update + self.worker_lost_ms {
                     // Heartbeat timeout
-                    let removed = wm.remove_expired_worker(id);
-                    warn!(
-                        "Worker {:?} has no heartbeat for more than {} ms and will be removed",
-                        removed, self.worker_lost_ms
-                    );
-                    // Asynchronously delete all block location data.
-                    let fs = self.fs.clone();
-                    let rm = self.replication_manager.clone();
-                    let res = self.executor.spawn(move || {
-                        let spend = TimeSpent::new();
-                        let block_ids = try_log!(fs.delete_locations(id), vec![]);
-                        let block_num = block_ids.len();
-                        if let Err(e) = rm.report_under_replicated_blocks(id, block_ids) {
-                            error!(
-                                "Errors on reporting under-replicated {} blocks. err: {:?}",
-                                block_num, e
-                            );
-                        }
-                        info!(
-                            "Delete worker {} all locations used {} ms",
-                            id,
-                            spend.used_ms()
-                        );
-                    });
-                    let _ = try_log!(res);
+                    if let Some(worker) = wm.remove_expired_worker(id) {
+                        removed_workers.push((id, worker.address, worker.last_update));
+                    }
                 }
             }
+        }
+
+        for (id, address, last_update) in blacklisted_workers {
+            warn!(
+                "Worker {} ({}) last heartbeat {} has exceeded blacklist timeout {} ms",
+                id, address, last_update, self.worker_blacklist_ms
+            );
+        }
+
+        for (id, address, last_update) in removed_workers {
+            warn!(
+                "Worker {} ({}) last heartbeat {} has exceeded lost timeout {} ms and will be removed",
+                id, address, last_update, self.worker_lost_ms
+            );
+            // Asynchronously delete all block location data.
+            let fs = self.fs.clone();
+            let rm = self.replication_manager.clone();
+            let res = self.executor.spawn(move || {
+                let spend = TimeSpent::new();
+                let block_ids = try_log!(fs.delete_locations(id), vec![]);
+                let block_num = block_ids.len();
+                if let Err(e) = rm.report_under_replicated_blocks(id, block_ids) {
+                    error!(
+                        "Errors on reporting under-replicated {} blocks. err: {:?}",
+                        block_num, e
+                    );
+                }
+                info!(
+                    "Delete worker {} all locations used {} ms",
+                    id,
+                    spend.used_ms()
+                );
+            });
+            let _ = try_log!(res);
         }
 
         if let Ok(info) = self.fs.master_info() {

--- a/curvine-server/src/master/fs/worker_manager.rs
+++ b/curvine-server/src/master/fs/worker_manager.rs
@@ -135,12 +135,12 @@ impl WorkerManager {
 
     pub fn add_blacklist_worker(&mut self, id: u32) -> Option<WorkerInfo> {
         match self.worker_map.workers.get_mut(&id) {
-            Some(v) => {
+            Some(v) if v.status != WorkerStatus::Blacklist => {
                 v.status = WorkerStatus::Blacklist;
                 Some(v.clone())
             }
 
-            None => None,
+            _ => None,
         }
     }
 

--- a/curvine-server/tests/worker_manager_test.rs
+++ b/curvine-server/tests/worker_manager_test.rs
@@ -1,0 +1,38 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use curvine_common::conf::ClusterConf;
+use curvine_common::state::{WorkerInfo, WorkerStatus};
+use curvine_server::master::fs::WorkerManager;
+
+#[test]
+fn add_blacklist_worker_is_idempotent() {
+    let conf = ClusterConf::default();
+    let mut manager = WorkerManager::new(&conf).unwrap();
+    let worker = WorkerInfo::default();
+    let worker_id = worker.worker_id();
+    manager.add_test_worker(worker);
+
+    let first = manager.add_blacklist_worker(worker_id);
+    assert!(matches!(
+        first.as_ref().map(|worker| worker.status),
+        Some(WorkerStatus::Blacklist)
+    ));
+
+    let second = manager.add_blacklist_worker(worker_id);
+    assert!(
+        second.is_none(),
+        "blacklisting the same worker twice should not report a new transition"
+    );
+}


### PR DESCRIPTION
# Summary

Shortens the master heartbeat checker's `worker_manager.write()` critical section. Worker blacklist/remove transitions are collected under the lock, while logging and asynchronous `delete_locations` scheduling are done after the lock is released.

# Issue Describe / Design

Related to #1011.

Root cause:
- `HeartbeatChecker::run` held the worker manager write lock while formatting warnings and submitting follow-up executor work for lost workers.
- If executor submission blocks or logging slows down, the write lock can unnecessarily delay worker registration, heartbeat processing, and worker selection paths.
- Repeated blacklist checks also returned the already-blacklisted worker, causing duplicate transition handling/logging.

Fix approach:
- Keep only the state transition (`add_blacklist_worker` / `remove_expired_worker`) inside the worker manager write lock.
- Move warning logs and `delete_locations` task submission outside the lock.
- Make `add_blacklist_worker` return `None` when the worker is already blacklisted, so callers only handle real state transitions.
- Add an integration test for blacklist idempotence in `curvine-server/tests`.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-server/src/master/fs/heartbeat_checker.rs` | Collects blacklisted/removed workers under lock and handles logs/delete-location scheduling after unlock. | Same worker lifecycle semantics; shorter write-lock hold time. |
| `curvine-server/src/master/fs/worker_manager.rs` | Makes blacklist transition idempotent. | Avoids duplicate blacklist transition handling for already-blacklisted workers. |
| `curvine-server/tests/worker_manager_test.rs` | Adds blacklist idempotence regression test. | Test-only. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo fmt --check` | PASS | |
| `git diff --check` | PASS | |
| `CARGO_TARGET_DIR=/tmp/curvine-heartbeat-checker-target cargo test -p curvine-server --test worker_manager_test add_blacklist_worker_is_idempotent -- --test-threads=1` | PASS | |
| `CARGO_TARGET_DIR=/tmp/curvine-heartbeat-checker-target cargo clippy -p curvine-server --all-targets --jobs 2 -- --deny=warnings --allow clippy::uninlined-format-args` | PASS | |

# Dependencies

- Related PRs: None
- Related issues: #1011
- Blocks / blocked by: None