### PR TITLE
feat(fuse): remove dead config params read_dir_fill_ino/remember/node_cache_size (#1023)

### DIFF
--- a/curvine-common/src/conf/fuse_conf.rs
+++ b/curvine-common/src/conf/fuse_conf.rs
@@ -81,13 +81,6 @@ pub struct FuseConf {
 
     pub web_port: u16,
 
-    // Whether to fill the fuse node id when traversing the directory.
-    // When executing list_status, if the node id is not filled, the node id returned to the kernel is in curvine and does not exist in the node cache.
-    // file attr has cache time. During the cache time, look up will not be executed. If you access this file, an error will be reported (node ​​does not exist)
-    // Setting will be true, which is equivalent to executing a lookup for each node before returning data to the kernel, and there will be no node.
-    // The default value is true
-    pub read_dir_fill_ino: bool,
-
     // Name search cache time.
     // After performing a name search, if the same name is requested again, the kernel will check the cache first.
     // If the buffer record is still valid, the cache result will be returned directly, unlike user space for requests.
@@ -116,10 +109,6 @@ pub struct FuseConf {
     // By default, it is set to the same value as attr_timeout (i.e. 1.0 seconds).
     pub ac_attr_timeout_set: f64,
 
-    // Parameters are used to specify whether the file system should remember the opened files and directories.
-    // By default, the FUSE file system clears the cache when a file or directory is closed.
-    pub remember: bool,
-
     // The maximum number of concurrent execution of backend tasks in the file system.It directly affects the performance and stability of the file system, and is important especially when dealing with high load or asynchronous I/O scenarios.
     pub max_background: u16,
 
@@ -133,8 +122,6 @@ pub struct FuseConf {
 
     // Metadata cache TTL (time to live)
     pub meta_cache_ttl: String,
-
-    pub node_cache_size: u64,
 
     pub node_cache_timeout: String,
 
@@ -336,13 +323,11 @@ impl Default for FuseConf {
             umask: Self::UMASK,
             uid: sys::get_uid(),
             gid: sys::get_gid(),
-            read_dir_fill_ino: true,
             entry_timeout: FuseConf::TTR_TIMEOUT,
             negative_timeout: 0.0,
             attr_timeout: FuseConf::TTR_TIMEOUT,
             ac_attr_timeout: FuseConf::TTR_TIMEOUT,
             ac_attr_timeout_set: FuseConf::TTR_TIMEOUT,
-            remember: false,
             web_port: ClusterConf::DEFAULT_FUSE_WEB_PORT,
 
             max_background: 256,
@@ -352,7 +337,6 @@ impl Default for FuseConf {
             meta_cache_capacity: 100000,
             meta_cache_ttl: "120s".to_string(),
 
-            node_cache_size: 200000,
             node_cache_timeout: "1h".to_string(),
 
             direct_io: false,
@@ -451,5 +435,22 @@ io_threads = 16
             conf.fuse.max_readahead_kb,
             Some(FuseConf::DEFAULT_MAX_READAHEAD_KB)
         );
+    }
+
+    #[test]
+    fn toml_with_removed_dead_keys_loads_clean() {
+        // read_dir_fill_ino / remember / node_cache_size were removed as dead
+        // params (issue #1023 §1). FuseConf is #[serde(default)] with no
+        // deny_unknown_fields, so legacy TOML carrying these keys must still
+        // deserialize without error (the keys are silently ignored).
+        let toml = r#"
+io_threads = 16
+read_dir_fill_ino = true
+remember = false
+node_cache_size = 200000
+"#;
+        let conf: FuseConf =
+            toml::from_str(toml).expect("legacy keys must be ignored, not rejected");
+        assert_eq!(conf.io_threads, 16);
     }
 }

--- a/curvine-docker/fluid/config-parse.py
+++ b/curvine-docker/fluid/config-parse.py
@@ -61,9 +61,9 @@ exec {fuse_cmd}
         'direct-io', 'write-back-cache', 'cache-readdir', 'non-seekable',
         'entry-timeout', 'attr-timeout', 'negative-timeout', 'ac-attr-timeout',
         'max-background', 'congestion-threshold',
-        'node-cache-size', 'node-cache-timeout',
+        'node-cache-timeout',
         'enable-meta-cache', 'meta-cache-capacity', 'meta-cache-ttl',
-        'read-dir-fill-ino', 'remember', 'check-permission', 'list-limit',
+        'check-permission', 'list-limit',
         'web-port',
     ]
     

--- a/curvine-fuse/src/cli/mount_args.rs
+++ b/curvine-fuse/src/cli/mount_args.rs
@@ -94,10 +94,6 @@ pub struct FuseMountArgs {
     #[arg(long, help = "Congestion threshold (optional)")]
     pub congestion_threshold: Option<u16>,
 
-    // Node cache settings
-    #[arg(long, help = "Node cache size (optional)")]
-    pub node_cache_size: Option<u64>,
-
     #[arg(long, help = "Node cache timeout (e.g., '1h', '30m') (optional)")]
     pub node_cache_timeout: Option<String>,
 
@@ -113,9 +109,6 @@ pub struct FuseMountArgs {
     options: Vec<String>,
 
     // Additional FuseConf fields
-    #[arg(long, help = "Fill inode number when reading directory (optional)")]
-    pub read_dir_fill_ino: Option<bool>,
-
     #[arg(long, help = "Enable write-back cache (optional)")]
     pub write_back_cache: Option<bool>,
 
@@ -139,9 +132,6 @@ pub struct FuseMountArgs {
 
     #[arg(long, help = "Metadata cache TTL (e.g., '120s', '2m') (optional)")]
     pub meta_cache_ttl: Option<String>,
-
-    #[arg(long, help = "Remember opened inodes across FUSE sessions (optional)")]
-    pub remember: Option<bool>,
 
     #[arg(long, help = "Auto-cache attr timeout in seconds (optional)")]
     pub ac_attr_timeout: Option<f64>,
@@ -255,20 +245,12 @@ impl FuseMountArgs {
             conf.fuse.congestion_threshold = congestion_threshold;
         }
 
-        if let Some(node_cache_size) = self.node_cache_size {
-            conf.fuse.node_cache_size = node_cache_size;
-        }
-
         if let Some(node_cache_timeout) = &self.node_cache_timeout {
             conf.fuse.node_cache_timeout = node_cache_timeout.clone();
         }
 
         if let Some(web_port) = self.web_port {
             conf.fuse.web_port = web_port;
-        }
-
-        if let Some(read_dir_fill_ino) = self.read_dir_fill_ino {
-            conf.fuse.read_dir_fill_ino = read_dir_fill_ino;
         }
 
         if let Some(write_back_cache) = self.write_back_cache {
@@ -297,10 +279,6 @@ impl FuseMountArgs {
 
         if let Some(meta_cache_ttl) = &self.meta_cache_ttl {
             conf.fuse.meta_cache_ttl = meta_cache_ttl.clone();
-        }
-
-        if let Some(remember) = self.remember {
-            conf.fuse.remember = remember;
         }
 
         if let Some(ac_attr_timeout) = self.ac_attr_timeout {

--- a/curvine-fuse/src/fs/state/node_state.rs
+++ b/curvine-fuse/src/fs/state/node_state.rs
@@ -1426,7 +1426,6 @@ mod test {
     pub fn ttl() -> CommonResult<()> {
         let mut conf = ClusterConf {
             fuse: FuseConf {
-                node_cache_size: 2,
                 node_cache_timeout: "100ms".to_string(),
                 ..Default::default()
             },


### PR DESCRIPTION
# Summary

Removes three `FuseConf` parameters that are declared, CLI-exposed and TOML-parsed but never consumed by any business logic. This is PR-1 of the incremental `FuseConf` cleanup tracked in #1023 (§1) — the safe, non-breaking removals only.

# Issue Describe / Design

Related to #1023 (§1 "Dead parameters"). One concern per PR; the breaking renames (§2/§3) and default-value discussions (§6/§7) are intentionally out of scope here.

Removed params (verified against current code — grepped all consumers, only CLI setters wrote them):
- `read_dir_fill_ino` — only a CLI setter; no code path reads it.
- `remember` — only a CLI setter; never wired into FUSE.
- `node_cache_size` — `NodeMap.nodes` is unbounded (evicted by TTL only); the capacity was never enforced. Distinct from the *live* `meta_cache_capacity` (consumed by `MetaCache::new`), which is untouched.

Backward-compatible: `FuseConf` is `#[serde(default)]` with no `deny_unknown_fields`, so legacy TOML carrying these keys still loads (keys silently ignored). Also dropped the three flags from the Fluid `config-parse.py` forwarding whitelist so a stale Fluid config can't pass a now-unknown CLI flag to the mount command.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| \`curvine-common/src/conf/fuse_conf.rs\` | Remove 3 fields + their \`Default\` lines; add regression test for legacy-TOML load | None — removed fields had no readers |
| \`curvine-fuse/src/cli/mount_args.rs\` | Remove 3 CLI args + their apply branches | \`--read-dir-fill-ino\` / \`--remember\` / \`--node-cache-size\` flags no longer accepted |
| \`curvine-fuse/src/fs/state/node_state.rs\` | Drop \`node_cache_size: 2\` from the \`ttl\` test setup | None — test still exercises \`node_cache_timeout\` |
| \`curvine-docker/fluid/config-parse.py\` | Remove the 3 dead flags from the forwarding whitelist | Prevents unknown-flag mount failure from stale Fluid configs |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| \`cargo build -p curvine-common -p curvine-fuse\` | PASS | |
| \`cargo test -p curvine-common conf::fuse_conf\` | PASS | 7/7, incl. new \`toml_with_removed_dead_keys_loads_clean\` |
| \`cargo test -p curvine-fuse ttl\` | PASS | 1/1 |
| \`cargo clippy -p curvine-common -p curvine-fuse\` | PASS | no warnings |
| \`cargo fmt\` | PASS | |

# Dependencies

- Related PRs: None (PR-2/§2, PR-3/§3, PR-4/§5 to follow)
- Related issues: #1023
- Blocks / blocked by: None