### PR TITLE
fix(master): refuse empty snapshot over populated filesystem (#1207)

### DIFF
--- a/curvine-server/src/master/journal/journal_loader.rs
+++ b/curvine-server/src/master/journal/journal_loader.rs
@@ -508,16 +508,17 @@ impl JournalLoader {
         // Never wipe a populated filesystem with an empty checkpoint. Harness
         // daily failures showed FileNotFound after restore from checkpoint_size=0
         // following raft quorum loss (CurvineIO/curvine#1207).
+        // get_file_counts() returns (dir_count, file_count).
         {
             let fs_dir = self.fs_dir.read();
-            let (files, dirs) = fs_dir.get_file_counts();
-            if actual_size == 0 && files > 0 {
+            let (dir_count, file_count) = fs_dir.get_file_counts();
+            if actual_size == 0 && file_count > 0 {
                 return err_box!(
                     "refusing to apply empty snapshot at {} ({} bytes) over filesystem with {} files and {} dirs",
                     restore_path,
                     actual_size,
-                    files,
-                    dirs
+                    file_count,
+                    dir_count
                 );
             }
         }

--- a/curvine-server/src/master/journal/journal_loader.rs
+++ b/curvine-server/src/master/journal/journal_loader.rs
@@ -482,35 +482,45 @@ impl JournalLoader {
     fn apply_snapshot0(&self, snapshot: SnapshotData) -> RaftResult<()> {
         let mut spend = TimeSpent::new();
 
-        // Compute checkpoint_size outside the write lock to avoid adding
-        // filesystem traversal I/O to the restore critical section.
-        // The traversal is skipped entirely when info logging is disabled.
-        let (restore_path, checkpoint_size) = match &snapshot.files_data {
-            Some(data) => {
-                let size = if log::log_enabled!(log::Level::Info) {
-                    FileUtils::dir_size(&data.dir).unwrap_or_else(|e| {
-                        warn!("failed to compute checkpoint size for {}: {}", data.dir, e);
-                        0
-                    })
-                } else {
-                    0
-                };
-                (data.dir.clone(), size)
-            }
+        // Resolve restore path first. Always measure dir size for safety checks;
+        // the logged checkpoint_size may still be 0 when info logging is disabled.
+        let restore_path = match &snapshot.files_data {
+            Some(data) => data.dir.clone(),
             None => {
                 let dir = self.fs_dir.read().get_checkpoint_path(LocalTime::mills());
                 FileUtils::create_dir(&dir, true)?;
-                let size = if log::log_enabled!(log::Level::Info) {
-                    FileUtils::dir_size(&dir).unwrap_or_else(|e| {
-                        warn!("failed to compute checkpoint size for {}: {}", dir, e);
-                        0
-                    })
-                } else {
-                    0
-                };
-                (dir, size)
+                dir
             }
         };
+        let actual_size = FileUtils::dir_size(&restore_path).unwrap_or_else(|e| {
+            warn!(
+                "failed to compute checkpoint size for {}: {}",
+                restore_path, e
+            );
+            0
+        });
+        let checkpoint_size = if log::log_enabled!(log::Level::Info) {
+            actual_size
+        } else {
+            0
+        };
+
+        // Never wipe a populated filesystem with an empty checkpoint. Harness
+        // daily failures showed FileNotFound after restore from checkpoint_size=0
+        // following raft quorum loss (CurvineIO/curvine#1207).
+        {
+            let fs_dir = self.fs_dir.read();
+            let (files, dirs) = fs_dir.get_file_counts();
+            if actual_size == 0 && files > 0 {
+                return err_box!(
+                    "refusing to apply empty snapshot at {} ({} bytes) over filesystem with {} files and {} dirs",
+                    restore_path,
+                    actual_size,
+                    files,
+                    dirs
+                );
+            }
+        }
 
         let mut fs_dir = self.fs_dir.write();
         fs_dir.restore(&restore_path, checkpoint_size)?;

--- a/curvine-server/tests/journal_test.rs
+++ b/curvine-server/tests/journal_test.rs
@@ -14,6 +14,7 @@
 
 use curvine_common::conf::ClusterConf;
 use curvine_common::fs::CurvineURI;
+use curvine_common::proto::raft::{AppliedIndex, FsmState, SnapshotData, SnapshotFileList};
 use curvine_common::raft::storage::{AppStorage, ApplyMsg};
 use curvine_common::raft::{NodeId, RaftPeer};
 use curvine_common::state::{
@@ -27,7 +28,7 @@ use curvine_server::master::journal::{
 };
 use curvine_server::master::{Master, MountManager};
 use log::info;
-use orpc::common::{Logger, TimeSpent};
+use orpc::common::{FileUtils, Logger, TimeSpent, Utils};
 use orpc::io::net::NetUtils;
 use orpc::runtime::{AsyncRuntime, RpcRuntime};
 use orpc::{err_box, CommonResult};
@@ -461,5 +462,110 @@ fn test_master_restart_with_snapshot_recovery() -> CommonResult<()> {
     drop(mnt_mgr);
     js.shutdown();
 
+    Ok(())
+}
+
+fn empty_checkpoint_snapshot(empty_dir: &str) -> SnapshotData {
+    let fsm_state = FsmState {
+        applied: AppliedIndex {
+            term: 1,
+            index: 1,
+            op_id: 0,
+            rpc_id: 0,
+        },
+        ufs_applied: AppliedIndex {
+            term: 1,
+            index: 1,
+            op_id: 0,
+            rpc_id: 0,
+        },
+    };
+    SnapshotData {
+        snapshot_id: 1,
+        node_id: 1,
+        create_time: 0,
+        bytes_data: None,
+        files_data: Some(SnapshotFileList {
+            dir: empty_dir.to_string(),
+            files: vec![],
+        }),
+        fsm_state,
+    }
+}
+
+// Refuse empty checkpoint over a FS that already has files; allow when file_count == 0
+// even if directories exist (tuple order: get_file_counts -> (dir_count, file_count)).
+#[test]
+fn test_apply_snapshot_refuses_empty_over_populated_files() -> CommonResult<()> {
+    Logger::default();
+    Master::init_test_metrics();
+
+    let test_id = Utils::rand_str(8);
+    let mut conf = ClusterConf {
+        testing: true,
+        ..Default::default()
+    };
+    conf.change_test_meta_dir(format!("meta-empty-snap-refuse-{}", test_id));
+
+    let js = JournalSystem::from_conf(&conf)?;
+    let fs = MasterFilesystem::with_js(&conf, &js);
+    fs.add_test_worker(WorkerInfo::default());
+    let loader = js.journal_loader();
+    let rt = AsyncRuntime::single();
+
+    // Directories only: guard must not refuse (file_count == 0).
+    fs.mkdir("/only-dirs/nested", true)?;
+    let (dir_count, file_count) = fs.get_file_counts();
+    assert!(
+        dir_count > 0,
+        "expected dirs after mkdir, got {}",
+        dir_count
+    );
+    assert_eq!(file_count, 0);
+
+    let empty_dirs = Utils::test_sub_dir(format!("empty-snap-dirs-{}", test_id));
+    FileUtils::create_dir(&empty_dirs, true)?;
+    assert_eq!(FileUtils::dir_size(&empty_dirs).unwrap_or(1), 0);
+
+    let dirs_only = rt.block_on(loader.apply_snapshot(empty_checkpoint_snapshot(&empty_dirs)));
+    if let Err(e) = &dirs_only {
+        let msg = e.to_string();
+        assert!(
+            !msg.contains("refusing to apply empty snapshot"),
+            "dirs-only FS must not hit the empty-snapshot guard: {}",
+            msg
+        );
+    }
+
+    // Rebuild a populated FS with files: empty checkpoint must be refused.
+    fs.mkdir("/with-files", true)?;
+    fs.create("/with-files/file.log", false)?;
+    let (dir_count, file_count) = fs.get_file_counts();
+    assert!(file_count > 0, "expected files after create");
+
+    let empty_files = Utils::test_sub_dir(format!("empty-snap-files-{}", test_id));
+    FileUtils::create_dir(&empty_files, true)?;
+    assert_eq!(FileUtils::dir_size(&empty_files).unwrap_or(1), 0);
+
+    let err = rt
+        .block_on(loader.apply_snapshot(empty_checkpoint_snapshot(&empty_files)))
+        .expect_err("empty snapshot over populated files must be refused");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("refusing to apply empty snapshot"),
+        "unexpected error: {}",
+        msg
+    );
+    assert!(
+        msg.contains(&format!("{} files", file_count))
+            && msg.contains(&format!("{} dirs", dir_count)),
+        "error should report (file_count, dir_count)=({}, {}); got: {}",
+        file_count,
+        dir_count,
+        msg
+    );
+
+    drop(fs);
+    js.shutdown();
     Ok(())
 }

--- a/repair-plan.json
+++ b/repair-plan.json
@@ -1,0 +1,29 @@
+{
+  "issue": "CurvineIO/curvine#1207",
+  "multica_issue": "CUR-61",
+  "fingerprint": "sha256:15fb19075be2d2fe6df145554fc1c3d1453d5a79ff97ee56eaa5b0ca69fe94bb",
+  "head_sha": "ea9978a4b77ead56a2ea59b41cd05ef66cbbda41",
+  "root_cause_hypothesis": "Under nextest load, the 2-master test cluster loses raft quorum (`quorum is not active`). A subsequent snapshot apply restores from an empty checkpoint (checkpoint_size=0, create_tree files=0), wiping metadata so FileStatus(/repl_test_3.dat) returns FileNotFound. Isolated runs pass; the wipe—not replication itself—is the failure mode.",
+  "affected_modules": [
+    "curvine-server/src/master/journal/journal_loader.rs"
+  ],
+  "planned_changes": [
+    "Before fs_dir.restore in apply_snapshot0, compute actual checkpoint dir size (independent of log level).",
+    "If the checkpoint is empty and the live filesystem already has files, refuse the apply instead of wiping metadata."
+  ],
+  "not_goals": [
+    "Do not change replication manager job scheduling.",
+    "Do not rewrite raft election/quorum timeouts in this PR.",
+    "Do not weaken legitimate format/empty-cluster bootstrap (still allow empty apply when live FS has no files)."
+  ],
+  "verification_plan": [
+    "cargo test -p curvine-tests --test replication_test test_replication_with_simulated_worker_failure",
+    "cargo test -p curvine-server --test journal_test (snapshot-related if present)",
+    "Unit-level coverage via journal_loader refusal path if testable"
+  ],
+  "estimated_non_generated_source_line_delta": 40,
+  "risk": {
+    "level": "medium",
+    "rationale": "Changes HA snapshot apply safety. Rejecting a bad empty snapshot is safer than wiping production metadata, but a node may remain on older FSM state until a valid snapshot/log catch-up; needs harness daily rerun."
+  }
+}


### PR DESCRIPTION
<!-- curvine-harness:issue:CurvineIO/curvine#1207 -->
<!-- curvine-harness:fingerprint:sha256:15fb19075be2d2fe6df145554fc1c3d1453d5a79ff97ee56eaa5b0ca69fe94bb -->

## Summary
- Fixes [CurvineIO/curvine#1207](https://github.com/CurvineIO/curvine/issues/1207) (Multica CUR-61)
- Root cause: under nextest load the 2-master cluster lost raft quorum; a later snapshot apply restored from an empty checkpoint (`checkpoint_size=0`, `create_tree files=0`), wiping metadata so `FileStatus(/repl_test_3.dat)` returned `FileNotFound`. Isolated runs pass; replication itself completed successfully before the wipe.
- Change: in `apply_snapshot0`, always measure checkpoint dir size and refuse apply when the checkpoint is empty while the live filesystem already has files.

## Changed files
- `curvine-server/src/master/journal/journal_loader.rs`
- `repair-plan.json`

## Evidence
- run_id: `20260720T085722Z-15c6cc26`
- tested head_sha: `ea9978a4b77ead56a2ea59b41cd05ef66cbbda41`
- harness_sha: `e8821100649d748e4120df664ab10c02d0f54d9e`
- fingerprint: `sha256:15fb19075be2d2fe6df145554fc1c3d1453d5a79ff97ee56eaa5b0ca69fe94bb`
- artifact: `file:///data/data1/liujifeng/curvine-harness-runners/daily-20260716/ordinary/runs/20260720T085722Z-15c6cc26`
- manifest_sha256: `sha256:ab345ff1b4f680a5807de409fcc3fb75bc00a0e246df9567717581bc6c1213d7`
- repair-plan sha256: `6410caa2ec5d19f5e5db8352fa23794a63ecca45c5e8a177e423b1bdeef2d568`
- risk: medium (HA snapshot safety; requires daily harness rerun)

## Test verified
```bash
cargo test -p curvine-server --test journal_test
# 4 passed
cargo test -p curvine-tests --test replication_test test_replication_with_simulated_worker_failure
# ok (~20s)
cargo clippy -p curvine-server --lib -- -D warnings
# ok
```

## Risk / required_rerun
Medium. Guarding empty snapshot apply avoids metadata wipe but a node may stay on older FSM state until a valid snapshot/log catch-up. Please rerun Harness `daily` (and preferably `integration`) against this commit.
