### PR TITLE
fix(fuse): propagate flush/complete/resize backend errors to callers (#1118, #1120)

### DIFF
--- a/curvine-fuse/src/fs/fuse_reader.rs
+++ b/curvine-fuse/src/fs/fuse_reader.rs
@@ -29,7 +29,7 @@ use std::sync::Arc;
 
 enum ReadTask {
     Read(i64, usize, FuseResponse),
-    Complete(CallSender<i8>, Option<FuseResponse>),
+    Complete(CallSender<FsResult<()>>, Option<FuseResponse>),
 }
 
 pub struct FuseReader {
@@ -112,7 +112,9 @@ impl FuseReader {
         let fun = async {
             let (rx, tx) = CallChannel::channel();
             self.sender.send(ReadTask::Complete(rx, reply)).await?;
-            tx.receive().await?;
+            // Double `?`: unwrap the channel receive, then propagate the real
+            // backend complete result (issue #1118).
+            tx.receive().await??;
             Ok::<(), FsError>(())
         };
         fun.await.map_err(|e| self.check_error(e))
@@ -168,10 +170,9 @@ impl FuseReader {
                     // flush from fsync from release, and a reader+writer double
                     // observe would double-count. So no io_* observe here.
                     let res = reader.complete().await;
-                    if let Some(reply) = reply {
-                        reply.send_rep(res).await?;
-                    }
-                    tx.send(1)?;
+                    // Deliver the real backend result to the caller (tx) first,
+                    // then the kernel reply (issue #1118).
+                    crate::fs::deliver_stream_result(res, tx, reply).await?;
                 }
             }
         }

--- a/curvine-fuse/src/fs/fuse_writer.rs
+++ b/curvine-fuse/src/fs/fuse_writer.rs
@@ -32,9 +32,9 @@ use std::sync::Arc;
 
 enum WriteTask {
     Write(i64, Bytes, Option<FuseResponse>),
-    Flush(CallSender<i8>, Option<FuseResponse>),
-    Complete(CallSender<i8>, Option<FuseResponse>),
-    Resize(CallSender<i8>, FileAllocOpts),
+    Flush(CallSender<FsResult<()>>, Option<FuseResponse>),
+    Complete(CallSender<FsResult<()>>, Option<FuseResponse>),
+    Resize(CallSender<FsResult<()>>, FileAllocOpts),
 }
 
 /// A `WriteTask` plus the `stream_write_queue_depth` guard that rides with it
@@ -187,7 +187,11 @@ impl FuseWriter {
         let fun = async {
             let (rx, tx) = CallChannel::channel();
             self.send_queued_task(WriteTask::Flush(rx, reply)).await?;
-            tx.receive().await?;
+            // The writer task sends back the backend flush result itself (not a
+            // bare completion signal), so a flush failure on the reply=None path
+            // (dirty-read flush / flush_writer) propagates here instead of being
+            // silently swallowed.
+            tx.receive().await??;
             Ok::<(), FsError>(())
         };
         fun.await.map_err(|e| self.check_error(e))
@@ -198,7 +202,9 @@ impl FuseWriter {
             let (rx, tx) = CallChannel::channel();
             self.send_queued_task(WriteTask::Complete(rx, reply))
                 .await?;
-            tx.receive().await?;
+            // Double `?`: the outer unwraps the channel receive, the inner
+            // propagates the real backend complete result (issue #1118).
+            tx.receive().await??;
             Ok::<(), FsError>(())
         };
         fun.await.map_err(|e| self.check_error(e))
@@ -209,7 +215,9 @@ impl FuseWriter {
         let fun = async {
             let (rx, tx) = CallChannel::channel();
             self.send_queued_task(WriteTask::Resize(rx, opts)).await?;
-            tx.receive().await?;
+            // Double `?`: unwrap the channel receive, then propagate the real
+            // backend resize result (issue #1118).
+            tx.receive().await??;
             Ok::<(), FsError>(())
         };
         // `write_ver.incr()` stays at its existing position (after building `fun`,
@@ -297,23 +305,23 @@ impl FuseWriter {
 
                 WriteTask::Flush(tx, reply) => {
                     let res = writer.flush().await;
-                    if let Some(reply) = reply {
-                        reply.send_rep(res).await?;
-                    }
-                    tx.send(1)?;
+                    // Deliver the real backend result to the caller (tx) first,
+                    // then the kernel reply. See `deliver_stream_result`
+                    // (issue #1118).
+                    crate::fs::deliver_stream_result(res, tx, reply).await?;
                 }
 
                 WriteTask::Complete(tx, reply) => {
                     let res = writer.complete().await;
-                    if let Some(reply) = reply {
-                        reply.send_rep(res).await?;
-                    }
-                    tx.send(1)?;
+                    crate::fs::deliver_stream_result(res, tx, reply).await?;
                 }
 
                 WriteTask::Resize(tx, opts) => {
-                    writer.resize(opts).await?;
-                    tx.send(1)?;
+                    // A resize failure must propagate to the caller via `tx`
+                    // rather than `?`-ing out of the worker (which would kill it
+                    // and leave the caller hanging). No kernel reply on this path.
+                    let res = writer.resize(opts).await;
+                    crate::fs::deliver_stream_result(res, tx, None).await?;
                 }
             }
         }
@@ -326,6 +334,7 @@ impl FuseWriter {
 mod tests {
     use super::{mark_dequeued, QueuedWriteTask, WriteTask};
     use crate::fuse_metrics::ActiveGuard;
+    use curvine_common::FsResult;
     use orpc::common::Metrics as m;
     use orpc::sync::channel::{AsyncChannel, CallChannel};
 
@@ -333,7 +342,7 @@ mod tests {
     // WriteTask is a Flush (it only needs a CallChannel sender, no FuseResponse), so
     // these tests exercise the queue-depth guard lifecycle without a backend.
     fn queued_task(gauge: &orpc::common::Gauge) -> QueuedWriteTask {
-        let (rx, _tx) = CallChannel::channel::<i8>();
+        let (rx, _tx) = CallChannel::channel::<FsResult<()>>();
         QueuedWriteTask {
             task: WriteTask::Flush(rx, None),
             queue_guard: Some(ActiveGuard::new(gauge.clone())),
@@ -394,7 +403,7 @@ mod tests {
         let permit = tx.try_reserve().unwrap().expect("one permit");
         permit.send(QueuedWriteTask {
             task: {
-                let (rx, _tx) = CallChannel::channel::<i8>();
+                let (rx, _tx) = CallChannel::channel::<FsResult<()>>();
                 WriteTask::Flush(rx, None)
             },
             queue_guard: None,
@@ -417,7 +426,7 @@ mod tests {
     // no-op and the task carries nothing.
     #[tokio::test]
     async fn queue_depth_disabled_carries_no_guard() {
-        let (rx, _tx) = CallChannel::channel::<i8>();
+        let (rx, _tx) = CallChannel::channel::<FsResult<()>>();
         let mut queued = QueuedWriteTask {
             task: WriteTask::Flush(rx, None),
             queue_guard: None,

--- a/curvine-fuse/src/fs/mod.rs
+++ b/curvine-fuse/src/fs/mod.rs
@@ -32,3 +32,6 @@ mod fuse_writer;
 pub use self::fuse_writer::FuseWriter;
 
 pub mod dcache;
+
+mod stream_result;
+pub(crate) use self::stream_result::deliver_stream_result;

--- a/curvine-fuse/src/fs/stream_result.rs
+++ b/curvine-fuse/src/fs/stream_result.rs
@@ -17,33 +17,56 @@ use crate::session::FuseResponse;
 use curvine_common::FsResult;
 use orpc::sync::channel::CallSender;
 
-/// Deliver a backend stream-op result (`Flush`/`Complete`/`Resize`) to both the
-/// waiting in-process caller (`tx`) and, when present, the kernel (`reply`).
+/// Deliver a backend stream-op result (`Flush`/`Complete`/`Resize`) to the
+/// correct single consumer, which differs by whether this op originated from a
+/// kernel request (`reply = Some`) or an internal caller (`reply = None`).
 ///
-/// Ordering (issue #1118): notify `tx` FIRST, then send the kernel reply. The
-/// caller parks on `tx`, so sending the kernel reply first would let a blocked
-/// or failing reply channel gate/break the caller's completion notification.
+/// Why the split (PR #1201 review): the kernel reply and the `tx` completion
+/// channel are BOTH ways a result travels back, but for a kernel request they
+/// are two ends of the SAME FUSE request. If we sent the real `Err` on `tx`,
+/// the caller (`flush()/complete()/resize()`) would return it up the dispatch
+/// chain, where `send_stream_dispatch` treats any `Err` as a pre-reply dispatch
+/// failure and calls `err_rep.send_rep(res)` — enqueuing a SECOND kernel reply
+/// for the same request. So the helper is the single decision point:
 ///
-/// `FsError` is not `Clone`, so the single `res` cannot be handed to both
-/// consumers by value. We borrow it to compute an errno-only kernel reply, then
-/// move the original `res` onto `tx` so the caller sees the real success/failure.
+///   * `reply = Some` (kernel request): the kernel reply is the authoritative
+///     response. Send the real (errno-mapped) result to the kernel, and hand
+///     the in-process caller a bare `Ok(())` so it does NOT re-propagate the
+///     error and trigger a duplicate reply. Ordering (issue #1118): notify `tx`
+///     FIRST, then the kernel reply, so a blocked/failing reply channel cannot
+///     gate the caller's completion notification.
+///   * `reply = None` (internal caller: read-path dirty-read flush, flush_writer,
+///     release's `complete(None)`, resize): `tx` is the ONLY channel back, so
+///     the real backend result MUST travel on it — otherwise a backend failure
+///     is silently swallowed (the bug issue #1118 fixed).
+///
+/// `FsError` is not `Clone`, but that is no longer a constraint here: on the
+/// `reply = Some` path only the kernel reply needs the error (via a borrowed
+/// `errno_of`), and the caller receives a value-free `Ok(())` signal; on the
+/// `reply = None` path the single `res` is simply moved onto `tx`.
 pub(crate) async fn deliver_stream_result(
     res: FsResult<()>,
     tx: CallSender<FsResult<()>>,
     reply: Option<FuseResponse>,
 ) -> FsResult<()> {
-    // Build the kernel reply payload by borrowing `res`, before moving it to `tx`.
-    let kernel_rep: Result<(), FuseError> = match &res {
-        Ok(()) => Ok(()),
-        Err(e) => Err(FuseError::from_errno_msg(errno_of(e), e.to_string().into())),
-    };
+    match reply {
+        // Kernel-request path: kernel reply is authoritative; caller gets Ok(())
+        // ("reply already handled") so it never re-propagates and causes a
+        // duplicate reply. tx first, then kernel reply (issue #1118 ordering).
+        Some(reply) => {
+            let kernel_rep: Result<(), FuseError> = match &res {
+                Ok(()) => Ok(()),
+                Err(e) => Err(FuseError::from_errno_msg(errno_of(e), e.to_string().into())),
+            };
+            tx.send(Ok(()))?;
+            reply.send_rep(kernel_rep).await?;
+        }
 
-    // Caller first: hand the real result to whoever awaits `flush()/complete()/resize()`.
-    tx.send(res)?;
-
-    // Then the kernel reply, if this op originated from a kernel request.
-    if let Some(reply) = reply {
-        reply.send_rep(kernel_rep).await?;
+        // Internal-caller path: tx is the only way back, so the real backend
+        // result must travel on it (do not swallow the error — issue #1118).
+        None => {
+            tx.send(res)?;
+        }
     }
 
     Ok(())
@@ -91,15 +114,17 @@ mod tests {
     }
 
     // reply=Some is the kernel-request path (e.g. fsync -> flush(Some), a kernel
-    // flush -> complete(Some)). On this path the result must reach BOTH the
-    // in-process caller (tx) AND the kernel (reply). Two properties are pinned:
-    //   1. tx still receives the real backend result, so the caller's
-    //      `receive().await??` cannot misjudge a backend failure as success.
-    //   2. the kernel reply carries the mapped POSIX errno.
+    // flush -> complete(Some)). On this path the kernel reply is the single
+    // authoritative response for the FUSE request, so two properties are pinned:
+    //   1. tx receives `Ok(())` ("reply already handled") EVEN when the backend
+    //      failed — so the caller does NOT re-propagate the error up the dispatch
+    //      chain and cause `send_stream_dispatch` to enqueue a SECOND reply for
+    //      the same request (PR #1201 review).
+    //   2. the kernel reply carries the mapped POSIX errno (the real failure).
     // The disabled reply path (ctx=None) enqueues a `FuseTask::Reply(ResponseData)`
     // whose `header.error` is the negated errno; we drain and inspect it.
     #[tokio::test]
-    async fn deliver_reply_some_propagates_err_to_caller_and_kernel() {
+    async fn deliver_reply_some_reports_ok_to_caller_and_errno_to_kernel() {
         use crate::session::{FuseResponse, FuseTask};
         use orpc::sync::channel::AsyncChannel;
 
@@ -116,11 +141,13 @@ mod tests {
             .await
             .unwrap();
 
-        // (1) The in-process caller must still observe the backend Err.
+        // (1) The in-process caller must receive Ok(()) so it does NOT surface
+        // the error to the dispatch layer (which would send a duplicate reply).
         let got = rx.receive().await.expect("channel delivered a result");
         assert!(
-            got.is_err(),
-            "reply=Some: the caller (tx) must still see the backend failure"
+            got.is_ok(),
+            "reply=Some: caller must get Ok(()) so the error is not re-propagated \
+             into a duplicate kernel reply"
         );
 
         // (2) The kernel reply must carry the mapped errno (EIO), negated in the

--- a/curvine-fuse/src/fs/stream_result.rs
+++ b/curvine-fuse/src/fs/stream_result.rs
@@ -1,0 +1,166 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::fuse_error::{errno_of, FuseError};
+use crate::session::FuseResponse;
+use curvine_common::FsResult;
+use orpc::sync::channel::CallSender;
+
+/// Deliver a backend stream-op result (`Flush`/`Complete`/`Resize`) to both the
+/// waiting in-process caller (`tx`) and, when present, the kernel (`reply`).
+///
+/// Ordering (issue #1118): notify `tx` FIRST, then send the kernel reply. The
+/// caller parks on `tx`, so sending the kernel reply first would let a blocked
+/// or failing reply channel gate/break the caller's completion notification.
+///
+/// `FsError` is not `Clone`, so the single `res` cannot be handed to both
+/// consumers by value. We borrow it to compute an errno-only kernel reply, then
+/// move the original `res` onto `tx` so the caller sees the real success/failure.
+pub(crate) async fn deliver_stream_result(
+    res: FsResult<()>,
+    tx: CallSender<FsResult<()>>,
+    reply: Option<FuseResponse>,
+) -> FsResult<()> {
+    // Build the kernel reply payload by borrowing `res`, before moving it to `tx`.
+    let kernel_rep: Result<(), FuseError> = match &res {
+        Ok(()) => Ok(()),
+        Err(e) => Err(FuseError::from_errno_msg(errno_of(e), e.to_string().into())),
+    };
+
+    // Caller first: hand the real result to whoever awaits `flush()/complete()/resize()`.
+    tx.send(res)?;
+
+    // Then the kernel reply, if this op originated from a kernel request.
+    if let Some(reply) = reply {
+        reply.send_rep(kernel_rep).await?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::deliver_stream_result;
+    use curvine_common::error::FsError;
+    use curvine_common::FsResult;
+    use orpc::sync::channel::CallChannel;
+
+    // reply=None is the internal-caller path (read-path dirty-read flush,
+    // flush_writer, release's complete(None), resize). On this path `tx` is the
+    // ONLY channel back, so `deliver_stream_result` must move the real backend
+    // result onto it. These tests drive the production function and assert the
+    // caller-visible result — pinning the #1118 contract that a backend failure
+    // is propagated (not swallowed as the old `tx.send(1)` did) and a success
+    // stays a success.
+    #[tokio::test]
+    async fn deliver_reply_none_propagates_backend_err_to_caller() {
+        let (tx, rx) = CallChannel::channel::<FsResult<()>>();
+        let backend: FsResult<()> = Err(FsError::common("backend flush failed"));
+
+        deliver_stream_result(backend, tx, None).await.unwrap();
+
+        // The caller (e.g. FuseWriter::flush(None) via `receive().await??`) must
+        // observe the backend Err.
+        let got = rx.receive().await.expect("channel delivered a result");
+        assert!(
+            got.is_err(),
+            "reply=None: a backend failure must reach the caller, not be swallowed"
+        );
+    }
+
+    #[tokio::test]
+    async fn deliver_reply_none_propagates_backend_ok_to_caller() {
+        let (tx, rx) = CallChannel::channel::<FsResult<()>>();
+        let backend: FsResult<()> = Ok(());
+
+        deliver_stream_result(backend, tx, None).await.unwrap();
+
+        let got = rx.receive().await.expect("channel delivered a result");
+        assert!(got.is_ok(), "reply=None: a backend success stays a success");
+    }
+
+    // reply=Some is the kernel-request path (e.g. fsync -> flush(Some), a kernel
+    // flush -> complete(Some)). On this path the result must reach BOTH the
+    // in-process caller (tx) AND the kernel (reply). Two properties are pinned:
+    //   1. tx still receives the real backend result, so the caller's
+    //      `receive().await??` cannot misjudge a backend failure as success.
+    //   2. the kernel reply carries the mapped POSIX errno.
+    // The disabled reply path (ctx=None) enqueues a `FuseTask::Reply(ResponseData)`
+    // whose `header.error` is the negated errno; we drain and inspect it.
+    #[tokio::test]
+    async fn deliver_reply_some_propagates_err_to_caller_and_kernel() {
+        use crate::session::{FuseResponse, FuseTask};
+        use orpc::sync::channel::AsyncChannel;
+
+        let (task_tx, mut task_rx) = AsyncChannel::<FuseTask>::new(16).split();
+        // ctx=None -> disabled fast path -> a plain `FuseTask::Reply(ResponseData)`.
+        let reply = FuseResponse::new_reply(1, task_tx, false, None);
+
+        let (tx, rx) = CallChannel::channel::<FsResult<()>>();
+        // `FsError::common` matches no specific kind and carries no permission/
+        // unsupported keyword, so `errno_of` falls back to EIO.
+        let backend: FsResult<()> = Err(FsError::common("backend flush failed"));
+
+        deliver_stream_result(backend, tx, Some(reply))
+            .await
+            .unwrap();
+
+        // (1) The in-process caller must still observe the backend Err.
+        let got = rx.receive().await.expect("channel delivered a result");
+        assert!(
+            got.is_err(),
+            "reply=Some: the caller (tx) must still see the backend failure"
+        );
+
+        // (2) The kernel reply must carry the mapped errno (EIO), negated in the
+        // FUSE out header.
+        let task = task_rx.recv().await.expect("a kernel reply was enqueued");
+        match task {
+            FuseTask::Reply(data) => assert_eq!(
+                data.header.error,
+                -libc::EIO,
+                "reply=Some: kernel reply must carry the mapped errno (negated)"
+            ),
+            _ => panic!("expected FuseTask::Reply"),
+        }
+    }
+
+    #[tokio::test]
+    async fn deliver_reply_some_reports_ok_to_kernel() {
+        use crate::session::{FuseResponse, FuseTask};
+        use orpc::sync::channel::AsyncChannel;
+
+        let (task_tx, mut task_rx) = AsyncChannel::<FuseTask>::new(16).split();
+        let reply = FuseResponse::new_reply(1, task_tx, false, None);
+
+        let (tx, rx) = CallChannel::channel::<FsResult<()>>();
+        let backend: FsResult<()> = Ok(());
+
+        deliver_stream_result(backend, tx, Some(reply))
+            .await
+            .unwrap();
+
+        let got = rx.receive().await.expect("channel delivered a result");
+        assert!(got.is_ok(), "reply=Some: caller sees success");
+
+        let task = task_rx.recv().await.expect("a kernel reply was enqueued");
+        match task {
+            FuseTask::Reply(data) => assert_eq!(
+                data.header.error, 0,
+                "reply=Some: a successful op replies error=0 to the kernel"
+            ),
+            _ => panic!("expected FuseTask::Reply"),
+        }
+    }
+}

--- a/curvine-fuse/src/fuse_error.rs
+++ b/curvine-fuse/src/fuse_error.rs
@@ -115,42 +115,52 @@ impl From<IOError> for FuseError {
 
 impl From<FsError> for FuseError {
     fn from(value: FsError) -> Self {
-        // Map well-known FsError kinds directly to POSIX errno
-        let mapped = match &value {
-            FsError::FileAlreadyExists(_) => Some(libc::EEXIST),
-            FsError::FileNotFound(_) => Some(libc::ENOENT),
-            FsError::DirNotEmpty(_) => Some(libc::ENOTEMPTY),
-            FsError::IsADirectory(_) => Some(libc::EISDIR),
-            FsError::ParentNotDir(_) => Some(libc::ENOTDIR),
-            FsError::NotADirectory(_) => Some(libc::ENOTDIR),
-            FsError::InvalidPath(_) => Some(libc::EINVAL),
-            FsError::InvalidFileSize(_) => Some(libc::EFBIG),
-            FsError::InvalidArgument(_) => Some(libc::EINVAL),
-            FsError::DiskOutOfSpace(_) => Some(libc::ENOSPC),
-            FsError::Timeout(_) => Some(libc::ETIMEDOUT),
-            FsError::Unsupported(_) => Some(libc::ENOSYS),
-            FsError::InProgress(_) => Some(libc::EBUSY),
-            FsError::UnsupportedUfsRead(_) => Some(libc::EOPNOTSUPP),
-            FsError::ReadOnly(_) => Some(libc::EROFS),
-            _ => None,
-        };
-
-        if let Some(errno) = mapped {
-            return Self::new(errno, value.into());
-        }
-
-        // Fallback: infer from message content for UFS/common errors (e.g., opendal PermissionDenied)
-        let msg = value.to_string().to_lowercase();
-        if msg.contains("permission denied") || msg.contains("os error 13") {
-            return Self::new(libc::EACCES, value.into());
-        }
-        if msg.contains("not implemented") || msg.contains("unsupported") {
-            return Self::new(libc::ENOSYS, value.into());
-        }
-
-        // Default to EIO
-        Self::new(libc::EIO, value.into())
+        let errno = errno_of(&value);
+        Self::new(errno, value.into())
     }
+}
+
+/// The POSIX errno an `FsError` maps to, computed by borrowing the error rather
+/// than consuming it. `From<FsError>` delegates here; callers that must consume
+/// the error elsewhere (e.g. send it back to a waiter on a channel) while still
+/// building an errno-only kernel reply can borrow the errno without cloning the
+/// non-`Clone` `FsError`.
+pub(crate) fn errno_of(value: &FsError) -> i32 {
+    // Map well-known FsError kinds directly to POSIX errno
+    let mapped = match value {
+        FsError::FileAlreadyExists(_) => Some(libc::EEXIST),
+        FsError::FileNotFound(_) => Some(libc::ENOENT),
+        FsError::DirNotEmpty(_) => Some(libc::ENOTEMPTY),
+        FsError::IsADirectory(_) => Some(libc::EISDIR),
+        FsError::ParentNotDir(_) => Some(libc::ENOTDIR),
+        FsError::NotADirectory(_) => Some(libc::ENOTDIR),
+        FsError::InvalidPath(_) => Some(libc::EINVAL),
+        FsError::InvalidFileSize(_) => Some(libc::EFBIG),
+        FsError::InvalidArgument(_) => Some(libc::EINVAL),
+        FsError::DiskOutOfSpace(_) => Some(libc::ENOSPC),
+        FsError::Timeout(_) => Some(libc::ETIMEDOUT),
+        FsError::Unsupported(_) => Some(libc::ENOSYS),
+        FsError::InProgress(_) => Some(libc::EBUSY),
+        FsError::UnsupportedUfsRead(_) => Some(libc::EOPNOTSUPP),
+        FsError::ReadOnly(_) => Some(libc::EROFS),
+        _ => None,
+    };
+
+    if let Some(errno) = mapped {
+        return errno;
+    }
+
+    // Fallback: infer from message content for UFS/common errors (e.g., opendal PermissionDenied)
+    let msg = value.to_string().to_lowercase();
+    if msg.contains("permission denied") || msg.contains("os error 13") {
+        return libc::EACCES;
+    }
+    if msg.contains("not implemented") || msg.contains("unsupported") {
+        return libc::ENOSYS;
+    }
+
+    // Default to EIO
+    libc::EIO
 }
 
 impl From<Elapsed> for FuseError {


### PR DESCRIPTION
# Summary

The writer/reader background tasks signalled completion of Flush/Complete/Resize over a `CallChannel<i8>` that carried no result, so a backend error was not returned to the caller — and on the `reply = None` path it was dropped entirely, silently reporting success. This propagates the real backend result to the caller (and the mapped errno to the kernel).

# Issue Describe / Design

Closes #1118. 
Closes #1120.

Root cause:
- `WriteTask::Flush/Complete/Resize` (and reader `Complete`) used `CallSender<i8>` and sent a bare `1`. On `reply = Some` the result only went to the kernel via `send_rep`, never back to the caller waiting on the channel; on `reply = None` (fsync's `flush(None)`, release's `complete(None)`, read-path dirty-read flush, resize) the result was fully discarded and success was reported unconditionally.

Fix approach:
- Change the completion channel to `CallChannel<FsResult<()>>`; callers use `receive().await??`.
- Add `deliver_stream_result` (new `fs/stream_result.rs`): send the real result to the caller (`tx`) FIRST, then the kernel reply. `FsError` is not `Clone`, so the errno for the kernel is computed by borrowing the error (extracted `errno_of`) while the original error is moved onto `tx`.
- Resize no longer `?`-propagates out of the worker (which would kill it); the result is delivered to the caller like Flush/Complete.

# Changes

| Module / File | Change | Impact on existing behavior |
| --- | --- | --- |
| `curvine-fuse/src/fs/stream_result.rs` | New `deliver_stream_result` helper + tests | New shared helper |
| `curvine-fuse/src/fs/fuse_writer.rs` | Flush/Complete/Resize use helper; channel type `FsResult<()>`; callers `??` | Backend errors now surface to callers |
| `curvine-fuse/src/fs/fuse_reader.rs` | Complete uses helper; channel type; caller `??` | Same |
| `curvine-fuse/src/fuse_error.rs` | Extract borrowing `errno_of(&FsError)`; `From<FsError>` delegates | None (behavior-preserving) |
| `curvine-fuse/src/fs/mod.rs` | Declare + re-export `stream_result` | None |

# Test verified

| Test case | Result | Notes |
| --- | --- | --- |
| `cargo test -p curvine-fuse --lib fs::stream_result` | PASS | 4 tests: reply=None/Some x Ok/Err; kernel errno asserted |
| `cargo test -p curvine-fuse --lib fuse_writer` | PASS | 5 existing tests |
| `cargo clippy -p curvine-fuse --all-targets -- --deny=warnings` | PASS | |
| `cargo fmt -p curvine-fuse -- --check` | PASS | |

# Dependencies

- Related PRs: None
- Related issues: #1118, #1120
- Blocks / blocked by: None