### PR TITLE
fix(fuse): refresh writer mtime in getattr

### DIFF
--- a/curvine-fuse/src/fs/fuse_writer.rs
+++ b/curvine-fuse/src/fs/fuse_writer.rs
@@ -23,6 +23,7 @@ use curvine_common::fs::{Path, Writer};
 use curvine_common::state::{FileAllocOpts, FileStatus};
 use curvine_common::FsResult;
 use log::error;
+use orpc::common::LocalTime;
 use orpc::runtime::{RpcRuntime, Runtime};
 use orpc::sync::channel::{AsyncChannel, AsyncReceiver, AsyncSender, CallChannel, CallSender};
 use orpc::sync::{AtomicCounter, AtomicLong, ErrorMonitor};
@@ -55,6 +56,7 @@ pub struct FuseWriter {
     status: FileStatus,
     is_ufs: bool,
     len: Arc<AtomicLong>,
+    mtime: Arc<AtomicLong>,
     write_ver: AtomicCounter,
     /// Phase 2b kill-switch flag: decides whether `send_queued_task` creates a
     /// `stream_write_queue_depth` guard. (The `path_type` label is captured as a
@@ -82,6 +84,7 @@ impl FuseWriter {
         let status = writer.status().clone();
         let monitor = err_monitor.clone();
         let len = Arc::new(AtomicLong::new(status.len));
+        let mtime = Arc::new(AtomicLong::new(status.mtime));
         let write_ver = AtomicCounter::new(0);
         // Phase 2b: backend kind + metrics gate, captured at open and moved into
         // the writer task for the per-IO observe (same as FuseReader).
@@ -89,8 +92,11 @@ impl FuseWriter {
         let metrics_enabled = conf.metrics_enabled;
 
         let len1 = len.clone();
+        let mtime1 = mtime.clone();
         rt.spawn(async move {
-            let res = Self::writer_future(writer, receiver, len1, path_type, metrics_enabled).await;
+            let res =
+                Self::writer_future(writer, receiver, len1, mtime1, path_type, metrics_enabled)
+                    .await;
             match res {
                 Ok(_) => (),
 
@@ -108,6 +114,7 @@ impl FuseWriter {
             status,
             is_ufs,
             len,
+            mtime,
             write_ver,
             metrics_enabled,
         }
@@ -217,6 +224,10 @@ impl FuseWriter {
         self.len.get()
     }
 
+    pub fn mtime(&self) -> i64 {
+        self.mtime.get()
+    }
+
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
@@ -225,6 +236,7 @@ impl FuseWriter {
         mut writer: UnifiedWriter,
         mut req_receiver: AsyncReceiver<QueuedWriteTask>,
         file_len: Arc<AtomicLong>,
+        file_mtime: Arc<AtomicLong>,
         path_type: &'static str,
         metrics_enabled: bool,
     ) -> FsResult<()> {
@@ -272,7 +284,8 @@ impl FuseWriter {
 
                     if res.is_ok() {
                         let cur_len = file_len.get();
-                        file_len.set(cur_len.max(off + len as i64))
+                        file_len.set(cur_len.max(off + len as i64));
+                        file_mtime.set(LocalTime::mills() as i64);
                     }
 
                     if let Some(reply) = reply {

--- a/curvine-fuse/src/fs/state/node_state.rs
+++ b/curvine-fuse/src/fs/state/node_state.rs
@@ -876,11 +876,26 @@ impl NodeState {
         if let Some(len) = self.get_writer_len(attr.ino).await {
             attr.size = attr.size.max(len)
         }
+
+        if let Some(mtime) = self.get_writer_mtime(attr.ino).await {
+            attr.mtime = (mtime.max(0) / 1000) as u64;
+            attr.mtimensec = ((mtime.max(0) % 1000) * 1_000_000) as u32;
+            attr.ctime = attr.mtime;
+            attr.ctimensec = attr.mtimensec;
+        }
     }
 
     pub async fn get_writer_len(&self, ino: u64) -> Option<u64> {
         if let Some(writer) = self.find_writer(ino).await {
             return Some(writer.len() as u64);
+        }
+
+        None
+    }
+
+    pub async fn get_writer_mtime(&self, ino: u64) -> Option<i64> {
+        if let Some(writer) = self.find_writer(ino).await {
+            return Some(writer.mtime());
         }
 
         None


### PR DESCRIPTION
**Summary**

Fix FUSE `fstat()` mtime visibility after `copy_file_range()` overwrites data through an open writable handle.

When a target file was already open for writing, had existing contents, and was overwritten through the raw `copy_file_range` syscall without changing file length, Curvine could keep reporting the old modification time through `fstat(fd)`. The data copy succeeded, but the active writer state only exposed updated length to getattr/fstat, so overwrites that did not extend the file were invisible to mtime-based checks.

**Minimal Reproducer**

```c
#define _GNU_SOURCE
#include <errno.h>
#include <fcntl.h>
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <sys/stat.h>
#include <sys/syscall.h>
#include <unistd.h>

static void die(const char *msg) {
    fprintf(stderr, "FAIL: %s: errno=%d (%s)\n", msg, errno, strerror(errno));
    exit(1);
}

static long get_mtime_sec_fd(int fd) {
    struct stat st;

    if (fstat(fd, &st) != 0)
        die("fstat");

    return st.st_mtime;
}

static void expect_full_copy(const char *label, ssize_t copied, size_t expected) {
    if (copied < 0)
        die(label);

    if (copied != (ssize_t)expected) {
        fprintf(stderr, "FAIL: %s copied=%zd expected=%zu\n",
                label, copied, expected);
        exit(1);
    }
}

int main(int argc, char **argv) {
    char src[4096];
    char dst[4096];
    int fd_src, fd_dst;
    long before, after;
    const char content[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ12345\n";
    ssize_t written;
    loff_t off_in = 0;
    ssize_t copied;

    if (argc != 2) {
        fprintf(stderr, "usage: %s <mount-dir>\n", argv[0]);
        return 2;
    }

    snprintf(src, sizeof(src), "%s/repro_cfr_src", argv[1]);
    snprintf(dst, sizeof(dst), "%s/repro_cfr_dst", argv[1]);

    unlink(src);
    unlink(dst);

    fd_src = open(src, O_RDWR | O_CREAT | O_TRUNC, 0664);
    if (fd_src < 0)
        die("open src");

    fd_dst = open(dst, O_RDWR | O_CREAT | O_TRUNC, 0664);
    if (fd_dst < 0)
        die("open dst");

    written = write(fd_src, content, sizeof(content) - 1);
    if (written != (ssize_t)(sizeof(content) - 1))
        die("write src");

    if (fsync(fd_src) != 0)
        die("fsync src");

    if (close(fd_src) != 0)
        die("close src after write");

    fd_src = open(src, O_RDONLY);
    if (fd_src < 0)
        die("reopen src readonly");

    copied = copy_file_range(fd_src, NULL, fd_dst, NULL, sizeof(content) - 1, 0);
    expect_full_copy("libc copy_file_range warmup", copied, sizeof(content) - 1);

    if (lseek(fd_src, 0, SEEK_SET) < 0)
        die("lseek src after warmup");

    if (lseek(fd_dst, 0, SEEK_SET) < 0)
        die("lseek dst after warmup");

    before = get_mtime_sec_fd(fd_dst);

    sleep(1);

    copied = syscall(__NR_copy_file_range,
                     fd_src, &off_in,
                     fd_dst, NULL,
                     sizeof(content) - 1,
                     0);
    expect_full_copy("raw copy_file_range overwrite", copied, sizeof(content) - 1);

    after = get_mtime_sec_fd(fd_dst);

    if (after == before) {
        fprintf(stderr,
                "FAIL: dst mtime did not change after copy_file_range: before=%ld after=%ld\n",
                before, after);
        return 1;
    }

    printf("PASS: dst mtime updated: before=%ld after=%ld\n", before, after);

    close(fd_src);
    close(fd_dst);
    unlink(src);
    unlink(dst);
    return 0;
}
```

Run it on a Curvine FUSE mount:

```bash
gcc -Wall -O2 /tmp/repro_copy_file_range_mtime.c -o /tmp/repro_copy_file_range_mtime
/tmp/repro_copy_file_range_mtime /curvine-fuse
```

Before the fix, the raw syscall overwrite succeeded but `fstat(fd_dst)` still reported the old mtime:

```text
FAIL: dst mtime did not change after copy_file_range: before=1784182554 after=1784182554
```

**Root Cause**

Curvine already merged active writer length into FUSE getattr/fstat results. That handled writes that extended the file, because the visible file size changed.

However, `copy_file_range()` can overwrite existing bytes without changing the target file length.

That meant:

- the target writer accepted the write
- the active writer length stayed unchanged
- getattr/fstat merged only writer length, not writer mtime
- `fstat(fd)` on the still-open target handle could keep returning the old mtime

Path-based `stat(path)` or later sync paths could observe fresher metadata, which made the issue specific to open-handle `fstat()` visibility after length-preserving writes.

**Changes**

- Track the latest successful write time in `FuseWriter`.
- Update that writer mtime after each successful queued write.
- When building FUSE getattr/fstat attributes, merge active writer mtime in addition to active writer length.
- Preserve existing writer length behavior and avoid adding an extra metadata RPC on every getattr.

**Verification**

- Minimal C reproducer passes after the fix.
- `cargo fmt --check` passes.
- `cargo check -p curvine-fuse` passes.
