### PR TITLE
fix(fuse): maintain inode refcount when lookup hits an existing server-id (#1162)

### DIFF
--- a/curvine-fuse/src/fs/dcache/dir_tree.rs
+++ b/curvine-fuse/src/fs/dcache/dir_tree.rs
@@ -198,11 +198,16 @@ impl DirTree {
             }
 
             None => {
-                let inode = (status.id > FUSE_ROOT_ID as i64)
-                    .then(|| self.get_inode(status.id as u64, None))
+                let existing = (status.id > FUSE_ROOT_ID as i64)
+                    .then(|| self.get_inode_mut(status.id as u64, None))
                     .flatten();
 
-                let ino = match inode {
+                match existing {
+                    // #1162: a new dentry name whose server-id resolves to an
+                    // already-existing inode (rename target / hard-link-like).
+                    // Reuse the inode in place: bump ref counters and re-point
+                    // parent/name. Must NOT re-insert, or the fresh `Inode`
+                    // would reset ref_ctr/n_lookup and leak the old entry.
                     Some(inode) => {
                         if inode.is_deleted() {
                             return err_fuse!(
@@ -211,15 +216,22 @@ impl DirTree {
                                 inode.ino
                             );
                         }
+                        inode.add_lookup(1);
+                        inode.add_ref(1);
+                        inode.parent = parent;
+                        inode.name = name.to_owned();
+                        inode.update_status(status);
                         inode.ino
                     }
 
-                    None => self.next_id(status.id),
-                };
-
-                self.inodes
-                    .insert(ino, Inode::with_status(ino, parent, name, status));
-                ino
+                    // A brand-new inode: allocate an id and insert.
+                    None => {
+                        let ino = self.next_id(status.id);
+                        self.inodes
+                            .insert(ino, Inode::with_status(ino, parent, name, status));
+                        ino
+                    }
+                }
             }
         };
 


### PR DESCRIPTION
# Summary

`DirTree::lookup` failed to maintain inode reference counters when a new dentry name resolved (via server-id) to an inode already present in the dcache, causing under-counted references and an inode leak. This fixes the counter maintenance for that path.

# Issue Describe / Design

Closes #1162 (partial — this PR fixes the lookup path; the unlink-side counter issue is addressed separately).

**Root cause**
`lookup` has a branch where a new `(parent, name)` dentry is not cached but its `status.id` (server-id) resolves to an existing inode (rename target / hard-link-like). That branch only read `inode.ino`, then fell through to the shared `self.inodes.insert(ino, Inode::with_status(...))` line — overwriting the live inode with a fresh one whose `ref_ctr`/`n_lookup` were reset to 1. Because the counters were under-counted, `unlink` + `forget` could never drive them to zero, so `should_unref()` never fired and the inode leaked / stayed stale in the dcache.

**Reproduction**
`cargo test -p curvine-fuse --lib lookup_existing_server_id_updates_inode_path_without_reinsert` fails on `main` with `assertion left == right failed, left: 1, right: 2` (pre-existing since #1041 / commit 654e3d1).

**Fix**
Split the branch: when the server-id resolves to an existing inode, update it in place (`add_lookup(1)` + `add_ref(1)`, re-point `parent`/`name`, refresh status) and do NOT re-insert. Only brand-new inodes take the `insert` path.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-fuse/src/fs/dcache/dir_tree.rs` | Split `lookup` None-branch into "reuse existing inode in place" vs "insert brand-new inode"; bump ref counters + re-point parent/name on reuse | Fixes ref-count under-count on rename/hard-link-like lookups; new-file path unchanged |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-fuse --lib lookup_existing_server_id_updates_inode_path_without_reinsert` | PASS | Was failing before this PR |
| `cargo test -p curvine-fuse --lib` (single-threaded) | 218 passed / 2 failed | The 2 remaining failures are the unlink-side counter issue, fixed in a follow-up PR |
| `cargo clippy -p curvine-fuse --all-targets -- --deny=warnings` | PASS | |

# Dependencies

- Related PRs: a follow-up PR will fix the `unlink` counter path (remaining 2 test failures)
- Related issues: #1162
- Blocks / blocked by: None