### PR TITLE
fix(conf): complete FuseConf::init numeric validation (#1124)

### DIFF
--- a/curvine-common/src/conf/fuse_conf.rs
+++ b/curvine-common/src/conf/fuse_conf.rs
@@ -89,6 +89,10 @@ pub struct FuseConf {
     // `mnt_per_task` alias kept for backward compatibility with pre-rename TOML
     // configs (issue #1023 §2); without it `#[serde(default)]` would silently
     // drop the old key and fall back to the default.
+    //
+    // Raw user input; `0` means "follow io_threads". Consumers must NOT read
+    // this directly — use `FuseConf::effective_tasks_per_mnt()` so the `0`
+    // fallback is applied against the (possibly CLI-overridden) io_threads.
     #[serde(alias = "mnt_per_task")]
     pub tasks_per_mnt: usize,
 
@@ -246,6 +250,39 @@ impl FuseConf {
         if self.io_threads == 0 {
             return err_box!("fuse.io_threads must be > 0");
         }
+        if self.mnt_number == 0 {
+            return err_box!("fuse.mnt_number must be > 0");
+        }
+        if self.list_limit == 0 {
+            return err_box!("fuse.list_limit must be > 0");
+        }
+        // path_lock_stripes is used as the modulus in NodeState::lock_path
+        // (hash % path_locks.len()); 0 stripes => empty vec => divide-by-zero
+        // panic on create/release.
+        if self.path_lock_stripes == 0 {
+            return err_box!("fuse.path_lock_stripes must be > 0");
+        }
+        // Upper-bound sanity check on the umask (input hygiene, e.g. an octal
+        // value mistakenly written as decimal); the low bits are the meaningful
+        // permission mask.
+        if self.umask > 0o7777 {
+            return err_box!("fuse.umask must be <= 0o7777 (octal file-permission bits)");
+        }
+        // max_background / congestion_threshold are returned verbatim in the
+        // FUSE init reply; a zero window or an inverted threshold is nonsensical
+        // to the kernel. Check max_background first: the congestion message
+        // references it.
+        if self.max_background == 0 {
+            return err_box!("fuse.max_background must be > 0");
+        }
+        if self.congestion_threshold == 0 || self.congestion_threshold > self.max_background {
+            return err_box!(
+                "fuse.congestion_threshold must be > 0 and <= fuse.max_background \
+                 (congestion_threshold = {}, max_background = {})",
+                self.congestion_threshold,
+                self.max_background
+            );
+        }
 
         self.attr_ttl = Duration::from_millis(self.attr_timeout_ms);
         self.entry_ttl = Duration::from_millis(self.entry_timeout_ms);
@@ -253,9 +290,12 @@ impl FuseConf {
         self.node_cache_ttl = DurationUnit::from_str(&self.node_cache_timeout)?.as_duration();
         self.meta_cache_ttl = DurationUnit::from_str(&self.meta_cache_timeout)?.as_duration();
 
-        if self.tasks_per_mnt == 0 {
-            self.tasks_per_mnt = self.io_threads;
-        }
+        // NOTE: `tasks_per_mnt == 0` means "follow io_threads". This is resolved
+        // at the consumption point (FuseChannel::new via `effective_tasks_per_mnt`),
+        // NOT normalized in place here: init() runs twice (once in
+        // ClusterConf::from, once after CLI overrides), and mutating the field on
+        // the first pass would freeze it so a later `--io-threads` override is not
+        // tracked. Keeping the raw value lets the consumer re-resolve every time.
 
         let fs_path = Path::from_str(&self.fs_path)?;
         self.fs_path = fs_path.path().to_owned();
@@ -278,6 +318,18 @@ impl FuseConf {
         }
 
         Ok(())
+    }
+
+    /// Effective per-mount IO task count: `tasks_per_mnt`, or `io_threads` when
+    /// `tasks_per_mnt == 0` ("follow io_threads"). Resolved on read rather than
+    /// stored, so a CLI `--io-threads` override applied after the config is
+    /// loaded is always tracked.
+    pub fn effective_tasks_per_mnt(&self) -> usize {
+        if self.tasks_per_mnt == 0 {
+            self.io_threads
+        } else {
+            self.tasks_per_mnt
+        }
     }
 
     /// Validates that `state_dir` is — or can be made — a writable directory.
@@ -618,6 +670,168 @@ mod tests {
         };
         conf.init()
             .expect("write_back_cache alone must be accepted");
+    }
+
+    #[test]
+    fn init_rejects_zero_path_lock_stripes() {
+        let mut conf = FuseConf {
+            path_lock_stripes: 0,
+            ..Default::default()
+        };
+        let err = conf
+            .init()
+            .expect_err("zero path_lock_stripes must be rejected");
+        assert!(
+            err.to_string().contains("path_lock_stripes"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn init_rejects_zero_list_limit() {
+        let mut conf = FuseConf {
+            list_limit: 0,
+            ..Default::default()
+        };
+        let err = conf.init().expect_err("zero list_limit must be rejected");
+        assert!(
+            err.to_string().contains("list_limit"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn init_rejects_zero_mnt_number() {
+        let mut conf = FuseConf {
+            mnt_number: 0,
+            ..Default::default()
+        };
+        let err = conf.init().expect_err("zero mnt_number must be rejected");
+        assert!(
+            err.to_string().contains("mnt_number"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn init_rejects_zero_max_background() {
+        let mut conf = FuseConf {
+            max_background: 0,
+            ..Default::default()
+        };
+        let err = conf
+            .init()
+            .expect_err("zero max_background must be rejected");
+        assert!(
+            err.to_string().contains("max_background"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn init_rejects_zero_congestion_threshold() {
+        let mut conf = FuseConf {
+            congestion_threshold: 0,
+            ..Default::default()
+        };
+        let err = conf
+            .init()
+            .expect_err("zero congestion_threshold must be rejected");
+        assert!(
+            err.to_string().contains("congestion_threshold"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn init_rejects_congestion_threshold_above_max_background() {
+        let mut conf = FuseConf {
+            max_background: 100,
+            congestion_threshold: 200,
+            ..Default::default()
+        };
+        let err = conf
+            .init()
+            .expect_err("congestion_threshold > max_background must be rejected");
+        assert!(
+            err.to_string().contains("congestion_threshold"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn init_accepts_congestion_threshold_equal_max_background() {
+        let mut conf = FuseConf {
+            max_background: 200,
+            congestion_threshold: 200,
+            ..Default::default()
+        };
+        conf.init()
+            .expect("congestion_threshold == max_background must be accepted");
+    }
+
+    #[test]
+    fn init_rejects_umask_out_of_range() {
+        let mut conf = FuseConf {
+            umask: 0o10000,
+            ..Default::default()
+        };
+        let err = conf.init().expect_err("umask > 0o7777 must be rejected");
+        assert!(
+            err.to_string().contains("umask"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn init_accepts_max_umask() {
+        let mut conf = FuseConf {
+            umask: 0o7777,
+            ..Default::default()
+        };
+        conf.init().expect("umask == 0o7777 must be accepted");
+    }
+
+    #[test]
+    fn effective_tasks_per_mnt_follows_io_threads_when_zero() {
+        // tasks_per_mnt == 0 means "follow io_threads"; resolution reads the
+        // current io_threads (so a CLI --io-threads override after init is tracked).
+        let mut conf = FuseConf {
+            tasks_per_mnt: 0,
+            io_threads: 64,
+            ..Default::default()
+        };
+        conf.init().expect("valid conf");
+        assert_eq!(conf.effective_tasks_per_mnt(), 64);
+
+        // Simulate a later CLI override of io_threads; re-init is idempotent and
+        // the raw tasks_per_mnt is untouched, so resolution tracks the new value.
+        conf.io_threads = 32;
+        conf.init().expect("valid conf");
+        assert_eq!(conf.effective_tasks_per_mnt(), 32);
+    }
+
+    #[test]
+    fn effective_tasks_per_mnt_preserves_explicit_value() {
+        let mut conf = FuseConf {
+            tasks_per_mnt: 5,
+            io_threads: 64,
+            ..Default::default()
+        };
+        conf.init().expect("valid conf");
+        // Explicit non-zero value is kept regardless of io_threads.
+        assert_eq!(conf.effective_tasks_per_mnt(), 5);
+        assert_eq!(
+            conf.tasks_per_mnt, 5,
+            "raw tasks_per_mnt must not be mutated"
+        );
     }
 
     #[test]

--- a/curvine-fuse/src/cli/mount_args.rs
+++ b/curvine-fuse/src/cli/mount_args.rs
@@ -93,10 +93,13 @@ pub struct FuseMountArgs {
     pub negative_timeout_ms: Option<u64>,
 
     // Performance settings
-    #[arg(long, help = "Max background operations (optional)")]
+    #[arg(long, help = "Max background operations; must be > 0 (optional)")]
     pub max_background: Option<u16>,
 
-    #[arg(long, help = "Congestion threshold (optional)")]
+    #[arg(
+        long,
+        help = "Congestion threshold; must be > 0 and <= max_background (optional)"
+    )]
     pub congestion_threshold: Option<u16>,
 
     // Node cache settings

--- a/curvine-fuse/src/session/channel/mod.rs
+++ b/curvine-fuse/src/session/channel/mod.rs
@@ -38,9 +38,12 @@ impl<T: FileSystem> FuseChannel<T> {
         let buf_size =
             FuseUtils::get_fuse_buf_size().max(max_readahead as usize + FUSE_BUFFER_HEADER_SIZE);
 
-        // Resolve `tasks_per_mnt == 0` ("follow io_threads") here rather than in
-        // FuseConf::init, so a CLI `--io-threads` override applied after config
-        // load is tracked (init runs before the override).
+        // Resolve `tasks_per_mnt == 0` ("follow io_threads") here, on read, rather
+        // than normalizing it in FuseConf::init. init() runs twice (once in
+        // ClusterConf::from, once after CLI overrides in mount_args), so mutating the
+        // field on the first pass would freeze it and a later `--io-threads` override
+        // would not be tracked. Resolving on read lets this consumer always see the
+        // current io_threads. See FuseConf::effective_tasks_per_mnt.
         let tasks_per_mnt = conf.effective_tasks_per_mnt();
         let mut receivers = Vec::with_capacity(tasks_per_mnt);
         let mut senders = Vec::with_capacity(tasks_per_mnt);

--- a/curvine-fuse/src/session/channel/mod.rs
+++ b/curvine-fuse/src/session/channel/mod.rs
@@ -38,10 +38,14 @@ impl<T: FileSystem> FuseChannel<T> {
         let buf_size =
             FuseUtils::get_fuse_buf_size().max(max_readahead as usize + FUSE_BUFFER_HEADER_SIZE);
 
-        let mut receivers = Vec::with_capacity(conf.tasks_per_mnt);
-        let mut senders = Vec::with_capacity(conf.tasks_per_mnt);
+        // Resolve `tasks_per_mnt == 0` ("follow io_threads") here rather than in
+        // FuseConf::init, so a CLI `--io-threads` override applied after config
+        // load is tracked (init runs before the override).
+        let tasks_per_mnt = conf.effective_tasks_per_mnt();
+        let mut receivers = Vec::with_capacity(tasks_per_mnt);
+        let mut senders = Vec::with_capacity(tasks_per_mnt);
         let pending_requests = Arc::new(FastDashMap::default());
-        for _ in 0..conf.tasks_per_mnt {
+        for _ in 0..tasks_per_mnt {
             let (tx, rx) = AsyncChannel::new(conf.fuse_channel_size).split();
             let fd = mnt.create_async_task_fd(conf.clone_fd)?;
 


### PR DESCRIPTION
# Summary

`FuseConf::init` previously validated only `io_threads` and `max_readahead_kb`. This adds the remaining numeric/range checks so an invalid config fails at mount startup instead of panicking or silently degrading at runtime, and fixes `tasks_per_mnt` not tracking a CLI `--io-threads` override.

# Issue Describe / Design

Closes #1124

## Numeric validation (via `err_box!`, matching the existing `io_threads` style)

- **`path_lock_stripes > 0`** — it is the modulus in `NodeState::lock_path` (`hash % path_locks.len()`). `0` stripes → empty vec → **divide-by-zero panic** on create/release. (Highest priority: real panic.)
- **`list_limit > 0`** — `0` makes `DirHandle::get_batch`'s `while buf.len() < limit` loop never pull a real entry, so **readdir silently returns empty**.
- **`mnt_number > 0`** — `0` was silently treated as a single mount by `get_all_mnt_path` (`<= 1` → single). Reject it as a meaningless value.
- **`max_background > 0` and `0 < congestion_threshold <= max_background`** — both are returned verbatim in the FUSE init reply; a zero window or an inverted threshold gives the kernel a nonsensical congestion window.
- **`umask <= 0o7777`** — input hygiene (e.g. an octal value mistakenly written as decimal). Note: this is a sanity bound, not a bug fix — `effective_perm`'s `default_mode & !umask` only uses the low permission bits, so a too-large umask does not actually corrupt anything today.

## `tasks_per_mnt` (0 = "follow io_threads")

`init()` runs twice (once in `ClusterConf::from`, once after CLI overrides in `mount_args`). It previously normalized `tasks_per_mnt = io_threads` in place on the first pass, which froze the field, so a later `--io-threads` override was **not** tracked (e.g. config `io_threads=32` + `--io-threads 64` left the per-mount task count at 32).

Fix: stop mutating the field in `init()`; resolve on read via the new `FuseConf::effective_tasks_per_mnt()`, called at the single consumer `FuseChannel::new`. The raw value stays intact, so resolution always sees the current (possibly overridden) `io_threads`. An explicit non-zero `tasks_per_mnt` is preserved as-is.

## Behavior change (migration note)

A config with `congestion_threshold > max_background`, or either field at `0`, now **fails `init()`** instead of being silently clamped by the kernel. Note `--max-background` and `--congestion-threshold` are independent CLI flags: lowering only `--max-background` below the default `congestion_threshold` (192) will now fail fast. All in-tree configs use the defaults (256/192) and set none of these fields, so nothing in the repo breaks.

## Not included

`sync_check_log_tick` (listed in the issue as a divide-by-zero) no longer divides by zero — #1074 changed `ticks % log_ticks` to `ticks.is_multiple_of(log_ticks)`, which does not panic on `0`. It is also a `ClientConf` field, outside this `FuseConf::init` scope. `worker_threads == 0` / channel sizes `== 0` are the issue's own listed non-issues.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-common/src/conf/fuse_conf.rs` | 5 numeric validations in `init()`; drop in-place `tasks_per_mnt` normalization; add `effective_tasks_per_mnt()`; 11 tests | Invalid values now fail at startup; `congestion > max_background` no longer silently clamped |
| `curvine-fuse/src/session/channel/mod.rs` | `FuseChannel::new` resolves task count via `effective_tasks_per_mnt()` | `--io-threads` override now tracked by per-mount task count |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-common --lib -- fuse_conf` | PASS | 30 passed (11 new: reject/accept for each field + boundary + effective_tasks) |
| `init_rejects_zero_{path_lock_stripes,list_limit,mnt_number,max_background,congestion_threshold}` | PASS | |
| `init_rejects_congestion_threshold_above_max_background` / `init_accepts_congestion_threshold_equal_max_background` | PASS | boundary |
| `init_rejects_umask_out_of_range` / `init_accepts_max_umask` | PASS | `0o10000` rejected, `0o7777` accepted |
| `effective_tasks_per_mnt_follows_io_threads_when_zero` | PASS | tracks io_threads across re-init (the double-init scenario) |
| `effective_tasks_per_mnt_preserves_explicit_value` | PASS | explicit value kept; raw not mutated |
| `cargo build -p curvine-fuse` / clippy / fmt | PASS | no warnings |

# Dependencies

- Related PRs: #1177 (#1125, sibling FuseConf init cross-field validation)
- Related issues: #1073 (io_threads validation, prior)
- Blocks / blocked by: None
