### PR TITLE
refactor(fuse): make FuseConf time fields unit-explicit and default meta cache on

### DIFF
--- a/curvine-common/src/conf/fuse_conf.rs
+++ b/curvine-common/src/conf/fuse_conf.rs
@@ -28,10 +28,9 @@ use std::time::Duration;
 //
 // 1. Kernel-side caching (the kernel caches on our behalf, controlled via the
 //    FUSE reply `entry_valid` / `attr_valid` fields):
-//    - `entry_timeout`   -> how long the kernel trusts a name->inode lookup.
-//    - `negative_timeout`-> how long the kernel caches a negative lookup (ENOENT).
-//    - `attr_timeout`    -> how long the kernel trusts cached file/dir attributes.
-//    - `ac_attr_timeout*`-> attr-cache timeout used for auto-cache refresh.
+//    - `entry_timeout_ms`   -> how long the kernel trusts a name->inode lookup.
+//    - `negative_timeout_ms`-> how long the kernel caches a negative lookup (ENOENT).
+//    - `attr_timeout_ms`    -> how long the kernel trusts cached file/dir attributes.
 //    These trade metadata freshness for fewer upcalls into user space.
 //
 // 2. User-side caching (maintained inside curvine-fuse itself):
@@ -116,33 +115,22 @@ pub struct FuseConf {
     // The default value is true
     pub read_dir_fill_ino: bool,
 
-    // Name search cache time.
+    // Name search cache time, in milliseconds.
     // After performing a name search, if the same name is requested again, the kernel will check the cache first.
     // If the buffer record is still valid, the cache result will be returned directly, unlike user space for requests.
-    // Default 1.0 seconds
-    pub entry_timeout: f64,
+    // Default 1000ms (1 second). Sub-second granularity is supported (e.g. 500 = 0.5s).
+    pub entry_timeout_ms: u64,
 
-    // The timeout (in seconds) of cache negative lookups.This means that if the file does not exist (find returns ENOENT)
+    // The timeout (in milliseconds) of cache negative lookups. This means that if the file does not exist (find returns ENOENT)
     // Then the search will only be redone after the timeout, and the file/directory will be assumed to not exist before this.
-    // The default value is 0.0 seconds, which means cache negative lookup is disabled.
-    pub negative_timeout: f64,
+    // The default value is 0ms, which means cache negative lookup is disabled.
+    pub negative_timeout_ms: u64,
 
-    // Cache time for file and directory attributes.
+    // Cache time for file and directory attributes, in milliseconds.
     // This means that after a file or directory attribute search, if the same attribute is requested again, the kernel will first check the cache.
     // If the record in the cache is still valid (i.e. the timeout time has not exceeded), the cached result will be returned directly without making a request to the user space again
-    // Default is 1.0 seconds.
-    pub attr_timeout: f64,
-
-    // Parameters are used to specify the file attribute cache timeout for automatic cache refresh.
-    // By default, it is set to the same value as attr_timeout (i.e. 1.0 seconds).
-    //
-    // When the file is opened, if the automatic cache (auto_cache) needs to refresh the file data, the kernel will check whether the cache of the file attributes has expired.
-    // If the cache record of file attributes is still valid (i.e. the timeout time has not exceeded), the automatic cache will refresh the file data.
-    pub ac_attr_timeout: f64,
-
-    // Parameters are used to specify the file attribute cache timeout for automatic cache refresh.
-    // By default, it is set to the same value as attr_timeout (i.e. 1.0 seconds).
-    pub ac_attr_timeout_set: f64,
+    // Default is 1000ms (1 second). Sub-second granularity is supported (e.g. 500 = 0.5s).
+    pub attr_timeout_ms: u64,
 
     // Parameters are used to specify whether the file system should remember the opened files and directories.
     // By default, the FUSE file system clears the cache when a file or directory is closed.
@@ -228,13 +216,15 @@ pub struct FuseConf {
 impl FuseConf {
     pub const FS_NAME: &'static str = "curvine-fuse";
 
-    /// Default kernel dentry (name lookup) cache timeout, in seconds.
-    pub const DEFAULT_ENTRY_TIMEOUT: f64 = 1.0;
+    /// Default kernel dentry (name lookup) cache timeout, in milliseconds.
+    pub const DEFAULT_ENTRY_TIMEOUT_MS: u64 = 1000;
 
-    /// Default kernel attribute cache timeout, in seconds. Also used as the
-    /// default for the auto-cache attr timeouts (`ac_attr_timeout*`), which the
-    /// FUSE convention sets equal to `attr_timeout`.
-    pub const DEFAULT_ATTR_TIMEOUT: f64 = 1.0;
+    /// Default kernel negative-lookup (ENOENT) cache timeout, in milliseconds.
+    /// `0` disables negative-lookup caching.
+    pub const DEFAULT_NEGATIVE_TIMEOUT_MS: u64 = 0;
+
+    /// Default kernel attribute cache timeout, in milliseconds.
+    pub const DEFAULT_ATTR_TIMEOUT_MS: u64 = 1000;
 
     /// Default umask applied to file-system-generated permission bits (octal 022).
     pub const DEFAULT_UMASK: u32 = 0o22;
@@ -243,9 +233,9 @@ impl FuseConf {
     pub const DEFAULT_MAX_READAHEAD_KB: u32 = 1024;
 
     pub fn init(&mut self) -> CommonResult<()> {
-        self.attr_ttl = Duration::from_secs_f64(self.attr_timeout);
-        self.entry_ttl = Duration::from_secs_f64(self.entry_timeout);
-        self.negative_ttl = Duration::from_secs_f64(self.negative_timeout);
+        self.attr_ttl = Duration::from_millis(self.attr_timeout_ms);
+        self.entry_ttl = Duration::from_millis(self.entry_timeout_ms);
+        self.negative_ttl = Duration::from_millis(self.negative_timeout_ms);
         self.node_cache_ttl = DurationUnit::from_str(&self.node_cache_timeout)?.as_duration();
         self.meta_cache_ttl_duration = DurationUnit::from_str(&self.meta_cache_ttl)?.as_duration();
 
@@ -364,11 +354,9 @@ impl Default for FuseConf {
             uid: sys::get_uid(),
             gid: sys::get_gid(),
             read_dir_fill_ino: true,
-            entry_timeout: FuseConf::DEFAULT_ENTRY_TIMEOUT,
-            negative_timeout: 0.0,
-            attr_timeout: FuseConf::DEFAULT_ATTR_TIMEOUT,
-            ac_attr_timeout: FuseConf::DEFAULT_ATTR_TIMEOUT,
-            ac_attr_timeout_set: FuseConf::DEFAULT_ATTR_TIMEOUT,
+            entry_timeout_ms: FuseConf::DEFAULT_ENTRY_TIMEOUT_MS,
+            negative_timeout_ms: FuseConf::DEFAULT_NEGATIVE_TIMEOUT_MS,
+            attr_timeout_ms: FuseConf::DEFAULT_ATTR_TIMEOUT_MS,
             remember: false,
             web_port: ClusterConf::DEFAULT_FUSE_WEB_PORT,
 

--- a/curvine-docker/deploy/example/conf/curvine-cluster.toml
+++ b/curvine-docker/deploy/example/conf/curvine-cluster.toml
@@ -38,7 +38,12 @@ master_addrs = [
 
 [fuse]
 debug = false
-
+# Kernel-side metadata cache timeouts (milliseconds).
+# BREAKING: the old second-based keys attr_timeout / entry_timeout /
+# negative_timeout were renamed to *_ms (value x1000) and are now ignored.
+attr_timeout_ms = 1000
+entry_timeout_ms = 1000
+negative_timeout_ms = 0
 
 [log]
 level = "info"

--- a/curvine-fuse/src/cli/mount_args.rs
+++ b/curvine-fuse/src/cli/mount_args.rs
@@ -78,14 +78,14 @@ pub struct FuseMountArgs {
     pub cache_readdir: Option<bool>,
 
     // Timeout settings
-    #[arg(long, help = "Entry timeout in seconds (optional)")]
-    pub entry_timeout: Option<f64>,
+    #[arg(long, help = "Entry timeout in milliseconds (optional)")]
+    pub entry_timeout_ms: Option<u64>,
 
-    #[arg(long, help = "Attribute timeout in seconds (optional)")]
-    pub attr_timeout: Option<f64>,
+    #[arg(long, help = "Attribute timeout in milliseconds (optional)")]
+    pub attr_timeout_ms: Option<u64>,
 
-    #[arg(long, help = "Negative timeout in seconds (optional)")]
-    pub negative_timeout: Option<f64>,
+    #[arg(long, help = "Negative timeout in milliseconds (optional)")]
+    pub negative_timeout_ms: Option<u64>,
 
     // Performance settings
     #[arg(long, help = "Max background operations (optional)")]
@@ -139,9 +139,6 @@ pub struct FuseMountArgs {
 
     #[arg(long, help = "Remember opened inodes across FUSE sessions (optional)")]
     pub remember: Option<bool>,
-
-    #[arg(long, help = "Auto-cache attr timeout in seconds (optional)")]
-    pub ac_attr_timeout: Option<f64>,
 
     #[arg(
         long,
@@ -232,16 +229,16 @@ impl FuseMountArgs {
             conf.fuse.cache_readdir = cache_readdir;
         }
 
-        if let Some(entry_timeout) = self.entry_timeout {
-            conf.fuse.entry_timeout = entry_timeout;
+        if let Some(entry_timeout_ms) = self.entry_timeout_ms {
+            conf.fuse.entry_timeout_ms = entry_timeout_ms;
         }
 
-        if let Some(attr_timeout) = self.attr_timeout {
-            conf.fuse.attr_timeout = attr_timeout;
+        if let Some(attr_timeout_ms) = self.attr_timeout_ms {
+            conf.fuse.attr_timeout_ms = attr_timeout_ms;
         }
 
-        if let Some(negative_timeout) = self.negative_timeout {
-            conf.fuse.negative_timeout = negative_timeout;
+        if let Some(negative_timeout_ms) = self.negative_timeout_ms {
+            conf.fuse.negative_timeout_ms = negative_timeout_ms;
         }
 
         if let Some(max_background) = self.max_background {
@@ -294,10 +291,6 @@ impl FuseMountArgs {
 
         if let Some(remember) = self.remember {
             conf.fuse.remember = remember;
-        }
-
-        if let Some(ac_attr_timeout) = self.ac_attr_timeout {
-            conf.fuse.ac_attr_timeout = ac_attr_timeout;
         }
 
         if let Some(list_limit) = self.list_limit {

--- a/etc/curvine-cluster.toml
+++ b/etc/curvine-cluster.toml
@@ -54,6 +54,14 @@ subnqn = "nqn.2024-01.io.curvine:subsystem2"
 
 # fuse configuration
 [fuse]
+# Kernel-side metadata cache timeouts (milliseconds).
+# NOTE: renamed in a breaking change — the old second-based f64 keys
+# (attr_timeout / entry_timeout / negative_timeout) are no longer recognized
+# and are silently ignored. Migrate by switching to the *_ms keys below and
+# multiplying the old value by 1000.
+attr_timeout_ms = 1000       # kernel attribute cache; 0 disables it
+entry_timeout_ms = 1000      # kernel dentry (name lookup) cache; 0 disables it
+negative_timeout_ms = 0      # negative-lookup (ENOENT) cache; 0 = disabled
 
 # The log configuration of the customer service side, and the customer service side of rust, java, and fuse use this log file.
 [log]


### PR DESCRIPTION
## Summary

Make the `FuseConf` kernel-cache timeout fields unit-explicit (seconds `f64` → milliseconds `u64`), remove two dead config-only fields, and default the userspace metadata cache on.

## Changes

| Area | Change |
|---|---|
| `curvine-common/src/conf/fuse_conf.rs` | Rename `attr_timeout`/`entry_timeout`/`negative_timeout` (`f64` seconds) → `*_ms` (`u64` milliseconds); `init()` uses `Duration::from_millis`; add `DEFAULT_NEGATIVE_TIMEOUT_MS`; default `enable_meta_cache = true`; drop dead `ac_attr_timeout` / `ac_attr_timeout_set` |
| `curvine-fuse/src/cli/mount_args.rs` | Rename CLI flags to `--*-timeout-ms`; remove `--ac-attr-timeout-ms` |
| `etc/curvine-cluster.toml`, `curvine-docker/deploy/example/conf/curvine-cluster.toml` | Document renamed keys in `[fuse]` templates |

## BREAKING CHANGE

The kernel-cache timeout fields are renamed and their unit changes from **seconds (f64)** to **milliseconds (u64)**:

```
attr_timeout     = 1.0  ->  attr_timeout_ms     = 1000
entry_timeout    = 1.0  ->  entry_timeout_ms    = 1000
negative_timeout = 0.0  ->  negative_timeout_ms = 0
```

The old keys are **no longer recognized and are silently ignored** (`FuseConf` is `#[serde(default)]` without `deny_unknown_fields`), so stale configs fall back to defaults. **No serde alias is added on purpose**: a second→millisecond alias would reinterpret an old value like `5.0` as `5ms` instead of `5000ms`, which is worse than a clean fallback. **Migrate by renaming to the `*_ms` keys and multiplying the old value by 1000.**

### Removed dead fields

`ac_attr_timeout` / `ac_attr_timeout_set` mirror libfuse's `auto_cache` mechanism. curvine-fuse talks the `/dev/fuse` protocol directly and never implements or reads them — they were config-only no-ops (like the previously removed `node_cache_size`). No migration needed.

## Test verified

- `cargo check -p curvine-common -p curvine-fuse` — passes
- `cargo fmt -p curvine-common -p curvine-fuse -- --check` — passes
- `cargo test -p curvine-common --lib conf::fuse_conf` — 7 passed
