### PR TITLE
refactor(fuse): clean up FuseConf constants and document cache layers (#1023)

### DIFF
--- a/curvine-common/src/conf/fuse_conf.rs
+++ b/curvine-common/src/conf/fuse_conf.rs
@@ -22,6 +22,34 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 // fuse configuration file.
+//
+// Caching in curvine-fuse spans three layers that are easy to conflate; the
+// boundaries are:
+//
+// 1. Kernel-side caching (the kernel caches on our behalf, controlled via the
+//    FUSE reply `entry_valid` / `attr_valid` fields):
+//    - `entry_timeout`   -> how long the kernel trusts a name->inode lookup.
+//    - `negative_timeout`-> how long the kernel caches a negative lookup (ENOENT).
+//    - `attr_timeout`    -> how long the kernel trusts cached file/dir attributes.
+//    - `ac_attr_timeout*`-> attr-cache timeout used for auto-cache refresh.
+//    These trade metadata freshness for fewer upcalls into user space.
+//
+// 2. User-side caching (maintained inside curvine-fuse itself):
+//    - `enable_meta_cache` / `meta_cache_capacity` / `meta_cache_ttl` -> the
+//      bounded metadata cache backed by `MetaCache` (capacity IS enforced).
+//    - `node_cache_timeout` -> TTL-based eviction of the inode/node map.
+//
+// 3. IO caching / data-path switches (control how file *data* is cached by the
+//    page cache, mutually interacting per open):
+//    - `direct_io`            -> bypass the page cache for all opens.
+//    - `open_direct_on_stale` -> per-open fallback to direct I/O only when the
+//      local metadata is detected stale (weaker global impact than `direct_io`).
+//    - `write_back_cache`     -> let the kernel buffer writes (write-back) vs
+//      write-through; interacts with `direct_io` (direct I/O disables it).
+//
+// Rule of thumb: layer 1 tunes how stale the *kernel* may be, layer 2 tunes the
+// process-local metadata caches, and layer 3 decides whether file *data* flows
+// through the page cache at all.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct FuseConf {
@@ -202,15 +230,16 @@ pub struct FuseConf {
 impl FuseConf {
     pub const FS_NAME: &'static str = "curvine-fuse";
 
-    pub const MAX_READ: u32 = 128 * 1024;
+    /// Default kernel dentry (name lookup) cache timeout, in seconds.
+    pub const DEFAULT_ENTRY_TIMEOUT: f64 = 1.0;
 
-    pub const MAX_WRITE: u32 = 128 * 1024;
+    /// Default kernel attribute cache timeout, in seconds. Also used as the
+    /// default for the auto-cache attr timeouts (`ac_attr_timeout*`), which the
+    /// FUSE convention sets equal to `attr_timeout`.
+    pub const DEFAULT_ATTR_TIMEOUT: f64 = 1.0;
 
-    pub const MAX_READ_AHEAD: u32 = 128 * 1024;
-
-    pub const TTR_TIMEOUT: f64 = 1.0;
-
-    pub const UMASK: u32 = 0o22;
+    /// Default umask applied to file-system-generated permission bits (octal 022).
+    pub const DEFAULT_UMASK: u32 = 0o22;
 
     /// Default FUSE BDI readahead window: 1 MiB (`1024` KB).
     pub const DEFAULT_MAX_READAHEAD_KB: u32 = 1024;
@@ -333,15 +362,15 @@ impl Default for FuseConf {
             fuse_channel_size: 0,
             stream_channel_size: 0,
             fuse_opts: vec![],
-            umask: Self::UMASK,
+            umask: Self::DEFAULT_UMASK,
             uid: sys::get_uid(),
             gid: sys::get_gid(),
             read_dir_fill_ino: true,
-            entry_timeout: FuseConf::TTR_TIMEOUT,
+            entry_timeout: FuseConf::DEFAULT_ENTRY_TIMEOUT,
             negative_timeout: 0.0,
-            attr_timeout: FuseConf::TTR_TIMEOUT,
-            ac_attr_timeout: FuseConf::TTR_TIMEOUT,
-            ac_attr_timeout_set: FuseConf::TTR_TIMEOUT,
+            attr_timeout: FuseConf::DEFAULT_ATTR_TIMEOUT,
+            ac_attr_timeout: FuseConf::DEFAULT_ATTR_TIMEOUT,
+            ac_attr_timeout_set: FuseConf::DEFAULT_ATTR_TIMEOUT,
             remember: false,
             web_port: ClusterConf::DEFAULT_FUSE_WEB_PORT,
 

--- a/curvine-common/src/conf/fuse_conf.rs
+++ b/curvine-common/src/conf/fuse_conf.rs
@@ -162,8 +162,6 @@ pub struct FuseConf {
     // Metadata cache TTL (time to live)
     pub meta_cache_ttl: String,
 
-    pub node_cache_size: u64,
-
     pub node_cache_timeout: String,
 
     // File and directory related options
@@ -381,7 +379,6 @@ impl Default for FuseConf {
             meta_cache_capacity: 100000,
             meta_cache_ttl: "120s".to_string(),
 
-            node_cache_size: 200000,
             node_cache_timeout: "1h".to_string(),
 
             direct_io: false,
@@ -480,5 +477,20 @@ io_threads = 16
             conf.fuse.max_readahead_kb,
             Some(FuseConf::DEFAULT_MAX_READAHEAD_KB)
         );
+    }
+
+    #[test]
+    fn toml_with_removed_node_cache_size_loads_clean() {
+        // node_cache_size was removed as a dead param (issue #1023 §1): the node
+        // map is evicted by node_cache_timeout (TTL) only, the capacity was never
+        // enforced. FuseConf is #[serde(default)] with no deny_unknown_fields, so
+        // legacy TOML carrying this key must still deserialize (key ignored).
+        let toml = r#"
+io_threads = 16
+node_cache_size = 200000
+"#;
+        let conf: FuseConf =
+            toml::from_str(toml).expect("legacy node_cache_size key must be ignored, not rejected");
+        assert_eq!(conf.io_threads, 16);
     }
 }

--- a/curvine-docker/fluid/config-parse.py
+++ b/curvine-docker/fluid/config-parse.py
@@ -61,7 +61,7 @@ exec {fuse_cmd}
         'direct-io', 'write-back-cache', 'cache-readdir', 'non-seekable',
         'entry-timeout', 'attr-timeout', 'negative-timeout', 'ac-attr-timeout',
         'max-background', 'congestion-threshold',
-        'node-cache-size', 'node-cache-timeout',
+        'node-cache-timeout',
         'enable-meta-cache', 'meta-cache-capacity', 'meta-cache-ttl',
         'read-dir-fill-ino', 'remember', 'check-permission', 'list-limit',
         'web-port',

--- a/curvine-fuse/src/cli/mount_args.rs
+++ b/curvine-fuse/src/cli/mount_args.rs
@@ -95,9 +95,6 @@ pub struct FuseMountArgs {
     pub congestion_threshold: Option<u16>,
 
     // Node cache settings
-    #[arg(long, help = "Node cache size (optional)")]
-    pub node_cache_size: Option<u64>,
-
     #[arg(long, help = "Node cache timeout (e.g., '1h', '30m') (optional)")]
     pub node_cache_timeout: Option<String>,
 
@@ -253,10 +250,6 @@ impl FuseMountArgs {
 
         if let Some(congestion_threshold) = self.congestion_threshold {
             conf.fuse.congestion_threshold = congestion_threshold;
-        }
-
-        if let Some(node_cache_size) = self.node_cache_size {
-            conf.fuse.node_cache_size = node_cache_size;
         }
 
         if let Some(node_cache_timeout) = &self.node_cache_timeout {

--- a/curvine-fuse/src/fs/state/node_state.rs
+++ b/curvine-fuse/src/fs/state/node_state.rs
@@ -1426,7 +1426,6 @@ mod test {
     pub fn ttl() -> CommonResult<()> {
         let mut conf = ClusterConf {
             fuse: FuseConf {
-                node_cache_size: 2,
                 node_cache_timeout: "100ms".to_string(),
                 ..Default::default()
             },

--- a/curvine-fuse/src/lib.rs
+++ b/curvine-fuse/src/lib.rs
@@ -120,8 +120,6 @@ pub const FUSE_S_ISGID: u32 = 0x400;
 // Default file permission code
 pub const FUSE_DEFAULT_MODE: u32 = 0o777;
 
-pub const FUSE_DEFAULT_UMASK: u32 = 0o022;
-
 pub const FUSE_UNKNOWN_INO: u64 = 0xffffffff;
 
 pub const FUSE_FOPEN_DIRECT_IO: u32 = 1 << 0;


### PR DESCRIPTION
# Summary

Cleans up `FuseConf`: removes dead associated constants and one dead param, renames misnamed constants to the `DEFAULT_*` convention, and documents the three easy-to-conflate cache layers. This is the merged PR-4 of the incremental `FuseConf` cleanup tracked in #1023 (§5 + §4 + the `node_cache_size` removal from §1). Purely internal — no TOML keys or CLI flags that anything actually consumes.

# Issue Describe / Design

Related to #1023 (§5 "Dead / misnamed associated constants", §4 "Overlapping cache parameters lack documented boundaries", and the `node_cache_size` item from §1 "Dead parameters"). The original standalone PR-1 (#1034) was closed and its `node_cache_size` removal folded in here; the `read_dir_fill_ino` / `remember` removals are dropped for now.

Design decisions:
- **Dead constants removed** (grepped repo-wide, zero readers): `FuseConf::MAX_READ`, `MAX_WRITE`, `MAX_READ_AHEAD`, and `curvine-fuse/src/lib.rs::FUSE_DEFAULT_UMASK`. The live, unrelated `read_handler.rs::MAX_READ_AHEAD` (16 MiB, `i64`) is intentionally left untouched.
- **`TTR_TIMEOUT` split, not just renamed.** The old single `TTR_TIMEOUT` (undefined 'TTR' acronym) fed four fields. Renaming it to one name would be misleading, so it becomes two semantically-honest constants — `DEFAULT_ENTRY_TIMEOUT` (for `entry_timeout`) and `DEFAULT_ATTR_TIMEOUT` (for `attr_timeout` / `ac_attr_timeout` / `ac_attr_timeout_set`, which FUSE convention keeps equal to `attr_timeout`). Both remain `1.0`, so defaults are unchanged.
- **`UMASK` -> `DEFAULT_UMASK`**, matching the well-formed `DEFAULT_MAX_READAHEAD_KB` / `client_conf::DEFAULT_FILE_SYSTEM_UMASK`.
- **`node_cache_size` removed** (dead param): declared, CLI-exposed and TOML-parsed but never consumed. `NodeMap.nodes` is evicted by `node_cache_timeout` (TTL) only via `CleanerTask -> clean_cache`; the capacity was never enforced. Distinct from the *live* `meta_cache_capacity` (consumed by `MetaCache::new`), which is untouched.
- **Cache-layer docs** added on `FuseConf` distinguishing kernel-side caching (entry/attr/negative timeouts -> FUSE `entry_valid`/`attr_valid`), user-side caching (`meta_cache_*` / `node_cache_*`), and IO-cache data-path switches (`direct_io` / `open_direct_on_stale` / `write_back_cache`).

Backward-compatible for `node_cache_size`: `FuseConf` is `#[serde(default)]` with no `deny_unknown_fields`, so legacy TOML carrying the key still loads (key silently ignored). Also dropped `--node-cache-size` from the Fluid `config-parse.py` forwarding whitelist so a stale Fluid config can't pass a now-unknown CLI flag.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-common/src/conf/fuse_conf.rs` | Remove dead `MAX_READ`/`MAX_WRITE`/`MAX_READ_AHEAD` and the dead `node_cache_size` field; rename `TTR_TIMEOUT`->`DEFAULT_ENTRY_TIMEOUT`+`DEFAULT_ATTR_TIMEOUT`, `UMASK`->`DEFAULT_UMASK`; add cache-layer doc block + regression test | None — default values unchanged; removed field had no readers |
| `curvine-fuse/src/lib.rs` | Remove dead `FUSE_DEFAULT_UMASK` | None — had zero readers |
| `curvine-fuse/src/cli/mount_args.rs` | Remove `--node-cache-size` CLI arg + its apply branch | `--node-cache-size` flag no longer accepted |
| `curvine-fuse/src/fs/state/node_state.rs` | Drop `node_cache_size: 2` from the `ttl` test setup | None — test still exercises `node_cache_timeout` |
| `curvine-docker/fluid/config-parse.py` | Remove `node-cache-size` from the forwarding whitelist | Prevents unknown-flag mount failure from stale Fluid configs |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo build -p curvine-common -p curvine-fuse` | PASS | |
| `cargo clippy -p curvine-common -p curvine-fuse` | PASS | no warnings (no dead-code/unused) |
| `cargo test -p curvine-common conf::fuse_conf` | PASS | 7/7, incl. new `toml_with_removed_node_cache_size_loads_clean` |
| `cargo test -p curvine-fuse ttl` | PASS | 1/1 |
| `cargo fmt` | PASS | |

# Dependencies

- Related PRs: supersedes #1034 (closed). PR-2 (§2) and PR-3 (§3) to follow.
- Related issues: #1023
- Blocks / blocked by: None
