### PR TITLE
docs(maintainers): add yangcx000 as committer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -11,4 +11,5 @@ The current maintainers of Curvine project consists of:
 | Barry | lzj7179@163.com | @lzjqsdd | Maintainer | OPPO |
 | John | hellojlong@163.com| @jlon | Maintainer | OPPO |
 | Le Dac Thuong | ledacthuong2210@gmail.com | @thuongle2210 | Committer | -- |
+| yangcx000 | chunxin.ycx@gmail.com | @yangcx000 | Committer | LiAuto |
 


### PR DESCRIPTION
# Summary

Add @yangcx000 (LiAuto) to the Current Maintainers list as a Committer, following approval as a Curvine committer.

# Changes

| Module / File | Change | Impact on existing behavior |
| --- | --- | --- |
| `MAINTAINERS.md` | Append a Committer row for @yangcx000 (LiAuto) | None (docs only) |

# Dependencies

- Related PRs: None
- Related issues: None