### PR TITLE
docs(skill): add comment density constraint to PR review scope (#1319)

### DIFF
--- a/.agents/skills/cv-submit-pr-review/SKILL.md
+++ b/.agents/skills/cv-submit-pr-review/SKILL.md
@@ -26,6 +26,7 @@ Focus **exclusively on code content**:
 |Correctness|Logic errors, edge cases, off-by-one, None/null handling, error propagation|
 |Safety|Concurrency races, panics / unwrap in hot paths, unsafe blocks, resource leaks, lock ordering|
 |Design|Naming, module boundaries, abstractions, consistency with existing patterns|
+|Comments|Header doc-comments on a method, function, or class that exceed **3 lines**; excessive inline comments that merely restate code instead of explaining intent. Flag any single-item header comment block longer than 3 lines as a `suggestion`-level finding and ask the author to trim it (move detail into the body or remove redundant lines).|
 
 **Ignore:** commit message quality, PR description wording, pure formatting nits (run `make format` separately).
 


### PR DESCRIPTION
# Summary

Adds a new "Comments" dimension to the cv-submit-pr-review skill's Review Scope table. The constraint flags method/function/class header doc-comments exceeding 3 lines, addressing excessive comment density in the codebase.

# Issue Describe / Design

Related issues: None

Design decision: The new "Comments" row sits alongside the existing Correctness / Safety / Design dimensions in the Review Scope table. Findings are raised at the suggestion level, asking authors to trim header comments by moving detail into the body or removing redundant lines. This keeps the review workflow unchanged while enforcing the 3-line cap.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `.agents/skills/cv-submit-pr-review/SKILL.md` | Added "Comments" row to Review Scope table with 3-line header comment constraint | None — skill documentation only |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| Manual review of SKILL.md table rendering | PASS | Markdown table renders correctly |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None
