### PR TITLE
fix(fuse): release handles after cleanup errors

### DIFF
--- a/curvine-fuse/src/fs/state/node_state.rs
+++ b/curvine-fuse/src/fs/state/node_state.rs
@@ -588,7 +588,8 @@ impl NodeState {
         let close_result: FuseResult<()> = match handle.as_ref() {
             FileHandle::Backend(_) if handle.has_writer() => {
                 let cleanup_handle = handle.clone();
-                self.writers
+                let (_, cleanup_result) = self
+                    .writers
                     .release_with_cleanup(handle.ino(), move |last| async move {
                         if last {
                             cleanup_handle.complete(None).await
@@ -596,20 +597,18 @@ impl NodeState {
                             cleanup_handle.flush(None).await
                         }
                     })
-                    .await
-                    .map(|_| ())
+                    .await;
+                cleanup_result
             }
 
             _ => Ok(()),
         };
 
-        // A failed close keeps both the handle and its shared-writer reference
-        // so cleanup state is not silently discarded. FUSE normally sends
-        // RELEASE only once; automatic retry of retained state is tracked by
-        // #1221.
-        if close_result.is_ok() {
-            let _ = self.remove_handle(ino, fh);
-        }
+        // FUSE sends RELEASE once per open handle, and its error is not retried.
+        // Remove the handle regardless of the close result so open-handle and
+        // shared-writer accounting continue to reflect kernel ownership.
+        // Retriable backend cleanup must be tracked separately (#1221).
+        let _ = self.remove_handle(ino, fh);
 
         Ok((handle, close_result))
     }
@@ -1525,7 +1524,7 @@ mod test {
 
     #[cfg(target_os = "linux")]
     #[test]
-    fn release_handle_failure_retains_handle_and_writer_for_retry() {
+    fn release_handle_failure_releases_handle_and_writer_reference() {
         let rt = Arc::new(AsyncRuntime::single());
         let task_rt = rt.clone();
 
@@ -1557,19 +1556,66 @@ mod test {
 
             let (_, first_result) = state.release_handle(1, handle.fh()).await.unwrap();
             assert!(first_result.is_err());
-            assert!(state.find_handle(1, handle.fh()).is_ok());
-            assert!(Arc::ptr_eq(
-                &state.find_writer(1).await.unwrap(),
-                &fuse_writer
-            ));
+            assert!(state.find_handle(1, handle.fh()).is_err());
+            assert!(!state.has_open_handles(1));
+            assert!(state.find_writer(1).await.is_none());
+        });
+    }
 
-            let (_, retry_result) = state.release_handle(1, handle.fh()).await.unwrap();
-            assert!(retry_result.is_err());
-            assert!(state.find_handle(1, handle.fh()).is_ok());
-            assert!(Arc::ptr_eq(
-                &state.find_writer(1).await.unwrap(),
-                &fuse_writer
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn release_handle_failure_decrements_shared_writer_reference() {
+        let rt = Arc::new(AsyncRuntime::single());
+        let task_rt = rt.clone();
+
+        rt.block_on(async move {
+            crate::FuseMetrics::ensure_init().unwrap();
+            let fs = UnifiedFileSystem::with_rt(ClusterConf::default(), task_rt.clone()).unwrap();
+            let state = NodeState::new(fs).unwrap();
+
+            let full_path = Path::from_str("/dev/full").unwrap();
+            let local_writer = LocalWriter::new(&full_path, 1).unwrap();
+            let status = local_writer.status().clone();
+            let fuse_writer = Arc::new(FuseWriter::new(
+                &state.conf,
+                task_rt,
+                UnifiedWriter::Local(local_writer),
             ));
+            state
+                .writers
+                .insert::<FuseError>(1, fuse_writer.clone())
+                .await
+                .unwrap();
+            let first_handle = state
+                .insert_handle_with_writer(1, None, Some(fuse_writer.clone()), status.clone())
+                .await;
+
+            let shared_writer = state
+                .writers
+                .get_or_create(1, async { Ok::<_, FuseError>(fuse_writer.clone()) })
+                .await
+                .unwrap();
+            let second_handle = state
+                .insert_handle_with_writer(1, None, Some(shared_writer), status)
+                .await;
+
+            fuse_writer
+                .write(0, Bytes::from_static(b"x"), None)
+                .await
+                .unwrap();
+
+            let (_, first_result) = state.release_handle(1, first_handle.fh()).await.unwrap();
+            assert!(first_result.is_err());
+            assert!(state.find_handle(1, first_handle.fh()).is_err());
+            assert!(state.find_handle(1, second_handle.fh()).is_ok());
+            assert!(state.has_open_handles(1));
+            assert!(state.find_writer(1).await.is_some());
+
+            let (_, second_result) = state.release_handle(1, second_handle.fh()).await.unwrap();
+            assert!(second_result.is_err());
+            assert!(state.find_handle(1, second_handle.fh()).is_err());
+            assert!(!state.has_open_handles(1));
+            assert!(state.find_writer(1).await.is_none());
         });
     }
 }

--- a/orpc/src/sync/async_map.rs
+++ b/orpc/src/sync/async_map.rs
@@ -218,13 +218,15 @@ impl<K: Eq + Hash + Display + Clone, T> AsyncSharedMap<K, T> {
         (true, res)
     }
 
-    /// Release one reference after its cleanup succeeds.
+    /// Release one reference after attempting its cleanup.
     ///
     /// `cleanup` receives whether this is the last reference, allowing callers
     /// to choose between per-reference cleanup (for example, flush) and final
-    /// cleanup (for example, complete). If cleanup fails, both the reference
-    /// count and resource remain unchanged so the same release can be retried.
-    pub async fn release_with_cleanup<E, F, Fut>(&self, key: K, cleanup: F) -> Result<bool, E>
+    /// cleanup (for example, complete). The reference is consumed even when
+    /// cleanup fails because the owner has already released it. The cleanup
+    /// result is returned separately so callers can report or schedule retry
+    /// work without keeping the resource in the active map.
+    pub async fn release_with_cleanup<E, F, Fut>(&self, key: K, cleanup: F) -> (bool, Result<(), E>)
     where
         E: Error,
         F: FnOnce(bool) -> Fut,
@@ -232,7 +234,7 @@ impl<K: Eq + Hash + Display + Clone, T> AsyncSharedMap<K, T> {
     {
         let entry = match self.inner.get(&key) {
             Some(entry) => entry.clone(),
-            None => return Ok(true),
+            None => return (true, Ok(())),
         };
 
         let mut state = entry.lock().await;
@@ -240,22 +242,22 @@ impl<K: Eq + Hash + Display + Clone, T> AsyncSharedMap<K, T> {
         if state.refs == 0 || state.resource.is_none() {
             drop(state);
             self.remove_entry(&key, &entry);
-            return Ok(true);
+            return (true, Ok(()));
         }
 
         let last = state.refs == 1;
-        cleanup(last).await?;
+        let result = cleanup(last).await;
 
         state.refs -= 1;
         if state.refs > 0 {
-            return Ok(false);
+            return (false, result);
         }
 
         state.resource.take();
         drop(state);
         self.remove_entry(&key, &entry);
 
-        Ok(true)
+        (true, result)
     }
 }
 
@@ -560,32 +562,23 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn release_with_cleanup_error_retains_last_reference_for_retry() {
+    async fn release_with_cleanup_error_releases_last_reference() {
         let map = AsyncSharedMap::<u64, u64>::new();
         map.insert::<StringError>(1, Arc::new(7)).await.unwrap();
 
-        let result = map
+        let (released, result) = map
             .release_with_cleanup(1, |last| async move {
                 assert!(last);
                 Err::<(), _>(StringError::from("cleanup failed"))
             })
             .await;
-        assert!(result.is_err());
-        assert_eq!(*map.get(&1).await.unwrap(), 7);
-
-        let released = map
-            .release_with_cleanup(1, |last| async move {
-                assert!(last);
-                Ok::<_, StringError>(())
-            })
-            .await
-            .unwrap();
         assert!(released);
+        assert!(result.is_err());
         assert!(map.get(&1).await.is_none());
     }
 
     #[tokio::test]
-    async fn release_with_cleanup_error_does_not_decrement_shared_reference() {
+    async fn release_with_cleanup_error_decrements_shared_reference() {
         let map = AsyncSharedMap::<u64, u64>::new();
         let first = map
             .get_or_create(1, async { Ok::<_, StringError>(Arc::new(7)) })
@@ -597,32 +590,24 @@ mod tests {
             .unwrap();
         assert!(Arc::ptr_eq(&first, &second));
 
-        let result = map
+        let (released, result) = map
             .release_with_cleanup(1, |last| async move {
                 assert!(!last);
                 Err::<(), _>(StringError::from("flush failed"))
             })
             .await;
-        assert!(result.is_err());
-
-        let released = map
-            .release_with_cleanup(1, |last| async move {
-                assert!(!last);
-                Ok::<_, StringError>(())
-            })
-            .await
-            .unwrap();
         assert!(!released);
+        assert!(result.is_err());
         assert!(map.get(&1).await.is_some());
 
-        let released = map
+        let (released, result) = map
             .release_with_cleanup(1, |last| async move {
                 assert!(last);
                 Ok::<_, StringError>(())
             })
-            .await
-            .unwrap();
+            .await;
         assert!(released);
+        assert!(result.is_ok());
         assert!(map.get(&1).await.is_none());
     }
 


### PR DESCRIPTION
# Summary

Release FUSE file handles and shared-writer references even when writer cleanup fails. Cleanup errors are still returned to the caller, while in-memory ownership now continues to match the handle lifecycle reported by the kernel.

# Issue Describe / Design

This is a standalone bug fix discovered after #1218; there is no dedicated issue to close.

## Root cause

#1218 retained the file handle and shared-writer reference when `flush` or `complete` failed. However, the kernel sends `RELEASE` once and does not retry or wait for its result. Keeping those active references therefore made `has_open_handles` and the writer reference count permanently larger than the kernel-owned handle count.

## Reproduction steps

1. Open a writable FUSE handle and make `flush` or `complete` fail during `RELEASE`.
2. Observe that the kernel has released the handle, but the old path retains both the handle and writer reference in memory.
3. Observe stale open-handle state and incorrect writer accounting because no second `RELEASE` is expected.

## Fix approach

- Attempt writer cleanup before releasing the reference, preserving the required flush-versus-complete decision.
- Consume the shared-writer reference regardless of the cleanup result.
- Remove the FUSE handle regardless of the cleanup result.
- Return the cleanup error separately so the release path still reports and logs the failure.
- Keep retriable backend cleanup separate from active kernel-handle ownership; the broader retry mechanism remains tracked by #1221.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `orpc/src/sync/async_map.rs` | Return release status and cleanup result separately, and consume the reference after every cleanup attempt | Failed cleanup no longer leaves a stale active reference |
| `curvine-fuse/src/fs/state/node_state.rs` | Always remove a released handle while continuing to propagate `flush`/`complete` errors | Handle and writer counts remain aligned with kernel ownership |
| `curvine-fuse/src/fs/state/node_state.rs` tests | Cover single-handle and shared-writer cleanup failures | Prevents stale-handle and incorrect reference-count regressions |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `make format` | PASS | Run in the remote Linux development environment |
| Workspace Clippy | PASS | Run in the remote Linux development environment |
| `cargo test -p orpc sync::async_map::tests -- --nocapture` | PASS | 12 passed |
| `cargo test -p curvine-fuse --lib fs::state::node_state::test:: -- --nocapture --test-threads=1` | PASS | 9 passed, including `/dev/full` cleanup-failure injection |
| Real FUSE mount E2E | NOT RUN | A normal mount does not deterministically trigger the cleanup-failure branch; focused fault-injection tests cover the changed path |

# Dependencies

- Related PRs: #1218
- Related issues: #1221
- Blocks / blocked by: None