### PR TITLE
fix(conf): restore localhost hostname defaults (#1134)

### DIFF
--- a/etc/curvine-env.sh
+++ b/etc/curvine-env.sh
@@ -18,24 +18,8 @@
 
 export CURVINE_HOME="$(cd "$(dirname "$0")"/..; pwd)"
 
-OS_NAME=$(uname 2>/dev/null || echo unknown)
-LOCAL_HOSTNAME=$(hostname 2>/dev/null || true)
-LOCAL_HOSTNAME=${LOCAL_HOSTNAME:-localhost}
-
-# Get the last IP address from local network interfaces, falling back to loopback.
-LOCAL_IP=127.0.0.1
-case "$OS_NAME" in
-    Linux)
-        DETECTED_IP=$(hostname -I 2>/dev/null | awk '{print $NF}')
-        ;;
-    Darwin)
-        DETECTED_IP=$(ifconfig 2>/dev/null | awk '$1 == "inet" && $2 != "127.0.0.1" { ip = $2 } END { print ip }')
-        ;;
-    *)
-        DETECTED_IP=
-        ;;
-esac
-LOCAL_IP=${DETECTED_IP:-$LOCAL_IP}
+LOCAL_HOSTNAME=localhost
+LOCAL_IP=localhost
 
 # master bound host name
 export CURVINE_MASTER_HOSTNAME=${CURVINE_MASTER_HOSTNAME:-$LOCAL_HOSTNAME}


### PR DESCRIPTION
# Summary

Restore `localhost` as the default master, worker, and client hostname for local deployments. This prevents auto-detected, unreachable network addresses from causing FUSE write failures.

# Issue Describe / Design

Closes #1134

Root cause: hostname and IP auto-detection may select an unreachable IPv6, container, virtual-interface, or multi-NIC address.

Reproduction: start a local cluster without hostname overrides, mount FUSE, and write a file. If the worker registers an unreachable address, the write fails with `EIO`.

Fix approach: set `LOCAL_HOSTNAME` and `LOCAL_IP` to `localhost`, while preserving explicit environment-variable overrides.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `etc/curvine-env.sh` | Set `LOCAL_HOSTNAME` and `LOCAL_IP` to `localhost`, removing automatic network detection | Local deployments use loopback by default while retaining explicit environment overrides |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| Shell syntax validation | PASS | `etc/curvine-env.sh` passed `bash -n` |
| Default hostname assertions | PASS | Master, worker, and client hostnames resolve to `localhost` |
| Environment override assertions | PASS | Explicit hostname values remain unchanged |
| `git diff --check` | PASS | No whitespace errors |
| `make format` | NOT RUN | `make` is unavailable in the current environment |

# Dependencies

- Related PRs: None
- Related issues: #1134
- Blocks / blocked by: None