### PR TITLE
fix(lancedb): resolve clippy needless_borrow and sort_by

### DIFF
--- a/curvine-lancedb/src/object_store.rs
+++ b/curvine-lancedb/src/object_store.rs
@@ -924,12 +924,12 @@ impl CurvineObjectStore {
         cv_path: &CurvinePath,
     ) -> OsResult<()> {
         let lock = self.acquire_object_write_lock(location).await?;
-        let result = match self.context.fs.get_status(&cv_path).await {
+        let result = match self.context.fs.get_status(cv_path).await {
             Ok(status) if status.is_dir => Ok(()),
             Ok(_) => {
                 self.context
                     .fs
-                    .delete(&cv_path, false)
+                    .delete(cv_path, false)
                     .await
                     .map_err(|e| fs_error_to_object_store(location, e))?;
                 Ok(())
@@ -1353,7 +1353,7 @@ impl CurvineObjectStore {
             }
         }
 
-        dirs.sort_by(|left, right| right.full_path().len().cmp(&left.full_path().len()));
+        dirs.sort_by_key(|right| std::cmp::Reverse(right.full_path().len()));
         for dir in dirs {
             match self.context.fs.delete(&dir, false).await {
                 Ok(()) => {}


### PR DESCRIPTION
## Summary

- Fix three `cargo clippy -D warnings` failures in `curvine-lancedb/src/object_store.rs` that block the harness **fast** profile on `upstream/main` @ `bbaef66`.
- Mechanical clippy rewrites only: drop needless borrows and replace `sort_by` with `sort_by_key` + `Reverse`.

## Linked issues / Multica

- Multica: CUR-46 (`b0e827fd-5fed-46ba-9da0-55a5e0c1f635`)
- Parent: CUR-45 (`d34c3b24-d4cc-4bec-8bcc-94ed80732937`)

## Root cause

`curvine-lancedb` fails clippy with:

1. `needless_borrow` at `get_status(&cv_path)` (L927)
2. `needless_borrow` at `delete(&cv_path, false)` (L932)
3. `unnecessary_sort_by` at descending path-length sort (L1356)

## Changed files

- `curvine-lancedb/src/object_store.rs`

## Harness evidence

| Field | Value |
|------|--------|
| run_id | `20260717T144531Z-6745e5d0` |
| failing head_sha | `bbaef66e2911b08d24da87be84a7fe7d94681e75` |
| fixed commit | `af03897e48384aa2f431a52cd4d29059da28b9b5` |
| fingerprint | `sha256:69d3bae4972b356d82296445901e6a80ccec05495fa8e239223b37f8ee8f8fe0` |
| manifest_sha256 | `sha256:f4396408b063324b0bdf9089bb20a169d826830e9a6f72fe8fc71336438477ee` |
| artifact_url | `file:///data/data1/liujifeng/curvine-harness-runners/daily-20260716/ordinary/runs/20260717T144531Z-6745e5d0` |
| repair-plan sha256 | `c8c86a35afb00b670b7c2e16b2f0eab33143916eaead92f72335ecb82576dfe6` |
| risk | low |

## Test verified

```bash
# Reproduce (before fix) on bbaef66:
cargo clippy -p curvine-lancedb -- -D warnings
# → exit 101, 3 errors as above

# After fix on this branch:
cargo fmt --all -- --check   # pass
cargo clippy -p curvine-lancedb -- -D warnings   # pass
```

Full harness re-run of `fast` profile against this commit is recommended for the tester agent.

## Risk

Low: API-equivalent clippy suggestions; no behavior change intended beyond lint compliance.
