### PR TITLE
fix(fuse): handle fallocate with non-zero offsets

### DIFF
--- a/build/tests/fuse-test.sh
+++ b/build/tests/fuse-test.sh
@@ -913,6 +913,44 @@ test_fallocate() {
         handle_error "Failed to allocate space" "$cmd"
         return
     fi
+
+    # Test 2: A non-zero offset past EOF extends the logical file size.
+    local range_file="$TEST_DIR/fallocate_offset_test.txt"
+    local initial_size=4096
+    local range_len=4096
+    truncate -s "$initial_size" "$range_file"
+    print_test "Allocating a range from a non-zero EOF offset"
+    TOTAL_TESTS=$((TOTAL_TESTS + 1))
+    cmd="fallocate -o $initial_size -l $range_len $range_file"
+    print_command "$cmd"
+    if eval "$cmd"; then
+        file_size=$(stat -f%z "$range_file" 2>/dev/null || stat -c%s "$range_file")
+        if [ "$file_size" -eq $((initial_size + range_len)) ]; then
+            print_success "Non-zero-offset fallocate extended the file successfully"
+        else
+            handle_error "Non-zero-offset fallocate returned the wrong size: $file_size" "$cmd"
+        fi
+    else
+        handle_error "Non-zero-offset fallocate failed" "$cmd"
+    fi
+
+    # Test 3: KEEP_SIZE accepts the same range without exposing a larger st_size.
+    local keep_size_file="$TEST_DIR/fallocate_keep_size_test.txt"
+    truncate -s "$initial_size" "$keep_size_file"
+    print_test "Allocating a non-zero-offset range with KEEP_SIZE"
+    TOTAL_TESTS=$((TOTAL_TESTS + 1))
+    cmd="fallocate -n -o $initial_size -l $range_len $keep_size_file"
+    print_command "$cmd"
+    if eval "$cmd"; then
+        file_size=$(stat -f%z "$keep_size_file" 2>/dev/null || stat -c%s "$keep_size_file")
+        if [ "$file_size" -eq "$initial_size" ]; then
+            print_success "KEEP_SIZE preserved the logical file size"
+        else
+            handle_error "KEEP_SIZE changed the file size to $file_size" "$cmd"
+        fi
+    else
+        handle_error "KEEP_SIZE fallocate failed" "$cmd"
+    fi
 }
 
 # Test 12: File locks (POSIX and BSD locks)

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -32,6 +32,7 @@ use curvine_common::state::{
     FileAllocMode, FileAllocOpts, FileLock, FileStatus, FileType, LockFlags, LockType, OpenFlags,
     SetAttrOpts,
 };
+use curvine_common::MAX_FILE_SIZE;
 use log::{debug, info, warn};
 use orpc::common::{ByteUnit, TimeSpent};
 use orpc::runtime::Runtime;
