### PR TITLE
fix(worker): submit incremental block reports asynchronously (#1011)

### DIFF
--- a/curvine-server/src/worker/block/block_actor.rs
+++ b/curvine-server/src/worker/block/block_actor.rs
@@ -23,6 +23,7 @@ use orpc::common::TimeSpent;
 use orpc::runtime::{GroupExecutor, Runtime};
 use orpc::sync::StateCtl;
 use orpc::CommonResult;
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 /// Worker block management role.
@@ -147,6 +148,7 @@ impl BlockActor {
             client,
             store,
             report_blocks,
+            report_in_flight: Arc::new(AtomicBool::new(false)),
         };
 
         scheduler.start(task)?;

--- a/curvine-server/src/worker/block/heartbeat_task.rs
+++ b/curvine-server/src/worker/block/heartbeat_task.rs
@@ -24,7 +24,8 @@ use orpc::runtime::{GroupExecutor, LoopTask};
 use orpc::server::ServerState;
 use orpc::sync::StateCtl;
 use orpc::try_log;
-use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 
 pub struct HeartbeatTask {
     pub(crate) executor: Arc<GroupExecutor>,
@@ -32,6 +33,7 @@ pub struct HeartbeatTask {
     pub(crate) client: MasterClient,
     pub(crate) store: BlockStore,
     pub(crate) report_blocks: Arc<DashMap<i64, BlockReportInfo>>,
+    pub(crate) report_in_flight: Arc<AtomicBool>,
 }
 
 impl HeartbeatTask {
@@ -96,8 +98,51 @@ impl HeartbeatTask {
     }
 
     pub fn put_missing_report(&self, blocks: Vec<BlockReportInfo>) {
+        Self::put_report_blocks(self.report_blocks.clone(), blocks);
+    }
+
+    fn put_report_blocks(
+        report_blocks: Arc<DashMap<i64, BlockReportInfo>>,
+        blocks: Vec<BlockReportInfo>,
+    ) {
         for block in blocks {
-            self.report_blocks.insert(block.id, block);
+            report_blocks.insert(block.id, block);
+        }
+    }
+
+    fn submit_block_report(&self, report_blocks: Vec<BlockReportInfo>) {
+        if self.report_in_flight.swap(true, Ordering::AcqRel) {
+            self.put_missing_report(report_blocks);
+            return;
+        }
+
+        let client = self.client.clone();
+        let pending_reports = self.report_blocks.clone();
+        let report_in_flight = self.report_in_flight.clone();
+        let task_reports = Arc::new(Mutex::new(Some(report_blocks)));
+        let task_reports_for_task = task_reports.clone();
+        let res = self.executor.spawn(move || {
+            let reports = task_reports_for_task
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .take()
+                .unwrap_or_default();
+            if let Err(e) = client.incr_block_report(&reports) {
+                error!("report blocks {}", e);
+                Self::put_report_blocks(pending_reports, reports);
+            }
+            report_in_flight.store(false, Ordering::Release);
+        });
+
+        if let Err(e) = res {
+            error!("submit block report task failed {}", e);
+            let reports = task_reports
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .take()
+                .unwrap_or_default();
+            self.put_missing_report(reports);
+            self.report_in_flight.store(false, Ordering::Release);
         }
     }
 }
@@ -139,17 +184,7 @@ impl LoopTask for HeartbeatTask {
             return Ok(());
         }
 
-        let res = self.client.incr_block_report(&report_blocks);
-        match res {
-            Ok(_cmds) => {
-                // @todo handles cmds returned by master.
-            }
-
-            Err(e) => {
-                error!("report blocks {}", e);
-                self.put_missing_report(report_blocks)
-            }
-        }
+        self.submit_block_report(report_blocks);
 
         Ok(())
     }


### PR DESCRIPTION
# Summary

This PR moves worker incremental block report RPCs out of the heartbeat loop. A worker keeps at most one incremental block report in flight; new report entries are put back into the pending map and retried by the next heartbeat.

# Issue Describe / Design

Related to #1011.

- Root cause: `HeartbeatTask::run` sent `client.incr_block_report` synchronously after heartbeat. When the master was slow or overloaded, the worker heartbeat loop could block on block report RPC latency instead of continuing its regular heartbeat cadence.
- Fix approach: submit incremental block reports to the existing worker executor and guard them with `report_in_flight`. Failed executor submission or failed master RPC requeues the report entries into `report_blocks`.
- Trade-off: this PR intentionally does not depend on #1019, so it uses the existing `executor.spawn` API. That keeps the PR independent from the ORPC `try_spawn` PR, but queue-full backpressure can still block briefly while enqueueing.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-server/src/worker/block/heartbeat_task.rs` | Add single in-flight async submission for incremental block reports and requeue on failure. | Heartbeat no longer waits for incremental block report RPC completion. |
| `curvine-server/src/worker/block/block_actor.rs` | Initialize the per-heartbeat-task in-flight guard. | No behavior change outside worker block report scheduling. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo fmt --check` | PASS | |
| `cargo clippy -p curvine-server --all-targets --jobs 2 -- --deny=warnings --allow clippy::uninlined-format-args` | PASS | No issues found. |
| `git diff --check` | PASS | |

# Dependencies

- Related PRs: #1005, #1029
- Related issues: #1011
- Blocks / blocked by: None