### PR TITLE
refactor(worker): centralize block-relative I/O handling

### DIFF
--- a/curvine-server/src/worker/block/block_meta.rs
+++ b/curvine-server/src/worker/block/block_meta.rs
@@ -15,12 +15,10 @@
 use crate::worker::storage::{DirState, VfsDir, ACTIVE_DIR, STAGING_DIR};
 use curvine_common::state::{ExtendedBlock, StorageType};
 use orpc::common::{ByteUnit, FileUtils};
-use orpc::io::{BlockDevice, IOResult, LocalFile};
+use orpc::io::LocalFile;
 
 #[cfg(feature = "spdk")]
-use log::info;
-#[cfg(feature = "spdk")]
-use orpc::io::SpdkBdev;
+use orpc::io::{IOError, IOResult};
 
 use orpc::{err_box, sys, try_err, CommonResult};
 use std::fmt::Formatter;
@@ -232,60 +230,11 @@ impl BlockMeta {
         Ok(file)
     }
 
-    pub fn create_writer(&self, off: i64, overwrite: bool) -> IOResult<BlockDevice> {
-        match self.storage_type() {
-            #[cfg(feature = "spdk")]
-            StorageType::SpdkDisk => {
-                let bdev_name = self.get_bdev_name()?;
-                let abs_offset = self.bdev_offset + off;
-                let max_len = 0.max(self.len - off);
-                info!(
-                    "Opening SPDK bdev '{}' for writing at offset {} (block {} base={}, max_len={})",
-                    bdev_name, abs_offset, self.id, self.bdev_offset, max_len
-                );
-                if max_len == 0 {
-                    return err_box!("Cannot open SPDK writer: no space remaining");
-                }
-                let bdev = SpdkBdev::open_write(&bdev_name, abs_offset, max_len)?;
-                Ok(BlockDevice::Spdk(bdev))
-            }
-            _ => {
-                let file = self.get_block_file()?;
-                let local = LocalFile::with_write_offset(file, overwrite, off)?;
-                Ok(BlockDevice::Local(local))
-            }
-        }
-    }
-
-    pub fn create_reader(&self, offset: u64) -> IOResult<BlockDevice> {
-        match self.storage_type() {
-            #[cfg(feature = "spdk")]
-            StorageType::SpdkDisk => {
-                let bdev_name = self.get_bdev_name()?;
-                let abs_offset = self.bdev_offset as u64 + offset;
-                let max_len = 0.max(self.len - offset as i64);
-                info!(
-                    "Opening SPDK bdev '{}' for reading at offset {} (block {} base={}, max_len={})",
-                    bdev_name, abs_offset, self.id, self.bdev_offset, max_len
-                );
-                if max_len == 0 {
-                    return err_box!("Cannot open SPDK reader: no space remaining");
-                }
-                let bdev = SpdkBdev::open_read(&bdev_name, abs_offset, max_len)?;
-                Ok(BlockDevice::Spdk(bdev))
-            }
-            _ => {
-                let local = LocalFile::with_read(self.get_block_file()?, offset)?;
-                Ok(BlockDevice::Local(local))
-            }
-        }
-    }
-
     /// Get the SPDK bdev name for this block.
     #[cfg(feature = "spdk")]
