### PR TITLE
refactor(fuse): clean up lib.rs constants naming, types, and visibility (#1142)

### DIFF
--- a/curvine-fuse/src/lib.rs
+++ b/curvine-fuse/src/lib.rs
@@ -96,7 +96,11 @@ pub const FUSE_WRITEBACK_CACHE: u32 = 1 << 16;
 
 pub const FUSE_POSIX_ACL: u32 = 1 << 20;
 
-pub const FUSE_DO_RENAME2: u32 = 1 << 11;
+/// FUSE init capability bit `1 << 11` (uapi `fuse.h`): the kernel supports
+/// ioctl on directories. NOTE: RENAME2 is an *opcode* (`FUSE_RENAME2 = 45`),
+/// not an init flag — bit 11 is `FUSE_HAS_IOCTL_DIR`. Not yet negotiated by
+/// this daemon.
+pub const FUSE_HAS_IOCTL_DIR: u32 = 1 << 11;
 
 /// Kernel automatically invalidates the page cache on open when mtime or size
 /// has changed (CAP_AUTO_INVAL_DATA, available since Linux 2.6.35).

--- a/curvine-fuse/src/lib.rs
+++ b/curvine-fuse/src/lib.rs
@@ -36,12 +36,7 @@ pub use self::fuse_utils::FuseUtils;
 
 pub type FuseResult<T> = Result<T, FuseError>;
 
-// fuse3 session type
-pub type RawSession = *mut core::ffi::c_void;
-
 pub const FUSE_DEVICE_NAME: &str = "/dev/fuse";
-
-pub const FUSE_NAME: &str = "curvine-fuse";
 
 pub const FUSE_IN_HEADER_LEN: usize = size_of::<fuse_in_header>();
 
@@ -49,14 +44,11 @@ pub const FUSE_SUCCESS: i32 = 0;
 
 pub const FUSE_OUT_HEADER_LEN: usize = size_of::<fuse_out_header>();
 
-pub const FILE_HANDLE_READ_BIT: u64 = 1 << 63;
+pub(crate) const FILE_HANDLE_READ_BIT: u64 = 1 << 63;
 
-pub const FILE_HANDLE_WRITE_BIT: u64 = 1 << 62;
+pub(crate) const FILE_HANDLE_WRITE_BIT: u64 = 1 << 62;
 
 pub const FUSE_ROOT_ID: u64 = 1;
-
-// curvine root node id.
-pub const FS_ROOT_ID: i64 = 1000;
 
 pub const FUSE_PATH_SEPARATOR: &str = "/";
 
@@ -66,6 +58,10 @@ pub const FUSE_KERNEL_VERSION: u32 = 7;
 
 pub const FUSE_KERNEL_MINOR_VERSION: u32 = 31;
 
+/// Upper bound on `max_pages` (the number of pages per request), matching the
+/// kernel's internal `FUSE_MAX_MAX_PAGES = 256` (`fs/fuse/fuse_i.h` on v5.4–v5.10;
+/// newer kernels moved it to the `fuse_max_pages_limit` sysctl). NOTE: this is a
+/// page-count LIMIT, distinct from the `FUSE_MAX_PAGES` init capability bit below.
 pub const FUSE_MAX_MAX_PAGES: usize = 256;
 
 pub const FUSE_BUFFER_HEADER_SIZE: usize = 0x1000; // 4096
@@ -74,6 +70,10 @@ pub const FUSE_DEFAULT_PAGE_SIZE: usize = 4096;
 
 pub const FUSE_PATH_MAX_DEPTH: usize = 4096;
 
+/// FUSE init capability bit (uapi `fuse.h`: `FUSE_MAX_PAGES = (1 << 22)`):
+/// negotiates that `fuse_init_out.max_pages` carries the per-request page count.
+/// NOTE: this is a capability BIT, distinct from the `FUSE_MAX_MAX_PAGES` page
+/// limit above — the near-identical names are both kernel-official.
 pub const FUSE_MAX_PAGES: u32 = 1 << 22;
 
 pub const FUSE_BIG_WRITES: u32 = 1 << 5;
@@ -108,9 +108,12 @@ pub const FUSE_EXPORT_SUPPORT: u32 = 1 << 4;
 
 pub const FUSE_MAX_NAME_LENGTH: usize = 255;
 
+/// Placeholder for the statfs `files`/`ffree` counts (total/free inodes) when the
+/// count is unknown — Curvine's distributed backend keeps no global inode
+/// statistics. The kernel passes this value through verbatim (it is not a
+/// kernel-recognized "unknown" sentinel), so `df -i` reports it as a large count.
+/// Distinct from `FUSE_UNKNOWN_INO` (an inode-number sentinel) despite the equal value.
 pub const FUSE_UNKNOWN_INODES: u64 = 0xffffffff;
-
-pub const FUSE_MAX_BACKGROUND: u16 = 16;
 
 pub const FUSE_CURRENT_DIR: &str = ".";
 
@@ -123,6 +126,10 @@ pub const FUSE_S_ISGID: u32 = 0x400;
 // Default file permission code
 pub const FUSE_DEFAULT_MODE: u32 = 0o777;
 
+/// Sentinel "invalid inode number": used for synthetic `.`/`..` dirents and
+/// reserved by `DirTree::next_id` so it is never handed out as a real inode.
+/// A non-zero sentinel is deliberate — `d_ino == 0` can be filtered by filldir.
+/// Distinct from `FUSE_UNKNOWN_INODES` (a statfs count) despite the equal value.
 pub const FUSE_UNKNOWN_INO: u64 = 0xffffffff;
 
 pub const FUSE_FOPEN_DIRECT_IO: u32 = 1 << 0;
@@ -133,11 +140,16 @@ pub const FUSE_FOPEN_NONSEEKABLE: u32 = 1 << 2;
 
 pub const FUSE_FOPEN_CACHE_DIR: u32 = 1 << 3;
 
-pub const FUSE_FOPEN_STREAM: u32 = 1 << 4;
+// FUSE FOPEN response flags kept for ABI completeness (kernel `fuse.h`), not yet
+// negotiated by this daemon; crate-internal until a feature wires them up.
+#[allow(dead_code)]
+pub(crate) const FUSE_FOPEN_STREAM: u32 = 1 << 4;
 
-pub const FUSE_FOPEN_NOFLUSH: u32 = 1 << 5;
+#[allow(dead_code)]
+pub(crate) const FUSE_FOPEN_NOFLUSH: u32 = 1 << 5;
 
-pub const FUSE_FOPEN_PARALLEL_DIRECT_WRITES: i32 = 1 << 6;
+#[allow(dead_code)]
+pub(crate) const FUSE_FOPEN_PARALLEL_DIRECT_WRITES: u32 = 1 << 6;
 
 // FUSE setattr valid bit flags (aligned with linux/fs/fuse definitions)
 pub const FATTR_MODE: u32 = 1 << 0;

--- a/curvine-fuse/src/session/fuse_mnt.rs
+++ b/curvine-fuse/src/session/fuse_mnt.rs
@@ -17,7 +17,7 @@
 use crate::raw::fuse_abi::fuse_args;
 use crate::raw::fuse_mount_pure;
 use crate::raw::fuse_umount_pure;
-use crate::{FuseUtils, RawSession, FUSE_CLONE_FD_MIN_VERSION, UNIX_KERNEL_VERSION};
+use crate::{FuseUtils, FUSE_CLONE_FD_MIN_VERSION, UNIX_KERNEL_VERSION};
 use curvine_common::conf::FuseConf;
 use log::{debug, error, info};
 use orpc::io::IOResult;


### PR DESCRIPTION
# Summary

Pure naming/type/visibility cleanup of the constants in `curvine-fuse/src/lib.rs`, per the review in #1142. No functional behavior changes — constant values are unchanged; several constants had misleading names, inconsistent types, or were dead / over-broad in visibility.

# Issue Describe / Design

Closes #1142

- **(a) `FUSE_MAX_PAGES` vs `FUSE_MAX_MAX_PAGES`** (capability bit vs page-count limit, easily confused): added doc comments explaining that one is a capability BIT and the other a page-count LIMIT, and that the near-identical names are both kernel-official.
- **(b) `FUSE_UNKNOWN_INODES` / `FUSE_UNKNOWN_INO`** (same value `0xffffffff`, different meaning): added comments distinguishing the statfs files/ffree placeholder from the synthetic-inode sentinel.
- **(c) `FUSE_FOPEN_PARALLEL_DIRECT_WRITES`**: changed `i32` -> `u32` for consistency with the other `FUSE_FOPEN_*` flags and `fuse_open_out.open_flags`.
- **(d) `FUSE_MAX_BACKGROUND = 16`**: deleted — dead (no use site) and stale vs the config default (256).
- **(e) unused / test-only public constants**: deleted the clearly-unused (`RawSession`, `FUSE_NAME`, `FS_ROOT_ID`); narrowed the rest to `pub(crate)` (`FILE_HANDLE_READ_BIT`/`WRITE_BIT`, and the not-yet-negotiated `FUSE_FOPEN_STREAM`/`NOFLUSH`/`PARALLEL_DIRECT_WRITES`, marked `#[allow(dead_code)]`).

Additionally, while auditing the constants against the kernel `uapi/fuse.h` (v7.45), one long-standing misnamed constant surfaced:

- **`FUSE_DO_RENAME2 = 1 << 11` -> `FUSE_HAS_IOCTL_DIR`**: bit `1 << 11` in the FUSE init flags is `FUSE_HAS_IOCTL_DIR`, not a rename2 capability. RENAME2 is an *opcode* (`FUSE_RENAME2 = 45`, correctly defined in `fuse_op_code.rs`), not an init flag. The old name was a latent trap — `out_flags |= FUSE_DO_RENAME2` would have negotiated ioctl-on-dir support instead. No use site exists, so this is a name/semantics fix only (value unchanged).

## FUSE protocol alignment audit

All FUSE-protocol constants in `lib.rs` were cross-checked against Linux `uapi/fuse.h` (v7.45). Init capability flags, `FUSE_FOPEN_*`, `FATTR_*`, and header sizes all match the kernel's official bit values. The only mismatch was the `FUSE_DO_RENAME2` name above (value was already correct for its true meaning).

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-fuse/src/lib.rs` | Comment disambiguation for `FUSE_MAX_PAGES`/`FUSE_MAX_MAX_PAGES` and `FUSE_UNKNOWN_INODES`/`FUSE_UNKNOWN_INO`; `FUSE_FOPEN_PARALLEL_DIRECT_WRITES` `i32`->`u32`; rename `FUSE_DO_RENAME2` -> `FUSE_HAS_IOCTL_DIR`; delete dead `FUSE_MAX_BACKGROUND`, `RawSession`, `FUSE_NAME`, `FS_ROOT_ID`; narrow `FILE_HANDLE_*` and unused `FUSE_FOPEN_*` to `pub(crate)` | None (constant values unchanged) |
| `curvine-fuse/src/session/fuse_mnt.rs` | Drop now-removed `RawSession` from `use` import (unused in body) | None |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo build --workspace` | PASS | No cross-crate breakage from deletions / `pub(crate)` narrowing |
| `cargo clippy -p curvine-fuse --lib` | PASS | No warnings |
| `cargo test -p curvine-fuse --lib` | PASS | 140 passed; `dir_tree::test` skipped (pre-existing failure on clean upstream `438c997`, unrelated) |
| `cargo fmt -p curvine-fuse -- --check` | PASS | |

# Dependencies

- Related PRs: None
- Related issues: #1088 (init capability allowlist)
- Blocks / blocked by: None
