### PR TITLE
fix(fuse): make interrupt requests no-reply (#1087)

### DIFF
--- a/curvine-fuse/src/fs/file_system.rs
+++ b/curvine-fuse/src/fs/file_system.rs
@@ -157,6 +157,10 @@ pub trait FileSystem: Send + Sync + 'static {
         async move { err_fuse!(libc::ENOSYS, "{:?}", op) }
     }
 
+    /// Best-effort fallback for an interrupt whose target is no longer present in
+    /// the dispatcher's pending-request map. The pending-request notification is
+    /// the primary cancellation path; this result reports internal handling only,
+    /// because the FUSE protocol does not send a reply for the interrupt request.
     fn interrupt(&self, _op: Interrupt<'_>) -> impl Future<Output = FuseResult<()>> + Send {
         async move { Ok(()) }
     }

--- a/curvine-fuse/src/session/channel/fuse_receiver.rs
+++ b/curvine-fuse/src/session/channel/fuse_receiver.rs
@@ -626,7 +626,7 @@ impl<T: FileSystem> FuseReceiver<T> {
                 } else {
                     fs.interrupt(op).await
                 };
-                reply.send_rep(res).await
+                reply.send_none(res)
             }
 
             FuseOperator::Symlink(op) => reply.send_rep(fs.symlink(op).await).await,
