### PR TITLE
fix(fuse): preserve writer size across setattr

### DIFF
--- a/build/tests/fuse-test.sh
+++ b/build/tests/fuse-test.sh
@@ -1338,6 +1338,9 @@ test_mmap() {
     run_python_script_test \
         "Testing MAP_SHARED mmap write visible to pread after cache-miss open" \
         "mmap_test.py" --dir "$TEST_DIR"
+    run_python_script_test \
+        "Testing mmap read after write and fchmod does not raise SIGBUS" \
+        "curvine_ltp_mmap_sigbus_repro.py" --dir "$TEST_DIR"
 }
 
 # Test 18: Pwrite visibility test

--- a/build/tests/scripts/curvine_ltp_mmap_sigbus_repro.py
+++ b/build/tests/scripts/curvine_ltp_mmap_sigbus_repro.py
@@ -34,7 +34,6 @@ import ctypes
 import errno
 import multiprocessing
 import os
-import platform
 import shutil
 import signal
 import sys
@@ -109,64 +108,35 @@ def case_dir(root: str, name: str) -> str:
     return path
 
 
-def _syscall_nr_mmap() -> int:
-    table = {
-        "x86_64": 9,
-        "aarch64": 222,
-    }
-    machine = platform.machine()
-    if machine not in table:
-        raise OSError(
-            errno.ENOSYS,
-            f"unsupported architecture for mmap: {machine}",
-        )
-    return table[machine]
-
-
-def _syscall_nr_munmap() -> int:
-    table = {
-        "x86_64": 11,
-        "aarch64": 215,
-    }
-    machine = platform.machine()
-    if machine not in table:
-        raise OSError(
-            errno.ENOSYS,
-            f"unsupported architecture for munmap: {machine}",
-        )
-    return table[machine]
-
-
 def sys_mmap(addr: int, length: int, prot: int, flags: int, fd: int, offset: int) -> int:
-    """mmap(addr, length, prot, flags, fd, offset) via raw syscall."""
+    """Call libc mmap with explicit ABI types so pointers are not truncated."""
     libc = ctypes.CDLL(None, use_errno=True)
-    syscall_fn = libc.syscall
-    syscall_fn.restype = ctypes.c_long
+    mmap_fn = libc.mmap
+    mmap_fn.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_size_t,
+        ctypes.c_int,
+        ctypes.c_int,
+        ctypes.c_int,
+        ctypes.c_long,
+    ]
+    mmap_fn.restype = ctypes.c_void_p
 
-    ret = int(
-        syscall_fn(
-            _syscall_nr_mmap(),
-            addr,
-            length,
-            prot,
-            flags,
-            fd,
-            offset,
-        )
-    )
-    if ret < 0:
+    ret = mmap_fn(addr, length, prot, flags, fd, offset)
+    if ret == ctypes.c_void_p(-1).value:
         err = ctypes.get_errno()
         raise OSError(err, os.strerror(err))
-    return ret
+    return int(ret)
 
 
 def sys_munmap(addr: int, length: int) -> None:
-    """munmap(addr, length) via raw syscall."""
+    """Call libc munmap with explicit ABI types."""
     libc = ctypes.CDLL(None, use_errno=True)
-    syscall_fn = libc.syscall
-    syscall_fn.restype = ctypes.c_long
+    munmap_fn = libc.munmap
+    munmap_fn.argtypes = [ctypes.c_void_p, ctypes.c_size_t]
+    munmap_fn.restype = ctypes.c_int
 
-    ret = int(syscall_fn(_syscall_nr_munmap(), addr, length))
+    ret = munmap_fn(addr, length)
     if ret < 0:
         err = ctypes.get_errno()
         raise OSError(err, os.strerror(err))
@@ -185,24 +155,37 @@ def _create_fill_file(path: str, page_sz: int, file_mode: int) -> None:
         os.close(fd)
 
 
-def _child_read_mapped_file(path: str, page_sz: int, prot: int) -> None:
+def _child_read_mapped_file(
+    path: str,
+    page_sz: int,
+    prot: int,
+    verify_contents: bool,
+) -> None:
     fd = os.open(path, O_RDONLY)
     try:
         addr = sys_mmap(0, page_sz, prot, MAP_SHARED, fd, 0)
         try:
