### PR TITLE
fix(unified): preserve readonly cache error taxonomy (#896)

### DIFF
--- a/curvine-client/src/unified/unified_filesystem.rs
+++ b/curvine-client/src/unified/unified_filesystem.rs
@@ -152,7 +152,7 @@ impl UnifiedFileSystem {
         let state = self.mount_cache.get_mount(self, path).await?;
         if let Some(mnt) = state {
             if mnt.info.is_read_only_cache_mode() && Self::is_mount_write_rpc(rpc_code) {
-                return err_ext!(FsError::read_only(format!(
+                return err_ext!(FsError::unsupported(format!(
                     "{} on read_only cache_mode mount {}",
                     rpc_code, path
                 )));


### PR DESCRIPTION
# Summary

Restore the shared `UnifiedFileSystem` read-only cache-mode write guard to return `FsError::Unsupported`, preserving the pre-#1038 error taxonomy for non-FUSE callers.

FUSE readonly enforcement is unchanged: `curvine-fuse` still constructs `FsError::ReadOnly` in its write-side guard, and `curvine-fuse` maps that to POSIX `EROFS`.

# Issue Describe / Design

Related to #896 and follow-up to #1038.

Root cause: #1038 moved FUSE write-side enforcement into `curvine-fuse`, but also changed the shared `UnifiedFileSystem::get_mount` guard from `Unsupported` to `ReadOnly`. Since FUSE no longer depends on that shared guard for readonly EROFS, the shared path can keep its previous non-FUSE behavior.

Fix approach: restore `UnifiedFileSystem::get_mount` to return `FsError::Unsupported` for write RPCs on read-only cache-mode mounts. The FUSE layer continues to look up mount metadata with `RpcCode::FileStatus` and returns `FsError::ReadOnly` itself.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-client/src/unified/unified_filesystem.rs` | Restore read-only cache-mode write RPC guard from `FsError::ReadOnly` to `FsError::Unsupported`. | Preserves non-FUSE/shared API error taxonomy; FUSE `EROFS` behavior remains unchanged. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo fmt` | PASS | No additional formatting changes. |
| `git diff --check` | PASS | No whitespace issues. |

# Dependencies

- Related PRs: #1038
- Related issues: #896
- Blocks / blocked by: None