### PR TITLE
fix(fuse): preserve deferred-delete cleanup failures (#1112)

### DIFF
--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -167,6 +167,12 @@ impl CurvineFileSystem {
         &self.state
     }
 
+    fn retain_first_error(first: &mut FuseResult<()>, next: FuseResult<()>) {
+        if first.is_ok() {
+            *first = next;
+        }
+    }
+
     fn to_file_lock(&self, arg: &fuse_lk_in) -> FileLock {
         let client_id = self.fs.cv().fs_context().clone_client_name();
         FileLock {
@@ -198,7 +204,12 @@ impl CurvineFileSystem {
                 lock.end = u64::MAX;
             }
 
-            self.fs.set_lock(&path, lock).await?;
+            if let Err(e) = self.fs.set_lock(&path, lock).await {
+                // Preserve the owner locally when the backend unlock fails so a
+                // retained handle can retry the cleanup.
+                handler.add_lock(flags, owner_id);
+                return Err(e.into());
+            }
         }
 
         Ok(())
@@ -1058,31 +1069,59 @@ impl fs::FileSystem for CurvineFileSystem {
         let path = self.state.get_path(ino)?;
         let _guard = self.state.lock_path(&path).await;
 
-        let handle = self.state.release_handle(ino, op.arg.fh).await?;
+        let (handle, mut release_result) = self.state.release_handle(ino, op.arg.fh).await?;
 
         if handle.has_writer() {
             self.state
                 .invalid_cache(op.header.nodeid, None, INVAL_REASON_RELEASE);
         }
 
-        let unlock_result = self
-            .fs_unlock(&handle, LockFlags::Flock)
-            .await
-            .and(self.fs_unlock(&handle, LockFlags::Plock).await);
-        unlock_result?;
-
-        if self.state.deferred_delete_ready(ino).await? {
-            debug!(
-                "release ino={}: no more open handles, executing delayed deletion of {}",
-                ino, path
+        let flock_result = self.fs_unlock(&handle, LockFlags::Flock).await;
+        if let Err(e) = &flock_result {
+            warn!(
+                "failed to release flock for ino={}, path={}: {}",
+                ino, path, e
             );
-            if let Err(e) = self.fs.delete(&path, false).await {
-                warn!("failed to delete {} after last handle closed: {}", path, e);
+        }
+        Self::retain_first_error(&mut release_result, flock_result);
+
+        let plock_result = self.fs_unlock(&handle, LockFlags::Plock).await;
+        if let Err(e) = &plock_result {
+            warn!(
+                "failed to release plock for ino={}, path={}: {}",
+                ino, path, e
+            );
+        }
+        Self::retain_first_error(&mut release_result, plock_result);
+
+        match self.state.deferred_delete_ready(ino).await {
+            Ok(true) => {
+                debug!(
+                    "release ino={}: no more open handles, executing delayed deletion of {}",
+                    ino, path
+                );
+                let delete_result = self
+                    .state
+                    .complete_deferred_delete(ino, self.fs.delete(&path, false).await);
+                if let Err(e) = &delete_result {
+                    warn!(
+                        "failed to delete {} after last handle closed; retaining pending delete: {}",
+                        path, e
+                    );
+                }
+                Self::retain_first_error(&mut release_result, delete_result);
             }
-            self.state.clear_mark_delete(ino)?;
+            Ok(false) => {}
+            Err(e) => {
+                warn!(
+                    "failed to evaluate deferred delete for ino={}, path={}: {}",
+                    ino, path, e
+                );
+                Self::retain_first_error(&mut release_result, Err(e));
+            }
         }
 
-        reply.send_rep::<(), FuseError>(Ok(())).await?;
+        reply.send_rep(release_result).await?;
         Ok(())
     }
 
@@ -1267,7 +1306,8 @@ impl fs::FileSystem for CurvineFileSystem {
                 name: op.name,
             };
             let res = self.create(op).await?;
-            let _ = self.state.release_handle(res.0.nodeid, res.1.fh).await?;
+            let (_, close_result) = self.state.release_handle(res.0.nodeid, res.1.fh).await?;
+            close_result?;
             let out = fuse_entry_out {
                 nodeid: res.0.nodeid,
                 generation: res.0.generation,

--- a/curvine-fuse/src/fs/state/node_state.rs
+++ b/curvine-fuse/src/fs/state/node_state.rs
@@ -603,8 +603,10 @@ impl NodeState {
             _ => Ok(()),
         };
 
-        // A failed close keeps both the handle and its shared-writer reference,
-        // allowing cleanup to be retried without losing pending-delete state.
+        // A failed close keeps both the handle and its shared-writer reference
+        // so cleanup state is not silently discarded. FUSE normally sends
+        // RELEASE only once; automatic retry of retained state is tracked by
+        // #1221.
         if close_result.is_ok() {
             let _ = self.remove_handle(ino, fh);
         }
@@ -630,6 +632,8 @@ impl NodeState {
         ino: u64,
         delete_result: Result<(), FsError>,
     ) -> FuseResult<()> {
+        // Keep the mark observable after failure. The background retry needed
+        // to reclaim it without another FUSE request is tracked by #1221.
         match delete_result {
             Ok(()) | Err(FsError::FileNotFound(_)) => self.clear_mark_delete(ino),
             Err(e) => Err(e.into()),

--- a/curvine-fuse/src/fs/state/node_state.rs
+++ b/curvine-fuse/src/fs/state/node_state.rs
@@ -573,7 +573,11 @@ impl NodeState {
         Self::remove_file_handle_locked(&mut lock, ino, fh)
     }
 
-    pub async fn release_handle(&self, ino: u64, fh: u64) -> FuseResult<Arc<FileHandle>> {
+    pub async fn release_handle(
+        &self,
+        ino: u64,
+        fh: u64,
+    ) -> FuseResult<(Arc<FileHandle>, FuseResult<()>)> {
         // Find the handle without removing it yet.  The handle stays in
         // self.handles while complete()/flush() runs so that
         // has_open_handles() keeps returning true during the commit —
@@ -581,29 +585,31 @@ impl NodeState {
         // file before the data upload finishes.
         let handle = self.find_handle(ino, fh)?;
 
-        let result: FuseResult<()> = match handle.as_ref() {
+        let close_result: FuseResult<()> = match handle.as_ref() {
             FileHandle::Backend(_) if handle.has_writer() => {
-                let (released, res) = self
-                    .writers
-                    .release(handle.ino(), async { handle.complete(None).await })
-                    .await;
-
-                if !released {
-                    handle.flush(None).await
-                } else {
-                    res
-                }
+                let cleanup_handle = handle.clone();
+                self.writers
+                    .release_with_cleanup(handle.ino(), move |last| async move {
+                        if last {
+                            cleanup_handle.complete(None).await
+                        } else {
+                            cleanup_handle.flush(None).await
+                        }
+                    })
+                    .await
+                    .map(|_| ())
             }
 
             _ => Ok(()),
         };
 
-        // Remove the handle *after* complete/flush has finished so that the
-        // file is not prematurely deleted while the commit is still running.
-        let _ = self.remove_handle(ino, fh);
+        // A failed close keeps both the handle and its shared-writer reference,
+        // allowing cleanup to be retried without losing pending-delete state.
+        if close_result.is_ok() {
+            let _ = self.remove_handle(ino, fh);
+        }
 
-        result?;
-        Ok(handle)
+        Ok((handle, close_result))
     }
 
     pub fn has_open_handles(&self, ino: u64) -> bool {
@@ -617,6 +623,17 @@ impl NodeState {
 
     pub fn clear_mark_delete(&self, ino: u64) -> FuseResult<()> {
         self.dir_write().clear_mark_delete(ino)
+    }
+
+    pub fn complete_deferred_delete(
+        &self,
+        ino: u64,
+        delete_result: Result<(), FsError>,
+    ) -> FuseResult<()> {
+        match delete_result {
+            Ok(()) | Err(FsError::FileNotFound(_)) => self.clear_mark_delete(ino),
+            Err(e) => Err(e.into()),
+        }
     }
 
     pub async fn fs_unlink(&self, parent: u64, name: &str) -> FuseResult<()> {
@@ -1220,9 +1237,11 @@ mod test {
     use crate::fs::state::file_handle::FileHandle;
     use crate::fs::state::{DirHandle, NodeState};
     use crate::fs::FuseWriter;
+    use crate::{FuseError, FUSE_ROOT_ID};
     use bytes::Bytes;
     use curvine_client::unified::{UnifiedFileSystem, UnifiedWriter};
     use curvine_common::conf::ClusterConf;
+    use curvine_common::error::FsError;
     use curvine_common::fs::local::LocalWriter;
     use curvine_common::fs::{ListStream, Path, StateReader, StateWriter, Writer};
     use curvine_common::state::FileStatus;
@@ -1448,6 +1467,81 @@ mod test {
                 result.is_err(),
                 "a file-handle persist failure must fail the whole state persist"
             );
+        });
+    }
+
+    #[test]
+    fn deferred_delete_error_retains_mark_until_success_or_not_found() {
+        let rt = Arc::new(AsyncRuntime::single());
+        let fs = UnifiedFileSystem::with_rt(ClusterConf::default(), rt).unwrap();
+        let state = NodeState::new(fs).unwrap();
+        let ino = {
+            let mut dir = state.dir_write();
+            let status = FileStatus::with_name(123, "pending".to_string(), false);
+            let ino = dir.lookup(FUSE_ROOT_ID, "pending", status).unwrap().ino;
+            dir.unlink(FUSE_ROOT_ID, "pending", true).unwrap();
+            ino
+        };
+
+        assert!(state.dir_read().pending_delete(ino));
+        assert!(state
+            .complete_deferred_delete(ino, Err(FsError::common("delete failed")))
+            .is_err());
+        assert!(state.dir_read().pending_delete(ino));
+
+        state
+            .complete_deferred_delete(ino, Err(FsError::file_not_found("/pending")))
+            .unwrap();
+        assert!(!state.dir_read().pending_delete(ino));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn release_handle_failure_retains_handle_and_writer_for_retry() {
+        let rt = Arc::new(AsyncRuntime::single());
+        let task_rt = rt.clone();
+
+        rt.block_on(async move {
+            crate::FuseMetrics::ensure_init().unwrap();
+            let fs = UnifiedFileSystem::with_rt(ClusterConf::default(), task_rt.clone()).unwrap();
+            let state = NodeState::new(fs).unwrap();
+
+            let full_path = Path::from_str("/dev/full").unwrap();
+            let local_writer = LocalWriter::new(&full_path, 1).unwrap();
+            let status = local_writer.status().clone();
+            let fuse_writer = Arc::new(FuseWriter::new(
+                &state.conf,
+                task_rt,
+                UnifiedWriter::Local(local_writer),
+            ));
+            state
+                .writers
+                .insert::<FuseError>(1, fuse_writer.clone())
+                .await
+                .unwrap();
+            let handle = state
+                .insert_handle_with_writer(1, None, Some(fuse_writer.clone()), status)
+                .await;
+            fuse_writer
+                .write(0, Bytes::from_static(b"x"), None)
+                .await
+                .unwrap();
+
+            let (_, first_result) = state.release_handle(1, handle.fh()).await.unwrap();
+            assert!(first_result.is_err());
+            assert!(state.find_handle(1, handle.fh()).is_ok());
+            assert!(Arc::ptr_eq(
+                &state.find_writer(1).await.unwrap(),
+                &fuse_writer
+            ));
+
+            let (_, retry_result) = state.release_handle(1, handle.fh()).await.unwrap();
+            assert!(retry_result.is_err());
+            assert!(state.find_handle(1, handle.fh()).is_ok());
+            assert!(Arc::ptr_eq(
+                &state.find_writer(1).await.unwrap(),
+                &fuse_writer
+            ));
         });
     }
 }

--- a/orpc/src/sync/async_map.rs
+++ b/orpc/src/sync/async_map.rs
@@ -40,9 +40,9 @@ impl<T> Default for SharedState<T> {
 /// One async mutex per key serializes create/release work. This keeps the
 /// implementation small and avoids exposing resources that are being closed.
 ///
-/// The futures passed to `get_or_create`, `with_resource`, and `release` must
-/// not call back into this map with the same key; doing so would wait on the
-/// same per-key mutex.
+/// The futures passed to `get_or_create`, `with_resource`, `release`, and
+/// `release_with_cleanup` must not call back into this map with the same key;
+/// doing so would wait on the same per-key mutex.
 pub struct AsyncSharedMap<K, T> {
     inner: FastDashMap<K, Arc<Mutex<SharedState<T>>>>,
 }
@@ -216,6 +216,46 @@ impl<K: Eq + Hash + Display + Clone, T> AsyncSharedMap<K, T> {
         self.remove_entry(&key, &entry);
 
         (true, res)
+    }
+
+    /// Release one reference after its cleanup succeeds.
+    ///
+    /// `cleanup` receives whether this is the last reference, allowing callers
+    /// to choose between per-reference cleanup (for example, flush) and final
+    /// cleanup (for example, complete). If cleanup fails, both the reference
+    /// count and resource remain unchanged so the same release can be retried.
+    pub async fn release_with_cleanup<E, F, Fut>(&self, key: K, cleanup: F) -> Result<bool, E>
+    where
+        E: Error,
+        F: FnOnce(bool) -> Fut,
+        Fut: Future<Output = Result<(), E>>,
+    {
+        let entry = match self.inner.get(&key) {
+            Some(entry) => entry.clone(),
+            None => return Ok(true),
+        };
+
+        let mut state = entry.lock().await;
+
+        if state.refs == 0 || state.resource.is_none() {
+            drop(state);
+            self.remove_entry(&key, &entry);
+            return Ok(true);
+        }
+
+        let last = state.refs == 1;
+        cleanup(last).await?;
+
+        state.refs -= 1;
+        if state.refs > 0 {
+            return Ok(false);
+        }
+
+        state.resource.take();
+        drop(state);
+        self.remove_entry(&key, &entry);
+
+        Ok(true)
     }
 }
 
@@ -517,6 +557,73 @@ mod tests {
             2
         );
         assert_eq!(creators.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn release_with_cleanup_error_retains_last_reference_for_retry() {
+        let map = AsyncSharedMap::<u64, u64>::new();
+        map.insert::<StringError>(1, Arc::new(7)).await.unwrap();
+
+        let result = map
+            .release_with_cleanup(1, |last| async move {
+                assert!(last);
+                Err::<(), _>(StringError::from("cleanup failed"))
+            })
+            .await;
+        assert!(result.is_err());
+        assert_eq!(*map.get(&1).await.unwrap(), 7);
+
+        let released = map
+            .release_with_cleanup(1, |last| async move {
+                assert!(last);
+                Ok::<_, StringError>(())
+            })
+            .await
+            .unwrap();
+        assert!(released);
+        assert!(map.get(&1).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn release_with_cleanup_error_does_not_decrement_shared_reference() {
+        let map = AsyncSharedMap::<u64, u64>::new();
+        let first = map
+            .get_or_create(1, async { Ok::<_, StringError>(Arc::new(7)) })
+            .await
+            .unwrap();
+        let second = map
+            .get_or_create(1, async { Ok::<_, StringError>(Arc::new(8)) })
+            .await
+            .unwrap();
+        assert!(Arc::ptr_eq(&first, &second));
+
+        let result = map
+            .release_with_cleanup(1, |last| async move {
+                assert!(!last);
+                Err::<(), _>(StringError::from("flush failed"))
+            })
+            .await;
+        assert!(result.is_err());
+
+        let released = map
+            .release_with_cleanup(1, |last| async move {
+                assert!(!last);
+                Ok::<_, StringError>(())
+            })
+            .await
+            .unwrap();
+        assert!(!released);
+        assert!(map.get(&1).await.is_some());
+
+        let released = map
+            .release_with_cleanup(1, |last| async move {
+                assert!(last);
+                Ok::<_, StringError>(())
+            })
+            .await
+            .unwrap();
+        assert!(released);
+        assert!(map.get(&1).await.is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
# Summary

Make the FUSE release path preserve retriable state and report backend cleanup failures instead of silently losing deferred deletes or writer-close errors.

# Issue Describe / Design

Closes #1112

Root causes:

- `release_handle` removed the file handle after `complete` or `flush` even when that operation failed.
- `release` short-circuited on the first close or unlock error, skipping remaining lock and deferred-delete cleanup.
- A failed deferred backend delete was logged but its delete mark was cleared and success was returned to the kernel.

Reproduction steps:

1. Unlink a file while its final writer handle remains open.
2. Inject a writer-complete or backend-delete failure during release.
3. Observe that the old path loses the handle or pending-delete state while backend cleanup has not completed.

Fix approach:

- Add an atomic shared-resource release operation that changes the reference count only after cleanup succeeds.
- Keep the file handle and shared writer reference when `complete` or `flush` fails.
- Attempt flock, plock, and deferred-delete cleanup independently, retain the first error, and send exactly one final release reply.
- Clear the pending-delete mark only after delete succeeds or the backend reports that the file is already absent.
- Restore the locally tracked lock owner when a backend unlock fails.

Known limitation / follow-up:

- FUSE normally sends `RELEASE` only once per file handle. This PR preserves and exposes failed cleanup state but does not automatically retry it after the request finishes.
- Background reaping, bounded retry, lifecycle handling, and aggregate cleanup metrics are tracked separately in #1221.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `orpc/src/sync/async_map.rs` | Add cleanup-before-release reference handling with retry preservation | Existing release API is unchanged |
| `curvine-fuse/src/fs/state/node_state.rs` | Preserve handles/writers on close failure, finalize deferred deletes conditionally, and document the automatic-retry limitation | Failed cleanup remains observable and retained for future recovery work |
| `curvine-fuse/src/fs/curvine_file_system.rs` | Run all release cleanup stages and return the first real error | No more silent deferred-delete success |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `make format` | PASS | Full workspace release-mode Clippy in a remote Linux environment; rerun after review update |
| `cargo test -p orpc release_with_cleanup -- --nocapture` | PASS | 2 focused reference-retention tests |
| `cargo test -p curvine-fuse fs::state::node_state::test:: -- --nocapture` | PASS | 8 state tests, including close and delete failure preservation |
| Mounted FUSE deferred-delete E2E | PASS | Opened, wrote, fsynced, unlinked while open, wrote again, closed, and confirmed backend deletion independently |

# Dependencies

- Related PRs: #1201 (merged)
- Related issues: #1112, #1221
- Blocks / blocked by: None
