### PR TITLE
fix(fuse): harden stream worker lifecycle (#1119)

### DIFF
--- a/curvine-client/src/block/block_writer.rs
+++ b/curvine-client/src/block/block_writer.rs
@@ -19,12 +19,32 @@ use crate::block::{BlockWriterLocal, BlockWriterRemote};
 use crate::file::FsContext;
 use curvine_common::state::{BlockLocation, CommitBlock, LocatedBlock, StorageType, WorkerAddress};
 use curvine_common::FsResult;
-use futures::future::try_join_all;
+use futures::future::{join_all, try_join_all};
 use orpc::err_box;
 use orpc::error::ErrorExt;
 use orpc::runtime::{RpcRuntime, Runtime};
 use orpc::sys::DataSlice;
 use std::sync::Arc;
+
+async fn finish_all_cancellations<I, F>(futures: I) -> FsResult<()>
+where
+    I: IntoIterator<Item = F>,
+    F: std::future::Future<Output = FsResult<()>>,
+{
+    let mut first_error = None;
+    for result in join_all(futures).await {
+        if let Err(e) = result {
+            if first_error.is_none() {
+                first_error = Some(e);
+            }
+        }
+    }
+
+    match first_error {
+        Some(e) => Err(e),
+        None => Ok(()),
+    }
+}
 
 enum WriterAdapter {
     Local(BlockWriterLocal),
@@ -226,17 +246,16 @@ impl BlockWriter {
     }
 
     pub async fn cancel(&mut self) -> FsResult<()> {
-        let futures = self.inners.iter_mut().map(|writer| async move {
-            writer
-                .cancel()
-                .await
-                .map_err(|e| (writer.worker_address().clone(), e))
+        let futures = self.inners.iter_mut().map(|writer| {
+            let worker_addr = writer.worker_address().clone();
+            async move {
+                writer
+                    .cancel()
+                    .await
+                    .map_err(|e| e.ctx(format!("failed to cancel block on {}", worker_addr)))
+            }
         });
-
-        if let Err((worker_addr, e)) = try_join_all(futures).await {
-            return Err(e.ctx(format!("failed to cancel block on {}", worker_addr)));
-        }
-        Ok(())
+        finish_all_cancellations(futures).await
     }
 
     pub fn remaining(&self) -> i64 {
@@ -299,5 +318,36 @@ impl BlockWriter {
             block_len: self.len(),
             locations: locs,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::finish_all_cancellations;
+    use curvine_common::error::FsError;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn cancellation_attempts_all_futures_and_returns_an_error() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let futures = (0..3).map(|index| {
+            let attempts = attempts.clone();
+            async move {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                if index == 1 {
+                    Err(FsError::common("injected cancellation failure"))
+                } else {
+                    Ok(())
+                }
+            }
+        });
+
+        assert!(finish_all_cancellations(futures).await.is_err());
+        assert_eq!(
+            attempts.load(Ordering::SeqCst),
+            3,
+            "one failure must not prevent the remaining cancellations"
+        );
     }
 }

--- a/curvine-client/src/file/fs_writer.rs
+++ b/curvine-client/src/file/fs_writer.rs
@@ -122,7 +122,10 @@ impl Writer for FsWriter {
     }
 
     async fn cancel(&mut self) -> FsResult<()> {
-        Ok(())
+        // Bytes still in the front buffer have never reached the backend and
+        // must not be flushed after cancellation.
+        self.buf.clear();
+        self.inner.cancel().await
     }
 
     async fn seek(&mut self, pos: i64) -> FsResult<()> {

--- a/curvine-client/src/file/fs_writer_base.rs
+++ b/curvine-client/src/file/fs_writer_base.rs
@@ -14,6 +14,7 @@
 
 use crate::block::BlockWriter;
 use crate::file::{FsClient, FsContext};
+use curvine_common::error::FsError;
 use curvine_common::fs::Path;
 use curvine_common::state::{FileAllocOpts, FileBlocks, FileStatus, WriteFileBlocks};
 use curvine_common::FsResult;
@@ -156,6 +157,33 @@ impl FsWriterBase {
     pub async fn complete(&mut self) -> FsResult<()> {
         self.complete0(false).await?;
         Ok(())
+    }
+
+    /// Cancel every block writer that still owns an uncommitted backend write
+    /// session. Cleanup is best effort: keep the first error for the caller, but
+    /// continue cancelling the remaining writers before dropping their state.
+    pub async fn cancel(&mut self) -> FsResult<()> {
+        let mut first_error: Option<FsError> = None;
+
+        if let Some(mut writer) = self.cur_writer.take() {
+            if let Err(e) = writer.cancel().await {
+                first_error = Some(e);
+            }
+        }
+
+        for (_, writer) in self.cache_writers.iter_mut() {
+            if let Err(e) = writer.cancel().await {
+                if first_error.is_none() {
+                    first_error = Some(e);
+                }
+            }
+        }
+        self.cache_writers.clear();
+
+        match first_error {
+            Some(e) => Err(e),
+            None => Ok(()),
+        }
     }
 
     async fn complete0(&mut self, only_flush: bool) -> FsResult<Option<FileBlocks>> {

--- a/curvine-client/src/file/fs_writer_base.rs
+++ b/curvine-client/src/file/fs_writer_base.rs
@@ -16,10 +16,12 @@ use crate::block::BlockWriter;
 use crate::file::{FsClient, FsContext};
 use curvine_common::error::FsError;
 use curvine_common::fs::Path;
-use curvine_common::state::{FileAllocOpts, FileBlocks, FileStatus, WriteFileBlocks};
+use curvine_common::state::{CommitBlock, FileAllocOpts, FileBlocks, FileStatus, WriteFileBlocks};
 use curvine_common::FsResult;
 use fxhash::FxHasher;
 use linked_hash_map::LinkedHashMap;
+use log::warn;
+use orpc::common::FastHashSet;
 use orpc::runtime::{RpcRuntime, Runtime};
 use orpc::sys::DataSlice;
 use orpc::{err_box, try_option_mut};
@@ -38,6 +40,12 @@ pub struct FsWriterBase {
 
     cache_limit: usize,
     cache_writers: LinkedHashMap<i64, BlockWriter, BuildHasherDefault<FxHasher>>,
+    /// Blocks whose contents must not be aborted during abnormal cleanup.
+    ///
+    /// This includes blocks already visible in the file when the writer was
+    /// opened, blocks published by a successful flush, and blocks finalized on
+    /// workers but still waiting for their commit metadata to reach the master.
+    durable_blocks: FastHashSet<i64>,
 }
 
 impl FsWriterBase {
@@ -45,6 +53,14 @@ impl FsWriterBase {
         let fs_client = FsClient::new(fs_context.clone());
         let cache_limit = fs_context.conf.client.max_cache_block_handles;
         let len = status.len;
+        let durable_blocks = FastHashSet::with_vec(
+            status
+                .block_locs
+                .iter()
+                .filter(|block| block.block.len > 0 && !block.locs.is_empty())
+                .map(|block| block.block.id)
+                .collect(),
+        );
         let file_blocks = WriteFileBlocks::new(status);
 
         let cache_writers = LinkedHashMap::with_capacity_and_hasher(
@@ -61,6 +77,7 @@ impl FsWriterBase {
             cur_writer: None,
             cache_limit,
             cache_writers,
+            durable_blocks,
         }
     }
 
@@ -159,26 +176,105 @@ impl FsWriterBase {
         Ok(())
     }
 
-    /// Cancel every block writer that still owns an uncommitted backend write
-    /// session. Cleanup is best effort: keep the first error for the caller, but
-    /// continue cancelling the remaining writers before dropping their state.
+    fn add_durable_commit(&mut self, commit: CommitBlock) -> FsResult<()> {
+        let block_id = commit.block_id;
+        self.file_blocks.add_commit(commit)?;
+        self.durable_blocks.insert(block_id);
+        Ok(())
+    }
+
+    fn restore_commit_blocks(&mut self, commits: &[CommitBlock]) {
+        for commit in commits {
+            if let Err(e) = self.add_durable_commit(commit.clone()) {
+                warn!(
+                    "failed to restore pending commit for block {}: {}",
+                    commit.block_id, e
+                );
+            }
+        }
+    }
+
+    fn committed_len(&self) -> i64 {
+        self.file_blocks
+            .block_locs
+            .iter()
+            .map(|block| block.block.len)
+            .sum()
+    }
+
+    /// Clean up every backend write session without invalidating durable data.
+    ///
+    /// A brand-new block that has never been flushed/finalized can be aborted.
+    /// Once a block was published by flush, existed before this writer, or was
+    /// finalized on a worker, aborting it would delete data the master may
+    /// already reference. Such a block is finalized instead, and any pending
+    /// commit metadata is submitted to the master with `only_flush=true`.
+    /// Cleanup remains best effort: preserve the first error while attempting
+    /// all remaining writers and the metadata submission.
     pub async fn cancel(&mut self) -> FsResult<()> {
         let mut first_error: Option<FsError> = None;
+        let mut cleanup_commits = Vec::new();
 
         if let Some(mut writer) = self.cur_writer.take() {
-            if let Err(e) = writer.cancel().await {
+            if self.durable_blocks.contains(&writer.block_id()) {
+                match writer.complete().await {
+                    Ok(commit) => cleanup_commits.push(commit),
+                    Err(e) => first_error = Some(e),
+                }
+            } else if let Err(e) = writer.cancel().await {
                 first_error = Some(e);
             }
         }
 
         for (_, writer) in self.cache_writers.iter_mut() {
-            if let Err(e) = writer.cancel().await {
+            if self.durable_blocks.contains(&writer.block_id()) {
+                match writer.complete().await {
+                    Ok(commit) => cleanup_commits.push(commit),
+                    Err(e) => {
+                        if first_error.is_none() {
+                            first_error = Some(e);
+                        }
+                    }
+                }
+            } else if let Err(e) = writer.cancel().await {
                 if first_error.is_none() {
                     first_error = Some(e);
                 }
             }
         }
         self.cache_writers.clear();
+
+        for commit in cleanup_commits {
+            if let Err(e) = self.add_durable_commit(commit) {
+                if first_error.is_none() {
+                    first_error = Some(e);
+                }
+            }
+        }
+
+        let commit_blocks = self.file_blocks.take_commit_blocks();
+        if !commit_blocks.is_empty() {
+            let committed_len = self.committed_len();
+            let result = self
+                .fs_client
+                .complete_file_by_id(
+                    &self.path,
+                    self.file_blocks.status.id,
+                    committed_len,
+                    commit_blocks.clone(),
+                    true,
+                )
+                .await;
+            if let Err(e) = result {
+                // Retain the metadata in case the owner can retry cleanup. More
+                // importantly, never compensate an ambiguous master response by
+                // deleting blocks that may already have been published.
+                self.restore_commit_blocks(&commit_blocks);
+                if first_error.is_none() {
+                    first_error = Some(e);
+                }
+            }
+        }
 
         match first_error {
             Some(e) => Err(e),
@@ -191,6 +287,7 @@ impl FsWriterBase {
             self.cache_writers.insert(writer.block_id(), writer);
         };
 
+        let mut writer_commits = Vec::with_capacity(self.cache_writers.len());
         for (_, writer) in self.cache_writers.iter_mut() {
             let commit_block = if only_flush {
                 writer.flush().await?;
@@ -199,23 +296,39 @@ impl FsWriterBase {
                 writer.complete().await?
             };
 
-            self.file_blocks.add_commit(commit_block)?;
+            writer_commits.push(commit_block);
+        }
+
+        for commit in writer_commits {
+            self.file_blocks.add_commit(commit)?;
         }
 
         if !only_flush {
             self.cache_writers.clear();
         }
 
-        let commits_blocks = self.file_blocks.take_commit_blocks();
-        self.fs_client
+        let commit_blocks = self.file_blocks.take_commit_blocks();
+        // From this point onward a request may have reached the master even if
+        // its response is lost. Treat every submitted block as durable before
+        // crossing that ambiguity boundary so later cleanup never aborts it.
+        for commit in &commit_blocks {
+            self.durable_blocks.insert(commit.block_id);
+        }
+
+        let result = self
+            .fs_client
             .complete_file_by_id(
                 &self.path,
                 self.file_blocks.status.id,
                 self.len,
-                commits_blocks,
+                commit_blocks.clone(),
                 only_flush,
             )
-            .await
+            .await;
+        if result.is_err() {
+            self.restore_commit_blocks(&commit_blocks);
+        }
+        result
     }
 
     async fn get_writer(&mut self) -> FsResult<&mut BlockWriter> {
@@ -265,16 +378,23 @@ impl FsWriterBase {
 
                         let commit_blocks = self.file_blocks.take_commit_blocks();
                         let last_block = self.file_blocks.last_block();
-                        let lb = self
+                        let add_result = self
                             .fs_client
                             .add_block_by_id(
                                 &self.path,
                                 self.file_blocks.status.id,
-                                commit_blocks,
+                                commit_blocks.clone(),
                                 self.len,
                                 last_block,
                             )
-                            .await?;
+                            .await;
+                        let lb = match add_result {
+                            Ok(block) => block,
+                            Err(e) => {
+                                self.restore_commit_blocks(&commit_blocks);
+                                return Err(e);
+                            }
+                        };
                         self.file_blocks.add_block(lb.clone())?;
                         let writer = BlockWriter::new(
                             self.fs_context.clone(),
@@ -329,13 +449,13 @@ impl FsWriterBase {
             if self.cache_writers.len() >= self.cache_limit {
                 if let Some((_, mut removed)) = self.cache_writers.pop_front() {
                     let commit_blocks = removed.complete().await?;
-                    self.file_blocks.add_commit(commit_blocks)?;
+                    self.add_durable_commit(commit_blocks)?;
                 }
             }
             self.cache_writers.insert(old.block_id(), old);
         } else {
             let commit_blocks = old.complete().await?;
-            self.file_blocks.add_commit(commit_blocks)?;
+            self.add_durable_commit(commit_blocks)?;
         }
 
         Ok(())
@@ -387,7 +507,7 @@ impl FsWriterBase {
                 let mut writer =
                     BlockWriter::new(self.fs_context.clone(), lb.clone(), 0, block_size).await?;
                 let commit_block = writer.complete().await?;
-                self.file_blocks.add_commit(commit_block)?;
+                self.add_durable_commit(commit_block)?;
             }
         }
 
@@ -395,6 +515,14 @@ impl FsWriterBase {
         self.pos = self.pos.min(len);
         self.len = len;
         self.file_blocks = file_blocks;
+        self.durable_blocks = FastHashSet::with_vec(
+            self.file_blocks
+                .block_locs
+                .iter()
+                .filter(|block| block.block.len > 0 && !block.locs.is_empty())
+                .map(|block| block.block.id)
+                .collect(),
+        );
 
         Ok(())
     }

--- a/curvine-client/src/file/fs_writer_buffer.rs
+++ b/curvine-client/src/file/fs_writer_buffer.rs
@@ -29,6 +29,7 @@ use std::sync::Arc;
 enum WriterTask {
     Flush(CallSender<i8>),
     Complete((bool, CallSender<i8>)),
+    Cancel(CallSender<FsResult<()>>),
     Seek((i64, CallSender<i8>)),
     Resize((FileAllocOpts, CallSender<FileBlocks>)),
 }
@@ -36,6 +37,21 @@ enum WriterTask {
 enum SelectTask {
     Control(WriterTask),
     Data(DataSlice),
+}
+
+async fn recv_task(
+    chunk_receiver: &mut AsyncReceiver<DataSlice>,
+    task_receiver: &mut AsyncReceiver<WriterTask>,
+) -> Option<SelectTask> {
+    tokio::select! {
+        biased;
+
+        // Control tasks take priority. Flush/complete/seek/resize drain the data
+        // queue explicitly, while cancel intentionally does not; prioritizing
+        // data here would keep writing queued chunks after cancellation arrived.
+        task = task_receiver.recv() => task.map(SelectTask::Control),
+        chunk = chunk_receiver.recv() => chunk.map(SelectTask::Data),
+    }
 }
 
 struct BufferChannel {
@@ -74,6 +90,16 @@ impl BufferChannel {
             self.task_sender.send(WriterTask::Flush(tx)).await?;
             rx.receive().await?;
             Ok::<(), IOError>(())
+        };
+        fun.await.map_err(|e| self.check_error(e))
+    }
+
+    async fn cancel(&mut self) -> FsResult<()> {
+        let fun = async {
+            let (tx, rx) = CallChannel::channel();
+            self.task_sender.send(WriterTask::Cancel(tx)).await?;
+            rx.receive().await??;
+            Ok::<(), FsError>(())
         };
         fun.await.map_err(|e| self.check_error(e))
     }
@@ -188,6 +214,10 @@ impl FsWriterBuffer {
         self.writer.flush().await
     }
 
+    pub async fn cancel(&mut self) -> FsResult<()> {
+        self.writer.cancel().await
+    }
+
     pub async fn seek(&mut self, pos: i64) -> FsResult<()> {
         self.writer.seek(pos).await?;
         self.pos = pos;
@@ -208,22 +238,9 @@ impl FsWriterBuffer {
     ) -> FsResult<()> {
         loop {
             // The queue can be written and controlled to complete any future.
-            let select_task = tokio::select! {
-                biased;
-
-                chunk = chunk_receiver.recv() => {
-                   let Some(chunk) = chunk else {
-                        return Ok(())
-                    };
-                   SelectTask::Data(chunk)
-                }
-
-                task = task_receiver.recv() => {
-                    let Some(task) = task else {
-                        return Ok(())
-                    };
-                    SelectTask::Control(task)
-                }
+            let select_task = match recv_task(&mut chunk_receiver, &mut task_receiver).await {
+                Some(task) => task,
+                None => return Ok(()),
             };
 
             match select_task {
@@ -242,6 +259,16 @@ impl FsWriterBuffer {
                         }
                         writer.complete().await?;
                         tx.send(1)?;
+                        return Ok(());
+                    }
+
+                    WriterTask::Cancel(tx) => {
+                        // Do not drain chunk_receiver: queued chunks are
+                        // uncommitted data and cancellation intentionally drops
+                        // them. FsWriterBase::cancel attempts every active block
+                        // writer before returning its first error.
+                        let res = writer.cancel().await;
+                        tx.send(res)?;
                         return Ok(());
                     }
 
@@ -277,5 +304,31 @@ impl FsWriterBuffer {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{recv_task, SelectTask, WriterTask};
+    use bytes::Bytes;
+    use curvine_common::FsResult;
+    use orpc::sync::channel::{AsyncChannel, CallChannel};
+    use orpc::sys::DataSlice;
+
+    #[tokio::test]
+    async fn cancel_control_preempts_queued_data() {
+        let (chunk_tx, mut chunk_rx) = AsyncChannel::new(2).split();
+        let (task_tx, mut task_rx) = AsyncChannel::new(2).split();
+        chunk_tx
+            .send(DataSlice::Bytes(Bytes::from_static(b"queued")))
+            .await
+            .unwrap();
+        let (cancel_tx, _cancel_rx) = CallChannel::channel::<FsResult<()>>();
+        task_tx.send(WriterTask::Cancel(cancel_tx)).await.unwrap();
+
+        assert!(matches!(
+            recv_task(&mut chunk_rx, &mut task_rx).await,
+            Some(SelectTask::Control(WriterTask::Cancel(_)))
+        ));
     }
 }

--- a/curvine-fuse/src/fs/fuse_reader.rs
+++ b/curvine-fuse/src/fs/fuse_reader.rs
@@ -21,7 +21,7 @@ use curvine_common::error::FsError;
 use curvine_common::fs::{Path, Reader};
 use curvine_common::state::FileStatus;
 use curvine_common::FsResult;
-use log::error;
+use log::{error, warn};
 use orpc::runtime::{RpcRuntime, Runtime};
 use orpc::sync::channel::{AsyncChannel, AsyncReceiver, AsyncSender, CallChannel, CallSender};
 use orpc::sync::ErrorMonitor;
@@ -161,7 +161,12 @@ impl FuseReader {
                         );
                     }
 
-                    reply.send_data(data.map_err(|x| x.into())).await?;
+                    if let Err(e) = reply.send_data(data.map_err(|x| x.into())).await {
+                        // The read itself is complete. Losing this request's reply
+                        // receiver must not kill the shared worker and make every
+                        // later read on the handle fail.
+                        warn!("failed to send FUSE read reply: {}", e);
+                    }
                 }
 
                 ReadTask::Complete(tx, reply) => {
@@ -216,6 +221,12 @@ mod tests {
         FuseResponse::new_reply(1, tx, false, Some(ctx))
     }
 
+    fn closed_reply(unique: u64) -> FuseResponse {
+        let (tx, rx) = AsyncChannel::<FuseTask>::new(1).split();
+        drop(rx);
+        FuseResponse::new_reply(unique, tx, false, None)
+    }
+
     fn read_op_arg(offset: u64, size: u32) -> fuse_read_in {
         fuse_read_in {
             fh: 0,
@@ -226,6 +237,64 @@ mod tests {
             flags: 0,
             padding: 0,
         }
+    }
+
+    #[test]
+    fn reply_send_error_does_not_kill_reader_worker() {
+        let rt = AsyncRuntime::single();
+        rt.block_on(async {
+            let path_buf = std::env::temp_dir().join(format!(
+                "fr_reply_failure_{}_{:?}",
+                std::process::id(),
+                std::thread::current().id()
+            ));
+            {
+                let mut file = std::fs::File::create(&path_buf).unwrap();
+                file.write_all(b"reader-worker-survives").unwrap();
+            }
+            let path = curvine_common::fs::Path::from_str(path_buf.to_str().unwrap()).unwrap();
+
+            // This is a lifecycle test, not a metrics test. Keep it isolated
+            // from the process-global metric counters used by parallel tests.
+            let mut conf = FuseConf::default();
+            conf.metrics_enabled = false;
+            let reader = UnifiedReader::Local(LocalReader::new(&path, 4096).unwrap());
+            let rt2 = Arc::new(AsyncRuntime::single());
+            let fuse_reader = FuseReader::new(&conf, rt2.clone(), reader);
+            std::mem::forget(rt2);
+
+            let header = fuse_in_header::default();
+            let first_arg = read_op_arg(0, 6);
+            fuse_reader
+                .read(
+                    Read {
+                        header: &header,
+                        arg: &first_arg,
+                    },
+                    closed_reply(1),
+                )
+                .await
+                .unwrap();
+
+            // Submit a normal second read. Receiving its response proves that the
+            // worker survived the first request's closed reply channel.
+            let (reply_tx, mut reply_rx) = AsyncChannel::<FuseTask>::new(1).split();
+            let second_arg = read_op_arg(7, 6);
+            fuse_reader
+                .read(
+                    Read {
+                        header: &header,
+                        arg: &second_arg,
+                    },
+                    FuseResponse::new_reply(2, reply_tx, false, None),
+                )
+                .await
+                .unwrap();
+            fuse_reader.complete(None).await.unwrap();
+
+            assert!(matches!(reply_rx.recv().await, Some(FuseTask::Reply(_))));
+            let _ = std::fs::remove_file(&path_buf);
+        });
     }
 
     // A real FuseReader over UnifiedReader::Local drives the read task body through

--- a/curvine-fuse/src/fs/fuse_reader.rs
+++ b/curvine-fuse/src/fs/fuse_reader.rs
@@ -256,8 +256,10 @@ mod tests {
 
             // This is a lifecycle test, not a metrics test. Keep it isolated
             // from the process-global metric counters used by parallel tests.
-            let mut conf = FuseConf::default();
-            conf.metrics_enabled = false;
+            let conf = FuseConf {
+                metrics_enabled: false,
+                ..Default::default()
+            };
             let reader = UnifiedReader::Local(LocalReader::new(&path, 4096).unwrap());
             let rt2 = Arc::new(AsyncRuntime::single());
             let fuse_reader = FuseReader::new(&conf, rt2.clone(), reader);

--- a/curvine-fuse/src/fs/fuse_writer.rs
+++ b/curvine-fuse/src/fs/fuse_writer.rs
@@ -729,8 +729,10 @@ mod tests {
 
                 // This is a lifecycle test, not a metrics test. Keep it isolated
                 // from the process-global metric counters used by parallel tests.
-                let mut conf = FuseConf::default();
-                conf.metrics_enabled = false;
+                let conf = FuseConf {
+                    metrics_enabled: false,
+                    ..Default::default()
+                };
                 let writer = UnifiedWriter::Local(LocalWriter::new(&path, 4096).unwrap());
                 let rt2 = Arc::new(AsyncRuntime::single());
                 let fuse_writer = FuseWriter::new(&conf, rt2.clone(), writer);

--- a/curvine-fuse/src/fs/fuse_writer.rs
+++ b/curvine-fuse/src/fs/fuse_writer.rs
@@ -22,7 +22,7 @@ use curvine_common::error::FsError;
 use curvine_common::fs::{Path, Writer};
 use curvine_common::state::{FileAllocOpts, FileStatus};
 use curvine_common::FsResult;
-use log::error;
+use log::{error, warn};
 use orpc::common::LocalTime;
 use orpc::runtime::{RpcRuntime, Runtime};
 use orpc::sync::channel::{AsyncChannel, AsyncReceiver, AsyncSender, CallChannel, CallSender};
@@ -297,7 +297,13 @@ impl FuseWriter {
                     }
 
                     if let Some(reply) = reply {
-                        reply.send_rep(res).await?;
+                        if let Err(e) = reply.send_rep(res).await {
+                            // The backend operation is already finished. A reply
+                            // enqueue failure means that this request's receiver
+                            // has gone away; it must not terminate the long-lived
+                            // writer worker and break later requests on the handle.
+                            warn!("failed to send FUSE write reply: {}", e);
+                        }
                     } else {
                         res?;
                     }
@@ -447,6 +453,7 @@ mod tests {
         };
         use crate::raw::fuse_abi::{fuse_in_header, fuse_write_in};
         use crate::session::{FuseResponse, FuseTask};
+        use bytes::Bytes;
         use curvine_client::unified::UnifiedWriter;
         use curvine_common::conf::FuseConf;
         use curvine_common::fs::local::LocalWriter;
@@ -470,6 +477,65 @@ mod tests {
                 active: Some(ActiveGuard::new(gauge)),
             };
             FuseResponse::new_reply(1, tx, false, Some(ctx))
+        }
+
+        fn closed_reply(unique: u64) -> FuseResponse {
+            let (tx, rx) = AsyncChannel::<FuseTask>::new(1).split();
+            drop(rx);
+            FuseResponse::new_reply(unique, tx, false, None)
+        }
+
+        #[test]
+        fn reply_send_error_does_not_kill_writer_worker() {
+            let rt = AsyncRuntime::single();
+            rt.block_on(async {
+                let path_buf = std::env::temp_dir().join(format!(
+                    "fw_reply_failure_{}_{:?}",
+                    std::process::id(),
+                    std::thread::current().id()
+                ));
+                let path = curvine_common::fs::Path::from_str(path_buf.to_str().unwrap()).unwrap();
+
+                // This is a lifecycle test, not a metrics test. Keep it isolated
+                // from the process-global metric counters used by parallel tests.
+                let mut conf = FuseConf::default();
+                conf.metrics_enabled = false;
+                let writer = UnifiedWriter::Local(LocalWriter::new(&path, 4096).unwrap());
+                let rt2 = Arc::new(AsyncRuntime::single());
+                let fuse_writer = FuseWriter::new(&conf, rt2.clone(), writer);
+                std::mem::forget(rt2);
+
+                // The first write succeeds in the backend, but its reply receiver
+                // is already closed. The following flush must still be handled by
+                // the same worker.
+                fuse_writer
+                    .write(0, Bytes::from_static(b"first"), Some(closed_reply(1)))
+                    .await
+                    .unwrap();
+                fuse_writer
+                    .flush(None)
+                    .await
+                    .expect("writer survives a write reply-send failure");
+
+                // Exercise the shared flush/complete result helper as well. Its
+                // internal completion arrives before this closed kernel reply;
+                // a later write and complete prove that the worker kept running.
+                fuse_writer
+                    .flush(Some(closed_reply(2)))
+                    .await
+                    .expect("flush caller receives the backend result");
+                fuse_writer
+                    .write(5, Bytes::from_static(b"second"), None)
+                    .await
+                    .unwrap();
+                fuse_writer
+                    .complete(None)
+                    .await
+                    .expect("writer survives a flush reply-send failure");
+
+                assert_eq!(std::fs::read(&path_buf).unwrap(), b"firstsecond");
+                let _ = std::fs::remove_file(&path_buf);
+            });
         }
 
         // A real FuseWriter over UnifiedWriter::Local drives the write task body via

--- a/curvine-fuse/src/fs/fuse_writer.rs
+++ b/curvine-fuse/src/fs/fuse_writer.rs
@@ -240,13 +240,59 @@ impl FuseWriter {
         self.len() == 0
     }
 
-    async fn writer_future(
-        mut writer: UnifiedWriter,
+    async fn writer_future<W: Writer>(
+        mut writer: W,
         mut req_receiver: AsyncReceiver<QueuedWriteTask>,
         file_len: Arc<AtomicLong>,
         file_mtime: Arc<AtomicLong>,
         path_type: &'static str,
         metrics_enabled: bool,
+    ) -> FsResult<()> {
+        let mut completed = false;
+        let worker_result = Self::run_writer_tasks(
+            &mut writer,
+            &mut req_receiver,
+            &file_len,
+            &file_mtime,
+            path_type,
+            metrics_enabled,
+            &mut completed,
+        )
+        .await;
+
+        if completed {
+            return worker_result;
+        }
+
+        // Channel closure or a fatal task error before the last successful
+        // complete is an abnormal exit. Explicitly cancel the backend writer so
+        // unfinished upload/block sessions are not left to an implicit drop.
+        let cancel_result = writer.cancel().await;
+        match (worker_result, cancel_result) {
+            (Err(worker_error), Err(cancel_error)) => {
+                // Cleanup is best effort and must not hide the error that caused
+                // the worker to exit.
+                error!(
+                    "failed to cancel writer after worker error: {}",
+                    cancel_error
+                );
+                Err(worker_error)
+            }
+            (Err(worker_error), Ok(())) => Err(worker_error),
+            (Ok(()), Err(cancel_error)) => Err(cancel_error),
+            (Ok(()), Ok(())) => Ok(()),
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn run_writer_tasks<W: Writer>(
+        writer: &mut W,
+        req_receiver: &mut AsyncReceiver<QueuedWriteTask>,
+        file_len: &AtomicLong,
+        file_mtime: &AtomicLong,
+        path_type: &'static str,
+        metrics_enabled: bool,
+        completed: &mut bool,
     ) -> FsResult<()> {
         while let Some(mut queued) = req_receiver.recv().await {
             // Dequeue point: drop the queue guard FIRST (before any backend work),
@@ -255,6 +301,10 @@ impl FuseWriter {
             mark_dequeued(&mut queued.queue_guard);
             match queued.task {
                 WriteTask::Write(off, data, reply) => {
+                    // A new write makes a prior complete no longer sufficient for
+                    // this worker's final state. Set this before backend IO so a
+                    // partial failed write is also cancelled on exit.
+                    *completed = false;
                     let len = data.len();
                     // Phase 2b: observe the write backend IO (io_type=write). The
                     // inflight guard wraps ONLY the `fuse_write` call; dropped
@@ -319,10 +369,12 @@ impl FuseWriter {
 
                 WriteTask::Complete(tx, reply) => {
                     let res = writer.complete().await;
+                    *completed = res.is_ok();
                     crate::fs::deliver_stream_result(res, tx, reply).await?;
                 }
 
                 WriteTask::Resize(tx, opts) => {
+                    *completed = false;
                     // A resize failure must propagate to the caller via `tx`
                     // rather than `?`-ing out of the worker (which would kill it
                     // and leave the caller hanging). No kernel reply on this path.
@@ -338,11 +390,190 @@ impl FuseWriter {
 
 #[cfg(test)]
 mod tests {
-    use super::{mark_dequeued, QueuedWriteTask, WriteTask};
+    use super::{mark_dequeued, FuseWriter, QueuedWriteTask, WriteTask};
     use crate::fuse_metrics::ActiveGuard;
+    use bytes::{Bytes, BytesMut};
+    use curvine_common::error::FsError;
+    use curvine_common::fs::{Path, Writer};
+    use curvine_common::state::FileStatus;
     use curvine_common::FsResult;
     use orpc::common::Metrics as m;
     use orpc::sync::channel::{AsyncChannel, CallChannel};
+    use orpc::sync::AtomicLong;
+    use orpc::sys::DataSlice;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    struct TrackingWriter {
+        path: Path,
+        status: FileStatus,
+        pos: i64,
+        chunk: BytesMut,
+        cancel_count: Arc<AtomicUsize>,
+        complete_count: Arc<AtomicUsize>,
+        fail_write: bool,
+        fail_cancel: bool,
+    }
+
+    impl TrackingWriter {
+        fn new(cancel_count: Arc<AtomicUsize>, complete_count: Arc<AtomicUsize>) -> Self {
+            Self {
+                path: Path::from_str("/tmp/fuse-writer-lifecycle").unwrap(),
+                status: FileStatus::default(),
+                pos: 0,
+                chunk: BytesMut::new(),
+                cancel_count,
+                complete_count,
+                fail_write: false,
+                fail_cancel: false,
+            }
+        }
+    }
+
+    impl Writer for TrackingWriter {
+        fn status(&self) -> &FileStatus {
+            &self.status
+        }
+
+        fn path(&self) -> &Path {
+            &self.path
+        }
+
+        fn pos(&self) -> i64 {
+            self.pos
+        }
+
+        fn pos_mut(&mut self) -> &mut i64 {
+            &mut self.pos
+        }
+
+        fn chunk_mut(&mut self) -> &mut BytesMut {
+            &mut self.chunk
+        }
+
+        fn chunk_size(&self) -> usize {
+            4096
+        }
+
+        async fn write_chunk(&mut self, chunk: DataSlice) -> FsResult<i64> {
+            if self.fail_write {
+                Err(FsError::common("injected backend write failure"))
+            } else {
+                Ok(chunk.len() as i64)
+            }
+        }
+
+        async fn flush(&mut self) -> FsResult<()> {
+            Ok(())
+        }
+
+        async fn complete(&mut self) -> FsResult<()> {
+            self.complete_count.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        async fn cancel(&mut self) -> FsResult<()> {
+            self.cancel_count.fetch_add(1, Ordering::SeqCst);
+            if self.fail_cancel {
+                Err(FsError::common("injected cancellation failure"))
+            } else {
+                Ok(())
+            }
+        }
+
+        async fn seek(&mut self, pos: i64) -> FsResult<()> {
+            self.pos = pos;
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn abnormal_channel_close_cancels_backend_writer_once() {
+        let cancel_count = Arc::new(AtomicUsize::new(0));
+        let complete_count = Arc::new(AtomicUsize::new(0));
+        let writer = TrackingWriter::new(cancel_count.clone(), complete_count.clone());
+        let (sender, receiver) = AsyncChannel::new(1).split();
+        drop(sender);
+
+        FuseWriter::writer_future(
+            writer,
+            receiver,
+            Arc::new(AtomicLong::new(0)),
+            Arc::new(AtomicLong::new(0)),
+            "test",
+            false,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(cancel_count.load(Ordering::SeqCst), 1);
+        assert_eq!(complete_count.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn normal_complete_does_not_cancel_backend_writer() {
+        let cancel_count = Arc::new(AtomicUsize::new(0));
+        let complete_count = Arc::new(AtomicUsize::new(0));
+        let writer = TrackingWriter::new(cancel_count.clone(), complete_count.clone());
+        let (sender, receiver) = AsyncChannel::new(1).split();
+        let (result_tx, result_rx) = CallChannel::channel::<FsResult<()>>();
+        sender
+            .send(QueuedWriteTask {
+                task: WriteTask::Complete(result_tx, None),
+                queue_guard: None,
+            })
+            .await
+            .unwrap();
+        drop(sender);
+
+        FuseWriter::writer_future(
+            writer,
+            receiver,
+            Arc::new(AtomicLong::new(0)),
+            Arc::new(AtomicLong::new(0)),
+            "test",
+            false,
+        )
+        .await
+        .unwrap();
+
+        assert!(result_rx.receive().await.unwrap().is_ok());
+        assert_eq!(complete_count.load(Ordering::SeqCst), 1);
+        assert_eq!(cancel_count.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn cancel_failure_does_not_mask_worker_error() {
+        let cancel_count = Arc::new(AtomicUsize::new(0));
+        let complete_count = Arc::new(AtomicUsize::new(0));
+        let mut writer = TrackingWriter::new(cancel_count.clone(), complete_count);
+        writer.fail_write = true;
+        writer.fail_cancel = true;
+        let (sender, receiver) = AsyncChannel::new(1).split();
+        sender
+            .send(QueuedWriteTask {
+                task: WriteTask::Write(0, Bytes::from_static(b"data"), None),
+                queue_guard: None,
+            })
+            .await
+            .unwrap();
+        drop(sender);
+
+        let error = FuseWriter::writer_future(
+            writer,
+            receiver,
+            Arc::new(AtomicLong::new(0)),
+            Arc::new(AtomicLong::new(0)),
+            "test",
+            false,
+        )
+        .await
+        .expect_err("the backend write failure remains visible");
+
+        assert!(error.to_string().contains("injected backend write failure"));
+        assert!(!error.to_string().contains("injected cancellation failure"));
+        assert_eq!(cancel_count.load(Ordering::SeqCst), 1);
+    }
 
     // Build a QueuedWriteTask carrying a queue guard backed by `gauge`. The wrapped
     // WriteTask is a Flush (it only needs a CallChannel sender, no FuseResponse), so

--- a/curvine-fuse/src/fs/fuse_writer.rs
+++ b/curvine-fuse/src/fs/fuse_writer.rs
@@ -249,6 +249,10 @@ impl FuseWriter {
         metrics_enabled: bool,
     ) -> FsResult<()> {
         let mut completed = false;
+        // Sticky once an operation may have made backend data durable or
+        // visible. Later writes do not clear it: aborting a shared block after
+        // an earlier fsync could delete the already-published prefix as well.
+        let mut preserve_on_exit = false;
         let worker_result = Self::run_writer_tasks(
             &mut writer,
             &mut req_receiver,
@@ -257,6 +261,7 @@ impl FuseWriter {
             path_type,
             metrics_enabled,
             &mut completed,
+            &mut preserve_on_exit,
         )
         .await;
 
@@ -264,22 +269,28 @@ impl FuseWriter {
             return worker_result;
         }
 
-        // Channel closure or a fatal task error before the last successful
-        // complete is an abnormal exit. Explicitly cancel the backend writer so
-        // unfinished upload/block sessions are not left to an implicit drop.
-        let cancel_result = writer.cancel().await;
-        match (worker_result, cancel_result) {
-            (Err(worker_error), Err(cancel_error)) => {
+        // Before the first durability boundary, aborting is the right cleanup
+        // for a brand-new unfinished upload. After flush/complete/resize was
+        // attempted, the backend or master may already reference the data even
+        // when its response was lost. Finalize instead: cancellation could
+        // delete a block that a successful fsync already published.
+        let cleanup_result = if preserve_on_exit {
+            writer.complete().await
+        } else {
+            writer.cancel().await
+        };
+        match (worker_result, cleanup_result) {
+            (Err(worker_error), Err(cleanup_error)) => {
                 // Cleanup is best effort and must not hide the error that caused
                 // the worker to exit.
                 error!(
-                    "failed to cancel writer after worker error: {}",
-                    cancel_error
+                    "failed to clean up writer after worker error: {}",
+                    cleanup_error
                 );
                 Err(worker_error)
             }
             (Err(worker_error), Ok(())) => Err(worker_error),
-            (Ok(()), Err(cancel_error)) => Err(cancel_error),
+            (Ok(()), Err(cleanup_error)) => Err(cleanup_error),
             (Ok(()), Ok(())) => Ok(()),
         }
     }
@@ -293,6 +304,7 @@ impl FuseWriter {
         path_type: &'static str,
         metrics_enabled: bool,
         completed: &mut bool,
+        preserve_on_exit: &mut bool,
     ) -> FsResult<()> {
         while let Some(mut queued) = req_receiver.recv().await {
             // Dequeue point: drop the queue guard FIRST (before any backend work),
@@ -360,6 +372,9 @@ impl FuseWriter {
                 }
 
                 WriteTask::Flush(tx, reply) => {
+                    // Set this before the await because a lost/failed response
+                    // cannot prove that the master did not publish the flush.
+                    *preserve_on_exit = true;
                     let res = writer.flush().await;
                     // Deliver the real backend result to the caller (tx) first,
                     // then the kernel reply. See `deliver_stream_result`
@@ -368,6 +383,7 @@ impl FuseWriter {
                 }
 
                 WriteTask::Complete(tx, reply) => {
+                    *preserve_on_exit = true;
                     let res = writer.complete().await;
                     *completed = res.is_ok();
                     crate::fs::deliver_stream_result(res, tx, reply).await?;
@@ -375,6 +391,7 @@ impl FuseWriter {
 
                 WriteTask::Resize(tx, opts) => {
                     *completed = false;
+                    *preserve_on_exit = true;
                     // A resize failure must propagate to the caller via `tx`
                     // rather than `?`-ing out of the worker (which would kill it
                     // and leave the caller hanging). No kernel reply on this path.
@@ -540,6 +557,85 @@ mod tests {
         assert!(result_rx.receive().await.unwrap().is_ok());
         assert_eq!(complete_count.load(Ordering::SeqCst), 1);
         assert_eq!(cancel_count.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn successful_flush_is_finalized_instead_of_cancelled_on_channel_close() {
+        let cancel_count = Arc::new(AtomicUsize::new(0));
+        let complete_count = Arc::new(AtomicUsize::new(0));
+        let writer = TrackingWriter::new(cancel_count.clone(), complete_count.clone());
+        let (sender, receiver) = AsyncChannel::new(1).split();
+        let (result_tx, result_rx) = CallChannel::channel::<FsResult<()>>();
+        sender
+            .send(QueuedWriteTask {
+                task: WriteTask::Flush(result_tx, None),
+                queue_guard: None,
+            })
+            .await
+            .unwrap();
+        drop(sender);
+
+        FuseWriter::writer_future(
+            writer,
+            receiver,
+            Arc::new(AtomicLong::new(0)),
+            Arc::new(AtomicLong::new(0)),
+            "test",
+            false,
+        )
+        .await
+        .unwrap();
+
+        assert!(result_rx.receive().await.unwrap().is_ok());
+        assert_eq!(complete_count.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            cancel_count.load(Ordering::SeqCst),
+            0,
+            "cancelling here could delete data published by the flush"
+        );
+    }
+
+    #[tokio::test]
+    async fn write_after_flush_keeps_the_durable_cleanup_boundary() {
+        let cancel_count = Arc::new(AtomicUsize::new(0));
+        let complete_count = Arc::new(AtomicUsize::new(0));
+        let writer = TrackingWriter::new(cancel_count.clone(), complete_count.clone());
+        let (sender, receiver) = AsyncChannel::new(2).split();
+        let (result_tx, result_rx) = CallChannel::channel::<FsResult<()>>();
+        sender
+            .send(QueuedWriteTask {
+                task: WriteTask::Flush(result_tx, None),
+                queue_guard: None,
+            })
+            .await
+            .unwrap();
+        sender
+            .send(QueuedWriteTask {
+                task: WriteTask::Write(0, Bytes::from_static(b"later"), None),
+                queue_guard: None,
+            })
+            .await
+            .unwrap();
+        drop(sender);
+
+        FuseWriter::writer_future(
+            writer,
+            receiver,
+            Arc::new(AtomicLong::new(0)),
+            Arc::new(AtomicLong::new(0)),
+            "test",
+            false,
+        )
+        .await
+        .unwrap();
+
+        assert!(result_rx.receive().await.unwrap().is_ok());
+        assert_eq!(complete_count.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            cancel_count.load(Ordering::SeqCst),
+            0,
+            "a later write must not make an earlier durable block abortable"
+        );
     }
 
     #[tokio::test]

--- a/curvine-fuse/src/fs/stream_result.rs
+++ b/curvine-fuse/src/fs/stream_result.rs
@@ -15,6 +15,7 @@
 use crate::fuse_error::{errno_of, FuseError};
 use crate::session::FuseResponse;
 use curvine_common::FsResult;
+use log::warn;
 use orpc::sync::channel::CallSender;
 
 /// Deliver a backend stream-op result (`Flush`/`Complete`/`Resize`) to the
@@ -58,14 +59,29 @@ pub(crate) async fn deliver_stream_result(
                 Ok(()) => Ok(()),
                 Err(e) => Err(FuseError::from_errno_msg(errno_of(e), e.to_string().into())),
             };
-            tx.send(Ok(()))?;
-            reply.send_rep(kernel_rep).await?;
+            if let Err(e) = tx.send(Ok(())) {
+                // The dispatch future was cancelled after submitting the task.
+                // Still attempt the authoritative kernel reply, and keep the
+                // stream worker alive for subsequent operations.
+                warn!("failed to deliver stream result to internal caller: {}", e);
+            }
+            if let Err(e) = reply.send_rep(kernel_rep).await {
+                // The backend work and internal notification are already done.
+                // A closed reply channel is local to this request and must not
+                // terminate the long-lived reader/writer worker.
+                warn!("failed to send FUSE stream reply: {}", e);
+            }
         }
 
         // Internal-caller path: tx is the only way back, so the real backend
         // result must travel on it (do not swallow the error — issue #1118).
         None => {
-            tx.send(res)?;
+            if let Err(e) = tx.send(res) {
+                // An internal caller can be cancelled while its backend task is
+                // in flight. Treat the abandoned receiver like a reply-send
+                // failure instead of killing the shared worker.
+                warn!("failed to deliver stream result to internal caller: {}", e);
+            }
         }
     }
 
@@ -189,5 +205,26 @@ mod tests {
             ),
             _ => panic!("expected FuseTask::Reply"),
         }
+    }
+
+    #[tokio::test]
+    async fn closed_reply_channel_does_not_fail_internal_completion() {
+        use crate::session::{FuseResponse, FuseTask};
+        use orpc::sync::channel::AsyncChannel;
+
+        let (task_tx, task_rx) = AsyncChannel::<FuseTask>::new(1).split();
+        drop(task_rx);
+        let reply = FuseResponse::new_reply(1, task_tx, false, None);
+        let (tx, rx) = CallChannel::channel::<FsResult<()>>();
+
+        deliver_stream_result(Ok(()), tx, Some(reply))
+            .await
+            .expect("reply-send failure is best effort");
+
+        assert!(rx
+            .receive()
+            .await
+            .expect("internal completion is delivered first")
+            .is_ok());
     }
 }


### PR DESCRIPTION
# Summary

Prevent long-lived FUSE reader and writer workers from terminating when reply delivery fails. Propagate writer cancellation through the client stack, while preserving blocks that may already be durable or visible when an abnormal writer exit is cleaned up.

# Issue Describe / Design

Closes #1119
Closes #1232
Closes #1233
Closes #1234

## Root cause

- Reader and writer workers treated reply-delivery failures as fatal worker errors.
- An abnormal writer-worker exit did not clean up the backend writer.
- Writer cancellation was not fully propagated through buffered writers, active block writers, cached writers, and replica writers.
- Cleanup could not distinguish a new uncommitted block from a block already published by `flush` or finalized on a worker. Blind cancellation could therefore delete published data, while pending commit metadata could be dropped without reaching the master.

## Reproduction steps

1. Close or disconnect the reply receiver for a FUSE read/write request.
2. Submit another request using the same worker.
3. Previously, the first reply failure terminated the worker and subsequent operations failed because the worker channel was closed.
4. If the worker exited before completion, backend state could remain uncleaned; after a successful fsync, cancellation could instead delete a block already recorded by the master.

## Fix approach

- Treat reply delivery as best effort after preserving the backend operation result.
- Keep long-lived reader and writer workers alive after reply-send failures.
- Track successful completion and the sticky durability boundary introduced by flush/complete/resize attempts.
- Abort only brand-new, never-published blocks. Finalize blocks that existed previously, were published by flush, or were already finalized on workers.
- Submit pending worker commit metadata to the master during abnormal cleanup and retain it across ambiguous RPC failures.
- Propagate cancellation through buffered, base, block, and replica writers.
- Preserve the original worker error if best-effort cleanup also fails.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-fuse/src/fs/fuse_reader.rs` | Keep the reader worker alive after reply delivery failures | Subsequent reads can continue |
| `curvine-fuse/src/fs/fuse_writer.rs` | Keep the writer alive after reply failures; abort before durability, finalize after durability | Prevents worker loss without deleting fsync-published data |
| `curvine-fuse/src/fs/stream_result.rs` | Separate backend results from best-effort reply delivery | Backend completion no longer depends on reply-channel state |
| `curvine-client/src/file/` | Propagate cancellation, track durable blocks, and submit pending commits during cleanup | Cleans unfinished sessions without orphaning worker-finalized blocks |
| `curvine-client/src/block/block_writer.rs` | Cancel all replica writers and return the first error | Cleanup continues even if one replica cancellation fails |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `make format` | PASS | Includes release Clippy checks |
| `cargo test -p curvine-client --lib -- --test-threads=1` | PASS | 55 passed |
| `cargo test -p curvine-fuse --lib fs::fuse_writer::tests -- --test-threads=1` | PASS | 11 passed, including flush-before-abnormal-close and write-after-flush cleanup regressions |
| `cargo test -p curvine-fuse --lib -- --test-threads=1` | PASS | 257 passed |
| Reply-channel fault-injection tests | PASS | Verified subsequent reader/writer operations remain available |
| Abnormal worker-exit tests | PASS | Verified never-flushed writes cancel, while flushed writes finalize and cleanup errors do not mask the root cause |
| Real FUSE mount E2E | PASS | Verified a 143 MiB multi-block file using write, fsync, continued write, second fsync, random overwrite, close/reopen, rename, and checksum comparison in a remote Linux environment |

# Dependencies

- Related PRs: None
- Related issues: #1119, #1232, #1233, #1234
- Blocks / blocked by: None
