### PR TITLE
fix(client): honor file block size in block writers

### DIFF
--- a/curvine-client/src/block/block_writer.rs
+++ b/curvine-client/src/block/block_writer.rs
@@ -109,6 +109,7 @@ impl WriterAdapter {
         located_block: &LocatedBlock,
         worker_addr: &WorkerAddress,
         pos: i64,
+        block_size: i64,
     ) -> FsResult<Self> {
         let conf = &fs_context.conf.client;
         // SPDK bypasses kernel — no local path for writes
@@ -122,6 +123,7 @@ impl WriterAdapter {
                 located_block.block.clone(),
                 worker_addr.clone(),
                 pos,
+                block_size,
             )
             .await?;
             Local(writer)
@@ -131,6 +133,7 @@ impl WriterAdapter {
                 located_block.block.clone(),
                 worker_addr.clone(),
                 pos,
+                block_size,
             )
             .await?;
             Remote(writer)
@@ -147,14 +150,20 @@ pub struct BlockWriter {
 }
 
 impl BlockWriter {
-    pub async fn new(fs_context: Arc<FsContext>, locate: LocatedBlock, pos: i64) -> FsResult<Self> {
+    pub async fn new(
+        fs_context: Arc<FsContext>,
+        locate: LocatedBlock,
+        pos: i64,
+        block_size: i64,
+    ) -> FsResult<Self> {
         if locate.locs.is_empty() {
             return err_box!("There is no available worker");
         }
 
         let mut inners = Vec::with_capacity(locate.locs.len());
         for addr in &locate.locs {
-            let adapter = WriterAdapter::new(fs_context.clone(), &locate, addr, pos).await?;
+            let adapter =
+                WriterAdapter::new(fs_context.clone(), &locate, addr, pos, block_size).await?;
             inners.push(adapter);
         }
 

--- a/curvine-client/src/block/block_writer_local.rs
+++ b/curvine-client/src/block/block_writer_local.rs
@@ -41,11 +41,10 @@ impl BlockWriterLocal {
         block: ExtendedBlock,
         worker_address: WorkerAddress,
         pos: i64,
+        block_size: i64,
     ) -> FsResult<Self> {
         let req_id = Utils::req_id();
         let seq_id = 0;
-
-        let block_size = fs_context.block_size();
         let client = fs_context.acquire_write(&worker_address).await?;
         let write_context = client
             .write_block(

--- a/curvine-client/src/block/block_writer_remote.rs
+++ b/curvine-client/src/block/block_writer_remote.rs
@@ -38,10 +38,10 @@ impl BlockWriterRemote {
         block: ExtendedBlock,
         worker_address: WorkerAddress,
         pos: i64,
+        block_size: i64,
     ) -> FsResult<Self> {
         let req_id = Utils::req_id();
         let seq_id = 0;
-        let block_size = fs_context.block_size();
 
         let client = fs_context.acquire_write(&worker_address).await?;
         let write_context = client

--- a/curvine-client/src/file/fs_writer_base.rs
+++ b/curvine-client/src/file/fs_writer_base.rs
@@ -219,7 +219,13 @@ impl FsWriterBase {
                                 } else {
                                     lb
                                 };
-                                BlockWriter::new(self.fs_context.clone(), lb, off).await?
+                                BlockWriter::new(
+                                    self.fs_context.clone(),
+                                    lb,
+                                    off,
+                                    self.file_blocks.status.block_size,
+                                )
+                                .await?
                             }
                         };
 
@@ -242,8 +248,13 @@ impl FsWriterBase {
                             )
                             .await?;
                         self.file_blocks.add_block(lb.clone())?;
-                        let writer =
-                            BlockWriter::new(self.fs_context.clone(), lb.clone(), 0).await?;
+                        let writer = BlockWriter::new(
+                            self.fs_context.clone(),
+                            lb.clone(),
+                            0,
+                            self.file_blocks.status.block_size,
+                        )
+                        .await?;
 
                         self.cur_writer.replace(writer);
                     }
@@ -331,6 +342,7 @@ impl FsWriterBase {
         // Step 2: Execute resize operation
         let file_blocks = self.fs_client.resize(&self.path, opts).await?;
         let mut file_blocks = WriteFileBlocks::new(file_blocks);
+        let block_size = file_blocks.status.block_size;
         if file_blocks.len() != len {
             return err_box!(
                 "Cannot resize file: {}, expect len {}, actual len {}",
@@ -344,7 +356,8 @@ impl FsWriterBase {
         // At most one such block exists.
         for lb in &mut file_blocks.block_locs {
             if lb.should_resize() {
-                let mut writer = BlockWriter::new(self.fs_context.clone(), lb.clone(), 0).await?;
+                let mut writer =
+                    BlockWriter::new(self.fs_context.clone(), lb.clone(), 0, block_size).await?;
                 let commit_block = writer.complete().await?;
                 self.file_blocks.add_commit(commit_block)?;
             }

--- a/curvine-server/src/worker/replication/worker_replication_manager.rs
+++ b/curvine-server/src/worker/replication/worker_replication_manager.rs
@@ -139,6 +139,7 @@ impl WorkerReplicationManager {
             extend_block,
             job.target_worker_addr.clone(),
             0,
+            self.fs_client_context.block_size(),
         )
         .await?;
         let mut reader = self.block_store.open_reader(&block_meta, 0)?;

--- a/curvine-tests/tests/fs_test.rs
+++ b/curvine-tests/tests/fs_test.rs
@@ -43,6 +43,16 @@ fn test_filesystem_end_to_end_operations_on_cluster() -> FsResult<()> {
     conf.client.write_chunk_size_str = "64B".to_string(); // Update string field
     conf.client.metric_report_enable = true;
 
+    // A file's block size may be overridden independently of the client default.
+    // Verify both remote and short-circuit writers use the file metadata value.
+    let mut override_conf = conf.clone();
+    override_conf.client.block_size = 64;
+    override_conf.client.block_size_str = "64B".to_string();
+    override_conf.client.short_circuit = false;
+    test_file_block_size_override(&testing, &rt, override_conf.clone())?;
+    override_conf.client.short_circuit = true;
+    test_file_block_size_override(&testing, &rt, override_conf)?;
+
     // Test short_circuit = false
     conf.client.short_circuit = false;
     run_filesystem_end_to_end_operations_on_cluster(&testing, &rt, conf.clone())?;
@@ -52,6 +62,44 @@ fn test_filesystem_end_to_end_operations_on_cluster() -> FsResult<()> {
     run_filesystem_end_to_end_operations_on_cluster(&testing, &rt, conf.clone())?;
 
     Ok(())
+}
+
+fn test_file_block_size_override(
+    testing: &Testing,
+    rt: &Arc<AsyncRuntime>,
+    conf: ClusterConf,
+) -> FsResult<()> {
+    let short_circuit = conf.client.short_circuit;
+    let opts = CreateFileOptsBuilder::with_conf(&conf.client)
+        .create_parent(true)
+        .block_size(128)
+        .build();
+    let fs = testing.get_fs(Some(rt.clone()), Some(conf))?;
+
+    rt.block_on(async move {
+        let path = Path::from_str(format!(
+            "/fs_test/block_size_override_{}.log",
+            short_circuit
+        ))?;
+        let data = vec![0x5a; 192];
+
+        let mut writer = fs.create_with_opts(&path, opts, true).await?;
+        writer.write(&data).await?;
+        writer.complete().await?;
+
+        let status = fs.get_status(&path).await?;
+        assert_eq!(status.block_size, 128);
+        assert_eq!(status.len, data.len() as i64);
+
+        let mut reader = fs.open(&path).await?;
+        let mut actual = BytesMut::zeroed(data.len());
+        let read = reader.read_full(&mut actual).await?;
+        reader.complete().await?;
+
+        assert_eq!(read, data.len());
+        assert_eq!(actual.as_ref(), data.as_slice());
+        Ok(())
+    })
 }
 
 fn run_filesystem_end_to_end_operations_on_cluster(


### PR DESCRIPTION
# Summary

Fix block writes for files whose metadata block size differs from the worker client's default block size.

The change propagates `FileStatus.block_size` through the normal file writer stack so block lookup, remaining-capacity calculations, seek offsets, and worker write requests all use the same per-file value.

# Issue Describe / Design

Related to: None

## Root cause

Load jobs and mount configurations can override the client default block size when creating a file. The resulting per-file block size is stored in `FileStatus.block_size`, and `WriteFileBlocks` uses it to map file offsets to blocks.

However, `BlockWriterLocal` and `BlockWriterRemote` independently read `FsContext::block_size()`, which returns the worker client's global default. When these values differed, the file layer could still consider an offset part of the current metadata block while the block writer considered its smaller block full. Reusing the cached writer then generated a seek at exactly the writer block boundary, which the worker rejected with `Invalid seek offset`.

## Reproduction steps

1. Configure the worker client block size as 64 MiB.
2. Create or load a file with a larger per-file block size, such as 128 MiB, through a job or mount override.
3. Write sequentially past 64 MiB.
4. Observe a write RPC carrying `offset = 67108864` for a worker block length of `67108864`.

## Fix approach

Pass the file metadata block size explicitly from `FsWriterBase` through `BlockWriter` and its local/remote adapters. Replication keeps its existing behavior by passing its configured context block size explicitly.

Add regression coverage for both remote and short-circuit writers with a 64-byte client default, a 128-byte per-file block size, and a 192-byte write that crosses both boundaries.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-client/src/file/fs_writer_base.rs` | Pass `FileStatus.block_size` to block writers for existing, newly allocated, and resized blocks | Correctly honors per-file block size overrides |
| `curvine-client/src/block/block_writer.rs` | Propagate the explicit block size through writer adapters | Keeps all replicas on the same file metadata contract |
| `curvine-client/src/block/block_writer_local.rs` | Stop deriving block capacity from the client default | Fixes short-circuit writes with overridden block sizes |
| `curvine-client/src/block/block_writer_remote.rs` | Stop deriving block capacity from the client default | Prevents invalid boundary seeks in remote writes |
| `curvine-server/src/worker/replication/worker_replication_manager.rs` | Pass the replication context block size explicitly | Preserves existing replication behavior |
| `curvine-tests/tests/fs_test.rs` | Add remote and short-circuit block-size override regression cases | Adds coverage for the reported boundary failure |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `rustfmt --edition 2021 --check <changed Rust files>` | PASS | All files changed by this fix are formatted |
| `git diff --check` | PASS | No whitespace errors |
| `cargo check -p curvine-client -p curvine-server --tests -j 1` | NOT COMPLETED | Windows validation host exhausted memory while compiling RocksDB/Curvine dependencies; no source diagnostic related to this change was emitted |
| Block-size override regression test | ADDED | Covers remote and short-circuit paths; execution requires a successful full test build |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None