### PR TITLE
fix(fuse): fail on config load errors (#1070)

### DIFF
--- a/curvine-fuse/src/cli/fuse_cli.rs
+++ b/curvine-fuse/src/cli/fuse_cli.rs
@@ -87,6 +87,23 @@ impl FuseCli {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use orpc::common::Utils;
+    use std::fs;
+
+    fn with_valid_conf<T>(extra_args: &[&str], test: impl FnOnce(FuseRuntimeArgs) -> T) -> T {
+        let conf_path = Utils::temp_file();
+        fs::write(&conf_path, "[fuse]\nio_threads = 1\n").expect("write test config");
+
+        let mut argv = vec!["curvine-fuse", "--conf", conf_path.as_str()];
+        argv.extend_from_slice(extra_args);
+        let args = FuseCli::try_parse_from(argv)
+            .expect("parse runtime arguments")
+            .resolve_runtime_args();
+        let result = test(args);
+
+        let _ = fs::remove_file(&conf_path);
+        result
+    }
 
     #[test]
     fn bare_invocation_preserves_top_level_flags() {
@@ -143,11 +160,10 @@ mod tests {
 
     #[test]
     fn runtime_args_apply_client_overrides_to_conf() {
-        let args = FuseCli::try_parse_from(["curvine-fuse", "--client.io-threads", "12"])
-            .unwrap()
-            .resolve_runtime_args();
-        let conf = args.get_conf().unwrap();
-        assert_eq!(conf.client.io_threads, 12);
+        with_valid_conf(&["--client.io-threads", "12"], |args| {
+            let conf = args.get_conf().unwrap();
+            assert_eq!(conf.client.io_threads, 12);
+        });
     }
 
     #[test]
@@ -168,26 +184,24 @@ mod tests {
     // false (the production emergency-downgrade path).
     #[test]
     fn metrics_enabled_cli_override_disables() {
-        let args = FuseCli::try_parse_from(["curvine-fuse", "--metrics-enabled", "false"])
-            .unwrap()
-            .resolve_runtime_args();
-        assert_eq!(args.mount.metrics_enabled, Some(false));
-        let conf = args.get_conf().unwrap();
-        assert!(
-            !conf.fuse.metrics_enabled,
-            "--metrics-enabled false must disable metrics in the resolved conf"
-        );
+        with_valid_conf(&["--metrics-enabled", "false"], |args| {
+            assert_eq!(args.mount.metrics_enabled, Some(false));
+            let conf = args.get_conf().unwrap();
+            assert!(
+                !conf.fuse.metrics_enabled,
+                "--metrics-enabled false must disable metrics in the resolved conf"
+            );
+        });
     }
 
     // Kill switch: when the flag is absent the conf keeps its default (true).
     #[test]
     fn metrics_enabled_absent_keeps_default() {
-        let args = FuseCli::try_parse_from(["curvine-fuse", "--io-threads", "4"])
-            .unwrap()
-            .resolve_runtime_args();
-        assert_eq!(args.mount.metrics_enabled, None);
-        let conf = args.get_conf().unwrap();
-        assert!(conf.fuse.metrics_enabled, "absent flag keeps default true");
+        with_valid_conf(&["--io-threads", "4"], |args| {
+            assert_eq!(args.mount.metrics_enabled, None);
+            let conf = args.get_conf().unwrap();
+            assert!(conf.fuse.metrics_enabled, "absent flag keeps default true");
+        });
     }
 
     #[test]

--- a/curvine-fuse/src/cli/mount_args.rs
+++ b/curvine-fuse/src/cli/mount_args.rs
@@ -189,17 +189,8 @@ impl FuseRuntimeArgs {
 impl FuseMountArgs {
     /// Parses the cluster configuration file and applies CLI overrides.
     pub fn get_conf(&self) -> CommonResult<ClusterConf> {
-        let mut conf = match ClusterConf::from(&self.conf) {
-            Ok(c) => {
-                println!("Loaded configuration from {}", self.conf);
-                c
-            }
-            Err(e) => {
-                eprintln!("Warning: Failed to load config file '{}': {}", self.conf, e);
-                eprintln!("Using default configuration");
-                Self::create_default_conf()
-            }
-        };
+        let mut conf = ClusterConf::from(&self.conf)?;
+        println!("Loaded configuration from {}", self.conf);
 
         // FUSE configuration - only override if command line values are specified
         if let Some(mnt_path) = &self.mnt_path {
@@ -343,10 +334,6 @@ impl FuseMountArgs {
         conf.fuse.init()?;
 
         Ok(conf)
-    }
-
-    fn create_default_conf() -> ClusterConf {
-        ClusterConf::default()
     }
 
     pub fn default_mnt_opts() -> Vec<String> {

--- a/curvine-fuse/src/cli/validate_run.rs
+++ b/curvine-fuse/src/cli/validate_run.rs
@@ -119,6 +119,26 @@ state_dir = "{}"
     }
 
     #[test]
+    fn validate_config_errors_when_config_file_is_missing() {
+        let conf =
+            std::env::temp_dir().join(format!("cv_validate_missing_{}.toml", std::process::id()));
+        let _ = std::fs::remove_file(&conf);
+
+        run_validate_config(args_for(conf.to_str().unwrap()))
+            .expect_err("missing config file must fail validation");
+    }
+
+    #[test]
+    fn validate_config_errors_when_toml_is_invalid() {
+        let conf = write_temp_toml("invalid", "[fuse\nio_threads = 8\n");
+
+        run_validate_config(args_for(conf.to_str().unwrap()))
+            .expect_err("invalid TOML must fail validation");
+
+        let _ = std::fs::remove_file(&conf);
+    }
+
+    #[test]
     fn validate_config_errors_when_state_dir_is_a_file() {
         // Point state_dir at an existing regular file → hard error.
         let file = std::env::temp_dir().join(format!("cv_vc_notdir_{}", std::process::id()));


### PR DESCRIPTION
# Summary

Make `curvine-fuse` fail immediately when its configuration file cannot be read or parsed, instead of silently mounting or validating with default cluster settings.

# Issue Describe / Design

Closes #1070

Root cause: `FuseMountArgs::get_conf` caught every `ClusterConf::from` error and replaced the failed configuration with `ClusterConf::default()`. As a result, both mount startup and `validate-config` could continue after a missing file or malformed TOML.

Reproduction:
1. Run `curvine-fuse validate-config --conf <missing-path>` or point `--conf` at malformed TOML.
2. Before this change, the command printed `Using default configuration` and exited with status 0.

Fix approach: propagate `ClusterConf::from` errors with `?`, remove the unused fallback helper, add regression coverage for missing and malformed configuration, and update existing CLI tests to provide an explicit valid config fixture.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-fuse/src/cli/mount_args.rs` | Propagate config read/parse errors and remove the implicit default fallback | Missing or invalid explicit config now causes startup/validation failure |
| `curvine-fuse/src/cli/validate_run.rs` | Add missing-file and invalid-TOML regression tests | Test-only |
| `curvine-fuse/src/cli/fuse_cli.rs` | Give existing config-resolution tests an explicit valid config fixture | Test-only |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| Before/after E2E: missing config | PASS | Exit status changed from 0 to 1; no default fallback after the fix |
| Before/after E2E: malformed TOML | PASS | Exit status changed from 0 to 1; parse error is returned after the fix |
| E2E: valid repository config | PASS | Exit status remains 0 |
| `cargo test --offline -p curvine-fuse 'cli::' -- --nocapture` | PASS | 29 passed, 0 failed |
| `make format` | PASS | Includes two release clippy passes with warnings denied |

# Dependencies

- Related PRs: None
- Related issues: #1070
- Blocks / blocked by: None
