### PR TITLE
feat(fuse): validate read/write offset+size and refresh reader snapshot after reopen (#1123)

### DIFF
--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -791,7 +791,7 @@ impl fs::FileSystem for CurvineFileSystem {
             // keep_cache may return true even after a remote modification, causing stale
             // reads.  This is intentional — metadata caching trades strict consistency
             // for performance, and callers that enable it accept this trade-off.
-            let keep_cache = self.state.keep_cache(ino, handle.status());
+            let keep_cache = self.state.keep_cache(ino, &handle.status());
             if keep_cache {
                 open_flags |= FUSE_FOPEN_KEEP_CACHE;
             } else if self.conf.open_direct_on_stale {
@@ -825,7 +825,7 @@ impl fs::FileSystem for CurvineFileSystem {
 
         let opts = FuseUtils::create_opts(&op, &self.fs);
         let handle = self.state.fs_create(ino, name, op.arg.flags, opts).await?;
-        let attr = FuseUtils::status_to_attr(&self.conf, handle.status())?;
+        let attr = FuseUtils::status_to_attr(&self.conf, &handle.status())?;
 
         if attr.ino != handle.ino() {
             return err_fuse!(

--- a/curvine-fuse/src/fs/state/backend_handle.rs
+++ b/curvine-fuse/src/fs/state/backend_handle.rs
@@ -17,7 +17,7 @@ use crate::fs::state::NodeState;
 use crate::fs::{FuseReader, FuseWriter};
 use crate::raw::fuse_abi::fuse_write_out;
 use crate::session::FuseResponse;
-use crate::{err_fuse, FuseError, FuseResult};
+use crate::{err_fuse, FuseError, FuseResult, FuseUtils};
 use curvine_common::fs::{Path, StateReader, StateWriter};
 use curvine_common::state::{CreateFileOptsBuilder, FileStatus, LockFlags, OpenFlags};
 use orpc::err_box;
@@ -64,12 +64,52 @@ impl BackendHandle {
         }
     }
 
+    /// Defensive upper bound for a single read/write request size. FUSE `size`
+    /// is a `u32` from the kernel and is normally already capped by the
+    /// `max_write`/`max_readahead` negotiated at init, but userspace still
+    /// validates it so an abnormal request cannot drive an oversized backend IO.
+    /// Same source as the `max_write` computed in `init`.
+    fn max_io_size() -> u64 {
+        FuseUtils::get_fuse_buf_size() as u64
+    }
+
+    /// Validate that a FUSE request offset (`u64`) fits in the signed `i64` the
+    /// backend uses; an offset `> i64::MAX` would wrap to a negative position
+    /// when cast `as i64`. Returns `EINVAL` instead of letting it reach the
+    /// backend.
+    fn check_offset(offset: u64) -> FuseResult<()> {
+        if offset > i64::MAX as u64 {
+            return err_fuse!(libc::EINVAL, "offset {} exceeds i64::MAX", offset);
+        }
+        Ok(())
+    }
+
+    /// Validate that a write length fits in the `u32` reported back to the kernel
+    /// (`fuse_write_out.size`); a larger length would truncate and silently
+    /// under-report the written byte count, so reject it with `EFBIG`.
+    fn check_write_len(len: usize) -> FuseResult<()> {
+        if len as u64 > u32::MAX as u64 {
+            return err_fuse!(libc::EFBIG, "write len {} exceeds u32::MAX", len);
+        }
+        Ok(())
+    }
+
     pub async fn read(
         &self,
         state: &NodeState,
         op: Read<'_>,
         reply: FuseResponse,
     ) -> FuseResult<()> {
+        Self::check_offset(op.arg.offset)?;
+        if op.arg.size as u64 > Self::max_io_size() {
+            return err_fuse!(
+                libc::EINVAL,
+                "read size {} exceeds max {}",
+                op.arg.size,
+                Self::max_io_size()
+            );
+        }
+
         let reader = match &self.reader {
             Some(v) => v,
             None => return err_fuse!(libc::EIO),
@@ -102,6 +142,11 @@ impl BackendHandle {
             reply.send_rep(res).await?;
             return Ok(());
         }
+
+        Self::check_offset(op.arg.offset)?;
+        // The write reply reports the written length as `u32` (`fuse_write_out.size`);
+        // reject anything that would truncate instead of silently under-reporting.
+        Self::check_write_len(op.data.len())?;
 
         if let Some(writer) = &self.writer {
             writer
@@ -216,9 +261,55 @@ impl BackendHandle {
             reader,
             writer,
             status,
+
             fh_locks: std::sync::Mutex::new(locks),
             read_ver: AtomicCounter::new(0),
         };
         Ok(handle)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BackendHandle;
+
+    // An offset within i64 range passes; an offset > i64::MAX (which would wrap
+    // negative when cast `as i64`) is rejected with EINVAL before it can reach
+    // the backend.
+    #[test]
+    fn offset_over_i64_max_returns_einval() {
+        assert!(BackendHandle::check_offset(0).is_ok());
+        assert!(BackendHandle::check_offset(i64::MAX as u64).is_ok());
+
+        let err = BackendHandle::check_offset(i64::MAX as u64 + 1)
+            .expect_err("offset > i64::MAX must be rejected");
+        assert_eq!(err.errno(), libc::EINVAL);
+
+        let err =
+            BackendHandle::check_offset(u64::MAX).expect_err("u64::MAX offset must be rejected");
+        assert_eq!(err.errno(), libc::EINVAL);
+    }
+
+    // The defensive read/write size bound is the FUSE buffer size, matching the
+    // `max_write` computed in `init`.
+    #[test]
+    fn max_io_size_matches_fuse_buf_size() {
+        assert_eq!(
+            BackendHandle::max_io_size(),
+            crate::FuseUtils::get_fuse_buf_size() as u64
+        );
+    }
+
+    // A write length that fits in the `u32` reply size passes; one that would
+    // truncate (`> u32::MAX`) is rejected with EFBIG.
+    #[test]
+    fn write_len_over_u32_returns_efbig() {
+        assert!(BackendHandle::check_write_len(0).is_ok());
+        assert!(BackendHandle::check_write_len(u32::MAX as usize).is_ok());
+
+        // usize is 64-bit on the supported targets, so u32::MAX + 1 is representable.
+        let err = BackendHandle::check_write_len(u32::MAX as usize + 1)
+            .expect_err("write len > u32::MAX must be rejected");
+        assert_eq!(err.errno(), libc::EFBIG);
     }
 }

--- a/curvine-fuse/src/fs/state/backend_handle.rs
+++ b/curvine-fuse/src/fs/state/backend_handle.rs
@@ -38,7 +38,9 @@ pub struct BackendHandle {
 
     pub reader: Option<RawPtr<FuseReader>>,
     pub writer: Option<Arc<FuseWriter>>, // Writer uses Arc for global sharing
-    pub status: FileStatus,
+    /// Open-time file status snapshot. Guarded by a lock because the read path
+    /// refreshes it in place after a dirty-read reopen (`read()` takes `&self`).
+    status: std::sync::RwLock<FileStatus>,
 
     fh_locks: std::sync::Mutex<HandleLock>,
 
@@ -58,7 +60,7 @@ impl BackendHandle {
             fh,
             reader,
             writer,
-            status,
+            status: std::sync::RwLock::new(status),
             fh_locks: std::sync::Mutex::new(HandleLock::default()),
             read_ver: AtomicCounter::new(0),
         }
@@ -122,6 +124,11 @@ impl BackendHandle {
 
                 let path = reader.path().clone();
                 let new_reader = state.new_reader(&path).await?;
+                // Refresh the handle's status snapshot from the freshly reopened
+                // reader before installing it, so `status()` reflects the current
+                // file (length/mtime) after a dirty-read reopen rather than the
+                // stale open-time snapshot.
+                self.refresh_status(new_reader.status().clone());
                 reader.replace(new_reader);
 
                 self.read_ver.set(writer_ver);
@@ -175,8 +182,18 @@ impl BackendHandle {
         Ok(())
     }
 
-    pub fn status(&self) -> &FileStatus {
-        &self.status
+    /// A clone of the current file status. Returns an owned value (not a
+    /// reference) because the status is lock-guarded: the read path can refresh
+    /// it in place after a dirty-read reopen.
+    pub fn status(&self) -> FileStatus {
+        self.status.read().unwrap().clone()
+    }
+
+    /// Replace the open-time status snapshot with a fresh one. Called from the
+    /// read path after a dirty-read reopen so `status()` no longer reports the
+    /// stale open-time length/mtime.
+    fn refresh_status(&self, status: FileStatus) {
+        *self.status.write().unwrap() = status;
     }
 
     // Add lock, only save the owner_id of the first lock
@@ -210,7 +227,7 @@ impl BackendHandle {
 
         writer.write_len(self.ino)?;
         writer.write_len(self.fh)?;
-        writer.write_struct(&self.status)?;
+        writer.write_struct(&*self.status.read().unwrap())?;
 
         writer.write_struct(&self.writer.is_some())?;
         writer.write_struct(&self.reader.is_some())?;
@@ -260,7 +277,7 @@ impl BackendHandle {
             fh,
             reader,
             writer,
-            status,
+            status: std::sync::RwLock::new(status),
 
             fh_locks: std::sync::Mutex::new(locks),
             read_ver: AtomicCounter::new(0),
@@ -311,5 +328,35 @@ mod tests {
         let err = BackendHandle::check_write_len(u32::MAX as usize + 1)
             .expect_err("write len > u32::MAX must be rejected");
         assert_eq!(err.errno(), libc::EFBIG);
+    }
+
+    // After a dirty-read reopen the read path calls `refresh_status` (through a
+    // shared `&self`); `status()` must then reflect the reopened file's
+    // length/mtime, not the stale open-time snapshot.
+    #[test]
+    fn refresh_status_updates_snapshot_through_shared_ref() {
+        use curvine_common::state::FileStatus;
+
+        let mut open_status = FileStatus::with_name(1, "f".to_string(), false);
+        open_status.len = 100;
+        open_status.mtime = 10;
+        let handle = BackendHandle::new(1, 10, None, None, open_status);
+        assert_eq!(handle.status().len, 100);
+        assert_eq!(handle.status().mtime, 10);
+
+        // Simulate the post-reopen refresh: a writer extended the file to 4096.
+        let mut new_status = FileStatus::with_name(1, "f".to_string(), false);
+        new_status.len = 4096;
+        new_status.mtime = 20;
+        // `handle` is an immutable binding — refresh_status takes `&self` and
+        // mutates through the lock, exactly as the read path does.
+        handle.refresh_status(new_status);
+
+        assert_eq!(
+            handle.status().len,
+            4096,
+            "status().len must reflect the reopened file, not the open-time 100"
+        );
+        assert_eq!(handle.status().mtime, 20);
     }
 }

--- a/curvine-fuse/src/fs/state/file_handle.rs
+++ b/curvine-fuse/src/fs/state/file_handle.rs
@@ -53,9 +53,9 @@ impl FileHandle {
         }
     }
 
-    pub fn status(&self) -> &FileStatus {
+    pub fn status(&self) -> FileStatus {
         match self {
-            FileHandle::Backend(h) => &h.status,
+            FileHandle::Backend(h) => h.status(),
         }
     }
 

--- a/curvine-fuse/src/fs/state/node_state.rs
+++ b/curvine-fuse/src/fs/state/node_state.rs
@@ -937,7 +937,7 @@ impl NodeState {
         } else {
             self.new_handle(None, &path, flags, opts).await?
         };
-        self.lookup_status(ino, name, handle.status())?;
+        self.lookup_status(ino, name, &handle.status())?;
         Ok(handle)
     }
 


### PR DESCRIPTION
# Summary

Two grouped robustness fixes on the curvine-fuse read/write data path (issue #1123): defensive validation of request offset/size at the handle boundary, and refreshing the handle's status snapshot after a dirty-read reopen.

# Issue Describe / Design

Closes #1123

Feature / P1-P2 robustness hardening. Two independent changes, one commit each.

(a) Offset/size validation — FUSE offset is u64 but the backend uses i64; an offset > i64::MAX wrapped to a negative position when cast `as i64` and flowed unchecked into the backend. The write reply reports the written length as u32 (`fuse_write_out.size`), silently truncating an abnormal > u32::MAX write. Fixed by validating at the BackendHandle read/write boundary before the cast (offset <= i64::MAX -> EINVAL; read size <= FUSE buffer size -> EINVAL; write len <= u32::MAX -> EFBIG).

(b) Reader snapshot refresh — `BackendHandle.status` was an open-time snapshot never updated after the read path flushes and reopens the reader on a detected writer-version change. Made it interior-mutable (RwLock) and refresh it from the reopened reader's status.

Design note (honest scope): user-visible stat length already bypasses this snapshot — `get_attr` goes through `fs_stat` + live `writer.len()`. So (b)'s practical impact is narrower than the issue text implies; the stale snapshot was mainly observable via the debug handle listing and the persisted snapshot. The refresh keeps the field internally consistent regardless.

# Changes

| Module / File | Change | Impact on existing behavior |
| --- | --- | --- |
| `curvine-fuse/src/fs/state/backend_handle.rs` | Add offset/size validation helpers + checks in read/write; make `status` RwLock-guarded, refresh after reopen | Oversized/negative offset & over-u32 write now rejected (EINVAL/EFBIG) instead of reaching backend; status() returns owned clone |
| `curvine-fuse/src/fs/state/file_handle.rs` | `status()` returns owned `FileStatus` | Signature change (internal) |
| `curvine-fuse/src/fs/state/node_state.rs` | Adapt caller to `&handle.status()` | None |
| `curvine-fuse/src/fs/curvine_file_system.rs` | Adapt two callers to `&handle.status()` | None |

# Test verified

| Test case | Result | Notes |
| --- | --- | --- |
| `cargo test -p curvine-fuse backend_handle` | PASS | 4 tests: offset_over_i64_max_returns_einval, write_len_over_u32_returns_efbig, max_io_size_matches_fuse_buf_size, refresh_status_updates_snapshot_through_shared_ref |
| `cargo clippy -p curvine-fuse --all-targets` | PASS | clean |
| `make format` | PASS | |

Note: 3 pre-existing `dcache::dir_tree` test failures exist on upstream/main independent of this PR (verified by stashing these changes).

# Dependencies

- Related PRs: None
- Related issues: #1123
- Blocks / blocked by: None