### PR TITLE
fix(fuse): negotiate an explicit FUSE capability allowlist in init (#1088)

### DIFF
--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -469,6 +469,19 @@ impl fs::FileSystem for CurvineFileSystem {
             unused: 0,
         };
 
+        // Log the negotiated capability set: what we advertise vs. what the
+        // kernel offered but we did not enable (so an operator can see why a
+        // capability is inactive). Note SPLICE/WRITEBACK may appear in "enabled"
+        // without being kernel-offered — they are config-gated daemon requests.
+        let dropped = op.arg.flags & !out_flags;
+        info!(
+            "FUSE init negotiated: abi={}.{} enabled=[{}] kernel_offered_not_enabled=[{}]",
+            op.arg.major,
+            op.arg.minor,
+            fuse_init_flag_names(out_flags).join(", "),
+            fuse_init_flag_names(dropped).join(", "),
+        );
+
         Ok(out)
     }
 
@@ -1301,9 +1314,10 @@ mod tests {
 
     use super::CurvineFileSystem;
     use crate::{
-        FUSE_ATOMIC_O_TRUNC, FUSE_DO_READDIRPLUS, FUSE_FLOCK_LOCKS, FUSE_HAS_IOCTL_DIR,
-        FUSE_MAX_PAGES, FUSE_POSIX_ACL, FUSE_POSIX_LOCKS, FUSE_SPLICE_MOVE, FUSE_SPLICE_READ,
-        FUSE_SPLICE_WRITE, FUSE_WRITEBACK_CACHE, SUPPORTED_INIT_FLAGS,
+        fuse_init_flag_names, FUSE_ATOMIC_O_TRUNC, FUSE_BIG_WRITES, FUSE_DO_READDIRPLUS,
+        FUSE_FLOCK_LOCKS, FUSE_HAS_IOCTL_DIR, FUSE_MAX_PAGES, FUSE_POSIX_ACL, FUSE_POSIX_LOCKS,
+        FUSE_SPLICE_MOVE, FUSE_SPLICE_READ, FUSE_SPLICE_WRITE, FUSE_WRITEBACK_CACHE,
+        SUPPORTED_INIT_FLAGS,
     };
 
     // #1122 + allowlist: the daemon must never advertise FUSE_ATOMIC_O_TRUNC
@@ -1398,5 +1412,20 @@ mod tests {
     fn atomic_o_trunc_bit_value_matches_uapi() {
         // uapi fuse.h: FUSE_ATOMIC_O_TRUNC = (1 << 3)
         assert_eq!(FUSE_ATOMIC_O_TRUNC, 1 << 3);
+    }
+
+    #[test]
+    fn fuse_init_flag_names_maps_known_and_unknown() {
+        // Known bits render as names.
+        let names = fuse_init_flag_names(FUSE_POSIX_LOCKS | FUSE_DO_READDIRPLUS);
+        assert!(names.contains(&"POSIX_LOCKS".to_string()));
+        assert!(names.contains(&"DO_READDIRPLUS".to_string()));
+        // Empty flags => empty list.
+        assert!(fuse_init_flag_names(0).is_empty());
+        // An unknown bit is surfaced as a hex token, not silently dropped.
+        let unknown = 1u32 << 30;
+        let names = fuse_init_flag_names(FUSE_BIG_WRITES | unknown);
+        assert!(names.contains(&"BIG_WRITES".to_string()));
+        assert!(names.iter().any(|n| n == "0x40000000"));
     }
 }

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -397,15 +397,36 @@ impl CurvineFileSystem {
         out
     }
 
-    /// Whether the daemon accepts the kernel's advertised FUSE ABI version.
+    /// Whether the kernel's advertised FUSE ABI version is at least the
+    /// daemon's minimum.
     ///
     /// Compared as a `(major, minor)` tuple against `FUSE_MIN_ABI`: reject any
     /// version below 7.31 (this correctly rejects a low-major/high-minor combo
     /// such as 6.40, which the old `major < 7 && minor < 31` check let through).
-    /// A higher major is accepted; the kernel re-issues INIT at the daemon's
-    /// major after we reply with our own version.
+    /// A higher major also compares as supported here; `init` handles that case
+    /// separately with a version-only reply (see `version_only_init_out`) before
+    /// this predicate gates the too-old case.
     fn abi_supported(major: u32, minor: u32) -> bool {
         (major, minor) >= FUSE_MIN_ABI
+    }
+
+    /// The INIT reply for a kernel whose major ABI is newer than the daemon's:
+    /// advertise only the daemon's own `(major, minor)` with no negotiated
+    /// flags, and leave every other field zeroed.
+    ///
+    /// Per the fuse.h version-negotiation convention, when the kernel major is
+    /// larger than the daemon's, userspace replies with its own major and skips
+    /// negotiation, and the kernel is expected to re-issue INIT at a matching
+    /// major. This mirrors libfuse `_do_init`'s `arg->major > 7` early return:
+    /// a `fuse_init_in` at an unknown higher major may not share our field
+    /// layout, so we must not interpret its flags. The kernel does not read the
+    /// other reply fields on a major mismatch, so they stay 0.
+    fn version_only_init_out() -> fuse_init_out {
+        fuse_init_out {
+            major: FUSE_KERNEL_VERSION,
+            minor: FUSE_KERNEL_MINOR_VERSION,
+            ..Default::default()
+        }
     }
 }
 
