### PR TITLE
refactor(worker): decouple block metadata from storage layouts

### DIFF
--- a/curvine-server/src/worker/block/block_meta.rs
+++ b/curvine-server/src/worker/block/block_meta.rs
@@ -12,19 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::worker::storage::{DirState, VfsDir, ACTIVE_DIR, STAGING_DIR};
+use crate::worker::storage::VfsDir;
 use curvine_common::state::{ExtendedBlock, StorageType};
-use orpc::common::{ByteUnit, FileUtils};
-use orpc::io::LocalFile;
-
-#[cfg(feature = "spdk")]
-use orpc::io::{IOError, IOResult};
-
-use orpc::{err_box, sys, try_err, CommonResult};
+use orpc::common::FileUtils;
+use orpc::{err_box, sys, CommonResult};
+use std::fmt;
 use std::fmt::Formatter;
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
-use std::{fmt, fs};
+use std::path::Path;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[repr(i8)]
@@ -58,7 +52,8 @@ pub struct BlockMeta {
     pub(crate) id: i64,
     pub(crate) len: i64,
     pub(crate) state: BlockState,
-    pub(crate) dir: Arc<DirState>,
+    pub(crate) dir_id: u32,
+    pub(crate) storage_type: StorageType,
     pub(crate) actual_len: i64,
     /// SPDK bdev byte offset
     pub(crate) bdev_offset: i64,
@@ -70,7 +65,8 @@ impl BlockMeta {
             id,
             len: block_size,
             state: BlockState::Writing,
-            dir: dir.state.clone(),
+            dir_id: dir.id(),
+            storage_type: dir.storage_type(),
             actual_len: block_size,
             bdev_offset: 0,
         }
@@ -100,7 +96,8 @@ impl BlockMeta {
                     id,
                     len,
                     state,
-                    dir: dir.state.clone(),
+                    dir_id: dir.id(),
+                    storage_type: dir.storage_type(),
                     actual_len,
                     bdev_offset: 0,
                 };
@@ -114,31 +111,19 @@ impl BlockMeta {
         Self::new(block.id, block.len, dir)
     }
 
-    pub fn with_final(meta: &BlockMeta) -> CommonResult<Self> {
-        let path = meta.get_block_path()?;
-        let (len, actual_len) = Self::get_len(&path)?;
-
+    pub fn with_final(meta: &BlockMeta, path: &Path) -> CommonResult<Self> {
+        let (len, actual_len) = Self::get_len(path)?;
         let meta = Self {
             id: meta.id,
             len,
             state: BlockState::Finalized,
-            dir: meta.dir.clone(),
+            dir_id: meta.dir_id,
+            storage_type: meta.storage_type,
             actual_len,
-            bdev_offset: meta.bdev_offset,
+            bdev_offset: 0,
         };
 
         Ok(meta)
-    }
-
-    pub fn with_id(id: i64) -> Self {
-        Self {
-            id,
-            len: 0,
-            state: BlockState::Finalized,
-            dir: Arc::new(DirState::default()),
-            actual_len: 0,
-            bdev_offset: 0,
-        }
     }
 
     /// Finalize SPDK block — uses in-memory BlockMeta length (no filesystem file).
@@ -147,8 +132,9 @@ impl BlockMeta {
             id: meta.id,
             len: committed_len,
             state: BlockState::Finalized,
-            dir: meta.dir.clone(),
-            actual_len: committed_len,
+            dir_id: meta.dir_id,
+            storage_type: meta.storage_type,
+            actual_len: meta.actual_len,
             bdev_offset: meta.bdev_offset,
         }
     }
@@ -177,80 +163,16 @@ impl BlockMeta {
         matches!(self.state, BlockState::Finalized | BlockState::Writing)
     }
 
-    // Write some test data.
-    pub fn write_test_data(&self, size: &str) -> CommonResult<()> {
-        let bytes = ByteUnit::from_str(size)?.as_byte();
-        let str = "A".repeat(bytes as usize);
-        LocalFile::write_string(self.get_block_path()?, str.as_str(), true)?;
-        Ok(())
-    }
-
-    fn get_block_dir(&self) -> CommonResult<PathBuf> {
-        let dir = match self.state {
-            BlockState::Finalized | BlockState::Writing => {
-                let uid = self.id as u64;
-                let d1 = (uid >> 48) & 0x1F;
-                let d2 = (uid >> 32) & 0x1F;
-
-                let mut path = PathBuf::from(&self.dir.base_path);
-                path.push(ACTIVE_DIR);
-                path.push(format!("b{}", d1));
-                path.push(format!("b{}", d2));
-                path
-            }
-
-            BlockState::Recovering => {
-                let mut path = PathBuf::from(&self.dir.base_path);
-                path.push(STAGING_DIR);
-                path
-            }
-        };
-
-        if dir.exists() {
-            if dir.is_dir() {
-                Ok(dir)
-            } else {
-                err_box!("Path {} not a dir", dir.to_string_lossy())
-            }
-        } else {
-            try_err!(fs::create_dir_all(&dir));
-            Ok(dir)
-        }
-    }
-
-    // 1/2/blk_blockid
-    pub fn get_block_path(&self) -> CommonResult<PathBuf> {
-        let mut path = self.get_block_dir()?;
-        path.push(self.state.get_name(self.id));
-        Ok(path)
-    }
-
-    pub fn get_block_file(&self) -> CommonResult<String> {
-        let file = self.get_block_path()?.to_string_lossy().to_string();
-        Ok(file)
-    }
-
-    /// Get the SPDK bdev name for this block.
-    #[cfg(feature = "spdk")]
-    pub(crate) fn get_bdev_name(&self) -> IOResult<String> {
-        self.dir.bdev_name.clone().ok_or_else(|| {
-            IOError::from(format!(
-                "block {} has StorageType::SpdkDisk but dir (dir_id={}) has no bdev_name assigned",
-                self.id, self.dir.dir_id
-            ))
-        })
-    }
-
     pub fn dir_id(&self) -> u32 {
-        self.dir.dir_id
+        self.dir_id
     }
 
     pub fn storage_type(&self) -> StorageType {
-        self.dir.storage_type
+        self.storage_type
     }
 
-    pub fn base_path(&self) -> &Path {
-        self.dir.base_path.as_path()
+    pub fn physical_bytes(&self) -> i64 {
+        self.actual_len
     }
 }
 
@@ -267,60 +189,49 @@ impl fmt::Display for BlockMeta {
 #[cfg(all(test, feature = "spdk"))]
 mod test {
     use super::*;
-    use crate::worker::storage::DirState;
+    use orpc::io::LocalFile;
+    use std::path::PathBuf;
+
     #[cfg(feature = "spdk")]
     fn spdk_writing_meta(id: i64, block_size: i64) -> BlockMeta {
-        let dir = Arc::new(DirState {
-            dir_id: 1,
-            base_path: PathBuf::from("/nonexistent/spdk/path"),
-            storage_type: StorageType::SpdkDisk,
-            bdev_name: Some("NVMe_test_n1".to_string()),
-            bdev_capacity: 1024 * 1024 * 1024,
-            offset_alloc: DirState::new_offset_alloc(
-                StorageType::SpdkDisk,
-                1024 * 1024 * 1024,
-                4096,
-            ),
-        });
         BlockMeta {
             id,
             len: block_size,
             state: BlockState::Writing,
-            dir,
+            dir_id: 1,
+            storage_type: StorageType::SpdkDisk,
             actual_len: block_size,
             bdev_offset: 0,
         }
     }
+
     #[test]
     fn with_final_spdk_succeeds() {
         let meta = spdk_writing_meta(1, 4096);
         let final_meta = BlockMeta::with_final_spdk(&meta, 2048);
         assert_eq!(final_meta.state, BlockState::Finalized);
         assert_eq!(final_meta.len, 2048);
+        assert_eq!(final_meta.bdev_offset, 0);
+        assert_eq!(final_meta.physical_bytes(), 4096);
     }
+
     #[test]
     fn with_final_local_succeeds() -> CommonResult<()> {
         let test_dir = "../testing/block_meta_test";
         let _ = std::fs::remove_dir_all(test_dir);
-        let dir = Arc::new(DirState {
-            dir_id: 0,
-            base_path: PathBuf::from(test_dir),
-            storage_type: StorageType::Ssd,
-            bdev_name: None,
-            bdev_capacity: 0,
-            offset_alloc: DirState::new_offset_alloc(StorageType::Ssd, 0, 512),
-        });
+        std::fs::create_dir_all(test_dir)?;
+        let path = PathBuf::from(test_dir).join("blk_1");
+        LocalFile::write_string(&path, "data", true)?;
         let meta = BlockMeta {
             id: 1,
             len: 100,
             state: BlockState::Writing,
-            dir,
+            dir_id: 0,
+            storage_type: StorageType::Ssd,
             actual_len: 100,
             bdev_offset: 0,
         };
-        let path = meta.get_block_path()?;
-        LocalFile::write_string(&path, &"data", true)?;
-        let final_meta = BlockMeta::with_final(&meta)?;
+        let final_meta = BlockMeta::with_final(&meta, &path)?;
         assert_eq!(final_meta.state, BlockState::Finalized);
         let _ = std::fs::remove_dir_all(test_dir);
         Ok(())

--- a/curvine-server/src/worker/block/block_store.rs
+++ b/curvine-server/src/worker/block/block_store.rs
@@ -124,13 +124,15 @@ impl BlockStore {
     pub fn async_remove_block(&self, id: i64) -> CommonResult<BlockMeta> {
         let removed = {
             let mut state = self.write()?;
-            let removed = state.remove_block_state_by_id(id)?;
+            let remove_result = state.remove_block_state_by_id(id);
+            // Heartbeat increments this counter before scheduling the task.
+            // Consume it even when metadata removal reports an error.
             state.decrement_blocks_to_delete();
-            removed
-        };
+            remove_result
+        }?;
 
         removed.layout.deallocate(&removed.dir, &removed.meta)?;
-        self.read()?.release_block_space(&removed.meta)?;
+        removed.release_space();
         Ok(removed.meta)
     }
 
@@ -166,5 +168,53 @@ impl BlockStore {
         }
 
         Ok(vec)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::worker::storage::Dataset;
+    use curvine_common::conf::WorkerConf;
+
+    fn create_store(name: &str) -> CommonResult<BlockStore> {
+        let conf = ClusterConf {
+            format_worker: true,
+            worker: WorkerConf {
+                dir_reserved: "0".to_string(),
+                data_dir: vec![format!("[MEM:1KB]../testing/block-store-{name}")],
+                ..WorkerConf::default()
+            },
+            ..ClusterConf::default()
+        };
+        BlockStore::new("test", &conf)
+    }
+
+    #[test]
+    fn async_remove_missing_block_releases_delete_count() -> CommonResult<()> {
+        let store = create_store("missing-block")?;
+        store.read()?.increment_blocks_to_delete();
+
+        assert!(store.async_remove_block(1).is_err());
+        assert_eq!(store.read()?.num_blocks_to_delete(), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn async_remove_invalid_dir_releases_delete_count() -> CommonResult<()> {
+        let store = create_store("invalid-dir")?;
+        {
+            let mut state = store.write()?;
+            let mut meta = BlockMeta::new(1, 100, state.dir_iter().next().unwrap());
+            meta.dir_id = u32::MAX;
+            state.put_test_meta(meta);
+            state.increment_blocks_to_delete();
+        }
+
+        assert!(store.async_remove_block(1).is_err());
+        let state = store.read()?;
+        assert!(state.get_block(1).is_none());
+        assert_eq!(state.num_blocks_to_delete(), 0);
+        Ok(())
     }
 }

--- a/curvine-server/src/worker/block/block_store.rs
+++ b/curvine-server/src/worker/block/block_store.rs
@@ -76,27 +76,27 @@ impl BlockStore {
     }
 
     pub fn open_writer(&self, meta: &BlockMeta, off: i64) -> CommonResult<BlockWriteContext> {
-        let layout = {
+        let (layout, dir) = {
             let state = self.read()?;
-            state.layout_for(meta)
+            state.layout_for(meta)?
         };
-        layout.open_writer(meta, off).map_err(Into::into)
+        layout.open_writer(&dir, meta, off).map_err(Into::into)
     }
 
     pub fn open_reader(&self, meta: &BlockMeta, off: i64) -> CommonResult<BlockReadContext> {
-        let layout = {
+        let (layout, dir) = {
             let state = self.read()?;
-            state.layout_for(meta)
+            state.layout_for(meta)?
         };
-        layout.open_reader(meta, off).map_err(Into::into)
+        layout.open_reader(&dir, meta, off).map_err(Into::into)
     }
 
     pub fn short_circuit(&self, meta: &BlockMeta) -> CommonResult<Option<String>> {
-        let layout = {
+        let (layout, dir) = {
             let state = self.read()?;
-            state.layout_for(meta)
+            state.layout_for(meta)?
         };
-        layout.short_circuit(meta)
+        layout.short_circuit(&dir, meta)
     }
 
     pub fn worker_id(&self) -> CommonResult<u32> {
@@ -122,17 +122,16 @@ impl BlockStore {
 
     // Asynchronously delete block.
     pub fn async_remove_block(&self, id: i64) -> CommonResult<BlockMeta> {
-        let (meta, layout) = {
+        let removed = {
             let mut state = self.write()?;
-            let (meta, layout) = state.remove_block_state_by_id(id)?;
+            let removed = state.remove_block_state_by_id(id)?;
             state.decrement_blocks_to_delete();
-            (meta, layout)
+            removed
         };
 
-        layout.deallocate(&meta)?;
-        let state = self.read()?;
-        state.release_block_space(&meta)?;
-        Ok(meta)
+        removed.layout.deallocate(&removed.dir, &removed.meta)?;
+        self.read()?.release_block_space(&removed.meta)?;
+        Ok(removed.meta)
     }
 
     // Get all storage information and check whether the storage directory is normal.

--- a/curvine-server/src/worker/storage/dir_list.rs
+++ b/curvine-server/src/worker/storage/dir_list.rs
@@ -13,18 +13,21 @@
 // limitations under the License.
 
 use crate::worker::storage::{ChoosingPolicy, RobinChoosingPolicy, VfsDir};
-use curvine_common::state::{ExtendedBlock, FileType, StorageType};
+use curvine_common::state::ExtendedBlock;
+#[cfg(test)]
+use curvine_common::state::{FileType, StorageType};
 use indexmap::map::Values;
 use indexmap::IndexMap;
 use log::{info, warn};
 use orpc::common::ByteUnit;
 use orpc::{err_box, CommonResult};
 use std::ops::Index;
+use std::sync::Arc;
 
 // Directory list.
 pub struct DirList {
-    pub(crate) dirs: IndexMap<u32, VfsDir>,
-    pub(crate) chooser: ChoosingPolicy,
+    dirs: IndexMap<u32, Arc<VfsDir>>,
+    chooser: ChoosingPolicy,
 }
 
 impl DirList {
@@ -34,7 +37,7 @@ impl DirList {
             if dirs.contains_key(&dir.id()) {
                 return err_box!("Storage ID hash conflict for dir {}", dir.id());
             }
-            dirs.insert(dir.id(), dir);
+            dirs.insert(dir.id(), Arc::new(dir));
         }
 
         Ok(Self {
@@ -51,15 +54,15 @@ impl DirList {
         self.len() == 0
     }
 
-    pub fn dir_iter(&self) -> Values<'_, u32, VfsDir> {
+    pub fn dir_iter(&self) -> Values<'_, u32, Arc<VfsDir>> {
         self.dirs.values()
     }
 
-    pub fn get_dir(&self, dir_id: u32) -> Option<&VfsDir> {
+    pub fn get_dir(&self, dir_id: u32) -> Option<&Arc<VfsDir>> {
         self.dirs.get(&dir_id)
     }
 
-    pub fn get_dir_index(&self, index: usize) -> Option<&VfsDir> {
+    pub fn get_dir_index(&self, index: usize) -> Option<&Arc<VfsDir>> {
         self.dirs.get_index(index).map(|x| x.1)
     }
 
@@ -93,18 +96,18 @@ impl DirList {
         used
     }
 
-    pub fn choose_dir(&mut self, block: &ExtendedBlock) -> CommonResult<&VfsDir> {
-        self.chooser.choose_dir(&self.dirs, block)
+    pub fn choose_dir(&mut self, block: &ExtendedBlock) -> CommonResult<Arc<VfsDir>> {
+        Ok(self.chooser.choose_dir(&self.dirs, block)?.clone())
     }
 
-    // Test-specific.
-    pub fn choose_dir_with_str<S: AsRef<str>>(
+    #[cfg(test)]
+    fn choose_dir_with_str<S: AsRef<str>>(
         &mut self,
         stg_type: StorageType,
         size_str: S,
-    ) -> CommonResult<&VfsDir> {
-        let block_size = ByteUnit::from_str(size_str.as_ref())?.as_byte();
-        let block = ExtendedBlock::new(0, block_size as i64, stg_type, FileType::File);
+    ) -> CommonResult<Arc<VfsDir>> {
+        let bytes = ByteUnit::from_str(size_str.as_ref())?.as_byte() as i64;
+        let block = ExtendedBlock::new(0, bytes, stg_type, FileType::File);
         self.choose_dir(&block)
     }
 
@@ -118,7 +121,7 @@ impl DirList {
                 ByteUnit::byte_to_string(dir.capacity() as u64),
                 ByteUnit::byte_to_string(dir.available() as u64),
             );
-            self.dirs.insert(dir.id(), dir);
+            self.dirs.insert(dir.id(), Arc::new(dir));
         } else {
             warn!("Dir {:?} already exists", dir)
         }
@@ -139,7 +142,7 @@ impl DirList {
 }
 
 impl Index<usize> for DirList {
-    type Output = VfsDir;
+    type Output = Arc<VfsDir>;
 
     fn index(&self, index: usize) -> &Self::Output {
         &self.dirs[index]

--- a/curvine-server/src/worker/storage/dir_state.rs
+++ b/curvine-server/src/worker/storage/dir_state.rs
@@ -14,18 +14,11 @@
 
 use curvine_common::state::StorageType;
 use std::collections::{BTreeMap, HashMap};
-use std::path::PathBuf;
 use std::sync::{Mutex, MutexGuard};
 
 #[derive(Debug, Default)]
 pub struct DirState {
-    pub(crate) dir_id: u32,
-    pub(crate) base_path: PathBuf,
-    pub(crate) storage_type: StorageType,
-    #[cfg(feature = "spdk")]
-    pub(crate) bdev_name: Option<String>,
-    #[cfg(not(feature = "spdk"))]
-    #[allow(dead_code)]
+    #[cfg_attr(not(feature = "spdk"), allow(dead_code))]
     pub(crate) bdev_name: Option<String>,
     pub(crate) bdev_capacity: i64,
     pub(crate) offset_alloc: BdevOffsetAllocator,
@@ -109,7 +102,12 @@ impl BdevOffsetAllocator {
                 block_id, inner.map[&block_id].0
             ));
         }
-        let aligned_size = align_up_i64(size, inner.align);
+        let aligned_size = align_up_i64(size, inner.align).ok_or_else(|| {
+            format!(
+                "invalid allocation size {} for alignment {}",
+                size, inner.align
+            )
+        })?;
 
         // Try free-list first
         let candidate = inner
@@ -130,13 +128,19 @@ impl BdevOffsetAllocator {
 
         // Fall back to bump
         let offset = inner.cursor;
-        if offset + aligned_size > inner.capacity {
+        let end = offset.checked_add(aligned_size).ok_or_else(|| {
+            format!(
+                "bdev allocation overflow: offset {}, size {}",
+                offset, aligned_size
+            )
+        })?;
+        if end > inner.capacity {
             return Err(format!(
                 "bdev full: need {} bytes at offset {}, capacity {}",
                 aligned_size, offset, inner.capacity
             ));
         }
-        inner.cursor += aligned_size;
+        inner.cursor = end;
         inner.map.insert(block_id, (offset, aligned_size));
         Ok(offset)
     }
@@ -249,6 +253,12 @@ impl BdevOffsetAllocator {
         inner.align
     }
 
+    /// Physical bytes charged for a logical allocation size.
+    pub fn allocation_size(&self, size: i64) -> Option<i64> {
+        let inner = self.lock_inner();
+        align_up_i64(size, inner.align)
+    }
+
     /// Size of the free-list (number of free ranges).
     pub fn free_list_size(&self) -> usize {
         let inner = self.lock_inner();
@@ -281,8 +291,11 @@ impl std::fmt::Debug for BdevOffsetAllocator {
     }
 }
 #[inline]
-fn align_up_i64(n: i64, align: i64) -> i64 {
-    (n + align - 1) & !(align - 1)
+fn align_up_i64(n: i64, align: i64) -> Option<i64> {
+    if n < 0 {
+        return None;
+    }
+    n.checked_add(align - 1).map(|v| v & !(align - 1))
 }
 // ---------------------------------------------------------------------------
 // Tests
@@ -302,6 +315,11 @@ mod test {
         a.allocate(1, 4096).unwrap();
         a.allocate(2, 4096).unwrap();
         assert!(a.allocate(3, 4096).is_err());
+    }
+    #[test]
+    fn allocation_size_overflow_is_rejected() {
+        let a = BdevOffsetAllocator::new(i64::MAX, 4096);
+        assert!(a.allocate(1, i64::MAX).is_err());
     }
     #[test]
     fn duplicate_block() {

--- a/curvine-server/src/worker/storage/layout/bdev_layout.rs
+++ b/curvine-server/src/worker/storage/layout/bdev_layout.rs
@@ -33,10 +33,21 @@ impl BdevLayout {
     pub fn new(spdk_meta: Option<Arc<SpdkMetaStore>>) -> Self {
         Self { spdk_meta }
     }
+
+    #[cfg(feature = "spdk")]
+    fn bdev_name(dir: &VfsDir) -> IOResult<&str> {
+        dir.state.bdev_name.as_deref().ok_or_else(|| {
+            IOError::from(format!("SPDK dir {} has no bdev name assigned", dir.id()))
+        })
+    }
 }
 
 impl BlockLayout for BdevLayout {
     fn allocate(&self, dir: &VfsDir, block: &ExtendedBlock) -> CommonResult<BlockMeta> {
+        let allocated_bytes = match dir.state.offset_alloc.allocation_size(block.len) {
+            Some(size) => size,
+            None => return err_box!("Invalid bdev allocation size: {}", block.len),
+        };
         let mut meta = BlockMeta::with_tmp(block, dir);
         let offset = dir
             .state
@@ -49,10 +60,45 @@ impl BlockLayout for BdevLayout {
                 ))
             })?;
         meta.bdev_offset = offset;
+        meta.actual_len = allocated_bytes;
         Ok(meta)
     }
 
-    fn finalize(&self, meta: &BlockMeta, committed_len: i64) -> CommonResult<BlockMeta> {
+    fn prepare_write(
+        &self,
+        dir: &VfsDir,
+        meta: &BlockMeta,
+        block: &ExtendedBlock,
+    ) -> CommonResult<BlockMeta> {
+        let (offset, allocated_bytes) =
+            dir.state.offset_alloc.get_entry(meta.id()).ok_or_else(|| {
+                orpc::err_msg!(format!(
+                    "No bdev allocation found for block {} in dir {}",
+                    meta.id(),
+                    dir.id()
+                ))
+            })?;
+        if block.len < 0 || block.len > allocated_bytes {
+            return err_box!(
+                "Block {} write size {} exceeds bdev extent {}",
+                meta.id(),
+                block.len,
+                allocated_bytes
+            );
+        }
+
+        let mut prepared = BlockMeta::new(meta.id(), block.len, dir);
+        prepared.bdev_offset = offset;
+        prepared.actual_len = allocated_bytes;
+        Ok(prepared)
+    }
+
+    fn finalize(
+        &self,
+        _dir: &VfsDir,
+        meta: &BlockMeta,
+        committed_len: i64,
+    ) -> CommonResult<BlockMeta> {
         Ok(BlockMeta::with_final_spdk(meta, committed_len))
     }
 
@@ -82,8 +128,9 @@ impl BlockLayout for BdevLayout {
                 id: record.block_id,
                 len: record.len,
                 state,
-                dir: dir.state.clone(),
-                actual_len: record.len,
+                dir_id: dir.id(),
+                storage_type: dir.storage_type(),
+                actual_len: record.size,
                 bdev_offset: record.offset,
             });
         }
@@ -98,55 +145,56 @@ impl BlockLayout for BdevLayout {
         Ok(blocks)
     }
 
-    fn release(&self, meta: &BlockMeta) -> CommonResult<()> {
-        meta.dir.offset_alloc.free(meta.id());
-        Ok(())
+    fn release(&self, dir: &VfsDir, meta: &BlockMeta) {
+        dir.state.offset_alloc.free(meta.id());
     }
 
     // SPDK blocks have no filesystem file; offset release happens in release().
-    fn deallocate(&self, _meta: &BlockMeta) -> CommonResult<()> {
+    fn deallocate(&self, _dir: &VfsDir, _meta: &BlockMeta) -> CommonResult<()> {
         Ok(())
     }
 
-    fn open_writer(&self, meta: &BlockMeta, off: i64) -> IOResult<BlockWriteContext> {
+    fn open_writer(&self, dir: &VfsDir, meta: &BlockMeta, off: i64) -> IOResult<BlockWriteContext> {
         validate_open_offset(meta, off)?;
         #[cfg(feature = "spdk")]
         {
-            let bdev_name = meta.get_bdev_name()?;
-            let abs_offset = meta.bdev_offset.checked_add(off).ok_or_else(|| {
+            let bdev_name = Self::bdev_name(dir)?;
+            let base_offset = meta.bdev_offset;
+            let abs_offset = base_offset.checked_add(off).ok_or_else(|| {
                 IOError::from(format!(
                     "Block write offset overflow: base={}, offset={}",
-                    meta.bdev_offset, off
+                    base_offset, off
                 ))
             })?;
             let max_len = 0.max(meta.len - off);
             info!(
                 "Opening SPDK bdev '{}' for writing at offset {} (block {} base={}, max_len={})",
-                bdev_name, abs_offset, meta.id, meta.bdev_offset, max_len
+                bdev_name, abs_offset, meta.id, base_offset, max_len
             );
             if max_len == 0 {
                 return err_box!("Cannot open SPDK writer: no space remaining");
             }
-            let bdev = SpdkBdev::open_write(&bdev_name, abs_offset, max_len)?;
+            let bdev = SpdkBdev::open_write(bdev_name, abs_offset, max_len)?;
             let device = BlockDevice::Spdk(bdev);
-            BlockWriteContext::new(device, meta.bdev_offset, meta.len, off)
+            BlockWriteContext::new(device, base_offset, meta.len, off)
         }
         #[cfg(not(feature = "spdk"))]
         {
-            let _ = (meta, off);
+            let _ = (dir, meta, off);
             err_box!("SPDK support not compiled in")
         }
     }
 
-    fn open_reader(&self, meta: &BlockMeta, off: i64) -> IOResult<BlockReadContext> {
+    fn open_reader(&self, dir: &VfsDir, meta: &BlockMeta, off: i64) -> IOResult<BlockReadContext> {
         validate_open_offset(meta, off)?;
         #[cfg(feature = "spdk")]
         {
-            let bdev_name = meta.get_bdev_name()?;
-            let abs_offset = meta.bdev_offset.checked_add(off).ok_or_else(|| {
+            let bdev_name = Self::bdev_name(dir)?;
+            let base_offset = meta.bdev_offset;
+            let abs_offset = base_offset.checked_add(off).ok_or_else(|| {
                 IOError::from(format!(
                     "Block read offset overflow: base={}, offset={}",
-                    meta.bdev_offset, off
+                    base_offset, off
                 ))
             })?;
             let abs_offset = u64::try_from(abs_offset).map_err(|_| {
@@ -158,23 +206,23 @@ impl BlockLayout for BdevLayout {
             let max_len = 0.max(meta.len - off);
             info!(
                 "Opening SPDK bdev '{}' for reading at offset {} (block {} base={}, max_len={})",
-                bdev_name, abs_offset, meta.id, meta.bdev_offset, max_len
+                bdev_name, abs_offset, meta.id, base_offset, max_len
             );
             if max_len == 0 {
                 return err_box!("Cannot open SPDK reader: no space remaining");
             }
-            let bdev = SpdkBdev::open_read(&bdev_name, abs_offset, max_len)?;
+            let bdev = SpdkBdev::open_read(bdev_name, abs_offset, max_len)?;
             let device = BlockDevice::Spdk(bdev);
-            BlockReadContext::new(device, meta.bdev_offset, meta.len, off)
+            BlockReadContext::new(device, base_offset, meta.len, off)
         }
         #[cfg(not(feature = "spdk"))]
         {
-            let _ = (meta, off);
+            let _ = (dir, meta, off);
             err_box!("SPDK support not compiled in")
         }
     }
 
-    fn short_circuit(&self, _meta: &BlockMeta) -> CommonResult<Option<String>> {
+    fn short_circuit(&self, _dir: &VfsDir, _meta: &BlockMeta) -> CommonResult<Option<String>> {
         Ok(None)
     }
 }

--- a/curvine-server/src/worker/storage/layout/file_layout.rs
+++ b/curvine-server/src/worker/storage/layout/file_layout.rs
@@ -16,29 +16,114 @@ use crate::worker::block::{BlockMeta, BlockState};
 use crate::worker::storage::layout::{validate_open_offset, BlockLayout};
 use crate::worker::storage::{BlockReadContext, BlockWriteContext, VfsDir};
 use curvine_common::state::ExtendedBlock;
+#[cfg(test)]
+use orpc::common::ByteUnit;
 use orpc::common::FileUtils;
 use orpc::io::{BlockDevice, IOError, IOResult, LocalFile};
-use orpc::CommonResult;
-use std::fs::File;
+use orpc::{err_box, try_err, CommonResult};
+use std::fs::{self, File};
+use std::path::PathBuf;
 
 #[derive(Clone, Copy)]
 pub struct FileLayout;
 
+const ACTIVE_DIR: &str = "active";
+const STAGING_DIR: &str = "staging";
+
+impl FileLayout {
+    fn active_dir(dir: &VfsDir) -> PathBuf {
+        dir.base_path().join(ACTIVE_DIR)
+    }
+
+    fn staging_dir(dir: &VfsDir) -> PathBuf {
+        dir.base_path().join(STAGING_DIR)
+    }
+
+    fn ensure_layout_dirs(dir: &VfsDir) -> CommonResult<()> {
+        FileUtils::create_dir(Self::active_dir(dir), true)?;
+        FileUtils::create_dir(Self::staging_dir(dir), true)?;
+        Ok(())
+    }
+
+    fn block_dir(dir: &VfsDir, meta: &BlockMeta) -> CommonResult<PathBuf> {
+        let path = match meta.state() {
+            BlockState::Finalized | BlockState::Writing => {
+                let uid = meta.id() as u64;
+                let d1 = (uid >> 48) & 0x1F;
+                let d2 = (uid >> 32) & 0x1F;
+                Self::active_dir(dir)
+                    .join(format!("b{}", d1))
+                    .join(format!("b{}", d2))
+            }
+            BlockState::Recovering => Self::staging_dir(dir),
+        };
+
+        if path.exists() {
+            if !path.is_dir() {
+                return err_box!("Path {} not a dir", path.to_string_lossy());
+            }
+        } else {
+            try_err!(fs::create_dir_all(&path));
+        }
+        Ok(path)
+    }
+
+    pub(crate) fn block_path(dir: &VfsDir, meta: &BlockMeta) -> CommonResult<PathBuf> {
+        Ok(Self::block_dir(dir, meta)?.join(meta.state().get_name(meta.id())))
+    }
+
+    fn block_file(dir: &VfsDir, meta: &BlockMeta) -> CommonResult<String> {
+        Ok(Self::block_path(dir, meta)?.to_string_lossy().to_string())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn write_test_data(dir: &VfsDir, meta: &BlockMeta, size: &str) -> CommonResult<()> {
+        let bytes = ByteUnit::from_str(size)?.as_byte();
+        LocalFile::write_string(
+            Self::block_path(dir, meta)?,
+            &"A".repeat(bytes as usize),
+            true,
+        )?;
+        Ok(())
+    }
+}
+
 impl BlockLayout for FileLayout {
     fn allocate(&self, dir: &VfsDir, block: &ExtendedBlock) -> CommonResult<BlockMeta> {
         let meta = BlockMeta::with_tmp(block, dir);
-        let file = meta.get_block_path()?;
+        let file = Self::block_path(dir, &meta)?;
         File::create(file)?;
         Ok(meta)
     }
 
-    fn finalize(&self, meta: &BlockMeta, _committed_len: i64) -> CommonResult<BlockMeta> {
-        BlockMeta::with_final(meta)
+    fn prepare_write(
+        &self,
+        dir: &VfsDir,
+        meta: &BlockMeta,
+        block: &ExtendedBlock,
+    ) -> CommonResult<BlockMeta> {
+        let mut prepared = BlockMeta::new(meta.id(), block.len, dir);
+        // The old file still occupies space until resize/finalize. Keep the
+        // larger physical charge so preparing a smaller write cannot temporarily
+        // overstate available capacity or under-release on abort.
+        prepared.actual_len = meta.actual_len.max(block.len);
+        Ok(prepared)
+    }
+
+    fn finalize(
+        &self,
+        dir: &VfsDir,
+        meta: &BlockMeta,
+        _committed_len: i64,
+    ) -> CommonResult<BlockMeta> {
+        let path = Self::block_path(dir, meta)?;
+        BlockMeta::with_final(meta, &path)
     }
 
     fn scan(&self, dir: &VfsDir) -> CommonResult<Vec<BlockMeta>> {
-        let active_dir = FileUtils::list_files(&dir.active_dir, true)?;
-        let staging_dir = FileUtils::list_files(&dir.staging_dir, true)?;
+        Self::ensure_layout_dirs(dir)?;
+        let active_dir = FileUtils::list_files(Self::active_dir(dir), true)?;
+        let staging_dir = FileUtils::list_files(Self::staging_dir(dir), true)?;
 
         let mut blocks = vec![];
         for file in active_dir {
@@ -57,32 +142,30 @@ impl BlockLayout for FileLayout {
     }
 
     // Filesystem blocks own no under-lock state; offset/file teardown is in deallocate().
-    fn release(&self, _meta: &BlockMeta) -> CommonResult<()> {
+    fn release(&self, _dir: &VfsDir, _meta: &BlockMeta) {}
+
+    fn deallocate(&self, dir: &VfsDir, meta: &BlockMeta) -> CommonResult<()> {
+        FileUtils::delete_path(Self::block_path(dir, meta)?, false)?;
         Ok(())
     }
 
-    fn deallocate(&self, meta: &BlockMeta) -> CommonResult<()> {
-        FileUtils::delete_path(meta.get_block_path()?, false)?;
-        Ok(())
-    }
-
-    fn open_writer(&self, meta: &BlockMeta, off: i64) -> IOResult<BlockWriteContext> {
+    fn open_writer(&self, dir: &VfsDir, meta: &BlockMeta, off: i64) -> IOResult<BlockWriteContext> {
         validate_open_offset(meta, off)?;
-        let file = meta.get_block_file()?;
+        let file = Self::block_file(dir, meta)?;
         let device = BlockDevice::Local(LocalFile::with_write_offset(file, false, off)?);
         BlockWriteContext::new(device, 0, meta.len, off)
     }
 
-    fn open_reader(&self, meta: &BlockMeta, off: i64) -> IOResult<BlockReadContext> {
+    fn open_reader(&self, dir: &VfsDir, meta: &BlockMeta, off: i64) -> IOResult<BlockReadContext> {
         validate_open_offset(meta, off)?;
         let read_off = u64::try_from(off)
             .map_err(|_| IOError::from(format!("Invalid read offset: {}", off)))?;
-        let file = meta.get_block_file()?;
+        let file = Self::block_file(dir, meta)?;
         let device = BlockDevice::Local(LocalFile::with_read(file, read_off)?);
         BlockReadContext::new(device, 0, meta.len, off)
     }
 
-    fn short_circuit(&self, meta: &BlockMeta) -> CommonResult<Option<String>> {
-        Ok(Some(meta.get_block_file()?))
+    fn short_circuit(&self, dir: &VfsDir, meta: &BlockMeta) -> CommonResult<Option<String>> {
+        Ok(Some(Self::block_file(dir, meta)?))
     }
 }

--- a/curvine-server/src/worker/storage/layout/file_layout.rs
+++ b/curvine-server/src/worker/storage/layout/file_layout.rs
@@ -102,6 +102,9 @@ impl BlockLayout for FileLayout {
         meta: &BlockMeta,
         block: &ExtendedBlock,
     ) -> CommonResult<BlockMeta> {
+        if block.len < 0 {
+            return err_box!("Invalid file block size: {}", block.len);
+        }
         let mut prepared = BlockMeta::new(meta.id(), block.len, dir);
         // The old file still occupies space until resize/finalize. Keep the
         // larger physical charge so preparing a smaller write cannot temporarily

--- a/curvine-server/src/worker/storage/layout/mod.rs
+++ b/curvine-server/src/worker/storage/layout/mod.rs
@@ -35,24 +35,37 @@ fn validate_open_offset(meta: &BlockMeta, off: i64) -> IOResult<()> {
 pub trait BlockLayout {
     fn allocate(&self, dir: &VfsDir, block: &ExtendedBlock) -> CommonResult<BlockMeta>;
 
-    fn finalize(&self, meta: &BlockMeta, committed_len: i64) -> CommonResult<BlockMeta>;
+    /// Prepare an existing physical allocation for writing.
+    fn prepare_write(
+        &self,
+        dir: &VfsDir,
+        meta: &BlockMeta,
+        block: &ExtendedBlock,
+    ) -> CommonResult<BlockMeta>;
+
+    fn finalize(
+        &self,
+        dir: &VfsDir,
+        meta: &BlockMeta,
+        committed_len: i64,
+    ) -> CommonResult<BlockMeta>;
 
     fn scan(&self, dir: &VfsDir) -> CommonResult<Vec<BlockMeta>>;
 
     /// Release layout-owned state while the dataset lock is still held.
-    fn release(&self, meta: &BlockMeta) -> CommonResult<()>;
+    fn release(&self, dir: &VfsDir, meta: &BlockMeta);
 
     /// Remove backing resources. Callers may run this outside the dataset lock.
-    fn deallocate(&self, meta: &BlockMeta) -> CommonResult<()>;
+    fn deallocate(&self, dir: &VfsDir, meta: &BlockMeta) -> CommonResult<()>;
 
-    fn open_writer(&self, meta: &BlockMeta, off: i64) -> IOResult<BlockWriteContext>;
+    fn open_writer(&self, dir: &VfsDir, meta: &BlockMeta, off: i64) -> IOResult<BlockWriteContext>;
 
-    fn open_reader(&self, meta: &BlockMeta, off: i64) -> IOResult<BlockReadContext>;
+    fn open_reader(&self, dir: &VfsDir, meta: &BlockMeta, off: i64) -> IOResult<BlockReadContext>;
 
     /// Local path a co-located client can open directly, `Ok(None)` if the
     /// layout cannot expose one (e.g. raw bdev). Errors are propagated so
     /// callers can distinguish "not eligible" from "path resolution failed".
-    fn short_circuit(&self, meta: &BlockMeta) -> CommonResult<Option<String>>;
+    fn short_circuit(&self, dir: &VfsDir, meta: &BlockMeta) -> CommonResult<Option<String>>;
 }
 
 #[derive(Clone)]
@@ -101,10 +114,27 @@ impl BlockLayout for BlockLayoutKind {
         }
     }
 
-    fn finalize(&self, meta: &BlockMeta, committed_len: i64) -> CommonResult<BlockMeta> {
+    fn prepare_write(
+        &self,
+        dir: &VfsDir,
+        meta: &BlockMeta,
+        block: &ExtendedBlock,
+    ) -> CommonResult<BlockMeta> {
         match self {
-            Self::File(layout) => layout.finalize(meta, committed_len),
-            Self::Bdev(layout) => layout.finalize(meta, committed_len),
+            Self::File(layout) => layout.prepare_write(dir, meta, block),
+            Self::Bdev(layout) => layout.prepare_write(dir, meta, block),
+        }
+    }
+
+    fn finalize(
+        &self,
+        dir: &VfsDir,
+        meta: &BlockMeta,
+        committed_len: i64,
+    ) -> CommonResult<BlockMeta> {
+        match self {
+            Self::File(layout) => layout.finalize(dir, meta, committed_len),
+            Self::Bdev(layout) => layout.finalize(dir, meta, committed_len),
         }
     }
 
@@ -115,38 +145,38 @@ impl BlockLayout for BlockLayoutKind {
         }
     }
 
-    fn release(&self, meta: &BlockMeta) -> CommonResult<()> {
+    fn release(&self, dir: &VfsDir, meta: &BlockMeta) {
         match self {
-            Self::File(layout) => layout.release(meta),
-            Self::Bdev(layout) => layout.release(meta),
+            Self::File(layout) => layout.release(dir, meta),
+            Self::Bdev(layout) => layout.release(dir, meta),
         }
     }
 
-    fn deallocate(&self, meta: &BlockMeta) -> CommonResult<()> {
+    fn deallocate(&self, dir: &VfsDir, meta: &BlockMeta) -> CommonResult<()> {
         match self {
-            Self::File(layout) => layout.deallocate(meta),
-            Self::Bdev(layout) => layout.deallocate(meta),
+            Self::File(layout) => layout.deallocate(dir, meta),
+            Self::Bdev(layout) => layout.deallocate(dir, meta),
         }
     }
 
-    fn open_writer(&self, meta: &BlockMeta, off: i64) -> IOResult<BlockWriteContext> {
+    fn open_writer(&self, dir: &VfsDir, meta: &BlockMeta, off: i64) -> IOResult<BlockWriteContext> {
         match self {
-            Self::File(layout) => layout.open_writer(meta, off),
-            Self::Bdev(layout) => layout.open_writer(meta, off),
+            Self::File(layout) => layout.open_writer(dir, meta, off),
+            Self::Bdev(layout) => layout.open_writer(dir, meta, off),
         }
     }
 
-    fn open_reader(&self, meta: &BlockMeta, off: i64) -> IOResult<BlockReadContext> {
+    fn open_reader(&self, dir: &VfsDir, meta: &BlockMeta, off: i64) -> IOResult<BlockReadContext> {
         match self {
-            Self::File(layout) => layout.open_reader(meta, off),
-            Self::Bdev(layout) => layout.open_reader(meta, off),
+            Self::File(layout) => layout.open_reader(dir, meta, off),
+            Self::Bdev(layout) => layout.open_reader(dir, meta, off),
         }
     }
 
-    fn short_circuit(&self, meta: &BlockMeta) -> CommonResult<Option<String>> {
+    fn short_circuit(&self, dir: &VfsDir, meta: &BlockMeta) -> CommonResult<Option<String>> {
         match self {
-            Self::File(layout) => layout.short_circuit(meta),
-            Self::Bdev(layout) => layout.short_circuit(meta),
+            Self::File(layout) => layout.short_circuit(dir, meta),
+            Self::Bdev(layout) => layout.short_circuit(dir, meta),
         }
     }
 }

--- a/curvine-server/src/worker/storage/mod.rs
+++ b/curvine-server/src/worker/storage/mod.rs
@@ -46,9 +46,3 @@ mod vfs_dataset;
 pub use self::vfs_dataset::VfsDataset;
 
 pub type BlockDataset = VfsDataset;
-
-// Normal block directory.
-pub const ACTIVE_DIR: &str = "active";
-
-// Temporary block directory, such as blocks triggered for recovery or replication status
-pub const STAGING_DIR: &str = "staging";

--- a/curvine-server/src/worker/storage/policy.rs
+++ b/curvine-server/src/worker/storage/policy.rs
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 use crate::worker::storage::VfsDir;
-use curvine_common::state::{ExtendedBlock, FileType, StorageType};
+use curvine_common::state::{ExtendedBlock, StorageType};
 use indexmap::IndexMap;
-use orpc::common::ByteUnit;
 use orpc::{err_box, CommonResult};
 use std::collections::HashMap;
+use std::sync::Arc;
 
 pub enum ChoosingPolicy {
     Robin(RobinChoosingPolicy),
@@ -26,9 +26,9 @@ pub enum ChoosingPolicy {
 impl ChoosingPolicy {
     pub fn choose_dir<'a>(
         &mut self,
-        dirs: &'a IndexMap<u32, VfsDir>,
+        dirs: &'a IndexMap<u32, Arc<VfsDir>>,
         block: &ExtendedBlock,
-    ) -> CommonResult<&'a VfsDir> {
+    ) -> CommonResult<&'a Arc<VfsDir>> {
         match self {
             ChoosingPolicy::Robin(c) => c.choose_dir(dirs, block),
         }
@@ -54,9 +54,9 @@ impl RobinChoosingPolicy {
 
     fn choose_dir<'a>(
         &mut self,
-        dirs: &'a IndexMap<u32, VfsDir>,
+        dirs: &'a IndexMap<u32, Arc<VfsDir>>,
         block: &ExtendedBlock,
-    ) -> CommonResult<&'a VfsDir> {
+    ) -> CommonResult<&'a Arc<VfsDir>> {
         let mut res = self.get_next_dir(dirs, block.storage_type, block.len);
         if res.is_none() && block.storage_type != StorageType::Disk {
             res = self.get_next_dir(dirs, StorageType::Disk, block.len)
@@ -69,24 +69,12 @@ impl RobinChoosingPolicy {
         }
     }
 
-    // Test-specific
-    pub fn choose_dir_with_str<'a, S: AsRef<str>>(
-        &mut self,
-        dirs: &'a IndexMap<u32, VfsDir>,
-        stg_type: StorageType,
-        size_str: S,
-    ) -> CommonResult<&'a VfsDir> {
-        let block_size = ByteUnit::from_str(size_str.as_ref())?.as_byte();
-        let block = ExtendedBlock::new(0, block_size as i64, stg_type, FileType::File);
-        self.choose_dir(dirs, &block)
-    }
-
     fn get_next_dir<'a>(
         &mut self,
-        dirs: &'a IndexMap<u32, VfsDir>,
+        dirs: &'a IndexMap<u32, Arc<VfsDir>>,
         stg_type: StorageType,
         block_size: i64,
-    ) -> Option<&'a VfsDir> {
+    ) -> Option<&'a Arc<VfsDir>> {
         let mut index = *self.cur_dirs.get(&stg_type).unwrap_or(&0);
 
         let start_index = index;

--- a/curvine-server/src/worker/storage/spdk_meta_store.rs
+++ b/curvine-server/src/worker/storage/spdk_meta_store.rs
@@ -128,17 +128,11 @@ impl SpdkMetaStore {
 
 impl BlockMetaStore for SpdkMetaStore {
     fn put_block_meta(&self, meta: &BlockMeta) -> CommonResult<()> {
-        let alloc_size = meta
-            .dir
-            .offset_alloc
-            .get_entry(meta.id())
-            .map_or(meta.actual_len, |(_, size)| size);
-
         self.put(
             meta.id(),
             meta.dir_id(),
             meta.bdev_offset,
-            alloc_size,
+            meta.actual_len,
             meta.len(),
             meta.is_final(),
         )

--- a/curvine-server/src/worker/storage/vfs_dataset.rs
+++ b/curvine-server/src/worker/storage/vfs_dataset.rs
@@ -37,6 +37,12 @@ pub struct VfsDataset {
     num_blocks_to_delete: AtomicUsize,
 }
 
+pub(crate) struct RemovedBlockState {
+    pub(crate) meta: BlockMeta,
+    pub(crate) layout: BlockLayoutKind,
+    pub(crate) dir: Arc<VfsDir>,
+}
+
 impl VfsDataset {
     fn new(
         cluster_id: &str,
@@ -153,9 +159,7 @@ impl VfsDataset {
 
     pub fn find_dir(&self, id: u32) -> CommonResult<&VfsDir> {
         match self.dir_list.get_dir(id) {
-            None => {
-                err_box!("No storage directory found: {:?}", id)
-            }
+            None => err_box!("No storage directory found: {:?}", id),
             Some(v) => Ok(v),
         }
     }
@@ -172,12 +176,18 @@ impl VfsDataset {
         self.ctime
     }
 
-    pub fn dir_iter(&self) -> Values<'_, u32, VfsDir> {
+    pub fn dir_iter(&self) -> Values<'_, u32, Arc<VfsDir>> {
         self.dir_list.dir_iter()
     }
 
     pub fn all_blocks(&self) -> Vec<BlockMeta> {
         self.meta.all_blocks()
+    }
+
+    #[cfg(test)]
+    fn write_test_data(&self, meta: &BlockMeta, size: &str) -> CommonResult<()> {
+        let dir = self.find_dir(meta.dir_id())?;
+        super::FileLayout::write_test_data(dir, meta, size)
     }
 
     #[cfg(test)]
@@ -192,38 +202,45 @@ impl VfsDataset {
             .map(|d| &d.state.offset_alloc)
     }
 
-    pub(crate) fn remove_block_state_by_id(
-        &mut self,
-        id: i64,
-    ) -> CommonResult<(BlockMeta, BlockLayoutKind)> {
+    pub(crate) fn remove_block_state_by_id(&mut self, id: i64) -> CommonResult<RemovedBlockState> {
+        let meta = match self.meta.get(id) {
+            None => return err_box!("Not found block {}", id),
+            Some(meta) => meta,
+        };
+        let layout = self.layouts.get(meta.storage_type()).clone();
+        let dir = match self.dir_list.get_dir(meta.dir_id()) {
+            None => return err_box!("No storage directory found: {:?}", meta.dir_id()),
+            Some(dir) => dir.clone(),
+        };
+
         let meta = match self.meta.remove(id) {
             None => return err_box!("Not found block {}", id),
             Some(meta) => meta,
         };
+        layout.release(&dir, &meta);
 
-        let layout = self.layouts.get(meta.storage_type());
-        if self.find_dir(meta.dir_id()).is_ok() {
-            layout.release(&meta)?;
-        }
-
-        Ok((meta, layout.clone()))
+        Ok(RemovedBlockState { meta, layout, dir })
     }
 
     pub(crate) fn release_block_space(&self, meta: &BlockMeta) -> CommonResult<()> {
         let dir = self.find_dir(meta.dir_id())?;
-        dir.release_space(meta.is_final(), meta.actual_len);
+        dir.release_space(meta.is_final(), meta.physical_bytes());
         Ok(())
     }
 
     pub(crate) fn remove_block_by_id(&mut self, id: i64) -> CommonResult<BlockMeta> {
-        let (meta, layout) = self.remove_block_state_by_id(id)?;
-        layout.deallocate(&meta)?;
-        self.release_block_space(&meta)?;
-        Ok(meta)
+        let removed = self.remove_block_state_by_id(id)?;
+        removed.layout.deallocate(&removed.dir, &removed.meta)?;
+        self.release_block_space(&removed.meta)?;
+        Ok(removed.meta)
     }
 
-    pub fn layout_for(&self, meta: &BlockMeta) -> BlockLayoutKind {
-        self.layouts.get(meta.storage_type()).clone()
+    pub fn layout_for(&self, meta: &BlockMeta) -> CommonResult<(BlockLayoutKind, Arc<VfsDir>)> {
+        let dir = match self.dir_list.get_dir(meta.dir_id()) {
+            None => return err_box!("No storage directory found: {:?}", meta.dir_id()),
+            Some(dir) => dir.clone(),
+        };
+        Ok((self.layouts.get(meta.storage_type()).clone(), dir))
     }
 }
 
@@ -265,12 +282,13 @@ impl Dataset for VfsDataset {
             Some(meta) => {
                 if meta.is_active() {
                     let dir = self.find_dir(meta.dir_id())?;
-                    // Create a new block meta, where block.len represents the block size
-                    let mut new_meta = BlockMeta::new(meta.id, block.len, dir);
-                    new_meta.bdev_offset = meta.bdev_offset; // preserve allocated offset
+                    let layout = self.layouts.get(meta.storage_type());
+                    let old_physical_bytes = meta.physical_bytes();
+                    let new_meta = layout.prepare_write(dir, &meta, block)?;
+                    let new_physical_bytes = new_meta.physical_bytes();
 
-                    dir.release_space(meta.is_final(), meta.actual_len);
-                    dir.reserve_space(false, new_meta.len);
+                    dir.release_space(meta.is_final(), old_physical_bytes);
+                    dir.reserve_space(false, new_physical_bytes);
                     self.meta.put(new_meta.clone());
 
                     Ok(new_meta)
@@ -286,10 +304,10 @@ impl Dataset for VfsDataset {
             None => {
                 let dir = self.dir_list.choose_dir(block)?;
                 let layout = self.layouts.get(dir.storage_type());
-                let meta = layout.allocate(dir, block)?;
+                let meta = layout.allocate(&dir, block)?;
 
                 self.meta.put(meta.clone());
-                dir.reserve_space(false, block.len);
+                dir.reserve_space(false, meta.physical_bytes());
 
                 Ok(meta)
             }
@@ -298,7 +316,7 @@ impl Dataset for VfsDataset {
 
     fn finalize_block(&mut self, block: &ExtendedBlock) -> CommonResult<BlockMeta> {
         // Keep the meta borrow scoped before mutating the meta store and dir accounting.
-        let (dir_id, actual_len, final_meta) = {
+        let (dir_id, reserved_bytes, final_bytes, final_meta) = {
             let meta = self.get_block_check(block.id)?;
             if meta.state() == &BlockState::Finalized {
                 if meta.len() == block.len {
@@ -320,8 +338,10 @@ impl Dataset for VfsDataset {
                 );
             }
 
+            let dir = self.find_dir(meta.dir_id())?;
             let layout = self.layouts.get(meta.storage_type());
-            let final_meta = layout.finalize(meta, block.len)?;
+            let reserved_bytes = meta.physical_bytes();
+            let final_meta = layout.finalize(dir, meta, block.len)?;
             if block.len != final_meta.len() {
                 return err_box!(
                     "Block {} length mismatch, expected: {}, actual: {}",
@@ -331,12 +351,13 @@ impl Dataset for VfsDataset {
                 );
             }
 
-            (meta.dir_id(), meta.actual_len, final_meta)
+            let final_bytes = final_meta.physical_bytes();
+            (meta.dir_id(), reserved_bytes, final_bytes, final_meta)
         };
 
         let dir = self.find_dir(dir_id)?;
-        dir.release_space(false, actual_len);
-        dir.reserve_space(true, final_meta.actual_len);
+        dir.release_space(false, reserved_bytes);
+        dir.reserve_space(true, final_bytes);
         self.meta.put(final_meta.clone());
 
         Ok(final_meta)
@@ -363,7 +384,6 @@ mod test {
     use orpc::sync::AtomicLong;
     use orpc::sys::FsStats;
     use orpc::CommonResult;
-    use std::path::PathBuf;
     use std::sync::atomic::AtomicBool;
     use std::sync::Arc;
 
@@ -385,26 +405,20 @@ mod test {
         VfsDataset::from_conf("test", &conf).unwrap()
     }
 
-    fn spdk_state(dir_id: u32) -> Arc<DirState> {
+    fn spdk_state() -> Arc<DirState> {
         Arc::new(DirState {
-            dir_id,
-            base_path: PathBuf::from("/tmp/spdk"),
-            storage_type: StorageType::SpdkDisk,
             bdev_name: Some("nvme0".into()),
             bdev_capacity: 1 << 30,
             offset_alloc: DirState::new_offset_alloc(StorageType::SpdkDisk, 1 << 30, 4096),
         })
     }
 
-    fn spdk_dir(state: Arc<DirState>) -> VfsDir {
-        let dir_id = state.dir_id;
+    fn spdk_dir(dir_id: u32, state: Arc<DirState>) -> VfsDir {
         let mut version = StorageVersion::with_cluster("t");
         version.dir_id = dir_id;
         VfsDir {
             version,
             stats: FsStats::new("/tmp"),
-            active_dir: PathBuf::from("/tmp/a"),
-            staging_dir: PathBuf::from("/tmp/s"),
             storage_type: StorageType::SpdkDisk,
             conf_capacity: 1 << 30,
             reserved_bytes: 0,
@@ -416,8 +430,8 @@ mod test {
     }
 
     fn spdk_dataset() -> CommonResult<VfsDataset> {
-        let st = spdk_state(1);
-        VfsDataset::new("t", DirList::new(vec![spdk_dir(st)])?, None)
+        let st = spdk_state();
+        VfsDataset::new("t", DirList::new(vec![spdk_dir(1, st)])?, None)
     }
 
     #[test]
@@ -426,7 +440,7 @@ mod test {
         let mut block = ExtendedBlock::with_mem(1, "100B")?;
         let meta = ds.open_block(&block)?;
         assert_eq!(ds.available(), 400);
-        meta.write_test_data("50B")?;
+        ds.write_test_data(&meta, "50B")?;
         block.len = 50;
         ds.finalize_block(&block)?;
         assert_eq!(ds.available(), 450);
@@ -437,12 +451,12 @@ mod test {
         let mut ds = create_data_set(true, "append");
         let mut block = ExtendedBlock::with_mem(1, "100B")?;
         let meta = ds.open_block(&block)?;
-        meta.write_test_data("50B")?;
+        ds.write_test_data(&meta, "50B")?;
         block.len = 50;
         ds.finalize_block(&block)?;
         block.len = 70;
         let meta2 = ds.open_block(&block)?;
-        meta2.write_test_data("20B")?;
+        ds.write_test_data(&meta2, "20B")?;
         ds.finalize_block(&block)?;
         assert_eq!(ds.available(), 430);
         Ok(())
@@ -452,8 +466,8 @@ mod test {
         let mut ds = create_data_set(true, "init");
         for id in 1..12 {
             let block = ExtendedBlock::with_mem(id, &format!("{}B", id))?;
-            ds.open_block(&block)?
-                .write_test_data(&format!("{}B", id))?;
+            let meta = ds.open_block(&block)?;
+            ds.write_test_data(&meta, &format!("{}B", id))?;
         }
         drop(ds);
         let ds = create_data_set(false, "init");
@@ -523,8 +537,8 @@ mod test {
     }
     #[test]
     fn spdk_restore_free_list() -> CommonResult<()> {
-        let st = spdk_state(1);
-        let mut ds = VfsDataset::new("t", DirList::new(vec![spdk_dir(st.clone())])?, None)?;
+        let st = spdk_state();
+        let mut ds = VfsDataset::new("t", DirList::new(vec![spdk_dir(1, st.clone())])?, None)?;
         let b1 = ExtendedBlock::new(1, 4096, StorageType::SpdkDisk, FileType::File);
         let b2 = ExtendedBlock::new(2, 4096, StorageType::SpdkDisk, FileType::File);
         let b3 = ExtendedBlock::new(3, 4096, StorageType::SpdkDisk, FileType::File);
@@ -535,7 +549,7 @@ mod test {
         ds.abort_block(&b2)?;
         let snap = st.offset_alloc.snapshot();
 
-        let st2 = spdk_state(1);
+        let st2 = spdk_state();
         st2.offset_alloc.restore(&snap);
 
         let entries = st2.offset_alloc.free_list_entries();

--- a/curvine-server/src/worker/storage/vfs_dataset.rs
+++ b/curvine-server/src/worker/storage/vfs_dataset.rs
@@ -43,6 +43,13 @@ pub(crate) struct RemovedBlockState {
     pub(crate) dir: Arc<VfsDir>,
 }
 
+impl RemovedBlockState {
+    pub(crate) fn release_space(&self) {
+        self.dir
+            .release_space(self.meta.is_final(), self.meta.physical_bytes());
+    }
+}
+
 impl VfsDataset {
     fn new(
         cluster_id: &str,
@@ -145,7 +152,7 @@ impl VfsDataset {
             let layout = self.layouts.get(dir.storage_type());
             let blocks = layout.scan(dir)?;
             for block in blocks {
-                dir.reserve_space(true, block.len);
+                dir.reserve_space(block.is_final(), block.physical_bytes());
                 self.meta.put(block);
             }
         }
@@ -202,8 +209,13 @@ impl VfsDataset {
             .map(|d| &d.state.offset_alloc)
     }
 
+    #[cfg(test)]
+    pub(crate) fn put_test_meta(&mut self, meta: BlockMeta) {
+        self.meta.put(meta);
+    }
+
     pub(crate) fn remove_block_state_by_id(&mut self, id: i64) -> CommonResult<RemovedBlockState> {
-        let meta = match self.meta.get(id) {
+        let meta = match self.meta.remove(id) {
             None => return err_box!("Not found block {}", id),
             Some(meta) => meta,
         };
@@ -213,10 +225,6 @@ impl VfsDataset {
             Some(dir) => dir.clone(),
         };
 
-        let meta = match self.meta.remove(id) {
-            None => return err_box!("Not found block {}", id),
-            Some(meta) => meta,
-        };
         layout.release(&dir, &meta);
 
         Ok(RemovedBlockState { meta, layout, dir })
@@ -378,7 +386,9 @@ impl Dataset for VfsDataset {
 
 #[cfg(test)]
 mod test {
-    use crate::worker::storage::{Dataset, DirList, DirState, StorageVersion, VfsDataset, VfsDir};
+    use crate::worker::storage::{
+        Dataset, DirList, DirState, SpdkMetaStore, StorageVersion, VfsDataset, VfsDir,
+    };
     use curvine_common::conf::{ClusterConf, WorkerConf};
     use curvine_common::state::{ExtendedBlock, FileType, StorageType};
     use orpc::sync::AtomicLong;
@@ -481,6 +491,49 @@ mod test {
         ds.open_block(&block)?;
         let ok = ds.abort_block(&block).is_ok();
         assert!(ok && ds.get_block(1).is_none());
+        Ok(())
+    }
+    #[test]
+    fn spdk_initialize_restores_physical_capacity() -> CommonResult<()> {
+        let path = "../testing/spdk_capacity_restore";
+        let _ = std::fs::remove_dir_all(path);
+        let store = Arc::new(SpdkMetaStore::open(path, true)?);
+        store.put(1, 1, 0, 4096, 1, true)?;
+
+        let dir = spdk_dir(1, spdk_state());
+        let available = dir.available();
+        let mut ds = VfsDataset::new("t", DirList::new(vec![dir])?, Some(store.clone()))?;
+
+        let meta = ds.get_block(1).unwrap();
+        assert_eq!(meta.len(), 1);
+        assert_eq!(meta.physical_bytes(), 4096);
+        assert_eq!(ds.available(), available - 4096);
+
+        ds.abort_block(&ExtendedBlock::with_id(1))?;
+        assert_eq!(ds.available(), available);
+        drop(ds);
+        drop(store);
+        let _ = std::fs::remove_dir_all(path);
+        Ok(())
+    }
+    #[test]
+    fn negative_file_prepare_write_keeps_metadata() -> CommonResult<()> {
+        let mut ds = create_data_set(true, "negative-prepare-write");
+        let mut block = ExtendedBlock::with_mem(1, "100B")?;
+        let meta = ds.open_block(&block)?;
+        ds.write_test_data(&meta, "50B")?;
+        block.len = 50;
+        let finalized = ds.finalize_block(&block)?;
+        let available = ds.available();
+
+        block.len = -1;
+        assert!(ds.open_block(&block).is_err());
+
+        let current = ds.get_block(block.id).unwrap();
+        assert!(current.is_final());
+        assert_eq!(current.len(), finalized.len());
+        assert_eq!(current.physical_bytes(), finalized.physical_bytes());
+        assert_eq!(ds.available(), available);
         Ok(())
     }
     #[test]

--- a/curvine-server/src/worker/storage/vfs_dir.rs
+++ b/curvine-server/src/worker/storage/vfs_dir.rs
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::worker::storage::{
-    DirState, StorageVersion, ACTIVE_DIR, DEFAULT_BLOCK_ALIGN, STAGING_DIR,
-};
+use crate::worker::storage::{DirState, StorageVersion, DEFAULT_BLOCK_ALIGN};
 use curvine_common::conf::WorkerDataDir;
 use curvine_common::state::StorageType;
 use log::*;
@@ -30,11 +28,14 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+/// A physical worker storage directory.
+///
+/// This type owns medium identity, capacity accounting, health, and the
+/// medium-specific device handle. It deliberately has no knowledge of how a
+/// block layout names or arranges data inside the directory.
 pub struct VfsDir {
     pub(crate) version: StorageVersion,
     pub(crate) stats: FsStats,
-    pub(crate) active_dir: PathBuf,
-    pub(crate) staging_dir: PathBuf,
     pub(crate) storage_type: StorageType,
     pub(crate) conf_capacity: i64,
     pub(crate) reserved_bytes: i64,
@@ -57,13 +58,9 @@ impl VfsDir {
         };
         let stats = FsStats::new(&stg_dir);
 
-        let active_dir = stats.path().join(ACTIVE_DIR);
-        let staging_dir = stats.path().join(STAGING_DIR);
-
         // SPDK: skip filesystem (no local dir, version file, or filesystem checks).
         if conf.storage_type != StorageType::SpdkDisk {
-            FileUtils::create_dir(&active_dir, true)?;
-            FileUtils::create_dir(&staging_dir, true)?;
+            FileUtils::create_dir(stats.path(), true)?;
             stats.check_dir()?;
             // Save version
             let ver_file = PathBuf::from_str(&stg_dir)?.join("version");
@@ -122,9 +119,6 @@ impl VfsDir {
         };
 
         let state = DirState {
-            dir_id: version.dir_id,
-            base_path: stats.path().to_path_buf(),
-            storage_type: conf.storage_type,
             bdev_name: bdev_name_str,
             bdev_capacity,
             offset_alloc: super::DirState::new_offset_alloc(
@@ -136,8 +130,6 @@ impl VfsDir {
         let dir = Self {
             version,
             stats,
-            active_dir,
-            staging_dir,
             storage_type: conf.storage_type,
             conf_capacity: conf.capacity as i64,
             reserved_bytes: reserved_bytes as i64,
@@ -364,15 +356,11 @@ mod test {
     use orpc::sync::AtomicLong;
     use orpc::sys::FsStats;
     use orpc::CommonResult;
-    use std::path::PathBuf;
     use std::sync::atomic::AtomicBool;
     use std::sync::Arc;
 
-    fn spdk_state(p: &str, cap: i64) -> Arc<DirState> {
+    fn spdk_state(_p: &str, cap: i64) -> Arc<DirState> {
         Arc::new(DirState {
-            dir_id: 1,
-            base_path: PathBuf::from(p),
-            storage_type: StorageType::SpdkDisk,
             bdev_name: Some("nvme0".into()),
             bdev_capacity: cap,
             offset_alloc: DirState::new_offset_alloc(StorageType::SpdkDisk, cap, 4096),
@@ -383,8 +371,6 @@ mod test {
         VfsDir {
             version: StorageVersion::with_cluster("t"),
             stats: FsStats::new(p),
-            active_dir: PathBuf::from(p).join("a"),
-            staging_dir: PathBuf::from(p).join("s"),
             storage_type: StorageType::SpdkDisk,
             conf_capacity: conf,
             reserved_bytes: 0,
@@ -395,11 +381,8 @@ mod test {
         }
     }
 
-    fn local_state(p: &str) -> Arc<DirState> {
+    fn local_state(_p: &str) -> Arc<DirState> {
         Arc::new(DirState {
-            dir_id: 1,
-            base_path: PathBuf::from(p),
-            storage_type: StorageType::Ssd,
             bdev_name: None,
             bdev_capacity: 0,
             offset_alloc: DirState::new_offset_alloc(StorageType::Ssd, 0, DEFAULT_BLOCK_ALIGN),
@@ -410,8 +393,6 @@ mod test {
         VfsDir {
             version: StorageVersion::with_cluster("t"),
             stats: FsStats::new(p),
-            active_dir: PathBuf::from(p).join("a"),
-            staging_dir: PathBuf::from(p).join("s"),
             storage_type: StorageType::Ssd,
             conf_capacity: 1 << 30,
             reserved_bytes: 0,
@@ -440,7 +421,7 @@ mod test {
         let tmp = layout.allocate(&dir, &block)?;
         dir.reserve_space(false, block.len);
 
-        let tmp_file = tmp.get_block_path()?;
+        let tmp_file = FileLayout::block_path(&dir, &tmp)?;
         LocalFile::write_string(
             tmp_file.as_path(),
             "1".repeat(ByteUnit::MB as usize).as_str(),
@@ -456,10 +437,10 @@ mod test {
 
         // commit block
         // commit block (committed_len = 1MB, the actual data written)
-        let final1 = layout.finalize(&tmp, ByteUnit::MB as i64)?;
-        let file = final1.get_block_path()?;
+        let final1 = layout.finalize(&dir, &tmp, ByteUnit::MB as i64)?;
+        let file = FileLayout::block_path(&dir, &final1)?;
         dir.release_space(false, block.len);
-        dir.reserve_space(false, final1.len);
+        dir.reserve_space(true, final1.len);
         println!(
             "final_file = {:?}, available = {}",
             file,
@@ -474,17 +455,18 @@ mod test {
     #[test]
     fn finalize_block_spdk() -> CommonResult<()> {
         let st = spdk_state("/spdk/final", 1 << 30);
-        let _dir = spdk_dir("/spdk/final", st.clone(), 1 << 30);
+        let dir = spdk_dir("/spdk/final", st, 1 << 30);
         let meta = BlockMeta {
             id: 1,
             len: 4096,
             state: BlockState::Writing,
-            dir: st,
+            dir_id: dir.id(),
+            storage_type: StorageType::SpdkDisk,
             actual_len: 4096,
             bdev_offset: 0,
         };
         let layout = BdevLayout::new(None);
-        let r = layout.finalize(&meta, 2048)?;
+        let r = layout.finalize(&dir, &meta, 2048)?;
         assert_eq!(r.len, 2048);
         Ok(())
     }


### PR DESCRIPTION
# Summary

Decouple worker block metadata from live storage-directory state and move
filesystem and SPDK placement behavior behind `BlockLayout`.

This creates a reusable boundary between dataset metadata, physical storage,
and logical data layout. Existing `VfsDataset` behavior is preserved while
other datasets can define their own metadata and layout without inheriting
the current block-file organization.

# Issue Describe / Design

Related issue: None.

## Why this refactor is needed

Previously, `BlockMeta` held an `Arc<DirState>` and exposed filesystem path
and SPDK device operations directly. This mixed several responsibilities:

- persistent block placement metadata;
- live directory and allocator state;
- current filesystem path conventions;
- SPDK device access;
- block lifecycle behavior.

As a result, another dataset would need to depend on current `VfsDataset`
internals and its active/staging path rules. The shared `Arc<DirState>` also
made ownership and lock boundaries harder to identify.

The intended separation is:

```text
BlockMeta:
  describes physical placement using value fields

VfsDir / DirState:
  owns one physical directory and medium-specific runtime state

BlockLayout:
  defines how data is organized and accessed on that medium

VfsDataset:
  owns its metadata and coordinates the current block lifecycle
```

## Reuse boundary

`VfsDir` is the reusable unit for one physical directory. It owns the
identity, path, storage medium, device information, capacity counters, and
medium-specific allocator state required to access that directory.

`DirList` remains the reusable group of `VfsDir` instances. A dataset can
resolve a `dir_id` through `DirList`, select its own `BlockLayout`, and build
its own reader and writer contexts without storing runtime directory objects
inside its metadata.

Other datasets can therefore reuse the same physical directories and medium
support while keeping their own metadata store, key model, path organization,
and lifecycle policy.

## Design decisions

- `BlockMeta` stores value-only physical placement fields.
- `VfsDir` owns directory identity, path, medium type, and runtime state.
- `FileLayout` owns filesystem path generation and local-file access.
- `BdevLayout` owns SPDK allocation, persistence, and device access.
- `VfsDataset` resolves a `BlockMeta` to its `VfsDir` and `BlockLayout`.
- Reader, writer, short-circuit, and asynchronous deallocation operations
  use owned layout and directory handles after leaving the dataset lock.
- Metadata is removed before physical deletion.
- Capacity is released only after physical deallocation succeeds.
- Restart accounting uses physical bytes, including aligned SPDK extents.
- Scheduled asynchronous deletions consume their counter on terminal errors.

No master metadata or external worker protocol is changed by this PR.

## Locking and follow-up optimization

This PR intentionally retains the global `RwLock<BlockDataset>` for block
lifecycle serialization. Changing the data model and lock model together
would make correctness and failure ordering difficult to review.

The refactor establishes the ownership boundaries needed for later lock
optimization:

1. Keep `DirList` and the layout registry as shared, mostly immutable
   physical-storage services.
2. Move directory selection state behind an internal atomic or small lock.
3. Store block metadata in a sharded map or use per-block synchronization.
4. Keep SPDK extent allocation protected by its allocator lock.
5. Keep directory capacity counters independently synchronized.
6. Resolve and clone metadata, directory, and layout handles in a short
   critical section, then perform I/O outside the dataset-wide lock.
7. Preserve metadata-first deletion and release capacity only after
   successful physical deallocation.

This PR is a prerequisite for reducing the global lock scope, but does not
claim to complete that concurrency change.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `worker/block/block_meta.rs` | Store placement values instead of live `DirState` | Internal representation only |
| `worker/storage/layout/*` | Own file paths, SPDK access, and lifecycle operations | Rejects invalid negative file sizes |
| `worker/storage/vfs_dataset.rs` | Resolve directories and restore physical capacity | Correct SPDK restart accounting |
| `worker/block/block_store.rs` | Reuse owned directory handles during async delete | Balances delete metrics on errors |
| `worker/storage/vfs_dir.rs` | Own directory identity and runtime state | Removes duplicate ownership |
| `worker/storage/dir_state.rs` | Retain medium-specific allocator state | Existing SPDK allocation preserved |
| `worker/storage/spdk_meta_store.rs` | Persist explicit placement values | Existing recovery behavior preserved |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `make format` | PASS | Formatting and two release Clippy passes |
| `cargo test -p curvine-server worker::storage` | PASS | 36 tests passed |
| `cargo test -p curvine-server worker::block::block_store::tests` | PASS | 2 tests passed |
| `git diff --check` | PASS | No whitespace errors |

# Dependencies

- Base: `main`
- Follow-up: #1196
- Related issues: None
- Blocks: #1196
