### PR TITLE
fix(fuse): support mknod for char, block, and fifo special files (#1228)

### DIFF
--- a/curvine-client/src/file/curvine_filesystem.rs
+++ b/curvine-client/src/file/curvine_filesystem.rs
@@ -316,6 +316,14 @@ impl CurvineFileSystem {
         self.fs_client.link(src_path, dst_path).await
     }
 
+    pub async fn create_special_node(
+        &self,
+        path: &Path,
+        opts: CreateFileOpts,
+    ) -> FsResult<FileStatus> {
+        self.fs_client.create_special_node(path, opts).await
+    }
+
     pub async fn get_mount_info(&self, path: &Path) -> FsResult<Option<MountInfo>> {
         self.fs_client.get_mount_info(path).await
     }

--- a/curvine-client/src/file/fs_client.rs
+++ b/curvine-client/src/file/fs_client.rs
@@ -581,9 +581,8 @@ impl FsClient {
     pub async fn create_special_node(
         &self,
         path: &Path,
-        mut opts: CreateFileOpts,
+        opts: CreateFileOpts,
     ) -> FsResult<FileStatus> {
-        opts.sync_ufs_meta = true;
         let flags = OpenFlags::new_create();
         let header = CreateFileRequest {
             path: path.encode(),

--- a/curvine-client/src/file/fs_client.rs
+++ b/curvine-client/src/file/fs_client.rs
@@ -578,6 +578,23 @@ impl FsClient {
         Ok(())
     }
 
+    pub async fn create_special_node(
+        &self,
+        path: &Path,
+        mut opts: CreateFileOpts,
+    ) -> FsResult<FileStatus> {
+        opts.sync_ufs_meta = true;
+        let flags = OpenFlags::new_create();
+        let header = CreateFileRequest {
+            path: path.encode(),
+            opts: ProtoUtils::create_opts_to_pb(opts, self.context.clone_client_name()),
+            flags: flags.value(),
+        };
+
+        let rep_header: CreateFileResponse = self.rpc(RpcCode::CreateFile, header).await?;
+        Ok(ProtoUtils::file_status_from_pb(rep_header.file_status))
+    }
+
     pub async fn resize(&self, path: &Path, alloc_opts: FileAllocOpts) -> FsResult<FileBlocks> {
         let req = FileResizeRequest {
             path: path.encode(),

--- a/curvine-client/src/unified/unified_filesystem.rs
+++ b/curvine-client/src/unified/unified_filesystem.rs
@@ -325,6 +325,20 @@ impl UnifiedFileSystem {
         self.track("Symlink", target, link.path(), fut).await
     }
 
+    pub async fn create_special_node(
+        &self,
+        path: &Path,
+        opts: CreateFileOpts,
+    ) -> FsResult<FileStatus> {
+        let fut = async {
+            match self.get_mount_checked(path, RpcCode::CreateFile).await? {
+                None => self.cv.create_special_node(path, opts).await,
+                Some(_) => err_ext!(FsError::unsupported("mknod")),
+            }
+        };
+        self.track("CreateSpecialNode", "", path.path(), fut).await
+    }
+
     pub async fn link(&self, src_path: &Path, dst_path: &Path) -> FsResult<()> {
         let fut = async {
             let _ = self.get_mount_checked(dst_path, RpcCode::Link).await?;

--- a/curvine-common/proto/common.proto
+++ b/curvine-common/proto/common.proto
@@ -35,6 +35,9 @@ enum FileTypeProto {
     FILE_TYPE_PROTO_STREAM = 3;
     FILE_TYPE_PROTO_AGG = 4;
     FILE_TYPE_PROTO_OBJECT = 5;
+    FILE_TYPE_PROTO_FIFO = 6;
+    FILE_TYPE_PROTO_CHAR = 7;
+    FILE_TYPE_PROTO_BLOCK = 8;
 }
 
 enum StorageStateProto {

--- a/curvine-common/src/state/file_type.rs
+++ b/curvine-common/src/state/file_type.rs
@@ -42,4 +42,17 @@ pub enum FileType {
     Agg = 4,
 
     Object = 5,
+
+    Fifo = 6,
+
+    Char = 7,
+
+    Block = 8,
+}
+
+/// Extended attribute key storing the device number (little-endian u32) for special nodes.
+pub const MKNOD_RDEV_XATTR: &str = "curvine.rdev";
+
+pub fn is_special_file_type(file_type: FileType) -> bool {
+    matches!(file_type, FileType::Fifo | FileType::Char | FileType::Block)
 }

--- a/curvine-common/src/state/mod.rs
+++ b/curvine-common/src/state/mod.rs
@@ -28,7 +28,7 @@ mod worker_node_tree;
 pub use self::worker_node_tree::WorkerNodeTree;
 
 mod file_type;
-pub use self::file_type::FileType;
+pub use self::file_type::{is_special_file_type, FileType, MKNOD_RDEV_XATTR};
 
 mod ttl_action;
 pub use self::ttl_action::TtlAction;

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -29,8 +29,8 @@ use curvine_common::conf::{ClusterConf, FuseConf};
 use curvine_common::error::FsError;
 use curvine_common::fs::{FileSystem, Path, RpcCode, StateReader, StateWriter};
 use curvine_common::state::{
-    FileAllocMode, FileAllocOpts, FileLock, FileStatus, FileType, LockFlags, LockType, OpenFlags,
-    SetAttrOpts,
+    is_special_file_type, FileAllocMode, FileAllocOpts, FileLock, FileStatus, FileType, LockFlags,
+    LockType, OpenFlags, SetAttrOpts,
 };
 use curvine_common::MAX_FILE_SIZE;
 use log::{debug, info, warn};
@@ -1006,12 +1006,25 @@ impl fs::FileSystem for CurvineFileSystem {
 
     async fn read(&self, op: Read<'_>, reply: FuseResponse) -> FuseResult<()> {
         let handle = self.state.find_handle(op.header.nodeid, op.arg.fh)?;
+        if is_special_file_type(handle.status().file_type) {
+            return err_fuse!(
+                libc::EOPNOTSUPP,
+                "read not supported for special file nodes"
+            );
+        }
         handle.read(&self.state, op, reply).await
     }
 
     async fn open(&self, op: Open<'_>) -> FuseResult<fuse_open_out> {
         let action = OpenAction::try_from(op.arg.flags)?;
         let path = self.state.get_path(op.header.nodeid)?;
+        let status = self.state.fs_stat(op.header.nodeid, None).await?;
+        if is_special_file_type(status.file_type) {
+            return err_fuse!(
+                libc::EOPNOTSUPP,
+                "open not supported for special file nodes"
+            );
+        }
         let truncate = (op.arg.flags & libc::O_TRUNC as u32) != 0;
         if action.write() || truncate {
             self.ensure_writable_path(&path, RpcCode::CreateFile)
@@ -1113,6 +1126,12 @@ impl fs::FileSystem for CurvineFileSystem {
 
     async fn write(&self, op: Write<'_>, reply: FuseResponse) -> FuseResult<()> {
         let handle = self.state.find_handle(op.header.nodeid, op.arg.fh)?;
+        if is_special_file_type(handle.status().file_type) {
+            return err_fuse!(
+                libc::EOPNOTSUPP,
+                "write not supported for special file nodes"
+            );
+        }
         handle.write(op, reply).await
     }
 

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -1344,7 +1344,8 @@ impl fs::FileSystem for CurvineFileSystem {
     /// This function handles the creation of file system nodes:
     /// - For regular files: delegates to `create()` and immediately closes the handle
     /// - For directories: delegates to `mkdir()`
-    /// - For other types (devices, fifos, etc.): returns EPERM error
+    /// - For char/block/fifo device nodes: creates metadata-only special nodes
+    /// - For other types (sockets, etc.): returns EPERM error
     ///
     /// # Arguments
     /// * `op` - MkNod operation containing:
@@ -1356,6 +1357,11 @@ impl fs::FileSystem for CurvineFileSystem {
     /// * `Ok(fuse_entry_out)` - Entry information for the created node
     /// * `Err(FuseError)` - Error if creation fails or unsupported type
     async fn mk_nod(&self, op: MkNod<'_>) -> FuseResult<fuse_entry_out> {
+        let name = try_option!(op.name.to_str());
+        if name.len() > FUSE_MAX_NAME_LENGTH {
+            return err_fuse!(libc::ENAMETOOLONG);
+        }
+
         if FuseUtils::s_isreg(op.arg.mode) {
             let create_in = fuse_create_in {
                 flags: OpenFlags::new_create().value(),
@@ -1392,6 +1398,14 @@ impl fs::FileSystem for CurvineFileSystem {
                 name: op.name,
             };
             self.mkdir(op).await
+        } else if let Some(file_type) = FuseUtils::special_file_type_from_mode(op.arg.mode) {
+            let path = self.state.get_path_name(op.header.nodeid, name)?;
+            self.ensure_writable_path(&path, RpcCode::CreateFile)
+                .await?;
+            let opts = FuseUtils::mknod_opts(&op, &self.fs, file_type);
+            self.fs.create_special_node(&path, opts).await?;
+            let attr = self.state.lookup_common(op.header.nodeid, name).await?;
+            Ok(FuseUtils::create_entry_out(&self.conf, attr))
         } else {
             err_fuse!(libc::EPERM)
         }

--- a/curvine-fuse/src/fuse_utils.rs
+++ b/curvine-fuse/src/fuse_utils.rs
@@ -14,7 +14,7 @@
 
 #![allow(unused_variables)]
 
-use crate::fs::operator::{Create, MkDir};
+use crate::fs::operator::{Create, MkDir, MkNod};
 use crate::raw::fuse_abi::{fuse_attr, fuse_entry_out, fuse_setattr_in};
 use crate::*;
 use bytes::BytesMut;
@@ -23,7 +23,7 @@ use curvine_common::conf::FuseConf;
 use curvine_common::fs::Path;
 use curvine_common::state::{
     CreateFileOpts, CreateFileOptsBuilder, FileStatus, FileType, MkdirOpts, MkdirOptsBuilder,
-    SetAttrOpts,
+    SetAttrOpts, MKNOD_RDEV_XATTR,
 };
 use orpc::common::LocalTime;
 use orpc::io::IOResult;
@@ -112,16 +112,45 @@ impl FuseUtils {
     }
 
     pub fn get_mode(perm: u32, typ: FileType) -> u32 {
-        // Strip any file-type / stray high bits before OR-ing the correct type bit.
         let perm = perm & 0o7777;
         match typ {
             FileType::Dir => perm | (libc::S_IFDIR as u32),
-
             #[cfg(target_os = "linux")]
             FileType::Link => perm | (libc::S_IFLNK as u32),
-
+            #[cfg(target_os = "linux")]
+            FileType::Fifo => perm | (libc::S_IFIFO as u32),
+            #[cfg(target_os = "linux")]
+            FileType::Char => perm | (libc::S_IFCHR as u32),
+            #[cfg(target_os = "linux")]
+            FileType::Block => perm | (libc::S_IFBLK as u32),
             _ => perm | (libc::S_IFREG as u32),
         }
+    }
+
+    #[cfg(target_os = "linux")]
+    pub fn special_file_type_from_mode(mode: u32) -> Option<FileType> {
+        match mode & libc::S_IFMT as u32 {
+            t if t == libc::S_IFIFO as u32 => Some(FileType::Fifo),
+            t if t == libc::S_IFCHR as u32 => Some(FileType::Char),
+            t if t == libc::S_IFBLK as u32 => Some(FileType::Block),
+            _ => None,
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    pub fn special_file_type_from_mode(_mode: u32) -> Option<FileType> {
+        None
+    }
+
+    pub fn rdev_from_status(status: &FileStatus) -> u32 {
+        status
+            .x_attr
+            .get(MKNOD_RDEV_XATTR)
+            .and_then(|bytes| {
+                let arr: [u8; 4] = bytes.get(..4)?.try_into().ok()?;
+                Some(u32::from_le_bytes(arr))
+            })
+            .unwrap_or(0)
     }
 
     pub fn s_isreg(mode: u32) -> bool {
@@ -223,6 +252,7 @@ impl FuseUtils {
         let size = match status.file_type {
             FileType::Link => status.target.as_ref().map(|x| x.len()).unwrap_or(0) as u64,
             FileType::Dir => FUSE_DEFAULT_PAGE_SIZE as u64,
+            FileType::Fifo | FileType::Char | FileType::Block => 0,
             // Regular files (File / Stream / Agg / Object) take their size from
             // `status.len`. Defend the FUSE boundary against abnormal backend
             // data: a negative len would cast to a huge u64, so reject it.
@@ -345,6 +375,7 @@ impl FuseUtils {
 
         let perm = FuseUtils::effective_perm(status, conf.umask);
         let mode = FuseUtils::get_mode(perm, status.file_type);
+        let rdev = FuseUtils::rdev_from_status(status);
 
         // A regular file/dir has at least one link; some backends (UFS/object
         // store) do not populate nlink, leaving it 0. Report at least 1.
@@ -364,7 +395,7 @@ impl FuseUtils {
             nlink,
             uid,
             gid,
-            rdev: 0,
+            rdev,
             blksize: FUSE_BLOCK_SIZE as u32,
             padding: 0,
         })
@@ -376,6 +407,22 @@ impl FuseUtils {
                 op.header.uid,
                 op.header.gid,
                 op.arg.mode & 0o7777 & !op.arg.umask,
+            )
+            .build()
+    }
+
+    pub fn mknod_opts(
+        op: &MkNod<'_>,
+        fs: &UnifiedFileSystem,
+        file_type: FileType,
+    ) -> CreateFileOpts {
+        let mode = op.arg.mode & 0o7777 & !op.arg.umask;
+        CreateFileOptsBuilder::with_conf(&fs.conf().client)
+            .file_type(file_type)
+            .acl(op.header.uid, op.header.gid, mode)
+            .x_attr(
+                MKNOD_RDEV_XATTR.to_string(),
+                op.arg.rdev.to_le_bytes().to_vec(),
             )
             .build()
     }
@@ -796,5 +843,36 @@ mod tests {
         let mut three = file_status(FileType::File, 0, 0o644);
         three.nlink = 3;
         assert_eq!(FuseUtils::status_to_attr(&conf, &three).unwrap().nlink, 3);
+    }
+
+    #[test]
+    fn special_file_type_from_mode_maps_chr_blk_fifo() {
+        assert_eq!(
+            FuseUtils::special_file_type_from_mode(0o20777),
+            Some(FileType::Char)
+        );
+        assert_eq!(
+            FuseUtils::special_file_type_from_mode(0o60777),
+            Some(FileType::Block)
+        );
+        assert_eq!(
+            FuseUtils::special_file_type_from_mode(0o10777),
+            Some(FileType::Fifo)
+        );
+        assert!(FuseUtils::special_file_type_from_mode(0o100644).is_none());
+    }
+
+    #[test]
+    fn status_to_attr_reports_special_node_mode_and_rdev() {
+        let conf = FuseConf::default();
+        let mut chr = file_status(FileType::Char, 0, 0o777);
+        chr.x_attr
+            .insert(MKNOD_RDEV_XATTR.to_string(), 42u32.to_le_bytes().to_vec());
+
+        let attr = FuseUtils::status_to_attr(&conf, &chr).unwrap();
+        assert_eq!(attr.mode & libc::S_IFMT as u32, libc::S_IFCHR as u32);
+        assert_eq!(attr.mode & 0o7777, 0o777);
+        assert_eq!(attr.rdev, 42);
+        assert_eq!(attr.size, 0);
     }
 }

--- a/curvine-fuse/src/fuse_utils.rs
+++ b/curvine-fuse/src/fuse_utils.rs
@@ -292,7 +292,8 @@ impl FuseUtils {
         // Kernel requested POSIX_ACL support (kernel_requested_POSIX_ACL: 1048576)
         // but we disabled it in our response, yet kernel still queries ACL attributes
         match name {
-            "security.capability"
+            MKNOD_RDEV_XATTR
+            | "security.capability"
             | "security.selinux"
             | "system.posix_acl_access"
             | "system.posix_acl_default" => match op {
@@ -586,6 +587,28 @@ mod tests {
         for op in [XattrOp::Get, XattrOp::Set, XattrOp::Remove] {
             FuseUtils::check_xattr("user.curvine", op).unwrap();
         }
+    }
+
+    #[test]
+    fn mknod_rdev_xattr_is_internal_only() {
+        assert_eq!(
+            FuseUtils::check_xattr(MKNOD_RDEV_XATTR, XattrOp::Get)
+                .unwrap_err()
+                .errno(),
+            libc::ENODATA
+        );
+        assert_eq!(
+            FuseUtils::check_xattr(MKNOD_RDEV_XATTR, XattrOp::Set)
+                .unwrap_err()
+                .errno(),
+            libc::EOPNOTSUPP
+        );
+        assert_eq!(
+            FuseUtils::check_xattr(MKNOD_RDEV_XATTR, XattrOp::Remove)
+                .unwrap_err()
+                .errno(),
+            libc::EOPNOTSUPP
+        );
     }
 
     #[test]

--- a/curvine-server/src/master/meta/inode/inode_file.rs
+++ b/curvine-server/src/master/meta/inode/inode_file.rs
@@ -17,8 +17,8 @@ use crate::master::meta::inode::{Inode, EMPTY_PARENT_ID};
 use crate::master::meta::store::InodeStore;
 use crate::master::meta::{BlockMeta, InodeId};
 use curvine_common::state::{
-    BlockLocation, CommitBlock, CreateFileOpts, ExtendedBlock, FileAllocOpts, FileType,
-    StoragePolicy,
+    is_special_file_type, BlockLocation, CommitBlock, CreateFileOpts, ExtendedBlock, FileAllocOpts,
+    FileType, StoragePolicy,
 };
 use curvine_common::FsResult;
 use orpc::common::LocalTime;
@@ -110,7 +110,7 @@ impl InodeFile {
             parent_id: EMPTY_PARENT_ID,
         };
 
-        if !opts.sync_ufs_meta {
+        if !opts.sync_ufs_meta && !is_special_file_type(opts.file_type) {
             file.features.set_writing(opts.client_name);
         }
         if !opts.x_attr.is_empty() {

--- a/repair-plan.json
+++ b/repair-plan.json
@@ -1,29 +1,35 @@
 {
-  "issue": "CurvineIO/curvine#1207",
-  "multica_issue": "CUR-61",
-  "fingerprint": "sha256:15fb19075be2d2fe6df145554fc1c3d1453d5a79ff97ee56eaa5b0ca69fe94bb",
-  "head_sha": "ea9978a4b77ead56a2ea59b41cd05ef66cbbda41",
-  "root_cause_hypothesis": "Under nextest load, the 2-master test cluster loses raft quorum (`quorum is not active`). A subsequent snapshot apply restores from an empty checkpoint (checkpoint_size=0, create_tree files=0), wiping metadata so FileStatus(/repl_test_3.dat) returns FileNotFound. Isolated runs pass; the wipe—not replication itself—is the failure mode.",
+  "issue": "CurvineIO/curvine#1228",
+  "multica_issue": "CUR-76",
+  "fingerprint": "sha256:8aa77797ff629acebb4c0e5bae7fd88da400e9a39222d2e40da8a06345634fc8",
+  "head_sha": "b5db9cb2fc576e49e0c7ba68235d3cdb2358e90c",
+  "root_cause_hypothesis": "curvine-fuse mk_nod delegates char/block/fifo creation to EPERM; metadata layer lacks special-file FileType and rdev reporting.",
   "affected_modules": [
-    "curvine-server/src/master/journal/journal_loader.rs"
+    "curvine-common/src/state/file_type.rs",
+    "curvine-common/proto/common.proto",
+    "curvine-server/src/master/meta/inode/inode_file.rs",
+    "curvine-client/src/file/fs_client.rs",
+    "curvine-fuse/src/fuse_utils.rs",
+    "curvine-fuse/src/fs/curvine_file_system.rs"
   ],
   "planned_changes": [
-    "Before fs_dir.restore in apply_snapshot0, compute actual checkpoint dir size (independent of log level).",
-    "If the checkpoint is empty and the live filesystem already has files, refuse the apply instead of wiping metadata."
+    "Add FileType Fifo/Char/Block and persist rdev in x_attr on create.",
+    "Create special nodes via CreateFile RPC without entering write-in-progress state.",
+    "Implement FUSE mk_nod for S_IFCHR/S_IFBLK/S_IFIFO and report correct mode+rdev in getattr."
   ],
   "not_goals": [
-    "Do not change replication manager job scheduling.",
-    "Do not rewrite raft election/quorum timeouts in this PR.",
-    "Do not weaken legitimate format/empty-cluster bootstrap (still allow empty apply when live FS has no files)."
+    "Do not implement S_IFSOCK or kernel loop-device mknod07 cases.",
+    "Do not change unrelated fcntl/fallocate/FIO paths.",
+    "Do not add new RPC codes; reuse CreateFile."
   ],
   "verification_plan": [
-    "cargo test -p curvine-tests --test replication_test test_replication_with_simulated_worker_failure",
-    "cargo test -p curvine-server --test journal_test (snapshot-related if present)",
-    "Unit-level coverage via journal_loader refusal path if testable"
+    "cargo fmt --all",
+    "cargo clippy -p curvine-fuse -p curvine-common -p curvine-client -p curvine-server -- -D warnings",
+    "cargo test -p curvine-fuse fuse_utils::"
   ],
-  "estimated_non_generated_source_line_delta": 40,
+  "estimated_non_generated_source_line_delta": 120,
   "risk": {
-    "level": "medium",
-    "rationale": "Changes HA snapshot apply safety. Rejecting a bad empty snapshot is safer than wiping production metadata, but a node may remain on older FSM state until a valid snapshot/log catch-up; needs harness daily rerun."
+    "level": "low",
+    "rationale": "Additive metadata types and FUSE mknod path; special files are metadata-only and do not allocate blocks."
   }
 }


### PR DESCRIPTION
<!-- curvine-automation:issue:CurvineIO/curvine#1228 -->
<!-- curvine-automation:fingerprint:sha256:8aa77797ff629acebb4c0e5bae7fd88da400e9a39222d2e40da8a06345634fc8 -->

## Summary

Enable FUSE/JFS `mknod(2)` for character devices, block devices, and FIFOs. Special nodes are stored as metadata-only inodes with device numbers persisted in extended attributes and reported through `getattr`.

## Related GitHub Issue

Fixes #1228

## Root cause

`curvine-fuse` `mk_nod` only delegated regular files and directories; all other `mknod` modes returned `EPERM`. The metadata layer also lacked `FileType` values and `rdev` reporting needed for POSIX special files.

## Changes

- Add `FileType::Fifo`, `FileType::Char`, and `FileType::Block` with matching protobuf enum values.
- Create special nodes through `CreateFile` without entering write-in-progress state; store `rdev` in `curvine.rdev` xattr.
- Implement FUSE `mk_nod` for `S_IFCHR` / `S_IFBLK` / `S_IFIFO` and return correct mode and `rdev` in attributes.

## Test verified

- `cargo fmt --all`
- `cargo clippy -p curvine-fuse -p curvine-common -p curvine-client -p curvine-server -- -D warnings`
- `cargo test -p curvine-fuse special_file_type_from_mode_maps`
- `cargo test -p curvine-fuse status_to_attr_reports_special_node`

## Dependencies

None.
