### PR TITLE
fix(fuse): create missing fs path before mount

### DIFF
--- a/curvine-fuse/src/cli/mount_run.rs
+++ b/curvine-fuse/src/cli/mount_run.rs
@@ -16,6 +16,10 @@ use crate::cli::FuseRuntimeArgs;
 use crate::fs::CurvineFileSystem;
 use crate::session::FuseSession;
 use crate::web_server::WebServer;
+use curvine_common::conf::FuseConf;
+use curvine_common::error::FsError;
+use curvine_common::fs::{FileSystem, Path};
+use log::info;
 use orpc::common::Logger;
 use orpc::runtime::{AsyncRuntime, RpcRuntime};
 use orpc::CommonResult;
@@ -43,6 +47,8 @@ pub fn run_mount(args: FuseRuntimeArgs) -> CommonResult<()> {
         let fs = CurvineFileSystem::new(cluster_conf, fuse_rt.clone()).unwrap();
         let conf = fs.conf().clone();
 
+        ensure_fs_path_exists(&fs, &conf).await?;
+
         let node_state = fs.state().clone();
         let web_port = conf.web_port;
         fuse_rt.spawn(async move {
@@ -56,4 +62,25 @@ pub fn run_mount(args: FuseRuntimeArgs) -> CommonResult<()> {
     })?;
 
     Ok(())
+}
+
+async fn ensure_fs_path_exists(fs: &CurvineFileSystem, conf: &FuseConf) -> CommonResult<()> {
+    let path = Path::from_str(&conf.fs_path)?;
+    if path.is_root() || !path.is_cv() {
+        return Ok(());
+    }
+
+    match fs.fs().get_status(&path).await {
+        Ok(status) if status.is_dir => Ok(()),
+        Ok(_) => Err(FsError::not_a_directory(path.full_path()).into()),
+        Err(FsError::FileNotFound(_)) => {
+            if conf.readonly {
+                return Err(FsError::read_only(path.full_path()).into());
+            }
+            fs.fs().mkdir(&path, true).await?;
+            info!("created missing FUSE fs-path {}", path.full_path());
+            Ok(())
+        }
+        Err(e) => Err(e.into()),
+    }
 }

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -69,6 +69,10 @@ impl CurvineFileSystem {
         &self.conf
     }
 
+    pub(crate) fn fs(&self) -> &UnifiedFileSystem {
+        &self.fs
+    }
+
     async fn ensure_writable_path(&self, path: &Path, rpc_code: RpcCode) -> FuseResult<()> {
         if self.conf.readonly {
             return Err(FsError::read_only(path.full_path()).into());


### PR DESCRIPTION
# Summary

Ensure the configured Curvine FUSE fs path exists before mounting. If the path is missing, the mount command now creates it recursively; if the path exists as a non-directory, mount startup returns an error.

# Issue Describe / Design

Related issues: None

Root cause
- The FUSE mount path could point to a Curvine path that does not exist yet, making startup depend on manual directory creation.

Fix approach
- Check the configured `fs_path` during mount startup.
- Skip root and non-Curvine paths.
- Create missing Curvine paths recursively.
- Reject existing paths that are not directories.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-fuse/src/cli/mount_run.rs` | Adds mount startup path validation and creation before launching the session. | Missing configured Curvine fs paths are now created automatically. |
| `curvine-fuse/src/fs/curvine_file_system.rs` | Exposes the underlying unified file system for startup checks. | No runtime behavior change outside the new startup check. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo fmt` | PASS | No file changes after formatting. |
| `make format` | NOT RUN | `make` is not available in the local PowerShell environment. |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None