### PR TITLE
docs(skills): update cv-submit-pr-review skill workflow

### DIFF
--- a/.agents/skills/cv-submit-pr-review/SKILL.md
+++ b/.agents/skills/cv-submit-pr-review/SKILL.md
@@ -1,170 +1,266 @@
 ---
 name: cv-submit-pr-review
-description: Perform a direct code review of a Curvine PR by reading the diff and changed files, analyzing correctness, safety, and design issues, and producing structured findings. Use when user asks to review a PR's code, do a code review, or check a PR before merge.
+description: Perform a direct code review of a Curvine PR by reading the diff and changed files, analyzing correctness, safety, and design issues, and producing structured findings. Use when user asks to review a PR's code, do a code review, or check a PR before merge.Review a pull request by inspecting the native PR diff with GitHub CLI, draft original review comments in English, ignore Copilot-generated comments, show the draft comments locally first, and only submit them to GitHub after explicit user confirmation.
 ---
 
-# cv-submit-pr-review
-
-Review a Curvine PR's code content directly: locate PR → read diff → gather context → analyze → report findings → optionally post review.
+# Review PR Workflow
 
 ## When to Use
 
-- User asks to review / check / look at a PR's code
-- User wants a code review before merge
-- User provides a PR URL or number and asks for review
-- User asks "is this PR OK?" or "review this change"
+Use this skill when the user asks to:
 
-**Not for:** responding to existing reviewer comments → use [cv-address-pr-review](../cv-address-pr-review/SKILL.md).
+* review a PR directly from its code changes
+
+* inspect the current branch PR or a specified PR number
+
+* draft review comments before posting them
+
+* submit drafted PR comments after confirmation
 
 ## Review Scope
 
 Focus **exclusively on code content**:
 
-| Dimension | What to check |
-| --------- | ------------- |
-| Correctness | Logic errors, edge cases, off-by-one, None/null handling, error propagation |
-| Safety | Concurrency races, panics / unwrap in hot paths, unsafe blocks, resource leaks, lock ordering |
-| Design | Naming, module boundaries, abstractions, consistency with existing patterns |
+|Dimension|What to check|
+|:----|:----|
+|Correctness|Logic errors, edge cases, off-by-one, None/null handling, error propagation|
+|Safety|Concurrency races, panics / unwrap in hot paths, unsafe blocks, resource leaks, lock ordering|
+|Design|Naming, module boundaries, abstractions, consistency with existing patterns|
 
 **Ignore:** commit message quality, PR description wording, pure formatting nits (run `make format` separately).
 
-## Step 1: Locate PR
+## Communication Rules
+
+* Use English for all PR-facing communication.
+
+* Use concise, professional, actionable review comments.
+
+* Do **not** reply to Copilot-generated comments.
+
+* Do **not** post any comment to GitHub until the user explicitly confirms.
+
+* Show drafted comments locally first.
+
+* Execute intermediate local analysis commands directly, including inline `python` / `python3` scripts used to parse API output, inspect diffs, or locate review anchors. Do **not** ask for confirmation for those local scripts.
+
+* Execute read-only GitHub CLI commands directly, including `gh pr view`, `gh pr diff`, and `gh api` GET requests used to inspect PR metadata, diffs, files, comments, or review state. Do **not** ask for confirmation for those read-only `gh` commands.
+
+* Ask for confirmation only before GitHub-side effects such as posting review comments or submitting a review.
+
+## Step 1: Locate the Target PR
+
+If the user provided a PR number, use it directly.
+
+Otherwise, locate the PR for the current branch:
+
+1. Get current branch:
 
 ```bash
-# Current branch
-gh pr view --json number,url,title,headRefName,baseRefName,additions,deletions,changedFiles
-
-# By number or URL
-gh pr view <number> --json number,url,title,headRefName,baseRefName,additions,deletions,changedFiles
+git branch --show-current
 ```
-
-If no PR exists on the current branch, ask the user for a PR number/URL or whether to review uncommitted local changes instead.
-
-## Step 2: Collect Diff
+1. Try current-branch PR directly:
 
 ```bash
-PR=<number>
+gh pr view --json number,url,headRefName,baseRefName,title
+```
+1. If the previous command fails, query by head branch:
 
