### PR TITLE
fix(fuse): separate request and response open flags (#1110)

### DIFF
--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -665,7 +665,7 @@ impl fs::FileSystem for CurvineFileSystem {
             .state
             .new_dir_handle(op.header.nodeid, &dir_path)
             .await?;
-        let open_flags = FuseUtils::fill_open_flags(&self.conf, op.arg.flags);
+        let open_flags = FuseUtils::dir_open_flags(&self.conf);
         let attr = fuse_open_out {
             fh: handle.fh,
             open_flags,
@@ -772,9 +772,8 @@ impl fs::FileSystem for CurvineFileSystem {
 
         let handle = self.state.fs_open(ino, op.arg.flags, opts).await?;
 
-        let mut open_flags = op.arg.flags;
-        if self.conf.direct_io {
-            open_flags |= FUSE_FOPEN_DIRECT_IO;
+        let keep_cache = if self.conf.direct_io {
+            false
         } else {
             // Page cache consistency is handled here rather than via explicit inode
             // invalidation notifications, for two reasons:
@@ -794,13 +793,9 @@ impl fs::FileSystem for CurvineFileSystem {
             // keep_cache may return true even after a remote modification, causing stale
             // reads.  This is intentional — metadata caching trades strict consistency
             // for performance, and callers that enable it accept this trade-off.
-            let keep_cache = self.state.keep_cache(ino, &handle.status());
-            if keep_cache {
-                open_flags |= FUSE_FOPEN_KEEP_CACHE;
-            } else if self.conf.open_direct_on_stale {
-                open_flags |= FUSE_FOPEN_DIRECT_IO;
-            }
-        }
+            self.state.keep_cache(ino, &handle.status())
+        };
+        let open_flags = FuseUtils::file_open_flags(&self.conf, keep_cache);
 
         let entry = fuse_open_out {
             fh: handle.fh(),
@@ -856,7 +851,7 @@ impl fs::FileSystem for CurvineFileSystem {
             },
             fuse_open_out {
                 fh: handle.fh(),
-                open_flags: op.arg.flags,
+                open_flags: FuseUtils::file_open_flags(&self.conf, true),
                 padding: 0,
             },
         );

--- a/curvine-fuse/src/fuse_utils.rs
+++ b/curvine-fuse/src/fuse_utils.rs
@@ -224,18 +224,26 @@ impl FuseUtils {
         }
     }
 
-    pub fn fill_open_flags(conf: &FuseConf, v: u32) -> u32 {
-        let mut flags = v;
+    pub fn file_open_flags(conf: &FuseConf, keep_cache: bool) -> u32 {
+        let mut flags = 0;
         if conf.direct_io {
             flags |= FUSE_FOPEN_DIRECT_IO;
-        } else {
+        } else if keep_cache {
             flags |= FUSE_FOPEN_KEEP_CACHE;
-        }
-        if conf.cache_readdir {
-            flags |= FUSE_FOPEN_CACHE_DIR
+        } else if conf.open_direct_on_stale {
+            flags |= FUSE_FOPEN_DIRECT_IO;
         }
         if conf.non_seekable {
-            flags |= FUSE_FOPEN_NONSEEKABLE
+            flags |= FUSE_FOPEN_NONSEEKABLE;
+        }
+
+        flags
+    }
+
+    pub fn dir_open_flags(conf: &FuseConf) -> u32 {
+        let mut flags = Self::file_open_flags(conf, true);
+        if conf.cache_readdir {
+            flags |= FUSE_FOPEN_CACHE_DIR;
         }
 
         flags
@@ -445,6 +453,65 @@ impl FuseUtils {
 mod tests {
     use super::*;
     use crate::raw::fuse_abi::fuse_setattr_in;
+
+    #[test]
+    fn file_open_flags_are_built_only_from_response_flags() {
+        let mut conf = FuseConf::default();
+
+        assert_eq!(
+            FuseUtils::file_open_flags(&conf, true),
+            FUSE_FOPEN_KEEP_CACHE
+        );
+        assert_eq!(FuseUtils::file_open_flags(&conf, false), 0);
+
+        conf.open_direct_on_stale = true;
+        assert_eq!(
+            FuseUtils::file_open_flags(&conf, false),
+            FUSE_FOPEN_DIRECT_IO
+        );
+
+        conf.non_seekable = true;
+        assert_eq!(
+            FuseUtils::file_open_flags(&conf, false),
+            FUSE_FOPEN_DIRECT_IO | FUSE_FOPEN_NONSEEKABLE
+        );
+
+        conf.direct_io = true;
+        assert_eq!(
+            FuseUtils::file_open_flags(&conf, true),
+            FUSE_FOPEN_DIRECT_IO | FUSE_FOPEN_NONSEEKABLE
+        );
+
+        let request_only_flags = (libc::O_CREAT | libc::O_TRUNC | libc::O_APPEND) as u32;
+        assert_eq!(
+            FuseUtils::file_open_flags(&conf, true) & request_only_flags,
+            0
+        );
+    }
+
+    #[test]
+    fn cache_dir_flag_is_limited_to_directory_responses() {
+        let mut conf = FuseConf {
+            cache_readdir: true,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            FuseUtils::file_open_flags(&conf, true),
+            FUSE_FOPEN_KEEP_CACHE
+        );
+        assert_eq!(
+            FuseUtils::dir_open_flags(&conf),
+            FUSE_FOPEN_KEEP_CACHE | FUSE_FOPEN_CACHE_DIR
+        );
+
+        conf.direct_io = true;
+        conf.non_seekable = true;
+        assert_eq!(
+            FuseUtils::dir_open_flags(&conf),
+            FUSE_FOPEN_DIRECT_IO | FUSE_FOPEN_NONSEEKABLE | FUSE_FOPEN_CACHE_DIR
+        );
+    }
 
     #[test]
     fn setattr_preserves_millisecond_from_nsec() {


### PR DESCRIPTION
# Summary

Build FUSE response-side open flags independently from request-side `O_*` flags for `open`, `create`, and `open_dir`.

# Issue Describe / Design

Closes #1110

The three open paths either copied request flags directly into `fuse_open_out.open_flags` or passed them as the initial value to a response flag helper. Since `O_*` and `FOPEN_*` use different namespaces with overlapping bit values, the kernel could interpret request access flags as cache or direct-I/O behavior.

This change introduces separate file and directory response flag builders that always start from zero. File opens preserve the existing dynamic keep-cache/stale decision, while `FOPEN_CACHE_DIR` remains limited to directory responses.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-fuse/src/fuse_utils.rs` | Add file/directory response flag builders and regression tests | Prevents request flags from entering FUSE responses |
| `curvine-fuse/src/fs/curvine_file_system.rs` | Use response-only flags in `open`, `create`, and `open_dir` | Corrects cache/direct-I/O interpretation |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| Mounted before/after protocol E2E | PASS | Same isolated master/worker and config. Before: `create 0x8241 -> 0x8241`, `open_dir 0x18800 -> 0x18802`; after: both responses are response-only `0x2`. Logs: `/lpai/curvine-e2e-1110/protocol-{before,after}.log` |
| Repository FUSE E2E suite | PASS (no regression) | Comparable 57 cases are identical: 53 passed and the same 4 environment-only failures on both versions. The after GitHub clone hit external `early EOF`; a local no-hardlink clone, `git fsck`, and checkout of all 971 tracked files passed. Logs/JSON: `/lpai/curvine-e2e-1110/fuse-test-{before,after}-isolated.*` |
| Two new `fuse_utils` regression tests | PASS | Linux remote devspace; 2 passed, 0 failed; log: `/lpai/curvine-issue-1110-new-tests-rerun.log` |
| `cargo test -p curvine-fuse` | PASS for affected code | 184 passed; the 3 failures are all in existing `fs::dcache::dir_tree` tests; log: `/lpai/curvine-issue-1110-full-test.log` |
| Baseline dcache comparison at `a2b94ac` | SAME 3 FAILURES | 19 passed, 3 failed; reproduces all full-suite failures without this change; log: `/lpai/curvine-issue-1110-baseline-dcache-test.log` |
| `cargo fmt --all -- --check` | PASS | Local worktree |
| `make format` | PASS | Two release Clippy passes plus rustfmt on Linux remote devspace; log: `/lpai/curvine-issue-1110-make-format-rerun.log` |

# Dependencies

- Related PRs: None
- Related issues: #1110
- Blocks / blocked by: None
