### PR TITLE
perf(client): prefetch next block on sequential write boundaries (#1291)

### DIFF
--- a/curvine-client/src/file/fs_writer_base.rs
+++ b/curvine-client/src/file/fs_writer_base.rs
@@ -138,7 +138,23 @@ impl FsWriterBase {
         )
     }
 
-    pub async fn write(&mut self, mut chunk: DataSlice) -> FsResult<()> {
+    pub async fn write(&mut self, chunk: DataSlice) -> FsResult<()> {
+        self.write_with_more_pending(chunk, false).await
+    }
+
+    /// Write `chunk`, optionally hinting that more application data is already
+    /// queued behind this chunk (e.g. `FsWriterBuffer` drained multiple items).
+    ///
+    /// Prefetch starts when either:
+    /// - this chunk still overflows the current block, or
+    /// - `more_data_pending` is true and the current block is within the
+    ///   prefetch threshold (so alloc/open overlaps the tail write).
+    /// Exact EOF with no queued follow-up data does not prefetch.
+    pub async fn write_with_more_pending(
+        &mut self,
+        mut chunk: DataSlice,
+        more_data_pending: bool,
+    ) -> FsResult<()> {
         if chunk.is_empty() {
             return Ok(());
         }
@@ -149,11 +165,11 @@ impl FsWriterBase {
 
         let mut remaining = chunk.len();
         while remaining > 0 {
-            // Only prefetch when this write still needs bytes beyond the current
-            // block. Speculative prefetch near EOF would allocate an unused
-            // 0-length next block that complete()/flush()/seek() must discard.
             if let Some(cur) = self.cur_writer.as_ref() {
-                if (remaining as i64) > cur.remaining() {
+                let overflows = (remaining as i64) > cur.remaining();
+                let queued_near_end =
+                    more_data_pending && cur.remaining() <= self.prefetch_threshold;
+                if overflows || queued_near_end {
                     self.maybe_start_prefetch();
                 }
             }
@@ -817,5 +833,33 @@ impl FsWriterBase {
         );
 
         Ok(())
+    }
+}
+
+impl Drop for FsWriterBase {
+    fn drop(&mut self) {
+        let Some(handle) = self.next_block_prefetch.take() else {
+            return;
+        };
+
+        // Prefer cancelling an already-finished prefetched writer. Abort alone
+        // would drop a completed BlockWriter without cancel() and leak the
+        // worker write session. In-flight tasks are aborted so they do not
+        // continue allocating after the writer is gone.
+        if handle.is_finished() {
+            let rt = self.fs_context.clone_runtime();
+            rt.spawn(async move {
+                if let Ok(Ok((_lb, mut writer))) = handle.await {
+                    if let Err(e) = writer.cancel().await {
+                        warn!(
+                            "failed to cancel prefetched writer on FsWriterBase drop: {}",
+                            e
+                        );
+                    }
+                }
+            });
+        } else {
+            handle.abort();
+        }
     }
 }

--- a/curvine-client/src/file/fs_writer_base.rs
+++ b/curvine-client/src/file/fs_writer_base.rs
@@ -16,18 +16,25 @@ use crate::block::BlockWriter;
 use crate::file::{FsClient, FsContext};
 use curvine_common::error::FsError;
 use curvine_common::fs::Path;
-use curvine_common::state::{CommitBlock, FileAllocOpts, FileBlocks, FileStatus, WriteFileBlocks};
+use curvine_common::state::{
+    CommitBlock, FileAllocOpts, FileBlocks, FileStatus, LocatedBlock, WriteFileBlocks,
+};
 use curvine_common::FsResult;
 use fxhash::FxHasher;
 use linked_hash_map::LinkedHashMap;
-use log::warn;
+use log::{debug, warn};
 use orpc::common::FastHashSet;
-use orpc::runtime::{RpcRuntime, Runtime};
+use orpc::runtime::{JoinHandle, RpcRuntime, Runtime};
 use orpc::sys::DataSlice;
 use orpc::{err_box, try_option_mut};
 use std::hash::BuildHasherDefault;
 use std::mem;
 use std::sync::Arc;
+use std::time::Instant;
+
+/// Background prefetch of the next sequential block so boundary switching does
+/// not serialize `add_block` + `BlockWriter::new` on the single write drain task.
+type NextBlockPrefetchHandle = JoinHandle<FsResult<(LocatedBlock, BlockWriter)>>;
 
 pub struct FsWriterBase {
     fs_context: Arc<FsContext>,
@@ -46,6 +53,15 @@ pub struct FsWriterBase {
     /// opened, blocks published by a successful flush, and blocks finalized on
     /// workers but still waiting for their commit metadata to reach the master.
     durable_blocks: FastHashSet<i64>,
+
+    /// Prefetch next block when current remaining bytes fall at or below this.
+    prefetch_threshold: i64,
+    next_block_prefetch: Option<NextBlockPrefetchHandle>,
+    /// Set when a prefetch task may have already allocated the next block on
+    /// the master. Sync allocation must flush commits via CompleteFile first,
+    /// because a repeated AddBlock returns the existing next block and ignores
+    /// piggybacked commit_blocks.
+    prefetch_alloc_attempted: bool,
 }
 
 impl FsWriterBase {
@@ -60,6 +76,10 @@ impl FsWriterBase {
                 .filter(|block| block.block.len > 0 && !block.locs.is_empty())
                 .map(|block| block.block.id)
                 .collect(),
+        );
+        let prefetch_threshold = Self::prefetch_threshold(
+            fs_context.conf.client.write_chunk_size as i64,
+            status.block_size,
         );
         let file_blocks = WriteFileBlocks::new(status);
 
@@ -78,7 +98,17 @@ impl FsWriterBase {
             cache_limit,
             cache_writers,
             durable_blocks,
+            prefetch_threshold,
+            next_block_prefetch: None,
+            prefetch_alloc_attempted: false,
         }
+    }
+
+    /// Start prefetch when a few write chunks remain in the current block.
+    fn prefetch_threshold(write_chunk_size: i64, block_size: i64) -> i64 {
+        let chunk = write_chunk_size.max(1);
+        let capped = (block_size / 8).max(chunk);
+        (chunk * 4).clamp(chunk, capped)
     }
 
     pub fn pos(&self) -> i64 {
@@ -128,6 +158,7 @@ impl FsWriterBase {
             if self.pos > self.len {
                 self.len = self.pos;
             }
+            self.maybe_start_prefetch();
         }
 
         Ok(())
@@ -159,12 +190,14 @@ impl FsWriterBase {
             if self.pos > self.len {
                 self.len = self.pos;
             }
+            self.maybe_start_prefetch();
         }
 
         Ok(())
     }
 
     pub async fn flush(&mut self) -> FsResult<()> {
+        self.discard_prefetch().await;
         self.complete0(true).await?;
         Ok(())
     }
@@ -178,6 +211,7 @@ impl FsWriterBase {
     // Write is completed, perform the following operations
     // 1. Submit the last block.
     pub async fn complete(&mut self) -> FsResult<()> {
+        self.discard_prefetch().await;
         self.complete0(false).await?;
         Ok(())
     }
@@ -218,6 +252,8 @@ impl FsWriterBase {
     /// Cleanup remains best effort: preserve the first error while attempting
     /// all remaining writers and the metadata submission.
     pub async fn cancel(&mut self) -> FsResult<()> {
+        self.discard_prefetch().await;
+
         let mut first_error: Option<FsError> = None;
         let mut cleanup_commits = Vec::new();
 
@@ -342,81 +378,271 @@ impl FsWriterBase {
             Some(v) if v.has_remaining() => (),
 
             _ => {
-                let block = self.file_blocks.get_block(self.pos);
-                match block {
-                    // step1: If block already exists, seek operation exists, need to overwrite previous block.
-                    // Multiple seek operations will automatically cache block writer, so need to check block writer cache.
-                    Some((off, lb)) => {
-                        let writer = match self.cache_writers.remove(&lb.id) {
-                            Some(mut v) => {
-                                // Writer from cache may have a different position, seek to correct offset
-                                v.seek(off).await?;
-                                v
+                if self.try_install_prefetch().await? {
+                    // Prefetched next block is ready; old block was completed and
+                    // its commit was flushed to the master separately.
+                } else {
+                    let block = self.file_blocks.get_block(self.pos);
+                    match block {
+                        // step1: If block already exists, seek operation exists, need to overwrite previous block.
+                        // Multiple seek operations will automatically cache block writer, so need to check block writer cache.
+                        Some((off, lb)) => {
+                            let writer = match self.cache_writers.remove(&lb.id) {
+                                Some(mut v) => {
+                                    // Writer from cache may have a different position, seek to correct offset
+                                    v.seek(off).await?;
+                                    v
+                                }
+
+                                None => {
+                                    let lb = if lb.should_assign() {
+                                        let assign_lb = self
+                                            .fs_client
+                                            .assign_worker(&self.path, lb.block.clone())
+                                            .await?;
+
+                                        self.file_blocks.update_locate(&assign_lb)?;
+                                        assign_lb
+                                    } else {
+                                        lb
+                                    };
+                                    BlockWriter::new(
+                                        self.fs_context.clone(),
+                                        lb,
+                                        off,
+                                        self.file_blocks.status.block_size,
+                                    )
+                                    .await?
+                                }
+                            };
+
+                            self.update_writer(Some(writer), true).await?;
+                        }
+
+                        None => {
+                            self.update_writer(None, false).await?;
+                            if self.prefetch_alloc_attempted {
+                                // Prefetch may have allocated next already; flush
+                                // commits before AddBlock or they would be dropped.
+                                self.flush_pending_commits().await?;
+                                self.prefetch_alloc_attempted = false;
                             }
 
-                            None => {
-                                let lb = if lb.should_assign() {
-                                    let assign_lb = self
-                                        .fs_client
-                                        .assign_worker(&self.path, lb.block.clone())
-                                        .await?;
-
-                                    self.file_blocks.update_locate(&assign_lb)?;
-                                    assign_lb
-                                } else {
-                                    lb
-                                };
-                                BlockWriter::new(
-                                    self.fs_context.clone(),
-                                    lb,
-                                    off,
-                                    self.file_blocks.status.block_size,
+                            let commit_blocks = self.file_blocks.take_commit_blocks();
+                            let last_block = self.file_blocks.last_block();
+                            let add_start = Instant::now();
+                            let add_result = self
+                                .fs_client
+                                .add_block_by_id(
+                                    &self.path,
+                                    self.file_blocks.status.id,
+                                    commit_blocks.clone(),
+                                    self.len,
+                                    last_block,
                                 )
-                                .await?
-                            }
-                        };
-
-                        self.update_writer(Some(writer), true).await?;
-                    }
-
-                    None => {
-                        self.update_writer(None, false).await?;
-
-                        let commit_blocks = self.file_blocks.take_commit_blocks();
-                        let last_block = self.file_blocks.last_block();
-                        let add_result = self
-                            .fs_client
-                            .add_block_by_id(
-                                &self.path,
-                                self.file_blocks.status.id,
-                                commit_blocks.clone(),
-                                self.len,
-                                last_block,
+                                .await;
+                            let lb = match add_result {
+                                Ok(block) => block,
+                                Err(e) => {
+                                    self.restore_commit_blocks(&commit_blocks);
+                                    return Err(e);
+                                }
+                            };
+                            debug!(
+                                "add_block sync path took {:?}, path={}",
+                                add_start.elapsed(),
+                                self.path
+                            );
+                            self.file_blocks.add_block(lb.clone())?;
+                            let open_start = Instant::now();
+                            let writer = BlockWriter::new(
+                                self.fs_context.clone(),
+                                lb.clone(),
+                                0,
+                                self.file_blocks.status.block_size,
                             )
-                            .await;
-                        let lb = match add_result {
-                            Ok(block) => block,
-                            Err(e) => {
-                                self.restore_commit_blocks(&commit_blocks);
-                                return Err(e);
-                            }
-                        };
-                        self.file_blocks.add_block(lb.clone())?;
-                        let writer = BlockWriter::new(
-                            self.fs_context.clone(),
-                            lb.clone(),
-                            0,
-                            self.file_blocks.status.block_size,
-                        )
-                        .await?;
+                            .await?;
+                            debug!(
+                                "BlockWriter::new sync path took {:?}, path={}",
+                                open_start.elapsed(),
+                                self.path
+                            );
 
-                        self.cur_writer.replace(writer);
-                    }
-                };
+                            self.cur_writer.replace(writer);
+                        }
+                    };
+                }
             }
         }
 
         Ok(try_option_mut!(self.cur_writer))
+    }
+
+    fn can_prefetch_next_block(&self) -> bool {
+        if self.next_block_prefetch.is_some() {
+            return false;
+        }
+        // Prefetch only helps sequential append; random writes keep existing paths.
+        if self.pos != self.len {
+            return false;
+        }
+        let Some(cur) = self.cur_writer.as_ref() else {
+            return false;
+        };
+        if cur.remaining() > self.prefetch_threshold {
+            return false;
+        }
+        let next_pos = self.pos + cur.remaining();
+        self.file_blocks.get_block(next_pos).is_none()
+    }
+
+    fn maybe_start_prefetch(&mut self) {
+        if !self.can_prefetch_next_block() {
+            return;
+        }
+
+        let fs_client = self.fs_client.clone();
+        let fs_context = self.fs_context.clone();
+        let path = self.path.clone();
+        let inode_id = self.file_blocks.status.id;
+        let last_block = self.file_blocks.last_block();
+        // Master file length must match already-committed block bytes. The
+        // current open block is still uncommitted, so use committed_len — not
+        // self.len — when allocating the next block early.
+        let committed_len = self.committed_len();
+        let block_size = self.file_blocks.status.block_size;
+        let rt = self.fs_context.clone_runtime();
+
+        debug!(
+            "prefetch next block: path={}, committed_len={}, remaining={}",
+            path,
+            committed_len,
+            self.cur_writer.as_ref().map(|w| w.remaining()).unwrap_or(0)
+        );
+
+        let handle = rt.spawn(async move {
+            let alloc_start = Instant::now();
+            let lb = fs_client
+                .add_block_by_id(&path, inode_id, vec![], committed_len, last_block)
+                .await?;
+            debug!(
+                "prefetch add_block took {:?}, path={}",
+                alloc_start.elapsed(),
+                path
+            );
+            let open_start = Instant::now();
+            let writer = BlockWriter::new(fs_context, lb.clone(), 0, block_size).await?;
+            debug!(
+                "prefetch BlockWriter::new took {:?}, path={}",
+                open_start.elapsed(),
+                path
+            );
+            Ok((lb, writer))
+        });
+
+        self.prefetch_alloc_attempted = true;
+        self.next_block_prefetch = Some(handle);
+    }
+
+    async fn take_prefetch_result(&mut self) -> Option<FsResult<(LocatedBlock, BlockWriter)>> {
+        let handle = self.next_block_prefetch.take()?;
+        match handle.await {
+            Ok(res) => Some(res),
+            Err(e) => Some(err_box!("prefetch task join failed: {}", e)),
+        }
+    }
+
+    /// Install a ready/in-flight prefetch as the current writer.
+    ///
+    /// Returns `true` when prefetch was consumed. On prefetch failure, clears
+    /// state and returns `false` so the caller can fall back to the sync path.
+    async fn try_install_prefetch(&mut self) -> FsResult<bool> {
+        let Some(result) = self.take_prefetch_result().await else {
+            return Ok(false);
+        };
+
+        let (lb, mut writer) = match result {
+            Ok(v) => v,
+            Err(e) => {
+                warn!(
+                    "prefetch next block failed, falling back to sync alloc: {:?}",
+                    e
+                );
+                // Keep prefetch_alloc_attempted so sync path flushes commits
+                // before AddBlock (master may already hold the next block).
+                return Ok(false);
+            }
+        };
+
+        // Preserve durability of the just-finished block: complete it and flush
+        // commits via CompleteFile. Re-using AddBlock would ignore commits because
+        // the next block is already allocated on the master.
+        let complete_start = Instant::now();
+        if let Err(e) = self.update_writer(None, false).await {
+            if let Err(cancel_err) = writer.cancel().await {
+                warn!(
+                    "failed to cancel prefetched writer after complete error: {}",
+                    cancel_err
+                );
+            }
+            return Err(e);
+        }
+        debug!(
+            "prefetch boundary old.complete took {:?}, path={}",
+            complete_start.elapsed(),
+            self.path
+        );
+        if let Err(e) = self.flush_pending_commits().await {
+            if let Err(cancel_err) = writer.cancel().await {
+                warn!(
+                    "failed to cancel prefetched writer after commit flush error: {}",
+                    cancel_err
+                );
+            }
+            return Err(e);
+        }
+        self.prefetch_alloc_attempted = false;
+        self.file_blocks.add_block(lb)?;
+        self.cur_writer.replace(writer);
+        Ok(true)
+    }
+
+    async fn flush_pending_commits(&mut self) -> FsResult<()> {
+        let commit_blocks = self.file_blocks.take_commit_blocks();
+        if commit_blocks.is_empty() {
+            return Ok(());
+        }
+
+        for commit in &commit_blocks {
+            self.durable_blocks.insert(commit.block_id);
+        }
+
+        let flush_start = Instant::now();
+        let result = self
+            .fs_client
+            .complete_file_by_id(
+                &self.path,
+                self.file_blocks.status.id,
+                self.len,
+                commit_blocks.clone(),
+                true,
+            )
+            .await;
+        debug!(
+            "prefetch boundary commit flush took {:?}, path={}",
+            flush_start.elapsed(),
+            self.path
+        );
+        if result.is_err() {
+            self.restore_commit_blocks(&commit_blocks);
+        }
+        result.map(|_| ())
+    }
+
+    async fn discard_prefetch(&mut self) {
+        if let Some(handle) = self.next_block_prefetch.take() {
+            handle.abort();
+        }
     }
 
     // Implement seek support for random writes
@@ -425,7 +651,11 @@ impl FsWriterBase {
             return err_box!("Cannot seek to negative position: {}", pos);
         } else if pos == self.pos() {
             return Ok(());
-        } else if pos > self.len {
+        }
+
+        self.discard_prefetch().await;
+
+        if pos > self.len {
             self.pos = pos;
             self.update_writer(None, true).await?;
             return Ok(());
@@ -488,6 +718,8 @@ impl FsWriterBase {
         opts.validate()?;
         let len = opts.len;
 
+        self.discard_prefetch().await;
+
         // Step 1: Flush only when there are uncommitted block writers. A
         // fallocate(2) extend on an open fd often follows fully committed
         // writes; forcing complete() whenever len > 0 can surface EIO from a
@@ -524,6 +756,8 @@ impl FsWriterBase {
         self.pos = self.pos.min(len);
         self.len = len;
         self.file_blocks = file_blocks;
+        self.next_block_prefetch = None;
+        self.prefetch_alloc_attempted = false;
         self.durable_blocks = FastHashSet::with_vec(
             self.file_blocks
                 .block_locs

--- a/curvine-client/src/file/fs_writer_base.rs
+++ b/curvine-client/src/file/fs_writer_base.rs
@@ -149,6 +149,7 @@ impl FsWriterBase {
     /// - this chunk still overflows the current block, or
     /// - `more_data_pending` is true and the current block is within the
     ///   prefetch threshold (so alloc/open overlaps the tail write).
+    ///
     /// Exact EOF with no queued follow-up data does not prefetch.
     pub async fn write_with_more_pending(
         &mut self,

--- a/curvine-client/src/file/fs_writer_base.rs
+++ b/curvine-client/src/file/fs_writer_base.rs
@@ -149,6 +149,15 @@ impl FsWriterBase {
 
         let mut remaining = chunk.len();
         while remaining > 0 {
+            // Only prefetch when this write still needs bytes beyond the current
+            // block. Speculative prefetch near EOF would allocate an unused
+            // 0-length next block that complete()/flush()/seek() must discard.
+            if let Some(cur) = self.cur_writer.as_ref() {
+                if (remaining as i64) > cur.remaining() {
+                    self.maybe_start_prefetch();
+                }
+            }
+
             let cur_writer = self.get_writer().await?;
             let write_len = remaining.min(cur_writer.remaining() as usize);
             cur_writer.write(chunk.split_to(write_len)).await?;
@@ -158,7 +167,6 @@ impl FsWriterBase {
             if self.pos > self.len {
                 self.len = self.pos;
             }
-            self.maybe_start_prefetch();
         }
 
         Ok(())
@@ -179,6 +187,12 @@ impl FsWriterBase {
 
         let mut remaining = chunk.len();
         while remaining > 0 {
+            if let Some(cur) = self.cur_writer.as_ref() {
+                if (remaining as i64) > cur.remaining() {
+                    self.maybe_start_prefetch();
+                }
+            }
+
             let cur_writer = rt.block_on(self.get_writer())?;
             let write_len = remaining.min(cur_writer.remaining() as usize);
 
@@ -190,7 +204,6 @@ impl FsWriterBase {
             if self.pos > self.len {
                 self.len = self.pos;
             }
-            self.maybe_start_prefetch();
         }
 
         Ok(())
@@ -640,8 +653,44 @@ impl FsWriterBase {
     }
 
     async fn discard_prefetch(&mut self) {
-        if let Some(handle) = self.next_block_prefetch.take() {
-            handle.abort();
+        let Some(handle) = self.next_block_prefetch.take() else {
+            return;
+        };
+
+        // Await (do not abort) so a finished alloc/open still yields a writer we
+        // can cancel. complete/flush/seek/resize/cancel are not latency-critical
+        // relative to leaking a worker write session or an untracked next block.
+        match handle.await {
+            Ok(Ok((lb, mut writer))) => {
+                debug!(
+                    "discarding prefetched block {} for path={}",
+                    lb.id, self.path
+                );
+                if let Err(e) = writer.cancel().await {
+                    warn!(
+                        "failed to cancel unused prefetched block writer {}: {}",
+                        writer.block_id(),
+                        e
+                    );
+                }
+                // Master may still retain the empty allocated block. Overflow-only
+                // prefetch avoids this at exact N*block_size EOF; for seek/flush
+                // mid-append, a later AddBlock recovers the same next block via
+                // search_next_block. Keep prefetch_alloc_attempted so sync alloc
+                // flushes commits before AddBlock.
+            }
+            Ok(Err(e)) => {
+                warn!(
+                    "prefetch task failed while discarding for path={}: {:?}",
+                    self.path, e
+                );
+            }
+            Err(e) => {
+                warn!(
+                    "prefetch task join failed while discarding for path={}: {}",
+                    self.path, e
+                );
+            }
         }
     }
 

--- a/curvine-client/src/file/fs_writer_buffer.rs
+++ b/curvine-client/src/file/fs_writer_buffer.rs
@@ -246,17 +246,13 @@ impl FsWriterBuffer {
             match select_task {
                 SelectTask::Control(task) => match task {
                     WriterTask::Flush(cx) => {
-                        while let Some(chunk) = chunk_receiver.try_recv()? {
-                            writer.write(chunk).await?;
-                        }
+                        Self::drain_chunks_with_prefetch(&mut chunk_receiver, &mut writer).await?;
                         writer.flush().await?;
                         cx.send(1)?;
                     }
 
                     WriterTask::Complete((_, tx)) => {
-                        while let Some(chunk) = chunk_receiver.try_recv()? {
-                            writer.write(chunk).await?;
-                        }
+                        Self::drain_chunks_with_prefetch(&mut chunk_receiver, &mut writer).await?;
                         writer.complete().await?;
                         tx.send(1)?;
                         return Ok(());
@@ -273,10 +269,7 @@ impl FsWriterBuffer {
                     }
 
                     WriterTask::Seek((pos, tx)) => {
-                        // Process all buffered data first
-                        while let Some(chunk) = chunk_receiver.try_recv()? {
-                            writer.write(chunk).await?
-                        }
+                        Self::drain_chunks_with_prefetch(&mut chunk_receiver, &mut writer).await?;
 
                         // Execute seek operation
                         writer.seek(pos).await?;
@@ -287,9 +280,7 @@ impl FsWriterBuffer {
                     }
 
                     WriterTask::Resize((opts, tx)) => {
-                        while let Some(chunk) = chunk_receiver.try_recv()? {
-                            writer.write(chunk).await?
-                        }
+                        Self::drain_chunks_with_prefetch(&mut chunk_receiver, &mut writer).await?;
 
                         writer.resize(opts).await?;
 
@@ -300,10 +291,41 @@ impl FsWriterBuffer {
                 },
 
                 SelectTask::Data(chunk) => {
-                    writer.write(chunk).await?;
+                    // Drain any already-queued chunks so we can tell FsWriterBase
+                    // whether more data is pending — required for prefetch overlap
+                    // when write_chunk_size evenly divides block_size.
+                    let mut batch = vec![chunk];
+                    while let Some(next) = chunk_receiver.try_recv()? {
+                        batch.push(next);
+                        if batch.len() >= 32 {
+                            break;
+                        }
+                    }
+                    let last = batch.len() - 1;
+                    for (i, c) in batch.into_iter().enumerate() {
+                        writer.write_with_more_pending(c, i < last).await?;
+                    }
                 }
             }
         }
+    }
+
+    async fn drain_chunks_with_prefetch(
+        chunk_receiver: &mut AsyncReceiver<DataSlice>,
+        writer: &mut FsWriterBase,
+    ) -> FsResult<()> {
+        let mut batch = Vec::new();
+        while let Some(chunk) = chunk_receiver.try_recv()? {
+            batch.push(chunk);
+        }
+        if batch.is_empty() {
+            return Ok(());
+        }
+        let last = batch.len() - 1;
+        for (i, c) in batch.into_iter().enumerate() {
+            writer.write_with_more_pending(c, i < last).await?;
+        }
+        Ok(())
     }
 }
 

--- a/curvine-tests/tests/block_test.rs
+++ b/curvine-tests/tests/block_test.rs
@@ -388,6 +388,111 @@ fn test_sequential_write_across_many_blocks_with_prefetch() -> CommonResult<()> 
     Ok(())
 }
 
+/// Exact N * block_size EOF must not leave a speculative 0-length next block
+/// after complete() (#1291 review: discard_prefetch / EOF prefetch).
+#[test]
+fn test_exact_block_multiple_complete_has_no_extra_empty_block() -> CommonResult<()> {
+    let testing = Testing::default();
+    let mut conf = testing.get_active_cluster_conf()?;
+    conf.client.short_circuit = true;
+    conf.client.block_size = 4 * 1024;
+    conf.client.block_size_str = "4KB".to_string();
+    conf.master.min_block_size = 4 * 1024;
+    conf.client.write_chunk_size = 1024;
+    conf.client.write_chunk_size_str = "1KB".to_string();
+    conf.client.write_chunk_num = 4;
+
+    let rt = Arc::new(conf.client_rpc_conf().create_runtime());
+    let fs = testing.get_fs(Some(rt.clone()), Some(conf))?;
+    let path = Path::from_str("/exact_n_blocks_no_extra.data")?;
+
+    rt.block_on(async move {
+        let block_size = 4 * 1024usize;
+        let n_blocks = 3usize;
+        let total = block_size * n_blocks;
+        let data = BytesMut::from(Utils::rand_str(total).as_bytes());
+
+        let mut writer = fs.create(&path, true).await?;
+        let chunk = 1024;
+        let mut off = 0;
+        while off < data.len() {
+            let end = (off + chunk).min(data.len());
+            writer.write(&data[off..end]).await?;
+            off = end;
+        }
+        writer.complete().await?;
+
+        let locs = fs.get_block_locations(&path).await?;
+        assert_eq!(
+            locs.block_locs.len(),
+            n_blocks,
+            "exact N*block_size complete must not retain a prefetched empty block"
+        );
+        for (i, lb) in locs.block_locs.iter().enumerate() {
+            assert_eq!(
+                lb.block.len as usize, block_size,
+                "block {i} should be full, not 0-length leftover"
+            );
+        }
+        Ok::<(), FsError>(())
+    })?;
+
+    Ok(())
+}
+
+/// Prefetch that is discarded by seek()/flush() must cancel the opened writer
+/// and still allow a consistent complete().
+#[test]
+fn test_prefetch_discard_on_seek_and_flush() -> CommonResult<()> {
+    let testing = Testing::default();
+    let mut conf = testing.get_active_cluster_conf()?;
+    conf.client.short_circuit = true;
+    conf.client.block_size = 4 * 1024;
+    conf.client.block_size_str = "4KB".to_string();
+    conf.master.min_block_size = 4 * 1024;
+    conf.client.write_chunk_size = 1024;
+    conf.client.write_chunk_size_str = "1KB".to_string();
+    conf.client.write_chunk_num = 4;
+
+    let rt = Arc::new(conf.client_rpc_conf().create_runtime());
+    let fs = testing.get_fs(Some(rt.clone()), Some(conf))?;
+
+    rt.block_on(async move {
+        let block_size = 4 * 1024usize;
+        // One write that overflows the first block so prefetch starts, then seek.
+        let path_seek = Path::from_str("/prefetch_discard_seek.data")?;
+        let overflow = block_size + block_size / 2;
+        let data = BytesMut::from(Utils::rand_str(overflow).as_bytes());
+        let mut writer = fs.create(&path_seek, true).await?;
+        writer.write(&data).await?;
+        // Discard in-flight/ready prefetch via seek, then finish cleanly.
+        writer.seek(0).await?;
+        writer.complete().await?;
+
+        let locs = fs.get_block_locations(&path_seek).await?;
+        assert!(
+            !locs.block_locs.is_empty(),
+            "file should retain written blocks after seek-discard"
+        );
+
+        // Overflow write then flush (also discards prefetch) then more write + complete.
+        let path_flush = Path::from_str("/prefetch_discard_flush.data")?;
+        let mut writer = fs.create(&path_flush, true).await?;
+        writer.write(&data).await?;
+        writer.flush().await?;
+        let more = BytesMut::from(Utils::rand_str(512).as_bytes());
+        writer.write(&more).await?;
+        writer.complete().await?;
+
+        let locs = fs.get_block_locations(&path_flush).await?;
+        let committed: i64 = locs.block_locs.iter().map(|b| b.block.len).sum();
+        assert_eq!(committed, (overflow + 512) as i64);
+        Ok::<(), FsError>(())
+    })?;
+
+    Ok(())
+}
+
 fn random_write(mut conf: ClusterConf, mark: &str) -> CommonResult<()> {
     let block_size = 1024;
     conf.client.block_size = block_size; // 1KB block size

--- a/curvine-tests/tests/block_test.rs
+++ b/curvine-tests/tests/block_test.rs
@@ -337,6 +337,10 @@ fn test_remote_random_write_with_replication() -> CommonResult<()> {
 
 /// Sequential append across many small blocks exercises next-block prefetch
 /// (#1291): allocate/open of block N+1 overlaps writing the tail of block N.
+///
+/// `write_chunk_size` must not evenly divide `block_size`, otherwise
+/// `Writer::write` delivers aligned chunks that never overflow a block and
+/// (without queued follow-up) would skip the prefetch gate.
 #[test]
 fn test_sequential_write_across_many_blocks_with_prefetch() -> CommonResult<()> {
     let testing = Testing::default();
@@ -345,9 +349,9 @@ fn test_sequential_write_across_many_blocks_with_prefetch() -> CommonResult<()> 
     conf.client.block_size = 4 * 1024;
     conf.client.block_size_str = "4KB".to_string();
     conf.master.min_block_size = 4 * 1024;
-    conf.client.write_chunk_size = 1024;
-    conf.client.write_chunk_size_str = "1KB".to_string();
-    conf.client.write_chunk_num = 4;
+    conf.client.write_chunk_size = 1500;
+    conf.client.write_chunk_size_str = "1500B".to_string();
+    conf.client.write_chunk_num = 8;
 
     let rt = Arc::new(conf.client_rpc_conf().create_runtime());
     let fs = testing.get_fs(Some(rt.clone()), Some(conf))?;
@@ -359,14 +363,9 @@ fn test_sequential_write_across_many_blocks_with_prefetch() -> CommonResult<()> 
         let data = BytesMut::from(Utils::rand_str(total).as_bytes());
 
         let mut writer = fs.create(&path, true).await?;
-        // Write in chunk-sized pieces so remaining() crosses the prefetch threshold.
-        let chunk = 1024;
-        let mut off = 0;
-        while off < data.len() {
-            let end = (off + chunk).min(data.len());
-            writer.write(&data[off..end]).await?;
-            off = end;
-        }
+        // One large write queues multiple buffer chunks so prefetch can overlap
+        // the current-block tail (and 1500 does not divide 4096).
+        writer.write(&data).await?;
         writer.complete().await?;
 
         let mut reader = fs.open(&path).await?;
@@ -398,9 +397,9 @@ fn test_exact_block_multiple_complete_has_no_extra_empty_block() -> CommonResult
     conf.client.block_size = 4 * 1024;
     conf.client.block_size_str = "4KB".to_string();
     conf.master.min_block_size = 4 * 1024;
-    conf.client.write_chunk_size = 1024;
-    conf.client.write_chunk_size_str = "1KB".to_string();
-    conf.client.write_chunk_num = 4;
+    conf.client.write_chunk_size = 1500;
+    conf.client.write_chunk_size_str = "1500B".to_string();
+    conf.client.write_chunk_num = 8;
 
     let rt = Arc::new(conf.client_rpc_conf().create_runtime());
     let fs = testing.get_fs(Some(rt.clone()), Some(conf))?;
@@ -413,13 +412,7 @@ fn test_exact_block_multiple_complete_has_no_extra_empty_block() -> CommonResult
         let data = BytesMut::from(Utils::rand_str(total).as_bytes());
 
         let mut writer = fs.create(&path, true).await?;
-        let chunk = 1024;
-        let mut off = 0;
-        while off < data.len() {
-            let end = (off + chunk).min(data.len());
-            writer.write(&data[off..end]).await?;
-            off = end;
-        }
+        writer.write(&data).await?;
         writer.complete().await?;
 
         let locs = fs.get_block_locations(&path).await?;
@@ -442,6 +435,10 @@ fn test_exact_block_multiple_complete_has_no_extra_empty_block() -> CommonResult
 
 /// Prefetch that is discarded by seek()/flush() must cancel the opened writer
 /// and still allow a consistent complete().
+///
+/// Uses `async_write` with a payload larger than `block_size` so `FsWriterBase`
+/// sees an overflowing slice and actually enters the prefetch path (unlike
+/// aligned `Writer::write` chunks that never overflow a single block).
 #[test]
 fn test_prefetch_discard_on_seek_and_flush() -> CommonResult<()> {
     let testing = Testing::default();
@@ -450,22 +447,23 @@ fn test_prefetch_discard_on_seek_and_flush() -> CommonResult<()> {
     conf.client.block_size = 4 * 1024;
     conf.client.block_size_str = "4KB".to_string();
     conf.master.min_block_size = 4 * 1024;
-    conf.client.write_chunk_size = 1024;
-    conf.client.write_chunk_size_str = "1KB".to_string();
-    conf.client.write_chunk_num = 4;
+    conf.client.write_chunk_size = 1500;
+    conf.client.write_chunk_size_str = "1500B".to_string();
+    conf.client.write_chunk_num = 8;
 
     let rt = Arc::new(conf.client_rpc_conf().create_runtime());
     let fs = testing.get_fs(Some(rt.clone()), Some(conf))?;
 
     rt.block_on(async move {
+        use orpc::sys::DataSlice;
+
         let block_size = 4 * 1024usize;
-        // One write that overflows the first block so prefetch starts, then seek.
         let path_seek = Path::from_str("/prefetch_discard_seek.data")?;
         let overflow = block_size + block_size / 2;
         let data = BytesMut::from(Utils::rand_str(overflow).as_bytes());
         let mut writer = fs.create(&path_seek, true).await?;
-        writer.write(&data).await?;
-        // Discard in-flight/ready prefetch via seek, then finish cleanly.
+        writer.async_write(DataSlice::Bytes(data.freeze())).await?;
+        // May discard an in-flight next-block prefetch if still pending.
         writer.seek(0).await?;
         writer.complete().await?;
 
@@ -475,10 +473,10 @@ fn test_prefetch_discard_on_seek_and_flush() -> CommonResult<()> {
             "file should retain written blocks after seek-discard"
         );
 
-        // Overflow write then flush (also discards prefetch) then more write + complete.
         let path_flush = Path::from_str("/prefetch_discard_flush.data")?;
+        let data = BytesMut::from(Utils::rand_str(overflow).as_bytes());
         let mut writer = fs.create(&path_flush, true).await?;
-        writer.write(&data).await?;
+        writer.async_write(DataSlice::Bytes(data.freeze())).await?;
         writer.flush().await?;
         let more = BytesMut::from(Utils::rand_str(512).as_bytes());
         writer.write(&more).await?;

--- a/curvine-tests/tests/block_test.rs
+++ b/curvine-tests/tests/block_test.rs
@@ -335,6 +335,59 @@ fn test_remote_random_write_with_replication() -> CommonResult<()> {
     random_write(conf, "remote_replicas")
 }
 
+/// Sequential append across many small blocks exercises next-block prefetch
+/// (#1291): allocate/open of block N+1 overlaps writing the tail of block N.
+#[test]
+fn test_sequential_write_across_many_blocks_with_prefetch() -> CommonResult<()> {
+    let testing = Testing::default();
+    let mut conf = testing.get_active_cluster_conf()?;
+    conf.client.short_circuit = true;
+    conf.client.block_size = 4 * 1024;
+    conf.client.block_size_str = "4KB".to_string();
+    conf.master.min_block_size = 4 * 1024;
+    conf.client.write_chunk_size = 1024;
+    conf.client.write_chunk_size_str = "1KB".to_string();
+    conf.client.write_chunk_num = 4;
+
+    let rt = Arc::new(conf.client_rpc_conf().create_runtime());
+    let fs = testing.get_fs(Some(rt.clone()), Some(conf))?;
+    let path = Path::from_str("/sequential_prefetch_many_blocks.data")?;
+
+    rt.block_on(async move {
+        let block_size = 4 * 1024usize;
+        let total = block_size * 8 + 512; // cross 8 full block boundaries
+        let data = BytesMut::from(Utils::rand_str(total).as_bytes());
+
+        let mut writer = fs.create(&path, true).await?;
+        // Write in chunk-sized pieces so remaining() crosses the prefetch threshold.
+        let chunk = 1024;
+        let mut off = 0;
+        while off < data.len() {
+            let end = (off + chunk).min(data.len());
+            writer.write(&data[off..end]).await?;
+            off = end;
+        }
+        writer.complete().await?;
+
+        let mut reader = fs.open(&path).await?;
+        let mut buf = BytesMut::zeroed(total);
+        let mut read = 0;
+        while read < total {
+            let n = reader.read(&mut buf[read..]).await?;
+            if n == 0 {
+                break;
+            }
+            read += n;
+        }
+        assert_eq!(read, total);
+        assert_eq!(&buf[..], &data[..]);
+        reader.complete().await?;
+        Ok::<(), FsError>(())
+    })?;
+
+    Ok(())
+}
+
 fn random_write(mut conf: ClusterConf, mark: &str) -> CommonResult<()> {
     let block_size = 1024;
     conf.client.block_size = block_size; // 1KB block size


### PR DESCRIPTION
# Summary

Prefetch the next block (`add_block` + `BlockWriter::new`) while writing the tail of the current block so sequential appends through `curvine-fuse` / buffered writers no longer stall the single per-file `write_future` for a full master+worker round-trip at every `block_size` boundary.

# Issue Describe / Design

Closes #1291

## Root cause

At each block boundary, `FsWriterBase::get_writer` serialized `old.complete()` → `add_block_by_id` (commit piggybacked) → `BlockWriter::new` on the only drain task. The bounded chunk channel filled and concurrent writers parked, matching the observed multi-second idle stalls.

## Fix approach

1. Prefetch when the current write overflows the active block, **or** when `FsWriterBuffer` has more queued chunks and the current block is within the prefetch threshold (keeps overlap for aligned `write_chunk_size` / `block_size`).
2. Exact EOF with no queued follow-up data does not prefetch (avoids empty next-block orphans).
3. At the boundary, install the prefetched writer after completing the old block; flush commits via `CompleteFile(only_flush=true)` because piggybacked `AddBlock` commits are ignored once next is allocated.
4. `discard_prefetch` awaits and `cancel()`s unused writers; `Drop` aborts in-flight tasks or cancels finished writers.
5. Regression tests use non-divisible chunk sizes and/or `async_write` so the prefetch path is actually exercised.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-client/src/file/fs_writer_base.rs` | Prefetch gates, discard/Drop cleanup, `write_with_more_pending` | Sequential append overlaps next-block alloc/open; drop-without-cleanup no longer leaks finished prefetch writers |
| `curvine-client/src/file/fs_writer_buffer.rs` | Batch queued chunks and pass `more_data_pending` | Aligned chunk/block writes can prefetch from queued follow-up data |
| `curvine-tests/tests/block_test.rs` | Prefetch / EOF / discard regressions | None |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `make format` | PASS | fmt + clippy (`-D warnings`) |
| `test_sequential_write_across_many_blocks_with_prefetch` | PASS | `write_chunk_size=1500`, `block_size=4096` |
| `test_exact_block_multiple_complete_has_no_extra_empty_block` | PASS | Exact 3×block_size → exactly 3 full blocks |
| `test_prefetch_discard_on_seek_and_flush` | PASS | `async_write` overflow + seek/flush |

# Dependencies

- Related PRs: None
- Related issues: #1291
- Blocks / blocked by: None