### PR TITLE
fix(fuse): harden kernel version and setattr timestamps (#1137)

### DIFF
--- a/curvine-fuse/src/fuse_utils.rs
+++ b/curvine-fuse/src/fuse_utils.rs
@@ -46,21 +46,23 @@ impl FuseUtils {
         BytesMut::from(bytes)
     }
 
-    pub fn get_kernel_version() -> f32 {
-        let output = Command::new("uname")
-            .arg("-r")
-            .output()
-            .expect("Failed to execute 'uname -r'");
-
-        // Convert output to string and remove the line break at the end
-        let kernel_ver = String::from_utf8_lossy(&output.stdout).trim().to_string();
-
-        let parts: Vec<&str> = kernel_ver.split('.').collect();
-        if parts.len() < 2 {
-            1f32
-        } else {
-            format!("{}.{}", parts[0], parts[1]).parse::<f32>().unwrap()
+    pub fn get_kernel_version() -> (u32, u32) {
+        let Ok(output) = Command::new("uname").arg("-r").output() else {
+            return (0, 0);
+        };
+        if !output.status.success() {
+            return (0, 0);
         }
+
+        let kernel_release = String::from_utf8_lossy(&output.stdout);
+        Self::parse_kernel_version(kernel_release.trim()).unwrap_or((0, 0))
+    }
+
+    fn parse_kernel_version(kernel_release: &str) -> Option<(u32, u32)> {
+        let mut parts = kernel_release.split('.');
+        let major = parts.next()?.parse().ok()?;
+        let minor = parts.next()?.parse().ok()?;
+        Some((major, minor))
     }
 
     pub fn get_mode(perm: u32, typ: FileType) -> u32 {
@@ -385,5 +387,32 @@ impl FuseUtils {
             nlink: 1,
             ..Default::default()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FuseUtils;
+    use crate::FUSE_CLONE_FD_MIN_VERSION;
+
+    #[test]
+    fn kernel_version_6_10_compares_greater_than_6_9() {
+        let version = FuseUtils::parse_kernel_version("6.10.3").unwrap();
+
+        assert!(version > (6, 9));
+    }
+
+    #[test]
+    fn kernel_version_4_10_enables_clone_fd() {
+        let version = FuseUtils::parse_kernel_version("4.10.0").unwrap();
+
+        assert!(version >= FUSE_CLONE_FD_MIN_VERSION);
+    }
+
+    #[test]
+    fn kernel_version_parse_failure_disables_clone_fd() {
+        let version = FuseUtils::parse_kernel_version("unexpected").unwrap_or((0, 0));
+
+        assert!(version < FUSE_CLONE_FD_MIN_VERSION);
     }
 }

--- a/curvine-fuse/src/fuse_utils.rs
+++ b/curvine-fuse/src/fuse_utils.rs
@@ -320,6 +320,9 @@ impl FuseUtils {
     }
 
     pub fn fuse_setattr_to_opts(setattr: &fuse_setattr_in) -> FuseResult<SetAttrOpts> {
+        // FATTR_SIZE is intentionally handled by CurvineFileSystem::set_attr because resizing
+        // requires the file handle and cache invalidation managed by the caller.
+
         // Only set fields when the corresponding valid flag is present
         let owner = if (setattr.valid & FATTR_UID) != 0 {
             match sys::get_username_by_uid(setattr.uid) {
@@ -351,13 +354,21 @@ impl FuseUtils {
         let mut mtime = None;
 
         if (setattr.valid & FATTR_ATIME) != 0 {
-            atime = Some((setattr.atime * 1000) as i64);
+            atime = Some(Self::timestamp_to_millis(
+                "atime",
+                setattr.atime,
+                setattr.atimensec,
+            )?);
         } else if (setattr.valid & FATTR_ATIME_NOW) != 0 {
             atime = Some(LocalTime::mills() as i64);
         }
 
         if (setattr.valid & FATTR_MTIME) != 0 {
-            mtime = Some((setattr.mtime * 1000) as i64);
+            mtime = Some(Self::timestamp_to_millis(
+                "mtime",
+                setattr.mtime,
+                setattr.mtimensec,
+            )?);
         } else if (setattr.valid & FATTR_MTIME_NOW) != 0 {
             mtime = Some(LocalTime::mills() as i64);
         }
@@ -370,6 +381,28 @@ impl FuseUtils {
             mtime,
             ..Default::default()
         })
+    }
+
+    fn timestamp_to_millis(field: &str, seconds: u64, nanoseconds: u32) -> FuseResult<i64> {
+        if nanoseconds >= 1_000_000_000 {
+            return err_fuse!(
+                libc::EINVAL,
+                "{} nanoseconds out of range: {}",
+                field,
+                nanoseconds
+            );
+        }
+
+        // FUSE represents seconds as u64, including negative Unix timestamps encoded in two's
+        // complement. Reinterpret it as i64 before doing checked arithmetic.
+        let seconds = seconds as i64;
+        match seconds
+            .checked_mul(1000)
+            .and_then(|millis| millis.checked_add(i64::from(nanoseconds / 1_000_000)))
+        {
+            Some(millis) => Ok(millis),
+            None => err_fuse!(libc::EINVAL, "{} timestamp out of range", field),
+        }
     }
 
     pub fn file_opts_to_status(path: &Path, opts: &CreateFileOpts) -> FileStatus {
@@ -393,7 +426,8 @@ impl FuseUtils {
 #[cfg(test)]
 mod tests {
     use super::FuseUtils;
-    use crate::FUSE_CLONE_FD_MIN_VERSION;
+    use crate::raw::fuse_abi::fuse_setattr_in;
+    use crate::{FATTR_ATIME, FATTR_MTIME, FUSE_CLONE_FD_MIN_VERSION};
 
     #[test]
     fn kernel_version_6_10_compares_greater_than_6_9() {
@@ -414,5 +448,42 @@ mod tests {
         let version = FuseUtils::parse_kernel_version("unexpected").unwrap_or((0, 0));
 
         assert!(version < FUSE_CLONE_FD_MIN_VERSION);
+    }
+
+    #[test]
+    fn setattr_preserves_millisecond_from_nsec() {
+        let setattr = fuse_setattr_in {
+            valid: FATTR_ATIME | FATTR_MTIME,
+            atime: 1_700_000_000,
+            mtime: 1_800_000_000,
+            atimensec: 123_456_789,
+            mtimensec: 987_654_321,
+            ..Default::default()
+        };
+
+        let opts = FuseUtils::fuse_setattr_to_opts(&setattr).unwrap();
+
+        assert_eq!(opts.atime, Some(1_700_000_000_123));
+        assert_eq!(opts.mtime, Some(1_800_000_000_987));
+    }
+
+    #[test]
+    fn setattr_rejects_out_of_range_nsec() {
+        for setattr in [
+            fuse_setattr_in {
+                valid: FATTR_ATIME,
+                atimensec: 1_000_000_000,
+                ..Default::default()
+            },
+            fuse_setattr_in {
+                valid: FATTR_MTIME,
+                mtimensec: 1_000_000_000,
+                ..Default::default()
+            },
+        ] {
+            let err = FuseUtils::fuse_setattr_to_opts(&setattr).unwrap_err();
+
+            assert_eq!(err.errno(), libc::EINVAL);
+        }
     }
 }

--- a/curvine-fuse/src/lib.rs
+++ b/curvine-fuse/src/lib.rs
@@ -157,7 +157,7 @@ pub const FATTR_ATIME_NOW: u32 = 1 << 7;
 pub const FATTR_MTIME_NOW: u32 = 1 << 8;
 
 // The minimum version of the clone fd feature can be used.
-pub const FUSE_CLONE_FD_MIN_VERSION: f32 = 4.2f32;
+pub const FUSE_CLONE_FD_MIN_VERSION: (u32, u32) = (4, 2);
 
 pub const FUSE_NOTIFY_UNIQUE: u64 = 0;
 
@@ -165,4 +165,4 @@ pub const STATE_FILE_MAGIC: &[u8; 4] = b"cvfs";
 
 pub const STATE_FILE_VERSION: u64 = 1;
 
-pub static UNIX_KERNEL_VERSION: Lazy<f32> = Lazy::new(FuseUtils::get_kernel_version);
+pub static UNIX_KERNEL_VERSION: Lazy<(u32, u32)> = Lazy::new(FuseUtils::get_kernel_version);

--- a/curvine-fuse/src/session/fuse_mnt.rs
+++ b/curvine-fuse/src/session/fuse_mnt.rs
@@ -59,7 +59,8 @@ impl FuseMnt {
     }
 
     fn create_task_fd(&self, clone: bool) -> IOResult<BorrowedFd> {
-        let clone_fd = if clone && *UNIX_KERNEL_VERSION >= FUSE_CLONE_FD_MIN_VERSION {
+        let kernel_version = *UNIX_KERNEL_VERSION;
+        let clone_fd = if clone && kernel_version >= FUSE_CLONE_FD_MIN_VERSION {
             match FuseUtils::fuse_clone_fd(self.fd) {
                 Ok(clone_fd) => {
                     debug!("Fuse clone fd, {} -> {}", self.fd, clone_fd);
@@ -68,9 +69,9 @@ impl FuseMnt {
 
                 Err(e) => {
                     error!(
-                        "clone fd failed, will fall back to shared fd mode; kernel version: {},\
+                        "clone fd failed, will fall back to shared fd mode; kernel version: {}.{},\
                      source fd {}, cause: {}",
-                        *UNIX_KERNEL_VERSION, self.fd, e
+                        kernel_version.0, kernel_version.1, self.fd, e
                     );
                     sys::dup(self.fd)?
                 }


### PR DESCRIPTION
# Summary

This PR fixes two correctness issues in the FUSE utility layer: kernel versions are now compared as `(major, minor)` tuples without startup panics, and explicit setattr timestamps now preserve millisecond precision from their nanosecond fields.

# Issue Describe / Design

Closes #1137
Closes #1139

Root causes:
- Kernel releases were parsed as `f32`, so `4.10` became `4.1`; command and parse failures could also panic during startup.
- `fuse_setattr_to_opts` multiplied only the seconds fields and discarded `atimensec` / `mtimensec`.

Reproduction:
- Parse `4.10.0` and compare it with the clone-fd minimum kernel version `4.2`.
- Convert a `fuse_setattr_in` containing non-zero nanoseconds and inspect the generated millisecond timestamps.

Fix approach:
- Parse kernel releases into `(u32, u32)`, fall back to `(0, 0)` on command or parse failure, and conservatively disable clone-fd in that case.
- Convert timestamps with `sec * 1000 + nsec / 1_000_000`, validate the nanosecond range, and use checked arithmetic.
- Keep `FATTR_SIZE` handling in the caller, where file-handle use and cache invalidation are managed.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-fuse/src/fuse_utils.rs` | Add safe kernel-version parsing, timestamp conversion, validation, and unit tests | Correct version ordering and preserve sub-second setattr precision |
| `curvine-fuse/src/lib.rs` | Change clone-fd version constants and cached kernel version from `f32` to tuple | Clone-fd gating now uses semantic version ordering |
| `curvine-fuse/src/session/fuse_mnt.rs` | Compare and log tuple kernel versions | No change to the successful clone-fd path |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo fmt --all -- --check` | PASS | Local and remote Linux |
| `cargo test -p curvine-fuse fuse_utils::tests` | PASS | 5 passed, 0 failed on remote Linux |
| `cargo clippy -p curvine-fuse --all-targets -- --deny warnings --allow clippy::uninlined-format-args` | PASS | Remote Linux |
| `cargo test -p curvine-fuse` | BASELINE FAIL | 163 passed; 3 unrelated `dir_tree` tests failed |
| Baseline `438c997` `dir_tree` tests | SAME FAILURES | The same 3 assertions fail without this PR |

# Dependencies

- Related PRs: None
- Related issues: #1137, #1139
- Blocks / blocked by: None