### PR TITLE
fix(fuse): reject IOSlice responses without panicking (#1097)

### DIFF
--- a/curvine-fuse/src/session/fuse_response.rs
+++ b/curvine-fuse/src/session/fuse_response.rs
@@ -61,6 +61,14 @@ impl ResponseData {
 
         // write data
         for data in &self.data {
+            // FUSE iovec responses can only contain memory-backed data. An
+            // IOSlice refers to an fd-backed region and cannot be represented
+            // as an std::io::IoSlice without a separate transfer path.
+            if matches!(data, DataSlice::IOSlice(_)) {
+                return orpc::err_box!(
+                    "DataSlice::IOSlice is not supported in FUSE iovec responses"
+                );
+            }
             iovec.push(IoSlice::new(data.as_slice()));
         }
         Ok((self.header.len as usize, iovec))
@@ -699,6 +707,42 @@ mod tests {
     };
     use orpc::common::{Gauge, Metrics as m};
     use orpc::sync::channel::{AsyncChannel, AsyncReceiver};
+
+    #[test]
+    fn as_iovec_rejects_io_slice_without_panicking() {
+        let response = ResponseData::new(
+            fuse_out_header {
+                len: (FUSE_OUT_HEADER_LEN + 1) as u32,
+                error: 0,
+                unique: 1,
+            },
+            vec![DataSlice::io_slice(-1, None, 1)],
+        );
+
+        let error = match response.as_iovec() {
+            Ok(_) => panic!("IOSlice response must be rejected"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("DataSlice::IOSlice"));
+    }
+
+    #[test]
+    fn as_iovec_accepts_memory_backed_data() {
+        let payload = b"reply";
+        let response = ResponseData::new(
+            fuse_out_header {
+                len: (FUSE_OUT_HEADER_LEN + payload.len()) as u32,
+                error: 0,
+                unique: 1,
+            },
+            vec![DataSlice::buffer(BytesMut::from(&payload[..]))],
+        );
+
+        let (len, iovec) = response.as_iovec().unwrap();
+        assert_eq!(len, FUSE_OUT_HEADER_LEN + payload.len());
+        assert_eq!(iovec.len(), 2);
+        assert_eq!(iovec[1].as_ref(), payload);
+    }
 
     // The finish paths (`finish_no_reply` / `finish_early` / enqueue-failure)
     // now read `FuseMetrics::get()`, which panics if the process-global registry

--- a/curvine-fuse/src/session/fuse_response.rs
+++ b/curvine-fuse/src/session/fuse_response.rs
@@ -741,7 +741,7 @@ mod tests {
         let (len, iovec) = response.as_iovec().unwrap();
         assert_eq!(len, FUSE_OUT_HEADER_LEN + payload.len());
         assert_eq!(iovec.len(), 2);
-        assert_eq!(iovec[1].as_ref(), payload);
+        assert_eq!(&*iovec[1], payload);
     }
 
     // The finish paths (`finish_no_reply` / `finish_early` / enqueue-failure)


### PR DESCRIPTION
# Summary

Reject fd-backed `DataSlice::IOSlice` fragments when assembling FUSE iovec responses, returning an error instead of panicking in `RawIOSlice::as_slice`.

# Issue Describe / Design

Closes #1097

- Root cause: `ResponseData::as_iovec` unconditionally called `DataSlice::as_slice`; the `IOSlice` implementation delegates to `RawIOSlice::as_slice`, which intentionally panics because fd-backed regions cannot be represented as borrowed memory bytes.
- Reproduction: construct a `ResponseData` containing `DataSlice::IOSlice` and call `as_iovec`.
- Fix approach: keep the current memory-backed iovec path unchanged, but reject `IOSlice` with an `IOError`. A future zero-copy fd transfer path remains out of scope.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-fuse/src/session/fuse_response.rs` | Reject `DataSlice::IOSlice` before calling `as_slice`; add rejection and memory-backed regression tests | Existing memory-backed FUSE responses are unchanged; unsupported fd-backed responses now return an error instead of panicking |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo fmt --all -- --check` | PASS | Linux remote |
| `cargo test -p curvine-fuse as_iovec_ --lib` | PASS | 2 passed, 0 failed |
| `cargo clippy -p curvine-fuse --lib --tests -- -D warnings` | PASS | Linux remote, Rust 1.92.0 |
| `cargo test -p curvine-fuse --lib` | BASELINE MATCH | PR: 163 passed, 3 existing `dir_tree` failures; upstream `main` reproduces the same 3 failures |
| GitHub Actions `build` / `commitlint` | PASS | PR head `8cb5dab` |

# Dependencies

- Related PRs: None
- Related issues: #1097
- Blocks / blocked by: None