### PR TITLE
feat(libsdk): propagate curvine-client UFS features (#1103)

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -369,10 +369,24 @@ if should_build_package "tests"; then
   COPY_TARGETS+=("curvine-bench")
 fi
 
+# Join libsdk SDK feature + UFS passthrough features (forwarded to curvine-client).
+libsdk_features() {
+  local sdk_feature="$1"
+  local alloc_feature="$2"
+  local features="${alloc_feature},${sdk_feature}"
+  local ufs
+  for ufs in "${UFS_TYPES[@]}"; do
+    features="${features},${ufs}"
+  done
+  echo "$features"
+}
+
 build_curvine_libsdk() {
   local sdk_feature="$1"
-  local sdk_cmd="cargo build $PROFILE -p curvine-libsdk --no-default-features --features curvine-common/system,${sdk_feature}"
-  echo "Building curvine-libsdk with feature: ${sdk_feature}"
+  local features
+  features="$(libsdk_features "$sdk_feature" "curvine-common/system")"
+  local sdk_cmd="cargo build $PROFILE -p curvine-libsdk --no-default-features --features ${features}"
+  echo "Building curvine-libsdk with features: ${features}"
   echo "Build command: ${sdk_cmd}"
   eval "$sdk_cmd"
 }
@@ -677,8 +691,10 @@ if [ $BUILD_PYTHON_SDK -eq 1 ]; then
 
   echo "Building Python wheel (maturin) into ${DIST_DIR}/lib ..."
   cd "$FS_HOME/curvine-libsdk"
+  PY_SDK_FEATURES="$(libsdk_features "python-sdk" "curvine-common/${ALLOC}")"
+  echo "maturin features: ${PY_SDK_FEATURES}"
   "${MATURIN_CMD[@]}" build --no-default-features \
-    --features "curvine-common/${ALLOC},python-sdk" \
+    --features "${PY_SDK_FEATURES}" \
     "${MATURIN_RELEASE[@]}" \
     --interpreter "$PYTHON_SDK_VENV/bin/python" \
     --compatibility "$MATURIN_COMPAT" \

--- a/build/build.sh
+++ b/build/build.sh
@@ -376,6 +376,13 @@ libsdk_features() {
   local features="${alloc_feature},${sdk_feature}"
   local ufs
   for ufs in "${UFS_TYPES[@]}"; do
+    # Reject shell metacharacters / unexpected tokens from --ufs before they enter argv.
+    case "$ufs" in
+      *[!a-zA-Z0-9_-]*|"")
+        echo "Error: invalid --ufs value: ${ufs}" >&2
+        return 1
+        ;;
+    esac
     features="${features},${ufs}"
   done
   echo "$features"
@@ -384,11 +391,16 @@ libsdk_features() {
 build_curvine_libsdk() {
   local sdk_feature="$1"
   local features
-  features="$(libsdk_features "$sdk_feature" "curvine-common/system")"
-  local sdk_cmd="cargo build $PROFILE -p curvine-libsdk --no-default-features --features ${features}"
+  features="$(libsdk_features "$sdk_feature" "curvine-common/system")" || exit 1
+  # Invoke cargo via argv (no eval) so --ufs values cannot inject shell metacharacters.
+  local -a sdk_cmd=(cargo build)
+  if [ -n "$PROFILE" ]; then
+    sdk_cmd+=("$PROFILE")
+  fi
+  sdk_cmd+=(-p curvine-libsdk --no-default-features --features "$features")
   echo "Building curvine-libsdk with features: ${features}"
-  echo "Build command: ${sdk_cmd}"
-  eval "$sdk_cmd"
+  echo "Build command: ${sdk_cmd[*]}"
+  "${sdk_cmd[@]}"
 }
 
 # Base command
@@ -691,7 +703,7 @@ if [ $BUILD_PYTHON_SDK -eq 1 ]; then
 
   echo "Building Python wheel (maturin) into ${DIST_DIR}/lib ..."
   cd "$FS_HOME/curvine-libsdk"
-  PY_SDK_FEATURES="$(libsdk_features "python-sdk" "curvine-common/${ALLOC}")"
+  PY_SDK_FEATURES="$(libsdk_features "python-sdk" "curvine-common/${ALLOC}")" || exit 1
   echo "maturin features: ${PY_SDK_FEATURES}"
   "${MATURIN_CMD[@]}" build --no-default-features \
     --features "${PY_SDK_FEATURES}" \

--- a/curvine-libsdk/Cargo.toml
+++ b/curvine-libsdk/Cargo.toml
@@ -14,6 +14,21 @@ rust-sdk = []
 java-sdk = ["dep:jni"]
 python-sdk = ["dep:pyo3"]
 
+# Forward optional UFS backends from curvine-client so Java/Python/Rust
+# consumers can enable them without depending on curvine-client directly.
+# Defaults stay lean: only java-sdk; no UFS backend is forced here.
+# (curvine-client still enables its own default `opendal-s3` unless consumers
+#  set `default-features = false` on that dependency elsewhere.)
+opendal-s3 = ["curvine-client/opendal-s3"]
+opendal-oss = ["curvine-client/opendal-oss"]
+opendal-gcs = ["curvine-client/opendal-gcs"]
+opendal-azblob = ["curvine-client/opendal-azblob"]
+opendal-cos = ["curvine-client/opendal-cos"]
+opendal-hdfs = ["curvine-client/opendal-hdfs"]
+opendal-webhdfs = ["curvine-client/opendal-webhdfs"]
+opendal-hdfs-native = ["curvine-client/opendal-hdfs-native"]
+oss-hdfs = ["curvine-client/oss-hdfs"]
+
 [dependencies]
 orpc = { workspace = true }
 curvine-client = { workspace = true }

--- a/curvine-libsdk/README.md
+++ b/curvine-libsdk/README.md
@@ -10,6 +10,49 @@ Rust **`cdylib`** with **Java (JNI)** and **Python (PyO3)**. Crate path: **`curv
 
 ---
 
+## UFS Cargo features
+
+`curvine-libsdk` forwards optional UFS backends from `curvine-client`. Default features remain **`java-sdk` only** — no extra UFS backends are enabled by the libsdk crate itself. Enable backends explicitly when you need them (e.g. load jobs against OSS-HDFS).
+
+| Feature | Forwards to |
+|---------|-------------|
+| `opendal-s3` | `curvine-client/opendal-s3` |
+| `opendal-oss` | `curvine-client/opendal-oss` |
+| `opendal-gcs` | `curvine-client/opendal-gcs` |
+| `opendal-azblob` | `curvine-client/opendal-azblob` |
+| `opendal-cos` | `curvine-client/opendal-cos` |
+| `opendal-hdfs` | `curvine-client/opendal-hdfs` |
+| `opendal-webhdfs` | `curvine-client/opendal-webhdfs` |
+| `opendal-hdfs-native` | `curvine-client/opendal-hdfs-native` |
+| `oss-hdfs` | `curvine-client/oss-hdfs` (JindoSDK; needs `JINDOSDK_HOME`) |
+
+**Rust consumers**
+
+```toml
+curvine-libsdk = { path = "...", features = ["java-sdk", "oss-hdfs"] }
+# or: features = ["rust-sdk", "opendal-oss"]
+```
+
+```bash
+cargo build -p curvine-libsdk --no-default-features --features "java-sdk,oss-hdfs"
+```
+
+**Java / Python packaging (`make` / `build/build.sh`)**
+
+`--ufs` flags are passed through into the libsdk cdylib / wheel build:
+
+```bash
+# Java JNI .so with OSS-HDFS + default OpenDAL S3
+make build ARGS='--package java --ufs oss-hdfs'
+
+# Python wheel with an extra OpenDAL backend
+make build ARGS='--package python --ufs opendal-oss'
+```
+
+`oss-hdfs` requires JindoSDK at build/link time (`JINDOSDK_HOME`, default `/opt/jindosdk`). Do not enable it for default public artifacts unless that native SDK is available on the build host.
+
+---
+
 ## Python SDK (recommended)
 
 **1. Build** — from workspace root:


### PR DESCRIPTION
# Summary

Expose Cargo feature passthrough on `curvine-libsdk` so Java/Python/Rust consumers can selectively enable optional `curvine-client` UFS backends (e.g. `oss-hdfs`) without depending on `curvine-client` directly. Keep libsdk defaults lean (`java-sdk` only).

# Issue Describe / Design

Closes #1103

- `curvine-client` already defines UFS features correctly; only libsdk plumbing was missing.
- Forward each backend feature 1:1 (`opendal-*`, `oss-hdfs`) instead of enabling all backends by default.
- Wire `build/build.sh` `--ufs` into the libsdk cdylib / maturin feature list so packaged Java/Python natives match the requested backends.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-libsdk/Cargo.toml` | Add UFS feature forwards to `curvine-client/*` | None by default; optional features only when enabled |
| `build/build.sh` | Pass `--ufs` into libsdk cargo / maturin features | Java/Python SDK builds with `--ufs` now compile matching backends into the cdylib/wheel |
| `curvine-libsdk/README.md` | Document feature mapping and consumer usage | Docs only |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo check -p curvine-libsdk --no-default-features --features java-sdk` | PASS | Default lean build |
| `cargo check -p curvine-libsdk --no-default-features --features java-sdk,opendal-oss` | PASS | |
| `cargo check -p curvine-libsdk --no-default-features --features java-sdk,opendal-webhdfs` | PASS | |
| `cargo tree` with/without `opendal-oss` | PASS | Confirms feature activates on `curvine-client` / `curvine-ufs` only when requested |
| `java-sdk,oss-hdfs` full link | SKIP | Requires JindoSDK headers (`JINDOSDK_HOME`); missing on build host |

# Dependencies

- Related PRs: None
- Related issues: #1103
- Blocks / blocked by: None