### PR TITLE
fix(fuse): assign a single ino for both writer map key and handle on create (#1121)

### DIFF
--- a/curvine-fuse/src/fs/dcache/dir_tree.rs
+++ b/curvine-fuse/src/fs/dcache/dir_tree.rs
@@ -998,4 +998,46 @@ mod test {
             "cache_ttl=0 still evicts when last_access + ttl <= now"
         );
     }
+
+    /// Root cause of CurvineIO/curvine#1121: for a freshly created file whose
+    /// backend id is not yet stable (`id <= FUSE_ROOT_ID` or `== FUSE_UNKNOWN_INO`),
+    /// `next_id` falls through to the auto-increment allocator, so calling it
+    /// TWICE for the same status yields two DIFFERENT inos. The create flow must
+    /// therefore resolve the ino exactly once and reuse it for both the writers
+    /// map key and the handle ino — otherwise `find_writer(handle.ino())` /
+    /// `release(handle.ino())` cannot locate the writer registered at create.
+    #[test]
+    fn next_id_diverges_when_backend_id_unassigned() {
+        use crate::FUSE_UNKNOWN_INO;
+        let t = DirTree::default();
+
+        // id == 0 (<= FUSE_ROOT_ID): both calls allocate, and must differ.
+        let a = t.next_id(0);
+        let b = t.next_id(0);
+        assert_ne!(
+            a, b,
+            "two next_id(0) calls must return distinct inos (this is why create must not call next_ino twice)"
+        );
+
+        // id == FUSE_UNKNOWN_INO: same divergence.
+        let c = t.next_id(FUSE_UNKNOWN_INO as i64);
+        let d = t.next_id(FUSE_UNKNOWN_INO as i64);
+        assert_ne!(
+            c, d,
+            "two next_id(FUSE_UNKNOWN_INO) calls must return distinct inos"
+        );
+
+        // Allocated inos never collide with reserved sentinels.
+        for id in [a, b, c, d] {
+            assert_ne!(id, FUSE_ROOT_ID);
+            assert_ne!(id, FUSE_UNKNOWN_INO);
+        }
+
+        // Contrast: a stable backend id (> FUSE_ROOT_ID, not yet in the tree) is
+        // returned verbatim and is stable across calls — the "common case" that
+        // masked the bug in end-to-end tests.
+        let stable = 12_345_u64;
+        assert_eq!(t.next_id(stable as i64), stable);
+        assert_eq!(t.next_id(stable as i64), stable);
+    }
 }

