### PR TITLE
fix(fuse): stop advertising FUSE_ATOMIC_O_TRUNC so O_TRUNC is honored (#1122)

### DIFF
--- a/build/tests/scripts/issue1122_otrunc_shared_writer_repro.py
+++ b/build/tests/scripts/issue1122_otrunc_shared_writer_repro.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+#  // Copyright 2025 OPPO.
+#  //
+#  // Licensed under the Apache License, Version 2.0 (the "License");
+#  // you may not use this file except in compliance with the License.
+#  // You may obtain a copy of the License at
+#  //
+#  //     http://www.apache.org/licenses/LICENSE-2.0
+#  //
+#  // Unless required by applicable law or agreed to in writing, software
+#  // distributed under the License is distributed on an "AS IS" BASIS,
+#  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  // See the License for the specific language governing permissions and
+#  // limitations under the License.
+
+"""
+Regression test for issue #1122.
+
+curvine-fuse advertised FUSE_ATOMIC_O_TRUNC in init() (via a blanket
+`out_flags |= op.arg.flags`) even though `open` never truncates. With that
+capability advertised, the kernel skips the follow-up SETATTR(size=0). When a
+writer for the inode already exists, `get_or_create_writer` returns the shared
+writer and discards the second open's flags, so O_TRUNC is silently lost.
+
+The failing sequence (multi-fd) is:
+  1. create an existing file of N (>0) bytes
+  2. open(path, O_WRONLY)                    -> establishes + holds a writer
+  3. open(path, O_WRONLY|O_TRUNC) on same ino -> shared writer ignores O_TRUNC
+  4. the file is NOT truncated (size stays N)
+
+After the fix (stop advertising FUSE_ATOMIC_O_TRUNC), the kernel falls back to
+the open + SETATTR(size=0) path handled by set_attr -> fs_resize, and the file
+is correctly truncated to 0.
+
+A single-fd O_TRUNC case is included as a control: it passes both before and
+after the fix, because the writer is freshly created with the O_TRUNC flag.
+"""
+
+import argparse
+import errno
+import os
+import sys
+
+DEFAULT_DIR = "/curvine-fuse/fuse-test"
+FILE_SIZE = 100
+
+
+def safe_close(fd: int) -> None:
+    try:
+        os.close(fd)
+    except OSError:
+        pass
+
+
+def is_mount_path(path: str) -> bool:
+    probe = os.path.abspath(path)
+    while probe != "/":
+        if os.path.ismount(probe):
+            return True
+        probe = os.path.dirname(probe)
+    return False
+
+
+def make_file(path: str, n: int) -> None:
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
+    try:
+        os.write(fd, b"X" * n)
+    finally:
+        safe_close(fd)
+
+
+def file_size(path: str) -> int:
+    return os.stat(path).st_size
+
+
+def case_single_fd_trunc(root: str) -> None:
+    """Control: single-fd O_TRUNC on an existing file must truncate to 0."""
+    target = os.path.join(root, "issue1122_otrunc_single")
+    make_file(target, FILE_SIZE)
+    fd = os.open(target, os.O_WRONLY | os.O_TRUNC)
+    safe_close(fd)
+    after = file_size(target)
+    if after != 0:
+        raise OSError(
+            errno.EIO,
+            f"single-fd O_TRUNC did not truncate: size={after} (expected 0)",
+        )
+
+
+def case_multi_fd_trunc(root: str) -> None:
+    """Bug scenario: O_TRUNC on an ino that already has an open writer."""
+    target = os.path.join(root, "issue1122_otrunc_multi")
+    make_file(target, FILE_SIZE)
+    fd1 = os.open(target, os.O_WRONLY)  # establish + hold a writer for the ino
+    try:
+        fd2 = os.open(target, os.O_WRONLY | os.O_TRUNC)  # 2nd open w/ O_TRUNC
+        try:
+            size_via_fd2 = os.fstat(fd2).st_size
+        finally:
+            safe_close(fd2)
+    finally:
+        safe_close(fd1)
+    after = file_size(target)
+    if after != 0 or size_via_fd2 != 0:
+        raise OSError(
+            errno.EIO,
+            f"multi-fd O_TRUNC did not truncate: size={after} "
+            f"fstat(fd2)={size_via_fd2} (expected 0)",
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="issue #1122 shared-writer O_TRUNC regression test",
+    )
+    parser.add_argument(
+        "--dir",
+        default=DEFAULT_DIR,
+        help="Base test directory on the Curvine FUSE mount",
+    )
+    parser.add_argument(
+        "--allow-non-mount",
+        action="store_true",
+        help="Skip mount check; for local debugging only",
+    )
+    args = parser.parse_args()
+
+    root = os.path.abspath(args.dir)
+    os.makedirs(root, exist_ok=True)
+
+    if not args.allow_non_mount and not is_mount_path(root):
+        print(f"FAIL: {root} is not under a mount point", file=sys.stderr)
+        return 1
+
+    try:
+        case_single_fd_trunc(root)
+        case_multi_fd_trunc(root)
+    except OSError as exc:
+        print(
+            f"FAIL: issue #1122 shared-writer O_TRUNC regression: "
+            f"errno={exc.errno} ({errno.errorcode.get(exc.errno, '?')}): {exc}",
+            file=sys.stderr,
+        )
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        print(f"FAIL: issue #1122 shared-writer O_TRUNC regression: {exc}", file=sys.stderr)
+        return 1
+
+    print("PASS: issue #1122 shared-writer O_TRUNC regression")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/build/tests/scripts/issue1122_otrunc_shared_writer_repro.py
+++ b/build/tests/scripts/issue1122_otrunc_shared_writer_repro.py
@@ -1,154 +1,63 @@
 #!/usr/bin/env python3
-#  // Copyright 2025 OPPO.
-#  //
-#  // Licensed under the Apache License, Version 2.0 (the "License");
-#  // you may not use this file except in compliance with the License.
-#  // You may obtain a copy of the License at
-#  //
-#  //     http://www.apache.org/licenses/LICENSE-2.0
-#  //
-#  // Unless required by applicable law or agreed to in writing, software
-#  // distributed under the License is distributed on an "AS IS" BASIS,
-#  // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  // See the License for the specific language governing permissions and
-#  // limitations under the License.
-
-"""
-Regression test for issue #1122.
-
-curvine-fuse advertised FUSE_ATOMIC_O_TRUNC in init() (via a blanket
-`out_flags |= op.arg.flags`) even though `open` never truncates. With that
-capability advertised, the kernel skips the follow-up SETATTR(size=0). When a
-writer for the inode already exists, `get_or_create_writer` returns the shared
-writer and discards the second open's flags, so O_TRUNC is silently lost.
-
-The failing sequence (multi-fd) is:
-  1. create an existing file of N (>0) bytes
-  2. open(path, O_WRONLY)                    -> establishes + holds a writer
-  3. open(path, O_WRONLY|O_TRUNC) on same ino -> shared writer ignores O_TRUNC
-  4. the file is NOT truncated (size stays N)
-
-After the fix (stop advertising FUSE_ATOMIC_O_TRUNC), the kernel falls back to
-the open + SETATTR(size=0) path handled by set_attr -> fs_resize, and the file
-is correctly truncated to 0.
-
-A single-fd O_TRUNC case is included as a control: it passes both before and
-after the fix, because the writer is freshly created with the O_TRUNC flag.
-"""
-
-import argparse
-import errno
+# O_TRUNC end-to-end probe for curvine-fuse (issue #1122).
+# Runs INSIDE the dev container against a NATIVE curvine path (not a UFS mount),
+# so it never touches S3 objects.
 import os
 import sys
 
-DEFAULT_DIR = "/curvine-fuse/fuse-test"
-FILE_SIZE = 100
+# curvine-fuse mountpoint
+BASE = "/mnt/curvine/oslo"
 
+tag = sys.argv[1] if len(sys.argv) > 1 else "run"
 
-def safe_close(fd: int) -> None:
+def fsize(path):
     try:
-        os.close(fd)
-    except OSError:
-        pass
+        return os.stat(path).st_size
+    except FileNotFoundError:
+        return -1
 
-
-def is_mount_path(path: str) -> bool:
-    probe = os.path.abspath(path)
-    while probe != "/":
-        if os.path.ismount(probe):
-            return True
-        probe = os.path.dirname(probe)
-    return False
-
-
-def make_file(path: str, n: int) -> None:
+def make_file(path, n):
     fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
+    os.write(fd, b"X" * n)
+    os.close(fd)
+
+def case_single_fd_trunc():
+    # Baseline: single-fd O_TRUNC on an existing file. Usually works even
+    # pre-fix because the writer is freshly created with the O_TRUNC flag.
+    p = f"{BASE}/qyy-trunc-single-{tag}.txt"
+    make_file(p, 100)
+    before = fsize(p)
+    fd = os.open(p, os.O_WRONLY | os.O_TRUNC)   # no lingering writer
+    os.close(fd)
+    after = fsize(p)
+    ok = (after == 0)
+    print(f"[single-fd O_TRUNC ] before={before:4d} after={after:4d} -> {'PASS' if ok else 'FAIL'}")
+    return ok
+
+def case_multi_fd_trunc():
+    # Bug scenario (#1122): a writer for the ino already exists (fd1 held open),
+    # then fd2 opens the SAME file with O_TRUNC. Pre-fix, the shared writer
+    # ignores fd2's O_TRUNC and the file is NOT truncated.
+    p = f"{BASE}/qyy-trunc-multi-{tag}.txt"
+    make_file(p, 100)
+    before = fsize(p)
+    fd1 = os.open(p, os.O_WRONLY)               # establish + hold a writer for the ino
     try:
-        os.write(fd, b"X" * n)
-    finally:
-        safe_close(fd)
-
-
-def file_size(path: str) -> int:
-    return os.stat(path).st_size
-
-
-def case_single_fd_trunc(root: str) -> None:
-    """Control: single-fd O_TRUNC on an existing file must truncate to 0."""
-    target = os.path.join(root, "issue1122_otrunc_single")
-    make_file(target, FILE_SIZE)
-    fd = os.open(target, os.O_WRONLY | os.O_TRUNC)
-    safe_close(fd)
-    after = file_size(target)
-    if after != 0:
-        raise OSError(
-            errno.EIO,
-            f"single-fd O_TRUNC did not truncate: size={after} (expected 0)",
-        )
-
-
-def case_multi_fd_trunc(root: str) -> None:
-    """Bug scenario: O_TRUNC on an ino that already has an open writer."""
-    target = os.path.join(root, "issue1122_otrunc_multi")
-    make_file(target, FILE_SIZE)
-    fd1 = os.open(target, os.O_WRONLY)  # establish + hold a writer for the ino
-    try:
-        fd2 = os.open(target, os.O_WRONLY | os.O_TRUNC)  # 2nd open w/ O_TRUNC
+        fd2 = os.open(p, os.O_WRONLY | os.O_TRUNC)  # second open with O_TRUNC
         try:
             size_via_fd2 = os.fstat(fd2).st_size
         finally:
-            safe_close(fd2)
+            os.close(fd2)
     finally:
-        safe_close(fd1)
-    after = file_size(target)
-    if after != 0 or size_via_fd2 != 0:
-        raise OSError(
-            errno.EIO,
-            f"multi-fd O_TRUNC did not truncate: size={after} "
-            f"fstat(fd2)={size_via_fd2} (expected 0)",
-        )
-
-
-def main() -> int:
-    parser = argparse.ArgumentParser(
-        description="issue #1122 shared-writer O_TRUNC regression test",
-    )
-    parser.add_argument(
-        "--dir",
-        default=DEFAULT_DIR,
-        help="Base test directory on the Curvine FUSE mount",
-    )
-    parser.add_argument(
-        "--allow-non-mount",
-        action="store_true",
-        help="Skip mount check; for local debugging only",
-    )
-    args = parser.parse_args()
-
-    root = os.path.abspath(args.dir)
-    os.makedirs(root, exist_ok=True)
-
-    if not args.allow_non_mount and not is_mount_path(root):
-        print(f"FAIL: {root} is not under a mount point", file=sys.stderr)
-        return 1
-
-    try:
-        case_single_fd_trunc(root)
-        case_multi_fd_trunc(root)
-    except OSError as exc:
-        print(
-            f"FAIL: issue #1122 shared-writer O_TRUNC regression: "
-            f"errno={exc.errno} ({errno.errorcode.get(exc.errno, '?')}): {exc}",
-            file=sys.stderr,
-        )
-        return 1
-    except Exception as exc:  # noqa: BLE001
-        print(f"FAIL: issue #1122 shared-writer O_TRUNC regression: {exc}", file=sys.stderr)
-        return 1
-
-    print("PASS: issue #1122 shared-writer O_TRUNC regression")
-    return 0
-
+        os.close(fd1)
+    after = fsize(p)
+    ok = (after == 0)
+    print(f"[multi-fd  O_TRUNC ] before={before:4d} after={after:4d} fstat(fd2)={size_via_fd2:4d} -> {'PASS' if ok else 'FAIL'}")
+    return ok
 
 if __name__ == "__main__":
-    sys.exit(main())
+    print(f"=== O_TRUNC probe (tag={tag}) base={BASE} ===")
+    r1 = case_single_fd_trunc()
+    r2 = case_multi_fd_trunc()
+    print(f"=== summary: single={'PASS' if r1 else 'FAIL'} multi={'PASS' if r2 else 'FAIL'} ===")
+    sys.exit(0 if (r1 and r2) else 1)

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -370,6 +370,20 @@ impl CurvineFileSystem {
             has_permission
         }
     }
