### PR TITLE
fix(master): prevent oversized fallocate stalls

### DIFF
--- a/crates/common/curvine-error/src/fs_error.rs
+++ b/crates/common/curvine-error/src/fs_error.rs
@@ -320,6 +320,10 @@ impl FsError {
         Self::InvalidArgument(ErrorImpl::with_source(msg.into().into()))
     }
 
+    pub fn disk_out_of_space(msg: impl Into<String>) -> Self {
+        Self::DiskOutOfSpace(ErrorImpl::with_source(msg.into().into()))
+    }
+
     pub fn unsupported<T: Into<String>>(feature: T) -> Self {
         let msg = format!("{} is not implemented", feature.into());
         Self::Unsupported(ErrorImpl::with_source(msg.into()))

--- a/curvine-server/src/master/fs/master_filesystem.rs
+++ b/curvine-server/src/master/fs/master_filesystem.rs
@@ -82,6 +82,28 @@ impl MasterFilesystem {
     // Max block-report location updates applied under a single fs_dir write lock.
     const BLOCK_REPORT_WRITE_CHUNK: usize = 4096;
 
+    fn validate_alloc_capacity(
+        current_len: i64,
+        replicas: u8,
+        opts: &FileAllocOpts,
+        available: i64,
+    ) -> FsResult<()> {
+        if opts.truncate || opts.len <= current_len {
+            return Ok(());
+        }
+
+        let logical_growth = opts.len - current_len;
+        let required = logical_growth.saturating_mul(i64::from(replicas));
+        if required > available {
+            return err_ext!(FsError::disk_out_of_space(format!(
+                "fallocate requires {} bytes for {} replicas, but only {} bytes are available",
+                logical_growth, replicas, available
+            )));
+        }
+
+        Ok(())
+    }
+
     pub fn new(
         conf: &ClusterConf,
         fs_dir: SyncFsDir,
@@ -1186,10 +1208,18 @@ impl MasterFilesystem {
         opts.validate()?;
 
         let path = path.as_ref();
+        let available = if opts.truncate {
+            i64::MAX
+        } else {
+            self.worker_manager.read().available_bytes()
+        };
         let (del_res, inode_id) = {
             let mut fs_dir = self.fs_dir.write();
             let inp = Self::resolve_path(&fs_dir, path)?;
-            let inode_id = try_option!(inp.get_last_inode(), "File {} not exists", path).id();
+            let inode = try_option!(inp.get_last_inode(), "File {} not exists", path);
+            let file = inode.as_file_ref()?;
+            Self::validate_alloc_capacity(file.len, file.replicas, &opts, available)?;
+            let inode_id = inode.id();
             let del_res = fs_dir.resize(&inp, opts)?;
             (del_res, inode_id)
         };
@@ -1253,5 +1283,29 @@ impl MasterFilesystem {
         let inp = Self::resolve_path(&fs_dir, path)?;
 
         fs_dir.set_lock(inp, lock, self.conf.lock_expire_time_ms())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fallocate_rejects_growth_larger_than_available_capacity() {
+        let opts = FileAllocOpts::with_alloc(200, FileAllocMode::DEFAULT);
+        let err = MasterFilesystem::validate_alloc_capacity(20, 2, &opts, 359).unwrap_err();
+        assert!(matches!(err, FsError::DiskOutOfSpace(_)));
+    }
+
+    #[test]
+    fn fallocate_accepts_exact_available_capacity() {
+        let opts = FileAllocOpts::with_alloc(200, FileAllocMode::DEFAULT);
+        assert!(MasterFilesystem::validate_alloc_capacity(20, 2, &opts, 360).is_ok());
+    }
+
+    #[test]
+    fn truncate_growth_does_not_require_physical_capacity() {
+        let opts = FileAllocOpts::with_truncate(200);
+        assert!(MasterFilesystem::validate_alloc_capacity(20, 2, &opts, 0).is_ok());
     }
 }

--- a/curvine-server/src/master/fs/master_filesystem.rs
+++ b/curvine-server/src/master/fs/master_filesystem.rs
@@ -1208,6 +1208,9 @@ impl MasterFilesystem {
         opts.validate()?;
 
         let path = path.as_ref();
+        // This snapshot only rejects individually impossible requests; it is not a
+        // reservation, so concurrent fallocates may observe the same capacity.
+        // Worker-side block allocation remains the hard enforcement point.
         let available = if opts.truncate {
             i64::MAX
         } else {

--- a/curvine-server/src/master/fs/worker_manager.rs
+++ b/curvine-server/src/master/fs/worker_manager.rs
@@ -130,6 +130,14 @@ impl WorkerManager {
         res
     }
 
+    pub fn available_bytes(&self) -> i64 {
+        self.worker_map
+            .workers()
+            .values()
+            .map(|worker| worker.available.max(0))
+            .fold(0, i64::saturating_add)
+    }
+
     pub fn remove_expired_worker(&mut self, id: u32) -> Option<WorkerInfo> {
         self.worker_map.remove_expired(id)
     }

--- a/curvine-server/src/master/fs/worker_manager.rs
+++ b/curvine-server/src/master/fs/worker_manager.rs
@@ -297,3 +297,26 @@ impl Display for WorkerManager {
         write!(f, "{}", str)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn worker_with_available(worker_id: u32, available: i64) -> WorkerInfo {
+        let mut worker = WorkerInfo::default();
+        worker.address.worker_id = worker_id;
+        worker.available = available;
+        worker
+    }
+
+    #[test]
+    fn available_bytes_clamps_negative_values_and_saturates() {
+        let mut manager = WorkerManager::new(&ClusterConf::default()).unwrap();
+        manager.add_test_worker(worker_with_available(1, -10));
+        manager.add_test_worker(worker_with_available(2, 20));
+        assert_eq!(manager.available_bytes(), 20);
+
+        manager.add_test_worker(worker_with_available(3, i64::MAX));
+        assert_eq!(manager.available_bytes(), i64::MAX);
+    }
+}

--- a/curvine-server/src/master/meta/inode/inode_file.rs
+++ b/curvine-server/src/master/meta/inode/inode_file.rs
@@ -436,20 +436,23 @@ impl InodeFile {
         let block_size = self.block_size as i64;
         let mut start = self.last_block_start_off();
 
-        // Start from the last block's start position, process each block until expect_len
+        // Only the existing tail block can overlap the extension boundary.
+        if let Some(last_block) = self.blocks.last_mut() {
+            let resize_len = block_size.min(expect_len - start);
+            last_block.len = resize_len as u32;
+            last_block
+                .alloc_opts
+                .replace(opts.clone_with_len(resize_len));
+            start += block_size;
+        }
+
+        // Append new blocks directly; searching the growing vector here makes large
+        // fallocate requests quadratic while the master metadata write lock is held.
         while start < expect_len {
             let resize_len = block_size.min(expect_len - start);
             let block_opts = opts.clone_with_len(resize_len);
-
-            if let Some(block) = self.search_block_mut_by_pos(start) {
-                // Found existing block, extend its length
-                block.len = resize_len as u32;
-                block.alloc_opts.replace(block_opts);
-            } else {
-                // No block found, create new block
-                let new_block_id = self.next_block_id()?;
-                self.add_block(BlockMeta::with_alloc(new_block_id, block_opts));
-            }
+            let new_block_id = self.next_block_id()?;
+            self.add_block(BlockMeta::with_alloc(new_block_id, block_opts));
             start += block_size;
         }
 
@@ -619,6 +622,34 @@ impl PartialEq for InodeFile {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use curvine_common::state::FileAllocMode;
+
+    fn test_file(block_size: i64) -> InodeFile {
+        let mut opts = CreateFileOpts::with_create(false);
+        opts.block_size = block_size;
+        InodeFile::with_opts(1, 0, opts)
+    }
+
+    #[test]
+    fn extend_updates_tail_once_and_appends_blocks_in_order() {
+        let mut file = test_file(4);
+        file.resize(FileAllocOpts::with_alloc(10, FileAllocMode::DEFAULT))
+            .unwrap();
+        let original_ids = file.block_ids();
+
+        file.resize(FileAllocOpts::with_alloc(15, FileAllocMode::DEFAULT))
+            .unwrap();
+
+        assert_eq!(file.len, 15);
+        assert_eq!(
+            file.blocks
+                .iter()
+                .map(|block| block.len)
+                .collect::<Vec<_>>(),
+            vec![4, 4, 4, 3]
+        );
+        assert_eq!(&file.block_ids()[..original_ids.len()], original_ids);
+    }
 
     #[test]
     fn complete_advances_existing_independent_ctime_with_mtime() {


### PR DESCRIPTION
**Summary**

Reject file preallocation requests that exceed the cluster's currently available physical capacity, and make master-side inode extension linear in the number of blocks being added.

Previously, an oversized `fallocate(2)` request could be accepted as long as the requested file length remained below Curvine's maximum file size. The master then attempted to materialize metadata for every block while holding the global filesystem metadata write lock. Large requests could therefore consume a CPU core for minutes and block unrelated metadata RPCs.

**Minimal Reproducer**

Create an empty file on a Curvine FUSE mount and request twice the capacity reported as available by `df`:

```bash
file=/mnt/curvine/fallocate-too-large
available_kib=$(df -P /mnt/curvine | awk 'END {print $4}')
too_large_kib=$((available_kib * 2))

: >"$file"
time fallocate -l "${too_large_kib}K" "$file"
```

Before the fix, the request did not fail promptly with `ENOSPC`. For a cluster using 128 MiB blocks, a request around 110 TiB caused the master to create metadata for roughly 900,000 blocks. While this work was in progress, other filesystem operations could time out because they also needed the global metadata lock.

After the fix, the same request returns `ENOSPC` immediately and the master continues serving unrelated metadata operations.

**Root Cause**

`FileAllocOpts::validate()` checked argument validity and the maximum supported file size, but it did not compare preallocation growth with available worker capacity. A request could therefore be valid as a file length while still being impossible to allocate on the cluster.

Once accepted, `InodeFile::extend()` processed the requested range one block at a time. For every position it called `search_block_mut_by_pos()`, which scanned the block vector from the beginning. Appending `n` blocks consequently required O(n^2) cumulative block comparisons.

The resize operation runs while the master holds the global `fs_dir` write lock. The quadratic loop therefore affected the entire metadata control plane, not only the client that issued the oversized request.

**Changes**

- Add a `DiskOutOfSpace` constructor for errors that map to POSIX `ENOSPC`.
- Aggregate currently available bytes from registered workers using the same capacity source exposed through filesystem statistics.
- Validate non-truncate allocation growth before expanding inode block metadata, including the file's replication factor in physical capacity requirements.
- Preserve sparse truncate behavior; growing a logical file with truncate does not require immediate physical capacity.
- Update only the existing tail block once and append subsequent block metadata directly, reducing inode extension from O(n^2) to O(n).
- Add unit coverage for insufficient capacity, exact-capacity allocation, sparse truncate growth, and ordered tail-block extension.

**Deployment Note**

The capacity check and inode extension logic run in the master process. Deploy the updated server binary and restart or fail over the active master for the change to take effect.

Worker and FUSE processes do not require code changes for this fix. Existing clients already map the master's `DiskOutOfSpace` error to `ENOSPC`.

**Verification**

- `cargo test -p curvine-server --lib` passes: `114 passed`, `1 ignored`.
- `cargo test -p curvine-common fs_error --lib` passes: `8 passed`.
- `cargo check --workspace` passes.
- An oversized preallocation integration reproducer returns `ENOSPC` and completes in approximately one second instead of timing out.
- `cargo fmt --all -- --check` passes.
- `git diff --check` passes.
