### PR TITLE
fix(fuse): inherit setgid on mkdir

### DIFF
--- a/curvine-server/src/master/meta/fs_dir.rs
+++ b/curvine-server/src/master/meta/fs_dir.rs
@@ -35,6 +35,8 @@ use std::collections::{HashMap, LinkedList};
 use std::mem;
 use std::sync::Arc;
 
+const MODE_SETGID: u32 = 0o2000;
+
 /// Note: The modification operation uses &mut self, which is a necessary improvement. We use the unsafe API to perform modifications.
 pub struct FsDir {
     pub(crate) root_dir: InodeView,
@@ -115,13 +117,19 @@ impl FsDir {
     // Create the first subdirectory that does not exist.
     // 1. If all directories on the path already exist, skip and return successful.
     // 2. If the parent directory does not exist, an error is returned.
-    fn create_single_dir(&mut self, mut inp: InodePath, opts: MkdirOpts) -> FsResult<InodePath> {
+    fn create_single_dir(
+        &mut self,
+        mut inp: InodePath,
+        mut opts: MkdirOpts,
+    ) -> FsResult<InodePath> {
         if inp.is_full() || inp.is_root() {
             return Ok(inp);
         }
 
         let pos = inp.existing_len() - 1;
         let name = inp.get_component(pos + 1)?.to_string();
+
+        Self::apply_setgid_directory_inheritance(&inp, &mut opts)?;
 
         let dir = InodeDir::with_opts(self.next_inode_id()?, LocalTime::mills() as i64, opts);
 
@@ -131,6 +139,23 @@ impl FsDir {
         self.journal_writer.log_mkdir(self, &parent_path, &dir)?;
 
         Ok(inp)
+    }
+
+    fn apply_setgid_directory_inheritance(inp: &InodePath, opts: &mut MkdirOpts) -> FsResult<()> {
+        if inp.existing_len() == 0 {
+            return Ok(());
+        }
+        let parent_pos = inp.existing_len() as i32 - 1;
+        let parent = match inp.get_inode(parent_pos) {
+            Some(parent) => parent,
+            None => return Ok(()),
+        };
+        let acl = parent.as_ref().acl()?;
+        if acl.mode & MODE_SETGID != 0 {
+            opts.group = acl.group.clone();
+            opts.mode |= MODE_SETGID;
+        }
+        Ok(())
     }
 
     // Create all previous directories that may be missing on the path.

--- a/curvine-server/tests/master_fs_test.rs
+++ b/curvine-server/tests/master_fs_test.rs
@@ -24,7 +24,8 @@ use curvine_common::raft::storage::{AppStorage, ApplyMsg};
 use curvine_common::state::MountOptions;
 use curvine_common::state::{
     BlockLocation, BlockReportInfo, BlockReportList, BlockReportStatus, ClientAddress, CommitBlock,
-    CreateFileOpts, CreateFileOptsBuilder, FileAllocOpts, StorageType, TtlAction, WorkerInfo,
+    CreateFileOpts, CreateFileOptsBuilder, FileAllocOpts, MkdirOptsBuilder, StorageType, TtlAction,
+    WorkerInfo,
 };
 use curvine_common::state::{OpenFlags, RenameFlags, SetAttrOptsBuilder};
 use curvine_common::utils::SerdeUtils;
@@ -757,6 +758,33 @@ fn mkdir(fs: &MasterFilesystem) -> CommonResult<()> {
     assert_eq!(list.len(), 3);
 
     fs.print_tree();
+
+    Ok(())
+}
+
+#[test]
+fn mkdir_inherits_setgid_parent_group_and_mode() -> CommonResult<()> {
+    let _serial = master_fs_test_serial();
+    let fs = new_fs(true, "mkdir-setgid-inherit");
+
+    let parent_opts = MkdirOptsBuilder::new()
+        .owner("parent-owner".to_string())
+        .group("parent-group".to_string())
+        .mode(0o2775)
+        .build();
+    fs.mkdir_with_opts("/parent", parent_opts)?;
+
+    let child_opts = MkdirOptsBuilder::new()
+        .owner("child-owner".to_string())
+        .group("child-group".to_string())
+        .mode(0o775)
+        .build();
+    fs.mkdir_with_opts("/parent/child", child_opts)?;
+
+    let child = fs.file_status("/parent/child")?;
+    assert_eq!("parent-group", child.group);
+    assert_eq!(0o2000, child.mode & 0o2000);
+    assert_eq!(0o775, child.mode & 0o777);
 
     Ok(())
 }


### PR DESCRIPTION
**Summary**

Fix FUSE directory creation inside setgid directories so new child directories inherit the parent directory group and `S_ISGID` bit.

Before this fix, Curvine used the requested mkdir group and mode directly when creating a directory. If the parent directory had `S_ISGID` set and a different group, the new child directory did not inherit the parent group and did not keep `S_ISGID`.

**Minimal Reproducer**

```c
#define _GNU_SOURCE
#include <errno.h>
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <sys/stat.h>
#include <sys/types.h>
#include <unistd.h>

static void die(const char *msg) {
    fprintf(stderr, "FAIL: %s: errno=%d (%s)\n", msg, errno, strerror(errno));
    exit(1);
}

int main(int argc, char **argv) {
    char parent[4096];
    char child[4096];
    struct stat pst, cst;

    if (argc != 2) {
        fprintf(stderr, "usage: %s <mount-dir>\n", argv[0]);
        return 2;
    }

    snprintf(parent, sizeof(parent), "%s/repro_mkdir_setgid_parent", argv[1]);
    snprintf(child, sizeof(child), "%s/repro_mkdir_setgid_parent/child", argv[1]);

    rmdir(child);
    rmdir(parent);

    if (mkdir(parent, 0777) != 0)
        die("mkdir parent");

    if (chown(parent, (uid_t)-1, getegid()) != 0)
        die("chown parent group");

    if (chmod(parent, 02777) != 0)
        die("chmod parent setgid");

    if (stat(parent, &pst) != 0)
        die("stat parent");

    if (!(pst.st_mode & S_ISGID)) {
        fprintf(stderr, "FAIL: parent does not have S_ISGID, mode=%04o\n",
                pst.st_mode & 07777);
        return 1;
    }

    if (mkdir(child, 0777) != 0)
        die("mkdir child");

    if (stat(child, &cst) != 0)
        die("stat child");

    if (cst.st_gid != pst.st_gid) {
        fprintf(stderr,
                "FAIL: child gid mismatch: got=%ld expected_parent_gid=%ld\n",
                (long)cst.st_gid, (long)pst.st_gid);
        return 1;
    }

    if (!(cst.st_mode & S_ISGID)) {
        fprintf(stderr,
                "FAIL: child did not inherit S_ISGID: child_mode=%04o parent_mode=%04o\n",
                cst.st_mode & 07777, pst.st_mode & 07777);
        return 1;
    }

    printf("PASS: child inherited gid=%ld and mode=%04o\n",
           (long)cst.st_gid, cst.st_mode & 07777);

    rmdir(child);
    rmdir(parent);
    return 0;
}
```

Run it on a Curvine FUSE mount:

```bash
gcc -Wall -O2 /tmp/repro_mkdir_setgid_inherit.c -o /tmp/repro_mkdir_setgid_inherit
/tmp/repro_mkdir_setgid_inherit /curvine-fuse
```

Before the fix, Curvine could create the child directory without the inherited `S_ISGID` bit, or with a group that did not match the parent directory group.

**Root Cause**

The directory creation path built `MkdirOpts` from the incoming request and passed those options directly into metadata creation.

That meant:

- the new directory group stayed as the caller/request group
- the new directory mode stayed as the requested mode after umask
- the parent directory mode was not checked for `S_ISGID`
- the POSIX setgid inheritance rule for new directories was skipped

On Linux, when a directory is created inside a parent directory with `S_ISGID` set, the child directory must inherit the parent group and keep `S_ISGID`.

**Changes**

- Before creating a directory inode, inspect the parent directory ACL.
- If the parent directory has `S_ISGID` set, override the new directory group with the parent group.
- Also set `S_ISGID` on the new directory mode.
- Keep the requested owner and low permission bits unchanged.
- Add a regression test for mkdir inside a setgid parent directory.

**Verification**

- Minimal C reproducer passes after the fix.
- `cargo fmt --check` passes.
- `cargo test -p curvine-server --test master_fs_test mkdir_inherits_setgid_parent_group_and_mode -- --nocapture --test-threads=1` passes.
- `cargo check -p curvine-server` passes.
