### PR TITLE
fix(cli): cap load-status progress display

### DIFF
--- a/curvine-common/src/state/job.rs
+++ b/curvine-common/src/state/job.rs
@@ -265,11 +265,16 @@ impl JobTaskProgress {
     pub fn progress_string(&self, show_bar: bool) -> String {
         let loaded = self.loaded_size.max(0) as u64;
         let total = self.total_size.max(0) as u64;
+        let display_loaded = if total == 0 {
+            loaded
+        } else {
+            loaded.min(total)
+        };
 
         let percentage = if total == 0 {
             0.0
         } else {
-            (loaded as f64 / total as f64 * 100.0).min(100.0)
+            display_loaded as f64 / total as f64 * 100.0
         };
 
         if show_bar {
@@ -277,7 +282,7 @@ impl JobTaskProgress {
                 return format!(
                     "[{}] 0.0% ({} / {})",
                     "░".repeat(20),
-                    ByteUnit::byte_to_string(loaded),
+                    ByteUnit::byte_to_string(display_loaded),
                     ByteUnit::byte_to_string(total)
                 );
             }
@@ -291,16 +296,39 @@ impl JobTaskProgress {
                 "[{}] {:.1}% ({} / {})",
                 progress_bar,
                 percentage,
-                ByteUnit::byte_to_string(loaded),
+                ByteUnit::byte_to_string(display_loaded),
                 ByteUnit::byte_to_string(total)
             )
         } else {
             format!(
                 "{:.1}% ({} / {})",
                 percentage,
-                ByteUnit::byte_to_string(loaded),
+                ByteUnit::byte_to_string(display_loaded),
                 ByteUnit::byte_to_string(total)
             )
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::JobTaskProgress;
+    use orpc::common::ByteUnit;
+
+    #[test]
+    fn progress_string_caps_loaded_bytes_at_total() {
+        let progress = JobTaskProgress {
+            loaded_size: 66,
+            total_size: 33,
+            ..Default::default()
+        };
+        let expected_counts = format!(
+            "{} / {}",
+            ByteUnit::byte_to_string(33),
+            ByteUnit::byte_to_string(33)
+        );
+
+        assert!(progress.progress_string(false).contains(&expected_counts));
+        assert!(progress.progress_string(true).contains(&expected_counts));
     }
 }

--- a/curvine-common/src/utils/display.rs
+++ b/curvine-common/src/utils/display.rs
@@ -145,12 +145,16 @@ impl ProgressDisplay for BasicProgress {
         if self.total == 0 {
             0.0
         } else {
-            (self.completed as f64 / self.total as f64) * 100.0
+            ((self.completed as f64 / self.total as f64) * 100.0).min(100.0)
         }
     }
 
     fn completed_size(&self) -> u64 {
-        self.completed
+        if self.total == 0 {
+            self.completed
+        } else {
+            self.completed.min(self.total)
+        }
     }
 
     fn total_size(&self) -> u64 {
@@ -465,5 +469,18 @@ mod tests {
 
         let bar = progress.format_progress_bar(&opts);
         assert_eq!(bar, "#######---");
+    }
+
+    #[test]
+    fn test_basic_progress_caps_over_complete_display() {
+        let progress = BasicProgress::new(66, 33);
+
+        assert_eq!(progress.progress(), 100.0);
+
+        let display = progress.format_progress();
+        assert!(display.contains("100.0%"));
+        assert!(display.contains("33/33"));
+        assert!(!display.contains("200.0%"));
+        assert!(!display.contains("66/33"));
     }
 }


### PR DESCRIPTION
# Summary

This PR prevents impossible load/export progress displays such as `200.0% (66/33 bytes)`. It caps user-facing progress values in both `BasicProgress` and `JobTaskProgress`, so CLI status output and client wait logs show the same bounded byte count.

# Issue Describe / Design

This is a bug fix.

- Root cause: `BasicProgress` and `JobTaskProgress::progress_string()` could receive `loaded_size > total_size` from export progress reports. The original CLI path displayed both the raw percentage and raw loaded byte count; the initial change capped `BasicProgress`, while `JobTaskProgress` still formatted the raw byte count.
- Reproduction steps: run `cv export <mounted-cv-file> --watch` for a small file on the `/acc-hdfs/starrocks` mount. The deployed CLI displayed completed export status as `200.0%` with byte counts like `64/32 bytes`.
- Fix approach: cap percentage and displayed completed bytes at total bytes when total is known, preserving raw completed bytes only when total is zero. `JobTaskProgress` now follows the same display contract as `BasicProgress`.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-common/src/utils/display.rs` | Clamp `BasicProgress` percentage and completed bytes when total is known | Fixes impossible CLI progress displays; normal progress output is unchanged |
| `curvine-common/src/utils/display.rs` | Add regression test for over-complete progress display | Prevents regressions for `200.0%` style output |
| `curvine-common/src/state/job.rs` | Clamp formatted `JobTaskProgress` byte counts to the known total | Keeps client wait logs and status formatting consistent with the CLI |
| `curvine-common/src/state/job.rs` | Add bar and non-bar formatting regression coverage | Prevents raw over-complete byte counts from returning through this progress surface |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-common test_basic_progress_caps_over_complete_display -- --nocapture` before fix | PASS | Existing CLI regression coverage remains green |
| `cargo test -p curvine-common state::job::tests::progress_string_caps_loaded_bytes_at_total --lib -- --exact` before fix | FAIL | Confirmed the new regression test catches raw `66/33` byte output |
| `cargo test -p curvine-common state::job::tests::progress_string_caps_loaded_bytes_at_total --lib -- --exact` after fix | PASS | Targeted status-formatting regression test passes |
| `cargo test -p curvine-common --lib -- --skip fs::state_file::tests::test_write_read` | PASS | 73 passed; the skipped existing test fails independently because its `../testing` directory fixture is not created |
| `cargo check -p curvine-common --lib` | PASS | Common crate compiles cleanly |
| `cargo fmt --check` | PASS | Formatting clean |
| `/app/curvine/bin/cv` smoke test on `/acc-hdfs/starrocks` | PASS | Covered safe `fs` operations, `report`, `node`, `version`, explicit `load`, `export`, `load-status`, and auto-load; temporary test data was removed |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None
