### PR TITLE
fix(fuse): parse kernel version as tuple (#1137)

### DIFF
--- a/curvine-fuse/src/fuse_utils.rs
+++ b/curvine-fuse/src/fuse_utils.rs
@@ -46,21 +46,23 @@ impl FuseUtils {
         BytesMut::from(bytes)
     }
 
-    pub fn get_kernel_version() -> f32 {
-        let output = Command::new("uname")
-            .arg("-r")
-            .output()
-            .expect("Failed to execute 'uname -r'");
-
-        // Convert output to string and remove the line break at the end
-        let kernel_ver = String::from_utf8_lossy(&output.stdout).trim().to_string();
-
-        let parts: Vec<&str> = kernel_ver.split('.').collect();
-        if parts.len() < 2 {
-            1f32
-        } else {
-            format!("{}.{}", parts[0], parts[1]).parse::<f32>().unwrap()
+    pub fn get_kernel_version() -> (u32, u32) {
+        let Ok(output) = Command::new("uname").arg("-r").output() else {
+            return (0, 0);
+        };
+        if !output.status.success() {
+            return (0, 0);
         }
+
+        let kernel_release = String::from_utf8_lossy(&output.stdout);
+        Self::parse_kernel_version(kernel_release.trim()).unwrap_or((0, 0))
+    }
+
+    fn parse_kernel_version(kernel_release: &str) -> Option<(u32, u32)> {
+        let mut parts = kernel_release.split('.');
+        let major = parts.next()?.parse().ok()?;
+        let minor = parts.next()?.parse().ok()?;
+        Some((major, minor))
     }
 
     pub fn get_mode(perm: u32, typ: FileType) -> u32 {
@@ -425,7 +427,7 @@ impl FuseUtils {
 mod tests {
     use super::FuseUtils;
     use crate::raw::fuse_abi::fuse_setattr_in;
-    use crate::{FATTR_ATIME, FATTR_MTIME};
+    use crate::{FATTR_ATIME, FATTR_MTIME, FUSE_CLONE_FD_MIN_VERSION};
 
     #[test]
     fn setattr_preserves_millisecond_from_nsec() {
@@ -462,5 +464,26 @@ mod tests {
 
             assert_eq!(err.errno(), libc::EINVAL);
         }
+    }
+
+    #[test]
+    fn kernel_version_6_10_compares_greater_than_6_9() {
+        let version = FuseUtils::parse_kernel_version("6.10.3").unwrap();
+
+        assert!(version > (6, 9));
+    }
+
+    #[test]
+    fn kernel_version_4_10_enables_clone_fd() {
+        let version = FuseUtils::parse_kernel_version("4.10.0").unwrap();
+
+        assert!(version >= FUSE_CLONE_FD_MIN_VERSION);
+    }
+
+    #[test]
+    fn kernel_version_parse_failure_disables_clone_fd() {
+        let version = FuseUtils::parse_kernel_version("unexpected").unwrap_or((0, 0));
+
+        assert!(version < FUSE_CLONE_FD_MIN_VERSION);
     }
 }

--- a/curvine-fuse/src/lib.rs
+++ b/curvine-fuse/src/lib.rs
@@ -179,7 +179,7 @@ pub const FATTR_ATIME_NOW: u32 = 1 << 7;
 pub const FATTR_MTIME_NOW: u32 = 1 << 8;
 
 // The minimum version of the clone fd feature can be used.
-pub const FUSE_CLONE_FD_MIN_VERSION: f32 = 4.2f32;
+pub const FUSE_CLONE_FD_MIN_VERSION: (u32, u32) = (4, 2);
 
 pub const FUSE_NOTIFY_UNIQUE: u64 = 0;
 
@@ -187,4 +187,4 @@ pub const STATE_FILE_MAGIC: &[u8; 4] = b"cvfs";
 
 pub const STATE_FILE_VERSION: u64 = 1;
 
-pub static UNIX_KERNEL_VERSION: Lazy<f32> = Lazy::new(FuseUtils::get_kernel_version);
+pub static UNIX_KERNEL_VERSION: Lazy<(u32, u32)> = Lazy::new(FuseUtils::get_kernel_version);

--- a/curvine-fuse/src/session/fuse_mnt.rs
+++ b/curvine-fuse/src/session/fuse_mnt.rs
@@ -59,7 +59,8 @@ impl FuseMnt {
     }
 
     fn create_task_fd(&self, clone: bool) -> IOResult<BorrowedFd> {
-        let clone_fd = if clone && *UNIX_KERNEL_VERSION >= FUSE_CLONE_FD_MIN_VERSION {
+        let kernel_version = *UNIX_KERNEL_VERSION;
+        let clone_fd = if clone && kernel_version >= FUSE_CLONE_FD_MIN_VERSION {
             match FuseUtils::fuse_clone_fd(self.fd) {
                 Ok(clone_fd) => {
                     debug!("Fuse clone fd, {} -> {}", self.fd, clone_fd);
@@ -68,9 +69,9 @@ impl FuseMnt {
 
                 Err(e) => {
                     error!(
-                        "clone fd failed, will fall back to shared fd mode; kernel version: {},\
+                        "clone fd failed, will fall back to shared fd mode; kernel version: {}.{},\
                      source fd {}, cause: {}",
-                        *UNIX_KERNEL_VERSION, self.fd, e
+                        kernel_version.0, kernel_version.1, self.fd, e
                     );
                     sys::dup(self.fd)?
                 }


### PR DESCRIPTION
# Summary

Parse Linux kernel versions as `(major, minor)` tuples instead of `f32`, preventing incorrect ordering and startup panics.

# Issue Describe / Design

Closes #1137

`4.10` was previously parsed as `4.1`, which could incorrectly disable clone-fd support. Command and parse failures could also panic.

The fix uses tuple comparison and falls back to `(0, 0)` on failure, conservatively disabling clone-fd.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-fuse/src/fuse_utils.rs` | Safely parse kernel versions as tuples and add tests | Correct version ordering and no parse panic |
| `curvine-fuse/src/lib.rs` | Change version constants and cache to tuple types | Semantic version comparison |
| `curvine-fuse/src/session/fuse_mnt.rs` | Compare and log tuple versions | Clone-fd behavior remains unchanged for supported kernels |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| Kernel-version unit tests | PASS | 3 passed |
| `cargo fmt --all -- --check` | PASS | |
| `cargo clippy -p curvine-fuse --all-targets` | PASS | |

# Dependencies

- Related PRs: None
- Related issues: #1137
- Blocks / blocked by: None