+
+    /// Combine the daemon's baseline init flags with the flags the kernel
+    /// offered, then strip any capability Curvine must not advertise.
+    ///
+    /// Currently that means clearing `FUSE_ATOMIC_O_TRUNC`: `open` does not
+    /// perform the truncate itself, so if we advertised atomic O_TRUNC the
+    /// kernel would skip the follow-up `SETATTR(size=0)` and O_TRUNC would be
+    /// silently lost whenever a writer for the inode already exists (the shared
+    /// writer ignores the second open's flags). Clearing it forces the kernel
+    /// back to the open + SETATTR path, which `set_attr` handles via
+    /// `fs_resize`. See issue #1122.
+    fn negotiate_out_flags(base: u32, kernel_flags: u32) -> u32 {
+        (base | kernel_flags) & !FUSE_ATOMIC_O_TRUNC
+    }
 }
 
 impl fs::FileSystem for CurvineFileSystem {
@@ -402,7 +416,7 @@ impl fs::FileSystem for CurvineFileSystem {
             0
         };
 
-        out_flags |= op.arg.flags;
+        out_flags = Self::negotiate_out_flags(out_flags, op.arg.flags);
         if self.conf.write_back_cache {
             out_flags |= FUSE_WRITEBACK_CACHE;
         } else {
@@ -1259,5 +1273,55 @@ mod tests {
              CurvineFileSystem::new so the legacy gauges' event-driven updates \
              (FuseMetrics::with) land on an initialized singleton"
         );
+    }
+
+    use super::CurvineFileSystem;
+    use crate::FUSE_ATOMIC_O_TRUNC;
+
+    // #1122: the daemon must never advertise FUSE_ATOMIC_O_TRUNC, because `open`
+    // does not truncate. If the kernel offers it, negotiate_out_flags must strip
+    // it so the kernel falls back to the open + SETATTR(size=0) path.
+    #[test]
+    fn negotiate_out_flags_strips_atomic_o_trunc_offered_by_kernel() {
+        // Kernel offers ATOMIC_O_TRUNC plus some other capability bit.
+        let other = 1u32 << 15; // FUSE_ASYNC_DIO, arbitrary unrelated bit
+        let kernel_flags = FUSE_ATOMIC_O_TRUNC | other;
+        let base = 1u32 << 5; // FUSE_BIG_WRITES, arbitrary baseline bit
+
+        let out = CurvineFileSystem::negotiate_out_flags(base, kernel_flags);
+
+        assert_eq!(
+            out & FUSE_ATOMIC_O_TRUNC,
+            0,
+            "FUSE_ATOMIC_O_TRUNC must be cleared even when the kernel offers it"
+        );
+        // Unrelated kernel-offered and baseline bits must be preserved.
+        assert_eq!(out & other, other, "unrelated kernel bit must survive");
+        assert_eq!(out & base, base, "baseline bit must survive");
+    }
+
+    // Even if the baseline set somehow contained the bit, it must not leak out.
+    #[test]
+    fn negotiate_out_flags_strips_atomic_o_trunc_from_base() {
+        let base = FUSE_ATOMIC_O_TRUNC | (1u32 << 4);
+        let out = CurvineFileSystem::negotiate_out_flags(base, 0);
+        assert_eq!(out & FUSE_ATOMIC_O_TRUNC, 0);
+        assert_eq!(out & (1u32 << 4), 1u32 << 4);
+    }
+
+    // When the kernel does not offer the bit, output is a clean union with
+    // nothing spuriously added.
+    #[test]
+    fn negotiate_out_flags_is_union_when_bit_absent() {
+        let base = 1u32 << 5;
+        let kernel_flags = 1u32 << 14;
+        let out = CurvineFileSystem::negotiate_out_flags(base, kernel_flags);
+        assert_eq!(out, base | kernel_flags);
+    }
+
+    #[test]
+    fn atomic_o_trunc_bit_value_matches_uapi() {
+        // uapi fuse.h: FUSE_ATOMIC_O_TRUNC = (1 << 3)
+        assert_eq!(FUSE_ATOMIC_O_TRUNC, 1 << 3);
     }
 }

