### PR TITLE
refactor(client): centralize I/O metrics tracking

### DIFF
--- a/curvine-client/src/client_metrics.rs
+++ b/curvine-client/src/client_metrics.rs
@@ -14,12 +14,15 @@
 
 use crate::file::FsContext;
 use curvine_common::state::{MetricType, MetricValue};
-use orpc::common::{Counter, CounterVec, HistogramVec, Metrics as m};
+use curvine_common::FsResult;
+use orpc::common::{Counter, CounterVec, HistogramVec, Metrics as m, TimeSpent};
 use orpc::common::{Gauge, Metrics};
 use orpc::sync::FastDashMap;
+use orpc::sys::DataSlice;
 use orpc::CommonResult;
 use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
+use std::future::Future;
 
 pub struct ClientMetrics {
     pub mount_cache_hits: CounterVec,
@@ -66,6 +69,34 @@ impl ClientMetrics {
         };
 
         Ok(cm)
+    }
+
+    /// Run a write future and record elapsed time; bytes are counted only on success.
+    pub async fn track_write<F>(&self, len: i64, fut: F) -> FsResult<i64>
+    where
+        F: Future<Output = FsResult<()>>,
+    {
+        let spent = TimeSpent::new();
+        let res = fut.await;
+        self.write_time_us.inc_by(spent.used_us() as i64);
+
+        res?;
+        self.write_bytes.inc_by(len);
+        Ok(len)
+    }
+
+    /// Run a read future and record elapsed time; returned bytes are counted on success.
+    pub async fn track_read<F>(&self, fut: F) -> FsResult<DataSlice>
+    where
+        F: Future<Output = FsResult<DataSlice>>,
+    {
+        let spent = TimeSpent::new();
+        let res = fut.await;
+        self.read_time_us.inc_by(spent.used_us() as i64);
+
+        let slice = res?;
+        self.read_bytes.inc_by(slice.len() as i64);
+        Ok(slice)
     }
 
     pub fn text_output(&self) -> CommonResult<String> {

--- a/curvine-client/src/file/fs_reader.rs
+++ b/curvine-client/src/file/fs_reader.rs
@@ -17,7 +17,7 @@ use curvine_common::fs::{Path, Reader};
 use curvine_common::state::{FileBlocks, FileStatus};
 use curvine_common::FsResult;
 use log::debug;
-use orpc::common::{ByteUnit, TimeSpent};
+use orpc::common::ByteUnit;
 use orpc::err_box;
 use orpc::sys::DataSlice;
 use std::sync::Arc;
@@ -31,6 +31,7 @@ pub struct FsReader {
     pos: i64,
     len: i64,
     file_blocks: FileBlocks,
+    metrics: &'static crate::ClientMetrics,
 }
 
 impl FsReader {
@@ -55,6 +56,7 @@ impl FsReader {
         );
 
         let inner = FsReaderBuffer::new(path, fs_context, file_blocks.clone(), read_detector)?;
+        let metrics = FsContext::get_metrics();
         let reader = Self {
             inner,
             chunk: DataSlice::Empty,
@@ -62,6 +64,7 @@ impl FsReader {
             pos: 0,
             len,
             file_blocks,
+            metrics,
         };
         Ok(reader)
     }
@@ -101,9 +104,7 @@ impl Reader for FsReader {
     }
 
     async fn read_chunk0(&mut self) -> FsResult<DataSlice> {
-        let _timer =
-            TimeSpent::timer_counter(Arc::new(FsContext::get_metrics().read_time_us.clone()));
-        self.inner.read().await
+        self.metrics.track_read(self.inner.read()).await
     }
 
     async fn seek(&mut self, pos: i64) -> FsResult<()> {

--- a/curvine-client/src/file/fs_reader_buffer.rs
+++ b/curvine-client/src/file/fs_reader_buffer.rs
@@ -361,10 +361,6 @@ impl FsReaderBuffer {
             }
         }
 
-        FsContext::get_metrics()
-            .read_bytes
-            .inc_by(bytes.len() as i64);
-
         Ok(bytes)
     }
 

--- a/curvine-client/src/file/fs_writer.rs
+++ b/curvine-client/src/file/fs_writer.rs
@@ -18,7 +18,7 @@ use curvine_common::fs::{Path, Writer};
 use curvine_common::state::{FileAllocOpts, FileBlocks, FileStatus};
 use curvine_common::FsResult;
 use log::debug;
-use orpc::common::{ByteUnit, TimeSpent};
+use orpc::common::ByteUnit;
 use orpc::sys::DataSlice;
 use orpc::{err_box, ternary};
 use std::sync::Arc;
@@ -31,6 +31,7 @@ pub struct FsWriter {
     chunk_size: usize,
     pos: i64,
     append: bool,
+    metrics: &'static crate::ClientMetrics,
 }
 
 impl FsWriter {
@@ -52,6 +53,7 @@ impl FsWriter {
 
         let writer = FsWriterBase::new(fs_context, path, status, pos);
         let inner = FsWriterBuffer::new(writer, chunk_num);
+        let metrics = FsContext::get_metrics();
 
         Self {
             inner,
@@ -59,6 +61,7 @@ impl FsWriter {
             chunk_size,
             pos,
             append,
+            metrics,
         }
     }
 
@@ -101,12 +104,8 @@ impl Writer for FsWriter {
     }
 
     async fn write_chunk(&mut self, chunk: DataSlice) -> FsResult<i64> {
-        let len = chunk.len();
-        let _timer =
-            TimeSpent::timer_counter(Arc::new(FsContext::get_metrics().write_time_us.clone()));
-        self.inner.write(chunk).await?;
-        FsContext::get_metrics().write_bytes.inc_by(len as i64);
-        Ok(len as i64)
+        let len = chunk.len() as i64;
+        self.metrics.track_write(len, self.inner.write(chunk)).await
     }
 
     async fn flush(&mut self) -> FsResult<()> {
@@ -129,6 +128,8 @@ impl Writer for FsWriter {
     async fn seek(&mut self, pos: i64) -> FsResult<()> {
         if pos < 0 {
             return err_box!(format!("Cannot seek to negative position: {}", pos));
+        } else if self.pos == pos {
+            return Ok(());
         }
 
         if self.append {


### PR DESCRIPTION
# Summary

Centralize client read and write metric accounting in `ClientMetrics` so latency and successful byte counts follow the same lifecycle. The reader and writer now reuse shared async tracking helpers, reducing duplicated instrumentation and keeping byte accounting at the public I/O boundary.

# Issue Describe / Design

No linked issue.

Previously, read/write latency and byte counters were updated independently in `FsReader`, `FsReaderBuffer`, and `FsWriter`. This made the metric lifecycle easy to diverge and placed read-byte accounting inside the buffering implementation.

The new `track_read` and `track_write` helpers enforce these rules:

- elapsed time is recorded after every completed I/O future, including failed operations;
- byte counters are incremented only when the operation succeeds;
- read bytes are measured from the `DataSlice` returned by the reader;
- write bytes use the submitted chunk length after a successful write.

`FsReader` and `FsWriter` cache the process-wide client metrics reference when they are constructed. The writer also returns early when seeking to its current position, avoiding unnecessary buffer flushing and inner seek work.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-client/src/client_metrics.rs` | Add shared async read/write tracking helpers | Standardizes latency and successful-byte accounting |
| `curvine-client/src/file/fs_reader.rs` | Route reads through `track_read` and cache metrics | Read metrics are recorded at the reader boundary |
| `curvine-client/src/file/fs_reader_buffer.rs` | Remove buffer-level read-byte increment | Prevents metric ownership from being split across layers |
| `curvine-client/src/file/fs_writer.rs` | Route writes through `track_write`, cache metrics, and short-circuit no-op seeks | Preserves successful write accounting and avoids redundant seek work |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `git diff --cached --check` | PASS | No whitespace errors |
| `cargo fmt --all -- --check` | PASS | Formatting is clean |
| `cargo check -p curvine-client --offline` | NOT COMPLETED | Repeated single-job builds reached the execution timeout while compiling `librocksdb-sys`; no change-related diagnostics were reported |
| `cargo test -p curvine-client` | NOT COMPLETED | Initial Windows build exhausted the available page file while compiling dependencies |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None