### PR TITLE
refactor(fuse): enable userspace metadata cache by default

### DIFF
--- a/curvine-common/src/conf/fuse_conf.rs
+++ b/curvine-common/src/conf/fuse_conf.rs
@@ -375,7 +375,7 @@ impl Default for FuseConf {
             max_background: 256,
             congestion_threshold: 192,
 
-            enable_meta_cache: false,
+            enable_meta_cache: true,
             meta_cache_capacity: 100000,
             meta_cache_ttl: "120s".to_string(),
 


### PR DESCRIPTION
## Summary

Flip the default of `enable_meta_cache` from `false` to `true`, so mounts that do not explicitly configure it now use the userspace metadata cache.

This is intentionally a standalone, single-line change: the behavioral default flip is kept separate from any mechanical/config refactors so it can be evaluated, bisected, and reverted independently.

## Behavior change (user-visible)

Mounts without an explicit `enable_meta_cache` setting will now serve filesystem metadata (lookup / getattr / readdir, plus file blocks) from the userspace `MetaCache` instead of issuing an RPC to the master every time.

- **Staleness window:** up to `meta_cache_ttl` (default `120s`). A metadata change made by *another* client can take up to that long to become visible on a mount that has the entry cached.
- **Trade-off:** fewer master RPCs / lower metadata latency, at the cost of the freshness guarantee above.
- **Scope of the cache:** gated on `enable_meta_cache` at the real caching paths — `node_state.rs` (lookup/attr/blocks) and `curvine_file_system.rs` (getattr/readdir/lookup).

## How to revert to previous behavior

```toml
[fuse]
enable_meta_cache = false
```

## Consistency notes

- The cache is **bounded**: `meta_cache_capacity` (default 100000 entries).
- **Local** mutating operations invalidate the affected path synchronously (setattr, setxattr/removexattr, resize, mkdir, and the other write paths call `invalidate_cache`). The staleness window therefore applies to **cross-client** changes, not to writes issued through the same mount.

## Changes

| File | Change |
| --- | --- |
| `curvine-common/src/conf/fuse_conf.rs` | `Default::default()` for `FuseConf` sets `enable_meta_cache: true` (was `false`) |

## Open question for reviewers

Please confirm the metadata cache layer is considered **production-ready to be on by default**. If there are known correctness or eviction gaps, we can hold this PR and keep the opt-in default until they're resolved.
