### PR TITLE
fix(fuse): propagate startup failures (#1069)

### DIFF
--- a/curvine-fuse/src/cli/mount_run.rs
+++ b/curvine-fuse/src/cli/mount_run.rs
@@ -44,20 +44,23 @@ pub fn run_mount(args: FuseRuntimeArgs) -> CommonResult<()> {
     let fuse_rt = rt.clone();
 
     rt.block_on(async move {
-        let fs = CurvineFileSystem::new(cluster_conf, fuse_rt.clone()).unwrap();
+        let fs = CurvineFileSystem::new(cluster_conf, fuse_rt.clone())?;
         let conf = fs.conf().clone();
 
         ensure_fs_path_exists(&fs, &conf).await?;
 
         let node_state = fs.state().clone();
         let web_port = conf.web_port;
+        let mut session = FuseSession::new(fuse_rt.clone(), fs, conf).await?;
+
+        // Do not leave the metrics server running when session construction fails.
+        // Build every startup-critical component before spawning background work.
         fuse_rt.spawn(async move {
             if let Err(e) = WebServer::start(web_port, node_state).await {
                 log::error!("Failed to start metrics server: {}", e);
             }
         });
 
-        let mut session = FuseSession::new(fuse_rt.clone(), fs, conf).await.unwrap();
         session.run().await
     })?;
 

--- a/curvine-fuse/src/session/fuse_mnt.rs
+++ b/curvine-fuse/src/session/fuse_mnt.rs
@@ -36,26 +36,23 @@ pub struct FuseMnt {
 }
 
 impl FuseMnt {
-    pub fn new(path: PathBuf, conf: &FuseConf) -> Self {
-        let res = fuse_mount_pure(path.as_path(), conf);
-        match res {
-            Ok(fd) => Self::from_fd(path, conf, fd),
-
-            Err(e) => {
-                panic!("fuse mount failed, path {:?}, err {:?}", path, e);
-            }
-        }
+    pub fn new(path: PathBuf, conf: &FuseConf) -> IOResult<Self> {
+        let fd = fuse_mount_pure(path.as_path(), conf)?;
+        Self::from_fd(path, conf, fd)
     }
 
-    pub fn from_fd(path: PathBuf, conf: &FuseConf, fd: RawIO) -> Self {
-        sys::set_pipe_blocking(fd, false).unwrap();
-        info!("fuse mount success, path {:?}, fd {}", path, fd);
-        Self {
+    pub fn from_fd(path: PathBuf, _conf: &FuseConf, fd: RawIO) -> IOResult<Self> {
+        // Construct the RAII owner before fallible fd setup. If setup fails,
+        // `mnt` is dropped and the mount is cleaned up instead of becoming stale.
+        let mnt = Self {
             path,
             fd,
             clone_fds: Mutex::new(vec![]),
             auto_unmount: true,
-        }
+        };
+        sys::set_pipe_blocking(mnt.fd, false)?;
+        info!("fuse mount success, path {:?}, fd {}", mnt.path, mnt.fd);
+        Ok(mnt)
     }
 
     fn create_task_fd(&self, clone: bool) -> IOResult<BorrowedFd> {
@@ -108,5 +105,43 @@ impl Drop for FuseMnt {
             fuse_umount_pure(self.path.as_path());
             info!("unmount path={:?}, fd={}", self.path, self.fd);
         }
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::FuseMnt;
+    use curvine_common::conf::FuseConf;
+    use std::path::PathBuf;
+
+    fn missing_path(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "curvine-missing-{label}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system clock is after the Unix epoch")
+                .as_nanos()
+        ))
+    }
+
+    #[test]
+    fn mount_failure_returns_error() {
+        let conf = FuseConf::default();
+
+        assert!(
+            FuseMnt::new(missing_path("mount"), &conf).is_err(),
+            "an invalid mount point must return an error instead of panicking"
+        );
+    }
+
+    #[test]
+    fn fd_setup_failure_returns_error() {
+        let conf = FuseConf::default();
+
+        assert!(
+            FuseMnt::from_fd(missing_path("fd"), &conf, -1).is_err(),
+            "an invalid FUSE fd must return an error instead of panicking"
+        );
     }
 }

--- a/curvine-fuse/src/session/fuse_session.rs
+++ b/curvine-fuse/src/session/fuse_session.rs
@@ -430,7 +430,7 @@ impl<T: FileSystem> FuseSession<T> {
             let mut mnts = vec![];
             let all_mnt_paths = conf.get_all_mnt_path()?;
             for path in all_mnt_paths {
-                mnts.push(FuseMnt::new(path, conf));
+                mnts.push(FuseMnt::new(path, conf)?);
             }
             Ok(mnts)
         }
@@ -561,7 +561,7 @@ impl<T: FileSystem> FuseSession<T> {
                 sys::fcntl_set(fd, flags | libc::FD_CLOEXEC)?;
 
                 let path_buf = PathBuf::from(path);
-                mnts.push(FuseMnt::from_fd(path_buf, conf, fd));
+                mnts.push(FuseMnt::from_fd(path_buf, conf, fd)?);
             }
             if let Some(stage) = stage {
                 stage.success();


### PR DESCRIPTION
# Summary

Propagate recoverable FUSE startup errors instead of panicking on filesystem, session, mount, or file-descriptor setup failures. Startup-critical components are now constructed before background services are spawned.

# Issue Describe / Design

Closes #1069

Root cause:

The startup path used `unwrap()` when constructing `CurvineFileSystem` and `FuseSession`. `FuseMnt::new` also panicked on mount failure, while `FuseMnt::from_fd` unwrapped non-blocking FD setup errors. Recoverable environmental failures therefore terminated the process with a panic instead of returning a normal CLI error.

Reproduction steps:

1. Start `curvine-fuse` without permission to mount a valid empty mount point.
2. Let the kernel reject the FUSE mount.
3. Observe that the previous implementation panics instead of returning the mount error.

Fix approach:

- Return `IOResult<FuseMnt>` from `FuseMnt::new` and `FuseMnt::from_fd`.
- Propagate errors through mount setup, state restoration, and `run_mount`.
- Construct the RAII mount owner before fallible FD setup so an FD setup failure automatically unmounts the partially initialized mount.
- Construct the FUSE session before spawning the metrics web server.
- Preserve the existing successful startup and graceful shutdown behavior.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-fuse/src/cli/mount_run.rs` | Replace startup `unwrap()` calls with error propagation and delay web-server spawn | Startup failures return normal errors; successful startup is unchanged |
| `curvine-fuse/src/session/fuse_mnt.rs` | Return `IOResult`, add RAII cleanup, and add regression tests | Mount and FD setup failures no longer panic or leave stale mounts |
| `curvine-fuse/src/session/fuse_session.rs` | Propagate mount construction and restore errors | Session initialization now reports mount failures to the caller |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-fuse --lib session:: -- --nocapture` | PASS | 66 tests passed |
| `cargo clippy -p curvine-fuse --all-targets -- -D warnings` | PASS | No warnings |
| `make format` | PASS | Repository formatting and release checks passed |
| Unprivileged FUSE mount failure | PASS | Exited with status 1 and reported `Operation not permitted`; no panic or backtrace |
| Successful FUSE mount followed by SIGTERM | PASS | Session started and the mount was cleanly unmounted |

# Dependencies

- Related PRs: None
- Related issues: #1069
- Blocks / blocked by: None
