### PR TITLE
fix(client): fall back to UFS on worker kill in cache_mode by typing worker-exhaustion error (#1131)

### DIFF
--- a/curvine-client/src/block/block_reader.rs
+++ b/curvine-client/src/block/block_reader.rs
@@ -15,6 +15,7 @@
 use crate::block::block_reader::ReaderAdapter::{Hole, Local, Remote};
 use crate::block::{BlockReaderHole, BlockReaderLocal, BlockReaderRemote};
 use crate::file::FsContext;
+use curvine_common::error::FsError;
 use curvine_common::state::{ClientAddress, ExtendedBlock, LocatedBlock, WorkerAddress};
 use curvine_common::FsResult;
 use log::warn;
@@ -22,7 +23,7 @@ use orpc::common::Utils;
 use orpc::error::ErrorExt;
 use orpc::runtime::{RpcRuntime, Runtime};
 use orpc::sys::DataSlice;
-use orpc::{err_box, CommonResult};
+use orpc::CommonResult;
 use std::sync::Arc;
 
 enum ReaderAdapter {
@@ -206,11 +207,11 @@ impl BlockReader {
             }
         }
 
-        err_box!(
+        Err(FsError::no_available_worker(format!(
             "There is no available worker, locs: {:?}, failed workers: {:?}",
             locs,
             fs_context.get_failed_workers()
-        )
+        )))
     }
 
     // Based on network transmission efficiency considerations, the data size of the underlying tcp is fixed each time.

