### PR TITLE
fix(orpc): retry FUSE splice reply on EAGAIN instead of awaiting readiness (#1215)

### DIFF
--- a/curvine-fuse/src/session/channel/fuse_sender.rs
+++ b/curvine-fuse/src/session/channel/fuse_sender.rs
@@ -203,6 +203,16 @@ impl<T: FileSystem> FuseSender<T> {
         }
     }
 
+    // Non-splice reply path. This uses AsyncFd::async_write (edge-triggered
+    // WRITABLE), which is the same readiness model that hangs the splice path in
+    // #1215 — but writev to /dev/fuse does not hit that trap. A FUSE reply write
+    // is matched to a pending kernel request and copied out; the fuse device has
+    // no send-buffer watermark, so a well-formed reply does not return EAGAIN the
+    // way the SPLICE_F_NONBLOCK pipe->device transfer does. It fails with a real
+    // errno (e.g. ENOENT for an unknown request) instead, which propagates here.
+    // This is why enable_splice=false is a sound workaround for #1215, not just an
+    // empirical one, and why the splice_retry helper is intentionally NOT applied
+    // to writev.
     pub async fn write(&mut self, rep: ResponseData) -> IOResult<()> {
         let (len, iovec) = rep.as_iovec()?;
         let written = self

--- a/orpc/src/sys/pipe/pipe2.rs
+++ b/orpc/src/sys/pipe/pipe2.rs
@@ -16,9 +16,10 @@ use crate::io::IOResult;
 use crate::sys::pipe::{AsyncFd, PipeFd, PipePool, PipeReader, PipeWriter};
 use crate::sys::{CInt, RawIO};
 use crate::{err_box, sys};
+use log::warn;
 use std::io::IoSlice;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 // Backoff bounds for the splice-path EAGAIN retry loop (see `splice_retry`).
 // /dev/fuse is permanently level-writable, so its writable edge never fires
@@ -27,6 +28,10 @@ use std::time::Duration;
 // (issue #1215); instead we retry the raw splice behind a bounded async backoff.
 const SPLICE_RETRY_MIN: Duration = Duration::from_micros(50);
 const SPLICE_RETRY_MAX: Duration = Duration::from_millis(5);
+// While retrying continuous EAGAIN, log a warning this often. Until the sender
+// watchdog lands (#1215 PR-B), a stuck sender is otherwise invisible (it makes
+// no progress and emits no error); this surfaces the failure mode in the field.
+const SPLICE_RETRY_WARN_INTERVAL: Duration = Duration::from_secs(5);
 
 pub struct Pipe2 {
     buf_size: usize,
@@ -171,8 +176,16 @@ impl Pipe2 {
     // worker instead of busy-spinning. Note: if the destination stays EAGAIN
     // forever this retries indefinitely (bounded-rate, not a hang) by design;
     // detecting a stuck sender and giving up is the watchdog's job (#1215 PR-B).
+    // While it keeps hitting EAGAIN it logs a warning every
+    // SPLICE_RETRY_WARN_INTERVAL so the otherwise-silent HOL-blocked sender is
+    // visible in the field before the watchdog lands.
     async fn splice_retry(mut f: impl FnMut() -> IOResult<CInt>) -> IOResult<CInt> {
         let mut delay = SPLICE_RETRY_MIN;
+        // Set on the first EAGAIN; measures how long this call has been stalled
+        // on continuous would-block. (Ok / real errors return, so there is no
+        // interleaved success to reset it within a single call.)
+        let mut eagain_since: Option<Instant> = None;
+        let mut next_warn = SPLICE_RETRY_WARN_INTERVAL;
         loop {
             match f() {
                 Ok(res) => return Ok(res),
@@ -182,6 +195,21 @@ impl Pipe2 {
                         continue;
                     }
                     if e.is_would_block() {
+                        let stalled = match eagain_since {
+                            Some(start) => start.elapsed(),
+                            None => {
+                                eagain_since = Some(Instant::now());
+                                Duration::ZERO
+                            }
+                        };
+                        if stalled >= next_warn {
+                            warn!(
+                                "splice to fuse fd stuck on EAGAIN for {:?}; still retrying \
+                                 (bounded-rate). A sender may be HOL-blocked (#1215).",
+                                stalled
+                            );
+                            next_warn += SPLICE_RETRY_WARN_INTERVAL;
+                        }
                         tokio::time::sleep(delay).await;
                         delay = (delay * 2).min(SPLICE_RETRY_MAX);
                         continue;

--- a/orpc/src/sys/pipe/pipe2.rs
+++ b/orpc/src/sys/pipe/pipe2.rs
@@ -14,10 +14,19 @@
 
 use crate::io::IOResult;
 use crate::sys::pipe::{AsyncFd, PipeFd, PipePool, PipeReader, PipeWriter};
-use crate::sys::RawIO;
+use crate::sys::{CInt, RawIO};
 use crate::{err_box, sys};
 use std::io::IoSlice;
 use std::sync::Arc;
+use std::time::Duration;
+
+// Backoff bounds for the splice-path EAGAIN retry loop (see `splice_retry`).
+// /dev/fuse is permanently level-writable, so its writable edge never fires
+// again after tokio's edge-triggered readiness clears on an EAGAIN from the
+// non-blocking splice. Awaiting the WRITABLE readiness there hangs forever
+// (issue #1215); instead we retry the raw splice behind a bounded async backoff.
+const SPLICE_RETRY_MIN: Duration = Duration::from_micros(50);
+const SPLICE_RETRY_MAX: Duration = Duration::from_millis(5);
 
 pub struct Pipe2 {
     buf_size: usize,
@@ -136,17 +145,51 @@ impl Pipe2 {
             );
         }
         let fd_in = self.reader.raw_fd();
+        let fd_out = fd_out.raw_fd();
         let mut remaining = len;
         while remaining > 0 {
-            let res = fd_out
-                .async_write(|fd| sys::splice(fd_in, None, fd.fd(), None, remaining))
-                .await?;
+            // /dev/fuse is permanently level-writable, so on EAGAIN its writable
+            // edge never fires again and awaiting AsyncFd WRITABLE readiness
+            // hangs forever (#1215). Retry the raw splice behind a bounded async
+            // backoff rather than waiting on the tokio readiness.
+            let res =
+                Self::splice_retry(|| sys::splice(fd_in, None, fd_out, None, remaining)).await?;
             if res == 0 {
                 return err_box!("splice returned 0");
             }
             remaining -= res as usize;
         }
         Ok(())
+    }
+
+    // Run the non-blocking splice syscall, retrying on EAGAIN behind a bounded
+    // exponential async backoff. Used on the FUSE reply path where the
+    // destination fd (/dev/fuse) is permanently level-writable, so tokio's
+    // edge-triggered WRITABLE readiness never fires again after an EAGAIN and
+    // awaiting it hangs forever (#1215). EINTR is retried immediately; any other
+    // error propagates. The backoff sleeps on the tokio timer so it yields the
+    // worker instead of busy-spinning. Note: if the destination stays EAGAIN
+    // forever this retries indefinitely (bounded-rate, not a hang) by design;
+    // detecting a stuck sender and giving up is the watchdog's job (#1215 PR-B).
+    async fn splice_retry(mut f: impl FnMut() -> IOResult<CInt>) -> IOResult<CInt> {
+        let mut delay = SPLICE_RETRY_MIN;
+        loop {
+            match f() {
+                Ok(res) => return Ok(res),
+                Err(e) => {
+                    let os = e.raw_error().raw_os_error();
+                    if os == Some(libc::EINTR) {
+                        continue;
+                    }
+                    if e.is_would_block() {
+                        tokio::time::sleep(delay).await;
+                        delay = (delay * 2).min(SPLICE_RETRY_MAX);
+                        continue;
+                    }
+                    return Err(e);
+                }
+            }
+        }
     }
 
     // Read the data of the pipeline into buf, pipe read -> buf
@@ -192,5 +235,77 @@ impl Drop for Pipe2 {
             // The pipeline in the resource is returned to the resource pool, not close.
             pool.release(self)
         }
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::Pipe2;
+    use crate::io::{IOError, IOResult};
+    use crate::sys::CInt;
+    use std::cell::Cell;
+    use std::io;
+
+    fn eagain() -> IOError {
+        IOError::new(io::Error::from_raw_os_error(libc::EAGAIN))
+    }
+
+    fn eintr() -> IOError {
+        IOError::new(io::Error::from_raw_os_error(libc::EINTR))
+    }
+
+    // Regression for #1215: on a permanently level-writable fd (/dev/fuse), the
+    // syscall returns EAGAIN but tokio's edge-triggered WRITABLE readiness never
+    // fires again. `splice_retry` must NOT propagate WouldBlock nor hang — it
+    // must retry the raw syscall until it succeeds. The OLD code awaited
+    // async_write readiness here and hung forever, so this test fails against it.
+    #[tokio::test]
+    async fn splice_retry_retries_eagain_until_ok() {
+        let calls = Cell::new(0u32);
+        let f = || -> IOResult<CInt> {
+            let n = calls.get();
+            calls.set(n + 1);
+            // First 5 attempts report EAGAIN (would-block), then succeed.
+            if n < 5 {
+                Err(eagain())
+            } else {
+                Ok(4096)
+            }
+        };
+
+        let res = Pipe2::splice_retry(f)
+            .await
+            .expect("must complete, not hang");
+        assert_eq!(res, 4096);
+        assert_eq!(calls.get(), 6, "5 EAGAIN retries + 1 success");
+    }
+
+    // EINTR is retried immediately (no backoff), like the drain loop in #965.
+    #[tokio::test]
+    async fn splice_retry_retries_eintr() {
+        let calls = Cell::new(0u32);
+        let f = || -> IOResult<CInt> {
+            let n = calls.get();
+            calls.set(n + 1);
+            if n < 3 {
+                Err(eintr())
+            } else {
+                Ok(1)
+            }
+        };
+        let res = Pipe2::splice_retry(f).await.unwrap();
+        assert_eq!(res, 1);
+        assert_eq!(calls.get(), 4);
+    }
+
+    // A genuine (non-would-block, non-EINTR) error must propagate, not be
+    // swallowed by the retry loop — otherwise a real splice failure would spin
+    // forever. Uses EPIPE (broken pipe), a real splice failure mode.
+    #[tokio::test]
+    async fn splice_retry_propagates_real_error() {
+        let f =
+            || -> IOResult<CInt> { Err(IOError::new(io::Error::from_raw_os_error(libc::EPIPE))) };
+        let err = Pipe2::splice_retry(f).await.unwrap_err();
+        assert_eq!(err.raw_error().raw_os_error(), Some(libc::EPIPE));
     }
 }


### PR DESCRIPTION
# Summary
The FUSE splice reply sender could hang forever under sustained high-concurrency large reads. This fixes the root cause by retrying the non-blocking splice on EAGAIN behind a bounded async backoff, instead of awaiting tokio's edge-triggered WRITABLE readiness on the permanently level-writable /dev/fuse fd.

# Issue Describe / Design
Closes #1215

Root cause:
- Reply path `Pipe2::read_io` splices pipe -> cloned /dev/fuse via `AsyncFd::async_write` (Interest::WRITABLE).
- The non-blocking splice (SPLICE_F_NONBLOCK) can return EAGAIN. tokio then calls `clear_ready()` and awaits the next writable **edge** (mio registers fds edge-triggered, EPOLLET).
- /dev/fuse's write direction is permanently level-writable — it never transitions not-writable -> writable, so no new writable edge is ever delivered. The `readiness().await` hangs forever; the sender future never returns Ok or Err (no error is logged), and all later replies on that sender are head-of-line blocked.
- This matches the reported state active_requests=508 / reply_queue_depth=507, and explains why `enable_splice=false` (single writev, which does not hit this path) is an effective workaround.

Fix:
- Add `Pipe2::splice_retry`: run the raw non-blocking splice, retry on EAGAIN behind a bounded exponential async backoff (50us -> 5ms), retry EINTR immediately, propagate any other error. The backoff sleeps on the tokio timer so it yields the worker (no busy-spin).
- `read_io` uses `splice_retry` on the raw fd, bypassing the unreliable WRITABLE readiness.
- Scope: `write_iov` (vmsplice -> pipe writer) is left unchanged — a pipe writer is not permanently level-writable and does not exhibit this failure, and on this path the pipe is empty on entry so vmsplice does not EAGAIN.

Note: if the destination stayed EAGAIN forever this retries at a bounded rate (not a hang) by design; detecting a stuck sender and failing the session over to the supervisor is tracked separately (watchdog follow-up).

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `orpc/src/sys/pipe/pipe2.rs` | Add `splice_retry` helper; `read_io` retries EAGAIN via backoff instead of awaiting AsyncFd WRITABLE readiness | Fixes the splice sender hang; `write_iov` and the #965 short-transfer loop unchanged |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p orpc --lib sys::pipe::pipe2` | PASS | 3 tests: EAGAIN retried to success, EINTR retried, real error (EPIPE) propagated |
| `cargo clippy -p orpc --all-targets -- --deny=warnings` | PASS | |
| `cargo fmt -p orpc -- --check` | PASS | |

# Dependencies
- Related PRs: None
- Related issues: #1215, #1079 (sender/receiver task supervision), #1093 (receiver-side splice), #965 (splice short-transfer / pipe drain)
- Blocks / blocked by: None