### PR TITLE
feat(fuse): strengthen validate-config — state_dir writability and unknown-key warnings (#1126)

### DIFF
--- a/curvine-common/src/conf/fuse_conf.rs
+++ b/curvine-common/src/conf/fuse_conf.rs
@@ -268,6 +268,89 @@ impl FuseConf {
         Ok(())
     }
 
+    /// Validates that `state_dir` is — or can be made — a writable directory.
+    ///
+    /// The SIGUSR1 persist/restore state file lives under `state_dir`
+    /// (`FuseSession::state_file`). Runtime `init()` stays lenient and never
+    /// touches it, so a bad `state_dir` (missing, not a directory, or
+    /// non-writable) would otherwise only fail at persist/restore time —
+    /// potentially during a graceful upgrade. `validate-config` calls this to
+    /// surface the problem before mount.
+    pub fn validate_state_dir(&self) -> CommonResult<()> {
+        let path = std::path::Path::new(&self.state_dir);
+
+        if path.exists() {
+            if !path.is_dir() {
+                return err_box!(
+                    "fuse.state_dir '{}' exists but is not a directory",
+                    self.state_dir
+                );
+            }
+        } else if let Err(e) = std::fs::create_dir_all(path) {
+            return err_box!(
+                "fuse.state_dir '{}' does not exist and could not be created: {}",
+                self.state_dir,
+                e
+            );
+        }
+
+        // Probe writability by creating (then removing) a temp file. Directory
+        // permission bits alone can be misleading (e.g. read-only mounts), so a
+        // real create is the reliable check.
+        let probe = path.join(format!(".curvine_fuse_state_probe_{}", std::process::id()));
+        match std::fs::File::create(&probe) {
+            Ok(_) => {
+                let _ = std::fs::remove_file(&probe);
+                Ok(())
+            }
+            Err(e) => err_box!("fuse.state_dir '{}' is not writable: {}", self.state_dir, e),
+        }
+    }
+
+    /// Canonical TOML key names for `FuseConf` fields, derived by serializing the
+    /// default so it cannot drift from the struct definition. `#[serde(skip_*)]`
+    /// runtime-only fields (the `*_ttl` durations) are excluded automatically.
+    fn known_field_names() -> Vec<String> {
+        match toml::Value::try_from(FuseConf::default()) {
+            Ok(toml::Value::Table(t)) => t.keys().cloned().collect(),
+            _ => vec![],
+        }
+    }
+
+    /// Returns keys in a raw `[fuse]` TOML table that do not match any current
+    /// `FuseConf` field. These are surfaced as warnings by `validate-config`:
+    /// they are silently dropped on load (FuseConf is `#[serde(default)]` with
+    /// no `deny_unknown_fields`), so a typo would otherwise never take effect
+    /// and never be noticed. Result is sorted for stable output.
+    ///
+    /// Note: a renamed field kept alive by `#[serde(alias)]` (e.g. the old
+    /// `mnt_per_task`) is reported here too — its canonical name is what
+    /// `FuseConf` exposes — so the value DOES still take effect via the alias.
+    /// The warning is intentionally phrased to cover both cases (typo vs.
+    /// deprecated/renamed) rather than claiming the setting was ignored.
+    pub fn unrecognized_fuse_keys(fuse_table: &toml::value::Table) -> Vec<String> {
+        let known: std::collections::HashSet<String> =
+            Self::known_field_names().into_iter().collect();
+
+        let mut unknown: Vec<String> = fuse_table
+            .keys()
+            .filter(|k| !known.contains(k.as_str()))
+            .cloned()
+            .collect();
+        unknown.sort();
+        unknown
+    }
+
+    /// Parses raw cluster TOML text and returns the unrecognized keys found
+    /// under the `[fuse]` table. Missing `[fuse]` table yields an empty list.
+    pub fn unrecognized_fuse_keys_from_toml(raw: &str) -> CommonResult<Vec<String>> {
+        let value: toml::Value = try_err!(toml::from_str(raw));
+        match value.get("fuse").and_then(|v| v.as_table()) {
+            Some(t) => Ok(Self::unrecognized_fuse_keys(t)),
+            None => Ok(vec![]),
+        }
+    }
+
     pub fn parse_fuse_opts(&self) -> Vec<CString> {
         let mut opts = vec![];
         opts.push(FFIUtils::new_cs_string("curvine-fuse"));
@@ -583,5 +666,98 @@ mnt_per_task = 7
         let conf: FuseConf =
             toml::from_str(toml).expect("legacy mnt_per_task key must deserialize via alias");
         assert_eq!(conf.tasks_per_mnt, 7);
+    }
+
+    #[test]
+    fn validate_state_dir_accepts_writable_dir() {
+        let dir = std::env::temp_dir().join(format!("cv_state_ok_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let conf = FuseConf {
+            state_dir: dir.to_string_lossy().to_string(),
+            ..Default::default()
+        };
+        conf.validate_state_dir()
+            .expect("writable directory must pass");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn validate_state_dir_creates_missing_dir() {
+        let dir =
+            std::env::temp_dir().join(format!("cv_state_missing_{}/nested", std::process::id()));
+        // Ensure it does not pre-exist.
+        let _ = std::fs::remove_dir_all(&dir);
+        let conf = FuseConf {
+            state_dir: dir.to_string_lossy().to_string(),
+            ..Default::default()
+        };
+        conf.validate_state_dir()
+            .expect("missing state_dir must be created");
+        assert!(dir.is_dir(), "state_dir should have been created");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn validate_state_dir_rejects_non_directory() {
+        let file = std::env::temp_dir().join(format!("cv_state_file_{}", std::process::id()));
+        std::fs::write(&file, b"x").unwrap();
+        let conf = FuseConf {
+            state_dir: file.to_string_lossy().to_string(),
+            ..Default::default()
+        };
+        let err = conf
+            .validate_state_dir()
+            .expect_err("a regular file must be rejected");
+        assert!(
+            err.to_string().contains("is not a directory"),
+            "unexpected error: {}",
+            err
+        );
+        let _ = std::fs::remove_file(&file);
+    }
+
+    #[test]
+    fn unrecognized_fuse_keys_flags_typo_and_legacy() {
+        // Every key not matching a current FuseConf field is flagged so the user
+        // can investigate: the typo (direct_iox), the dropped legacy param
+        // (node_cache_size), and the renamed key still alive via #[serde(alias)]
+        // (mnt_per_task). A current field (io_threads) is NOT flagged.
+        let raw = r#"
+[fuse]
+io_threads = 16
+node_cache_size = 200000
+mnt_per_task = 7
+direct_iox = true
+"#;
+        let unknown = FuseConf::unrecognized_fuse_keys_from_toml(raw).unwrap();
+        assert_eq!(
+            unknown,
+            vec![
+                "direct_iox".to_string(),
+                "mnt_per_task".to_string(),
+                "node_cache_size".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn unrecognized_fuse_keys_empty_when_all_known() {
+        let raw = r#"
+[fuse]
+io_threads = 16
+direct_io = true
+state_dir = "/tmp"
+"#;
+        let unknown = FuseConf::unrecognized_fuse_keys_from_toml(raw).unwrap();
+        assert!(unknown.is_empty(), "unexpected unknown keys: {:?}", unknown);
+    }
+
+    #[test]
+    fn unrecognized_fuse_keys_empty_without_fuse_table() {
+        let raw = r#"
+cluster_id = "test"
+"#;
+        let unknown = FuseConf::unrecognized_fuse_keys_from_toml(raw).unwrap();
+        assert!(unknown.is_empty());
     }
 }

--- a/curvine-fuse/src/cli/mount_args.rs
+++ b/curvine-fuse/src/cli/mount_args.rs
@@ -178,6 +178,12 @@ impl FuseRuntimeArgs {
         conf.client.init()?;
         Ok(conf)
     }
+
+    /// Path to the configuration file that `get_conf` loads from. Used by
+    /// `validate-config` to re-read the raw TOML for unknown-key detection.
+    pub fn conf_path(&self) -> &str {
+        &self.mount.conf
+    }
 }
 
 impl FuseMountArgs {

--- a/curvine-fuse/src/cli/validate_run.rs
+++ b/curvine-fuse/src/cli/validate_run.rs
@@ -13,11 +13,159 @@
 // limitations under the License.
 
 use crate::cli::FuseRuntimeArgs;
+use curvine_common::conf::FuseConf;
 use orpc::CommonResult;
+use std::fs::read_to_string;
 
 /// Validates configuration by loading and initializing cluster settings without mounting.
+///
+/// Beyond the hard load/parse checks done by `get_conf`, this surfaces two
+/// problems that would otherwise only appear at runtime (or never):
+///   - `fuse.state_dir` must be (or be creatable as) a writable directory —
+///     hard error, since a bad value fails the SIGUSR1 persist/restore path,
+///     often mid graceful-upgrade;
+///   - unrecognized `[fuse]` TOML keys — warning, since `FuseConf`
+///     intentionally ignores unknown keys for legacy compatibility
+///     (`#[serde(default)]`, no `deny_unknown_fields`). A misspelled key is
+///     silently dropped so its setting never takes effect; a deprecated/renamed
+///     key may still apply via `#[serde(alias)]`. Either way it is worth
+///     surfacing so the user can verify intent.
+///
 /// Exits quietly on success; failures are returned via `CommonResult` for stderr reporting.
 pub fn run_validate_config(args: FuseRuntimeArgs) -> CommonResult<()> {
-    args.get_conf()?;
+    let conf = args.get_conf()?;
+
+    // (a) state_dir must be a writable directory (create if missing).
+    conf.fuse.validate_state_dir()?;
+
+    // (b) Warn on unrecognized [fuse] keys. Re-read the raw TOML because the
+    // typed load already discarded them. A read failure here is non-fatal: the
+    // typed load above already succeeded, so we simply skip the key audit.
+    match read_to_string(args.conf_path()) {
+        Ok(raw) => match FuseConf::unrecognized_fuse_keys_from_toml(&raw) {
+            Ok(unknown) if !unknown.is_empty() => {
+                for key in &unknown {
+                    eprintln!(
+                        "Warning: unrecognized [fuse] config key '{}' — possible typo or a \
+                         deprecated/renamed setting; please verify it is still valid",
+                        key
+                    );
+                }
+            }
+            Ok(_) => {}
+            Err(e) => {
+                eprintln!("Warning: could not audit [fuse] keys: {}", e);
+            }
+        },
+        Err(e) => {
+            eprintln!(
+                "Warning: could not re-read config file '{}' for [fuse] key audit: {}",
+                args.conf_path(),
+                e
+            );
+        }
+    }
+
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::{FuseCli, FuseSubcommand};
+    use clap::Parser;
+    use std::io::Write;
+
+    // Builds FuseRuntimeArgs pointing at a real config file on disk, the same
+    // way the CLI does (`curvine-fuse validate-config --conf <path>`).
+    fn args_for(conf_path: &str) -> FuseRuntimeArgs {
+        let cli = FuseCli::try_parse_from(["curvine-fuse", "validate-config", "--conf", conf_path])
+            .expect("parse validate-config");
+        match cli.cmd {
+            Some(FuseSubcommand::ValidateConfig(args)) => args,
+            _ => panic!("expected validate-config subcommand"),
+        }
+    }
+
+    // Writes `body` to a uniquely named temp .toml and returns its path.
+    fn write_temp_toml(tag: &str, body: &str) -> std::path::PathBuf {
+        let path =
+            std::env::temp_dir().join(format!("cv_validate_{}_{}.toml", tag, std::process::id()));
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(body.as_bytes()).unwrap();
+        path
+    }
+
+    #[test]
+    fn validate_config_ok_for_clean_conf() {
+        let state_dir = std::env::temp_dir().join(format!("cv_vc_state_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&state_dir);
+        let body = format!(
+            r#"
+[fuse]
+io_threads = 8
+state_dir = "{}"
+"#,
+            state_dir.to_string_lossy()
+        );
+        let conf = write_temp_toml("ok", &body);
+
+        run_validate_config(args_for(conf.to_str().unwrap())).expect("clean config must validate");
+        // state_dir should have been created by the writability check.
+        assert!(state_dir.is_dir());
+
+        let _ = std::fs::remove_file(&conf);
+        let _ = std::fs::remove_dir_all(&state_dir);
+    }
+
+    #[test]
+    fn validate_config_errors_when_state_dir_is_a_file() {
+        // Point state_dir at an existing regular file → hard error.
+        let file = std::env::temp_dir().join(format!("cv_vc_notdir_{}", std::process::id()));
+        std::fs::write(&file, b"x").unwrap();
+        let body = format!(
+            r#"
+[fuse]
+io_threads = 8
+state_dir = "{}"
+"#,
+            file.to_string_lossy()
+        );
+        let conf = write_temp_toml("notdir", &body);
+
+        let err = run_validate_config(args_for(conf.to_str().unwrap()))
+            .expect_err("non-directory state_dir must fail");
+        assert!(
+            err.to_string().contains("is not a directory"),
+            "unexpected error: {}",
+            err
+        );
+
+        let _ = std::fs::remove_file(&conf);
+        let _ = std::fs::remove_file(&file);
+    }
+
+    #[test]
+    fn validate_config_ok_but_warns_on_unrecognized_key() {
+        // An unrecognized key does NOT fail validation (warning only); the run
+        // still returns Ok. The warning itself goes to stderr via eprintln.
+        let state_dir = std::env::temp_dir().join(format!("cv_vc_warn_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&state_dir);
+        let body = format!(
+            r#"
+[fuse]
+io_threads = 8
+state_dir = "{}"
+direct_iox = true
+"#,
+            state_dir.to_string_lossy()
+        );
+        let conf = write_temp_toml("warn", &body);
+
+        run_validate_config(args_for(conf.to_str().unwrap()))
+            .expect("unrecognized key must warn, not fail");
+
+        let _ = std::fs::remove_file(&conf);
+        let _ = std::fs::remove_dir_all(&state_dir);
+    }
 }


### PR DESCRIPTION
# Summary

Extends the `curvine-fuse validate-config` subcommand to catch two FuseConf configuration problems before mount that would otherwise only surface at runtime (or never): a non-writable `state_dir` and silently-dropped unknown `[fuse]` keys. Runtime `init()` stays lenient for legacy compatibility.

# Issue Describe / Design

Closes #1126

This is a feature from a FuseConf configuration-init review. `validate-config` previously only ran `get_conf`, so it caught hard load/parse errors but never checked `state_dir` writability or warned on unknown keys.

Design decisions and trade-offs:
- **(a) `state_dir` — hard error.** The SIGUSR1 persist/restore state file lives under `state_dir` (`FuseSession::state_file`). A bad value (missing / not a directory / non-writable) would otherwise only fail at persist/restore time, potentially mid graceful-upgrade. `validate-config` now verifies it is — or can be created as — a writable directory (probing with a real temp-file create, since directory permission bits alone can be misleading on read-only mounts). Runtime `init()` is left untouched so legacy behavior is unchanged.
- **(b) unknown `[fuse]` keys — warning.** `FuseConf` is `#[serde(default)]` with no `deny_unknown_fields` (intentional, for legacy compatibility), so a misspelled key like `direct_iox` is silently dropped and never takes effect. `validate-config` re-reads the raw TOML and warns on any `[fuse]` key that does not match a current `FuseConf` field. No allowlist is used: every unrecognized key is surfaced so the user can investigate (a deprecated/renamed key kept alive via `#[serde(alias)]` is reported too — the warning is phrased to cover both typo and deprecated/renamed cases rather than claiming the setting was ignored). This is a warning, not a failure — the config still validates.
- Warnings go to stderr via `eprintln!` (not the log framework) because the `validate-config` path does not initialize `Logger`; stderr is also what the CSI driver captures from the subprocess.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-common/src/conf/fuse_conf.rs` | Add `validate_state_dir()`, `unrecognized_fuse_keys()` / `unrecognized_fuse_keys_from_toml()` (+ unit tests) | None — new methods; runtime `init()` unchanged |
| `curvine-fuse/src/cli/mount_args.rs` | Add `FuseRuntimeArgs::conf_path()` to expose the config path for re-reading raw TOML | None |
| `curvine-fuse/src/cli/validate_run.rs` | Wire both checks into `run_validate_config` (+ end-to-end tests) | `validate-config` now errors on bad `state_dir` and warns on unknown `[fuse]` keys |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-common --lib conf::fuse_conf` | PASS | 19 tests; covers state_dir 3 states + unrecognized-key 3 cases |
| `cargo test -p curvine-fuse --lib cli::validate_run` | PASS | 3 end-to-end tests: clean OK / state_dir-is-file error / unknown-key warns-not-fails |
| `cargo fmt -- --check` | PASS | |
| `cargo clippy -p curvine-common -p curvine-fuse --tests` | PASS | no warnings |

# Dependencies

- Related PRs: None
- Related issues: #1126
- Blocks / blocked by: None