### PR TITLE
feat(master): add weighted worker allocation policy

### DIFF
--- a/curvine-common/proto/common.proto
+++ b/curvine-common/proto/common.proto
@@ -163,6 +163,7 @@ message WorkerInfoProto {
     required uint64 last_update = 6;
     map<string, StorageInfoProto> storage_map = 7;
     required int64 reserved_bytes = 8 [default = 0];
+    optional uint32 weight = 9 [default = 1];
 }
 
 message FileAllocOptsProto {

--- a/curvine-common/proto/worker.proto
+++ b/curvine-common/proto/worker.proto
@@ -79,6 +79,7 @@ message WorkerHeartbeatRequest {
 
     repeated StorageInfoProto storages = 8;
     repeated BlockReportInfoProto blocks = 9;
+    optional uint32 weight = 10 [default = 1];
 }
 
 message WorkerHeartbeatResponse {

--- a/curvine-common/src/conf/worker_conf.rs
+++ b/curvine-common/src/conf/worker_conf.rs
@@ -114,6 +114,12 @@ impl WorkerDataDir {
 pub struct WorkerConf {
     pub hostname: String,
 
+    /// Relative allocation weight used by the master's `weighted` worker policy.
+    /// A value of 0 keeps the worker registered but excludes it from new allocations.
+    /// This is trusted administrator configuration; use values that reflect the
+    /// intended relative capacity of workers in the cluster.
+    pub weight: u32,
+
     pub rpc_port: u16,
     pub web_port: u16,
 
@@ -177,6 +183,7 @@ impl Default for WorkerConf {
     fn default() -> Self {
         Self {
             hostname: ClusterConf::DEFAULT_HOSTNAME.to_string(),
+            weight: 1,
             rpc_port: ClusterConf::DEFAULT_WORKER_PORT,
             web_port: ClusterConf::DEFAULT_WORKER_WEB_PORT,
             dir_reserved: "0".to_string(),

--- a/curvine-common/src/state/worker_info.rs
+++ b/curvine-common/src/state/worker_info.rs
@@ -23,6 +23,8 @@ use std::fmt::{Display, Formatter};
 #[serde(default)]
 pub struct WorkerInfo {
     pub address: WorkerAddress,
+    #[serde(default = "WorkerInfo::default_weight")]
+    pub weight: u32,
     pub capacity: i64,
     pub available: i64,
     pub fs_used: i64,
@@ -35,9 +37,14 @@ pub struct WorkerInfo {
 }
 
 impl WorkerInfo {
-    pub fn new(addr: WorkerAddress) -> Self {
+    pub const fn default_weight() -> u32 {
+        1
+    }
+
+    pub fn new(addr: WorkerAddress, weight: u32) -> Self {
         Self {
             address: addr,
+            weight,
             capacity: 0,
             available: 0,
             fs_used: 0,
@@ -109,6 +116,7 @@ impl Default for WorkerInfo {
 
         Self {
             address,
+            weight: Self::default_weight(),
             capacity: 1 << 30,
             available: 1 << 30,
             fs_used: 0,

--- a/curvine-common/src/utils/proto_utils.rs
+++ b/curvine-common/src/utils/proto_utils.rs
@@ -332,6 +332,7 @@ impl ProtoUtils {
             non_fs_used: src.non_fs_used,
             last_update: src.last_update,
             reserved_bytes: src.reserved_bytes,
+            weight: Some(src.weight),
             storage_map: Default::default(),
         };
 
@@ -372,6 +373,7 @@ impl ProtoUtils {
                 fs_used: info.fs_used,
                 non_fs_used: info.non_fs_used,
                 reserved_bytes: info.reserved_bytes,
+                weight: info.weight.unwrap_or_else(WorkerInfo::default_weight),
                 ..Default::default()
             };
             for (k, v) in info.storage_map {

--- a/curvine-common/tests/worker_info_proto_test.rs
+++ b/curvine-common/tests/worker_info_proto_test.rs
@@ -1,0 +1,25 @@
+use curvine_common::state::WorkerInfo;
+use curvine_common::utils::ProtoUtils;
+
+#[test]
+fn worker_info_proto_preserves_weight() {
+    let worker = WorkerInfo {
+        weight: 42,
+        ..Default::default()
+    };
+
+    let proto = ProtoUtils::worker_info_to_pb(worker);
+    assert_eq!(proto.weight, Some(42));
+
+    let restored = ProtoUtils::worker_info_from_pb(vec![proto]);
+    assert_eq!(restored[0].weight, 42);
+}
+
+#[test]
+fn worker_info_proto_defaults_missing_weight() {
+    let mut proto = ProtoUtils::worker_info_to_pb(WorkerInfo::default());
+    proto.weight = None;
+
+    let restored = ProtoUtils::worker_info_from_pb(vec![proto]);
+    assert_eq!(restored[0].weight, WorkerInfo::default_weight());
+}

--- a/curvine-server/src/master/fs/policy/mod.rs
+++ b/curvine-server/src/master/fs/policy/mod.rs
@@ -27,6 +27,9 @@ pub use self::random_worker_policy::RandomWorkerPolicy;
 mod load_based_worker_policy;
 pub use self::load_based_worker_policy::LoadBasedWorkerPolicy;
 
+mod weighted_worker_policy;
+pub use self::weighted_worker_policy::WeightedWorkerPolicy;
+
 mod worker_policy_adapter;
 pub use self::worker_policy_adapter::WorkerPolicyAdapter;
 

--- a/curvine-server/src/master/fs/policy/weighted_worker_policy.rs
+++ b/curvine-server/src/master/fs/policy/weighted_worker_policy.rs
@@ -1,0 +1,228 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::master::fs::policy::{ChooseContext, WorkerPolicy};
+use curvine_common::state::{WorkerAddress, WorkerInfo};
+use indexmap::IndexMap;
+use orpc::{err_box, CommonResult};
+use rand::{thread_rng, Rng};
+use std::collections::HashSet;
+
+/// Selects workers randomly in proportion to their configured weights.
+///
+/// Selection is without replacement, so a worker can host at most one replica
+/// of a block. Workers with weight 0 remain registered but receive no new data.
+pub struct WeightedWorkerPolicy {}
+
+impl Default for WeightedWorkerPolicy {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl WeightedWorkerPolicy {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    fn is_eligible(
+        id: &u32,
+        worker: &WorkerInfo,
+        exclude_workers: &HashSet<u32>,
+        selected_ids: &HashSet<u32>,
+        min_available: i64,
+    ) -> bool {
+        worker.is_live()
+            && !exclude_workers.contains(id)
+            && !selected_ids.contains(id)
+            && worker.available >= min_available
+            && worker.weight > 0
+    }
+
+    fn select_weighted_workers<R: Rng + ?Sized>(
+        &self,
+        workers: &IndexMap<u32, WorkerInfo>,
+        count: usize,
+        exclude_workers: &HashSet<u32>,
+        min_available: i64,
+        rng: &mut R,
+    ) -> CommonResult<Vec<WorkerAddress>> {
+        let mut selected = Vec::with_capacity(count.min(workers.len()));
+        let mut selected_ids = HashSet::with_capacity(count);
+
+        // Treat each worker as a virtual range whose length is its weight.
+        // Calculate the full range once, then shrink it as workers are selected.
+        let mut total_weight = workers
+            .iter()
+            .filter(|(id, worker)| {
+                Self::is_eligible(id, worker, exclude_workers, &selected_ids, min_available)
+            })
+            .map(|(_, worker)| worker.weight as u64)
+            .sum::<u64>();
+
+        if total_weight == 0 {
+            return err_box!("No eligible workers for weighted selection");
+        }
+
+        for _ in 0..count {
+            if total_weight == 0 {
+                break;
+            }
+
+            // The second pass locates the worker containing the random offset.
+            let mut target = rng.gen_range(0..total_weight);
+            let mut found = false;
+            for (id, worker) in workers {
+                if !Self::is_eligible(id, worker, exclude_workers, &selected_ids, min_available) {
+                    continue;
+                }
+
+                let weight = worker.weight as u64;
+                if target < weight {
+                    selected_ids.insert(*id);
+                    selected.push(worker.address.clone());
+                    total_weight -= weight;
+                    found = true;
+                    break;
+                }
+                target -= weight;
+            }
+
+            if !found {
+                return err_box!("Worker weight state is inconsistent");
+            }
+        }
+
+        Ok(selected)
+    }
+}
+
+impl WorkerPolicy for WeightedWorkerPolicy {
+    fn choose(
+        &self,
+        workers: &IndexMap<u32, WorkerInfo>,
+        ctx: ChooseContext,
+    ) -> CommonResult<Vec<WorkerAddress>> {
+        if workers.is_empty() {
+            return err_box!("No workers available");
+        }
+        if ctx.replicas < 1 {
+            return err_box!("The number of replicas cannot be 0");
+        }
+
+        self.select_weighted_workers(
+            workers,
+            ctx.replicas as usize,
+            &ctx.exclude_workers,
+            ctx.block_size,
+            &mut thread_rng(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::rngs::StdRng;
+    use rand::SeedableRng;
+
+    fn worker(id: u32, weight: u32) -> WorkerInfo {
+        WorkerInfo {
+            address: WorkerAddress {
+                worker_id: id,
+                ..Default::default()
+            },
+            weight,
+            capacity: 1024,
+            available: 1024,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn weighted_selection_respects_weights() {
+        let policy = WeightedWorkerPolicy::new();
+        let workers = IndexMap::from([(1, worker(1, 1)), (2, worker(2, 3)), (3, worker(3, 6))]);
+        let mut rng = StdRng::seed_from_u64(42);
+        let mut counts = [0_u32; 3];
+
+        for _ in 0..10_000 {
+            let selected = policy
+                .select_weighted_workers(&workers, 1, &HashSet::new(), 0, &mut rng)
+                .unwrap();
+            counts[selected[0].worker_id as usize - 1] += 1;
+        }
+
+        let actual = counts.map(|count| count as f64 / 10_000.0);
+        let expected = [0.1, 0.3, 0.6];
+        for (actual, expected) in actual.into_iter().zip(expected) {
+            assert!(
+                (actual - expected).abs() < 0.02,
+                "actual ratio {actual:.3} differs from expected {expected:.3}"
+            );
+        }
+    }
+
+    #[test]
+    fn weighted_selection_does_not_duplicate_replicas() {
+        let policy = WeightedWorkerPolicy::new();
+        let workers = IndexMap::from([(1, worker(1, 1)), (2, worker(2, 10)), (3, worker(3, 100))]);
+        let mut rng = StdRng::seed_from_u64(7);
+
+        let selected = policy
+            .select_weighted_workers(&workers, 3, &HashSet::new(), 0, &mut rng)
+            .unwrap();
+        let selected_ids: HashSet<u32> = selected.iter().map(|worker| worker.worker_id).collect();
+
+        assert_eq!(selected.len(), 3);
+        assert_eq!(selected_ids.len(), 3);
+    }
+
+    #[test]
+    fn weighted_selection_filters_ineligible_workers() {
+        let policy = WeightedWorkerPolicy::new();
+        let mut no_space = worker(4, 100);
+        no_space.available = 10;
+        let workers = IndexMap::from([
+            (1, worker(1, 1)),
+            (2, worker(2, 10)),
+            (3, worker(3, 0)),
+            (4, no_space),
+        ]);
+        let mut rng = StdRng::seed_from_u64(7);
+
+        let selected = policy
+            .select_weighted_workers(&workers, 3, &HashSet::from([2]), 20, &mut rng)
+            .unwrap();
+
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].worker_id, 1);
+    }
+
+    #[test]
+    fn weighted_selection_accepts_exact_available_space() {
+        let policy = WeightedWorkerPolicy::new();
+        let mut exact_space = worker(1, 1);
+        exact_space.available = 20;
+        let workers = IndexMap::from([(1, exact_space)]);
+        let mut rng = StdRng::seed_from_u64(9);
+
+        let selected = policy
+            .select_weighted_workers(&workers, 1, &HashSet::new(), 20, &mut rng)
+            .unwrap();
+
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].worker_id, 1);
+    }
+}

--- a/curvine-server/src/master/fs/policy/worker_policy_adapter.rs
+++ b/curvine-server/src/master/fs/policy/worker_policy_adapter.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::master::fs::policy::WorkerPolicyAdapter::{LoadBased, Local, Random, Robin};
+use crate::master::fs::policy::WorkerPolicyAdapter::{LoadBased, Local, Random, Robin, Weighted};
 use crate::master::fs::policy::{
     ChooseContext, LoadBasedWorkerPolicy, LocalWorkerPolicy, RandomWorkerPolicy, RobinWorkerPolicy,
-    WorkerPolicy,
+    WeightedWorkerPolicy, WorkerPolicy,
 };
 use curvine_common::conf::ClusterConf;
 use curvine_common::state::{WorkerAddress, WorkerInfo};
@@ -27,6 +27,7 @@ pub enum WorkerPolicyAdapter {
     Local(LocalWorkerPolicy),
     Random(RandomWorkerPolicy),
     LoadBased(LoadBasedWorkerPolicy),
+    Weighted(WeightedWorkerPolicy),
 }
 
 impl WorkerPolicyAdapter {
@@ -34,6 +35,7 @@ impl WorkerPolicyAdapter {
     pub const LOCAL: &'static str = "local";
     pub const RANDOM: &'static str = "random";
     pub const LOAD_BASED: &'static str = "load_based";
+    pub const WEIGHTED: &'static str = "weighted";
 
     pub fn from_conf(conf: &ClusterConf) -> CommonResult<Self> {
         let policy_str = conf.master.worker_policy.as_str();
@@ -42,6 +44,7 @@ impl WorkerPolicyAdapter {
             Self::ROBIN => Robin(RobinWorkerPolicy::new()),
             Self::RANDOM => Random(RandomWorkerPolicy::new()),
             Self::LOAD_BASED => LoadBased(LoadBasedWorkerPolicy::new()),
+            Self::WEIGHTED => Weighted(WeightedWorkerPolicy::new()),
             _ => return err_box!("Unsupported worker policy {}", policy_str),
         };
         Ok(policy)
@@ -57,6 +60,7 @@ impl WorkerPolicyAdapter {
             Local(ref f) => f.choose(workers, ctx),
             Random(ref f) => f.choose(workers, ctx),
             LoadBased(ref f) => f.choose(workers, ctx),
+            Weighted(ref f) => f.choose(workers, ctx),
         }
     }
 
@@ -71,6 +75,7 @@ impl WorkerPolicyAdapter {
             Local(ref f) => f.choose_workers(workers, Some(count), exclude_workers),
             Random(ref f) => f.choose_workers(workers, Some(count), exclude_workers),
             LoadBased(ref f) => f.choose_workers(workers, Some(count), exclude_workers),
+            Weighted(ref f) => f.choose_workers(workers, Some(count), exclude_workers),
         }
     }
 }

--- a/curvine-server/src/master/fs/state/worker_map.rs
+++ b/curvine-server/src/master/fs/state/worker_map.rs
@@ -56,12 +56,17 @@ impl WorkerMap {
         Ok(())
     }
 
-    pub fn insert(&mut self, addr: WorkerAddress, storages: Vec<StorageInfo>) -> FsResult<()> {
+    pub fn insert(
+        &mut self,
+        addr: WorkerAddress,
+        weight: u32,
+        storages: Vec<StorageInfo>,
+    ) -> FsResult<()> {
         self.ensure_worker_id_addr(&addr)?;
 
         // Register the worker and update the storage information.
         // @todo Heartbeat may be too simple and directly covers historical data.
-        let mut info = WorkerInfo::new(addr);
+        let mut info = WorkerInfo::new(addr, weight);
         let worker_id = info.worker_id();
         for item in storages {
             info.add_storage(item);

--- a/curvine-server/src/master/fs/worker_manager.rs
+++ b/curvine-server/src/master/fs/worker_manager.rs
@@ -53,6 +53,7 @@ impl WorkerManager {
         cluster_id: &str,
         status: HeartbeatStatus,
         addr: WorkerAddress,
+        weight: u32,
         storages: Vec<StorageInfo>,
     ) -> FsResult<Vec<WorkerCommand>> {
         // The cluster id must match to prevent misregistration.
@@ -85,7 +86,7 @@ impl WorkerManager {
             }
         };
 
-        self.worker_map.insert(addr, storages)?;
+        self.worker_map.insert(addr, weight, storages)?;
         Ok(cmds)
     }
 

--- a/curvine-server/src/master/master_handler.rs
+++ b/curvine-server/src/master/master_handler.rs
@@ -25,7 +25,7 @@ use curvine_common::fs::RpcCode;
 use curvine_common::proto::*;
 use curvine_common::state::{
     CreateFileOpts, DeleteBlockCmd, FileBlocks, FileStatus, FreeResult, HeartbeatStatus,
-    ListOptions, MasterInfo, OpenFlags, RenameFlags, WorkerCommand,
+    ListOptions, MasterInfo, OpenFlags, RenameFlags, WorkerCommand, WorkerInfo,
 };
 use curvine_common::utils::ProtoUtils;
 use curvine_common::FsResult;
@@ -478,6 +478,9 @@ impl MasterHandler {
     ) -> FsResult<Vec<WorkerCommand>> {
         let status = HeartbeatStatus::from(header.status);
         let address = ProtoUtils::worker_address_from_pb(&header.address);
+        // Worker weight comes from trusted administrator configuration. Preserve the
+        // configured u32 value so the master does not silently alter allocation ratios.
+        let weight = header.weight.unwrap_or_else(WorkerInfo::default_weight);
         if matches!(status, HeartbeatStatus::Start) {
             fs.reset_full_block_report(address.worker_id);
         }
@@ -487,6 +490,7 @@ impl MasterHandler {
             &header.cluster_id,
             status,
             address,
+            weight,
             ProtoUtils::storage_info_list_from_pb(header.storages),
         )?;
         Ok(cmds)

--- a/curvine-server/src/worker/block/block_actor.rs
+++ b/curvine-server/src/worker/block/block_actor.rs
@@ -61,6 +61,7 @@ impl BlockActor {
             store.cluster_id()?,
             store.worker_id()?,
             worker_addr,
+            conf.worker.weight,
         );
         let executor = GroupExecutor::new(
             "worker-block-executor",

--- a/curvine-server/src/worker/block/master_client.rs
+++ b/curvine-server/src/worker/block/master_client.rs
@@ -30,6 +30,7 @@ pub struct MasterClient {
     pub(crate) cluster_id: String,
     pub(crate) worker_id: u32,
     pub(crate) worker_addr: WorkerAddress,
+    pub(crate) worker_weight: u32,
 }
 
 impl MasterClient {
@@ -38,6 +39,7 @@ impl MasterClient {
         cluster_id: impl Into<String>,
         worker_id: u32,
         worker_addr: WorkerAddress,
+        worker_weight: u32,
     ) -> Self {
         // Directly reused file system client service.
         let fs_client = FsClient::new(context);
@@ -46,6 +48,7 @@ impl MasterClient {
             cluster_id: cluster_id.into(),
             worker_id,
             worker_addr,
+            worker_weight,
         }
     }
 
@@ -60,6 +63,7 @@ impl MasterClient {
             cluster_id: self.cluster_id.clone(),
             worker_id: self.worker_id,
             address: ProtoUtils::worker_address_to_pb(&self.worker_addr),
+            weight: Some(self.worker_weight),
             ..Default::default()
         };
         for item in storages {

--- a/etc/curvine-cluster.toml
+++ b/etc/curvine-cluster.toml
@@ -33,6 +33,8 @@ auth_token_env = "CURVINE_FAULT_TOKEN"
 # master configuration
 [master]
 meta_dir = "testing/meta"
+# Worker selection policy: local, robin, random, load_based, or weighted.
+# worker_policy = "weighted"
 log = { level = "info", log_dir = "stdout", file_name = "master.log" }
 
 
@@ -46,6 +48,10 @@ journal_dir = "testing/journal"
 
 # Worker configuration
 [worker]
+# Relative allocation weight used when master.worker_policy = "weighted".
+# Set higher values on more capable nodes; 0 disables new allocations to this worker.
+# This is trusted administrator configuration and is not capped by the master.
+weight = 1
 dir_reserved = "0"
 data_dir = [
     "[DISK]testing/data",


### PR DESCRIPTION
# Summary

Add a configurable weighted worker selection policy for heterogeneous clusters. More capable workers can receive proportionally more block allocations while zero-weight workers remain registered without receiving new data.

# Issue Describe / Design

No related issue.

The policy uses integer weighted roulette without materializing virtual worker entries. Selection is performed without replacement, bounded by the requested replica count, and validates inconsistent weight state defensively.

Worker weights are carried in an optional heartbeat field and stored in `WorkerInfo`. This keeps `WorkerAddress` unchanged, preserving bincode compatibility between mixed master and worker versions. Missing weights default to 1.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-common/proto` | Add optional weight fields to worker heartbeat and worker info | Backward compatible; missing values default to 1 |
| `curvine-common/src/conf` | Add worker weight configuration | Existing configurations continue using weight 1 |
| `curvine-server/src/master/fs/policy` | Add weighted worker selection policy | Enabled only when `master.worker_policy = "weighted"` |
| `curvine-server/src/worker` | Report configured weight through heartbeat | No change for other policies |
| `get_master_info` conversion | Return worker allocation weights | Adds optional response metadata |
| Tests | Cover distribution, filtering, uniqueness, exact capacity, and protobuf defaults | No production behavior change |
| `etc/curvine-cluster.toml` | Document weighted policy configuration | Documentation only |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo fmt --all -- --check` | PASS | |
| Weighted policy and protobuf unit tests | NOT RUN | Per user request; test commands were provided |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None