### PR TITLE
fix(worker): preserve finalized blocks when writes abort (#1318)

### DIFF
--- a/curvine-server/src/worker/block/block_store.rs
+++ b/curvine-server/src/worker/block/block_store.rs
@@ -70,7 +70,9 @@ impl BlockStore {
 
     pub fn get_block(&self, id: i64) -> CommonResult<BlockMeta> {
         let state = self.read()?;
-        let b = state.get_block_check(id)?;
+        let b = state
+            .get_readable_block(id)
+            .ok_or_else(|| orpc::err_msg!(format!("block {} not exists", id)))?;
         Ok(b.clone())
     }
 
@@ -130,7 +132,7 @@ impl BlockStore {
             remove_result
         }?;
 
-        removed.layout.deallocate(&removed.dir, &removed.meta)?;
+        removed.deallocate()?;
         removed.release_space();
         Ok(removed.meta)
     }

--- a/curvine-server/src/worker/storage/layout/bdev_layout.rs
+++ b/curvine-server/src/worker/storage/layout/bdev_layout.rs
@@ -43,6 +43,10 @@ impl BdevLayout {
 }
 
 impl BlockLayout for BdevLayout {
+    fn preserves_committed_on_write(&self) -> bool {
+        false
+    }
+
     fn allocate(&self, dir: &VfsDir, block: &ExtendedBlock) -> CommonResult<BlockMeta> {
         let allocated_bytes = match dir.state.offset_alloc.allocation_size(block.len) {
             Some(size) => size,

--- a/curvine-server/src/worker/storage/layout/file_layout.rs
+++ b/curvine-server/src/worker/storage/layout/file_layout.rs
@@ -21,7 +21,7 @@ use orpc::common::ByteUnit;
 use orpc::common::FileUtils;
 use orpc::io::{BlockDevice, IOError, IOResult, LocalFile};
 use orpc::{err_box, try_err, CommonResult};
-use std::fs::{self, File};
+use std::fs::{self, OpenOptions};
 use std::path::PathBuf;
 
 #[derive(Clone, Copy)]
@@ -47,7 +47,7 @@ impl FileLayout {
 
     fn block_dir(dir: &VfsDir, meta: &BlockMeta) -> CommonResult<PathBuf> {
         let path = match meta.state() {
-            BlockState::Finalized | BlockState::Writing => {
+            BlockState::Finalized => {
                 let uid = meta.id() as u64;
                 let d1 = (uid >> 48) & 0x1F;
                 let d2 = (uid >> 32) & 0x1F;
@@ -55,7 +55,7 @@ impl FileLayout {
                     .join(format!("b{}", d1))
                     .join(format!("b{}", d2))
             }
-            BlockState::Recovering => Self::staging_dir(dir),
+            BlockState::Writing | BlockState::Recovering => Self::staging_dir(dir),
         };
 
         if path.exists() {
@@ -89,10 +89,14 @@ impl FileLayout {
 }
 
 impl BlockLayout for FileLayout {
+    fn preserves_committed_on_write(&self) -> bool {
+        true
+    }
+
     fn allocate(&self, dir: &VfsDir, block: &ExtendedBlock) -> CommonResult<BlockMeta> {
         let meta = BlockMeta::with_tmp(block, dir);
         let file = Self::block_path(dir, &meta)?;
-        File::create(file)?;
+        OpenOptions::new().write(true).create_new(true).open(file)?;
         Ok(meta)
     }
 
@@ -106,10 +110,25 @@ impl BlockLayout for FileLayout {
             return err_box!("Invalid file block size: {}", block.len);
         }
         let mut prepared = BlockMeta::new(meta.id(), block.len, dir);
-        // The old file still occupies space until resize/finalize. Keep the
-        // larger physical charge so preparing a smaller write cannot temporarily
-        // overstate available capacity or under-release on abort.
         prepared.actual_len = meta.actual_len.max(block.len);
+
+        if meta.is_final() {
+            let committed_path = Self::block_path(dir, meta)?;
+            let staging_path = Self::block_path(dir, &prepared)?;
+            if staging_path.exists() {
+                return err_box!(
+                    "Cannot rewrite block {} because staging file {} already exists",
+                    meta.id(),
+                    staging_path.display()
+                );
+            }
+
+            if let Err(e) = fs::copy(&committed_path, &staging_path) {
+                let _ = fs::remove_file(&staging_path);
+                return Err(e.into());
+            }
+        }
+
         Ok(prepared)
     }
 
@@ -117,10 +136,22 @@ impl BlockLayout for FileLayout {
         &self,
         dir: &VfsDir,
         meta: &BlockMeta,
-        _committed_len: i64,
+        committed_len: i64,
     ) -> CommonResult<BlockMeta> {
-        let path = Self::block_path(dir, meta)?;
-        BlockMeta::with_final(meta, &path)
+        let staging_path = Self::block_path(dir, meta)?;
+        let final_meta = BlockMeta::with_final(meta, &staging_path)?;
+        if final_meta.len() != committed_len {
+            return err_box!(
+                "Block {} length mismatch, expected: {}, actual: {}",
+                meta.id(),
+                committed_len,
+                final_meta.len()
+            );
+        }
+
+        let active_path = Self::block_path(dir, &final_meta)?;
+        FileUtils::rename(staging_path, active_path)?;
+        Ok(final_meta)
     }
 
     fn scan(&self, dir: &VfsDir) -> CommonResult<Vec<BlockMeta>> {

--- a/curvine-server/src/worker/storage/layout/file_layout.rs
+++ b/curvine-server/src/worker/storage/layout/file_layout.rs
@@ -21,6 +21,7 @@ use orpc::common::ByteUnit;
 use orpc::common::FileUtils;
 use orpc::io::{BlockDevice, IOError, IOResult, LocalFile};
 use orpc::{err_box, try_err, CommonResult};
+use std::collections::HashSet;
 use std::fs::{self, OpenOptions};
 use std::path::PathBuf;
 
@@ -123,6 +124,10 @@ impl BlockLayout for FileLayout {
                 );
             }
 
+            // This copy is intentionally serialized by the dataset write lock so
+            // the committed-to-staging transition cannot race another writer.
+            // Existing open readers keep using active; new metadata operations
+            // wait for the copy to finish.
             if let Err(e) = fs::copy(&committed_path, &staging_path) {
                 let _ = fs::remove_file(&staging_path);
                 return Err(e.into());
@@ -160,14 +165,23 @@ impl BlockLayout for FileLayout {
         let staging_dir = FileUtils::list_files(Self::staging_dir(dir), true)?;
 
         let mut blocks = vec![];
+        let mut active_ids = HashSet::new();
         for file in active_dir {
             if let Ok(meta) = BlockMeta::from_file(&file, BlockState::Finalized, dir) {
+                active_ids.insert(meta.id());
                 blocks.push(meta);
             }
         }
 
         for file in staging_dir {
             if let Ok(meta) = BlockMeta::from_file(&file, BlockState::Recovering, dir) {
+                // A crash during a rewrite can leave the committed active file
+                // and an incomplete staging copy. Prefer the published active
+                // generation and discard staging before capacity is reserved.
+                if active_ids.contains(&meta.id()) {
+                    fs::remove_file(file)?;
+                    continue;
+                }
                 blocks.push(meta);
             }
         }

--- a/curvine-server/src/worker/storage/layout/file_layout.rs
+++ b/curvine-server/src/worker/storage/layout/file_layout.rs
@@ -111,6 +111,7 @@ impl BlockLayout for FileLayout {
             return err_box!("Invalid file block size: {}", block.len);
         }
         let mut prepared = BlockMeta::new(meta.id(), block.len, dir);
+        // A staging rewrite starts from the committed allocation and may grow, so charge the larger size.
         prepared.actual_len = meta.actual_len.max(block.len);
 
         if meta.is_final() {

--- a/curvine-server/src/worker/storage/layout/mod.rs
+++ b/curvine-server/src/worker/storage/layout/mod.rs
@@ -33,6 +33,10 @@ fn validate_open_offset(meta: &BlockMeta, off: i64) -> IOResult<()> {
 }
 
 pub trait BlockLayout {
+    /// Whether rewriting a finalized block keeps the committed allocation
+    /// readable until the new write is finalized or aborted.
+    fn preserves_committed_on_write(&self) -> bool;
+
     fn allocate(&self, dir: &VfsDir, block: &ExtendedBlock) -> CommonResult<BlockMeta>;
 
     /// Prepare an existing physical allocation for writing.
@@ -107,6 +111,13 @@ impl BlockLayouts {
 }
 
 impl BlockLayout for BlockLayoutKind {
+    fn preserves_committed_on_write(&self) -> bool {
+        match self {
+            Self::File(layout) => layout.preserves_committed_on_write(),
+            Self::Bdev(layout) => layout.preserves_committed_on_write(),
+        }
+    }
+
     fn allocate(&self, dir: &VfsDir, block: &ExtendedBlock) -> CommonResult<BlockMeta> {
         match self {
             Self::File(layout) => layout.allocate(dir, block),

--- a/curvine-server/src/worker/storage/vfs_dataset.rs
+++ b/curvine-server/src/worker/storage/vfs_dataset.rs
@@ -729,6 +729,43 @@ mod test {
         Ok(())
     }
     #[test]
+    fn restart_during_rewrite_discards_staging_and_keeps_committed() -> CommonResult<()> {
+        let dataset_name = "restart-during-rewrite";
+        let mut ds = create_data_set(true, dataset_name);
+        let mut block = ExtendedBlock::with_mem(1, "100B")?;
+        let writing = ds.open_block(&block)?;
+        ds.write_test_data(&writing, "40B")?;
+        block.len = 40;
+        let finalized = ds.finalize_block(&block)?;
+        let finalized_available = ds.available();
+        let active_path = {
+            let dir = ds.find_dir(finalized.dir_id())?;
+            FileLayout::block_path(dir, &finalized)?
+        };
+        let committed_bytes = std::fs::read(&active_path)?;
+
+        block.len = 60;
+        let rewriting = ds.open_block(&block)?;
+        let staging_path = {
+            let dir = ds.find_dir(rewriting.dir_id())?;
+            FileLayout::block_path(dir, &rewriting)?
+        };
+        std::fs::write(&staging_path, b"partial rewrite")?;
+        assert!(active_path.exists());
+        assert!(staging_path.exists());
+        drop(ds);
+
+        let restarted = create_data_set(false, dataset_name);
+        let recovered = restarted.get_block(block.id).unwrap();
+        assert!(recovered.is_final());
+        assert_eq!(recovered.len(), finalized.len());
+        assert_eq!(restarted.num_blocks(), 1);
+        assert_eq!(restarted.available(), finalized_available);
+        assert_eq!(std::fs::read(active_path)?, committed_bytes);
+        assert!(!staging_path.exists());
+        Ok(())
+    }
+    #[test]
     fn finalize_rewrite_publishes_staging_file() -> CommonResult<()> {
         let mut ds = create_data_set(true, "finalize-rewrite-publishes");
         let mut block = ExtendedBlock::with_mem(1, "100B")?;

--- a/curvine-server/src/worker/storage/vfs_dataset.rs
+++ b/curvine-server/src/worker/storage/vfs_dataset.rs
@@ -33,20 +33,34 @@ pub struct VfsDataset {
     ctime: u64,
     dir_list: DirList,
     meta: VfsMetaStore,
+    committed_rewrites: HashMap<i64, BlockMeta>,
     layouts: BlockLayouts,
     num_blocks_to_delete: AtomicUsize,
 }
 
 pub(crate) struct RemovedBlockState {
     pub(crate) meta: BlockMeta,
+    committed: Option<BlockMeta>,
     pub(crate) layout: BlockLayoutKind,
     pub(crate) dir: Arc<VfsDir>,
 }
 
 impl RemovedBlockState {
+    pub(crate) fn deallocate(&self) -> CommonResult<()> {
+        self.layout.deallocate(&self.dir, &self.meta)?;
+        if let Some(committed) = self.committed.as_ref() {
+            self.layout.deallocate(&self.dir, committed)?;
+        }
+        Ok(())
+    }
+
     pub(crate) fn release_space(&self) {
         self.dir
             .release_space(self.meta.is_final(), self.meta.physical_bytes());
+        if let Some(committed) = self.committed.as_ref() {
+            self.dir
+                .release_space(committed.is_final(), committed.physical_bytes());
+        }
     }
 }
 
@@ -67,6 +81,7 @@ impl VfsDataset {
             ctime: LocalTime::mills(),
             dir_list,
             meta: VfsMetaStore::new(spdk_meta.clone()),
+            committed_rewrites: HashMap::new(),
             layouts: BlockLayouts::new(spdk_meta),
             num_blocks_to_delete: AtomicUsize::new(0),
         };
@@ -189,7 +204,22 @@ impl VfsDataset {
     }
 
     pub fn all_blocks(&self) -> Vec<BlockMeta> {
-        self.meta.all_blocks()
+        self.meta
+            .all_blocks()
+            .into_iter()
+            .map(|meta| {
+                self.committed_rewrites
+                    .get(&meta.id())
+                    .cloned()
+                    .unwrap_or(meta)
+            })
+            .collect()
+    }
+
+    pub(crate) fn get_readable_block(&self, id: i64) -> Option<&BlockMeta> {
+        self.committed_rewrites
+            .get(&id)
+            .or_else(|| self.meta.get(id))
     }
 
     #[cfg(test)]
@@ -220,6 +250,7 @@ impl VfsDataset {
             None => return err_box!("Not found block {}", id),
             Some(meta) => meta,
         };
+        let committed = self.committed_rewrites.remove(&id);
         let layout = self.layouts.get(meta.storage_type()).clone();
         let dir = match self.dir_list.get_dir(meta.dir_id()) {
             None => return err_box!("No storage directory found: {:?}", meta.dir_id()),
@@ -227,19 +258,22 @@ impl VfsDataset {
         };
 
         layout.release(&dir, &meta);
+        if let Some(committed) = committed.as_ref() {
+            layout.release(&dir, committed);
+        }
 
-        Ok(RemovedBlockState { meta, layout, dir })
-    }
-
-    pub(crate) fn release_block_space(&self, meta: &BlockMeta) -> CommonResult<()> {
-        self.dir_list
-            .release_space(meta.dir_id(), meta.is_final(), meta.physical_bytes())
+        Ok(RemovedBlockState {
+            meta,
+            committed,
+            layout,
+            dir,
+        })
     }
 
     pub(crate) fn remove_block_by_id(&mut self, id: i64) -> CommonResult<BlockMeta> {
         let removed = self.remove_block_state_by_id(id)?;
-        removed.layout.deallocate(&removed.dir, &removed.meta)?;
-        self.release_block_space(&removed.meta)?;
+        removed.deallocate()?;
+        removed.release_space();
         Ok(removed.meta)
     }
 
@@ -304,16 +338,36 @@ impl Dataset for VfsDataset {
                 if meta.is_active() {
                     let dir = self.find_dir(meta.dir_id())?;
                     let layout = self.layouts.get(meta.storage_type());
+                    let preserves_committed =
+                        meta.is_final() && layout.preserves_committed_on_write();
+                    if preserves_committed {
+                        let required_bytes = meta.physical_bytes().max(block.len);
+                        if required_bytes > dir.available() {
+                            return err_box!(
+                                "Not enough space in storage dir {} for block {} rewrite: need {}, available {}",
+                                meta.dir_id(),
+                                meta.id(),
+                                required_bytes,
+                                dir.available()
+                            );
+                        }
+                    }
+
                     let old_physical_bytes = meta.physical_bytes();
                     let new_meta = layout.prepare_write(dir, &meta, block)?;
                     let new_physical_bytes = new_meta.physical_bytes();
 
-                    self.dir_list.update_write_space(
-                        meta.dir_id(),
-                        meta.is_final(),
-                        old_physical_bytes,
-                        new_physical_bytes,
-                    )?;
+                    if preserves_committed {
+                        dir.reserve_space(false, new_physical_bytes);
+                        self.committed_rewrites.insert(meta.id(), meta);
+                    } else {
+                        self.dir_list.update_write_space(
+                            meta.dir_id(),
+                            meta.is_final(),
+                            old_physical_bytes,
+                            new_physical_bytes,
+                        )?;
+                    }
                     self.meta.put(new_meta.clone());
 
                     Ok(new_meta)
@@ -382,6 +436,13 @@ impl Dataset for VfsDataset {
             (meta.dir_id(), reserved_bytes, final_bytes, final_meta)
         };
 
+        if let Some(committed) = self.committed_rewrites.remove(&block.id) {
+            self.dir_list.release_space(
+                committed.dir_id(),
+                committed.is_final(),
+                committed.physical_bytes(),
+            )?;
+        }
         self.dir_list
             .update_final_space(dir_id, reserved_bytes, final_bytes)?;
         self.meta.put(final_meta.clone());
@@ -390,21 +451,37 @@ impl Dataset for VfsDataset {
     }
 
     fn abort_block(&mut self, block: &ExtendedBlock) -> CommonResult<()> {
+        let Some(meta) = self.meta.get(block.id).cloned() else {
+            return Ok(());
+        };
+
+        if let Some(committed) = self.committed_rewrites.get(&block.id).cloned() {
+            let (layout, dir) = self.layout_for(&meta)?;
+            layout.deallocate(&dir, &meta)?;
+            layout.release(&dir, &meta);
+            dir.release_space(false, meta.physical_bytes());
+            self.meta.remove(block.id);
+            self.committed_rewrites.remove(&block.id);
+            self.meta.put(committed);
+            return Ok(());
+        }
+
+        self.remove_block_by_id(block.id)?;
+        Ok(())
+    }
+
+    fn remove_block(&mut self, block: &ExtendedBlock) -> CommonResult<()> {
         if self.meta.get(block.id).is_none() {
             return Ok(());
         }
         self.remove_block_by_id(block.id)?;
         Ok(())
     }
-
-    fn remove_block(&mut self, block: &ExtendedBlock) -> CommonResult<()> {
-        self.abort_block(block)
-    }
 }
 
 #[cfg(test)]
 mod test {
-    use crate::worker::block::BlockMeta;
+    use crate::worker::block::{BlockMeta, BlockState};
     use crate::worker::storage::{
         Dataset, DirList, DirState, FileLayout, SpdkMetaStore, StorageVersion, VfsDataset, VfsDir,
     };
@@ -414,6 +491,7 @@ mod test {
     use orpc::sync::AtomicLong;
     use orpc::sys::FsStats;
     use orpc::CommonResult;
+    use std::io::Write;
     use std::sync::atomic::AtomicBool;
     use std::sync::Arc;
 
@@ -481,14 +559,14 @@ mod test {
         let mut ds = create_data_set(true, "append");
         let mut block = ExtendedBlock::with_mem(1, "100B")?;
         let meta = ds.open_block(&block)?;
-        ds.write_test_data(&meta, "50B")?;
-        block.len = 50;
+        ds.write_test_data(&meta, "40B")?;
+        block.len = 40;
         ds.finalize_block(&block)?;
-        block.len = 70;
+        block.len = 60;
         let meta2 = ds.open_block(&block)?;
         ds.write_test_data(&meta2, "20B")?;
         ds.finalize_block(&block)?;
-        assert_eq!(ds.available(), 430);
+        assert_eq!(ds.available(), 440);
         Ok(())
     }
     #[test]
@@ -595,10 +673,9 @@ mod test {
         Ok(())
     }
     #[test]
-    fn smaller_prepared_write_holds_old_capacity_until_completion() -> CommonResult<()> {
-        let mut ds = create_data_set(true, "smaller-prepared-write");
+    fn abort_rewrite_restores_committed_capacity() -> CommonResult<()> {
+        let mut ds = create_data_set(true, "abort-rewrite-restores-capacity");
         let mut block = ExtendedBlock::with_mem(1, "100B")?;
-        let total_available = ds.available();
         let meta = ds.open_block(&block)?;
         ds.write_test_data(&meta, "50B")?;
         block.len = 50;
@@ -607,9 +684,111 @@ mod test {
 
         block.len = 20;
         ds.open_block(&block)?;
-        assert_eq!(ds.available(), finalized_available);
+        assert_eq!(ds.available(), finalized_available - 50);
         ds.abort_block(&block)?;
-        assert_eq!(ds.available(), total_available);
+        assert_eq!(ds.available(), finalized_available);
+        assert!(ds.get_block(block.id).unwrap().is_final());
+        Ok(())
+    }
+    #[test]
+    fn abort_rewrite_preserves_finalized_file() -> CommonResult<()> {
+        let mut ds = create_data_set(true, "abort-rewrite-preserves-finalized");
+        let mut block = ExtendedBlock::with_mem(1, "100B")?;
+        let meta = ds.open_block(&block)?;
+        ds.write_test_data(&meta, "40B")?;
+        block.len = 40;
+        let finalized = ds.finalize_block(&block)?;
+        let finalized_available = ds.available();
+        let active_path = {
+            let dir = ds.find_dir(finalized.dir_id())?;
+            FileLayout::block_path(dir, &finalized)?
+        };
+        let committed_bytes = std::fs::read(&active_path)?;
+
+        block.len = 60;
+        let writing = ds.open_block(&block)?;
+        let staging_path = {
+            let dir = ds.find_dir(writing.dir_id())?;
+            FileLayout::block_path(dir, &writing)?
+        };
+        assert!(active_path.exists());
+        assert!(staging_path.exists());
+        assert!(ds.get_block(block.id).unwrap().state() == &BlockState::Writing);
+        assert!(ds.get_readable_block(block.id).unwrap().is_final());
+        assert!(ds.all_blocks()[0].is_final());
+
+        std::fs::write(&staging_path, b"partial rewrite")?;
+        ds.abort_block(&block)?;
+
+        let restored = ds.get_block(block.id).unwrap();
+        assert!(restored.is_final());
+        assert_eq!(restored.len(), finalized.len());
+        assert_eq!(std::fs::read(active_path)?, committed_bytes);
+        assert!(!staging_path.exists());
+        assert_eq!(ds.available(), finalized_available);
+        Ok(())
+    }
+    #[test]
+    fn finalize_rewrite_publishes_staging_file() -> CommonResult<()> {
+        let mut ds = create_data_set(true, "finalize-rewrite-publishes");
+        let mut block = ExtendedBlock::with_mem(1, "100B")?;
+        let writing = ds.open_block(&block)?;
+        let initial_path = {
+            let dir = ds.find_dir(writing.dir_id())?;
+            FileLayout::block_path(dir, &writing)?
+        };
+        std::fs::write(&initial_path, b"old")?;
+        block.len = 3;
+        let finalized = ds.finalize_block(&block)?;
+        let active_path = {
+            let dir = ds.find_dir(finalized.dir_id())?;
+            FileLayout::block_path(dir, &finalized)?
+        };
+
+        block.len = 6;
+        let rewriting = ds.open_block(&block)?;
+        let staging_path = {
+            let dir = ds.find_dir(rewriting.dir_id())?;
+            FileLayout::block_path(dir, &rewriting)?
+        };
+        let mut staging = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&staging_path)?;
+        staging.write_all(b"new")?;
+        drop(staging);
+
+        let published = ds.finalize_block(&block)?;
+        assert!(published.is_final());
+        assert_eq!(std::fs::read(active_path)?, b"oldnew");
+        assert!(!staging_path.exists());
+        assert!(ds.committed_rewrites.is_empty());
+        Ok(())
+    }
+    #[test]
+    fn remove_block_during_rewrite_deletes_active_and_staging_files() -> CommonResult<()> {
+        let mut ds = create_data_set(true, "remove-during-rewrite");
+        let mut block = ExtendedBlock::with_mem(1, "100B")?;
+        let writing = ds.open_block(&block)?;
+        ds.write_test_data(&writing, "40B")?;
+        block.len = 40;
+        let finalized = ds.finalize_block(&block)?;
+        let active_path = {
+            let dir = ds.find_dir(finalized.dir_id())?;
+            FileLayout::block_path(dir, &finalized)?
+        };
+
+        block.len = 60;
+        let rewriting = ds.open_block(&block)?;
+        let staging_path = {
+            let dir = ds.find_dir(rewriting.dir_id())?;
+            FileLayout::block_path(dir, &rewriting)?
+        };
+        ds.remove_block(&block)?;
+
+        assert!(ds.get_block(block.id).is_none());
+        assert!(!active_path.exists());
+        assert!(!staging_path.exists());
+        assert!(ds.committed_rewrites.is_empty());
         Ok(())
     }
     #[test]


### PR DESCRIPTION
# Summary

Prevent aborted file-backed block rewrites from deleting or corrupting previously finalized data. New writes and rewrites now use staging files, while the committed block remains readable until the new write is successfully published.

# Issue Describe / Design

Closes #1318

Root cause:

- `Writing` and `Finalized` blocks shared the same active physical path.
- Rewrites modified committed data in place.
- `abort_block` unconditionally removed the current physical block.

Fix approach:

- Store file-backed `Writing` blocks under `staging/`.
- Copy committed data to staging before a rewrite.
- Keep the committed metadata readable and reportable while rewriting.
- On abort, delete only staging and restore committed metadata.
- On finalize, validate length and atomically rename staging to active.
- On restart, prefer an existing finalized active generation and discard an incomplete staging rewrite with the same block ID.
- Account for committed and staging capacity independently.
- Remove both active and staging files when deleting the logical block.
- Keep SPDK behavior unchanged.

Known trade-off:

- The initial committed-to-staging copy is serialized by the dataset write lock to fence concurrent metadata transitions. Existing open readers continue reading the active file, while new metadata operations can wait for a large copy to finish. Moving the copy outside the lock requires a separate fenced prepare/copy/commit lifecycle.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| Worker file layout | Route writing blocks through staging and publish with rename | File-backed writes gain an explicit publication boundary |
| Worker startup scan | Reconcile active/staging rewrite conflicts in favor of committed active data | Interrupted rewrites no longer shadow committed data or reserve capacity twice |
| Worker dataset | Track committed rewrite state and restore it on abort | Failed rewrites preserve old data |
| Block store | Return committed data during an active rewrite | Readers do not observe partial rewrite data |
| Layout abstraction | Describe whether a layout preserves committed data | SPDK behavior remains unchanged |
| Worker tests | Add abort, finalize, capacity, deletion, and restart-recovery coverage | Prevents regression |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-server restart_during_rewrite_discards_staging_and_keeps_committed --lib --no-default-features` | PASS | Linux/Rust 1.92, 1 passed |
| `cargo test -p curvine-server worker:: --lib --no-default-features` | PASS | Linux/Rust 1.92, 58 passed |
| `make format` | PASS | Linux; includes release Clippy and formatting |
| `git diff --check` | PASS | No whitespace errors |

# Dependencies

- Related PRs: None
- Related issues: #1318
- Blocks / blocked by: None
