### PR TITLE
fix(worker): size replication targets from source block metadata

### DIFF
--- a/curvine-server/src/worker/block/block_meta.rs
+++ b/curvine-server/src/worker/block/block_meta.rs
@@ -174,6 +174,19 @@ impl BlockMeta {
     pub fn physical_bytes(&self) -> i64 {
         self.actual_len
     }
+
+    /// Capacity the target worker must reserve when replicating this block.
+    ///
+    /// File-backed blocks can grow when reopened, so their committed logical
+    /// length is sufficient. SPDK blocks use fixed extents and must preserve
+    /// the source allocation so a partial final block can still be appended up
+    /// to its original block boundary.
+    pub fn replication_capacity(&self) -> i64 {
+        match self.storage_type {
+            StorageType::SpdkDisk => self.len.max(self.actual_len),
+            _ => self.len,
+        }
+    }
 }
 
 impl fmt::Display for BlockMeta {

--- a/curvine-server/src/worker/replication/worker_replication_manager.rs
+++ b/curvine-server/src/worker/replication/worker_replication_manager.rs
@@ -128,18 +128,21 @@ impl WorkerReplicationManager {
         job.with_storage_type(block_meta.storage_type());
         let extend_block =
             ExtendedBlock::new(block_meta.id, 0, block_meta.storage_type(), FileType::File);
+        let target_capacity = block_meta.replication_capacity();
         info!(
-            "Replicating block_id: {} from {} to {}",
+            "Replicating block_id: {} from {} to {} (copy_bytes={}, target_capacity={})",
             job.block_id,
             self.block_store.worker_id()?,
-            job.target_worker_addr.worker_id
+            job.target_worker_addr.worker_id,
+            block_meta.len,
+            target_capacity
         );
         let mut writer = BlockWriterRemote::new(
             &self.fs_client_context,
             extend_block,
             job.target_worker_addr.clone(),
             0,
-            self.fs_client_context.block_size(),
+            target_capacity,
         )
         .await?;
         let mut reader = self.block_store.open_reader(&block_meta, 0)?;

--- a/curvine-tests/tests/replication_test.rs
+++ b/curvine-tests/tests/replication_test.rs
@@ -22,7 +22,9 @@ use log::info;
 use orpc::common::Utils;
 use orpc::runtime::RpcRuntime;
 use orpc::{CommonError, CommonResult};
+use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 use tempfile::TempDir;
 
 /// Create a test configuration for replication testing
@@ -129,12 +131,7 @@ fn test_block_replication_e2e() -> CommonResult<()> {
     let target_block_locations = final_locations.get(&block_id);
     if let Some(locations) = target_block_locations {
         info!("Target block locations: {}", locations.len());
-        if locations.len()
-            > initial_locations
-                .get(&block_id)
-                .map(|l| l.len())
-                .unwrap_or(0)
-        {
+        if locations.len() > replica_count(&initial_locations, block_id) {
             info!(
                 "✓ Block replication succeeded - block {} now has {} replicas",
                 block_id,
@@ -271,6 +268,78 @@ fn test_replication_with_simulated_worker_failure() -> CommonResult<()> {
     Ok(())
 }
 
+/// Replication must size the target from source block metadata rather than the
+/// worker client's unrelated default block size.
+#[test]
+fn test_replication_honors_source_block_capacity() -> CommonResult<()> {
+    const CLIENT_DEFAULT_BLOCK_SIZE: i64 = 32 * 1024;
+    const FILE_BLOCK_SIZE: i64 = 64 * 1024;
+    const FILE_SIZE: usize = 96 * 1024;
+    const REPLICATION_TIMEOUT: Duration = Duration::from_secs(8);
+    const REPLICATION_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+    let testing = Testing::builder()
+        .default()
+        .masters(2)
+        .workers(3)
+        .mutate_conf(|conf| {
+            conf.client.block_size_str = format!("{CLIENT_DEFAULT_BLOCK_SIZE}B");
+            conf.master.min_block_size = CLIENT_DEFAULT_BLOCK_SIZE;
+            conf.master.min_replication = 1;
+            conf.master.max_replication = 3;
+            conf.master.block_replication_enabled = true;
+        })
+        .build()?;
+    let cluster = testing.start_cluster()?;
+    let mut conf = testing.get_active_cluster_conf()?;
+    conf.client.block_size_str = format!("{FILE_BLOCK_SIZE}B");
+    conf.client.init()?;
+    let rt = Arc::new(conf.client_rpc_conf().create_runtime());
+    let fs = testing.get_fs(Some(rt.clone()), Some(conf))?;
+
+    let path = Path::from_str("/replication_large_block.dat")?;
+    let test_data = generate_test_data(FILE_SIZE);
+    let file_blocks = rt.block_on(async { write_test_file(&fs, &path, &test_data).await })?;
+    let oversized_block = file_blocks
+        .block_locs
+        .iter()
+        .find(|block| block.block.len > CLIENT_DEFAULT_BLOCK_SIZE)
+        .expect("missing block larger than the worker client default");
+    let block_id = oversized_block.block.id;
+
+    let initial_locations = rt.block_on(async { get_block_locations(&fs, &path).await })?;
+    let initial_replica_count = replica_count(&initial_locations, block_id);
+
+    cluster
+        .get_active_master_replication_manager()
+        .report_under_replicated_blocks(1, vec![block_id])?;
+
+    let deadline = Instant::now() + REPLICATION_TIMEOUT;
+    loop {
+        let current_locations = rt.block_on(async { get_block_locations(&fs, &path).await })?;
+        let current_replica_count = replica_count(&current_locations, block_id);
+        if current_replica_count > initial_replica_count {
+            break;
+        }
+        if Instant::now() >= deadline {
+            return Err(CommonError::from(format!(
+                "oversized block {} did not gain a replica before timeout (before={}, after={})",
+                block_id, initial_replica_count, current_replica_count
+            )));
+        }
+        std::thread::sleep(REPLICATION_POLL_INTERVAL);
+    }
+
+    let read_data = rt.block_on(async { read_test_file(&fs, &path).await })?;
+    if read_data != test_data {
+        return Err(CommonError::from(
+            "Data integrity check failed after oversized-block replication",
+        ));
+    }
+
+    Ok(())
+}
+
 async fn write_test_file(
     fs: &CurvineFileSystem,
     path: &Path,
@@ -308,15 +377,22 @@ async fn read_test_file(fs: &CurvineFileSystem, path: &Path) -> CommonResult<Vec
 async fn get_block_locations(
     fs: &CurvineFileSystem,
     path: &Path,
-) -> CommonResult<std::collections::HashMap<i64, Vec<WorkerAddress>>> {
+) -> CommonResult<HashMap<i64, Vec<WorkerAddress>>> {
     let block_locations = fs.get_block_locations(path).await?;
 
-    let mut location_map = std::collections::HashMap::new();
+    let mut location_map = HashMap::new();
     for block_location in block_locations.block_locs.iter() {
         location_map.insert(block_location.block.id, block_location.locs.clone());
     }
 
     Ok(location_map)
+}
+
+fn replica_count(locations: &HashMap<i64, Vec<WorkerAddress>>, block_id: i64) -> usize {
+    locations
+        .get(&block_id)
+        .map(|locations| locations.len())
+        .unwrap_or(0)
 }
 
 fn generate_test_data(size: usize) -> Vec<u8> {

--- a/curvine-tests/tests/replication_test.rs
+++ b/curvine-tests/tests/replication_test.rs
@@ -306,6 +306,7 @@ fn test_replication_honors_source_block_capacity() -> CommonResult<()> {
         .find(|block| block.block.len > CLIENT_DEFAULT_BLOCK_SIZE)
         .expect("missing block larger than the worker client default");
     let block_id = oversized_block.block.id;
+    let original_locations = oversized_block.locs.clone();
 
     let initial_locations = rt.block_on(async { get_block_locations(&fs, &path).await })?;
     let initial_replica_count = replica_count(&initial_locations, block_id);
@@ -329,6 +330,27 @@ fn test_replication_honors_source_block_capacity() -> CommonResult<()> {
         }
         std::thread::sleep(REPLICATION_POLL_INTERVAL);
     }
+
+    let fs_dir = cluster.get_active_master_fs().fs_dir();
+    {
+        let mut fs_dir = fs_dir.write();
+        let reports = original_locations
+            .iter()
+            .map(|location| {
+                (
+                    false,
+                    block_id,
+                    BlockLocation {
+                        worker_id: location.worker_id,
+                        storage_type: Default::default(),
+                    },
+                )
+            })
+            .collect();
+        fs_dir.block_report(reports)?;
+    }
+    let latest_locations = rt.block_on(async { get_block_locations(&fs, &path).await })?;
+    assert_eq!(1, replica_count(&latest_locations, block_id));
 
     let read_data = rt.block_on(async { read_test_file(&fs, &path).await })?;
     if read_data != test_data {


### PR DESCRIPTION
# Summary

Fix worker block replication when the source file uses a larger per-file block size than the replication worker's client default.

Replication now derives both the bytes to copy and the capacity to reserve from the source `BlockMeta`, instead of using the unrelated `FsContext::block_size()`. This also preserves the source allocation extent for SPDK-backed blocks.

# Issue Describe / Design

## Reproduction configuration

The regression test uses deliberately different block-size settings:

| Setting | Value | Meaning |
| ------- | ----- | ------- |
| Worker/client default block size | 32KB | The `FsContext::block_size()` available inside `WorkerReplicationManager` |
| File block size | 64KB | The per-file block size selected when the file is created |
| File size | 96KB | Produces one 64KB block and one 32KB partial block |
| Initial replicas | 2 | Allows the test to verify that replication adds another location |

The production equivalent is a file created by a load job or mount with, for example, a 64MB block size while the worker client default remains 4MB.

## When the problem occurs

The problem is triggered only when all of the following are true:

1. A file is created with a per-file block size larger than the replication worker's client default.
2. At least one finalized source block is larger than that worker default.
3. The block becomes under-replicated and the master schedules a replication job.
4. The source worker opens a remote writer on the target worker.

Normal reads are unaffected because readers use the block metadata and read only the finalized block length. The failure occurs specifically while creating the replication target.

## Block-size meanings

The values involved have different responsibilities:

- The file block size is selected when the file is created through `CreateFileOpts::block_size`. It determines how the file is split into blocks and is recorded as file metadata.
- `FsContext::block_size()` is the client default used when a caller does not provide a per-file override. It is not authoritative metadata for an existing source block.
- `BlockMeta::len` is the finalized logical byte length of the source block and is the number of bytes replication must copy.
- `BlockMeta::actual_len` is the source block's physical allocation size. For SPDK storage, this represents the fixed extent that must be preserved on the target.
- The `block_size` argument passed when opening `BlockWriterRemote` is the target block capacity. It is not the size of an individual RPC payload.
- Replication still transfers data in `replicate_chunk_size` chunks, so the target capacity can be larger than the RPC message size.

## Root cause

`WorkerReplicationManager::replicate_block` correctly loaded the source block metadata:

```rust
let block_meta = self.block_store.get_block(job.block_id)?;
```

However, it ignored that metadata when opening the target writer and used:

```rust
self.fs_client_context.block_size()
```

That value belongs to the worker's internal client configuration. It may differ from the block size chosen by the client, load job, or mount that originally created the file.

For example:

- source block logical length: 64MB
- worker client default: 4MB
- old target capacity: 4MB

Replication attempted to copy all 64MB into a target block allocated for 4MB. Once the copied offset exceeded the target capacity, the target write or completion path rejected the block, leaving it under-replicated.

## Fix approach

Introduce `BlockMeta::replication_capacity()` as the single source of truth for target allocation:

- File-backed blocks reserve `BlockMeta::len`. Regular files can grow, so the committed logical length is sufficient.
- SPDK-backed blocks reserve `max(BlockMeta::len, BlockMeta::actual_len)`. SPDK blocks use fixed extents, so replication must preserve the physical allocation even when the finalized logical block is partial.

The replication manager now:

1. Uses `block_meta.len` as the number of bytes to copy.
2. Uses `block_meta.replication_capacity()` as the target writer capacity.
3. Logs both values to make allocation mismatches observable.
4. Continues transferring data in bounded replication chunks.

This is intentionally scoped to the worker replication write path. It does not require protocol changes, additional master lookups, or reconstruction of the source file's `FileStatus`.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-server/src/worker/block/block_meta.rs` | Add `replication_capacity()` with file-backed and SPDK-specific allocation semantics | Centralizes the target-capacity decision |
| `curvine-server/src/worker/replication/worker_replication_manager.rs` | Allocate the target from source block metadata instead of `FsContext::block_size()` | Replication succeeds when per-file and worker default block sizes differ |
| `curvine-tests/tests/replication_test.rs` | Add a 32KB worker / 64KB file regression test with replica polling and integrity verification | Prevents regression without fixed sleeps |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-tests --test replication_test test_replication_honors_source_block_capacity` | PASS | Confirmed a 64KB source block replicated while the worker default remained 32KB |
| `cargo test -p curvine-tests --test replication_test` | PASS | 3 passed, 0 failed |
| Curvine example-cluster SPDK replication smoke test | PASS | Verified SPDK target allocation and replicated data |
| `cargo fmt --all` | PASS | |
| `git diff --check` | PASS | |
| `make format` | BLOCKED | Existing unrelated unused imports in `curvine-fuse/src/fs/state/node_state.rs` fail Clippy with `-D warnings` |
