### PR TITLE
fix(fuse): correct FuseError display, elapsed errno, and err_fuse! errno validation (#1129)

### DIFF
--- a/curvine-fuse/src/fuse_error.rs
+++ b/curvine-fuse/src/fuse_error.rs
@@ -26,14 +26,58 @@ pub struct FuseError {
 }
 
 impl FuseError {
-    pub fn new(errno: i32, error: CommonError) -> Self {
+    // crate-private: the public safe constructor is `from_errno_msg`, which
+    // normalizes the errno. Keeping `new` internal prevents external/future code
+    // from bypassing normalization and building an illegal (non-positive) errno.
+    pub(crate) fn new(errno: i32, error: CommonError) -> Self {
+        // Internal invariant: FuseError always holds a positive POSIX errno.
+        // `ResponseData::create` negates it (`-error`) when encoding the reply, so
+        // a negative/zero errno here would produce an illegal FUSE reply frame.
+        // Surfaced loudly in debug; release callers should route arbitrary integers
+        // through `err_fuse!` / `from_errno_msg`, which normalize the value.
+        debug_assert!(
+            errno > 0,
+            "FuseError errno must be a positive POSIX errno, got {}",
+            errno
+        );
         Self { errno, error }
+    }
+
+    /// Build a `FuseError` from an arbitrary integer errno, normalizing it to a
+    /// positive POSIX errno via [`normalize_errno`]. This is the construction
+    /// path used by `err_fuse!`; it also lets callers that need a `FuseError`
+    /// value (not a `Result`) build one directly — e.g. before passing it to
+    /// `send_rep_tagged` — without the `let _: FuseResult<_> = err_fuse!(...)`
+    /// detour.
+    pub fn from_errno_msg<E: TryInto<i32>>(errno: E, error: CommonError) -> Self {
+        Self::new(normalize_errno(errno), error)
     }
 
     /// The POSIX errno this error maps to. Used by the metrics finish path to
     /// stash the errno label source.
     pub(crate) fn errno(&self) -> i32 {
         self.errno
+    }
+}
+
+/// Normalize an arbitrary integer errno into a positive POSIX errno.
+///
+/// Uses `TryInto<i32>` for a genuine range check (no `as` truncation/wrapping):
+/// a value that does not fit in `i32`, or is non-positive, falls back to `EIO`.
+/// This keeps `FuseError`'s "positive errno" invariant and prevents an illegal
+/// FUSE reply frame (the reply path negates the errno). Release-safe — never
+/// panics — but a non-positive / out-of-range input trips a `debug_assert` so a
+/// caller bug is surfaced in debug/test builds rather than silently coerced.
+pub(crate) fn normalize_errno<E: TryInto<i32>>(errno: E) -> i32 {
+    match errno.try_into() {
+        Ok(e) if e > 0 => e,
+        _ => {
+            debug_assert!(
+                false,
+                "err_fuse! errno is non-positive or out of i32 range; falling back to EIO"
+            );
+            libc::EIO
+        }
     }
 }
 
@@ -47,7 +91,7 @@ impl std::error::Error for FuseError {}
 
 impl fmt::Display for FuseError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "errno {}: {}", self.error, self.errno)
+        write!(fmt, "errno {}: {}", self.errno, self.error)
     }
 }
 
