### PR TITLE
feat(conf): add net_interface to auto-resolve node IPv4 from a NIC

### DIFF
--- a/curvine-common/Cargo.toml
+++ b/curvine-common/Cargo.toml
@@ -48,6 +48,10 @@ anyhow = { workspace = true }
 tracing = { workspace = true }
 bitflags = { workspace = true }
 
+# Enumerate network interface addresses (getifaddrs) to resolve the local IPv4
+# from a named interface such as `eth0`. `net` feature adds the ifaddrs API.
+nix = { workspace = true, features = ["net"] }
+
 mimalloc = { workspace = true, optional = true }
 
 [target.'cfg(unix)'.dependencies]

--- a/curvine-common/src/conf/cluster_conf.rs
+++ b/curvine-common/src/conf/cluster_conf.rs
@@ -100,6 +100,27 @@ impl ClusterConf {
         // interface honors the per-role hostname env-var overrides instead.
         if !conf.net_interface.is_empty() {
             let ip = Self::interface_ipv4(&conf.net_interface)?;
+
+            // net_interface takes precedence over the CURVINE_*_HOSTNAME env
+            // vars. Warn (rather than silently ignore) when any of them is also
+            // set, so an operator who exported a hostname override but sees it
+            // have no effect can tell why. `from()` runs during config loading,
+            // before `Logger::init`, so the log macros would be dropped — use
+            // eprintln! to make the warning visible on stderr.
+            for env_key in [
+                Self::ENV_MASTER_HOSTNAME,
+                Self::ENV_WORKER_HOSTNAME,
+                Self::ENV_CLIENT_HOSTNAME,
+            ] {
+                if let Ok(v) = env::var(env_key) {
+                    eprintln!(
+                        "[WARN] net_interface '{}' is set (resolved to {}); ignoring {}='{}'. \
+                         net_interface overrides the CURVINE_*_HOSTNAME env vars.",
+                        conf.net_interface, ip, env_key, v
+                    );
+                }
+            }
+
             conf.master.hostname = ip.clone();
             conf.journal.hostname = ip.clone();
             conf.worker.hostname = ip.clone();

--- a/curvine-common/src/conf/cluster_conf.rs
+++ b/curvine-common/src/conf/cluster_conf.rs
@@ -401,6 +401,7 @@ mod tests {
     // journal address (journal.hostname:rpc_port) resolves to a node id in
     // journal_addrs. When journal_addrs contains a matching entry, it passes.
     #[test]
+    #[allow(clippy::field_reassign_with_default)]
     fn check_master_hostname_net_interface_matching_journal_addr_ok() {
         let mut conf = ClusterConf::default();
         conf.net_interface = "eth0".to_string();
@@ -418,6 +419,7 @@ mod tests {
     // journal_addrs, node_id resolution fails and check_master_hostname must
     // surface a clear error instead of deferring to an opaque raft failure.
     #[test]
+    #[allow(clippy::field_reassign_with_default)]
     fn check_master_hostname_net_interface_missing_journal_addr_errors() {
         let mut conf = ClusterConf::default();
         conf.net_interface = "eth0".to_string();

--- a/curvine-common/src/conf/cluster_conf.rs
+++ b/curvine-common/src/conf/cluster_conf.rs
@@ -20,6 +20,7 @@ use crate::conf::{
 use crate::rocksdb::DBConf;
 use crate::version;
 use log::info;
+use nix::ifaddrs::getifaddrs;
 use orpc::client::{ClientConf as RpcConf, ClientFactory, SyncClient};
 use orpc::common::{LogConf, Utils};
 use orpc::io::net::{InetAddr, NodeAddr};
@@ -44,6 +45,11 @@ pub struct ClusterConf {
     pub testing: bool,
 
     pub cluster_id: String,
+
+    /// Network interface (e.g. `eth0`) used to resolve the local IPv4 address
+    /// that is applied to the master/journal/worker/client hostnames. Empty by
+    /// default: when empty, the original hostname configuration is kept as-is.
+    pub net_interface: String,
 
     pub master: MasterConf,
 
@@ -88,19 +94,31 @@ impl ClusterConf {
         let str = try_err!(read_to_string(path.as_ref()));
         let mut conf = try_err!(toml::from_str::<Self>(&str));
 
-        if let Ok(v) = env::var(Self::ENV_MASTER_HOSTNAME) {
-            conf.master.hostname = v.to_owned();
-            conf.journal.hostname = v;
-        }
+        // Hostname resolution is either/or. A configured network interface
+        // (non-empty, e.g. `eth0`) wins: resolve its local IPv4 and apply it to
+        // every role hostname, ignoring the hostname env vars. An empty
+        // interface honors the per-role hostname env-var overrides instead.
+        if !conf.net_interface.is_empty() {
+            let ip = Self::interface_ipv4(&conf.net_interface)?;
+            conf.master.hostname = ip.clone();
+            conf.journal.hostname = ip.clone();
+            conf.worker.hostname = ip.clone();
+            conf.client.hostname = ip;
+        } else {
+            if let Ok(v) = env::var(Self::ENV_MASTER_HOSTNAME) {
+                conf.master.hostname = v.to_owned();
+                conf.journal.hostname = v;
+            }
 
-        // Apply worker hostname from environment variable (used by worker process)
-        if let Ok(v) = env::var(Self::ENV_WORKER_HOSTNAME) {
-            conf.worker.hostname = v;
-        }
+            // Apply worker hostname from environment variable (used by worker process)
+            if let Ok(v) = env::var(Self::ENV_WORKER_HOSTNAME) {
+                conf.worker.hostname = v;
+            }
 
-        // Apply client hostname from environment variable
-        if let Ok(v) = env::var(Self::ENV_CLIENT_HOSTNAME) {
-            conf.client.hostname = v;
+            // Apply client hostname from environment variable
+            if let Ok(v) = env::var(Self::ENV_CLIENT_HOSTNAME) {
+                conf.client.hostname = v;
+            }
         }
 
         conf.master.init()?;
@@ -119,6 +137,32 @@ impl ClusterConf {
     }
 
     pub fn check_master_hostname(&mut self) -> CommonResult<()> {
+        // With `net_interface`, `master.hostname` is the NIC-resolved IPv4, so
+        // validate the property raft actually depends on: the local journal
+        // address must resolve to a node id in `journal_addrs`. Checking it here
+        // turns the otherwise opaque, deep-in-raft "Not a master role" failure
+        // into a clear, actionable startup error.
+        if !self.net_interface.is_empty() {
+            if let Err(e) = self.journal.node_id() {
+                return err_box!(
+                    "net_interface '{}' resolved journal address to '{}', which is not found in \
+                     journal_addrs [{}]. When using net_interface, each node's entry in \
+                     journal_addrs must use the exact IPv4 that the interface resolves to. \
+                     (underlying error: {})",
+                    self.net_interface,
+                    self.journal.local_addr(),
+                    self.journal
+                        .journal_addrs
+                        .iter()
+                        .map(|peer| format!("{}:{}", peer.hostname, peer.port))
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                    e
+                );
+            }
+            return Ok(());
+        }
+
         let hostname_exists = self
             .journal
             .journal_addrs
@@ -277,6 +321,31 @@ impl ClusterConf {
     pub fn to_pretty_toml(&self) -> CommonResult<String> {
         Ok(toml::to_string_pretty(self)?)
     }
+
+    /// Resolve the local IPv4 address bound to the named network interface
+    /// (e.g. `eth0`).
+    ///
+    /// Enumerates the host's interface addresses via `getifaddrs(3)` and returns
+    /// the first IPv4 address whose interface name matches `interface`. Returns
+    /// an error if the interface does not exist or has no IPv4 address assigned
+    /// (an IPv6-only interface yields no match).
+    pub fn interface_ipv4<T: AsRef<str>>(interface: T) -> CommonResult<String> {
+        let interface = interface.as_ref();
+        let addrs = try_err!(getifaddrs());
+        for ifaddr in addrs {
+            if ifaddr.interface_name != interface {
+                continue;
+            }
+            // Only entries carrying an address are relevant; an interface can
+            // also surface broadcast/netmask-only rows we must skip.
+            if let Some(address) = ifaddr.address {
+                if let Some(sin) = address.as_sockaddr_in() {
+                    return Ok(sin.ip().to_string());
+                }
+            }
+        }
+        err_box!("no IPv4 address found on network interface '{}'", interface)
+    }
 }
 
 impl Default for ClusterConf {
@@ -286,6 +355,7 @@ impl Default for ClusterConf {
             format_worker: true,
             testing: false,
             cluster_id: "curvine".to_string(),
+            net_interface: String::new(),
             master: Default::default(),
             journal: Default::default(),
             worker: Default::default(),
@@ -302,5 +372,63 @@ impl Default for ClusterConf {
 impl Display for ClusterConf {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ClusterConf;
+    use crate::raft::RaftPeer;
+
+    // The loopback interface is present on every supported host and always
+    // carries 127.0.0.1, so it is a stable target for the happy path.
+    #[test]
+    fn interface_ipv4_resolves_loopback() {
+        let ip = ClusterConf::interface_ipv4("lo")
+            .expect("loopback interface must resolve to an IPv4 address");
+        assert_eq!(ip, "127.0.0.1");
+    }
+
+    // A non-existent interface has no matching IPv4 entry and must error rather
+    // than silently returning a bogus address.
+    #[test]
+    fn interface_ipv4_unknown_interface_errors() {
+        let res = ClusterConf::interface_ipv4("curvine_no_such_if0");
+        assert!(res.is_err(), "unknown interface must return an error");
+    }
+
+    // With net_interface set, check_master_hostname validates that the local
+    // journal address (journal.hostname:rpc_port) resolves to a node id in
+    // journal_addrs. When journal_addrs contains a matching entry, it passes.
+    #[test]
+    fn check_master_hostname_net_interface_matching_journal_addr_ok() {
+        let mut conf = ClusterConf::default();
+        conf.net_interface = "eth0".to_string();
+        conf.journal.hostname = "10.0.0.5".to_string();
+        conf.journal.rpc_port = 8996;
+        conf.journal.journal_addrs = vec![RaftPeer::new(1, "10.0.0.5", 8996)];
+
+        assert!(
+            conf.check_master_hostname().is_ok(),
+            "local journal address present in journal_addrs must pass"
+        );
+    }
+
+    // With net_interface set, if the local journal address is absent from
+    // journal_addrs, node_id resolution fails and check_master_hostname must
+    // surface a clear error instead of deferring to an opaque raft failure.
+    #[test]
+    fn check_master_hostname_net_interface_missing_journal_addr_errors() {
+        let mut conf = ClusterConf::default();
+        conf.net_interface = "eth0".to_string();
+        conf.journal.hostname = "10.0.0.5".to_string();
+        conf.journal.rpc_port = 8996;
+        // journal_addrs lists a different address, so the local node is not found.
+        conf.journal.journal_addrs = vec![RaftPeer::new(1, "10.0.0.9", 8996)];
+
+        assert!(
+            conf.check_master_hostname().is_err(),
+            "local journal address absent from journal_addrs must error"
+        );
     }
 }

--- a/curvine-docker/deploy/example/conf/curvine-cluster.toml
+++ b/curvine-docker/deploy/example/conf/curvine-cluster.toml
@@ -3,6 +3,19 @@ format_master = false
 format_worker = false
 cluster_id = "curvine"
 
+# Network interface (e.g. "eth0") used to auto-resolve this node's local IPv4.
+# When set (non-empty), on startup the resolved IPv4 is applied to the
+# master/journal/worker/client hostnames, and the CURVINE_*_HOSTNAME env vars
+# are ignored. When empty (the default), hostnames come from the config below
+# and may be overridden by the CURVINE_*_HOSTNAME env vars.
+#
+# Multi-node note: this only fills THIS node's own hostname. The cluster
+# membership lists (journal.journal_addrs and client.master_addrs) must still
+# be written out explicitly, and each node's entry must use the exact IPv4 that
+# its interface resolves to -- otherwise the node cannot locate itself in the
+# raft group and startup fails with a clear error.
+# net_interface = "eth0"
+
 [master]
 rpc_port = 8995
 web_port = 9000

--- a/curvine-docker/deploy/spdk/curvine-cluster-spdk.toml
+++ b/curvine-docker/deploy/spdk/curvine-cluster-spdk.toml
@@ -4,6 +4,19 @@
 format_master = true  
 format_worker = true  
 
+# Network interface (e.g. "eth0") used to auto-resolve this node's local IPv4.  
+# When set (non-empty), on startup the resolved IPv4 is applied to the  
+# master/journal/worker/client hostnames, and the CURVINE_*_HOSTNAME env vars  
+# are ignored. When empty (the default), hostnames come from the config below  
+# and may be overridden by the CURVINE_*_HOSTNAME env vars.  
+#  
+# Multi-node note: this only fills THIS node's own hostname. The cluster  
+# membership lists (journal.journal_addrs and client.master_addrs) must still  
+# be written out explicitly, and each node's entry must use the exact IPv4 that  
+# its interface resolves to -- otherwise the node cannot locate itself in the  
+# raft group and startup fails with a clear error.  
+# net_interface = "eth0"  
+
 # master configuration  
 [master]  
 meta_dir = "testing/meta"  

--- a/etc/curvine-cluster.toml
+++ b/etc/curvine-cluster.toml
@@ -5,6 +5,19 @@
 format_master = false
 format_worker = false
 
+# Network interface (e.g. "eth0") used to auto-resolve this node's local IPv4.
+# When set (non-empty), on startup the resolved IPv4 is applied to the
+# master/journal/worker/client hostnames, and the CURVINE_*_HOSTNAME env vars
+# are ignored. When empty (the default), hostnames come from the config below
+# and may be overridden by the CURVINE_*_HOSTNAME env vars.
+#
+# Multi-node note: this only fills THIS node's own hostname. The cluster
+# membership lists (journal.journal_addrs and client.master_addrs) must still
+# be written out explicitly, and each node's entry must use the exact IPv4 that
+# its interface resolves to -- otherwise the node cannot locate itself in the
+# raft group and startup fails with a clear error.
+# net_interface = "eth0"
+
 # Test-only remote fault control. Exposing the HTTP API requires BOTH:
 #   1) enabled = true below, and
 #   2) binaries built with `--features fault-injection`


### PR DESCRIPTION
# Summary

Add an optional `net_interface` config field so each node can auto-resolve
its own local IPv4 from a named NIC (e.g. `eth0`) at startup, instead of
hard-coding a hostname/IP per node. Useful for multi-node deployments where
the same config is distributed to every node.

# Design

- New top-level field `net_interface` (default empty -> behavior unchanged).
- When non-empty, the IPv4 bound to that interface (via `getifaddrs`) is
  applied to master/journal/worker/client hostnames, and the
  `CURVINE_*_HOSTNAME` env vars are ignored (interface takes precedence).
- When empty, the existing hostname + env-var override path is used as-is.
- `check_master_hostname`, under `net_interface`, validates that the local
  journal address resolves to a node id in `journal_addrs`; otherwise raft
  later fails with an opaque "Not a master role" error, so we surface a
  clear, actionable startup error instead.
- Multi-node caveat documented in the sample configs: membership lists
  (`journal_addrs` / `master_addrs`) must still be written explicitly, and
  each node's entry must match the exact IPv4 the interface resolves to.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-common/src/conf/cluster_conf.rs` | Add `net_interface` field, `interface_ipv4()`, either/or resolution in `from()`, validation in `check_master_hostname()`, unit tests | None when field empty (default) |
| `curvine-common/Cargo.toml` | Enable `nix` `net` feature for `getifaddrs` | None |
| `etc/curvine-cluster.toml`, `curvine-docker/deploy/example/conf/curvine-cluster.toml`, `curvine-docker/deploy/spdk/curvine-cluster-spdk.toml` | Document `net_interface` (commented out) | None |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-common --lib cluster_conf::tests` | PASS | 4 tests: loopback resolve, unknown-iface error, journal-addr match/mismatch |
| `cargo build -p curvine-common -p curvine-server` | PASS | |
| `cargo fmt -p curvine-common -- --check` | PASS | |
| `cargo clippy -p curvine-common` | PASS | no warnings |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None