-# Full diff with stats
-gh pr diff ${PR}
+```bash
+gh pr list --head "$(git branch --show-current)" --json number,url,headRefName,baseRefName,title --limit 1
+```
+If no PR is found, stop and ask the user whether to create one first.
+## Step 2: Collect PR Context
 
-# Per-file summary
-gh pr view ${PR} --json files --jq '.files[] | "\(.path)\t+\(.additions)\t-\(.deletions)"'
+For PR number `<PR_NUMBER>`, collect:
+
+1. PR metadata:
+
+```bash
+gh pr view <PR_NUMBER> --json number,url,title,body,headRefName,baseRefName,reviews
+```
+1. PR diff:
+
+```bash
+gh pr diff <PR_NUMBER>
+```
+1. Changed files:
+
+```bash
+gh api "repos/{owner}/{repo}/pulls/<PR_NUMBER>/files?per_page=100"
+```
+1. Existing review comments, only to avoid duplicates:
+
+```bash
+gh api "repos/{owner}/{repo}/pulls/<PR_NUMBER>/comments?per_page=100"
 ```
 
-For large PRs (> ~1000 lines), review file-by-file in logical batches rather than one giant diff.
-
-## Step 3: Gather Context
 
 For each changed file, read the **full file** (not just the diff hunk) so you understand surrounding code, types, and call sites:
 
+
 1. Read the changed file in full
+
 2. Find callers / definitions of changed symbols (`SearchSymbol`, `Grep`)
+
 3. Check related module knowledge via `SearchMemory` for conventions and patterns
+
 
 Context prevents false positives — a change that looks wrong in isolation may be correct given surrounding code.
 
-## Step 4: Analyze (Per File)
 
-Work through each changed file systematically. For every non-trivial change ask:
+Ignore comments authored by:
 
-- **Correctness:** Does the logic do what it claims? Are edge cases handled? Are errors propagated, not swallowed?
-- **Safety:** Can this panic? Is there a race? Are locks held correctly? Any `unsafe`? Any resource (file/conn/mutex) not released?
-- **Design:** Does this fit existing patterns in the module? Is the abstraction at the right level? Are names clear?
+* `Copilot`
 
-Cross-reference against:
-- Module knowledge cards (`SearchMemory`) for architecture and conventions
-- Existing tests to verify the change is covered
+* `copilot-pull-request-reviewer[bot]`
 
-## Step 5: Findings Report (Mandatory Before Any Action)
+Do not review Copilot's review text itself. Review the native PR code content.
 
-Output a table of all findings. Do **not** post to GitHub yet.
+
+## Step 3: Review the Native PR Code
+
+Inspect the actual code changes and look for:
+
+* correctness issues
+
+* regressions
+
+* missing validation or edge-case handling
+
+* unsafe or brittle logic
+
+* missing or insufficient tests
+
+* maintainability issues worth commenting on
+
+Only draft comments that are specific and actionable.
+
+ Do not manufacture comments just to increase comment count.
+
+Prefer line-specific comments when possible.
+
+ Use a general PR comment only for cross-file or high-level issues.
+
+## Step 4: Build a Local Draft Checklist
+
+Before posting anything, output a local checklist for the user.
+
+ This checklist is only for the local chat.
+
+ Do **not** post this table to GitHub.
+
+Use this template:
 
 ```markdown
-| # | Severity | File:Line | Finding | Suggestion |
-| - | -------- | --------- | ------- | ---------- |
-| 1 | Critical | src/foo.rs:42 | Unwrap on Option that can be None when X | Use `ok_or_else` + error propagation |
-| 2 | Major | src/bar.rs:88 | Lock held across await — potential deadlock | Move await outside lock scope |
-| 3 | Minor | src/baz.rs:15 | Name `do_thing` is vague | Rename to `replicate_block` |
+| draft_id | path | line | category | action | status | summary |
+|----------|------|------|----------|--------|--------|---------|
+| 1 | src/foo.rs | 42 | must-fix | draft-comment | todo | missing error handling |
+| 2 | .github/workflows/build.yml | 88 | suggestion | draft-comment | todo | test failure path is swallowed |
 ```
