### PR TITLE
docs(fuse): trim implementation-phase noise from metrics comments

### DIFF
--- a/curvine-fuse/src/cli/fuse_cli.rs
+++ b/curvine-fuse/src/cli/fuse_cli.rs
@@ -173,7 +173,7 @@ mod tests {
         assert_eq!(args.mount.io_threads, Some(8));
     }
 
-    // Kill switch: FuseConf defaults metrics on (Phase 1–3 ship enabled).
+    // Kill switch: FuseConf defaults metrics on (ships enabled).
     #[test]
     fn metrics_enabled_defaults_to_true() {
         use curvine_common::conf::FuseConf;

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -536,21 +536,14 @@ impl CurvineFileSystem {
         }
     }
 
-    /// Negotiate the init reply flags as an explicit allowlist rather than
-    /// blindly echoing every kernel-offered capability.
-    ///
-    /// Two categories:
-    /// 1. Kernel-negotiated caps: `SUPPORTED_INIT_FLAGS & kernel_flags` — only
-    ///    bits the daemon implements AND the kernel offered. This inherently
-    ///    excludes `FUSE_ATOMIC_O_TRUNC` (open does not truncate, #1122),
-    ///    `FUSE_POSIX_ACL`, `FUSE_HAS_IOCTL_DIR`, and any unknown/future bit,
-    ///    since none are in `SUPPORTED_INIT_FLAGS`. `FUSE_MAX_PAGES` survives
-    ///    only when the kernel offers it.
-    /// 2. Config-gated daemon-requested caps, forced on (NOT masked by the
-    ///    kernel offer): `FUSE_WRITEBACK_CACHE` when `write_back_cache`, and the
-    ///    `FUSE_SPLICE_*` bits when `enable_splice`. Splice is driven by the
-    ///    channel talking splice(2) on the fuse fd directly, independent of an
-    ///    init-flag offer, so it must be advertised on config alone.
+    /// Negotiate init reply flags as an explicit allowlist, not a blind echo:
+    /// 1. Kernel-negotiated: `SUPPORTED_INIT_FLAGS & kernel_flags` (only caps the
+    ///    daemon implements AND the kernel offered — see `SUPPORTED_INIT_FLAGS` for
+    ///    what that deliberately excludes).
+    /// 2. Config-gated, forced on regardless of the kernel offer:
+    ///    `FUSE_WRITEBACK_CACHE` (when `write_back_cache`) and `FUSE_SPLICE_*` (when
+    ///    `enable_splice` — splice drives the fuse fd directly, so it is advertised
+    ///    on config alone).
     fn negotiate_out_flags(kernel_flags: u32, write_back_cache: bool, enable_splice: bool) -> u32 {
         let mut out = SUPPORTED_INIT_FLAGS & kernel_flags;
         if write_back_cache {
@@ -1068,24 +1061,13 @@ impl fs::FileSystem for CurvineFileSystem {
         let keep_cache = if self.conf.direct_io {
             false
         } else {
-            // Page cache consistency is handled here rather than via explicit inode
-            // invalidation notifications, for two reasons:
-            //
-            // 1. Sending inode-invalidation notifications (FUSE_NOTIFY_INVAL_INODE) on
-            //    some older kernel versions can trigger a deadlock inside send_inode_out.
-            //
-            // 2. On open, the kernel always issues a fresh getattr to the FUSE daemon
-            //    regardless of whether the attr cache is still valid.  The kernel then
-            //    compares mtime and file size; if either has changed it automatically
-            //    invalidates the page cache for that inode.  This behaviour is governed
-            //    by the CAP_AUTO_INVAL_DATA capability (available since Linux 2.6.35,
-            //    enabled by default), so no additional notification is required from
-            //    our side.
-            //
-            // Note: if the user-space metadata cache (enable_meta_cache) is enabled,
-            // keep_cache may return true even after a remote modification, causing stale
-            // reads.  This is intentional — metadata caching trades strict consistency
-            // for performance, and callers that enable it accept this trade-off.
+            // Page cache consistency is handled here, not via explicit inode
+            // invalidation, because: (1) FUSE_NOTIFY_INVAL_INODE can deadlock inside
+            // send_inode_out on some older kernels; (2) on open the kernel issues a
+            // fresh getattr and auto-invalidates the page cache if mtime/size changed
+            // (CAP_AUTO_INVAL_DATA, on by default since Linux 2.6.35), so no notify is
+            // needed. Note: with enable_meta_cache, keep_cache may return true after a
+            // remote modification (stale reads) — an intentional consistency/perf trade.
             self.state.keep_cache(ino, &handle.status())
         };
         let open_flags = FuseUtils::file_open_flags(&self.conf, keep_cache);
@@ -1390,23 +1372,11 @@ impl fs::FileSystem for CurvineFileSystem {
         Ok(())
     }
 
-    /// Create a file system node (mknod system call)
-    ///
-    /// This function handles the creation of file system nodes:
-    /// - For regular files: delegates to `create()` and immediately closes the handle
-    /// - For directories: delegates to `mkdir()`
-    /// - For char/block/fifo device nodes: creates metadata-only special nodes
-    /// - For other types (sockets, etc.): returns EPERM error
-    ///
-    /// # Arguments
-    /// * `op` - MkNod operation containing:
-    ///   - `mode`: file type and permissions
-    ///   - `umask`: file creation mask
-    ///   - `name`: name of the node to create
-    ///
-    /// # Returns
-    /// * `Ok(fuse_entry_out)` - Entry information for the created node
-    /// * `Err(FuseError)` - Error if creation fails or unsupported type
+    /// Create a filesystem node (`mknod`):
+    /// - regular file: delegates to `create()` then closes the handle;
+    /// - directory: delegates to `mkdir()`;
+    /// - char/block/fifo: creates a metadata-only special node;
+    /// - other types (sockets, …): returns EPERM.
     async fn mk_nod(&self, op: MkNod<'_>) -> FuseResult<fuse_entry_out> {
         let name = try_option!(op.name.to_str());
         if name.len() > FUSE_MAX_NAME_LENGTH {
@@ -1608,29 +1578,13 @@ mod tests {
         assert_eq!(zero_range.errno, libc::EOPNOTSUPP);
     }
 
-    /// Pin the production init-order invariant the event-driven gauges depend on:
-    /// `FuseMetrics::ensure_init()` MUST run before `NodeState::new()` in
-    /// `CurvineFileSystem::new`. Since the scrape-time `set_metrics()` refresh
-    /// was removed, the legacy gauges are only correct if their
-    /// event-driven updates (routed through `FuseMetrics::with`) land on an
-    /// initialized singleton; the `NodeMap::new` root baseline `set(1)` is the
-    /// first such update and fires inside `NodeState::new`. If a refactor moved
-    /// `ensure_init()` after `NodeState::new` (or dropped it), that baseline —
-    /// and every subsequent inc/dec — would be silently no-op'd by `with`, and
-    /// the gauges would drift permanently low with no panic.
-    ///
-    /// A behavioral assertion (construct, then check the singleton is init) is
-    /// useless here: the process-global `OnceCell` is already initialized by
-    /// other tests in this binary, so it would pass even if `ensure_init` were
-    /// deleted. We assert on the source text instead, which catches both a
-    /// reordering and an outright removal.
-    ///
-    /// The search is scoped to the body of `fn new` so the literals in this
-    /// test's own doc comment / assert message do not satisfy `find()` — that
-    /// self-reference would make the `.expect` guards dead (the strings always
-    /// exist in this file) and let a removal of the real call slip through by
-    /// matching the prose instead. Slicing to `fn new` keeps `.expect` a real
-    /// "the call was deleted" guard.
+    /// Pin that `FuseMetrics::ensure_init()` runs before `NodeState::new()` in
+    /// `CurvineFileSystem::new`: the event-driven gauges are silently no-op'd by
+    /// `with()` (drifting permanently low, no panic) if a mutation fires before
+    /// init. A behavioral check is useless (the process-global `OnceCell` is
+    /// already init by other tests in this binary), so we assert on the source
+    /// text — scoped to the body of `fn new`, so this test's own doc/assert
+    /// literals don't satisfy `find()` and mask a real removal.
     #[test]
     fn ensure_init_precedes_node_state() {
         let src = include_str!("curvine_file_system.rs");

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -1608,10 +1608,10 @@ mod tests {
         assert_eq!(zero_range.errno, libc::EOPNOTSUPP);
     }
 
-    /// Pin the production init-order invariant that Phase 1b-2 depends on:
+    /// Pin the production init-order invariant the event-driven gauges depend on:
     /// `FuseMetrics::ensure_init()` MUST run before `NodeState::new()` in
-    /// `CurvineFileSystem::new`. After 1b-2 removed the scrape-time
-    /// `set_metrics()` refresh, the legacy gauges are only correct if their
+    /// `CurvineFileSystem::new`. Since the scrape-time `set_metrics()` refresh
+    /// was removed, the legacy gauges are only correct if their
     /// event-driven updates (routed through `FuseMetrics::with`) land on an
     /// initialized singleton; the `NodeMap::new` root baseline `set(1)` is the
     /// first such update and fires inside `NodeState::new`. If a refactor moved

--- a/curvine-fuse/src/fs/fuse_reader.rs
+++ b/curvine-fuse/src/fs/fuse_reader.rs
@@ -47,7 +47,7 @@ impl FuseReader {
         let err_monitor = Arc::new(ErrorMonitor::new());
         let (sender, receiver) = AsyncChannel::new(conf.stream_channel_size).split();
         let status = reader.status().clone();
-        // Phase 2b: capture the backend kind and the metrics gate at open time and
+        // capture the backend kind and the metrics gate at open time and
         // move them into the read task, so the per-IO observe in `read_future` has
         // the `path_type` label without re-resolving it on the hot path.
         let path_type = reader.path_type();
@@ -129,7 +129,7 @@ impl FuseReader {
         while let Some(task) = req_receiver.recv().await {
             match task {
                 ReadTask::Read(off, len, reply) => {
-                    // Phase 2b: observe the read backend IO (io_type=read). The
+                    // observe the read backend IO (io_type=read). The
                     // inflight guard wraps ONLY the `fuse_read` call (backend
                     // concurrency), and is dropped before the reply enqueue so the
                     // gauge excludes reply-channel time. Then record duration /

--- a/curvine-fuse/src/fs/fuse_writer.rs
+++ b/curvine-fuse/src/fs/fuse_writer.rs
@@ -139,18 +139,14 @@ impl FuseWriter {
         self.err_monitor.take_error().unwrap_or(e)
     }
 
-    /// Enqueue a `WriteTask` into the writer channel, carrying the
-    /// `stream_write_queue_depth` guard. Reserve-first on a bounded
-    /// channel so a producer parked in `reserve().await` (channel full) is NOT
-    /// counted as backlog — the guard is created only AFTER a permit is in hand
-    /// (bounded) or just before the synchronous unbounded send. No manual
-    /// inc/dec/rollback: the guard rides the task and the writer drops it at the
-    /// dequeue point (or it is dropped with an un-received task on teardown).
+    /// Enqueue a `WriteTask`, carrying the `stream_write_queue_depth` guard.
+    /// Reserve-first on a bounded channel so a producer parked in `reserve().await`
+    /// isn't counted as backlog (guard created only after a permit is in hand); the
+    /// guard rides the task and drops at the writer's dequeue point.
     ///
-    /// IMPORTANT: this helper only handles the queue guard + channel send. It must
-    /// NOT touch `write_ver` — the producers below keep `write_ver.incr()` at its
-    /// existing position (a read-after-write consistency dependency, not a metrics
-    /// concern), see `write`/`resize`.
+    /// IMPORTANT: only handles the queue guard + send — it must NOT touch
+    /// `write_ver` (the producers keep `write_ver.incr()` where it is, a
+    /// read-after-write consistency dependency; see `write`/`resize`).
     async fn send_queued_task(&self, task: WriteTask) -> Result<(), FsError> {
         if self.sender.is_bounded() {
             // Reserve a permit first WITHOUT a guard; a cancelled reserve leaves the

--- a/curvine-fuse/src/fs/fuse_writer.rs
+++ b/curvine-fuse/src/fs/fuse_writer.rs
@@ -38,7 +38,7 @@ enum WriteTask {
 }
 
 /// A `WriteTask` plus the `stream_write_queue_depth` guard that rides with it
-/// through the writer channel (Phase 2b). The guard is created at the enqueue
+/// through the writer channel. The guard is created at the enqueue
 /// boundary (reserve-first on a bounded channel, so a producer parked in
 /// `reserve().await` is not counted) and dropped the moment `writer_future`
 /// dequeues — or, if the task is never received (writer task exit / channel drop),
@@ -58,7 +58,7 @@ pub struct FuseWriter {
     len: Arc<AtomicLong>,
     mtime: Arc<AtomicLong>,
     write_ver: AtomicCounter,
-    /// Phase 2b kill-switch flag: decides whether `send_queued_task` creates a
+    /// kill-switch flag: decides whether `send_queued_task` creates a
     /// `stream_write_queue_depth` guard. (The `path_type` label is captured as a
     /// local and moved into the writer task, not stored here.)
     metrics_enabled: bool,
@@ -86,7 +86,7 @@ impl FuseWriter {
         let len = Arc::new(AtomicLong::new(status.len));
         let mtime = Arc::new(AtomicLong::new(status.mtime));
         let write_ver = AtomicCounter::new(0);
-        // Phase 2b: backend kind + metrics gate, captured at open and moved into
+        // backend kind + metrics gate, captured at open and moved into
         // the writer task for the per-IO observe (same as FuseReader).
         let path_type = writer.path_type();
         let metrics_enabled = conf.metrics_enabled;
@@ -140,7 +140,7 @@ impl FuseWriter {
     }
 
     /// Enqueue a `WriteTask` into the writer channel, carrying the
-    /// `stream_write_queue_depth` guard (Phase 2b). Reserve-first on a bounded
+    /// `stream_write_queue_depth` guard. Reserve-first on a bounded
     /// channel so a producer parked in `reserve().await` (channel full) is NOT
     /// counted as backlog — the guard is created only AFTER a permit is in hand
     /// (bounded) or just before the synchronous unbounded send. No manual
@@ -318,7 +318,7 @@ impl FuseWriter {
                     // partial failed write is also cancelled on exit.
                     *completed = false;
                     let len = data.len();
-                    // Phase 2b: observe the write backend IO (io_type=write). The
+                    // observe the write backend IO (io_type=write). The
                     // inflight guard wraps ONLY the `fuse_write` call; dropped
                     // before the reply enqueue. zero-length writes never reach here
                     // (FileHandle::write direct-replies), so every sample is a real
@@ -704,8 +704,8 @@ mod tests {
     }
 
     // (b) A task enqueued but NEVER received (writer task exit / channel drop) still
-    // balances: the guard rides the task and drops with it. Covers R3 P1#3 (worker
-    // exit) + channel drop teardown.
+    // balances: the guard rides the task and drops with it. Covers the
+    // worker-exit + channel-drop teardown case.
     #[tokio::test]
     async fn queue_depth_unreceived_task_drop_balances() {
         let g = m::new_gauge("test_swqd_unrecv", "test").unwrap();
@@ -769,7 +769,7 @@ mod tests {
         assert!(queued.queue_guard.is_none());
     }
 
-    // --- Phase 2b: real FuseWriter task-body integration (codex review P1-2) ---
+    // --- real FuseWriter task-body integration ---
 
     mod task_body_integration {
         use super::super::FuseWriter;

--- a/curvine-fuse/src/fs/stream_result.rs
+++ b/curvine-fuse/src/fs/stream_result.rs
@@ -18,33 +18,18 @@ use curvine_common::FsResult;
 use log::warn;
 use orpc::sync::channel::CallSender;
 
-/// Deliver a backend stream-op result (`Flush`/`Complete`/`Resize`) to the
-/// correct single consumer, which differs by whether this op originated from a
-/// kernel request (`reply = Some`) or an internal caller (`reply = None`).
+/// Deliver a backend stream-op result (`Flush`/`Complete`/`Resize`) to the one
+/// correct consumer, which differs by origin:
 ///
-/// Why the split (PR #1201 review): the kernel reply and the `tx` completion
-/// channel are BOTH ways a result travels back, but for a kernel request they
-/// are two ends of the SAME FUSE request. If we sent the real `Err` on `tx`,
-/// the caller (`flush()/complete()/resize()`) would return it up the dispatch
-/// chain, where `send_stream_dispatch` treats any `Err` as a pre-reply dispatch
-/// failure and calls `err_rep.send_rep(res)` — enqueuing a SECOND kernel reply
-/// for the same request. So the helper is the single decision point:
-///
-///   * `reply = Some` (kernel request): the kernel reply is the authoritative
-///     response. Send the real (errno-mapped) result to the kernel, and hand
-///     the in-process caller a bare `Ok(())` so it does NOT re-propagate the
-///     error and trigger a duplicate reply. Ordering (issue #1118): notify `tx`
-///     FIRST, then the kernel reply, so a blocked/failing reply channel cannot
-///     gate the caller's completion notification.
-///   * `reply = None` (internal caller: read-path dirty-read flush, flush_writer,
-///     release's `complete(None)`, resize): `tx` is the ONLY channel back, so
-///     the real backend result MUST travel on it — otherwise a backend failure
-///     is silently swallowed (the bug issue #1118 fixed).
-///
-/// `FsError` is not `Clone`, but that is no longer a constraint here: on the
-/// `reply = Some` path only the kernel reply needs the error (via a borrowed
-/// `errno_of`), and the caller receives a value-free `Ok(())` signal; on the
-/// `reply = None` path the single `res` is simply moved onto `tx`.
+///   * `reply = Some` (kernel request): the kernel reply is authoritative. Send
+///     the real (errno-mapped) result to the kernel and hand the in-process
+///     caller a bare `Ok(())` — if the caller re-propagated the `Err`,
+///     `send_stream_dispatch` would treat it as a dispatch failure and enqueue a
+///     SECOND kernel reply for the same request. Notify `tx` FIRST, then reply,
+///     so a blocked reply channel cannot gate the caller's completion (#1118).
+///   * `reply = None` (internal caller: dirty-read flush, flush_writer,
+///     release's `complete(None)`, resize): `tx` is the ONLY channel back, so the
+///     real result MUST travel on it, else a backend failure is swallowed (#1118).
 pub(crate) async fn deliver_stream_result(
     res: FsResult<()>,
     tx: CallSender<FsResult<()>>,

--- a/curvine-fuse/src/fuse_error.rs
+++ b/curvine-fuse/src/fuse_error.rs
@@ -186,7 +186,7 @@ impl From<std::io::Error> for FuseError {
 /// `FsError -> errno` mapping above). Any errno outside the table collapses to
 /// `"OTHER"`; if a new errno starts being produced, add it here and to the
 /// design doc's label table together.
-// Phase 0 enabling primitive: defined here, wired to call sites in Phase 1.
+// Enabling primitive: defined here, wired to call sites separately.
 #[allow(dead_code)]
 pub(crate) fn errno_label(errno: i32) -> &'static str {
     match errno {

--- a/curvine-fuse/src/fuse_metrics.rs
+++ b/curvine-fuse/src/fuse_metrics.rs
@@ -41,7 +41,7 @@ const STAGE_DURATION_BUCKETS_US: &[f64] = &[
     100000.0,
 ];
 
-/// Buckets (bytes) for a single stream read/write size (Phase 2b `io_size_bytes`).
+/// Buckets (bytes) for a single stream read/write size (`io_size_bytes`).
 /// 8 buckets spanning 4KiB–64MiB. The first bucket (`le=4096`) is NOT a minimum
 /// observation floor — a sub-4KiB read/write (e.g. a 1-byte read) is observed
 /// normally and lands in this first bucket. Zero-length writes are a *semantic*
@@ -51,8 +51,8 @@ const IO_SIZE_BUCKETS: &[f64] = &[
     4096.0, 16384.0, 65536.0, 262144.0, 1048576.0, 4194304.0, 16777216.0, 67108864.0,
 ];
 
-/// Buckets (entry count) for a single `read_dir_common` batch (Phase 3a
-/// `readdir_entries`). A batch is one readdir syscall's worth of dirents, not the
+/// Buckets (entry count) for a single `read_dir_common` batch (`readdir_entries`).
+/// A batch is one readdir syscall's worth of dirents, not the
 /// whole directory; the upper buckets cover large single batches. Spans 1–4096.
 const READDIR_ENTRIES_BUCKETS: &[f64] = &[1.0, 4.0, 16.0, 64.0, 256.0, 1024.0, 4096.0];
 
@@ -60,18 +60,18 @@ const READDIR_ENTRIES_BUCKETS: &[f64] = &[1.0, 4.0, 16.0, 64.0, 256.0, 1024.0, 4
 pub(crate) const REPLY_TYPE_REPLIED: &str = "replied";
 pub(crate) const REPLY_TYPE_NO_REPLY: &str = "no_reply";
 
-// `stage` label values. `reply_write` ships in 1a-2; `meta_spawn` in 1b
-// (rt.spawn submission -> first poll scheduling delay); `operation` in 2a (the
-// whole metadata dispatch_meta match). NOTE: `stream_enqueue` is a reserved
-// stage value that Phase 2 deliberately does NOT emit — the send_stream
-// read/write dispatch is covered by the dedicated `io_dispatch_duration_us`
-// metric instead (it can include a consistency flush/reopen, so it is not a
-// pure channel push). Do not add a STAGE_STREAM_ENQUEUE const.
+// `stage` label values. `meta_spawn` is the rt.spawn submission -> first poll
+// scheduling delay; `operation` is the whole metadata dispatch_meta match. NOTE:
+// `stream_enqueue` is a reserved stage value that is deliberately NOT emitted —
+// the send_stream read/write dispatch is covered by the dedicated
+// `io_dispatch_duration_us` metric instead (it can include a consistency
+// flush/reopen, so it is not a pure channel push). Do not add a
+// STAGE_STREAM_ENQUEUE const.
 pub(crate) const STAGE_REPLY_WRITE: &str = "reply_write";
 pub(crate) const STAGE_META_SPAWN: &str = "meta_spawn";
 pub(crate) const STAGE_OPERATION: &str = "operation";
-// Phase 2b: the read/write backend call in the reader/writer task body. This is
-// the ONLY `stage_duration_us` emission point Phase 2b adds. flush/fsync/release
+// The read/write backend call in the reader/writer task body — the ONLY
+// `stage_duration_us` emission point for stream IO. flush/fsync/release
 // deliberately emit NO stage (their result status is not clean — it mixes backend
 // and reply-enqueue errors — so a `stage_duration_us{status}` would carry that
 // pollution); they use the status-less `stream_lifecycle_*` family instead. The
@@ -79,7 +79,7 @@ pub(crate) const STAGE_OPERATION: &str = "operation";
 // `io_dispatch_duration_us`); see the `STAGE_STREAM_ENQUEUE` note above.
 pub(crate) const STAGE_STREAM_IO: &str = "stream_io";
 
-// `io_type` label values (Phase 2b). Lowercase, low-cardinality, zero-allocation.
+// `io_type` label values. Lowercase, low-cardinality, zero-allocation.
 // read/write feed the `io_*` families (with `status`); flush/fsync/release feed
 // the independent `stream_lifecycle_*` families (no `status`). The two never mix.
 pub(crate) const IO_TYPE_READ: &str = "read";
@@ -88,7 +88,7 @@ pub(crate) const IO_TYPE_FLUSH: &str = "flush";
 pub(crate) const IO_TYPE_FSYNC: &str = "fsync";
 pub(crate) const IO_TYPE_RELEASE: &str = "release";
 
-// `path_type` label values (Phase 2b), the backend a stream IO targets. read/write
+// `path_type` label values, the backend a stream IO targets. read/write
 // resolve the real backend via `UnifiedReader/Writer::path_type()` (which returns
 // these same literals from curvine-client); flush/fsync/release use `unknown` for
 // now (the send_stream layer does not look up the handle). Only `unknown` is read
@@ -114,20 +114,20 @@ pub(crate) const PATH_TYPE_FALLBACK: &str = "fallback";
 pub(crate) const PATH_TYPE_LOCAL: &str = "local";
 pub(crate) const PATH_TYPE_UNKNOWN: &str = "unknown";
 
-// Phase 3a `cache` label values (on `user_meta_cache_*`): the meta-cache namespace.
+// `cache` label values (on `user_meta_cache_*`): the meta-cache namespace.
 pub(crate) const CACHE_STATUS: &str = "status";
 pub(crate) const CACHE_LIST: &str = "list";
 pub(crate) const CACHE_BLOCKS: &str = "blocks";
 
-// Phase 3a `status` label values on the `*_cache_total` counters.
+// `status` label values on the `*_cache_total` counters.
 pub(crate) const CACHE_RESULT_HIT: &str = "hit";
 pub(crate) const CACHE_RESULT_MISS: &str = "miss";
 pub(crate) const CACHE_RESULT_PUT: &str = "put";
 
-// Phase 3a `operation` label value on `node_cache_total`.
+// `operation` label value on `node_cache_total`.
 pub(crate) const NODE_CACHE_OP_LOOKUP: &str = "lookup";
 
-// Phase 3a `reason` label values on `user_meta_cache_invalidations_total`, one per
+// `reason` label values on `user_meta_cache_invalidations_total`, one per
 // real `invalid_cache` call site (see the design doc's 15-value enum).
 #[cfg_attr(not(test), allow(dead_code))]
 pub(crate) const INVAL_REASON_SETATTR: &str = "setattr";
@@ -156,11 +156,11 @@ pub(crate) const INVAL_REASON_RENAME: &str = "rename";
 pub(crate) const INVAL_REASON_SYMLINK: &str = "symlink";
 pub(crate) const INVAL_REASON_FSYNC: &str = "fsync";
 
-// Phase 3a `status` label on the readdir histograms.
+// `status` label on the readdir histograms.
 pub(crate) const READDIR_STATUS_SUCCESS: &str = "success";
 pub(crate) const READDIR_STATUS_ERROR: &str = "error";
 
-// Phase 3b `stage` label values on the DEDICATED state-recovery families
+// `stage` label values on the DEDICATED state-recovery families
 // (`state_persist_stage_duration_us` / `state_restore_stage_duration_us`). These
 // are a SEPARATE domain from the request `stage_duration_us` enum
 // (reply_write/meta_spawn/operation/stream_io) — they share the label NAME but
@@ -171,20 +171,20 @@ pub(crate) const STATE_STAGE_FILE_HANDLES: &str = "file_handles";
 pub(crate) const STATE_STAGE_DIR_HANDLES: &str = "dir_handles";
 pub(crate) const STATE_STAGE_MOUNT_FDS: &str = "mount_fds";
 
-// Phase 3b `kind` label on `state_persist_handle_count`.
+// `kind` label on `state_persist_handle_count`.
 pub(crate) const STATE_KIND_NODE_MAP: &str = "node_map";
 pub(crate) const STATE_KIND_FILE_HANDLES: &str = "file_handles";
 pub(crate) const STATE_KIND_DIR_HANDLES: &str = "dir_handles";
 
-// Phase 3b `status` label on state_persist/restore families + stage timers.
+// `status` label on state_persist/restore families + stage timers.
 pub(crate) const STATE_STATUS_SUCCESS: &str = "success";
 pub(crate) const STATE_STATUS_ERROR: &str = "error";
 
-// Phase 3b `result` label on `session_init_total`.
+// `result` label on `session_init_total`.
 pub(crate) const SESSION_INIT_SUCCESS: &str = "success";
 pub(crate) const SESSION_INIT_ERROR: &str = "error";
 
-// Phase 3b `reason` label on `session_shutdown_total` (6 bounded values). The
+// `reason` label on `session_shutdown_total` (6 bounded values). The
 // `run_all` select arm splits its three match outcomes; the signal arms and the
 // fd-watcher contribute the rest. Recorded once via a `ShutdownOnce` CAS.
 pub(crate) const SHUTDOWN_COMPLETED: &str = "completed";
@@ -194,8 +194,8 @@ pub(crate) const SHUTDOWN_TERM_SIGNAL: &str = "term_signal";
 pub(crate) const SHUTDOWN_SIGUSR1_PERSIST: &str = "sigusr1_persist";
 pub(crate) const SHUTDOWN_FD_WATCHER: &str = "fd_watcher";
 
-// `phase` label values (`decode_errors_total`). `parse` (parse-after-ctx
-// cleanup) ships in 1a-2; `decode` (from_bytes failures) in 1b.
+// `phase` label values (`decode_errors_total`). `parse` is parse-after-ctx
+// cleanup; `decode` is a `from_bytes` failure.
 pub(crate) const DECODE_PHASE_PARSE: &str = "parse";
 pub(crate) const DECODE_PHASE_DECODE: &str = "decode";
 
@@ -205,45 +205,37 @@ pub(crate) const DECODE_PHASE_DECODE: &str = "decode";
 pub(crate) const RECEIVE_ACTION_CONTINUE: &str = "continue";
 pub(crate) const RECEIVE_ACTION_EXIT: &str = "exit";
 
-// `reason` label value for `reply_enqueue_errors_total`. Phase 1a-2 only uses
-// `channel_closed`: a tokio `SendError` means exactly "channel closed" and
-// cannot reliably distinguish runtime shutdown, so we do not invent a reason
-// from the error string (see plan R6).
+// `reason` label value for `reply_enqueue_errors_total`. Only `channel_closed`
+// is used: a tokio `SendError` means exactly "channel closed" and cannot reliably
+// distinguish runtime shutdown, so we do not invent a reason from the error string.
 pub(crate) const ENQUEUE_REASON_CHANNEL_CLOSED: &str = "channel_closed";
 
 // `status` label values for `notify_total`. These are a delivery lifecycle,
 // NOT a request status — deliberately separate consts so they are never
-// confused with `FuseReqStatus::as_str()` (see plan R12).
+// confused with `FuseReqStatus::as_str()`.
 pub(crate) const NOTIFY_SUCCESS: &str = "success";
 pub(crate) const NOTIFY_ENQUEUE_FAILED: &str = "enqueue_failed";
 pub(crate) const NOTIFY_WRITE_FAILED: &str = "write_failed";
 
 // Defensive `reason` label used only when an `Unsupported` status reaches the
-// finish helper with no source tag — which is a wiring bug (every 1a-2
-// Unsupported site tags its reason). It is surfaced via debug_assert!/warn! and
-// bucketed distinctly so a missing tag never masquerades as a real
-// `unimplemented_opcode` gap.
+// finish helper with no source tag — which is a wiring bug (every Unsupported
+// site tags its reason). It is surfaced via debug_assert!/warn! and bucketed
+// distinctly so a missing tag never masquerades as a real `unimplemented_opcode`
+// gap.
 const UNSUPPORTED_REASON_MISSING: &str = "missing_reason";
 
 /// Fallback `errno` label when a delivery (kernel-fd write) failure carries no
 /// OS errno — used by `response_write_errors_total` instead of `errno_label(0)`
-/// so a missing errno never reads as a literal "raw 0" (see plan R7).
+/// so a missing errno never reads as a literal "raw 0".
 const ERRNO_LABEL_OTHER: &str = "OTHER";
 
 static FUSE_METRICS: OnceCell<FuseMetrics> = OnceCell::new();
 
 /// Process-global FUSE metrics registry.
 ///
-/// The struct is intentionally shaped so that **each implementation phase
-/// registers the concrete metric families it first uses** — it is *not*
-/// front-loaded with every future metric. Adding a later phase's metrics is an
-/// additive change (a new field + a registration line), never a refactor of the
-/// existing fields. This keeps each phase's diff self-contained and avoids
-/// locking metric names / label sets before the code that uses them exists.
-///
-/// Phase 0 registers only the three pre-existing runtime gauges; the helper
-/// types below (`FuseReqLabels`, `ActiveGuard`, `HistogramTimer`) are the
-/// enabling primitives that later phases build on, and carry no call sites yet.
+/// Adding a metric is an additive change (a new field + a registration line in
+/// `register`), never a refactor of the existing fields — so metric names /
+/// label sets are only locked once the code that uses them exists.
 pub struct FuseMetrics {
     pub inode_num: Gauge,
     pub file_handle_num: Gauge,
@@ -254,7 +246,7 @@ pub struct FuseMetrics {
     pub write_back_mem_usage: Gauge,
     pub write_back_mem_limit: Gauge,
 
-    // --- Phase 3b-1: namespaced aliases of the legacy gauges above ---
+    // --- namespaced aliases of the legacy gauges above ---
     // Event-driven at the same insert/remove/restore sites, kept exactly in
     // lockstep with their legacy counterparts (updated inside the same
     // `FuseMetrics::with` closure). The legacy `*_num` gauges are deprecated and
@@ -263,7 +255,7 @@ pub struct FuseMetrics {
     pub file_handle_count: Gauge,
     pub dir_handle_count: Gauge,
 
-    // --- Phase 1a-2: end-to-end request metrics ---
+    // --- end-to-end request metrics ---
     /// E2E in-flight requests, driven by `ActiveGuard`: incremented at ctx
     /// creation, decremented at the sender/no-reply finish. `kind`.
     pub(crate) active_requests: GaugeVec,
@@ -276,13 +268,13 @@ pub struct FuseMetrics {
     pub(crate) errors_total: CounterVec,
     /// Interrupted requests (the SETLKW interrupt-notify path). `opcode`.
     pub(crate) interrupted_total: CounterVec,
-    /// Unsupported requests. `opcode,reason`. Phase 1a-2 emits
+    /// Unsupported requests. `opcode,reason`. Emits
     /// `unknown_opcode` / `unimplemented_opcode`; `trait_default` reserved.
     pub(crate) unsupported_total: CounterVec,
     /// Kernel notifications. `code,status` where status is a delivery lifecycle
     /// (`success|enqueue_failed|write_failed`), not a request status.
     pub(crate) notify_total: CounterVec,
-    /// Structural decode/parse failures. `phase,reason`. Phase 1a-2 emits only
+    /// Structural decode/parse failures. `phase,reason`. Emits only
     /// `phase=parse,reason=other`; the schema supports the full reason set but
     /// other series are not pre-created.
     pub(crate) decode_errors_total: CounterVec,
@@ -293,15 +285,15 @@ pub struct FuseMetrics {
     /// `opcode,request_status`.
     pub(crate) response_bytes_total: CounterVec,
     /// Reply-channel enqueue failures (request never reaches the sender).
-    /// `opcode,reason`. Phase 1a-2 only uses reason `channel_closed`.
+    /// `opcode,reason`. Only uses reason `channel_closed`.
     pub(crate) reply_enqueue_errors_total: CounterVec,
     /// Kernel-fd write failures in the sender (delivery failure). `opcode,errno`.
     pub(crate) response_write_errors_total: CounterVec,
     /// Per-stage latency, opcode-free. `stage,kind,status`. Bounded `stage`
-    /// enum emitted by the current build (reply_write in 1a-2, meta_spawn in 1b).
+    /// enum (reply_write, meta_spawn, operation, stream_io).
     pub(crate) stage_duration_us: HistogramVec,
 
-    // --- Phase 1b-1: framework health + scrape hygiene ---
+    // --- framework health + scrape hygiene ---
     /// Receiver loop wait: splice + header-parse, INCLUDING idle wait for the
     /// next kernel request. A saturation/health histogram, NOT request latency.
     pub(crate) receive_loop_wait_duration_us: Histogram,
@@ -316,7 +308,7 @@ pub struct FuseMetrics {
     /// `/metrics` last scrape output size in bytes. Self-observation gauge.
     pub(crate) metrics_scrape_bytes: Gauge,
 
-    // --- Phase 2a: metadata operation, reply-queue depth, SETLKW ---
+    // --- metadata operation, reply-queue depth, SETLKW ---
     /// Per-op metadata operation latency, observed at a single timer around the
     /// whole `dispatch_meta` match. `opcode,kind,status` (kind always
     /// `metadata`). Status is the stashed `op_status` (FS-operation result),
@@ -356,14 +348,14 @@ pub struct FuseMetrics {
     /// No label.
     pub(crate) setlkw_inflight: Gauge,
 
-    // --- Phase 2b: stream IO (read/write backend + flush/fsync/release lifecycle) ---
+    // --- stream IO (read/write backend + flush/fsync/release lifecycle) ---
     //
     // Two deliberately-separate families. `io_*` covers read/write backend IO and
     // carries `status` (the backend result is clean). `stream_lifecycle_*` covers
     // flush/fsync/release and carries NO status (their result mixes backend and
     // reply-enqueue errors, so a status label would be dishonest) — and because a
     // Prometheus family's label set is fixed at registration, the two cannot share
-    // a family (R3 P0#1).
+    // a family.
     /// read/write backend IO latency, observed in the reader/writer task body when
     /// the backend `fuse_read`/`fuse_write` returns. `io_type` ∈ {read,write},
     /// `path_type` is the resolved backend, `status` ∈ {success,error}.
@@ -417,7 +409,7 @@ pub struct FuseMetrics {
     /// `_total` suffix (a gauge), no label.
     pub(crate) stream_write_queue_depth: Gauge,
 
-    // --- Phase 3a: cache + readdir metrics ---
+    // --- cache + readdir metrics ---
     /// MetaCache hit/miss/put on the daemon's userspace metadata cache.
     /// `cache` ∈ {status,list,blocks}, `status` ∈ {hit,miss,put}. `miss` is
     /// recorded the moment the cache read returns `None` (before the backend
@@ -449,7 +441,7 @@ pub struct FuseMetrics {
     /// the full-traversal cost is a deferred `opendir_duration_us`. `status`.
     pub(crate) readdir_duration_us: HistogramVec,
 
-    // --- Phase 3b: state recovery + session lifecycle ---
+    // --- state recovery + session lifecycle ---
     /// Persist attempts (SIGUSR1). `status` ∈ {success,error}, recorded once at
     /// the `fuse_session.rs::persist` entry/exit.
     pub(crate) state_persist_total: CounterVec,
@@ -496,12 +488,10 @@ impl FuseMetrics {
     /// no-op when not (instead of `get()`'s panic).
     ///
     /// This is the access path for the **legacy compatibility gauges**
-    /// (`inode_num` / `file_handle_num` / `dir_handle_num`) **and their Phase 3b-1
+    /// (`inode_num` / `file_handle_num` / `dir_handle_num`) **and their
     /// namespaced aliases** (`curvine_fuse_{inode,file_handle,dir_handle}_count`),
-    /// which are updated unconditionally at their inode/handle mutation sites
-    /// (Phase 1b-2 made them event-driven and removed the scrape-time
-    /// `set_metrics()` refresh; 3b-1 added the aliases in lockstep at the same
-    /// sites). Those sites live in `NodeState`/`NodeMap`, whose unit tests
+    /// which are updated unconditionally (event-driven) at their inode/handle
+    /// mutation sites, in lockstep. Those sites live in `NodeState`/`NodeMap`, whose unit tests
     /// construct state with a bare `NodeState::new` and never call
     /// `ensure_init()`; routing every gauge write through `with()` keeps them
     /// from panicking on the uninitialized singleton. The aliases MUST use this
@@ -541,7 +531,7 @@ impl FuseMetrics {
                 "FUSE write-back page cache size limit (bytes)",
             )?,
 
-            // Phase 3b-1: namespaced aliases (same values, event-driven in lockstep).
+            // Namespaced aliases (same values, event-driven in lockstep).
             inode_count: m::new_gauge(
                 "curvine_fuse_inode_count",
                 "FUSE inode count in dcache (namespaced alias of inode_num)",
@@ -781,7 +771,7 @@ impl FuseMetrics {
                  task-embedded guard, dropped at the dequeue point",
             )?,
 
-            // Phase 3a: cache + readdir.
+            // cache + readdir.
             user_meta_cache_total: m::new_counter_vec(
                 "curvine_fuse_user_meta_cache_total",
                 "userspace metadata cache (NodeState/DirTree) hit/miss/put by cache namespace. status=hit|miss|put",
@@ -817,7 +807,7 @@ impl FuseMetrics {
                 REQUEST_DURATION_BUCKETS_US,
             )?,
 
-            // Phase 3b: state recovery + session lifecycle.
+            // state recovery + session lifecycle.
             state_persist_total: m::new_counter_vec(
                 "curvine_fuse_state_persist_total",
                 "FUSE state-persist attempts (SIGUSR1). status=success|error",
@@ -869,7 +859,7 @@ impl FuseMetrics {
         })
     }
 
-    // --- Phase 1a-2 emission helpers ---
+    // --- emission helpers ---
     //
     // These are the single place each metric's `with_label_values` lives, so the
     // finish paths (sender / no-reply / enqueue-failure / parse-early) never hand
@@ -907,7 +897,7 @@ impl FuseMetrics {
     /// The full sender finish emission: request total + duration, response
     /// write latency/bytes, the `reply_write` stage, and the per-status error /
     /// unsupported / interrupted / delivery-failure counters. Pure (no IO), so
-    /// it is unit-testable without a kernel fd (plan R13).
+    /// it is unit-testable without a kernel fd.
     ///
     /// **Two statuses, deliberately separate** (design doc "operation vs request
     /// status"):
@@ -977,7 +967,7 @@ impl FuseMetrics {
     ///
     /// **Call exactly once per request, only from a request terminal path.**
     /// Calling it twice double-counts the op-level counters for one request. In
-    /// particular, the Phase 2 `operation_duration_us` timer must only `observe`
+    /// particular, the `operation_duration_us` timer must only `observe`
     /// latency — it must NOT call this (the request terminal already did).
     pub(crate) fn record_op_terminal(
         &self,
@@ -995,8 +985,8 @@ impl FuseMetrics {
             }
             FuseReqStatus::Unsupported => {
                 // Source-tagged reason is the only authority (never inferred from
-                // errno). 1a-2 always tags Unsupported at its source sites; a
-                // missing tag is a wiring bug, surfaced (not silently bucketed).
+                // errno). Every Unsupported site tags its reason; a missing tag is
+                // a wiring bug, surfaced (not silently bucketed).
                 let reason = match unsupported_reason {
                     Some(r) => r,
                     None => {
@@ -1026,7 +1016,7 @@ impl FuseMetrics {
     }
 
     /// `reply_enqueue_errors_total +1` — the reply never reached the sender.
-    /// `reason` is a channel-level reason const (Phase 1a-2 only uses
+    /// `reason` is a channel-level reason const (only
     /// `ENQUEUE_REASON_CHANNEL_CLOSED`).
     pub(crate) fn record_reply_enqueue_error(&self, opcode: &'static str, reason: &'static str) {
         self.reply_enqueue_errors_total
@@ -1036,14 +1026,14 @@ impl FuseMetrics {
 
     /// `decode_errors_total{phase="parse"} +1` — a structural parse failure that
     /// happened after the request ctx existed. `reason` is the parse-failure
-    /// reason (Phase 1a-2 only emits `"other"`).
+    /// reason (only `"other"` is emitted).
     pub(crate) fn record_parse_error(&self, reason: &'static str) {
         self.decode_errors_total
             .with_label_values(&[DECODE_PHASE_PARSE, reason])
             .inc();
     }
 
-    // --- Phase 1b-1 framework health helpers ---
+    // --- framework health helpers ---
 
     /// `decode_errors_total{phase="decode"} +1` — a structural `from_bytes`
     /// failure before any request ctx exists. `reason` is `"other"` for now
@@ -1106,11 +1096,11 @@ impl FuseMetrics {
         }
     }
 
-    // --- Phase 2a emission helpers ---
+    // --- emission helpers ---
 
     /// Observe the metadata operation latency once around the whole
     /// `dispatch_meta` match, feeding **two** families from one timer (the same
-    /// dual-emit shape as the 2b `stream_io` call site):
+    /// dual-emit shape as the `stream_io` call site):
     /// - `operation_duration_us{opcode,kind=metadata,status}` — per-opcode detail.
     /// - `stage_duration_us{stage=operation,kind=metadata,status}` — the
     ///   opcode-free stage view, so the operation stage is comparable against the
@@ -1150,8 +1140,8 @@ impl FuseMetrics {
     /// Uses `get()` (strict), like `setlkw_inflight_guard` / `setlkw_wait_timer`:
     /// because this is only ever reached on the metrics-enabled path, an
     /// uninitialized singleton here is a wiring/init-order regression and SHOULD
-    /// surface as a panic rather than silently drop `reply_queue_depth` (review
-    /// P1#5). Production order guarantees init before any reply (ensure_init
+    /// surface as a panic rather than silently drop `reply_queue_depth`.
+    /// Production order guarantees init before any reply (ensure_init
     /// precedes NodeState; pinned by `ensure_init_precedes_node_state`); the
     /// enabled-path unit tests call `ensure_init()` in their fixtures. The guard is
     /// moved into the `RequestReply`/`NotifyReply` task and decrements when the
@@ -1197,7 +1187,7 @@ impl FuseMetrics {
         }
     }
 
-    // --- Phase 2b emission helpers ---
+    // --- emission helpers ---
 
     /// Record one read/write backend IO in the reader/writer task body, feeding
     /// the read/write `io_*` families plus the opcode-free `stage_duration_us`
@@ -1246,7 +1236,7 @@ impl FuseMetrics {
             .with_label_values(&[io_type, path_type])
             .observe(request_size as f64);
         if ok {
-            // Success-only byte series, fixed status=success (R3 P0#2).
+            // Success-only byte series, fixed status=success.
             self.io_bytes_total
                 .with_label_values(&[io_type, path_type, FuseReqStatus::Success.as_str()])
                 .inc_by(transferred_bytes as i64);
@@ -1330,7 +1320,7 @@ impl FuseMetrics {
         }
     }
 
-    // --- Phase 3a emission helpers (called via `FuseMetrics::with`) ---
+    // --- emission helpers (called via `FuseMetrics::with`) ---
 
     /// `user_meta_cache_total{cache,status} +1`. `cache` ∈ {status,list,blocks},
     /// `status` ∈ {hit,miss,put}.
@@ -1386,7 +1376,7 @@ impl FuseMetrics {
             .observe(elapsed_us as f64);
     }
 
-    // --- Phase 3b emission helpers (called via `FuseMetrics::with`) ---
+    // --- emission helpers (called via `FuseMetrics::with`) ---
 
     /// `state_persist_total{status} +1` / `state_restore_total{status} +1`.
     pub(crate) fn record_state_total(&self, is_persist: bool, status: &'static str) {
@@ -1540,15 +1530,15 @@ impl FuseReqKind {
 /// task.
 ///
 /// The move-only request context that *owns* the in-flight guard (`FuseReqCtx`)
-/// is defined where it is used (Phase 1a-1); these labels are the part that
-/// travels onto the reply.
+/// is defined where it is used; these labels are the part that travels onto the
+/// reply.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct FuseReqLabels {
     pub(crate) opcode: &'static str,
     pub(crate) kind: FuseReqKind,
     pub(crate) start: Instant,
     /// Request size from the parsed header. Carried for a future per-request
-    /// byte metric; not read by any Phase 1a-2 series yet.
+    /// byte metric; not read by any series yet.
     #[allow(dead_code)]
     pub(crate) request_bytes: u32,
 }
@@ -1628,17 +1618,17 @@ pub(crate) struct FuseReqCtx {
 ///
 /// `op_status` / `errno` / `unsupported_reason` are stored **independently of**
 /// `active`, so taking the guard out into the reply task does not clear the
-/// status the operation-duration timer reads later (Phase 1a-2 / Phase 2).
+/// status the operation-duration timer reads later.
 #[derive(Debug)]
 pub(crate) struct FuseRespMetrics {
     pub(crate) labels: FuseReqLabels,
     /// The E2E guard; `take()`n exactly once when the reply is built.
     pub(crate) active: Option<ActiveGuard>,
     /// FS-operation result status. Stashed by every finish path and asserted by
-    /// tests; the production read (the `operation_duration_us{status}` timer)
-    /// lands in Phase 2. Kept separate from `request_status` because the two can
-    /// diverge (op succeeds, delivery fails).
-    #[allow(dead_code)] // production reader is operation_duration_us in Phase 2.
+    /// tests; the production read is the `operation_duration_us{status}` timer.
+    /// Kept separate from `request_status` because the two can diverge (op
+    /// succeeds, delivery fails).
+    #[allow(dead_code)] // production reader is operation_duration_us.
     pub(crate) op_status: Option<FuseReqStatus>,
     /// Final delivery/result status. The replied path carries status on the
     /// `RequestReply` task (read by the sender), so this slot copy exists for the
@@ -1691,10 +1681,9 @@ impl FuseRespMetrics {
 /// type can back different scopes (`active_requests`, `stream_io_inflight`,
 /// `meta_task_inflight`) just by being constructed from different gauges.
 ///
-/// The `None` (no-op) form is what Phase 1a-1 uses: it exercises the full
-/// move-and-drop lifetime — proving single-take / single-drop ownership — while
-/// touching no real gauge. Phase 1a-2 swaps in `new(active_requests_gauge)` so
-/// the same plumbing then drives the real metric.
+/// The `None` (no-op) form exercises the full move-and-drop lifetime — proving
+/// single-take / single-drop ownership — while touching no real gauge;
+/// `new(active_requests_gauge)` uses the same plumbing to drive the real metric.
 #[derive(Debug)]
 pub(crate) struct ActiveGuard {
     gauge: Option<Gauge>,
@@ -1707,8 +1696,8 @@ impl ActiveGuard {
         Self { gauge: Some(gauge) }
     }
 
-    /// A no-op guard: same move/drop semantics, but touches no gauge. Used in
-    /// Phase 1a-1 to validate ownership before the real gauge is wired (1a-2).
+    /// A no-op guard: same move/drop semantics, but touches no gauge. Used to
+    /// validate ownership without a real gauge.
     pub(crate) fn noop() -> Self {
         Self { gauge: None }
     }
@@ -1732,8 +1721,8 @@ impl Drop for ActiveGuard {
 ///
 /// Durations are measured with the monotonic clock (`Instant`).
 ///
-/// Wired to call sites since Phase 2a (`setlkw_wait_timer`) and Phase 2b
-/// (`io_dispatch_timer` / the `stream_lifecycle_scope` duration timer).
+/// Backs `setlkw_wait_timer`, `io_dispatch_timer`, and the
+/// `stream_lifecycle_scope` duration timer.
 #[derive(Debug)]
 pub(crate) struct HistogramTimer {
     start: Instant,
@@ -1756,7 +1745,7 @@ impl Drop for HistogramTimer {
     }
 }
 
-/// Phase 3a readdir timer for `read_dir_common`. Records
+/// Readdir timer for `read_dir_common`. Records
 /// `readdir_duration_us{status=error}` on drop UNLESS `success(entries)` was
 /// called, which instead records `readdir_duration_us{status=success}` +
 /// `readdir_entries{status=success}`. So an early `?` return or an async
@@ -1803,7 +1792,7 @@ impl Drop for ReaddirTimer {
     }
 }
 
-/// Phase 3b per-stage timer for state persist/restore (D9). Records the stage
+/// Per-stage timer for state persist/restore. Records the stage
 /// duration on drop with `status=error` UNLESS `success()` is called first (which
 /// records `status=success` and disarms the error drop). So an early `?` return
 /// or async cancellation mid-stage is counted as `error` ("the attempt did not
@@ -1852,7 +1841,7 @@ impl Drop for StateStageTimer {
     }
 }
 
-/// Phase 3b shutdown-reason de-duplicator (D4). `session_shutdown_total` must be
+/// Shutdown-reason de-duplicator. `session_shutdown_total` must be
 /// recorded exactly once per session, by the FIRST cause: the fd-watcher, a
 /// signal arm, and the `run_all` completion arm can all race to report a reason.
 /// A single `compare_exchange` CAS lets the first caller win; later callers
@@ -1898,7 +1887,7 @@ mod tests {
     use orpc::common::Metrics as m;
 
     // Compile-time guarantee that the guards/timer are `Send`. They must travel
-    // into spawned tasks and onto reply tasks (Phase 1a); if a future field
+    // into spawned tasks and onto reply tasks; if a future field
     // change made them `!Send`, this fails to compile here rather than silently
     // at the first cross-task move.
     #[test]
@@ -2046,7 +2035,7 @@ mod tests {
         assert_eq!(FuseReqStatus::Unsupported.as_str(), "unsupported");
     }
 
-    // test 1: a successful replied request increments requests_total{replied,
+    // a successful replied request increments requests_total{replied,
     // success} + request_duration once, response_write/bytes/reply_write stage
     // once, and NO error/unsupported/interrupted counter.
     #[test]
@@ -2117,7 +2106,7 @@ mod tests {
         );
     }
 
-    // test 14: a real error (untagged) increments errors_total with the errno
+    // a real error (untagged) increments errors_total with the errno
     // label and NOT unsupported_total.
     #[test]
     fn record_request_finish_error_emits_errors_total_with_errno() {
@@ -2186,7 +2175,7 @@ mod tests {
         );
     }
 
-    // test 16 / P1#1: op succeeds but the kernel-fd write fails. The kernel
+    // op succeeds but the kernel-fd write fails. The kernel
     // observes a failed request, so the request_status-labelled series go to
     // `error`, while the op-level counters stay clean (op succeeded). The write
     // errno is the independent delivery dimension.
@@ -2259,7 +2248,7 @@ mod tests {
         );
     }
 
-    // P1#2: a defensive guard — an Unsupported op_status with no source tag is a
+    // a defensive guard — an Unsupported op_status with no source tag is a
     // wiring bug. It must not silently masquerade as unimplemented_opcode; it is
     // bucketed under missing_reason (and asserts in debug). Pass request_status
     // == op_status (write succeeded) so only the op-status path is exercised.
@@ -2312,7 +2301,7 @@ mod tests {
         );
     }
 
-    // test 12: notify lifecycle states are distinct counters under notify_total.
+    // notify lifecycle states are distinct counters under notify_total.
     #[test]
     fn record_notify_result_counts_three_states() {
         FuseMetrics::ensure_init().unwrap();
@@ -2340,8 +2329,6 @@ mod tests {
             1
         );
     }
-
-    // --- Phase 1b-1 ---
 
     // receive_errors_total: errno + action labels recorded as a delta.
     #[test]
@@ -2373,8 +2360,8 @@ mod tests {
         );
     }
 
-    // record_decode_error emits under phase=decode (the 1b site; 1a-2 already
-    // had phase=parse via record_parse_error). We assert only the decode series
+    // record_decode_error emits under phase=decode (record_parse_error already
+    // covers phase=parse). We assert only the decode series
     // delta: a cross-series ("parse untouched") assertion can't be made reliably
     // against the process-global registry under parallel tests, and a `>=` guard
     // would prove nothing — so we don't pretend to. `decode` vs `parse` being
@@ -2449,7 +2436,7 @@ mod tests {
     }
 
     // record_meta_spawn observes the stage_duration_us{meta_spawn,metadata,success}
-    // series — guards against a label/status/kind typo in the core 1b-1 helper.
+    // series — guards against a label/status/kind typo in the core helper.
     #[test]
     fn record_meta_spawn_observes_correct_labels() {
         FuseMetrics::ensure_init().unwrap();
@@ -2482,9 +2469,9 @@ mod tests {
         );
     }
 
-    // --- Phase 2a helper tests ---
+    // --- helper tests ---
 
-    // E1: record_operation feeds BOTH families from one timer — the per-opcode
+    // record_operation feeds BOTH families from one timer — the per-opcode
     // `operation_duration_us{opcode,kind=metadata,status}` and the opcode-free
     // `stage_duration_us{stage=operation,kind=metadata,status}` — under the
     // stashed op_status (here: success). Unique opcode + delta on the shared
@@ -2531,7 +2518,7 @@ mod tests {
         );
     }
 
-    // E2: status comes through verbatim (here: error) — the timer observes
+    // status comes through verbatim (here: error) — the timer observes
     // whatever op_status the caller read back from the slot, NOT a hard-coded
     // success. Guards against a status-source regression in the helper labels.
     #[test]
@@ -2562,7 +2549,7 @@ mod tests {
         );
     }
 
-    // E (B2 gate): reply_queue_guard returns Some once the singleton is
+    // B2 gate: reply_queue_guard returns Some once the singleton is
     // initialized, inc on create / dec on drop. (The disabled path produces the
     // legacy Reply and never calls this; the gate lives at the FuseResponse call
     // site, so there is no `false` arm to assert here.)
@@ -2586,7 +2573,7 @@ mod tests {
         );
     }
 
-    // E4: setlkw_inflight_guard gate — disabled is None (never noop), enabled
+    // setlkw_inflight_guard gate — disabled is None (never noop), enabled
     // inc/dec balances the gauge.
     #[test]
     fn setlkw_inflight_guard_gate() {
@@ -2604,7 +2591,7 @@ mod tests {
         assert_eq!(mx.setlkw_inflight.get(), before, "guard dec on drop");
     }
 
-    // E17: setlkw_wait_timer gate — disabled builds NO timer (no clock read, no
+    // setlkw_wait_timer gate — disabled builds NO timer (no clock read, no
     // observe on drop), enabled observes exactly once on drop.
     #[test]
     fn setlkw_wait_timer_gate() {
@@ -2634,7 +2621,7 @@ mod tests {
         );
     }
 
-    // --- Phase 2b helper tests ---
+    // --- helper tests ---
     //
     // The process-global registry accumulates across parallel tests, so value
     // assertions read a child's counter/histogram before and after and check the
@@ -2644,7 +2631,7 @@ mod tests {
     // takes `path_type` as a parameter, so a test-only label is just as valid a
     // child as a real backend and never collides with another test or with e2e.
 
-    // E (dispatch_io_type / lifecycle_io_type closed maps, R-overall P1#6): the 5
+    // dispatch_io_type / lifecycle_io_type closed maps: the 5
     // stream opcodes map to the LOWERCASE io_type consts (NOT opcode.as_str(), which
     // is "Read"/"Fsync" etc.); non-stream / non-IO opcodes map to None; and exactly
     // one of the two maps is Some for any known stream opcode.
@@ -2699,7 +2686,7 @@ mod tests {
         }
     }
 
-    // E7/E13/E14 (read/write io family): a successful read records duration + stage
+    // read/write io family: a successful read records duration + stage
     // + requests{success} + size + bytes{success}; an error records duration + stage
     // + requests{error} + size, but creates NO bytes child (never inc_by(0)). Uses a
     // unique path_type so the children are isolated on the shared registry.
@@ -2808,7 +2795,7 @@ mod tests {
         );
     }
 
-    // E6 (stream_io_inflight gate): disabled is None (never noop); enabled is Some
+    // stream_io_inflight gate: disabled is None (never noop); enabled is Some
     // and inc/dec balances the GaugeVec child for the given io_type. Uses the real
     // read child but reads before/after deltas so it is parallel-safe.
     #[test]
@@ -2842,11 +2829,10 @@ mod tests {
         );
     }
 
-    // E21 (stream_lifecycle_scope): opening the scope counts the attempt
+    // stream_lifecycle_scope: opening the scope counts the attempt
     // immediately (before the backend runs), holds the inflight guard while alive
     // (gauge>0), and observes the duration once on drop; the inflight returns to
-    // baseline after drop. Asserts the FULL {io_type,path_type="unknown"} label set
-    // (R-overall P1#5).
+    // baseline after drop. Asserts the FULL {io_type,path_type="unknown"} label set.
     #[test]
     fn stream_lifecycle_scope_counts_attempt_holds_inflight_observes_on_drop() {
         FuseMetrics::ensure_init().unwrap();
@@ -2907,7 +2893,7 @@ mod tests {
         );
     }
 
-    // E (io_dispatch_timer): observes once on drop under the io_type child.
+    // io_dispatch_timer: observes once on drop under the io_type child.
     #[test]
     fn io_dispatch_timer_observes_once_on_drop() {
         FuseMetrics::ensure_init().unwrap();
@@ -2928,7 +2914,7 @@ mod tests {
         );
     }
 
-    // E4 (stream_write_queue_guard gate): disabled None (never noop), enabled inc/dec
+    // stream_write_queue_guard gate: disabled None (never noop), enabled inc/dec
     // balances the gauge.
     #[test]
     fn stream_write_queue_guard_gate() {
@@ -2954,7 +2940,7 @@ mod tests {
         );
     }
 
-    // E24 (negative assertion, io family is read/write only): record_stream_io must
+    // negative assertion, io family is read/write only: record_stream_io must
     // never be called with a flush/fsync/release io_type in production — the family
     // SPLIT is structural (lifecycle uses stream_lifecycle_*). Here we assert the
     // closed maps enforce that split: an io_type that would land in io_* only ever
@@ -2996,22 +2982,22 @@ mod tests {
         assert_eq!(PATH_TYPE_UNKNOWN, "unknown");
     }
 
-    // E27 (negative assertion): there is NO STAGE_STREAM_ENQUEUE const and
-    // stage=stream_io is the only Phase 2b stage value. This is a compile-time-ish
-    // guard: STAGE_STREAM_IO is "stream_io" and there is no "stream_enqueue" stage
-    // const to reference (grep-enforced in review; asserted by value here).
+    // negative assertion: there is NO STAGE_STREAM_ENQUEUE const and
+    // stage=stream_io is the only stream stage value. STAGE_STREAM_IO is
+    // "stream_io" and there is no "stream_enqueue" stage const to reference
+    // (asserted by value here).
     #[test]
-    fn stage_stream_io_is_the_only_phase2b_stage() {
+    fn stage_stream_io_is_the_only_stream_stage() {
         assert_eq!(STAGE_STREAM_IO, "stream_io");
         // No STAGE_STREAM_ENQUEUE exists; if one were added this test's neighbors
         // (the no-enqueue rule) and the send_stream code review would catch it.
     }
 
-    // --- Phase 3a helper tests ---
+    // --- helper tests ---
     //
-    // Same parallel-safety discipline as Phase 2b: the process-global registry
-    // accumulates across parallel tests, so value assertions read a child's
-    // counter before/after on a label set the test owns. `user_meta_cache_total`
+    // Same parallel-safety discipline as the stream IO tests: the process-global
+    // registry accumulates across parallel tests, so value assertions read a
+    // child's counter before/after on a label set the test owns. `user_meta_cache_total`
     // and `*_invalidations_total` take the `cache` label as a param, so each test
     // uses a UNIQUE synthetic `cache` value to isolate its children. The no-label
     // `negative_entry_returned_total` uses a before/after delta.
@@ -3221,12 +3207,12 @@ mod tests {
             INVAL_REASON_FSYNC,
         ];
         assert_eq!(reasons.len(), 15);
-        // No catch-all `other` and no `kernel_notify` (dropped in Phase 3a).
+        // No catch-all `other` and no `kernel_notify`.
         assert!(!reasons.contains(&"other"));
         assert!(!reasons.contains(&"kernel_notify"));
     }
 
-    // --- Phase 3b seam tests ---
+    // --- seam tests ---
 
     // ShutdownOnce records exactly once (first cause wins); later callers no-op.
     // Verified via the return-value of record_once (true only for the winner),
@@ -3350,7 +3336,7 @@ mod tests {
         }
     }
 
-    // P3#5: the lifecycle record helpers actually emit through the singleton
+    // the lifecycle record helpers actually emit through the singleton
     // (exercises the `FuseMetrics::with(|m| m.record_session_init/...)` path the
     // session uses). Shared global children → lower-bound deltas, parallel-safe.
     #[test]
@@ -3394,7 +3380,7 @@ mod tests {
         assert!(v == 0 || v == 1, "health gauge is binary");
     }
 
-    // P3#5: gate decision (enabled vs disabled) is deterministic against an
+    // gate decision (enabled vs disabled) is deterministic against an
     // isolated counter — the exact `if enabled { emit }` shape the session call
     // sites use to gate every lifecycle/state emission on metrics_enabled.
     #[test]

--- a/curvine-fuse/src/fuse_metrics.rs
+++ b/curvine-fuse/src/fuse_metrics.rs
@@ -99,15 +99,11 @@ pub(crate) const IO_TYPE_RELEASE: &str = "release";
 pub(crate) const PATH_TYPE_CURVINE: &str = "curvine";
 #[cfg_attr(not(test), allow(dead_code))] // value produced by path_type(); fuse-side use is test-only.
 pub(crate) const PATH_TYPE_UFS: &str = "ufs";
-// ⚠ `fallback` is the READER WRAPPER TYPE, not the backend a given read actually
-// hit. `UnifiedReader::Fallback(FallbackFsReader)` tries Curvine first and only
-// switches to UFS after a worker error, but `path_type` is captured ONCE at handle
-// construction — so a long-lived fallback-capable reader reports EVERY read
-// (including Curvine cache hits) as `fallback`. Read it as "this handle is
-// fallback-capable", NOT "this read fell back to UFS". A precise per-read backend
-// label would need the reader to surface its actual outcome per `fuse_read`
-// (deferred to a behaviour PR). Dashboards must not treat `fallback` latency/bytes
-// as real UFS-fallback IO.
+// ⚠ `fallback` is the READER WRAPPER TYPE, not the backend a read actually hit:
+// `path_type` is captured once at handle construction, so a fallback-capable
+// reader reports EVERY read (incl. Curvine cache hits) as `fallback`. Read it as
+// "this handle is fallback-capable", NOT "this read fell back to UFS" — dashboards
+// must not treat `fallback` latency/bytes as real UFS-fallback IO.
 #[cfg_attr(not(test), allow(dead_code))] // reader-only Fallback variant; fuse-side use is test-only.
 pub(crate) const PATH_TYPE_FALLBACK: &str = "fallback";
 #[cfg_attr(not(test), allow(dead_code))] // value produced by path_type(); fuse-side use is test-only.
@@ -484,28 +480,18 @@ impl FuseMetrics {
             .expect("FuseMetrics not initialized; call ensure_init from CurvineFileSystem::new")
     }
 
-    /// Run `f` against the metrics singleton iff it has been initialized; a
-    /// no-op when not (instead of `get()`'s panic).
+    /// Run `f` against the metrics singleton iff initialized; a silent no-op when
+    /// not (instead of `get()`'s panic).
     ///
-    /// This is the access path for the **legacy compatibility gauges**
-    /// (`inode_num` / `file_handle_num` / `dir_handle_num`) **and their
-    /// namespaced aliases** (`curvine_fuse_{inode,file_handle,dir_handle}_count`),
-    /// which are updated unconditionally (event-driven) at their inode/handle
-    /// mutation sites, in lockstep. Those sites live in `NodeState`/`NodeMap`, whose unit tests
-    /// construct state with a bare `NodeState::new` and never call
-    /// `ensure_init()`; routing every gauge write through `with()` keeps them
-    /// from panicking on the uninitialized singleton. The aliases MUST use this
-    /// same `with()` path — do NOT switch them to `FuseMetrics::get()`, which
-    /// would reintroduce that panic on the bare-`NodeState` test paths.
-    ///
-    /// The uninit branch is a deliberate, silent no-op — NOT a `debug_assert!`.
-    /// Tests run in debug with a process-global `OnceCell` whose init order
-    /// across parallel tests is unspecified, so a `node_state` test that fires
-    /// a mutation before any `ensure_init()` would trip the assert and reintroduce
-    /// exactly the flakiness this helper removes. The production invariant
-    /// (`ensure_init()` before `NodeState::new`) is instead pinned by the
-    /// `ensure_init_precedes_node_state` test below, which is the right place to
-    /// catch an ordering regression.
+    /// This is the access path for the legacy compatibility gauges and their
+    /// namespaced aliases, updated event-driven at inode/handle mutation sites in
+    /// `NodeState`/`NodeMap` — whose unit tests use a bare `NodeState::new` without
+    /// `ensure_init()`. Routing every gauge write through `with()` keeps those from
+    /// panicking; the aliases MUST use this path too — do NOT switch them to
+    /// `FuseMetrics::get()`. The uninit branch is a no-op, NOT a `debug_assert!`
+    /// (parallel tests have unspecified `OnceCell` init order). The production
+    /// invariant (`ensure_init()` before `NodeState::new`) is pinned by
+    /// `ensure_init_precedes_node_state`.
     pub(crate) fn with<F: FnOnce(&Self)>(f: F) {
         if let Some(m) = FUSE_METRICS.get() {
             f(m);
@@ -894,25 +880,18 @@ impl FuseMetrics {
             .observe(elapsed_us as f64);
     }
 
-    /// The full sender finish emission: request total + duration, response
-    /// write latency/bytes, the `reply_write` stage, and the per-status error /
-    /// unsupported / interrupted / delivery-failure counters. Pure (no IO), so
-    /// it is unit-testable without a kernel fd.
+    /// The full sender finish emission (request total + duration, response
+    /// write latency/bytes, `reply_write` stage, per-status counters). Pure, so
+    /// unit-testable without a kernel fd.
     ///
-    /// **Two statuses, deliberately separate** (design doc "operation vs request
-    /// status"):
-    /// - `op_status` — the FS-operation result. Drives `errors_total` /
-    ///   `unsupported_total` / `interrupted_total`, which carry the real errno /
-    ///   reason. A delivery failure does NOT change these (a write failure on a
-    ///   successful op is not an FS error).
-    /// - `request_status` — the final result the kernel observes. Equal to
-    ///   `op_status` on the common path, but `Error` when delivery fails (the
-    ///   `WriteOutcome::Failed` case here, or enqueue failure on the early-finish
-    ///   path). Drives `requests_total` / `request_duration_us` /
-    ///   `response_write_duration_us` / `response_bytes_total`.
+    /// Two statuses, deliberately separate:
+    /// - `op_status` — the FS result. Drives `errors_total` / `unsupported_total`
+    ///   / `interrupted_total`; a delivery failure does NOT change these.
+    /// - `request_status` — what the kernel observes: `op_status`, but `Error` when
+    ///   delivery/enqueue fails. Drives `requests_total` / `request_duration_us` /
+    ///   `response_write_*`.
     ///
-    /// The kernel-fd write errno itself is the independent delivery dimension and
-    /// lands in `response_write_errors_total{opcode,errno}`.
+    /// The write errno itself lands in `response_write_errors_total{opcode,errno}`.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn record_request_finish(
         &self,
@@ -1098,20 +1077,12 @@ impl FuseMetrics {
 
     // --- emission helpers ---
 
-    /// Observe the metadata operation latency once around the whole
-    /// `dispatch_meta` match, feeding **two** families from one timer (the same
-    /// dual-emit shape as the `stream_io` call site):
-    /// - `operation_duration_us{opcode,kind=metadata,status}` — per-opcode detail.
-    /// - `stage_duration_us{stage=operation,kind=metadata,status}` — the
-    ///   opcode-free stage view, so the operation stage is comparable against the
-    ///   other framework stages (`reply_enqueue`/`reply_write`/`meta_spawn`) at
-    ///   bounded cardinality.
-    ///
-    /// `status` is the stashed `op_status` (FS-operation result), read back after
-    /// the match — NOT the enqueue outcome. The duration includes the awaited
-    /// reply enqueue by construction. It does NOT call `record_op_terminal`: the
-    /// request terminal path already counted the op outcome; this only observes
-    /// latency.
+    /// Observe metadata operation latency once around the whole `dispatch_meta`
+    /// match, feeding two families from one timer: per-opcode
+    /// `operation_duration_us{opcode,kind=metadata,status}` and the opcode-free
+    /// `stage_duration_us{stage=operation,...}`. `status` is the stashed `op_status`
+    /// (FS result), not the enqueue outcome. Only observes latency — the request
+    /// terminal already counted the op outcome (does NOT call `record_op_terminal`).
     pub(crate) fn record_operation(
         &self,
         opcode: &'static str,
@@ -1132,33 +1103,21 @@ impl FuseMetrics {
     /// Build the `reply_queue_depth` guard for a task entering the reply channel.
     /// Returns `Some(ActiveGuard)` (incrementing the gauge).
     ///
-    /// **Call only from the metrics-enabled reply path** (`self.metrics.is_some()`
-    /// in `FuseResponse`). The disabled path produces the legacy `Reply` variant
-    /// and never reaches here, so the "disabled = `None`, never `noop()`" contract
-    /// is enforced at the call site, not by a `metrics_enabled` flag here.
-    ///
-    /// Uses `get()` (strict), like `setlkw_inflight_guard` / `setlkw_wait_timer`:
-    /// because this is only ever reached on the metrics-enabled path, an
-    /// uninitialized singleton here is a wiring/init-order regression and SHOULD
-    /// surface as a panic rather than silently drop `reply_queue_depth`.
-    /// Production order guarantees init before any reply (ensure_init
-    /// precedes NodeState; pinned by `ensure_init_precedes_node_state`); the
-    /// enabled-path unit tests call `ensure_init()` in their fixtures. The guard is
-    /// moved into the `RequestReply`/`NotifyReply` task and decrements when the
-    /// sender dequeues (or when an un-received task is dropped).
+    /// Call only from the metrics-enabled reply path; the disabled path uses the
+    /// legacy `Reply` and never reaches here. Uses strict `get()` on purpose: an
+    /// uninitialized singleton on this path is a wiring/init-order regression that
+    /// SHOULD panic rather than silently drop `reply_queue_depth` (production init
+    /// order is pinned by `ensure_init_precedes_node_state`). The guard rides the
+    /// reply task and decrements when the sender dequeues it (or it is dropped).
     pub(crate) fn reply_queue_guard() -> Option<ActiveGuard> {
         Some(ActiveGuard::new(Self::get().reply_queue_depth.clone()))
     }
 
-    /// Build the `setlkw_inflight` guard for a SETLKW interruptible-request scope.
-    /// `Some` when enabled, `None` when disabled (never `noop()`). Created after
-    /// the `pending_requests` insert and held across the whole `select!`; its Drop
-    /// — not the `pending_requests.remove` — decrements the gauge, so every
-    /// `select!` branch / early return / cancellation balances. NOTE: the guard
-    /// scope is the whole `dispatch_meta_interrupt`, NOT the `pending_requests` map
-    /// entry — under reply-channel backpressure the gauge can stay non-zero after
-    /// the map entry is already removed (the interrupt branch removes before the
-    /// reply enqueue completes).
+    /// The `setlkw_inflight` guard for a SETLKW scope: `Some` when enabled, `None`
+    /// (never `noop()`) when disabled. Held across the whole `select!`; its Drop
+    /// (not `pending_requests.remove`) decrements, so every branch/cancellation
+    /// balances. Its scope is the whole `dispatch_meta_interrupt`, NOT the map
+    /// entry — so under backpressure the gauge can outlive the removed entry.
     pub(crate) fn setlkw_inflight_guard(metrics_enabled: bool) -> Option<ActiveGuard> {
         if metrics_enabled {
             Some(ActiveGuard::new(Self::get().setlkw_inflight.clone()))
@@ -1167,16 +1126,11 @@ impl FuseMetrics {
         }
     }
 
-    /// Build the SETLKW interruptible-request timer (RAII): `Some(HistogramTimer)`
-    /// when enabled, `None` when disabled (no clock read, no observe). Created in
-    /// `dispatch_meta_interrupt` BEFORE the `select!`, so its scope is the WHOLE
-    /// interruptible SETLKW request (parse, dispatch, `set_lkw()` lock polling, and
-    /// reply enqueue) — NOT pure lock-acquisition time (matches the registration
-    /// help; reply-channel backpressure can inflate it, so do not read it as lock
-    /// contention). It observes on every drop: normal completion, interrupt
-    /// cancellation, AND a malformed SETLKW whose `parse_operator()` fails before
-    /// `set_lkw()` is ever called (near-zero sample — the reason the timer lives
-    /// here and not inside `set_lkw()`).
+    /// The SETLKW request timer (RAII): `Some` when enabled, `None` when disabled.
+    /// Created before the `select!` so its scope is the WHOLE interruptible request
+    /// (not pure lock-acquisition time — backpressure can inflate it). Observes on
+    /// every drop, including a malformed SETLKW that fails parse before `set_lkw()`
+    /// is called — the reason it lives here and not inside `set_lkw()`.
     pub(crate) fn setlkw_wait_timer(metrics_enabled: bool) -> Option<HistogramTimer> {
         if metrics_enabled {
             Some(HistogramTimer::new(
@@ -1189,22 +1143,14 @@ impl FuseMetrics {
 
     // --- emission helpers ---
 
-    /// Record one read/write backend IO in the reader/writer task body, feeding
-    /// the read/write `io_*` families plus the opcode-free `stage_duration_us`
-    /// (the same dual-emit shape as `record_operation`: `io_*` carries
-    /// `path_type` detail, the stage view stays opcode-free at bounded
-    /// cardinality). `io_type` is `IO_TYPE_READ`/`IO_TYPE_WRITE`; `path_type` is
-    /// the backend resolved at handle open.
-    ///
-    /// - `io_duration_us{io_type,path_type,status}` + `stage_duration_us{stage=
-    ///   stream_io,kind=stream,status}`: observed on success AND error.
-    /// - `io_requests_total{io_type,path_type,status}`: +1 every attempt, error
-    ///   included.
-    /// - `io_size_bytes{io_type,path_type}`: the *request* size (read=requested,
-    ///   write=input len), observed on success and error.
-    /// - `io_bytes_total{io_type,path_type,status=success}`: the *transferred*
-    ///   bytes, ONLY on success (an error creates no byte series — never
-    ///   `inc_by(0)`).
+    /// Record one read/write backend IO in the reader/writer task body, feeding the
+    /// `io_*` families plus the opcode-free `stage_duration_us` (dual-emit, like
+    /// `record_operation`). Emits:
+    /// - `io_duration_us` + `stage_duration_us{stage=stream_io}`: success AND error.
+    /// - `io_requests_total`: +1 every attempt, error included.
+    /// - `io_size_bytes`: the *request* size (read=requested, write=input len).
+    /// - `io_bytes_total{status=success}`: the *transferred* bytes, success ONLY
+    ///   (an error creates no byte series — never `inc_by(0)`).
     pub(crate) fn record_stream_io(
         &self,
         io_type: &'static str,
@@ -1291,19 +1237,13 @@ impl FuseMetrics {
     }
 
     /// Open a flush/fsync/release lifecycle scope at `send_stream`: count the
-    /// attempt now (`stream_lifecycle_requests_total{io_type,path_type=unknown}`,
-    /// before the backend runs so a pre-dispatch error still counts) and return a
-    /// `StreamLifecycleScope` holding the duration timer and the inflight guard.
-    /// Both release together at the end of the send_stream arm (the timer
-    /// observes, the guard decrements); the drop *order* between them carries no
-    /// observable semantics. `io_type` is `IO_TYPE_FLUSH`/`FSYNC`/`RELEASE`.
-    ///
-    /// All three sub-metrics use the fixed `path_type=unknown` (the send_stream
-    /// layer does not look up the handle). Attempt-count and timer/guard are wired
-    /// here together with no `.await`/early-return between them, so the family is
-    /// never half-balanced. Like the other guard helpers, this is only ever
-    /// reached on the metrics-enabled path (the caller maps it in behind an
-    /// `enabled` check), so `get()` (strict) is correct.
+    /// attempt now (before the backend runs, so a pre-dispatch error still counts)
+    /// and return a `StreamLifecycleScope` holding the duration timer + inflight
+    /// guard, which release together at the end of the arm. All three sub-metrics
+    /// use fixed `path_type=unknown` (this layer does not look up the handle).
+    /// Attempt-count and timer/guard are wired with no `.await`/early-return
+    /// between them, so the family is never half-balanced. Metrics-enabled path
+    /// only, so strict `get()` is correct.
     pub(crate) fn stream_lifecycle_scope(io_type: &'static str) -> StreamLifecycleScope {
         let m = Self::get();
         m.stream_lifecycle_requests_total
@@ -1673,17 +1613,10 @@ impl FuseRespMetrics {
 }
 
 /// RAII guard for an in-flight gauge: increments on construction, decrements
-/// exactly once on drop.
-///
-/// It is `Send` and movable (so it can travel into a spawned task or onto a
-/// reply task), and deliberately **not** `Copy` — a `Copy` guard could
-/// double-decrement. The guard holds an optional `Gauge` handle so a single
-/// type can back different scopes (`active_requests`, `stream_io_inflight`,
-/// `meta_task_inflight`) just by being constructed from different gauges.
-///
-/// The `None` (no-op) form exercises the full move-and-drop lifetime — proving
-/// single-take / single-drop ownership — while touching no real gauge;
-/// `new(active_requests_gauge)` uses the same plumbing to drive the real metric.
+/// exactly once on drop. `Send` and movable (travels into a spawned/reply task),
+/// deliberately NOT `Copy` (which could double-decrement). The optional `Gauge`
+/// lets one type back different scopes (`active_requests`, `stream_io_inflight`,
+/// …); the `None` form exercises the same move/drop lifetime with no real gauge.
 #[derive(Debug)]
 pub(crate) struct ActiveGuard {
     gauge: Option<Gauge>,
@@ -1711,18 +1644,12 @@ impl Drop for ActiveGuard {
     }
 }
 
-/// Zero-allocation RAII timer for a histogram.
+/// Zero-allocation RAII timer for a histogram (monotonic clock).
 ///
-/// Holds an already-resolved `Histogram` (e.g. obtained once via
-/// `HistogramVec::with_label_values(...)` and stored), so its `drop` is a single
-/// `observe()` with **no allocation and no per-call label-map probe**. This is
-/// the hot-path replacement for `orpc`'s `MetricTimerVec`, which re-allocates a
-/// `Vec<&str>` on every drop and must not be used per request.
-///
-/// Durations are measured with the monotonic clock (`Instant`).
-///
-/// Backs `setlkw_wait_timer`, `io_dispatch_timer`, and the
-/// `stream_lifecycle_scope` duration timer.
+/// Holds an already-resolved `Histogram`, so its `drop` is a single `observe()`
+/// with no allocation and no per-call label-map probe — the hot-path replacement
+/// for `orpc`'s `MetricTimerVec` (which re-allocates per drop). Backs
+/// `setlkw_wait_timer`, `io_dispatch_timer`, and `stream_lifecycle_scope`.
 #[derive(Debug)]
 pub(crate) struct HistogramTimer {
     start: Instant,

--- a/curvine-fuse/src/session/channel/fuse_receiver.rs
+++ b/curvine-fuse/src/session/channel/fuse_receiver.rs
@@ -295,29 +295,19 @@ impl<T: FileSystem> FuseReceiver<T> {
         // fresh context.
         let err_rep = rep.clone();
 
-        // IO attribution at the send_stream layer, created AFTER parse
-        // success and BEFORE the match, so they cover the match arm AND the
-        // `if res.is_err()` error reply enqueue below (a pre-dispatch error — e.g.
-        // a handle lookup failure — replies there, not inside `fs.<io>`). For a
-        // known stream opcode exactly one of these is `Some`:
-        //   - read/write  -> `io_dispatch_duration_us{io_type}` RAII timer (dispatch
-        //     latency: may include a read-after-write consistency flush/reopen for
-        //     read, or a zero-length no-op direct reply for write — NOT pure enqueue).
-        //   - flush/fsync/release -> a `StreamLifecycleScope` (attempt counted now,
-        //     duration timer + inflight guard held across the whole arm).
-        // The read/write backend `io_*` (duration/bytes/size/inflight) is recorded
-        // separately in the reader/writer task body; this layer does NOT
-        // re-record it. Gated on `metrics_enabled` (disabled => both None, no
-        // attempt counted, no clock read).
+        // IO attribution, created after parse success and before the match so it
+        // covers the match arm AND the `if res.is_err()` error-reply enqueue below
+        // (a pre-dispatch error replies there, not inside `fs.<io>`). Exactly one is
+        // `Some` per known stream opcode: read/write -> `io_dispatch_duration_us`
+        // RAII timer; flush/fsync/release -> a `StreamLifecycleScope`. The backend
+        // `io_*` is recorded in the reader/writer task body, not re-recorded here.
+        // Gated on `metrics_enabled`.
         //
-        // ⚠ INVARIANT (do not break): there must be NO `.await` and NO early
-        // return between `parse_operator()` succeeding above and the two scopes
-        // below. `stream_lifecycle_scope` counts the attempt and arms the
-        // duration timer + inflight guard as one atomic step; inserting a
-        // suspension/return in this window could count an attempt whose timer
-        // never observes (or vice versa), unbalancing the lifecycle family. The
-        // first awaits are the `fs.<io>(op, rep).await` calls inside the match,
-        // already covered by the scopes.
+        // ⚠ INVARIANT: NO `.await` and NO early return between `parse_operator()`
+        // above and the two scopes below — `stream_lifecycle_scope` counts the
+        // attempt and arms its timer + inflight guard as one atomic step, so a
+        // suspension here could unbalance the lifecycle family. The first awaits are
+        // the `fs.<io>(op, rep).await` calls inside the match, already covered.
         let _dispatch = if metrics_enabled {
             dispatch_io_type(req.opcode()).map(FuseMetrics::io_dispatch_timer)
         } else {
@@ -407,18 +397,12 @@ impl<T: FileSystem> FuseReceiver<T> {
     pub async fn start(mut self, mut shutdown_rx: watch::Receiver<bool>) -> FuseResult<()> {
         debug!("fuse receiver started");
         loop {
-            // Receiver loop wait covers idle wait for the next kernel request
-            // plus the splice and header parse below. Observed only on the
-            // `receive()` Ok path (splice errors are counted by
-            // receive_errors_total instead). framework health -> metrics_enabled:
-            // when disabled we don't even read the clock (matches meta_spawn's
-            // `Option<Instant>` and the kill-switch "no machinery" goal).
-            //
-            // The clock is read before the `select!`, so a wake from the
-            // shutdown branch (rather than `receive()`) reads an `Instant` that
-            // is never observed. Acceptable: shutdown is rare and the read is
-            // cheap; scoping the start to only the receive branch would tangle
-            // with the `&mut self` borrow inside `select!` for no real gain.
+            // Loop-wait timer: idle wait for the next request + splice + header
+            // parse, observed only on the `receive()` Ok path (splice errors go to
+            // receive_errors_total). Read before the `select!`, so a shutdown-branch
+            // wake reads an `Instant` that is never observed — acceptable (shutdown
+            // is rare; scoping it to the receive branch would tangle the `&mut self`
+            // borrow inside `select!`). Gated on `metrics_enabled`.
             let wait_start = if self.metrics_enabled {
                 Some(mono_now())
             } else {
@@ -450,14 +434,11 @@ impl<T: FileSystem> FuseReceiver<T> {
                             };
 
                             if self.debug {
-                                // Debug logging must NOT parse the operator here:
-                                // a parse failure would `?`-return out of the
-                                // receiver loop *before* the context is created,
-                                // both terminating the receiver and bypassing the
-                                // dispatch-path `finish_early` cleanup. The
-                                // dispatch path (`dispatch_meta` / `send_stream`)
-                                // is the single parse + cleanup site. Log only the
-                                // fields available without parsing the body.
+                                // Do NOT parse the operator here: a parse failure
+                                // would `?`-return out of the loop before the ctx
+                                // exists, bypassing the dispatch path's `finish_early`
+                                // cleanup (the single parse+cleanup site). Log only
+                                // the header fields.
                                 info!(
                                     "receive unique: {}, code: {:?}",
                                     req.unique(),
@@ -477,18 +458,12 @@ impl<T: FileSystem> FuseReceiver<T> {
                                 let reply = self.new_reply(req.unique(), labels);
                                 let fs = self.fs.clone();
                                 let pending_requests = self.pending_requests.clone();
-                                // meta_task_inflight guard + meta_spawn stage are
-                                // created BEFORE spawn so they cover the runtime
-                                // queue wait (submission -> first poll). Both gated
-                                // on metrics_enabled (None / no observe when off);
-                                // production disabled path must NOT use a noop guard.
-                                //
-                                // Boundary: `meta_spawn` measures tasks that reach
-                                // first poll. If the runtime drops/aborts a task
-                                // before its first poll (e.g. shutdown), the guard
-                                // still dec's meta_task_inflight on drop, but no
-                                // meta_spawn sample is recorded. Out of scope
-                                // (would need spawn-drop instrumentation).
+                                // meta_task_inflight guard + meta_spawn stage created
+                                // BEFORE spawn so they cover the runtime queue wait
+                                // (submission -> first poll). Gated on metrics_enabled
+                                // (None when off — not a noop guard). A task
+                                // dropped before its first poll still dec's the guard
+                                // but records no meta_spawn sample (out of scope).
                                 let meta_guard = FuseMetrics::meta_task_guard(self.metrics_enabled);
                                 let spawn_start =
                                     if self.metrics_enabled { Some(mono_now()) } else { None };
@@ -563,38 +538,16 @@ impl<T: FileSystem> FuseReceiver<T> {
         let mut pending_request =
             PendingRequestGuard::register(pending_requests.clone(), req.unique(), notify.clone());
 
-        // This branch is reached only for FUSE_SETLKW (`is_interrupt()` is true
-        // only there), so the SETLKW metrics live here, wrapping the whole
-        // interruptible-request scope (parse + dispatch_meta + lock polling +
-        // reply enqueue):
-        //
-        // - `setlkw_inflight`: SETLKW interruptible-request scopes in flight.
-        // - `setlkw_wait_duration_us`: the interruptible-request-duration timer.
-        //   It is created here, BEFORE the `select!`, NOT inside `set_lkw()` — so
-        //   an interrupt that wins the `select!` before `dispatch_meta`'s future
-        //   ever polls into `set_lkw()` (immediate / fast cancellation) still
-        //   records a sample on drop; placing it inside `set_lkw()` would miss
-        //   exactly that case.
-        //
-        // CONSEQUENCE: this is NOT pure lock-acquisition time —
-        // the scope spans parse, dispatch, AND the reply-channel enqueue, so
-        // reply-channel backpressure can inflate it. The metric is deliberately
-        // an "interruptible-request duration" wrapper, not a lock-contention gauge
-        // (see its help); dashboards must not read it as lock wait. Likewise a
-        // malformed SETLKW that fails `parse_operator()` produces a near-zero
-        // sample (timer exists before parse). This wrapper framing was the chosen
-        // trade-off over special-casing the SETLKW dispatch arm (which would touch
-        // the dispatch matrix the design avoids).
-        //
-        // Both are RAII: their Drop — not the `pending_requests.remove` — does the
-        // gauge dec / histogram observe, so every `select!` branch (and any future
-        // drop / cancellation) balances the gauge and records a sample exactly
-        // once. Gated by `reply.metrics.is_some()` (== metrics_enabled; the
-        // singleton is initialized whenever that holds), so disabled builds create
-        // neither.
-        //
-        // The pending-request map has its own RAII guard above. The two select
-        // branches remove eagerly, while the guard's Drop covers task abort/drop.
+        // FUSE_SETLKW only. The `setlkw_wait_duration_us` timer + `setlkw_inflight`
+        // gauge wrap the WHOLE interruptible-request scope (parse + dispatch + lock
+        // poll + reply enqueue), created BEFORE the `select!` so an interrupt that
+        // wins before `set_lkw()` is ever polled still records a sample on drop.
+        // Consequence: this is NOT lock-acquisition time (reply-channel backpressure
+        // can inflate it; a parse failure yields a near-zero sample) — it is an
+        // interruptible-request-duration wrapper, not a lock-contention gauge.
+        // Both are RAII (Drop does the observe/dec, so every branch balances exactly
+        // once) and gated by `reply.metrics.is_some()`. The pending-request map has
+        // its own RAII guard above.
         let _setlkw_inflight = FuseMetrics::setlkw_inflight_guard(reply.metrics.is_some());
         let _setlkw_wait = FuseMetrics::setlkw_wait_timer(reply.metrics.is_some());
 
@@ -724,25 +677,15 @@ impl<T: FileSystem> FuseReceiver<T> {
 
             FuseOperator::SetLkW(op) => reply.send_rep(fs.set_lkw(op).await).await,
 
-            // Exhaustive fallback — NOT a `_` wildcard, deliberately: listing the
-            // remaining variants makes the match exhaustive, so adding a new
-            // `FuseOperator` variant without a dispatch arm here (or in
-            // `send_stream_dispatch`) fails to compile. This is the compile-time
-            // guarantee `expected_dispatch` cannot give (it is `#[cfg(test)]` and
-            // opcode-level, not arm-level), and is what would have caught the
-            // RENAME2 half-wiring. The arms handled here:
-            //   - `Notimplemented`: parse mapped an unknown/unsupported opcode to
-            //     the catch-all variant.
-            //   - the five stream ops (Read/Write/Flush/Release/FSync): these are
-            //     dispatched by `send_stream_dispatch`, never through this
-            //     metadata path, so reaching them here is a routing bug — but they
-            //     must still be named to keep the match exhaustive.
-            // Source-tag as Unsupported (not a backend Error). Split the reason:
-            //   - opcode == NOT_SUPPORTED (num_enum default for a raw opcode this
-            //     build has no enum value for) -> `unknown_opcode`.
-            //   - a known but intentionally-unsupported opcode (BMAP/POLL/IOCTL/
-            //     LSEEK) -> `unimplemented_opcode`. The authoritative
-            //     intentional-vs-gap record is `FuseOpCode::expected_dispatch`.
+            // Exhaustive fallback, NOT a `_` wildcard: naming the remaining variants
+            // makes adding a new `FuseOperator` without a dispatch arm a compile
+            // error — the arm-level guarantee `expected_dispatch` can't give, which
+            // would have caught the RENAME2 half-wiring. The stream ops here are a
+            // routing bug (they go through `send_stream_dispatch`) but must be named
+            // for exhaustiveness. Tag Unsupported (not backend Error): NOT_SUPPORTED
+            // (unknown raw opcode) -> `unknown_opcode`; a known-but-unsupported op
+            // (BMAP/POLL/IOCTL/LSEEK) -> `unimplemented_opcode`. See
+            // `FuseOpCode::expected_dispatch` for the intentional-vs-gap record.
             FuseOperator::Notimplemented
             | FuseOperator::Read(_)
             | FuseOperator::Write(_)
@@ -760,29 +703,16 @@ impl<T: FileSystem> FuseReceiver<T> {
             }
         };
 
-        // operation_duration_us{opcode,kind=metadata,status}: observe once, after
-        // the whole match. `status` is the stashed `op_status` (the FS-operation
-        // result computed by `finish_status`), NOT the `IOResult` of `res` — a
-        // successful enqueue of an error frame returns `Ok(())`, so deriving status
-        // from `res` would mislabel almost everything `success`. The send helpers
-        // stash `op_status` synchronously before enqueuing, and each match arm
-        // awaits its send, so by here the slot's `op_status` is the FS result.
-        //
-        // `op_start` is `Some` iff metrics are enabled (it was built with
-        // `reply.metrics.is_some().then(mono_now)`), so a disabled request never
-        // read the clock and skips the observe here too. A missing `op_status`
-        // (e.g. a no-reply path that didn't stash, or a defensive gap) is treated
-        // as `Error` rather than silently dropped — the only realistic miss is a
-        // wiring bug, and `Error` is the safe non-success bucket.
+        // operation_duration_us{opcode,kind=metadata,status}: observe once after the
+        // match. `status` is the stashed `op_status` (the FS result), NOT `res` — a
+        // successful enqueue of an error frame returns `Ok(())`, so `res` would
+        // mislabel almost everything `success`. `op_start` is `Some` iff metrics are
+        // enabled, so disabled requests skip this.
         if let Some(start) = op_start {
-            // Every dispatched metadata op should have stashed `op_status` via a
-            // send helper / no-reply finish before the match returned. A `None`
-            // here means some arm bypassed that — a wiring bug. Surface it loudly
-            // in debug (debug_assert) AND leave a release-visible `warn!` so a
-            // production occurrence is diagnosable (it would otherwise only show as
-            // an unexplained `status=error` latency sample). Release still falls
-            // back to `Error` (the safe non-success bucket) rather than dropping
-            // the sample.
+            // A missing `op_status` means a dispatch arm bypassed the send/no-reply
+            // finish helpers — a wiring bug. Surface it (debug_assert + release
+            // warn!) and fall back to `Error` (the safe non-success bucket) rather
+            // than dropping the sample.
             let op_status = match reply.metrics_op_status() {
                 Some(s) => s,
                 None => {
@@ -1311,15 +1241,11 @@ mod tests {
                 .await
             });
 
-            // Wait until `set_lkw()` has ACTUALLY been polled (it sets `polled`
-            // then blocks forever), THEN fire the interrupt. Waiting on the
-            // `pending_requests` entry would be racy: the entry is inserted BEFORE
-            // the `select!`, so seeing it does NOT prove the dispatch branch (and
-            // thus `set_lkw()`) has been polled — under some schedules notify could
-            // win before `set_lkw()` is ever entered, breaking the `polled==true`
-            // assertion. Gating on `polled` makes this test deterministically cover
-            // "set_lkw entered, then interrupted". A timeout prevents a dead wait if
-            // that invariant ever regresses.
+            // Wait until `set_lkw()` has actually been polled (it sets `polled` then
+            // blocks forever) BEFORE firing the interrupt. Gating on the
+            // `pending_requests` entry would be racy — it is inserted before the
+            // `select!`, so notify could win before `set_lkw()` is entered, breaking
+            // the `polled==true` assertion. The timeout guards against a dead wait.
             tokio::time::timeout(std::time::Duration::from_secs(5), async {
                 loop {
                     if polled.load(Ordering::SeqCst) {
@@ -1649,27 +1575,17 @@ mod tests {
             )
         }
 
-        // Drive ONE stream op through the REAL `send_stream_dispatch` core to
-        // completion, returning the dispatch result.
+        // Drive ONE stream op through the real `send_stream_dispatch` to completion.
         //
-        // FD-FREE by construction: `send_stream_dispatch` takes only `&fs` + a
-        // pre-built `FuseResponse` (gate derived from `rep.metrics.is_some()`), so
-        // this helper needs just an in-memory reply channel and a single-thread
-        // runtime — NO fd, NO Pipe2, NO reactor. This matters: reaching the dispatch
-        // via a real `FuseReceiver` would drag in a `Pipe2` whose Drop deregisters
-        // from the tokio reactor AFTER closing its fds, aborting the process with an
-        // `IO Safety violation` under the parallel harness.
-        //
-        // The reply channel is drained by a spawned task so the error-reply enqueue
-        // inside the dispatch never blocks regardless of how many ops a body drives.
-        //
-        // Assertions use POSITIVE LOWER BOUNDS, not exact deltas: they feed the
-        // process-global registry under FIXED io_type labels shared by every
-        // send_stream test, so a concurrent test can also bump them. The
-        // deterministic negatives are covered by the structural unit tests in
-        // `fuse_metrics`. `with_metrics_ctx` decides whether the built `FuseResponse`
-        // carries a metrics ctx — which IS the metrics on/off switch for the dispatch
-        // (there is no separate flag).
+        // FD-FREE: `send_stream_dispatch` needs only `&fs` + a pre-built
+        // `FuseResponse`, so an in-memory channel + single-thread runtime suffice —
+        // NO fd/Pipe2/reactor. This matters: reaching dispatch via a real
+        // `FuseReceiver` drags in a `Pipe2` whose Drop deregisters from the reactor
+        // AFTER closing its fds, aborting with `IO Safety violation` under the
+        // parallel harness. Assertions use LOWER BOUNDS, not exact deltas: the
+        // process-global registry uses FIXED io_type labels a concurrent test can
+        // also bump (deterministic negatives live in `fuse_metrics` unit tests).
+        // `with_metrics_ctx` = the metrics on/off switch (gate is `rep.metrics.is_some()`).
         fn dispatch_one(with_metrics_ctx: bool, req: FuseRequest) {
             use crate::fuse_metrics::{FuseReqCtx, FuseReqKind, FuseReqLabels};
             FuseMetrics::ensure_init().unwrap();
@@ -1678,16 +1594,10 @@ mod tests {
                 let fs = Arc::new(TestFileSystem::new(
                     curvine_common::conf::FuseConf::default(),
                 ));
-                // Reply channel with a drainer so any enqueued error reply is consumed
-                // (never blocks), independent of how many ops the caller drives.
+                // Drainer so an enqueued error reply never blocks.
                 let (tx, mut rx) = AsyncChannel::new(64).split();
                 let drainer = tokio::spawn(async move { while rx.recv().await.is_some() {} });
 
-                // Build the reply handle exactly as `send_stream`'s caller would.
-                // with-ctx => an active guard backed by a throwaway gauge; without =>
-                // None (the legacy zero-cost path). The presence of the ctx IS the
-                // metrics gate — `send_stream_dispatch` derives it from
-                // `rep.metrics.is_some()`, so there is no separate flag to pass.
                 let opcode = req.opcode().as_str();
                 let ctx = if with_metrics_ctx {
                     let gauge = orpc::common::Metrics::new_gauge(
@@ -1812,26 +1722,14 @@ mod tests {
             );
         }
 
-        // A direct disabled-path integration test for `send_stream`. The
-        // send_stream gate (`self.metrics_enabled`) is a DIFFERENT source from the
-        // reader/writer task body's gate (`FuseConf.metrics_enabled`), so this
-        // guards the send_stream wiring specifically.
-        //
-        // This is a SMOKE test, not a no-emission proof.
-        // - It proves: one op of EACH stream family runs end-to-end through the real
-        //   disabled `send_stream` and completes (no panic, no hang). It is a guard
-        //   against the disabled send_stream path being wired so badly it cannot even
-        //   run all five families.
-        // - It does NOT prove "disabled emits nothing": the metrics singleton is
-        //   already initialized in the test binary, so a regression that wrongly built
-        //   the dispatch timer / lifecycle scope on the disabled path would NOT panic
-        //   here — it would just (wrongly) emit. The deterministic "disabled => guard
-        //   is None, emits nothing" guarantee is pinned by the isolated helper `*_gate`
-        //   unit tests instead. An `== before` count assertion is deliberately avoided:
-        //   the io_type labels are a fixed set shared with the enabled send_stream
-        //   tests, so it would be flaky under the default parallel harness. This split
-        //   — smoke for wiring here, isolated unit test for the no-emission guarantee —
-        //   is the same discipline the rest of this metrics work follows.
+        // A SMOKE test for the disabled `send_stream` wiring (its gate,
+        // `self.metrics_enabled`, is a different source from the task body's
+        // `FuseConf.metrics_enabled`): it proves one op of each stream family runs
+        // end-to-end with metrics off and completes. It does NOT prove "emits
+        // nothing" — the singleton is already initialized in the test binary, and an
+        // `== before` count would be flaky on the shared io_type labels; the
+        // deterministic no-emission guarantee is pinned by the isolated `*_gate`
+        // unit tests instead.
         #[test]
         fn disabled_send_stream_runs_clean_for_all_families() {
             // ENOSYS replies (TestFileSystem); the point is the metrics gate, not the
@@ -1846,13 +1744,10 @@ mod tests {
         }
 
         // A malformed stream request whose `parse_operator()` fails AFTER the ctx
-        // was built. This is the ctx-before-parse corner case the seam must
-        // preserve: the parse failure must finish the ctx early (drop the active
+        // was built: the parse failure must finish the ctx early (drop the active
         // guard, record the parse decode error) and must NOT enter the
-        // dispatch/lifecycle RAII scope (no io_dispatch / lifecycle sample).
-        // Pins the seam's most fragile behaviour — that nobody inserts an early
-        // return / await between ctx creation and the scope in a way that leaks the
-        // guard or emits a stray dispatch sample on the parse-failure path.
+        // dispatch/lifecycle RAII scope. Pins that nobody inserts an early
+        // return/await between ctx creation and the scope.
         #[test]
         fn malformed_stream_request_finishes_early_without_dispatch_or_lifecycle() {
             use crate::fuse_metrics::{FuseReqCtx, FuseReqKind, FuseReqLabels, DECODE_PHASE_PARSE};
@@ -1930,20 +1825,12 @@ mod tests {
 
     // --- Issue #1089: stream pre-dispatch error-reply coverage ---
     //
-    // These prove the property the issue asks for: when a stream op
-    // (read/write/flush/release/fsync) fails BEFORE it replies to the kernel (a
-    // "pre-dispatch error" — e.g. a handle-lookup miss), `send_stream_dispatch`
-    // enqueues EXACTLY ONE error reply, via the `if res.is_err() { err_rep.send_rep }`
-    // fallback (`fuse_receiver.rs` ~:317), and never double-replies.
-    //
-    // FD-FREE, same construction as `send_stream_integration::dispatch_one`: the
-    // dispatch core takes only `&fs` + a pre-built `FuseResponse` over an in-memory
-    // channel, so there is no `kernel_fd`/`Pipe2`/reactor and no fd lifecycle hazard.
-    //
-    // Unlike the sibling metrics tests (which share process-global label children and
-    // can only assert lower bounds), these assert an EXACT count of `== 1`: the reply
-    // channel is per-test (never shared), so counting its enqueued `FuseTask`s is
-    // deterministic and parallel-safe.
+    // Prove that when a stream op fails BEFORE replying (a "pre-dispatch error",
+    // e.g. a handle-lookup miss), `send_stream_dispatch` enqueues EXACTLY ONE error
+    // reply via its `if res.is_err() { err_rep.send_rep }` fallback and never
+    // double-replies. FD-free (same `dispatch_one` construction). These assert an
+    // EXACT `== 1` (not lower bounds): the reply channel is per-test, so counting
+    // its enqueued `FuseTask`s is deterministic.
     mod stream_error_coverage {
         use crate::err_fuse;
         use crate::fs::operator::{FSync, Flush, Read, Release, Write};
@@ -1974,13 +1861,9 @@ mod tests {
         // the handle-lookup path is EBADF, so we model that.
         const ERRNO: i32 = libc::EBADF;
 
-        // A FileSystem whose stream ops fail WITHOUT touching `_reply` — the exact
-        // shape of a pre-dispatch error (handle lookup fails, or backend returns Err
-        // before replying). Only these five are overridden; every other op keeps the
-        // trait default (see `BlockingSetlkwFs` for the same "override one, inherit
-        // the rest" pattern). This is deliberately more explicit than reusing
-        // `TestFileSystem` (whose defaults return ENOSYS): a dedicated mock lets the
-        // assertions pin the errno on the wire, and documents the EBADF nuance above.
+        // A FileSystem whose stream ops fail WITHOUT touching `_reply` — the shape of
+        // a pre-dispatch error. A dedicated mock (rather than `TestFileSystem`'s
+        // ENOSYS default) lets the assertions pin EBADF on the wire.
         struct PreDispatchErrFs;
         impl FileSystem for PreDispatchErrFs {
             async fn read(&self, _op: Read<'_>, _reply: FuseResponse) -> FuseResult<()> {
@@ -2001,17 +1884,11 @@ mod tests {
         }
 
         // A FileSystem whose `read` REPLIES via the passed-in `reply` and THEN returns
-        // `Err`. This is the "Verified nuance" from #1089: an op that already answered
-        // the kernel but still surfaces an error. It exercises the exact end-to-end path
-        // `send_stream_dispatch` guards — the reply is sent through the original `rep`,
-        // then `if res.is_err() { err_rep.send_rep(res) }` fires on the shared clone — so
-        // driving it through `dispatch_and_collect` proves the fallback CANNOT
-        // double-reply, not just that the slot guard works in isolation.
-        //
-        // `cfg(not(debug_assertions))`: its only user, `err_rep_fallback_after_a_reply_
-        // is_noop`, is release-only (a real double reply trips `commit_reply_task`'s
-        // `debug_assert!` in debug), so gating the mock the same way avoids a
-        // "never constructed" warning in debug builds.
+        // `Err` — the #1089 "Verified nuance". Driven through `dispatch_and_collect`,
+        // it proves the `if res.is_err() { err_rep.send_rep(res) }` fallback cannot
+        // double-reply end-to-end, not just that the slot guard works in isolation.
+        // `cfg(not(debug_assertions))` matches its only (release-only) user, so the
+        // mock is not "never constructed" in debug.
         #[cfg(not(debug_assertions))]
         struct ReplyThenErrFs;
         #[cfg(not(debug_assertions))]

--- a/curvine-fuse/src/session/channel/fuse_receiver.rs
+++ b/curvine-fuse/src/session/channel/fuse_receiver.rs
@@ -258,16 +258,16 @@ impl<T: FileSystem> FuseReceiver<T> {
         Self::send_stream_dispatch(&self.fs, req, rep).await
     }
 
-    /// The stream dispatch + Phase 2b IO attribution core, factored out of
-    /// `send_stream` so it can be driven in tests against a hand-built
-    /// `FuseResponse` without a real `FuseReceiver`/`kernel_fd`/`Pipe2`/reactor.
-    /// `rep` is the reply handle already built by the caller (`new_reply`).
+    /// The stream dispatch + IO attribution core, factored out of `send_stream`
+    /// so it can be driven in tests against a hand-built `FuseResponse` without a
+    /// real `FuseReceiver`/`kernel_fd`/`Pipe2`/reactor. `rep` is the reply handle
+    /// already built by the caller (`new_reply`).
     ///
     /// The metrics kill switch is derived from a SINGLE source of truth —
-    /// `rep.metrics.is_some()` — NOT a separate `metrics_enabled` flag (review
-    /// round-5 P2-1): when metrics are disabled, `new_reply` builds the legacy
-    /// ctx-less reply (`metrics == None`), and when enabled it builds the ctx-bearing
-    /// one. Deriving the gate from `rep` makes it impossible to wire a "record stream
+    /// `rep.metrics.is_some()` — NOT a separate `metrics_enabled` flag: when
+    /// metrics are disabled, `new_reply` builds the legacy ctx-less reply
+    /// (`metrics == None`), and when enabled it builds the ctx-bearing one.
+    /// Deriving the gate from `rep` makes it impossible to wire a "record stream
     /// metrics but no request ctx" (or the inverse) split-brain state. Kept private
     /// (the tests module is a child module and reaches it without `pub(crate)`).
     async fn send_stream_dispatch(
@@ -295,7 +295,7 @@ impl<T: FileSystem> FuseReceiver<T> {
         // fresh context.
         let err_rep = rep.clone();
 
-        // Phase 2b: IO attribution at the send_stream layer, created AFTER parse
+        // IO attribution at the send_stream layer, created AFTER parse
         // success and BEFORE the match, so they cover the match arm AND the
         // `if res.is_err()` error reply enqueue below (a pre-dispatch error — e.g.
         // a handle lookup failure — replies there, not inside `fs.<io>`). For a
@@ -306,7 +306,7 @@ impl<T: FileSystem> FuseReceiver<T> {
         //   - flush/fsync/release -> a `StreamLifecycleScope` (attempt counted now,
         //     duration timer + inflight guard held across the whole arm).
         // The read/write backend `io_*` (duration/bytes/size/inflight) is recorded
-        // separately in the reader/writer task body (C2); this layer does NOT
+        // separately in the reader/writer task body; this layer does NOT
         // re-record it. Gated on `metrics_enabled` (disabled => both None, no
         // attempt counted, no clock read).
         //
@@ -487,8 +487,8 @@ impl<T: FileSystem> FuseReceiver<T> {
                                 // first poll. If the runtime drops/aborts a task
                                 // before its first poll (e.g. shutdown), the guard
                                 // still dec's meta_task_inflight on drop, but no
-                                // meta_spawn sample is recorded. Out of scope for
-                                // 1b-1 (would need spawn-drop instrumentation).
+                                // meta_spawn sample is recorded. Out of scope
+                                // (would need spawn-drop instrumentation).
                                 let meta_guard = FuseMetrics::meta_task_guard(self.metrics_enabled);
                                 let spawn_start =
                                     if self.metrics_enabled { Some(mono_now()) } else { None };
@@ -576,7 +576,7 @@ impl<T: FileSystem> FuseReceiver<T> {
         //   records a sample on drop; placing it inside `set_lkw()` would miss
         //   exactly that case.
         //
-        // CONSEQUENCE (review R2 P1#1): this is NOT pure lock-acquisition time —
+        // CONSEQUENCE: this is NOT pure lock-acquisition time —
         // the scope spans parse, dispatch, AND the reply-channel enqueue, so
         // reply-channel backpressure can inflate it. The metric is deliberately
         // an "interruptible-request duration" wrapper, not a lock-contention gauge
@@ -634,7 +634,7 @@ impl<T: FileSystem> FuseReceiver<T> {
         };
 
         // operation_duration_us: a single timer around the whole match (NOT
-        // per-arm — the design's anti-goal is touching the ~30 dispatch arms).
+        // per-arm — deliberately avoids touching the ~30 dispatch arms).
         // Gated by `reply.metrics.is_some()` (the disabled-mode signal — this is
         // a free fn with no `metrics_enabled` field), so disabled mode does not
         // even read the clock. Started after parse success, so a parse failure
@@ -782,7 +782,7 @@ impl<T: FileSystem> FuseReceiver<T> {
             // production occurrence is diagnosable (it would otherwise only show as
             // an unexplained `status=error` latency sample). Release still falls
             // back to `Error` (the safe non-success bucket) rather than dropping
-            // the sample (review R1 P2#6 / R2 P2#8).
+            // the sample.
             let op_status = match reply.metrics_op_status() {
                 Some(s) => s,
                 None => {
@@ -882,7 +882,7 @@ mod tests {
         );
     }
 
-    // --- Phase 2a: dispatch_meta integration (operation_duration_us wiring) ---
+    // --- dispatch_meta integration (operation_duration_us wiring) ---
     //
     // These drive the real `dispatch_meta` link — parse_operator -> match arm ->
     // send helper stashes op_status -> post-match `record_operation` reads it back
@@ -1227,7 +1227,7 @@ mod tests {
             assert_eq!(op_dur_count("Access", "error"), e_before);
         }
 
-        // --- R2 P1#5: immediate-interrupt SETLKW records a wait sample ---
+        // --- immediate-interrupt SETLKW records a wait sample ---
 
         const OP_SETLKW: u32 = 33;
 
@@ -1281,7 +1281,7 @@ mod tests {
         // pending_requests Notify, so the notify branch wins and the dispatch
         // (set_lkw) branch is cancelled.
         //
-        // SCOPE (review R3 P1#1): this covers "set_lkw entered, then interrupted",
+        // SCOPE: this covers "set_lkw entered, then interrupted",
         // NOT "interrupt wins before set_lkw is ever polled" — the assertion
         // `polled == true` makes that explicit. The complementary case where the
         // timer's outer placement matters even though `set_lkw()` is NEVER reached
@@ -1363,7 +1363,7 @@ mod tests {
                 polled.load(Ordering::SeqCst),
                 "set_lkw was polled (the dispatch branch started)"
             );
-            // The core P1#1 invariant: a wait sample is recorded even though the
+            // The core invariant: a wait sample is recorded even though the
             // lock poll loop never completed.
             assert!(
                 setlkw_wait_count() > wait_before,
@@ -1425,7 +1425,7 @@ mod tests {
             );
         }
 
-        // R3 P1#1: the case that actually justifies hoisting the timer OUT of
+        // The case that actually justifies hoisting the timer OUT of
         // `set_lkw()`. A malformed SETLKW (empty payload) fails `parse_operator()`
         // inside `dispatch_meta`, so `set_lkw()` is NEVER called — yet because the
         // timer is created in `dispatch_meta_interrupt` BEFORE the `select!`, a
@@ -1560,7 +1560,7 @@ mod tests {
         }
     }
 
-    // --- Phase 2b: send_stream IO attribution integration ---
+    // --- send_stream IO attribution integration ---
     //
     // These drive the real stream dispatch core `FuseReceiver::send_stream_dispatch`
     // (extracted from `send_stream` so it needs only `&fs`, a `FuseRequest`, and a
@@ -1649,38 +1649,27 @@ mod tests {
             )
         }
 
-        // Drive ONE stream op through the REAL `send_stream_dispatch` core and run it
-        // to completion. `op` is the FUSE opcode; `unique`/`payload` build the
-        // request. Returns the dispatch result.
+        // Drive ONE stream op through the REAL `send_stream_dispatch` core to
+        // completion, returning the dispatch result.
         //
-        // FD-FREE by construction (review round-2/3/4 P1): earlier rounds built a
-        // real `FuseReceiver` here just to reach `send_stream`, which dragged in a
-        // `kernel_fd` `AsyncFd` + an internal `Pipe2` whose Drop deregisters from the
-        // tokio reactor AFTER closing its fds — aborting the process with `IO Safety
-        // violation` under the default parallel harness, and which leak workarounds
-        // failed to tame across two rounds. The real fix (codex's repeated
-        // recommendation): `send_stream`'s metrics/dispatch logic was extracted into
-        // `FuseReceiver::send_stream_dispatch`, which takes a pre-built `FuseResponse`
-        // (the metrics gate is derived from `rep.metrics.is_some()`) and only needs
-        // `&fs` — NO fd, NO Pipe2, NO reactor. So this helper builds just a
-        // `FuseResponse` over an in-memory reply channel
-        // and a single-thread runtime to `block_on` the async fn (which spawns
-        // nothing and touches no fd). Nothing here registers with a reactor, so there
-        // is no fd/runtime lifecycle hazard at all.
+        // FD-FREE by construction: `send_stream_dispatch` takes only `&fs` + a
+        // pre-built `FuseResponse` (gate derived from `rep.metrics.is_some()`), so
+        // this helper needs just an in-memory reply channel and a single-thread
+        // runtime — NO fd, NO Pipe2, NO reactor. This matters: reaching the dispatch
+        // via a real `FuseReceiver` would drag in a `Pipe2` whose Drop deregisters
+        // from the tokio reactor AFTER closing its fds, aborting the process with an
+        // `IO Safety violation` under the parallel harness.
         //
         // The reply channel is drained by a spawned task so the error-reply enqueue
-        // inside the dispatch (the path the lifecycle/dispatch RAII scope covers)
-        // never blocks regardless of how many ops a body drives (review round-4 P2-1).
+        // inside the dispatch never blocks regardless of how many ops a body drives.
         //
-        // Parallel-safety of the ASSERTIONS: these feed the process-global registry
-        // under FIXED io_type labels shared by every send_stream test, so the tests
-        // assert only POSITIVE LOWER BOUNDS on each op's own label ("incremented by
-        // at least 1"), never exact deltas. The deterministic negatives are covered
-        // by the structural unit tests in `fuse_metrics`.
-        // `with_metrics_ctx` decides whether the built `FuseResponse` carries a metrics
-        // ctx — which, since `send_stream_dispatch` derives its gate from
-        // `rep.metrics.is_some()`, IS the metrics on/off switch for the dispatch. It is
-        // NOT a separate flag passed to the dispatch (there is none).
+        // Assertions use POSITIVE LOWER BOUNDS, not exact deltas: they feed the
+        // process-global registry under FIXED io_type labels shared by every
+        // send_stream test, so a concurrent test can also bump them. The
+        // deterministic negatives are covered by the structural unit tests in
+        // `fuse_metrics`. `with_metrics_ctx` decides whether the built `FuseResponse`
+        // carries a metrics ctx — which IS the metrics on/off switch for the dispatch
+        // (there is no separate flag).
         fn dispatch_one(with_metrics_ctx: bool, req: FuseRequest) {
             use crate::fuse_metrics::{FuseReqCtx, FuseReqKind, FuseReqLabels};
             FuseMetrics::ensure_init().unwrap();
@@ -1745,7 +1734,7 @@ mod tests {
                 .get_sample_count()
         }
 
-        // E21/E26: a flush whose backend errors (pre-dispatch ENOSYS) STILL records a
+        // a flush whose backend errors (pre-dispatch ENOSYS) STILL records a
         // lifecycle attempt (counted before the match) AND a duration sample (the RAII
         // timer observes on drop, covering the error reply enqueue that happens inside
         // the scope), under {io_type=flush,path_type=unknown}. Lower-bound asserts.
@@ -1783,7 +1772,7 @@ mod tests {
             );
         }
 
-        // E15 (release attributed at send_stream): one FUSE Release opcode increments
+        // release attributed at send_stream: one FUSE Release opcode increments
         // stream_lifecycle_requests_total{release}. Doing it here (one operator arm =
         // one increment) is what avoids the reader+writer double-count the task-body
         // approach would have. Lower-bound assert (parallel-safe).
@@ -1800,7 +1789,7 @@ mod tests {
             );
         }
 
-        // E20/E25: read/write at send_stream record io_dispatch_duration_us{io_type}.
+        // read/write at send_stream record io_dispatch_duration_us{io_type}.
         // The backend io_* (duration/bytes/size) is recorded in the task body, not
         // here, so a pre-dispatch ENOSYS read/write records dispatch only — which is
         // exactly what this asserts (the dispatch timer fired). Lower-bound asserts.
@@ -1823,12 +1812,12 @@ mod tests {
             );
         }
 
-        // P2-2 (review round-2): a direct disabled-path integration test for
-        // `send_stream`. The send_stream gate (`self.metrics_enabled`) is a DIFFERENT
-        // source from the reader/writer task body's gate (`FuseConf.metrics_enabled`),
-        // so this guards the send_stream wiring specifically.
+        // A direct disabled-path integration test for `send_stream`. The
+        // send_stream gate (`self.metrics_enabled`) is a DIFFERENT source from the
+        // reader/writer task body's gate (`FuseConf.metrics_enabled`), so this
+        // guards the send_stream wiring specifically.
         //
-        // What this is (review round-3 P2-2): a SMOKE test, not a no-emission proof.
+        // This is a SMOKE test, not a no-emission proof.
         // - It proves: one op of EACH stream family runs end-to-end through the real
         //   disabled `send_stream` and completes (no panic, no hang). It is a guard
         //   against the disabled send_stream path being wired so badly it cannot even
@@ -1846,7 +1835,7 @@ mod tests {
         #[test]
         fn disabled_send_stream_runs_clean_for_all_families() {
             // ENOSYS replies (TestFileSystem); the point is the metrics gate, not the
-            // op result. None of these may touch the Phase 2b stream metrics.
+            // op result. None of these may touch the stream metrics.
             dispatch_one(false, flush_request(7101));
             dispatch_one(false, fsync_request(7102));
             dispatch_one(false, release_request(7103));
@@ -1856,11 +1845,11 @@ mod tests {
             // five op families to completion with `metrics_enabled=false`.
         }
 
-        // P2-2 (review round-5): a malformed stream request whose `parse_operator()`
-        // fails AFTER the ctx was built. This is the ctx-before-parse corner case the
-        // round-4 seam refactor must preserve: the parse failure must finish the ctx
-        // early (drop the active guard, record the parse decode error) and must NOT
-        // enter the dispatch/lifecycle RAII scope (no io_dispatch / lifecycle sample).
+        // A malformed stream request whose `parse_operator()` fails AFTER the ctx
+        // was built. This is the ctx-before-parse corner case the seam must
+        // preserve: the parse failure must finish the ctx early (drop the active
+        // guard, record the parse decode error) and must NOT enter the
+        // dispatch/lifecycle RAII scope (no io_dispatch / lifecycle sample).
         // Pins the seam's most fragile behaviour — that nobody inserts an early
         // return / await between ctx creation and the scope in a way that leaks the
         // guard or emits a stray dispatch sample on the parse-failure path.

--- a/curvine-fuse/src/session/fuse_notify_code.rs
+++ b/curvine-fuse/src/session/fuse_notify_code.rs
@@ -41,7 +41,7 @@ impl FuseNotifyCode {
     /// `code_max`) collapse to `other` so the `notify_total{code}` series stays
     /// bounded to exactly the documented values. If a new code needs its own
     /// label, add it here and to the design doc's Label rules together.
-    // Phase 0 enabling primitive: defined here, wired to call sites in Phase 1.
+    // Enabling primitive: defined here, wired to call sites separately.
     #[allow(dead_code)]
     pub(crate) fn as_str(&self) -> &'static str {
         match self {

--- a/curvine-fuse/src/session/fuse_op_code.rs
+++ b/curvine-fuse/src/session/fuse_op_code.rs
@@ -76,7 +76,7 @@ impl FuseOpCode {
     ///
     /// Names are short CamelCase (e.g. `Lookup`, `GetAttr`, `Read`) matching
     /// the `opcode` label convention in the FUSE metrics design.
-    // Phase 0 enabling primitive: defined here, wired to call sites in Phase 1.
+    // Enabling primitive: defined here, wired to call sites separately.
     #[allow(dead_code)]
     pub(crate) fn as_str(&self) -> &'static str {
         match self {

--- a/curvine-fuse/src/session/fuse_response.rs
+++ b/curvine-fuse/src/session/fuse_response.rs
@@ -91,7 +91,7 @@ impl ResponseData {
 
 // Send fuse response to the mount point.
 //
-// `metrics` is the per-request metrics slot (Phase 1a): `Some` when metrics are
+// `metrics` is the per-request metrics slot: `Some` when metrics are
 // enabled, `None` for the disabled fast path. It is `Arc<Mutex<…>>` so that
 // cloning a `FuseResponse` (used by `dispatch_meta`, which borrows `&self`)
 // shares the *same* slot — the active guard is taken exactly once regardless of
@@ -129,7 +129,7 @@ impl FuseResponse {
     }
 
     /// The stashed FS-operation status, read back after the reply path has run
-    /// (Phase 2a `operation_duration_us`). `None` when metrics are disabled (no
+    /// (for `operation_duration_us`). `None` when metrics are disabled (no
     /// slot) or when nothing finished the request yet. The send helpers stash
     /// `op_status` synchronously before enqueueing, so by the time `dispatch_meta`
     /// finishes its match this reflects the FS result, not the enqueue outcome.
@@ -152,8 +152,8 @@ impl FuseResponse {
     /// source tag — **never from errno alone** (a backend `ENOSYS`/`EINTR` with
     /// no tag stays `Error`). `Unsupported`/`Interrupted` are reached only when
     /// the caller passes the matching tag (set at the wildcard / `Notimplemented`
-    /// / SETLKW-interrupt sites). Phase 1a-1 wires this as control flow; the
-    /// status-labelled metrics read the stashed value in Phase 1a-2.
+    /// / SETLKW-interrupt sites). This is control flow; the status-labelled
+    /// metrics read the stashed value.
     fn err_status(unsupported_reason: Option<&'static str>, interrupted: bool) -> FuseReqStatus {
         // The two source tags are mutually exclusive — no current call site
         // passes both, and the classification below would silently drop the
@@ -430,7 +430,7 @@ impl FuseResponse {
     ///
     /// `reason` is the `&'static str` parse-failure reason
     /// (`short_read`/`invalid_header`/`length_mismatch`/`other`) — stashed now,
-    /// read by `decode_errors_total{phase="parse",reason}` in Phase 1a-2. A
+    /// read by `decode_errors_total{phase="parse",reason}`. A
     /// reason rather than an errno is carried because structural parse failures
     /// have no stable OS errno; `errno` is kept too for diagnostics.
     pub(crate) fn finish_early(&self, errno: i32, reason: &'static str) {
@@ -450,8 +450,8 @@ impl FuseResponse {
 
             // A structural parse failure after the ctx existed: record the
             // decode error, but NOT `requests_total` (the request never
-            // dispatched). Phase 1a-2 only ever passes reason="other" (the
-            // `finish_early` call sites); finer reasons need decoder changes.
+            // dispatched). The `finish_early` call sites only ever pass
+            // reason="other"; finer reasons need decoder changes.
             FuseMetrics::get().record_parse_error(reason);
         }
     }
@@ -954,7 +954,7 @@ mod tests {
             assert_eq!(
                 slot.parse_reason,
                 Some("other"),
-                "parse reason stashed for 1a-2"
+                "parse reason stashed for decode_errors"
             );
             assert_eq!(slot.op_status, Some(FuseReqStatus::Error));
         }
@@ -1181,7 +1181,7 @@ mod tests {
         assert_eq!(g.get(), 0, "guard dropped once with the consumed task");
     }
 
-    // P1#1: enqueue failure layered on a FAILED op must still record the
+    // enqueue failure layered on a FAILED op must still record the
     // op-level terminal counter with the real FS errno — the channel error must
     // not swallow the operation failure (symmetric with the sender write-failure
     // path's op/request status split).
@@ -1217,7 +1217,7 @@ mod tests {
         assert_eq!(g.get(), 0);
     }
 
-    // P1#1: enqueue failure layered on a tagged-unsupported op still records
+    // enqueue failure layered on a tagged-unsupported op still records
     // unsupported_total{reason}.
     #[tokio::test]
     async fn enqueue_failure_on_unsupported_op_still_records_unsupported_total() {
@@ -1242,7 +1242,7 @@ mod tests {
         assert_eq!(g.get(), 0);
     }
 
-    // P1#1: enqueue failure layered on an interrupted op still records
+    // enqueue failure layered on an interrupted op still records
     // interrupted_total.
     #[tokio::test]
     async fn enqueue_failure_on_interrupted_op_still_records_interrupted_total() {
@@ -1264,7 +1264,7 @@ mod tests {
         assert_eq!(g.get(), 0);
     }
 
-    // P1#2 (round-2): a stream worker (FuseReader::read_future /
+    // a stream worker (FuseReader::read_future /
     // FuseWriter::writer_future) holds the `FuseResponse` and replies via
     // `send_data`/`send_rep` from *inside* the task. If the reply channel is
     // closed by then (sender shutdown), the worker's `send_*().await` returns Err
@@ -1308,7 +1308,7 @@ mod tests {
         assert_eq!(errors_total(OP, "metadata", "OTHER"), 0);
     }
 
-    // P1#2 companion: the writer worker's `send_rep` path on a closed channel.
+    // companion: the writer worker's `send_rep` path on a closed channel.
     #[tokio::test]
     async fn stream_worker_send_rep_enqueue_failure_finishes_without_leak() {
         init_metrics();
@@ -1329,7 +1329,7 @@ mod tests {
         );
     }
 
-    // P2#2 (round-3): the worker enqueue-failure finish records under the real
+    // the worker enqueue-failure finish records under the real
     // stream kind label — verifies `request_duration_us{kind="stream",error}`.
     #[tokio::test]
     async fn stream_worker_enqueue_failure_records_stream_kind_duration() {
@@ -1393,7 +1393,7 @@ mod tests {
         (FuseResponse::new_reply(unique, tx, false, Some(ctx)), rx)
     }
 
-    // P1 (round-3): on a bounded channel, if the task is cancelled while the
+    // on a bounded channel, if the task is cancelled while the
     // reply is suspended on `reserve().await` (channel full), the request must
     // NOT enter a "silent finished" state — the slot stays `finished=false` and
     // the guard is released by passive Drop, so a retry/cleanup is still possible
@@ -1447,7 +1447,7 @@ mod tests {
         );
     }
 
-    // P1 (round-3): bounded channel, reserve succeeds (slot free) -> the reply
+    // bounded channel, reserve succeeds (slot free) -> the reply
     // finishes normally (RequestReply enqueued, slot finished, guard rides task).
     #[tokio::test]
     async fn bounded_reserve_success_finishes_normally() {
@@ -1537,7 +1537,7 @@ mod tests {
         assert_eq!(g.get(), 0, "guard dropped on early finish");
     }
 
-    // --- Phase 2a: reply_queue_depth task-embedded guard ---
+    // --- reply_queue_depth task-embedded guard ---
     //
     // The production `reply_queue_guard()` increments the *process-global*
     // `reply_queue_depth` gauge, which every parallel test in this binary shares.
@@ -1690,7 +1690,7 @@ mod tests {
         }
     }
 
-    // --- Phase 2a: reply_queue_depth REAL queue lifecycle (review P1#4) ---
+    // --- reply_queue_depth REAL queue lifecycle ---
     //
     // These drive an actual channel with locally-gauged guards (NOT the global
     // `reply_queue_depth`, which parallel tests share and would make absolute/delta
@@ -1715,7 +1715,7 @@ mod tests {
         }
     }
 
-    // P1#4 (a): recv dequeues -> the queue guard drops at the dequeue point, so
+    // recv dequeues -> the queue guard drops at the dequeue point, so
     // queue depth returns to baseline BEFORE any splice; the active guard is a
     // SEPARATE scope and is still held (active stays 1 while queue is back to 0).
     #[tokio::test]
@@ -1754,7 +1754,7 @@ mod tests {
         }
     }
 
-    // P1#4 (b): a task enqueued but NEVER received (sender/channel dropped) still
+    // a task enqueued but NEVER received (sender/channel dropped) still
     // balances — the queue guard rides the task and drops with it, no leak.
     #[tokio::test]
     async fn reply_queue_depth_unreceived_task_drop_balances() {
@@ -1779,12 +1779,12 @@ mod tests {
         assert_eq!(active_g.get(), 0, "and the active guard too");
     }
 
-    // P1#4 (c): bounded-full reserve-first does NOT inflate queue depth. The real
+    // bounded-full reserve-first does NOT inflate queue depth. The real
     // `commit_reply_task` creates the queue guard only AFTER a permit is acquired
     // (see `finish_request`), so a producer parked in `reserve().await` on a full
     // channel holds no guard.
     //
-    // SCOPE (review R2 P2#6): this is a PROTOCOL-LEVEL STAND-IN, not a real
+    // SCOPE: this is a PROTOCOL-LEVEL STAND-IN, not a real
     // blocked-producer test. It asserts the reserve-first invariant directly
     // against a full bounded channel (`try_reserve()` yields no permit -> no guard
     // built -> local gauge stays 0); it does NOT drive `FuseResponse::finish_request`

--- a/curvine-fuse/src/session/fuse_response.rs
+++ b/curvine-fuse/src/session/fuse_response.rs
@@ -171,21 +171,14 @@ impl FuseResponse {
         }
     }
 
-    /// Build the reply task and enqueue it. The single finish entry point for a
-    /// replied request:
-    ///
-    /// - metrics enabled: stash status/errno, `take()` the active guard out of
-    ///   the shared slot (move-only, exactly once), mark `finished`, then send a
-    ///   `RequestReply`. All slot access is scoped *before* the `.await` so the
-    ///   `parking_lot` guard is never held across the await. **If the enqueue
-    ///   fails**, the request never reaches the sender, so we re-lock and correct
-    ///   `request_status` to `Error` (the `Pending → FinishedEarly(enqueue err)`
-    ///   transition) while leaving `op_status` as the FS-operation result.
-    /// - metrics disabled: send the legacy `Reply`.
-    ///
-    /// `status`/`errno` are computed by the caller (which still holds the typed
-    /// result); they cannot be derived from the enqueue outcome because a
-    /// successful enqueue of an error frame returns `Ok(())`.
+    /// Build the reply task and enqueue it — the single finish entry point for a
+    /// replied request. Metrics enabled: stash status/errno, `take()` the active
+    /// guard from the shared slot (all slot access scoped before the `.await`, so
+    /// the `parking_lot` guard never crosses it), mark `finished`, send a
+    /// `RequestReply`; on enqueue failure, re-lock and correct `request_status` to
+    /// `Error` (leaving `op_status` as the FS result). Metrics disabled: legacy
+    /// `Reply`. `status`/`errno` come from the caller — a successful enqueue of an
+    /// error frame returns `Ok(())`, so they can't be derived from the outcome.
     async fn finish_request(
         &self,
         data: ResponseData,
@@ -198,18 +191,13 @@ impl FuseResponse {
             Some(slot) => slot,
         };
 
-        // **Cancellation safety on bounded channels.** A bounded `send().await`
-        // can suspend (channel full); if the holding task is cancelled mid-await,
-        // the task — and the `ActiveGuard` moved into it — is dropped, decrementing
-        // `active_requests` but emitting NO terminal metric. To avoid that
-        // "silent finish", on bounded channels we first `reserve()` a permit
-        // WITHOUT touching the slot. The only suspendable point is the reserve;
-        // if cancelled there, the slot is still `finished=false` and the guard is
-        // still in the slot, so the request is simply dropped (guard decremented
-        // by its own Drop) with no half-finished state. Once the permit is in
-        // hand, we commit the slot and `permit.send(...)` synchronously (no await,
-        // cannot be cancelled). Unbounded `send` is already synchronous, so it
-        // keeps the simple commit-then-send fast path.
+        // Cancellation safety on bounded channels: a bounded `send().await` can
+        // suspend when full, and cancellation there would drop the guard (dec'ing
+        // `active_requests`) while emitting NO terminal metric. So on bounded
+        // channels we `reserve()` a permit FIRST without touching the slot (the only
+        // suspendable point); if cancelled there the slot is untouched and the
+        // request is cleanly dropped. Once the permit is in hand we commit the slot
+        // and `permit.send(...)` synchronously. Unbounded `send` is already sync.
         if self.sender.is_bounded() {
             let permit = match self.sender.reserve().await {
                 Ok(p) => p,
@@ -422,17 +410,12 @@ impl FuseResponse {
         }
     }
 
-    /// Finish a request that errored **before** any reply could be produced —
-    /// e.g. a structural `parse_operator()` failure after the context was
-    /// created. Drops the active guard and marks the slot `finished` so the
-    /// `active_requests` count cannot leak, but enqueues **no** task and emits
-    /// no `requests_total` (the request never dispatched).
-    ///
-    /// `reason` is the `&'static str` parse-failure reason
-    /// (`short_read`/`invalid_header`/`length_mismatch`/`other`) — stashed now,
-    /// read by `decode_errors_total{phase="parse",reason}`. A
-    /// reason rather than an errno is carried because structural parse failures
-    /// have no stable OS errno; `errno` is kept too for diagnostics.
+    /// Finish a request that errored BEFORE any reply (e.g. a `parse_operator()`
+    /// failure after the ctx was created): drop the active guard and mark the slot
+    /// `finished` so `active_requests` can't leak, but enqueue NO task and emit no
+    /// `requests_total` (never dispatched). `reason` (stashed for
+    /// `decode_errors_total{phase=parse}`) is carried instead of an errno because
+    /// structural parse failures have no stable OS errno.
     pub(crate) fn finish_early(&self, errno: i32, reason: &'static str) {
         if let Some(slot) = &self.metrics {
             {
@@ -528,16 +511,11 @@ impl FuseResponse {
 
     /// Metrics-enabled `send_notify`: enqueue a `NotifyReply` carrying a
     /// `reply_queue_depth` guard, using the same reserve-first discipline as the
-    /// request reply path so a producer blocked on a full bounded channel is not
-    /// counted as backlog. The guard is created only *after* the enqueue boundary
-    /// is committed (bounded: permit acquired; unbounded: just before the
-    /// synchronous send), and rides on the task to the sender's dequeue point.
-    ///
-    /// `enqueue_failed` is recorded at every point the notify fails to enter the
-    /// channel — the bounded `reserve()` error path (NEW: previously only the
-    /// `send()` error was counted) and the unbounded `send()` error path. A
-    /// *cancelled* bounded `reserve().await` is not a failure: no guard was
-    /// created and nothing is recorded.
+    /// reply path (guard created only after the enqueue boundary is committed, so a
+    /// producer blocked on a full channel isn't counted as backlog). `enqueue_failed`
+    /// is recorded on both the bounded `reserve()` and unbounded `send()` error
+    /// paths; a cancelled `reserve().await` is not a failure (no guard, nothing
+    /// recorded).
     async fn send_notify_metrics(&self, code: FuseNotifyCode, data: ResponseData) -> IOResult<()> {
         let code_str = code.as_str();
 
@@ -1779,21 +1757,13 @@ mod tests {
         assert_eq!(active_g.get(), 0, "and the active guard too");
     }
 
-    // bounded-full reserve-first does NOT inflate queue depth. The real
-    // `commit_reply_task` creates the queue guard only AFTER a permit is acquired
-    // (see `finish_request`), so a producer parked in `reserve().await` on a full
-    // channel holds no guard.
-    //
-    // SCOPE: this is a PROTOCOL-LEVEL STAND-IN, not a real
-    // blocked-producer test. It asserts the reserve-first invariant directly
-    // against a full bounded channel (`try_reserve()` yields no permit -> no guard
-    // built -> local gauge stays 0); it does NOT drive `FuseResponse::finish_request`
-    // through a pending `reserve().await` and observe the guard's absence while the
-    // send future is parked. The cancellation half of that production path —
-    // `reserve()` cancelled mid-await leaves the slot unfinished — IS covered by
-    // `bounded_reserve_cancellation_leaves_slot_unfinished`. Driving a genuinely
-    // parked producer + observing queue depth would need the shared global gauge
-    // (parallel-unsafe) or a custom waker harness; deferred as not worth the flake.
+    // bounded-full reserve-first does NOT inflate queue depth: the queue guard is
+    // created only AFTER a permit is acquired, so a producer parked in
+    // `reserve().await` holds none. A PROTOCOL-LEVEL STAND-IN — it asserts the
+    // invariant against a full channel (`try_reserve()` -> no permit -> gauge 0),
+    // not a genuinely parked producer (which would need the shared global gauge or
+    // a waker harness). The cancellation half is covered by
+    // `bounded_reserve_cancellation_leaves_slot_unfinished`.
     #[tokio::test]
     async fn reply_queue_depth_bounded_full_does_not_inflate() {
         let queue_g = m::new_gauge("qd_bounded_full_queue", "test").unwrap();

--- a/curvine-fuse/src/session/fuse_session.rs
+++ b/curvine-fuse/src/session/fuse_session.rs
@@ -54,7 +54,7 @@ pub struct FuseSession<T> {
     conf: FuseConf,
 }
 
-/// Phase 3b (P2-1/P2-2/P3-1): closes out a `run()` invocation on EVERY exit path
+/// closes out a `run()` invocation on EVERY exit path
 /// — normal completion, signal arms, and the SIGUSR1 run-all/persist error returns.
 /// Its `Drop` is deliberately lightweight, synchronous, infallible, non-blocking:
 /// it only `abort()`s the fd-watcher task (so a stale watcher can't cross-session
@@ -82,7 +82,7 @@ impl Drop for RunCleanupGuard {
 /// The health close-out decision used by `RunCleanupGuard::drop`: when metrics
 /// are enabled, set the kernel-fd-health gauge to 0 (session no longer serving).
 /// Extracted as a `set_health` taker so the enabled-gate close-out is unit-testable
-/// against an injected isolated gauge (R2 P3#3) without touching the process-global
+/// against an injected isolated gauge without touching the process-global
 /// gauge or constructing a real `FuseSession`.
 fn close_out_health<F: FnOnce(bool)>(enabled: bool, set_health: F) {
     if enabled {
@@ -147,7 +147,7 @@ impl<T: FileSystem> FuseSession<T> {
     pub const STATE_PATH: &'static str = "CURVINE_FUSE_STATE_PATH";
 
     pub async fn new(rt: Arc<Runtime>, fs: T, conf: FuseConf) -> FuseResult<Self> {
-        // Phase 3b (D11/P2-5): record session_init_total once. Capture
+        // record session_init_total once. Capture
         // `metrics_enabled` BEFORE `conf` is moved into the session. The whole
         // body runs in an inner async so every early `?` is counted as `error`.
         let enabled = conf.metrics_enabled;
@@ -161,7 +161,7 @@ impl<T: FileSystem> FuseSession<T> {
             FuseMetrics::with(|m| m.record_session_init(res));
             if result.is_ok() {
                 // Health is set to 1 only once the whole session is built and
-                // about to be returned Ok — not at function entry (P2-4), so a
+                // about to be returned Ok — not at function entry, so a
                 // channel-build failure never briefly shows health=1.
                 FuseMetrics::with(|m| m.set_kernel_fd_health(true));
             }
@@ -220,11 +220,11 @@ impl<T: FileSystem> FuseSession<T> {
         let mnts = std::mem::take(&mut self.mnts);
         let enabled = self.conf.metrics_enabled;
 
-        // Phase 3b (D4): one ShutdownOnce records session_shutdown_total exactly
+        // one ShutdownOnce records session_shutdown_total exactly
         // once — the first cause (fd_watcher / signal / run_all completion) wins.
         let shutdown_once = ShutdownOnce::new(enabled);
 
-        // Phase 3b (P2-2/P3-1): the fd watcher returns a JoinHandle; a
+        // the fd watcher returns a JoinHandle; a
         // RunCleanupGuard holds it and, on EVERY run() exit path (including the
         // SIGUSR1 run-all/persist error returns below), aborts the watcher and sets
         // kernel_fd_health=0. This both closes out the health gauge and prevents a
@@ -369,7 +369,7 @@ impl<T: FileSystem> FuseSession<T> {
                 };
 
                 if unhealthy {
-                    // Phase 3b (D4/P2-2): one synchronous, ordered burst —
+                    // one synchronous, ordered burst —
                     // record the reason, set health 0, THEN broadcast shutdown,
                     // then return. `send` is last so a cleanup abort (which only
                     // fires after run() is already unwinding) cannot truncate the
@@ -437,7 +437,7 @@ impl<T: FileSystem> FuseSession<T> {
     }
 
     async fn persist(&self, mnts: Vec<FuseMnt>) -> CommonResult<()> {
-        // Phase 3b: record the top-level persist outcome once, and time the
+        // record the top-level persist outcome once, and time the
         // mount_fds stage here (node_map/file_handles/dir_handles stages are timed
         // inside self.fs.persist -> NodeState::persist).
         let enabled = self.conf.metrics_enabled;
@@ -470,7 +470,7 @@ impl<T: FileSystem> FuseSession<T> {
                 mnt.auto_unmount(false);
 
                 let flags = sys::fcntl_get(mnt.fd)?;
-                // Propagate the F_SETFD failure (Phase 3b P1): if clearing
+                // Propagate the F_SETFD failure: if clearing
                 // FD_CLOEXEC fails the persisted fd cannot be inherited by the
                 // child, so the persist must fail — the `?` drops the mount_fds
                 // StateStageTimer as error and the top-level state_persist_total
@@ -491,7 +491,7 @@ impl<T: FileSystem> FuseSession<T> {
 
         self.fs.persist(&mut writer).await?;
 
-        // Phase 3b (R2 P3#2): explicitly flush the BufWriter BEFORE spawning the
+        // explicitly flush the BufWriter BEFORE spawning the
         // child. `reload_param` spawn()s a new process that immediately opens this
         // same state file for restore; the BufWriter would otherwise only flush on
         // drop (after persist_inner returns, i.e. after the child has started), so
@@ -516,7 +516,7 @@ impl<T: FileSystem> FuseSession<T> {
     }
 
     async fn restore(file: &str, conf: &FuseConf, fs: &T) -> CommonResult<Vec<FuseMnt>> {
-        // Phase 3b: record the top-level restore outcome once. `conf` is available
+        // record the top-level restore outcome once. `conf` is available
         // on this static fn, so the metrics_enabled kill-switch is reachable. A
         // NodeState magic/version header failure inside fs.restore records
         // state_restore_total{error}; note mount_fds may already have recorded
@@ -636,7 +636,7 @@ mod fd_watcher_tests {
 mod cleanup_guard_tests {
     use super::RunCleanupGuard;
 
-    // Phase 3b P3#4: the RunCleanupGuard close-out is the control-flow-sensitive
+    // The RunCleanupGuard close-out is the control-flow-sensitive
     // seam reviewers flagged repeatedly. Prove fd-free (no real FuseSession/Pipe2,
     // just a trivial spawned task) that Drop ABORTS the held watcher handle on
     // every exit path. The health-gauge side (set 0) is exercised by the
@@ -679,7 +679,7 @@ mod cleanup_guard_tests {
         // dropping here must not panic
     }
 
-    // Phase 3b R2 P3#3: the health close-out side of the guard. enabled=true must
+    // The health close-out side of the guard. enabled=true must
     // set health 0 (the SIGUSR1-persist-error early-return path relies on this);
     // enabled=false must not touch the gauge. Tested against an injected captured
     // value (deterministic, no process-global gauge).

--- a/curvine-fuse/src/session/mod.rs
+++ b/curvine-fuse/src/session/mod.rs
@@ -55,11 +55,11 @@ pub(crate) enum FuseTask {
         errno: i32,
         /// Source tag for `status == Unsupported`, carried so the sender can emit
         /// `unsupported_total{reason}` without reaching back into the metrics
-        /// slot. Phase 1a-2 emits `unknown_opcode` / `unimplemented_opcode`;
+        /// slot. Emits `unknown_opcode` / `unimplemented_opcode`;
         /// `trait_default` is reserved for a later phase (no source site yet).
         /// `None` for non-unsupported replies.
         unsupported_reason: Option<&'static str>,
-        /// Phase 2a `reply_queue_depth` guard, created at the enqueue boundary so
+        /// `reply_queue_depth` guard, created at the enqueue boundary so
         /// the gauge counts this task's time in the reply channel. The sender
         /// `take()`s/drops it the moment it dequeues (the dequeue point, NOT after
         /// the splice); a task dropped without ever being received (sender exit /
@@ -72,7 +72,7 @@ pub(crate) enum FuseTask {
     NotifyReply {
         data: ResponseData,
         code: &'static str,
-        /// Phase 2a `reply_queue_depth` guard — same lifecycle as the
+        /// `reply_queue_depth` guard — same lifecycle as the
         /// `RequestReply` variant's. Notifications share the reply channel, so
         /// they count toward the same backlog. `None` when metrics disabled.
         queue_guard: Option<ActiveGuard>,

--- a/curvine-fuse/src/web_server.rs
+++ b/curvine-fuse/src/web_server.rs
@@ -31,26 +31,17 @@ impl WebServer {
     }
 }
 
-// The `NodeState` is still injected into the router (`with_state`) so
-// `WebServer::start`'s public signature is unchanged, but the handler no longer
-// reads it: the legacy gauges (inode/handle) are event-driven and
-// removed the scrape-time `set_metrics()` refresh, so the scrape is now a pure
-// `text_output()` with no map traversal under read locks.
+// `NodeState` is still injected (`with_state`) to keep `WebServer::start`'s
+// signature stable, but the handler no longer reads it: the gauges are now
+// event-driven, so the scrape is a pure `text_output()` with no map traversal
+// under read locks.
 async fn metrics_handler(State(_): State<Arc<NodeState>>) -> String {
     let fuse_metrics = FuseMetrics::get();
 
-    // Scrape hygiene (unconditional, self-observation): time the render and
-    // record the output size. Last-scrape semantics — the values in *this*
-    // response reflect the previous scrape; the current scrape is visible next
-    // time. This ordering (text_output THEN record_scrape) is what makes it
-    // "last scrape"; do not reorder. Recorded on both success and the
-    // error-body fallback.
-    //
-    // The scrape-time `set_metrics()` map traversal is gone, so this
-    // timer covers the meaningful scrape work — the `text_output()` render —
-    // rather than under-counting by that traversal. It deliberately does NOT
-    // include Axum's `State` extraction or the `FuseMetrics::get()` before
-    // `start`; those are tiny and out of scope for a render-regression signal.
+    // Scrape hygiene: time the render + record output size. Last-scrape semantics
+    // — the values in *this* response reflect the PREVIOUS scrape (order
+    // text_output THEN record_scrape; do not reorder). Covers the `text_output()`
+    // render only, not Axum's `State` extraction (tiny, out of scope).
     let start = mono_now();
     let output = Metrics::text_output().unwrap_or_else(|e| format!("Error: {}", e));
     fuse_metrics.record_scrape(start.elapsed().as_micros() as u64, output.len());

--- a/curvine-fuse/src/web_server.rs
+++ b/curvine-fuse/src/web_server.rs
@@ -33,7 +33,7 @@ impl WebServer {
 
 // The `NodeState` is still injected into the router (`with_state`) so
 // `WebServer::start`'s public signature is unchanged, but the handler no longer
-// reads it: Phase 1b-2 made the legacy gauges (inode/handle) event-driven and
+// reads it: the legacy gauges (inode/handle) are event-driven and
 // removed the scrape-time `set_metrics()` refresh, so the scrape is now a pure
 // `text_output()` with no map traversal under read locks.
 async fn metrics_handler(State(_): State<Arc<NodeState>>) -> String {
@@ -46,7 +46,7 @@ async fn metrics_handler(State(_): State<Arc<NodeState>>) -> String {
     // "last scrape"; do not reorder. Recorded on both success and the
     // error-body fallback.
     //
-    // As of 1b-2 the scrape-time `set_metrics()` map traversal is gone, so this
+    // The scrape-time `set_metrics()` map traversal is gone, so this
     // timer covers the meaningful scrape work — the `text_output()` render —
     // rather than under-counting by that traversal. It deliberately does NOT
     // include Axum's `State` extraction or the `FuseMetrics::get()` before


### PR DESCRIPTION
# Summary

The `curvine-fuse` metrics were built across implementation phases (1–3) plus several review rounds, leaving comments littered with process labels — `Phase N`, `review Rn Pn#n`, `round-N`, `codex`, `En`/`Dn` — that carry no meaning for a reader of the current code. This trims that noise and compresses a few over-long implementation narratives, while deliberately preserving the design constraints those comments also carried.

Comment-only change (13 files, net −25 lines). No logic, no metric names/labels, and no test behavior changed.

# Issue Describe / Design

Not tied to an issue — routine readability cleanup of the metrics implementation comments.

## What was removed

- Implementation-phase labels: `Phase 2a`, `1a-2`, `3b-1`, etc. (including `// --- Phase Nx: … ---` section-header prefixes).
- Review-process tags: `review R2 P1#1`, `round-4 P2-1`, `En`/`En/En` test tags, `Dn`, `plan Rn`, and "codex's repeated recommendation" / "failed to tame across two rounds" style narration of how the code was arrived at.

## What was deliberately kept (the review focus)

These comments also encoded real, non-obvious design constraints; only the process labels were stripped, the rationale stays:
- ctx-before-parse, and the "no `.await` / early-return between `parse_operator()` and the two RAII scopes" invariant.
- The fd-free test-harness rationale (a real `Pipe2` Drop deregisters from the tokio reactor *after* closing its fds → `IO Safety violation` abort under the parallel harness).
- Why stream metric assertions use lower bounds (process-global shared labels → exact deltas flake).
- `op_status` vs `request_status` separation (can diverge: op succeeds, delivery fails).
- Why the legacy gauges' `with()` path must not become `get()` (bare-`NodeState` tests would panic).
- The `io_*` vs `stream_lifecycle_*` family split, single-timer-not-per-arm, `ensure_init` precedes `NodeState`, etc.

## Incidental noise-token fixes (not comments)

- Test fn renamed: `stage_stream_io_is_the_only_phase2b_stage` → `stage_stream_io_is_the_only_stream_stage` (no external caller).
- Assert-message string: `"parse reason stashed for 1a-2"` → `"parse reason stashed for decode_errors"`.

Two doc rewrites also became slightly more accurate: the `stage_duration_us` field doc now enumerates all four live stages, and `STAGE_STREAM_IO` is described as "the ONLY `stage_duration_us` emission point for stream IO".

# Changes

| Module / File | Change |
| ------------- | ------ |
| `curvine-fuse/src/fuse_metrics.rs` | Bulk of the cleanup: strip `Phase N` labels, section-header prefixes, `En`/`Pn#n` test tags; condense the `FuseMetrics` struct / guard / timer doc blocks | 
| `curvine-fuse/src/session/channel/fuse_receiver.rs` | Strip `review Rn Pn#n` / `round-N` / `codex`; condense the `send_stream_dispatch` and `dispatch_one` doc blocks (constraints kept) |
| `curvine-fuse/src/session/fuse_response.rs`, `fuse_session.rs`, `mod.rs` | Strip `Phase`/`Dn`/`Pn-n` labels from doc and inline comments |
| `curvine-fuse/src/fs/{curvine_file_system,fuse_reader,fuse_writer}.rs`, `fuse_error.rs`, `cli/fuse_cli.rs`, `session/{fuse_op_code,fuse_notify_code}.rs`, `web_server.rs` | Scattered single-line label removals |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `git diff` audit | PASS | Effectively comment-only; the only non-`//` changes are the two intentional noise tokens above |
| `cargo fmt -p curvine-fuse -- --check` | PASS | comment rewrites respect line width |
| `cargo clippy -p curvine-fuse --lib --tests` | PASS | no warnings |
| `cargo test -p curvine-fuse --lib -- --test-threads=1` | PASS | 249 passed (a `local_writer_task_body_observes_io...` failure under the parallel harness is a pre-existing flake — reproduces on unmodified main — from an exact-count assertion on a process-global metric, unrelated to this change) |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None