### PR TITLE
fix(client): make block client pool session-safe

### DIFF
--- a/curvine-client/src/block/block_client.rs
+++ b/curvine-client/src/block/block_client.rs
@@ -93,7 +93,13 @@ impl BlockClient {
 
     pub async fn rpc(&self, msg: Message) -> FsResult<Message> {
         let client = try_option_ref!(self.client);
-        let rep_msg = client.timeout_rpc(self.timeout, msg).await?;
+        let rep_msg = match client.timeout_rpc(self.timeout, msg).await {
+            Ok(rep_msg) => rep_msg,
+            Err(err) => {
+                client.set_closed();
+                return Err(FsError::from(err));
+            }
+        };
         match rep_msg.check_error_ext::<FsError>() {
             Ok(_) => Ok(rep_msg),
             Err(e) => Err(e.ctx(format!("rpc failed to worker {}", self.worker_addr))),

--- a/curvine-client/src/block/block_client.rs
+++ b/curvine-client/src/block/block_client.rs
@@ -85,6 +85,12 @@ impl BlockClient {
         self.uptime = LocalTime::mills();
     }
 
+    pub fn is_active(&self) -> bool {
+        self.client
+            .as_ref()
+            .is_some_and(|client| client.is_active())
+    }
+
     pub async fn rpc(&self, msg: Message) -> FsResult<Message> {
         let client = try_option_ref!(self.client);
         let rep_msg = client.timeout_rpc(self.timeout, msg).await?;

--- a/curvine-client/src/block/block_client_pool.rs
+++ b/curvine-client/src/block/block_client_pool.rs
@@ -112,12 +112,12 @@ impl BlockClientPool {
             let idle_duration = current_time.saturating_sub(client.uptime());
             self.cur_idle_size.decr();
 
-            if idle_duration < self.idle_time_ms {
+            if idle_duration < self.idle_time_ms && client.is_active() {
                 debug!("acquiring connection for worker {} from pool", addr);
                 return Ok(client);
             } else {
                 debug!(
-                    "connection for worker {} expired (idle={}ms), removing from pool",
+                    "connection for worker {} is inactive or expired (idle={}ms), removing from pool",
                     addr, idle_duration
                 );
                 client.clear_pool();
@@ -140,7 +140,13 @@ impl BlockClientPool {
             Some(pool) if pool.id == self.id => {
                 let addr = client.worker_addr().clone();
 
-                if self.cur_idle_size.get() >= self.max_idle_size {
+                if !client.is_active() {
+                    debug!(
+                        "connection for worker {} is closed, not returning to pool",
+                        client.worker_addr()
+                    );
+                    client.clear_pool();
+                } else if self.cur_idle_size.get() >= self.max_idle_size {
                     debug!(
                         "pool full(max={}), closing connection for worker {}",
                         self.max_idle_size,

--- a/curvine-client/src/block/block_reader_local.rs
+++ b/curvine-client/src/block/block_reader_local.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::block::BlockClient;
 use crate::file::FsContext;
 use bytes::BytesMut;
 use curvine_common::error::FsError;
@@ -26,7 +27,7 @@ use std::sync::Arc;
 
 pub struct BlockReaderLocal {
     rt: Arc<Runtime>,
-    fs_context: Arc<FsContext>,
+    client: BlockClient,
     os_cache: CacheManager,
     last_task: Option<ReadAheadTask>,
     block: ExtendedBlock,
@@ -69,7 +70,7 @@ impl BlockReaderLocal {
 
         let reader = Self {
             rt: fs_context.clone_runtime(),
-            fs_context: fs_context.clone(),
+            client,
             os_cache: fs_context.clone_os_cache(),
             last_task: None,
             block,
@@ -155,8 +156,7 @@ impl BlockReaderLocal {
     // Reading is completed and the server needs to be notified.
     pub async fn complete(&mut self) -> FsResult<()> {
         let next_seq_id = self.next_seq_id();
-        let client = self.fs_context.acquire_read(&self.worker_address).await?;
-        client
+        self.client
             .read_commit(&self.block, self.req_id, next_seq_id)
             .await?;
         Ok(())

--- a/curvine-client/src/block/block_writer_local.rs
+++ b/curvine-client/src/block/block_writer_local.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::block::BlockClient;
 use crate::file::FsContext;
 use curvine_common::error::FsError;
 use curvine_common::state::{ExtendedBlock, WorkerAddress};
@@ -25,7 +26,7 @@ use std::sync::Arc;
 
 pub struct BlockWriterLocal {
     rt: Arc<Runtime>,
-    fs_context: Arc<FsContext>,
+    client: BlockClient,
     block: ExtendedBlock,
     worker_address: WorkerAddress,
     file: RawPtr<LocalFile>,
@@ -64,7 +65,7 @@ impl BlockWriterLocal {
 
         let writer = Self {
             rt: fs_context.clone_runtime(),
-            fs_context,
+            client,
             block,
             worker_address,
             file: RawPtr::from_owned(file),
@@ -118,8 +119,7 @@ impl BlockWriterLocal {
     pub async fn complete(&mut self) -> FsResult<()> {
         self.flush().await?;
         let next_seq_id = self.next_seq_id();
-        let client = self.fs_context.acquire_write(&self.worker_address).await?;
-        client
+        self.client
             .write_commit(
                 &self.block,
                 self.pos(),
@@ -133,8 +133,7 @@ impl BlockWriterLocal {
 
     pub async fn cancel(&mut self) -> FsResult<()> {
         let next_seq_id = self.next_seq_id();
-        let client = self.fs_context.acquire_write(&self.worker_address).await?;
-        client
+        self.client
             .write_commit(
                 &self.block,
                 self.pos(),

--- a/curvine-server/src/worker/handler/batch_write_handler.rs
+++ b/curvine-server/src/worker/handler/batch_write_handler.rs
@@ -79,6 +79,7 @@ impl BatchWriteHandler {
         let mut responses = Vec::with_capacity(header.blocks.len());
         let mut files = Vec::with_capacity(header.blocks.len());
         let mut contexts = Vec::with_capacity(header.blocks.len());
+        self.is_commit = false;
 
         for (i, block_proto) in header.blocks.iter().cloned().enumerate() {
             let unique_req_id = msg.req_id() + i as i64;

--- a/curvine-server/src/worker/handler/write_handler.rs
+++ b/curvine-server/src/worker/handler/write_handler.rs
@@ -96,6 +96,7 @@ impl WriteHandler {
                 context.block_size
             );
         }
+        self.is_commit = false;
 
         let open_block = ExtendedBlock {
             len: context.block_size,

--- a/orpc/src/client/rpc_client.rs
+++ b/orpc/src/client/rpc_client.rs
@@ -95,9 +95,21 @@ impl RpcClient {
         let rep_msg = match &self.sender {
             BoxSender::Frame(f) => {
                 let frame = f.as_mut();
-                frame.send(msg).await?;
-                let msg = frame.receive().await?;
+                if let Err(e) = frame.send(msg).await {
+                    self.set_closed();
+                    return Err(e);
+                }
+
+                let msg = match frame.receive().await {
+                    Ok(msg) => msg,
+                    Err(e) => {
+                        self.set_closed();
+                        return Err(e);
+                    }
+                };
+
                 if msg.is_empty() {
+                    self.set_closed();
                     return err_box!("Connection {} is closed", self.state.conn_info());
                 } else {
                     msg


### PR DESCRIPTION
# Summary

Fix block client reuse so local block open/read-write/commit stays on the same worker connection, and prevent closed raw RPC connections from being returned to or reused by the block client pool.

# Issue Describe / Design

Related to client-side small-file block connection reuse.

- Root cause 1: local short-circuit block read/write opens a stateful worker-side block handler, but `complete`/`cancel` reacquired a block client from the pool. Under reuse, the commit could be sent on a different worker connection than the open request.
- Root cause 2: raw `RpcClient` returned `Connection ... is closed` on send/receive EOF without marking `ClientState` closed, so the pool could treat an EOF connection as active.
- Root cause 3: reused worker write handlers did not reset `is_commit` on a new open, so a reused handler could keep stale commit state.

Fix approach:
- Keep the `BlockClient` acquired during local block open inside `BlockReaderLocal`/`BlockWriterLocal` and use that same client for commit/cancel.
- Filter inactive clients when acquiring/releasing pooled block clients.
- Mark raw RPC clients closed on real send/receive errors and EOF.
- Reset worker write/batch-write commit state when a new block open starts.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-client/src/block/block_reader_local.rs` | Store the opened `BlockClient` and use it for read commit. | Preserves worker-side session affinity for local reads. |
| `curvine-client/src/block/block_writer_local.rs` | Store the opened `BlockClient` and use it for write commit/cancel. | Preserves worker-side session affinity for local writes. |
| `curvine-client/src/block/block_client_pool.rs` | Drop inactive pooled clients on acquire/release. | Prevents reuse of closed block connections. |
| `curvine-client/src/block/block_client.rs` | Expose active-state check from the underlying RPC client. | Enables pool health filtering. |
| `orpc/src/client/rpc_client.rs` | Mark raw RPC clients closed on send/receive error or EOF. | Keeps RPC state consistent with network reality. |
| `curvine-server/src/worker/handler/write_handler.rs` | Reset commit state on new write open. | Avoids stale state across reused worker handlers. |
| `curvine-server/src/worker/handler/batch_write_handler.rs` | Reset commit state on new batch write open. | Avoids stale state across reused batch handlers. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo fmt --check` | PASS | |
| `CARGO_TARGET_DIR=/tmp/curvine-client-pool-hotfix-target cargo build --release -p curvine-server -p curvine-client -p curvine-tests --jobs 2` | PASS | |
| `CARGO_TARGET_DIR=/tmp/curvine-client-pool-hotfix-target cargo clippy -p orpc -p curvine-client -p curvine-server --all-targets --jobs 2 -- --deny=warnings --allow clippy::uninlined-format-args` | PASS | |
| `git diff --check` | PASS | |
| Local E2E, pool enabled: `fs.write` 2048 files, 64 threads, 4KB files | PASS | Cold local cluster, `block_size_str=1MB`. |
| Local E2E, pool enabled: `fs.write` 4096 files, 64 threads, 4KB files | PASS | Warm local cluster. |
| Local E2E, pool enabled: `fs.read` 4096 files, 64 threads, 4KB files | PASS | Warm local cluster. |
| Local E2E, no-pool control: `fs.write`/`fs.read` 4096 files, 64 threads, 4KB files | PASS | Warm local cluster. |

Note: 4096-file cold-start writes can still hit local startup/connection pressure in this environment even with the block pool disabled; that is not caused by this pool-session fix and should be tracked separately.

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None
