### PR TITLE
feat(client): track master and worker RPC latency

### DIFF
--- a/curvine-client/src/block/block_client.rs
+++ b/curvine-client/src/block/block_client.rs
@@ -226,7 +226,7 @@ impl BlockClient {
             .proto_header(header)
             .build();
 
-        let _ = self.rpc(msg).await?;
+        let _ = FsContext::metrics_track("WriteCommitBlock", self.rpc(msg)).await?;
         Ok(())
     }
 
@@ -260,7 +260,7 @@ impl BlockClient {
             .proto_header(request)
             .build();
 
-        let rep = self.rpc(msg).await?;
+        let rep = FsContext::metrics_track("OpenBlock", self.rpc(msg)).await?;
         let rep_header: BlockReadResponse = rep.parse_header()?;
 
         Ok(BlockReadContext::from_req(rep_header))
@@ -285,7 +285,7 @@ impl BlockClient {
             .proto_header(request)
             .build();
 
-        let _ = self.rpc(msg).await?;
+        let _ = FsContext::metrics_track("ReadCommitBlock", self.rpc(msg)).await?;
         Ok(())
     }
 

--- a/curvine-client/src/file/fs_client.rs
+++ b/curvine-client/src/file/fs_client.rs
@@ -316,7 +316,8 @@ impl FsClient {
             inode_id,
         };
 
-        let rep_header = self.rpc(RpcCode::AddBlock, header).await?;
+        let rep_header =
+            FsContext::metrics_track("AddBlock", self.rpc(RpcCode::AddBlock, header)).await?;
         let locate_block = ProtoUtils::located_block_from_pb(rep_header);
         Ok(locate_block)
     }
@@ -396,7 +397,9 @@ impl FsClient {
             inode_id,
         };
 
-        let rep: CompleteFileResponse = self.rpc(RpcCode::CompleteFile, header).await?;
+        let operation = if only_flush { "Flush" } else { "Complete" };
+        let rep: CompleteFileResponse =
+            FsContext::metrics_track(operation, self.rpc(RpcCode::CompleteFile, header)).await?;
 
         Ok(rep.file_blocks.map(ProtoUtils::file_blocks_from_pb))
     }

--- a/curvine-client/src/file/fs_context.rs
+++ b/curvine-client/src/file/fs_context.rs
@@ -26,11 +26,12 @@ use moka::policy::EvictionPolicy;
 use moka::sync::{Cache, CacheBuilder};
 use once_cell::sync::OnceCell;
 use orpc::client::{ClientConf, ClusterConnector};
-use orpc::common::Utils;
+use orpc::common::{TimeSpent, Utils};
 use orpc::io::net::NetUtils;
 use orpc::io::IOResult;
 use orpc::runtime::{RpcRuntime, Runtime};
 use orpc::sys::CacheManager;
+use std::future::Future;
 use std::hash::BuildHasherDefault;
 use std::sync::Arc;
 use std::time::Duration;
@@ -177,6 +178,19 @@ impl FsContext {
 
     pub fn get_metrics<'a>() -> &'a ClientMetrics {
         CLIENT_METRICS.get().expect("client get metrics error!")
+    }
+
+    pub async fn metrics_track<F, T>(operation: &'static str, future: F) -> FsResult<T>
+    where
+        F: Future<Output = FsResult<T>>,
+    {
+        let spent = TimeSpent::new();
+        let result = future.await;
+        Self::get_metrics()
+            .metadata_operation_duration
+            .with_label_values(&[operation])
+            .observe(spent.used_us() as f64);
+        result
     }
 
     // Exclude a worker


### PR DESCRIPTION
# Summary

Add client-side latency metrics for master and worker block lifecycle RPCs. All operations are reported through the existing `client_metadata_operation_duration` histogram.

# Issue Describe / Design

No related issue.

The change introduces an async `FsContext::metrics_track` helper that measures a supplied RPC future and returns its original result unchanged. This keeps timing behavior consistent across master and worker calls and records both successful and failed RPC durations.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-client/src/file/fs_context.rs` | Add the reusable async `metrics_track` helper | Adds latency observation without changing RPC results |
| `curvine-client/src/file/fs_client.rs` | Track `AddBlock`, `Flush`, and `Complete` master RPCs | Adds metrics only |
| `curvine-client/src/block/block_client.rs` | Track `OpenBlock` and read/write `CommitBlock` worker RPCs | Adds metrics only |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo fmt --all -- --check` | PASS | Formatting verified |
| `git diff --check` | PASS | No whitespace errors |
| Compile / tests | NOT RUN | Per request, validation was limited to static inspection |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None