### PR TITLE
fix(orpc): spdk EAL: Cannot use IOVA as 'PA' since physical addresses are not available in  Linux VM

### DIFF
--- a/curvine-docker/deploy/spdk/curvine-cluster-spdk.toml
+++ b/curvine-docker/deploy/spdk/curvine-cluster-spdk.toml
@@ -36,6 +36,7 @@ enabled = true
 app_name = "curvine"  
 hugepage = "10MB"
 reactor_mask = "0x30"  
+# iova_mode = "va"  # set on VM/container hosts if env_init fails with PA IOVA error
 # NVMe-oF targets  
 [[worker.spdk_disk.targets]]
 trtype = "tcp"  

--- a/curvine-server/tests/common/mod.rs
+++ b/curvine-server/tests/common/mod.rs
@@ -13,3 +13,15 @@ pub fn require_spdk_test_env() {
         std::process::exit(0);
     }
 }
+
+/// IOVA mode for SPDK integration tests.
+///
+/// Defaults to `"va"` because VM/container/AMD hosts often fail auto-detect
+/// (spdk/spdk#2683). Set `SPDK_IOVA_MODE` to override; use empty string to
+/// exercise SPDK auto-detection.
+pub fn spdk_iova_mode_for_test() -> String {
+    match std::env::var("SPDK_IOVA_MODE") {
+        Ok(v) => v,
+        Err(_) => "va".to_string(),
+    }
+}

--- a/curvine-server/tests/spdk_stress_test.rs
+++ b/curvine-server/tests/spdk_stress_test.rs
@@ -53,6 +53,7 @@ fn get_worker() -> &'static ClusterConf {
             hugepage_str: format!("{}MB", hugepage_mb),
             hugepage_mb,
             reactor_mask: std::env::var("SPDK_REACTOR_MASK").unwrap_or_else(|_| "0x2".to_string()),
