### PR TITLE
perf(fuse): reuse cached file blocks when opening readers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,7 +452,7 @@ dependencies = [
  "derive_builder",
  "futures",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.12.25",
  "reqwest-eventsource",
  "secrecy",
  "serde",
@@ -1012,7 +1012,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tower 0.5.2",
  "tower-layer",
@@ -1035,7 +1035,7 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1948,7 +1948,7 @@ dependencies = [
  "curvine-common",
  "curvine-ufs",
  "orpc",
- "reqwest",
+ "reqwest 0.12.25",
  "serde",
  "serde_json",
  "tokio",
@@ -3029,7 +3029,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3962,7 +3962,7 @@ dependencies = [
  "log",
  "num_cpus",
  "rand 0.9.2",
- "reqwest",
+ "reqwest 0.12.25",
  "serde",
  "serde_json",
  "thiserror 2.0.16",
@@ -4174,7 +4174,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.0",
- "system-configuration",
+ "system-configuration 0.6.1",
  "tokio",
  "tower-service",
  "tracing",
@@ -4494,7 +4494,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5032,7 +5032,7 @@ dependencies = [
  "log",
  "object_store",
  "rand 0.9.2",
- "reqwest",
+ "reqwest 0.12.25",
  "serde",
  "serde_json",
  "snafu 0.9.0",
@@ -5048,7 +5048,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee2e48de899e2931afb67fcddd0a08e439bf5d8b6ea2a2ed9cb8f4df669bd5cc"
 dependencies = [
- "reqwest",
+ "reqwest 0.12.25",
  "serde",
  "serde_json",
  "serde_repr",
@@ -5169,7 +5169,7 @@ dependencies = [
  "polars-arrow",
  "rand 0.9.2",
  "regex",
- "reqwest",
+ "reqwest 0.12.25",
  "semver",
  "serde",
  "serde_json",
@@ -5961,9 +5961,9 @@ dependencies = [
  "percent-encoding",
  "quick-xml 0.38.4",
  "rand 0.9.2",
- "reqwest",
+ "reqwest 0.12.25",
  "ring",
- "rustls-pemfile",
+ "rustls-pemfile 2.2.0",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -6055,7 +6055,7 @@ dependencies = [
  "percent-encoding",
  "quick-xml 0.38.4",
  "reqsign",
- "reqwest",
+ "reqwest 0.12.25",
  "serde",
  "serde_json",
  "sha2",
@@ -7608,7 +7608,7 @@ dependencies = [
  "percent-encoding",
  "quick-xml 0.37.5",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.12.25",
  "rsa",
  "rust-ini",
  "serde",
@@ -7616,6 +7616,47 @@ dependencies = [
  "sha1",
  "sha2",
  "tokio",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper-rustls 0.24.2",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls 0.21.12",
+ "rustls-pemfile 1.0.4",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 0.1.2",
+ "system-configuration 0.5.1",
+ "tokio",
+ "tokio-rustls 0.24.1",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 0.25.4",
+ "winreg",
 ]
 
 [[package]]
@@ -7649,7 +7690,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tokio-rustls 0.26.4",
  "tokio-util",
@@ -7676,7 +7717,7 @@ dependencies = [
  "mime",
  "nom 7.1.3",
  "pin-project-lite",
- "reqwest",
+ "reqwest 0.12.25",
  "thiserror 1.0.69",
 ]
 
@@ -7859,6 +7900,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -8484,7 +8534,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8603,6 +8653,12 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -8652,13 +8708,34 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "system-configuration-sys 0.5.0",
+]
+
+[[package]]
+name = "system-configuration"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags 2.10.0",
  "core-foundation 0.9.4",
- "system-configuration-sys",
+ "system-configuration-sys 0.6.0",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -9162,7 +9239,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -9710,6 +9787,12 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
@@ -9929,6 +10012,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -9976,6 +10068,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -10028,6 +10135,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -10046,6 +10159,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -10061,6 +10180,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -10094,6 +10219,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -10109,6 +10240,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -10130,6 +10267,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -10145,6 +10288,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -10165,6 +10314,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -890,7 +890,7 @@ impl fs::FileSystem for CurvineFileSystem {
         }
 
         self.fs_unlock(&handle, LockFlags::Plock).await?;
-        handle.flush(Some(reply)).await
+        handle.flush(&self.state, Some(reply)).await
     }
 
     async fn release(&self, op: Release<'_>, reply: FuseResponse) -> FuseResult<()> {
@@ -1067,7 +1067,7 @@ impl fs::FileSystem for CurvineFileSystem {
             self.ensure_writable_path(&path, RpcCode::CreateFile)
                 .await?;
         }
-        handle.flush(Some(reply)).await?;
+        handle.flush(&self.state, Some(reply)).await?;
 
         if handle.has_writer() {
             self.state

--- a/curvine-fuse/src/fs/dcache/inode.rs
+++ b/curvine-fuse/src/fs/dcache/inode.rs
@@ -16,7 +16,9 @@ use crate::fs::dcache::{DirEntry, Lifecycle};
 use crate::raw::fuse_abi::fuse_attr;
 use crate::{err_fuse, FuseResult, FuseUtils, FUSE_PATH_SEPARATOR, FUSE_ROOT_ID};
 use curvine_common::conf::FuseConf;
-use curvine_common::state::{FileStatus, LocatedBlock, SetAttrOpts, SetAttrOptsBuilder};
+use curvine_common::state::{
+    FileBlocks, FileStatus, LocatedBlock, SetAttrOpts, SetAttrOptsBuilder,
+};
 use orpc::common::LocalTime;
 use orpc::try_option_mut;
 use serde::{Deserialize, Serialize};
@@ -124,6 +126,10 @@ impl Inode {
             let _ = self.dir.take();
         }
 
+        if self.status.mtime != status.mtime || self.status.len != status.len {
+            self.invalidate_file_blocks();
+        }
+
         status.id = self.ino as i64;
         self.status = status;
 
@@ -134,7 +140,34 @@ impl Inode {
     pub fn invalid_cache(&mut self) {
         if matches!(self.lifecycle, Lifecycle::Cached) {
             self.lifecycle = Lifecycle::Invalid;
+            self.invalidate_file_blocks();
         }
+    }
+
+    pub fn get_file_blocks(&self, ttl: u64) -> Option<FileBlocks> {
+        if self.cache_valid(ttl) {
+            self.locs
+                .as_ref()
+                .map(|locs| FileBlocks::new(self.clone_status(), (**locs).clone()))
+        } else {
+            None
+        }
+    }
+
+    pub fn put_file_blocks(&mut self, blocks: &FileBlocks) {
+        self.locs = Some(Box::new(blocks.block_locs.clone()));
+
+        if !self.is_dirty() {
+            self.status = blocks.status.clone();
+            self.status.id = self.ino as i64;
+
+            self.lifecycle = Lifecycle::Cached;
+            self.last_access = LocalTime::mills();
+        }
+    }
+
+    pub fn invalidate_file_blocks(&mut self) {
+        self.locs.take();
     }
 
     pub fn is_root(&self) -> bool {

--- a/curvine-fuse/src/fs/dcache/inode.rs
+++ b/curvine-fuse/src/fs/dcache/inode.rs
@@ -326,3 +326,51 @@ impl DerefMut for Inode {
         &mut self.status
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Inode;
+    use curvine_common::state::{FileBlocks, FileStatus, LocatedBlock};
+
+    fn file_status(len: i64, mtime: i64) -> FileStatus {
+        let mut status = FileStatus::with_name(42, "file".to_owned(), false);
+        status.len = len;
+        status.mtime = mtime;
+        status
+    }
+
+    #[test]
+    fn file_blocks_put_get_and_expire() {
+        let mut inode = Inode::with_status(42, 1, "file", file_status(10, 1));
+        let blocks = FileBlocks::new(file_status(20, 2), vec![LocatedBlock::default()]);
+
+        assert!(inode.get_file_blocks(60_000).is_none());
+
+        inode.put_file_blocks(&blocks);
+        let cached = inode
+            .get_file_blocks(60_000)
+            .expect("put file blocks should make them available");
+        assert_eq!(cached.status.id, 42);
+        assert_eq!(cached.status.name, "file");
+        assert_eq!(cached.status.len, 20);
+        assert_eq!(cached.status.mtime, 2);
+        assert_eq!(cached.block_locs.len(), 1);
+
+        inode.last_access = 0;
+        assert!(inode.get_file_blocks(0).is_none());
+    }
+
+    #[test]
+    fn file_blocks_are_invalidated_explicitly_and_on_status_change() {
+        let mut inode = Inode::with_status(42, 1, "file", file_status(10, 1));
+        let blocks = FileBlocks::new(file_status(10, 1), vec![LocatedBlock::default()]);
+
+        inode.put_file_blocks(&blocks);
+        inode.invalidate_file_blocks();
+        assert!(inode.get_file_blocks(60_000).is_none());
+
+        inode.put_file_blocks(&blocks);
+        inode.update_status(file_status(11, 2));
+        assert!(inode.get_file_blocks(60_000).is_none());
+    }
+}

--- a/curvine-fuse/src/fs/state/backend_handle.rs
+++ b/curvine-fuse/src/fs/state/backend_handle.rs
@@ -121,8 +121,9 @@ impl BackendHandle {
             let writer_ver = writer.write_ver();
             let read_ver = self.read_ver.get();
             if read_ver != writer_ver {
-                writer.flush(None).await?;
+                let result = writer.flush(None).await;
                 state.invalidate_file_blocks(self.ino);
+                result?;
 
                 let path = reader.path().clone();
                 let new_reader = state.open_reader(Some(self.ino), &path).await?;
@@ -169,8 +170,9 @@ impl BackendHandle {
 
     pub async fn flush(&self, state: &NodeState, reply: Option<FuseResponse>) -> FuseResult<()> {
         if let Some(writer) = &self.writer {
-            writer.flush(reply).await?;
+            let result = writer.flush(reply).await;
             state.invalidate_file_blocks(self.ino);
+            result?;
         } else if let Some(reply) = reply {
             reply.send_rep(Ok::<(), FuseError>(())).await?;
         }

--- a/curvine-fuse/src/fs/state/backend_handle.rs
+++ b/curvine-fuse/src/fs/state/backend_handle.rs
@@ -119,11 +119,13 @@ impl BackendHandle {
 
         if let Some(writer) = state.find_writer(self.ino).await {
             let writer_ver = writer.write_ver();
-            if self.read_ver.get() != writer_ver {
+            let read_ver = self.read_ver.get();
+            if read_ver != writer_ver {
                 writer.flush(None).await?;
+                state.invalidate_file_blocks(self.ino);
 
                 let path = reader.path().clone();
-                let new_reader = state.new_reader(&path).await?;
+                let new_reader = state.open_reader(Some(self.ino), &path).await?;
                 // Refresh the handle's status snapshot from the freshly reopened
                 // reader before installing it, so `status()` reflects the current
                 // file (length/mtime) after a dirty-read reopen rather than the
@@ -165,9 +167,10 @@ impl BackendHandle {
         }
     }
 
-    pub async fn flush(&self, reply: Option<FuseResponse>) -> FuseResult<()> {
+    pub async fn flush(&self, state: &NodeState, reply: Option<FuseResponse>) -> FuseResult<()> {
         if let Some(writer) = &self.writer {
             writer.flush(reply).await?;
+            state.invalidate_file_blocks(self.ino);
         } else if let Some(reply) = reply {
             reply.send_rep(Ok::<(), FuseError>(())).await?;
         }
@@ -266,7 +269,7 @@ impl BackendHandle {
         };
 
         let reader = if has_reader {
-            let reader = state.new_reader(&path).await?;
+            let reader = state.open_reader(Some(ino), &path).await?;
             Some(RawPtr::from_owned(reader))
         } else {
             None

--- a/curvine-fuse/src/fs/state/file_handle.rs
+++ b/curvine-fuse/src/fs/state/file_handle.rs
@@ -83,9 +83,9 @@ impl FileHandle {
         }
     }
 
-    pub async fn flush(&self, reply: Option<FuseResponse>) -> FuseResult<()> {
+    pub async fn flush(&self, state: &NodeState, reply: Option<FuseResponse>) -> FuseResult<()> {
         match self {
-            FileHandle::Backend(h) => h.flush(reply).await,
+            FileHandle::Backend(h) => h.flush(state, reply).await,
         }
     }
 

--- a/curvine-fuse/src/fs/state/node_state.rs
+++ b/curvine-fuse/src/fs/state/node_state.rs
@@ -17,21 +17,23 @@ use crate::fs::state::file_handle::FileHandle;
 use crate::fs::state::DirHandle;
 use crate::fs::{FuseReader, FuseWriter};
 use crate::fuse_metrics::{
-    StateStageTimer, CACHE_RESULT_HIT, CACHE_RESULT_MISS, CACHE_RESULT_PUT, CACHE_STATUS,
-    STATE_KIND_DIR_HANDLES, STATE_KIND_FILE_HANDLES, STATE_KIND_NODE_MAP, STATE_STAGE_DIR_HANDLES,
-    STATE_STAGE_FILE_HANDLES, STATE_STAGE_NODE_MAP,
+    StateStageTimer, CACHE_BLOCKS, CACHE_RESULT_HIT, CACHE_RESULT_MISS, CACHE_RESULT_PUT,
+    CACHE_STATUS, STATE_KIND_DIR_HANDLES, STATE_KIND_FILE_HANDLES, STATE_KIND_NODE_MAP,
+    STATE_STAGE_DIR_HANDLES, STATE_STAGE_FILE_HANDLES, STATE_STAGE_NODE_MAP,
 };
 use crate::raw::fuse_abi::{fuse_attr, fuse_forget_one};
 use crate::{
     err_fuse, FuseError, FuseMetrics, FuseResult, FuseUtils, FUSE_CURRENT_DIR, FUSE_PARENT_DIR,
     FUSE_ROOT_ID, STATE_FILE_MAGIC, STATE_FILE_VERSION,
 };
-use curvine_client::unified::UnifiedFileSystem;
+use curvine_client::file::FsReader;
+use curvine_client::unified::{UnifiedFileSystem, UnifiedReader};
 use curvine_common::conf::{ClientConf, ClusterConf, FuseConf};
 use curvine_common::error::FsError;
 use curvine_common::fs::{FileSystem, ListStream, Path, StateReader, StateWriter};
 use curvine_common::state::{
-    CreateFileOpts, FileAllocOpts, FileStatus, ListOptions, MkdirOpts, OpenFlags, SetAttrOpts,
+    CreateFileOpts, FileAllocOpts, FileBlocks, FileStatus, ListOptions, MkdirOpts, OpenFlags,
+    SetAttrOpts,
 };
 use futures::stream::{self, StreamExt};
 use log::{debug, error, info, warn};
@@ -369,15 +371,58 @@ impl NodeState {
         )))
     }
 
-    pub async fn new_reader(&self, path: &Path) -> FuseResult<FuseReader> {
-        let reader = self.fs.open(path).await?;
-        let reader = FuseReader::new(&self.conf, self.fs.clone_runtime(), reader);
-        Ok(reader)
+    fn get_file_blocks(&self, ino: Option<u64>) -> Option<FileBlocks> {
+        if !self.enable_meta_cache {
+            return None;
+        }
+        let ino = ino?;
+        self.dir_read()
+            .get_inode(ino, None)
+            .and_then(|inode| inode.get_file_blocks(self.meta_cache_ttl))
+    }
+
+    fn wrap_reader(&self, unified: UnifiedReader) -> FuseReader {
+        FuseReader::new(&self.conf, self.fs.clone_runtime(), unified)
+    }
+
+    fn put_file_blocks(&self, ino: u64, blocks: &FileBlocks) {
+        if let Some(inode) = self.dir_write().get_inode_mut(ino, None) {
+            inode.put_file_blocks(blocks);
+            self.record_blocks_cache(CACHE_RESULT_PUT);
+        }
+    }
+
+    pub fn invalidate_file_blocks(&self, ino: u64) {
+        if let Some(inode) = self.dir_write().get_inode_mut(ino, None) {
+            inode.invalidate_file_blocks();
+        }
+    }
+
+    pub async fn open_reader(&self, ino: Option<u64>, path: &Path) -> FuseResult<FuseReader> {
+        if let Some(blocks) = self.get_file_blocks(ino) {
+            self.record_blocks_cache(CACHE_RESULT_HIT);
+            let unified = UnifiedReader::Cv(FsReader::new(
+                path.clone(),
+                self.fs.fs_context().clone(),
+                blocks,
+            )?);
+            return Ok(self.wrap_reader(unified));
+        }
+
+        self.record_blocks_cache(CACHE_RESULT_MISS);
+        let unified = self.fs.open(path).await?;
+        if self.enable_meta_cache {
+            if let (Some(ino), UnifiedReader::Cv(reader)) = (ino, &unified) {
+                self.put_file_blocks(ino, reader.file_blocks());
+            }
+        }
+        Ok(self.wrap_reader(unified))
     }
 
     pub async fn flush_writer(&self, ino: u64) -> FuseResult<()> {
         if let Some(existing_writer) = self.find_writer(ino).await {
             existing_writer.flush(None).await?;
+            self.invalidate_file_blocks(ino);
         }
         Ok(())
     }
@@ -393,7 +438,7 @@ impl NodeState {
 
         // Read-only: only a reader, no writer to register in the writers map.
         if mode == OpenFlags::RDONLY {
-            let reader = self.new_reader(path).await?;
+            let reader = self.open_reader(ino, path).await?;
             let mut status = reader.status().clone();
             let ino = ino.unwrap_or(self.next_ino(&status));
             status.id = ino as i64;
@@ -436,7 +481,7 @@ impl NodeState {
                 );
                 None
             } else {
-                let reader = self.new_reader(path).await?;
+                let reader = self.open_reader(Some(ino), path).await?;
                 Some(RawPtr::from_owned(reader))
             }
         } else {
@@ -589,7 +634,7 @@ impl NodeState {
                     .await;
 
                 if !released {
-                    handle.flush(None).await
+                    handle.flush(self, None).await
                 } else {
                     res
                 }
@@ -781,6 +826,12 @@ impl NodeState {
     fn record_status_cache(&self, status: &'static str) {
         if self.conf.metrics_enabled {
             FuseMetrics::with(|m| m.record_user_meta_cache(CACHE_STATUS, status));
+        }
+    }
+
+    fn record_blocks_cache(&self, status: &'static str) {
+        if self.conf.metrics_enabled {
+            FuseMetrics::with(|m| m.record_user_meta_cache(CACHE_BLOCKS, status));
         }
     }
 

--- a/curvine-fuse/src/fs/state/node_state.rs
+++ b/curvine-fuse/src/fs/state/node_state.rs
@@ -409,7 +409,9 @@ impl NodeState {
             return Ok(self.wrap_reader(unified));
         }
 
-        self.record_blocks_cache(CACHE_RESULT_MISS);
+        if self.enable_meta_cache {
+            self.record_blocks_cache(CACHE_RESULT_MISS);
+        }
         let unified = self.fs.open(path).await?;
         if self.enable_meta_cache {
             if let (Some(ino), UnifiedReader::Cv(reader)) = (ino, &unified) {
@@ -421,8 +423,9 @@ impl NodeState {
 
     pub async fn flush_writer(&self, ino: u64) -> FuseResult<()> {
         if let Some(existing_writer) = self.find_writer(ino).await {
-            existing_writer.flush(None).await?;
+            let result = existing_writer.flush(None).await;
             self.invalidate_file_blocks(ino);
+            result?;
         }
         Ok(())
     }


### PR DESCRIPTION
# Summary

Reuse cached Curvine file block metadata when FUSE opens or reopens readers. This avoids repeated metadata lookups while preserving correctness by invalidating cached block locations after file metadata changes and writer flushes.

The change intentionally keeps only the backend file-handle path. The removed write-back `CacheHandle` implementation is not restored.

# Issue Describe / Design

No linked issue.

Reader creation previously called the unified filesystem open path every time, even when the inode dcache already held valid file status and block-location metadata. Reopening a reader after a local writer changed the file also required explicit coordination so cached locations could not outlive the data they describe.

The implementation adds a block-metadata layer to the existing inode cache:

- Reconstruct `FileBlocks` from a valid inode dcache entry and build `FsReader` directly on a cache hit.
- Populate the inode block cache after a normal Curvine reader open.
- Invalidate cached blocks when inode length or modification time changes.
- Invalidate cached blocks after writer flushes and before reopening readers against newly persisted data.
- Record block-cache hit, miss, and put events through the existing FUSE metadata-cache metrics.
- Preserve the backend handle implementation and exclude the removed write-back `CacheHandle` path.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-fuse/src/fs/dcache/inode.rs` | Store, retrieve, and invalidate `FileBlocks` alongside cached inode metadata | Valid cached block locations can be reused; stale locations are discarded |
| `curvine-fuse/src/fs/state/node_state.rs` | Add cache-aware reader opening, block-cache population/invalidation, and metrics | Reduces repeated metadata opens while tracking cache effectiveness |
| `curvine-fuse/src/fs/state/backend_handle.rs` | Reopen readers through the cache-aware path and invalidate blocks after flush | Reader snapshots remain consistent with writer updates |
| `curvine-fuse/src/fs/state/file_handle.rs` | Pass `NodeState` through backend flush handling | Enables centralized block-cache invalidation without restoring write-back handles |
| `curvine-fuse/src/fs/curvine_file_system.rs` | Supply node state during flush and fsync paths | Preserves existing flush behavior while invalidating stale block metadata |
| `Cargo.lock` | Refresh resolved transitive dependency entries carried by the source commit | No intended runtime behavior change |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo fmt --all -- --check` | PASS | Formatting is clean |
| `git diff --check open/main...HEAD` | PASS | No whitespace or conflict-marker errors |
| `cargo check -p curvine-fuse --locked --target-dir target-codex-check` | NOT COMPLETED | Windows exhausted the available page file while compiling dependencies (OS error 1455); no change-related source diagnostic was reported |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None