### PR TITLE
fix(lancedb): fix clippy warnings in object_store (CUR-48)

### DIFF
--- a/curvine-lancedb/src/object_store.rs
+++ b/curvine-lancedb/src/object_store.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::cmp::Reverse;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::env;
 use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
@@ -924,12 +925,12 @@ impl CurvineObjectStore {
         cv_path: &CurvinePath,
     ) -> OsResult<()> {
         let lock = self.acquire_object_write_lock(location).await?;
-        let result = match self.context.fs.get_status(&cv_path).await {
+        let result = match self.context.fs.get_status(cv_path).await {
             Ok(status) if status.is_dir => Ok(()),
             Ok(_) => {
                 self.context
                     .fs
-                    .delete(&cv_path, false)
+                    .delete(cv_path, false)
                     .await
                     .map_err(|e| fs_error_to_object_store(location, e))?;
                 Ok(())
@@ -1353,7 +1354,7 @@ impl CurvineObjectStore {
             }
         }
 
-        dirs.sort_by(|left, right| right.full_path().len().cmp(&left.full_path().len()));
+        dirs.sort_by_key(|dir| Reverse(dir.full_path().len()));
         for dir in dirs {
             match self.context.fs.delete(&dir, false).await {
                 Ok(()) => {}


### PR DESCRIPTION
## Summary

- Fix three `cargo clippy -D warnings` failures in `curvine-lancedb` that break the harness **fast** profile at build layer.
- Remove needless borrows on `&CurvinePath` and replace descending `sort_by` with `sort_by_key` + `Reverse`.

## Multica / Evidence

| Field | Value |
|---|---|
| Multica issue | CUR-48 (`8761b25c-0f49-424c-9fb3-35241effc0b5`) |
| Parent | CUR-47 |
| profile | `fast` |
| run_id | `20260717T144531Z-6745e5d0` |
| tested head_sha (pre-fix) | `bbaef66e2911b08d24da87be84a7fe7d94681e75` |
| fix commit | `07689343a0f4bbf91a54f807f4df5422fff1a36b` |
| fingerprint | `sha256:69d3bae4972b356d82296445901e6a80ccec05495fa8e239223b37f8ee8f8fe0` |
| environment_fingerprint | `sha256:2320185b07210b8eea99d000a241d25dd844e35214400201719e4352df966fae` |
| manifest_sha256 | `sha256:f4396408b063324b0bdf9089bb20a169d826830e9a6f72fe8fc71336438477ee` |
| artifact_url | `file:///var/lib/curvine-harness/runs/20260717T144531Z-6745e5d0` |
| image_digest | `sha256:4ff9e66bdf1a366b0c9031ec800ddd4c000c366d8b61d48357fa856398a0c893` |
| repair-plan.json sha256 | `5acc3ca2625aa8fa14c55fc0c06762889e69fa96eaa5ccf60a681f435f90439e` |
| risk | **low** — lint-equivalent rewrites only; prune order remains longest-path-first |

## Root cause

On `bbaef66e`, `cargo clippy --workspace --all-targets -- -D warnings` fails (exit 101) in `curvine-lancedb/src/object_store.rs`:

1. `clippy::needless_borrow` at L927 / L932 (`&cv_path` where `cv_path: &CurvinePath`)
2. `clippy::unnecessary_sort_by` at L1356 (prefer `sort_by_key` + `Reverse`)

## Changes

| File | Change |
|---|---|
| `curvine-lancedb/src/object_store.rs` | Pass `cv_path` without extra `&`; `dirs.sort_by_key(\|dir\| Reverse(dir.full_path().len()))`; import `std::cmp::Reverse` |

## Test verified

```bash
# Reproduced (pre-fix):
cargo clippy -p curvine-lancedb --all-targets -- -D warnings
# → 3 errors: needless_borrow ×2, unnecessary_sort_by ×1; exit failure

# After fix:
cargo fmt -p curvine-lancedb
cargo clippy -p curvine-lancedb --all-targets -- -D warnings
# → Finished successfully (exit 0)
```

Suggested harness re-run:

```bash
./run-harness.sh ordinary fast --ref 07689343a0f4bbf91a54f807f4df5422fff1a36b
```

## Remaining risk

Low. Full workspace clippy / harness fast profile container re-run not executed in this agent environment beyond `curvine-lancedb` package; recommend tester re-run of the failing profile.
