### PR TITLE
fix(orpc): create testing/ directory in Utils::test_file (#1184)

### DIFF
--- a/orpc/src/common/utils.rs
+++ b/orpc/src/common/utils.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::common::{FileUtils, LocalTime};
+use crate::common::LocalTime;
 use crate::runtime::Runtime;
 use crate::CommonResult;
 use md5::{Digest, Md5};
@@ -148,8 +148,9 @@ impl Utils {
         let mut path = env::current_dir().unwrap_or(PathBuf::from("."));
         path.push("../testing");
 
-        // Ensure the testing directory exists
-        let _ = FileUtils::create_parent_dir(&path, true);
+        // Create the testing/ directory itself (create_parent_dir would only
+        // ensure the parent of ../testing, i.e. the workspace root).
+        fs::create_dir_all(&path).expect("failed to create testing/ for Utils::test_file");
 
         path.push(format!("test-{}", Self::rand_id()));
         format!("{}", path.display())
@@ -355,5 +356,21 @@ mod tests {
     fn cur_dir() {
         let dir = Utils::cur_dir_sub("meta");
         println!("{}", dir)
+    }
+
+    #[test]
+    fn test_file_creates_testing_directory() {
+        use std::path::Path;
+
+        let path = Utils::test_file();
+        let parent = Path::new(&path).parent().expect("test file has parent");
+        assert!(
+            parent.is_dir(),
+            "Utils::test_file must create testing/; missing {:?}",
+            parent
+        );
+        // Ensure the returned path is writable (the original ENOENT failure mode).
+        std::fs::File::create(&path).expect("should be able to create file under testing/");
+        let _ = std::fs::remove_file(&path);
     }
 }


### PR DESCRIPTION
# Summary

Fix `Utils::test_file()` so it creates the workspace `testing/` directory itself instead of only ensuring its parent exists. Clean checkouts (and curvine-next sync trees) no longer fail `state_file::test_write_read` with ENOENT.

# Issue Describe / Design

Closes #1184

## Root cause
`test_file()` called `FileUtils::create_parent_dir` on `cwd/../testing`. That helper creates the **parent** of the given path, so it never creates `testing/` — only the workspace root. Errors were discarded via `let _ = ...`, so the helper silently returned a path under a missing directory.

## Reproduction
```bash
rm -rf testing   # or use a tree without testing/
cargo test -p curvine-common --lib fs::state_file::tests::test_write_read
# IOError: No such file or directory
```

## Fix approach
Align with `Utils::test_sub_dir`: call `fs::create_dir_all` on `../testing` before appending the random filename, and panic on failure so test setup errors are visible. Add a unit test that asserts the parent directory exists and is writable.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `orpc/src/common/utils.rs` | Create `testing/` via `create_dir_all`; fail loudly on error; add unit test | Test helpers work on clean checkout; no production runtime impact |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p orpc --lib common::utils::tests::test_file_creates_testing_directory` | PASS | |
| `cargo test -p curvine-common --lib fs::state_file::tests::test_write_read` (without pre-existing `testing/`) | PASS | |

# Dependencies

- Related PRs: None
- Related issues: #1184
- Blocks / blocked by: None
