### PR TITLE
fix(fuse): align mode and protected-link permission checks with POSIX (#1269)

### DIFF
--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -456,17 +456,27 @@ impl CurvineFileSystem {
             }
         };
 
+        let meta_ttl = self.conf.meta_cache_ttl.as_millis() as u64;
         while dir_ino != 0 {
             let check_header = fuse_in_header {
                 uid: header.uid,
                 gid: header.gid,
+                pid: header.pid,
                 nodeid: dir_ino,
                 ..Default::default()
             };
+            // Only trust ACL bits from a valid dcache entry. The mount-root placeholder
+            // starts as Lifecycle::Invalid; using it fail-closes every non-root traverse
+            // with EACCES (breaks LTP chmod/chown under nobody).
             let cached_status = {
                 let dir = self.state.dir_read();
-                dir.get_inode(dir_ino, None)
-                    .map(|inode| inode.clone_status())
+                dir.get_inode(dir_ino, None).and_then(|inode| {
+                    if inode.cache_valid(meta_ttl) {
+                        Some(inode.clone_status())
+                    } else {
+                        None
+                    }
+                })
             };
             if let Some(status) = cached_status {
                 self.check_access_permissions(&status, &check_header, libc::X_OK as u32)?;
@@ -501,6 +511,7 @@ impl CurvineFileSystem {
             status.mode,
             header.uid,
             header.gid,
+            header.pid,
             file_uid,
             file_gid,
         );
@@ -572,19 +583,23 @@ impl CurvineFileSystem {
         }
     }
 
-    /// Determine which permission bits to check based on user relationship to file
+    /// Determine which permission bits to check based on user relationship to file.
+    ///
+    /// Group membership includes the caller's effective gid and supplementary groups
+    /// from `/proc/<pid>/status` (same source as setattr setgid checks).
     fn get_effective_permission_bits(
         &self,
         mode: u32,
         current_uid: u32,
         current_gid: u32,
+        caller_pid: u32,
         file_uid: u32,
         file_gid: u32,
     ) -> u32 {
         if current_uid == file_uid {
             // Owner permissions (bits 8-10)
             (mode >> 6) & 0o7
-        } else if current_gid == file_gid {
+        } else if FuseUtils::caller_in_file_group(current_gid, file_gid, caller_pid) {
             // Group permissions (bits 5-7)
             (mode >> 3) & 0o7
         } else {
@@ -1089,7 +1104,10 @@ impl fs::FileSystem for CurvineFileSystem {
 
         let mode_only = (op.arg.valid & (FATTR_UID | FATTR_GID | FATTR_SIZE)) == 0
             && (op.arg.valid & FATTR_MODE) != 0;
-        let skip_traverse = op.arg.fh != 0 || (mode_only && op.header.uid == file_uid);
+        // Path-based chmod must still traverse; fh-based fchmod/fchown must not
+        // (POSIX open-file descriptors do not re-check path search permission).
+        let skip_traverse =
+            (op.arg.valid & FATTR_FH) != 0 || (mode_only && op.header.uid == file_uid);
 
         if !skip_traverse {
             self.check_traverse_permissions(op.header.nodeid, op.header)

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -1224,12 +1224,11 @@ impl fs::FileSystem for CurvineFileSystem {
             None
         };
 
-        let mode_only = (op.arg.valid & (FATTR_UID | FATTR_GID | FATTR_SIZE)) == 0
-            && (op.arg.valid & FATTR_MODE) != 0;
-        // Path-based chmod must still traverse; fh-based fchmod/fchown must not
-        // (POSIX open-file descriptors do not re-check path search permission).
-        let skip_traverse =
-            (op.arg.valid & FATTR_FH) != 0 || (mode_only && op.header.uid == file_uid);
+        // Path-based chmod(2)/chown(2)/truncate must still traverse the path prefix
+        // regardless of file ownership (POSIX search permission). Only fh-based
+        // fchmod/fchown (FATTR_FH) skips traverse — open-file descriptors do not
+        // re-check path search permission.
+        let skip_traverse = (op.arg.valid & FATTR_FH) != 0;
 
         if !skip_traverse {
             self.check_traverse_permissions(op.header.nodeid, op.header)

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -727,6 +727,84 @@ impl CurvineFileSystem {
         valid != 0 && (valid & !Self::SETATTR_TIME_VALID) == 0
     }
 
+    /// Linux `fs.protected_symlinks`: in sticky+world-writable directories, following a
+    /// symlink is allowed only if the follower owns the symlink, or the directory
+    /// owner matches the symlink owner. CAP_DAC_OVERRIDE does **not** bypass this
+    /// (root as sticky-dir owner still gets EACCES for another user's symlink).
+    ///
+    /// FUSE may not reliably apply VFS `may_follow_link` (attribute/sticky reporting
+    /// differences), so enforce the same policy in userspace when `check_permission`.
+    fn check_protected_symlink_follow(
+        check_permission: bool,
+        follower_uid: u32,
+        symlink_uid: u32,
+        parent_uid: u32,
+        parent_mode: u32,
+    ) -> FuseResult<()> {
+        if !check_permission {
+            return Ok(());
+        }
+        if follower_uid == symlink_uid || parent_uid == symlink_uid {
+            return Ok(());
+        }
+        let sticky_world = (libc::S_ISVTX as u32) | (libc::S_IWOTH as u32);
+        if (parent_mode & sticky_world) != sticky_world {
+            return Ok(());
+        }
+        err_fuse!(
+            libc::EACCES,
+            "protected_symlinks: uid {} may not follow symlink owned by uid {} \
+             in sticky world-writable dir owned by uid {}",
+            follower_uid,
+            symlink_uid,
+            parent_uid
+        )
+    }
+
+    /// Linux `fs.protected_hardlinks` / `may_linkat`: non-owners may hardlink a
+    /// regular file only when it is a safe source (no setuid / dangerous setgid)
+    /// and the caller has read+write permission. Otherwise EPERM. Root/owner always
+    /// allowed (capability / ownership bypass).
+    fn check_protected_hardlink(
+        check_permission: bool,
+        caller_uid: u32,
+        file_uid: u32,
+        file_type: FileType,
+        mode: u32,
+        has_read_write: bool,
+    ) -> FuseResult<()> {
+        if !check_permission || caller_uid == 0 || caller_uid == file_uid {
+            return Ok(());
+        }
+        if file_type != FileType::File {
+            return err_fuse!(
+                libc::EPERM,
+                "protected_hardlinks: non-owner may not hardlink non-regular file"
+            );
+        }
+        if (mode & libc::S_ISUID as u32) != 0 {
+            return err_fuse!(
+                libc::EPERM,
+                "protected_hardlinks: non-owner may not hardlink setuid file"
+            );
+        }
+        if (mode & (libc::S_ISGID as u32 | libc::S_IXGRP as u32))
+            == (libc::S_ISGID as u32 | libc::S_IXGRP as u32)
+        {
+            return err_fuse!(
+                libc::EPERM,
+                "protected_hardlinks: non-owner may not hardlink setgid+group-exec file"
+            );
+        }
+        if !has_read_write {
+            return err_fuse!(
+                libc::EPERM,
+                "protected_hardlinks: non-owner needs read+write on source"
+            );
+        }
+        Ok(())
+    }
+
     /// Linux utime(2): owner/root may always set times; NULL/`*_NOW` also allow W_OK.
     #[allow(clippy::too_many_arguments)]
     fn check_utime_setattr_permission(
@@ -1599,6 +1677,23 @@ impl fs::FileSystem for CurvineFileSystem {
         self.ensure_writable_path(&src_path, RpcCode::Link).await?;
         self.ensure_writable_path(&des_path, RpcCode::Link).await?;
 
+        // fs.protected_hardlinks (LTP prot_hsymlinks): deny unsafe non-owner hardlinks.
+        if self.conf.check_permission {
+            let src_status = self.state.fs_stat(oldnodeid, None).await?;
+            let file_uid = self.resolve_file_uid(&src_status.owner);
+            let has_read_write = self
+                .check_access_permissions(&src_status, op.header, (libc::R_OK | libc::W_OK) as u32)
+                .is_ok();
+            Self::check_protected_hardlink(
+                true,
+                op.header.uid,
+                file_uid,
+                src_status.file_type,
+                src_status.mode,
+                has_read_write,
+            )?;
+        }
+
         debug!(
             "link: src_path={}, des_path={}, oldnodeid={}, parent={}",
             src_path, des_path, oldnodeid, op.header.nodeid
@@ -1690,6 +1785,25 @@ impl fs::FileSystem for CurvineFileSystem {
         // Check if it's actually a symlink
         if status.file_type != FileType::Link {
             return err_fuse!(libc::EINVAL, "Not a symbolic link: {}", status.path);
+        }
+
+        // fs.protected_symlinks (LTP prot_hsymlinks): VFS may_follow_link is not
+        // reliably enforced for this FUSE mount, so apply the same sticky-dir policy
+        // when the kernel issues READLINK to follow a symlink. Root is not exempt.
+        if self.conf.check_permission {
+            let symlink_uid = self.resolve_file_uid(&status.owner);
+            let parent_ino = self.state.get_parent_ino(op.header.nodeid)?;
+            if parent_ino != 0 {
+                let parent_status = self.state.fs_stat(parent_ino, None).await?;
+                let parent_uid = self.resolve_file_uid(&parent_status.owner);
+                Self::check_protected_symlink_follow(
+                    true,
+                    op.header.uid,
+                    symlink_uid,
+                    parent_uid,
+                    parent_status.mode,
+                )?;
+            }
         }
 
         // Get the target from the file status
@@ -1901,7 +2015,7 @@ impl fs::FileSystem for CurvineFileSystem {
 #[cfg(test)]
 mod tests {
     use crate::{FATTR_ATIME_NOW, FATTR_GID, FATTR_MODE, FATTR_MTIME, FATTR_MTIME_NOW, FATTR_UID};
-    use curvine_common::state::{FileAllocMode, INTERNAL_CTIME_XATTR};
+    use curvine_common::state::{FileAllocMode, FileType, INTERNAL_CTIME_XATTR};
 
     #[test]
     fn posix_access_requires_mode_check_for_root() {
@@ -2191,6 +2305,81 @@ mod tests {
         )
         .unwrap_err();
         assert_eq!(err.errno(), libc::EACCES);
+    }
+
+    #[test]
+    fn protected_symlinks_denies_sticky_dir_owner_following_foreign_link() {
+        // prot_hsymlinks link_4: root owns sticky dir, hsym owns symlink.
+        let err =
+            super::CurvineFileSystem::check_protected_symlink_follow(true, 0, 1000, 0, 0o1777)
+                .unwrap_err();
+        assert_eq!(err.errno(), libc::EACCES);
+
+        // prot_hsymlinks link_5: hsym owns sticky dir, root owns symlink.
+        let err =
+            super::CurvineFileSystem::check_protected_symlink_follow(true, 1000, 0, 1000, 0o1777)
+                .unwrap_err();
+        assert_eq!(err.errno(), libc::EACCES);
+    }
+
+    #[test]
+    fn protected_symlinks_allows_owner_match_or_non_sticky() {
+        // Follower owns the symlink.
+        super::CurvineFileSystem::check_protected_symlink_follow(true, 1000, 1000, 0, 0o1777)
+            .unwrap();
+        // Directory owner matches symlink owner.
+        super::CurvineFileSystem::check_protected_symlink_follow(true, 0, 1000, 1000, 0o1777)
+            .unwrap();
+        // Not sticky+world-writable.
+        super::CurvineFileSystem::check_protected_symlink_follow(true, 0, 1000, 0, 0o0777).unwrap();
+        // check_permission disabled.
+        super::CurvineFileSystem::check_protected_symlink_follow(false, 0, 1000, 0, 0o1777)
+            .unwrap();
+    }
+
+    #[test]
+    fn protected_hardlinks_denies_non_owner_without_rw() {
+        let err = super::CurvineFileSystem::check_protected_hardlink(
+            true,
+            1000,
+            0,
+            FileType::File,
+            0o644,
+            false,
+        )
+        .unwrap_err();
+        assert_eq!(err.errno(), libc::EPERM);
+    }
+
+    #[test]
+    fn protected_hardlinks_allows_owner_root_or_rw_source() {
+        super::CurvineFileSystem::check_protected_hardlink(
+            true,
+            0,
+            0,
+            FileType::File,
+            0o644,
+            false,
+        )
+        .unwrap();
+        super::CurvineFileSystem::check_protected_hardlink(
+            true,
+            1000,
+            1000,
+            FileType::File,
+            0o644,
+            false,
+        )
+        .unwrap();
+        super::CurvineFileSystem::check_protected_hardlink(
+            true,
+            1000,
+            0,
+            FileType::File,
+            0o666,
+            true,
+        )
+        .unwrap();
     }
 
     /// Pin that `FuseMetrics::ensure_init()` runs before `NodeState::new()` in

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -659,6 +659,7 @@ impl CurvineFileSystem {
         check_permission: bool,
         caller_uid: u32,
         caller_gid: u32,
+        caller_pid: u32,
         file_uid: u32,
         valid: u32,
         target_gid: Option<u32>,
@@ -684,7 +685,7 @@ impl CurvineFileSystem {
                 );
             }
             if let Some(gid) = target_gid {
-                if !FuseUtils::caller_in_file_group(caller_gid, gid) {
+                if !FuseUtils::caller_in_file_group(caller_gid, gid, caller_pid) {
                     return err_fuse!(
                         libc::EPERM,
                         "setattr gid change denied for gid {} not in caller groups",
@@ -1077,9 +1078,6 @@ impl fs::FileSystem for CurvineFileSystem {
         let path = self.state.get_path(op.header.nodeid)?;
         self.ensure_writable_path(&path, RpcCode::SetAttr).await?;
 
-        self.check_traverse_permissions(op.header.nodeid, op.header)
-            .await?;
-
         let cur_status = self.state.fs_stat(op.header.nodeid, None).await?;
         let file_uid = self.resolve_file_uid(&cur_status.owner);
         let file_gid = self.resolve_file_gid(&cur_status.group);
@@ -1088,10 +1086,21 @@ impl fs::FileSystem for CurvineFileSystem {
         } else {
             None
         };
+
+        let mode_only = (op.arg.valid & (FATTR_UID | FATTR_GID | FATTR_SIZE)) == 0
+            && (op.arg.valid & FATTR_MODE) != 0;
+        let skip_traverse = op.arg.fh != 0 || (mode_only && op.header.uid == file_uid);
+
+        if !skip_traverse {
+            self.check_traverse_permissions(op.header.nodeid, op.header)
+                .await?;
+        }
+
         Self::check_setattr_permission(
             self.conf.check_permission,
             op.header.uid,
             op.header.gid,
+            op.header.pid,
             file_uid,
             op.arg.valid,
             target_gid,
@@ -1102,7 +1111,8 @@ impl fs::FileSystem for CurvineFileSystem {
 
         if (op.arg.valid & FATTR_MODE) != 0 {
             if let Some(mode) = opts.mode {
-                let in_file_group = FuseUtils::caller_in_file_group(op.header.gid, file_gid);
+                let in_file_group =
+                    FuseUtils::caller_in_file_group(op.header.gid, file_gid, op.header.pid);
                 opts.mode = Some(FuseUtils::normalize_chmod_mode(
                     mode,
                     op.header.uid,
@@ -1965,7 +1975,7 @@ mod tests {
     #[test]
     fn setattr_permission_denies_non_owner_chown() {
         let err = super::CurvineFileSystem::check_setattr_permission(
-            true, 1000, 1000, 0, FATTR_UID, None,
+            true, 1000, 1000, 0, 0, FATTR_UID, None,
         )
         .unwrap_err();
         assert_eq!(err.errno(), libc::EPERM);
@@ -1974,7 +1984,7 @@ mod tests {
     #[test]
     fn setattr_permission_denies_owner_uid_change() {
         let err = super::CurvineFileSystem::check_setattr_permission(
-            true, 1000, 1000, 1000, FATTR_UID, None,
+            true, 1000, 1000, 0, 1000, FATTR_UID, None,
         )
         .unwrap_err();
         assert_eq!(err.errno(), libc::EPERM);
@@ -1982,14 +1992,14 @@ mod tests {
 
     #[test]
     fn setattr_permission_allows_root_chown() {
-        super::CurvineFileSystem::check_setattr_permission(true, 0, 0, 1000, FATTR_UID, None)
+        super::CurvineFileSystem::check_setattr_permission(true, 0, 0, 0, 1000, FATTR_UID, None)
             .unwrap();
     }
 
     #[test]
     fn setattr_permission_allows_owner_mode_change() {
         super::CurvineFileSystem::check_setattr_permission(
-            true, 1000, 1000, 1000, FATTR_MODE, None,
+            true, 1000, 1000, 0, 1000, FATTR_MODE, None,
         )
         .unwrap();
     }
@@ -2000,6 +2010,7 @@ mod tests {
             true,
             1000,
             100,
+            0,
             1000,
             FATTR_GID,
             Some(200),
@@ -2014,6 +2025,7 @@ mod tests {
             true,
             1000,
             100,
+            0,
             1000,
             FATTR_GID,
             Some(100),
@@ -2023,8 +2035,16 @@ mod tests {
 
     #[test]
     fn setattr_permission_ignores_mtime_only_changes() {
-        super::CurvineFileSystem::check_setattr_permission(true, 1000, 1000, 0, FATTR_MTIME, None)
-            .unwrap();
+        super::CurvineFileSystem::check_setattr_permission(
+            true,
+            1000,
+            1000,
+            0,
+            0,
+            FATTR_MTIME,
+            None,
+        )
+        .unwrap();
     }
 
     /// Pin that `FuseMetrics::ensure_init()` runs before `NodeState::new()` in

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -721,6 +721,49 @@ impl CurvineFileSystem {
         Ok(())
     }
 
+    const SETATTR_TIME_VALID: u32 = FATTR_ATIME | FATTR_MTIME | FATTR_ATIME_NOW | FATTR_MTIME_NOW;
+
+    fn is_time_only_setattr(valid: u32) -> bool {
+        valid != 0 && (valid & !Self::SETATTR_TIME_VALID) == 0
+    }
+
+    /// Linux utime(2): owner/root may always set times; NULL/`*_NOW` also allow W_OK.
+    #[allow(clippy::too_many_arguments)]
+    fn check_utime_setattr_permission(
+        check_permission: bool,
+        valid: u32,
+        caller_uid: u32,
+        caller_gid: u32,
+        caller_pid: u32,
+        file_uid: u32,
+        file_gid: u32,
+        mode: u32,
+    ) -> FuseResult<()> {
+        if !check_permission || caller_uid == 0 || caller_uid == file_uid {
+            return Ok(());
+        }
+
+        let setting_now = (valid & (FATTR_ATIME_NOW | FATTR_MTIME_NOW)) != 0;
+        if setting_now {
+            let permission_bits =
+                if FuseUtils::caller_in_file_group(caller_gid, file_gid, caller_pid) {
+                    (mode >> 3) & 0o7
+                } else {
+                    mode & 0o7
+                };
+            if Self::permission_mask_allows(permission_bits, libc::W_OK as u32) {
+                return Ok(());
+            }
+            return err_fuse!(
+                libc::EACCES,
+                "utime denied without write access for uid {}",
+                caller_uid
+            );
+        }
+
+        err_fuse!(libc::EPERM, "utime denied for non-owner uid {}", caller_uid)
+    }
+
     /// Negotiate init reply flags as an explicit allowlist, not a blind echo:
     /// 1. Kernel-negotiated: `SUPPORTED_INIT_FLAGS & kernel_flags` (only caps the
     ///    daemon implements AND the kernel offered — see `SUPPORTED_INIT_FLAGS` for
@@ -1076,9 +1119,10 @@ impl fs::FileSystem for CurvineFileSystem {
         let mut fuse_attr = FuseUtils::status_to_attr(&self.conf, &status)?;
         fuse_attr.ino = op.header.nodeid;
         self.state.update_writer_len(&mut fuse_attr).await;
+        let (_, _, attr_valid, attr_valid_nsec) = FuseUtils::kernel_cache_timeouts(&self.conf);
         let attr = fuse_attr_out {
-            attr_valid: self.conf.attr_ttl.as_secs(),
-            attr_valid_nsec: self.conf.attr_ttl.subsec_nanos(),
+            attr_valid,
+            attr_valid_nsec,
             dummy: 0,
             attr: fuse_attr,
         };
@@ -1114,15 +1158,33 @@ impl fs::FileSystem for CurvineFileSystem {
                 .await?;
         }
 
-        Self::check_setattr_permission(
-            self.conf.check_permission,
-            op.header.uid,
-            op.header.gid,
-            op.header.pid,
-            file_uid,
-            op.arg.valid,
-            target_gid,
-        )?;
+        if Self::is_time_only_setattr(op.arg.valid) {
+            Self::check_utime_setattr_permission(
+                self.conf.check_permission,
+                op.arg.valid,
+                op.header.uid,
+                op.header.gid,
+                op.header.pid,
+                file_uid,
+                file_gid,
+                cur_status.mode,
+            )?;
+        } else {
+            Self::check_setattr_permission(
+                self.conf.check_permission,
+                op.header.uid,
+                op.header.gid,
+                op.header.pid,
+                file_uid,
+                op.arg.valid,
+                target_gid,
+            )?;
+        }
+
+        // truncate(2) / ftruncate: write permission required on the named file.
+        if (op.arg.valid & FATTR_SIZE) != 0 && self.conf.check_permission && op.header.uid != 0 {
+            self.check_access_permissions(&cur_status, op.header, libc::W_OK as u32)?;
+        }
 
         // Convert setattr to opts with UID/GID numeric fallback
         let mut opts = FuseUtils::fuse_setattr_to_opts(op.arg)?;
@@ -1178,9 +1240,10 @@ impl fs::FileSystem for CurvineFileSystem {
         // the writer's final metadata commit. Never let its stale size shrink the
         // kernel inode below the bytes already accepted by the active writer.
         self.state.update_writer_len(&mut attr).await;
+        let (_, _, attr_valid, attr_valid_nsec) = FuseUtils::kernel_cache_timeouts(&self.conf);
         let attr = fuse_attr_out {
-            attr_valid: self.conf.attr_ttl.as_secs(),
-            attr_valid_nsec: self.conf.attr_ttl.subsec_nanos(),
+            attr_valid,
+            attr_valid_nsec,
             dummy: 0,
             attr,
         };
@@ -1404,14 +1467,16 @@ impl fs::FileSystem for CurvineFileSystem {
             );
         }
 
+        let (entry_valid, entry_valid_nsec, attr_valid, attr_valid_nsec) =
+            FuseUtils::kernel_cache_timeouts(&self.conf);
         let r = fuse_create_out(
             fuse_entry_out {
                 nodeid: handle.ino(),
                 generation: 0,
-                entry_valid: self.conf.entry_ttl.as_secs(),
-                attr_valid: self.conf.attr_ttl.as_secs(),
-                entry_valid_nsec: self.conf.entry_ttl.subsec_nanos(),
-                attr_valid_nsec: self.conf.attr_ttl.subsec_nanos(),
+                entry_valid,
+                attr_valid,
+                entry_valid_nsec,
+                attr_valid_nsec,
                 attr,
             },
             fuse_open_out {
@@ -1614,6 +1679,11 @@ impl fs::FileSystem for CurvineFileSystem {
 
     // Read the target of a symbolic link
     async fn readlink(&self, op: Readlink<'_>) -> FuseResult<BytesMut> {
+        // Path-based readlink(2) requires search permission on every directory in
+        // the path prefix (LTP readlink03 EACCES).
+        self.check_traverse_permissions(op.header.nodeid, op.header)
+            .await?;
+
         // Get file status to read the symlink target
         let status = self.state.fs_stat(op.header.nodeid, None).await?;
 
@@ -1830,7 +1900,7 @@ impl fs::FileSystem for CurvineFileSystem {
 
 #[cfg(test)]
 mod tests {
-    use crate::{FATTR_GID, FATTR_MODE, FATTR_MTIME, FATTR_UID};
+    use crate::{FATTR_ATIME_NOW, FATTR_GID, FATTR_MODE, FATTR_MTIME, FATTR_MTIME_NOW, FATTR_UID};
     use curvine_common::state::{FileAllocMode, INTERNAL_CTIME_XATTR};
 
     #[test]
@@ -2063,6 +2133,64 @@ mod tests {
             None,
         )
         .unwrap();
+    }
+
+    #[test]
+    fn is_time_only_setattr_detects_utime_flags() {
+        assert!(super::CurvineFileSystem::is_time_only_setattr(
+            FATTR_ATIME_NOW | FATTR_MTIME_NOW
+        ));
+        assert!(super::CurvineFileSystem::is_time_only_setattr(FATTR_MTIME));
+        assert!(!super::CurvineFileSystem::is_time_only_setattr(
+            FATTR_MTIME | FATTR_MODE
+        ));
+    }
+
+    #[test]
+    fn utime_setattr_allows_non_owner_with_write_for_now() {
+        super::CurvineFileSystem::check_utime_setattr_permission(
+            true,
+            FATTR_ATIME_NOW | FATTR_MTIME_NOW,
+            1000,
+            100,
+            0,
+            0,
+            100,
+            0o660,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn utime_setattr_denies_non_owner_explicit_times() {
+        let err = super::CurvineFileSystem::check_utime_setattr_permission(
+            true,
+            FATTR_MTIME,
+            1000,
+            100,
+            0,
+            0,
+            100,
+            0o666,
+        )
+        .unwrap_err();
+        assert_eq!(err.errno(), libc::EPERM);
+    }
+
+    #[test]
+    fn utime_setattr_denies_non_owner_now_without_write() {
+        let err = super::CurvineFileSystem::check_utime_setattr_permission(
+            true,
+            FATTR_ATIME_NOW | FATTR_MTIME_NOW,
+            1000,
+            100,
+            0,
+            0,
+            100,
+            0o555,
+        )
+        .unwrap_err();
+        assert_eq!(err.errno(), libc::EACCES);
     }
 
     /// Pin that `FuseMetrics::ensure_init()` runs before `NodeState::new()` in

--- a/curvine-fuse/src/fs/dcache/dir_tree.rs
+++ b/curvine-fuse/src/fs/dcache/dir_tree.rs
@@ -267,7 +267,11 @@ impl DirTree {
         let ino = self.get_ino_check(parent, Some(name))?;
         let should_remove = {
             let inode = self.get_inode_mut_check(ino, None)?;
-            if mark_delete {
+            // Only mark the whole inode deleted when removing its last link.
+            // Otherwise remaining hardlink names would see is_deleted() and
+            // LOOKUP would spuriously return ENOENT (LTP prot_hsymlinks cleanup).
+            let last_link = inode.nlink <= 1;
+            if mark_delete && last_link {
                 inode.mark_delete = true;
             }
             inode.sub_ref(1);
@@ -413,8 +417,10 @@ impl DirTree {
         inode.add_link(1);
 
         inode.update_status(status);
-        inode.parent = new_id;
-        inode.name = new_name.to_string();
+        // Hardlinks share one inode across multiple (parent, name) dentries.
+        // Keep the original primary parent/name so get_path / clear_mark_delete
+        // and deferred-delete do not jump to the newest hardlink location.
+        // Unlink/lookup resolve paths via the caller's (parent, name), not these fields.
 
         Ok(inode)
     }

--- a/curvine-fuse/src/fs/dcache/inode.rs
+++ b/curvine-fuse/src/fs/dcache/inode.rs
@@ -44,11 +44,14 @@ pub struct Inode {
 
 impl Inode {
     pub fn new_root() -> Self {
+        // Match master `AclFeature::DEFAULT_MODE` (0o777). A mode-0 placeholder would
+        // fail-closed on every non-root path traverse that walks the mount root.
         let root_st = FileStatus {
             is_dir: true,
             name: FUSE_PATH_SEPARATOR.to_owned(),
             path: FUSE_PATH_SEPARATOR.to_owned(),
             nlink: 2,
+            mode: 0o777,
             ..Default::default()
         };
         let dir = Some(Box::new(DirEntry::new()));

--- a/curvine-fuse/src/fs/state/node_state.rs
+++ b/curvine-fuse/src/fs/state/node_state.rs
@@ -626,6 +626,19 @@ impl NodeState {
         self.dir_write().clear_mark_delete(ino)
     }
 
+    /// Clear inode `mark_delete` and the `deleted_children` entry for a specific
+    /// hardlink name under `parent` (not the inode's primary parent/name).
+    pub fn clear_unlink_state(&self, ino: u64, parent: u64, name: &str) -> FuseResult<()> {
+        let mut dir = self.dir_write();
+        if let Some(inode) = dir.get_inode_mut(ino, None) {
+            inode.mark_delete = false;
+        }
+        if let Ok(parent_dir) = dir.get_dir_mut_check(parent) {
+            parent_dir.clear_deleted_child(name);
+        }
+        Ok(())
+    }
+
     pub fn complete_deferred_delete(
         &self,
         ino: u64,
@@ -640,10 +653,25 @@ impl NodeState {
     }
 
     pub async fn fs_unlink(&self, parent: u64, name: &str) -> FuseResult<()> {
-        let (ino, path) = {
+        let path = {
             let dir = self.dir_read();
-            let inode = dir.get_inode_check(parent, Some(name))?;
-            (inode.ino, dir.get_path_name(parent, name)?)
+            dir.get_path_name(parent, name)?
+        };
+
+        let ino = {
+            let dir = self.dir_read();
+            dir.get_inode(parent, Some(name)).map(|inode| inode.ino)
+        };
+
+        // Kernel may still hold a dentry after our dcache dropped the name
+        // (hardlink + FORGET races). Best-effort delete on master; treat
+        // already-gone as success so recursive cleanup (LTP tst_rmdir) is
+        // not failed by ENOENT on a stale name.
+        let Some(ino) = ino else {
+            return match self.fs.delete(&path, false).await {
+                Ok(()) | Err(FsError::FileNotFound(_)) => Ok(()),
+                Err(e) => Err(e.into()),
+            };
         };
 
         // Always mark for deletion and remove the directory entry first,
@@ -677,14 +705,15 @@ impl NodeState {
             Ok(()) => (),
             Err(FsError::FileNotFound(_)) => (),
             Err(e) => {
-                self.clear_mark_delete(ino)?;
+                self.clear_unlink_state(ino, parent, name)?;
                 return Err(e.into());
             }
         }
 
-        // Clear mark_delete + deleted_child entry now that the server-side
-        // delete has completed.  clear_mark_delete handles both in one lock.
-        self.clear_mark_delete(ino)?;
+        // Clear mark_delete + this name's deleted_child entry now that the
+        // server-side delete has completed (use unlink parent/name, not the
+        // inode primary path — hardlinks share one inode across names).
+        self.clear_unlink_state(ino, parent, name)?;
 
         Ok(())
     }

--- a/curvine-fuse/src/fuse_utils.rs
+++ b/curvine-fuse/src/fuse_utils.rs
@@ -557,12 +557,39 @@ impl FuseUtils {
         FileStatus::with_name(FUSE_UNKNOWN_INO as i64, name.to_string(), true)
     }
 
-    /// Whether the caller's effective group matches `file_gid`.
+    /// Supplementary groups for the FUSE requester, resolved from `/proc/<pid>/status`.
     ///
-    /// FUSE only exposes the requester's effective gid via `fuse_in_header.gid`;
-    /// supplementary groups are not available, so only the effective gid is compared.
-    pub fn caller_in_file_group(effective_gid: u32, file_gid: u32) -> bool {
-        effective_gid == file_gid
+    /// `fuse_in_header` exposes only the effective gid; chmod(2) setgid handling and
+    /// chown gid changes must also consider supplementary groups of the caller pid.
+    pub fn caller_supplementary_groups(pid: u32) -> Vec<u32> {
+        if pid == 0 {
+            return Vec::new();
+        }
+
+        let status_path = format!("/proc/{pid}/status");
+        let Ok(content) = std::fs::read_to_string(status_path) else {
+            return Vec::new();
+        };
+
+        content
+            .lines()
+            .find_map(|line| line.strip_prefix("Groups:"))
+            .map(|groups| {
+                groups
+                    .split_whitespace()
+                    .filter_map(|gid| gid.parse::<u32>().ok())
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// Whether the caller belongs to `file_gid` via effective or supplementary groups.
+    pub fn caller_in_file_group(effective_gid: u32, file_gid: u32, pid: u32) -> bool {
+        if effective_gid == file_gid {
+            return true;
+        }
+
+        Self::caller_supplementary_groups(pid).contains(&file_gid)
     }
 
     /// Apply Linux chmod/fchmod security rules for special mode bits.
@@ -828,9 +855,18 @@ mod tests {
     }
 
     #[test]
-    fn caller_in_file_group_matches_effective_gid_only() {
-        assert!(FuseUtils::caller_in_file_group(100, 100));
-        assert!(!FuseUtils::caller_in_file_group(100, 200));
+    fn caller_in_file_group_matches_effective_gid() {
+        assert!(FuseUtils::caller_in_file_group(100, 100, 0));
+        assert!(!FuseUtils::caller_in_file_group(100, 200, 0));
+    }
+
+    #[test]
+    fn caller_in_file_group_considers_supplementary_groups() {
+        let pid = std::process::id();
+        let groups = FuseUtils::caller_supplementary_groups(pid);
+        if let Some(&gid) = groups.first() {
+            assert!(FuseUtils::caller_in_file_group(0, gid, pid));
+        }
     }
 
     #[test]

--- a/curvine-fuse/src/fuse_utils.rs
+++ b/curvine-fuse/src/fuse_utils.rs
@@ -541,14 +541,35 @@ impl FuseUtils {
             .build()
     }
 
+    /// Kernel dentry/attribute cache lifetimes for FUSE replies.
+    ///
+    /// When userspace permission checks are enabled, timeouts must be zero so the
+    /// kernel revalidates after parent mode changes (e.g. chmod removing search).
+    /// Otherwise cached LOOKUP/GETATTR can skip path-prefix X_OK and report success
+    /// where POSIX requires EACCES (LTP lstat02/stat03/readlink03).
+    pub fn kernel_cache_timeouts(conf: &FuseConf) -> (u64, u32, u64, u32) {
+        if conf.check_permission {
+            (0, 0, 0, 0)
+        } else {
+            (
+                conf.entry_ttl.as_secs(),
+                conf.entry_ttl.subsec_nanos(),
+                conf.attr_ttl.as_secs(),
+                conf.attr_ttl.subsec_nanos(),
+            )
+        }
+    }
+
     pub fn create_entry_out(conf: &FuseConf, attr: fuse_attr) -> fuse_entry_out {
+        let (entry_valid, entry_valid_nsec, attr_valid, attr_valid_nsec) =
+            Self::kernel_cache_timeouts(conf);
         fuse_entry_out {
             nodeid: attr.ino,
             generation: 0,
-            entry_valid: conf.entry_ttl.as_secs(),
-            attr_valid: conf.attr_ttl.as_secs(),
-            entry_valid_nsec: conf.entry_ttl.subsec_nanos(),
-            attr_valid_nsec: conf.attr_ttl.subsec_nanos(),
+            entry_valid,
+            attr_valid,
+            entry_valid_nsec,
+            attr_valid_nsec,
             attr,
         }
     }

--- a/curvine-fuse/src/lib.rs
+++ b/curvine-fuse/src/lib.rs
@@ -282,6 +282,8 @@ pub const FATTR_ATIME: u32 = 1 << 4;
 
 pub const FATTR_MTIME: u32 = 1 << 5;
 
+pub const FATTR_FH: u32 = 1 << 6;
+
 pub const FATTR_ATIME_NOW: u32 = 1 << 7;
 
 pub const FATTR_MTIME_NOW: u32 = 1 << 8;


### PR DESCRIPTION
<!-- curvine-automation:pr:CurvineIO/curvine:1269 -->

# Summary

Align Curvine FUSE path/mode permission checks with POSIX and Linux sticky-directory link policy so chmod/fchmod/stat/truncate/utime and protected symlink/hardlink cases behave correctly under `check_permission`.

# Issue Describe / Design

Closes #1269

## Root cause

1. Mount-root dcache used an invalid ACL placeholder (`mode=0`), so non-root path traverse always failed with `EACCES`.
2. Non-zero kernel entry/attr timeouts let LOOKUP/GETATTR succeed after a parent lost execute permission.
3. Truncate lacked a write check; utime(2) did not follow owner/`*_NOW`+write rules; readlink lacked path traverse checks.
4. Sticky world-writable `protected_symlinks` / `protected_hardlinks` were not enforced in userspace, so LTP `prot_hsymlinks` allowed forbidden follows and hardlinks.
5. Hardlink dcache rewrote the primary parent/name and marked shared inodes deleted too early, causing cleanup `ENOENT` after the functional checks passed.

## Fix approach

- Hydrate root ACL for traverse; trust only valid cached ACL bits.
- Zero kernel entry/attr timeouts when `check_permission` is enabled.
- Enforce truncate write permission, utime(2) rules, and readlink traverse checks.
- Apply Linux sticky-dir symlink follow and safe-hardlink policy in `readlink`/`link`.
- Keep hardlink primary path stable; mark_delete only on the last link; make dcache-miss unlink idempotent on the master.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-fuse/src/fs/curvine_file_system.rs` | POSIX setattr/utime/truncate/traverse checks; protected symlink/hardlink helpers | Stricter permission denials matching Linux when `check_permission` is on |
| `curvine-fuse/src/fuse_utils.rs` | Zero kernel cache timeouts under `check_permission` | Parents revalidated after chmod -x |
| `curvine-fuse/src/lib.rs` | Expose `FATTR_FH` | FH-based setattr can skip path traverse |
| `curvine-fuse/src/fs/dcache/inode.rs` | Root placeholder mode `0o777` | Non-root traverse no longer fail-closed at mount root |
| `curvine-fuse/src/fs/dcache/dir_tree.rs` | Hardlink primary path stable; last-link mark_delete | Correct hardlink cleanup / LOOKUP |
| `curvine-fuse/src/fs/state/node_state.rs` | Idempotent unlink on dcache miss; clear unlink state by name | Stale dentry cleanup no longer returns spurious `ENOENT` |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `make format` | PASS | fmt + clippy gate |
| `cargo test -p curvine-fuse --lib` (permission/protected/hardlink helpers) | PASS | Unit tests for new helpers |
| LTP mode/permission focused suite (22 assigned cases) | PASS | Including `prot_hsymlinks` |
| Full LTP profile on fixed HEAD (3 independent runs) | PASS for assigned set | Assigned cases absent; no new failures vs baseline; historical unrelated failures unchanged |

# Dependencies

- Related PRs: None
- Related issues: #1269
- Blocks / blocked by: None

<!-- curvine-automation: topic=FUSE-MODE-PERMISSION issue=1269 -->
