### PR TITLE
fix(fuse): wire RENAME2/FSYNCDIR/DESTROY and add an opcode-status matrix (#1088)

### DIFF
--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -39,6 +39,7 @@ use orpc::runtime::Runtime;
 use orpc::sys::FFIUtils;
 use orpc::{sys, ternary, try_option};
 use std::collections::HashMap;
+use std::ffi::OsStr;
 use std::sync::Arc;
 
 pub struct CurvineFileSystem {
@@ -189,6 +190,40 @@ impl CurvineFileSystem {
         if first.is_ok() {
             *first = next;
         }
+    }
+
+    /// Shared rename path resolution used by both `rename` and `rename2`.
+    async fn rename_paths(
+        &self,
+        old_id: u64,
+        old_name: &OsStr,
+        new_dir: u64,
+        new_name: &OsStr,
+    ) -> FuseResult<()> {
+        let old_name = try_option!(old_name.to_str());
+        let new_name = try_option!(new_name.to_str());
+        if new_name.len() > FUSE_MAX_NAME_LENGTH {
+            return err_fuse!(libc::ENAMETOOLONG);
+        }
+
+        let (old_path, new_path) = self.state.get_path2(old_id, old_name, new_dir, new_name)?;
+        self.ensure_writable_path(&old_path, RpcCode::Rename)
+            .await?;
+        self.ensure_writable_path(&new_path, RpcCode::Rename)
+            .await?;
+
+        self.state
+            .fs_rename(old_id, old_name, new_dir, new_name)
+            .await
+    }
+
+    /// Whether a RENAME2 `flags` value is supported. Checked against the RAW
+    /// value (not `RenameFlags::from_bits_truncate`, which would silently drop
+    /// unknown high bits and let a flag the kernel required pass as a plain
+    /// rename). The FUSE-facing client only issues flag-less renames, so any
+    /// non-zero flag (NO_REPLACE/EXCHANGE/WHITEOUT/…) is rejected with ENOSYS.
+    fn rename2_flags_supported(flags: u32) -> bool {
+        flags == 0
     }
 
     fn to_file_lock(&self, arg: &fuse_lk_in) -> FileLock {
@@ -1203,24 +1238,24 @@ impl fs::FileSystem for CurvineFileSystem {
     }
 
     async fn rename(&self, op: Rename<'_>) -> FuseResult<()> {
-        let old_name = try_option!(op.old_name.to_str());
-        let new_name = try_option!(op.new_name.to_str());
-        if new_name.len() > FUSE_MAX_NAME_LENGTH {
-            return err_fuse!(libc::ENAMETOOLONG);
+        self.rename_paths(op.header.nodeid, op.old_name, op.arg.newdir, op.new_name)
+            .await
+    }
+
+    async fn rename2(&self, op: Rename2<'_>) -> FuseResult<()> {
+        // The FUSE-facing client rename path only issues flag-less renames, so
+        // NO_REPLACE/EXCHANGE/WHITEOUT are not plumbed through to the master RPC.
+        // Reject any flag with ENOSYS (POSIX-correct, and strictly better than
+        // the previous "all RENAME2 -> ENOSYS via the dispatch wildcard").
+        if !Self::rename2_flags_supported(op.arg.flags) {
+            return err_fuse!(
+                libc::ENOSYS,
+                "RENAME2 flags 0x{:x} not supported (flag-less rename only)",
+                op.arg.flags
+            );
         }
-
-        let (old_path, new_path) =
-            self.state
-                .get_path2(op.header.nodeid, old_name, op.arg.newdir, new_name)?;
-        self.ensure_writable_path(&old_path, RpcCode::Rename)
-            .await?;
-        self.ensure_writable_path(&new_path, RpcCode::Rename)
-            .await?;
-
-        self.state
-            .fs_rename(op.header.nodeid, old_name, op.arg.newdir, new_name)
-            .await?;
-        Ok(())
+        self.rename_paths(op.header.nodeid, op.old_name, op.arg.newdir, op.new_name)
+            .await
     }
 
     async fn batch_forget(&self, op: BatchForget<'_>) -> FuseResult<()> {
@@ -1729,5 +1764,18 @@ mod tests {
         let names = fuse_init_flag_names(FUSE_BIG_WRITES | unknown);
         assert!(names.contains(&"BIG_WRITES".to_string()));
         assert!(names.iter().any(|n| n == "0x40000000"));
+    }
+
+    #[test]
+    fn rename2_flags_supported_only_accepts_zero() {
+        // Flag-less rename is the only supported form.
+        assert!(CurvineFileSystem::rename2_flags_supported(0));
+        // Known rename flags are rejected (client does not plumb them through).
+        assert!(!CurvineFileSystem::rename2_flags_supported(1)); // RENAME_NOREPLACE
+        assert!(!CurvineFileSystem::rename2_flags_supported(2)); // RENAME_EXCHANGE
+        assert!(!CurvineFileSystem::rename2_flags_supported(4)); // RENAME_WHITEOUT
+                                                                 // An unknown high bit must also be rejected — checked against the raw
+                                                                 // value, so it is not silently truncated away (the RenameFlags footgun).
+        assert!(!CurvineFileSystem::rename2_flags_supported(1 << 6));
     }
 }

--- a/curvine-fuse/src/fs/file_system.rs
+++ b/curvine-fuse/src/fs/file_system.rs
@@ -157,6 +157,29 @@ pub trait FileSystem: Send + Sync + 'static {
         async move { err_fuse!(libc::ENOSYS, "{:?}", op) }
     }
 
+    /// `renameat2(2)` with flags. Default ENOSYS (like `rename`); an
+    /// implementation may delegate the flag-less case to `rename` and reject
+    /// unsupported flags.
+    fn rename2(&self, op: Rename2<'_>) -> impl Future<Output = FuseResult<()>> + Send {
+        async move { err_fuse!(libc::ENOSYS, "{:?}", op) }
+    }
+
+    /// `fsync(2)`/`fdatasync(2)` on a directory fd. Default is a benign no-op:
+    /// directory metadata is synchronized to the master via RPC on each
+    /// mutation, so there is no client-side directory write buffer to flush.
+    fn fsync_dir(&self, _op: FSyncDir<'_>) -> impl Future<Output = FuseResult<()>> + Send {
+        async move { Ok(()) }
+    }
+
+    /// The kernel's teardown signal, sent synchronously on a clean umount and
+    /// awaiting an (empty) reply. Curvine performs its real unmount cleanup
+    /// out-of-band via `FuseSession` (which calls `unmount()`), so `destroy`
+    /// only acknowledges with an empty reply and deliberately does NOT call
+    /// `unmount()` here, to avoid a double unmount.
+    fn destroy(&self, _op: Destroy<'_>) -> impl Future<Output = FuseResult<()>> + Send {
+        async move { Ok(()) }
+    }
+
     /// Best-effort fallback for an interrupt whose target is no longer present in
     /// the dispatcher's pending-request map. The pending-request notification is
     /// the primary cancellation path; this result reports internal handling only,

--- a/curvine-fuse/src/fs/operator.rs
+++ b/curvine-fuse/src/fs/operator.rs
@@ -21,7 +21,6 @@ use std::fmt::{Debug, Formatter};
 #[derive(Debug)]
 pub enum FuseOperator<'a> {
     Notimplemented,
-    Empty,
     Init(Init<'a>),
     StatFs(StatFs<'a>),
     ReadDir(ReadDir<'a>),
@@ -54,6 +53,8 @@ pub enum FuseOperator<'a> {
     Interrupt(Interrupt<'a>),
     ListXAttr(ListXAttr<'a>),
     FSync(FSync<'a>),
+    FSyncDir(FSyncDir<'a>),
+    Destroy(Destroy<'a>),
     Symlink(Symlink<'a>),
     Readlink(Readlink<'a>),
     GetLk(GetLk<'a>),
@@ -351,6 +352,15 @@ pub struct ListXAttr<'a> {
 
 #[derive(Debug)]
 pub struct FSync<'a> {
+    pub header: &'a fuse_in_header,
+    pub arg: &'a fuse_fsync_in,
+}
+
+// fsync on a directory fd. Shares `fuse_fsync_in` with file FSync, but is a
+// distinct operator: FSYNC is stream-routed to `fsync`, FSYNCDIR is meta-routed
+// to `fsync_dir`.
+#[derive(Debug)]
+pub struct FSyncDir<'a> {
     pub header: &'a fuse_in_header,
     pub arg: &'a fuse_fsync_in,
 }

--- a/curvine-fuse/src/session/channel/fuse_receiver.rs
+++ b/curvine-fuse/src/session/channel/fuse_receiver.rs
@@ -331,7 +331,7 @@ impl<T: FileSystem> FuseReceiver<T> {
 
         // NOTE: keep this match's stream arms in sync with `FuseRequest::is_stream()`
         // (Read/Write/Flush/Release/Fsync). `send_stream` is only entered when
-        // `is_stream()` is true, so the wildcard is unreachable today; it exists
+        // `is_stream()` is true, so the fallback is unreachable today; it exists
         // as a defensive branch in case the two ever drift.
         let res = match operator {
             FuseOperator::Read(op) => fs.read(op, rep).await,
@@ -344,11 +344,48 @@ impl<T: FileSystem> FuseReceiver<T> {
 
             FuseOperator::FSync(op) => fs.fsync(op, rep).await,
 
-            _ => {
-                // Defensive: a stream-gated request whose operator is not a known
-                // stream op. Tag it `unimplemented_opcode` so it classifies as
-                // Unsupported — the same semantics as the metadata `dispatch_meta`
-                // wildcard — rather than a plain backend Error.
+            // Exhaustive fallback — NOT a `_` wildcard: naming every non-stream
+            // variant keeps the match exhaustive, so a newly-added `FuseOperator`
+            // variant that is not wired here (or in `dispatch_meta`) fails to
+            // compile. Reaching any of these is a routing bug (`send_stream` is
+            // only entered when `is_stream()`), so tag `unimplemented_opcode` —
+            // same Unsupported classification as the `dispatch_meta` fallback —
+            // rather than a plain backend Error.
+            FuseOperator::Notimplemented
+            | FuseOperator::Init(_)
+            | FuseOperator::StatFs(_)
+            | FuseOperator::ReadDir(_)
+            | FuseOperator::Lookup(_)
+            | FuseOperator::GetAttr(_)
+            | FuseOperator::SetAttr(_)
+            | FuseOperator::GetXAttr(_)
+            | FuseOperator::SetXAttr(_)
+            | FuseOperator::RemoveXAttr(_)
+            | FuseOperator::OpenDir(_)
+            | FuseOperator::Mkdir(_)
+            | FuseOperator::FAllocate(_)
+            | FuseOperator::ReleaseDir(_)
+            | FuseOperator::Access(_)
+            | FuseOperator::ReadDirPlus(_)
+            | FuseOperator::Forget(_)
+            | FuseOperator::Open(_)
+            | FuseOperator::MkNod(_)
+            | FuseOperator::Create(_)
+            | FuseOperator::Unlink(_)
+            | FuseOperator::RmDir(_)
+            | FuseOperator::Link(_)
+            | FuseOperator::BatchForget(_)
+            | FuseOperator::Rename(_)
+            | FuseOperator::Rename2(_)
+            | FuseOperator::Interrupt(_)
+            | FuseOperator::ListXAttr(_)
+            | FuseOperator::FSyncDir(_)
+            | FuseOperator::Destroy(_)
+            | FuseOperator::Symlink(_)
+            | FuseOperator::Readlink(_)
+            | FuseOperator::GetLk(_)
+            | FuseOperator::SetLk(_)
+            | FuseOperator::SetLkW(_) => {
                 let err: FuseResult<fuse_out_header> = err_fuse!(
                     libc::ENOSYS,
                     "unsupported stream operation {:?}",
@@ -687,17 +724,31 @@ impl<T: FileSystem> FuseReceiver<T> {
 
             FuseOperator::SetLkW(op) => reply.send_rep(fs.set_lkw(op).await).await,
 
-            _ => {
-                // A parsed-but-unhandled opcode: source-tagged as Unsupported so
-                // it classifies that way (not a backend Error). The reason splits
-                // two cases the kernel can produce:
-                //   - opcode == NOT_SUPPORTED (the num_enum default, raw opcode
-                //     this build has no enum value for) -> `unknown_opcode`
-                //     (a kernel/daemon protocol-compatibility signal).
-                //   - a known but intentionally-unsupported opcode (BMAP/POLL/
-                //     IOCTL/LSEEK) -> `unimplemented_opcode`. Which opcodes are
-                //     intentionally unsupported vs. a real gap is recorded
-                //     authoritatively by `FuseOpCode::expected_dispatch`.
+            // Exhaustive fallback — NOT a `_` wildcard, deliberately: listing the
+            // remaining variants makes the match exhaustive, so adding a new
+            // `FuseOperator` variant without a dispatch arm here (or in
+            // `send_stream_dispatch`) fails to compile. This is the compile-time
+            // guarantee `expected_dispatch` cannot give (it is `#[cfg(test)]` and
+            // opcode-level, not arm-level), and is what would have caught the
+            // RENAME2 half-wiring. The arms handled here:
+            //   - `Notimplemented`: parse mapped an unknown/unsupported opcode to
+            //     the catch-all variant.
+            //   - the five stream ops (Read/Write/Flush/Release/FSync): these are
+            //     dispatched by `send_stream_dispatch`, never through this
+            //     metadata path, so reaching them here is a routing bug — but they
+            //     must still be named to keep the match exhaustive.
+            // Source-tag as Unsupported (not a backend Error). Split the reason:
+            //   - opcode == NOT_SUPPORTED (num_enum default for a raw opcode this
+            //     build has no enum value for) -> `unknown_opcode`.
+            //   - a known but intentionally-unsupported opcode (BMAP/POLL/IOCTL/
+            //     LSEEK) -> `unimplemented_opcode`. The authoritative
+            //     intentional-vs-gap record is `FuseOpCode::expected_dispatch`.
+            FuseOperator::Notimplemented
+            | FuseOperator::Read(_)
+            | FuseOperator::Write(_)
+            | FuseOperator::Flush(_)
+            | FuseOperator::Release(_)
+            | FuseOperator::FSync(_) => {
                 let reason = if req.opcode() == FuseOpCode::NOT_SUPPORTED {
                     "unknown_opcode"
                 } else {

--- a/curvine-fuse/src/session/channel/fuse_receiver.rs
+++ b/curvine-fuse/src/session/channel/fuse_receiver.rs
@@ -661,6 +661,12 @@ impl<T: FileSystem> FuseReceiver<T> {
 
             FuseOperator::Rename(op) => reply.send_rep(fs.rename(op).await).await,
 
+            FuseOperator::Rename2(op) => reply.send_rep(fs.rename2(op).await).await,
+
+            FuseOperator::FSyncDir(op) => reply.send_rep(fs.fsync_dir(op).await).await,
+
+            FuseOperator::Destroy(op) => reply.send_rep(fs.destroy(op).await).await,
+
             FuseOperator::Interrupt(op) => {
                 let res = if let Some(notify) = pending_requests.get(&op.arg.unique) {
                     notify.notify_one();
@@ -688,8 +694,10 @@ impl<T: FileSystem> FuseReceiver<T> {
                 //   - opcode == NOT_SUPPORTED (the num_enum default, raw opcode
                 //     this build has no enum value for) -> `unknown_opcode`
                 //     (a kernel/daemon protocol-compatibility signal).
-                //   - a known opcode with no dispatch arm (e.g. Rename2) ->
-                //     `unimplemented_opcode` (an implementation-gap signal).
+                //   - a known but intentionally-unsupported opcode (BMAP/POLL/
+                //     IOCTL/LSEEK) -> `unimplemented_opcode`. Which opcodes are
+                //     intentionally unsupported vs. a real gap is recorded
+                //     authoritatively by `FuseOpCode::expected_dispatch`.
                 let reason = if req.opcode() == FuseOpCode::NOT_SUPPORTED {
                     "unknown_opcode"
                 } else {
@@ -835,7 +843,9 @@ mod tests {
         use crate::fuse_metrics::{
             FuseMetrics, FuseReqCtx, FuseReqKind, FuseReqLabels, FuseReqStatus,
         };
-        use crate::raw::fuse_abi::{fuse_forget_in, fuse_in_header, fuse_interrupt_in};
+        use crate::raw::fuse_abi::{
+            fuse_forget_in, fuse_fsync_in, fuse_in_header, fuse_interrupt_in, fuse_rename2_in,
+        };
         use crate::session::{FuseRequest, FuseResponse, FuseTask};
         use crate::FuseUtils;
         use bytes::{BufMut, BytesMut};
@@ -1411,6 +1421,91 @@ mod tests {
                 pending2.get(&2002).is_none(),
                 "malformed SETLKW dispatch branch removed its pending_requests entry"
             );
+        }
+
+        // --- Issue #1088: opcode coverage — arm-wired vs intentional wildcard ---
+
+        const OP_RENAME2: u32 = 45;
+        const OP_FSYNCDIR: u32 = 30;
+        const OP_DESTROY: u32 = 38;
+        const OP_BMAP: u32 = 37;
+
+        // Drive dispatch_meta and return the enqueued RequestReply's
+        // (unsupported_reason, errno). Panics if no RequestReply was enqueued.
+        async fn dispatch_reason_errno(
+            req: &FuseRequest,
+            opcode: &'static str,
+        ) -> (Option<&'static str>, i32) {
+            let pending = FastDashMap::default();
+            let (reply, mut rx) = metrics_reply(req.get_header().unwrap().unique, opcode);
+            let _ = super::super::FuseReceiver::dispatch_meta(&pending, &fs(), req, &reply).await;
+            match rx.try_recv().unwrap().expect("a RequestReply task") {
+                FuseTask::RequestReply {
+                    unsupported_reason,
+                    errno,
+                    ..
+                } => (unsupported_reason, errno),
+                _ => panic!("expected a RequestReply task"),
+            }
+        }
+
+        // RENAME2 with flags==0 reaches the real arm (not the wildcard). The
+        // TestFileSystem inherits the trait-default rename2 (ENOSYS), so errno is
+        // ENOSYS here, but the key assertion is unsupported_reason == None (arm
+        // wired, not half-wired via the wildcard).
+        #[tokio::test]
+        async fn rename2_flagless_reaches_dispatch_arm() {
+            let arg = fuse_rename2_in {
+                newdir: 2,
+                flags: 0,
+                padding: 0,
+            };
+            let mut payload = Vec::from(FuseUtils::struct_as_bytes(&arg));
+            payload.extend_from_slice(b"old\0new\0");
+            let req = make_request(OP_RENAME2, 3001, 1, &payload);
+            let (reason, _errno) = dispatch_reason_errno(&req, "Rename2").await;
+            assert_eq!(
+                reason, None,
+                "RENAME2 must reach its dispatch arm, not the wildcard"
+            );
+        }
+
+        // FSYNCDIR is wired to the no-op fsync_dir default -> empty success reply,
+        // untagged.
+        #[tokio::test]
+        async fn fsyncdir_reaches_dispatch_arm_and_succeeds() {
+            let req = make_request(
+                OP_FSYNCDIR,
+                3002,
+                1,
+                FuseUtils::struct_as_bytes(&fuse_fsync_in::default()),
+            );
+            let (reason, errno) = dispatch_reason_errno(&req, "FsyncDir").await;
+            assert_eq!(reason, None, "FSYNCDIR must reach its dispatch arm");
+            assert_eq!(errno, 0, "fsync_dir default is a no-op success");
+        }
+
+        // DESTROY is reply-expecting (send_rep, NOT send_none): it MUST enqueue a
+        // RequestReply, and the no-op default yields an empty success reply.
+        #[tokio::test]
+        async fn destroy_reaches_dispatch_arm_and_succeeds() {
+            let req = make_request(OP_DESTROY, 3003, 0, &[]);
+            let (reason, errno) = dispatch_reason_errno(&req, "Destroy").await;
+            assert_eq!(reason, None, "DESTROY must reach its dispatch arm");
+            assert_eq!(errno, 0, "destroy default acks with an empty success reply");
+        }
+
+        // BMAP has no arm on purpose -> wildcard, tagged unimplemented_opcode.
+        #[tokio::test]
+        async fn bmap_falls_through_wildcard_as_unimplemented() {
+            let req = make_request(OP_BMAP, 3004, 1, &[]);
+            let (reason, errno) = dispatch_reason_errno(&req, "BMap").await;
+            assert_eq!(
+                reason,
+                Some("unimplemented_opcode"),
+                "BMAP is intentionally unsupported -> wildcard"
+            );
+            assert_eq!(errno, libc::ENOSYS);
         }
     }
 

--- a/curvine-fuse/src/session/fuse_op_code.rs
+++ b/curvine-fuse/src/session/fuse_op_code.rs
@@ -130,11 +130,16 @@ impl FuseOpCode {
     }
 }
 
-/// The dispatch status of an opcode: the single source of truth for whether an
-/// opcode is handled, and — for the unhandled ones — whether that is deliberate.
-/// Kept as an exhaustive match (no wildcard) so a newly-added `FuseOpCode`
-/// variant fails to compile until it is consciously classified here, preventing
-/// silent half-wiring (a parsed opcode with no dispatch arm, as RENAME2 once was).
+/// The dispatch status of an opcode: an opcode-level record of whether an
+/// opcode is handled, and — for the unhandled ones — whether that is deliberate
+/// (`Unsupported`) or protocol-internal (`Internal`), with the rationale.
+///
+/// The compile-time guarantee that a *parsed* operator actually has a dispatch
+/// arm lives in the exhaustive (no-`_`) matches in `dispatch_meta` and
+/// `send_stream_dispatch`: adding a `FuseOperator` variant with no arm fails to
+/// compile there. This matrix complements that with the opcode-level intent
+/// (why BMAP/POLL/etc. are ENOSYS, which opcodes are protocol-internal); its own
+/// exhaustive match likewise forces a newly-added `FuseOpCode` to be classified.
 #[cfg(test)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub(crate) enum DispatchStatus {

--- a/curvine-fuse/src/session/fuse_op_code.rs
+++ b/curvine-fuse/src/session/fuse_op_code.rs
@@ -130,6 +130,96 @@ impl FuseOpCode {
     }
 }
 
+/// The dispatch status of an opcode: the single source of truth for whether an
+/// opcode is handled, and — for the unhandled ones — whether that is deliberate.
+/// Kept as an exhaustive match (no wildcard) so a newly-added `FuseOpCode`
+/// variant fails to compile until it is consciously classified here, preventing
+/// silent half-wiring (a parsed opcode with no dispatch arm, as RENAME2 once was).
+#[cfg(test)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub(crate) enum DispatchStatus {
+    /// Has a real `dispatch_meta`/`send_stream_dispatch` arm.
+    Handled,
+    /// Dispatched via `send_none` (no reply to the kernel).
+    NoReply,
+    /// Intentionally falls through the dispatch wildcard to ENOSYS.
+    Unsupported,
+    /// Not dispatched to a `FileSystem` op here (protocol/enum-internal).
+    Internal,
+}
+
+#[cfg(test)]
+impl FuseOpCode {
+    pub(crate) fn expected_dispatch(&self) -> DispatchStatus {
+        use DispatchStatus::*;
+        match self {
+            // No-reply ops (send_none).
+            FuseOpCode::FUSE_FORGET
+            | FuseOpCode::FUSE_BATCH_FORGET
+            | FuseOpCode::FUSE_INTERRUPT => NoReply,
+
+            // Intentionally unsupported (ENOSYS via wildcard):
+            //   - FUSE_BMAP:  logical->physical block map, only for block-backed
+            //     (fuseblk) filesystems; meaningless for a distributed fs.
+            //   - FUSE_POLL:  readiness for special/char files; regular files are
+            //     always ready, so the VFS never needs it here.
+            //   - FUSE_IOCTL: device/fs-specific ioctls; no passthrough (and
+            //     FUSE_HAS_IOCTL_DIR is deliberately not negotiated in init).
+            //   - FUSE_LSEEK: SEEK_HOLE/SEEK_DATA only; ENOSYS is a safe VFS
+            //     fallback (kernel treats the file as hole-less).
+            FuseOpCode::FUSE_BMAP
+            | FuseOpCode::FUSE_POLL
+            | FuseOpCode::FUSE_IOCTL
+            | FuseOpCode::FUSE_LSEEK => Unsupported,
+
+            // Not dispatched as a FileSystem op: NOT_SUPPORTED is the num_enum
+            // default for unknown raw opcodes; CUSE_INIT is a CUSE handshake, not
+            // a filesystem path; NOTIFY_REPLY is a daemon->kernel notify channel.
+            FuseOpCode::NOT_SUPPORTED | FuseOpCode::CUSE_INIT | FuseOpCode::FUSE_NOTIFY_REPLY => {
+                Internal
+            }
+
+            // Everything else has a real dispatch arm.
+            FuseOpCode::FUSE_LOOKUP
+            | FuseOpCode::FUSE_GETATTR
+            | FuseOpCode::FUSE_SETATTR
+            | FuseOpCode::FUSE_READLINK
+            | FuseOpCode::FUSE_SYMLINK
+            | FuseOpCode::FUSE_MKNOD
+            | FuseOpCode::FUSE_MKDIR
+            | FuseOpCode::FUSE_UNLINK
+            | FuseOpCode::FUSE_RMDIR
+            | FuseOpCode::FUSE_RENAME
+            | FuseOpCode::FUSE_LINK
+            | FuseOpCode::FUSE_OPEN
+            | FuseOpCode::FUSE_READ
+            | FuseOpCode::FUSE_WRITE
+            | FuseOpCode::FUSE_STATFS
+            | FuseOpCode::FUSE_RELEASE
+            | FuseOpCode::FUSE_FSYNC
+            | FuseOpCode::FUSE_SETXATTR
+            | FuseOpCode::FUSE_GETXATTR
+            | FuseOpCode::FUSE_LISTXATTR
+            | FuseOpCode::FUSE_REMOVEXATTR
+            | FuseOpCode::FUSE_FLUSH
+            | FuseOpCode::FUSE_INIT
+            | FuseOpCode::FUSE_OPENDIR
+            | FuseOpCode::FUSE_READDIR
+            | FuseOpCode::FUSE_RELEASEDIR
+            | FuseOpCode::FUSE_FSYNCDIR
+            | FuseOpCode::FUSE_GETLK
+            | FuseOpCode::FUSE_SETLK
+            | FuseOpCode::FUSE_SETLKW
+            | FuseOpCode::FUSE_ACCESS
+            | FuseOpCode::FUSE_CREATE
+            | FuseOpCode::FUSE_DESTROY
+            | FuseOpCode::FUSE_FALLOCATE
+            | FuseOpCode::FUSE_READDIRPLUS
+            | FuseOpCode::FUSE_RENAME2 => Handled,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::FuseOpCode;
@@ -190,6 +280,71 @@ mod tests {
         ];
         for (op, expected) in table {
             assert_eq!(op.as_str(), expected, "label mismatch for {:?}", op);
+        }
+    }
+
+    #[test]
+    fn expected_dispatch_classifies_every_opcode() {
+        use super::DispatchStatus::*;
+        // Full (variant, expected-status) table. `expected_dispatch` is an
+        // exhaustive match, so adding a FuseOpCode variant already fails to
+        // compile until classified there; this table additionally pins the
+        // intended status so a reclassification is a conscious edit.
+        let table = [
+            (FuseOpCode::NOT_SUPPORTED, Internal),
+            (FuseOpCode::FUSE_LOOKUP, Handled),
+            (FuseOpCode::FUSE_FORGET, NoReply),
+            (FuseOpCode::FUSE_GETATTR, Handled),
+            (FuseOpCode::FUSE_SETATTR, Handled),
+            (FuseOpCode::FUSE_READLINK, Handled),
+            (FuseOpCode::FUSE_SYMLINK, Handled),
+            (FuseOpCode::FUSE_MKNOD, Handled),
+            (FuseOpCode::FUSE_MKDIR, Handled),
+            (FuseOpCode::FUSE_UNLINK, Handled),
+            (FuseOpCode::FUSE_RMDIR, Handled),
+            (FuseOpCode::FUSE_RENAME, Handled),
+            (FuseOpCode::FUSE_LINK, Handled),
+            (FuseOpCode::FUSE_OPEN, Handled),
+            (FuseOpCode::FUSE_READ, Handled),
+            (FuseOpCode::FUSE_WRITE, Handled),
+            (FuseOpCode::FUSE_STATFS, Handled),
+            (FuseOpCode::FUSE_RELEASE, Handled),
+            (FuseOpCode::FUSE_FSYNC, Handled),
+            (FuseOpCode::FUSE_SETXATTR, Handled),
+            (FuseOpCode::FUSE_GETXATTR, Handled),
+            (FuseOpCode::FUSE_LISTXATTR, Handled),
+            (FuseOpCode::FUSE_REMOVEXATTR, Handled),
+            (FuseOpCode::FUSE_FLUSH, Handled),
+            (FuseOpCode::FUSE_INIT, Handled),
+            (FuseOpCode::FUSE_OPENDIR, Handled),
+            (FuseOpCode::FUSE_READDIR, Handled),
+            (FuseOpCode::FUSE_RELEASEDIR, Handled),
+            (FuseOpCode::FUSE_FSYNCDIR, Handled),
+            (FuseOpCode::FUSE_GETLK, Handled),
+            (FuseOpCode::FUSE_SETLK, Handled),
+            (FuseOpCode::FUSE_SETLKW, Handled),
+            (FuseOpCode::FUSE_ACCESS, Handled),
+            (FuseOpCode::FUSE_CREATE, Handled),
+            (FuseOpCode::FUSE_INTERRUPT, NoReply),
+            (FuseOpCode::FUSE_BMAP, Unsupported),
+            (FuseOpCode::FUSE_DESTROY, Handled),
+            (FuseOpCode::FUSE_IOCTL, Unsupported),
+            (FuseOpCode::FUSE_POLL, Unsupported),
+            (FuseOpCode::FUSE_NOTIFY_REPLY, Internal),
+            (FuseOpCode::FUSE_BATCH_FORGET, NoReply),
+            (FuseOpCode::FUSE_FALLOCATE, Handled),
+            (FuseOpCode::FUSE_READDIRPLUS, Handled),
+            (FuseOpCode::FUSE_RENAME2, Handled),
+            (FuseOpCode::FUSE_LSEEK, Unsupported),
+            (FuseOpCode::CUSE_INIT, Internal),
+        ];
+        for (op, expected) in table {
+            assert_eq!(
+                op.expected_dispatch(),
+                expected,
+                "dispatch status mismatch for {:?}",
+                op
+            );
         }
     }
 }

--- a/curvine-fuse/src/session/fuse_op_code.rs
+++ b/curvine-fuse/src/session/fuse_op_code.rs
@@ -175,6 +175,12 @@ impl FuseOpCode {
             // Not dispatched as a FileSystem op: NOT_SUPPORTED is the num_enum
             // default for unknown raw opcodes; CUSE_INIT is a CUSE handshake, not
             // a filesystem path; NOTIFY_REPLY is a daemon->kernel notify channel.
+            // These have no `parse_operator` arm, so they never reach the
+            // dispatcher during normal operation. If one ever did, it would fall
+            // through the dispatch wildcard like `Unsupported` (NOT_SUPPORTED as
+            // `unknown_opcode`, the others as `unimplemented_opcode`); `Internal`
+            // records that we intentionally do not route them, not that reaching
+            // dispatch is impossible.
             FuseOpCode::NOT_SUPPORTED | FuseOpCode::CUSE_INIT | FuseOpCode::FUSE_NOTIFY_REPLY => {
                 Internal
             }

--- a/curvine-fuse/src/session/fuse_request.rs
+++ b/curvine-fuse/src/session/fuse_request.rs
@@ -309,6 +309,16 @@ impl FuseRequest {
                 arg: decoder.get_struct()?,
             }),
 
+            FUSE_FSYNCDIR => FuseOperator::FSyncDir(FSyncDir {
+                header,
+                arg: decoder.get_struct()?,
+            }),
+
+            FUSE_DESTROY => FuseOperator::Destroy(Destroy { header }),
+
+            // Opcodes with no arm fall through to `Notimplemented` -> ENOSYS.
+            // Whether that is intentional (BMAP/POLL/IOCTL/LSEEK etc.) or a gap
+            // is recorded authoritatively by `FuseOpCode::expected_dispatch`.
             _ => FuseOperator::Notimplemented,
         };
 


### PR DESCRIPTION
# Summary

Wire the FUSE opcodes that reached the dispatch wildcard and returned ENOSYS despite being parseable or benign (RENAME2, FSYNCDIR, DESTROY), document the ones intentionally unsupported, remove dead code, and add a compile-time opcode-status matrix as the single source of truth. This is the opcode-coverage half of #1088 (the init capability-allowlist half is #1183).

# Issue Describe / Design

Relates to #1088 (opcode-coverage portion; capability allowlist is in #1183)

- **RENAME2** — was parsed into `FuseOperator::Rename2` but had no dispatch arm or trait method, so every `renameat2(2)` hit the wildcard → ENOSYS. Adds a `rename2` trait method and dispatch arm. A shared `rename_paths` helper backs both `rename` and `rename2` (no duplicated logic). Flag-less renames behave exactly as `rename` did; any RENAME2 flag (`NO_REPLACE`/`EXCHANGE`/`WHITEOUT`) is rejected with ENOSYS via a static `rename2_flags_supported`, checked against the **raw** flags value (not `RenameFlags::from_bits_truncate`, which would silently drop unknown high bits). The FUSE-facing client only issues flag-less renames today, so this conservative rejection is correct and strictly better than the previous "all RENAME2 → ENOSYS".
- **FSYNCDIR** — was unparsed → ENOSYS. Wires parse + a **distinct** `FSyncDir` operator (not reusing `FSync`, which is stream-routed to `fsync`) + a `fsync_dir` trait method defaulting to a no-op `Ok(())`: directory metadata is synchronized to the master per mutation, so there is no client-side dir write buffer to flush. Removes a spurious ENOSYS for apps that fsync directory fds.
- **DESTROY** — had an orphan `Destroy` struct but no variant/parse/dispatch. Wires it to reply with an empty success frame via `send_rep` (DESTROY is reply-expecting, **not** a `send_none` no-reply op — using `send_none` would hang the kernel). The `destroy` trait default is a no-op that deliberately does **not** call `unmount()`; real unmount cleanup is driven out-of-band by `FuseSession`, so calling it here would double-unmount.
- **BMAP/POLL/IOCTL/LSEEK** — documented as intentionally unsupported (still ENOSYS via the wildcard); no dispatch arms added. Rationale recorded on `expected_dispatch`.
- **Dead code** — removed the unused `FuseOperator::Empty` variant.
- **Single source of truth** — adds `FuseOpCode::expected_dispatch`, an exhaustive (no-wildcard) classification of every opcode as `Handled`/`NoReply`/`Unsupported`/`Internal`. Adding a new opcode fails to compile until it is classified, preventing the RENAME2-style half-wiring from recurring. A behavioral test drives `dispatch_meta` and asserts the `unsupported_reason` tag (`None` for a wired arm, `"unimplemented_opcode"` for the intentional wildcard), tying the classification to actual dispatch.

# Changes

| Module / File | Change |
| ------------- | ------ |
| `curvine-fuse/src/fs/operator.rs` | Add `FSyncDir` struct + `FSyncDir`/`Destroy` variants; remove dead `Empty` |
| `curvine-fuse/src/session/fuse_request.rs` | Parse arms for `FUSE_FSYNCDIR`/`FUSE_DESTROY`; wildcard comment → `expected_dispatch` |
| `curvine-fuse/src/fs/file_system.rs` | Trait methods `rename2` (ENOSYS default), `fsync_dir`/`destroy` (no-op Ok default) |
| `curvine-fuse/src/fs/curvine_file_system.rs` | `rename_paths` helper; `rename` delegates; `rename2` + `rename2_flags_supported` |
| `curvine-fuse/src/session/channel/fuse_receiver.rs` | `Rename2`/`FSyncDir`/`Destroy` dispatch arms; behavioral coverage tests |
| `curvine-fuse/src/session/fuse_op_code.rs` | `DispatchStatus` + `expected_dispatch` matrix + completeness test + rationale |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-fuse --lib` | PASS | 193 passed; `dir_tree::test` pre-existing failure skipped |
| `rename2_flags_supported_only_accepts_zero` | PASS | 0 accepted; NO_REPLACE/EXCHANGE/WHITEOUT and unknown high bit rejected |
| `rename2/fsyncdir/destroy_reaches_dispatch_arm*` | PASS | `unsupported_reason: None` (arm wired); fsyncdir/destroy → empty success |
| `bmap_falls_through_wildcard_as_unimplemented` | PASS | `unsupported_reason: Some("unimplemented_opcode")` |
| `expected_dispatch_classifies_every_opcode` | PASS | full-table classification |
| `cargo clippy -p curvine-fuse --lib --tests` / `fmt --check` | PASS | no warnings |

# Dependencies

- Related PRs: #1183 (#1088 init capability allowlist)
- Related issues: #1088
- Blocks / blocked by: None