--- a/curvine-client/src/unified/fallback_fs_reader.rs
+++ b/curvine-client/src/unified/fallback_fs_reader.rs
@@ -98,7 +98,7 @@ impl FallbackFsReader {
 pub(crate) fn is_worker_err(e: &FsError) -> bool {
     if matches!(
         e,
-        FsError::IO(_) | FsError::Pipeline(_) | FsError::Timeout(_)
+        FsError::IO(_) | FsError::Pipeline(_) | FsError::Timeout(_) | FsError::NoAvailableWorker(_)
     ) {
         return true;
     }
@@ -283,5 +283,30 @@ mod tests {
     fn test_is_worker_err_common_connection_refused() {
         let e = FsError::common("Connection refused (os error 111)");
         assert!(is_worker_err(&e));
+    }
+
+    // TC: a "no available worker" failure (all block replicas exhausted mid-read)
+    // must be classified as a worker error so FallbackFsReader falls back to UFS.
+    // It is a typed variant (FsError::NoAvailableWorker), so classification does
+    // NOT depend on the error message string — the block_reader message can be
+    // reworded without regressing fallback.
+    #[test]
+    fn test_is_worker_err_no_available_worker() {
+        let e = FsError::no_available_worker(
+            "There is no available worker, locs: [], failed workers: []",
+        );
+        assert!(is_worker_err(&e));
+    }
+
+    // Regression guard: this is exactly the bug we fixed. Before typing the
+    // error, block_reader produced a generic FsError::Common("There is no
+    // available worker ..."), whose message is NOT in the Common transport-
+    // failure whitelist, so is_worker_err returned false and fallback silently
+    // did not trigger (user saw EIO). Assert the untyped Common form is still
+    // NOT matched, proving the typed variant is what makes fallback work.
+    #[test]
+    fn test_is_worker_err_common_no_available_worker_not_matched() {
+        let e = FsError::common("There is no available worker, locs: [], failed workers: []");
+        assert!(!is_worker_err(&e));
     }
 }

--- a/curvine-common/src/error/fs_error.rs
+++ b/curvine-common/src/error/fs_error.rs
@@ -65,6 +65,7 @@ pub enum ErrorKind {
     InvalidArgument = 28,
     BlockNotFound = 29,
     ReadOnly = 30,
+    NoAvailableWorker = 31,
 
     #[num_enum(default)]
     Common = 10000,
@@ -185,6 +186,15 @@ pub enum FsError {
     // Pipeline replication does not meet minimum replicas
     #[error("{0}")]
     MinReplicasNotMet(ErrorImpl<StringError>),
+
+    // No worker replica is available to serve a block read (e.g. all replicas
+    // failed mid-read, or the block has no locations). This is a worker-level
+    // failure and, unlike a generic Common error, is typed so that fallback
+    // logic (FallbackFsReader::is_worker_err) can detect it without matching on
+    // the error message string.
+    #[error("{0}")]
+    NoAvailableWorker(ErrorImpl<StringError>),
+
     // Job not found
     #[error("{0}")]
     JobNotFound(ErrorImpl<StringError>),
@@ -317,6 +327,10 @@ impl FsError {
         Self::MinReplicasNotMet(ErrorImpl::with_source(msg.into()))
     }
 
+    pub fn no_available_worker(msg: impl Into<String>) -> Self {
+        Self::NoAvailableWorker(ErrorImpl::with_source(msg.into().into()))
+    }
+
     pub fn is_pipeline_error(&self) -> bool {
         matches!(self, FsError::Pipeline(_))
     }
@@ -380,6 +394,7 @@ impl FsError {
             FsError::ReadOnly(_) => ErrorKind::ReadOnly,
             FsError::Pipeline(_) => ErrorKind::Pipeline,
             FsError::MinReplicasNotMet(_) => ErrorKind::MinReplicasNotMet,
+            FsError::NoAvailableWorker(_) => ErrorKind::NoAvailableWorker,
             FsError::JobNotFound(_) => ErrorKind::JobNotFound,
             FsError::Common(_) => ErrorKind::Common,
         }
@@ -527,6 +542,7 @@ impl ErrorExt for FsError {
             FsError::ReadOnly(e) => FsError::ReadOnly(e.ctx(ctx)),
             FsError::Pipeline(e) => FsError::Pipeline(e.ctx(ctx)),
             FsError::MinReplicasNotMet(e) => FsError::MinReplicasNotMet(e.ctx(ctx)),
+            FsError::NoAvailableWorker(e) => FsError::NoAvailableWorker(e.ctx(ctx)),
             FsError::JobNotFound(e) => FsError::JobNotFound(e.ctx(ctx)),
             FsError::Common(e) => FsError::Common(e.ctx(ctx)),
         }
@@ -563,6 +579,7 @@ impl ErrorExt for FsError {
             FsError::ReadOnly(e) => e.encode(ErrorKind::ReadOnly),
             FsError::Pipeline(e) => e.encode(ErrorKind::Pipeline),
             FsError::MinReplicasNotMet(e) => e.encode(ErrorKind::MinReplicasNotMet),
+            FsError::NoAvailableWorker(e) => e.encode(ErrorKind::NoAvailableWorker),
             FsError::JobNotFound(e) => e.encode(ErrorKind::JobNotFound),
             FsError::Common(e) => e.encode(ErrorKind::Common),
         }
@@ -602,6 +619,7 @@ impl ErrorExt for FsError {
             ErrorKind::ReadOnly => FsError::ReadOnly(de.into_string()),
             ErrorKind::Pipeline => FsError::Pipeline(de.into_string()),
             ErrorKind::MinReplicasNotMet => FsError::MinReplicasNotMet(de.into_string()),
+            ErrorKind::NoAvailableWorker => FsError::NoAvailableWorker(de.into_string()),
             ErrorKind::JobNotFound => FsError::JobNotFound(de.into_string()),
             ErrorKind::Common => FsError::Common(de.into_string()),
         }
@@ -684,5 +702,19 @@ mod tests {
         let bytes = error.encode();
         let decoded = FsError::decode(bytes);
         assert!(matches!(decoded.kind(), ErrorKind::MinReplicasNotMet));
+    }
+
+    #[test]
+    pub fn no_available_worker_error_kind_test() {
+        let error = FsError::no_available_worker("There is no available worker");
+
+        assert!(matches!(error.kind(), ErrorKind::NoAvailableWorker));
+        assert!(matches!(error, FsError::NoAvailableWorker(_)));
+
+        // Round-trips across RPC encode/decode without collapsing into Common.
+        let bytes = error.encode();
+        let decoded = FsError::decode(bytes);
+        assert!(matches!(decoded.kind(), ErrorKind::NoAvailableWorker));
+        assert!(matches!(decoded, FsError::NoAvailableWorker(_)));
     }
 }


### PR DESCRIPTION
# Summary

Reading an already-cached file in cache_mode and killing the serving worker mid-read returned EIO to the application instead of transparently falling back to S3/UFS. This types the "no available worker" failure so the existing fallback path recognizes it. Write paths are unchanged.

# Issue Describe / Design

Closes #1131

**Root cause**

When a worker is killed mid-read, the streamed block fails with a transport error (`early eof`). `BlockReader::read` (block_reader.rs:217-253) removes the failed replica from `locs` and retries the rest via `get_reader`. In cache_mode a cached block typically has a single replica, so `locs` becomes empty and `get_reader` (block_reader.rs:168-214) short-circuits to `err_box!("There is no available worker, ...")`.

`err_box!` yields a `FsError::Common` (via `From<String>`), discarding the original typed transport error. `FallbackFsReader::is_worker_err` classifies `IO/Pipeline/Timeout` by type, but classifies `Common` by a message-substring whitelist (`connection refused`, `early eof`, ...). `"there is no available worker"` is not in that whitelist, so `is_worker_err` returns `false`, the UFS fallback branch is never entered, and the error surfaces as EIO.

Observed chain in `fuse.log`:

    block_reader.rs:236  read data error ... early eof
    fs_reader_buffer.rs  buffer read error: Common(...There is no available worker...)
    fuse_response.rs     errno ...There is no available worker...: 5   (EIO)

**Reproduction**

1. Mount an S3 bucket in cache_mode: `cv mount s3://my-bucket /my-bucket --write-type=cache_mode -c s3.endpoint_url=<endpoint> ...`
2. Read a large file once so a worker caches it.
3. Start a large sequential read and kill the worker mid-read: `dd if=/mnt/curvine/my-bucket/10g.txt of=/dev/null bs=1M count=10240 status=progress`
4. `dd` fails with `Input/output error` partway through instead of falling back to S3.

**Fix approach**

Classify the failure by type, not by message string:

- Add a typed `FsError::NoAvailableWorker` variant (+ `ErrorKind::NoAvailableWorker`), so the worker-failure signal survives propagation and RPC encode/decode instead of collapsing into `Common`.
- Emit it from the read path (`BlockReader::get_reader`) in place of `err_box!`. Write paths (`block_writer.rs`, `batch_block_writer.rs`) are intentionally left unchanged, since their "no available worker" has different semantics.
- Add `FsError::NoAvailableWorker(_)` to the type-based arm of `is_worker_err`, so fallback classification no longer depends on message text. The existing `Common` substring whitelist is kept as a fallback for other not-yet-typed paths.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-common/src/error/fs_error.rs` | Add `ErrorKind::NoAvailableWorker` + `FsError::NoAvailableWorker` variant, `no_available_worker()` ctor, and arms in `kind`/`ctx`/`encode`/`decode` | New error variant; round-trips across RPC. No change to existing variants. |
| `curvine-client/src/block/block_reader.rs` | Read-path replica exhaustion now returns `FsError::no_available_worker(...)` instead of `err_box!` (untyped `Common`) | Same message text; error type changes from `Common` to `NoAvailableWorker` on the read path only. |
| `curvine-client/src/unified/fallback_fs_reader.rs` | Add `NoAvailableWorker` to the type-based arm of `is_worker_err` | cache_mode/fs_mode now fall back to UFS on worker exhaustion (the intended behavior). |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-common --lib error::fs_error` | PASS | Incl. new `no_available_worker_error_kind_test` (encode/decode round-trip) |
| `cargo test -p curvine-client --lib is_worker_err` | PASS | New: typed variant recognized; regression guard that old untyped `Common("no available worker")` is NOT recognized |
| `cargo test -p curvine-tests --test fallback_read_test` | PASS | All 13 existing fallback cases (fs_mode + cache_mode) still pass |

# Dependencies

- Related PRs: None
- Related issues: #1131
- Distinct from #920 (master-down stat fallback) and #955 (cache_mode consistency semantics): this is a worker-down data-read path defect.

(by LiAuto)