@@ -111,7 +155,9 @@ impl From<FsError> for FuseError {
 
 impl From<Elapsed> for FuseError {
     fn from(value: Elapsed) -> Self {
-        Self::new(libc::EIO, value.into())
+        // A tokio timeout is a timeout, same as FsError::Timeout -> ETIMEDOUT;
+        // keep both conversion paths consistent instead of degrading to EIO.
+        Self::new(libc::ETIMEDOUT, value.into())
     }
 }
 
@@ -182,6 +228,33 @@ pub(crate) fn splice_errno_label(errno: i32) -> &'static str {
 mod tests {
     use super::{errno_label, splice_errno_label, FuseError};
     use curvine_common::error::FsError;
+
+    // Display prints the errno NUMBER first, then the message ("errno 2: ...").
+    #[test]
+    fn display_prints_errno_before_message() {
+        let err = FuseError::new(libc::ENOENT, "no such file".into());
+        let s = format!("{}", err);
+        assert!(
+            s.starts_with(&format!("errno {}: ", libc::ENOENT)),
+            "expected errno number first, got: {}",
+            s
+        );
+        assert!(s.contains("no such file"));
+    }
+
+    // A tokio timeout maps to ETIMEDOUT, consistent with FsError::Timeout — not EIO.
+    #[tokio::test]
+    async fn elapsed_maps_to_etimedout() {
+        let elapsed = tokio::time::timeout(
+            std::time::Duration::from_millis(0),
+            std::future::pending::<()>(),
+        )
+        .await
+        .expect_err("zero-duration timeout must elapse");
+        let err: FuseError = elapsed.into();
+        assert_eq!(err.errno, libc::ETIMEDOUT);
+        assert_eq!(errno_label(err.errno), "ETIMEDOUT");
+    }
 
     #[test]
     fn invalid_file_size_maps_to_efbig() {

--- a/curvine-fuse/src/lib.rs
+++ b/curvine-fuse/src/lib.rs
@@ -20,10 +20,16 @@ use once_cell::sync::Lazy;
 
 pub mod cli;
 pub mod fs;
-pub mod macros;
+// Crate-internal only: `macros` exposes no public API (its sole item, the
+// `err_fuse!` macro, is `pub(crate)`), so the module is `mod`, not `pub mod`.
+mod macros;
 pub mod raw;
 pub mod session;
 pub mod web_server;
+
+// Re-export the crate-internal `err_fuse!` macro at the crate root so existing
+// `use crate::err_fuse;` imports resolve. Not `#[macro_export]`ed — see macros.rs.
+pub(crate) use macros::err_fuse;
 
 mod fuse_error;
 pub use self::fuse_error::FuseError;

--- a/curvine-fuse/src/macros.rs
+++ b/curvine-fuse/src/macros.rs
@@ -13,37 +13,124 @@
 // limitations under the License.
 
 // Create fuse error.
-#[macro_export]
+//
+// Crate-internal macro: NOT `#[macro_export]`ed, because its expansion
+// references crate-private helpers (`crate::fuse_error::normalize_errno` /
+// `errno_label`) and `orpc::err_msg!`, which are not reachable from an external
+// crate — exporting it would advertise an unusable public macro. It is made
+// importable within the crate via `pub(crate) use err_fuse;` below (re-exported
+// at the crate root in lib.rs) so existing `use crate::err_fuse;` imports keep
+// working. All call sites are inside curvine-fuse.
+//
+// The errno expression is normalized to a positive POSIX errno by
+// `FuseError::from_errno_msg` (via `normalize_errno`), so a negative / zero /
+// out-of-range input can never produce an illegal FUSE reply frame. Errno
+// normalization and construction live in `fuse_error.rs` — this macro is only
+// the `Err(...)` sugar plus the default message.
 macro_rules! err_fuse {
     ($errno:expr) => ({
-        let msg = orpc::err_msg!("err_fuse {}", $errno);
-        let err = $crate::FuseError::new($errno as i32, msg.into());
-        Err(err)
+        // Single-arg form: synthesize a default message with the symbolic errno
+        // label (e.g. "err_fuse ENOSYS") using the normalized errno.
+        let errno = $crate::fuse_error::normalize_errno($errno);
+        let msg = orpc::err_msg!("err_fuse {}", $crate::fuse_error::errno_label(errno));
+        Err($crate::FuseError::from_errno_msg(errno, msg.into()))
     });
 
     ($errno:expr, $msg:expr) => ({
         let msg = orpc::err_msg!("{}", $msg);
-        let err = $crate::FuseError::new($errno as i32, msg.into());
-        Err(err)
+        Err($crate::FuseError::from_errno_msg($errno, msg.into()))
     });
 
     ($errno:expr, $f:tt, $($arg:expr),+) => ({
         let msg = orpc::err_msg!($f, $($arg),+);
-        let err = $crate::FuseError::new($errno as i32, msg.into());
-        Err(err)
+        Err($crate::FuseError::from_errno_msg($errno, msg.into()))
     });
 }
+
+// Make the crate-internal macro importable via a path (`use crate::err_fuse;`)
+// without `#[macro_export]`. Re-exported at the crate root in lib.rs.
+pub(crate) use err_fuse;
 
 #[cfg(test)]
 mod test {
     use crate::FuseResult;
 
+    // A positive libc errno is preserved unchanged, and the single-arg default
+    // message carries the symbolic errno label (not the raw number).
     #[test]
-    pub fn test() {
-        let err1: FuseResult<u32> = err_fuse!(1_usize);
-        println!("err1: {:?}", err1);
+    fn err_fuse_positive_errno_preserved() {
+        let err: FuseResult<u32> = err_fuse!(libc::ENOENT);
+        let e = err.unwrap_err();
+        assert_eq!(e.errno, libc::ENOENT);
+        assert!(
+            e.error.to_string().contains("ENOENT"),
+            "single-arg default message should contain the errno label, got: {}",
+            e.error
+        );
+    }
 
-        let err2: FuseResult<u32> = err_fuse!(2, "error {}", 2);
-        println!("err12 {:?}", err2)
+    // The format arm interpolates its arguments into the message.
+    #[test]
+    fn err_fuse_formats_message() {
+        let err: FuseResult<u32> = err_fuse!(libc::EINVAL, "bad {}", 5);
+        let e = err.unwrap_err();
+        assert_eq!(e.errno, libc::EINVAL);
+        assert!(
+            e.error.to_string().contains("bad 5"),
+            "message should contain formatted args, got: {}",
+            e.error
+        );
+    }
+
+    // Illegal errno (out of i32 range / zero / negative) is normalized by
+    // `normalize_errno`: it trips a `debug_assert` in debug/test builds (exposing
+    // the caller bug) and falls back to EIO in release. This mirrors the crate's
+    // double-reply guard pattern (debug panics, release is safe). The release
+    // fallback is asserted in the `#[cfg(not(debug_assertions))]` variants below.
+
+    // Debug builds: an out-of-range errno panics via the debug_assert.
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "out of i32 range")]
+    fn err_fuse_oversized_errno_panics_in_debug() {
+        let _: FuseResult<u32> = err_fuse!(u64::MAX);
+    }
+
+    // Debug builds: a zero errno panics via the debug_assert.
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "out of i32 range")]
+    fn err_fuse_zero_errno_panics_in_debug() {
+        let _: FuseResult<u32> = err_fuse!(0_usize);
+    }
+
+    // Debug builds: a negative errno panics via the debug_assert (the direct
+    // illegal-FUSE-frame case: it would otherwise encode as +errno).
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "out of i32 range")]
+    fn err_fuse_negative_errno_panics_in_debug() {
+        let _: FuseResult<u32> = err_fuse!(-libc::ENOENT);
+    }
+
+    // Release builds: illegal errno falls back to EIO instead of encoding an
+    // illegal frame or truncating via `as`.
+    #[cfg(not(debug_assertions))]
+    #[test]
+    fn err_fuse_illegal_errno_falls_back_to_eio() {
+        assert_eq!(
+            (err_fuse!(u64::MAX) as FuseResult<u32>).unwrap_err().errno,
+            libc::EIO
+        );
+        assert_eq!(
+            (err_fuse!(0_usize) as FuseResult<u32>).unwrap_err().errno,
+            libc::EIO
+        );
+        assert_eq!(
+            (err_fuse!(-libc::ENOENT) as FuseResult<u32>)
+                .unwrap_err()
+                .errno,
+            libc::EIO
+        );
     }
 }

