### PR TITLE
fix(build): improve launcher compatibility and shutdown handling (#1060)

### DIFF
--- a/build/bin/dfs
+++ b/build/bin/dfs
@@ -24,7 +24,19 @@ export CLASSPATH=$(echo $CURVINE_HOME/lib/curvine-hadoop-*shade.jar | tr ' ' ':'
 # Choose whether to use a Java client or a Rust client according to the command
 if [ "$1" = "fs" ] || [ "$1" = "report" ]; then
     # Use Java client to process file system commands
-    java -Xms256m -Xmx256m \
+    # Java 8 reports versions as 1.8.x, while Java 9+ reports the major version first.
+    JAVA_MAJOR_VERSION=$(java -version 2>&1 | awk -F '"' '/version/ {
+        split($2, version, /[._-]/)
+        print version[1] == 1 ? version[2] : version[1]
+        exit
+    }')
+    JAVA_OPTS=()
+    # --add-opens was introduced in Java 9 and is required for Curvine's NIO access.
+    if [[ "$JAVA_MAJOR_VERSION" =~ ^[0-9]+$ ]] && (( JAVA_MAJOR_VERSION >= 9 )); then
+        JAVA_OPTS+=(--add-opens=java.base/java.nio=ALL-UNNAMED)
+    fi
+
+    java "${JAVA_OPTS[@]}" -Xms256m -Xmx256m \
     -Dcurvine.conf.dir=${CURVINE_HOME}/conf \
     io.curvine.CurvineShell "$@"
 else

--- a/build/bin/launch-process.sh
+++ b/build/bin/launch-process.sh
@@ -58,7 +58,7 @@ start() {
       --service ${SERVICE_NAME} \
       --conf ${CURVINE_CONF_FILE} \
       > ${OUT_FILE} 2>&1 < /dev/null  &
-     elif [[ "$SERVICE_NAME" = "fuse" ]]; then
+    elif [[ "$SERVICE_NAME" = "fuse" ]]; then
        name="curvine-fuse"
        nohup ${CURVINE_HOME}/lib/curvine-fuse \
        $PARAMS \
@@ -103,7 +103,7 @@ stop() {
     if kill -0 $PID > /dev/null 2>&1; then
       echo "stopping ${SERVICE_NAME}"
 
-      kill ${PID} && rm -f "PID_FILE"
+      kill ${PID}
       waitPid $PID;
 
       if kill -0 $PID > /dev/null 2>&1; then
@@ -112,6 +112,10 @@ stop() {
       else
         echo "${SERVICE_NAME} stop gracefully"
       fi
+      rm -f "${PID_FILE}"
+    elif [ -d "/proc/${PID}" ]; then
+      echo "process pid=${PID} cannot be signalled; it may belong to another user. Please check permissions"
+      exit 1
     else
       echo "no ${SERVICE_NAME} to stop"
     fi
@@ -222,4 +226,3 @@ esac
 }
 
 run ${ACTION}
-


### PR DESCRIPTION
# Summary

Improves the DFS and process launcher scripts for Java 9+ compatibility and safer shutdown handling.

# Issue Describe / Design

Closes #1060

Root cause:
- `bin/dfs` starts the Java DFS client without opening the required `java.nio` module on Java 9+.
- `bin/launch-process.sh` removes a literal `PID_FILE` path and cannot distinguish a missing process from one owned by another user.

Reproduction steps:
1. Run `bin/dfs fs -ls /` with Java 9 or later.
2. Stop a service and check whether its configured PID file is removed.
3. Attempt to stop a service owned by another user.

Fix approach:
- Detect the Java major version and add `--add-opens=java.base/java.nio=ALL-UNNAMED` only on Java 9+.
- Remove the configured PID file and report permission-related shutdown failures accurately.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `build/bin/dfs` | Detect Java version and add the required module opening on Java 9+. | Enables compatible Java DFS execution; Java 8 behavior remains unchanged. |
| `build/bin/launch-process.sh` | Correct PID cleanup and distinguish processes owned by another user. | Improves shutdown diagnostics and removes stale PID files. |

# Test verified

| Test case | Result | Notes | screenshot |
| --------- | ------ | ----- |  ----- |
| `bin/dfs fs -rmdir /mydir` | PASS | Syntax validation passed with Java 9 or later. | <img width="994" height="226" alt="image" src="https://github.com/user-attachments/assets/9e174c58-e1ff-479f-ae53-379eb998a965" /> |
| `bin/curvine-fuse.sh stop` | PASS | Better hint information. | <img width="679" height="48" alt="image" src="https://github.com/user-attachments/assets/9ed589ed-69bc-4cc5-90aa-609e2d34bc8b" /> |

All pid files were deleted after shutdown.
<img width="643" height="607" alt="image" src="https://github.com/user-attachments/assets/ab194122-b5cb-4321-8fc0-be90f62c365b" />

# Dependencies

- Related PRs: None
- Related issues: #1060
- Blocks / blocked by: None