### PR TITLE
fix(skills): quote skill template description

### DIFF
--- a/.agents/skills/cv-add-skills/assets/skill-template/SKILL.md
+++ b/.agents/skills/cv-add-skills/assets/skill-template/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cv-<name>
-description: <One sentence: what this skill does>. Use when <comma-separated triggers>.
+description: "<One sentence: what this skill does>. Use when <comma-separated triggers>."
 ---
 
 # cv-<name>


### PR DESCRIPTION
# Summary

Quote the `description` placeholder in the `cv-add-skills` skill template so its YAML frontmatter parses correctly.

# Issue Describe / Design

Root cause:
- The template description placeholder contains an unquoted colon (`One sentence: ...`), which YAML parses as an invalid mapping context.

Fix approach:
- Wrap the placeholder description in double quotes.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `.agents/skills/cv-add-skills/assets/skill-template/SKILL.md` | Quote the YAML `description` placeholder | Fixes parsing of the skill template frontmatter |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `ruby -e 'require "yaml"; ... YAML.safe_load(...)'` | PASS | Verified template frontmatter parses successfully |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None