--- a/curvine-fuse/src/fs/state/backend_handle.rs
+++ b/curvine-fuse/src/fs/state/backend_handle.rs
@@ -196,7 +196,7 @@ impl BackendHandle {
         let writer = if has_writer {
             let opts = CreateFileOptsBuilder::with_conf(state.client_conf()).build();
             let writer = state
-                .get_or_create_writer(Some(ino), &path, OpenFlags::new_write_only(), opts)
+                .get_or_create_writer(ino, &path, OpenFlags::new_write_only(), opts)
                 .await?;
             Some(writer)
         } else {

--- a/curvine-fuse/src/fs/state/node_state.rs
+++ b/curvine-fuse/src/fs/state/node_state.rs
@@ -23,8 +23,8 @@ use crate::fuse_metrics::{
 };
 use crate::raw::fuse_abi::{fuse_attr, fuse_forget_one};
 use crate::{
-    err_fuse, FuseMetrics, FuseResult, FuseUtils, FUSE_CURRENT_DIR, FUSE_PARENT_DIR, FUSE_ROOT_ID,
-    STATE_FILE_MAGIC, STATE_FILE_VERSION,
+    err_fuse, FuseError, FuseMetrics, FuseResult, FuseUtils, FUSE_CURRENT_DIR, FUSE_PARENT_DIR,
+    FUSE_ROOT_ID, STATE_FILE_MAGIC, STATE_FILE_VERSION,
 };
 use curvine_client::unified::UnifiedFileSystem;
 use curvine_common::conf::{ClientConf, ClusterConf, FuseConf};
@@ -336,27 +336,23 @@ impl NodeState {
         self.writers.get(&ino).await
     }
 
+    // Get or create the writer registered under `ino`. The caller is
+    // responsible for resolving the inode first (see `new_handle`), so that the
+    // writer-map key and the handle ino are guaranteed to be the same value.
     pub async fn get_or_create_writer(
         &self,
-        ino: Option<u64>,
+        ino: u64,
         path: &Path,
         flags: OpenFlags,
         opts: CreateFileOpts,
     ) -> FuseResult<Arc<FuseWriter>> {
-        if let Some(ino) = ino {
-            self.writers
-                .get_or_create(ino, async {
-                    let writer = self.fs.open_with_opts(path, opts, flags).await?;
-                    let writer = FuseWriter::new(&self.conf, self.fs.clone_runtime(), writer);
-                    Ok(Arc::new(writer))
-                })
-                .await
-        } else {
-            let writer = self.fs.open_with_opts(path, opts, flags).await?;
-            let writer = Arc::new(FuseWriter::new(&self.conf, self.fs.clone_runtime(), writer));
-            let ino = self.next_ino(writer.status());
-            self.writers.insert(ino, writer.clone()).await
-        }
+        self.writers
+            .get_or_create(ino, async {
+                let writer = self.fs.open_with_opts(path, opts, flags).await?;
+                let writer = FuseWriter::new(&self.conf, self.fs.clone_runtime(), writer);
+                Ok(Arc::new(writer))
+            })
+            .await
     }
 
     pub async fn new_writer(
@@ -393,55 +389,65 @@ impl NodeState {
         flags: OpenFlags,
         opts: CreateFileOpts,
     ) -> FuseResult<Arc<FileHandle>> {
-        let (reader, writer) = match flags.access_mode() {
-            mode if mode == OpenFlags::RDONLY => {
-                let reader = self.new_reader(path).await?;
-                (Some(RawPtr::from_owned(reader)), None)
-            }
+        let mode = flags.access_mode();
 
-            mode if mode == OpenFlags::WRONLY => {
+        // Read-only: only a reader, no writer to register in the writers map.
+        if mode == OpenFlags::RDONLY {
+            let reader = self.new_reader(path).await?;
+            let mut status = reader.status().clone();
+            let ino = ino.unwrap_or(self.next_ino(&status));
+            status.id = ino as i64;
+            let handle = self
+                .insert_handle_with_writer(ino, Some(RawPtr::from_owned(reader)), None, status)
+                .await;
+            return Ok(handle);
+        }
+
+        if mode != OpenFlags::WRONLY && mode != OpenFlags::RDWR {
+            return err_fuse!(libc::EINVAL, "Invalid access mode: {:?}", mode);
+        }
+
+        // Write modes (WRONLY / RDWR): resolve the inode ONCE and register the
+        // writer under that same ino, so the writer-map key always equals the
+        // handle ino. When `ino` is provided (open / restore) we reuse it; when
+        // it is None (create) we open the writer first, derive the ino from its
+        // status a single time, then insert it under that key. This avoids the
+        // previous double `next_ino` call that could diverge for a freshly
+        // created file whose backend id was not yet assigned.
+        let (ino, writer) = match ino {
+            Some(ino) => {
                 let writer = self.get_or_create_writer(ino, path, flags, opts).await?;
-                (None, Some(writer))
+                (ino, writer)
             }
-
-            mode if mode == OpenFlags::RDWR => {
-                let writer = self.get_or_create_writer(ino, path, flags, opts).await?;
-                let reader = if writer.is_ufs() {
-                    warn!(
-                        "ufs {} -> {} does not support read-write mode for file opening, reader will be None",
-                        path,
-                        writer.path().full_path()
-                    );
-                    None
-                } else {
-                    let reader = self.new_reader(path).await?;
-                    Some(RawPtr::from_owned(reader))
-                };
-
-                (reader, Some(writer))
+            None => {
+                let writer = self.new_writer(path, flags, opts).await?;
+                let ino = self.next_ino(writer.status());
+                let writer = self.writers.insert::<FuseError>(ino, writer).await?;
+                (ino, writer)
             }
+        };
 
-            _ => {
-                return err_fuse!(
-                    libc::EINVAL,
-                    "Invalid access mode: {:?}",
-                    flags.access_mode()
+        let reader = if mode == OpenFlags::RDWR {
+            if writer.is_ufs() {
+                warn!(
+                    "ufs {} -> {} does not support read-write mode for file opening, reader will be None",
+                    path,
+                    writer.path().full_path()
                 );
+                None
+            } else {
+                let reader = self.new_reader(path).await?;
+                Some(RawPtr::from_owned(reader))
             }
+        } else {
+            None
         };
 
-        let mut status = if let Some(writer) = &writer {
-            writer.status().clone()
-        } else if let Some(reader) = &reader {
-            reader.status().clone()
-        } else {
-            return err_fuse!(libc::EINVAL, "Invalid flags: {:?}", flags);
-        };
-        let ino = ino.unwrap_or(self.next_ino(&status));
+        let mut status = writer.status().clone();
         status.id = ino as i64;
 
         let handle = self
-            .insert_handle_with_writer(ino, reader, writer, status)
+            .insert_handle_with_writer(ino, reader, Some(writer), status)
             .await;
 
         Ok(handle)


### PR DESCRIPTION
# Summary

On create of a new file, the writers-map key and the handle ino were each computed independently via `next_ino`, which could diverge for a freshly created file whose backend id was not yet assigned. This makes the create flow resolve the ino exactly once and reuse it for both, so the writer registered at create is always findable by the handle's ino.

# Issue Describe / Design

Closes #1121

Root cause:
- `fs_create` (write mode) -> `new_handle(None, ...)` computed `next_ino` twice: once as the writers-map key (inside `get_or_create_writer`), once for the handle ino.
- `dir_tree::next_id(cv_id)` returns `cv_id` verbatim when it is a stable id (`> FUSE_ROOT_ID`, not `FUSE_UNKNOWN_INO`, not present) -- the common case, so both calls agreed. But when `status.id <= FUSE_ROOT_ID` or `== FUSE_UNKNOWN_INO`, both calls fall through to the auto-increment allocator and return two different inos -> writers-map key != `handle.ino()`.

Impact (when diverged): `find_writer(handle.ino())` / `release(handle.ino())` cannot locate the writer registered at create -> flush/complete/len updates lost and the writer map entry leaks.

Fix approach:
- `get_or_create_writer` no longer allocates an inode; its signature narrows from `Option<u64>` to `u64` and the caller resolves the ino first.
- `new_handle` resolves the ino exactly once on the create path (open writer -> derive ino from status once -> insert under that key), then builds the handle with the same ino. Read-only / open / restore paths are unchanged.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-fuse/src/fs/state/node_state.rs` | `get_or_create_writer` signature `Option<u64>`->`u64`, drops self-allocation branch; `new_handle` resolves ino once on create | None for common case; fixes divergence when backend id unassigned |
| `curvine-fuse/src/fs/state/backend_handle.rs` | Restore path passes `ino` instead of `Some(ino)` | None |
| `curvine-fuse/src/fs/dcache/dir_tree.rs` | Add unit test `next_id_diverges_when_backend_id_unassigned` | Test only |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-fuse --lib next_id_diverges_when_backend_id_unassigned` | PASS | New test: proves next_id diverges for id=0 / FUSE_UNKNOWN_INO, is stable for a valid id |
| `cargo build -p curvine-fuse` | PASS | |
| `cargo fmt --check -p curvine-fuse` | PASS | |
| `cargo clippy -p curvine-fuse` | PASS | no warnings |

Note: this is a condition-triggered / defensive fix. In the normal create path the backend assigns a valid id immediately, so the divergence is not reachable in regular flow; the fix removes the theoretical divergence point and clarifies ownership of inode allocation.

# Dependencies

- Related PRs: None
- Related issues: #1121
- Blocks / blocked by: None