### PR TITLE
refactor(spdk): decouple bdev and poller dead flags by removing qpair_dead from IoRequest

### DIFF
--- a/orpc/src/io/spdk_bdev.rs
+++ b/orpc/src/io/spdk_bdev.rs
@@ -350,7 +350,6 @@ impl SpdkBdev {
                 },
                 completion: completion.clone(),
                 bdev_inflight: self.inflight.clone(),
-                qpair_dead: self.io_channel.qpair_dead.clone(),
             };
             if self.io_channel.poller_tx.send(req).is_err() {
                 self.inflight
@@ -368,6 +367,7 @@ impl SpdkBdev {
             }
             let rc = completion.wait(self.io_timeout_ms * 1000);
             if rc != 0 {
+                self.io_channel.qpair_dead.store(true, Ordering::Release);
                 return err_box!(
                     "NVMe read failed on '{}' at offset={}: {}",
                     self.name,
@@ -430,7 +430,6 @@ impl SpdkBdev {
                     },
                     completion: completion.clone(),
                     bdev_inflight: self.inflight.clone(),
-                    qpair_dead: self.io_channel.qpair_dead.clone(),
                 };
                 if self.io_channel.poller_tx.send(req).is_err() {
                     self.inflight
@@ -449,6 +448,7 @@ impl SpdkBdev {
                 let rc = completion.wait(self.io_timeout_ms * 1000);
 
                 if rc != 0 {
+                    self.io_channel.qpair_dead.store(true, Ordering::Release);
                     return err_box!(
                         "Read-modify-write: read failed on '{}' at offset={}: {}",
                         self.name,
@@ -479,7 +479,6 @@ impl SpdkBdev {
                 },
                 completion: completion.clone(),
                 bdev_inflight: self.inflight.clone(),
-                qpair_dead: self.io_channel.qpair_dead.clone(),
             };
             if self.io_channel.poller_tx.send(req).is_err() {
                 self.inflight
@@ -497,6 +496,7 @@ impl SpdkBdev {
             }
             let rc = completion.wait(self.io_timeout_ms * 1000);
             if rc != 0 {
+                self.io_channel.qpair_dead.store(true, Ordering::Release);
                 return err_box!(
                     "NVMe write failed on '{}' at offset={}, len={}: {}",
                     self.name,
@@ -528,7 +528,6 @@ impl SpdkBdev {
             },
             completion: completion.clone(),
             bdev_inflight: self.inflight.clone(),
-            qpair_dead: self.io_channel.qpair_dead.clone(),
         };
         if self.io_channel.poller_tx.send(req).is_err() {
             return err_box!("SPDK poller thread is gone");
@@ -544,6 +543,7 @@ impl SpdkBdev {
         }
         let rc = completion.wait(self.io_timeout_ms * 1000);
         if rc != 0 {
+            self.io_channel.qpair_dead.store(true, Ordering::Release);
             return err_box!(
                 "NVMe flush failed on '{}': {}",
                 self.name,

--- a/orpc/src/io/spdk_bdev.rs
+++ b/orpc/src/io/spdk_bdev.rs
@@ -367,7 +367,9 @@ impl SpdkBdev {
             }
             let rc = completion.wait(self.io_timeout_ms * 1000);
             if rc != 0 {
-                self.io_channel.qpair_dead.store(true, Ordering::Release);
+                if rc == -libc::EIO {
+                    self.io_channel.qpair_dead.store(true, Ordering::Release);
+                }
                 return err_box!(
                     "NVMe read failed on '{}' at offset={}: {}",
                     self.name,
@@ -448,7 +450,9 @@ impl SpdkBdev {
                 let rc = completion.wait(self.io_timeout_ms * 1000);
 
                 if rc != 0 {
-                    self.io_channel.qpair_dead.store(true, Ordering::Release);
+                    if rc == -libc::EIO {
+                        self.io_channel.qpair_dead.store(true, Ordering::Release);
+                    }
                     return err_box!(
                         "Read-modify-write: read failed on '{}' at offset={}: {}",
                         self.name,
@@ -496,7 +500,9 @@ impl SpdkBdev {
             }
             let rc = completion.wait(self.io_timeout_ms * 1000);
             if rc != 0 {
-                self.io_channel.qpair_dead.store(true, Ordering::Release);
+                if rc == -libc::EIO {
+                    self.io_channel.qpair_dead.store(true, Ordering::Release);
+                }
                 return err_box!(
                     "NVMe write failed on '{}' at offset={}, len={}: {}",
                     self.name,
@@ -543,7 +549,9 @@ impl SpdkBdev {
         }
         let rc = completion.wait(self.io_timeout_ms * 1000);
         if rc != 0 {
-            self.io_channel.qpair_dead.store(true, Ordering::Release);
+            if rc == -libc::EIO {
+                self.io_channel.qpair_dead.store(true, Ordering::Release);
+            }
             return err_box!(
                 "NVMe flush failed on '{}': {}",
                 self.name,

--- a/orpc/src/io/spdk_poller.rs
+++ b/orpc/src/io/spdk_poller.rs
@@ -269,6 +269,7 @@ impl SpdkPoller {
         let mut state = PollerState::Idle;
         // Tracks per-qpair state (dead flag + pending Vec) for force-completion.
         let mut dead_qpairs: HashMap<usize, Box<QpairState>> = HashMap::new();
+        let has_orphaned = AtomicBool::new(false);
 
         // Verify curvine_async_ctx buffer fits the C struct.
         debug_assert!(
@@ -305,6 +306,8 @@ impl SpdkPoller {
                             &req,
                             &mut active_qpairs,
                             &mut dead_qpairs,
+                            &*orphaned,
+                            &has_orphaned,
                             config.io_queue_depth,
                         );
                     }
@@ -316,7 +319,13 @@ impl SpdkPoller {
                 }
 
                 // Poll qpairs for completions and detect failures
-                Self::poll_and_sweep(&mut active_qpairs, &mut dead_qpairs, &*orphaned, "poller");
+                Self::poll_and_sweep(
+                    &mut active_qpairs,
+                    &mut dead_qpairs,
+                    &*orphaned,
+                    &has_orphaned,
+                    "poller",
+                );
 
                 // Process admin completions (keep-alive)
                 Self::process_admin_completions(&active_ctrlrs);
@@ -393,6 +402,8 @@ impl SpdkPoller {
                                     &req,
                                     &mut active_qpairs,
                                     &mut dead_qpairs,
+                                    &*orphaned,
+                                    &has_orphaned,
                                     config.io_queue_depth,
                                 );
                             }
@@ -412,6 +423,7 @@ impl SpdkPoller {
                             &mut active_qpairs,
                             &mut dead_qpairs,
                             &*orphaned,
+                            &has_orphaned,
                             "keep-alive",
                         );
 
@@ -510,6 +522,8 @@ impl SpdkPoller {
         req: &IoRequest,
         active_qpairs: &mut Vec<*mut spdk_ffi::spdk_nvme_qpair>,
         dead_qpairs: &mut HashMap<usize, Box<QpairState>>,
+        orphaned: &Mutex<HashMap<usize, Box<QpairState>>>,
+        has_orphaned: &AtomicBool,
         io_queue_depth: usize,
     ) {
         let qpair = match &req.op {
@@ -522,6 +536,17 @@ impl SpdkPoller {
         };
 
         let key = qpair as usize;
+
+        // Fast-fail if this qpair was previously orphaned (poller-detected death).
+        if has_orphaned.load(Ordering::Acquire) {
+            if let Ok(guard) = orphaned.lock() {
+                if guard.contains_key(&key) {
+                    req.completion.complete(-libc::ENODEV);
+                    req.bdev_inflight.fetch_sub(1, Ordering::Release);
+                    return;
+                }
+            }
+        }
 
         // Register/retrieve QpairState on first sight of this qpair.
         let qs = dead_qpairs.entry(key).or_insert_with(|| {
@@ -668,6 +693,7 @@ impl SpdkPoller {
         active_qpairs: &mut Vec<*mut spdk_ffi::spdk_nvme_qpair>,
         dead_qpairs: &mut HashMap<usize, Box<QpairState>>,
         orphaned: &Mutex<HashMap<usize, Box<QpairState>>>,
+        has_orphaned: &AtomicBool,
         context: &str,
     ) {
         let err_keys: Vec<usize> = active_qpairs
@@ -705,6 +731,7 @@ impl SpdkPoller {
                 guard.insert(key, qs);
             }
         }
+        has_orphaned.store(true, Ordering::Release);
         error!(
             "{} qpair(s) failed, removed from active set",
             err_keys.len()

--- a/orpc/src/io/spdk_poller.rs
+++ b/orpc/src/io/spdk_poller.rs
@@ -541,8 +541,9 @@ impl SpdkPoller {
         if has_orphaned.load(Ordering::Acquire) {
             if let Ok(guard) = orphaned.lock() {
                 if guard.contains_key(&key) {
-                    req.completion.complete(-libc::ENODEV);
-                    req.bdev_inflight.fetch_sub(1, Ordering::Release);
+                    if req.completion.complete(-libc::EIO) {
+                        req.bdev_inflight.fetch_sub(1, Ordering::Release);
+                    }
                     return;
                 }
             }

--- a/orpc/src/io/spdk_poller.rs
+++ b/orpc/src/io/spdk_poller.rs
@@ -733,6 +733,7 @@ impl SpdkPoller {
             }
         }
         has_orphaned.store(true, Ordering::Release);
+        // TODO: reset has_orphaned when orphaned map drains empty (in reclaim_stale)
         error!(
             "{} qpair(s) failed, removed from active set",
             err_keys.len()
@@ -756,6 +757,7 @@ unsafe impl Send for QpairState {}
 
 impl QpairState {
     #[cfg(test)]
+    // TODO: when this becomes production (deferred cleanup PR), reset has_orphaned after draining empty
     fn reclaim_stale(&mut self) {
         for ptr in self.stale.drain(..) {
             unsafe { drop(Box::from_raw(ptr as *mut CallbackCtx)) };

--- a/orpc/src/io/spdk_poller.rs
+++ b/orpc/src/io/spdk_poller.rs
@@ -119,9 +119,6 @@ pub struct IoRequest {
     pub completion: Arc<IoCompletion>,
     /// Per-bdev in-flight counter. Decremented on completion.
     pub bdev_inflight: Arc<AtomicUsize>,
-    /// Per-qpair dead flag. Set by the poller when qpair poll fails;
-    /// checked by the bdev to fail subsequent I/Os fast.
-    pub qpair_dead: Arc<AtomicBool>,
 }
 
 // SAFETY: exclusive ownership - blocks until completion.
@@ -232,7 +229,6 @@ impl SpdkPoller {
             op: IoOp::UnregisterQpair { qpair, ack: ack_tx },
             completion: IoCompletion::new(),
             bdev_inflight: Arc::new(AtomicUsize::new(0)),
-            qpair_dead: Arc::new(AtomicBool::new(false)),
         };
         if let Some(tx) = &self.tx {
             let _ = tx.send(req);
@@ -530,18 +526,11 @@ impl SpdkPoller {
         // Register/retrieve QpairState on first sight of this qpair.
         let qs = dead_qpairs.entry(key).or_insert_with(|| {
             Box::new(QpairState {
-                dead: req.qpair_dead.clone(),
+                dead: Arc::new(AtomicBool::new(false)),
                 pending: Vec::with_capacity(io_queue_depth),
                 stale: Vec::new(),
             })
         });
-
-        // Fast-fail if this qpair is already known dead.
-        if req.qpair_dead.load(Ordering::Acquire) {
-            req.bdev_inflight.fetch_sub(1, Ordering::Release);
-            req.completion.complete(-libc::ENXIO);
-            return;
-        }
 
         let pending_idx = qs.pending.len();
         let qs_ptr = &mut **qs as *mut QpairState;
@@ -880,6 +869,8 @@ mod test {
         assert!(dead_qpairs.contains_key(&DEAD));
         assert_eq!(dead_qpairs[&DEAD].stale.len(), 2);
         assert_eq!(dead_qpairs[&DEAD].pending.len(), 0);
+
+        // Assert: dead flag set.
         assert!(dead_flag.load(Ordering::Acquire));
 
         // Reclaim stale entries (frees CallbackCtx, signals already done).
@@ -998,6 +989,30 @@ mod test {
     }
 
     #[test]
+    fn poller_callback_empty_pending_signals_completion() {
+        let inflight = Arc::new(AtomicUsize::new(1));
+        let completion = IoCompletion::new();
+        let qs = Box::new(QpairState {
+            dead: Arc::new(AtomicBool::new(false)),
+            pending: Vec::new(),
+            stale: Vec::new(),
+        });
+        let ctx = Box::into_raw(Box::new(CallbackCtx {
+            completion: completion.clone(),
+            async_ctx: unsafe { std::mem::zeroed() },
+            bdev_inflight: inflight.clone(),
+            qpair_state: &*qs as *const QpairState as *mut QpairState,
+            pending_idx: 0,
+        }));
+
+        unsafe { poller_callback(ctx as *mut c_void, 42) };
+
+        // Hot path always signals completion and decrements inflight.
+        assert_eq!(completion.wait(0), 42);
+        assert_eq!(inflight.load(Ordering::Acquire), 0);
+    }
+
+    #[test]
     fn submit_one_rc_error_cleans_up_pending_entry() {
         // Pre-push: entry added before SPDK submit call.
         let inflight = Arc::new(AtomicUsize::new(1));
@@ -1109,14 +1124,22 @@ mod test {
             completion_0.complete(-libc::EIO);
         }
 
+        // ctx_0 freed and cleaned up.
         assert_eq!(qs.pending.len(), 1);
         assert_eq!(completion_0.wait(0), -libc::EIO);
         assert_eq!(inflight_0.load(Ordering::Acquire), 0);
 
+        // ctx_1 still alive, reindexed to 0.
         assert_eq!(unsafe { (*qs.pending[0]).pending_idx }, 0);
         assert_eq!(completion_1.wait(1), -libc::ETIMEDOUT);
+        assert_eq!(
+            inflight_1.load(Ordering::Acquire),
+            1,
+            "stale entry inflight must not be decremented"
+        );
         assert_eq!(inflight_1.load(Ordering::Acquire), 1);
 
+        // Clean up ctx_1.
         unsafe { drop(Box::from_raw(ctx_1)) };
     }
 
@@ -1237,7 +1260,6 @@ mod test {
             op: IoOp::UnregisterQpair { qpair, ack: ack_tx },
             completion: IoCompletion::new(),
             bdev_inflight: Arc::new(AtomicUsize::new(0)),
-            qpair_dead: Arc::new(AtomicBool::new(false)),
         };
 
         SpdkPoller::handle_unregister(&req, &mut active_qpairs, &mut dead_qpairs, &orphaned);
@@ -1334,7 +1356,6 @@ mod test {
             op: IoOp::UnregisterQpair { qpair, ack: ack_tx },
             completion: IoCompletion::new(),
             bdev_inflight: Arc::new(AtomicUsize::new(0)),
-            qpair_dead: Arc::new(AtomicBool::new(false)),
         };
 
         SpdkPoller::handle_unregister(&req, &mut active_qpairs, &mut dead_qpairs, &orphaned);


### PR DESCRIPTION
# Description

- Remove the shared `qpair_dead` flag from `IoRequest` and eliminate the old fast-fail check in `submit_one`. The bdev now owns its own `qpair_dead` flag, set directly on transport error. The poller's `QpairState.dead` becomes independent (`Arc::new(AtomicBool::new(false))`) instead of cloning the bdev's flag.
- Fix NVMe error misclassification: only poison `qpair_dead` on confirmed transport failure (`-EIO`), not for NVMe command/media statuses or timeouts.
- Close the idle keep-alive propagation gap: `submit_one` checks the orphaned map with an `AtomicBool` guard to fast-fail before touching the transport.
- Resolves part of [issue-710](https://github.com/CurvineIO/curvine/issues/710)

# Motivation

The shared `qpair_dead` flag in `IoRequest` introduced cross-thread coupling between the bdev I/O path and the poller thread. Every I/O request carried a clone of the same `Arc<AtomicBool>`, which was then checked by the poller's `submit_one` before submission. This design:

- Added per-request overhead (an extra `Arc` clone + atomic load on the fast path)
- Tied the bdev's error detection to the poller's I/O submission logic
- Required the bdev to pass thread-shared state through `IoRequest`, which complicated the struct's ownership story

# Key Changes

- `spdk_poller.rs`
  - Removed `qpair_dead` field from `IoRequest`.
  - Removed the old `-ENXIO` fast-fail check in `submit_one`.
  - `QpairState.dead` now uses a fresh `Arc::new(AtomicBool::new(false))` instead of `req.qpair_dead.clone()`.
  - Added orphaned map check in `submit_one` with `has_orphaned` AtomicBool guard, fast-failing with `-EIO` when a previously orphaned qpair receives new I/O.
  - `poll_and_sweep` sets `has_orphaned.store(true)` after orphaning.

- `spdk_bdev.rs`
  - Removed `qpair_dead: self.io_channel.qpair_dead.clone()` from all `IoRequest` constructions.
  - Only poison `qpair_dead` on `rc == -libc::EIO` (confirmed transport failure), not for NVMe command statuses (positive) or `-ETIMEDOUT`. Applied to read, rmw-read, write, and flush.

- Tests:
  + Added poller_callback_empty_pending_signals_completion (underflow guard coverage)
  + strengthened submit_one_rc_error_reindexes_on_swap_remove with inflight isolation assertions
# Impact
- `IoRequest` no longer carries poller-internal state. Each layer manages its own dead flag. Reduces per-request allocation and atomic traffic.
- NVMe command errors no longer permanently disable a healthy qpair.
- Zero I/Os hit the dead transport after an idle keep-alive death, orphaned check triggers the bdev circuit-breaker on the first I/O.

# Future works:
5. **Derive qpair activeness**: from `pending` state, remove `active_qpairs` Vec
6. **Deferred qpair cleanup**: Strategy for clean deferred removal 
7. **Unregister ctrlr + detach target**: Complete controller teardown

