### PR TITLE
feat(cli): add explicit UFS load and export jobs

### DIFF
--- a/curvine-cli/src/cmds/export.rs
+++ b/curvine-cli/src/cmds/export.rs
@@ -1,0 +1,62 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::cmds::LoadStatusCommand;
+use crate::util::*;
+use clap::Parser;
+use curvine_client::rpc::JobMasterClient;
+use curvine_common::state::LoadJobCommand;
+use orpc::CommonResult;
+
+#[derive(Parser, Debug)]
+pub struct ExportCommand {
+    /// Curvine source path to export to the mounted UFS
+    path: String,
+
+    /// Watch export job status after submission
+    #[arg(long, short = 'w')]
+    watch: bool,
+}
+
+impl ExportCommand {
+    pub async fn execute(&self, client: JobMasterClient) -> CommonResult<()> {
+        if self.path.trim().is_empty() {
+            eprintln!("Error: Path cannot be empty");
+            std::process::exit(1);
+        }
+
+        println!("\nExporting Curvine file to mounted UFS");
+        println!("Source path: {}", self.path);
+
+        let command = LoadJobCommand::builder(&self.path).build();
+        let rep = handle_rpc_result(client.submit_export_job(command)).await;
+
+        println!("\nExport job submitted successfully");
+        println!("Job ID: {}", rep.job_id);
+        println!("Target path: {}", rep.target_path);
+        println!(
+            "\nTo check job status, run: curvine load-status {}",
+            rep.job_id
+        );
+
+        if self.watch {
+            let status_command =
+                LoadStatusCommand::new(rep.job_id.clone(), false, "1s".to_string());
+
+            status_command.execute(client).await?;
+        }
+
+        Ok(())
+    }
+}

