### PR TITLE
refactor(worker): centralize physical storage capacity

### DIFF
--- a/curvine-server/src/worker/block/block_store.rs
+++ b/curvine-server/src/worker/block/block_store.rs
@@ -18,7 +18,6 @@ use crate::worker::storage::{
 };
 use curvine_common::conf::ClusterConf;
 use curvine_common::state::{ExtendedBlock, StorageInfo};
-use log::error;
 use orpc::CommonResult;
 use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
@@ -141,33 +140,7 @@ impl BlockStore {
     // This method is called by the heartbeat thread and returns all storage information, including failed storage.
     pub fn get_and_check_storages(&self) -> CommonResult<Vec<StorageInfo>> {
         let state = self.read()?;
-        let mut vec = vec![];
-        for item in state.dir_iter() {
-            let failed = match item.check_dir() {
-                Ok(_) => false,
-                Err(e) => {
-                    error!("check_dir {}: {}", item.id(), e);
-                    item.set_failed();
-                    true
-                }
-            };
-            let info = StorageInfo {
-                dir_id: item.id(),
-                storage_id: item.version().storage_id.to_string(),
-                failed,
-                capacity: item.capacity(),
-                fs_used: item.fs_used(),
-                non_fs_used: item.non_fs_used(),
-                available: item.available(),
-                reserved_bytes: item.reserved_bytes(),
-                storage_type: item.storage_type(),
-                block_num: state.num_blocks() as i64,
-                dir_path: item.path_str().to_string(),
-            };
-            vec.push(info);
-        }
-
-        Ok(vec)
+        Ok(state.get_and_check_storages())
     }
 }
 

--- a/curvine-server/src/worker/storage/dir_list.rs
+++ b/curvine-server/src/worker/storage/dir_list.rs
@@ -128,12 +128,6 @@ impl DirList {
             .clone())
     }
 
-    /// Add physical bytes after allocation succeeds or during startup restoration.
-    pub fn reserve_space(&self, dir_id: u32, is_final: bool, bytes: i64) -> CommonResult<()> {
-        self.get_dir_check(dir_id)?.reserve_space(is_final, bytes);
-        Ok(())
-    }
-
     /// Update space usage when an existing block enters writing.
     pub fn update_write_space(
         &self,
@@ -228,7 +222,7 @@ impl DirList {
     ) -> CommonResult<Arc<VfsDir>> {
         let bytes = ByteUnit::from_str(size_str.as_ref())?.as_byte() as i64;
         let dir = self.choose_dir(StorageRequest::new(stg_type, bytes)?)?;
-        self.reserve_space(dir.id(), false, bytes)?;
+        dir.reserve_space(false, bytes);
         Ok(dir)
     }
 
@@ -338,7 +332,7 @@ mod tests {
             10 * ByteUnit::MB as i64,
         )?)?;
         assert_eq!(group.available(), before);
-        group.reserve_space(dir.id(), false, 10 * ByteUnit::MB as i64)?;
+        dir.reserve_space(false, 10 * ByteUnit::MB as i64);
         assert_eq!(group.available(), before - 10 * ByteUnit::MB as i64);
         Ok(())
     }
