### PR TITLE
fix(fuse): reject zero io_threads (#1073)

### DIFF
--- a/curvine-common/src/conf/fuse_conf.rs
+++ b/curvine-common/src/conf/fuse_conf.rs
@@ -241,6 +241,10 @@ impl FuseConf {
     pub const DEFAULT_MAX_READAHEAD_KB: u32 = 1024;
 
     pub fn init(&mut self) -> CommonResult<()> {
+        if self.io_threads == 0 {
+            return err_box!("fuse.io_threads must be > 0");
+        }
+
         self.attr_ttl = Duration::from_millis(self.attr_timeout_ms);
         self.entry_ttl = Duration::from_millis(self.entry_timeout_ms);
         self.negative_ttl = Duration::from_millis(self.negative_timeout_ms);
@@ -434,6 +438,29 @@ mod tests {
             conf.max_readahead_kb,
             Some(FuseConf::DEFAULT_MAX_READAHEAD_KB)
         );
+    }
+
+    #[test]
+    fn init_rejects_zero_io_threads() {
+        let mut conf = FuseConf {
+            io_threads: 0,
+            ..Default::default()
+        };
+        let err = conf.init().expect_err("zero io_threads must be rejected");
+        assert!(
+            err.to_string().contains("fuse.io_threads must be > 0"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn init_accepts_positive_io_threads() {
+        let mut conf = FuseConf {
+            io_threads: 1,
+            ..Default::default()
+        };
+        conf.init().expect("positive io_threads must be accepted");
     }
 
     #[test]

--- a/curvine-fuse/src/cli/mount_args.rs
+++ b/curvine-fuse/src/cli/mount_args.rs
@@ -356,3 +356,35 @@ impl FuseMountArgs {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::FuseMountArgs;
+    use clap::Parser;
+    use orpc::common::Utils;
+    use std::fs;
+
+    #[test]
+    fn get_conf_rejects_zero_io_threads_cli_override() {
+        let conf_path = Utils::temp_file();
+        fs::write(&conf_path, "[fuse]\nio_threads = 1\n").expect("write test config");
+
+        let args = FuseMountArgs::try_parse_from([
+            "curvine-fuse",
+            "--conf",
+            &conf_path,
+            "--io-threads",
+            "0",
+        ])
+        .expect("parse mount arguments");
+        let result = args.get_conf();
+        let _ = fs::remove_file(&conf_path);
+
+        let err = result.expect_err("zero io_threads override must be rejected");
+        assert!(
+            err.to_string().contains("fuse.io_threads must be > 0"),
+            "unexpected error: {}",
+            err
+        );
+    }
+}


### PR DESCRIPTION
# Summary

Validate `fuse.io_threads` during `FuseConf::init` and reject zero with a structured error. This prevents invalid configuration from reaching Tokio runtime construction and causing a startup panic.

# Issue Describe / Design

Closes #1073

Previously, `FuseConf::init` accepted `io_threads == 0`. The value was later passed to Tokio's `Builder::worker_threads`, where zero worker threads caused `builder.build().unwrap()` to panic.

The validation is performed in `FuseConf::init` so invalid configuration fails early, before runtime resources are created.

# Changes

| Module / File | Change |
| ------------- | ------ |
| `curvine-common/src/conf/fuse_conf.rs` | Reject `io_threads == 0` and add boundary tests |
| `curvine-fuse/src/cli/mount_args.rs` | Add a startup-path test covering the `--io-threads 0` CLI override |

# Test verified

| Test case | Result |
| --------- | ------ |
| `make format` | PASS |
| `cargo test -p curvine-common conf::fuse_conf::tests -- --nocapture` | PASS, 13 tests |
| `cargo test -p curvine-fuse get_conf_rejects_zero_io_threads_cli_override -- --nocapture` | PASS |

# Dependencies

- Related issues: #1073
- Related PRs: None