### PR TITLE
fix(fuse): inherit parent group for mknod special nodes (#1251)

### DIFF
--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -1098,9 +1098,7 @@ impl fs::FileSystem for CurvineFileSystem {
 
         let mut opts = FuseUtils::create_opts(&op, &self.fs);
         let parent_status = self.state.fs_stat(ino, None).await?;
-        if parent_status.mode & FUSE_S_ISGID != 0 {
-            opts.group = parent_status.group;
-        }
+        FuseUtils::apply_setgid_parent_group(&mut opts, &parent_status);
 
         let handle = self.state.fs_create(ino, name, op.arg.flags, opts).await?;
         let attr = FuseUtils::status_to_attr(&self.conf, &handle.status())?;
@@ -1423,7 +1421,9 @@ impl fs::FileSystem for CurvineFileSystem {
             let path = self.state.get_path_name(op.header.nodeid, name)?;
             self.ensure_writable_path(&path, RpcCode::CreateFile)
                 .await?;
-            let opts = FuseUtils::mknod_opts(&op, &self.fs, file_type);
+            let mut opts = FuseUtils::mknod_opts(&op, &self.fs, file_type);
+            let parent_status = self.state.fs_stat(op.header.nodeid, None).await?;
+            FuseUtils::apply_setgid_parent_group(&mut opts, &parent_status);
             self.fs.create_special_node(&path, opts).await?;
             let attr = self.state.lookup_common(op.header.nodeid, name).await?;
             Ok(FuseUtils::create_entry_out(&self.conf, attr))

--- a/curvine-fuse/src/fuse_utils.rs
+++ b/curvine-fuse/src/fuse_utils.rs
@@ -285,6 +285,13 @@ impl FuseUtils {
             .build()
     }
 
+    /// When the parent directory has the setgid bit, new nodes inherit its group.
+    pub fn apply_setgid_parent_group(opts: &mut CreateFileOpts, parent: &FileStatus) {
+        if parent.mode & FUSE_S_ISGID != 0 {
+            opts.group = parent.group.clone();
+        }
+    }
+
     pub fn check_xattr(name: &str, op: XattrOp) -> FuseResult<()> {
         // Handle system extended attributes FIRST, before any path resolution
         // This avoids unnecessary operations and provides fastest response
@@ -866,6 +873,23 @@ mod tests {
         let mut three = file_status(FileType::File, 0, 0o644);
         three.nlink = 3;
         assert_eq!(FuseUtils::status_to_attr(&conf, &three).unwrap().nlink, 3);
+    }
+
+    #[test]
+    fn apply_setgid_parent_group_inherits_parent_group() {
+        let mut opts = CreateFileOpts::with_create(false);
+        opts.group = "nogroup".to_string();
+
+        let mut parent = file_status(FileType::Dir, 0, 0o2775);
+        parent.group = "project".to_string();
+
+        FuseUtils::apply_setgid_parent_group(&mut opts, &parent);
+        assert_eq!(opts.group, "project");
+
+        parent.mode = 0o755;
+        opts.group = "nogroup".to_string();
+        FuseUtils::apply_setgid_parent_group(&mut opts, &parent);
+        assert_eq!(opts.group, "nogroup");
     }
 
     #[test]

--- a/curvine-fuse/src/fuse_utils.rs
+++ b/curvine-fuse/src/fuse_utils.rs
@@ -288,7 +288,7 @@ impl FuseUtils {
     /// When the parent directory has the setgid bit, new nodes inherit its group.
     pub fn apply_setgid_parent_group(opts: &mut CreateFileOpts, parent: &FileStatus) {
         if parent.mode & FUSE_S_ISGID != 0 {
-            opts.group = parent.group.clone();
+            opts.group.clone_from(&parent.group);
         }
     }
 

--- a/repair-plan.json
+++ b/repair-plan.json
@@ -1,0 +1,30 @@
+{
+  "issue": "CurvineIO/curvine#1225",
+  "multica_issue": "CUR-81",
+  "fingerprint": "sha256:e65c1ac301a58707e070d5c5ee13a39c9e24f46ff722caa252ab909f22bee6b7",
+  "head_sha": "abe42934895c49a3203d8a202c00241bc9d8402a",
+  "root_cause_hypothesis": "After fallocate, fio writes 256KiB blocks. When a block writer fills, get_writer rotates to the next preallocated block but update_writer cached the full block without committing metadata. The next write at offset 262144 hits EIO. Redundant complete_file with empty commits during resize also contributed to EIO before #1231.",
+  "affected_modules": [
+    "curvine-client/src/file/fs_writer_base.rs"
+  ],
+  "planned_changes": [
+    "Commit exhausted block writers instead of caching them when rotating to the next block.",
+    "Skip complete_file RPC when complete0 has no commit blocks after draining writers."
+  ],
+  "not_goals": [
+    "Do not change fallocate punch-hole modes or unrelated FUSE ops.",
+    "Do not modify harness runner configuration."
+  ],
+  "verification_plan": [
+    "make format",
+    "cargo clippy -p curvine-client -p curvine-fuse -p curvine-common -- -D warnings",
+    "cargo test -p curvine-fuse fallocate",
+    "cargo test -p curvine-client --lib fs_writer",
+    "CURVINE_SHA=<fix> privileged fuse harness fio sub-tests"
+  ],
+  "estimated_non_generated_source_line_delta": 12,
+  "risk": {
+    "level": "low",
+    "rationale": "Narrows writer-cache eligibility to in-progress blocks; empty complete short-circuit is idempotent."
+  }
+}

--- a/repair-plan.json
+++ b/repair-plan.json
@@ -1,30 +1,32 @@
 {
-  "issue": "CurvineIO/curvine#1225",
-  "multica_issue": "CUR-81",
-  "fingerprint": "sha256:e65c1ac301a58707e070d5c5ee13a39c9e24f46ff722caa252ab909f22bee6b7",
+  "issue": "CurvineIO/curvine#1251",
+  "multica_issue": "CUR-84",
+  "fingerprint": "sha256:1a0cf36c58902b91bb92f759f6733f61575db461d57269b889fcdd1df4d5b446",
   "head_sha": "abe42934895c49a3203d8a202c00241bc9d8402a",
-  "root_cause_hypothesis": "After fallocate, fio writes 256KiB blocks. When a block writer fills, get_writer rotates to the next preallocated block but update_writer cached the full block without committing metadata. The next write at offset 262144 hits EIO. Redundant complete_file with empty commits during resize also contributed to EIO before #1231.",
+  "root_cause_hypothesis": "FUSE mknod for char/block/fifo special nodes uses the caller gid from the FUSE header without applying POSIX setgid-directory group inheritance, unlike create(). LTP mknod03/04 expect the parent directory group when S_ISGID is set.",
   "affected_modules": [
-    "curvine-client/src/file/fs_writer_base.rs"
+    "curvine-fuse/src/fs/curvine_file_system.rs",
+    "curvine-fuse/src/fuse_utils.rs"
   ],
   "planned_changes": [
-    "Commit exhausted block writers instead of caching them when rotating to the next block.",
-    "Skip complete_file RPC when complete0 has no commit blocks after draining writers."
+    "Extract apply_setgid_parent_group helper shared by create() and mknod special-file path.",
+    "Apply parent setgid group inheritance before create_special_node in mk_nod."
   ],
   "not_goals": [
-    "Do not change fallocate punch-hole modes or unrelated FUSE ops.",
-    "Do not modify harness runner configuration."
+    "Do not change regular-file or mkdir mknod delegation paths (already correct).",
+    "Do not alter server-side mkdir setgid handling.",
+    "Do not add socket mknod support."
   ],
   "verification_plan": [
     "make format",
-    "cargo clippy -p curvine-client -p curvine-fuse -p curvine-common -- -D warnings",
-    "cargo test -p curvine-fuse fallocate",
-    "cargo test -p curvine-client --lib fs_writer",
-    "CURVINE_SHA=<fix> privileged fuse harness fio sub-tests"
+    "cargo clippy -p curvine-fuse -- -D warnings",
+    "cargo test -p curvine-fuse apply_setgid_parent_group",
+    "cargo test -p curvine-fuse special_file_type",
+    "CURVINE_SHA=<fix> harness privileged-fuse mknod03/04/setxattr02 when available"
   ],
-  "estimated_non_generated_source_line_delta": 12,
+  "estimated_non_generated_source_line_delta": 20,
   "risk": {
     "level": "low",
-    "rationale": "Narrows writer-cache eligibility to in-progress blocks; empty complete short-circuit is idempotent."
+    "rationale": "Mirrors existing create() setgid inheritance for mknod special nodes only."
   }
 }


### PR DESCRIPTION
<!-- curvine-automation:issue:CurvineIO/curvine#1251 -->
<!-- curvine-automation:fingerprint:sha256:1a0cf36c58902b91bb92f759f6733f61575db461d57269b889fcdd1df4d5b446 -->

## Summary

FUSE `mknod` for char/block/fifo special nodes now inherit the parent directory group when the parent has the setgid bit, matching POSIX behavior and the existing `create()` path for regular files.

## Related issue

Fixes #1251

## Root cause

After special-file `mknod` support landed (#1228/#1229), `mk_nod` built `CreateFileOpts` from the caller's FUSE header gid only. In setgid directories, LTP `mknod03`/`mknod04` expect the parent's group, which `create()` already applied but the special-node branch did not.

## Changes

- Add `FuseUtils::apply_setgid_parent_group` and reuse it from `create()` and `mk_nod` special-file creation.
- Unit test covers setgid and non-setgid parents.

## Test verified

- `cargo fmt -p curvine-fuse`
- `cargo clippy -p curvine-fuse -- -D warnings`
- `cargo test -p curvine-fuse apply_setgid_parent_group`

## Dependencies

None
