### PR TITLE
fix(fuse): enforce POSIX file open permissions

### DIFF
--- a/crates/common/curvine-config/src/fuse_conf.rs
+++ b/crates/common/curvine-config/src/fuse_conf.rs
@@ -474,9 +474,18 @@ impl FuseConf {
 
     pub fn set_fuse_opts(&self, mount_options: &mut String) {
         let mut ro_added = false;
+        let mut default_permissions_added = false;
         if self.readonly {
             mount_options.push_str(",ro");
             ro_added = true;
+        }
+
+        // The kernel can distinguish an executable load from a normal read while
+        // FUSE_OPEN only exposes O_RDONLY for both. Keep permission enforcement in
+        // the VFS whenever Curvine permission checks are enabled.
+        if self.check_permission {
+            mount_options.push_str(",default_permissions");
+            default_permissions_added = true;
         }
 
         self.fuse_opts.iter().for_each(|opt| match opt.as_str() {
@@ -487,7 +496,10 @@ impl FuseConf {
                 }
             }
             "default_permissions" => {
-                mount_options.push_str(",default_permissions");
+                if !default_permissions_added {
+                    mount_options.push_str(",default_permissions");
+                    default_permissions_added = true;
+                }
             }
             "allow_other" => {
                 mount_options.push_str(",allow_other");
@@ -875,6 +887,57 @@ max_readahead_kb = 1024
             mount_options.split(',').filter(|opt| *opt == "ro").count(),
             1
         );
+    }
+
+    #[test]
+    fn permission_checks_enable_kernel_default_permissions() {
+        let conf = FuseConf {
+            check_permission: true,
+            ..Default::default()
+        };
+        let mut mount_options = String::new();
+        conf.set_fuse_opts(&mut mount_options);
+
+        assert_eq!(
+            mount_options
+                .split(',')
+                .filter(|opt| *opt == "default_permissions")
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn explicit_default_permissions_is_not_duplicated() {
+        let conf = FuseConf {
+            check_permission: true,
+            fuse_opts: vec!["default_permissions".to_string()],
+            ..Default::default()
+        };
+        let mut mount_options = String::new();
+        conf.set_fuse_opts(&mut mount_options);
+
+        assert_eq!(
+            mount_options
+                .split(',')
+                .filter(|opt| *opt == "default_permissions")
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn disabled_permission_checks_do_not_force_default_permissions() {
+        let conf = FuseConf {
+            check_permission: false,
+            ..Default::default()
+        };
+        let mut mount_options = String::new();
+        conf.set_fuse_opts(&mut mount_options);
+
+        assert!(!mount_options
+            .split(',')
+            .any(|opt| opt == "default_permissions"));
     }
 
     #[test]

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::fs::dcache::CleanerTask;
+use crate::fs::dcache::{CleanerTask, Inode};
 use crate::fs::operator::*;
 use crate::fs::plock_wait_registry::{LockOwner, PlockWaitGuard, PlockWaitRegistry};
 use crate::fs::state::{FileHandle, NodeState};
@@ -406,6 +406,10 @@ impl CurvineFileSystem {
         }
     }
 
+    fn traversal_cached_status(inode: &Inode, meta_ttl: u64) -> Option<FileStatus> {
+        inode.cache_valid(meta_ttl).then(|| inode.clone_status())
+    }
+
     /// Linux root access(2) bypasses R_OK/W_OK but still validates X_OK against any
     /// execute bit in the file mode, not the caller's owner/group/other class.
     fn check_root_access_permissions(status: &FileStatus) -> FuseResult<()> {
@@ -459,9 +463,7 @@ impl CurvineFileSystem {
                 match dir.get_inode(dir_ino, None) {
                     Some(inode) => {
                         let is_root = inode.is_root();
-                        let status = inode
-                            .cache_valid(meta_ttl)
-                            .then(|| inode.clone_status());
+                        let status = Self::traversal_cached_status(inode, meta_ttl);
                         (is_root, status)
                     }
                     None => (false, None),
@@ -1943,8 +1945,9 @@ impl fs::FileSystem for CurvineFileSystem {
 
 #[cfg(test)]
 mod tests {
+    use crate::fs::dcache::Inode;
     use crate::{FATTR_ATIME_NOW, FATTR_GID, FATTR_MODE, FATTR_MTIME, FATTR_MTIME_NOW, FATTR_UID};
-    use curvine_common::state::{FileAllocMode, FileType, INTERNAL_CTIME_XATTR};
+    use curvine_common::state::{FileAllocMode, FileStatus, FileType, INTERNAL_CTIME_XATTR};
 
     #[test]
     fn userspace_open_checks_only_unambiguous_write_modes() {
@@ -1963,6 +1966,27 @@ mod tests {
             CurvineFileSystem::open_userspace_acl_mask(OpenAction::ReadWrite),
             Some((libc::R_OK | libc::W_OK) as u32)
         );
+    }
+
+    #[test]
+    fn traversal_ignores_synthetic_root_until_backend_status_is_loaded() {
+        use super::CurvineFileSystem;
+
+        let mut root = Inode::new_root();
+        let meta_ttl = 60_000;
+        assert!(CurvineFileSystem::traversal_cached_status(&root, meta_ttl).is_none());
+
+        root.update_status(FileStatus {
+            is_dir: true,
+            mode: 0o755,
+            ..Default::default()
+        });
+
+        let status = CurvineFileSystem::traversal_cached_status(&root, meta_ttl).unwrap();
+        assert_eq!(status.mode, 0o755);
+
+        root.invalid_cache();
+        assert!(CurvineFileSystem::traversal_cached_status(&root, meta_ttl).is_none());
     }
 
     #[test]

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -395,6 +395,17 @@ impl CurvineFileSystem {
         self.check_access_permissions(&status, header, mask)
     }
 
+    /// Read-only FUSE opens cannot distinguish an executable load from a normal
+    /// read, so the kernel handles those through `default_permissions`. Write
+    /// modes remain unambiguous and keep the userspace check as defense in depth.
+    fn open_userspace_acl_mask(action: OpenAction) -> Option<u32> {
+        match action {
+            OpenAction::ReadOnly => None,
+            OpenAction::WriteOnly => Some(libc::W_OK as u32),
+            OpenAction::ReadWrite => Some((libc::R_OK | libc::W_OK) as u32),
+        }
+    }
+
     /// Linux root access(2) bypasses R_OK/W_OK but still validates X_OK against any
     /// execute bit in the file mode, not the caller's owner/group/other class.
     fn check_root_access_permissions(status: &FileStatus) -> FuseResult<()> {
@@ -443,19 +454,20 @@ impl CurvineFileSystem {
                 nodeid: dir_ino,
                 ..Default::default()
             };
-            // Only trust ACL bits from a valid dcache entry. The mount-root placeholder
-            // starts as Lifecycle::Invalid; using it fail-closes every non-root traverse
-            // with EACCES (breaks LTP chmod/chown under nobody).
-            let cached_status = {
+            let (is_root, cached_status) = {
                 let dir = self.state.dir_read();
-                dir.get_inode(dir_ino, None).and_then(|inode| {
-                    if inode.cache_valid(meta_ttl) {
-                        Some(inode.clone_status())
-                    } else {
-                        None
+                match dir.get_inode(dir_ino, None) {
+                    Some(inode) => {
+                        let is_root = inode.is_root();
+                        let status = inode
+                            .cache_valid(meta_ttl)
+                            .then(|| inode.clone_status());
+                        (is_root, status)
                     }
-                })
+                    None => (false, None),
+                }
             };
+
             if let Some(status) = cached_status {
                 self.check_access_permissions(&status, &check_header, libc::X_OK as u32)?;
             } else {
@@ -463,10 +475,6 @@ impl CurvineFileSystem {
                     .await?;
             }
 
-            let is_root = {
-                let dir = self.state.dir_read();
-                dir.get_inode_check(dir_ino, None)?.is_root()
-            };
             if is_root {
                 break;
             }
@@ -1399,7 +1407,6 @@ impl fs::FileSystem for CurvineFileSystem {
             if action.write() || truncate {
                 return err_fuse!(libc::EACCES, "special file nodes are read-only metadata");
             }
-            self.check_permissions(op.header, action.acl_mask()).await?;
             let ino = op.header.nodeid;
             let handle = self.state.new_meta_handle(ino, status).await?;
             let open_flags = FuseUtils::file_open_flags(&self.conf, false);
@@ -1414,8 +1421,9 @@ impl fs::FileSystem for CurvineFileSystem {
             self.ensure_writable_path(&path, RpcCode::CreateFile)
                 .await?;
         }
-        self.check_permissions(op.header, action.acl_mask()).await?;
-
+        if let Some(mask) = Self::open_userspace_acl_mask(action) {
+            self.check_permissions(op.header, mask).await?;
+        }
         let ino = op.header.nodeid;
         let opts = FuseUtils::open_opts(&self.fs);
 
@@ -1937,6 +1945,25 @@ impl fs::FileSystem for CurvineFileSystem {
 mod tests {
     use crate::{FATTR_ATIME_NOW, FATTR_GID, FATTR_MODE, FATTR_MTIME, FATTR_MTIME_NOW, FATTR_UID};
     use curvine_common::state::{FileAllocMode, FileType, INTERNAL_CTIME_XATTR};
+
+    #[test]
+    fn userspace_open_checks_only_unambiguous_write_modes() {
+        use super::CurvineFileSystem;
+        use crate::fs::operator::OpenAction;
+
+        assert_eq!(
+            CurvineFileSystem::open_userspace_acl_mask(OpenAction::ReadOnly),
+            None
+        );
+        assert_eq!(
+            CurvineFileSystem::open_userspace_acl_mask(OpenAction::WriteOnly),
+            Some(libc::W_OK as u32)
+        );
+        assert_eq!(
+            CurvineFileSystem::open_userspace_acl_mask(OpenAction::ReadWrite),
+            Some((libc::R_OK | libc::W_OK) as u32)
+        );
+    }
 
     #[test]
     fn posix_access_requires_mode_check_for_root() {

--- a/curvine-fuse/src/fs/state/node_state.rs
+++ b/curvine-fuse/src/fs/state/node_state.rs
@@ -929,18 +929,22 @@ impl NodeState {
         let path = self.get_path_common(ino, name)?;
         let status = self.fs.get_status(&path).await?;
 
+        self.cache_resolved_status(ino, name, &status);
+
+        Ok(status)
+    }
+
+    fn cache_resolved_status(&self, ino: u64, name: Option<&str>, status: &FileStatus) {
         // The root inode starts as synthetic metadata with mode 0. Cache its first
         // real backend status even when the general metadata cache is disabled so
         // every path traversal does not issue another root get_status RPC.
         let cache_root = ino == FUSE_ROOT_ID && name.is_none();
         if self.enable_meta_cache || cache_root {
-            let _ = self.update_status(ino, name, &status);
+            let _ = self.update_status(ino, name, status);
             if self.enable_meta_cache {
                 self.record_status_cache(CACHE_RESULT_PUT);
             }
         }
-
-        Ok(status)
     }
 
     pub async fn fs_mkdir(&self, ino: u64, name: &str, opts: MkdirOpts) -> FuseResult<fuse_attr> {
@@ -1360,6 +1364,37 @@ mod test {
         assert!(NodeState::map_remove_handle(&mut map, 2, 21).1);
         assert!(map.get(&2).is_none());
         assert!(!NodeState::map_remove_handle(&mut map, 2, 99).1);
+    }
+
+    #[test]
+    fn resolved_root_status_is_cached_when_metadata_cache_is_disabled() {
+        let rt = Arc::new(AsyncRuntime::single());
+        let fs = UnifiedFileSystem::with_rt(ClusterConf::default(), rt).unwrap();
+        let state = NodeState::new(fs).unwrap();
+        assert!(!state.enable_meta_cache);
+        assert_eq!(
+            state
+                .dir_read()
+                .get_inode(FUSE_ROOT_ID, None)
+                .unwrap()
+                .lifecycle,
+            crate::fs::dcache::Lifecycle::Invalid
+        );
+
+        state.cache_resolved_status(
+            FUSE_ROOT_ID,
+            None,
+            &FileStatus {
+                is_dir: true,
+                mode: 0o755,
+                ..Default::default()
+            },
+        );
+
+        let dir = state.dir_read();
+        let root = dir.get_inode(FUSE_ROOT_ID, None).unwrap();
+        assert_eq!(root.lifecycle, crate::fs::dcache::Lifecycle::Cached);
+        assert_eq!(root.mode, 0o755);
     }
 
     #[test]

--- a/curvine-fuse/src/fs/state/node_state.rs
+++ b/curvine-fuse/src/fs/state/node_state.rs
@@ -929,9 +929,15 @@ impl NodeState {
         let path = self.get_path_common(ino, name)?;
         let status = self.fs.get_status(&path).await?;
 
-        if self.enable_meta_cache {
+        // The root inode starts as synthetic metadata with mode 0. Cache its first
+        // real backend status even when the general metadata cache is disabled so
+        // every path traversal does not issue another root get_status RPC.
+        let cache_root = ino == FUSE_ROOT_ID && name.is_none();
+        if self.enable_meta_cache || cache_root {
             let _ = self.update_status(ino, name, &status);
-            self.record_status_cache(CACHE_RESULT_PUT);
+            if self.enable_meta_cache {
+                self.record_status_cache(CACHE_RESULT_PUT);
+            }
         }
 
         Ok(status)


### PR DESCRIPTION
**Summary**

Fix FUSE file-open permission handling for execute-only files and non-root write opens, and correct traversal checks at the mounted backend root.

Linux opens an executable through an internal read-only FUSE handle even when the caller only requires execute permission. Curvine previously interpreted that `FUSE_OPEN(O_RDONLY)` as an ordinary read and required `R_OK`, which incorrectly rejected valid execute-only files. Separately, path traversal could check the synthetic FUSE root inode before its real backend metadata had been loaded, causing valid non-root operations to fail against a synthetic mode of zero.

**Minimal Reproducer**

Create a small executable and make it executable but not readable by the test user:

```bash
cat >/tmp/execute-only.c <<'EOF'
#include <stdio.h>

int main(void)
{
    puts("execute-only file ran successfully");
    return 0;
}
EOF

gcc -Wall -O2 /tmp/execute-only.c -o /mnt/curvine/execute-only
chown 99:99 /mnt/curvine/execute-only
chmod 0100 /mnt/curvine/execute-only
```

Execute it as the owner:

```bash
setpriv --reuid=99 --regid=500 --clear-groups \
    /mnt/curvine/execute-only
```

Before the fix, the kernel sent `FUSE_OPEN(O_RDONLY)` while loading the executable. Curvine mapped that request to `R_OK`, so the command failed with `EACCES` even though owner execute permission was present.

The related write failure can be reproduced with a writable file owned by a non-root user:

```bash
touch /mnt/curvine/write-only
chown 99:99 /mnt/curvine/write-only
chmod 0200 /mnt/curvine/write-only

setpriv --reuid=99 --regid=500 --clear-groups \
    sh -c 'printf data > /mnt/curvine/write-only'
```

The writable open succeeded, but the following truncate-related `SETATTR` could fail while traversing the synthetic FUSE root inode with mode zero.

**Root Cause**

Curvine performed file-open permission checks entirely in userspace based on the access mode in `fuse_open_in.flags`:

```text
O_RDONLY -> R_OK
O_WRONLY -> W_OK
O_RDWR   -> R_OK | W_OK
```

This mapping is valid for ordinary `open(2)` calls, but it cannot represent an executable load. The Linux VFS checks execute permission before loading the file, then sends an internal read-only open to the FUSE daemon. The FUSE open request does not expose a reliable flag that distinguishes this internal open from a normal read. Requiring `R_OK` in the daemon therefore rejects execute-only files, while simply removing read checks without kernel permission enforcement would allow ordinary reads of those files.

The correct distinction is available inside the kernel permission path. The FUSE `default_permissions` mount option lets the VFS enforce the original operation's permission mask before dispatching the request to userspace.

Write-only and read-write opens remain unambiguous in the FUSE request, so Curvine keeps their userspace `W_OK` and `R_OK | W_OK` checks as defense in depth and to preserve fresh backend permission validation.

The traversal failure had a separate cause. `Inode::new_root()` creates a synthetic dcache root before backend metadata is available. Its initial `FileStatus` has mode zero. The traversal check used that synthetic status as if it were authoritative, so non-root operations below the mount root could be denied even when the real exported directory was searchable.

**Changes**

- Add `default_permissions` automatically when Curvine permission checking is enabled, without duplicating an explicitly configured mount option.
- Delegate read-only open permission decisions to the kernel so executable loading is distinguished from ordinary reading.
- Retain userspace permission checks for `WriteOnly` and `ReadWrite` opens.
- Resolve the real backend root status before using it for traversal checks.
- Cache the resolved root status in the dcache even when the general metadata cache is disabled, avoiding an extra root metadata RPC on every traversal.
- Add unit coverage for mount-option generation and per-open userspace masks.

**Deployment Note**

`default_permissions` is fixed when the FUSE connection is mounted. Upgrading from a version that did not enable this option requires stopping and remounting the FUSE client. A hot reload that inherits the existing `/dev/fuse` file descriptor does not change the original mount options.

Master and worker processes do not need to restart for this FUSE-only change.

**Verification**

- `cargo test -p curvine-fuse --lib -- --test-threads=1` passes: `295 passed`.
- FUSE configuration tests pass: `36 passed`.
- `cargo build --release -p curvine-fuse` passes.
- `make format` passes, including workspace release checks.
- `git diff --check` passes.