@@ -420,6 +441,23 @@ impl fs::FileSystem for CurvineFileSystem {
                 FUSE_KERNEL_VERSION,
                 FUSE_KERNEL_MINOR_VERSION
             );
+        }
+
+        // Kernel major newer than ours: reply with our own version only and do
+        // NOT negotiate flags — the `fuse_init_in` layout at an unknown higher
+        // major cannot be trusted (see `version_only_init_out`). Only when the
+        // majors already match do we run the allowlist negotiation below.
+        if op.arg.major > FUSE_KERNEL_VERSION {
+            info!(
+                "FUSE init: kernel offered abi={}.{} (major > {}); replying version-only \
+                 {}.{} and skipping capability negotiation",
+                op.arg.major,
+                op.arg.minor,
+                FUSE_KERNEL_VERSION,
+                FUSE_KERNEL_VERSION,
+                FUSE_KERNEL_MINOR_VERSION,
+            );
+            return Ok(Self::version_only_init_out());
         }
 
         // Negotiate an explicit allowlist (see `negotiate_out_flags`): only caps
@@ -450,8 +488,9 @@ impl fs::FileSystem for CurvineFileSystem {
         let out = fuse_init_out {
             // Advertise the daemon's own ABI, not the kernel's: curvine only
             // implements the 7.31 struct/semantics, so it must not claim a higher
-            // version. On a higher-major kernel this makes the kernel re-issue
-            // INIT at our major (init is idempotent, dispatched per INIT).
+            // version. The higher-major case is already handled above; here the
+            // majors match, and we reply with our own minor so we never claim a
+            // minor the kernel does not have.
             major: FUSE_KERNEL_VERSION,
             minor: FUSE_KERNEL_MINOR_VERSION,
             max_readahead,
@@ -471,11 +510,19 @@ impl fs::FileSystem for CurvineFileSystem {
 
         // Log the negotiated capability set: what we advertise vs. what the
         // kernel offered but we did not enable (so an operator can see why a
-        // capability is inactive). Note SPLICE/WRITEBACK may appear in "enabled"
-        // without being kernel-offered — they are config-gated daemon requests.
+        // capability is inactive). Report BOTH the version we advertise on the
+        // wire (`negotiated_abi`, always our own) and what the kernel offered
+        // (`kernel_offered_abi`) — the two differ in minor when the kernel is
+        // newer (e.g. offered 7.40, connection runs at 7.31), so a single "abi="
+        // field would misreport the live version. Note SPLICE/WRITEBACK may
+        // appear in "enabled" without being kernel-offered — they are
+        // config-gated daemon requests.
         let dropped = op.arg.flags & !out_flags;
         info!(
-            "FUSE init negotiated: abi={}.{} enabled=[{}] kernel_offered_not_enabled=[{}]",
+            "FUSE init negotiated: negotiated_abi={}.{} kernel_offered_abi={}.{} \
+             enabled=[{}] kernel_offered_not_enabled=[{}]",
+            FUSE_KERNEL_VERSION,
+            FUSE_KERNEL_MINOR_VERSION,
             op.arg.major,
             op.arg.minor,
             fuse_init_flag_names(out_flags).join(", "),
@@ -1315,9 +1362,9 @@ mod tests {
     use super::CurvineFileSystem;
     use crate::{
         fuse_init_flag_names, FUSE_ATOMIC_O_TRUNC, FUSE_BIG_WRITES, FUSE_DO_READDIRPLUS,
-        FUSE_FLOCK_LOCKS, FUSE_HAS_IOCTL_DIR, FUSE_MAX_PAGES, FUSE_POSIX_ACL, FUSE_POSIX_LOCKS,
-        FUSE_SPLICE_MOVE, FUSE_SPLICE_READ, FUSE_SPLICE_WRITE, FUSE_WRITEBACK_CACHE,
-        SUPPORTED_INIT_FLAGS,
+        FUSE_FLOCK_LOCKS, FUSE_HAS_IOCTL_DIR, FUSE_KERNEL_MINOR_VERSION, FUSE_KERNEL_VERSION,
+        FUSE_MAX_PAGES, FUSE_POSIX_ACL, FUSE_POSIX_LOCKS, FUSE_SPLICE_MOVE, FUSE_SPLICE_READ,
+        FUSE_SPLICE_WRITE, FUSE_WRITEBACK_CACHE, SUPPORTED_INIT_FLAGS,
     };
 
     // #1122 + allowlist: the daemon must never advertise FUSE_ATOMIC_O_TRUNC
@@ -1406,6 +1453,24 @@ mod tests {
         assert!(!CurvineFileSystem::abi_supported(6, 40));
         assert!(!CurvineFileSystem::abi_supported(6, 0));
         assert!(!CurvineFileSystem::abi_supported(0, 0));
+    }
+
+    // Higher-major short reply (mirrors libfuse `_do_init`'s `arg->major > 7`
+    // path): advertise only our own version, negotiate no flags, zero the rest.
+    #[test]
+    fn version_only_init_out_advertises_own_version_no_flags() {
+        let out = CurvineFileSystem::version_only_init_out();
+        assert_eq!(out.major, FUSE_KERNEL_VERSION);
+        assert_eq!(out.minor, FUSE_KERNEL_MINOR_VERSION);
+        assert_eq!(
+            out.flags, 0,
+            "no capability negotiation on a major mismatch"
+        );
+        // Fields the kernel does not read on a major mismatch stay zeroed.
+        assert_eq!(out.max_readahead, 0);
+        assert_eq!(out.max_write, 0);
+        assert_eq!(out.max_background, 0);
+        assert_eq!(out.congestion_threshold, 0);
     }
 
     #[test]

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -371,57 +371,73 @@ impl CurvineFileSystem {
         }
     }
 
-    /// Combine the daemon's baseline init flags with the flags the kernel
-    /// offered, then strip any capability Curvine must not advertise.
+    /// Negotiate the init reply flags as an explicit allowlist rather than
+    /// blindly echoing every kernel-offered capability.
     ///
-    /// Currently that means clearing `FUSE_ATOMIC_O_TRUNC`: `open` does not
-    /// perform the truncate itself, so if we advertised atomic O_TRUNC the
-    /// kernel would skip the follow-up `SETATTR(size=0)` and O_TRUNC would be
-    /// silently lost whenever a writer for the inode already exists (the shared
-    /// writer ignores the second open's flags). Clearing it forces the kernel
-    /// back to the open + SETATTR path, which `set_attr` handles via
-    /// `fs_resize`. See issue #1122.
-    fn negotiate_out_flags(base: u32, kernel_flags: u32) -> u32 {
-        (base | kernel_flags) & !FUSE_ATOMIC_O_TRUNC
+    /// Two categories:
+    /// 1. Kernel-negotiated caps: `SUPPORTED_INIT_FLAGS & kernel_flags` — only
+    ///    bits the daemon implements AND the kernel offered. This inherently
+    ///    excludes `FUSE_ATOMIC_O_TRUNC` (open does not truncate, #1122),
+    ///    `FUSE_POSIX_ACL`, `FUSE_HAS_IOCTL_DIR`, and any unknown/future bit,
+    ///    since none are in `SUPPORTED_INIT_FLAGS`. `FUSE_MAX_PAGES` survives
+    ///    only when the kernel offers it.
+    /// 2. Config-gated daemon-requested caps, forced on (NOT masked by the
+    ///    kernel offer): `FUSE_WRITEBACK_CACHE` when `write_back_cache`, and the
+    ///    `FUSE_SPLICE_*` bits when `enable_splice`. Splice is driven by the
+    ///    channel talking splice(2) on the fuse fd directly, independent of an
+    ///    init-flag offer, so it must be advertised on config alone.
+    fn negotiate_out_flags(kernel_flags: u32, write_back_cache: bool, enable_splice: bool) -> u32 {
+        let mut out = SUPPORTED_INIT_FLAGS & kernel_flags;
+        if write_back_cache {
+            out |= FUSE_WRITEBACK_CACHE;
+        }
+        if enable_splice {
+            out |= FUSE_SPLICE_MOVE | FUSE_SPLICE_WRITE | FUSE_SPLICE_READ;
+        }
+        out
+    }
+
+    /// Whether the daemon accepts the kernel's advertised FUSE ABI version.
+    ///
+    /// Compared as a `(major, minor)` tuple against `FUSE_MIN_ABI`: reject any
+    /// version below 7.31 (this correctly rejects a low-major/high-minor combo
+    /// such as 6.40, which the old `major < 7 && minor < 31` check let through).
+    /// A higher major is accepted; the kernel re-issues INIT at the daemon's
+    /// major after we reply with our own version.
+    fn abi_supported(major: u32, minor: u32) -> bool {
+        (major, minor) >= FUSE_MIN_ABI
     }
 }
 
 impl fs::FileSystem for CurvineFileSystem {
     async fn init(&self, op: Init<'_>) -> FuseResult<fuse_init_out> {
-        if op.arg.major < FUSE_KERNEL_VERSION && op.arg.minor < FUSE_KERNEL_MINOR_VERSION {
+        if !Self::abi_supported(op.arg.major, op.arg.minor) {
             return err_fuse!(
                 libc::EPROTO,
-                "Unsupported FUSE ABI version {}.{}",
+                "unsupported FUSE ABI {}.{}: curvine requires >= {}.{}",
                 op.arg.major,
-                op.arg.minor
+                op.arg.minor,
+                FUSE_KERNEL_VERSION,
+                FUSE_KERNEL_MINOR_VERSION
             );
         }
 
-        let mut out_flags = FUSE_BIG_WRITES
-            | FUSE_ASYNC_READ
-            | FUSE_ASYNC_DIO
-            | FUSE_SPLICE_MOVE
-            | FUSE_SPLICE_WRITE
-            | FUSE_SPLICE_READ
-            | FUSE_READDIRPLUS_AUTO
-            | FUSE_AUTO_INVAL_DATA
-            | FUSE_EXPORT_SUPPORT;
+        // Negotiate an explicit allowlist (see `negotiate_out_flags`): only caps
+        // the daemon implements AND the kernel offered, plus config-gated
+        // writeback/splice. `max_pages` then keys off the negotiated result.
+        let out_flags = Self::negotiate_out_flags(
+            op.arg.flags,
+            self.conf.write_back_cache,
+            self.conf.enable_splice,
+        );
 
         let max_write = FuseUtils::get_fuse_buf_size() - FUSE_BUFFER_HEADER_SIZE;
         let page_size = sys::get_pagesize()?;
-        let max_pages = if op.arg.flags & FUSE_MAX_PAGES != 0 {
-            out_flags |= FUSE_MAX_PAGES;
+        let max_pages = if out_flags & FUSE_MAX_PAGES != 0 {
             (max_write - 1) / page_size + 1
         } else {
             0
         };
-
-        out_flags = Self::negotiate_out_flags(out_flags, op.arg.flags);
-        if self.conf.write_back_cache {
-            out_flags |= FUSE_WRITEBACK_CACHE;
-        } else {
-            out_flags &= !FUSE_WRITEBACK_CACHE;
-        }
 
         // If `fuse.max_readahead_kb` is configured, raise the negotiated
         // `max_readahead` so the kernel cap (min(bdi.max_readahead_kb,
@@ -432,8 +448,12 @@ impl fs::FileSystem for CurvineFileSystem {
         };
 
         let out = fuse_init_out {
-            major: op.arg.major,
-            minor: op.arg.minor,
+            // Advertise the daemon's own ABI, not the kernel's: curvine only
+            // implements the 7.31 struct/semantics, so it must not claim a higher
+            // version. On a higher-major kernel this makes the kernel re-issue
+            // INIT at our major (init is idempotent, dispatched per INIT).
+            major: FUSE_KERNEL_VERSION,
+            minor: FUSE_KERNEL_MINOR_VERSION,
             max_readahead,
             flags: out_flags,
             max_background: self.conf.max_background,
@@ -1280,47 +1300,98 @@ mod tests {
     }
 
     use super::CurvineFileSystem;
-    use crate::FUSE_ATOMIC_O_TRUNC;
+    use crate::{
+        FUSE_ATOMIC_O_TRUNC, FUSE_DO_READDIRPLUS, FUSE_FLOCK_LOCKS, FUSE_HAS_IOCTL_DIR,
+        FUSE_MAX_PAGES, FUSE_POSIX_ACL, FUSE_POSIX_LOCKS, FUSE_SPLICE_MOVE, FUSE_SPLICE_READ,
+        FUSE_SPLICE_WRITE, FUSE_WRITEBACK_CACHE, SUPPORTED_INIT_FLAGS,
+    };
 
-    // #1122: the daemon must never advertise FUSE_ATOMIC_O_TRUNC, because `open`
-    // does not truncate. If the kernel offers it, negotiate_out_flags must strip
-    // it so the kernel falls back to the open + SETATTR(size=0) path.
+    // #1122 + allowlist: the daemon must never advertise FUSE_ATOMIC_O_TRUNC
+    // (open does not truncate) or any other unsupported capability, even when
+    // the kernel offers it. The allowlist mask drops them.
     #[test]
-    fn negotiate_out_flags_strips_atomic_o_trunc_offered_by_kernel() {
-        // Kernel offers ATOMIC_O_TRUNC plus some other capability bit.
-        let other = 1u32 << 15; // FUSE_ASYNC_DIO, arbitrary unrelated bit
-        let kernel_flags = FUSE_ATOMIC_O_TRUNC | other;
-        let base = 1u32 << 5; // FUSE_BIG_WRITES, arbitrary baseline bit
-
-        let out = CurvineFileSystem::negotiate_out_flags(base, kernel_flags);
-
+    fn negotiate_out_flags_drops_unsupported_kernel_caps() {
+        let unsupported = FUSE_ATOMIC_O_TRUNC | FUSE_POSIX_ACL | FUSE_HAS_IOCTL_DIR | (1u32 << 30);
+        let out = CurvineFileSystem::negotiate_out_flags(unsupported, false, false);
         assert_eq!(
-            out & FUSE_ATOMIC_O_TRUNC,
-            0,
-            "FUSE_ATOMIC_O_TRUNC must be cleared even when the kernel offers it"
+            out, 0,
+            "no unsupported kernel-offered bit may be advertised"
         );
-        // Unrelated kernel-offered and baseline bits must be preserved.
-        assert_eq!(out & other, other, "unrelated kernel bit must survive");
-        assert_eq!(out & base, base, "baseline bit must survive");
     }
 
-    // Even if the baseline set somehow contained the bit, it must not leak out.
+    // Supported caps pass through when the kernel offers them. Guards against
+    // regressing distributed locking / readdirplus, which were only enabled by
+    // the old blind OR.
     #[test]
-    fn negotiate_out_flags_strips_atomic_o_trunc_from_base() {
-        let base = FUSE_ATOMIC_O_TRUNC | (1u32 << 4);
-        let out = CurvineFileSystem::negotiate_out_flags(base, 0);
-        assert_eq!(out & FUSE_ATOMIC_O_TRUNC, 0);
-        assert_eq!(out & (1u32 << 4), 1u32 << 4);
+    fn negotiate_out_flags_passes_through_supported_caps() {
+        let out = CurvineFileSystem::negotiate_out_flags(SUPPORTED_INIT_FLAGS, false, false);
+        assert_eq!(
+            out, SUPPORTED_INIT_FLAGS,
+            "all supported+offered caps survive"
+        );
+        // Explicit regression guards for the previously-implicit caps.
+        assert_eq!(out & FUSE_POSIX_LOCKS, FUSE_POSIX_LOCKS);
+        assert_eq!(out & FUSE_FLOCK_LOCKS, FUSE_FLOCK_LOCKS);
+        assert_eq!(out & FUSE_DO_READDIRPLUS, FUSE_DO_READDIRPLUS);
     }
 
-    // When the kernel does not offer the bit, output is a clean union with
-    // nothing spuriously added.
+    // A supported cap the kernel did NOT offer must not be advertised (no
+    // phantom capabilities).
     #[test]
-    fn negotiate_out_flags_is_union_when_bit_absent() {
-        let base = 1u32 << 5;
-        let kernel_flags = 1u32 << 14;
-        let out = CurvineFileSystem::negotiate_out_flags(base, kernel_flags);
-        assert_eq!(out, base | kernel_flags);
+    fn negotiate_out_flags_no_phantom_when_kernel_offers_nothing() {
+        let out = CurvineFileSystem::negotiate_out_flags(0, false, false);
+        assert_eq!(out, 0);
+        assert_eq!(out & FUSE_MAX_PAGES, 0);
+        assert_eq!(out & FUSE_POSIX_LOCKS, 0);
+    }
+
+    // WRITEBACK is a config-gated daemon-requested cap: present iff write_back,
+    // absent otherwise even when the kernel offers it.
+    #[test]
+    fn negotiate_out_flags_writeback_is_config_gated() {
+        let on = CurvineFileSystem::negotiate_out_flags(0, true, false);
+        assert_eq!(on & FUSE_WRITEBACK_CACHE, FUSE_WRITEBACK_CACHE);
+        let off = CurvineFileSystem::negotiate_out_flags(FUSE_WRITEBACK_CACHE, false, false);
+        assert_eq!(off & FUSE_WRITEBACK_CACHE, 0);
+    }
+
+    // SPLICE is config-gated and forced (not masked by the kernel offer, since
+    // the channel drives splice(2) directly).
+    #[test]
+    fn negotiate_out_flags_splice_is_config_gated() {
+        let splice = FUSE_SPLICE_MOVE | FUSE_SPLICE_WRITE | FUSE_SPLICE_READ;
+        let on = CurvineFileSystem::negotiate_out_flags(0, false, true);
+        assert_eq!(
+            on & splice,
+            splice,
+            "splice advertised on config even if kernel omits it"
+        );
+        let off = CurvineFileSystem::negotiate_out_flags(splice, false, false);
+        assert_eq!(off & splice, 0, "splice not advertised when disabled");
+    }
+
+    // Containment: output never contains a bit outside the allowed universe,
+    // regardless of what the kernel offers.
+    #[test]
+    fn negotiate_out_flags_containment() {
+        let splice = FUSE_SPLICE_MOVE | FUSE_SPLICE_WRITE | FUSE_SPLICE_READ;
+        let allowed = SUPPORTED_INIT_FLAGS | splice | FUSE_WRITEBACK_CACHE;
+        let out = CurvineFileSystem::negotiate_out_flags(0xFFFF_FFFF, true, true);
+        assert_eq!(out & !allowed, 0, "no bit outside the allowed universe");
+    }
+
+    #[test]
+    fn abi_supported_tuple_comparison() {
+        // Accept >= 7.31, including a higher major.
+        assert!(CurvineFileSystem::abi_supported(7, 31));
+        assert!(CurvineFileSystem::abi_supported(7, 32));
+        assert!(CurvineFileSystem::abi_supported(8, 0));
+        // Reject anything below 7.31 — including the low-major/high-minor combo
+        // the old `major < 7 && minor < 31` check let through.
+        assert!(!CurvineFileSystem::abi_supported(7, 30));
+        assert!(!CurvineFileSystem::abi_supported(6, 40));
+        assert!(!CurvineFileSystem::abi_supported(6, 0));
+        assert!(!CurvineFileSystem::abi_supported(0, 0));
     }
 
     #[test]

--- a/curvine-fuse/src/lib.rs
+++ b/curvine-fuse/src/lib.rs
@@ -98,6 +98,16 @@ pub const FUSE_DO_READDIRPLUS: u32 = 1 << 13;
 
 pub const FUSE_READDIRPLUS_AUTO: u32 = 1 << 14;
 
+/// FUSE init capability bit (uapi `fuse.h`: `FUSE_POSIX_LOCKS = (1 << 1)`):
+/// remote POSIX (fcntl) file locking. Implemented via `get_lk`/`set_lk`/
+/// `set_lkw`, which route to the distributed backend's lock service.
+pub const FUSE_POSIX_LOCKS: u32 = 1 << 1;
+
+/// FUSE init capability bit (uapi `fuse.h`: `FUSE_FLOCK_LOCKS = (1 << 10)`):
+/// remote BSD (flock) file locking. Implemented via the same lock path;
+/// `release`/`flush` drop flock/posix locks through `LockFlags::Flock`/`Plock`.
+pub const FUSE_FLOCK_LOCKS: u32 = 1 << 10;
+
 pub const FUSE_WRITEBACK_CACHE: u32 = 1 << 16;
 
 pub const FUSE_POSIX_ACL: u32 = 1 << 20;
@@ -126,6 +136,37 @@ pub const FUSE_EXPORT_SUPPORT: u32 = 1 << 4;
 ///   - linux/fuse.h:339        `#define FUSE_ATOMIC_O_TRUNC     (1 << 3)`
 ///   - fuse3/fuse_common.h:158 `#define FUSE_CAP_ATOMIC_O_TRUNC (1 << 3)`
 pub const FUSE_ATOMIC_O_TRUNC: u32 = 1 << 3;
+
+/// Init capabilities the daemon actually implements, negotiated as an explicit
+/// allowlist: `init` advertises `SUPPORTED_INIT_FLAGS & op.arg.flags` (only what
+/// BOTH the daemon supports and the kernel offered), instead of blindly echoing
+/// every kernel-offered flag. Each bit here maps to a real implementation:
+/// ASYNC_READ/ASYNC_DIO (async read + direct-io pipeline), BIG_WRITES (writer
+/// handles >4KiB writes), AUTO_INVAL_DATA (kernel auto-invalidates page cache on
+/// open), EXPORT_SUPPORT (`.`/`..` lookup reconstruction), READDIRPLUS_AUTO +
+/// DO_READDIRPLUS (`read_dir_plus`), POSIX_LOCKS + FLOCK_LOCKS
+/// (`get_lk`/`set_lk`/`set_lkw`), MAX_PAGES (negotiated only if the kernel offers it).
+///
+/// Deliberately EXCLUDED (never advertised): FUSE_ATOMIC_O_TRUNC (open does not
+/// truncate, #1122), FUSE_POSIX_ACL (no ACL handling), FUSE_HAS_IOCTL_DIR (no
+/// ioctl), and any unknown/future kernel bit. FUSE_WRITEBACK_CACHE and the
+/// FUSE_SPLICE_* bits are config-gated daemon-requested caps handled separately
+/// (see `negotiate_out_flags`), not part of this kernel-masked allowlist.
+pub const SUPPORTED_INIT_FLAGS: u32 = FUSE_ASYNC_READ
+    | FUSE_BIG_WRITES
+    | FUSE_ASYNC_DIO
+    | FUSE_AUTO_INVAL_DATA
+    | FUSE_EXPORT_SUPPORT
+    | FUSE_READDIRPLUS_AUTO
+    | FUSE_DO_READDIRPLUS
+    | FUSE_POSIX_LOCKS
+    | FUSE_FLOCK_LOCKS
+    | FUSE_MAX_PAGES;
+
+/// Minimum FUSE ABI (major, minor) the daemon accepts. curvine only implements
+/// the 7.31 struct layout / semantics, so it rejects older kernels and, on
+/// negotiation, advertises exactly this version rather than echoing the kernel.
+pub const FUSE_MIN_ABI: (u32, u32) = (FUSE_KERNEL_VERSION, FUSE_KERNEL_MINOR_VERSION);
 
 pub const FUSE_MAX_NAME_LENGTH: usize = 255;
 

--- a/curvine-fuse/src/lib.rs
+++ b/curvine-fuse/src/lib.rs
@@ -163,6 +163,42 @@ pub const SUPPORTED_INIT_FLAGS: u32 = FUSE_ASYNC_READ
     | FUSE_FLOCK_LOCKS
     | FUSE_MAX_PAGES;
 
+/// Human-readable names of the FUSE init-capability bits set in `flags`, for
+/// logging the negotiated capability set. Known bits are named; any leftover
+/// unknown bits are appended as a single `0x…` hex token so nothing is hidden.
+pub fn fuse_init_flag_names(flags: u32) -> Vec<String> {
+    const KNOWN: &[(u32, &str)] = &[
+        (FUSE_ASYNC_READ, "ASYNC_READ"),
+        (FUSE_POSIX_LOCKS, "POSIX_LOCKS"),
+        (FUSE_ATOMIC_O_TRUNC, "ATOMIC_O_TRUNC"),
+        (FUSE_EXPORT_SUPPORT, "EXPORT_SUPPORT"),
+        (FUSE_BIG_WRITES, "BIG_WRITES"),
+        (FUSE_SPLICE_WRITE, "SPLICE_WRITE"),
+        (FUSE_SPLICE_MOVE, "SPLICE_MOVE"),
+        (FUSE_SPLICE_READ, "SPLICE_READ"),
+        (FUSE_FLOCK_LOCKS, "FLOCK_LOCKS"),
+        (FUSE_HAS_IOCTL_DIR, "HAS_IOCTL_DIR"),
+        (FUSE_AUTO_INVAL_DATA, "AUTO_INVAL_DATA"),
+        (FUSE_DO_READDIRPLUS, "DO_READDIRPLUS"),
+        (FUSE_READDIRPLUS_AUTO, "READDIRPLUS_AUTO"),
+        (FUSE_ASYNC_DIO, "ASYNC_DIO"),
+        (FUSE_WRITEBACK_CACHE, "WRITEBACK_CACHE"),
+        (FUSE_POSIX_ACL, "POSIX_ACL"),
+        (FUSE_MAX_PAGES, "MAX_PAGES"),
+    ];
+    let mut names: Vec<String> = KNOWN
+        .iter()
+        .filter(|(bit, _)| flags & bit != 0)
+        .map(|(_, name)| name.to_string())
+        .collect();
+    let known_mask: u32 = KNOWN.iter().fold(0, |acc, (bit, _)| acc | bit);
+    let unknown = flags & !known_mask;
+    if unknown != 0 {
+        names.push(format!("0x{:x}", unknown));
+    }
+    names
+}
+
 /// Minimum FUSE ABI (major, minor) the daemon accepts. curvine only implements
 /// the 7.31 struct layout / semantics, so it rejects older kernels and, on
 /// negotiation, advertises exactly this version rather than echoing the kernel.


### PR DESCRIPTION
# Summary

`CurvineFileSystem::init` blindly OR-ed every kernel-offered flag into the init reply (`(base | op.arg.flags) & !FUSE_ATOMIC_O_TRUNC`), advertising capabilities the daemon does not implement; the ABI version check used a buggy `&&`; and `FUSE_SPLICE_*` was advertised unconditionally, decoupled from `enable_splice`. This replaces the blind OR with an explicit capability allowlist, fixes the ABI comparison, gates splice on config, and logs the negotiated capability diff.

# Issue Describe / Design

Closes #1088

## Capability allowlist

`init` now advertises `SUPPORTED_INIT_FLAGS & op.arg.flags` — only caps the daemon implements **and** the kernel offered. `SUPPORTED_INIT_FLAGS` is an explicit set in `lib.rs`, each bit annotated to its implementation. This inherently drops `FUSE_ATOMIC_O_TRUNC` (#1122), `FUSE_POSIX_ACL`, `FUSE_HAS_IOCTL_DIR`, and any unknown/future kernel bit — no more `& !ATOMIC_O_TRUNC` special-case.

**Making previously-implicit caps explicit (important — read before assuming a regression):** `FUSE_POSIX_LOCKS`, `FUSE_FLOCK_LOCKS`, and `FUSE_DO_READDIRPLUS` were only ever enabled via the blind OR, even though `get_lk`/`set_lk`/`set_lkw` and `read_dir_plus` are real implementations routing to the distributed backend. They are now in `SUPPORTED_INIT_FLAGS`, so distributed locking and readdirplus behave exactly as before on ≥7.31 kernels. The visibly-larger flag set is just the old implicit dependency made explicit — **not** newly-advertised behavior. (Base caps that were previously force-advertised are now kernel-gated, i.e. advertised only when the kernel also offers them; on a real ≥7.31 kernel these are always offered, so no wire-level change.)

## Config-gated daemon-requested caps

Forced on, **not** masked by the kernel offer:
- `FUSE_WRITEBACK_CACHE` when `write_back_cache` (unchanged behavior).
- `FUSE_SPLICE_*` when `enable_splice`. Splice is driven by the channel talking `splice(2)` on the fuse fd directly (independent of an init-flag offer), so it must be advertised on config alone — and is now consistent with `enable_splice` instead of always-on. Default `enable_splice=true`, so the default is unchanged; `false` now correctly stops advertising splice.

## ABI version check

Compare `(major, minor)` as a tuple against `FUSE_MIN_ABI` (7.31), fixing the `major < 7 && minor < 31` bug that let a low-major/high-minor combo (e.g. 6.40) through. The init reply now advertises the daemon's own 7.31 version instead of echoing the kernel's — curvine only implements the 7.31 struct/semantics, so on a higher-major kernel this makes the kernel re-issue INIT at our major (`init` is idempotent, dispatched per INIT). Stricter: kernels below 7.31 that previously slipped through are now rejected with EPROTO (they were already ABI-mismatched, since curvine sends 7.31 structs).

## Negotiated capability diff logging

After negotiation, `init` logs at info level the advertised set and the capabilities the kernel offered but the daemon did NOT enable (`kernel_flags & !out_flags`). This lets an operator see at startup why a capability is inactive (dropped by the allowlist) or confirm a config gate took effect (e.g. SPLICE absent when `enable_splice=false`). Flags are rendered as readable names via `fuse_init_flag_names`, with unknown bits surfaced as a hex token rather than hidden.

## Out of scope (separate issue)

Opcode coverage — the parsed-but-unhandled `Rename2` (no dispatch arm/trait method), the orphan `Destroy` struct, and unparsed `FSYNCDIR`/`LSEEK`/`BMAP`/`POLL`/`IOCTL` — is a distinct dispatch/trait concern and does not involve init-flag negotiation. Left for a follow-up.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-fuse/src/lib.rs` | Add `FUSE_POSIX_LOCKS`/`FUSE_FLOCK_LOCKS`, `SUPPORTED_INIT_FLAGS` (annotated allowlist), `FUSE_MIN_ABI`, `fuse_init_flag_names` | None (new constants/helper) |
| `curvine-fuse/src/fs/curvine_file_system.rs` | Rewrite `negotiate_out_flags` as a pure allowlist fn; add `abi_supported`; `init` uses tuple ABI check + advertises own version + config-gated negotiate + info-level capability diff log; rewrite/extend tests | Wire flags unchanged on ≥7.31 kernels; splice now config-consistent; sub-7.31 kernels rejected; new startup log line |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-fuse --lib` | PASS | 191+ passed; `dir_tree::test` pre-existing failure skipped |
| `negotiate_out_flags_*` (6 tests) | PASS | drops unsupported; passes through supported (POSIX_LOCKS/FLOCK_LOCKS/DO_READDIRPLUS regression guards); no phantom; WRITEBACK/SPLICE config gates; containment |
| `abi_supported_tuple_comparison` | PASS | accepts ≥7.31 incl. higher major; rejects 7.30 / 6.40 / 6.0 |
| `fuse_init_flag_names_maps_known_and_unknown` | PASS | named bits + unknown-bit hex token |
| `cargo clippy -p curvine-fuse --lib` / `fmt --check` | PASS | no warnings |

# Dependencies

- Related PRs: None
- Related issues: #1122 (ATOMIC_O_TRUNC, prior), #1142 (FUSE_HAS_IOCTL_DIR rename)
- Blocks / blocked by: None
