### PR TITLE
fix(fuse): correct extended attribute semantics (#1113)

### DIFF
--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -146,6 +146,24 @@ impl CurvineFileSystem {
         &self.fs
     }
 
+    fn validate_set_xattr_flags(flags: u32, exists: bool) -> FuseResult<()> {
+        let create = libc::XATTR_CREATE as u32;
+        let replace = libc::XATTR_REPLACE as u32;
+        let known = create | replace;
+
+        if flags & !known != 0 || flags & known == known {
+            return err_fuse!(libc::EINVAL, "Invalid setxattr flags: {:#x}", flags);
+        }
+        if flags & create != 0 && exists {
+            return err_fuse!(libc::EEXIST, "Extended attribute already exists");
+        }
+        if flags & replace != 0 && !exists {
+            return err_fuse!(libc::ENODATA, "Extended attribute does not exist");
+        }
+
+        Ok(())
+    }
+
     async fn ensure_writable_path(&self, path: &Path, rpc_code: RpcCode) -> FuseResult<()> {
         if self.conf.readonly {
             return Err(FsError::read_only(path.full_path()).into());
@@ -640,7 +658,7 @@ impl fs::FileSystem for CurvineFileSystem {
 
     async fn get_xattr(&self, op: GetXAttr<'_>) -> FuseResult<BytesMut> {
         let name = try_option!(op.name.to_str());
-        FuseUtils::check_xattr(name, true)?;
+        FuseUtils::check_xattr(name, XattrOp::Get)?;
 
         let status = self.state.fs_stat(op.header.nodeid, None).await?;
         let mut buf = FuseBuf::default();
@@ -666,9 +684,15 @@ impl fs::FileSystem for CurvineFileSystem {
 
     async fn set_xattr(&self, op: SetXAttr<'_>) -> FuseResult<()> {
         let name = try_option!(op.name.to_str());
-        FuseUtils::check_xattr(name, true)?;
+        FuseUtils::check_xattr(name, XattrOp::Set)?;
         let path = self.state.get_path(op.header.nodeid)?;
         self.ensure_writable_path(&path, RpcCode::SetAttr).await?;
+
+        // Serialize the existence check and update within this FUSE process so
+        // concurrent CREATE/REPLACE requests cannot both validate stale state.
+        let _guard = self.state.lock_path(&path).await;
+        let status = self.state.fs_stat(op.header.nodeid, None).await?;
+        Self::validate_set_xattr_flags(op.arg.flags, status.x_attr.contains_key(name))?;
 
         // Get the xattr value from the request
         let value_slice: &[u8] = op.value;
@@ -688,12 +712,14 @@ impl fs::FileSystem for CurvineFileSystem {
 
     async fn remove_xattr(&self, op: RemoveXAttr<'_>) -> FuseResult<()> {
         let name = try_option!(op.name.to_str());
-        if FuseUtils::check_xattr(name, false).is_err() {
-            return Ok(());
-        }
+        FuseUtils::check_xattr(name, XattrOp::Remove)?;
 
         let path = self.state.get_path(op.header.nodeid)?;
         self.ensure_writable_path(&path, RpcCode::SetAttr).await?;
+
+        // Share the same path lock as set_xattr so a conditional REPLACE does
+        // not validate existence immediately before a concurrent removal.
+        let _guard = self.state.lock_path(&path).await;
 
         debug!("Removing xattr: path='{}' name='{}'", path, name);
 
@@ -714,12 +740,14 @@ impl fs::FileSystem for CurvineFileSystem {
 
         // Add custom xattr names from the file
         for name in status.x_attr.keys() {
+            // Hidden/protected attributes must not be advertised when getxattr
+            // deliberately makes them unreadable.
+            if FuseUtils::check_xattr(name, XattrOp::Get).is_err() {
+                continue;
+            }
             xattr_names.extend_from_slice(name.as_bytes());
             xattr_names.push(0); // null terminator
         }
-
-        // Add the special "id" attribute
-        xattr_names.extend_from_slice(b"id\0");
 
         let mut buf = FuseBuf::default();
 
@@ -1499,6 +1527,42 @@ mod tests {
         FUSE_MAX_PAGES, FUSE_POSIX_ACL, FUSE_POSIX_LOCKS, FUSE_SPLICE_MOVE, FUSE_SPLICE_READ,
         FUSE_SPLICE_WRITE, FUSE_WRITEBACK_CACHE, SUPPORTED_INIT_FLAGS,
     };
+
+    #[test]
+    fn set_xattr_flags_enforce_create_and_replace_semantics() {
+        let create = libc::XATTR_CREATE as u32;
+        let replace = libc::XATTR_REPLACE as u32;
+
+        CurvineFileSystem::validate_set_xattr_flags(0, false).unwrap();
+        CurvineFileSystem::validate_set_xattr_flags(0, true).unwrap();
+        CurvineFileSystem::validate_set_xattr_flags(create, false).unwrap();
+        CurvineFileSystem::validate_set_xattr_flags(replace, true).unwrap();
+
+        assert_eq!(
+            CurvineFileSystem::validate_set_xattr_flags(create, true)
+                .unwrap_err()
+                .errno(),
+            libc::EEXIST
+        );
+        assert_eq!(
+            CurvineFileSystem::validate_set_xattr_flags(replace, false)
+                .unwrap_err()
+                .errno(),
+            libc::ENODATA
+        );
+        assert_eq!(
+            CurvineFileSystem::validate_set_xattr_flags(create | replace, false)
+                .unwrap_err()
+                .errno(),
+            libc::EINVAL
+        );
+        assert_eq!(
+            CurvineFileSystem::validate_set_xattr_flags(1 << 31, false)
+                .unwrap_err()
+                .errno(),
+            libc::EINVAL
+        );
+    }
 
     // #1122 + allowlist: the daemon must never advertise FUSE_ATOMIC_O_TRUNC
     // (open does not truncate) or any other unsupported capability, even when

--- a/curvine-fuse/src/fs/operator.rs
+++ b/curvine-fuse/src/fs/operator.rs
@@ -247,10 +247,10 @@ pub struct GetXAttr<'a> {
 
 /// SetXAttr request structure:
 /// ```text
-/// +0                         +40                    +56           +56+len(name)+1
+/// +0                         +40                    +48           +48+len(name)+1
 /// |--------------------------|---------------------|-------------|--------------------------|
 /// |    fuse_in_header        | fuse_setxattr_in    |    name     |    value                 |
-/// |      (40 bytes)          |     (16 bytes)      | (variable)  | (size bytes)             |
+/// |      (40 bytes)          |      (8 bytes)      | (variable)  | (size bytes)             |
 /// |--------------------------|---------------------|-------------|--------------------------|
 /// ```
 

--- a/curvine-fuse/src/fuse_utils.rs
+++ b/curvine-fuse/src/fuse_utils.rs
@@ -32,6 +32,13 @@ use orpc::sys::{FFIUtils, RawIO};
 use std::process::Command;
 use std::slice;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum XattrOp {
+    Get,
+    Set,
+    Remove,
+}
+
 pub struct FuseUtils;
 
 impl FuseUtils {
@@ -248,7 +255,7 @@ impl FuseUtils {
             .build()
     }
 
-    pub fn check_xattr(name: &str, read: bool) -> FuseResult<()> {
+    pub fn check_xattr(name: &str, op: XattrOp) -> FuseResult<()> {
         // Handle system extended attributes FIRST, before any path resolution
         // This avoids unnecessary operations and provides fastest response
         // Kernel may still query these even if FUSE_POSIX_ACL is disabled in init response
@@ -258,13 +265,13 @@ impl FuseUtils {
             "security.capability"
             | "security.selinux"
             | "system.posix_acl_access"
-            | "system.posix_acl_default" => {
-                if read {
-                    err_fuse!(libc::ENODATA, "get_xattr {}", name)
-                } else {
-                    err_fuse!(libc::EOPNOTSUPP, "set_xattr {}", name)
+            | "system.posix_acl_default" => match op {
+                XattrOp::Get => err_fuse!(libc::ENODATA, "get_xattr {}", name),
+                XattrOp::Set => err_fuse!(libc::EOPNOTSUPP, "set_xattr {}", name),
+                XattrOp::Remove => {
+                    err_fuse!(libc::EOPNOTSUPP, "remove_xattr {}", name)
                 }
-            }
+            },
             _ => Ok(()),
         }
     }
@@ -497,6 +504,42 @@ impl FuseUtils {
 mod tests {
     use super::*;
     use crate::raw::fuse_abi::fuse_setattr_in;
+
+    #[test]
+    fn protected_xattr_errors_match_operation() {
+        for name in [
+            "security.capability",
+            "security.selinux",
+            "system.posix_acl_access",
+            "system.posix_acl_default",
+        ] {
+            assert_eq!(
+                FuseUtils::check_xattr(name, XattrOp::Get)
+                    .unwrap_err()
+                    .errno(),
+                libc::ENODATA
+            );
+            assert_eq!(
+                FuseUtils::check_xattr(name, XattrOp::Set)
+                    .unwrap_err()
+                    .errno(),
+                libc::EOPNOTSUPP
+            );
+            assert_eq!(
+                FuseUtils::check_xattr(name, XattrOp::Remove)
+                    .unwrap_err()
+                    .errno(),
+                libc::EOPNOTSUPP
+            );
+        }
+    }
+
+    #[test]
+    fn user_xattr_is_allowed_for_every_operation() {
+        for op in [XattrOp::Get, XattrOp::Set, XattrOp::Remove] {
+            FuseUtils::check_xattr("user.curvine", op).unwrap();
+        }
+    }
 
     #[test]
     fn file_open_flags_are_built_only_from_response_flags() {

--- a/curvine-fuse/src/lib.rs
+++ b/curvine-fuse/src/lib.rs
@@ -38,7 +38,7 @@ pub mod fuse_metrics;
 pub use self::fuse_metrics::FuseMetrics;
 
 mod fuse_utils;
-pub use self::fuse_utils::FuseUtils;
+pub use self::fuse_utils::{FuseUtils, XattrOp};
 
 pub type FuseResult<T> = Result<T, FuseError>;
 

--- a/curvine-fuse/src/raw/fuse_abi.rs
+++ b/curvine-fuse/src/raw/fuse_abi.rs
@@ -234,14 +234,13 @@ pub struct fuse_getxattr_in {
     pub padding: u32,
 }
 
+/// The 8-byte compatibility form used unless `FUSE_SETXATTR_EXT` is negotiated.
+/// Curvine's INIT capability allowlist does not advertise that extension.
 #[repr(C)]
 #[derive(Debug, Default)]
 pub struct fuse_setxattr_in {
     pub size: u32,
     pub flags: u32,
-    //maybe different in version
-    pub setxattr_flags: u32,
-    pub padding: u32,
 }
 
 #[allow(non_camel_case_types)]

--- a/curvine-fuse/src/session/fuse_request.rs
+++ b/curvine-fuse/src/session/fuse_request.rs
@@ -327,3 +327,49 @@ impl Display for FuseRequest {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::raw::fuse_abi::fuse_setxattr_in;
+    use crate::FuseUtils;
+    use bytes::BytesMut;
+    use std::ffi::OsStr;
+
+    #[test]
+    fn setxattr_uses_compat_header_and_preserves_name_and_value() {
+        assert_eq!(size_of::<fuse_setxattr_in>(), 8);
+
+        let name = b"user.curvine.full-name\0";
+        let value = b"xattr-value";
+        let arg = fuse_setxattr_in {
+            size: value.len() as u32,
+            flags: libc::XATTR_CREATE as u32,
+        };
+        let request_len =
+            size_of::<fuse_in_header>() + size_of::<fuse_setxattr_in>() + name.len() + value.len();
+        let header = fuse_in_header {
+            len: request_len as u32,
+            opcode: FUSE_SETXATTR as u32,
+            unique: 42,
+            nodeid: 7,
+            ..Default::default()
+        };
+
+        let mut bytes = BytesMut::with_capacity(request_len);
+        bytes.extend_from_slice(FuseUtils::struct_as_bytes(&header));
+        bytes.extend_from_slice(FuseUtils::struct_as_bytes(&arg));
+        bytes.extend_from_slice(name);
+        bytes.extend_from_slice(value);
+
+        let request = FuseRequest::from_bytes(bytes.freeze()).unwrap();
+        match request.parse_operator().unwrap() {
+            FuseOperator::SetXAttr(op) => {
+                assert_eq!(op.name, OsStr::new("user.curvine.full-name"));
+                assert_eq!(op.value, value);
+                assert_eq!(op.arg.flags, libc::XATTR_CREATE as u32);
+            }
+            other => panic!("expected SetXAttr, got {other:?}"),
+        }
+    }
+}


### PR DESCRIPTION
# Summary

Correct FUSE extended-attribute semantics for conditional create/replace operations, protected attributes, attribute listing, and compatibility request parsing.

# Issue Describe / Design

Closes #1113

Root causes:

- `setxattr` ignored `XATTR_CREATE` and `XATTR_REPLACE`.
- Protected xattr removal silently returned success.
- `listxattr` advertised an unreadable synthetic `id` attribute.
- The compatibility `SETXATTR` request was parsed with the extended header even though `FUSE_SETXATTR_EXT` is not negotiated.

Fix approach:

- Validate CREATE/REPLACE flags and serialize the existence check and update within the FUSE process.
- Introduce an explicit `XattrOp` enum for operation-specific error handling.
- Stop advertising unreadable or protected attributes.
- Parse the 8-byte compatibility request header, consistent with the capability allowlist from #1183.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine_file_system.rs` | Enforce CREATE/REPLACE semantics and propagate protected-xattr errors | Correct POSIX-visible behavior |
| `fuse_utils.rs` | Replace the ambiguous read flag with `XattrOp` | Operation-specific errno mapping |
| `fuse_abi.rs` / `fuse_request.rs` | Parse the compatibility SETXATTR request layout | Prevent shifted name/value parsing |
| `operator.rs` / `lib.rs` | Update ABI documentation and exports | No unrelated behavior change |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `make format` | PASS | Full workspace release-mode Clippy in a remote Linux environment |
| `cargo test -p curvine-fuse xattr -- --nocapture` | PASS | 4 focused tests |
| Mounted FUSE xattr E2E | PASS | Verified CREATE, REPLACE, invalid flags, protected attributes, and list/get consistency |

# Dependencies

- Related PRs: #1183 (merged)
- Related issues: #1113
- Blocks / blocked by: None