### PR TITLE
fix(fuse): truncate active writer when master size matches target

### DIFF
--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -74,6 +74,19 @@ impl CurvineFileSystem {
         &self.conf
     }
 
+    fn setattr_size_needs_resize(
+        target_len: u64,
+        status_len: i64,
+        writer_len: Option<u64>,
+    ) -> bool {
+        let status_matches = u64::try_from(status_len) == Ok(target_len);
+        let writer_matches = match writer_len {
+            Some(len) => len == target_len,
+            None => true,
+        };
+        !status_matches || !writer_matches
+    }
+
     fn normalize_fallocate(
         current_len: i64,
         offset: u64,
@@ -1114,7 +1127,8 @@ impl fs::FileSystem for CurvineFileSystem {
         let mut status = self.state.fs_set_attr(op.header.nodeid, opts).await?;
         if (op.arg.valid & FATTR_SIZE) != 0 {
             let expect_len = op.arg.size as i64;
-            if expect_len != status.len {
+            let writer_len = self.state.get_writer_len(op.header.nodeid).await;
+            if Self::setattr_size_needs_resize(op.arg.size, status.len, writer_len) {
                 let resize_opts = FileAllocOpts::with_truncate(expect_len);
                 self.state
                     .fs_resize(op.header.nodeid, op.arg.fh, resize_opts)
@@ -1889,6 +1903,35 @@ mod tests {
         )
         .unwrap();
         assert!(opts.is_none());
+    }
+
+    #[test]
+    fn setattr_size_resizes_when_active_writer_differs_from_master() {
+        let target = 0x75000;
+
+        assert!(!super::CurvineFileSystem::setattr_size_needs_resize(
+            target,
+            target as i64,
+            Some(target),
+        ));
+        assert!(!super::CurvineFileSystem::setattr_size_needs_resize(
+            target,
+            target as i64,
+            None,
+        ));
+
+        // generic/091: Master already has the truncate target, while the active
+        // writer still exposes the page appended immediately before ftruncate.
+        assert!(super::CurvineFileSystem::setattr_size_needs_resize(
+            target,
+            target as i64,
+            Some(0x76000),
+        ));
+        assert!(super::CurvineFileSystem::setattr_size_needs_resize(
+            target,
+            0x74000,
+            Some(target),
+        ));
     }
 
     #[test]


### PR DESCRIPTION
**Summary**

Fix FUSE `ftruncate()` returning a stale active-writer size when the requested
length already matches the Master-side file length.

Curvine tracks an open writable file in two places: the Master stores the last
committed file length, while the active `FuseWriter` tracks bytes accepted by
the current writable handle. A write can extend the active writer before that
length is committed to the Master.

If the file is then truncated back to the Master-side length, the FUSE
`SETATTR(size=...)` path previously compared the target only with the Master
status. Because those two lengths already matched, Curvine skipped the writer
resize. The response path then merged the still-larger writer length into the
returned attributes, so `ftruncate()` succeeded while `fstat()` and
`lseek(SEEK_END)` continued to expose the extra page.

**Minimal Reproducer**

```c
#define _GNU_SOURCE

#include <fcntl.h>
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <sys/stat.h>
#include <unistd.h>

int main(int argc, char **argv)
{
    const off_t target = 0x75000;
    const size_t page_size = 4096;
    char buffer[4096];
    struct stat st;
    off_t src = 0;
    off_t dst = target;
    off_t end;
    int fd;

    if (argc != 2) {
        fprintf(stderr, "Usage: %s FILE\n", argv[0]);
        return EXIT_FAILURE;
    }

    memset(buffer, 'A', sizeof(buffer));

    fd = open(argv[1], O_CREAT | O_TRUNC | O_RDWR, 0644);
    if (fd == -1) {
        perror("open");
        return EXIT_FAILURE;
    }

    if (write(fd, buffer, page_size) != (ssize_t)page_size) {
        perror("write");
        return EXIT_FAILURE;
    }

    if (ftruncate(fd, target) == -1) {
        perror("initial ftruncate");
        return EXIT_FAILURE;
    }

    if (copy_file_range(fd, &src, fd, &dst, page_size, 0) !=
        (ssize_t)page_size) {
        perror("copy_file_range");
        return EXIT_FAILURE;
    }

    /* The active writer is now one page longer than the committed length. */
    if (ftruncate(fd, target) == -1) {
        perror("final ftruncate");
        return EXIT_FAILURE;
    }

    if (fstat(fd, &st) == -1) {
        perror("fstat");
        return EXIT_FAILURE;
    }

    end = lseek(fd, 0, SEEK_END);
    if (end == (off_t)-1) {
        perror("lseek");
        return EXIT_FAILURE;
    }

    close(fd);
    unlink(argv[1]);

    if (st.st_size != target || end != target) {
        fprintf(stderr,
                "FAIL: expected 0x%lx, stat=0x%lx, seek=0x%lx\n",
                (unsigned long)target,
                (unsigned long)st.st_size,
                (unsigned long)end);
        return EXIT_FAILURE;
    }

    printf("PASS: truncate updated the active writer length\n");
    return EXIT_SUCCESS;
}
```

Run it on a Curvine FUSE mount:

```bash
gcc -Wall -O2 /tmp/active_writer_truncate_repro.c \
    -o /tmp/active_writer_truncate_repro
/tmp/active_writer_truncate_repro \
    /mnt/curvine/active-writer-truncate-repro
```

Before the fix, the final truncate could return success while the open file
descriptor remained one page too large:

```text
FAIL: expected 0x75000, stat=0x76000, seek=0x76000
```

**Root Cause**

FUSE file size changes arrive through `SETATTR` with `FATTR_SIZE`. Curvine
intentionally excludes size from the ordinary Master `SetAttrOpts`, because a
resize must be ordered through the active writer when one exists.

The old decision was based only on the Master response:

```rust
let expect_len = op.arg.size as i64;
if expect_len != status.len {
    self.state.fs_resize(...).await?;
}
```

The failing state was:

```text
requested length:     0x75000
Master status length: 0x75000
active writer length: 0x76000
```

Because the requested and Master lengths matched, `fs_resize()` was skipped.
The active writer therefore remained at `0x76000`.

The response was then passed through `update_writer_len()`, which correctly
protects metadata-only `SETATTR` operations from shrinking the kernel inode
below data already accepted by the writer:

```rust
attr.size = attr.size.max(writer_len);
```

That protection exposed the unmodified writer length in the truncate response.
The bug was therefore not in the Master resize implementation or in
`FuseWriter::resize()`. The resize was incorrectly skipped before either path
could run.

**Changes**

- Compare the requested size with both the Master status and the active writer
  length before deciding that no resize is needed.
- Route the resize through the existing inode-level writer-aware
  `NodeState::fs_resize()` path whenever either length differs.
- Keep the no-op fast path when the Master and active writer already agree with
  the requested length.
- Add a unit regression covering the state where the Master already matches the
  target but the active writer is one page longer.

**Verification**

- Active-writer truncate regression passes and reports the requested size from
  both `fstat()` and `lseek(SEEK_END)`.
- Related repeated write/resize regression passes.
- `cargo test -p curvine-fuse` passes: `295 passed`.
- `cargo fmt --all -- --check` passes.
- `cargo build --release -p curvine-fuse` passes.
- `git diff --check` passes.
