### PR TITLE
fix(fuse): stop advertising FUSE_EXPORT_SUPPORT until root ./.. lookup works (#1088)

### DIFF
--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -1598,9 +1598,9 @@ mod tests {
     use super::CurvineFileSystem;
     use crate::{
         fuse_init_flag_names, FUSE_ATOMIC_O_TRUNC, FUSE_BIG_WRITES, FUSE_DO_READDIRPLUS,
-        FUSE_FLOCK_LOCKS, FUSE_HAS_IOCTL_DIR, FUSE_KERNEL_MINOR_VERSION, FUSE_KERNEL_VERSION,
-        FUSE_MAX_PAGES, FUSE_POSIX_ACL, FUSE_POSIX_LOCKS, FUSE_SPLICE_MOVE, FUSE_SPLICE_READ,
-        FUSE_SPLICE_WRITE, FUSE_WRITEBACK_CACHE, SUPPORTED_INIT_FLAGS,
+        FUSE_EXPORT_SUPPORT, FUSE_FLOCK_LOCKS, FUSE_HAS_IOCTL_DIR, FUSE_KERNEL_MINOR_VERSION,
+        FUSE_KERNEL_VERSION, FUSE_MAX_PAGES, FUSE_POSIX_ACL, FUSE_POSIX_LOCKS, FUSE_SPLICE_MOVE,
+        FUSE_SPLICE_READ, FUSE_SPLICE_WRITE, FUSE_WRITEBACK_CACHE, SUPPORTED_INIT_FLAGS,
     };
 
     #[test]
@@ -1642,13 +1642,36 @@ mod tests {
     // #1122 + allowlist: the daemon must never advertise FUSE_ATOMIC_O_TRUNC
     // (open does not truncate) or any other unsupported capability, even when
     // the kernel offers it. The allowlist mask drops them.
+    //
+    // FUSE_EXPORT_SUPPORT is included here (dropped even when offered): its `.`/`..`
+    // reconstruction relies on root `.`/`..` lookups that currently return ENOENT,
+    // so the daemon must not advertise it. Not advertising it leaves the kernel's
+    // `fc->export_support` unset, so the kernel never issues the root `.`/`..` LOOKUP.
     #[test]
     fn negotiate_out_flags_drops_unsupported_kernel_caps() {
-        let unsupported = FUSE_ATOMIC_O_TRUNC | FUSE_POSIX_ACL | FUSE_HAS_IOCTL_DIR | (1u32 << 30);
+        let unsupported = FUSE_ATOMIC_O_TRUNC
+            | FUSE_POSIX_ACL
+            | FUSE_HAS_IOCTL_DIR
+            | FUSE_EXPORT_SUPPORT
+            | (1u32 << 30);
         let out = CurvineFileSystem::negotiate_out_flags(unsupported, false, false);
         assert_eq!(
             out, 0,
             "no unsupported kernel-offered bit may be advertised"
+        );
+    }
+
+    // EXPORT_SUPPORT must NOT be in the allowlist: advertising it turns on the
+    // kernel's `.`/`..` handle-reconstruction path, which the daemon cannot serve
+    // (root `.`/`..` lookups return ENOENT). This pins that a future edit cannot
+    // silently re-add it. Paired with `negotiate_out_flags_drops_unsupported_kernel_caps`
+    // (proves it is dropped even when the kernel offers it).
+    #[test]
+    fn export_support_not_in_allowlist() {
+        assert_eq!(
+            SUPPORTED_INIT_FLAGS & FUSE_EXPORT_SUPPORT,
+            0,
+            "FUSE_EXPORT_SUPPORT must not be advertised until root `.`/`..` lookup works"
         );
     }
 
@@ -1764,6 +1787,10 @@ mod tests {
         let names = fuse_init_flag_names(FUSE_BIG_WRITES | unknown);
         assert!(names.contains(&"BIG_WRITES".to_string()));
         assert!(names.iter().any(|n| n == "0x40000000"));
+        // EXPORT_SUPPORT stays wired into logging even though it left the allowlist
+        // (the documented reason the constant is retained), so an offered-but-dropped
+        // bit is still rendered by name rather than as an opaque hex token.
+        assert!(fuse_init_flag_names(FUSE_EXPORT_SUPPORT).contains(&"EXPORT_SUPPORT".to_string()));
     }
 
     #[test]

--- a/curvine-fuse/src/fs/state/node_state.rs
+++ b/curvine-fuse/src/fs/state/node_state.rs
@@ -851,13 +851,19 @@ impl NodeState {
     }
 
     pub async fn fs_lookup(&self, ino: u64, name: &str) -> FuseResult<fuse_attr> {
-        // NOTE: the `.`/`..` branches below are BROKEN for the root inode: root's
-        // `parent` is the `0` sentinel, so `LOOKUP(root, ".")` resolves to `(0, "/")`
-        // and `LOOKUP(root, "..")` does `get_inode_check(0)` — both miss (inode 0 does
-        // not exist) and return ENOENT. This is why `FUSE_EXPORT_SUPPORT` is kept out
-        // of `SUPPORTED_INIT_FLAGS` (see `crate::FUSE_EXPORT_SUPPORT`): advertising it
-        // is the only thing that makes the kernel send a root `.`/`..` LOOKUP. If this
-        // is ever fixed to handle root correctly, revisit re-adding that capability.
+        // NOTE: the `.`/`..` branches below are BROKEN wherever they resolve through
+        // the root, because root's `parent` is the `0` sentinel and inode 0 does not
+        // exist. Two cases both miss and return ENOENT:
+        //   - `LOOKUP(root, ".")` -> `(root.parent, ..)` = `(0, "/")`, and
+        //     `LOOKUP(root, "..")` -> `get_inode_check(root.parent=0)`.
+        //   - `LOOKUP(child_of_root, "..")` -> `get_inode_check(parent.parent)` where
+        //     `parent` is root, i.e. `get_inode_check(0)` — so ANY direct child of the
+        //     mount root fails too, not just the root inode.
+        // This is why `FUSE_EXPORT_SUPPORT` is kept out of `SUPPORTED_INIT_FLAGS` (see
+        // `crate::FUSE_EXPORT_SUPPORT`): advertising it is the only thing that makes
+        // the kernel send these `.`/`..` LOOKUPs (`fuse_get_parent` walks `..` for any
+        // direct child of the mount root). A follow-up that re-adds the capability must
+        // special-case `parent == root` (and root itself), not only `LOOKUP(root, .)`.
         let (ino, cow_name) = if name == FUSE_CURRENT_DIR {
             let dir = self.dir_read();
             let inode = dir.get_inode_check(ino, None)?;

--- a/curvine-fuse/src/fs/state/node_state.rs
+++ b/curvine-fuse/src/fs/state/node_state.rs
@@ -851,6 +851,13 @@ impl NodeState {
     }
 
     pub async fn fs_lookup(&self, ino: u64, name: &str) -> FuseResult<fuse_attr> {
+        // NOTE: the `.`/`..` branches below are BROKEN for the root inode: root's
+        // `parent` is the `0` sentinel, so `LOOKUP(root, ".")` resolves to `(0, "/")`
+        // and `LOOKUP(root, "..")` does `get_inode_check(0)` — both miss (inode 0 does
+        // not exist) and return ENOENT. This is why `FUSE_EXPORT_SUPPORT` is kept out
+        // of `SUPPORTED_INIT_FLAGS` (see `crate::FUSE_EXPORT_SUPPORT`): advertising it
+        // is the only thing that makes the kernel send a root `.`/`..` LOOKUP. If this
+        // is ever fixed to handle root correctly, revisit re-adding that capability.
         let (ino, cow_name) = if name == FUSE_CURRENT_DIR {
             let dir = self.dir_read();
             let inode = dir.get_inode_check(ino, None)?;

--- a/curvine-fuse/src/lib.rs
+++ b/curvine-fuse/src/lib.rs
@@ -126,12 +126,13 @@ pub const FUSE_AUTO_INVAL_DATA: u32 = 1 << 12;
 /// `LOOKUP(nodeid, ".")` / `LOOKUP(nodeid, "..")` reconstruction.
 ///
 /// Deliberately NOT in `SUPPORTED_INIT_FLAGS` (see there): the reconstruction it
-/// promises relies on `NodeState::fs_lookup` handling root `.`/`..`, which today
-/// returns ENOENT for the root inode (root's `parent` is the `0` sentinel, so
-/// `LOOKUP(root, ".")` resolves to `(0, "/")` and `LOOKUP(root, "..")` hits
-/// `get_inode_check(0)` — both miss). Advertising the cap would expose a protocol
-/// path the daemon cannot satisfy. The constant is retained for
-/// `fuse_init_flag_names` (so an offered-but-not-enabled bit is still logged).
+/// promises relies on `NodeState::fs_lookup` handling `.`/`..` through the root,
+/// which today returns ENOENT wherever the resolution hits root's `0`-sentinel
+/// parent — both `LOOKUP(root, "."/"..")` AND `LOOKUP(child_of_root, "..")` (any
+/// direct child of the mount root, which is exactly what `fuse_get_parent` walks).
+/// Advertising the cap would expose a protocol path the daemon cannot satisfy; a
+/// follow-up must special-case `parent == root` (and root itself). The constant is
+/// retained for `fuse_init_flag_names` (so an offered-but-not-enabled bit is logged).
 pub const FUSE_EXPORT_SUPPORT: u32 = 1 << 4;
 
 /// Kernel init capability bit: the daemon handles O_TRUNC atomically inside

--- a/curvine-fuse/src/lib.rs
+++ b/curvine-fuse/src/lib.rs
@@ -124,6 +124,14 @@ pub const FUSE_AUTO_INVAL_DATA: u32 = 1 << 12;
 
 /// Kernel exportfs support: enables `name_to_handle_at` / `open_by_handle_at` via
 /// `LOOKUP(nodeid, ".")` / `LOOKUP(nodeid, "..")` reconstruction.
+///
+/// Deliberately NOT in `SUPPORTED_INIT_FLAGS` (see there): the reconstruction it
+/// promises relies on `NodeState::fs_lookup` handling root `.`/`..`, which today
+/// returns ENOENT for the root inode (root's `parent` is the `0` sentinel, so
+/// `LOOKUP(root, ".")` resolves to `(0, "/")` and `LOOKUP(root, "..")` hits
+/// `get_inode_check(0)` — both miss). Advertising the cap would expose a protocol
+/// path the daemon cannot satisfy. The constant is retained for
+/// `fuse_init_flag_names` (so an offered-but-not-enabled bit is still logged).
 pub const FUSE_EXPORT_SUPPORT: u32 = 1 << 4;
 
 /// Kernel init capability bit: the daemon handles O_TRUNC atomically inside
@@ -143,20 +151,27 @@ pub const FUSE_ATOMIC_O_TRUNC: u32 = 1 << 3;
 /// every kernel-offered flag. Each bit here maps to a real implementation:
 /// ASYNC_READ/ASYNC_DIO (async read + direct-io pipeline), BIG_WRITES (writer
 /// handles >4KiB writes), AUTO_INVAL_DATA (kernel auto-invalidates page cache on
-/// open), EXPORT_SUPPORT (`.`/`..` lookup reconstruction), READDIRPLUS_AUTO +
-/// DO_READDIRPLUS (`read_dir_plus`), POSIX_LOCKS + FLOCK_LOCKS
-/// (`get_lk`/`set_lk`/`set_lkw`), MAX_PAGES (negotiated only if the kernel offers it).
+/// open), READDIRPLUS_AUTO + DO_READDIRPLUS (`read_dir_plus`), POSIX_LOCKS +
+/// FLOCK_LOCKS (`get_lk`/`set_lk`/`set_lkw`), MAX_PAGES (negotiated only if the
+/// kernel offers it).
 ///
 /// Deliberately EXCLUDED (never advertised): FUSE_ATOMIC_O_TRUNC (open does not
 /// truncate, #1122), FUSE_POSIX_ACL (no ACL handling), FUSE_HAS_IOCTL_DIR (no
-/// ioctl), and any unknown/future kernel bit. FUSE_WRITEBACK_CACHE and the
-/// FUSE_SPLICE_* bits are config-gated daemon-requested caps handled separately
-/// (see `negotiate_out_flags`), not part of this kernel-masked allowlist.
+/// ioctl), FUSE_EXPORT_SUPPORT (its `.`/`..` reconstruction relies on root
+/// `.`/`..` lookups that currently return ENOENT — see `FUSE_EXPORT_SUPPORT`),
+/// and any unknown/future kernel bit. FUSE_WRITEBACK_CACHE and the FUSE_SPLICE_*
+/// bits are config-gated daemon-requested caps handled separately (see
+/// `negotiate_out_flags`), not part of this kernel-masked allowlist.
+///
+/// Not advertising EXPORT_SUPPORT is sufficient to keep the broken root `.`/`..`
+/// path unreachable: the kernel's `fuse_get_parent` / `fuse_get_dentry` (the only
+/// sites that emit a `.`/`..` LOOKUP to the daemon) both short-circuit with
+/// `-ESTALE` when `fc->export_support` is unset, and normal path walk resolves
+/// `.`/`..` in-kernel without a FUSE request.
 pub const SUPPORTED_INIT_FLAGS: u32 = FUSE_ASYNC_READ
     | FUSE_BIG_WRITES
     | FUSE_ASYNC_DIO
     | FUSE_AUTO_INVAL_DATA
-    | FUSE_EXPORT_SUPPORT
     | FUSE_READDIRPLUS_AUTO
     | FUSE_DO_READDIRPLUS
     | FUSE_POSIX_LOCKS


### PR DESCRIPTION
# Summary

The FUSE init capability allowlist (#1189) advertised `FUSE_EXPORT_SUPPORT`, but the daemon cannot serve the `.`/`..` handle-reconstruction that capability promises. This removes it from `SUPPORTED_INIT_FLAGS` so the daemon stops advertising a protocol path it cannot satisfy.

# Issue Describe / Design

Relates to #1088 (follow-up to the init capability-allowlist work merged in #1189; #1088 is already closed).

## Root cause

`FUSE_EXPORT_SUPPORT` tells the kernel the filesystem supports NFS-style file-handle → inode reconstruction (`name_to_handle_at` / `open_by_handle_at`, NFS re-export), which the kernel drives via `LOOKUP(nodeid, ".")` / `LOOKUP(nodeid, "..")`. But `NodeState::fs_lookup` returns ENOENT for the **root** inode's `.`/`..`:

- root's `parent` is the `0` sentinel (`Inode::new_root`), so `LOOKUP(root, ".")` resolves to `(0, "/")` → `get_path_name(0, "/")` → `get_inode_check(0)` misses;
- `LOOKUP(root, "..")` does `get_inode_check(parent_inode.parent = 0)` → misses.

Advertising the capability therefore exposes a path the daemon answers with ENOENT.

## Fix (conservative)

Remove `FUSE_EXPORT_SUPPORT` from `SUPPORTED_INIT_FLAGS`. This alone makes the broken path unreachable, verified against the Linux kernel source (`fs/fuse/inode.c`, v5.15 and mainline):

- `fuse_get_parent` (the only site issuing `LOOKUP(child, "..")`) does `if (!fc->export_support) return ERR_PTR(-ESTALE);` before any request;
- `fuse_get_dentry` (the only site issuing `LOOKUP(nodeid, ".")`) does `if (!fc->export_support) goto out_err;` before `fuse_lookup_name`;
- `process_init_reply` sets `fc->export_support = 1` only if the daemon echoes the flag — which it no longer does, so both sites short-circuit;
- normal VFS path walk resolves `.`/`..` in-kernel (`handle_dots`) without a FUSE request, and dentry revalidate uses the real entry name, never literal `.`/`..`.

The constant is retained (still used by `fuse_init_flag_names`, so an offered-but-dropped bit is still logged by name). This does **not** fix root `.`/`..` in `fs_lookup` — that is a deliberate scope choice; a follow-up may implement it and re-add the capability. A breadcrumb at the `fs_lookup` root branches cross-references the constant.

## Behavior change

The mount is no longer advertised as NFS-exportable / usable with `open_by_handle_at` reconstruction. Since that capability never actually worked (root `.`/`..` → ENOENT), this removes a broken advertisement rather than a working feature. `.`/`..` entries in `ls -la` come from readdir's synthetic dot entries and are unaffected.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-fuse/src/lib.rs` | Remove `FUSE_EXPORT_SUPPORT` from `SUPPORTED_INIT_FLAGS`; document why (kernel gating + root `.`/`..` gap); constant retained for logging | Daemon no longer advertises exportfs; no other cap affected |
| `curvine-fuse/src/fs/state/node_state.rs` | Breadcrumb comment at the `fs_lookup` root `.`/`..` branches cross-referencing the constant | None (comment only) |
| `curvine-fuse/src/fs/curvine_file_system.rs` | `negotiate_out_flags_drops_unsupported_kernel_caps` now covers `FUSE_EXPORT_SUPPORT`; new `export_support_not_in_allowlist` regression; flag-names test pins it stays wired into logging | None (tests) |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-fuse --lib fs::curvine_file_system::tests` | PASS | 18 passed |
| `export_support_not_in_allowlist` | PASS | `SUPPORTED_INIT_FLAGS & FUSE_EXPORT_SUPPORT == 0` |
| `negotiate_out_flags_drops_unsupported_kernel_caps` | PASS | EXPORT_SUPPORT dropped even when kernel offers it |
| `fuse_init_flag_names_maps_known_and_unknown` | PASS | EXPORT_SUPPORT still rendered by name in logs |
| `cargo fmt -p curvine-fuse -- --check` / `cargo clippy -p curvine-fuse --lib --tests` | PASS | no warnings |

# Dependencies

- Related PRs: #1189 (init capability allowlist, introduced the advertisement)
- Related issues: #1088
- Blocks / blocked by: None