-            mapped = (ctypes.c_char * page_sz).from_address(addr)
-            if bytes(mapped) != b"A" * page_sz:
-                raise OSError(errno.EIO, "mapped memory area contains invalid data")
+            # A PROT_EXEC-only mapping is intentionally not data-readable. mmap03
+            # only verifies that creating the executable mapping succeeds.
+            if verify_contents:
+                mapped = (ctypes.c_char * page_sz).from_address(addr)
+                if bytes(mapped) != b"A" * page_sz:
+                    raise OSError(errno.EIO, "mapped memory area contains invalid data")
         finally:
             sys_munmap(addr, page_sz)
     finally:
         os.close(fd)
 
 
-def _run_mmap_read_child(path: str, page_sz: int, prot: int) -> None:
+def _run_mmap_read_child(
+    path: str,
+    page_sz: int,
+    prot: int,
+    verify_contents: bool = True,
+) -> None:
     proc = multiprocessing.Process(
         target=_child_read_mapped_file,
-        args=(path, page_sz, prot),
+        args=(path, page_sz, prot, verify_contents),
     )
     proc.start()
     proc.join()
@@ -244,10 +227,10 @@ def test_mmap_shared_exec_file_readable(root: str) -> int:
     _create_fill_file(target, page_sz, 0o555)
 
     def run() -> None:
-        _run_mmap_read_child(target, page_sz, PROT_EXEC)
+        _run_mmap_read_child(target, page_sz, PROT_EXEC, verify_contents=False)
 
     return expect_ok(
-        "PROT_EXEC MAP_SHARED mmap of mode-0555 file readable without SIGBUS (mmap03)",
+        "PROT_EXEC MAP_SHARED mmap of mode-0555 file succeeds (mmap03)",
         run,
     )
 

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -640,6 +640,10 @@ impl fs::FileSystem for CurvineFileSystem {
 
         let mut attr = FuseUtils::status_to_attr(&self.conf, &status)?;
         attr.ino = op.header.nodeid;
+        // Metadata-only setattr (for example fchmod after write) may race ahead of
+        // the writer's final metadata commit. Never let its stale size shrink the
+        // kernel inode below the bytes already accepted by the active writer.
+        self.state.update_writer_len(&mut attr).await;
         let attr = fuse_attr_out {
             attr_valid: self.conf.attr_ttl.as_secs(),
             attr_valid_nsec: self.conf.attr_ttl.subsec_nanos(),


### PR DESCRIPTION
**Summary**

Fix FUSE `mmap()` SIGBUS failures after writing a file and changing its mode through an active writable handle.

When a process wrote data and then called `fchmod()` before closing the file, Curvine could return the stale Master-side file length in the FUSE `SETATTR` response. The writer had already accepted the data, but its final metadata commit had not completed yet. The kernel could therefore update the inode size to zero, causing a later page fault on a valid file mapping to deliver SIGBUS.

**Minimal Reproducer**

```c
#define _GNU_SOURCE

#include <fcntl.h>
#include <signal.h>
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <sys/mman.h>
#include <sys/stat.h>
#include <sys/wait.h>
#include <unistd.h>

static void write_all(int fd, const void *buf, size_t len)
{
    const char *p = buf;

    while (len > 0) {
        ssize_t n = write(fd, p, len);

        if (n < 0) {
            perror("write");
            exit(EXIT_FAILURE);
        }

        p += n;
        len -= (size_t)n;
    }
}

int main(int argc, char **argv)
{
    const char *path;
    long page_size;
    char *buffer;
    int fd;
    int prot = PROT_READ;
    mode_t mode = 0444;
    pid_t pid;
    int status;

    if (argc < 2) {
        fprintf(stderr, "Usage: %s FILE [exec]\n", argv[0]);
        return EXIT_FAILURE;
    }

    path = argv[1];

    if (argc >= 3 && strcmp(argv[2], "exec") == 0) {
        prot |= PROT_EXEC;
        mode = 0555;
    }

    page_size = sysconf(_SC_PAGESIZE);
    if (page_size <= 0) {
        perror("sysconf");
        return EXIT_FAILURE;
    }

    buffer = malloc((size_t)page_size);
    if (buffer == NULL) {
        perror("malloc");
        return EXIT_FAILURE;
    }

    memset(buffer, 'A', (size_t)page_size);

    fd = open(path, O_RDWR | O_CREAT | O_TRUNC, 0666);
    if (fd == -1) {
        perror("open for write");
        return EXIT_FAILURE;
    }

    write_all(fd, buffer, (size_t)page_size);

    /* This metadata-only setattr races with the writer metadata commit. */
    if (fchmod(fd, mode) == -1) {
        perror("fchmod");
        return EXIT_FAILURE;
    }

    if (close(fd) == -1) {
        perror("close writer");
        return EXIT_FAILURE;
    }

    free(buffer);

    pid = fork();
    if (pid == -1) {
        perror("fork");
        return EXIT_FAILURE;
    }

    if (pid == 0) {
        volatile unsigned char value;
        void *mapping;

        fd = open(path, O_RDONLY);
        if (fd == -1) {
            perror("child open");
            _exit(2);
        }

        mapping = mmap(NULL, (size_t)page_size, prot, MAP_SHARED, fd, 0);
        if (mapping == MAP_FAILED) {
            perror("mmap");
            _exit(3);
        }

        value = ((volatile unsigned char *)mapping)[0];

        munmap(mapping, (size_t)page_size);
        close(fd);
        _exit(value == 'A' ? 0 : 4);
    }

    if (waitpid(pid, &status, 0) == -1) {
        perror("waitpid");
        return EXIT_FAILURE;
    }

    unlink(path);

    if (WIFSIGNALED(status)) {
        int sig = WTERMSIG(status);

        fprintf(stderr, "FAIL: mmap access killed child with %s (%d)\n",
                strsignal(sig), sig);
        return EXIT_FAILURE;
    }

    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
        fprintf(stderr, "FAIL: child exited with status %d\n",
                WIFEXITED(status) ? WEXITSTATUS(status) : -1);
        return EXIT_FAILURE;
    }

    printf("PASS: mmap page contains the written data\n");
    return EXIT_SUCCESS;
}
```

Run it on a Curvine FUSE mount:

```bash
gcc -Wall -O2 /tmp/mmap_sigbus_repro.c -o /tmp/mmap_sigbus_repro
/tmp/mmap_sigbus_repro /mnt/curvine/mmap-read-repro
/tmp/mmap_sigbus_repro /mnt/curvine/mmap-exec-repro exec
```

Before the fix, both mappings were created successfully, but accessing the first mapped byte killed the child with SIGBUS:

```text
FAIL: mmap access killed child with Bus error (7)
Reproduced Curvine mmap SIGBUS bug
```

**Root Cause**

Curvine writes data asynchronously through an active `FuseWriter`. After the FUSE write reply, the writer knows the accepted file length, but the Master metadata may still contain the old length until the writer is flushed or completed.

The FUSE getattr path already merged the active writer length into the returned attributes. The setattr path did not.

The failing sequence was:

1. Create a file and write one page.
2. Call `fchmod()` while the writable handle and writer are still active.
3. Handle the resulting FUSE `SETATTR` through the Master metadata path.
4. Return a successful `SETATTR` response containing the stale Master-side size.
5. Let the kernel update its inode attributes from that response.
6. Reopen and map the file, then receive SIGBUS when a page fault is evaluated against the stale EOF.

The data itself was committed correctly. After closing the writer, path-based `stat()` and ordinary reads reported the expected 4096-byte file. The failure was caused by the transient stale size exposed to the kernel by the metadata-only `SETATTR` response.

**Changes**

- Merge the active writer length into FUSE `SETATTR` response attributes, matching the existing getattr behavior.
- Prevent metadata-only operations such as `fchmod()` from shrinking the kernel inode below bytes already accepted by the active writer.
- Add the mmap SIGBUS reproducer to the FUSE mmap regression group.
- Fix the Python reproducer to call libc `mmap()` and `munmap()` with explicit ABI types.
- Verify that a `PROT_EXEC`-only mapping succeeds without reading from a non-readable mapping.

**Verification**

- Minimal C reproducer passes for `PROT_READ`.
- Minimal C reproducer passes for `PROT_READ | PROT_EXEC`.
- Python mmap SIGBUS regression passes: `3/3 passed`.
- `cargo fmt --check` passes.
- `cargo build --locked --release -p curvine-fuse` passes.
- `git diff --check` passes.
