### PR TITLE
docs: add DCO (Developer Certificate of Origin) file (#1220)

### DIFF
--- a/DCO
+++ b/DCO
@@ -1,0 +1,34 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.


### PR DESCRIPTION
# Summary

Adds the Developer Certificate of Origin (DCO) v1.1 text to the repository
root as a `DCO` file, following the convention used by
[sustainable-computing-io/kepler](https://github.com/sustainable-computing-io/kepler/blob/main/DCO).
This gives contributors a standard reference for the sign-off requirement.

# Issue Describe / Design

No pre-existing issue. Community/governance file to document the Developer
Certificate of Origin.

Design decisions:
- File named `DCO` (no extension), matching the kepler reference and the
  broader CNCF/Linux Foundation convention.
- Verbatim DCO v1.1 text from The Linux Foundation (the canonical,
  unmodifiable license document).
- Placed in the repository root alongside other community files
  (README.md, MAINTAINERS.md, CODE_OF_CONDUCT.md, CONTRIBUTING.md).

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `DCO` | New file with the Developer Certificate of Origin v1.1 text | None (docs only) |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| File content matches kepler DCO v1.1 | PASS | Verbatim text verified against raw source |
| Only `DCO` staged | PASS | `.qoder/` IDE cache excluded |
| `make format` | N/A | Skipped - plain-text legal document; cargo fmt/clippy do not apply |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None