### PR TITLE
fix(fuse): support read-only create

### DIFF
--- a/build/tests/fuse-test.sh
+++ b/build/tests/fuse-test.sh
@@ -62,6 +62,7 @@ This script tests basic filesystem operations including:
   - POSIX rename semantics (EISDIR, ENOTEMPTY, EINVAL)
   - Mmap read/write (MAP_SHARED mmap ↔ pread coherence, issue #850)
   - Active-writer path truncate regression (PR #962)
+  - Read-only open with O_CREAT creates a missing file
 
 For FIO performance tests, use fio-test.sh instead.
 
@@ -1369,6 +1370,15 @@ test_pr962_active_writer_truncate() {
         "pr962_active_writer_truncate_repro.py" --dir "$TEST_DIR"
 }
 
+# Test 22: O_CREAT with read-only access still creates the file
+test_open_creat_rdonly() {
+    CURRENT_TEST_GROUP="Test 22: Open Create ReadOnly"
+    print_header "$CURRENT_TEST_GROUP"
+    run_python_script_test \
+        "Testing open(path, O_CREAT|O_RDONLY) creates a missing file" \
+        "open_creat_rdonly_repro.py" --dir "$TEST_DIR"
+}
+
 # Print final report
 print_report() {
     print_header "Test Summary"
@@ -1475,6 +1485,7 @@ main() {
     test_rename
     test_file_handle_at
     test_pr962_active_writer_truncate
+    test_open_creat_rdonly
 
     test_git_clone
 

--- a/build/tests/scripts/open_creat_rdonly_repro.py
+++ b/build/tests/scripts/open_creat_rdonly_repro.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+#  // Copyright 2025 OPPO.
+#  //
+#  // Licensed under the Apache License, Version 2.0 (the "License");
+#  // you may not use this file except in compliance with the License.
+#  // You may obtain a copy of the License at
+#  //
+#  //     http://www.apache.org/licenses/LICENSE-2.0
+#  //
+#  // Unless required by applicable law or agreed to in writing, software
+#  // distributed under the License is distributed on an "AS IS" BASIS,
+#  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  // See the License for the specific language governing permissions and
+#  // limitations under the License.
+
+"""
+Regression test for open(path, O_CREAT | O_RDONLY, mode).
+
+O_CREAT is independent from the access mode: opening a missing file with
+O_CREAT|O_RDONLY must create the file and return a read-only fd. Curvine used
+to route FUSE CREATE through the read-only reader path before creating the
+inode, so the operation failed with ENOENT.
+"""
+
+import argparse
+import errno
+import os
+import shutil
+import sys
+
+DEFAULT_DIR = "/curvine-fuse/fuse-test"
+
+
+def safe_close(fd: int) -> None:
+    try:
+        os.close(fd)
+    except OSError:
+        pass
+
+
+def case_dir(root: str, name: str) -> str:
+    path = os.path.join(root, name)
+    if os.path.exists(path):
+        shutil.rmtree(path)
+    os.makedirs(path)
+    return path
+
+
+def is_mount_path(path: str) -> bool:
+    probe = os.path.abspath(path)
+    while probe != "/":
+        if os.path.ismount(probe):
+            return True
+        probe = os.path.dirname(probe)
+    return False
+
+
+def run_case(root: str) -> None:
+    workdir = case_dir(root, "open_creat_rdonly")
+    target = os.path.join(workdir, "created-readonly")
+
+    fd = os.open(target, os.O_CREAT | os.O_RDONLY, 0o644)
+    try:
+        st = os.fstat(fd)
+        if not os.path.isfile(target):
+            raise OSError(errno.ENOENT, "created file is not visible")
+        if (st.st_mode & 0o777) != 0o644:
+            raise OSError(errno.EIO, f"created mode is {st.st_mode & 0o777:o}, expected 644")
+        try:
+            os.write(fd, b"x")
+        except OSError as exc:
+            if exc.errno != errno.EBADF:
+                raise OSError(exc.errno, f"write on read-only fd returned {exc}") from exc
+        else:
+            raise OSError(errno.EIO, "write on read-only fd unexpectedly succeeded")
+    finally:
+        safe_close(fd)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="open(O_CREAT|O_RDONLY) regression test",
+    )
+    parser.add_argument(
+        "--dir",
+        default=DEFAULT_DIR,
+        help="Base test directory on the Curvine FUSE mount",
+    )
+    parser.add_argument(
+        "--allow-non-mount",
+        action="store_true",
+        help="Skip mount check; for local debugging only",
+    )
+    args = parser.parse_args()
+
+    root = os.path.abspath(args.dir)
+    os.makedirs(root, exist_ok=True)
+
+    if not args.allow_non_mount and not is_mount_path(root):
+        print(f"FAIL: {root} is not under a mount point", file=sys.stderr)
+        return 1
+
+    try:
+        run_case(root)
+    except OSError as exc:
+        print(
+            f"FAIL: open(O_CREAT|O_RDONLY) regression: "
+            f"errno={exc.errno} ({errno.errorcode.get(exc.errno, '?')}): {exc}",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        print(f"FAIL: open(O_CREAT|O_RDONLY) regression: {exc}", file=sys.stderr)
+        return 1
+
+    print("PASS: open(O_CREAT|O_RDONLY) regression")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/curvine-client/src/unified/unified_filesystem.rs
+++ b/curvine-client/src/unified/unified_filesystem.rs
@@ -496,7 +496,7 @@ impl UnifiedFileSystem {
         let mut write_path = path.path().to_owned();
 
         let fut = async {
-            let rpc_code = if flags.read_only() {
+            let rpc_code = if flags.read_only() && !flags.create() {
                 RpcCode::OpenFile
             } else {
                 RpcCode::CreateFile

--- a/curvine-fuse/src/fs/state/node_state.rs
+++ b/curvine-fuse/src/fs/state/node_state.rs
@@ -917,7 +917,20 @@ impl NodeState {
         let path = self.get_path_name(ino, name)?;
         let _guard = self.lock_path(&path).await;
 
-        let handle = self.new_handle(None, &path, flags, opts).await?;
+        let handle = if flags.read_only() {
+            let writer = self
+                .new_writer(&path, flags.set_write_only(), opts.clone())
+                .await?;
+            let mut status = writer.status().clone();
+            writer.complete(None).await?;
+
+            let child_ino = self.next_ino(&status);
+            status.id = child_ino as i64;
+            let _ = self.lookup_status(ino, name, &status)?;
+            return self.new_handle(Some(child_ino), &path, flags, opts).await;
+        } else {
+            self.new_handle(None, &path, flags, opts).await?
+        };
         self.lookup_status(ino, name, handle.status())?;
         Ok(handle)
     }


### PR DESCRIPTION
# Summary

Fix FUSE `open(path, O_CREAT | O_RDONLY, mode)` on a missing file.

When a file was opened with `O_CREAT | O_RDONLY`, Curvine returned `ENOENT`
instead of creating the file and returning a read-only file descriptor. `O_CREAT`
is independent from the access mode: read-only controls whether the returned fd
can be written, but it must not suppress the create side effect.

# Minimal Reproducer

```c
#define _GNU_SOURCE
#include <errno.h>
#include <fcntl.h>
#include <stdio.h>
#include <string.h>
#include <sys/stat.h>
#include <unistd.h>

int main(int argc, char **argv) {
    const char *path;
    struct stat st;
    int fd;

    if (argc != 2) {
        fprintf(stderr, "usage: %s <mount-dir>\n", argv[0]);
        return 2;
    }

    char file[4096];
    snprintf(file, sizeof(file), "%s/open_creat_rdonly.dat", argv[1]);
    path = file;

    unlink(path);

    fd = open(path, O_CREAT | O_RDONLY, 0644);
    if (fd < 0) {
        fprintf(stderr,
                "open(O_CREAT|O_RDONLY) failed errno=%d (%s)\n",
                errno,
                strerror(errno));
        return 1;
    }

    if (fstat(fd, &st) != 0) {
        perror("fstat");
        close(fd);
        return 1;
    }

    if (!S_ISREG(st.st_mode)) {
        fprintf(stderr, "created path is not a regular file\n");
        close(fd);
        unlink(path);
        return 1;
    }

    if ((st.st_mode & 0777) != 0644) {
        fprintf(stderr,
                "unexpected mode: got %03o expected 644\n",
                (unsigned)(st.st_mode & 0777));
        close(fd);
        unlink(path);
        return 1;
    }

    if (write(fd, "x", 1) >= 0 || errno != EBADF) {
        fprintf(stderr,
                "write on read-only fd should fail with EBADF, errno=%d\n",
                errno);
        close(fd);
        unlink(path);
        return 1;
    }

    close(fd);
    unlink(path);

    return 0;
}
```

Run it on a Curvine FUSE mount:

```bash
gcc /tmp/open_creat_rdonly.c -o /tmp/open_creat_rdonly
/tmp/open_creat_rdonly /curvine-fuse
```

Before the fix, it failed at the create-open step:

```text
open(O_CREAT|O_RDONLY) failed errno=2 (No such file or directory)
```

# Root Cause

The read-only create path was routed as if it were a pure read-only open.

That meant:

- `UnifiedFileSystem::open_with_opts()` selected `OpenFile` whenever the access
  mode was read-only, even when `O_CREAT` was also set.
- FUSE `NodeState::fs_create()` reused the normal handle creation helper.
- For `O_CREAT | O_RDONLY`, that helper entered the read-only branch and tried to
  build a reader for a file that had not been created yet.
- The backend therefore returned `ENOENT`.

# Changes

- Treat `O_CREAT` as create intent even when the access mode is read-only.
- Route read-only create operations through `CreateFile` instead of `OpenFile`.
- In the FUSE create path, create the inode through a temporary write-only writer,
  complete it, then reopen the same path as read-only.
- Keep the returned fd read-only, so writes through that fd still fail with
  `EBADF`.
- Add a FUSE regression script for `open(path, O_CREAT | O_RDONLY, mode)` and
  wire it into `fuse-test.sh`.

# Verification

- Minimal C reproducer passes after the fix.
- `cargo fmt --check` passes.
- `cargo check -p curvine-client -p curvine-fuse` passes.
- `python3 build/tests/scripts/open_creat_rdonly_repro.py --dir /tmp/curvine-open-creat-rdonly-test --allow-non-mount` passes.

