### PR TITLE
fix(fuse): preserve zero permission mode

### DIFF
--- a/build/tests/fuse-test.sh
+++ b/build/tests/fuse-test.sh
@@ -63,6 +63,7 @@ This script tests basic filesystem operations including:
   - Mmap read/write (MAP_SHARED mmap ↔ pread coherence, issue #850)
   - Active-writer path truncate regression (PR #962)
   - Read-only open with O_CREAT creates a missing file
+  - Mode 0000 is preserved by chmod, fchmod, and umask-filtered create
 
 For FIO performance tests, use fio-test.sh instead.
 
@@ -1379,6 +1380,15 @@ test_open_creat_rdonly() {
         "open_creat_rdonly_repro.py" --dir "$TEST_DIR"
 }
 
+# Test 23: mode 0000 is a valid persisted permission mode
+test_mode_zero_permissions() {
+    CURRENT_TEST_GROUP="Test 23: Mode Zero Permissions"
+    print_header "$CURRENT_TEST_GROUP"
+    run_python_script_test \
+        "Testing chmod/fchmod/umask preserve mode 0000" \
+        "mode_zero_permissions_repro.py" --dir "$TEST_DIR"
+}
+
 # Print final report
 print_report() {
     print_header "Test Summary"
@@ -1486,6 +1496,7 @@ main() {
     test_file_handle_at
     test_pr962_active_writer_truncate
     test_open_creat_rdonly
+    test_mode_zero_permissions
 
     test_git_clone
 

--- a/build/tests/scripts/mode_zero_permissions_repro.py
+++ b/build/tests/scripts/mode_zero_permissions_repro.py
@@ -14,21 +14,15 @@
 #  // limitations under the License.
 
 """
-chmod/fchmod mode bits not persisted on Curvine FUSE — reproducer for LTP failures.
+Regression test for mode 0000 persistence on Curvine FUSE.
 
-Root cause: setattr (chmod/fchmod) and create-time umask application do not
-persist permission mode 0000.  chmod(2)/fchmod(2) return success, but stat()
-still reports the previous mode (e.g. 0755).  Likewise creat(2) under
-umask(0777) should yield mode 0000 but the file keeps a non-zero mode.
-
-Covered LTP cases (each line is one minimal repro scenario):
-  chmod01  — chmod(path, 0000) succeeds yet stat() mode stays 0755 (TFAIL test 1)
-  fchmod01 — fchmod(fd, 0000) succeeds yet fstat() mode stays 0755 (TFAIL)
-  umask01  — umask(0777) + creat(0777) yields mode 0755 instead of 0000 (TFAIL)
+chmod(2), fchmod(2), and create-time umask application can all legitimately
+produce permission mode 0000. Curvine used to treat mode 0 as "unset", so stat()
+reported a default non-zero mode instead of preserving the requested mode.
 
 Usage:
-    python3 curvine_ltp_chmod_mode_repro.py --dir /curvine-fuse/fuse-test
-    python3 curvine_ltp_chmod_mode_repro.py --dir /curvine-fuse/fuse-test --allow-non-mount
+    python3 mode_zero_permissions_repro.py --dir /curvine-fuse/fuse-test
+    python3 mode_zero_permissions_repro.py --dir /curvine-fuse/fuse-test --allow-non-mount
 """
 
 import argparse
@@ -40,8 +34,7 @@ from typing import Callable
 
 DEFAULT_DIR = "/curvine-fuse/fuse-test"
 
-# LTP chmod01 / fchmod01 initial file mode (S_IRUSR|S_IWUSR|S_IRGRP|S_IROTH).
-_LTP_FILE_MODE = 0o644
+_INITIAL_FILE_MODE = 0o644
 
 
 def expect_ok(name: str, fn: Callable[[], None]) -> int:
@@ -112,13 +105,12 @@ def _raise_mode_mismatch(actual: int, expected: int, label: str) -> None:
 
 
 def test_chmod_zero_mode_persisted(root: str) -> int:
-    # Related LTP cases: chmod01
     # chmod(2) with mode 0000 must clear all permission bits visible via stat(2).
     workdir = case_dir(root, "chmod_zero_mode")
     target = os.path.join(workdir, "testfile")
 
     def run_chmod_zero() -> None:
-        fd = os.open(target, os.O_CREAT | os.O_RDWR, _LTP_FILE_MODE)
+        fd = os.open(target, os.O_CREAT | os.O_RDWR, _INITIAL_FILE_MODE)
         os.close(fd)
         os.chmod(target, 0)
         actual = _low9_mode(os.stat(target).st_mode)
@@ -126,19 +118,18 @@ def test_chmod_zero_mode_persisted(root: str) -> int:
             _raise_mode_mismatch(actual, 0, "stat after chmod(path, 0000)")
 
     return expect_ok(
-        "chmod(path, 0000) then stat() shows mode 0000 (chmod01)",
+        "chmod(path, 0000) then stat() shows mode 0000",
         run_chmod_zero,
     )
 
 
 def test_fchmod_zero_mode_persisted(root: str) -> int:
-    # Related LTP cases: fchmod01
     # fchmod(2) with mode 0000 must clear all permission bits visible via fstat(2).
     workdir = case_dir(root, "fchmod_zero_mode")
     target = os.path.join(workdir, "testfile")
 
     def run_fchmod_zero() -> None:
-        fd = os.open(target, os.O_CREAT | os.O_RDWR, _LTP_FILE_MODE)
+        fd = os.open(target, os.O_CREAT | os.O_RDWR, _INITIAL_FILE_MODE)
         os.fchmod(fd, 0)
         actual = _low9_mode(os.fstat(fd).st_mode)
         os.close(fd)
@@ -146,13 +137,12 @@ def test_fchmod_zero_mode_persisted(root: str) -> int:
             _raise_mode_mismatch(actual, 0, "fstat after fchmod(fd, 0000)")
 
     return expect_ok(
-        "fchmod(fd, 0000) then fstat() shows mode 0000 (fchmod01)",
+        "fchmod(fd, 0000) then fstat() shows mode 0000",
         run_fchmod_zero,
     )
 
 
 def test_creat_under_full_umask_has_zero_mode(root: str) -> int:
-    # Related LTP cases: umask01
     # creat(2) under umask(0777) must produce a file whose low 9 mode bits are 0000.
     workdir = case_dir(root, "umask_zero_mode")
     target = os.path.join(workdir, "testfile")
@@ -169,7 +159,7 @@ def test_creat_under_full_umask_has_zero_mode(root: str) -> int:
             os.umask(prev)
 
     return expect_ok(
-        "umask(0777)+creat(0777) yields file mode 0000 (umask01)",
+        "umask(0777)+creat(0777) yields file mode 0000",
         run_umask_creat_zero,
     )
 
@@ -177,17 +167,17 @@ def test_creat_under_full_umask_has_zero_mode(root: str) -> int:
 TESTS: list[tuple[str, str, Callable[..., int]]] = [
     (
         "1",
-        "chmod(path, 0000) persists via stat (chmod01)",
+        "chmod(path, 0000) persists via stat",
         test_chmod_zero_mode_persisted,
     ),
     (
         "2",
-        "fchmod(fd, 0000) persists via fstat (fchmod01)",
+        "fchmod(fd, 0000) persists via fstat",
         test_fchmod_zero_mode_persisted,
     ),
     (
         "3",
-        "umask(0777)+creat yields mode 0000 (umask01)",
+        "umask(0777)+creat yields mode 0000",
         test_creat_under_full_umask_has_zero_mode,
     ),
 ]
@@ -195,7 +185,7 @@ TESTS: list[tuple[str, str, Callable[..., int]]] = [
 
 def main() -> int:
     parser = argparse.ArgumentParser(
-        description="chmod/fchmod mode-0000 not persisted on Curvine FUSE — reproducer",
+        description="mode-0000 persistence regression test for Curvine FUSE",
     )
     parser.add_argument(
         "--dir",

--- a/curvine-fuse/src/fuse_utils.rs
+++ b/curvine-fuse/src/fuse_utils.rs
@@ -174,16 +174,13 @@ impl FuseUtils {
     }
 
     pub fn create_opts(op: &Create<'_>, fs: &UnifiedFileSystem) -> CreateFileOpts {
-        let mut builder = CreateFileOptsBuilder::with_conf(&fs.conf().client);
-        if op.arg.mode != 0 {
-            builder = builder.acl(
+        CreateFileOptsBuilder::with_conf(&fs.conf().client)
+            .acl(
                 op.header.uid,
                 op.header.gid,
                 op.arg.mode & 0o7777 & !op.arg.umask,
             )
-        }
-
-        builder.build()
+            .build()
     }
 
     pub fn check_xattr(name: &str, read: bool) -> FuseResult<()> {
@@ -262,11 +259,12 @@ impl FuseUtils {
             }
         };
 
-        let mode = if status.mode != 0 {
-            FuseUtils::get_mode(status.mode, status.file_type)
+        let perm = if status.id == FUSE_UNKNOWN_INO as i64 && FuseUtils.is_dot(&status.name) {
+            FUSE_DEFAULT_MODE & !conf.umask
         } else {
-            FuseUtils::get_mode(FUSE_DEFAULT_MODE & !conf.umask, status.file_type)
+            status.mode
         };
+        let mode = FuseUtils::get_mode(perm, status.file_type);
         let size = FuseUtils::fuse_st_size(status);
 
         // For links, nlink should be greater than 1
@@ -294,16 +292,13 @@ impl FuseUtils {
     }
 
     pub fn mkdir_opts(op: &MkDir<'_>, fs: &UnifiedFileSystem) -> MkdirOpts {
-        let mut builder = MkdirOptsBuilder::with_conf(&fs.conf().client);
-        if op.arg.mode != 0 {
-            builder = builder.acl(
+        MkdirOptsBuilder::with_conf(&fs.conf().client)
+            .acl(
                 op.header.uid,
                 op.header.gid,
                 op.arg.mode & 0o7777 & !op.arg.umask,
             )
-        }
-
-        builder.build()
+            .build()
     }
 
     pub fn create_entry_out(conf: &FuseConf, attr: fuse_attr) -> fuse_entry_out {


### PR DESCRIPTION
## Summary

Fix Curvine FUSE preserving permission mode `0000`.

When a file was changed to mode `0000` through `chmod` or `fchmod`, or created under a full `umask(0777)`, Curvine could report the file with a default mode such as `0755` instead of `0000`. The operation succeeded, but later `stat`/`fstat` did not reflect the requested permissions.

## Minimal Reproducer

```c
#include <errno.h>
#include <fcntl.h>
#include <stdio.h>
#include <sys/stat.h>
#include <unistd.h>

int main(int argc, char **argv) {
    char path[4096];
    struct stat st;

    if (argc != 2) {
        fprintf(stderr, "usage: %s <mount-dir>\n", argv[0]);
        return 2;
    }

    snprintf(path, sizeof(path), "%s/mode_zero.dat", argv[1]);
    unlink(path);

    int fd = open(path, O_CREAT | O_RDWR, 0644);
    if (fd < 0) {
        perror("open");
        return 1;
    }
    close(fd);

    if (chmod(path, 0000) != 0) {
        perror("chmod");
        return 1;
    }

    if (stat(path, &st) != 0) {
        perror("stat");
        return 1;
    }

    if ((st.st_mode & 0777) != 0000) {
        fprintf(stderr, "expected mode 0000, got %03o\n",
                (unsigned)(st.st_mode & 0777));
        return 1;
    }

    unlink(path);
    return 0;
}
```

Run it on a Curvine FUSE mount:

```bash
gcc /tmp/mode_zero.c -o /tmp/mode_zero
/tmp/mode_zero /curvine-fuse
```

## Root Cause

Curvine FUSE treated `mode == 0` as an unset value.

That affected multiple paths:

- `create` skipped ACL/mode initialization when the computed mode was `0000`.
- `mkdir` had the same `mode != 0` guard.
- `status_to_attr` converted persisted `mode == 0` back to the configured default mode.

As a result, valid POSIX mode `0000` was lost or hidden behind the default permission mode.

## Changes

- Always apply the kernel-provided create mode after umask, even when it becomes `0000`.
- Always apply the kernel-provided mkdir mode after umask.
- Preserve `status.mode == 0` when converting metadata to FUSE attributes.
- Set default permissions only for synthetic `.` and `..` directory entries.
- Add a regression test covering `chmod`, `fchmod`, and full-umask create.

## Verification

- Minimal reproducer passes after the fix.
- `python3 build/tests/scripts/mode_zero_permissions_repro.py --dir /tmp/curvine-mode-zero-repro --allow-non-mount` passes.
- `cargo fmt --check` passes.
- `cargo check -p curvine-fuse` passes.
