### PR TITLE
feat(fuse): enforce readonly mount mode (#896)

### DIFF
--- a/curvine-client/src/unified/unified_filesystem.rs
+++ b/curvine-client/src/unified/unified_filesystem.rs
@@ -152,7 +152,7 @@ impl UnifiedFileSystem {
         let state = self.mount_cache.get_mount(self, path).await?;
         if let Some(mnt) = state {
             if mnt.info.is_read_only_cache_mode() && Self::is_mount_write_rpc(rpc_code) {
-                return err_ext!(FsError::unsupported(format!(
+                return err_ext!(FsError::read_only(format!(
                     "{} on read_only cache_mode mount {}",
                     rpc_code, path
                 )));
@@ -284,6 +284,7 @@ impl UnifiedFileSystem {
 
     pub async fn link(&self, src_path: &Path, dst_path: &Path) -> FsResult<()> {
         let fut = async {
+            let _ = self.get_mount_checked(dst_path, RpcCode::Link).await?;
             match self.get_mount_checked(src_path, RpcCode::Link).await? {
                 None => self.cv.link(src_path, dst_path).await,
                 Some(_) => err_ext!(FsError::unsupported("link")),

--- a/curvine-common/src/conf/fuse_conf.rs
+++ b/curvine-common/src/conf/fuse_conf.rs
@@ -98,6 +98,9 @@ pub struct FuseConf {
     // Mount the configuration, needs to be passed to the linux kernel.
     pub fuse_opts: Vec<String>,
 
+    // Mount the whole FUSE filesystem read-only at the kernel level.
+    pub readonly: bool,
+
     // Overwrite the permission bits set by the file system in st_mode.
     // The generated permission bit is the missing permission bit in the given umask value.This value is given in octal representation.
     // Default value 022
@@ -320,7 +323,14 @@ impl FuseConf {
     }
 
     pub fn set_fuse_opts(&self, mount_options: &mut String) {
+        if self.readonly {
+            mount_options.push_str(",ro");
+        }
+
         self.fuse_opts.iter().for_each(|opt| match opt.as_str() {
+            "ro" => {
+                mount_options.push_str(",ro");
+            }
             "default_permissions" => {
                 mount_options.push_str(",default_permissions");
             }
@@ -360,6 +370,7 @@ impl Default for FuseConf {
             fuse_channel_size: 0,
             stream_channel_size: 0,
             fuse_opts: vec![],
+            readonly: false,
             umask: Self::DEFAULT_UMASK,
             uid: sys::get_uid(),
             gid: sys::get_gid(),
@@ -460,6 +471,23 @@ max_readahead_kb = 1024
             conf.max_readahead_kb,
             Some(FuseConf::DEFAULT_MAX_READAHEAD_KB)
         );
+    }
+
+    #[test]
+    fn readonly_adds_ro_mount_option() {
+        let conf = FuseConf {
+            readonly: true,
+            ..Default::default()
+        };
+        let mut mount_options = String::new();
+        conf.set_fuse_opts(&mut mount_options);
+        assert!(mount_options.split(',').any(|opt| opt == "ro"));
+    }
+
+    #[test]
+    fn toml_readonly_is_parsed() {
+        let conf: FuseConf = toml::from_str("readonly = true").expect("parse");
+        assert!(conf.readonly);
     }
 
     #[test]

--- a/curvine-common/src/conf/fuse_conf.rs
+++ b/curvine-common/src/conf/fuse_conf.rs
@@ -323,13 +323,18 @@ impl FuseConf {
     }
 
     pub fn set_fuse_opts(&self, mount_options: &mut String) {
+        let mut ro_added = false;
         if self.readonly {
             mount_options.push_str(",ro");
+            ro_added = true;
         }
 
         self.fuse_opts.iter().for_each(|opt| match opt.as_str() {
             "ro" => {
-                mount_options.push_str(",ro");
+                if !ro_added {
+                    mount_options.push_str(",ro");
+                    ro_added = true;
+                }
             }
             "default_permissions" => {
                 mount_options.push_str(",default_permissions");
@@ -482,6 +487,22 @@ max_readahead_kb = 1024
         let mut mount_options = String::new();
         conf.set_fuse_opts(&mut mount_options);
         assert!(mount_options.split(',').any(|opt| opt == "ro"));
+    }
+
+    #[test]
+    fn readonly_does_not_duplicate_ro_mount_option() {
+        let conf = FuseConf {
+            readonly: true,
+            fuse_opts: vec!["ro".to_string()],
+            ..Default::default()
+        };
+        let mut mount_options = String::new();
+        conf.set_fuse_opts(&mut mount_options);
+
+        assert_eq!(
+            mount_options.split(',').filter(|opt| *opt == "ro").count(),
+            1
+        );
     }
 
     #[test]

--- a/curvine-common/src/error/fs_error.rs
+++ b/curvine-common/src/error/fs_error.rs
@@ -64,6 +64,7 @@ pub enum ErrorKind {
     NotADirectory = 27,
     InvalidArgument = 28,
     BlockNotFound = 29,
+    ReadOnly = 30,
 
     #[num_enum(default)]
     Common = 10000,
@@ -173,6 +174,10 @@ pub enum FsError {
     #[error("{0}")]
     UnsupportedUfsRead(ErrorImpl<StringError>),
 
+    // Read-only file system or mount
+    #[error("{0}")]
+    ReadOnly(ErrorImpl<StringError>),
+
     // Pipeline replication error with failed worker info
     #[error("{0}")]
     Pipeline(ErrorImpl<StringError>),
@@ -234,6 +239,11 @@ impl FsError {
     pub fn unsupported_ufs_read(path: impl AsRef<str>) -> Self {
         let msg = format!("File {} unsupported ufs read", path.as_ref());
         Self::UnsupportedUfsRead(ErrorImpl::with_source(msg.into()))
+    }
+
+    pub fn read_only(path: impl AsRef<str>) -> Self {
+        let msg = format!("{} is on a read-only mount", path.as_ref());
+        Self::ReadOnly(ErrorImpl::with_source(msg.into()))
     }
 
     pub fn job_not_found(job_id: impl AsRef<str>) -> Self {
@@ -367,6 +377,7 @@ impl FsError {
             FsError::Ufs(_) => ErrorKind::Ufs,
             FsError::Expired(_) => ErrorKind::Expired,
             FsError::UnsupportedUfsRead(_) => ErrorKind::UnsupportedUfsRead,
+            FsError::ReadOnly(_) => ErrorKind::ReadOnly,
             FsError::Pipeline(_) => ErrorKind::Pipeline,
             FsError::MinReplicasNotMet(_) => ErrorKind::MinReplicasNotMet,
             FsError::JobNotFound(_) => ErrorKind::JobNotFound,
@@ -513,6 +524,7 @@ impl ErrorExt for FsError {
             FsError::Ufs(e) => FsError::Ufs(e.ctx(ctx)),
             FsError::Expired(e) => FsError::Expired(e.ctx(ctx)),
             FsError::UnsupportedUfsRead(e) => FsError::UnsupportedUfsRead(e.ctx(ctx)),
+            FsError::ReadOnly(e) => FsError::ReadOnly(e.ctx(ctx)),
             FsError::Pipeline(e) => FsError::Pipeline(e.ctx(ctx)),
             FsError::MinReplicasNotMet(e) => FsError::MinReplicasNotMet(e.ctx(ctx)),
             FsError::JobNotFound(e) => FsError::JobNotFound(e.ctx(ctx)),
@@ -548,6 +560,7 @@ impl ErrorExt for FsError {
             FsError::Ufs(e) => e.encode(ErrorKind::Ufs),
             FsError::Expired(e) => e.encode(ErrorKind::Expired),
             FsError::UnsupportedUfsRead(e) => e.encode(ErrorKind::UnsupportedUfsRead),
+            FsError::ReadOnly(e) => e.encode(ErrorKind::ReadOnly),
             FsError::Pipeline(e) => e.encode(ErrorKind::Pipeline),
             FsError::MinReplicasNotMet(e) => e.encode(ErrorKind::MinReplicasNotMet),
             FsError::JobNotFound(e) => e.encode(ErrorKind::JobNotFound),
@@ -586,6 +599,7 @@ impl ErrorExt for FsError {
             ErrorKind::Ufs => FsError::Ufs(de.into_string()),
             ErrorKind::Expired => FsError::Expired(de.into_string()),
             ErrorKind::UnsupportedUfsRead => FsError::UnsupportedUfsRead(de.into_string()),
+            ErrorKind::ReadOnly => FsError::ReadOnly(de.into_string()),
             ErrorKind::Pipeline => FsError::Pipeline(de.into_string()),
             ErrorKind::MinReplicasNotMet => FsError::MinReplicasNotMet(de.into_string()),
             ErrorKind::JobNotFound => FsError::JobNotFound(de.into_string()),
@@ -650,6 +664,16 @@ mod tests {
         let error = FsError::pipeline_error(789, "Test error");
 
         assert!(matches!(error.kind(), ErrorKind::Pipeline));
+    }
+
+    #[test]
+    pub fn read_only_error_kind_test() {
+        let error = FsError::read_only("/mnt/ro");
+
+        assert!(matches!(error.kind(), ErrorKind::ReadOnly));
+        let bytes = error.encode();
+        let decoded = FsError::decode(bytes);
+        assert!(matches!(decoded.kind(), ErrorKind::ReadOnly));
     }
 
     #[test]

--- a/curvine-fuse/src/cli/mount_args.rs
+++ b/curvine-fuse/src/cli/mount_args.rs
@@ -109,6 +109,13 @@ pub struct FuseMountArgs {
     #[arg(short, long)]
     options: Vec<String>,
 
+    #[arg(
+        long,
+        action = clap::ArgAction::SetTrue,
+        help = "Mount the entire FUSE filesystem read-only"
+    )]
+    readonly: bool,
+
     // Additional FuseConf fields
     #[arg(long, help = "Fill inode number when reading directory (optional)")]
     pub read_dir_fill_ino: Option<bool>,
@@ -262,6 +269,10 @@ impl FuseMountArgs {
 
         if let Some(read_dir_fill_ino) = self.read_dir_fill_ino {
             conf.fuse.read_dir_fill_ino = read_dir_fill_ino;
+        }
+
+        if self.readonly {
+            conf.fuse.readonly = true;
         }
 
         if let Some(write_back_cache) = self.write_back_cache {

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -175,7 +175,15 @@ impl CurvineFileSystem {
             return Err(FsError::read_only(path.full_path()).into());
         }
 
-        self.fs.get_mount(path, rpc_code).await?;
+        if let Some((_, mnt)) = self.fs.get_mount(path, RpcCode::FileStatus).await? {
+            if mnt.info.is_read_only_cache_mode() {
+                return Err(FsError::read_only(format!(
+                    "{} on read_only cache_mode mount {}",
+                    rpc_code, path
+                ))
+                .into());
+            }
+        }
         Ok(())
     }
 

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -29,7 +29,7 @@ use crate::{err_fuse, FuseError, FuseResult, FuseUtils};
 use curvine_client::unified::UnifiedFileSystem;
 use curvine_common::conf::{ClusterConf, FuseConf};
 use curvine_common::error::FsError;
-use curvine_common::fs::{FileSystem, Path, StateReader, StateWriter};
+use curvine_common::fs::{FileSystem, Path, RpcCode, StateReader, StateWriter};
 use curvine_common::state::{
     CreateFileOptsBuilder, FileAllocMode, FileAllocOpts, FileLock, FileStatus, LockFlags, LockType,
     MkdirOptsBuilder, OpenFlags, SetAttrOpts,
@@ -168,6 +168,15 @@ impl CurvineFileSystem {
             attr_valid_nsec: conf.attr_ttl.subsec_nanos(),
             attr,
         }
+    }
+
+    async fn ensure_writable_path(&self, path: &Path, rpc_code: RpcCode) -> FuseResult<()> {
+        if self.conf.readonly {
+            return Err(FsError::read_only(path.full_path()).into());
+        }
+
+        self.fs.get_mount(path, rpc_code).await?;
+        Ok(())
     }
 
     pub fn new_dot_status(name: &str) -> FileStatus {
@@ -878,6 +887,7 @@ impl fs::FileSystem for CurvineFileSystem {
     async fn set_xattr(&self, op: SetXAttr<'_>) -> FuseResult<()> {
         let name = try_option!(op.name.to_str());
         let path = self.state.get_path(op.header.nodeid)?;
+        self.ensure_writable_path(&path, RpcCode::SetAttr).await?;
 
         // Get the xattr value from the request
         let value_slice: &[u8] = op.value;
@@ -921,6 +931,7 @@ impl fs::FileSystem for CurvineFileSystem {
     async fn remove_xattr(&self, op: RemoveXAttr<'_>) -> FuseResult<()> {
         let name = try_option!(op.name.to_str());
         let path = self.state.get_path(op.header.nodeid)?;
+        self.ensure_writable_path(&path, RpcCode::SetAttr).await?;
 
         debug!("Removing xattr: path='{}' name='{}'", path, name);
 
@@ -1019,6 +1030,7 @@ impl fs::FileSystem for CurvineFileSystem {
             op.header.nodeid, op.arg
         );
         let path = self.state.get_path(op.header.nodeid)?;
+        self.ensure_writable_path(&path, RpcCode::SetAttr).await?;
 
         // Convert setattr to opts with UID/GID numeric fallback
         let mut opts = match Self::fuse_setattr_to_opts(op.arg) {
@@ -1158,6 +1170,7 @@ impl fs::FileSystem for CurvineFileSystem {
         }
 
         let path = self.state.get_path_name(op.header.nodeid, name)?;
+        self.ensure_writable_path(&path, RpcCode::Mkdir).await?;
 
         let mut opts = MkdirOptsBuilder::with_conf(&self.fs.conf().client);
         // Apply requested mode and ownership to directory if provided
@@ -1188,6 +1201,8 @@ impl fs::FileSystem for CurvineFileSystem {
 
     async fn allocate(&self, op: FAllocate<'_>) -> FuseResult<()> {
         let path = self.state.get_path(op.header.nodeid)?;
+        self.ensure_writable_path(&path, RpcCode::ResizeFile)
+            .await?;
 
         let opts = FileAllocOpts {
             truncate: false,
@@ -1227,6 +1242,11 @@ impl fs::FileSystem for CurvineFileSystem {
         let path = self.state.get_path(op.header.nodeid)?;
         // Check file access permissions before opening
         let action = OpenAction::try_from(op.arg.flags)?;
+        let truncate = (op.arg.flags & libc::O_TRUNC as u32) != 0;
+        if action.write() || truncate {
+            self.ensure_writable_path(&path, RpcCode::CreateFile)
+                .await?;
+        }
         self.check_permissions(&path, op.header, action.acl_mask())
             .await?;
 
@@ -1301,6 +1321,8 @@ impl fs::FileSystem for CurvineFileSystem {
         }
 
         let path = self.state.get_path_common(id, Some(name))?;
+        self.ensure_writable_path(&path, RpcCode::CreateFile)
+            .await?;
         let node = self.state.find_node(id, Some(name))?;
         let flags = op.arg.flags;
 
@@ -1343,6 +1365,9 @@ impl fs::FileSystem for CurvineFileSystem {
 
     async fn write(&self, op: Write<'_>, reply: FuseResponse) -> FuseResult<()> {
         let handle = self.state.find_handle(op.header.nodeid, op.arg.fh)?;
+        let path = self.state.get_path(op.header.nodeid)?;
+        self.ensure_writable_path(&path, RpcCode::CreateFile)
+            .await?;
         handle.write(op, reply).await
     }
 
@@ -1399,6 +1424,7 @@ impl fs::FileSystem for CurvineFileSystem {
         let parent_ino = op.header.nodeid;
 
         let path = self.state.get_path_common(parent_ino, Some(name))?;
+        self.ensure_writable_path(&path, RpcCode::Delete).await?;
         if self.state.should_delete_now(parent_ino, Some(name))? {
             self.fs.delete(&path, false).await?;
         }
@@ -1414,6 +1440,8 @@ impl fs::FileSystem for CurvineFileSystem {
 
         let des_path = self.state.get_path_common(op.header.nodeid, Some(name))?;
         let src_path = self.state.get_path(oldnodeid)?;
+        self.ensure_writable_path(&src_path, RpcCode::Link).await?;
+        self.ensure_writable_path(&des_path, RpcCode::Link).await?;
 
         debug!(
             "link: src_path={}, des_path={}, oldnodeid={}, parent={}",
@@ -1438,6 +1466,7 @@ impl fs::FileSystem for CurvineFileSystem {
     async fn rm_dir(&self, op: RmDir<'_>) -> FuseResult<()> {
         let name = try_option!(op.name.to_str());
         let path = self.state.get_path_common(op.header.nodeid, Some(name))?;
+        self.ensure_writable_path(&path, RpcCode::Delete).await?;
 
         self.fs.delete(&path, false).await?;
         self.state.unlink_node(op.header.nodeid, Some(name))?;
@@ -1456,6 +1485,10 @@ impl fs::FileSystem for CurvineFileSystem {
         let (old_path, new_path) =
             self.state
                 .get_path2(op.header.nodeid, old_name, op.arg.newdir, new_name)?;
+        self.ensure_writable_path(&old_path, RpcCode::Rename)
+            .await?;
+        self.ensure_writable_path(&new_path, RpcCode::Rename)
+            .await?;
 
         self.fs.rename(&old_path, &new_path).await?;
 
@@ -1493,6 +1526,8 @@ impl fs::FileSystem for CurvineFileSystem {
         };
 
         let link_path = self.state.get_path_common(parent, linkname)?;
+        self.ensure_writable_path(&link_path, RpcCode::Symlink)
+            .await?;
         self.fs.symlink(target, &link_path, false).await?;
 
         self.invalidate_cache(&link_path, INVAL_REASON_SYMLINK)?;
@@ -1532,6 +1567,11 @@ impl fs::FileSystem for CurvineFileSystem {
 
     async fn fsync(&self, op: FSync<'_>, reply: FuseResponse) -> FuseResult<()> {
         let handle = self.state.find_handle(op.header.nodeid, op.arg.fh)?;
+        if handle.writer.is_some() {
+            let path = self.state.get_path(op.header.nodeid)?;
+            self.ensure_writable_path(&path, RpcCode::CreateFile)
+                .await?;
+        }
         handle.flush(Some(reply)).await?;
 
         let path = Path::from_str(&handle.status.path)?;
@@ -1624,6 +1664,7 @@ impl fs::FileSystem for CurvineFileSystem {
 
     async fn set_lk(&self, op: SetLk<'_>) -> FuseResult<()> {
         let path = self.state.get_path(op.header.nodeid)?;
+        self.ensure_writable_path(&path, RpcCode::SetLock).await?;
         let handle = self.state.find_handle(op.header.nodeid, op.arg.fh)?;
 
         let lock = self.to_file_lock(op.arg);
@@ -1640,6 +1681,7 @@ impl fs::FileSystem for CurvineFileSystem {
 
     async fn set_lkw(&self, op: SetLkW<'_>) -> FuseResult<()> {
         let path = self.state.get_path(op.header.nodeid)?;
+        self.ensure_writable_path(&path, RpcCode::SetLock).await?;
         let handle = self.state.find_handle(op.header.nodeid, op.arg.fh)?;
 
         let conf = &self.fs.conf().client;

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -1365,9 +1365,6 @@ impl fs::FileSystem for CurvineFileSystem {
 
     async fn write(&self, op: Write<'_>, reply: FuseResponse) -> FuseResult<()> {
         let handle = self.state.find_handle(op.header.nodeid, op.arg.fh)?;
-        let path = self.state.get_path(op.header.nodeid)?;
-        self.ensure_writable_path(&path, RpcCode::CreateFile)
-            .await?;
         handle.write(op, reply).await
     }
 

--- a/curvine-fuse/src/fuse_error.rs
+++ b/curvine-fuse/src/fuse_error.rs
@@ -87,6 +87,7 @@ impl From<FsError> for FuseError {
             FsError::Unsupported(_) => Some(libc::ENOSYS),
             FsError::InProgress(_) => Some(libc::EBUSY),
             FsError::UnsupportedUfsRead(_) => Some(libc::EOPNOTSUPP),
+            FsError::ReadOnly(_) => Some(libc::EROFS),
             _ => None,
         };
 
@@ -157,6 +158,7 @@ pub(crate) fn errno_label(errno: i32) -> &'static str {
         libc::EBUSY => "EBUSY",
         libc::ENAMETOOLONG => "ENAMETOOLONG",
         libc::EFBIG => "EFBIG",
+        libc::EROFS => "EROFS",
         _ => "OTHER",
     }
 }
@@ -189,6 +191,13 @@ mod tests {
     }
 
     #[test]
+    fn read_only_maps_to_erofs() {
+        let err: FuseError = FsError::read_only("/mnt/ro").into();
+        assert_eq!(err.errno, libc::EROFS);
+        assert_eq!(errno_label(err.errno), "EROFS");
+    }
+
+    #[test]
     fn errno_label_maps_the_closed_set() {
         // Full (errno, expected-label) table. Any accidental relabeling must
         // update this table and the design doc's errno Label rules together.
@@ -217,6 +226,7 @@ mod tests {
             (libc::EBUSY, "EBUSY"),
             (libc::ENAMETOOLONG, "ENAMETOOLONG"),
             (libc::EFBIG, "EFBIG"),
+            (libc::EROFS, "EROFS"),
         ];
         for (e, expected) in table {
             assert_eq!(errno_label(e), expected, "label mismatch for errno {}", e);

--- a/curvine-lancedb/src/object_store.rs
+++ b/curvine-lancedb/src/object_store.rs
@@ -1871,7 +1871,9 @@ fn fs_error_to_object_store(location: &Path, error: FsError) -> OsError {
             path: location.to_string(),
             source: Box::new(e),
         },
-        e @ FsError::Unsupported(_) | e @ FsError::UnsupportedUfsRead(_) => OsError::NotSupported {
+        e @ FsError::Unsupported(_)
+        | e @ FsError::UnsupportedUfsRead(_)
+        | e @ FsError::ReadOnly(_) => OsError::NotSupported {
             source: Box::new(e),
         },
         e => OsError::Generic {
@@ -1931,6 +1933,14 @@ mod tests {
         let message = "[curvine-master] ERROR: File /tmp/lancedb/events.lance/_versions not exists(curvine-server/src/master/meta/fs_dir.rs:452): ";
 
         assert!(is_curvine_missing_common_message(message));
+    }
+
+    #[test]
+    fn readonly_fs_error_maps_to_object_store_not_supported() {
+        let location = Path::from("dataset.lance");
+        let err = fs_error_to_object_store(&location, FsError::read_only("read-only mount"));
+
+        assert!(matches!(err, OsError::NotSupported { .. }));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Enforce `access_mode=read_only` bucket mounts in FUSE write-side operations with `EROFS`.
- Add `FsError::ReadOnly` and map it to POSIX `EROFS`.
- Add global `--readonly` / `fuse.readonly=true` support for whole-FUSE `ro` mount options.

## Issue Describe / Design
Fixes #896.

This reuses the existing bucket-level `access_mode=read_only/read_write` metadata. Since OS `MS_RDONLY` only applies to the whole FUSE mount, per-bucket readonly behavior is enforced in curvine-fuse by checking write-side FUSE ops against mount metadata before they reach Curvine/UFS writers. The FUSE guard constructs the readonly error and maps it to EROFS; the unified layer retains a ReadOnly fallback for non-FUSE callers.

## Changes
| Area | Change |
| --- | --- |
| common error | Add `ReadOnly` error kind and encode/decode coverage |
| fuse error | Map readonly failures to `EROFS` |
| fuse config/CLI | Add `fuse.readonly` and `--readonly` for whole-mount `ro`; avoid duplicate `ro` mount options |
| unified fs | Return readonly errors for read-only cache-mode write RPCs |
| curvine-fuse | Short-circuit create/mkdir/unlink/rmdir/rename/setattr/xattr/link/symlink/fallocate/locks in the FUSE guard with `EROFS`; avoid per-write mount lookup in the data hot path |
| curvine-lancedb | Preserve `FsError::ReadOnly` as object-store `NotSupported` instead of `Generic` |

## Test verified
- `cargo fmt`
- `git diff --check`
- Remote Linux: `cargo test -p curvine-common readonly -- --nocapture` passed
- Remote Linux PR branch S3/FUSE probe: read-only cache-mode write returns `EROFS(30) / Read-only file system`
- Local macOS: `cargo test -p curvine-common readonly -- --nocapture` blocked by local `librocksdb-sys` C++ toolchain failure: missing standard headers like `cstdint`, `array`, `memory`.
- Remote Linux: `cargo test -p curvine-lancedb readonly_fs_error_maps_to_object_store_not_supported -- --nocapture` blocked by crates.io download timeout for `openssl-probe v0.2.1`.