--- a/curvine-cli/src/cmds/load.rs
+++ b/curvine-cli/src/cmds/load.rs
@@ -21,7 +21,11 @@ use orpc::CommonResult;
 
 #[derive(Parser, Debug)]
 pub struct LoadCommand {
-    path: String,
+    /// UFS source path to load into Curvine, or a UFS-backed Curvine path
+    source_path: String,
+
+    /// Optional Curvine target path for explicit UFS-to-Curvine load
+    target_path: Option<String>,
 
     /// Watch load job status after submission
     #[arg(long, short = 'w')]
@@ -30,15 +34,31 @@ pub struct LoadCommand {
 
 impl LoadCommand {
     pub async fn execute(&self, client: JobMasterClient) -> CommonResult<()> {
-        if self.path.trim().is_empty() {
+        if self.source_path.trim().is_empty() {
             eprintln!("Error: Path cannot be empty");
+            std::process::exit(1);
+        }
+        if self
+            .target_path
+            .as_ref()
+            .is_some_and(|target_path| target_path.trim().is_empty())
+        {
+            eprintln!("Error: Target path cannot be empty");
             std::process::exit(1);
         }
 
         println!("\n Loading file to Curvine");
-        println!("Source path: {}", self.path);
+        println!("Source path: {}", self.source_path);
+        if let Some(target_path) = &self.target_path {
+            println!("Target path: {}", target_path);
+        }
 
-        let command = LoadJobCommand::builder(&self.path).build();
+        let command_builder = LoadJobCommand::builder(&self.source_path);
+        let command = if let Some(target_path) = &self.target_path {
+            command_builder.target_path(target_path).build()
+        } else {
+            command_builder.build()
+        };
         let rep = handle_rpc_result(client.submit_load_job(command)).await;
         println!("{}", rep);
 
@@ -50,5 +70,21 @@ impl LoadCommand {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_explicit_cv_target_path() {
+        let cmd =
+            LoadCommand::try_parse_from(["load", "s3://flink/user", "/flink/user", "--watch"])
+                .expect("load command should accept an optional CV target path");
+
+        assert_eq!(cmd.source_path, "s3://flink/user");
+        assert_eq!(cmd.target_path.as_deref(), Some("/flink/user"));
+        assert!(cmd.watch);
     }
 }

--- a/curvine-cli/src/cmds/mod.rs
+++ b/curvine-cli/src/cmds/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod bench;
+mod export;
 mod fs;
 mod load;
 mod load_cancel;
@@ -23,6 +24,7 @@ mod report;
 mod umount;
 
 pub use bench::BenchCommand;
+pub use export::ExportCommand;
 pub use fs::FsCommand;
 pub use load::LoadCommand;
 pub use load_cancel::CancelLoadCommand;

--- a/curvine-cli/src/commands.rs
+++ b/curvine-cli/src/commands.rs
@@ -31,6 +31,10 @@ pub enum Commands {
     #[command(name = "load")]
     Load(LoadCommand),
 
+    /// Exporting Curvine files to mounted UFS
+    #[command(name = "export")]
+    Export(ExportCommand),
+
     /// Query loading task status
     #[command(name = "load-status")]
     LoadStatus(LoadStatusCommand),

--- a/curvine-cli/src/main.rs
+++ b/curvine-cli/src/main.rs
@@ -180,6 +180,7 @@ fn main() -> CommonResult<()> {
             Commands::Fs(cmd) => cmd.execute(curvine_fs).await,
             Commands::Report(cmd) => cmd.execute(curvine_fs).await,
             Commands::Load(cmd) => cmd.execute(load_client).await,
+            Commands::Export(cmd) => cmd.execute(load_client).await,
             Commands::LoadStatus(cmd) => cmd.execute(load_client).await,
             Commands::CancelLoad(cmd) => cmd.execute(load_client).await,
             Commands::Mount(cmd) => cmd.execute(curvine_fs).await,
@@ -197,4 +198,17 @@ fn main() -> CommonResult<()> {
 
         result
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn export_subcommand_is_available() {
+        let args = CurvineArgs::try_parse_from(["curvine", "export", "/mnt/file", "--watch"])
+            .expect("export command should parse");
+
+        assert!(matches!(args.command, Commands::Export(_)));
+    }
 }

--- a/curvine-client/src/rpc/job_master_client.rs
+++ b/curvine-client/src/rpc/job_master_client.rs
@@ -55,8 +55,21 @@ impl JobMasterClient {
 
     // Submit loading task
     pub async fn submit_load_job(&self, command: LoadJobCommand) -> FsResult<LoadJobResult> {
+        self.submit_job(JobTaskType::Load, command).await
+    }
+
+    // Submit export task
+    pub async fn submit_export_job(&self, command: LoadJobCommand) -> FsResult<LoadJobResult> {
+        self.submit_job(JobTaskType::Export, command).await
+    }
+
+    async fn submit_job(
+        &self,
+        job_type: JobTaskType,
+        command: LoadJobCommand,
+    ) -> FsResult<LoadJobResult> {
         let req = SubmitJobRequest {
-            job_type: JobTaskType::Load.into(),
+            job_type: job_type.into(),
             job_command: SerdeUtils::serialize(&command)?,
         };
 

--- a/curvine-common/proto/job.proto
+++ b/curvine-common/proto/job.proto
@@ -19,6 +19,7 @@ enum JobTaskStateProto {
 
 enum JobTaskTypeProto {
   LOAD = 1;
+  EXPORT = 2;
 }
 
 message JobTaskProgressProto {

--- a/curvine-common/src/state/job.rs
+++ b/curvine-common/src/state/job.rs
@@ -106,6 +106,7 @@ impl LoadJobResult {
 pub enum JobTaskType {
     #[num_enum(default)]
     Load = 1,
+    Export = 2,
 }
 
 #[derive(Default)]

--- a/curvine-server/src/master/job/job_handler.rs
+++ b/curvine-server/src/master/job/job_handler.rs
@@ -17,7 +17,7 @@ use curvine_common::proto::{
     CancelJobRequest, CancelJobResponse, GetJobStatusRequest, GetJobStatusResponse,
     SubmitJobRequest, SubmitJobResponse, TaskReportRequest, TaskReportResponse,
 };
-use curvine_common::state::LoadJobCommand;
+use curvine_common::state::{JobTaskType, LoadJobCommand};
 use curvine_common::utils::{ProtoUtils, SerdeUtils};
 use curvine_common::FsResult;
 use orpc::err_box;
@@ -37,11 +37,11 @@ impl JobHandler {
         Self { job_manager }
     }
 
-    /// Submit loading task
+    /// Submit a load or export job.
     ///
-    /// Handles the submission of a new load job by parsing the request,
-    /// validating parameters, and forwarding to the load manager.
-    pub async fn submit_load_job(
+    /// Handles the submission of a new job by parsing the request,
+    /// validating parameters, and forwarding to the job manager.
+    pub async fn submit_job(
         &self,
         ctx: &mut RpcContext<'_>,
         buf: &mut FrameBuf,
@@ -54,7 +54,13 @@ impl JobHandler {
             return err_box!("Path cannot be empty");
         }
 
-        let res = self.job_manager.submit_load_job(command).await?;
+        let res = match req.job_type {
+            v if v == JobTaskType::Load as i32 => self.job_manager.submit_load_job(command).await?,
+            v if v == JobTaskType::Export as i32 => {
+                self.job_manager.submit_export_job(command).await?
+            }
+            v => return err_box!("Unsupported job type: {}", v),
+        };
         let response = SubmitJobResponse {
             job_id: res.job_id,
             target_path: res.target_path,

--- a/curvine-server/src/master/job/job_manager.rs
+++ b/curvine-server/src/master/job/job_manager.rs
@@ -171,8 +171,8 @@ impl JobManager {
         let source_path = Path::from_str(&command.source_path)?;
 
         // Check mount info for both UFS and CV paths. Public load jobs import
-        // from UFS into Curvine; CV paths are accepted only when existing
-        // metadata marks them as UFS-only.
+        // from UFS into Curvine; CV file paths must already be UFS-backed so
+        // load cannot be used as an accidental CV-to-UFS export path.
         let mnt = if let Some(mnt) = self.mount_manager.get_mount_info(&source_path)? {
             mnt
         } else {
@@ -212,6 +212,18 @@ impl JobManager {
         }
 
         Ok(res)
+    }
+
+    pub async fn submit_export_job(&self, command: LoadJobCommand) -> FsResult<LoadJobResult> {
+        let source_path = Path::from_str(&command.source_path)?;
+
+        let mnt = if let Some(mnt) = self.mount_manager.get_mount_info(&source_path)? {
+            mnt
+        } else {
+            return err_box!("Not found mount info for path: {}", source_path);
+        };
+
+        self.create_runner().submit_export_task(command, mnt).await
     }
 
     /// Handle cancellation of tasks

--- a/curvine-server/src/master/job/job_runner.rs
+++ b/curvine-server/src/master/job/job_runner.rs
@@ -97,32 +97,74 @@ impl LoadJobRunner {
         cv_source_mode: CvSourceMode,
     ) -> FsResult<(JobContext, Path, Path)> {
         let command_source = Path::from_str(&command.source_path)?;
-        let (source_path, target_path) = match (cv_source_mode, command_source.is_cv()) {
-            (CvSourceMode::LoadUfsOnlyFromUfs, false) => {
-                let target_path = mnt.get_cv_path(&command_source)?;
-                (command_source, target_path)
-            }
-            (CvSourceMode::LoadUfsOnlyFromUfs, true) => {
-                let status = self.master_fs.file_status(command_source.path())?;
-                if !status.storage_policy.ufs_only() {
+        let command_target = match command.target_path.as_ref() {
+            Some(target_path) => Some(Path::from_str(target_path)?),
+            None => None,
+        };
+
+        let (source_path, target_path) =
+            match (cv_source_mode, command_source.is_cv(), command_target) {
+                (CvSourceMode::LoadUfsOnlyFromUfs, false, Some(target_path)) => {
+                    if !target_path.is_cv() {
+                        return err_box!(
+                            "load job target path {} must be a CV path",
+                            target_path.full_path()
+                        );
+                    }
+
+                    let mounted_target = mnt.get_cv_path(&command_source)?;
+                    if mounted_target != target_path {
+                        let requested = target_path.full_path();
+                        let mounted = mounted_target.full_path();
+                        let source = command_source.full_path();
+                        return err_box!(
+                        "load job target path {} does not match mounted CV path {} for source {}",
+                        requested,
+                        mounted,
+                        source
+                    );
+                    }
+
+                    (command_source, target_path)
+                }
+                (CvSourceMode::LoadUfsOnlyFromUfs, false, None) => {
+                    let target_path = mnt.get_cv_path(&command_source)?;
+                    (command_source, target_path)
+                }
+                (CvSourceMode::LoadUfsOnlyFromUfs, true, Some(_)) => {
+                    let source = command_source.full_path();
                     return err_box!(
-                        "load job for CV path {} requires UFS-only metadata",
+                    "load job with explicit target requires a UFS source path, got CV source {}",
+                    source
+                );
+                }
+                (CvSourceMode::LoadUfsOnlyFromUfs, true, None) => {
+                    let status = self.master_fs.file_status(command_source.path())?;
+                    if !status.is_dir && !status.storage_policy.ufs_exists() {
+                        return err_box!(
+                            "load job for CV path {} requires UFS-backed metadata",
+                            command_source.full_path()
+                        );
+                    }
+                    (mnt.get_ufs_path(&command_source)?, command_source)
+                }
+                (CvSourceMode::ExportCurvineToUfs, true, Some(_)) => {
+                    return err_box!(
+                        "export job source path {} does not accept an explicit target path",
                         command_source.full_path()
                     );
                 }
-                (mnt.get_ufs_path(&command_source)?, command_source)
-            }
-            (CvSourceMode::ExportCurvineToUfs, true) => {
-                let target_path = mnt.get_ufs_path(&command_source)?;
-                (command_source, target_path)
-            }
-            (CvSourceMode::ExportCurvineToUfs, false) => {
-                return err_box!(
-                    "export job source path {} must be a CV path",
-                    command_source.full_path()
-                );
-            }
-        };
+                (CvSourceMode::ExportCurvineToUfs, true, None) => {
+                    let target_path = mnt.get_ufs_path(&command_source)?;
+                    (command_source, target_path)
+                }
+                (CvSourceMode::ExportCurvineToUfs, false, _) => {
+                    return err_box!(
+                        "export job source path {} must be a CV path",
+                        command_source.full_path()
+                    );
+                }
+            };
         let job_id = CommonUtils::create_job_id(source_path.full_path());
         let run_id = self.next_run_id();
         let job_context = JobContext::with_conf(

--- a/curvine-server/src/master/master_handler.rs
+++ b/curvine-server/src/master/master_handler.rs
@@ -943,7 +943,7 @@ impl MessageHandler for MasterHandler {
             Err(FsError::not_leader_master(ctx.code, self.client_ip()))
         } else {
             match code {
-                RpcCode::SubmitJob => self.job_handler.submit_load_job(ctx, &mut self.buf).await,
+                RpcCode::SubmitJob => self.job_handler.submit_job(ctx, &mut self.buf).await,
                 RpcCode::GetJobStatus => self.job_handler.get_load_status(ctx, &mut self.buf),
                 RpcCode::CancelJob => self.job_handler.cancel_job(ctx, &mut self.buf).await,
                 RpcCode::ReportTask => self.job_handler.task_report(ctx, &mut self.buf),

--- a/curvine-server/tests/load_job_submit_test.rs
+++ b/curvine-server/tests/load_job_submit_test.rs
@@ -15,7 +15,7 @@
 use curvine_common::conf::{ClientConf, ClusterConf, JournalConf, MasterConf};
 use curvine_common::state::{
     JobTaskProgress, JobTaskState, LoadJobCommand, LoadJobInfo, LoadTaskInfo, MountInfo,
-    MountOptions, OpenFlags, StorageType, TtlAction, WorkerAddress, WorkerInfo,
+    MountOptions, OpenFlags, StorageType, TtlAction, WorkerAddress, WorkerInfo, WriteType,
 };
 use curvine_common::utils::CommonUtils;
 use curvine_server::master::fs::MasterFilesystem;
@@ -35,6 +35,20 @@ fn new_job_manager(name: &str) -> CommonResult<(Arc<JobManager>, Arc<Runtime>, S
 
 fn new_job_manager_with_fs(
     name: &str,
+) -> CommonResult<(Arc<JobManager>, Arc<Runtime>, String, MasterFilesystem)> {
+    new_job_manager_with_mount_options(name, MountOptions::builder().build())
+}
+
+fn new_job_manager_with_write_type(
+    name: &str,
+    write_type: WriteType,
+) -> CommonResult<(Arc<JobManager>, Arc<Runtime>, String, MasterFilesystem)> {
+    new_job_manager_with_mount_options(name, MountOptions::builder().write_type(write_type).build())
+}
+
+fn new_job_manager_with_mount_options(
+    name: &str,
+    mount_options: MountOptions,
 ) -> CommonResult<(Arc<JobManager>, Arc<Runtime>, String, MasterFilesystem)> {
     Master::init_test_metrics();
     let test_name = format!("{}-{}", name, Utils::rand_id());
@@ -70,7 +84,7 @@ fn new_job_manager_with_fs(
 
     let ufs_root_dir = Utils::test_sub_dir(format!("load-job-submit/ufs-{}", test_name));
     let ufs_root = format!("file://{}", ufs_root_dir);
-    mount_manager.mount(None, "/mnt", &ufs_root, &MountOptions::builder().build())?;
+    mount_manager.mount(None, "/mnt", &ufs_root, &mount_options)?;
 
     Ok((
         job_manager,
@@ -103,6 +117,13 @@ fn load_task(task_id: &str, job_id: &str) -> LoadTaskInfo {
         target_path: "/mnt/source".to_string(),
         create_time: 0,
     }
+}
+
+fn ufs_root_from_missing_source(missing_source: &str) -> String {
+    missing_source
+        .strip_suffix("/missing-file")
+        .expect("test helper returns a missing file below the UFS root")
+        .to_string()
 }
 
 #[test]
@@ -145,7 +166,7 @@ fn submit_load_job_returns_before_ufs_planning() -> CommonResult<()> {
 #[test]
 fn fs_mode_cv_path_load_uses_ufs_source_when_metadata_is_ufs_only() -> CommonResult<()> {
     let (job_manager, rt, missing_source, master_fs) =
-        new_job_manager_with_fs("fs-cv-load-ufs-only")?;
+        new_job_manager_with_write_type("fs-cv-load-ufs-only", WriteType::FsMode)?;
     let source = missing_source.replace("/missing-file", "/ufs-only-file");
     let local_source = source
         .strip_prefix("file://")
@@ -180,9 +201,162 @@ fn fs_mode_cv_path_load_uses_ufs_source_when_metadata_is_ufs_only() -> CommonRes
 }
 
 #[test]
-fn cv_path_load_without_ufs_only_metadata_is_rejected() -> CommonResult<()> {
+fn cache_mode_mount_root_directory_load_uses_ufs_source() -> CommonResult<()> {
+    let (job_manager, rt, missing_source, _master_fs) =
+        new_job_manager_with_write_type("cache-root-dir-load", WriteType::CacheMode)?;
+    let source = ufs_root_from_missing_source(&missing_source);
+    let local_source = source
+        .strip_prefix("file://")
+        .expect("test UFS path uses file scheme");
+    std::fs::create_dir_all(local_source)?;
+    std::fs::write(
+        std::path::Path::new(local_source).join("file.txt"),
+        b"load-data",
+    )?;
+
+    let cv_path = "/mnt";
+    let (expected_source, _) = job_manager
+        .get_mnt(&curvine_common::fs::Path::from_str(cv_path)?)?
+        .expect("test CV path should match mount");
+    let expected_source = expected_source.clone_uri();
+    let expected_job_id = CommonUtils::create_job_id(&expected_source);
+
+    rt.block_on(async {
+        let result = job_manager
+            .submit_load_job(LoadJobCommand::builder(cv_path).build())
+            .await?;
+
+        assert_eq!(result.job_id, expected_job_id);
+        assert_eq!(result.target_path, cv_path);
+
+        let status = job_manager.get_job_status(&result.job_id)?;
+        assert_eq!(status.source_path, expected_source);
+        assert_eq!(status.target_path, cv_path);
+        Ok(())
+    })
+}
+
+#[test]
+fn fs_mode_mount_root_directory_load_uses_ufs_source() -> CommonResult<()> {
+    let (job_manager, rt, missing_source, _master_fs) =
+        new_job_manager_with_write_type("fs-root-dir-load", WriteType::FsMode)?;
+    let source = ufs_root_from_missing_source(&missing_source);
+    let local_source = source
+        .strip_prefix("file://")
+        .expect("test UFS path uses file scheme");
+    std::fs::create_dir_all(local_source)?;
+    std::fs::write(
+        std::path::Path::new(local_source).join("file.txt"),
+        b"load-data",
+    )?;
+
+    let cv_path = "/mnt";
+    let (expected_source, _) = job_manager
+        .get_mnt(&curvine_common::fs::Path::from_str(cv_path)?)?
+        .expect("test CV path should match mount");
+    let expected_source = expected_source.clone_uri();
+    let expected_job_id = CommonUtils::create_job_id(&expected_source);
+
+    rt.block_on(async {
+        let result = job_manager
+            .submit_load_job(LoadJobCommand::builder(cv_path).build())
+            .await?;
+
+        assert_eq!(result.job_id, expected_job_id);
+        assert_eq!(result.target_path, cv_path);
+
+        let status = job_manager.get_job_status(&result.job_id)?;
+        assert_eq!(status.source_path, expected_source);
+        assert_eq!(status.target_path, cv_path);
+        Ok(())
+    })
+}
+
+#[test]
+fn cv_child_directory_load_under_mount_uses_ufs_source_without_ufs_only_metadata(
+) -> CommonResult<()> {
+    let (job_manager, rt, missing_source, master_fs) =
+        new_job_manager_with_write_type("cv-child-dir-load", WriteType::FsMode)?;
+    let source = missing_source.replace("/missing-file", "/dir");
+    let local_source = source
+        .strip_prefix("file://")
+        .expect("test UFS path uses file scheme");
+    std::fs::create_dir_all(local_source)?;
+    std::fs::write(
+        std::path::Path::new(local_source).join("file.txt"),
+        b"load-data",
+    )?;
+
+    let cv_path = "/mnt/dir";
+    master_fs.mkdir(cv_path, true)?;
+    let cv_status = master_fs.file_status(cv_path)?;
+    assert!(cv_status.is_dir);
+    assert!(!cv_status.storage_policy.ufs_only());
+    let expected_job_id = CommonUtils::create_job_id(&source);
+
+    rt.block_on(async {
+        let result = job_manager
+            .submit_load_job(LoadJobCommand::builder(cv_path).build())
+            .await?;
+
+        assert_eq!(result.job_id, expected_job_id);
+        assert_eq!(result.target_path, cv_path);
+
+        let status = job_manager.get_job_status(&result.job_id)?;
+        assert_eq!(status.source_path, source);
+        assert_eq!(status.target_path, cv_path);
+        Ok(())
+    })
+}
+
+#[test]
+fn cv_file_load_with_ufs_backed_cached_metadata_uses_ufs_source() -> CommonResult<()> {
+    let (job_manager, rt, missing_source, master_fs) =
+        new_job_manager_with_fs("fs-cv-load-ufs-backed")?;
+    let source = missing_source.replace("/missing-file", "/ufs-backed-file");
+    let local_source = source
+        .strip_prefix("file://")
+        .expect("test UFS path uses file scheme");
+    if let Some(parent) = std::path::Path::new(local_source).parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(local_source, b"load-data")?;
+
+    let cv_path = "/mnt/ufs-backed-file";
+    let source_path = curvine_common::fs::Path::from_str(&source)?;
+    let (_, mount) = job_manager
+        .get_mnt(&source_path)?
+        .expect("test source should match mount");
+    let sync_opts = mount.info.get_sync_opts(&ClientConf::default(), 1, 9);
+    master_fs.create_with_opts(cv_path, sync_opts, OpenFlags::new_create())?;
+    master_fs.set_attr(
+        cv_path,
+        curvine_common::state::SetAttrOptsBuilder::new()
+            .ufs_mtime(1)
+            .build(),
+    )?;
+    let cv_status = master_fs.file_status(cv_path)?;
+    assert!(cv_status.storage_policy.both_exists());
+    let expected_job_id = CommonUtils::create_job_id(&source);
+
+    rt.block_on(async {
+        let result = job_manager
+            .submit_load_job(LoadJobCommand::builder(cv_path).build())
+            .await?;
+
+        assert_eq!(result.job_id, expected_job_id);
+        assert_eq!(result.target_path, cv_path);
+
+        let status = job_manager.get_job_status(&result.job_id)?;
+        assert_eq!(status.source_path, source);
+        assert_eq!(status.target_path, cv_path);
+        Ok(())
+    })
+}
+
+fn assert_cv_only_file_load_is_rejected(name: &str, write_type: WriteType) -> CommonResult<()> {
     let (job_manager, rt, _missing_source, master_fs) =
-        new_job_manager_with_fs("cv-load-rejects-export")?;
+        new_job_manager_with_write_type(name, write_type)?;
     let cv_path = "/mnt/native-file";
     let create_opts = curvine_common::state::CreateFileOptsBuilder::new()
         .create_parent(true)
@@ -195,7 +369,99 @@ fn cv_path_load_without_ufs_only_metadata_is_rejected() -> CommonResult<()> {
             .await
             .expect_err("ordinary CV load should not fall back to CV-to-UFS export");
         assert!(
-            err.to_string().contains("requires UFS-only metadata"),
+            err.to_string().contains("requires UFS-backed metadata"),
+            "unexpected error: {}",
+            err
+        );
+        Ok(())
+    })
+}
+
+#[test]
+fn cache_mode_cv_path_load_without_ufs_backed_metadata_is_rejected() -> CommonResult<()> {
+    assert_cv_only_file_load_is_rejected("cache-cv-load-rejects-export", WriteType::CacheMode)
+}
+
+#[test]
+fn fs_mode_cv_path_load_without_ufs_backed_metadata_is_rejected() -> CommonResult<()> {
+    assert_cv_only_file_load_is_rejected("fs-cv-load-rejects-export", WriteType::FsMode)
+}
+
+#[test]
+fn ufs_load_with_explicit_cv_target_uses_import_direction() -> CommonResult<()> {
+    let (job_manager, rt, missing_source) = new_job_manager("explicit-load-target")?;
+    let source = missing_source.replace("/missing-file", "/explicit-target-file");
+    let local_source = source
+        .strip_prefix("file://")
+        .expect("test UFS path uses file scheme");
+    if let Some(parent) = std::path::Path::new(local_source).parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(local_source, b"load-data")?;
+
+    let target = "/mnt/explicit-target-file";
+    let expected_job_id = CommonUtils::create_job_id(&source);
+
+    rt.block_on(async {
+        let result = job_manager
+            .submit_load_job(LoadJobCommand::builder(&source).target_path(target).build())
+            .await?;
+
+        assert_eq!(result.job_id, expected_job_id);
+        assert_eq!(result.target_path, target);
+
+        let status = job_manager.get_job_status(&result.job_id)?;
+        assert_eq!(status.source_path, source);
+        assert_eq!(status.target_path, target);
+        Ok(())
+    })
+}
+
+#[test]
+fn ufs_load_with_mismatched_explicit_cv_target_is_rejected() -> CommonResult<()> {
+    let (job_manager, rt, missing_source) = new_job_manager("explicit-load-target-mismatch")?;
+    let source = missing_source.replace("/missing-file", "/source-file");
+
+    rt.block_on(async {
+        let err = job_manager
+            .submit_load_job(
+                LoadJobCommand::builder(source)
+                    .target_path("/mnt/other-file")
+                    .build(),
+            )
+            .await
+            .expect_err("explicit target must match the mount mapping");
+        assert!(
+            err.to_string().contains("does not match mounted CV path"),
+            "unexpected error: {}",
+            err
+        );
+        Ok(())
+    })
+}
+
+#[test]
+fn load_with_explicit_target_rejects_cv_source_to_prevent_export() -> CommonResult<()> {
+    let (job_manager, rt, _missing_source, master_fs) =
+        new_job_manager_with_fs("explicit-load-target-cv-source")?;
+    let cv_path = "/mnt/native-export-file";
+    let create_opts = curvine_common::state::CreateFileOptsBuilder::new()
+        .create_parent(true)
+        .build();
+    master_fs.create_with_opts(cv_path, create_opts, OpenFlags::new_create())?;
+
+    rt.block_on(async {
+        let err = job_manager
+            .submit_load_job(
+                LoadJobCommand::builder(cv_path)
+                    .target_path("file:///tmp/native-export-file")
+                    .build(),
+            )
+            .await
+            .expect_err("load must not use explicit target to export CV data");
+        assert!(
+            err.to_string()
+                .contains("explicit target requires a UFS source path"),
             "unexpected error: {}",
             err
         );
@@ -229,6 +495,48 @@ fn direct_export_task_keeps_cv_source_for_fs_mode_journal_sync() -> CommonResult
         assert_eq!(result.job_id, expected_job_id);
         assert_eq!(result.target_path, expected_target);
         assert_eq!(result.state, JobTaskState::Completed);
+        Ok(())
+    })
+}
+
+#[test]
+fn submit_export_job_keeps_cv_source_for_user_export() -> CommonResult<()> {
+    let (job_manager, rt, _missing_source, master_fs) = new_job_manager_with_fs("public-export")?;
+    let cv_path = "/mnt/public-export-dir";
+    master_fs.mkdir(cv_path, true)?;
+    let expected_target = job_manager
+        .get_mnt(&curvine_common::fs::Path::from_str(cv_path)?)?
+        .expect("test CV path should match mount")
+        .0
+        .clone_uri();
+    let expected_job_id = CommonUtils::create_job_id(cv_path);
+
+    rt.block_on(async {
+        let result = job_manager
+            .submit_export_job(LoadJobCommand::builder(cv_path).build())
+            .await?;
+
+        assert_eq!(result.job_id, expected_job_id);
+        assert_eq!(result.target_path, expected_target);
+        assert_eq!(result.state, JobTaskState::Completed);
+        Ok(())
+    })
+}
+
+#[test]
+fn submit_export_job_rejects_ufs_source_path() -> CommonResult<()> {
+    let (job_manager, rt, missing_source) = new_job_manager("public-export-ufs")?;
+
+    rt.block_on(async {
+        let err = job_manager
+            .submit_export_job(LoadJobCommand::builder(missing_source).build())
+            .await
+            .expect_err("export must not accept a UFS source path");
+        assert!(
+            err.to_string().contains("must be a CV path"),
+            "unexpected error: {}",
+            err
+        );
         Ok(())
     })
 }


### PR DESCRIPTION
# Summary

Add public CLI support for `cv export` and `cv load <ufs-source> <cv-target>`. Fix mounted Curvine-path load so `cv load /mounted/dir` resolves back to the mounted UFS path for both `fs_mode` and `cache_mode`.

The load path still rejects CV-only files. That keeps `load` as UFS-to-Curvine import and prevents it from becoming an accidental CV-to-UFS export path.

# Issue Describe / Design

Related to Fluid CacheRuntime DataLoad validation.

Root cause:
- The public load path treated every CV source path like a file that must have strict `ufs_only` metadata.
- Mount roots and child directories are normal Curvine directories, so `cv load /flink/user` could fail after a valid mount.
- A loaded file becomes UFS-backed `Both`, so requiring strict `ufs_only` also made repeated file loads fail.

Design:
- `cv load <ufs-source>` imports from UFS into the mounted CV target.
- `cv load <ufs-source> <cv-target>` is accepted only when `<cv-target>` matches the mount mapping.
- `cv load <mounted-cv-dir>` resolves the CV directory back to UFS and imports recursively.
- `cv load <mounted-cv-file>` requires UFS-backed metadata (`Ufs` or `Both`).
- CV-only files remain rejected with `requires UFS-backed metadata`.
- CV-to-UFS sync uses the new `Export` job type and `cv export`, not `cv load`.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-cli/src/cmds/export.rs` | Add `cv export <cv-path> [--watch]`. | New user-facing export command. |
| `curvine-cli/src/cmds/load.rs` | Add optional explicit target: `cv load <ufs-source> <cv-target>`. | Existing single-argument load still works. |
| `curvine-common/proto/job.proto`, `curvine-common/src/state/job.rs` | Add `Export` job type and load target field. | Extends job protocol. |
| `curvine-client/src/rpc/job_master_client.rs` | Add command-based load submission and export submission. | Client can submit both load and export jobs. |
| `curvine-server/src/master/job/*` | Dispatch load/export by job type and validate direction. | Mounted CV directories load correctly; CV-only files stay rejected. |
| `curvine-server/tests/load_job_submit_test.rs` | Add matrix coverage for `fs_mode`, `cache_mode`, `Ufs`, `Both`, CV-only rejection, explicit target validation, and export. | Prevents regressions in load/export direction handling. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `make format` | PASS | Runs project pre-commit/check flow. |
| `make all` | PASS | Full local build completed. |
| `cargo fmt --all -- --check` | PASS | Formatting clean. |
| `cargo test -p curvine-server --test load_job_submit_test` | PASS | 19 passed. |
| `cargo test -p curvine-cli` | PASS | 16 passed. |
| `cargo check -p curvine-cli -p curvine-server` | PASS | Related crates compile. |
| Local dist: `fs_mode` mount root then `cv load -w <cv-root>` | PASS | Root resolved to UFS and completed. |
| Local dist: `cache_mode` mount root then `cv load -w <cv-root>` | PASS | CacheRuntime-style load completed. |
| Local dist: repeated `cv load -w <cv-file>` after cache | PASS | Returned `Already loaded`; no UFS-only error. |
| Local dist: CV-only file under fs_mode mount | PASS | Rejected with `requires UFS-backed metadata`. |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None