+            iova_mode: common::spdk_iova_mode_for_test(),
             targets: vec![NvmeTarget {
                 traddr,
                 trsvcid,

--- a/curvine-server/tests/spdk_worker_test.rs
+++ b/curvine-server/tests/spdk_worker_test.rs
@@ -46,6 +46,7 @@ fn start_spdk_worker() -> ClusterConf {
         hugepage_str: format!("{}MB", hugepage_mb),
         hugepage_mb,
         reactor_mask: std::env::var("SPDK_REACTOR_MASK").unwrap_or_else(|_| "0x2".to_string()),
+        iova_mode: common::spdk_iova_mode_for_test(),
         targets: vec![NvmeTarget {
             traddr,
             trsvcid,

--- a/orpc/csrc/spdk_opts_helper.c
+++ b/orpc/csrc/spdk_opts_helper.c
@@ -24,6 +24,9 @@ void curvine_spdk_env_opts_set_core_mask(struct spdk_env_opts *opts, const char 
 void curvine_spdk_env_opts_set_mem_size(struct spdk_env_opts *opts, int size_mb) {
     opts->mem_size = size_mb;
 }
+void curvine_spdk_env_opts_set_iova_mode(struct spdk_env_opts *opts, const char *mode) {
+    opts->iova_mode = mode;
+}
 int curvine_spdk_env_init(struct spdk_env_opts *opts) {
     return spdk_env_init(opts);
 }

--- a/orpc/src/io/spdk_bdev.rs
+++ b/orpc/src/io/spdk_bdev.rs
@@ -773,6 +773,7 @@ mod test {
         let subnqn = std::env::var("SPDK_TARGET_NQN")
             .unwrap_or_else(|_| "nqn.2024-01.io.curvine:test".into());
         let trtype = std::env::var("SPDK_TRANSPORT_TYPE").unwrap_or_else(|_| "tcp".into());
+        conf.iova_mode = std::env::var("SPDK_IOVA_MODE").unwrap_or_else(|_| "va".into());
         conf.targets = vec![crate::io::spdk_env::NvmeTarget {
             traddr,
             trsvcid,

--- a/orpc/src/io/spdk_bdev.rs
+++ b/orpc/src/io/spdk_bdev.rs
@@ -773,7 +773,7 @@ mod test {
         let subnqn = std::env::var("SPDK_TARGET_NQN")
             .unwrap_or_else(|_| "nqn.2024-01.io.curvine:test".into());
         let trtype = std::env::var("SPDK_TRANSPORT_TYPE").unwrap_or_else(|_| "tcp".into());
-        conf.iova_mode = std::env::var("SPDK_IOVA_MODE").unwrap_or_else(|_| "va".into());
+        conf.iova_mode = crate::io::spdk_env::spdk_iova_mode_for_test();
         conf.targets = vec![crate::io::spdk_env::NvmeTarget {
             traddr,
             trsvcid,

--- a/orpc/src/io/spdk_bdev_test.rs
+++ b/orpc/src/io/spdk_bdev_test.rs
@@ -27,6 +27,7 @@ fn test_spdk_conf() -> SpdkConf {
     let subnqn =
         std::env::var("SPDK_TARGET_NQN").unwrap_or("nqn.2024-01.io.curvine:test".to_string());
     let trtype = std::env::var("SPDK_TRANSPORT_TYPE").unwrap_or("tcp".to_string());
+    let iova_mode = std::env::var("SPDK_IOVA_MODE").unwrap_or_else(|_| "va".to_string());
 
     SpdkConf {
         enabled: true,
@@ -37,6 +38,7 @@ fn test_spdk_conf() -> SpdkConf {
             .unwrap_or(256),
         reactor_mask: std::env::var("SPDK_REACTOR_MASK").unwrap_or("0x1".to_string()),
         keep_alive_timeout_ms: 500,
+        iova_mode,
 
         targets: vec![NvmeTarget {
             traddr,

--- a/orpc/src/io/spdk_bdev_test.rs
+++ b/orpc/src/io/spdk_bdev_test.rs
@@ -27,7 +27,7 @@ fn test_spdk_conf() -> SpdkConf {
     let subnqn =
         std::env::var("SPDK_TARGET_NQN").unwrap_or("nqn.2024-01.io.curvine:test".to_string());
     let trtype = std::env::var("SPDK_TRANSPORT_TYPE").unwrap_or("tcp".to_string());
-    let iova_mode = std::env::var("SPDK_IOVA_MODE").unwrap_or_else(|_| "va".to_string());
+    let iova_mode = crate::io::spdk_env::spdk_iova_mode_for_test();
 
     SpdkConf {
         enabled: true,

--- a/orpc/src/io/spdk_env.rs
+++ b/orpc/src/io/spdk_env.rs
@@ -429,15 +429,26 @@ impl Default for SpdkConf {
 
 impl Display for SpdkConf {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let iova_mode_label = if self.iova_mode.is_empty() {
+            "auto"
+        } else {
+            self.iova_mode.as_str()
+        };
         write!(
             f,
-            "SpdkConf(enabled={}, hugepage={}MB, reactor_mask={}, targets={})",
+            "SpdkConf(enabled={}, hugepage={}MB, reactor_mask={}, iova_mode={}, targets={})",
             self.enabled,
             self.hugepage_mb,
             self.reactor_mask,
+            iova_mode_label,
             self.targets.len()
         )
     }
+}
+
+#[cfg(test)]
+pub(crate) fn spdk_iova_mode_for_test() -> String {
+    std::env::var("SPDK_IOVA_MODE").unwrap_or_else(|_| "va".to_string())
 }
 
 // Bdev descriptor (discovered after init)

--- a/orpc/src/io/spdk_env.rs
+++ b/orpc/src/io/spdk_env.rs
@@ -256,6 +256,10 @@ pub struct SpdkConf {
     #[serde(skip)]
     pub hugepage_mb: u32, // parsed by init()
     pub reactor_mask: String, // hex, e.g. "0x3"
+    /// DPDK IOVA mode override. Empty = let SPDK/DPDK auto-detect (default).
+    /// Set to "va" when auto-detect fails (VM/virtio/AMD IOMMU, spdk/spdk#2683),
+    /// or "pa" for bare metal that requires physical addresses.
+    pub iova_mode: String,
     pub targets: Vec<NvmeTarget>,
     pub io_queue_depth: u32,
     pub io_queue_requests: u32,
@@ -351,6 +355,13 @@ impl SpdkConf {
             );
         }
 
+        if !self.iova_mode.is_empty() && self.iova_mode != "va" && self.iova_mode != "pa" {
+            return err_box!(
+                "SpdkConf: iova_mode must be 'va', 'pa', or empty (auto-detect), got '{}'",
+                self.iova_mode
+            );
+        }
+
         for (i, target) in self.targets.iter().enumerate() {
             target.validate().map_err(|e| {
                 let msg = format!("SpdkConf: targets[{}]: {}", i, e);
@@ -399,6 +410,7 @@ impl Default for SpdkConf {
             hugepage_str: "1024MB".to_string(),
             hugepage_mb: 1024,
             reactor_mask: "0x1".to_string(),
+            iova_mode: String::new(),
             targets: vec![],
             io_queue_depth: 128,
             io_queue_requests: 512,
@@ -850,14 +862,25 @@ impl SpdkEnv {
 
     fn env_init(&self) -> CommonResult<()> {
         use std::ffi::CString;
+        let iova_mode_label = if self.conf.iova_mode.is_empty() {
+            "auto"
+        } else {
+            self.conf.iova_mode.as_str()
+        };
         info!(
-            "SPDK env_init: app={}, hugepage={}MB, mask={}",
-            self.conf.app_name, self.conf.hugepage_mb, self.conf.reactor_mask
+            "SPDK env_init: app={}, hugepage={}MB, mask={}, iova_mode={}",
+            self.conf.app_name, self.conf.hugepage_mb, self.conf.reactor_mask, iova_mode_label
         );
         let app_name = CString::new(self.conf.app_name.as_str())
             .map_err(|e| err_msg!(format!("invalid app_name: {}", e)))?;
         let core_mask = CString::new(self.conf.reactor_mask.as_str())
             .map_err(|e| err_msg!(format!("invalid reactor_mask: {}", e)))?;
+        let iova_mode = (!self.conf.iova_mode.is_empty())
+            .then(|| {
+                CString::new(self.conf.iova_mode.as_str())
+                    .map_err(|e| err_msg!(format!("invalid iova_mode: {}", e)))
+            })
+            .transpose()?;
         unsafe {
             // Verify our opaque buffer is large enough.
             let real_size = spdk_ffi::curvine_spdk_env_opts_sizeof();
@@ -877,6 +900,9 @@ impl SpdkEnv {
             spdk_ffi::curvine_spdk_env_opts_set_name(&mut opts, app_name.as_ptr());
             spdk_ffi::curvine_spdk_env_opts_set_core_mask(&mut opts, core_mask.as_ptr());
             spdk_ffi::curvine_spdk_env_opts_set_mem_size(&mut opts, self.conf.hugepage_mb as i32);
+            if let Some(ref mode) = iova_mode {
+                spdk_ffi::curvine_spdk_env_opts_set_iova_mode(&mut opts, mode.as_ptr());
+            }
             let rc = spdk_ffi::curvine_spdk_env_init(&mut opts);
             if rc != 0 {
                 return err_box!("spdk_env_init failed with rc={}", rc);
@@ -1301,6 +1327,49 @@ mod test {
             assert_eq!(conf.keep_alive_timeout_ms, 10_000);
             assert_eq!(conf.poll_interval_ms, 100);
             assert!(conf.hugepage_mb > 0);
+            assert!(conf.iova_mode.is_empty());
+        }
+
+        #[test]
+        fn iova_mode_empty_means_auto_detect() {
+            let conf = SpdkConf::default();
+            assert!(conf.iova_mode.is_empty());
+        }
+
+        #[test]
+        fn validate_rejects_unknown_iova_mode() {
+            let mut conf = SpdkConf {
+                enabled: true,
+                iova_mode: "dc".into(),
+                targets: vec![NvmeTarget {
+                    traddr: "10.0.0.1".into(),
+                    trsvcid: 4420,
+                    subnqn: "nqn.test".into(),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            };
+            conf.init().unwrap();
+            assert!(conf.validate().is_err());
+        }
+
+        #[test]
+        fn validate_accepts_va_and_pa_iova_mode() {
+            for mode in ["va", "pa"] {
+                let mut conf = SpdkConf {
+                    enabled: true,
+                    iova_mode: mode.into(),
+                    targets: vec![NvmeTarget {
+                        traddr: "10.0.0.1".into(),
+                        trsvcid: 4420,
+                        subnqn: "nqn.test".into(),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                };
+                conf.init().unwrap();
+                assert!(conf.validate().is_ok(), "mode={mode}");
+            }
         }
 
         #[test]

--- a/orpc/src/io/spdk_ffi.rs
+++ b/orpc/src/io/spdk_ffi.rs
@@ -30,6 +30,7 @@ extern "C" {
     pub fn curvine_spdk_env_opts_set_name(opts: *mut spdk_env_opts, name: *const c_char);
     pub fn curvine_spdk_env_opts_set_core_mask(opts: *mut spdk_env_opts, mask: *const c_char);
     pub fn curvine_spdk_env_opts_set_mem_size(opts: *mut spdk_env_opts, mem_size: c_int);
+    pub fn curvine_spdk_env_opts_set_iova_mode(opts: *mut spdk_env_opts, mode: *const c_char);
     pub fn curvine_spdk_env_init(opts: *mut spdk_env_opts) -> c_int;
     pub fn spdk_env_fini();
     // Transport ID (via C helper)


### PR DESCRIPTION
# Summary

We have been running SPDK smoke on the example cluster (malloc NVMe-oF target + worker initiator), and sometimes the worker dies at `spdk_env_init()` with:

```
Cannot use IOVA as `PA` since physical addresses are not available
Cannot set up PCI infrastructure
```

Curvine never set `spdk_env_opts.iova_mode` before; it relied on SPDK/DPDK auto-detection. That works on bare metal, but on VMs, containers, or some AMD IOMMU setups it often picks `pa` when physical addresses are not actually available. Same class of problem as [spdk/spdk#2683](https://github.com/spdk/spdk/issues/2683).

This PR adds an **opt-in** `iova_mode` knob instead of forcing a global default, so prod bare-metal behavior stays unchanged while constrained envs can opt into `"va"`.

# Issue Describe / Design

Related to [spdk/spdk#2683](https://github.com/spdk/spdk/issues/2683)

**Root cause:** `spdk_env_opts.iova_mode` was left unset; DPDK auto-detection mis-picks `pa` on hosts without usable physical addresses.

**Repro:** Run worker SPDK initiator on a Linux VM / container against a local NVMe-oF target, for example malloc `nvmf_tgt` on `127.0.0.1:4420`. `spdk_env_init()` fails intermittently with the PA IOVA error above. Our `nvmf_tgt` already uses `--iova-mode=va`, but the worker had no equivalent config.

**Fix approach:**
- Add `SpdkConf.iova_mode` + `curvine_spdk_env_opts_set_iova_mode()` FFI
- **Empty (default):** skip `set_iova_mode`, keep auto-detect, no behavior change for existing deployments
- **`"va"` / `"pa"`:** explicit override when auto-detect breaks
- Integration test helpers default to `"va"` and remain overridable via `SPDK_IOVA_MODE`; empty string exercises auto-detect

**Why not default everything to `va`?** Auto-detect is usually right on real hardware. Forcing `va` globally would paper over environment issues. Opt-in override is safer.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `orpc/csrc/spdk_opts_helper.c` | Add `curvine_spdk_env_opts_set_iova_mode()` | None |
| `orpc/src/io/spdk_ffi.rs` | FFI declaration | None |
| `orpc/src/io/spdk_env.rs` | `SpdkConf.iova_mode`, validation, pass-through in `env_init`, `Display` output, and orpc test helper | None when unset; explicit `va`/`pa` when configured |
| `orpc/src/io/spdk_bdev.rs`, `orpc/src/io/spdk_bdev_test.rs` | Use the shared orpc SPDK IOVA test helper | Test-only |
| `curvine-server/tests/common/mod.rs` | `spdk_iova_mode_for_test()` helper, default `"va"` | Test-only |
| `curvine-server/tests/spdk_*_test.rs` | Use helper in test worker conf | Test-only |
| `curvine-docker/deploy/spdk/curvine-cluster-spdk.toml` | Document optional `iova_mode = "va"` for VM/container deployments | Example config only |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| Unit tests: empty = auto-detect, `va`/`pa` accepted, invalid values rejected | PASS | `orpc/src/io/spdk_env.rs` |
| Example-cluster SPDK smoke | PASS | malloc NVMe-oF target + worker initiator; `fs blocks` shows `SpdkDisk` |
| `cargo fmt --check` | PASS | Local after review fixes |
| `cargo test -p orpc` | PASS | Local after review fixes |

**Bottom line for prod:** if you do not set `iova_mode`, nothing changes from today.

# Dependencies

- Related PRs: None
- Related issues: [spdk/spdk#2683](https://github.com/spdk/spdk/issues/2683)
- Blocks / blocked by: None
