### PR TITLE
feat(fault): add distributed fault injection framework (#940)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2005,6 +2005,7 @@ dependencies = [
  "crc32fast",
  "crossbeam",
  "curvine-common-macros",
+ "curvine-fault",
  "dashmap 5.5.3",
  "flate2",
  "futures",
@@ -2049,6 +2050,21 @@ dependencies = [
  "quote",
  "serde",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "curvine-fault"
+version = "0.2.0"
+dependencies = [
+ "async-trait",
+ "axum",
+ "linkme",
+ "parking_lot",
+ "reqwest 0.11.27",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
 ]
 
 [[package]]
@@ -2157,6 +2173,7 @@ dependencies = [
  "clap",
  "curvine-client",
  "curvine-common",
+ "curvine-fault",
  "curvine-ufs",
  "curvine-web",
  "dashmap 5.5.3",
@@ -5359,6 +5376,26 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linkme"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "linux-raw-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ resolver = "2"
 
 members = [
     "orpc",
+    "curvine-fault",
     "curvine-common",
     "curvine-common/macros",
     "curvine-server",
@@ -28,6 +29,7 @@ members = [
 # curvine-lancedb stays opt-in because it pulls heavy Lance/Arrow dependencies.
 default-members = [
     "orpc",
+    "curvine-fault",
     "curvine-common",
     "curvine-server",
     "curvine-client",
@@ -46,6 +48,7 @@ license = "Apache-2.0"
 
 [workspace.dependencies]
 orpc = { path = "orpc" }
+curvine-fault = { path = "curvine-fault" }
 curvine-common = { path = "curvine-common" }
 curvine-client = { path = "curvine-client" }
 curvine-libsdk = { path = "curvine-libsdk" }
@@ -125,6 +128,7 @@ linked-hash-map = "0.5.6"
 fxhash = "0.2.1"
 serde_with = "3.12.0"
 parking_lot = "0.12.3"
+linkme = "0.3.35"
 anyhow = "1.0.97"
 url = "2.2.2"
 async-trait = "0.1.76"
@@ -141,6 +145,7 @@ md-5 = "0.10.6"
 bitflags = { version = "2.10.0", features = ["serde"] }
 glob = "0.3"
 lru = "0.16.1"
+reqwest = { version = "0.11", features = ["json", "rustls-tls"], default-features = false }
 
 mimalloc = "0.1.48"
 tikv-jemallocator = { version = "0.6.1", features = ["stats", "unprefixed_malloc_on_supported_platforms"] }

--- a/curvine-common/Cargo.toml
+++ b/curvine-common/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 
 [dependencies]
 orpc = { workspace = true }
+curvine-fault = { workspace = true }
 tokio = { workspace = true }
 futures = { workspace = true }
 async-stream =  { workspace = true }

--- a/curvine-common/src/conf/cluster_conf.rs
+++ b/curvine-common/src/conf/cluster_conf.rs
@@ -14,7 +14,9 @@
 
 use crate::alloc::allocator_type_name;
 use crate::conf::CliConf;
-use crate::conf::{ClientConf, FuseConf, JobConf, JournalConf, MasterConf, WorkerConf};
+use crate::conf::{
+    ClientConf, FaultHttpConfig, FuseConf, JobConf, JournalConf, MasterConf, WorkerConf,
+};
 use crate::rocksdb::DBConf;
 use crate::version;
 use log::info;
@@ -49,6 +51,13 @@ pub struct ClusterConf {
     pub journal: JournalConf,
 
     pub worker: WorkerConf,
+
+    /// Test-only fault HTTP control plane.
+    ///
+    /// Fault point instrumentation is controlled by Cargo features. This
+    /// setting only controls HTTP route exposure; enabling it without the
+    /// corresponding Cargo feature fails server startup.
+    pub fault_injection: FaultHttpConfig,
 
     pub log: LogConf,
 
@@ -280,6 +289,7 @@ impl Default for ClusterConf {
             master: Default::default(),
             journal: Default::default(),
             worker: Default::default(),
+            fault_injection: Default::default(),
             log: Default::default(),
             client: Default::default(),
             fuse: FuseConf::default(),

--- a/curvine-common/src/conf/mod.rs
+++ b/curvine-common/src/conf/mod.rs
@@ -21,6 +21,8 @@ pub use self::worker_conf::*;
 mod cluster_conf;
 pub use self::cluster_conf::*;
 
+pub use curvine_fault::FaultHttpConfig;
+
 mod client_conf;
 pub use self::client_conf::*;
 

--- a/curvine-fault/Cargo.toml
+++ b/curvine-fault/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "curvine-fault"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[features]
+default = []
+# Compiles `fault_point!` into real evaluation code. Without this feature the
+# macro expands to nothing, so instrumented binaries carry no fault logic.
+fault-injection = []
+http-client = ["dep:reqwest", "dep:async-trait"]
+# Embeddable Axum router for hosts that own their HTTP listener, such as
+# Curvine Master and Worker.
+http-server = ["fault-injection", "dep:axum", "dep:serde_json"]
+
+[dependencies]
+serde = { workspace = true }
+parking_lot = { workspace = true }
+linkme = { workspace = true }
+thiserror = { workspace = true }
+reqwest = { workspace = true, optional = true }
+async-trait = { workspace = true, optional = true }
+tokio = { workspace = true }
+axum = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }
+
+[[example]]
+name = "in_process"
+required-features = ["fault-injection"]
+
+[[example]]
+name = "http_remote"
+required-features = ["http-server", "http-client"]

--- a/curvine-fault/README.md
+++ b/curvine-fault/README.md
@@ -1,0 +1,344 @@
+# curvine-fault
+
+`curvine-fault` is a feature-gated fault-injection runtime for Rust services.
+It combines call-site fault points, structured rules, queryable execution
+evidence, in-process control, and an optional authenticated HTTP router.
+
+The crate does not depend on Curvine Client, Master, Worker, or their error
+types. Curvine uses it as the common engine for local tests and distributed
+cluster fault injection.
+
+## Architecture
+
+```text
+fault_point! call sites
+        │
+        ├── linkme registrations ──> complete linked-point catalog
+        │
+        └── evaluate context ──────> process or isolated FaultRuntime
+                                           │
+                         ┌─────────────────┴─────────────────┐
+                         │                                   │
+               FaultLocalController             FaultHttpControl::mount
+                                                             │
+                                                   FaultHttpController
+```
+
+Each OS process has one lazily initialized process Runtime. It contains every
+fault point linked into that binary and one shared rule/evidence table. An
+isolated Runtime uses the same complete catalog but owns an independent rule
+table for unit tests.
+
+Every linked point is available for configuration. A rule that the workload
+does not reach remains at `executions = 0`, so tests must observe evidence
+after running the workload.
+
+## Feature flags
+
+| Feature | Effect |
+| --- | --- |
+| default | `fault_point!` expands to an empty block |
+| `fault-injection` | Compiles point registration and Runtime evaluation |
+| `http-client` | Enables `FaultHttpController` and `FaultTestSession` |
+| `http-server` | Enables the embeddable authenticated Axum router |
+
+The Cargo feature decides whether fault points exist. A host's runtime
+`fault_injection.enabled` setting controls only whether its HTTP route is
+exposed; it does not initialize or disable the in-process Runtime.
+
+Hosts normally forward their own feature:
+
+```toml
+[dependencies]
+curvine-fault = { path = "../curvine-fault" }
+
+[features]
+fault-injection = ["curvine-fault/fault-injection"]
+```
+
+Because Cargo unifies dependency features, a library that controls its own
+instrumentation feature should export a local macro alias:
+
+```rust
+#[cfg(feature = "fault-injection")]
+pub(crate) use curvine_fault::fault_point;
+
+#[cfg(not(feature = "fault-injection"))]
+pub(crate) use curvine_fault::__noop_fault_point as fault_point;
+```
+
+## Declaring a point
+
+One macro call declares, registers, and evaluates a point:
+
+```rust
+fn dispatch(msg: &Message) -> Result<Response, MyError> {
+    crate::fault_point! {
+        sync,
+        name: "worker.rpc.before_dispatch",
+        description: "Before a Worker RPC is dispatched",
+        context: {
+            "req_id" => msg.req_id(),
+            "rpc_code" => msg.code() as i32,
+        },
+        return_error: |fault| Err(MyError::injected(fault.message)),
+    }
+
+    // Normal business path.
+}
+```
+
+The macro derives the catalog contract from the call site:
+
+- `sync` or `async` defines Delay execution;
+- context keys become available matcher keys;
+- `Record`, `Delay`, and `Crash` are available on every point;
+- a `return_error` closure additionally enables `ReturnError`;
+- identical declarations of one name merge into one catalog entry;
+- conflicting same-name declarations fail Runtime construction and report
+  both source locations.
+
+Point names are opaque non-empty strings to the Runtime. Curvine uses readable
+hierarchical names such as `worker.rpc.before_dispatch`, but the prefix is not
+a Runtime selector.
+
+### ReturnError
+
+The HTTP rule carries only an error message. The call-site closure converts it
+to the surrounding function's natural return value, and Rust checks the type:
+
+```rust
+return_error: |fault| Err(FsError::common(fault.message)),
+```
+
+An async point uses an async closure when required by its return contract.
+Resource rollback remains business logic: a point placed after acquiring a
+lease, reserving space, or opening a writing block must call the same cleanup
+helper as the normal error path.
+
+### Non-returning point
+
+Omit the closure when the point supports only `Record`, `Delay`, and `Crash`:
+
+```rust
+crate::fault_point! {
+    async,
+    name: "worker.heartbeat.before_send",
+    description: "Before a Worker heartbeat is sent",
+    context: {"worker_id" => worker_id},
+}
+```
+
+## Runtime
+
+The crate owns one lazily initialized process Runtime. Business handlers do
+not initialize it or carry Runtime fields: the default `fault_point!` form
+uses it automatically. Local setup code that needs to configure rules can get
+the same Runtime directly:
+
+```rust
+let runtime = FaultRuntime::process();
+```
+
+The first access constructs the complete linked catalog. Conflicting
+declarations of one point name are programming errors and fail immediately
+with both source locations. Hosts that mount `FaultHttpControl` initialize the
+Runtime while building their Web router; processes without a Web control plane
+initialize it at the first point evaluation or local configuration.
+
+Tests that need independent rule tables use:
+
+```rust
+let runtime = FaultRuntime::isolated()?;
+```
+
+An in-process MiniCluster naturally shares the process Runtime and rule table.
+Use isolated Runtimes with the explicit `runtime:` macro argument only when a
+test requires per-instance isolation.
+
+## Rules
+
+A rule has a required `point` and `action`. `description`, `matcher`, and
+`trigger` are optional:
+
+```json
+{
+  "point": "worker.rpc.before_dispatch",
+  "action": {
+    "type": "return_error",
+    "error": {"message": "injected Worker RPC failure"}
+  }
+}
+```
+
+Defaults are:
+
+| Field | Default |
+| --- | --- |
+| `description` | `null` |
+| `matcher` | `{}` (match every evaluation) |
+| `trigger.after` | `0` |
+| `trigger.max_hits` | `null` (unlimited) |
+| `trigger.probability` | `1.0` |
+| `trigger.seed` | `0` |
+
+Matcher fields use exact equality with AND semantics. Context and matcher are
+open scalar maps supporting integer, string, and Boolean values.
+
+Rust tests can use `FaultRuleBuilder`:
+
+```rust
+let rule = FaultRuleBuilder::named("worker.rpc.before_dispatch")
+    .matches("rpc_code", 80_i32)?
+    .after(1)
+    .times(2)?
+    .return_error("injected failure")?;
+
+runtime.configure("case.fail-write", rule)?;
+```
+
+`FaultRuleBuilder::named` performs best-effort validation against points linked
+into the caller. The target Runtime remains authoritative for remote rules.
+
+## Actions
+
+| Action | Behavior |
+| --- | --- |
+| `record` | Records evidence and continues evaluating later rules |
+| `return_error` | Invokes the call-site closure and returns from the business function |
+| `delay` | Sleeps before the business path continues |
+| `crash` | Calls `std::process::abort()` |
+
+A sync point implements Delay with `std::thread::sleep` and blocks its caller
+thread. An async point uses `tokio::time::sleep` and suspends only its future.
+The Runtime does not limit Delay duration or Crash; expose the control plane
+only in an isolated test environment.
+
+## Evidence
+
+Every rule reports:
+
+- `evaluations`: calls reaching the point;
+- `matches`: contexts satisfying the matcher;
+- `executions`: actions selected after trigger evaluation;
+- `last_evaluated_context`: latest evaluated context;
+- `last_context`: latest context that executed the action.
+
+Interpretation:
+
+```text
+evaluations = 0  → workload did not reach this linked point
+matches = 0      → point ran, but matcher did not match
+executions = 0   → matcher ran, but after/probability/max_hits did not select it
+executions > 0   → action was selected
+```
+
+Configuration success alone never proves that a fault occurred.
+
+## HTTP control plane
+
+Hosts with an Axum server use `FaultHttpControl::mount`. Curvine Master and
+Worker mount it on their existing Web port. Standalone Client tests normally
+use `FaultLocalController` and do not require a Web server. The lower-level
+`fault_router` API remains available when a host intentionally wants to expose
+an isolated Runtime instead of the process Runtime.
+
+`FaultHttpConfig` and `FaultHttpControl` are reusable by any Axum host. The
+host embeds the configuration in its own model, constructs the control once,
+and passes its router through `mount`:
+
+```rust
+let fault_http = FaultHttpControl::from_env(&config.fault_injection)?;
+
+let router = Router::new().route("/health", get(health));
+let router = fault_http.mount(router);
+```
+
+```toml
+[fault_injection]
+enabled = true
+auth_token_env = "FAULT_HTTP_TOKEN"
+```
+
+When disabled, `mount` returns the original router and does not read the
+environment. Enabling the configuration without the `http-server` feature,
+without an environment-variable name, or without a non-empty token fails
+construction instead of silently exposing an unusable control plane.
+
+Every HTTP request requires `Authorization: Bearer <token>`:
+
+| Method | Path | Behavior |
+| --- | --- | --- |
+| GET | `/api/v1/debug/faults` | Status, complete catalog, rules, evidence |
+| PUT | `/api/v1/debug/faults/rules/:rule_id` | Install or replace a rule |
+| GET | `/api/v1/debug/faults/rules/:rule_id` | Read one rule |
+| DELETE | `/api/v1/debug/faults/rules/:rule_id` | Remove one rule |
+| DELETE | `/api/v1/debug/faults/rules` | Clear all rules |
+
+```bash
+curl -X PUT http://worker-2:9001/api/v1/debug/faults/rules/case.fail-write \
+  -H "Authorization: Bearer ${CURVINE_FAULT_TOKEN}" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "point":"worker.rpc.before_dispatch",
+    "matcher":{"rpc_code":80,"request_status":2},
+    "trigger":{"max_hits":1},
+    "action":{"type":"return_error","error":{"message":"injected failure"}}
+  }'
+```
+
+An empty configured token rejects every request. The router provides no TLS or
+network policy and must be exposed only on loopback or a trusted test network.
+The crate provides an embeddable router rather than a standalone listener.
+
+## Test lifecycle
+
+Distributed tests use:
+
+```text
+Preflight → Configure → Workload → Observe → Cleanup
+```
+
+1. **Preflight** verifies that the controller can reach the target and that its
+   rule set is empty.
+2. **Configure** installs rules and confirms their initial counters.
+3. **Workload** runs the real Client API, RPC, or IO operation.
+4. **Observe** asserts the workload outcome and execution evidence.
+5. **Cleanup** quiesces the workload, clears all rules, verifies the target is
+   clean, and runs a fault-free recovery check.
+
+Rules are in memory and have no TTL or generation. Tests must execute Cleanup
+on normal and error-return paths. Cleanup does not cancel actions that already
+started.
+
+## Curvine configuration
+
+Build Server instrumentation explicitly:
+
+```bash
+cargo build -p curvine-server --features fault-injection
+```
+
+Enable the authenticated HTTP route:
+
+```toml
+[fault_injection]
+enabled = true
+auth_token_env = "CURVINE_FAULT_TOKEN"
+```
+
+Enabling this configuration in a binary built without the corresponding
+feature fails server startup instead of silently omitting the requested HTTP
+route.
+
+## Examples and tests
+
+```bash
+cargo run -p curvine-fault --example in_process \
+  --features fault-injection
+
+cargo run -p curvine-fault --example http_remote \
+  --features http-server,http-client
+
+cargo test -p curvine-fault --all-features
+```

--- a/curvine-fault/examples/http_remote.rs
+++ b/curvine-fault/examples/http_remote.rs
@@ -1,0 +1,97 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Remote fault injection over an embedded `fault_router` plus a client
+//! driving the full configure / trigger / observe / cleanup lifecycle.
+//!
+//! Hosts that already expose an Axum web server (Curvine Master/Worker) mount
+//! the same router. This example owns a temporary listener to demonstrate how
+//! a host embeds the router.
+//!
+//! ```bash
+//! cargo run -p curvine-fault --example http_remote \
+//!   --features http-server,http-client
+//! ```
+
+use curvine_fault::{
+    fault_point, ConfigureFaultRule, FaultAction, FaultController, FaultErrorSpec, FaultHttpConfig,
+    FaultHttpControl, FaultHttpController,
+};
+
+fn handle_request(req_id: i64) -> Result<(), String> {
+    fault_point! {
+        sync,
+        name: "agent.request.before_handle",
+        description: "Before an agent request is handled",
+        context: { "req_id" => req_id },
+        return_error: |fault| Err(fault.message),
+    }
+    Ok(())
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    const TOKEN: &str = "example-secret";
+    const TOKEN_ENV: &str = "CURVINE_FAULT_HTTP_REMOTE_EXAMPLE_TOKEN";
+
+    std::env::set_var(TOKEN_ENV, TOKEN);
+    let fault_http = FaultHttpControl::from_env(&FaultHttpConfig {
+        enabled: true,
+        auth_token_env: TOKEN_ENV.to_string(),
+    })?;
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let address = listener.local_addr()?;
+    let server = tokio::spawn(async move {
+        axum::serve(listener, fault_http.mount(axum::Router::new()))
+            .await
+            .unwrap();
+    });
+    println!("fault API listening on http://{address} (bearer token: {TOKEN})");
+    println!("try: curl -H 'Authorization: Bearer {TOKEN}' http://{address}/api/v1/debug/faults");
+
+    // A remote controller (any machine that can reach the port) installs a rule.
+    let controller = FaultHttpController::new(format!("http://{address}"), TOKEN)?;
+    controller
+        .configure(
+            "fail-req-42",
+            ConfigureFaultRule {
+                point: "agent.request.before_handle".to_string(),
+                matcher: {
+                    let mut matcher = curvine_fault::FaultMatcher::default();
+                    matcher.insert("req_id", 42_i64);
+                    matcher
+                },
+                action: FaultAction::ReturnError {
+                    error: FaultErrorSpec {
+                        message: "injected by remote controller".to_string(),
+                    },
+                },
+                ..Default::default()
+            },
+        )
+        .await?;
+
+    assert!(handle_request(1).is_ok());
+    assert_eq!(
+        handle_request(42).unwrap_err(),
+        "injected by remote controller"
+    );
+
+    let status = controller.status().await?;
+    println!("remote status: rules={}", status.rules.len());
+    controller.clear().await?;
+    server.abort();
+    Ok(())
+}

--- a/curvine-fault/examples/in_process.rs
+++ b/curvine-fault/examples/in_process.rs
@@ -1,0 +1,55 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! In-process fault injection: declare a point, install a rule, observe it.
+//!
+//! ```bash
+//! cargo run -p curvine-fault --example in_process --features fault-injection
+//! ```
+
+use curvine_fault::{fault_point, FaultRuleBuilder, FaultRuntime};
+
+fn read_block(block_id: i64) -> Result<Vec<u8>, String> {
+    fault_point! {
+        sync,
+        name: "storage.block.before_read",
+        description: "Before a block read is served",
+        context: { "block_id" => block_id },
+        return_error: |fault| Err(fault.message),
+    }
+    Ok(vec![0_u8; 16])
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let runtime = FaultRuntime::process();
+
+    // Fail only block 7, only once.
+    let rule = FaultRuleBuilder::named("storage.block.before_read")
+        .matches("block_id", 7_i64)?
+        .times(1)?
+        .return_error("injected read failure")?;
+    runtime.configure("fail-block-7-once", rule)?;
+
+    assert!(read_block(1).is_ok());
+    assert_eq!(read_block(7).unwrap_err(), "injected read failure");
+    assert!(read_block(7).is_ok(), "max_hits=1 exhausts the rule");
+
+    let status = runtime.status();
+    let rule = &status.rules[0];
+    println!(
+        "rule {}: evaluations={} matches={} executions={}",
+        rule.id, rule.evaluations, rule.matches, rule.executions
+    );
+    Ok(())
+}

--- a/curvine-fault/src/builder.rs
+++ b/curvine-fault/src/builder.rs
@@ -1,0 +1,192 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{
+    ConfigureFaultRule, FaultAction, FaultErrorSpec, FaultMatcher, FaultPointSpec,
+    FaultRuntimeError, FaultValue, FAULT_POINT_REGISTRATIONS,
+};
+
+#[derive(Debug, Clone)]
+pub struct FaultRuleBuilder {
+    point: Option<&'static FaultPointSpec>,
+    rule: ConfigureFaultRule,
+}
+
+impl FaultRuleBuilder {
+    pub fn named(point_name: impl Into<String>) -> Self {
+        let point_name = point_name.into();
+        Self {
+            point: FAULT_POINT_REGISTRATIONS
+                .iter()
+                .find(|registration| registration.point.name == point_name)
+                .map(|registration| registration.point),
+            rule: ConfigureFaultRule {
+                point: point_name,
+                ..Default::default()
+            },
+        }
+    }
+
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.rule.description = Some(description.into());
+        self
+    }
+
+    pub fn matcher(mut self, matcher: FaultMatcher) -> Result<Self, FaultRuntimeError> {
+        for key in matcher.keys() {
+            self.ensure_matcher(key)?;
+        }
+        self.rule.matcher = matcher;
+        Ok(self)
+    }
+
+    pub fn matches(
+        mut self,
+        key: impl Into<String>,
+        value: impl Into<FaultValue>,
+    ) -> Result<Self, FaultRuntimeError> {
+        let key = key.into();
+        self.ensure_matcher(&key)?;
+        self.rule.matcher.insert(key, value);
+        Ok(self)
+    }
+
+    pub fn times(mut self, max_hits: u64) -> Result<Self, FaultRuntimeError> {
+        if max_hits == 0 {
+            return Err(FaultRuntimeError::InvalidRule(
+                "trigger max_hits must be greater than 0".to_string(),
+            ));
+        }
+        self.rule.trigger.max_hits = Some(max_hits);
+        Ok(self)
+    }
+
+    pub fn after(mut self, matches: u64) -> Self {
+        self.rule.trigger.after = matches;
+        self
+    }
+
+    pub fn probability(mut self, probability: f64, seed: u64) -> Result<Self, FaultRuntimeError> {
+        if !(0.0..=1.0).contains(&probability) {
+            return Err(FaultRuntimeError::InvalidRule(
+                "trigger probability must be between 0 and 1".to_string(),
+            ));
+        }
+        self.rule.trigger.probability = probability;
+        self.rule.trigger.seed = seed;
+        Ok(self)
+    }
+
+    pub fn record(self) -> Result<ConfigureFaultRule, FaultRuntimeError> {
+        self.action(FaultAction::Record)
+    }
+
+    pub fn return_error(
+        self,
+        message: impl Into<String>,
+    ) -> Result<ConfigureFaultRule, FaultRuntimeError> {
+        self.action(FaultAction::ReturnError {
+            error: FaultErrorSpec {
+                message: message.into(),
+            },
+        })
+    }
+
+    pub fn delay(self, duration_ms: u64) -> Result<ConfigureFaultRule, FaultRuntimeError> {
+        self.action(FaultAction::Delay { duration_ms })
+    }
+
+    pub fn crash(self) -> Result<ConfigureFaultRule, FaultRuntimeError> {
+        self.action(FaultAction::Crash)
+    }
+
+    pub fn action(mut self, action: FaultAction) -> Result<ConfigureFaultRule, FaultRuntimeError> {
+        let kind = action.kind();
+        if self
+            .point
+            .is_some_and(|point| !point.actions.contains(&kind))
+        {
+            return Err(FaultRuntimeError::InvalidRule(format!(
+                "action {kind:?} is not available at {}",
+                self.rule.point
+            )));
+        }
+        self.rule.action = action;
+        Ok(self.rule)
+    }
+
+    fn ensure_matcher(&self, key: &str) -> Result<(), FaultRuntimeError> {
+        if self.point.is_none_or(|point| point.matchers.contains(&key)) {
+            Ok(())
+        } else {
+            Err(FaultRuntimeError::InvalidRule(format!(
+                "matcher {key:?} is not available at {}",
+                self.rule.point
+            )))
+        }
+    }
+}
+
+#[cfg(all(test, feature = "fault-injection"))]
+mod tests {
+    use super::*;
+    use crate::{fault_point, FaultRuntime};
+
+    #[allow(dead_code)]
+    fn builder_point(runtime: &FaultRuntime) -> Result<(), String> {
+        fault_point! {
+            sync,
+            name: "client.builder.test",
+            description: "builder test",
+            runtime: runtime,
+            context: {"rpc_code" => 7_i32},
+            return_error: |fault| Err(fault.message),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn builder_uses_local_registration_and_defers_unknown_points() {
+        let rule = FaultRuleBuilder::named("client.builder.test")
+            .matches("rpc_code", 7_i32)
+            .unwrap()
+            .times(3)
+            .unwrap()
+            .return_error("expected")
+            .unwrap();
+        assert_eq!(rule.point, "client.builder.test");
+        assert_eq!(rule.matcher, fault_matcher("rpc_code", 7_i32));
+        assert_eq!(rule.trigger.max_hits, Some(3));
+
+        assert!(FaultRuleBuilder::named("client.builder.test")
+            .times(0)
+            .is_err());
+        assert!(FaultRuleBuilder::named("client.builder.test")
+            .matches("block_id", 1_i64)
+            .is_err());
+
+        let remote_only = FaultRuleBuilder::named("worker.remote.only")
+            .matches("arbitrary", true)
+            .unwrap()
+            .return_error("validated by the remote runtime")
+            .unwrap();
+        assert_eq!(remote_only.point, "worker.remote.only");
+    }
+
+    fn fault_matcher(key: &str, value: impl Into<FaultValue>) -> FaultMatcher {
+        let mut matcher = FaultMatcher::default();
+        matcher.insert(key, value);
+        matcher
+    }
+}

--- a/curvine-fault/src/catalog.rs
+++ b/curvine-fault/src/catalog.rs
@@ -1,0 +1,119 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{FaultPointRegistration, FaultPointSpec, FaultRuntimeError};
+use std::collections::{BTreeMap, HashSet};
+
+/// Builds the process catalog from every point linked into the binary.
+///
+/// This is the default catalog model for process-owned runtimes. It validates
+/// and merges registrations, but deliberately does not infer whether a
+/// particular workload will reach a linked call site.
+pub(crate) fn build_full_catalog(
+    registrations: &'static [FaultPointRegistration],
+) -> Result<Vec<&'static FaultPointSpec>, FaultRuntimeError> {
+    let mut points = BTreeMap::<&str, &FaultPointRegistration>::new();
+    for registration in registrations {
+        let point = registration.point;
+        validate_point(point)?;
+        if let Some(existing) = points.get(point.name) {
+            if !same_contract(existing.point, point) {
+                return Err(FaultRuntimeError::InvalidRule(format!(
+                    "conflicting fault point {} at {}:{} and {}:{}",
+                    point.name, existing.file, existing.line, registration.file, registration.line,
+                )));
+            }
+            continue;
+        }
+        points.insert(point.name, registration);
+    }
+    Ok(points
+        .into_values()
+        .map(|registration| registration.point)
+        .collect())
+}
+
+pub(crate) fn validate_point(point: &FaultPointSpec) -> Result<(), FaultRuntimeError> {
+    if point.name.is_empty() {
+        return Err(FaultRuntimeError::InvalidRule(
+            "fault point name must not be empty".to_string(),
+        ));
+    }
+    if point.actions.is_empty() {
+        return Err(FaultRuntimeError::InvalidRule(format!(
+            "fault point {} must declare at least one action",
+            point.name
+        )));
+    }
+    let mut matchers = HashSet::new();
+    for matcher in point.matchers {
+        if matcher.is_empty() {
+            return Err(FaultRuntimeError::InvalidRule(format!(
+                "fault point {} declares an empty matcher key",
+                point.name
+            )));
+        }
+        if !matchers.insert(*matcher) {
+            return Err(FaultRuntimeError::InvalidRule(format!(
+                "fault point {} declares duplicate matcher {matcher:?}",
+                point.name
+            )));
+        }
+    }
+    let mut actions = HashSet::new();
+    for action in point.actions {
+        if !actions.insert(*action) {
+            return Err(FaultRuntimeError::InvalidRule(format!(
+                "fault point {} declares duplicate action {action:?}",
+                point.name
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn same_contract(left: &FaultPointSpec, right: &FaultPointSpec) -> bool {
+    left.name == right.name
+        && left.description == right.description
+        && left.execution == right.execution
+        && same_set(left.matchers, right.matchers)
+        && same_set(left.actions, right.actions)
+}
+
+fn same_set<T: Eq + std::hash::Hash>(left: &[T], right: &[T]) -> bool {
+    left.len() == right.len()
+        && left.iter().collect::<HashSet<_>>() == right.iter().collect::<HashSet<_>>()
+}
+
+pub(crate) fn validate_rule_id(rule_id: &str) -> Result<(), FaultRuntimeError> {
+    if rule_id.is_empty() || rule_id.len() > 128 {
+        return Err(FaultRuntimeError::InvalidRule(
+            "rule id must contain 1 to 128 characters".to_string(),
+        ));
+    }
+    if matches!(rule_id, "." | "..") {
+        return Err(FaultRuntimeError::InvalidRule(
+            "rule id must not be a URL dot-segment".to_string(),
+        ));
+    }
+    if rule_id
+        .bytes()
+        .any(|byte| !byte.is_ascii_alphanumeric() && !matches!(byte, b'-' | b'_' | b'.'))
+    {
+        return Err(FaultRuntimeError::InvalidRule(
+            "rule id may contain only ASCII letters, digits, '-', '_' and '.'".to_string(),
+        ));
+    }
+    Ok(())
+}

--- a/curvine-fault/src/controller.rs
+++ b/curvine-fault/src/controller.rs
@@ -1,0 +1,613 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::catalog::validate_rule_id;
+use crate::{
+    ConfigureFaultRule, FaultControlError, FaultRuleView, FaultRuntime, FaultRuntimeStatus,
+};
+use async_trait::async_trait;
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+#[async_trait]
+pub trait FaultController: Send + Sync {
+    async fn status(&self) -> Result<FaultRuntimeStatus, FaultControlError>;
+
+    async fn configure(
+        &self,
+        rule_id: &str,
+        rule: ConfigureFaultRule,
+    ) -> Result<FaultRuleView, FaultControlError>;
+
+    async fn rule(&self, rule_id: &str) -> Result<Option<FaultRuleView>, FaultControlError>;
+
+    async fn remove(&self, rule_id: &str) -> Result<bool, FaultControlError>;
+
+    async fn clear(&self) -> Result<usize, FaultControlError>;
+
+    async fn preflight_clean(&self) -> Result<FaultRuntimeStatus, FaultControlError> {
+        let status = self.status().await?;
+        if status.rules.is_empty() {
+            Ok(status)
+        } else {
+            Err(FaultControlError::DirtyTarget {
+                rules: status.rules.into_iter().map(|rule| rule.id).collect(),
+            })
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct FaultLocalController {
+    runtime: FaultRuntime,
+}
+
+impl FaultLocalController {
+    pub fn new(runtime: FaultRuntime) -> Self {
+        Self { runtime }
+    }
+}
+
+#[async_trait]
+impl FaultController for FaultLocalController {
+    async fn status(&self) -> Result<FaultRuntimeStatus, FaultControlError> {
+        Ok(self.runtime.status())
+    }
+
+    async fn configure(
+        &self,
+        rule_id: &str,
+        rule: ConfigureFaultRule,
+    ) -> Result<FaultRuleView, FaultControlError> {
+        self.runtime.configure(rule_id, rule).map_err(Into::into)
+    }
+
+    async fn remove(&self, rule_id: &str) -> Result<bool, FaultControlError> {
+        self.runtime.remove(rule_id).map_err(Into::into)
+    }
+
+    async fn rule(&self, rule_id: &str) -> Result<Option<FaultRuleView>, FaultControlError> {
+        self.runtime.rule(rule_id).map_err(Into::into)
+    }
+
+    async fn clear(&self) -> Result<usize, FaultControlError> {
+        self.runtime.clear().map_err(Into::into)
+    }
+}
+
+#[derive(Clone)]
+pub struct FaultHttpController {
+    client: reqwest::Client,
+    base_url: reqwest::Url,
+    token: String,
+}
+
+impl FaultHttpController {
+    /// Creates a controller from the target site's root URL.
+    pub fn new(
+        base_url: impl AsRef<str>,
+        token: impl Into<String>,
+    ) -> Result<Self, FaultControlError> {
+        let client = reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(3))
+            .timeout(Duration::from_secs(10))
+            .build()
+            .map_err(|error| FaultControlError::Transport(error.to_string()))?;
+        let base_url = fault_api_url(base_url.as_ref())?;
+        Ok(Self {
+            client,
+            base_url,
+            token: token.into(),
+        })
+    }
+
+    fn rules_url(&self) -> reqwest::Url {
+        let mut url = self.base_url.clone();
+        url.path_segments_mut()
+            .expect("FaultHttpController accepts only hierarchical base URLs")
+            .push("rules");
+        url
+    }
+
+    fn rule_url(&self, rule_id: &str) -> Result<reqwest::Url, FaultControlError> {
+        validate_rule_id(rule_id)?;
+        let mut url = self.rules_url();
+        url.path_segments_mut()
+            .expect("FaultHttpController accepts only hierarchical base URLs")
+            .push(rule_id);
+        Ok(url)
+    }
+
+    async fn response_error(response: reqwest::Response) -> FaultControlError {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        FaultControlError::Transport(format!("HTTP {status}: {body}"))
+    }
+}
+
+fn fault_api_url(base_url: &str) -> Result<reqwest::Url, FaultControlError> {
+    let mut base_url = reqwest::Url::parse(base_url)
+        .map_err(|error| FaultControlError::Transport(error.to_string()))?;
+    if base_url.query().is_some() || base_url.fragment().is_some() {
+        return Err(FaultControlError::Transport(
+            "fault controller base URL must not contain a query or fragment".to_string(),
+        ));
+    }
+    if base_url.path() != "/" {
+        return Err(FaultControlError::Transport(
+            "fault controller base URL must be a site root".to_string(),
+        ));
+    }
+    base_url.set_path("/api/v1/debug/faults");
+    Ok(base_url)
+}
+
+#[async_trait]
+impl FaultController for FaultHttpController {
+    async fn status(&self) -> Result<FaultRuntimeStatus, FaultControlError> {
+        let response = self
+            .client
+            .get(self.base_url.clone())
+            .bearer_auth(&self.token)
+            .send()
+            .await
+            .map_err(|error| FaultControlError::Transport(error.to_string()))?;
+        if !response.status().is_success() {
+            return Err(Self::response_error(response).await);
+        }
+        response
+            .json()
+            .await
+            .map_err(|error| FaultControlError::Transport(error.to_string()))
+    }
+
+    async fn configure(
+        &self,
+        rule_id: &str,
+        rule: ConfigureFaultRule,
+    ) -> Result<FaultRuleView, FaultControlError> {
+        let url = self.rule_url(rule_id)?;
+        let response = self
+            .client
+            .put(url)
+            .bearer_auth(&self.token)
+            .json(&rule)
+            .send()
+            .await
+            .map_err(|error| FaultControlError::Transport(error.to_string()))?;
+        if !response.status().is_success() {
+            return Err(Self::response_error(response).await);
+        }
+        response
+            .json()
+            .await
+            .map_err(|error| FaultControlError::Transport(error.to_string()))
+    }
+
+    async fn rule(&self, rule_id: &str) -> Result<Option<FaultRuleView>, FaultControlError> {
+        let url = self.rule_url(rule_id)?;
+        let response = self
+            .client
+            .get(url)
+            .bearer_auth(&self.token)
+            .send()
+            .await
+            .map_err(|error| FaultControlError::Transport(error.to_string()))?;
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        if !response.status().is_success() {
+            return Err(Self::response_error(response).await);
+        }
+        response
+            .json()
+            .await
+            .map(Some)
+            .map_err(|error| FaultControlError::Transport(error.to_string()))
+    }
+
+    async fn remove(&self, rule_id: &str) -> Result<bool, FaultControlError> {
+        let url = self.rule_url(rule_id)?;
+        let response = self
+            .client
+            .delete(url)
+            .bearer_auth(&self.token)
+            .send()
+            .await
+            .map_err(|error| FaultControlError::Transport(error.to_string()))?;
+        if !response.status().is_success() {
+            return Err(Self::response_error(response).await);
+        }
+        #[derive(serde::Deserialize)]
+        struct Removed {
+            removed: bool,
+        }
+        response
+            .json::<Removed>()
+            .await
+            .map(|result| result.removed)
+            .map_err(|error| FaultControlError::Transport(error.to_string()))
+    }
+
+    async fn clear(&self) -> Result<usize, FaultControlError> {
+        let response = self
+            .client
+            .delete(self.rules_url())
+            .bearer_auth(&self.token)
+            .send()
+            .await
+            .map_err(|error| FaultControlError::Transport(error.to_string()))?;
+        if !response.status().is_success() {
+            return Err(Self::response_error(response).await);
+        }
+        #[derive(serde::Deserialize)]
+        struct Cleared {
+            cleared: usize,
+        }
+        response
+            .json::<Cleared>()
+            .await
+            .map(|result| result.cleared)
+            .map_err(|error| FaultControlError::Transport(error.to_string()))
+    }
+}
+
+pub struct FaultTestSession {
+    targets: BTreeMap<String, Arc<dyn FaultController>>,
+}
+
+impl FaultTestSession {
+    pub fn new() -> Self {
+        Self {
+            targets: BTreeMap::new(),
+        }
+    }
+
+    pub fn add_target(&mut self, name: impl Into<String>, controller: Arc<dyn FaultController>) {
+        self.targets.insert(name.into(), controller);
+    }
+
+    pub async fn preflight(&self) -> Result<(), FaultControlError> {
+        for controller in self.targets.values() {
+            controller.preflight_clean().await?;
+        }
+        Ok(())
+    }
+
+    pub async fn configure(
+        &self,
+        target: &str,
+        rule_id: &str,
+        rule: ConfigureFaultRule,
+    ) -> Result<FaultRuleView, FaultControlError> {
+        self.target(target)?.configure(rule_id, rule).await
+    }
+
+    pub async fn observe(&self, target: &str) -> Result<FaultRuntimeStatus, FaultControlError> {
+        self.target(target)?.status().await
+    }
+
+    pub async fn rule(
+        &self,
+        target: &str,
+        rule_id: &str,
+    ) -> Result<Option<FaultRuleView>, FaultControlError> {
+        self.target(target)?.rule(rule_id).await
+    }
+
+    pub async fn wait_for_executions(
+        &self,
+        target: &str,
+        rule_id: &str,
+        expected: u64,
+        timeout: Duration,
+    ) -> Result<FaultRuleView, FaultControlError> {
+        let deadline = tokio::time::Instant::now() + timeout;
+        let mut observed = 0;
+        loop {
+            let now = tokio::time::Instant::now();
+            let remaining = deadline.saturating_duration_since(now);
+            let rule = match tokio::time::timeout(remaining, self.rule(target, rule_id)).await {
+                Ok(result) => result?.ok_or_else(|| FaultControlError::UnknownRule {
+                    target: target.to_string(),
+                    rule_id: rule_id.to_string(),
+                })?,
+                Err(_) => {
+                    return Err(FaultControlError::WaitTimeout {
+                        target: target.to_string(),
+                        rule_id: rule_id.to_string(),
+                        expected,
+                        observed,
+                    });
+                }
+            };
+            observed = rule.executions;
+            if rule.executions >= expected {
+                return Ok(rule);
+            }
+
+            let now = tokio::time::Instant::now();
+            if now >= deadline {
+                return Err(FaultControlError::WaitTimeout {
+                    target: target.to_string(),
+                    rule_id: rule_id.to_string(),
+                    expected,
+                    observed,
+                });
+            }
+            tokio::time::sleep(Duration::from_millis(100).min(deadline - now)).await;
+        }
+    }
+
+    pub async fn cleanup(&self) -> Result<(), FaultControlError> {
+        let mut failures = Vec::new();
+        for (target, controller) in &self.targets {
+            if let Err(error) = controller.clear().await {
+                failures.push(format!("{target} clear: {error}"));
+            }
+            if let Err(error) = controller.preflight_clean().await {
+                failures.push(format!("{target} verify: {error}"));
+            }
+        }
+        if failures.is_empty() {
+            Ok(())
+        } else {
+            Err(FaultControlError::Transport(format!(
+                "fault cleanup failed: {}",
+                failures.join("; ")
+            )))
+        }
+    }
+
+    fn target(&self, name: &str) -> Result<Arc<dyn FaultController>, FaultControlError> {
+        self.targets
+            .get(name)
+            .cloned()
+            .ok_or_else(|| FaultControlError::UnknownTarget(name.to_string()))
+    }
+}
+
+impl Default for FaultTestSession {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(all(test, feature = "fault-injection"))]
+mod tests {
+    use super::*;
+    use crate::{fault_point, FaultAction, FAULT_POINT_REGISTRATIONS};
+
+    const CONTROLLER_POINT_NAME: &str = "client.controller.test";
+
+    #[allow(dead_code)]
+    fn declare_controller_point(runtime: &FaultRuntime) {
+        fault_point! {
+            sync,
+            name: "client.controller.test",
+            description: "controller test point",
+            runtime: runtime,
+            context: {},
+        }
+    }
+
+    fn controller_point() -> &'static crate::FaultPointSpec {
+        FAULT_POINT_REGISTRATIONS
+            .iter()
+            .find(|registration| registration.point.name == CONTROLLER_POINT_NAME)
+            .unwrap()
+            .point
+    }
+
+    struct HangingController;
+
+    struct CleanupFailureController;
+
+    #[async_trait]
+    impl FaultController for HangingController {
+        async fn status(&self) -> Result<FaultRuntimeStatus, FaultControlError> {
+            std::future::pending().await
+        }
+
+        async fn configure(
+            &self,
+            _rule_id: &str,
+            _rule: ConfigureFaultRule,
+        ) -> Result<FaultRuleView, FaultControlError> {
+            std::future::pending().await
+        }
+
+        async fn rule(&self, _rule_id: &str) -> Result<Option<FaultRuleView>, FaultControlError> {
+            std::future::pending().await
+        }
+
+        async fn remove(&self, _rule_id: &str) -> Result<bool, FaultControlError> {
+            std::future::pending().await
+        }
+
+        async fn clear(&self) -> Result<usize, FaultControlError> {
+            std::future::pending().await
+        }
+    }
+
+    #[async_trait]
+    impl FaultController for CleanupFailureController {
+        async fn status(&self) -> Result<FaultRuntimeStatus, FaultControlError> {
+            Ok(FaultRuntimeStatus {
+                points: Vec::new(),
+                rules: Vec::new(),
+            })
+        }
+
+        async fn configure(
+            &self,
+            _rule_id: &str,
+            _rule: ConfigureFaultRule,
+        ) -> Result<FaultRuleView, FaultControlError> {
+            Err(FaultControlError::Transport(
+                "configure is unavailable".to_string(),
+            ))
+        }
+
+        async fn rule(&self, _rule_id: &str) -> Result<Option<FaultRuleView>, FaultControlError> {
+            Ok(None)
+        }
+
+        async fn remove(&self, _rule_id: &str) -> Result<bool, FaultControlError> {
+            Ok(false)
+        }
+
+        async fn clear(&self) -> Result<usize, FaultControlError> {
+            Err(FaultControlError::Transport(
+                "expected clear failure".to_string(),
+            ))
+        }
+    }
+
+    #[tokio::test]
+    async fn session_preflight_observe_and_cleanup() {
+        let runtime = FaultRuntime::isolated().unwrap();
+        let mut session = FaultTestSession::new();
+        session.add_target(
+            "local",
+            Arc::new(FaultLocalController::new(runtime.clone())),
+        );
+        session.preflight().await.unwrap();
+        session
+            .configure(
+                "local",
+                "record",
+                ConfigureFaultRule {
+                    point: CONTROLLER_POINT_NAME.to_string(),
+                    action: FaultAction::Record,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        runtime
+            .configure(
+                "untracked",
+                ConfigureFaultRule {
+                    point: CONTROLLER_POINT_NAME.to_string(),
+                    action: FaultAction::Record,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        runtime.evaluate(controller_point(), &crate::FaultContext::default());
+        assert_eq!(
+            session
+                .rule("local", "record")
+                .await
+                .unwrap()
+                .unwrap()
+                .executions,
+            1
+        );
+        assert_eq!(
+            session
+                .wait_for_executions("local", "record", 1, Duration::from_secs(1))
+                .await
+                .unwrap()
+                .executions,
+            1
+        );
+        session.cleanup().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn cleanup_attempts_every_target_when_one_target_fails() {
+        fn configure_record(runtime: &FaultRuntime, id: &str) {
+            runtime
+                .configure(
+                    id,
+                    ConfigureFaultRule {
+                        point: CONTROLLER_POINT_NAME.to_string(),
+                        action: FaultAction::Record,
+                        ..Default::default()
+                    },
+                )
+                .unwrap();
+        }
+
+        let first = FaultRuntime::isolated().unwrap();
+        let second = FaultRuntime::isolated().unwrap();
+        configure_record(&first, "first-rule");
+        configure_record(&second, "second-rule");
+
+        let mut session = FaultTestSession::new();
+        session.add_target(
+            "a-first",
+            Arc::new(FaultLocalController::new(first.clone())),
+        );
+        session.add_target("b-failing", Arc::new(CleanupFailureController));
+        session.add_target(
+            "c-second",
+            Arc::new(FaultLocalController::new(second.clone())),
+        );
+
+        let error = session.cleanup().await.unwrap_err().to_string();
+        assert!(error.contains("b-failing clear"));
+        assert!(first.status().rules.is_empty());
+        assert!(second.status().rules.is_empty());
+    }
+
+    #[tokio::test]
+    async fn session_reports_unknown_and_dirty_targets() {
+        let runtime = FaultRuntime::isolated().unwrap();
+        runtime
+            .configure(
+                "existing",
+                ConfigureFaultRule {
+                    point: CONTROLLER_POINT_NAME.to_string(),
+                    action: FaultAction::Record,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        let mut session = FaultTestSession::new();
+        session.add_target("local", Arc::new(FaultLocalController::new(runtime)));
+        assert!(matches!(
+            session.observe("missing").await,
+            Err(FaultControlError::UnknownTarget(target)) if target == "missing"
+        ));
+        assert!(matches!(
+            session.preflight().await,
+            Err(FaultControlError::DirtyTarget { rules }) if rules == ["existing"]
+        ));
+        assert!(matches!(
+            session
+                .wait_for_executions("local", "existing", 1, Duration::ZERO)
+                .await,
+            Err(FaultControlError::WaitTimeout { observed: 0, .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn wait_deadline_bounds_a_hanging_controller_request() {
+        let mut session = FaultTestSession::new();
+        session.add_target("hanging", Arc::new(HangingController));
+        let started = tokio::time::Instant::now();
+        assert!(matches!(
+            session
+                .wait_for_executions("hanging", "rule", 1, Duration::from_millis(20),)
+                .await,
+            Err(FaultControlError::WaitTimeout { observed: 0, .. })
+        ));
+        assert!(started.elapsed() < Duration::from_secs(1));
+    }
+}

--- a/curvine-fault/src/error.rs
+++ b/curvine-fault/src/error.rs
@@ -1,0 +1,68 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum FaultRuntimeError {
+    #[error("unknown fault point: {0}")]
+    UnknownPoint(String),
+
+    #[error("invalid fault rule: {0}")]
+    InvalidRule(String),
+}
+
+#[derive(Debug, Error)]
+pub enum FaultHttpError {
+    #[error("fault HTTP control requires the `http-server` Cargo feature")]
+    FeatureDisabled,
+
+    #[error("fault HTTP bearer token environment variable is not configured")]
+    TokenEnvironmentNotConfigured,
+
+    #[error("fault HTTP bearer token environment variable {0} is not set")]
+    TokenEnvironmentNotSet(String),
+
+    #[error("fault HTTP bearer token environment variable {0} is empty")]
+    EmptyToken(String),
+}
+
+#[cfg(feature = "http-client")]
+#[derive(Debug, Error)]
+pub enum FaultControlError {
+    #[error(transparent)]
+    Runtime(#[from] FaultRuntimeError),
+
+    #[error("unknown fault target: {0}")]
+    UnknownTarget(String),
+
+    #[error("unknown fault rule {rule_id} at target {target}")]
+    UnknownRule { target: String, rule_id: String },
+
+    #[error("fault target is not clean: {rules:?}")]
+    DirtyTarget { rules: Vec<String> },
+
+    #[error("fault controller transport error: {0}")]
+    Transport(String),
+
+    #[error(
+        "timed out waiting for rule {rule_id} at target {target}: expected {expected} executions, observed {observed}"
+    )]
+    WaitTimeout {
+        target: String,
+        rule_id: String,
+        expected: u64,
+        observed: u64,
+    },
+}

--- a/curvine-fault/src/http_control.rs
+++ b/curvine-fault/src/http_control.rs
@@ -1,0 +1,122 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{FaultHttpConfig, FaultHttpError};
+
+#[cfg(feature = "http-server")]
+use crate::http_server::process_fault_router;
+#[cfg(feature = "http-server")]
+use crate::FaultHttpAuth;
+
+/// Optional HTTP exposure for the crate-owned process fault Runtime.
+///
+/// Hosts construct this once from their configuration and pass their Axum
+/// router through [`Self::mount`]. Business fault points do not depend on
+/// this type or on an HTTP server.
+#[derive(Clone, Default)]
+pub struct FaultHttpControl {
+    #[cfg(feature = "http-server")]
+    auth: Option<FaultHttpAuth>,
+}
+
+impl FaultHttpControl {
+    /// Creates an HTTP control-plane mount from an environment-backed token.
+    ///
+    /// A disabled configuration creates a no-op mount and never reads the
+    /// environment. Enabling the configuration without compiling the
+    /// `http-server` feature fails instead of silently omitting the routes.
+    pub fn from_env(config: &FaultHttpConfig) -> Result<Self, FaultHttpError> {
+        if !config.enabled {
+            return Ok(Self::default());
+        }
+        Self::enabled_from_env(&config.auth_token_env)
+    }
+
+    #[cfg(feature = "http-server")]
+    fn enabled_from_env(token_env: &str) -> Result<Self, FaultHttpError> {
+        if token_env.is_empty() {
+            return Err(FaultHttpError::TokenEnvironmentNotConfigured);
+        }
+        let token = std::env::var(token_env)
+            .map_err(|_| FaultHttpError::TokenEnvironmentNotSet(token_env.to_string()))?;
+        if token.is_empty() {
+            return Err(FaultHttpError::EmptyToken(token_env.to_string()));
+        }
+        Ok(Self {
+            auth: Some(FaultHttpAuth::new(token)),
+        })
+    }
+
+    #[cfg(not(feature = "http-server"))]
+    fn enabled_from_env(_token_env: &str) -> Result<Self, FaultHttpError> {
+        Err(FaultHttpError::FeatureDisabled)
+    }
+
+    /// Merges the authenticated fault routes when HTTP control is enabled.
+    #[cfg(feature = "http-server")]
+    pub fn mount(&self, router: axum::Router) -> axum::Router {
+        match &self.auth {
+            Some(auth) => router.merge(process_fault_router(auth.clone())),
+            None => router,
+        }
+    }
+
+    /// Returns the host value unchanged when HTTP support is not compiled.
+    #[cfg(not(feature = "http-server"))]
+    pub fn mount<T>(&self, host: T) -> T {
+        host
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disabled_control_does_not_require_token_configuration() {
+        let control = FaultHttpControl::from_env(&FaultHttpConfig::default()).unwrap();
+
+        #[cfg(feature = "http-server")]
+        assert!(control.auth.is_none());
+        #[cfg(not(feature = "http-server"))]
+        assert_eq!(control.mount(7), 7);
+    }
+
+    #[cfg(not(feature = "http-server"))]
+    #[test]
+    fn enabled_control_requires_http_server_feature() {
+        let Err(error) = FaultHttpControl::from_env(&FaultHttpConfig {
+            enabled: true,
+            auth_token_env: "FAULT_HTTP_TOKEN".to_string(),
+        }) else {
+            panic!("enabled HTTP control must require the http-server feature");
+        };
+        assert!(matches!(error, FaultHttpError::FeatureDisabled));
+    }
+
+    #[cfg(feature = "http-server")]
+    #[test]
+    fn enabled_control_requires_token_environment_name() {
+        let Err(error) = FaultHttpControl::from_env(&FaultHttpConfig {
+            enabled: true,
+            auth_token_env: String::new(),
+        }) else {
+            panic!("enabled HTTP control must require a token environment name");
+        };
+        assert!(matches!(
+            error,
+            FaultHttpError::TokenEnvironmentNotConfigured
+        ));
+    }
+}

--- a/curvine-fault/src/http_server.rs
+++ b/curvine-fault/src/http_server.rs
@@ -1,0 +1,324 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Axum control plane for remote fault injection.
+//!
+//! [`fault_router`] is the low-level API for mounting a selected Runtime.
+//! Normal hosts use [`crate::FaultHttpControl`] to mount the process Runtime.
+//! Every route requires a bearer token; an empty token rejects all requests,
+//! so a misconfigured host fails closed.
+
+use crate::{
+    ConfigureFaultRule, FaultRuleView, FaultRuntime, FaultRuntimeError, FaultRuntimeStatus,
+};
+use axum::extract::{Path, Request, State};
+use axum::http::{header::AUTHORIZATION, HeaderMap, StatusCode};
+use axum::middleware::{self, Next};
+use axum::response::{IntoResponse, Response};
+use axum::routing::{delete, get};
+use axum::{Json, Router};
+use serde_json::json;
+use std::sync::Arc;
+
+/// Bearer-token guard for the fault HTTP API.
+#[derive(Clone)]
+pub struct FaultHttpAuth {
+    token: Arc<str>,
+}
+
+impl FaultHttpAuth {
+    /// Creates a guard from a shared secret. An empty token never authorizes
+    /// any request, so callers without a secret expose only 401 responses.
+    pub fn new(token: impl AsRef<str>) -> Self {
+        Self {
+            token: Arc::from(token.as_ref()),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct FaultHttpState {
+    runtime: FaultRuntime,
+}
+
+#[derive(Debug)]
+struct FaultApiError {
+    status: StatusCode,
+    message: String,
+}
+
+impl From<FaultRuntimeError> for FaultApiError {
+    fn from(value: FaultRuntimeError) -> Self {
+        let status = match value {
+            FaultRuntimeError::UnknownPoint(_) | FaultRuntimeError::InvalidRule(_) => {
+                StatusCode::UNPROCESSABLE_ENTITY
+            }
+        };
+        Self {
+            status,
+            message: value.to_string(),
+        }
+    }
+}
+
+impl IntoResponse for FaultApiError {
+    fn into_response(self) -> Response {
+        (self.status, Json(json!({"message": self.message}))).into_response()
+    }
+}
+
+fn authorize(auth: &FaultHttpAuth, headers: &HeaderMap) -> Result<(), FaultApiError> {
+    if auth.token.is_empty() {
+        return Err(FaultApiError {
+            status: StatusCode::UNAUTHORIZED,
+            message: "fault injection bearer token is not configured".to_string(),
+        });
+    }
+    let provided = headers
+        .get(AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.strip_prefix("Bearer "));
+    if provided.is_some_and(|provided| constant_time_eq(auth.token.as_bytes(), provided.as_bytes()))
+    {
+        Ok(())
+    } else {
+        Err(FaultApiError {
+            status: StatusCode::UNAUTHORIZED,
+            message: "fault injection bearer token is missing or invalid".to_string(),
+        })
+    }
+}
+
+async fn status(
+    State(state): State<FaultHttpState>,
+) -> Result<Json<FaultRuntimeStatus>, FaultApiError> {
+    Ok(Json(state.runtime.status()))
+}
+
+async fn configure(
+    State(state): State<FaultHttpState>,
+    Path(rule_id): Path<String>,
+    Json(rule): Json<ConfigureFaultRule>,
+) -> Result<Json<FaultRuleView>, FaultApiError> {
+    Ok(Json(state.runtime.configure(rule_id, rule)?))
+}
+
+async fn remove(
+    State(state): State<FaultHttpState>,
+    Path(rule_id): Path<String>,
+) -> Result<Json<serde_json::Value>, FaultApiError> {
+    let removed = state.runtime.remove(rule_id)?;
+    Ok(Json(json!({"removed": removed})))
+}
+
+async fn get_rule(
+    State(state): State<FaultHttpState>,
+    Path(rule_id): Path<String>,
+) -> Result<Json<FaultRuleView>, FaultApiError> {
+    state
+        .runtime
+        .rule(&rule_id)?
+        .map(Json)
+        .ok_or_else(|| FaultApiError {
+            status: StatusCode::NOT_FOUND,
+            message: format!("unknown fault rule: {rule_id}"),
+        })
+}
+
+async fn clear(
+    State(state): State<FaultHttpState>,
+) -> Result<Json<serde_json::Value>, FaultApiError> {
+    let cleared = state.runtime.clear()?;
+    Ok(Json(json!({"cleared": cleared})))
+}
+
+async fn require_auth(
+    State(auth): State<FaultHttpAuth>,
+    request: Request,
+    next: Next,
+) -> Result<Response, FaultApiError> {
+    authorize(&auth, request.headers())?;
+    Ok(next.run(request).await)
+}
+
+/// Builds the fault API router for one runtime.
+pub fn fault_router(runtime: FaultRuntime, auth: FaultHttpAuth) -> Router {
+    Router::new()
+        .route("/api/v1/debug/faults", get(status))
+        .route("/api/v1/debug/faults/rules", delete(clear))
+        .route(
+            "/api/v1/debug/faults/rules/:rule_id",
+            get(get_rule).put(configure).delete(remove),
+        )
+        .route_layer(middleware::from_fn_with_state(auth, require_auth))
+        .with_state(FaultHttpState { runtime })
+}
+
+/// Builds the fault API router for the lazily initialized process runtime.
+pub(crate) fn process_fault_router(auth: FaultHttpAuth) -> Router {
+    fault_router(FaultRuntime::process().clone(), auth)
+}
+
+fn constant_time_eq(expected: &[u8], provided: &[u8]) -> bool {
+    if expected.len() != provided.len() {
+        return false;
+    }
+    expected
+        .iter()
+        .zip(provided)
+        .fold(0_u8, |diff, (left, right)| diff | (left ^ right))
+        == 0
+}
+
+#[cfg(all(test, feature = "fault-injection", feature = "http-client"))]
+mod tests {
+    use super::*;
+    use crate::{
+        fault_point, FaultAction, FaultContext, FaultController, FaultHttpController,
+        FaultTestSession, FAULT_POINT_REGISTRATIONS,
+    };
+    use std::time::Duration;
+
+    const SERVER_POINT: &str = "worker.http_server.test";
+
+    #[allow(dead_code)]
+    fn declare_server_point(runtime: &FaultRuntime) {
+        fault_point! {
+            sync,
+            name: "worker.http_server.test",
+            description: "http server test point",
+            runtime: runtime,
+            context: {},
+        }
+    }
+
+    fn test_runtime() -> FaultRuntime {
+        FaultRuntime::isolated().unwrap()
+    }
+
+    #[tokio::test]
+    async fn authenticated_http_lifecycle() {
+        let runtime = test_runtime();
+        let auth = FaultHttpAuth::new("secret");
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let served_runtime = runtime.clone();
+        let server = tokio::spawn(async move {
+            axum::serve(listener, fault_router(served_runtime, auth))
+                .await
+                .unwrap();
+        });
+
+        let controller =
+            Arc::new(FaultHttpController::new(format!("http://{address}"), "secret").unwrap());
+        let mut session = FaultTestSession::new();
+        session.add_target("worker", controller.clone());
+        session.preflight().await.unwrap();
+
+        let view = session
+            .configure(
+                "worker",
+                "record",
+                ConfigureFaultRule {
+                    point: SERVER_POINT.to_string(),
+                    action: FaultAction::Record,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(view.id, "record");
+
+        assert_eq!(
+            controller.rule("record").await.unwrap().unwrap().id,
+            "record"
+        );
+        assert!(controller.rule("missing").await.unwrap().is_none());
+
+        let point = FAULT_POINT_REGISTRATIONS
+            .iter()
+            .find(|registration| registration.point.name == SERVER_POINT)
+            .unwrap()
+            .point;
+        runtime.evaluate(point, &FaultContext::default());
+        assert_eq!(
+            session
+                .wait_for_executions("worker", "record", 1, Duration::from_secs(1))
+                .await
+                .unwrap()
+                .executions,
+            1
+        );
+        session.cleanup().await.unwrap();
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn authentication_precedes_json_body_extraction() {
+        let runtime = test_runtime();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            axum::serve(
+                listener,
+                fault_router(runtime, FaultHttpAuth::new("secret")),
+            )
+            .await
+            .unwrap();
+        });
+
+        let response = reqwest::Client::new()
+            .put(format!(
+                "http://{address}/api/v1/debug/faults/rules/unauthorized"
+            ))
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body("{")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status().as_u16(), 401);
+
+        server.abort();
+    }
+
+    #[test]
+    fn bearer_auth_requires_an_exact_nonempty_token() {
+        let auth = FaultHttpAuth::new("secret");
+        let mut headers = HeaderMap::new();
+        assert_eq!(
+            authorize(&auth, &headers).unwrap_err().status,
+            StatusCode::UNAUTHORIZED
+        );
+
+        for value in ["Bearer wrong", "Basic secret"] {
+            headers.insert(AUTHORIZATION, value.parse().unwrap());
+            assert_eq!(
+                authorize(&auth, &headers).unwrap_err().status,
+                StatusCode::UNAUTHORIZED
+            );
+        }
+
+        headers.insert(AUTHORIZATION, "Bearer secret".parse().unwrap());
+        assert!(authorize(&auth, &headers).is_ok());
+
+        headers.insert(AUTHORIZATION, "Bearer ".parse().unwrap());
+        assert_eq!(
+            authorize(&FaultHttpAuth::new(""), &headers)
+                .unwrap_err()
+                .status,
+            StatusCode::UNAUTHORIZED
+        );
+    }
+}

--- a/curvine-fault/src/lib.rs
+++ b/curvine-fault/src/lib.rs
@@ -1,0 +1,444 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod builder;
+mod catalog;
+mod error;
+mod http_control;
+mod model;
+mod runtime;
+
+#[cfg(feature = "http-client")]
+mod controller;
+
+#[cfg(feature = "http-server")]
+mod http_server;
+
+pub use builder::FaultRuleBuilder;
+#[cfg(feature = "http-client")]
+pub use controller::{
+    FaultController, FaultHttpController, FaultLocalController, FaultTestSession,
+};
+#[cfg(feature = "http-client")]
+pub use error::FaultControlError;
+pub use error::FaultHttpError;
+pub use error::FaultRuntimeError;
+pub use http_control::FaultHttpControl;
+#[cfg(feature = "http-server")]
+pub use http_server::{fault_router, FaultHttpAuth};
+pub use model::*;
+pub use runtime::FaultRuntime;
+
+#[doc(hidden)]
+pub use linkme as __linkme;
+#[doc(hidden)]
+pub use linkme::distributed_slice as __distributed_slice;
+
+#[linkme::distributed_slice]
+#[doc(hidden)]
+pub static FAULT_POINT_REGISTRATIONS: [FaultPointRegistration];
+
+#[doc(hidden)]
+pub fn execute_sync_action(decision: Option<FaultDecision>) -> Option<FaultErrorSpec> {
+    match decision {
+        Some(FaultDecision {
+            action: FaultAction::Delay { duration_ms },
+            ..
+        }) => {
+            std::thread::sleep(std::time::Duration::from_millis(duration_ms));
+            None
+        }
+        decision => execute_non_delay_action(decision),
+    }
+}
+
+#[doc(hidden)]
+pub async fn execute_async_action(decision: Option<FaultDecision>) -> Option<FaultErrorSpec> {
+    match decision {
+        Some(FaultDecision {
+            action: FaultAction::Delay { duration_ms },
+            ..
+        }) => {
+            tokio::time::sleep(std::time::Duration::from_millis(duration_ms)).await;
+            None
+        }
+        decision => execute_non_delay_action(decision),
+    }
+}
+
+fn execute_non_delay_action(decision: Option<FaultDecision>) -> Option<FaultErrorSpec> {
+    let decision = decision?;
+    match decision.action {
+        FaultAction::Record => None,
+        FaultAction::ReturnError { error } => Some(error),
+        FaultAction::Crash => std::process::abort(),
+        FaultAction::Delay { .. } => unreachable!("delay must be handled by the execution model"),
+    }
+}
+
+#[doc(hidden)]
+pub fn invoke_return_handler<R, F>(handler: F, error: FaultErrorSpec) -> R
+where
+    F: FnOnce(FaultErrorSpec) -> R,
+{
+    handler(error)
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __fault_evaluate {
+    ($runtime:expr, $point:expr, $context:expr) => {
+        ($runtime).evaluate($point, $context)
+    };
+    ($point:expr, $context:expr) => {
+        $crate::FaultRuntime::process().evaluate($point, $context)
+    };
+}
+
+#[macro_export]
+macro_rules! fault_context {
+    ($($key:literal => $value:expr),* $(,)?) => {{
+        let mut __context = $crate::FaultContext::default();
+        $(__context.insert($key, $value);)*
+        __context
+    }};
+}
+
+#[cfg(feature = "fault-injection")]
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __fault_point_spec {
+    (
+        name: $name:literal,
+        description: $description:literal,
+        execution: $execution:expr,
+        matchers: [$($matcher:literal),* $(,)?],
+        actions: [$($action:expr),* $(,)?] $(,)?
+    ) => {{
+        const _: () = assert!(
+            $crate::point_name_is_valid($name),
+            "fault point name must not be empty",
+        );
+        static __POINT: $crate::FaultPointSpec = $crate::FaultPointSpec {
+            name: $name,
+            description: $description,
+            execution: $execution,
+            matchers: &[$($matcher),*],
+            actions: &[$($action),*],
+        };
+        #[$crate::__distributed_slice($crate::FAULT_POINT_REGISTRATIONS)]
+        #[linkme(crate = $crate::__linkme)]
+        static __REGISTRATION: $crate::FaultPointRegistration = $crate::FaultPointRegistration {
+            point: &__POINT,
+            file: file!(),
+            line: line!(),
+        };
+        &__POINT
+    }};
+}
+
+#[cfg(feature = "fault-injection")]
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __fault_point_prepare {
+    (
+        execution: $execution:expr,
+        actions: [$($action:expr),* $(,)?],
+        name: $name:literal,
+        description: $description:literal,
+        $(runtime: $runtime:expr,)?
+        context: {$($key:literal => $value:expr),* $(,)?} $(,)?
+    ) => {{
+        let __point = $crate::__fault_point_spec! {
+            name: $name,
+            description: $description,
+            execution: $execution,
+            matchers: [$($key),*],
+            actions: [$($action),*],
+        };
+        let __context = $crate::fault_context! {$($key => $value),*};
+        let __decision =
+            $crate::__fault_evaluate!($($runtime,)? __point, &__context);
+        (__point, __decision)
+    }};
+}
+
+/// Declares, registers, and evaluates one fault point.
+///
+/// # Sync vs async
+///
+/// - A `sync` point executes `Delay` with `std::thread::sleep` on the caller
+///   thread. On Curvine Master/Worker sync ORPC lanes that means the
+///   `spawn_blocking` pool thread, which can stall other sync RPCs for the
+///   full delay. Use only for short, intentional chaos.
+/// - An `async` point executes `Delay` with `tokio::time::sleep`, so only the
+///   current request future is suspended. Prefer this for long delays.
+///
+/// The action JSON is the same (`{"type":"delay","duration_ms":...}`); which
+/// sleep runs is determined solely by whether the call site used `sync` or
+/// `async`. There is no separate "async delay" action.
+///
+/// A `return_error` closure constructs the surrounding function's natural
+/// return value; RPC handlers must follow their sync or async wire contract.
+///
+/// Without the `fault-injection` feature every form expands to an empty
+/// block, so instrumented call sites cost nothing in production builds.
+#[cfg(feature = "fault-injection")]
+#[macro_export]
+macro_rules! fault_point {
+    (
+        sync,
+        name: $name:literal,
+        description: $description:literal,
+        $(runtime: $runtime:expr,)?
+        context: {$($key:literal => $value:expr),* $(,)?} $(,)?
+    ) => {{
+        let (__point, __decision) = $crate::__fault_point_prepare! {
+            execution: $crate::FaultExecution::Sync,
+            actions: [
+                $crate::FaultActionKind::Record,
+                $crate::FaultActionKind::Delay,
+                $crate::FaultActionKind::Crash,
+            ],
+            name: $name,
+            description: $description,
+            $(runtime: $runtime,)?
+            context: {$($key => $value),*},
+        };
+        if $crate::execute_sync_action(__decision).is_some() {
+            panic!(
+                "fault point {} produced ReturnError without a return_error handler",
+                __point.name
+            );
+        }
+    }};
+    (
+        sync,
+        name: $name:literal,
+        description: $description:literal,
+        $(runtime: $runtime:expr,)?
+        context: {$($key:literal => $value:expr),* $(,)?},
+        return_error: $handler:expr $(,)?
+    ) => {{
+        let (_, __decision) = $crate::__fault_point_prepare! {
+            execution: $crate::FaultExecution::Sync,
+            actions: [
+                $crate::FaultActionKind::Record,
+                $crate::FaultActionKind::ReturnError,
+                $crate::FaultActionKind::Delay,
+                $crate::FaultActionKind::Crash,
+            ],
+            name: $name,
+            description: $description,
+            $(runtime: $runtime,)?
+            context: {$($key => $value),*},
+        };
+        if let Some(__fault_error) = $crate::execute_sync_action(__decision) {
+            return $crate::invoke_return_handler($handler, __fault_error);
+        }
+    }};
+    (
+        async,
+        name: $name:literal,
+        description: $description:literal,
+        $(runtime: $runtime:expr,)?
+        context: {$($key:literal => $value:expr),* $(,)?} $(,)?
+    ) => {{
+        let (__point, __decision) = $crate::__fault_point_prepare! {
+            execution: $crate::FaultExecution::Async,
+            actions: [
+                $crate::FaultActionKind::Record,
+                $crate::FaultActionKind::Delay,
+                $crate::FaultActionKind::Crash,
+            ],
+            name: $name,
+            description: $description,
+            $(runtime: $runtime,)?
+            context: {$($key => $value),*},
+        };
+        if $crate::execute_async_action(__decision).await.is_some() {
+            panic!(
+                "fault point {} produced ReturnError without a return_error handler",
+                __point.name
+            );
+        }
+    }};
+    (
+        async,
+        name: $name:literal,
+        description: $description:literal,
+        $(runtime: $runtime:expr,)?
+        context: {$($key:literal => $value:expr),* $(,)?},
+        return_error: $handler:expr $(,)?
+    ) => {{
+        let (_, __decision) = $crate::__fault_point_prepare! {
+            execution: $crate::FaultExecution::Async,
+            actions: [
+                $crate::FaultActionKind::Record,
+                $crate::FaultActionKind::ReturnError,
+                $crate::FaultActionKind::Delay,
+                $crate::FaultActionKind::Crash,
+            ],
+            name: $name,
+            description: $description,
+            $(runtime: $runtime,)?
+            context: {$($key => $value),*},
+        };
+        if let Some(__fault_error) = $crate::execute_async_action(__decision).await {
+            return $crate::invoke_return_handler($handler, __fault_error).await;
+        }
+    }};
+}
+
+/// Shared no-op implementation for consumers that keep their own fault
+/// feature disabled while Cargo enables the engine through another crate.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __noop_fault_point {
+    ($($tokens:tt)*) => {{}};
+}
+
+/// No-op form used when the `fault-injection` feature is disabled.
+#[cfg(not(feature = "fault-injection"))]
+pub use crate::__noop_fault_point as fault_point;
+
+#[cfg(all(test, feature = "fault-injection"))]
+mod tests {
+    use super::*;
+
+    fn runtime() -> FaultRuntime {
+        FaultRuntime::isolated().unwrap()
+    }
+
+    fn sync_return(runtime: &FaultRuntime) -> Result<(), String> {
+        fault_point! {
+            sync,
+            name: "client.macro.sync_return",
+            description: "sync return macro test",
+            runtime: runtime,
+            context: {},
+            return_error: |fault| Err(fault.message),
+        }
+        Ok(())
+    }
+
+    async fn async_return(runtime: &FaultRuntime) -> Result<(), String> {
+        fault_point! {
+            async,
+            name: "client.macro.async_return",
+            description: "async return macro test",
+            runtime: runtime,
+            context: {},
+            return_error: |fault| async move { Err(fault.message) },
+        }
+        Ok(())
+    }
+
+    fn duplicate_first(runtime: &FaultRuntime) {
+        fault_point! {
+            sync,
+            name: "client.macro.duplicate",
+            description: "identical declarations are merged",
+            runtime: runtime,
+            context: {"rpc_code" => 1_i32},
+        }
+    }
+
+    fn duplicate_second(runtime: &FaultRuntime) {
+        fault_point! {
+            sync,
+            name: "client.macro.duplicate",
+            description: "identical declarations are merged",
+            runtime: runtime,
+            context: {"rpc_code" => 2_i32},
+        }
+    }
+
+    #[tokio::test]
+    async fn fault_point_macro_executes_return_delay_and_merges_identical_points() {
+        let runtime = runtime();
+        for (id, point) in [
+            ("sync-return", "client.macro.sync_return"),
+            ("async-return", "client.macro.async_return"),
+        ] {
+            runtime
+                .configure(
+                    id,
+                    ConfigureFaultRule {
+                        point: point.to_string(),
+                        action: FaultAction::ReturnError {
+                            error: FaultErrorSpec {
+                                message: id.to_string(),
+                            },
+                        },
+                        ..Default::default()
+                    },
+                )
+                .unwrap();
+        }
+        runtime
+            .configure(
+                "sync-delay",
+                ConfigureFaultRule {
+                    point: "client.macro.duplicate".to_string(),
+                    action: FaultAction::Delay { duration_ms: 0 },
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        assert_eq!(sync_return(&runtime).unwrap_err(), "sync-return");
+        assert_eq!(async_return(&runtime).await.unwrap_err(), "async-return");
+        duplicate_first(&runtime);
+        duplicate_second(&runtime);
+
+        let status = runtime.status();
+        let duplicate_points = status
+            .points
+            .iter()
+            .filter(|point| point.name == "client.macro.duplicate")
+            .count();
+        assert_eq!(duplicate_points, 1);
+        let return_point = status
+            .points
+            .iter()
+            .find(|point| point.name == "client.macro.sync_return")
+            .unwrap();
+        assert!(return_point.actions.contains(&FaultActionKind::ReturnError));
+        assert!(return_point.actions.contains(&FaultActionKind::Delay));
+        assert!(return_point.actions.contains(&FaultActionKind::Crash));
+    }
+
+    #[test]
+    fn explicit_runtime_form_isolates_in_process_instances() {
+        let first = runtime();
+        let second = runtime();
+        first
+            .configure(
+                "first-only",
+                ConfigureFaultRule {
+                    point: "client.macro.sync_return".to_string(),
+                    action: FaultAction::ReturnError {
+                        error: FaultErrorSpec {
+                            message: "first".to_string(),
+                        },
+                    },
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        assert_eq!(sync_return(&first).unwrap_err(), "first");
+        assert!(sync_return(&second).is_ok());
+    }
+}

--- a/curvine-fault/src/model.rs
+++ b/curvine-fault/src/model.rs
@@ -1,0 +1,375 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// Configuration for exposing the process fault Runtime through HTTP.
+///
+/// The configuration is framework-level and can be embedded directly in a
+/// host application's own configuration model.
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(default, deny_unknown_fields)]
+pub struct FaultHttpConfig {
+    /// Whether the host should expose the fault HTTP routes.
+    pub enabled: bool,
+
+    /// Environment variable containing the bearer token.
+    ///
+    /// The secret itself is deliberately not stored in application config.
+    pub auth_token_env: String,
+}
+
+/// Validates the minimum point-name contract used by `fault_point!`.
+#[doc(hidden)]
+pub const fn point_name_is_valid(name: &str) -> bool {
+    !name.is_empty()
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum FaultExecution {
+    Sync,
+    Async,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum FaultActionKind {
+    Record,
+    ReturnError,
+    Delay,
+    Crash,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+pub struct FaultPointSpec {
+    pub name: &'static str,
+    pub description: &'static str,
+    pub execution: FaultExecution,
+    pub matchers: &'static [&'static str],
+    pub actions: &'static [FaultActionKind],
+}
+
+#[derive(Debug, Clone, Copy)]
+#[doc(hidden)]
+pub struct FaultPointRegistration {
+    pub point: &'static FaultPointSpec,
+    pub file: &'static str,
+    pub line: u32,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct FaultPointView {
+    pub name: String,
+    pub description: String,
+    pub execution: FaultExecution,
+    pub matchers: Vec<String>,
+    pub actions: Vec<FaultActionKind>,
+}
+
+impl From<&FaultPointSpec> for FaultPointView {
+    fn from(value: &FaultPointSpec) -> Self {
+        Self {
+            name: value.name.to_string(),
+            description: value.description.to_string(),
+            execution: value.execution,
+            matchers: value
+                .matchers
+                .iter()
+                .map(|matcher| (*matcher).to_string())
+                .collect(),
+            actions: value.actions.to_vec(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum FaultValue {
+    I64(i64),
+    String(String),
+    Bool(bool),
+}
+
+impl From<i64> for FaultValue {
+    fn from(value: i64) -> Self {
+        Self::I64(value)
+    }
+}
+
+impl From<i32> for FaultValue {
+    fn from(value: i32) -> Self {
+        Self::I64(i64::from(value))
+    }
+}
+
+impl From<i8> for FaultValue {
+    fn from(value: i8) -> Self {
+        Self::I64(i64::from(value))
+    }
+}
+
+impl From<u32> for FaultValue {
+    fn from(value: u32) -> Self {
+        Self::I64(i64::from(value))
+    }
+}
+
+impl From<String> for FaultValue {
+    fn from(value: String) -> Self {
+        Self::String(value)
+    }
+}
+
+impl From<&str> for FaultValue {
+    fn from(value: &str) -> Self {
+        Self::String(value.to_string())
+    }
+}
+
+impl From<bool> for FaultValue {
+    fn from(value: bool) -> Self {
+        Self::Bool(value)
+    }
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(transparent)]
+pub struct FaultMatcher(BTreeMap<String, FaultValue>);
+
+impl FaultMatcher {
+    pub fn insert(
+        &mut self,
+        key: impl Into<String>,
+        value: impl Into<FaultValue>,
+    ) -> Option<FaultValue> {
+        self.0.insert(key.into(), value.into())
+    }
+
+    pub fn keys(&self) -> impl Iterator<Item = &str> {
+        self.0.keys().map(String::as_str)
+    }
+
+    pub(crate) fn matches(&self, context: &FaultContext) -> bool {
+        self.0
+            .iter()
+            .all(|(key, expected)| context.get(key) == Some(expected))
+    }
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(transparent)]
+pub struct FaultContext(BTreeMap<String, FaultValue>);
+
+impl FaultContext {
+    pub fn insert(
+        &mut self,
+        key: impl Into<String>,
+        value: impl Into<FaultValue>,
+    ) -> Option<FaultValue> {
+        self.0.insert(key.into(), value.into())
+    }
+
+    pub fn get(&self, key: &str) -> Option<&FaultValue> {
+        self.0.get(key)
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[serde(default, deny_unknown_fields)]
+pub struct FaultTrigger {
+    pub after: u64,
+    pub max_hits: Option<u64>,
+    pub probability: f64,
+    pub seed: u64,
+}
+
+impl Default for FaultTrigger {
+    fn default() -> Self {
+        Self {
+            after: 0,
+            max_hits: None,
+            probability: 1.0,
+            seed: 0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct FaultErrorSpec {
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+pub enum FaultAction {
+    Record,
+    ReturnError { error: FaultErrorSpec },
+    Delay { duration_ms: u64 },
+    Crash,
+}
+
+impl FaultAction {
+    pub fn kind(&self) -> FaultActionKind {
+        match self {
+            Self::Record => FaultActionKind::Record,
+            Self::ReturnError { .. } => FaultActionKind::ReturnError,
+            Self::Delay { .. } => FaultActionKind::Delay,
+            Self::Crash => FaultActionKind::Crash,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub struct FaultDecision {
+    pub rule_id: String,
+    pub action: FaultAction,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct ConfigureFaultRule {
+    /// Optional human-readable purpose of the rule.
+    #[serde(default)]
+    pub description: Option<String>,
+    /// Required catalog point name.
+    pub point: String,
+    /// Optional exact-match fields. An empty matcher selects every context.
+    #[serde(default)]
+    pub matcher: FaultMatcher,
+    /// Optional execution controls. Omitted fields use `FaultTrigger::default`.
+    #[serde(default)]
+    pub trigger: FaultTrigger,
+    /// Required behavior to execute.
+    pub action: FaultAction,
+}
+
+impl Default for ConfigureFaultRule {
+    fn default() -> Self {
+        Self {
+            description: None,
+            point: String::new(),
+            matcher: FaultMatcher::default(),
+            trigger: FaultTrigger::default(),
+            action: FaultAction::Record,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub struct FaultRuleView {
+    pub id: String,
+    pub description: Option<String>,
+    pub point: String,
+    pub matcher: FaultMatcher,
+    pub trigger: FaultTrigger,
+    pub action: FaultAction,
+    pub evaluations: u64,
+    pub matches: u64,
+    pub executions: u64,
+    pub last_evaluated_context: Option<FaultContext>,
+    pub last_context: Option<FaultContext>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct FaultRuntimeStatus {
+    pub points: Vec<FaultPointView>,
+    pub rules: Vec<FaultRuleView>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matcher_keeps_flat_json_and_uses_exact_and_semantics() {
+        let matcher: FaultMatcher =
+            serde_json::from_str(r#"{"enabled":true,"rpc_code":9,"target":"worker-2"}"#).unwrap();
+        assert_eq!(
+            serde_json::to_value(&matcher).unwrap(),
+            serde_json::json!({
+                "enabled": true,
+                "rpc_code": 9,
+                "target": "worker-2",
+            })
+        );
+
+        let matching = crate::fault_context! {
+            "enabled" => true,
+            "rpc_code" => 9_i32,
+            "target" => "worker-2",
+            "unmatched_context_field" => 1_i64,
+        };
+        assert!(matcher.matches(&matching));
+
+        let different = crate::fault_context! {
+            "enabled" => true,
+            "rpc_code" => 10_i32,
+            "target" => "worker-2",
+        };
+        assert!(!matcher.matches(&different));
+    }
+
+    #[test]
+    fn rule_json_requires_point_and_action_and_defaults_optional_fields() {
+        let minimal: ConfigureFaultRule = serde_json::from_str(
+            r#"{
+                "point":"worker.rpc.before_dispatch",
+                "action":{
+                    "type":"return_error",
+                    "error":{"message":"expected"}
+                }
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(minimal.description, None);
+        assert!(matches!(
+            minimal.action,
+            FaultAction::ReturnError {
+                error: FaultErrorSpec { ref message }
+            } if message == "expected"
+        ));
+        assert!(minimal
+            .matcher
+            .matches(&crate::fault_context! {"rpc_code" => 1_i32}));
+        assert_eq!(minimal.trigger, FaultTrigger::default());
+
+        let partial_trigger: ConfigureFaultRule = serde_json::from_str(
+            r#"{
+                "point":"worker.rpc.before_dispatch",
+                "trigger":{"max_hits":1},
+                "action":{"type":"record"}
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(partial_trigger.trigger.after, 0);
+        assert_eq!(partial_trigger.trigger.max_hits, Some(1));
+        assert_eq!(partial_trigger.trigger.probability, 1.0);
+        assert_eq!(partial_trigger.trigger.seed, 0);
+
+        assert!(
+            serde_json::from_str::<ConfigureFaultRule>(r#"{"action":{"type":"record"}}"#).is_err()
+        );
+        assert!(serde_json::from_str::<ConfigureFaultRule>(
+            r#"{"point":"worker.rpc.before_dispatch"}"#
+        )
+        .is_err());
+        assert!(serde_json::from_str::<FaultAction>(
+            r#"{"type":"return_error","error":{"kind":"io","message":"legacy"}}"#
+        )
+        .is_err());
+    }
+}

--- a/curvine-fault/src/runtime.rs
+++ b/curvine-fault/src/runtime.rs
@@ -1,0 +1,318 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(all(test, feature = "fault-injection"))]
+use crate::catalog::validate_point;
+use crate::catalog::{build_full_catalog, validate_rule_id};
+use crate::{
+    ConfigureFaultRule, FaultAction, FaultContext, FaultDecision, FaultPointSpec, FaultRuleView,
+    FaultRuntimeError, FaultRuntimeStatus, FAULT_POINT_REGISTRATIONS,
+};
+use parking_lot::RwLock;
+use std::collections::BTreeMap;
+use std::sync::{Arc, LazyLock};
+
+#[derive(Debug)]
+struct FaultRule {
+    id: String,
+    description: Option<String>,
+    point: String,
+    matcher: crate::FaultMatcher,
+    trigger: crate::FaultTrigger,
+    action: FaultAction,
+    evidence: RwLock<FaultEvidence>,
+}
+
+#[derive(Debug, Default)]
+struct FaultEvidence {
+    evaluations: u64,
+    matches: u64,
+    executions: u64,
+    last_evaluated_context: Option<FaultContext>,
+    last_context: Option<FaultContext>,
+}
+
+impl FaultRule {
+    fn view(&self) -> FaultRuleView {
+        let evidence = self.evidence.read();
+        FaultRuleView {
+            id: self.id.clone(),
+            description: self.description.clone(),
+            point: self.point.clone(),
+            matcher: self.matcher.clone(),
+            trigger: self.trigger.clone(),
+            action: self.action.clone(),
+            evaluations: evidence.evaluations,
+            matches: evidence.matches,
+            executions: evidence.executions,
+            last_evaluated_context: evidence.last_evaluated_context.clone(),
+            last_context: evidence.last_context.clone(),
+        }
+    }
+
+    fn trigger_matches(&self, match_number: u64) -> bool {
+        if match_number <= self.trigger.after {
+            return false;
+        }
+        if self.trigger.probability < 1.0 {
+            let sample = stable_probability_sample(&self.id, self.trigger.seed, match_number);
+            if sample >= self.trigger.probability {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+fn stable_probability_sample(rule_id: &str, seed: u64, match_number: u64) -> f64 {
+    (stable_probability_hash(rule_id, seed, match_number) >> 11) as f64 / (1_u64 << 53) as f64
+}
+
+fn stable_probability_hash(rule_id: &str, seed: u64, match_number: u64) -> u64 {
+    // Keep both the byte encoding and finalizer fixed so sampling is stable across builds.
+    const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
+    const FNV_PRIME: u64 = 0x100000001b3;
+
+    let mut hash = FNV_OFFSET_BASIS;
+    for byte in rule_id
+        .bytes()
+        .chain(seed.to_le_bytes())
+        .chain(match_number.to_le_bytes())
+    {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    hash = (hash ^ (hash >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    hash = (hash ^ (hash >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    hash ^ (hash >> 31)
+}
+
+#[derive(Debug)]
+struct FaultRuntimeInner {
+    catalog: Vec<&'static FaultPointSpec>,
+    rules: RwLock<BTreeMap<String, Arc<FaultRule>>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct FaultRuntime {
+    inner: Arc<FaultRuntimeInner>,
+}
+
+static PROCESS_FAULT_RUNTIME: LazyLock<FaultRuntime> = LazyLock::new(|| {
+    FaultRuntime::isolated()
+        .unwrap_or_else(|error| panic!("failed to initialize the process fault runtime: {error}"))
+});
+
+impl FaultRuntime {
+    /// Creates an isolated runtime containing every fault point linked into
+    /// the current binary.
+    ///
+    /// Isolated runtimes are intended for unit tests that need independent
+    /// rule tables. Production call sites use [`Self::process`] implicitly
+    /// through [`crate::fault_point!`].
+    pub fn isolated() -> Result<Self, FaultRuntimeError> {
+        let catalog = build_full_catalog(&FAULT_POINT_REGISTRATIONS)?;
+        Ok(Self {
+            inner: Arc::new(FaultRuntimeInner {
+                catalog,
+                rules: RwLock::new(BTreeMap::new()),
+            }),
+        })
+    }
+
+    /// Returns the lazily initialized full-catalog process Runtime.
+    ///
+    /// Business code does not initialize or carry this Runtime. The default
+    /// [`crate::fault_point!`] form evaluates against it automatically. A
+    /// conflicting linked-point catalog is a programming error and fails at
+    /// first access with both declaration locations in the error message.
+    pub fn process() -> &'static Self {
+        &PROCESS_FAULT_RUNTIME
+    }
+
+    /// Installs or replaces one rule.
+    ///
+    /// Rules for the same point are evaluated in rule-ID order. `Record`
+    /// rules publish evidence and allow evaluation to continue; the first
+    /// other rule that executes supplies the behavior decision.
+    pub fn configure(
+        &self,
+        rule_id: impl AsRef<str>,
+        request: ConfigureFaultRule,
+    ) -> Result<FaultRuleView, FaultRuntimeError> {
+        let rule_id = rule_id.as_ref();
+        validate_rule_id(rule_id)?;
+        let point = self.point_spec(&request.point)?;
+        self.validate_rule(point, &request)?;
+
+        let mut rules = self.inner.rules.write();
+        let rule = Arc::new(FaultRule {
+            id: rule_id.to_string(),
+            description: request.description,
+            point: request.point,
+            matcher: request.matcher,
+            trigger: request.trigger,
+            action: request.action,
+            evidence: RwLock::new(FaultEvidence::default()),
+        });
+        let view = rule.view();
+        rules.insert(rule_id.to_string(), rule);
+        Ok(view)
+    }
+
+    pub fn remove(&self, rule_id: impl AsRef<str>) -> Result<bool, FaultRuntimeError> {
+        let rule_id = rule_id.as_ref();
+        validate_rule_id(rule_id)?;
+        Ok(self.inner.rules.write().remove(rule_id).is_some())
+    }
+
+    pub fn rule(
+        &self,
+        rule_id: impl AsRef<str>,
+    ) -> Result<Option<FaultRuleView>, FaultRuntimeError> {
+        let rule_id = rule_id.as_ref();
+        validate_rule_id(rule_id)?;
+        Ok(self.inner.rules.read().get(rule_id).map(|rule| rule.view()))
+    }
+
+    pub fn clear(&self) -> Result<usize, FaultRuntimeError> {
+        let mut rules = self.inner.rules.write();
+        let count = rules.len();
+        rules.clear();
+        Ok(count)
+    }
+
+    pub fn status(&self) -> FaultRuntimeStatus {
+        FaultRuntimeStatus {
+            points: self
+                .inner
+                .catalog
+                .iter()
+                .map(|point| crate::FaultPointView::from(*point))
+                .collect(),
+            rules: self
+                .inner
+                .rules
+                .read()
+                .values()
+                .map(|rule| rule.view())
+                .collect(),
+        }
+    }
+
+    /// Evaluates rules for one point using stable rule-ID ordering.
+    ///
+    /// One write guard publishes all evidence produced by a rule evaluation,
+    /// so status readers never observe a partially updated counter snapshot.
+    /// `Record` continues to the next rule; the first other executed action
+    /// ends evaluation and becomes the returned decision.
+    pub fn evaluate(
+        &self,
+        point: &'static FaultPointSpec,
+        context: &FaultContext,
+    ) -> Option<FaultDecision> {
+        let rules = self
+            .inner
+            .rules
+            .read()
+            .values()
+            .filter(|rule| rule.point == point.name)
+            .cloned()
+            .collect::<Vec<_>>();
+
+        for rule in rules {
+            let matcher_matches = rule.matcher.matches(context);
+            let should_execute = {
+                let mut evidence = rule.evidence.write();
+                evidence.evaluations += 1;
+                evidence.last_evaluated_context = Some(context.clone());
+                if !matcher_matches {
+                    false
+                } else {
+                    evidence.matches += 1;
+                    let match_number = evidence.matches;
+                    if !rule.trigger_matches(match_number)
+                        || rule
+                            .trigger
+                            .max_hits
+                            .is_some_and(|max_hits| evidence.executions >= max_hits)
+                    {
+                        false
+                    } else {
+                        evidence.executions += 1;
+                        evidence.last_context = Some(context.clone());
+                        true
+                    }
+                }
+            };
+            if !should_execute {
+                continue;
+            }
+            if matches!(rule.action, FaultAction::Record) {
+                continue;
+            }
+            return Some(FaultDecision {
+                rule_id: rule.id.clone(),
+                action: rule.action.clone(),
+            });
+        }
+        None
+    }
+
+    fn point_spec(&self, point: &str) -> Result<&'static FaultPointSpec, FaultRuntimeError> {
+        self.inner
+            .catalog
+            .iter()
+            .copied()
+            .find(|spec| spec.name == point)
+            .ok_or_else(|| FaultRuntimeError::UnknownPoint(point.to_string()))
+    }
+
+    fn validate_rule(
+        &self,
+        point: &FaultPointSpec,
+        request: &ConfigureFaultRule,
+    ) -> Result<(), FaultRuntimeError> {
+        for key in request.matcher.keys() {
+            if !point.matchers.contains(&key) {
+                return Err(FaultRuntimeError::InvalidRule(format!(
+                    "matcher {key:?} is not available at {}",
+                    point.name
+                )));
+            }
+        }
+        if !point.actions.contains(&request.action.kind()) {
+            return Err(FaultRuntimeError::InvalidRule(format!(
+                "action {:?} is not available at {}",
+                request.action.kind(),
+                point.name
+            )));
+        }
+        if !(0.0..=1.0).contains(&request.trigger.probability) {
+            return Err(FaultRuntimeError::InvalidRule(
+                "trigger probability must be between 0 and 1".to_string(),
+            ));
+        }
+        if request.trigger.max_hits == Some(0) {
+            return Err(FaultRuntimeError::InvalidRule(
+                "trigger max_hits must be greater than zero".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(all(test, feature = "fault-injection"))]
+#[path = "runtime_tests.rs"]
+mod tests;

--- a/curvine-fault/src/runtime_tests.rs
+++ b/curvine-fault/src/runtime_tests.rs
@@ -1,0 +1,507 @@
+use super::*;
+use crate::{fault_point, FaultActionKind, FaultExecution, FaultMatcher, FaultTrigger};
+
+const TEST_POINT_NAME: &str = "client.runtime.before";
+
+#[allow(dead_code)]
+fn declare_test_point(runtime: &FaultRuntime) -> Result<(), String> {
+    fault_point! {
+        sync,
+        name: "client.runtime.before",
+        description: "runtime test point",
+        runtime: runtime,
+        context: {"block_index" => 0_u32},
+        return_error: |fault| Err(fault.message),
+    }
+    Ok(())
+}
+
+fn test_point() -> &'static FaultPointSpec {
+    FAULT_POINT_REGISTRATIONS
+        .iter()
+        .find(|registration| registration.point.name == TEST_POINT_NAME)
+        .unwrap()
+        .point
+}
+
+fn runtime() -> FaultRuntime {
+    FaultRuntime::isolated().unwrap()
+}
+
+fn declare_arbitrary_point(runtime: &FaultRuntime) {
+    fault_point! {
+        sync,
+        name: "gateway.runtime.before",
+        description: "point using an arbitrary application-defined name",
+        runtime: runtime,
+        context: {},
+    }
+}
+
+#[test]
+fn arbitrary_point_names_register_and_execute() {
+    let runtime = FaultRuntime::isolated().unwrap();
+    let status = runtime.status();
+    assert!(status
+        .points
+        .iter()
+        .any(|point| point.name == "gateway.runtime.before"));
+
+    runtime
+        .configure(
+            "gateway-record",
+            ConfigureFaultRule {
+                point: "gateway.runtime.before".to_string(),
+                action: FaultAction::Record,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    declare_arbitrary_point(&runtime);
+    assert_eq!(
+        runtime.rule("gateway-record").unwrap().unwrap().executions,
+        1
+    );
+}
+
+fn matcher(key: &str, value: impl Into<crate::FaultValue>) -> FaultMatcher {
+    let mut matcher = FaultMatcher::default();
+    matcher.insert(key, value);
+    matcher
+}
+
+#[test]
+fn structured_trigger_and_evidence() {
+    let runtime = runtime();
+    runtime
+        .configure(
+            "fail_second",
+            ConfigureFaultRule {
+                point: TEST_POINT_NAME.to_string(),
+                matcher: matcher("block_index", 1_u32),
+                trigger: FaultTrigger {
+                    max_hits: Some(1),
+                    ..Default::default()
+                },
+                action: FaultAction::ReturnError {
+                    error: crate::FaultErrorSpec {
+                        message: "expected".to_string(),
+                    },
+                },
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+    assert!(runtime
+        .evaluate(
+            test_point(),
+            &crate::fault_context! { "block_index" => 0_u32 }
+        )
+        .is_none());
+    assert!(matches!(
+        runtime.evaluate(
+            test_point(),
+            &crate::fault_context! { "block_index" => 1_u32 }
+        ),
+        Some(FaultDecision {
+            action: FaultAction::ReturnError { .. },
+            ..
+        })
+    ));
+    assert!(runtime
+        .evaluate(
+            test_point(),
+            &crate::fault_context! { "block_index" => 1_u32 }
+        )
+        .is_none());
+    assert!(runtime
+        .evaluate(
+            test_point(),
+            &crate::fault_context! { "block_index" => 0_u32 }
+        )
+        .is_none());
+
+    let rule = runtime.rule("fail_second").unwrap().unwrap();
+    assert_eq!(rule.evaluations, 4);
+    assert_eq!(rule.matches, 2);
+    assert_eq!(rule.executions, 1);
+    assert_eq!(
+        rule.last_evaluated_context
+            .as_ref()
+            .unwrap()
+            .get("block_index"),
+        Some(&crate::FaultValue::I64(0))
+    );
+    assert_eq!(
+        rule.last_context.as_ref().unwrap().get("block_index"),
+        Some(&crate::FaultValue::I64(1))
+    );
+}
+
+#[test]
+fn rules_use_id_order_and_record_continues_to_first_behavior() {
+    let runtime = runtime();
+    for (id, action) in [
+        (
+            "z-behavior",
+            FaultAction::ReturnError {
+                error: crate::FaultErrorSpec {
+                    message: "z".to_string(),
+                },
+            },
+        ),
+        ("a-record", FaultAction::Record),
+        (
+            "b-behavior",
+            FaultAction::ReturnError {
+                error: crate::FaultErrorSpec {
+                    message: "b".to_string(),
+                },
+            },
+        ),
+    ] {
+        runtime
+            .configure(
+                id,
+                ConfigureFaultRule {
+                    point: TEST_POINT_NAME.to_string(),
+                    action,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+    }
+
+    let decision = runtime
+        .evaluate(test_point(), &FaultContext::default())
+        .unwrap();
+    assert_eq!(decision.rule_id, "b-behavior");
+    assert_eq!(runtime.rule("a-record").unwrap().unwrap().executions, 1);
+    assert_eq!(runtime.rule("b-behavior").unwrap().unwrap().executions, 1);
+    assert_eq!(runtime.rule("z-behavior").unwrap().unwrap().evaluations, 0);
+}
+
+#[test]
+fn raw_rules_reject_invalid_ids_points_triggers_and_capabilities() {
+    let runtime = runtime();
+    for invalid_id in ["", ".", "bad/id"] {
+        assert!(matches!(
+            runtime.configure(
+                invalid_id,
+                ConfigureFaultRule {
+                    point: TEST_POINT_NAME.to_string(),
+                    ..Default::default()
+                }
+            ),
+            Err(FaultRuntimeError::InvalidRule(_))
+        ));
+    }
+
+    assert!(matches!(
+        runtime.configure(
+            "unknown-point",
+            ConfigureFaultRule {
+                point: "missing.point".to_string(),
+                ..Default::default()
+            },
+        ),
+        Err(FaultRuntimeError::UnknownPoint(_))
+    ));
+
+    for (id, trigger) in [
+        (
+            "negative-probability",
+            FaultTrigger {
+                probability: -0.1,
+                ..Default::default()
+            },
+        ),
+        (
+            "excessive-probability",
+            FaultTrigger {
+                probability: 1.1,
+                ..Default::default()
+            },
+        ),
+        (
+            "zero-max-hits",
+            FaultTrigger {
+                max_hits: Some(0),
+                ..Default::default()
+            },
+        ),
+    ] {
+        assert!(matches!(
+            runtime.configure(
+                id,
+                ConfigureFaultRule {
+                    point: TEST_POINT_NAME.to_string(),
+                    trigger,
+                    ..Default::default()
+                },
+            ),
+            Err(FaultRuntimeError::InvalidRule(_))
+        ));
+    }
+
+    assert!(matches!(
+        runtime.configure(
+            "bad-matcher",
+            ConfigureFaultRule {
+                point: TEST_POINT_NAME.to_string(),
+                matcher: matcher("undeclared", true),
+                ..Default::default()
+            },
+        ),
+        Err(FaultRuntimeError::InvalidRule(_))
+    ));
+    assert!(matches!(
+        runtime.configure(
+            "bad",
+            ConfigureFaultRule {
+                point: "gateway.runtime.before".to_string(),
+                action: FaultAction::ReturnError {
+                    error: crate::FaultErrorSpec {
+                        message: "unsupported".to_string(),
+                    },
+                },
+                ..Default::default()
+            },
+        ),
+        Err(FaultRuntimeError::InvalidRule(_))
+    ));
+}
+
+#[test]
+fn configuring_the_same_rule_id_replaces_rule_and_resets_evidence() {
+    let runtime = runtime();
+    runtime
+        .configure(
+            "replace-me",
+            ConfigureFaultRule {
+                point: TEST_POINT_NAME.to_string(),
+                action: FaultAction::ReturnError {
+                    error: crate::FaultErrorSpec {
+                        message: "first".to_string(),
+                    },
+                },
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    assert!(runtime
+        .evaluate(test_point(), &FaultContext::default())
+        .is_some());
+    assert_eq!(runtime.rule("replace-me").unwrap().unwrap().executions, 1);
+
+    let replacement = runtime
+        .configure(
+            "replace-me",
+            ConfigureFaultRule {
+                description: Some("replacement".to_string()),
+                point: TEST_POINT_NAME.to_string(),
+                trigger: FaultTrigger {
+                    max_hits: Some(2),
+                    ..Default::default()
+                },
+                action: FaultAction::ReturnError {
+                    error: crate::FaultErrorSpec {
+                        message: "second".to_string(),
+                    },
+                },
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    assert_eq!(replacement.description.as_deref(), Some("replacement"));
+    assert_eq!(replacement.evaluations, 0);
+    assert_eq!(replacement.matches, 0);
+    assert_eq!(replacement.executions, 0);
+    assert_eq!(runtime.status().rules.len(), 1);
+
+    let decision = runtime
+        .evaluate(test_point(), &FaultContext::default())
+        .unwrap();
+    assert!(matches!(
+        decision.action,
+        FaultAction::ReturnError {
+            error: crate::FaultErrorSpec { ref message }
+        } if message == "second"
+    ));
+}
+
+#[test]
+fn accepts_unbounded_delay_and_process_crash_rules() {
+    let runtime = runtime();
+    for (id, action) in [
+        (
+            "long-delay",
+            FaultAction::Delay {
+                duration_ms: u64::MAX,
+            },
+        ),
+        ("process-crash", FaultAction::Crash),
+    ] {
+        runtime
+            .configure(
+                id,
+                ConfigureFaultRule {
+                    point: TEST_POINT_NAME.to_string(),
+                    action,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+    }
+    assert_eq!(runtime.status().rules.len(), 2);
+}
+
+#[test]
+fn max_hits_is_atomic_across_concurrent_evaluations() {
+    let runtime = runtime();
+    runtime
+        .configure(
+            "once",
+            ConfigureFaultRule {
+                point: TEST_POINT_NAME.to_string(),
+                trigger: FaultTrigger {
+                    max_hits: Some(1),
+                    ..Default::default()
+                },
+                action: FaultAction::ReturnError {
+                    error: crate::FaultErrorSpec {
+                        message: "expected".to_string(),
+                    },
+                },
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+    let barrier = Arc::new(std::sync::Barrier::new(32));
+    let executions = (0..32)
+        .map(|_| {
+            let runtime = runtime.clone();
+            let barrier = barrier.clone();
+            std::thread::spawn(move || {
+                barrier.wait();
+                runtime
+                    .evaluate(test_point(), &FaultContext::default())
+                    .is_some()
+            })
+        })
+        .collect::<Vec<_>>()
+        .into_iter()
+        .map(|thread| thread.join().unwrap())
+        .filter(|executed| *executed)
+        .count();
+
+    assert_eq!(executions, 1);
+    assert_eq!(runtime.rule("once").unwrap().unwrap().executions, 1);
+}
+
+#[test]
+fn trigger_after_skips_matching_calls_before_execution() {
+    let runtime = runtime();
+    runtime
+        .configure(
+            "after-two",
+            ConfigureFaultRule {
+                point: TEST_POINT_NAME.to_string(),
+                trigger: FaultTrigger {
+                    after: 2,
+                    ..Default::default()
+                },
+                action: FaultAction::ReturnError {
+                    error: crate::FaultErrorSpec {
+                        message: "expected".to_string(),
+                    },
+                },
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+    let context = FaultContext::default();
+    assert!(runtime.evaluate(test_point(), &context).is_none());
+    assert!(runtime.evaluate(test_point(), &context).is_none());
+    assert!(runtime.evaluate(test_point(), &context).is_some());
+
+    let rule = &runtime.status().rules[0];
+    assert_eq!(rule.matches, 3);
+    assert_eq!(rule.executions, 1);
+}
+
+#[test]
+fn trigger_probability_boundaries_and_seed_are_deterministic() {
+    assert_eq!(
+        stable_probability_hash("probability", 7, 1),
+        0x2bdd_198d_953e_3dcf
+    );
+
+    fn configured_runtime(probability: f64, seed: u64) -> FaultRuntime {
+        let runtime = runtime();
+        runtime
+            .configure(
+                "probability",
+                ConfigureFaultRule {
+                    point: TEST_POINT_NAME.to_string(),
+                    trigger: FaultTrigger {
+                        probability,
+                        seed,
+                        ..Default::default()
+                    },
+                    action: FaultAction::ReturnError {
+                        error: crate::FaultErrorSpec {
+                            message: "expected".to_string(),
+                        },
+                    },
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        runtime
+    }
+
+    let context = FaultContext::default();
+    assert!(configured_runtime(0.0, 7)
+        .evaluate(test_point(), &context)
+        .is_none());
+    assert!(configured_runtime(1.0, 7)
+        .evaluate(test_point(), &context)
+        .is_some());
+
+    let first = configured_runtime(0.5, 7);
+    let second = configured_runtime(0.5, 7);
+    let first_results = (0..32)
+        .map(|_| first.evaluate(test_point(), &context).is_some())
+        .collect::<Vec<_>>();
+    let second_results = (0..32)
+        .map(|_| second.evaluate(test_point(), &context).is_some())
+        .collect::<Vec<_>>();
+    assert_eq!(first_results, second_results);
+    assert!(first_results.iter().any(|executed| *executed));
+    assert!(first_results.iter().any(|executed| !*executed));
+}
+
+#[test]
+fn rejects_invalid_points() {
+    static EMPTY_NAME: crate::FaultPointSpec = crate::FaultPointSpec {
+        name: "",
+        description: "point without a name",
+        execution: FaultExecution::Sync,
+        matchers: &[],
+        actions: &[FaultActionKind::Record],
+    };
+    assert!(validate_point(&EMPTY_NAME).is_err());
+
+    static DUPLICATE_MATCHERS: crate::FaultPointSpec = crate::FaultPointSpec {
+        name: "client.test.duplicate_matchers",
+        description: "duplicate matcher point",
+        execution: FaultExecution::Sync,
+        matchers: &["index", "index"],
+        actions: &[FaultActionKind::Record],
+    };
+    assert!(validate_point(&DUPLICATE_MATCHERS).is_err());
+}

--- a/curvine-fault/tests/catalog_conflict.rs
+++ b/curvine-fault/tests/catalog_conflict.rs
@@ -1,0 +1,47 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg(feature = "fault-injection")]
+
+use curvine_fault::{fault_point, FaultRuntime};
+
+#[allow(dead_code)]
+fn first_declaration(runtime: &FaultRuntime) {
+    fault_point! {
+        sync,
+        name: "client.test.conflicting_contract",
+        description: "first declaration",
+        runtime: runtime,
+        context: {"rpc_code" => 1_i32},
+    }
+}
+
+#[allow(dead_code)]
+fn second_declaration(runtime: &FaultRuntime) {
+    fault_point! {
+        sync,
+        name: "client.test.conflicting_contract",
+        description: "second declaration",
+        runtime: runtime,
+        context: {"rpc_code" => 2_i32},
+    }
+}
+
+#[test]
+fn conflicting_implicit_declarations_report_both_call_sites() {
+    let error = FaultRuntime::isolated().unwrap_err().to_string();
+
+    assert!(error.contains("client.test.conflicting_contract"));
+    assert!(error.matches("catalog_conflict.rs:").count() >= 2);
+}

--- a/curvine-fault/tests/feature_off.rs
+++ b/curvine-fault/tests/feature_off.rs
@@ -1,0 +1,44 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg(not(feature = "fault-injection"))]
+
+use curvine_fault::fault_point;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static CONTEXT_EVALUATIONS: AtomicUsize = AtomicUsize::new(0);
+
+#[allow(dead_code)]
+fn context_value() -> i64 {
+    CONTEXT_EVALUATIONS.fetch_add(1, Ordering::SeqCst);
+    1
+}
+
+fn disabled_point() {
+    fault_point! {
+        sync,
+        name: "test.feature_off.noop",
+        description: "Feature-off macro must not register or evaluate context",
+        context: {"value" => context_value()},
+    }
+}
+
+#[test]
+fn feature_off_macro_has_no_registration_or_context_side_effect() {
+    disabled_point();
+    assert_eq!(CONTEXT_EVALUATIONS.load(Ordering::SeqCst), 0);
+    assert!(curvine_fault::FAULT_POINT_REGISTRATIONS
+        .iter()
+        .all(|registration| registration.point.name != "test.feature_off.noop"));
+}

--- a/curvine-fault/tests/process_runtime.rs
+++ b/curvine-fault/tests/process_runtime.rs
@@ -1,0 +1,103 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg(feature = "fault-injection")]
+
+use curvine_fault::{fault_point, ConfigureFaultRule, FaultAction, FaultErrorSpec, FaultRuntime};
+
+fn embedded_client_point() -> Result<(), String> {
+    fault_point! {
+        sync,
+        name: "client.process_runtime.before_call",
+        description: "Client point executed inside a process-owned runtime",
+        context: {},
+        return_error: |fault| Err(fault.message),
+    }
+    Ok(())
+}
+
+#[allow(dead_code)]
+fn linked_but_unreached_master_point() {
+    fault_point! {
+        sync,
+        name: "master.process_runtime.unreachable",
+        description: "A linked point that this test workload does not call",
+        context: {},
+    }
+}
+
+#[test]
+fn process_runtime_owns_all_linked_points_and_default_macro_uses_it() {
+    // No startup hook installs a Runtime. Reaching the default macro form is
+    // sufficient to initialize the crate-owned process Runtime.
+    assert!(embedded_client_point().is_ok());
+    let runtime = FaultRuntime::process();
+
+    let status = runtime.status();
+    assert!(status
+        .points
+        .iter()
+        .any(|point| point.name == "client.process_runtime.before_call"));
+    assert!(status
+        .points
+        .iter()
+        .any(|point| point.name == "master.process_runtime.unreachable"));
+    runtime
+        .configure(
+            "inactive-master-rule",
+            ConfigureFaultRule {
+                point: "master.process_runtime.unreachable".to_string(),
+                action: FaultAction::Record,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    assert_eq!(
+        runtime
+            .rule("inactive-master-rule")
+            .unwrap()
+            .unwrap()
+            .executions,
+        0,
+        "configuring a linked point does not imply that the workload reached it"
+    );
+    runtime
+        .configure(
+            "embedded-client-error",
+            ConfigureFaultRule {
+                point: "client.process_runtime.before_call".to_string(),
+                action: FaultAction::ReturnError {
+                    error: FaultErrorSpec {
+                        message: "expected".to_string(),
+                    },
+                },
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+    assert_eq!(embedded_client_point().unwrap_err(), "expected");
+    assert_eq!(
+        runtime
+            .rule("embedded-client-error")
+            .unwrap()
+            .unwrap()
+            .executions,
+        1
+    );
+    let reused = FaultRuntime::process();
+    assert!(std::ptr::eq(runtime, reused));
+    assert!(reused.rule("embedded-client-error").unwrap().is_some());
+    runtime.clear().unwrap();
+}

--- a/curvine-server/Cargo.toml
+++ b/curvine-server/Cargo.toml
@@ -11,10 +11,14 @@ default = []
 jni = ["curvine-ufs/jni"]
 spdk = ["orpc/spdk"]
 spdk-rdma = ["spdk", "orpc/spdk-rdma"]
+fault-injection = [
+    "curvine-fault/http-server",
+]
 
 [dependencies]
 orpc = { workspace = true }
 curvine-common = { workspace = true }
+curvine-fault = { workspace = true }
 curvine-client = { workspace = true }
 curvine-ufs = { workspace = true }
 curvine-web = { workspace = true }
@@ -49,3 +53,6 @@ url = { workspace = true }
 parking_lot = { workspace = true }
 lru = { workspace = true }
 byteorder = { workspace = true }
+
+[dev-dependencies]
+curvine-fault = { workspace = true, features = ["http-client"] }

--- a/curvine-server/src/lib.rs
+++ b/curvine-server/src/lib.rs
@@ -16,3 +16,9 @@ pub mod common;
 pub mod master;
 pub mod test;
 pub mod worker;
+
+#[cfg(feature = "fault-injection")]
+pub(crate) use curvine_fault::fault_point;
+
+#[cfg(not(feature = "fault-injection"))]
+pub(crate) use curvine_fault::__noop_fault_point as fault_point;

--- a/curvine-server/src/master/master_handler.rs
+++ b/curvine-server/src/master/master_handler.rs
@@ -866,6 +866,17 @@ impl MessageHandler for MasterHandler {
     }
 
     fn handle(&mut self, msg: &Message) -> FsResult<Message> {
+        crate::fault_point! {
+            sync,
+            name: "master.rpc.before_sync_dispatch",
+            description: "Before a synchronous Master RPC is dispatched to its business handler",
+            context: {
+                "req_id" => msg.req_id(),
+                "rpc_code" => msg.code() as i32,
+            },
+            return_error: |fault| Ok(msg.error_ext(&FsError::common(fault.message))),
+        }
+
         let mut rpc_context = RpcContext::new(msg);
         let ctx = &mut rpc_context;
         let code = RpcCode::from(msg.code());
@@ -935,6 +946,19 @@ impl MessageHandler for MasterHandler {
     }
 
     async fn async_handle(&mut self, msg: Message) -> FsResult<Message> {
+        crate::fault_point! {
+            async,
+            name: "master.rpc.before_async_dispatch",
+            description: "Before an asynchronous Master RPC is dispatched to its business handler",
+            context: {
+                "req_id" => msg.req_id(),
+                "rpc_code" => msg.code() as i32,
+            },
+            return_error: |fault| async {
+                Ok(msg.error_ext(&FsError::common(fault.message)))
+            },
+        }
+
         let mut rpc_context = RpcContext::new(&msg);
         let ctx = &mut rpc_context;
         let code = RpcCode::from(msg.code());

--- a/curvine-server/src/master/master_server.rs
+++ b/curvine-server/src/master/master_server.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use once_cell::sync::OnceCell;
 
 use curvine_common::conf::ClusterConf;
+use curvine_fault::FaultHttpControl;
 use curvine_web::server::{WebHandlerService, WebServer};
 use log::error;
 use orpc::common::{LocalTime, Logger};
@@ -24,7 +25,7 @@ use orpc::handler::HandlerService;
 use orpc::io::net::ConnState;
 use orpc::runtime::{GroupExecutor, RpcRuntime, Runtime};
 use orpc::server::{RpcServer, ServerStateListener};
-use orpc::{err_box, CommonResult};
+use orpc::{err_box, CommonError, CommonResult};
 
 use crate::master::fs::{FsRetryCache, MasterActor, MasterFilesystem};
 use crate::master::journal::JournalSystem;
@@ -51,11 +52,12 @@ pub struct MasterService {
     get_block_locations_rpc_executor: Arc<GroupExecutor>,
     replication_manager: Arc<MasterReplicationManager>,
     metrics: &'static MasterMetrics,
+    fault_http: FaultHttpControl,
 }
 
 impl MasterService {
     #[allow(clippy::too_many_arguments)]
-    pub fn new(
+    pub(crate) fn new(
         conf: ClusterConf,
         fs: MasterFilesystem,
         retry_cache: Option<FsRetryCache>,
@@ -69,6 +71,7 @@ impl MasterService {
         get_block_locations_rpc_executor: Arc<GroupExecutor>,
         replication_manager: Arc<MasterReplicationManager>,
         metrics: &'static MasterMetrics,
+        fault_http: FaultHttpControl,
     ) -> Self {
         Self {
             conf,
@@ -84,6 +87,7 @@ impl MasterService {
             get_block_locations_rpc_executor,
             replication_manager,
             metrics,
+            fault_http,
         }
     }
 
@@ -134,7 +138,12 @@ impl WebHandlerService for MasterService {
     type Item = MasterRouterHandler;
 
     fn get_handler(&self) -> Self::Item {
-        MasterRouterHandler::new(self.conf.clone(), self.fs.clone(), self.metrics)
+        MasterRouterHandler::new(
+            self.conf.clone(),
+            self.fs.clone(),
+            self.metrics,
+            self.fault_http.clone(),
+        )
     }
 }
 
@@ -157,6 +166,8 @@ impl Master {
         }
 
         Logger::init(log);
+        let fault_http = FaultHttpControl::from_env(&conf.fault_injection)
+            .map_err(|error| CommonError::from(error.to_string()))?;
         let metrics = MASTER_METRICS.get_or_try_init(MasterMetrics::new)?;
         conf.print();
 
@@ -212,6 +223,7 @@ impl Master {
             get_block_locations_rpc_executor,
             replication_manager.clone(),
             metrics,
+            fault_http,
         );
 
         let rpc_conf = conf.master_server_conf();

--- a/curvine-server/src/master/router_handler.rs
+++ b/curvine-server/src/master/router_handler.rs
@@ -23,6 +23,7 @@ use serde_json::{json, Value};
 use curvine_common::conf::ClusterConf;
 use curvine_common::state::{FileBlocks, FileStatus, WorkerInfo};
 use curvine_common::FsResult;
+use curvine_fault::FaultHttpControl;
 use curvine_web::router::RouterHandler;
 use orpc::common::LocalTime;
 use orpc::err_box;
@@ -36,15 +37,22 @@ pub struct MasterRouterHandler {
     conf: ClusterConf,
     start_time: String,
     metrics: &'static MasterMetrics,
+    fault_http: FaultHttpControl,
 }
 
 impl MasterRouterHandler {
-    pub fn new(conf: ClusterConf, fs: MasterFilesystem, metrics: &'static MasterMetrics) -> Self {
+    pub(crate) fn new(
+        conf: ClusterConf,
+        fs: MasterFilesystem,
+        metrics: &'static MasterMetrics,
+        fault_http: FaultHttpControl,
+    ) -> Self {
         Self {
             fs,
             conf,
             start_time: LocalTime::now_datetime(),
             metrics,
+            fault_http,
         }
     }
 }
@@ -247,7 +255,7 @@ impl RouterHandler for MasterRouterHandler {
     fn router(&self) -> Router {
         let instance = Arc::new(self.clone());
         let conf = self.conf.clone();
-        Router::new()
+        let router = Router::new()
             .route("/metrics", get(metrics))
             .route("/report", get(report))
             .route("/api/overview", get(overview))
@@ -259,6 +267,8 @@ impl RouterHandler for MasterRouterHandler {
             .route("/get-dcm", get(get_dcm))
             .route("/remove-dcm", get(remove_dcm))
             .route("/workers", get(workers1))
-            .layer(Extension(instance))
+            .layer(Extension(instance));
+
+        self.fault_http.mount(router)
     }
 }

--- a/curvine-server/src/worker/handler/router_handler.rs
+++ b/curvine-server/src/worker/handler/router_handler.rs
@@ -12,15 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::worker::Worker;
 use axum::routing::get;
 use axum::Router;
-
 use curvine_common::FsResult;
+use curvine_fault::FaultHttpControl;
 use curvine_web::router::RouterHandler;
 
-use crate::worker::Worker;
-
-pub struct WorkerRouterHandler;
+#[derive(Clone)]
+pub struct WorkerRouterHandler {
+    pub(crate) fault_http: FaultHttpControl,
+}
 
 async fn metrics() -> FsResult<String> {
     let metrics = Worker::get_metrics()?;
@@ -29,6 +31,8 @@ async fn metrics() -> FsResult<String> {
 
 impl RouterHandler for WorkerRouterHandler {
     fn router(&self) -> Router {
-        Router::new().route("/metrics", get(metrics))
+        let router = Router::new().route("/metrics", get(metrics));
+
+        self.fault_http.mount(router)
     }
 }

--- a/curvine-server/src/worker/handler/worker_handler.rs
+++ b/curvine-server/src/worker/handler/worker_handler.rs
@@ -40,6 +40,18 @@ impl MessageHandler for WorkerHandler {
     type Error = FsError;
 
     fn handle(&mut self, msg: &Message) -> FsResult<Message> {
+        crate::fault_point! {
+            sync,
+            name: "worker.rpc.before_dispatch",
+            description: "Before a Worker RPC is dispatched to its business handler",
+            context: {
+                "req_id" => msg.req_id(),
+                "rpc_code" => msg.code() as i32,
+                "request_status" => i8::from(msg.request_status()),
+            },
+            return_error: |fault| Err(FsError::common(fault.message)),
+        }
+
         let code = RpcCode::from(msg.code());
         match code {
             RpcCode::SubmitTask => self.task_submit(msg),

--- a/curvine-server/src/worker/worker_server.rs
+++ b/curvine-server/src/worker/worker_server.rs
@@ -20,6 +20,7 @@ use crate::worker::task::TaskManager;
 use crate::worker::WorkerMetrics;
 use curvine_common::conf::ClusterConf;
 use curvine_common::state::{HeartbeatStatus, WorkerAddress};
+use curvine_fault::FaultHttpControl;
 use curvine_web::server::{WebHandlerService, WebServer};
 use log::info;
 use once_cell::sync::OnceCell;
@@ -46,10 +47,13 @@ pub struct WorkerService {
     task_manager: Arc<TaskManager>,
     rt: Arc<Runtime>,
     replication_manager: Arc<WorkerReplicationManager>,
+    fault_http: FaultHttpControl,
 }
 
 impl WorkerService {
     pub fn with_conf(conf: &ClusterConf, rt: Arc<Runtime>) -> CommonResult<Self> {
+        let fault_http = FaultHttpControl::from_env(&conf.fault_injection)
+            .map_err(|error| CommonError::from(error.to_string()))?;
         let store: BlockStore = BlockStore::new(&conf.cluster_id, conf)?;
 
         let task_manager = TaskManager::with_rt(rt.clone(), conf)?;
@@ -63,6 +67,7 @@ impl WorkerService {
             task_manager: Arc::new(task_manager),
             rt,
             replication_manager,
+            fault_http,
         };
         Ok(ws)
     }
@@ -94,7 +99,9 @@ impl WebHandlerService for WorkerService {
     type Item = WorkerRouterHandler;
 
     fn get_handler(&self) -> Self::Item {
-        WorkerRouterHandler {}
+        WorkerRouterHandler {
+            fault_http: self.fault_http.clone(),
+        }
     }
 }
 

--- a/curvine-server/tests/master_fs_test.rs
+++ b/curvine-server/tests/master_fs_test.rs
@@ -38,11 +38,16 @@ use orpc::common::LocalTime;
 use orpc::common::Utils;
 use orpc::handler::MessageHandler;
 use orpc::message::Builder;
+#[cfg(feature = "fault-injection")]
+use orpc::message::ResponseStatus;
 use orpc::runtime::{AsyncRuntime, GroupExecutor, RpcRuntime};
 use orpc::CommonResult;
 use raft::eraftpb::Entry;
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
+
+#[cfg(feature = "fault-injection")]
+use curvine_fault::{FaultRuleBuilder, FaultRuntime};
 
 // Master metrics gauges are process-wide; master_fs_test cases must not run in parallel or
 // inode_file_num / inode_dir_num race with other tests' format/init.
@@ -150,15 +155,20 @@ fn file_counts(fs: &MasterFilesystem) -> (i64, i64) {
 }
 
 fn new_handler() -> MasterHandler {
+    new_handler_for_test("retry")
+}
+
+fn new_handler_for_test(test_name: &str) -> MasterHandler {
     Master::init_test_metrics();
 
     let test_id = Utils::rand_str(8);
     let mut conf = ClusterConf::format();
     conf.journal.enable = false;
 
-    conf.master.meta_dir = Utils::test_sub_dir(format!("master-fs-test/meta-retry-{test_id}"));
+    conf.master.meta_dir =
+        Utils::test_sub_dir(format!("master-fs-test/meta-{test_name}-{test_id}"));
     conf.journal.journal_dir =
-        Utils::test_sub_dir(format!("master-fs-test/journal-retry-{test_id}"));
+        Utils::test_sub_dir(format!("master-fs-test/journal-{test_name}-{test_id}"));
 
     let journal_system = JournalSystem::from_conf(&conf).unwrap();
     let fs = MasterFilesystem::with_js(&conf, &journal_system);
@@ -196,6 +206,52 @@ fn new_handler() -> MasterHandler {
         replication_manager,
         Master::get_metrics().expect("test master metrics should initialize"),
     )
+}
+
+#[cfg(feature = "fault-injection")]
+#[test]
+fn test_master_sync_and_async_rpc_points_follow_dispatch_paths() -> CommonResult<()> {
+    let _serial = master_fs_test_serial();
+    let faults = FaultRuntime::process();
+    faults.clear()?;
+    for (id, point, code) in [
+        (
+            "sync-dispatch",
+            "master.rpc.before_sync_dispatch",
+            RpcCode::Mkdir,
+        ),
+        (
+            "async-dispatch",
+            "master.rpc.before_async_dispatch",
+            RpcCode::SubmitJob,
+        ),
+    ] {
+        let rule = FaultRuleBuilder::named(point)
+            .matches("rpc_code", code as i32)?
+            .times(1)?
+            .return_error(id)?;
+        faults.configure(id, rule)?;
+    }
+
+    let mut handler = new_handler_for_test("fault-dispatch");
+    let sync_request = Builder::new_rpc(RpcCode::Mkdir).build();
+    let sync_response = handler.handle(&sync_request)?;
+
+    let async_request = Builder::new_rpc(RpcCode::SubmitJob).build();
+    let rt = AsyncRuntime::single();
+    let async_response = rt.block_on(handler.async_handle(async_request))?;
+    for response in [sync_response, async_response] {
+        assert_eq!(response.response_status(), ResponseStatus::Error);
+        assert!(matches!(
+            response.check_error_ext::<FsError>(),
+            Err(FsError::Common(_))
+        ));
+    }
+
+    let status = faults.status();
+    assert!(status.rules.iter().all(|rule| rule.executions == 1));
+    faults.clear()?;
+    Ok(())
 }
 
 #[test]

--- a/curvine-server/tests/worker_test.rs
+++ b/curvine-server/tests/worker_test.rs
@@ -30,8 +30,29 @@ use orpc::CommonResult;
 use prost::bytes::BytesMut;
 use std::thread;
 
+#[cfg(feature = "fault-injection")]
+use curvine_fault::{
+    FaultController, FaultHttpController, FaultRuleBuilder, FaultRuntime, FaultTestSession,
+    FaultValue,
+};
+#[cfg(feature = "fault-injection")]
+use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
+#[cfg(feature = "fault-injection")]
+use std::time::Duration;
+
 const CHUNK_SIZE: i32 = 1024;
 const LOOP_NUM: i32 = 100;
+
+#[cfg(feature = "fault-injection")]
+static WORKER_FAULT_TEST_SERIAL: OnceLock<Mutex<()>> = OnceLock::new();
+
+#[cfg(feature = "fault-injection")]
+fn worker_fault_test_serial() -> MutexGuard<'static, ()> {
+    WORKER_FAULT_TEST_SERIAL
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
 
 // Test the worker interface function.
 fn start_worker() -> ClusterConf {
@@ -48,6 +69,38 @@ fn start_worker() -> ClusterConf {
 
     let server = Worker::with_conf(conf.clone()).unwrap();
     thread::spawn(move || server.start_standalone());
+    conf
+}
+
+#[cfg(feature = "fault-injection")]
+fn start_worker_with_faults() -> ClusterConf {
+    const TOKEN_ENV: &str = "CURVINE_WORKER_TEST_FAULT_TOKEN";
+    std::env::set_var(TOKEN_ENV, "worker-test-secret");
+
+    let mut conf = ClusterConf::default();
+    conf.worker.rpc_port = NetUtils::hold_available_port();
+    conf.worker.web_port = NetUtils::hold_available_port();
+    conf.worker.data_dir = vec![format!(
+        "[MEM:10MB]../testing/worker-fault-test-{}",
+        Utils::req_id().abs()
+    )];
+    conf.fault_injection.enabled = true;
+    conf.fault_injection.auth_token_env = TOKEN_ENV.to_string();
+    conf.client.init().unwrap();
+
+    let server = Worker::with_conf(conf.clone()).unwrap();
+    let faults = FaultRuntime::process();
+    faults
+        .clear()
+        .expect("fault-enabled Worker test must start from a clean Runtime");
+    // Use Worker::block_on_start so the Web control plane is bound; the older
+    // start_standalone path only starts the RPC server.
+    thread::spawn(move || {
+        if let Err(error) = server.block_on_start() {
+            log::error!("fault-enabled worker failed to start: {error}");
+            std::process::abort();
+        }
+    });
     conf
 }
 
@@ -300,6 +353,122 @@ fn test_worker_batch_remote_write_complete_and_read_back() -> CommonResult<()> {
         );
     }
 
+    Ok(())
+}
+
+#[cfg(feature = "fault-injection")]
+#[test]
+// Host-integration coverage: the generic crate tests cannot prove that a
+// Worker mounts the HTTP router and evaluates a real RPC point in one process.
+fn test_worker_fault_http_control_plane_e2e() -> CommonResult<()> {
+    let _serial = worker_fault_test_serial();
+    let conf = start_worker_with_faults();
+    let token = std::env::var("CURVINE_WORKER_TEST_FAULT_TOKEN")
+        .expect("start_worker_with_faults sets the fault token env");
+    let base = format!("http://{}:{}", conf.worker.hostname, conf.worker.web_port);
+    let open_req_id = Utils::req_id();
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    let session = rt.block_on(async {
+        let controller = Arc::new(
+            FaultHttpController::new(&base, &token)
+                .map_err(|e| orpc::CommonError::from(e.to_string()))?,
+        );
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(15);
+        loop {
+            match controller.status().await {
+                Ok(status) => {
+                    assert!(status
+                        .points
+                        .iter()
+                        .any(|point| point.name == "worker.rpc.before_dispatch"));
+                    break;
+                }
+                Err(error) if std::time::Instant::now() < deadline => {
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                    let _ = error;
+                }
+                Err(error) => {
+                    return Err(orpc::CommonError::from(format!(
+                        "worker fault HTTP never became ready at {base}: {error}"
+                    )));
+                }
+            }
+        }
+
+        let mut session = FaultTestSession::new();
+        session.add_target("worker", controller);
+        session
+            .preflight()
+            .await
+            .map_err(|e| orpc::CommonError::from(e.to_string()))?;
+        let rule = FaultRuleBuilder::named("worker.rpc.before_dispatch")
+            .matches("req_id", open_req_id)
+            .and_then(|builder| builder.matches("rpc_code", RpcCode::WriteBlock as i32))
+            .and_then(|builder| builder.matches("request_status", i8::from(RequestStatus::Open)))
+            .and_then(|builder| builder.times(1))
+            .and_then(|builder| builder.return_error("worker HTTP control-plane failure"))
+            .map_err(|e| orpc::CommonError::from(e.to_string()))?;
+        session
+            .configure("worker", "http-fail-write-open", rule)
+            .await
+            .map_err(|e| orpc::CommonError::from(e.to_string()))?;
+
+        Ok::<FaultTestSession, orpc::CommonError>(session)
+    })?;
+
+    let block_size = (CHUNK_SIZE * LOOP_NUM) as i64;
+    let request = BlockWriteRequest {
+        block: ProtoUtils::extend_block_to_pb(ExtendedBlock::new(
+            Utils::req_id().abs(),
+            block_size,
+            StorageType::Disk,
+            FileType::File,
+        )),
+        off: 0,
+        block_size,
+        short_circuit: false,
+        client_name: "fault-http-test".to_string(),
+        chunk_size: CHUNK_SIZE,
+        pipeline_stream: Vec::new(),
+    };
+    let open = Builder::new()
+        .code(RpcCode::WriteBlock)
+        .request(RequestStatus::Open)
+        .req_id(open_req_id)
+        .seq_id(0)
+        .proto_header(request)
+        .build();
+    assert!(conf.worker_sync_client()?.rpc_check(open).is_err());
+
+    rt.block_on(async {
+        let rule = session
+            .wait_for_executions("worker", "http-fail-write-open", 1, Duration::from_secs(5))
+            .await
+            .map_err(|e| orpc::CommonError::from(e.to_string()))?;
+        assert_eq!(rule.executions, 1);
+        assert_eq!(
+            rule.last_context.as_ref().unwrap().get("rpc_code"),
+            Some(&FaultValue::I64(RpcCode::WriteBlock as i64))
+        );
+        assert_eq!(
+            rule.last_context.as_ref().unwrap().get("request_status"),
+            Some(&FaultValue::I64(RequestStatus::Open as i8 as i64))
+        );
+        session
+            .cleanup()
+            .await
+            .map_err(|e| orpc::CommonError::from(e.to_string()))?;
+        Ok::<(), orpc::CommonError>(())
+    })?;
+
+    let healthy_block = Utils::req_id().abs();
+    let write_ck = block_write(healthy_block, &conf)?;
+    let read_ck = block_read(healthy_block, &conf)?;
+    assert_eq!(write_ck, read_ck);
     Ok(())
 }
 

--- a/etc/curvine-cluster.toml
+++ b/etc/curvine-cluster.toml
@@ -5,6 +5,17 @@
 format_master = false
 format_worker = false
 
+# Test-only remote fault control. Exposing the HTTP API requires BOTH:
+#   1) enabled = true below, and
+#   2) binaries built with `--features fault-injection`
+#      (e.g. curvine-server/fault-injection).
+# Enabling this without rebuilding fails server startup instead of silently
+# omitting the requested route.
+# Keep disabled in normal runs.
+[fault_injection]
+enabled = false
+auth_token_env = "CURVINE_FAULT_TOKEN"
+
 
 # master configuration
 [master]


### PR DESCRIPTION
# Summary

Add a reusable, feature-gated distributed fault-injection framework for local tests and real multi-process Curvine clusters.

The framework provides call-site point registration, structured rules, deterministic triggers, queryable execution evidence, a crate-owned process Runtime, in-process control, and an authenticated HTTP control plane. Business objects do not carry or initialize fault-runtime fields.

# Issue Describe / Design

Related to #940 and design issue #1064.

Key design decisions:

- `fault_point!` declares, link-registers, and evaluates a point at its real business location.
- Matcher keys are derived from the point context and use exact AND semantics.
- `Record`, `ReturnError`, `Delay`, and `Crash` use a structured protocol rather than a third-party string DSL.
- `ReturnError` is converted into the surrounding function's natural return type by a call-site closure.
- One lazy process Runtime contains every linked point and is used automatically by the default macro form.
- Isolated Runtimes remain available for unit tests that require independent rule tables.
- Configuration success proves only that a point contract exists in the target binary. Tests must inspect execution evidence to prove reachability and execution.
- Master and Worker expose the process Runtime through `FaultHttpControl::mount` on their existing Axum Web services.
- The Cargo feature controls whether point instrumentation exists. `[fault_injection].enabled` controls only HTTP exposure.
- Tests follow Preflight → Configure → Workload → Observe → Cleanup.

Minimal remote rule:

```json
{
  "point": "worker.rpc.before_dispatch",
  "action": {
    "type": "return_error",
    "error": {
      "message": "injected Worker RPC failure"
    }
  }
}
```

Optional `matcher` and `trigger` fields default to match-all and unlimited immediate execution.

This PR intentionally does not implement batch-commit semantics, partial-write/corrupt-read executors, external network or disk providers, TTL/owner/generation cleanup, or the planned `cv fault` CLI.

Design:

- [Design Issue #1064](https://github.com/CurvineIO/curvine/issues/1064)
- [English design](https://github.com/CurvineIO/curvine/issues/1064#issuecomment-4955376823)
- [Chinese design](https://github.com/CurvineIO/curvine/issues/1064#issuecomment-4955384992)

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-fault` | Add point registration, rule/model validation, lazy process and isolated Runtimes, evidence, builders, local/HTTP controllers, sessions, HTTP configuration and router mounting | No active injection when the feature is disabled |
| `curvine-common` | Embed the generic `FaultHttpConfig` in `ClusterConf` | HTTP control disabled by default |
| `curvine-server` | Mount `FaultHttpControl` and add Master sync, Master async, and Worker RPC dispatch points | Feature-gated |
| Documentation/examples | Document in-process and distributed usage and the test lifecycle | None |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-fault` | PASS | Feature-off macro and HTTP-control contracts |
| `cargo test -p curvine-fault --all-features` | PASS | 24 unit tests plus catalog-conflict and process-runtime integration tests |
| Master dispatch integration test | PASS | Real sync and async production dispatch paths |
| Worker HTTP control-plane E2E | PASS | HTTP configure → real RPC fault → evidence → cleanup → recovery |
| `cargo test -p curvine-common conf::tests::cluster` | PASS | Cluster configuration deserialization |
| Server feature-on and feature-off checks | PASS | Both build modes |
| Fault/Common/Client/Server clippy | PASS | All targets with `-D warnings` |
| `make format` / `cargo fmt --all -- --check` / `git diff --check` | PASS | Clean formatting and diff |

# Dependencies

- Related PRs: None
- Related issues: #940, #1064
- Blocks / blocked by: None