+Status values:
+* `todo`: not drafted yet
 
-### Severity levels
+* `in-progress`: currently drafting
 
-| Level | Meaning |
-| ----- | ------- |
-| Critical | Bug, data loss, security hole, deadlock — must fix before merge |
-| Major | Likely bug, missing error handling, design issue — should fix |
-| Minor | Clarity, naming, minor consistency — nice to have |
-| Nit | Style / preference — optional |
+* `done`: draft ready for user review
 
-If **no issues found**, state that explicitly with a brief summary of what was checked.
+* `skipped`: no comment needed
 
-## Step 6: User Decision
+## Step 5: Draft the Review Comments Locally
 
-Present the findings table and ask the user how to proceed:
+For each draft comment, include:
 
-- **Fix** — address findings locally, then use [cv-create-pr](../cv-create-pr/SKILL.md) to update
-- **Post review** — submit findings as a GitHub PR review (Step 7)
-- **Discuss** — clarify specific findings before acting
+* file path
 
-Do **not** fix or post anything without explicit user approval.
+* target line if line-specific
 
-## Step 7: Post Review to GitHub (Optional)
+* short issue summary
 
-Only when the user asks to post. Submit as a PR review with inline + summary comments.
+* final English comment text
 
-### Inline comments
+Comment body requirements:
+
+* state the concrete issue
+
+* explain the impact briefly
+
+* suggest a fix or direction
+
+* keep it short and professional
+
+Good example:
+
+```plain
+This path can silently treat a failed test run as success because the step always exits 0 before the final status check. Consider failing immediately here or making the status propagation explicit so the workflow cannot report a false green result.
+```
+## Step 6: Ask for Confirmation Before Posting
+
+After listing the local draft comments, stop and ask the user to confirm.
+
+Do not submit anything to GitHub until the user explicitly says to proceed.
+
+## Step 7: Submit Comments to GitHub After Confirmation
+
+When submitting GitHub comments from the shell, always pass the review body through a HEREDOC or another shell-safe quoted form. Do **not** embed raw backticks directly inside a double-quoted shell argument, because shell command substitution can corrupt the posted comment text.
+
+### Submit a line review comment
+
+Use the PR head commit SHA from `gh pr view <PR_NUMBER> --json commits` or PR detail metadata.
 
 ```bash
 gh api \
   -X POST \
-  "repos/{owner}/{repo}/pulls/${PR}/comments" \
-  -f body="<finding detail + suggestion>" \
-  -f path="<file>" \
-  -F line=<line> \
-  -F side=RIGHT \
-  -f commit_id="$(gh pr view ${PR} --json headRefOid --jq .headRefOid)"
+  "repos/{owner}/{repo}/pulls/<PR_NUMBER>/comments" \
+  -f body="$(cat <<'EOF'
+Comment text here
+EOF
+)" \
+  -f commit_id='<HEAD_SHA>' \
+  -f path='path/to/file' \
+  -F line=<LINE_NUMBER> \
+  -f side='RIGHT'
 ```
-
-Use `line` for single-line, or `start_line` + `line` for multi-line ranges (both on `side=RIGHT`).
-
-### Review summary
+### Submit a general PR review comment
 
 ```bash
-gh pr review ${PR} \
-  --request \
-  --body "$(cat <<'EOF'
-## Code Review
-
-Reviewed <N> files, <M> lines changed.
-
-### Summary
-<overall assessment: is the change sound? what's the main risk?>
-
-### Findings: <count>
-- Critical: <n>
-- Major: <n>
-- Minor: <n>
-
-See inline comments for details.
+gh pr review <PR_NUMBER> --comment --body "$(cat <<'EOF'
+General review comment text here
 EOF
 )"
 ```
+Post only the comments the user approved.
+## Filters and Defaults
 
-Review states: `--request` (request changes), `--approve`, or `--comment` (neutral). Default to `--comment` unless the user specifies otherwise.
+* Ignore Copilot-generated comments unless the user explicitly asks to review or reply to them.
+
+* Avoid duplicating existing human review comments unless the new comment is materially clearer.
+
+* Prefer fewer high-signal comments over many low-value comments.
+
+* Do not make code changes as part of this workflow unless the user separately asks for fixes.
+
 
 ## Checklist
 
