### PR TITLE
fix(fuse): close fuse fd when mount fails (#1072)

### DIFF
--- a/curvine-fuse/src/raw/fuse_pure.rs
+++ b/curvine-fuse/src/raw/fuse_pure.rs
@@ -21,6 +21,7 @@ use orpc::sys::RawIO;
 use std::ffi::CString;
 use std::fs::File;
 use std::io::ErrorKind;
+use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, OwnedFd};
 use std::path::Path;
 
 use std::os::unix::fs::PermissionsExt;
@@ -126,10 +127,13 @@ fn fuse_mount_sys(mnt: &Path, conf: &FuseConf) -> IOResult<RawIO> {
             return Err(std::io::Error::from(ErrorKind::Other).into());
         }
     };
+    // SAFETY: open returned a fresh descriptor whose ownership is transferred here.
+    // Keep ownership until mount succeeds so every failure path closes /dev/fuse.
+    let fd = unsafe { OwnedFd::from_raw_fd(fd) };
     let mut flags = 0;
     let mut mount_options = format!(
         "fd={},rootmode={:o},user_id={},group_id={}",
-        fd,
+        fd.as_raw_fd(),
         mountpoint_mode,
         getuid(),
         getgid()
@@ -167,16 +171,21 @@ fn fuse_mount_sys(mnt: &Path, conf: &FuseConf) -> IOResult<RawIO> {
         }
     };
 
+    complete_mount(fd, result, mnt)
+}
+
+fn complete_mount(fd: OwnedFd, result: libc::c_int, mnt: &Path) -> IOResult<RawIO> {
     if result != 0 {
+        let error = std::io::Error::last_os_error();
         error!(
             "Mount fuse failed, {} with result {}",
             mnt.display(),
             result
         );
-        return err_io!(-1);
+        return Err(error.into());
     }
     info!("Mounted at {}", mnt.display());
-    Ok(fd)
+    Ok(fd.into_raw_fd())
 }
 
 fn detect_fusermount_bin() -> String {
@@ -222,5 +231,41 @@ pub fn fuse_umount_pure(mnt: &Path) {
 
     if let Ok(output) = builder.output() {
         info!("fusermount: {}", String::from_utf8_lossy(&output.stdout));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::complete_mount;
+    use std::fs::File;
+    use std::os::unix::io::{AsRawFd, OwnedFd};
+    use std::path::Path;
+
+    #[test]
+    fn failed_mount_closes_fuse_fd() {
+        let fd: OwnedFd = File::open("/dev/null").expect("open test fd").into();
+        let raw_fd = fd.as_raw_fd();
+
+        assert!(complete_mount(fd, -1, Path::new("/invalid-mount")).is_err());
+
+        let result = unsafe { libc::fcntl(raw_fd, libc::F_GETFD) };
+        assert_eq!(result, -1, "failed mount must close the owned FUSE fd");
+        assert_eq!(
+            std::io::Error::last_os_error().raw_os_error(),
+            Some(libc::EBADF)
+        );
+    }
+
+    #[test]
+    fn successful_mount_transfers_fuse_fd() {
+        let fd: OwnedFd = File::open("/dev/null").expect("open test fd").into();
+        let raw_fd = fd.as_raw_fd();
+
+        let returned_fd =
+            complete_mount(fd, 0, Path::new("/test-mount")).expect("successful mount transfers fd");
+
+        assert_eq!(returned_fd, raw_fd);
+        assert_ne!(unsafe { libc::fcntl(returned_fd, libc::F_GETFD) }, -1);
+        assert_eq!(unsafe { libc::close(returned_fd) }, 0);
     }
 }


### PR DESCRIPTION
# Summary

Close the `/dev/fuse` file descriptor automatically when the mount syscall fails, while preserving ownership transfer to `FuseMnt` after a successful mount.

# Issue Describe / Design

Closes #1072

Root cause:

`fuse_mount_sys` kept the descriptor returned by opening `/dev/fuse` as a raw fd. When `libc::mount` failed, the function returned without closing it.

Reproduction:

1. Open `/dev/fuse`.
2. Trigger a mount syscall failure.
3. Repeat in the same process and observe leaked descriptors.

Fix approach:

- Wrap the newly opened descriptor in `OwnedFd`.
- Keep RAII ownership across all mount preparation and failure paths.
- Transfer ownership with `into_raw_fd()` only after the mount succeeds.
- Preserve the mount syscall error before logging and fd cleanup.
- Add tests for both failure cleanup and successful ownership transfer.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-fuse/src/raw/fuse_pure.rs` | Own `/dev/fuse` with RAII until mount succeeds | Failed mounts no longer leak descriptors |
| `curvine-fuse/src/raw/fuse_pure.rs` | Add failure and success ownership tests | Test-only |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-fuse raw::fuse_pure::tests -- --nocapture` | PASS | 2 tests passed on the Linux remote devspace |
| `make format` | PASS | Release Clippy and formatting completed |
| `cargo clippy --release -p curvine-fuse --all-targets -- --deny warnings --allow clippy::uninlined-format-args` | PASS | Linux remote devspace |
| `cargo fmt --all -- --check` | PASS | |
| `git diff --check` | PASS | |
| `cargo test -p curvine-fuse --lib` | BASELINE FAILURE | 158 passed; 3 existing `dir_tree` failures reproduced unchanged on `origin/main` at `d216041` |

# Dependencies

- Related PRs: None
- Related issues: #1072
- Blocks / blocked by: None
