### PR TITLE
docs: add cluster shutdown instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,17 @@ Curvine uses TOML - formatted configuration files. An example configuration is l
 - Cluster configuration (number of nodes, replication factor)
 - Performance tuning parameters
 
+Stop the cluster:
+
+```bash
+# Stop the FUSE mount
+bin/curvine-fuse.sh stop
+
+# Stop the worker and master nodes
+bin/curvine-worker.sh stop
+bin/curvine-master.sh stop
+```
+
 ## 🏗️ Architecture Design
 
 Curvine adopts a master-slave architecture:

--- a/README_zh.md
+++ b/README_zh.md
@@ -199,8 +199,8 @@ bin/cv report
 
 执行文件系统命令：
 ```bash
-bin/dfs fs mkdir /a
-bin/dfs fs ls /
+bin/dfs fs -mkdir /a
+bin/dfs fs -ls /
 ```
 
 访问 Web 界面：
@@ -215,6 +215,17 @@ Curvine 使用 TOML 格式的配置文件。示例配置位于 conf/curvine-clus
 - 存储策略（缓存大小、存储类型）
 - 集群配置（节点数量、副本因子）
 - 性能调优参数
+
+停止:
+
+```bash
+# Stop the FUSE mount
+bin/curvine-fuse.sh stop
+
+# Stop the worker and master nodes
+bin/curvine-worker.sh stop
+bin/curvine-master.sh stop
+```
 
 ## 🏗️ 架构设计
 


### PR DESCRIPTION
Document the cluster shutdown sequence in both top-level READMEs and correct the Chinese compatible HDFS command syntax. Closes #1058 

<img width="993" height="241" alt="image" src="https://github.com/user-attachments/assets/0ee91442-3fa3-4e64-8692-579ef05b2bfd" />
