### PR TITLE
fix(client): lazily initialize mount UFS

### DIFF
--- a/curvine-client/src/unified/mount_cache.rs
+++ b/curvine-client/src/unified/mount_cache.rs
@@ -67,6 +67,7 @@ use curvine_common::fs::Path;
 use curvine_common::state::MountInfo;
 use curvine_common::FsResult;
 use log::{debug, warn};
+use once_cell::sync::OnceCell;
 use orpc::common::{FastHashMap, LocalTime};
 use orpc::runtime::RpcRuntime;
 use orpc::sync::AtomicCounter;
@@ -79,21 +80,28 @@ use tokio::sync::Mutex;
 /// Contains mount metadata, UFS handler, and path conversion utilities.
 pub struct MountValue {
     pub info: MountInfo,
-    pub ufs: UfsFileSystem,
+    ufs: OnceCell<UfsFileSystem>,
     pub mount_id: String,
 }
 
 impl MountValue {
     pub fn new(info: MountInfo) -> FsResult<Self> {
-        let ufs_path = Path::from_str(&info.ufs_path)?;
-        let ufs = UfsFileSystem::new(&ufs_path, info.properties.clone(), info.provider)?;
         let mount_id = format!("{}", info.mount_id);
 
         Ok(Self {
             info,
-            ufs,
+            ufs: OnceCell::new(),
             mount_id,
         })
+    }
+
+    pub fn ufs(&self) -> FsResult<UfsFileSystem> {
+        self.ufs
+            .get_or_try_init(|| {
+                let ufs_path = Path::from_str(&self.info.ufs_path)?;
+                UfsFileSystem::new(&ufs_path, self.info.properties.clone(), self.info.provider)
+            })
+            .cloned()
     }
 
     /// Converts CV path to UFS path
@@ -331,5 +339,60 @@ impl MountCache {
     pub fn remove(&self, path: &Path) {
         let mut state = self.mounts.write().unwrap();
         state.remove(path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use curvine_common::state::{AccessMode, MountInfo, Provider, TtlAction, WriteType};
+    use std::collections::HashMap;
+
+    fn opendal_oss_mount() -> MountInfo {
+        MountInfo {
+            cv_path: "/oss-mount/data".to_string(),
+            ufs_path: "oss://example-bucket/data".to_string(),
+            mount_id: 1,
+            properties: HashMap::new(),
+            ttl_ms: 7 * 24 * 60 * 60 * 1000,
+            ttl_action: TtlAction::Delete,
+            read_verify_ufs: false,
+            storage_type: None,
+            block_size: None,
+            replicas: None,
+            write_type: WriteType::CacheMode,
+            provider: Some(Provider::Opendal),
+            auto_cache: true,
+            access_mode: AccessMode::ReadOnly,
+        }
+    }
+
+    #[test]
+    fn cache_insert_is_metadata_only_for_unsupported_provider() {
+        let mut mounts = InnerMap::default();
+
+        mounts
+            .insert(opendal_oss_mount())
+            .expect("mount cache refresh should not initialize UFS providers");
+
+        assert!(mounts.get(true, "/flink/checkpoints").is_none());
+        let mount = mounts
+            .get(true, "/oss-mount/data")
+            .expect("mounted path should be cached");
+        assert!(mount.ufs.get().is_none());
+    }
+
+    #[test]
+    fn unsupported_provider_error_is_lazy_until_mount_use() {
+        let mut mounts = InnerMap::default();
+        mounts
+            .insert(opendal_oss_mount())
+            .expect("mount cache refresh should not initialize UFS providers");
+
+        let mount = mounts
+            .get(true, "/oss-mount/data")
+            .expect("mounted path should be cached");
+
+        assert!(mount.ufs().is_err());
     }
 }

--- a/curvine-client/src/unified/unified_filesystem.rs
+++ b/curvine-client/src/unified/unified_filesystem.rs
@@ -333,7 +333,7 @@ impl UnifiedFileSystem {
         mount: &MountValue,
     ) -> FsResult<CacheValidity> {
         if mount.info.read_verify_ufs {
-            let ufs_status = mount.ufs.get_status(ufs_path).await?;
+            let ufs_status = mount.ufs()?.get_status(ufs_path).await?;
             if cv_status.cv_valid(Some(&ufs_status)) {
                 Ok(CacheValidity::Valid)
             } else {
@@ -368,7 +368,7 @@ impl UnifiedFileSystem {
                 Ok(Some(FallbackFsReader::new(
                     cv_reader,
                     ufs_path.clone(),
-                    mount.ufs.clone(),
+                    mount.ufs()?,
                     mount.info.is_fs_mode(),
                 )))
             } else if blocks.ufs_exists() {
@@ -387,7 +387,7 @@ impl UnifiedFileSystem {
                     Ok(Some(FallbackFsReader::new(
                         cv_reader,
                         ufs_path.clone(),
-                        mount.ufs.clone(),
+                        mount.ufs()?,
                         mount.info.is_fs_mode(),
                     )))
                 }
@@ -475,7 +475,7 @@ impl UnifiedFileSystem {
     ) -> FsResult<()> {
         let opts = mnt.info.merge_create_opts(opts);
         let ufs_path = mnt.get_ufs_path(path)?;
-        let mut reader = mnt.ufs.open(&ufs_path).await?;
+        let mut reader = mnt.ufs()?.open(&ufs_path).await?;
         if reader.len() != cv_len {
             return err_box!(
                 "file length mismatch: cv_path={:?}, ufs_path={:?}, ufs_len={}, cv_len={}",
@@ -558,10 +558,11 @@ impl UnifiedFileSystem {
                     }
 
                     write_path = ufs_path.full_path().to_owned();
+                    let ufs = mount.ufs()?;
                     if flags.append() {
-                        mount.ufs.append(&ufs_path).await
+                        ufs.append(&ufs_path).await
                     } else {
-                        mount.ufs.create(&ufs_path, flags.overwrite()).await
+                        ufs.create(&ufs_path, flags.overwrite()).await
                     }
                 }
             }
@@ -586,7 +587,7 @@ impl UnifiedFileSystem {
                 None => Ok(Some(self.cv.mkdir_with_opts(path, opts).await?)),
 
                 Some((ufs_path, mount)) => {
-                    let flag = mount.ufs.mkdir(&ufs_path, opts.create_parent).await?;
+                    let flag = mount.ufs()?.mkdir(&ufs_path, opts.create_parent).await?;
                     if !flag {
                         err_ext!(FsError::file_exists(ufs_path.path()))
                     } else {
@@ -671,7 +672,7 @@ impl FileSystem<UnifiedWriter, UnifiedReader> for UnifiedFileSystem {
         let fut = async {
             match self.get_mount_checked(path, RpcCode::Exists).await? {
                 None => self.cv.exists(path).await,
-                Some((ufs_path, mount)) => mount.ufs.exists(&ufs_path).await,
+                Some((ufs_path, mount)) => mount.ufs()?.exists(&ufs_path).await,
             }
         };
         self.track("Exists", path.path(), "", fut).await
@@ -720,7 +721,7 @@ impl FileSystem<UnifiedWriter, UnifiedReader> for UnifiedFileSystem {
                 // Reading from ufs
                 if self.enable_read_ufs {
                     debug!("read from ufs, ufs path {}, cv path: {}", ufs_path, path);
-                    mount.ufs.open(&ufs_path).await
+                    mount.ufs()?.open(&ufs_path).await
                 } else {
                     err_ext!(FsError::unsupported_ufs_read(path.path()))
                 }
@@ -742,7 +743,7 @@ impl FileSystem<UnifiedWriter, UnifiedReader> for UnifiedFileSystem {
                 None => self.cv.rename(src, dst).await,
                 Some((src_ufs, mount)) => {
                     let dst_ufs = mount.get_ufs_path(dst)?;
-                    let res = mount.ufs.rename(&src_ufs, &dst_ufs).await?;
+                    let res = mount.ufs()?.rename(&src_ufs, &dst_ufs).await?;
 
                     // After rename, the file's mtime changes, making the cached data invalid
                     if let Err(e) = self.cv.delete(src, true).await {
@@ -771,7 +772,7 @@ impl FileSystem<UnifiedWriter, UnifiedReader> for UnifiedFileSystem {
                         );
                     }
 
-                    mount.ufs.delete(&ufs_path, recursive).await?;
+                    mount.ufs()?.delete(&ufs_path, recursive).await?;
 
                     // delete cache
                     if let Err(e) = self.cv.delete(path, recursive).await {
@@ -801,14 +802,14 @@ impl FileSystem<UnifiedWriter, UnifiedReader> for UnifiedFileSystem {
                             Ok(v)
                         }
                         CacheValidity::Invalid(Some(ufs_status)) => Ok(ufs_status),
-                        CacheValidity::Invalid(None) => mnt.ufs.get_status(&ufs_path).await,
+                        CacheValidity::Invalid(None) => mnt.ufs()?.get_status(&ufs_path).await,
                     },
 
                     Err(e) => {
                         if !matches!(e, FsError::FileNotFound(_) | FsError::Expired(_)) {
                             warn!("failed to get status file {}: {}", path, e);
                         };
-                        mnt.ufs.get_status(&ufs_path).await
+                        mnt.ufs()?.get_status(&ufs_path).await
                     }
                 },
             }
@@ -820,7 +821,7 @@ impl FileSystem<UnifiedWriter, UnifiedReader> for UnifiedFileSystem {
         let fut = async {
             match self.get_mount_checked(path, RpcCode::ListStatus).await? {
                 None => self.cv.list_status(path).await,
-                Some((ufs_path, mount)) => mount.ufs.list_status(&ufs_path).await,
+                Some((ufs_path, mount)) => mount.ufs()?.list_status(&ufs_path).await,
             }
         };
         self.track("ListStatus", path.path(), "", fut).await
@@ -830,7 +831,7 @@ impl FileSystem<UnifiedWriter, UnifiedReader> for UnifiedFileSystem {
         let fut = async {
             match self.get_mount_checked(path, RpcCode::ListStatus).await? {
                 None => self.cv.list_status_bytes(path).await,
-                Some((ufs_path, mount)) => mount.ufs.list_status_bytes(&ufs_path).await,
+                Some((ufs_path, mount)) => mount.ufs()?.list_status_bytes(&ufs_path).await,
             }
         };
         self.track("ListStatus", path.path(), "", fut).await
@@ -840,7 +841,7 @@ impl FileSystem<UnifiedWriter, UnifiedReader> for UnifiedFileSystem {
         let fut = async {
             match self.get_mount_checked(path, RpcCode::ListOptions).await? {
                 None => self.cv.list_options(path, options).await,
-                Some((ufs_path, mount)) => mount.ufs.list_options(&ufs_path, options).await,
+                Some((ufs_path, mount)) => mount.ufs()?.list_options(&ufs_path, options).await,
             }
         };
         self.track("ListOptions", path.path(), "", fut).await
@@ -850,7 +851,9 @@ impl FileSystem<UnifiedWriter, UnifiedReader> for UnifiedFileSystem {
         let fut = async {
             match self.get_mount_checked(path, RpcCode::ListOptions).await? {
                 None => self.cv.list_options_bytes(path, options).await,
-                Some((ufs_path, mount)) => mount.ufs.list_options_bytes(&ufs_path, options).await,
+                Some((ufs_path, mount)) => {
+                    mount.ufs()?.list_options_bytes(&ufs_path, options).await
+                }
             }
         };
         self.track("ListOptions", path.path(), "", fut).await
@@ -860,7 +863,7 @@ impl FileSystem<UnifiedWriter, UnifiedReader> for UnifiedFileSystem {
         let fut = async {
             match self.get_mount_checked(path, RpcCode::ListOptions).await? {
                 None => self.cv.list_stream(path, options).await,
-                Some((ufs_path, mount)) => mount.ufs.list_stream(&ufs_path, options).await,
+                Some((ufs_path, mount)) => mount.ufs()?.list_stream(&ufs_path, options).await,
             }
         };
         self.track("ListStream", path.path(), "", fut).await

--- a/curvine-server/src/common/ufs_factory.rs
+++ b/curvine-server/src/common/ufs_factory.rs
@@ -58,6 +58,6 @@ impl UfsFactory {
     }
 
     pub fn get_ufs(&self, mnt: &MountInfo) -> FsResult<UfsFileSystem> {
-        self.get_mnt(mnt).map(|x| x.ufs.clone())
+        self.get_mnt(mnt)?.ufs()
     }
 }

--- a/curvine-server/src/master/job/job_runner.rs
+++ b/curvine-server/src/master/job/job_runner.rs
@@ -226,7 +226,7 @@ impl LoadJobRunner {
         }
 
         // Target looks valid locally; confirm against UFS source before skipping.
-        let source_status = mnt.ufs.get_status(source_path).await?;
+        let source_status = mnt.ufs()?.get_status(source_path).await?;
         Ok(cv_status.cv_valid(Some(&source_status)))
     }
 

--- a/curvine-server/src/master/journal/ufs_loader.rs
+++ b/curvine-server/src/master/journal/ufs_loader.rs
@@ -63,18 +63,18 @@ impl UfsLoader {
 
     async fn mkdir_parent(&self, path: &Path, mnt: &MountValue) -> FsResult<()> {
         if let Some(parent) = mnt.info.get_ufs_path(path)?.parent()? {
-            mnt.ufs.mkdir(&parent, true).await?;
+            mnt.ufs()?.mkdir(&parent, true).await?;
         }
         Ok(())
     }
 
     async fn mkdir_with_parent_retry(&self, path: &Path, mnt: &MountValue) -> FsResult<bool> {
         let ufs_path = mnt.info.get_ufs_path(path)?;
-        match mnt.ufs.mkdir(&ufs_path, false).await {
+        match mnt.ufs()?.mkdir(&ufs_path, false).await {
             Ok(created) => Ok(created),
             Err(FsError::FileNotFound(_)) => {
                 self.mkdir_parent(path, mnt).await?;
-                mnt.ufs.mkdir(&ufs_path, false).await
+                mnt.ufs()?.mkdir(&ufs_path, false).await
             }
             Err(e) => Err(e),
         }
@@ -152,7 +152,8 @@ impl UfsLoader {
         let src = Path::from_str(&e.src)?;
         let dst = Path::from_str(&e.dst)?;
         if let Some((src_ufs_path, mnt)) = self.get_mnt(&src)? {
-            if !mnt.ufs.exists(&src_ufs_path).await? {
+            let ufs = mnt.ufs()?;
+            if !ufs.exists(&src_ufs_path).await? {
                 warn!(
                     "rename: src file not exists: {}, exporting dst {}",
                     src_ufs_path,
@@ -166,21 +167,21 @@ impl UfsLoader {
             }
 
             let src_dst_path = mnt.info.get_ufs_path(&dst)?;
-            if mnt.ufs.fs_kind().support_rename() {
-                match mnt.ufs.rename(&src_ufs_path, &src_dst_path).await {
+            if ufs.fs_kind().support_rename() {
+                match ufs.rename(&src_ufs_path, &src_dst_path).await {
                     Ok(_) => {}
                     Err(e @ FsError::FileNotFound(_)) => {
-                        if !mnt.ufs.exists(&src_ufs_path).await? {
+                        if !ufs.exists(&src_ufs_path).await? {
                             return Err(e.into());
                         }
                         self.mkdir_parent(&dst, &mnt).await?;
-                        mnt.ufs.rename(&src_ufs_path, &src_dst_path).await?;
+                        ufs.rename(&src_ufs_path, &src_dst_path).await?;
                     }
                     Err(e) => return Err(e.into()),
                 }
                 Ok(())
             } else {
-                mnt.ufs.delete(&src_ufs_path, true).await?;
+                ufs.delete(&src_ufs_path, true).await?;
                 self.submit_export_task(&dst, &mnt).await?;
                 Ok(())
             }
@@ -192,8 +193,9 @@ impl UfsLoader {
     pub async fn delete(&self, e: &DeleteEntry) -> CommonResult<()> {
         let path = Path::from_str(&e.path)?;
         if let Some((ufs_path, mnt)) = self.get_mnt(&path)? {
-            if mnt.ufs.exists(&ufs_path).await? {
-                mnt.ufs.delete(&ufs_path, true).await?;
+            let ufs = mnt.ufs()?;
+            if ufs.exists(&ufs_path).await? {
+                ufs.delete(&ufs_path, true).await?;
             } else {
                 warn!("delete: src file not exists: {}", ufs_path);
             }

--- a/curvine-tests/tests/fallback_read_test.rs
+++ b/curvine-tests/tests/fallback_read_test.rs
@@ -155,7 +155,7 @@ async fn write_ufs_and_warm_cache(
         .unwrap()
         .unwrap();
 
-    let mut w = mount.ufs.create(&ufs_path, true).await.unwrap();
+    let mut w = mount.ufs().unwrap().create(&ufs_path, true).await.unwrap();
     w.write(data.as_bytes()).await.unwrap();
     w.complete().await.unwrap();
 
@@ -223,7 +223,7 @@ async fn build_reader_with_unreachable_worker(
     FallbackFsReader::new(
         cv_reader,
         ufs_path,
-        mount.ufs.clone(),
+        mount.ufs().unwrap(),
         mount.info.is_fs_mode(),
     )
 }
@@ -398,7 +398,7 @@ fn test_tc12_worker_failure_ufs_mtime_mismatch_returns_error() {
             .await
             .unwrap()
             .unwrap();
-        let mut ufs_writer = mount.ufs.create(&ufs_path, true).await.unwrap();
+        let mut ufs_writer = mount.ufs().unwrap().create(&ufs_path, true).await.unwrap();
         ufs_writer.write(b"changed-in-ufs").await.unwrap();
         ufs_writer.complete().await.unwrap();
 
@@ -510,7 +510,7 @@ fn test_tc17_cachemode_worker_failure_pos0_reads_current_s3() {
             .await
             .unwrap()
             .unwrap();
-        let mut w = mount.ufs.create(&ufs_path, true).await.unwrap();
+        let mut w = mount.ufs().unwrap().create(&ufs_path, true).await.unwrap();
         w.write(changed.as_bytes()).await.unwrap();
         w.complete().await.unwrap();
 
@@ -556,7 +556,7 @@ fn test_tc18_cachemode_worker_failure_shrunk_past_pos_errors() {
             .await
             .unwrap()
             .unwrap();
-        let mut w = mount.ufs.create(&ufs_path, true).await.unwrap();
+        let mut w = mount.ufs().unwrap().create(&ufs_path, true).await.unwrap();
         w.write(changed.as_bytes()).await.unwrap();
         w.complete().await.unwrap();
 
@@ -636,7 +636,7 @@ fn test_tc20_cachemode_worker_failure_grown_reads_current_s3() {
             .await
             .unwrap()
             .unwrap();
-        let mut w = mount.ufs.create(&ufs_path, true).await.unwrap();
+        let mut w = mount.ufs().unwrap().create(&ufs_path, true).await.unwrap();
         w.write(changed.as_bytes()).await.unwrap();
         w.complete().await.unwrap();
 
@@ -683,7 +683,7 @@ fn test_tc21_cachemode_fallback_len_reflects_current_s3() {
             .await
             .unwrap()
             .unwrap();
-        let mut w = mount.ufs.create(&ufs_path, true).await.unwrap();
+        let mut w = mount.ufs().unwrap().create(&ufs_path, true).await.unwrap();
         w.write(changed.as_bytes()).await.unwrap();
         w.complete().await.unwrap();
 

--- a/curvine-tests/tests/write_cache_test.rs
+++ b/curvine-tests/tests/write_cache_test.rs
@@ -53,14 +53,15 @@ fn test_cache_mode() {
             .await
             .unwrap()
             .unwrap();
-        let ufs_reader_before = mnt.ufs.open(&ufs_path).await.unwrap();
+        let ufs = mnt.ufs().unwrap();
+        let ufs_reader_before = ufs.open(&ufs_path).await.unwrap();
         let mtime_before = ufs_reader_before.status().mtime;
         drop(ufs_reader_before);
 
         fs.async_cache(&path).unwrap();
         fs.wait_job_complete(&path, false).await.unwrap();
 
-        let ufs_reader_after = mnt.ufs.open(&ufs_path).await.unwrap();
+        let ufs_reader_after = ufs.open(&ufs_path).await.unwrap();
         let mtime_after = ufs_reader_after.status().mtime;
         drop(ufs_reader_after);
         assert_eq!(
@@ -140,7 +141,7 @@ fn test_fs_mode() {
         let mut ufs_gone = awaitility::at_most(Duration::from_secs(60));
         ufs_gone.poll_interval(Duration::from_millis(100));
         ufs_gone
-            .until_async(|| async { !mnt.ufs.exists(&ufs_path).await.unwrap_or(true) })
+            .until_async(|| async { !mnt.ufs().unwrap().exists(&ufs_path).await.unwrap_or(true) })
             .await;
         ufs_gone
             .result()
@@ -174,7 +175,7 @@ fn test_cache_mode_free() {
             .await
             .unwrap()
             .unwrap();
-        assert!(mnt.ufs.exists(&ufs_path).await.unwrap());
+        assert!(mnt.ufs().unwrap().exists(&ufs_path).await.unwrap());
 
         fs.free(&path, false).await.unwrap();
 
@@ -183,7 +184,7 @@ fn test_cache_mode_free() {
             "cache mode free should remove Curvine file metadata"
         );
         assert!(
-            mnt.ufs.exists(&ufs_path).await.unwrap(),
+            mnt.ufs().unwrap().exists(&ufs_path).await.unwrap(),
             "cache mode free must not delete the UFS file"
         );
 
@@ -402,7 +403,7 @@ async fn try_verify_cv_ufs_consistency(fs: &UnifiedFileSystem, path: &Path) -> b
         Ok(Some(v)) => v,
         _ => return false,
     };
-    let mut ufs_reader = match mnt.ufs.open(&ufs_path).await {
+    let mut ufs_reader = match mnt.ufs().unwrap().open(&ufs_path).await {
         Ok(r) => r,
         Err(_) => return false,
     };


### PR DESCRIPTION
# Summary

This PR makes mount cache refresh metadata-only by lazily initializing each mount UFS handler only when that mount is actually used. This prevents one unsupported optional UFS provider in the global mount table from breaking unrelated Curvine client operations.

# Issue Describe / Design

Root cause:
- `InnerMap::insert` called `MountValue::new`, and `MountValue::new` eagerly built `UfsFileSystem` from every mount entry during mount table refresh.
- A client build that does not support a specific provider/scheme combination, for example an `oss://` mount using the opendal provider, can fail refresh with `Unsupported scheme: oss`.
- Because normal client operations call mount lookup before proceeding, that refresh error can propagate to unrelated `cv://` writes outside the problematic mount.

Reproduction steps:
- Add a mount table entry whose UFS provider/scheme is unsupported by the current client build.
- Perform an unrelated Curvine write path that triggers mount cache refresh.
- The write fails during refresh before it reaches its own target path.

Fix approach:
- Store only `MountInfo` and path indexes during mount cache refresh.
- Move UFS construction behind `MountValue::ufs()` using `once_cell::sync::OnceCell`.
- Keep provider errors visible when the request actually uses that mount.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-client/src/unified/mount_cache.rs` | Make `MountValue::new` metadata-only and lazily initialize UFS via `ufs()` | Mount refresh no longer fails because of unused unsupported providers |
| `curvine-client/src/unified/unified_filesystem.rs` | Replace direct `mount.ufs` field usage with `mount.ufs()?` | UFS errors are preserved for matched mount operations |
| `curvine-server/src/common/ufs_factory.rs` | Return lazy UFS from cached mount values | Same UFS cache semantics, lazy construction |
| `curvine-server/src/master/journal/ufs_loader.rs` | Use lazy UFS accessor in journal UFS operations | No intended behavior change |
| `curvine-server/src/master/job/job_runner.rs` | Use lazy UFS accessor in load-job validation | No intended behavior change |
| `curvine-tests/tests/write_cache_test.rs` | Update tests for lazy UFS accessor | Test-only API adjustment |
| `curvine-tests/tests/fallback_read_test.rs` | Update tests for lazy UFS accessor | Test-only API adjustment |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-client mount_cache::tests -- --nocapture` | PASS | Covers metadata-only insert and lazy provider error |
| `cargo test -p curvine-client --no-default-features mount_cache::tests -- --nocapture` | PASS | Covers reduced-feature client build |
| `cargo test -p curvine-client --lib` | PASS | 53 passed |
| `cargo test -p curvine-server --lib` | PASS | 82 passed, 1 ignored |
| `cargo test -p curvine-tests --test write_cache_test --no-run` | PASS | Compile check |
| `cargo test -p curvine-tests --test fallback_read_test --no-run` | PASS | Compile check |
| `cargo test -p curvine-server --test load_job_submit_test --no-run` | PASS | Compile check |
| `make format` | PASS | Includes workspace release checks and pre-commit script |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None