### PR TITLE
feat(fluid): add ReportSummary support (#1153)

### DIFF
--- a/curvine-cli/src/cmds/report.rs
+++ b/curvine-cli/src/cmds/report.rs
@@ -17,6 +17,7 @@ use clap::{Parser, Subcommand};
 use curvine_client::unified::UnifiedFileSystem;
 use curvine_common::state::MasterInfo;
 use orpc::CommonResult;
+use serde::Serialize;
 
 #[derive(Parser, Debug)]
 pub struct ReportCommand {
@@ -35,6 +36,8 @@ pub enum ReportSubCommand {
         #[clap(value_name = "WORKER_ADDRESS")]
         worker_address: Option<String>,
     },
+    /// Print Fluid CacheRuntime ReportSummary JSON
+    FluidSummary,
     Used,
     Available,
 }
@@ -58,6 +61,9 @@ impl ReportCommand {
                         println!("{}", report.capacity_cluster());
                     }
                 }
+                ReportSubCommand::FluidSummary => {
+                    println!("{}", report.fluid_summary());
+                }
                 ReportSubCommand::Used => {
                     println!("{}", report.used());
                 }
@@ -75,6 +81,17 @@ impl ReportCommand {
 
 struct CurvineReport {
     info: MasterInfo,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct FluidReportSummary {
+    cached: String,
+    cached_percentage: String,
+    cache_capacity: String,
+    cache_hit_ratio: String,
+    file_num: String,
+    ufs_total: String,
 }
 
 impl CurvineReport {
@@ -342,6 +359,22 @@ impl CurvineReport {
         builder
     }
 
+    pub fn fluid_summary(&self) -> String {
+        // Fluid defines cachedPercentage against UFS total. Curvine does not
+        // keep UFS total as cheap master metadata yet, so avoid deriving it
+        // from cache capacity.
+        let summary = FluidReportSummary {
+            cached: fluid_bytes_to_string(self.info.fs_used),
+            cached_percentage: "0".to_string(),
+            cache_capacity: fluid_bytes_to_string(self.info.capacity),
+            cache_hit_ratio: "0".to_string(),
+            file_num: self.info.inode_file_num.to_string(),
+            ufs_total: "0".to_string(),
+        };
+
+        serde_json::to_string(&summary).expect("Fluid report summary serialization should not fail")
+    }
+
     // Helper method to calculate percentage
     fn get_percent(numerator: i64, denominator: i64) -> f64 {
         if denominator == 0 {
@@ -349,4 +382,29 @@ impl CurvineReport {
         }
         (numerator as f64 / denominator as f64) * 100.0
     }
+}
+
+fn fluid_bytes_to_string(size: i64) -> String {
+    const KIB: f64 = 1024.0;
+    const MIB: f64 = KIB * 1024.0;
+    const GIB: f64 = MIB * 1024.0;
+    const TIB: f64 = GIB * 1024.0;
+    const PIB: f64 = TIB * 1024.0;
+
+    let size = size.max(0) as f64;
+    let (value, unit) = if size >= PIB {
+        (size / PIB, "PiB")
+    } else if size >= TIB {
+        (size / TIB, "TiB")
+    } else if size >= GIB {
+        (size / GIB, "GiB")
+    } else if size >= MIB {
+        (size / MIB, "MiB")
+    } else if size >= KIB {
+        (size / KIB, "KiB")
+    } else {
+        (size, "B")
+    };
+
+    format!("{value:.2}{unit}")
 }

--- a/curvine-cli/tests/report_fluid_summary.rs
+++ b/curvine-cli/tests/report_fluid_summary.rs
@@ -1,0 +1,18 @@
+use std::process::Command;
+
+#[test]
+fn fluid_summary_subcommand_is_available() {
+    let output = Command::new(env!("CARGO_BIN_EXE_curvine-cli"))
+        .args(["report", "fluid-summary", "--help"])
+        .output()
+        .expect("run curvine-cli report fluid-summary --help");
+
+    assert!(
+        output.status.success(),
+        "help command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Print Fluid CacheRuntime ReportSummary JSON"));
+}

--- a/curvine-docker/deploy/Dockerfile_rocky9
+++ b/curvine-docker/deploy/Dockerfile_rocky9
@@ -180,12 +180,13 @@ COPY curvine-docker/fluid/entrypoint.sh /fluid-entrypoint.sh
 COPY curvine-docker/fluid/generate_config.py /app/curvine/generate_config.py
 COPY curvine-docker/fluid/config-parse.py /app/curvine/config-parse.py
 COPY curvine-docker/fluid/mountUfs.sh /app/curvine/mountUfs.sh
+COPY curvine-docker/fluid/reportSummary.sh /app/curvine/reportSummary.sh
 
 # Make all binaries and scripts executable
 RUN find /app/curvine -type f -name "*.sh" -exec chmod +x {} \; \
     && find /app/curvine -type f -path "*/bin/*" -exec chmod +x {} \; \
     && find /app/curvine -type f -path "*/lib/*" -exec chmod +x {} \; \
-    && chmod +x /app/curvine/generate_config.py /app/curvine/config-parse.py /app/curvine/mountUfs.sh \
+    && chmod +x /app/curvine/generate_config.py /app/curvine/config-parse.py /app/curvine/mountUfs.sh /app/curvine/reportSummary.sh \
     && chmod +x /fluid-entrypoint.sh \
     && chmod +x /entrypoint.sh
 

--- a/curvine-docker/deploy/Dockerfile_ubuntu24
+++ b/curvine-docker/deploy/Dockerfile_ubuntu24
@@ -250,12 +250,13 @@ COPY curvine-docker/fluid/entrypoint.sh /fluid-entrypoint.sh
 COPY curvine-docker/fluid/generate_config.py /app/curvine/generate_config.py
 COPY curvine-docker/fluid/config-parse.py /app/curvine/config-parse.py
 COPY curvine-docker/fluid/mountUfs.sh /app/curvine/mountUfs.sh
+COPY curvine-docker/fluid/reportSummary.sh /app/curvine/reportSummary.sh
 
 # Make all binaries and scripts executable
 RUN find /app/curvine -type f -name "*.sh" -exec chmod +x {} \; \
     && find /app/curvine -type f -path "*/bin/*" -exec chmod +x {} \; \
     && find /app/curvine -type f -path "*/lib/*" -exec chmod +x {} \; \
-    && chmod +x /app/curvine/generate_config.py /app/curvine/config-parse.py /app/curvine/mountUfs.sh \
+    && chmod +x /app/curvine/generate_config.py /app/curvine/config-parse.py /app/curvine/mountUfs.sh /app/curvine/reportSummary.sh \
     && chmod +x /fluid-entrypoint.sh \
     && chmod +x /entrypoint.sh
 

--- a/curvine-docker/fluid/cache-runtime/curvine-cache-runtime-class.yaml
+++ b/curvine-docker/fluid/cache-runtime/curvine-cache-runtime-class.yaml
@@ -291,6 +291,12 @@ topology:
         - -c
         - /app/curvine/mountUfs.sh
         timeout: 120
+      ReportSummary:
+        command:
+        - bash
+        - -c
+        - /app/curvine/reportSummary.sh
+        timeout: 30
     template:
       spec:
         restartPolicy: Always

--- a/curvine-docker/fluid/reportSummary.sh
+++ b/curvine-docker/fluid/reportSummary.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CURVINE_HOME="${CURVINE_HOME:-/app/curvine}"
+CURVINE_CONF_FILE="${CURVINE_CONF_FILE:-${CURVINE_HOME}/conf/curvine-cluster.toml}"
+CV_BIN="${CURVINE_CLI:-${CURVINE_HOME}/bin/cv}"
+
+if [ ! -x "$CV_BIN" ]; then
+  echo "Curvine CLI not found or not executable: $CV_BIN" >&2
+  exit 1
+fi
+
+exec "$CV_BIN" report fluid-summary --conf "$CURVINE_CONF_FILE"


### PR DESCRIPTION
# Summary

This PR adds a Fluid ReportSummary command so Fluid can update Dataset cache status from Curvine master metrics.

# Issue Describe / Design

Closes #1153

This follows Fluid Generic CacheRuntime's `ReportSummary` contract: the command prints strict JSON to stdout, and failures go to stderr. Curvine exposes it as `cv report fluid-summary`, then wires Fluid to call `/app/curvine/reportSummary.sh` from the main Curvine image.

Design decisions and trade-offs:
- Use one existing master info RPC, so the command is cheap and does not scan UFS data.
- Report known Curvine metadata directly: cached bytes, cache capacity, and file count.
- Keep `ufsTotal`, `cachedPercentage`, and `cacheHitRatio` as `0` for now because Curvine does not keep low-cost authoritative UFS total or hit-ratio metadata in master state yet. This avoids deriving Fluid's dataset percentage from cache capacity, which would mix two different meanings.
- Do not update `Cargo.lock` because this PR does not change dependency declarations; local lockfile regeneration is unrelated noise.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-cli/src/cmds/report.rs` | Add `report fluid-summary` and JSON serialization for Fluid ReportSummary fields. | Existing report commands are unchanged. |
| `curvine-cli/tests/report_fluid_summary.rs` | Add CLI integration coverage for the new subcommand. | Test-only change. |
| `curvine-docker/fluid/reportSummary.sh` | Add the Fluid execution wrapper that calls `cv report fluid-summary`. | Only used by Fluid integration. |
| `curvine-docker/deploy/Dockerfile_rocky9` / `Dockerfile_ubuntu24` | Include the ReportSummary wrapper in the main Curvine image. | Main image gains one Fluid wrapper script; normal entrypoints remain unchanged. |
| `curvine-docker/fluid/cache-runtime/curvine-cache-runtime-class.yaml` | Register `ReportSummary` in the CacheRuntimeClass execution entries. | Enables Fluid to call Curvine ReportSummary. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo fmt --check` | PASS | Formatting check. |
| `cargo test -p curvine-cli -- --nocapture` | PASS | 18 tests passed. |
| `bash -n curvine-docker/fluid/reportSummary.sh curvine-docker/fluid/mountUfs.sh curvine-docker/fluid/entrypoint.sh curvine-docker/deploy/entrypoint.sh` | PASS | Shell syntax check. |
| `python3 -c 'import yaml; yaml.safe_load(open("curvine-docker/fluid/cache-runtime/curvine-cache-runtime-class.yaml")); print("yaml ok")'` | PASS | CacheRuntimeClass YAML parses. |
| `git diff --check` | PASS | No whitespace errors. |
| `cargo test -p curvine-cli --locked -- --nocapture` | NOT USED | Current `Cargo.lock` on main requires local regeneration; this PR intentionally does not include that unrelated lockfile change. |

# Dependencies

- Related PRs: None
- Related issues: #1153
- Blocks / blocked by: None