@@ -67,6 +68,78 @@ impl CurvineFileSystem {
 
     pub fn conf(&self) -> &FuseConf {
         &self.conf
+    }
+
+    fn normalize_fallocate(
+        current_len: i64,
+        offset: u64,
+        length: u64,
+        raw_mode: u32,
+    ) -> FuseResult<Option<FileAllocOpts>> {
+        if length == 0 {
+            return err_fuse!(libc::EINVAL, "fallocate length must be greater than zero");
+        }
+
+        let mode = match FileAllocMode::from_bits(raw_mode as i32) {
+            Some(mode) => mode,
+            None => {
+                return err_fuse!(
+                    libc::EOPNOTSUPP,
+                    "unsupported fallocate mode: {:#x}",
+                    raw_mode
+                )
+            }
+        };
+        // The backend resize API only accepts a target file length and cannot
+        // preserve the byte range required by ZERO_RANGE.
+        let allowed = FileAllocMode::DEFAULT | FileAllocMode::KEEP_SIZE;
+        if !(mode & !allowed).is_empty() {
+            return err_fuse!(
+                libc::EOPNOTSUPP,
+                "unsupported fallocate mode: {:#x}",
+                raw_mode
+            );
+        }
+
+        let offset = match i64::try_from(offset) {
+            Ok(offset) => offset,
+            Err(_) => return err_fuse!(libc::EFBIG, "fallocate offset exceeds supported size"),
+        };
+        let length = match i64::try_from(length) {
+            Ok(length) => length,
+            Err(_) => return err_fuse!(libc::EFBIG, "fallocate length exceeds supported size"),
+        };
+        let end = match offset.checked_add(length) {
+            Some(end) => end,
+            None => return err_fuse!(libc::EFBIG, "fallocate range overflows"),
+        };
+        if end > MAX_FILE_SIZE {
+            return err_fuse!(
+                libc::EFBIG,
+                "fallocate end {} exceeds maximum file size {}",
+                end,
+                MAX_FILE_SIZE
+            );
+        }
+
+        // Curvine allocates storage lazily across the cluster, so KEEP_SIZE has
+        // no logical metadata change to apply. Writes into the range still
+        // allocate blocks normally without exposing a larger st_size early.
+        if mode.contains(FileAllocMode::KEEP_SIZE) {
+            return Ok(None);
+        }
+
+        let target_len = current_len.max(end);
+        if target_len == current_len {
+            return Ok(None);
+        }
+
+        Ok(Some(FileAllocOpts {
+            truncate: false,
+            off: 0,
+            len: target_len,
+            mode,
+        }))
     }
 
     pub(crate) fn fs(&self) -> &UnifiedFileSystem {
@@ -720,11 +793,18 @@ impl fs::FileSystem for CurvineFileSystem {
         self.ensure_writable_path(&path, RpcCode::ResizeFile)
             .await?;
 
-        let opts = FileAllocOpts {
-            truncate: false,
-            off: op.arg.offset as i64,
-            len: op.arg.length as i64,
-            mode: FileAllocMode::from_bits_truncate(op.arg.mode as i32),
+        let status = self.state.fs_stat(op.header.nodeid, None).await?;
+        let writer_len = self
+            .state
+            .get_writer_len(op.header.nodeid)
+            .await
+            .map(|len| len as i64)
+            .unwrap_or(status.len);
+        let current_len = status.len.max(writer_len);
+        let Some(opts) =
+            Self::normalize_fallocate(current_len, op.arg.offset, op.arg.length, op.arg.mode)?
+        else {
+            return Ok(());
         };
 
         self.state
@@ -1210,6 +1290,58 @@ impl fs::FileSystem for CurvineFileSystem {
 
 #[cfg(test)]
 mod tests {
+    use super::CurvineFileSystem;
+    use curvine_common::state::FileAllocMode;
+
+    #[test]
+    fn fallocate_default_converts_range_to_target_length() {
+        let opts = CurvineFileSystem::normalize_fallocate(4096, 4096, 4096, 0)
+            .unwrap()
+            .unwrap();
+        assert_eq!(opts.off, 0);
+        assert_eq!(opts.len, 8192);
+        assert_eq!(opts.mode, FileAllocMode::DEFAULT);
+    }
+
+    #[test]
+    fn fallocate_inside_file_does_not_shrink_it() {
+        let opts = CurvineFileSystem::normalize_fallocate(8192, 1024, 4096, 0).unwrap();
+        assert!(opts.is_none());
+    }
+
+    #[test]
+    fn fallocate_keep_size_preserves_logical_length() {
+        let opts = CurvineFileSystem::normalize_fallocate(
+            4096,
+            4096,
+            4096,
+            FileAllocMode::KEEP_SIZE.bits() as u32,
+        )
+        .unwrap();
+        assert!(opts.is_none());
+    }
+
+    #[test]
+    fn fallocate_rejects_invalid_ranges_and_modes() {
+        let zero_len = CurvineFileSystem::normalize_fallocate(0, 0, 0, 0).unwrap_err();
+        assert_eq!(zero_len.errno, libc::EINVAL);
+
+        let too_large = CurvineFileSystem::normalize_fallocate(0, u64::MAX, 1, 0).unwrap_err();
+        assert_eq!(too_large.errno, libc::EFBIG);
+
+        let unsupported = CurvineFileSystem::normalize_fallocate(0, 0, 4096, 0x02).unwrap_err();
+        assert_eq!(unsupported.errno, libc::EOPNOTSUPP);
+
+        let zero_range = CurvineFileSystem::normalize_fallocate(
+            8192,
+            4096,
+            4096,
+            FileAllocMode::ZERO_RANGE.bits() as u32,
+        )
+        .unwrap_err();
+        assert_eq!(zero_range.errno, libc::EOPNOTSUPP);
+    }
+
     /// Pin the production init-order invariant that Phase 1b-2 depends on:
     /// `FuseMetrics::ensure_init()` MUST run before `NodeState::new()` in
     /// `CurvineFileSystem::new`. After 1b-2 removed the scrape-time

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -1290,12 +1290,11 @@ impl fs::FileSystem for CurvineFileSystem {
 
 #[cfg(test)]
 mod tests {
-    use super::CurvineFileSystem;
     use curvine_common::state::FileAllocMode;
 
     #[test]
     fn fallocate_default_converts_range_to_target_length() {
-        let opts = CurvineFileSystem::normalize_fallocate(4096, 4096, 4096, 0)
+        let opts = super::CurvineFileSystem::normalize_fallocate(4096, 4096, 4096, 0)
             .unwrap()
             .unwrap();
         assert_eq!(opts.off, 0);
@@ -1305,13 +1304,13 @@ mod tests {
 
     #[test]
     fn fallocate_inside_file_does_not_shrink_it() {
-        let opts = CurvineFileSystem::normalize_fallocate(8192, 1024, 4096, 0).unwrap();
+        let opts = super::CurvineFileSystem::normalize_fallocate(8192, 1024, 4096, 0).unwrap();
         assert!(opts.is_none());
     }
 
     #[test]
     fn fallocate_keep_size_preserves_logical_length() {
-        let opts = CurvineFileSystem::normalize_fallocate(
+        let opts = super::CurvineFileSystem::normalize_fallocate(
             4096,
             4096,
             4096,
@@ -1323,16 +1322,18 @@ mod tests {
 
     #[test]
     fn fallocate_rejects_invalid_ranges_and_modes() {
-        let zero_len = CurvineFileSystem::normalize_fallocate(0, 0, 0, 0).unwrap_err();
+        let zero_len = super::CurvineFileSystem::normalize_fallocate(0, 0, 0, 0).unwrap_err();
         assert_eq!(zero_len.errno, libc::EINVAL);
 
-        let too_large = CurvineFileSystem::normalize_fallocate(0, u64::MAX, 1, 0).unwrap_err();
+        let too_large =
+            super::CurvineFileSystem::normalize_fallocate(0, u64::MAX, 1, 0).unwrap_err();
         assert_eq!(too_large.errno, libc::EFBIG);
 
-        let unsupported = CurvineFileSystem::normalize_fallocate(0, 0, 4096, 0x02).unwrap_err();
+        let unsupported =
+            super::CurvineFileSystem::normalize_fallocate(0, 0, 4096, 0x02).unwrap_err();
         assert_eq!(unsupported.errno, libc::EOPNOTSUPP);
 
-        let zero_range = CurvineFileSystem::normalize_fallocate(
+        let zero_range = super::CurvineFileSystem::normalize_fallocate(
             8192,
             4096,
             4096,


### PR DESCRIPTION
**Summary**

Fix valid FUSE `fallocate()` calls returning `EIO` when the allocation range starts at a non-zero offset.

Curvine forwarded the POSIX `offset` and `length` directly into an internal resize API that only accepted `offset == 0` and interpreted `length` as the final file size. As a result, allocating a range at EOF or inside an existing file failed before reaching the resize path.

The fix normalizes the POSIX range into Curvine's target-length representation, preserves the current file size for ranges already covered by the file, and handles `FALLOC_FL_KEEP_SIZE` without exposing a larger logical size.

**Minimal Reproducer**

```c
#define _GNU_SOURCE

#include <errno.h>
#include <fcntl.h>
#include <linux/falloc.h>
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <sys/stat.h>
#include <unistd.h>

#define INITIAL_SIZE 4096
#define ALLOC_LEN 4096

static void die(const char *what)
{
    fprintf(stderr, "FAIL: %s: errno=%d (%s)\n",
            what, errno, strerror(errno));
    exit(EXIT_FAILURE);
}

int main(int argc, char **argv)
{
    const char *path;
    int mode = 0;
    int fd;
    struct stat st;
    off_t offset;
    off_t expected_size;

    if (argc < 2 || argc > 3) {
        fprintf(stderr, "Usage: %s FILE [keep-size]\n", argv[0]);
        return 2;
    }

    path = argv[1];
    if (argc == 3) {
        if (strcmp(argv[2], "keep-size") != 0) {
            fprintf(stderr, "Unknown mode: %s\n", argv[2]);
            return 2;
        }
        mode = FALLOC_FL_KEEP_SIZE;
    }

    unlink(path);
    fd = open(path, O_RDWR | O_CREAT | O_TRUNC, 0700);
    if (fd == -1)
        die("open");

    if (ftruncate(fd, INITIAL_SIZE) == -1)
        die("ftruncate");

    if (fstat(fd, &st) == -1)
        die("fstat before fallocate");

    offset = st.st_size;
    expected_size = mode == FALLOC_FL_KEEP_SIZE
                    ? st.st_size
                    : st.st_size + ALLOC_LEN;

    if (fallocate(fd, mode, offset, ALLOC_LEN) == -1) {
        fprintf(stderr,
                "FAIL: fallocate(mode=%d, offset=%lld, len=%d): "
                "errno=%d (%s)\n",
                mode, (long long)offset, ALLOC_LEN,
                errno, strerror(errno));
        close(fd);
        unlink(path);
        return EXIT_FAILURE;
    }

    if (fstat(fd, &st) == -1)
        die("fstat after fallocate");

    if (st.st_size != expected_size) {
        fprintf(stderr, "FAIL: size=%lld, expected=%lld\n",
                (long long)st.st_size, (long long)expected_size);
        close(fd);
        unlink(path);
        return EXIT_FAILURE;
    }

    printf("PASS: fallocate(mode=%d, offset=%lld, len=%d), size=%lld\n",
           mode, (long long)offset, ALLOC_LEN, (long long)st.st_size);

    close(fd);
    unlink(path);
    return EXIT_SUCCESS;
}
```

Run both supported modes on a Curvine FUSE mount:

```bash
gcc -Wall -Wextra -O2 /tmp/fallocate_repro.c -o /tmp/fallocate_repro
/tmp/fallocate_repro /mnt/curvine/fallocate-default-repro
/tmp/fallocate_repro /mnt/curvine/fallocate-keep-repro keep-size
```

Before the fix, both calls failed with `EIO`:

```text
FAIL: fallocate(mode=0, offset=4096, len=4096): errno=5 (Input/output error)
FAIL: fallocate(mode=1, offset=4096, len=4096): errno=5 (Input/output error)
```

**Root Cause**

The FUSE request provides a POSIX allocation range as `offset` plus `length`. Curvine's internal `FileAllocOpts` resize path uses a different representation:

- `off` was required to be zero.
- `len` represented the target logical file length, not the range length.

The FUSE handler copied the request fields directly:

```text
off = offset
len = length
```

For any valid non-zero offset, `FileAllocOpts::validate()` rejected the operation. The internal error was then returned through FUSE as `EIO`.

Removing only the zero-offset validation would not be sufficient. For example, allocating `[4096, 8192)` requires a target length of 8192, while passing `len = 4096` could leave the file unchanged or even route the operation as a shrink when the existing file was larger.

The handler also needs the latest active-writer length. Master metadata may lag behind bytes already accepted by an open writer, so calculating the target from Master state alone could still produce an incorrect file size.

`FALLOC_FL_KEEP_SIZE` requires that the allocation endpoint is not exposed through `st_size`. Curvine allocates distributed storage lazily when data is written, so this mode does not need a logical metadata resize; writes into the requested range continue to allocate blocks normally.

**Changes**

- Validate zero-length, overflowing, oversized, and unsupported allocation ranges at the FUSE boundary with appropriate errno values.
- Calculate the allocation endpoint with checked `offset + length` arithmetic.
- Merge Master file length with the active writer length before normalizing the request.
- Convert default allocation ranges extending past EOF into an internal zero-offset target-length resize.
- Return success without shrinking the file when the requested range is already inside the current logical size.
- Preserve logical file size for `FALLOC_FL_KEEP_SIZE` under Curvine's lazy allocation model.
- Add unit tests covering EOF extension, allocation inside an existing file, `KEEP_SIZE`, invalid ranges, and unsupported modes.
- Add FUSE regression cases for non-zero-offset default and `KEEP_SIZE` allocations.

**Verification**

- Minimal C reproducer passes in default mode with the file growing from 4096 to 8192 bytes.
- Minimal C reproducer passes with `FALLOC_FL_KEEP_SIZE` and the file remaining 4096 bytes.
- Valid non-zero-offset allocations inside sparse and existing file ranges succeed.
- Invalid descriptors, zero lengths, negative ranges, oversized ranges, and unsupported modes retain their expected errno behavior.
- Targeted fallocate unit tests pass: `4 passed, 0 failed`.
- `cargo fmt --check` passes.
- `cargo build --locked --release -p curvine-fuse` passes.
- `git diff --check` passes.
