### PR TITLE
refactor(master): simplify RPC runtime dispatch (#1235)

### DIFF
--- a/curvine-common/src/conf/master_conf.rs
+++ b/curvine-common/src/conf/master_conf.rs
@@ -29,6 +29,7 @@ pub struct MasterConf {
     pub web_port: u16,
     pub io_threads: usize,
     pub worker_threads: usize,
+    pub actor_threads: usize,
 
     // Master network read and write data timeout time, and whether to close idle connection; the default timeout is 10 minutes, close connections with timeout without data.
     pub io_timeout: String,
@@ -245,6 +246,7 @@ impl Default for MasterConf {
             web_port: ClusterConf::DEFAULT_MASTER_WEB_PORT,
             io_threads: 32,
             worker_threads: Utils::worker_threads(32),
+            actor_threads: 4,
             io_timeout: "10m".to_string(),
             io_close_idle: true,
 

--- a/curvine-server/src/master/master_handler.rs
+++ b/curvine-server/src/master/master_handler.rs
@@ -33,10 +33,8 @@ use orpc::err_box;
 use orpc::handler::{FrameBuf, MessageHandler};
 use orpc::io::net::ConnState;
 use orpc::message::Message;
-use orpc::runtime::GroupExecutor;
-use std::panic::{self, AssertUnwindSafe};
+use orpc::runtime::Runtime;
 use std::sync::Arc;
-use tokio::sync::oneshot;
 
 pub struct MasterHandler {
     pub(crate) fs: MasterFilesystem,
@@ -46,12 +44,8 @@ pub struct MasterHandler {
     pub(crate) conn_state: Option<ConnState>,
     pub(crate) job_handler: JobHandler,
     pub(crate) mount_manager: Arc<MountManager>,
-    pub(crate) heartbeat_rpc_executor: Arc<GroupExecutor>,
-    pub(crate) block_report_rpc_executor: Arc<GroupExecutor>,
-    pub(crate) control_rpc_executor: Arc<GroupExecutor>,
-    pub(crate) list_rpc_executor: Arc<GroupExecutor>,
-    pub(crate) get_block_locations_rpc_executor: Arc<GroupExecutor>,
     pub(crate) replication_handler: Option<MasterReplicationHandler>,
+    pub(crate) actor_rt: Arc<Runtime>,
     pub(crate) buf: FrameBuf,
 }
 
@@ -64,12 +58,8 @@ impl MasterHandler {
         conn_state: Option<ConnState>,
         mount_manager: Arc<MountManager>,
         job_handler: JobHandler,
-        heartbeat_rpc_executor: Arc<GroupExecutor>,
-        block_report_rpc_executor: Arc<GroupExecutor>,
-        control_rpc_executor: Arc<GroupExecutor>,
-        list_rpc_executor: Arc<GroupExecutor>,
-        get_block_locations_rpc_executor: Arc<GroupExecutor>,
         replication_manager: Arc<MasterReplicationManager>,
+        actor_rt: Arc<Runtime>,
         metrics: &'static MasterMetrics,
     ) -> Self {
         Self {
@@ -80,12 +70,8 @@ impl MasterHandler {
             conn_state,
             mount_manager,
             job_handler,
-            heartbeat_rpc_executor,
-            block_report_rpc_executor,
-            control_rpc_executor,
-            list_rpc_executor,
-            get_block_locations_rpc_executor,
             replication_handler: Some(MasterReplicationHandler::new(replication_manager)),
+            actor_rt,
             buf: FrameBuf::new(conf.master.buffer_size),
         }
     }
@@ -730,20 +716,6 @@ impl MasterHandler {
         fs.list_options(&path, opts)
     }
 
-    async fn run_master_rpc_task<T, F>(executor: Arc<GroupExecutor>, task: F) -> FsResult<T>
-    where
-        T: Send + 'static,
-        F: FnOnce() -> FsResult<T> + Send + 'static,
-    {
-        let (tx, rx) = oneshot::channel();
-        executor.try_spawn(move || {
-            let res = panic::catch_unwind(AssertUnwindSafe(task))
-                .unwrap_or_else(|_| err_box!("master rpc lane task panicked"));
-            let _ = tx.send(res);
-        })?;
-        rx.await?
-    }
-
     fn record_rpc_observability(&self, ctx: &RpcContext<'_>, response: &FsResult<Message>) {
         let used_us = ctx.spent.used_us();
         if self.audit_logging_enabled {
@@ -761,94 +733,6 @@ impl MasterHandler {
                 .observe(used_us as f64);
         };
     }
-
-    async fn async_get_block_locations(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
-        let req: GetBlockLocationsRequest = ctx.parse_header()?;
-        ctx.set_audit(Some(req.path.to_string()), None);
-        let fs = self.fs.clone();
-        let blocks =
-            Self::run_master_rpc_task(self.get_block_locations_rpc_executor.clone(), move || {
-                Self::process_get_block_locations(fs, req.path)
-            })
-            .await?;
-        let rep_header = GetBlockLocationsResponse {
-            blocks: ProtoUtils::file_blocks_to_pb(blocks),
-        };
-        ctx.response_buf(rep_header, &mut self.buf)
-    }
-
-    async fn async_get_master_info(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
-        let _: GetMasterInfoRequest = ctx.parse_header()?;
-        let fs = self.fs.clone();
-        let info = Self::run_master_rpc_task(self.control_rpc_executor.clone(), move || {
-            Self::process_get_master_info(fs)
-        })
-        .await?;
-        let rep_header = ProtoUtils::master_info_to_pb(info);
-        ctx.response_buf(rep_header, &mut self.buf)
-    }
-
-    async fn async_list_status(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
-        let header: ListStatusRequest = ctx.parse_header()?;
-        ctx.set_audit(Some(header.path.to_string()), None);
-        let fs = self.fs.clone();
-        let list = Self::run_master_rpc_task(self.list_rpc_executor.clone(), move || {
-            Self::process_list_status(fs, header.path)
-        })
-        .await?;
-        let statuses = list
-            .into_iter()
-            .map(ProtoUtils::file_status_to_pb)
-            .collect();
-        ctx.response_buf(ListStatusResponse { statuses }, &mut self.buf)
-    }
-
-    async fn async_list_options(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
-        let header: ListOptionsRequest = ctx.parse_header()?;
-        if header.options.limit.unwrap_or(0) < 0 {
-            return err_box!("list options limit must be greater than 0");
-        }
-        let opts = ProtoUtils::list_options_from_pb(header.options);
-        let audit_path = format!("{}[{}]", header.path, opts);
-        ctx.set_audit(Some(audit_path), None);
-        let fs = self.fs.clone();
-        let list = Self::run_master_rpc_task(self.list_rpc_executor.clone(), move || {
-            Self::process_list_options(fs, header.path, opts)
-        })
-        .await?;
-        let statuses = list
-            .into_iter()
-            .map(ProtoUtils::file_status_to_pb)
-            .collect();
-        ctx.response_buf(ListOptionsResponse { statuses }, &mut self.buf)
-    }
-
-    async fn async_worker_heartbeat(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
-        let header: WorkerHeartbeatRequest = ctx.parse_header()?;
-        let fs = self.fs.clone();
-        let cmds = Self::run_master_rpc_task(self.heartbeat_rpc_executor.clone(), move || {
-            Self::process_worker_heartbeat(fs, header)
-        })
-        .await?;
-        let rep_header = WorkerHeartbeatResponse {
-            cmds: ProtoUtils::worker_cmd_to_pb(cmds),
-        };
-        ctx.response_buf(rep_header, &mut self.buf)
-    }
-
-    async fn async_worker_block_report(&mut self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
-        let header: BlockReportListRequest = ctx.parse_header()?;
-        let fs = self.fs.clone();
-        let replication_handler = self.replication_handler.clone();
-        let cmds = Self::run_master_rpc_task(self.block_report_rpc_executor.clone(), move || {
-            Self::process_block_report(fs, replication_handler, header)
-        })
-        .await?;
-        let rep_header = BlockReportListResponse {
-            cmds: ProtoUtils::worker_cmd_to_pb(cmds),
-        };
-        ctx.response_buf(rep_header, &mut self.buf)
-    }
 }
 
 impl MessageHandler for MasterHandler {
@@ -858,16 +742,7 @@ impl MessageHandler for MasterHandler {
         let code = RpcCode::from(msg.code());
         !matches!(
             code,
-            RpcCode::SubmitJob
-                | RpcCode::GetJobStatus
-                | RpcCode::CancelJob
-                | RpcCode::ReportTask
-                | RpcCode::GetBlockLocations
-                | RpcCode::GetMasterInfo
-                | RpcCode::ListStatus
-                | RpcCode::ListOptions
-                | RpcCode::WorkerHeartbeat
-                | RpcCode::WorkerBlockReport
+            RpcCode::SubmitJob | RpcCode::GetJobStatus | RpcCode::CancelJob | RpcCode::ReportTask
         )
     }
 
@@ -977,12 +852,6 @@ impl MessageHandler for MasterHandler {
                 RpcCode::GetJobStatus => self.job_handler.get_load_status(ctx, &mut self.buf),
                 RpcCode::CancelJob => self.job_handler.cancel_job(ctx, &mut self.buf).await,
                 RpcCode::ReportTask => self.job_handler.task_report(ctx, &mut self.buf),
-                RpcCode::GetBlockLocations => self.async_get_block_locations(ctx).await,
-                RpcCode::GetMasterInfo => self.async_get_master_info(ctx).await,
-                RpcCode::ListStatus => self.async_list_status(ctx).await,
-                RpcCode::ListOptions => self.async_list_options(ctx).await,
-                RpcCode::WorkerHeartbeat => self.async_worker_heartbeat(ctx).await,
-                RpcCode::WorkerBlockReport => self.async_worker_block_report(ctx).await,
 
                 v => err_box!("unsupported operation {:?}", v),
             }
@@ -993,6 +862,18 @@ impl MessageHandler for MasterHandler {
         match res {
             Ok(v) => Ok(v),
             Err(e) => Ok(msg.error_ext(&e)),
+        }
+    }
+
+    fn get_rt(&self, msg: &Message) -> Option<&Runtime> {
+        let code = RpcCode::from(msg.code());
+        if matches!(
+            code,
+            RpcCode::WorkerHeartbeat | RpcCode::WorkerBlockReport | RpcCode::GetMasterInfo
+        ) {
+            Some(&self.actor_rt)
+        } else {
+            None
         }
     }
 }

--- a/curvine-server/src/master/master_server.rs
+++ b/curvine-server/src/master/master_server.rs
@@ -23,7 +23,7 @@ use log::error;
 use orpc::common::{LocalTime, Logger};
 use orpc::handler::HandlerService;
 use orpc::io::net::ConnState;
-use orpc::runtime::{GroupExecutor, RpcRuntime, Runtime};
+use orpc::runtime::{AsyncRuntime, RpcRuntime, Runtime};
 use orpc::server::{RpcServer, ServerStateListener};
 use orpc::{err_box, CommonError, CommonResult};
 
@@ -45,11 +45,7 @@ pub struct MasterService {
     mount_manager: Arc<MountManager>,
     job_manager: Arc<JobManager>,
     rt: Arc<Runtime>,
-    heartbeat_rpc_executor: Arc<GroupExecutor>,
-    block_report_rpc_executor: Arc<GroupExecutor>,
-    control_rpc_executor: Arc<GroupExecutor>,
-    list_rpc_executor: Arc<GroupExecutor>,
-    get_block_locations_rpc_executor: Arc<GroupExecutor>,
+    actor_rt: Arc<Runtime>,
     replication_manager: Arc<MasterReplicationManager>,
     metrics: &'static MasterMetrics,
     fault_http: FaultHttpControl,
@@ -64,15 +60,15 @@ impl MasterService {
         mount_manager: Arc<MountManager>,
         job_manager: Arc<JobManager>,
         rt: Arc<Runtime>,
-        heartbeat_rpc_executor: Arc<GroupExecutor>,
-        block_report_rpc_executor: Arc<GroupExecutor>,
-        control_rpc_executor: Arc<GroupExecutor>,
-        list_rpc_executor: Arc<GroupExecutor>,
-        get_block_locations_rpc_executor: Arc<GroupExecutor>,
         replication_manager: Arc<MasterReplicationManager>,
         metrics: &'static MasterMetrics,
         fault_http: FaultHttpControl,
     ) -> Self {
+        let actor_rt = Arc::new(AsyncRuntime::new(
+            "master-actor",
+            1,
+            conf.master.actor_threads,
+        ));
         Self {
             conf,
             fs,
@@ -80,11 +76,7 @@ impl MasterService {
             mount_manager,
             job_manager,
             rt,
-            heartbeat_rpc_executor,
-            block_report_rpc_executor,
-            control_rpc_executor,
-            list_rpc_executor,
-            get_block_locations_rpc_executor,
+            actor_rt,
             replication_manager,
             metrics,
             fault_http,
@@ -123,12 +115,8 @@ impl HandlerService for MasterService {
             client_state,
             self.mount_manager.clone(),
             JobHandler::new(self.job_manager.clone()),
-            self.heartbeat_rpc_executor.clone(),
-            self.block_report_rpc_executor.clone(),
-            self.control_rpc_executor.clone(),
-            self.list_rpc_executor.clone(),
-            self.get_block_locations_rpc_executor.clone(),
             self.replication_manager.clone(),
+            self.actor_rt.clone(),
             self.metrics,
         )
     }
@@ -180,23 +168,6 @@ impl Master {
         let job_manager = journal_system.job_manager();
 
         let rt = Arc::new(conf.master_server_conf().create_runtime());
-        let heartbeat_rpc_executor = Arc::new(GroupExecutor::new("master-heartbeat-rpc", 2, 1024));
-        let block_report_rpc_executor =
-            Arc::new(GroupExecutor::new("master-block-report-rpc", 2, 128));
-        let control_rpc_executor = Arc::new(GroupExecutor::new("master-control-rpc", 2, 1024));
-        let read_lane_threads = conf.master.worker_threads.saturating_sub(4).max(1);
-        let read_lane_queue = conf.master.worker_threads.saturating_mul(2).max(1);
-        let list_rpc_executor = Arc::new(GroupExecutor::new(
-            "master-list-rpc",
-            read_lane_threads,
-            read_lane_queue,
-        ));
-        let get_block_locations_rpc_executor = Arc::new(GroupExecutor::new(
-            "master-get-block-locations-rpc",
-            read_lane_threads,
-            read_lane_queue,
-        ));
-
         let replication_manager = MasterReplicationManager::new(&fs, &conf, &rt, &worker_manager)?;
 
         let actor = MasterActor::new(
@@ -216,11 +187,6 @@ impl Master {
             mount_manager.clone(),
             job_manager.clone(),
             rt.clone(),
-            heartbeat_rpc_executor,
-            block_report_rpc_executor,
-            control_rpc_executor,
-            list_rpc_executor,
-            get_block_locations_rpc_executor,
             replication_manager.clone(),
             metrics,
             fault_http,

--- a/curvine-server/tests/master_fs_test.rs
+++ b/curvine-server/tests/master_fs_test.rs
@@ -41,7 +41,7 @@ use orpc::handler::MessageHandler;
 use orpc::message::Builder;
 #[cfg(feature = "fault-injection")]
 use orpc::message::ResponseStatus;
-use orpc::runtime::{AsyncRuntime, GroupExecutor, RpcRuntime};
+use orpc::runtime::{AsyncRuntime, RpcRuntime};
 use orpc::CommonResult;
 use raft::eraftpb::Entry;
 use std::sync::{Arc, Mutex, OnceLock};
@@ -195,16 +195,8 @@ fn new_handler_for_test(test_name: &str) -> MasterHandler {
         None,
         mount_manager,
         JobHandler::new(job_manager),
-        Arc::new(GroupExecutor::new("test-master-heartbeat-rpc", 1, 8)),
-        Arc::new(GroupExecutor::new("test-master-block-report-rpc", 1, 8)),
-        Arc::new(GroupExecutor::new("test-master-control-rpc", 1, 8)),
-        Arc::new(GroupExecutor::new("test-master-list-rpc", 1, 8)),
-        Arc::new(GroupExecutor::new(
-            "test-master-get-block-locations-rpc",
-            1,
-            8,
-        )),
         replication_manager,
+        rt,
         Master::get_metrics().expect("test master metrics should initialize"),
     )
 }

--- a/orpc/src/handler/message_handler.rs
+++ b/orpc/src/handler/message_handler.rs
@@ -14,6 +14,7 @@
 
 use crate::error::{CommonErrorExt, ErrorExt};
 use crate::message::Message;
+use crate::runtime::Runtime;
 use crate::sys::DataSlice;
 use bytes::BytesMut;
 use log::info;
@@ -41,6 +42,10 @@ pub trait MessageHandler: Send + Sync + 'static {
         msg: Message,
     ) -> impl Future<Output = Result<Message, Self::Error>> + Send {
         async { panic!("Please implement the async_handle method") }
+    }
+
+    fn get_rt(&self, _msg: &Message) -> Option<&Runtime> {
+        None
     }
 }
 

--- a/orpc/src/handler/stream_handler.rs
+++ b/orpc/src/handler/stream_handler.rs
@@ -73,33 +73,25 @@ impl<F: Frame, M: MessageHandler> StreamHandler<F, M> {
 
     pub async fn call(&mut self, request: Message) -> IOResult<()> {
         let response = if self.handler.is_sync(&request) {
-            let handler = self.handler.clone();
-            self.rt
-                .spawn_blocking(move || match handler.as_mut().handle(&request) {
-                    Err(e) => {
-                        debug!("handler request {} error: {}", request.req_id(), e);
-                        request.error_ext(&e)
-                    }
+            let rt = self.handler.get_rt(&request).unwrap_or(&self.rt);
 
-                    Ok(v) => v,
-                })
-                .await?
+            let handler = self.handler.clone();
+            rt.spawn_blocking(move || match handler.as_mut().handle(&request) {
+                Err(e) => {
+                    debug!("handler request {} error: {}", request.req_id(), e);
+                    request.error_ext(&e)
+                }
+
+                Ok(v) => v,
+            })
+            .await?
         } else {
-            let code = request.code();
-            let request_status = request.request_status();
-            let req_id = request.req_id();
-            let seq_id = request.seq_id();
+            let protocol = request.protocol;
             match self.handler.as_mut().async_handle(request).await {
                 Ok(v) => v,
                 Err(e) => {
-                    debug!("handler request {} error: {}", req_id, e);
-                    let error_response_base = Builder::new()
-                        .code(code)
-                        .request(request_status)
-                        .req_id(req_id)
-                        .seq_id(seq_id)
-                        .build();
-                    error_response_base.error_ext(&e)
+                    debug!("handler request {} error: {}", protocol.req_id, e);
+                    Builder::protocol(protocol).build().error_ext(&e)
                 }
             }
         };

--- a/orpc/src/message/message_builder.rs
+++ b/orpc/src/message/message_builder.rs
@@ -43,6 +43,17 @@ impl MessageBuilder {
         }
     }
 
+    pub fn protocol(protocol: Protocol) -> Self {
+        Builder {
+            code: protocol.code,
+            status: protocol.status,
+            req_id: protocol.req_id,
+            seq_id: protocol.seq_id,
+            header: None,
+            data: DataSlice::Empty,
+        }
+    }
+
     // Create a RequestStatus::Rpc request.
     pub fn new_rpc<T: Into<i8>>(code: T) -> Self {
         Builder {


### PR DESCRIPTION
# Summary

Simplify master RPC dispatch by replacing per-RPC `GroupExecutor` lanes with request-specific runtime selection through `MessageHandler`. Actor-oriented RPCs use a dedicated configurable runtime, while filesystem reads use the regular synchronous handler path.

# Issue Describe / Design

The previous implementation manually wrapped several synchronous master RPCs in async tasks and maintained separate executors for heartbeat, block report, control, list, and block-location requests.

This change adds a runtime-selection hook to `MessageHandler`. The master handler routes worker heartbeat, worker block report, and master-info requests to a dedicated actor runtime, removing the executor-specific wrappers and constructor plumbing. Async error responses now retain the original request protocol metadata.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-common/src/conf/master_conf.rs` | Add configurable `actor_threads` | Adds a dedicated master actor runtime setting |
| `curvine-server/src/master/` | Replace per-RPC executors with runtime selection | Simplifies dispatch and routes actor RPCs through the actor runtime |
| `orpc/src/handler/` | Add handler-specific runtime selection | Sync handlers can select a runtime per request |
| `orpc/src/message/message_builder.rs` | Build responses from existing protocol metadata | Async errors preserve request identifiers and status |
| `curvine-server/tests/master_fs_test.rs` | Update handler construction | Adapts tests to the new runtime argument |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `git diff --check HEAD^ HEAD` | PASS | No whitespace errors |
| `cargo test -p curvine-server --test master_fs_test --no-run` | BLOCKED | Windows build fails in `curvine-common` because `nix::ifaddrs` is unavailable |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None