### PR TITLE
docs: add ADOPTERS.md with OPPO as adopter (#1219)

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,13 @@
+# Who's using Curvine
+
+Curvine is used by a growing range of companies and projects for AI-native and cloud-native file system workloads, from LLM training and AI Agent platforms to big-data analytics and multimodal data lakes.
+
+If you are using Curvine and your name is not on this list, please send us a PR!
+
+## Companies/Projects using Curvine in production
+
+These companies and projects are using Curvine in production. If your company is using Curvine, open a PR to add your company or project name and a description of how you are using Curvine.
+
+| Company / Project | Use Case |
+| --- | --- |
+| OPPO | OPPO uses Curvine as a multi-cloud big-data cache acceleration layer. Curvine's FUSE interface hosts big-data compute intermediate data, accelerates multimodal data lake access via LanceDB caching, and speeds up StarRocks hot-data queries in compute-storage separated architectures. |


### PR DESCRIPTION
# Summary

Adds a community `ADOPTERS.md` to the repository root, listing OPPO as a
production adopter of Curvine. The file follows the
[openfga/community ADOPTERS.md](https://github.com/openfga/community/blob/main/ADOPTERS.md)
convention and invites other adopters to submit PRs.

# Issue Describe / Design

No pre-existing issue. Community file to track production adoption of Curvine.

Design decisions:
- Follow the openfga ADOPTERS.md structure: title, intro, call-to-action, and a
  "Companies/Projects using Curvine in production" table.
- List only OPPO for now, with a use-case description covering:
  - Multi-cloud big-data cache acceleration
  - Curvine FUSE hosting big-data compute intermediate data
  - Multimodal data lake LanceDB cache acceleration
  - StarRocks hot-data acceleration
- Written in English to match existing community files (README.md, MAINTAINERS.md).

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `ADOPTERS.md` | New community file listing OPPO as a production adopter with use-case description | None (docs only) |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| Markdown render | PASS | Table and headings render correctly |
| Only `ADOPTERS.md` staged | PASS | `.qoder/` IDE cache excluded |
| `make format` | N/A | Skipped - pure-markdown new file; cargo fmt/clippy do not apply |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None