### PR TITLE
fix(fuse): reject overlong lookup names

### DIFF
--- a/build/tests/fuse-test.sh
+++ b/build/tests/fuse-test.sh
@@ -64,6 +64,7 @@ This script tests basic filesystem operations including:
   - Active-writer path truncate regression (PR #962)
   - Read-only open with O_CREAT creates a missing file
   - Mode 0000 is preserved by chmod, fchmod, and umask-filtered create
+  - Overlong lookup names return ENAMETOOLONG
 
 For FIO performance tests, use fio-test.sh instead.
 
@@ -1389,6 +1390,15 @@ test_mode_zero_permissions() {
         "mode_zero_permissions_repro.py" --dir "$TEST_DIR"
 }
 
+# Test 24: lookup of an overlong name returns ENAMETOOLONG
+test_lookup_enametoolong() {
+    CURRENT_TEST_GROUP="Test 24: Lookup ENAMETOOLONG"
+    print_header "$CURRENT_TEST_GROUP"
+    run_python_script_test \
+        "Testing lookup on overlong names returns ENAMETOOLONG" \
+        "lookup_enametoolong_repro.py" --dir "$TEST_DIR"
+}
+
 # Print final report
 print_report() {
     print_header "Test Summary"
@@ -1497,6 +1507,7 @@ main() {
     test_pr962_active_writer_truncate
     test_open_creat_rdonly
     test_mode_zero_permissions
+    test_lookup_enametoolong
 
     test_git_clone
 

--- a/build/tests/scripts/lookup_enametoolong_repro.py
+++ b/build/tests/scripts/lookup_enametoolong_repro.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+#  // Copyright 2025 OPPO.
+#  //
+#  // Licensed under the Apache License, Version 2.0 (the "License");
+#  // you may not use this file except in compliance with the License.
+#  // You may obtain a copy of the License at
+#  //
+#  //     http://www.apache.org/licenses/LICENSE-2.0
+#  //
+#  // Unless required by applicable law or agreed to in writing, software
+#  // distributed under the License is distributed on an "AS IS" BASIS,
+#  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  // See the License for the specific language governing permissions and
+#  // limitations under the License.
+
+"""
+Regression test for lookup of a name longer than the FUSE name limit.
+
+Curvine FUSE advertises a 255-byte name limit. Lookup operations on a single
+path component longer than that must fail with ENAMETOOLONG instead of falling
+through to a backend lookup and returning ENOENT.
+"""
+
+import argparse
+import errno
+import os
+import shutil
+import sys
+from typing import Callable
+
+DEFAULT_DIR = "/curvine-fuse/fuse-test"
+LONG_NAME = "a" * 256
+
+
+def case_dir(root: str, name: str) -> str:
+    path = os.path.join(root, name)
+    if os.path.exists(path):
+        shutil.rmtree(path)
+    os.makedirs(path)
+    return path
+
+
+def is_mount_path(path: str) -> bool:
+    probe = os.path.abspath(path)
+    while probe != "/":
+        if os.path.ismount(probe):
+            return True
+        probe = os.path.dirname(probe)
+    return False
+
+
+def expect_enametoolong(name: str, fn: Callable[[], None]) -> int:
+    try:
+        fn()
+    except OSError as exc:
+        if exc.errno == errno.ENAMETOOLONG:
+            print(f"  PASS: {name}")
+            return 0
+        print(
+            f"  FAIL: {name}: expected ENAMETOOLONG, got errno={exc.errno} "
+            f"({errno.errorcode.get(exc.errno, '?')}): {exc}",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"  FAIL: {name}: operation unexpectedly succeeded", file=sys.stderr)
+    return 1
+
+
+def test_chdir_long_name(workdir: str) -> int:
+    def run() -> None:
+        old_cwd = os.getcwd()
+        try:
+            os.chdir(workdir)
+            os.chdir(LONG_NAME)
+        finally:
+            os.chdir(old_cwd)
+
+    return expect_enametoolong("chdir on 256-byte name returns ENAMETOOLONG", run)
+
+
+def test_open_long_name(workdir: str) -> int:
+    def run() -> None:
+        os.open(os.path.join(workdir, LONG_NAME), os.O_RDWR)
+
+    return expect_enametoolong("open on 256-byte name returns ENAMETOOLONG", run)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="lookup ENAMETOOLONG regression test",
+    )
+    parser.add_argument(
+        "--dir",
+        default=DEFAULT_DIR,
+        help="Base test directory on the Curvine FUSE mount",
+    )
+    parser.add_argument(
+        "--allow-non-mount",
+        action="store_true",
+        help="Skip mount check; for local debugging only",
+    )
+    args = parser.parse_args()
+
+    root = os.path.abspath(args.dir)
+    os.makedirs(root, exist_ok=True)
+
+    if not args.allow_non_mount and not is_mount_path(root):
+        print(f"FAIL: {root} is not under a mount point", file=sys.stderr)
+        return 1
+
+    workdir = case_dir(root, "lookup_enametoolong")
+    failures = test_chdir_long_name(workdir)
+    failures += test_open_long_name(workdir)
+
+    if failures:
+        print(f"FAIL: lookup ENAMETOOLONG regression ({failures} failures)")
+        return 1
+
+    print("PASS: lookup ENAMETOOLONG regression")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -441,6 +441,9 @@ impl fs::FileSystem for CurvineFileSystem {
     // Query inode.
     async fn lookup(&self, op: Lookup<'_>) -> FuseResult<fuse_entry_out> {
         let name = try_option!(op.name.to_str());
+        if name.len() > FUSE_MAX_NAME_LENGTH {
+            return err_fuse!(libc::ENAMETOOLONG);
+        }
 
         self.check_permissions(op.header, libc::X_OK as u32).await?;
 


### PR DESCRIPTION
 Fix FUSE lookup returning ENOENT instead of ENAMETOOLONG for overlong path components.
 When chdir() or open() was called with a single filename component longer than Curvine FUSE’s advertised name limit, Curvine continued into normal lookup and returned ENOENT. Linux filesystems return ENAMETOOLONG for this case.