-    fn get_bdev_name(&self) -> IOResult<String> {
+    pub(crate) fn get_bdev_name(&self) -> IOResult<String> {
         self.dir.bdev_name.clone().ok_or_else(|| {
-            orpc::io::IOError::from(format!(
+            IOError::from(format!(
                 "block {} has StorageType::SpdkDisk but dir (dir_id={}) has no bdev_name assigned",
                 self.id, self.dir.dir_id
             ))

--- a/curvine-server/src/worker/block/block_store.rs
+++ b/curvine-server/src/worker/block/block_store.rs
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 use crate::worker::block::BlockMeta;
-use crate::worker::storage::{BlockDataset, BlockLayout, Dataset};
+use crate::worker::storage::{
+    BlockDataset, BlockLayout, BlockReadContext, BlockWriteContext, Dataset,
+};
 use curvine_common::conf::ClusterConf;
 use curvine_common::state::{ExtendedBlock, StorageInfo};
 use log::error;
@@ -71,6 +73,30 @@ impl BlockStore {
         let state = self.read()?;
         let b = state.get_block_check(id)?;
         Ok(b.clone())
+    }
+
+    pub fn open_writer(&self, meta: &BlockMeta, off: i64) -> CommonResult<BlockWriteContext> {
+        let layout = {
+            let state = self.read()?;
+            state.layout_for(meta)
+        };
+        layout.open_writer(meta, off).map_err(Into::into)
+    }
+
+    pub fn open_reader(&self, meta: &BlockMeta, off: i64) -> CommonResult<BlockReadContext> {
+        let layout = {
+            let state = self.read()?;
+            state.layout_for(meta)
+        };
+        layout.open_reader(meta, off).map_err(Into::into)
+    }
+
+    pub fn short_circuit(&self, meta: &BlockMeta) -> CommonResult<Option<String>> {
+        let layout = {
+            let state = self.read()?;
+            state.layout_for(meta)
+        };
+        layout.short_circuit(meta)
     }
 
     pub fn worker_id(&self) -> CommonResult<u32> {

--- a/curvine-server/src/worker/handler/batch_write_handler.rs
+++ b/curvine-server/src/worker/handler/batch_write_handler.rs
@@ -194,7 +194,7 @@ impl BatchWriteHandler {
             }
             if block.len > context.block_size {
                 return err_box!(
-                    "Invalid write offset: {}, block size: {}",
+                    "Invalid block length: {}, block size: {}",
                     block.len,
                     context.block_size
                 );

--- a/curvine-server/src/worker/handler/batch_write_handler.rs
+++ b/curvine-server/src/worker/handler/batch_write_handler.rs
@@ -15,6 +15,7 @@
 use crate::worker::block::BlockStore;
 use crate::worker::handler::WriteContext;
 use crate::worker::handler::WriteHandler;
+use crate::worker::storage::BlockWriteContext;
 use curvine_common::error::FsError;
 use curvine_common::fs::RpcCode;
 use curvine_common::proto::{
@@ -26,7 +27,6 @@ use curvine_common::utils::ProtoUtils;
 use curvine_common::FsResult;
 use orpc::err_box;
 use orpc::handler::MessageHandler;
-use orpc::io::{BlockDevice, BlockIO};
 use orpc::message::{Builder, Message, RequestStatus};
 use orpc::sys::DataSlice;
 use orpc::CommonResult;
@@ -34,7 +34,7 @@ use orpc::CommonResult;
 pub struct BatchWriteHandler {
     pub(crate) store: BlockStore,
     pub(crate) context: Option<Vec<WriteContext>>,
-    pub(crate) file: Option<Vec<Option<BlockDevice>>>,
+    pub(crate) file: Option<Vec<Option<BlockWriteContext>>>,
     pub(crate) is_commit: bool,
     pub(crate) write_handler: WriteHandler,
 }
@@ -208,9 +208,7 @@ impl BatchWriteHandler {
             }
         }
         for file in files.iter_mut() {
-            if let Some(file) = file.take() {
-                drop(file);
-            }
+            file.take();
         }
 
         for block in commit_blocks {
@@ -254,7 +252,6 @@ impl BatchWriteHandler {
         let files_drain = std::mem::take(files_vec);
         let contexts_drain = std::mem::take(contexts_vec);
 
-        // Process each file in order
         let mut files_iter = files_drain.into_iter();
         let mut contexts_iter = contexts_drain.into_iter();
 
@@ -306,7 +303,6 @@ impl BatchWriteHandler {
                 return Err(e);
             }
 
-            // Collect processed file and context back into the original vectors
             let Some(file) = self.write_handler.file.take() else {
                 return err_box!("batch write lost file state at index {}", i);
             };
@@ -314,7 +310,6 @@ impl BatchWriteHandler {
                 return err_box!("batch write lost context state at index {}", i);
             };
 
-            // Push back to reuse the pre-allocated capacity from open_batch
             files_vec.push(Some(file));
             contexts_vec.push(context);
         }

--- a/curvine-server/src/worker/handler/context.rs
+++ b/curvine-server/src/worker/handler/context.rs
@@ -55,7 +55,6 @@ pub struct ReadContext {
     pub enable_read_ahead: bool,
     pub read_ahead_len: i64,
     pub drop_cache_len: i64,
-    pub bdev_offset: i64,
 }
 
 impl ReadContext {
@@ -71,7 +70,6 @@ impl ReadContext {
             enable_read_ahead: req.enable_read_ahead,
             read_ahead_len: req.read_ahead_len,
             drop_cache_len: req.drop_cache_len,
-            bdev_offset: 0, // default for local files; set by ReadHandler for SPDK
         };
 
         Ok(context)

--- a/curvine-server/src/worker/handler/read_handler.rs
+++ b/curvine-server/src/worker/handler/read_handler.rs
@@ -14,16 +14,15 @@
 
 use crate::worker::block::BlockStore;
 use crate::worker::handler::ReadContext;
+use crate::worker::storage::BlockReadContext;
 use crate::worker::{Worker, WorkerMetrics};
 use curvine_common::error::FsError;
 use curvine_common::proto::{BlockReadResponse, DataHeaderProto};
-use curvine_common::state::StorageType;
 use curvine_common::FsResult;
 use log::{info, warn};
 use orpc::common::{ByteUnit, TimeSpent};
 use orpc::error::ErrorExt;
 use orpc::handler::MessageHandler;
-use orpc::io::{BlockDevice, BlockIO};
 use orpc::message::{Builder, Message, RequestStatus};
 use orpc::sys::{CacheManager, ReadAheadTask};
 use orpc::{err_box, ternary, try_option_mut, CommonResult};
@@ -33,7 +32,7 @@ pub struct ReadHandler {
     pub(crate) store: BlockStore,
     pub(crate) os_cache: CacheManager,
     pub(crate) context: Option<ReadContext>,
-    pub(crate) file: Option<BlockDevice>,
+    pub(crate) file: Option<BlockReadContext>,
     pub(crate) last_task: Option<ReadAheadTask>,
     pub(crate) io_slow_us: u64,
     pub(crate) enable_send_file: bool,
@@ -59,12 +58,19 @@ impl ReadHandler {
     }
 
     pub fn open(&mut self, msg: &Message) -> FsResult<Message> {
-        let mut context = ReadContext::from_req(msg)?;
+        let context = ReadContext::from_req(msg)?;
         let meta = self.store.get_block(context.block_id).map_err(|e| {
             FsError::block_not_found(context.block_id)
                 .ctx(format!("worker block store lookup failed: {}", e))
         })?;
 
+        if context.off < 0 {
+            return err_box!(
+                "Invalid read offset: {}, block length: {}",
+                context.off,
+                meta.len
+            );
+        }
         if context.off > meta.len {
             return err_box!(
                 "The length of the requested data exceeds the maximum length of the block file, \
@@ -87,16 +93,20 @@ impl ReadHandler {
             );
         }
 
-        // Check short-circuit before open. SPDK has no filesystem path.
-        let is_short_circuit =
-            context.short_circuit && meta.storage_type() != StorageType::SpdkDisk;
-        let (label, path, file) = if is_short_circuit {
-            let path = meta.get_block_file()?;
-            ("local", path, None)
+        let sc_path = if context.short_circuit {
+            self.store.short_circuit(&meta)?
         } else {
-            let file = meta.create_reader(context.off as u64)?;
-            ("remote", file.path().to_string(), Some(file))
+            None
         };
+
+        let (is_short_circuit, path, file) = if let Some(path) = sc_path {
+            (true, path, None)
+        } else {
+            let file = self.store.open_reader(&meta, context.off)?;
+            let path = file.path().to_string();
+            (false, path, Some(file))
+        };
+        let label = if is_short_circuit { "local" } else { "remote" };
 
         self.os_cache = CacheManager::new(
             context.enable_read_ahead,
@@ -124,7 +134,6 @@ impl ReadHandler {
         };
 
         let _ = mem::replace(&mut self.file, file);
-        context.bdev_offset = meta.bdev_offset;
         let _ = self.context.replace(context);
 
         self.metrics.read_blocks.with_label_values(&[label]).inc();
@@ -150,23 +159,14 @@ impl ReadHandler {
 
         if msg.header_len() > 0 {
             let header: DataHeaderProto = msg.parse_header()?;
-            let abs_offset = if file.supports_short_circuit() {
-                header.offset
-            } else {
-                context.bdev_offset + header.offset
-            };
-            if abs_offset != file.pos() {
-                file.seek(abs_offset)?;
-            }
+            file.seek_to(header.offset)?;
         }
 
         let spend = TimeSpent::new();
-        // OS page cache read-ahead is only available for local files
         if let Some(local) = file.as_local_mut() {
             self.last_task = local.read_ahead(&self.os_cache, self.last_task.take());
         }
 
-        // SPDK bypasses kernel — sendfile unavailable
         let enable_send_file = self.enable_send_file && file.supports_send_file();
         let region = file.read_region(enable_send_file, context.chunk_size)?;
 
@@ -186,25 +186,16 @@ impl ReadHandler {
         Ok(msg.success_with_data(None, region))
     }
 
-    // Reading is completed and the file is closed.
     pub fn complete(&mut self, msg: &Message) -> FsResult<Message> {
         let _block_id = match &self.context {
             Some(v) => {
-                //Remote reading
                 Self::check_context(v, msg)?;
                 v.block_id
             }
-
-            None => {
-                // Local short circuit reading, block information is in the header.
-                // let c = ReadContext::from_req(msg)?;
-                // c.block_id
-                -1
-            }
+            None => -1,
         };
 
-        let file = self.file.take();
-        drop(file);
+        self.file = None;
 
         info!("Read block end for req_id {}", msg.req_id());
         Ok(msg.success())

--- a/curvine-server/src/worker/handler/write_handler.rs
+++ b/curvine-server/src/worker/handler/write_handler.rs
@@ -282,7 +282,7 @@ impl WriteHandler {
                 );
             }
             return err_box!(
-                "Invalid write offset: {}, block size: {}",
+                "Invalid block length: {}, block size: {}",
                 context.block.len,
                 context.block_size
             );

--- a/curvine-server/src/worker/handler/write_handler.rs
+++ b/curvine-server/src/worker/handler/write_handler.rs
@@ -14,6 +14,7 @@
 
 use crate::worker::block::BlockStore;
 use crate::worker::handler::WriteContext;
+use crate::worker::storage::BlockWriteContext;
 use crate::worker::{Worker, WorkerMetrics};
 use curvine_common::error::FsError;
 use curvine_common::proto::{BlockWriteResponse, DataHeaderProto};
@@ -22,7 +23,6 @@ use curvine_common::FsResult;
 use log::{info, warn};
 use orpc::common::{ByteUnit, TimeSpent};
 use orpc::handler::MessageHandler;
-use orpc::io::{BlockDevice, BlockIO};
 use orpc::message::{Builder, Message, RequestStatus};
 use orpc::{err_box, ternary, try_option_mut, CommonResult};
 use std::mem;
@@ -30,7 +30,7 @@ use std::mem;
 pub struct WriteHandler {
     pub(crate) store: BlockStore,
     pub(crate) context: Option<WriteContext>,
-    pub(crate) file: Option<BlockDevice>,
+    pub(crate) file: Option<BlockWriteContext>,
     pub(crate) is_commit: bool,
     pub(crate) io_slow_us: u64,
     pub(crate) metrics: &'static WorkerMetrics,
@@ -50,7 +50,7 @@ impl WriteHandler {
         })
     }
 
-    pub fn resize(file: &mut BlockDevice, ctx: &WriteContext) -> FsResult<()> {
+    pub fn resize(file: &mut BlockWriteContext, ctx: &WriteContext) -> FsResult<()> {
         let opts = if let Some(opts) = &ctx.block.alloc_opts {
             opts
         } else {
@@ -64,22 +64,20 @@ impl WriteHandler {
                 ctx.block_size
             );
         }
-        // SPDK: NVMe namespace has fixed capacity, just validate fits.
-        if !file.supports_short_circuit() {
+        if !file.supports_resize() {
             return Ok(());
         }
 
-        // Remove KEEP_SIZE flag to fix length mismatch at finalization.
         let mut mode = opts.mode;
         mode.remove(FileAllocMode::KEEP_SIZE);
         file.resize(opts.truncate, opts.off, opts.len, mode.bits())?;
 
-        if opts.len != file.len() {
+        if opts.len != file.device_len() {
             return err_box!(
                 "invalid resize file {} operation: resize {} != actual {}, opts={:?}",
                 file.path(),
                 opts.len,
-                file.len(),
+                file.device_len(),
                 opts
             );
         }
@@ -89,7 +87,7 @@ impl WriteHandler {
 
     pub fn open(&mut self, msg: &Message) -> FsResult<Message> {
         let context = WriteContext::from_req(msg)?;
-        if context.off > context.block_size {
+        if context.off < 0 || context.off > context.block_size {
             return err_box!(
                 "Invalid write offset: {}, block size: {}",
                 context.off,
@@ -104,12 +102,12 @@ impl WriteHandler {
         };
 
         let meta = self.store.open_block(&open_block)?;
-        let mut file = match meta.create_writer(context.off, false) {
+        let mut file = match self.store.open_writer(&meta, context.off) {
             Ok(file) => file,
             Err(e) => {
                 if let Err(abort_err) = self.store.abort_block(&context.block) {
                     log::warn!(
-                        "failed to abort block {} after create_writer error: {}",
+                        "failed to abort block {} after open_writer error: {}",
                         context.block.id,
                         abort_err
                     );
@@ -117,7 +115,6 @@ impl WriteHandler {
                 return Err(e.into());
             }
         };
-        // check file resize
         if let Err(e) = Self::resize(&mut file, &context) {
             drop(file);
             if let Err(abort_err) = self.store.abort_block(&context.block) {
@@ -130,9 +127,29 @@ impl WriteHandler {
             return Err(e);
         }
 
-        let is_short_circuit = context.short_circuit && file.supports_short_circuit();
-        let (label, path, file) = if is_short_circuit {
-            ("local", file.path().to_string(), None)
+        // Same source of truth as the read path: layout decides short-circuit
+        // eligibility and the local path (None for layouts without one, e.g. bdev).
+        let sc_path = if context.short_circuit {
+            match self.store.short_circuit(&meta) {
+                Ok(path) => path,
+                Err(e) => {
+                    drop(file);
+                    if let Err(abort_err) = self.store.abort_block(&context.block) {
+                        log::warn!(
+                            "failed to abort block {} after short_circuit error: {}",
+                            context.block.id,
+                            abort_err
+                        );
+                    }
+                    return Err(e.into());
+                }
+            }
+        } else {
+            None
+        };
+        let is_short_circuit = sc_path.is_some();
+        let (label, path, file) = if let Some(path) = sc_path {
+            ("local", path, None)
         } else {
             ("remote", file.path().to_string(), Some(file))
         };
@@ -181,10 +198,8 @@ impl WriteHandler {
         let context = try_option_mut!(self.context);
         Self::check_context(context, msg)?;
 
-        // msg.header
         if msg.header_len() > 0 {
             let header: DataHeaderProto = msg.parse_header()?;
-            // Flush operation should not trigger seek or boundary check
             if !header.flush {
                 if header.offset < 0 || header.offset >= context.block_size {
                     return err_box!(
@@ -193,36 +208,12 @@ impl WriteHandler {
                         context.block_size
                     );
                 }
-                // SPDK: file.pos()/seek() = absolute bdev offset
-                let abs_offset = if file.supports_short_circuit() {
-                    header.offset
-                } else {
-                    (file.len() - context.block_size) + header.offset
-                };
-                file.seek(abs_offset)?;
+                file.seek_to(header.offset)?;
             }
         }
 
-        // Write existing data blocks.
         let data_len = msg.data_len() as i64;
         if data_len > 0 {
-            // SPDK: pos() = absolute bdev offset
-            let write_limit = if file.supports_short_circuit() {
-                // Local files: pos() is relative to file start
-                context.block_size
-            } else {
-                // SPDK bdevs: pos() is absolute, len() is the upper bound
-                file.len()
-            };
-            if file.pos() + data_len > write_limit {
-                return err_box!(
-                    "Write range [{}, {}) exceeds block size {}",
-                    file.pos(),
-                    file.pos() + data_len,
-                    context.block_size
-                );
-            }
-
             let spend = TimeSpent::new();
             file.write_region(&msg.data)?;
 
@@ -266,14 +257,30 @@ impl WriteHandler {
         }
         let context = WriteContext::from_req(msg)?;
 
-        // flush and close the file.
         let file = self.file.take();
         if let Some(mut file) = file {
-            file.flush()?;
+            if let Err(flush_err) = file.flush() {
+                drop(file);
+                if let Err(abort_err) = self.store.abort_block(&context.block) {
+                    log::warn!(
+                        "failed to abort block {} after flush error: {}",
+                        context.block.id,
+                        abort_err
+                    );
+                }
+                return Err(flush_err.into());
+            }
             drop(file);
         }
 
         if context.block.len > context.block_size {
+            if let Err(abort_err) = self.store.abort_block(&context.block) {
+                log::warn!(
+                    "failed to abort block {} after length check failed: {}",
+                    context.block.id,
+                    abort_err
+                );
+            }
             return err_box!(
                 "Invalid write offset: {}, block size: {}",
                 context.block.len,
@@ -281,7 +288,6 @@ impl WriteHandler {
             );
         }
 
-        // Submit block.
         self.commit_block(&context.block, commit)?;
         self.is_commit = true;
 

--- a/curvine-server/src/worker/replication/worker_replication_manager.rs
+++ b/curvine-server/src/worker/replication/worker_replication_manager.rs
@@ -22,7 +22,6 @@ use curvine_common::proto::{ReportBlockReplicationRequest, ReportBlockReplicatio
 use curvine_common::state::{ExtendedBlock, FileType};
 use log::{error, info};
 use once_cell::sync::OnceCell;
-use orpc::io::BlockIO;
 use orpc::runtime::{AsyncRuntime, RpcRuntime};
 use orpc::{err_box, CommonResult};
 use std::sync::Arc;
@@ -142,13 +141,14 @@ impl WorkerReplicationManager {
             0,
         )
         .await?;
-        let mut reader = block_meta.create_reader(0)?;
+        let mut reader = self.block_store.open_reader(&block_meta, 0)?;
         let mut remaining = block_meta.len;
         while remaining > 0 {
             let size = remaining.min(self.replicate_chunk_size as i64);
             let slice = reader.read_region(true, size as i32)?;
+            let read_len = slice.len() as i64;
             writer.write(slice).await?;
-            remaining -= size;
+            remaining -= read_len;
         }
         writer.flush().await?;
         writer.complete().await?;

--- a/curvine-server/src/worker/storage/block_io_context.rs
+++ b/curvine-server/src/worker/storage/block_io_context.rs
@@ -233,7 +233,7 @@ mod tests {
     use std::fs::remove_file;
 
     /// Open the underlying LocalFile at position 0 (no pre-positioning) so
-    /// `BlockIOContext::new` is solely responsible for establishing the
+    /// `Block{Read,Write}Context::new` is solely responsible for establishing the
     /// `device.pos() == device_base + block_pos` invariant. This mirrors the
     /// shared-device scenario (bdev/pool) that the abstraction targets.
     fn shared_write_device(path: &str) -> IOResult<BlockDevice> {

--- a/curvine-server/src/worker/storage/block_io_context.rs
+++ b/curvine-server/src/worker/storage/block_io_context.rs
@@ -233,9 +233,10 @@ mod tests {
     use std::fs::remove_file;
 
     /// Open the underlying LocalFile at position 0 (no pre-positioning) so
-    /// `Block{Read,Write}Context::new` is solely responsible for establishing the
-    /// `device.pos() == device_base + block_pos` invariant. This mirrors the
-    /// shared-device scenario (bdev/pool) that the abstraction targets.
+    /// `BlockWriteContext::new` / `BlockReadContext::new` are solely responsible
+    /// for establishing the `device.pos() == device_base + block_pos` invariant.
+    /// This mirrors the shared-device scenario (bdev/pool) that the abstraction
+    /// targets.
     fn shared_write_device(path: &str) -> IOResult<BlockDevice> {
         Ok(BlockDevice::Local(LocalFile::with_write(path, false)?))
     }

--- a/curvine-server/src/worker/storage/block_io_context.rs
+++ b/curvine-server/src/worker/storage/block_io_context.rs
@@ -1,0 +1,324 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use orpc::io::{BlockDevice, BlockIO, IOError, IOResult, LocalFile};
+use orpc::sys::DataSlice;
+use orpc::{err_box, try_err};
+
+fn absolute_offset(device_base: i64, block_off: i64) -> IOResult<i64> {
+    device_base
+        .checked_add(block_off)
+        .ok_or_else(|| IOError::from("absolute block offset overflow"))
+}
+
+/// Block-relative write session produced by layout.
+pub struct BlockWriteContext {
+    device: BlockDevice,
+    /// Base offset of the block on the backing device (0 for file-backed blocks).
+    device_base: i64,
+    block_size: i64,
+    block_pos: i64,
+}
+
+impl BlockWriteContext {
+    /// Establish the invariant `device.pos() == device_base + block_pos` by
+    /// unconditionally seeking the underlying device. Callers must not rely on
+    /// the layout having pre-positioned the device.
+    pub fn new(
+        mut device: BlockDevice,
+        device_base: i64,
+        block_size: i64,
+        initial_off: i64,
+    ) -> IOResult<Self> {
+        if initial_off < 0 || initial_off > block_size {
+            return err_box!(
+                "Invalid initial offset: {}, block length: {}",
+                initial_off,
+                block_size
+            );
+        }
+        let absolute = absolute_offset(device_base, initial_off)?;
+        try_err!(device.seek(absolute));
+        Ok(Self {
+            device,
+            device_base,
+            block_size,
+            block_pos: initial_off,
+        })
+    }
+
+    pub fn path(&self) -> &str {
+        self.device.path()
+    }
+
+    pub fn block_pos(&self) -> i64 {
+        self.block_pos
+    }
+
+    pub fn supports_resize(&self) -> bool {
+        self.device.supports_resize()
+    }
+
+    pub fn seek_to(&mut self, block_off: i64) -> IOResult<()> {
+        if block_off < 0 || block_off > self.block_size {
+            return err_box!(
+                "Invalid seek offset: {}, block length: {}",
+                block_off,
+                self.block_size
+            );
+        }
+        if block_off != self.block_pos {
+            let absolute = absolute_offset(self.device_base, block_off)?;
+            try_err!(self.device.seek(absolute));
+            self.block_pos = block_off;
+        }
+        Ok(())
+    }
+
+    pub fn write_region(&mut self, region: &DataSlice) -> IOResult<()> {
+        let data_len = region.len() as i64;
+        let Some(write_end) = self.block_pos.checked_add(data_len) else {
+            return err_box!(
+                "Write range overflow: offset={}, length={}",
+                self.block_pos,
+                data_len
+            );
+        };
+        if write_end > self.block_size {
+            return err_box!(
+                "Write range [{}, {}) exceeds block size {}",
+                self.block_pos,
+                write_end,
+                self.block_size
+            );
+        }
+        try_err!(self.device.write_region(region));
+        self.block_pos = write_end;
+        Ok(())
+    }
+
+    pub fn flush(&mut self) -> IOResult<()> {
+        self.device.flush()
+    }
+
+    /// Callers must gate on `supports_resize()`; see `WriteHandler::resize`.
+    pub fn resize(&mut self, truncate: bool, block_off: i64, len: i64, mode: i32) -> IOResult<()> {
+        if block_off < 0 || len < 0 {
+            return err_box!("Invalid resize range: offset={}, length={}", block_off, len);
+        }
+        let resize_end = block_off.checked_add(len).ok_or_else(|| {
+            IOError::from(format!(
+                "Resize range overflow: offset={}, length={}",
+                block_off, len
+            ))
+        })?;
+        if resize_end > self.block_size {
+            return err_box!(
+                "Resize range [{}, {}) exceeds block size {}",
+                block_off,
+                resize_end,
+                self.block_size
+            );
+        }
+        let absolute = absolute_offset(self.device_base, block_off)?;
+        try_err!(self.device.resize(truncate, absolute, len, mode));
+        Ok(())
+    }
+
+    pub fn device_len(&self) -> i64 {
+        self.device.len()
+    }
+}
+
+/// Block-relative read session produced by layout.
+pub struct BlockReadContext {
+    device: BlockDevice,
+    /// Base offset of the block on the backing device (0 for file-backed blocks).
+    device_base: i64,
+    block_size: i64,
+    block_pos: i64,
+}
+
+impl BlockReadContext {
+    /// Establish the invariant `device.pos() == device_base + block_pos` by
+    /// unconditionally seeking the underlying device. Callers must not rely on
+    /// the layout having pre-positioned the device.
+    pub fn new(
+        mut device: BlockDevice,
+        device_base: i64,
+        block_size: i64,
+        initial_off: i64,
+    ) -> IOResult<Self> {
+        if initial_off < 0 || initial_off > block_size {
+            return err_box!(
+                "Invalid initial offset: {}, block length: {}",
+                initial_off,
+                block_size
+            );
+        }
+        let absolute = absolute_offset(device_base, initial_off)?;
+        try_err!(device.seek(absolute));
+        Ok(Self {
+            device,
+            device_base,
+            block_size,
+            block_pos: initial_off,
+        })
+    }
+
+    pub fn path(&self) -> &str {
+        self.device.path()
+    }
+
+    pub fn block_pos(&self) -> i64 {
+        self.block_pos
+    }
+
+    pub fn seek_to(&mut self, block_off: i64) -> IOResult<()> {
+        if block_off < 0 || block_off > self.block_size {
+            return err_box!(
+                "Invalid seek offset: {}, block length: {}",
+                block_off,
+                self.block_size
+            );
+        }
+        if block_off != self.block_pos {
+            let absolute = absolute_offset(self.device_base, block_off)?;
+            try_err!(self.device.seek(absolute));
+            self.block_pos = block_off;
+        }
+        Ok(())
+    }
+
+    pub fn read_region(&mut self, enable_send_file: bool, len: i32) -> IOResult<DataSlice> {
+        let remaining = self.block_size - self.block_pos;
+        let read_len = (len as i64).min(remaining);
+        if read_len <= 0 {
+            return err_box!(
+                "offset exceeds block length, length={}, offset={}",
+                self.block_size,
+                self.block_pos
+            );
+        }
+        let region = self.device.read_region(enable_send_file, read_len as i32)?;
+        // Advance by the bytes represented by the returned region.
+        self.block_pos += region.len() as i64;
+        Ok(region)
+    }
+
+    pub fn supports_send_file(&self) -> bool {
+        self.device.supports_send_file()
+    }
+
+    pub fn as_local_mut(&mut self) -> Option<&mut LocalFile> {
+        self.device.as_local_mut()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use orpc::common::Utils;
+    use std::fs::remove_file;
+
+    /// Open the underlying LocalFile at position 0 (no pre-positioning) so
+    /// `BlockIOContext::new` is solely responsible for establishing the
+    /// `device.pos() == device_base + block_pos` invariant. This mirrors the
+    /// shared-device scenario (bdev/pool) that the abstraction targets.
+    fn shared_write_device(path: &str) -> IOResult<BlockDevice> {
+        Ok(BlockDevice::Local(LocalFile::with_write(path, false)?))
+    }
+
+    fn shared_read_device(path: &str) -> IOResult<BlockDevice> {
+        Ok(BlockDevice::Local(LocalFile::with_read(path, 0)?))
+    }
+
+    fn ensure_parent(path: &str) -> std::io::Result<()> {
+        if let Some(parent) = std::path::Path::new(path).parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn read_context_translates_block_relative_offsets() -> Result<(), Box<dyn std::error::Error>> {
+        let path = Utils::test_file();
+        ensure_parent(&path)?;
+        LocalFile::write_string(&path, "AAAAbbbbccccDDDD", true)?;
+
+        let device = shared_read_device(&path)?;
+        let mut ctx = BlockReadContext::new(device, 4, 8, 0)?;
+        let region = ctx.read_region(false, 2)?;
+        let bytes = match &region {
+            DataSlice::Bytes(b) => &b[..],
+            DataSlice::Buffer(b) => &b[..],
+            other => panic!("unexpected slice variant: {:?}", other),
+        };
+        assert_eq!(bytes, b"bb");
+
+        ctx.seek_to(4)?;
+        let region = ctx.read_region(false, 4)?;
+        let bytes = match &region {
+            DataSlice::Bytes(b) => &b[..],
+            DataSlice::Buffer(b) => &b[..],
+            other => panic!("unexpected slice variant: {:?}", other),
+        };
+        assert_eq!(bytes, b"cccc");
+
+        let _ = remove_file(&path);
+        Ok(())
+    }
+
+    /// Non-zero `device_base` plus in-block seek must translate correctly and
+    /// still enforce boundary checks against `block_size`, not device length.
+    #[test]
+    fn write_context_translates_offsets_with_boundary() -> Result<(), Box<dyn std::error::Error>> {
+        let path = Utils::test_file();
+        ensure_parent(&path)?;
+        LocalFile::write_string(&path, "AAAAxxxxxxxxCCCC", true)?;
+
+        let device = shared_write_device(&path)?;
+        let mut ctx = BlockWriteContext::new(device, 4, 8, 0)?;
+
+        let data = DataSlice::Bytes(bytes::Bytes::from_static(b"BB"));
+        ctx.write_region(&data)?;
+        ctx.seek_to(4)?;
+        let data = DataSlice::Bytes(bytes::Bytes::from_static(b"YY"));
+        ctx.write_region(&data)?;
+        assert_eq!(ctx.block_pos(), 6);
+
+        // Seek exactly to EOF of the block is allowed; any subsequent write must fail.
+        ctx.seek_to(8)?;
+        assert_eq!(ctx.block_pos(), 8);
+        let overflow = DataSlice::Bytes(bytes::Bytes::from_static(b"Z"));
+        let err = ctx.write_region(&overflow).unwrap_err().to_string();
+        assert!(err.contains("exceeds block size"));
+
+        // Beyond block_size seek is rejected.
+        let err = ctx.seek_to(9).unwrap_err().to_string();
+        assert!(err.contains("Invalid seek offset"));
+
+        drop(ctx);
+        let raw = std::fs::read(&path)?;
+        assert_eq!(&raw[..4], b"AAAA");
+        assert_eq!(&raw[4..6], b"BB");
+        assert_eq!(&raw[6..8], b"xx");
+        assert_eq!(&raw[8..10], b"YY");
+        assert_eq!(&raw[10..12], b"xx");
+        assert_eq!(&raw[12..16], b"CCCC");
+
+        let _ = remove_file(&path);
+        Ok(())
+    }
+}

--- a/curvine-server/src/worker/storage/layout/bdev_layout.rs
+++ b/curvine-server/src/worker/storage/layout/bdev_layout.rs
@@ -13,12 +13,16 @@
 // limitations under the License.
 
 use crate::worker::block::{BlockMeta, BlockState};
-use crate::worker::storage::layout::BlockLayout;
-use crate::worker::storage::{SpdkMetaStore, VfsDir};
+use crate::worker::storage::layout::{validate_open_offset, BlockLayout};
+use crate::worker::storage::{BlockReadContext, BlockWriteContext, SpdkMetaStore, VfsDir};
 use curvine_common::state::ExtendedBlock;
 use log::{info, warn};
-use orpc::CommonResult;
+use orpc::io::IOResult;
+use orpc::{err_box, CommonResult};
 use std::sync::Arc;
+
+#[cfg(feature = "spdk")]
+use orpc::io::{BlockDevice, IOError, SpdkBdev};
 
 #[derive(Clone)]
 pub struct BdevLayout {
@@ -102,5 +106,75 @@ impl BlockLayout for BdevLayout {
     // SPDK blocks have no filesystem file; offset release happens in release().
     fn deallocate(&self, _meta: &BlockMeta) -> CommonResult<()> {
         Ok(())
+    }
+
+    fn open_writer(&self, meta: &BlockMeta, off: i64) -> IOResult<BlockWriteContext> {
+        validate_open_offset(meta, off)?;
+        #[cfg(feature = "spdk")]
+        {
+            let bdev_name = meta.get_bdev_name()?;
+            let abs_offset = meta.bdev_offset.checked_add(off).ok_or_else(|| {
+                IOError::from(format!(
+                    "Block write offset overflow: base={}, offset={}",
+                    meta.bdev_offset, off
+                ))
+            })?;
+            let max_len = 0.max(meta.len - off);
+            info!(
+                "Opening SPDK bdev '{}' for writing at offset {} (block {} base={}, max_len={})",
+                bdev_name, abs_offset, meta.id, meta.bdev_offset, max_len
+            );
+            if max_len == 0 {
+                return err_box!("Cannot open SPDK writer: no space remaining");
+            }
+            let bdev = SpdkBdev::open_write(&bdev_name, abs_offset, max_len)?;
+            let device = BlockDevice::Spdk(bdev);
+            BlockWriteContext::new(device, meta.bdev_offset, meta.len, off)
+        }
+        #[cfg(not(feature = "spdk"))]
+        {
+            let _ = (meta, off);
+            err_box!("SPDK support not compiled in")
+        }
+    }
+
+    fn open_reader(&self, meta: &BlockMeta, off: i64) -> IOResult<BlockReadContext> {
+        validate_open_offset(meta, off)?;
+        #[cfg(feature = "spdk")]
+        {
+            let bdev_name = meta.get_bdev_name()?;
+            let abs_offset = meta.bdev_offset.checked_add(off).ok_or_else(|| {
+                IOError::from(format!(
+                    "Block read offset overflow: base={}, offset={}",
+                    meta.bdev_offset, off
+                ))
+            })?;
+            let abs_offset = u64::try_from(abs_offset).map_err(|_| {
+                IOError::from(format!(
+                    "Invalid absolute block read offset: {}",
+                    abs_offset
+                ))
+            })?;
+            let max_len = 0.max(meta.len - off);
+            info!(
+                "Opening SPDK bdev '{}' for reading at offset {} (block {} base={}, max_len={})",
+                bdev_name, abs_offset, meta.id, meta.bdev_offset, max_len
+            );
+            if max_len == 0 {
+                return err_box!("Cannot open SPDK reader: no space remaining");
+            }
+            let bdev = SpdkBdev::open_read(&bdev_name, abs_offset, max_len)?;
+            let device = BlockDevice::Spdk(bdev);
+            BlockReadContext::new(device, meta.bdev_offset, meta.len, off)
+        }
+        #[cfg(not(feature = "spdk"))]
+        {
+            let _ = (meta, off);
+            err_box!("SPDK support not compiled in")
+        }
+    }
+
+    fn short_circuit(&self, _meta: &BlockMeta) -> CommonResult<Option<String>> {
+        Ok(None)
     }
 }

--- a/curvine-server/src/worker/storage/layout/file_layout.rs
+++ b/curvine-server/src/worker/storage/layout/file_layout.rs
@@ -13,10 +13,11 @@
 // limitations under the License.
 
 use crate::worker::block::{BlockMeta, BlockState};
-use crate::worker::storage::layout::BlockLayout;
-use crate::worker::storage::VfsDir;
+use crate::worker::storage::layout::{validate_open_offset, BlockLayout};
+use crate::worker::storage::{BlockReadContext, BlockWriteContext, VfsDir};
 use curvine_common::state::ExtendedBlock;
 use orpc::common::FileUtils;
+use orpc::io::{BlockDevice, IOError, IOResult, LocalFile};
 use orpc::CommonResult;
 use std::fs::File;
 
@@ -63,5 +64,25 @@ impl BlockLayout for FileLayout {
     fn deallocate(&self, meta: &BlockMeta) -> CommonResult<()> {
         FileUtils::delete_path(meta.get_block_path()?, false)?;
         Ok(())
+    }
+
+    fn open_writer(&self, meta: &BlockMeta, off: i64) -> IOResult<BlockWriteContext> {
+        validate_open_offset(meta, off)?;
+        let file = meta.get_block_file()?;
+        let device = BlockDevice::Local(LocalFile::with_write_offset(file, false, off)?);
+        BlockWriteContext::new(device, 0, meta.len, off)
+    }
+
+    fn open_reader(&self, meta: &BlockMeta, off: i64) -> IOResult<BlockReadContext> {
+        validate_open_offset(meta, off)?;
+        let read_off = u64::try_from(off)
+            .map_err(|_| IOError::from(format!("Invalid read offset: {}", off)))?;
+        let file = meta.get_block_file()?;
+        let device = BlockDevice::Local(LocalFile::with_read(file, read_off)?);
+        BlockReadContext::new(device, 0, meta.len, off)
+    }
+
+    fn short_circuit(&self, meta: &BlockMeta) -> CommonResult<Option<String>> {
+        Ok(Some(meta.get_block_file()?))
     }
 }

--- a/curvine-server/src/worker/storage/layout/mod.rs
+++ b/curvine-server/src/worker/storage/layout/mod.rs
@@ -19,10 +19,18 @@ pub use self::bdev_layout::BdevLayout;
 pub use self::file_layout::FileLayout;
 
 use crate::worker::block::BlockMeta;
-use crate::worker::storage::{SpdkMetaStore, VfsDir};
+use crate::worker::storage::{BlockReadContext, BlockWriteContext, SpdkMetaStore, VfsDir};
 use curvine_common::state::{ExtendedBlock, StorageType};
-use orpc::CommonResult;
+use orpc::io::IOResult;
+use orpc::{err_box, CommonResult};
 use std::sync::Arc;
+
+fn validate_open_offset(meta: &BlockMeta, off: i64) -> IOResult<()> {
+    if off < 0 || off > meta.len {
+        return err_box!("Invalid block offset: {}, block length: {}", off, meta.len);
+    }
+    Ok(())
+}
 
 pub trait BlockLayout {
     fn allocate(&self, dir: &VfsDir, block: &ExtendedBlock) -> CommonResult<BlockMeta>;
@@ -36,6 +44,15 @@ pub trait BlockLayout {
 
     /// Remove backing resources. Callers may run this outside the dataset lock.
     fn deallocate(&self, meta: &BlockMeta) -> CommonResult<()>;
+
+    fn open_writer(&self, meta: &BlockMeta, off: i64) -> IOResult<BlockWriteContext>;
+
+    fn open_reader(&self, meta: &BlockMeta, off: i64) -> IOResult<BlockReadContext>;
+
+    /// Local path a co-located client can open directly, `Ok(None)` if the
+    /// layout cannot expose one (e.g. raw bdev). Errors are propagated so
+    /// callers can distinguish "not eligible" from "path resolution failed".
+    fn short_circuit(&self, meta: &BlockMeta) -> CommonResult<Option<String>>;
 }
 
 #[derive(Clone)]
@@ -109,6 +126,27 @@ impl BlockLayout for BlockLayoutKind {
         match self {
             Self::File(layout) => layout.deallocate(meta),
             Self::Bdev(layout) => layout.deallocate(meta),
+        }
+    }
+
+    fn open_writer(&self, meta: &BlockMeta, off: i64) -> IOResult<BlockWriteContext> {
+        match self {
+            Self::File(layout) => layout.open_writer(meta, off),
+            Self::Bdev(layout) => layout.open_writer(meta, off),
+        }
+    }
+
+    fn open_reader(&self, meta: &BlockMeta, off: i64) -> IOResult<BlockReadContext> {
+        match self {
+            Self::File(layout) => layout.open_reader(meta, off),
+            Self::Bdev(layout) => layout.open_reader(meta, off),
+        }
+    }
+
+    fn short_circuit(&self, meta: &BlockMeta) -> CommonResult<Option<String>> {
+        match self {
+            Self::File(layout) => layout.short_circuit(meta),
+            Self::Bdev(layout) => layout.short_circuit(meta),
         }
     }
 }

--- a/curvine-server/src/worker/storage/mod.rs
+++ b/curvine-server/src/worker/storage/mod.rs
@@ -39,6 +39,9 @@ pub use self::meta_store::*;
 mod layout;
 pub use self::layout::*;
 
+mod block_io_context;
+pub use self::block_io_context::{BlockReadContext, BlockWriteContext};
+
 mod vfs_dataset;
 pub use self::vfs_dataset::VfsDataset;
 

--- a/curvine-server/src/worker/storage/vfs_dataset.rs
+++ b/curvine-server/src/worker/storage/vfs_dataset.rs
@@ -221,6 +221,10 @@ impl VfsDataset {
         self.release_block_space(&meta)?;
         Ok(meta)
     }
+
+    pub fn layout_for(&self, meta: &BlockMeta) -> BlockLayoutKind {
+        self.layouts.get(meta.storage_type()).clone()
+    }
 }
 
 impl Dataset for VfsDataset {

--- a/curvine-server/tests/worker_test.rs
+++ b/curvine-server/tests/worker_test.rs
@@ -98,7 +98,7 @@ fn test_worker_complete_oversized_block_aborts_pending_block() -> CommonResult<(
         .proto_header(request)
         .build();
     let err = client.rpc_check(complete).unwrap_err();
-    assert!(err.to_string().contains("Invalid write offset"));
+    assert!(err.to_string().contains("Invalid block length"));
 
     let read_client = conf.worker_sync_client()?;
     let read = BlockReadRequest {

--- a/curvine-server/tests/worker_test.rs
+++ b/curvine-server/tests/worker_test.rs
@@ -19,7 +19,7 @@ use curvine_common::proto::{
     BlocksBatchCommitRequest, BlocksBatchWriteRequest, BlocksBatchWriteResponse, DataHeaderProto,
     FileWriteData, FilesBatchWriteRequest,
 };
-use curvine_common::state::{ExtendedBlock, FileType, StorageType};
+use curvine_common::state::{ExtendedBlock, FileAllocOpts, FileType, StorageType};
 use curvine_common::utils::ProtoUtils;
 use curvine_server::worker::Worker;
 use orpc::common::Utils;
@@ -60,6 +60,69 @@ fn test_worker_block_write_and_read_with_checksum_validation() -> CommonResult<(
     let read_ck = block_read(block_id, &conf)?;
 
     assert_eq!(write_ck, read_ck);
+    Ok(())
+}
+
+#[test]
+fn test_worker_complete_oversized_block_aborts_pending_block() -> CommonResult<()> {
+    let conf = start_worker();
+    let client = conf.worker_sync_client()?;
+    let block_id = Utils::req_id().abs();
+    let block_size = CHUNK_SIZE as i64;
+    let block = ExtendedBlock::new(block_id, block_size + 1, StorageType::Disk, FileType::File);
+    let request = BlockWriteRequest {
+        block: ProtoUtils::extend_block_to_pb(block),
+        off: 0,
+        block_size,
+        short_circuit: false,
+        client_name: "test".to_string(),
+        chunk_size: CHUNK_SIZE,
+        pipeline_stream: Vec::new(),
+    };
+    let req_id = Utils::req_id();
+
+    let open = Builder::new()
+        .code(RpcCode::WriteBlock)
+        .request(RequestStatus::Open)
+        .req_id(req_id)
+        .seq_id(0)
+        .proto_header(request.clone())
+        .build();
+    let _: BlockWriteResponse = client.rpc_check(open)?.parse_header()?;
+
+    let complete = Builder::new()
+        .code(RpcCode::WriteBlock)
+        .request(RequestStatus::Complete)
+        .req_id(req_id)
+        .seq_id(1)
+        .proto_header(request)
+        .build();
+    let err = client.rpc_check(complete).unwrap_err();
+    assert!(err.to_string().contains("Invalid write offset"));
+
+    let read_client = conf.worker_sync_client()?;
+    let read = BlockReadRequest {
+        id: block_id,
+        off: 0,
+        len: 1,
+        chunk_size: CHUNK_SIZE,
+        short_circuit: false,
+        ..Default::default()
+    };
+    let read_open = Builder::new()
+        .code(RpcCode::ReadBlock)
+        .request(RequestStatus::Open)
+        .req_id(Utils::req_id())
+        .seq_id(0)
+        .proto_header(read)
+        .build();
+    let err = read_client.rpc_check(read_open).unwrap_err();
+    assert!(
+        err.to_string()
+            .contains(&format!("Block {} not found", block_id)),
+        "unexpected read error: {err}"
+    );
+
     Ok(())
 }
 
@@ -361,6 +424,69 @@ fn block_write(id: i64, conf: &ClusterConf) -> CommonResult<u64> {
     let _: Message = client.rpc(msg)?;
 
     Ok(checksum)
+}
+
+#[test]
+fn test_worker_short_circuit_open_resizes_block_file() -> CommonResult<()> {
+    let conf = start_worker();
+    let block_id = Utils::req_id().abs();
+    let block_size = CHUNK_SIZE as i64;
+    let target_len = block_size / 2;
+    let mut block = ExtendedBlock::new(block_id, target_len, StorageType::Disk, FileType::File);
+    block.alloc_opts = Some(FileAllocOpts::with_truncate(target_len));
+
+    let request = BlockWriteRequest {
+        block: ProtoUtils::extend_block_to_pb(block.clone()),
+        off: 0,
+        block_size,
+        short_circuit: true,
+        client_name: "test".to_string(),
+        chunk_size: CHUNK_SIZE,
+        pipeline_stream: Vec::new(),
+    };
+
+    let req_id = Utils::req_id();
+    let open = Builder::new()
+        .code(RpcCode::WriteBlock)
+        .request(RequestStatus::Open)
+        .req_id(req_id)
+        .seq_id(0)
+        .proto_header(request)
+        .build();
+
+    let client = conf.worker_sync_client()?;
+    let response: BlockWriteResponse = client.rpc(open)?.parse_header()?;
+    let path = response
+        .path
+        .as_ref()
+        .expect("short-circuit write should return local path");
+    assert_eq!(
+        std::fs::metadata(path)?.len(),
+        target_len as u64,
+        "short-circuit open must apply alloc_opts resize on worker before client writes"
+    );
+
+    block.len = target_len;
+    let complete_block = ProtoUtils::extend_block_to_pb(block);
+    let complete = BlockWriteRequest {
+        block: complete_block,
+        off: 0,
+        block_size,
+        short_circuit: true,
+        client_name: "test".to_string(),
+        chunk_size: CHUNK_SIZE,
+        pipeline_stream: Vec::new(),
+    };
+    let complete_msg = Builder::new()
+        .code(RpcCode::WriteBlock)
+        .request(RequestStatus::Complete)
+        .req_id(req_id)
+        .seq_id(1)
+        .proto_header(complete)
+        .build();
+    let _: Message = client.rpc(complete_msg)?;
+
+    Ok(())
 }
 
 fn block_read(id: i64, conf: &ClusterConf) -> CommonResult<u64> {

--- a/orpc/src/io/block_io.rs
+++ b/orpc/src/io/block_io.rs
@@ -96,6 +96,11 @@ impl BlockDevice {
     pub fn supports_short_circuit(&self) -> bool {
         matches!(self, BlockDevice::Local(_))
     }
+    /// Whether this device supports resize (fallocate/truncate).
+    /// SPDK blocks live in pre-allocated bdev extents; resize is meaningless.
+    pub fn supports_resize(&self) -> bool {
+        matches!(self, BlockDevice::Local(_))
+    }
     /// Get the inner `LocalFile`, if this is a local device.
     #[allow(unreachable_patterns)]
     pub fn as_local(&self) -> Option<&LocalFile> {


### PR DESCRIPTION
# Summary

Refactor worker block I/O so handlers operate only on block-relative
offsets. Layout-specific open logic and absolute device addressing are
moved behind `BlockLayout` and `BlockRead/WriteContext`, without changing
the intended remote read/write behavior.

# Issue Describe / Design

No tracking issue yet.

### Why

Worker read/write handlers previously mixed two coordinate systems:

- local files used offsets relative to the block/file start
- SPDK bdevs used absolute device offsets, forcing handlers to special-case
  `bdev_offset`, `supports_short_circuit()`, and device `len()`/`pos()`

That made layout knowledge leak into the RPC session layer and made every
new storage backend a handler change.

### Approach

1. Keep `BlockMeta` as metadata only.
2. Make `BlockLayout` responsible for opening a block-scoped I/O session.
3. Introduce `BlockWriteContext` / `BlockReadContext` as the single place that:
   - stores `device_base`
   - translates block offsets to absolute device offsets
   - enforces block-size boundaries
4. Let handlers call `seek_to` / `read_region` / `write_region` without knowing
   whether the backend is a file or a bdev.

### Trade-offs

- Short-circuit remains a path handoff to the co-located client; it does not use
  `Block*Context` for data I/O, because the client already opens a per-block file
  and operates in block-relative coordinates.
- Capability probes such as `supports_resize()` / `supports_send_file()` /
  `as_local_mut()` remain as intentional escape hatches for filesystem-only
  features.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-server/.../block_io_context.rs` | New block-relative write/read session wrappers | None |
| `curvine-server/.../layout/mod.rs` | Extend `BlockLayout` with open/short-circuit APIs and shared offset validation | None |
| `curvine-server/.../layout/file_layout.rs` | File-backed open + short-circuit path | None |
| `curvine-server/.../layout/bdev_layout.rs` | SPDK-backed open; short-circuit returns `None` | None |
| `curvine-server/.../block_store.rs` | Store-level open/short-circuit delegation | None |
| `curvine-server/.../read_handler.rs` | Consume `BlockReadContext` | None for valid traffic; clearer offset handling |
| `curvine-server/.../write_handler.rs` | Consume `BlockWriteContext`; better flush/length-check abort | Cleanup on invalid complete is safer |
| `curvine-server/.../batch_write_handler.rs` | Track `BlockWriteContext` instead of raw devices | None |
| `curvine-server/.../worker_replication_manager.rs` | Use store open + actual read length | More correct under short reads |
| `curvine-server/tests/worker_test.rs` | Add abort and short-circuit resize regressions | Coverage only |
| `orpc/src/io/block_io.rs` | Add `supports_resize()` | None |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `make format` | PASS | |
| `cargo test -p curvine-server --test worker_test -- --test-threads=1` | PASS | Includes oversized-complete abort and short-circuit resize coverage |
| `cargo test -p curvine-server --lib block_io -- --test-threads=1` | PASS | Block-relative offset translation unit tests |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None