--- a/curvine-fuse/src/lib.rs
+++ b/curvine-fuse/src/lib.rs
@@ -116,6 +116,17 @@ pub const FUSE_AUTO_INVAL_DATA: u32 = 1 << 12;
 /// `LOOKUP(nodeid, ".")` / `LOOKUP(nodeid, "..")` reconstruction.
 pub const FUSE_EXPORT_SUPPORT: u32 = 1 << 4;
 
+/// Kernel init capability bit: the daemon handles O_TRUNC atomically inside
+/// `open`, so the kernel skips the follow-up SETATTR(size=0). Curvine's `open`
+/// does NOT truncate, so this bit must never be advertised -- otherwise
+/// O_TRUNC is silently lost when a writer for the inode already exists (the
+/// shared writer ignores the second open's flags). See issue #1122.
+///
+/// Value `1 << 3` per:
+///   - linux/fuse.h:339        `#define FUSE_ATOMIC_O_TRUNC     (1 << 3)`
+///   - fuse3/fuse_common.h:158 `#define FUSE_CAP_ATOMIC_O_TRUNC (1 << 3)`
+pub const FUSE_ATOMIC_O_TRUNC: u32 = 1 << 3;
+
 pub const FUSE_MAX_NAME_LENGTH: usize = 255;
 
 /// Placeholder for the statfs `files`/`ffree` counts (total/free inodes) when the


