### PR TITLE
fix(worker): support legacy SPDK storage prefix

### DIFF
--- a/curvine-common/src/state/storage_info.rs
+++ b/curvine-common/src/state/storage_info.rs
@@ -75,7 +75,7 @@ impl TryFrom<&str> for StorageType {
             "HDD" => Self::Hdd,
             "UFS" => Self::Ufs,
             "DISK" => Self::Disk,
-            "SPDK_DISK" => Self::SpdkDisk,
+            "SPDK" | "SPDK_DISK" => Self::SpdkDisk,
 
             _ => return err_box!("invalid storage type: {}", value),
         };
@@ -119,6 +119,10 @@ mod test {
         // Case-insensitive
         let typ2 = StorageType::try_from("spdk_disk").unwrap();
         assert_eq!(typ2, StorageType::SpdkDisk);
+
+        // Backward-compatible alias used by early SPDK configurations.
+        let alias = StorageType::try_from("spdk").unwrap();
+        assert_eq!(alias, StorageType::SpdkDisk);
 
         // Numeric value
         let val: i32 = StorageType::SpdkDisk.into();


### PR DESCRIPTION
# Summary

Support the legacy `[SPDK]` worker data-directory prefix while keeping `SPDK_DISK` as the canonical storage type name. This restores backward compatibility for existing configurations and allows the existing SPDK integration tests to continue exercising the bdev-backed layout without fixture changes.

# Issue Describe / Design

Related issues: None.

Root cause: `StorageType::from_str_name` falls back to `Disk` when a prefix is not recognized. After the storage type was renamed to `SPDK_DISK`, existing `[SPDK]` configurations and the original SPDK test fixtures resolved to `Disk` instead of `SpdkDisk`.

Reproduction steps:

1. Configure a worker data directory with `[SPDK]/path`.
2. Enable SPDK and provide a reachable NVMe-oF target.
3. Start the worker or run the existing SPDK worker tests.
4. Observe that the data directory resolves to `Disk` rather than `SpdkDisk`.

The fix accepts `SPDK` as a backward-compatible alias. The existing tests intentionally retain `[SPDK]`, providing end-to-end coverage that the legacy prefix initializes the SPDK bdev layout.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-common/src/state/storage_info.rs` | Accept `SPDK` and `SPDK_DISK` as `StorageType::SpdkDisk`, with a regression assertion for the alias | Restores compatibility for legacy SPDK data-directory configurations |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `make format` | PASS | Formatting and Clippy checks |
| `cargo test -p curvine-common storage_type_spdk_disk_roundtrip` | PASS | Covers canonical and legacy aliases |
| `cargo test -p curvine-server --test spdk_worker_test --features spdk -- --test-threads=1` | PASS | 1/1 with the unchanged `[SPDK]` fixture on the example Linux SPDK malloc NVMe-oF target; logs show `SpdkDisk` |
| `cargo test -p curvine-server --test spdk_stress_test --features spdk -- --test-threads=1` | PASS | 6/6 with the unchanged `[SPDK]` fixture on the same target |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None