### PR TITLE
feat(libsdk): add Java load job client APIs (#1288)

### DIFF
--- a/curvine-libsdk/java/pom.xml
+++ b/curvine-libsdk/java/pom.xml
@@ -304,7 +304,7 @@
                         <include>master.proto</include>
                         <include>worker.proto</include>
                         <include>mount.proto</include>
-                        <include>load.proto</include>
+                        <include>job.proto</include>
                     </includes>
                     <skip>false</skip>
                 </configuration>

--- a/curvine-libsdk/java/pom.xml
+++ b/curvine-libsdk/java/pom.xml
@@ -310,7 +310,8 @@
                 </configuration>
                 <executions>
                     <execution>
-                        <phase>compile</phase>
+                        <!-- Run before scala/java compile (process-resources) so clean mvn test works. -->
+                        <phase>generate-sources</phase>
                         <goals>
                             <goal>compile</goal>
                         </goals>

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineLoadClient.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineLoadClient.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.Objects;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Independent Java client for Curvine load jobs.
@@ -51,7 +52,7 @@ public final class CurvineLoadClient implements Closeable {
     private static final long SUCCESS = 0;
 
     private final long nativeHandle;
-    private volatile boolean closed;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
 
     private CurvineLoadClient(long nativeHandle) {
         this.nativeHandle = nativeHandle;
@@ -139,7 +140,7 @@ public final class CurvineLoadClient implements Closeable {
             throw new IllegalArgumentException("pollInterval must be positive");
         }
 
-        long deadlineNanos = System.nanoTime() + timeout.toNanos();
+        long deadlineNanos = saturatingDeadlineNanos(timeout);
         LoadJobStatus status;
         while (true) {
             status = getJobStatus(jobId);
@@ -153,15 +154,13 @@ public final class CurvineLoadClient implements Closeable {
                                 ? ": " + status.getProgress().getMessage()
                                 : ""));
             }
-            if (System.nanoTime() >= deadlineNanos) {
+            long remainingNanos = deadlineNanos - System.nanoTime();
+            if (remainingNanos <= 0L) {
                 throw new TimeoutException(
                         "load job " + jobId + " not complete after " + timeout
                                 + ", last state=" + status.getState());
             }
-            long sleepMs = Math.min(
-                    pollInterval.toMillis(),
-                    Math.max(1L, (deadlineNanos - System.nanoTime()) / 1_000_000L));
-            Thread.sleep(sleepMs);
+            sleepNanos(Math.min(pollInterval.toNanos(), remainingNanos));
         }
     }
 
@@ -175,10 +174,9 @@ public final class CurvineLoadClient implements Closeable {
 
     @Override
     public void close() throws IOException {
-        if (closed) {
+        if (!closed.compareAndSet(false, true)) {
             return;
         }
-        closed = true;
         long errno = CurvineNative.closeFilesystem(nativeHandle);
         if (errno < SUCCESS) {
             throw CurvineException.create((int) errno, "close CurvineLoadClient failed");
@@ -186,9 +184,28 @@ public final class CurvineLoadClient implements Closeable {
     }
 
     private void ensureOpen() throws IOException {
-        if (closed) {
+        if (closed.get()) {
             throw new IOException("CurvineLoadClient is closed");
         }
+    }
+
+    /** Compute {@code nanoTime + timeout} without wrapping on overflow. */
+    static long saturatingDeadlineNanos(Duration timeout) {
+        long now = System.nanoTime();
+        long timeoutNanos = timeout.toNanos();
+        try {
+            return Math.addExact(now, timeoutNanos);
+        } catch (ArithmeticException overflow) {
+            return Long.MAX_VALUE;
+        }
+    }
+
+    /** Sleep at least 1ns to avoid busy-looping when the interval truncates to 0ms. */
+    static void sleepNanos(long nanos) throws InterruptedException {
+        long sleepNanos = Math.max(1L, nanos);
+        long sleepMs = sleepNanos / 1_000_000L;
+        int nanoPart = (int) (sleepNanos % 1_000_000L);
+        Thread.sleep(sleepMs, nanoPart);
     }
 
     private static void requireJobId(String jobId) {

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineLoadClient.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineLoadClient.java
@@ -1,0 +1,205 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.curvine;
+
+import io.curvine.exception.CurvineException;
+import io.curvine.proto.GetJobStatusResponse;
+import io.curvine.proto.SubmitJobResponse;
+import org.apache.hadoop.conf.Configuration;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Independent Java client for Curvine load jobs.
+ *
+ * <p>Mirrors Rust libsdk {@code JobClient}: submit / get status / cancel, plus a
+ * Java-side wait helper with explicit timeout and poll interval.
+ *
+ * <pre>{@code
+ * try (CurvineLoadClient client = CurvineLoadClient.from(conf)) {
+ *     LoadJobResult result = client.submitLoad(
+ *             LoadJobRequest.builder()
+ *                     .sourcePath("oss://bucket/path/file")
+ *                     .targetPath("/mnt/path/file")
+ *                     .overwrite(true)
+ *                     .build());
+ *     LoadJobStatus status = client.waitJobComplete(
+ *             result.getJobId(), Duration.ofMinutes(10), Duration.ofSeconds(1));
+ * }
+ * }</pre>
+ *
+ * <p>Load remains UFS-to-Curvine and must stay inside an existing mount mapping;
+ * this client does not implement arbitrary URI copy.
+ */
+public final class CurvineLoadClient implements Closeable {
+    private static final long SUCCESS = 0;
+
+    private final long nativeHandle;
+    private volatile boolean closed;
+
+    private CurvineLoadClient(long nativeHandle) {
+        this.nativeHandle = nativeHandle;
+    }
+
+    public static CurvineLoadClient from(FilesystemConf conf) throws IOException {
+        Objects.requireNonNull(conf, "conf");
+        try {
+            long handle = CurvineNative.newFilesystem(conf.toToml());
+            if (handle < SUCCESS) {
+                throw CurvineException.create((int) handle, "failed to create CurvineLoadClient");
+            }
+            return new CurvineLoadClient(handle);
+        } catch (IllegalAccessException e) {
+            throw new IOException("failed to serialize FilesystemConf", e);
+        }
+    }
+
+    public static CurvineLoadClient from(Configuration conf) throws IOException {
+        try {
+            return from(new FilesystemConf(conf));
+        } catch (IllegalAccessException e) {
+            throw new IOException("failed to build FilesystemConf", e);
+        }
+    }
+
+    /**
+     * Submit a load job. Equivalent to Rust {@code JobClient::submit_load_job}.
+     */
+    public LoadJobResult submitLoad(LoadJobRequest request) throws IOException {
+        ensureOpen();
+        Objects.requireNonNull(request, "request");
+        byte[] bytes = CurvineNative.submitLoadJob(
+                nativeHandle,
+                request.getSourcePath(),
+                request.getTargetPath(),
+                request.isOverwrite());
+        checkBytes(bytes);
+        return LoadJobResult.fromProto(SubmitJobResponse.parseFrom(bytes));
+    }
+
+    /**
+     * Query job status by id. Equivalent to Rust {@code JobClient::get_status}.
+     */
+    public LoadJobStatus getJobStatus(String jobId) throws IOException {
+        ensureOpen();
+        requireJobId(jobId);
+        byte[] bytes = CurvineNative.getJobStatus(nativeHandle, jobId);
+        checkBytes(bytes);
+        return LoadJobStatus.fromProto(GetJobStatusResponse.parseFrom(bytes));
+    }
+
+    /**
+     * Cancel a job by id. Equivalent to Rust {@code JobClient::cancel}.
+     */
+    public void cancelJob(String jobId) throws IOException {
+        ensureOpen();
+        requireJobId(jobId);
+        long errno = CurvineNative.cancelJob(nativeHandle, jobId);
+        if (errno < SUCCESS) {
+            throw CurvineException.create((int) errno, "cancelJob failed: " + jobId);
+        }
+    }
+
+    /**
+     * Poll job status until finished or timeout.
+     *
+     * @param jobId        job id from {@link #submitLoad}
+     * @param timeout      max wait duration
+     * @param pollInterval sleep between status queries
+     * @return final status when the job reaches a terminal state
+     * @throws TimeoutException if the job is still running after {@code timeout}
+     * @throws IOException      if the job fails / is canceled, or RPC fails
+     */
+    public LoadJobStatus waitJobComplete(String jobId, Duration timeout, Duration pollInterval)
+            throws IOException, TimeoutException, InterruptedException {
+        ensureOpen();
+        requireJobId(jobId);
+        Objects.requireNonNull(timeout, "timeout");
+        Objects.requireNonNull(pollInterval, "pollInterval");
+        if (timeout.isNegative() || timeout.isZero()) {
+            throw new IllegalArgumentException("timeout must be positive");
+        }
+        if (pollInterval.isNegative() || pollInterval.isZero()) {
+            throw new IllegalArgumentException("pollInterval must be positive");
+        }
+
+        long deadlineNanos = System.nanoTime() + timeout.toNanos();
+        LoadJobStatus status;
+        while (true) {
+            status = getJobStatus(jobId);
+            if (status.isFinished()) {
+                if (status.isSuccessful()) {
+                    return status;
+                }
+                throw new IOException(
+                        "load job " + jobId + " ended with state " + status.getState()
+                                + (status.getProgress() != null
+                                ? ": " + status.getProgress().getMessage()
+                                : ""));
+            }
+            if (System.nanoTime() >= deadlineNanos) {
+                throw new TimeoutException(
+                        "load job " + jobId + " not complete after " + timeout
+                                + ", last state=" + status.getState());
+            }
+            long sleepMs = Math.min(
+                    pollInterval.toMillis(),
+                    Math.max(1L, (deadlineNanos - System.nanoTime()) / 1_000_000L));
+            Thread.sleep(sleepMs);
+        }
+    }
+
+    /**
+     * Convenience wait with 1s poll interval.
+     */
+    public LoadJobStatus waitJobComplete(String jobId, Duration timeout)
+            throws IOException, TimeoutException, InterruptedException {
+        return waitJobComplete(jobId, timeout, Duration.ofSeconds(1));
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        long errno = CurvineNative.closeFilesystem(nativeHandle);
+        if (errno < SUCCESS) {
+            throw CurvineException.create((int) errno, "close CurvineLoadClient failed");
+        }
+    }
+
+    private void ensureOpen() throws IOException {
+        if (closed) {
+            throw new IOException("CurvineLoadClient is closed");
+        }
+    }
+
+    private static void requireJobId(String jobId) {
+        if (jobId == null || jobId.trim().isEmpty()) {
+            throw new IllegalArgumentException("jobId cannot be empty");
+        }
+    }
+
+    private static void checkBytes(byte[] bytes) throws IOException {
+        if (bytes == null) {
+            throw new CurvineException("native load job call returned null");
+        }
+    }
+}

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineNative.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineNative.java
@@ -330,4 +330,27 @@ public class CurvineNative {
     public static native byte[] getMountInfo(long nativeHandle, String path) throws IOException;
 
     public static native String togglePath(long nativeHandle, String path, boolean checkCache) throws IOException;
+
+    /**
+     * Submit a UFS-to-Curvine load job.
+     *
+     * @param nativeHandle filesystem native handle
+     * @param sourcePath UFS path or mounted CV path
+     * @param targetPath optional explicit CV target path; may be null
+     * @param overwrite whether to overwrite existing target
+     * @return serialized {@code SubmitJobResponse} protobuf bytes
+     */
+    public static native byte[] submitLoadJob(
+            long nativeHandle, String sourcePath, String targetPath, boolean overwrite)
+            throws IOException;
+
+    /**
+     * Query load job status by job id.
+     *
+     * @return serialized {@code GetJobStatusResponse} protobuf bytes
+     */
+    public static native byte[] getJobStatus(long nativeHandle, String jobId) throws IOException;
+
+    /** Cancel a load job by job id. */
+    public static native long cancelJob(long nativeHandle, String jobId) throws IOException;
 }

--- a/curvine-libsdk/java/src/main/java/io/curvine/LoadJobRequest.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/LoadJobRequest.java
@@ -1,0 +1,83 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.curvine;
+
+/**
+ * Request to submit a UFS-to-Curvine load job.
+ *
+ * <p>Aligned with CLI {@code cv load} / Rust {@code LoadJobCommand} minimal fields.
+ */
+public final class LoadJobRequest {
+    private final String sourcePath;
+    private final String targetPath;
+    private final boolean overwrite;
+
+    private LoadJobRequest(Builder builder) {
+        this.sourcePath = builder.sourcePath;
+        this.targetPath = builder.targetPath;
+        this.overwrite = builder.overwrite;
+    }
+
+    public String getSourcePath() {
+        return sourcePath;
+    }
+
+    /** Optional explicit CV target path; may be {@code null}. */
+    public String getTargetPath() {
+        return targetPath;
+    }
+
+    public boolean isOverwrite() {
+        return overwrite;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private String sourcePath;
+        private String targetPath;
+        private boolean overwrite = true;
+
+        private Builder() {
+        }
+
+        public Builder sourcePath(String sourcePath) {
+            this.sourcePath = sourcePath;
+            return this;
+        }
+
+        public Builder targetPath(String targetPath) {
+            this.targetPath = targetPath;
+            return this;
+        }
+
+        public Builder overwrite(boolean overwrite) {
+            this.overwrite = overwrite;
+            return this;
+        }
+
+        public LoadJobRequest build() {
+            if (sourcePath == null || sourcePath.trim().isEmpty()) {
+                throw new IllegalArgumentException("sourcePath cannot be empty");
+            }
+            if (targetPath != null && targetPath.trim().isEmpty()) {
+                throw new IllegalArgumentException("targetPath cannot be empty when set");
+            }
+            return new LoadJobRequest(this);
+        }
+    }
+}

--- a/curvine-libsdk/java/src/main/java/io/curvine/LoadJobResult.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/LoadJobResult.java
@@ -1,0 +1,58 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.curvine;
+
+import io.curvine.proto.JobTaskStateProto;
+import io.curvine.proto.SubmitJobResponse;
+
+/**
+ * Outcome of submitting a load job. Mirrors Rust {@code LoadJobResult}.
+ */
+public final class LoadJobResult {
+    private final String jobId;
+    private final String targetPath;
+    private final JobTaskStateProto state;
+
+    public LoadJobResult(String jobId, String targetPath, JobTaskStateProto state) {
+        this.jobId = jobId;
+        this.targetPath = targetPath;
+        this.state = state;
+    }
+
+    public static LoadJobResult fromProto(SubmitJobResponse response) {
+        return new LoadJobResult(
+                response.getJobId(),
+                response.getTargetPath(),
+                response.getState());
+    }
+
+    public String getJobId() {
+        return jobId;
+    }
+
+    public String getTargetPath() {
+        return targetPath;
+    }
+
+    public JobTaskStateProto getState() {
+        return state;
+    }
+
+    @Override
+    public String toString() {
+        return "LoadJobResult{jobId='" + jobId + "', targetPath='" + targetPath
+                + "', state=" + state + '}';
+    }
+}

--- a/curvine-libsdk/java/src/main/java/io/curvine/LoadJobStatus.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/LoadJobStatus.java
@@ -1,0 +1,88 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.curvine;
+
+import io.curvine.proto.GetJobStatusResponse;
+import io.curvine.proto.JobTaskProgressProto;
+import io.curvine.proto.JobTaskStateProto;
+
+/**
+ * Load job status snapshot. Mirrors Rust {@code JobStatus}.
+ */
+public final class LoadJobStatus {
+    private final String jobId;
+    private final JobTaskStateProto state;
+    private final String sourcePath;
+    private final String targetPath;
+    private final JobTaskProgressProto progress;
+
+    public LoadJobStatus(
+            String jobId,
+            JobTaskStateProto state,
+            String sourcePath,
+            String targetPath,
+            JobTaskProgressProto progress) {
+        this.jobId = jobId;
+        this.state = state;
+        this.sourcePath = sourcePath;
+        this.targetPath = targetPath;
+        this.progress = progress;
+    }
+
+    public static LoadJobStatus fromProto(GetJobStatusResponse response) {
+        return new LoadJobStatus(
+                response.getJobId(),
+                response.getState(),
+                response.getSourcePath(),
+                response.getTargetPath(),
+                response.getProgress());
+    }
+
+    public String getJobId() {
+        return jobId;
+    }
+
+    public JobTaskStateProto getState() {
+        return state;
+    }
+
+    public String getSourcePath() {
+        return sourcePath;
+    }
+
+    public String getTargetPath() {
+        return targetPath;
+    }
+
+    public JobTaskProgressProto getProgress() {
+        return progress;
+    }
+
+    public boolean isFinished() {
+        return state == JobTaskStateProto.COMPLETED
+                || state == JobTaskStateProto.FAILED
+                || state == JobTaskStateProto.CANCELED;
+    }
+
+    public boolean isSuccessful() {
+        return state == JobTaskStateProto.COMPLETED;
+    }
+
+    @Override
+    public String toString() {
+        return "LoadJobStatus{jobId='" + jobId + "', state=" + state
+                + ", sourcePath='" + sourcePath + "', targetPath='" + targetPath + "'}";
+    }
+}

--- a/curvine-libsdk/java/src/test/java/io/curvine/LoadJobClientTest.java
+++ b/curvine-libsdk/java/src/test/java/io/curvine/LoadJobClientTest.java
@@ -1,0 +1,107 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.curvine;
+
+import io.curvine.proto.GetJobStatusResponse;
+import io.curvine.proto.JobTaskProgressProto;
+import io.curvine.proto.JobTaskStateProto;
+import io.curvine.proto.SubmitJobResponse;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LoadJobClientTest {
+
+    @Test
+    public void requestBuilderRequiresSource() {
+        try {
+            LoadJobRequest.builder().build();
+            Assert.fail("expected IllegalArgumentException");
+        } catch (IllegalArgumentException expected) {
+            Assert.assertTrue(expected.getMessage().contains("sourcePath"));
+        }
+    }
+
+    @Test
+    public void requestBuilderRejectsEmptyTarget() {
+        try {
+            LoadJobRequest.builder()
+                    .sourcePath("s3://bucket/a")
+                    .targetPath("   ")
+                    .build();
+            Assert.fail("expected IllegalArgumentException");
+        } catch (IllegalArgumentException expected) {
+            Assert.assertTrue(expected.getMessage().contains("targetPath"));
+        }
+    }
+
+    @Test
+    public void requestBuilderDefaultsOverwriteTrue() {
+        LoadJobRequest request = LoadJobRequest.builder()
+                .sourcePath("s3://bucket/a")
+                .targetPath("/mnt/a")
+                .build();
+        Assert.assertEquals("s3://bucket/a", request.getSourcePath());
+        Assert.assertEquals("/mnt/a", request.getTargetPath());
+        Assert.assertTrue(request.isOverwrite());
+    }
+
+    @Test
+    public void loadJobResultFromProto() {
+        SubmitJobResponse response = SubmitJobResponse.newBuilder()
+                .setJobId("job-1")
+                .setTargetPath("/mnt/a")
+                .setState(JobTaskStateProto.PENDING)
+                .build();
+        LoadJobResult result = LoadJobResult.fromProto(response);
+        Assert.assertEquals("job-1", result.getJobId());
+        Assert.assertEquals("/mnt/a", result.getTargetPath());
+        Assert.assertEquals(JobTaskStateProto.PENDING, result.getState());
+    }
+
+    @Test
+    public void loadJobStatusFinishedHelpers() {
+        LoadJobStatus completed = LoadJobStatus.fromProto(GetJobStatusResponse.newBuilder()
+                .setJobId("job-1")
+                .setState(JobTaskStateProto.COMPLETED)
+                .setSourcePath("s3://bucket/a")
+                .setTargetPath("/mnt/a")
+                .setProgress(JobTaskProgressProto.newBuilder()
+                        .setLoadedSize(10)
+                        .setTotalSize(10)
+                        .setUpdateTime(1)
+                        .setState(JobTaskStateProto.COMPLETED.getNumber())
+                        .setMessage("ok")
+                        .build())
+                .build());
+        Assert.assertTrue(completed.isFinished());
+        Assert.assertTrue(completed.isSuccessful());
+
+        LoadJobStatus failed = LoadJobStatus.fromProto(GetJobStatusResponse.newBuilder()
+                .setJobId("job-2")
+                .setState(JobTaskStateProto.FAILED)
+                .setSourcePath("s3://bucket/b")
+                .setTargetPath("/mnt/b")
+                .setProgress(JobTaskProgressProto.newBuilder()
+                        .setLoadedSize(0)
+                        .setTotalSize(0)
+                        .setUpdateTime(1)
+                        .setState(JobTaskStateProto.FAILED.getNumber())
+                        .setMessage("boom")
+                        .build())
+                .build());
+        Assert.assertTrue(failed.isFinished());
+        Assert.assertFalse(failed.isSuccessful());
+    }
+}

--- a/curvine-libsdk/java/src/test/java/io/curvine/LoadJobClientTest.java
+++ b/curvine-libsdk/java/src/test/java/io/curvine/LoadJobClientTest.java
@@ -21,6 +21,8 @@ import io.curvine.proto.SubmitJobResponse;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.time.Duration;
+
 public class LoadJobClientTest {
 
     @Test
@@ -103,5 +105,18 @@ public class LoadJobClientTest {
                 .build());
         Assert.assertTrue(failed.isFinished());
         Assert.assertFalse(failed.isSuccessful());
+    }
+
+    @Test
+    public void saturatingDeadlineDoesNotWrap() {
+        long deadline = CurvineLoadClient.saturatingDeadlineNanos(Duration.ofNanos(Long.MAX_VALUE));
+        Assert.assertEquals(Long.MAX_VALUE, deadline);
+    }
+
+    @Test
+    public void sleepNanosAcceptsSubMillisInterval() throws InterruptedException {
+        long start = System.nanoTime();
+        CurvineLoadClient.sleepNanos(500_000L); // 0.5ms
+        Assert.assertTrue(System.nanoTime() - start >= 500_000L);
     }
 }

--- a/curvine-libsdk/src/core/mod.rs
+++ b/curvine-libsdk/src/core/mod.rs
@@ -14,7 +14,7 @@
 
 mod filesystem;
 #[allow(dead_code)]
-mod job;
+pub(crate) mod job;
 #[allow(dead_code)]
 mod master;
 mod session;

--- a/curvine-libsdk/src/java/java_abi.rs
+++ b/curvine-libsdk/src/java/java_abi.rs
@@ -289,3 +289,42 @@ pub unsafe extern "C" fn Java_io_curvine_CurvineNative_togglePath(
     let fs = &*fs_ptr;
     java_err2!(env, fs.toggle_path(&mut env, path, check_cache))
 }
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_io_curvine_CurvineNative_submitLoadJob(
+    mut env: JNIEnv,
+    _this: JObject,
+    fs_ptr: *mut JavaFilesystem,
+    source_path: JString,
+    target_path: JString,
+    overwrite: jboolean,
+) -> jarray {
+    let fs = &*fs_ptr;
+    java_err2!(
+        env,
+        fs.submit_load_job(&mut env, source_path, target_path, overwrite)
+    )
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_io_curvine_CurvineNative_getJobStatus(
+    mut env: JNIEnv,
+    _this: JObject,
+    fs_ptr: *mut JavaFilesystem,
+    job_id: JString,
+) -> jarray {
+    let fs = &*fs_ptr;
+    java_err2!(env, fs.get_job_status(&mut env, job_id))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_io_curvine_CurvineNative_cancelJob(
+    mut env: JNIEnv,
+    _this: JObject,
+    fs_ptr: *mut JavaFilesystem,
+    job_id: JString,
+) -> jlong {
+    let fs = &*fs_ptr;
+    java_err!(env, fs.cancel_job(&mut env, job_id));
+    SUCCESS
+}

--- a/curvine-libsdk/src/java/java_filesystem.rs
+++ b/curvine-libsdk/src/java/java_filesystem.rs
@@ -12,8 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::core::job;
 use crate::java::JavaUtils;
 use crate::{FilesystemConf, LibFilesystem, LibFsReader, LibFsWriter};
+use curvine_common::proto::{GetJobStatusResponse, SubmitJobResponse};
+use curvine_common::state::LoadJobCommand;
+use curvine_common::utils::ProtoUtils;
 use curvine_common::FsResult;
 use jni::objects::JString;
 use jni::sys::{jarray, jboolean, jstring};
@@ -116,6 +120,64 @@ impl JavaFilesystem {
             .toggle_path(path, JavaUtils::jbool_to_bool(check_cache))?;
         let string = JavaUtils::new_jstring(env, ufs_path.map(|x| x.clone_display_path()))?;
         Ok(string)
+    }
+
+    /// Submit a UFS-to-Curvine load job. Mirrors Rust `JobClient::submit_load_job`.
+    pub fn submit_load_job(
+        &self,
+        env: &mut JNIEnv,
+        source_path: JString,
+        target_path: JString,
+        overwrite: jboolean,
+    ) -> FsResult<jarray> {
+        let source = JavaUtils::jstring_to_string(env, &source_path)?;
+        let target = if target_path.is_null() {
+            None
+        } else {
+            let value = JavaUtils::jstring_to_string(env, &target_path)?;
+            if value.trim().is_empty() {
+                None
+            } else {
+                Some(value)
+            }
+        };
+
+        let mut builder =
+            LoadJobCommand::builder(source).overwrite(JavaUtils::jbool_to_bool(overwrite));
+        if let Some(target) = target {
+            builder = builder.target_path(target);
+        }
+        let result = job::submit_load_job(self.inner.session(), builder.build())?;
+        let response = SubmitJobResponse {
+            job_id: result.job_id,
+            target_path: result.target_path,
+            state: i32::from(result.state as i8),
+        };
+        let bytes = ProtoUtils::encode(response)?;
+        let byte_arr = JavaUtils::new_jarray(env, &bytes)?;
+        Ok(byte_arr)
+    }
+
+    /// Query load job status by id. Mirrors Rust `JobClient::get_status`.
+    pub fn get_job_status(&self, env: &mut JNIEnv, job_id: JString) -> FsResult<jarray> {
+        let job_id = JavaUtils::jstring_to_string(env, &job_id)?;
+        let status = job::get_job_status(self.inner.session(), job_id)?;
+        let response = GetJobStatusResponse {
+            job_id: status.job_id,
+            state: i32::from(status.state as i8),
+            source_path: status.source_path,
+            target_path: status.target_path,
+            progress: ProtoUtils::work_progress_to_pb(status.progress),
+        };
+        let bytes = ProtoUtils::encode(response)?;
+        let byte_arr = JavaUtils::new_jarray(env, &bytes)?;
+        Ok(byte_arr)
+    }
+
+    /// Cancel a load job by id. Mirrors Rust `JobClient::cancel`.
+    pub fn cancel_job(&self, env: &mut JNIEnv, job_id: JString) -> FsResult<()> {
+        let job_id = JavaUtils::jstring_to_string(env, &job_id)?;
+        job::cancel_job(self.inner.session(), job_id)
     }
 
     pub fn cleanup(&self) {


### PR DESCRIPTION
# Summary

Add an independent Java `CurvineLoadClient` for Curvine load jobs (submit / status / cancel / wait), wired through JNI to the existing Rust `JobClient` / `core::job` path. Hadoop `FileSystem` APIs are unchanged.

# Issue Describe / Design

Closes #1288

Design decisions:
- Keep load APIs off `FileSystem` as a separate client (mirrors Rust libsdk `JobClient`).
- Reuse server-side mount validation and job RPC semantics; no arbitrary URI copy.
- Return protobuf `SubmitJobResponse` / `GetJobStatusResponse` bytes from JNI; Java models wrap them.
- Implement `waitJobComplete` in Java with explicit timeout/poll interval (matches issue API shape better than Rust conf-fixed wait).
- Fix Java protobuf include: `load.proto` → `job.proto`.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-libsdk/src/java/java_filesystem.rs` | Add submit/status/cancel via `core::job` | None |
| `curvine-libsdk/src/java/java_abi.rs` | JNI exports for load job methods | None |
| `curvine-libsdk/java/.../CurvineNative.java` | Native method declarations | None |
| `curvine-libsdk/java/.../CurvineLoadClient.java` | Independent Java load client | New API |
| `curvine-libsdk/java/.../LoadJob*.java` | Request/result/status models | New API |
| `curvine-libsdk/java/pom.xml` | Generate `job.proto` for Java | Fixes stale missing `load.proto` include |
| `curvine-libsdk/java/src/test/.../LoadJobClientTest.java` | Unit tests for models/helpers | None |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `make format` | PASS | format + clippy |
| `cargo check -p curvine-libsdk --features java-sdk` | PASS | |
| `mvn -Dtest=LoadJobClientTest test` | PASS | 5 tests |
| Cluster integration (submit/status/cancel/wait against live mount) | NOT RUN | Needs cluster + UFS mount; follow-up QA |

# Dependencies

- Related PRs: None
- Related issues: #1288
- Blocks / blocked by: None

Made with [Cursor](https://cursor.com)