### PR TITLE
refactor(rpc): make message handlers safely shareable

### DIFF
--- a/curvine-common/src/conf/master_conf.rs
+++ b/curvine-common/src/conf/master_conf.rs
@@ -35,6 +35,9 @@ pub struct MasterConf {
     pub io_timeout: String,
     pub io_close_idle: bool,
 
+    // Whether metadata requests can be processed concurrently within a connection.
+    pub meta_request_concurrent: bool,
+
     // Metadata configuration, currently only supports rocksdb.
     // rocksdb configuration.
     pub meta_dir: String,
@@ -131,6 +134,9 @@ pub struct MasterConf {
 
     pub buffer_size: usize,
 
+    pub conn_limit: usize,
+    pub global_limit: usize,
+
     #[serde(default = "MasterConf::rocksdb_default")]
     pub rocksdb: DBConf,
 }
@@ -163,6 +169,14 @@ impl MasterConf {
 
         if self.heartbeat_interval_unit > self.worker_lost_interval_unit {
             return err_box!("Worker_lost_interval must be greater than heartbeat_interval");
+        }
+
+        if self.conn_limit == 0 {
+            return err_box!("master.conn_limit must be greater than zero");
+        }
+
+        if self.global_limit == 0 {
+            return err_box!("master.global_limit must be greater than zero");
         }
 
         Ok(())
@@ -249,6 +263,7 @@ impl Default for MasterConf {
             actor_threads: 4,
             io_timeout: "10m".to_string(),
             io_close_idle: true,
+            meta_request_concurrent: true,
 
             meta_dir: dir,
 
@@ -319,6 +334,9 @@ impl Default for MasterConf {
             lock_expire_time_unit: Default::default(),
 
             buffer_size: 128 * 1024,
+
+            conn_limit: 8,
+            global_limit: 4096,
 
             rocksdb,
         };

--- a/curvine-common/src/raft/raft_server.rs
+++ b/curvine-common/src/raft/raft_server.rs
@@ -24,6 +24,7 @@ use orpc::io::net::ConnState;
 use orpc::message::Message;
 use orpc::runtime::Runtime;
 use orpc::server::{RpcServer, ServerConf, ServerStateListener};
+use orpc::sync::FastMutex;
 use orpc::{err_box, try_option, CommonResult};
 use std::sync::Arc;
 use std::time::Duration;
@@ -94,7 +95,7 @@ impl HandlerService for RaftService {
     fn get_message_handler(&self, _: Option<ConnState>) -> Self::Item {
         RaftHandler {
             sender: self.sender.clone(),
-            download_handler: SnapshotDownloadHandler::new(1024 * 1024),
+            download_handler: FastMutex::new(SnapshotDownloadHandler::new(1024 * 1024)),
             retry_cache: self.retry_cache.clone(),
         }
     }
@@ -102,7 +103,7 @@ impl HandlerService for RaftService {
 
 pub struct RaftHandler {
     sender: mpsc::Sender<Envelope>,
-    download_handler: SnapshotDownloadHandler,
+    download_handler: FastMutex<SnapshotDownloadHandler>,
     retry_cache: Arc<Cache<i64, ()>>,
 }
 
@@ -114,16 +115,16 @@ impl MessageHandler for RaftHandler {
         matches!(code, RaftCode::SnapshotDownload)
     }
 
-    fn handle(&mut self, msg: &Message) -> RaftResult<Message> {
+    fn handle(&self, msg: &Message) -> RaftResult<Message> {
         let code = RaftCode::from(msg.code());
         match code {
-            RaftCode::SnapshotDownload => self.download_handler.handle(msg),
+            RaftCode::SnapshotDownload => self.download_handler.lock().handle(msg),
 
             _ => err_box!("Unsupported request type: {:?}", code),
         }
     }
 
-    async fn async_handle(&mut self, msg: Message) -> Result<Message, Self::Error> {
+    async fn async_handle(&self, msg: Message) -> Result<Message, Self::Error> {
         // Check for duplicate requests
         if RaftCode::from(msg.code()) == RaftCode::Propose {
             match self.retry_cache.get(&msg.req_id()) {

--- a/curvine-common/src/raft/snapshot/download_handler.rs
+++ b/curvine-common/src/raft/snapshot/download_handler.rs
@@ -14,9 +14,8 @@
 
 use crate::proto::raft::{SnapshotDownloadRequest, SnapshotDownloadResponse};
 use crate::raft::snapshot::FileReader;
-use crate::raft::{RaftError, RaftResult, RaftUtils};
+use crate::raft::{RaftResult, RaftUtils};
 use log::{debug, error};
-use orpc::handler::MessageHandler;
 use orpc::message::{Builder, Message, RequestStatus};
 use orpc::sys::DataSlice;
 use orpc::{err_box, try_option_mut};
@@ -93,12 +92,8 @@ impl SnapshotDownloadHandler {
         let _ = self.reader.take();
         Ok(msg.success())
     }
-}
 
-impl MessageHandler for SnapshotDownloadHandler {
-    type Error = RaftError;
-
-    fn handle(&mut self, msg: &Message) -> RaftResult<Message> {
+    pub fn handle(&mut self, msg: &Message) -> RaftResult<Message> {
         let res = match msg.request_status() {
             RequestStatus::Open => self.open(msg),
 

--- a/curvine-server/src/master/job/job_handler.rs
+++ b/curvine-server/src/master/job/job_handler.rs
@@ -21,7 +21,6 @@ use curvine_common::state::{JobTaskType, LoadJobCommand};
 use curvine_common::utils::{ProtoUtils, SerdeUtils};
 use curvine_common::FsResult;
 use orpc::err_box;
-use orpc::handler::FrameBuf;
 use orpc::message::Message;
 use std::sync::Arc;
 
@@ -41,11 +40,7 @@ impl JobHandler {
     ///
     /// Handles the submission of a new job by parsing the request,
     /// validating parameters, and forwarding to the job manager.
-    pub async fn submit_job(
-        &self,
-        ctx: &mut RpcContext<'_>,
-        buf: &mut FrameBuf,
-    ) -> FsResult<Message> {
+    pub async fn submit_job(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let req: SubmitJobRequest = ctx.parse_header()?;
         let command: LoadJobCommand = SerdeUtils::deserialize(&req.job_command)?;
         ctx.set_audit(Some(command.source_path.clone()), None);
@@ -67,18 +62,14 @@ impl JobHandler {
             state: res.state as i32,
         };
 
-        ctx.response_buf(response, buf)
+        ctx.response(response)
     }
 
     /// Get the loading task status
     ///
     /// Retrieves the current status of a load job by its ID and constructs
     /// a response with detailed metrics.
-    pub fn get_load_status(
-        &self,
-        ctx: &mut RpcContext<'_>,
-        buf: &mut FrameBuf,
-    ) -> FsResult<Message> {
+    pub fn get_load_status(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let req: GetJobStatusRequest = ctx.parse_header()?;
         ctx.set_audit(Some(req.job_id.clone()), None);
 
@@ -91,18 +82,14 @@ impl JobHandler {
             progress: ProtoUtils::work_progress_to_pb(status.progress),
         };
 
-        ctx.response_buf(response, buf)
+        ctx.response(response)
     }
 
     /// Cancel the loading task
     ///
     /// Handles the cancellation of a load job by its ID and returns
     /// the result of the cancellation operation.
-    pub async fn cancel_job(
-        &self,
-        ctx: &mut RpcContext<'_>,
-        buf: &mut FrameBuf,
-    ) -> FsResult<Message> {
+    pub async fn cancel_job(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let req: CancelJobRequest = ctx.parse_header()?;
 
         let job_id = req.job_id;
@@ -110,14 +97,14 @@ impl JobHandler {
 
         self.job_manager.cancel_job(job_id.clone()).await?;
 
-        ctx.response_buf(CancelJobResponse {}, buf)
+        ctx.response(CancelJobResponse {})
     }
 
     /// Handle the task status reported by Worker
     ///
     /// Processes status reports from worker nodes about load tasks,
     /// updating the job status in the load manager.
-    pub fn task_report(&self, ctx: &mut RpcContext<'_>, buf: &mut FrameBuf) -> FsResult<Message> {
+    pub fn task_report(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let req: TaskReportRequest = ctx.parse_header()?;
         let job_id = req.job_id.clone();
         ctx.set_audit(Some(job_id.clone()), None);
@@ -129,6 +116,6 @@ impl JobHandler {
             ProtoUtils::work_progress_from_pb(req.report),
         )?;
 
-        ctx.response_buf(TaskReportResponse {}, buf)
+        ctx.response(TaskReportResponse {})
     }
 }

--- a/curvine-server/src/master/master_handler.rs
+++ b/curvine-server/src/master/master_handler.rs
@@ -30,7 +30,7 @@ use curvine_common::state::{
 use curvine_common::utils::ProtoUtils;
 use curvine_common::FsResult;
 use orpc::err_box;
-use orpc::handler::{FrameBuf, MessageHandler};
+use orpc::handler::MessageHandler;
 use orpc::io::net::ConnState;
 use orpc::message::Message;
 use orpc::runtime::Runtime;
@@ -46,7 +46,6 @@ pub struct MasterHandler {
     pub(crate) mount_manager: Arc<MountManager>,
     pub(crate) replication_handler: Option<MasterReplicationHandler>,
     pub(crate) actor_rt: Arc<Runtime>,
-    pub(crate) buf: FrameBuf,
 }
 
 impl MasterHandler {
@@ -72,7 +71,6 @@ impl MasterHandler {
             job_handler,
             replication_handler: Some(MasterReplicationHandler::new(replication_manager)),
             actor_rt,
-            buf: FrameBuf::new(conf.master.buffer_size),
         }
     }
 
@@ -99,7 +97,7 @@ impl MasterHandler {
         }
     }
 
-    pub fn mkdir(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+    pub fn mkdir(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let header: MkdirRequest = ctx.parse_header()?;
         ctx.set_audit(Some(header.path.to_string()), None);
 
@@ -109,11 +107,11 @@ impl MasterHandler {
             status: ProtoUtils::file_status_to_pb(status),
             ..Default::default()
         };
-        ctx.response_buf(rep_header, &mut self.buf)
+        ctx.response(rep_header)
     }
 
     fn create_file0(
-        &mut self,
+        &self,
         req_id: i64,
         path: String,
         opts: CreateFileOpts,
@@ -131,7 +129,7 @@ impl MasterHandler {
         self.set_req_cache(req_id, res)
     }
 
-    pub fn retry_check_create_file(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+    pub fn retry_check_create_file(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let header: CreateFileRequest = ctx.parse_header()?;
         ctx.set_audit(Some(header.path.to_string()), None);
 
@@ -142,10 +140,10 @@ impl MasterHandler {
         let rep_header = CreateFileResponse {
             file_status: ProtoUtils::file_status_to_pb(status),
         };
-        ctx.response_buf(rep_header, &mut self.buf)
+        ctx.response(rep_header)
     }
 
-    pub fn retry_check_open_file(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+    pub fn retry_check_open_file(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let header: OpenFileRequest = ctx.parse_header()?;
 
         let opts = ProtoUtils::create_opts_from_pb(header.opts);
@@ -158,11 +156,11 @@ impl MasterHandler {
         let rep_header = OpenFileResponse {
             file_blocks: ProtoUtils::file_blocks_to_pb(file_blocks),
         };
-        ctx.response_buf(rep_header, &mut self.buf)
+        ctx.response(rep_header)
     }
 
     fn open_file0(
-        &mut self,
+        &self,
         req_id: i64,
         path: String,
         opts: CreateFileOpts,
@@ -180,7 +178,7 @@ impl MasterHandler {
         self.set_req_cache(req_id, res)
     }
 
-    pub fn file_status(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+    pub fn file_status(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let header: GetFileStatusRequest = ctx.parse_header()?;
         ctx.set_audit(Some(header.path.to_string()), None);
 
@@ -189,19 +187,19 @@ impl MasterHandler {
             status: ProtoUtils::file_status_to_pb(status),
         };
 
-        ctx.response_buf(rep_header, &mut self.buf)
+        ctx.response(rep_header)
     }
 
-    pub fn exists(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+    pub fn exists(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let header: ExistsRequest = ctx.parse_header()?;
         ctx.set_audit(Some(header.path.to_string()), None);
 
         let exists = self.fs.exists(&header.path)?;
         let rep_header = ExistsResponse { exists };
-        ctx.response_buf(rep_header, &mut self.buf)
+        ctx.response(rep_header)
     }
 
-    pub fn delete0(&mut self, req_id: i64, header: DeleteRequest) -> FsResult<bool> {
+    pub fn delete0(&self, req_id: i64, header: DeleteRequest) -> FsResult<bool> {
         if self.check_is_retry(req_id)? {
             return Ok(true);
         }
@@ -217,26 +215,23 @@ impl MasterHandler {
         self.set_req_cache(req_id, res)
     }
 
-    pub fn retry_check_delete(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+    pub fn retry_check_delete(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let header: DeleteRequest = ctx.parse_header()?;
         ctx.set_audit(Some(header.path.to_string()), None);
 
         self.delete0(ctx.msg.req_id(), header)?;
         let rep_header = DeleteResponse::default();
-        ctx.response_buf(rep_header, &mut self.buf)
+        ctx.response(rep_header)
     }
 
-    pub fn retry_check_free(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+    pub fn retry_check_free(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let header: FreeRequest = ctx.parse_header()?;
         ctx.set_audit(Some(header.path.to_string()), None);
 
         let res = self.free0(ctx.msg.req_id(), header)?;
-        ctx.response_buf(
-            FreeResponse {
-                res: ProtoUtils::free_res_to_pb(res),
-            },
-            &mut self.buf,
-        )
+        ctx.response(FreeResponse {
+            res: ProtoUtils::free_res_to_pb(res),
+        })
     }
 
     pub fn free0(&self, req_id: i64, header: FreeRequest) -> FsResult<FreeResult> {
@@ -248,7 +243,7 @@ impl MasterHandler {
         self.set_req_cache(req_id, res)
     }
 
-    pub fn rename0(&mut self, req_id: i64, header: RenameRequest) -> FsResult<bool> {
+    pub fn rename0(&self, req_id: i64, header: RenameRequest) -> FsResult<bool> {
         if self.check_is_retry(req_id)? {
             return Ok(true);
         }
@@ -257,16 +252,16 @@ impl MasterHandler {
         self.set_req_cache(req_id, res)
     }
 
-    pub fn retry_check_rename(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+    pub fn retry_check_rename(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let header: RenameRequest = ctx.parse_header()?;
         ctx.set_audit(Some(header.src.to_string()), Some(header.dst.to_string()));
 
         let result = self.rename0(ctx.msg.req_id(), header)?;
         let rep_header = RenameResponse { result };
-        ctx.response_buf(rep_header, &mut self.buf)
+        ctx.response(rep_header)
     }
 
-    pub fn list_status(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+    pub fn list_status(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let header: ListStatusRequest = ctx.parse_header()?;
         ctx.set_audit(Some(header.path.to_string()), None);
 
@@ -277,7 +272,7 @@ impl MasterHandler {
             .collect();
 
         let rep_header = ListStatusResponse { statuses: res };
-        ctx.response_buf(rep_header, &mut self.buf)
+        ctx.response(rep_header)
     }
 
     fn process_list_status(fs: MasterFilesystem, path: String) -> FsResult<Vec<FileStatus>> {
@@ -285,7 +280,7 @@ impl MasterHandler {
     }
 
     // The add block internally determines whether it is a retry request.
-    pub fn add_block(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+    pub fn add_block(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let req: AddBlockRequest = ctx.parse_header()?;
         ctx.set_audit(Some(req.path.to_string()), None);
 
@@ -308,11 +303,11 @@ impl MasterHandler {
             last_block,
         )?;
         let rep_header = ProtoUtils::located_block_to_pb(located_block);
-        ctx.response_buf(rep_header, &mut self.buf)
+        ctx.response(rep_header)
     }
 
     // Complete_file internally determines whether it is a retry request.
-    pub fn complete_file(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+    pub fn complete_file(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let req: CompleteFileRequest = ctx.parse_header()?;
 
         let audit_path = if req.only_flush {
@@ -339,10 +334,10 @@ impl MasterHandler {
             result: true,
             file_blocks: file_blocks.map(ProtoUtils::file_blocks_to_pb),
         };
-        ctx.response_buf(rep_header, &mut self.buf)
+        ctx.response(rep_header)
     }
 
-    pub fn create_files_batch(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+    pub fn create_files_batch(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let header: CreateFilesBatchRequest = ctx.parse_header()?;
 
         let mut results = Vec::with_capacity(header.requests.len());
@@ -362,10 +357,10 @@ impl MasterHandler {
                 .map(ProtoUtils::file_status_to_pb)
                 .collect(),
         };
-        ctx.response_buf(rep_header, &mut self.buf)
+        ctx.response(rep_header)
     }
 
-    pub fn add_blocks_batch(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+    pub fn add_blocks_batch(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let header: AddBlocksBatchRequest = ctx.parse_header()?;
         let mut results = Vec::with_capacity(header.requests.len());
         for req in header.requests {
@@ -391,10 +386,10 @@ impl MasterHandler {
         }
 
         let rep_header = AddBlocksBatchResponse { blocks: results };
-        ctx.response_buf(rep_header, &mut self.buf)
+        ctx.response(rep_header)
     }
 
-    pub fn complete_files_batch(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+    pub fn complete_files_batch(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let header: CompleteFilesBatchRequest = ctx.parse_header()?;
 
         let mut results = Vec::new();
@@ -419,10 +414,10 @@ impl MasterHandler {
         }
 
         let rep_header = CompleteFilesBatchResponse { results };
-        ctx.response_buf(rep_header, &mut self.buf)
+        ctx.response(rep_header)
     }
 
-    pub fn get_block_locations(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+    pub fn get_block_locations(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let req: GetBlockLocationsRequest = ctx.parse_header()?;
         ctx.set_audit(Some(req.path.to_string()), None);
 
@@ -430,32 +425,32 @@ impl MasterHandler {
         let rep_header = GetBlockLocationsResponse {
             blocks: ProtoUtils::file_blocks_to_pb(blocks),
         };
-        ctx.response_buf(rep_header, &mut self.buf)
+        ctx.response(rep_header)
     }
 
     fn process_get_block_locations(fs: MasterFilesystem, path: String) -> FsResult<FileBlocks> {
         fs.get_block_locations(path)
     }
 
-    pub fn get_master_info(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+    pub fn get_master_info(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let _: GetMasterInfoRequest = ctx.parse_header()?;
 
         let info = Self::process_get_master_info(self.fs.clone())?;
         let rep_header = ProtoUtils::master_info_to_pb(info);
-        ctx.response_buf(rep_header, &mut self.buf)
+        ctx.response(rep_header)
     }
 
     fn process_get_master_info(fs: MasterFilesystem) -> FsResult<MasterInfo> {
         fs.master_info()
     }
 
-    pub fn worker_heartbeat(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+    pub fn worker_heartbeat(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let header: WorkerHeartbeatRequest = ctx.parse_header()?;
         let cmds = Self::process_worker_heartbeat(self.fs.clone(), header)?;
         let rep_header = WorkerHeartbeatResponse {
             cmds: ProtoUtils::worker_cmd_to_pb(cmds),
         };
-        ctx.response_buf(rep_header, &mut self.buf)
+        ctx.response(rep_header)
     }
 
     fn process_worker_heartbeat(
@@ -482,14 +477,14 @@ impl MasterHandler {
         Ok(cmds)
     }
 
-    pub fn block_report(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+    pub fn block_report(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let header: BlockReportListRequest = ctx.parse_header()?;
         let cmds =
             Self::process_block_report(self.fs.clone(), self.replication_handler.clone(), header)?;
         let rep_header = BlockReportListResponse {
             cmds: ProtoUtils::worker_cmd_to_pb(cmds),
         };
-        ctx.response_buf(rep_header, &mut self.buf)
+        ctx.response(rep_header)
     }
 
     fn process_block_report(
@@ -520,7 +515,7 @@ impl MasterHandler {
         self.fs.clone()
     }
 
-    fn mount(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+    fn mount(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let request: MountRequest = ctx.parse_header()?;
         let mnt_opt = ProtoUtils::mount_options_from_pb(request.mount_options);
 
@@ -532,19 +527,19 @@ impl MasterHandler {
         self.mount_manager
             .mount(None, &request.cv_path, &request.ufs_path, &mnt_opt)?;
         let rep_header = MountResponse::default();
-        ctx.response_buf(rep_header, &mut self.buf)
+        ctx.response(rep_header)
     }
 
-    fn umount(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+    fn umount(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let request: UnMountRequest = ctx.parse_header()?;
         ctx.set_audit(Some(request.cv_path.to_string()), None);
 
         self.mount_manager.umount(&request.cv_path)?;
         let rep_header = UnMountResponse::default();
-        ctx.response_buf(rep_header, &mut self.buf)
+        ctx.response(rep_header)
     }
 
-    fn get_mount_info(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+    fn get_mount_info(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let request: GetMountInfoRequest = ctx.parse_header()?;
         ctx.set_audit(Some(request.path.to_string()), None);
 
@@ -553,10 +548,10 @@ impl MasterHandler {
         let rep_header = GetMountInfoResponse {
             mount_info: ret.map(ProtoUtils::mount_info_to_pb),
         };
-        ctx.response_buf(rep_header, &mut self.buf)
+        ctx.response(rep_header)
     }
 
-    fn get_mount_table(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+    fn get_mount_table(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let _: GetMountTableRequest = ctx.parse_header()?;
         let table = self.mount_manager.get_mount_table()?;
 
@@ -565,12 +560,12 @@ impl MasterHandler {
             .map(ProtoUtils::mount_info_to_pb)
             .collect();
         let rep_header = GetMountTableResponse { mount_table };
-        ctx.response_buf(rep_header, &mut self.buf)
+        ctx.response(rep_header)
     }
 
-    fn set_attr_retry_check(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+    fn set_attr_retry_check(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         if self.check_is_retry(ctx.msg.req_id())? {
-            return ctx.response_buf(SetAttrResponse::default(), &mut self.buf);
+            return ctx.response(SetAttrResponse::default());
         }
 
         let header: SetAttrRequest = ctx.parse_header()?;
@@ -579,15 +574,12 @@ impl MasterHandler {
         let opts = ProtoUtils::set_attr_opts_from_pb(header.opts);
         let status = self.fs.set_attr(header.path, opts)?;
 
-        ctx.response_buf(
-            SetAttrResponse {
-                status: ProtoUtils::file_status_to_pb(status),
-            },
-            &mut self.buf,
-        )
+        ctx.response(SetAttrResponse {
+            status: ProtoUtils::file_status_to_pb(status),
+        })
     }
 
-    fn symlink_retry_check(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+    fn symlink_retry_check(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let header: SymlinkRequest = ctx.parse_header()?;
         ctx.set_audit(
             Some(header.target.to_string()),
@@ -595,7 +587,7 @@ impl MasterHandler {
         );
 
         if self.check_is_retry(ctx.msg.req_id())? {
-            return ctx.response_buf(SymlinkResponse::default(), &mut self.buf);
+            return ctx.response(SymlinkResponse::default());
         }
 
         self.fs.symlink_with_owner_group(
@@ -607,19 +599,19 @@ impl MasterHandler {
             header.group,
         )?;
 
-        ctx.response_buf(SymlinkResponse::default(), &mut self.buf)
+        ctx.response(SymlinkResponse::default())
     }
 
-    fn metrics_report(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+    fn metrics_report(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let header: MetricsReportRequest = ctx.parse_header()?;
 
         let metrics = ProtoUtils::metrics_report_from_pb(header.metrics);
         Master::get_metrics()?.metrics_report(metrics)?;
 
-        ctx.response_buf(MetricsReportResponse {}, &mut self.buf)
+        ctx.response(MetricsReportResponse {})
     }
 
-    fn link_retry_check(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+    fn link_retry_check(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let header: LinkRequest = ctx.parse_header()?;
         ctx.set_audit(
             Some(header.src_path.to_string()),
@@ -627,15 +619,15 @@ impl MasterHandler {
         );
 
         if self.check_is_retry(ctx.msg.req_id())? {
-            return ctx.response_buf(LinkResponse::default(), &mut self.buf);
+            return ctx.response(LinkResponse::default());
         }
 
         self.fs.link(&header.src_path, &header.dst_path)?;
 
-        ctx.response_buf(LinkResponse::default(), &mut self.buf)
+        ctx.response(LinkResponse::default())
     }
 
-    pub fn resize_file(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+    pub fn resize_file(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let header: FileResizeRequest = ctx.parse_header()?;
         ctx.set_audit(Some(header.path.to_string()), None);
 
@@ -646,10 +638,10 @@ impl MasterHandler {
         let rep_header = FileResizeResponse {
             file_blocks: ProtoUtils::file_blocks_to_pb(file_blocks),
         };
-        ctx.response_buf(rep_header, &mut self.buf)
+        ctx.response(rep_header)
     }
 
-    pub fn assign_worker(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+    pub fn assign_worker(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let header: AssignWorkerRequest = ctx.parse_header()?;
         ctx.set_audit(Some(header.path.to_string()), None);
 
@@ -662,10 +654,10 @@ impl MasterHandler {
         let rep_header = AssignWorkerResponse {
             block: ProtoUtils::located_block_to_pb(block),
         };
-        ctx.response_buf(rep_header, &mut self.buf)
+        ctx.response(rep_header)
     }
 
-    pub fn get_lock(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+    pub fn get_lock(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let header: GetLockRequest = ctx.parse_header()?;
         let lock = ProtoUtils::file_lock_from_pb(header.lock);
         ctx.set_audit(Some(header.path.to_string()), None);
@@ -674,10 +666,10 @@ impl MasterHandler {
         let rep_header = GetLockResponse {
             conflict: conflict.map(ProtoUtils::file_lock_to_pb),
         };
-        ctx.response_buf(rep_header, &mut self.buf)
+        ctx.response(rep_header)
     }
 
-    pub fn set_lock(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+    pub fn set_lock(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let header: SetLockRequest = ctx.parse_header()?;
         let lock = ProtoUtils::file_lock_from_pb(header.lock);
 
@@ -691,10 +683,10 @@ impl MasterHandler {
         let rep_header = SetLockResponse {
             conflict: conflict.map(ProtoUtils::file_lock_to_pb),
         };
-        ctx.response_buf(rep_header, &mut self.buf)
+        ctx.response(rep_header)
     }
 
-    pub fn list_options(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+    pub fn list_options(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let header: ListOptionsRequest = ctx.parse_header()?;
         if header.options.limit.unwrap_or(0) < 0 {
             return err_box!("list options limit must be greater than 0");
@@ -709,7 +701,7 @@ impl MasterHandler {
             .map(ProtoUtils::file_status_to_pb)
             .collect();
         let rep_header = ListOptionsResponse { statuses: res };
-        ctx.response_buf(rep_header, &mut self.buf)
+        ctx.response(rep_header)
     }
 
     fn process_list_options(
@@ -750,7 +742,7 @@ impl MessageHandler for MasterHandler {
         )
     }
 
-    fn handle(&mut self, msg: &Message) -> FsResult<Message> {
+    fn handle(&self, msg: &Message) -> FsResult<Message> {
         crate::fault_point! {
             sync,
             name: "master.rpc.before_sync_dispatch",
@@ -811,7 +803,7 @@ impl MessageHandler for MasterHandler {
             RpcCode::GetMasterInfo => self.get_master_info(ctx),
 
             RpcCode::ReportBlockReplicationResult => {
-                if let Some(ref mut replication_service) = self.replication_handler {
+                if let Some(ref replication_service) = self.replication_handler {
                     return replication_service.handle(msg);
                 } else {
                     return Err(FsError::common("Replication service not initialized"));
@@ -830,7 +822,7 @@ impl MessageHandler for MasterHandler {
         }
     }
 
-    async fn async_handle(&mut self, msg: Message) -> FsResult<Message> {
+    async fn async_handle(&self, msg: Message) -> FsResult<Message> {
         crate::fault_point! {
             async,
             name: "master.rpc.before_async_dispatch",
@@ -852,10 +844,10 @@ impl MessageHandler for MasterHandler {
             Err(FsError::not_leader_master(ctx.code, self.client_ip()))
         } else {
             match code {
-                RpcCode::SubmitJob => self.job_handler.submit_job(ctx, &mut self.buf).await,
-                RpcCode::GetJobStatus => self.job_handler.get_load_status(ctx, &mut self.buf),
-                RpcCode::CancelJob => self.job_handler.cancel_job(ctx, &mut self.buf).await,
-                RpcCode::ReportTask => self.job_handler.task_report(ctx, &mut self.buf),
+                RpcCode::SubmitJob => self.job_handler.submit_job(ctx).await,
+                RpcCode::GetJobStatus => self.job_handler.get_load_status(ctx),
+                RpcCode::CancelJob => self.job_handler.cancel_job(ctx).await,
+                RpcCode::ReportTask => self.job_handler.task_report(ctx),
 
                 v => err_box!("unsupported operation {:?}", v),
             }

--- a/curvine-server/src/master/master_server.rs
+++ b/curvine-server/src/master/master_server.rs
@@ -21,7 +21,7 @@ use curvine_fault::FaultHttpControl;
 use curvine_web::server::{WebHandlerService, WebServer};
 use log::error;
 use orpc::common::{LocalTime, Logger};
-use orpc::handler::HandlerService;
+use orpc::handler::{HandlerService, LimitConf};
 use orpc::io::net::ConnState;
 use orpc::runtime::{AsyncRuntime, RpcRuntime, Runtime};
 use orpc::server::{RpcServer, ServerStateListener};
@@ -47,6 +47,7 @@ pub struct MasterService {
     rt: Arc<Runtime>,
     actor_rt: Arc<Runtime>,
     replication_manager: Arc<MasterReplicationManager>,
+    limit: LimitConf,
     metrics: &'static MasterMetrics,
     fault_http: FaultHttpControl,
 }
@@ -69,6 +70,7 @@ impl MasterService {
             1,
             conf.master.actor_threads,
         ));
+        let limit = LimitConf::new(conf.master.conn_limit, conf.master.global_limit);
         Self {
             conf,
             fs,
@@ -78,6 +80,7 @@ impl MasterService {
             rt,
             actor_rt,
             replication_manager,
+            limit,
             metrics,
             fault_http,
         }
@@ -119,6 +122,14 @@ impl HandlerService for MasterService {
             self.actor_rt.clone(),
             self.metrics,
         )
+    }
+
+    fn is_stream(&self) -> bool {
+        !self.conf.master.meta_request_concurrent
+    }
+
+    fn get_limit(&self) -> LimitConf {
+        self.limit.clone()
     }
 }
 

--- a/curvine-server/src/master/replication/master_replication_handler.rs
+++ b/curvine-server/src/master/replication/master_replication_handler.rs
@@ -64,7 +64,7 @@ impl MasterReplicationHandler {
 impl MessageHandler for MasterReplicationHandler {
     type Error = FsError;
 
-    fn handle(&mut self, msg: &Message) -> FsResult<Message> {
+    fn handle(&self, msg: &Message) -> FsResult<Message> {
         let code = RpcCode::from(msg.code());
 
         // Create RpcContext

--- a/curvine-server/src/master/rpc_context.rs
+++ b/curvine-server/src/master/rpc_context.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use bytes::BytesMut;
 use curvine_common::fs::RpcCode;
 use curvine_common::FsResult;
 use log::info;
 use orpc::common::TimeSpent;
-use orpc::handler::FrameBuf;
 use orpc::io::net::ConnState;
 use orpc::message::{Builder, Message};
 use orpc::CommonResult;
@@ -53,20 +53,10 @@ impl<'a> RpcContext<'a> {
     }
 
     pub fn response<T: PMessage + Default>(&self, header: T) -> FsResult<Message> {
-        let rep_msg = Builder::success_with_header(self.msg, header).build();
-        Ok(rep_msg)
-    }
+        let mut buf = BytesMut::with_capacity(header.encoded_len());
+        header.encode(&mut buf)?;
 
-    pub fn response_buf<T: PMessage + Default>(
-        &self,
-        header: T,
-        buf: &mut FrameBuf,
-    ) -> FsResult<Message> {
-        let len = header.encoded_len();
-        let mut encode_buf = buf.take_capacity(len);
-        header.encode(&mut encode_buf)?;
-
-        let rep_msg = Builder::success(self.msg).header(encode_buf).build();
+        let rep_msg = Builder::success(self.msg).header(buf).build();
         Ok(rep_msg)
     }
 

--- a/curvine-server/src/worker/handler/batch_write_handler.rs
+++ b/curvine-server/src/worker/handler/batch_write_handler.rs
@@ -26,7 +26,6 @@ use curvine_common::proto::{
 use curvine_common::utils::ProtoUtils;
 use curvine_common::FsResult;
 use orpc::err_box;
-use orpc::handler::MessageHandler;
 use orpc::message::{Builder, Message, RequestStatus};
 use orpc::sys::DataSlice;
 use orpc::CommonResult;
@@ -349,11 +348,8 @@ impl BatchWriteHandler {
 
         Ok(msg.success())
     }
-}
 
-impl MessageHandler for BatchWriteHandler {
-    type Error = FsError;
-    fn handle(&mut self, msg: &Message) -> FsResult<Message> {
+    pub fn handle(&mut self, msg: &Message) -> FsResult<Message> {
         let request_status = msg.request_status();
         match request_status {
             // batch operations

--- a/curvine-server/src/worker/handler/batch_write_handler.rs
+++ b/curvine-server/src/worker/handler/batch_write_handler.rs
@@ -16,7 +16,6 @@ use crate::worker::block::BlockStore;
 use crate::worker::handler::WriteContext;
 use crate::worker::handler::WriteHandler;
 use crate::worker::storage::BlockWriteContext;
-use curvine_common::error::FsError;
 use curvine_common::fs::RpcCode;
 use curvine_common::proto::{
     BlockWriteRequest, BlockWriteResponse, BlocksBatchCommitRequest, BlocksBatchCommitResponse,

--- a/curvine-server/src/worker/handler/block_handler.rs
+++ b/curvine-server/src/worker/handler/block_handler.rs
@@ -15,7 +15,6 @@
 use crate::worker::block::BlockStore;
 use crate::worker::handler::BlockHandler::{BatchWriter, Reader, Writer};
 use crate::worker::handler::{BatchWriteHandler, ReadHandler, WriteHandler};
-use curvine_common::error::FsError;
 use curvine_common::fs::RpcCode;
 use curvine_common::FsResult;
 use orpc::message::Message;

--- a/curvine-server/src/worker/handler/block_handler.rs
+++ b/curvine-server/src/worker/handler/block_handler.rs
@@ -18,7 +18,6 @@ use crate::worker::handler::{BatchWriteHandler, ReadHandler, WriteHandler};
 use curvine_common::error::FsError;
 use curvine_common::fs::RpcCode;
 use curvine_common::FsResult;
-use orpc::handler::MessageHandler;
 use orpc::message::Message;
 use orpc::{err_box, CommonResult};
 
@@ -42,12 +41,8 @@ impl BlockHandler {
 
         Ok(handler)
     }
-}
 
-impl MessageHandler for BlockHandler {
-    type Error = FsError;
-
-    fn handle(&mut self, msg: &Message) -> FsResult<Message> {
+    pub fn handle(&mut self, msg: &Message) -> FsResult<Message> {
         let response = match self {
             Writer(h) => h.handle(msg),
             Reader(h) => h.handle(msg),

--- a/curvine-server/src/worker/handler/read_handler.rs
+++ b/curvine-server/src/worker/handler/read_handler.rs
@@ -22,7 +22,6 @@ use curvine_common::FsResult;
 use log::{info, warn};
 use orpc::common::{ByteUnit, TimeSpent};
 use orpc::error::ErrorExt;
-use orpc::handler::MessageHandler;
 use orpc::message::{Builder, Message, RequestStatus};
 use orpc::sys::{CacheManager, ReadAheadTask};
 use orpc::{err_box, ternary, try_option_mut, CommonResult};
@@ -200,12 +199,8 @@ impl ReadHandler {
         info!("Read block end for req_id {}", msg.req_id());
         Ok(msg.success())
     }
-}
 
-impl MessageHandler for ReadHandler {
-    type Error = FsError;
-
-    fn handle(&mut self, msg: &Message) -> FsResult<Message> {
+    pub fn handle(&mut self, msg: &Message) -> FsResult<Message> {
         let request_status = msg.request_status();
 
         match request_status {

--- a/curvine-server/src/worker/handler/worker_handler.rs
+++ b/curvine-server/src/worker/handler/worker_handler.rs
@@ -26,11 +26,12 @@ use orpc::err_box;
 use orpc::handler::MessageHandler;
 use orpc::message::{Builder, Message, RequestStatus, ResponseStatus};
 use orpc::runtime::Runtime;
+use orpc::sync::FastMutex;
 use std::sync::Arc;
 
 pub struct WorkerHandler {
     pub store: BlockStore,
-    pub handler: Option<BlockHandler>,
+    pub handler: FastMutex<Option<BlockHandler>>,
     pub task_manager: Arc<TaskManager>,
     pub rt: Arc<Runtime>,
     pub replication_handler: WorkerReplicationHandler,
@@ -39,7 +40,7 @@ pub struct WorkerHandler {
 impl MessageHandler for WorkerHandler {
     type Error = FsError;
 
-    fn handle(&mut self, msg: &Message) -> FsResult<Message> {
+    fn handle(&self, msg: &Message) -> FsResult<Message> {
         crate::fault_point! {
             sync,
             name: "worker.rpc.before_dispatch",
@@ -61,7 +62,8 @@ impl MessageHandler for WorkerHandler {
             RpcCode::SubmitBlockReplicationJob => self.replication_handler.handle(msg),
 
             _ => {
-                let h = self.get_handler(msg)?;
+                let mut handler = self.handler.lock();
+                let h = self.get_handler(msg, &mut handler)?;
                 let res = h.handle(msg);
 
                 if res
@@ -72,7 +74,7 @@ impl MessageHandler for WorkerHandler {
                         RequestStatus::Cancel | RequestStatus::Complete
                     )
                 {
-                    let _ = self.handler.take();
+                    let _ = handler.take();
                 };
 
                 res
@@ -82,20 +84,23 @@ impl MessageHandler for WorkerHandler {
 }
 
 impl WorkerHandler {
-    fn get_handler(&mut self, msg: &Message) -> FsResult<&mut BlockHandler> {
+    fn get_handler<'a>(
+        &self,
+        msg: &Message,
+        handler: &'a mut Option<BlockHandler>,
+    ) -> FsResult<&'a mut BlockHandler> {
         let code = RpcCode::from(msg.code());
 
         let need_new_handler = match msg.request_status() {
             RequestStatus::Open => true,
-            _ => self.handler.is_none() || !Self::handler_matches_code(&self.handler, code),
+            _ => handler.is_none() || !Self::handler_matches_code(handler, code),
         };
 
         if need_new_handler {
-            let handler = BlockHandler::new(code, self.store.clone())?;
-            let _ = self.handler.replace(handler);
+            let _ = handler.replace(BlockHandler::new(code, self.store.clone())?);
         }
 
-        match self.handler.as_mut() {
+        match handler.as_mut() {
             None => err_box!("The request is not initialized"),
             Some(v) => Ok(v),
         }

--- a/curvine-server/src/worker/handler/write_handler.rs
+++ b/curvine-server/src/worker/handler/write_handler.rs
@@ -16,7 +16,6 @@ use crate::worker::block::BlockStore;
 use crate::worker::handler::WriteContext;
 use crate::worker::storage::BlockWriteContext;
 use crate::worker::{Worker, WorkerMetrics};
-use curvine_common::error::FsError;
 use curvine_common::proto::{BlockWriteResponse, DataHeaderProto};
 use curvine_common::state::{ExtendedBlock, FileAllocMode};
 use curvine_common::FsResult;

--- a/curvine-server/src/worker/handler/write_handler.rs
+++ b/curvine-server/src/worker/handler/write_handler.rs
@@ -22,7 +22,6 @@ use curvine_common::state::{ExtendedBlock, FileAllocMode};
 use curvine_common::FsResult;
 use log::{info, warn};
 use orpc::common::{ByteUnit, TimeSpent};
-use orpc::handler::MessageHandler;
 use orpc::message::{Builder, Message, RequestStatus};
 use orpc::{err_box, ternary, try_option_mut, CommonResult};
 use std::mem;
@@ -301,12 +300,8 @@ impl WriteHandler {
 
         Ok(msg.success())
     }
-}
 
-impl MessageHandler for WriteHandler {
-    type Error = FsError;
-
-    fn handle(&mut self, msg: &Message) -> FsResult<Message> {
+    pub fn handle(&mut self, msg: &Message) -> FsResult<Message> {
         let request_status = msg.request_status();
 
         match request_status {

--- a/curvine-server/src/worker/replication/worker_replication_handler.rs
+++ b/curvine-server/src/worker/replication/worker_replication_handler.rs
@@ -54,7 +54,7 @@ impl WorkerReplicationHandler {
 impl MessageHandler for WorkerReplicationHandler {
     type Error = FsError;
 
-    fn handle(&mut self, msg: &Message) -> FsResult<Message> {
+    fn handle(&self, msg: &Message) -> FsResult<Message> {
         let code = RpcCode::from(msg.code());
 
         let mut rpc_context = RpcContext::new(msg);

--- a/curvine-server/src/worker/worker_server.rs
+++ b/curvine-server/src/worker/worker_server.rs
@@ -32,6 +32,7 @@ use orpc::io::net::ConnState;
 use orpc::io::spdk_env::SpdkEnv;
 use orpc::runtime::{RpcRuntime, Runtime};
 use orpc::server::{RpcServer, ServerStateListener};
+use orpc::sync::FastMutex;
 use orpc::{CommonError, CommonResult};
 use std::sync::Arc;
 use std::thread;
@@ -87,7 +88,7 @@ impl HandlerService for WorkerService {
     fn get_message_handler(&self, _: Option<ConnState>) -> Self::Item {
         WorkerHandler {
             store: self.store.clone(),
-            handler: None,
+            handler: FastMutex::new(None),
             task_manager: self.task_manager.clone(),
             rt: self.rt.clone(),
             replication_handler: WorkerReplicationHandler::new(&self.replication_manager),

--- a/curvine-server/tests/master_fs_test.rs
+++ b/curvine-server/tests/master_fs_test.rs
@@ -226,7 +226,7 @@ fn test_master_sync_and_async_rpc_points_follow_dispatch_paths() -> CommonResult
         faults.configure(id, rule)?;
     }
 
-    let mut handler = new_handler_for_test("fault-dispatch");
+    let handler = new_handler_for_test("fault-dispatch");
     let sync_request = Builder::new_rpc(RpcCode::Mkdir).build();
     let sync_response = handler.handle(&sync_request)?;
 
@@ -248,7 +248,7 @@ fn test_master_sync_and_async_rpc_points_follow_dispatch_paths() -> CommonResult
 }
 
 #[test]
-fn worker_reports_and_metadata_reads_do_not_use_master_sync_pool() {
+fn only_job_requests_use_the_async_handler() {
     let _serial = master_fs_test_serial();
     let handler = new_handler();
 
@@ -257,6 +257,15 @@ fn worker_reports_and_metadata_reads_do_not_use_master_sync_pool() {
         RpcCode::GetJobStatus,
         RpcCode::CancelJob,
         RpcCode::ReportTask,
+    ] {
+        let msg = Builder::new_rpc(code).build();
+        assert!(
+            !handler.is_sync(&msg),
+            "{code:?} must use the async handler"
+        );
+    }
+
+    for code in [
         RpcCode::GetBlockLocations,
         RpcCode::GetMasterInfo,
         RpcCode::ListStatus,
@@ -265,7 +274,7 @@ fn worker_reports_and_metadata_reads_do_not_use_master_sync_pool() {
         RpcCode::WorkerBlockReport,
     ] {
         let msg = Builder::new_rpc(code).build();
-        assert!(!handler.is_sync(&msg), "{code:?} must use an async lane");
+        assert!(handler.is_sync(&msg), "{code:?} must use the sync handler");
     }
 
     let mkdir = Builder::new_rpc(RpcCode::Mkdir).build();
@@ -273,15 +282,14 @@ fn worker_reports_and_metadata_reads_do_not_use_master_sync_pool() {
 }
 
 #[test]
-fn async_rpc_to_standby_returns_rpc_error_response() -> CommonResult<()> {
+fn sync_rpc_to_standby_returns_rpc_error_response() -> CommonResult<()> {
     let _serial = master_fs_test_serial();
-    let mut handler = new_handler();
+    let handler = new_handler();
     let msg = Builder::new_rpc(RpcCode::GetMasterInfo)
         .proto_header(GetMasterInfoRequest::default())
         .build();
 
-    let rt = AsyncRuntime::single();
-    let response = rt.block_on(handler.async_handle(msg))?;
+    let response = handler.handle(&msg)?;
 
     assert!(!response.is_success());
     let err = response.check_error_ext::<FsError>().unwrap_err();

--- a/orpc/src/client/buffer_client.rs
+++ b/orpc/src/client/buffer_client.rs
@@ -15,7 +15,7 @@
 use crate::client::dispatch::{CallMap, Envelope};
 use crate::client::raw_client::RawClient;
 use crate::client::{ClientConf, ClientState};
-use crate::handler::{ReadFrame, WriteFrame};
+use crate::handler::{Frame, ReadFrame, WriteFrame};
 use crate::io::net::InetAddr;
 use crate::io::{IOError, IOResult};
 use crate::message::{BoxMessage, Message, RefMessage};

--- a/orpc/src/handler/frame.rs
+++ b/orpc/src/handler/frame.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::handler::{ReadFrame, WriteFrame};
 use std::future::Future;
 
 use crate::io::net::ConnState;
@@ -24,4 +25,6 @@ pub trait Frame {
     fn receive(&mut self) -> impl Future<Output = IOResult<Message>>;
 
     fn new_conn_state(&self) -> ConnState;
+
+    fn split(self) -> (ReadFrame, WriteFrame);
 }

--- a/orpc/src/handler/handler_service.rs
+++ b/orpc/src/handler/handler_service.rs
@@ -68,6 +68,10 @@ pub trait HandlerService: Send + Sync + 'static {
         StreamHandler::new(rt, frame, handler, conf)
     }
 
+    fn is_stream(&self) -> bool {
+        true
+    }
+
     fn get_limit(&self) -> LimitConf {
         panic!("BufferHandler service must provide a shared LimitConf")
     }

--- a/orpc/src/handler/handler_service.rs
+++ b/orpc/src/handler/handler_service.rs
@@ -17,13 +17,32 @@ use crate::io::net::ConnState;
 use crate::runtime::Runtime;
 use crate::server::ServerConf;
 use std::sync::Arc;
+use tokio::sync::Semaphore;
+
+#[derive(Clone, Debug)]
+pub struct LimitConf {
+    pub conn_limit: usize,
+    pub global_limit: Arc<Semaphore>,
+}
+
+impl LimitConf {
+    pub fn new(conn_limit: usize, global_limit: usize) -> Self {
+        assert!(conn_limit > 0, "connection limit must be greater than zero");
+        assert!(global_limit > 0, "global limit must be greater than zero");
+        Self {
+            conn_limit,
+            global_limit: Arc::new(Semaphore::new(global_limit)),
+        }
+    }
+}
 
 /// The message processor runs and manages the following functions:
 /// 1. Manage the creation of MessageHandler.
 /// 2. Global variables required to manage business logic.
 ///
-/// Unlike the ordinary rpc framework, orpc is used to handle file reading and writing. The handler is stateful and needs to pay attention to thread safety issues.
-/// In order to save overhead and avoid ownership issues, naked pointers are used to call message processing functions.
+/// Unlike ordinary RPC frameworks, orpc also handles stateful file read/write
+/// streams. Handlers are shared through `Arc`, so connection-local mutable
+/// state must use explicit interior synchronization.
 pub trait HandlerService: Send + Sync + 'static {
     type Item: MessageHandler;
     // Whether to pass connection information.
@@ -48,6 +67,10 @@ pub trait HandlerService: Send + Sync + 'static {
         let handler = self.get_message_handler(conn_state);
         StreamHandler::new(rt, frame, handler, conf)
     }
+
+    fn get_limit(&self) -> LimitConf {
+        panic!("BufferHandler service must provide a shared LimitConf")
+    }
 }
 
 #[allow(unused)]
@@ -59,5 +82,39 @@ impl HandlerService for TestService {
 
     fn get_message_handler(&self, _: Option<ConnState>) -> Self::Item {
         TestMessageHandler {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{HandlerService, LimitConf, TestService};
+    use std::sync::Arc;
+
+    #[test]
+    fn cloned_limit_conf_shares_global_semaphore() {
+        let limit = LimitConf::new(8, 4096);
+        let cloned = limit.clone();
+
+        assert_eq!(limit.conn_limit, 8);
+        assert_eq!(limit.global_limit.available_permits(), 4096);
+        assert!(Arc::ptr_eq(&limit.global_limit, &cloned.global_limit));
+    }
+
+    #[test]
+    #[should_panic(expected = "connection limit must be greater than zero")]
+    fn zero_connection_limit_is_rejected() {
+        LimitConf::new(0, 4096);
+    }
+
+    #[test]
+    #[should_panic(expected = "global limit must be greater than zero")]
+    fn zero_global_limit_is_rejected() {
+        LimitConf::new(8, 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "BufferHandler service must provide a shared LimitConf")]
+    fn buffer_service_must_provide_shared_limit() {
+        TestService.get_limit();
     }
 }

--- a/orpc/src/handler/message_handler.rs
+++ b/orpc/src/handler/message_handler.rs
@@ -30,15 +30,15 @@ pub trait MessageHandler: Send + Sync + 'static {
         true
     }
 
-    // Process messages in synchronization, and call rt.spawn_blocking in the io thread to process.
-    // There is currently no good way to unify asynchronous and synchronous code.
-    fn handle(&mut self, msg: &Message) -> Result<Message, Self::Error>;
+    // Process synchronous messages on the runtime blocking pool. Implementations
+    // keep request state local or protect connection-local mutable state explicitly.
+    fn handle(&self, msg: &Message) -> Result<Message, Self::Error>;
 
     // 1.7.5 starts to support async trait.
     // In some scenarios, messages will not be processed directly, and messages need to be sent through the channel, and asynchronous functions are required.
     #[allow(unused)]
     fn async_handle(
-        &mut self,
+        &self,
         msg: Message,
     ) -> impl Future<Output = Result<Message, Self::Error>> + Send {
         async { panic!("Please implement the async_handle method") }
@@ -55,7 +55,7 @@ pub struct TestMessageHandler;
 impl MessageHandler for TestMessageHandler {
     type Error = CommonErrorExt;
 
-    fn handle(&mut self, msg: &Message) -> Result<Message, Self::Error> {
+    fn handle(&self, msg: &Message) -> Result<Message, Self::Error> {
         info!("request = {:?}", msg);
 
         let res = match msg.header_bytes() {

--- a/orpc/src/handler/mod.rs
+++ b/orpc/src/handler/mod.rs
@@ -19,7 +19,7 @@ mod message_handler;
 pub use self::message_handler::*;
 
 mod handler_service;
-pub use self::handler_service::HandlerService;
+pub use self::handler_service::{HandlerService, LimitConf};
 
 mod rpc_codec;
 pub use self::rpc_codec::RpcCodec;

--- a/orpc/src/handler/rpc_frame.rs
+++ b/orpc/src/handler/rpc_frame.rs
@@ -185,13 +185,6 @@ impl RpcFrame {
     pub fn into_tokio_frame(self) -> Framed<TcpStream, RpcCodec> {
         Framed::with_capacity(self.io, RpcCodec::new(), self.buf.buf_size())
     }
-
-    pub fn split(self) -> (ReadFrame, WriteFrame) {
-        let (read, write) = tokio::io::split(self.io);
-        let read_frame = ReadFrame::new(read, self.buf.clone());
-        let write_frame = WriteFrame::new(write, self.buf);
-        (read_frame, write_frame)
-    }
 }
 
 #[cfg(target_os = "linux")]
@@ -268,5 +261,12 @@ impl Frame for RpcFrame {
         let client_addr = self.io.peer_addr().unwrap_or(ip);
         let local_addr = self.io.local_addr().unwrap_or(ip);
         ConnState::new(client_addr.into(), local_addr.into())
+    }
+
+    fn split(self) -> (ReadFrame, WriteFrame) {
+        let (read, write) = tokio::io::split(self.io);
+        let read_frame = ReadFrame::new(read, self.buf.clone());
+        let write_frame = WriteFrame::new(write, self.buf);
+        (read_frame, write_frame)
     }
 }

--- a/orpc/src/handler/stream_handler.rs
+++ b/orpc/src/handler/stream_handler.rs
@@ -17,7 +17,6 @@ use crate::io::IOResult;
 use crate::message::{Builder, Message};
 use crate::runtime::{RpcRuntime, Runtime};
 use crate::server::ServerConf;
-use crate::sys::RawPtr;
 use log::debug;
 use std::sync::Arc;
 use std::time::Duration;
@@ -27,7 +26,7 @@ use tokio::time::timeout;
 pub struct StreamHandler<F, M> {
     rt: Arc<Runtime>,
     frame: F,
-    handler: RawPtr<M>,
+    handler: Arc<M>,
     close_idle: bool,
     timeout: Duration,
 }
@@ -37,7 +36,7 @@ impl<F: Frame, M: MessageHandler> StreamHandler<F, M> {
         StreamHandler {
             rt,
             frame,
-            handler: RawPtr::from_owned(handler),
+            handler: Arc::new(handler),
             close_idle: conf.close_idle,
             timeout: Duration::from_millis(conf.timeout_ms),
         }
@@ -76,7 +75,7 @@ impl<F: Frame, M: MessageHandler> StreamHandler<F, M> {
             let rt = self.handler.get_rt(&request).unwrap_or(&self.rt);
 
             let handler = self.handler.clone();
-            rt.spawn_blocking(move || match handler.as_mut().handle(&request) {
+            rt.spawn_blocking(move || match handler.handle(&request) {
                 Err(e) => {
                     debug!("handler request {} error: {}", request.req_id(), e);
                     request.error_ext(&e)
@@ -87,7 +86,7 @@ impl<F: Frame, M: MessageHandler> StreamHandler<F, M> {
             .await?
         } else {
             let protocol = request.protocol;
-            match self.handler.as_mut().async_handle(request).await {
+            match self.handler.async_handle(request).await {
                 Ok(v) => v,
                 Err(e) => {
                     debug!("handler request {} error: {}", protocol.req_id, e);

--- a/orpc/src/test/file/file_handler.rs
+++ b/orpc/src/test/file/file_handler.rs
@@ -17,6 +17,7 @@ use crate::handler::{HandlerService, MessageHandler};
 use crate::io::net::ConnState;
 use crate::io::LocalFile;
 use crate::message::*;
+use crate::sync::FastMutex;
 use crate::sys::{CacheManager, DataSlice, ReadAheadTask};
 use crate::test::file::dir_location::DirLocation;
 use crate::{err_box, CommonResultExt};
@@ -34,8 +35,12 @@ pub enum RpcCode {
 pub struct FileHandler {
     location: Arc<DirLocation>,
     os_cache: Arc<CacheManager>,
-    file: Option<LocalFile>,
     chunk_size: i32,
+    state: FastMutex<FileHandlerState>,
+}
+
+struct FileHandlerState {
+    file: Option<LocalFile>,
     last_task: Option<ReadAheadTask>,
 }
 
@@ -44,13 +49,20 @@ impl FileHandler {
         FileHandler {
             location,
             os_cache,
-            file: None,
             chunk_size,
-            last_task: None,
+            state: FastMutex::new(FileHandlerState {
+                file: None,
+                last_task: None,
+            }),
         }
     }
 
-    pub fn do_open(&mut self, msg: &Message, for_write: bool) -> CommonResultExt<Message> {
+    fn do_open(
+        &self,
+        state: &mut FileHandlerState,
+        msg: &Message,
+        for_write: bool,
+    ) -> CommonResultExt<Message> {
         let block_id = if let Some(ref v) = msg.header {
             let mut bytes = [0; 8];
             bytes.copy_from_slice(&v[0..8]);
@@ -59,16 +71,17 @@ impl FileHandler {
             0
         };
 
-        self.file = Some(self.location.get_or_create(block_id, for_write)?);
+        state.file = Some(self.location.get_or_create(block_id, for_write)?);
         Ok(msg.success_with_data(None, DataSlice::Empty))
     }
 
-    pub fn do_write(&mut self, msg: &Message) -> CommonResultExt<Message> {
+    pub fn do_write(&self, msg: &Message) -> CommonResultExt<Message> {
+        let mut state = self.state.lock();
         match msg.request_status() {
-            RequestStatus::Open => self.do_open(msg, true),
+            RequestStatus::Open => self.do_open(&mut state, msg, true),
 
             RequestStatus::Running => {
-                if let Some(ref mut f) = self.file {
+                if let Some(ref mut f) = state.file {
                     f.write_region(&msg.data)?;
                     Ok(msg.success_with_data(None, DataSlice::Empty))
                 } else {
@@ -80,14 +93,17 @@ impl FileHandler {
         }
     }
 
-    pub fn do_read(&mut self, msg: &Message) -> CommonResultExt<Message> {
+    pub fn do_read(&self, msg: &Message) -> CommonResultExt<Message> {
+        let mut state = self.state.lock();
         match msg.request_status() {
-            RequestStatus::Open => self.do_open(msg, false),
+            RequestStatus::Open => self.do_open(&mut state, msg, false),
 
             RequestStatus::Running => {
-                if let Some(ref mut f) = self.file {
-                    self.last_task = f.read_ahead(&self.os_cache, self.last_task.take());
+                let last_task = state.last_task.take();
+                if let Some(ref mut f) = state.file {
+                    let next_task = f.read_ahead(&self.os_cache, last_task);
                     let region = f.read_region(true, self.chunk_size)?;
+                    state.last_task = next_task;
                     Ok(msg.success_with_data(None, region))
                 } else {
                     err_box!("file not initialized")
@@ -102,7 +118,7 @@ impl FileHandler {
 impl MessageHandler for FileHandler {
     type Error = CommonErrorExt;
 
-    fn handle(&mut self, msg: &Message) -> CommonResultExt<Message> {
+    fn handle(&self, msg: &Message) -> CommonResultExt<Message> {
         let code = RpcCode::from(msg.protocol.code);
         match code {
             RpcCode::Write => self.do_write(msg),

--- a/orpc/src/test/simple_server.rs
+++ b/orpc/src/test/simple_server.rs
@@ -34,7 +34,7 @@ pub struct SimpleHandler {
 impl MessageHandler for SimpleHandler {
     type Error = CommonErrorExt;
 
-    fn handle(&mut self, msg: &Message) -> CommonResultExt<Message> {
+    fn handle(&self, msg: &Message) -> CommonResultExt<Message> {
         let id = msg.req_id();
         if self.mock && !self.call_map.contains_key(&id) {
             self.call_map.insert(id, 1);

--- a/orpc/tests/stream_handler_test.rs
+++ b/orpc/tests/stream_handler_test.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use orpc::error::CommonErrorExt;
-use orpc::handler::{Frame, MessageHandler, StreamHandler};
+use orpc::handler::{Frame, MessageHandler, ReadFrame, StreamHandler, WriteFrame};
 use orpc::io::net::ConnState;
 use orpc::io::IOResult;
 use orpc::message::{BoxMessage, Builder, Message, RefMessage, RequestStatus};
@@ -38,6 +38,10 @@ impl Frame for MemoryFrame {
     fn new_conn_state(&self) -> ConnState {
         ConnState::default()
     }
+
+    fn split(self) -> (ReadFrame, WriteFrame) {
+        panic!("MemoryFrame does not support split")
+    }
 }
 
 struct AsyncErrorHandler;
@@ -49,11 +53,11 @@ impl MessageHandler for AsyncErrorHandler {
         false
     }
 
-    fn handle(&mut self, _msg: &Message) -> Result<Message, Self::Error> {
+    fn handle(&self, _msg: &Message) -> Result<Message, Self::Error> {
         unreachable!("test handler only uses async_handle")
     }
 
-    async fn async_handle(&mut self, _msg: Message) -> Result<Message, Self::Error> {
+    async fn async_handle(&self, _msg: Message) -> Result<Message, Self::Error> {
         Err(CommonErrorExt::from("async handler failed".to_string()))
     }
 }


### PR DESCRIPTION
# Summary

Refactor RPC message handlers to use shared references so handler instances can be safely owned by `Arc` and reused across asynchronous and blocking dispatch paths. The change also moves mutable connection state behind explicit synchronization and makes response buffers request-local.

# Issue Describe / Design

Related issues: None.

The previous `MessageHandler` contract required `&mut self`, which prevented safe sharing across concurrent RPC execution paths and encouraged connection-local mutable state to live directly on handlers.

This refactor changes synchronous and asynchronous callbacks to `&self`. Stateful handlers use `FastMutex` for interior synchronization, while response encoding allocates request-local buffers. `Frame::split` and shared connection/global limit configuration prepare the RPC layer for concurrent buffered dispatch while preserving the master's existing `GroupExecutor` routing for long-running metadata operations.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `orpc/src/handler` | Make `MessageHandler` shareable, store handlers in `Arc`, add `Frame::split`, and introduce `LimitConf` | Handler ownership and synchronization model changes; RPC protocol behavior is unchanged |
| `curvine-server/src/master` | Remove handler-owned response buffers, use request-local encoding, and retain `GroupExecutor` dispatch | Reduces shared mutable state without changing RPC semantics |
| `curvine-server/src/worker` and raft handlers | Protect connection-local mutable state with `FastMutex` and adapt implementations to `&self` | Stateful request ordering remains serialized where required |
| `curvine-common/src/conf/master_conf.rs` | Add metadata concurrency and connection/global limit settings | Adds validated configuration with defaults |
| Tests | Adapt handler implementations and assertions to the shared handler contract | Test-only compatibility updates |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo fmt --all -- --check` | PASS | |
| `cargo check -p orpc` | PASS | |
| `cargo check -p orpc -p curvine-server` | BLOCKED | Existing Windows build issue: `nix::ifaddrs` is unavailable in the current configuration |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None