### PR TITLE
fix(fuse): reclaim inode in unlink when it drops the last reference (#1162)

### DIFF
--- a/curvine-fuse/src/fs/dcache/dir_tree.rs
+++ b/curvine-fuse/src/fs/dcache/dir_tree.rs
@@ -231,18 +231,31 @@ impl DirTree {
     }
 
     pub fn unlink(&mut self, parent: u64, name: &str, mark_delete: bool) -> FuseResult<()> {
-        let inode = self.get_inode_mut_check(parent, Some(name))?;
-        if mark_delete {
-            inode.mark_delete = true;
-        }
-        inode.sub_ref(1);
-        inode.sub_link(1);
+        let (ino, should_remove) = {
+            let inode = self.get_inode_mut_check(parent, Some(name))?;
+            if mark_delete {
+                inode.mark_delete = true;
+            }
+            inode.sub_ref(1);
+            inode.sub_link(1);
+            // Never reclaim while mark_delete is set: the inode must outlive the
+            // deferred-delete flow (pending_delete / clear_mark_delete look it up
+            // by ino after the server-side delete completes).
+            (inode.ino, !mark_delete && inode.should_unref())
+        };
 
         // Remove directory entry; keep parent inode's `DirEntry` even when `children` is empty.
         let dir = self.get_dir_mut_check(parent)?;
         dir.remove_child(name);
         if mark_delete {
             dir.mark_deleted_child(name);
+        }
+
+        // #1162: when this unlink drops the last reference (kernel already
+        // forgot the inode), reclaim it here just like `forget` does; otherwise
+        // the inode leaks in the dcache.
+        if should_remove {
+            self.remove_inode(ino);
         }
 
         Ok(())


### PR DESCRIPTION
# Summary

`DirTree::unlink` decremented an inode's `ref_ctr`/`nlink` but never reclaimed the inode when those reached zero, unlike `forget` and `rename`. When `unlink` is the operation that drives the counters to zero, the inode was orphaned in the dcache and never removed. This adds the missing reclaim.

# Issue Describe / Design

Closes #1162 (partial — this PR fixes the unlink path; the lookup path is fixed in a separate PR).

**Root cause**
`forget` and `rename` both check `should_unref()` (`n_lookup == 0 && ref_ctr == 0`) after decrementing counters and call `remove_inode`. `unlink` did neither. So in the ordering `lookup -> forget -> unlink`, `forget` clears `n_lookup` (inode kept because `ref_ctr` is still 1), then `unlink` clears `ref_ctr` — at which point `should_unref()` is true, but `unlink` never checked, leaving the inode stranded in the dcache.

**Reproduction**
On `main`:
- `create_then_forget_then_unlink` fails at `assert!(get_inode(200).is_none())`
- `create_lookup_rename_link_unlink_forget_keeps_tree_consistent` fails at `assert!(get_inode(f).is_none())`

(pre-existing since #1041 / commit 654e3d1.)

**Fix**
After decrementing, compute `should_unref()` and call `remove_inode`, mirroring `forget`/`rename`. The reclaim is guarded with `!mark_delete`: during the deferred-delete flow (`fs_unlink` in `node_state.rs`) the inode must outlive `unlink`, because `pending_delete(ino)` / `clear_mark_delete(ino)` look the inode up by `ino` after the server-side delete completes. Reclaiming a `mark_delete` inode here would skip the backend delete and leave a stale `deleted_child` marker in the parent dir.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-fuse/src/fs/dcache/dir_tree.rs` | `unlink` now reclaims the inode via `remove_inode` when `!mark_delete && should_unref()`; borrow scoped to extract `ino` + bool first | Fixes inode leak when unlink drops the last ref; deferred-delete (mark_delete) path unchanged |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-fuse --lib create_then_forget_then_unlink` | PASS | Was failing before this PR |
| `cargo test -p curvine-fuse --lib create_lookup_rename_link_unlink_forget_keeps_tree_consistent` | PASS | Was failing before this PR |
| `cargo test -p curvine-fuse --lib dcache::dir_tree` | 21 passed / 1 failed | The 1 remaining failure (`lookup_existing_server_id_...`) is the lookup-path issue, fixed by the companion PR |
| `cargo clippy -p curvine-fuse --all-targets -- --deny=warnings` | PASS | |

# Dependencies

- Related PRs: companion PR fixing the `lookup` server-id path (remaining 1 test failure)
- Related issues: #1162
- Blocks / blocked by: None