### PR TITLE
fix(master): reconcile full block reports asynchronously (#1011)

### DIFF
--- a/curvine-server/src/master/fs/master_filesystem.rs
+++ b/curvine-server/src/master/fs/master_filesystem.rs
@@ -20,13 +20,15 @@ use crate::master::meta::FsDir;
 
 use crate::master::fs::DeleteResult;
 use crate::master::meta::parse_glob_pattern;
+use crate::master::replication::master_replication_handler::MasterReplicationHandler;
 use crate::master::{Master, MasterMonitor, SyncFsDir, SyncWorkerManager};
 use curvine_common::conf::{ClusterConf, MasterConf};
 use curvine_common::error::FsError;
 use curvine_common::state::*;
 use curvine_common::FsResult;
-use log::warn;
+use log::{error, info, warn};
 use orpc::common::LocalTime;
+use orpc::runtime::GroupExecutor;
 use orpc::sync::ArcRwLock;
 use orpc::{err_box, err_ext, try_option, CommonResult};
 use parking_lot::Mutex;
@@ -40,6 +42,8 @@ pub struct MasterFilesystem {
     pub master_monitor: MasterMonitor,
     pub conf: Arc<MasterConf>,
     full_block_reports: Arc<Mutex<HashMap<u32, FullBlockReportState>>>,
+    full_block_reconciles: Arc<Mutex<HashMap<u32, FullBlockReconcileState>>>,
+    full_block_reconcile_executor: Arc<GroupExecutor>,
 }
 
 struct FullBlockReportState {
@@ -48,9 +52,25 @@ struct FullBlockReportState {
     reported_blocks: HashSet<i64>,
 }
 
+struct FullBlockReconcileState {
+    running: bool,
+    generation: u64,
+    pending: Option<FullBlockReconcileJob>,
+}
+
+struct FullBlockReconcileJob {
+    generation: u64,
+    reported_blocks: HashSet<i64>,
+}
+
 const FULL_BLOCK_REPORT_TTL_MS: u64 = 60 * 60 * 1000;
+const FULL_BLOCK_RECONCILE_THREADS: usize = 2;
+const FULL_BLOCK_RECONCILE_QUEUE_SIZE: usize = 128;
 
 impl MasterFilesystem {
+    // Max block-report location updates applied under a single fs_dir write lock.
+    const BLOCK_REPORT_WRITE_CHUNK: usize = 4096;
+
     pub fn new(
         conf: &ClusterConf,
         fs_dir: SyncFsDir,
@@ -63,6 +83,12 @@ impl MasterFilesystem {
             master_monitor,
             conf: Arc::new(conf.master.clone()),
             full_block_reports: Default::default(),
+            full_block_reconciles: Default::default(),
+            full_block_reconcile_executor: Arc::new(GroupExecutor::new(
+                "master-full-block-reconcile",
+                FULL_BLOCK_RECONCILE_THREADS,
+                FULL_BLOCK_RECONCILE_QUEUE_SIZE,
+            )),
         }
     }
 
@@ -73,6 +99,12 @@ impl MasterFilesystem {
             master_monitor: js.master_monitor(),
             conf: Arc::new(conf.master.clone()),
             full_block_reports: Default::default(),
+            full_block_reconciles: Default::default(),
+            full_block_reconcile_executor: Arc::new(GroupExecutor::new(
+                "master-full-block-reconcile",
+                FULL_BLOCK_RECONCILE_THREADS,
+                FULL_BLOCK_RECONCILE_QUEUE_SIZE,
+            )),
         }
     }
 
@@ -769,11 +801,38 @@ impl MasterFilesystem {
 
     pub fn reset_full_block_report(&self, worker_id: u32) {
         self.full_block_reports.lock().remove(&worker_id);
+        self.invalidate_full_block_reconcile(worker_id);
+    }
+
+    fn invalidate_full_block_reconcile(&self, worker_id: u32) {
+        let mut reconciles = self.full_block_reconciles.lock();
+        if let Some(state) = reconciles.get_mut(&worker_id) {
+            state.generation = state.generation.saturating_add(1);
+            state.pending = None;
+            if !state.running {
+                reconciles.remove(&worker_id);
+            }
+        }
     }
 
     /// Process block reports
-    pub fn block_report(&self, list: BlockReportList) -> FsResult<Vec<i64>> {
+    pub fn block_report(
+        &self,
+        list: BlockReportList,
+        replication_handler: Option<MasterReplicationHandler>,
+    ) -> FsResult<Vec<i64>> {
         // @todo check cluster.
+        let invalidate_full_reconcile = !list.full_report
+            && list.blocks.iter().any(|block| {
+                matches!(
+                    block.status,
+                    BlockReportStatus::Finalized | BlockReportStatus::Writing
+                )
+            });
+        if invalidate_full_reconcile {
+            self.invalidate_full_block_reconcile(list.worker_id);
+        }
+
         let full_reported_blocks = self.collect_full_block_report(&list);
         if list.blocks.is_empty() && full_reported_blocks.is_none() {
             return Ok(Vec::new());
@@ -828,29 +887,180 @@ impl MasterFilesystem {
         }
         drop(wm);
 
-        let mut stale_block_ids = Vec::new();
-        let mut fs_dir = self.fs_dir.write();
         if let Some(reported_blocks) = full_reported_blocks {
-            let existing_blocks = fs_dir.get_worker_block_ids(list.worker_id)?;
-            for block_id in existing_blocks {
-                if !reported_blocks.contains(&block_id) {
-                    batch.push((false, block_id, BlockLocation::with_id(list.worker_id)));
-                    stale_block_ids.push(block_id);
+            self.submit_full_block_reconcile(list.worker_id, reported_blocks, replication_handler)?;
+        }
+
+        self.apply_block_report_batch(batch)?;
+        Ok(Vec::new())
+    }
+
+    fn submit_full_block_reconcile(
+        &self,
+        worker_id: u32,
+        reported_blocks: HashSet<i64>,
+        replication_handler: Option<MasterReplicationHandler>,
+    ) -> FsResult<()> {
+        let should_spawn = {
+            let mut reconciles = self.full_block_reconciles.lock();
+            let state = reconciles
+                .entry(worker_id)
+                .or_insert_with(|| FullBlockReconcileState {
+                    running: false,
+                    generation: 0,
+                    pending: None,
+                });
+            state.generation = state.generation.saturating_add(1);
+            let generation = state.generation;
+            state.pending = Some(FullBlockReconcileJob {
+                generation,
+                reported_blocks,
+            });
+            if state.running {
+                false
+            } else {
+                state.running = true;
+                true
+            }
+        };
+
+        if !should_spawn {
+            return Ok(());
+        }
+
+        let fs = self.clone();
+        let res = self
+            .full_block_reconcile_executor
+            .fixed_spawn(worker_id as i64, move || {
+                fs.run_full_block_reconcile(worker_id, replication_handler);
+            });
+        if let Err(e) = &res {
+            self.full_block_reconciles.lock().remove(&worker_id);
+            error!("submit full block report reconcile for worker {worker_id} failed: {e}");
+        }
+        res?;
+        Ok(())
+    }
+
+    fn run_full_block_reconcile(
+        &self,
+        worker_id: u32,
+        replication_handler: Option<MasterReplicationHandler>,
+    ) {
+        loop {
+            let job = {
+                let mut reconciles = self.full_block_reconciles.lock();
+                match reconciles.get_mut(&worker_id) {
+                    Some(state) => match state.pending.take() {
+                        Some(v) => v,
+                        None => {
+                            reconciles.remove(&worker_id);
+                            return;
+                        }
+                    },
+                    None => return,
+                }
+            };
+
+            if !self.is_full_block_reconcile_current(worker_id, job.generation) {
+                info!(
+                    "skip stale full block report reconcile for worker {}, generation {}",
+                    worker_id, job.generation
+                );
+                continue;
+            }
+
+            match self.reconcile_full_block_report(worker_id, job.generation, job.reported_blocks) {
+                Ok(stale_block_ids) => {
+                    let stale_block_count = stale_block_ids.len();
+                    if stale_block_count > 0 {
+                        info!(
+                            "full block report reconciled {} stale block locations for worker {}",
+                            stale_block_count, worker_id
+                        );
+                        if let Some(replication_handler) = &replication_handler {
+                            if let Err(e) = replication_handler
+                                .report_under_replicated_blocks(worker_id, stale_block_ids)
+                            {
+                                error!(
+                                    "Errors on reporting under-replicated {} blocks from full block report reconciliation. err: {:?}",
+                                    stale_block_count, e
+                                );
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    error!(
+                        "full block report reconcile for worker {} failed: {}",
+                        worker_id, e
+                    );
                 }
             }
         }
+    }
 
-        fs_dir.block_report(batch)?;
+    fn reconcile_full_block_report(
+        &self,
+        worker_id: u32,
+        generation: u64,
+        reported_blocks: HashSet<i64>,
+    ) -> FsResult<Vec<i64>> {
+        let existing_blocks = {
+            let fs_dir = self.fs_dir.read();
+            fs_dir.get_worker_block_ids(worker_id)?
+        };
 
-        if !stale_block_ids.is_empty() {
-            warn!(
-                "full block report reconciled {} stale block locations for worker {}",
-                stale_block_ids.len(),
-                list.worker_id
-            );
+        let mut stale_block_ids = Vec::new();
+        let mut batch = Vec::new();
+        for block_id in existing_blocks {
+            if !reported_blocks.contains(&block_id) {
+                batch.push((false, block_id, BlockLocation::with_id(worker_id)));
+                stale_block_ids.push(block_id);
+            }
+        }
+
+        if !batch.is_empty() {
+            if !self.is_full_block_reconcile_current(worker_id, generation) {
+                info!(
+                    "skip stale full block report reconcile apply for worker {}, generation {}",
+                    worker_id, generation
+                );
+                return Ok(Vec::new());
+            }
+            self.apply_block_report_batch(batch)?;
         }
 
         Ok(stale_block_ids)
+    }
+
+    /// Applies block-report location updates in bounded chunks so the global
+    /// fs_dir write lock is held only briefly per chunk. Each entry is an
+    /// independent add/remove for one block location, so chunk boundaries do
+    /// not break cross-entry invariants.
+    fn apply_block_report_batch(&self, batch: Vec<(bool, i64, BlockLocation)>) -> FsResult<()> {
+        if batch.is_empty() {
+            return Ok(());
+        }
+
+        let mut iter = batch.into_iter();
+        loop {
+            let chunk: Vec<_> = iter.by_ref().take(Self::BLOCK_REPORT_WRITE_CHUNK).collect();
+            if chunk.is_empty() {
+                break;
+            }
+            let mut fs_dir = self.fs_dir.write();
+            fs_dir.block_report(chunk)?;
+        }
+        Ok(())
+    }
+
+    fn is_full_block_reconcile_current(&self, worker_id: u32, generation: u64) -> bool {
+        self.full_block_reconciles
+            .lock()
+            .get(&worker_id)
+            .map(|state| state.generation == generation)
+            .unwrap_or(false)
     }
 
     pub fn delete_locations(&self, worker_id: u32) -> FsResult<Vec<i64>> {

--- a/curvine-server/src/master/master_handler.rs
+++ b/curvine-server/src/master/master_handler.rs
@@ -461,7 +461,9 @@ impl MasterHandler {
         let header: BlockReportListRequest = ctx.parse_header()?;
         let list = ProtoUtils::block_report_list_from_pb(header);
         let worker_id = list.worker_id;
-        let stale_block_ids = self.fs.block_report(list)?;
+        let stale_block_ids = self
+            .fs
+            .block_report(list, self.replication_handler.clone())?;
         let stale_block_count = stale_block_ids.len();
         if stale_block_count > 0 {
             if let Some(replication_handler) = &self.replication_handler {

--- a/curvine-server/tests/lock_order_deadlock_stress_test.rs
+++ b/curvine-server/tests/lock_order_deadlock_stress_test.rs
@@ -108,7 +108,7 @@ fn stress_add_block_vs_block_report_no_hang() {
                 )],
             };
 
-            let res = fs_b.block_report(report);
+            let res = fs_b.block_report(report, None);
             if res.is_ok() {
                 ok += 1;
             } else {
@@ -187,6 +187,6 @@ fn sanity_single_thread_paths_progress() {
                 0,
             )],
         };
-        let _ = fs.block_report(report);
+        let _ = fs.block_report(report, None);
     }
 }

--- a/curvine-server/tests/master_fs_test.rs
+++ b/curvine-server/tests/master_fs_test.rs
@@ -22,7 +22,8 @@ use curvine_common::proto::{
 use curvine_common::raft::storage::{AppStorage, ApplyMsg};
 use curvine_common::state::MountOptions;
 use curvine_common::state::{
-    BlockLocation, ClientAddress, CommitBlock, CreateFileOpts, FileAllocOpts, WorkerInfo,
+    BlockLocation, BlockReportInfo, BlockReportList, BlockReportStatus, ClientAddress, CommitBlock,
+    CreateFileOpts, FileAllocOpts, StorageType, WorkerInfo,
 };
 use curvine_common::state::{OpenFlags, RenameFlags, SetAttrOptsBuilder};
 use curvine_common::utils::SerdeUtils;
@@ -821,6 +822,94 @@ fn add_block_retry(fs: &MasterFilesystem) -> CommonResult<()> {
     assert_eq!(locs.block_locs.len(), 2);
 
     Ok(())
+}
+
+#[test]
+fn full_block_report_reconcile_removes_stale_location_async() -> CommonResult<()> {
+    let _serial = master_fs_test_serial();
+    let fs = new_fs(true, "full-block-reconcile-async");
+    let path = "/full-block-reconcile.log";
+    let addr = ClientAddress::default();
+    let status = fs.create(path, false)?;
+
+    let first = fs.add_block(path, None, addr.clone(), vec![], vec![], 0, None)?;
+    let first_commit = CommitBlock {
+        block_id: first.block.id,
+        block_len: status.block_size,
+        locations: vec![BlockLocation::with_id(100)],
+    };
+    let second = fs.add_block(
+        path,
+        None,
+        addr,
+        vec![first_commit],
+        vec![],
+        status.block_size,
+        Some(first.block.clone()),
+    )?;
+
+    fs.block_report(
+        BlockReportList {
+            cluster_id: "curvine".into(),
+            worker_id: 100,
+            full_report: false,
+            total_len: 0,
+            blocks: vec![
+                BlockReportInfo::new(
+                    first.block.id,
+                    BlockReportStatus::Finalized,
+                    StorageType::Disk,
+                    first.block.len,
+                ),
+                BlockReportInfo::new(
+                    second.block.id,
+                    BlockReportStatus::Finalized,
+                    StorageType::Disk,
+                    second.block.len,
+                ),
+            ],
+        },
+        None,
+    )?;
+
+    let before = fs.get_block_locations(path)?;
+    assert_eq!(before.block_locs.len(), 2);
+    assert!(!before.block_locs[1].locs.is_empty());
+
+    fs.block_report(
+        BlockReportList {
+            cluster_id: "curvine".into(),
+            worker_id: 100,
+            full_report: true,
+            total_len: 1,
+            blocks: vec![BlockReportInfo::new(
+                first.block.id,
+                BlockReportStatus::Finalized,
+                StorageType::Disk,
+                first.block.len,
+            )],
+        },
+        None,
+    )?;
+
+    for _ in 0..50 {
+        let blocks = fs.get_block_locations(path)?;
+        let stale = blocks
+            .block_locs
+            .iter()
+            .find(|block| block.block.id == second.block.id)
+            .expect("second block metadata should remain");
+        if stale.locs.is_empty() {
+            return Ok(());
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+
+    let blocks = fs.get_block_locations(path)?;
+    panic!(
+        "stale worker location for block {} was not reconciled: {:?}",
+        second.block.id, blocks
+    );
 }
 
 fn complete_file_retry(fs: &MasterFilesystem) -> CommonResult<()> {


### PR DESCRIPTION
# Summary

This PR moves full block report stale-location reconciliation out of the foreground `block_report` path. The master still applies the current report entries immediately, but the expensive stale-location scan and delete batch runs in a bounded background lane.

# Issue Describe / Design

Related to #1011.

- Root cause: a completed full block report made the master scan all existing block locations for that worker and apply stale-location removals while serving the block report RPC. For large workers this holds or repeatedly contends on the global `fs_dir` lock and can delay other control-plane metadata operations.
- Fix approach: keep incremental block report updates synchronous, enqueue only the completed full-report reconcile work, and keep at most the latest pending reconcile job per worker. New finalized/writing incremental reports invalidate stale full-report reconcile generations so a delayed full report cannot remove a newer worker location.
- Semantics: under-replicated reporting is preserved by moving it into the background reconcile path. The foreground RPC no longer waits for stale-location reconciliation to finish.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-server/src/master/fs/master_filesystem.rs` | Add per-worker full-report reconcile state, bounded background executor, generation invalidation, and chunked `fs_dir.block_report` apply. | Full-report stale cleanup becomes asynchronous; current report entries are still applied before RPC response. |
| `curvine-server/src/master/master_handler.rs` | Pass the replication handler into `block_report` so background reconcile can preserve under-replicated reporting. | Existing under-replicated reporting is preserved after async reconciliation. |
| `curvine-server/tests/master_fs_test.rs` | Add behavior test for async stale-location removal after full block report. | Covers visible metadata result. |
| `curvine-server/tests/lock_order_deadlock_stress_test.rs` | Update direct test calls to pass no replication handler. | Test-only API adjustment. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo fmt --check` | PASS | |
| `cargo test -p curvine-server --test master_fs_test full_block_report_reconcile_removes_stale_location_async -- --test-threads=1` | PASS | 1 passed. |
| `cargo test -p curvine-server --test lock_order_deadlock_stress_test -- --test-threads=1` | PASS | 2 passed. |
| `cargo test -p curvine-server --test master_fs_test -- --test-threads=1` | PASS | 22 passed. |
| `cargo clippy -p curvine-server --all-targets --jobs 2 -- --deny=warnings --allow clippy::uninlined-format-args` | PASS | No issues found. |
| `git diff --check` | PASS | |

# Dependencies

- Related PRs: #1005, #1019, #1024, #1029, #1030
- Related issues: #1011
- Blocks / blocked by: None