### PR TITLE
fix(client): detect SPDK storage via worker-reported has_spdk flag in LocatedBlock

### DIFF
--- a/curvine-client/src/block/batch_block_writer.rs
+++ b/curvine-client/src/block/batch_block_writer.rs
@@ -15,8 +15,9 @@
 use crate::block::batch_block_writer::BatchWriterAdapter::{BatchLocal, BatchRemote};
 use crate::block::{BatchBlockWriterLocal, BatchBlockWriterRemote};
 use crate::file::FsContext;
+use curvine_common::error::FsError;
 use curvine_common::fs::Path;
-use curvine_common::state::{CommitBlock, ExtendedBlock, LocatedBlock, StorageType, WorkerAddress};
+use curvine_common::state::{CommitBlock, ExtendedBlock, LocatedBlock, WorkerAddress};
 use curvine_common::FsResult;
 use futures::future::try_join_all;
 use orpc::err_box;
@@ -64,17 +65,32 @@ impl BatchWriterAdapter {
     ) -> FsResult<Self> {
         let conf = &fs_context.conf.client;
         // SPDK bypasses kernel — no local path. Disable short-circuit if any block uses SPDK.
-        let has_spdk = located_blocks
-            .iter()
-            .any(|lb| lb.block.storage_type == StorageType::SpdkDisk);
+        // Use has_spdk from worker-reported actual storage type, not block.storage_type
+        let has_spdk = located_blocks.iter().any(|lb| lb.has_spdk);
         let short_circuit =
             conf.short_circuit && fs_context.is_local_worker(worker_addr) && !has_spdk;
 
         let blocks: Vec<ExtendedBlock> = located_blocks.iter().map(|lb| lb.block.clone()).collect();
         let adapter = if short_circuit {
-            let writer =
-                BatchBlockWriterLocal::new(fs_context, blocks, worker_addr.clone(), 0).await?;
-            BatchLocal(writer)
+            match BatchBlockWriterLocal::new(
+                fs_context.clone(),
+                blocks.clone(),
+                worker_addr.clone(),
+                0,
+            )
+            .await
+            {
+                Ok(writer) => BatchLocal(writer),
+                Err(FsError::NoLocalPath(_)) => {
+                    // Server has no local path for batch blocks (e.g. SPDK bdev).
+                    // BatchBlockWriterLocal already aborted the open; retry via remote.
+                    let writer =
+                        BatchBlockWriterRemote::new(&fs_context, blocks, worker_addr.clone(), 0)
+                            .await?;
+                    BatchRemote(writer)
+                }
+                Err(e) => return Err(e),
+            }
         } else {
             let writer =
                 BatchBlockWriterRemote::new(&fs_context, blocks, worker_addr.clone(), 0).await?;

--- a/curvine-client/src/block/batch_block_writer_local.rs
+++ b/curvine-client/src/block/batch_block_writer_local.rs
@@ -8,7 +8,6 @@ use orpc::common::Utils;
 use orpc::io::LocalFile;
 use orpc::runtime::{RpcRuntime, Runtime};
 use orpc::sys::RawPtr;
-use orpc::try_option;
 use std::sync::Arc;
 
 pub struct BatchBlockWriterLocal {
@@ -49,9 +48,24 @@ impl BatchBlockWriterLocal {
         // Create multiple files, one for each block context
         let mut files = Vec::new();
         for context in &write_context.contexts {
-            let path = try_option!(&context.path);
-            let file = LocalFile::with_write_offset(path, false, pos)?;
-            files.push(RawPtr::from_owned(file));
+            match &context.path {
+                Some(path) => {
+                    let file = LocalFile::with_write_offset(path, false, pos)?;
+                    files.push(RawPtr::from_owned(file));
+                }
+                None => {
+                    // No local path available (e.g. SPDK bdev without filesystem path).
+                    // Abort all blocks on the server before returning so state is clean.
+                    let _ = client
+                        .write_commit_batch(&blocks, pos, block_size, req_id, 0, true)
+                        .await;
+                    return Err(FsError::no_local_path(format!(
+                        "no local path for batch block {} (storage type {:?})",
+                        blocks[files.len()].id,
+                        context.storage_type
+                    )));
+                }
+            }
         }
 
         Ok(Self {

--- a/curvine-client/src/block/block_writer.rs
+++ b/curvine-client/src/block/block_writer.rs
@@ -17,7 +17,8 @@
 use crate::block::block_writer::WriterAdapter::{Local, Remote};
 use crate::block::{BlockWriterLocal, BlockWriterRemote};
 use crate::file::FsContext;
-use curvine_common::state::{BlockLocation, CommitBlock, LocatedBlock, StorageType, WorkerAddress};
+use curvine_common::error::FsError;
+use curvine_common::state::{BlockLocation, CommitBlock, LocatedBlock, WorkerAddress};
 use curvine_common::FsResult;
 use futures::future::try_join_all;
 use orpc::err_box;
@@ -112,21 +113,38 @@ impl WriterAdapter {
         block_size: i64,
     ) -> FsResult<Self> {
         let conf = &fs_context.conf.client;
-        // SPDK bypasses kernel — no local path for writes
+        // SPDK bypasses kernel — no local path for writes.
+        // Use has_spdk (from worker-reported actual storage type)
         let short_circuit = conf.short_circuit
             && fs_context.is_local_worker(worker_addr)
-            && located_block.block.storage_type != StorageType::SpdkDisk;
+            && !located_block.has_spdk;
 
         let adapter = if short_circuit {
-            let writer = BlockWriterLocal::new(
-                fs_context,
+            match BlockWriterLocal::new(
+                fs_context.clone(),
                 located_block.block.clone(),
                 worker_addr.clone(),
                 pos,
                 block_size,
             )
-            .await?;
-            Local(writer)
+            .await
+            {
+                Ok(writer) => Local(writer),
+                Err(FsError::NoLocalPath(_)) => {
+                    // Server has no local path for this block (e.g. SPDK bdev).
+                    // BlockWriterLocal already aborted the open; retry via remote.
+                    let writer = BlockWriterRemote::new(
+                        &fs_context,
+                        located_block.block.clone(),
+                        worker_addr.clone(),
+                        pos,
+                        block_size,
+                    )
+                    .await?;
+                    Remote(writer)
+                }
+                Err(e) => return Err(e),
+            }
         } else {
             let writer = BlockWriterRemote::new(
                 &fs_context,

--- a/curvine-client/src/block/block_writer_local.rs
+++ b/curvine-client/src/block/block_writer_local.rs
@@ -18,10 +18,10 @@ use curvine_common::error::FsError;
 use curvine_common::state::{ExtendedBlock, WorkerAddress};
 use curvine_common::FsResult;
 use orpc::common::Utils;
+use orpc::err_box;
 use orpc::io::LocalFile;
 use orpc::runtime::{RpcRuntime, Runtime};
 use orpc::sys::{DataSlice, RawPtr};
-use orpc::{err_box, try_option};
 use std::sync::Arc;
 
 pub struct BlockWriterLocal {
@@ -59,7 +59,20 @@ impl BlockWriterLocal {
             )
             .await?;
 
-        let path = try_option!(write_context.path);
+        let path = match write_context.path {
+            Some(p) => p,
+            None => {
+                // No local path available (e.g. SPDK bdev without filesystem path).
+                // Abort the block on the server before returning so state is clean.
+                let _ = client
+                    .write_commit(&block, pos, block_size, req_id, 0, true)
+                    .await;
+                return Err(FsError::no_local_path(format!(
+                    "no local path for block {} (storage type {:?})",
+                    block.id, block.storage_type
+                )));
+            }
+        };
         let file = LocalFile::with_write_offset(path, false, pos)?;
 
         let writer = Self {

--- a/curvine-common/proto/common.proto
+++ b/curvine-common/proto/common.proto
@@ -107,6 +107,7 @@ message LocatedBlockProto {
     required ExtendedBlockProto block = 1;
     required int64 offset = 2;
     repeated WorkerAddressProto locs = 3;
+    optional bool has_spdk = 4 [default = false];
 }
 
 // All block information in the file.

--- a/curvine-common/src/error/fs_error.rs
+++ b/curvine-common/src/error/fs_error.rs
@@ -66,6 +66,7 @@ pub enum ErrorKind {
     BlockNotFound = 29,
     ReadOnly = 30,
     NoAvailableWorker = 31,
+    NoLocalPath = 32,
 
     #[num_enum(default)]
     Common = 10000,
@@ -195,6 +196,10 @@ pub enum FsError {
     #[error("{0}")]
     NoAvailableWorker(ErrorImpl<StringError>),
 
+    // The server has no local filesystem path for this block (e.g. SPDK bdev).
+    #[error("{0}")]
+    NoLocalPath(ErrorImpl<StringError>),
+
     // Job not found
     #[error("{0}")]
     JobNotFound(ErrorImpl<StringError>),
@@ -212,6 +217,10 @@ impl FsError {
 
     pub fn from_error<E: std::error::Error>(e: E) -> Self {
         Self::Common(ErrorImpl::with_source(e.to_string().into()))
+    }
+
+    pub fn no_local_path(msg: impl Into<String>) -> Self {
+        Self::NoLocalPath(ErrorImpl::with_source(msg.into().into()))
     }
 
     pub fn not_leader_master(code: RpcCode, client_ip: &str) -> Self {
@@ -395,6 +404,7 @@ impl FsError {
             FsError::Pipeline(_) => ErrorKind::Pipeline,
             FsError::MinReplicasNotMet(_) => ErrorKind::MinReplicasNotMet,
             FsError::NoAvailableWorker(_) => ErrorKind::NoAvailableWorker,
+            FsError::NoLocalPath(_) => ErrorKind::NoLocalPath,
             FsError::JobNotFound(_) => ErrorKind::JobNotFound,
             FsError::Common(_) => ErrorKind::Common,
         }
@@ -543,6 +553,7 @@ impl ErrorExt for FsError {
             FsError::Pipeline(e) => FsError::Pipeline(e.ctx(ctx)),
             FsError::MinReplicasNotMet(e) => FsError::MinReplicasNotMet(e.ctx(ctx)),
             FsError::NoAvailableWorker(e) => FsError::NoAvailableWorker(e.ctx(ctx)),
+            FsError::NoLocalPath(e) => FsError::NoLocalPath(e.ctx(ctx)),
             FsError::JobNotFound(e) => FsError::JobNotFound(e.ctx(ctx)),
             FsError::Common(e) => FsError::Common(e.ctx(ctx)),
         }
@@ -580,6 +591,7 @@ impl ErrorExt for FsError {
             FsError::Pipeline(e) => e.encode(ErrorKind::Pipeline),
             FsError::MinReplicasNotMet(e) => e.encode(ErrorKind::MinReplicasNotMet),
             FsError::NoAvailableWorker(e) => e.encode(ErrorKind::NoAvailableWorker),
+            FsError::NoLocalPath(e) => e.encode(ErrorKind::NoLocalPath),
             FsError::JobNotFound(e) => e.encode(ErrorKind::JobNotFound),
             FsError::Common(e) => e.encode(ErrorKind::Common),
         }
@@ -620,6 +632,7 @@ impl ErrorExt for FsError {
             ErrorKind::Pipeline => FsError::Pipeline(de.into_string()),
             ErrorKind::MinReplicasNotMet => FsError::MinReplicasNotMet(de.into_string()),
             ErrorKind::NoAvailableWorker => FsError::NoAvailableWorker(de.into_string()),
+            ErrorKind::NoLocalPath => FsError::NoLocalPath(de.into_string()),
             ErrorKind::JobNotFound => FsError::JobNotFound(de.into_string()),
             ErrorKind::Common => FsError::Common(de.into_string()),
         }

--- a/curvine-common/src/state/block_info.rs
+++ b/curvine-common/src/state/block_info.rs
@@ -128,11 +128,16 @@ impl ExtendedBlock {
 pub struct LocatedBlock {
     pub block: ExtendedBlock,
     pub locs: Vec<WorkerAddress>,
+    pub has_spdk: bool,
 }
 
 impl LocatedBlock {
     pub fn new(block: ExtendedBlock, locs: Vec<WorkerAddress>) -> Self {
-        Self { block, locs }
+        Self {
+            block,
+            locs,
+            has_spdk: false,
+        }
     }
 
     pub fn should_resize(&self) -> bool {

--- a/curvine-common/src/utils/proto_utils.rs
+++ b/curvine-common/src/utils/proto_utils.rs
@@ -172,6 +172,7 @@ impl ProtoUtils {
             block: b,
             offset: 0,
             locs,
+            has_spdk: Some(block.has_spdk),
         }
     }
 
@@ -185,6 +186,7 @@ impl ProtoUtils {
         LocatedBlock {
             block: Self::extend_block_from_pb(block.block),
             locs,
+            has_spdk: block.has_spdk.unwrap_or(false),
         }
     }
 

--- a/curvine-server/src/master/fs/master_filesystem.rs
+++ b/curvine-server/src/master/fs/master_filesystem.rs
@@ -570,11 +570,16 @@ impl MasterFilesystem {
         }
 
         let choose_workers = self.choose_worker_for_file(file, client_addr, exclude_workers)?;
+        let has_spdk = {
+            let wm = self.worker_manager.read();
+            wm.workers_have_spdk(&choose_workers)
+        };
         let block =
             fs_dir.acquire_new_block(path, inode, commit_blocks, &choose_workers, file_len)?;
         let located = LocatedBlock {
             block,
             locs: choose_workers,
+            has_spdk,
         };
 
         Ok(located)
@@ -1218,11 +1223,16 @@ impl MasterFilesystem {
         let inp = Self::resolve_path(&fs_dir, path)?;
 
         let choose_workers = self.choose_worker(&inp, client_addr, exclude_workers)?;
+        let has_spdk = {
+            let wm = self.worker_manager.read();
+            wm.workers_have_spdk(&choose_workers)
+        };
         let block = fs_dir.assign_worker(inp, block.id, &choose_workers)?;
 
         Ok(LocatedBlock {
             block,
             locs: choose_workers,
+            has_spdk,
         })
     }
 

--- a/curvine-server/src/master/fs/worker_manager.rs
+++ b/curvine-server/src/master/fs/worker_manager.rs
@@ -17,8 +17,8 @@ use crate::master::fs::state::{BlockMap, WorkerMap};
 use crate::master::fs::DeleteResult;
 use curvine_common::conf::ClusterConf;
 use curvine_common::state::{
-    BlockLocation, ExtendedBlock, HeartbeatStatus, LocatedBlock, StorageInfo, WorkerAddress,
-    WorkerCommand, WorkerInfo, WorkerStatus,
+    BlockLocation, ExtendedBlock, HeartbeatStatus, LocatedBlock, StorageInfo, StorageType,
+    WorkerAddress, WorkerCommand, WorkerInfo, WorkerStatus,
 };
 use curvine_common::FsResult;
 use log::{info, warn};
@@ -169,9 +169,11 @@ impl WorkerManager {
         locs: &[BlockLocation],
     ) -> FsResult<LocatedBlock> {
         let mut addrs = Vec::with_capacity(locs.len());
+        let mut live_storage_types = Vec::with_capacity(locs.len());
         for loc in locs {
             if let Some(info) = self.get_worker(loc.worker_id) {
                 addrs.push(info.address.clone());
+                live_storage_types.push(loc.storage_type);
             } else {
                 warn!(
                     "File {} block {}, worker {} replicas has been lost",
@@ -190,9 +192,29 @@ impl WorkerManager {
             );
         }
 
-        let lb = LocatedBlock { block, locs: addrs };
+        let has_spdk = live_storage_types.contains(&StorageType::SpdkDisk);
+        let lb = LocatedBlock {
+            block,
+            locs: addrs,
+            has_spdk,
+        };
 
         Ok(lb)
+    }
+
+    pub fn workers_have_spdk(&self, addrs: &[WorkerAddress]) -> bool {
+        for addr in addrs {
+            if let Some(info) = self.get_worker(addr.worker_id) {
+                if info
+                    .storage_map
+                    .values()
+                    .any(|s| s.storage_type == StorageType::SpdkDisk)
+                {
+                    return true;
+                }
+            }
+        }
+        false
     }
 
     pub fn add_test_worker(&mut self, worker: WorkerInfo) {

--- a/curvine-server/tests/master_fs_test.rs
+++ b/curvine-server/tests/master_fs_test.rs
@@ -25,7 +25,7 @@ use curvine_common::state::MountOptions;
 use curvine_common::state::{
     BlockLocation, BlockReportInfo, BlockReportList, BlockReportStatus, ClientAddress, CommitBlock,
     CreateFileOpts, CreateFileOptsBuilder, FileAllocOpts, MkdirOptsBuilder, StorageType, TtlAction,
-    WorkerInfo,
+    WorkerAddress, WorkerInfo,
 };
 use curvine_common::state::{OpenFlags, RenameFlags, SetAttrOptsBuilder};
 use curvine_common::utils::SerdeUtils;
@@ -1803,4 +1803,172 @@ fn resize_rejects_extreme_file_size() {
 
     let status = fs.file_status("/extreme.log").unwrap();
     assert_eq!(status.len, 0);
+}
+
+#[test]
+fn located_block_has_spdk_reflects_worker_reported_storage_type() -> CommonResult<()> {
+    let _serial = master_fs_test_serial();
+
+    // Scenario A: worker reports SpdkDisk -> has_spdk should be true
+    {
+        let fs = new_fs(true, "has-spdk-spdk");
+        let path = "/has-spdk-spdk.log";
+        let addr = ClientAddress::default();
+        fs.create(path, false)?;
+
+        let block = fs.add_block(path, None, addr.clone(), vec![], vec![], 0, None)?;
+
+        fs.block_report(
+            BlockReportList {
+                cluster_id: "curvine".into(),
+                worker_id: block.locs[0].worker_id,
+                full_report: true,
+                total_len: 1,
+                blocks: vec![BlockReportInfo::new(
+                    block.block.id,
+                    BlockReportStatus::Finalized,
+                    StorageType::SpdkDisk,
+                    block.block.len,
+                )],
+            },
+            None,
+        )?;
+
+        let fb = fs.get_block_locations(path)?;
+        assert_eq!(fb.block_locs.len(), 1);
+        assert!(
+            fb.block_locs[0].has_spdk,
+            "has_spdk should be true when worker reports SpdkDisk"
+        );
+    }
+
+    // Scenario B: worker reports Mem -> has_spdk should be false
+    {
+        let fs = new_fs(true, "has-spdk-mem");
+        let path = "/has-spdk-mem.log";
+        let addr = ClientAddress::default();
+        fs.create(path, false)?;
+
+        let block = fs.add_block(path, None, addr.clone(), vec![], vec![], 0, None)?;
+
+        fs.block_report(
+            BlockReportList {
+                cluster_id: "curvine".into(),
+                worker_id: block.locs[0].worker_id,
+                full_report: true,
+                total_len: 1,
+                blocks: vec![BlockReportInfo::new(
+                    block.block.id,
+                    BlockReportStatus::Finalized,
+                    StorageType::Mem,
+                    block.block.len,
+                )],
+            },
+            None,
+        )?;
+
+        let fb = fs.get_block_locations(path)?;
+        assert_eq!(fb.block_locs.len(), 1);
+        assert!(
+            !fb.block_locs[0].has_spdk,
+            "has_spdk should be false when worker reports Mem"
+        );
+    }
+
+    // Scenario C: worker reports Disk -> has_spdk should be false
+    {
+        let fs = new_fs(true, "has-spdk-disk");
+        let path = "/has-spdk-disk.log";
+        let addr = ClientAddress::default();
+        fs.create(path, false)?;
+
+        let block = fs.add_block(path, None, addr.clone(), vec![], vec![], 0, None)?;
+
+        fs.block_report(
+            BlockReportList {
+                cluster_id: "curvine".into(),
+                worker_id: block.locs[0].worker_id,
+                full_report: true,
+                total_len: 1,
+                blocks: vec![BlockReportInfo::new(
+                    block.block.id,
+                    BlockReportStatus::Finalized,
+                    StorageType::Disk,
+                    block.block.len,
+                )],
+            },
+            None,
+        )?;
+
+        let fb = fs.get_block_locations(path)?;
+        assert_eq!(fb.block_locs.len(), 1);
+        assert!(
+            !fb.block_locs[0].has_spdk,
+            "has_spdk should be false when worker reports Disk"
+        );
+    }
+
+    // Scenario D: mixed replicas across 2 workers — one SpdkDisk, one Disk -> has_spdk should be true
+    {
+        let fs = new_fs(true, "has-spdk-mixed");
+        let path = "/has-spdk-mixed.log";
+        let addr = ClientAddress::default();
+        fs.create(path, false)?;
+
+        // Add second worker (worker_id=200) so we can have 2 replicas on different workers
+        let worker2_addr = WorkerAddress {
+            worker_id: 200,
+            ip_addr: "127.0.0.2".to_string(),
+            rpc_port: 667,
+            ..Default::default()
+        };
+        let worker2 = WorkerInfo::new(worker2_addr, 0);
+        fs.add_test_worker(worker2);
+
+        let block = fs.add_block(path, None, addr.clone(), vec![], vec![], 0, None)?;
+
+        // Worker 100 (default) reports block as SpdkDisk
+        fs.block_report(
+            BlockReportList {
+                cluster_id: "curvine".into(),
+                worker_id: 100,
+                full_report: true,
+                total_len: 1,
+                blocks: vec![BlockReportInfo::new(
+                    block.block.id,
+                    BlockReportStatus::Finalized,
+                    StorageType::SpdkDisk,
+                    block.block.len,
+                )],
+            },
+            None,
+        )?;
+
+        // Worker 200 reports same block as Disk
+        fs.block_report(
+            BlockReportList {
+                cluster_id: "curvine".into(),
+                worker_id: 200,
+                full_report: false,
+                total_len: 0,
+                blocks: vec![BlockReportInfo::new(
+                    block.block.id,
+                    BlockReportStatus::Finalized,
+                    StorageType::Disk,
+                    block.block.len,
+                )],
+            },
+            None,
+        )?;
+
+        let fb = fs.get_block_locations(path)?;
+        assert_eq!(fb.block_locs.len(), 1);
+        assert_eq!(fb.block_locs[0].locs.len(), 2, "should have 2 replicas");
+        assert!(
+            fb.block_locs[0].has_spdk,
+            "has_spdk should be true when any replica reports SpdkDisk"
+        );
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
## Summary

- When `short_circuit=true` (default) and fuse + worker are co-located, SPDK writes fail with EIO because the client mis-dispatches to `BlockWriterLocal`, which requires a filesystem path that SPDK bdevs do not have. This PR adds a `has_spdk` flag to `LocatedBlock`, computed by the master from worker-reported `BlockLocation.storage_type`, so the client can correctly skip short-circuit for SPDK blocks.

- `block.storage_type` is the file-level requested type (e.g. `Disk`), not the actual worker-reported type. A block can span SPDK and Disk replicas concurrently. `has_spdk` is `true` when any **live** worker-reported `BlockLocation.storage_type`
  is `SpdkDisk`.
- Client fallback: if `BlockWriterLocal` / `BatchBlockWriterLocal` fails (e.g. missing local path), the open is aborted via `write_commit(cancel=true)` and the write is retried via the remote writer. This ensures clean server state.
- Closes [issue-1077](https://github.com/CurvineIO/curvine/issues/1077)

## Changes and Impacts

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-common/proto/common.proto` | Add `optional bool has_spdk = 4` to `LocatedBlockProto` | Backward compatible (optional field, default false) |
| `curvine-common/src/state/block_info.rs` | Add `has_spdk: bool` to `LocatedBlock` struct | Default `false` preserves existing behavior |
| `curvine-common/src/utils/proto_utils.rs` | Wire `has_spdk` in proto conversion | None |
| `curvine-server/src/master/fs/worker_manager.rs` | Compute `has_spdk` from worker-reported `BlockLocation.storage_type` | None (new field) |
| `curvine-server/src/master/fs/master_filesystem.rs` | Compute has_spdk via workers_have_spdk() at new block allocation and additional block assignment | SPDK blocks get correct has_spdk immediately, not just after first worker report |
| `curvine-client/src/block/block_writer.rs` | Use `!located_block.has_spdk` instead of `storage_type != SpdkDisk`; add fallback to remote on `BlockWriterLocal` failure | SPDK writes now route to remote correctly |
| `curvine-client/src/block/block_writer_local.rs` | Graceful `path: None` handling: abort open via `write_commit(cancel=true)` then return NoLocalPath error | Defense-in-depth: clean server state on failure |
| `curvine-client/src/block/batch_block_writer.rs` | Use `lb.has_spdk` instead of `block.storage_type == SpdkDisk`; add fallback to remote | Same fix for batch writes |
| `curvine-client/src/block/batch_block_writer_local.rs` | Graceful `path: None` handling: abort via `write_commit_batch(cancel=true)` | Defense-in-depth for batch |
| `curvine-server/tests/master_fs_test.rs` | Unit test: `located_block_has_spdk_reflects_worker_reported_storage_type` (4 scenarios) | None (test only) |
| `curvine-common/src/error/fs_error.rs` | Add `NoLocalPath` error variant (code 32) and `FsError::no_local_path()` constructor | Typed error for SPDK path-missing cases; |


## Test verified
- Passed: `dd if=/dev/zero of=/curvine-fuse/fio-spdk/x bs=1M count=10`
```
    sudo BUILD_ARGS="-p core -p fuse --spdk-rdma" NVME_PCI_ADDR=0000:00:0e.0 make docker-compose-spdk
    sudo docker exec -it spdk-worker-1 bash

    [root@fedora37 app]# curvine-fuse.sh start 
        Starting curvine-fuse with arguments: start
        fuse start success, pid=112
        Loaded configuration from /app/curvine/conf/curvine-cluster.toml
        2026/07/20 16:19:41.149 INFO cluster_conf.rs:272 allocator: tikv_jemallocator::Jemalloc    
        2026/07/20 16:19:41.149 INFO cluster_conf.rs:273 git version: 08f6ebb    
        2026/07/20 16:19:41.149 INFO cluster_conf.rs:274 cluster conf start: 
        format_master = true
        format_worker = true
        testing = false
        cluster_id = "curvine"

    [root@fedora37 app]# mkdir -p /curvine-fuse/fio-spdk
    [root@fedora37 app]# dd if=/dev/zero of=/curvine-fuse/fio-spdk/x bs=1M count=10
        10+0 records in
        10+0 records out
        10485760 bytes (10 MB, 10 MiB) copied, 0.0591448 s, 177 MB/s
```

- Passed: `located_block_has_spdk_reflects_worker_reported_storage_type`

