### PR TITLE
refactor(conf): unify ClientConf time fields to u64 *_ms

### DIFF
--- a/curvine-client/src/file/fs_context.rs
+++ b/curvine-client/src/file/fs_context.rs
@@ -33,6 +33,7 @@ use orpc::runtime::{RpcRuntime, Runtime};
 use orpc::sys::CacheManager;
 use std::hash::BuildHasherDefault;
 use std::sync::Arc;
+use std::time::Duration;
 
 static CLIENT_METRICS: OnceCell<ClientMetrics> = OnceCell::new();
 
@@ -81,14 +82,14 @@ impl FsContext {
         );
 
         let exclude_workers = CacheBuilder::default()
-            .time_to_live(conf.client.failed_worker_ttl)
+            .time_to_live(Duration::from_millis(conf.client.failed_worker_ttl_ms))
             .eviction_policy(EvictionPolicy::lru())
             .build_with_hasher(BuildHasherDefault::<FxHasher>::default());
 
         let block_pool = Arc::new(BlockClientPool::new(
             conf.client.enable_block_conn_pool,
             conf.client.block_conn_idle_size,
-            conf.client.block_conn_idle_time.as_millis() as u64,
+            conf.client.block_conn_idle_time_ms,
         ));
 
         let context = Self {
@@ -206,7 +207,7 @@ impl FsContext {
 
     pub fn start_clean_task(fs: CurvineFileSystem, pool: Arc<BlockClientPool>) {
         let metric_report_enable = fs.conf().client.metric_report_enable;
-        let interval = fs.conf().client.clean_task_interval;
+        let interval = Duration::from_millis(fs.conf().client.clean_task_interval_ms);
 
         fs.clone_runtime().spawn(async move {
             let mut interval = tokio::time::interval(interval);

--- a/curvine-client/src/rpc/job_master_client.rs
+++ b/curvine-client/src/rpc/job_master_client.rs
@@ -15,6 +15,7 @@
 use curvine_common::error::FsError;
 use log::info;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::time;
 
 use curvine_common::fs::RpcCode;
@@ -128,7 +129,7 @@ impl JobMasterClient {
         job_id: impl AsRef<str>,
         fail_if_not_found: bool,
     ) -> FsResult<()> {
-        let time = self.client.conf().client.max_sync_wait_timeout;
+        let time = Duration::from_millis(self.client.conf().client.max_sync_wait_timeout_ms);
         time::timeout(time, self.wait_job_complete0(job_id, fail_if_not_found)).await?
     }
 
@@ -137,7 +138,7 @@ impl JobMasterClient {
         job_id: impl AsRef<str>,
         fail_if_not_found: bool,
     ) -> FsResult<()> {
-        let mut ticks = 0;
+        let mut ticks: u64 = 0;
         let time = TimeSpent::new();
         let conf = &self.client.conf().client;
         let job_id = job_id.as_ref();
@@ -150,7 +151,8 @@ impl JobMasterClient {
                         if fail_if_not_found {
                             return Err(err);
                         } else {
-                            time::sleep(conf.sync_check_interval_min).await;
+                            time::sleep(Duration::from_millis(conf.sync_check_interval_min_ms))
+                                .await;
                             JobStatus {
                                 job_id: job_id.to_string(),
                                 ..Default::default()
@@ -176,12 +178,12 @@ impl JobMasterClient {
                 _ => {
                     ticks += 1;
 
-                    let sleep_time = conf
-                        .sync_check_interval_max
-                        .min(conf.sync_check_interval_min * ticks);
-                    time::sleep(sleep_time).await;
+                    let sleep_ms = conf
+                        .sync_check_interval_max_ms
+                        .min(conf.sync_check_interval_min_ms * ticks);
+                    time::sleep(Duration::from_millis(sleep_ms)).await;
 
-                    if ticks % conf.sync_check_log_tick == 0 {
+                    if ticks.is_multiple_of(conf.sync_check_log_tick as u64) {
                         info!(
                             "waiting for job {} to complete, elapsed: {} ms, progress: {}",
                             status.job_id,

--- a/curvine-client/src/rpc/job_master_client.rs
+++ b/curvine-client/src/rpc/job_master_client.rs
@@ -180,7 +180,7 @@ impl JobMasterClient {
 
                     let sleep_ms = conf
                         .sync_check_interval_max_ms
-                        .min(conf.sync_check_interval_min_ms * ticks);
+                        .min(conf.sync_check_interval_min_ms.saturating_mul(ticks));
                     time::sleep(Duration::from_millis(sleep_ms)).await;
 
                     if ticks.is_multiple_of(conf.sync_check_log_tick as u64) {

--- a/curvine-client/src/unified/unified_filesystem.rs
+++ b/curvine-client/src/unified/unified_filesystem.rs
@@ -54,7 +54,7 @@ pub struct UnifiedFileSystem {
 
 impl UnifiedFileSystem {
     pub fn with_rt(conf: ClusterConf, rt: Arc<Runtime>) -> FsResult<Self> {
-        let update_interval = conf.client.mount_update_ttl;
+        let update_interval_ms = conf.client.mount_update_ttl_ms;
         let enable_unified = conf.client.enable_unified_fs;
         let enable_read_ufs = conf.client.enable_rust_read_ufs;
         let audit_logging_enabled = conf.client.audit_logging_enabled;
@@ -62,7 +62,7 @@ impl UnifiedFileSystem {
         let cv = CurvineFileSystem::with_rt(conf, rt.clone())?;
         let fs = UnifiedFileSystem {
             cv,
-            mount_cache: Arc::new(MountCache::new(update_interval.as_millis() as u64)),
+            mount_cache: Arc::new(MountCache::new(update_interval_ms)),
             enable_unified,
             enable_read_ufs,
             audit_logging_enabled,

--- a/curvine-client/tests/block_client_pool_test.rs
+++ b/curvine-client/tests/block_client_pool_test.rs
@@ -51,7 +51,7 @@ fn create_test_context() -> FsContext {
     let mut conf = ClusterConf::default();
     conf.client.enable_block_conn_pool = true;
     conf.client.block_conn_idle_size = 10;
-    conf.client.block_conn_idle_time = Duration::from_secs(30);
+    conf.client.block_conn_idle_time_ms = 30_000;
 
     let rt = TEST_SERVER.1.clone();
     FsContext::with_rt(conf, rt).unwrap()

--- a/curvine-common/src/conf/client_conf.rs
+++ b/curvine-common/src/conf/client_conf.rs
@@ -20,7 +20,6 @@ use orpc::common::{ByteUnit, DurationUnit, Utils};
 use orpc::io::net::InetAddr;
 use orpc::CommonResult;
 use serde::{Deserialize, Serialize};
-use std::time::Duration;
 
 #[derive(Debug, Clone, Serialize, Deserialize, ClientCliArgs)]
 #[client_cli(prefix = "client", strip_suffix = "_str", opt_in)]
@@ -170,12 +169,10 @@ pub struct ClientConf {
     #[client_cli]
     pub drop_cache_len_str: String,
 
-    // Worker blacklist survival time
-    #[serde(skip)]
-    pub failed_worker_ttl: Duration,
+    // Worker blacklist survival time, in milliseconds.
     #[serde(alias = "failed_worker_ttl")]
     #[client_cli]
-    pub failed_worker_ttl_str: String,
+    pub failed_worker_ttl_ms: u64,
 
     // Whether to enable the unified file system
     #[client_cli]
@@ -190,12 +187,10 @@ pub struct ClientConf {
     #[client_cli]
     pub audit_logging_enabled: bool,
 
-    // Mount information update interval
-    #[serde(skip)]
-    pub mount_update_ttl: Duration,
+    // Mount information update interval, in milliseconds.
     #[serde(alias = "mount_update_ttl")]
     #[client_cli]
-    pub mount_update_ttl_str: String,
+    pub mount_update_ttl_ms: u64,
 
     // File creation umask in octal notation (e.g. 022 or 0o22).
     #[client_cli(octal)]
@@ -204,11 +199,10 @@ pub struct ClientConf {
     #[client_cli]
     pub metric_report_enable: bool,
 
-    #[serde(skip)]
-    pub clean_task_interval: Duration,
+    // Cleanup task interval, in milliseconds.
     #[serde(alias = "clean_task_interval")]
     #[client_cli]
-    pub clean_task_interval_str: String,
+    pub clean_task_interval_ms: u64,
 
     #[client_cli]
     pub close_timeout_secs: u64,
@@ -216,26 +210,20 @@ pub struct ClientConf {
     #[client_cli(skip)]
     pub metadata_operation_buckets: Vec<f64>,
 
-    // Minimum interval for checking if ufs sync task is complete / checking if curvine file data has updates
-    #[serde(skip)]
-    pub sync_check_interval_min: Duration,
+    // Minimum interval for checking if ufs sync task is complete / checking if curvine file data has updates, in milliseconds
     #[serde(alias = "sync_check_interval_min")]
     #[client_cli]
-    pub sync_check_interval_min_str: String,
+    pub sync_check_interval_min_ms: u64,
 
-    // Maximum interval for checking if ufs sync task is complete / checking if curvine file data has updates
-    #[serde(skip)]
-    pub sync_check_interval_max: Duration,
+    // Maximum interval for checking if ufs sync task is complete / checking if curvine file data has updates, in milliseconds
     #[serde(alias = "sync_check_interval_max")]
     #[client_cli]
-    pub sync_check_interval_max_str: String,
+    pub sync_check_interval_max_ms: u64,
 
-    // Maximum timeout for waiting for sync job to complete
-    #[serde(skip)]
-    pub max_sync_wait_timeout: Duration,
+    // Maximum timeout for waiting for sync job to complete, in milliseconds
     #[serde(alias = "max_sync_wait_timeout")]
     #[client_cli]
-    pub max_sync_wait_timeout_str: String,
+    pub max_sync_wait_timeout_ms: u64,
 
     // Number of sync_check_interval cycles before logging
     #[client_cli]
@@ -246,11 +234,10 @@ pub struct ClientConf {
     #[client_cli]
     pub block_conn_idle_size: usize,
 
-    #[serde(skip)]
-    pub block_conn_idle_time: Duration,
+    // Block connection idle time, in milliseconds.
     #[serde(alias = "block_conn_idle_time")]
     #[client_cli]
-    pub block_conn_idle_time_str: String,
+    pub block_conn_idle_time_ms: u64,
 
     #[serde(skip)]
     pub small_file_size: i64,
@@ -284,7 +271,7 @@ impl ClientConf {
 
     pub const DEFAULT_FILE_SYSTEM_MODE: u32 = 0o777;
 
-    pub const DEFAULT_CLEAN_TASK_INTERVAL_STR: &'static str = "60s";
+    pub const DEFAULT_CLEAN_TASK_INTERVAL_MS: u64 = 60 * 1000;
 
     pub const DEFAULT_CLOSE_TIMEOUT_SECS: u64 = 5;
 
@@ -325,28 +312,11 @@ impl ClientConf {
             self.enable_read_ahead = false
         }
 
-        self.failed_worker_ttl = DurationUnit::from_str(&self.failed_worker_ttl_str)?.as_duration();
-        self.mount_update_ttl = DurationUnit::from_str(&self.mount_update_ttl_str)?.as_duration();
-
         self.small_file_size = ByteUnit::from_str(&self.small_file_size_str)?.as_byte() as i64;
-
-        self.block_conn_idle_time =
-            DurationUnit::from_str(&self.block_conn_idle_time_str)?.as_duration();
 
         self.ttl_ms = DurationUnit::from_str(&self.ttl_ms_str)?.as_millis() as i64;
         self.ttl_action = TtlAction::try_from(self.ttl_action_str.as_str())?;
         self.storage_type = StorageType::try_from(self.storage_type_str.as_str())?;
-
-        self.clean_task_interval =
-            DurationUnit::from_str(&self.clean_task_interval_str)?.as_duration();
-
-        self.sync_check_interval_min =
-            DurationUnit::from_str(&self.sync_check_interval_min_str)?.as_duration();
-        self.sync_check_interval_max =
-            DurationUnit::from_str(&self.sync_check_interval_max_str)?.as_duration();
-
-        self.max_sync_wait_timeout =
-            DurationUnit::from_str(&self.max_sync_wait_timeout_str)?.as_duration();
 
         // Process smart prefetch configuration
         self.large_file_size = ByteUnit::from_str(&self.large_file_size_str)?.as_byte() as i64;
@@ -444,23 +414,20 @@ impl Default for ClientConf {
             drop_cache_len: 0,
             drop_cache_len_str: "1MB".to_string(),
 
-            failed_worker_ttl: Duration::default(),
-            failed_worker_ttl_str: "10m".to_owned(),
+            failed_worker_ttl_ms: 10 * 60 * 1000,
 
             enable_unified_fs: true,
             enable_rust_read_ufs: true,
 
             audit_logging_enabled: true,
 
-            mount_update_ttl: Default::default(),
-            mount_update_ttl_str: "10s".to_string(),
+            mount_update_ttl_ms: 10 * 1000,
 
             umask: Self::DEFAULT_FILE_SYSTEM_UMASK,
 
             metric_report_enable: true,
 
-            clean_task_interval: Default::default(),
-            clean_task_interval_str: Self::DEFAULT_CLEAN_TASK_INTERVAL_STR.to_string(),
+            clean_task_interval_ms: Self::DEFAULT_CLEAN_TASK_INTERVAL_MS,
 
             close_timeout_secs: Self::DEFAULT_CLOSE_TIMEOUT_SECS,
 
@@ -468,14 +435,11 @@ impl Default for ClientConf {
                 10.0, 50.0, 100.0, 500.0, 1000.0, 5000.0, 10000.0, 50000.0, 100000.0,
             ],
 
-            sync_check_interval_min: Default::default(),
-            sync_check_interval_min_str: "100ms".to_string(),
+            sync_check_interval_min_ms: 100,
 
-            sync_check_interval_max: Default::default(),
-            sync_check_interval_max_str: "1s".to_string(),
+            sync_check_interval_max_ms: 1000,
 
-            max_sync_wait_timeout: Default::default(),
-            max_sync_wait_timeout_str: "5m".to_string(),
+            max_sync_wait_timeout_ms: 5 * 60 * 1000,
 
             sync_check_log_tick: 3,
 
@@ -485,8 +449,7 @@ impl Default for ClientConf {
             small_file_size: 0,
             small_file_size_str: "4MB".to_string(),
 
-            block_conn_idle_time: Duration::from_secs(60),
-            block_conn_idle_time_str: "60s".to_string(),
+            block_conn_idle_time_ms: 60 * 1000,
 
             enable_smart_prefetch: true,
             large_file_size: 0,

--- a/curvine-common/tests/client_conf_cli_test.rs
+++ b/curvine-common/tests/client_conf_cli_test.rs
@@ -221,7 +221,7 @@ fn apply_to_updates_c6_fields() {
     let overrides = ClientConfCliOverrides {
         hostname: Some("node-a".to_string()),
         auto_cache_ttl: Some("14d".to_string()),
-        failed_worker_ttl_str: Some("30m".to_string()),
+        failed_worker_ttl_ms: Some(30 * 60 * 1000),
         sync_check_log_tick: Some(5),
         enable_smart_prefetch: Some(false),
         ..Default::default()
@@ -231,9 +231,28 @@ fn apply_to_updates_c6_fields() {
 
     assert_eq!(conf.hostname, "node-a");
     assert_eq!(conf.auto_cache_ttl, "14d");
-    assert_eq!(conf.failed_worker_ttl_str, "30m");
+    assert_eq!(conf.failed_worker_ttl_ms, 30 * 60 * 1000);
     assert_eq!(conf.sync_check_log_tick, 5);
     assert!(!conf.enable_smart_prefetch);
+}
+
+#[test]
+fn toml_legacy_time_field_aliases_preserved() {
+    // The *_ms time fields were renamed from String (e.g. failed_worker_ttl = "10m")
+    // to u64 milliseconds (issue #1023-style hygiene). ClientConf is #[serde(default)]
+    // without deny_unknown_fields, so a serde alias on each renamed field keeps legacy
+    // numeric configs working. NOTE: legacy *string* values ("10m") no longer parse —
+    // this is an intentional breaking change; only numeric (ms) legacy values are kept.
+    let toml = r#"
+failed_worker_ttl = 600000
+mount_update_ttl = 10000
+block_conn_idle_time = 60000
+"#;
+    let conf: ClientConf =
+        toml::from_str(toml).expect("legacy numeric time keys must deserialize via alias");
+    assert_eq!(conf.failed_worker_ttl_ms, 600000);
+    assert_eq!(conf.mount_update_ttl_ms, 10000);
+    assert_eq!(conf.block_conn_idle_time_ms, 60000);
 }
 
 #[test]

--- a/curvine-common/tests/client_conf_cli_test.rs
+++ b/curvine-common/tests/client_conf_cli_test.rs
@@ -256,6 +256,23 @@ block_conn_idle_time = 60000
 }
 
 #[test]
+fn toml_legacy_string_duration_is_rejected() {
+    // The string->ms migration is intentionally breaking: a human-readable
+    // duration like "10m" must NOT silently deserialize into a u64 ms field.
+    // This locks the contract so we cannot regress into accepting duration
+    // strings again (which would reintroduce the DurationUnit dependency).
+    let toml = r#"
+failed_worker_ttl = "10m"
+"#;
+    let result = toml::from_str::<ClientConf>(toml);
+    assert!(
+        result.is_err(),
+        "string duration value must be rejected, got: {:?}",
+        result.map(|c| c.failed_worker_ttl_ms)
+    );
+}
+
+#[test]
 fn client_cli_flags_parse_alongside_mount_io_threads() {
     #[derive(Debug, Parser)]
     struct MountLikeArgs {

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -1157,11 +1157,11 @@ impl fs::FileSystem for CurvineFileSystem {
         self.state.fs_fsync(op.header.nodeid, None).await?;
 
         let conf = &self.fs.conf().client;
-        let check_interval_min = conf.sync_check_interval_min;
-        let check_interval_max = conf.sync_check_interval_max;
+        let check_interval_min_ms = conf.sync_check_interval_min_ms;
+        let check_interval_max_ms = conf.sync_check_interval_max_ms;
         let log_ticks = conf.sync_check_log_tick;
 
-        let mut ticks = 0;
+        let mut ticks: u64 = 0;
         let time = TimeSpent::new();
 
         // NOTE: `setlkw_wait_duration_us` is NOT observed here. Its RAII timer is
@@ -1179,10 +1179,10 @@ impl fs::FileSystem for CurvineFileSystem {
             }
 
             ticks += 1;
-            let sleep_time = check_interval_max.min(check_interval_min * ticks);
-            tokio::time::sleep(sleep_time).await;
+            let sleep_ms = check_interval_max_ms.min(check_interval_min_ms * ticks);
+            tokio::time::sleep(std::time::Duration::from_millis(sleep_ms)).await;
 
-            if ticks % log_ticks == 0 {
+            if ticks.is_multiple_of(log_ticks as u64) {
                 info!("waiting lock for {}, elapsed: {} ms", path, time.used_ms());
             }
         }

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -1179,7 +1179,7 @@ impl fs::FileSystem for CurvineFileSystem {
             }
 
             ticks += 1;
-            let sleep_ms = check_interval_max_ms.min(check_interval_min_ms * ticks);
+            let sleep_ms = check_interval_max_ms.min(check_interval_min_ms.saturating_mul(ticks));
             tokio::time::sleep(std::time::Duration::from_millis(sleep_ms)).await;
 
             if ticks.is_multiple_of(log_ticks as u64) {

--- a/curvine-libsdk/java/src/main/java/io/curvine/FilesystemConf.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/FilesystemConf.java
@@ -71,7 +71,7 @@ public class FilesystemConf {
     public String read_ahead_len = "0";
     public String drop_cache_len = "1MB";
 
-    public String failed_worker_ttl = "10m";
+    public long failed_worker_ttl_ms = 10 * 60 * 1000;
 
     public boolean enable_unified_fs  = true;
 
@@ -81,19 +81,19 @@ public class FilesystemConf {
 
     public int umask = 022;
 
-    public String mount_update_ttl = "10s";
+    public long mount_update_ttl_ms = 10 * 1000;
 
-    public String sync_check_interval_min = "100ms";
+    public long sync_check_interval_min_ms = 100;
 
-    public String sync_check_interval_max = "1s";
+    public long sync_check_interval_max_ms = 1000;
 
-    public String max_sync_wait_timeout = "5m";
+    public long max_sync_wait_timeout_ms = 5 * 60 * 1000;
 
     public int sync_check_log_tick = 3;
 
     public boolean enable_block_conn_pool = true;
     public int block_conn_idle_size = 128;
-    public String block_conn_idle_time = "60s";
+    public long block_conn_idle_time_ms = 60 * 1000;
 
     public String small_file_size = "4MB";
 
@@ -242,19 +242,19 @@ public class FilesystemConf {
                 ", enable_read_ahead=" + enable_read_ahead +
                 ", read_ahead_len='" + read_ahead_len + '\'' +
                 ", drop_cache_len='" + drop_cache_len + '\'' +
-                ", failed_worker_ttl='" + failed_worker_ttl + '\'' +
+                ", failed_worker_ttl_ms=" + failed_worker_ttl_ms +
                 ", enable_unified_fs=" + enable_unified_fs +
                 ", enable_read_ufs=" + enable_rust_read_ufs +
                 ", enable_fallback_read_ufs=" + enable_fallback_read_ufs +
                 ", umask=" + umask +
-                ", mount_update_ttl='" + mount_update_ttl + '\'' +
-                ", sync_check_interval_min='" + sync_check_interval_min + '\'' +
-                ", sync_check_interval_max='" + sync_check_interval_max + '\'' +
-                ", max_sync_wait_timeout='" + max_sync_wait_timeout + '\'' +
+                ", mount_update_ttl_ms=" + mount_update_ttl_ms +
+                ", sync_check_interval_min_ms=" + sync_check_interval_min_ms +
+                ", sync_check_interval_max_ms=" + sync_check_interval_max_ms +
+                ", max_sync_wait_timeout_ms=" + max_sync_wait_timeout_ms +
                 ", sync_check_log_tick=" + sync_check_log_tick +
                 ", enable_block_conn_pool=" + enable_block_conn_pool +
                 ", block_conn_idle_size=" + block_conn_idle_size +
-                ", block_conn_idle_time='" + block_conn_idle_time + '\'' +
+                ", block_conn_idle_time_ms=" + block_conn_idle_time_ms +
                 ", small_file_size='" + small_file_size + '\'' +
                 ", enable_smart_prefetch=" + enable_smart_prefetch +
                 ", large_file_size='" + large_file_size + '\'' +

--- a/curvine-libsdk/src/filesystem_conf.rs
+++ b/curvine-libsdk/src/filesystem_conf.rs
@@ -20,7 +20,6 @@ use orpc::common::LogConf;
 use orpc::io::net::InetAddr;
 use orpc::{err_box, try_err};
 use serde::{Deserialize, Serialize};
-use std::time::Duration;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(default)]
@@ -89,21 +88,21 @@ pub struct FilesystemConf {
     pub display_thread: bool,
     pub display_position: bool,
 
-    pub failed_worker_ttl: String,
+    pub failed_worker_ttl_ms: u64,
 
     pub enable_unified_fs: bool,
     pub enable_rust_read_ufs: bool,
 
-    pub mount_update_ttl: String,
+    pub mount_update_ttl_ms: u64,
 
-    pub sync_check_interval_min: String,
-    pub sync_check_interval_max: String,
-    pub max_sync_wait_timeout: String,
+    pub sync_check_interval_min_ms: u64,
+    pub sync_check_interval_max_ms: u64,
+    pub max_sync_wait_timeout_ms: u64,
     pub sync_check_log_tick: u32,
 
     pub enable_block_conn_pool: bool,
     pub block_conn_idle_size: usize,
-    pub block_conn_idle_time: String,
+    pub block_conn_idle_time_ms: u64,
 
     pub small_file_size: String,
 
@@ -146,12 +145,12 @@ impl FilesystemConf {
             ttl_ms: "0".to_string(),
             ttl_action: "none".to_string(),
             storage_type: "disk".to_string(),
-            failed_worker_ttl: "30s".to_string(),
-            mount_update_ttl: "5m".to_string(),
-            sync_check_interval_min: "1s".to_string(),
-            sync_check_interval_max: "5s".to_string(),
-            max_sync_wait_timeout: "30s".to_string(),
-            block_conn_idle_time: "30s".to_string(),
+            failed_worker_ttl_ms: 30_000,
+            mount_update_ttl_ms: 5 * 60_000,
+            sync_check_interval_min_ms: 1_000,
+            sync_check_interval_max_ms: 5_000,
+            max_sync_wait_timeout_ms: 30_000,
+            block_conn_idle_time_ms: 30_000,
             small_file_size: "1MB".to_string(),
             large_file_size: "64MB".to_string(),
             log_level: log.level,
@@ -229,21 +228,20 @@ impl FilesystemConf {
             auto_cache_ttl: self.auto_cache_ttl,
             default_cache_ttl: self.default_cache_ttl,
 
-            failed_worker_ttl: Duration::default(),
-            failed_worker_ttl_str: self.failed_worker_ttl,
+            failed_worker_ttl_ms: self.failed_worker_ttl_ms,
 
             enable_unified_fs: self.enable_unified_fs,
             enable_rust_read_ufs: self.enable_rust_read_ufs,
-            mount_update_ttl_str: self.mount_update_ttl,
+            mount_update_ttl_ms: self.mount_update_ttl_ms,
 
-            sync_check_interval_min_str: self.sync_check_interval_min,
-            sync_check_interval_max_str: self.sync_check_interval_max,
-            max_sync_wait_timeout_str: self.max_sync_wait_timeout,
+            sync_check_interval_min_ms: self.sync_check_interval_min_ms,
+            sync_check_interval_max_ms: self.sync_check_interval_max_ms,
+            max_sync_wait_timeout_ms: self.max_sync_wait_timeout_ms,
             sync_check_log_tick: self.sync_check_log_tick,
 
             enable_block_conn_pool: self.enable_block_conn_pool,
             block_conn_idle_size: self.block_conn_idle_size,
-            block_conn_idle_time_str: self.block_conn_idle_time,
+            block_conn_idle_time_ms: self.block_conn_idle_time_ms,
 
             small_file_size_str: self.small_file_size,
 

--- a/curvine-libsdk/src/filesystem_conf.rs
+++ b/curvine-libsdk/src/filesystem_conf.rs
@@ -88,20 +88,26 @@ pub struct FilesystemConf {
     pub display_thread: bool,
     pub display_position: bool,
 
+    #[serde(alias = "failed_worker_ttl")]
     pub failed_worker_ttl_ms: u64,
 
     pub enable_unified_fs: bool,
     pub enable_rust_read_ufs: bool,
 
+    #[serde(alias = "mount_update_ttl")]
     pub mount_update_ttl_ms: u64,
 
+    #[serde(alias = "sync_check_interval_min")]
     pub sync_check_interval_min_ms: u64,
+    #[serde(alias = "sync_check_interval_max")]
     pub sync_check_interval_max_ms: u64,
+    #[serde(alias = "max_sync_wait_timeout")]
     pub max_sync_wait_timeout_ms: u64,
     pub sync_check_log_tick: u32,
 
     pub enable_block_conn_pool: bool,
     pub block_conn_idle_size: usize,
+    #[serde(alias = "block_conn_idle_time")]
     pub block_conn_idle_time_ms: u64,
 
     pub small_file_size: String,

--- a/curvine-server/src/common/ufs_factory.rs
+++ b/curvine-server/src/common/ufs_factory.rs
@@ -34,7 +34,7 @@ impl UfsFactory {
         let client_factory = ClientFactory::with_rt(conf.client_rpc_conf(), rt);
         Self {
             client_factory,
-            ufs_cache: FastSyncCache::with_ttl(conf.mount_update_ttl),
+            ufs_cache: FastSyncCache::with_ttl(Duration::from_millis(conf.mount_update_ttl_ms)),
         }
     }
 


### PR DESCRIPTION
# Summary

Unify the time-related fields in `ClientConf` to a single `u64` millisecond representation (`*_ms`), matching the existing `*_timeout_ms` convention already used for the RPC/connection timeouts. This removes the `String` + derived-`Duration` double-field pattern and the per-field `DurationUnit` parse in `init()`.

# Issue Describe / Design

Config-hygiene refactor (same class as the FuseConf cleanup). Seven settings each existed as a serializable `String` "raw" field (e.g. `failed_worker_ttl = "10m"`) plus a `#[serde(skip)]` derived `Duration`, converted once in `init()`. Business logic only ever read the derived `Duration`, and every consumer immediately turned it back into milliseconds — the `Duration` layer was a pure round-trip.

Collapsed fields:

| Old (String + Duration) | New |
| ----------------------- | --- |
| `failed_worker_ttl` | `failed_worker_ttl_ms: u64` |
| `mount_update_ttl` | `mount_update_ttl_ms: u64` |
| `clean_task_interval` | `clean_task_interval_ms: u64` |
| `sync_check_interval_min` | `sync_check_interval_min_ms: u64` |
| `sync_check_interval_max` | `sync_check_interval_max_ms: u64` |
| `max_sync_wait_timeout` | `max_sync_wait_timeout_ms: u64` |
| `block_conn_idle_time` | `block_conn_idle_time_ms: u64` |

## Breaking changes (migration required)

- **Legacy string values no longer parse.** A config with `failed_worker_ttl = "10m"` will now **fail to load** — it must become `failed_worker_ttl_ms = 600000`. Each field keeps `#[serde(alias = "<old_key>")]`, so the *old key name* still works, but only for **numeric (ms)** values. This is intentional: a hard error surfaces the change instead of silently falling back to a default (`ClientConf` is `#[serde(default)]` without `deny_unknown_fields`).
- **CLI flags renamed**: `--client-failed-worker-ttl` → `--client-failed-worker-ttl-ms` (and the other six). The `ClientCliArgs` derive uses `strip_suffix = "_str"`; since the fields are no longer `_str`, the `_ms` suffix is preserved in the flag — consistent with the ms naming.

# Changes

| Module / File | Change | Impact |
| ------------- | ------ | ------ |
| `curvine-common/src/conf/client_conf.rs` | 7 fields → `u64 *_ms` + serde alias; drop DurationUnit parses in `init()`; ms defaults; `DEFAULT_CLEAN_TASK_INTERVAL_STR`→`_MS` | Breaking: see above |
| `curvine-libsdk/src/filesystem_conf.rs` | mirror field types (`String`→`u64`) + `into_cluster_conf` mapping | Breaking for SDK callers |
| `curvine-client/src/file/fs_context.rs` | wrap ms in `Duration::from_millis` at use site | None |
| `curvine-client/src/unified/unified_filesystem.rs` | same | None |
| `curvine-client/src/rpc/job_master_client.rs` | sync-check loop computes in ms (`ticks: u64`) | None |
| `curvine-fuse/src/fs/curvine_file_system.rs` | setlkw wait loop computes in ms | None |
| `curvine-server/src/common/ufs_factory.rs` | `Duration::from_millis(mount_update_ttl_ms)` | None |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo build --workspace --tests` | PASS | |
| `make format` | PASS | |
| `cargo test -p curvine-common --test client_conf_cli_test` | PASS | 15 tests, incl. new `toml_legacy_time_field_aliases_preserved` |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None