--- a/curvine-fuse/src/session/channel/fuse_receiver.rs
+++ b/curvine-fuse/src/session/channel/fuse_receiver.rs
@@ -527,7 +527,7 @@ impl<T: FileSystem> FuseReceiver<T> {
 
             _ = notify.notified() => {
                 pending_requests.remove(&req.unique());
-                let err: FuseResult<()> = err_fuse!(EINTR, "operation interrupted");
+                let err: FuseResult<()> = err_fuse!(libc::EINTR, "operation interrupted");
                 // Source-tagged as interrupted (the SETLKW interrupt-notify path),
                 // not inferred from the EINTR errno.
                 reply.send_rep_tagged(err, None, true).await.map_err(|x| x.into())


### PR DESCRIPTION
# Summary

A set of small, low-risk fixes to the curvine-fuse error path: correct the `FuseError` `Display` order, map tokio `Elapsed` to `ETIMEDOUT`, and route all `err_fuse!` errno construction through a validating normalizer so a negative/zero/out-of-range errno can never encode an illegal FUSE reply frame.

# Issue Describe / Design

Closes #1129

Root causes / fixes:
- **Display order**: `FuseError::Display` printed the message before the errno number (`errno <message>: <n>`), polluting log search. Fixed to `errno <n>: <message>`.
- **Elapsed -> EIO inconsistency**: `From<Elapsed>` returned `EIO` while `FsError::Timeout` returns `ETIMEDOUT`. The same timeout condition now maps to `ETIMEDOUT` on both paths.
- **errno validation**: `err_fuse!` used `$errno as i32`, which silently truncated large values and let a negative errno through (the reply path negates the errno, so a negative one would encode a positive/illegal frame). Errno construction is now centralized in `FuseError::from_errno_msg` / `normalize_errno`, which uses `TryInto<i32>` for a real range check, `debug_assert`s on illegal input (surfaces caller bugs in debug/test), and falls back to `EIO` in release (never panics).
- **Macro hygiene**: `err_fuse!` was `#[macro_export]`ed but its expansion referenced crate-private helpers and `orpc`, so it was never usable from an external crate. It is now a crate-internal macro; `FuseError::new` is `pub(crate)` with `from_errno_msg` as the public safe constructor; the `macros` module is private (no public API).
- Minor: single-arg `err_fuse!` default message now uses the symbolic errno label; fixed a bare `EINTR` -> `libc::EINTR` at the one outlier call site.

# Changes

| Module / File | Change | Impact on existing behavior |
| --- | --- | --- |
| `curvine-fuse/src/fuse_error.rs` | Fix `Display` order; `From<Elapsed>`->ETIMEDOUT; add `normalize_errno` + `from_errno_msg`; `new` -> `pub(crate)` with positive-errno `debug_assert` | Elapsed now maps ETIMEDOUT (was EIO); `new` no longer public |
| `curvine-fuse/src/macros.rs` | `err_fuse!` routes through `from_errno_msg`; drop `#[macro_export]`, `pub(crate) use`; label in default msg; tests -> assertions | err_fuse! now crate-internal; illegal errno -> EIO (release) / debug-assert (debug) |
| `curvine-fuse/src/lib.rs` | `mod macros` (was `pub mod`) + crate-root re-export of `err_fuse!` | `curvine_fuse::macros` no longer public (was empty API) |
| `curvine-fuse/src/session/channel/fuse_receiver.rs` | bare `EINTR` -> `libc::EINTR` | None |

# Test verified

| Test case | Result | Notes |
| --- | --- | --- |
| `cargo test -p curvine-fuse --lib macros` | PASS | 5 tests (3 debug should_panic on illegal errno) |
| `cargo test -p curvine-fuse --lib fuse_error` | PASS | 7 tests incl. new display/elapsed cases |
| `cargo build -p curvine-fuse` / `-p curvine-tests` | PASS | full workspace compiles |
| `cargo clippy -p curvine-fuse --lib` | PASS | no warnings |
| `cargo fmt -p curvine-fuse -- --check` | PASS | |

Note: 3 pre-existing `dir_tree` test failures exist on upstream `main` (verified via stash), unrelated to this PR (it does not touch dcache).

# Dependencies

- Related PRs: None
- Related issues: Closes #1129
- Blocks / blocked by: None