@@ -359,7 +353,7 @@ mod tests {
         let available = group.available();
         let dir = group.choose_dir(StorageRequest::new(StorageType::Ssd, available)?)?;
         assert_eq!(group.available(), available);
-        group.reserve_space(dir.id(), false, available)?;
+        dir.reserve_space(false, available);
         assert_eq!(group.available(), 0);
         group.release_space(dir.id(), false, available)?;
         assert_eq!(group.available(), available);

--- a/curvine-server/src/worker/storage/dir_list.rs
+++ b/curvine-server/src/worker/storage/dir_list.rs
@@ -13,16 +13,33 @@
 // limitations under the License.
 
 use crate::worker::storage::{ChoosingPolicy, RobinChoosingPolicy, VfsDir};
-use curvine_common::state::ExtendedBlock;
-#[cfg(test)]
-use curvine_common::state::{FileType, StorageType};
+use curvine_common::state::{StorageInfo, StorageType};
 use indexmap::map::Values;
 use indexmap::IndexMap;
-use log::{info, warn};
+use log::{error, info, warn};
 use orpc::common::ByteUnit;
 use orpc::{err_box, CommonResult};
 use std::ops::Index;
 use std::sync::Arc;
+
+/// Layout-independent request for physical capacity.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct StorageRequest {
+    pub storage_type: StorageType,
+    pub bytes: i64,
+}
+
+impl StorageRequest {
+    pub fn new(storage_type: StorageType, bytes: i64) -> CommonResult<Self> {
+        if bytes < 0 {
+            return err_box!("Storage allocation size cannot be negative: {}", bytes);
+        }
+        Ok(Self {
+            storage_type,
+            bytes,
+        })
+    }
+}
 
 // Directory list.
 pub struct DirList {
@@ -62,6 +79,13 @@ impl DirList {
         self.dirs.get(&dir_id)
     }
 
+    fn get_dir_check(&self, dir_id: u32) -> CommonResult<&VfsDir> {
+        match self.get_dir(dir_id) {
+            Some(dir) => Ok(dir),
+            None => err_box!("No storage directory found: {}", dir_id),
+        }
+    }
+
     pub fn get_dir_index(&self, index: usize) -> Option<&Arc<VfsDir>> {
         self.dirs.get_index(index).map(|x| x.1)
     }
@@ -96,19 +120,116 @@ impl DirList {
         used
     }
 
-    pub fn choose_dir(&mut self, block: &ExtendedBlock) -> CommonResult<Arc<VfsDir>> {
-        Ok(self.chooser.choose_dir(&self.dirs, block)?.clone())
+    /// Select a physical directory without changing its capacity accounting.
+    pub fn choose_dir(&mut self, request: StorageRequest) -> CommonResult<Arc<VfsDir>> {
+        Ok(self
+            .chooser
+            .choose_dir(&self.dirs, request.storage_type, request.bytes)?
+            .clone())
+    }
+
+    /// Add physical bytes after allocation succeeds or during startup restoration.
+    pub fn reserve_space(&self, dir_id: u32, is_final: bool, bytes: i64) -> CommonResult<()> {
+        self.get_dir_check(dir_id)?.reserve_space(is_final, bytes);
+        Ok(())
+    }
+
+    /// Update space usage when an existing block enters writing.
+    pub fn update_write_space(
+        &self,
+        dir_id: u32,
+        was_final: bool,
+        old_bytes: i64,
+        new_bytes: i64,
+    ) -> CommonResult<()> {
+        if new_bytes < 0 {
+            return err_box!("Storage allocation size cannot be negative: {}", new_bytes);
+        }
+        let dir = self.get_dir_check(dir_id)?;
+        let reclaimable = old_bytes.max(0);
+        if new_bytes > dir.available().saturating_add(reclaimable) {
+            return err_box!(
+                "Not enough space in storage dir {}: need {}, available {} (including {} reusable bytes)",
+                dir_id,
+                new_bytes,
+                dir.available(),
+                reclaimable
+            );
+        }
+
+        dir.release_space(was_final, old_bytes);
+        dir.reserve_space(false, new_bytes);
+        Ok(())
+    }
+
+    /// Update space usage when a writing block is finalized.
+    pub fn update_final_space(
+        &self,
+        dir_id: u32,
+        reserved_bytes: i64,
+        final_bytes: i64,
+    ) -> CommonResult<()> {
+        if final_bytes < 0 {
+            return err_box!(
+                "Storage allocation size cannot be negative: {}",
+                final_bytes
+            );
+        }
+        let dir = self.get_dir_check(dir_id)?;
+        dir.release_space(false, reserved_bytes);
+        dir.reserve_space(true, final_bytes);
+        Ok(())
+    }
+
+    /// Return capacity held by an aborted or removed block.
+    pub fn release_space(&self, dir_id: u32, is_final: bool, bytes: i64) -> CommonResult<()> {
+        self.get_dir_check(dir_id)?.release_space(is_final, bytes);
+        Ok(())
+    }
+
+    /// Collect per-directory heartbeat state and update physical health.
+    pub fn get_and_check_storages(&self, block_num: i64) -> Vec<StorageInfo> {
+        self.dir_iter()
+            .map(|dir| {
+                let failed = match dir.check_dir() {
+                    Ok(_) => false,
+                    Err(e) => {
+                        error!("check_dir {}: {}", dir.id(), e);
+                        dir.set_failed();
+                        true
+                    }
+                };
+                StorageInfo {
+                    dir_id: dir.id(),
+                    storage_id: dir.version().storage_id.to_string(),
+                    failed,
+                    capacity: dir.capacity(),
+                    fs_used: dir.fs_used(),
+                    non_fs_used: dir.non_fs_used(),
+                    available: dir.available(),
+                    reserved_bytes: dir.reserved_bytes(),
+                    storage_type: dir.storage_type(),
+                    block_num,
+                    dir_path: dir.path_str().to_string(),
+                }
+            })
+            .collect()
+    }
+
+    pub fn failed_count(&self) -> usize {
+        self.dir_iter().filter(|dir| dir.is_failed()).count()
     }
 
     #[cfg(test)]
-    fn choose_dir_with_str<S: AsRef<str>>(
+    fn reserve_with_str<S: AsRef<str>>(
         &mut self,
         stg_type: StorageType,
         size_str: S,
     ) -> CommonResult<Arc<VfsDir>> {
         let bytes = ByteUnit::from_str(size_str.as_ref())?.as_byte() as i64;
-        let block = ExtendedBlock::new(0, bytes, stg_type, FileType::File);
-        self.choose_dir(&block)
+        let dir = self.choose_dir(StorageRequest::new(stg_type, bytes)?)?;
+        self.reserve_space(dir.id(), false, bytes)?;
+        Ok(dir)
     }
 
     pub fn add_dir(&mut self, dir: VfsDir) {
@@ -151,7 +272,7 @@ impl Index<usize> for DirList {
 
 #[cfg(test)]
 mod tests {
-    use crate::worker::storage::{DirList, VfsDir};
+    use crate::worker::storage::{DirList, StorageRequest, VfsDir};
     use curvine_common::conf::WorkerDataDir;
     use curvine_common::state::StorageType;
     use orpc::common::{ByteUnit, FileUtils};
@@ -176,17 +297,17 @@ mod tests {
 
         let mut list = DirList::new(vfs_dir)?;
 
-        let mem = list.choose_dir_with_str(StorageType::Mem, "5MB")?;
+        let mem = list.reserve_with_str(StorageType::Mem, "5MB")?;
         println!("choose mem: {:?}", mem.base_path());
         assert_eq!(dirs[0].path_str(), mem.path_str());
 
         println!("available {:?}", list.available());
 
-        let ssd1 = list.choose_dir_with_str(StorageType::Mem, "90MB")?;
+        let ssd1 = list.reserve_with_str(StorageType::Mem, "90MB")?;
         println!("choose ssd1: {:?}", ssd1.base_path());
         assert_eq!(dirs[1].path_str(), ssd1.path_str());
 
-        let ssd2 = list.choose_dir_with_str(StorageType::Mem, "90MB")?;
+        let ssd2 = list.reserve_with_str(StorageType::Mem, "90MB")?;
         println!("choose ssd2: {:?}", ssd2.base_path());
         assert_eq!(dirs[2].path_str(), ssd2.path_str());
 
@@ -199,6 +320,49 @@ mod tests {
         // assert_eq!(list.capacity(), 21 * ByteUnit::GB as i64);
         // assert_eq!(list.available(), 2500 * ByteUnit::MB as i64);
 
+        Ok(())
+    }
+
+    #[test]
+    fn choosing_dir_does_not_change_capacity() -> CommonResult<()> {
+        FileUtils::delete_path("../testing/dir-selection-capacity", true)?;
+        let dir = VfsDir::from_dir(
+            "",
+            WorkerDataDir::from_str("[SSD:100MB]../testing/dir-selection-capacity")?,
+        )?;
+        let mut group = DirList::new(vec![dir])?;
+        let before = group.available();
+
+        let dir = group.choose_dir(StorageRequest::new(
+            StorageType::Ssd,
+            10 * ByteUnit::MB as i64,
+        )?)?;
+        assert_eq!(group.available(), before);
+        group.reserve_space(dir.id(), false, 10 * ByteUnit::MB as i64)?;
+        assert_eq!(group.available(), before - 10 * ByteUnit::MB as i64);
+        Ok(())
+    }
+
+    #[test]
+    fn exact_fit_and_empty_group_are_handled() -> CommonResult<()> {
+        let mut empty = DirList::new(vec![])?;
+        assert!(empty
+            .choose_dir(StorageRequest::new(StorageType::Ssd, 1)?)
+            .is_err());
+
+        FileUtils::delete_path("../testing/capacity-exact-fit", true)?;
+        let dir = VfsDir::from_dir(
+            "",
+            WorkerDataDir::from_str("[SSD:10MB]../testing/capacity-exact-fit")?,
+        )?;
+        let mut group = DirList::new(vec![dir])?;
+        let available = group.available();
+        let dir = group.choose_dir(StorageRequest::new(StorageType::Ssd, available)?)?;
+        assert_eq!(group.available(), available);
+        group.reserve_space(dir.id(), false, available)?;
+        assert_eq!(group.available(), 0);
+        group.release_space(dir.id(), false, available)?;
+        assert_eq!(group.available(), available);
         Ok(())
     }
 }

--- a/curvine-server/src/worker/storage/mod.rs
+++ b/curvine-server/src/worker/storage/mod.rs
@@ -22,7 +22,7 @@ mod policy;
 pub use self::policy::*;
 
 mod dir_list;
-pub use self::dir_list::DirList;
+pub use self::dir_list::{DirList, StorageRequest};
 
 mod version;
 pub use self::version::*;

--- a/curvine-server/src/worker/storage/policy.rs
+++ b/curvine-server/src/worker/storage/policy.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::worker::storage::VfsDir;
-use curvine_common::state::{ExtendedBlock, StorageType};
+use curvine_common::state::StorageType;
 use indexmap::IndexMap;
 use orpc::{err_box, CommonResult};
 use std::collections::HashMap;
@@ -27,10 +27,11 @@ impl ChoosingPolicy {
     pub fn choose_dir<'a>(
         &mut self,
         dirs: &'a IndexMap<u32, Arc<VfsDir>>,
-        block: &ExtendedBlock,
+        storage_type: StorageType,
+        required_bytes: i64,
     ) -> CommonResult<&'a Arc<VfsDir>> {
         match self {
-            ChoosingPolicy::Robin(c) => c.choose_dir(dirs, block),
+            ChoosingPolicy::Robin(c) => c.choose_dir(dirs, storage_type, required_bytes),
         }
     }
 }
@@ -55,17 +56,26 @@ impl RobinChoosingPolicy {
     fn choose_dir<'a>(
         &mut self,
         dirs: &'a IndexMap<u32, Arc<VfsDir>>,
-        block: &ExtendedBlock,
+        storage_type: StorageType,
+        required_bytes: i64,
     ) -> CommonResult<&'a Arc<VfsDir>> {
-        let mut res = self.get_next_dir(dirs, block.storage_type, block.len);
-        if res.is_none() && block.storage_type != StorageType::Disk {
-            res = self.get_next_dir(dirs, StorageType::Disk, block.len)
+        if dirs.is_empty() {
+            return err_box!("No physical storage directories are configured");
+        }
+
+        let mut res = self.get_next_dir(dirs, storage_type, required_bytes);
+        if res.is_none() && storage_type != StorageType::Disk {
+            res = self.get_next_dir(dirs, StorageType::Disk, required_bytes)
         }
 
         if let Some(v) = res {
             Ok(v)
         } else {
-            err_box!("Not enough space to save {} block", block.size_string())
+            err_box!(
+                "Not enough {:?} storage capacity for {} bytes",
+                storage_type,
+                required_bytes
+            )
         }
     }
 

--- a/curvine-server/src/worker/storage/vfs_dataset.rs
+++ b/curvine-server/src/worker/storage/vfs_dataset.rs
@@ -153,8 +153,7 @@ impl VfsDataset {
             let blocks = layout.scan(dir)?;
             for block in blocks {
                 let physical_bytes = block.physical_bytes();
-                self.dir_list
-                    .reserve_space(dir.id(), block.is_final(), physical_bytes)?;
+                dir.reserve_space(block.is_final(), physical_bytes);
                 self.meta.put(block);
             }
         }
@@ -334,8 +333,7 @@ impl Dataset for VfsDataset {
                 let layout = self.layouts.get(dir.storage_type());
                 let meta = layout.allocate(&dir, block)?;
 
-                self.dir_list
-                    .reserve_space(dir.id(), false, meta.physical_bytes())?;
+                dir.reserve_space(false, meta.physical_bytes());
                 self.meta.put(meta.clone());
 
                 Ok(meta)

--- a/curvine-server/src/worker/storage/vfs_dataset.rs
+++ b/curvine-server/src/worker/storage/vfs_dataset.rs
@@ -14,11 +14,11 @@
 
 use crate::worker::block::{BlockMeta, BlockState};
 use crate::worker::storage::{
-    BlockLayout, BlockLayoutKind, BlockLayouts, Dataset, DirList, SpdkMetaStore, StorageVersion,
-    VfsDir, VfsMetaStore,
+    BlockLayout, BlockLayoutKind, BlockLayouts, Dataset, DirList, SpdkMetaStore, StorageRequest,
+    StorageVersion, VfsDir, VfsMetaStore,
 };
 use curvine_common::conf::{ClusterConf, WorkerDataDir};
-use curvine_common::state::{ExtendedBlock, StorageType};
+use curvine_common::state::{ExtendedBlock, StorageInfo, StorageType};
 use indexmap::map::Values;
 use log::info;
 use orpc::common::{ByteUnit, FileUtils, LocalTime, TimeSpent};
@@ -152,7 +152,9 @@ impl VfsDataset {
             let layout = self.layouts.get(dir.storage_type());
             let blocks = layout.scan(dir)?;
             for block in blocks {
-                dir.reserve_space(block.is_final(), block.physical_bytes());
+                let physical_bytes = block.physical_bytes();
+                self.dir_list
+                    .reserve_space(dir.id(), block.is_final(), physical_bytes)?;
                 self.meta.put(block);
             }
         }
@@ -231,9 +233,8 @@ impl VfsDataset {
     }
 
     pub(crate) fn release_block_space(&self, meta: &BlockMeta) -> CommonResult<()> {
-        let dir = self.find_dir(meta.dir_id())?;
-        dir.release_space(meta.is_final(), meta.physical_bytes());
-        Ok(())
+        self.dir_list
+            .release_space(meta.dir_id(), meta.is_final(), meta.physical_bytes())
     }
 
     pub(crate) fn remove_block_by_id(&mut self, id: i64) -> CommonResult<BlockMeta> {
@@ -249,6 +250,19 @@ impl VfsDataset {
             Some(dir) => dir.clone(),
         };
         Ok((self.layouts.get(meta.storage_type()).clone(), dir))
+    }
+
+    pub fn get_and_check_storages(&self) -> Vec<StorageInfo> {
+        self.dir_list
+            .get_and_check_storages(self.meta.block_count() as i64)
+    }
+
+    pub fn failed_storage_count(&self) -> usize {
+        self.dir_list.failed_count()
+    }
+
+    pub fn storage_count(&self) -> usize {
+        self.dir_list.len()
     }
 }
 
@@ -295,8 +309,12 @@ impl Dataset for VfsDataset {
                     let new_meta = layout.prepare_write(dir, &meta, block)?;
                     let new_physical_bytes = new_meta.physical_bytes();
 
-                    dir.release_space(meta.is_final(), old_physical_bytes);
-                    dir.reserve_space(false, new_physical_bytes);
+                    self.dir_list.update_write_space(
+                        meta.dir_id(),
+                        meta.is_final(),
+                        old_physical_bytes,
+                        new_physical_bytes,
+                    )?;
                     self.meta.put(new_meta.clone());
 
                     Ok(new_meta)
@@ -310,12 +328,15 @@ impl Dataset for VfsDataset {
             }
 
             None => {
-                let dir = self.dir_list.choose_dir(block)?;
+                let dir = self
+                    .dir_list
+                    .choose_dir(StorageRequest::new(block.storage_type, block.len)?)?;
                 let layout = self.layouts.get(dir.storage_type());
                 let meta = layout.allocate(&dir, block)?;
 
+                self.dir_list
+                    .reserve_space(dir.id(), false, meta.physical_bytes())?;
                 self.meta.put(meta.clone());
-                dir.reserve_space(false, meta.physical_bytes());
 
                 Ok(meta)
             }
@@ -363,9 +384,8 @@ impl Dataset for VfsDataset {
             (meta.dir_id(), reserved_bytes, final_bytes, final_meta)
         };
 
-        let dir = self.find_dir(dir_id)?;
-        dir.release_space(false, reserved_bytes);
-        dir.reserve_space(true, final_bytes);
+        self.dir_list
+            .update_final_space(dir_id, reserved_bytes, final_bytes)?;
         self.meta.put(final_meta.clone());
 
         Ok(final_meta)
@@ -386,11 +406,13 @@ impl Dataset for VfsDataset {
 
 #[cfg(test)]
 mod test {
+    use crate::worker::block::BlockMeta;
     use crate::worker::storage::{
-        Dataset, DirList, DirState, SpdkMetaStore, StorageVersion, VfsDataset, VfsDir,
+        Dataset, DirList, DirState, FileLayout, SpdkMetaStore, StorageVersion, VfsDataset, VfsDir,
     };
     use curvine_common::conf::{ClusterConf, WorkerConf};
     use curvine_common::state::{ExtendedBlock, FileType, StorageType};
+    use orpc::common::FileUtils;
     use orpc::sync::AtomicLong;
     use orpc::sys::FsStats;
     use orpc::CommonResult;
@@ -487,10 +509,109 @@ mod test {
     #[test]
     fn abort_spdk() -> CommonResult<()> {
         let mut ds = spdk_dataset()?;
-        let block = ExtendedBlock::new(1, 4096, StorageType::SpdkDisk, FileType::File);
+        let block = ExtendedBlock::new(1, 1, StorageType::SpdkDisk, FileType::File);
+        let available = ds.available();
         ds.open_block(&block)?;
+        assert_eq!(ds.available(), available - 4096);
         let ok = ds.abort_block(&block).is_ok();
         assert!(ok && ds.get_block(1).is_none());
+        assert_eq!(ds.available(), available);
+        Ok(())
+    }
+    #[test]
+    fn spdk_prepare_write_preserves_extent_charge() -> CommonResult<()> {
+        let mut ds = spdk_dataset()?;
+        let mut block = ExtendedBlock::new(1, 1, StorageType::SpdkDisk, FileType::File);
+        let available = ds.available();
+        ds.open_block(&block)?;
+        ds.finalize_block(&block)?;
+        assert_eq!(ds.available(), available - 4096);
+
+        block.len = 4097;
+        assert!(ds.open_block(&block).is_err());
+        assert_eq!(ds.available(), available - 4096);
+        assert!(ds.get_block(block.id).unwrap().is_final());
+
+        ds.abort_block(&block)?;
+        assert_eq!(ds.available(), available);
+        Ok(())
+    }
+    #[test]
+    fn abort_and_failed_prepare_write_preserve_capacity() -> CommonResult<()> {
+        let mut ds = create_data_set(true, "capacity-rollback");
+        let mut block = ExtendedBlock::with_mem(1, "100B")?;
+        let available = ds.available();
+        ds.open_block(&block)?;
+        assert_eq!(ds.available(), available - 100);
+        ds.abort_block(&block)?;
+        assert_eq!(ds.available(), available);
+
+        let meta = ds.open_block(&block)?;
+        ds.write_test_data(&meta, "50B")?;
+        block.len = 50;
+        ds.finalize_block(&block)?;
+        let finalized_available = ds.available();
+
+        block.len = 101;
+        assert!(ds.open_block(&block).is_err());
+        assert_eq!(ds.available(), finalized_available);
+        assert!(ds.get_block(block.id).unwrap().is_final());
+        Ok(())
+    }
+    #[test]
+    fn failed_file_deallocate_keeps_capacity_reserved() -> CommonResult<()> {
+        let mut ds = create_data_set(true, "deallocate-failure");
+        let block = ExtendedBlock::with_mem(1, "100B")?;
+        let available = ds.available();
+        let meta = ds.open_block(&block)?;
+        let dir = ds.find_dir(meta.dir_id())?;
+        let block_path = FileLayout::block_path(dir, &meta)?;
+
+        FileUtils::delete_path(&block_path, false)?;
+        std::fs::create_dir(&block_path)?;
+        std::fs::write(block_path.join("child"), b"data")?;
+
+        assert!(ds.abort_block(&block).is_err());
+        assert!(ds.get_block(block.id).is_none());
+        assert_eq!(ds.available(), available - 100);
+
+        FileUtils::delete_path(block_path, true)?;
+        Ok(())
+    }
+    #[test]
+    fn failed_file_allocate_does_not_reserve_capacity() -> CommonResult<()> {
+        let mut ds = create_data_set(true, "allocate-failure");
+        let block = ExtendedBlock::with_mem(1, "100B")?;
+        let available = ds.available();
+        let dir = ds.dir_iter().next().unwrap().clone();
+        let meta = BlockMeta::with_tmp(&block, &dir);
+        let block_path = FileLayout::block_path(&dir, &meta)?;
+
+        std::fs::create_dir(&block_path)?;
+
+        assert!(ds.open_block(&block).is_err());
+        assert!(ds.get_block(block.id).is_none());
+        assert_eq!(ds.available(), available);
+
+        FileUtils::delete_path(block_path, true)?;
+        Ok(())
+    }
+    #[test]
+    fn smaller_prepared_write_holds_old_capacity_until_completion() -> CommonResult<()> {
+        let mut ds = create_data_set(true, "smaller-prepared-write");
+        let mut block = ExtendedBlock::with_mem(1, "100B")?;
+        let total_available = ds.available();
+        let meta = ds.open_block(&block)?;
+        ds.write_test_data(&meta, "50B")?;
+        block.len = 50;
+        ds.finalize_block(&block)?;
+        let finalized_available = ds.available();
+
+        block.len = 20;
+        ds.open_block(&block)?;
+        assert_eq!(ds.available(), finalized_available);
+        ds.abort_block(&block)?;
+        assert_eq!(ds.available(), total_available);
         Ok(())
     }
     #[test]

--- a/curvine-server/src/worker/storage/vfs_dir.rs
+++ b/curvine-server/src/worker/storage/vfs_dir.rs
@@ -238,7 +238,7 @@ impl VfsDir {
     }
 
     // Allocate reserved space for writing blocks.
-    pub fn reserve_space(&self, is_final: bool, size: i64) {
+    pub(super) fn reserve_space(&self, is_final: bool, size: i64) {
         if size <= 0 {
             return;
         }
@@ -251,7 +251,7 @@ impl VfsDir {
     }
 
     // Free up space.
-    pub fn release_space(&self, is_final: bool, size: i64) {
+    pub(super) fn release_space(&self, is_final: bool, size: i64) {
         if size <= 0 {
             return;
         }
@@ -261,7 +261,7 @@ impl VfsDir {
                 let mut new_bytes = old_bytes - size;
                 if new_bytes < 0 {
                     warn!(
-                        "tmp bytes become negative {}, reset to 0, dir {:?}",
+                        "final bytes become negative {}, reset to 0, dir {:?}",
                         new_bytes,
                         self.stats.path()
                     );
@@ -301,10 +301,23 @@ impl VfsDir {
         self.stats.check_dir()
     }
 
+    pub(super) fn allocation_size(&self, requested_bytes: i64) -> Option<i64> {
+        if requested_bytes < 0 {
+            return None;
+        }
+        if self.storage_type == StorageType::SpdkDisk {
+            self.state.offset_alloc.allocation_size(requested_bytes)
+        } else {
+            Some(requested_bytes)
+        }
+    }
+
     pub fn can_allocate(&self, stg_type: StorageType, block_size: i64) -> bool {
         (stg_type == StorageType::Disk || stg_type == self.storage_type)
             && !self.is_failed()
-            && self.available() > block_size
+            && self
+                .allocation_size(block_size)
+                .is_some_and(|required| self.available() >= required)
     }
 
     pub fn is_failed(&self) -> bool {

--- a/curvine-server/src/worker/worker_metrics.rs
+++ b/curvine-server/src/worker/worker_metrics.rs
@@ -85,17 +85,10 @@ impl WorkerMetrics {
         self.num_blocks_to_delete
             .set(state.num_blocks_to_delete() as i64);
 
-        let mut storage_failed = 0;
-        for item in state.dir_iter() {
-            if item.is_failed() {
-                storage_failed += 1;
-            }
-        }
-        self.storage_failed.set(storage_failed);
+        self.storage_failed.set(state.failed_storage_count() as i64);
         self.used_memory_bytes.set(SysUtils::used_memory() as i64);
 
-        let total_disks = state.dir_iter().count();
-        self.store_total_disks.set(total_disks as i64);
+        self.store_total_disks.set(state.storage_count() as i64);
 
         Metrics::text_output()
     }


### PR DESCRIPTION
# Summary

Centralize physical directory selection, compound capacity transitions,
storage health reporting, and worker storage metrics in reusable `DirList`
and `VfsDir` APIs.

`VfsDataset` and other datasets can reuse the same physical disk-group
management while keeping their own metadata, layout, and lifecycle policy.

# Issue Describe / Design

Related issue: None.

## Why this refactor is needed

Physical storage management was spread across `VfsDataset`, `BlockStore`,
`VfsDir`, worker metrics, and layout code. This made another dataset
duplicate directory selection, physical capacity accounting, health checks,
and storage reporting.

It also made these boundaries difficult to review:

- logical block length versus aligned SPDK extent size;
- physical allocation versus capacity charging;
- finalize, prepare-write, abort, and removal transitions;
- layout-owned state versus directory-owned counters;
- metadata locking versus slow physical I/O.

Directory selection and physical capacity are properties of worker storage,
not properties of a specific block-file layout.

## Reuse boundary

`VfsDir` represents one physical storage directory. It owns:

- directory identity, path, and storage medium;
- capacity, used bytes, and reserved bytes;
- health state and device identity;
- SPDK allocation size and allocator state;
- the final and temporary capacity counters for that directory.

`DirList` represents a reusable physical disk group. It owns:

- lookup by `dir_id`;
- selection by storage type and physical byte requirement;
- compound prepare-write and finalize capacity transitions;
- aggregate capacity, availability, and usage;
- health checks, heartbeat reporting, and failed-directory counts.

A new allocation keeps the selected `Arc<VfsDir>`. After layout allocation
succeeds, the dataset charges that exact directory directly. This preserves
the original infallible accounting step and avoids a second lookup that
could create a post-allocation error path.

```text
Dataset:
  owns metadata, keys, layout, and lifecycle policy

DirList:
  owns disk-group selection, compound transitions, and reporting

VfsDir:
  owns one physical directory and its capacity counters
```

## Capacity transition rules

Directory selection uses a layout-independent request:

```text
StorageRequest {
    storage_type,
    bytes,
}
```

Capacity changes preserve this ordering:

```text
new allocation:
  choose VfsDir
  allocate physical storage
  charge physical bytes on the selected VfsDir
  publish block metadata

deallocation:
  remove metadata
  release layout-owned state
  delete physical storage
  release physical bytes
```

If physical allocation fails, capacity is not charged. If physical
deallocation fails, capacity remains charged. For SPDK, accounting uses the
aligned extent size rather than the logical block length, including startup
recovery.

Directory selection itself does not charge capacity. Exact-fit allocations
are accepted, while empty groups, negative sizes, and overflowing aligned
sizes return errors.

## Locking and follow-up optimization

This PR keeps the global `RwLock<BlockDataset>`. Current compound operations
rely on that outer lock to serialize metadata and capacity transitions.

The ownership boundaries introduced here support later lock reduction:

1. Keep the directory map and layout registry immutable after startup and
   share them through `Arc`.
2. Protect only round-robin or weighted chooser state with a small lock.
3. Make compound capacity changes linearizable at the selected `VfsDir`.
4. Shard block metadata or introduce per-block lifecycle synchronization.
5. Resolve owned metadata, layout, and directory handles in a short critical
   section, then perform physical I/O outside the dataset-wide lock.
6. Preserve metadata-first removal and release capacity only after successful
   physical deallocation.

# Changes

| Module | Change | Impact |
| ------ | ------ | ------ |
| `worker/storage/dir_list.rs` | Add requests, selection, compound accounting, health, and reporting | Reusable disk-group behavior |
| `worker/storage/vfs_dir.rs` | Convert logical requests to medium-specific physical sizes | SPDK uses aligned extents |
| `worker/storage/vfs_dataset.rs` | Coordinate layouts with physical capacity transitions | Preserves lifecycle ordering |
| `worker/storage/policy.rs` | Handle exact-fit and empty-directory selection | Corrects allocation boundaries |
| `worker/block/block_store.rs` | Delegate storage reports through the dataset | Removes duplicate reporting |
| `worker/worker_metrics.rs` | Read failed and total storage counts from the dataset | Preserves metric semantics |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-server worker::storage` | PASS | 43 tests passed |
| `cargo clippy -p curvine-server --all-targets -- -D warnings` | PASS | Worker/server targets |
| `cargo fmt --all -- --check` | PASS | No formatting differences |
| `git diff --check` | PASS | No whitespace errors |

The full workspace `make format` currently stops on an unrelated unused
`Writer` import in `curvine-fuse/src/fs/state/node_state.rs` from the latest
base branch. No unrelated FUSE change is included in this PR.

# Dependencies

- Base: `main`
- Related PRs: #1195 (merged)
- Related issues: None
- Blocks / blocked by: None
