### PR TITLE
fix(fuse): inherit group in setgid directories

### DIFF
--- a/build/tests/fuse-test.sh
+++ b/build/tests/fuse-test.sh
@@ -64,6 +64,7 @@ This script tests basic filesystem operations including:
   - Active-writer path truncate regression (PR #962)
   - Read-only open with O_CREAT creates a missing file
   - Mode 0000 is preserved by chmod, fchmod, and umask-filtered create
+  - Files created in setgid directories inherit the parent group
 
 For FIO performance tests, use fio-test.sh instead.
 
@@ -1389,6 +1390,15 @@ test_mode_zero_permissions() {
         "mode_zero_permissions_repro.py" --dir "$TEST_DIR"
 }
 
+# Test 24: files created in setgid directories inherit the parent group
+test_setgid_group_inherit() {
+    CURRENT_TEST_GROUP="Test 24: Setgid Group Inheritance"
+    print_header "$CURRENT_TEST_GROUP"
+    run_python_script_test \
+        "Testing file group inheritance in setgid directories" \
+        "setgid_group_inherit_repro.py" --dir "$TEST_DIR"
+}
+
 # Print final report
 print_report() {
     print_header "Test Summary"
@@ -1497,6 +1507,7 @@ main() {
     test_pr962_active_writer_truncate
     test_open_creat_rdonly
     test_mode_zero_permissions
+    test_setgid_group_inherit
 
     test_git_clone
 

--- a/build/tests/scripts/setgid_group_inherit_repro.py
+++ b/build/tests/scripts/setgid_group_inherit_repro.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+#  // Copyright 2025 OPPO.
+#  //
+#  // Licensed under the Apache License, Version 2.0 (the "License");
+#  // you may not use this file except in compliance with the License.
+#  // You may obtain a copy of the License at
+#  //
+#  //     http://www.apache.org/licenses/LICENSE-2.0
+#  //
+#  // Unless required by applicable law or agreed to in writing, software
+#  // distributed under the License is distributed on an "AS IS" BASIS,
+#  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  // See the License for the specific language governing permissions and
+#  // limitations under the License.
+
+"""
+Regression test for file group inheritance in setgid directories.
+
+When a regular file is created inside a directory with the setgid bit set, the
+new file must inherit the parent directory's group instead of the process group.
+"""
+
+import argparse
+import errno
+import grp
+import os
+import pwd
+import shutil
+import stat
+import sys
+
+DEFAULT_DIR = "/curvine-fuse/fuse-test"
+
+
+def case_dir(root: str, name: str) -> str:
+    path = os.path.join(root, name)
+    if os.path.exists(path):
+        shutil.rmtree(path)
+    os.makedirs(path)
+    return path
+
+
+def is_mount_path(path: str) -> bool:
+    probe = os.path.abspath(path)
+    while probe != "/":
+        if os.path.ismount(probe):
+            return True
+        probe = os.path.dirname(probe)
+    return False
+
+
+def run_case(root: str) -> None:
+    parent_gid = grp.getgrnam("bin").gr_gid
+    nobody = pwd.getpwnam("nobody")
+
+    workdir = case_dir(root, "setgid_group_inherit")
+    parent = os.path.join(workdir, "parent")
+    child = os.path.join(parent, "child")
+
+    os.mkdir(parent, 0o777)
+    os.chown(parent, 0, parent_gid)
+    os.chmod(parent, 0o2777)
+
+    parent_stat = os.stat(parent)
+    if parent_stat.st_gid != parent_gid or not (parent_stat.st_mode & stat.S_ISGID):
+        raise OSError(
+            errno.EIO,
+            f"bad parent metadata gid={parent_stat.st_gid}, mode={stat.S_IMODE(parent_stat.st_mode):o}",
+        )
+
+    old_euid = os.geteuid()
+    old_egid = os.getegid()
+    fd = -1
+    try:
+        os.setegid(nobody.pw_gid)
+        os.seteuid(nobody.pw_uid)
+        fd = os.open(child, os.O_CREAT | os.O_EXCL | os.O_RDWR, 0o777)
+    finally:
+        os.seteuid(old_euid)
+        os.setegid(old_egid)
+        if fd >= 0:
+            os.close(fd)
+
+    child_stat = os.stat(child)
+    if child_stat.st_gid != parent_gid:
+        raise OSError(
+            errno.EIO,
+            f"child gid is {child_stat.st_gid}, expected parent gid {parent_gid}",
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="setgid directory group inheritance regression test",
+    )
+    parser.add_argument(
+        "--dir",
+        default=DEFAULT_DIR,
+        help="Base test directory on the Curvine FUSE mount",
+    )
+    parser.add_argument(
+        "--allow-non-mount",
+        action="store_true",
+        help="Skip mount check; for local debugging only",
+    )
+    args = parser.parse_args()
+
+    if os.geteuid() != 0:
+        print("SKIP: setgid group inheritance test requires root")
+        return 0
+
+    try:
+        grp.getgrnam("bin")
+        pwd.getpwnam("nobody")
+    except KeyError as exc:
+        print(f"SKIP: required account is missing: {exc}")
+        return 0
+
+    root = os.path.abspath(args.dir)
+    os.makedirs(root, exist_ok=True)
+
+    if not args.allow_non_mount and not is_mount_path(root):
+        print(f"FAIL: {root} is not under a mount point", file=sys.stderr)
+        return 1
+
+    try:
+        run_case(root)
+    except OSError as exc:
+        print(
+            f"FAIL: setgid group inheritance: errno={exc.errno} "
+            f"({errno.errorcode.get(exc.errno, '?')}): {exc}",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        print(f"FAIL: setgid group inheritance: {exc}", file=sys.stderr)
+        return 1
+
+    print("PASS: setgid group inheritance")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/build/tests/scripts/setgid_group_inherit_repro.py
+++ b/build/tests/scripts/setgid_group_inherit_repro.py
@@ -3,7 +3,7 @@
 #  //
 #  // Licensed under the Apache License, Version 2.0 (the "License");
 #  // you may not use this file except in compliance with the License.
-#  // You may obtain a copy of the License at
+#  // You may obtain a copy of the License at 
 #  //
 #  //     http://www.apache.org/licenses/LICENSE-2.0
 #  //

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -823,7 +823,12 @@ impl fs::FileSystem for CurvineFileSystem {
         self.ensure_writable_path(&path, RpcCode::CreateFile)
             .await?;
 
-        let opts = FuseUtils::create_opts(&op, &self.fs);
+        let mut opts = FuseUtils::create_opts(&op, &self.fs);
+        let parent_status = self.state.fs_stat(ino, None).await?;
+        if parent_status.mode & FUSE_S_ISGID != 0 {
+            opts.group = parent_status.group;
+        }
+
         let handle = self.state.fs_create(ino, name, op.arg.flags, opts).await?;
         let attr = FuseUtils::status_to_attr(&self.conf, handle.status())?;
 


### PR DESCRIPTION
**Summary**

Fix FUSE file creation inside setgid directories so new files inherit the parent directory group.

Before this fix, Curvine used the caller's gid from the FUSE request when creating a file. If the parent directory had `S_ISGID` set and a different group, the new file still got the caller's group instead of the parent directory's group.

**Minimal Reproducer**

```c
#define _GNU_SOURCE
#include <errno.h>
#include <fcntl.h>
#include <grp.h>
#include <pwd.h>
#include <stdio.h>
#include <string.h>
#include <sys/stat.h>
#include <unistd.h>

int main(int argc, char **argv) {
    char dir[4096];
    char file[4096];
    struct stat st;
    struct group *bin_group;
    struct passwd *nobody_user;
    gid_t parent_gid;
    gid_t old_egid;
    uid_t old_euid;
    int fd;

    if (argc != 2) {
        fprintf(stderr, "usage: %s <mount-dir>\n", argv[0]);
        return 2;
    }

    bin_group = getgrnam("bin");
    if (!bin_group) {
        fprintf(stderr, "missing group: bin\n");
        return 1;
    }
    parent_gid = bin_group->gr_gid;

    nobody_user = getpwnam("nobody");
    if (!nobody_user) {
        fprintf(stderr, "missing user: nobody\n");
        return 1;
    }

    snprintf(dir, sizeof(dir), "%s/setgid_parent", argv[1]);
    snprintf(file, sizeof(file), "%s/child", dir);

    unlink(file);
    rmdir(dir);

    if (mkdir(dir, 0777) != 0) {
        perror("mkdir");
        return 1;
    }

    if (chown(dir, 0, parent_gid) != 0) {
        perror("chown dir to root:bin");
        return 1;
    }

    if (chmod(dir, 02777) != 0) {
        perror("chmod dir setgid");
        return 1;
    }

    old_euid = geteuid();
    old_egid = getegid();

    setegid(nobody_user->pw_gid);
    seteuid(nobody_user->pw_uid);

    fd = open(file, O_CREAT | O_EXCL | O_RDWR, 0777);

    seteuid(old_euid);
    setegid(old_egid);

    if (fd < 0) {
        fprintf(stderr, "open child failed errno=%d (%s)\n", errno, strerror(errno));
        return 1;
    }
    close(fd);

    if (stat(file, &st) != 0) {
        perror("stat child");
        return 1;
    }

    if (st.st_gid != parent_gid) {
        fprintf(stderr, "FAIL: child gid=%u, expected parent gid=%u\n",
                (unsigned)st.st_gid,
                (unsigned)parent_gid);
        return 1;
    }

    printf("PASS: child inherited parent setgid directory gid=%u\n",
           (unsigned)parent_gid);

    unlink(file);
    rmdir(dir);
    return 0;
}
```

Run it on a Curvine FUSE mount:

```bash
gcc /tmp/repro_setgid_group_inherit.c -o /tmp/repro_setgid_group_inherit
sudo /tmp/repro_setgid_group_inherit /curvine-fuse
```

Before the fix, Curvine reported the child file with the caller's gid, for example:

```text
FAIL: child gid=65534, expected parent gid=2
```

**Root Cause**

The FUSE create path built `CreateFileOpts` directly from the request header:

- owner came from the caller uid
- group came from the caller gid
- mode came from the requested create mode after umask

That is correct for normal directories, but not for setgid directories. On Linux, when a file is created inside a directory with `S_ISGID` set, the new file must inherit the parent directory's group.

Curvine did not check the parent directory mode before creating the child file, so the parent group inheritance rule was skipped.

**Changes**

- In FUSE `create()`, fetch the parent directory metadata before creating the file.
- If the parent directory has `S_ISGID` set, override the new file group with the parent directory group.
- Keep the existing caller uid and requested mode behavior unchanged.
- Add a regression test for file creation inside setgid directories.

**Verification**

- Minimal C reproducer passes after the fix.
- `python3 build/tests/scripts/setgid_group_inherit_repro.py --dir /tmp/curvine-setgid-group-inherit --allow-non-mount` passes.
- `cargo fmt --check` passes.
- `cargo check -p curvine-fuse` passes.
