### PR TITLE
ci(java-sdk): add PR-gated compile check for Java SDK

### DIFF
--- a/.github/workflows/java-compile-check.yml
+++ b/.github/workflows/java-compile-check.yml
@@ -1,0 +1,30 @@
+name: Java SDK Compile Check
+
+on:
+  pull_request:
+    paths:
+      - 'curvine-libsdk/java/**'
+      - 'curvine-common/proto/**'
+
+permissions:
+  contents: read
+
+jobs:
+  compile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Compile Java SDK
+        run: |
+          cd curvine-libsdk/java
+          mvn compile -B -q
+        # protobuf:compile runs automatically (bound to compile phase).
+        # protoc is downloaded from Maven Central via protocArtifact — no separate install needed.


### PR DESCRIPTION
# Summary

Add a lightweight CI workflow that compiles the Java SDK on pull requests touching `curvine-libsdk/java/` or `curvine-common/proto/`. This closes the gap where Java SDK changes could merge without any automated compile signal.

# Issue Describe / Design

Previously, `build-java-sdk.yml` only triggers on version tags or manual dispatch and always uses `-DskipTests`. No PR-gated feedback existed for Java code changes. This new workflow provides a fast compile-only gate (no tests, no native library build) so that syntax errors, missing imports, and protobuf schema mismatches are caught before merge.

Design decisions:
- **Separate workflow** rather than adding to `build.yml` — keeps the Rust CI focused and allows independent triggering on Java-specific paths.
- **Path filters** include `curvine-common/proto/**` because the protobuf plugin reads `.proto` files from that directory.
- **No protoc install step** — the `protobuf-maven-plugin` uses `protocArtifact` to download protoc from Maven Central automatically during the compile phase.
- **JDK 8** matches `maven.compiler.source/target` in `pom.xml`.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `.github/workflows/java-compile-check.yml` | New workflow: PR-gated Java compile check | None — additive CI signal only |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| YAML lint (`yaml-lint java-compile-check.yml`) | PASS | Syntax validated |
| Workflow trigger validation | Pending | Will verify on PR creation that the check triggers for Java paths |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None