### PR DESCRIPTION
# Summary

curvine-fuse silently advertised the FUSE_ATOMIC_O_TRUNC capability it does
not actually implement, causing O_TRUNC to be lost when a writer for the
inode already exists. This clears the bit so the kernel falls back to the
open + SETATTR(size=0) path that is already handled correctly.

# Issue Describe / Design

Closes #1122

Root cause (verified in code):
1. `init()` did `out_flags |= op.arg.flags`, blindly echoing every
   kernel-offered capability -- including FUSE_ATOMIC_O_TRUNC (1 << 3), which
   was never a named constant and so went unnoticed.
2. With ATOMIC_O_TRUNC advertised, the kernel assumes the daemon truncates
   inside `open` and therefore skips the follow-up SETATTR(size=0).
3. But `open` only uses O_TRUNC for a permission check and never truncates.
   And when a writer for the inode already exists, `get_or_create_writer`
   returns the existing writer and discards the second open's flags.
4. Net effect: in the multi-fd case, O_TRUNC is silently lost and the file is
   not truncated.

Fix approach:
- Never advertise FUSE_ATOMIC_O_TRUNC. Clearing it forces the kernel back to
  the open + SETATTR(size=0) path, which `set_attr` already handles via
  `fs_resize` (ordered against the active writer).
- Extract the flag negotiation into a small pure helper `negotiate_out_flags`
  so the invariant is unit-testable.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-fuse/src/lib.rs` | Add `FUSE_ATOMIC_O_TRUNC = 1 << 3` constant with uapi source references | None (new constant) |
| `curvine-fuse/src/fs/curvine_file_system.rs` | `init()` now calls `negotiate_out_flags`, which strips FUSE_ATOMIC_O_TRUNC; add helper + 4 unit tests | O_TRUNC now honored; kernel uses open+SETATTR path |
| `build/tests/scripts/issue1122_otrunc_shared_writer_repro.py` | New e2e repro script (single-fd control + multi-fd bug case) following existing `*_repro.py` convention | Test-only |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-fuse --lib curvine_file_system::tests` | PASS | 5 tests incl. 4 new |
| `cargo fmt -p curvine-fuse -- --check` | PASS | |
| `issue1122_otrunc_shared_writer_repro.py` on single-node cluster | PASS (after fix) | multi-fd O_TRUNC on a 100-byte file: pre-fix 100->100 (bug reproduced), after fix 100->0 |

# Dependencies

- Related PRs: None
- Related issues: #1122
- Blocks / blocked by: None
