### PR TITLE
fix(client): preserve per-file batch write outcomes (#1045)

### DIFF
--- a/curvine-client/src/block/batch_block_writer.rs
+++ b/curvine-client/src/block/batch_block_writer.rs
@@ -18,13 +18,36 @@ use crate::file::FsContext;
 use curvine_common::fs::Path;
 use curvine_common::state::{CommitBlock, ExtendedBlock, LocatedBlock, StorageType, WorkerAddress};
 use curvine_common::FsResult;
-use futures::future::try_join_all;
+use futures::future::join_all;
 use orpc::err_box;
 use std::sync::Arc;
 
 enum BatchWriterAdapter {
     BatchLocal(BatchBlockWriterLocal),
     BatchRemote(BatchBlockWriterRemote),
+}
+
+struct BatchWriterGroup {
+    writer: BatchWriterAdapter,
+    indices: Vec<usize>,
+}
+
+async fn cancel_writer_groups(fs_context: &FsContext, groups: &mut [BatchWriterGroup]) {
+    let futures = groups.iter_mut().map(|group| async move {
+        let worker = group.writer.worker_address().clone();
+        let cancels = vec![true; group.indices.len()];
+        (worker, group.writer.complete(&cancels).await)
+    });
+    for (worker, result) in join_all(futures).await {
+        if let Err(error) = result {
+            fs_context.add_failed_worker(&worker);
+            log::warn!(
+                "failed to cancel batch blocks on worker {}: {}",
+                worker,
+                error
+            );
+        }
+    }
 }
 
 impl BatchWriterAdapter {
@@ -35,24 +58,26 @@ impl BatchWriterAdapter {
         }
     }
 
-    async fn write(&mut self, files: &[(&Path, &str)]) -> FsResult<()> {
+    async fn write(&mut self, files: &[(&Path, &str)]) -> FsResult<Vec<bool>> {
         match self {
             BatchLocal(f) => f.write(files).await,
             BatchRemote(f) => f.write(files).await,
         }
     }
 
-    async fn flush(&mut self) -> FsResult<()> {
+    /// Client-side flush is only needed for short-circuit local writers.
+    /// Remote writers flush inside Worker `complete_block`, so this returns `None`.
+    async fn flush_active(&mut self, active: &[bool]) -> FsResult<Option<Vec<bool>>> {
         match self {
-            BatchLocal(f) => f.flush().await,
-            BatchRemote(f) => f.flush().await,
+            BatchLocal(f) => Ok(Some(f.flush_active(active).await?)),
+            BatchRemote(_) => Ok(None),
         }
     }
 
-    async fn complete(&mut self) -> FsResult<()> {
+    async fn complete(&mut self, cancels: &[bool]) -> FsResult<Vec<bool>> {
         match self {
-            BatchLocal(f) => f.complete().await,
-            BatchRemote(f) => f.complete().await,
+            BatchLocal(f) => f.complete(cancels).await,
+            BatchRemote(f) => f.complete(cancels).await,
         }
     }
 
@@ -61,7 +86,7 @@ impl BatchWriterAdapter {
         fs_context: Arc<FsContext>,
         located_blocks: &[LocatedBlock],
         worker_addr: &WorkerAddress,
-    ) -> FsResult<Self> {
+    ) -> FsResult<(Self, Vec<bool>)> {
         let conf = &fs_context.conf.client;
         // SPDK bypasses kernel — no local path. Disable short-circuit if any block uses SPDK.
         let has_spdk = located_blocks
@@ -71,127 +96,293 @@ impl BatchWriterAdapter {
             conf.short_circuit && fs_context.is_local_worker(worker_addr) && !has_spdk;
 
         let blocks: Vec<ExtendedBlock> = located_blocks.iter().map(|lb| lb.block.clone()).collect();
-        let adapter = if short_circuit {
-            let writer =
+        if short_circuit {
+            let (writer, results) =
                 BatchBlockWriterLocal::new(fs_context, blocks, worker_addr.clone(), 0).await?;
-            BatchLocal(writer)
+            Ok((BatchLocal(writer), results))
         } else {
-            let writer =
+            let (writer, results) =
                 BatchBlockWriterRemote::new(&fs_context, blocks, worker_addr.clone(), 0).await?;
-            BatchRemote(writer)
-        };
-
-        Ok(adapter)
+            Ok((BatchRemote(writer), results))
+        }
     }
 }
 
 pub struct BatchBlockWriter {
-    inners: Vec<BatchWriterAdapter>,
+    groups: Vec<BatchWriterGroup>,
     fs_context: Arc<FsContext>,
     located_blocks: Vec<LocatedBlock>,
-    file_lengths: Vec<i64>,
+    item_success: Vec<bool>,
 }
+
+fn group_blocks_by_worker(
+    located_blocks: &[LocatedBlock],
+) -> (Vec<(WorkerAddress, Vec<usize>)>, Vec<bool>) {
+    let mut item_success = vec![true; located_blocks.len()];
+    let mut worker_groups: Vec<(WorkerAddress, Vec<usize>)> = Vec::new();
+    for (index, located_block) in located_blocks.iter().enumerate() {
+        if located_block.locs.is_empty() {
+            item_success[index] = false;
+        }
+        for worker in &located_block.locs {
+            if let Some((_address, indices)) = worker_groups
+                .iter_mut()
+                .find(|(address, _indices)| address == worker)
+            {
+                indices.push(index);
+            } else {
+                worker_groups.push((worker.clone(), vec![index]));
+            }
+        }
+    }
+    (worker_groups, item_success)
+}
+
 impl BatchBlockWriter {
     /// Create multiple BlockWriters for batch operations  
     pub async fn new(
         fs_context: Arc<FsContext>,
-        located_blocks: Vec<LocatedBlock>, // all blocks have the same worker information
+        located_blocks: Vec<LocatedBlock>,
     ) -> FsResult<Self> {
         if located_blocks.is_empty() {
             return err_box!("No blocks provided");
         }
 
-        // Get the first block to extract worker information
-        let first_locate = located_blocks.first().unwrap();
+        let (worker_groups, mut item_success) = group_blocks_by_worker(&located_blocks);
 
-        if first_locate.locs.is_empty() {
-            return err_box!("There is no available worker");
+        let mut groups = Vec::with_capacity(worker_groups.len());
+        for (worker, indices) in worker_groups {
+            let blocks = indices
+                .iter()
+                .map(|index| located_blocks[*index].clone())
+                .collect::<Vec<_>>();
+            match BatchWriterAdapter::new(fs_context.clone(), &blocks, &worker).await {
+                Ok((writer, open_results)) => {
+                    for (index, success) in indices.iter().zip(open_results.iter()) {
+                        item_success[*index] &= *success;
+                    }
+                    groups.push(BatchWriterGroup { writer, indices });
+                }
+                Err(error) => {
+                    fs_context.add_failed_worker(&worker);
+                    log::warn!("batch open failed on worker {}: {}", worker, error);
+                    for index in indices {
+                        item_success[index] = false;
+                    }
+                }
+            }
         }
-
-        // Create adapters for each worker (same workers for all blocks)
-        let mut inners = Vec::with_capacity(first_locate.locs.len());
-        for addr in &first_locate.locs {
-            // Create a batch adapter that can handle multiple blocks
-            let adapter =
-                BatchWriterAdapter::new(fs_context.clone(), &located_blocks, addr).await?;
-            inners.push(adapter);
-        }
-        let num_of_blocks = located_blocks.len();
 
         Ok(Self {
-            inners,
+            groups,
             fs_context,
             located_blocks,
-            file_lengths: Vec::with_capacity(num_of_blocks),
+            item_success,
         })
     }
 
-    pub async fn write(&mut self, files: &[(&Path, &str)]) -> FsResult<()> {
-        // Store individual file lengths
-        for (_, content) in files {
-            self.file_lengths.push(content.len() as i64);
-        }
-        // Write each file separately to all writers with index
-        let futures = self.inners.iter_mut().map(|writer| async move {
-            writer
-                .write(files)
-                .await
-                .map_err(|e| (writer.worker_address().clone(), e))
-        });
-
-        if let Err((worker_addr, e)) = try_join_all(futures).await {
-            self.fs_context.add_failed_worker(&worker_addr);
-            return Err(e);
-        }
-
-        Ok(())
-    }
-
-    pub async fn flush(&mut self) -> FsResult<()> {
-        let futures = self.inners.iter_mut().map(|writer| async move {
-            writer
-                .flush()
-                .await
-                .map_err(|e| (writer.worker_address().clone(), e))
-        });
-
-        if let Err((worker_addr, e)) = try_join_all(futures).await {
-            self.fs_context.add_failed_worker(&worker_addr);
-            return Err(e);
-        }
-        Ok(())
-    }
-
-    /// Complete all writers and return commit blocks  
-    pub async fn complete(&mut self) -> FsResult<Vec<CommitBlock>> {
-        let futures = self.inners.iter_mut().map(|writer| async move {
-            writer
-                .complete()
-                .await
-                .map_err(|e| (writer.worker_address().clone(), e))
-        });
-
-        if let Err((worker_addr, e)) = try_join_all(futures).await {
-            self.fs_context.add_failed_worker(&worker_addr);
-            return Err(e);
-        }
-
-        Ok(self.to_commit_blocks())
-    }
-
-    pub fn to_commit_blocks(&self) -> Vec<CommitBlock> {
-        let mut commit_blocks = Vec::with_capacity(self.located_blocks.len());
-
-        for (i, located_block) in self.located_blocks.iter().enumerate() {
-            let mut commit_block = CommitBlock::from(located_block);
-
-            if let Some(&length) = self.file_lengths.get(i) {
-                commit_block.block_len = length;
+    fn merge_worker_results<FailedWorker>(
+        results: &mut [bool],
+        responses: Vec<(WorkerAddress, Vec<usize>, FsResult<Vec<bool>>)>,
+        operation: &str,
+        mut failed_worker: FailedWorker,
+    ) where
+        FailedWorker: FnMut(&WorkerAddress),
+    {
+        for (worker_addr, indices, response) in responses {
+            let worker_results = match response {
+                Ok(results) => results,
+                Err(error) => {
+                    failed_worker(&worker_addr);
+                    log::warn!(
+                        "batch {} failed on worker {}: {}",
+                        operation,
+                        worker_addr,
+                        error
+                    );
+                    for index in indices {
+                        results[index] = false;
+                    }
+                    continue;
+                }
+            };
+            if worker_results.len() != indices.len() {
+                failed_worker(&worker_addr);
+                log::warn!(
+                    "batch {} result count mismatch on worker {}, expected {}, actual {}",
+                    operation,
+                    worker_addr,
+                    indices.len(),
+                    worker_results.len()
+                );
+                for index in indices {
+                    results[index] = false;
+                }
+                continue;
             }
-
-            commit_blocks.push(commit_block);
+            for (index, worker_success) in indices.iter().zip(worker_results.iter()) {
+                results[*index] &= *worker_success;
+            }
         }
+    }
 
-        commit_blocks
+    async fn cancel_all(&mut self) {
+        cancel_writer_groups(&self.fs_context, &mut self.groups).await;
+        self.item_success.fill(false);
+    }
+
+    pub async fn write(&mut self, files: &[(&Path, &str)]) -> FsResult<()> {
+        if files.len() != self.located_blocks.len() {
+            let error = err_box!(
+                "batch write count mismatch, files={}, blocks={}",
+                files.len(),
+                self.located_blocks.len()
+            );
+            self.cancel_all().await;
+            return error;
+        }
+        for (located_block, (_, content)) in self.located_blocks.iter_mut().zip(files) {
+            located_block.block.len = content.len() as i64;
+        }
+        let futures = self.groups.iter_mut().map(|group| async move {
+            let worker_addr = group.writer.worker_address().clone();
+            let indices = group.indices.clone();
+            let worker_files = indices
+                .iter()
+                .map(|index| files[*index])
+                .collect::<Vec<_>>();
+            (
+                worker_addr,
+                indices,
+                group.writer.write(&worker_files).await,
+            )
+        });
+        let responses = join_all(futures).await;
+        let mut results = self.item_success.clone();
+        Self::merge_worker_results(&mut results, responses, "write", |worker| {
+            self.fs_context.add_failed_worker(worker)
+        });
+        self.item_success = results.clone();
+        Ok(())
+    }
+
+    /// Flush short-circuit local groups for still-active items, then AND results
+    /// back onto the original file indices. Remote groups are skipped.
+    async fn flush_active_local(&mut self) -> Vec<bool> {
+        let active = self.item_success.clone();
+        let futures = self.groups.iter_mut().map(|group| {
+            let worker_active = group
+                .indices
+                .iter()
+                .map(|index| active[*index])
+                .collect::<Vec<_>>();
+            async move {
+                let worker_addr = group.writer.worker_address().clone();
+                let indices = group.indices.clone();
+                match group.writer.flush_active(&worker_active).await {
+                    Ok(Some(results)) => Some((worker_addr, indices, Ok(results))),
+                    Ok(None) => None,
+                    Err(error) => Some((worker_addr, indices, Err(error))),
+                }
+            }
+        });
+        let responses = join_all(futures)
+            .await
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+        let mut results = self.item_success.clone();
+        Self::merge_worker_results(&mut results, responses, "flush", |worker| {
+            self.fs_context.add_failed_worker(worker)
+        });
+        results
+    }
+
+    pub async fn complete(&mut self) -> Vec<Option<CommitBlock>> {
+        let flushed = self.flush_active_local().await;
+        let cancels: Vec<bool> = flushed.iter().map(|success| !success).collect();
+        let futures = self.groups.iter_mut().map(|group| {
+            let worker_cancels = group
+                .indices
+                .iter()
+                .map(|index| cancels[*index])
+                .collect::<Vec<_>>();
+            async move {
+                let worker_addr = group.writer.worker_address().clone();
+                let indices = group.indices.clone();
+                (
+                    worker_addr,
+                    indices,
+                    group.writer.complete(&worker_cancels).await,
+                )
+            }
+        });
+        let responses = join_all(futures).await;
+        let mut results = flushed;
+        Self::merge_worker_results(&mut results, responses, "commit", |worker| {
+            self.fs_context.add_failed_worker(worker)
+        });
+        self.item_success = results.clone();
+        self.located_blocks
+            .iter()
+            .zip(results)
+            .map(|(block, success)| success.then(|| CommitBlock::from(block)))
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use curvine_common::state::FileType;
+
+    fn worker(worker_id: u32) -> WorkerAddress {
+        WorkerAddress {
+            worker_id,
+            ..Default::default()
+        }
+    }
+
+    fn block(id: i64, locs: Vec<WorkerAddress>) -> LocatedBlock {
+        LocatedBlock {
+            block: ExtendedBlock::new(id, 0, StorageType::Disk, FileType::File),
+            locs,
+        }
+    }
+
+    #[test]
+    fn groups_each_file_only_on_its_assigned_workers() {
+        let worker_1 = worker(1);
+        let worker_2 = worker(2);
+        let worker_3 = worker(3);
+        let blocks = vec![
+            block(1, vec![worker_1.clone(), worker_2.clone()]),
+            block(2, vec![worker_2.clone()]),
+            block(3, vec![worker_3.clone()]),
+            block(4, vec![]),
+        ];
+
+        let (groups, initial_results) = group_blocks_by_worker(&blocks);
+
+        assert_eq!(initial_results, vec![true, true, true, false]);
+        assert_eq!(groups.len(), 3);
+        assert_eq!(groups[0], (worker_1, vec![0]));
+        assert_eq!(groups[1], (worker_2, vec![0, 1]));
+        assert_eq!(groups[2], (worker_3, vec![2]));
+    }
+
+    #[test]
+    fn replica_results_are_anded_per_original_file() {
+        let worker_1 = worker(1);
+        let worker_2 = worker(2);
+        let mut results = vec![true, true, true];
+        let responses = vec![
+            (worker_1, vec![0, 1], Ok(vec![true, false])),
+            (worker_2, vec![0, 2], Ok(vec![false, true])),
+        ];
+
+        BatchBlockWriter::merge_worker_results(&mut results, responses, "test", |_| {});
+
+        assert_eq!(results, vec![false, false, true]);
     }
 }

--- a/curvine-client/src/block/batch_block_writer_local.rs
+++ b/curvine-client/src/block/batch_block_writer_local.rs
@@ -8,7 +8,6 @@ use orpc::common::Utils;
 use orpc::io::LocalFile;
 use orpc::runtime::{RpcRuntime, Runtime};
 use orpc::sys::RawPtr;
-use orpc::try_option;
 use std::sync::Arc;
 
 pub struct BatchBlockWriterLocal {
@@ -16,7 +15,7 @@ pub struct BatchBlockWriterLocal {
     blocks: Vec<ExtendedBlock>,
     worker_address: WorkerAddress,
     client: BlockClient,
-    files: Vec<RawPtr<LocalFile>>,
+    files: Vec<Option<RawPtr<LocalFile>>>,
     block_size: i64,
     pos: i64,
     req_id: i64,
@@ -28,13 +27,13 @@ impl BatchBlockWriterLocal {
         blocks: Vec<ExtendedBlock>,
         worker_address: WorkerAddress,
         pos: i64,
-    ) -> FsResult<Self> {
+    ) -> FsResult<(Self, Vec<bool>)> {
         let req_id = Utils::req_id();
         let block_size = fs_context.block_size();
         let client = fs_context.block_client(&worker_address).await?;
 
         // SINGLE RPC call to setup multiple blocks
-        let write_context = client
+        let write_context = match client
             .write_blocks_batch(
                 &blocks,
                 0,
@@ -44,32 +43,72 @@ impl BatchBlockWriterLocal {
                 fs_context.write_chunk_size() as i32,
                 true,
             )
-            .await?;
+            .await
+        {
+            Ok(context) => context,
+            Err(error) => {
+                let cancels = vec![true; blocks.len()];
+                if let Err(cancel_error) = client
+                    .write_commit_batch(&blocks, 0, block_size, req_id, 1, &cancels)
+                    .await
+                {
+                    log::warn!(
+                        "failed to cancel local batch blocks after open error: {}",
+                        cancel_error
+                    );
+                }
+                return Err(error);
+            }
+        };
 
-        // Create multiple files, one for each block context
-        let mut files = Vec::new();
-        for context in &write_context.contexts {
-            let path = try_option!(&context.path);
-            let file = LocalFile::with_write_offset(path, false, pos)?;
-            files.push(RawPtr::from_owned(file));
+        let mut files = Vec::with_capacity(write_context.len());
+        let mut results = Vec::with_capacity(write_context.len());
+        for result in write_context {
+            let file = match result {
+                Ok(context) => match context.path.as_deref() {
+                    Some(path) => match LocalFile::with_write_offset(path, false, pos) {
+                        Ok(file) => Some(RawPtr::from_owned(file)),
+                        Err(error) => {
+                            log::warn!("failed to open local batch file {}: {}", path, error);
+                            None
+                        }
+                    },
+                    None => {
+                        log::warn!("local batch open response is missing a file path");
+                        None
+                    }
+                },
+                Err(error) => {
+                    log::warn!("failed to open local batch block: {}", error);
+                    None
+                }
+            };
+            results.push(file.is_some());
+            files.push(file);
         }
 
-        Ok(Self {
-            rt: fs_context.clone_runtime(),
-            blocks,
-            worker_address,
-            client,
-            files,
-            block_size,
-            pos: 0,
-            req_id,
-        })
+        Ok((
+            Self {
+                rt: fs_context.clone_runtime(),
+                blocks,
+                worker_address,
+                client,
+                files,
+                block_size,
+                pos: 0,
+                req_id,
+            },
+            results,
+        ))
     }
 
     // SINGLE RPC call to complete all blocks
-    pub async fn complete(&mut self) -> FsResult<()> {
-        // flush before commit
-        self.flush().await?;
+    pub async fn complete(&mut self, cancels: &[bool]) -> FsResult<Vec<bool>> {
+        for (file, cancel) in self.files.iter_mut().zip(cancels.iter()) {
+            if *cancel {
+                file.take();
+            }
+        }
         self.client
             .write_commit_batch(
                 &self.blocks,
@@ -77,31 +116,62 @@ impl BatchBlockWriterLocal {
                 self.block_size,
                 self.req_id,
                 0,
-                false,
+                cancels,
             )
             .await
     }
 
-    pub async fn flush(&mut self) -> FsResult<()> {
-        for file in &mut self.files {
+    /// Flush only still-active short-circuit files before mixed commit/cancel.
+    /// Inactive or already-failed items are reported as `false` without flushing.
+    pub async fn flush_active(&mut self, active: &[bool]) -> FsResult<Vec<bool>> {
+        if active.len() != self.files.len() {
+            return orpc::err_box!(
+                "batch local flush count mismatch, active={}, files={}",
+                active.len(),
+                self.files.len()
+            );
+        }
+        let mut results = Vec::with_capacity(self.files.len());
+        for (file, active) in self.files.iter_mut().zip(active.iter()) {
+            let Some(file) = file else {
+                results.push(false);
+                continue;
+            };
+            if !active {
+                results.push(false);
+                continue;
+            }
             let file_clone = file.clone();
-            self.rt
+            let result = self
+                .rt
                 .spawn_blocking(move || {
                     file_clone.as_mut().flush()?;
                     Ok::<(), FsError>(())
                 })
-                .await??;
+                .await?;
+            results.push(result.is_ok());
         }
-        Ok(())
+        Ok(results)
     }
 
     pub fn worker_address(&self) -> &WorkerAddress {
         &self.worker_address
     }
 
-    pub async fn write(&mut self, files: &[(&Path, &str)]) -> FsResult<()> {
+    pub async fn write(&mut self, files: &[(&Path, &str)]) -> FsResult<Vec<bool>> {
+        if files.len() != self.files.len() {
+            return orpc::err_box!(
+                "batch local write count mismatch, request={}, files={}",
+                files.len(),
+                self.files.len()
+            );
+        }
+        let mut results = Vec::with_capacity(files.len());
         for (index, file) in files.iter().enumerate() {
-            let local_file = self.files[index].clone();
+            let Some(local_file) = self.files[index].clone() else {
+                results.push(false);
+                continue;
+            };
             let current_pos = file.1.len() as i64;
             let content_owned = file.1.to_string();
             let handle = self.rt.spawn_blocking(move || {
@@ -109,14 +179,13 @@ impl BatchBlockWriterLocal {
                 local_file.as_mut().write_all(&bytes_content)?;
                 Ok::<(), FsError>(())
             });
-            handle.await??;
-
-            // update length of block
-            if current_pos > self.blocks[index].len {
+            let result = handle.await?;
+            if result.is_ok() && current_pos > self.blocks[index].len {
                 self.blocks[index].len = current_pos;
             }
+            results.push(result.is_ok());
         }
 
-        Ok(())
+        Ok(results)
     }
 }

--- a/curvine-client/src/block/batch_block_writer_remote.rs
+++ b/curvine-client/src/block/batch_block_writer_remote.rs
@@ -18,7 +18,6 @@ use curvine_common::fs::Path;
 use curvine_common::state::{ExtendedBlock, WorkerAddress};
 use curvine_common::FsResult;
 use orpc::common::Utils;
-use orpc::err_box;
 
 pub struct BatchBlockWriterRemote {
     blocks: Vec<ExtendedBlock>,
@@ -36,33 +35,58 @@ impl BatchBlockWriterRemote {
         blocks: Vec<ExtendedBlock>,
         worker_address: WorkerAddress,
         pos: i64,
-    ) -> FsResult<Self> {
+    ) -> FsResult<(Self, Vec<bool>)> {
         let req_id = Utils::req_id();
         let seq_id = 0;
         let block_size = fs_context.block_size();
 
         let client = fs_context.block_client(&worker_address).await?;
-        let write_context = client
+        let write_context = match client
             .write_blocks_batch(
                 &blocks,
                 0,
                 block_size,
                 req_id,
-                fs_context.write_chunk_size() as i32,
+                seq_id,
                 fs_context.write_chunk_size() as i32,
                 false,
             )
-            .await?;
-
-        for context in &write_context.contexts {
-            if block_size != context.block_size {
-                return err_box!(
-                    "Abnormal block size, expected length {}, actual length {}",
-                    block_size,
-                    context.block_size
-                );
+            .await
+        {
+            Ok(context) => context,
+            Err(error) => {
+                let cancels = vec![true; blocks.len()];
+                if let Err(cancel_error) = client
+                    .write_commit_batch(&blocks, pos, block_size, req_id, seq_id + 1, &cancels)
+                    .await
+                {
+                    log::warn!(
+                        "failed to cancel remote batch blocks after open error: {}",
+                        cancel_error
+                    );
+                }
+                return Err(error);
             }
-        }
+        };
+
+        let open_results = write_context
+            .into_iter()
+            .map(|result| match result {
+                Ok(context) if block_size == context.block_size => true,
+                Ok(context) => {
+                    log::warn!(
+                        "abnormal batch block size, expected {}, actual {}",
+                        block_size,
+                        context.block_size
+                    );
+                    false
+                }
+                Err(error) => {
+                    log::warn!("failed to open remote batch block: {}", error);
+                    false
+                }
+            })
+            .collect();
 
         let writer = Self {
             blocks,
@@ -74,7 +98,7 @@ impl BatchBlockWriterRemote {
             block_size,
         };
 
-        Ok(writer)
+        Ok((writer, open_results))
     }
 
     fn next_seq_id(&mut self) -> i32 {
@@ -83,34 +107,25 @@ impl BatchBlockWriterRemote {
     }
 
     // Write data.
-    pub async fn write(&mut self, files: &[(&Path, &str)]) -> FsResult<()> {
+    pub async fn write(&mut self, files: &[(&Path, &str)]) -> FsResult<Vec<bool>> {
         let next_seq_id = self.next_seq_id();
 
-        // Send all files in one RPC call
-        self.client
+        let results = self
+            .client
             .write_files_batch(files, self.req_id, next_seq_id)
             .await?;
 
-        for (i, (_, content)) in files.iter().enumerate() {
-            if i < self.blocks.len() {
+        for (i, ((_, content), success)) in files.iter().zip(results.iter()).enumerate() {
+            if *success && i < self.blocks.len() {
                 let file_len = content.len() as i64;
                 self.blocks[i].len = file_len;
             }
         }
-        Ok(())
-    }
-
-    pub async fn flush(&mut self) -> FsResult<()> {
-        let next_seq_id = self.next_seq_id();
-        self.client
-            .write_flush(self.pos, self.req_id, next_seq_id)
-            .await?;
-
-        Ok(())
+        Ok(results)
     }
 
     // Write complete
-    pub async fn complete(&mut self) -> FsResult<()> {
+    pub async fn complete(&mut self, cancels: &[bool]) -> FsResult<Vec<bool>> {
         let next_seq_id = self.next_seq_id();
         self.client
             .write_commit_batch(
@@ -119,10 +134,9 @@ impl BatchBlockWriterRemote {
                 self.block_size,
                 self.req_id,
                 next_seq_id,
-                false,
+                cancels,
             )
-            .await?;
-        Ok(())
+            .await
     }
 
     pub fn worker_address(&self) -> &WorkerAddress {

--- a/curvine-client/src/block/block_client.rs
+++ b/curvine-client/src/block/block_client.rs
@@ -14,9 +14,7 @@
 
 #![allow(clippy::too_many_arguments)]
 
-use crate::block::{
-    BlockClientPool, BlockReadContext, CreateBatchBlockContext, CreateBlockContext,
-};
+use crate::block::{BlockClientPool, BlockReadContext, CreateBlockContext};
 use crate::file::FsContext;
 use curvine_common::conf::ClientConf;
 use curvine_common::error::FsError;
@@ -24,14 +22,16 @@ use curvine_common::fs::Path;
 use curvine_common::fs::RpcCode;
 use curvine_common::proto::{
     BlockReadRequest, BlockReadResponse, BlockWriteRequest, BlockWriteResponse,
-    BlocksBatchCommitRequest, BlocksBatchWriteRequest, BlocksBatchWriteResponse, DataHeaderProto,
-    FileWriteData, FilesBatchWriteRequest,
+    BlocksBatchCommitRequest, BlocksBatchCommitResponse, BlocksBatchWriteRequest,
+    BlocksBatchWriteResponse, DataHeaderProto, FileWriteData, FilesBatchWriteRequest,
+    FilesBatchWriteResponse,
 };
 use curvine_common::state::{ExtendedBlock, StorageType, WorkerAddress};
 use curvine_common::utils::ProtoUtils;
 use curvine_common::FsResult;
 use orpc::client::RpcClient;
 use orpc::common::LocalTime;
+use orpc::err_box;
 use orpc::error::ErrorExt;
 use orpc::message::{Builder, Message, RequestStatus};
 use orpc::sys::DataSlice;
@@ -46,6 +46,18 @@ pub struct BlockClient {
     pool: Option<Arc<BlockClientPool>>,
     worker_addr: WorkerAddress,
     uptime: u64,
+}
+
+fn check_batch_result_count(kind: &str, expected: usize, actual: usize) -> FsResult<()> {
+    if actual != expected {
+        return err_box!(
+            "Batch {} result count mismatch, expected {}, actual {}",
+            kind,
+            expected,
+            actual
+        );
+    }
+    Ok(())
 }
 
 impl BlockClient {
@@ -319,7 +331,7 @@ impl BlockClient {
         seq_id: i32,
         chunk_size: i32,
         short_circuit: bool,
-    ) -> FsResult<CreateBatchBlockContext> {
+    ) -> FsResult<Vec<Result<CreateBlockContext, String>>> {
         let blocks_pb: Vec<_> = blocks
             .iter()
             .map(|block| ProtoUtils::extend_block_to_pb(block.clone()))
@@ -346,20 +358,23 @@ impl BlockClient {
 
         let rep = self.rpc(msg).await?;
         let rep_header: BlocksBatchWriteResponse = rep.parse_header()?;
-        let mut batch_context = CreateBatchBlockContext::new(req_id);
-
-        for response in rep_header.responses {
-            let context = CreateBlockContext {
-                id: response.id,
-                off: response.off,
-                block_size: response.block_size,
-                storage_type: StorageType::from(response.storage_type),
-                path: response.path,
-            };
-            batch_context.push(context);
-        }
-
-        Ok(batch_context)
+        check_batch_result_count("open", blocks.len(), rep_header.results.len())?;
+        Ok(rep_header
+            .results
+            .into_iter()
+            .map(|result| match result.response {
+                Some(response) => Ok(CreateBlockContext {
+                    id: response.id,
+                    off: response.off,
+                    block_size: response.block_size,
+                    storage_type: StorageType::from(response.storage_type),
+                    path: response.path,
+                }),
+                None => Err(result
+                    .error
+                    .unwrap_or_else(|| "batch open failed without an error".to_string())),
+            })
+            .collect())
     }
 
     pub async fn write_commit_batch(
@@ -369,14 +384,21 @@ impl BlockClient {
         block_size: i64,
         req_id: i64,
         seq_id: i32,
-        cancel: bool,
-    ) -> FsResult<()> {
-        // Convert blocks to protobuf
-        let blocks_pb: Vec<_> = blocks
+        cancels: &[bool],
+    ) -> FsResult<Vec<bool>> {
+        if blocks.len() != cancels.len() {
+            return err_box!(
+                "Batch commit action count mismatch, blocks={}, cancels={}",
+                blocks.len(),
+                cancels.len()
+            );
+        }
+        let blocks_pb = blocks
             .iter()
-            .map(|block| ProtoUtils::extend_block_to_pb(block.clone()))
+            .cloned()
+            .map(ProtoUtils::extend_block_to_pb)
             .collect();
-
+        let cancel = cancels.iter().all(|cancel| *cancel);
         let header = BlocksBatchCommitRequest {
             blocks: blocks_pb,
             off,
@@ -384,8 +406,8 @@ impl BlockClient {
             req_id,
             seq_id,
             cancel,
+            cancel_flags: cancels.to_vec(),
         };
-
         let status = if cancel {
             RequestStatus::Cancel
         } else {
@@ -400,8 +422,10 @@ impl BlockClient {
             .proto_header(header)
             .build();
 
-        let _ = self.rpc(msg).await?;
-        Ok(())
+        let response = self.rpc(msg).await?;
+        let response: BlocksBatchCommitResponse = response.parse_header()?;
+        check_batch_result_count("commit", blocks.len(), response.results.len())?;
+        Ok(response.results)
     }
 
     pub async fn write_files_batch(
@@ -409,7 +433,7 @@ impl BlockClient {
         files: &[(&Path, &str)],
         req_id: i64,
         seq_id: i32,
-    ) -> CommonResult<()> {
+    ) -> FsResult<Vec<bool>> {
         let file_data: Vec<_> = files
             .iter()
             .map(|(path, content)| FileWriteData {
@@ -432,8 +456,10 @@ impl BlockClient {
             .proto_header(header)
             .build();
 
-        let _ = self.rpc(msg).await?;
-        Ok(())
+        let response = self.rpc(msg).await?;
+        let response: FilesBatchWriteResponse = response.parse_header()?;
+        check_batch_result_count("write", files.len(), response.results.len())?;
+        Ok(response.results)
     }
 }
 

--- a/curvine-client/src/block/context.rs
+++ b/curvine-client/src/block/context.rs
@@ -40,29 +40,3 @@ impl BlockReadContext {
         }
     }
 }
-
-pub struct CreateBatchBlockContext {
-    pub contexts: Vec<CreateBlockContext>,
-    pub batch_id: i64,
-}
-
-impl CreateBatchBlockContext {
-    pub fn new(batch_id: i64) -> Self {
-        Self {
-            contexts: Vec::new(),
-            batch_id,
-        }
-    }
-
-    pub fn push(&mut self, context: CreateBlockContext) {
-        self.contexts.push(context);
-    }
-
-    pub fn len(&self) -> usize {
-        self.contexts.len()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.contexts.is_empty()
-    }
-}

--- a/curvine-client/src/file/curvine_filesystem.rs
+++ b/curvine-client/src/file/curvine_filesystem.rs
@@ -13,7 +13,10 @@
 // limitations under the License.
 
 use crate::block::BatchBlockWriter;
-use crate::file::{FsClient, FsContext, FsReader, FsWriter, FsWriterBase};
+use crate::file::{
+    BatchAddBlockRequest, BatchCompleteFileRequest, FsClient, FsContext, FsReader, FsWriter,
+    FsWriterBase,
+};
 use crate::ClientMetrics;
 use async_stream::stream;
 use bytes::BytesMut;
@@ -21,11 +24,11 @@ use curvine_common::alloc::allocator_type_name;
 use curvine_common::conf::ClusterConf;
 use curvine_common::error::FsError;
 use curvine_common::fs::{FileSystem, FsKind, ListStream, Path, Reader, Writer};
-use curvine_common::state::{CommitBlock, FreeResult, ListOptions};
 use curvine_common::state::{
     CreateFileOpts, CreateFileOptsBuilder, FileAllocOpts, FileBlocks, FileLock, FileStatus,
     MasterInfo, MkdirOpts, MkdirOptsBuilder, MountInfo, MountOptions, OpenFlags, SetAttrOpts,
 };
+use curvine_common::state::{FreeResult, ListOptions};
 use curvine_common::utils::ProtoUtils;
 use curvine_common::version::GIT_VERSION;
 use curvine_common::FsResult;
@@ -42,6 +45,13 @@ use tokio::time::timeout;
 pub struct CurvineFileSystem {
     pub(crate) fs_context: Arc<FsContext>,
     pub(crate) fs_client: Arc<FsClient>,
+}
+
+struct BatchFileItem<'a> {
+    index: usize,
+    path: &'a Path,
+    content: &'a str,
+    inode_id: i64,
 }
 
 impl CurvineFileSystem {
@@ -390,45 +400,94 @@ impl CurvineFileSystem {
         }
     }
 
-    pub async fn write_batch_string(&self, files: &[(Path, &str)]) -> FsResult<()> {
+    pub async fn write_batch_string(&self, files: &[(Path, &str)]) -> FsResult<Vec<FsResult<()>>> {
         let chunk_size = self.fs_context().write_chunk_size();
         let mut batch = Vec::with_capacity(files.len());
         let mut batch_memory = 0;
+        let mut results: Vec<Option<FsResult<()>>> =
+            std::iter::repeat_with(|| None).take(files.len()).collect();
 
-        for (path, content) in files.iter() {
+        for (index, (path, content)) in files.iter().enumerate() {
             let content_size: usize = content.len();
 
             if content_size >= chunk_size {
-                self.write_string(path, content.to_string()).await?;
+                if !batch.is_empty() {
+                    self.collect_batch_file_results(&batch, &mut results).await;
+                    batch.clear();
+                    batch_memory = 0;
+                }
+                results[index] = Some(self.write_string(path, *content).await);
                 continue;
             }
 
             if batch_memory + content_size > chunk_size {
-                self.handle_batch_files(&batch).await?;
+                self.collect_batch_file_results(&batch, &mut results).await;
                 batch.clear();
                 batch_memory = 0;
             }
 
-            batch.push((path, content));
+            batch.push((index, path, *content));
             batch_memory += content_size;
         }
 
-        // Final flush
         if !batch.is_empty() {
-            self.handle_batch_files(&batch).await?;
+            self.collect_batch_file_results(&batch, &mut results).await;
         }
 
-        Ok(())
+        Ok(results
+            .into_iter()
+            .enumerate()
+            .map(|(index, result)| {
+                result.unwrap_or_else(|| {
+                    Err(FsError::common(format!(
+                        "missing batch write outcome for {} at index {}",
+                        files[index].0.encode(),
+                        index
+                    )))
+                })
+            })
+            .collect())
     }
 
-    async fn handle_batch_files(&self, files: &[(&Path, &str)]) -> FsResult<()> {
+    async fn collect_batch_file_results(
+        &self,
+        files: &[(usize, &Path, &str)],
+        outcomes: &mut [Option<FsResult<()>>],
+    ) {
+        let Err(error) = self.handle_batch_files(files, outcomes).await else {
+            return;
+        };
+        let error = error.to_string();
+        Self::record_batch_file_error(files, outcomes, &error);
+    }
+
+    fn record_batch_file_error(
+        files: &[(usize, &Path, &str)],
+        outcomes: &mut [Option<FsResult<()>>],
+        error: &str,
+    ) {
+        for (index, path, _content) in files {
+            if outcomes[*index].is_none() {
+                outcomes[*index] = Some(Err(FsError::common(format!(
+                    "failed to write batch file {}: {}",
+                    path.encode(),
+                    error
+                ))));
+            }
+        }
+    }
+
+    async fn handle_batch_files(
+        &self,
+        files: &[(usize, &Path, &str)],
+        outcomes: &mut [Option<FsResult<()>>],
+    ) -> FsResult<()> {
         if files.is_empty() {
             return Ok(());
         }
 
-        // Step 1: Batch create files
         let mut create_requests = Vec::with_capacity(files.len());
-        for (path, _) in files {
+        for (_index, path, _content) in files {
             let opts = self.create_opts_builder().create_parent(true).build();
             let flags = OpenFlags::new_write_only()
                 .set_create(true)
@@ -436,44 +495,110 @@ impl CurvineFileSystem {
             create_requests.push((path.encode(), opts, flags));
         }
 
-        let file_statuses = self.fs_client().create_files_batch(create_requests).await?;
-
-        // Step 2: Batch allocate blocks
-        let mut add_block_requests = Vec::with_capacity(file_statuses.len());
-        for ((path, _content), _status) in files.iter().zip(file_statuses.iter()) {
-            add_block_requests.push(path.encode());
+        let create_results = self.fs_client().create_files_batch(create_requests).await?;
+        let mut created = Vec::new();
+        for ((index, path, content), result) in files.iter().zip(create_results.into_iter()) {
+            match result {
+                Ok(status) => created.push(BatchFileItem {
+                    index: *index,
+                    path,
+                    content,
+                    inode_id: status.id,
+                }),
+                Err(error) => {
+                    outcomes[*index] = Some(Err(FsError::common(format!(
+                        "failed to create batch file {}: {}",
+                        path.encode(),
+                        error
+                    ))));
+                }
+            }
+        }
+        if created.is_empty() {
+            return Ok(());
         }
 
-        let allocated_blocks: Vec<curvine_common::state::LocatedBlock> = self
+        let add_block_requests = created
+            .iter()
+            .map(|item| BatchAddBlockRequest {
+                path: item.path.encode(),
+                inode_id: item.inode_id,
+            })
+            .collect();
+        let add_results = self
             .fs_client()
             .add_blocks_batch(add_block_requests)
             .await?;
-
-        // The allocated blocks should correspond to the add_block_requests sent above.
-        let mut batch_writer =
-            BatchBlockWriter::new(self.fs_context.clone(), allocated_blocks).await?;
-
-        // Write all data (no flushing yet)
-        batch_writer.write(files).await?;
-
-        // Step 4: Complete all files at worker side
-        let commit_blocks = batch_writer.complete().await?;
-
-        // Step 5: Batch complete at master side
-        let mut complete_requests: Vec<(String, i64, Vec<CommitBlock>, String, bool)> =
-            Vec::with_capacity(files.len());
-        for ((path, content), commit_block) in files.iter().zip(commit_blocks.iter()) {
-            complete_requests.push((
-                path.encode(),
-                content.len() as i64,
-                vec![commit_block.clone()],
-                self.fs_context().clone_client_name(),
-                false,
-            ));
+        let mut worker_items = Vec::new();
+        let mut located_blocks = Vec::new();
+        for (item, result) in created.into_iter().zip(add_results.into_iter()) {
+            match result {
+                Ok(block) => {
+                    worker_items.push(item);
+                    located_blocks.push(block);
+                }
+                Err(error) => {
+                    outcomes[item.index] = Some(Err(FsError::common(format!(
+                        "failed to allocate block for {}: {}",
+                        item.path.encode(),
+                        error
+                    ))));
+                }
+            }
         }
-        self.fs_client()
+        if worker_items.is_empty() {
+            return Ok(());
+        }
+
+        let worker_files: Vec<(&Path, &str)> = worker_items
+            .iter()
+            .map(|item| (item.path, item.content))
+            .collect();
+        let mut batch_writer =
+            BatchBlockWriter::new(self.fs_context.clone(), located_blocks).await?;
+        batch_writer.write(&worker_files).await?;
+        let worker_results = batch_writer.complete().await;
+
+        let mut complete_requests = Vec::new();
+        let mut complete_indices = Vec::new();
+        for (item, commit_block) in worker_items.iter().zip(worker_results.into_iter()) {
+            match commit_block {
+                Some(commit_block) => {
+                    complete_requests.push(BatchCompleteFileRequest {
+                        path: item.path.encode(),
+                        inode_id: item.inode_id,
+                        len: item.content.len() as i64,
+                        commit_blocks: vec![commit_block],
+                        client_name: self.fs_context().clone_client_name(),
+                        only_flush: false,
+                    });
+                    complete_indices.push((item.index, item.path));
+                }
+                None => {
+                    outcomes[item.index] = Some(Err(FsError::common(format!(
+                        "failed to complete worker blocks for {}",
+                        item.path.encode()
+                    ))));
+                }
+            }
+        }
+        if complete_requests.is_empty() {
+            return Ok(());
+        }
+
+        let complete_results = self
+            .fs_client()
             .complete_files_batch(complete_requests)
             .await?;
+        for ((index, path), result) in complete_indices.into_iter().zip(complete_results) {
+            outcomes[index] = Some(result.map_err(|error| {
+                FsError::common(format!(
+                    "failed to complete batch file {}: {}",
+                    path.encode(),
+                    error
+                ))
+            }));
+        }
         Ok(())
     }
 }
@@ -542,5 +667,40 @@ impl FileSystem<FsWriter, FsReader> for CurvineFileSystem {
 
     async fn list_stream(&self, path: &Path, opts: ListOptions) -> FsResult<ListStream> {
         self.list_stream(path, opts).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn batch_error_preserves_results_from_other_items() {
+        let item_error = Path::from("/item-error");
+        let batch_error = Path::from("/batch-error");
+        let files = [(1, &item_error, "b"), (2, &batch_error, "c")];
+        let mut outcomes = vec![
+            Some(Ok(())),
+            Some(Err(FsError::common("specific item error"))),
+            None,
+        ];
+
+        CurvineFileSystem::record_batch_file_error(&files, &mut outcomes, "worker unavailable");
+
+        assert!(outcomes[0].as_ref().unwrap().is_ok());
+        assert!(outcomes[1]
+            .as_ref()
+            .unwrap()
+            .as_ref()
+            .unwrap_err()
+            .to_string()
+            .contains("specific item error"));
+        assert!(outcomes[2]
+            .as_ref()
+            .unwrap()
+            .as_ref()
+            .unwrap_err()
+            .to_string()
+            .contains("worker unavailable"));
     }
 }

--- a/curvine-client/src/file/fs_client.rs
+++ b/curvine-client/src/file/fs_client.rs
@@ -29,6 +29,20 @@ use prost::Message as PMessage;
 use std::collections::LinkedList;
 use std::sync::Arc;
 
+pub struct BatchAddBlockRequest {
+    pub path: String,
+    pub inode_id: i64,
+}
+
+pub struct BatchCompleteFileRequest {
+    pub path: String,
+    pub inode_id: i64,
+    pub len: i64,
+    pub commit_blocks: Vec<CommitBlock>,
+    pub client_name: String,
+    pub only_flush: bool,
+}
+
 #[derive(Clone)]
 pub struct FsClient {
     context: Arc<FsContext>,
@@ -75,7 +89,8 @@ impl FsClient {
     pub async fn create_files_batch(
         &self,
         requests: Vec<(String, CreateFileOpts, OpenFlags)>,
-    ) -> FsResult<Vec<FileStatus>> {
+    ) -> FsResult<Vec<Result<FileStatus, String>>> {
+        let expected = requests.len();
         let pb_requests: Vec<CreateFileRequest> = requests
             .into_iter()
             .map(|(path, opts, flags)| CreateFileRequest {
@@ -90,10 +105,26 @@ impl FsClient {
         };
 
         let rep: CreateFilesBatchResponse = self.rpc(RpcCode::CreateFilesBatch, header).await?;
+        if rep.results.len() != expected {
+            return err_box!(
+                "create batch result count mismatch, expected {}, actual {}",
+                expected,
+                rep.results.len()
+            );
+        }
         Ok(rep
-            .file_statuses
+            .results
             .into_iter()
-            .map(ProtoUtils::file_status_from_pb)
+            .map(|result| {
+                result
+                    .file_status
+                    .map(ProtoUtils::file_status_from_pb)
+                    .ok_or_else(|| {
+                        result
+                            .error
+                            .unwrap_or_else(|| "create file failed".to_string())
+                    })
+            })
             .collect())
     }
 
@@ -321,20 +352,24 @@ impl FsClient {
         Ok(locate_block)
     }
 
-    pub async fn add_blocks_batch(&self, requests: Vec<String>) -> FsResult<Vec<LocatedBlock>> {
+    pub async fn add_blocks_batch(
+        &self,
+        requests: Vec<BatchAddBlockRequest>,
+    ) -> FsResult<Vec<Result<LocatedBlock, String>>> {
+        let expected = requests.len();
         let pb_requests: Vec<AddBlockRequest> = requests
             .into_iter()
-            .map(|path| {
+            .map(|request| {
                 let commit_blocks: Vec<CommitBlockProto> = Vec::new();
                 AddBlockRequest {
-                    path,
+                    path: request.path,
                     commit_blocks,
                     exclude_workers: self.context.exclude_workers(),
                     located: true,
                     client_address: self.context.client_addr_pb(),
                     file_len: 0,
                     last_block: None,
-                    inode_id: None,
+                    inode_id: Some(request.inode_id),
                 }
             })
             .collect();
@@ -343,10 +378,26 @@ impl FsClient {
             requests: pb_requests,
         };
         let rep: AddBlocksBatchResponse = self.rpc(RpcCode::AddBlocksBatch, header).await?;
+        if rep.results.len() != expected {
+            return err_box!(
+                "add block batch result count mismatch, expected {}, actual {}",
+                expected,
+                rep.results.len()
+            );
+        }
         Ok(rep
-            .blocks
+            .results
             .into_iter()
-            .map(ProtoUtils::located_block_from_pb)
+            .map(|result| {
+                result
+                    .block
+                    .map(ProtoUtils::located_block_from_pb)
+                    .ok_or_else(|| {
+                        result
+                            .error
+                            .unwrap_or_else(|| "add block failed".to_string())
+                    })
+            })
             .collect())
     }
 
@@ -403,22 +454,24 @@ impl FsClient {
 
     pub async fn complete_files_batch(
         &self,
-        requests: Vec<(String, i64, Vec<CommitBlock>, String, bool)>,
-    ) -> FsResult<Vec<bool>> {
+        requests: Vec<BatchCompleteFileRequest>,
+    ) -> FsResult<Vec<Result<(), String>>> {
+        let expected = requests.len();
         let pb_requests: Vec<CompleteFileRequest> = requests
             .into_iter()
-            .map(|(path, len, commit_blocks, client_name, only_flush)| {
-                let commit_blocks = commit_blocks
+            .map(|request| {
+                let commit_blocks = request
+                    .commit_blocks
                     .into_iter()
                     .map(ProtoUtils::commit_block_to_pb)
                     .collect();
                 CompleteFileRequest {
-                    path,
-                    len,
-                    client_name,
+                    path: request.path,
+                    len: request.len,
+                    client_name: request.client_name,
                     commit_blocks,
-                    only_flush,
-                    inode_id: None,
+                    only_flush: request.only_flush,
+                    inode_id: Some(request.inode_id),
                 }
             })
             .collect();
@@ -428,7 +481,26 @@ impl FsClient {
         };
 
         let rep: CompleteFilesBatchResponse = self.rpc(RpcCode::CompleteFilesBatch, header).await?;
-        Ok(rep.results)
+        if rep.details.len() != expected {
+            return err_box!(
+                "complete batch result count mismatch, expected {}, actual {}",
+                expected,
+                rep.details.len()
+            );
+        }
+        Ok(rep
+            .details
+            .into_iter()
+            .map(|result| {
+                if result.success {
+                    Ok(())
+                } else {
+                    Err(result
+                        .error
+                        .unwrap_or_else(|| "complete file failed".to_string()))
+                }
+            })
+            .collect())
     }
 
     pub async fn get_block_locations(&self, path: &Path) -> FsResult<FileBlocks> {

--- a/curvine-client/src/file/mod.rs
+++ b/curvine-client/src/file/mod.rs
@@ -16,7 +16,7 @@ mod curvine_filesystem;
 pub use self::curvine_filesystem::*;
 
 mod fs_client;
-pub use self::fs_client::FsClient;
+pub use self::fs_client::{BatchAddBlockRequest, BatchCompleteFileRequest, FsClient};
 
 mod fs_writer_base;
 pub use self::fs_writer_base::FsWriterBase;

--- a/curvine-common/proto/master.proto
+++ b/curvine-common/proto/master.proto
@@ -59,17 +59,29 @@ message CreateFileResponse {
 message CreateFilesBatchRequest {  
     repeated CreateFileRequest requests = 1;  
 }  
-  
+
+message CreateFileBatchResult {
+    optional FileStatusProto file_status = 1;
+    optional string error = 2;
+}
+
 message CreateFilesBatchResponse {  
-    repeated FileStatusProto file_statuses = 1;  
+    repeated FileStatusProto file_statuses = 1;
+    repeated CreateFileBatchResult results = 2;
 }  
-  
+
 message CompleteFilesBatchRequest {  
     repeated CompleteFileRequest requests = 1;  
-}  
-  
-message CompleteFilesBatchResponse {  
-    repeated bool results = 1;  
+}
+
+message CompleteFileBatchResult {
+    required bool success = 1;
+    optional string error = 2;
+}
+
+message CompleteFilesBatchResponse {
+    repeated bool results = 1;
+    repeated CompleteFileBatchResult details = 2;
 }
 
 message OpenFileRequest {
@@ -156,10 +168,16 @@ message AddBlockResponse {
 // apply for allocation of blocks batch
 message AddBlocksBatchRequest {  
     repeated AddBlockRequest requests = 1;  
-}  
-  
-message AddBlocksBatchResponse {  
-    repeated LocatedBlockProto blocks = 1;  
+}
+
+message AddBlockBatchResult {
+    optional LocatedBlockProto block = 1;
+    optional string error = 2;
+}
+
+message AddBlocksBatchResponse {
+    repeated LocatedBlockProto blocks = 1;
+    repeated AddBlockBatchResult results = 2;
 }
 
 message RequestReplacementWorkerRequest {

--- a/curvine-common/proto/worker.proto
+++ b/curvine-common/proto/worker.proto
@@ -149,6 +149,12 @@ message BlocksBatchWriteRequest {
 
 message BlocksBatchWriteResponse {
     repeated BlockWriteResponse responses = 1;
+    repeated BlockBatchOpenResult results = 2;
+}
+
+message BlockBatchOpenResult {
+    optional BlockWriteResponse response = 1;
+    optional string error = 2;
 }
 
 message BlocksBatchCommitRequest {
@@ -158,6 +164,7 @@ message BlocksBatchCommitRequest {
     required int64 req_id = 4;
     required int32 seq_id = 5;
     required bool cancel = 6;
+    repeated bool cancel_flags = 7;
 }
 
 message BlocksBatchCommitResponse {

--- a/curvine-server/src/master/master_handler.rs
+++ b/curvine-server/src/master/master_handler.rs
@@ -366,15 +366,25 @@ impl MasterHandler {
 
             // Generate unique req_id for each file in batch
             let unique_req_id = ctx.msg.req_id() + index as i64;
-            let status = self.create_file0(unique_req_id, req.path, opts, flags)?;
-            results.push(status);
+            let result = match self.create_file0(unique_req_id, req.path, opts, flags) {
+                Ok(status) => {
+                    let status = ProtoUtils::file_status_to_pb(status);
+                    CreateFileBatchResult {
+                        file_status: Some(status),
+                        error: None,
+                    }
+                }
+                Err(error) => CreateFileBatchResult {
+                    file_status: None,
+                    error: Some(error.to_string()),
+                },
+            };
+            results.push(result);
         }
 
         let rep_header = CreateFilesBatchResponse {
-            file_statuses: results
-                .into_iter()
-                .map(ProtoUtils::file_status_to_pb)
-                .collect(),
+            file_statuses: Vec::new(),
+            results,
         };
         ctx.response_buf(rep_header, &mut self.buf)
     }
@@ -392,7 +402,7 @@ impl MasterHandler {
                 .collect();
 
             let last_block = req.last_block.map(ProtoUtils::extend_block_from_pb);
-            let located_block = self.fs.add_block(
+            let result = self.fs.add_block(
                 path,
                 req.inode_id,
                 client_addr,
@@ -400,39 +410,63 @@ impl MasterHandler {
                 req.exclude_workers,
                 req.file_len,
                 last_block,
-            )?;
-            results.push(ProtoUtils::located_block_to_pb(located_block));
+            );
+            results.push(match result {
+                Ok(block) => {
+                    let block = ProtoUtils::located_block_to_pb(block);
+                    AddBlockBatchResult {
+                        block: Some(block),
+                        error: None,
+                    }
+                }
+                Err(error) => AddBlockBatchResult {
+                    block: None,
+                    error: Some(error.to_string()),
+                },
+            });
         }
 
-        let rep_header = AddBlocksBatchResponse { blocks: results };
+        let rep_header = AddBlocksBatchResponse {
+            blocks: Vec::new(),
+            results,
+        };
         ctx.response_buf(rep_header, &mut self.buf)
     }
 
     pub fn complete_files_batch(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let header: CompleteFilesBatchRequest = ctx.parse_header()?;
 
-        let mut results = Vec::new();
+        let mut details = Vec::with_capacity(header.requests.len());
         for req in header.requests {
             let commit_blocks = req
                 .commit_blocks
                 .into_iter()
                 .map(ProtoUtils::commit_block_from_pb)
                 .collect();
-            let result = self
-                .fs
-                .complete_file(
-                    req.path,
-                    req.inode_id,
-                    req.len,
-                    commit_blocks,
-                    req.client_name,
-                    req.only_flush,
-                )
-                .is_ok();
-            results.push(result);
+            let result = self.fs.complete_file(
+                req.path,
+                req.inode_id,
+                req.len,
+                commit_blocks,
+                req.client_name,
+                req.only_flush,
+            );
+            details.push(match result {
+                Ok(_) => CompleteFileBatchResult {
+                    success: true,
+                    error: None,
+                },
+                Err(error) => CompleteFileBatchResult {
+                    success: false,
+                    error: Some(error.to_string()),
+                },
+            });
         }
 
-        let rep_header = CompleteFilesBatchResponse { results };
+        let rep_header = CompleteFilesBatchResponse {
+            results: Vec::new(),
+            details,
+        };
         ctx.response_buf(rep_header, &mut self.buf)
     }
 

--- a/curvine-server/src/worker/handler/batch_write_handler.rs
+++ b/curvine-server/src/worker/handler/batch_write_handler.rs
@@ -19,9 +19,9 @@ use crate::worker::storage::BlockWriteContext;
 use curvine_common::error::FsError;
 use curvine_common::fs::RpcCode;
 use curvine_common::proto::{
-    BlockWriteRequest, BlockWriteResponse, BlocksBatchCommitRequest, BlocksBatchCommitResponse,
-    BlocksBatchWriteRequest, BlocksBatchWriteResponse, DataHeaderProto, FilesBatchWriteRequest,
-    FilesBatchWriteResponse,
+    BlockBatchOpenResult, BlockWriteRequest, BlockWriteResponse, BlocksBatchCommitRequest,
+    BlocksBatchCommitResponse, BlocksBatchWriteRequest, BlocksBatchWriteResponse,
+    FilesBatchWriteRequest, FilesBatchWriteResponse,
 };
 use curvine_common::utils::ProtoUtils;
 use curvine_common::FsResult;
@@ -33,9 +33,8 @@ use orpc::CommonResult;
 
 pub struct BatchWriteHandler {
     pub(crate) store: BlockStore,
-    pub(crate) context: Option<Vec<WriteContext>>,
+    pub(crate) context: Option<Vec<Option<WriteContext>>>,
     pub(crate) file: Option<Vec<Option<BlockWriteContext>>>,
-    pub(crate) is_commit: bool,
     pub(crate) write_handler: WriteHandler,
 }
 
@@ -46,24 +45,12 @@ impl BatchWriteHandler {
             store,
             context: None,
             file: None,
-            is_commit: false,
             write_handler: WriteHandler::new(store_clone)?,
         })
     }
 
-    fn check_context(context: &WriteContext, expected_req_id: i64) -> FsResult<()> {
-        if context.req_id != expected_req_id {
-            return err_box!(
-                "Request id mismatch, expected {}, actual {}",
-                context.req_id,
-                expected_req_id
-            );
-        }
-        Ok(())
-    }
-
-    fn abort_open_contexts(store: &BlockStore, contexts: &[WriteContext]) {
-        for context in contexts {
+    fn abort_open_contexts(store: &BlockStore, contexts: &[Option<WriteContext>]) {
+        for context in contexts.iter().flatten() {
             if let Err(e) = store.abort_block(&context.block) {
                 log::warn!(
                     "failed to abort batch-opened block {} after open error: {}",
@@ -74,12 +61,19 @@ impl BatchWriteHandler {
         }
     }
 
+    fn abort_batch_state(&mut self) {
+        // Close all open devices before releasing their block allocations.
+        drop(self.file.take());
+        if let Some(contexts) = self.context.take() {
+            Self::abort_open_contexts(&self.store, &contexts);
+        }
+    }
+
     pub fn open_batch(&mut self, msg: &Message) -> FsResult<Message> {
         let header: BlocksBatchWriteRequest = msg.parse_header()?;
-        let mut responses = Vec::with_capacity(header.blocks.len());
+        let mut results = Vec::with_capacity(header.blocks.len());
         let mut files = Vec::with_capacity(header.blocks.len());
         let mut contexts = Vec::with_capacity(header.blocks.len());
-        self.is_commit = false;
 
         for (i, block_proto) in header.blocks.iter().cloned().enumerate() {
             let unique_req_id = msg.req_id() + i as i64;
@@ -106,22 +100,36 @@ impl BatchWriteHandler {
             let response = match self.write_handler.open(&single_msg_req) {
                 Ok(response) => response,
                 Err(e) => {
-                    Self::abort_open_contexts(&self.store, &contexts);
-                    return Err(e);
+                    drop(self.write_handler.file.take());
+                    self.write_handler.context.take();
+                    results.push(BlockBatchOpenResult {
+                        response: None,
+                        error: Some(e.to_string()),
+                    });
+                    files.push(None);
+                    contexts.push(None);
+                    continue;
                 }
             };
 
             // Extract file and context from handler and store in batch vectors
             let Some(context) = self.write_handler.context.take() else {
-                Self::abort_open_contexts(&self.store, &contexts);
-                return err_box!(
-                    "batch open did not create write context for block index {}",
-                    i
-                );
+                drop(self.write_handler.file.take());
+                results.push(BlockBatchOpenResult {
+                    response: None,
+                    error: Some(format!(
+                        "batch open did not create write context for block index {}",
+                        i
+                    )),
+                });
+                files.push(None);
+                contexts.push(None);
+                continue;
             };
             let block_response: BlockWriteResponse = match response.parse_header() {
                 Ok(response) => response,
                 Err(e) => {
+                    drop(self.write_handler.file.take());
                     if let Err(abort_err) = self.store.abort_block(&context.block) {
                         log::warn!(
                             "failed to abort batch-opened block {} after response parse error: {}",
@@ -129,97 +137,113 @@ impl BatchWriteHandler {
                             abort_err
                         );
                     }
-                    Self::abort_open_contexts(&self.store, &contexts);
-                    return Err(e.into());
+                    results.push(BlockBatchOpenResult {
+                        response: None,
+                        error: Some(e.to_string()),
+                    });
+                    files.push(None);
+                    contexts.push(None);
+                    continue;
                 }
             };
-            responses.push(block_response);
+            results.push(BlockBatchOpenResult {
+                response: Some(block_response),
+                error: None,
+            });
             files.push(self.write_handler.file.take());
-            contexts.push(context);
+            contexts.push(Some(context));
         }
         self.file = Some(files);
         self.context = Some(contexts);
-        let batch_response = BlocksBatchWriteResponse { responses };
+        let batch_response = BlocksBatchWriteResponse {
+            responses: Vec::new(),
+            results,
+        };
 
         Ok(Builder::success(msg).proto_header(batch_response).build())
     }
 
-    pub fn complete_batch(&mut self, msg: &Message, commit: bool) -> FsResult<Message> {
-        // Parse the flattened batch request
-        let header: BlocksBatchCommitRequest = msg.parse_header()?;
-        let mut results = Vec::new();
-
-        if self.is_commit {
-            return if !msg.data.is_empty() {
-                err_box!("The block has been committed and data cannot be written anymore.")
-            } else {
-                Ok(msg.success())
-            };
-        }
-
-        let Some(contexts) = self.context.as_ref() else {
+    pub fn complete_batch(&mut self, msg: &Message, cancel_request: bool) -> FsResult<Message> {
+        let header: BlocksBatchCommitRequest = match msg.parse_header() {
+            Ok(header) => header,
+            Err(error) => {
+                self.abort_batch_state();
+                return Err(error.into());
+            }
+        };
+        let cancels = if header.cancel_flags.is_empty() {
+            vec![header.cancel; header.blocks.len()]
+        } else if header.cancel_flags.len() == header.blocks.len() {
+            header.cancel_flags.clone()
+        } else {
+            let block_count = header.blocks.len();
+            let action_count = header.cancel_flags.len();
+            self.abort_batch_state();
+            return err_box!(
+                "batch commit action count mismatch: blocks={}, actions={}",
+                block_count,
+                action_count
+            );
+        };
+        let Some(contexts) = self.context.take() else {
             return err_box!("batch commit without open context");
         };
-        let Some(files) = self.file.as_mut() else {
+        let Some(files) = self.file.take() else {
+            Self::abort_open_contexts(&self.store, &contexts);
             return err_box!("batch commit without open files");
         };
         if contexts.len() != header.blocks.len() || files.len() != header.blocks.len() {
+            let context_count = contexts.len();
+            let file_count = files.len();
+            drop(files);
+            Self::abort_open_contexts(&self.store, &contexts);
             return err_box!(
-                "batch commit block count mismatch: blocks={}, contexts={}, files={}",
+                "batch commit request count mismatch: blocks={}, contexts={}, files={}",
                 header.blocks.len(),
-                contexts.len(),
-                files.len()
+                context_count,
+                file_count
             );
         }
+        if cancel_request && cancels.iter().any(|cancel| !cancel) {
+            drop(files);
+            Self::abort_open_contexts(&self.store, &contexts);
+            return err_box!("batch cancel request contains commit items");
+        }
 
-        let mut commit_blocks = Vec::with_capacity(header.blocks.len());
-        for (i, block_proto) in header.blocks.into_iter().enumerate() {
-            let Some(context) = contexts.get(i) else {
-                return err_box!("missing batch write context at index {}", i);
+        let mut results = Vec::with_capacity(header.blocks.len());
+        for (index, (((block, cancel), opened), file)) in header
+            .blocks
+            .into_iter()
+            .zip(cancels.into_iter())
+            .zip(contexts.into_iter())
+            .zip(files.into_iter())
+            .enumerate()
+        {
+            let Some(opened) = opened else {
+                drop(file);
+                results.push(false);
+                continue;
             };
-            let expected_req_id = msg.req_id() + i as i64;
-            Self::check_context(context, expected_req_id)?;
-
-            let block = ProtoUtils::extend_block_from_pb(block_proto);
-            if block.id != context.block.id
-                || block.storage_type != context.block.storage_type
-                || block.file_type != context.block.file_type
-            {
-                return err_box!(
-                    "batch commit block mismatch at index {}: opened={:?}, committed={:?}",
-                    i,
-                    context.block,
-                    block
+            let requested = WriteContext {
+                block: ProtoUtils::extend_block_from_pb(block),
+                req_id: msg.req_id() + index as i64,
+                chunk_size: opened.chunk_size,
+                short_circuit: opened.short_circuit,
+                off: header.off,
+                block_size: header.block_size,
+            };
+            let result =
+                WriteHandler::complete_block(&self.store, file, Some(&opened), &requested, !cancel);
+            if let Err(error) = result.as_ref() {
+                log::warn!(
+                    "failed to complete batch block {} at index {}: {}",
+                    requested.block.id,
+                    index,
+                    error
                 );
             }
-            if block.len > context.block_size {
-                return err_box!(
-                    "Invalid block length: {}, block size: {}",
-                    block.len,
-                    context.block_size
-                );
-            }
-            commit_blocks.push(block);
+            results.push(result.is_ok());
         }
-
-        for file in files.iter_mut() {
-            if let Some(file) = file.as_mut() {
-                file.flush()?;
-            }
-        }
-        for file in files.iter_mut() {
-            file.take();
-        }
-
-        for block in commit_blocks {
-            if commit {
-                self.store.finalize_block(&block)?;
-            } else {
-                self.store.abort_block(&block)?;
-            }
-            results.push(true);
-        }
-        self.is_commit = true;
         let batch_response = BlocksBatchCommitResponse { results };
 
         Ok(Builder::success(msg).proto_header(batch_response).build())
@@ -228,7 +252,6 @@ impl BatchWriteHandler {
     pub fn write_batch(&mut self, msg: &Message) -> FsResult<Message> {
         let header: FilesBatchWriteRequest = msg.parse_header()?;
 
-        // Use drain to extract elements while preserving the vector's allocated memory
         let Some(files_vec) = self.file.as_mut() else {
             return err_box!("batch write without open files");
         };
@@ -243,24 +266,25 @@ impl BatchWriteHandler {
                 contexts_vec.len()
             );
         }
-        if files_vec.iter().any(Option::is_none) {
-            return err_box!(
-                "batch remote write received running data for short-circuit batch writer"
-            );
-        }
+        let files = std::mem::take(files_vec);
+        let contexts = std::mem::take(contexts_vec);
+        let mut results = Vec::with_capacity(header.files.len());
 
-        let files_drain = std::mem::take(files_vec);
-        let contexts_drain = std::mem::take(contexts_vec);
-
-        let mut files_iter = files_drain.into_iter();
-        let mut contexts_iter = contexts_drain.into_iter();
-
-        for (i, file_data) in header.files.iter().enumerate() {
-            // Convert bytes to DataSlice
+        for (i, ((file_data, file), context)) in header
+            .files
+            .iter()
+            .zip(files.into_iter())
+            .zip(contexts.into_iter())
+            .enumerate()
+        {
+            let (Some(file), Some(context)) = (file, context) else {
+                files_vec.push(None);
+                contexts_vec.push(None);
+                results.push(false);
+                continue;
+            };
             let data_slice = DataSlice::Bytes(bytes::Bytes::from(file_data.clone().content));
-
             let unique_req_id = header.req_id + i as i64;
-            // Create a temporary message for each file
             let single_msg = Builder::new()
                 .code(RpcCode::WriteBlock)
                 .request(RequestStatus::Running)
@@ -269,85 +293,25 @@ impl BatchWriteHandler {
                 .data(data_slice)
                 .build();
 
-            // Get the next file and context from iterators (preserves original order)
-            let Some(file) = files_iter.next() else {
-                return err_box!("missing batch write file at index {}", i);
-            };
-            let Some(file) = file else {
-                return err_box!("batch remote write missing file state at index {}", i);
-            };
-            let Some(context) = contexts_iter.next() else {
-                return err_box!("missing batch write context at index {}", i);
-            };
-
             self.write_handler.file = Some(file);
             self.write_handler.context = Some(context);
-
-            if let Err(e) = self.write_handler.write(&single_msg) {
-                let Some(file) = self.write_handler.file.take() else {
-                    return err_box!(
-                        "batch write lost file state after write error at index {}",
-                        i
-                    );
-                };
-                let Some(context) = self.write_handler.context.take() else {
-                    return err_box!(
-                        "batch write lost context state after write error at index {}",
-                        i
-                    );
-                };
-                files_vec.push(Some(file));
-                contexts_vec.push(context);
-                files_vec.extend(files_iter);
-                contexts_vec.extend(contexts_iter);
-                return Err(e);
-            }
-
+            let result = self.write_handler.write(&single_msg);
             let Some(file) = self.write_handler.file.take() else {
                 return err_box!("batch write lost file state at index {}", i);
             };
             let Some(context) = self.write_handler.context.take() else {
                 return err_box!("batch write lost context state at index {}", i);
             };
-
             files_vec.push(Some(file));
-            contexts_vec.push(context);
-        }
-
-        let batch_response = FilesBatchWriteResponse {
-            results: vec![true; header.files.len()],
-        };
-        Ok(Builder::success(msg).proto_header(batch_response).build())
-    }
-
-    pub fn flush_batch(&mut self, msg: &Message) -> FsResult<Message> {
-        let header: DataHeaderProto = msg.parse_header()?;
-        if !header.flush {
-            return err_box!("batch writer received non-flush WriteBlock running request");
-        }
-
-        let Some(files) = self.file.as_mut() else {
-            return err_box!("batch flush without open files");
-        };
-        let Some(contexts) = self.context.as_ref() else {
-            return err_box!("batch flush without open context");
-        };
-        if files.len() != contexts.len() {
-            return err_box!(
-                "batch flush state mismatch: files={}, contexts={}",
-                files.len(),
-                contexts.len()
-            );
-        }
-        for (i, (file, context)) in files.iter_mut().zip(contexts.iter()).enumerate() {
-            let expected_req_id = msg.req_id() + i as i64;
-            Self::check_context(context, expected_req_id)?;
-            if let Some(file) = file.as_mut() {
-                file.flush()?;
+            contexts_vec.push(Some(context));
+            if let Err(error) = result.as_ref() {
+                log::warn!("failed to write batch block at index {}: {}", i, error);
             }
+            results.push(result.is_ok());
         }
 
-        Ok(msg.success())
+        let batch_response = FilesBatchWriteResponse { results };
+        Ok(Builder::success(msg).proto_header(batch_response).build())
     }
 }
 
@@ -358,13 +322,16 @@ impl MessageHandler for BatchWriteHandler {
         match request_status {
             // batch operations
             RequestStatus::Open => self.open_batch(msg),
-            RequestStatus::Running if RpcCode::from(msg.code()) == RpcCode::WriteBlock => {
-                self.flush_batch(msg)
-            }
             RequestStatus::Running => self.write_batch(msg),
-            RequestStatus::Complete => self.complete_batch(msg, true),
-            RequestStatus::Cancel => self.complete_batch(msg, false),
+            RequestStatus::Complete => self.complete_batch(msg, false),
+            RequestStatus::Cancel => self.complete_batch(msg, true),
             _ => err_box!("Unsupported request type"),
         }
+    }
+}
+
+impl Drop for BatchWriteHandler {
+    fn drop(&mut self) {
+        self.abort_batch_state();
     }
 }

--- a/curvine-server/src/worker/handler/worker_handler.rs
+++ b/curvine-server/src/worker/handler/worker_handler.rs
@@ -99,7 +99,6 @@ impl WorkerHandler {
                     Some(BlockHandler::BatchWriter(_)),
                     RpcCode::WriteBlocksBatch
                 )
-                | (Some(BlockHandler::BatchWriter(_)), RpcCode::WriteBlock)
         )
     }
 

--- a/curvine-server/src/worker/handler/write_handler.rs
+++ b/curvine-server/src/worker/handler/write_handler.rs
@@ -234,13 +234,70 @@ impl WriteHandler {
         Ok(msg.success())
     }
 
-    fn commit_block(&self, block: &ExtendedBlock, commit: bool) -> FsResult<()> {
-        if commit {
-            self.store.finalize_block(block)?;
-        } else {
-            self.store.abort_block(block)?;
+    pub(crate) fn complete_block(
+        store: &BlockStore,
+        file: Option<BlockWriteContext>,
+        opened: Option<&WriteContext>,
+        requested: &WriteContext,
+        commit: bool,
+    ) -> FsResult<()> {
+        let opened_block = opened.map(|context| &context.block);
+        let mut file = file;
+        let result = (|| {
+            if let Some(opened) = opened {
+                if opened.req_id != requested.req_id {
+                    return err_box!(
+                        "Request id mismatch, expected {}, actual {}",
+                        opened.req_id,
+                        requested.req_id
+                    );
+                }
+                if opened.block.id != requested.block.id
+                    || opened.block.storage_type != requested.block.storage_type
+                    || opened.block.file_type != requested.block.file_type
+                {
+                    return err_box!(
+                        "write block mismatch: opened={:?}, completed={:?}",
+                        opened.block,
+                        requested.block
+                    );
+                }
+            }
+
+            if requested.block.len > requested.block_size {
+                return err_box!(
+                    "Invalid block length: {}, block size: {}",
+                    requested.block.len,
+                    requested.block_size
+                );
+            }
+
+            if !commit {
+                drop(file.take());
+                store.abort_block(opened_block.unwrap_or(&requested.block))?;
+                return Ok(());
+            }
+
+            if let Some(file) = file.as_mut() {
+                file.flush()?;
+            }
+            drop(file.take());
+            store.finalize_block(&requested.block)?;
+            Ok(())
+        })();
+
+        if result.is_err() {
+            drop(file.take());
+            if let Some(opened_block) = opened_block {
+                if let Err(abort_error) = store.abort_block(opened_block) {
+                    warn!(
+                        "failed to abort block {} after completion error: {}",
+                        opened_block.id, abort_error
+                    );
+                }
+            }
         }
-        Ok(())
+        result
     }
 
     pub fn complete(&mut self, msg: &Message, commit: bool) -> FsResult<Message> {
@@ -252,51 +309,32 @@ impl WriteHandler {
             };
         }
 
-        if let Some(context) = self.context.take() {
-            Self::check_context(&context, msg)?;
-        }
-        let context = WriteContext::from_req(msg)?;
-
-        let file = self.file.take();
-        if let Some(mut file) = file {
-            if let Err(flush_err) = file.flush() {
-                drop(file);
-                if let Err(abort_err) = self.store.abort_block(&context.block) {
-                    log::warn!(
-                        "failed to abort block {} after flush error: {}",
-                        context.block.id,
-                        abort_err
-                    );
+        let requested = match WriteContext::from_req(msg) {
+            Ok(requested) => requested,
+            Err(error) => {
+                drop(self.file.take());
+                if let Some(opened) = self.context.take() {
+                    if let Err(abort_error) = self.store.abort_block(&opened.block) {
+                        warn!(
+                            "failed to abort block {} after invalid completion request: {}",
+                            opened.block.id, abort_error
+                        );
+                    }
                 }
-                return Err(flush_err.into());
+                return Err(error);
             }
-            drop(file);
-        }
-
-        if context.block.len > context.block_size {
-            if let Err(abort_err) = self.store.abort_block(&context.block) {
-                log::warn!(
-                    "failed to abort block {} after length check failed: {}",
-                    context.block.id,
-                    abort_err
-                );
-            }
-            return err_box!(
-                "Invalid block length: {}, block size: {}",
-                context.block.len,
-                context.block_size
-            );
-        }
-
-        self.commit_block(&context.block, commit)?;
+        };
+        let opened = self.context.take();
+        let file = self.file.take();
+        Self::complete_block(&self.store, file, opened.as_ref(), &requested, commit)?;
         self.is_commit = true;
 
         info!(
             "write block end for req_id {}, is commit: {}, off: {}, len: {}",
             msg.req_id(),
             commit,
-            context.off,
-            context.block.len
+            requested.off,
+            requested.block.len
         );
 
         Ok(msg.success())

--- a/curvine-server/src/worker/storage/vfs_dataset.rs
+++ b/curvine-server/src/worker/storage/vfs_dataset.rs
@@ -433,6 +433,20 @@ mod test {
         Ok(())
     }
     #[test]
+    fn abort_releases_reserved_space_and_removes_block() -> CommonResult<()> {
+        let mut ds = create_data_set(true, "abort-release");
+        let block = ExtendedBlock::with_mem(1, "100B")?;
+        let initial_available = ds.available();
+        ds.open_block(&block)?;
+        assert_eq!(ds.available(), initial_available - 100);
+
+        ds.abort_block(&block)?;
+
+        assert_eq!(ds.available(), initial_available);
+        assert!(ds.get_block(block.id).is_none());
+        Ok(())
+    }
+    #[test]
     fn append() -> CommonResult<()> {
         let mut ds = create_data_set(true, "append");
         let mut block = ExtendedBlock::with_mem(1, "100B")?;

--- a/curvine-server/tests/worker_test.rs
+++ b/curvine-server/tests/worker_test.rs
@@ -16,12 +16,13 @@ use curvine_common::conf::ClusterConf;
 use curvine_common::fs::RpcCode;
 use curvine_common::proto::{
     BlockReadRequest, BlockReadResponse, BlockWriteRequest, BlockWriteResponse,
-    BlocksBatchCommitRequest, BlocksBatchWriteRequest, BlocksBatchWriteResponse, DataHeaderProto,
-    FileWriteData, FilesBatchWriteRequest,
+    BlocksBatchCommitRequest, BlocksBatchCommitResponse, BlocksBatchWriteRequest,
+    BlocksBatchWriteResponse, FileWriteData, FilesBatchWriteRequest, FilesBatchWriteResponse,
 };
 use curvine_common::state::{ExtendedBlock, FileAllocOpts, FileType, StorageType};
 use curvine_common::utils::ProtoUtils;
 use curvine_server::worker::Worker;
+use orpc::client::SyncClient;
 use orpc::common::Utils;
 use orpc::io::net::NetUtils;
 use orpc::message::{Builder, Message, RequestStatus};
@@ -32,6 +33,101 @@ use std::thread;
 
 const CHUNK_SIZE: i32 = 1024;
 const LOOP_NUM: i32 = 100;
+
+fn batch_commit_request(
+    blocks: &[ExtendedBlock],
+    block_size: i64,
+    req_id: i64,
+    seq_id: i32,
+    cancel: bool,
+) -> BlocksBatchCommitRequest {
+    BlocksBatchCommitRequest {
+        blocks: blocks
+            .iter()
+            .cloned()
+            .map(ProtoUtils::extend_block_to_pb)
+            .collect(),
+        off: 0,
+        block_size,
+        req_id,
+        seq_id,
+        cancel,
+        cancel_flags: Vec::new(),
+    }
+}
+
+fn open_batch(
+    client: &SyncClient,
+    blocks: &[ExtendedBlock],
+    block_size: i64,
+    req_id: i64,
+    short_circuit: bool,
+) -> CommonResult<BlocksBatchWriteResponse> {
+    let request = BlocksBatchWriteRequest {
+        blocks: blocks
+            .iter()
+            .cloned()
+            .map(ProtoUtils::extend_block_to_pb)
+            .collect(),
+        off: 0,
+        block_size,
+        req_id,
+        seq_id: 0,
+        chunk_size: CHUNK_SIZE,
+        short_circuit,
+        client_name: "test".to_string(),
+    };
+    let message = Builder::new()
+        .code(RpcCode::WriteBlocksBatch)
+        .request(RequestStatus::Open)
+        .req_id(req_id)
+        .seq_id(0)
+        .proto_header(request)
+        .build();
+    client.rpc_check(message)?.parse_header()
+}
+
+fn write_batch(
+    client: &SyncClient,
+    contents: &[&str],
+    req_id: i64,
+    seq_id: i32,
+) -> CommonResult<FilesBatchWriteResponse> {
+    let request = FilesBatchWriteRequest {
+        files: contents
+            .iter()
+            .map(|content| FileWriteData {
+                path: String::new(),
+                content: content.as_bytes().to_vec(),
+            })
+            .collect(),
+        req_id,
+        seq_id,
+    };
+    let message = Builder::new()
+        .code(RpcCode::WriteBlocksBatch)
+        .request(RequestStatus::Running)
+        .req_id(req_id)
+        .seq_id(seq_id)
+        .proto_header(request)
+        .build();
+    client.rpc_check(message)?.parse_header()
+}
+
+fn complete_batch(
+    client: &SyncClient,
+    request: BlocksBatchCommitRequest,
+    status: RequestStatus,
+) -> CommonResult<BlocksBatchCommitResponse> {
+    let message = Builder::new()
+        .code(RpcCode::WriteBlocksBatch)
+        .request(status)
+        .req_id(request.req_id)
+        .seq_id(request.seq_id)
+        .proto_header(request)
+        .build();
+    client.rpc_check(message)?.parse_header()
+}
 
 // Test the worker interface function.
 fn start_worker() -> ClusterConf {
@@ -138,54 +234,19 @@ fn test_worker_batch_short_circuit_complete_uses_open_context_without_server_fil
     ];
 
     let open_req_id = Utils::req_id();
-    let open = BlocksBatchWriteRequest {
-        blocks: blocks
-            .iter()
-            .cloned()
-            .map(ProtoUtils::extend_block_to_pb)
-            .collect(),
-        off: 0,
-        block_size,
-        req_id: open_req_id,
-        seq_id: 0,
-        chunk_size: CHUNK_SIZE,
-        short_circuit: true,
-        client_name: "test".to_string(),
-    };
-    let open_msg = Builder::new()
-        .code(RpcCode::WriteBlocksBatch)
-        .request(RequestStatus::Open)
-        .req_id(open_req_id)
-        .seq_id(0)
-        .proto_header(open)
-        .build();
-    let response: BlocksBatchWriteResponse = client.rpc_check(open_msg)?.parse_header()?;
-    assert_eq!(response.responses.len(), blocks.len());
-    assert!(response
-        .responses
-        .iter()
-        .all(|response| response.path.is_some()));
+    let response = open_batch(&client, &blocks, block_size, open_req_id, true)?;
+    assert_eq!(response.results.len(), blocks.len());
+    assert!(response.results.iter().all(|result| result
+        .response
+        .as_ref()
+        .is_some_and(|response| response.path.is_some())));
 
-    let complete = BlocksBatchCommitRequest {
-        blocks: blocks
-            .iter()
-            .cloned()
-            .map(ProtoUtils::extend_block_to_pb)
-            .collect(),
-        off: 0,
-        block_size,
-        req_id: open_req_id,
-        seq_id: 1,
-        cancel: false,
-    };
-    let complete_msg = Builder::new()
-        .code(RpcCode::WriteBlocksBatch)
-        .request(RequestStatus::Complete)
-        .req_id(complete.req_id)
-        .seq_id(1)
-        .proto_header(complete)
-        .build();
-    let _: Message = client.rpc_check(complete_msg)?;
+    let response = complete_batch(
+        &client,
+        batch_commit_request(&blocks, block_size, open_req_id, 1, false),
+        RequestStatus::Complete,
+    )?;
+    assert_eq!(response.results, vec![true, true]);
 
     Ok(())
 }
@@ -202,29 +263,59 @@ fn test_worker_batch_short_circuit_complete_requires_open_connection() -> Common
     ];
 
     let req_id = Utils::req_id();
-    let open = BlocksBatchWriteRequest {
-        blocks: blocks
-            .iter()
-            .cloned()
-            .map(ProtoUtils::extend_block_to_pb)
-            .collect(),
-        off: 0,
-        block_size,
-        req_id,
-        seq_id: 0,
-        chunk_size: CHUNK_SIZE,
-        short_circuit: true,
-        client_name: "test".to_string(),
-    };
-    let open_msg = Builder::new()
-        .code(RpcCode::WriteBlocksBatch)
-        .request(RequestStatus::Open)
-        .req_id(req_id)
-        .seq_id(0)
-        .proto_header(open)
-        .build();
-    let _: BlocksBatchWriteResponse = open_client.rpc_check(open_msg)?.parse_header()?;
+    open_batch(&open_client, &blocks, block_size, req_id, true)?;
 
+    let complete = batch_commit_request(&blocks, block_size, req_id, 1, false);
+    assert!(complete_batch(&complete_client, complete, RequestStatus::Complete).is_err());
+
+    Ok(())
+}
+
+#[test]
+fn test_worker_batch_open_failure_is_per_block() -> CommonResult<()> {
+    let conf = start_worker();
+    let client = conf.worker_sync_client()?;
+    let block_size = CHUNK_SIZE as i64;
+    let req_id = Utils::req_id();
+    let mut blocks = [
+        ExtendedBlock::new(Utils::req_id().abs(), 0, StorageType::Disk, FileType::File),
+        ExtendedBlock::new(Utils::req_id().abs(), 0, StorageType::Disk, FileType::File),
+    ];
+    blocks[1].alloc_opts = Some(FileAllocOpts::with_truncate(block_size + 1));
+
+    let response = open_batch(&client, &blocks, block_size, req_id, false)?;
+    assert!(response.results[0].response.is_some());
+    assert!(response.results[1].response.is_none());
+    assert!(response.results[1].error.is_some());
+
+    let response = complete_batch(
+        &client,
+        batch_commit_request(&blocks, block_size, req_id, 1, true),
+        RequestStatus::Cancel,
+    )?;
+    assert_eq!(response.results, vec![true, false]);
+
+    Ok(())
+}
+
+#[test]
+fn test_worker_batch_write_failure_does_not_stop_other_blocks() -> CommonResult<()> {
+    let conf = start_worker();
+    let client = conf.worker_sync_client()?;
+    let block_size = 8;
+    let req_id = Utils::req_id();
+    let mut blocks = [
+        ExtendedBlock::new(Utils::req_id().abs(), 0, StorageType::Disk, FileType::File),
+        ExtendedBlock::new(Utils::req_id().abs(), 0, StorageType::Disk, FileType::File),
+    ];
+
+    open_batch(&client, &blocks, block_size, req_id, false)?;
+
+    let contents = ["too-large", "ok"];
+    let response = write_batch(&client, &contents, req_id, 1)?;
+    assert_eq!(response.results, vec![false, true]);
+
+    blocks[1].len = contents[1].len() as i64;
     let complete = BlocksBatchCommitRequest {
         blocks: blocks
             .iter()
@@ -234,18 +325,53 @@ fn test_worker_batch_short_circuit_complete_requires_open_connection() -> Common
         off: 0,
         block_size,
         req_id,
-        seq_id: 1,
+        seq_id: 2,
         cancel: false,
+        cancel_flags: vec![true, false],
     };
-    let complete_msg = Builder::new()
-        .code(RpcCode::WriteBlocksBatch)
-        .request(RequestStatus::Complete)
-        .req_id(req_id)
-        .seq_id(1)
-        .proto_header(complete)
-        .build();
-    assert!(complete_client.rpc_check(complete_msg).is_err());
+    let response = complete_batch(&client, complete, RequestStatus::Complete)?;
+    assert_eq!(response.results, vec![true, true]);
 
+    assert!(block_read_bytes(blocks[0].id, 1, &conf).is_err());
+    assert_eq!(
+        block_read_bytes(blocks[1].id, contents[1].len() as i64, &conf)?,
+        contents[1].as_bytes()
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_worker_batch_invalid_complete_aborts_all_open_blocks() -> CommonResult<()> {
+    let conf = start_worker();
+    let client = conf.worker_sync_client()?;
+    let block_size = CHUNK_SIZE as i64;
+    let blocks = [
+        ExtendedBlock::new(Utils::req_id().abs(), 0, StorageType::Disk, FileType::File),
+        ExtendedBlock::new(Utils::req_id().abs(), 0, StorageType::Disk, FileType::File),
+    ];
+    let req_id = Utils::req_id();
+    let response = open_batch(&client, &blocks, block_size, req_id, true)?;
+    let paths: Vec<_> = response
+        .results
+        .into_iter()
+        .map(|result| {
+            result
+                .response
+                .expect("batch open response")
+                .path
+                .expect("short-circuit path")
+        })
+        .collect();
+    assert!(paths.iter().all(|path| std::path::Path::new(path).exists()));
+
+    // Report only one of the two opened blocks to trigger batch-wide count validation.
+    let invalid_complete = batch_commit_request(&blocks[..1], block_size, req_id, 1, false);
+    assert!(complete_batch(&client, invalid_complete, RequestStatus::Complete).is_err());
+
+    assert!(paths
+        .iter()
+        .all(|path| !std::path::Path::new(path).exists()));
     Ok(())
 }
 
@@ -260,102 +386,21 @@ fn test_worker_batch_remote_write_complete_and_read_back() -> CommonResult<()> {
         ExtendedBlock::new(Utils::req_id().abs(), 0, StorageType::Disk, FileType::File),
     ];
 
-    let open = BlocksBatchWriteRequest {
-        blocks: blocks
-            .iter()
-            .cloned()
-            .map(ProtoUtils::extend_block_to_pb)
-            .collect(),
-        off: 0,
-        block_size,
-        req_id,
-        seq_id: 0,
-        chunk_size: CHUNK_SIZE,
-        short_circuit: false,
-        client_name: "test".to_string(),
-    };
-    let open_msg = Builder::new()
-        .code(RpcCode::WriteBlocksBatch)
-        .request(RequestStatus::Open)
-        .req_id(req_id)
-        .seq_id(0)
-        .proto_header(open)
-        .build();
-    let _: BlocksBatchWriteResponse = client.rpc_check(open_msg)?.parse_header()?;
+    open_batch(&client, &blocks, block_size, req_id, false)?;
 
     let contents = ["batch-block-a", "batch-block-b"];
-    let write = FilesBatchWriteRequest {
-        files: contents
-            .iter()
-            .map(|content| FileWriteData {
-                path: String::new(),
-                content: content.as_bytes().to_vec(),
-            })
-            .collect(),
-        req_id,
-        seq_id: 1,
-    };
-    let write_msg = Builder::new()
-        .code(RpcCode::WriteBlocksBatch)
-        .request(RequestStatus::Running)
-        .req_id(req_id)
-        .seq_id(1)
-        .proto_header(write)
-        .build();
-    let _: Message = client.rpc_check(write_msg)?;
-
-    let non_flush = DataHeaderProto {
-        offset: 0,
-        flush: false,
-        is_last: false,
-    };
-    let non_flush_msg = Builder::new()
-        .code(RpcCode::WriteBlock)
-        .request(RequestStatus::Running)
-        .req_id(req_id)
-        .seq_id(2)
-        .proto_header(non_flush)
-        .build();
-    assert!(client.rpc_check(non_flush_msg).is_err());
-
-    let flush = DataHeaderProto {
-        offset: 0,
-        flush: true,
-        is_last: false,
-    };
-    let flush_msg = Builder::new()
-        .code(RpcCode::WriteBlock)
-        .request(RequestStatus::Running)
-        .req_id(req_id)
-        .seq_id(3)
-        .proto_header(flush)
-        .build();
-    let _: Message = client.rpc_check(flush_msg)?;
+    write_batch(&client, &contents, req_id, 1)?;
 
     for (block, content) in blocks.iter_mut().zip(contents) {
         block.len = content.len() as i64;
     }
 
-    let complete = BlocksBatchCommitRequest {
-        blocks: blocks
-            .iter()
-            .cloned()
-            .map(ProtoUtils::extend_block_to_pb)
-            .collect(),
-        off: 0,
-        block_size,
-        req_id,
-        seq_id: 4,
-        cancel: false,
-    };
-    let complete_msg = Builder::new()
-        .code(RpcCode::WriteBlocksBatch)
-        .request(RequestStatus::Complete)
-        .req_id(req_id)
-        .seq_id(4)
-        .proto_header(complete)
-        .build();
-    let _: Message = client.rpc_check(complete_msg)?;
+    let response = complete_batch(
+        &client,
+        batch_commit_request(&blocks, block_size, req_id, 2, false),
+        RequestStatus::Complete,
+    )?;
+    assert_eq!(response.results, vec![true, true]);
     for (block, content) in blocks.iter().zip(contents) {
         assert_eq!(
             block_read_bytes(block.id, content.len() as i64, &conf)?,
@@ -364,6 +409,156 @@ fn test_worker_batch_remote_write_complete_and_read_back() -> CommonResult<()> {
     }
 
     Ok(())
+}
+
+#[test]
+fn test_worker_batch_finalize_failure_is_per_block_and_cleans_up() -> CommonResult<()> {
+    let conf = start_worker();
+    let client = conf.worker_sync_client()?;
+    let block_size = CHUNK_SIZE as i64;
+    let req_id = Utils::req_id();
+    let mut blocks = [
+        ExtendedBlock::new(Utils::req_id().abs(), 0, StorageType::Disk, FileType::File),
+        ExtendedBlock::new(Utils::req_id().abs(), 0, StorageType::Disk, FileType::File),
+    ];
+
+    open_batch(&client, &blocks, block_size, req_id, false)?;
+
+    let contents = ["batch-finalize-fails", "batch-finalize-succeeds"];
+    write_batch(&client, &contents, req_id, 1)?;
+
+    // Deliberately report the wrong committed length for block 0 so the real
+    // VfsDataset::finalize_block length check fails while block 1 can still commit.
+    blocks[0].len = contents[0].len() as i64 + 1;
+    blocks[1].len = contents[1].len() as i64;
+    let response = complete_batch(
+        &client,
+        batch_commit_request(&blocks, block_size, req_id, 2, false),
+        RequestStatus::Complete,
+    )?;
+    assert_eq!(response.results, vec![false, true]);
+
+    assert!(block_read_bytes(blocks[0].id, contents[0].len() as i64, &conf).is_err());
+    assert_eq!(
+        block_read_bytes(blocks[1].id, contents[1].len() as i64, &conf)?,
+        contents[1].as_bytes()
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_worker_failed_finalize_retry_does_not_abort_finalized_block() -> CommonResult<()> {
+    let conf = start_worker();
+    let client = conf.worker_sync_client()?;
+    let block_size = CHUNK_SIZE as i64;
+    let content = "finalized-block-must-survive";
+    let mut block = ExtendedBlock::new(Utils::req_id().abs(), 0, StorageType::Disk, FileType::File);
+    let req_id = Utils::req_id();
+
+    open_batch(&client, &[block.clone()], block_size, req_id, false)?;
+    write_batch(&client, &[content], req_id, 1)?;
+    block.len = content.len() as i64;
+    let response = complete_batch(
+        &client,
+        batch_commit_request(&[block.clone()], block_size, req_id, 2, false),
+        RequestStatus::Complete,
+    )?;
+    assert_eq!(response.results, vec![true]);
+    drop(client);
+
+    let mut mismatched = block.clone();
+    mismatched.len += 1;
+    let retry_req_id = Utils::req_id();
+    let request = BlockWriteRequest {
+        block: ProtoUtils::extend_block_to_pb(mismatched),
+        off: 0,
+        block_size,
+        short_circuit: false,
+        client_name: "test".to_string(),
+        chunk_size: CHUNK_SIZE,
+        pipeline_stream: Vec::new(),
+    };
+    let retry = Builder::new()
+        .code(RpcCode::WriteBlock)
+        .request(RequestStatus::Complete)
+        .req_id(retry_req_id)
+        .seq_id(0)
+        .proto_header(request)
+        .build();
+    assert!(conf.worker_sync_client()?.rpc_check(retry).is_err());
+
+    assert_eq!(
+        block_read_bytes(block.id, block.len, &conf)?,
+        content.as_bytes()
+    );
+    Ok(())
+}
+
+#[test]
+fn test_worker_batch_cancel_reports_success_and_cleans_up_each_block() -> CommonResult<()> {
+    let conf = start_worker();
+    let client = conf.worker_sync_client()?;
+    let block_size = CHUNK_SIZE as i64;
+    let req_id = Utils::req_id();
+    let blocks = [
+        ExtendedBlock::new(Utils::req_id().abs(), 0, StorageType::Disk, FileType::File),
+        ExtendedBlock::new(Utils::req_id().abs(), 0, StorageType::Disk, FileType::File),
+    ];
+
+    open_batch(&client, &blocks, block_size, req_id, false)?;
+
+    let response = complete_batch(
+        &client,
+        batch_commit_request(&blocks, block_size, req_id, 1, true),
+        RequestStatus::Cancel,
+    )?;
+    assert_eq!(response.results, vec![true, true]);
+    for block in blocks {
+        assert!(block_read_bytes(block.id, 1, &conf).is_err());
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_worker_batch_disconnect_aborts_open_blocks() -> CommonResult<()> {
+    let conf = start_worker();
+    let client = conf.worker_sync_client()?;
+    let block_size = CHUNK_SIZE as i64;
+    let req_id = Utils::req_id();
+    let blocks = [
+        ExtendedBlock::new(Utils::req_id().abs(), 0, StorageType::Disk, FileType::File),
+        ExtendedBlock::new(Utils::req_id().abs(), 0, StorageType::Disk, FileType::File),
+    ];
+    let opened = open_batch(&client, &blocks, block_size, req_id, true)?;
+    let paths = opened
+        .results
+        .into_iter()
+        .map(|result| {
+            result
+                .response
+                .expect("successful batch open")
+                .path
+                .expect("short-circuit path")
+        })
+        .collect::<Vec<_>>();
+    assert!(paths.iter().all(|path| std::path::Path::new(path).exists()));
+
+    drop(client);
+    for _ in 0..100 {
+        if paths
+            .iter()
+            .all(|path| !std::path::Path::new(path).exists())
+        {
+            return Ok(());
+        }
+        thread::sleep(std::time::Duration::from_millis(10));
+    }
+    orpc::err_box!(
+        "batch disconnect did not abort all open blocks: {:?}",
+        paths
+    )
 }
 
 fn block_write(id: i64, conf: &ClusterConf) -> CommonResult<u64> {
@@ -386,7 +581,7 @@ fn block_write(id: i64, conf: &ClusterConf) -> CommonResult<u64> {
         .request(RequestStatus::Open)
         .req_id(req_id)
         .seq_id(seq_id)
-        .proto_header(request)
+        .proto_header(request.clone())
         .build();
 
     let client = conf.worker_sync_client()?;
@@ -419,6 +614,7 @@ fn block_write(id: i64, conf: &ClusterConf) -> CommonResult<u64> {
         .request(RequestStatus::Complete)
         .req_id(req_id)
         .seq_id(seq_id)
+        .proto_header(request)
         .build();
 
     let _: Message = client.rpc(msg)?;

--- a/curvine-tests/tests/fs_test.rs
+++ b/curvine-tests/tests/fs_test.rs
@@ -13,13 +13,17 @@
 // limitations under the License.
 
 use bytes::BytesMut;
-use curvine_client::file::{CurvineFileSystem, FsContext};
+use curvine_client::block::BatchBlockWriter;
+use curvine_client::file::{
+    BatchAddBlockRequest, BatchCompleteFileRequest, CurvineFileSystem, FsContext,
+};
 use curvine_client::ClientMetrics;
 use curvine_common::conf::ClusterConf;
+use curvine_common::error::FsError;
 use curvine_common::fs::{Path, Reader, Writer};
 use curvine_common::state::{
-    CreateFileOptsBuilder, ListOptions, MkdirOptsBuilder, SetAttrOptsBuilder, StorageState,
-    TtlAction,
+    CreateFileOptsBuilder, ListOptions, MkdirOptsBuilder, OpenFlags, SetAttrOptsBuilder,
+    StorageState, TtlAction,
 };
 use curvine_common::state::{FileLock, LockFlags, LockType};
 use curvine_common::FsResult;
@@ -54,6 +58,49 @@ fn test_filesystem_end_to_end_operations_on_cluster() -> FsResult<()> {
     Ok(())
 }
 
+#[test]
+fn test_batch_worker_partial_failure_end_to_end() -> FsResult<()> {
+    let rt = Arc::new(AsyncRuntime::single());
+    let testing = Testing::builder().default().build()?;
+    testing.start_cluster()?;
+    let mut conf = testing.get_active_cluster_conf()?;
+
+    // Keep the payloads in one batch while making one item exceed its block.
+    // This exercises a real Worker per-item write failure through the public API.
+    conf.client.short_circuit = false;
+    conf.client.write_chunk_size = 64;
+    conf.client.write_chunk_size_str = "64B".to_string();
+    conf.client.block_size = 8;
+    conf.client.block_size_str = "8B".to_string();
+    run_batch_worker_partial_failure_end_to_end(&testing, &rt, conf)
+}
+
+fn run_batch_worker_partial_failure_end_to_end(
+    testing: &Testing,
+    rt: &Arc<AsyncRuntime>,
+    conf: ClusterConf,
+) -> FsResult<()> {
+    let fs = testing.get_fs(Some(rt.clone()), Some(conf))?;
+    rt.block_on(async move {
+        let root = Path::from_str("/batch_worker_partial_failure")?;
+        let _ = fs.delete(&root, true).await;
+
+        let oversized = Path::from_str("/batch_worker_partial_failure/oversized")?;
+        let successful = Path::from_str("/batch_worker_partial_failure/successful")?;
+        let files = [(oversized.clone(), "too-large"), (successful.clone(), "ok")];
+
+        let outcomes = fs.write_batch_string(&files).await?;
+        assert_eq!(outcomes.len(), 2);
+        assert!(outcomes[0].is_err());
+        assert!(outcomes[1].is_ok());
+        assert_eq!(fs.read_string(&successful).await?, "ok");
+        let failed_status = fs.get_status(&oversized).await?;
+        assert!(!failed_status.is_complete);
+        assert_eq!(failed_status.len, 0);
+        Ok(())
+    })
+}
+
 fn run_filesystem_end_to_end_operations_on_cluster(
     testing: &Testing,
     rt: &Arc<AsyncRuntime>,
@@ -75,6 +122,9 @@ fn run_filesystem_end_to_end_operations_on_cluster(
 
         test_batch_writing(&fs).await?;
         println!("test_batch_writing done");
+
+        test_batch_inode_identity_survives_rename(&fs).await?;
+        println!("test_batch_inode_identity_survives_rename done");
 
         file_status(&fs).await?;
         println!("file_status done");
@@ -315,7 +365,11 @@ async fn test_batch_writing(fs: &CurvineFileSystem) -> CommonResult<()> {
         batch_files.push((path, test_small_data.as_str()));
     }
 
-    fs.write_batch_string(&batch_files).await?;
+    let outcomes = fs.write_batch_string(&batch_files).await?;
+    assert_eq!(outcomes.len(), batch_files.len());
+    for outcome in outcomes {
+        outcome?;
+    }
     // Using batch
     // Get block locations for all files
     let mut results = Vec::new();
@@ -360,6 +414,83 @@ async fn test_batch_writing(fs: &CurvineFileSystem) -> CommonResult<()> {
         println!("Verified file_{}: len={}, content matches", i, status.len);
     }
     println!("✓ All {} files written and verified correctly", num_files);
+
+    let parent_file = Path::from_str("/batch_test/batch/mixed_parent")?;
+    let invalid_child = Path::from_str("/batch_test/batch/mixed_parent/child")?;
+    let mixed_files = [
+        (parent_file.clone(), "successful item"),
+        (invalid_child, "failed item"),
+    ];
+    let mixed_outcomes = fs.write_batch_string(&mixed_files).await?;
+    assert_eq!(mixed_outcomes.len(), 2);
+    assert!(mixed_outcomes[0].is_ok());
+    assert!(mixed_outcomes[1].is_err());
+    assert_eq!(
+        read_file_content(fs, &parent_file).await?,
+        "successful item"
+    );
+
+    Ok(())
+}
+
+async fn test_batch_inode_identity_survives_rename(fs: &CurvineFileSystem) -> FsResult<()> {
+    let original = Path::from_str("/fs_test/batch_inode_original")?;
+    let renamed = Path::from_str("/fs_test/batch_inode_renamed")?;
+    let content = "batch inode identity";
+    let opts = fs.create_opts_builder().create_parent(true).build();
+    let flags = OpenFlags::new_write_only()
+        .set_create(true)
+        .set_overwrite(true);
+
+    let mut create_results = fs
+        .fs_client()
+        .create_files_batch(vec![(original.encode(), opts, flags)])
+        .await?;
+    let status = create_results
+        .pop()
+        .ok_or_else(|| FsError::common("missing batch create result"))?
+        .map_err(FsError::common)?;
+
+    assert!(fs.rename(&original, &renamed).await?);
+
+    let mut add_results = fs
+        .fs_client()
+        .add_blocks_batch(vec![BatchAddBlockRequest {
+            path: original.encode(),
+            inode_id: status.id,
+        }])
+        .await?;
+    let located_block = add_results
+        .pop()
+        .ok_or_else(|| FsError::common("missing batch add-block result"))?
+        .map_err(FsError::common)?;
+
+    let mut writer = BatchBlockWriter::new(fs.fs_context(), vec![located_block]).await?;
+    writer.write(&[(&renamed, content)]).await?;
+    let commit_block = writer
+        .complete()
+        .await
+        .pop()
+        .flatten()
+        .ok_or_else(|| FsError::common("batch worker commit failed"))?;
+
+    let mut complete_results = fs
+        .fs_client()
+        .complete_files_batch(vec![BatchCompleteFileRequest {
+            path: original.encode(),
+            inode_id: status.id,
+            len: content.len() as i64,
+            commit_blocks: vec![commit_block],
+            client_name: fs.fs_context().clone_client_name(),
+            only_flush: false,
+        }])
+        .await?;
+    complete_results
+        .pop()
+        .ok_or_else(|| FsError::common("missing batch complete result"))?
+        .map_err(FsError::common)?;
+
+    assert_eq!(fs.read_string(&renamed).await?, content);
     Ok(())
 }
 


### PR DESCRIPTION
# Summary

Make small-file batch writes a vectorized form of standalone file writes. Every input now receives one ordered `FsResult<()>`, and a failure in one file no longer stops, hides, or changes the outcome of another file.

# Issue Describe / Design

Closes #1045

The old path had two coupled problems:

1. Worker batch open/write/complete processing could stop at the first item-local error, so later blocks were not processed and the response could not describe every block.
2. Client and Master layers collapsed per-block responses into one aggregate `FsResult<()>`, so the original caller could not identify which file succeeded.

The fix treats batch execution as an indexed collection of standalone writes. File `i` is successful only when its create, block allocation, data write/flush, every Worker replica completion, and Master completion all succeed. Item-local failures remain attached to index `i`; batch-wide errors are reserved for failures that cannot be attributed safely.

Key design points:

- Worker open/write/complete loops continue after item-local errors and return one ordered result per block.
- Batch and standalone completion share `WriteHandler::complete_block`, including validation, flush, finalize, and best-effort abort behavior.
- The existing `BlocksBatchCommitRequest` / `BlocksBatchCommitResponse` RPC is retained. An additive `cancel_flags` field allows successful items to finalize and failed items to abort in the same request; the existing `results[i]` reports each requested operation.
- `BatchBlockWriter` groups blocks by their actual assigned Worker, collects all Worker responses, and ANDs replica outcomes back onto original file indices.
- Only Worker-complete files are sent to Master completion, and Master results are restored to the original input order.
- The inode returned by batch create is carried through add-block and complete-file requests, so a rename between phases cannot retarget metadata operations by path.
- Remote completion relies on the standalone Worker completion path; the obsolete remote batch-flush path is removed. Short-circuit local files are still flushed before completion.
- `write_batch_string` returns `FsResult<Vec<FsResult<()>>>`. Oversized inputs continue through `write_string`, while smaller internal batches preserve the original global order.

## Compatibility

- The public Rust return type changes from `FsResult<()>` to `FsResult<Vec<FsResult<()>>>`. The repository has no production caller of this API outside tests.
- Worker commit keeps the same RPC and protobuf message. `cancel_flags` is additive, and a new Worker still accepts the legacy batch-wide `cancel` field. However, a new client must not use mixed per-item completion against an old Worker because the old Worker ignores `cancel_flags`; update client and Worker together for the batch-write path.
- Master response details and inode IDs are additive protobuf fields, but the new client expects ordered structured batch results. A coordinated client/server upgrade is recommended for this currently unused batch API.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| Worker write handlers | Process open/write/complete per item; reuse standalone completion; remove obsolete remote batch flush | One block failure no longer short-circuits later blocks |
| Worker protocol/client | Retain the existing batch commit RPC, add per-item `cancel_flags`, and consume ordered `results` | Mixed finalize/abort is expressible without replacing the RPC |
| `BatchBlockWriter` | Group by actual Worker assignment, collect all responses, and AND replica results by original index | Heterogeneous placements and partial replica failures are handled correctly |
| Master batch RPCs | Return structured create/add/complete results and carry `inode_id` after create | Per-file metadata failures remain attributable; rename cannot lose inode identity |
| `CurvineFileSystem` | Return ordered `Vec<FsResult<()>>`, split internal batches safely, and complete only Worker-successful files | Callers can retry only failed files |
| Tests | Cover Worker item isolation, cleanup, grouping, replica aggregation, inode identity, and public partial-failure outcomes | Verifies the full Worker → Client → Master → public-result path |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `make format` | PASS | Full release formatting and Clippy checks; `bdi.rs` is unchanged |
| `cargo test -p curvine-client -p curvine-server --lib` | PASS | Client: 52 passed; Server: 83 passed, 1 ignored |
| `cargo test -p curvine-server --test worker_test -- --test-threads=1` | PASS | 13 Worker integration tests, including partial completion and cleanup |
| `cargo test -p curvine-tests --test fs_test test_filesystem_end_to_end_operations_on_cluster -- --test-threads=1` | PASS | Includes ordered outcomes and inode identity across rename |
| `cargo test -p curvine-tests --test fs_test test_batch_worker_partial_failure_end_to_end -- --test-threads=1` | PASS | Real Worker validation failure reaches the public result as `[Err, Ok]`; successful file reads back |

# Dependencies

- Related PRs: None
- Related issues: #1045
- Blocks / blocked by: None