@@ -773,7 +773,7 @@ mod tests {
         use crate::fuse_metrics::{
             FuseMetrics, FuseReqCtx, FuseReqKind, FuseReqLabels, FuseReqStatus,
         };
-        use crate::raw::fuse_abi::{fuse_forget_in, fuse_in_header};
+        use crate::raw::fuse_abi::{fuse_forget_in, fuse_in_header, fuse_interrupt_in};
         use crate::session::{FuseRequest, FuseResponse, FuseTask};
         use crate::FuseUtils;
         use bytes::{BufMut, BytesMut};
@@ -792,6 +792,7 @@ mod tests {
         const OP_GETATTR: u32 = 3;
         const OP_STATFS: u32 = 17;
         const OP_ACCESS: u32 = 34;
+        const OP_INTERRUPT: u32 = 36;
 
         // Build a raw FUSE request: header (len auto-filled) + payload, then parse.
         fn make_request(opcode: u32, unique: u64, nodeid: u64, payload: &[u8]) -> FuseRequest {
@@ -831,6 +832,13 @@ mod tests {
         fn forget_request(unique: u64) -> FuseRequest {
             let arg = fuse_forget_in { nlookup: 1 };
             make_request(OP_FORGET, unique, 2, FuseUtils::struct_as_bytes(&arg))
+        }
+
+        fn interrupt_request(unique: u64, interrupted_unique: u64) -> FuseRequest {
+            let arg = fuse_interrupt_in {
+                unique: interrupted_unique,
+            };
+            make_request(OP_INTERRUPT, unique, 0, FuseUtils::struct_as_bytes(&arg))
         }
 
         // A reply whose metrics slot is live (active guard backed by a throwaway
@@ -882,6 +890,17 @@ mod tests {
 
         fn fs() -> TestFileSystem {
             TestFileSystem::new(FuseConf::default())
+        }
+
+        struct InterruptTrackingFileSystem {
+            called: Arc<AtomicBool>,
+        }
+
+        impl FileSystem for InterruptTrackingFileSystem {
+            async fn interrupt(&self, _op: crate::fs::operator::Interrupt<'_>) -> FuseResult<()> {
+                self.called.store(true, Ordering::SeqCst);
+                Ok(())
+            }
         }
 
         // (1a) GetAttr succeeds (TestFileSystem returns Ok) -> operation sample
@@ -954,6 +973,68 @@ mod tests {
             assert!(
                 rx.try_recv().unwrap().is_none(),
                 "Forget is no-reply: no task enqueued"
+            );
+        }
+
+        #[tokio::test]
+        async fn interrupt_notifies_pending_request_and_enqueues_nothing() {
+            let interrupted_unique = 2001;
+            let pending = FastDashMap::default();
+            let notify = std::sync::Arc::new(tokio::sync::Notify::new());
+            pending.insert(interrupted_unique, notify.clone());
+            let (reply, mut rx) = metrics_reply(1006, "Interrupt");
+            let fallback_called = Arc::new(AtomicBool::new(false));
+            let fs = InterruptTrackingFileSystem {
+                called: fallback_called.clone(),
+            };
+
+            super::super::FuseReceiver::dispatch_meta(
+                &pending,
+                &fs,
+                &interrupt_request(1006, interrupted_unique),
+                &reply,
+            )
+            .await
+            .unwrap();
+
+            tokio::time::timeout(std::time::Duration::from_secs(1), notify.notified())
+                .await
+                .expect("pending request is notified");
+            assert!(
+                rx.try_recv().unwrap().is_none(),
+                "Interrupt is no-reply: no task enqueued"
+            );
+            assert!(
+                !fallback_called.load(Ordering::SeqCst),
+                "pending request notification is the primary interrupt path"
+            );
+        }
+
+        #[tokio::test]
+        async fn late_interrupt_enqueues_nothing() {
+            let pending = FastDashMap::default();
+            let (reply, mut rx) = metrics_reply(1007, "Interrupt");
+            let fallback_called = Arc::new(AtomicBool::new(false));
+            let fs = InterruptTrackingFileSystem {
+                called: fallback_called.clone(),
+            };
+
+            super::super::FuseReceiver::dispatch_meta(
+                &pending,
+                &fs,
+                &interrupt_request(1007, 2002),
+                &reply,
+            )
+            .await
+            .unwrap();
+
+            assert!(
+                rx.try_recv().unwrap().is_none(),
+                "late Interrupt is no-reply: no task enqueued"
+            );
+            assert!(
+                fallback_called.load(Ordering::SeqCst),
+                "late Interrupt invokes the best-effort filesystem fallback"
             );
         }
 

--- a/curvine-fuse/src/session/fuse_response.rs
+++ b/curvine-fuse/src/session/fuse_response.rs
@@ -642,8 +642,9 @@ impl FuseResponse {
     }
 
     pub fn send_none(&self, res: FuseResult<()>) -> IOResult<()> {
-        // No reply is sent to the kernel for Forget/BatchForget, but the request
-        // context must still be finished (guard dropped, result classified).
+        // No reply is sent to the kernel for protocol no-reply operations such as
+        // Forget, BatchForget, and Interrupt, but the request context must still
+        // be finished (guard dropped, result classified).
         self.finish_no_reply(res);
         Ok(())
     }


### PR DESCRIPTION
# Summary

Make FUSE_INTERRUPT a protocol no-reply operation while preserving pending SETLKW cancellation and the late-interrupt fallback path.

# Issue Describe / Design

Closes #1087

Root cause: the metadata dispatcher used the normal reply path for FUSE_INTERRUPT even though the kernel does not expect a response to the interrupt control request. A late interrupt also produced a success reply after the original request had already completed.

Reproduction: dispatch a FUSE_INTERRUPT request and observe that a reply task is enqueued for the interrupt request itself.

Fix approach: finish the interrupt request through the existing no-reply response path. Pending requests are still notified first; when the target is already absent, FileSystem::interrupt remains a best-effort internal fallback.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-fuse/src/session/channel/fuse_receiver.rs` | Route FUSE_INTERRUPT through `send_none` and add pending/late interrupt tests | Interrupt requests no longer enqueue kernel replies |
| `curvine-fuse/src/fs/file_system.rs` | Document the best-effort fallback contract | Documentation only |
| `curvine-fuse/src/session/fuse_response.rs` | Clarify the shared no-reply helper comment | Documentation only |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo fmt --all -- --check` | PASS | Formatting verification only; no local tests were run |
| `cargo test -p curvine-fuse --lib dispatch_meta_integration::interrupt_notifies_pending_request_and_enqueues_nothing -- --nocapture` | PASS | LPAI remote devspace |
| `cargo test -p curvine-fuse --lib dispatch_meta_integration::late_interrupt_enqueues_nothing -- --nocapture` | PASS | LPAI remote devspace |
| Real `/dev/fuse` mount: conflicting `F_SETLKW` interrupted by `SIGUSR1` | PASS | Child returned `EINTR`; Interrupt metric was `reply_type="no_reply"`; no replied Interrupt metric; mount remained healthy |

# Dependencies

- Related PRs: None
- Related issues: #1087
- Blocks / blocked by: None
