### PR TITLE
fix(conf): reject conflicting direct_io + write_back_cache in FuseConf (#1125)

### DIFF
--- a/curvine-common/src/conf/fuse_conf.rs
+++ b/curvine-common/src/conf/fuse_conf.rs
@@ -47,7 +47,7 @@ use std::time::Duration;
 //    - `open_direct_on_stale` -> per-open fallback to direct I/O only when the
 //      local metadata is detected stale (weaker global impact than `direct_io`).
 //    - `write_back_cache`     -> let the kernel buffer writes (write-back) vs
-//      write-through; interacts with `direct_io` (direct I/O disables it).
+//      write-through; conflicts with `direct_io` and is rejected by `init()`.
 //
 // Rule of thumb: layer 1 tunes how stale the *kernel* may be, layer 2 tunes the
 // process-local metadata caches, and layer 3 decides whether file *data* flows
@@ -265,6 +265,16 @@ impl FuseConf {
 
         if let Some(0) = self.max_readahead_kb {
             return err_box!("fuse.max_readahead_kb must be > 0 when set");
+        }
+
+        // direct_io bypasses the page cache; write_back_cache relies on the kernel
+        // buffering writes in that same page cache. Enabling both is semantically
+        // conflicting, so reject it rather than silently letting one win.
+        if self.direct_io && self.write_back_cache {
+            return err_box!(
+                "fuse.direct_io and fuse.write_back_cache cannot both be enabled: \
+                 direct I/O bypasses the page cache that write-back caching depends on"
+            );
         }
 
         Ok(())
@@ -570,6 +580,44 @@ mod tests {
         };
         conf.init().expect("positive value must be accepted");
         assert_eq!(conf.max_readahead_kb, Some(1024));
+    }
+
+    #[test]
+    fn init_rejects_direct_io_with_write_back_cache() {
+        let mut conf = FuseConf {
+            direct_io: true,
+            write_back_cache: true,
+            ..Default::default()
+        };
+        let err = conf
+            .init()
+            .expect_err("direct_io + write_back_cache must be rejected");
+        assert!(
+            err.to_string().contains("direct_io") && err.to_string().contains("write_back_cache"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn init_allows_direct_io_alone() {
+        let mut conf = FuseConf {
+            direct_io: true,
+            write_back_cache: false,
+            ..Default::default()
+        };
+        conf.init().expect("direct_io alone must be accepted");
+    }
+
+    #[test]
+    fn init_allows_write_back_cache_alone() {
+        let mut conf = FuseConf {
+            direct_io: false,
+            write_back_cache: true,
+            ..Default::default()
+        };
+        conf.init()
+            .expect("write_back_cache alone must be accepted");
     }
 
     #[test]


### PR DESCRIPTION
# Summary

`FuseConf::init` performed no cross-field validation of the cache/IO switches, so the semantically conflicting combination `direct_io = true` + `write_back_cache = true` was silently accepted. This adds a startup-time reject for that combination.

# Issue Describe / Design

Closes #1125

`direct_io` sets the per-open `FUSE_FOPEN_DIRECT_IO` flag (`fuse_utils.rs`, bypassing the page cache), while `write_back_cache` negotiates `FUSE_WRITEBACK_CACHE` (`curvine_file_system.rs`, which relies on the kernel buffering writes in that same page cache). Enabling both is contradictory. Both are global switches, and both the TOML load path (`ClusterConf::from` → `fuse.init()`) and the CLI path (`get_conf` → `fuse.init()`) funnel through `init()`, so a single check there covers every entry point.

Fix: reject the combination in `init()` with `err_box!`, matching the existing `io_threads` / `max_readahead_kb` validations, so a bad config fails the mount at startup with a clear message instead of producing contradictory kernel behavior. Also corrected the stale doc comment that claimed "direct I/O disables it" (the code never disabled `write_back_cache`; it is now rejected).

## Scope — what this PR intentionally does NOT do

Issue #1125 lists three combinations; this PR addresses only the first, which is the sole true semantic conflict. The others were analyzed and deliberately deferred:

- **(2) `direct_io && open_direct_on_stale`** — the issue calls this a "dead config" and suggests a warning. On inspection this is a *harmless redundancy*, not a conflict: `file_open_flags` (`fuse_utils.rs`) is an `if direct_io { DIRECT_IO } else if keep_cache { KEEP_CACHE } else if open_direct_on_stale { DIRECT_IO }` chain. Under `direct_io = true` the first branch already yields full direct I/O, which strictly satisfies `open_direct_on_stale`'s "fall back to direct I/O when stale" intent — the final flag is `DIRECT_IO` either way, so behavior is correct and safe. No warning is added: the priority is already handled correctly, and `init()` runs during config load (likely before the logger is initialized), so a `log::warn!` there would probably be swallowed.
- **(3) `cache_readdir` directory invalidation** — this is a functional correctness concern about directory-change invalidation, not a config-combination conflict that `init()` can validate. Out of scope here.
- **`write_back_cache` gating** — the issue notes `write_back_cache` interacts with flush/fsync/release semantics and should stay gated until that path is complete. This PR neither fixes nor regresses `write_back_cache`'s own completeness; the `init_allows_write_back_cache_alone` test only asserts the new reject does not misfire on single-switch use, not that `write_back_cache` alone is feature-complete.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-common/src/conf/fuse_conf.rs` | `init()` rejects `direct_io && write_back_cache` via `err_box!`; fix stale doc comment; add 3 tests | A config with both switches now fails at startup (previously silently accepted); single-switch configs unaffected |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `init_rejects_direct_io_with_write_back_cache` | PASS | both enabled → `init()` returns Err |
| `init_allows_direct_io_alone` | PASS | regression: direct_io alone still Ok |
| `init_allows_write_back_cache_alone` | PASS | regression: write_back_cache alone still Ok |
| `cargo test -p curvine-common --lib -- fuse_conf` | PASS | 7 init tests pass, no regressions |
| `cargo clippy -p curvine-common --lib` | PASS | no warnings |
| `cargo fmt --check` | PASS | |

# Dependencies

- Related PRs: None
- Related issues: #1088 (init capability allowlist, for the `FUSE_WRITEBACK_CACHE` negotiation side)
- Blocks / blocked by: None
