### PR TITLE
fix(fuse): preserve symlink owner

### DIFF
--- a/build/tests/fuse-test.sh
+++ b/build/tests/fuse-test.sh
@@ -64,6 +64,7 @@ This script tests basic filesystem operations including:
   - Active-writer path truncate regression (PR #962)
   - Read-only open with O_CREAT creates a missing file
   - Mode 0000 is preserved by chmod, fchmod, and umask-filtered create
+  - Symlink owner and group metadata
 
 For FIO performance tests, use fio-test.sh instead.
 
@@ -1389,6 +1390,15 @@ test_mode_zero_permissions() {
         "mode_zero_permissions_repro.py" --dir "$TEST_DIR"
 }
 
+# Test 24: symlink owner/group metadata
+test_symlink_owner() {
+    CURRENT_TEST_GROUP="Test 24: Symlink Owner"
+    print_header "$CURRENT_TEST_GROUP"
+    run_python_script_test \
+        "Testing symlink owner and group metadata" \
+        "symlink_owner_repro.py" --dir "$TEST_DIR"
+}
+
 # Print final report
 print_report() {
     print_header "Test Summary"
@@ -1497,6 +1507,7 @@ main() {
     test_pr962_active_writer_truncate
     test_open_creat_rdonly
     test_mode_zero_permissions
+    test_symlink_owner
 
     test_git_clone
 

--- a/build/tests/scripts/symlink_owner_repro.py
+++ b/build/tests/scripts/symlink_owner_repro.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+#  // Copyright 2025 OPPO.
+#  //
+#  // Licensed under the Apache License, Version 2.0 (the "License");
+#  // you may not use this file except in compliance with the License.
+#  // You may obtain a copy of the License at
+#  //
+#  //     http://www.apache.org/licenses/LICENSE-2.0
+#  //
+#  // Unless required by applicable law or agreed to in writing, software
+#  // distributed under the License is distributed on an "AS IS" BASIS,
+#  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  // See the License for the specific language governing permissions and
+#  // limitations under the License.
+
+"""
+Regression test for symlink owner/group metadata.
+
+Symlinks created through FUSE must store the caller uid/gid. Otherwise lstat()
+falls back to the configured FUSE uid/gid instead of reporting the creator.
+"""
+
+import argparse
+import errno
+import os
+import shutil
+import sys
+
+DEFAULT_DIR = "/curvine-fuse/fuse-test"
+
+
+def case_dir(root: str, name: str) -> str:
+    path = os.path.join(root, name)
+    if os.path.exists(path):
+        shutil.rmtree(path)
+    os.makedirs(path)
+    return path
+
+
+def is_mount_path(path: str) -> bool:
+    probe = os.path.abspath(path)
+    while probe != "/":
+        if os.path.ismount(probe):
+            return True
+        probe = os.path.dirname(probe)
+    return False
+
+
+def run_case(root: str) -> None:
+    workdir = case_dir(root, "symlink_owner")
+    target = os.path.join(workdir, "target")
+    link = os.path.join(workdir, "link")
+
+    fd = os.open(target, os.O_CREAT | os.O_TRUNC | os.O_RDWR, 0o644)
+    os.close(fd)
+    os.symlink("target", link)
+
+    st = os.lstat(link)
+    if st.st_uid != os.geteuid() or st.st_gid != os.getegid():
+        raise OSError(
+            errno.EIO,
+            f"symlink uid:gid is {st.st_uid}:{st.st_gid}, "
+            f"expected {os.geteuid()}:{os.getegid()}",
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="symlink owner/group regression test",
+    )
+    parser.add_argument(
+        "--dir",
+        default=DEFAULT_DIR,
+        help="Base test directory on the Curvine FUSE mount",
+    )
+    parser.add_argument(
+        "--allow-non-mount",
+        action="store_true",
+        help="Skip mount check; for local debugging only",
+    )
+    args = parser.parse_args()
+
+    root = os.path.abspath(args.dir)
+    os.makedirs(root, exist_ok=True)
+
+    if not args.allow_non_mount and not is_mount_path(root):
+        print(f"FAIL: {root} is not under a mount point", file=sys.stderr)
+        return 1
+
+    try:
+        run_case(root)
+    except OSError as exc:
+        print(
+            f"FAIL: symlink owner/group: errno={exc.errno} "
+            f"({errno.errorcode.get(exc.errno, '?')}): {exc}",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        print(f"FAIL: symlink owner/group: {exc}", file=sys.stderr)
+        return 1
+
+    print("PASS: symlink owner/group")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/curvine-client/src/file/curvine_filesystem.rs
+++ b/curvine-client/src/file/curvine_filesystem.rs
@@ -299,6 +299,19 @@ impl CurvineFileSystem {
         self.fs_client.symlink(target, link, force).await
     }
 
+    pub async fn symlink_with_owner_group(
+        &self,
+        target: &str,
+        link: &Path,
+        force: bool,
+        owner: Option<String>,
+        group: Option<String>,
+    ) -> FsResult<()> {
+        self.fs_client
+            .symlink_with_owner_group(target, link, force, owner, group)
+            .await
+    }
+
     pub async fn link(&self, src_path: &Path, dst_path: &Path) -> FsResult<()> {
         self.fs_client.link(src_path, dst_path).await
     }

--- a/curvine-client/src/file/fs_client.rs
+++ b/curvine-client/src/file/fs_client.rs
@@ -528,11 +528,25 @@ impl FsClient {
     }
 
     pub async fn symlink(&self, target: &str, link: &Path, force: bool) -> FsResult<()> {
+        self.symlink_with_owner_group(target, link, force, None, None)
+            .await
+    }
+
+    pub async fn symlink_with_owner_group(
+        &self,
+        target: &str,
+        link: &Path,
+        force: bool,
+        owner: Option<String>,
+        group: Option<String>,
+    ) -> FsResult<()> {
         let req = SymlinkRequest {
             target: target.to_string(),
             link: link.encode(),
             force,
             mode: ClientConf::DEFAULT_FILE_SYSTEM_MODE,
+            owner,
+            group,
         };
         let _: SymlinkResponse = self.rpc(RpcCode::Symlink, req).await?;
         Ok(())

--- a/curvine-client/src/unified/unified_filesystem.rs
+++ b/curvine-client/src/unified/unified_filesystem.rs
@@ -304,6 +304,27 @@ impl UnifiedFileSystem {
         self.track("Symlink", target, link.path(), fut).await
     }
 
+    pub async fn symlink_with_owner_group(
+        &self,
+        target: &str,
+        link: &Path,
+        force: bool,
+        owner: Option<String>,
+        group: Option<String>,
+    ) -> FsResult<()> {
+        let fut = async {
+            match self.get_mount_checked(link, RpcCode::Symlink).await? {
+                None => {
+                    self.cv
+                        .symlink_with_owner_group(target, link, force, owner, group)
+                        .await
+                }
+                Some(_) => err_ext!(FsError::unsupported("symlink")),
+            }
+        };
+        self.track("Symlink", target, link.path(), fut).await
+    }
+
     pub async fn link(&self, src_path: &Path, dst_path: &Path) -> FsResult<()> {
         let fut = async {
             let _ = self.get_mount_checked(dst_path, RpcCode::Link).await?;

--- a/curvine-common/proto/master.proto
+++ b/curvine-common/proto/master.proto
@@ -257,6 +257,8 @@ message SymlinkRequest {
     required string link = 2;
     required bool force = 3;
     required uint32 mode = 4;
+    optional string owner = 5;
+    optional string group = 6;
 }
 
 message SymlinkResponse {

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -996,7 +996,11 @@ impl fs::FileSystem for CurvineFileSystem {
         let link_path = self.state.get_path_common(id, Some(linkname))?;
         self.ensure_writable_path(&link_path, RpcCode::Symlink)
             .await?;
-        self.fs.symlink(target, &link_path, false).await?;
+        let owner = sys::get_username_by_uid(op.header.uid).unwrap_or(op.header.uid.to_string());
+        let group = sys::get_groupname_by_gid(op.header.gid).unwrap_or(op.header.gid.to_string());
+        self.fs
+            .symlink_with_owner_group(target, &link_path, false, Some(owner), Some(group))
+            .await?;
 
         let attr = self.state.lookup_common(id, linkname).await?;
         Ok(FuseUtils::create_entry_out(&self.conf, attr))

--- a/curvine-server/src/master/fs/master_filesystem.rs
+++ b/curvine-server/src/master/fs/master_filesystem.rs
@@ -1151,10 +1151,22 @@ impl MasterFilesystem {
         force: bool,
         mode: u32,
     ) -> FsResult<()> {
+        self.symlink_with_owner_group(target, link, force, mode, None, None)
+    }
+
+    pub fn symlink_with_owner_group<T: AsRef<str>>(
+        &self,
+        target: T,
+        link: T,
+        force: bool,
+        mode: u32,
+        owner: Option<String>,
+        group: Option<String>,
+    ) -> FsResult<()> {
         let mut fs_dir = self.fs_dir.write();
         let target = target.as_ref().to_string();
         let link = Self::resolve_path(&fs_dir, link.as_ref())?;
-        fs_dir.symlink(target, link, force, mode)
+        fs_dir.symlink(target, link, force, mode, owner, group)
     }
 
     pub fn link<T: AsRef<str>>(&self, src_path: T, dst_path: T) -> FsResult<()> {

--- a/curvine-server/src/master/master_handler.rs
+++ b/curvine-server/src/master/master_handler.rs
@@ -608,8 +608,14 @@ impl MasterHandler {
             return ctx.response_buf(SymlinkResponse::default(), &mut self.buf);
         }
 
-        self.fs
-            .symlink(&header.target, &header.link, header.force, header.mode)?;
+        self.fs.symlink_with_owner_group(
+            &header.target,
+            &header.link,
+            header.force,
+            header.mode,
+            header.owner,
+            header.group,
+        )?;
 
         ctx.response_buf(SymlinkResponse::default(), &mut self.buf)
     }

--- a/curvine-server/src/master/meta/fs_dir.rs
+++ b/curvine-server/src/master/meta/fs_dir.rs
@@ -886,10 +886,19 @@ impl FsDir {
         link: InodePath,
         force: bool,
         mode: u32,
+        owner: Option<String>,
+        group: Option<String>,
     ) -> FsResult<()> {
         let op_ms = LocalTime::mills();
 
-        let new_inode = InodeFile::with_link(self.inode_id.next()?, op_ms as i64, target, mode);
+        let new_inode = InodeFile::with_link(
+            self.inode_id.next()?,
+            op_ms as i64,
+            target,
+            mode,
+            owner,
+            group,
+        );
 
         let link = self.unprotected_symlink(link, new_inode.clone(), force)?;
         self.journal_writer

--- a/curvine-server/src/master/meta/inode/inode_file.rs
+++ b/curvine-server/src/master/meta/inode/inode_file.rs
@@ -122,7 +122,14 @@ impl InodeFile {
         file
     }
 
-    pub fn with_link(id: i64, time: i64, target: impl Into<String>, mode: u32) -> Self {
+    pub fn with_link(
+        id: i64,
+        time: i64,
+        target: impl Into<String>,
+        mode: u32,
+        owner: Option<String>,
+        group: Option<String>,
+    ) -> Self {
         Self {
             id,
             file_type: FileType::Link,
@@ -136,7 +143,11 @@ impl InodeFile {
             features: FileFeature {
                 x_attr: Default::default(),
                 file_write: None,
-                acl: AclFeature::with_mode(mode),
+                acl: AclFeature {
+                    mode,
+                    owner: owner.unwrap_or_default(),
+                    group: group.unwrap_or_default(),
+                },
             },
 
             blocks: vec![],


### PR DESCRIPTION
**Summary**

Fix Curvine FUSE preserving symlink owner and group metadata.

Before this fix, symlinks created through Curvine FUSE did not store the caller uid/gid. As a result, `lstat()` reported the configured FUSE fallback uid/gid instead of the symlink creator. For example, a symlink created by root could appear as `1000:1000` when the FUSE mount was configured with `uid=1000,gid=1000`.

**Minimal Reproducer**

```c
#define _GNU_SOURCE
#include <errno.h>
#include <fcntl.h>
#include <stdio.h>
#include <string.h>
#include <sys/stat.h>
#include <unistd.h>

int main(int argc, char **argv) {
    char target[4096];
    char linkpath[4096];
    struct stat st;

    if (argc != 2) {
        fprintf(stderr, "usage: %s <mount-dir>\n", argv[0]);
        return 2;
    }

    snprintf(target, sizeof(target), "%s/symlink_owner_target", argv[1]);
    snprintf(linkpath, sizeof(linkpath), "%s/symlink_owner_link", argv[1]);

    unlink(linkpath);
    unlink(target);

    int fd = open(target, O_CREAT | O_RDWR | O_TRUNC, 0644);
    if (fd < 0) {
        perror("open target");
        return 1;
    }
    close(fd);

    if (symlink("symlink_owner_target", linkpath) != 0) {
        perror("symlink");
        return 1;
    }

    if (lstat(linkpath, &st) != 0) {
        perror("lstat link");
        return 1;
    }

    if (st.st_uid != geteuid() || st.st_gid != getegid()) {
        fprintf(stderr,
                "FAIL: symlink uid:gid=%u:%u, expected %u:%u\n",
                (unsigned)st.st_uid, (unsigned)st.st_gid,
                (unsigned)geteuid(), (unsigned)getegid());
        return 1;
    }

    printf("PASS: symlink owner/group is %u:%u\n",
           (unsigned)st.st_uid, (unsigned)st.st_gid);

    unlink(linkpath);
    unlink(target);
    return 0;
}
```

Run it on a Curvine FUSE mount:

```bash
gcc /tmp/repro_symlink_owner.c -o /tmp/repro_symlink_owner
sudo /tmp/repro_symlink_owner /curvine-fuse
```

Before the fix, Curvine reported the symlink with the configured fallback uid/gid, for example:

```text
FAIL: symlink uid:gid=1000:1000, expected 0:0
```

**Root Cause**

The FUSE symlink path did not pass the caller uid/gid into the backend symlink creation request.

The server created symlink inodes with:

```rust
AclFeature::with_mode(mode)
```

That initialized the symlink mode but left owner and group empty. Later, when FUSE converted `FileStatus` to attributes, empty owner/group fields were resolved through the configured FUSE fallback uid/gid.

Regular file and directory creation already passed owner/group through create options, so this issue was specific to symlink creation.

**Changes**

- Extend the symlink request path to carry optional owner/group metadata.
- Add an internal client/unified filesystem method for creating symlinks with owner/group.
- In FUSE `symlink()`, derive owner/group from the request header uid/gid and pass them through.
- Store owner/group in the symlink inode ACL when the master creates the symlink.
- Keep the existing public symlink API behavior unchanged for non-FUSE callers.
- Add a regression test for symlink owner/group metadata.

**Verification**

- Minimal C reproducer passes after the fix.
- `python3 build/tests/scripts/symlink_owner_repro.py --dir /tmp/curvine-symlink-owner --allow-non-mount` passes.
- `cargo fmt` passes.
- `cargo check -p curvine-fuse` passes.
- `cargo check -p curvine-server` passes.
