### PR TITLE
fix(fuse): read full spliced requests from pipe (#1093)

### DIFF
--- a/curvine-fuse/src/session/channel/fuse_receiver.rs
+++ b/curvine-fuse/src/session/channel/fuse_receiver.rs
@@ -30,7 +30,7 @@ use orpc::runtime::{RpcRuntime, Runtime};
 use orpc::sync::channel::AsyncSender;
 use orpc::sync::FastDashMap;
 use orpc::sys::pipe::{AsyncFd, Pipe2, PipeFd};
-use orpc::{err_box, sys, try_option_ref};
+use orpc::{err_box, sys, try_option_mut};
 use std::sync::Arc;
 use tokio::sync::{watch, Notify};
 
@@ -119,7 +119,7 @@ impl<T: FileSystem> FuseReceiver<T> {
     }
 
     pub async fn splice(&mut self) -> IOResult<BytesMut> {
-        let pipe2 = try_option_ref!(self.pipe2);
+        let pipe2 = try_option_mut!(self.pipe2);
 
         let write_len = pipe2.write_io(&self.kernel_fd, None, self.fuse_len).await?;
 
@@ -128,19 +128,15 @@ impl<T: FileSystem> FuseReceiver<T> {
             self.buf.set_len(write_len);
         }
 
-        let read_len = pipe2.read_buf(&mut self.buf[..write_len]).await?;
-        if write_len != read_len {
-            return err_box!(
-                "splice read and write lengths are inconsistent, write len {}, read len {}",
-                write_len,
-                read_len
-            );
-        }
-        if read_len < FUSE_IN_HEADER_LEN {
+        // `write_len` is the number of bytes splice actually moved from
+        // /dev/fuse, not the configured maximum request size. A pipe read may
+        // return fewer bytes, so consume exactly that transfer before parsing.
+        pipe2.read_buf_full(&mut self.buf[..write_len]).await?;
+        if write_len < FUSE_IN_HEADER_LEN {
             return err_box!("short read on fuse device");
         };
 
-        Ok(self.buf.split_to(read_len))
+        Ok(self.buf.split_to(write_len))
     }
 
     /// Build a reply handle for `unique`. When `labels` is `Some`, a metrics

--- a/orpc/src/sys/pipe/pipe2.rs
+++ b/orpc/src/sys/pipe/pipe2.rs
@@ -16,7 +16,7 @@ use crate::io::IOResult;
 use crate::sys::pipe::{AsyncFd, PipeFd, PipePool, PipeReader, PipeWriter};
 use crate::sys::RawIO;
 use crate::{err_box, sys};
-use std::io::IoSlice;
+use std::io::{ErrorKind, IoSlice};
 use std::sync::Arc;
 
 pub struct Pipe2 {
@@ -155,6 +155,52 @@ impl Pipe2 {
         Ok(res as usize)
     }
 
+    /// Read exactly `buf.len()` bytes from the pipe.
+    ///
+    /// The pipe is non-blocking, so a single read may consume only part of a
+    /// transfer. `PipeReader::async_read` waits for readiness again after
+    /// `EAGAIN`; this loop handles successful short reads and retries `EINTR`.
+    /// A zero-length read is terminal because otherwise the loop could wait
+    /// forever for bytes that will never arrive.
+    pub async fn read_buf_full(&mut self, buf: &mut [u8]) -> IOResult<()> {
+        if buf.len() > self.buf_size {
+            return err_box!(
+                "read_buf_full: request size {} exceeds pipe buffer size {}",
+                buf.len(),
+                self.buf_size
+            );
+        }
+
+        let expected = buf.len();
+        let mut read = 0;
+        while read < expected {
+            match self.read_buf(&mut buf[read..]).await {
+                Ok(0) => {
+                    // Do not return a partially consumed pipe to its pool. The
+                    // FuseReceiver uses an unpooled pipe, but keeping this rule
+                    // here makes the helper safe for pooled callers as well.
+                    let _ = self.pool.take();
+                    return err_box!(
+                        "read_buf_full: pipe closed after {} of {} bytes",
+                        read,
+                        expected
+                    );
+                }
+                Ok(len) => read += len,
+                Err(e) if e.kind() == ErrorKind::Interrupted => continue,
+                Err(e) => {
+                    // A terminal error may leave unread bytes in the pipe. Drop
+                    // rather than pool it so those bytes cannot poison a later
+                    // transfer.
+                    let _ = self.pool.take();
+                    return Err(e);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     pub fn deregister(&mut self) -> PipeFd {
         let _ = self.reader.deregister();
         let _ = self.writer.deregister();
@@ -192,5 +238,42 @@ impl Drop for Pipe2 {
             // The pipeline in the resource is returned to the resource pool, not close.
             pool.release(self)
         }
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::Pipe2;
+    use crate::sys;
+    use crate::sys::pipe::{AsyncFd, OwnedFd, PipeFd};
+    use std::io::IoSlice;
+
+    #[tokio::test]
+    async fn read_buf_full_waits_for_all_partial_reads() {
+        let mut pipe = Pipe2::new(PipeFd::new(4096, false, false).unwrap()).unwrap();
+        let first = b"first-half";
+        let second = b"second-half";
+        let mut actual = vec![0; first.len() + second.len()];
+        let write_owner = OwnedFd::new(sys::dup(pipe.write_raw_fd()).unwrap());
+        let write_fd = AsyncFd::new(write_owner.as_borrowed()).unwrap();
+
+        pipe.write_iov(first.len(), &[IoSlice::new(first)])
+            .await
+            .unwrap();
+
+        let (read_result, ()) = tokio::join!(pipe.read_buf_full(&mut actual), async {
+            // The reader consumes the first half and then observes EAGAIN.
+            // Supplying the second half later proves it waits for readiness
+            // and resumes instead of treating the first short read as fatal.
+            tokio::task::yield_now().await;
+            let written = write_fd
+                .async_write(|fd| sys::writev(fd.fd(), &[IoSlice::new(second)]))
+                .await
+                .unwrap();
+            assert_eq!(written as usize, second.len());
+        });
+
+        read_result.unwrap();
+        assert_eq!(actual, [first.as_slice(), second.as_slice()].concat());
     }
 }


### PR DESCRIPTION
# Summary

Ensure the FUSE splice receive path reads every byte that splice(2) already transferred into the pipe before parsing the request. This prevents valid requests from being dropped when a non-blocking pipe read completes partially.

# Issue Describe / Design

Closes #1093

The receiver previously called Pipe2::read_buf once and treated any read_len != write_len result as fatal. A legal short pipe read therefore dropped the request and terminated that receiver.

The fix adds an exact-length asynchronous pipe read:

- use the actual byte count returned by splice(2), not the configured maximum request size;
- continue after successful short reads;
- rely on async readiness for EAGAIN and retry EINTR;
- treat zero progress as terminal;
- prevent a partially consumed pipe from returning to the pool after a terminal error.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| orpc/src/sys/pipe/pipe2.rs | Add read_buf_full and a deterministic partial-read regression test | Non-blocking pipe transfers are consumed completely; terminal partial pipes are not reused |
| curvine-fuse/src/session/channel/fuse_receiver.rs | Read exactly the byte count returned by the FUSE-to-pipe splice | Short pipe reads no longer drop otherwise valid FUSE requests |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| cargo test -p orpc read_buf_full_waits_for_all_partial_reads -- --nocapture | PASS | Delivers a request in two pipe writes and verifies the reader waits and reconstructs it |
| cargo clippy -p orpc -p curvine-fuse --all-targets -- --deny warnings --allow clippy::uninlined-format-args | PASS | All changed targets are clean |
| cargo test -p curvine-fuse --lib | BASELINE MATCH | 210 passed; the same 3 unrelated dcache tests fail on unmodified main |
| Actual FUSE mount with splice enabled | PASS | Three 32 MiB write, fsync, and readback rounds matched exact size and content; the daemon remained healthy and unmounted cleanly |
| make format | PASS | Formatting and release Clippy checks passed |

# Dependencies

- Related PRs: None
- Related issues: #1093
- Blocks / blocked by: None