-- [ ] PR located and diff collected
-- [ ] Changed files read in full (not just hunks)
-- [ ] Callers / definitions of changed symbols checked
-- [ ] Module conventions verified (knowledge cards / existing patterns)
-- [ ] Findings table produced with severity per item
-- [ ] User decided on next action (fix / post / discuss)
-- [ ] Review posted only after explicit approval
+- [ ]  PR located and diff collected
+
+- [ ]  Changed files read in full (not just hunks)
+
+- [ ]  Callers / definitions of changed symbols checked
+
+- [ ]  Module conventions verified (knowledge cards / existing patterns)
+
+- [ ]  Findings table produced with severity per item
+
+- [ ]  User decided on next action (fix / post / discuss)
+
+- [ ]  Review posted only after explicit approval
 
 ## Related
 
-- Handle existing reviewer comments → [cv-address-pr-review](../cv-address-pr-review/SKILL.md)
-- Fix findings and update PR → [cv-create-pr](../cv-create-pr/SKILL.md)
-- Review during issue fix → [cv-handle-issue](../cv-handle-issue/SKILL.md)
+* Handle existing reviewer comments → [cv-address-pr-review](https://../cv-address-pr-review/SKILL.md)
+
+* Fix findings and update PR → [cv-create-pr](https://../cv-create-pr/SKILL.md)
+
+* Review during issue fix → [cv-handle-issue](https://../cv-handle-issue/SKILL.md)
+

--- a/.agents/skills/cv-submit-pr-review/SKILL.md
+++ b/.agents/skills/cv-submit-pr-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cv-submit-pr-review
-description: Perform a direct code review of a Curvine PR by reading the diff and changed files, analyzing correctness, safety, and design issues, and producing structured findings. Use when user asks to review a PR's code, do a code review, or check a PR before merge.Review a pull request by inspecting the native PR diff with GitHub CLI, draft original review comments in English, ignore Copilot-generated comments, show the draft comments locally first, and only submit them to GitHub after explicit user confirmation.
+description: Perform a direct code review of a Curvine PR by reading the diff and changed files, analyzing correctness, safety, and design issues, and producing structured findings. Use when user asks to review a PR's code, do a code review, or check a PR before merge.
 ---
 
 # Review PR Workflow
@@ -258,9 +258,9 @@ Post only the comments the user approved.
 
 ## Related
 
-* Handle existing reviewer comments → [cv-address-pr-review](https://../cv-address-pr-review/SKILL.md)
+* Handle existing reviewer comments → [cv-address-pr-review](../cv-address-pr-review/SKILL.md)
 
-* Fix findings and update PR → [cv-create-pr](https://../cv-create-pr/SKILL.md)
+* Fix findings and update PR → [cv-create-pr](../cv-create-pr/SKILL.md)
 
-* Review during issue fix → [cv-handle-issue](https://../cv-handle-issue/SKILL.md)
+* Review during issue fix → [cv-handle-issue](../cv-handle-issue/SKILL.md)
 


### PR DESCRIPTION
# Summary

Restructure the `cv-submit-pr-review` skill documentation into an explicit, step-by-step PR review workflow so the review process is clearer and more repeatable.

# Issue Describe / Design

No linked issue. This is a documentation-only update to a project skill file.

Design notes:
- Reorganized into ordered steps: locate PR, collect context, review native code, build a local draft checklist, draft comments, confirm before posting, and submit.
- Added explicit communication rules distinguishing read-only inspection commands (run directly) from side-effecting GitHub operations (require user confirmation).
- Documented Copilot comment filtering and duplicate-avoidance defaults.
- Added shell-safe HEREDOC guidance for posting comments to avoid backtick corruption.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `.agents/skills/cv-submit-pr-review/SKILL.md` | Rewrote skill into stepwise workflow with communication rules, draft checklist, and posting guidance | None (docs only); guides agent behavior for PR reviews |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| Manual review of rendered markdown | PASS | Documentation-only change; no code affected |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None

Made with [Cursor](https://cursor.com)