### PR TITLE
fix(fuse): gate BDI log imports on Linux

### DIFF
--- a/curvine-fuse/src/session/bdi.rs
+++ b/curvine-fuse/src/session/bdi.rs
@@ -25,6 +25,7 @@
 
 use std::path::Path;
 
+#[cfg(target_os = "linux")]
 use log::{info, warn};
 
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
# Summary

Fix macOS clippy failures caused by unconditional imports used only by the Linux-specific FUSE BDI implementation.

# Issue Describe / Design

The BDI implementation and all usages of `info!` and `warn!` are guarded by `#[cfg(target_os = "linux")]`, but the corresponding `log::{info, warn}` import was unconditional.

On macOS, the Linux-only implementation is removed during conditional compilation, leaving both imports unused. The project runs clippy with `--deny warnings`, so the unused-import warning becomes a build failure.

Apply the same `#[cfg(target_os = "linux")]` guard to the log import. This keeps Linux behavior unchanged while preventing the unused import from being compiled on macOS.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-fuse/src/session/bdi.rs` | Guard BDI log imports with `target_os = "linux"` | None; compile-time cleanup for non-Linux platforms |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `make format` | PASS | Workspace format and release clippy completed |
| `cargo clippy -p curvine-fuse --all-targets -- --deny warnings --allow clippy::uninlined-format-args` | PASS | Verified on Darwin/macOS |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None