### PR TITLE
feat(metrics): per-sender last-progress gauge for reply-sender stall detection

### DIFF
--- a/curvine-fuse/src/fuse_metrics.rs
+++ b/curvine-fuse/src/fuse_metrics.rs
@@ -334,9 +334,15 @@ pub struct FuseMetrics {
     /// created at enqueue and dropped when the sender dequeues (or when an
     /// un-received task is dropped). No `_total` suffix (it is a gauge).
     pub(crate) reply_queue_depth: Gauge,
-    /// Per-sender last-progress timestamp (Unix seconds), labelled by `sender`
-    /// (the sender's channel index). Set after every successful reply write in
-    /// `FuseSender`. This is the Prometheus "last success timestamp" pattern:
+    /// Per-sender last-progress timestamp (Unix seconds), labelled by `mnt`
+    /// (the mount path) and `sender` (the sender's channel index within that
+    /// mount). Set after every successful reply write in `FuseSender`, and
+    /// initialized to the sender's construction time so a cold series is not a
+    /// spurious 0. The `mnt` dimension is required: FuseSession creates one
+    /// FuseChannel per mount and every mount's senders are indexed 0..N against
+    /// this process-global vec, so without `mnt` two mounts would collide on
+    /// `sender="0"` and an active mount could mask a stalled mount's series.
+    /// This is the Prometheus "last success timestamp" pattern:
     /// scrape-side `time() - curvine_fuse_sender_last_progress_unixtime` yields
     /// the age since a sender last delivered a reply, so a single sender stalled
     /// in `send().await` (issue #1215) shows a growing age while its siblings
@@ -679,10 +685,12 @@ impl FuseMetrics {
             sender_last_progress_unixtime: m::new_gauge_vec(
                 "curvine_fuse_sender_last_progress_unixtime",
                 "Unix timestamp (seconds) of the last successful reply write per sender \
-                 (label sender=channel index). Use time() - <this> at scrape time to get \
-                 the age since a sender last delivered a reply; a growing age on one sender \
-                 while siblings refresh indicates a stalled reply sender (issue #1215)",
-                &["sender"],
+                 (labels mnt=mount path, sender=channel index within the mount; initialized \
+                 to sender construction time so a cold series is not a spurious 0). Use \
+                 time() - <this> at scrape time to get the age since a sender last delivered \
+                 a reply; a growing age on one series while siblings refresh indicates a \
+                 stalled reply sender (issue #1215)",
+                &["mnt", "sender"],
             )?,
             setlkw_inflight: m::new_gauge(
                 "curvine_fuse_setlkw_inflight",
@@ -1431,13 +1439,16 @@ impl FuseMetrics {
         self.kernel_fd_health.set(if healthy { 1 } else { 0 });
     }
 
-    /// Return the per-sender child gauge for `sender_last_progress_unixtime`.
-    /// Fetched ONCE per sender (the child is an Arc-backed handle, cheap to hold
-    /// and cheap to `.set()`), so the hot reply path does no label lookup or
-    /// string allocation. Call `record_sender_progress` on the returned handle.
-    pub(crate) fn sender_progress_gauge(&self, idx: usize) -> Gauge {
+    /// Return the per-sender child gauge for `sender_last_progress_unixtime`,
+    /// keyed by mount path + channel index. Fetched ONCE per sender (the child is
+    /// an Arc-backed handle, cheap to hold and cheap to `.set()`), so the hot
+    /// reply path does no label lookup or string allocation. The `mnt` label
+    /// disambiguates senders across mounts (each mount indexes its senders
+    /// 0..N, so the index alone is not unique). Call `record_sender_progress` on
+    /// the returned handle.
+    pub(crate) fn sender_progress_gauge(&self, mnt: &str, idx: usize) -> Gauge {
         self.sender_last_progress_unixtime
-            .with_label_values(&[&idx.to_string()])
+            .with_label_values(&[mnt, &idx.to_string()])
     }
 
     /// Set a sender's last-progress gauge to now (Unix seconds). Deliberately
@@ -1919,6 +1930,37 @@ mod tests {
             v,
             before,
             after
+        );
+    }
+
+    // #1215 review fix: the metric must carry a `mnt` dimension so senders with
+    // the same channel index on DIFFERENT mounts do not collide on one series
+    // (which would let an active mount mask a stalled mount's stall). Fetches two
+    // child gauges with the same idx but different mnt from the real process-wide
+    // vec and asserts they are independent series — a write to one does not move
+    // the other. Uses unique mnt paths so it is safe under parallel test runs.
+    #[test]
+    fn sender_progress_gauge_distinct_per_mount_same_index() {
+        FuseMetrics::ensure_init().unwrap();
+        let m = FuseMetrics::get();
+        let ga = m.sender_progress_gauge("/test/mnt-collision-a", 0);
+        let gb = m.sender_progress_gauge("/test/mnt-collision-b", 0);
+
+        ga.set(111);
+        gb.set(222);
+        assert_eq!(ga.get(), 111, "mount A series holds its own value");
+        assert_eq!(
+            gb.get(),
+            222,
+            "mount B series is independent; same idx on another mount must not collide"
+        );
+
+        // Re-fetching the same (mnt, idx) returns the same underlying series.
+        let ga2 = m.sender_progress_gauge("/test/mnt-collision-a", 0);
+        assert_eq!(
+            ga2.get(),
+            111,
+            "same (mnt, idx) maps to the same child gauge"
         );
     }
 

--- a/curvine-fuse/src/fuse_metrics.rs
+++ b/curvine-fuse/src/fuse_metrics.rs
@@ -17,7 +17,9 @@ use std::time::Instant;
 use log::warn;
 use once_cell::sync::OnceCell;
 
-use orpc::common::{Counter, CounterVec, Gauge, GaugeVec, Histogram, HistogramVec, Metrics as m};
+use orpc::common::{
+    Counter, CounterVec, Gauge, GaugeVec, Histogram, HistogramVec, LocalTime, Metrics as m,
+};
 use orpc::CommonResult;
 
 use crate::fuse_error::errno_label;
@@ -332,6 +334,15 @@ pub struct FuseMetrics {
     /// created at enqueue and dropped when the sender dequeues (or when an
     /// un-received task is dropped). No `_total` suffix (it is a gauge).
     pub(crate) reply_queue_depth: Gauge,
+    /// Per-sender last-progress timestamp (Unix seconds), labelled by `sender`
+    /// (the sender's channel index). Set after every successful reply write in
+    /// `FuseSender`. This is the Prometheus "last success timestamp" pattern:
+    /// scrape-side `time() - curvine_fuse_sender_last_progress_unixtime` yields
+    /// the age since a sender last delivered a reply, so a single sender stalled
+    /// in `send().await` (issue #1215) shows a growing age while its siblings
+    /// keep refreshing — which a global gauge cannot distinguish. Observability
+    /// only; no automatic action is taken on a stale sender here.
+    pub(crate) sender_last_progress_unixtime: GaugeVec,
     /// SETLKW interruptible-request scope in flight (NOT a `pending_requests` map
     /// size): the guard spans the whole `dispatch_meta_interrupt` scope, so under
     /// reply-channel backpressure it can stay non-zero after the map entry is
@@ -664,6 +675,14 @@ impl FuseMetrics {
             reply_queue_depth: m::new_gauge(
                 "curvine_fuse_reply_queue_depth",
                 "Reply-channel backlog (tasks enqueued but not yet received by the sender)",
+            )?,
+            sender_last_progress_unixtime: m::new_gauge_vec(
+                "curvine_fuse_sender_last_progress_unixtime",
+                "Unix timestamp (seconds) of the last successful reply write per sender \
+                 (label sender=channel index). Use time() - <this> at scrape time to get \
+                 the age since a sender last delivered a reply; a growing age on one sender \
+                 while siblings refresh indicates a stalled reply sender (issue #1215)",
+                &["sender"],
             )?,
             setlkw_inflight: m::new_gauge(
                 "curvine_fuse_setlkw_inflight",
@@ -1411,6 +1430,26 @@ impl FuseMetrics {
     pub(crate) fn set_kernel_fd_health(&self, healthy: bool) {
         self.kernel_fd_health.set(if healthy { 1 } else { 0 });
     }
+
+    /// Return the per-sender child gauge for `sender_last_progress_unixtime`.
+    /// Fetched ONCE per sender (the child is an Arc-backed handle, cheap to hold
+    /// and cheap to `.set()`), so the hot reply path does no label lookup or
+    /// string allocation. Call `record_sender_progress` on the returned handle.
+    pub(crate) fn sender_progress_gauge(&self, idx: usize) -> Gauge {
+        self.sender_last_progress_unixtime
+            .with_label_values(&[&idx.to_string()])
+    }
+
+    /// Set a sender's last-progress gauge to now (Unix seconds). Deliberately
+    /// WALL-CLOCK (unlike `mono_now`'s monotonic duration source): this is a
+    /// timestamp meant to be compared against Prometheus `time()` at scrape,
+    /// which is also wall-clock — the two must share the same clock. An NTP step
+    /// only perturbs the derived age transiently, acceptable for a coarse
+    /// staleness signal.
+    pub(crate) fn record_sender_progress(gauge: &Gauge) {
+        let secs = (LocalTime::mills() / 1000) as i64;
+        gauge.set(secs);
+    }
 }
 
 /// Map a stream opcode to the read/write `io_type` for `io_dispatch_duration_us`,
@@ -1857,6 +1896,30 @@ mod tests {
         assert_send::<ActiveGuard>();
         assert_send::<HistogramTimer>();
         assert_send::<FuseReqLabels>();
+    }
+
+    // #1215 observability: record_sender_progress writes the current wall-clock
+    // Unix time (seconds) into the given gauge. Uses an INJECTED isolated gauge
+    // (not the process-global vec) so it is parallel-safe. Asserts the value is a
+    // plausible current Unix timestamp — i.e. the production mills()/1000 clock
+    // conversion actually lands in seconds, not millis.
+    #[test]
+    fn record_sender_progress_sets_current_unix_seconds() {
+        let g = m::new_gauge("test_sender_progress_gauge", "test").unwrap();
+        assert_eq!(g.get(), 0, "fresh gauge starts at 0");
+
+        let before = (LocalTime::mills() / 1000) as i64;
+        FuseMetrics::record_sender_progress(&g);
+        let after = (LocalTime::mills() / 1000) as i64;
+
+        let v = g.get();
+        assert!(
+            v >= before && v <= after,
+            "gauge {} must be a current Unix-second timestamp in [{}, {}]",
+            v,
+            before,
+            after
+        );
     }
 
     #[test]

--- a/curvine-fuse/src/session/channel/fuse_sender.rs
+++ b/curvine-fuse/src/session/channel/fuse_sender.rs
@@ -20,6 +20,7 @@ use crate::fuse_metrics::{
 use crate::session::{FuseTask, ResponseData};
 use crate::FuseResult;
 use log::{info, warn};
+use orpc::common::Gauge;
 use orpc::io::IOResult;
 use orpc::runtime::Runtime;
 use orpc::sync::channel::AsyncReceiver;
@@ -43,9 +44,15 @@ pub struct FuseSender<T> {
     receiver: AsyncReceiver<FuseTask>,
     pipe2: Option<Pipe2>,
     debug: bool,
+    /// Per-sender `sender_last_progress_unixtime` child gauge, fetched once at
+    /// construction (no per-reply label lookup). `None` when metrics are
+    /// disabled. Set after every successful reply write; a growing scrape-side
+    /// age on one sender localizes a stalled reply sender (issue #1215).
+    progress: Option<Gauge>,
 }
 
 impl<T: FileSystem> FuseSender<T> {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         fs: Arc<T>,
         rt: Arc<Runtime>,
@@ -54,9 +61,16 @@ impl<T: FileSystem> FuseSender<T> {
         buf_size: usize,
         debug: bool,
         enable_splice: bool,
+        idx: usize,
+        metrics_enabled: bool,
     ) -> IOResult<Self> {
         let pipe2 = if enable_splice {
             Some(Pipe2::new(PipeFd::new(buf_size, false, false)?)?)
+        } else {
+            None
+        };
+        let progress = if metrics_enabled {
+            Some(FuseMetrics::get().sender_progress_gauge(idx))
         } else {
             None
         };
@@ -67,6 +81,7 @@ impl<T: FileSystem> FuseSender<T> {
             receiver,
             pipe2,
             debug,
+            progress,
         };
 
         Ok(fuse_rx)
@@ -147,6 +162,17 @@ impl<T: FileSystem> FuseSender<T> {
 
                     // Finish point: drop the in-flight guard after the write.
                     drop(active);
+
+                    // Observability (#1215): record sender liveness on a
+                    // successful delivery. A stalled sender stops advancing this
+                    // timestamp while siblings keep refreshing, localizing the
+                    // stall at scrape time. Not recorded on a failed write (the
+                    // sender is still alive; the failure has its own metric).
+                    if matches!(write, WriteOutcome::Success) {
+                        if let Some(g) = &self.progress {
+                            FuseMetrics::record_sender_progress(g);
+                        }
+                    }
                 }
 
                 // A kernel notification: same splice, no request guard/finish.
@@ -163,7 +189,13 @@ impl<T: FileSystem> FuseSender<T> {
                     let id = data.header.unique;
                     let metrics = FuseMetrics::get();
                     match self.send(data).await {
-                        Ok(()) => metrics.record_notify_result(code, NOTIFY_SUCCESS),
+                        Ok(()) => {
+                            metrics.record_notify_result(code, NOTIFY_SUCCESS);
+                            // Same liveness signal as the request path (#1215).
+                            if let Some(g) = &self.progress {
+                                FuseMetrics::record_sender_progress(g);
+                            }
+                        }
                         Err(e) => {
                             if e.raw_error().raw_os_error() != Some(libc::ENOENT) {
                                 warn!("error send notify {}: {}", id, e);

--- a/curvine-fuse/src/session/channel/fuse_sender.rs
+++ b/curvine-fuse/src/session/channel/fuse_sender.rs
@@ -61,6 +61,7 @@ impl<T: FileSystem> FuseSender<T> {
         buf_size: usize,
         debug: bool,
         enable_splice: bool,
+        mnt: &str,
         idx: usize,
         metrics_enabled: bool,
     ) -> IOResult<Self> {
@@ -70,7 +71,13 @@ impl<T: FileSystem> FuseSender<T> {
             None
         };
         let progress = if metrics_enabled {
-            Some(FuseMetrics::get().sender_progress_gauge(idx))
+            let g = FuseMetrics::get().sender_progress_gauge(mnt, idx);
+            // Seed the cold series with construction time, not the default 0, so a
+            // scrape-side `time() - <metric>` is ~0 for a freshly built / idle
+            // sender instead of a huge age that would false-page at startup (#1215
+            // review). The real signal is a series whose value stops advancing.
+            FuseMetrics::record_sender_progress(&g);
+            Some(g)
         } else {
             None
         };

--- a/curvine-fuse/src/session/channel/mod.rs
+++ b/curvine-fuse/src/session/channel/mod.rs
@@ -48,7 +48,7 @@ impl<T: FileSystem> FuseChannel<T> {
         let mut receivers = Vec::with_capacity(tasks_per_mnt);
         let mut senders = Vec::with_capacity(tasks_per_mnt);
         let pending_requests = Arc::new(FastDashMap::default());
-        for _ in 0..tasks_per_mnt {
+        for idx in 0..tasks_per_mnt {
             let (tx, rx) = AsyncChannel::new(conf.fuse_channel_size).split();
             let fd = mnt.create_async_task_fd(conf.clone_fd)?;
 
@@ -60,6 +60,8 @@ impl<T: FileSystem> FuseChannel<T> {
                 buf_size,
                 conf.debug,
                 conf.enable_splice,
+                idx,
+                conf.metrics_enabled,
             )?;
 
             let receiver = FuseReceiver::new(

--- a/curvine-fuse/src/session/channel/mod.rs
+++ b/curvine-fuse/src/session/channel/mod.rs
@@ -48,6 +48,9 @@ impl<T: FileSystem> FuseChannel<T> {
         let mut receivers = Vec::with_capacity(tasks_per_mnt);
         let mut senders = Vec::with_capacity(tasks_per_mnt);
         let pending_requests = Arc::new(FastDashMap::default());
+        // Mount path is the `mnt` label that disambiguates sender indices across
+        // mounts (each mount indexes its senders 0..N). Computed once here.
+        let mnt_label = mnt.path.to_string_lossy().into_owned();
         for idx in 0..tasks_per_mnt {
             let (tx, rx) = AsyncChannel::new(conf.fuse_channel_size).split();
             let fd = mnt.create_async_task_fd(conf.clone_fd)?;
@@ -60,6 +63,7 @@ impl<T: FileSystem> FuseChannel<T> {
                 buf_size,
                 conf.debug,
                 conf.enable_splice,
+                &mnt_label,
                 idx,
                 conf.metrics_enabled,
             )?;


### PR DESCRIPTION
# Summary
Add a per-sender liveness metric so a stalled FUSE reply sender can be localized from metrics alone. Companion to #1241 (the splice-hang root-cause fix); this PR is the observability half and is independent of it.

# Issue Describe / Design
Related to #1215

Problem: when one reply sender stops making progress (issue #1215), the existing `curvine_fuse_reply_queue_depth` / `curvine_fuse_active_requests` are process-global gauges — they show that *something* is backed up but cannot tell a single stalled sender apart from transient high load, and cannot say *which* sender.

Design:
- New `curvine_fuse_sender_last_progress_unixtime{sender=<channel index>}` gauge, set to the current wall-clock Unix time (seconds) after every successful reply write in `FuseSender` (both the request-reply and notify paths).
- This is the Prometheus "last success timestamp" pattern. At scrape time:
  ```promql
  time() - curvine_fuse_sender_last_progress_unixtime
  ```
  yields the age since each sender last delivered a reply. A single sender stalled in `send().await` shows a growing age on its series while siblings keep refreshing.
- Example alert: `time() - curvine_fuse_sender_last_progress_unixtime > 30` for a sustained window.

Design decisions / trade-offs:
- Wall-clock (not the monotonic `mono_now` used for durations) is deliberate: the value is compared against Prometheus `time()`, which is also wall-clock, so the two must share a clock. An NTP step only perturbs the derived age transiently.
- The per-sender child gauge is fetched once at construction, so the hot reply path does no label lookup or string allocation — just one CLOCK_REALTIME vDSO read + one atomic store (~20ns). Fully skipped when metrics are disabled (`progress: Option<Gauge>` is `None`).
- Observability only: no automatic action is taken on a stale sender here. Consuming this signal to fail the session over to the supervisor is intentionally left as a follow-up (watchdog).

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-fuse/src/fuse_metrics.rs` | New `sender_last_progress_unixtime` GaugeVec; `sender_progress_gauge(idx)` (fetch child once) and `record_sender_progress(&Gauge)` helpers | None (additive metric) |
| `curvine-fuse/src/session/channel/fuse_sender.rs` | `FuseSender` holds `Option<Gauge>`; `new` takes `idx` + `metrics_enabled`; record progress after successful request/notify replies | None on the delivery path; one atomic store + vDSO clock read per successful reply when metrics enabled |
| `curvine-fuse/src/session/channel/mod.rs` | Pass sender index + `metrics_enabled` into `FuseSender::new` | None |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-fuse --lib fuse_metrics::tests` | PASS | 48 tests; incl. new `record_sender_progress_sets_current_unix_seconds` (asserts the gauge lands a current Unix-second timestamp) |
| `cargo test -p curvine-fuse --lib session::channel` | PASS | 30 tests, sender/receiver paths unaffected |
| `cargo clippy -p curvine-fuse --all-targets -- --deny=warnings` | PASS | |
| `cargo fmt -p curvine-fuse -- --check` | PASS | |

# Dependencies
- Related PRs: #1241 (splice reply-sender hang root-cause fix; independent root cause, not bundled)
- Related issues: #1215
- Blocks / blocked by: None