### PR TITLE
fix(orpc): create testing/ directory in Utils::test_file (#1184)

### DIFF
--- a/orpc/src/common/utils.rs
+++ b/orpc/src/common/utils.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::common::{FileUtils, LocalTime};
+use crate::common::LocalTime;
 use crate::runtime::Runtime;
 use crate::CommonResult;
 use md5::{Digest, Md5};
@@ -148,8 +148,9 @@ impl Utils {
         let mut path = env::current_dir().unwrap_or(PathBuf::from("."));
         path.push("../testing");
 
-        // Ensure the testing directory exists
-        let _ = FileUtils::create_parent_dir(&path, true);
+        // Ensure the testing directory itself exists (not only its parent).
+        // create_parent_dir(../testing) would only create the workspace root.
+        let _ = fs::create_dir_all(&path);
 
         path.push(format!("test-{}", Self::rand_id()));
         format!("{}", path.display())
@@ -355,5 +356,42 @@ mod tests {
     fn cur_dir() {
         let dir = Utils::cur_dir_sub("meta");
         println!("{}", dir)
+    }
+
+    #[test]
+    fn test_file_creates_testing_dir() {
+        use std::env;
+        use std::fs;
+        use std::path::Path;
+        use std::sync::Mutex;
+
+        // Serialize CWD mutations across parallel tests in this crate.
+        static CWD_LOCK: Mutex<()> = Mutex::new(());
+        let _guard = CWD_LOCK.lock().unwrap();
+
+        let base = env::temp_dir().join(format!("orpc-test-file-{}", Utils::rand_id()));
+        let work = base.join("crate_cwd");
+        fs::create_dir_all(&work).unwrap();
+
+        let testing = base.join("testing");
+        assert!(!testing.exists());
+
+        let prev = env::current_dir().unwrap();
+        env::set_current_dir(&work).unwrap();
+
+        let file = Utils::test_file();
+        let parent = Path::new(&file)
+            .parent()
+            .and_then(|p| p.canonicalize().ok());
+        let testing_canon = testing.canonicalize().ok();
+        let ok = testing.is_dir() && parent == testing_canon;
+
+        env::set_current_dir(prev).unwrap();
+        let _ = fs::remove_dir_all(&base);
+
+        assert!(
+            ok,
+            "test_file() must create ../testing and place the file under it"
+        );
     }
 }

--- a/orpc/src/common/utils.rs
+++ b/orpc/src/common/utils.rs
@@ -150,7 +150,9 @@ impl Utils {
 
         // Ensure the testing directory itself exists (not only its parent).
         // create_parent_dir(../testing) would only create the workspace root.
-        let _ = fs::create_dir_all(&path);
+        fs::create_dir_all(&path).unwrap_or_else(|e| {
+            panic!("failed to create testing dir {}: {}", path.display(), e);
+        });
 
         path.push(format!("test-{}", Self::rand_id()));
         format!("{}", path.display())
@@ -162,7 +164,9 @@ impl Utils {
         path.push(sub);
 
         // Ensure the sub directory exists
-        let _ = fs::create_dir_all(&path);
+        fs::create_dir_all(&path).unwrap_or_else(|e| {
+            panic!("failed to create testing sub dir {}: {}", path.display(), e);
+        });
 
         format!("{}", path.display())
     }


### PR DESCRIPTION
# Summary

`Utils::test_file()` called `create_parent_dir` on `../testing`, which only creates the workspace root and never creates `testing/` itself. Clean checkouts then fail with ENOENT in consumers such as `state_file::test_write_read`.

# Issue Describe / Design

Closes #1184

Closes CUR-56

## Root cause

`FileUtils::create_parent_dir(path)` creates the **parent** of `path`. For `cwd/../testing` that parent is the workspace root, so `testing/` is never created. The error was also discarded via `let _ = ...`.

## Reproduction

1. Ensure workspace-root `testing/` does not exist (`rm -rf testing`).
2. `cargo test -p curvine-common --lib fs::state_file::tests::test_write_read`
3. Observe ENOENT at `StateWriter::new`.

## Fix approach

Align `test_file()` with `test_sub_dir()`: call `fs::create_dir_all` on the `../testing` directory before appending the random filename. Add a unit test that runs under a temporary CWD without a pre-existing `testing/` directory.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `orpc/src/common/utils.rs` | `test_file()` creates `testing/` via `create_dir_all`; add `test_file_creates_testing_dir` | Tests that rely on `test_file()` now work on clean checkouts; no production path change |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p orpc --lib common::utils::tests::test_file_creates_testing_dir -- --exact` | PASS | Temp CWD without pre-existing `testing/` |
| `cargo test -p curvine-common --lib fs::state_file::tests::test_write_read -- --exact` | PASS | After `rm -rf testing` |

# Dependencies

- Related PRs: None
- Related issues: #1184
- Blocks / blocked by: None

Made with [Cursor](https://cursor.com)