### PR TITLE
feat(transfer): isolate load and export jobs from master

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,17 @@ dependencies = [
 
 [[package]]
 name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.16",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
@@ -211,7 +222,7 @@ version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c8955af33b25f3b175ee10af580577280b4bd01f7e823d94c7cdef7cf8c9aef"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
@@ -369,7 +380,7 @@ version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68bf3e3efbd1278f770d67e5dc410257300b161b93baedb3aae836144edcaf4b"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
@@ -1273,6 +1284,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
+dependencies = [
+ "borsh-derive",
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8fb4fb5740e4b2c4884ff95f5f32f5e8479db1e8fd8eb49ddbe09eb09bb7c"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1294,10 +1329,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "btoi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd6407f73a9b8b6162d8a2ef999fe6afd7cc15902ebf42c5cd296addf17e0ad"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "bufstream"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40e38929add23cdf8a366df9b0e088953150724bcbe5fc330b0d8eb3b328eec8"
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "bytecount"
@@ -1946,12 +2018,14 @@ dependencies = [
  "comfy-table",
  "curvine-client",
  "curvine-common",
+ "curvine-server",
  "curvine-ufs",
  "orpc",
  "reqwest 0.12.25",
  "serde",
  "serde_json",
  "tokio",
+ "toml",
 ]
 
 [[package]]
@@ -2158,6 +2232,7 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
+ "crossbeam",
  "curvine-client",
  "curvine-common",
  "curvine-fault",
@@ -2171,6 +2246,7 @@ dependencies = [
  "log",
  "lru 0.16.1",
  "mini-moka",
+ "mysql",
  "num_enum",
  "once_cell",
  "orpc",
@@ -2180,6 +2256,7 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "rocksdb",
+ "rusqlite",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -2418,7 +2495,7 @@ version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d551054acec0398ca604512310b77ce05c46f66e54b54d48200a686e385cca4e"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow",
  "arrow-ipc",
  "chrono",
@@ -2642,7 +2719,7 @@ version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b644f9cf696df9233ce6958b9807666d78563b56f923267474dd6c07795f1f8f"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow",
  "datafusion-common",
  "datafusion-doc",
@@ -2663,7 +2740,7 @@ version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1de2deaaabe8923ce9ea9f29c47bbb4ee14f67ea2fe1ab5398d9bbebcf86e56"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow",
  "datafusion-common",
  "datafusion-expr-common",
@@ -2773,7 +2850,7 @@ version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d48022b8af9988c1d852644f9e8b5584c490659769a550c5e8d39457a1da0a5"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow",
  "datafusion-common",
  "datafusion-expr",
@@ -2811,7 +2888,7 @@ version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147253ca3e6b9d59c162de64c02800973018660e13340dd1886dd038d17ac429"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow",
  "chrono",
  "datafusion-common",
@@ -2846,7 +2923,7 @@ version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68253dc0ee5330aa558b2549c9b0da5af9fc17d753ae73022939014ad616fc28"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow",
  "arrow-ord",
  "arrow-schema",
@@ -2988,6 +3065,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_utils"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "362f47930db19fe7735f527e6595e4900316b893ebf6d48ad3d31be928d57dd6"
+dependencies = [
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -3226,6 +3314,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
 name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3339,6 +3433,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "foreign_vec"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3351,6 +3460,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "frunk"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28aef0f9aa070bce60767c12ba9cb41efeaf1a2bc6427f87b7d83f11239a16d7"
+dependencies = [
+ "frunk_core 0.4.4",
+ "frunk_derives",
+ "frunk_proc_macros",
+ "serde",
+]
+
+[[package]]
+name = "frunk_core"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "476eeaa382e3462b84da5d6ba3da97b5786823c2d0d3a0d04ef088d073da225c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "frunk_core"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bd3c9ba2e323e8b19e77f15873f60974a7d82f89b80e50c53be44b8b92927c1"
+
+[[package]]
+name = "frunk_derives"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0b4095fc99e1d858e5b8c7125d2638372ec85aa0fe6c807105cf10b0265ca6c"
+dependencies = [
+ "frunk_proc_macro_helpers",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "frunk_proc_macro_helpers"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b70229a1347a20d4af9c06116cc452acef34f798668c6b69e97dd5c8a88052bd"
+dependencies = [
+ "frunk_core 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "frunk_proc_macros"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c63fe4306e13ece9d1ac23ce02f121ffefd42ae876ad03ec2caf07232bde3023"
+dependencies = [
+ "frunk_core 0.5.0",
+ "frunk_proc_macro_helpers",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3818,6 +3989,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
 
 [[package]]
 name = "hashbrown"
@@ -3825,7 +3999,7 @@ version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "allocator-api2",
  "rayon",
 ]
@@ -3859,6 +4033,15 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "hdfs-native"
@@ -4396,6 +4579,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-enum"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de9008599afe8527a8c9d70423437363b321649161e98473f433de802d76107"
+dependencies = [
+ "derive_utils",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4930,7 +5122,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
- "twox-hash",
+ "twox-hash 2.1.2",
  "uuid",
 ]
 
@@ -5116,7 +5308,7 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce0f4d7f739dc30608fe8b202cbb40986c2937e1a5a189f98fb06d7b8543156a"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow",
  "arrow-array",
  "arrow-cast",
@@ -5346,6 +5538,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5490,7 +5693,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90071f8077f8e40adfc4b7fe9cd495ce316263f19e75c2211eeff3fdf475a3d9"
 dependencies = [
- "twox-hash",
+ "twox-hash 2.1.2",
 ]
 
 [[package]]
@@ -5745,6 +5948,114 @@ name = "murmurhash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
+
+[[package]]
+name = "mysql"
+version = "25.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6ad644efb545e459029b1ffa7c969d830975bd76906820913247620df10050b"
+dependencies = [
+ "bufstream",
+ "bytes",
+ "crossbeam",
+ "flate2",
+ "io-enum",
+ "libc",
+ "lru 0.12.5",
+ "mysql_common",
+ "named_pipe",
+ "native-tls",
+ "pem",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+ "socket2 0.5.10",
+ "twox-hash 1.6.3",
+ "url",
+]
+
+[[package]]
+name = "mysql-common-derive"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63c3512cf11487168e0e9db7157801bf5273be13055a9cc95356dc9e0035e49c"
+dependencies = [
+ "darling",
+ "heck 0.5.0",
+ "num-bigint",
+ "proc-macro-crate",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "termcolor",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "mysql_common"
+version = "0.32.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478b0ff3f7d67b79da2b96f56f334431aef65e15ba4b29dd74a4236e29582bdc"
+dependencies = [
+ "base64 0.21.7",
+ "bigdecimal",
+ "bindgen",
+ "bitflags 2.10.0",
+ "bitvec",
+ "btoi",
+ "byteorder",
+ "bytes",
+ "cc",
+ "cmake",
+ "crc32fast",
+ "flate2",
+ "frunk",
+ "lazy_static",
+ "mysql-common-derive",
+ "num-bigint",
+ "num-traits",
+ "rand 0.8.5",
+ "regex",
+ "rust_decimal",
+ "saturating",
+ "serde",
+ "serde_json",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "subprocess",
+ "thiserror 1.0.69",
+ "time",
+ "uuid",
+ "zstd",
+]
+
+[[package]]
+name = "named_pipe"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad9c443cce91fc3e12f017290db75dde490d685cdaaf508d7159d7cf41f0eb2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
 
 [[package]]
 name = "ndarray"
@@ -6067,10 +6378,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -6466,7 +6814,7 @@ version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "725b09f2b5ef31279b66e27bbab63c58d49d8f6696b66b1f46c7eaab95e80f75"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "atoi",
  "atoi_simd",
  "bytemuck",
@@ -6527,7 +6875,7 @@ version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "465f70d3e96b6d0b1a43c358ba451286b8c8bd56696feff020d65702aa33e35c"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "bitflags 2.10.0",
  "bytemuck",
  "chrono",
@@ -6571,7 +6919,7 @@ version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2c8589e418cbe4a48228d64b2a8a40284a82ec3c98817c0c2bcc0267701338b"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "atoi_simd",
  "bytes",
  "chrono",
@@ -6601,7 +6949,7 @@ version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2632b1af668e2058d5f8f916d8fbde3cac63d03ae29a705f598e41dcfeb7f"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "bitflags 2.10.0",
  "glob",
  "once_cell",
@@ -6624,7 +6972,7 @@ version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efdbdb4d9a92109bc2e0ce8e17af5ae8ab643bb5b7ee9d1d74f0aeffd1fbc95f"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "argminmax",
  "base64 0.21.7",
  "bytemuck",
@@ -6654,7 +7002,7 @@ version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b421d2196f786fdfe162db614c8485f8308fe41575d4de634a39bbe460d1eb6a"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "base64 0.21.7",
  "ethnum",
  "num-traits",
@@ -6698,7 +7046,7 @@ version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fb8e2302e20c44defd5be8cad9c96e75face63c3a5f609aced8c4ec3b3ac97d"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "bytemuck",
  "chrono-tz 0.8.6",
  "hashbrown 0.14.5",
@@ -6774,7 +7122,7 @@ version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c760b6c698cfe2fbbbd93d6cfb408db14ececfe1d92445dae2229ce1b5b21ae8"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "bytemuck",
  "hashbrown 0.14.5",
  "indexmap 2.14.0",
@@ -7061,6 +7409,26 @@ checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
 dependencies = [
  "ar_archive_writer",
  "cc",
+]
+
+[[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -7413,7 +7781,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e47a395bdb55442b883c89062d6bcff25dc90fa5f8369af81e0ac6d49d78cf81"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "brotli",
  "paste",
  "rand 0.9.2",
@@ -7589,6 +7957,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "reqsign"
 version = "0.16.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7738,6 +8115,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rkyv"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "roaring"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7797,6 +8203,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.10.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rust-ini"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7815,6 +8235,23 @@ checksum = "e46a2036019fdb888131db7a4c847a1063a7493f971ed94ea82c67eada63ca54"
 dependencies = [
  "serde",
  "serde_derive",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be2a24f50780bc85f09cc6ac299bdf1424302742d77221106859c9d8b102126a"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand 0.8.5",
+ "rkyv",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -7996,6 +8433,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "saturating"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece8e78b2f38ec51c51f5d475df0a7187ba5111b2a28bdc761ee05b075d40a71"
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8060,6 +8503,12 @@ dependencies = [
  "ring",
  "untrusted",
 ]
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "secrecy"
@@ -8620,6 +9069,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "subprocess"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c56e8662b206b9892d7a5a3f2ecdbcb455d3d6b259111373b7e08b8055158a8"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8931,6 +9390,15 @@ dependencies = [
  "once_cell",
  "rustix 1.0.8",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -9414,6 +9882,17 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "rand 0.8.5",
+ "static_assertions",
+]
+
+[[package]]
+name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
@@ -9658,6 +10137,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
+ "serde",
  "wasm-bindgen-macro",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,8 @@ prost = "0.11.9"
 prost-build = "0.11.9"
 bincode = "1.3.3"
 serde_json = "1.0.125"
+rusqlite = { version = "0.32.1", features = ["bundled"] }
+mysql = "25.0.1"
 
 
 once_cell = "1.18.0"

--- a/build/bin/curvine-transfer.sh
+++ b/build/bin/curvine-transfer.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+#
+# Copyright 2025 OPPO.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"$(cd "`dirname "$0"`"; pwd)"/launch-process.sh transfer $1

--- a/build/bin/launch-process.sh
+++ b/build/bin/launch-process.sh
@@ -52,7 +52,7 @@ start() {
     check
 
     name="unknown"
-    if [[ "$SERVICE_NAME" = "worker" ]] || [[ "$SERVICE_NAME" = "master" ]]; then
+    if [[ "$SERVICE_NAME" = "worker" ]] || [[ "$SERVICE_NAME" = "master" ]] || [[ "$SERVICE_NAME" = "transfer" ]]; then
       name="curvine-server"
       nohup ${CURVINE_HOME}/lib/curvine-server \
       --service ${SERVICE_NAME} \

--- a/build/bin/local-cluster.sh
+++ b/build/bin/local-cluster.sh
@@ -150,13 +150,62 @@ wait_service_ready() {
     return 1
 }
 
+read_bool() {
+    local section=$1
+    local key=$2
+    local default_value=$3
+    local conf_file="${CURVINE_CONF_FILE:-$CURVINE_HOME/conf/curvine-cluster.toml}"
+
+    if [ ! -f "$conf_file" ]; then
+        echo "$default_value"
+        return
+    fi
+
+    awk -v section="[$section]" -v key="$key" -v default_value="$default_value" '
+        /^[[:space:]]*\[/ {
+            line = $0
+            sub(/[[:space:]]*#.*/, "", line)
+            gsub(/[[:space:]]/, "", line)
+            in_section = (line == section)
+        }
+        in_section {
+            line = $0
+            sub(/[[:space:]]*#.*/, "", line)
+            gsub(/[[:space:]]/, "", line)
+            if (line ~ "^" key "=") {
+                sub(/^[^=]*=/, "", line)
+                print line
+                found = 1
+                exit
+            }
+        }
+        END {
+            if (!found) {
+                print default_value
+            }
+        }
+    ' "$conf_file"
+}
+
+transfer_enabled() {
+    [ "$(read_bool "transfer" "enabled" "false")" = "true" ]
+}
+
+active_services() {
+    local services=("${SERVICES[@]}")
+    if transfer_enabled; then
+        services+=("transfer")
+    fi
+    echo "${services[@]}"
+}
+
 # Start all services
 start_all() {
     print_info "Starting Curvine local cluster..."
     
     # Check if there is already a service running
     local running=false
-    for service in "${SERVICES[@]}"; do
+    for service in $(active_services); do
         if [ -f "$CURVINE_HOME/${service}.pid" ]; then
             local pid=$(cat "$CURVINE_HOME/${service}.pid")
             if kill -0 "$pid" > /dev/null 2>&1; then
@@ -173,6 +222,7 @@ start_all() {
     
     local master_port=$(read_rpc_port "master" 8995)
     local worker_port=$(read_rpc_port "worker" 8997)
+    local transfer_port=$(read_rpc_port "transfer" 9010)
 
     print_info "Starting master..."
     "$BIN_DIR/curvine-master.sh" start
@@ -181,6 +231,12 @@ start_all() {
     print_info "Starting worker..."
     "$BIN_DIR/curvine-worker.sh" start
     wait_service_ready "worker" "$worker_port" 60 || return 1
+
+    if transfer_enabled; then
+        print_info "Starting transfer..."
+        "$BIN_DIR/curvine-transfer.sh" start
+        wait_service_ready "transfer" "$transfer_port" 60 || return 1
+    fi
     
     print_info "All services started. Use 'status' to check cluster status."
 }
@@ -190,8 +246,9 @@ stop_all() {
     print_info "Stopping Curvine local cluster..."
     
     # Stop service in reverse order
-    for (( idx=${#SERVICES[@]}-1 ; idx>=0 ; idx--)) ; do
-        service="${SERVICES[idx]}"
+    local services=($(active_services))
+    for (( idx=${#services[@]}-1 ; idx>=0 ; idx--)) ; do
+        service="${services[idx]}"
         print_info "Stopping $service..."
         "$BIN_DIR/curvine-${service}.sh" stop
         sleep 1
@@ -199,7 +256,7 @@ stop_all() {
     
     # Check if any service is still running
     local still_running=false
-    for service in "${SERVICES[@]}"; do
+    for service in "${services[@]}"; do
         if [ -f "$CURVINE_HOME/${service}.pid" ]; then
             local pid=$(cat "$CURVINE_HOME/${service}.pid")
             if kill -0 "$pid" > /dev/null 2>&1; then
@@ -212,7 +269,7 @@ stop_all() {
     if [ "$still_running" = true ] && [ "$1" = "force" ]; then
         print_warn "Force killing remaining processes..."
         pkill -9 -f "curvine"
-        for service in "${SERVICES[@]}"; do
+        for service in "${services[@]}"; do
             if [ -f "$CURVINE_HOME/${service}.pid" ]; then
                 rm -f "$CURVINE_HOME/${service}.pid"
             fi
@@ -234,9 +291,10 @@ restart_all() {
 show_status() {
     print_info "Curvine local cluster status:"
     echo "-----------------------------------"
+    local services=($(active_services))
     
     local all_running=true
-    for service in "${SERVICES[@]}"; do
+    for service in "${services[@]}"; do
         echo -n "$service: "
         if ! check_service_status "$service"; then
             all_running=false

--- a/build/bin/restart-all.sh
+++ b/build/bin/restart-all.sh
@@ -56,6 +56,47 @@ read_rpc_port() {
     ' "$conf_file"
 }
 
+read_bool() {
+    local section=$1
+    local key=$2
+    local default_value=$3
+    local conf_file="${CURVINE_CONF_FILE:-${BIN_DIR}/../conf/curvine-cluster.toml}"
+
+    if [ ! -f "$conf_file" ]; then
+        echo "$default_value"
+        return
+    fi
+
+    awk -v section="[$section]" -v key="$key" -v default_value="$default_value" '
+        /^[[:space:]]*\[/ {
+            line = $0
+            sub(/[[:space:]]*#.*/, "", line)
+            gsub(/[[:space:]]/, "", line)
+            in_section = (line == section)
+        }
+        in_section {
+            line = $0
+            sub(/[[:space:]]*#.*/, "", line)
+            gsub(/[[:space:]]/, "", line)
+            if (line ~ "^" key "=") {
+                sub(/^[^=]*=/, "", line)
+                print line
+                found = 1
+                exit
+            }
+        }
+        END {
+            if (!found) {
+                print default_value
+            }
+        }
+    ' "$conf_file"
+}
+
+transfer_enabled() {
+    [ "$(read_bool "transfer" "enabled" "false")" = "true" ]
+}
+
 # Function to wait for a process to start
 wait_for_process() {
     local service_name=$1
@@ -122,6 +163,7 @@ sleep 3
 
 MASTER_PORT=$(read_rpc_port "master" 8995)
 WORKER_PORT=$(read_rpc_port "worker" 8997)
+TRANSFER_PORT=$(read_rpc_port "transfer" 9010)
 
 # Start master and worker services
 ${BIN_DIR}/curvine-master.sh start
@@ -133,6 +175,12 @@ ${BIN_DIR}/curvine-worker.sh start
 # Wait for master and worker to start
 wait_for_process "worker" || exit 1
 wait_for_port "worker" "$WORKER_PORT" 60 || exit 1
+
+if transfer_enabled; then
+    ${BIN_DIR}/curvine-transfer.sh start
+    wait_for_process "transfer" || exit 1
+    wait_for_port "transfer" "$TRANSFER_PORT" 60 || exit 1
+fi
 
 # Start fuse service
 ${BIN_DIR}/curvine-fuse.sh start

--- a/curvine-cli/Cargo.toml
+++ b/curvine-cli/Cargo.toml
@@ -17,3 +17,7 @@ chrono = { workspace = true }
 bytes = { workspace = true }
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false}
 comfy-table = { version = "7.2.2", default-features = false }
+
+[dev-dependencies]
+curvine-server = { workspace = true }
+toml = { workspace = true }

--- a/curvine-cli/src/cmds/export.rs
+++ b/curvine-cli/src/cmds/export.rs
@@ -15,9 +15,11 @@
 use crate::cmds::LoadStatusCommand;
 use crate::util::*;
 use clap::Parser;
-use curvine_client::rpc::JobMasterClient;
-use curvine_common::state::LoadJobCommand;
-use orpc::CommonResult;
+use curvine_client::rpc::{JobMasterClient, TransferClient};
+use curvine_client::unified::UnifiedFileSystem;
+use curvine_common::fs::Path;
+use curvine_common::state::{LoadJobCommand, TransferCommand, TransferKind};
+use orpc::{err_box, CommonResult};
 
 #[derive(Parser, Debug)]
 pub struct ExportCommand {
@@ -27,10 +29,14 @@ pub struct ExportCommand {
     /// Watch export job status after submission
     #[arg(long, short = 'w')]
     watch: bool,
+
+    /// Do not overwrite an existing target file
+    #[arg(long = "no-overwrite", default_value_t = true, action = clap::ArgAction::SetFalse)]
+    overwrite: bool,
 }
 
 impl ExportCommand {
-    pub async fn execute(&self, client: JobMasterClient) -> CommonResult<()> {
+    pub async fn execute_legacy(&self, client: JobMasterClient) -> CommonResult<()> {
         if self.path.trim().is_empty() {
             eprintln!("Error: Path cannot be empty");
             std::process::exit(1);
@@ -55,6 +61,60 @@ impl ExportCommand {
                 LoadStatusCommand::new(rep.job_id.clone(), false, "1s".to_string());
 
             status_command.execute(client).await?;
+        }
+
+        Ok(())
+    }
+
+    pub async fn execute_transfer(
+        &self,
+        fs: UnifiedFileSystem,
+        transfer_client: TransferClient,
+    ) -> CommonResult<()> {
+        if self.path.trim().is_empty() {
+            eprintln!("Error: Path cannot be empty");
+            std::process::exit(1);
+        }
+
+        println!("\nExporting Curvine file to UFS");
+        println!("Source path: {}", self.path);
+
+        let source = Path::from_str(&self.path)?;
+        if !source.is_cv() {
+            return err_box!("export source must be a Curvine path: {}", self.path);
+        }
+        let target = match fs.toggle_path(&source, true).await? {
+            Some(target) => target,
+            None => return err_box!("{} is not mounted", self.path),
+        };
+        if target.is_cv() {
+            return err_box!("export target must be a UFS path: {}", target.full_path());
+        }
+
+        let mut command = TransferCommand {
+            kind: TransferKind::Export,
+            source_path: source.clone_uri(),
+            target_path: target.clone_uri(),
+            client_request_id: TransferCommand::default_client_request_id(
+                TransferKind::Export,
+                source.clone_uri(),
+                target.clone_uri(),
+            ),
+            submitter: "curvine-cli".to_string(),
+            tenant: String::new(),
+            options: Default::default(),
+        };
+        command.set_overwrite(self.overwrite);
+        let rep = handle_rpc_result(transfer_client.submit(command)).await;
+        println!("Job ID: {}", rep.job_id);
+        println!("Target path: {}", target.full_path());
+        println!("State: {}", rep.state);
+
+        if self.watch {
+            let status_command = LoadStatusCommand::new(rep.job_id, false, "1s".to_string());
+            status_command
+                .execute_transfer_only(transfer_client)
+                .await?;
         }
 
         Ok(())

--- a/curvine-cli/src/cmds/load.rs
+++ b/curvine-cli/src/cmds/load.rs
@@ -15,9 +15,11 @@
 use crate::cmds::LoadStatusCommand;
 use crate::util::*;
 use clap::Parser;
-use curvine_client::rpc::JobMasterClient;
-use curvine_common::state::LoadJobCommand;
-use orpc::CommonResult;
+use curvine_client::rpc::{JobMasterClient, TransferClient};
+use curvine_client::unified::UnifiedFileSystem;
+use curvine_common::fs::Path;
+use curvine_common::state::{LoadJobCommand, TransferCommand, TransferKind};
+use orpc::{err_box, CommonResult};
 
 #[derive(Parser, Debug)]
 pub struct LoadCommand {
@@ -30,10 +32,14 @@ pub struct LoadCommand {
     /// Watch load job status after submission
     #[arg(long, short = 'w')]
     watch: bool,
+
+    /// Do not overwrite an existing target file
+    #[arg(long = "no-overwrite", default_value_t = true, action = clap::ArgAction::SetFalse)]
+    overwrite: bool,
 }
 
 impl LoadCommand {
-    pub async fn execute(&self, client: JobMasterClient) -> CommonResult<()> {
+    pub async fn execute_legacy(&self, client: JobMasterClient) -> CommonResult<()> {
         if self.source_path.trim().is_empty() {
             eprintln!("Error: Path cannot be empty");
             std::process::exit(1);
@@ -47,7 +53,7 @@ impl LoadCommand {
             std::process::exit(1);
         }
 
-        println!("\n Loading file to Curvine");
+        println!("\nLoading file to Curvine");
         println!("Source path: {}", self.source_path);
         if let Some(target_path) = &self.target_path {
             println!("Target path: {}", target_path);
@@ -65,8 +71,82 @@ impl LoadCommand {
         if self.watch {
             let status_command =
                 LoadStatusCommand::new(rep.job_id.clone(), false, "1s".to_string());
-
             status_command.execute(client).await?;
+        }
+
+        Ok(())
+    }
+
+    pub async fn execute_transfer(
+        &self,
+        fs: UnifiedFileSystem,
+        transfer_client: TransferClient,
+    ) -> CommonResult<()> {
+        if self.source_path.trim().is_empty() {
+            eprintln!("Error: Path cannot be empty");
+            std::process::exit(1);
+        }
+        if self
+            .target_path
+            .as_ref()
+            .is_some_and(|target_path| target_path.trim().is_empty())
+        {
+            eprintln!("Error: Target path cannot be empty");
+            std::process::exit(1);
+        }
+
+        println!("\nLoading file to Curvine");
+        println!("Source path: {}", self.source_path);
+        if let Some(target_path) = &self.target_path {
+            println!("Target path: {}", target_path);
+        }
+
+        let input = Path::from_str(&self.source_path)?;
+        let (source, target) = if let Some(target_path) = &self.target_path {
+            (input, Path::from_str(target_path)?)
+        } else {
+            let peer = match fs.toggle_path(&input, true).await? {
+                Some(peer) => peer,
+                None => return err_box!("{} is not mounted", self.source_path),
+            };
+            if input.is_cv() {
+                (peer, input)
+            } else {
+                (input, peer)
+            }
+        };
+        if source.is_cv() || !target.is_cv() {
+            return err_box!(
+                "load requires a UFS source and Curvine target: {} -> {}",
+                source.full_path(),
+                target.full_path()
+            );
+        }
+        let mut command = TransferCommand {
+            kind: TransferKind::Load,
+            source_path: source.clone_uri(),
+            target_path: target.clone_uri(),
+            client_request_id: TransferCommand::default_client_request_id(
+                TransferKind::Load,
+                source.clone_uri(),
+                target.clone_uri(),
+            ),
+            submitter: "curvine-cli".to_string(),
+            tenant: String::new(),
+            options: Default::default(),
+        };
+        command.set_overwrite(self.overwrite);
+        let rep = handle_rpc_result(transfer_client.submit(command)).await;
+        println!("Job ID: {}", rep.job_id);
+        println!("Target path: {}", target.full_path());
+        println!("State: {}", rep.state);
+
+        if self.watch {
+            let status_command = LoadStatusCommand::new(rep.job_id, false, "1s".to_string());
+
+            status_command
+                .execute_transfer_only(transfer_client)
+                .await?;
         }
 
         Ok(())

--- a/curvine-cli/src/cmds/load_cancel.rs
+++ b/curvine-cli/src/cmds/load_cancel.rs
@@ -63,7 +63,7 @@ fn print_transfer_cancel_result(state: i32) {
             println!("│ ✅ Job cancel request accepted");
             println!("│ State: {:?}", state);
         }
-        TransferState::Completed | TransferState::Failed => {
+        TransferState::Completed | TransferState::Failed | TransferState::PartialSuccess => {
             println!("│ ℹ️ Job is already terminal");
             println!("│ State: {:?}", state);
         }

--- a/curvine-cli/src/cmds/load_cancel.rs
+++ b/curvine-cli/src/cmds/load_cancel.rs
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 use clap::Parser;
-use curvine_client::rpc::JobMasterClient;
+use curvine_client::rpc::{JobMasterClient, TransferClient};
+use curvine_common::state::TransferState;
 use orpc::CommonResult;
 
 use crate::util::*;
@@ -25,7 +26,6 @@ pub struct CancelLoadCommand {
 
 impl CancelLoadCommand {
     pub async fn execute(&self, client: JobMasterClient) -> CommonResult<()> {
-        // Verify the task ID
         if self.job_id.trim().is_empty() {
             eprintln!("Error: Job ID cannot be empty");
             std::process::exit(1);
@@ -34,10 +34,42 @@ impl CancelLoadCommand {
         println!("\nCancelling load job");
         println!("┌─────────────────────────────────");
         println!("│ Job ID: {}", self.job_id);
-
         handle_rpc_result(client.cancel_job(&self.job_id)).await;
-        println!("│ ✅ Job cancelled successfully");
+        println!("│ Job cancelled successfully");
         println!("└─────────────────────────────────");
         Ok(())
+    }
+
+    pub async fn execute_transfer_only(&self, transfer_client: TransferClient) -> CommonResult<()> {
+        if self.job_id.trim().is_empty() {
+            eprintln!("Error: Job ID cannot be empty");
+            std::process::exit(1);
+        }
+
+        println!("\nCancelling transfer job");
+        println!("┌─────────────────────────────────");
+        println!("│ Job ID: {}", self.job_id);
+        let response = handle_rpc_result(transfer_client.cancel(&self.job_id, None)).await;
+        print_transfer_cancel_result(response.state);
+        println!("└─────────────────────────────────");
+        Ok(())
+    }
+}
+
+fn print_transfer_cancel_result(state: i32) {
+    let state = TransferState::from(state);
+    match state {
+        TransferState::Canceling | TransferState::Canceled => {
+            println!("│ ✅ Job cancel request accepted");
+            println!("│ State: {:?}", state);
+        }
+        TransferState::Completed | TransferState::Failed => {
+            println!("│ ℹ️ Job is already terminal");
+            println!("│ State: {:?}", state);
+        }
+        _ => {
+            println!("│ ✅ Job cancel request accepted");
+            println!("│ State: {:?}", state);
+        }
     }
 }

--- a/curvine-cli/src/cmds/load_status.rs
+++ b/curvine-cli/src/cmds/load_status.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use clap::Parser;
-use curvine_client::rpc::JobMasterClient;
+use curvine_client::rpc::{JobMasterClient, TransferClient};
 use curvine_common::state::JobTaskState;
 use orpc::CommonResult;
 
@@ -38,8 +38,9 @@ impl LoadStatusCommand {
             watch: Some(watch),
         }
     }
+
     pub async fn execute(&self, client: JobMasterClient) -> CommonResult<()> {
-        println!("\n Checking status for {}", self.job_id);
+        println!("\nChecking status for {}", self.job_id);
 
         if let Some(watch_interval) = &self.watch {
             self.watch_status(client, watch_interval).await
@@ -50,13 +51,44 @@ impl LoadStatusCommand {
         }
     }
 
-    /// keep watch job status
-    ///
-    /// # Arguments
-    /// * `client` - LoadClient Instance
-    /// * `interval_str` - Example：5s, 1m
     async fn watch_status(&self, client: JobMasterClient, interval_str: &str) -> CommonResult<()> {
-        // Resolution refresh interval
+        let duration = parse_duration(interval_str).unwrap_or_else(|_| {
+            eprintln!("Error: Invalid watch interval format: {}", interval_str);
+            std::process::exit(1);
+        });
+
+        loop {
+            let status = handle_rpc_result(client.get_job_status(&self.job_id)).await;
+            println!("{}", status);
+            if matches!(
+                status.state,
+                JobTaskState::Completed | JobTaskState::Failed | JobTaskState::Canceled
+            ) {
+                break;
+            }
+            tokio::time::sleep(duration).await;
+        }
+
+        Ok(())
+    }
+
+    pub async fn execute_transfer_only(&self, transfer_client: TransferClient) -> CommonResult<()> {
+        println!("\n Checking status for {}", self.job_id);
+
+        if let Some(watch_interval) = &self.watch {
+            self.watch_transfer_status(transfer_client, watch_interval)
+                .await
+        } else {
+            print_transfer_status(&transfer_client, &self.job_id).await?;
+            Ok(())
+        }
+    }
+
+    async fn watch_transfer_status(
+        &self,
+        transfer_client: TransferClient,
+        interval_str: &str,
+    ) -> CommonResult<()> {
         let duration = parse_duration(interval_str).unwrap_or_else(|_| {
             eprintln!("❌ Error: Invalid watch interval format: {}", interval_str);
             eprintln!("    Supported formats: <number>s (seconds), <number>m (minutes)");
@@ -65,7 +97,7 @@ impl LoadStatusCommand {
         });
 
         println!(
-            "Watching job status (refresh every {}). Press Ctrl+C to stop.",
+            "Watching transfer status (refresh every {}). Press Ctrl+C to stop.",
             format_duration(&duration)
         );
 
@@ -85,13 +117,11 @@ impl LoadStatusCommand {
             );
             println!("Press Ctrl+C to stop watching.");
 
-            let status = handle_rpc_result(client.get_job_status(&self.job_id)).await;
-            println!("{}", status);
-
-            if status.state == JobTaskState::Completed
-                || status.state == JobTaskState::Failed
-                || status.state == JobTaskState::Canceled
-            {
+            let state = print_transfer_status(&transfer_client, &self.job_id).await?;
+            if matches!(
+                state,
+                JobTaskState::Completed | JobTaskState::Failed | JobTaskState::Canceled
+            ) {
                 break;
             }
 
@@ -99,5 +129,32 @@ impl LoadStatusCommand {
         }
 
         Ok(())
+    }
+}
+
+async fn print_transfer_status(
+    client: &TransferClient,
+    job_id: &str,
+) -> CommonResult<JobTaskState> {
+    let status = handle_rpc_result(client.status(job_id)).await;
+    let state = transfer_state_to_job_state(status.state);
+    println!("Job ID: {}", status.job_id);
+    println!("Run ID: {}", status.run_id);
+    println!("State: {:?}", state);
+    println!(
+        "Progress: {} / {}, message={}",
+        status.progress.loaded_size, status.progress.total_size, status.progress.message
+    );
+    Ok(state)
+}
+
+fn transfer_state_to_job_state(state: i32) -> JobTaskState {
+    match state {
+        1 => JobTaskState::Pending,
+        2..=5 => JobTaskState::Loading,
+        6 => JobTaskState::Completed,
+        7 => JobTaskState::Failed,
+        8 => JobTaskState::Canceled,
+        _ => JobTaskState::UNKNOWN,
     }
 }

--- a/curvine-cli/src/cmds/load_status.rs
+++ b/curvine-cli/src/cmds/load_status.rs
@@ -14,7 +14,7 @@
 
 use clap::Parser;
 use curvine_client::rpc::{JobMasterClient, TransferClient};
-use curvine_common::state::JobTaskState;
+use curvine_common::state::{JobTaskState, TransferState};
 use orpc::CommonResult;
 
 use crate::util::*;
@@ -118,10 +118,7 @@ impl LoadStatusCommand {
             println!("Press Ctrl+C to stop watching.");
 
             let state = print_transfer_status(&transfer_client, &self.job_id).await?;
-            if matches!(
-                state,
-                JobTaskState::Completed | JobTaskState::Failed | JobTaskState::Canceled
-            ) {
+            if state.is_terminal() {
                 break;
             }
 
@@ -135,26 +132,27 @@ impl LoadStatusCommand {
 async fn print_transfer_status(
     client: &TransferClient,
     job_id: &str,
-) -> CommonResult<JobTaskState> {
+) -> CommonResult<TransferState> {
     let status = handle_rpc_result(client.status(job_id)).await;
-    let state = transfer_state_to_job_state(status.state);
+    let state = TransferState::from(status.state);
     println!("Job ID: {}", status.job_id);
     println!("Run ID: {}", status.run_id);
     println!("State: {:?}", state);
     println!(
         "Progress: {} / {}, message={}",
-        status.progress.loaded_size, status.progress.total_size, status.progress.message
+        bytes_to_string(status.progress.loaded_size.max(0)),
+        bytes_to_string(status.progress.total_size.max(0)),
+        status.progress.message
     );
-    Ok(state)
-}
-
-fn transfer_state_to_job_state(state: i32) -> JobTaskState {
-    match state {
-        1 => JobTaskState::Pending,
-        2..=5 => JobTaskState::Loading,
-        6 => JobTaskState::Completed,
-        7 => JobTaskState::Failed,
-        8 => JobTaskState::Canceled,
-        _ => JobTaskState::UNKNOWN,
+    if let Some(summary) = status.task_summary {
+        println!(
+            "Tasks: {} completed, {} failed, {} running, {} pending; {} cached",
+            summary.completed,
+            summary.failed,
+            summary.running,
+            summary.pending,
+            bytes_to_string(summary.completed_size.max(0)),
+        );
     }
+    Ok(state)
 }

--- a/curvine-cli/src/cmds/mod.rs
+++ b/curvine-cli/src/cmds/mod.rs
@@ -21,6 +21,7 @@ mod load_status;
 mod mount;
 mod node;
 mod report;
+pub mod transfer;
 mod umount;
 
 pub use bench::BenchCommand;
@@ -32,4 +33,5 @@ pub use load_status::LoadStatusCommand;
 pub use mount::MountCommand;
 pub use node::NodeCommand;
 pub use report::ReportCommand;
+pub use transfer::TransferCommand;
 pub use umount::UnMountCommand;

--- a/curvine-cli/src/cmds/mount.rs
+++ b/curvine-cli/src/cmds/mount.rs
@@ -289,7 +289,7 @@ impl MountCommand {
         if !configs.is_empty() {
             println!("Configuration:");
             for (key, value) in &configs {
-                println!("  {} = {}", key, value);
+                println!("  {} = {}", key, display_config_value(key, value));
             }
             println!("\n");
         }
@@ -299,7 +299,7 @@ impl MountCommand {
 
         if !self.update && self.check_path_consist && ufs_path.authority_path() != cv_path.path() {
             return err_box!(
-                "with --check-path, ufs path and cv path must be consistent. ufs: {}, cv: {}",
+                "with --check-path-consist, UFS and Curvine paths must match. UFS: {}, Curvine: {}",
                 ufs_path.authority_path(),
                 cv_path.path()
             );
@@ -314,11 +314,19 @@ impl MountCommand {
             &ufs_path,
             mnt_opts.add_properties.clone(),
             mnt_opts.provider,
-        )?;
-        if let Err(e) = ufs.list_status(&ufs_path).await {
-            eprintln!("Error: {}", e);
-            std::process::exit(1);
-        }
+        )
+        .map_err(|_| {
+            FsError::common(format!(
+                "Unable to initialize UFS {}. Verify the URI, mount configuration, and credentials.",
+                ufs_path.full_path()
+            ))
+        })?;
+        ufs.list_status(&ufs_path).await.map_err(|_| {
+            FsError::common(format!(
+                "Unable to access UFS {}. Verify the endpoint, credentials, and network connectivity.",
+                ufs_path.full_path()
+            ))
+        })?;
 
         handle_rpc_result(fs.mount(&ufs_path, &cv_path, mnt_opts)).await;
         println!("│ ✅️ mount success.");
@@ -559,4 +567,24 @@ impl MountCommand {
 
         Ok(opts.build())
     }
+}
+
+fn display_config_value<'a>(key: &str, value: &'a str) -> &'a str {
+    if is_sensitive_config_key(key) {
+        "******"
+    } else {
+        value
+    }
+}
+
+fn is_sensitive_config_key(key: &str) -> bool {
+    let key = key.to_ascii_lowercase();
+    key.contains("credential")
+        || key.contains("secret")
+        || key.contains("token")
+        || key.contains("password")
+        || key.contains("access_key")
+        || key.ends_with(".access")
+        || key.ends_with(".ak")
+        || key.ends_with(".sk")
 }

--- a/curvine-cli/src/cmds/transfer.rs
+++ b/curvine-cli/src/cmds/transfer.rs
@@ -331,6 +331,7 @@ impl TransferTenantsCommand {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn list_transfer_pages(
     client: &TransferClient,
     kind: Option<TransferKind>,
@@ -796,7 +797,7 @@ fn format_timestamp(timestamp_ms: i64) -> String {
 }
 
 fn transfer_is_terminal(state: i32) -> bool {
-    matches!(state, 6 | 7 | 8 | 9)
+    matches!(state, 6..=9)
 }
 
 fn kind_name(kind: i32) -> &'static str {

--- a/curvine-cli/src/cmds/transfer.rs
+++ b/curvine-cli/src/cmds/transfer.rs
@@ -1,0 +1,801 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+
+use clap::{Parser, Subcommand, ValueEnum};
+use comfy_table::{presets::ASCII_MARKDOWN, Table};
+use curvine_client::rpc::TransferClient;
+use curvine_common::proto::{
+    CancelTransferResponse, GetTransferStatusResponse, ListTransferTenantsResponse,
+    ListTransfersResponse, SubmitTransferResponse, TransferJobStatusProto, TransferTaskStatusProto,
+    TransferTenantSummaryProto,
+};
+use curvine_common::state::{TransferKind, TransferState};
+use orpc::{err_box, CommonResult};
+
+use crate::util::{bytes_to_string, handle_rpc_result, parse_duration};
+
+#[derive(Parser, Debug)]
+pub struct TransferCommand {
+    #[command(subcommand)]
+    command: TransferSubCommand,
+}
+
+#[derive(Subcommand, Debug)]
+enum TransferSubCommand {
+    /// List transfer jobs
+    List(TransferListCommand),
+
+    /// Show one transfer job; add --verbose for task details
+    Status(TransferStatusCommand),
+
+    /// Show task page for one transfer job
+    Tasks(TransferTasksCommand),
+
+    /// Cancel one transfer job
+    Cancel(TransferCancelCommand),
+
+    /// Retry a failed or canceled transfer job
+    Retry(TransferRetryCommand),
+
+    /// Summarize transfer jobs by tenant
+    Tenants(TransferTenantsCommand),
+}
+
+#[derive(Parser, Debug)]
+pub struct TransferListCommand {
+    #[arg(long)]
+    kind: Option<TransferKindArg>,
+
+    #[arg(long)]
+    state: Option<TransferStateArg>,
+
+    #[arg(long)]
+    submitter: Option<String>,
+
+    #[arg(long)]
+    tenant: Option<String>,
+
+    #[arg(long, default_value_t = 20)]
+    limit: u32,
+
+    #[arg(long)]
+    page_token: Option<String>,
+
+    #[arg(long)]
+    all: bool,
+
+    #[arg(long, value_enum, default_value_t = OutputFormat::Table)]
+    format: OutputFormat,
+
+    #[arg(long)]
+    full_id: bool,
+
+    #[arg(long, short = 'v')]
+    verbose: bool,
+}
+
+#[derive(Parser, Debug)]
+pub struct TransferStatusCommand {
+    job_id: String,
+
+    #[arg(long, short = 'v')]
+    verbose: bool,
+
+    #[arg(long, short = 'w')]
+    watch: bool,
+
+    #[arg(long, default_value = "1s")]
+    interval: String,
+
+    #[arg(long, default_value_t = 20)]
+    limit: u32,
+
+    #[arg(long)]
+    page_token: Option<String>,
+
+    #[arg(long)]
+    all: bool,
+
+    #[arg(long, value_enum, default_value_t = OutputFormat::Table)]
+    format: OutputFormat,
+
+    #[arg(long)]
+    full_id: bool,
+}
+
+#[derive(Parser, Debug)]
+pub struct TransferTasksCommand {
+    job_id: String,
+
+    #[arg(long, short = 'v')]
+    verbose: bool,
+
+    #[arg(long, default_value_t = 50)]
+    limit: u32,
+
+    #[arg(long)]
+    page_token: Option<String>,
+
+    #[arg(long)]
+    all: bool,
+
+    #[arg(long, value_enum, default_value_t = OutputFormat::Table)]
+    format: OutputFormat,
+
+    #[arg(long)]
+    full_id: bool,
+}
+
+#[derive(Parser, Debug)]
+pub struct TransferCancelCommand {
+    job_id: String,
+
+    #[arg(long)]
+    run_id: Option<u64>,
+
+    #[arg(long, value_enum, default_value_t = OutputFormat::Table)]
+    format: OutputFormat,
+}
+
+#[derive(Parser, Debug)]
+pub struct TransferRetryCommand {
+    job_id: String,
+
+    #[arg(long, value_enum, default_value_t = OutputFormat::Table)]
+    format: OutputFormat,
+}
+
+#[derive(Parser, Debug)]
+pub struct TransferTenantsCommand {
+    #[arg(long, default_value_t = 20)]
+    limit: u32,
+
+    #[arg(long)]
+    page_token: Option<String>,
+
+    #[arg(long)]
+    all: bool,
+
+    #[arg(long, value_enum, default_value_t = OutputFormat::Table)]
+    format: OutputFormat,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum TransferKindArg {
+    Load,
+    Export,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum TransferStateArg {
+    Pending,
+    Planning,
+    Dispatching,
+    Running,
+    Canceling,
+    Completed,
+    Failed,
+    Canceled,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum, PartialEq, Eq)]
+pub enum OutputFormat {
+    Table,
+    Json,
+}
+
+impl TransferCommand {
+    pub async fn execute(&self, client: TransferClient) -> CommonResult<()> {
+        match &self.command {
+            TransferSubCommand::List(cmd) => cmd.execute(client).await,
+            TransferSubCommand::Status(cmd) => cmd.execute(client).await,
+            TransferSubCommand::Tasks(cmd) => cmd.execute(client).await,
+            TransferSubCommand::Cancel(cmd) => cmd.execute(client).await,
+            TransferSubCommand::Retry(cmd) => cmd.execute(client).await,
+            TransferSubCommand::Tenants(cmd) => cmd.execute(client).await,
+        }
+    }
+}
+
+impl TransferListCommand {
+    async fn execute(&self, client: TransferClient) -> CommonResult<()> {
+        let response = list_transfer_pages(
+            &client,
+            self.kind.map(TransferKind::from),
+            self.state.map(TransferState::from),
+            self.submitter.clone(),
+            self.tenant.clone(),
+            self.limit,
+            self.page_token.clone(),
+            self.all,
+        )
+        .await?;
+        if self.format == OutputFormat::Json {
+            println!("{}", serde_json::to_string_pretty(&response)?);
+            return Ok(());
+        }
+        print_jobs_table(&response.jobs, self.full_id, self.verbose);
+        print_next_page(response.next_page_token.as_deref());
+        Ok(())
+    }
+}
+
+impl TransferStatusCommand {
+    async fn execute(&self, client: TransferClient) -> CommonResult<()> {
+        if self.watch && self.format == OutputFormat::Json {
+            return err_box!("--watch only supports --format table");
+        }
+        let interval = self
+            .watch
+            .then(|| parse_watch_interval(&self.interval))
+            .transpose()?;
+        let include_tasks = self.verbose || self.format == OutputFormat::Json;
+        let mut first = true;
+        loop {
+            let response = status_transfer_pages(
+                &client,
+                &self.job_id,
+                if include_tasks { self.limit } else { 0 },
+                include_tasks.then(|| self.page_token.clone()).flatten(),
+                include_tasks && self.all,
+            )
+            .await?;
+            if self.format == OutputFormat::Json {
+                println!("{}", serde_json::to_string_pretty(&response)?);
+                return Ok(());
+            }
+            if !first {
+                println!();
+            }
+            first = false;
+            let job = status_to_job(&response);
+            print_status_summary(&job, self.verbose);
+            if self.verbose {
+                print_tasks_table(&response.tasks, self.full_id, true);
+                print_next_page(response.next_page_token.as_deref());
+            }
+            if !self.watch || transfer_is_terminal(response.state) {
+                return Ok(());
+            }
+            if let Some(interval) = interval {
+                tokio::time::sleep(interval).await;
+            }
+        }
+    }
+}
+
+impl TransferTasksCommand {
+    async fn execute(&self, client: TransferClient) -> CommonResult<()> {
+        let response = status_transfer_pages(
+            &client,
+            &self.job_id,
+            self.limit,
+            self.page_token.clone(),
+            self.all,
+        )
+        .await?;
+        if self.format == OutputFormat::Json {
+            println!("{}", serde_json::to_string_pretty(&response.tasks)?);
+            return Ok(());
+        }
+        print_tasks_table(&response.tasks, self.full_id, self.verbose);
+        print_next_page(response.next_page_token.as_deref());
+        Ok(())
+    }
+}
+
+impl TransferCancelCommand {
+    async fn execute(&self, client: TransferClient) -> CommonResult<()> {
+        let response = handle_rpc_result(client.cancel(&self.job_id, self.run_id)).await;
+        println!("{}", render_cancel_response(&response, self.format)?);
+        Ok(())
+    }
+}
+
+impl TransferRetryCommand {
+    async fn execute(&self, client: TransferClient) -> CommonResult<()> {
+        let response = handle_rpc_result(client.retry(&self.job_id)).await;
+        println!(
+            "{}",
+            render_retry_response(&self.job_id, &response, self.format)?
+        );
+        Ok(())
+    }
+}
+
+impl TransferTenantsCommand {
+    async fn execute(&self, client: TransferClient) -> CommonResult<()> {
+        let response =
+            list_tenant_pages(&client, self.limit, self.page_token.clone(), self.all).await?;
+        if self.format == OutputFormat::Json {
+            println!("{}", serde_json::to_string_pretty(&response)?);
+            return Ok(());
+        }
+        print_tenants_table(&response.tenants);
+        print_next_page(response.next_page_token.as_deref());
+        Ok(())
+    }
+}
+
+async fn list_transfer_pages(
+    client: &TransferClient,
+    kind: Option<TransferKind>,
+    state: Option<TransferState>,
+    submitter: Option<String>,
+    tenant: Option<String>,
+    limit: u32,
+    page_token: Option<String>,
+    all: bool,
+) -> CommonResult<ListTransfersResponse> {
+    validate_all_page_limit(limit, all)?;
+    let mut response = handle_rpc_result(client.list(
+        kind,
+        state,
+        submitter.clone(),
+        tenant.clone(),
+        Some(limit),
+        page_token.clone(),
+    ))
+    .await;
+    if !all {
+        return Ok(response);
+    }
+
+    let mut previous_token = page_token;
+    while let Some(next_token) = response.next_page_token.clone() {
+        ensure_page_advanced(previous_token.as_deref(), &next_token)?;
+        let mut next = handle_rpc_result(client.list(
+            kind,
+            state,
+            submitter.clone(),
+            tenant.clone(),
+            Some(limit),
+            Some(next_token.clone()),
+        ))
+        .await;
+        response.jobs.append(&mut next.jobs);
+        previous_token = Some(next_token);
+        response.next_page_token = next.next_page_token;
+    }
+    Ok(response)
+}
+
+async fn status_transfer_pages(
+    client: &TransferClient,
+    job_id: &str,
+    limit: u32,
+    page_token: Option<String>,
+    all: bool,
+) -> CommonResult<GetTransferStatusResponse> {
+    validate_all_page_limit(limit, all)?;
+    let mut response =
+        handle_rpc_result(client.status_page(job_id, Some(limit), page_token.clone())).await;
+    if !all {
+        return Ok(response);
+    }
+
+    let mut previous_token = page_token;
+    while let Some(next_token) = response.next_page_token.clone() {
+        ensure_page_advanced(previous_token.as_deref(), &next_token)?;
+        let mut next =
+            handle_rpc_result(client.status_page(job_id, Some(limit), Some(next_token.clone())))
+                .await;
+        response.tasks.append(&mut next.tasks);
+        previous_token = Some(next_token);
+        response.next_page_token = next.next_page_token;
+    }
+    Ok(response)
+}
+
+async fn list_tenant_pages(
+    client: &TransferClient,
+    limit: u32,
+    page_token: Option<String>,
+    all: bool,
+) -> CommonResult<ListTransferTenantsResponse> {
+    validate_all_page_limit(limit, all)?;
+    let mut response =
+        handle_rpc_result(client.list_tenants(Some(limit), page_token.clone())).await;
+    if !all {
+        return Ok(response);
+    }
+
+    let mut previous_token = page_token;
+    while let Some(next_token) = response.next_page_token.clone() {
+        ensure_page_advanced(previous_token.as_deref(), &next_token)?;
+        let mut next =
+            handle_rpc_result(client.list_tenants(Some(limit), Some(next_token.clone()))).await;
+        response.tenants.append(&mut next.tenants);
+        previous_token = Some(next_token);
+        response.next_page_token = next.next_page_token;
+    }
+    Ok(response)
+}
+
+fn validate_all_page_limit(limit: u32, all: bool) -> CommonResult<()> {
+    if all && limit == 0 {
+        return err_box!("--all requires --limit to be greater than 0");
+    }
+    Ok(())
+}
+
+fn ensure_page_advanced(previous: Option<&str>, next: &str) -> CommonResult<()> {
+    if previous == Some(next) {
+        return err_box!("Transfer service returned the same next_page_token: {next}");
+    }
+    Ok(())
+}
+
+fn parse_watch_interval(value: &str) -> CommonResult<Duration> {
+    let interval = match parse_duration(value) {
+        Ok(interval) => interval,
+        Err(err) => return err_box!("Invalid --interval {}: {}", value, err),
+    };
+    if interval.is_zero() {
+        return err_box!("--interval must be greater than zero");
+    }
+    Ok(interval)
+}
+
+fn status_to_job(response: &GetTransferStatusResponse) -> TransferJobStatusProto {
+    TransferJobStatusProto {
+        job_id: response.job_id.clone(),
+        run_id: response.run_id,
+        kind: response.kind.unwrap_or_default(),
+        state: response.state,
+        source_path: response.source_path.clone().unwrap_or_default(),
+        target_path: response.target_path.clone().unwrap_or_default(),
+        progress: response.progress.clone(),
+        submitter: response.submitter.clone().unwrap_or_default(),
+        tenant: response.tenant.clone().unwrap_or_default(),
+        created_at: response.created_at.unwrap_or_default(),
+        updated_at: response.updated_at.unwrap_or_default(),
+        owner: response.owner.clone(),
+        lease_epoch: response.lease_epoch,
+        lease_expire_at: response.lease_expire_at,
+        cv_metadata_epoch: response.cv_metadata_epoch,
+    }
+}
+
+pub fn render_cancel_response(
+    response: &CancelTransferResponse,
+    format: OutputFormat,
+) -> CommonResult<String> {
+    if format == OutputFormat::Json {
+        return Ok(serde_json::to_string_pretty(response)?);
+    }
+    let mut table = md_table();
+    table.set_header(["JOB ID", "STATE"]);
+    table.add_row([
+        response.job_id.clone(),
+        state_name(response.state).to_string(),
+    ]);
+    Ok(table.to_string())
+}
+
+pub fn render_retry_response(
+    original_job_id: &str,
+    response: &SubmitTransferResponse,
+    format: OutputFormat,
+) -> CommonResult<String> {
+    if format == OutputFormat::Json {
+        return Ok(serde_json::to_string_pretty(response)?);
+    }
+    let mut table = md_table();
+    table.set_header(["RETRY OF", "NEW JOB ID", "STATE"]);
+    table.add_row([
+        short_id(original_job_id),
+        response.job_id.clone(),
+        state_name(response.state).to_string(),
+    ]);
+    Ok(table.to_string())
+}
+
+impl From<TransferKindArg> for TransferKind {
+    fn from(value: TransferKindArg) -> Self {
+        match value {
+            TransferKindArg::Load => TransferKind::Load,
+            TransferKindArg::Export => TransferKind::Export,
+        }
+    }
+}
+
+impl From<TransferStateArg> for TransferState {
+    fn from(value: TransferStateArg) -> Self {
+        match value {
+            TransferStateArg::Pending => TransferState::Pending,
+            TransferStateArg::Planning => TransferState::Planning,
+            TransferStateArg::Dispatching => TransferState::Dispatching,
+            TransferStateArg::Running => TransferState::Running,
+            TransferStateArg::Canceling => TransferState::Canceling,
+            TransferStateArg::Completed => TransferState::Completed,
+            TransferStateArg::Failed => TransferState::Failed,
+            TransferStateArg::Canceled => TransferState::Canceled,
+        }
+    }
+}
+
+fn print_jobs_table(jobs: &[TransferJobStatusProto], full_id: bool, verbose: bool) {
+    let mut table = md_table();
+    if verbose {
+        table.set_header([
+            "JOB ID", "KIND", "STATE", "PROGRESS", "OWNER", "CV EPOCH", "SOURCE", "TARGET",
+            "UPDATED", "MESSAGE",
+        ]);
+    } else {
+        table.set_header([
+            "JOB ID", "KIND", "STATE", "PROGRESS", "SOURCE", "TARGET", "UPDATED",
+        ]);
+    }
+    for job in jobs {
+        let mut row = vec![
+            display_id(&job.job_id, full_id),
+            kind_name(job.kind).to_string(),
+            state_name(job.state).to_string(),
+            progress_text(job.progress.loaded_size, job.progress.total_size),
+        ];
+        if verbose {
+            row.push(owner_text(job.owner.as_deref()));
+            row.push(
+                job.cv_metadata_epoch
+                    .map(|epoch| epoch.to_string())
+                    .unwrap_or_else(|| "-".to_string()),
+            );
+        }
+        row.push(truncate_middle(
+            &job.source_path,
+            if verbose { 36 } else { 28 },
+        ));
+        row.push(truncate_middle(
+            &job.target_path,
+            if verbose { 36 } else { 28 },
+        ));
+        row.push(format_timestamp(job.updated_at));
+        if verbose {
+            row.push(truncate_middle(&job.progress.message, 32));
+        }
+        table.add_row(row);
+    }
+    println!("{table}");
+}
+
+fn print_status_summary(job: &TransferJobStatusProto, verbose: bool) {
+    let mut table = md_table();
+    table.set_header(["FIELD", "VALUE"]);
+    table.add_row(["Job ID".to_string(), job.job_id.clone()]);
+    table.add_row(["Run".to_string(), job.run_id.to_string()]);
+    if job.kind != 0 {
+        table.add_row(["Kind".to_string(), kind_name(job.kind).to_string()]);
+    }
+    table.add_row(["State".to_string(), state_name(job.state).to_string()]);
+    table.add_row([
+        "Progress".to_string(),
+        progress_text(job.progress.loaded_size, job.progress.total_size),
+    ]);
+    if !job.progress.message.is_empty() {
+        table.add_row(["Message".to_string(), job.progress.message.clone()]);
+    }
+    if !job.source_path.is_empty() {
+        table.add_row(["Source".to_string(), job.source_path.clone()]);
+    }
+    if !job.target_path.is_empty() {
+        table.add_row(["Target".to_string(), job.target_path.clone()]);
+    }
+    table.add_row(["Updated".to_string(), format_timestamp(job.updated_at)]);
+    if verbose {
+        if !job.submitter.is_empty() {
+            table.add_row(["Submitter".to_string(), job.submitter.clone()]);
+        }
+        if !job.tenant.is_empty() {
+            table.add_row(["Tenant".to_string(), job.tenant.clone()]);
+        }
+        if let Some(owner) = &job.owner {
+            if !owner.is_empty() {
+                table.add_row(["Owner".to_string(), owner.clone()]);
+            }
+        }
+        if let Some(epoch) = job.lease_epoch {
+            table.add_row(["Lease".to_string(), epoch.to_string()]);
+        }
+        if let Some(expire_at) = job.lease_expire_at {
+            table.add_row(["Lease Expires".to_string(), format_timestamp(expire_at)]);
+        }
+        if let Some(epoch) = job.cv_metadata_epoch {
+            table.add_row(["CV Metadata Epoch".to_string(), epoch.to_string()]);
+        }
+        table.add_row(["Created".to_string(), format_timestamp(job.created_at)]);
+    }
+    println!("{table}");
+}
+
+fn print_tasks_table(tasks: &[TransferTaskStatusProto], full_id: bool, verbose: bool) {
+    let mut table = md_table();
+    if verbose {
+        table.set_header([
+            "TASK ID", "ATTEMPT", "STATE", "PROGRESS", "WORKER", "SESSION", "RETRY", "MESSAGE",
+            "SOURCE", "TARGET",
+        ]);
+    } else {
+        table.set_header([
+            "TASK ID", "STATE", "PROGRESS", "WORKER", "RETRY", "SOURCE", "TARGET",
+        ]);
+    }
+    for task in tasks {
+        let mut row = vec![
+            display_id(&task.task_id, full_id),
+            task_state_name(task.state).to_string(),
+            progress_text(task.progress.loaded_size, task.progress.total_size),
+            task.worker_id.to_string(),
+            task.retry_count.to_string(),
+        ];
+        if verbose {
+            row.insert(1, task.attempt_id.to_string());
+            row.insert(5, display_id(&task.worker_session_id, full_id));
+            row.push(truncate_middle(&task.progress.message, 28));
+        }
+        row.push(truncate_middle(
+            &task.source_path,
+            if verbose { 36 } else { 28 },
+        ));
+        row.push(truncate_middle(
+            &task.target_path,
+            if verbose { 36 } else { 28 },
+        ));
+        table.add_row(row);
+    }
+    println!("{table}");
+}
+
+fn print_tenants_table(tenants: &[TransferTenantSummaryProto]) {
+    let mut table = md_table();
+    table.set_header([
+        "TENANT",
+        "PENDING",
+        "EXECUTING",
+        "COMPLETED",
+        "FAILED",
+        "CANCELED",
+        "TOTAL",
+    ]);
+    for tenant in tenants {
+        table.add_row([
+            if tenant.tenant.is_empty() {
+                "<default>".to_string()
+            } else {
+                tenant.tenant.clone()
+            },
+            tenant.pending.to_string(),
+            tenant.executing.to_string(),
+            tenant.completed.to_string(),
+            tenant.failed.to_string(),
+            tenant.canceled.to_string(),
+            tenant.total.to_string(),
+        ]);
+    }
+    println!("{table}");
+}
+
+fn print_next_page(next_page_token: Option<&str>) {
+    if let Some(token) = next_page_token {
+        println!("More results: use --page-token {token}");
+    }
+}
+
+fn md_table() -> Table {
+    let mut table = Table::new();
+    table.load_preset(ASCII_MARKDOWN);
+    table
+}
+
+fn short_id(value: &str) -> String {
+    value.chars().take(12).collect()
+}
+
+fn display_id(value: &str, full_id: bool) -> String {
+    if full_id {
+        value.to_string()
+    } else {
+        short_id(value)
+    }
+}
+
+fn owner_text(owner: Option<&str>) -> String {
+    match owner {
+        Some(value) if !value.is_empty() => short_id(value),
+        _ => String::new(),
+    }
+}
+
+fn truncate_middle(value: &str, max_len: usize) -> String {
+    let char_len = value.chars().count();
+    if char_len <= max_len {
+        return value.to_string();
+    }
+    if max_len <= 3 {
+        return value.chars().take(max_len).collect();
+    }
+    let keep = (max_len - 3) / 2;
+    let tail = max_len - 3 - keep;
+    let head: String = value.chars().take(keep).collect();
+    let mut tail_chars: Vec<char> = value.chars().rev().take(tail).collect();
+    tail_chars.reverse();
+    let tail_text: String = tail_chars.into_iter().collect();
+    format!("{head}...{tail_text}")
+}
+
+fn progress_text(loaded: i64, total: i64) -> String {
+    if total <= 0 {
+        return bytes_to_string(loaded.max(0));
+    }
+    let loaded = loaded.max(0);
+    let percentage = (loaded as f64 / total as f64 * 100.0).clamp(0.0, 100.0);
+    format!(
+        "{} / {} ({percentage:.0}%)",
+        bytes_to_string(loaded),
+        bytes_to_string(total)
+    )
+}
+
+fn format_timestamp(timestamp_ms: i64) -> String {
+    if timestamp_ms <= 0 {
+        return "-".to_string();
+    }
+    let Some(timestamp) = chrono::DateTime::from_timestamp_millis(timestamp_ms) else {
+        return "-".to_string();
+    };
+    timestamp
+        .with_timezone(&chrono::Local)
+        .format("%Y-%m-%d %H:%M:%S")
+        .to_string()
+}
+
+fn transfer_is_terminal(state: i32) -> bool {
+    matches!(state, 6 | 7 | 8)
+}
+
+fn kind_name(kind: i32) -> &'static str {
+    match kind {
+        1 => "Load",
+        2 => "Export",
+        _ => "Unknown",
+    }
+}
+
+fn state_name(state: i32) -> &'static str {
+    match state {
+        1 => "Pending",
+        2 => "Planning",
+        3 => "Dispatching",
+        4 => "Running",
+        5 => "Canceling",
+        6 => "Completed",
+        7 => "Failed",
+        8 => "Canceled",
+        _ => "Unknown",
+    }
+}
+
+fn task_state_name(state: i32) -> &'static str {
+    match state {
+        1 => "Pending",
+        2 => "Running",
+        3 => "Completed",
+        4 => "Failed",
+        5 => "Canceled",
+        6 => "Stale",
+        _ => "Unknown",
+    }
+}

--- a/curvine-cli/src/cmds/transfer.rs
+++ b/curvine-cli/src/cmds/transfer.rs
@@ -47,7 +47,7 @@ enum TransferSubCommand {
     /// Cancel one transfer job
     Cancel(TransferCancelCommand),
 
-    /// Retry a failed or canceled transfer job
+    /// Retry a failed, canceled, or partially successful transfer as a new job
     Retry(TransferRetryCommand),
 
     /// Summarize transfer jobs by tenant
@@ -189,6 +189,7 @@ enum TransferStateArg {
     Completed,
     Failed,
     Canceled,
+    PartialSuccess,
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum, PartialEq, Eq)]
@@ -262,7 +263,7 @@ impl TransferStatusCommand {
             }
             first = false;
             let job = status_to_job(&response);
-            print_status_summary(&job, self.verbose);
+            print_status_summary(&job, response.task_summary.as_ref(), self.verbose);
             if self.verbose {
                 print_tasks_table(&response.tasks, self.full_id, true);
                 print_next_page(response.next_page_token.as_deref());
@@ -524,6 +525,7 @@ impl From<TransferStateArg> for TransferState {
             TransferStateArg::Completed => TransferState::Completed,
             TransferStateArg::Failed => TransferState::Failed,
             TransferStateArg::Canceled => TransferState::Canceled,
+            TransferStateArg::PartialSuccess => TransferState::PartialSuccess,
         }
     }
 }
@@ -572,7 +574,11 @@ fn print_jobs_table(jobs: &[TransferJobStatusProto], full_id: bool, verbose: boo
     println!("{table}");
 }
 
-fn print_status_summary(job: &TransferJobStatusProto, verbose: bool) {
+fn print_status_summary(
+    job: &TransferJobStatusProto,
+    task_summary: Option<&curvine_common::proto::TransferTaskSummaryProto>,
+    verbose: bool,
+) {
     let mut table = md_table();
     table.set_header(["FIELD", "VALUE"]);
     table.add_row(["Job ID".to_string(), job.job_id.clone()]);
@@ -585,6 +591,9 @@ fn print_status_summary(job: &TransferJobStatusProto, verbose: bool) {
         "Progress".to_string(),
         progress_text(job.progress.loaded_size, job.progress.total_size),
     ]);
+    if let Some(summary) = task_summary {
+        table.add_row(["Tasks".to_string(), task_summary_text(summary)]);
+    }
     if !job.progress.message.is_empty() {
         table.add_row(["Message".to_string(), job.progress.message.clone()]);
     }
@@ -668,6 +677,7 @@ fn print_tenants_table(tenants: &[TransferTenantSummaryProto]) {
         "COMPLETED",
         "FAILED",
         "CANCELED",
+        "PARTIAL",
         "TOTAL",
     ]);
     for tenant in tenants {
@@ -682,10 +692,33 @@ fn print_tenants_table(tenants: &[TransferTenantSummaryProto]) {
             tenant.completed.to_string(),
             tenant.failed.to_string(),
             tenant.canceled.to_string(),
+            tenant.partial_success.to_string(),
             tenant.total.to_string(),
         ]);
     }
     println!("{table}");
+}
+
+fn task_summary_text(summary: &curvine_common::proto::TransferTaskSummaryProto) -> String {
+    let mut parts = vec![
+        format!("{} completed", summary.completed),
+        format!("{} failed", summary.failed),
+        format!("{} running", summary.running),
+    ];
+    if summary.pending > 0 {
+        parts.push(format!("{} pending", summary.pending));
+    }
+    if summary.canceled > 0 {
+        parts.push(format!("{} canceled", summary.canceled));
+    }
+    if summary.stale > 0 {
+        parts.push(format!("{} stale", summary.stale));
+    }
+    parts.push(format!(
+        "{} cached",
+        bytes_to_string(summary.completed_size.max(0))
+    ));
+    parts.join(", ")
 }
 
 fn print_next_page(next_page_token: Option<&str>) {
@@ -763,7 +796,7 @@ fn format_timestamp(timestamp_ms: i64) -> String {
 }
 
 fn transfer_is_terminal(state: i32) -> bool {
-    matches!(state, 6 | 7 | 8)
+    matches!(state, 6 | 7 | 8 | 9)
 }
 
 fn kind_name(kind: i32) -> &'static str {
@@ -784,6 +817,7 @@ fn state_name(state: i32) -> &'static str {
         6 => "Completed",
         7 => "Failed",
         8 => "Canceled",
+        9 => "PartialSuccess",
         _ => "Unknown",
     }
 }

--- a/curvine-cli/src/commands.rs
+++ b/curvine-cli/src/commands.rs
@@ -36,12 +36,24 @@ pub enum Commands {
     Export(ExportCommand),
 
     /// Query loading task status
-    #[command(name = "load-status")]
+    #[command(name = "load-status", hide = true)]
     LoadStatus(LoadStatusCommand),
 
+    /// Query transfer task status
+    #[command(name = "transfer-status", hide = true)]
+    TransferStatus(LoadStatusCommand),
+
     /// Cancel loading task
-    #[command(name = "cancel-load")]
+    #[command(name = "cancel-load", hide = true)]
     CancelLoad(CancelLoadCommand),
+
+    /// Cancel transfer task
+    #[command(name = "cancel-transfer", hide = true)]
+    CancelTransfer(CancelLoadCommand),
+
+    /// Manage transfer jobs
+    #[command(name = "transfer")]
+    Transfer(TransferCommand),
 
     /// mount ufs to curvine
     #[command(name = "mount")]

--- a/curvine-cli/src/lib.rs
+++ b/curvine-cli/src/lib.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod job_master_client;
-pub use self::job_master_client::JobMasterClient;
-
-mod transfer_client;
-pub use self::transfer_client::TransferClient;
+pub mod cmds;
+pub mod commands;
+pub mod util;

--- a/curvine-cli/src/main.rs
+++ b/curvine-cli/src/main.rs
@@ -18,7 +18,7 @@ mod util;
 
 use clap::Parser;
 use commands::Commands;
-use curvine_client::rpc::JobMasterClient;
+use curvine_client::rpc::{JobMasterClient, TransferClient};
 use curvine_client::unified::UnifiedFileSystem;
 use curvine_common::conf::ClusterConf;
 use curvine_common::version;
@@ -33,12 +33,7 @@ use std::sync::Arc;
 #[command(author, version = version::VERSION, about, long_about = None)]
 pub struct CurvineArgs {
     /// Configuration file path (optional)
-    #[arg(
-        short,
-        long,
-        help = "Configuration file path (optional)",
-        global = true
-    )]
+    #[arg(long, help = "Configuration file path (optional)", global = true)]
     pub conf: Option<String>,
 
     /// Master address list (e.g., 'm1:8995,m2:8995')
@@ -173,16 +168,65 @@ fn main() -> CommonResult<()> {
     let curvine_fs = UnifiedFileSystem::with_rt(conf.clone(), rt.clone())?;
     let fs_client = curvine_fs.fs_client();
     let load_client = JobMasterClient::new(fs_client.clone());
+    let transfer_client = if conf.transfer.enabled {
+        Some(TransferClient::with_rt(&conf, rt.clone())?)
+    } else {
+        None
+    };
 
     rt.block_on(async move {
         let result = match args.command {
             Commands::Bench(cmd) => cmd.execute(curvine_fs, conf_source.clone()).await,
             Commands::Fs(cmd) => cmd.execute(curvine_fs).await,
             Commands::Report(cmd) => cmd.execute(curvine_fs).await,
-            Commands::Load(cmd) => cmd.execute(load_client).await,
-            Commands::Export(cmd) => cmd.execute(load_client).await,
-            Commands::LoadStatus(cmd) => cmd.execute(load_client).await,
-            Commands::CancelLoad(cmd) => cmd.execute(load_client).await,
+            Commands::Load(cmd) => {
+                match transfer_client.clone() {
+                    Some(transfer_client) => cmd.execute_transfer(curvine_fs.clone(), transfer_client).await,
+                    None => cmd.execute_legacy(load_client.clone()).await,
+                }
+            }
+            Commands::Export(cmd) => {
+                match transfer_client.clone() {
+                    Some(transfer_client) => cmd.execute_transfer(curvine_fs.clone(), transfer_client).await,
+                    None => cmd.execute_legacy(load_client.clone()).await,
+                }
+            }
+            Commands::LoadStatus(cmd) => {
+                match transfer_client.clone() {
+                    Some(transfer_client) => cmd.execute_transfer_only(transfer_client).await,
+                    None => cmd.execute(load_client.clone()).await,
+                }
+            }
+            Commands::TransferStatus(cmd) => {
+                let Some(transfer_client) = transfer_client.clone() else {
+                    return err_box!(
+                        "transfer-status requires transfer.enabled=true and a running curvine-transfer service"
+                    );
+                };
+                cmd.execute_transfer_only(transfer_client).await
+            }
+            Commands::CancelLoad(cmd) => {
+                match transfer_client.clone() {
+                    Some(transfer_client) => cmd.execute_transfer_only(transfer_client).await,
+                    None => cmd.execute(load_client.clone()).await,
+                }
+            }
+            Commands::CancelTransfer(cmd) => {
+                let Some(transfer_client) = transfer_client.clone() else {
+                    return err_box!(
+                        "cancel-transfer requires transfer.enabled=true and a running curvine-transfer service"
+                    );
+                };
+                cmd.execute_transfer_only(transfer_client).await
+            }
+            Commands::Transfer(cmd) => {
+                let Some(transfer_client) = transfer_client.clone() else {
+                    return err_box!(
+                        "transfer requires transfer.enabled=true and a running curvine-transfer service"
+                    );
+                };
+                cmd.execute(transfer_client).await
+            }
             Commands::Mount(cmd) => cmd.execute(curvine_fs).await,
             Commands::UnMount(cmd) => cmd.execute(fs_client).await,
             Commands::Node(cmd) => cmd.execute(fs_client, conf.clone()).await,

--- a/curvine-cli/tests/cli_parse_test.rs
+++ b/curvine-cli/tests/cli_parse_test.rs
@@ -1,0 +1,239 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::process::Command;
+use std::process::Stdio;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use curvine_cli::cmds::transfer::{render_cancel_response, OutputFormat};
+use curvine_common::proto::CancelTransferResponse;
+
+#[test]
+fn mount_accepts_short_config_without_clap_debug_assert() {
+    let output = Command::new(env!("CARGO_BIN_EXE_curvine-cli"))
+        .args([
+            "mount",
+            "s3://bucket/path",
+            "/bucket/path",
+            "-c",
+            "s3.endpoint_url=http://example.invalid",
+            "--help",
+        ])
+        .output()
+        .expect("run curvine-cli mount --help");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("Short option names must be unique"),
+        "mount -c triggered clap debug assert: {stderr}"
+    );
+    assert!(output.status.success(), "unexpected stderr: {stderr}");
+}
+
+#[test]
+fn mount_redacts_sensitive_config_values() {
+    let secret = "plain-secret-value";
+    let access = "plain-access-value";
+    let mut child = Command::new(env!("CARGO_BIN_EXE_curvine-cli"))
+        .args([
+            "--master-addrs",
+            "127.0.0.1:1",
+            "mount",
+            "s3://bucket/path",
+            "/path",
+            "--check-path-consist=false",
+            "-c",
+            "s3.endpoint_url=http://example.invalid",
+            "-c",
+            "s3.credentials.secret=plain-secret-value",
+            "-c",
+            "s3.credentials.access=plain-access-value",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("run curvine-cli mount");
+
+    let start = Instant::now();
+    loop {
+        if child.try_wait().expect("poll curvine-cli mount").is_some() {
+            break;
+        }
+        if start.elapsed() >= Duration::from_secs(2) {
+            child.kill().expect("kill curvine-cli mount");
+            break;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+
+    let output = child.wait_with_output().expect("collect curvine-cli mount");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("s3.credentials.secret = ******"),
+        "secret was not redacted: {stdout}"
+    );
+    assert!(
+        stdout.contains("s3.credentials.access = ******"),
+        "access credential was not redacted: {stdout}"
+    );
+    assert!(
+        !stdout.contains(secret),
+        "secret leaked in stdout: {stdout}"
+    );
+    assert!(
+        !stdout.contains(access),
+        "access leaked in stdout: {stdout}"
+    );
+}
+
+#[test]
+fn transfer_commands_are_registered() {
+    for command in ["export", "transfer-status", "cancel-transfer", "transfer"] {
+        let output = Command::new(env!("CARGO_BIN_EXE_curvine-cli"))
+            .args([command, "--help"])
+            .output()
+            .unwrap_or_else(|err| panic!("run curvine-cli {command} --help: {err}"));
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "curvine-cli {command} --help failed: {stderr}"
+        );
+    }
+}
+
+#[test]
+fn legacy_load_commands_remain_available_during_rolling_upgrade() {
+    for command in ["load", "load-status", "cancel-load"] {
+        let output = Command::new(env!("CARGO_BIN_EXE_curvine-cli"))
+            .args([command, "--help"])
+            .output()
+            .expect("run curvine-cli legacy load command");
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "curvine-cli {command} --help failed: {stderr}"
+        );
+    }
+}
+
+#[test]
+fn transfer_subcommands_are_registered() {
+    for subcommand in ["list", "status", "tasks", "cancel", "retry", "tenants"] {
+        let output = Command::new(env!("CARGO_BIN_EXE_curvine-cli"))
+            .args(["transfer", subcommand, "--help"])
+            .output()
+            .unwrap_or_else(|err| panic!("run curvine-cli transfer {subcommand} --help: {err}"));
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "curvine-cli transfer {subcommand} --help failed: {stderr}"
+        );
+    }
+}
+
+#[test]
+fn transfer_tenants_command_accepts_pagination_and_format() {
+    let output = Command::new(env!("CARGO_BIN_EXE_curvine-cli"))
+        .args([
+            "transfer",
+            "tenants",
+            "--limit",
+            "10",
+            "--page-token",
+            "20",
+            "--format",
+            "json",
+            "--help",
+        ])
+        .output()
+        .expect("run curvine-cli transfer tenants --help");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "curvine-cli transfer tenants --help failed: {stderr}"
+    );
+}
+
+#[test]
+fn transfer_cancel_command_accepts_run_id_and_format() {
+    let output = Command::new(env!("CARGO_BIN_EXE_curvine-cli"))
+        .args([
+            "transfer", "cancel", "job-123", "--run-id", "7", "--format", "json", "--help",
+        ])
+        .output()
+        .expect("run curvine-cli transfer cancel --help");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "curvine-cli transfer cancel --help failed: {stderr}"
+    );
+}
+
+#[test]
+fn transfer_list_accepts_submitter_and_tenant_filters() {
+    let output = Command::new(env!("CARGO_BIN_EXE_curvine-cli"))
+        .args([
+            "transfer",
+            "list",
+            "--submitter",
+            "flink",
+            "--tenant",
+            "tenant-a",
+            "--limit",
+            "10",
+            "--help",
+        ])
+        .output()
+        .expect("run curvine-cli transfer list --help");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "curvine-cli transfer list --help failed: {stderr}"
+    );
+}
+
+#[test]
+fn transfer_cancel_table_output_uses_server_state() {
+    let response = CancelTransferResponse {
+        job_id: "transfer-job-1234567890".to_string(),
+        state: 5,
+    };
+
+    let output = render_cancel_response(&response, OutputFormat::Table).unwrap();
+
+    assert!(output.contains("transfer-job-1234567890"));
+    assert!(output.contains("Canceling"));
+    assert!(!output.contains("Canceled"));
+}
+
+#[test]
+fn transfer_cancel_json_output_preserves_response() {
+    let response = CancelTransferResponse {
+        job_id: "transfer-job-terminal".to_string(),
+        state: 8,
+    };
+
+    let output = render_cancel_response(&response, OutputFormat::Json).unwrap();
+    let parsed: CancelTransferResponse = serde_json::from_str(&output).unwrap();
+
+    assert_eq!(parsed.job_id, response.job_id);
+    assert_eq!(parsed.state, response.state);
+}

--- a/curvine-cli/tests/transfer_cli_e2e_test.rs
+++ b/curvine-cli/tests/transfer_cli_e2e_test.rs
@@ -1,0 +1,748 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fs;
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::path::Path as StdPath;
+use std::process::Command;
+use std::thread;
+use std::time::Duration;
+
+use curvine_common::conf::ClusterConf;
+use curvine_common::fs::Path;
+use curvine_common::proto::TransferStateProto;
+use curvine_common::state::{
+    MountOptions, TransferCommand, TransferJobRecord, TransferKind, TransferProgress,
+    TransferState, TransferTaskRecord, TransferTaskState,
+};
+use curvine_server::test::MiniCluster;
+use curvine_server::transfer::{SqliteTransferStore, TransferServer, TransferStore};
+use orpc::common::LocalTime;
+use orpc::io::net::NetUtils;
+use orpc::runtime::RpcRuntime;
+use serde_json::Value;
+
+#[test]
+fn transfer_cli_reads_real_transfer_service_state() {
+    let test_id = format!(
+        "transfer-cli-e2e-{}-{}",
+        std::process::id(),
+        LocalTime::mills()
+    );
+    let base_dir = std::env::temp_dir().join(&test_id);
+    let ufs_dir = base_dir.join("ufs");
+    let cli_mount_dir = base_dir.join("cli-mount");
+    fs::create_dir_all(&ufs_dir).unwrap();
+    fs::create_dir_all(&cli_mount_dir).unwrap();
+    fs::write(ufs_dir.join("hello.txt"), b"hello-from-cli").unwrap();
+    fs::write(
+        ufs_dir.join("no-overwrite-load-source.txt"),
+        b"new-load-content",
+    )
+    .unwrap();
+    fs::write(cli_mount_dir.join("watch-load.txt"), b"watch-load-content").unwrap();
+
+    let mut conf = ClusterConf::default();
+    conf.master.meta_dir = base_dir.join("meta").display().to_string();
+    conf.journal.journal_dir = base_dir.join("journal").display().to_string();
+    conf.worker.data_dir = vec![base_dir.join("worker").display().to_string()];
+    conf.transfer.enabled = true;
+    conf.transfer.store_url = format!("sqlite://{}", base_dir.join("transfer.db").display());
+    conf.transfer.hostname = "localhost".to_string();
+    conf.transfer.rpc_port = NetUtils::hold_available_port();
+    conf.transfer.web_port = NetUtils::hold_available_port();
+    conf.transfer.instance_id = "transfer-cli-e2e".to_string();
+    conf.transfer.metadata_replica_refresh_interval_str = "1s".to_string();
+    conf.transfer.endpoints = vec![format!(
+        "{}:{}",
+        conf.transfer.hostname, conf.transfer.rpc_port
+    )];
+    conf.transfer.init().unwrap();
+
+    let cluster = MiniCluster::with_num(&conf, 1, 1);
+    let runtime_conf = cluster.cluster_conf.clone();
+    let conf_path = base_dir.join("curvine-cluster.toml");
+    fs::write(&conf_path, toml::to_string(&runtime_conf).unwrap()).unwrap();
+
+    cluster.start_cluster();
+    let rt = cluster.clone_client_rt();
+    rt.block_on(async {
+        let fs = cluster.new_fs();
+        fs.mount(
+            &Path::from_str(format!("file://{}", ufs_dir.display())).unwrap(),
+            &Path::from_str("/mnt").unwrap(),
+            MountOptions::builder().build(),
+        )
+        .await
+        .unwrap();
+        fs.write_string(
+            &Path::from_str("/mnt/export-cli.txt").unwrap(),
+            "export-from-cli",
+        )
+        .await
+        .unwrap();
+        fs.write_string(
+            &Path::from_str("/mnt/export-watch.txt").unwrap(),
+            "export-watch-content",
+        )
+        .await
+        .unwrap();
+        fs.write_string(
+            &Path::from_str("/mnt/no-overwrite-load-target.txt").unwrap(),
+            "existing-load-content",
+        )
+        .await
+        .unwrap();
+        fs.write_string(
+            &Path::from_str("/mnt/no-overwrite-export.txt").unwrap(),
+            "new-export-content",
+        )
+        .await
+        .unwrap();
+    });
+    fs::write(
+        ufs_dir.join("no-overwrite-export.txt"),
+        b"existing-export-content",
+    )
+    .unwrap();
+
+    let transfer = TransferServer::with_conf(runtime_conf.clone()).unwrap();
+    thread::spawn(move || transfer.block_on_start());
+    thread::sleep(Duration::from_millis(500));
+
+    run_cli(
+        &conf_path,
+        &[
+            "mount",
+            &format!("file://{}", cli_mount_dir.display()),
+            "/cli",
+            "--check-path-consist",
+            "false",
+            "--auto-cache",
+            "false",
+        ],
+    );
+
+    let watched_load = run_cli(
+        &conf_path,
+        &[
+            "load",
+            &format!("file://{}/watch-load.txt", cli_mount_dir.display()),
+            "/cli/watch-load.txt",
+            "--watch",
+        ],
+    );
+    let watched_load_job_id = extract_job_id(&watched_load.stdout);
+    let watched_load_status = wait_cli_state(
+        &conf_path,
+        &watched_load_job_id,
+        TransferStateProto::TransferCompleted,
+    );
+    assert_eq!(
+        watched_load_status["state"].as_i64(),
+        Some(TransferStateProto::TransferCompleted as i64)
+    );
+
+    let load = run_cli(
+        &conf_path,
+        &["load", &format!("file://{}/hello.txt", ufs_dir.display())],
+    );
+    let job_id = extract_job_id(&load.stdout);
+
+    let completed_status =
+        wait_cli_state(&conf_path, &job_id, TransferStateProto::TransferCompleted);
+    assert_eq!(
+        completed_status["job_id"].as_str(),
+        Some(job_id.as_str()),
+        "status json should describe the submitted job: {completed_status}"
+    );
+
+    let load_status = run_cli(&conf_path, &["load-status", &job_id]);
+    assert!(
+        load_status.stdout.contains("Completed"),
+        "load-status should query Transfer state: {}",
+        load_status.stdout
+    );
+
+    let tasks = run_cli_json(
+        &conf_path,
+        &["transfer", "tasks", &job_id, "--format", "json"],
+    );
+    assert!(
+        tasks
+            .as_array()
+            .map(|items| !items.is_empty())
+            .unwrap_or(false),
+        "tasks json should contain at least one task: {tasks}"
+    );
+
+    let detailed_status = run_cli(
+        &conf_path,
+        &["transfer", "status", &job_id, "--verbose", "--full-id"],
+    );
+    assert!(
+        detailed_status.stdout.contains(&job_id),
+        "verbose status should include the full job id: {}",
+        detailed_status.stdout
+    );
+    assert!(
+        detailed_status.stdout.contains("Tasks"),
+        "transfer status should display task counts: {}",
+        detailed_status.stdout
+    );
+
+    let list = run_cli_json(&conf_path, &["transfer", "list", "--format", "json"]);
+    assert!(
+        list["jobs"]
+            .as_array()
+            .unwrap_or(&Vec::new())
+            .iter()
+            .any(|job| job["job_id"].as_str() == Some(job_id.as_str())),
+        "list json should contain submitted job {job_id}: {list}"
+    );
+
+    let same_path_export = run_cli(&conf_path, &["export", "/mnt/hello.txt"]);
+    let same_path_export_job_id = extract_job_id(&same_path_export.stdout);
+    assert_ne!(
+        same_path_export_job_id, job_id,
+        "load and export for the same Curvine path must not share one idempotency key"
+    );
+    let same_path_export_status = wait_cli_state(
+        &conf_path,
+        &same_path_export_job_id,
+        TransferStateProto::TransferCompleted,
+    );
+    assert_eq!(
+        same_path_export_status["kind"].as_i64(),
+        Some(TransferKind::Export as i32 as i64),
+        "same-path export must create an Export job: {same_path_export_status}"
+    );
+
+    let export = run_cli(&conf_path, &["export", "/mnt/export-cli.txt"]);
+    let export_job_id = extract_job_id(&export.stdout);
+    let export_status = wait_cli_state(
+        &conf_path,
+        &export_job_id,
+        TransferStateProto::TransferCompleted,
+    );
+    assert_eq!(
+        export_status["job_id"].as_str(),
+        Some(export_job_id.as_str()),
+        "export status json should describe the submitted job: {export_status}"
+    );
+    assert_eq!(
+        fs::read_to_string(ufs_dir.join("export-cli.txt")).unwrap(),
+        "export-from-cli"
+    );
+
+    let watched_export = run_cli(&conf_path, &["export", "/mnt/export-watch.txt", "--watch"]);
+    let watched_export_job_id = extract_job_id(&watched_export.stdout);
+    wait_cli_state(
+        &conf_path,
+        &watched_export_job_id,
+        TransferStateProto::TransferCompleted,
+    );
+    assert_eq!(
+        fs::read_to_string(ufs_dir.join("export-watch.txt")).unwrap(),
+        "export-watch-content"
+    );
+
+    let no_overwrite_load = run_cli(
+        &conf_path,
+        &[
+            "load",
+            &format!("file://{}/no-overwrite-load-source.txt", ufs_dir.display()),
+            "/mnt/no-overwrite-load-target.txt",
+            "--no-overwrite",
+        ],
+    );
+    let no_overwrite_load_job_id = extract_job_id(&no_overwrite_load.stdout);
+    wait_cli_state(
+        &conf_path,
+        &no_overwrite_load_job_id,
+        TransferStateProto::TransferFailed,
+    );
+
+    let no_overwrite_export = run_cli(
+        &conf_path,
+        &["export", "/mnt/no-overwrite-export.txt", "--no-overwrite"],
+    );
+    let no_overwrite_export_job_id = extract_job_id(&no_overwrite_export.stdout);
+    wait_cli_state(
+        &conf_path,
+        &no_overwrite_export_job_id,
+        TransferStateProto::TransferFailed,
+    );
+    assert_eq!(
+        fs::read_to_string(ufs_dir.join("no-overwrite-export.txt")).unwrap(),
+        "existing-export-content"
+    );
+
+    let first_page = run_cli_json(
+        &conf_path,
+        &["transfer", "list", "--limit", "1", "--format", "json"],
+    );
+    assert_eq!(
+        first_page["jobs"].as_array().map(Vec::len),
+        Some(1),
+        "single-page list should honor limit: {first_page}"
+    );
+    assert!(
+        first_page["next_page_token"].as_str().is_some(),
+        "single-page list should expose next_page_token: {first_page}"
+    );
+
+    let all_pages = run_cli_json(
+        &conf_path,
+        &[
+            "transfer", "list", "--limit", "1", "--all", "--format", "json",
+        ],
+    );
+    let empty_jobs = Vec::new();
+    let all_jobs = all_pages["jobs"].as_array().unwrap_or(&empty_jobs);
+    assert!(
+        all_jobs
+            .iter()
+            .any(|job| job["job_id"].as_str() == Some(job_id.as_str())),
+        "--all list should include load job {job_id}: {all_pages}"
+    );
+    assert!(
+        all_jobs
+            .iter()
+            .any(|job| job["job_id"].as_str() == Some(export_job_id.as_str())),
+        "--all list should include export job {export_job_id}: {all_pages}"
+    );
+    assert!(
+        all_pages["next_page_token"].as_str().is_none(),
+        "--all list should consume every page: {all_pages}"
+    );
+
+    let load_jobs = run_cli_json(
+        &conf_path,
+        &[
+            "transfer",
+            "list",
+            "--kind",
+            "load",
+            "--state",
+            "completed",
+            "--all",
+            "--format",
+            "json",
+        ],
+    );
+    let empty_load_jobs = Vec::new();
+    let load_job_items = load_jobs["jobs"].as_array().unwrap_or(&empty_load_jobs);
+    assert!(
+        load_job_items
+            .iter()
+            .all(|job| job["kind"].as_i64() == Some(TransferKind::Load as i32 as i64)),
+        "kind filter should only return Load jobs: {load_jobs}"
+    );
+    assert!(
+        load_job_items
+            .iter()
+            .any(|job| job["job_id"].as_str() == Some(job_id.as_str())),
+        "kind/state filter should include completed load job {job_id}: {load_jobs}"
+    );
+
+    let tenants = run_cli_json(
+        &conf_path,
+        &["transfer", "tenants", "--all", "--format", "json"],
+    );
+    let empty_tenants = Vec::new();
+    let tenant_items = tenants["tenants"].as_array().unwrap_or(&empty_tenants);
+    assert!(
+        !tenant_items.is_empty(),
+        "transfer tenants should return server data: {tenants}"
+    );
+
+    let cancel_job_id = "cli-cancel-load-pending-job";
+    let store = SqliteTransferStore::open(runtime_conf.transfer.sqlite_store_path()).unwrap();
+    store
+        .create_or_get_by_request_id(cancel_job(
+            cancel_job_id,
+            &runtime_conf.transfer.instance_id,
+        ))
+        .unwrap();
+    store
+        .insert_tasks(vec![cancel_task(cancel_job_id)])
+        .unwrap();
+    let cancel = run_cli(&conf_path, &["cancel-load", cancel_job_id]);
+    assert!(
+        cancel.stdout.contains(cancel_job_id),
+        "cancel output should include full job id: {}",
+        cancel.stdout
+    );
+    assert!(
+        cancel.stdout.contains("Canceling") || cancel.stdout.contains("Canceled"),
+        "cancel output should show server cancel state: {}",
+        cancel.stdout
+    );
+    wait_cli_state(
+        &conf_path,
+        cancel_job_id,
+        TransferStateProto::TransferCanceled,
+    );
+
+    let _ = fs::remove_dir_all(base_dir);
+}
+
+#[test]
+#[ignore = "requires Docker to run MinIO"]
+fn transfer_cli_loads_from_and_exports_to_minio() {
+    let minio = MinioServer::start();
+    let test_id = format!(
+        "transfer-cli-minio-e2e-{}-{}",
+        std::process::id(),
+        LocalTime::mills()
+    );
+    let base_dir = std::env::temp_dir().join(&test_id);
+    fs::create_dir_all(&base_dir).unwrap();
+    let payload = "minio-transfer-payload";
+    let source_file = base_dir.join("source.txt");
+    fs::write(&source_file, payload).unwrap();
+
+    let bucket = format!("curvine-transfer-e2e-{}", LocalTime::mills());
+    minio.create_bucket(&bucket);
+    minio.put_file(&base_dir, "source.txt", &format!("{bucket}/input/load.txt"));
+
+    let mut conf = ClusterConf::default();
+    conf.master.meta_dir = base_dir.join("meta").display().to_string();
+    conf.journal.journal_dir = base_dir.join("journal").display().to_string();
+    conf.worker.data_dir = vec![base_dir.join("worker").display().to_string()];
+    conf.transfer.enabled = true;
+    conf.transfer.store_url = format!("sqlite://{}", base_dir.join("transfer.db").display());
+    conf.transfer.hostname = "localhost".to_string();
+    conf.transfer.rpc_port = NetUtils::hold_available_port();
+    conf.transfer.web_port = NetUtils::hold_available_port();
+    conf.transfer.instance_id = "transfer-cli-minio-e2e".to_string();
+    conf.transfer.metadata_replica_refresh_interval_str = "1s".to_string();
+    conf.transfer.endpoints = vec![format!(
+        "{}:{}",
+        conf.transfer.hostname, conf.transfer.rpc_port
+    )];
+    conf.transfer.init().unwrap();
+
+    let cluster = MiniCluster::with_num(&conf, 1, 1);
+    let runtime_conf = cluster.cluster_conf.clone();
+    let conf_path = base_dir.join("curvine-cluster.toml");
+    fs::write(&conf_path, toml::to_string(&runtime_conf).unwrap()).unwrap();
+    cluster.start_cluster();
+
+    let transfer = TransferServer::with_conf(runtime_conf).unwrap();
+    thread::spawn(move || transfer.block_on_start());
+    thread::sleep(Duration::from_millis(500));
+
+    let cv_mount = "/minio";
+    let endpoint_conf = format!("s3.endpoint_url={}", minio.endpoint);
+    let access_conf = format!("s3.credentials.access={}", MinioServer::ROOT_USER);
+    let secret_conf = format!("s3.credentials.secret={}", MinioServer::ROOT_PASSWORD);
+    let bucket_uri = format!("s3://{bucket}");
+    run_cli(
+        &conf_path,
+        &[
+            "mount",
+            &bucket_uri,
+            cv_mount,
+            "-c",
+            &endpoint_conf,
+            "-c",
+            "s3.region_name=us-east-1",
+            "-c",
+            &access_conf,
+            "-c",
+            &secret_conf,
+            "--check-path-consist",
+            "false",
+            "--auto-cache",
+            "false",
+        ],
+    );
+
+    let source_uri = format!("s3://{bucket}/input/load.txt");
+    let load = run_cli(
+        &conf_path,
+        &["load", &source_uri, "/minio/load.txt", "--watch"],
+    );
+    let load_job_id = extract_job_id(&load.stdout);
+    wait_cli_state(
+        &conf_path,
+        &load_job_id,
+        TransferStateProto::TransferCompleted,
+    );
+
+    let export = run_cli(&conf_path, &["export", "/minio/load.txt", "--watch"]);
+    let export_job_id = extract_job_id(&export.stdout);
+    wait_cli_state(
+        &conf_path,
+        &export_job_id,
+        TransferStateProto::TransferCompleted,
+    );
+    assert_eq!(minio.read_object(&format!("{bucket}/load.txt")), payload);
+
+    let _ = fs::remove_dir_all(base_dir);
+}
+
+struct CliOutput {
+    stdout: String,
+}
+
+fn run_cli(conf_path: &StdPath, args: &[&str]) -> CliOutput {
+    let output = Command::new(env!("CARGO_BIN_EXE_curvine-cli"))
+        .env("CURVINE_CONF_FILE", conf_path)
+        .args(args)
+        .output()
+        .unwrap_or_else(|err| panic!("run curvine-cli {args:?}: {err}"));
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    assert!(
+        output.status.success(),
+        "curvine-cli {args:?} failed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    CliOutput { stdout }
+}
+
+fn run_cli_json(conf_path: &StdPath, args: &[&str]) -> Value {
+    let output = run_cli(conf_path, args);
+    serde_json::from_str(&output.stdout)
+        .unwrap_or_else(|err| panic!("parse cli json from {args:?}: {err}\n{}", output.stdout))
+}
+
+fn wait_cli_state(conf_path: &StdPath, job_id: &str, expected: TransferStateProto) -> Value {
+    for _ in 0..80 {
+        let status = run_cli_json(
+            conf_path,
+            &["transfer", "status", job_id, "--format", "json"],
+        );
+        if status["state"].as_i64() == Some(expected as i64) {
+            return status;
+        }
+        thread::sleep(Duration::from_millis(250));
+    }
+    panic!("transfer {job_id} did not reach {expected:?}");
+}
+
+const MINIO_IMAGE: &str =
+    "minio/minio@sha256:a1ea29fa28355559ef137d71fc570e508a214ec84ff8083e39bc5428980b015e";
+const MINIO_MC_IMAGE: &str =
+    "minio/mc@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727";
+
+struct MinioServer {
+    name: String,
+    endpoint: String,
+}
+
+impl MinioServer {
+    const ROOT_USER: &str = "minioadmin";
+    const ROOT_PASSWORD: &str = "minioadmin";
+
+    fn start() -> Self {
+        let port = NetUtils::get_available_port();
+        let name = format!(
+            "curvine-transfer-minio-{}-{}",
+            std::process::id(),
+            LocalTime::mills()
+        );
+        let endpoint = format!("http://127.0.0.1:{port}");
+        let port_mapping = format!("127.0.0.1:{port}:9000");
+        let output = Command::new("docker")
+            .args([
+                "run",
+                "-d",
+                "--rm",
+                "--name",
+                &name,
+                "-p",
+                &port_mapping,
+                "-e",
+                "MINIO_ROOT_USER=minioadmin",
+                "-e",
+                "MINIO_ROOT_PASSWORD=minioadmin",
+                MINIO_IMAGE,
+                "server",
+                "/data",
+                "--address",
+                ":9000",
+            ])
+            .output()
+            .unwrap_or_else(|err| panic!("start MinIO container: {err}"));
+        assert!(
+            output.status.success(),
+            "start MinIO container failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            wait_minio_ready(port, Duration::from_secs(30)),
+            "MinIO did not become ready"
+        );
+        Self { name, endpoint }
+    }
+
+    fn create_bucket(&self, bucket: &str) {
+        self.run_mc(
+            None,
+            &["mb", "--ignore-existing", &format!("minio/{bucket}")],
+        );
+    }
+
+    fn put_file(&self, source_dir: &StdPath, source_name: &str, object: &str) {
+        self.run_mc(
+            Some(source_dir),
+            &[
+                "cp",
+                &format!("/data/{source_name}"),
+                &format!("minio/{object}"),
+            ],
+        );
+    }
+
+    fn read_object(&self, object: &str) -> String {
+        let output = self.run_mc_output(None, &["cat", &format!("minio/{object}")]);
+        String::from_utf8(output.stdout).unwrap()
+    }
+
+    fn run_mc(&self, source_dir: Option<&StdPath>, args: &[&str]) {
+        let output = self.run_mc_output(source_dir, args);
+        assert!(
+            output.status.success(),
+            "MinIO client {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn run_mc_output(&self, source_dir: Option<&StdPath>, args: &[&str]) -> std::process::Output {
+        let host = format!(
+            "http://{}:{}@{}",
+            Self::ROOT_USER,
+            Self::ROOT_PASSWORD,
+            self.endpoint.trim_start_matches("http://")
+        );
+        let mut command = Command::new("docker");
+        command
+            .args(["run", "--rm", "--network", "host", "-e"])
+            .arg(format!("MC_HOST_minio={host}"));
+        if let Some(source_dir) = source_dir {
+            command
+                .arg("-v")
+                .arg(format!("{}:/data:ro", source_dir.display()));
+        }
+        command
+            .arg(MINIO_MC_IMAGE)
+            .args(args)
+            .output()
+            .unwrap_or_else(|err| panic!("run MinIO client {args:?}: {err}"))
+    }
+}
+
+impl Drop for MinioServer {
+    fn drop(&mut self) {
+        let _ = Command::new("docker")
+            .args(["rm", "-f", &self.name])
+            .status();
+    }
+}
+
+fn wait_minio_ready(port: u16, timeout: Duration) -> bool {
+    let deadline = std::time::Instant::now() + timeout;
+    while std::time::Instant::now() < deadline {
+        if let Ok(mut stream) = TcpStream::connect(("127.0.0.1", port)) {
+            let _ = stream.set_read_timeout(Some(Duration::from_secs(1)));
+            if stream
+                .write_all(
+                    b"GET /minio/health/ready HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+                )
+                .is_ok()
+            {
+                let mut response = String::new();
+                if stream.read_to_string(&mut response).is_ok() && response.contains("200 OK") {
+                    return true;
+                }
+            }
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    false
+}
+
+fn extract_job_id(stdout: &str) -> String {
+    stdout
+        .lines()
+        .find_map(|line| line.strip_prefix("Job ID: "))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| panic!("load output did not contain Job ID: {stdout}"))
+        .to_string()
+}
+
+fn cancel_job(job_id: &str, owner: &str) -> TransferJobRecord {
+    let command = TransferCommand {
+        kind: TransferKind::Load,
+        source_path: "file:///cancel.txt".to_string(),
+        target_path: "/mnt/cancel.txt".to_string(),
+        client_request_id: format!("{job_id}-request"),
+        submitter: "cli-e2e".to_string(),
+        tenant: "test".to_string(),
+        options: Default::default(),
+    };
+    let now = LocalTime::mills() as i64;
+    TransferJobRecord {
+        job_key: command.client_request_id.clone(),
+        job_id: job_id.to_string(),
+        run_id: 1,
+        kind: command.kind,
+        source_path: command.source_path.clone(),
+        target_path: command.target_path.clone(),
+        command_json: serde_json::to_string(&command).unwrap(),
+        mount_snapshot_json: String::new(),
+        secret_ref_json: String::new(),
+        cluster_snapshot_version: 1,
+        cv_metadata_epoch: None,
+        state: TransferState::Running,
+        owner: owner.to_string(),
+        lease_epoch: 1,
+        lease_expire_at: now + 120_000,
+        cancel_requested: false,
+        summary: TransferProgress::default(),
+        client_request_id: command.client_request_id,
+        submitter: command.submitter,
+        tenant: command.tenant,
+        created_at: now - 1_000,
+        updated_at: now - 1_000,
+    }
+}
+
+fn cancel_task(job_id: &str) -> TransferTaskRecord {
+    let now = LocalTime::mills() as i64;
+    TransferTaskRecord {
+        job_id: job_id.to_string(),
+        run_id: 1,
+        task_id: "cancel-task".to_string(),
+        attempt_id: 1,
+        source_path: "file:///cancel.txt".to_string(),
+        target_path: "/mnt/cancel.txt".to_string(),
+        worker_id: 0,
+        worker_session_id: String::new(),
+        source_read_plan_json: String::new(),
+        report_target_json: "{}".to_string(),
+        state: TransferTaskState::Running,
+        progress: TransferProgress::default(),
+        retry_count: 0,
+        attempt_started_at: now - 1_000,
+        last_report_at: now - 1_000,
+        stale_deadline_at: now + 120_000,
+        updated_at: now - 1_000,
+    }
+}

--- a/curvine-client/src/file/curvine_filesystem.rs
+++ b/curvine-client/src/file/curvine_filesystem.rs
@@ -21,6 +21,7 @@ use curvine_common::alloc::allocator_type_name;
 use curvine_common::conf::ClusterConf;
 use curvine_common::error::FsError;
 use curvine_common::fs::{FileSystem, FsKind, ListStream, Path, Reader, Writer};
+use curvine_common::proto::{GetCvMetadataDeltaPageResponse, GetCvMetadataSnapshotPageResponse};
 use curvine_common::state::{CommitBlock, FreeResult, ListOptions};
 use curvine_common::state::{
     CreateFileOpts, CreateFileOptsBuilder, FileAllocOpts, FileBlocks, FileLock, FileStatus,
@@ -53,7 +54,7 @@ impl CurvineFileSystem {
             fs_client: Arc::new(fs_client),
         };
 
-        FsContext::start_clean_task(fs.clone(), fs.fs_context.block_pool.clone());
+        FsContext::start_clean_task(&fs.fs_context, fs.fs_context.block_pool.clone());
 
         let c = &fs.conf().client;
         info!(
@@ -192,6 +193,28 @@ impl CurvineFileSystem {
 
     pub async fn list_status(&self, path: &Path) -> FsResult<Vec<FileStatus>> {
         self.fs_client.list_status(path).await
+    }
+
+    pub async fn get_cv_metadata_snapshot_page(
+        &self,
+        page_token: Option<String>,
+        page_size: Option<u32>,
+    ) -> FsResult<GetCvMetadataSnapshotPageResponse> {
+        self.fs_client
+            .get_cv_metadata_snapshot_page(page_token, page_size)
+            .await
+    }
+
+    pub async fn get_cv_metadata_delta_page(
+        &self,
+        from_epoch: u64,
+        target_epoch: Option<u64>,
+        page_token: Option<String>,
+        page_size: Option<u32>,
+    ) -> FsResult<GetCvMetadataDeltaPageResponse> {
+        self.fs_client
+            .get_cv_metadata_delta_page(from_epoch, target_epoch, page_token, page_size)
+            .await
     }
 
     pub async fn list_status_bytes(&self, path: &Path) -> FsResult<BytesMut> {

--- a/curvine-client/src/file/fs_client.rs
+++ b/curvine-client/src/file/fs_client.rs
@@ -445,6 +445,34 @@ impl FsClient {
         Ok(res)
     }
 
+    pub async fn get_cv_metadata_snapshot_page(
+        &self,
+        page_token: Option<String>,
+        page_size: Option<u32>,
+    ) -> FsResult<GetCvMetadataSnapshotPageResponse> {
+        let header = GetCvMetadataSnapshotPageRequest {
+            page_token,
+            page_size,
+        };
+        self.rpc(RpcCode::GetCvMetadataSnapshotPage, header).await
+    }
+
+    pub async fn get_cv_metadata_delta_page(
+        &self,
+        from_epoch: u64,
+        target_epoch: Option<u64>,
+        page_token: Option<String>,
+        page_size: Option<u32>,
+    ) -> FsResult<GetCvMetadataDeltaPageResponse> {
+        let header = GetCvMetadataDeltaPageRequest {
+            from_epoch,
+            target_epoch,
+            page_token,
+            page_size,
+        };
+        self.rpc(RpcCode::GetCvMetadataDeltaPage, header).await
+    }
+
     pub async fn get_master_info(&self) -> FsResult<MasterInfo> {
         let header = GetMasterInfoRequest::default();
         let rep: GetMasterInfoResponse = self.rpc(RpcCode::GetMasterInfo, header).await?;

--- a/curvine-client/src/file/fs_context.rs
+++ b/curvine-client/src/file/fs_context.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::block::{BlockClient, BlockClientPool};
-use crate::file::CurvineFileSystem;
+use crate::file::FsClient;
 use crate::ClientMetrics;
 use curvine_common::conf::ClusterConf;
 use curvine_common::proto::ClientAddressProto;
@@ -33,7 +33,7 @@ use orpc::runtime::{RpcRuntime, Runtime};
 use orpc::sys::CacheManager;
 use std::future::Future;
 use std::hash::BuildHasherDefault;
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 use std::time::Duration;
 
 static CLIENT_METRICS: OnceCell<ClientMetrics> = OnceCell::new();
@@ -219,23 +219,45 @@ impl FsContext {
         self.failed_workers.iter().map(|x| x.1.worker_id).collect()
     }
 
-    pub fn start_clean_task(fs: CurvineFileSystem, pool: Arc<BlockClientPool>) {
-        let metric_report_enable = fs.conf().client.metric_report_enable;
-        let interval = Duration::from_millis(fs.conf().client.clean_task_interval_ms);
+    pub fn start_clean_task(context: &Arc<FsContext>, pool: Arc<BlockClientPool>) {
+        let metric_report_enable = context.conf.client.metric_report_enable;
+        let interval = Duration::from_millis(context.conf.client.clean_task_interval_ms);
+        let context = Arc::downgrade(context);
 
-        fs.clone_runtime().spawn(async move {
-            let mut interval = tokio::time::interval(interval);
-            loop {
-                interval.tick().await;
+        if let Some(strong_context) = context.upgrade() {
+            strong_context.clone_runtime().spawn(async move {
+                Self::run_clean_task(context, pool, metric_report_enable, interval).await;
+            });
+        }
+    }
 
-                pool.clear_idle_conn();
+    async fn run_clean_task(
+        context: Weak<FsContext>,
+        pool: Arc<BlockClientPool>,
+        metric_report_enable: bool,
+        interval: std::time::Duration,
+    ) {
+        let mut interval = tokio::time::interval(interval);
+        loop {
+            interval.tick().await;
 
-                if metric_report_enable {
-                    if let Err(e) = fs.metrics_report().await {
-                        warn!("metrics report: {}", e)
-                    }
+            pool.clear_idle_conn();
+
+            if metric_report_enable {
+                let Some(context) = context.upgrade() else {
+                    return;
+                };
+                if let Err(e) = Self::metrics_report(&context).await {
+                    warn!("metrics report: {}", e);
                 }
+            } else if context.strong_count() == 0 {
+                return;
             }
-        });
+        }
+    }
+
+    async fn metrics_report(context: &Arc<FsContext>) -> FsResult<()> {
+        let metrics = ClientMetrics::encode()?;
+        FsClient::new(context.clone()).metrics_report(metrics).await
     }
 }

--- a/curvine-client/src/file/fs_writer.rs
+++ b/curvine-client/src/file/fs_writer.rs
@@ -18,7 +18,7 @@ use curvine_common::fs::{Path, Writer};
 use curvine_common::state::{FileAllocOpts, FileBlocks, FileStatus};
 use curvine_common::FsResult;
 use log::debug;
-use orpc::common::ByteUnit;
+use orpc::common::{ByteUnit, TimeSpent};
 use orpc::sys::DataSlice;
 use orpc::{err_box, ternary};
 use std::sync::Arc;
@@ -31,7 +31,6 @@ pub struct FsWriter {
     chunk_size: usize,
     pos: i64,
     append: bool,
-    metrics: &'static crate::ClientMetrics,
 }
 
 impl FsWriter {
@@ -53,7 +52,6 @@ impl FsWriter {
 
         let writer = FsWriterBase::new(fs_context, path, status, pos);
         let inner = FsWriterBuffer::new(writer, chunk_num);
-        let metrics = FsContext::get_metrics();
 
         Self {
             inner,
@@ -61,7 +59,6 @@ impl FsWriter {
             chunk_size,
             pos,
             append,
-            metrics,
         }
     }
 
@@ -104,8 +101,12 @@ impl Writer for FsWriter {
     }
 
     async fn write_chunk(&mut self, chunk: DataSlice) -> FsResult<i64> {
-        let len = chunk.len() as i64;
-        self.metrics.track_write(len, self.inner.write(chunk)).await
+        let len = chunk.len();
+        let _timer =
+            TimeSpent::timer_counter(Arc::new(FsContext::get_metrics().write_time_us.clone()));
+        self.inner.write(chunk).await?;
+        FsContext::get_metrics().write_bytes.inc_by(len as i64);
+        Ok(len as i64)
     }
 
     async fn flush(&mut self) -> FsResult<()> {
@@ -122,8 +123,6 @@ impl Writer for FsWriter {
     }
 
     async fn cancel(&mut self) -> FsResult<()> {
-        // Bytes still in the front buffer have never reached the backend and
-        // must not be flushed after cancellation.
         self.buf.clear();
         self.inner.cancel().await
     }
@@ -131,8 +130,6 @@ impl Writer for FsWriter {
     async fn seek(&mut self, pos: i64) -> FsResult<()> {
         if pos < 0 {
             return err_box!(format!("Cannot seek to negative position: {}", pos));
-        } else if self.pos == pos {
-            return Ok(());
         }
 
         if self.append {

--- a/curvine-client/src/rpc/transfer_client.rs
+++ b/curvine-client/src/rpc/transfer_client.rs
@@ -52,10 +52,17 @@ impl TransferClient {
     }
 
     pub fn with_endpoint(context: &Arc<FsContext>, endpoint: impl Into<String>) -> FsResult<Self> {
+        Self::with_report_endpoints(context, vec![endpoint.into()])
+    }
+
+    pub fn with_report_endpoints(
+        context: &Arc<FsContext>,
+        endpoints: Vec<String>,
+    ) -> FsResult<Self> {
         Self::with_endpoints(
             context.conf.client_rpc_conf(),
             context.clone_runtime(),
-            vec![endpoint.into()],
+            endpoints,
         )
     }
 

--- a/curvine-client/src/rpc/transfer_client.rs
+++ b/curvine-client/src/rpc/transfer_client.rs
@@ -1,0 +1,259 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use curvine_common::error::FsError;
+use curvine_common::fs::RpcCode;
+use curvine_common::proto::{
+    CancelTransferRequest, CancelTransferResponse, GetTransferStatusRequest,
+    GetTransferStatusResponse, ListTransferTenantsRequest, ListTransferTenantsResponse,
+    ListTransfersRequest, ListTransfersResponse, RetryTransferRequest, SubmitTransferRequest,
+    SubmitTransferResponse, TransferProgressProto, TransferTaskReportRequest,
+    TransferTaskReportResponse, WatchTransferRequest, WatchTransferResponse,
+};
+use curvine_common::state::{
+    JobTaskProgress, JobTaskState, TransferCommand, TransferKind, TransferState,
+    TransferTaskReportInfo,
+};
+use curvine_common::utils::SerdeUtils;
+use curvine_common::FsResult;
+use orpc::client::ClusterConnector;
+use orpc::io::net::NodeAddr;
+use orpc::runtime::Runtime;
+
+use crate::file::FsContext;
+
+const TRANSFER_PROTOCOL_VERSION: u32 = 1;
+
+#[derive(Clone)]
+pub struct TransferClient {
+    connector: Arc<ClusterConnector>,
+}
+
+impl TransferClient {
+    pub fn with_context(context: &Arc<FsContext>) -> FsResult<Self> {
+        Self::with_endpoints(
+            context.conf.client_rpc_conf(),
+            context.clone_runtime(),
+            transfer_endpoints(context),
+        )
+    }
+
+    pub fn with_endpoint(context: &Arc<FsContext>, endpoint: impl Into<String>) -> FsResult<Self> {
+        Self::with_endpoints(
+            context.conf.client_rpc_conf(),
+            context.clone_runtime(),
+            vec![endpoint.into()],
+        )
+    }
+
+    pub fn with_rt(conf: &curvine_common::conf::ClusterConf, rt: Arc<Runtime>) -> FsResult<Self> {
+        Self::with_endpoints(
+            conf.client_rpc_conf(),
+            rt,
+            transfer_endpoints_from_conf(conf),
+        )
+    }
+
+    fn with_endpoints(
+        conf: orpc::client::ClientConf,
+        rt: Arc<Runtime>,
+        endpoints: Vec<String>,
+    ) -> FsResult<Self> {
+        let connector = ClusterConnector::with_rt(conf, rt);
+        for endpoint in endpoints {
+            connector.add_node(NodeAddr::from_str(endpoint)?)?;
+        }
+        Ok(Self {
+            connector: Arc::new(connector),
+        })
+    }
+
+    pub async fn submit(&self, command: TransferCommand) -> FsResult<SubmitTransferResponse> {
+        let req = SubmitTransferRequest {
+            kind: transfer_kind_code(command.kind),
+            source_path: command.source_path.clone(),
+            target_path: command.target_path.clone(),
+            client_request_id: command.client_request_id.clone(),
+            submitter: command.submitter.clone(),
+            tenant: command.tenant.clone(),
+            command: SerdeUtils::serialize_json(&command)?,
+            protocol_version: Some(TRANSFER_PROTOCOL_VERSION),
+        };
+        self.connector
+            .proto_rpc::<_, SubmitTransferResponse, FsError>(RpcCode::SubmitTransfer, req)
+            .await
+    }
+
+    pub async fn status(&self, job_id: impl AsRef<str>) -> FsResult<GetTransferStatusResponse> {
+        self.status_page(job_id, None, None).await
+    }
+
+    pub async fn retry(&self, job_id: impl AsRef<str>) -> FsResult<SubmitTransferResponse> {
+        let req = RetryTransferRequest {
+            job_id: job_id.as_ref().to_string(),
+        };
+        self.connector
+            .proto_rpc::<_, SubmitTransferResponse, FsError>(RpcCode::RetryTransfer, req)
+            .await
+    }
+
+    pub async fn status_page(
+        &self,
+        job_id: impl AsRef<str>,
+        page_size: Option<u32>,
+        page_token: Option<String>,
+    ) -> FsResult<GetTransferStatusResponse> {
+        let req = GetTransferStatusRequest {
+            job_id: job_id.as_ref().to_string(),
+            page_size,
+            page_token,
+        };
+        self.connector
+            .proto_rpc::<_, GetTransferStatusResponse, FsError>(RpcCode::GetTransferStatus, req)
+            .await
+    }
+
+    pub async fn list(
+        &self,
+        kind: Option<TransferKind>,
+        state: Option<TransferState>,
+        submitter: Option<String>,
+        tenant: Option<String>,
+        page_size: Option<u32>,
+        page_token: Option<String>,
+    ) -> FsResult<ListTransfersResponse> {
+        let req = ListTransfersRequest {
+            kind: kind.map(transfer_kind_code),
+            state: state.map(transfer_state_code),
+            page_size,
+            page_token,
+            submitter,
+            tenant,
+        };
+        self.connector
+            .proto_rpc::<_, ListTransfersResponse, FsError>(RpcCode::ListTransfers, req)
+            .await
+    }
+
+    pub async fn list_tenants(
+        &self,
+        page_size: Option<u32>,
+        page_token: Option<String>,
+    ) -> FsResult<ListTransferTenantsResponse> {
+        let req = ListTransferTenantsRequest {
+            page_size,
+            page_token,
+        };
+        self.connector
+            .proto_rpc::<_, ListTransferTenantsResponse, FsError>(RpcCode::ListTransferTenants, req)
+            .await
+    }
+
+    pub async fn watch(
+        &self,
+        job_id: impl AsRef<str>,
+        since_updated_at: Option<u64>,
+        page_size: Option<u32>,
+        page_token: Option<String>,
+    ) -> FsResult<WatchTransferResponse> {
+        let req = WatchTransferRequest {
+            job_id: job_id.as_ref().to_string(),
+            since_updated_at,
+            page_size,
+            page_token,
+        };
+        self.connector
+            .proto_rpc::<_, WatchTransferResponse, FsError>(RpcCode::WatchTransfer, req)
+            .await
+    }
+
+    pub async fn cancel(
+        &self,
+        job_id: impl AsRef<str>,
+        run_id: Option<u64>,
+    ) -> FsResult<CancelTransferResponse> {
+        let req = CancelTransferRequest {
+            job_id: job_id.as_ref().to_string(),
+            run_id,
+        };
+        self.connector
+            .proto_rpc::<_, CancelTransferResponse, FsError>(RpcCode::CancelTransfer, req)
+            .await
+    }
+
+    pub async fn report_task(
+        &self,
+        job_id: impl AsRef<str>,
+        task_id: impl AsRef<str>,
+        info: &TransferTaskReportInfo,
+        progress: JobTaskProgress,
+    ) -> FsResult<bool> {
+        let req = TransferTaskReportRequest {
+            job_id: job_id.as_ref().to_string(),
+            run_id: info.run_id,
+            task_id: task_id.as_ref().to_string(),
+            attempt_id: info.attempt_id,
+            worker_id: info.worker_id,
+            worker_session_id: info.worker_session_id.clone(),
+            state: transfer_task_state_code(progress.state),
+            progress: TransferProgressProto {
+                loaded_size: progress.loaded_size,
+                total_size: progress.total_size,
+                update_time: progress.update_time,
+                message: progress.message,
+            },
+            protocol_version: Some(TRANSFER_PROTOCOL_VERSION),
+        };
+        let response = self
+            .connector
+            .proto_rpc::<_, TransferTaskReportResponse, FsError>(RpcCode::ReportTransferTask, req)
+            .await?;
+        Ok(response.accepted)
+    }
+}
+
+fn transfer_endpoints(context: &Arc<FsContext>) -> Vec<String> {
+    transfer_endpoints_from_conf(&context.conf)
+}
+
+fn transfer_endpoints_from_conf(conf: &curvine_common::conf::ClusterConf) -> Vec<String> {
+    if conf.transfer.endpoints.is_empty() {
+        vec![format!(
+            "{}:{}",
+            conf.transfer.hostname, conf.transfer.rpc_port
+        )]
+    } else {
+        conf.transfer.endpoints.clone()
+    }
+}
+
+fn transfer_kind_code(kind: TransferKind) -> i32 {
+    kind as i32
+}
+
+fn transfer_state_code(state: TransferState) -> i32 {
+    state as i32
+}
+
+fn transfer_task_state_code(state: JobTaskState) -> i32 {
+    match state {
+        JobTaskState::Pending | JobTaskState::UNKNOWN => 1,
+        JobTaskState::Loading => 2,
+        JobTaskState::Completed => 3,
+        JobTaskState::Failed => 4,
+        JobTaskState::Canceled => 5,
+    }
+}

--- a/curvine-client/src/unified/unified_filesystem.rs
+++ b/curvine-client/src/unified/unified_filesystem.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::file::{CurvineFileSystem, FsClient, FsContext, FsReader};
-use crate::rpc::JobMasterClient;
+use crate::rpc::{JobMasterClient, TransferClient};
 use crate::unified::{FallbackFsReader, MountCache, MountValue, UnifiedReader, UnifiedWriter};
 use crate::ClientMetrics;
 use bytes::BytesMut;
@@ -22,11 +22,12 @@ use curvine_common::error::FsError;
 use curvine_common::fs::{FileSystem, FsKind, ListStream, Path, Reader, RpcCode, Writer};
 use curvine_common::state::{
     CreateFileOpts, FileAllocOpts, FileLock, FileStatus, FreeResult, JobStatus, ListOptions,
-    LoadJobCommand, MasterInfo, MkdirOpts, MkdirOptsBuilder, MountInfo, MountOptions, OpenFlags,
-    SetAttrOpts,
+    MasterInfo, MkdirOpts, MkdirOptsBuilder, MountInfo, MountOptions, OpenFlags, SetAttrOpts,
+    TransferCommand, TransferKind, TransferState,
 };
 use curvine_common::utils::CommonUtils;
 use curvine_common::FsResult;
+use dashmap::DashSet;
 use log::{debug, error, info, warn};
 use orpc::common::TimeSpent;
 use orpc::runtime::{RpcRuntime, Runtime};
@@ -34,6 +35,10 @@ use orpc::{err_box, err_ext};
 use std::borrow::Cow;
 use std::future::Future;
 use std::sync::Arc;
+use std::time::Duration;
+use tokio::time;
+
+const TRANSFER_SUBMIT_MAX_ATTEMPTS: usize = 3;
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone)]
@@ -49,6 +54,7 @@ pub struct UnifiedFileSystem {
     enable_unified: bool,
     enable_read_ufs: bool,
     audit_logging_enabled: bool,
+    async_cache_pending: Arc<DashSet<String>>,
     metrics: &'static ClientMetrics,
 }
 
@@ -66,6 +72,7 @@ impl UnifiedFileSystem {
             enable_unified,
             enable_read_ufs,
             audit_logging_enabled,
+            async_cache_pending: Arc::new(DashSet::new()),
             metrics: FsContext::get_metrics(),
         };
 
@@ -432,44 +439,120 @@ impl UnifiedFileSystem {
     }
 
     pub fn async_cache(&self, source_path: &Path) -> FsResult<()> {
-        let client = JobMasterClient::new(self.fs_client());
         let source_path = source_path.clone_uri();
+        if self.async_cache_pending.contains(&source_path) {
+            debug!("async cache request already pending for {}", source_path);
+            return Ok(());
+        }
+        let pending_capacity = self.cv.conf().transfer.client_pending_queue_size();
+        if self.async_cache_pending.len() >= pending_capacity {
+            return Err(FsError::transfer_overloaded(format!(
+                "client async cache pending queue is full, capacity={}",
+                pending_capacity
+            )));
+        }
+        self.async_cache_pending.insert(source_path.clone());
+        let fs = self.clone();
         let log = self.audit_logging_enabled;
         let metrics = self.metrics;
 
         self.fs_context().rt().spawn(async move {
             let time = TimeSpent::new();
-            let command = LoadJobCommand::builder(source_path.clone()).build();
-            let res = client.submit_load_job(command).await;
+            let res = fs.submit_async_cache(&source_path).await;
 
             let used_us = time.used_us();
+            let metric_name = res
+                .as_ref()
+                .map(|(cmd, _, _)| cmd.as_str())
+                .unwrap_or("SubmitCacheJob");
             metrics
                 .metadata_operation_duration
-                .with_label_values(&["SubmitJob"])
+                .with_label_values(&[metric_name])
                 .observe(used_us as f64);
 
             match res {
                 Err(e) => warn!("submit async cache error for {}: {}", source_path, e),
-                Ok(res) => {
+                Ok((cmd, job_id, target_path)) => {
                     if log {
                         info!(
                             target: "audit",
                             "cmd={} ok={} src={} dst={} usedUs={}",
-                            "SubmitJob",
+                            cmd,
                             true,
                             source_path,
-                            res.target_path,
+                            target_path,
                            used_us
                         );
                     }
+                    debug!(
+                        "submitted async cache transfer {} for {}",
+                        job_id, source_path
+                    );
                 }
             }
+            fs.async_cache_pending.remove(&source_path);
         });
 
         Ok(())
     }
 
+    async fn submit_async_cache(&self, source_path: &str) -> FsResult<(String, String, String)> {
+        if self.cv.conf().transfer.enabled {
+            let client = TransferClient::with_context(self.fs_context())?;
+            let command = self
+                .cache_transfer_command(&Path::from_str(source_path)?)
+                .await?;
+            let target_path = command.target_path.clone();
+            let rep = submit_transfer_with_backoff(&client, command).await?;
+            return Ok(("SubmitTransfer".to_string(), rep.job_id, target_path));
+        }
+        Err(FsError::common(format!(
+            "auto cache load requires transfer.enabled=true and a running curvine-transfer service; refusing to submit legacy Master LoadJob for {}",
+            source_path
+        )))
+    }
+
+    async fn cache_transfer_command(&self, requested_path: &Path) -> FsResult<TransferCommand> {
+        let mount = self
+            .mount_cache
+            .get_mount(self, requested_path)
+            .await?
+            .ok_or_else(|| FsError::common(format!("{} is not mounted", requested_path)))?;
+        let (source, target) = if requested_path.is_cv() {
+            (mount.get_ufs_path(requested_path)?, requested_path.clone())
+        } else {
+            (requested_path.clone(), mount.get_cv_path(requested_path)?)
+        };
+        mount.ufs.get_status(&source).await?;
+
+        Ok(TransferCommand {
+            kind: TransferKind::Load,
+            source_path: source.clone_uri(),
+            target_path: target.clone_uri(),
+            client_request_id: TransferCommand::default_client_request_id(
+                TransferKind::Load,
+                source.clone_uri(),
+                target.clone_uri(),
+            ),
+            submitter: "curvine-client".to_string(),
+            tenant: String::new(),
+            options: Default::default(),
+        })
+    }
+
     pub async fn wait_job_complete(&self, path: &Path, fail_if_not_found: bool) -> FsResult<()> {
+        if self.cv.conf().transfer.enabled {
+            let command = self.cache_transfer_command(path).await?;
+            let client = TransferClient::with_context(self.fs_context())?;
+            let job = submit_transfer_with_backoff(&client, command).await?;
+            return wait_transfer_complete(
+                &client,
+                &job.job_id,
+                &self.cv.conf().client,
+                fail_if_not_found,
+            )
+            .await;
+        }
         if !path.is_cv() {
             return err_box!("the current file {} is not a cache file", path);
         }
@@ -670,6 +753,123 @@ impl UnifiedFileSystem {
             }
         };
         self.track("SetLock", path.path(), "", fut).await
+    }
+}
+
+async fn submit_transfer_with_backoff(
+    client: &TransferClient,
+    command: TransferCommand,
+) -> FsResult<curvine_common::proto::SubmitTransferResponse> {
+    let mut attempt = 0usize;
+    loop {
+        match client.submit(command.clone()).await {
+            Ok(response) => return Ok(response),
+            Err(err)
+                if attempt + 1 < TRANSFER_SUBMIT_MAX_ATTEMPTS
+                    && retryable_transfer_submit_error(&err) =>
+            {
+                attempt += 1;
+                let delay_ms = 200_u64.saturating_mul(1_u64 << (attempt - 1));
+                warn!(
+                    "retry transfer submit for {} after retryable error (attempt {}/{}): {}",
+                    command.source_path,
+                    attempt + 1,
+                    TRANSFER_SUBMIT_MAX_ATTEMPTS,
+                    err
+                );
+                tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+            }
+            Err(err) => return Err(err),
+        }
+    }
+}
+
+fn retryable_transfer_submit_error(err: &FsError) -> bool {
+    match err {
+        FsError::IO(_)
+        | FsError::Pipeline(_)
+        | FsError::Timeout(_)
+        | FsError::TransferOverloaded(_)
+        | FsError::TransferStoreUnavailable(_) => true,
+        FsError::Common(inner) => {
+            let message = inner.to_string();
+            message.contains("TransferQueueFull")
+                || message.contains("TransferOverloaded")
+                || message.contains("TransferStoreUnavailable")
+                || message.contains("sqlite transfer store error:")
+                || message.contains("mysql transfer store error:")
+        }
+        _ => false,
+    }
+}
+
+async fn wait_transfer_complete(
+    client: &TransferClient,
+    job_id: &str,
+    client_conf: &curvine_common::conf::ClientConf,
+    fail_if_not_found: bool,
+) -> FsResult<()> {
+    time::timeout(
+        Duration::from_millis(client_conf.max_sync_wait_timeout_ms),
+        wait_transfer_complete0(client, job_id, client_conf, fail_if_not_found),
+    )
+    .await?
+}
+
+async fn wait_transfer_complete0(
+    client: &TransferClient,
+    job_id: &str,
+    client_conf: &curvine_common::conf::ClientConf,
+    fail_if_not_found: bool,
+) -> FsResult<()> {
+    let mut ticks = 0_u64;
+    let elapsed = TimeSpent::new();
+
+    loop {
+        let status = match client.status(job_id).await {
+            Ok(status) => status,
+            Err(err @ FsError::JobNotFound(_)) if !fail_if_not_found => {
+                time::sleep(Duration::from_millis(
+                    client_conf.sync_check_interval_min_ms,
+                ))
+                .await;
+                continue;
+            }
+            Err(err) => return Err(err),
+        };
+        let state = TransferState::from(status.state);
+        match state {
+            TransferState::Completed => return Ok(()),
+            TransferState::Failed | TransferState::Canceled => {
+                return err_box!(
+                    "transfer {} {:?}: {}",
+                    status.job_id,
+                    state,
+                    status.progress.message
+                )
+            }
+            TransferState::Pending
+            | TransferState::Planning
+            | TransferState::Dispatching
+            | TransferState::Running
+            | TransferState::Canceling => {
+                ticks += 1;
+                let sleep_ms = client_conf
+                    .sync_check_interval_max_ms
+                    .min(client_conf.sync_check_interval_min_ms.saturating_mul(ticks));
+                time::sleep(Duration::from_millis(sleep_ms)).await;
+
+                if ticks.is_multiple_of(u64::from(client_conf.sync_check_log_tick)) {
+                    info!(
+                        "waiting for transfer {} to complete, elapsed: {} ms, loaded_size={}, total_size={}",
+                        status.job_id,
+                        elapsed.used_ms(),
+                        status.progress.loaded_size,
+                        status.progress.total_size
+                    );
+                }
+            }
+        }
     }
 }
 

--- a/curvine-client/src/unified/unified_filesystem.rs
+++ b/curvine-client/src/unified/unified_filesystem.rs
@@ -523,7 +523,7 @@ impl UnifiedFileSystem {
         } else {
             (requested_path.clone(), mount.get_cv_path(requested_path)?)
         };
-        mount.ufs.get_status(&source).await?;
+        mount.ufs()?.get_status(&source).await?;
 
         Ok(TransferCommand {
             kind: TransferKind::Load,

--- a/curvine-client/src/unified/unified_filesystem.rs
+++ b/curvine-client/src/unified/unified_filesystem.rs
@@ -840,7 +840,7 @@ async fn wait_transfer_complete0(
         let state = TransferState::from(status.state);
         match state {
             TransferState::Completed => return Ok(()),
-            TransferState::Failed | TransferState::Canceled => {
+            TransferState::Failed | TransferState::Canceled | TransferState::PartialSuccess => {
                 return err_box!(
                     "transfer {} {:?}: {}",
                     status.job_id,

--- a/curvine-common/build.rs
+++ b/curvine-common/build.rs
@@ -40,6 +40,7 @@ fn main() {
         "master.proto",
         "worker.proto",
         "job.proto",
+        "transfer.proto",
         "mount.proto",
         "replication.proto",
     ];

--- a/curvine-common/proto/common.proto
+++ b/curvine-common/proto/common.proto
@@ -170,6 +170,12 @@ message WorkerInfoProto {
     map<string, StorageInfoProto> storage_map = 7;
     required int64 reserved_bytes = 8 [default = 0];
     optional uint32 weight = 9 [default = 1];
+    optional string worker_session_id = 10 [default = ""];
+    optional bool transfer_task_submit = 11 [default = false];
+    optional bool transfer_report_target = 12 [default = false];
+    optional bool transfer_query_task = 13 [default = false];
+    optional bool transfer_attempt_safe_output = 14 [default = false];
+    optional bool transfer_source_read_plan = 15 [default = false];
 }
 
 message FileAllocOptsProto {

--- a/curvine-common/proto/job.proto
+++ b/curvine-common/proto/job.proto
@@ -74,6 +74,8 @@ message SubmitTaskRequest {
 
 message SubmitTaskResponse {
   required string task_id = 1;
+  optional bool accepted = 2 [default = true];
+  optional string reject_reason = 3 [default = ""];
 }
 
 message TaskReportRequest {

--- a/curvine-common/proto/master.proto
+++ b/curvine-common/proto/master.proto
@@ -344,3 +344,38 @@ message ListOptionsRequest {
 message ListOptionsResponse {
     repeated FileStatusProto statuses = 1;
 }
+message CvMetadataSnapshotEntryProto {
+    required FileStatusProto status = 1;
+    optional FileBlocksProto blocks = 2;
+}
+
+message GetCvMetadataSnapshotPageRequest {
+    optional string page_token = 1;
+    optional uint32 page_size = 2 [default = 10000];
+}
+
+message GetCvMetadataSnapshotPageResponse {
+    repeated CvMetadataSnapshotEntryProto entries = 1;
+    optional string next_page_token = 2;
+    required uint64 epoch = 3;
+}
+
+message CvMetadataDeltaEntryProto {
+    required string path = 1;
+    optional CvMetadataSnapshotEntryProto entry = 2;
+}
+
+message GetCvMetadataDeltaPageRequest {
+    required uint64 from_epoch = 1;
+    optional uint64 target_epoch = 2;
+    optional string page_token = 3;
+    optional uint32 page_size = 4 [default = 10000];
+}
+
+message GetCvMetadataDeltaPageResponse {
+    repeated CvMetadataDeltaEntryProto entries = 1;
+    optional string next_page_token = 2;
+    required uint64 from_epoch = 3;
+    required uint64 to_epoch = 4;
+    required bool full_snapshot_required = 5;
+}

--- a/curvine-common/proto/transfer.proto
+++ b/curvine-common/proto/transfer.proto
@@ -19,6 +19,7 @@ enum TransferStateProto {
   TRANSFER_COMPLETED = 6;
   TRANSFER_FAILED = 7;
   TRANSFER_CANCELED = 8;
+  TRANSFER_PARTIAL_SUCCESS = 9;
 }
 
 enum TransferTaskStateProto {
@@ -48,6 +49,16 @@ message TransferTaskStatusProto {
   required TransferProgressProto progress = 8;
   required uint32 retry_count = 9;
   required int64 updated_at = 10;
+}
+
+message TransferTaskSummaryProto {
+  required uint64 pending = 1;
+  required uint64 running = 2;
+  required uint64 completed = 3;
+  required uint64 failed = 4;
+  required uint64 canceled = 5;
+  required uint64 stale = 6;
+  required int64 completed_size = 7;
 }
 
 message TransferJobStatusProto {
@@ -109,6 +120,7 @@ message GetTransferStatusResponse {
   optional uint64 lease_epoch = 15;
   optional int64 lease_expire_at = 16;
   optional uint64 cv_metadata_epoch = 17;
+  optional TransferTaskSummaryProto task_summary = 18;
 }
 
 message ListTransfersRequest {
@@ -133,6 +145,7 @@ message TransferTenantSummaryProto {
   required uint64 failed = 5;
   required uint64 canceled = 6;
   required uint64 total = 7;
+  required uint64 partial_success = 8;
 }
 
 message ListTransferTenantsRequest {
@@ -168,6 +181,7 @@ message WatchTransferResponse {
   optional uint64 lease_epoch = 13;
   optional int64 lease_expire_at = 14;
   optional uint64 cv_metadata_epoch = 15;
+  optional TransferTaskSummaryProto task_summary = 16;
 }
 
 message CancelTransferRequest {

--- a/curvine-common/proto/transfer.proto
+++ b/curvine-common/proto/transfer.proto
@@ -1,0 +1,215 @@
+syntax = "proto2";
+package proto;
+
+option java_package = "io.curvine.proto";
+option java_multiple_files = true;
+option java_outer_classname = "TransferProto";
+
+enum TransferKindProto {
+  TRANSFER_LOAD = 1;
+  TRANSFER_EXPORT = 2;
+}
+
+enum TransferStateProto {
+  TRANSFER_PENDING = 1;
+  TRANSFER_PLANNING = 2;
+  TRANSFER_DISPATCHING = 3;
+  TRANSFER_RUNNING = 4;
+  TRANSFER_CANCELING = 5;
+  TRANSFER_COMPLETED = 6;
+  TRANSFER_FAILED = 7;
+  TRANSFER_CANCELED = 8;
+}
+
+enum TransferTaskStateProto {
+  TRANSFER_TASK_PENDING = 1;
+  TRANSFER_TASK_RUNNING = 2;
+  TRANSFER_TASK_COMPLETED = 3;
+  TRANSFER_TASK_FAILED = 4;
+  TRANSFER_TASK_CANCELED = 5;
+  TRANSFER_TASK_STALE = 6;
+}
+
+message TransferProgressProto {
+  required int64 loaded_size = 1;
+  required int64 total_size = 2;
+  required int64 update_time = 3;
+  required string message = 4;
+}
+
+message TransferTaskStatusProto {
+  required string task_id = 1;
+  required uint64 attempt_id = 2;
+  required string source_path = 3;
+  required string target_path = 4;
+  required uint32 worker_id = 5;
+  required string worker_session_id = 6;
+  required TransferTaskStateProto state = 7;
+  required TransferProgressProto progress = 8;
+  required uint32 retry_count = 9;
+  required int64 updated_at = 10;
+}
+
+message TransferJobStatusProto {
+  required string job_id = 1;
+  required uint64 run_id = 2;
+  required TransferKindProto kind = 3;
+  required TransferStateProto state = 4;
+  required string source_path = 5;
+  required string target_path = 6;
+  required TransferProgressProto progress = 7;
+  required string submitter = 8;
+  required string tenant = 9;
+  required int64 created_at = 10;
+  required int64 updated_at = 11;
+  optional string owner = 12;
+  optional uint64 lease_epoch = 13;
+  optional int64 lease_expire_at = 14;
+  optional uint64 cv_metadata_epoch = 15;
+}
+
+message SubmitTransferRequest {
+  required TransferKindProto kind = 1;
+  required string source_path = 2;
+  required string target_path = 3;
+  required string client_request_id = 4;
+  required string submitter = 5;
+  required string tenant = 6;
+  required bytes command = 7;
+  optional uint32 protocol_version = 8 [default = 1];
+}
+
+message SubmitTransferResponse {
+  required string job_id = 1;
+  required uint64 run_id = 2;
+  required TransferStateProto state = 3;
+}
+
+message GetTransferStatusRequest {
+  required string job_id = 1;
+  optional uint32 page_size = 2;
+  optional string page_token = 3;
+}
+
+message GetTransferStatusResponse {
+  required string job_id = 1;
+  required uint64 run_id = 2;
+  required TransferStateProto state = 3;
+  required TransferProgressProto progress = 4;
+  repeated TransferTaskStatusProto tasks = 5;
+  optional string next_page_token = 6;
+  optional TransferKindProto kind = 7;
+  optional string source_path = 8;
+  optional string target_path = 9;
+  optional string submitter = 10;
+  optional string tenant = 11;
+  optional int64 created_at = 12;
+  optional int64 updated_at = 13;
+  optional string owner = 14;
+  optional uint64 lease_epoch = 15;
+  optional int64 lease_expire_at = 16;
+  optional uint64 cv_metadata_epoch = 17;
+}
+
+message ListTransfersRequest {
+  optional TransferKindProto kind = 1;
+  optional TransferStateProto state = 2;
+  optional uint32 page_size = 3;
+  optional string page_token = 4;
+  optional string submitter = 5;
+  optional string tenant = 6;
+}
+
+message ListTransfersResponse {
+  repeated TransferJobStatusProto jobs = 1;
+  optional string next_page_token = 2;
+}
+
+message TransferTenantSummaryProto {
+  required string tenant = 1;
+  required uint64 pending = 2;
+  required uint64 executing = 3;
+  required uint64 completed = 4;
+  required uint64 failed = 5;
+  required uint64 canceled = 6;
+  required uint64 total = 7;
+}
+
+message ListTransferTenantsRequest {
+  optional uint32 page_size = 1;
+  optional string page_token = 2;
+}
+
+message ListTransferTenantsResponse {
+  repeated TransferTenantSummaryProto tenants = 1;
+  optional string next_page_token = 2;
+}
+
+message WatchTransferRequest {
+  required string job_id = 1;
+  optional uint64 since_updated_at = 2;
+  optional uint32 page_size = 3;
+  optional string page_token = 4;
+}
+
+message WatchTransferResponse {
+  required string job_id = 1;
+  required uint64 run_id = 2;
+  required TransferStateProto state = 3;
+  required TransferProgressProto progress = 4;
+  repeated TransferTaskStatusProto tasks = 5;
+  optional string next_page_token = 6;
+  required int64 updated_at = 7;
+  required bool changed = 8;
+  optional TransferKindProto kind = 9;
+  optional string source_path = 10;
+  optional string target_path = 11;
+  optional string owner = 12;
+  optional uint64 lease_epoch = 13;
+  optional int64 lease_expire_at = 14;
+  optional uint64 cv_metadata_epoch = 15;
+}
+
+message CancelTransferRequest {
+  required string job_id = 1;
+  optional uint64 run_id = 2;
+}
+
+message CancelTransferResponse {
+  required string job_id = 1;
+  required TransferStateProto state = 2;
+}
+
+message RetryTransferRequest {
+  required string job_id = 1;
+}
+
+message TransferTaskReportRequest {
+  required string job_id = 1;
+  required uint64 run_id = 2;
+  required string task_id = 3;
+  required uint64 attempt_id = 4;
+  required uint32 worker_id = 5;
+  required string worker_session_id = 6;
+  required TransferTaskStateProto state = 7;
+  required TransferProgressProto progress = 8;
+  optional uint32 protocol_version = 9 [default = 1];
+}
+
+message TransferTaskReportResponse {
+  required bool accepted = 1;
+}
+
+message QueryTransferTaskRequest {
+  required string job_id = 1;
+  required uint64 run_id = 2;
+  required string task_id = 3;
+  required uint64 attempt_id = 4;
+  required string worker_session_id = 5;
+}
+
+message QueryTransferTaskResponse {
+  required bool found = 1;
+  required TransferTaskStateProto state = 2;
+  required TransferProgressProto progress = 3;
+}

--- a/curvine-common/proto/worker.proto
+++ b/curvine-common/proto/worker.proto
@@ -80,6 +80,12 @@ message WorkerHeartbeatRequest {
     repeated StorageInfoProto storages = 8;
     repeated BlockReportInfoProto blocks = 9;
     optional uint32 weight = 10 [default = 1];
+    optional string worker_session_id = 11 [default = ""];
+    optional bool transfer_task_submit = 12 [default = false];
+    optional bool transfer_report_target = 13 [default = false];
+    optional bool transfer_query_task = 14 [default = false];
+    optional bool transfer_attempt_safe_output = 15 [default = false];
+    optional bool transfer_source_read_plan = 16 [default = false];
 }
 
 message WorkerHeartbeatResponse {

--- a/curvine-common/src/conf/cluster_conf.rs
+++ b/curvine-common/src/conf/cluster_conf.rs
@@ -15,7 +15,8 @@
 use crate::alloc::allocator_type_name;
 use crate::conf::CliConf;
 use crate::conf::{
-    ClientConf, FaultHttpConfig, FuseConf, JobConf, JournalConf, MasterConf, WorkerConf,
+    ClientConf, FaultHttpConfig, FuseConf, JobConf, JournalConf, MasterConf, TransferConf,
+    WorkerConf,
 };
 use crate::rocksdb::DBConf;
 use crate::version;
@@ -73,6 +74,8 @@ pub struct ClusterConf {
 
     pub job: JobConf,
 
+    pub transfer: TransferConf,
+
     pub cli: CliConf,
 }
 
@@ -124,7 +127,8 @@ impl ClusterConf {
             conf.master.hostname = ip.clone();
             conf.journal.hostname = ip.clone();
             conf.worker.hostname = ip.clone();
-            conf.client.hostname = ip;
+            conf.client.hostname = ip.clone();
+            conf.transfer.hostname = ip;
         } else {
             if let Ok(v) = env::var(Self::ENV_MASTER_HOSTNAME) {
                 conf.master.hostname = v.to_owned();
@@ -146,6 +150,7 @@ impl ClusterConf {
         conf.client.init()?;
         conf.fuse.init()?;
         conf.job.init()?;
+        conf.transfer.init()?;
 
         if conf.client.master_addrs.is_empty() {
             for peer in &mut conf.journal.journal_addrs {
@@ -288,6 +293,19 @@ impl ClusterConf {
         web_conf
     }
 
+    pub fn transfer_server_conf(&self) -> ServerConf {
+        self.transfer.server_conf(&self.cluster_id)
+    }
+
+    pub fn transfer_web_conf(&self) -> ServerConf {
+        let mut web_conf =
+            ServerConf::with_hostname(&self.transfer.hostname, self.transfer.web_port);
+        web_conf.name = format!("{}-transfer-web", self.cluster_id);
+        web_conf.io_threads = self.transfer.io_threads;
+        web_conf.worker_threads = self.transfer.worker_threads;
+        web_conf
+    }
+
     pub fn client_rpc_conf(&self) -> RpcConf {
         self.client.client_rpc_conf()
     }
@@ -385,6 +403,7 @@ impl Default for ClusterConf {
             client: Default::default(),
             fuse: FuseConf::default(),
             job: Default::default(),
+            transfer: Default::default(),
             cli: Default::default(),
         }
     }

--- a/curvine-common/src/conf/journal_conf.rs
+++ b/curvine-common/src/conf/journal_conf.rs
@@ -57,6 +57,14 @@ pub struct JournalConf {
     // How many entries are created after creating snapshots.
     pub snapshot_entries: u64,
 
+    // Internal ring buffer for Transfer metadata replica delta sync.
+    #[serde(
+        skip_serializing,
+        skip_deserializing,
+        default = "JournalConf::default_metadata_delta_log_capacity"
+    )]
+    pub metadata_delta_log_capacity: usize,
+
     pub snapshot_read_chunk_size: usize,
 
     // Network configuration between raft node communications.
@@ -118,6 +126,11 @@ pub struct JournalConf {
 
 impl JournalConf {
     pub const DEFAULT_NODE_ID: u64 = 0;
+    pub const DEFAULT_METADATA_DELTA_LOG_CAPACITY: usize = 100_000;
+
+    fn default_metadata_delta_log_capacity() -> usize {
+        Self::DEFAULT_METADATA_DELTA_LOG_CAPACITY
+    }
 
     // Create a test configuration, which will also randomly select a server port.
     pub fn with_test() -> Self {
@@ -229,6 +242,7 @@ impl Default for JournalConf {
             writer_flush_batch_ms: 10,
             snapshot_interval: "6h".to_string(),
             snapshot_entries: 1000000,
+            metadata_delta_log_capacity: Self::DEFAULT_METADATA_DELTA_LOG_CAPACITY,
             snapshot_read_chunk_size: 1024 * 1024,
 
             conn_retry_max_duration_ms: 0,

--- a/curvine-common/src/conf/mod.rs
+++ b/curvine-common/src/conf/mod.rs
@@ -39,6 +39,9 @@ pub use self::ufs_conf::UfsConfBuilder;
 mod job_conf;
 pub use self::job_conf::JobConf;
 
+mod transfer_conf;
+pub use self::transfer_conf::*;
+
 mod cli_conf;
 pub use self::cli_conf::CliConf;
 

--- a/curvine-common/src/conf/transfer_conf.rs
+++ b/curvine-common/src/conf/transfer_conf.rs
@@ -181,6 +181,11 @@ impl TransferConf {
             }
             _ => {}
         }
+        if self.endpoints.len() > 1 && self.effective_store_type() != TransferStoreType::Mysql {
+            return Err(FsError::common(
+                "multiple transfer.endpoints require transfer.store_url=mysql:// so instances share one TransferStore",
+            ));
+        }
         if self.enabled && self.effective_store_type() == TransferStoreType::Mysql {
             self.validate_mysql_store()?;
         }

--- a/curvine-common/src/conf/transfer_conf.rs
+++ b/curvine-common/src/conf/transfer_conf.rs
@@ -1,0 +1,524 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::error::FsError;
+use crate::FsResult;
+use orpc::common::DurationUnit;
+use orpc::server::ServerConf;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum TransferStoreType {
+    Auto,
+    Memory,
+    Sqlite,
+    Mysql,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum TransferCvMetadataReaderType {
+    Auto,
+    Disabled,
+    Master,
+    Replica,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct TransferConf {
+    pub enabled: bool,
+    // Deprecated compatibility inputs normalize into store_url during init.
+    #[serde(skip_serializing)]
+    pub store_type: TransferStoreType,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub store_url: String,
+    pub hostname: String,
+    pub rpc_port: u16,
+    pub web_port: u16,
+    #[serde(skip, default = "TransferConf::default_io_threads")]
+    pub io_threads: usize,
+    #[serde(skip, default = "TransferConf::default_worker_threads")]
+    pub worker_threads: usize,
+    pub instance_id: String,
+    pub endpoints: Vec<String>,
+    #[serde(skip_serializing)]
+    pub sqlite_path: String,
+    #[serde(skip_serializing)]
+    pub mysql_url: String,
+    pub cv_metadata_reader: TransferCvMetadataReaderType,
+    #[serde(skip, default = "TransferConf::default_metadata_replica_max_entries")]
+    pub metadata_replica_max_entries: usize,
+    #[serde(skip)]
+    pub allow_submit_with_stale_snapshot: bool,
+    pub max_running_transfers: usize,
+    #[serde(skip, default = "TransferConf::default_max_tasks_per_transfer")]
+    pub max_tasks_per_transfer: usize,
+    #[serde(
+        skip,
+        default = "TransferConf::default_ufs_max_concurrency_per_endpoint"
+    )]
+    pub ufs_max_concurrency_per_endpoint: usize,
+    #[serde(skip, default = "TransferConf::default_task_max_retries")]
+    pub task_max_retries: usize,
+
+    #[serde(skip)]
+    pub task_report_interval: Duration,
+    #[serde(skip, default = "TransferConf::default_task_report_interval_str")]
+    pub task_report_interval_str: String,
+
+    #[serde(skip)]
+    pub task_stale_timeout: Duration,
+    #[serde(skip, default = "TransferConf::default_task_stale_timeout_str")]
+    pub task_stale_timeout_str: String,
+
+    #[serde(skip)]
+    pub lease_timeout: Duration,
+    #[serde(alias = "lease_timeout")]
+    pub lease_timeout_str: String,
+
+    #[serde(skip)]
+    pub cluster_snapshot_max_staleness: Duration,
+    #[serde(
+        skip,
+        default = "TransferConf::default_cluster_snapshot_max_staleness_str"
+    )]
+    pub cluster_snapshot_max_staleness_str: String,
+
+    #[serde(skip)]
+    pub terminal_retention: Duration,
+    #[serde(alias = "terminal_retention")]
+    pub terminal_retention_str: String,
+
+    #[serde(skip)]
+    pub metadata_replica_refresh_interval: Duration,
+    #[serde(
+        skip,
+        default = "TransferConf::default_metadata_replica_refresh_interval_str"
+    )]
+    pub metadata_replica_refresh_interval_str: String,
+
+    #[serde(skip)]
+    pub metadata_replica_max_staleness: Duration,
+    #[serde(
+        skip,
+        default = "TransferConf::default_metadata_replica_max_staleness_str"
+    )]
+    pub metadata_replica_max_staleness_str: String,
+}
+
+impl TransferConf {
+    pub const DEFAULT_TASK_REPORT_INTERVAL: &'static str = "10s";
+    pub const DEFAULT_TASK_STALE_TIMEOUT: &'static str = "60s";
+    pub const DEFAULT_LEASE_TIMEOUT: &'static str = "120s";
+    pub const DEFAULT_CLUSTER_SNAPSHOT_MAX_STALENESS: &'static str = "60s";
+    pub const DEFAULT_TERMINAL_RETENTION: &'static str = "168h";
+    pub const DEFAULT_METADATA_REPLICA_REFRESH_INTERVAL: &'static str = "30s";
+    pub const DEFAULT_METADATA_REPLICA_MAX_STALENESS: &'static str = "120s";
+    pub const DEFAULT_METADATA_REPLICA_MAX_ENTRIES: usize = 1_000_000;
+    pub const DEFAULT_METADATA_REPLICA_PAGE_SIZE: usize = 1000;
+    pub const DEFAULT_METADATA_REPLICA_HISTORY_SIZE: usize = 2;
+    pub const DEFAULT_MAX_PLANNING_TRANSFERS: usize = 8;
+    pub const DEFAULT_PLANNING_BATCH_SIZE: usize = 1000;
+    pub const DEFAULT_WORKER_DISPATCH_CONCURRENCY: usize = 256;
+    pub const DEFAULT_TASK_REPORT_QUEUE_SIZE: usize = 10_000;
+    pub const DEFAULT_TASK_PROBE_CONCURRENCY: usize = 64;
+    pub const DEFAULT_CLIENT_PENDING_QUEUE_SIZE: usize = 1024;
+    pub const DEFAULT_CLEANUP_BATCH_SIZE: usize = 1000;
+    pub const DEFAULT_RPC_PORT: u16 = 9010;
+    pub const DEFAULT_WEB_PORT: u16 = 9011;
+    pub const DEFAULT_IO_THREADS: usize = 4;
+    pub const DEFAULT_WORKER_THREADS: usize = 8;
+    pub const DEFAULT_MAX_TASKS_PER_TRANSFER: usize = 100_000;
+    pub const DEFAULT_UFS_MAX_CONCURRENCY_PER_ENDPOINT: usize = 32;
+    pub const DEFAULT_TASK_MAX_RETRIES: usize = 3;
+
+    pub fn init(&mut self) -> FsResult<()> {
+        self.infer_store_url();
+        if self.endpoints.is_empty() {
+            self.endpoints
+                .push(format!("{}:{}", self.hostname, self.rpc_port));
+        }
+        self.lease_timeout = DurationUnit::from_str(&self.lease_timeout_str)?.as_duration();
+        self.task_stale_timeout = Self::derive_task_stale_timeout(self.lease_timeout);
+        self.task_report_interval = Self::derive_task_report_interval(self.task_stale_timeout);
+        self.cluster_snapshot_max_staleness =
+            DurationUnit::from_str(&self.cluster_snapshot_max_staleness_str)?.as_duration();
+        self.terminal_retention =
+            DurationUnit::from_str(&self.terminal_retention_str)?.as_duration();
+        self.metadata_replica_refresh_interval =
+            DurationUnit::from_str(&self.metadata_replica_refresh_interval_str)?.as_duration();
+        self.metadata_replica_max_staleness =
+            DurationUnit::from_str(&self.metadata_replica_max_staleness_str)?.as_duration();
+        if !self.store_url.is_empty() && self.effective_store_type() == TransferStoreType::Auto {
+            return Err(FsError::common(
+                "transfer.store_url must use memory://, sqlite://, or mysql://",
+            ));
+        }
+        match self.effective_store_type() {
+            TransferStoreType::Sqlite if self.sqlite_store_path().is_empty() => {
+                return Err(FsError::common(
+                    "transfer.store_url=sqlite:// requires a database path",
+                ));
+            }
+            TransferStoreType::Mysql if self.mysql_store_url().is_empty() => {
+                return Err(FsError::common(
+                    "transfer.store_url=mysql:// requires a database URL",
+                ));
+            }
+            _ => {}
+        }
+        if self.enabled && self.effective_store_type() == TransferStoreType::Mysql {
+            self.validate_mysql_store()?;
+        }
+        if self.max_running_transfers == 0 {
+            return Err(FsError::common(
+                "transfer.max_running_transfers must be greater than 0",
+            ));
+        }
+        if self.ufs_max_concurrency_per_endpoint == 0 {
+            return Err(FsError::common(
+                "transfer.ufs_max_concurrency_per_endpoint must be greater than 0",
+            ));
+        }
+        if self.metadata_replica_max_entries == 0 {
+            return Err(FsError::common(
+                "transfer.metadata_replica_max_entries must be greater than 0",
+            ));
+        }
+        if self.cluster_snapshot_max_staleness.is_zero() {
+            return Err(FsError::common(
+                "transfer.cluster_snapshot_max_staleness must be greater than 0",
+            ));
+        }
+        if self.metadata_replica_refresh_interval.is_zero() {
+            return Err(FsError::common(
+                "transfer.metadata_replica_refresh_interval must be greater than 0",
+            ));
+        }
+        if self.metadata_replica_max_staleness.is_zero() {
+            return Err(FsError::common(
+                "transfer.metadata_replica_max_staleness must be greater than 0",
+            ));
+        }
+        if self.lease_timeout.is_zero() {
+            return Err(FsError::common(
+                "transfer.lease_timeout must be greater than 0",
+            ));
+        }
+        if self.max_tasks_per_transfer == 0 {
+            return Err(FsError::common(
+                "transfer.max_tasks_per_transfer must be greater than 0",
+            ));
+        }
+        Ok(())
+    }
+
+    fn infer_store_url(&mut self) {
+        if !self.store_url.is_empty() {
+            return;
+        }
+
+        self.store_url = match self.effective_store_type() {
+            TransferStoreType::Memory => "memory://".to_string(),
+            TransferStoreType::Sqlite => format!("sqlite://{}", self.sqlite_path),
+            TransferStoreType::Mysql => self.mysql_url.clone(),
+            TransferStoreType::Auto => String::new(),
+        };
+    }
+
+    pub fn effective_store_type(&self) -> TransferStoreType {
+        if !self.store_url.is_empty() {
+            return if self.store_url == "memory://" {
+                TransferStoreType::Memory
+            } else if self.store_url.starts_with("sqlite://") {
+                TransferStoreType::Sqlite
+            } else if self.store_url.starts_with("mysql://") {
+                TransferStoreType::Mysql
+            } else {
+                TransferStoreType::Auto
+            };
+        }
+        match self.store_type {
+            TransferStoreType::Auto if self.mysql_url.is_empty() => TransferStoreType::Sqlite,
+            TransferStoreType::Auto => TransferStoreType::Mysql,
+            store_type => store_type,
+        }
+    }
+
+    pub fn effective_cv_metadata_reader(&self) -> TransferCvMetadataReaderType {
+        match self.cv_metadata_reader {
+            TransferCvMetadataReaderType::Auto => TransferCvMetadataReaderType::Replica,
+            reader => reader,
+        }
+    }
+
+    pub fn sqlite_store_path(&self) -> &str {
+        self.store_url
+            .strip_prefix("sqlite://")
+            .unwrap_or(&self.sqlite_path)
+    }
+
+    pub fn mysql_store_url(&self) -> &str {
+        if self.store_url.starts_with("mysql://") {
+            &self.store_url
+        } else {
+            &self.mysql_url
+        }
+    }
+
+    fn validate_mysql_store(&self) -> FsResult<()> {
+        if self.effective_cv_metadata_reader() != TransferCvMetadataReaderType::Replica {
+            return Err(FsError::common(
+                "production transfer requires transfer.cv_metadata_reader=replica",
+            ));
+        }
+        if self.allow_submit_with_stale_snapshot {
+            return Err(FsError::common(
+                "production transfer forbids transfer.allow_submit_with_stale_snapshot=true",
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn max_executing_transfers(&self) -> u64 {
+        self.max_running_transfers as u64
+    }
+
+    fn default_io_threads() -> usize {
+        Self::DEFAULT_IO_THREADS
+    }
+
+    fn default_worker_threads() -> usize {
+        Self::DEFAULT_WORKER_THREADS
+    }
+
+    fn default_max_tasks_per_transfer() -> usize {
+        Self::DEFAULT_MAX_TASKS_PER_TRANSFER
+    }
+
+    fn default_ufs_max_concurrency_per_endpoint() -> usize {
+        Self::DEFAULT_UFS_MAX_CONCURRENCY_PER_ENDPOINT
+    }
+
+    fn default_task_max_retries() -> usize {
+        Self::DEFAULT_TASK_MAX_RETRIES
+    }
+
+    fn default_task_report_interval_str() -> String {
+        Self::DEFAULT_TASK_REPORT_INTERVAL.to_string()
+    }
+
+    fn default_task_stale_timeout_str() -> String {
+        Self::DEFAULT_TASK_STALE_TIMEOUT.to_string()
+    }
+
+    fn default_metadata_replica_max_entries() -> usize {
+        Self::DEFAULT_METADATA_REPLICA_MAX_ENTRIES
+    }
+
+    fn default_cluster_snapshot_max_staleness_str() -> String {
+        Self::DEFAULT_CLUSTER_SNAPSHOT_MAX_STALENESS.to_string()
+    }
+
+    fn default_metadata_replica_refresh_interval_str() -> String {
+        Self::DEFAULT_METADATA_REPLICA_REFRESH_INTERVAL.to_string()
+    }
+
+    fn default_metadata_replica_max_staleness_str() -> String {
+        Self::DEFAULT_METADATA_REPLICA_MAX_STALENESS.to_string()
+    }
+
+    pub fn metadata_replica_page_size(&self) -> usize {
+        Self::DEFAULT_METADATA_REPLICA_PAGE_SIZE
+    }
+
+    pub fn metadata_replica_history_size(&self) -> usize {
+        Self::DEFAULT_METADATA_REPLICA_HISTORY_SIZE
+    }
+
+    pub fn scheduler_workers(&self) -> usize {
+        Self::DEFAULT_MAX_PLANNING_TRANSFERS
+            .min(self.max_running_transfers.max(1))
+            .max(1)
+    }
+
+    pub fn planning_batch_size(&self) -> usize {
+        Self::DEFAULT_PLANNING_BATCH_SIZE
+    }
+
+    pub fn worker_dispatch_concurrency(&self) -> usize {
+        Self::DEFAULT_WORKER_DISPATCH_CONCURRENCY
+    }
+
+    pub fn task_report_queue_size(&self) -> usize {
+        Self::DEFAULT_TASK_REPORT_QUEUE_SIZE
+    }
+
+    pub fn task_probe_concurrency(&self) -> usize {
+        Self::DEFAULT_TASK_PROBE_CONCURRENCY
+    }
+
+    pub fn client_pending_queue_size(&self) -> usize {
+        Self::DEFAULT_CLIENT_PENDING_QUEUE_SIZE
+    }
+
+    pub fn cleanup_batch_size(&self) -> usize {
+        Self::DEFAULT_CLEANUP_BATCH_SIZE
+    }
+
+    fn derive_task_stale_timeout(lease_timeout: Duration) -> Duration {
+        lease_timeout.div_f64(2.0)
+    }
+
+    fn derive_task_report_interval(task_stale_timeout: Duration) -> Duration {
+        let derived = task_stale_timeout.div_f64(6.0);
+        let default = DurationUnit::from_str(Self::DEFAULT_TASK_REPORT_INTERVAL)
+            .expect("default transfer task report interval must be valid")
+            .as_duration();
+        derived.min(default).max(Duration::from_millis(1))
+    }
+
+    pub fn server_conf(&self, cluster_id: &str) -> ServerConf {
+        let mut conf = ServerConf::with_hostname(&self.hostname, self.rpc_port);
+        conf.name = format!("{}-transfer", cluster_id);
+        conf.io_threads = self.io_threads;
+        conf.worker_threads = self.worker_threads;
+        conf
+    }
+}
+
+impl Default for TransferConf {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            store_type: TransferStoreType::Auto,
+            store_url: String::new(),
+            hostname: "localhost".to_string(),
+            rpc_port: Self::DEFAULT_RPC_PORT,
+            web_port: Self::DEFAULT_WEB_PORT,
+            io_threads: Self::DEFAULT_IO_THREADS,
+            worker_threads: Self::DEFAULT_WORKER_THREADS,
+            instance_id: String::new(),
+            endpoints: vec![],
+            sqlite_path: "data/transfer/transfer.db".to_string(),
+            mysql_url: String::new(),
+            cv_metadata_reader: TransferCvMetadataReaderType::Auto,
+            metadata_replica_max_entries: Self::DEFAULT_METADATA_REPLICA_MAX_ENTRIES,
+            allow_submit_with_stale_snapshot: false,
+            max_running_transfers: 64,
+            max_tasks_per_transfer: Self::DEFAULT_MAX_TASKS_PER_TRANSFER,
+            ufs_max_concurrency_per_endpoint: Self::DEFAULT_UFS_MAX_CONCURRENCY_PER_ENDPOINT,
+            task_max_retries: Self::DEFAULT_TASK_MAX_RETRIES,
+            task_report_interval: Duration::default(),
+            task_report_interval_str: Self::DEFAULT_TASK_REPORT_INTERVAL.to_string(),
+            task_stale_timeout: Duration::default(),
+            task_stale_timeout_str: Self::DEFAULT_TASK_STALE_TIMEOUT.to_string(),
+            lease_timeout: Duration::default(),
+            lease_timeout_str: Self::DEFAULT_LEASE_TIMEOUT.to_string(),
+            cluster_snapshot_max_staleness: Duration::default(),
+            cluster_snapshot_max_staleness_str: Self::DEFAULT_CLUSTER_SNAPSHOT_MAX_STALENESS
+                .to_string(),
+            terminal_retention: Duration::default(),
+            terminal_retention_str: Self::DEFAULT_TERMINAL_RETENTION.to_string(),
+            metadata_replica_refresh_interval: Duration::default(),
+            metadata_replica_refresh_interval_str: Self::DEFAULT_METADATA_REPLICA_REFRESH_INTERVAL
+                .to_string(),
+            metadata_replica_max_staleness: Duration::default(),
+            metadata_replica_max_staleness_str: Self::DEFAULT_METADATA_REPLICA_MAX_STALENESS
+                .to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TransferConf, TransferCvMetadataReaderType, TransferStoreType};
+
+    #[test]
+    fn defaults_to_local_sqlite_with_a_local_endpoint() {
+        let mut conf = TransferConf {
+            enabled: true,
+            ..Default::default()
+        };
+
+        conf.init().unwrap();
+
+        assert_eq!(conf.effective_store_type(), TransferStoreType::Sqlite);
+        assert_eq!(conf.store_url, "sqlite://data/transfer/transfer.db");
+        assert_eq!(
+            conf.effective_cv_metadata_reader(),
+            TransferCvMetadataReaderType::Replica
+        );
+        assert_eq!(conf.endpoints, vec!["localhost:9010"]);
+    }
+
+    #[test]
+    fn mysql_url_selects_production_safe_defaults() {
+        let mut conf: TransferConf = toml::from_str(
+            r#"
+                enabled = true
+                store_url = "mysql://root:curvine@127.0.0.1:3306/curvine_transfer"
+            "#,
+        )
+        .unwrap();
+
+        conf.init().unwrap();
+
+        assert_eq!(conf.effective_store_type(), TransferStoreType::Mysql);
+        assert_eq!(
+            conf.store_url,
+            "mysql://root:curvine@127.0.0.1:3306/curvine_transfer"
+        );
+        assert_eq!(
+            conf.effective_cv_metadata_reader(),
+            TransferCvMetadataReaderType::Replica
+        );
+    }
+
+    #[test]
+    fn auto_mysql_rejects_development_metadata_reader() {
+        let mut conf = TransferConf {
+            enabled: true,
+            store_url: "mysql://root:curvine@127.0.0.1:3306/curvine_transfer".to_string(),
+            cv_metadata_reader: TransferCvMetadataReaderType::Master,
+            ..Default::default()
+        };
+
+        let err = conf.init().unwrap_err().to_string();
+
+        assert!(err.contains("requires transfer.cv_metadata_reader=replica"));
+    }
+
+    #[test]
+    fn accepts_memory_store_url_and_rejects_unknown_scheme() {
+        let mut memory = TransferConf {
+            enabled: true,
+            store_url: "memory://".to_string(),
+            ..Default::default()
+        };
+        memory.init().unwrap();
+        assert_eq!(memory.effective_store_type(), TransferStoreType::Memory);
+
+        let mut invalid = TransferConf {
+            enabled: true,
+            store_url: "postgres://transfer".to_string(),
+            ..Default::default()
+        };
+        let err = invalid.init().unwrap_err().to_string();
+        assert!(err.contains("transfer.store_url must use"));
+    }
+}

--- a/curvine-common/src/error/fs_error.rs
+++ b/curvine-common/src/error/fs_error.rs
@@ -67,6 +67,10 @@ pub enum ErrorKind {
     ReadOnly = 30,
     NoAvailableWorker = 31,
     NoLocalPath = 32,
+    TransferOverloaded = 33,
+    TransferStoreUnavailable = 34,
+    TransferAlreadyRunning = 35,
+    TransferTargetConflict = 36,
 
     #[num_enum(default)]
     Common = 10000,
@@ -204,6 +208,22 @@ pub enum FsError {
     #[error("{0}")]
     JobNotFound(ErrorImpl<StringError>),
 
+    // Transfer service or client-side transfer queue is overloaded.
+    #[error("{0}")]
+    TransferOverloaded(ErrorImpl<StringError>),
+
+    // Transfer state store is unavailable or failed a backend operation.
+    #[error("{0}")]
+    TransferStoreUnavailable(ErrorImpl<StringError>),
+
+    // A transfer with the same job key is already running with incompatible options.
+    #[error("{0}")]
+    TransferAlreadyRunning(ErrorImpl<StringError>),
+
+    // A non-terminal transfer already owns the same target path tree.
+    #[error("{0}")]
+    TransferTargetConflict(ErrorImpl<StringError>),
+
     // Other errors that are not defined.
     #[error("{0}")]
     Common(ErrorImpl<StringError>),
@@ -240,6 +260,10 @@ impl FsError {
         Self::InProgress(ErrorImpl::with_source(msg.into()))
     }
 
+    pub fn in_progress_msg(msg: impl Into<String>) -> Self {
+        Self::InProgress(ErrorImpl::with_source(msg.into().into()))
+    }
+
     pub fn file_not_found(path: impl AsRef<str>) -> Self {
         let msg = format!("File {} not found", path.as_ref());
         Self::FileNotFound(ErrorImpl::with_source(msg.into()))
@@ -268,6 +292,22 @@ impl FsError {
     pub fn job_not_found(job_id: impl AsRef<str>) -> Self {
         let msg = format!("Job {} not found", job_id.as_ref());
         Self::JobNotFound(ErrorImpl::with_source(msg.into()))
+    }
+
+    pub fn transfer_overloaded(msg: impl Into<String>) -> Self {
+        Self::TransferOverloaded(ErrorImpl::with_source(msg.into().into()))
+    }
+
+    pub fn transfer_store_unavailable(msg: impl Into<String>) -> Self {
+        Self::TransferStoreUnavailable(ErrorImpl::with_source(msg.into().into()))
+    }
+
+    pub fn transfer_already_running(msg: impl Into<String>) -> Self {
+        Self::TransferAlreadyRunning(ErrorImpl::with_source(msg.into().into()))
+    }
+
+    pub fn transfer_target_conflict(msg: impl Into<String>) -> Self {
+        Self::TransferTargetConflict(ErrorImpl::with_source(msg.into().into()))
     }
 
     pub fn file_exists(path: impl AsRef<str>) -> Self {
@@ -406,6 +446,10 @@ impl FsError {
             FsError::NoAvailableWorker(_) => ErrorKind::NoAvailableWorker,
             FsError::NoLocalPath(_) => ErrorKind::NoLocalPath,
             FsError::JobNotFound(_) => ErrorKind::JobNotFound,
+            FsError::TransferOverloaded(_) => ErrorKind::TransferOverloaded,
+            FsError::TransferStoreUnavailable(_) => ErrorKind::TransferStoreUnavailable,
+            FsError::TransferAlreadyRunning(_) => ErrorKind::TransferAlreadyRunning,
+            FsError::TransferTargetConflict(_) => ErrorKind::TransferTargetConflict,
             FsError::Common(_) => ErrorKind::Common,
         }
     }
@@ -555,6 +599,10 @@ impl ErrorExt for FsError {
             FsError::NoAvailableWorker(e) => FsError::NoAvailableWorker(e.ctx(ctx)),
             FsError::NoLocalPath(e) => FsError::NoLocalPath(e.ctx(ctx)),
             FsError::JobNotFound(e) => FsError::JobNotFound(e.ctx(ctx)),
+            FsError::TransferOverloaded(e) => FsError::TransferOverloaded(e.ctx(ctx)),
+            FsError::TransferStoreUnavailable(e) => FsError::TransferStoreUnavailable(e.ctx(ctx)),
+            FsError::TransferAlreadyRunning(e) => FsError::TransferAlreadyRunning(e.ctx(ctx)),
+            FsError::TransferTargetConflict(e) => FsError::TransferTargetConflict(e.ctx(ctx)),
             FsError::Common(e) => FsError::Common(e.ctx(ctx)),
         }
     }
@@ -593,6 +641,10 @@ impl ErrorExt for FsError {
             FsError::NoAvailableWorker(e) => e.encode(ErrorKind::NoAvailableWorker),
             FsError::NoLocalPath(e) => e.encode(ErrorKind::NoLocalPath),
             FsError::JobNotFound(e) => e.encode(ErrorKind::JobNotFound),
+            FsError::TransferOverloaded(e) => e.encode(ErrorKind::TransferOverloaded),
+            FsError::TransferStoreUnavailable(e) => e.encode(ErrorKind::TransferStoreUnavailable),
+            FsError::TransferAlreadyRunning(e) => e.encode(ErrorKind::TransferAlreadyRunning),
+            FsError::TransferTargetConflict(e) => e.encode(ErrorKind::TransferTargetConflict),
             FsError::Common(e) => e.encode(ErrorKind::Common),
         }
     }
@@ -634,6 +686,12 @@ impl ErrorExt for FsError {
             ErrorKind::NoAvailableWorker => FsError::NoAvailableWorker(de.into_string()),
             ErrorKind::NoLocalPath => FsError::NoLocalPath(de.into_string()),
             ErrorKind::JobNotFound => FsError::JobNotFound(de.into_string()),
+            ErrorKind::TransferOverloaded => FsError::TransferOverloaded(de.into_string()),
+            ErrorKind::TransferStoreUnavailable => {
+                FsError::TransferStoreUnavailable(de.into_string())
+            }
+            ErrorKind::TransferAlreadyRunning => FsError::TransferAlreadyRunning(de.into_string()),
+            ErrorKind::TransferTargetConflict => FsError::TransferTargetConflict(de.into_string()),
             ErrorKind::Common => FsError::Common(de.into_string()),
         }
     }
@@ -729,5 +787,49 @@ mod tests {
         let decoded = FsError::decode(bytes);
         assert!(matches!(decoded.kind(), ErrorKind::NoAvailableWorker));
         assert!(matches!(decoded, FsError::NoAvailableWorker(_)));
+    }
+
+    #[test]
+    pub fn transfer_overloaded_round_trip_test() {
+        let error = FsError::transfer_overloaded("transfer task report queue is full");
+
+        assert!(matches!(error.kind(), ErrorKind::TransferOverloaded));
+        let bytes = error.encode();
+        let decoded = FsError::decode(bytes);
+        assert!(matches!(decoded, FsError::TransferOverloaded(_)));
+        assert!(decoded.to_string().contains("queue is full"));
+    }
+
+    #[test]
+    pub fn transfer_store_unavailable_round_trip_test() {
+        let error = FsError::transfer_store_unavailable("mysql transfer store error");
+
+        assert!(matches!(error.kind(), ErrorKind::TransferStoreUnavailable));
+        let bytes = error.encode();
+        let decoded = FsError::decode(bytes);
+        assert!(matches!(decoded, FsError::TransferStoreUnavailable(_)));
+        assert!(decoded.to_string().contains("mysql transfer store error"));
+    }
+
+    #[test]
+    pub fn transfer_already_running_round_trip_test() {
+        let error = FsError::transfer_already_running("same job key has different command");
+
+        assert!(matches!(error.kind(), ErrorKind::TransferAlreadyRunning));
+        let bytes = error.encode();
+        let decoded = FsError::decode(bytes);
+        assert!(matches!(decoded, FsError::TransferAlreadyRunning(_)));
+        assert!(decoded.to_string().contains("different command"));
+    }
+
+    #[test]
+    pub fn transfer_target_conflict_round_trip_test() {
+        let error = FsError::transfer_target_conflict("target /a conflicts with active transfer");
+
+        assert!(matches!(error.kind(), ErrorKind::TransferTargetConflict));
+        let bytes = error.encode();
+        let decoded = FsError::decode(bytes);
+        assert!(matches!(decoded, FsError::TransferTargetConflict(_)));
+        assert!(decoded.to_string().contains("/a"));
     }
 }

--- a/curvine-common/src/fs/rpc_code.rs
+++ b/curvine-common/src/fs/rpc_code.rs
@@ -49,6 +49,8 @@ pub enum RpcCode {
     CompleteFilesBatch = 25,
     Free = 26,
     ListOptions = 27,
+    GetCvMetadataSnapshotPage = 28,
+    GetCvMetadataDeltaPage = 29,
 
     // manager interface.
     Mount = 30,
@@ -62,6 +64,15 @@ pub enum RpcCode {
     CancelJob = 37,
     ReportTask = 38,
     SubmitTask = 39,
+    SubmitTransfer = 46,
+    GetTransferStatus = 47,
+    CancelTransfer = 48,
+    ReportTransferTask = 49,
+    QueryTransferTask = 50,
+    WatchTransfer = 51,
+    ListTransfers = 52,
+    ListTransferTenants = 53,
+    RetryTransfer = 54,
     WorkerHeartbeat = 40,
     WorkerBlockReport = 41,
 

--- a/curvine-common/src/state/job.rs
+++ b/curvine-common/src/state/job.rs
@@ -247,7 +247,10 @@ pub struct TransferTaskReportInfo {
     pub attempt_id: u64,
     pub worker_id: u32,
     pub worker_session_id: String,
+    #[serde(default)]
     pub report_target: String,
+    #[serde(default)]
+    pub report_endpoints: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/curvine-common/src/state/job.rs
+++ b/curvine-common/src/state/job.rs
@@ -235,6 +235,19 @@ pub struct LoadTaskInfo {
     pub source_path: String,
     pub target_path: String,
     pub create_time: i64,
+    #[serde(default)]
+    pub source_read_plan_json: String,
+    #[serde(default)]
+    pub transfer_report: Option<TransferTaskReportInfo>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransferTaskReportInfo {
+    pub run_id: u64,
+    pub attempt_id: u64,
+    pub worker_id: u32,
+    pub worker_session_id: String,
+    pub report_target: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/curvine-common/src/state/mod.rs
+++ b/curvine-common/src/state/mod.rs
@@ -22,7 +22,7 @@ mod heartbeat_status;
 pub use self::heartbeat_status::HeartbeatStatus;
 
 mod worker_info;
-pub use self::worker_info::WorkerInfo;
+pub use self::worker_info::{TransferWorkerCapabilities, WorkerInfo};
 
 mod worker_node_tree;
 pub use self::worker_node_tree::WorkerNodeTree;
@@ -70,6 +70,9 @@ pub use self::opts::*;
 
 mod job;
 pub use self::job::*;
+
+mod transfer;
+pub use self::transfer::*;
 
 mod metrics;
 pub use self::metrics::*;

--- a/curvine-common/src/state/transfer.rs
+++ b/curvine-common/src/state/transfer.rs
@@ -68,13 +68,17 @@ pub enum TransferState {
     Completed = 6,
     Failed = 7,
     Canceled = 8,
+    PartialSuccess = 9,
 }
 
 impl TransferState {
     pub fn is_terminal(self) -> bool {
         matches!(
             self,
-            TransferState::Completed | TransferState::Failed | TransferState::Canceled
+            TransferState::Completed
+                | TransferState::Failed
+                | TransferState::Canceled
+                | TransferState::PartialSuccess
         )
     }
 
@@ -245,9 +249,21 @@ pub struct TransferTaskRecord {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TransferTaskSummary {
     pub progress: TransferProgress,
+    pub counts: TransferTaskCounts,
     pub has_task: bool,
     pub has_failed: bool,
     pub all_completed: bool,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct TransferTaskCounts {
+    pub pending: u64,
+    pub running: u64,
+    pub completed: u64,
+    pub failed: u64,
+    pub canceled: u64,
+    pub stale: u64,
+    pub completed_size: i64,
 }
 
 pub fn summarize_transfer_tasks<'a>(
@@ -259,6 +275,7 @@ pub fn summarize_transfer_tasks<'a>(
             update_time,
             ..Default::default()
         },
+        counts: TransferTaskCounts::default(),
         has_task: false,
         has_failed: false,
         all_completed: true,
@@ -273,6 +290,18 @@ pub fn summarize_transfer_tasks<'a>(
         summary.all_completed &= task.state == TransferTaskState::Completed;
         summary.progress.loaded_size += task.progress.loaded_size;
         summary.progress.total_size += task.progress.total_size;
+
+        match task.state {
+            TransferTaskState::Pending => summary.counts.pending += 1,
+            TransferTaskState::Running => summary.counts.running += 1,
+            TransferTaskState::Completed => {
+                summary.counts.completed += 1;
+                summary.counts.completed_size += task.progress.loaded_size.max(0);
+            }
+            TransferTaskState::Failed => summary.counts.failed += 1,
+            TransferTaskState::Canceled => summary.counts.canceled += 1,
+            TransferTaskState::Stale => summary.counts.stale += 1,
+        }
 
         if !task.progress.message.is_empty() {
             last_message = task.progress.message.clone();
@@ -377,6 +406,7 @@ pub struct TransferTenantSummary {
     pub completed: u64,
     pub failed: u64,
     pub canceled: u64,
+    pub partial_success: u64,
     pub total: u64,
 }
 

--- a/curvine-common/src/state/transfer.rs
+++ b/curvine-common/src/state/transfer.rs
@@ -1,0 +1,392 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use num_enum::{FromPrimitive, IntoPrimitive};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+use crate::utils::CommonUtils;
+
+pub const TRANSFER_TEMP_PATH_MARKER: &str = ".curvine-transfer-tmp-";
+
+pub fn is_transfer_temp_path(path: &str) -> bool {
+    path.contains(TRANSFER_TEMP_PATH_MARKER)
+}
+
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Hash,
+    IntoPrimitive,
+    FromPrimitive,
+    Serialize,
+    Deserialize,
+)]
+#[repr(i32)]
+pub enum TransferKind {
+    #[default]
+    Load = 1,
+    Export = 2,
+}
+
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Hash,
+    IntoPrimitive,
+    FromPrimitive,
+    Serialize,
+    Deserialize,
+)]
+#[repr(i32)]
+pub enum TransferState {
+    #[default]
+    Pending = 1,
+    Planning = 2,
+    Dispatching = 3,
+    Running = 4,
+    Canceling = 5,
+    Completed = 6,
+    Failed = 7,
+    Canceled = 8,
+}
+
+impl TransferState {
+    pub fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            TransferState::Completed | TransferState::Failed | TransferState::Canceled
+        )
+    }
+
+    pub fn is_runnable(self) -> bool {
+        matches!(
+            self,
+            TransferState::Pending
+                | TransferState::Planning
+                | TransferState::Dispatching
+                | TransferState::Running
+                | TransferState::Canceling
+        )
+    }
+
+    pub fn is_executing(self) -> bool {
+        matches!(
+            self,
+            TransferState::Planning
+                | TransferState::Dispatching
+                | TransferState::Running
+                | TransferState::Canceling
+        )
+    }
+}
+
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Hash,
+    IntoPrimitive,
+    FromPrimitive,
+    Serialize,
+    Deserialize,
+)]
+#[repr(i32)]
+pub enum TransferTaskState {
+    #[default]
+    Pending = 1,
+    Running = 2,
+    Completed = 3,
+    Failed = 4,
+    Canceled = 5,
+    Stale = 6,
+}
+
+impl TransferTaskState {
+    pub fn is_running(self) -> bool {
+        matches!(
+            self,
+            TransferTaskState::Pending | TransferTaskState::Running
+        )
+    }
+
+    pub fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            TransferTaskState::Completed
+                | TransferTaskState::Failed
+                | TransferTaskState::Canceled
+                | TransferTaskState::Stale
+        )
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TransferCommand {
+    pub kind: TransferKind,
+    pub source_path: String,
+    pub target_path: String,
+    pub client_request_id: String,
+    pub submitter: String,
+    pub tenant: String,
+    pub options: BTreeMap<String, String>,
+}
+
+impl TransferCommand {
+    pub const OVERWRITE_OPTION: &'static str = "overwrite";
+
+    pub fn job_key(&self) -> String {
+        format!("{:?}:{}:{}", self.kind, self.source_path, self.target_path)
+    }
+
+    pub fn default_client_request_id(
+        kind: TransferKind,
+        source_path: impl AsRef<str>,
+        target_path: impl AsRef<str>,
+    ) -> String {
+        CommonUtils::create_job_id(format!(
+            "{:?}:{}:{}",
+            kind,
+            source_path.as_ref(),
+            target_path.as_ref()
+        ))
+    }
+
+    pub fn overwrite(&self) -> bool {
+        self.options
+            .get(Self::OVERWRITE_OPTION)
+            .and_then(|value| value.parse::<bool>().ok())
+            .unwrap_or(true)
+    }
+
+    pub fn set_overwrite(&mut self, overwrite: bool) {
+        self.options
+            .insert(Self::OVERWRITE_OPTION.to_string(), overwrite.to_string());
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TransferProgress {
+    pub loaded_size: i64,
+    pub total_size: i64,
+    pub update_time: i64,
+    pub message: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TransferJobRecord {
+    pub job_key: String,
+    pub job_id: String,
+    pub run_id: u64,
+    pub kind: TransferKind,
+    pub source_path: String,
+    pub target_path: String,
+    pub command_json: String,
+    pub mount_snapshot_json: String,
+    pub secret_ref_json: String,
+    pub cluster_snapshot_version: u64,
+    pub cv_metadata_epoch: Option<u64>,
+    pub state: TransferState,
+    pub owner: String,
+    pub lease_epoch: u64,
+    pub lease_expire_at: i64,
+    pub cancel_requested: bool,
+    pub summary: TransferProgress,
+    pub client_request_id: String,
+    pub submitter: String,
+    pub tenant: String,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TransferTaskRecord {
+    pub job_id: String,
+    pub run_id: u64,
+    pub task_id: String,
+    pub attempt_id: u64,
+    pub source_path: String,
+    pub target_path: String,
+    pub worker_id: u32,
+    pub worker_session_id: String,
+    pub source_read_plan_json: String,
+    pub report_target_json: String,
+    pub state: TransferTaskState,
+    pub progress: TransferProgress,
+    pub retry_count: u32,
+    pub attempt_started_at: i64,
+    pub last_report_at: i64,
+    pub stale_deadline_at: i64,
+    pub updated_at: i64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TransferTaskSummary {
+    pub progress: TransferProgress,
+    pub has_task: bool,
+    pub has_failed: bool,
+    pub all_completed: bool,
+}
+
+pub fn summarize_transfer_tasks<'a>(
+    tasks: impl IntoIterator<Item = &'a TransferTaskRecord>,
+    update_time: i64,
+) -> TransferTaskSummary {
+    let mut summary = TransferTaskSummary {
+        progress: TransferProgress {
+            update_time,
+            ..Default::default()
+        },
+        has_task: false,
+        has_failed: false,
+        all_completed: true,
+    };
+    let mut failed_count = 0;
+    let mut first_error = String::new();
+    let mut last_message = String::new();
+
+    for task in tasks {
+        summary.has_task = true;
+        summary.has_failed |= task.state == TransferTaskState::Failed;
+        summary.all_completed &= task.state == TransferTaskState::Completed;
+        summary.progress.loaded_size += task.progress.loaded_size;
+        summary.progress.total_size += task.progress.total_size;
+
+        if !task.progress.message.is_empty() {
+            last_message = task.progress.message.clone();
+        }
+        if task.state == TransferTaskState::Failed {
+            failed_count += 1;
+            if first_error.is_empty() && !task.progress.message.is_empty() {
+                first_error = task.progress.message.clone();
+            }
+        }
+    }
+
+    if failed_count > 0 {
+        if first_error.is_empty() {
+            first_error = "transfer task failed".to_string();
+        }
+        summary.progress.message = format!(
+            "{} transfer task(s) failed: {}",
+            failed_count,
+            normalize_summary_message(&first_error)
+        );
+    } else {
+        summary.progress.message = last_message;
+    }
+    summary
+}
+
+fn normalize_summary_message(message: &str) -> String {
+    message
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .chars()
+        .take(512)
+        .collect()
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TransferLease {
+    pub job_id: String,
+    pub run_id: u64,
+    pub owner: String,
+    pub lease_epoch: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TransferStateUpdate {
+    pub job_id: String,
+    pub run_id: u64,
+    pub owner: String,
+    pub lease_epoch: u64,
+    pub from_states: Vec<TransferState>,
+    pub to_state: TransferState,
+    pub message: String,
+    pub now_ms: i64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TaskAttemptStart {
+    pub job_id: String,
+    pub run_id: u64,
+    pub owner: String,
+    pub lease_epoch: u64,
+    pub task_id: String,
+    pub attempt_id: u64,
+    pub worker_id: u32,
+    pub worker_session_id: String,
+    pub report_target_json: String,
+    pub now_ms: i64,
+    pub stale_deadline_at: i64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TransferTaskReport {
+    pub job_id: String,
+    pub run_id: u64,
+    pub task_id: String,
+    pub attempt_id: u64,
+    pub worker_id: u32,
+    pub worker_session_id: String,
+    pub state: TransferTaskState,
+    pub progress: TransferProgress,
+    pub now_ms: i64,
+    pub stale_deadline_at: i64,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct TransferListFilter {
+    pub kind: Option<TransferKind>,
+    pub state: Option<TransferState>,
+    pub submitter: Option<String>,
+    pub tenant: Option<String>,
+    pub limit: usize,
+    pub offset: usize,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct TransferTenantSummary {
+    pub tenant: String,
+    pub pending: u64,
+    pub executing: u64,
+    pub completed: u64,
+    pub failed: u64,
+    pub canceled: u64,
+    pub total: u64,
+}
+
+impl TransferTenantSummary {
+    pub fn active(&self) -> u64 {
+        self.pending.saturating_add(self.executing)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StaleTaskAttempt {
+    pub task: TransferTaskRecord,
+}

--- a/curvine-common/src/state/worker_address.rs
+++ b/curvine-common/src/state/worker_address.rs
@@ -31,6 +31,12 @@ impl WorkerAddress {
         self.hostname == hostname
     }
 
+    pub fn same_endpoint(&self, other: &Self) -> bool {
+        self.hostname == other.hostname
+            && self.ip_addr == other.ip_addr
+            && self.rpc_port == other.rpc_port
+    }
+
     pub fn connect_addr(&self) -> String {
         format!("{}:{}", self.ip_addr, self.rpc_port)
     }

--- a/curvine-common/src/state/worker_info.rs
+++ b/curvine-common/src/state/worker_info.rs
@@ -18,6 +18,36 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct TransferWorkerCapabilities {
+    pub task_submit: bool,
+    pub report_target: bool,
+    pub query_task: bool,
+    pub attempt_safe_output: bool,
+    pub source_read_plan: bool,
+}
+
+impl TransferWorkerCapabilities {
+    pub fn current() -> Self {
+        Self {
+            task_submit: true,
+            report_target: true,
+            query_task: true,
+            attempt_safe_output: true,
+            source_read_plan: true,
+        }
+    }
+
+    pub fn supports_transfer(&self) -> bool {
+        self.task_submit
+            && self.report_target
+            && self.query_task
+            && self.attempt_safe_output
+            && self.source_read_plan
+    }
+}
+
 // Describes a worker, which is the basic unit of master management worker.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
@@ -34,6 +64,8 @@ pub struct WorkerInfo {
     pub block_num: i64,
     pub storage_map: HashMap<String, StorageInfo>,
     pub status: WorkerStatus,
+    pub worker_session_id: String,
+    pub transfer_capabilities: TransferWorkerCapabilities,
 }
 
 impl WorkerInfo {
@@ -54,6 +86,8 @@ impl WorkerInfo {
             last_update: LocalTime::mills(),
             storage_map: Default::default(),
             status: WorkerStatus::Live,
+            worker_session_id: String::new(),
+            transfer_capabilities: TransferWorkerCapabilities::default(),
         }
     }
 
@@ -126,6 +160,8 @@ impl Default for WorkerInfo {
             block_num: 0,
             storage_map: Default::default(),
             status: WorkerStatus::Live,
+            worker_session_id: String::new(),
+            transfer_capabilities: TransferWorkerCapabilities::default(),
         }
     }
 }

--- a/curvine-common/src/utils/proto_utils.rs
+++ b/curvine-common/src/utils/proto_utils.rs
@@ -346,6 +346,12 @@ impl ProtoUtils {
             last_update: src.last_update,
             reserved_bytes: src.reserved_bytes,
             weight: Some(src.weight),
+            worker_session_id: Some(src.worker_session_id),
+            transfer_task_submit: Some(src.transfer_capabilities.task_submit),
+            transfer_report_target: Some(src.transfer_capabilities.report_target),
+            transfer_query_task: Some(src.transfer_capabilities.query_task),
+            transfer_attempt_safe_output: Some(src.transfer_capabilities.attempt_safe_output),
+            transfer_source_read_plan: Some(src.transfer_capabilities.source_read_plan),
             storage_map: Default::default(),
         };
 
@@ -387,6 +393,14 @@ impl ProtoUtils {
                 non_fs_used: info.non_fs_used,
                 reserved_bytes: info.reserved_bytes,
                 weight: info.weight.unwrap_or_else(WorkerInfo::default_weight),
+                worker_session_id: info.worker_session_id.unwrap_or_default(),
+                transfer_capabilities: TransferWorkerCapabilities {
+                    task_submit: info.transfer_task_submit.unwrap_or(false),
+                    report_target: info.transfer_report_target.unwrap_or(false),
+                    query_task: info.transfer_query_task.unwrap_or(false),
+                    attempt_safe_output: info.transfer_attempt_safe_output.unwrap_or(false),
+                    source_read_plan: info.transfer_source_read_plan.unwrap_or(false),
+                },
                 ..Default::default()
             };
             for (k, v) in info.storage_map {

--- a/curvine-docker/deploy/Dockerfile_rocky9
+++ b/curvine-docker/deploy/Dockerfile_rocky9
@@ -207,7 +207,9 @@ WORKDIR $APP_HOME
 # 8997: Worker RPC
 # 9000: Master Web UI
 # 9001: Worker Web UI / Master Web1
-EXPOSE 8995 8996 8997 9000 9001
+# 9010: Transfer RPC
+# 9011: Transfer Web UI
+EXPOSE 8995 8996 8997 9000 9001 9010 9011
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["master", "start"]

--- a/curvine-docker/deploy/Dockerfile_ubuntu24
+++ b/curvine-docker/deploy/Dockerfile_ubuntu24
@@ -116,7 +116,7 @@ RUN ARCH=$(uname -m) && \
 
 ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 
-# Runtime image only needs master/worker runtime binaries, CLI/FUSE helpers, and WebUI.
+# Runtime image contains master, worker and transfer service binaries, CLI/FUSE helpers, and WebUI.
 # Override with --build-arg BUILD_ARGS="..." when building SDKs, WebUI, tests, or alternate UFS sets.
 ARG BUILD_ARGS="-p server -p client -p cli -p fuse -p web --skip-java-sdk --skip-python-sdk --ufs opendal-s3 --ufs opendal-oss --ufs opendal-azblob --ufs opendal-gcs --ufs opendal-hdfs --ufs opendal-webhdfs --ufs oss-hdfs"
 
@@ -277,7 +277,9 @@ WORKDIR $APP_HOME
 # 8997: Worker RPC
 # 9000: Master Web UI
 # 9001: Worker Web UI / Master Web1
-EXPOSE 8995 8996 8997 9000 9001
+# 9010: Transfer RPC
+# 9011: Transfer Web UI
+EXPOSE 8995 8996 8997 9000 9001 9010 9011
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["master", "start"]

--- a/curvine-docker/deploy/entrypoint.sh
+++ b/curvine-docker/deploy/entrypoint.sh
@@ -46,7 +46,7 @@ if is_fluid_mode "${1:-}"; then
 fi
 
 # Start the curvine service process
-# Service type: master, worker
+# Service type: master, worker, transfer
 SERVER_TYPE=${1:-master}
 
 # Operation type: start, stop, restart
@@ -178,7 +178,7 @@ restart_service() {
 set_hosts
 
 case "$SERVER_TYPE" in
-  (master|worker)
+  (master|worker|transfer)
     case "$ACTION_TYPE" in
       start)
         start_service "$SERVER_TYPE"

--- a/curvine-docker/deploy/spdk/curvine-cluster-spdk.toml
+++ b/curvine-docker/deploy/spdk/curvine-cluster-spdk.toml
@@ -62,6 +62,9 @@ subnqn = "nqn.2026-05.curvine:cnode1"
 [client]
 short_circuit = false
 
+[transfer]
+enabled = true
+
 # fuse configuration  
 [fuse]  
   

--- a/curvine-docker/deploy/spdk/docker-compose.yml
+++ b/curvine-docker/deploy/spdk/docker-compose.yml
@@ -74,3 +74,23 @@ services:
         condition: service_healthy
     command: ["worker", "start"]
     restart: unless-stopped
+
+  # ============================================================
+  # Curvine Transfer
+  # ============================================================
+  transfer:
+    build:
+      context: ../../..
+      dockerfile: curvine-docker/deploy/Dockerfile_rocky9
+      args:
+        BUILD_ARGS: "${BUILD_ARGS}"
+    network_mode: "host"
+    volumes:
+      - ${CURVINE_CONF_FILE:-./curvine-cluster-spdk.toml}:/app/curvine/conf/curvine-cluster.toml
+    depends_on:
+      master:
+        condition: service_started
+      worker:
+        condition: service_started
+    command: ["transfer", "start"]
+    restart: unless-stopped

--- a/curvine-server/Cargo.toml
+++ b/curvine-server/Cargo.toml
@@ -42,6 +42,8 @@ linked-hash-map = { workspace = true }
 dashmap = { workspace = true }
 axum = { workspace = true }
 serde_json = { workspace = true }
+rusqlite = { workspace = true }
+mysql = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true }
 bytes = { workspace = true }
@@ -51,6 +53,6 @@ url = { workspace = true }
 parking_lot = { workspace = true }
 lru = { workspace = true }
 byteorder = { workspace = true }
-
 [dev-dependencies]
 curvine-fault = { workspace = true, features = ["http-client"] }
+crossbeam = { workspace = true }

--- a/curvine-server/Cargo.toml
+++ b/curvine-server/Cargo.toml
@@ -53,6 +53,6 @@ url = { workspace = true }
 parking_lot = { workspace = true }
 lru = { workspace = true }
 byteorder = { workspace = true }
+crossbeam = { workspace = true }
 [dev-dependencies]
 curvine-fault = { workspace = true, features = ["http-client"] }
-crossbeam = { workspace = true }

--- a/curvine-server/src/bin/curvine-server.rs
+++ b/curvine-server/src/bin/curvine-server.rs
@@ -16,6 +16,7 @@ use clap::Parser;
 use curvine_common::conf::ClusterConf;
 use curvine_common::version;
 use curvine_server::master::Master;
+use curvine_server::transfer::TransferServer;
 use curvine_server::worker::Worker;
 use orpc::common::{LocalTime, Utils};
 use orpc::{err_box, CommonResult};
@@ -45,6 +46,11 @@ fn main() -> CommonResult<()> {
             let worker = Worker::with_conf(conf)?;
             worker.block_on_start()?;
         }
+
+        ServiceType::Transfer => {
+            let transfer = TransferServer::with_conf(conf)?;
+            transfer.block_on_start()?;
+        }
     }
 
     Ok(())
@@ -68,6 +74,7 @@ impl ServerArgs {
         match service.as_str() {
             "master" => Ok(ServiceType::Master),
             "worker" => Ok(ServiceType::Worker),
+            "transfer" => Ok(ServiceType::Transfer),
             v => err_box!("Unsupported service type: {}", v),
         }
     }
@@ -80,4 +87,5 @@ impl ServerArgs {
 pub enum ServiceType {
     Master,
     Worker,
+    Transfer,
 }

--- a/curvine-server/src/lib.rs
+++ b/curvine-server/src/lib.rs
@@ -15,6 +15,7 @@
 pub mod common;
 pub mod master;
 pub mod test;
+pub mod transfer;
 pub mod worker;
 
 #[cfg(feature = "fault-injection")]

--- a/curvine-server/src/master/fs/master_filesystem.rs
+++ b/curvine-server/src/master/fs/master_filesystem.rs
@@ -32,8 +32,32 @@ use orpc::runtime::GroupExecutor;
 use orpc::sync::ArcRwLock;
 use orpc::{err_box, err_ext, try_option, CommonResult};
 use parking_lot::Mutex;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
+
+pub struct CvMetadataSnapshotEntry {
+    pub status: FileStatus,
+    pub blocks: Option<FileBlocks>,
+}
+
+pub struct CvMetadataSnapshotPage {
+    pub entries: Vec<CvMetadataSnapshotEntry>,
+    pub next_page_token: Option<String>,
+    pub epoch: u64,
+}
+
+pub struct CvMetadataDeltaEntry {
+    pub path: String,
+    pub entry: Option<CvMetadataSnapshotEntry>,
+}
+
+pub struct CvMetadataDeltaPage {
+    pub entries: Vec<CvMetadataDeltaEntry>,
+    pub next_page_token: Option<String>,
+    pub from_epoch: u64,
+    pub to_epoch: u64,
+    pub full_snapshot_required: bool,
+}
 
 #[derive(Clone)]
 pub struct MasterFilesystem {
@@ -54,6 +78,23 @@ pub(crate) enum BlockInodeState {
     File,
     Missing,
     NotFile,
+}
+
+fn child_snapshot_path(parent: &str, child_name: &str) -> String {
+    if parent == "/" {
+        format!("/{child_name}")
+    } else {
+        format!("{parent}/{child_name}")
+    }
+}
+
+fn snapshot_token_in_subtree(token: &str, subtree_path: &str) -> bool {
+    token == subtree_path
+        || (subtree_path != "/"
+            && token
+                .strip_prefix(subtree_path)
+                .map(|rest| rest.starts_with(PATH_SEPARATOR))
+                .unwrap_or(false))
 }
 
 struct FullBlockReportState {
@@ -686,6 +727,279 @@ impl MasterFilesystem {
         };
 
         Ok(locate_blocks)
+    }
+
+    pub fn cv_metadata_snapshot_page(
+        &self,
+        page_token: Option<String>,
+        page_size: usize,
+    ) -> FsResult<CvMetadataSnapshotPage> {
+        if page_size == 0 {
+            return err_box!("cv metadata snapshot page_size must be greater than 0");
+        }
+
+        let fs_dir = self.fs_dir.read();
+        let epoch = fs_dir.op_id.get();
+        let start_after = page_token.filter(|token| !token.is_empty());
+        let mut entries = Vec::with_capacity(page_size.saturating_add(1));
+        self.collect_cv_metadata_snapshot_page(
+            &fs_dir,
+            fs_dir.root_dir(),
+            "/",
+            start_after.as_deref(),
+            page_size.saturating_add(1),
+            &mut entries,
+        )?;
+
+        let next_page_token = if entries.len() > page_size {
+            let token = entries
+                .get(page_size.saturating_sub(1))
+                .map(|entry| entry.status.path.clone());
+            entries.truncate(page_size);
+            token
+        } else {
+            None
+        };
+
+        Ok(CvMetadataSnapshotPage {
+            entries,
+            next_page_token,
+            epoch,
+        })
+    }
+
+    pub fn cv_metadata_delta_page(
+        &self,
+        from_epoch: u64,
+        target_epoch: Option<u64>,
+        page_token: Option<String>,
+        page_size: usize,
+    ) -> FsResult<CvMetadataDeltaPage> {
+        if page_size == 0 {
+            return err_box!("cv metadata delta page_size must be greater than 0");
+        }
+
+        let fs_dir = self.fs_dir.read();
+        let current_epoch = fs_dir.op_id.get();
+        let to_epoch = target_epoch.unwrap_or(current_epoch);
+        if to_epoch > current_epoch {
+            return err_box!(
+                "cv metadata delta target_epoch {} is newer than current epoch {}",
+                to_epoch,
+                current_epoch
+            );
+        }
+        if from_epoch > to_epoch {
+            return err_box!(
+                "cv metadata delta from_epoch {} is newer than target epoch {}",
+                from_epoch,
+                to_epoch
+            );
+        }
+        if target_epoch.is_some() && to_epoch < current_epoch {
+            return Ok(CvMetadataDeltaPage {
+                entries: Vec::new(),
+                next_page_token: None,
+                from_epoch,
+                to_epoch,
+                full_snapshot_required: true,
+            });
+        }
+        if from_epoch == to_epoch {
+            return Ok(CvMetadataDeltaPage {
+                entries: Vec::new(),
+                next_page_token: None,
+                from_epoch,
+                to_epoch,
+                full_snapshot_required: false,
+            });
+        }
+
+        let Some(changes) = fs_dir
+            .journal_writer
+            .cv_metadata_changes_since(from_epoch, to_epoch)
+        else {
+            return Ok(CvMetadataDeltaPage {
+                entries: Vec::new(),
+                next_page_token: None,
+                from_epoch,
+                to_epoch,
+                full_snapshot_required: true,
+            });
+        };
+
+        let mut changed_paths = BTreeMap::new();
+        for change in changes {
+            changed_paths
+                .entry(change.path)
+                .and_modify(|include_subtree| *include_subtree |= change.include_subtree)
+                .or_insert(change.include_subtree);
+        }
+
+        let mut delta_entries = BTreeMap::new();
+        for (path, include_subtree) in changed_paths {
+            if include_subtree {
+                self.collect_cv_metadata_delta_subtree(&fs_dir, &path, &mut delta_entries)?;
+            } else {
+                let entry = self.cv_metadata_entry_for_path(&fs_dir, &path)?;
+                delta_entries.insert(path, entry);
+            }
+        }
+
+        let start_after = page_token.filter(|token| !token.is_empty());
+        let mut page_entries = Vec::with_capacity(page_size.saturating_add(1));
+        for (path, entry) in delta_entries {
+            if start_after
+                .as_deref()
+                .map(|token| path.as_str() <= token)
+                .unwrap_or(false)
+            {
+                continue;
+            }
+            page_entries.push(CvMetadataDeltaEntry { path, entry });
+            if page_entries.len() > page_size {
+                break;
+            }
+        }
+
+        let next_page_token = if page_entries.len() > page_size {
+            let token = page_entries
+                .get(page_size.saturating_sub(1))
+                .map(|entry| entry.path.clone());
+            page_entries.truncate(page_size);
+            token
+        } else {
+            None
+        };
+
+        Ok(CvMetadataDeltaPage {
+            entries: page_entries,
+            next_page_token,
+            from_epoch,
+            to_epoch,
+            full_snapshot_required: false,
+        })
+    }
+
+    fn collect_cv_metadata_delta_subtree(
+        &self,
+        fs_dir: &FsDir,
+        path: &str,
+        entries: &mut BTreeMap<String, Option<CvMetadataSnapshotEntry>>,
+    ) -> FsResult<()> {
+        let Some(entry) = self.cv_metadata_entry_for_path(fs_dir, path)? else {
+            entries.insert(path.to_string(), None);
+            return Ok(());
+        };
+
+        let is_dir = entry.status.is_dir;
+        entries.insert(path.to_string(), Some(entry));
+        if !is_dir {
+            return Ok(());
+        }
+
+        let inp = Self::resolve_path(fs_dir, path)?;
+        let Some(inode) = inp.get_last_inode() else {
+            return Ok(());
+        };
+        let resolved = self.resolve_snapshot_inode(fs_dir, &inode)?;
+        if let InodeView::Dir(dir) = resolved {
+            for child in dir.children_iter() {
+                let child_path = child_snapshot_path(path, child.name());
+                self.collect_cv_metadata_delta_subtree(fs_dir, &child_path, entries)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn cv_metadata_entry_for_path(
+        &self,
+        fs_dir: &FsDir,
+        path: &str,
+    ) -> FsResult<Option<CvMetadataSnapshotEntry>> {
+        let inp = match Self::resolve_path(fs_dir, path) {
+            Ok(inp) => inp,
+            Err(_) => return Ok(None),
+        };
+        let Some(inode) = inp.get_last_inode() else {
+            return Ok(None);
+        };
+        let resolved = self.resolve_snapshot_inode(fs_dir, &inode)?;
+        let status = resolved.to_file_status(path)?;
+        let blocks = if let Ok(file) = resolved.as_file_ref() {
+            Some(FileBlocks::new(
+                status.clone(),
+                self.get_block_locs(path, fs_dir, file)?,
+            ))
+        } else {
+            None
+        };
+        Ok(Some(CvMetadataSnapshotEntry { status, blocks }))
+    }
+
+    fn collect_cv_metadata_snapshot_page(
+        &self,
+        fs_dir: &FsDir,
+        inode: &InodeView,
+        path: &str,
+        start_after: Option<&str>,
+        limit: usize,
+        entries: &mut Vec<CvMetadataSnapshotEntry>,
+    ) -> FsResult<()> {
+        if entries.len() >= limit {
+            return Ok(());
+        }
+        if let Some(token) = start_after {
+            if path != "/" && token > path && !snapshot_token_in_subtree(token, path) {
+                return Ok(());
+            }
+        }
+
+        let resolved = self.resolve_snapshot_inode(fs_dir, inode)?;
+        if start_after.map(|token| path > token).unwrap_or(true) {
+            let status = resolved.to_file_status(path)?;
+            let blocks = if let Ok(file) = resolved.as_file_ref() {
+                Some(FileBlocks::new(
+                    status.clone(),
+                    self.get_block_locs(path, fs_dir, file)?,
+                ))
+            } else {
+                None
+            };
+            entries.push(CvMetadataSnapshotEntry { status, blocks });
+            if entries.len() >= limit {
+                return Ok(());
+            }
+        }
+
+        if let InodeView::Dir(dir) = resolved {
+            for child in dir.children_iter() {
+                let child_path = child_snapshot_path(path, child.name());
+                self.collect_cv_metadata_snapshot_page(
+                    fs_dir,
+                    child,
+                    &child_path,
+                    start_after,
+                    limit,
+                    entries,
+                )?;
+                if entries.len() >= limit {
+                    return Ok(());
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn resolve_snapshot_inode(&self, fs_dir: &FsDir, inode: &InodeView) -> FsResult<InodeView> {
+        if let InodeView::FileEntry(entry) = inode {
+            return fs_dir
+                .store
+                .get_inode(entry.id, Some(&entry.name))?
+                .ok_or_else(|| FsError::file_not_found(entry.name.clone()));
+        }
+        Ok(inode.clone())
     }
 
     pub fn master_info(&self) -> FsResult<MasterInfo> {

--- a/curvine-server/src/master/fs/state/worker_map.rs
+++ b/curvine-server/src/master/fs/state/worker_map.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use curvine_common::state::{StorageInfo, WorkerAddress, WorkerInfo, WorkerStatus};
+use curvine_common::state::{
+    StorageInfo, TransferWorkerCapabilities, WorkerAddress, WorkerInfo, WorkerStatus,
+};
 use curvine_common::FsResult;
 use indexmap::IndexMap;
 use log::{error, info, warn};
@@ -43,6 +45,30 @@ impl WorkerMap {
         self.lost_workers.swap_remove(&addr.worker_id);
     }
 
+    pub fn remove_same_endpoint(&mut self, addr: &WorkerAddress) -> Vec<WorkerInfo> {
+        let stale_worker_ids: Vec<u32> = self
+            .workers
+            .iter()
+            .filter_map(|(worker_id, worker)| {
+                if *worker_id != addr.worker_id && worker.address.same_endpoint(addr) {
+                    Some(*worker_id)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        let mut removed = Vec::with_capacity(stale_worker_ids.len());
+        for worker_id in stale_worker_ids {
+            if let Some(worker) = self.workers.swap_remove(&worker_id) {
+                self.lost_workers.swap_remove(&worker_id);
+                removed.push(worker);
+            }
+        }
+
+        removed
+    }
+
     pub fn ensure_worker_id_addr(&self, addr: &WorkerAddress) -> FsResult<()> {
         if let Some(v) = self.workers.get(&addr.worker_id) {
             if v.address != *addr {
@@ -60,13 +86,24 @@ impl WorkerMap {
         &mut self,
         addr: WorkerAddress,
         weight: u32,
+        worker_session_id: String,
+        transfer_capabilities: TransferWorkerCapabilities,
         storages: Vec<StorageInfo>,
     ) -> FsResult<()> {
         self.ensure_worker_id_addr(&addr)?;
+        for stale in self.remove_same_endpoint(&addr) {
+            warn!(
+                "Remove stale worker {} before registering {} on the same endpoint",
+                stale.simple_debug(),
+                addr
+            );
+        }
 
         // Register the worker and update the storage information.
         // @todo Heartbeat may be too simple and directly covers historical data.
         let mut info = WorkerInfo::new(addr, weight);
+        info.worker_session_id = worker_session_id;
+        info.transfer_capabilities = transfer_capabilities;
         let worker_id = info.worker_id();
         for item in storages {
             info.add_storage(item);
@@ -104,7 +141,18 @@ impl WorkerMap {
 
     // Delete blocks that have been offline
     pub fn remove_offline(&mut self, id: u32) -> Option<WorkerInfo> {
-        self.remove_expired(id)
+        let worker = match self.workers.swap_remove(&id) {
+            None => {
+                warn!("Not found worker {}", id);
+                return None;
+            }
+
+            Some(v) => v,
+        };
+
+        info!("remove offline worker {}", worker.address);
+        self.lost_workers.insert(id, worker.clone());
+        Some(worker)
     }
 
     pub fn workers(&self) -> &IndexMap<u32, WorkerInfo> {

--- a/curvine-server/src/master/fs/worker_manager.rs
+++ b/curvine-server/src/master/fs/worker_manager.rs
@@ -18,7 +18,7 @@ use crate::master::fs::DeleteResult;
 use curvine_common::conf::ClusterConf;
 use curvine_common::state::{
     BlockLocation, ExtendedBlock, HeartbeatStatus, LocatedBlock, StorageInfo, StorageType,
-    WorkerAddress, WorkerCommand, WorkerInfo, WorkerStatus,
+    TransferWorkerCapabilities, WorkerAddress, WorkerCommand, WorkerInfo, WorkerStatus,
 };
 use curvine_common::FsResult;
 use log::{info, warn};
@@ -54,6 +54,8 @@ impl WorkerManager {
         status: HeartbeatStatus,
         addr: WorkerAddress,
         weight: u32,
+        worker_session_id: String,
+        transfer_capabilities: TransferWorkerCapabilities,
         storages: Vec<StorageInfo>,
     ) -> FsResult<Vec<WorkerCommand>> {
         // The cluster id must match to prevent misregistration.
@@ -71,6 +73,13 @@ impl WorkerManager {
                 // Enforce the same worker_id ↔ address rule as insert() before remove(): a Start
                 // from a conflicting address must not evict the live registration.
                 self.worker_map.ensure_worker_id_addr(&addr)?;
+                for stale in self.worker_map.remove_same_endpoint(&addr) {
+                    warn!(
+                        "Remove stale worker {} on restart endpoint {}",
+                        stale.simple_debug(),
+                        addr
+                    );
+                }
                 // Same node restarting: clear the slot so we do not treat it as ready or run
                 // Running heartbeat bookkeeping until insert() on the next Running beat.
                 self.worker_map.remove(&addr);
@@ -86,7 +95,13 @@ impl WorkerManager {
             }
         };
 
-        self.worker_map.insert(addr, weight, storages)?;
+        self.worker_map.insert(
+            addr,
+            weight,
+            worker_session_id,
+            transfer_capabilities,
+            storages,
+        )?;
         Ok(cmds)
     }
 

--- a/curvine-server/src/master/fs/worker_manager.rs
+++ b/curvine-server/src/master/fs/worker_manager.rs
@@ -48,6 +48,7 @@ impl WorkerManager {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn heartbeat(
         &mut self,
         cluster_id: &str,

--- a/curvine-server/src/master/job/job_manager.rs
+++ b/curvine-server/src/master/job/job_manager.rs
@@ -46,6 +46,7 @@ pub struct JobManager {
     job_max_files: usize,
     run_seq: Arc<AtomicCounter>,
     load_job_semaphore: Arc<Semaphore>,
+    transfer_enabled: bool,
 }
 
 impl JobManager {
@@ -68,6 +69,7 @@ impl JobManager {
             job_max_files: conf.job.job_max_files,
             run_seq: Arc::new(AtomicCounter::new(0)),
             load_job_semaphore: Arc::new(Semaphore::new(conf.job.master_max_concurrent_load_jobs)),
+            transfer_enabled: conf.transfer.enabled,
         }
     }
 
@@ -164,10 +166,21 @@ impl JobManager {
         &self.rt
     }
 
+    fn reject_legacy_submit(&self) -> FsResult<()> {
+        if self.transfer_enabled {
+            return err_box!(
+                "Legacy Master SubmitJob is disabled because transfer.enabled=true; use curvine-transfer SubmitTransfer instead"
+            );
+        }
+        Ok(())
+    }
+
     /// See `LoadJobRunner::submit_load_task` for the concurrency contract: concurrent
     /// submits for the same path while a load is running return the **existing** run’s
     /// result; the new command’s options are not applied (first submitter wins).
     pub async fn submit_load_job(&self, command: LoadJobCommand) -> FsResult<LoadJobResult> {
+        self.reject_legacy_submit()?;
+
         let source_path = Path::from_str(&command.source_path)?;
 
         // Check mount info for both UFS and CV paths. Public load jobs import
@@ -215,6 +228,8 @@ impl JobManager {
     }
 
     pub async fn submit_export_job(&self, command: LoadJobCommand) -> FsResult<LoadJobResult> {
+        self.reject_legacy_submit()?;
+
         let source_path = Path::from_str(&command.source_path)?;
 
         let mnt = if let Some(mnt) = self.mount_manager.get_mount_info(&source_path)? {

--- a/curvine-server/src/master/job/job_runner.rs
+++ b/curvine-server/src/master/job/job_runner.rs
@@ -692,6 +692,8 @@ impl LoadJobRunner {
                     source_path: source_path.clone_uri(),
                     target_path: target_path.clone_uri(),
                     create_time: LocalTime::mills() as i64,
+                    source_read_plan_json: String::new(),
+                    transfer_report: None,
                 };
                 tasks.insert(task_id.clone(), TaskDetail::new(task));
 

--- a/curvine-server/src/master/job/job_worker_client.rs
+++ b/curvine-server/src/master/job/job_worker_client.rs
@@ -41,13 +41,27 @@ impl JobWorkerClient {
         RpcUtils::proto_rpc(&self.client, self.timeout, code, header).await
     }
 
-    pub async fn submit_load_task(&self, task: LoadTaskInfo) -> FsResult<()> {
+    pub async fn submit_load_task_response(
+        &self,
+        task: LoadTaskInfo,
+    ) -> FsResult<SubmitTaskResponse> {
         let request = SubmitTaskRequest {
             task_type: JobTaskType::Load.into(),
             task_command: SerdeUtils::serialize(&task)?,
         };
 
-        let _: SubmitTaskResponse = self.rpc(RpcCode::SubmitTask, request).await?;
+        self.rpc(RpcCode::SubmitTask, request).await
+    }
+
+    pub async fn submit_load_task(&self, task: LoadTaskInfo) -> FsResult<()> {
+        let response = self.submit_load_task_response(task).await?;
+        if !response.accepted.unwrap_or(true) {
+            return Err(curvine_common::error::FsError::common(format!(
+                "Worker rejected load task {}: {}",
+                response.task_id,
+                response.reject_reason.unwrap_or_default()
+            )));
+        }
         Ok(())
     }
 
@@ -58,5 +72,24 @@ impl JobWorkerClient {
 
         let _: CancelJobResponse = self.rpc(RpcCode::CancelJob, request).await?;
         Ok(())
+    }
+
+    pub async fn query_transfer_task(
+        &self,
+        job_id: impl AsRef<str>,
+        run_id: u64,
+        task_id: impl AsRef<str>,
+        attempt_id: u64,
+        worker_session_id: impl AsRef<str>,
+    ) -> FsResult<QueryTransferTaskResponse> {
+        let request = QueryTransferTaskRequest {
+            job_id: job_id.as_ref().to_string(),
+            run_id,
+            task_id: task_id.as_ref().to_string(),
+            attempt_id,
+            worker_session_id: worker_session_id.as_ref().to_string(),
+        };
+
+        self.rpc(RpcCode::QueryTransferTask, request).await
     }
 }

--- a/curvine-server/src/master/journal/entry.rs
+++ b/curvine-server/src/master/journal/entry.rs
@@ -17,6 +17,13 @@ use crate::master::meta::BlockMeta;
 use curvine_common::state::{CommitBlock, FileLock, MountInfo, SetAttrOpts};
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Clone)]
+pub(crate) struct CvMetadataChange {
+    pub(crate) op_id: u64,
+    pub(crate) path: String,
+    pub(crate) include_subtree: bool,
+}
+
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct MkdirEntry {
     pub(crate) op_id: u64,
@@ -244,6 +251,52 @@ impl JournalEntry {
             JournalEntry::Symlink(e) => Some(e.new_inode.id),
             JournalEntry::SetLocks(e) => Some(e.ino),
             _ => None,
+        }
+    }
+
+    pub(crate) fn cv_metadata_changes(&self) -> Vec<CvMetadataChange> {
+        match self {
+            JournalEntry::Mkdir(e) => vec![CvMetadataChange::single(e.op_id, &e.path)],
+            JournalEntry::CreateFile(e) => vec![CvMetadataChange::single(e.op_id, &e.path)],
+            JournalEntry::ReopenFile(e) => vec![CvMetadataChange::single(e.op_id, &e.path)],
+            JournalEntry::OverWriteFile(e) => vec![CvMetadataChange::single(e.op_id, &e.path)],
+            JournalEntry::AddBlock(e) => vec![CvMetadataChange::single(e.op_id, &e.path)],
+            JournalEntry::CompleteFile(e) => vec![CvMetadataChange::single(e.op_id, &e.path)],
+            JournalEntry::Rename(e) => vec![
+                CvMetadataChange::subtree(e.op_id, &e.src),
+                CvMetadataChange::subtree(e.op_id, &e.dst),
+            ],
+            JournalEntry::Delete(e) => vec![CvMetadataChange::subtree(e.op_id, &e.path)],
+            JournalEntry::SetAttr(e) => vec![CvMetadataChange::single(e.op_id, &e.path)],
+            JournalEntry::Symlink(e) => vec![CvMetadataChange::single(e.op_id, &e.link)],
+            JournalEntry::Link(e) => vec![
+                CvMetadataChange::single(e.op_id, &e.src_path),
+                CvMetadataChange::single(e.op_id, &e.dst_path),
+            ],
+            JournalEntry::Free(e) => vec![CvMetadataChange::subtree(e.op_id, &e.path)],
+            JournalEntry::Mount(_)
+            | JournalEntry::UnMount(_)
+            | JournalEntry::SetLocks(_)
+            | JournalEntry::UfsApplied(_)
+            | JournalEntry::Snapshot(_) => Vec::new(),
+        }
+    }
+}
+
+impl CvMetadataChange {
+    fn single(op_id: u64, path: &str) -> Self {
+        Self {
+            op_id,
+            path: path.to_string(),
+            include_subtree: false,
+        }
+    }
+
+    fn subtree(op_id: u64, path: &str) -> Self {
+        Self {
+            op_id,
+            path: path.to_string(),
+            include_subtree: true,
         }
     }
 }

--- a/curvine-server/src/master/journal/journal_writer.rs
+++ b/curvine-server/src/master/journal/journal_writer.rs
@@ -27,6 +27,7 @@ use orpc::common::LocalTime;
 use orpc::err_box;
 use orpc::sync::channel::{BlockingChannel, BlockingReceiver, BlockingSender};
 use orpc::sync::AtomicCounter;
+use std::collections::VecDeque;
 use std::sync::Mutex;
 
 // Write metadata operation logs.
@@ -36,9 +37,17 @@ pub struct JournalWriter {
     sender: BlockingSender<JournalEntry>,
     metrics: &'static MasterMetrics,
     receiver: Option<Mutex<BlockingReceiver<JournalEntry>>>,
+    metadata_delta_log: Mutex<MetadataDeltaLog>,
 
     snapshot_entries: u64,
     entries_since_snapshot: AtomicCounter,
+}
+
+#[derive(Default)]
+struct MetadataDeltaLog {
+    capacity: usize,
+    low_watermark: u64,
+    changes: VecDeque<CvMetadataChange>,
 }
 
 impl JournalWriter {
@@ -62,6 +71,7 @@ impl JournalWriter {
             sender,
             metrics,
             receiver,
+            metadata_delta_log: Mutex::new(MetadataDeltaLog::new(conf.metadata_delta_log_capacity)),
             snapshot_entries: conf.snapshot_entries,
             entries_since_snapshot: AtomicCounter::new(0),
         })
@@ -76,10 +86,19 @@ impl JournalWriter {
 
     fn send(&self, fs_dir: &FsDir, entry: JournalEntry) -> FsResult<()> {
         if self.enable {
+            self.record_metadata_delta(&entry);
             self.send_inner(entry)?;
             self.maybe_emit_snapshot(fs_dir)?;
         }
         Ok(())
+    }
+
+    fn record_metadata_delta(&self, entry: &JournalEntry) {
+        let changes = entry.cv_metadata_changes();
+        if changes.is_empty() {
+            return;
+        }
+        self.metadata_delta_log.lock().unwrap().push(changes);
     }
 
     fn maybe_emit_snapshot(&self, fs_dir: &FsDir) -> FsResult<()> {
@@ -349,5 +368,50 @@ impl JournalWriter {
             entries.push(v);
         }
         entries
+    }
+
+    pub(crate) fn cv_metadata_changes_since(
+        &self,
+        from_epoch: u64,
+        to_epoch: u64,
+    ) -> Option<Vec<CvMetadataChange>> {
+        let log = self.metadata_delta_log.lock().unwrap();
+        if from_epoch < log.low_watermark {
+            return None;
+        }
+        Some(
+            log.changes
+                .iter()
+                .filter(|change| change.op_id > from_epoch && change.op_id <= to_epoch)
+                .cloned()
+                .collect(),
+        )
+    }
+}
+
+impl MetadataDeltaLog {
+    fn new(capacity: usize) -> Self {
+        Self {
+            capacity,
+            low_watermark: 0,
+            changes: VecDeque::with_capacity(capacity.min(1024)),
+        }
+    }
+
+    fn push(&mut self, changes: Vec<CvMetadataChange>) {
+        if self.capacity == 0 {
+            if let Some(max_op_id) = changes.iter().map(|change| change.op_id).max() {
+                self.low_watermark = self.low_watermark.max(max_op_id);
+            }
+            return;
+        }
+        for change in changes {
+            self.changes.push_back(change);
+            while self.changes.len() > self.capacity {
+                if let Some(evicted) = self.changes.pop_front() {
+                    self.low_watermark = self.low_watermark.max(evicted.op_id);
+                }
+            }
+        }
     }
 }

--- a/curvine-server/src/master/journal/ufs_loader.rs
+++ b/curvine-server/src/master/journal/ufs_loader.rs
@@ -20,7 +20,7 @@ use curvine_client::unified::MountValue;
 use curvine_common::conf::JournalConf;
 use curvine_common::error::FsError;
 use curvine_common::fs::{FileSystem, Path};
-use curvine_common::state::{JobTaskState, LoadJobCommand};
+use curvine_common::state::{is_transfer_temp_path, JobTaskState, LoadJobCommand};
 use curvine_common::FsResult;
 use log::{info, warn};
 use orpc::common::DurationUnit;
@@ -138,6 +138,9 @@ impl UfsLoader {
         if !e.file.is_complete() || e.file.ufs_only() {
             return Ok(());
         }
+        if is_transfer_temp_path(&e.path) {
+            return Ok(());
+        }
 
         let path = Path::from_str(&e.path)?;
         if let Some((_, mnt)) = self.get_mnt(&path)? {
@@ -149,6 +152,10 @@ impl UfsLoader {
     }
 
     pub async fn rename(&self, e: &RenameEntry) -> CommonResult<()> {
+        if is_transfer_temp_path(&e.src) || is_transfer_temp_path(&e.dst) {
+            return Ok(());
+        }
+
         let src = Path::from_str(&e.src)?;
         let dst = Path::from_str(&e.dst)?;
         if let Some((src_ufs_path, mnt)) = self.get_mnt(&src)? {

--- a/curvine-server/src/master/master_handler.rs
+++ b/curvine-server/src/master/master_handler.rs
@@ -33,8 +33,10 @@ use orpc::err_box;
 use orpc::handler::MessageHandler;
 use orpc::io::net::ConnState;
 use orpc::message::Message;
-use orpc::runtime::Runtime;
+use orpc::runtime::{GroupExecutor, Runtime};
+use std::panic::{self, AssertUnwindSafe};
 use std::sync::Arc;
+use tokio::sync::oneshot;
 
 pub struct MasterHandler {
     pub(crate) fs: MasterFilesystem,
@@ -44,6 +46,11 @@ pub struct MasterHandler {
     pub(crate) conn_state: Option<ConnState>,
     pub(crate) job_handler: JobHandler,
     pub(crate) mount_manager: Arc<MountManager>,
+    pub(crate) heartbeat_rpc_executor: Arc<GroupExecutor>,
+    pub(crate) block_report_rpc_executor: Arc<GroupExecutor>,
+    pub(crate) control_rpc_executor: Arc<GroupExecutor>,
+    pub(crate) list_rpc_executor: Arc<GroupExecutor>,
+    pub(crate) get_block_locations_rpc_executor: Arc<GroupExecutor>,
     pub(crate) replication_handler: Option<MasterReplicationHandler>,
     pub(crate) actor_rt: Arc<Runtime>,
 }
@@ -57,6 +64,11 @@ impl MasterHandler {
         conn_state: Option<ConnState>,
         mount_manager: Arc<MountManager>,
         job_handler: JobHandler,
+        heartbeat_rpc_executor: Arc<GroupExecutor>,
+        block_report_rpc_executor: Arc<GroupExecutor>,
+        control_rpc_executor: Arc<GroupExecutor>,
+        list_rpc_executor: Arc<GroupExecutor>,
+        get_block_locations_rpc_executor: Arc<GroupExecutor>,
         replication_manager: Arc<MasterReplicationManager>,
         actor_rt: Arc<Runtime>,
         metrics: &'static MasterMetrics,
@@ -69,6 +81,11 @@ impl MasterHandler {
             conn_state,
             mount_manager,
             job_handler,
+            heartbeat_rpc_executor,
+            block_report_rpc_executor,
+            control_rpc_executor,
+            list_rpc_executor,
+            get_block_locations_rpc_executor,
             replication_handler: Some(MasterReplicationHandler::new(replication_manager)),
             actor_rt,
         }
@@ -472,6 +489,14 @@ impl MasterHandler {
             status,
             address,
             weight,
+            header.worker_session_id.unwrap_or_default(),
+            curvine_common::state::TransferWorkerCapabilities {
+                task_submit: header.transfer_task_submit.unwrap_or(false),
+                report_target: header.transfer_report_target.unwrap_or(false),
+                query_task: header.transfer_query_task.unwrap_or(false),
+                attempt_safe_output: header.transfer_attempt_safe_output.unwrap_or(false),
+                source_read_plan: header.transfer_source_read_plan.unwrap_or(false),
+            },
             ProtoUtils::storage_info_list_from_pb(header.storages),
         )?;
         Ok(cmds)
@@ -729,6 +754,173 @@ impl MasterHandler {
                 .observe(used_us as f64);
         };
     }
+
+    async fn run_master_rpc_task<T, F>(executor: Arc<GroupExecutor>, task: F) -> FsResult<T>
+    where
+        T: Send + 'static,
+        F: FnOnce() -> FsResult<T> + Send + 'static,
+    {
+        let (tx, rx) = oneshot::channel();
+        executor.try_spawn(move || {
+            let res = panic::catch_unwind(AssertUnwindSafe(task))
+                .unwrap_or_else(|_| err_box!("master rpc lane task panicked"));
+            let _ = tx.send(res);
+        })?;
+        rx.await?
+    }
+
+    async fn async_get_block_locations(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+        let req: GetBlockLocationsRequest = ctx.parse_header()?;
+        ctx.set_audit(Some(req.path.to_string()), None);
+        let fs = self.fs.clone();
+        let blocks =
+            Self::run_master_rpc_task(self.get_block_locations_rpc_executor.clone(), move || {
+                Self::process_get_block_locations(fs, req.path)
+            })
+            .await?;
+        let rep_header = GetBlockLocationsResponse {
+            blocks: ProtoUtils::file_blocks_to_pb(blocks),
+        };
+        ctx.response(rep_header)
+    }
+
+    async fn async_get_master_info(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+        let _: GetMasterInfoRequest = ctx.parse_header()?;
+        let fs = self.fs.clone();
+        let info = Self::run_master_rpc_task(self.control_rpc_executor.clone(), move || {
+            Self::process_get_master_info(fs)
+        })
+        .await?;
+        let rep_header = ProtoUtils::master_info_to_pb(info);
+        ctx.response(rep_header)
+    }
+
+    async fn async_get_cv_metadata_snapshot_page(
+        &self,
+        ctx: &mut RpcContext<'_>,
+    ) -> FsResult<Message> {
+        let req: GetCvMetadataSnapshotPageRequest = ctx.parse_header()?;
+        ctx.set_audit(Some("cv-metadata-snapshot".to_string()), None);
+        let fs = self.fs.clone();
+        let rep_header = Self::run_master_rpc_task(self.control_rpc_executor.clone(), move || {
+            let page = fs.cv_metadata_snapshot_page(
+                req.page_token,
+                req.page_size.unwrap_or(10_000) as usize,
+            )?;
+            Ok(GetCvMetadataSnapshotPageResponse {
+                entries: page
+                    .entries
+                    .into_iter()
+                    .map(|entry| CvMetadataSnapshotEntryProto {
+                        status: ProtoUtils::file_status_to_pb(entry.status),
+                        blocks: entry.blocks.map(ProtoUtils::file_blocks_to_pb),
+                    })
+                    .collect(),
+                next_page_token: page.next_page_token,
+                epoch: page.epoch,
+            })
+        })
+        .await?;
+        ctx.response(rep_header)
+    }
+
+    async fn async_get_cv_metadata_delta_page(
+        &self,
+        ctx: &mut RpcContext<'_>,
+    ) -> FsResult<Message> {
+        let req: GetCvMetadataDeltaPageRequest = ctx.parse_header()?;
+        ctx.set_audit(Some("cv-metadata-delta".to_string()), None);
+        let fs = self.fs.clone();
+        let rep_header = Self::run_master_rpc_task(self.control_rpc_executor.clone(), move || {
+            let page = fs.cv_metadata_delta_page(
+                req.from_epoch,
+                req.target_epoch,
+                req.page_token,
+                req.page_size.unwrap_or(10_000) as usize,
+            )?;
+            Ok(GetCvMetadataDeltaPageResponse {
+                entries: page
+                    .entries
+                    .into_iter()
+                    .map(|entry| CvMetadataDeltaEntryProto {
+                        path: entry.path,
+                        entry: entry.entry.map(|entry| CvMetadataSnapshotEntryProto {
+                            status: ProtoUtils::file_status_to_pb(entry.status),
+                            blocks: entry.blocks.map(ProtoUtils::file_blocks_to_pb),
+                        }),
+                    })
+                    .collect(),
+                next_page_token: page.next_page_token,
+                from_epoch: page.from_epoch,
+                to_epoch: page.to_epoch,
+                full_snapshot_required: page.full_snapshot_required,
+            })
+        })
+        .await?;
+        ctx.response(rep_header)
+    }
+
+    async fn async_list_status(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+        let header: ListStatusRequest = ctx.parse_header()?;
+        ctx.set_audit(Some(header.path.to_string()), None);
+        let fs = self.fs.clone();
+        let list = Self::run_master_rpc_task(self.list_rpc_executor.clone(), move || {
+            Self::process_list_status(fs, header.path)
+        })
+        .await?;
+        let statuses = list
+            .into_iter()
+            .map(ProtoUtils::file_status_to_pb)
+            .collect();
+        ctx.response(ListStatusResponse { statuses })
+    }
+
+    async fn async_list_options(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+        let header: ListOptionsRequest = ctx.parse_header()?;
+        if header.options.limit.unwrap_or(0) < 0 {
+            return err_box!("list options limit must be greater than 0");
+        }
+        let opts = ProtoUtils::list_options_from_pb(header.options);
+        let audit_path = format!("{}[{}]", header.path, opts);
+        ctx.set_audit(Some(audit_path), None);
+        let fs = self.fs.clone();
+        let list = Self::run_master_rpc_task(self.list_rpc_executor.clone(), move || {
+            Self::process_list_options(fs, header.path, opts)
+        })
+        .await?;
+        let statuses = list
+            .into_iter()
+            .map(ProtoUtils::file_status_to_pb)
+            .collect();
+        ctx.response(ListOptionsResponse { statuses })
+    }
+
+    async fn async_worker_heartbeat(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+        let header: WorkerHeartbeatRequest = ctx.parse_header()?;
+        let fs = self.fs.clone();
+        let cmds = Self::run_master_rpc_task(self.heartbeat_rpc_executor.clone(), move || {
+            Self::process_worker_heartbeat(fs, header)
+        })
+        .await?;
+        let rep_header = WorkerHeartbeatResponse {
+            cmds: ProtoUtils::worker_cmd_to_pb(cmds),
+        };
+        ctx.response(rep_header)
+    }
+
+    async fn async_worker_block_report(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+        let header: BlockReportListRequest = ctx.parse_header()?;
+        let fs = self.fs.clone();
+        let replication_handler = self.replication_handler.clone();
+        let cmds = Self::run_master_rpc_task(self.block_report_rpc_executor.clone(), move || {
+            Self::process_block_report(fs, replication_handler, header)
+        })
+        .await?;
+        let rep_header = BlockReportListResponse {
+            cmds: ProtoUtils::worker_cmd_to_pb(cmds),
+        };
+        ctx.response(rep_header)
+    }
 }
 
 impl MessageHandler for MasterHandler {
@@ -738,7 +930,18 @@ impl MessageHandler for MasterHandler {
         let code = RpcCode::from(msg.code());
         !matches!(
             code,
-            RpcCode::SubmitJob | RpcCode::GetJobStatus | RpcCode::CancelJob | RpcCode::ReportTask
+            RpcCode::SubmitJob
+                | RpcCode::GetJobStatus
+                | RpcCode::CancelJob
+                | RpcCode::ReportTask
+                | RpcCode::GetBlockLocations
+                | RpcCode::GetMasterInfo
+                | RpcCode::GetCvMetadataSnapshotPage
+                | RpcCode::GetCvMetadataDeltaPage
+                | RpcCode::ListStatus
+                | RpcCode::ListOptions
+                | RpcCode::WorkerHeartbeat
+                | RpcCode::WorkerBlockReport
         )
     }
 
@@ -848,6 +1051,16 @@ impl MessageHandler for MasterHandler {
                 RpcCode::GetJobStatus => self.job_handler.get_load_status(ctx),
                 RpcCode::CancelJob => self.job_handler.cancel_job(ctx).await,
                 RpcCode::ReportTask => self.job_handler.task_report(ctx),
+                RpcCode::GetBlockLocations => self.async_get_block_locations(ctx).await,
+                RpcCode::GetMasterInfo => self.async_get_master_info(ctx).await,
+                RpcCode::GetCvMetadataSnapshotPage => {
+                    self.async_get_cv_metadata_snapshot_page(ctx).await
+                }
+                RpcCode::GetCvMetadataDeltaPage => self.async_get_cv_metadata_delta_page(ctx).await,
+                RpcCode::ListStatus => self.async_list_status(ctx).await,
+                RpcCode::ListOptions => self.async_list_options(ctx).await,
+                RpcCode::WorkerHeartbeat => self.async_worker_heartbeat(ctx).await,
+                RpcCode::WorkerBlockReport => self.async_worker_block_report(ctx).await,
 
                 v => err_box!("unsupported operation {:?}", v),
             }

--- a/curvine-server/src/master/master_server.rs
+++ b/curvine-server/src/master/master_server.rs
@@ -23,8 +23,8 @@ use log::error;
 use orpc::common::{LocalTime, Logger};
 use orpc::handler::{HandlerService, LimitConf};
 use orpc::io::net::ConnState;
-use orpc::runtime::{AsyncRuntime, RpcRuntime, Runtime};
-use orpc::server::{RpcServer, ServerStateListener};
+use orpc::runtime::{AsyncRuntime, GroupExecutor, RpcRuntime, Runtime};
+use orpc::server::{RpcServer, ServerShutdownHandle, ServerStateListener};
 use orpc::{err_box, CommonError, CommonResult};
 
 use crate::master::fs::{FsRetryCache, MasterActor, MasterFilesystem};
@@ -46,6 +46,11 @@ pub struct MasterService {
     job_manager: Arc<JobManager>,
     rt: Arc<Runtime>,
     actor_rt: Arc<Runtime>,
+    heartbeat_rpc_executor: Arc<GroupExecutor>,
+    block_report_rpc_executor: Arc<GroupExecutor>,
+    control_rpc_executor: Arc<GroupExecutor>,
+    list_rpc_executor: Arc<GroupExecutor>,
+    get_block_locations_rpc_executor: Arc<GroupExecutor>,
     replication_manager: Arc<MasterReplicationManager>,
     limit: LimitConf,
     metrics: &'static MasterMetrics,
@@ -71,6 +76,22 @@ impl MasterService {
             conf.master.actor_threads,
         ));
         let limit = LimitConf::new(conf.master.conn_limit, conf.master.global_limit);
+        let heartbeat_rpc_executor = Arc::new(GroupExecutor::new("master-heartbeat-rpc", 2, 1024));
+        let block_report_rpc_executor =
+            Arc::new(GroupExecutor::new("master-block-report-rpc", 2, 128));
+        let control_rpc_executor = Arc::new(GroupExecutor::new("master-control-rpc", 2, 1024));
+        let read_lane_threads = conf.master.worker_threads.saturating_sub(4).max(1);
+        let read_lane_queue = conf.master.worker_threads.saturating_mul(2).max(1);
+        let list_rpc_executor = Arc::new(GroupExecutor::new(
+            "master-list-rpc",
+            read_lane_threads,
+            read_lane_queue,
+        ));
+        let get_block_locations_rpc_executor = Arc::new(GroupExecutor::new(
+            "master-get-block-locations-rpc",
+            read_lane_threads,
+            read_lane_queue,
+        ));
         Self {
             conf,
             fs,
@@ -79,6 +100,11 @@ impl MasterService {
             job_manager,
             rt,
             actor_rt,
+            heartbeat_rpc_executor,
+            block_report_rpc_executor,
+            control_rpc_executor,
+            list_rpc_executor,
+            get_block_locations_rpc_executor,
             replication_manager,
             limit,
             metrics,
@@ -118,6 +144,11 @@ impl HandlerService for MasterService {
             client_state,
             self.mount_manager.clone(),
             JobHandler::new(self.job_manager.clone()),
+            self.heartbeat_rpc_executor.clone(),
+            self.block_report_rpc_executor.clone(),
+            self.control_rpc_executor.clone(),
+            self.list_rpc_executor.clone(),
+            self.get_block_locations_rpc_executor.clone(),
             self.replication_manager.clone(),
             self.actor_rt.clone(),
             self.metrics,
@@ -155,6 +186,19 @@ pub struct Master {
     mount_manager: Arc<MountManager>,
     job_manager: Arc<JobManager>,
     replication_manager: Arc<MasterReplicationManager>,
+}
+
+#[derive(Clone)]
+pub struct MasterShutdown {
+    rpc: ServerShutdownHandle,
+    web: ServerShutdownHandle,
+}
+
+impl MasterShutdown {
+    pub fn shutdown(&self) {
+        self.web.shutdown();
+        self.rpc.shutdown();
+    }
 }
 
 impl Master {
@@ -277,6 +321,18 @@ impl Master {
         };
         let mut status = rt.block_on(async { self.start().await })?;
         rt.block_on(async { status.wait_stop().await })
+    }
+
+    pub fn shutdown_handle(&self) -> CommonResult<MasterShutdown> {
+        let rpc = match self.rpc_server.as_ref() {
+            Some(server) => server.shutdown_handle(),
+            None => return err_box!("master rpc server is not initialized"),
+        };
+        let web = match self.web_server.as_ref() {
+            Some(server) => server.shutdown_handle(),
+            None => return err_box!("master web server is not initialized"),
+        };
+        Ok(MasterShutdown { rpc, web })
     }
 
     pub fn get_metrics<'a>() -> CommonResult<&'a MasterMetrics> {

--- a/curvine-server/src/master/mount/mount_table.rs
+++ b/curvine-server/src/master/mount/mount_table.rs
@@ -158,7 +158,7 @@ impl MountTable {
     }
 
     pub fn unprotected_add_mount(&self, info: MountInfo) -> FsResult<()> {
-        info!("add mount: {:?}", info);
+        info!("add mount: {:?}", redacted_mount_info(&info));
 
         let mut inner = self.write_inner()?;
         inner
@@ -320,4 +320,26 @@ impl MountTable {
         inner.mountpath2id.remove(&info.cv_path);
         Ok(())
     }
+}
+
+fn redacted_mount_info(info: &MountInfo) -> MountInfo {
+    let mut redacted = info.clone();
+    for (key, value) in &mut redacted.properties {
+        if is_sensitive_mount_property(key) {
+            *value = "******".to_string();
+        }
+    }
+    redacted
+}
+
+fn is_sensitive_mount_property(key: &str) -> bool {
+    let key = key.to_ascii_lowercase();
+    key.contains("credential")
+        || key.contains("secret")
+        || key.contains("token")
+        || key.contains("password")
+        || key.contains("access_key")
+        || key.ends_with(".access")
+        || key.ends_with(".ak")
+        || key.ends_with(".sk")
 }

--- a/curvine-server/src/test/mini_cluster.rs
+++ b/curvine-server/src/test/mini_cluster.rs
@@ -14,8 +14,8 @@
 
 use crate::master::fs::MasterFilesystem;
 use crate::master::replication::master_replication_manager::MasterReplicationManager;
-use crate::master::Master;
-use crate::worker::Worker;
+use crate::master::{Master, MasterShutdown};
+use crate::worker::{Worker, WorkerShutdown};
 use curvine_client::file::CurvineFileSystem;
 use curvine_common::conf::ClusterConf;
 use curvine_common::raft::{NodeId, RaftPeer};
@@ -29,7 +29,7 @@ use orpc::runtime::{RpcRuntime, Runtime};
 use orpc::{err_box, CommonResult};
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex, OnceLock};
-use std::thread;
+use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
 pub struct MasterEntry(MasterFilesystem, Arc<MasterReplicationManager>);
@@ -43,6 +43,22 @@ pub struct MiniCluster {
 
     pub master_entries: DashMap<usize, MasterEntry>,
     pub client_rt: Arc<Runtime>,
+    shutdown_handles: Mutex<Vec<ClusterServerShutdown>>,
+    server_threads: Mutex<Vec<JoinHandle<()>>>,
+}
+
+enum ClusterServerShutdown {
+    Master(MasterShutdown),
+    Worker(WorkerShutdown),
+}
+
+impl ClusterServerShutdown {
+    fn shutdown(&self) {
+        match self {
+            Self::Master(handle) => handle.shutdown(),
+            Self::Worker(handle) => handle.shutdown(),
+        }
+    }
 }
 
 static RESERVED_TEST_PORTS: OnceLock<Mutex<HashSet<u16>>> = OnceLock::new();
@@ -71,6 +87,8 @@ impl MiniCluster {
             worker_conf,
             master_entries: Default::default(),
             client_rt,
+            shutdown_handles: Mutex::new(vec![]),
+            server_threads: Mutex::new(vec![]),
         }
     }
 
@@ -106,28 +124,58 @@ impl MiniCluster {
     pub fn start_master(&self) {
         for (index, conf) in self.master_conf.iter().enumerate() {
             let master = Master::with_conf(conf.clone()).unwrap();
+            let shutdown = master
+                .shutdown_handle()
+                .expect("master shutdown handle should be available before startup");
             self.master_entries.insert(
                 index,
                 MasterEntry(master.get_fs(), master.get_replication_manager()),
             );
-            thread::spawn(move || {
+            let handle = thread::spawn(move || {
                 if let Err(e) = master.block_on_start() {
                     log::error!("mini cluster master failed to start: {}", e);
                     std::process::abort();
                 }
             });
+            self.shutdown_handles
+                .lock()
+                .unwrap()
+                .push(ClusterServerShutdown::Master(shutdown));
+            self.server_threads.lock().unwrap().push(handle);
         }
     }
 
     pub fn start_worker(&self) {
         for conf in &self.worker_conf {
             let worker = Worker::with_conf(conf.clone()).unwrap();
-            thread::spawn(move || {
+            let shutdown = worker
+                .shutdown_handle()
+                .expect("worker shutdown handle should be available before startup");
+            let handle = thread::spawn(move || {
                 if let Err(e) = worker.block_on_start() {
                     log::error!("mini cluster worker failed to start: {}", e);
                     std::process::abort();
                 }
             });
+            self.shutdown_handles
+                .lock()
+                .unwrap()
+                .push(ClusterServerShutdown::Worker(shutdown));
+            self.server_threads.lock().unwrap().push(handle);
+        }
+    }
+
+    pub fn shutdown(&self) {
+        let mut shutdown_handles = self.shutdown_handles.lock().unwrap();
+        for handle in shutdown_handles.iter().rev() {
+            handle.shutdown();
+        }
+        shutdown_handles.clear();
+        drop(shutdown_handles);
+
+        let mut server_threads = self.server_threads.lock().unwrap();
+        for handle in server_threads.drain(..) {
+            let _ = handle.join();
         }
     }
 
@@ -367,5 +415,11 @@ impl MiniCluster {
 impl Default for MiniCluster {
     fn default() -> Self {
         Self::with_num(&ClusterConf::default(), 1, 1)
+    }
+}
+
+impl Drop for MiniCluster {
+    fn drop(&mut self) {
+        self.shutdown();
     }
 }

--- a/curvine-server/src/transfer/backend.rs
+++ b/curvine-server/src/transfer/backend.rs
@@ -15,15 +15,14 @@
 use curvine_common::error::FsError;
 use curvine_common::state::{
     StaleTaskAttempt, TaskAttemptStart, TransferJobRecord, TransferLease, TransferListFilter,
-    TransferState, TransferStateUpdate, TransferTaskRecord, TransferTaskReport, TransferTaskState,
-    TransferTenantSummary,
+    TransferStateUpdate, TransferTaskRecord, TransferTaskReport, TransferTenantSummary,
 };
 use curvine_common::FsResult;
 use std::time::Instant;
 
 use crate::transfer::{
     MemoryTransferStore, MysqlTransferStore, SqliteTransferStore, TransferMetrics,
-    TransferRequeueUpdate, TransferStore,
+    TransferPlannedTasks, TransferRequeueUpdate, TransferStore, TransferTaskStateUpdate,
 };
 
 pub enum TransferStoreBackend {
@@ -217,26 +216,6 @@ impl TransferStore for TransferStoreBackend {
         })
     }
 
-    fn set_transfer_state(
-        &self,
-        job_id: &str,
-        run_id: u64,
-        state: TransferState,
-        message: impl Into<String>,
-        now_ms: i64,
-    ) -> FsResult<bool> {
-        let message = message.into();
-        self.record_store_operation("set_transfer_state", || match self {
-            Self::Memory(store) => {
-                store.set_transfer_state(job_id, run_id, state, message.clone(), now_ms)
-            }
-            Self::Sqlite(store) => {
-                store.set_transfer_state(job_id, run_id, state, message.clone(), now_ms)
-            }
-            Self::Mysql(store) => store.set_transfer_state(job_id, run_id, state, message, now_ms),
-        })
-    }
-
     fn requeue_transfer(&self, update: TransferRequeueUpdate) -> FsResult<bool> {
         self.record_store_operation("requeue_transfer", || match self {
             Self::Memory(store) => store.requeue_transfer(update),
@@ -290,25 +269,19 @@ impl TransferStore for TransferStoreBackend {
         })
     }
 
-    fn update_task_state(
-        &self,
-        job_id: &str,
-        run_id: u64,
-        task_id: &str,
-        state: TransferTaskState,
-        message: impl Into<String>,
-        now_ms: i64,
-    ) -> FsResult<bool> {
+    fn persist_planned_tasks(&self, update: TransferPlannedTasks) -> FsResult<bool> {
+        self.record_store_operation("persist_planned_tasks", || match self {
+            Self::Memory(store) => store.persist_planned_tasks(update),
+            Self::Sqlite(store) => store.persist_planned_tasks(update),
+            Self::Mysql(store) => store.persist_planned_tasks(update),
+        })
+    }
+
+    fn update_task_state(&self, update: TransferTaskStateUpdate) -> FsResult<bool> {
         self.record_store_operation("update_task_state", || match self {
-            Self::Memory(store) => {
-                store.update_task_state(job_id, run_id, task_id, state, message, now_ms)
-            }
-            Self::Sqlite(store) => {
-                store.update_task_state(job_id, run_id, task_id, state, message, now_ms)
-            }
-            Self::Mysql(store) => {
-                store.update_task_state(job_id, run_id, task_id, state, message, now_ms)
-            }
+            Self::Memory(store) => store.update_task_state(update),
+            Self::Sqlite(store) => store.update_task_state(update),
+            Self::Mysql(store) => store.update_task_state(update),
         })
     }
 
@@ -347,15 +320,39 @@ impl TransferStore for TransferStoreBackend {
         })
     }
 
-    fn list_recoverable_tasks(
+    fn list_stale_running_tasks(
         &self,
         job_id: &str,
         run_id: u64,
+        stale_before_ms: i64,
+        limit: usize,
     ) -> FsResult<Vec<TransferTaskRecord>> {
-        self.record_store_operation("list_recoverable_tasks", || match self {
-            Self::Memory(store) => store.list_recoverable_tasks(job_id, run_id),
-            Self::Sqlite(store) => store.list_recoverable_tasks(job_id, run_id),
-            Self::Mysql(store) => store.list_recoverable_tasks(job_id, run_id),
+        self.record_store_operation("list_stale_running_tasks", || match self {
+            Self::Memory(store) => {
+                store.list_stale_running_tasks(job_id, run_id, stale_before_ms, limit)
+            }
+            Self::Sqlite(store) => {
+                store.list_stale_running_tasks(job_id, run_id, stale_before_ms, limit)
+            }
+            Self::Mysql(store) => {
+                store.list_stale_running_tasks(job_id, run_id, stale_before_ms, limit)
+            }
+        })
+    }
+
+    fn has_failed_tasks(&self, job_id: &str, run_id: u64) -> FsResult<bool> {
+        self.record_store_operation("has_failed_tasks", || match self {
+            Self::Memory(store) => store.has_failed_tasks(job_id, run_id),
+            Self::Sqlite(store) => store.has_failed_tasks(job_id, run_id),
+            Self::Mysql(store) => store.has_failed_tasks(job_id, run_id),
+        })
+    }
+
+    fn has_recoverable_tasks(&self, job_id: &str, run_id: u64) -> FsResult<bool> {
+        self.record_store_operation("has_recoverable_tasks", || match self {
+            Self::Memory(store) => store.has_recoverable_tasks(job_id, run_id),
+            Self::Sqlite(store) => store.has_recoverable_tasks(job_id, run_id),
+            Self::Mysql(store) => store.has_recoverable_tasks(job_id, run_id),
         })
     }
 

--- a/curvine-server/src/transfer/backend.rs
+++ b/curvine-server/src/transfer/backend.rs
@@ -1,0 +1,439 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use curvine_common::error::FsError;
+use curvine_common::state::{
+    StaleTaskAttempt, TaskAttemptStart, TransferJobRecord, TransferLease, TransferListFilter,
+    TransferState, TransferStateUpdate, TransferTaskRecord, TransferTaskReport, TransferTaskState,
+    TransferTenantSummary,
+};
+use curvine_common::FsResult;
+use std::time::Instant;
+
+use crate::transfer::{
+    MemoryTransferStore, MysqlTransferStore, SqliteTransferStore, TransferMetrics,
+    TransferRequeueUpdate, TransferStore,
+};
+
+pub enum TransferStoreBackend {
+    Memory(MemoryTransferStore),
+    Sqlite(SqliteTransferStore),
+    Mysql(MysqlTransferStore),
+}
+
+impl TransferStore for TransferStoreBackend {
+    fn check_available(&self) -> FsResult<()> {
+        self.record_store_operation("check_available", || match self {
+            Self::Memory(store) => store.check_available(),
+            Self::Sqlite(store) => store.check_available(),
+            Self::Mysql(store) => store.check_available(),
+        })
+    }
+
+    fn create_or_get_by_request_id(&self, job: TransferJobRecord) -> FsResult<TransferJobRecord> {
+        self.record_store_operation("create_or_get_by_request_id", || match self {
+            Self::Memory(store) => store.create_or_get_by_request_id(job),
+            Self::Sqlite(store) => store.create_or_get_by_request_id(job),
+            Self::Mysql(store) => store.create_or_get_by_request_id(job),
+        })
+    }
+
+    fn create_or_get_by_request_id_checked(
+        &self,
+        job: TransferJobRecord,
+    ) -> FsResult<TransferJobRecord> {
+        self.record_store_operation("create_or_get_by_request_id_checked", || match self {
+            Self::Memory(store) => store.create_or_get_by_request_id_checked(job),
+            Self::Sqlite(store) => store.create_or_get_by_request_id_checked(job),
+            Self::Mysql(store) => store.create_or_get_by_request_id_checked(job),
+        })
+    }
+
+    fn get_transfer(&self, job_id: &str) -> FsResult<Option<TransferJobRecord>> {
+        self.record_store_operation("get_transfer", || match self {
+            Self::Memory(store) => store.get_transfer(job_id),
+            Self::Sqlite(store) => store.get_transfer(job_id),
+            Self::Mysql(store) => store.get_transfer(job_id),
+        })
+    }
+
+    fn get_transfer_by_request(
+        &self,
+        submitter: &str,
+        client_request_id: &str,
+    ) -> FsResult<Option<TransferJobRecord>> {
+        self.record_store_operation("get_transfer_by_request", || match self {
+            Self::Memory(store) => store.get_transfer_by_request(submitter, client_request_id),
+            Self::Sqlite(store) => store.get_transfer_by_request(submitter, client_request_id),
+            Self::Mysql(store) => store.get_transfer_by_request(submitter, client_request_id),
+        })
+    }
+
+    fn list_active_transfers(&self) -> FsResult<Vec<TransferJobRecord>> {
+        self.record_store_operation("list_active_transfers", || match self {
+            Self::Memory(store) => store.list_active_transfers(),
+            Self::Sqlite(store) => store.list_active_transfers(),
+            Self::Mysql(store) => store.list_active_transfers(),
+        })
+    }
+
+    fn find_conflicting_active_transfer(
+        &self,
+        target_path: &str,
+        submitter: &str,
+        client_request_id: &str,
+    ) -> FsResult<Option<TransferJobRecord>> {
+        self.record_store_operation("find_conflicting_active_transfer", || match self {
+            Self::Memory(store) => {
+                store.find_conflicting_active_transfer(target_path, submitter, client_request_id)
+            }
+            Self::Sqlite(store) => {
+                store.find_conflicting_active_transfer(target_path, submitter, client_request_id)
+            }
+            Self::Mysql(store) => {
+                store.find_conflicting_active_transfer(target_path, submitter, client_request_id)
+            }
+        })
+    }
+
+    fn count_active_transfers(&self) -> FsResult<u64> {
+        self.record_store_operation("count_active_transfers", || match self {
+            Self::Memory(store) => store.count_active_transfers(),
+            Self::Sqlite(store) => store.count_active_transfers(),
+            Self::Mysql(store) => store.count_active_transfers(),
+        })
+    }
+
+    fn count_executing_transfers(&self) -> FsResult<u64> {
+        self.record_store_operation("count_executing_transfers", || match self {
+            Self::Memory(store) => store.count_executing_transfers(),
+            Self::Sqlite(store) => store.count_executing_transfers(),
+            Self::Mysql(store) => store.count_executing_transfers(),
+        })
+    }
+
+    fn list_transfers(&self, filter: TransferListFilter) -> FsResult<Vec<TransferJobRecord>> {
+        self.record_store_operation("list_transfers", || match self {
+            Self::Memory(store) => store.list_transfers(filter),
+            Self::Sqlite(store) => store.list_transfers(filter),
+            Self::Mysql(store) => store.list_transfers(filter),
+        })
+    }
+
+    fn list_tenant_summaries(
+        &self,
+        limit: usize,
+        offset: usize,
+    ) -> FsResult<Vec<TransferTenantSummary>> {
+        self.record_store_operation("list_tenant_summaries", || match self {
+            Self::Memory(store) => store.list_tenant_summaries(limit, offset),
+            Self::Sqlite(store) => store.list_tenant_summaries(limit, offset),
+            Self::Mysql(store) => store.list_tenant_summaries(limit, offset),
+        })
+    }
+
+    fn purge_terminal_transfers(&self, older_than_ms: i64, limit: usize) -> FsResult<usize> {
+        self.record_store_operation("purge_terminal_transfers", || match self {
+            Self::Memory(store) => store.purge_terminal_transfers(older_than_ms, limit),
+            Self::Sqlite(store) => store.purge_terminal_transfers(older_than_ms, limit),
+            Self::Mysql(store) => store.purge_terminal_transfers(older_than_ms, limit),
+        })
+    }
+
+    fn list_transfer_tasks(&self, job_id: &str, run_id: u64) -> FsResult<Vec<TransferTaskRecord>> {
+        self.record_store_operation("list_transfer_tasks", || match self {
+            Self::Memory(store) => store.list_transfer_tasks(job_id, run_id),
+            Self::Sqlite(store) => store.list_transfer_tasks(job_id, run_id),
+            Self::Mysql(store) => store.list_transfer_tasks(job_id, run_id),
+        })
+    }
+
+    fn request_cancel(&self, job_id: &str, run_id: u64, now_ms: i64) -> FsResult<bool> {
+        self.record_store_operation("request_cancel", || match self {
+            Self::Memory(store) => store.request_cancel(job_id, run_id, now_ms),
+            Self::Sqlite(store) => store.request_cancel(job_id, run_id, now_ms),
+            Self::Mysql(store) => store.request_cancel(job_id, run_id, now_ms),
+        })
+    }
+
+    fn acquire_runnable_transfer(
+        &self,
+        owner: &str,
+        lease_ms: i64,
+        now_ms: i64,
+        max_executing_transfers: u64,
+    ) -> FsResult<Option<TransferLease>> {
+        self.record_store_operation("acquire_runnable_transfer", || match self {
+            Self::Memory(store) => {
+                store.acquire_runnable_transfer(owner, lease_ms, now_ms, max_executing_transfers)
+            }
+            Self::Sqlite(store) => {
+                store.acquire_runnable_transfer(owner, lease_ms, now_ms, max_executing_transfers)
+            }
+            Self::Mysql(store) => {
+                store.acquire_runnable_transfer(owner, lease_ms, now_ms, max_executing_transfers)
+            }
+        })
+    }
+
+    fn renew_lease(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        owner: &str,
+        lease_epoch: u64,
+        lease_ms: i64,
+        now_ms: i64,
+    ) -> FsResult<bool> {
+        self.record_store_operation("renew_lease", || match self {
+            Self::Memory(store) => {
+                store.renew_lease(job_id, run_id, owner, lease_epoch, lease_ms, now_ms)
+            }
+            Self::Sqlite(store) => {
+                store.renew_lease(job_id, run_id, owner, lease_epoch, lease_ms, now_ms)
+            }
+            Self::Mysql(store) => {
+                store.renew_lease(job_id, run_id, owner, lease_epoch, lease_ms, now_ms)
+            }
+        })
+    }
+
+    fn update_transfer_state(&self, update: TransferStateUpdate) -> FsResult<bool> {
+        self.record_store_operation("update_transfer_state", || match self {
+            Self::Memory(store) => store.update_transfer_state(update),
+            Self::Sqlite(store) => store.update_transfer_state(update),
+            Self::Mysql(store) => store.update_transfer_state(update),
+        })
+    }
+
+    fn set_transfer_state(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        state: TransferState,
+        message: impl Into<String>,
+        now_ms: i64,
+    ) -> FsResult<bool> {
+        let message = message.into();
+        self.record_store_operation("set_transfer_state", || match self {
+            Self::Memory(store) => {
+                store.set_transfer_state(job_id, run_id, state, message.clone(), now_ms)
+            }
+            Self::Sqlite(store) => {
+                store.set_transfer_state(job_id, run_id, state, message.clone(), now_ms)
+            }
+            Self::Mysql(store) => store.set_transfer_state(job_id, run_id, state, message, now_ms),
+        })
+    }
+
+    fn requeue_transfer(&self, update: TransferRequeueUpdate) -> FsResult<bool> {
+        self.record_store_operation("requeue_transfer", || match self {
+            Self::Memory(store) => store.requeue_transfer(update),
+            Self::Sqlite(store) => store.requeue_transfer(update),
+            Self::Mysql(store) => store.requeue_transfer(update),
+        })
+    }
+
+    fn set_transfer_cv_metadata_epoch(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        owner: &str,
+        lease_epoch: u64,
+        cv_metadata_epoch: u64,
+        now_ms: i64,
+    ) -> FsResult<bool> {
+        self.record_store_operation("set_transfer_cv_metadata_epoch", || match self {
+            Self::Memory(store) => store.set_transfer_cv_metadata_epoch(
+                job_id,
+                run_id,
+                owner,
+                lease_epoch,
+                cv_metadata_epoch,
+                now_ms,
+            ),
+            Self::Sqlite(store) => store.set_transfer_cv_metadata_epoch(
+                job_id,
+                run_id,
+                owner,
+                lease_epoch,
+                cv_metadata_epoch,
+                now_ms,
+            ),
+            Self::Mysql(store) => store.set_transfer_cv_metadata_epoch(
+                job_id,
+                run_id,
+                owner,
+                lease_epoch,
+                cv_metadata_epoch,
+                now_ms,
+            ),
+        })
+    }
+
+    fn insert_tasks(&self, tasks: Vec<TransferTaskRecord>) -> FsResult<()> {
+        self.record_store_operation("insert_tasks", || match self {
+            Self::Memory(store) => store.insert_tasks(tasks),
+            Self::Sqlite(store) => store.insert_tasks(tasks),
+            Self::Mysql(store) => store.insert_tasks(tasks),
+        })
+    }
+
+    fn update_task_state(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        task_id: &str,
+        state: TransferTaskState,
+        message: impl Into<String>,
+        now_ms: i64,
+    ) -> FsResult<bool> {
+        self.record_store_operation("update_task_state", || match self {
+            Self::Memory(store) => {
+                store.update_task_state(job_id, run_id, task_id, state, message, now_ms)
+            }
+            Self::Sqlite(store) => {
+                store.update_task_state(job_id, run_id, task_id, state, message, now_ms)
+            }
+            Self::Mysql(store) => {
+                store.update_task_state(job_id, run_id, task_id, state, message, now_ms)
+            }
+        })
+    }
+
+    fn claim_pending_tasks(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        limit: usize,
+    ) -> FsResult<Vec<TransferTaskRecord>> {
+        self.record_store_operation("claim_pending_tasks", || match self {
+            Self::Memory(store) => store.claim_pending_tasks(job_id, run_id, limit),
+            Self::Sqlite(store) => store.claim_pending_tasks(job_id, run_id, limit),
+            Self::Mysql(store) => store.claim_pending_tasks(job_id, run_id, limit),
+        })
+    }
+
+    fn mark_stale_attempts(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        owner: &str,
+        lease_epoch: u64,
+        now_ms: i64,
+        limit: usize,
+    ) -> FsResult<Vec<StaleTaskAttempt>> {
+        self.record_store_operation("mark_stale_attempts", || match self {
+            Self::Memory(store) => {
+                store.mark_stale_attempts(job_id, run_id, owner, lease_epoch, now_ms, limit)
+            }
+            Self::Sqlite(store) => {
+                store.mark_stale_attempts(job_id, run_id, owner, lease_epoch, now_ms, limit)
+            }
+            Self::Mysql(store) => {
+                store.mark_stale_attempts(job_id, run_id, owner, lease_epoch, now_ms, limit)
+            }
+        })
+    }
+
+    fn list_recoverable_tasks(
+        &self,
+        job_id: &str,
+        run_id: u64,
+    ) -> FsResult<Vec<TransferTaskRecord>> {
+        self.record_store_operation("list_recoverable_tasks", || match self {
+            Self::Memory(store) => store.list_recoverable_tasks(job_id, run_id),
+            Self::Sqlite(store) => store.list_recoverable_tasks(job_id, run_id),
+            Self::Mysql(store) => store.list_recoverable_tasks(job_id, run_id),
+        })
+    }
+
+    fn start_task_attempt(&self, start: TaskAttemptStart) -> FsResult<bool> {
+        self.record_store_operation("start_task_attempt", || match self {
+            Self::Memory(store) => store.start_task_attempt(start),
+            Self::Sqlite(store) => store.start_task_attempt(start),
+            Self::Mysql(store) => store.start_task_attempt(start),
+        })
+    }
+
+    fn update_task_report(&self, report: TransferTaskReport) -> FsResult<bool> {
+        self.record_store_operation("update_task_report", || match self {
+            Self::Memory(store) => store.update_task_report(report),
+            Self::Sqlite(store) => store.update_task_report(report),
+            Self::Mysql(store) => store.update_task_report(report),
+        })
+    }
+}
+
+impl TransferStoreBackend {
+    pub fn backend_label(&self) -> &'static str {
+        match self {
+            Self::Memory(_) => "memory",
+            Self::Sqlite(_) => "sqlite",
+            Self::Mysql(_) => "mysql",
+        }
+    }
+
+    fn record_store_operation<T>(
+        &self,
+        operation: &'static str,
+        f: impl FnOnce() -> FsResult<T>,
+    ) -> FsResult<T> {
+        let start = Instant::now();
+        let result = f();
+        if let Ok(metrics) = TransferMetrics::get() {
+            let backend = self.backend_label();
+            metrics.observe_store_operation(
+                backend,
+                operation,
+                if result.is_ok() { "success" } else { "error" },
+                start.elapsed().as_micros(),
+            );
+            if is_store_unavailable_result(&result) {
+                metrics.record_store_unavailable(backend, operation);
+            } else {
+                metrics.record_store_available(backend);
+            }
+        }
+        result
+    }
+}
+
+fn is_store_unavailable_result<T>(result: &FsResult<T>) -> bool {
+    let Err(err) = result else {
+        return false;
+    };
+    is_store_unavailable_error(err)
+}
+
+pub(crate) fn is_store_unavailable_error(err: &FsError) -> bool {
+    if matches!(
+        err.kind(),
+        curvine_common::error::ErrorKind::IO
+            | curvine_common::error::ErrorKind::TransferStoreUnavailable
+    ) {
+        return true;
+    }
+
+    let message = err.to_string();
+    message.contains("sqlite transfer store error:")
+        || message.contains("mysql transfer store error:")
+        || message.contains("Unknown database")
+        || message.contains("No database selected")
+        || message.contains("doesn't exist")
+        || message.contains("Can't connect")
+        || message.contains("Connection refused")
+        || message.contains("Lost connection")
+        || message.contains("server has gone away")
+}

--- a/curvine-server/src/transfer/cluster_cache.rs
+++ b/curvine-server/src/transfer/cluster_cache.rs
@@ -1,0 +1,343 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use curvine_client::file::CurvineFileSystem;
+use curvine_common::error::FsError;
+use curvine_common::fs::Path;
+use curvine_common::state::{MountInfo, TransferKind, WorkerInfo};
+use curvine_common::FsResult;
+use log::warn;
+use orpc::common::LocalTime;
+use orpc::runtime::RpcRuntime;
+use parking_lot::{Mutex, RwLock};
+use std::collections::HashSet;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use crate::transfer::TransferMetrics;
+
+#[derive(Clone, Default)]
+pub struct ClusterSnapshot {
+    pub version: u64,
+    pub mounts: Vec<MountInfo>,
+    pub workers: Vec<WorkerInfo>,
+    pub updated_at: i64,
+}
+
+#[derive(Clone)]
+pub struct ClusterMetadataCache {
+    fs: CurvineFileSystem,
+    snapshot: Arc<RwLock<ClusterSnapshot>>,
+    rejected_worker_sessions: Arc<RwLock<HashSet<(u32, String)>>>,
+    refresh_lock: Arc<Mutex<()>>,
+    max_staleness: Duration,
+    allow_stale_snapshot: bool,
+}
+
+impl ClusterMetadataCache {
+    pub fn new(fs: CurvineFileSystem) -> Self {
+        Self::with_snapshot_policy(fs, Duration::MAX, true)
+    }
+
+    pub fn with_snapshot_policy(
+        fs: CurvineFileSystem,
+        max_staleness: Duration,
+        allow_stale_snapshot: bool,
+    ) -> Self {
+        Self {
+            fs,
+            snapshot: Arc::new(RwLock::new(ClusterSnapshot::default())),
+            rejected_worker_sessions: Arc::new(RwLock::new(HashSet::new())),
+            refresh_lock: Arc::new(Mutex::new(())),
+            max_staleness,
+            allow_stale_snapshot,
+        }
+    }
+
+    pub fn snapshot(&self) -> ClusterSnapshot {
+        self.snapshot.read().clone()
+    }
+
+    pub fn check_ready(&self) -> FsResult<()> {
+        let snapshot = self.snapshot();
+        if snapshot.updated_at <= 0 {
+            return Err(FsError::common(
+                "Transfer cluster metadata is unavailable; retry shortly",
+            ));
+        }
+        self.check_snapshot_fresh(&snapshot)
+    }
+
+    pub fn remove_worker_session(&self, worker_id: u32, worker_session_id: &str) {
+        self.rejected_worker_sessions
+            .write()
+            .insert((worker_id, worker_session_id.to_string()));
+        let mut snapshot = self.snapshot.write();
+        snapshot.workers.retain(|worker| {
+            !(worker.worker_id() == worker_id && worker.worker_session_id == worker_session_id)
+        });
+    }
+
+    pub async fn refresh(&self) -> FsResult<()> {
+        let start = Instant::now();
+        let result = self.refresh_inner().await;
+        let snapshot = self.snapshot();
+        let (live_workers, capable_workers) = worker_counts(&snapshot.workers);
+        if let Ok(metrics) = TransferMetrics::get() {
+            metrics.observe_cluster_snapshot_refresh(
+                if result.is_ok() { "success" } else { "failure" },
+                start.elapsed().as_micros(),
+                if result.is_ok() {
+                    Some(snapshot.version)
+                } else {
+                    None
+                },
+                if snapshot.updated_at > 0 {
+                    Some(snapshot.updated_at)
+                } else {
+                    None
+                },
+                Some(live_workers),
+                Some(capable_workers),
+            );
+        }
+        result
+    }
+
+    async fn refresh_inner(&self) -> FsResult<()> {
+        let mounts = self.fs.get_mount_table().await?;
+        let master = self.fs.get_master_info().await?;
+        let mut workers = master.live_workers;
+        {
+            let mut rejected = self.rejected_worker_sessions.write();
+            rejected.retain(|(worker_id, worker_session_id)| {
+                workers.iter().any(|worker| {
+                    worker.worker_id() == *worker_id
+                        && worker.worker_session_id == *worker_session_id
+                })
+            });
+            workers.retain(|worker| {
+                !rejected.contains(&(worker.worker_id(), worker.worker_session_id.clone()))
+            });
+        }
+        let mut snapshot = self.snapshot.write();
+        snapshot.version = snapshot.version.saturating_add(1);
+        snapshot.mounts = mounts;
+        snapshot.workers = workers;
+        snapshot.updated_at = LocalTime::mills() as i64;
+        Ok(())
+    }
+
+    pub fn find_mount(
+        &self,
+        kind: TransferKind,
+        source: &Path,
+        target: &Path,
+    ) -> FsResult<MountInfo> {
+        self.find_mount_with_version(kind, source, target)
+            .map(|snapshot| snapshot.mount)
+    }
+
+    pub fn find_mount_with_version(
+        &self,
+        kind: TransferKind,
+        source: &Path,
+        target: &Path,
+    ) -> FsResult<MountSnapshot> {
+        let snapshot = self.snapshot();
+        if snapshot.mounts.is_empty() {
+            return Err(FsError::common("Cluster mount snapshot is unavailable"));
+        }
+        self.check_snapshot_fresh(&snapshot)?;
+        self.matching_mount_snapshot(kind, source, target, &snapshot)
+            .ok_or_else(|| {
+                FsError::common(format!(
+                    "No mount found for {:?}: {} -> {}",
+                    kind,
+                    source.full_path(),
+                    target.full_path()
+                ))
+            })
+    }
+
+    pub fn find_mount_with_refresh(
+        &self,
+        kind: TransferKind,
+        source: &Path,
+        target: &Path,
+    ) -> FsResult<MountSnapshot> {
+        let snapshot = self.snapshot();
+        self.check_snapshot_fresh(&snapshot)?;
+        if let Some(snapshot) = self.matching_mount_snapshot(kind, source, target, &snapshot) {
+            return Ok(snapshot);
+        }
+
+        let _guard = self.refresh_lock.lock();
+        let snapshot = self.snapshot();
+        self.check_snapshot_fresh(&snapshot)?;
+        if let Some(snapshot) = self.matching_mount_snapshot(kind, source, target, &snapshot) {
+            return Ok(snapshot);
+        }
+
+        // SubmitTransfer is synchronous and may run within a Tokio task.
+        self.refresh_blocking()?;
+        self.find_mount_with_version(kind, source, target)
+    }
+
+    fn matching_mount_snapshot(
+        &self,
+        kind: TransferKind,
+        source: &Path,
+        target: &Path,
+        snapshot: &ClusterSnapshot,
+    ) -> Option<MountSnapshot> {
+        let source_text = if source.is_cv() {
+            source.path().to_string()
+        } else {
+            source.full_path().to_string()
+        };
+        let target_text = if target.is_cv() {
+            target.path().to_string()
+        } else {
+            target.full_path().to_string()
+        };
+
+        snapshot
+            .mounts
+            .iter()
+            .find(|mount| match kind {
+                TransferKind::Load => {
+                    source_text.starts_with(&mount.ufs_path)
+                        && target_text.starts_with(&mount.cv_path)
+                }
+                TransferKind::Export => {
+                    source_text.starts_with(&mount.cv_path)
+                        && target_text.starts_with(&mount.ufs_path)
+                }
+            })
+            .cloned()
+            .map(|mount| MountSnapshot {
+                mount,
+                version: snapshot.version,
+            })
+    }
+
+    fn refresh_blocking(&self) -> FsResult<()> {
+        let cache = self.clone();
+        std::thread::scope(|scope| {
+            scope
+                .spawn(move || {
+                    let rt = cache.fs.clone_runtime();
+                    rt.block_on(cache.refresh())
+                })
+                .join()
+                .map_err(|_| FsError::common("Transfer cluster metadata refresh thread panicked"))?
+        })
+    }
+
+    pub fn live_workers(&self) -> FsResult<Vec<WorkerInfo>> {
+        let snapshot = self.snapshot();
+        self.check_snapshot_fresh(&snapshot)?;
+        let (live_count, capable_count) = worker_counts(&snapshot.workers);
+        if let Ok(metrics) = TransferMetrics::get() {
+            metrics.set_cluster_snapshot(
+                Some(snapshot.version),
+                if snapshot.updated_at > 0 {
+                    Some(snapshot.updated_at)
+                } else {
+                    None
+                },
+                Some(live_count),
+                Some(capable_count),
+            );
+        }
+        let workers: Vec<_> = snapshot
+            .workers
+            .into_iter()
+            .filter(|worker| {
+                worker.is_live()
+                    && !worker.worker_session_id.is_empty()
+                    && worker.transfer_capabilities.supports_transfer()
+            })
+            .collect();
+        if workers.is_empty() {
+            return Err(FsError::common(
+                "No live worker with required transfer capabilities is available",
+            ));
+        }
+        Ok(workers)
+    }
+
+    fn check_snapshot_fresh(&self, snapshot: &ClusterSnapshot) -> FsResult<()> {
+        if self.allow_stale_snapshot {
+            return Ok(());
+        }
+        let updated_at = snapshot.updated_at;
+        if updated_at <= 0 {
+            return Err(FsError::common(
+                "Transfer cluster metadata is unavailable; retry shortly",
+            ));
+        }
+        let max_staleness_ms = self.max_staleness.as_millis().min(i64::MAX as u128) as i64;
+        let staleness_ms = (LocalTime::mills() as i64).saturating_sub(updated_at);
+        if staleness_ms > max_staleness_ms {
+            return Err(FsError::common(
+                "Transfer cluster metadata is stale; retry shortly",
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn start_refresh_loop(self, interval: Duration, stop: Arc<AtomicBool>) {
+        let rt = self.fs.clone_runtime();
+        rt.spawn(async move {
+            while !stop.load(Ordering::Relaxed) {
+                if let Err(err) = self.refresh().await {
+                    warn!("refresh transfer cluster metadata failed: {}", err);
+                }
+                if wait_or_stopped(interval, &stop).await {
+                    break;
+                }
+            }
+        });
+    }
+}
+
+fn worker_counts(workers: &[WorkerInfo]) -> (usize, usize) {
+    let live = workers.iter().filter(|worker| worker.is_live()).count();
+    let capable = workers
+        .iter()
+        .filter(|worker| worker.is_live() && worker.transfer_capabilities.supports_transfer())
+        .count();
+    (live, capable)
+}
+
+async fn wait_or_stopped(interval: Duration, stop: &AtomicBool) -> bool {
+    let deadline = Instant::now() + interval;
+    while !stop.load(Ordering::Relaxed) {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return false;
+        }
+        tokio::time::sleep(remaining.min(Duration::from_millis(100))).await;
+    }
+    true
+}
+
+#[derive(Clone)]
+pub struct MountSnapshot {
+    pub mount: MountInfo,
+    pub version: u64,
+}

--- a/curvine-server/src/transfer/cluster_cache.rs
+++ b/curvine-server/src/transfer/cluster_cache.rs
@@ -74,7 +74,7 @@ impl ClusterMetadataCache {
         let snapshot = self.snapshot();
         if snapshot.updated_at <= 0 {
             return Err(FsError::common(
-                "Transfer cluster metadata is unavailable; retry shortly",
+                "Cluster metadata is unavailable; retry shortly",
             ));
         }
         self.check_snapshot_fresh(&snapshot)
@@ -204,14 +204,14 @@ impl ClusterMetadataCache {
         snapshot: &ClusterSnapshot,
     ) -> Option<MountSnapshot> {
         let source_text = if source.is_cv() {
-            source.path().to_string()
+            source.path()
         } else {
-            source.full_path().to_string()
+            source.full_path()
         };
         let target_text = if target.is_cv() {
-            target.path().to_string()
+            target.path()
         } else {
-            target.full_path().to_string()
+            target.full_path()
         };
 
         snapshot
@@ -219,12 +219,12 @@ impl ClusterMetadataCache {
             .iter()
             .find(|mount| match kind {
                 TransferKind::Load => {
-                    source_text.starts_with(&mount.ufs_path)
-                        && target_text.starts_with(&mount.cv_path)
+                    Path::has_prefix(source_text, &mount.ufs_path)
+                        && Path::has_prefix(target_text, &mount.cv_path)
                 }
                 TransferKind::Export => {
-                    source_text.starts_with(&mount.cv_path)
-                        && target_text.starts_with(&mount.ufs_path)
+                    Path::has_prefix(source_text, &mount.cv_path)
+                        && Path::has_prefix(target_text, &mount.ufs_path)
                 }
             })
             .cloned()
@@ -294,7 +294,7 @@ impl ClusterMetadataCache {
         let staleness_ms = (LocalTime::mills() as i64).saturating_sub(updated_at);
         if staleness_ms > max_staleness_ms {
             return Err(FsError::common(
-                "Transfer cluster metadata is stale; retry shortly",
+                "Cluster metadata snapshot is stale; retry shortly",
             ));
         }
         Ok(())

--- a/curvine-server/src/transfer/cv_metadata_reader.rs
+++ b/curvine-server/src/transfer/cv_metadata_reader.rs
@@ -1,0 +1,748 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use curvine_client::file::CurvineFileSystem;
+use curvine_common::error::FsError;
+use curvine_common::fs::Path;
+use curvine_common::state::{FileBlocks, FileStatus};
+use curvine_common::utils::ProtoUtils;
+use curvine_common::FsResult;
+use futures::future::BoxFuture;
+use log::{info, warn};
+use orpc::common::LocalTime;
+use parking_lot::RwLock;
+use std::collections::{HashMap, VecDeque};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use crate::transfer::{MetadataReplicaRefreshObservation, TransferMetrics};
+
+pub trait CvMetadataReader: Send + Sync + 'static {
+    fn current_epoch(&self) -> FsResult<Option<u64>>;
+
+    fn current_refresh_time_ms(&self) -> FsResult<Option<i64>> {
+        Ok(None)
+    }
+
+    fn covers_time_ms(&self, _time_ms: i64) -> FsResult<bool> {
+        Ok(true)
+    }
+
+    fn get_status<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, FsResult<FileStatus>>;
+
+    fn get_status_at_epoch<'a>(
+        &'a self,
+        path: &'a Path,
+        _epoch: Option<u64>,
+    ) -> BoxFuture<'a, FsResult<FileStatus>> {
+        self.get_status(path)
+    }
+
+    fn list_status<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, FsResult<Vec<FileStatus>>>;
+
+    fn list_status_at_epoch<'a>(
+        &'a self,
+        path: &'a Path,
+        _epoch: Option<u64>,
+    ) -> BoxFuture<'a, FsResult<Vec<FileStatus>>> {
+        self.list_status(path)
+    }
+
+    fn get_block_locations<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, FsResult<FileBlocks>>;
+
+    fn get_block_locations_at_epoch<'a>(
+        &'a self,
+        path: &'a Path,
+        _epoch: Option<u64>,
+    ) -> BoxFuture<'a, FsResult<FileBlocks>> {
+        self.get_block_locations(path)
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct DisabledCvMetadataReader;
+
+impl DisabledCvMetadataReader {
+    fn disabled_error(path: &Path) -> FsError {
+        FsError::common(format!(
+            "CV metadata reader is disabled for {}; configure a production metadata replica, or explicitly enable transfer.cv_metadata_reader=master for development only",
+            path.full_path()
+        ))
+    }
+}
+
+impl CvMetadataReader for DisabledCvMetadataReader {
+    fn current_epoch(&self) -> FsResult<Option<u64>> {
+        Ok(None)
+    }
+
+    fn current_refresh_time_ms(&self) -> FsResult<Option<i64>> {
+        Ok(None)
+    }
+
+    fn covers_time_ms(&self, _time_ms: i64) -> FsResult<bool> {
+        Ok(false)
+    }
+
+    fn get_status<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, FsResult<FileStatus>> {
+        Box::pin(async move { Err(Self::disabled_error(path)) })
+    }
+
+    fn list_status<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, FsResult<Vec<FileStatus>>> {
+        Box::pin(async move { Err(Self::disabled_error(path)) })
+    }
+
+    fn get_block_locations<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, FsResult<FileBlocks>> {
+        Box::pin(async move { Err(Self::disabled_error(path)) })
+    }
+}
+
+#[derive(Clone)]
+pub struct MasterCvMetadataReader {
+    fs: CurvineFileSystem,
+}
+
+impl MasterCvMetadataReader {
+    pub fn new(fs: CurvineFileSystem) -> Self {
+        Self { fs }
+    }
+}
+
+impl CvMetadataReader for MasterCvMetadataReader {
+    fn current_epoch(&self) -> FsResult<Option<u64>> {
+        Ok(None)
+    }
+
+    fn current_refresh_time_ms(&self) -> FsResult<Option<i64>> {
+        Ok(None)
+    }
+
+    fn get_status<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, FsResult<FileStatus>> {
+        Box::pin(async move { self.fs.get_status(path).await })
+    }
+
+    fn list_status<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, FsResult<Vec<FileStatus>>> {
+        Box::pin(async move { self.fs.list_status(path).await })
+    }
+
+    fn get_block_locations<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, FsResult<FileBlocks>> {
+        Box::pin(async move { self.fs.get_block_locations(path).await })
+    }
+}
+
+#[derive(Clone)]
+pub struct MetadataReplicaReader {
+    inner: Arc<MetadataReplicaInner>,
+}
+
+struct MetadataReplicaInner {
+    fs: CurvineFileSystem,
+    state: RwLock<MetadataReplicaState>,
+    max_entries: usize,
+    page_size: usize,
+    history_size: usize,
+    max_staleness: Duration,
+}
+
+#[derive(Clone, Default)]
+struct MetadataReplicaState {
+    current: MetadataReplicaSnapshot,
+    history: VecDeque<MetadataReplicaSnapshot>,
+}
+
+#[derive(Clone, Default)]
+struct MetadataReplicaSnapshot {
+    version: u64,
+    refresh_time_ms: i64,
+    statuses: HashMap<String, FileStatus>,
+    children: HashMap<String, Vec<FileStatus>>,
+    blocks: HashMap<String, FileBlocks>,
+}
+
+impl MetadataReplicaReader {
+    pub fn new(
+        fs: CurvineFileSystem,
+        max_entries: usize,
+        page_size: usize,
+        history_size: usize,
+        max_staleness: Duration,
+    ) -> Self {
+        Self {
+            inner: Arc::new(MetadataReplicaInner {
+                fs,
+                state: RwLock::new(MetadataReplicaState::default()),
+                max_entries,
+                page_size,
+                history_size,
+                max_staleness,
+            }),
+        }
+    }
+
+    pub fn start_refresh_loop(&self, interval: Duration, stop: Arc<AtomicBool>) {
+        let reader = self.clone();
+        tokio::spawn(async move {
+            while !stop.load(Ordering::Relaxed) {
+                if wait_or_stopped(interval, &stop).await {
+                    break;
+                }
+                if let Err(err) = reader.refresh().await {
+                    warn!("metadata replica refresh failed: {}", err);
+                }
+            }
+        });
+    }
+
+    pub async fn refresh(&self) -> FsResult<u64> {
+        let start = Instant::now();
+        match self.refresh_delta(start).await {
+            Ok(Some(version)) => return Ok(version),
+            Ok(None) => {}
+            Err(err) => {
+                warn!(
+                    "metadata replica delta refresh failed, falling back to full snapshot: {}",
+                    err
+                );
+            }
+        }
+        self.refresh_full(start).await
+    }
+
+    async fn refresh_delta(&self, start: Instant) -> FsResult<Option<u64>> {
+        let mut snapshot = {
+            let state = self.inner.state.read();
+            if state.current.refresh_time_ms <= 0 {
+                return Ok(None);
+            }
+            state.current.clone()
+        };
+        let from_epoch = snapshot.version;
+        let mut target_epoch = None;
+        let mut page_token = None;
+        let mut page_count = 0usize;
+        loop {
+            let page = self
+                .inner
+                .fs
+                .get_cv_metadata_delta_page(
+                    from_epoch,
+                    target_epoch,
+                    page_token.clone(),
+                    Some(self.inner.page_size as u32),
+                )
+                .await?;
+            page_count = page_count.saturating_add(1);
+            if page.full_snapshot_required {
+                return Ok(None);
+            }
+            if page.from_epoch != from_epoch {
+                return Err(FsError::common(format!(
+                    "Metadata replica delta from_epoch mismatch: expected={}, actual={}",
+                    from_epoch, page.from_epoch
+                )));
+            }
+            if let Some(epoch) = target_epoch {
+                if epoch != page.to_epoch {
+                    return Err(FsError::common(format!(
+                        "Metadata replica delta target epoch changed during refresh: expected={}, actual={}",
+                        epoch, page.to_epoch
+                    )));
+                }
+            } else {
+                target_epoch = Some(page.to_epoch);
+            }
+
+            for entry in page.entries {
+                apply_delta_entry(&mut snapshot, entry)?;
+            }
+
+            match page.next_page_token {
+                Some(next) if Some(next.clone()) != page_token => page_token = Some(next),
+                Some(next) => {
+                    return Err(FsError::common(format!(
+                        "Metadata replica delta page token did not advance: {}",
+                        next
+                    )));
+                }
+                None => break,
+            }
+        }
+
+        rebuild_snapshot_children(&mut snapshot);
+        self.check_entry_limit(snapshot.statuses.len())?;
+        let version = target_epoch.unwrap_or(from_epoch);
+        snapshot.version = version;
+        let entries = snapshot.statuses.len();
+        let refresh_time_ms = LocalTime::mills() as i64;
+        snapshot.refresh_time_ms = refresh_time_ms;
+        self.publish_snapshot(snapshot);
+        record_replica_refresh(
+            "success",
+            start,
+            Some(version),
+            Some(entries),
+            Some(self.inner.page_size),
+            Some(page_count),
+            Some(refresh_time_ms),
+        );
+        info!(
+            "metadata replica delta refreshed: from_epoch={}, version={}, entries={}",
+            from_epoch, version, entries
+        );
+        Ok(Some(version))
+    }
+
+    async fn refresh_full(&self, start: Instant) -> FsResult<u64> {
+        let mut snapshot = MetadataReplicaSnapshot::default();
+
+        let mut page_token = None;
+        let mut expected_epoch = None;
+        let mut page_count = 0usize;
+        loop {
+            let page = match self
+                .inner
+                .fs
+                .get_cv_metadata_snapshot_page(
+                    page_token.clone(),
+                    Some(self.inner.page_size as u32),
+                )
+                .await
+            {
+                Ok(page) => page,
+                Err(err) => {
+                    record_replica_refresh(
+                        "failure",
+                        start,
+                        expected_epoch,
+                        Some(snapshot.statuses.len()),
+                        Some(self.inner.page_size),
+                        Some(page_count),
+                        None,
+                    );
+                    return Err(err);
+                }
+            };
+            page_count = page_count.saturating_add(1);
+
+            if let Some(epoch) = expected_epoch {
+                if epoch != page.epoch {
+                    record_replica_refresh(
+                        "failure",
+                        start,
+                        Some(epoch),
+                        Some(snapshot.statuses.len()),
+                        Some(self.inner.page_size),
+                        Some(page_count),
+                        None,
+                    );
+                    return Err(FsError::common(format!(
+                        "Metadata replica snapshot epoch changed during refresh: expected={}, actual={}",
+                        epoch, page.epoch
+                    )));
+                }
+            } else {
+                expected_epoch = Some(page.epoch);
+            }
+
+            for entry in page.entries {
+                let status = ProtoUtils::file_status_from_pb(entry.status);
+                let path = match Path::from_str(&status.path) {
+                    Ok(path) => path,
+                    Err(err) => {
+                        record_replica_refresh(
+                            "failure",
+                            start,
+                            expected_epoch,
+                            Some(snapshot.statuses.len()),
+                            Some(self.inner.page_size),
+                            Some(page_count),
+                            None,
+                        );
+                        return Err(replica_error(err));
+                    }
+                };
+                let key = normalized_cv_key(&path);
+                if status.is_dir {
+                    snapshot.children.entry(key.clone()).or_default();
+                } else if let Some(blocks) = entry.blocks {
+                    snapshot
+                        .blocks
+                        .insert(key.clone(), ProtoUtils::file_blocks_from_pb(blocks));
+                }
+
+                if key != "/" {
+                    let parent_key = parent_cv_key(&key);
+                    snapshot
+                        .children
+                        .entry(parent_key)
+                        .or_default()
+                        .push(status.clone());
+                }
+                snapshot.statuses.insert(key, status);
+                if let Err(err) = self.check_entry_limit(snapshot.statuses.len()) {
+                    record_replica_refresh(
+                        "failure",
+                        start,
+                        expected_epoch,
+                        Some(snapshot.statuses.len()),
+                        Some(self.inner.page_size),
+                        Some(page_count),
+                        None,
+                    );
+                    return Err(err);
+                }
+            }
+
+            match page.next_page_token {
+                Some(next) if Some(next.clone()) != page_token => page_token = Some(next),
+                Some(next) => {
+                    record_replica_refresh(
+                        "failure",
+                        start,
+                        expected_epoch,
+                        Some(snapshot.statuses.len()),
+                        Some(self.inner.page_size),
+                        Some(page_count),
+                        None,
+                    );
+                    return Err(FsError::common(format!(
+                        "Metadata replica snapshot page token did not advance: {}",
+                        next
+                    )));
+                }
+                None => break,
+            }
+        }
+
+        if !snapshot.statuses.contains_key("/") {
+            record_replica_refresh(
+                "failure",
+                start,
+                expected_epoch,
+                Some(0),
+                Some(self.inner.page_size),
+                Some(page_count),
+                None,
+            );
+            return Err(FsError::common(
+                "Metadata replica snapshot did not include root entry",
+            ));
+        }
+        for children in snapshot.children.values_mut() {
+            children.sort_by(|left, right| left.name.cmp(&right.name));
+        }
+
+        let current_version = self.inner.state.read().current.version;
+        snapshot.version = expected_epoch.unwrap_or_else(|| current_version.saturating_add(1));
+        let version = snapshot.version;
+        let entries = snapshot.statuses.len();
+        let refresh_time_ms = LocalTime::mills() as i64;
+        snapshot.refresh_time_ms = refresh_time_ms;
+        self.publish_snapshot(snapshot);
+        record_replica_refresh(
+            "success",
+            start,
+            Some(version),
+            Some(entries),
+            Some(self.inner.page_size),
+            Some(page_count),
+            Some(refresh_time_ms),
+        );
+        info!(
+            "metadata replica refreshed: version={}, entries={}",
+            version, entries
+        );
+        Ok(version)
+    }
+
+    fn publish_snapshot(&self, snapshot: MetadataReplicaSnapshot) {
+        let mut guard = self.inner.state.write();
+        let previous = std::mem::replace(&mut guard.current, snapshot);
+        if previous.refresh_time_ms > 0 && previous.version != guard.current.version {
+            guard.history.push_front(previous);
+            let max_previous = self.inner.history_size.saturating_sub(1);
+            while guard.history.len() > max_previous {
+                guard.history.pop_back();
+            }
+        }
+    }
+
+    fn check_entry_limit(&self, entries: usize) -> FsResult<()> {
+        if entries > self.inner.max_entries {
+            return Err(FsError::common(format!(
+                "Metadata replica entry limit exceeded: entries={}, limit={}",
+                entries, self.inner.max_entries
+            )));
+        }
+        Ok(())
+    }
+
+    fn check_snapshot_fresh(&self, snapshot: &MetadataReplicaSnapshot) -> FsResult<()> {
+        if snapshot.refresh_time_ms <= 0 {
+            return Err(FsError::common(
+                "Metadata replica is not ready; wait for initial refresh",
+            ));
+        }
+        let now_ms = LocalTime::mills() as i64;
+        let max_staleness_ms = self.inner.max_staleness.as_millis().min(i64::MAX as u128) as i64;
+        let staleness_ms = now_ms.saturating_sub(snapshot.refresh_time_ms);
+        if staleness_ms > max_staleness_ms {
+            return Err(FsError::common(format!(
+                "Metadata replica is stale: staleness_ms={}, max_staleness_ms={}, version={}",
+                staleness_ms, max_staleness_ms, snapshot.version
+            )));
+        }
+        Ok(())
+    }
+
+    fn with_snapshot_at_epoch<T>(
+        &self,
+        epoch: Option<u64>,
+        path: &Path,
+        f: impl FnOnce(&MetadataReplicaSnapshot, &str) -> FsResult<T>,
+    ) -> FsResult<T> {
+        let key = normalized_cv_key(path);
+        let state = self.inner.state.read();
+        let snapshot = match epoch {
+            Some(epoch) if state.current.version != epoch => state
+                .history
+                .iter()
+                .find(|snapshot| snapshot.version == epoch)
+                .ok_or_else(|| {
+                    FsError::common(format!(
+                        "CV metadata replica epoch {} is no longer available for {}",
+                        epoch,
+                        path.full_path()
+                    ))
+                })?,
+            _ => &state.current,
+        };
+        self.check_snapshot_fresh(snapshot)?;
+        f(snapshot, &key)
+    }
+}
+
+impl CvMetadataReader for MetadataReplicaReader {
+    fn current_epoch(&self) -> FsResult<Option<u64>> {
+        let state = self.inner.state.read();
+        self.check_snapshot_fresh(&state.current)?;
+        Ok(Some(state.current.version))
+    }
+
+    fn current_refresh_time_ms(&self) -> FsResult<Option<i64>> {
+        let state = self.inner.state.read();
+        self.check_snapshot_fresh(&state.current)?;
+        Ok(Some(state.current.refresh_time_ms))
+    }
+
+    fn covers_time_ms(&self, time_ms: i64) -> FsResult<bool> {
+        let state = self.inner.state.read();
+        self.check_snapshot_fresh(&state.current)?;
+        Ok(state.current.refresh_time_ms >= time_ms)
+    }
+
+    fn get_status<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, FsResult<FileStatus>> {
+        self.get_status_at_epoch(path, None)
+    }
+
+    fn get_status_at_epoch<'a>(
+        &'a self,
+        path: &'a Path,
+        epoch: Option<u64>,
+    ) -> BoxFuture<'a, FsResult<FileStatus>> {
+        Box::pin(async move {
+            self.with_snapshot_at_epoch(epoch, path, |snapshot, key| {
+                snapshot
+                    .statuses
+                    .get(key)
+                    .cloned()
+                    .ok_or_else(|| FsError::file_not_found(path.full_path()))
+            })
+        })
+    }
+
+    fn list_status<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, FsResult<Vec<FileStatus>>> {
+        self.list_status_at_epoch(path, None)
+    }
+
+    fn list_status_at_epoch<'a>(
+        &'a self,
+        path: &'a Path,
+        epoch: Option<u64>,
+    ) -> BoxFuture<'a, FsResult<Vec<FileStatus>>> {
+        Box::pin(async move {
+            self.with_snapshot_at_epoch(epoch, path, |snapshot, key| {
+                let status = snapshot
+                    .statuses
+                    .get(key)
+                    .ok_or_else(|| FsError::file_not_found(path.full_path()))?;
+                if !status.is_dir {
+                    return Err(FsError::common(format!(
+                        "Path {} is not a directory",
+                        path.full_path()
+                    )));
+                }
+                Ok(snapshot.children.get(key).cloned().unwrap_or_default())
+            })
+        })
+    }
+
+    fn get_block_locations<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, FsResult<FileBlocks>> {
+        self.get_block_locations_at_epoch(path, None)
+    }
+
+    fn get_block_locations_at_epoch<'a>(
+        &'a self,
+        path: &'a Path,
+        epoch: Option<u64>,
+    ) -> BoxFuture<'a, FsResult<FileBlocks>> {
+        Box::pin(async move {
+            self.with_snapshot_at_epoch(epoch, path, |snapshot, key| {
+                snapshot
+                    .blocks
+                    .get(key)
+                    .cloned()
+                    .ok_or_else(|| FsError::file_not_found(path.full_path()))
+            })
+        })
+    }
+}
+
+async fn wait_or_stopped(interval: Duration, stop: &AtomicBool) -> bool {
+    let deadline = Instant::now() + interval;
+    while !stop.load(Ordering::Relaxed) {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return false;
+        }
+        tokio::time::sleep(remaining.min(Duration::from_millis(100))).await;
+    }
+    true
+}
+
+fn normalized_cv_key(path: &Path) -> String {
+    let text = path.path().trim_end_matches('/');
+    if text.is_empty() {
+        "/".to_string()
+    } else {
+        text.to_string()
+    }
+}
+
+fn parent_cv_key(key: &str) -> String {
+    match key.rsplit_once('/') {
+        Some(("", _)) | None => "/".to_string(),
+        Some((parent, _)) => parent.to_string(),
+    }
+}
+
+fn apply_delta_entry(
+    snapshot: &mut MetadataReplicaSnapshot,
+    entry: curvine_common::proto::CvMetadataDeltaEntryProto,
+) -> FsResult<()> {
+    let path = Path::from_str(&entry.path).map_err(replica_error)?;
+    let key = normalized_cv_key(&path);
+    match entry.entry {
+        Some(entry) => {
+            let status = ProtoUtils::file_status_from_pb(entry.status);
+            if status.is_dir {
+                snapshot.children.entry(key.clone()).or_default();
+                snapshot.blocks.remove(&key);
+            } else if let Some(blocks) = entry.blocks {
+                snapshot
+                    .blocks
+                    .insert(key.clone(), ProtoUtils::file_blocks_from_pb(blocks));
+                snapshot.children.remove(&key);
+            } else {
+                snapshot.blocks.remove(&key);
+                snapshot.children.remove(&key);
+            }
+            snapshot.statuses.insert(key, status);
+        }
+        None => remove_snapshot_subtree(snapshot, &key),
+    }
+    Ok(())
+}
+
+fn remove_snapshot_subtree(snapshot: &mut MetadataReplicaSnapshot, key: &str) {
+    let prefix = if key == "/" {
+        "/".to_string()
+    } else {
+        format!("{key}/")
+    };
+    let removed: Vec<String> = snapshot
+        .statuses
+        .keys()
+        .filter(|path| path.as_str() == key || path.starts_with(&prefix))
+        .cloned()
+        .collect();
+    for path in removed {
+        snapshot.statuses.remove(&path);
+        snapshot.children.remove(&path);
+        snapshot.blocks.remove(&path);
+    }
+}
+
+fn rebuild_snapshot_children(snapshot: &mut MetadataReplicaSnapshot) {
+    snapshot.children.clear();
+    let mut statuses: Vec<FileStatus> = snapshot.statuses.values().cloned().collect();
+    statuses.sort_by(|left, right| left.path.cmp(&right.path));
+    for status in statuses {
+        let Ok(path) = Path::from_str(&status.path) else {
+            continue;
+        };
+        let key = normalized_cv_key(&path);
+        if status.is_dir {
+            snapshot.children.entry(key.clone()).or_default();
+        }
+        if key != "/" {
+            let parent_key = parent_cv_key(&key);
+            snapshot
+                .children
+                .entry(parent_key)
+                .or_default()
+                .push(status);
+        }
+    }
+    for children in snapshot.children.values_mut() {
+        children.sort_by(|left, right| left.name.cmp(&right.name));
+    }
+}
+
+fn record_replica_refresh(
+    result: &str,
+    start: Instant,
+    version: Option<u64>,
+    entries: Option<usize>,
+    page_size: Option<usize>,
+    pages: Option<usize>,
+    refresh_time_ms: Option<i64>,
+) {
+    if let Ok(metrics) = TransferMetrics::get() {
+        metrics.observe_metadata_replica_refresh(MetadataReplicaRefreshObservation {
+            result,
+            elapsed_us: start.elapsed().as_micros(),
+            version,
+            entries,
+            page_size,
+            pages,
+            refresh_time_ms,
+        });
+    }
+}
+
+fn replica_error(err: impl std::fmt::Display) -> FsError {
+    FsError::common(format!("Metadata replica refresh failed: {}", err))
+}

--- a/curvine-server/src/transfer/handler.rs
+++ b/curvine-server/src/transfer/handler.rs
@@ -25,7 +25,7 @@ use curvine_common::FsResult;
 use orpc::handler::MessageHandler;
 use orpc::message::{Builder, Message};
 
-use crate::transfer::{progress_to_proto, TransferService, TransferStore};
+use crate::transfer::{progress_to_proto, task_summary_to_proto, TransferService, TransferStore};
 
 pub struct TransferHandler<S> {
     service: TransferService<S>,
@@ -52,7 +52,7 @@ where
 
     fn get_transfer_status(&self, msg: &Message) -> FsResult<Message> {
         let req: GetTransferStatusRequest = msg.parse_header()?;
-        let (job, tasks, next_page_token) =
+        let (job, task_summary, tasks, next_page_token) =
             self.service
                 .get_transfer_status(&req.job_id, req.page_size, req.page_token)?;
         let response = GetTransferStatusResponse {
@@ -73,6 +73,7 @@ where
             lease_epoch: Some(job.lease_epoch),
             lease_expire_at: Some(job.lease_expire_at),
             cv_metadata_epoch: job.cv_metadata_epoch,
+            task_summary: Some(task_summary_to_proto(task_summary)),
         };
         Ok(Builder::success(msg).proto_header(response).build())
     }
@@ -102,7 +103,7 @@ where
 
     fn watch_transfer(&self, msg: &Message) -> FsResult<Message> {
         let req: WatchTransferRequest = msg.parse_header()?;
-        let (job, tasks, next_page_token, changed) = self.service.watch_transfer(
+        let (job, task_summary, tasks, next_page_token, changed) = self.service.watch_transfer(
             &req.job_id,
             req.since_updated_at,
             req.page_size,
@@ -124,6 +125,7 @@ where
             lease_epoch: Some(job.lease_epoch),
             lease_expire_at: Some(job.lease_expire_at),
             cv_metadata_epoch: job.cv_metadata_epoch,
+            task_summary: Some(task_summary_to_proto(task_summary)),
         };
         Ok(Builder::success(msg).proto_header(response).build())
     }

--- a/curvine-server/src/transfer/handler.rs
+++ b/curvine-server/src/transfer/handler.rs
@@ -1,0 +1,175 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use curvine_common::error::FsError;
+use curvine_common::fs::RpcCode;
+use curvine_common::proto::{
+    CancelTransferRequest, CancelTransferResponse, GetTransferStatusRequest,
+    GetTransferStatusResponse, ListTransferTenantsRequest, ListTransfersRequest,
+    RetryTransferRequest, SubmitTransferRequest, SubmitTransferResponse, TransferTaskReportRequest,
+    TransferTaskReportResponse, WatchTransferRequest, WatchTransferResponse,
+};
+use curvine_common::state::TransferState;
+use curvine_common::FsResult;
+use orpc::handler::MessageHandler;
+use orpc::message::{Builder, Message};
+
+use crate::transfer::{progress_to_proto, TransferService, TransferStore};
+
+pub struct TransferHandler<S> {
+    service: TransferService<S>,
+}
+
+impl<S> TransferHandler<S>
+where
+    S: TransferStore,
+{
+    pub fn new(service: TransferService<S>) -> Self {
+        Self { service }
+    }
+
+    fn submit_transfer(&self, msg: &Message) -> FsResult<Message> {
+        let req: SubmitTransferRequest = msg.parse_header()?;
+        let job = self.service.submit_transfer(req)?;
+        let response = SubmitTransferResponse {
+            job_id: job.job_id,
+            run_id: job.run_id,
+            state: transfer_state_code(job.state),
+        };
+        Ok(Builder::success(msg).proto_header(response).build())
+    }
+
+    fn get_transfer_status(&self, msg: &Message) -> FsResult<Message> {
+        let req: GetTransferStatusRequest = msg.parse_header()?;
+        let (job, tasks, next_page_token) =
+            self.service
+                .get_transfer_status(&req.job_id, req.page_size, req.page_token)?;
+        let response = GetTransferStatusResponse {
+            job_id: job.job_id,
+            run_id: job.run_id,
+            state: transfer_state_code(job.state),
+            progress: progress_to_proto(job.summary),
+            tasks,
+            next_page_token,
+            kind: Some(job.kind as i32),
+            source_path: Some(job.source_path),
+            target_path: Some(job.target_path),
+            submitter: Some(job.submitter),
+            tenant: Some(job.tenant),
+            created_at: Some(job.created_at),
+            updated_at: Some(job.updated_at),
+            owner: Some(job.owner),
+            lease_epoch: Some(job.lease_epoch),
+            lease_expire_at: Some(job.lease_expire_at),
+            cv_metadata_epoch: job.cv_metadata_epoch,
+        };
+        Ok(Builder::success(msg).proto_header(response).build())
+    }
+
+    fn retry_transfer(&self, msg: &Message) -> FsResult<Message> {
+        let req: RetryTransferRequest = msg.parse_header()?;
+        let job = self.service.retry_transfer(&req.job_id)?;
+        let response = SubmitTransferResponse {
+            job_id: job.job_id,
+            run_id: job.run_id,
+            state: transfer_state_code(job.state),
+        };
+        Ok(Builder::success(msg).proto_header(response).build())
+    }
+
+    fn list_transfers(&self, msg: &Message) -> FsResult<Message> {
+        let req: ListTransfersRequest = msg.parse_header()?;
+        let response = self.service.list_transfers(req)?;
+        Ok(Builder::success(msg).proto_header(response).build())
+    }
+
+    fn list_transfer_tenants(&self, msg: &Message) -> FsResult<Message> {
+        let req: ListTransferTenantsRequest = msg.parse_header()?;
+        let response = self.service.list_tenant_summaries(req)?;
+        Ok(Builder::success(msg).proto_header(response).build())
+    }
+
+    fn watch_transfer(&self, msg: &Message) -> FsResult<Message> {
+        let req: WatchTransferRequest = msg.parse_header()?;
+        let (job, tasks, next_page_token, changed) = self.service.watch_transfer(
+            &req.job_id,
+            req.since_updated_at,
+            req.page_size,
+            req.page_token,
+        )?;
+        let response = WatchTransferResponse {
+            job_id: job.job_id,
+            run_id: job.run_id,
+            state: transfer_state_code(job.state),
+            progress: progress_to_proto(job.summary),
+            tasks,
+            next_page_token,
+            updated_at: job.updated_at,
+            changed,
+            kind: Some(job.kind as i32),
+            source_path: Some(job.source_path),
+            target_path: Some(job.target_path),
+            owner: Some(job.owner),
+            lease_epoch: Some(job.lease_epoch),
+            lease_expire_at: Some(job.lease_expire_at),
+            cv_metadata_epoch: job.cv_metadata_epoch,
+        };
+        Ok(Builder::success(msg).proto_header(response).build())
+    }
+
+    fn cancel_transfer(&self, msg: &Message) -> FsResult<Message> {
+        let req: CancelTransferRequest = msg.parse_header()?;
+        let state = self.service.request_cancel(&req.job_id, req.run_id)?;
+        let response = CancelTransferResponse {
+            job_id: req.job_id,
+            state: transfer_state_code(state),
+        };
+        Ok(Builder::success(msg).proto_header(response).build())
+    }
+
+    fn report_task(&self, msg: &Message) -> FsResult<Message> {
+        let req: TransferTaskReportRequest = msg.parse_header()?;
+        let accepted = self.service.report_task(req)?;
+        let response = TransferTaskReportResponse { accepted };
+        Ok(Builder::success(msg).proto_header(response).build())
+    }
+}
+
+impl<S> MessageHandler for TransferHandler<S>
+where
+    S: TransferStore,
+{
+    type Error = FsError;
+
+    fn handle(&mut self, msg: &Message) -> FsResult<Message> {
+        match RpcCode::from(msg.code()) {
+            RpcCode::SubmitTransfer => self.submit_transfer(msg),
+            RpcCode::GetTransferStatus => self.get_transfer_status(msg),
+            RpcCode::RetryTransfer => self.retry_transfer(msg),
+            RpcCode::ListTransfers => self.list_transfers(msg),
+            RpcCode::WatchTransfer => self.watch_transfer(msg),
+            RpcCode::CancelTransfer => self.cancel_transfer(msg),
+            RpcCode::ReportTransferTask => self.report_task(msg),
+            RpcCode::ListTransferTenants => self.list_transfer_tenants(msg),
+            code => Err(FsError::common(format!(
+                "Unsupported transfer rpc code {}",
+                code
+            ))),
+        }
+    }
+}
+
+fn transfer_state_code(state: TransferState) -> i32 {
+    state as i32
+}

--- a/curvine-server/src/transfer/handler.rs
+++ b/curvine-server/src/transfer/handler.rs
@@ -154,7 +154,7 @@ where
 {
     type Error = FsError;
 
-    fn handle(&mut self, msg: &Message) -> FsResult<Message> {
+    fn handle(&self, msg: &Message) -> FsResult<Message> {
         match RpcCode::from(msg.code()) {
             RpcCode::SubmitTransfer => self.submit_transfer(msg),
             RpcCode::GetTransferStatus => self.get_transfer_status(msg),

--- a/curvine-server/src/transfer/job_snapshot.rs
+++ b/curvine-server/src/transfer/job_snapshot.rs
@@ -1,0 +1,42 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::transfer::ClusterMetadataCache;
+use curvine_common::error::FsError;
+use curvine_common::fs::Path;
+use curvine_common::state::{MountInfo, TransferJobRecord};
+use curvine_common::FsResult;
+
+pub fn job_mount_snapshot(
+    job: &TransferJobRecord,
+    cache: &ClusterMetadataCache,
+) -> FsResult<MountInfo> {
+    if !is_empty_snapshot(&job.mount_snapshot_json) {
+        return serde_json::from_str(&job.mount_snapshot_json).map_err(|err| {
+            FsError::common(format!(
+                "Invalid transfer mount snapshot for job {}: {}",
+                job.job_id, err
+            ))
+        });
+    }
+
+    let source = Path::from_str(&job.source_path)?;
+    let target = Path::from_str(&job.target_path)?;
+    cache.find_mount(job.kind, &source, &target)
+}
+
+fn is_empty_snapshot(value: &str) -> bool {
+    let value = value.trim();
+    value.is_empty() || value == "{}"
+}

--- a/curvine-server/src/transfer/memory_store.rs
+++ b/curvine-server/src/transfer/memory_store.rs
@@ -16,14 +16,17 @@ use std::collections::HashMap;
 
 use curvine_common::error::FsError;
 use curvine_common::state::{
-    summarize_transfer_tasks, StaleTaskAttempt, TaskAttemptStart, TransferJobRecord, TransferLease,
-    TransferListFilter, TransferState, TransferStateUpdate, TransferTaskRecord, TransferTaskReport,
-    TransferTaskState, TransferTenantSummary,
+    StaleTaskAttempt, TaskAttemptStart, TransferJobRecord, TransferLease, TransferListFilter,
+    TransferState, TransferStateUpdate, TransferTaskRecord, TransferTaskReport, TransferTaskState,
+    TransferTenantSummary,
 };
 use curvine_common::FsResult;
 use parking_lot::Mutex;
 
-use crate::transfer::{TransferRequeueUpdate, TransferStore};
+use crate::transfer::{
+    apply_task_report_progress, TransferPlannedTasks, TransferRequeueUpdate, TransferStore,
+    TransferTaskStateUpdate,
+};
 
 #[derive(Default)]
 pub struct MemoryTransferStore {
@@ -359,6 +362,7 @@ impl TransferStore for MemoryTransferStore {
         if job.run_id != run_id
             || job.owner != owner
             || job.lease_epoch != lease_epoch
+            || job.lease_expire_at <= now_ms
             || job.state.is_terminal()
         {
             return Ok(false);
@@ -377,6 +381,7 @@ impl TransferStore for MemoryTransferStore {
         if job.run_id != update.run_id
             || job.owner != update.owner
             || job.lease_epoch != update.lease_epoch
+            || job.lease_expire_at <= update.now_ms
             || !update.from_states.contains(&job.state)
         {
             return Ok(false);
@@ -388,29 +393,6 @@ impl TransferStore for MemoryTransferStore {
         Ok(true)
     }
 
-    fn set_transfer_state(
-        &self,
-        job_id: &str,
-        run_id: u64,
-        state: TransferState,
-        message: impl Into<String>,
-        now_ms: i64,
-    ) -> FsResult<bool> {
-        let mut inner = self.inner.lock();
-        let Some(job) = inner.jobs.get_mut(job_id) else {
-            return Ok(false);
-        };
-        if job.run_id != run_id {
-            return Ok(false);
-        }
-
-        job.state = state;
-        job.summary.message = message.into();
-        job.summary.update_time = now_ms;
-        job.updated_at = now_ms;
-        Ok(true)
-    }
-
     fn requeue_transfer(&self, update: TransferRequeueUpdate) -> FsResult<bool> {
         let mut inner = self.inner.lock();
         let Some(job) = inner.jobs.get_mut(&update.job_id) else {
@@ -419,6 +401,7 @@ impl TransferStore for MemoryTransferStore {
         if job.run_id != update.run_id
             || job.owner != update.owner
             || job.lease_epoch != update.lease_epoch
+            || job.lease_expire_at <= update.now_ms
             || job.state != TransferState::Planning
         {
             return Ok(false);
@@ -449,6 +432,7 @@ impl TransferStore for MemoryTransferStore {
         if job.run_id != run_id
             || job.owner != owner
             || job.lease_epoch != lease_epoch
+            || job.lease_expire_at <= now_ms
             || job.state.is_terminal()
         {
             return Ok(false);
@@ -474,25 +458,58 @@ impl TransferStore for MemoryTransferStore {
         Ok(())
     }
 
-    fn update_task_state(
-        &self,
-        job_id: &str,
-        run_id: u64,
-        task_id: &str,
-        state: TransferTaskState,
-        message: impl Into<String>,
-        now_ms: i64,
-    ) -> FsResult<bool> {
+    fn persist_planned_tasks(&self, update: TransferPlannedTasks) -> FsResult<bool> {
         let mut inner = self.inner.lock();
-        let key = (job_id.to_string(), run_id, task_id.to_string());
+        let valid_owner = inner.jobs.get(&update.job_id).is_some_and(|job| {
+            job.run_id == update.run_id
+                && job.owner == update.owner
+                && job.lease_epoch == update.lease_epoch
+                && job.lease_expire_at > update.now_ms
+                && job.state == TransferState::Planning
+        });
+        if !valid_owner {
+            return Ok(false);
+        }
+        for task in update.tasks {
+            let key = (task.job_id.clone(), task.run_id, task.task_id.clone());
+            inner.tasks.entry(key).or_insert(task);
+        }
+        let job = inner
+            .jobs
+            .get_mut(&update.job_id)
+            .ok_or_else(|| FsError::job_not_found(&update.job_id))?;
+        job.state = TransferState::Dispatching;
+        job.summary.message = update.message;
+        job.summary.update_time = update.now_ms;
+        job.updated_at = update.now_ms;
+        Ok(true)
+    }
+
+    fn update_task_state(&self, update: TransferTaskStateUpdate) -> FsResult<bool> {
+        let mut inner = self.inner.lock();
+        let Some(job) = inner.jobs.get(&update.job_id) else {
+            return Ok(false);
+        };
+        if job.run_id != update.run_id
+            || job.owner != update.owner
+            || job.lease_epoch != update.lease_epoch
+            || job.lease_expire_at <= update.now_ms
+            || job.state.is_terminal()
+        {
+            return Ok(false);
+        }
+        let key = (update.job_id, update.run_id, update.task_id);
         let Some(task) = inner.tasks.get_mut(&key) else {
             return Ok(false);
         };
+        if !update.from_states.is_empty() && !update.from_states.contains(&task.state) {
+            return Ok(false);
+        }
 
-        task.state = state;
-        task.progress.message = message.into();
-        task.progress.update_time = now_ms;
-        task.updated_at = now_ms;
+        task.state = update.state;
+        task.progress.message = update.message;
+        task.progress.update_time = update.now_ms;
+        task.updated_at = update.now_ms;
         Ok(true)
     }
 
@@ -529,7 +546,11 @@ impl TransferStore for MemoryTransferStore {
         let Some(job) = inner.jobs.get(job_id) else {
             return Ok(Vec::new());
         };
-        if job.run_id != run_id || job.owner != owner || job.lease_epoch != lease_epoch {
+        if job.run_id != run_id
+            || job.owner != owner
+            || job.lease_epoch != lease_epoch
+            || job.lease_expire_at <= now_ms
+        {
             return Ok(Vec::new());
         }
 
@@ -553,10 +574,12 @@ impl TransferStore for MemoryTransferStore {
         Ok(stale)
     }
 
-    fn list_recoverable_tasks(
+    fn list_stale_running_tasks(
         &self,
         job_id: &str,
         run_id: u64,
+        stale_before_ms: i64,
+        limit: usize,
     ) -> FsResult<Vec<TransferTaskRecord>> {
         Ok(self
             .inner
@@ -566,15 +589,33 @@ impl TransferStore for MemoryTransferStore {
             .filter(|task| {
                 task.job_id == job_id
                     && task.run_id == run_id
-                    && matches!(
-                        task.state,
-                        TransferTaskState::Pending
-                            | TransferTaskState::Running
-                            | TransferTaskState::Stale
-                    )
+                    && task.state == TransferTaskState::Running
+                    && task.stale_deadline_at < stale_before_ms
             })
+            .take(limit)
             .cloned()
             .collect())
+    }
+
+    fn has_failed_tasks(&self, job_id: &str, run_id: u64) -> FsResult<bool> {
+        Ok(self.inner.lock().tasks.values().any(|task| {
+            task.job_id == job_id
+                && task.run_id == run_id
+                && task.state == TransferTaskState::Failed
+        }))
+    }
+
+    fn has_recoverable_tasks(&self, job_id: &str, run_id: u64) -> FsResult<bool> {
+        Ok(self.inner.lock().tasks.values().any(|task| {
+            task.job_id == job_id
+                && task.run_id == run_id
+                && matches!(
+                    task.state,
+                    TransferTaskState::Pending
+                        | TransferTaskState::Running
+                        | TransferTaskState::Stale
+                )
+        }))
     }
 
     fn start_task_attempt(&self, start: TaskAttemptStart) -> FsResult<bool> {
@@ -585,6 +626,7 @@ impl TransferStore for MemoryTransferStore {
         if job.run_id != start.run_id
             || job.owner != start.owner
             || job.lease_epoch != start.lease_epoch
+            || job.lease_expire_at <= start.now_ms
             || job.cancel_requested
             || job.state.is_terminal()
         {
@@ -616,7 +658,7 @@ impl TransferStore for MemoryTransferStore {
     fn update_task_report(&self, report: TransferTaskReport) -> FsResult<bool> {
         let mut inner = self.inner.lock();
         let key = (report.job_id, report.run_id, report.task_id);
-        let (task_job_id, task_state) = {
+        let (task_job_id, previous_progress) = {
             let Some(task) = inner.tasks.get_mut(&key) else {
                 return Ok(false);
             };
@@ -628,36 +670,23 @@ impl TransferStore for MemoryTransferStore {
                 return Ok(false);
             }
 
+            let previous_progress = task.progress.clone();
             task.state = report.state;
-            task.progress = report.progress;
+            task.progress = report.progress.clone();
             task.last_report_at = report.now_ms;
             task.stale_deadline_at = report.stale_deadline_at;
             task.updated_at = report.now_ms;
-            (task.job_id.clone(), task.state)
+            (task.job_id.clone(), previous_progress)
         };
 
-        let summary = summarize_transfer_tasks(
-            inner
-                .tasks
-                .values()
-                .filter(|task| task.job_id == task_job_id && task.run_id == report.run_id),
-            report.now_ms,
-        );
-        let has_failed = summary.has_failed;
-        let all_completed = summary.all_completed;
-        let has_task = summary.has_task;
-        let progress = summary.progress;
-
         if let Some(job) = inner.jobs.get_mut(&task_job_id) {
-            job.summary = progress;
+            apply_task_report_progress(
+                &mut job.summary,
+                &previous_progress,
+                &report.progress,
+                report.now_ms,
+            );
             job.updated_at = report.now_ms;
-            if has_failed {
-                job.state = TransferState::Failed;
-            } else if has_task && all_completed {
-                job.state = TransferState::Completed;
-            } else if task_state == TransferTaskState::Completed {
-                job.state = TransferState::Running;
-            }
         }
         Ok(true)
     }
@@ -691,6 +720,9 @@ fn add_job_to_tenant_summary(
         TransferState::Completed => summary.completed = summary.completed.saturating_add(1),
         TransferState::Failed => summary.failed = summary.failed.saturating_add(1),
         TransferState::Canceled => summary.canceled = summary.canceled.saturating_add(1),
+        TransferState::PartialSuccess => {
+            summary.partial_success = summary.partial_success.saturating_add(1)
+        }
     }
 }
 

--- a/curvine-server/src/transfer/memory_store.rs
+++ b/curvine-server/src/transfer/memory_store.rs
@@ -1,0 +1,735 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+
+use curvine_common::error::FsError;
+use curvine_common::state::{
+    summarize_transfer_tasks, StaleTaskAttempt, TaskAttemptStart, TransferJobRecord, TransferLease,
+    TransferListFilter, TransferState, TransferStateUpdate, TransferTaskRecord, TransferTaskReport,
+    TransferTaskState, TransferTenantSummary,
+};
+use curvine_common::FsResult;
+use parking_lot::Mutex;
+
+use crate::transfer::{TransferRequeueUpdate, TransferStore};
+
+#[derive(Default)]
+pub struct MemoryTransferStore {
+    inner: Mutex<MemoryTransferState>,
+}
+
+#[derive(Default)]
+struct MemoryTransferState {
+    jobs: HashMap<String, TransferJobRecord>,
+    request_index: HashMap<(String, String), String>,
+    tasks: HashMap<(String, u64, String), TransferTaskRecord>,
+}
+
+impl MemoryTransferStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl TransferStore for MemoryTransferStore {
+    fn check_available(&self) -> FsResult<()> {
+        Ok(())
+    }
+
+    fn create_or_get_by_request_id(&self, job: TransferJobRecord) -> FsResult<TransferJobRecord> {
+        self.create_or_get_by_request_id_checked(job)
+    }
+
+    fn create_or_get_by_request_id_checked(
+        &self,
+        job: TransferJobRecord,
+    ) -> FsResult<TransferJobRecord> {
+        let mut inner = self.inner.lock();
+        let request_key = (job.submitter.clone(), job.client_request_id.clone());
+        if let Some(job_id) = inner.request_index.get(&request_key) {
+            return inner
+                .jobs
+                .get(job_id)
+                .cloned()
+                .ok_or_else(|| FsError::job_not_found(job_id));
+        }
+
+        if let Some(existing) = inner
+            .jobs
+            .values()
+            .find(|existing| existing.job_key == job.job_key && !existing.state.is_terminal())
+        {
+            if existing.command_json == job.command_json {
+                return Ok(existing.clone());
+            }
+            return Err(FsError::transfer_already_running(format!(
+                "job_key {} has running job {} with different command",
+                existing.job_key, existing.job_id
+            )));
+        }
+
+        if let Some(existing) = inner.jobs.values().find(|existing| {
+            !(existing.state.is_terminal()
+                || (existing.submitter == job.submitter
+                    && existing.client_request_id == job.client_request_id))
+                && target_paths_conflict(&existing.target_path, &job.target_path)
+        }) {
+            return Err(FsError::transfer_target_conflict(format!(
+                "target {} conflicts with active transfer {} target {}",
+                job.target_path, existing.job_id, existing.target_path
+            )));
+        }
+
+        inner.request_index.insert(request_key, job.job_id.clone());
+        inner.jobs.insert(job.job_id.clone(), job.clone());
+        Ok(job)
+    }
+
+    fn get_transfer(&self, job_id: &str) -> FsResult<Option<TransferJobRecord>> {
+        Ok(self.inner.lock().jobs.get(job_id).cloned())
+    }
+
+    fn get_transfer_by_request(
+        &self,
+        submitter: &str,
+        client_request_id: &str,
+    ) -> FsResult<Option<TransferJobRecord>> {
+        let inner = self.inner.lock();
+        let Some(job_id) = inner
+            .request_index
+            .get(&(submitter.to_string(), client_request_id.to_string()))
+        else {
+            return Ok(None);
+        };
+        Ok(inner.jobs.get(job_id).cloned())
+    }
+
+    fn list_active_transfers(&self) -> FsResult<Vec<TransferJobRecord>> {
+        Ok(self
+            .inner
+            .lock()
+            .jobs
+            .values()
+            .filter(|job| !job.state.is_terminal())
+            .cloned()
+            .collect())
+    }
+
+    fn find_conflicting_active_transfer(
+        &self,
+        target_path: &str,
+        submitter: &str,
+        client_request_id: &str,
+    ) -> FsResult<Option<TransferJobRecord>> {
+        Ok(self
+            .inner
+            .lock()
+            .jobs
+            .values()
+            .find(|job| {
+                !(job.state.is_terminal()
+                    || (job.submitter == submitter && job.client_request_id == client_request_id))
+                    && target_paths_conflict(target_path, &job.target_path)
+            })
+            .cloned())
+    }
+
+    fn count_active_transfers(&self) -> FsResult<u64> {
+        Ok(self
+            .inner
+            .lock()
+            .jobs
+            .values()
+            .filter(|job| !job.state.is_terminal())
+            .count() as u64)
+    }
+
+    fn count_executing_transfers(&self) -> FsResult<u64> {
+        Ok(self
+            .inner
+            .lock()
+            .jobs
+            .values()
+            .filter(|job| job.state.is_executing())
+            .count() as u64)
+    }
+
+    fn list_transfers(&self, filter: TransferListFilter) -> FsResult<Vec<TransferJobRecord>> {
+        let mut jobs: Vec<_> = self
+            .inner
+            .lock()
+            .jobs
+            .values()
+            .filter(|job| filter.kind.is_none_or(|kind| job.kind == kind))
+            .filter(|job| filter.state.is_none_or(|state| job.state == state))
+            .filter(|job| {
+                filter
+                    .submitter
+                    .as_ref()
+                    .is_none_or(|submitter| job.submitter == *submitter)
+            })
+            .filter(|job| {
+                filter
+                    .tenant
+                    .as_ref()
+                    .is_none_or(|tenant| job.tenant == *tenant)
+            })
+            .cloned()
+            .collect();
+        jobs.sort_by(|left, right| {
+            right
+                .updated_at
+                .cmp(&left.updated_at)
+                .then_with(|| right.created_at.cmp(&left.created_at))
+                .then_with(|| right.job_id.cmp(&left.job_id))
+        });
+        Ok(jobs
+            .into_iter()
+            .skip(filter.offset)
+            .take(filter.limit)
+            .collect())
+    }
+
+    fn list_tenant_summaries(
+        &self,
+        limit: usize,
+        offset: usize,
+    ) -> FsResult<Vec<TransferTenantSummary>> {
+        let inner = self.inner.lock();
+        let mut summaries = HashMap::<String, TransferTenantSummary>::new();
+        for job in inner.jobs.values() {
+            add_job_to_tenant_summary(&mut summaries, job);
+        }
+        Ok(sorted_tenant_summaries(summaries, limit, offset))
+    }
+
+    fn purge_terminal_transfers(&self, older_than_ms: i64, limit: usize) -> FsResult<usize> {
+        if limit == 0 {
+            return Ok(0);
+        }
+        let mut inner = self.inner.lock();
+        let job_ids = inner
+            .jobs
+            .values()
+            .filter(|job| job.state.is_terminal() && job.updated_at < older_than_ms)
+            .take(limit)
+            .map(|job| job.job_id.clone())
+            .collect::<Vec<_>>();
+        for job_id in &job_ids {
+            inner.jobs.remove(job_id);
+            inner
+                .request_index
+                .retain(|_, indexed_job_id| indexed_job_id != job_id);
+            inner
+                .tasks
+                .retain(|(task_job_id, _, _), _| task_job_id != job_id);
+        }
+        Ok(job_ids.len())
+    }
+
+    fn list_transfer_tasks(&self, job_id: &str, run_id: u64) -> FsResult<Vec<TransferTaskRecord>> {
+        Ok(self
+            .inner
+            .lock()
+            .tasks
+            .values()
+            .filter(|task| task.job_id == job_id && task.run_id == run_id)
+            .cloned()
+            .collect())
+    }
+
+    fn request_cancel(&self, job_id: &str, run_id: u64, now_ms: i64) -> FsResult<bool> {
+        let mut inner = self.inner.lock();
+        let Some(job) = inner.jobs.get_mut(job_id) else {
+            return Ok(false);
+        };
+        if job.run_id != run_id || job.state.is_terminal() {
+            return Ok(false);
+        }
+        job.cancel_requested = true;
+        job.state = TransferState::Canceling;
+        job.summary.message = "cancel requested".to_string();
+        job.summary.update_time = now_ms;
+        job.updated_at = now_ms;
+        Ok(true)
+    }
+
+    fn acquire_runnable_transfer(
+        &self,
+        owner: &str,
+        lease_ms: i64,
+        now_ms: i64,
+        max_executing_transfers: u64,
+    ) -> FsResult<Option<TransferLease>> {
+        let mut inner = self.inner.lock();
+        let executing = inner
+            .jobs
+            .values()
+            .filter(|job| job.state.is_executing())
+            .count() as u64;
+        let candidate_id = inner
+            .jobs
+            .values()
+            .filter(|job| {
+                job.owner == owner
+                    && matches!(job.state, TransferState::Running | TransferState::Canceling)
+                    && job.lease_expire_at > now_ms
+                    && job.updated_at < now_ms
+            })
+            .min_by_key(|job| job.updated_at)
+            .map(|job| job.job_id.clone())
+            .or_else(|| {
+                inner
+                    .jobs
+                    .values()
+                    .filter(|job| {
+                        job.state.is_runnable()
+                            && job.state != TransferState::Pending
+                            && job.lease_expire_at <= now_ms
+                    })
+                    .min_by_key(|job| job.updated_at)
+                    .map(|job| job.job_id.clone())
+            })
+            .or_else(|| {
+                if executing >= max_executing_transfers {
+                    return None;
+                }
+                inner
+                    .jobs
+                    .values()
+                    .filter(|job| {
+                        job.state == TransferState::Pending && job.lease_expire_at <= now_ms
+                    })
+                    .min_by_key(|job| {
+                        let executing_for_tenant = executing_for_tenant(&inner, &job.tenant);
+                        let tenant_pressure = u64::from(executing_for_tenant > 0);
+                        (tenant_pressure, job.updated_at, job.job_id.clone())
+                    })
+                    .map(|job| job.job_id.clone())
+            });
+        let Some(candidate_id) = candidate_id else {
+            return Ok(None);
+        };
+        let Some(job) = inner.jobs.get_mut(&candidate_id) else {
+            return Ok(None);
+        };
+
+        if job.state == TransferState::Pending {
+            job.state = TransferState::Planning;
+            job.summary.message = "acquired for planning".to_string();
+            job.summary.update_time = now_ms;
+        }
+        job.owner = owner.to_string();
+        job.lease_epoch = job.lease_epoch.saturating_add(1);
+        job.lease_expire_at = now_ms.saturating_add(lease_ms);
+        job.updated_at = now_ms;
+        Ok(Some(TransferLease {
+            job_id: job.job_id.clone(),
+            run_id: job.run_id,
+            owner: job.owner.clone(),
+            lease_epoch: job.lease_epoch,
+        }))
+    }
+
+    fn renew_lease(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        owner: &str,
+        lease_epoch: u64,
+        lease_ms: i64,
+        now_ms: i64,
+    ) -> FsResult<bool> {
+        let mut inner = self.inner.lock();
+        let Some(job) = inner.jobs.get_mut(job_id) else {
+            return Ok(false);
+        };
+        if job.run_id != run_id
+            || job.owner != owner
+            || job.lease_epoch != lease_epoch
+            || job.state.is_terminal()
+        {
+            return Ok(false);
+        }
+
+        job.lease_expire_at = now_ms.saturating_add(lease_ms);
+        job.updated_at = now_ms;
+        Ok(true)
+    }
+
+    fn update_transfer_state(&self, update: TransferStateUpdate) -> FsResult<bool> {
+        let mut inner = self.inner.lock();
+        let Some(job) = inner.jobs.get_mut(&update.job_id) else {
+            return Ok(false);
+        };
+        if job.run_id != update.run_id
+            || job.owner != update.owner
+            || job.lease_epoch != update.lease_epoch
+            || !update.from_states.contains(&job.state)
+        {
+            return Ok(false);
+        }
+
+        job.state = update.to_state;
+        job.summary.message = update.message;
+        job.updated_at = update.now_ms;
+        Ok(true)
+    }
+
+    fn set_transfer_state(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        state: TransferState,
+        message: impl Into<String>,
+        now_ms: i64,
+    ) -> FsResult<bool> {
+        let mut inner = self.inner.lock();
+        let Some(job) = inner.jobs.get_mut(job_id) else {
+            return Ok(false);
+        };
+        if job.run_id != run_id {
+            return Ok(false);
+        }
+
+        job.state = state;
+        job.summary.message = message.into();
+        job.summary.update_time = now_ms;
+        job.updated_at = now_ms;
+        Ok(true)
+    }
+
+    fn requeue_transfer(&self, update: TransferRequeueUpdate) -> FsResult<bool> {
+        let mut inner = self.inner.lock();
+        let Some(job) = inner.jobs.get_mut(&update.job_id) else {
+            return Ok(false);
+        };
+        if job.run_id != update.run_id
+            || job.owner != update.owner
+            || job.lease_epoch != update.lease_epoch
+            || job.state != TransferState::Planning
+        {
+            return Ok(false);
+        }
+
+        job.state = TransferState::Pending;
+        job.owner.clear();
+        job.lease_expire_at = update.next_attempt_at_ms;
+        job.summary.message = update.message;
+        job.summary.update_time = update.now_ms;
+        job.updated_at = update.now_ms;
+        Ok(true)
+    }
+
+    fn set_transfer_cv_metadata_epoch(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        owner: &str,
+        lease_epoch: u64,
+        cv_metadata_epoch: u64,
+        now_ms: i64,
+    ) -> FsResult<bool> {
+        let mut inner = self.inner.lock();
+        let Some(job) = inner.jobs.get_mut(job_id) else {
+            return Ok(false);
+        };
+        if job.run_id != run_id
+            || job.owner != owner
+            || job.lease_epoch != lease_epoch
+            || job.state.is_terminal()
+        {
+            return Ok(false);
+        }
+        if job
+            .cv_metadata_epoch
+            .is_some_and(|existing| existing != cv_metadata_epoch)
+        {
+            return Ok(false);
+        }
+
+        job.cv_metadata_epoch = Some(cv_metadata_epoch);
+        job.updated_at = now_ms;
+        Ok(true)
+    }
+
+    fn insert_tasks(&self, tasks: Vec<TransferTaskRecord>) -> FsResult<()> {
+        let mut inner = self.inner.lock();
+        for task in tasks {
+            let key = (task.job_id.clone(), task.run_id, task.task_id.clone());
+            inner.tasks.entry(key).or_insert(task);
+        }
+        Ok(())
+    }
+
+    fn update_task_state(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        task_id: &str,
+        state: TransferTaskState,
+        message: impl Into<String>,
+        now_ms: i64,
+    ) -> FsResult<bool> {
+        let mut inner = self.inner.lock();
+        let key = (job_id.to_string(), run_id, task_id.to_string());
+        let Some(task) = inner.tasks.get_mut(&key) else {
+            return Ok(false);
+        };
+
+        task.state = state;
+        task.progress.message = message.into();
+        task.progress.update_time = now_ms;
+        task.updated_at = now_ms;
+        Ok(true)
+    }
+
+    fn claim_pending_tasks(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        limit: usize,
+    ) -> FsResult<Vec<TransferTaskRecord>> {
+        let inner = self.inner.lock();
+        Ok(inner
+            .tasks
+            .values()
+            .filter(|task| {
+                task.job_id == job_id
+                    && task.run_id == run_id
+                    && task.state == TransferTaskState::Pending
+            })
+            .take(limit)
+            .cloned()
+            .collect())
+    }
+
+    fn mark_stale_attempts(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        owner: &str,
+        lease_epoch: u64,
+        now_ms: i64,
+        limit: usize,
+    ) -> FsResult<Vec<StaleTaskAttempt>> {
+        let mut inner = self.inner.lock();
+        let Some(job) = inner.jobs.get(job_id) else {
+            return Ok(Vec::new());
+        };
+        if job.run_id != run_id || job.owner != owner || job.lease_epoch != lease_epoch {
+            return Ok(Vec::new());
+        }
+
+        let mut stale = Vec::new();
+        for task in inner.tasks.values_mut().filter(|task| {
+            task.job_id == job_id
+                && task.run_id == run_id
+                && task.state == TransferTaskState::Running
+                && task.stale_deadline_at < now_ms
+        }) {
+            task.state = TransferTaskState::Stale;
+            task.retry_count = task.retry_count.saturating_add(1);
+            task.progress.message = "task stale timeout".to_string();
+            task.progress.update_time = now_ms;
+            task.updated_at = now_ms;
+            stale.push(StaleTaskAttempt { task: task.clone() });
+            if stale.len() >= limit {
+                break;
+            }
+        }
+        Ok(stale)
+    }
+
+    fn list_recoverable_tasks(
+        &self,
+        job_id: &str,
+        run_id: u64,
+    ) -> FsResult<Vec<TransferTaskRecord>> {
+        Ok(self
+            .inner
+            .lock()
+            .tasks
+            .values()
+            .filter(|task| {
+                task.job_id == job_id
+                    && task.run_id == run_id
+                    && matches!(
+                        task.state,
+                        TransferTaskState::Pending
+                            | TransferTaskState::Running
+                            | TransferTaskState::Stale
+                    )
+            })
+            .cloned()
+            .collect())
+    }
+
+    fn start_task_attempt(&self, start: TaskAttemptStart) -> FsResult<bool> {
+        let mut inner = self.inner.lock();
+        let Some(job) = inner.jobs.get(&start.job_id) else {
+            return Ok(false);
+        };
+        if job.run_id != start.run_id
+            || job.owner != start.owner
+            || job.lease_epoch != start.lease_epoch
+            || job.cancel_requested
+            || job.state.is_terminal()
+        {
+            return Ok(false);
+        }
+        let key = (start.job_id, start.run_id, start.task_id);
+        let Some(task) = inner.tasks.get_mut(&key) else {
+            return Ok(false);
+        };
+        if !matches!(
+            task.state,
+            TransferTaskState::Pending | TransferTaskState::Stale
+        ) {
+            return Ok(false);
+        }
+
+        task.attempt_id = start.attempt_id;
+        task.worker_id = start.worker_id;
+        task.worker_session_id = start.worker_session_id;
+        task.report_target_json = start.report_target_json;
+        task.state = TransferTaskState::Running;
+        task.attempt_started_at = start.now_ms;
+        task.last_report_at = start.now_ms;
+        task.stale_deadline_at = start.stale_deadline_at;
+        task.updated_at = start.now_ms;
+        Ok(true)
+    }
+
+    fn update_task_report(&self, report: TransferTaskReport) -> FsResult<bool> {
+        let mut inner = self.inner.lock();
+        let key = (report.job_id, report.run_id, report.task_id);
+        let (task_job_id, task_state) = {
+            let Some(task) = inner.tasks.get_mut(&key) else {
+                return Ok(false);
+            };
+            if task.attempt_id != report.attempt_id
+                || task.worker_id != report.worker_id
+                || task.worker_session_id != report.worker_session_id
+                || !task.state.is_running()
+            {
+                return Ok(false);
+            }
+
+            task.state = report.state;
+            task.progress = report.progress;
+            task.last_report_at = report.now_ms;
+            task.stale_deadline_at = report.stale_deadline_at;
+            task.updated_at = report.now_ms;
+            (task.job_id.clone(), task.state)
+        };
+
+        let summary = summarize_transfer_tasks(
+            inner
+                .tasks
+                .values()
+                .filter(|task| task.job_id == task_job_id && task.run_id == report.run_id),
+            report.now_ms,
+        );
+        let has_failed = summary.has_failed;
+        let all_completed = summary.all_completed;
+        let has_task = summary.has_task;
+        let progress = summary.progress;
+
+        if let Some(job) = inner.jobs.get_mut(&task_job_id) {
+            job.summary = progress;
+            job.updated_at = report.now_ms;
+            if has_failed {
+                job.state = TransferState::Failed;
+            } else if has_task && all_completed {
+                job.state = TransferState::Completed;
+            } else if task_state == TransferTaskState::Completed {
+                job.state = TransferState::Running;
+            }
+        }
+        Ok(true)
+    }
+}
+
+fn executing_for_tenant(inner: &MemoryTransferState, tenant: &str) -> u64 {
+    inner
+        .jobs
+        .values()
+        .filter(|job| job.tenant == tenant && job.state.is_executing())
+        .count() as u64
+}
+
+fn add_job_to_tenant_summary(
+    summaries: &mut HashMap<String, TransferTenantSummary>,
+    job: &TransferJobRecord,
+) {
+    let summary = summaries
+        .entry(job.tenant.clone())
+        .or_insert_with(|| TransferTenantSummary {
+            tenant: job.tenant.clone(),
+            ..Default::default()
+        });
+    summary.total = summary.total.saturating_add(1);
+    match job.state {
+        TransferState::Pending => summary.pending = summary.pending.saturating_add(1),
+        TransferState::Planning
+        | TransferState::Dispatching
+        | TransferState::Running
+        | TransferState::Canceling => summary.executing = summary.executing.saturating_add(1),
+        TransferState::Completed => summary.completed = summary.completed.saturating_add(1),
+        TransferState::Failed => summary.failed = summary.failed.saturating_add(1),
+        TransferState::Canceled => summary.canceled = summary.canceled.saturating_add(1),
+    }
+}
+
+fn sorted_tenant_summaries(
+    summaries: HashMap<String, TransferTenantSummary>,
+    limit: usize,
+    offset: usize,
+) -> Vec<TransferTenantSummary> {
+    let mut values = summaries.into_values().collect::<Vec<_>>();
+    values.sort_by(|left, right| {
+        right
+            .active()
+            .cmp(&left.active())
+            .then_with(|| right.total.cmp(&left.total))
+            .then_with(|| left.tenant.cmp(&right.tenant))
+    });
+    values.into_iter().skip(offset).take(limit).collect()
+}
+
+fn target_paths_conflict(left: &str, right: &str) -> bool {
+    let left = normalize_target_path(left);
+    let right = normalize_target_path(right);
+    if left == "/" || right == "/" {
+        return true;
+    }
+    left == right
+        || left
+            .strip_prefix(&right)
+            .is_some_and(|suffix| suffix.starts_with('/'))
+        || right
+            .strip_prefix(&left)
+            .is_some_and(|suffix| suffix.starts_with('/'))
+}
+
+fn normalize_target_path(path: &str) -> String {
+    let trimmed = path.trim_end_matches('/');
+    if trimmed.is_empty() {
+        "/".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}

--- a/curvine-server/src/transfer/metrics.rs
+++ b/curvine-server/src/transfer/metrics.rs
@@ -1,0 +1,531 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use curvine_common::error::FsError;
+use curvine_common::FsResult;
+use once_cell::sync::OnceCell;
+use orpc::common::{Counter, CounterVec, Gauge, GaugeVec, HistogramVec, Metrics as m};
+use std::collections::HashMap;
+use std::fmt::{Debug, Formatter};
+use std::sync::Mutex;
+use std::time::Instant;
+
+static TRANSFER_METRICS: OnceCell<TransferMetrics> = OnceCell::new();
+
+pub struct TransferMetrics {
+    submit_total: CounterVec,
+    report_total: CounterVec,
+    report_queue_len: Gauge,
+    report_queue_len_by_lane: GaugeVec,
+    active_jobs: Gauge,
+    executing_jobs: Gauge,
+    pending_jobs: Gauge,
+    cleanup_purged_total: Counter,
+    acquire_total: CounterVec,
+    planning_total: CounterVec,
+    dispatch_total: CounterVec,
+    lease_renew_total: CounterVec,
+    stale_retry_total: CounterVec,
+    terminal_total: CounterVec,
+    store_operation_duration_us: HistogramVec,
+    store_operation_total: CounterVec,
+    store_unavailable: GaugeVec,
+    store_unavailable_total: CounterVec,
+    store_unavailable_duration_us_total: CounterVec,
+    store_unavailable_since: Mutex<HashMap<String, Instant>>,
+    metadata_operation_duration_us: HistogramVec,
+    metadata_operation_total: CounterVec,
+    metadata_replica_version: Gauge,
+    metadata_replica_entries: Gauge,
+    metadata_replica_page_size: Gauge,
+    metadata_replica_pages: Gauge,
+    metadata_replica_last_refresh_time_ms: Gauge,
+    metadata_replica_refresh_total: CounterVec,
+    metadata_replica_refresh_duration_us: HistogramVec,
+    cluster_snapshot_version: Gauge,
+    cluster_snapshot_staleness_ms: Gauge,
+    cluster_snapshot_live_workers: Gauge,
+    cluster_snapshot_capable_workers: Gauge,
+    cluster_snapshot_refresh_total: CounterVec,
+    cluster_snapshot_refresh_duration_us: HistogramVec,
+}
+
+pub struct MetadataReplicaRefreshObservation<'a> {
+    pub result: &'a str,
+    pub elapsed_us: u128,
+    pub version: Option<u64>,
+    pub entries: Option<usize>,
+    pub page_size: Option<usize>,
+    pub pages: Option<usize>,
+    pub refresh_time_ms: Option<i64>,
+}
+
+impl TransferMetrics {
+    pub fn get() -> FsResult<&'static Self> {
+        TRANSFER_METRICS.get_or_try_init(Self::new)
+    }
+
+    fn new() -> FsResult<Self> {
+        let metrics = Self {
+            submit_total: m::new_counter_vec(
+                "transfer_submit_total",
+                "Transfer submit requests by kind and result",
+                &["kind", "result"],
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            report_total: m::new_counter_vec(
+                "transfer_task_report_total",
+                "Transfer task report requests by result",
+                &["result"],
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            report_queue_len: m::new_gauge(
+                "transfer_task_report_queue_len",
+                "Current transfer task report queue length",
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            report_queue_len_by_lane: m::new_gauge_vec(
+                "transfer_task_report_queue_len_by_lane",
+                "Current transfer task report queue length by lane",
+                &["lane"],
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            active_jobs: m::new_gauge(
+                "transfer_active_jobs",
+                "Current non-terminal transfer jobs in TransferStore",
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            executing_jobs: m::new_gauge(
+                "transfer_executing_jobs",
+                "Current transfer jobs being planned, dispatched, running, or canceling",
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            pending_jobs: m::new_gauge(
+                "transfer_pending_jobs",
+                "Current pending transfer jobs waiting in TransferStore backlog",
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            cleanup_purged_total: m::new_counter(
+                "transfer_cleanup_purged_total",
+                "Total terminal transfer jobs purged by cleanup",
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            acquire_total: m::new_counter_vec(
+                "transfer_acquire_total",
+                "Transfer scheduler acquire attempts by result",
+                &["result"],
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            planning_total: m::new_counter_vec(
+                "transfer_planning_total",
+                "Transfer planning results by kind and result",
+                &["kind", "result"],
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            dispatch_total: m::new_counter_vec(
+                "transfer_dispatch_total",
+                "Transfer task dispatch results by result",
+                &["result"],
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            lease_renew_total: m::new_counter_vec(
+                "transfer_lease_renew_total",
+                "Transfer lease renew attempts by result",
+                &["result"],
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            stale_retry_total: m::new_counter_vec(
+                "transfer_stale_retry_total",
+                "Transfer stale task retry decisions by result",
+                &["result"],
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            terminal_total: m::new_counter_vec(
+                "transfer_terminal_total",
+                "Transfer terminal state transitions by state and reason",
+                &["state", "reason"],
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            store_operation_duration_us: m::new_histogram_vec_with_buckets(
+                "transfer_store_operation_duration_us",
+                "TransferStore operation latency in microseconds",
+                &["backend", "operation", "result"],
+                &[
+                    100.0,
+                    500.0,
+                    1_000.0,
+                    5_000.0,
+                    10_000.0,
+                    50_000.0,
+                    100_000.0,
+                    500_000.0,
+                    1_000_000.0,
+                ],
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            store_operation_total: m::new_counter_vec(
+                "transfer_store_operation_total",
+                "TransferStore operations by backend, operation, and result",
+                &["backend", "operation", "result"],
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            store_unavailable: m::new_gauge_vec(
+                "transfer_store_unavailable",
+                "Whether TransferStore backend is currently unavailable",
+                &["backend"],
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            store_unavailable_total: m::new_counter_vec(
+                "transfer_store_unavailable_total",
+                "TransferStore unavailable events by backend and operation",
+                &["backend", "operation"],
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            store_unavailable_duration_us_total: m::new_counter_vec(
+                "transfer_store_unavailable_duration_us_total",
+                "Total observed TransferStore unavailable duration in microseconds",
+                &["backend"],
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            store_unavailable_since: Mutex::new(HashMap::new()),
+            metadata_operation_duration_us: m::new_histogram_vec_with_buckets(
+                "transfer_metadata_operation_duration_us",
+                "Transfer planning metadata operation latency in microseconds",
+                &["source", "operation", "result"],
+                &[
+                    100.0,
+                    500.0,
+                    1_000.0,
+                    5_000.0,
+                    10_000.0,
+                    50_000.0,
+                    100_000.0,
+                    500_000.0,
+                    1_000_000.0,
+                    5_000_000.0,
+                ],
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            metadata_operation_total: m::new_counter_vec(
+                "transfer_metadata_operation_total",
+                "Transfer planning metadata operations by source, operation, and result",
+                &["source", "operation", "result"],
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            metadata_replica_version: m::new_gauge(
+                "transfer_metadata_replica_version",
+                "Current Transfer metadata replica snapshot version",
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            metadata_replica_entries: m::new_gauge(
+                "transfer_metadata_replica_entries",
+                "Current Transfer metadata replica entry count",
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            metadata_replica_page_size: m::new_gauge(
+                "transfer_metadata_replica_page_size",
+                "Configured Transfer metadata replica snapshot page size",
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            metadata_replica_pages: m::new_gauge(
+                "transfer_metadata_replica_pages",
+                "Pages read by the last Transfer metadata replica refresh",
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            metadata_replica_last_refresh_time_ms: m::new_gauge(
+                "transfer_metadata_replica_last_refresh_time_ms",
+                "Last successful Transfer metadata replica refresh timestamp in milliseconds",
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            metadata_replica_refresh_total: m::new_counter_vec(
+                "transfer_metadata_replica_refresh_total",
+                "Transfer metadata replica refresh attempts by result",
+                &["result"],
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            metadata_replica_refresh_duration_us: m::new_histogram_vec_with_buckets(
+                "transfer_metadata_replica_refresh_duration_us",
+                "Transfer metadata replica refresh latency in microseconds",
+                &["result"],
+                &[
+                    1_000.0,
+                    10_000.0,
+                    50_000.0,
+                    100_000.0,
+                    500_000.0,
+                    1_000_000.0,
+                    5_000_000.0,
+                    30_000_000.0,
+                    120_000_000.0,
+                ],
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            cluster_snapshot_version: m::new_gauge(
+                "transfer_cluster_snapshot_version",
+                "Current Transfer cluster metadata snapshot version",
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            cluster_snapshot_staleness_ms: m::new_gauge(
+                "transfer_cluster_snapshot_staleness_ms",
+                "Current Transfer cluster metadata snapshot staleness in milliseconds",
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            cluster_snapshot_live_workers: m::new_gauge(
+                "transfer_cluster_snapshot_live_workers",
+                "Current live workers in the Transfer cluster snapshot",
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            cluster_snapshot_capable_workers: m::new_gauge(
+                "transfer_cluster_snapshot_capable_workers",
+                "Current live workers with Transfer capabilities in the Transfer cluster snapshot",
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            cluster_snapshot_refresh_total: m::new_counter_vec(
+                "transfer_cluster_snapshot_refresh_total",
+                "Transfer cluster metadata snapshot refresh attempts by result",
+                &["result"],
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            cluster_snapshot_refresh_duration_us: m::new_histogram_vec_with_buckets(
+                "transfer_cluster_snapshot_refresh_duration_us",
+                "Transfer cluster metadata snapshot refresh latency in microseconds",
+                &["result"],
+                &[
+                    100.0,
+                    500.0,
+                    1_000.0,
+                    5_000.0,
+                    10_000.0,
+                    50_000.0,
+                    100_000.0,
+                    500_000.0,
+                    1_000_000.0,
+                    5_000_000.0,
+                ],
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+        };
+        for backend in ["memory", "sqlite", "mysql"] {
+            metrics
+                .store_unavailable
+                .with_label_values(&[backend])
+                .set(0);
+            metrics
+                .store_unavailable_duration_us_total
+                .with_label_values(&[backend])
+                .inc_by(0);
+        }
+        Ok(metrics)
+    }
+
+    pub fn inc_submit(&self, kind: &str, result: &str) {
+        self.submit_total.with_label_values(&[kind, result]).inc();
+    }
+
+    pub fn inc_report(&self, result: &str) {
+        self.report_total.with_label_values(&[result]).inc();
+    }
+
+    pub fn set_report_queue_len(&self, value: usize) {
+        self.report_queue_len.set(value as i64);
+    }
+
+    pub fn set_report_queue_len_by_lane(&self, progress: usize, terminal: usize) {
+        self.report_queue_len_by_lane
+            .with_label_values(&["progress"])
+            .set(progress as i64);
+        self.report_queue_len_by_lane
+            .with_label_values(&["terminal"])
+            .set(terminal as i64);
+    }
+
+    pub fn set_job_counts(&self, active: u64, executing: u64) {
+        let pending = active.saturating_sub(executing);
+        self.active_jobs.set(active as i64);
+        self.executing_jobs.set(executing as i64);
+        self.pending_jobs.set(pending as i64);
+    }
+
+    pub fn inc_cleanup_purged(&self, value: usize) {
+        if value > 0 {
+            self.cleanup_purged_total.inc_by(value as i64);
+        }
+    }
+
+    pub fn inc_acquire(&self, result: &str) {
+        self.acquire_total.with_label_values(&[result]).inc();
+    }
+
+    pub fn inc_planning(&self, kind: &str, result: &str) {
+        self.planning_total.with_label_values(&[kind, result]).inc();
+    }
+
+    pub fn inc_dispatch(&self, result: &str, value: usize) {
+        if value > 0 {
+            self.dispatch_total
+                .with_label_values(&[result])
+                .inc_by(value as i64);
+        }
+    }
+
+    pub fn inc_lease_renew(&self, result: &str) {
+        self.lease_renew_total.with_label_values(&[result]).inc();
+    }
+
+    pub fn inc_stale_retry(&self, result: &str) {
+        self.stale_retry_total.with_label_values(&[result]).inc();
+    }
+
+    pub fn inc_terminal(&self, state: &str, reason: &str) {
+        self.terminal_total
+            .with_label_values(&[state, reason])
+            .inc();
+    }
+
+    pub fn observe_store_operation(
+        &self,
+        backend: &str,
+        operation: &str,
+        result: &str,
+        elapsed_us: u128,
+    ) {
+        let labels = &[backend, operation, result];
+        self.store_operation_duration_us
+            .with_label_values(labels)
+            .observe(elapsed_us as f64);
+        self.store_operation_total.with_label_values(labels).inc();
+    }
+
+    pub fn record_store_unavailable(&self, backend: &str, operation: &str) {
+        self.store_unavailable.with_label_values(&[backend]).set(1);
+        self.store_unavailable_total
+            .with_label_values(&[backend, operation])
+            .inc();
+        if let Ok(mut unavailable_since) = self.store_unavailable_since.lock() {
+            unavailable_since
+                .entry(backend.to_string())
+                .or_insert_with(Instant::now);
+        }
+    }
+
+    pub fn record_store_available(&self, backend: &str) {
+        self.store_unavailable.with_label_values(&[backend]).set(0);
+        if let Ok(mut unavailable_since) = self.store_unavailable_since.lock() {
+            if let Some(start) = unavailable_since.remove(backend) {
+                let elapsed_us = start.elapsed().as_micros();
+                if elapsed_us > 0 {
+                    self.store_unavailable_duration_us_total
+                        .with_label_values(&[backend])
+                        .inc_by(elapsed_us.min(i64::MAX as u128) as i64);
+                }
+            }
+        }
+    }
+
+    pub fn is_store_unavailable(&self, backend: &str) -> bool {
+        self.store_unavailable_since
+            .lock()
+            .map(|unavailable_since| unavailable_since.contains_key(backend))
+            .unwrap_or(true)
+    }
+
+    pub fn observe_metadata_operation(
+        &self,
+        source: &str,
+        operation: &str,
+        result: &str,
+        elapsed_us: u128,
+    ) {
+        let labels = &[source, operation, result];
+        self.metadata_operation_duration_us
+            .with_label_values(labels)
+            .observe(elapsed_us as f64);
+        self.metadata_operation_total
+            .with_label_values(labels)
+            .inc();
+    }
+
+    pub fn observe_metadata_replica_refresh(&self, obs: MetadataReplicaRefreshObservation<'_>) {
+        self.metadata_replica_refresh_total
+            .with_label_values(&[obs.result])
+            .inc();
+        self.metadata_replica_refresh_duration_us
+            .with_label_values(&[obs.result])
+            .observe(obs.elapsed_us as f64);
+        if let Some(version) = obs.version {
+            self.metadata_replica_version.set(version as i64);
+        }
+        if let Some(entries) = obs.entries {
+            self.metadata_replica_entries.set(entries as i64);
+        }
+        if let Some(page_size) = obs.page_size {
+            self.metadata_replica_page_size.set(page_size as i64);
+        }
+        if let Some(pages) = obs.pages {
+            self.metadata_replica_pages.set(pages as i64);
+        }
+        if let Some(refresh_time_ms) = obs.refresh_time_ms {
+            self.metadata_replica_last_refresh_time_ms
+                .set(refresh_time_ms);
+        }
+    }
+
+    pub fn observe_cluster_snapshot_refresh(
+        &self,
+        result: &str,
+        elapsed_us: u128,
+        version: Option<u64>,
+        updated_at_ms: Option<i64>,
+        live_workers: Option<usize>,
+        capable_workers: Option<usize>,
+    ) {
+        self.cluster_snapshot_refresh_total
+            .with_label_values(&[result])
+            .inc();
+        self.cluster_snapshot_refresh_duration_us
+            .with_label_values(&[result])
+            .observe(elapsed_us as f64);
+        self.set_cluster_snapshot(version, updated_at_ms, live_workers, capable_workers);
+    }
+
+    pub fn set_cluster_snapshot(
+        &self,
+        version: Option<u64>,
+        updated_at_ms: Option<i64>,
+        live_workers: Option<usize>,
+        capable_workers: Option<usize>,
+    ) {
+        if let Some(version) = version {
+            self.cluster_snapshot_version.set(version as i64);
+        }
+        if let Some(updated_at_ms) = updated_at_ms {
+            let staleness_ms =
+                orpc::common::LocalTime::mills().saturating_sub(updated_at_ms.max(0) as u64);
+            self.cluster_snapshot_staleness_ms.set(staleness_ms as i64);
+        }
+        if let Some(live_workers) = live_workers {
+            self.cluster_snapshot_live_workers.set(live_workers as i64);
+        }
+        if let Some(capable_workers) = capable_workers {
+            self.cluster_snapshot_capable_workers
+                .set(capable_workers as i64);
+        }
+    }
+}
+
+impl Debug for TransferMetrics {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "TransferMetrics")
+    }
+}

--- a/curvine-server/src/transfer/mod.rs
+++ b/curvine-server/src/transfer/mod.rs
@@ -60,6 +60,26 @@ pub use self::router_handler::TransferRouterHandler;
 mod transfer_server;
 pub use self::transfer_server::{TransferServer, TransferServerShutdown};
 
+pub(crate) fn apply_task_report_progress(
+    summary: &mut curvine_common::state::TransferProgress,
+    previous: &curvine_common::state::TransferProgress,
+    current: &curvine_common::state::TransferProgress,
+    now_ms: i64,
+) {
+    summary.loaded_size = summary
+        .loaded_size
+        .saturating_sub(previous.loaded_size)
+        .saturating_add(current.loaded_size)
+        .max(0);
+    summary.total_size = summary
+        .total_size
+        .saturating_sub(previous.total_size)
+        .saturating_add(current.total_size)
+        .max(0);
+    summary.update_time = now_ms;
+    summary.message = current.message.clone();
+}
+
 pub(crate) fn transfer_failure_message(
     kind: curvine_common::state::TransferKind,
     source_path: &str,
@@ -95,8 +115,15 @@ pub(crate) fn transfer_failure_message(
             "Transfer metadata store is unavailable; retry after it recovers".to_string()
         }
         ErrorKind::TransferOverloaded => "Transfer service is busy; retry later".to_string(),
-        _ => format!(
-            "transfer from {source_path} to {target_path} failed; check the Transfer service logs"
-        ),
+        _ => {
+            let details = err.to_string();
+            if details.is_empty() {
+                format!(
+                    "transfer from {source_path} to {target_path} failed; check the Transfer service logs"
+                )
+            } else {
+                format!("transfer from {source_path} to {target_path} failed: {details}")
+            }
+        }
     }
 }

--- a/curvine-server/src/transfer/mod.rs
+++ b/curvine-server/src/transfer/mod.rs
@@ -1,0 +1,102 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod store;
+pub use self::store::*;
+
+mod memory_store;
+pub use self::memory_store::MemoryTransferStore;
+
+mod sqlite_store;
+pub use self::sqlite_store::SqliteTransferStore;
+
+mod mysql_store;
+pub use self::mysql_store::MysqlTransferStore;
+
+mod metrics;
+pub use self::metrics::{MetadataReplicaRefreshObservation, TransferMetrics};
+
+mod backend;
+pub(crate) use self::backend::is_store_unavailable_error;
+pub use self::backend::TransferStoreBackend;
+
+mod cluster_cache;
+pub use self::cluster_cache::ClusterMetadataCache;
+
+mod cv_metadata_reader;
+pub use self::cv_metadata_reader::{
+    CvMetadataReader, DisabledCvMetadataReader, MasterCvMetadataReader, MetadataReplicaReader,
+};
+
+mod job_snapshot;
+pub use self::job_snapshot::job_mount_snapshot;
+
+mod planner;
+pub use self::planner::TransferPlanner;
+
+mod scheduler;
+pub use self::scheduler::TransferScheduler;
+
+mod service;
+pub use self::service::*;
+
+mod handler;
+pub use self::handler::TransferHandler;
+
+mod router_handler;
+pub use self::router_handler::TransferRouterHandler;
+
+mod transfer_server;
+pub use self::transfer_server::{TransferServer, TransferServerShutdown};
+
+pub(crate) fn transfer_failure_message(
+    kind: curvine_common::state::TransferKind,
+    source_path: &str,
+    target_path: &str,
+    err: &curvine_common::error::FsError,
+) -> String {
+    use curvine_common::error::ErrorKind;
+
+    let source_label = match kind {
+        curvine_common::state::TransferKind::Load => "source object",
+        curvine_common::state::TransferKind::Export => "source file",
+    };
+    match err.kind() {
+        ErrorKind::FileNotFound | ErrorKind::Expired => {
+            format!("{source_label} not found: {source_path}")
+        }
+        ErrorKind::FileAlreadyExists => format!("target already exists: {target_path}"),
+        ErrorKind::ParentNotDir | ErrorKind::NotADirectory => {
+            format!("target parent is not a directory: {target_path}")
+        }
+        ErrorKind::IsADirectory => format!("target is a directory: {target_path}"),
+        ErrorKind::ReadOnly => format!("target is read-only: {target_path}"),
+        ErrorKind::DiskOutOfSpace => {
+            format!("not enough Curvine worker disk space to transfer {source_path}; free space and retry")
+        }
+        ErrorKind::Timeout => format!(
+            "timed out while accessing {source_path}; verify storage connectivity and retry"
+        ),
+        ErrorKind::IO | ErrorKind::Ufs | ErrorKind::Pipeline => format!(
+            "cannot access transfer storage for {source_path}; verify the mount, credentials, and network connectivity"
+        ),
+        ErrorKind::TransferStoreUnavailable => {
+            "Transfer metadata store is unavailable; retry after it recovers".to_string()
+        }
+        ErrorKind::TransferOverloaded => "Transfer service is busy; retry later".to_string(),
+        _ => format!(
+            "transfer from {source_path} to {target_path} failed; check the Transfer service logs"
+        ),
+    }
+}

--- a/curvine-server/src/transfer/mysql_store.rs
+++ b/curvine-server/src/transfer/mysql_store.rs
@@ -14,21 +14,25 @@
 
 use curvine_common::error::FsError;
 use curvine_common::state::{
-    summarize_transfer_tasks, StaleTaskAttempt, TaskAttemptStart, TransferJobRecord, TransferLease,
-    TransferListFilter, TransferState, TransferStateUpdate, TransferTaskRecord, TransferTaskReport,
-    TransferTaskState, TransferTenantSummary,
+    StaleTaskAttempt, TaskAttemptStart, TransferJobRecord, TransferLease, TransferListFilter,
+    TransferState, TransferStateUpdate, TransferTaskRecord, TransferTaskReport, TransferTaskState,
+    TransferTenantSummary,
 };
 use curvine_common::FsResult;
 use mysql::prelude::*;
 use mysql::{params, Params, Pool, PooledConn, TxOpts, Value as MysqlValue};
 
-use crate::transfer::{TransferRequeueUpdate, TransferStore};
+use crate::transfer::{
+    apply_task_report_progress, TransferPlannedTasks, TransferRequeueUpdate, TransferStore,
+    TransferTaskStateUpdate,
+};
 
 const TRANSFER_SCHEMA_VERSION: u64 = 4;
 const TRANSFER_SCHEMA_V3: u64 = 3;
 
 type TenantSummaryRow = (
     String,
+    Option<u64>,
     Option<u64>,
     Option<u64>,
     Option<u64>,
@@ -118,7 +122,7 @@ impl TransferStore for MysqlTransferStore {
     fn list_active_transfers(&self) -> FsResult<Vec<TransferJobRecord>> {
         select_jobs(
             &mut self.conn()?,
-            "select record_json from transfer_jobs where state not in (6, 7, 8)",
+            "select record_json from transfer_jobs where state not in (6, 7, 8, 9)",
             Params::Empty,
         )
     }
@@ -140,7 +144,7 @@ impl TransferStore for MysqlTransferStore {
     fn count_active_transfers(&self) -> FsResult<u64> {
         self.conn()?
             .exec_first::<u64, _, _>(
-                "select count(*) from transfer_jobs where state not in (6, 7, 8)",
+                "select count(*) from transfer_jobs where state not in (6, 7, 8, 9)",
                 Params::Empty,
             )
             .map_err(mysql_err)?
@@ -184,6 +188,7 @@ impl TransferStore for MysqlTransferStore {
                         sum(case when state = 6 then 1 else 0 end) as completed,
                         sum(case when state = 7 then 1 else 0 end) as failed,
                         sum(case when state = 8 then 1 else 0 end) as canceled,
+                        sum(case when state = 9 then 1 else 0 end) as partial_success,
                         count(*) as total
                  from transfer_jobs
                  group by tenant
@@ -195,13 +200,23 @@ impl TransferStore for MysqlTransferStore {
                     "limit" => limit as u64,
                     "offset" => offset as u64,
                 },
-                |(tenant, pending, executing, completed, failed, canceled, total): TenantSummaryRow| TransferTenantSummary {
+                |(
+                    tenant,
+                    pending,
+                    executing,
+                    completed,
+                    failed,
+                    canceled,
+                    partial_success,
+                    total,
+                ): TenantSummaryRow| TransferTenantSummary {
                     tenant,
                     pending: pending.unwrap_or_default(),
                     executing: executing.unwrap_or_default(),
                     completed: completed.unwrap_or_default(),
                     failed: failed.unwrap_or_default(),
                     canceled: canceled.unwrap_or_default(),
+                    partial_success: partial_success.unwrap_or_default(),
                     total,
                 },
             )
@@ -219,7 +234,7 @@ impl TransferStore for MysqlTransferStore {
         let job_ids: Vec<String> = tx
             .exec(
                 "select job_id from transfer_jobs
-                 where state in (6, 7, 8) and updated_at < :older_than_ms
+                 where state in (6, 7, 8, 9) and updated_at < :older_than_ms
                  order by updated_at asc
                  limit :limit",
                 params! {
@@ -235,7 +250,7 @@ impl TransferStore for MysqlTransferStore {
             )
             .map_err(mysql_err)?;
             tx.exec_drop(
-                "delete from transfer_jobs where job_id = :job_id and state in (6, 7, 8)",
+                "delete from transfer_jobs where job_id = :job_id and state in (6, 7, 8, 9)",
                 params! { "job_id" => job_id },
             )
             .map_err(mysql_err)?;
@@ -249,16 +264,25 @@ impl TransferStore for MysqlTransferStore {
     }
 
     fn request_cancel(&self, job_id: &str, run_id: u64, now_ms: i64) -> FsResult<bool> {
-        let mut job = match self.get_transfer(job_id)? {
+        let mut conn = self.conn()?;
+        let mut tx = conn
+            .start_transaction(TxOpts::default())
+            .map_err(mysql_err)?;
+        let mut job = match select_job_by_id_for_update(&mut tx, job_id)? {
             Some(job) if job.run_id == run_id && !job.state.is_terminal() => job,
-            _ => return Ok(false),
+            _ => {
+                tx.commit().map_err(mysql_err)?;
+                return Ok(false);
+            }
         };
         job.cancel_requested = true;
         job.state = TransferState::Canceling;
         job.summary.message = "cancel requested".to_string();
         job.summary.update_time = now_ms;
         job.updated_at = now_ms;
-        exec_update_job(&mut self.conn()?, &job)
+        let updated = exec_update_job(&mut tx, &job)?;
+        tx.commit().map_err(mysql_err)?;
+        Ok(updated)
     }
 
     fn acquire_runnable_transfer(
@@ -380,20 +404,30 @@ impl TransferStore for MysqlTransferStore {
         lease_ms: i64,
         now_ms: i64,
     ) -> FsResult<bool> {
-        let mut job = match self.get_transfer(job_id)? {
+        let mut conn = self.conn()?;
+        let mut tx = conn
+            .start_transaction(TxOpts::default())
+            .map_err(mysql_err)?;
+        let mut job = match select_job_by_id_for_update(&mut tx, job_id)? {
             Some(job)
                 if job.run_id == run_id
                     && job.owner == owner
                     && job.lease_epoch == lease_epoch
+                    && job.lease_expire_at > now_ms
                     && !job.state.is_terminal() =>
             {
                 job
             }
-            _ => return Ok(false),
+            _ => {
+                tx.commit().map_err(mysql_err)?;
+                return Ok(false);
+            }
         };
         job.lease_expire_at = now_ms.saturating_add(lease_ms);
         job.updated_at = now_ms;
-        exec_update_job(&mut self.conn()?, &job)
+        let updated = exec_update_job(&mut tx, &job)?;
+        tx.commit().map_err(mysql_err)?;
+        Ok(updated)
     }
 
     fn update_transfer_state(&self, update: TransferStateUpdate) -> FsResult<bool> {
@@ -406,6 +440,7 @@ impl TransferStore for MysqlTransferStore {
                 if job.run_id == update.run_id
                     && job.owner == update.owner
                     && job.lease_epoch == update.lease_epoch
+                    && job.lease_expire_at > update.now_ms
                     && update.from_states.contains(&job.state) =>
             {
                 job
@@ -424,25 +459,6 @@ impl TransferStore for MysqlTransferStore {
         Ok(updated)
     }
 
-    fn set_transfer_state(
-        &self,
-        job_id: &str,
-        run_id: u64,
-        state: TransferState,
-        message: impl Into<String>,
-        now_ms: i64,
-    ) -> FsResult<bool> {
-        let mut job = match self.get_transfer(job_id)? {
-            Some(job) if job.run_id == run_id => job,
-            _ => return Ok(false),
-        };
-        job.state = state;
-        job.summary.message = message.into();
-        job.summary.update_time = now_ms;
-        job.updated_at = now_ms;
-        exec_update_job(&mut self.conn()?, &job)
-    }
-
     fn requeue_transfer(&self, update: TransferRequeueUpdate) -> FsResult<bool> {
         let mut conn = self.conn()?;
         let mut tx = conn
@@ -453,6 +469,7 @@ impl TransferStore for MysqlTransferStore {
                 if job.run_id == update.run_id
                     && job.owner == update.owner
                     && job.lease_epoch == update.lease_epoch
+                    && job.lease_expire_at > update.now_ms
                     && job.state == TransferState::Planning =>
             {
                 job
@@ -491,6 +508,7 @@ impl TransferStore for MysqlTransferStore {
                 if job.run_id == run_id
                     && job.owner == owner
                     && job.lease_epoch == lease_epoch
+                    && job.lease_expire_at > now_ms
                     && !job.state.is_terminal()
                     && job
                         .cv_metadata_epoch
@@ -522,24 +540,81 @@ impl TransferStore for MysqlTransferStore {
         Ok(())
     }
 
-    fn update_task_state(
-        &self,
-        job_id: &str,
-        run_id: u64,
-        task_id: &str,
-        state: TransferTaskState,
-        message: impl Into<String>,
-        now_ms: i64,
-    ) -> FsResult<bool> {
-        let mut task = match select_task(&mut self.conn()?, job_id, run_id, task_id)? {
-            Some(task) => task,
-            None => return Ok(false),
+    fn persist_planned_tasks(&self, update: TransferPlannedTasks) -> FsResult<bool> {
+        let mut conn = self.conn()?;
+        let mut tx = conn
+            .start_transaction(TxOpts::default())
+            .map_err(mysql_err)?;
+        let mut job = match select_job_by_id_for_update(&mut tx, &update.job_id)? {
+            Some(job)
+                if job.run_id == update.run_id
+                    && job.owner == update.owner
+                    && job.lease_epoch == update.lease_epoch
+                    && job.lease_expire_at > update.now_ms
+                    && job.state == TransferState::Planning =>
+            {
+                job
+            }
+            _ => {
+                tx.commit().map_err(mysql_err)?;
+                return Ok(false);
+            }
         };
-        task.state = state;
-        task.progress.message = message.into();
-        task.progress.update_time = now_ms;
-        task.updated_at = now_ms;
-        exec_update_task(&mut self.conn()?, &task)
+        for task in update.tasks {
+            insert_task(&mut tx, &task)?;
+        }
+        job.state = TransferState::Dispatching;
+        job.summary.message = update.message;
+        job.summary.update_time = update.now_ms;
+        job.updated_at = update.now_ms;
+        let updated = exec_update_job(&mut tx, &job)?;
+        tx.commit().map_err(mysql_err)?;
+        Ok(updated)
+    }
+
+    fn update_task_state(&self, update: TransferTaskStateUpdate) -> FsResult<bool> {
+        let mut conn = self.conn()?;
+        let mut tx = conn
+            .start_transaction(TxOpts::default())
+            .map_err(mysql_err)?;
+        match select_job_by_id_for_update(&mut tx, &update.job_id)? {
+            Some(job)
+                if job.run_id == update.run_id
+                    && job.owner == update.owner
+                    && job.lease_epoch == update.lease_epoch
+                    && job.lease_expire_at > update.now_ms
+                    && !job.state.is_terminal() =>
+            {
+                job
+            }
+            _ => {
+                tx.commit().map_err(mysql_err)?;
+                return Ok(false);
+            }
+        };
+        let mut task = match select_task_for_update(
+            &mut tx,
+            &update.job_id,
+            update.run_id,
+            &update.task_id,
+        )? {
+            Some(task) => task,
+            None => {
+                tx.commit().map_err(mysql_err)?;
+                return Ok(false);
+            }
+        };
+        if !update.from_states.is_empty() && !update.from_states.contains(&task.state) {
+            tx.commit().map_err(mysql_err)?;
+            return Ok(false);
+        }
+        task.state = update.state;
+        task.progress.message = update.message;
+        task.progress.update_time = update.now_ms;
+        task.updated_at = update.now_ms;
+        let updated = exec_update_task(&mut tx, &task)?;
+        tx.commit().map_err(mysql_err)?;
+        Ok(updated)
     }
 
     fn claim_pending_tasks(
@@ -574,12 +649,13 @@ impl TransferStore for MysqlTransferStore {
             .exec_first(
                 "select 1 from transfer_jobs
                  where job_id = :job_id and run_id = :run_id and owner = :owner
-                   and lease_epoch = :lease_epoch",
+                   and lease_epoch = :lease_epoch and lease_expire_at > :now_ms",
                 params! {
                     "job_id" => job_id,
                     "run_id" => run_id,
                     "owner" => owner,
                     "lease_epoch" => lease_epoch,
+                    "now_ms" => now_ms,
                 },
             )
             .map_err(mysql_err)?;
@@ -617,22 +693,62 @@ impl TransferStore for MysqlTransferStore {
         Ok(stale)
     }
 
-    fn list_recoverable_tasks(
+    fn list_stale_running_tasks(
         &self,
         job_id: &str,
         run_id: u64,
+        stale_before_ms: i64,
+        limit: usize,
     ) -> FsResult<Vec<TransferTaskRecord>> {
         let rows: Vec<String> = self
             .conn()?
             .exec(
                 "select record_json from transfer_tasks
-                 where job_id = :job_id and run_id = :run_id and state in (1, 2, 6)",
-                params! { "job_id" => job_id, "run_id" => run_id },
+                 where job_id = :job_id and run_id = :run_id and state = 2
+                   and stale_deadline_at < :stale_before_ms
+                 order by stale_deadline_at asc
+                 limit :limit",
+                params! {
+                    "job_id" => job_id,
+                    "run_id" => run_id,
+                    "stale_before_ms" => stale_before_ms,
+                    "limit" => limit as u64,
+                },
             )
             .map_err(mysql_err)?;
         rows.into_iter()
             .map(|row| serde_json::from_str(&row).map_err(json_err))
             .collect()
+    }
+
+    fn has_failed_tasks(&self, job_id: &str, run_id: u64) -> FsResult<bool> {
+        let result: Option<u8> = self
+            .conn()?
+            .exec_first(
+                "select 1 from transfer_tasks
+                 where job_id = :job_id and run_id = :run_id and state = :state
+                 limit 1",
+                params! {
+                    "job_id" => job_id,
+                    "run_id" => run_id,
+                    "state" => TransferTaskState::Failed as i32,
+                },
+            )
+            .map_err(mysql_err)?;
+        Ok(result.is_some())
+    }
+
+    fn has_recoverable_tasks(&self, job_id: &str, run_id: u64) -> FsResult<bool> {
+        let result: Option<u8> = self
+            .conn()?
+            .exec_first(
+                "select 1 from transfer_tasks
+                 where job_id = :job_id and run_id = :run_id and state in (1, 2, 6)
+                 limit 1",
+                params! { "job_id" => job_id, "run_id" => run_id },
+            )
+            .map_err(mysql_err)?;
+        Ok(result.is_some())
     }
 
     fn start_task_attempt(&self, start: TaskAttemptStart) -> FsResult<bool> {
@@ -647,6 +763,7 @@ impl TransferStore for MysqlTransferStore {
         if job.run_id != start.run_id
             || job.owner != start.owner
             || job.lease_epoch != start.lease_epoch
+            || job.lease_expire_at <= start.now_ms
             || job.cancel_requested
             || job.state.is_terminal()
         {
@@ -687,6 +804,13 @@ impl TransferStore for MysqlTransferStore {
         let mut tx = conn
             .start_transaction(TxOpts::default())
             .map_err(mysql_err)?;
+        let mut job = match select_job_by_id_for_update(&mut tx, &report.job_id)? {
+            Some(job) if job.run_id == report.run_id => job,
+            _ => {
+                tx.commit().map_err(mysql_err)?;
+                return Ok(false);
+            }
+        };
         let mut task = match select_task_for_update(
             &mut tx,
             &report.job_id,
@@ -706,13 +830,21 @@ impl TransferStore for MysqlTransferStore {
                 return Ok(false);
             }
         };
+        let previous_progress = task.progress.clone();
         task.state = report.state;
-        task.progress = report.progress;
+        task.progress = report.progress.clone();
         task.last_report_at = report.now_ms;
         task.stale_deadline_at = report.stale_deadline_at;
         task.updated_at = report.now_ms;
         exec_update_task(&mut tx, &task)?;
-        update_job_summary(&mut tx, &report.job_id, report.run_id, report.now_ms)?;
+        apply_task_report_progress(
+            &mut job.summary,
+            &previous_progress,
+            &report.progress,
+            report.now_ms,
+        );
+        job.updated_at = report.now_ms;
+        exec_update_job(&mut tx, &job)?;
         tx.commit().map_err(mysql_err)?;
         Ok(true)
     }
@@ -1001,7 +1133,7 @@ fn select_non_terminal_job_by_key(
     select_job(
         conn,
         "select record_json from transfer_jobs
-         where job_key = :job_key and state not in (6, 7, 8)
+         where job_key = :job_key and state not in (6, 7, 8, 9)
          limit 1",
         params! { "job_key" => job_key },
     )
@@ -1017,7 +1149,7 @@ fn select_conflicting_active_transfer(
     let exact_or_child = select_job(
         conn,
         "select record_json from transfer_jobs
-         where state not in (6, 7, 8)
+         where state not in (6, 7, 8, 9)
            and not (submitter = :submitter and client_request_id = :client_request_id)
            and (
                target_path = :target_path
@@ -1041,7 +1173,7 @@ fn select_conflicting_active_transfer(
         let ancestor_conflict = select_job(
             conn,
             "select record_json from transfer_jobs
-             where state not in (6, 7, 8)
+             where state not in (6, 7, 8, 9)
                and not (submitter = :submitter and client_request_id = :client_request_id)
                and target_path = :target_path
              limit 1
@@ -1149,24 +1281,6 @@ fn list_filter_mysql_params(filter: &TransferListFilter) -> (String, Vec<MysqlVa
     }
 }
 
-fn select_task(
-    conn: &mut impl Queryable,
-    job_id: &str,
-    run_id: u64,
-    task_id: &str,
-) -> FsResult<Option<TransferTaskRecord>> {
-    let value: Option<String> = conn
-        .exec_first(
-            "select record_json from transfer_tasks
-             where job_id = :job_id and run_id = :run_id and task_id = :task_id",
-            params! { "job_id" => job_id, "run_id" => run_id, "task_id" => task_id },
-        )
-        .map_err(mysql_err)?;
-    value
-        .map(|json| serde_json::from_str(&json).map_err(json_err))
-        .transpose()
-}
-
 fn select_task_for_update(
     conn: &mut impl Queryable,
     job_id: &str,
@@ -1248,26 +1362,6 @@ fn exec_update_task(conn: &mut impl Queryable, task: &TransferTaskRecord) -> FsR
 fn exec_affected(conn: &mut impl Queryable, sql: &str, params: mysql::Params) -> FsResult<u64> {
     let result = conn.exec_iter(sql, params).map_err(mysql_err)?;
     Ok(result.affected_rows())
-}
-
-fn update_job_summary(
-    conn: &mut impl Queryable,
-    job_id: &str,
-    run_id: u64,
-    now_ms: i64,
-) -> FsResult<()> {
-    let tasks = select_tasks(conn, job_id, run_id, None, None)?;
-    let mut job = select_job_by_id(conn, job_id)?.ok_or_else(|| FsError::job_not_found(job_id))?;
-    let summary = summarize_transfer_tasks(&tasks, now_ms);
-    job.summary = summary.progress;
-    job.updated_at = now_ms;
-    if summary.has_failed {
-        job.state = TransferState::Failed;
-    } else if summary.has_task && summary.all_completed {
-        job.state = TransferState::Completed;
-    }
-    let _ = exec_update_job(conn, &job)?;
-    Ok(())
 }
 
 fn job_params(job: &TransferJobRecord) -> FsResult<mysql::Params> {

--- a/curvine-server/src/transfer/mysql_store.rs
+++ b/curvine-server/src/transfer/mysql_store.rs
@@ -1,0 +1,1329 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use curvine_common::error::FsError;
+use curvine_common::state::{
+    summarize_transfer_tasks, StaleTaskAttempt, TaskAttemptStart, TransferJobRecord, TransferLease,
+    TransferListFilter, TransferState, TransferStateUpdate, TransferTaskRecord, TransferTaskReport,
+    TransferTaskState, TransferTenantSummary,
+};
+use curvine_common::FsResult;
+use mysql::prelude::*;
+use mysql::{params, Params, Pool, PooledConn, TxOpts, Value as MysqlValue};
+
+use crate::transfer::{TransferRequeueUpdate, TransferStore};
+
+const TRANSFER_SCHEMA_VERSION: u64 = 4;
+const TRANSFER_SCHEMA_V3: u64 = 3;
+
+type TenantSummaryRow = (
+    String,
+    Option<u64>,
+    Option<u64>,
+    Option<u64>,
+    Option<u64>,
+    Option<u64>,
+    u64,
+);
+
+pub struct MysqlTransferStore {
+    pool: Pool,
+}
+
+impl MysqlTransferStore {
+    pub fn open(url: &str) -> FsResult<Self> {
+        let pool = Pool::new(url).map_err(mysql_err)?;
+        let mut conn = pool.get_conn().map_err(mysql_err)?;
+        init_schema(&mut conn)?;
+        Ok(Self { pool })
+    }
+
+    fn conn(&self) -> FsResult<PooledConn> {
+        self.pool.get_conn().map_err(mysql_err)
+    }
+}
+
+impl TransferStore for MysqlTransferStore {
+    fn check_available(&self) -> FsResult<()> {
+        self.conn()?.query_drop("select 1").map_err(mysql_err)
+    }
+
+    fn create_or_get_by_request_id(&self, job: TransferJobRecord) -> FsResult<TransferJobRecord> {
+        self.create_or_get_by_request_id_checked(job)
+    }
+
+    fn create_or_get_by_request_id_checked(
+        &self,
+        job: TransferJobRecord,
+    ) -> FsResult<TransferJobRecord> {
+        let mut conn = self.conn()?;
+        let mut tx = conn
+            .start_transaction(TxOpts::default())
+            .map_err(mysql_err)?;
+        if let Some(existing) =
+            select_job_by_request(&mut tx, &job.submitter, &job.client_request_id)?
+        {
+            tx.commit().map_err(mysql_err)?;
+            return Ok(existing);
+        }
+        if let Some(existing) = select_non_terminal_job_by_key(&mut tx, &job.job_key)? {
+            if existing.command_json == job.command_json {
+                tx.commit().map_err(mysql_err)?;
+                return Ok(existing);
+            }
+            return Err(FsError::transfer_already_running(format!(
+                "job_key {} has running job {} with different command",
+                existing.job_key, existing.job_id
+            )));
+        }
+        if let Some(existing) = select_conflicting_active_transfer(
+            &mut tx,
+            &job.target_path,
+            &job.submitter,
+            &job.client_request_id,
+        )? {
+            return Err(FsError::transfer_target_conflict(format!(
+                "target {} conflicts with active transfer {} target {}",
+                job.target_path, existing.job_id, existing.target_path
+            )));
+        }
+        insert_job(&mut tx, &job)?;
+        tx.commit().map_err(mysql_err)?;
+        Ok(job)
+    }
+
+    fn get_transfer(&self, job_id: &str) -> FsResult<Option<TransferJobRecord>> {
+        select_job_by_id(&mut self.conn()?, job_id)
+    }
+
+    fn get_transfer_by_request(
+        &self,
+        submitter: &str,
+        client_request_id: &str,
+    ) -> FsResult<Option<TransferJobRecord>> {
+        select_job_by_request(&mut self.conn()?, submitter, client_request_id)
+    }
+
+    fn list_active_transfers(&self) -> FsResult<Vec<TransferJobRecord>> {
+        select_jobs(
+            &mut self.conn()?,
+            "select record_json from transfer_jobs where state not in (6, 7, 8)",
+            Params::Empty,
+        )
+    }
+
+    fn find_conflicting_active_transfer(
+        &self,
+        target_path: &str,
+        submitter: &str,
+        client_request_id: &str,
+    ) -> FsResult<Option<TransferJobRecord>> {
+        select_conflicting_active_transfer(
+            &mut self.conn()?,
+            target_path,
+            submitter,
+            client_request_id,
+        )
+    }
+
+    fn count_active_transfers(&self) -> FsResult<u64> {
+        self.conn()?
+            .exec_first::<u64, _, _>(
+                "select count(*) from transfer_jobs where state not in (6, 7, 8)",
+                Params::Empty,
+            )
+            .map_err(mysql_err)?
+            .ok_or_else(|| FsError::common("Failed to count active transfer jobs"))
+    }
+
+    fn count_executing_transfers(&self) -> FsResult<u64> {
+        self.conn()?
+            .exec_first::<u64, _, _>(
+                "select count(*) from transfer_jobs where state in (2, 3, 4, 5)",
+                Params::Empty,
+            )
+            .map_err(mysql_err)?
+            .ok_or_else(|| FsError::common("Failed to count executing transfer jobs"))
+    }
+
+    fn list_transfers(&self, filter: TransferListFilter) -> FsResult<Vec<TransferJobRecord>> {
+        let mut conn = self.conn()?;
+        let (where_sql, mut values) = list_filter_mysql_params(&filter);
+        let sql = format!(
+            "select record_json from transfer_jobs
+             {where_sql}
+             order by updated_at desc, created_at desc, job_id desc
+             limit ? offset ?"
+        );
+        values.push(MysqlValue::from(filter.limit as u64));
+        values.push(MysqlValue::from(filter.offset as u64));
+        select_jobs(&mut conn, &sql, Params::Positional(values))
+    }
+
+    fn list_tenant_summaries(
+        &self,
+        limit: usize,
+        offset: usize,
+    ) -> FsResult<Vec<TransferTenantSummary>> {
+        self.conn()?
+            .exec_map(
+                "select tenant,
+                        sum(case when state = 1 then 1 else 0 end) as pending,
+                        sum(case when state in (2, 3, 4, 5) then 1 else 0 end) as executing,
+                        sum(case when state = 6 then 1 else 0 end) as completed,
+                        sum(case when state = 7 then 1 else 0 end) as failed,
+                        sum(case when state = 8 then 1 else 0 end) as canceled,
+                        count(*) as total
+                 from transfer_jobs
+                 group by tenant
+                 order by (sum(case when state in (1, 2, 3, 4, 5) then 1 else 0 end)) desc,
+                          count(*) desc,
+                          tenant asc
+                 limit :limit offset :offset",
+                params! {
+                    "limit" => limit as u64,
+                    "offset" => offset as u64,
+                },
+                |(tenant, pending, executing, completed, failed, canceled, total): TenantSummaryRow| TransferTenantSummary {
+                    tenant,
+                    pending: pending.unwrap_or_default(),
+                    executing: executing.unwrap_or_default(),
+                    completed: completed.unwrap_or_default(),
+                    failed: failed.unwrap_or_default(),
+                    canceled: canceled.unwrap_or_default(),
+                    total,
+                },
+            )
+            .map_err(mysql_err)
+    }
+
+    fn purge_terminal_transfers(&self, older_than_ms: i64, limit: usize) -> FsResult<usize> {
+        if limit == 0 {
+            return Ok(0);
+        }
+        let mut conn = self.conn()?;
+        let mut tx = conn
+            .start_transaction(TxOpts::default())
+            .map_err(mysql_err)?;
+        let job_ids: Vec<String> = tx
+            .exec(
+                "select job_id from transfer_jobs
+                 where state in (6, 7, 8) and updated_at < :older_than_ms
+                 order by updated_at asc
+                 limit :limit",
+                params! {
+                    "older_than_ms" => older_than_ms,
+                    "limit" => limit as u64,
+                },
+            )
+            .map_err(mysql_err)?;
+        for job_id in &job_ids {
+            tx.exec_drop(
+                "delete from transfer_tasks where job_id = :job_id",
+                params! { "job_id" => job_id },
+            )
+            .map_err(mysql_err)?;
+            tx.exec_drop(
+                "delete from transfer_jobs where job_id = :job_id and state in (6, 7, 8)",
+                params! { "job_id" => job_id },
+            )
+            .map_err(mysql_err)?;
+        }
+        tx.commit().map_err(mysql_err)?;
+        Ok(job_ids.len())
+    }
+
+    fn list_transfer_tasks(&self, job_id: &str, run_id: u64) -> FsResult<Vec<TransferTaskRecord>> {
+        select_tasks(&mut self.conn()?, job_id, run_id, None, None)
+    }
+
+    fn request_cancel(&self, job_id: &str, run_id: u64, now_ms: i64) -> FsResult<bool> {
+        let mut job = match self.get_transfer(job_id)? {
+            Some(job) if job.run_id == run_id && !job.state.is_terminal() => job,
+            _ => return Ok(false),
+        };
+        job.cancel_requested = true;
+        job.state = TransferState::Canceling;
+        job.summary.message = "cancel requested".to_string();
+        job.summary.update_time = now_ms;
+        job.updated_at = now_ms;
+        exec_update_job(&mut self.conn()?, &job)
+    }
+
+    fn acquire_runnable_transfer(
+        &self,
+        owner: &str,
+        lease_ms: i64,
+        now_ms: i64,
+        max_executing_transfers: u64,
+    ) -> FsResult<Option<TransferLease>> {
+        let mut conn = self.conn()?;
+        let mut tx = conn
+            .start_transaction(TxOpts::default())
+            .map_err(mysql_err)?;
+
+        tx.exec_first::<u64, _, _>(
+            "select version from transfer_schema_version where id = 1 for update",
+            Params::Empty,
+        )
+        .map_err(mysql_err)?
+        .ok_or_else(|| FsError::common("Missing mysql transfer schema version"))?;
+        let executing = tx
+            .exec_first::<u64, _, _>(
+                "select count(*) from transfer_jobs where state in (2, 3, 4, 5)",
+                Params::Empty,
+            )
+            .map_err(mysql_err)?
+            .ok_or_else(|| FsError::common("Failed to count executing transfer jobs"))?;
+        let mut job: Option<(String, u64, u64, i32)> = tx
+            .exec_first(
+                "select job_id, run_id, lease_epoch, state
+                 from transfer_jobs
+                 where owner = :owner and state in (4, 5) and lease_expire_at > :now_ms
+                   and updated_at < :now_ms
+                 order by updated_at asc
+                 limit 1",
+                params! { "owner" => owner, "now_ms" => now_ms },
+            )
+            .map_err(mysql_err)?;
+        if job.is_none() {
+            job = tx
+                .exec_first(
+                    "select job_id, run_id, lease_epoch, state
+                 from transfer_jobs
+                 where state in (2, 3, 4, 5) and lease_expire_at <= :now_ms
+                 order by updated_at asc
+                 limit 1",
+                    params! { "now_ms" => now_ms },
+                )
+                .map_err(mysql_err)?;
+        }
+        if job.is_none() && executing < max_executing_transfers {
+            job = tx
+                .exec_first(
+                    "select pending.job_id, pending.run_id, pending.lease_epoch, pending.state
+                     from transfer_jobs pending
+                     where pending.state = 1 and pending.lease_expire_at <= :now_ms
+                     order by case when exists (
+                         select 1 from transfer_jobs executing
+                         where executing.tenant = pending.tenant and executing.state in (2, 3, 4, 5)
+                         limit 1
+                     ) then 1 else 0 end asc,
+                     pending.updated_at asc, pending.job_id asc
+                     limit 1",
+                    params! { "now_ms" => now_ms },
+                )
+                .map_err(mysql_err)?;
+        }
+        let Some((job_id, run_id, lease_epoch, state)) = job else {
+            tx.commit().map_err(mysql_err)?;
+            return Ok(None);
+        };
+        let mut record =
+            select_job_by_id(&mut tx, &job_id)?.ok_or_else(|| FsError::job_not_found(&job_id))?;
+        if state == TransferState::Pending as i32 {
+            record.state = TransferState::Planning;
+            record.summary.message = "acquired for planning".to_string();
+            record.summary.update_time = now_ms;
+        }
+        record.owner = owner.to_string();
+        record.lease_epoch = lease_epoch.saturating_add(1);
+        record.lease_expire_at = now_ms.saturating_add(lease_ms);
+        record.updated_at = now_ms;
+        let affected = exec_affected(
+            &mut tx,
+            "update transfer_jobs
+             set state = :state, owner = :owner, lease_epoch = :new_epoch, lease_expire_at = :lease_expire_at,
+                 record_json = :record_json, updated_at = :updated_at
+             where job_id = :job_id and run_id = :run_id and lease_epoch = :old_epoch",
+            params! {
+                "state" => record.state as i32,
+                "owner" => owner,
+                "new_epoch" => record.lease_epoch,
+                "lease_expire_at" => record.lease_expire_at,
+                "record_json" => json(&record)?,
+                "updated_at" => now_ms,
+                "job_id" => &job_id,
+                "run_id" => run_id,
+                "old_epoch" => lease_epoch,
+            },
+        )?;
+        tx.commit().map_err(mysql_err)?;
+        if affected == 0 {
+            return Ok(None);
+        }
+        Ok(Some(TransferLease {
+            job_id,
+            run_id,
+            owner: owner.to_string(),
+            lease_epoch: record.lease_epoch,
+        }))
+    }
+
+    fn renew_lease(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        owner: &str,
+        lease_epoch: u64,
+        lease_ms: i64,
+        now_ms: i64,
+    ) -> FsResult<bool> {
+        let mut job = match self.get_transfer(job_id)? {
+            Some(job)
+                if job.run_id == run_id
+                    && job.owner == owner
+                    && job.lease_epoch == lease_epoch
+                    && !job.state.is_terminal() =>
+            {
+                job
+            }
+            _ => return Ok(false),
+        };
+        job.lease_expire_at = now_ms.saturating_add(lease_ms);
+        job.updated_at = now_ms;
+        exec_update_job(&mut self.conn()?, &job)
+    }
+
+    fn update_transfer_state(&self, update: TransferStateUpdate) -> FsResult<bool> {
+        let mut conn = self.conn()?;
+        let mut tx = conn
+            .start_transaction(TxOpts::default())
+            .map_err(mysql_err)?;
+        let mut job = match select_job_by_id_for_update(&mut tx, &update.job_id)? {
+            Some(job)
+                if job.run_id == update.run_id
+                    && job.owner == update.owner
+                    && job.lease_epoch == update.lease_epoch
+                    && update.from_states.contains(&job.state) =>
+            {
+                job
+            }
+            _ => {
+                tx.commit().map_err(mysql_err)?;
+                return Ok(false);
+            }
+        };
+        job.state = update.to_state;
+        job.summary.message = update.message;
+        job.summary.update_time = update.now_ms;
+        job.updated_at = update.now_ms;
+        let updated = exec_update_job(&mut tx, &job)?;
+        tx.commit().map_err(mysql_err)?;
+        Ok(updated)
+    }
+
+    fn set_transfer_state(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        state: TransferState,
+        message: impl Into<String>,
+        now_ms: i64,
+    ) -> FsResult<bool> {
+        let mut job = match self.get_transfer(job_id)? {
+            Some(job) if job.run_id == run_id => job,
+            _ => return Ok(false),
+        };
+        job.state = state;
+        job.summary.message = message.into();
+        job.summary.update_time = now_ms;
+        job.updated_at = now_ms;
+        exec_update_job(&mut self.conn()?, &job)
+    }
+
+    fn requeue_transfer(&self, update: TransferRequeueUpdate) -> FsResult<bool> {
+        let mut conn = self.conn()?;
+        let mut tx = conn
+            .start_transaction(TxOpts::default())
+            .map_err(mysql_err)?;
+        let mut job = match select_job_by_id_for_update(&mut tx, &update.job_id)? {
+            Some(job)
+                if job.run_id == update.run_id
+                    && job.owner == update.owner
+                    && job.lease_epoch == update.lease_epoch
+                    && job.state == TransferState::Planning =>
+            {
+                job
+            }
+            _ => {
+                tx.commit().map_err(mysql_err)?;
+                return Ok(false);
+            }
+        };
+        job.state = TransferState::Pending;
+        job.owner.clear();
+        job.lease_expire_at = update.next_attempt_at_ms;
+        job.summary.message = update.message;
+        job.summary.update_time = update.now_ms;
+        job.updated_at = update.now_ms;
+        let updated = exec_update_job(&mut tx, &job)?;
+        tx.commit().map_err(mysql_err)?;
+        Ok(updated)
+    }
+
+    fn set_transfer_cv_metadata_epoch(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        owner: &str,
+        lease_epoch: u64,
+        cv_metadata_epoch: u64,
+        now_ms: i64,
+    ) -> FsResult<bool> {
+        let mut conn = self.conn()?;
+        let mut tx = conn
+            .start_transaction(TxOpts::default())
+            .map_err(mysql_err)?;
+        let mut job = match select_job_by_id_for_update(&mut tx, job_id)? {
+            Some(job)
+                if job.run_id == run_id
+                    && job.owner == owner
+                    && job.lease_epoch == lease_epoch
+                    && !job.state.is_terminal()
+                    && job
+                        .cv_metadata_epoch
+                        .is_none_or(|existing| existing == cv_metadata_epoch) =>
+            {
+                job
+            }
+            _ => {
+                tx.commit().map_err(mysql_err)?;
+                return Ok(false);
+            }
+        };
+        job.cv_metadata_epoch = Some(cv_metadata_epoch);
+        job.updated_at = now_ms;
+        let updated = exec_update_job(&mut tx, &job)?;
+        tx.commit().map_err(mysql_err)?;
+        Ok(updated)
+    }
+
+    fn insert_tasks(&self, tasks: Vec<TransferTaskRecord>) -> FsResult<()> {
+        let mut conn = self.conn()?;
+        let mut tx = conn
+            .start_transaction(TxOpts::default())
+            .map_err(mysql_err)?;
+        for task in tasks {
+            insert_task(&mut tx, &task)?;
+        }
+        tx.commit().map_err(mysql_err)?;
+        Ok(())
+    }
+
+    fn update_task_state(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        task_id: &str,
+        state: TransferTaskState,
+        message: impl Into<String>,
+        now_ms: i64,
+    ) -> FsResult<bool> {
+        let mut task = match select_task(&mut self.conn()?, job_id, run_id, task_id)? {
+            Some(task) => task,
+            None => return Ok(false),
+        };
+        task.state = state;
+        task.progress.message = message.into();
+        task.progress.update_time = now_ms;
+        task.updated_at = now_ms;
+        exec_update_task(&mut self.conn()?, &task)
+    }
+
+    fn claim_pending_tasks(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        limit: usize,
+    ) -> FsResult<Vec<TransferTaskRecord>> {
+        select_tasks(
+            &mut self.conn()?,
+            job_id,
+            run_id,
+            Some(TransferTaskState::Pending),
+            Some(limit),
+        )
+    }
+
+    fn mark_stale_attempts(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        owner: &str,
+        lease_epoch: u64,
+        now_ms: i64,
+        limit: usize,
+    ) -> FsResult<Vec<StaleTaskAttempt>> {
+        let mut conn = self.conn()?;
+        let mut tx = conn
+            .start_transaction(TxOpts::default())
+            .map_err(mysql_err)?;
+        let valid_owner: Option<u8> = tx
+            .exec_first(
+                "select 1 from transfer_jobs
+                 where job_id = :job_id and run_id = :run_id and owner = :owner
+                   and lease_epoch = :lease_epoch",
+                params! {
+                    "job_id" => job_id,
+                    "run_id" => run_id,
+                    "owner" => owner,
+                    "lease_epoch" => lease_epoch,
+                },
+            )
+            .map_err(mysql_err)?;
+        if valid_owner.is_none() {
+            tx.commit().map_err(mysql_err)?;
+            return Ok(Vec::new());
+        }
+        let rows: Vec<String> = tx
+            .exec(
+                "select record_json from transfer_tasks
+                 where job_id = :job_id and run_id = :run_id and state = 2
+                   and stale_deadline_at < :now_ms
+                 order by stale_deadline_at asc
+                 limit :limit",
+                params! {
+                    "job_id" => job_id,
+                    "run_id" => run_id,
+                    "now_ms" => now_ms,
+                    "limit" => limit as u64,
+                },
+            )
+            .map_err(mysql_err)?;
+        let mut stale = Vec::with_capacity(rows.len());
+        for row in rows {
+            let mut task: TransferTaskRecord = serde_json::from_str(&row).map_err(json_err)?;
+            task.state = TransferTaskState::Stale;
+            task.retry_count = task.retry_count.saturating_add(1);
+            task.progress.message = "task stale timeout".to_string();
+            task.progress.update_time = now_ms;
+            task.updated_at = now_ms;
+            exec_update_task(&mut tx, &task)?;
+            stale.push(StaleTaskAttempt { task });
+        }
+        tx.commit().map_err(mysql_err)?;
+        Ok(stale)
+    }
+
+    fn list_recoverable_tasks(
+        &self,
+        job_id: &str,
+        run_id: u64,
+    ) -> FsResult<Vec<TransferTaskRecord>> {
+        let rows: Vec<String> = self
+            .conn()?
+            .exec(
+                "select record_json from transfer_tasks
+                 where job_id = :job_id and run_id = :run_id and state in (1, 2, 6)",
+                params! { "job_id" => job_id, "run_id" => run_id },
+            )
+            .map_err(mysql_err)?;
+        rows.into_iter()
+            .map(|row| serde_json::from_str(&row).map_err(json_err))
+            .collect()
+    }
+
+    fn start_task_attempt(&self, start: TaskAttemptStart) -> FsResult<bool> {
+        let mut conn = self.conn()?;
+        let mut tx = conn
+            .start_transaction(TxOpts::default())
+            .map_err(mysql_err)?;
+        let Some(job) = select_job_by_id_for_update(&mut tx, &start.job_id)? else {
+            tx.commit().map_err(mysql_err)?;
+            return Ok(false);
+        };
+        if job.run_id != start.run_id
+            || job.owner != start.owner
+            || job.lease_epoch != start.lease_epoch
+            || job.cancel_requested
+            || job.state.is_terminal()
+        {
+            tx.commit().map_err(mysql_err)?;
+            return Ok(false);
+        }
+        let mut task =
+            match select_task_for_update(&mut tx, &start.job_id, start.run_id, &start.task_id)? {
+                Some(task)
+                    if matches!(
+                        task.state,
+                        TransferTaskState::Pending | TransferTaskState::Stale
+                    ) =>
+                {
+                    task
+                }
+                _ => {
+                    tx.commit().map_err(mysql_err)?;
+                    return Ok(false);
+                }
+            };
+        task.attempt_id = start.attempt_id;
+        task.worker_id = start.worker_id;
+        task.worker_session_id = start.worker_session_id;
+        task.report_target_json = start.report_target_json;
+        task.state = TransferTaskState::Running;
+        task.attempt_started_at = start.now_ms;
+        task.last_report_at = start.now_ms;
+        task.stale_deadline_at = start.stale_deadline_at;
+        task.updated_at = start.now_ms;
+        let updated = exec_update_task(&mut tx, &task)?;
+        tx.commit().map_err(mysql_err)?;
+        Ok(updated)
+    }
+
+    fn update_task_report(&self, report: TransferTaskReport) -> FsResult<bool> {
+        let mut conn = self.conn()?;
+        let mut tx = conn
+            .start_transaction(TxOpts::default())
+            .map_err(mysql_err)?;
+        let mut task = match select_task_for_update(
+            &mut tx,
+            &report.job_id,
+            report.run_id,
+            &report.task_id,
+        )? {
+            Some(task)
+                if task.attempt_id == report.attempt_id
+                    && task.worker_id == report.worker_id
+                    && task.worker_session_id == report.worker_session_id
+                    && task.state.is_running() =>
+            {
+                task
+            }
+            _ => {
+                tx.commit().map_err(mysql_err)?;
+                return Ok(false);
+            }
+        };
+        task.state = report.state;
+        task.progress = report.progress;
+        task.last_report_at = report.now_ms;
+        task.stale_deadline_at = report.stale_deadline_at;
+        task.updated_at = report.now_ms;
+        exec_update_task(&mut tx, &task)?;
+        update_job_summary(&mut tx, &report.job_id, report.run_id, report.now_ms)?;
+        tx.commit().map_err(mysql_err)?;
+        Ok(true)
+    }
+}
+
+fn init_schema(conn: &mut PooledConn) -> FsResult<()> {
+    conn.query_drop(
+        "create table if not exists transfer_schema_version (
+            id tinyint unsigned primary key,
+            version bigint unsigned not null,
+            updated_at bigint not null
+        )",
+    )
+    .map_err(mysql_err)?;
+    let now_ms = orpc::common::LocalTime::mills();
+    conn.exec_drop(
+        "insert ignore into transfer_schema_version(id, version, updated_at)
+         values (1, :version, :updated_at)",
+        params! {
+            "version" => TRANSFER_SCHEMA_VERSION,
+            "updated_at" => now_ms,
+        },
+    )
+    .map_err(mysql_err)?;
+    let version = conn
+        .exec_first::<u64, _, _>(
+            "select version from transfer_schema_version where id = 1",
+            Params::Empty,
+        )
+        .map_err(mysql_err)?
+        .ok_or_else(|| FsError::common("Missing mysql transfer schema version"))?;
+    migrate_mysql_schema(conn, version, now_ms)?;
+
+    conn.query_drop(
+        "create table if not exists transfer_jobs (
+            job_id varchar(128) primary key,
+            submitter varchar(255) not null,
+            tenant varchar(255) not null,
+            client_request_id varchar(255) not null,
+            job_key varchar(1024) not null,
+            target_path varchar(2048) not null,
+            run_id bigint unsigned not null,
+            kind int not null,
+            state int not null,
+            owner varchar(255) not null,
+            lease_epoch bigint unsigned not null,
+            lease_expire_at bigint not null,
+            cancel_requested tinyint not null,
+            record_json longtext not null,
+            created_at bigint not null,
+            updated_at bigint not null,
+            unique key transfer_jobs_request_idx(submitter, client_request_id),
+            key transfer_jobs_job_key_state_idx(job_key(255), state),
+            key transfer_jobs_target_state_idx(target_path(255), state),
+            key transfer_jobs_state_lease_idx(state, lease_expire_at),
+            key transfer_jobs_owner_state_updated_idx(owner, state, updated_at),
+            key transfer_jobs_tenant_state_updated_idx(tenant, state, updated_at),
+            key transfer_jobs_submitter_state_updated_idx(submitter, state, updated_at)
+        )",
+    )
+    .map_err(mysql_err)?;
+    conn.query_drop(
+        "create table if not exists transfer_tasks (
+            job_id varchar(128) not null,
+            run_id bigint unsigned not null,
+            task_id varchar(255) not null,
+            state int not null,
+            attempt_id bigint unsigned not null,
+            worker_id bigint unsigned not null,
+            worker_session_id varchar(255) not null,
+            stale_deadline_at bigint not null,
+            record_json longtext not null,
+            updated_at bigint not null,
+            primary key(job_id, run_id, task_id),
+            key transfer_tasks_job_state_idx(job_id, run_id, state),
+            key transfer_tasks_worker_idx(worker_id, worker_session_id, state),
+            key transfer_tasks_stale_idx(state, stale_deadline_at)
+        )",
+    )
+    .map_err(mysql_err)?;
+    Ok(())
+}
+
+fn migrate_mysql_schema(conn: &mut PooledConn, mut version: u64, now_ms: u64) -> FsResult<()> {
+    if version > TRANSFER_SCHEMA_VERSION {
+        return Err(FsError::common(format!(
+            "Unsupported mysql transfer schema version {}, expected {}",
+            version, TRANSFER_SCHEMA_VERSION
+        )));
+    }
+    if version == 2 {
+        migrate_mysql_schema_v2_to_v3(conn)?;
+        update_mysql_schema_version(conn, TRANSFER_SCHEMA_V3, now_ms)?;
+        version = TRANSFER_SCHEMA_V3;
+    }
+    if version == TRANSFER_SCHEMA_V3 {
+        migrate_mysql_schema_v3_to_v4(conn)?;
+        update_mysql_schema_version(conn, TRANSFER_SCHEMA_VERSION, now_ms)?;
+    } else if version != TRANSFER_SCHEMA_VERSION {
+        return Err(FsError::common(format!(
+            "Unsupported mysql transfer schema version {}, expected {}",
+            version, TRANSFER_SCHEMA_VERSION
+        )));
+    }
+    Ok(())
+}
+
+fn migrate_mysql_schema_v2_to_v3(conn: &mut PooledConn) -> FsResult<()> {
+    if !mysql_column_exists(conn, "transfer_jobs", "target_path")? {
+        conn.query_drop(
+            "alter table transfer_jobs
+             add column target_path varchar(2048) not null default '' after job_key",
+        )
+        .map_err(mysql_err)?;
+    }
+    conn.query_drop(
+        "update transfer_jobs
+         set target_path = json_unquote(json_extract(record_json, '$.target_path'))
+         where target_path = ''",
+    )
+    .map_err(mysql_err)?;
+    create_mysql_target_index(conn)?;
+    Ok(())
+}
+
+fn migrate_mysql_schema_v3_to_v4(conn: &mut PooledConn) -> FsResult<()> {
+    if !mysql_column_exists(conn, "transfer_jobs", "tenant")? {
+        conn.query_drop(
+            "alter table transfer_jobs
+             add column tenant varchar(255) not null default '' after submitter",
+        )
+        .map_err(mysql_err)?;
+    }
+    conn.query_drop(
+        "update transfer_jobs
+         set tenant = coalesce(json_unquote(json_extract(record_json, '$.tenant')), '')
+         where tenant = ''",
+    )
+    .map_err(mysql_err)?;
+    create_mysql_list_indexes(conn)?;
+    Ok(())
+}
+
+fn update_mysql_schema_version(conn: &mut PooledConn, version: u64, now_ms: u64) -> FsResult<()> {
+    conn.exec_drop(
+        "update transfer_schema_version
+         set version = :version, updated_at = :updated_at
+         where id = 1",
+        params! {
+            "version" => version,
+            "updated_at" => now_ms,
+        },
+    )
+    .map_err(mysql_err)?;
+    Ok(())
+}
+
+fn create_mysql_target_index(conn: &mut PooledConn) -> FsResult<()> {
+    conn.query_drop(
+        "create index transfer_jobs_target_state_idx
+         on transfer_jobs(target_path(255), state)",
+    )
+    .or_else(|err| {
+        if mysql_error_code(&err) == Some(1061) {
+            Ok(())
+        } else {
+            Err(err)
+        }
+    })
+    .map_err(mysql_err)?;
+    Ok(())
+}
+
+fn create_mysql_list_indexes(conn: &mut PooledConn) -> FsResult<()> {
+    conn.query_drop(
+        "create index transfer_jobs_tenant_state_updated_idx
+         on transfer_jobs(tenant, state, updated_at)",
+    )
+    .or_else(|err| {
+        if mysql_error_code(&err) == Some(1061) {
+            Ok(())
+        } else {
+            Err(err)
+        }
+    })
+    .map_err(mysql_err)?;
+    conn.query_drop(
+        "create index transfer_jobs_submitter_state_updated_idx
+         on transfer_jobs(submitter, state, updated_at)",
+    )
+    .or_else(|err| {
+        if mysql_error_code(&err) == Some(1061) {
+            Ok(())
+        } else {
+            Err(err)
+        }
+    })
+    .map_err(mysql_err)?;
+    Ok(())
+}
+
+fn mysql_column_exists(conn: &mut PooledConn, table: &str, column: &str) -> FsResult<bool> {
+    conn.exec_first::<String, _, _>(
+        "select column_name from information_schema.columns
+         where table_schema = database()
+           and table_name = :table
+           and column_name = :column",
+        params! {
+            "table" => table,
+            "column" => column,
+        },
+    )
+    .map(|value| value.is_some())
+    .map_err(mysql_err)
+}
+
+fn insert_job(conn: &mut impl Queryable, job: &TransferJobRecord) -> FsResult<()> {
+    let _ = exec_affected(
+        conn,
+        "insert into transfer_jobs (
+            job_id, submitter, tenant, client_request_id, job_key, target_path, run_id, kind, state, owner, lease_epoch,
+            lease_expire_at, cancel_requested, record_json, created_at, updated_at
+        ) values (
+            :job_id, :submitter, :tenant, :client_request_id, :job_key, :target_path, :run_id, :kind, :state, :owner,
+            :lease_epoch, :lease_expire_at, :cancel_requested, :record_json, :created_at, :updated_at
+        )",
+        job_params(job)?,
+    )?;
+    Ok(())
+}
+
+fn insert_task(conn: &mut impl Queryable, task: &TransferTaskRecord) -> FsResult<()> {
+    let _ = exec_affected(
+        conn,
+        "insert ignore into transfer_tasks (
+            job_id, run_id, task_id, state, attempt_id, worker_id, worker_session_id,
+            stale_deadline_at, record_json, updated_at
+        ) values (
+            :job_id, :run_id, :task_id, :state, :attempt_id, :worker_id, :worker_session_id,
+            :stale_deadline_at, :record_json, :updated_at
+        )",
+        task_params(task)?,
+    )?;
+    Ok(())
+}
+
+fn select_job_by_id(
+    conn: &mut impl Queryable,
+    job_id: &str,
+) -> FsResult<Option<TransferJobRecord>> {
+    select_job(
+        conn,
+        "select record_json from transfer_jobs where job_id = :job_id",
+        params! { "job_id" => job_id },
+    )
+}
+
+fn select_job_by_id_for_update(
+    conn: &mut impl Queryable,
+    job_id: &str,
+) -> FsResult<Option<TransferJobRecord>> {
+    select_job(
+        conn,
+        "select record_json from transfer_jobs where job_id = :job_id for update",
+        params! { "job_id" => job_id },
+    )
+}
+
+fn select_job_by_request(
+    conn: &mut impl Queryable,
+    submitter: &str,
+    client_request_id: &str,
+) -> FsResult<Option<TransferJobRecord>> {
+    select_job(
+        conn,
+        "select record_json from transfer_jobs
+         where submitter = :submitter and client_request_id = :client_request_id",
+        params! { "submitter" => submitter, "client_request_id" => client_request_id },
+    )
+}
+
+fn select_non_terminal_job_by_key(
+    conn: &mut impl Queryable,
+    job_key: &str,
+) -> FsResult<Option<TransferJobRecord>> {
+    select_job(
+        conn,
+        "select record_json from transfer_jobs
+         where job_key = :job_key and state not in (6, 7, 8)
+         limit 1",
+        params! { "job_key" => job_key },
+    )
+}
+
+fn select_conflicting_active_transfer(
+    conn: &mut impl Queryable,
+    target_path: &str,
+    submitter: &str,
+    client_request_id: &str,
+) -> FsResult<Option<TransferJobRecord>> {
+    let (child_lower, child_upper) = child_path_bounds(target_path);
+    let exact_or_child = select_job(
+        conn,
+        "select record_json from transfer_jobs
+         where state not in (6, 7, 8)
+           and not (submitter = :submitter and client_request_id = :client_request_id)
+           and (
+               target_path = :target_path
+               or (target_path >= :child_lower and target_path < :child_upper)
+           )
+         limit 1
+         for update",
+        params! {
+            "target_path" => target_path,
+            "submitter" => submitter,
+            "client_request_id" => client_request_id,
+            "child_lower" => child_lower,
+            "child_upper" => child_upper,
+        },
+    )?;
+    if exact_or_child.is_some() {
+        return Ok(exact_or_child);
+    }
+
+    for ancestor in ancestor_paths(target_path) {
+        let ancestor_conflict = select_job(
+            conn,
+            "select record_json from transfer_jobs
+             where state not in (6, 7, 8)
+               and not (submitter = :submitter and client_request_id = :client_request_id)
+               and target_path = :target_path
+             limit 1
+             for update",
+            params! {
+                "target_path" => ancestor,
+                "submitter" => submitter,
+                "client_request_id" => client_request_id,
+            },
+        )?;
+        if ancestor_conflict.is_some() {
+            return Ok(ancestor_conflict);
+        }
+    }
+    Ok(None)
+}
+
+fn select_job(
+    conn: &mut impl Queryable,
+    sql: &str,
+    params: mysql::Params,
+) -> FsResult<Option<TransferJobRecord>> {
+    let value: Option<String> = conn.exec_first(sql, params).map_err(mysql_err)?;
+    value
+        .map(|json| serde_json::from_str(&json).map_err(json_err))
+        .transpose()
+}
+
+fn ancestor_paths(target_path: &str) -> Vec<String> {
+    if target_path == "/" {
+        return Vec::new();
+    }
+    let mut ancestors = vec!["/".to_string()];
+    let trimmed = target_path.trim_matches('/');
+    let mut current = String::new();
+    let mut parts = trimmed.split('/').peekable();
+    while let Some(part) = parts.next() {
+        if parts.peek().is_none() {
+            break;
+        }
+        current.push('/');
+        current.push_str(part);
+        ancestors.push(current.clone());
+    }
+    ancestors
+}
+
+fn child_path_bounds(target_path: &str) -> (String, String) {
+    let lower = if target_path == "/" {
+        "/".to_string()
+    } else {
+        format!("{}/", target_path.trim_end_matches('/'))
+    };
+    let upper = lexicographic_successor(&lower).unwrap_or_else(|| "\u{10ffff}".to_string());
+    (lower, upper)
+}
+
+fn lexicographic_successor(value: &str) -> Option<String> {
+    let mut bytes = value.as_bytes().to_vec();
+    for index in (0..bytes.len()).rev() {
+        if bytes[index] < u8::MAX {
+            bytes[index] += 1;
+            bytes.truncate(index + 1);
+            return String::from_utf8(bytes).ok();
+        }
+    }
+    None
+}
+
+fn select_jobs(
+    conn: &mut impl Queryable,
+    sql: &str,
+    params: mysql::Params,
+) -> FsResult<Vec<TransferJobRecord>> {
+    let values: Vec<String> = conn.exec(sql, params).map_err(mysql_err)?;
+    values
+        .into_iter()
+        .map(|json| serde_json::from_str(&json).map_err(json_err))
+        .collect()
+}
+
+fn list_filter_mysql_params(filter: &TransferListFilter) -> (String, Vec<MysqlValue>) {
+    let mut clauses = Vec::new();
+    let mut values = Vec::new();
+    if let Some(kind) = filter.kind {
+        clauses.push("kind = ?");
+        values.push(MysqlValue::from(kind as i32));
+    }
+    if let Some(state) = filter.state {
+        clauses.push("state = ?");
+        values.push(MysqlValue::from(state as i32));
+    }
+    if let Some(submitter) = &filter.submitter {
+        clauses.push("submitter = ?");
+        values.push(MysqlValue::from(submitter.as_str()));
+    }
+    if let Some(tenant) = &filter.tenant {
+        clauses.push("tenant = ?");
+        values.push(MysqlValue::from(tenant.as_str()));
+    }
+    if clauses.is_empty() {
+        (String::new(), values)
+    } else {
+        (format!("where {}", clauses.join(" and ")), values)
+    }
+}
+
+fn select_task(
+    conn: &mut impl Queryable,
+    job_id: &str,
+    run_id: u64,
+    task_id: &str,
+) -> FsResult<Option<TransferTaskRecord>> {
+    let value: Option<String> = conn
+        .exec_first(
+            "select record_json from transfer_tasks
+             where job_id = :job_id and run_id = :run_id and task_id = :task_id",
+            params! { "job_id" => job_id, "run_id" => run_id, "task_id" => task_id },
+        )
+        .map_err(mysql_err)?;
+    value
+        .map(|json| serde_json::from_str(&json).map_err(json_err))
+        .transpose()
+}
+
+fn select_task_for_update(
+    conn: &mut impl Queryable,
+    job_id: &str,
+    run_id: u64,
+    task_id: &str,
+) -> FsResult<Option<TransferTaskRecord>> {
+    let value: Option<String> = conn
+        .exec_first(
+            "select record_json from transfer_tasks
+             where job_id = :job_id and run_id = :run_id and task_id = :task_id
+             for update",
+            params! { "job_id" => job_id, "run_id" => run_id, "task_id" => task_id },
+        )
+        .map_err(mysql_err)?;
+    value
+        .map(|json| serde_json::from_str(&json).map_err(json_err))
+        .transpose()
+}
+
+fn select_tasks(
+    conn: &mut impl Queryable,
+    job_id: &str,
+    run_id: u64,
+    state: Option<TransferTaskState>,
+    limit: Option<usize>,
+) -> FsResult<Vec<TransferTaskRecord>> {
+    let mut sql =
+        "select record_json from transfer_tasks where job_id = :job_id and run_id = :run_id"
+            .to_string();
+    if state.is_some() {
+        sql.push_str(" and state = :state");
+    }
+    sql.push_str(" order by updated_at asc");
+    if limit.is_some() {
+        sql.push_str(" limit :limit");
+    }
+    let rows: Vec<String> = conn
+        .exec(
+            sql,
+            params! {
+                "job_id" => job_id,
+                "run_id" => run_id,
+                "state" => state.map(|s| s as i32),
+                "limit" => limit.map(|v| v as u64),
+            },
+        )
+        .map_err(mysql_err)?;
+    rows.into_iter()
+        .map(|json| serde_json::from_str(&json).map_err(json_err))
+        .collect()
+}
+
+fn exec_update_job(conn: &mut impl Queryable, job: &TransferJobRecord) -> FsResult<bool> {
+    let affected = exec_affected(
+        conn,
+        "update transfer_jobs
+         set tenant = :tenant, target_path = :target_path, kind = :kind, state = :state, owner = :owner, lease_epoch = :lease_epoch,
+             lease_expire_at = :lease_expire_at, cancel_requested = :cancel_requested,
+             record_json = :record_json, created_at = :created_at, updated_at = :updated_at
+         where job_id = :job_id and run_id = :run_id",
+        job_params(job)?,
+    )?;
+    Ok(affected > 0)
+}
+
+fn exec_update_task(conn: &mut impl Queryable, task: &TransferTaskRecord) -> FsResult<bool> {
+    let affected = exec_affected(
+        conn,
+        "update transfer_tasks
+         set state = :state, attempt_id = :attempt_id, worker_id = :worker_id,
+             worker_session_id = :worker_session_id, stale_deadline_at = :stale_deadline_at,
+             record_json = :record_json, updated_at = :updated_at
+         where job_id = :job_id and run_id = :run_id and task_id = :task_id",
+        task_params(task)?,
+    )?;
+    Ok(affected > 0)
+}
+
+fn exec_affected(conn: &mut impl Queryable, sql: &str, params: mysql::Params) -> FsResult<u64> {
+    let result = conn.exec_iter(sql, params).map_err(mysql_err)?;
+    Ok(result.affected_rows())
+}
+
+fn update_job_summary(
+    conn: &mut impl Queryable,
+    job_id: &str,
+    run_id: u64,
+    now_ms: i64,
+) -> FsResult<()> {
+    let tasks = select_tasks(conn, job_id, run_id, None, None)?;
+    let mut job = select_job_by_id(conn, job_id)?.ok_or_else(|| FsError::job_not_found(job_id))?;
+    let summary = summarize_transfer_tasks(&tasks, now_ms);
+    job.summary = summary.progress;
+    job.updated_at = now_ms;
+    if summary.has_failed {
+        job.state = TransferState::Failed;
+    } else if summary.has_task && summary.all_completed {
+        job.state = TransferState::Completed;
+    }
+    let _ = exec_update_job(conn, &job)?;
+    Ok(())
+}
+
+fn job_params(job: &TransferJobRecord) -> FsResult<mysql::Params> {
+    Ok(params! {
+        "job_id" => &job.job_id,
+        "submitter" => &job.submitter,
+        "tenant" => &job.tenant,
+        "client_request_id" => &job.client_request_id,
+        "job_key" => &job.job_key,
+        "target_path" => &job.target_path,
+        "run_id" => job.run_id,
+        "kind" => job.kind as i32,
+        "state" => job.state as i32,
+        "owner" => &job.owner,
+        "lease_epoch" => job.lease_epoch,
+        "lease_expire_at" => job.lease_expire_at,
+        "cancel_requested" => job.cancel_requested,
+        "record_json" => json(job)?,
+        "created_at" => job.created_at,
+        "updated_at" => job.updated_at,
+    })
+}
+
+fn task_params(task: &TransferTaskRecord) -> FsResult<mysql::Params> {
+    Ok(params! {
+        "job_id" => &task.job_id,
+        "run_id" => task.run_id,
+        "task_id" => &task.task_id,
+        "state" => task.state as i32,
+        "attempt_id" => task.attempt_id,
+        "worker_id" => task.worker_id,
+        "worker_session_id" => &task.worker_session_id,
+        "stale_deadline_at" => task.stale_deadline_at,
+        "record_json" => json(task)?,
+        "updated_at" => task.updated_at,
+    })
+}
+
+fn json<T: serde::Serialize>(value: &T) -> FsResult<String> {
+    serde_json::to_string(value).map_err(json_err)
+}
+
+fn json_err(_: serde_json::Error) -> FsError {
+    FsError::common("Transfer metadata store contains invalid data")
+}
+
+fn mysql_err(err: mysql::Error) -> FsError {
+    log::warn!("transfer MySQL store operation failed: {}", err);
+    FsError::transfer_store_unavailable(
+        "Transfer metadata store is unavailable; verify transfer.store_url and database connectivity",
+    )
+}
+
+fn mysql_error_code(err: &mysql::Error) -> Option<u16> {
+    match err {
+        mysql::Error::MySqlError(err) => Some(err.code),
+        _ => None,
+    }
+}

--- a/curvine-server/src/transfer/planner.rs
+++ b/curvine-server/src/transfer/planner.rs
@@ -215,23 +215,8 @@ impl TransferPlanner {
         Ok(epoch_before != epoch_after)
     }
 
-    fn load_job_info(&self, job: &TransferJobRecord, mount: &MountInfo) -> LoadJobInfo {
-        let overwrite = transfer_command(job)
-            .map(|command| command.overwrite())
-            .unwrap_or(true);
-        LoadJobInfo {
-            job_id: job.job_id.clone(),
-            source_path: job.source_path.clone(),
-            target_path: job.target_path.clone(),
-            replicas: mount.replicas.unwrap_or(self.client_conf.replicas),
-            block_size: mount.block_size.unwrap_or(self.client_conf.block_size),
-            storage_type: mount.storage_type.unwrap_or(self.client_conf.storage_type),
-            ttl_ms: mount.ttl_ms,
-            ttl_action: mount.ttl_action,
-            mount_info: mount.clone(),
-            create_time: job.created_at,
-            overwrite: Some(overwrite),
-        }
+    pub(crate) fn load_job_info(&self, job: &TransferJobRecord, mount: &MountInfo) -> LoadJobInfo {
+        load_job_info(job, mount, &self.client_conf)
     }
 
     async fn get_status(
@@ -330,6 +315,29 @@ impl TransferPlanner {
                 err
             ))
         })
+    }
+}
+
+pub(crate) fn load_job_info(
+    job: &TransferJobRecord,
+    mount: &MountInfo,
+    client_conf: &ClientConf,
+) -> LoadJobInfo {
+    let overwrite = transfer_command(job)
+        .map(|command| command.overwrite())
+        .unwrap_or(true);
+    LoadJobInfo {
+        job_id: job.job_id.clone(),
+        source_path: job.source_path.clone(),
+        target_path: job.target_path.clone(),
+        replicas: mount.replicas.unwrap_or(client_conf.replicas),
+        block_size: mount.block_size.unwrap_or(client_conf.block_size),
+        storage_type: mount.storage_type.unwrap_or(client_conf.storage_type),
+        ttl_ms: mount.ttl_ms,
+        ttl_action: mount.ttl_action,
+        mount_info: mount.clone(),
+        create_time: job.created_at,
+        overwrite: Some(overwrite),
     }
 }
 

--- a/curvine-server/src/transfer/planner.rs
+++ b/curvine-server/src/transfer/planner.rs
@@ -1,0 +1,437 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::common::UfsFactory;
+use crate::transfer::{
+    job_mount_snapshot, ClusterMetadataCache, CvMetadataReader, TransferMetrics,
+};
+use curvine_common::conf::ClientConf;
+use curvine_common::error::FsError;
+use curvine_common::fs::{FileSystem, Path};
+use curvine_common::state::{
+    FileStatus, LoadJobInfo, MountInfo, TransferCommand, TransferJobRecord, TransferKind,
+    TransferTaskRecord, TransferTaskState,
+};
+use curvine_common::FsResult;
+use orpc::common::LocalTime;
+use orpc::err_box;
+use parking_lot::Mutex;
+use std::collections::{HashMap, VecDeque};
+use std::sync::Arc;
+use std::time::Instant;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+const MAX_EXPORT_EPOCH_PLAN_RETRIES: usize = 3;
+
+pub struct PlannedTransfer {
+    pub job_info: LoadJobInfo,
+    pub tasks: Vec<TransferTaskRecord>,
+    pub total_size: i64,
+    pub cv_metadata_epoch: Option<u64>,
+}
+
+#[derive(Clone)]
+pub struct TransferPlanner {
+    cv_metadata: Arc<dyn CvMetadataReader>,
+    factory: Arc<UfsFactory>,
+    cache: ClusterMetadataCache,
+    client_conf: ClientConf,
+    max_tasks_per_transfer: usize,
+    ufs_limiter: Arc<UfsEndpointLimiter>,
+}
+
+impl TransferPlanner {
+    pub fn new(
+        cv_metadata: Arc<dyn CvMetadataReader>,
+        factory: Arc<UfsFactory>,
+        cache: ClusterMetadataCache,
+        client_conf: ClientConf,
+        max_tasks_per_transfer: usize,
+        ufs_max_concurrency_per_endpoint: usize,
+    ) -> Self {
+        Self {
+            cv_metadata,
+            factory,
+            cache,
+            client_conf,
+            max_tasks_per_transfer,
+            ufs_limiter: Arc::new(UfsEndpointLimiter::new(ufs_max_concurrency_per_endpoint)),
+        }
+    }
+
+    pub async fn plan(&self, job: &TransferJobRecord) -> FsResult<PlannedTransfer> {
+        for attempt in 0..MAX_EXPORT_EPOCH_PLAN_RETRIES {
+            let cv_metadata_epoch = self.export_epoch_before_plan(job)?;
+            let planned = self.plan_once(job, cv_metadata_epoch).await?;
+            if !self.export_epoch_changed(job, cv_metadata_epoch)? {
+                return Ok(planned);
+            }
+            log::warn!(
+                "CV metadata replica epoch changed while planning export {}, retry {}/{}",
+                job.job_id,
+                attempt + 1,
+                MAX_EXPORT_EPOCH_PLAN_RETRIES
+            );
+        }
+        Err(FsError::common(format!(
+            "CV metadata replica epoch changed during export planning {} after {} retries",
+            job.job_id, MAX_EXPORT_EPOCH_PLAN_RETRIES
+        )))
+    }
+
+    async fn plan_once(
+        &self,
+        job: &TransferJobRecord,
+        cv_metadata_epoch: Option<u64>,
+    ) -> FsResult<PlannedTransfer> {
+        let source = Path::from_str(&job.source_path)?;
+        let target = Path::from_str(&job.target_path)?;
+        let mount = job_mount_snapshot(job, &self.cache)?;
+        let job_info = self.load_job_info(job, &mount);
+        let source_status = self
+            .get_status(job, &source, &mount, cv_metadata_epoch)
+            .await?;
+        if source_status.is_dir {
+            self.validate_directory_target(job, &target, &mount, cv_metadata_epoch)
+                .await?;
+        }
+
+        let mut tasks = Vec::new();
+        let mut total_size = 0;
+        let mut stack = VecDeque::new();
+        stack.push_back(source_status);
+
+        while let Some(status) = stack.pop_front() {
+            let path = Path::from_str(&status.path)?;
+            if status.is_dir {
+                for child in self
+                    .list_status(job, &path, &mount, cv_metadata_epoch)
+                    .await?
+                {
+                    stack.push_back(child);
+                }
+                continue;
+            }
+
+            let task_target = append_relative_path(&source, &target, &path)?;
+            let task_id = format!("{}_task_{}", job.job_id, tasks.len());
+            let source_read_plan_json = self
+                .source_read_plan_json(job, &path, cv_metadata_epoch)
+                .await?;
+            total_size += status.len;
+            tasks.push(TransferTaskRecord {
+                job_id: job.job_id.clone(),
+                run_id: job.run_id,
+                task_id,
+                attempt_id: 0,
+                source_path: path.clone_uri(),
+                target_path: task_target.clone_uri(),
+                worker_id: 0,
+                worker_session_id: String::new(),
+                source_read_plan_json,
+                report_target_json: String::new(),
+                state: TransferTaskState::Pending,
+                progress: Default::default(),
+                retry_count: 0,
+                attempt_started_at: 0,
+                last_report_at: 0,
+                stale_deadline_at: 0,
+                updated_at: LocalTime::mills() as i64,
+            });
+
+            if tasks.len() > self.max_tasks_per_transfer {
+                return err_box!(
+                    "Transfer {} files exceeds {}",
+                    job.job_id,
+                    self.max_tasks_per_transfer
+                );
+            }
+        }
+
+        Ok(PlannedTransfer {
+            job_info,
+            tasks,
+            total_size,
+            cv_metadata_epoch,
+        })
+    }
+
+    async fn validate_directory_target(
+        &self,
+        job: &TransferJobRecord,
+        target: &Path,
+        mount: &MountInfo,
+        cv_metadata_epoch: Option<u64>,
+    ) -> FsResult<()> {
+        match self.get_status(job, target, mount, cv_metadata_epoch).await {
+            Ok(status) if status.is_dir => Ok(()),
+            Ok(_) => err_box!(
+                "Transfer target {} is a file; refusing to transfer directory into file",
+                target.full_path()
+            ),
+            Err(FsError::FileNotFound(_)) => Ok(()),
+            Err(err) => Err(err),
+        }
+    }
+
+    fn export_epoch_before_plan(&self, job: &TransferJobRecord) -> FsResult<Option<u64>> {
+        if job.kind != TransferKind::Export {
+            return Ok(None);
+        }
+        let Some(epoch) = self.cv_metadata.current_epoch()? else {
+            return Ok(None);
+        };
+        Ok(Some(job.cv_metadata_epoch.unwrap_or(epoch)))
+    }
+
+    fn export_epoch_changed(
+        &self,
+        job: &TransferJobRecord,
+        epoch_before: Option<u64>,
+    ) -> FsResult<bool> {
+        if job.kind != TransferKind::Export {
+            return Ok(false);
+        }
+        if job.cv_metadata_epoch.is_some() {
+            return Ok(false);
+        }
+        let Some(epoch_before) = epoch_before else {
+            return Ok(false);
+        };
+        let Some(epoch_after) = self.cv_metadata.current_epoch()? else {
+            return Ok(false);
+        };
+        Ok(epoch_before != epoch_after)
+    }
+
+    fn load_job_info(&self, job: &TransferJobRecord, mount: &MountInfo) -> LoadJobInfo {
+        let overwrite = transfer_command(job)
+            .map(|command| command.overwrite())
+            .unwrap_or(true);
+        LoadJobInfo {
+            job_id: job.job_id.clone(),
+            source_path: job.source_path.clone(),
+            target_path: job.target_path.clone(),
+            replicas: mount.replicas.unwrap_or(self.client_conf.replicas),
+            block_size: mount.block_size.unwrap_or(self.client_conf.block_size),
+            storage_type: mount.storage_type.unwrap_or(self.client_conf.storage_type),
+            ttl_ms: mount.ttl_ms,
+            ttl_action: mount.ttl_action,
+            mount_info: mount.clone(),
+            create_time: job.created_at,
+            overwrite: Some(overwrite),
+        }
+    }
+
+    async fn get_status(
+        &self,
+        job: &TransferJobRecord,
+        path: &Path,
+        mount: &MountInfo,
+        cv_metadata_epoch: Option<u64>,
+    ) -> FsResult<FileStatus> {
+        let start = Instant::now();
+        if path.is_cv() {
+            let result = self
+                .cv_metadata
+                .get_status_at_epoch(path, cv_metadata_epoch)
+                .await;
+            record_metadata_operation("cv", "get_status", result.is_ok(), start);
+            result.map_err(|err| self.map_export_cv_not_found(job, path, err))
+        } else {
+            let _permit = self.ufs_limiter.acquire(mount).await?;
+            let result = match self.factory.get_ufs(mount) {
+                Ok(ufs) => ufs.get_status(path).await,
+                Err(err) => Err(err),
+            };
+            record_metadata_operation("ufs", "get_status", result.is_ok(), start);
+            result
+        }
+    }
+
+    fn map_export_cv_not_found(
+        &self,
+        job: &TransferJobRecord,
+        path: &Path,
+        err: FsError,
+    ) -> FsError {
+        if job.kind != TransferKind::Export || !matches!(err, FsError::FileNotFound(_)) {
+            return err;
+        }
+        match self.cv_metadata.covers_time_ms(job.created_at) {
+            Ok(false) => FsError::in_progress_msg(format!(
+                "CV metadata replica has not caught up for export {}: path={}, job_created_at={}",
+                job.job_id,
+                path.full_path(),
+                job.created_at
+            )),
+            Ok(true) => err,
+            Err(refresh_err) => refresh_err,
+        }
+    }
+
+    async fn list_status(
+        &self,
+        job: &TransferJobRecord,
+        path: &Path,
+        mount: &MountInfo,
+        cv_metadata_epoch: Option<u64>,
+    ) -> FsResult<Vec<FileStatus>> {
+        let start = Instant::now();
+        if path.is_cv() {
+            let result = self
+                .cv_metadata
+                .list_status_at_epoch(path, cv_metadata_epoch)
+                .await;
+            record_metadata_operation("cv", "list_status", result.is_ok(), start);
+            result.map_err(|err| self.map_export_cv_not_found(job, path, err))
+        } else {
+            let _permit = self.ufs_limiter.acquire(mount).await?;
+            let result = match self.factory.get_ufs(mount) {
+                Ok(ufs) => ufs.list_status(path).await,
+                Err(err) => Err(err),
+            };
+            record_metadata_operation("ufs", "list_status", result.is_ok(), start);
+            result
+        }
+    }
+
+    async fn source_read_plan_json(
+        &self,
+        job: &TransferJobRecord,
+        path: &Path,
+        cv_metadata_epoch: Option<u64>,
+    ) -> FsResult<String> {
+        if !path.is_cv() {
+            return Ok(String::new());
+        }
+        let start = Instant::now();
+        let blocks = self
+            .cv_metadata
+            .get_block_locations_at_epoch(path, cv_metadata_epoch)
+            .await;
+        record_metadata_operation("cv", "get_block_locations", blocks.is_ok(), start);
+        let blocks = blocks.map_err(|err| self.map_export_cv_not_found(job, path, err))?;
+        serde_json::to_string(&blocks).map_err(|err| {
+            FsError::common(format!(
+                "Failed to serialize CV source read plan for {}: {}",
+                path.full_path(),
+                err
+            ))
+        })
+    }
+}
+
+struct UfsEndpointLimiter {
+    max_per_endpoint: usize,
+    semaphores: Mutex<HashMap<String, Arc<Semaphore>>>,
+}
+
+impl UfsEndpointLimiter {
+    fn new(max_per_endpoint: usize) -> Self {
+        Self {
+            max_per_endpoint,
+            semaphores: Mutex::new(HashMap::new()),
+        }
+    }
+
+    async fn acquire(&self, mount: &MountInfo) -> FsResult<OwnedSemaphorePermit> {
+        let endpoint = ufs_endpoint_key(mount);
+        let semaphore = {
+            let mut semaphores = self.semaphores.lock();
+            semaphores
+                .entry(endpoint)
+                .or_insert_with(|| Arc::new(Semaphore::new(self.max_per_endpoint)))
+                .clone()
+        };
+        semaphore.acquire_owned().await.map_err(|err| {
+            FsError::common(format!(
+                "Failed to acquire UFS endpoint planning permit: {}",
+                err
+            ))
+        })
+    }
+}
+
+fn ufs_endpoint_key(mount: &MountInfo) -> String {
+    let Ok(path) = Path::from_str(&mount.ufs_path) else {
+        return mount.ufs_path.clone();
+    };
+    match path.scheme() {
+        Some("file") => "file://".to_string(),
+        Some(scheme) => format!("{}://{}", scheme, path.authority().unwrap_or("")),
+        None => mount.ufs_path.clone(),
+    }
+}
+
+fn record_metadata_operation(
+    source: &'static str,
+    operation: &'static str,
+    success: bool,
+    start: Instant,
+) {
+    if let Ok(metrics) = TransferMetrics::get() {
+        metrics.observe_metadata_operation(
+            source,
+            operation,
+            if success { "success" } else { "error" },
+            start.elapsed().as_micros(),
+        );
+    }
+}
+
+fn append_relative_path(source_root: &Path, target_root: &Path, source: &Path) -> FsResult<Path> {
+    let source_root_text = normalized_path_text(source_root);
+    let source_text = normalized_path_text(source);
+    let target_root_text = normalized_path_text(target_root);
+
+    let relative = if source_text == source_root_text {
+        ""
+    } else {
+        source_text
+            .strip_prefix(source_root_text.as_str())
+            .ok_or_else(|| {
+                FsError::common(format!(
+                    "Source path {} is not under transfer root {}",
+                    source.full_path(),
+                    source_root.full_path()
+                ))
+            })?
+            .trim_start_matches('/')
+    };
+
+    let target = if relative.is_empty() {
+        target_root_text
+    } else {
+        format!("{}/{}", target_root_text.trim_end_matches('/'), relative)
+    };
+    Ok(Path::from_str(target)?)
+}
+
+fn transfer_command(job: &TransferJobRecord) -> FsResult<TransferCommand> {
+    serde_json::from_str(&job.command_json).map_err(|err| {
+        FsError::common(format!(
+            "Invalid transfer command json for job {}: {}",
+            job.job_id, err
+        ))
+    })
+}
+
+fn normalized_path_text(path: &Path) -> String {
+    if path.is_cv() {
+        path.path().trim_end_matches('/').to_string()
+    } else {
+        path.full_path().trim_end_matches('/').to_string()
+    }
+}

--- a/curvine-server/src/transfer/router_handler.rs
+++ b/curvine-server/src/transfer/router_handler.rs
@@ -95,7 +95,7 @@ async fn readyz(
         );
         return (
             StatusCode::SERVICE_UNAVAILABLE,
-            "not ready: cluster metadata is unavailable\n".to_string(),
+            format!("not ready: {err}\n"),
         );
     }
 

--- a/curvine-server/src/transfer/router_handler.rs
+++ b/curvine-server/src/transfer/router_handler.rs
@@ -1,0 +1,138 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use axum::http::StatusCode;
+use axum::routing::get;
+use axum::Router;
+use curvine_web::router::RouterHandler;
+use log::warn;
+use orpc::common::Metrics;
+
+use crate::transfer::{
+    ClusterMetadataCache, CvMetadataReader, TransferService, TransferStoreBackend,
+};
+
+pub struct TransferRouterHandler {
+    ready: Arc<AtomicBool>,
+    store_backend: &'static str,
+    service: TransferService<TransferStoreBackend>,
+    cluster_cache: ClusterMetadataCache,
+    cv_metadata: Option<Arc<dyn CvMetadataReader>>,
+}
+
+impl TransferRouterHandler {
+    pub fn new(
+        ready: Arc<AtomicBool>,
+        store_backend: &'static str,
+        service: TransferService<TransferStoreBackend>,
+        cluster_cache: ClusterMetadataCache,
+        cv_metadata: Option<Arc<dyn CvMetadataReader>>,
+    ) -> Self {
+        Self {
+            ready,
+            store_backend,
+            service,
+            cluster_cache,
+            cv_metadata,
+        }
+    }
+}
+
+async fn metrics() -> String {
+    Metrics::text_output().unwrap_or_else(|err| {
+        warn!("failed to encode transfer metrics: {}", err);
+        "metrics unavailable\n".to_string()
+    })
+}
+
+async fn healthz() -> &'static str {
+    "ok\n"
+}
+
+async fn readyz(
+    ready: Arc<AtomicBool>,
+    store_backend: &'static str,
+    service: TransferService<TransferStoreBackend>,
+    cluster_cache: ClusterMetadataCache,
+    cv_metadata: Option<Arc<dyn CvMetadataReader>>,
+) -> (StatusCode, String) {
+    if !ready.load(Ordering::Relaxed) {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "not ready: starting\n".to_string(),
+        );
+    }
+
+    if let Err(err) = service.check_store_available() {
+        warn!(
+            "transfer readiness check failed for {store_backend} store: {}",
+            err
+        );
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            format!("not ready: {store_backend} transfer metadata store is unavailable\n"),
+        );
+    }
+
+    if let Err(err) = cluster_cache.check_ready() {
+        warn!(
+            "transfer readiness check failed for cluster metadata: {}",
+            err
+        );
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "not ready: cluster metadata is unavailable\n".to_string(),
+        );
+    }
+
+    if let Some(reader) = cv_metadata {
+        if let Err(err) = reader.current_epoch() {
+            warn!("transfer readiness check failed for CV metadata: {}", err);
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "not ready: Curvine metadata is unavailable\n".to_string(),
+            );
+        }
+    }
+
+    (StatusCode::OK, "ok\n".to_string())
+}
+
+impl RouterHandler for TransferRouterHandler {
+    fn router(&self) -> Router {
+        let ready = self.ready.clone();
+        let store_backend = self.store_backend;
+        let service = self.service.clone();
+        let cluster_cache = self.cluster_cache.clone();
+        let cv_metadata = self.cv_metadata.clone();
+        Router::new()
+            .route("/healthz", get(healthz))
+            .route(
+                "/readyz",
+                get(move || {
+                    readyz(
+                        ready.clone(),
+                        store_backend,
+                        service.clone(),
+                        cluster_cache.clone(),
+                        cv_metadata.clone(),
+                    )
+                }),
+            )
+            .route("/metrics", get(metrics))
+    }
+}

--- a/curvine-server/src/transfer/scheduler.rs
+++ b/curvine-server/src/transfer/scheduler.rs
@@ -14,15 +14,15 @@
 
 use crate::common::UfsFactory;
 use crate::transfer::{
-    is_store_unavailable_error, job_mount_snapshot, transfer_failure_message, TransferPlanner,
-    TransferRequeueUpdate, TransferStore,
+    is_store_unavailable_error, job_mount_snapshot, transfer_failure_message, TransferPlannedTasks,
+    TransferPlanner, TransferRequeueUpdate, TransferStore, TransferTaskStateUpdate,
 };
 use curvine_common::conf::TransferConf;
 use curvine_common::error::FsError;
 use curvine_common::state::{
-    summarize_transfer_tasks, LoadJobInfo, LoadTaskInfo, TaskAttemptStart, TransferCommand,
-    TransferJobRecord, TransferLease, TransferProgress, TransferState, TransferStateUpdate,
-    TransferTaskRecord, TransferTaskReport, TransferTaskReportInfo, TransferTaskState, WorkerInfo,
+    summarize_transfer_tasks, LoadJobInfo, LoadTaskInfo, TaskAttemptStart, TransferJobRecord,
+    TransferLease, TransferProgress, TransferState, TransferStateUpdate, TransferTaskRecord,
+    TransferTaskReport, TransferTaskReportInfo, TransferTaskState, WorkerInfo,
 };
 use curvine_common::FsResult;
 use futures::stream::{self, StreamExt, TryStreamExt};
@@ -46,7 +46,7 @@ pub struct TransferScheduler<S> {
     cache: ClusterMetadataCache,
     factory: Arc<UfsFactory>,
     owner: String,
-    report_target: String,
+    report_endpoints: Vec<String>,
     conf: TransferConf,
     worker_cursor: Arc<AtomicUsize>,
     last_cleanup_ms: Arc<AtomicU64>,
@@ -60,7 +60,7 @@ impl<S> Clone for TransferScheduler<S> {
             cache: self.cache.clone(),
             factory: self.factory.clone(),
             owner: self.owner.clone(),
-            report_target: self.report_target.clone(),
+            report_endpoints: self.report_endpoints.clone(),
             conf: self.conf.clone(),
             worker_cursor: self.worker_cursor.clone(),
             last_cleanup_ms: self.last_cleanup_ms.clone(),
@@ -78,7 +78,7 @@ where
         cache: ClusterMetadataCache,
         factory: Arc<UfsFactory>,
         owner: String,
-        report_target: String,
+        report_endpoints: Vec<String>,
         conf: TransferConf,
     ) -> Self {
         Self {
@@ -87,7 +87,7 @@ where
             cache,
             factory,
             owner,
-            report_target,
+            report_endpoints,
             conf,
             worker_cursor: Arc::new(AtomicUsize::new(0)),
             last_cleanup_ms: Arc::new(AtomicU64::new(0)),
@@ -150,7 +150,10 @@ where
             TransferState::Canceling => {
                 self.cancel_transfer(&job, &lease).await?;
             }
-            TransferState::Completed | TransferState::Failed | TransferState::Canceled => {}
+            TransferState::Completed
+            | TransferState::Failed
+            | TransferState::Canceled
+            | TransferState::PartialSuccess => {}
         }
         Ok(())
     }
@@ -252,6 +255,8 @@ where
                 });
                 self.fail_transfer(
                     &job,
+                    &lease,
+                    &[TransferState::Planning],
                     transfer_failure_message(job.kind, &job.source_path, &job.target_path, &err),
                 )?;
                 return Err(err);
@@ -277,11 +282,12 @@ where
         }
 
         if planned.tasks.is_empty() {
-            self.set_transfer_state(
+            self.transition(
                 &job,
+                &lease,
+                &[TransferState::Planning],
                 TransferState::Completed,
                 "transfer has no file tasks",
-                now_ms(),
             )?;
             record_metric(|metrics| {
                 metrics.inc_planning(transfer_kind_label(job.kind), "empty");
@@ -292,16 +298,27 @@ where
         }
 
         let task_count = planned.tasks.len();
-        self.store.insert_tasks(planned.tasks)?;
-        self.set_transfer_state(
-            &job,
-            TransferState::Dispatching,
-            format!("planned total_size={}", planned.total_size),
-            now_ms(),
-        )?;
+        let total_size = planned.total_size;
+        let job_info = planned.job_info;
+        let persisted = self.store.persist_planned_tasks(TransferPlannedTasks {
+            job_id: job.job_id.clone(),
+            run_id: job.run_id,
+            owner: lease.owner.clone(),
+            lease_epoch: lease.lease_epoch,
+            tasks: planned.tasks,
+            message: format!("planned total_size={total_size}"),
+            now_ms: now_ms(),
+        })?;
+        if !persisted {
+            warn!(
+                "stop planning transfer {} because owner {} lease epoch {} is stale",
+                job.job_id, lease.owner, lease.lease_epoch
+            );
+            return Ok(());
+        }
         debug!(
             "transfer {} planned with job info source={}, target={}",
-            job.job_id, planned.job_info.source_path, planned.job_info.target_path
+            job.job_id, job_info.source_path, job_info.target_path
         );
         record_metric(|metrics| {
             metrics.inc_planning(transfer_kind_label(job.kind), "success");
@@ -343,6 +360,8 @@ where
                     }
                     self.fail_transfer(
                         &job,
+                        &lease,
+                        &[TransferState::Dispatching],
                         transfer_failure_message(
                             job.kind,
                             &job.source_path,
@@ -435,7 +454,7 @@ where
             let job_info = job_info.clone();
             let owner = lease.owner.clone();
             let lease_epoch = lease.lease_epoch;
-            let report_target = self.report_target.clone();
+            let report_endpoints = self.report_endpoints.clone();
             let task_stale_timeout_ms = duration_ms(self.conf.task_stale_timeout);
             async move {
                 dispatch_one(DispatchTaskRequest {
@@ -447,7 +466,7 @@ where
                     lease_epoch,
                     task,
                     worker,
-                    report_target,
+                    report_endpoints,
                     task_stale_timeout_ms,
                 })
                 .await
@@ -464,36 +483,7 @@ where
         job: &TransferJobRecord,
         mount: &curvine_common::state::MountInfo,
     ) -> curvine_common::state::LoadJobInfo {
-        let overwrite = transfer_command(job)
-            .map(|command| command.overwrite())
-            .unwrap_or(true);
-        curvine_common::state::LoadJobInfo {
-            job_id: job.job_id.clone(),
-            source_path: job.source_path.clone(),
-            target_path: job.target_path.clone(),
-            replicas: mount.replicas.unwrap_or(self.conf_default_replicas()),
-            block_size: mount.block_size.unwrap_or(self.conf_default_block_size()),
-            storage_type: mount
-                .storage_type
-                .unwrap_or(self.conf_default_storage_type()),
-            ttl_ms: mount.ttl_ms,
-            ttl_action: mount.ttl_action,
-            mount_info: mount.clone(),
-            create_time: job.created_at,
-            overwrite: Some(overwrite),
-        }
-    }
-
-    fn conf_default_replicas(&self) -> i32 {
-        curvine_common::conf::ClientConf::default().replicas
-    }
-
-    fn conf_default_block_size(&self) -> i64 {
-        curvine_common::conf::ClientConf::default().block_size
-    }
-
-    fn conf_default_storage_type(&self) -> curvine_common::state::StorageType {
-        curvine_common::conf::ClientConf::default().storage_type
+        self.planner.load_job_info(job, mount)
     }
 
     async fn check_running_transfer(
@@ -513,30 +503,42 @@ where
         )?;
         for attempt in stale {
             if attempt.task.retry_count as usize > self.conf.task_max_retries {
-                self.store.update_task_state(
-                    &attempt.task.job_id,
-                    attempt.task.run_id,
-                    &attempt.task.task_id,
-                    TransferTaskState::Failed,
-                    "transfer task did not report progress before the retry limit was reached; check Transfer worker health",
-                    now,
-                )?;
-                self.fail_transfer(
-                    &job,
-                    "transfer task did not report progress before the retry limit was reached; check Transfer worker health",
-                )?;
+                if !self.store.update_task_state(TransferTaskStateUpdate {
+                    job_id: attempt.task.job_id.clone(),
+                    run_id: attempt.task.run_id,
+                    owner: lease.owner.clone(),
+                    lease_epoch: lease.lease_epoch,
+                    task_id: attempt.task.task_id.clone(),
+                    from_states: vec![TransferTaskState::Stale],
+                    state: TransferTaskState::Failed,
+                    message: "transfer task did not report progress before the retry limit was reached; check Transfer worker health".to_string(),
+                    now_ms: now,
+                })? {
+                    return Ok(());
+                }
+                self.finish_failed_transfer(&job, &lease).await?;
                 record_metric(|metrics| metrics.inc_stale_retry("exhausted"));
                 return Ok(());
             }
-            self.store.update_task_state(
-                &attempt.task.job_id,
-                attempt.task.run_id,
-                &attempt.task.task_id,
-                TransferTaskState::Pending,
-                "retry stale task attempt",
-                now,
-            )?;
+            if !self.store.update_task_state(TransferTaskStateUpdate {
+                job_id: attempt.task.job_id.clone(),
+                run_id: attempt.task.run_id,
+                owner: lease.owner.clone(),
+                lease_epoch: lease.lease_epoch,
+                task_id: attempt.task.task_id.clone(),
+                from_states: vec![TransferTaskState::Stale],
+                state: TransferTaskState::Pending,
+                message: "retry stale task attempt".to_string(),
+                now_ms: now,
+            })? {
+                return Ok(());
+            }
             record_metric(|metrics| metrics.inc_stale_retry("scheduled"));
+        }
+
+        if self.store.has_failed_tasks(&job.job_id, job.run_id)? {
+            self.finish_failed_transfer(&job, &lease).await?;
+            return Ok(());
         }
 
         if !self
@@ -544,31 +546,18 @@ where
             .claim_pending_tasks(&job.job_id, job.run_id, 1)?
             .is_empty()
         {
-            self.set_transfer_state(
+            self.transition(
                 &job,
+                &lease,
+                &[TransferState::Running],
                 TransferState::Dispatching,
                 "redispatch stale tasks",
-                now,
             )?;
             self.dispatch_pending_tasks(job, lease).await?;
             return Ok(());
         }
 
-        let tasks = self.store.list_transfer_tasks(&job.job_id, job.run_id)?;
-        if tasks.is_empty() {
-            return Ok(());
-        }
-
-        let summary = summarize_transfer_tasks(&tasks, now);
-        if summary.has_failed {
-            self.fail_transfer(&job, summary.progress.message)?;
-            return Ok(());
-        }
-
-        if summary.all_completed {
-            self.set_transfer_state(&job, TransferState::Completed, "all tasks completed", now)?;
-            record_metric(|metrics| metrics.inc_terminal("completed", "all_tasks_completed"));
-        } else {
+        if self.store.has_recoverable_tasks(&job.job_id, job.run_id)? {
             let renewed = self.store.renew_lease(
                 &lease.job_id,
                 lease.run_id,
@@ -580,18 +569,28 @@ where
             record_metric(|metrics| {
                 metrics.inc_lease_renew(if renewed { "success" } else { "stale" })
             });
+        } else {
+            let _ = self.transition(
+                &job,
+                &lease,
+                &[TransferState::Running],
+                TransferState::Completed,
+                "all tasks completed",
+            )?;
+            record_metric(|metrics| metrics.inc_terminal("completed", "all_tasks_completed"));
         }
         Ok(())
     }
 
     async fn probe_stale_running_tasks(&self, job: &TransferJobRecord, now: i64) -> FsResult<()> {
-        let tasks = self.store.list_recoverable_tasks(&job.job_id, job.run_id)?;
+        let tasks = self.store.list_stale_running_tasks(
+            &job.job_id,
+            job.run_id,
+            now,
+            self.conf.task_probe_concurrency(),
+        )?;
         let workers = self.cache.live_workers().unwrap_or_default();
-        for task in tasks
-            .into_iter()
-            .filter(|task| task.state == TransferTaskState::Running && task.stale_deadline_at < now)
-            .take(self.conf.task_probe_concurrency())
-        {
+        for task in tasks {
             let Some(worker) = workers.iter().find(|worker| {
                 worker.worker_id() == task.worker_id
                     && worker.worker_session_id == task.worker_session_id
@@ -641,22 +640,89 @@ where
     async fn cancel_transfer(
         &self,
         job: &TransferJobRecord,
-        _lease: &TransferLease,
+        lease: &TransferLease,
+    ) -> FsResult<()> {
+        self.stop_recoverable_tasks(job, lease, "transfer canceled")
+            .await?;
+
+        let _ = self.transition(
+            job,
+            lease,
+            &[TransferState::Canceling],
+            TransferState::Canceled,
+            "transfer canceled",
+        )?;
+        record_metric(|metrics| metrics.inc_terminal("canceled", "cancel_requested"));
+        Ok(())
+    }
+
+    async fn finish_failed_transfer(
+        &self,
+        job: &TransferJobRecord,
+        lease: &TransferLease,
+    ) -> FsResult<()> {
+        self.stop_recoverable_tasks(job, lease, "transfer stopped after a task failed")
+            .await?;
+        let tasks = self.store.list_transfer_tasks(&job.job_id, job.run_id)?;
+        let summary = summarize_transfer_tasks(&tasks, now_ms());
+        let state = if summary.counts.completed > 0 {
+            TransferState::PartialSuccess
+        } else {
+            TransferState::Failed
+        };
+        let message = if state == TransferState::PartialSuccess {
+            format!(
+                "{}; {} file(s) completed and remain cached",
+                summary.progress.message, summary.counts.completed
+            )
+        } else {
+            summary.progress.message
+        };
+        let _ = self.transition(job, lease, &[TransferState::Running], state, message)?;
+        record_metric(|metrics| {
+            metrics.inc_terminal(
+                if state == TransferState::PartialSuccess {
+                    "partial_success"
+                } else {
+                    "failed"
+                },
+                "task_failed",
+            )
+        });
+        Ok(())
+    }
+
+    async fn stop_recoverable_tasks(
+        &self,
+        job: &TransferJobRecord,
+        lease: &TransferLease,
+        message: &str,
     ) -> FsResult<()> {
         let tasks = self.store.list_transfer_tasks(&job.job_id, job.run_id)?;
         let mut workers = HashSet::new();
         for task in tasks {
+            if !matches!(
+                task.state,
+                TransferTaskState::Pending | TransferTaskState::Running | TransferTaskState::Stale
+            ) {
+                continue;
+            }
             if task.worker_id != 0 {
                 workers.insert(task.worker_id);
             }
-            self.store.update_task_state(
-                &task.job_id,
-                task.run_id,
-                &task.task_id,
-                TransferTaskState::Canceled,
-                "transfer canceled",
-                now_ms(),
-            )?;
+            if !self.store.update_task_state(TransferTaskStateUpdate {
+                job_id: task.job_id.clone(),
+                run_id: task.run_id,
+                owner: lease.owner.clone(),
+                lease_epoch: lease.lease_epoch,
+                task_id: task.task_id,
+                from_states: vec![task.state],
+                state: TransferTaskState::Canceled,
+                message: message.to_string(),
+                now_ms: now_ms(),
+            })? {
+                continue;
+            }
         }
 
         let live_workers = match self.cache.live_workers() {
@@ -685,8 +751,6 @@ where
             }
         }
 
-        self.set_transfer_state(job, TransferState::Canceled, "transfer canceled", now_ms())?;
-        record_metric(|metrics| metrics.inc_terminal("canceled", "cancel_requested"));
         Ok(())
     }
 
@@ -731,42 +795,16 @@ where
         Ok(updated)
     }
 
-    fn set_transfer_state(
+    fn fail_transfer(
         &self,
         job: &TransferJobRecord,
-        to_state: TransferState,
+        lease: &TransferLease,
+        from_states: &[TransferState],
         message: impl Into<String>,
-        now_ms: i64,
-    ) -> FsResult<bool> {
-        let message = message.into();
-        let updated = self.store.set_transfer_state(
-            &job.job_id,
-            job.run_id,
-            to_state,
-            message.clone(),
-            now_ms,
-        )?;
-        if updated {
-            info!(
-                "transfer state set job_id={} run_id={} kind={:?} tenant={} owner={} lease_epoch={} from={:?} to={:?} message={}",
-                job.job_id,
-                job.run_id,
-                job.kind,
-                job.tenant,
-                job.owner,
-                job.lease_epoch,
-                job.state,
-                to_state,
-                message
-            );
-        }
-        Ok(updated)
-    }
-
-    fn fail_transfer(&self, job: &TransferJobRecord, message: impl Into<String>) -> FsResult<()> {
+    ) -> FsResult<()> {
         let message = message.into();
         error!("transfer {} failed: {}", job.job_id, message);
-        self.set_transfer_state(job, TransferState::Failed, message, now_ms())?;
+        let _ = self.transition(job, lease, from_states, TransferState::Failed, message)?;
         record_metric(|metrics| metrics.inc_terminal("failed", "error"));
         Ok(())
     }
@@ -781,7 +819,7 @@ struct DispatchTaskRequest<S> {
     lease_epoch: u64,
     task: TransferTaskRecord,
     worker: WorkerInfo,
-    report_target: String,
+    report_endpoints: Vec<String>,
     task_stale_timeout_ms: i64,
 }
 
@@ -798,7 +836,7 @@ where
         lease_epoch,
         task,
         worker,
-        report_target,
+        report_endpoints,
         task_stale_timeout_ms,
     } = request;
     let now = now_ms();
@@ -816,13 +854,15 @@ where
     let started = store.start_task_attempt(TaskAttemptStart {
         job_id: task.job_id.clone(),
         run_id: task.run_id,
-        owner,
+        owner: owner.clone(),
         lease_epoch,
         task_id: task.task_id.clone(),
         attempt_id,
         worker_id: worker.worker_id(),
         worker_session_id: worker.worker_session_id.clone(),
-        report_target_json: report_target.clone(),
+        report_target_json: serde_json::to_string(&report_endpoints).map_err(|err| {
+            FsError::common(format!("Failed to encode Transfer report endpoints: {err}"))
+        })?,
         now_ms: now,
         stale_deadline_at: now.saturating_add(task_stale_timeout_ms),
     })?;
@@ -843,7 +883,8 @@ where
             attempt_id,
             worker_id: worker.worker_id(),
             worker_session_id: worker.worker_session_id.clone(),
-            report_target,
+            report_target: report_endpoints.first().cloned().unwrap_or_default(),
+            report_endpoints,
         }),
     };
 
@@ -855,14 +896,19 @@ where
                 "worker {} rejected transfer task {} attempt {} before accepting it: {}",
                 worker, task.task_id, attempt_id, reason
             );
-            store.update_task_state(
-                &task.job_id,
-                task.run_id,
-                &task.task_id,
-                TransferTaskState::Pending,
-                format!("worker rejected task before accept: {}", reason),
-                now_ms(),
-            )?;
+            if !store.update_task_state(TransferTaskStateUpdate {
+                job_id: task.job_id.clone(),
+                run_id: task.run_id,
+                owner,
+                lease_epoch,
+                task_id: task.task_id.clone(),
+                from_states: vec![TransferTaskState::Running],
+                state: TransferTaskState::Pending,
+                message: format!("worker rejected task before accept: {}", reason),
+                now_ms: now_ms(),
+            })? {
+                return Ok(false);
+            }
             if let Err(err) = cache.refresh().await {
                 warn!(
                     "refresh cluster metadata after worker rejection failed: {}",
@@ -888,15 +934,6 @@ fn now_ms() -> i64 {
 
 fn duration_ms(duration: Duration) -> i64 {
     i64::try_from(duration.as_millis()).unwrap_or(i64::MAX)
-}
-
-fn transfer_command(job: &TransferJobRecord) -> FsResult<TransferCommand> {
-    serde_json::from_str(&job.command_json).map_err(|err| {
-        FsError::common(format!(
-            "Invalid transfer command json for job {}: {}",
-            job.job_id, err
-        ))
-    })
 }
 
 fn transfer_task_state(state: i32) -> TransferTaskState {

--- a/curvine-server/src/transfer/scheduler.rs
+++ b/curvine-server/src/transfer/scheduler.rs
@@ -1,0 +1,925 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::common::UfsFactory;
+use crate::transfer::{
+    is_store_unavailable_error, job_mount_snapshot, transfer_failure_message, TransferPlanner,
+    TransferRequeueUpdate, TransferStore,
+};
+use curvine_common::conf::TransferConf;
+use curvine_common::error::FsError;
+use curvine_common::state::{
+    summarize_transfer_tasks, LoadJobInfo, LoadTaskInfo, TaskAttemptStart, TransferCommand,
+    TransferJobRecord, TransferLease, TransferProgress, TransferState, TransferStateUpdate,
+    TransferTaskRecord, TransferTaskReport, TransferTaskReportInfo, TransferTaskState, WorkerInfo,
+};
+use curvine_common::FsResult;
+use futures::stream::{self, StreamExt, TryStreamExt};
+use log::{debug, error, info, warn};
+use orpc::common::LocalTime;
+use orpc::runtime::RpcRuntime;
+use std::collections::HashSet;
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+const PLANNING_REQUEUE_DELAY_MS: i64 = 1_000;
+
+use crate::transfer::{ClusterMetadataCache, TransferMetrics};
+
+const TRANSFER_CLEANUP_INTERVAL_MS: u64 = 60_000;
+
+pub struct TransferScheduler<S> {
+    store: Arc<S>,
+    planner: TransferPlanner,
+    cache: ClusterMetadataCache,
+    factory: Arc<UfsFactory>,
+    owner: String,
+    report_target: String,
+    conf: TransferConf,
+    worker_cursor: Arc<AtomicUsize>,
+    last_cleanup_ms: Arc<AtomicU64>,
+}
+
+impl<S> Clone for TransferScheduler<S> {
+    fn clone(&self) -> Self {
+        Self {
+            store: self.store.clone(),
+            planner: self.planner.clone(),
+            cache: self.cache.clone(),
+            factory: self.factory.clone(),
+            owner: self.owner.clone(),
+            report_target: self.report_target.clone(),
+            conf: self.conf.clone(),
+            worker_cursor: self.worker_cursor.clone(),
+            last_cleanup_ms: self.last_cleanup_ms.clone(),
+        }
+    }
+}
+
+impl<S> TransferScheduler<S>
+where
+    S: TransferStore,
+{
+    pub fn new(
+        store: Arc<S>,
+        planner: TransferPlanner,
+        cache: ClusterMetadataCache,
+        factory: Arc<UfsFactory>,
+        owner: String,
+        report_target: String,
+        conf: TransferConf,
+    ) -> Self {
+        Self {
+            store,
+            planner,
+            cache,
+            factory,
+            owner,
+            report_target,
+            conf,
+            worker_cursor: Arc::new(AtomicUsize::new(0)),
+            last_cleanup_ms: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    pub fn start(self, rt: Arc<orpc::runtime::Runtime>, stop: Arc<AtomicBool>) {
+        let workers = self.conf.scheduler_workers();
+        for index in 0..workers {
+            let scheduler = self.clone();
+            let stop = stop.clone();
+            rt.spawn(async move {
+                while !stop.load(Ordering::Relaxed) {
+                    if let Err(err) = scheduler.run_once().await {
+                        warn!("transfer scheduler worker {} tick failed: {}", index, err);
+                    }
+                    tokio::time::sleep(Duration::from_millis(200)).await;
+                }
+            });
+        }
+    }
+
+    async fn run_once(&self) -> FsResult<()> {
+        let now_ms = now_ms();
+        self.cleanup_terminal_transfers(now_ms)?;
+        let (active, executing) = self.transfer_counts()?;
+        self.record_job_counts(active, executing);
+        let Some(lease) = self.store.acquire_runnable_transfer(
+            &self.owner,
+            duration_ms(self.conf.lease_timeout),
+            now_ms,
+            self.conf.max_executing_transfers(),
+        )?
+        else {
+            record_metric(|metrics| metrics.inc_acquire("empty"));
+            return Ok(());
+        };
+        record_metric(|metrics| metrics.inc_acquire("ok"));
+
+        let Some(job) = self.store.get_transfer(&lease.job_id)? else {
+            record_metric(|metrics| metrics.inc_acquire("missing_job"));
+            return Ok(());
+        };
+
+        if job.cancel_requested {
+            self.cancel_transfer(&job, &lease).await?;
+            return Ok(());
+        }
+
+        match job.state {
+            TransferState::Pending | TransferState::Planning => {
+                self.plan_transfer(job, lease).await?;
+            }
+            TransferState::Dispatching => {
+                self.dispatch_pending_tasks(job, lease).await?;
+            }
+            TransferState::Running => {
+                self.check_running_transfer(job, lease).await?;
+            }
+            TransferState::Canceling => {
+                self.cancel_transfer(&job, &lease).await?;
+            }
+            TransferState::Completed | TransferState::Failed | TransferState::Canceled => {}
+        }
+        Ok(())
+    }
+
+    fn transfer_counts(&self) -> FsResult<(u64, u64)> {
+        Ok((
+            self.store.count_active_transfers()?,
+            self.store.count_executing_transfers()?,
+        ))
+    }
+
+    fn record_job_counts(&self, active: u64, executing: u64) {
+        if let Ok(metrics) = TransferMetrics::get() {
+            metrics.set_job_counts(active, executing);
+        }
+    }
+
+    fn cleanup_terminal_transfers(&self, now_ms: i64) -> FsResult<()> {
+        let now = now_ms.max(0) as u64;
+        let last = self.last_cleanup_ms.load(Ordering::Relaxed);
+        if now.saturating_sub(last) < TRANSFER_CLEANUP_INTERVAL_MS {
+            return Ok(());
+        }
+        if self
+            .last_cleanup_ms
+            .compare_exchange(last, now, Ordering::Relaxed, Ordering::Relaxed)
+            .is_err()
+        {
+            return Ok(());
+        }
+        let retention_ms =
+            i64::try_from(self.conf.terminal_retention.as_millis()).unwrap_or(i64::MAX);
+        let older_than = now_ms.saturating_sub(retention_ms);
+        let purged = self
+            .store
+            .purge_terminal_transfers(older_than, self.conf.cleanup_batch_size())?;
+        if purged >= self.conf.cleanup_batch_size() {
+            self.last_cleanup_ms.store(0, Ordering::Relaxed);
+        }
+        if purged > 0 {
+            if let Ok(metrics) = TransferMetrics::get() {
+                metrics.inc_cleanup_purged(purged);
+            }
+            info!(
+                "purged {} terminal transfer jobs older than {}",
+                purged, older_than
+            );
+        }
+        Ok(())
+    }
+
+    async fn plan_transfer(&self, job: TransferJobRecord, lease: TransferLease) -> FsResult<()> {
+        if !self.transition(
+            &job,
+            &lease,
+            &[TransferState::Pending, TransferState::Planning],
+            TransferState::Planning,
+            "planning transfer",
+        )? {
+            record_metric(|metrics| metrics.inc_planning(transfer_kind_label(job.kind), "stale"));
+            return Ok(());
+        }
+
+        let planned = match self.planner.plan(&job).await {
+            Ok(planned) => planned,
+            Err(err @ FsError::InProgress(_)) => {
+                record_metric(|metrics| {
+                    metrics.inc_planning(transfer_kind_label(job.kind), "retry")
+                });
+                let now = now_ms();
+                let requeued = self.store.requeue_transfer(TransferRequeueUpdate {
+                    job_id: job.job_id.clone(),
+                    run_id: job.run_id,
+                    owner: lease.owner.clone(),
+                    lease_epoch: lease.lease_epoch,
+                    message: format!("planning delayed: {}", err),
+                    next_attempt_at_ms: now.saturating_add(PLANNING_REQUEUE_DELAY_MS),
+                    now_ms: now,
+                })?;
+                if requeued {
+                    info!(
+                        "transfer state requeue job_id={} run_id={} kind={:?} tenant={} owner={} lease_epoch={} state={:?} next_attempt_at_ms={} reason={}",
+                        job.job_id,
+                        job.run_id,
+                        job.kind,
+                        job.tenant,
+                        lease.owner,
+                        lease.lease_epoch,
+                        job.state,
+                        now.saturating_add(PLANNING_REQUEUE_DELAY_MS),
+                        err
+                    );
+                }
+                return Ok(());
+            }
+            Err(err) => {
+                record_metric(|metrics| {
+                    metrics.inc_planning(transfer_kind_label(job.kind), "failure")
+                });
+                self.fail_transfer(
+                    &job,
+                    transfer_failure_message(job.kind, &job.source_path, &job.target_path, &err),
+                )?;
+                return Err(err);
+            }
+        };
+
+        if let Some(cv_metadata_epoch) = planned.cv_metadata_epoch {
+            let updated = self.store.set_transfer_cv_metadata_epoch(
+                &job.job_id,
+                job.run_id,
+                &lease.owner,
+                lease.lease_epoch,
+                cv_metadata_epoch,
+                now_ms(),
+            )?;
+            if !updated {
+                warn!(
+                    "stop planning export transfer {} because cv metadata epoch {} could not be persisted",
+                    job.job_id, cv_metadata_epoch
+                );
+                return Ok(());
+            }
+        }
+
+        if planned.tasks.is_empty() {
+            self.set_transfer_state(
+                &job,
+                TransferState::Completed,
+                "transfer has no file tasks",
+                now_ms(),
+            )?;
+            record_metric(|metrics| {
+                metrics.inc_planning(transfer_kind_label(job.kind), "empty");
+                metrics.inc_terminal("completed", "empty");
+            });
+            info!("transfer {} completed with no file tasks", job.job_id);
+            return Ok(());
+        }
+
+        let task_count = planned.tasks.len();
+        self.store.insert_tasks(planned.tasks)?;
+        self.set_transfer_state(
+            &job,
+            TransferState::Dispatching,
+            format!("planned total_size={}", planned.total_size),
+            now_ms(),
+        )?;
+        debug!(
+            "transfer {} planned with job info source={}, target={}",
+            job.job_id, planned.job_info.source_path, planned.job_info.target_path
+        );
+        record_metric(|metrics| {
+            metrics.inc_planning(transfer_kind_label(job.kind), "success");
+            metrics.inc_dispatch("planned_tasks", task_count);
+        });
+
+        self.dispatch_pending_tasks(job, lease).await
+    }
+
+    async fn dispatch_pending_tasks(
+        &self,
+        job: TransferJobRecord,
+        lease: TransferLease,
+    ) -> FsResult<()> {
+        let mut dispatched = 0usize;
+        loop {
+            if self.cancel_requested(&job, &lease).await? {
+                return Ok(());
+            }
+            let tasks = self.store.claim_pending_tasks(
+                &job.job_id,
+                job.run_id,
+                self.conf.planning_batch_size(),
+            )?;
+            if tasks.is_empty() {
+                break;
+            }
+
+            let started = match self.dispatch_batch(&job, &lease, tasks).await {
+                Ok(started) => started,
+                Err(err) => {
+                    record_metric(|metrics| metrics.inc_dispatch("failure", 1));
+                    if is_store_unavailable_error(&err) {
+                        warn!(
+                            "pause dispatching transfer {} because transfer store is unavailable: {}",
+                            job.job_id, err
+                        );
+                        return Err(err);
+                    }
+                    self.fail_transfer(
+                        &job,
+                        transfer_failure_message(
+                            job.kind,
+                            &job.source_path,
+                            &job.target_path,
+                            &err,
+                        ),
+                    )?;
+                    return Err(err);
+                }
+            };
+            dispatched += started;
+            record_metric(|metrics| metrics.inc_dispatch("started", started));
+            if started == 0 {
+                record_metric(|metrics| metrics.inc_dispatch("not_started", 1));
+                break;
+            }
+            let renewed = self.store.renew_lease(
+                &lease.job_id,
+                lease.run_id,
+                &lease.owner,
+                lease.lease_epoch,
+                duration_ms(self.conf.lease_timeout),
+                now_ms(),
+            )?;
+            record_metric(|metrics| {
+                metrics.inc_lease_renew(if renewed { "success" } else { "stale" })
+            });
+            if !renewed {
+                warn!(
+                    "stop dispatching transfer {} because owner {} lease epoch {} is stale",
+                    lease.job_id, lease.owner, lease.lease_epoch
+                );
+                return Ok(());
+            }
+        }
+
+        if self.cancel_requested(&job, &lease).await? {
+            return Ok(());
+        }
+        let _ = self.transition(
+            &job,
+            &lease,
+            &[TransferState::Dispatching],
+            TransferState::Running,
+            format!("dispatched {} tasks", dispatched),
+        )?;
+        Ok(())
+    }
+
+    async fn cancel_requested(
+        &self,
+        job: &TransferJobRecord,
+        lease: &TransferLease,
+    ) -> FsResult<bool> {
+        let Some(current) = self.store.get_transfer(&job.job_id)? else {
+            return Ok(false);
+        };
+        if current.run_id != job.run_id || !current.cancel_requested {
+            return Ok(false);
+        }
+        self.cancel_transfer(&current, lease).await?;
+        Ok(true)
+    }
+
+    async fn dispatch_batch(
+        &self,
+        job: &TransferJobRecord,
+        lease: &TransferLease,
+        tasks: Vec<TransferTaskRecord>,
+    ) -> FsResult<usize> {
+        let workers = match self.cache.live_workers() {
+            Ok(workers) => workers,
+            Err(err) => {
+                debug!(
+                    "no live worker with required transfer capabilities is available for transfer {}: {}",
+                    job.job_id, err
+                );
+                return Ok(0);
+            }
+        };
+        let mount = job_mount_snapshot(job, &self.cache)?;
+        let job_info = self.planner_job_info(job, &mount);
+        let limit = self.conf.worker_dispatch_concurrency();
+
+        let started = stream::iter(tasks.into_iter().map(|task| {
+            let worker = self.choose_worker(&workers);
+            let store = self.store.clone();
+            let factory = self.factory.clone();
+            let cache = self.cache.clone();
+            let job_info = job_info.clone();
+            let owner = lease.owner.clone();
+            let lease_epoch = lease.lease_epoch;
+            let report_target = self.report_target.clone();
+            let task_stale_timeout_ms = duration_ms(self.conf.task_stale_timeout);
+            async move {
+                dispatch_one(DispatchTaskRequest {
+                    store,
+                    factory,
+                    cache,
+                    job_info,
+                    owner,
+                    lease_epoch,
+                    task,
+                    worker,
+                    report_target,
+                    task_stale_timeout_ms,
+                })
+                .await
+            }
+        }))
+        .buffer_unordered(limit)
+        .try_collect::<Vec<_>>()
+        .await?;
+        Ok(started.into_iter().filter(|value| *value).count())
+    }
+
+    fn planner_job_info(
+        &self,
+        job: &TransferJobRecord,
+        mount: &curvine_common::state::MountInfo,
+    ) -> curvine_common::state::LoadJobInfo {
+        let overwrite = transfer_command(job)
+            .map(|command| command.overwrite())
+            .unwrap_or(true);
+        curvine_common::state::LoadJobInfo {
+            job_id: job.job_id.clone(),
+            source_path: job.source_path.clone(),
+            target_path: job.target_path.clone(),
+            replicas: mount.replicas.unwrap_or(self.conf_default_replicas()),
+            block_size: mount.block_size.unwrap_or(self.conf_default_block_size()),
+            storage_type: mount
+                .storage_type
+                .unwrap_or(self.conf_default_storage_type()),
+            ttl_ms: mount.ttl_ms,
+            ttl_action: mount.ttl_action,
+            mount_info: mount.clone(),
+            create_time: job.created_at,
+            overwrite: Some(overwrite),
+        }
+    }
+
+    fn conf_default_replicas(&self) -> i32 {
+        curvine_common::conf::ClientConf::default().replicas
+    }
+
+    fn conf_default_block_size(&self) -> i64 {
+        curvine_common::conf::ClientConf::default().block_size
+    }
+
+    fn conf_default_storage_type(&self) -> curvine_common::state::StorageType {
+        curvine_common::conf::ClientConf::default().storage_type
+    }
+
+    async fn check_running_transfer(
+        &self,
+        job: TransferJobRecord,
+        lease: TransferLease,
+    ) -> FsResult<()> {
+        let now = now_ms();
+        self.probe_stale_running_tasks(&job, now).await?;
+        let stale = self.store.mark_stale_attempts(
+            &job.job_id,
+            job.run_id,
+            &lease.owner,
+            lease.lease_epoch,
+            now,
+            self.conf.task_probe_concurrency(),
+        )?;
+        for attempt in stale {
+            if attempt.task.retry_count as usize > self.conf.task_max_retries {
+                self.store.update_task_state(
+                    &attempt.task.job_id,
+                    attempt.task.run_id,
+                    &attempt.task.task_id,
+                    TransferTaskState::Failed,
+                    "transfer task did not report progress before the retry limit was reached; check Transfer worker health",
+                    now,
+                )?;
+                self.fail_transfer(
+                    &job,
+                    "transfer task did not report progress before the retry limit was reached; check Transfer worker health",
+                )?;
+                record_metric(|metrics| metrics.inc_stale_retry("exhausted"));
+                return Ok(());
+            }
+            self.store.update_task_state(
+                &attempt.task.job_id,
+                attempt.task.run_id,
+                &attempt.task.task_id,
+                TransferTaskState::Pending,
+                "retry stale task attempt",
+                now,
+            )?;
+            record_metric(|metrics| metrics.inc_stale_retry("scheduled"));
+        }
+
+        if !self
+            .store
+            .claim_pending_tasks(&job.job_id, job.run_id, 1)?
+            .is_empty()
+        {
+            self.set_transfer_state(
+                &job,
+                TransferState::Dispatching,
+                "redispatch stale tasks",
+                now,
+            )?;
+            self.dispatch_pending_tasks(job, lease).await?;
+            return Ok(());
+        }
+
+        let tasks = self.store.list_transfer_tasks(&job.job_id, job.run_id)?;
+        if tasks.is_empty() {
+            return Ok(());
+        }
+
+        let summary = summarize_transfer_tasks(&tasks, now);
+        if summary.has_failed {
+            self.fail_transfer(&job, summary.progress.message)?;
+            return Ok(());
+        }
+
+        if summary.all_completed {
+            self.set_transfer_state(&job, TransferState::Completed, "all tasks completed", now)?;
+            record_metric(|metrics| metrics.inc_terminal("completed", "all_tasks_completed"));
+        } else {
+            let renewed = self.store.renew_lease(
+                &lease.job_id,
+                lease.run_id,
+                &lease.owner,
+                lease.lease_epoch,
+                duration_ms(self.conf.lease_timeout),
+                now,
+            )?;
+            record_metric(|metrics| {
+                metrics.inc_lease_renew(if renewed { "success" } else { "stale" })
+            });
+        }
+        Ok(())
+    }
+
+    async fn probe_stale_running_tasks(&self, job: &TransferJobRecord, now: i64) -> FsResult<()> {
+        let tasks = self.store.list_recoverable_tasks(&job.job_id, job.run_id)?;
+        let workers = self.cache.live_workers().unwrap_or_default();
+        for task in tasks
+            .into_iter()
+            .filter(|task| task.state == TransferTaskState::Running && task.stale_deadline_at < now)
+            .take(self.conf.task_probe_concurrency())
+        {
+            let Some(worker) = workers.iter().find(|worker| {
+                worker.worker_id() == task.worker_id
+                    && worker.worker_session_id == task.worker_session_id
+            }) else {
+                continue;
+            };
+            let Ok(client) = self.factory.get_worker_client(&worker.address).await else {
+                continue;
+            };
+            let Ok(response) = client
+                .query_transfer_task(
+                    &task.job_id,
+                    task.run_id,
+                    &task.task_id,
+                    task.attempt_id,
+                    &task.worker_session_id,
+                )
+                .await
+            else {
+                continue;
+            };
+            if !response.found {
+                continue;
+            }
+            let report = TransferTaskReport {
+                job_id: task.job_id,
+                run_id: task.run_id,
+                task_id: task.task_id,
+                attempt_id: task.attempt_id,
+                worker_id: task.worker_id,
+                worker_session_id: task.worker_session_id,
+                state: transfer_task_state(response.state),
+                progress: TransferProgress {
+                    loaded_size: response.progress.loaded_size,
+                    total_size: response.progress.total_size,
+                    update_time: response.progress.update_time,
+                    message: response.progress.message,
+                },
+                now_ms: now,
+                stale_deadline_at: now.saturating_add(duration_ms(self.conf.task_stale_timeout)),
+            };
+            let _ = self.store.update_task_report(report)?;
+        }
+        Ok(())
+    }
+
+    async fn cancel_transfer(
+        &self,
+        job: &TransferJobRecord,
+        _lease: &TransferLease,
+    ) -> FsResult<()> {
+        let tasks = self.store.list_transfer_tasks(&job.job_id, job.run_id)?;
+        let mut workers = HashSet::new();
+        for task in tasks {
+            if task.worker_id != 0 {
+                workers.insert(task.worker_id);
+            }
+            self.store.update_task_state(
+                &task.job_id,
+                task.run_id,
+                &task.task_id,
+                TransferTaskState::Canceled,
+                "transfer canceled",
+                now_ms(),
+            )?;
+        }
+
+        let live_workers = match self.cache.live_workers() {
+            Ok(workers) => workers,
+            Err(err) => {
+                warn!(
+                    "cancel transfer {} without live worker snapshot: {}",
+                    job.job_id, err
+                );
+                Vec::new()
+            }
+        };
+        for worker in live_workers {
+            if workers.contains(&worker.worker_id()) {
+                match self.factory.get_worker_client(&worker.address).await {
+                    Ok(client) => {
+                        if let Err(err) = client.cancel_job(&job.job_id).await {
+                            warn!(
+                                "cancel transfer {} on worker {} failed: {}",
+                                job.job_id, worker, err
+                            );
+                        }
+                    }
+                    Err(err) => warn!("connect worker {} for cancel failed: {}", worker, err),
+                }
+            }
+        }
+
+        self.set_transfer_state(job, TransferState::Canceled, "transfer canceled", now_ms())?;
+        record_metric(|metrics| metrics.inc_terminal("canceled", "cancel_requested"));
+        Ok(())
+    }
+
+    fn choose_worker(&self, workers: &[WorkerInfo]) -> WorkerInfo {
+        let index = self.worker_cursor.fetch_add(1, Ordering::Relaxed) % workers.len();
+        workers[index].clone()
+    }
+
+    fn transition(
+        &self,
+        job: &TransferJobRecord,
+        lease: &TransferLease,
+        from_states: &[TransferState],
+        to_state: TransferState,
+        message: impl Into<String>,
+    ) -> FsResult<bool> {
+        let message = message.into();
+        let updated = self.store.update_transfer_state(TransferStateUpdate {
+            job_id: lease.job_id.clone(),
+            run_id: lease.run_id,
+            owner: lease.owner.clone(),
+            lease_epoch: lease.lease_epoch,
+            from_states: from_states.to_vec(),
+            to_state,
+            message: message.clone(),
+            now_ms: now_ms(),
+        })?;
+        if updated {
+            info!(
+                "transfer state transition job_id={} run_id={} kind={:?} tenant={} owner={} lease_epoch={} from={:?} to={:?} message={}",
+                lease.job_id,
+                lease.run_id,
+                job.kind,
+                job.tenant,
+                lease.owner,
+                lease.lease_epoch,
+                from_states,
+                to_state,
+                message
+            );
+        }
+        Ok(updated)
+    }
+
+    fn set_transfer_state(
+        &self,
+        job: &TransferJobRecord,
+        to_state: TransferState,
+        message: impl Into<String>,
+        now_ms: i64,
+    ) -> FsResult<bool> {
+        let message = message.into();
+        let updated = self.store.set_transfer_state(
+            &job.job_id,
+            job.run_id,
+            to_state,
+            message.clone(),
+            now_ms,
+        )?;
+        if updated {
+            info!(
+                "transfer state set job_id={} run_id={} kind={:?} tenant={} owner={} lease_epoch={} from={:?} to={:?} message={}",
+                job.job_id,
+                job.run_id,
+                job.kind,
+                job.tenant,
+                job.owner,
+                job.lease_epoch,
+                job.state,
+                to_state,
+                message
+            );
+        }
+        Ok(updated)
+    }
+
+    fn fail_transfer(&self, job: &TransferJobRecord, message: impl Into<String>) -> FsResult<()> {
+        let message = message.into();
+        error!("transfer {} failed: {}", job.job_id, message);
+        self.set_transfer_state(job, TransferState::Failed, message, now_ms())?;
+        record_metric(|metrics| metrics.inc_terminal("failed", "error"));
+        Ok(())
+    }
+}
+
+struct DispatchTaskRequest<S> {
+    store: Arc<S>,
+    factory: Arc<UfsFactory>,
+    cache: ClusterMetadataCache,
+    job_info: LoadJobInfo,
+    owner: String,
+    lease_epoch: u64,
+    task: TransferTaskRecord,
+    worker: WorkerInfo,
+    report_target: String,
+    task_stale_timeout_ms: i64,
+}
+
+async fn dispatch_one<S>(request: DispatchTaskRequest<S>) -> FsResult<bool>
+where
+    S: TransferStore,
+{
+    let DispatchTaskRequest {
+        store,
+        factory,
+        cache,
+        job_info,
+        owner,
+        lease_epoch,
+        task,
+        worker,
+        report_target,
+        task_stale_timeout_ms,
+    } = request;
+    let now = now_ms();
+    let attempt_id = task.attempt_id.saturating_add(1);
+    let client = match factory.get_worker_client(&worker.address).await {
+        Ok(client) => client,
+        Err(err) => {
+            warn!(
+                "connect worker {} for transfer task {} failed before submit; retry in next scheduler tick: {}",
+                worker, task.task_id, err
+            );
+            return Ok(false);
+        }
+    };
+    let started = store.start_task_attempt(TaskAttemptStart {
+        job_id: task.job_id.clone(),
+        run_id: task.run_id,
+        owner,
+        lease_epoch,
+        task_id: task.task_id.clone(),
+        attempt_id,
+        worker_id: worker.worker_id(),
+        worker_session_id: worker.worker_session_id.clone(),
+        report_target_json: report_target.clone(),
+        now_ms: now,
+        stale_deadline_at: now.saturating_add(task_stale_timeout_ms),
+    })?;
+    if !started {
+        return Ok(false);
+    }
+
+    let load_task = LoadTaskInfo {
+        job: job_info,
+        task_id: task.task_id.clone(),
+        worker: worker.address.clone(),
+        source_path: task.source_path.clone(),
+        target_path: task.target_path.clone(),
+        create_time: now,
+        source_read_plan_json: task.source_read_plan_json.clone(),
+        transfer_report: Some(TransferTaskReportInfo {
+            run_id: task.run_id,
+            attempt_id,
+            worker_id: worker.worker_id(),
+            worker_session_id: worker.worker_session_id.clone(),
+            report_target,
+        }),
+    };
+
+    match client.submit_load_task_response(load_task).await {
+        Ok(response) if response.accepted.unwrap_or(true) => Ok(true),
+        Ok(response) => {
+            let reason = response.reject_reason.unwrap_or_default();
+            warn!(
+                "worker {} rejected transfer task {} attempt {} before accepting it: {}",
+                worker, task.task_id, attempt_id, reason
+            );
+            store.update_task_state(
+                &task.job_id,
+                task.run_id,
+                &task.task_id,
+                TransferTaskState::Pending,
+                format!("worker rejected task before accept: {}", reason),
+                now_ms(),
+            )?;
+            if let Err(err) = cache.refresh().await {
+                warn!(
+                    "refresh cluster metadata after worker rejection failed: {}",
+                    err
+                );
+            }
+            cache.remove_worker_session(worker.worker_id(), &worker.worker_session_id);
+            Ok(false)
+        }
+        Err(err) => {
+            warn!(
+                "submit transfer task {} attempt {} to worker {} returned error after attempt start; keep running and let query/stale recovery decide final state: {}",
+                task.task_id, attempt_id, worker, err
+            );
+            Ok(true)
+        }
+    }
+}
+
+fn now_ms() -> i64 {
+    LocalTime::mills() as i64
+}
+
+fn duration_ms(duration: Duration) -> i64 {
+    i64::try_from(duration.as_millis()).unwrap_or(i64::MAX)
+}
+
+fn transfer_command(job: &TransferJobRecord) -> FsResult<TransferCommand> {
+    serde_json::from_str(&job.command_json).map_err(|err| {
+        FsError::common(format!(
+            "Invalid transfer command json for job {}: {}",
+            job.job_id, err
+        ))
+    })
+}
+
+fn transfer_task_state(state: i32) -> TransferTaskState {
+    match state {
+        1 => TransferTaskState::Pending,
+        2 => TransferTaskState::Running,
+        3 => TransferTaskState::Completed,
+        4 => TransferTaskState::Failed,
+        5 => TransferTaskState::Canceled,
+        6 => TransferTaskState::Stale,
+        _ => TransferTaskState::Failed,
+    }
+}
+
+fn record_metric(f: impl FnOnce(&TransferMetrics)) {
+    if let Ok(metrics) = TransferMetrics::get() {
+        f(metrics);
+    }
+}
+
+fn transfer_kind_label(kind: curvine_common::state::TransferKind) -> &'static str {
+    match kind {
+        curvine_common::state::TransferKind::Load => "load",
+        curvine_common::state::TransferKind::Export => "export",
+    }
+}

--- a/curvine-server/src/transfer/service.rs
+++ b/curvine-server/src/transfer/service.rs
@@ -22,11 +22,12 @@ use curvine_common::proto::{
     ListTransferTenantsRequest, ListTransferTenantsResponse, ListTransfersRequest,
     ListTransfersResponse, SubmitTransferRequest, TransferJobStatusProto, TransferKindProto,
     TransferProgressProto, TransferTaskReportRequest, TransferTaskStateProto,
-    TransferTaskStatusProto, TransferTenantSummaryProto,
+    TransferTaskStatusProto, TransferTaskSummaryProto, TransferTenantSummaryProto,
 };
 use curvine_common::state::{
-    TransferCommand, TransferJobRecord, TransferKind, TransferListFilter, TransferProgress,
-    TransferState, TransferTaskRecord, TransferTaskReport, TransferTaskState,
+    summarize_transfer_tasks, TransferCommand, TransferJobRecord, TransferKind, TransferListFilter,
+    TransferProgress, TransferState, TransferTaskCounts, TransferTaskRecord, TransferTaskReport,
+    TransferTaskState,
 };
 use curvine_common::utils::SerdeUtils;
 use curvine_common::FsResult;
@@ -41,6 +42,20 @@ const PROGRESS_REPORT_COALESCE_BATCH: usize = 256;
 const TRANSFER_PROTOCOL_VERSION: u32 = 1;
 const DEFAULT_LIST_PAGE_SIZE: usize = 20;
 const MAX_LIST_PAGE_SIZE: usize = 1000;
+
+type TransferStatusPage = (
+    TransferJobRecord,
+    TransferTaskCounts,
+    Vec<TransferTaskStatusProto>,
+    Option<String>,
+);
+type TransferWatchPage = (
+    TransferJobRecord,
+    TransferTaskCounts,
+    Vec<TransferTaskStatusProto>,
+    Option<String>,
+    bool,
+);
 
 pub struct TransferService<S> {
     store: Arc<S>,
@@ -146,15 +161,15 @@ where
         let client_request_id = if req.client_request_id.is_empty() {
             Uuid::new_v4().to_string()
         } else {
-            req.client_request_id
+            req.client_request_id.clone()
         };
         let mut command = TransferCommand {
             kind,
             source_path: req.source_path.clone(),
             target_path: req.target_path.clone(),
-            client_request_id,
-            submitter: req.submitter,
-            tenant: req.tenant,
+            client_request_id: client_request_id.clone(),
+            submitter: req.submitter.clone(),
+            tenant: req.tenant.clone(),
             options: Default::default(),
         };
         if !req.command.is_empty() {
@@ -162,15 +177,24 @@ where
             if command.kind != kind
                 || command.source_path != req.source_path
                 || command.target_path != req.target_path
+                || command.client_request_id != client_request_id
+                || command.submitter != req.submitter
+                || command.tenant != req.tenant
             {
                 return Err(FsError::common(format!(
-                    "Transfer command payload does not match request fields: request kind={:?}, source={}, target={}; payload kind={:?}, source={}, target={}",
+                    "Transfer command payload does not match request identity fields: request kind={:?}, source={}, target={}, client request id={}, submitter={}, tenant={}; payload kind={:?}, source={}, target={}, client request id={}, submitter={}, tenant={}",
                     kind,
                     req.source_path,
                     req.target_path,
+                    client_request_id,
+                    req.submitter,
+                    req.tenant,
                     command.kind,
                     command.source_path,
-                    command.target_path
+                    command.target_path,
+                    command.client_request_id,
+                    command.submitter,
+                    command.tenant,
                 )));
             }
         }
@@ -253,9 +277,12 @@ where
 
     pub fn retry_transfer(&self, job_id: &str) -> FsResult<TransferJobRecord> {
         let job = self.get_transfer(job_id)?;
-        if !matches!(job.state, TransferState::Failed | TransferState::Canceled) {
+        if !matches!(
+            job.state,
+            TransferState::Failed | TransferState::Canceled | TransferState::PartialSuccess
+        ) {
             return Err(FsError::common(format!(
-                "Only failed or canceled transfers can be retried; job {} is currently {}",
+                "Only failed, canceled, or partially successful transfers can be retried; job {} is currently {}",
                 job_id,
                 transfer_state_name(job.state)
             )));
@@ -280,15 +307,12 @@ where
         job_id: &str,
         page_size: Option<u32>,
         page_token: Option<String>,
-    ) -> FsResult<(
-        TransferJobRecord,
-        Vec<TransferTaskStatusProto>,
-        Option<String>,
-    )> {
+    ) -> FsResult<TransferStatusPage> {
         let job = self.get_transfer(job_id)?;
-        let (tasks, next_page_token) =
-            self.page_tasks(&job.job_id, job.run_id, page_size, page_token)?;
-        Ok((job, tasks, next_page_token))
+        let tasks = self.store.list_transfer_tasks(&job.job_id, job.run_id)?;
+        let counts = summarize_transfer_tasks(&tasks, now_ms()).counts;
+        let (tasks, next_page_token) = self.page_tasks(tasks, page_size, page_token)?;
+        Ok((job, counts, tasks, next_page_token))
     }
 
     pub fn list_transfers(&self, req: ListTransfersRequest) -> FsResult<ListTransfersResponse> {
@@ -339,6 +363,7 @@ where
                     failed: summary.failed,
                     canceled: summary.canceled,
                     total: summary.total,
+                    partial_success: summary.partial_success,
                 })
                 .collect(),
             next_page_token,
@@ -351,18 +376,13 @@ where
         since_updated_at: Option<u64>,
         page_size: Option<u32>,
         page_token: Option<String>,
-    ) -> FsResult<(
-        TransferJobRecord,
-        Vec<TransferTaskStatusProto>,
-        Option<String>,
-        bool,
-    )> {
-        let (job, tasks, next_page_token) =
+    ) -> FsResult<TransferWatchPage> {
+        let (job, counts, tasks, next_page_token) =
             self.get_transfer_status(job_id, page_size, page_token)?;
         let changed = since_updated_at
             .map(|since| job.updated_at as u64 > since)
             .unwrap_or(true);
-        Ok((job, tasks, next_page_token, changed))
+        Ok((job, counts, tasks, next_page_token, changed))
     }
 
     pub fn request_cancel(&self, job_id: &str, run_id: Option<u64>) -> FsResult<TransferState> {
@@ -396,12 +416,10 @@ where
 
     fn page_tasks(
         &self,
-        job_id: &str,
-        run_id: u64,
+        mut tasks: Vec<TransferTaskRecord>,
         page_size: Option<u32>,
         page_token: Option<String>,
     ) -> FsResult<(Vec<TransferTaskStatusProto>, Option<String>)> {
-        let mut tasks = self.store.list_transfer_tasks(job_id, run_id)?;
         tasks.sort_by(|left, right| left.task_id.cmp(&right.task_id));
         let offset = parse_page_token(page_token)?;
         let page_size = page_size.unwrap_or(0) as usize;
@@ -737,6 +755,7 @@ fn transfer_state(state: i32) -> FsResult<TransferState> {
         6 => Ok(TransferState::Completed),
         7 => Ok(TransferState::Failed),
         8 => Ok(TransferState::Canceled),
+        9 => Ok(TransferState::PartialSuccess),
         _ => Err(FsError::common(format!("Unknown transfer state {}", state))),
     }
 }
@@ -751,6 +770,7 @@ fn transfer_state_name(state: TransferState) -> &'static str {
         TransferState::Completed => "Completed",
         TransferState::Failed => "Failed",
         TransferState::Canceled => "Canceled",
+        TransferState::PartialSuccess => "PartialSuccess",
     }
 }
 
@@ -833,6 +853,18 @@ pub fn progress_to_proto(value: TransferProgress) -> TransferProgressProto {
         total_size: value.total_size,
         update_time: value.update_time,
         message: value.message,
+    }
+}
+
+pub fn task_summary_to_proto(value: TransferTaskCounts) -> TransferTaskSummaryProto {
+    TransferTaskSummaryProto {
+        pending: value.pending,
+        running: value.running,
+        completed: value.completed,
+        failed: value.failed,
+        canceled: value.canceled,
+        stale: value.stale,
+        completed_size: value.completed_size,
     }
 }
 

--- a/curvine-server/src/transfer/service.rs
+++ b/curvine-server/src/transfer/service.rs
@@ -1,0 +1,904 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::sync::{mpsc, Arc};
+
+use crossbeam::channel;
+use curvine_common::error::FsError;
+use curvine_common::fs::Path;
+use curvine_common::proto::{
+    ListTransferTenantsRequest, ListTransferTenantsResponse, ListTransfersRequest,
+    ListTransfersResponse, SubmitTransferRequest, TransferJobStatusProto, TransferKindProto,
+    TransferProgressProto, TransferTaskReportRequest, TransferTaskStateProto,
+    TransferTaskStatusProto, TransferTenantSummaryProto,
+};
+use curvine_common::state::{
+    TransferCommand, TransferJobRecord, TransferKind, TransferListFilter, TransferProgress,
+    TransferState, TransferTaskRecord, TransferTaskReport, TransferTaskState,
+};
+use curvine_common::utils::SerdeUtils;
+use curvine_common::FsResult;
+use orpc::common::LocalTime;
+use std::time::Duration;
+use uuid::Uuid;
+
+use crate::transfer::{ClusterMetadataCache, TransferMetrics, TransferStore};
+
+const PROGRESS_REPORT_COALESCE_BATCH: usize = 256;
+
+const TRANSFER_PROTOCOL_VERSION: u32 = 1;
+const DEFAULT_LIST_PAGE_SIZE: usize = 20;
+const MAX_LIST_PAGE_SIZE: usize = 1000;
+
+pub struct TransferService<S> {
+    store: Arc<S>,
+    cache: Option<ClusterMetadataCache>,
+    task_stale_timeout_ms: i64,
+    report_dispatcher: Option<TransferReportDispatcher<S>>,
+}
+
+impl<S> Clone for TransferService<S> {
+    fn clone(&self) -> Self {
+        Self {
+            store: self.store.clone(),
+            cache: self.cache.clone(),
+            task_stale_timeout_ms: self.task_stale_timeout_ms,
+            report_dispatcher: self.report_dispatcher.clone(),
+        }
+    }
+}
+
+impl<S> TransferService<S>
+where
+    S: TransferStore,
+{
+    pub fn new(store: Arc<S>) -> Self {
+        Self {
+            store,
+            cache: None,
+            task_stale_timeout_ms: 60_000,
+            report_dispatcher: None,
+        }
+    }
+
+    pub fn with_task_stale_timeout(store: Arc<S>, task_stale_timeout: Duration) -> Self {
+        Self {
+            store,
+            cache: None,
+            task_stale_timeout_ms: i64::try_from(task_stale_timeout.as_millis())
+                .unwrap_or(i64::MAX),
+            report_dispatcher: None,
+        }
+    }
+
+    pub fn with_report_queue(
+        store: Arc<S>,
+        task_stale_timeout: Duration,
+        task_report_queue_size: usize,
+        task_report_workers: usize,
+    ) -> FsResult<Self> {
+        let task_stale_timeout_ms =
+            i64::try_from(task_stale_timeout.as_millis()).unwrap_or(i64::MAX);
+        Ok(Self {
+            store: store.clone(),
+            cache: None,
+            task_stale_timeout_ms,
+            report_dispatcher: Some(TransferReportDispatcher::new(
+                store,
+                task_stale_timeout_ms,
+                task_report_queue_size,
+                task_report_workers,
+            )?),
+        })
+    }
+
+    pub fn with_cache(
+        store: Arc<S>,
+        cache: ClusterMetadataCache,
+        task_stale_timeout: Duration,
+    ) -> Self {
+        Self {
+            store,
+            cache: Some(cache),
+            task_stale_timeout_ms: i64::try_from(task_stale_timeout.as_millis())
+                .unwrap_or(i64::MAX),
+            report_dispatcher: None,
+        }
+    }
+
+    pub fn with_cache_and_report_queue(
+        store: Arc<S>,
+        cache: ClusterMetadataCache,
+        task_stale_timeout: Duration,
+        task_report_queue_size: usize,
+        task_report_workers: usize,
+    ) -> FsResult<Self> {
+        let task_stale_timeout_ms =
+            i64::try_from(task_stale_timeout.as_millis()).unwrap_or(i64::MAX);
+        Ok(Self {
+            store: store.clone(),
+            cache: Some(cache),
+            task_stale_timeout_ms,
+            report_dispatcher: Some(TransferReportDispatcher::new(
+                store,
+                task_stale_timeout_ms,
+                task_report_queue_size,
+                task_report_workers,
+            )?),
+        })
+    }
+
+    pub fn submit_transfer(&self, req: SubmitTransferRequest) -> FsResult<TransferJobRecord> {
+        validate_protocol_version(req.protocol_version)?;
+        let kind = transfer_kind(req.kind)?;
+        let client_request_id = if req.client_request_id.is_empty() {
+            Uuid::new_v4().to_string()
+        } else {
+            req.client_request_id
+        };
+        let mut command = TransferCommand {
+            kind,
+            source_path: req.source_path.clone(),
+            target_path: req.target_path.clone(),
+            client_request_id,
+            submitter: req.submitter,
+            tenant: req.tenant,
+            options: Default::default(),
+        };
+        if !req.command.is_empty() {
+            command = decode_transfer_command(&req.command)?;
+            if command.kind != kind
+                || command.source_path != req.source_path
+                || command.target_path != req.target_path
+            {
+                return Err(FsError::common(format!(
+                    "Transfer command payload does not match request fields: request kind={:?}, source={}, target={}; payload kind={:?}, source={}, target={}",
+                    kind,
+                    req.source_path,
+                    req.target_path,
+                    command.kind,
+                    command.source_path,
+                    command.target_path
+                )));
+            }
+        }
+        validate_transfer_paths(command.kind, &command.source_path, &command.target_path)?;
+        command.target_path = normalized_transfer_path(&Path::from_str(&command.target_path)?);
+        let snapshot = self.transfer_snapshot(&command)?;
+        let now_ms = now_ms();
+        let command_json =
+            String::from_utf8(encode_transfer_command(&command)?).map_err(|err| {
+                FsError::common(format!("Failed to encode transfer command: {}", err))
+            })?;
+        let job = TransferJobRecord {
+            job_key: command.job_key(),
+            job_id: Uuid::new_v4().to_string(),
+            run_id: 1,
+            kind,
+            source_path: command.source_path.clone(),
+            target_path: command.target_path.clone(),
+            command_json,
+            mount_snapshot_json: snapshot.mount_snapshot_json,
+            secret_ref_json: "{}".to_string(),
+            cluster_snapshot_version: snapshot.cluster_snapshot_version,
+            cv_metadata_epoch: None,
+            state: TransferState::Pending,
+            owner: String::new(),
+            lease_epoch: 0,
+            lease_expire_at: 0,
+            cancel_requested: false,
+            summary: TransferProgress::default(),
+            client_request_id: command.client_request_id,
+            submitter: command.submitter,
+            tenant: command.tenant,
+            created_at: now_ms,
+            updated_at: now_ms,
+        };
+        let job = self.store.create_or_get_by_request_id_checked(job)?;
+        record_submit_metric(kind, "accepted");
+        log::info!(
+            "transfer submit accepted job_id={} run_id={} kind={:?} tenant={} submitter={} source={} target={} state={:?}",
+            job.job_id,
+            job.run_id,
+            job.kind,
+            job.tenant,
+            job.submitter,
+            job.source_path,
+            job.target_path,
+            job.state
+        );
+        Ok(job)
+    }
+
+    pub fn check_store_available(&self) -> FsResult<()> {
+        self.store.check_available()
+    }
+
+    fn transfer_snapshot(&self, command: &TransferCommand) -> FsResult<TransferSubmitSnapshot> {
+        let Some(cache) = &self.cache else {
+            return Ok(TransferSubmitSnapshot::default());
+        };
+        let source = Path::from_str(&command.source_path)?;
+        let target = Path::from_str(&command.target_path)?;
+        let snapshot = cache.find_mount_with_refresh(command.kind, &source, &target)?;
+        let mount_snapshot_json = serde_json::to_string(&snapshot.mount).map_err(|err| {
+            FsError::common(format!(
+                "Failed to serialize transfer mount snapshot for {} -> {}: {}",
+                command.source_path, command.target_path, err
+            ))
+        })?;
+        Ok(TransferSubmitSnapshot {
+            mount_snapshot_json,
+            cluster_snapshot_version: snapshot.version,
+        })
+    }
+
+    pub fn get_transfer(&self, job_id: &str) -> FsResult<TransferJobRecord> {
+        self.store
+            .get_transfer(job_id)?
+            .ok_or_else(|| FsError::job_not_found(job_id))
+    }
+
+    pub fn retry_transfer(&self, job_id: &str) -> FsResult<TransferJobRecord> {
+        let job = self.get_transfer(job_id)?;
+        if !matches!(job.state, TransferState::Failed | TransferState::Canceled) {
+            return Err(FsError::common(format!(
+                "Only failed or canceled transfers can be retried; job {} is currently {}",
+                job_id,
+                transfer_state_name(job.state)
+            )));
+        }
+
+        let mut command = decode_transfer_command(job.command_json.as_bytes())?;
+        command.client_request_id = Uuid::new_v4().to_string();
+        self.submit_transfer(SubmitTransferRequest {
+            kind: command.kind as i32,
+            source_path: command.source_path.clone(),
+            target_path: command.target_path.clone(),
+            client_request_id: command.client_request_id.clone(),
+            submitter: command.submitter.clone(),
+            tenant: command.tenant.clone(),
+            command: encode_transfer_command(&command)?,
+            protocol_version: Some(TRANSFER_PROTOCOL_VERSION),
+        })
+    }
+
+    pub fn get_transfer_status(
+        &self,
+        job_id: &str,
+        page_size: Option<u32>,
+        page_token: Option<String>,
+    ) -> FsResult<(
+        TransferJobRecord,
+        Vec<TransferTaskStatusProto>,
+        Option<String>,
+    )> {
+        let job = self.get_transfer(job_id)?;
+        let (tasks, next_page_token) =
+            self.page_tasks(&job.job_id, job.run_id, page_size, page_token)?;
+        Ok((job, tasks, next_page_token))
+    }
+
+    pub fn list_transfers(&self, req: ListTransfersRequest) -> FsResult<ListTransfersResponse> {
+        let page_size = bounded_page_size(req.page_size);
+        let offset = parse_page_token(req.page_token)?;
+        let filter = TransferListFilter {
+            kind: req.kind.map(transfer_kind).transpose()?,
+            state: req.state.map(transfer_state).transpose()?,
+            submitter: non_empty_filter(req.submitter),
+            tenant: non_empty_filter(req.tenant),
+            limit: page_size + 1,
+            offset,
+        };
+        let mut jobs = self.store.list_transfers(filter)?;
+        let next_page_token = if jobs.len() > page_size {
+            jobs.truncate(page_size);
+            Some((offset + page_size).to_string())
+        } else {
+            None
+        };
+        Ok(ListTransfersResponse {
+            jobs: jobs.into_iter().map(job_to_proto).collect(),
+            next_page_token,
+        })
+    }
+
+    pub fn list_tenant_summaries(
+        &self,
+        req: ListTransferTenantsRequest,
+    ) -> FsResult<ListTransferTenantsResponse> {
+        let page_size = bounded_page_size(req.page_size);
+        let offset = parse_page_token(req.page_token)?;
+        let mut summaries = self.store.list_tenant_summaries(page_size + 1, offset)?;
+        let next_page_token = if summaries.len() > page_size {
+            summaries.truncate(page_size);
+            Some((offset + page_size).to_string())
+        } else {
+            None
+        };
+        Ok(ListTransferTenantsResponse {
+            tenants: summaries
+                .into_iter()
+                .map(|summary| TransferTenantSummaryProto {
+                    tenant: summary.tenant,
+                    pending: summary.pending,
+                    executing: summary.executing,
+                    completed: summary.completed,
+                    failed: summary.failed,
+                    canceled: summary.canceled,
+                    total: summary.total,
+                })
+                .collect(),
+            next_page_token,
+        })
+    }
+
+    pub fn watch_transfer(
+        &self,
+        job_id: &str,
+        since_updated_at: Option<u64>,
+        page_size: Option<u32>,
+        page_token: Option<String>,
+    ) -> FsResult<(
+        TransferJobRecord,
+        Vec<TransferTaskStatusProto>,
+        Option<String>,
+        bool,
+    )> {
+        let (job, tasks, next_page_token) =
+            self.get_transfer_status(job_id, page_size, page_token)?;
+        let changed = since_updated_at
+            .map(|since| job.updated_at as u64 > since)
+            .unwrap_or(true);
+        Ok((job, tasks, next_page_token, changed))
+    }
+
+    pub fn request_cancel(&self, job_id: &str, run_id: Option<u64>) -> FsResult<TransferState> {
+        let job = self.get_transfer(job_id)?;
+        let target_run_id = run_id.unwrap_or(job.run_id);
+        let _ = self.store.request_cancel(job_id, target_run_id, now_ms())?;
+        Ok(self.get_transfer(job_id)?.state)
+    }
+
+    pub fn report_task(&self, req: TransferTaskReportRequest) -> FsResult<bool> {
+        validate_protocol_version(req.protocol_version)?;
+        let state = transfer_task_state(req.state)?;
+        if let Some(dispatcher) = &self.report_dispatcher {
+            return dispatcher.report_task(req, state);
+        }
+        let now_ms = now_ms();
+        let report = TransferTaskReport {
+            job_id: req.job_id,
+            run_id: req.run_id,
+            task_id: req.task_id,
+            attempt_id: req.attempt_id,
+            worker_id: req.worker_id,
+            worker_session_id: req.worker_session_id,
+            state,
+            progress: progress_from_proto(req.progress),
+            now_ms,
+            stale_deadline_at: now_ms.saturating_add(self.task_stale_timeout_ms),
+        };
+        self.store.update_task_report(report)
+    }
+
+    fn page_tasks(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        page_size: Option<u32>,
+        page_token: Option<String>,
+    ) -> FsResult<(Vec<TransferTaskStatusProto>, Option<String>)> {
+        let mut tasks = self.store.list_transfer_tasks(job_id, run_id)?;
+        tasks.sort_by(|left, right| left.task_id.cmp(&right.task_id));
+        let offset = parse_page_token(page_token)?;
+        let page_size = page_size.unwrap_or(0) as usize;
+        if page_size == 0 {
+            return Ok((Vec::new(), None));
+        }
+        let page = tasks
+            .iter()
+            .skip(offset)
+            .take(page_size)
+            .cloned()
+            .map(task_to_proto)
+            .collect::<Vec<_>>();
+        let next = offset.saturating_add(page.len());
+        let next_page_token = if next < tasks.len() {
+            Some(next.to_string())
+        } else {
+            None
+        };
+        Ok((page, next_page_token))
+    }
+}
+
+struct TransferReportEnvelope {
+    req: TransferTaskReportRequest,
+    state: TransferTaskState,
+    reply: Option<mpsc::Sender<FsResult<bool>>>,
+}
+
+#[derive(Hash, Eq, PartialEq)]
+struct ProgressReportKey {
+    job_id: String,
+    run_id: u64,
+    task_id: String,
+    attempt_id: u64,
+    worker_session_id: String,
+}
+
+impl ProgressReportKey {
+    fn new(envelope: &TransferReportEnvelope) -> Self {
+        Self {
+            job_id: envelope.req.job_id.clone(),
+            run_id: envelope.req.run_id,
+            task_id: envelope.req.task_id.clone(),
+            attempt_id: envelope.req.attempt_id,
+            worker_session_id: envelope.req.worker_session_id.clone(),
+        }
+    }
+}
+
+struct TransferReportDispatcher<S> {
+    progress_sender: channel::Sender<TransferReportEnvelope>,
+    terminal_sender: channel::Sender<TransferReportEnvelope>,
+    _store: Arc<S>,
+}
+
+impl<S> Clone for TransferReportDispatcher<S> {
+    fn clone(&self) -> Self {
+        Self {
+            progress_sender: self.progress_sender.clone(),
+            terminal_sender: self.terminal_sender.clone(),
+            _store: self._store.clone(),
+        }
+    }
+}
+
+impl<S> TransferReportDispatcher<S>
+where
+    S: TransferStore,
+{
+    fn new(
+        store: Arc<S>,
+        task_stale_timeout_ms: i64,
+        queue_size: usize,
+        workers: usize,
+    ) -> FsResult<Self> {
+        let (progress_sender, progress_receiver) =
+            channel::bounded::<TransferReportEnvelope>(queue_size.max(1));
+        let (terminal_sender, terminal_receiver) =
+            channel::bounded::<TransferReportEnvelope>(queue_size.max(1));
+        let worker_count = workers.max(1);
+        Self::spawn_report_workers(
+            "progress",
+            progress_receiver,
+            store.clone(),
+            task_stale_timeout_ms,
+            worker_count,
+        )?;
+        Self::spawn_report_workers(
+            "terminal",
+            terminal_receiver,
+            store.clone(),
+            task_stale_timeout_ms,
+            worker_count,
+        )?;
+        if let Ok(metrics) = TransferMetrics::get() {
+            metrics.set_report_queue_len_by_lane(0, 0);
+        }
+        Ok(Self {
+            progress_sender,
+            terminal_sender,
+            _store: store,
+        })
+    }
+
+    fn spawn_report_workers(
+        lane: &'static str,
+        receiver: channel::Receiver<TransferReportEnvelope>,
+        store: Arc<S>,
+        task_stale_timeout_ms: i64,
+        worker_count: usize,
+    ) -> FsResult<()> {
+        for index in 0..worker_count {
+            let receiver = receiver.clone();
+            let store = store.clone();
+            std::thread::Builder::new()
+                .name(format!("transfer-report-{lane}-{index}"))
+                .spawn(move || {
+                    while let Ok(envelope) = receiver.recv() {
+                        if lane == "progress" {
+                            let mut reports = HashMap::new();
+                            reports.insert(ProgressReportKey::new(&envelope), envelope);
+                            for _ in 1..PROGRESS_REPORT_COALESCE_BATCH {
+                                match receiver.try_recv() {
+                                    Ok(envelope) => {
+                                        reports.insert(ProgressReportKey::new(&envelope), envelope);
+                                    }
+                                    Err(channel::TryRecvError::Empty) => break,
+                                    Err(channel::TryRecvError::Disconnected) => return,
+                                }
+                            }
+                            for envelope in reports.into_values() {
+                                Self::handle_report_envelope(
+                                    &store,
+                                    task_stale_timeout_ms,
+                                    envelope,
+                                );
+                            }
+                        } else {
+                            Self::handle_report_envelope(&store, task_stale_timeout_ms, envelope);
+                        }
+                    }
+                })
+                .map_err(|err| {
+                    FsError::common(format!(
+                        "Failed to start transfer report {} worker {}: {}",
+                        lane, index, err
+                    ))
+                })?;
+        }
+        Ok(())
+    }
+
+    fn handle_report_envelope(
+        store: &S,
+        task_stale_timeout_ms: i64,
+        envelope: TransferReportEnvelope,
+    ) {
+        let now_ms = now_ms();
+        let state = envelope.state;
+        let report = TransferTaskReport {
+            job_id: envelope.req.job_id,
+            run_id: envelope.req.run_id,
+            task_id: envelope.req.task_id,
+            attempt_id: envelope.req.attempt_id,
+            worker_id: envelope.req.worker_id,
+            worker_session_id: envelope.req.worker_session_id,
+            state,
+            progress: progress_from_proto(envelope.req.progress),
+            now_ms,
+            stale_deadline_at: now_ms.saturating_add(task_stale_timeout_ms),
+        };
+        let result = store.update_task_report(report);
+        match envelope.reply {
+            Some(reply) => {
+                let _ = reply.send(result);
+            }
+            None => match result {
+                Ok(true) => record_report_metric("accepted_async"),
+                Ok(false) => record_report_metric("rejected_async"),
+                Err(err) => {
+                    record_report_metric("failure_async");
+                    log::warn!(
+                        "async transfer task report update failed: state={:?}, err={}",
+                        state,
+                        err
+                    );
+                }
+            },
+        }
+    }
+
+    fn report_task(
+        &self,
+        req: TransferTaskReportRequest,
+        state: TransferTaskState,
+    ) -> FsResult<bool> {
+        let wait_store_result = state.is_terminal();
+        let (reply_tx, reply_rx) = if wait_store_result {
+            let (tx, rx) = mpsc::channel();
+            (Some(tx), Some(rx))
+        } else {
+            (None, None)
+        };
+        let lane = if wait_store_result {
+            "terminal"
+        } else {
+            "progress"
+        };
+        let sender = if wait_store_result {
+            &self.terminal_sender
+        } else {
+            &self.progress_sender
+        };
+        sender
+            .try_send(TransferReportEnvelope {
+                req,
+                state,
+                reply: reply_tx,
+            })
+            .map_err(|err| match err {
+                channel::TrySendError::Full(_) => {
+                    record_report_metric(&format!("{lane}_queue_full"));
+                    FsError::transfer_overloaded(format!(
+                        "transfer task report {lane} queue is full"
+                    ))
+                }
+                channel::TrySendError::Disconnected(_) => {
+                    record_report_metric(&format!("{lane}_unavailable"));
+                    FsError::common(format!(
+                        "TransferReportUnavailable: transfer task report {lane} queue closed"
+                    ))
+                }
+            })?;
+        if let Ok(metrics) = TransferMetrics::get() {
+            let progress_len = self.progress_sender.len();
+            let terminal_len = self.terminal_sender.len();
+            metrics.set_report_queue_len(progress_len + terminal_len);
+            metrics.set_report_queue_len_by_lane(progress_len, terminal_len);
+        }
+        let Some(reply_rx) = reply_rx else {
+            record_report_metric("queued");
+            return Ok(true);
+        };
+        let accepted = reply_rx
+            .recv_timeout(Duration::from_secs(5))
+            .map_err(|err| {
+                FsError::common(format!(
+                    "TransferReportUnavailable: transfer task report worker did not reply: {}",
+                    err
+                ))
+            })??;
+        record_report_metric(if accepted { "accepted" } else { "rejected" });
+        Ok(accepted)
+    }
+}
+
+fn record_submit_metric(kind: TransferKind, result: &str) {
+    if let Ok(metrics) = TransferMetrics::get() {
+        let kind = match kind {
+            TransferKind::Load => "load",
+            TransferKind::Export => "export",
+        };
+        metrics.inc_submit(kind, result);
+    }
+}
+
+fn record_report_metric(result: &str) {
+    if let Ok(metrics) = TransferMetrics::get() {
+        metrics.inc_report(result);
+    }
+}
+
+struct TransferSubmitSnapshot {
+    mount_snapshot_json: String,
+    cluster_snapshot_version: u64,
+}
+
+impl Default for TransferSubmitSnapshot {
+    fn default() -> Self {
+        Self {
+            mount_snapshot_json: "{}".to_string(),
+            cluster_snapshot_version: 0,
+        }
+    }
+}
+
+fn validate_protocol_version(protocol_version: Option<u32>) -> FsResult<()> {
+    let protocol_version = protocol_version.unwrap_or(TRANSFER_PROTOCOL_VERSION);
+    if protocol_version != TRANSFER_PROTOCOL_VERSION {
+        return Err(FsError::common(format!(
+            "Unsupported transfer protocol version {}, supported {}",
+            protocol_version, TRANSFER_PROTOCOL_VERSION
+        )));
+    }
+    Ok(())
+}
+
+fn bounded_page_size(page_size: Option<u32>) -> usize {
+    page_size
+        .map(|value| value as usize)
+        .filter(|value| *value > 0)
+        .unwrap_or(DEFAULT_LIST_PAGE_SIZE)
+        .min(MAX_LIST_PAGE_SIZE)
+}
+
+fn non_empty_filter(value: Option<String>) -> Option<String> {
+    value.and_then(|value| {
+        let value = value.trim().to_string();
+        if value.is_empty() {
+            None
+        } else {
+            Some(value)
+        }
+    })
+}
+
+fn transfer_kind(kind: i32) -> FsResult<TransferKind> {
+    match TransferKindProto::from_i32(kind) {
+        Some(TransferKindProto::TransferLoad) => Ok(TransferKind::Load),
+        Some(TransferKindProto::TransferExport) => Ok(TransferKind::Export),
+        None => Err(FsError::common(format!("Invalid transfer kind {}", kind))),
+    }
+}
+
+fn transfer_state(state: i32) -> FsResult<TransferState> {
+    match state {
+        1 => Ok(TransferState::Pending),
+        2 => Ok(TransferState::Planning),
+        3 => Ok(TransferState::Dispatching),
+        4 => Ok(TransferState::Running),
+        5 => Ok(TransferState::Canceling),
+        6 => Ok(TransferState::Completed),
+        7 => Ok(TransferState::Failed),
+        8 => Ok(TransferState::Canceled),
+        _ => Err(FsError::common(format!("Unknown transfer state {}", state))),
+    }
+}
+
+fn transfer_state_name(state: TransferState) -> &'static str {
+    match state {
+        TransferState::Pending => "Pending",
+        TransferState::Planning => "Planning",
+        TransferState::Dispatching => "Dispatching",
+        TransferState::Running => "Running",
+        TransferState::Canceling => "Canceling",
+        TransferState::Completed => "Completed",
+        TransferState::Failed => "Failed",
+        TransferState::Canceled => "Canceled",
+    }
+}
+
+fn validate_transfer_paths(kind: TransferKind, source: &str, target: &str) -> FsResult<()> {
+    let source_path = Path::from_str(source)
+        .map_err(|_| FsError::common(format!("Invalid transfer source path: {source}")))?;
+    let target_path = Path::from_str(target)
+        .map_err(|_| FsError::common(format!("Invalid transfer target path: {target}")))?;
+    reject_relative_segments(&source_path)?;
+    reject_relative_segments(&target_path)?;
+    match kind {
+        TransferKind::Load if !source_path.is_cv() && target_path.is_cv() => Ok(()),
+        TransferKind::Export if source_path.is_cv() && !target_path.is_cv() => Ok(()),
+        TransferKind::Load => Err(FsError::common(format!(
+            "Invalid Load direction: source={}, target={}",
+            source, target
+        ))),
+        TransferKind::Export => Err(FsError::common(format!(
+            "Invalid Export direction: source={}, target={}",
+            source, target
+        ))),
+    }
+}
+
+fn reject_relative_segments(path: &Path) -> FsResult<()> {
+    if path
+        .path()
+        .split('/')
+        .any(|part| matches!(part, "." | ".."))
+    {
+        return Err(FsError::common(format!(
+            "Invalid transfer path contains relative segment: {}",
+            path.full_path()
+        )));
+    }
+    Ok(())
+}
+
+fn normalized_transfer_path(path: &Path) -> String {
+    let text = if path.is_cv() {
+        path.path().to_string()
+    } else {
+        path.full_path().to_string()
+    };
+    let trimmed = text.trim_end_matches('/');
+    if trimmed.is_empty() {
+        "/".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn transfer_task_state(state: i32) -> FsResult<TransferTaskState> {
+    match state {
+        1 => Ok(TransferTaskState::Pending),
+        2 => Ok(TransferTaskState::Running),
+        3 => Ok(TransferTaskState::Completed),
+        4 => Ok(TransferTaskState::Failed),
+        5 => Ok(TransferTaskState::Canceled),
+        6 => Ok(TransferTaskState::Stale),
+        _ => Err(FsError::common(format!(
+            "Invalid transfer task state {}",
+            state
+        ))),
+    }
+}
+
+fn progress_from_proto(value: TransferProgressProto) -> TransferProgress {
+    TransferProgress {
+        loaded_size: value.loaded_size,
+        total_size: value.total_size,
+        update_time: value.update_time,
+        message: value.message,
+    }
+}
+
+pub fn progress_to_proto(value: TransferProgress) -> TransferProgressProto {
+    TransferProgressProto {
+        loaded_size: value.loaded_size,
+        total_size: value.total_size,
+        update_time: value.update_time,
+        message: value.message,
+    }
+}
+
+pub fn task_to_proto(task: TransferTaskRecord) -> TransferTaskStatusProto {
+    TransferTaskStatusProto {
+        task_id: task.task_id,
+        attempt_id: task.attempt_id,
+        source_path: task.source_path,
+        target_path: task.target_path,
+        worker_id: task.worker_id,
+        worker_session_id: task.worker_session_id,
+        state: task_state_code(task.state),
+        progress: progress_to_proto(task.progress),
+        retry_count: task.retry_count,
+        updated_at: task.updated_at,
+    }
+}
+
+pub fn job_to_proto(job: TransferJobRecord) -> TransferJobStatusProto {
+    TransferJobStatusProto {
+        job_id: job.job_id,
+        run_id: job.run_id,
+        kind: job.kind as i32,
+        state: job.state as i32,
+        source_path: job.source_path,
+        target_path: job.target_path,
+        progress: progress_to_proto(job.summary),
+        submitter: job.submitter,
+        tenant: job.tenant,
+        created_at: job.created_at,
+        updated_at: job.updated_at,
+        owner: Some(job.owner),
+        lease_epoch: Some(job.lease_epoch),
+        lease_expire_at: Some(job.lease_expire_at),
+        cv_metadata_epoch: job.cv_metadata_epoch,
+    }
+}
+
+fn task_state_code(state: TransferTaskState) -> i32 {
+    match state {
+        TransferTaskState::Pending => TransferTaskStateProto::TransferTaskPending as i32,
+        TransferTaskState::Running => TransferTaskStateProto::TransferTaskRunning as i32,
+        TransferTaskState::Completed => TransferTaskStateProto::TransferTaskCompleted as i32,
+        TransferTaskState::Failed => TransferTaskStateProto::TransferTaskFailed as i32,
+        TransferTaskState::Canceled => TransferTaskStateProto::TransferTaskCanceled as i32,
+        TransferTaskState::Stale => TransferTaskStateProto::TransferTaskStale as i32,
+    }
+}
+
+fn parse_page_token(page_token: Option<String>) -> FsResult<usize> {
+    match page_token.filter(|token| !token.is_empty()) {
+        Some(token) => token.parse::<usize>().map_err(|_| {
+            FsError::common("Invalid transfer page token; use a non-negative integer")
+        }),
+        None => Ok(0),
+    }
+}
+
+fn now_ms() -> i64 {
+    i64::try_from(LocalTime::mills()).unwrap_or(i64::MAX)
+}
+
+pub fn encode_transfer_command(command: &TransferCommand) -> FsResult<Vec<u8>> {
+    Ok(SerdeUtils::serialize_json(command)?)
+}
+
+fn decode_transfer_command(bytes: &[u8]) -> FsResult<TransferCommand> {
+    serde_json::from_slice(bytes).map_err(|_| FsError::common("Invalid transfer command payload"))
+}

--- a/curvine-server/src/transfer/sqlite_store.rs
+++ b/curvine-server/src/transfer/sqlite_store.rs
@@ -1,0 +1,1372 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use curvine_common::error::FsError;
+use curvine_common::state::{
+    summarize_transfer_tasks, StaleTaskAttempt, TaskAttemptStart, TransferCommand,
+    TransferJobRecord, TransferKind, TransferLease, TransferListFilter, TransferProgress,
+    TransferState, TransferStateUpdate, TransferTaskRecord, TransferTaskReport, TransferTaskState,
+    TransferTenantSummary,
+};
+use curvine_common::FsResult;
+use parking_lot::Mutex;
+use rusqlite::{
+    params, params_from_iter, types::Value as SqliteValue, Connection, OptionalExtension, Row,
+};
+use std::fs;
+use std::path::Path;
+
+use crate::transfer::{TransferRequeueUpdate, TransferStore};
+
+const TRANSFER_SCHEMA_VERSION: i64 = 2;
+
+pub struct SqliteTransferStore {
+    conn: Mutex<Connection>,
+}
+
+impl SqliteTransferStore {
+    pub fn open(path: impl AsRef<Path>) -> FsResult<Self> {
+        if let Some(parent) = path.as_ref().parent() {
+            fs::create_dir_all(parent).map_err(|err| {
+                FsError::common(format!(
+                    "Failed to create sqlite transfer store directory {}: {}",
+                    parent.display(),
+                    err
+                ))
+            })?;
+        }
+        let conn = Connection::open(path.as_ref()).map_err(sqlite_err)?;
+        init_schema(&conn)?;
+        Ok(Self {
+            conn: Mutex::new(conn),
+        })
+    }
+}
+
+impl TransferStore for SqliteTransferStore {
+    fn check_available(&self) -> FsResult<()> {
+        self.conn
+            .lock()
+            .query_row("select 1", [], |_| Ok(()))
+            .map_err(sqlite_err)
+    }
+
+    fn create_or_get_by_request_id(&self, job: TransferJobRecord) -> FsResult<TransferJobRecord> {
+        self.create_or_get_by_request_id_checked(job)
+    }
+
+    fn create_or_get_by_request_id_checked(
+        &self,
+        job: TransferJobRecord,
+    ) -> FsResult<TransferJobRecord> {
+        let mut conn = self.conn.lock();
+        let tx = conn.transaction().map_err(sqlite_err)?;
+        if let Some(existing) = select_job_by_request(&tx, &job.submitter, &job.client_request_id)?
+        {
+            tx.commit().map_err(sqlite_err)?;
+            return Ok(existing);
+        }
+
+        if let Some(existing) = select_non_terminal_job_by_key(&tx, &job.job_key)? {
+            if existing.command_json == job.command_json {
+                tx.commit().map_err(sqlite_err)?;
+                return Ok(existing);
+            }
+            return Err(FsError::transfer_already_running(format!(
+                "job_key {} has running job {} with different command",
+                existing.job_key, existing.job_id
+            )));
+        }
+
+        if let Some(existing) = select_conflicting_active_transfer(
+            &tx,
+            &job.target_path,
+            &job.submitter,
+            &job.client_request_id,
+        )? {
+            return Err(FsError::transfer_target_conflict(format!(
+                "target {} conflicts with active transfer {} target {}",
+                job.target_path, existing.job_id, existing.target_path
+            )));
+        }
+
+        insert_job(&tx, &job)?;
+        tx.commit().map_err(sqlite_err)?;
+        Ok(job)
+    }
+
+    fn get_transfer(&self, job_id: &str) -> FsResult<Option<TransferJobRecord>> {
+        select_job_by_id(&self.conn.lock(), job_id)
+    }
+
+    fn get_transfer_by_request(
+        &self,
+        submitter: &str,
+        client_request_id: &str,
+    ) -> FsResult<Option<TransferJobRecord>> {
+        select_job_by_request(&self.conn.lock(), submitter, client_request_id)
+    }
+
+    fn list_active_transfers(&self) -> FsResult<Vec<TransferJobRecord>> {
+        let conn = self.conn.lock();
+        let mut stmt = conn
+            .prepare(job_select_sql("where state not in (6, 7, 8)").as_str())
+            .map_err(sqlite_err)?;
+        let rows = stmt.query_map([], sqlite_job_row).map_err(sqlite_err)?;
+        collect_sqlite_rows(rows)
+    }
+
+    fn find_conflicting_active_transfer(
+        &self,
+        target_path: &str,
+        submitter: &str,
+        client_request_id: &str,
+    ) -> FsResult<Option<TransferJobRecord>> {
+        select_conflicting_active_transfer(
+            &self.conn.lock(),
+            target_path,
+            submitter,
+            client_request_id,
+        )
+    }
+
+    fn count_active_transfers(&self) -> FsResult<u64> {
+        self.conn
+            .lock()
+            .query_row(
+                "select count(*) from transfer_jobs where state not in (6, 7, 8)",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .map(|count| count as u64)
+            .map_err(sqlite_err)
+    }
+
+    fn count_executing_transfers(&self) -> FsResult<u64> {
+        self.conn
+            .lock()
+            .query_row(
+                "select count(*) from transfer_jobs where state in (2, 3, 4, 5)",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .map(|count| count as u64)
+            .map_err(sqlite_err)
+    }
+
+    fn list_transfers(&self, filter: TransferListFilter) -> FsResult<Vec<TransferJobRecord>> {
+        let conn = self.conn.lock();
+        let (where_sql, values) = list_filter_sqlite_params(&filter);
+        let sql = job_select_sql(&format!(
+            "{where_sql}
+             order by updated_at desc, created_at desc, job_id desc
+             limit ? offset ?"
+        ));
+        let mut values = values;
+        values.push(SqliteValue::Integer(filter.limit as i64));
+        values.push(SqliteValue::Integer(filter.offset as i64));
+        let mut stmt = conn.prepare(sql.as_str()).map_err(sqlite_err)?;
+        let rows = stmt
+            .query_map(params_from_iter(values), sqlite_job_row)
+            .map_err(sqlite_err)?;
+        collect_sqlite_rows(rows)
+    }
+
+    fn list_tenant_summaries(
+        &self,
+        limit: usize,
+        offset: usize,
+    ) -> FsResult<Vec<TransferTenantSummary>> {
+        let conn = self.conn.lock();
+        let mut stmt = conn
+            .prepare(
+                "select tenant,
+                        sum(case when state = 1 then 1 else 0 end) as pending,
+                        sum(case when state in (2, 3, 4, 5) then 1 else 0 end) as executing,
+                        sum(case when state = 6 then 1 else 0 end) as completed,
+                        sum(case when state = 7 then 1 else 0 end) as failed,
+                        sum(case when state = 8 then 1 else 0 end) as canceled,
+                        count(*) as total
+                 from transfer_jobs
+                 group by tenant
+                 order by (sum(case when state in (1, 2, 3, 4, 5) then 1 else 0 end)) desc,
+                          count(*) desc,
+                          tenant asc
+                 limit ?1 offset ?2",
+            )
+            .map_err(sqlite_err)?;
+        let rows = stmt
+            .query_map(
+                params![limit as i64, offset as i64],
+                sqlite_tenant_summary_row,
+            )
+            .map_err(sqlite_err)?;
+        collect_sqlite_rows(rows)
+    }
+
+    fn purge_terminal_transfers(&self, older_than_ms: i64, limit: usize) -> FsResult<usize> {
+        if limit == 0 {
+            return Ok(0);
+        }
+        let mut conn = self.conn.lock();
+        let tx = conn.transaction().map_err(sqlite_err)?;
+        let job_ids = {
+            let mut stmt = tx
+                .prepare(
+                    "select job_id from transfer_jobs
+                     where state in (6, 7, 8) and updated_at < ?1
+                     order by updated_at asc
+                     limit ?2",
+                )
+                .map_err(sqlite_err)?;
+            let rows = stmt
+                .query_map(params![older_than_ms, limit as i64], |row| {
+                    row.get::<_, String>(0)
+                })
+                .map_err(sqlite_err)?;
+            collect_sqlite_rows(rows)?
+        };
+        for job_id in &job_ids {
+            tx.execute(
+                "delete from transfer_tasks where job_id = ?1",
+                params![job_id],
+            )
+            .map_err(sqlite_err)?;
+            tx.execute(
+                "delete from transfer_jobs where job_id = ?1 and state in (6, 7, 8)",
+                params![job_id],
+            )
+            .map_err(sqlite_err)?;
+        }
+        tx.commit().map_err(sqlite_err)?;
+        Ok(job_ids.len())
+    }
+
+    fn list_transfer_tasks(&self, job_id: &str, run_id: u64) -> FsResult<Vec<TransferTaskRecord>> {
+        let conn = self.conn.lock();
+        let mut stmt = conn
+            .prepare(
+                "select job_id, run_id, task_id, attempt_id, source_path, target_path,
+                        worker_id, worker_session_id, source_read_plan_json, report_target_json,
+                        state, progress_json, retry_count, attempt_started_at, last_report_at,
+                        stale_deadline_at, updated_at
+                 from transfer_tasks where job_id = ?1 and run_id = ?2",
+            )
+            .map_err(sqlite_err)?;
+        let rows = stmt
+            .query_map(params![job_id, run_id as i64], sqlite_task_row)
+            .map_err(sqlite_err)?;
+        collect_sqlite_rows(rows)
+    }
+
+    fn request_cancel(&self, job_id: &str, run_id: u64, now_ms: i64) -> FsResult<bool> {
+        let mut conn = self.conn.lock();
+        let tx = conn.transaction().map_err(sqlite_err)?;
+        let Some(summary_json) = tx
+            .query_row(
+                "select summary_json from transfer_jobs
+                 where job_id = ?1 and run_id = ?2 and state not in (6, 7, 8)",
+                params![job_id, run_id as i64],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .map_err(sqlite_err)?
+        else {
+            tx.commit().map_err(sqlite_err)?;
+            return Ok(false);
+        };
+        let mut summary: TransferProgress =
+            serde_json::from_str(&summary_json).map_err(|err| FsError::common(err.to_string()))?;
+        summary.message = "cancel requested".to_string();
+        summary.update_time = now_ms;
+        let summary_json = transfer_progress_json(&summary)?;
+        let affected = tx
+            .execute(
+                "update transfer_jobs
+                 set cancel_requested = 1, state = ?3, summary_json = ?4, updated_at = ?5
+                 where job_id = ?1 and run_id = ?2 and state not in (6, 7, 8)",
+                params![
+                    job_id,
+                    run_id as i64,
+                    TransferState::Canceling as i32,
+                    summary_json,
+                    now_ms
+                ],
+            )
+            .map_err(sqlite_err)?;
+        tx.commit().map_err(sqlite_err)?;
+        Ok(affected > 0)
+    }
+
+    fn acquire_runnable_transfer(
+        &self,
+        owner: &str,
+        lease_ms: i64,
+        now_ms: i64,
+        max_executing_transfers: u64,
+    ) -> FsResult<Option<TransferLease>> {
+        let mut conn = self.conn.lock();
+        let tx = conn.transaction().map_err(sqlite_err)?;
+        let executing = tx
+            .query_row(
+                "select count(*) from transfer_jobs where state in (2, 3, 4, 5)",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .map_err(sqlite_err)? as u64;
+        let mut candidate: Option<(String, i64, i64, i64)> = tx
+            .query_row(
+                "select job_id, run_id, lease_epoch, state
+                 from transfer_jobs
+                 where owner = ?1 and state in (4, 5) and lease_expire_at > ?2 and updated_at < ?2
+                 order by updated_at asc
+                 limit 1",
+                params![owner, now_ms],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .optional()
+            .map_err(sqlite_err)?;
+        if candidate.is_none() {
+            candidate = tx
+                .query_row(
+                    "select job_id, run_id, lease_epoch, state
+                 from transfer_jobs
+                 where state in (2, 3, 4, 5) and lease_expire_at <= ?1
+                 order by updated_at asc
+                 limit 1",
+                    params![now_ms],
+                    |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+                )
+                .optional()
+                .map_err(sqlite_err)?;
+        }
+        if candidate.is_none() && executing < max_executing_transfers {
+            candidate = tx
+                .query_row(
+                    "select pending.job_id, pending.run_id, pending.lease_epoch, pending.state
+                     from transfer_jobs pending
+                     where pending.state = 1 and pending.lease_expire_at <= ?1
+                     order by case when exists (
+                         select 1 from transfer_jobs executing
+                         where executing.tenant = pending.tenant and executing.state in (2, 3, 4, 5)
+                         limit 1
+                     ) then 1 else 0 end asc,
+                     pending.updated_at asc, pending.job_id asc
+                     limit 1",
+                    params![now_ms],
+                    |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+                )
+                .optional()
+                .map_err(sqlite_err)?;
+        }
+        let Some((job_id, run_id, lease_epoch, state)) = candidate else {
+            tx.commit().map_err(sqlite_err)?;
+            return Ok(None);
+        };
+
+        let new_epoch = lease_epoch.saturating_add(1);
+        let new_state = if state == TransferState::Pending as i64 {
+            TransferState::Planning as i32
+        } else {
+            state as i32
+        };
+        let summary_json = if state == TransferState::Pending as i64 {
+            transfer_progress_json(&TransferProgress {
+                update_time: now_ms,
+                message: "acquired for planning".to_string(),
+                ..Default::default()
+            })?
+        } else {
+            tx.query_row(
+                "select summary_json from transfer_jobs where job_id = ?1",
+                params![job_id],
+                |row| row.get::<_, String>(0),
+            )
+            .map_err(sqlite_err)?
+        };
+        let affected = tx
+            .execute(
+                "update transfer_jobs
+                 set state = ?1, owner = ?2, lease_epoch = ?3, lease_expire_at = ?4,
+                     summary_json = ?5, updated_at = ?6
+                 where job_id = ?7 and run_id = ?8 and lease_epoch = ?9",
+                params![
+                    new_state,
+                    owner,
+                    new_epoch,
+                    now_ms.saturating_add(lease_ms),
+                    summary_json,
+                    now_ms,
+                    job_id,
+                    run_id,
+                    lease_epoch
+                ],
+            )
+            .map_err(sqlite_err)?;
+        tx.commit().map_err(sqlite_err)?;
+        if affected == 0 {
+            return Ok(None);
+        }
+        Ok(Some(TransferLease {
+            job_id,
+            run_id: run_id as u64,
+            owner: owner.to_string(),
+            lease_epoch: new_epoch as u64,
+        }))
+    }
+
+    fn renew_lease(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        owner: &str,
+        lease_epoch: u64,
+        lease_ms: i64,
+        now_ms: i64,
+    ) -> FsResult<bool> {
+        let affected = self
+            .conn
+            .lock()
+            .execute(
+                "update transfer_jobs
+                 set lease_expire_at = ?6, updated_at = ?7
+                 where job_id = ?1 and run_id = ?2 and owner = ?3 and lease_epoch = ?4
+                   and state not in (6, 7, 8)",
+                params![
+                    job_id,
+                    run_id as i64,
+                    owner,
+                    lease_epoch as i64,
+                    lease_ms,
+                    now_ms.saturating_add(lease_ms),
+                    now_ms
+                ],
+            )
+            .map_err(sqlite_err)?;
+        Ok(affected > 0)
+    }
+
+    fn update_transfer_state(&self, update: TransferStateUpdate) -> FsResult<bool> {
+        let states = state_list(&update.from_states);
+        let sql = format!(
+            "update transfer_jobs
+             set state = ?1, summary_json = ?2, updated_at = ?3
+             where job_id = ?4 and run_id = ?5 and owner = ?6 and lease_epoch = ?7
+               and state in ({states})"
+        );
+        let summary = transfer_progress_json(&TransferProgress {
+            message: update.message,
+            update_time: update.now_ms,
+            ..Default::default()
+        })?;
+        let affected = self
+            .conn
+            .lock()
+            .execute(
+                &sql,
+                params![
+                    update.to_state as i32,
+                    summary,
+                    update.now_ms,
+                    update.job_id,
+                    update.run_id as i64,
+                    update.owner,
+                    update.lease_epoch as i64
+                ],
+            )
+            .map_err(sqlite_err)?;
+        Ok(affected > 0)
+    }
+
+    fn set_transfer_state(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        state: TransferState,
+        message: impl Into<String>,
+        now_ms: i64,
+    ) -> FsResult<bool> {
+        let mut job = match self.get_transfer(job_id)? {
+            Some(job) if job.run_id == run_id => job,
+            _ => return Ok(false),
+        };
+        job.state = state;
+        job.summary.message = message.into();
+        job.summary.update_time = now_ms;
+        let affected = self
+            .conn
+            .lock()
+            .execute(
+                "update transfer_jobs set state = ?1, summary_json = ?2, updated_at = ?3
+                 where job_id = ?4 and run_id = ?5",
+                params![
+                    state as i32,
+                    transfer_progress_json(&job.summary)?,
+                    now_ms,
+                    job_id,
+                    run_id as i64
+                ],
+            )
+            .map_err(sqlite_err)?;
+        Ok(affected > 0)
+    }
+
+    fn requeue_transfer(&self, update: TransferRequeueUpdate) -> FsResult<bool> {
+        let summary = transfer_progress_json(&TransferProgress {
+            message: update.message,
+            update_time: update.now_ms,
+            ..Default::default()
+        })?;
+        let affected = self
+            .conn
+            .lock()
+            .execute(
+                "update transfer_jobs
+                 set state = ?1, owner = '', lease_expire_at = ?2, summary_json = ?3, updated_at = ?4
+                 where job_id = ?5 and run_id = ?6 and owner = ?7 and lease_epoch = ?8
+                   and state = ?9",
+                params![
+                    TransferState::Pending as i32,
+                    update.next_attempt_at_ms,
+                    summary,
+                    update.now_ms,
+                    update.job_id,
+                    update.run_id as i64,
+                    update.owner,
+                    update.lease_epoch as i64,
+                    TransferState::Planning as i32
+                ],
+            )
+            .map_err(sqlite_err)?;
+        Ok(affected > 0)
+    }
+
+    fn set_transfer_cv_metadata_epoch(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        owner: &str,
+        lease_epoch: u64,
+        cv_metadata_epoch: u64,
+        now_ms: i64,
+    ) -> FsResult<bool> {
+        let affected = self
+            .conn
+            .lock()
+            .execute(
+                "update transfer_jobs
+                 set cv_metadata_epoch = ?1, updated_at = ?2
+                 where job_id = ?3 and run_id = ?4 and owner = ?5 and lease_epoch = ?6
+                   and state not in (6, 7, 8)
+                   and (cv_metadata_epoch is null or cv_metadata_epoch = ?1)",
+                params![
+                    cv_metadata_epoch as i64,
+                    now_ms,
+                    job_id,
+                    run_id as i64,
+                    owner,
+                    lease_epoch as i64
+                ],
+            )
+            .map_err(sqlite_err)?;
+        Ok(affected > 0)
+    }
+
+    fn insert_tasks(&self, tasks: Vec<TransferTaskRecord>) -> FsResult<()> {
+        let mut conn = self.conn.lock();
+        let tx = conn.transaction().map_err(sqlite_err)?;
+        for task in tasks {
+            insert_task(&tx, &task)?;
+        }
+        tx.commit().map_err(sqlite_err)?;
+        Ok(())
+    }
+
+    fn update_task_state(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        task_id: &str,
+        state: TransferTaskState,
+        message: impl Into<String>,
+        now_ms: i64,
+    ) -> FsResult<bool> {
+        let mut progress = TransferProgress {
+            message: message.into(),
+            update_time: now_ms,
+            ..Default::default()
+        };
+        if let Some(task) = self
+            .list_transfer_tasks(job_id, run_id)?
+            .into_iter()
+            .find(|task| task.task_id == task_id)
+        {
+            progress.loaded_size = task.progress.loaded_size;
+            progress.total_size = task.progress.total_size;
+        }
+        let affected = self
+            .conn
+            .lock()
+            .execute(
+                "update transfer_tasks set state = ?1, progress_json = ?2, updated_at = ?3
+                 where job_id = ?4 and run_id = ?5 and task_id = ?6",
+                params![
+                    state as i32,
+                    transfer_progress_json(&progress)?,
+                    now_ms,
+                    job_id,
+                    run_id as i64,
+                    task_id
+                ],
+            )
+            .map_err(sqlite_err)?;
+        Ok(affected > 0)
+    }
+
+    fn claim_pending_tasks(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        limit: usize,
+    ) -> FsResult<Vec<TransferTaskRecord>> {
+        let conn = self.conn.lock();
+        let mut stmt = conn
+            .prepare(
+                "select job_id, run_id, task_id, attempt_id, source_path, target_path,
+                        worker_id, worker_session_id, source_read_plan_json, report_target_json,
+                        state, progress_json, retry_count, attempt_started_at, last_report_at,
+                        stale_deadline_at, updated_at
+                 from transfer_tasks
+                 where job_id = ?1 and run_id = ?2 and state = 1
+                 order by updated_at asc
+                 limit ?3",
+            )
+            .map_err(sqlite_err)?;
+        let rows = stmt
+            .query_map(
+                params![job_id, run_id as i64, limit as i64],
+                sqlite_task_row,
+            )
+            .map_err(sqlite_err)?;
+        collect_sqlite_rows(rows)
+    }
+
+    fn mark_stale_attempts(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        owner: &str,
+        lease_epoch: u64,
+        now_ms: i64,
+        limit: usize,
+    ) -> FsResult<Vec<StaleTaskAttempt>> {
+        let mut conn = self.conn.lock();
+        let tx = conn.transaction().map_err(sqlite_err)?;
+        let valid_owner: Option<i64> = tx
+            .query_row(
+                "select 1 from transfer_jobs
+                 where job_id = ?1 and run_id = ?2 and owner = ?3 and lease_epoch = ?4",
+                params![job_id, run_id as i64, owner, lease_epoch as i64],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(sqlite_err)?;
+        if valid_owner.is_none() {
+            tx.commit().map_err(sqlite_err)?;
+            return Ok(Vec::new());
+        }
+
+        let tasks = {
+            let mut stmt = tx
+                .prepare(
+                    "select job_id, run_id, task_id, attempt_id, source_path, target_path,
+                            worker_id, worker_session_id, source_read_plan_json, report_target_json,
+                            state, progress_json, retry_count, attempt_started_at, last_report_at,
+                            stale_deadline_at, updated_at
+                     from transfer_tasks
+                     where job_id = ?1 and run_id = ?2 and state = 2 and stale_deadline_at < ?3
+                     order by stale_deadline_at asc
+                     limit ?4",
+                )
+                .map_err(sqlite_err)?;
+            let rows = stmt
+                .query_map(
+                    params![job_id, run_id as i64, now_ms, limit as i64],
+                    sqlite_task_row,
+                )
+                .map_err(sqlite_err)?;
+            collect_sqlite_rows(rows)?
+        };
+
+        let mut stale = Vec::with_capacity(tasks.len());
+        for mut task in tasks {
+            task.state = TransferTaskState::Stale;
+            task.retry_count = task.retry_count.saturating_add(1);
+            task.progress.message = "task stale timeout".to_string();
+            task.progress.update_time = now_ms;
+            task.updated_at = now_ms;
+            update_task_record(&tx, &task)?;
+            stale.push(StaleTaskAttempt { task });
+        }
+        tx.commit().map_err(sqlite_err)?;
+        Ok(stale)
+    }
+
+    fn list_recoverable_tasks(
+        &self,
+        job_id: &str,
+        run_id: u64,
+    ) -> FsResult<Vec<TransferTaskRecord>> {
+        let conn = self.conn.lock();
+        let mut stmt = conn
+            .prepare(
+                "select job_id, run_id, task_id, attempt_id, source_path, target_path,
+                        worker_id, worker_session_id, source_read_plan_json, report_target_json,
+                        state, progress_json, retry_count, attempt_started_at, last_report_at,
+                        stale_deadline_at, updated_at
+                 from transfer_tasks
+                 where job_id = ?1 and run_id = ?2 and state in (1, 2, 6)",
+            )
+            .map_err(sqlite_err)?;
+        let rows = stmt
+            .query_map(params![job_id, run_id as i64], sqlite_task_row)
+            .map_err(sqlite_err)?;
+        collect_sqlite_rows(rows)
+    }
+
+    fn start_task_attempt(&self, start: TaskAttemptStart) -> FsResult<bool> {
+        let affected = self
+            .conn
+            .lock()
+            .execute(
+                "update transfer_tasks
+                 set attempt_id = ?1, worker_id = ?2, worker_session_id = ?3,
+                     report_target_json = ?4, state = 2, attempt_started_at = ?5,
+                     last_report_at = ?5, stale_deadline_at = ?6, updated_at = ?5
+                 where job_id = ?7 and run_id = ?8 and task_id = ?9 and state in (1, 6)
+                   and exists (
+                       select 1 from transfer_jobs
+                        where job_id = ?7 and run_id = ?8 and owner = ?10
+                          and lease_epoch = ?11 and cancel_requested = 0
+                          and state not in (6, 7, 8)
+                   )",
+                params![
+                    start.attempt_id as i64,
+                    start.worker_id as i64,
+                    start.worker_session_id,
+                    start.report_target_json,
+                    start.now_ms,
+                    start.stale_deadline_at,
+                    start.job_id,
+                    start.run_id as i64,
+                    start.task_id,
+                    start.owner,
+                    start.lease_epoch as i64
+                ],
+            )
+            .map_err(sqlite_err)?;
+        Ok(affected > 0)
+    }
+
+    fn update_task_report(&self, report: TransferTaskReport) -> FsResult<bool> {
+        let mut conn = self.conn.lock();
+        let tx = conn.transaction().map_err(sqlite_err)?;
+        let affected = tx
+            .execute(
+                "update transfer_tasks
+                 set state = ?1, progress_json = ?2, last_report_at = ?3,
+                     stale_deadline_at = ?4, updated_at = ?3
+                 where job_id = ?5 and run_id = ?6 and task_id = ?7 and attempt_id = ?8
+                   and worker_id = ?9 and worker_session_id = ?10 and state in (1, 2)",
+                params![
+                    report.state as i32,
+                    transfer_progress_json(&report.progress)?,
+                    report.now_ms,
+                    report.stale_deadline_at,
+                    report.job_id,
+                    report.run_id as i64,
+                    report.task_id,
+                    report.attempt_id as i64,
+                    report.worker_id as i64,
+                    report.worker_session_id
+                ],
+            )
+            .map_err(sqlite_err)?;
+        if affected == 0 {
+            tx.commit().map_err(sqlite_err)?;
+            return Ok(false);
+        }
+
+        update_job_summary(&tx, &report.job_id, report.run_id, report.now_ms)?;
+        tx.commit().map_err(sqlite_err)?;
+        Ok(true)
+    }
+}
+
+fn update_task_record(conn: &Connection, task: &TransferTaskRecord) -> FsResult<bool> {
+    let affected = conn
+        .execute(
+            "update transfer_tasks
+             set attempt_id = ?1, worker_id = ?2, worker_session_id = ?3,
+                 source_read_plan_json = ?4, report_target_json = ?5, state = ?6,
+                 progress_json = ?7, retry_count = ?8, attempt_started_at = ?9,
+                 last_report_at = ?10, stale_deadline_at = ?11, updated_at = ?12
+             where job_id = ?13 and run_id = ?14 and task_id = ?15",
+            params![
+                task.attempt_id as i64,
+                task.worker_id as i64,
+                task.worker_session_id,
+                task.source_read_plan_json,
+                task.report_target_json,
+                task.state as i32,
+                transfer_progress_json(&task.progress)?,
+                task.retry_count as i64,
+                task.attempt_started_at,
+                task.last_report_at,
+                task.stale_deadline_at,
+                task.updated_at,
+                task.job_id,
+                task.run_id as i64,
+                task.task_id
+            ],
+        )
+        .map_err(sqlite_err)?;
+    Ok(affected > 0)
+}
+
+fn init_schema(conn: &Connection) -> FsResult<()> {
+    conn.execute_batch(
+        "
+        create table if not exists transfer_schema_version (
+            id integer primary key check(id = 1),
+            version integer not null,
+            updated_at integer not null
+        );
+        insert or ignore into transfer_schema_version(id, version, updated_at)
+            values (1, 2, strftime('%s', 'now') * 1000);
+        ",
+    )
+    .map_err(sqlite_err)?;
+    let version = conn
+        .query_row(
+            "select version from transfer_schema_version where id = 1",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .map_err(sqlite_err)?;
+    migrate_schema(conn, version)?;
+    create_base_tables(conn)?;
+    create_indexes(conn)?;
+    Ok(())
+}
+
+fn create_base_tables(conn: &Connection) -> FsResult<()> {
+    conn.execute_batch(
+        "
+        create table if not exists transfer_jobs (
+            job_id text primary key,
+            job_key text not null,
+            run_id integer not null,
+            kind integer not null,
+            source_path text not null,
+            target_path text not null,
+            command_json text not null,
+            mount_snapshot_json text not null,
+            secret_ref_json text not null,
+            cluster_snapshot_version integer not null,
+            cv_metadata_epoch integer,
+            state integer not null,
+            owner text not null,
+            lease_epoch integer not null,
+            lease_expire_at integer not null,
+            cancel_requested integer not null,
+            summary_json text not null,
+            client_request_id text not null,
+            submitter text not null,
+            tenant text not null,
+            created_at integer not null,
+            updated_at integer not null
+        );
+        create table if not exists transfer_tasks (
+            job_id text not null,
+            run_id integer not null,
+            task_id text not null,
+            attempt_id integer not null,
+            source_path text not null,
+            target_path text not null,
+            worker_id integer not null,
+            worker_session_id text not null,
+            source_read_plan_json text not null,
+            report_target_json text not null,
+            state integer not null,
+            progress_json text not null,
+            retry_count integer not null,
+            attempt_started_at integer not null,
+            last_report_at integer not null,
+            stale_deadline_at integer not null,
+            updated_at integer not null,
+            primary key(job_id, run_id, task_id)
+        );
+        ",
+    )
+    .map_err(sqlite_err)?;
+    Ok(())
+}
+
+fn create_indexes(conn: &Connection) -> FsResult<()> {
+    conn.execute_batch(
+        "
+        create unique index if not exists transfer_jobs_request_idx
+            on transfer_jobs(submitter, client_request_id);
+        create index if not exists transfer_jobs_job_key_state_idx
+            on transfer_jobs(job_key, state);
+        create index if not exists transfer_jobs_state_lease_idx
+            on transfer_jobs(state, lease_expire_at);
+        create index if not exists transfer_jobs_owner_state_updated_idx
+            on transfer_jobs(owner, state, updated_at);
+        create index if not exists transfer_jobs_target_state_idx
+            on transfer_jobs(target_path, state);
+        create index if not exists transfer_jobs_tenant_state_updated_idx
+            on transfer_jobs(tenant, state, updated_at);
+        create index if not exists transfer_jobs_submitter_state_updated_idx
+            on transfer_jobs(submitter, state, updated_at);
+        create index if not exists transfer_tasks_job_state_idx
+            on transfer_tasks(job_id, run_id, state);
+        create index if not exists transfer_tasks_worker_idx
+            on transfer_tasks(worker_id, worker_session_id, state);
+        create index if not exists transfer_tasks_stale_idx
+            on transfer_tasks(state, stale_deadline_at);
+        ",
+    )
+    .map_err(sqlite_err)?;
+    Ok(())
+}
+
+fn migrate_schema(conn: &Connection, version: i64) -> FsResult<()> {
+    if version == 1 {
+        migrate_sqlite_schema_v1_to_v2(conn)?;
+        conn.execute(
+            "update transfer_schema_version
+             set version = ?1, updated_at = strftime('%s', 'now') * 1000
+             where id = 1",
+            params![TRANSFER_SCHEMA_VERSION],
+        )
+        .map_err(sqlite_err)?;
+        return Ok(());
+    }
+    if version != TRANSFER_SCHEMA_VERSION {
+        return Err(FsError::common(format!(
+            "Unsupported sqlite transfer schema version {}, expected {}",
+            version, TRANSFER_SCHEMA_VERSION
+        )));
+    }
+    Ok(())
+}
+
+fn migrate_sqlite_schema_v1_to_v2(conn: &Connection) -> FsResult<()> {
+    if !sqlite_column_exists(conn, "transfer_jobs", "target_path")? {
+        conn.execute(
+            "alter table transfer_jobs add column target_path text not null default ''",
+            [],
+        )
+        .map_err(sqlite_err)?;
+    }
+    let mut stmt = conn
+        .prepare("select job_id, command_json from transfer_jobs where target_path = ''")
+        .map_err(sqlite_err)?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })
+        .map_err(sqlite_err)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(sqlite_err)?;
+    for (job_id, command_json) in rows {
+        let command: TransferCommand = serde_json::from_str(&command_json)
+            .map_err(|err| FsError::common(format!("Invalid transfer command json: {}", err)))?;
+        conn.execute(
+            "update transfer_jobs set target_path = ?1 where job_id = ?2",
+            params![command.target_path, job_id],
+        )
+        .map_err(sqlite_err)?;
+    }
+    Ok(())
+}
+
+fn sqlite_column_exists(conn: &Connection, table: &str, column: &str) -> FsResult<bool> {
+    let mut stmt = conn
+        .prepare(format!("pragma table_info({table})").as_str())
+        .map_err(sqlite_err)?;
+    let columns = stmt
+        .query_map([], |row| row.get::<_, String>(1))
+        .map_err(sqlite_err)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(sqlite_err)?;
+    Ok(columns.iter().any(|name| name == column))
+}
+
+fn insert_job(conn: &Connection, job: &TransferJobRecord) -> FsResult<()> {
+    conn.execute(
+        "insert into transfer_jobs (
+            job_id, job_key, run_id, kind, source_path, target_path, command_json,
+            mount_snapshot_json, secret_ref_json, cluster_snapshot_version, cv_metadata_epoch,
+            state, owner, lease_epoch, lease_expire_at, cancel_requested, summary_json,
+            client_request_id, submitter, tenant, created_at, updated_at
+        ) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16,
+                  ?17, ?18, ?19, ?20, ?21, ?22)",
+        params![
+            job.job_id,
+            job.job_key,
+            job.run_id as i64,
+            job.kind as i32,
+            job.source_path,
+            job.target_path,
+            job.command_json,
+            job.mount_snapshot_json,
+            job.secret_ref_json,
+            job.cluster_snapshot_version as i64,
+            job.cv_metadata_epoch.map(|v| v as i64),
+            job.state as i32,
+            job.owner,
+            job.lease_epoch as i64,
+            job.lease_expire_at,
+            if job.cancel_requested { 1_i64 } else { 0_i64 },
+            transfer_progress_json(&job.summary)?,
+            job.client_request_id,
+            job.submitter,
+            job.tenant,
+            job.created_at,
+            job.updated_at
+        ],
+    )
+    .map_err(sqlite_err)?;
+    Ok(())
+}
+
+fn insert_task(conn: &Connection, task: &TransferTaskRecord) -> FsResult<()> {
+    conn.execute(
+        "insert or ignore into transfer_tasks (
+            job_id, run_id, task_id, attempt_id, source_path, target_path, worker_id,
+            worker_session_id, source_read_plan_json, report_target_json, state, progress_json,
+            retry_count, attempt_started_at, last_report_at, stale_deadline_at, updated_at
+        ) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
+        params![
+            task.job_id,
+            task.run_id as i64,
+            task.task_id,
+            task.attempt_id as i64,
+            task.source_path,
+            task.target_path,
+            task.worker_id as i64,
+            task.worker_session_id,
+            task.source_read_plan_json,
+            task.report_target_json,
+            task.state as i32,
+            transfer_progress_json(&task.progress)?,
+            task.retry_count as i64,
+            task.attempt_started_at,
+            task.last_report_at,
+            task.stale_deadline_at,
+            task.updated_at
+        ],
+    )
+    .map_err(sqlite_err)?;
+    Ok(())
+}
+
+fn select_job_by_id(conn: &Connection, job_id: &str) -> FsResult<Option<TransferJobRecord>> {
+    conn.query_row(
+        job_select_sql("where job_id = ?1").as_str(),
+        params![job_id],
+        sqlite_job_row,
+    )
+    .optional()
+    .map_err(sqlite_err)
+}
+
+fn select_job_by_request(
+    conn: &Connection,
+    submitter: &str,
+    client_request_id: &str,
+) -> FsResult<Option<TransferJobRecord>> {
+    conn.query_row(
+        job_select_sql("where submitter = ?1 and client_request_id = ?2").as_str(),
+        params![submitter, client_request_id],
+        sqlite_job_row,
+    )
+    .optional()
+    .map_err(sqlite_err)
+}
+
+fn select_non_terminal_job_by_key(
+    conn: &Connection,
+    job_key: &str,
+) -> FsResult<Option<TransferJobRecord>> {
+    conn.query_row(
+        job_select_sql("where job_key = ?1 and state not in (6, 7, 8) limit 1").as_str(),
+        params![job_key],
+        sqlite_job_row,
+    )
+    .optional()
+    .map_err(sqlite_err)
+}
+
+fn select_conflicting_active_transfer(
+    conn: &Connection,
+    target_path: &str,
+    submitter: &str,
+    client_request_id: &str,
+) -> FsResult<Option<TransferJobRecord>> {
+    let child_prefix = format!("{}/%", target_path.trim_end_matches('/'));
+    let exact_or_child = conn
+        .query_row(
+            job_select_sql(
+                "where state not in (6, 7, 8)
+               and not (submitter = ?2 and client_request_id = ?3)
+               and (
+                   target_path = ?1
+                   or target_path like ?4
+               )
+             limit 1",
+            )
+            .as_str(),
+            params![target_path, submitter, client_request_id, child_prefix],
+            sqlite_job_row,
+        )
+        .optional()
+        .map_err(sqlite_err)?;
+    if exact_or_child.is_some() {
+        return Ok(exact_or_child);
+    }
+
+    for ancestor in ancestor_paths(target_path) {
+        let ancestor_conflict = conn
+            .query_row(
+                job_select_sql(
+                    "where state not in (6, 7, 8)
+                       and not (submitter = ?2 and client_request_id = ?3)
+                       and target_path = ?1
+                     limit 1",
+                )
+                .as_str(),
+                params![ancestor, submitter, client_request_id],
+                sqlite_job_row,
+            )
+            .optional()
+            .map_err(sqlite_err)?;
+        if ancestor_conflict.is_some() {
+            return Ok(ancestor_conflict);
+        }
+    }
+    Ok(None)
+}
+
+fn job_select_sql(where_sql: &str) -> String {
+    format!(
+        "select job_id, job_key, run_id, kind, source_path, target_path, command_json,
+                mount_snapshot_json, secret_ref_json, cluster_snapshot_version, cv_metadata_epoch,
+                state, owner, lease_epoch, lease_expire_at, cancel_requested, summary_json,
+                client_request_id, submitter, tenant, created_at, updated_at
+         from transfer_jobs {where_sql}"
+    )
+}
+
+fn ancestor_paths(target_path: &str) -> Vec<String> {
+    if target_path == "/" {
+        return Vec::new();
+    }
+    let mut ancestors = vec!["/".to_string()];
+    let trimmed = target_path.trim_matches('/');
+    let mut current = String::new();
+    let mut parts = trimmed.split('/').peekable();
+    while let Some(part) = parts.next() {
+        if parts.peek().is_none() {
+            break;
+        }
+        current.push('/');
+        current.push_str(part);
+        ancestors.push(current.clone());
+    }
+    ancestors
+}
+
+fn sqlite_job_row(row: &Row<'_>) -> rusqlite::Result<TransferJobRecord> {
+    let summary_json: String = row.get(16)?;
+    Ok(TransferJobRecord {
+        job_id: row.get(0)?,
+        job_key: row.get(1)?,
+        run_id: row.get::<_, i64>(2)? as u64,
+        kind: TransferKind::from(row.get::<_, i32>(3)?),
+        source_path: row.get(4)?,
+        target_path: row.get(5)?,
+        command_json: row.get(6)?,
+        mount_snapshot_json: row.get(7)?,
+        secret_ref_json: row.get(8)?,
+        cluster_snapshot_version: row.get::<_, i64>(9)? as u64,
+        cv_metadata_epoch: row.get::<_, Option<i64>>(10)?.map(|v| v as u64),
+        state: TransferState::from(row.get::<_, i32>(11)?),
+        owner: row.get(12)?,
+        lease_epoch: row.get::<_, i64>(13)? as u64,
+        lease_expire_at: row.get(14)?,
+        cancel_requested: row.get::<_, i64>(15)? != 0,
+        summary: serde_json::from_str(&summary_json).unwrap_or_default(),
+        client_request_id: row.get(17)?,
+        submitter: row.get(18)?,
+        tenant: row.get(19)?,
+        created_at: row.get(20)?,
+        updated_at: row.get(21)?,
+    })
+}
+
+fn list_filter_sqlite_params(filter: &TransferListFilter) -> (String, Vec<SqliteValue>) {
+    let mut clauses = Vec::new();
+    let mut values = Vec::new();
+    if let Some(kind) = filter.kind {
+        clauses.push("kind = ?");
+        values.push(SqliteValue::Integer(kind as i32 as i64));
+    }
+    if let Some(state) = filter.state {
+        clauses.push("state = ?");
+        values.push(SqliteValue::Integer(state as i32 as i64));
+    }
+    if let Some(submitter) = &filter.submitter {
+        clauses.push("submitter = ?");
+        values.push(SqliteValue::Text(submitter.clone()));
+    }
+    if let Some(tenant) = &filter.tenant {
+        clauses.push("tenant = ?");
+        values.push(SqliteValue::Text(tenant.clone()));
+    }
+    if clauses.is_empty() {
+        (String::new(), values)
+    } else {
+        (format!("where {}", clauses.join(" and ")), values)
+    }
+}
+
+fn sqlite_task_row(row: &Row<'_>) -> rusqlite::Result<TransferTaskRecord> {
+    let progress_json: String = row.get(11)?;
+    Ok(TransferTaskRecord {
+        job_id: row.get(0)?,
+        run_id: row.get::<_, i64>(1)? as u64,
+        task_id: row.get(2)?,
+        attempt_id: row.get::<_, i64>(3)? as u64,
+        source_path: row.get(4)?,
+        target_path: row.get(5)?,
+        worker_id: row.get::<_, i64>(6)? as u32,
+        worker_session_id: row.get(7)?,
+        source_read_plan_json: row.get(8)?,
+        report_target_json: row.get(9)?,
+        state: TransferTaskState::from(row.get::<_, i32>(10)?),
+        progress: serde_json::from_str(&progress_json).unwrap_or_default(),
+        retry_count: row.get::<_, i64>(12)? as u32,
+        attempt_started_at: row.get(13)?,
+        last_report_at: row.get(14)?,
+        stale_deadline_at: row.get(15)?,
+        updated_at: row.get(16)?,
+    })
+}
+
+fn sqlite_tenant_summary_row(row: &Row<'_>) -> rusqlite::Result<TransferTenantSummary> {
+    Ok(TransferTenantSummary {
+        tenant: row.get(0)?,
+        pending: row.get::<_, i64>(1)? as u64,
+        executing: row.get::<_, i64>(2)? as u64,
+        completed: row.get::<_, i64>(3)? as u64,
+        failed: row.get::<_, i64>(4)? as u64,
+        canceled: row.get::<_, i64>(5)? as u64,
+        total: row.get::<_, i64>(6)? as u64,
+    })
+}
+
+fn update_job_summary(conn: &Connection, job_id: &str, run_id: u64, now_ms: i64) -> FsResult<()> {
+    let tasks = {
+        let mut stmt = conn
+            .prepare(
+                "select job_id, run_id, task_id, attempt_id, source_path, target_path,
+                        worker_id, worker_session_id, source_read_plan_json, report_target_json,
+                        state, progress_json, retry_count, attempt_started_at, last_report_at,
+                        stale_deadline_at, updated_at
+                 from transfer_tasks where job_id = ?1 and run_id = ?2",
+            )
+            .map_err(sqlite_err)?;
+        let rows = stmt
+            .query_map(params![job_id, run_id as i64], sqlite_task_row)
+            .map_err(sqlite_err)?;
+        collect_sqlite_rows(rows)?
+    };
+    let summary = summarize_transfer_tasks(&tasks, now_ms);
+    let state = if summary.has_failed {
+        Some(TransferState::Failed)
+    } else if summary.has_task && summary.all_completed {
+        Some(TransferState::Completed)
+    } else {
+        None
+    };
+    if let Some(state) = state {
+        conn.execute(
+            "update transfer_jobs set state = ?1, summary_json = ?2, updated_at = ?3
+             where job_id = ?4 and run_id = ?5",
+            params![
+                state as i32,
+                transfer_progress_json(&summary.progress)?,
+                now_ms,
+                job_id,
+                run_id as i64
+            ],
+        )
+        .map_err(sqlite_err)?;
+    } else {
+        conn.execute(
+            "update transfer_jobs set summary_json = ?1, updated_at = ?2
+             where job_id = ?3 and run_id = ?4",
+            params![
+                transfer_progress_json(&summary.progress)?,
+                now_ms,
+                job_id,
+                run_id as i64
+            ],
+        )
+        .map_err(sqlite_err)?;
+    }
+    Ok(())
+}
+
+fn collect_sqlite_rows<T>(rows: impl Iterator<Item = rusqlite::Result<T>>) -> FsResult<Vec<T>> {
+    let mut values = Vec::new();
+    for row in rows {
+        values.push(row.map_err(sqlite_err)?);
+    }
+    Ok(values)
+}
+
+fn transfer_progress_json(progress: &TransferProgress) -> FsResult<String> {
+    serde_json::to_string(progress)
+        .map_err(|_| FsError::common("Unable to encode transfer progress"))
+}
+
+fn state_list(states: &[TransferState]) -> String {
+    states
+        .iter()
+        .map(|state| (*state as i32).to_string())
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn sqlite_err(err: rusqlite::Error) -> FsError {
+    log::warn!("transfer SQLite store operation failed: {}", err);
+    FsError::transfer_store_unavailable(
+        "Transfer metadata store is unavailable; verify transfer.store_url and local disk health",
+    )
+}

--- a/curvine-server/src/transfer/sqlite_store.rs
+++ b/curvine-server/src/transfer/sqlite_store.rs
@@ -14,10 +14,9 @@
 
 use curvine_common::error::FsError;
 use curvine_common::state::{
-    summarize_transfer_tasks, StaleTaskAttempt, TaskAttemptStart, TransferCommand,
-    TransferJobRecord, TransferKind, TransferLease, TransferListFilter, TransferProgress,
-    TransferState, TransferStateUpdate, TransferTaskRecord, TransferTaskReport, TransferTaskState,
-    TransferTenantSummary,
+    StaleTaskAttempt, TaskAttemptStart, TransferCommand, TransferJobRecord, TransferKind,
+    TransferLease, TransferListFilter, TransferProgress, TransferState, TransferStateUpdate,
+    TransferTaskRecord, TransferTaskReport, TransferTaskState, TransferTenantSummary,
 };
 use curvine_common::FsResult;
 use parking_lot::Mutex;
@@ -27,7 +26,10 @@ use rusqlite::{
 use std::fs;
 use std::path::Path;
 
-use crate::transfer::{TransferRequeueUpdate, TransferStore};
+use crate::transfer::{
+    apply_task_report_progress, TransferPlannedTasks, TransferRequeueUpdate, TransferStore,
+    TransferTaskStateUpdate,
+};
 
 const TRANSFER_SCHEMA_VERSION: i64 = 2;
 
@@ -121,7 +123,7 @@ impl TransferStore for SqliteTransferStore {
     fn list_active_transfers(&self) -> FsResult<Vec<TransferJobRecord>> {
         let conn = self.conn.lock();
         let mut stmt = conn
-            .prepare(job_select_sql("where state not in (6, 7, 8)").as_str())
+            .prepare(job_select_sql("where state not in (6, 7, 8, 9)").as_str())
             .map_err(sqlite_err)?;
         let rows = stmt.query_map([], sqlite_job_row).map_err(sqlite_err)?;
         collect_sqlite_rows(rows)
@@ -145,7 +147,7 @@ impl TransferStore for SqliteTransferStore {
         self.conn
             .lock()
             .query_row(
-                "select count(*) from transfer_jobs where state not in (6, 7, 8)",
+                "select count(*) from transfer_jobs where state not in (6, 7, 8, 9)",
                 [],
                 |row| row.get::<_, i64>(0),
             )
@@ -197,6 +199,7 @@ impl TransferStore for SqliteTransferStore {
                         sum(case when state = 6 then 1 else 0 end) as completed,
                         sum(case when state = 7 then 1 else 0 end) as failed,
                         sum(case when state = 8 then 1 else 0 end) as canceled,
+                        sum(case when state = 9 then 1 else 0 end) as partial_success,
                         count(*) as total
                  from transfer_jobs
                  group by tenant
@@ -225,7 +228,7 @@ impl TransferStore for SqliteTransferStore {
             let mut stmt = tx
                 .prepare(
                     "select job_id from transfer_jobs
-                     where state in (6, 7, 8) and updated_at < ?1
+                     where state in (6, 7, 8, 9) and updated_at < ?1
                      order by updated_at asc
                      limit ?2",
                 )
@@ -244,7 +247,7 @@ impl TransferStore for SqliteTransferStore {
             )
             .map_err(sqlite_err)?;
             tx.execute(
-                "delete from transfer_jobs where job_id = ?1 and state in (6, 7, 8)",
+                "delete from transfer_jobs where job_id = ?1 and state in (6, 7, 8, 9)",
                 params![job_id],
             )
             .map_err(sqlite_err)?;
@@ -276,7 +279,7 @@ impl TransferStore for SqliteTransferStore {
         let Some(summary_json) = tx
             .query_row(
                 "select summary_json from transfer_jobs
-                 where job_id = ?1 and run_id = ?2 and state not in (6, 7, 8)",
+                 where job_id = ?1 and run_id = ?2 and state not in (6, 7, 8, 9)",
                 params![job_id, run_id as i64],
                 |row| row.get::<_, String>(0),
             )
@@ -295,7 +298,7 @@ impl TransferStore for SqliteTransferStore {
             .execute(
                 "update transfer_jobs
                  set cancel_requested = 1, state = ?3, summary_json = ?4, updated_at = ?5
-                 where job_id = ?1 and run_id = ?2 and state not in (6, 7, 8)",
+                 where job_id = ?1 and run_id = ?2 and state not in (6, 7, 8, 9)",
                 params![
                     job_id,
                     run_id as i64,
@@ -442,7 +445,7 @@ impl TransferStore for SqliteTransferStore {
                 "update transfer_jobs
                  set lease_expire_at = ?6, updated_at = ?7
                  where job_id = ?1 and run_id = ?2 and owner = ?3 and lease_epoch = ?4
-                   and state not in (6, 7, 8)",
+                   and state not in (6, 7, 8, 9) and lease_expire_at > ?7",
                 params![
                     job_id,
                     run_id as i64,
@@ -463,21 +466,31 @@ impl TransferStore for SqliteTransferStore {
             "update transfer_jobs
              set state = ?1, summary_json = ?2, updated_at = ?3
              where job_id = ?4 and run_id = ?5 and owner = ?6 and lease_epoch = ?7
-               and state in ({states})"
+               and lease_expire_at > ?3 and state in ({states})"
         );
-        let summary = transfer_progress_json(&TransferProgress {
-            message: update.message,
-            update_time: update.now_ms,
-            ..Default::default()
-        })?;
-        let affected = self
-            .conn
-            .lock()
+        let mut conn = self.conn.lock();
+        let tx = conn.transaction().map_err(sqlite_err)?;
+        let Some(job) = tx
+            .query_row(
+                job_select_sql("where job_id = ?1").as_str(),
+                params![&update.job_id],
+                sqlite_job_row,
+            )
+            .optional()
+            .map_err(sqlite_err)?
+        else {
+            tx.commit().map_err(sqlite_err)?;
+            return Ok(false);
+        };
+        let mut summary = job.summary;
+        summary.message = update.message;
+        summary.update_time = update.now_ms;
+        let affected = tx
             .execute(
                 &sql,
                 params![
                     update.to_state as i32,
-                    summary,
+                    transfer_progress_json(&summary)?,
                     update.now_ms,
                     update.job_id,
                     update.run_id as i64,
@@ -486,39 +499,7 @@ impl TransferStore for SqliteTransferStore {
                 ],
             )
             .map_err(sqlite_err)?;
-        Ok(affected > 0)
-    }
-
-    fn set_transfer_state(
-        &self,
-        job_id: &str,
-        run_id: u64,
-        state: TransferState,
-        message: impl Into<String>,
-        now_ms: i64,
-    ) -> FsResult<bool> {
-        let mut job = match self.get_transfer(job_id)? {
-            Some(job) if job.run_id == run_id => job,
-            _ => return Ok(false),
-        };
-        job.state = state;
-        job.summary.message = message.into();
-        job.summary.update_time = now_ms;
-        let affected = self
-            .conn
-            .lock()
-            .execute(
-                "update transfer_jobs set state = ?1, summary_json = ?2, updated_at = ?3
-                 where job_id = ?4 and run_id = ?5",
-                params![
-                    state as i32,
-                    transfer_progress_json(&job.summary)?,
-                    now_ms,
-                    job_id,
-                    run_id as i64
-                ],
-            )
-            .map_err(sqlite_err)?;
+        tx.commit().map_err(sqlite_err)?;
         Ok(affected > 0)
     }
 
@@ -535,7 +516,7 @@ impl TransferStore for SqliteTransferStore {
                 "update transfer_jobs
                  set state = ?1, owner = '', lease_expire_at = ?2, summary_json = ?3, updated_at = ?4
                  where job_id = ?5 and run_id = ?6 and owner = ?7 and lease_epoch = ?8
-                   and state = ?9",
+                   and lease_expire_at > ?4 and state = ?9",
                 params![
                     TransferState::Pending as i32,
                     update.next_attempt_at_ms,
@@ -568,7 +549,7 @@ impl TransferStore for SqliteTransferStore {
                 "update transfer_jobs
                  set cv_metadata_epoch = ?1, updated_at = ?2
                  where job_id = ?3 and run_id = ?4 and owner = ?5 and lease_epoch = ?6
-                   and state not in (6, 7, 8)
+                   and lease_expire_at > ?2 and state not in (6, 7, 8, 9)
                    and (cv_metadata_epoch is null or cv_metadata_epoch = ?1)",
                 params![
                     cv_metadata_epoch as i64,
@@ -593,45 +574,96 @@ impl TransferStore for SqliteTransferStore {
         Ok(())
     }
 
-    fn update_task_state(
-        &self,
-        job_id: &str,
-        run_id: u64,
-        task_id: &str,
-        state: TransferTaskState,
-        message: impl Into<String>,
-        now_ms: i64,
-    ) -> FsResult<bool> {
-        let mut progress = TransferProgress {
-            message: message.into(),
-            update_time: now_ms,
+    fn persist_planned_tasks(&self, update: TransferPlannedTasks) -> FsResult<bool> {
+        let mut conn = self.conn.lock();
+        let tx = conn.transaction().map_err(sqlite_err)?;
+        let summary = transfer_progress_json(&TransferProgress {
+            message: update.message,
+            update_time: update.now_ms,
             ..Default::default()
-        };
-        if let Some(task) = self
-            .list_transfer_tasks(job_id, run_id)?
-            .into_iter()
-            .find(|task| task.task_id == task_id)
-        {
-            progress.loaded_size = task.progress.loaded_size;
-            progress.total_size = task.progress.total_size;
-        }
-        let affected = self
-            .conn
-            .lock()
+        })?;
+        let affected = tx
             .execute(
-                "update transfer_tasks set state = ?1, progress_json = ?2, updated_at = ?3
-                 where job_id = ?4 and run_id = ?5 and task_id = ?6",
+                "update transfer_jobs
+                 set state = ?1, summary_json = ?2, updated_at = ?3
+                 where job_id = ?4 and run_id = ?5 and owner = ?6 and lease_epoch = ?7
+                   and lease_expire_at > ?3 and state = ?8",
                 params![
-                    state as i32,
-                    transfer_progress_json(&progress)?,
-                    now_ms,
-                    job_id,
-                    run_id as i64,
-                    task_id
+                    TransferState::Dispatching as i32,
+                    summary,
+                    update.now_ms,
+                    update.job_id,
+                    update.run_id as i64,
+                    update.owner,
+                    update.lease_epoch as i64,
+                    TransferState::Planning as i32,
                 ],
             )
             .map_err(sqlite_err)?;
-        Ok(affected > 0)
+        if affected == 0 {
+            tx.commit().map_err(sqlite_err)?;
+            return Ok(false);
+        }
+        for task in update.tasks {
+            insert_task(&tx, &task)?;
+        }
+        tx.commit().map_err(sqlite_err)?;
+        Ok(true)
+    }
+
+    fn update_task_state(&self, update: TransferTaskStateUpdate) -> FsResult<bool> {
+        let mut conn = self.conn.lock();
+        let tx = conn.transaction().map_err(sqlite_err)?;
+        let Some(job) = tx
+            .query_row(
+                job_select_sql("where job_id = ?1").as_str(),
+                params![&update.job_id],
+                sqlite_job_row,
+            )
+            .optional()
+            .map_err(sqlite_err)?
+        else {
+            tx.commit().map_err(sqlite_err)?;
+            return Ok(false);
+        };
+        if job.run_id != update.run_id
+            || job.owner != update.owner
+            || job.lease_epoch != update.lease_epoch
+            || job.lease_expire_at <= update.now_ms
+            || job.state.is_terminal()
+        {
+            tx.commit().map_err(sqlite_err)?;
+            return Ok(false);
+        }
+        let Some(mut task) = tx
+            .query_row(
+                "select job_id, run_id, task_id, attempt_id, source_path, target_path,
+                        worker_id, worker_session_id, source_read_plan_json, report_target_json,
+                        state, progress_json, retry_count, attempt_started_at, last_report_at,
+                        stale_deadline_at, updated_at
+                 from transfer_tasks
+                 where job_id = ?1 and run_id = ?2 and task_id = ?3",
+                params![&update.job_id, update.run_id as i64, &update.task_id],
+                sqlite_task_row,
+            )
+            .optional()
+            .map_err(sqlite_err)?
+        else {
+            tx.commit().map_err(sqlite_err)?;
+            return Ok(false);
+        };
+        if !update.from_states.is_empty() && !update.from_states.contains(&task.state) {
+            tx.commit().map_err(sqlite_err)?;
+            return Ok(false);
+        }
+
+        task.state = update.state;
+        task.progress.message = update.message;
+        task.progress.update_time = update.now_ms;
+        task.updated_at = update.now_ms;
+        update_task_record(&tx, &task)?;
+        tx.commit().map_err(sqlite_err)?;
+        Ok(true)
     }
 
     fn claim_pending_tasks(
@@ -676,8 +708,9 @@ impl TransferStore for SqliteTransferStore {
         let valid_owner: Option<i64> = tx
             .query_row(
                 "select 1 from transfer_jobs
-                 where job_id = ?1 and run_id = ?2 and owner = ?3 and lease_epoch = ?4",
-                params![job_id, run_id as i64, owner, lease_epoch as i64],
+                 where job_id = ?1 and run_id = ?2 and owner = ?3 and lease_epoch = ?4
+                   and lease_expire_at > ?5",
+                params![job_id, run_id as i64, owner, lease_epoch as i64, now_ms],
                 |row| row.get(0),
             )
             .optional()
@@ -723,10 +756,12 @@ impl TransferStore for SqliteTransferStore {
         Ok(stale)
     }
 
-    fn list_recoverable_tasks(
+    fn list_stale_running_tasks(
         &self,
         job_id: &str,
         run_id: u64,
+        stale_before_ms: i64,
+        limit: usize,
     ) -> FsResult<Vec<TransferTaskRecord>> {
         let conn = self.conn.lock();
         let mut stmt = conn
@@ -736,13 +771,46 @@ impl TransferStore for SqliteTransferStore {
                         state, progress_json, retry_count, attempt_started_at, last_report_at,
                         stale_deadline_at, updated_at
                  from transfer_tasks
-                 where job_id = ?1 and run_id = ?2 and state in (1, 2, 6)",
+                 where job_id = ?1 and run_id = ?2 and state = 2 and stale_deadline_at < ?3
+                 order by stale_deadline_at asc
+                 limit ?4",
             )
             .map_err(sqlite_err)?;
         let rows = stmt
-            .query_map(params![job_id, run_id as i64], sqlite_task_row)
+            .query_map(
+                params![job_id, run_id as i64, stale_before_ms, limit as i64],
+                sqlite_task_row,
+            )
             .map_err(sqlite_err)?;
         collect_sqlite_rows(rows)
+    }
+
+    fn has_failed_tasks(&self, job_id: &str, run_id: u64) -> FsResult<bool> {
+        self.conn
+            .lock()
+            .query_row(
+                "select exists(
+                     select 1 from transfer_tasks
+                      where job_id = ?1 and run_id = ?2 and state = ?3
+                 )",
+                params![job_id, run_id as i64, TransferTaskState::Failed as i32],
+                |row| row.get(0),
+            )
+            .map_err(sqlite_err)
+    }
+
+    fn has_recoverable_tasks(&self, job_id: &str, run_id: u64) -> FsResult<bool> {
+        self.conn
+            .lock()
+            .query_row(
+                "select exists(
+                     select 1 from transfer_tasks
+                      where job_id = ?1 and run_id = ?2 and state in (1, 2, 6)
+                 )",
+                params![job_id, run_id as i64],
+                |row| row.get(0),
+            )
+            .map_err(sqlite_err)
     }
 
     fn start_task_attempt(&self, start: TaskAttemptStart) -> FsResult<bool> {
@@ -759,7 +827,7 @@ impl TransferStore for SqliteTransferStore {
                        select 1 from transfer_jobs
                         where job_id = ?7 and run_id = ?8 and owner = ?10
                           and lease_epoch = ?11 and cancel_requested = 0
-                          and state not in (6, 7, 8)
+                          and lease_expire_at > ?5 and state not in (6, 7, 8, 9)
                    )",
                 params![
                     start.attempt_id as i64,
@@ -782,6 +850,31 @@ impl TransferStore for SqliteTransferStore {
     fn update_task_report(&self, report: TransferTaskReport) -> FsResult<bool> {
         let mut conn = self.conn.lock();
         let tx = conn.transaction().map_err(sqlite_err)?;
+        let previous = tx
+            .query_row(
+                "select job_id, run_id, task_id, attempt_id, source_path, target_path,
+                        worker_id, worker_session_id, source_read_plan_json, report_target_json,
+                        state, progress_json, retry_count, attempt_started_at, last_report_at,
+                        stale_deadline_at, updated_at
+                 from transfer_tasks
+                 where job_id = ?1 and run_id = ?2 and task_id = ?3",
+                params![report.job_id, report.run_id as i64, report.task_id],
+                sqlite_task_row,
+            )
+            .optional()
+            .map_err(sqlite_err)?;
+        let Some(previous) = previous else {
+            tx.commit().map_err(sqlite_err)?;
+            return Ok(false);
+        };
+        if previous.attempt_id != report.attempt_id
+            || previous.worker_id != report.worker_id
+            || previous.worker_session_id != report.worker_session_id
+            || !previous.state.is_running()
+        {
+            tx.commit().map_err(sqlite_err)?;
+            return Ok(false);
+        }
         let affected = tx
             .execute(
                 "update transfer_tasks
@@ -807,8 +900,32 @@ impl TransferStore for SqliteTransferStore {
             tx.commit().map_err(sqlite_err)?;
             return Ok(false);
         }
-
-        update_job_summary(&tx, &report.job_id, report.run_id, report.now_ms)?;
+        let mut job = tx
+            .query_row(
+                job_select_sql("where job_id = ?1").as_str(),
+                params![report.job_id],
+                sqlite_job_row,
+            )
+            .optional()
+            .map_err(sqlite_err)?
+            .ok_or_else(|| FsError::job_not_found(&report.job_id))?;
+        apply_task_report_progress(
+            &mut job.summary,
+            &previous.progress,
+            &report.progress,
+            report.now_ms,
+        );
+        tx.execute(
+            "update transfer_jobs set summary_json = ?1, updated_at = ?2
+             where job_id = ?3 and run_id = ?4",
+            params![
+                transfer_progress_json(&job.summary)?,
+                report.now_ms,
+                report.job_id,
+                report.run_id as i64,
+            ],
+        )
+        .map_err(sqlite_err)?;
         tx.commit().map_err(sqlite_err)?;
         Ok(true)
     }
@@ -1114,7 +1231,7 @@ fn select_non_terminal_job_by_key(
     job_key: &str,
 ) -> FsResult<Option<TransferJobRecord>> {
     conn.query_row(
-        job_select_sql("where job_key = ?1 and state not in (6, 7, 8) limit 1").as_str(),
+        job_select_sql("where job_key = ?1 and state not in (6, 7, 8, 9) limit 1").as_str(),
         params![job_key],
         sqlite_job_row,
     )
@@ -1132,7 +1249,7 @@ fn select_conflicting_active_transfer(
     let exact_or_child = conn
         .query_row(
             job_select_sql(
-                "where state not in (6, 7, 8)
+                "where state not in (6, 7, 8, 9)
                and not (submitter = ?2 and client_request_id = ?3)
                and (
                    target_path = ?1
@@ -1154,7 +1271,7 @@ fn select_conflicting_active_transfer(
         let ancestor_conflict = conn
             .query_row(
                 job_select_sql(
-                    "where state not in (6, 7, 8)
+                    "where state not in (6, 7, 8, 9)
                        and not (submitter = ?2 and client_request_id = ?3)
                        and target_path = ?1
                      limit 1",
@@ -1286,61 +1403,9 @@ fn sqlite_tenant_summary_row(row: &Row<'_>) -> rusqlite::Result<TransferTenantSu
         completed: row.get::<_, i64>(3)? as u64,
         failed: row.get::<_, i64>(4)? as u64,
         canceled: row.get::<_, i64>(5)? as u64,
-        total: row.get::<_, i64>(6)? as u64,
+        partial_success: row.get::<_, i64>(6)? as u64,
+        total: row.get::<_, i64>(7)? as u64,
     })
-}
-
-fn update_job_summary(conn: &Connection, job_id: &str, run_id: u64, now_ms: i64) -> FsResult<()> {
-    let tasks = {
-        let mut stmt = conn
-            .prepare(
-                "select job_id, run_id, task_id, attempt_id, source_path, target_path,
-                        worker_id, worker_session_id, source_read_plan_json, report_target_json,
-                        state, progress_json, retry_count, attempt_started_at, last_report_at,
-                        stale_deadline_at, updated_at
-                 from transfer_tasks where job_id = ?1 and run_id = ?2",
-            )
-            .map_err(sqlite_err)?;
-        let rows = stmt
-            .query_map(params![job_id, run_id as i64], sqlite_task_row)
-            .map_err(sqlite_err)?;
-        collect_sqlite_rows(rows)?
-    };
-    let summary = summarize_transfer_tasks(&tasks, now_ms);
-    let state = if summary.has_failed {
-        Some(TransferState::Failed)
-    } else if summary.has_task && summary.all_completed {
-        Some(TransferState::Completed)
-    } else {
-        None
-    };
-    if let Some(state) = state {
-        conn.execute(
-            "update transfer_jobs set state = ?1, summary_json = ?2, updated_at = ?3
-             where job_id = ?4 and run_id = ?5",
-            params![
-                state as i32,
-                transfer_progress_json(&summary.progress)?,
-                now_ms,
-                job_id,
-                run_id as i64
-            ],
-        )
-        .map_err(sqlite_err)?;
-    } else {
-        conn.execute(
-            "update transfer_jobs set summary_json = ?1, updated_at = ?2
-             where job_id = ?3 and run_id = ?4",
-            params![
-                transfer_progress_json(&summary.progress)?,
-                now_ms,
-                job_id,
-                run_id as i64
-            ],
-        )
-        .map_err(sqlite_err)?;
-    }
-    Ok(())
 }
 
 fn collect_sqlite_rows<T>(rows: impl Iterator<Item = rusqlite::Result<T>>) -> FsResult<Vec<T>> {

--- a/curvine-server/src/transfer/store.rs
+++ b/curvine-server/src/transfer/store.rs
@@ -14,7 +14,7 @@
 
 use curvine_common::state::{
     StaleTaskAttempt, TaskAttemptStart, TransferJobRecord, TransferLease, TransferListFilter,
-    TransferState, TransferStateUpdate, TransferTaskRecord, TransferTaskReport, TransferTaskState,
+    TransferStateUpdate, TransferTaskRecord, TransferTaskReport, TransferTaskState,
     TransferTenantSummary,
 };
 use curvine_common::FsResult;
@@ -84,15 +84,6 @@ pub trait TransferStore: Send + Sync + 'static {
 
     fn update_transfer_state(&self, update: TransferStateUpdate) -> FsResult<bool>;
 
-    fn set_transfer_state(
-        &self,
-        job_id: &str,
-        run_id: u64,
-        state: TransferState,
-        message: impl Into<String>,
-        now_ms: i64,
-    ) -> FsResult<bool>;
-
     fn requeue_transfer(&self, update: TransferRequeueUpdate) -> FsResult<bool>;
 
     fn set_transfer_cv_metadata_epoch(
@@ -107,15 +98,9 @@ pub trait TransferStore: Send + Sync + 'static {
 
     fn insert_tasks(&self, tasks: Vec<TransferTaskRecord>) -> FsResult<()>;
 
-    fn update_task_state(
-        &self,
-        job_id: &str,
-        run_id: u64,
-        task_id: &str,
-        state: TransferTaskState,
-        message: impl Into<String>,
-        now_ms: i64,
-    ) -> FsResult<bool>;
+    fn persist_planned_tasks(&self, update: TransferPlannedTasks) -> FsResult<bool>;
+
+    fn update_task_state(&self, update: TransferTaskStateUpdate) -> FsResult<bool>;
 
     fn claim_pending_tasks(
         &self,
@@ -134,11 +119,17 @@ pub trait TransferStore: Send + Sync + 'static {
         limit: usize,
     ) -> FsResult<Vec<StaleTaskAttempt>>;
 
-    fn list_recoverable_tasks(
+    fn list_stale_running_tasks(
         &self,
         job_id: &str,
         run_id: u64,
+        stale_before_ms: i64,
+        limit: usize,
     ) -> FsResult<Vec<TransferTaskRecord>>;
+
+    fn has_failed_tasks(&self, job_id: &str, run_id: u64) -> FsResult<bool>;
+
+    fn has_recoverable_tasks(&self, job_id: &str, run_id: u64) -> FsResult<bool>;
 
     fn start_task_attempt(&self, start: TaskAttemptStart) -> FsResult<bool>;
 
@@ -152,5 +143,27 @@ pub struct TransferRequeueUpdate {
     pub lease_epoch: u64,
     pub message: String,
     pub next_attempt_at_ms: i64,
+    pub now_ms: i64,
+}
+
+pub struct TransferPlannedTasks {
+    pub job_id: String,
+    pub run_id: u64,
+    pub owner: String,
+    pub lease_epoch: u64,
+    pub tasks: Vec<TransferTaskRecord>,
+    pub message: String,
+    pub now_ms: i64,
+}
+
+pub struct TransferTaskStateUpdate {
+    pub job_id: String,
+    pub run_id: u64,
+    pub owner: String,
+    pub lease_epoch: u64,
+    pub task_id: String,
+    pub from_states: Vec<TransferTaskState>,
+    pub state: TransferTaskState,
+    pub message: String,
     pub now_ms: i64,
 }

--- a/curvine-server/src/transfer/store.rs
+++ b/curvine-server/src/transfer/store.rs
@@ -1,0 +1,156 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use curvine_common::state::{
+    StaleTaskAttempt, TaskAttemptStart, TransferJobRecord, TransferLease, TransferListFilter,
+    TransferState, TransferStateUpdate, TransferTaskRecord, TransferTaskReport, TransferTaskState,
+    TransferTenantSummary,
+};
+use curvine_common::FsResult;
+
+pub trait TransferStore: Send + Sync + 'static {
+    fn check_available(&self) -> FsResult<()>;
+
+    fn create_or_get_by_request_id(&self, job: TransferJobRecord) -> FsResult<TransferJobRecord>;
+
+    fn create_or_get_by_request_id_checked(
+        &self,
+        job: TransferJobRecord,
+    ) -> FsResult<TransferJobRecord>;
+
+    fn get_transfer(&self, job_id: &str) -> FsResult<Option<TransferJobRecord>>;
+
+    fn get_transfer_by_request(
+        &self,
+        submitter: &str,
+        client_request_id: &str,
+    ) -> FsResult<Option<TransferJobRecord>>;
+
+    fn list_active_transfers(&self) -> FsResult<Vec<TransferJobRecord>>;
+
+    fn find_conflicting_active_transfer(
+        &self,
+        target_path: &str,
+        submitter: &str,
+        client_request_id: &str,
+    ) -> FsResult<Option<TransferJobRecord>>;
+
+    fn count_active_transfers(&self) -> FsResult<u64>;
+
+    fn count_executing_transfers(&self) -> FsResult<u64>;
+
+    fn list_transfers(&self, filter: TransferListFilter) -> FsResult<Vec<TransferJobRecord>>;
+
+    fn list_tenant_summaries(
+        &self,
+        limit: usize,
+        offset: usize,
+    ) -> FsResult<Vec<TransferTenantSummary>>;
+
+    fn purge_terminal_transfers(&self, older_than_ms: i64, limit: usize) -> FsResult<usize>;
+
+    fn list_transfer_tasks(&self, job_id: &str, run_id: u64) -> FsResult<Vec<TransferTaskRecord>>;
+
+    fn request_cancel(&self, job_id: &str, run_id: u64, now_ms: i64) -> FsResult<bool>;
+
+    fn acquire_runnable_transfer(
+        &self,
+        owner: &str,
+        lease_ms: i64,
+        now_ms: i64,
+        max_executing_transfers: u64,
+    ) -> FsResult<Option<TransferLease>>;
+
+    fn renew_lease(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        owner: &str,
+        lease_epoch: u64,
+        lease_ms: i64,
+        now_ms: i64,
+    ) -> FsResult<bool>;
+
+    fn update_transfer_state(&self, update: TransferStateUpdate) -> FsResult<bool>;
+
+    fn set_transfer_state(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        state: TransferState,
+        message: impl Into<String>,
+        now_ms: i64,
+    ) -> FsResult<bool>;
+
+    fn requeue_transfer(&self, update: TransferRequeueUpdate) -> FsResult<bool>;
+
+    fn set_transfer_cv_metadata_epoch(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        owner: &str,
+        lease_epoch: u64,
+        cv_metadata_epoch: u64,
+        now_ms: i64,
+    ) -> FsResult<bool>;
+
+    fn insert_tasks(&self, tasks: Vec<TransferTaskRecord>) -> FsResult<()>;
+
+    fn update_task_state(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        task_id: &str,
+        state: TransferTaskState,
+        message: impl Into<String>,
+        now_ms: i64,
+    ) -> FsResult<bool>;
+
+    fn claim_pending_tasks(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        limit: usize,
+    ) -> FsResult<Vec<TransferTaskRecord>>;
+
+    fn mark_stale_attempts(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        owner: &str,
+        lease_epoch: u64,
+        now_ms: i64,
+        limit: usize,
+    ) -> FsResult<Vec<StaleTaskAttempt>>;
+
+    fn list_recoverable_tasks(
+        &self,
+        job_id: &str,
+        run_id: u64,
+    ) -> FsResult<Vec<TransferTaskRecord>>;
+
+    fn start_task_attempt(&self, start: TaskAttemptStart) -> FsResult<bool>;
+
+    fn update_task_report(&self, report: TransferTaskReport) -> FsResult<bool>;
+}
+
+pub struct TransferRequeueUpdate {
+    pub job_id: String,
+    pub run_id: u64,
+    pub owner: String,
+    pub lease_epoch: u64,
+    pub message: String,
+    pub next_attempt_at_ms: i64,
+    pub now_ms: i64,
+}

--- a/curvine-server/src/transfer/transfer_server.rs
+++ b/curvine-server/src/transfer/transfer_server.rs
@@ -1,0 +1,284 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::common::UfsFactory;
+use curvine_client::file::CurvineFileSystem;
+use curvine_common::conf::{ClusterConf, TransferCvMetadataReaderType, TransferStoreType};
+use curvine_common::error::FsError;
+use curvine_web::server::{WebHandlerService, WebServer};
+use log::info;
+use orpc::common::Logger;
+use orpc::handler::HandlerService;
+use orpc::io::net::ConnState;
+use orpc::runtime::RpcRuntime;
+use orpc::server::{RpcServer, ServerShutdownHandle, ServerStateListener};
+use orpc::CommonResult;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use crate::transfer::{
+    ClusterMetadataCache, CvMetadataReader, DisabledCvMetadataReader, MasterCvMetadataReader,
+    MemoryTransferStore, MetadataReplicaReader, MysqlTransferStore, SqliteTransferStore,
+    TransferHandler, TransferMetrics, TransferPlanner, TransferRouterHandler, TransferScheduler,
+    TransferService, TransferStoreBackend,
+};
+
+#[derive(Clone)]
+pub struct TransferRpcService {
+    service: TransferService<TransferStoreBackend>,
+    ready: Arc<AtomicBool>,
+    store_backend: &'static str,
+    cluster_cache: ClusterMetadataCache,
+    cv_metadata: Option<Arc<dyn CvMetadataReader>>,
+}
+
+impl TransferRpcService {
+    fn new(
+        service: TransferService<TransferStoreBackend>,
+        ready: Arc<AtomicBool>,
+        store_backend: &'static str,
+        cluster_cache: ClusterMetadataCache,
+        cv_metadata: Option<Arc<dyn CvMetadataReader>>,
+    ) -> Self {
+        Self {
+            service,
+            ready,
+            store_backend,
+            cluster_cache,
+            cv_metadata,
+        }
+    }
+}
+
+impl HandlerService for TransferRpcService {
+    type Item = TransferHandler<TransferStoreBackend>;
+
+    fn get_message_handler(&self, _: Option<ConnState>) -> Self::Item {
+        TransferHandler::new(self.service.clone())
+    }
+}
+
+impl WebHandlerService for TransferRpcService {
+    type Item = TransferRouterHandler;
+
+    fn get_handler(&self) -> Self::Item {
+        TransferRouterHandler::new(
+            self.ready.clone(),
+            self.store_backend,
+            self.service.clone(),
+            self.cluster_cache.clone(),
+            self.cv_metadata.clone(),
+        )
+    }
+}
+
+pub struct TransferServer {
+    rpc_server: RpcServer<TransferRpcService>,
+    web_server: WebServer<TransferRpcService>,
+    cluster_cache: ClusterMetadataCache,
+    scheduler: TransferScheduler<TransferStoreBackend>,
+    metadata_replica: Option<(MetadataReplicaReader, std::time::Duration)>,
+    ready: Arc<AtomicBool>,
+    shutdown: TransferServerShutdown,
+}
+
+#[derive(Clone)]
+pub struct TransferServerShutdown {
+    stop: Arc<AtomicBool>,
+    rpc: ServerShutdownHandle,
+    web: ServerShutdownHandle,
+}
+
+impl TransferServerShutdown {
+    pub fn shutdown(&self) {
+        self.stop.store(true, Ordering::Relaxed);
+        self.web.shutdown();
+        self.rpc.shutdown();
+    }
+}
+
+impl TransferServer {
+    pub fn with_conf(conf: ClusterConf) -> CommonResult<Self> {
+        if !conf.transfer.enabled {
+            return Err(FsError::common("curvine-transfer requires transfer.enabled=true").into());
+        }
+        if conf.transfer.endpoints.is_empty() {
+            return Err(FsError::common(
+                "curvine-transfer requires transfer.endpoints to route worker task reports",
+            )
+            .into());
+        }
+        Logger::init(conf.master.log.clone());
+        let _ = TransferMetrics::get()?;
+        conf.print();
+
+        let rt = Arc::new(conf.transfer_server_conf().create_runtime());
+        let stop = Arc::new(AtomicBool::new(false));
+        let store = Arc::new(match conf.transfer.effective_store_type() {
+            TransferStoreType::Auto => unreachable!("resolved transfer store type cannot be auto"),
+            TransferStoreType::Memory => TransferStoreBackend::Memory(MemoryTransferStore::new()),
+            TransferStoreType::Sqlite => TransferStoreBackend::Sqlite(SqliteTransferStore::open(
+                conf.transfer.sqlite_store_path(),
+            )?),
+            TransferStoreType::Mysql => TransferStoreBackend::Mysql(MysqlTransferStore::open(
+                conf.transfer.mysql_store_url(),
+            )?),
+        });
+        let store_backend = store.backend_label();
+        let fs = CurvineFileSystem::with_rt(conf.clone(), rt.clone())?;
+        let factory = Arc::new(UfsFactory::with_rt(&conf.client, rt.clone()));
+        let cache = ClusterMetadataCache::with_snapshot_policy(
+            fs.clone(),
+            conf.transfer.cluster_snapshot_max_staleness,
+            conf.transfer.allow_submit_with_stale_snapshot,
+        );
+        cache.clone().start_refresh_loop(
+            Duration::from_millis(conf.client.mount_update_ttl_ms),
+            stop.clone(),
+        );
+        let mut metadata_replica = None;
+        let cv_metadata: Arc<dyn CvMetadataReader> =
+            match conf.transfer.effective_cv_metadata_reader() {
+                TransferCvMetadataReaderType::Auto => {
+                    unreachable!("resolved CV metadata reader cannot be auto")
+                }
+                TransferCvMetadataReaderType::Disabled => Arc::new(DisabledCvMetadataReader),
+                TransferCvMetadataReaderType::Master => Arc::new(MasterCvMetadataReader::new(fs)),
+                TransferCvMetadataReaderType::Replica => {
+                    let reader = MetadataReplicaReader::new(
+                        fs.clone(),
+                        conf.transfer.metadata_replica_max_entries,
+                        conf.transfer.metadata_replica_page_size(),
+                        conf.transfer.metadata_replica_history_size(),
+                        conf.transfer.metadata_replica_max_staleness,
+                    );
+                    metadata_replica = Some((
+                        reader.clone(),
+                        conf.transfer.metadata_replica_refresh_interval,
+                    ));
+                    Arc::new(reader)
+                }
+            };
+
+        let owner = if conf.transfer.instance_id.is_empty() {
+            uuid::Uuid::new_v4().to_string()
+        } else {
+            conf.transfer.instance_id.clone()
+        };
+        let report_target =
+            conf.transfer.endpoints.first().cloned().unwrap_or_else(|| {
+                format!("{}:{}", conf.transfer.hostname, conf.transfer.rpc_port)
+            });
+        let planner = TransferPlanner::new(
+            cv_metadata.clone(),
+            factory.clone(),
+            cache.clone(),
+            conf.client.clone(),
+            conf.transfer.max_tasks_per_transfer,
+            conf.transfer.ufs_max_concurrency_per_endpoint,
+        );
+        let scheduler = TransferScheduler::new(
+            store.clone(),
+            planner,
+            cache.clone(),
+            factory,
+            owner,
+            report_target,
+            conf.transfer.clone(),
+        );
+
+        let ready = Arc::new(AtomicBool::new(false));
+        let service = TransferRpcService::new(
+            TransferService::with_cache_and_report_queue(
+                store,
+                cache.clone(),
+                conf.transfer.task_stale_timeout,
+                conf.transfer.task_report_queue_size(),
+                conf.transfer.worker_threads,
+            )?,
+            ready.clone(),
+            store_backend,
+            cache.clone(),
+            Some(cv_metadata.clone()),
+        );
+        let rpc_server =
+            RpcServer::with_rt(rt.clone(), conf.transfer_server_conf(), service.clone());
+        let web_server = WebServer::with_rt(rt, conf.transfer_web_conf(), service);
+        let shutdown = TransferServerShutdown {
+            stop,
+            rpc: rpc_server.shutdown_handle(),
+            web: web_server.shutdown_handle(),
+        };
+        let shutdown_on_rpc_stop = shutdown.clone();
+        rpc_server.add_shutdown_hook(move || {
+            shutdown_on_rpc_stop.shutdown();
+        });
+        Ok(Self {
+            rpc_server,
+            web_server,
+            cluster_cache: cache,
+            scheduler,
+            metadata_replica,
+            ready,
+            shutdown,
+        })
+    }
+
+    pub fn shutdown_handle(&self) -> TransferServerShutdown {
+        self.shutdown.clone()
+    }
+
+    pub async fn start(self) -> CommonResult<ServerStateListener> {
+        let shutdown = self.shutdown.clone();
+        let ready = self.ready.clone();
+        let web_name = self.web_server.server_name().to_string();
+        let bind_addr = self.web_server.resolve_bind_addr();
+        let mut web_status = self.web_server.start();
+        WebServer::<TransferRpcService>::wait_bind(&mut web_status, &web_name, &bind_addr).await?;
+
+        let result = async {
+            self.cluster_cache.refresh().await?;
+            if let Some((reader, refresh_interval)) = &self.metadata_replica {
+                reader.refresh().await?;
+                reader.start_refresh_loop(*refresh_interval, self.shutdown.stop.clone());
+            }
+            self.scheduler
+                .start(self.rpc_server.clone_rt(), self.shutdown.stop.clone());
+            info!("Starting curvine-transfer rpc server");
+            let mut rpc_status = self.rpc_server.start();
+            rpc_status.wait_running().await?;
+            ready.store(true, Ordering::Relaxed);
+            Ok(rpc_status)
+        }
+        .await;
+
+        if result.is_err() {
+            shutdown.shutdown();
+        }
+        result
+    }
+
+    pub fn block_on_start(self) -> CommonResult<()> {
+        let rt = self.rpc_server.clone_rt();
+        rt.block_on(async move {
+            let mut status = self.start().await?;
+            if let Err(err) = status.wait_stop().await {
+                log::warn!("curvine-transfer wait stop failed: {}", err);
+            }
+            Ok(())
+        })
+    }
+}

--- a/curvine-server/src/transfer/transfer_server.rs
+++ b/curvine-server/src/transfer/transfer_server.rs
@@ -178,10 +178,6 @@ impl TransferServer {
         } else {
             conf.transfer.instance_id.clone()
         };
-        let report_target =
-            conf.transfer.endpoints.first().cloned().unwrap_or_else(|| {
-                format!("{}:{}", conf.transfer.hostname, conf.transfer.rpc_port)
-            });
         let planner = TransferPlanner::new(
             cv_metadata.clone(),
             factory.clone(),
@@ -196,7 +192,7 @@ impl TransferServer {
             cache.clone(),
             factory,
             owner,
-            report_target,
+            conf.transfer.endpoints.clone(),
             conf.transfer.clone(),
         );
 

--- a/curvine-server/src/worker/block/block_actor.rs
+++ b/curvine-server/src/worker/block/block_actor.rs
@@ -51,6 +51,7 @@ impl BlockActor {
         rt: Arc<Runtime>,
         conf: &ClusterConf,
         worker_addr: WorkerAddress,
+        worker_session_id: String,
         store: BlockStore,
         worker_ctl: StateCtl,
     ) -> CommonResult<BlockActor> {
@@ -62,6 +63,7 @@ impl BlockActor {
             store.worker_id()?,
             worker_addr,
             conf.worker.weight,
+            worker_session_id,
         );
         let executor = GroupExecutor::new(
             "worker-block-executor",

--- a/curvine-server/src/worker/block/master_client.rs
+++ b/curvine-server/src/worker/block/master_client.rs
@@ -16,7 +16,9 @@ use crate::worker::block::{BlockMeta, BlockState};
 use curvine_client::file::{FsClient, FsContext};
 use curvine_common::fs::RpcCode;
 use curvine_common::proto::*;
-use curvine_common::state::{BlockReportInfo, HeartbeatStatus, StorageInfo, WorkerAddress};
+use curvine_common::state::{
+    BlockReportInfo, HeartbeatStatus, StorageInfo, TransferWorkerCapabilities, WorkerAddress,
+};
 use curvine_common::utils::ProtoUtils;
 use orpc::CommonResult;
 use std::sync::Arc;
@@ -31,6 +33,7 @@ pub struct MasterClient {
     pub(crate) worker_id: u32,
     pub(crate) worker_addr: WorkerAddress,
     pub(crate) worker_weight: u32,
+    pub(crate) worker_session_id: String,
 }
 
 impl MasterClient {
@@ -40,6 +43,7 @@ impl MasterClient {
         worker_id: u32,
         worker_addr: WorkerAddress,
         worker_weight: u32,
+        worker_session_id: impl Into<String>,
     ) -> Self {
         // Directly reused file system client service.
         let fs_client = FsClient::new(context);
@@ -49,6 +53,7 @@ impl MasterClient {
             worker_id,
             worker_addr,
             worker_weight,
+            worker_session_id: worker_session_id.into(),
         }
     }
 
@@ -58,12 +63,19 @@ impl MasterClient {
         status: HeartbeatStatus,
         storages: Vec<StorageInfo>,
     ) -> CommonResult<WorkerHeartbeatResponse> {
+        let transfer_capabilities = TransferWorkerCapabilities::current();
         let mut req = WorkerHeartbeatRequest {
             status: status.into(),
             cluster_id: self.cluster_id.clone(),
             worker_id: self.worker_id,
             address: ProtoUtils::worker_address_to_pb(&self.worker_addr),
             weight: Some(self.worker_weight),
+            worker_session_id: Some(self.worker_session_id.clone()),
+            transfer_task_submit: Some(transfer_capabilities.task_submit),
+            transfer_report_target: Some(transfer_capabilities.report_target),
+            transfer_query_task: Some(transfer_capabilities.query_task),
+            transfer_attempt_safe_output: Some(transfer_capabilities.attempt_safe_output),
+            transfer_source_read_plan: Some(transfer_capabilities.source_read_plan),
             ..Default::default()
         };
         for item in storages {

--- a/curvine-server/src/worker/handler/worker_handler.rs
+++ b/curvine-server/src/worker/handler/worker_handler.rs
@@ -57,6 +57,8 @@ impl MessageHandler for WorkerHandler {
         match code {
             RpcCode::SubmitTask => self.task_submit(msg),
 
+            RpcCode::QueryTransferTask => self.query_transfer_task(msg),
+
             RpcCode::CancelJob => self.cancel_job(msg),
 
             RpcCode::SubmitBlockReplicationJob => self.replication_handler.handle(msg),
@@ -125,8 +127,12 @@ impl WorkerHandler {
         let task: LoadTaskInfo = SerdeUtils::deserialize(&req.task_command)?;
         let task_id = task.task_id.clone();
 
-        self.task_manager.submit_task(task)?;
-        let response = SubmitTaskResponse { task_id };
+        let submit = self.task_manager.submit_task(task)?;
+        let response = SubmitTaskResponse {
+            task_id,
+            accepted: Some(submit.accepted),
+            reject_reason: Some(submit.reject_reason),
+        };
 
         Ok(Builder::success(msg).proto_header(response).build())
     }
@@ -135,5 +141,61 @@ impl WorkerHandler {
         let req: CancelJobRequest = msg.parse_header()?;
         self.task_manager.cancel_job(req.job_id)?;
         Ok(msg.success())
+    }
+
+    pub fn query_transfer_task(&self, msg: &Message) -> FsResult<Message> {
+        let req: QueryTransferTaskRequest = msg.parse_header()?;
+        let progress = self.task_manager.query_transfer_task(
+            &req.job_id,
+            &req.task_id,
+            req.run_id,
+            req.attempt_id,
+            &req.worker_session_id,
+        )?;
+
+        let response = match progress {
+            Some(progress) => QueryTransferTaskResponse {
+                found: true,
+                state: transfer_task_state_code(progress.state),
+                progress: TransferProgressProto {
+                    loaded_size: progress.loaded_size,
+                    total_size: progress.total_size,
+                    update_time: progress.update_time,
+                    message: progress.message,
+                },
+            },
+            None => QueryTransferTaskResponse {
+                found: false,
+                state: TransferTaskStateProto::TransferTaskFailed.into(),
+                progress: TransferProgressProto {
+                    loaded_size: 0,
+                    total_size: 0,
+                    update_time: 0,
+                    message: String::new(),
+                },
+            },
+        };
+        Ok(Builder::success(msg).proto_header(response).build())
+    }
+}
+
+fn transfer_task_state_code(state: curvine_common::state::JobTaskState) -> i32 {
+    match state {
+        curvine_common::state::JobTaskState::Pending
+        | curvine_common::state::JobTaskState::UNKNOWN => {
+            TransferTaskStateProto::TransferTaskPending.into()
+        }
+        curvine_common::state::JobTaskState::Loading => {
+            TransferTaskStateProto::TransferTaskRunning.into()
+        }
+        curvine_common::state::JobTaskState::Completed => {
+            TransferTaskStateProto::TransferTaskCompleted.into()
+        }
+        curvine_common::state::JobTaskState::Failed => {
+            TransferTaskStateProto::TransferTaskFailed.into()
+        }
+        curvine_common::state::JobTaskState::Canceled => {
+            TransferTaskStateProto::TransferTaskCanceled.into()
+        }
     }
 }

--- a/curvine-server/src/worker/task/load_task_runner.rs
+++ b/curvine-server/src/worker/task/load_task_runner.rs
@@ -71,15 +71,26 @@ impl LoadTaskRunner {
     ) -> Self {
         let master_client = JobMasterClient::new(fs.fs_client());
         let transfer_client = match task.info.transfer_report.as_ref() {
-            Some(report) if report.report_target.is_empty() => transfer_client,
+            Some(report)
+                if report.report_endpoints.is_empty() && report.report_target.is_empty() =>
+            {
+                transfer_client
+            }
             Some(report) => {
-                match TransferClient::with_endpoint(&fs.fs_context(), report.report_target.clone())
-                {
+                let report_endpoints = if report.report_endpoints.is_empty() {
+                    vec![report.report_target.clone()]
+                } else {
+                    report.report_endpoints.clone()
+                };
+                match TransferClient::with_report_endpoints(
+                    &fs.fs_context(),
+                    report_endpoints.clone(),
+                ) {
                     Ok(client) => Some(client),
                     Err(err) => {
                         warn!(
-                            "transfer task {} has invalid report target {}: {}",
-                            task.info.task_id, report.report_target, err
+                            "transfer task {} has invalid report endpoints {:?}: {}",
+                            task.info.task_id, report_endpoints, err
                         );
                         None
                     }
@@ -532,10 +543,15 @@ impl LoadTaskRunner {
         let task = &self.task.info;
         if let Some(report_info) = &task.transfer_report {
             let Some(client) = &self.transfer_client else {
+                let report_endpoints = if report_info.report_endpoints.is_empty() {
+                    vec![report_info.report_target.clone()]
+                } else {
+                    report_info.report_endpoints.clone()
+                };
                 return err_box!(
-                    "Transfer task {} has no transfer client for report target {}",
+                    "Transfer task {} has no transfer client for report endpoints {:?}",
                     task.task_id,
-                    report_info.report_target
+                    report_endpoints
                 );
             };
             let accepted = tokio::time::timeout(

--- a/curvine-server/src/worker/task/load_task_runner.rs
+++ b/curvine-server/src/worker/task/load_task_runner.rs
@@ -13,30 +13,51 @@
 // limitations under the License.
 
 use crate::common::UfsFactory;
+use crate::transfer::transfer_failure_message;
 use crate::worker::task::TaskContext;
-use curvine_client::file::CurvineFileSystem;
+use curvine_client::file::{CurvineFileSystem, FsReader};
 use curvine_client::rpc::JobMasterClient;
+use curvine_client::rpc::TransferClient;
 use curvine_client::unified::{UfsFileSystem, UnifiedReader, UnifiedWriter};
 use curvine_common::error::FsError;
 use curvine_common::fs::{FileSystem, Path, Reader, Writer};
 use curvine_common::state::{
-    CreateFileOptsBuilder, FileAllocOpts, JobTaskState, SetAttrOptsBuilder,
+    CreateFileOptsBuilder, FileBlocks, FileStatus, JobTaskProgress, JobTaskState,
+    SetAttrOptsBuilder, TRANSFER_TEMP_PATH_MARKER,
 };
 use curvine_common::FsResult;
 use log::{error, info, warn};
 use orpc::common::{LocalTime, TimeSpent};
 use orpc::err_box;
-use orpc::runtime::RpcRuntime;
-use orpc::sys::DataSlice;
 use std::sync::Arc;
+use std::time::Duration;
+
+const TRANSFER_REPORT_TIMEOUT_MS: u64 = 5_000;
+const TRANSFER_COMMIT_JOB_ID_XATTR: &str = "curvine.transfer.job_id";
+const TRANSFER_COMMIT_RUN_ID_XATTR: &str = "curvine.transfer.run_id";
+const TRANSFER_COMMIT_TASK_ID_XATTR: &str = "curvine.transfer.task_id";
+const TRANSFER_COMMIT_SOURCE_PATH_XATTR: &str = "curvine.transfer.source_path";
 
 pub struct LoadTaskRunner {
     task: Arc<TaskContext>,
     fs: CurvineFileSystem,
     factory: Arc<UfsFactory>,
     master_client: JobMasterClient,
+    transfer_client: Option<TransferClient>,
     progress_interval_ms: u64,
     task_timeout_ms: u64,
+}
+
+struct CopyStream {
+    reader: UnifiedReader,
+    writer: UnifiedWriter,
+    final_path: Path,
+    temp_path: Option<Path>,
+}
+
+enum CommitTarget {
+    RenameTemp,
+    AlreadyCommitted,
 }
 
 impl LoadTaskRunner {
@@ -44,15 +65,34 @@ impl LoadTaskRunner {
         task: Arc<TaskContext>,
         fs: CurvineFileSystem,
         factory: Arc<UfsFactory>,
+        transfer_client: Option<TransferClient>,
         progress_interval_ms: u64,
         task_timeout_ms: u64,
     ) -> Self {
         let master_client = JobMasterClient::new(fs.fs_client());
+        let transfer_client = match task.info.transfer_report.as_ref() {
+            Some(report) if report.report_target.is_empty() => transfer_client,
+            Some(report) => {
+                match TransferClient::with_endpoint(&fs.fs_context(), report.report_target.clone())
+                {
+                    Ok(client) => Some(client),
+                    Err(err) => {
+                        warn!(
+                            "transfer task {} has invalid report target {}: {}",
+                            task.info.task_id, report.report_target, err
+                        );
+                        None
+                    }
+                }
+            }
+            None => transfer_client,
+        };
         Self {
             task,
             fs,
             factory,
             master_client,
+            transfer_client,
             progress_interval_ms,
             task_timeout_ms,
         }
@@ -62,108 +102,149 @@ impl LoadTaskRunner {
         self.factory.get_ufs(&self.task.info.job.mount_info)
     }
 
-    pub async fn run(&self) {
-        if let Err(e) = self.run0().await {
-            // The data replication process fails, set the status and report to the master
-            error!("task {} execute failed: {}", self.task.info.task_id, e);
-            let progress = self.task.set_failed(e.to_string());
-            let res = self
-                .master_client
-                .report_task(
-                    self.task.info.job.job_id.clone(),
-                    self.task.info.task_id.clone(),
-                    progress,
-                )
-                .await;
+    pub async fn run(&self) -> bool {
+        match self.run0().await {
+            Ok(remove_task) => remove_task,
+            Err(e) => {
+                // The data replication process fails, set the status and report to the master
+                error!("task {} execute failed: {}", self.task.info.task_id, e);
+                let progress = self.task.set_failed(transfer_failure_message(
+                    match Path::from_str(&self.task.info.source_path) {
+                        Ok(source) if source.is_cv() => curvine_common::state::TransferKind::Export,
+                        _ => curvine_common::state::TransferKind::Load,
+                    },
+                    &self.task.info.source_path,
+                    &self.task.info.target_path,
+                    &e,
+                ));
+                let res = self.report_progress(progress).await;
 
-            if let Err(e) = res {
-                warn!("report task {}", e)
+                if let Err(e) = res {
+                    warn!("report task {}", e);
+                    return self.task.info.transfer_report.is_none();
+                }
+                true
             }
-        }
-
-        crate::fault_point! {
-            async,
-            name: "worker.load_task.after_run",
-            description: "After a worker load task runner has fully exited",
-            context: {
-                "task_id" => self.task.info.task_id.clone(),
-            },
         }
     }
 
-    async fn run0(&self) -> FsResult<()> {
+    async fn run0(&self) -> FsResult<bool> {
         if self.task.is_cancel() {
-            info!("task {} was cancelled", self.task.info.task_id);
-            return Ok(());
+            info!(
+                "task {} was cancelled before starting",
+                self.task.info.task_id
+            );
+            return Ok(true);
         }
+
         self.task
             .update_state(JobTaskState::Loading, "Task started");
 
-        // Fast path: UFS(e.g. S3) -> Curvine of a large file. A single OpenDAL
-        // reader does not scale by cranking its internal `.concurrent(N)`
-        // prefetch alone -- that knob only hides single-connection latency (a
-        // small value like 2 is enough to saturate one connection); pushing it
-        // higher plateaus because one reader still commits through one writer.
-        // The way to scale is N *independent* streams, each an independent reader
-        // pulling a disjoint byte range into its own writer, which scale
-        // near-linearly (measured on BOS S3, single node: 8 streams ~1.36 GB/s
-        // vs ~215 MB/s single stream, ~6x). So for a big UFS->CV load we fan out
-        // into N independent readers writing to N contiguous regions, instead of
-        // one serial stream.
-        let source_path = Path::from_str(&self.task.info.source_path)?;
-        let target_path = Path::from_str(&self.task.info.target_path)?;
-        if !source_path.is_cv() && target_path.is_cv() && self.max_parallel_streams() > 1 {
-            // Probe source length cheaply, then let effective_streams() decide
-            // the fan-out width from file size. A small file yields 1 stream, so
-            // we fall through to the serial path below.
-            let src_len = self.get_ufs()?.get_status(&source_path).await?.len;
-            if self.effective_streams(src_len) > 1 {
-                return self.run_parallel(&source_path, &target_path, src_len).await;
-            }
-        }
-
-        let (mut reader, mut writer) = self.create_stream().await?;
+        let mut stream = self.create_stream().await?;
         if self.task.is_cancel() {
             info!("task {} was cancelled", self.task.info.task_id);
-            return Ok(());
+            return self.cancel_stream(&mut stream).await;
         }
+        let Some((copied_bytes, reader_len, read_cost_ms, total_cost_ms)) =
+            (match self.copy_and_commit_stream(&mut stream).await {
+                Ok(result) => result,
+                Err(err) => {
+                    self.cleanup_failed_stream(&stream).await;
+                    return Err(err);
+                }
+            })
+        else {
+            return Ok(true);
+        };
+
+        let (cv_path, ufs_mtime) = if stream.final_path.is_cv() {
+            // ufs -> cv
+            (&stream.final_path, stream.reader.status().mtime)
+        } else {
+            // cv -> ufs
+            let ufs_status = self.get_ufs()?.get_status(&stream.final_path).await?;
+            (stream.reader.path(), ufs_status.mtime)
+        };
+
+        let mut attr_builder = SetAttrOptsBuilder::new().ufs_mtime(ufs_mtime);
+        if stream.final_path.is_cv() {
+            if let Some(report) = &self.task.info.transfer_report {
+                attr_builder = attr_builder
+                    .add_x_attr(
+                        TRANSFER_COMMIT_JOB_ID_XATTR,
+                        self.task.info.job.job_id.as_bytes().to_vec(),
+                    )
+                    .add_x_attr(
+                        TRANSFER_COMMIT_RUN_ID_XATTR,
+                        report.run_id.to_string().into_bytes(),
+                    )
+                    .add_x_attr(
+                        TRANSFER_COMMIT_TASK_ID_XATTR,
+                        self.task.info.task_id.as_bytes().to_vec(),
+                    )
+                    .add_x_attr(
+                        TRANSFER_COMMIT_SOURCE_PATH_XATTR,
+                        self.task.info.source_path.as_bytes().to_vec(),
+                    );
+            }
+        }
+        let attr_opts = attr_builder.build();
+        self.fs.set_attr(cv_path, attr_opts).await?;
+
+        if let Err(err) = self.update_progress0(copied_bytes, reader_len, true).await {
+            if self.task.info.transfer_report.is_some() {
+                warn!(
+                    "final transfer task report failed, keep task for scheduler probe: job={}, task={}, err={}",
+                    self.task.info.job.job_id, self.task.info.task_id, err
+                );
+                return Ok(false);
+            }
+            return Err(err);
+        }
+
+        info!(
+            "task {} completed, source_path {}, target_path {}, ufs_mtime:{}, copy bytes {}, read cost {} ms, task cost {} ms",
+            self.task.info.task_id,
+            self.task.info.source_path,
+            self.task.info.target_path,
+            ufs_mtime,
+            copied_bytes,
+            read_cost_ms,
+            total_cost_ms,
+        );
+
+        Ok(true)
+    }
+
+    async fn copy_and_commit_stream(
+        &self,
+        stream: &mut CopyStream,
+    ) -> FsResult<Option<(i64, i64, u64, u64)>> {
         let mut last_progress_time = LocalTime::mills();
         let mut read_cost_ms = 0;
         let mut total_cost_ms = 0;
 
-        // Pipelined copy: overlap "read next chunk from source" with "write the
-        // previously-read chunk to the target". The serial version read and wrote
-        // strictly alternately, so a slow high-latency source (e.g. S3 over a
-        // single connection) idled the writer and vice versa, capping throughput
-        // at ~1/(1/read + 1/write). By prefetching the next chunk concurrently
-        // with the current write via try_join!, effective throughput approaches
-        // max(read, write) instead of their harmonic-style sum. This needs no
-        // extra task/thread: both futures are polled on the same task.
-        let mut pending = reader.async_read(None).await?;
-
         loop {
             if self.task.is_cancel() {
                 info!("task {} was cancelled", self.task.info.task_id);
-                return Ok(());
-            }
-
-            if pending.is_empty() {
-                break;
+                self.cancel_stream(stream).await?;
+                return Ok(None);
             }
 
             let spend = TimeSpent::new();
-            // Read the next chunk while writing the current one.
-            let (next, ()) = tokio::try_join!(
-                reader.async_read(None),
-                writer.async_write(std::mem::replace(&mut pending, DataSlice::Empty)),
-            )?;
+            let chunk = stream.reader.async_read(None).await?;
             read_cost_ms += spend.used_ms();
+
+            if chunk.is_empty() {
+                break;
+            }
+
+            stream.writer.async_write(chunk).await?;
             total_cost_ms += spend.used_ms();
-            pending = next;
 
             if LocalTime::mills() > last_progress_time + self.progress_interval_ms {
                 last_progress_time = LocalTime::mills();
-                self.update_progress(writer.pos(), reader.len(), false)
+                self.update_progress(stream.writer.pos(), stream.reader.len(), false)
                     .await;
             }
 
@@ -176,375 +257,214 @@ impl LoadTaskRunner {
             }
         }
 
-        writer.complete().await?;
-        reader.complete().await?;
-
-        let (cv_path, ufs_mtime) = if writer.path().is_cv() {
-            // ufs -> cv
-            (writer.path(), reader.status().mtime)
-        } else {
-            // cv -> ufs
-            let ufs_status = self.get_ufs()?.get_status(writer.path()).await?;
-            (reader.path(), ufs_status.mtime)
-        };
-
-        let attr_opts = SetAttrOptsBuilder::new().ufs_mtime(ufs_mtime).build();
-        self.fs.set_attr(cv_path, attr_opts).await?;
-
-        self.update_progress(writer.pos(), reader.len(), true).await;
-
-        info!(
-            "task {} completed, source_path {}, target_path {}, ufs_mtime:{}, copy bytes {}, read cost {} ms, task cost {} ms",
-            self.task.info.task_id,
-            self.task.info.source_path,
-            self.task.info.target_path,
-            ufs_mtime,
-            writer.pos(),
+        stream.writer.complete().await?;
+        stream.reader.complete().await?;
+        let copied_bytes = stream.writer.pos();
+        let reader_len = stream.reader.len();
+        self.commit_output(stream).await?;
+        Ok(Some((
+            copied_bytes,
+            reader_len,
             read_cost_ms,
             total_cost_ms,
-        );
-
-        Ok(())
+        )))
     }
 
-    /// Upper bound on the number of independent reader+writer streams a large
-    /// UFS->CV load may fan out into. Read from the mount property
-    /// `load_task.parallel_streams` (per-bucket tunable), defaulting to 8.
-    /// Clamped to >= 1. This is a CAP: the actual stream count is derived from
-    /// file size by [`Self::effective_streams`].
-    fn max_parallel_streams(&self) -> usize {
-        self.task
-            .info
-            .job
-            .mount_info
-            .properties
-            .get("load_task.parallel_streams")
-            .and_then(|v| v.parse::<usize>().ok())
-            .unwrap_or(8)
-            .max(1)
+    async fn cleanup_failed_stream(&self, stream: &CopyStream) {
+        let Some(temp_path) = &stream.temp_path else {
+            return;
+        };
+        if let Err(err) = self.delete_temp_output(temp_path).await {
+            warn!(
+                "delete failed transfer temp output {} failed for task {}: {}",
+                temp_path.full_path(),
+                self.task.info.task_id,
+                err
+            );
+        }
     }
 
-    /// Minimum number of bytes a single stream must be responsible for before
-    /// fanning out is worthwhile. Each extra stream carries fixed setup cost
-    /// (UFS open, open_for_write RPC, per-block add_block, complete) that does
-    /// NOT shrink with file size, so a stream only pays off once it moves at
-    /// least this many bytes. Configurable via the mount property
-    /// `load_task.min_bytes_per_stream` (per-bucket tunable), defaulting to
-    /// 256 MiB. Clamped to >= 1.
-    ///
-    /// This subsumes the old boolean `load_task.parallel_threshold`: a file
-    /// smaller than this value yields `effective_streams == 1`, i.e. no fan-out.
-    fn min_bytes_per_stream(&self) -> i64 {
-        self.task
-            .info
-            .job
-            .mount_info
-            .properties
-            .get("load_task.min_bytes_per_stream")
-            .and_then(|v| v.parse::<i64>().ok())
-            .unwrap_or(256 * 1024 * 1024)
-            .max(1)
-    }
-
-    /// Derive the stream count for a load of `src_len` bytes, growing the count
-    /// with file size instead of always jumping to the cap. Fixed per-stream
-    /// setup cost (opens/RPCs/complete) is independent of file size, so a
-    /// mid-size file over-parallelized to the full cap can be slower than a
-    /// smaller fan-out. We give each stream at least `min_bytes_per_stream` and
-    /// clamp to `[1, max_parallel_streams]`:
-    ///
-    ///   effective = clamp(src_len / min_bytes_per_stream, 1, cap)
-    ///
-    /// Examples (min=256 MiB, cap=8): 100 MiB -> 1 stream (no fan-out),
-    /// 512 MiB -> 2, 1 GiB -> 4, 2 GiB -> 8, 200 GiB -> 8 (capped).
-    fn effective_streams(&self, src_len: i64) -> usize {
-        Self::stream_count(
-            src_len,
-            self.min_bytes_per_stream(),
-            self.max_parallel_streams(),
-        )
-    }
-
-    /// Pure fan-out width math (extracted for unit testing): give each stream at
-    /// least `min_bytes` bytes, clamp to `[1, cap]`. `min_bytes` and `cap` are
-    /// treated as >= 1.
-    fn stream_count(src_len: i64, min_bytes: i64, cap: usize) -> usize {
-        let min_bytes = min_bytes.max(1);
-        let cap = cap.max(1);
-        let by_size = (src_len / min_bytes).max(0) as usize;
-        by_size.clamp(1, cap)
-    }
-
-    /// Compute the per-stream segment length for a parallel load.
-    ///
-    /// The segment is `ceil(src_len / streams)` rounded UP to a whole number of
-    /// `block_size` blocks. Block alignment is a correctness requirement: each
-    /// stream gets its own writer, and the block is Curvine's unit of allocation
-    /// and commit — if two streams' ranges shared a block they would race on that
-    /// block. Rounding up guarantees stream `i` owns `[i*seg, (i+1)*seg)` with a
-    /// block boundary at every `seg`, so block sets are disjoint.
-    ///
-    /// Returns a value that is always >= `block_size` and a multiple of it (so
-    /// callers must still clamp the last segment to `src_len`). `streams` and
-    /// `block_size` are treated as >= 1.
-    fn segment_len(src_len: i64, streams: usize, block_size: i64) -> i64 {
-        let streams = streams.max(1) as i64;
-        let block_size = block_size.max(1);
-        let raw = (src_len + streams - 1) / streams;
-        let aligned = ((raw + block_size - 1) / block_size) * block_size;
-        aligned.max(block_size)
-    }
-
-    /// Per-`async_read` request size within a stream. Capped so a single read
-    /// doesn't try to buffer a whole (potentially multi-GiB) segment at once.
-    const READ_CHUNK_BYTES: i64 = 16 * 1024 * 1024;
-
-    /// Fan a large UFS->CV load into N independent streams, each of which opens
-    /// its OWN reader AND its OWN writer for a disjoint, block-aligned byte range
-    /// of the file, then reads-from-UFS and writes-to-Curvine that range end to
-    /// end. This is "multi-read + multi-write":
-    ///
-    /// - Read side: N independent UFS readers scale near-linearly (a single
-    ///   OpenDAL reader's internal `.concurrent()` prefetch does not).
-    /// - Write side: N independent Curvine writers scale near-linearly too; a
-    ///   single writer tops out around one block-writer's throughput.
-    ///
-    /// Correctness relies on three Curvine properties:
-    /// 1. `resize(src_len)` up front allocates every block, giving each full
-    ///    block length `block_size` and the final block the remainder, so
-    ///    `compute_len()` already sums to exactly `src_len`. The master-side
-    ///    `complete()` length check (`compute_len == file.len`) therefore holds
-    ///    no matter which writer commits when.
-    /// 2. Segments are rounded up to a whole number of `block_size` blocks, so no
-    ///    two writers ever touch the same block (the unit of allocation/commit).
-    /// 3. Curvine natively supports multiple concurrent writers on one file
-    ///    (`add_block` is idempotent on already-allocated blocks).
-    async fn run_parallel(
-        &self,
-        source_path: &Path,
-        target_path: &Path,
-        src_len: i64,
-    ) -> FsResult<()> {
-        let streams = self.effective_streams(src_len);
-        let block_size = self.task.info.job.block_size.max(1);
-        let seg = Self::segment_len(src_len, streams, block_size);
-        let spend = TimeSpent::new();
-        // Absolute deadline shared by every stream, so a single hung stream is
-        // caught mid-segment instead of only after the whole (multi-GiB) segment
-        // finishes. Same budget as the outer join-loop timeout check.
-        let deadline_ms = LocalTime::mills() + self.task_timeout_ms;
-
-        // Pre-create + resize the target to src_len so ALL blocks are allocated
-        // up front (see property 1 above). We drop the owner writer WITHOUT
-        // completing it: completing would clear the file's write feature; we only
-        // needed the resize to allocate blocks (they persist in master meta).
-        {
-            let mut owner = self.create_unified(target_path).await?;
-            owner.resize(FileAllocOpts::with_truncate(src_len)).await?;
-            drop(owner);
+    async fn cancel_stream(&self, stream: &mut CopyStream) -> FsResult<bool> {
+        if let Err(err) = stream.writer.cancel().await {
+            warn!(
+                "cancel transfer writer failed for task {} temp {:?}: {}",
+                self.task.info.task_id, stream.temp_path, err
+            );
         }
 
-        // Fan out: each stream reads its range from UFS and writes it to the
-        // (already allocated) target region with its own reader + writer.
-        let task_timeout_ms = self.task_timeout_ms;
-        let mut handles = Vec::with_capacity(streams);
-        for i in 0..streams {
-            let off = i as i64 * seg;
-            if off >= src_len {
-                break;
-            }
-            let len = seg.min(src_len - off);
-            let ufs = self.get_ufs()?;
-            let fs = self.fs.clone();
-            let src = source_path.clone();
-            let dst = target_path.clone();
-            let rt = self.fs.clone_runtime();
-            let task = self.task.clone();
-            handles.push(rt.spawn(async move {
-                let mut reader = ufs.open(&src).await?;
-                reader.seek(off).await?;
-                // open_for_write(overwrite=false): attach as an additional writer
-                // to the existing (resized) file without truncating it.
-                let mut writer = fs.open_for_write(&dst, false).await?;
-                writer.seek(off).await?;
-
-                crate::fault_point! {
-                    async,
-                    name: "worker.load_task.parallel.before_segment_copy",
-                    description: "After a parallel load segment opens its streams and before it copies data",
-                    context: {
-                        "task_id" => task.info.task_id.clone(),
-                        "stream_index" => i as i64,
-                        "segment_offset" => off,
-                        "segment_len" => len,
-                    },
-                }
-
-                let mut remaining = len;
-                while remaining > 0 {
-                    // Honor cancellation and the shared deadline INSIDE the
-                    // segment loop: a segment can be multiple GiB, so checking
-                    // only between segments would let a canceled/timed-out job
-                    // keep reading from UFS and committing blocks. On early exit
-                    // cancel the writer so it does not complete() a partial
-                    // segment onto the pre-resized target.
-                    if task.is_cancel() {
-                        let _ = writer.cancel().await;
-                        return FsResult::Ok(0);
-                    }
-                    if LocalTime::mills() > deadline_ms {
-                        let _ = writer.cancel().await;
-                        return err_box!(
-                            "Task {} exceed timeout {} ms (segment [{}, {}))",
-                            task.info.task_id,
-                            task_timeout_ms,
-                            off,
-                            off + len
-                        );
-                    }
-                    let want = remaining.min(Self::READ_CHUNK_BYTES) as usize;
-                    let chunk = reader.async_read(Some(want)).await?;
-                    if chunk.is_empty() {
-                        break;
-                    }
-                    remaining -= chunk.len() as i64;
-                    writer.async_write(chunk).await?;
-                }
-                // Guard against silent short writes: if the source returned EOF
-                // before its advertised length, the file would be left with a
-                // hole in this segment. Fail loudly instead of committing partial
-                // data that would later read back as corrupt.
-                if remaining != 0 {
-                    let _ = writer.cancel().await;
-                    return err_box!(
-                        "short read on segment [{}, {}): {} bytes missing (source shorter than stat len?)",
-                        off,
-                        off + len,
-                        remaining
-                    );
-                }
-                // All writers share one FsContext client_name, so whichever
-                // stream completes first clears the file's write feature while
-                // other streams may still be committing blocks. This is safe
-                // ONLY because of correctness property (1) above: resize()
-                // pre-allocated every block so compute_len == file.len already
-                // holds regardless of commit order. Do NOT "fix" this into
-                // per-stream client IDs -- it is intentional.
-                writer.complete().await?;
-                reader.complete().await?;
-                FsResult::Ok(len)
-            }));
-        }
-
-        // Join all streams. On ANY early exit (cancel, segment error, timeout)
-        // abort the handles we have not yet awaited: a task blocked in a UFS read
-        // never observes is_cancel() on its own, so without this it could keep
-        // reading and complete() onto the target after the job is done/failed.
-        let mut written: i64 = 0;
-        for idx in 0..handles.len() {
-            if self.task.is_cancel() {
-                info!("task {} was cancelled", self.task.info.task_id);
-                Self::abort_remaining(&handles, idx);
-                return Ok(());
-            }
-            crate::fault_point! {
-                async,
-                name: "worker.load_task.parallel.before_join_await",
-                description: "After the parent cancellation check and before awaiting a parallel load stream",
-                context: {
-                    "task_id" => self.task.info.task_id.clone(),
-                    "stream_index" => idx as i64,
-                },
-            }
-            match (&mut handles[idx]).await {
-                Ok(Ok(n)) => {
-                    written += n;
-                    self.update_progress(written, src_len, false).await;
-                }
-                Ok(Err(e)) => {
-                    Self::abort_remaining(&handles, idx + 1);
-                    return Err(e);
-                }
-                Err(e) => {
-                    Self::abort_remaining(&handles, idx + 1);
-                    return err_box!("parallel load join error: {}", e);
-                }
-            }
-            if spend.used_ms() > self.task_timeout_ms {
-                Self::abort_remaining(&handles, idx + 1);
-                return err_box!(
-                    "Task {} exceed timeout {} ms",
+        if let Some(temp_path) = &stream.temp_path {
+            if let Err(err) = self.delete_temp_output(temp_path).await {
+                warn!(
+                    "delete cancelled transfer temp output {} failed for task {}: {}",
+                    temp_path.full_path(),
                     self.task.info.task_id,
-                    self.task_timeout_ms
+                    err
                 );
             }
         }
 
-        // Cancellation may happen after the loop's pre-await check while the
-        // final stream is still running. That stream returns Ok(0), so recheck
-        // here before stamping the pre-resized target as a valid cache entry.
-        if self.task.is_cancel() {
-            info!("task {} was cancelled", self.task.info.task_id);
-            return Ok(());
-        }
-        if written != src_len {
-            return err_box!(
-                "Task {} parallel load incomplete: wrote {} of {} bytes; refusing to mark cache valid",
-                self.task.info.task_id,
-                written,
-                src_len
+        let progress = self.task.set_canceled("task canceled");
+        if let Err(err) = self.report_progress(progress).await {
+            info!(
+                "cancelled task report was not accepted, remove local task anyway: job={}, task={}, err={}",
+                self.task.info.job.job_id, self.task.info.task_id, err
             );
         }
-
-        // ufs -> cv: stamp the source mtime onto the cached file (cache validity).
-        let ufs_mtime = self.get_ufs()?.get_status(source_path).await?.mtime;
-        let attr_opts = SetAttrOptsBuilder::new().ufs_mtime(ufs_mtime).build();
-        self.fs.set_attr(target_path, attr_opts).await?;
-
-        self.update_progress(written, src_len, true).await;
-
-        info!(
-            "task {} completed (parallel x{}), source_path {}, target_path {}, ufs_mtime:{}, copy bytes {}, task cost {} ms",
-            self.task.info.task_id,
-            streams,
-            self.task.info.source_path,
-            self.task.info.target_path,
-            ufs_mtime,
-            written,
-            spend.used_ms(),
-        );
-
-        Ok(())
+        Ok(true)
     }
 
-    /// Abort every not-yet-awaited stream handle in `handles[from..]`. Called on
-    /// any early exit from the join loop so background streams stop reading UFS
-    /// and never complete() onto the target after the job is done/failed. Tokio
-    /// abort is best-effort (it fires at the next await point); combined with the
-    /// in-loop is_cancel()/deadline checks this bounds how long a stream can run
-    /// past the parent's decision to stop.
-    fn abort_remaining(handles: &[orpc::runtime::JoinHandle<FsResult<i64>>], from: usize) {
-        for h in handles.iter().skip(from) {
-            h.abort();
+    async fn delete_temp_output(&self, temp_path: &Path) -> FsResult<()> {
+        if temp_path.is_cv() {
+            match self.fs.delete(temp_path, false).await {
+                Ok(()) | Err(FsError::FileNotFound(_)) => Ok(()),
+                Err(err) => Err(err),
+            }
+        } else {
+            let ufs = self.get_ufs()?;
+            match ufs.delete(temp_path, false).await {
+                Ok(()) | Err(FsError::FileNotFound(_)) => Ok(()),
+                Err(err) => Err(err),
+            }
         }
     }
 
-    async fn create_stream(&self) -> FsResult<(UnifiedReader, UnifiedWriter)> {
+    async fn create_stream(&self) -> FsResult<CopyStream> {
         let source_path = Path::from_str(&self.task.info.source_path)?;
         let target_path = Path::from_str(&self.task.info.target_path)?;
+        let write_path = self.transfer_temp_path(&target_path)?;
 
         // Create reader (automatically selects filesystem based on scheme)
         let reader = self.open_unified(&source_path).await?;
 
         // Create writer (automatically selects filesystem based on scheme)
-        let writer = self.create_unified(&target_path).await?;
+        let writer = self.create_unified(&write_path).await?;
 
-        Ok((reader, writer))
+        Ok(CopyStream {
+            reader,
+            writer,
+            final_path: target_path,
+            temp_path: self.task.info.transfer_report.as_ref().map(|_| write_path),
+        })
+    }
+
+    fn transfer_temp_path(&self, target_path: &Path) -> FsResult<Path> {
+        let Some(report) = &self.task.info.transfer_report else {
+            return Ok(target_path.clone());
+        };
+        Ok(Path::from_str(format!(
+            "{}{}{}-{}-{}-{}",
+            target_path.full_path(),
+            TRANSFER_TEMP_PATH_MARKER,
+            self.task.info.job.job_id,
+            report.run_id,
+            self.task.info.task_id,
+            report.attempt_id
+        ))?)
+    }
+
+    async fn commit_output(&self, stream: &CopyStream) -> FsResult<()> {
+        let Some(temp_path) = &stream.temp_path else {
+            return Ok(());
+        };
+        let overwrite = self.task.info.job.overwrite.unwrap_or(false);
+        if stream.final_path.is_cv() {
+            match self
+                .validate_cv_commit_target(&stream.final_path, stream.reader.status(), overwrite)
+                .await?
+            {
+                CommitTarget::RenameTemp => {
+                    self.fs.rename(temp_path, &stream.final_path).await?;
+                }
+                CommitTarget::AlreadyCommitted => {
+                    if let Err(err) = self.fs.delete(temp_path, false).await {
+                        warn!(
+                            "delete redundant transfer temp output {} failed after idempotent commit check: {}",
+                            temp_path.full_path(),
+                            err
+                        );
+                    }
+                }
+            }
+        } else {
+            let ufs = self.get_ufs()?;
+            commit_ufs_output(&ufs, temp_path, &stream.final_path, overwrite).await?;
+        }
+        Ok(())
+    }
+
+    async fn validate_cv_commit_target(
+        &self,
+        path: &Path,
+        source_status: &FileStatus,
+        overwrite: bool,
+    ) -> FsResult<CommitTarget> {
+        match self.fs.get_status(path).await {
+            Ok(status) if status.is_dir => err_box!(
+                "Transfer target {} is a directory; refusing to overwrite directory with file",
+                path.full_path()
+            ),
+            Ok(status) if !overwrite => {
+                if self.is_committed_transfer_output(&status, source_status) {
+                    Ok(CommitTarget::AlreadyCommitted)
+                } else {
+                    Err(FsError::file_exists(path.full_path()))
+                }
+            }
+            Ok(_) => Ok(CommitTarget::RenameTemp),
+            Err(FsError::FileNotFound(_)) => Ok(CommitTarget::RenameTemp),
+            Err(err) => Err(err),
+        }
+    }
+
+    fn is_committed_transfer_output(
+        &self,
+        target_status: &FileStatus,
+        source_status: &FileStatus,
+    ) -> bool {
+        if target_status.len != source_status.len
+            || target_status.storage_policy.ufs_mtime != source_status.mtime
+        {
+            return false;
+        }
+        let Some(report) = &self.task.info.transfer_report else {
+            return false;
+        };
+
+        xattr_equals(
+            target_status,
+            TRANSFER_COMMIT_JOB_ID_XATTR,
+            self.task.info.job.job_id.as_bytes(),
+        ) && xattr_equals(
+            target_status,
+            TRANSFER_COMMIT_RUN_ID_XATTR,
+            report.run_id.to_string().as_bytes(),
+        ) && xattr_equals(
+            target_status,
+            TRANSFER_COMMIT_TASK_ID_XATTR,
+            self.task.info.task_id.as_bytes(),
+        ) && xattr_equals(
+            target_status,
+            TRANSFER_COMMIT_SOURCE_PATH_XATTR,
+            self.task.info.source_path.as_bytes(),
+        )
     }
 
     async fn open_unified(&self, path: &Path) -> FsResult<UnifiedReader> {
         if path.is_cv() {
-            let reader = self.fs.open(path).await?;
+            let reader = if self.task.info.source_read_plan_json.is_empty() {
+                self.fs.open(path).await?
+            } else {
+                let file_blocks: FileBlocks =
+                    serde_json::from_str(&self.task.info.source_read_plan_json).map_err(|err| {
+                        FsError::common(format!(
+                            "Invalid CV source read plan for task {} path {}: {}",
+                            self.task.info.task_id,
+                            path.full_path(),
+                            err
+                        ))
+                    })?;
+                FsReader::new(path.clone(), self.fs.fs_context(), file_blocks)?
+            };
             Ok(UnifiedReader::Cv(reader))
         } else {
             // UFS path
@@ -605,137 +525,122 @@ impl LoadTaskRunner {
         is_last: bool,
     ) -> FsResult<()> {
         let progress = self.task.update_progress(loaded_size, total_size, is_last);
-        let task = &self.task;
-
-        self.master_client
-            .report_task(&task.info.job.job_id, &task.info.task_id, progress)
-            .await
+        self.report_progress(progress).await
     }
+
+    async fn report_progress(&self, progress: JobTaskProgress) -> FsResult<()> {
+        let task = &self.task.info;
+        if let Some(report_info) = &task.transfer_report {
+            let Some(client) = &self.transfer_client else {
+                return err_box!(
+                    "Transfer task {} has no transfer client for report target {}",
+                    task.task_id,
+                    report_info.report_target
+                );
+            };
+            let accepted = tokio::time::timeout(
+                Duration::from_millis(TRANSFER_REPORT_TIMEOUT_MS),
+                client.report_task(&task.job.job_id, &task.task_id, report_info, progress),
+            )
+            .await
+            .map_err(|_| {
+                FsError::common(format!(
+                    "Transfer task report timed out after {} ms: job={}, task={}, attempt={}",
+                    TRANSFER_REPORT_TIMEOUT_MS,
+                    task.job.job_id,
+                    task.task_id,
+                    report_info.attempt_id
+                ))
+            })??;
+            if !accepted {
+                return err_box!(
+                    "Transfer task report rejected: job={}, task={}, attempt={}",
+                    task.job.job_id,
+                    task.task_id,
+                    report_info.attempt_id
+                );
+            }
+            Ok(())
+        } else {
+            self.master_client
+                .report_task(&task.job.job_id, &task.task_id, progress)
+                .await
+        }
+    }
+}
+
+async fn commit_ufs_output(
+    ufs: &UfsFileSystem,
+    temp_path: &Path,
+    final_path: &Path,
+    overwrite: bool,
+) -> FsResult<()> {
+    match ufs.get_status(final_path).await {
+        Ok(status) if status.is_dir => {
+            return err_box!(
+                "Transfer target {} is a directory; refusing to overwrite directory with file",
+                final_path.full_path()
+            );
+        }
+        Ok(_) if !overwrite => return Err(FsError::file_exists(final_path.full_path())),
+        Ok(_) | Err(FsError::FileNotFound(_)) => {}
+        Err(err) => return Err(err),
+    }
+
+    if let Some(parent) = final_path.parent()? {
+        ufs.mkdir(&parent, true).await?;
+    }
+    if !ufs.rename(temp_path, final_path).await? {
+        return err_box!(
+            "Transfer output rename did not commit {} to {}",
+            temp_path.full_path(),
+            final_path.full_path()
+        );
+    }
+    Ok(())
+}
+
+fn xattr_equals(status: &FileStatus, key: &str, expected: &[u8]) -> bool {
+    status
+        .x_attr
+        .get(key)
+        .map(|actual| actual.as_slice() == expected)
+        .unwrap_or(false)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::LoadTaskRunner;
-
-    const MB: i64 = 1024 * 1024;
-
-    // Reproduce the exact planning loop run_parallel uses, so tests exercise the
-    // real offset/len math (block alignment + last-segment clamp), which is the
-    // most error-prone part of the fan-out.
-    fn plan(src_len: i64, streams: usize, block_size: i64) -> Vec<(i64, i64)> {
-        let seg = LoadTaskRunner::segment_len(src_len, streams, block_size);
-        let mut ranges = Vec::new();
-        for i in 0..streams {
-            let off = i as i64 * seg;
-            if off >= src_len {
-                break;
-            }
-            let len = seg.min(src_len - off);
-            ranges.push((off, len));
-        }
-        ranges
-    }
+    use super::commit_ufs_output;
+    use curvine_client::unified::UfsFileSystem;
+    use curvine_common::fs::Path;
+    use orpc::runtime::{AsyncRuntime, RpcRuntime};
+    use std::collections::HashMap;
+    use std::fs;
 
     #[test]
-    fn segment_len_is_block_aligned() {
-        // 10 GiB, 8 streams, 4 MiB blocks: ceil(10Gi/8)=1280MiB, already aligned.
-        let seg = LoadTaskRunner::segment_len(10 * 1024 * MB, 8, 4 * MB);
+    fn failed_ufs_overwrite_commit_keeps_existing_target() {
+        let base_dir = std::env::temp_dir().join(format!(
+            "transfer-ufs-commit-{}-{}",
+            std::process::id(),
+            orpc::common::LocalTime::mills()
+        ));
+        fs::create_dir_all(&base_dir).unwrap();
+        let target = Path::from_str(format!("file://{}/target.txt", base_dir.display())).unwrap();
+        let missing_temp =
+            Path::from_str(format!("file://{}/missing-temp.txt", base_dir.display())).unwrap();
+        fs::write(base_dir.join("target.txt"), "original-target").unwrap();
+
+        let ufs = UfsFileSystem::new(&target, HashMap::new(), None).unwrap();
+        let rt = AsyncRuntime::single();
+        let err = rt
+            .block_on(commit_ufs_output(&ufs, &missing_temp, &target, true))
+            .unwrap_err();
+        assert!(err.to_string().contains("No such file") || err.to_string().contains("not found"));
         assert_eq!(
-            seg % (4 * MB),
-            0,
-            "segment must be a multiple of block_size"
+            fs::read_to_string(base_dir.join("target.txt")).unwrap(),
+            "original-target"
         );
-        assert!(seg >= 10 * 1024 * MB / 8);
-    }
 
-    #[test]
-    fn segment_len_rounds_up_to_block_multiple() {
-        // Non-block-multiple raw segment must round UP so writers never share a block.
-        // src=100MiB, 3 streams => raw ceil ≈ 33.34MiB; rounded up to a 4MiB
-        // multiple that is 36MiB (9 blocks).
-        let seg = LoadTaskRunner::segment_len(100 * MB, 3, 4 * MB);
-        assert_eq!(seg, 36 * MB);
-        assert_eq!(seg % (4 * MB), 0);
-    }
-
-    #[test]
-    fn segment_len_never_below_block_size() {
-        // Tiny file, many streams: segment must not collapse to 0.
-        let seg = LoadTaskRunner::segment_len(1, 8, 4 * MB);
-        assert_eq!(seg, 4 * MB);
-    }
-
-    #[test]
-    fn segment_len_handles_zero_streams_and_block() {
-        // Defensive: streams/block_size are clamped to >= 1, no divide-by-zero.
-        assert_eq!(LoadTaskRunner::segment_len(1000, 0, 0), 1000);
-    }
-
-    #[test]
-    fn plan_ranges_are_contiguous_disjoint_and_cover_whole_file() {
-        // The critical invariant: the union of all stream ranges must be exactly
-        // [0, src_len) with no gaps and no overlaps (else data is lost/corrupted).
-        for &(src_len, streams, block_size) in &[
-            (10 * 1024 * MB, 8, 4 * MB),
-            (100 * MB, 3, 4 * MB),
-            (7 * MB + 123, 4, 4 * MB), // not block-aligned total
-            (4 * MB, 8, 4 * MB),       // fewer effective streams than requested
-            (1, 8, 4 * MB),            // tiny file -> single stream
-        ] {
-            let ranges = plan(src_len, streams, block_size);
-            assert!(!ranges.is_empty(), "must produce at least one range");
-            // First starts at 0.
-            assert_eq!(ranges[0].0, 0);
-            // Contiguous + disjoint.
-            let mut expected_off = 0;
-            for (off, len) in &ranges {
-                assert_eq!(*off, expected_off, "gap/overlap at {}", off);
-                assert!(*len > 0, "empty segment");
-                expected_off += len;
-            }
-            // Covers exactly the whole file.
-            assert_eq!(
-                expected_off, src_len,
-                "ranges must cover exactly [0,{})",
-                src_len
-            );
-            // Every non-final segment start is block-aligned (disjoint block sets).
-            for (off, _) in &ranges {
-                assert_eq!(*off % block_size, 0, "segment start not block-aligned");
-            }
-        }
-    }
-
-    #[test]
-    fn plan_does_not_over_allocate_streams_for_small_files() {
-        // 4 MiB file with 8 requested streams and 4 MiB blocks: only 1 stream
-        // should actually get a range (the rest would start at/after EOF).
-        let ranges = plan(4 * MB, 8, 4 * MB);
-        assert_eq!(ranges.len(), 1);
-        assert_eq!(ranges[0], (0, 4 * MB));
-    }
-
-    #[test]
-    fn stream_count_grows_with_size_and_caps() {
-        let min = 256 * MB;
-        let cap = 8;
-        // Below min_bytes -> single stream (no fan-out), subsumes old threshold.
-        assert_eq!(LoadTaskRunner::stream_count(100 * MB, min, cap), 1);
-        assert_eq!(LoadTaskRunner::stream_count(min - 1, min, cap), 1);
-        // Grows linearly with size.
-        assert_eq!(LoadTaskRunner::stream_count(512 * MB, min, cap), 2);
-        assert_eq!(LoadTaskRunner::stream_count(1024 * MB, min, cap), 4);
-        assert_eq!(LoadTaskRunner::stream_count(2048 * MB, min, cap), 8);
-        // Clamped at the cap for very large files.
-        assert_eq!(LoadTaskRunner::stream_count(200 * 1024 * MB, min, cap), 8);
-    }
-
-    #[test]
-    fn stream_count_defensive_bounds() {
-        // Zero/negative length -> 1 (never 0), zero min_bytes/cap clamped to 1.
-        assert_eq!(LoadTaskRunner::stream_count(0, 256 * MB, 8), 1);
-        assert_eq!(LoadTaskRunner::stream_count(-5, 256 * MB, 8), 1);
-        assert_eq!(LoadTaskRunner::stream_count(1024 * MB, 0, 8), 8);
-        assert_eq!(LoadTaskRunner::stream_count(1024 * MB, 256 * MB, 0), 1);
+        let _ = fs::remove_dir_all(base_dir);
     }
 }

--- a/curvine-server/src/worker/task/task_context.rs
+++ b/curvine-server/src/worker/task/task_context.rs
@@ -37,7 +37,7 @@ impl TaskContext {
         self.state.state()
     }
 
-    fn progress(&self) -> MutexGuard<'_, JobTaskProgress> {
+    fn progress_lock(&self) -> MutexGuard<'_, JobTaskProgress> {
         match self.progress.lock() {
             Ok(progress) => progress,
             Err(e) => {
@@ -47,9 +47,35 @@ impl TaskContext {
         }
     }
 
+    pub fn progress(&self) -> JobTaskProgress {
+        let lock = self.progress_lock();
+        JobTaskProgress {
+            state: self.get_state(),
+            total_size: lock.total_size,
+            loaded_size: lock.loaded_size,
+            update_time: lock.update_time,
+            message: lock.message.clone(),
+        }
+    }
+
     pub fn set_failed(&self, message: impl Into<String>) -> JobTaskProgress {
-        let mut lock = self.progress();
+        let mut lock = self.progress_lock();
         self.state.set_state(JobTaskState::Failed);
+        lock.message = message.into();
+        lock.update_time = LocalTime::mills() as i64;
+
+        JobTaskProgress {
+            state: self.get_state(),
+            total_size: lock.total_size,
+            loaded_size: lock.loaded_size,
+            update_time: lock.update_time,
+            message: lock.message.clone(),
+        }
+    }
+
+    pub fn set_canceled(&self, message: impl Into<String>) -> JobTaskProgress {
+        let mut lock = self.progress_lock();
+        self.state.set_state(JobTaskState::Canceled);
         lock.message = message.into();
         lock.update_time = LocalTime::mills() as i64;
 
@@ -71,7 +97,7 @@ impl TaskContext {
     }
 
     pub fn update_state(&self, state: JobTaskState, message: impl Into<String>) {
-        let mut lock = self.progress();
+        let mut lock = self.progress_lock();
         if self.state.state::<JobTaskState>() == JobTaskState::Canceled
             && state != JobTaskState::Canceled
         {
@@ -88,7 +114,7 @@ impl TaskContext {
         total_size: i64,
         is_last: bool,
     ) -> JobTaskProgress {
-        let mut lock = self.progress();
+        let mut lock = self.progress_lock();
         if self.state.state::<JobTaskState>() == JobTaskState::Canceled {
             return JobTaskProgress {
                 state: JobTaskState::Canceled,

--- a/curvine-server/src/worker/task/task_manager.rs
+++ b/curvine-server/src/worker/task/task_manager.rs
@@ -161,9 +161,12 @@ impl TaskManager {
     ///      context** (a later `submit_task` may have superseded it)
     pub fn submit_task(&self, task: LoadTaskInfo) -> FsResult<TaskSubmitResult> {
         if let Some(report) = &task.transfer_report {
-            if self.transfer_client.is_none() {
+            if report.report_endpoints.is_empty()
+                && report.report_target.is_empty()
+                && self.transfer_client.is_none()
+            {
                 return Ok(TaskSubmitResult::rejected(format!(
-                    "Reject transfer task {} because transfer client is unavailable",
+                    "Reject transfer task {} because no Transfer report endpoint is available",
                     task.task_id
                 )));
             }

--- a/curvine-server/src/worker/task/task_manager.rs
+++ b/curvine-server/src/worker/task/task_manager.rs
@@ -16,8 +16,9 @@ use crate::common::UfsFactory;
 use crate::worker::task::load_task_runner::LoadTaskRunner;
 use crate::worker::task::{TaskContext, TaskStore};
 use curvine_client::file::{CurvineFileSystem, FsContext};
+use curvine_client::rpc::TransferClient;
 use curvine_common::conf::ClusterConf;
-use curvine_common::state::{JobTaskState, LoadTaskInfo};
+use curvine_common::state::{JobTaskProgress, LoadTaskInfo, TransferTaskReportInfo};
 use curvine_common::FsResult;
 use dashmap::mapref::entry::Entry;
 use log::{debug, info, warn};
@@ -30,9 +31,32 @@ pub struct TaskManager {
     fs: CurvineFileSystem,
     tasks: TaskStore,
     factory: Arc<UfsFactory>,
+    transfer_client: Option<TransferClient>,
+    worker_session_id: String,
     progress_interval_ms: u64,
     task_timeout_ms: u64,
     worker_task_semaphore: Arc<Semaphore>,
+}
+
+pub struct TaskSubmitResult {
+    pub accepted: bool,
+    pub reject_reason: String,
+}
+
+impl TaskSubmitResult {
+    fn accepted() -> Self {
+        Self {
+            accepted: true,
+            reject_reason: String::new(),
+        }
+    }
+
+    fn rejected(reason: impl Into<String>) -> Self {
+        Self {
+            accepted: false,
+            reject_reason: reason.into(),
+        }
+    }
 }
 
 impl TaskManager {
@@ -69,18 +93,25 @@ impl TaskManager {
     /// # Limit concurrent load tasks to prevent resource exhaustion
     /// worker_max_concurrent_tasks = 10
     /// ```
-    pub fn with_rt(rt: Arc<Runtime>, conf: &ClusterConf) -> FsResult<Self> {
+    pub fn with_rt(
+        rt: Arc<Runtime>,
+        conf: &ClusterConf,
+        worker_session_id: impl Into<String>,
+    ) -> FsResult<Self> {
         let mut new_conf = conf.clone();
         new_conf.client.hostname = "localhost".to_string();
 
         let fs = CurvineFileSystem::with_rt(new_conf, rt.clone())?;
         let factory = Arc::new(UfsFactory::with_rt(&conf.client, rt.clone()));
+        let transfer_client = TransferClient::with_context(&fs.fs_context()).ok();
         let worker_task_semaphore = Arc::new(Semaphore::new(conf.job.worker_max_concurrent_tasks));
         let mgr = Self {
             rt,
             fs,
             tasks: TaskStore::new(),
             factory,
+            transfer_client,
+            worker_session_id: worker_session_id.into(),
             progress_interval_ms: conf.job.task_report_interval.as_millis() as u64,
             task_timeout_ms: conf.job.task_timeout.as_millis() as u64,
             worker_task_semaphore,
@@ -128,14 +159,57 @@ impl TaskManager {
     ///    - Automatically releases the permit on completion
     ///    - Removes the map entry **only if it still points at its own
     ///      context** (a later `submit_task` may have superseded it)
-    pub fn submit_task(&self, task: LoadTaskInfo) -> FsResult<()> {
+    pub fn submit_task(&self, task: LoadTaskInfo) -> FsResult<TaskSubmitResult> {
+        if let Some(report) = &task.transfer_report {
+            if self.transfer_client.is_none() {
+                return Ok(TaskSubmitResult::rejected(format!(
+                    "Reject transfer task {} because transfer client is unavailable",
+                    task.task_id
+                )));
+            }
+            if report.worker_session_id != self.worker_session_id {
+                return Ok(TaskSubmitResult::rejected(format!(
+                    "Reject transfer task {} for stale worker session {}, current session {}",
+                    task.task_id, report.worker_session_id, self.worker_session_id
+                )));
+            }
+        }
+
         let task_id = task.task_id.clone();
         let context = Arc::new(TaskContext::new(task));
 
         match self.tasks.entry(task_id.clone()) {
             Entry::Occupied(mut occ) => {
+                if let Some(new_report) = &context.info.transfer_report {
+                    let old_report = occ.get().info.transfer_report.as_ref();
+                    if let Some(old_report) = old_report {
+                        if old_report.run_id == new_report.run_id
+                            && old_report.attempt_id == new_report.attempt_id
+                        {
+                            debug!(
+                                "ignore duplicate transfer task submit {}, attempt {}",
+                                task_id, new_report.attempt_id
+                            );
+                            return Ok(TaskSubmitResult::accepted());
+                        }
+                        if old_report.run_id > new_report.run_id
+                            || (old_report.run_id == new_report.run_id
+                                && old_report.attempt_id > new_report.attempt_id)
+                        {
+                            return Ok(TaskSubmitResult::rejected(format!(
+                                "Reject stale transfer task {} run {} attempt {}, current run {} attempt {}",
+                                task_id,
+                                new_report.run_id,
+                                new_report.attempt_id,
+                                old_report.run_id,
+                                old_report.attempt_id
+                            )));
+                        }
+                    }
+                }
+
                 let old = occ.insert(context.clone());
-                old.update_state(JobTaskState::Canceled, "superseded by new submit");
+                old.set_canceled("superseded by new submit");
                 warn!(
                     "cancel duplicate task {} (source_path={})",
                     old.info.task_id, old.info.source_path
@@ -155,6 +229,7 @@ impl TaskManager {
             context.clone(),
             self.fs.clone(),
             self.factory.clone(),
+            self.transfer_client.clone(),
             self.progress_interval_ms,
             self.task_timeout_ms,
         );
@@ -165,9 +240,10 @@ impl TaskManager {
 
         // Spawn task with concurrency control
         self.rt.spawn(async move {
+            let mut remove_task = true;
             match semaphore.acquire().await {
                 Ok(permit) => {
-                    runner.run().await;
+                    remove_task = runner.run().await;
                     drop(permit);
                 }
                 Err(e) => {
@@ -175,10 +251,12 @@ impl TaskManager {
                 }
             }
 
-            let _ = tasks.remove_if(&task_id, |_, ctx| Arc::ptr_eq(ctx, &context_this));
+            if remove_task {
+                let _ = tasks.remove_if(&task_id, |_, ctx| Arc::ptr_eq(ctx, &context_this));
+            }
         });
 
-        Ok(())
+        Ok(TaskSubmitResult::accepted())
     }
 
     pub fn cancel_job(&self, job_id: impl AsRef<str>) -> FsResult<()> {
@@ -193,6 +271,31 @@ impl TaskManager {
         Ok(())
     }
 
+    pub fn query_transfer_task(
+        &self,
+        job_id: &str,
+        task_id: &str,
+        run_id: u64,
+        attempt_id: u64,
+        worker_session_id: &str,
+    ) -> FsResult<Option<JobTaskProgress>> {
+        let Some(task) = self.tasks.get(task_id) else {
+            return Ok(None);
+        };
+        if task.info.job.job_id != job_id {
+            return Ok(None);
+        }
+        if !transfer_report_matches(
+            task.info.transfer_report.as_ref(),
+            run_id,
+            attempt_id,
+            worker_session_id,
+        ) {
+            return Ok(None);
+        }
+        Ok(Some(task.progress()))
+    }
+
     pub fn get_fs_context(&self) -> Arc<FsContext> {
         self.fs.fs_context()
     }
@@ -200,4 +303,19 @@ impl TaskManager {
     pub fn available_worker_task_permits(&self) -> usize {
         self.worker_task_semaphore.available_permits()
     }
+}
+
+fn transfer_report_matches(
+    report: Option<&TransferTaskReportInfo>,
+    run_id: u64,
+    attempt_id: u64,
+    worker_session_id: &str,
+) -> bool {
+    matches!(
+        report,
+        Some(report)
+            if report.run_id == run_id
+                && report.attempt_id == attempt_id
+                && report.worker_session_id == worker_session_id
+    )
 }

--- a/curvine-server/src/worker/task/task_store.rs
+++ b/curvine-server/src/worker/task/task_store.rs
@@ -15,7 +15,7 @@
 use std::ops::Deref;
 use std::sync::Arc;
 
-use curvine_common::state::{JobTaskState, LoadTaskInfo};
+use curvine_common::state::LoadTaskInfo;
 use orpc::sync::FastDashMap;
 
 use crate::worker::task::TaskContext;
@@ -60,7 +60,7 @@ impl TaskStore {
     pub fn cancel(&self, job_id: impl AsRef<str>) -> Vec<Arc<TaskContext>> {
         let all_tasks = self.get_all_tasks(job_id);
         for context in all_tasks.iter() {
-            context.update_state(JobTaskState::Canceled, "canceled by master");
+            context.set_canceled("canceled by master");
             let _ = self.tasks.remove(&context.info.task_id);
         }
 
@@ -112,6 +112,8 @@ mod supersede_tests {
             source_path: "s".to_string(),
             target_path: "t".to_string(),
             create_time: 0,
+            source_read_plan_json: String::new(),
+            transfer_report: None,
         }
     }
 

--- a/curvine-server/src/worker/worker_server.rs
+++ b/curvine-server/src/worker/worker_server.rs
@@ -24,6 +24,7 @@ use curvine_fault::FaultHttpControl;
 use curvine_web::server::{WebHandlerService, WebServer};
 use log::info;
 use once_cell::sync::OnceCell;
+use orpc::common::Utils;
 use orpc::common::{LocalTime, Logger};
 use orpc::error::StringError;
 use orpc::handler::HandlerService;
@@ -31,7 +32,7 @@ use orpc::io::net::ConnState;
 #[cfg(feature = "spdk")]
 use orpc::io::spdk_env::SpdkEnv;
 use orpc::runtime::{RpcRuntime, Runtime};
-use orpc::server::{RpcServer, ServerStateListener};
+use orpc::server::{RpcServer, ServerShutdownHandle, ServerStateListener};
 use orpc::sync::FastMutex;
 use orpc::{CommonError, CommonResult};
 use std::sync::Arc;
@@ -52,12 +53,16 @@ pub struct WorkerService {
 }
 
 impl WorkerService {
-    pub fn with_conf(conf: &ClusterConf, rt: Arc<Runtime>) -> CommonResult<Self> {
+    pub fn with_conf(
+        conf: &ClusterConf,
+        rt: Arc<Runtime>,
+        worker_session_id: String,
+    ) -> CommonResult<Self> {
         let fault_http = FaultHttpControl::from_env(&conf.fault_injection)
             .map_err(|error| CommonError::from(error.to_string()))?;
         let store: BlockStore = BlockStore::new(&conf.cluster_id, conf)?;
 
-        let task_manager = TaskManager::with_rt(rt.clone(), conf)?;
+        let task_manager = TaskManager::with_rt(rt.clone(), conf, worker_session_id)?;
 
         let replication_manager =
             WorkerReplicationManager::new(&store, &rt, conf, &task_manager.get_fs_context());
@@ -114,6 +119,19 @@ pub struct Worker {
     rpc_server: Option<RpcServer<WorkerService>>,
     web_server: Option<WebServer<WorkerService>>,
     block_actor: BlockActor,
+}
+
+#[derive(Clone)]
+pub struct WorkerShutdown {
+    rpc: ServerShutdownHandle,
+    web: ServerShutdownHandle,
+}
+
+impl WorkerShutdown {
+    pub fn shutdown(&self) {
+        self.web.shutdown();
+        self.rpc.shutdown();
+    }
 }
 
 impl Worker {
@@ -185,7 +203,9 @@ impl Worker {
         }
 
         let rt = Arc::new(conf.worker_server_conf().create_runtime());
-        let service: WorkerService = WorkerService::with_conf(&conf, rt.clone())?;
+        let worker_session_id = Utils::uuid();
+        let service: WorkerService =
+            WorkerService::with_conf(&conf, rt.clone(), worker_session_id.clone())?;
         let worker_id = service.store.worker_id()?;
 
         CLUSTER_CONF.get_or_init(|| conf.clone());
@@ -209,6 +229,7 @@ impl Worker {
             rt.clone(),
             &conf,
             addr.clone(),
+            worker_session_id,
             block_store.clone(),
             rpc_server.new_state_ctl(),
         )?;
@@ -284,6 +305,20 @@ impl Worker {
 
         let mut rpc_status = rt.block_on(async { self.start().await })?;
         rt.block_on(async { rpc_status.wait_stop().await })
+    }
+
+    pub fn shutdown_handle(&self) -> CommonResult<WorkerShutdown> {
+        let rpc = self
+            .rpc_server
+            .as_ref()
+            .ok_or_else(|| CommonError::from("worker rpc server is not initialized"))?
+            .shutdown_handle();
+        let web = self
+            .web_server
+            .as_ref()
+            .ok_or_else(|| CommonError::from("worker web server is not initialized"))?
+            .shutdown_handle();
+        Ok(WorkerShutdown { rpc, web })
     }
 
     // Start a standalone worker.

--- a/curvine-server/tests/journal_test.rs
+++ b/curvine-server/tests/journal_test.rs
@@ -19,7 +19,7 @@ use curvine_common::raft::storage::{AppStorage, ApplyMsg};
 use curvine_common::raft::{NodeId, RaftPeer};
 use curvine_common::state::{
     BlockLocation, ClientAddress, CommitBlock, CreateFileOpts, MountOptions, OpenFlags,
-    RenameFlags, WorkerInfo, WriteType,
+    RenameFlags, WorkerInfo, WriteType, TRANSFER_TEMP_PATH_MARKER,
 };
 use curvine_common::utils::SerdeUtils;
 use curvine_server::master::fs::MasterFilesystem;
@@ -411,6 +411,70 @@ fn test_ufs_loader_mkdir_recreates_missing_ufs_parent() -> CommonResult<()> {
     rt.block_on(async { loader.mkdir(&mkdir_entry).await })?;
 
     assert!(ufs_dir.join("db/table/log").is_dir());
+    let _ = std::fs::remove_dir_all(&ufs_dir);
+
+    Ok(())
+}
+
+#[test]
+fn test_ufs_loader_skips_transfer_internal_rename() -> CommonResult<()> {
+    Master::init_test_metrics();
+
+    let mut conf = ClusterConf {
+        testing: true,
+        ..Default::default()
+    };
+    conf.change_test_meta_dir(format!(
+        "ufs-loader-transfer-rename-{}",
+        orpc::common::LocalTime::mills()
+    ));
+
+    let journal_system = JournalSystem::from_conf(&conf)?;
+    let fs = MasterFilesystem::with_js(&conf, &journal_system);
+    let mount_manager = journal_system.mount_manager();
+
+    let ufs_dir = std::env::temp_dir().join(format!(
+        "curvine-ufs-loader-transfer-{}-{}",
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    ));
+    let _ = std::fs::remove_dir_all(&ufs_dir);
+    std::fs::create_dir_all(&ufs_dir)?;
+
+    let mount_opts = MountOptions::builder()
+        .write_type(WriteType::FsMode)
+        .build();
+    mount_manager.mount(
+        None,
+        "/mnt",
+        format!("file://{}/", ufs_dir.display()).as_ref(),
+        &mount_opts,
+    )?;
+
+    let temp_path = format!("/mnt/data.txt{TRANSFER_TEMP_PATH_MARKER}job-1-1-task-1-1");
+    fs.create(&temp_path, true)?;
+    journal_system.fs().fs_dir.read().take_entries();
+
+    fs.rename(temp_path.as_str(), "/mnt/data.txt", RenameFlags::empty())?;
+    let rename_entry = match journal_system
+        .fs()
+        .fs_dir
+        .read()
+        .take_entries()
+        .into_iter()
+        .find_map(|entry| match entry {
+            JournalEntry::Rename(e) => Some(e),
+            _ => None,
+        }) {
+        Some(entry) => entry,
+        None => return err_box!("missing transfer rename journal entry"),
+    };
+
+    let loader = UfsLoader::new(journal_system.job_manager(), &conf.journal);
+    let rt = AsyncRuntime::single();
+    rt.block_on(async { loader.rename(&rename_entry).await })?;
+
+    assert!(!ufs_dir.join("data.txt").exists());
     let _ = std::fs::remove_dir_all(&ufs_dir);
 
     Ok(())

--- a/curvine-server/tests/load_job_submit_test.rs
+++ b/curvine-server/tests/load_job_submit_test.rs
@@ -116,6 +116,8 @@ fn load_task(task_id: &str, job_id: &str) -> LoadTaskInfo {
         source_path: "file://source".to_string(),
         target_path: "/mnt/source".to_string(),
         create_time: 0,
+        source_read_plan_json: String::new(),
+        transfer_report: None,
     }
 }
 

--- a/curvine-server/tests/master_fs_test.rs
+++ b/curvine-server/tests/master_fs_test.rs
@@ -41,7 +41,7 @@ use orpc::handler::MessageHandler;
 use orpc::message::Builder;
 #[cfg(feature = "fault-injection")]
 use orpc::message::ResponseStatus;
-use orpc::runtime::{AsyncRuntime, RpcRuntime};
+use orpc::runtime::{AsyncRuntime, GroupExecutor, RpcRuntime};
 use orpc::CommonResult;
 use raft::eraftpb::Entry;
 use std::sync::{Arc, Mutex, OnceLock};
@@ -188,6 +188,7 @@ fn new_handler_for_test(test_name: &str) -> MasterHandler {
         rt.clone(),
         &conf,
     ));
+    let rpc_lane = Arc::new(GroupExecutor::new("master-handler-test", 1, 16));
     MasterHandler::new(
         &conf,
         fs,
@@ -195,6 +196,11 @@ fn new_handler_for_test(test_name: &str) -> MasterHandler {
         None,
         mount_manager,
         JobHandler::new(job_manager),
+        rpc_lane.clone(),
+        rpc_lane.clone(),
+        rpc_lane.clone(),
+        rpc_lane.clone(),
+        rpc_lane,
         replication_manager,
         rt,
         Master::get_metrics().expect("test master metrics should initialize"),
@@ -248,7 +254,7 @@ fn test_master_sync_and_async_rpc_points_follow_dispatch_paths() -> CommonResult
 }
 
 #[test]
-fn only_job_requests_use_the_async_handler() {
+fn control_plane_requests_use_the_async_handler() {
     let _serial = master_fs_test_serial();
     let handler = new_handler();
 
@@ -257,24 +263,20 @@ fn only_job_requests_use_the_async_handler() {
         RpcCode::GetJobStatus,
         RpcCode::CancelJob,
         RpcCode::ReportTask,
-    ] {
-        let msg = Builder::new_rpc(code).build();
-        assert!(
-            !handler.is_sync(&msg),
-            "{code:?} must use the async handler"
-        );
-    }
-
-    for code in [
         RpcCode::GetBlockLocations,
         RpcCode::GetMasterInfo,
+        RpcCode::GetCvMetadataSnapshotPage,
+        RpcCode::GetCvMetadataDeltaPage,
         RpcCode::ListStatus,
         RpcCode::ListOptions,
         RpcCode::WorkerHeartbeat,
         RpcCode::WorkerBlockReport,
     ] {
         let msg = Builder::new_rpc(code).build();
-        assert!(handler.is_sync(&msg), "{code:?} must use the sync handler");
+        assert!(
+            !handler.is_sync(&msg),
+            "{code:?} must use the async handler"
+        );
     }
 
     let mkdir = Builder::new_rpc(RpcCode::Mkdir).build();

--- a/curvine-server/tests/transfer.rs
+++ b/curvine-server/tests/transfer.rs
@@ -1,0 +1,14 @@
+#[path = "transfer/memory_store_test.rs"]
+mod memory_store_test;
+
+#[path = "transfer/sqlite_store_test.rs"]
+mod sqlite_store_test;
+
+#[path = "transfer/mysql_store_test.rs"]
+mod mysql_store_test;
+
+#[path = "transfer/planner_test.rs"]
+mod planner_test;
+
+#[path = "transfer/e2e_transfer_test.rs"]
+mod e2e_transfer_test;

--- a/curvine-server/tests/transfer/e2e_transfer_test.rs
+++ b/curvine-server/tests/transfer/e2e_transfer_test.rs
@@ -1,0 +1,5178 @@
+use std::collections::HashSet;
+use std::fs;
+use std::io::{Read, Write};
+use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream};
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use curvine_client::file::CurvineFileSystem;
+use curvine_client::rpc::{JobMasterClient, TransferClient};
+use curvine_client::unified::UnifiedFileSystem;
+use curvine_common::conf::{ClusterConf, TransferCvMetadataReaderType, TransferStoreType};
+use curvine_common::error::FsError;
+use curvine_common::fs::Path;
+use curvine_common::proto::{
+    GetTransferStatusResponse, SubmitTransferRequest, TransferKindProto, TransferStateProto,
+    TransferTaskStateProto,
+};
+use curvine_common::state::{
+    JobTaskProgress, JobTaskState, LoadJobCommand, LoadJobInfo, LoadTaskInfo, MountInfo,
+    MountOptions, StorageType, TaskAttemptStart, TransferCommand, TransferJobRecord, TransferKind,
+    TransferProgress, TransferTaskRecord, TransferTaskReportInfo, TransferTaskState, TtlAction,
+    WorkerAddress, WorkerInfo,
+};
+use curvine_common::utils::ProtoUtils;
+use curvine_server::common::UfsFactory;
+use curvine_server::test::MiniCluster;
+use curvine_server::transfer::{
+    ClusterMetadataCache, CvMetadataReader, MemoryTransferStore, MetadataReplicaReader,
+    MysqlTransferStore, SqliteTransferStore, TransferServer, TransferServerShutdown,
+    TransferService, TransferStore,
+};
+use curvine_server::worker::task::{LoadTaskRunner, TaskContext};
+use mysql::params;
+use mysql::prelude::*;
+use orpc::io::net::NetUtils;
+use orpc::runtime::{AsyncRuntime, RpcRuntime};
+
+#[test]
+fn test_transfer_server_requires_enabled_config() {
+    let conf = ClusterConf::default();
+    let err = match TransferServer::with_conf(conf) {
+        Ok(_) => panic!("transfer server should reject disabled transfer config"),
+        Err(err) => err.to_string(),
+    };
+    assert!(
+        err.contains("curvine-transfer requires transfer.enabled=true"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn test_transfer_server_infers_local_report_endpoint() {
+    let mut conf = ClusterConf::default();
+    conf.transfer.enabled = true;
+    conf.transfer.endpoints.clear();
+    conf.transfer.init().unwrap();
+
+    assert_eq!(conf.transfer.endpoints, vec!["localhost:9010"]);
+}
+
+#[test]
+fn test_transfer_readyz_rejects_stale_cluster_snapshot() {
+    let test_id = format!(
+        "transfer-readyz-stale-snapshot-{}-{}",
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    );
+    let base_dir = std::env::temp_dir().join(&test_id);
+    let _ = fs::remove_dir_all(&base_dir);
+
+    let mut conf = ClusterConf::default();
+    conf.master.meta_dir = base_dir.join("meta").display().to_string();
+    conf.journal.journal_dir = base_dir.join("journal").display().to_string();
+    conf.worker.data_dir = vec![base_dir.join("worker").display().to_string()];
+    conf.transfer.enabled = true;
+    conf.transfer.hostname = "localhost".to_string();
+    conf.transfer.rpc_port = NetUtils::get_available_port();
+    conf.transfer.web_port = NetUtils::get_available_port();
+    conf.transfer.endpoints = vec![format!(
+        "{}:{}",
+        conf.transfer.hostname, conf.transfer.rpc_port
+    )];
+    conf.transfer.cluster_snapshot_max_staleness_str = "200ms".to_string();
+    conf.transfer.init().unwrap();
+
+    let cluster = MiniCluster::with_num(&conf, 1, 1);
+    cluster.start_cluster();
+    let rt = cluster.clone_client_rt();
+    rt.block_on(async {
+        let mut transfer_server = InProcessTransferServer::start(cluster.cluster_conf.clone());
+        let ready = read_http_path(cluster.cluster_conf.transfer.web_port, "/readyz");
+        assert!(
+            ready.contains("200 OK") && ready.ends_with("ok\n"),
+            "transfer readiness should be ok after initial snapshot, response: {ready}"
+        );
+
+        tokio::time::sleep(Duration::from_millis(350)).await;
+        let stale = read_http_path(cluster.cluster_conf.transfer.web_port, "/readyz");
+        assert!(
+            stale.contains("503 Service Unavailable")
+                && stale.contains("Cluster metadata snapshot is stale"),
+            "transfer readiness should reject stale cluster snapshot, response: {stale}"
+        );
+
+        transfer_server.stop();
+        let _ = fs::remove_dir_all(base_dir);
+    });
+}
+
+#[test]
+fn test_transfer_server_does_not_fallback_when_mysql_store_is_unavailable() {
+    let mut conf = ClusterConf::default();
+    conf.transfer.enabled = true;
+    conf.transfer.store_type = TransferStoreType::Mysql;
+    conf.transfer.mysql_url =
+        "mysql://root:curvine@127.0.0.1:1/curvine_transfer_unavailable".into();
+    conf.transfer.endpoints = vec!["localhost:9010".to_string()];
+    conf.transfer.init().unwrap();
+
+    let err = match TransferServer::with_conf(conf) {
+        Ok(_) => panic!("transfer server should fail when mysql store is unavailable"),
+        Err(err) => err.to_string(),
+    };
+    assert!(
+        err.contains("Transfer metadata store is unavailable"),
+        "unexpected mysql unavailable error: {err}"
+    );
+}
+
+#[test]
+fn test_master_submit_job_is_disabled_when_transfer_is_enabled() {
+    let test_id = format!(
+        "transfer-master-submit-disabled-{}-{}",
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    );
+    let base_dir = std::env::temp_dir().join(&test_id);
+
+    let mut conf = ClusterConf::default();
+    conf.master.meta_dir = base_dir.join("meta").display().to_string();
+    conf.journal.journal_dir = base_dir.join("journal").display().to_string();
+    conf.worker.data_dir = vec![base_dir.join("worker").display().to_string()];
+    conf.transfer.enabled = true;
+    conf.transfer.init().unwrap();
+
+    let cluster = MiniCluster::with_num(&conf, 1, 1);
+    cluster.start_cluster();
+    let rt = cluster.clone_client_rt();
+
+    rt.block_on(async {
+        let fs = wait_master_and_create_fs(&cluster).await;
+        let client = JobMasterClient::new(fs.fs_client());
+        let err = client
+            .submit_load_job(LoadJobCommand::builder("/mnt/file.txt").build())
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("Legacy Master SubmitJob is disabled because transfer.enabled=true"),
+            "unexpected error: {err}"
+        );
+
+        let err = client
+            .submit_export_job(LoadJobCommand::builder("/mnt/file.txt").build())
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("Legacy Master SubmitJob is disabled because transfer.enabled=true"),
+            "legacy Master Export SubmitJob must be disabled: {err}"
+        );
+
+        let _ = fs::remove_dir_all(base_dir);
+    });
+}
+
+#[test]
+fn test_submit_transfer_refreshes_missing_mount_snapshot() {
+    let test_id = format!(
+        "transfer-local-snapshot-submit-{}-{}",
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    );
+    let base_dir = std::env::temp_dir().join(&test_id);
+    let ufs_dir = base_dir.join("ufs");
+    fs::create_dir_all(&ufs_dir).unwrap();
+
+    let mut conf = ClusterConf::default();
+    conf.master.meta_dir = base_dir.join("meta").display().to_string();
+    conf.journal.journal_dir = base_dir.join("journal").display().to_string();
+    conf.worker.data_dir = vec![base_dir.join("worker").display().to_string()];
+    conf.transfer.enabled = true;
+    conf.transfer.init().unwrap();
+
+    let cluster = MiniCluster::with_num(&conf, 1, 1);
+    cluster.start_cluster();
+    let rt = cluster.clone_client_rt();
+
+    rt.block_on(async {
+        let fs = CurvineFileSystem::with_rt(cluster.cluster_conf.clone(), rt.clone()).unwrap();
+        fs.mount(
+            &Path::from_str(format!("file://{}", ufs_dir.display())).unwrap(),
+            &Path::from_str("/mnt").unwrap(),
+            MountOptions::builder().build(),
+        )
+        .await
+        .unwrap();
+
+        let cache = ClusterMetadataCache::new(fs);
+        let service = TransferService::with_cache(
+            Arc::new(MemoryTransferStore::new()),
+            cache.clone(),
+            cluster.cluster_conf.transfer.task_stale_timeout,
+        );
+        let request = SubmitTransferRequest {
+            kind: TransferKindProto::TransferLoad as i32,
+            source_path: format!("file://{}/snapshot.txt", ufs_dir.display()),
+            target_path: "/mnt/snapshot.txt".to_string(),
+            client_request_id: test_id.clone(),
+            submitter: "snapshot-submit".to_string(),
+            tenant: "test".to_string(),
+            command: Vec::new(),
+            protocol_version: Some(1),
+        };
+
+        let job = service.submit_transfer(request).unwrap();
+        assert_eq!(job.target_path, "/mnt/snapshot.txt");
+        assert!(
+            job.cluster_snapshot_version > 0,
+            "SubmitTransfer should persist the refreshed mount snapshot version"
+        );
+    });
+
+    let _ = fs::remove_dir_all(base_dir);
+}
+
+#[test]
+fn test_submit_transfer_rejects_stale_cluster_snapshot_by_default() {
+    let test_id = format!(
+        "transfer-stale-cluster-snapshot-{}-{}",
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    );
+    let base_dir = std::env::temp_dir().join(&test_id);
+    let ufs_dir = base_dir.join("ufs");
+    fs::create_dir_all(&ufs_dir).unwrap();
+
+    let mut conf = ClusterConf::default();
+    conf.master.meta_dir = base_dir.join("meta").display().to_string();
+    conf.journal.journal_dir = base_dir.join("journal").display().to_string();
+    conf.worker.data_dir = vec![base_dir.join("worker").display().to_string()];
+    conf.transfer.enabled = true;
+    conf.transfer.cluster_snapshot_max_staleness_str = "1ms".to_string();
+    conf.transfer.init().unwrap();
+
+    let cluster = MiniCluster::with_num(&conf, 1, 1);
+    cluster.start_cluster();
+    let rt = cluster.clone_client_rt();
+
+    rt.block_on(async {
+        let fs = CurvineFileSystem::with_rt(cluster.cluster_conf.clone(), rt.clone()).unwrap();
+        fs.mount(
+            &Path::from_str(format!("file://{}", ufs_dir.display())).unwrap(),
+            &Path::from_str("/mnt").unwrap(),
+            MountOptions::builder().build(),
+        )
+        .await
+        .unwrap();
+
+        let request = SubmitTransferRequest {
+            kind: TransferKindProto::TransferLoad as i32,
+            source_path: format!("file://{}/stale.txt", ufs_dir.display()),
+            target_path: "/mnt/stale.txt".to_string(),
+            client_request_id: format!("{test_id}-stale"),
+            submitter: "stale-submit".to_string(),
+            tenant: "test".to_string(),
+            command: Vec::new(),
+            protocol_version: Some(1),
+        };
+
+        let cache = ClusterMetadataCache::with_snapshot_policy(
+            fs.clone(),
+            cluster.cluster_conf.transfer.cluster_snapshot_max_staleness,
+            false,
+        );
+        cache.refresh().await.unwrap();
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        let service = TransferService::with_cache(
+            Arc::new(MemoryTransferStore::new()),
+            cache,
+            cluster.cluster_conf.transfer.task_stale_timeout,
+        );
+        let err = service.submit_transfer(request.clone()).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Cluster metadata snapshot is stale"),
+            "SubmitTransfer should reject stale cluster snapshot by default: {err}"
+        );
+
+        let stale_allowed_cache = ClusterMetadataCache::with_snapshot_policy(
+            fs,
+            cluster.cluster_conf.transfer.cluster_snapshot_max_staleness,
+            true,
+        );
+        stale_allowed_cache.refresh().await.unwrap();
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        let service = TransferService::with_cache(
+            Arc::new(MemoryTransferStore::new()),
+            stale_allowed_cache,
+            cluster.cluster_conf.transfer.task_stale_timeout,
+        );
+        let mut allowed_request = request;
+        allowed_request.client_request_id = format!("{test_id}-allowed");
+        let job = service.submit_transfer(allowed_request).unwrap();
+        assert_eq!(job.target_path, "/mnt/stale.txt");
+    });
+
+    let _ = fs::remove_dir_all(base_dir);
+}
+
+#[test]
+fn test_transfer_load_file_end_to_end() {
+    let test_id = format!(
+        "transfer-e2e-{}-{}",
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    );
+    let base_dir = std::env::temp_dir().join(&test_id);
+    let ufs_dir = base_dir.join("ufs");
+    fs::create_dir_all(&ufs_dir).unwrap();
+    fs::write(ufs_dir.join("hello.txt"), b"hello-transfer").unwrap();
+
+    let mut conf = ClusterConf::default();
+    conf.master.meta_dir = base_dir.join("meta").display().to_string();
+    conf.journal.journal_dir = base_dir.join("journal").display().to_string();
+    conf.worker.data_dir = vec![base_dir.join("worker").display().to_string()];
+    conf.transfer.enabled = true;
+    conf.transfer.store_type = TransferStoreType::Sqlite;
+    conf.transfer.sqlite_path = base_dir.join("transfer.db").display().to_string();
+    conf.transfer.hostname = "localhost".to_string();
+    conf.transfer.rpc_port = NetUtils::hold_available_port();
+    conf.transfer.web_port = NetUtils::hold_available_port();
+    conf.transfer.endpoints = vec![format!(
+        "{}:{}",
+        conf.transfer.hostname, conf.transfer.rpc_port
+    )];
+    conf.transfer.init().unwrap();
+
+    let cluster = MiniCluster::with_num(&conf, 1, 1);
+    cluster.start_cluster();
+    let rt = cluster.clone_client_rt();
+
+    rt.block_on(async {
+        let fs = CurvineFileSystem::with_rt(cluster.cluster_conf.clone(), rt.clone()).unwrap();
+        fs.mount(
+            &Path::from_str(format!("file://{}", ufs_dir.display())).unwrap(),
+            &Path::from_str("/mnt").unwrap(),
+            MountOptions::builder().build(),
+        )
+        .await
+        .unwrap();
+
+        let mut transfer_server =
+            InProcessTransferServer::start_liveness(cluster.cluster_conf.clone());
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        let healthz = read_http_path(cluster.cluster_conf.transfer.web_port, "/healthz");
+        assert!(
+            healthz.ends_with("ok\n"),
+            "transfer health endpoint should return ok, response: {healthz}"
+        );
+        let readyz = read_http_path(cluster.cluster_conf.transfer.web_port, "/readyz");
+        assert!(
+            readyz.ends_with("ok\n"),
+            "transfer readiness endpoint should return ok after startup, response: {readyz}"
+        );
+        let startup_metrics = read_http_metrics(cluster.cluster_conf.transfer.web_port);
+        assert!(
+            startup_metrics.contains("transfer_task_report_queue_len"),
+            "transfer metrics endpoint should expose transfer metrics"
+        );
+        assert!(
+            startup_metrics.contains("transfer_task_report_queue_len_by_lane"),
+            "transfer metrics endpoint should expose report lane metrics"
+        );
+        assert!(
+            startup_metrics.contains("transfer_acquire_total"),
+            "transfer metrics endpoint should expose scheduler metrics"
+        );
+
+        let client = TransferClient::with_rt(&cluster.cluster_conf, rt.clone()).unwrap();
+        let source = Path::from_str(format!("file://{}/hello.txt", ufs_dir.display())).unwrap();
+        let target = Path::from_str("/mnt/hello.txt").unwrap();
+        let submit = client
+            .submit(TransferCommand {
+                kind: TransferKind::Load,
+                source_path: source.clone_uri(),
+                target_path: target.clone_uri(),
+                client_request_id: test_id.clone(),
+                submitter: "e2e".to_string(),
+                tenant: "test".to_string(),
+                options: Default::default(),
+            })
+            .await
+            .unwrap();
+
+        let mut final_state = submit.state;
+        for _ in 0..80 {
+            let status = client
+                .status_page(&submit.job_id, Some(10), None)
+                .await
+                .unwrap();
+            final_state = status.state;
+            if final_state == TransferStateProto::TransferCompleted as i32
+                || final_state == TransferStateProto::TransferFailed as i32
+            {
+                assert!(!status.tasks.is_empty(), "status should return task page");
+                assert_eq!(
+                    status.cv_metadata_epoch, None,
+                    "load planning should not persist a CV metadata snapshot epoch"
+                );
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
+
+        assert_eq!(final_state, TransferStateProto::TransferCompleted as i32);
+        let content = fs.read_string(&target).await.unwrap();
+        assert_eq!(content, "hello-transfer");
+        let ufs_content = fs::read_to_string(ufs_dir.join("hello.txt")).unwrap();
+        assert_eq!(ufs_content, "hello-transfer");
+        let completed_metrics = read_http_metrics(cluster.cluster_conf.transfer.web_port);
+        assert!(
+            completed_metrics.contains("transfer_store_operation_duration_us"),
+            "transfer metrics endpoint should expose store operation latency"
+        );
+        assert!(
+            completed_metrics.contains("transfer_store_unavailable"),
+            "transfer metrics endpoint should expose store availability"
+        );
+        assert!(
+            completed_metrics.contains("transfer_store_unavailable_duration_us_total"),
+            "transfer metrics endpoint should expose store unavailable duration"
+        );
+        assert!(
+            completed_metrics.contains("transfer_metadata_operation_duration_us"),
+            "transfer metrics endpoint should expose metadata operation latency"
+        );
+        assert!(
+            completed_metrics.contains("source=\"ufs\""),
+            "transfer metadata metrics should record UFS planning operations"
+        );
+
+        transfer_server.stop();
+        let _ = fs::remove_dir_all(base_dir);
+    });
+}
+
+#[test]
+fn test_unified_async_cache_waits_for_transfer_job() {
+    let test_id = format!(
+        "transfer-unified-wait-e2e-{}-{}",
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    );
+    let base_dir = std::env::temp_dir().join(&test_id);
+    let ufs_dir = base_dir.join("ufs");
+    fs::create_dir_all(&ufs_dir).unwrap();
+    fs::write(ufs_dir.join("cached.txt"), b"unified-transfer-cache").unwrap();
+
+    let mut conf = ClusterConf::default();
+    conf.master.meta_dir = base_dir.join("meta").display().to_string();
+    conf.journal.journal_dir = base_dir.join("journal").display().to_string();
+    conf.worker.data_dir = vec![base_dir.join("worker").display().to_string()];
+    conf.transfer.enabled = true;
+    conf.transfer.store_type = TransferStoreType::Sqlite;
+    conf.transfer.sqlite_path = base_dir.join("transfer.db").display().to_string();
+    conf.transfer.hostname = "localhost".to_string();
+    conf.transfer.rpc_port = NetUtils::hold_available_port();
+    conf.transfer.web_port = NetUtils::hold_available_port();
+    conf.transfer.endpoints = vec![format!(
+        "{}:{}",
+        conf.transfer.hostname, conf.transfer.rpc_port
+    )];
+    conf.transfer.init().unwrap();
+
+    let cluster = MiniCluster::with_num(&conf, 1, 1);
+    cluster.start_cluster();
+    let rt = cluster.clone_client_rt();
+
+    rt.block_on(async {
+        let unified = UnifiedFileSystem::with_rt(cluster.cluster_conf.clone(), rt.clone()).unwrap();
+        let target = Path::from_str("/mnt/cached.txt").unwrap();
+        unified
+            .mount(
+                &Path::from_str(format!("file://{}", ufs_dir.display())).unwrap(),
+                &Path::from_str("/mnt").unwrap(),
+                MountOptions::builder().build(),
+            )
+            .await
+            .unwrap();
+
+        let mut transfer_server =
+            InProcessTransferServer::start_liveness(cluster.cluster_conf.clone());
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        unified.async_cache(&target).unwrap();
+        unified.wait_job_complete(&target, true).await.unwrap();
+        assert_eq!(
+            unified.cv().read_string(&target).await.unwrap(),
+            "unified-transfer-cache"
+        );
+
+        transfer_server.stop();
+        let _ = fs::remove_dir_all(base_dir);
+    });
+}
+
+#[test]
+fn test_transfer_load_directory_uses_multiple_workers_end_to_end() {
+    const FILE_COUNT: usize = 36;
+    const PAYLOAD_BYTES: usize = 32 * 1024;
+
+    let test_id = format!(
+        "transfer-multi-worker-e2e-{}-{}",
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    );
+    let base_dir = std::env::temp_dir().join(&test_id);
+    let ufs_dir = base_dir.join("ufs");
+    for shard in 0..3 {
+        fs::create_dir_all(ufs_dir.join(format!("nested-{shard}"))).unwrap();
+    }
+    let mut expected_total_size = 0i64;
+    for index in 0..FILE_COUNT {
+        let shard = index % 3;
+        let path = ufs_dir
+            .join(format!("nested-{shard}"))
+            .join(format!("file-{index}.txt"));
+        let payload = format!(
+            "multi-worker-content-{index}\n{}",
+            "x".repeat(PAYLOAD_BYTES)
+        );
+        expected_total_size += payload.len() as i64;
+        fs::write(path, payload).unwrap();
+    }
+
+    let mut conf = ClusterConf::default();
+    conf.master.meta_dir = base_dir.join("meta").display().to_string();
+    conf.journal.journal_dir = base_dir.join("journal").display().to_string();
+    conf.worker.data_dir = vec![base_dir.join("worker").display().to_string()];
+    conf.transfer.enabled = true;
+    conf.transfer.store_type = TransferStoreType::Sqlite;
+    conf.transfer.sqlite_path = base_dir.join("transfer.db").display().to_string();
+    conf.transfer.cv_metadata_reader = TransferCvMetadataReaderType::Master;
+    conf.transfer.hostname = "localhost".to_string();
+    conf.transfer.rpc_port = NetUtils::hold_available_port();
+    conf.transfer.web_port = NetUtils::hold_available_port();
+    conf.transfer.endpoints = vec![format!(
+        "{}:{}",
+        conf.transfer.hostname, conf.transfer.rpc_port
+    )];
+    conf.transfer.init().unwrap();
+
+    let cluster = MiniCluster::with_num(&conf, 1, 3);
+    cluster.start_cluster();
+    let rt = cluster.clone_client_rt();
+
+    rt.block_on(async {
+        let fs = wait_master_and_create_fs(&cluster).await;
+        fs.mount(
+            &Path::from_str(format!("file://{}", ufs_dir.display())).unwrap(),
+            &Path::from_str("/mnt").unwrap(),
+            MountOptions::builder().build(),
+        )
+        .await
+        .unwrap();
+
+        let mut transfer_server =
+            InProcessTransferServer::start_liveness(cluster.cluster_conf.clone());
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        let startup_metrics = read_http_metrics(cluster.cluster_conf.transfer.web_port);
+        assert!(
+            startup_metrics.contains("transfer_cluster_snapshot_version"),
+            "transfer metrics should expose cluster snapshot version"
+        );
+        assert!(
+            startup_metrics.contains("transfer_cluster_snapshot_staleness_ms"),
+            "transfer metrics should expose cluster snapshot staleness"
+        );
+        assert!(
+            startup_metrics.contains("transfer_cluster_snapshot_capable_workers"),
+            "transfer metrics should expose capable worker count"
+        );
+
+        let client = TransferClient::with_rt(&cluster.cluster_conf, rt.clone()).unwrap();
+        let submit = client
+            .submit(TransferCommand {
+                kind: TransferKind::Load,
+                source_path: format!("file://{}", ufs_dir.display()),
+                target_path: "/mnt/multi-worker-load".to_string(),
+                client_request_id: test_id.clone(),
+                submitter: "multi-worker-e2e".to_string(),
+                tenant: "test".to_string(),
+                options: Default::default(),
+            })
+            .await
+            .unwrap();
+
+        let status = wait_transfer_state(
+            &client,
+            &submit.job_id,
+            TransferStateProto::TransferCompleted,
+            Duration::from_secs(60),
+        )
+        .await;
+        assert_eq!(
+            status.tasks.len(),
+            FILE_COUNT,
+            "directory load should create one task per source file"
+        );
+        let worker_sessions = status
+            .tasks
+            .iter()
+            .map(|task| (task.worker_id, task.worker_session_id.clone()))
+            .collect::<HashSet<_>>();
+        assert!(
+            worker_sessions.len() == 3,
+            "multi-worker load should execute on all three workers, got {:?}",
+            worker_sessions
+        );
+        assert!(
+            status
+                .tasks
+                .iter()
+                .all(|task| task.state == TransferTaskStateProto::TransferTaskCompleted as i32),
+            "all directory load tasks must complete: {:?}",
+            status.tasks
+        );
+
+        assert_eq!(
+            status.progress.total_size, expected_total_size,
+            "transfer total size should match source bytes"
+        );
+        assert_eq!(
+            status.progress.loaded_size, expected_total_size,
+            "transfer loaded size should match source bytes"
+        );
+
+        for index in 0..FILE_COUNT {
+            let shard = index % 3;
+            let target = format!("/mnt/multi-worker-load/nested-{shard}/file-{index}.txt");
+            let content = fs
+                .read_string(&Path::from_str(target).unwrap())
+                .await
+                .unwrap();
+            assert!(
+                content.starts_with(&format!("multi-worker-content-{index}\n")),
+                "unexpected copied content for file {index}"
+            );
+            assert_eq!(
+                content.len(),
+                "multi-worker-content-\n".len() + index.to_string().len() + PAYLOAD_BYTES
+            );
+        }
+
+        let metrics = read_http_metrics(cluster.cluster_conf.transfer.web_port);
+        assert!(
+            metrics.contains("transfer_task_report_total"),
+            "transfer metrics should include task report counters after multi-worker load"
+        );
+        assert!(
+            metrics.contains("transfer_dispatch_total"),
+            "transfer metrics should include dispatch counters after multi-worker load"
+        );
+
+        transfer_server.stop();
+        let _ = fs::remove_dir_all(base_dir);
+    });
+}
+
+#[test]
+#[ignore = "stress e2e: run explicitly to validate load storm backlog, dispatch, reports, and data consistency"]
+fn test_transfer_load_storm_keeps_jobs_pending_and_completes_without_master_job_path() {
+    const JOB_COUNT: usize = 48;
+    const FILES_PER_JOB: usize = 6;
+    const PAYLOAD_BYTES: usize = 64 * 1024;
+
+    let test_id = format!(
+        "transfer-load-storm-e2e-{}-{}",
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    );
+    let base_dir = std::env::temp_dir().join(&test_id);
+    let ufs_dir = base_dir.join("ufs");
+    for job_index in 0..JOB_COUNT {
+        let job_dir = ufs_dir.join(format!("job-{job_index}"));
+        fs::create_dir_all(&job_dir).unwrap();
+        for file_index in 0..FILES_PER_JOB {
+            let payload = format!(
+                "load-storm-job-{job_index}-file-{file_index}\n{}",
+                "x".repeat(PAYLOAD_BYTES)
+            );
+            fs::write(job_dir.join(format!("file-{file_index}.bin")), payload).unwrap();
+        }
+    }
+
+    let mut conf = ClusterConf::default();
+    conf.master.meta_dir = base_dir.join("meta").display().to_string();
+    conf.journal.journal_dir = base_dir.join("journal").display().to_string();
+    conf.worker.data_dir = vec![base_dir.join("worker").display().to_string()];
+    conf.transfer.enabled = true;
+    conf.transfer.store_type = TransferStoreType::Sqlite;
+    conf.transfer.sqlite_path = base_dir.join("transfer.db").display().to_string();
+    conf.transfer.cv_metadata_reader = TransferCvMetadataReaderType::Master;
+    conf.transfer.hostname = "localhost".to_string();
+    conf.transfer.rpc_port = NetUtils::hold_available_port();
+    conf.transfer.web_port = NetUtils::hold_available_port();
+    conf.transfer.endpoints = vec![format!(
+        "{}:{}",
+        conf.transfer.hostname, conf.transfer.rpc_port
+    )];
+    conf.transfer.max_running_transfers = 2;
+    conf.transfer.init().unwrap();
+
+    let cluster = MiniCluster::with_num(&conf, 1, 3);
+    cluster.start_cluster();
+    let rt = cluster.clone_client_rt();
+
+    rt.block_on(async {
+        let fs = wait_master_and_create_fs(&cluster).await;
+        fs.mount(
+            &Path::from_str(format!("file://{}", ufs_dir.display())).unwrap(),
+            &Path::from_str("/mnt").unwrap(),
+            MountOptions::builder().build(),
+        )
+        .await
+        .unwrap();
+
+        let store = Arc::new(SqliteTransferStore::open(&cluster.cluster_conf.transfer.sqlite_path).unwrap());
+        let mut transfer_server = InProcessTransferServer::start(cluster.cluster_conf.clone());
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        let client = Arc::new(TransferClient::with_rt(&cluster.cluster_conf, rt.clone()).unwrap());
+
+        let submit_started = std::time::Instant::now();
+        let mut handles = Vec::with_capacity(JOB_COUNT);
+        for job_index in 0..JOB_COUNT {
+            let client = client.clone();
+            let source_path = format!("file://{}/job-{job_index}", ufs_dir.display());
+            let target_path = format!("/mnt/load-storm/job-{job_index}");
+            let client_request_id = format!("{test_id}-{job_index}");
+            handles.push(tokio::spawn(async move {
+                client
+                    .submit(TransferCommand {
+                        kind: TransferKind::Load,
+                        source_path,
+                        target_path,
+                        client_request_id,
+                        submitter: "load-storm-e2e".to_string(),
+                        tenant: "stress".to_string(),
+                        options: Default::default(),
+                    })
+                    .await
+                    .unwrap()
+                    .job_id
+            }));
+        }
+        let mut job_ids = Vec::with_capacity(JOB_COUNT);
+        for handle in handles {
+            job_ids.push(handle.await.unwrap());
+        }
+        eprintln!(
+            "submitted {JOB_COUNT} load jobs with {} total files in {:?}",
+            JOB_COUNT * FILES_PER_JOB,
+            submit_started.elapsed()
+        );
+
+        let legacy_client = JobMasterClient::new(fs.fs_client());
+        let legacy_err = legacy_client
+            .submit_load_job(LoadJobCommand::builder("/mnt/load-storm/legacy.txt").build())
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(
+            legacy_err.contains("Legacy Master SubmitJob is disabled because transfer.enabled=true"),
+            "legacy Master SubmitJob must stay blocked during load storm: {legacy_err}"
+        );
+
+        let mut max_observed_executing = 0u64;
+        let mut observed_pending_backlog = false;
+        let deadline = std::time::Instant::now() + Duration::from_secs(180);
+        loop {
+            let active = store.count_active_transfers().unwrap();
+            let executing = store.count_executing_transfers().unwrap();
+            max_observed_executing = max_observed_executing.max(executing);
+            if active > executing {
+                observed_pending_backlog = true;
+            }
+
+            let mut completed = 0usize;
+            for job_id in &job_ids {
+                let status = client.status_page(job_id, Some(10), None).await.unwrap();
+                if status.state == TransferStateProto::TransferCompleted as i32 {
+                    completed += 1;
+                }
+            }
+            if completed == JOB_COUNT {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "load storm did not complete in time: completed={completed}/{JOB_COUNT}, active={active}, executing={executing}"
+            );
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+
+        assert!(
+            observed_pending_backlog,
+            "load storm should create Pending backlog when max_running_transfers is lower than submitted jobs"
+        );
+        assert!(
+            max_observed_executing <= cluster.cluster_conf.transfer.max_running_transfers as u64,
+            "executing transfers exceeded configured window: observed={}, limit={}",
+            max_observed_executing,
+            cluster.cluster_conf.transfer.max_running_transfers
+        );
+
+        let mut worker_sessions = HashSet::new();
+        for (job_index, job_id) in job_ids.iter().enumerate() {
+            let status = client
+                .status_page(job_id, Some(FILES_PER_JOB as u32 + 1), None)
+                .await
+                .unwrap();
+            assert_eq!(
+                status.state,
+                TransferStateProto::TransferCompleted as i32,
+                "job {job_id} should complete"
+            );
+            assert_eq!(
+                status.tasks.len(),
+                FILES_PER_JOB,
+                "job {job_id} should have one task per source file"
+            );
+            for task in &status.tasks {
+                assert_eq!(
+                    task.state,
+                    TransferTaskStateProto::TransferTaskCompleted as i32
+                );
+                worker_sessions.insert((task.worker_id, task.worker_session_id.clone()));
+            }
+            for file_index in 0..FILES_PER_JOB {
+                let target =
+                    Path::from_str(format!("/mnt/load-storm/job-{job_index}/file-{file_index}.bin"))
+                        .unwrap();
+                let content = fs.read_string(&target).await.unwrap();
+                assert!(
+                    content.starts_with(&format!("load-storm-job-{job_index}-file-{file_index}\n")),
+                    "unexpected copied content for {target}"
+                );
+                assert_eq!(
+                    content.len(),
+                    format!("load-storm-job-{job_index}-file-{file_index}\n").len()
+                        + PAYLOAD_BYTES
+                );
+            }
+        }
+        assert!(
+            worker_sessions.len() >= 2,
+            "load storm should use multiple workers, got {:?}",
+            worker_sessions
+        );
+
+        let metrics = read_http_metrics(cluster.cluster_conf.transfer.web_port);
+        for metric in [
+            "transfer_submit_total",
+            "transfer_pending_jobs",
+            "transfer_executing_jobs",
+            "transfer_dispatch_total",
+            "transfer_task_report_total",
+        ] {
+            assert!(
+                metrics.contains(metric),
+                "transfer metrics should expose {metric} after load storm"
+            );
+        }
+
+        transfer_server.stop();
+        let _ = fs::remove_dir_all(base_dir);
+    });
+}
+
+#[test]
+fn test_transfer_recovers_completed_task_when_final_report_is_lost() {
+    let test_id = format!(
+        "transfer-lost-final-report-{}-{}",
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    );
+    let base_dir = std::env::temp_dir().join(&test_id);
+    let ufs_dir = base_dir.join("ufs");
+    fs::create_dir_all(&ufs_dir).unwrap();
+    fs::write(ufs_dir.join("lost-report.txt"), b"lost-final-report").unwrap();
+
+    let mut conf = ClusterConf::default();
+    conf.master.meta_dir = base_dir.join("meta").display().to_string();
+    conf.journal.journal_dir = base_dir.join("journal").display().to_string();
+    conf.worker.data_dir = vec![base_dir.join("worker").display().to_string()];
+    conf.transfer.enabled = true;
+    conf.transfer.store_type = TransferStoreType::Sqlite;
+    conf.transfer.sqlite_path = base_dir.join("transfer.db").display().to_string();
+    conf.transfer.hostname = "localhost".to_string();
+    conf.transfer.rpc_port = NetUtils::hold_available_port();
+    conf.transfer.web_port = NetUtils::hold_available_port();
+    conf.transfer.instance_id = "transfer-child-recover".to_string();
+    let actual_transfer_endpoint = format!("{}:{}", conf.transfer.hostname, conf.transfer.rpc_port);
+    conf.transfer.endpoints = vec!["localhost:1".to_string()];
+    conf.transfer.lease_timeout_str = "1s".to_string();
+    conf.transfer.init().unwrap();
+
+    let cluster = MiniCluster::with_num(&conf, 1, 1);
+    cluster.start_cluster();
+    let rt = cluster.clone_client_rt();
+
+    rt.block_on(async {
+        let fs = CurvineFileSystem::with_rt(cluster.cluster_conf.clone(), rt.clone()).unwrap();
+        fs.mount(
+            &Path::from_str(format!("file://{}", ufs_dir.display())).unwrap(),
+            &Path::from_str("/mnt").unwrap(),
+            MountOptions::builder().build(),
+        )
+        .await
+        .unwrap();
+
+        let mut transfer_server = InProcessTransferServer::start(cluster.cluster_conf.clone());
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        let mut client_conf = cluster.cluster_conf.clone();
+        client_conf.transfer.endpoints = vec![actual_transfer_endpoint];
+        let client = TransferClient::with_rt(&client_conf, rt.clone()).unwrap();
+        let target = Path::from_str("/mnt/lost-report.txt").unwrap();
+        let submit = client
+            .submit(TransferCommand {
+                kind: TransferKind::Load,
+                source_path: format!("file://{}/lost-report.txt", ufs_dir.display()),
+                target_path: target.clone_uri(),
+                client_request_id: test_id.clone(),
+                submitter: "lost-final-report-e2e".to_string(),
+                tenant: "test".to_string(),
+                options: Default::default(),
+            })
+            .await
+            .unwrap();
+
+        let mut final_state = submit.state;
+        let mut task_state = 0;
+        for _ in 0..120 {
+            let status = client
+                .status_page(&submit.job_id, Some(10), None)
+                .await
+                .unwrap();
+            final_state = status.state;
+            if let Some(task) = status.tasks.first() {
+                task_state = task.state;
+            }
+            if final_state == TransferStateProto::TransferCompleted as i32
+                || final_state == TransferStateProto::TransferFailed as i32
+            {
+                assert!(!status.tasks.is_empty(), "status should return task page");
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
+
+        assert_eq!(final_state, TransferStateProto::TransferCompleted as i32);
+        assert_eq!(
+            task_state,
+            TransferTaskStateProto::TransferTaskCompleted as i32
+        );
+        assert_eq!(fs.read_string(&target).await.unwrap(), "lost-final-report");
+
+        transfer_server.stop();
+        let _ = fs::remove_dir_all(base_dir);
+    });
+}
+
+#[test]
+fn test_transfer_cancel_pending_job_end_to_end() {
+    let test_id = format!(
+        "transfer-cancel-pending-{}-{}",
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    );
+    let base_dir = std::env::temp_dir().join(&test_id);
+    let ufs_dir = base_dir.join("ufs");
+    fs::create_dir_all(&ufs_dir).unwrap();
+    fs::write(ufs_dir.join("pending.txt"), b"cancel-pending").unwrap();
+
+    let mut conf = ClusterConf::default();
+    conf.master.meta_dir = base_dir.join("meta").display().to_string();
+    conf.journal.journal_dir = base_dir.join("journal").display().to_string();
+    conf.transfer.enabled = true;
+    conf.transfer.store_type = TransferStoreType::Sqlite;
+    conf.transfer.sqlite_path = base_dir.join("transfer.db").display().to_string();
+    conf.transfer.hostname = "localhost".to_string();
+    conf.transfer.rpc_port = NetUtils::hold_available_port();
+    conf.transfer.web_port = NetUtils::hold_available_port();
+    conf.transfer.instance_id = "transfer-cancel-pending".to_string();
+    conf.transfer.endpoints = vec![format!(
+        "{}:{}",
+        conf.transfer.hostname, conf.transfer.rpc_port
+    )];
+    conf.transfer.init().unwrap();
+
+    let cluster = MiniCluster::with_num(&conf, 1, 0);
+    cluster.start_cluster();
+    let rt = cluster.clone_client_rt();
+
+    rt.block_on(async {
+        let fs = CurvineFileSystem::with_rt(cluster.cluster_conf.clone(), rt.clone()).unwrap();
+        fs.mount(
+            &Path::from_str(format!("file://{}", ufs_dir.display())).unwrap(),
+            &Path::from_str("/mnt").unwrap(),
+            MountOptions::builder().build(),
+        )
+        .await
+        .unwrap();
+
+        let mut transfer_server = InProcessTransferServer::start(cluster.cluster_conf.clone());
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        let client = TransferClient::with_rt(&cluster.cluster_conf, rt.clone()).unwrap();
+        let submit = client
+            .submit(TransferCommand {
+                kind: TransferKind::Load,
+                source_path: format!("file://{}/pending.txt", ufs_dir.display()),
+                target_path: "/mnt/pending.txt".to_string(),
+                client_request_id: test_id.clone(),
+                submitter: "cancel-pending-e2e".to_string(),
+                tenant: "test".to_string(),
+                options: Default::default(),
+            })
+            .await
+            .unwrap();
+
+        let cancel = client.cancel(&submit.job_id, None).await.unwrap();
+        assert_eq!(cancel.job_id, submit.job_id);
+        assert!(
+            cancel.state == TransferStateProto::TransferCanceling as i32
+                || cancel.state == TransferStateProto::TransferCanceled as i32,
+            "cancel RPC should return a cancel state, got {}",
+            cancel.state
+        );
+        let status = wait_transfer_state(
+            &client,
+            &submit.job_id,
+            TransferStateProto::TransferCanceled,
+            Duration::from_secs(20),
+        )
+        .await;
+        assert_eq!(status.state, TransferStateProto::TransferCanceled as i32);
+        assert!(
+            status.tasks.iter().all(|task| {
+                task.state == TransferTaskStateProto::TransferTaskCanceled as i32
+                    || task.state == TransferTaskStateProto::TransferTaskPending as i32
+            }),
+            "pending cancel should not start running task after cancel, tasks: {:?}",
+            status.tasks
+        );
+
+        transfer_server.stop();
+        let _ = fs::remove_dir_all(base_dir);
+    });
+}
+
+#[test]
+fn test_transfer_cancel_running_worker_task_does_not_commit_output() {
+    let test_id = format!(
+        "transfer-cancel-running-worker-{}-{}",
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    );
+    let base_dir = std::env::temp_dir().join(&test_id);
+    let ufs_dir = base_dir.join("ufs");
+    fs::create_dir_all(&ufs_dir).unwrap();
+    let source_path = ufs_dir.join("large-source.bin");
+    let source = fs::File::create(&source_path).unwrap();
+    source.set_len(2 * 1024 * 1024 * 1024).unwrap();
+
+    let mut conf = ClusterConf::default();
+    conf.master.meta_dir = base_dir.join("meta").display().to_string();
+    conf.journal.journal_dir = base_dir.join("journal").display().to_string();
+    conf.worker.data_dir = vec![base_dir.join("worker").display().to_string()];
+    conf.transfer.enabled = true;
+    conf.transfer.store_type = TransferStoreType::Sqlite;
+    conf.transfer.sqlite_path = base_dir.join("transfer.db").display().to_string();
+    conf.transfer.hostname = "localhost".to_string();
+    conf.transfer.rpc_port = NetUtils::hold_available_port();
+    conf.transfer.web_port = NetUtils::hold_available_port();
+    conf.transfer.instance_id = "transfer-cancel-running-worker".to_string();
+    conf.transfer.endpoints = vec![format!(
+        "{}:{}",
+        conf.transfer.hostname, conf.transfer.rpc_port
+    )];
+    conf.transfer.init().unwrap();
+
+    let cluster = MiniCluster::with_num(&conf, 1, 1);
+    cluster.start_cluster();
+    let rt = cluster.clone_client_rt();
+
+    rt.block_on(async {
+        let fs = CurvineFileSystem::with_rt(cluster.cluster_conf.clone(), rt.clone()).unwrap();
+        fs.mount(
+            &Path::from_str(format!("file://{}", ufs_dir.display())).unwrap(),
+            &Path::from_str("/mnt").unwrap(),
+            MountOptions::builder().build(),
+        )
+        .await
+        .unwrap();
+
+        let mut transfer_server = InProcessTransferServer::start(cluster.cluster_conf.clone());
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        let client = TransferClient::with_rt(&cluster.cluster_conf, rt.clone()).unwrap();
+        let target = Path::from_str("/mnt/cancelled-large.bin").unwrap();
+        let submit = client
+            .submit(TransferCommand {
+                kind: TransferKind::Load,
+                source_path: format!("file://{}", source_path.display()),
+                target_path: target.clone_uri(),
+                client_request_id: test_id.clone(),
+                submitter: "cancel-running-worker-e2e".to_string(),
+                tenant: "test".to_string(),
+                options: Default::default(),
+            })
+            .await
+            .unwrap();
+
+        let _running = wait_transfer_task_state(
+            &client,
+            &submit.job_id,
+            TransferTaskStateProto::TransferTaskRunning,
+            Duration::from_secs(20),
+        )
+        .await;
+
+        let cancel = client.cancel(&submit.job_id, None).await.unwrap();
+        assert!(
+            cancel.state == TransferStateProto::TransferCanceling as i32
+                || cancel.state == TransferStateProto::TransferCanceled as i32,
+            "cancel RPC should return a cancel state, got {}",
+            cancel.state
+        );
+        let status = wait_transfer_state(
+            &client,
+            &submit.job_id,
+            TransferStateProto::TransferCanceled,
+            Duration::from_secs(30),
+        )
+        .await;
+        assert_eq!(status.state, TransferStateProto::TransferCanceled as i32);
+        assert!(
+            status
+                .tasks
+                .iter()
+                .all(|task| { task.state == TransferTaskStateProto::TransferTaskCanceled as i32 }),
+            "running worker cancel should leave only canceled tasks: {:?}",
+            status.tasks
+        );
+        assert!(
+            !fs.exists(&target).await.unwrap(),
+            "canceled running transfer must not commit final target"
+        );
+
+        transfer_server.stop();
+        let _ = fs::remove_dir_all(base_dir);
+    });
+}
+
+#[test]
+fn test_transfer_runner_keeps_pre_start_cancel_terminal() {
+    let rt = Arc::new(AsyncRuntime::single());
+    let conf = ClusterConf::default();
+    let fs = CurvineFileSystem::with_rt(conf.clone(), rt.clone()).unwrap();
+    let task = Arc::new(TaskContext::new(LoadTaskInfo {
+        job: LoadJobInfo {
+            job_id: "pre_start_cancel_job".to_string(),
+            source_path: "file:///unused-source".to_string(),
+            target_path: "/unused-target".to_string(),
+            block_size: 4096,
+            replicas: 1,
+            storage_type: StorageType::default(),
+            ttl_ms: 0,
+            ttl_action: TtlAction::default(),
+            mount_info: MountInfo::default(),
+            create_time: 0,
+            overwrite: None,
+        },
+        task_id: "pre_start_cancel_task".to_string(),
+        worker: WorkerAddress::default(),
+        source_path: "file:///unused-source".to_string(),
+        target_path: "/unused-target".to_string(),
+        create_time: 0,
+        source_read_plan_json: String::new(),
+        transfer_report: None,
+    }));
+    task.set_canceled("queued task canceled before runner start");
+
+    let runner = LoadTaskRunner::new(
+        task.clone(),
+        fs,
+        Arc::new(UfsFactory::with_rt(&conf.client, rt.clone())),
+        None,
+        10_000,
+        60_000,
+    );
+
+    let remove_task = rt.block_on(async { runner.run().await });
+    assert!(remove_task, "pre-start canceled task should be removable");
+    assert_eq!(task.get_state(), JobTaskState::Canceled);
+    assert_eq!(
+        task.progress().message,
+        "queued task canceled before runner start"
+    );
+}
+
+#[test]
+fn test_transfer_does_not_dispatch_to_worker_without_transfer_capabilities() {
+    let test_id = format!(
+        "transfer-worker-capability-{}-{}",
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    );
+    let base_dir = std::env::temp_dir().join(&test_id);
+    let ufs_dir = base_dir.join("ufs");
+    fs::create_dir_all(&ufs_dir).unwrap();
+    fs::write(ufs_dir.join("capability.txt"), b"capability-gated").unwrap();
+
+    let mut conf = ClusterConf::default();
+    conf.master.meta_dir = base_dir.join("meta").display().to_string();
+    conf.journal.journal_dir = base_dir.join("journal").display().to_string();
+    conf.transfer.enabled = true;
+    conf.transfer.store_type = TransferStoreType::Sqlite;
+    conf.transfer.sqlite_path = base_dir.join("transfer.db").display().to_string();
+    conf.transfer.hostname = "localhost".to_string();
+    conf.transfer.rpc_port = NetUtils::hold_available_port();
+    conf.transfer.web_port = NetUtils::hold_available_port();
+    conf.transfer.instance_id = "transfer-worker-capability".to_string();
+    conf.transfer.endpoints = vec![format!(
+        "{}:{}",
+        conf.transfer.hostname, conf.transfer.rpc_port
+    )];
+    conf.transfer.init().unwrap();
+
+    let cluster = MiniCluster::with_num(&conf, 1, 0);
+    cluster.start_cluster();
+    let rt = cluster.clone_client_rt();
+
+    {
+        let active_master = cluster.get_active_master_fs();
+        let mut worker_manager = active_master.worker_manager.write();
+        let mut legacy_worker = WorkerInfo::new(
+            WorkerAddress {
+                worker_id: 424242,
+                hostname: "legacy-worker".to_string(),
+                ip_addr: "127.0.0.1".to_string(),
+                rpc_port: NetUtils::hold_available_port() as u32,
+                web_port: NetUtils::hold_available_port() as u32,
+            },
+            WorkerInfo::default_weight(),
+        );
+        legacy_worker.worker_session_id = "legacy-session-without-transfer-capability".to_string();
+        worker_manager.add_test_worker(legacy_worker);
+    }
+
+    rt.block_on(async {
+        let fs = CurvineFileSystem::with_rt(cluster.cluster_conf.clone(), rt.clone()).unwrap();
+        fs.mount(
+            &Path::from_str(format!("file://{}", ufs_dir.display())).unwrap(),
+            &Path::from_str("/mnt").unwrap(),
+            MountOptions::builder().build(),
+        )
+        .await
+        .unwrap();
+
+        let mut transfer_server = InProcessTransferServer::start(cluster.cluster_conf.clone());
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        let client = TransferClient::with_rt(&cluster.cluster_conf, rt.clone()).unwrap();
+        let submit = client
+            .submit(TransferCommand {
+                kind: TransferKind::Load,
+                source_path: format!("file://{}/capability.txt", ufs_dir.display()),
+                target_path: "/mnt/capability.txt".to_string(),
+                client_request_id: test_id.clone(),
+                submitter: "capability-e2e".to_string(),
+                tenant: "test".to_string(),
+                options: Default::default(),
+            })
+            .await
+            .unwrap();
+
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        let status = client
+            .status_page(&submit.job_id, Some(10), None)
+            .await
+            .unwrap();
+        assert_ne!(
+            status.state,
+            TransferStateProto::TransferCompleted as i32,
+            "legacy worker without transfer capabilities must not complete transfer"
+        );
+        assert!(
+            !status.tasks.is_empty(),
+            "scheduler should have planned tasks before dispatch capability gating"
+        );
+        assert!(
+            status.tasks.iter().all(|task| {
+                task.state == TransferTaskStateProto::TransferTaskPending as i32
+                    && task.worker_id == 0
+                    && task.worker_session_id.is_empty()
+            }),
+            "tasks must remain unassigned when only legacy workers are live: {:?}",
+            status.tasks
+        );
+
+        transfer_server.stop();
+        let _ = fs::remove_dir_all(base_dir);
+    });
+}
+
+#[test]
+fn test_transfer_cancel_running_job_end_to_end() {
+    let test_id = format!(
+        "transfer-cancel-running-{}-{}",
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    );
+    let base_dir = std::env::temp_dir().join(&test_id);
+    fs::create_dir_all(&base_dir).unwrap();
+
+    let mut conf = ClusterConf::default();
+    conf.master.meta_dir = base_dir.join("meta").display().to_string();
+    conf.journal.journal_dir = base_dir.join("journal").display().to_string();
+    conf.transfer.enabled = true;
+    conf.transfer.store_type = TransferStoreType::Sqlite;
+    conf.transfer.sqlite_path = base_dir.join("transfer.db").display().to_string();
+    conf.transfer.hostname = "localhost".to_string();
+    conf.transfer.rpc_port = NetUtils::hold_available_port();
+    conf.transfer.web_port = NetUtils::hold_available_port();
+    conf.transfer.instance_id = "transfer-cancel-running".to_string();
+    conf.transfer.endpoints = vec![format!(
+        "{}:{}",
+        conf.transfer.hostname, conf.transfer.rpc_port
+    )];
+    conf.transfer.init().unwrap();
+
+    let now_ms = orpc::common::LocalTime::mills() as i64;
+    let store = SqliteTransferStore::open(conf.transfer.sqlite_path.clone()).unwrap();
+    let job_id = format!("{test_id}-job");
+    let mut job = TransferJobRecord {
+        job_key: format!("Load:file:///{test_id}:/cancel/{test_id}"),
+        job_id: job_id.clone(),
+        run_id: 1,
+        kind: TransferKind::Load,
+        source_path: format!("file:///{test_id}"),
+        target_path: format!("/cancel/{test_id}"),
+        command_json: "{}".to_string(),
+        mount_snapshot_json: "{}".to_string(),
+        secret_ref_json: "{}".to_string(),
+        cluster_snapshot_version: 1,
+        cv_metadata_epoch: None,
+        state: curvine_common::state::TransferState::Running,
+        owner: "transfer-cancel-running".to_string(),
+        lease_epoch: 1,
+        lease_expire_at: now_ms + 120_000,
+        cancel_requested: false,
+        summary: TransferProgress::default(),
+        client_request_id: format!("{test_id}-request"),
+        submitter: "cancel-running-e2e".to_string(),
+        tenant: "test".to_string(),
+        created_at: now_ms - 1_000,
+        updated_at: now_ms - 1_000,
+    };
+    job.summary.message = "preloaded running job".to_string();
+    store.create_or_get_by_request_id(job).unwrap();
+    store
+        .insert_tasks(vec![TransferTaskRecord {
+            job_id: job_id.clone(),
+            run_id: 1,
+            task_id: "task-1".to_string(),
+            attempt_id: 1,
+            source_path: format!("file:///{test_id}/source"),
+            target_path: format!("/cancel/{test_id}/target"),
+            worker_id: 0,
+            worker_session_id: String::new(),
+            source_read_plan_json: String::new(),
+            report_target_json: "{}".to_string(),
+            state: TransferTaskState::Running,
+            progress: TransferProgress::default(),
+            retry_count: 0,
+            attempt_started_at: now_ms - 1_000,
+            last_report_at: now_ms - 1_000,
+            stale_deadline_at: now_ms + 120_000,
+            updated_at: now_ms - 1_000,
+        }])
+        .unwrap();
+    drop(store);
+
+    let cluster = MiniCluster::with_num(&conf, 1, 0);
+    cluster.start_cluster();
+    let rt = cluster.clone_client_rt();
+
+    rt.block_on(async {
+        let mut transfer_server = InProcessTransferServer::start(cluster.cluster_conf.clone());
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        let client = TransferClient::with_rt(&cluster.cluster_conf, rt.clone()).unwrap();
+        let cancel = client.cancel(&job_id, None).await.unwrap();
+        assert_eq!(cancel.job_id, job_id);
+        assert!(
+            cancel.state == TransferStateProto::TransferCanceling as i32
+                || cancel.state == TransferStateProto::TransferCanceled as i32,
+            "cancel RPC should return a cancel state, got {}",
+            cancel.state
+        );
+        let status = wait_transfer_state(
+            &client,
+            &job_id,
+            TransferStateProto::TransferCanceled,
+            Duration::from_secs(20),
+        )
+        .await;
+        assert_eq!(status.state, TransferStateProto::TransferCanceled as i32);
+        assert_eq!(status.tasks.len(), 1);
+        assert_eq!(
+            status.tasks[0].state,
+            TransferTaskStateProto::TransferTaskCanceled as i32
+        );
+
+        transfer_server.stop();
+        let _ = fs::remove_dir_all(base_dir);
+    });
+}
+
+#[test]
+fn test_transfer_reports_partial_success_after_task_failure() {
+    let test_id = format!(
+        "transfer-partial-success-{}-{}",
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    );
+    let base_dir = std::env::temp_dir().join(&test_id);
+    fs::create_dir_all(&base_dir).unwrap();
+
+    let mut conf = ClusterConf::default();
+    conf.master.meta_dir = base_dir.join("meta").display().to_string();
+    conf.journal.journal_dir = base_dir.join("journal").display().to_string();
+    conf.transfer.enabled = true;
+    conf.transfer.store_type = TransferStoreType::Sqlite;
+    conf.transfer.sqlite_path = base_dir.join("transfer.db").display().to_string();
+    conf.transfer.hostname = "localhost".to_string();
+    conf.transfer.rpc_port = NetUtils::hold_available_port();
+    conf.transfer.web_port = NetUtils::hold_available_port();
+    conf.transfer.instance_id = "transfer-partial-success".to_string();
+    conf.transfer.endpoints = vec![format!(
+        "{}:{}",
+        conf.transfer.hostname, conf.transfer.rpc_port
+    )];
+    conf.transfer.init().unwrap();
+
+    let now_ms = orpc::common::LocalTime::mills() as i64;
+    let store = SqliteTransferStore::open(conf.transfer.sqlite_path.clone()).unwrap();
+    let job_id = format!("{test_id}-job");
+    let mut job = TransferJobRecord {
+        job_key: format!("Load:file:///{test_id}:/partial/{test_id}"),
+        job_id: job_id.clone(),
+        run_id: 1,
+        kind: TransferKind::Load,
+        source_path: format!("file:///{test_id}"),
+        target_path: format!("/partial/{test_id}"),
+        command_json: "{}".to_string(),
+        mount_snapshot_json: "{}".to_string(),
+        secret_ref_json: "{}".to_string(),
+        cluster_snapshot_version: 1,
+        cv_metadata_epoch: None,
+        state: curvine_common::state::TransferState::Running,
+        owner: "transfer-partial-success".to_string(),
+        lease_epoch: 1,
+        lease_expire_at: now_ms + 120_000,
+        cancel_requested: false,
+        summary: TransferProgress {
+            loaded_size: 1_024,
+            total_size: 3_584,
+            update_time: now_ms,
+            message: "one task failed".to_string(),
+        },
+        client_request_id: format!("{test_id}-request"),
+        submitter: "partial-success-e2e".to_string(),
+        tenant: "test".to_string(),
+        created_at: now_ms - 1_000,
+        updated_at: now_ms - 1_000,
+    };
+    job.summary.message = "one task failed".to_string();
+    store.create_or_get_by_request_id(job).unwrap();
+    store
+        .insert_tasks(vec![
+            TransferTaskRecord {
+                job_id: job_id.clone(),
+                run_id: 1,
+                task_id: "completed".to_string(),
+                attempt_id: 1,
+                source_path: format!("file:///{test_id}/completed"),
+                target_path: format!("/partial/{test_id}/completed"),
+                worker_id: 0,
+                worker_session_id: String::new(),
+                source_read_plan_json: String::new(),
+                report_target_json: "{}".to_string(),
+                state: TransferTaskState::Completed,
+                progress: TransferProgress {
+                    loaded_size: 1_024,
+                    total_size: 1_024,
+                    update_time: now_ms,
+                    message: String::new(),
+                },
+                retry_count: 0,
+                attempt_started_at: now_ms - 1_000,
+                last_report_at: now_ms - 1_000,
+                stale_deadline_at: now_ms + 120_000,
+                updated_at: now_ms - 1_000,
+            },
+            TransferTaskRecord {
+                job_id: job_id.clone(),
+                run_id: 1,
+                task_id: "failed".to_string(),
+                attempt_id: 1,
+                source_path: format!("file:///{test_id}/failed"),
+                target_path: format!("/partial/{test_id}/failed"),
+                worker_id: 0,
+                worker_session_id: String::new(),
+                source_read_plan_json: String::new(),
+                report_target_json: "{}".to_string(),
+                state: TransferTaskState::Failed,
+                progress: TransferProgress {
+                    loaded_size: 0,
+                    total_size: 2_048,
+                    update_time: now_ms,
+                    message: "source object not found".to_string(),
+                },
+                retry_count: 0,
+                attempt_started_at: now_ms - 1_000,
+                last_report_at: now_ms - 1_000,
+                stale_deadline_at: now_ms + 120_000,
+                updated_at: now_ms - 1_000,
+            },
+            TransferTaskRecord {
+                job_id: job_id.clone(),
+                run_id: 1,
+                task_id: "pending".to_string(),
+                attempt_id: 0,
+                source_path: format!("file:///{test_id}/pending"),
+                target_path: format!("/partial/{test_id}/pending"),
+                worker_id: 0,
+                worker_session_id: String::new(),
+                source_read_plan_json: String::new(),
+                report_target_json: "{}".to_string(),
+                state: TransferTaskState::Pending,
+                progress: TransferProgress {
+                    loaded_size: 0,
+                    total_size: 512,
+                    update_time: now_ms,
+                    message: String::new(),
+                },
+                retry_count: 0,
+                attempt_started_at: 0,
+                last_report_at: 0,
+                stale_deadline_at: 0,
+                updated_at: now_ms - 1_000,
+            },
+        ])
+        .unwrap();
+    drop(store);
+
+    let cluster = MiniCluster::with_num(&conf, 1, 0);
+    cluster.start_cluster();
+    let rt = cluster.clone_client_rt();
+    rt.block_on(async {
+        let mut transfer_server = InProcessTransferServer::start(cluster.cluster_conf.clone());
+        let client = TransferClient::with_rt(&cluster.cluster_conf, rt.clone()).unwrap();
+        let status = wait_transfer_state(
+            &client,
+            &job_id,
+            TransferStateProto::TransferPartialSuccess,
+            Duration::from_secs(20),
+        )
+        .await;
+
+        assert_eq!(status.progress.loaded_size, 1_024);
+        assert_eq!(status.progress.total_size, 3_584);
+        assert!(status.progress.message.contains("source object not found"));
+        let summary = status
+            .task_summary
+            .expect("status must include task summary");
+        assert_eq!(summary.completed, 1);
+        assert_eq!(summary.failed, 1);
+        assert_eq!(summary.canceled, 1);
+        assert_eq!(summary.completed_size, 1_024);
+        assert!(status.tasks.iter().any(|task| {
+            task.task_id == "pending"
+                && task.state == TransferTaskStateProto::TransferTaskCanceled as i32
+        }));
+
+        transfer_server.stop();
+        let _ = fs::remove_dir_all(base_dir);
+    });
+}
+
+#[test]
+fn test_transfer_rejects_unsafe_target_overwrite() {
+    let test_id = format!(
+        "transfer-target-policy-{}-{}",
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    );
+    let base_dir = std::env::temp_dir().join(&test_id);
+    let ufs_dir = base_dir.join("ufs");
+    fs::create_dir_all(&ufs_dir).unwrap();
+    fs::create_dir_all(ufs_dir.join("dir-source")).unwrap();
+    fs::write(ufs_dir.join("existing-source.txt"), b"new-content").unwrap();
+    fs::write(ufs_dir.join("dir-source.txt"), b"dir-content").unwrap();
+    fs::write(ufs_dir.join("dir-source").join("child.txt"), b"dir-child").unwrap();
+
+    let mut conf = ClusterConf::default();
+    conf.master.meta_dir = base_dir.join("meta").display().to_string();
+    conf.journal.journal_dir = base_dir.join("journal").display().to_string();
+    conf.worker.data_dir = vec![base_dir.join("worker").display().to_string()];
+    conf.transfer.enabled = true;
+    conf.transfer.store_type = TransferStoreType::Sqlite;
+    conf.transfer.sqlite_path = base_dir.join("transfer.db").display().to_string();
+    conf.transfer.cv_metadata_reader = TransferCvMetadataReaderType::Master;
+    conf.transfer.hostname = "localhost".to_string();
+    conf.transfer.rpc_port = NetUtils::hold_available_port();
+    conf.transfer.web_port = NetUtils::hold_available_port();
+    conf.transfer.endpoints = vec![format!(
+        "{}:{}",
+        conf.transfer.hostname, conf.transfer.rpc_port
+    )];
+    conf.transfer.init().unwrap();
+
+    let cluster = MiniCluster::with_num(&conf, 1, 1);
+    cluster.start_cluster();
+    let rt = cluster.clone_client_rt();
+
+    rt.block_on(async {
+        let fs = CurvineFileSystem::with_rt(cluster.cluster_conf.clone(), rt.clone()).unwrap();
+        fs.mount(
+            &Path::from_str(format!("file://{}", ufs_dir.display())).unwrap(),
+            &Path::from_str("/mnt").unwrap(),
+            MountOptions::builder().build(),
+        )
+        .await
+        .unwrap();
+        fs.write_string(&Path::from_str("/mnt/existing.txt").unwrap(), "old-content")
+            .await
+            .unwrap();
+        fs.mkdir(&Path::from_str("/mnt/existing-dir").unwrap(), true)
+            .await
+            .unwrap();
+
+        let mut transfer_server = InProcessTransferServer::start(cluster.cluster_conf.clone());
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        let client = TransferClient::with_rt(&cluster.cluster_conf, rt.clone()).unwrap();
+
+        let mut no_overwrite = TransferCommand {
+            kind: TransferKind::Load,
+            source_path: format!("file://{}/existing-source.txt", ufs_dir.display()),
+            target_path: "/mnt/existing.txt".to_string(),
+            client_request_id: format!("{test_id}-no-overwrite"),
+            submitter: "target-policy-e2e".to_string(),
+            tenant: "test".to_string(),
+            options: Default::default(),
+        };
+        no_overwrite.set_overwrite(false);
+        let no_overwrite_job = client.submit(no_overwrite).await.unwrap();
+        assert_transfer_failed(&client, &no_overwrite_job.job_id).await;
+        assert_eq!(
+            fs.read_string(&Path::from_str("/mnt/existing.txt").unwrap())
+                .await
+                .unwrap(),
+            "old-content"
+        );
+
+        let dir_target_job = client
+            .submit(TransferCommand {
+                kind: TransferKind::Load,
+                source_path: format!("file://{}/dir-source.txt", ufs_dir.display()),
+                target_path: "/mnt/existing-dir".to_string(),
+                client_request_id: format!("{test_id}-dir-target"),
+                submitter: "target-policy-e2e".to_string(),
+                tenant: "test".to_string(),
+                options: Default::default(),
+            })
+            .await
+            .unwrap();
+        assert_transfer_failed(&client, &dir_target_job.job_id).await;
+        assert!(
+            fs.get_status(&Path::from_str("/mnt/existing-dir").unwrap())
+                .await
+                .unwrap()
+                .is_dir,
+            "directory target should remain a directory"
+        );
+
+        let directory_into_file_job = client
+            .submit(TransferCommand {
+                kind: TransferKind::Load,
+                source_path: format!("file://{}/dir-source", ufs_dir.display()),
+                target_path: "/mnt/existing.txt".to_string(),
+                client_request_id: format!("{test_id}-directory-into-file"),
+                submitter: "target-policy-e2e".to_string(),
+                tenant: "test".to_string(),
+                options: Default::default(),
+            })
+            .await
+            .unwrap();
+        let directory_into_file_status =
+            assert_transfer_failed(&client, &directory_into_file_job.job_id).await;
+        assert!(
+            directory_into_file_status
+                .progress
+                .message
+                .contains("refusing to transfer directory into file"),
+            "directory source should fail on target type preflight, got: {}",
+            directory_into_file_status.progress.message
+        );
+        assert_eq!(
+            fs.read_string(&Path::from_str("/mnt/existing.txt").unwrap())
+                .await
+                .unwrap(),
+            "old-content"
+        );
+
+        transfer_server.stop();
+        let _ = fs::remove_dir_all(base_dir);
+    });
+}
+
+#[test]
+fn test_transfer_load_file_end_to_end_with_mysql_store() {
+    let Some(mysql_url) = mysql_transfer_store_url("mysql-e2e") else {
+        eprintln!("skip mysql transfer e2e: CURVINE_TRANSFER_MYSQL_URL is not set");
+        return;
+    };
+    let test_id = format!(
+        "transfer-mysql-e2e-{}-{}",
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    );
+    let base_dir = std::env::temp_dir().join(&test_id);
+    let ufs_dir = base_dir.join("ufs");
+    fs::create_dir_all(&ufs_dir).unwrap();
+    fs::write(ufs_dir.join("hello.txt"), b"mysql-transfer").unwrap();
+
+    let mut conf = ClusterConf::default();
+    conf.master.meta_dir = base_dir.join("meta").display().to_string();
+    conf.journal.journal_dir = base_dir.join("journal").display().to_string();
+    conf.worker.data_dir = vec![base_dir.join("worker").display().to_string()];
+    conf.transfer.enabled = true;
+    conf.transfer.store_type = TransferStoreType::Mysql;
+    conf.transfer.mysql_url = mysql_url;
+    conf.transfer.hostname = "localhost".to_string();
+    conf.transfer.rpc_port = NetUtils::hold_available_port();
+    conf.transfer.web_port = NetUtils::hold_available_port();
+    conf.transfer.instance_id = "transfer-child-recover".to_string();
+    conf.transfer.endpoints = vec![format!(
+        "{}:{}",
+        conf.transfer.hostname, conf.transfer.rpc_port
+    )];
+    conf.transfer.init().unwrap();
+
+    let cluster = MiniCluster::with_num(&conf, 1, 1);
+    cluster.start_cluster();
+    let rt = cluster.clone_client_rt();
+
+    rt.block_on(async {
+        let fs = CurvineFileSystem::with_rt(cluster.cluster_conf.clone(), rt.clone()).unwrap();
+        fs.mount(
+            &Path::from_str(format!("file://{}", ufs_dir.display())).unwrap(),
+            &Path::from_str("/mnt").unwrap(),
+            MountOptions::builder().build(),
+        )
+        .await
+        .unwrap();
+
+        let mut transfer_server = InProcessTransferServer::start(cluster.cluster_conf.clone());
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        let client = TransferClient::with_rt(&cluster.cluster_conf, rt.clone()).unwrap();
+        let target = Path::from_str("/mnt/hello.txt").unwrap();
+        let submit = client
+            .submit(TransferCommand {
+                kind: TransferKind::Load,
+                source_path: format!("file://{}/hello.txt", ufs_dir.display()),
+                target_path: target.clone_uri(),
+                client_request_id: test_id.clone(),
+                submitter: "mysql-e2e".to_string(),
+                tenant: "test".to_string(),
+                options: Default::default(),
+            })
+            .await
+            .unwrap();
+
+        let mut final_state = submit.state;
+        for _ in 0..80 {
+            let status = client
+                .status_page(&submit.job_id, Some(10), None)
+                .await
+                .unwrap();
+            final_state = status.state;
+            if final_state == TransferStateProto::TransferCompleted as i32
+                || final_state == TransferStateProto::TransferFailed as i32
+            {
+                assert!(!status.tasks.is_empty(), "status should return task page");
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
+
+        assert_eq!(final_state, TransferStateProto::TransferCompleted as i32);
+        assert_eq!(fs.read_string(&target).await.unwrap(), "mysql-transfer");
+
+        transfer_server.stop();
+        let _ = fs::remove_dir_all(base_dir);
+    });
+}
+
+#[test]
+fn test_transfer_mysql_server_recovers_after_store_outage() {
+    let Some((mysql_url, base_url, db_name)) = mysql_transfer_store_url_with_db("mysql-outage")
+    else {
+        eprintln!("skip mysql store outage recovery e2e: CURVINE_TRANSFER_MYSQL_URL is not set");
+        return;
+    };
+    let test_id = format!(
+        "transfer-mysql-store-outage-{}-{}",
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    );
+    let base_dir = std::env::temp_dir().join(&test_id);
+    let ufs_dir = base_dir.join("ufs");
+    fs::create_dir_all(&ufs_dir).unwrap();
+    fs::write(ufs_dir.join("after-outage.txt"), b"mysql-store-recovered").unwrap();
+
+    let mut conf = ClusterConf::default();
+    conf.master.meta_dir = base_dir.join("meta").display().to_string();
+    conf.journal.journal_dir = base_dir.join("journal").display().to_string();
+    conf.worker.data_dir = vec![base_dir.join("worker").display().to_string()];
+    conf.transfer.enabled = true;
+    conf.transfer.store_type = TransferStoreType::Mysql;
+    conf.transfer.mysql_url = mysql_url.clone();
+    conf.transfer.hostname = "localhost".to_string();
+    conf.transfer.rpc_port = NetUtils::get_available_port();
+    conf.transfer.web_port = NetUtils::get_available_port();
+    conf.transfer.instance_id = "transfer-store-outage".to_string();
+    conf.transfer.endpoints = vec![format!(
+        "{}:{}",
+        conf.transfer.hostname, conf.transfer.rpc_port
+    )];
+    conf.transfer.init().unwrap();
+
+    let cluster = MiniCluster::with_num(&conf, 1, 1);
+    cluster.start_cluster();
+    let rt = cluster.clone_client_rt();
+
+    rt.block_on(async {
+        let fs = CurvineFileSystem::with_rt(cluster.cluster_conf.clone(), rt.clone()).unwrap();
+        fs.mount(
+            &Path::from_str(format!("file://{}", ufs_dir.display())).unwrap(),
+            &Path::from_str("/mnt").unwrap(),
+            MountOptions::builder().build(),
+        )
+        .await
+        .unwrap();
+
+        let mut transfer_server = InProcessTransferServer::start(cluster.cluster_conf.clone());
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        let client = TransferClient::with_rt(&cluster.cluster_conf, rt.clone()).unwrap();
+
+        drop_mysql_database(&base_url, &db_name);
+        let outage = client
+            .submit(TransferCommand {
+                kind: TransferKind::Load,
+                source_path: format!("file://{}/after-outage.txt", ufs_dir.display()),
+                target_path: "/mnt/after-outage-outage.txt".to_string(),
+                client_request_id: format!("{test_id}-outage"),
+                submitter: "mysql-store-outage-e2e".to_string(),
+                tenant: "test".to_string(),
+                options: Default::default(),
+            })
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(
+            outage.contains("transfer_jobs")
+                || outage.contains("Unknown database")
+                || outage.contains("doesn't exist")
+                || outage.contains("No database selected"),
+            "unexpected store outage error: {outage}"
+        );
+
+        create_mysql_database(&base_url, &db_name);
+        let restored_store = MysqlTransferStore::open(&mysql_url).unwrap();
+        drop(restored_store);
+
+        let target = Path::from_str("/mnt/after-outage.txt").unwrap();
+        let submit = client
+            .submit(TransferCommand {
+                kind: TransferKind::Load,
+                source_path: format!("file://{}/after-outage.txt", ufs_dir.display()),
+                target_path: target.clone_uri(),
+                client_request_id: format!("{test_id}-recovered"),
+                submitter: "mysql-store-outage-e2e".to_string(),
+                tenant: "test".to_string(),
+                options: Default::default(),
+            })
+            .await
+            .unwrap();
+
+        let status = wait_transfer_state(
+            &client,
+            &submit.job_id,
+            TransferStateProto::TransferCompleted,
+            Duration::from_secs(30),
+        )
+        .await;
+        assert!(!status.tasks.is_empty(), "status should return task page");
+        assert_eq!(
+            fs.read_string(&target).await.unwrap(),
+            "mysql-store-recovered"
+        );
+
+        transfer_server.stop();
+        let _ = fs::remove_dir_all(base_dir);
+    });
+}
+
+#[test]
+fn test_transfer_readyz_rejects_idle_mysql_store_outage() {
+    let Some((mysql_url, proxy)) = mysql_transfer_store_url_with_proxy("readyz-store-outage")
+    else {
+        eprintln!(
+            "skip mysql readyz store outage e2e: CURVINE_TRANSFER_MYSQL_URL must use host:port"
+        );
+        return;
+    };
+    let test_id = format!(
+        "transfer-readyz-store-outage-{}-{}",
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    );
+    let base_dir = std::env::temp_dir().join(&test_id);
+
+    let mut conf = ClusterConf::default();
+    conf.master.meta_dir = base_dir.join("meta").display().to_string();
+    conf.journal.journal_dir = base_dir.join("journal").display().to_string();
+    conf.worker.data_dir = vec![base_dir.join("worker").display().to_string()];
+    conf.transfer.enabled = true;
+    conf.transfer.store_type = TransferStoreType::Mysql;
+    conf.transfer.mysql_url = mysql_url;
+    conf.transfer.hostname = "localhost".to_string();
+    conf.transfer.rpc_port = NetUtils::get_available_port();
+    conf.transfer.web_port = NetUtils::get_available_port();
+    conf.transfer.instance_id = "transfer-readyz-store-outage".to_string();
+    conf.transfer.endpoints = vec![format!(
+        "{}:{}",
+        conf.transfer.hostname, conf.transfer.rpc_port
+    )];
+    conf.transfer.init().unwrap();
+
+    let cluster = MiniCluster::with_num(&conf, 1, 0);
+    cluster.start_cluster();
+    let rt = cluster.clone_client_rt();
+
+    rt.block_on(async {
+        let mut transfer_server = InProcessTransferServer::start(cluster.cluster_conf.clone());
+        let ready = read_http_path(cluster.cluster_conf.transfer.web_port, "/readyz");
+        assert!(
+            ready.ends_with("ok\n"),
+            "transfer readiness should be ok before store outage, response: {ready}"
+        );
+
+        proxy.set_available(false);
+        let not_ready = read_http_path(cluster.cluster_conf.transfer.web_port, "/readyz");
+        assert!(
+            not_ready.contains("503 Service Unavailable")
+                && not_ready.contains("store unavailable"),
+            "transfer readiness should actively reject idle mysql outage, response: {not_ready}"
+        );
+
+        transfer_server.stop();
+        let _ = fs::remove_dir_all(base_dir);
+    });
+}
+
+#[test]
+fn test_external_transfer_readyz_rejects_idle_mysql_store_outage() {
+    let Some((mysql_url, proxy)) = mysql_transfer_store_url_with_proxy("external-readyz-outage")
+    else {
+        eprintln!(
+            "skip external mysql readyz store outage e2e: CURVINE_TRANSFER_MYSQL_URL must use host:port"
+        );
+        return;
+    };
+    let binary = match curvine_server_binary() {
+        Some(binary) => binary,
+        None => {
+            eprintln!("skip external mysql readyz store outage e2e: curvine-server binary missing");
+            return;
+        }
+    };
+    let test_id = format!(
+        "transfer-external-readyz-store-outage-{}-{}",
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    );
+    let base_dir = std::env::temp_dir().join(&test_id);
+
+    let mut conf = ClusterConf::default();
+    conf.master.meta_dir = base_dir.join("meta").display().to_string();
+    conf.journal.journal_dir = base_dir.join("journal").display().to_string();
+    conf.worker.data_dir = vec![base_dir.join("worker").display().to_string()];
+    conf.transfer.enabled = true;
+    conf.transfer.store_type = TransferStoreType::Mysql;
+    conf.transfer.mysql_url = mysql_url;
+    conf.transfer.hostname = "localhost".to_string();
+    conf.transfer.rpc_port = NetUtils::get_available_port();
+    conf.transfer.web_port = NetUtils::get_available_port();
+    conf.transfer.instance_id = "transfer-external-readyz-store-outage".to_string();
+    conf.transfer.endpoints = vec![format!(
+        "{}:{}",
+        conf.transfer.hostname, conf.transfer.rpc_port
+    )];
+    conf.transfer.init().unwrap();
+
+    let cluster = MiniCluster::with_num(&conf, 1, 0);
+    cluster.start_cluster();
+
+    let (transfer_conf, mut transfer_child) = spawn_transfer_child_until_healthy(
+        &binary,
+        cluster.cluster_conf.clone(),
+        &base_dir,
+        "external-readyz",
+    );
+    let ready = read_http_path(transfer_conf.transfer.web_port, "/readyz");
+    assert!(
+        ready.ends_with("ok\n"),
+        "external transfer readiness should be ok before store outage, response: {ready}"
+    );
+
+    proxy.set_available(false);
+    let not_ready = read_http_path(transfer_conf.transfer.web_port, "/readyz");
+    assert!(
+        not_ready.contains("503 Service Unavailable") && not_ready.contains("store unavailable"),
+        "external transfer readiness should reject idle mysql outage, response: {not_ready}"
+    );
+
+    proxy.set_available(true);
+    let restored = wait_http_path(
+        transfer_conf.transfer.web_port,
+        "/readyz",
+        Duration::from_secs(10),
+    );
+    assert!(
+        restored,
+        "external transfer readiness should recover after mysql proxy restore"
+    );
+
+    transfer_child.stop();
+    let _ = fs::remove_dir_all(base_dir);
+}
+
+#[test]
+fn test_transfer_mysql_recovers_completed_running_task_after_transient_store_disconnect() {
+    let Some((mysql_url, proxy)) =
+        mysql_transfer_store_url_with_proxy("mysql-running-store-disconnect")
+    else {
+        eprintln!(
+            "skip mysql transient store disconnect e2e: CURVINE_TRANSFER_MYSQL_URL must use host:port"
+        );
+        return;
+    };
+    let test_id = format!(
+        "transfer-mysql-running-store-disconnect-{}-{}",
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    );
+    let base_dir = std::env::temp_dir().join(&test_id);
+    let ufs_dir = base_dir.join("ufs");
+    fs::create_dir_all(&ufs_dir).unwrap();
+    let mut source = fs::File::create(ufs_dir.join("disconnect.bin")).unwrap();
+    let block = vec![7u8; 1024 * 1024];
+    for _ in 0..64 {
+        source.write_all(&block).unwrap();
+    }
+    drop(source);
+
+    let mut conf = ClusterConf::default();
+    conf.master.meta_dir = base_dir.join("meta").display().to_string();
+    conf.journal.journal_dir = base_dir.join("journal").display().to_string();
+    conf.worker.data_dir = vec![base_dir.join("worker").display().to_string()];
+    conf.transfer.enabled = true;
+    conf.transfer.store_type = TransferStoreType::Mysql;
+    conf.transfer.mysql_url = mysql_url.clone();
+    conf.transfer.hostname = "localhost".to_string();
+    conf.transfer.rpc_port = NetUtils::get_available_port();
+    conf.transfer.web_port = NetUtils::get_available_port();
+    conf.transfer.instance_id = "transfer-store-disconnect".to_string();
+    conf.transfer.endpoints = vec![format!(
+        "{}:{}",
+        conf.transfer.hostname, conf.transfer.rpc_port
+    )];
+    conf.transfer.lease_timeout_str = "1s".to_string();
+    conf.transfer.init().unwrap();
+
+    let cluster = MiniCluster::with_num(&conf, 1, 1);
+    cluster.start_cluster();
+    let rt = cluster.clone_client_rt();
+
+    rt.block_on(async {
+        let fs = CurvineFileSystem::with_rt(cluster.cluster_conf.clone(), rt.clone()).unwrap();
+        fs.mount(
+            &Path::from_str(format!("file://{}", ufs_dir.display())).unwrap(),
+            &Path::from_str("/mnt").unwrap(),
+            MountOptions::builder().build(),
+        )
+        .await
+        .unwrap();
+
+        let mut transfer_server = InProcessTransferServer::start(cluster.cluster_conf.clone());
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        let client = TransferClient::with_rt(&cluster.cluster_conf, rt.clone()).unwrap();
+        let target = Path::from_str("/mnt/disconnect.bin").unwrap();
+        let submit = client
+            .submit(TransferCommand {
+                kind: TransferKind::Load,
+                source_path: format!("file://{}/disconnect.bin", ufs_dir.display()),
+                target_path: target.clone_uri(),
+                client_request_id: test_id.clone(),
+                submitter: "mysql-store-disconnect-e2e".to_string(),
+                tenant: "test".to_string(),
+                options: Default::default(),
+            })
+            .await
+            .unwrap();
+
+        let store = MysqlTransferStore::open(&mysql_url).unwrap();
+        let mut running_task = None;
+        for _ in 0..1200 {
+            let tasks = store
+                .list_transfer_tasks(&submit.job_id, submit.run_id)
+                .unwrap();
+            running_task = tasks
+                .into_iter()
+                .find(|task| task.state == TransferTaskState::Running);
+            if running_task.is_some() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        let running_task = running_task.expect("task must reach running before store disconnect");
+        assert!(
+            wait_worker_task_visible(&fs, &cluster.cluster_conf, rt.clone(), &running_task).await,
+            "worker should accept task before store disconnect"
+        );
+
+        proxy.set_available(false);
+        let mut committed_while_disconnected = false;
+        for _ in 0..600 {
+            if fs.get_status(&target).await.is_ok() {
+                committed_while_disconnected = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        assert!(
+            committed_while_disconnected,
+            "worker should commit output locally while transfer store is disconnected"
+        );
+        tokio::time::sleep(Duration::from_millis(800)).await;
+        let state_during_disconnect = client.status(&submit.job_id).await;
+        assert!(
+            state_during_disconnect.is_err(),
+            "status should fail while transfer store connection is disconnected"
+        );
+
+        proxy.set_available(true);
+        let status = wait_transfer_state(
+            &client,
+            &submit.job_id,
+            TransferStateProto::TransferCompleted,
+            Duration::from_secs(30),
+        )
+        .await;
+        assert!(!status.tasks.is_empty(), "status should return task page");
+
+        let tasks = store
+            .list_transfer_tasks(&submit.job_id, submit.run_id)
+            .unwrap();
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].state, TransferTaskState::Completed);
+        assert_eq!(
+            tasks[0].attempt_id, 1,
+            "store recovery should complete the original task by probe, not by retry"
+        );
+        assert_eq!(
+            tasks[0].retry_count, 0,
+            "store recovery should not mark the completed local task stale"
+        );
+        assert_eq!(fs.get_status(&target).await.unwrap().len, 64 * 1024 * 1024);
+
+        transfer_server.stop();
+        let _ = fs::remove_dir_all(base_dir);
+    });
+}
+
+#[test]
+fn test_transfer_mysql_recovers_planning_job_after_owner_loss() {
+    let Some(mysql_url) = mysql_transfer_store_url("mysql-recover-planning") else {
+        eprintln!("skip mysql transfer recovery e2e: CURVINE_TRANSFER_MYSQL_URL is not set");
+        return;
+    };
+    let test_id = format!(
+        "transfer-mysql-recover-{}-{}",
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    );
+    let base_dir = std::env::temp_dir().join(&test_id);
+    let ufs_dir = base_dir.join("ufs");
+    fs::create_dir_all(&ufs_dir).unwrap();
+    fs::write(ufs_dir.join("recover.txt"), b"mysql-recovery").unwrap();
+
+    let mut conf = ClusterConf::default();
+    conf.master.meta_dir = base_dir.join("meta").display().to_string();
+    conf.journal.journal_dir = base_dir.join("journal").display().to_string();
+    conf.worker.data_dir = vec![base_dir.join("worker").display().to_string()];
+    conf.transfer.enabled = true;
+    conf.transfer.store_type = TransferStoreType::Mysql;
+    conf.transfer.mysql_url = mysql_url.clone();
+    conf.transfer.hostname = "localhost".to_string();
+    conf.transfer.rpc_port = NetUtils::get_available_port();
+    conf.transfer.web_port = NetUtils::get_available_port();
+    conf.transfer.instance_id = "transfer-child-recover".to_string();
+    conf.transfer.endpoints = vec![format!(
+        "{}:{}",
+        conf.transfer.hostname, conf.transfer.rpc_port
+    )];
+    conf.transfer.init().unwrap();
+
+    let cluster = MiniCluster::with_num(&conf, 1, 1);
+    cluster.start_cluster();
+    let rt = cluster.clone_client_rt();
+
+    rt.block_on(async {
+        let fs = CurvineFileSystem::with_rt(cluster.cluster_conf.clone(), rt.clone()).unwrap();
+        fs.mount(
+            &Path::from_str(format!("file://{}", ufs_dir.display())).unwrap(),
+            &Path::from_str("/mnt").unwrap(),
+            MountOptions::builder().build(),
+        )
+        .await
+        .unwrap();
+
+        let store = Arc::new(MysqlTransferStore::open(&mysql_url).unwrap());
+        let cache = ClusterMetadataCache::new(fs.clone());
+        cache.refresh().await.unwrap();
+        let service = TransferService::with_cache(
+            store.clone(),
+            cache,
+            cluster.cluster_conf.transfer.task_stale_timeout,
+        );
+        let job = service
+            .submit_transfer(SubmitTransferRequest {
+                kind: TransferKindProto::TransferLoad as i32,
+                source_path: format!("file://{}/recover.txt", ufs_dir.display()),
+                target_path: "/mnt/recover.txt".to_string(),
+                client_request_id: test_id.clone(),
+                submitter: "mysql-recovery-e2e".to_string(),
+                tenant: "test".to_string(),
+                command: Vec::new(),
+                protocol_version: Some(1),
+            })
+            .unwrap();
+
+        let dead_lease = store
+            .acquire_runnable_transfer("dead-transfer-owner", 1, 1, 1)
+            .unwrap()
+            .unwrap();
+        assert_eq!(dead_lease.job_id, job.job_id);
+        assert_eq!(
+            store.get_transfer(&job.job_id).unwrap().unwrap().state,
+            curvine_common::state::TransferState::Planning
+        );
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        let binary = curvine_server_binary()
+            .expect("external transfer restart e2e requires target/debug/curvine-server");
+        let (transfer_conf, mut transfer_child) = spawn_transfer_child_until_healthy(
+            &binary,
+            cluster.cluster_conf.clone(),
+            &base_dir,
+            "transfer-child",
+        );
+
+        let client = TransferClient::with_rt(&transfer_conf, rt.clone()).unwrap();
+        let mut final_state = 0;
+        let mut owner = String::new();
+        for _ in 0..100 {
+            let status = client
+                .status_page(&job.job_id, Some(10), None)
+                .await
+                .unwrap();
+            final_state = status.state;
+            owner = status.owner.unwrap_or_default();
+            if final_state == TransferStateProto::TransferCompleted as i32
+                || final_state == TransferStateProto::TransferFailed as i32
+            {
+                assert!(!status.tasks.is_empty(), "status should return task page");
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
+
+        assert_ne!(owner, "dead-transfer-owner");
+        assert_eq!(final_state, TransferStateProto::TransferCompleted as i32);
+        assert_eq!(
+            fs.read_string(&Path::from_str("/mnt/recover.txt").unwrap())
+                .await
+                .unwrap(),
+            "mysql-recovery"
+        );
+
+        transfer_child.stop();
+        let _ = fs::remove_dir_all(base_dir);
+    });
+}
+
+#[test]
+fn test_transfer_mysql_recovers_running_task_after_owner_loss() {
+    let Some(mysql_url) = mysql_transfer_store_url("mysql-recover-running") else {
+        eprintln!(
+            "skip mysql transfer running recovery e2e: CURVINE_TRANSFER_MYSQL_URL is not set"
+        );
+        return;
+    };
+    let test_id = format!(
+        "transfer-mysql-running-recover-{}-{}",
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    );
+    let base_dir = std::env::temp_dir().join(&test_id);
+    let ufs_dir = base_dir.join("ufs");
+    fs::create_dir_all(&ufs_dir).unwrap();
+    fs::write(ufs_dir.join("running.txt"), b"mysql-running-recovery").unwrap();
+
+    let mut conf = ClusterConf::default();
+    conf.master.meta_dir = base_dir.join("meta").display().to_string();
+    conf.journal.journal_dir = base_dir.join("journal").display().to_string();
+    conf.worker.data_dir = vec![base_dir.join("worker").display().to_string()];
+    conf.transfer.enabled = true;
+    conf.transfer.store_type = TransferStoreType::Mysql;
+    conf.transfer.mysql_url = mysql_url.clone();
+    conf.transfer.hostname = "localhost".to_string();
+    conf.transfer.rpc_port = NetUtils::get_available_port();
+    conf.transfer.web_port = NetUtils::get_available_port();
+    conf.transfer.instance_id = "transfer-running-owner-a".to_string();
+    conf.transfer.endpoints = vec!["localhost:1".to_string()];
+    conf.transfer.lease_timeout_str = "700ms".to_string();
+    conf.transfer.init().unwrap();
+
+    let cluster = MiniCluster::with_num(&conf, 1, 1);
+    cluster.start_cluster();
+    let rt = cluster.clone_client_rt();
+
+    rt.block_on(async {
+        let fs = CurvineFileSystem::with_rt(cluster.cluster_conf.clone(), rt.clone()).unwrap();
+        fs.mount(
+            &Path::from_str(format!("file://{}", ufs_dir.display())).unwrap(),
+            &Path::from_str("/mnt").unwrap(),
+            MountOptions::builder().build(),
+        )
+        .await
+        .unwrap();
+
+        let binary = curvine_server_binary()
+            .expect("external transfer restart e2e requires target/debug/curvine-server");
+        let (first_conf, mut first_child) = spawn_transfer_child_until_healthy(
+            &binary,
+            cluster.cluster_conf.clone(),
+            &base_dir,
+            "transfer-running-owner-a",
+        );
+        let first_endpoint = format!(
+            "{}:{}",
+            first_conf.transfer.hostname, first_conf.transfer.rpc_port
+        );
+        let mut client_conf = cluster.cluster_conf.clone();
+        client_conf.transfer.endpoints = vec![first_endpoint];
+        let client = TransferClient::with_rt(&client_conf, rt.clone()).unwrap();
+        let target = Path::from_str("/mnt/running.txt").unwrap();
+        let submit = client
+            .submit(TransferCommand {
+                kind: TransferKind::Load,
+                source_path: format!("file://{}/running.txt", ufs_dir.display()),
+                target_path: target.clone_uri(),
+                client_request_id: test_id.clone(),
+                submitter: "mysql-running-recovery-e2e".to_string(),
+                tenant: "test".to_string(),
+                options: Default::default(),
+            })
+            .await
+            .unwrap();
+
+        let store = MysqlTransferStore::open(&mysql_url).unwrap();
+        let running_task = wait_for_mysql_running_task_after_local_commit(
+            &fs,
+            &store,
+            &submit.job_id,
+            submit.run_id,
+            &target,
+            "mysql-running-recovery",
+            Duration::from_secs(30),
+        )
+        .await;
+        assert!(
+            running_task.is_some(),
+            "first owner should leave a running task with completed local output before it dies"
+        );
+        assert_ne!(
+            store.get_transfer(&submit.job_id).unwrap().unwrap().state,
+            curvine_common::state::TransferState::Completed,
+            "first owner must not complete the job before failover"
+        );
+        first_child.stop();
+
+        let mut second_conf = cluster.cluster_conf.clone();
+        second_conf.transfer.rpc_port = NetUtils::get_available_port();
+        second_conf.transfer.web_port = NetUtils::get_available_port();
+        second_conf.transfer.instance_id = "transfer-running-owner-b".to_string();
+        second_conf.transfer.endpoints = vec![format!(
+            "{}:{}",
+            second_conf.transfer.hostname, second_conf.transfer.rpc_port
+        )];
+        second_conf.transfer.init().unwrap();
+        let (second_conf, mut second_child) = spawn_transfer_child_until_healthy(
+            &binary,
+            second_conf,
+            &base_dir,
+            "transfer-running-owner-b",
+        );
+        let second_client = TransferClient::with_rt(&second_conf, rt.clone()).unwrap();
+
+        let mut final_state = 0;
+        let mut owner = String::new();
+        for _ in 0..120 {
+            let status = second_client
+                .status_page(&submit.job_id, Some(10), None)
+                .await
+                .unwrap();
+            final_state = status.state;
+            owner = status.owner.unwrap_or_default();
+            if final_state == TransferStateProto::TransferCompleted as i32
+                || final_state == TransferStateProto::TransferFailed as i32
+            {
+                assert!(!status.tasks.is_empty(), "status should return task page");
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
+
+        assert_eq!(owner, "transfer-running-owner-b");
+        assert_eq!(final_state, TransferStateProto::TransferCompleted as i32);
+        let final_tasks = store
+            .list_transfer_tasks(&submit.job_id, submit.run_id)
+            .unwrap();
+        assert_eq!(final_tasks.len(), 1);
+        assert_eq!(
+            final_tasks[0].state,
+            curvine_common::state::TransferTaskState::Completed
+        );
+        assert_eq!(
+            final_tasks[0].attempt_id, 1,
+            "running recovery must complete by probing the original attempt, not by retrying"
+        );
+        assert_eq!(
+            final_tasks[0].retry_count, 0,
+            "running recovery must not mark stale and redispatch the task"
+        );
+        assert_eq!(
+            fs.read_string(&target).await.unwrap(),
+            "mysql-running-recovery"
+        );
+
+        second_child.stop();
+        let _ = fs::remove_dir_all(base_dir);
+    });
+}
+
+#[test]
+fn test_transfer_mysql_retry_accepts_already_committed_output_after_lost_report() {
+    let Some(mysql_url) = mysql_transfer_store_url("mysql-retry-commit") else {
+        eprintln!("skip mysql transfer retry commit e2e: CURVINE_TRANSFER_MYSQL_URL is not set");
+        return;
+    };
+    let test_id = format!(
+        "transfer-mysql-retry-commit-{}-{}",
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    );
+    let base_dir = std::env::temp_dir().join(&test_id);
+    let ufs_dir = base_dir.join("ufs");
+    fs::create_dir_all(&ufs_dir).unwrap();
+    fs::write(ufs_dir.join("retry.txt"), b"mysql-retry-commit").unwrap();
+
+    let mut conf = ClusterConf::default();
+    conf.master.meta_dir = base_dir.join("meta").display().to_string();
+    conf.journal.journal_dir = base_dir.join("journal").display().to_string();
+    conf.worker.data_dir = vec![base_dir.join("worker").display().to_string()];
+    conf.transfer.enabled = true;
+    conf.transfer.store_type = TransferStoreType::Mysql;
+    conf.transfer.mysql_url = mysql_url.clone();
+    conf.transfer.hostname = "localhost".to_string();
+    conf.transfer.rpc_port = NetUtils::get_available_port();
+    conf.transfer.web_port = NetUtils::get_available_port();
+    conf.transfer.instance_id = "transfer-retry-owner-a".to_string();
+    conf.transfer.endpoints = vec!["localhost:1".to_string()];
+    conf.transfer.lease_timeout_str = "1s".to_string();
+    conf.transfer.init().unwrap();
+
+    let cluster = MiniCluster::with_num(&conf, 1, 1);
+    cluster.start_cluster();
+    let rt = cluster.clone_client_rt();
+
+    rt.block_on(async {
+        let fs = CurvineFileSystem::with_rt(cluster.cluster_conf.clone(), rt.clone()).unwrap();
+        fs.mount(
+            &Path::from_str(format!("file://{}", ufs_dir.display())).unwrap(),
+            &Path::from_str("/mnt").unwrap(),
+            MountOptions::builder().build(),
+        )
+        .await
+        .unwrap();
+
+        let binary = curvine_server_binary()
+            .expect("external transfer retry e2e requires target/debug/curvine-server");
+        let (first_conf, mut first_child) = spawn_transfer_child_until_healthy(
+            &binary,
+            cluster.cluster_conf.clone(),
+            &base_dir,
+            "transfer-retry-owner-a",
+        );
+        let first_endpoint = format!(
+            "{}:{}",
+            first_conf.transfer.hostname, first_conf.transfer.rpc_port
+        );
+        let mut client_conf = cluster.cluster_conf.clone();
+        client_conf.transfer.endpoints = vec![first_endpoint];
+        let client = TransferClient::with_rt(&client_conf, rt.clone()).unwrap();
+        let target = Path::from_str("/mnt/retry.txt").unwrap();
+        let mut command = TransferCommand {
+            kind: TransferKind::Load,
+            source_path: format!("file://{}/retry.txt", ufs_dir.display()),
+            target_path: target.clone_uri(),
+            client_request_id: test_id.clone(),
+            submitter: "mysql-retry-commit-e2e".to_string(),
+            tenant: "test".to_string(),
+            options: Default::default(),
+        };
+        command.set_overwrite(false);
+        let submit = client.submit(command).await.unwrap();
+
+        let store = MysqlTransferStore::open(&mysql_url).unwrap();
+        let mut task = wait_for_mysql_running_task_after_local_commit(
+            &fs,
+            &store,
+            &submit.job_id,
+            submit.run_id,
+            &target,
+            "mysql-retry-commit",
+            Duration::from_secs(30),
+        )
+        .await
+        .expect("first owner should leave running task after committing output locally");
+        first_child.stop();
+
+        task.worker_session_id = "lost-report-session".to_string();
+        task.stale_deadline_at = 1;
+        force_mysql_task_state(&mysql_url, &task);
+
+        let mut second_conf = cluster.cluster_conf.clone();
+        second_conf.transfer.rpc_port = NetUtils::get_available_port();
+        second_conf.transfer.web_port = NetUtils::get_available_port();
+        second_conf.transfer.instance_id = "transfer-retry-owner-b".to_string();
+        second_conf.transfer.endpoints = vec![format!(
+            "{}:{}",
+            second_conf.transfer.hostname, second_conf.transfer.rpc_port
+        )];
+        second_conf.transfer.init().unwrap();
+        let (second_conf, mut second_child) = spawn_transfer_child_until_healthy(
+            &binary,
+            second_conf,
+            &base_dir,
+            "transfer-retry-owner-b",
+        );
+        let second_client = TransferClient::with_rt(&second_conf, rt.clone()).unwrap();
+
+        let mut final_state = 0;
+        for _ in 0..120 {
+            let status = second_client
+                .status_page(&submit.job_id, Some(10), None)
+                .await
+                .unwrap();
+            final_state = status.state;
+            if final_state == TransferStateProto::TransferCompleted as i32
+                || final_state == TransferStateProto::TransferFailed as i32
+            {
+                assert!(!status.tasks.is_empty(), "status should return task page");
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
+
+        assert_eq!(final_state, TransferStateProto::TransferCompleted as i32);
+        let final_tasks = store
+            .list_transfer_tasks(&submit.job_id, submit.run_id)
+            .unwrap();
+        assert_eq!(final_tasks.len(), 1);
+        assert_eq!(final_tasks[0].state, TransferTaskState::Completed);
+        assert_eq!(
+            final_tasks[0].attempt_id, 2,
+            "retry commit recovery must dispatch a second attempt"
+        );
+        assert!(
+            final_tasks[0].retry_count > 0,
+            "retry commit recovery must mark the stale first attempt"
+        );
+        assert_eq!(fs.read_string(&target).await.unwrap(), "mysql-retry-commit");
+
+        second_child.stop();
+        let _ = fs::remove_dir_all(base_dir);
+    });
+}
+
+#[test]
+fn test_transfer_mysql_retries_running_task_after_worker_restart() {
+    let Some(mysql_url) = mysql_transfer_store_url("mysql-worker-restart") else {
+        eprintln!("skip mysql worker restart e2e: CURVINE_TRANSFER_MYSQL_URL is not set");
+        return;
+    };
+    let test_id = format!(
+        "transfer-mysql-worker-restart-{}-{}",
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    );
+    let base_dir = std::env::temp_dir().join(&test_id);
+    let ufs_dir = base_dir.join("ufs");
+    fs::create_dir_all(&ufs_dir).unwrap();
+    fs::write(ufs_dir.join("worker-restart.txt"), b"worker-restart").unwrap();
+
+    let mut conf = ClusterConf::default();
+    conf.master.meta_dir = base_dir.join("meta").display().to_string();
+    conf.journal.journal_dir = base_dir.join("journal").display().to_string();
+    conf.worker.data_dir = vec![base_dir.join("worker").display().to_string()];
+    conf.transfer.enabled = true;
+    conf.transfer.store_type = TransferStoreType::Mysql;
+    conf.transfer.mysql_url = mysql_url.clone();
+    conf.transfer.hostname = "localhost".to_string();
+    conf.transfer.rpc_port = NetUtils::get_available_port();
+    conf.transfer.web_port = NetUtils::get_available_port();
+    conf.transfer.instance_id = "transfer-worker-restart-owner".to_string();
+    conf.transfer.endpoints = vec!["localhost:1".to_string()];
+    conf.transfer.lease_timeout_str = "2s".to_string();
+    conf.transfer.init().unwrap();
+
+    let cluster = MiniCluster::with_num(&conf, 1, 0);
+    cluster.start_master();
+    let rt = cluster.clone_client_rt();
+
+    rt.block_on(async {
+        let fs = wait_master_and_create_fs(&cluster).await;
+        fs.mount(
+            &Path::from_str(format!("file://{}", ufs_dir.display())).unwrap(),
+            &Path::from_str("/mnt").unwrap(),
+            MountOptions::builder().build(),
+        )
+        .await
+        .unwrap();
+
+        let binary = curvine_server_binary()
+            .expect("external worker restart e2e requires target/debug/curvine-server");
+        let mut worker_conf = cluster.cluster_conf.clone();
+        worker_conf.worker.rpc_port = NetUtils::get_available_port();
+        worker_conf.worker.web_port = NetUtils::get_available_port();
+        worker_conf.worker.data_dir = vec![base_dir.join("worker").display().to_string()];
+        let worker_conf_path = base_dir.join("worker-restart.toml");
+        std::fs::write(&worker_conf_path, toml::to_string(&worker_conf).unwrap()).unwrap();
+        let first_worker_log = base_dir.join("worker-restart-a.log");
+        let mut first_worker_child =
+            ServiceChild::spawn(&binary, "worker", &worker_conf_path, &first_worker_log);
+        let first_worker = wait_for_registered_worker_session(
+            &fs,
+            None,
+            Duration::from_secs(20),
+            &first_worker_log,
+            &mut first_worker_child,
+        )
+        .await;
+
+        let mut transfer_server = InProcessTransferServer::start(cluster.cluster_conf.clone());
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        let mut client_conf = cluster.cluster_conf.clone();
+        client_conf.transfer.endpoints = vec![format!(
+            "{}:{}",
+            client_conf.transfer.hostname, client_conf.transfer.rpc_port
+        )];
+        let client = TransferClient::with_rt(&client_conf, rt.clone()).unwrap();
+        let target = Path::from_str("/mnt/worker-restart.txt").unwrap();
+        let submit = client
+            .submit(TransferCommand {
+                kind: TransferKind::Load,
+                source_path: format!("file://{}/worker-restart.txt", ufs_dir.display()),
+                target_path: target.clone_uri(),
+                client_request_id: test_id.clone(),
+                submitter: "mysql-worker-restart-e2e".to_string(),
+                tenant: "test".to_string(),
+                options: Default::default(),
+            })
+            .await
+            .unwrap();
+
+        let store = MysqlTransferStore::open(&mysql_url).unwrap();
+        let first_task = wait_for_mysql_running_task_after_local_commit(
+            &fs,
+            &store,
+            &submit.job_id,
+            submit.run_id,
+            &target,
+            "worker-restart",
+            Duration::from_secs(30),
+        )
+        .await
+        .expect("first worker should leave running task after local commit");
+        assert_eq!(first_task.worker_session_id, first_worker.worker_session_id);
+
+        first_worker_child.stop();
+        let second_worker_log = base_dir.join("worker-restart-b.log");
+        let mut second_worker_child =
+            ServiceChild::spawn(&binary, "worker", &worker_conf_path, &second_worker_log);
+        let second_worker = wait_for_registered_worker_session(
+            &fs,
+            Some(&first_worker.worker_session_id),
+            Duration::from_secs(20),
+            &second_worker_log,
+            &mut second_worker_child,
+        )
+        .await;
+        assert_ne!(
+            second_worker.worker_session_id, first_worker.worker_session_id,
+            "worker restart must publish a new session"
+        );
+
+        let mut final_state = 0;
+        for _ in 0..120 {
+            let status = client
+                .status_page(&submit.job_id, Some(10), None)
+                .await
+                .unwrap();
+            final_state = status.state;
+            if final_state == TransferStateProto::TransferCompleted as i32
+                || final_state == TransferStateProto::TransferFailed as i32
+            {
+                assert!(!status.tasks.is_empty(), "status should return task page");
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
+
+        assert_eq!(final_state, TransferStateProto::TransferCompleted as i32);
+        let final_tasks = store
+            .list_transfer_tasks(&submit.job_id, submit.run_id)
+            .unwrap();
+        assert_eq!(final_tasks.len(), 1);
+        assert_eq!(final_tasks[0].state, TransferTaskState::Completed);
+        assert_eq!(
+            final_tasks[0].worker_id, second_worker.worker_id,
+            "retry must use the restarted worker identity"
+        );
+        assert_eq!(
+            final_tasks[0].worker_session_id, second_worker.worker_session_id,
+            "retry must run on the restarted worker session"
+        );
+        assert!(
+            final_tasks[0].attempt_id > 1,
+            "worker restart must retry instead of probing the old session as completed"
+        );
+        assert!(
+            final_tasks[0].retry_count > 0,
+            "worker restart must mark the old running attempt stale"
+        );
+        assert_eq!(fs.read_string(&target).await.unwrap(), "worker-restart");
+
+        transfer_server.stop();
+        second_worker_child.stop();
+        let _ = fs::remove_dir_all(base_dir);
+    });
+}
+
+#[test]
+fn test_transfer_mysql_two_servers_share_store_without_duplicate_tasks() {
+    let Some(mysql_url) = mysql_transfer_store_url("mysql-two-server") else {
+        eprintln!("skip mysql transfer two-server e2e: CURVINE_TRANSFER_MYSQL_URL is not set");
+        return;
+    };
+    let test_id = format!(
+        "transfer-mysql-two-server-{}-{}",
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    );
+    let base_dir = std::env::temp_dir().join(&test_id);
+    let ufs_dir = base_dir.join("ufs");
+    fs::create_dir_all(&ufs_dir).unwrap();
+    for index in 0..6 {
+        fs::write(
+            ufs_dir.join(format!("file-{index}.txt")),
+            format!("two-server-{index}"),
+        )
+        .unwrap();
+    }
+
+    let mut conf = ClusterConf::default();
+    conf.master.meta_dir = base_dir.join("meta").display().to_string();
+    conf.journal.journal_dir = base_dir.join("journal").display().to_string();
+    conf.worker.data_dir = vec![base_dir.join("worker").display().to_string()];
+    conf.transfer.enabled = true;
+    conf.transfer.store_type = TransferStoreType::Mysql;
+    conf.transfer.mysql_url = mysql_url.clone();
+    conf.transfer.hostname = "localhost".to_string();
+    conf.transfer.rpc_port = NetUtils::hold_available_port();
+    conf.transfer.web_port = NetUtils::hold_available_port();
+    conf.transfer.instance_id = "transfer-e2e-a".to_string();
+    conf.transfer.max_running_transfers = 2;
+    conf.transfer.endpoints = vec![format!(
+        "{}:{}",
+        conf.transfer.hostname, conf.transfer.rpc_port
+    )];
+    conf.transfer.init().unwrap();
+
+    let cluster = MiniCluster::with_num(&conf, 1, 1);
+    cluster.start_cluster();
+    let rt = cluster.clone_client_rt();
+
+    rt.block_on(async {
+        let fs = CurvineFileSystem::with_rt(cluster.cluster_conf.clone(), rt.clone()).unwrap();
+        fs.mount(
+            &Path::from_str(format!("file://{}", ufs_dir.display())).unwrap(),
+            &Path::from_str("/mnt").unwrap(),
+            MountOptions::builder().build(),
+        )
+        .await
+        .unwrap();
+
+        let store = Arc::new(MysqlTransferStore::open(&mysql_url).unwrap());
+        let cache = ClusterMetadataCache::new(fs.clone());
+        cache.refresh().await.unwrap();
+        let service = TransferService::with_cache(
+            store.clone(),
+            cache,
+            cluster.cluster_conf.transfer.task_stale_timeout,
+        );
+        let mut job_ids = Vec::new();
+        for index in 0..6 {
+            let job = service
+                .submit_transfer(SubmitTransferRequest {
+                    kind: TransferKindProto::TransferLoad as i32,
+                    source_path: format!("file://{}/file-{index}.txt", ufs_dir.display()),
+                    target_path: format!("/mnt/file-{index}.txt"),
+                    client_request_id: format!("{test_id}-{index}"),
+                    submitter: "mysql-two-server-e2e".to_string(),
+                    tenant: "test".to_string(),
+                    command: Vec::new(),
+                    protocol_version: Some(1),
+                })
+                .unwrap();
+            job_ids.push(job.job_id);
+        }
+
+        let mut transfer_server_a = InProcessTransferServer::start(cluster.cluster_conf.clone());
+
+        let mut second_conf = cluster.cluster_conf.clone();
+        second_conf.transfer.rpc_port = NetUtils::hold_available_port();
+        second_conf.transfer.web_port = NetUtils::hold_available_port();
+        second_conf.transfer.instance_id = "transfer-e2e-b".to_string();
+        second_conf.transfer.endpoints = vec![format!(
+            "{}:{}",
+            second_conf.transfer.hostname, second_conf.transfer.rpc_port
+        )];
+        second_conf.transfer.init().unwrap();
+        let mut transfer_server_b = InProcessTransferServer::start(second_conf);
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        for _ in 0..120 {
+            let mut completed = 0;
+            for job_id in &job_ids {
+                let job = store.get_transfer(job_id).unwrap().unwrap();
+                if job.state == curvine_common::state::TransferState::Completed {
+                    completed += 1;
+                }
+            }
+            if completed == job_ids.len() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
+
+        for (index, job_id) in job_ids.iter().enumerate() {
+            let job = store.get_transfer(job_id).unwrap().unwrap();
+            assert_eq!(
+                job.state,
+                curvine_common::state::TransferState::Completed,
+                "job {} should complete, actual {:?}",
+                job_id,
+                job.state
+            );
+            assert!(
+                job.owner == "transfer-e2e-a" || job.owner == "transfer-e2e-b",
+                "unexpected job owner: {}",
+                job.owner
+            );
+            let tasks = store.list_transfer_tasks(job_id, job.run_id).unwrap();
+            assert_eq!(
+                tasks.len(),
+                1,
+                "job {} should have one planned task",
+                job_id
+            );
+            assert_eq!(
+                tasks[0].state,
+                curvine_common::state::TransferTaskState::Completed
+            );
+            assert_eq!(
+                fs.read_string(&Path::from_str(format!("/mnt/file-{index}.txt")).unwrap())
+                    .await
+                    .unwrap(),
+                format!("two-server-{index}")
+            );
+        }
+
+        transfer_server_b.stop();
+        transfer_server_a.stop();
+        let _ = fs::remove_dir_all(base_dir);
+    });
+}
+
+#[test]
+fn test_transfer_mysql_external_process_rolling_upgrade_recovers_backlog() {
+    let Some(mysql_url) = mysql_transfer_store_url("mysql-rolling-upgrade") else {
+        eprintln!("skip mysql transfer rolling upgrade e2e: CURVINE_TRANSFER_MYSQL_URL is not set");
+        return;
+    };
+    let test_id = format!(
+        "transfer-mysql-rolling-upgrade-{}-{}",
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    );
+    let base_dir = std::env::temp_dir().join(&test_id);
+    let ufs_dir = base_dir.join("ufs");
+    fs::create_dir_all(&ufs_dir).unwrap();
+    let job_count = 24usize;
+    let payload = "x".repeat(1024 * 1024);
+    for index in 0..job_count {
+        fs::write(
+            ufs_dir.join(format!("rolling-{index}.bin")),
+            payload.as_bytes(),
+        )
+        .unwrap();
+    }
+
+    let mut conf = ClusterConf::default();
+    conf.master.meta_dir = base_dir.join("meta").display().to_string();
+    conf.journal.journal_dir = base_dir.join("journal").display().to_string();
+    conf.worker.data_dir = vec![base_dir.join("worker").display().to_string()];
+    conf.transfer.enabled = true;
+    conf.transfer.store_type = TransferStoreType::Mysql;
+    conf.transfer.mysql_url = mysql_url.clone();
+    conf.transfer.hostname = "localhost".to_string();
+    conf.transfer.rpc_port = NetUtils::get_available_port();
+    conf.transfer.web_port = NetUtils::get_available_port();
+    conf.transfer.instance_id = "transfer-rolling-a".to_string();
+    conf.transfer.max_running_transfers = 1;
+    conf.transfer.lease_timeout_str = "1500ms".to_string();
+    conf.transfer.endpoints = vec![format!(
+        "{}:{}",
+        conf.transfer.hostname, conf.transfer.rpc_port
+    )];
+    conf.transfer.init().unwrap();
+
+    let cluster = MiniCluster::with_num(&conf, 1, 1);
+    cluster.start_cluster();
+    let rt = cluster.clone_client_rt();
+
+    rt.block_on(async {
+        let fs = CurvineFileSystem::with_rt(cluster.cluster_conf.clone(), rt.clone()).unwrap();
+        fs.mount(
+            &Path::from_str(format!("file://{}", ufs_dir.display())).unwrap(),
+            &Path::from_str("/mnt").unwrap(),
+            MountOptions::builder().build(),
+        )
+        .await
+        .unwrap();
+
+        let store = Arc::new(MysqlTransferStore::open(&mysql_url).unwrap());
+        let cache = ClusterMetadataCache::new(fs.clone());
+        cache.refresh().await.unwrap();
+        let service = TransferService::with_cache(
+            store.clone(),
+            cache,
+            cluster.cluster_conf.transfer.task_stale_timeout,
+        );
+        let mut job_ids = Vec::with_capacity(job_count);
+        for index in 0..job_count {
+            let job = service
+                .submit_transfer(SubmitTransferRequest {
+                    kind: TransferKindProto::TransferLoad as i32,
+                    source_path: format!("file://{}/rolling-{index}.bin", ufs_dir.display()),
+                    target_path: format!("/mnt/rolling-{index}.bin"),
+                    client_request_id: format!("{test_id}-{index}"),
+                    submitter: "mysql-rolling-upgrade-e2e".to_string(),
+                    tenant: "test".to_string(),
+                    command: Vec::new(),
+                    protocol_version: Some(1),
+                })
+                .unwrap();
+            job_ids.push(job.job_id);
+        }
+
+        let binary = curvine_server_binary()
+            .expect("external transfer rolling upgrade e2e requires target/debug/curvine-server");
+        let (first_conf, mut first_child) = spawn_transfer_child_until_healthy(
+            &binary,
+            cluster.cluster_conf.clone(),
+            &base_dir,
+            "transfer-rolling-a",
+        );
+        let mut first_owned = 0usize;
+        for _ in 0..80 {
+            first_owned = count_jobs_with_owner(&store, &job_ids, "transfer-rolling-a");
+            if first_owned > 0 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        assert!(
+            first_owned > 0,
+            "first transfer process should acquire at least one job before rolling stop"
+        );
+        first_child.stop();
+        assert!(
+            !wait_http_path(
+                first_conf.transfer.web_port,
+                "/healthz",
+                Duration::from_millis(300)
+            ),
+            "old transfer health endpoint should be unavailable after rolling stop"
+        );
+
+        let mut second_conf = cluster.cluster_conf.clone();
+        second_conf.transfer.rpc_port = NetUtils::get_available_port();
+        second_conf.transfer.web_port = NetUtils::get_available_port();
+        second_conf.transfer.instance_id = "transfer-rolling-b".to_string();
+        second_conf.transfer.endpoints = vec![format!(
+            "{}:{}",
+            second_conf.transfer.hostname, second_conf.transfer.rpc_port
+        )];
+        second_conf.transfer.init().unwrap();
+        let (second_conf, mut second_child) = spawn_transfer_child_until_healthy(
+            &binary,
+            second_conf,
+            &base_dir,
+            "transfer-rolling-b",
+        );
+        let second_client = TransferClient::with_rt(&second_conf, rt.clone()).unwrap();
+
+        for _ in 0..480 {
+            let completed = job_ids
+                .iter()
+                .filter(|job_id| {
+                    store.get_transfer(job_id).unwrap().unwrap().state
+                        == curvine_common::state::TransferState::Completed
+                })
+                .count();
+            if completed == job_count {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
+
+        let mut second_owned = 0usize;
+        let state_summary = transfer_state_summary(&store, &job_ids);
+        for (index, job_id) in job_ids.iter().enumerate() {
+            let status = second_client
+                .status_page(job_id, Some(10), None)
+                .await
+                .unwrap();
+            assert_eq!(
+                status.state,
+                TransferStateProto::TransferCompleted as i32,
+                "job {job_id} should complete after rolling upgrade; state summary: {state_summary}"
+            );
+            let owner = status.owner.unwrap_or_default();
+            assert!(
+                owner == "transfer-rolling-a" || owner == "transfer-rolling-b",
+                "unexpected owner after rolling upgrade: {owner}"
+            );
+            if owner == "transfer-rolling-b" {
+                second_owned += 1;
+            }
+            assert_eq!(status.tasks.len(), 1, "job {job_id} should have one task");
+            assert_eq!(
+                status.tasks[0].state,
+                TransferTaskStateProto::TransferTaskCompleted as i32
+            );
+            assert_eq!(
+                fs.read_string(&Path::from_str(format!("/mnt/rolling-{index}.bin")).unwrap())
+                    .await
+                    .unwrap(),
+                payload
+            );
+        }
+        assert!(
+            second_owned > 0,
+            "second transfer process should take over at least one unfinished job"
+        );
+
+        second_child.stop();
+        let _ = fs::remove_dir_all(base_dir);
+    });
+}
+
+#[test]
+fn test_transfer_mysql_external_process_multi_instance_rolling_upgrade() {
+    let Some(mysql_url) = mysql_transfer_store_url("mysql-multi-rolling") else {
+        eprintln!("skip mysql multi-instance rolling e2e: CURVINE_TRANSFER_MYSQL_URL is not set");
+        return;
+    };
+    let binary = match curvine_server_binary() {
+        Some(binary) => binary,
+        None => {
+            eprintln!("skip mysql multi-instance rolling e2e: curvine-server binary missing");
+            return;
+        }
+    };
+    let test_id = format!(
+        "transfer-mysql-multi-rolling-{}-{}",
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    );
+    let base_dir = std::env::temp_dir().join(&test_id);
+    let ufs_dir = base_dir.join("ufs");
+    fs::create_dir_all(&ufs_dir).unwrap();
+    let job_count = 18usize;
+    let payload = "multi-rolling-".repeat(64 * 1024);
+    for index in 0..job_count {
+        fs::write(
+            ufs_dir.join(format!("multi-rolling-{index}.bin")),
+            payload.as_bytes(),
+        )
+        .unwrap();
+    }
+
+    let mut conf = ClusterConf::default();
+    conf.master.meta_dir = base_dir.join("meta").display().to_string();
+    conf.journal.journal_dir = base_dir.join("journal").display().to_string();
+    conf.worker.data_dir = vec![base_dir.join("worker").display().to_string()];
+    conf.transfer.enabled = true;
+    conf.transfer.store_type = TransferStoreType::Mysql;
+    conf.transfer.mysql_url = mysql_url.clone();
+    conf.transfer.hostname = "localhost".to_string();
+    conf.transfer.rpc_port = NetUtils::get_available_port();
+    conf.transfer.web_port = NetUtils::get_available_port();
+    conf.transfer.instance_id = "transfer-multi-rolling-a".to_string();
+    conf.transfer.max_running_transfers = 2;
+    conf.transfer.lease_timeout_str = "1500ms".to_string();
+    conf.transfer.endpoints = vec![format!(
+        "{}:{}",
+        conf.transfer.hostname, conf.transfer.rpc_port
+    )];
+    conf.transfer.init().unwrap();
+
+    let cluster = MiniCluster::with_num(&conf, 1, 2);
+    cluster.start_cluster();
+    let rt = cluster.clone_client_rt();
+
+    rt.block_on(async {
+        let fs = CurvineFileSystem::with_rt(cluster.cluster_conf.clone(), rt.clone()).unwrap();
+        fs.mount(
+            &Path::from_str(format!("file://{}", ufs_dir.display())).unwrap(),
+            &Path::from_str("/mnt").unwrap(),
+            MountOptions::builder().build(),
+        )
+        .await
+        .unwrap();
+
+        let store = Arc::new(MysqlTransferStore::open(&mysql_url).unwrap());
+        let cache = ClusterMetadataCache::new(fs.clone());
+        cache.refresh().await.unwrap();
+        let service = TransferService::with_cache(
+            store.clone(),
+            cache,
+            cluster.cluster_conf.transfer.task_stale_timeout,
+        );
+        let mut job_ids = Vec::with_capacity(job_count);
+        for index in 0..job_count {
+            let job = service
+                .submit_transfer(SubmitTransferRequest {
+                    kind: TransferKindProto::TransferLoad as i32,
+                    source_path: format!(
+                        "file://{}/multi-rolling-{index}.bin",
+                        ufs_dir.display()
+                    ),
+                    target_path: format!("/mnt/multi-rolling-{index}.bin"),
+                    client_request_id: format!("{test_id}-{index}"),
+                    submitter: "mysql-multi-rolling-e2e".to_string(),
+                    tenant: "test".to_string(),
+                    command: Vec::new(),
+                    protocol_version: Some(1),
+                })
+                .unwrap();
+            job_ids.push(job.job_id);
+        }
+
+        let (first_conf, mut first_child) = spawn_transfer_child_until_healthy(
+            &binary,
+            cluster.cluster_conf.clone(),
+            &base_dir,
+            "transfer-multi-rolling-a",
+        );
+        let mut second_conf = cluster.cluster_conf.clone();
+        second_conf.transfer.rpc_port = NetUtils::get_available_port();
+        second_conf.transfer.web_port = NetUtils::get_available_port();
+        second_conf.transfer.instance_id = "transfer-multi-rolling-b".to_string();
+        second_conf.transfer.endpoints = vec![format!(
+            "{}:{}",
+            second_conf.transfer.hostname, second_conf.transfer.rpc_port
+        )];
+        second_conf.transfer.init().unwrap();
+        let (second_conf, mut second_child) = spawn_transfer_child_until_healthy(
+            &binary,
+            second_conf,
+            &base_dir,
+            "transfer-multi-rolling-b",
+        );
+
+        for _ in 0..120 {
+            let first_owned =
+                count_jobs_with_owner(&store, &job_ids, "transfer-multi-rolling-a");
+            let second_owned =
+                count_jobs_with_owner(&store, &job_ids, "transfer-multi-rolling-b");
+            if first_owned > 0 && second_owned > 0 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        assert!(
+            count_jobs_with_owner(&store, &job_ids, "transfer-multi-rolling-a") > 0,
+            "first transfer process should own jobs before rolling replacement"
+        );
+        assert!(
+            count_jobs_with_owner(&store, &job_ids, "transfer-multi-rolling-b") > 0,
+            "second transfer process should own jobs before rolling replacement"
+        );
+
+        first_child.stop();
+        assert!(
+            !wait_http_path(
+                first_conf.transfer.web_port,
+                "/healthz",
+                Duration::from_millis(300)
+            ),
+            "old rolling instance should be unavailable after stop"
+        );
+
+        let mut third_conf = cluster.cluster_conf.clone();
+        third_conf.transfer.rpc_port = NetUtils::get_available_port();
+        third_conf.transfer.web_port = NetUtils::get_available_port();
+        third_conf.transfer.instance_id = "transfer-multi-rolling-c".to_string();
+        third_conf.transfer.endpoints = vec![format!(
+            "{}:{}",
+            third_conf.transfer.hostname, third_conf.transfer.rpc_port
+        )];
+        third_conf.transfer.init().unwrap();
+        let (third_conf, mut third_child) = spawn_transfer_child_until_healthy(
+            &binary,
+            third_conf,
+            &base_dir,
+            "transfer-multi-rolling-c",
+        );
+        let third_client = TransferClient::with_rt(&third_conf, rt.clone()).unwrap();
+
+        for _ in 0..480 {
+            let completed = job_ids
+                .iter()
+                .filter(|job_id| {
+                    store.get_transfer(job_id).unwrap().unwrap().state
+                        == curvine_common::state::TransferState::Completed
+                })
+                .count();
+            if completed == job_count {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
+
+        let state_summary = transfer_state_summary(&store, &job_ids);
+        let mut second_owned = 0usize;
+        let mut third_owned = 0usize;
+        for (index, job_id) in job_ids.iter().enumerate() {
+            let status = third_client
+                .status_page(job_id, Some(10), None)
+                .await
+                .unwrap();
+            assert_eq!(
+                status.state,
+                TransferStateProto::TransferCompleted as i32,
+                "job {job_id} should complete after multi-instance rolling upgrade; state summary: {state_summary}"
+            );
+            let owner = status.owner.unwrap_or_default();
+            assert!(
+                matches!(
+                    owner.as_str(),
+                    "transfer-multi-rolling-a"
+                        | "transfer-multi-rolling-b"
+                        | "transfer-multi-rolling-c"
+                ),
+                "unexpected owner after multi-instance rolling upgrade: {owner}"
+            );
+            if owner == "transfer-multi-rolling-b" {
+                second_owned += 1;
+            }
+            if owner == "transfer-multi-rolling-c" {
+                third_owned += 1;
+            }
+            assert_eq!(status.tasks.len(), 1, "job {job_id} should have one task");
+            assert_eq!(
+                status.tasks[0].state,
+                TransferTaskStateProto::TransferTaskCompleted as i32
+            );
+            assert_eq!(
+                fs.read_string(&Path::from_str(format!("/mnt/multi-rolling-{index}.bin")).unwrap())
+                    .await
+                    .unwrap(),
+                payload
+            );
+        }
+        assert!(
+            second_owned > 0,
+            "existing peer should keep making progress during rolling replacement"
+        );
+        assert!(
+            third_owned > 0,
+            "new transfer process should acquire unfinished backlog after rolling replacement"
+        );
+
+        third_child.stop();
+        second_child.stop();
+        let _ = fs::remove_dir_all(base_dir);
+        let _ = second_conf;
+    });
+}
+
+#[test]
+fn test_transfer_mysql_external_process_rolls_after_store_outage() {
+    let Some((mysql_url, proxy)) = mysql_transfer_store_url_with_proxy("rolling-store-outage")
+    else {
+        eprintln!(
+            "skip mysql rolling store outage e2e: CURVINE_TRANSFER_MYSQL_URL must use host:port"
+        );
+        return;
+    };
+    let binary = match curvine_server_binary() {
+        Some(binary) => binary,
+        None => {
+            eprintln!("skip mysql rolling store outage e2e: curvine-server binary missing");
+            return;
+        }
+    };
+    let test_id = format!(
+        "transfer-mysql-rolling-store-outage-{}-{}",
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    );
+    let base_dir = std::env::temp_dir().join(&test_id);
+    let ufs_dir = base_dir.join("ufs");
+    fs::create_dir_all(&ufs_dir).unwrap();
+    let job_count = 8usize;
+    let payload = "rolling-store-outage";
+    for index in 0..job_count {
+        fs::write(
+            ufs_dir.join(format!("outage-{index}.txt")),
+            format!("{payload}-{index}"),
+        )
+        .unwrap();
+    }
+
+    let mut conf = ClusterConf::default();
+    conf.master.meta_dir = base_dir.join("meta").display().to_string();
+    conf.journal.journal_dir = base_dir.join("journal").display().to_string();
+    conf.worker.data_dir = vec![base_dir.join("worker").display().to_string()];
+    conf.transfer.enabled = true;
+    conf.transfer.store_type = TransferStoreType::Mysql;
+    conf.transfer.mysql_url = mysql_url.clone();
+    conf.transfer.hostname = "localhost".to_string();
+    conf.transfer.rpc_port = NetUtils::get_available_port();
+    conf.transfer.web_port = NetUtils::get_available_port();
+    conf.transfer.instance_id = "transfer-rolling-outage-a".to_string();
+    conf.transfer.max_running_transfers = 1;
+    conf.transfer.lease_timeout_str = "1500ms".to_string();
+    conf.transfer.endpoints = vec![format!(
+        "{}:{}",
+        conf.transfer.hostname, conf.transfer.rpc_port
+    )];
+    conf.transfer.init().unwrap();
+
+    let cluster = MiniCluster::with_num(&conf, 1, 1);
+    cluster.start_cluster();
+    let rt = cluster.clone_client_rt();
+
+    rt.block_on(async {
+        let fs = CurvineFileSystem::with_rt(cluster.cluster_conf.clone(), rt.clone()).unwrap();
+        fs.mount(
+            &Path::from_str(format!("file://{}", ufs_dir.display())).unwrap(),
+            &Path::from_str("/mnt").unwrap(),
+            MountOptions::builder().build(),
+        )
+        .await
+        .unwrap();
+
+        let store = Arc::new(MysqlTransferStore::open(&mysql_url).unwrap());
+        let cache = ClusterMetadataCache::new(fs.clone());
+        cache.refresh().await.unwrap();
+        let service = TransferService::with_cache(
+            store.clone(),
+            cache,
+            cluster.cluster_conf.transfer.task_stale_timeout,
+        );
+        let mut job_ids = Vec::with_capacity(job_count);
+        for index in 0..job_count {
+            let job = service
+                .submit_transfer(SubmitTransferRequest {
+                    kind: TransferKindProto::TransferLoad as i32,
+                    source_path: format!("file://{}/outage-{index}.txt", ufs_dir.display()),
+                    target_path: format!("/mnt/outage-{index}.txt"),
+                    client_request_id: format!("{test_id}-{index}"),
+                    submitter: "mysql-rolling-store-outage-e2e".to_string(),
+                    tenant: "test".to_string(),
+                    command: Vec::new(),
+                    protocol_version: Some(1),
+                })
+                .unwrap();
+            job_ids.push(job.job_id);
+        }
+
+        let (first_conf, mut first_child) = spawn_transfer_child_until_healthy(
+            &binary,
+            cluster.cluster_conf.clone(),
+            &base_dir,
+            "transfer-rolling-outage-a",
+        );
+        let mut first_owned = 0usize;
+        for _ in 0..80 {
+            first_owned = count_jobs_with_owner(&store, &job_ids, "transfer-rolling-outage-a");
+            if first_owned > 0 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        assert!(
+            first_owned > 0,
+            "first transfer process should acquire at least one job before outage"
+        );
+
+        proxy.set_available(false);
+        first_child.stop();
+        assert!(
+            !wait_http_path(
+                first_conf.transfer.web_port,
+                "/healthz",
+                Duration::from_millis(300)
+            ),
+            "old transfer health endpoint should be unavailable after kill"
+        );
+
+        let mut second_conf = cluster.cluster_conf.clone();
+        second_conf.transfer.rpc_port = NetUtils::get_available_port();
+        second_conf.transfer.web_port = NetUtils::get_available_port();
+        second_conf.transfer.instance_id = "transfer-rolling-outage-b".to_string();
+        second_conf.transfer.endpoints = vec![format!(
+            "{}:{}",
+            second_conf.transfer.hostname, second_conf.transfer.rpc_port
+        )];
+        second_conf.transfer.init().unwrap();
+        let second_conf_path = base_dir.join("transfer-rolling-outage-b-unavailable.toml");
+        fs::write(&second_conf_path, toml::to_string(&second_conf).unwrap()).unwrap();
+        let second_log_path = base_dir.join("transfer-rolling-outage-b-unavailable.log");
+        let mut second_child = TransferChild::spawn(&binary, &second_conf_path, &second_log_path);
+        assert!(
+            !wait_http_path(second_conf.transfer.web_port, "/readyz", Duration::from_secs(2)),
+            "new transfer process must not become ready while mysql store is unavailable"
+        );
+        second_child.stop();
+
+        proxy.set_available(true);
+        let (second_conf, mut second_child) = spawn_transfer_child_until_healthy(
+            &binary,
+            second_conf,
+            &base_dir,
+            "transfer-rolling-outage-b",
+        );
+        let second_client = TransferClient::with_rt(&second_conf, rt.clone()).unwrap();
+
+        for _ in 0..240 {
+            let completed = job_ids
+                .iter()
+                .filter(|job_id| {
+                    store.get_transfer(job_id).unwrap().unwrap().state
+                        == curvine_common::state::TransferState::Completed
+                })
+                .count();
+            if completed == job_count {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
+
+        let state_summary = transfer_state_summary(&store, &job_ids);
+        let mut second_owned = 0usize;
+        for (index, job_id) in job_ids.iter().enumerate() {
+            let status = second_client
+                .status_page(job_id, Some(10), None)
+                .await
+                .unwrap();
+            assert_eq!(
+                status.state,
+                TransferStateProto::TransferCompleted as i32,
+                "job {job_id} should complete after rolling store outage; state summary: {state_summary}"
+            );
+            if status.owner.as_deref() == Some("transfer-rolling-outage-b") {
+                second_owned += 1;
+            }
+            assert_eq!(
+                fs.read_string(&Path::from_str(format!("/mnt/outage-{index}.txt")).unwrap())
+                    .await
+                    .unwrap(),
+                format!("{payload}-{index}")
+            );
+        }
+        assert!(
+            second_owned > 0,
+            "new transfer process should own at least one job after store outage recovery"
+        );
+
+        second_child.stop();
+        let _ = fs::remove_dir_all(base_dir);
+    });
+}
+
+#[test]
+fn test_transfer_mysql_rpc_report_storm_does_not_starve_terminal_reports() {
+    let Some(mysql_url) = mysql_transfer_store_url("mysql-rpc-report-storm") else {
+        eprintln!("skip mysql rpc report storm e2e: CURVINE_TRANSFER_MYSQL_URL is not set");
+        return;
+    };
+    let test_id = format!(
+        "transfer-mysql-rpc-report-storm-{}-{}",
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    );
+    let base_dir = std::env::temp_dir().join(&test_id);
+    fs::create_dir_all(&base_dir).unwrap();
+
+    let mut conf = ClusterConf::default();
+    conf.master.meta_dir = base_dir.join("meta").display().to_string();
+    conf.journal.journal_dir = base_dir.join("journal").display().to_string();
+    conf.transfer.enabled = true;
+    conf.transfer.store_type = TransferStoreType::Mysql;
+    conf.transfer.mysql_url = mysql_url.clone();
+    conf.transfer.hostname = "localhost".to_string();
+    conf.transfer.rpc_port = NetUtils::hold_available_port();
+    conf.transfer.web_port = NetUtils::hold_available_port();
+    conf.transfer.instance_id = "transfer-report-storm-rpc".to_string();
+    conf.transfer.worker_threads = 4;
+    conf.transfer.endpoints = vec![format!(
+        "{}:{}",
+        conf.transfer.hostname, conf.transfer.rpc_port
+    )];
+    conf.transfer.init().unwrap();
+
+    let cluster = MiniCluster::with_num(&conf, 1, 0);
+    cluster.start_cluster();
+    let rt = cluster.clone_client_rt();
+
+    rt.block_on(async {
+        let store = Arc::new(MysqlTransferStore::open(&mysql_url).unwrap());
+        let now_ms = orpc::common::LocalTime::mills() as i64;
+        let job_id = format!("{test_id}-job");
+        let task_count = 16usize;
+        let running_reports = 512usize;
+
+        store
+            .create_or_get_by_request_id(TransferJobRecord {
+                job_key: format!("Load:file:///{test_id}:/storm/{test_id}"),
+                job_id: job_id.clone(),
+                run_id: 1,
+                kind: TransferKind::Load,
+                source_path: format!("file:///{test_id}"),
+                target_path: format!("/storm/{test_id}"),
+                command_json: "{}".to_string(),
+                mount_snapshot_json: "{}".to_string(),
+                secret_ref_json: "{}".to_string(),
+                cluster_snapshot_version: 1,
+                cv_metadata_epoch: None,
+                state: curvine_common::state::TransferState::Pending,
+                owner: String::new(),
+                lease_epoch: 0,
+                lease_expire_at: 0,
+                cancel_requested: false,
+                summary: TransferProgress::default(),
+                client_request_id: format!("{test_id}-request"),
+                submitter: "rpc-report-storm-e2e".to_string(),
+                tenant: "default".to_string(),
+                created_at: now_ms,
+                updated_at: now_ms,
+            })
+            .unwrap();
+
+        let tasks = (0..task_count)
+            .map(|index| TransferTaskRecord {
+                job_id: job_id.clone(),
+                run_id: 1,
+                task_id: format!("task-{index}"),
+                attempt_id: 0,
+                source_path: format!("file:///{test_id}/source-{index}"),
+                target_path: format!("/storm/{test_id}/target-{index}"),
+                worker_id: 0,
+                worker_session_id: String::new(),
+                source_read_plan_json: String::new(),
+                report_target_json: String::new(),
+                state: TransferTaskState::Pending,
+                progress: TransferProgress::default(),
+                retry_count: 0,
+                attempt_started_at: 0,
+                last_report_at: 0,
+                stale_deadline_at: 0,
+                updated_at: now_ms,
+            })
+            .collect::<Vec<_>>();
+        store.insert_tasks(tasks).unwrap();
+        let lease = store
+            .acquire_runnable_transfer("report-storm-owner", 600_000, now_ms, 100)
+            .unwrap()
+            .expect("preloaded transfer should be acquirable");
+        for index in 0..task_count {
+            assert!(store
+                .start_task_attempt(TaskAttemptStart {
+                    job_id: job_id.clone(),
+                    run_id: 1,
+                    owner: lease.owner.clone(),
+                    lease_epoch: lease.lease_epoch,
+                    task_id: format!("task-{index}"),
+                    attempt_id: 1,
+                    worker_id: 10_000 + index as u32,
+                    worker_session_id: format!("storm-session-{index}"),
+                    report_target_json: "{}".to_string(),
+                    now_ms,
+                    stale_deadline_at: now_ms + 600_000,
+                })
+                .unwrap());
+        }
+
+        let mut transfer_server = InProcessTransferServer::start(cluster.cluster_conf.clone());
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        let client = Arc::new(TransferClient::with_rt(&cluster.cluster_conf, rt.clone()).unwrap());
+
+        let workers = 16usize;
+        let reports_per_worker = running_reports / workers;
+        let mut handles = Vec::with_capacity(workers);
+        for worker in 0..workers {
+            let client = client.clone();
+            let job_id = job_id.clone();
+            handles.push(tokio::spawn(async move {
+                for index in 0..reports_per_worker {
+                    let task_index = (worker * reports_per_worker + index) % task_count;
+                    let info = TransferTaskReportInfo {
+                        run_id: 1,
+                        attempt_id: 1,
+                        worker_id: 10_000 + task_index as u32,
+                        worker_session_id: format!("storm-session-{task_index}"),
+                        report_target: String::new(),
+                        report_endpoints: Vec::new(),
+                    };
+                    let progress = JobTaskProgress {
+                        state: JobTaskState::Loading,
+                        loaded_size: index as i64,
+                        total_size: running_reports as i64,
+                        update_time: orpc::common::LocalTime::mills() as i64,
+                        message: format!("running-{worker}-{index}"),
+                    };
+                    assert!(
+                        client
+                            .report_task(&job_id, format!("task-{task_index}"), &info, progress)
+                            .await
+                            .unwrap(),
+                        "running report should be accepted by transfer rpc queue"
+                    );
+                }
+            }));
+        }
+        for handle in handles {
+            handle.await.unwrap();
+        }
+
+        for index in 0..task_count {
+            let info = TransferTaskReportInfo {
+                run_id: 1,
+                attempt_id: 1,
+                worker_id: 10_000 + index as u32,
+                worker_session_id: format!("storm-session-{index}"),
+                report_target: String::new(),
+                report_endpoints: Vec::new(),
+            };
+            let progress = JobTaskProgress {
+                state: JobTaskState::Completed,
+                loaded_size: 1,
+                total_size: 1,
+                update_time: orpc::common::LocalTime::mills() as i64,
+                message: format!("completed-{index}"),
+            };
+            assert!(
+                client
+                    .report_task(&job_id, format!("task-{index}"), &info, progress)
+                    .await
+                    .unwrap(),
+                "terminal report should not be starved by previous report storm"
+            );
+        }
+
+        let final_job = store.get_transfer(&job_id).unwrap().unwrap();
+        assert_eq!(
+            final_job.state,
+            curvine_common::state::TransferState::Completed
+        );
+        assert_eq!(final_job.summary.loaded_size, task_count as i64);
+        assert_eq!(final_job.summary.total_size, task_count as i64);
+        let final_tasks = store.list_transfer_tasks(&job_id, 1).unwrap();
+        assert_eq!(final_tasks.len(), task_count);
+        assert!(
+            final_tasks
+                .iter()
+                .all(|task| task.state == TransferTaskState::Completed),
+            "all tasks should be completed after terminal report burst"
+        );
+
+        transfer_server.stop();
+        let _ = fs::remove_dir_all(base_dir);
+    });
+}
+
+#[test]
+fn test_transfer_master_metadata_reader_is_development_only() {
+    let mut conf = ClusterConf::default();
+    conf.transfer.enabled = true;
+    conf.transfer.store_url = "mysql://root:curvine@127.0.0.1:3306/curvine_transfer".to_string();
+    conf.transfer.cv_metadata_reader = TransferCvMetadataReaderType::Master;
+
+    let err = conf.transfer.init().unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("production transfer requires transfer.cv_metadata_reader=replica"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn test_transfer_export_file_end_to_end() {
+    let test_id = format!(
+        "transfer-export-e2e-{}-{}",
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    );
+    let base_dir = std::env::temp_dir().join(&test_id);
+    let ufs_dir = base_dir.join("ufs");
+    fs::create_dir_all(&ufs_dir).unwrap();
+
+    let mut conf = ClusterConf::default();
+    conf.master.meta_dir = base_dir.join("meta").display().to_string();
+    conf.journal.journal_dir = base_dir.join("journal").display().to_string();
+    conf.worker.data_dir = vec![base_dir.join("worker").display().to_string()];
+    conf.transfer.enabled = true;
+    conf.transfer.store_type = TransferStoreType::Sqlite;
+    conf.transfer.sqlite_path = base_dir.join("transfer.db").display().to_string();
+    conf.transfer.cv_metadata_reader = TransferCvMetadataReaderType::Master;
+    conf.transfer.hostname = "localhost".to_string();
+    conf.transfer.rpc_port = NetUtils::hold_available_port();
+    conf.transfer.web_port = NetUtils::hold_available_port();
+    conf.transfer.endpoints = vec![format!(
+        "{}:{}",
+        conf.transfer.hostname, conf.transfer.rpc_port
+    )];
+    conf.transfer.init().unwrap();
+
+    let cluster = MiniCluster::with_num(&conf, 1, 1);
+    cluster.start_cluster();
+    let rt = cluster.clone_client_rt();
+
+    rt.block_on(async {
+        let fs = CurvineFileSystem::with_rt(cluster.cluster_conf.clone(), rt.clone()).unwrap();
+        fs.mount(
+            &Path::from_str(format!("file://{}", ufs_dir.display())).unwrap(),
+            &Path::from_str("/mnt").unwrap(),
+            MountOptions::builder().build(),
+        )
+        .await
+        .unwrap();
+
+        let source = Path::from_str("/mnt/export.txt").unwrap();
+        fs.write_string(&source, "cv-to-ufs").await.unwrap();
+
+        let mut transfer_server = InProcessTransferServer::start(cluster.cluster_conf.clone());
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        let client = TransferClient::with_rt(&cluster.cluster_conf, rt.clone()).unwrap();
+        let target = Path::from_str(format!("file://{}/export.txt", ufs_dir.display())).unwrap();
+        let submit = client
+            .submit(TransferCommand {
+                kind: TransferKind::Export,
+                source_path: source.clone_uri(),
+                target_path: target.clone_uri(),
+                client_request_id: test_id.clone(),
+                submitter: "e2e".to_string(),
+                tenant: "test".to_string(),
+                options: Default::default(),
+            })
+            .await
+            .unwrap();
+
+        let mut final_state = submit.state;
+        let mut task_state = 0;
+        for _ in 0..80 {
+            let status = client
+                .status_page(&submit.job_id, Some(10), None)
+                .await
+                .unwrap();
+            final_state = status.state;
+            if let Some(task) = status.tasks.first() {
+                task_state = task.state;
+            }
+            if final_state == TransferStateProto::TransferCompleted as i32
+                || final_state == TransferStateProto::TransferFailed as i32
+            {
+                assert!(!status.tasks.is_empty(), "status should return task page");
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
+
+        assert_eq!(final_state, TransferStateProto::TransferCompleted as i32);
+        assert_eq!(
+            task_state,
+            TransferTaskStateProto::TransferTaskCompleted as i32
+        );
+        let content = fs::read_to_string(ufs_dir.join("export.txt")).unwrap();
+        assert_eq!(content, "cv-to-ufs");
+
+        transfer_server.stop();
+        let _ = fs::remove_dir_all(base_dir);
+    });
+}
+
+#[test]
+fn test_transfer_export_ufs_overwrite_policy() {
+    let test_id = format!(
+        "transfer-export-ufs-overwrite-{}-{}",
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    );
+    let base_dir = std::env::temp_dir().join(&test_id);
+    let ufs_dir = base_dir.join("ufs");
+    fs::create_dir_all(&ufs_dir).unwrap();
+    fs::write(ufs_dir.join("existing.txt"), b"old-ufs-content").unwrap();
+    fs::create_dir_all(ufs_dir.join("existing-dir")).unwrap();
+
+    let mut conf = ClusterConf::default();
+    conf.master.meta_dir = base_dir.join("meta").display().to_string();
+    conf.journal.journal_dir = base_dir.join("journal").display().to_string();
+    conf.worker.data_dir = vec![base_dir.join("worker").display().to_string()];
+    conf.transfer.enabled = true;
+    conf.transfer.store_type = TransferStoreType::Sqlite;
+    conf.transfer.sqlite_path = base_dir.join("transfer.db").display().to_string();
+    conf.transfer.cv_metadata_reader = TransferCvMetadataReaderType::Master;
+    conf.transfer.hostname = "localhost".to_string();
+    conf.transfer.rpc_port = NetUtils::hold_available_port();
+    conf.transfer.web_port = NetUtils::hold_available_port();
+    conf.transfer.endpoints = vec![format!(
+        "{}:{}",
+        conf.transfer.hostname, conf.transfer.rpc_port
+    )];
+    conf.transfer.init().unwrap();
+
+    let cluster = MiniCluster::with_num(&conf, 1, 1);
+    cluster.start_cluster();
+    let rt = cluster.clone_client_rt();
+
+    rt.block_on(async {
+        let fs = CurvineFileSystem::with_rt(cluster.cluster_conf.clone(), rt.clone()).unwrap();
+        fs.mount(
+            &Path::from_str(format!("file://{}", ufs_dir.display())).unwrap(),
+            &Path::from_str("/mnt").unwrap(),
+            MountOptions::builder().build(),
+        )
+        .await
+        .unwrap();
+
+        let source = Path::from_str("/mnt/export-overwrite.txt").unwrap();
+        fs.write_string(&source, "new-ufs-content").await.unwrap();
+
+        let mut transfer_server = InProcessTransferServer::start(cluster.cluster_conf.clone());
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        let client = TransferClient::with_rt(&cluster.cluster_conf, rt.clone()).unwrap();
+
+        let mut no_overwrite = TransferCommand {
+            kind: TransferKind::Export,
+            source_path: source.clone_uri(),
+            target_path: format!("file://{}/existing.txt", ufs_dir.display()),
+            client_request_id: format!("{test_id}-no-overwrite"),
+            submitter: "export-ufs-overwrite-e2e".to_string(),
+            tenant: "test".to_string(),
+            options: Default::default(),
+        };
+        no_overwrite.set_overwrite(false);
+        let no_overwrite_job = client.submit(no_overwrite).await.unwrap();
+        let no_overwrite_status = assert_transfer_failed(&client, &no_overwrite_job.job_id).await;
+        assert!(
+            no_overwrite_status
+                .progress
+                .message
+                .contains("already exists"),
+            "overwrite=false should fail because UFS target exists, got: {}",
+            no_overwrite_status.progress.message
+        );
+        assert_eq!(
+            fs::read_to_string(ufs_dir.join("existing.txt")).unwrap(),
+            "old-ufs-content"
+        );
+
+        let dir_target_job = client
+            .submit(TransferCommand {
+                kind: TransferKind::Export,
+                source_path: source.clone_uri(),
+                target_path: format!("file://{}/existing-dir", ufs_dir.display()),
+                client_request_id: format!("{test_id}-dir-target"),
+                submitter: "export-ufs-overwrite-e2e".to_string(),
+                tenant: "test".to_string(),
+                options: Default::default(),
+            })
+            .await
+            .unwrap();
+        let dir_target_status = assert_transfer_failed(&client, &dir_target_job.job_id).await;
+        assert!(
+            dir_target_status
+                .progress
+                .message
+                .contains("refusing to overwrite directory with file"),
+            "file export into UFS directory should fail clearly, got: {}",
+            dir_target_status.progress.message
+        );
+        assert!(
+            ufs_dir.join("existing-dir").is_dir(),
+            "directory target should remain a directory"
+        );
+
+        let overwrite_job = client
+            .submit(TransferCommand {
+                kind: TransferKind::Export,
+                source_path: source.clone_uri(),
+                target_path: format!("file://{}/existing.txt", ufs_dir.display()),
+                client_request_id: format!("{test_id}-overwrite"),
+                submitter: "export-ufs-overwrite-e2e".to_string(),
+                tenant: "test".to_string(),
+                options: Default::default(),
+            })
+            .await
+            .unwrap();
+        let overwrite_status = wait_transfer_state(
+            &client,
+            &overwrite_job.job_id,
+            TransferStateProto::TransferCompleted,
+            Duration::from_secs(30),
+        )
+        .await;
+        assert_eq!(overwrite_status.tasks.len(), 1);
+        assert_eq!(
+            overwrite_status.tasks[0].state,
+            TransferTaskStateProto::TransferTaskCompleted as i32
+        );
+        assert_eq!(
+            fs::read_to_string(ufs_dir.join("existing.txt")).unwrap(),
+            "new-ufs-content"
+        );
+
+        transfer_server.stop();
+        let _ = fs::remove_dir_all(base_dir);
+    });
+}
+
+#[test]
+fn test_transfer_export_file_with_metadata_replica_reader() {
+    let test_id = format!(
+        "transfer-export-replica-e2e-{}-{}",
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    );
+    let base_dir = std::env::temp_dir().join(&test_id);
+    let ufs_dir = base_dir.join("ufs");
+    fs::create_dir_all(&ufs_dir).unwrap();
+
+    let mut conf = ClusterConf::default();
+    conf.master.meta_dir = base_dir.join("meta").display().to_string();
+    conf.journal.journal_dir = base_dir.join("journal").display().to_string();
+    conf.worker.data_dir = vec![base_dir.join("worker").display().to_string()];
+    conf.transfer.enabled = true;
+    conf.transfer.store_type = TransferStoreType::Sqlite;
+    conf.transfer.sqlite_path = base_dir.join("transfer.db").display().to_string();
+    conf.transfer.cv_metadata_reader = TransferCvMetadataReaderType::Replica;
+    conf.transfer.metadata_replica_refresh_interval_str = "1h".to_string();
+    conf.transfer.hostname = "localhost".to_string();
+    conf.transfer.rpc_port = NetUtils::hold_available_port();
+    conf.transfer.web_port = NetUtils::hold_available_port();
+    conf.transfer.endpoints = vec![format!(
+        "{}:{}",
+        conf.transfer.hostname, conf.transfer.rpc_port
+    )];
+    conf.transfer.init().unwrap();
+
+    let cluster = MiniCluster::with_num(&conf, 1, 1);
+    cluster.start_cluster();
+    let rt = cluster.clone_client_rt();
+
+    rt.block_on(async {
+        let fs = CurvineFileSystem::with_rt(cluster.cluster_conf.clone(), rt.clone()).unwrap();
+        fs.mount(
+            &Path::from_str(format!("file://{}", ufs_dir.display())).unwrap(),
+            &Path::from_str("/mnt").unwrap(),
+            MountOptions::builder().build(),
+        )
+        .await
+        .unwrap();
+
+        let source = Path::from_str("/mnt/export-replica.txt").unwrap();
+        fs.write_string(&source, "cv-to-ufs-replica").await.unwrap();
+
+        let mut transfer_server = InProcessTransferServer::start(cluster.cluster_conf.clone());
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        let metrics = read_http_metrics(cluster.cluster_conf.transfer.web_port);
+        assert!(
+            metrics.contains("transfer_metadata_replica_version"),
+            "transfer metrics should expose metadata replica version"
+        );
+        assert!(
+            metrics.contains("transfer_metadata_replica_entries"),
+            "transfer metrics should expose metadata replica entry count"
+        );
+        assert!(
+            metrics.contains("transfer_metadata_replica_page_size"),
+            "transfer metrics should expose metadata replica page size"
+        );
+        assert!(
+            metrics.contains("transfer_metadata_replica_pages"),
+            "transfer metrics should expose metadata replica page count"
+        );
+        assert!(
+            metrics.contains("transfer_metadata_replica_refresh_total"),
+            "transfer metrics should expose metadata replica refresh attempts"
+        );
+
+        let client = TransferClient::with_rt(&cluster.cluster_conf, rt.clone()).unwrap();
+        let target =
+            Path::from_str(format!("file://{}/export-replica.txt", ufs_dir.display())).unwrap();
+        let submit = client
+            .submit(TransferCommand {
+                kind: TransferKind::Export,
+                source_path: source.clone_uri(),
+                target_path: target.clone_uri(),
+                client_request_id: test_id.clone(),
+                submitter: "replica-e2e".to_string(),
+                tenant: "test".to_string(),
+                options: Default::default(),
+            })
+            .await
+            .unwrap();
+
+        let mut final_state = submit.state;
+        for _ in 0..80 {
+            let status = client
+                .status_page(&submit.job_id, Some(10), None)
+                .await
+                .unwrap();
+            final_state = status.state;
+            if final_state == TransferStateProto::TransferCompleted as i32
+                || final_state == TransferStateProto::TransferFailed as i32
+            {
+                assert!(!status.tasks.is_empty(), "status should return task page");
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
+
+        assert_eq!(final_state, TransferStateProto::TransferCompleted as i32);
+        let content = fs::read_to_string(ufs_dir.join("export-replica.txt")).unwrap();
+        assert_eq!(content, "cv-to-ufs-replica");
+
+        transfer_server.stop();
+        let _ = fs::remove_dir_all(base_dir);
+    });
+}
+
+#[test]
+fn test_transfer_export_rejects_stale_metadata_replica() {
+    let test_id = format!(
+        "transfer-export-stale-replica-e2e-{}-{}",
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    );
+    let base_dir = std::env::temp_dir().join(&test_id);
+    let ufs_dir = base_dir.join("ufs");
+    fs::create_dir_all(&ufs_dir).unwrap();
+
+    let mut conf = ClusterConf::default();
+    conf.master.meta_dir = base_dir.join("meta").display().to_string();
+    conf.journal.journal_dir = base_dir.join("journal").display().to_string();
+    conf.worker.data_dir = vec![base_dir.join("worker").display().to_string()];
+    conf.transfer.enabled = true;
+    conf.transfer.store_type = TransferStoreType::Sqlite;
+    conf.transfer.sqlite_path = base_dir.join("transfer.db").display().to_string();
+    conf.transfer.cv_metadata_reader = TransferCvMetadataReaderType::Replica;
+    conf.transfer.metadata_replica_refresh_interval_str = "1h".to_string();
+    conf.transfer.metadata_replica_max_staleness_str = "1ms".to_string();
+    conf.transfer.hostname = "localhost".to_string();
+    conf.transfer.rpc_port = NetUtils::hold_available_port();
+    conf.transfer.web_port = NetUtils::hold_available_port();
+    conf.transfer.endpoints = vec![format!(
+        "{}:{}",
+        conf.transfer.hostname, conf.transfer.rpc_port
+    )];
+    conf.transfer.init().unwrap();
+
+    let cluster = MiniCluster::with_num(&conf, 1, 1);
+    cluster.start_cluster();
+    let rt = cluster.clone_client_rt();
+
+    rt.block_on(async {
+        let fs = CurvineFileSystem::with_rt(cluster.cluster_conf.clone(), rt.clone()).unwrap();
+        fs.mount(
+            &Path::from_str(format!("file://{}", ufs_dir.display())).unwrap(),
+            &Path::from_str("/mnt").unwrap(),
+            MountOptions::builder().build(),
+        )
+        .await
+        .unwrap();
+
+        let source = Path::from_str("/mnt/stale-replica.txt").unwrap();
+        fs.write_string(&source, "stale-replica").await.unwrap();
+
+        let mut transfer_server =
+            InProcessTransferServer::start_liveness(cluster.cluster_conf.clone());
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        let client = TransferClient::with_rt(&cluster.cluster_conf, rt.clone()).unwrap();
+        let target =
+            Path::from_str(format!("file://{}/stale-replica.txt", ufs_dir.display())).unwrap();
+        let submit = client
+            .submit(TransferCommand {
+                kind: TransferKind::Export,
+                source_path: source.clone_uri(),
+                target_path: target.clone_uri(),
+                client_request_id: test_id.clone(),
+                submitter: "stale-replica-e2e".to_string(),
+                tenant: "test".to_string(),
+                options: Default::default(),
+            })
+            .await
+            .unwrap();
+
+        assert_transfer_failed(&client, &submit.job_id).await;
+        assert!(
+            !ufs_dir.join("stale-replica.txt").exists(),
+            "stale replica export must not create target data"
+        );
+
+        transfer_server.stop();
+        let _ = fs::remove_dir_all(base_dir);
+    });
+}
+
+#[test]
+fn test_metadata_replica_entry_limit_allows_exact_limit_only() {
+    let test_id = format!(
+        "transfer-replica-limit-e2e-{}-{}",
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    );
+    let base_dir = std::env::temp_dir().join(&test_id);
+
+    let mut conf = ClusterConf::default();
+    conf.master.meta_dir = base_dir.join("meta").display().to_string();
+    conf.journal.journal_dir = base_dir.join("journal").display().to_string();
+    conf.worker.data_dir = vec![base_dir.join("worker").display().to_string()];
+    conf.transfer.enabled = true;
+    conf.transfer.init().unwrap();
+
+    let cluster = MiniCluster::with_num(&conf, 1, 1);
+    cluster.start_cluster();
+    let rt = cluster.clone_client_rt();
+
+    rt.block_on(async {
+        let fs = CurvineFileSystem::with_rt(cluster.cluster_conf.clone(), rt.clone()).unwrap();
+        let reader = MetadataReplicaReader::new(fs.clone(), 1, 1, 2, Duration::from_secs(60));
+        reader
+            .refresh()
+            .await
+            .expect("root-only namespace should fit exact entry limit");
+
+        fs.mkdir(&Path::from_str("/limit-child").unwrap(), false)
+            .await
+            .unwrap();
+        let err = reader.refresh().await.unwrap_err().to_string();
+        assert!(
+            err.contains("Metadata replica entry limit exceeded"),
+            "unexpected error: {err}"
+        );
+
+        let _ = fs::remove_dir_all(base_dir);
+    });
+}
+
+#[test]
+fn test_metadata_replica_reader_serves_retained_epoch() {
+    let test_id = format!(
+        "transfer-replica-history-e2e-{}-{}",
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    );
+    let base_dir = std::env::temp_dir().join(&test_id);
+
+    let mut conf = ClusterConf::default();
+    conf.master.meta_dir = base_dir.join("meta").display().to_string();
+    conf.journal.journal_dir = base_dir.join("journal").display().to_string();
+    conf.worker.data_dir = vec![base_dir.join("worker").display().to_string()];
+    conf.transfer.enabled = true;
+    conf.transfer.init().unwrap();
+
+    let cluster = MiniCluster::with_num(&conf, 1, 1);
+    cluster.start_cluster();
+    let rt = cluster.clone_client_rt();
+
+    rt.block_on(async {
+        let fs = CurvineFileSystem::with_rt(cluster.cluster_conf.clone(), rt.clone()).unwrap();
+        fs.mkdir(&Path::from_str("/history").unwrap(), false)
+            .await
+            .unwrap();
+        fs.write_string(&Path::from_str("/history/old.txt").unwrap(), "old")
+            .await
+            .unwrap();
+
+        let reader = MetadataReplicaReader::new(fs.clone(), 100, 1, 2, Duration::from_secs(60));
+        let old_epoch = reader.refresh().await.unwrap();
+
+        fs.write_string(&Path::from_str("/history/new.txt").unwrap(), "new")
+            .await
+            .unwrap();
+        let new_epoch = reader.refresh().await.unwrap();
+        assert_ne!(old_epoch, new_epoch);
+
+        let old_path = Path::from_str("/history/old.txt").unwrap();
+        let new_path = Path::from_str("/history/new.txt").unwrap();
+        assert!(reader
+            .get_status_at_epoch(&old_path, Some(old_epoch))
+            .await
+            .is_ok());
+        assert!(matches!(
+            reader
+                .get_status_at_epoch(&new_path, Some(old_epoch))
+                .await
+                .unwrap_err(),
+            FsError::FileNotFound(_)
+        ));
+        assert!(reader
+            .get_status_at_epoch(&new_path, Some(new_epoch))
+            .await
+            .is_ok());
+
+        fs.mkdir(&Path::from_str("/history/tree").unwrap(), false)
+            .await
+            .unwrap();
+        fs.write_string(&Path::from_str("/history/tree/child.txt").unwrap(), "child")
+            .await
+            .unwrap();
+        let tree_epoch = reader.refresh().await.unwrap();
+        let tree_child = Path::from_str("/history/tree/child.txt").unwrap();
+        assert!(reader
+            .get_status_at_epoch(&tree_child, Some(tree_epoch))
+            .await
+            .is_ok());
+
+        let moved_child = Path::from_str("/history/moved/child.txt").unwrap();
+        fs.rename(
+            &Path::from_str("/history/tree").unwrap(),
+            &Path::from_str("/history/moved").unwrap(),
+        )
+        .await
+        .unwrap();
+        let moved_epoch = reader.refresh().await.unwrap();
+        assert_ne!(tree_epoch, moved_epoch);
+        assert!(matches!(
+            reader
+                .get_status_at_epoch(&tree_child, Some(moved_epoch))
+                .await
+                .unwrap_err(),
+            FsError::FileNotFound(_)
+        ));
+        assert!(reader
+            .get_status_at_epoch(&moved_child, Some(moved_epoch))
+            .await
+            .is_ok());
+
+        fs.delete(&Path::from_str("/history/moved").unwrap(), true)
+            .await
+            .unwrap();
+        let deleted_epoch = reader.refresh().await.unwrap();
+        assert_ne!(moved_epoch, deleted_epoch);
+        assert!(matches!(
+            reader
+                .get_status_at_epoch(&moved_child, Some(deleted_epoch))
+                .await
+                .unwrap_err(),
+            FsError::FileNotFound(_)
+        ));
+
+        let evicting_reader =
+            MetadataReplicaReader::new(fs.clone(), 100, 1, 1, Duration::from_secs(60));
+        let evicted_epoch = evicting_reader.refresh().await.unwrap();
+        fs.write_string(&Path::from_str("/history/latest.txt").unwrap(), "latest")
+            .await
+            .unwrap();
+        let latest_epoch = evicting_reader.refresh().await.unwrap();
+        assert_ne!(evicted_epoch, latest_epoch);
+        let err = evicting_reader
+            .get_status_at_epoch(&old_path, Some(evicted_epoch))
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("is no longer available"),
+            "unexpected error: {err}"
+        );
+
+        let _ = fs::remove_dir_all(base_dir);
+    });
+}
+
+#[test]
+fn test_metadata_replica_falls_back_when_delta_window_is_lost() {
+    let test_id = format!(
+        "transfer-replica-delta-fallback-e2e-{}-{}",
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    );
+    let base_dir = std::env::temp_dir().join(&test_id);
+
+    let mut conf = ClusterConf::default();
+    conf.master.meta_dir = base_dir.join("meta").display().to_string();
+    conf.journal.journal_dir = base_dir.join("journal").display().to_string();
+    conf.journal.metadata_delta_log_capacity = 1;
+    conf.worker.data_dir = vec![base_dir.join("worker").display().to_string()];
+    conf.transfer.enabled = true;
+    conf.transfer.init().unwrap();
+
+    let cluster = MiniCluster::with_num(&conf, 1, 1);
+    cluster.start_cluster();
+    let rt = cluster.clone_client_rt();
+
+    rt.block_on(async {
+        let fs = CurvineFileSystem::with_rt(cluster.cluster_conf.clone(), rt.clone()).unwrap();
+        let reader = MetadataReplicaReader::new(fs.clone(), 100, 1, 2, Duration::from_secs(60));
+        let base_epoch = reader.refresh().await.unwrap();
+
+        let evicted_path = Path::from_str("/delta-evicted").unwrap();
+        let retained_path = Path::from_str("/delta-retained").unwrap();
+        fs.mkdir(&evicted_path, false).await.unwrap();
+        fs.mkdir(&retained_path, false).await.unwrap();
+
+        let refreshed_epoch = reader.refresh().await.unwrap();
+        assert_ne!(base_epoch, refreshed_epoch);
+        assert!(reader.get_status(&evicted_path).await.is_ok());
+        assert!(reader.get_status(&retained_path).await.is_ok());
+
+        let _ = fs::remove_dir_all(base_dir);
+    });
+}
+
+#[test]
+fn test_metadata_delta_requires_full_snapshot_when_target_epoch_advances_between_pages() {
+    let test_id = format!(
+        "transfer-replica-delta-epoch-e2e-{}-{}",
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    );
+    let base_dir = std::env::temp_dir().join(&test_id);
+
+    let mut conf = ClusterConf::default();
+    conf.master.meta_dir = base_dir.join("meta").display().to_string();
+    conf.journal.journal_dir = base_dir.join("journal").display().to_string();
+    conf.worker.data_dir = vec![base_dir.join("worker").display().to_string()];
+    conf.transfer.enabled = true;
+    conf.transfer.init().unwrap();
+
+    let cluster = MiniCluster::with_num(&conf, 1, 1);
+    cluster.start_cluster();
+    let rt = cluster.clone_client_rt();
+
+    rt.block_on(async {
+        let fs = CurvineFileSystem::with_rt(cluster.cluster_conf.clone(), rt.clone()).unwrap();
+        let base_epoch = fs
+            .get_cv_metadata_snapshot_page(None, Some(100))
+            .await
+            .unwrap()
+            .epoch;
+
+        fs.mkdir(&Path::from_str("/delta").unwrap(), false)
+            .await
+            .unwrap();
+        fs.mkdir(&Path::from_str("/delta/child").unwrap(), false)
+            .await
+            .unwrap();
+
+        let first = fs
+            .get_cv_metadata_delta_page(base_epoch, None, None, Some(1))
+            .await
+            .unwrap();
+        assert_eq!(first.entries.len(), 1);
+        let page_token = first
+            .next_page_token
+            .clone()
+            .expect("delta should span more than one page");
+
+        fs.delete(&Path::from_str("/delta/child").unwrap(), true)
+            .await
+            .unwrap();
+
+        let next = fs
+            .get_cv_metadata_delta_page(base_epoch, Some(first.to_epoch), Some(page_token), Some(1))
+            .await
+            .unwrap();
+        assert!(
+            next.full_snapshot_required,
+            "a fixed-epoch delta page must not be built from newer metadata"
+        );
+        assert!(next.entries.is_empty());
+
+        let _ = fs::remove_dir_all(base_dir);
+    });
+}
+
+#[test]
+fn test_cv_metadata_snapshot_page_returns_statuses_and_blocks() {
+    let test_id = format!(
+        "transfer-replica-page-e2e-{}-{}",
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    );
+    let base_dir = std::env::temp_dir().join(&test_id);
+
+    let mut conf = ClusterConf::default();
+    conf.master.meta_dir = base_dir.join("meta").display().to_string();
+    conf.journal.journal_dir = base_dir.join("journal").display().to_string();
+    conf.worker.data_dir = vec![base_dir.join("worker").display().to_string()];
+    conf.transfer.enabled = true;
+    conf.transfer.init().unwrap();
+
+    let cluster = MiniCluster::with_num(&conf, 1, 1);
+    cluster.start_cluster();
+    let rt = cluster.clone_client_rt();
+
+    rt.block_on(async {
+        let fs = CurvineFileSystem::with_rt(cluster.cluster_conf.clone(), rt.clone()).unwrap();
+        fs.mkdir(&Path::from_str("/snapshot").unwrap(), false)
+            .await
+            .unwrap();
+        fs.mkdir(&Path::from_str("/snapshot/dir").unwrap(), false)
+            .await
+            .unwrap();
+        fs.write_string(&Path::from_str("/snapshot/dir/file.txt").unwrap(), "page")
+            .await
+            .unwrap();
+
+        let first = fs
+            .get_cv_metadata_snapshot_page(None, Some(2))
+            .await
+            .unwrap();
+        assert_eq!(first.entries.len(), 2);
+        let token = first
+            .next_page_token
+            .clone()
+            .expect("first page should have a next token");
+        let second = fs
+            .get_cv_metadata_snapshot_page(Some(token), Some(2))
+            .await
+            .unwrap();
+        assert_eq!(
+            first.epoch, second.epoch,
+            "metadata snapshot pages must share one epoch"
+        );
+
+        let mut entries = first.entries;
+        entries.extend(second.entries);
+        let statuses = entries
+            .iter()
+            .map(|entry| ProtoUtils::file_status_from_pb(entry.status.clone()))
+            .collect::<Vec<_>>();
+        let paths = statuses
+            .iter()
+            .map(|status| status.path.as_str())
+            .collect::<HashSet<_>>();
+        assert!(paths.contains("/"));
+        assert!(paths.contains("/snapshot"));
+        assert!(paths.contains("/snapshot/dir"));
+        assert!(paths.contains("/snapshot/dir/file.txt"));
+
+        let file_entry = entries
+            .iter()
+            .find(|entry| entry.status.path == "/snapshot/dir/file.txt")
+            .expect("snapshot page should include file entry");
+        let blocks = file_entry
+            .blocks
+            .clone()
+            .map(ProtoUtils::file_blocks_from_pb)
+            .expect("file entry should carry block locations");
+        assert_eq!(blocks.status.path, "/snapshot/dir/file.txt");
+        assert!(!blocks.block_locs.is_empty());
+
+        let _ = fs::remove_dir_all(base_dir);
+    });
+}
+
+fn mysql_transfer_store_url(name: &str) -> Option<String> {
+    mysql_transfer_store_url_with_db(name).map(|(store_url, _, _)| store_url)
+}
+
+struct MysqlTcpProxy {
+    listen_addr: SocketAddr,
+    available: Arc<AtomicBool>,
+    running: Arc<AtomicBool>,
+    streams: Arc<Mutex<Vec<TcpStream>>>,
+}
+
+impl MysqlTcpProxy {
+    fn start(target_addr: SocketAddr) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let listen_addr = listener.local_addr().unwrap();
+        let available = Arc::new(AtomicBool::new(true));
+        let running = Arc::new(AtomicBool::new(true));
+        let streams = Arc::new(Mutex::new(Vec::new()));
+        let accept_available = available.clone();
+        let accept_running = running.clone();
+        let accept_streams = streams.clone();
+        thread::spawn(move || {
+            while accept_running.load(Ordering::SeqCst) {
+                match listener.accept() {
+                    Ok((client, _)) if accept_available.load(Ordering::SeqCst) => {
+                        let Ok(server) = TcpStream::connect(target_addr) else {
+                            let _ = client.shutdown(Shutdown::Both);
+                            continue;
+                        };
+                        if let Ok(mut guard) = accept_streams.lock() {
+                            if let Ok(stream) = client.try_clone() {
+                                guard.push(stream);
+                            }
+                            if let Ok(stream) = server.try_clone() {
+                                guard.push(stream);
+                            }
+                        }
+                        proxy_bidirectional(client, server);
+                    }
+                    Ok((client, _)) => {
+                        let _ = client.shutdown(Shutdown::Both);
+                    }
+                    Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+        Self {
+            listen_addr,
+            available,
+            running,
+            streams,
+        }
+    }
+
+    fn set_available(&self, available: bool) {
+        self.available.store(available, Ordering::SeqCst);
+        if !available {
+            if let Ok(mut streams) = self.streams.lock() {
+                for stream in streams.iter() {
+                    let _ = stream.shutdown(Shutdown::Both);
+                }
+                streams.clear();
+            }
+        }
+    }
+}
+
+impl Drop for MysqlTcpProxy {
+    fn drop(&mut self) {
+        self.running.store(false, Ordering::SeqCst);
+        self.set_available(false);
+        let _ = TcpStream::connect(self.listen_addr);
+    }
+}
+
+fn proxy_bidirectional(client: TcpStream, server: TcpStream) {
+    let mut client_reader = client.try_clone().unwrap();
+    let mut client_writer = client;
+    let mut server_reader = server.try_clone().unwrap();
+    let mut server_writer = server;
+    thread::spawn(move || {
+        let _ = std::io::copy(&mut client_reader, &mut server_writer);
+        let _ = server_writer.shutdown(Shutdown::Write);
+    });
+    thread::spawn(move || {
+        let _ = std::io::copy(&mut server_reader, &mut client_writer);
+        let _ = client_writer.shutdown(Shutdown::Write);
+    });
+}
+
+fn mysql_transfer_store_url_with_proxy(name: &str) -> Option<(String, MysqlTcpProxy)> {
+    let (store_url, _, _) = mysql_transfer_store_url_with_db(name)?;
+    let target_addr = mysql_url_host_port(&store_url)?
+        .parse::<SocketAddr>()
+        .ok()?;
+    let proxy = MysqlTcpProxy::start(target_addr);
+    let proxied_url = store_url.replace(
+        &target_addr.to_string(),
+        &format!("127.0.0.1:{}", proxy.listen_addr.port()),
+    );
+    Some((proxied_url, proxy))
+}
+
+fn mysql_url_host_port(url: &str) -> Option<String> {
+    let after_at = url.split_once('@')?.1;
+    let host_port = after_at
+        .split(['/', '?'])
+        .next()
+        .filter(|value| value.contains(':'))?;
+    Some(host_port.to_string())
+}
+
+fn mysql_transfer_store_url_with_db(name: &str) -> Option<(String, String, String)> {
+    let base_url = std::env::var("CURVINE_TRANSFER_MYSQL_URL").ok()?;
+    let safe_name = name.replace('-', "_");
+    let safe_name = &safe_name[..safe_name.len().min(20)];
+    let db_name = format!(
+        "cv_transfer_{}_{}_{}",
+        safe_name,
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    );
+    let pool = mysql::Pool::new(limited_mysql_pool_url(&base_url).as_str()).unwrap();
+    let mut conn = pool.get_conn().unwrap();
+    conn.query_drop(format!("create database `{}`", db_name))
+        .unwrap();
+    let separator = if base_url.contains('?') { '&' } else { '?' };
+    let store_url = format!(
+        "{}/{}{}pool_min=0&pool_max=1",
+        base_url.trim_end_matches('/'),
+        db_name,
+        separator
+    );
+    Some((store_url, base_url, db_name))
+}
+
+fn drop_mysql_database(base_url: &str, db_name: &str) {
+    let pool = mysql::Pool::new(limited_mysql_pool_url(base_url).as_str()).unwrap();
+    let mut conn = pool.get_conn().unwrap();
+    conn.query_drop(format!("drop database if exists `{}`", db_name))
+        .unwrap();
+}
+
+fn create_mysql_database(base_url: &str, db_name: &str) {
+    let pool = mysql::Pool::new(limited_mysql_pool_url(base_url).as_str()).unwrap();
+    let mut conn = pool.get_conn().unwrap();
+    conn.query_drop(format!("create database `{}`", db_name))
+        .unwrap();
+}
+
+fn limited_mysql_pool_url(url: &str) -> String {
+    let separator = if url.contains('?') { '&' } else { '?' };
+    format!("{url}{separator}pool_min=0&pool_max=1")
+}
+
+fn force_mysql_task_state(store_url: &str, task: &TransferTaskRecord) {
+    let pool = mysql::Pool::new(store_url).unwrap();
+    let mut conn = pool.get_conn().unwrap();
+    let record_json = serde_json::to_string(task).unwrap();
+    conn.exec_drop(
+        "update transfer_tasks
+         set state = :state, attempt_id = :attempt_id, worker_id = :worker_id,
+             worker_session_id = :worker_session_id, stale_deadline_at = :stale_deadline_at,
+             record_json = :record_json, updated_at = :updated_at
+         where job_id = :job_id and run_id = :run_id and task_id = :task_id",
+        params! {
+            "state" => task.state as i32,
+            "attempt_id" => task.attempt_id,
+            "worker_id" => task.worker_id,
+            "worker_session_id" => &task.worker_session_id,
+            "stale_deadline_at" => task.stale_deadline_at,
+            "record_json" => record_json,
+            "updated_at" => task.updated_at,
+            "job_id" => &task.job_id,
+            "run_id" => task.run_id,
+            "task_id" => &task.task_id,
+        },
+    )
+    .unwrap();
+}
+
+async fn wait_for_mysql_running_task_after_local_commit(
+    fs: &CurvineFileSystem,
+    store: &MysqlTransferStore,
+    job_id: &str,
+    run_id: u64,
+    target: &Path,
+    expected_content: &str,
+    timeout: Duration,
+) -> Option<TransferTaskRecord> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if fs.read_string(target).await.ok().as_deref() == Some(expected_content) {
+            let tasks = store.list_transfer_tasks(job_id, run_id).unwrap();
+            if let Some(task) = tasks
+                .into_iter()
+                .find(|task| task.state == TransferTaskState::Running)
+            {
+                return Some(task);
+            }
+        }
+        if Instant::now() >= deadline {
+            return None;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+async fn wait_master_and_create_fs(cluster: &MiniCluster) -> CurvineFileSystem {
+    let deadline = std::time::Instant::now() + Duration::from_secs(60);
+    let fs = cluster.new_fs();
+    while std::time::Instant::now() < deadline {
+        if fs.get_master_info().await.is_ok() {
+            return fs;
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    panic!("master did not become ready within 60 seconds");
+}
+
+struct RegisteredWorker {
+    worker_id: u32,
+    worker_session_id: String,
+}
+
+async fn wait_for_registered_worker_session(
+    fs: &CurvineFileSystem,
+    previous_session_id: Option<&str>,
+    timeout: Duration,
+    log_path: &std::path::Path,
+    child: &mut ServiceChild,
+) -> RegisteredWorker {
+    let deadline = std::time::Instant::now() + timeout;
+    while std::time::Instant::now() < deadline {
+        if let Ok(info) = fs.get_master_info().await {
+            if let Some(worker) = info.live_workers.into_iter().find(|worker| {
+                !worker.worker_session_id.is_empty()
+                    && previous_session_id
+                        .map(|previous| worker.worker_session_id != previous)
+                        .unwrap_or(true)
+            }) {
+                return RegisteredWorker {
+                    worker_id: worker.worker_id(),
+                    worker_session_id: worker.worker_session_id,
+                };
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    child.stop();
+    panic!(
+        "worker did not register with expected session; child log: {}",
+        fs::read_to_string(log_path).unwrap_or_default()
+    );
+}
+
+async fn wait_worker_task_visible(
+    fs: &CurvineFileSystem,
+    conf: &ClusterConf,
+    rt: Arc<orpc::runtime::Runtime>,
+    task: &TransferTaskRecord,
+) -> bool {
+    let factory = UfsFactory::with_rt(&conf.client, rt);
+    for _ in 0..120 {
+        if let Ok(info) = fs.get_master_info().await {
+            if let Some(worker) = info
+                .live_workers
+                .into_iter()
+                .find(|worker| worker.worker_id() == task.worker_id)
+            {
+                if let Ok(client) = factory.get_worker_client(&worker.address).await {
+                    if let Ok(response) = client
+                        .query_transfer_task(
+                            &task.job_id,
+                            task.run_id,
+                            &task.task_id,
+                            task.attempt_id,
+                            &task.worker_session_id,
+                        )
+                        .await
+                    {
+                        if response.found {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    false
+}
+
+async fn assert_transfer_failed(
+    client: &TransferClient,
+    job_id: &str,
+) -> GetTransferStatusResponse {
+    let mut final_status = None;
+    for _ in 0..80 {
+        let status = client.status_page(job_id, Some(10), None).await.unwrap();
+        let state = status.state;
+        final_status = Some(status);
+        if state == TransferStateProto::TransferCompleted as i32
+            || state == TransferStateProto::TransferFailed as i32
+        {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+    let final_status = final_status.expect("transfer status should be available");
+    assert_eq!(
+        final_status.state,
+        TransferStateProto::TransferFailed as i32
+    );
+    final_status
+}
+
+async fn wait_transfer_state(
+    client: &TransferClient,
+    job_id: &str,
+    expected: TransferStateProto,
+    timeout: Duration,
+) -> GetTransferStatusResponse {
+    let deadline = std::time::Instant::now() + timeout;
+    let mut last = None;
+    while std::time::Instant::now() < deadline {
+        let status = client.status_page(job_id, Some(100), None).await.unwrap();
+        if status.state == expected as i32 {
+            return status;
+        }
+        last = Some(status);
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+    panic!(
+        "transfer {job_id} did not reach {:?} within {:?}; last status: {:?}",
+        expected, timeout, last
+    );
+}
+
+async fn wait_transfer_task_state(
+    client: &TransferClient,
+    job_id: &str,
+    expected: TransferTaskStateProto,
+    timeout: Duration,
+) -> GetTransferStatusResponse {
+    let deadline = std::time::Instant::now() + timeout;
+    let mut last = None;
+    while std::time::Instant::now() < deadline {
+        let status = client.status_page(job_id, Some(100), None).await.unwrap();
+        if status
+            .tasks
+            .iter()
+            .any(|task| task.state == expected as i32)
+        {
+            return status;
+        }
+        last = Some(status);
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    panic!(
+        "transfer {job_id} did not have task state {:?} within {:?}; last status: {:?}",
+        expected, timeout, last
+    );
+}
+
+fn count_jobs_with_owner(store: &MysqlTransferStore, job_ids: &[String], owner: &str) -> usize {
+    job_ids
+        .iter()
+        .filter(|job_id| {
+            store
+                .get_transfer(job_id)
+                .unwrap()
+                .map(|job| job.owner == owner)
+                .unwrap_or(false)
+        })
+        .count()
+}
+
+fn transfer_state_summary(store: &MysqlTransferStore, job_ids: &[String]) -> String {
+    let mut states = std::collections::BTreeMap::new();
+    for job_id in job_ids {
+        let state = store
+            .get_transfer(job_id)
+            .unwrap()
+            .map(|job| format!("{:?}", job.state))
+            .unwrap_or_else(|| "Missing".to_string());
+        *states.entry(state).or_insert(0usize) += 1;
+    }
+    states
+        .into_iter()
+        .map(|(state, count)| format!("{state}={count}"))
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn spawn_transfer_child_until_healthy(
+    binary: &str,
+    mut conf: ClusterConf,
+    base_dir: &std::path::Path,
+    name: &str,
+) -> (ClusterConf, TransferChild) {
+    for attempt in 0..5 {
+        if attempt > 0 {
+            conf.transfer.rpc_port = NetUtils::get_available_port();
+            conf.transfer.web_port = NetUtils::get_available_port();
+            conf.transfer.endpoints = vec![format!(
+                "{}:{}",
+                conf.transfer.hostname, conf.transfer.rpc_port
+            )];
+            conf.transfer.init().unwrap();
+        }
+        let conf_path = base_dir.join(format!("{name}-{attempt}.toml"));
+        fs::write(&conf_path, toml::to_string(&conf).unwrap()).unwrap();
+        let child_log_path = base_dir.join(format!("{name}-{attempt}.log"));
+        let mut child = TransferChild::spawn(binary, &conf_path, &child_log_path);
+        if wait_http_path(conf.transfer.web_port, "/readyz", Duration::from_secs(90)) {
+            return (conf, child);
+        }
+        child.stop();
+        let child_log = fs::read_to_string(&child_log_path).unwrap_or_default();
+        if attempt == 4 {
+            panic!("external transfer process did not become healthy; child log: {child_log}");
+        }
+        assert!(
+            child_log.contains("Address already in use"),
+            "external transfer process failed for non-port-conflict reason; child log: {child_log}"
+        );
+    }
+    unreachable!("transfer child health retry loop must return or panic")
+}
+
+struct TransferChild {
+    child: Child,
+}
+
+impl TransferChild {
+    fn spawn(binary: &str, conf_path: &std::path::Path, log_path: &std::path::Path) -> Self {
+        let stdout = fs::File::create(log_path)
+            .unwrap_or_else(|err| panic!("failed to create transfer child log: {err}"));
+        let stderr = stdout
+            .try_clone()
+            .unwrap_or_else(|err| panic!("failed to clone transfer child log: {err}"));
+        let child = Command::new(binary)
+            .arg("--service")
+            .arg("transfer")
+            .arg("--conf")
+            .arg(conf_path)
+            .stdout(Stdio::from(stdout))
+            .stderr(Stdio::from(stderr))
+            .spawn()
+            .unwrap_or_else(|err| panic!("failed to spawn external transfer process: {err}"));
+        Self { child }
+    }
+
+    fn stop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+impl Drop for TransferChild {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+struct InProcessTransferServer {
+    shutdown: Option<TransferServerShutdown>,
+    handle: Option<thread::JoinHandle<()>>,
+}
+
+impl InProcessTransferServer {
+    fn start(conf: ClusterConf) -> Self {
+        Self::start_with_probe(conf, "/readyz")
+    }
+
+    fn start_liveness(conf: ClusterConf) -> Self {
+        Self::start_with_probe(conf, "/healthz")
+    }
+
+    fn start_with_probe(conf: ClusterConf, probe_path: &'static str) -> Self {
+        let web_port = conf.transfer.web_port;
+        let transfer = TransferServer::with_conf(conf).unwrap();
+        let shutdown = transfer.shutdown_handle();
+        let handle = thread::spawn(move || {
+            if let Err(err) = transfer.block_on_start() {
+                panic!("in-process transfer server failed: {err}");
+            }
+        });
+        let mut server = Self {
+            shutdown: Some(shutdown),
+            handle: Some(handle),
+        };
+        let deadline = std::time::Instant::now() + Duration::from_secs(30);
+        while std::time::Instant::now() < deadline {
+            if wait_http_path(web_port, probe_path, Duration::from_millis(200)) {
+                return server;
+            }
+            if server
+                .handle
+                .as_ref()
+                .map(|handle| handle.is_finished())
+                .unwrap_or(false)
+            {
+                server.stop();
+                panic!("in-process transfer server exited before it became healthy");
+            }
+        }
+        server.stop();
+        panic!("in-process transfer server did not pass {probe_path} within 30 seconds");
+    }
+
+    fn stop(&mut self) {
+        if let Some(shutdown) = self.shutdown.take() {
+            shutdown.shutdown();
+        }
+        if let Some(handle) = self.handle.take() {
+            handle
+                .join()
+                .unwrap_or_else(|err| panic!("in-process transfer server panicked: {err:?}"));
+        }
+    }
+}
+
+impl Drop for InProcessTransferServer {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+struct ServiceChild {
+    child: Child,
+}
+
+impl ServiceChild {
+    fn spawn(
+        binary: &str,
+        service: &str,
+        conf_path: &std::path::Path,
+        log_path: &std::path::Path,
+    ) -> Self {
+        let stdout = fs::File::create(log_path)
+            .unwrap_or_else(|err| panic!("failed to create {service} child log: {err}"));
+        let stderr = stdout
+            .try_clone()
+            .unwrap_or_else(|err| panic!("failed to clone {service} child log: {err}"));
+        let child = Command::new(binary)
+            .arg("--service")
+            .arg(service)
+            .arg("--conf")
+            .arg(conf_path)
+            .stdout(Stdio::from(stdout))
+            .stderr(Stdio::from(stderr))
+            .spawn()
+            .unwrap_or_else(|err| panic!("failed to spawn external {service} process: {err}"));
+        Self { child }
+    }
+
+    fn stop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+impl Drop for ServiceChild {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+fn curvine_server_binary() -> Option<String> {
+    if let Some(path) = option_env!("CARGO_BIN_EXE_curvine-server") {
+        return Some(path.to_string());
+    }
+    let current = std::env::current_exe().ok()?;
+    let debug_dir = current.parent()?.parent()?;
+    let candidate: PathBuf = debug_dir.join("curvine-server");
+    candidate.exists().then(|| candidate.display().to_string())
+}
+
+fn wait_http_path(port: u16, path: &str, timeout: Duration) -> bool {
+    let deadline = std::time::Instant::now() + timeout;
+    while std::time::Instant::now() < deadline {
+        if let Ok(response) = try_read_http_path(port, path) {
+            if response.contains("200 OK") {
+                return true;
+            }
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    false
+}
+
+fn read_http_metrics(port: u16) -> String {
+    read_http_path(port, "/metrics")
+}
+
+fn read_http_path(port: u16, path: &str) -> String {
+    try_read_http_path(port, path).unwrap()
+}
+
+fn try_read_http_path(port: u16, path: &str) -> std::io::Result<String> {
+    let mut stream = TcpStream::connect(("127.0.0.1", port))?;
+    stream.set_read_timeout(Some(Duration::from_secs(5)))?;
+    let request = format!("GET {path} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+    stream.write_all(request.as_bytes())?;
+    let mut response = String::new();
+    stream.read_to_string(&mut response)?;
+    Ok(response)
+}

--- a/curvine-server/tests/transfer/memory_store_test.rs
+++ b/curvine-server/tests/transfer/memory_store_test.rs
@@ -1,0 +1,1400 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use curvine_common::conf::{JournalConf, TransferConf, TransferCvMetadataReaderType};
+use curvine_common::error::ErrorKind;
+use curvine_common::proto::{
+    SubmitTransferRequest, TransferKindProto, TransferProgressProto, TransferTaskReportRequest,
+    TransferTaskStateProto,
+};
+use curvine_common::state::{
+    TaskAttemptStart, TransferCommand, TransferJobRecord, TransferKind, TransferListFilter,
+    TransferProgress, TransferState, TransferStateUpdate, TransferTaskRecord, TransferTaskReport,
+    TransferTaskState,
+};
+use curvine_server::transfer::{
+    MemoryTransferStore, TransferPlannedTasks, TransferService, TransferStore,
+};
+use std::sync::Arc;
+use std::time::Duration;
+
+fn job(job_id: &str, request_id: &str) -> TransferJobRecord {
+    TransferJobRecord {
+        job_key: "Load:s3://bucket/a:/a".to_string(),
+        job_id: job_id.to_string(),
+        run_id: 1,
+        kind: TransferKind::Load,
+        source_path: "s3://bucket/a".to_string(),
+        target_path: "/a".to_string(),
+        command_json: "{}".to_string(),
+        mount_snapshot_json: "{}".to_string(),
+        secret_ref_json: "{}".to_string(),
+        cluster_snapshot_version: 1,
+        cv_metadata_epoch: None,
+        state: TransferState::Pending,
+        owner: String::new(),
+        lease_epoch: 0,
+        lease_expire_at: 0,
+        cancel_requested: false,
+        summary: TransferProgress::default(),
+        client_request_id: request_id.to_string(),
+        submitter: "sr".to_string(),
+        tenant: "default".to_string(),
+        created_at: 1,
+        updated_at: 1,
+    }
+}
+
+fn task(job_id: &str) -> TransferTaskRecord {
+    TransferTaskRecord {
+        job_id: job_id.to_string(),
+        run_id: 1,
+        task_id: "task-1".to_string(),
+        attempt_id: 0,
+        source_path: "s3://bucket/a".to_string(),
+        target_path: "/a".to_string(),
+        worker_id: 0,
+        worker_session_id: String::new(),
+        source_read_plan_json: String::new(),
+        report_target_json: String::new(),
+        state: TransferTaskState::Pending,
+        progress: TransferProgress::default(),
+        retry_count: 0,
+        attempt_started_at: 0,
+        last_report_at: 0,
+        stale_deadline_at: 0,
+        updated_at: 0,
+    }
+}
+
+fn submit_request(request_id: &str, source: &str, target: &str) -> SubmitTransferRequest {
+    SubmitTransferRequest {
+        kind: TransferKindProto::TransferLoad as i32,
+        source_path: source.to_string(),
+        target_path: target.to_string(),
+        client_request_id: request_id.to_string(),
+        submitter: "sr".to_string(),
+        tenant: "default".to_string(),
+        command: Vec::new(),
+        protocol_version: Some(1),
+    }
+}
+
+fn submit_request_with_kind(
+    request_id: &str,
+    kind: TransferKindProto,
+    source: &str,
+    target: &str,
+) -> SubmitTransferRequest {
+    SubmitTransferRequest {
+        kind: kind as i32,
+        source_path: source.to_string(),
+        target_path: target.to_string(),
+        client_request_id: request_id.to_string(),
+        submitter: "sr".to_string(),
+        tenant: "default".to_string(),
+        command: Vec::new(),
+        protocol_version: Some(1),
+    }
+}
+
+#[test]
+fn retry_transfer_creates_a_new_job_with_the_original_command() {
+    let store = Arc::new(MemoryTransferStore::new());
+    let service = TransferService::new(store.clone());
+    let mut command = TransferCommand {
+        kind: TransferKind::Load,
+        source_path: "s3://bucket/retry-source".to_string(),
+        target_path: "/retry-target".to_string(),
+        client_request_id: "retry-original".to_string(),
+        submitter: "operator".to_string(),
+        tenant: "tenant-a".to_string(),
+        options: Default::default(),
+    };
+    command.set_overwrite(false);
+    let submitted = service
+        .submit_transfer(SubmitTransferRequest {
+            kind: TransferKindProto::TransferLoad as i32,
+            source_path: command.source_path.clone(),
+            target_path: command.target_path.clone(),
+            client_request_id: command.client_request_id.clone(),
+            submitter: command.submitter.clone(),
+            tenant: command.tenant.clone(),
+            command: serde_json::to_vec(&command).unwrap(),
+            protocol_version: Some(1),
+        })
+        .unwrap();
+    let lease = store
+        .acquire_runnable_transfer("retry-test", 1_000, 10, 100)
+        .unwrap()
+        .unwrap();
+    assert!(store
+        .update_transfer_state(TransferStateUpdate {
+            job_id: submitted.job_id.clone(),
+            run_id: submitted.run_id,
+            owner: lease.owner,
+            lease_epoch: lease.lease_epoch,
+            from_states: vec![TransferState::Planning],
+            to_state: TransferState::Failed,
+            message: "source object not found".to_string(),
+            now_ms: 11,
+        })
+        .unwrap());
+
+    let retried = service.retry_transfer(&submitted.job_id).unwrap();
+    let retried_command: TransferCommand = serde_json::from_str(&retried.command_json).unwrap();
+
+    assert_ne!(retried.job_id, submitted.job_id);
+    assert_ne!(retried.client_request_id, submitted.client_request_id);
+    assert_eq!(retried.state, TransferState::Pending);
+    assert_eq!(retried_command.kind, command.kind);
+    assert_eq!(retried_command.source_path, command.source_path);
+    assert_eq!(retried_command.target_path, command.target_path);
+    assert_eq!(retried_command.submitter, command.submitter);
+    assert_eq!(retried_command.tenant, command.tenant);
+    assert_eq!(retried_command.options, command.options);
+}
+
+#[test]
+fn transfer_conf_rejects_zero_scheduler_limits() {
+    let mut conf = TransferConf {
+        enabled: true,
+        ufs_max_concurrency_per_endpoint: 0,
+        ..Default::default()
+    };
+    let err = conf.init().unwrap_err().to_string();
+    assert!(
+        err.contains("transfer.ufs_max_concurrency_per_endpoint must be greater than 0"),
+        "unexpected error: {err}"
+    );
+
+    let mut conf = TransferConf {
+        enabled: true,
+        metadata_replica_refresh_interval_str: "0ms".to_string(),
+        ..Default::default()
+    };
+    let err = conf.init().unwrap_err().to_string();
+    assert!(
+        err.contains("transfer.metadata_replica_refresh_interval must be greater than 0"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn transfer_conf_derives_recovery_timeouts_from_lease() {
+    let mut conf = TransferConf {
+        enabled: true,
+        lease_timeout_str: "6s".to_string(),
+        ..Default::default()
+    };
+    conf.init().unwrap();
+    assert_eq!(conf.lease_timeout, Duration::from_secs(6));
+    assert_eq!(conf.task_stale_timeout, Duration::from_secs(3));
+    assert_eq!(conf.task_report_interval, Duration::from_millis(500));
+
+    let mut conf = TransferConf {
+        enabled: true,
+        lease_timeout_str: "0ms".to_string(),
+        ..Default::default()
+    };
+    let err = conf.init().unwrap_err().to_string();
+    assert!(
+        err.contains("transfer.lease_timeout must be greater than 0"),
+        "unexpected error: {err}"
+    );
+
+    let mut conf = TransferConf {
+        enabled: true,
+        cluster_snapshot_max_staleness_str: "0ms".to_string(),
+        ..Default::default()
+    };
+    let err = conf.init().unwrap_err().to_string();
+    assert!(
+        err.contains("transfer.cluster_snapshot_max_staleness must be greater than 0"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn transfer_conf_rejects_multiple_endpoints_with_local_sqlite() {
+    let mut conf = TransferConf {
+        enabled: true,
+        endpoints: vec!["transfer-a:9010".to_string(), "transfer-b:9010".to_string()],
+        ..Default::default()
+    };
+
+    let err = conf.init().unwrap_err().to_string();
+
+    assert!(
+        err.contains("multiple transfer.endpoints require transfer.store_url=mysql://"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn submit_transfer_rejects_command_identity_mismatch() {
+    let service = TransferService::new(Arc::new(MemoryTransferStore::new()));
+    let command = TransferCommand {
+        kind: TransferKind::Load,
+        source_path: "s3://bucket/source".to_string(),
+        target_path: "/target".to_string(),
+        client_request_id: "payload-request".to_string(),
+        submitter: "payload-submitter".to_string(),
+        tenant: "payload-tenant".to_string(),
+        options: Default::default(),
+    };
+
+    let err = service
+        .submit_transfer(SubmitTransferRequest {
+            kind: TransferKindProto::TransferLoad as i32,
+            source_path: command.source_path.clone(),
+            target_path: command.target_path.clone(),
+            client_request_id: "header-request".to_string(),
+            submitter: command.submitter.clone(),
+            tenant: command.tenant.clone(),
+            command: serde_json::to_vec(&command).unwrap(),
+            protocol_version: Some(1),
+        })
+        .unwrap_err();
+
+    assert!(err.to_string().contains("client request id"));
+}
+
+#[test]
+fn expired_owner_cannot_advance_transfer_state() {
+    let store = MemoryTransferStore::new();
+    store
+        .create_or_get_by_request_id(job("job-1", "req-1"))
+        .unwrap();
+    let lease = store
+        .acquire_runnable_transfer("owner-a", 100, 10, 100)
+        .unwrap()
+        .unwrap();
+
+    assert!(!store
+        .update_transfer_state(TransferStateUpdate {
+            job_id: lease.job_id,
+            run_id: lease.run_id,
+            owner: lease.owner,
+            lease_epoch: lease.lease_epoch,
+            from_states: vec![TransferState::Planning],
+            to_state: TransferState::Dispatching,
+            message: "stale planning result".to_string(),
+            now_ms: 110,
+        })
+        .unwrap());
+}
+
+#[test]
+fn expired_owner_cannot_persist_planned_tasks() {
+    let store = MemoryTransferStore::new();
+    store
+        .create_or_get_by_request_id(job("job-1", "req-1"))
+        .unwrap();
+    let lease = store
+        .acquire_runnable_transfer("owner-a", 100, 10, 100)
+        .unwrap()
+        .unwrap();
+
+    assert!(!store
+        .persist_planned_tasks(TransferPlannedTasks {
+            job_id: lease.job_id.clone(),
+            run_id: lease.run_id,
+            owner: lease.owner,
+            lease_epoch: lease.lease_epoch,
+            tasks: vec![task("job-1")],
+            message: "planned total_size=0".to_string(),
+            now_ms: 110,
+        })
+        .unwrap());
+    assert!(store.list_transfer_tasks("job-1", 1).unwrap().is_empty());
+    assert_eq!(
+        store.get_transfer("job-1").unwrap().unwrap().state,
+        TransferState::Planning
+    );
+}
+
+#[test]
+fn task_report_updates_progress_without_terminalizing_transfer() {
+    let store = MemoryTransferStore::new();
+    store
+        .create_or_get_by_request_id(job("job-1", "req-1"))
+        .unwrap();
+    store.insert_tasks(vec![task("job-1")]).unwrap();
+    let lease = store
+        .acquire_runnable_transfer("owner-a", 100, 10, 100)
+        .unwrap()
+        .unwrap();
+    assert!(store
+        .start_task_attempt(TaskAttemptStart {
+            job_id: "job-1".to_string(),
+            run_id: 1,
+            owner: lease.owner,
+            lease_epoch: lease.lease_epoch,
+            task_id: "task-1".to_string(),
+            attempt_id: 1,
+            worker_id: 1,
+            worker_session_id: "worker-a".to_string(),
+            report_target_json: "[]".to_string(),
+            now_ms: 20,
+            stale_deadline_at: 70,
+        })
+        .unwrap());
+
+    assert!(store
+        .update_task_report(TransferTaskReport {
+            job_id: "job-1".to_string(),
+            run_id: 1,
+            task_id: "task-1".to_string(),
+            attempt_id: 1,
+            worker_id: 1,
+            worker_session_id: "worker-a".to_string(),
+            state: TransferTaskState::Completed,
+            progress: TransferProgress {
+                loaded_size: 10,
+                total_size: 10,
+                update_time: 30,
+                message: "copied".to_string(),
+            },
+            now_ms: 30,
+            stale_deadline_at: 80,
+        })
+        .unwrap());
+
+    let job = store.get_transfer("job-1").unwrap().unwrap();
+    assert_eq!(job.state, TransferState::Planning);
+    assert_eq!(job.summary.loaded_size, 10);
+    assert_eq!(job.summary.total_size, 10);
+}
+
+#[test]
+fn terminal_report_cannot_override_canceling_transfer() {
+    let store = MemoryTransferStore::new();
+    store
+        .create_or_get_by_request_id(job("job-1", "req-1"))
+        .unwrap();
+    store.insert_tasks(vec![task("job-1")]).unwrap();
+    let lease = store
+        .acquire_runnable_transfer("owner-a", 100, 10, 100)
+        .unwrap()
+        .unwrap();
+    assert!(store
+        .start_task_attempt(TaskAttemptStart {
+            job_id: "job-1".to_string(),
+            run_id: 1,
+            owner: lease.owner,
+            lease_epoch: lease.lease_epoch,
+            task_id: "task-1".to_string(),
+            attempt_id: 1,
+            worker_id: 1,
+            worker_session_id: "worker-a".to_string(),
+            report_target_json: "[]".to_string(),
+            now_ms: 20,
+            stale_deadline_at: 70,
+        })
+        .unwrap());
+    assert!(store.request_cancel("job-1", 1, 21).unwrap());
+
+    assert!(store
+        .update_task_report(TransferTaskReport {
+            job_id: "job-1".to_string(),
+            run_id: 1,
+            task_id: "task-1".to_string(),
+            attempt_id: 1,
+            worker_id: 1,
+            worker_session_id: "worker-a".to_string(),
+            state: TransferTaskState::Completed,
+            progress: TransferProgress {
+                loaded_size: 10,
+                total_size: 10,
+                update_time: 30,
+                message: "completed after cancel request".to_string(),
+            },
+            now_ms: 30,
+            stale_deadline_at: 80,
+        })
+        .unwrap());
+
+    assert_eq!(
+        store.get_transfer("job-1").unwrap().unwrap().state,
+        TransferState::Canceling
+    );
+}
+
+#[test]
+fn transfer_conf_keeps_internal_knobs_out_of_config_surface() {
+    let toml = r#"
+enabled = true
+io_threads = 0
+worker_threads = 0
+metadata_replica_max_entries = 0
+metadata_replica_page_size = 0
+metadata_replica_history_size = 0
+allow_submit_with_stale_snapshot = true
+max_planning_transfers = 0
+max_active_transfers = 0
+max_queued_transfers = 0
+max_tasks_per_transfer = 0
+ufs_max_concurrency_per_endpoint = 0
+task_max_retries = 0
+task_report_interval = "0ms"
+task_stale_timeout = "0ms"
+planning_batch_size = 0
+worker_dispatch_concurrency = 0
+task_report_queue_size = 0
+task_probe_concurrency = 0
+worker_report_retry_queue_size = 0
+client_pending_queue_size = 0
+status_page_size = 0
+watch_queue_size = 0
+cleanup_batch_size = 0
+cluster_snapshot_max_staleness = "0ms"
+metadata_replica_refresh_interval = "0ms"
+metadata_replica_max_staleness = "0ms"
+"#;
+
+    let mut conf: TransferConf = toml::from_str(toml).unwrap();
+    conf.init().unwrap();
+
+    assert_eq!(
+        conf.metadata_replica_page_size(),
+        TransferConf::DEFAULT_METADATA_REPLICA_PAGE_SIZE
+    );
+    assert_eq!(
+        conf.metadata_replica_history_size(),
+        TransferConf::DEFAULT_METADATA_REPLICA_HISTORY_SIZE
+    );
+    assert_eq!(
+        conf.scheduler_workers(),
+        TransferConf::DEFAULT_MAX_PLANNING_TRANSFERS
+    );
+    assert_eq!(
+        conf.planning_batch_size(),
+        TransferConf::DEFAULT_PLANNING_BATCH_SIZE
+    );
+    assert_eq!(
+        conf.worker_dispatch_concurrency(),
+        TransferConf::DEFAULT_WORKER_DISPATCH_CONCURRENCY
+    );
+    assert_eq!(
+        conf.task_report_queue_size(),
+        TransferConf::DEFAULT_TASK_REPORT_QUEUE_SIZE
+    );
+    assert_eq!(
+        conf.task_probe_concurrency(),
+        TransferConf::DEFAULT_TASK_PROBE_CONCURRENCY
+    );
+    assert_eq!(
+        conf.cleanup_batch_size(),
+        TransferConf::DEFAULT_CLEANUP_BATCH_SIZE
+    );
+    assert_eq!(conf.io_threads, TransferConf::DEFAULT_IO_THREADS);
+    assert_eq!(conf.worker_threads, TransferConf::DEFAULT_WORKER_THREADS);
+    assert_eq!(
+        conf.metadata_replica_max_entries,
+        TransferConf::DEFAULT_METADATA_REPLICA_MAX_ENTRIES
+    );
+    assert!(!conf.allow_submit_with_stale_snapshot);
+    assert_eq!(
+        conf.max_tasks_per_transfer,
+        TransferConf::DEFAULT_MAX_TASKS_PER_TRANSFER
+    );
+    assert_eq!(
+        conf.ufs_max_concurrency_per_endpoint,
+        TransferConf::DEFAULT_UFS_MAX_CONCURRENCY_PER_ENDPOINT
+    );
+    assert_eq!(
+        conf.task_max_retries,
+        TransferConf::DEFAULT_TASK_MAX_RETRIES
+    );
+    assert_eq!(conf.lease_timeout, Duration::from_secs(120));
+    assert_eq!(conf.task_stale_timeout, Duration::from_secs(60));
+    assert_eq!(conf.task_report_interval, Duration::from_secs(10));
+    assert_eq!(
+        conf.cluster_snapshot_max_staleness_str,
+        TransferConf::DEFAULT_CLUSTER_SNAPSHOT_MAX_STALENESS
+    );
+    assert_eq!(
+        conf.metadata_replica_refresh_interval_str,
+        TransferConf::DEFAULT_METADATA_REPLICA_REFRESH_INTERVAL
+    );
+    assert_eq!(
+        conf.metadata_replica_max_staleness_str,
+        TransferConf::DEFAULT_METADATA_REPLICA_MAX_STALENESS
+    );
+
+    let serialized = toml::to_string(&conf).unwrap();
+    for hidden in [
+        "io_threads",
+        "worker_threads",
+        "allow_memory_store",
+        "allow_master_metadata_reader",
+        "metadata_replica_max_entries",
+        "metadata_replica_page_size",
+        "metadata_replica_history_size",
+        "allow_submit_with_stale_snapshot",
+        "max_planning_transfers",
+        "max_active_transfers",
+        "max_queued_transfers",
+        "max_tasks_per_transfer",
+        "ufs_max_concurrency_per_endpoint",
+        "task_max_retries",
+        "task_report_interval",
+        "task_stale_timeout",
+        "planning_batch_size",
+        "worker_dispatch_concurrency",
+        "task_report_queue_size",
+        "task_probe_concurrency",
+        "worker_report_retry_queue_size",
+        "client_pending_queue_size",
+        "status_page_size",
+        "watch_queue_size",
+        "cleanup_batch_size",
+        "cluster_snapshot_max_staleness",
+        "metadata_replica_refresh_interval",
+        "metadata_replica_max_staleness",
+    ] {
+        assert!(
+            !serialized.contains(hidden),
+            "internal knob leaked into transfer config: {hidden}\n{serialized}"
+        );
+    }
+}
+
+#[test]
+fn journal_conf_keeps_transfer_delta_capacity_out_of_config_surface() {
+    let toml = r#"
+metadata_delta_log_capacity = 0
+"#;
+
+    let conf: JournalConf = toml::from_str(toml).unwrap();
+    assert_eq!(
+        conf.metadata_delta_log_capacity,
+        JournalConf::DEFAULT_METADATA_DELTA_LOG_CAPACITY
+    );
+
+    let serialized = toml::to_string(&conf).unwrap();
+    assert!(
+        !serialized.contains("metadata_delta_log_capacity"),
+        "internal transfer delta capacity leaked into journal config: {serialized}"
+    );
+}
+
+#[test]
+fn mysql_store_enforces_safe_defaults() {
+    let mut conf = TransferConf {
+        enabled: true,
+        store_url: "mysql://root:curvine@127.0.0.1:3306/curvine_transfer".to_string(),
+        cv_metadata_reader: TransferCvMetadataReaderType::Disabled,
+        ..Default::default()
+    };
+    let err = conf.init().unwrap_err().to_string();
+    assert!(
+        err.contains("production transfer requires transfer.cv_metadata_reader=replica"),
+        "unexpected error: {err}"
+    );
+
+    let mut conf = TransferConf {
+        enabled: true,
+        store_url: "mysql://root:curvine@127.0.0.1:3306/curvine_transfer".to_string(),
+        ..Default::default()
+    };
+    conf.init().unwrap();
+
+    let mut conf = TransferConf {
+        enabled: true,
+        store_url: "mysql://root:curvine@127.0.0.1:3306/curvine_transfer".to_string(),
+        allow_submit_with_stale_snapshot: true,
+        ..Default::default()
+    };
+    let err = conf.init().unwrap_err().to_string();
+    assert!(
+        err.contains("production transfer forbids transfer.allow_submit_with_stale_snapshot=true"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn submit_is_idempotent_by_submitter_and_request_id() {
+    let store = MemoryTransferStore::new();
+
+    let first = store
+        .create_or_get_by_request_id(job("job-1", "req-1"))
+        .unwrap();
+    let second = store
+        .create_or_get_by_request_id(job("job-2", "req-1"))
+        .unwrap();
+
+    assert_eq!(first.job_id, "job-1");
+    assert_eq!(second.job_id, "job-1");
+}
+
+#[test]
+fn submit_rejects_conflicting_target_tree() {
+    let store = Arc::new(MemoryTransferStore::new());
+    let service = TransferService::new(store);
+
+    let first = service
+        .submit_transfer(submit_request("req-1", "s3://bucket/a", "/a"))
+        .unwrap();
+    let replay = service
+        .submit_transfer(submit_request("req-1", "s3://bucket/a", "/a"))
+        .unwrap();
+    assert_eq!(first.job_id, replay.job_id);
+
+    let conflict = service
+        .submit_transfer(submit_request("req-2", "s3://bucket/b", "/a/child"))
+        .unwrap_err();
+    assert!(
+        matches!(conflict.kind(), ErrorKind::TransferTargetConflict),
+        "unexpected conflict error: {conflict}"
+    );
+
+    let root_conflict = service
+        .submit_transfer(submit_request("req-3", "s3://bucket/root", "/"))
+        .unwrap_err();
+    assert!(
+        matches!(root_conflict.kind(), ErrorKind::TransferTargetConflict),
+        "unexpected root conflict error: {root_conflict}"
+    );
+}
+
+#[test]
+fn submit_rejects_same_job_key_with_different_command() {
+    let store = Arc::new(MemoryTransferStore::new());
+    let service = TransferService::new(store);
+
+    service
+        .submit_transfer(submit_request("req-1", "s3://bucket/a", "/a"))
+        .unwrap();
+    let mut request = submit_request("req-2", "s3://bucket/a", "/a");
+    let mut command = curvine_common::state::TransferCommand {
+        kind: TransferKind::Load,
+        source_path: "s3://bucket/a".to_string(),
+        target_path: "/a".to_string(),
+        client_request_id: "req-2".to_string(),
+        submitter: "sr".to_string(),
+        tenant: "default".to_string(),
+        options: Default::default(),
+    };
+    command
+        .options
+        .insert("overwrite".to_string(), "true".to_string());
+    request.command = serde_json::to_vec(&command).unwrap();
+
+    let err = service.submit_transfer(request).unwrap_err();
+    assert!(matches!(err.kind(), ErrorKind::TransferAlreadyRunning));
+}
+
+#[test]
+fn submit_accepts_pending_backlog_and_keeps_idempotency() {
+    let store = Arc::new(MemoryTransferStore::new());
+    let service = TransferService::with_task_stale_timeout(store.clone(), Duration::from_secs(60));
+
+    let first = service
+        .submit_transfer(submit_request("req-1", "s3://bucket/a", "/a"))
+        .unwrap();
+    let replay = service
+        .submit_transfer(submit_request("req-1", "s3://bucket/a", "/a"))
+        .unwrap();
+    assert_eq!(first.job_id, replay.job_id);
+
+    let second = service
+        .submit_transfer(submit_request("req-2", "s3://bucket/b", "/b"))
+        .unwrap();
+    assert_ne!(first.job_id, second.job_id);
+    assert_eq!(store.count_active_transfers().unwrap(), 2);
+    assert_eq!(store.count_executing_transfers().unwrap(), 0);
+}
+
+#[test]
+fn acquire_can_skip_pending_backlog_without_blocking_executing_jobs() {
+    let store = MemoryTransferStore::new();
+    store
+        .create_or_get_by_request_id(job("pending", "req-pending"))
+        .unwrap();
+
+    let mut running = job("running", "req-running");
+    running.job_key = "Load:s3://bucket/running:/running".to_string();
+    running.source_path = "s3://bucket/running".to_string();
+    running.target_path = "/running".to_string();
+    running.state = TransferState::Running;
+    running.updated_at = 1;
+    store.create_or_get_by_request_id(running).unwrap();
+
+    let lease = store
+        .acquire_runnable_transfer("owner-a", 1000, 10, 1)
+        .unwrap()
+        .unwrap();
+    assert_eq!(lease.job_id, "running");
+
+    let pending = store.get_transfer("pending").unwrap().unwrap();
+    assert_eq!(pending.state, TransferState::Pending);
+    assert_eq!(store.count_active_transfers().unwrap(), 2);
+    assert_eq!(store.count_executing_transfers().unwrap(), 1);
+}
+
+#[test]
+fn acquire_pending_prefers_tenant_with_fewer_executing_jobs() {
+    let store = MemoryTransferStore::new();
+
+    let mut running = job("running-noisy", "req-running-noisy");
+    running.job_key = "Load:s3://bucket/running-noisy:/running-noisy".to_string();
+    running.source_path = "s3://bucket/running-noisy".to_string();
+    running.target_path = "/running-noisy".to_string();
+    running.tenant = "noisy".to_string();
+    running.state = TransferState::Running;
+    running.owner = "owner-running".to_string();
+    running.lease_expire_at = 1_000;
+    running.updated_at = 10;
+    store.create_or_get_by_request_id(running).unwrap();
+
+    let mut noisy_pending = job("pending-noisy", "req-pending-noisy");
+    noisy_pending.job_key = "Load:s3://bucket/pending-noisy:/pending-noisy".to_string();
+    noisy_pending.source_path = "s3://bucket/pending-noisy".to_string();
+    noisy_pending.target_path = "/pending-noisy".to_string();
+    noisy_pending.tenant = "noisy".to_string();
+    noisy_pending.updated_at = 1;
+    store.create_or_get_by_request_id(noisy_pending).unwrap();
+
+    let mut quiet_pending = job("pending-quiet", "req-pending-quiet");
+    quiet_pending.job_key = "Load:s3://bucket/pending-quiet:/pending-quiet".to_string();
+    quiet_pending.source_path = "s3://bucket/pending-quiet".to_string();
+    quiet_pending.target_path = "/pending-quiet".to_string();
+    quiet_pending.tenant = "quiet".to_string();
+    quiet_pending.updated_at = 100;
+    store.create_or_get_by_request_id(quiet_pending).unwrap();
+
+    let lease = store
+        .acquire_runnable_transfer("owner-a", 1000, 200, 2)
+        .unwrap()
+        .unwrap();
+    assert_eq!(lease.job_id, "pending-quiet");
+}
+
+#[test]
+fn acquire_pending_with_builtin_fairness_prefers_tenant_without_executing_jobs() {
+    let store = MemoryTransferStore::new();
+
+    let mut running = job("running-noisy", "req-running-noisy");
+    running.job_key = "Load:s3://bucket/running-noisy:/running-noisy".to_string();
+    running.source_path = "s3://bucket/running-noisy".to_string();
+    running.target_path = "/running-noisy".to_string();
+    running.tenant = "noisy".to_string();
+    running.state = TransferState::Running;
+    running.owner = "owner-running".to_string();
+    running.lease_expire_at = 1_000;
+    running.updated_at = 10;
+    store.create_or_get_by_request_id(running).unwrap();
+
+    let mut noisy_pending = job("pending-noisy", "req-pending-noisy");
+    noisy_pending.job_key = "Load:s3://bucket/pending-noisy:/pending-noisy".to_string();
+    noisy_pending.source_path = "s3://bucket/pending-noisy".to_string();
+    noisy_pending.target_path = "/pending-noisy".to_string();
+    noisy_pending.tenant = "noisy".to_string();
+    noisy_pending.updated_at = 1;
+    store.create_or_get_by_request_id(noisy_pending).unwrap();
+
+    let mut quiet_pending = job("pending-quiet", "req-pending-quiet");
+    quiet_pending.job_key = "Load:s3://bucket/pending-quiet:/pending-quiet".to_string();
+    quiet_pending.source_path = "s3://bucket/pending-quiet".to_string();
+    quiet_pending.target_path = "/pending-quiet".to_string();
+    quiet_pending.tenant = "quiet".to_string();
+    quiet_pending.updated_at = 100;
+    store.create_or_get_by_request_id(quiet_pending).unwrap();
+
+    let lease = store
+        .acquire_runnable_transfer("owner-a", 1000, 200, 2)
+        .unwrap()
+        .unwrap();
+    assert_eq!(lease.job_id, "pending-quiet");
+}
+
+#[test]
+fn list_tenant_summaries_counts_states_and_orders_active_tenants() {
+    let store = MemoryTransferStore::new();
+    for (job_id, request_id, tenant, state) in [
+        (
+            "job-a-pending",
+            "req-a-pending",
+            "tenant-a",
+            TransferState::Pending,
+        ),
+        (
+            "job-a-running",
+            "req-a-running",
+            "tenant-a",
+            TransferState::Running,
+        ),
+        (
+            "job-a-completed",
+            "req-a-completed",
+            "tenant-a",
+            TransferState::Completed,
+        ),
+        (
+            "job-b-failed",
+            "req-b-failed",
+            "tenant-b",
+            TransferState::Failed,
+        ),
+        (
+            "job-b-canceled",
+            "req-b-canceled",
+            "tenant-b",
+            TransferState::Canceled,
+        ),
+        (
+            "job-c-pending",
+            "req-c-pending",
+            "tenant-c",
+            TransferState::Pending,
+        ),
+    ] {
+        let mut job = job(job_id, request_id);
+        job.tenant = tenant.to_string();
+        job.state = state;
+        job.job_key = format!("Load:s3://bucket/{job_id}:/{job_id}");
+        job.source_path = format!("s3://bucket/{job_id}");
+        job.target_path = format!("/{job_id}");
+        store.create_or_get_by_request_id(job).unwrap();
+    }
+
+    let summaries = store.list_tenant_summaries(10, 0).unwrap();
+    assert_eq!(summaries.len(), 3);
+    assert_eq!(summaries[0].tenant, "tenant-a");
+    assert_eq!(summaries[0].pending, 1);
+    assert_eq!(summaries[0].executing, 1);
+    assert_eq!(summaries[0].completed, 1);
+    assert_eq!(summaries[0].total, 3);
+    assert_eq!(summaries[1].tenant, "tenant-c");
+    assert_eq!(summaries[1].pending, 1);
+    assert_eq!(summaries[2].tenant, "tenant-b");
+    assert_eq!(summaries[2].failed, 1);
+    assert_eq!(summaries[2].canceled, 1);
+
+    let page = store.list_tenant_summaries(1, 1).unwrap();
+    assert_eq!(page.len(), 1);
+    assert_eq!(page[0].tenant, "tenant-c");
+}
+
+#[test]
+fn submit_rejects_unsupported_protocol_version() {
+    let store = Arc::new(MemoryTransferStore::new());
+    let service = TransferService::new(store);
+    let mut request = submit_request("req-1", "s3://bucket/a", "/a");
+    request.protocol_version = Some(2);
+
+    let error = service.submit_transfer(request).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("Unsupported transfer protocol version"),
+        "unexpected protocol error: {error}"
+    );
+}
+
+#[test]
+fn submit_rejects_invalid_transfer_direction() {
+    let store = Arc::new(MemoryTransferStore::new());
+    let service = TransferService::new(store);
+
+    let invalid_load = service
+        .submit_transfer(submit_request_with_kind(
+            "req-load",
+            TransferKindProto::TransferLoad,
+            "/cv/file",
+            "s3://bucket/file",
+        ))
+        .unwrap_err();
+    assert!(
+        invalid_load.to_string().contains("Invalid Load direction"),
+        "unexpected load direction error: {invalid_load}"
+    );
+
+    let invalid_export = service
+        .submit_transfer(submit_request_with_kind(
+            "req-export",
+            TransferKindProto::TransferExport,
+            "s3://bucket/file",
+            "/cv/file",
+        ))
+        .unwrap_err();
+    assert!(
+        invalid_export
+            .to_string()
+            .contains("Invalid Export direction"),
+        "unexpected export direction error: {invalid_export}"
+    );
+}
+
+#[test]
+fn submit_rejects_relative_path_segments() {
+    let store = Arc::new(MemoryTransferStore::new());
+    let service = TransferService::new(store);
+
+    let error = service
+        .submit_transfer(submit_request("req-1", "s3://bucket/a/../b", "/b"))
+        .unwrap_err();
+    assert!(
+        error.to_string().contains("relative segment"),
+        "unexpected relative path error: {error}"
+    );
+}
+
+#[test]
+fn list_transfers_filters_and_paginates_by_updated_time() {
+    let store = MemoryTransferStore::new();
+    let mut first = job("job-1", "req-1");
+    first.job_key = "Load:s3://bucket/a:/a".to_string();
+    first.source_path = "s3://bucket/a".to_string();
+    first.target_path = "/a".to_string();
+    first.updated_at = 10;
+    store.create_or_get_by_request_id(first).unwrap();
+
+    let mut second = job("job-2", "req-2");
+    second.job_key = "Load:s3://bucket/b:/b".to_string();
+    second.source_path = "s3://bucket/b".to_string();
+    second.target_path = "/b".to_string();
+    second.submitter = "flink".to_string();
+    second.tenant = "tenant-a".to_string();
+    second.updated_at = 30;
+    second.state = TransferState::Completed;
+    store.create_or_get_by_request_id(second).unwrap();
+
+    let mut third = job("job-3", "req-3");
+    third.updated_at = 20;
+    third.kind = TransferKind::Export;
+    third.job_key = "Export:/a:s3://bucket/a".to_string();
+    third.source_path = "/a".to_string();
+    third.target_path = "s3://bucket/a".to_string();
+    store.create_or_get_by_request_id(third).unwrap();
+
+    let page = store
+        .list_transfers(TransferListFilter {
+            limit: 2,
+            ..Default::default()
+        })
+        .unwrap();
+    assert_eq!(
+        page.iter()
+            .map(|job| job.job_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["job-2", "job-3"]
+    );
+
+    let exports = store
+        .list_transfers(TransferListFilter {
+            kind: Some(TransferKind::Export),
+            limit: 10,
+            ..Default::default()
+        })
+        .unwrap();
+    assert_eq!(exports.len(), 1);
+    assert_eq!(exports[0].job_id, "job-3");
+
+    let completed = store
+        .list_transfers(TransferListFilter {
+            state: Some(TransferState::Completed),
+            limit: 10,
+            ..Default::default()
+        })
+        .unwrap();
+    assert_eq!(completed.len(), 1);
+    assert_eq!(completed[0].job_id, "job-2");
+
+    let tenant_jobs = store
+        .list_transfers(TransferListFilter {
+            tenant: Some("tenant-a".to_string()),
+            limit: 10,
+            ..Default::default()
+        })
+        .unwrap();
+    assert_eq!(tenant_jobs.len(), 1);
+    assert_eq!(tenant_jobs[0].job_id, "job-2");
+
+    let submitter_jobs = store
+        .list_transfers(TransferListFilter {
+            submitter: Some("flink".to_string()),
+            limit: 10,
+            ..Default::default()
+        })
+        .unwrap();
+    assert_eq!(submitter_jobs.len(), 1);
+    assert_eq!(submitter_jobs[0].job_id, "job-2");
+}
+
+#[test]
+fn purge_terminal_transfers_keeps_active_jobs() {
+    let store = MemoryTransferStore::new();
+    let mut active = job("job-active", "req-active");
+    active.updated_at = 1;
+    store.create_or_get_by_request_id(active).unwrap();
+
+    let mut completed = job("job-completed", "req-completed");
+    completed.job_key = "Load:s3://bucket/completed:/completed".to_string();
+    completed.source_path = "s3://bucket/completed".to_string();
+    completed.target_path = "/completed".to_string();
+    completed.state = TransferState::Completed;
+    completed.updated_at = 1;
+    store.create_or_get_by_request_id(completed).unwrap();
+    store.insert_tasks(vec![task("job-completed")]).unwrap();
+
+    assert_eq!(store.purge_terminal_transfers(10, 100).unwrap(), 1);
+    assert!(store.get_transfer("job-active").unwrap().is_some());
+    assert!(store.get_transfer("job-completed").unwrap().is_none());
+    assert!(store
+        .list_transfer_tasks("job-completed", 1)
+        .unwrap()
+        .is_empty());
+}
+
+#[test]
+fn lease_owner_and_epoch_guard_state_transition() {
+    let store = MemoryTransferStore::new();
+    store
+        .create_or_get_by_request_id(job("job-1", "req-1"))
+        .unwrap();
+
+    let lease = store
+        .acquire_runnable_transfer("owner-a", 1000, 10, 100)
+        .unwrap()
+        .unwrap();
+
+    let stale_owner_update = TransferStateUpdate {
+        job_id: "job-1".to_string(),
+        run_id: 1,
+        owner: "owner-b".to_string(),
+        lease_epoch: lease.lease_epoch,
+        from_states: vec![TransferState::Pending],
+        to_state: TransferState::Planning,
+        message: "planning".to_string(),
+        now_ms: 11,
+    };
+    assert!(!store.update_transfer_state(stale_owner_update).unwrap());
+
+    let valid_update = TransferStateUpdate {
+        job_id: "job-1".to_string(),
+        run_id: 1,
+        owner: lease.owner,
+        lease_epoch: lease.lease_epoch,
+        from_states: vec![TransferState::Planning],
+        to_state: TransferState::Planning,
+        message: "planning".to_string(),
+        now_ms: 12,
+    };
+    assert!(store.update_transfer_state(valid_update).unwrap());
+    assert_eq!(
+        store.get_transfer("job-1").unwrap().unwrap().state,
+        TransferState::Planning
+    );
+}
+
+#[test]
+fn owner_can_reacquire_running_transfer_before_lease_expiry() {
+    let store = MemoryTransferStore::new();
+    store
+        .create_or_get_by_request_id(job("job-1", "req-1"))
+        .unwrap();
+
+    let lease = store
+        .acquire_runnable_transfer("owner-a", 1000, 10, 100)
+        .unwrap()
+        .unwrap();
+    assert!(store
+        .update_transfer_state(TransferStateUpdate {
+            job_id: "job-1".to_string(),
+            run_id: 1,
+            owner: lease.owner.clone(),
+            lease_epoch: lease.lease_epoch,
+            from_states: vec![TransferState::Planning],
+            to_state: TransferState::Running,
+            message: "running".to_string(),
+            now_ms: 11,
+        })
+        .unwrap());
+
+    assert!(store
+        .acquire_runnable_transfer("owner-b", 1000, 20, 100)
+        .unwrap()
+        .is_none());
+
+    let reacquired = store
+        .acquire_runnable_transfer("owner-a", 1000, 20, 100)
+        .unwrap()
+        .unwrap();
+    assert_eq!(reacquired.job_id, "job-1");
+    assert_eq!(reacquired.owner, "owner-a");
+    assert!(reacquired.lease_epoch > lease.lease_epoch);
+}
+
+#[test]
+fn task_report_requires_current_attempt_and_worker_session() {
+    let store = MemoryTransferStore::new();
+    store
+        .create_or_get_by_request_id(job("job-1", "req-1"))
+        .unwrap();
+    store.insert_tasks(vec![task("job-1")]).unwrap();
+    let lease = store
+        .acquire_runnable_transfer("owner-a", 100, 10, 100)
+        .unwrap()
+        .unwrap();
+
+    assert!(store
+        .start_task_attempt(TaskAttemptStart {
+            job_id: "job-1".to_string(),
+            run_id: 1,
+            owner: lease.owner,
+            lease_epoch: lease.lease_epoch,
+            task_id: "task-1".to_string(),
+            attempt_id: 7,
+            worker_id: 10,
+            worker_session_id: "session-a".to_string(),
+            report_target_json: "{}".to_string(),
+            now_ms: 10,
+            stale_deadline_at: 70,
+        })
+        .unwrap());
+
+    let mut report = TransferTaskReport {
+        job_id: "job-1".to_string(),
+        run_id: 1,
+        task_id: "task-1".to_string(),
+        attempt_id: 7,
+        worker_id: 10,
+        worker_session_id: "session-old".to_string(),
+        state: TransferTaskState::Running,
+        progress: TransferProgress {
+            loaded_size: 1,
+            total_size: 10,
+            update_time: 20,
+            message: String::new(),
+        },
+        now_ms: 20,
+        stale_deadline_at: 80,
+    };
+    assert!(!store.update_task_report(report.clone()).unwrap());
+
+    report.worker_session_id = "session-a".to_string();
+    report.state = TransferTaskState::Failed;
+    report.progress.message = "copy failed\npermission denied".to_string();
+    assert!(store.update_task_report(report).unwrap());
+    let job = store.get_transfer("job-1").unwrap().unwrap();
+    assert_eq!(job.state, TransferState::Planning);
+    assert_eq!(job.summary.loaded_size, 1);
+    assert_eq!(job.summary.total_size, 10);
+    assert_eq!(job.summary.message, "copy failed\npermission denied");
+}
+
+#[test]
+fn start_task_attempt_rejects_cancel_requested_job() {
+    let store = MemoryTransferStore::new();
+    store
+        .create_or_get_by_request_id(job("job-1", "req-1"))
+        .unwrap();
+    store.insert_tasks(vec![task("job-1")]).unwrap();
+    let lease = store
+        .acquire_runnable_transfer("owner-a", 100, 10, 100)
+        .unwrap()
+        .unwrap();
+    assert!(store.request_cancel("job-1", 1, 11).unwrap());
+    assert_eq!(
+        store.get_transfer("job-1").unwrap().unwrap().state,
+        TransferState::Canceling
+    );
+
+    assert!(!store
+        .start_task_attempt(TaskAttemptStart {
+            job_id: "job-1".to_string(),
+            run_id: 1,
+            owner: lease.owner,
+            lease_epoch: lease.lease_epoch,
+            task_id: "task-1".to_string(),
+            attempt_id: 1,
+            worker_id: 10,
+            worker_session_id: "session-a".to_string(),
+            report_target_json: "{}".to_string(),
+            now_ms: 12,
+            stale_deadline_at: 72,
+        })
+        .unwrap());
+
+    let task = store.list_transfer_tasks("job-1", 1).unwrap().remove(0);
+    assert_eq!(task.state, TransferTaskState::Pending);
+}
+
+#[test]
+fn queued_task_report_returns_store_acceptance() {
+    let store = Arc::new(MemoryTransferStore::new());
+    store
+        .create_or_get_by_request_id(job("job-1", "req-1"))
+        .unwrap();
+    store.insert_tasks(vec![task("job-1")]).unwrap();
+    let lease = store
+        .acquire_runnable_transfer("owner-a", 100, 10, 100)
+        .unwrap()
+        .unwrap();
+    assert!(store
+        .start_task_attempt(TaskAttemptStart {
+            job_id: "job-1".to_string(),
+            run_id: 1,
+            owner: lease.owner,
+            lease_epoch: lease.lease_epoch,
+            task_id: "task-1".to_string(),
+            attempt_id: 7,
+            worker_id: 10,
+            worker_session_id: "session-a".to_string(),
+            report_target_json: "{}".to_string(),
+            now_ms: 10,
+            stale_deadline_at: 70,
+        })
+        .unwrap());
+    let service =
+        TransferService::with_report_queue(store, Duration::from_secs(60), 16, 1).unwrap();
+
+    let mut request = transfer_task_report_request("session-old");
+    assert!(!service.report_task(request.clone()).unwrap());
+
+    request.worker_session_id = "session-a".to_string();
+    assert!(service.report_task(request).unwrap());
+}
+
+#[test]
+fn queued_progress_report_returns_after_enqueue_without_state_pollution() {
+    let store = Arc::new(MemoryTransferStore::new());
+    store
+        .create_or_get_by_request_id(job("job-1", "req-1"))
+        .unwrap();
+    store.insert_tasks(vec![task("job-1")]).unwrap();
+    let lease = store
+        .acquire_runnable_transfer("owner-a", 100, 10, 100)
+        .unwrap()
+        .unwrap();
+    assert!(store
+        .start_task_attempt(TaskAttemptStart {
+            job_id: "job-1".to_string(),
+            run_id: 1,
+            owner: lease.owner,
+            lease_epoch: lease.lease_epoch,
+            task_id: "task-1".to_string(),
+            attempt_id: 7,
+            worker_id: 10,
+            worker_session_id: "session-a".to_string(),
+            report_target_json: "{}".to_string(),
+            now_ms: 10,
+            stale_deadline_at: 70,
+        })
+        .unwrap());
+    let service =
+        TransferService::with_report_queue(store.clone(), Duration::from_secs(60), 16, 1).unwrap();
+
+    let mut request = transfer_task_report_request("session-old");
+    request.state = TransferTaskStateProto::TransferTaskRunning as i32;
+    request.progress.message = "stale progress".to_string();
+    assert!(
+        service.report_task(request).unwrap(),
+        "non-terminal progress report should acknowledge enqueue"
+    );
+
+    std::thread::sleep(Duration::from_millis(100));
+    let task = store.list_transfer_tasks("job-1", 1).unwrap().remove(0);
+    assert_eq!(task.state, TransferTaskState::Running);
+    assert_ne!(task.progress.message, "stale progress");
+}
+
+#[test]
+fn queued_progress_report_storm_does_not_block_terminal_report() {
+    let store = Arc::new(MemoryTransferStore::new());
+    store
+        .create_or_get_by_request_id(job("job-1", "req-1"))
+        .unwrap();
+    store.insert_tasks(vec![task("job-1")]).unwrap();
+    let lease = store
+        .acquire_runnable_transfer("owner-a", 100, 10, 100)
+        .unwrap()
+        .unwrap();
+    assert!(store
+        .start_task_attempt(TaskAttemptStart {
+            job_id: "job-1".to_string(),
+            run_id: 1,
+            owner: lease.owner,
+            lease_epoch: lease.lease_epoch,
+            task_id: "task-1".to_string(),
+            attempt_id: 7,
+            worker_id: 10,
+            worker_session_id: "session-a".to_string(),
+            report_target_json: "{}".to_string(),
+            now_ms: 10,
+            stale_deadline_at: 70,
+        })
+        .unwrap());
+    let service = Arc::new(
+        TransferService::with_report_queue(store.clone(), Duration::from_secs(60), 4096, 4)
+            .unwrap(),
+    );
+    let workers = 16;
+    let reports_per_worker = 100;
+    let barrier = Arc::new(std::sync::Barrier::new(workers));
+
+    let handles = (0..workers)
+        .map(|worker| {
+            let service = service.clone();
+            let barrier = barrier.clone();
+            std::thread::spawn(move || {
+                barrier.wait();
+                for index in 0..reports_per_worker {
+                    let mut request = transfer_task_report_request("session-a");
+                    request.state = TransferTaskStateProto::TransferTaskRunning as i32;
+                    request.progress.loaded_size = (worker * reports_per_worker + index) as i64;
+                    request.progress.message = format!("progress-{worker}-{index}");
+                    assert!(service.report_task(request).unwrap());
+                }
+            })
+        })
+        .collect::<Vec<_>>();
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    let mut terminal = transfer_task_report_request("session-a");
+    terminal.state = TransferTaskStateProto::TransferTaskCompleted as i32;
+    terminal.progress.message = "done-after-storm".to_string();
+    assert!(
+        service.report_task(terminal).unwrap(),
+        "terminal report should still wait for and observe store acceptance"
+    );
+
+    let task = store.list_transfer_tasks("job-1", 1).unwrap().remove(0);
+    assert_eq!(task.state, TransferTaskState::Completed);
+    assert_eq!(task.progress.message, "done-after-storm");
+}
+
+fn transfer_task_report_request(worker_session_id: &str) -> TransferTaskReportRequest {
+    TransferTaskReportRequest {
+        job_id: "job-1".to_string(),
+        run_id: 1,
+        task_id: "task-1".to_string(),
+        attempt_id: 7,
+        worker_id: 10,
+        worker_session_id: worker_session_id.to_string(),
+        state: TransferTaskStateProto::TransferTaskCompleted as i32,
+        progress: TransferProgressProto {
+            loaded_size: 10,
+            total_size: 10,
+            update_time: 20,
+            message: "done".to_string(),
+        },
+        protocol_version: Some(1),
+    }
+}

--- a/curvine-server/tests/transfer/mysql_store_test.rs
+++ b/curvine-server/tests/transfer/mysql_store_test.rs
@@ -1,0 +1,1272 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use curvine_common::error::ErrorKind;
+use curvine_common::proto::{SubmitTransferRequest, TransferKindProto};
+use curvine_common::state::{
+    TaskAttemptStart, TransferJobRecord, TransferKind, TransferProgress, TransferState,
+    TransferStateUpdate, TransferTaskRecord, TransferTaskReport, TransferTaskState,
+};
+use curvine_server::transfer::{
+    MysqlTransferStore, TransferService, TransferStore, TransferStoreBackend,
+};
+use mysql::params;
+use mysql::prelude::*;
+use orpc::common::Metrics;
+use std::sync::{Arc, Barrier};
+use std::thread;
+use uuid::Uuid;
+
+fn mysql_store(name: &str) -> Option<(MysqlTransferStore, String, String, String)> {
+    let base_url = std::env::var("CURVINE_TRANSFER_MYSQL_URL").ok()?;
+    let safe_name = name.replace('-', "_");
+    let safe_name = &safe_name[..safe_name.len().min(20)];
+    let suffix = Uuid::new_v4().simple().to_string();
+    let db_name = format!(
+        "cv_transfer_{}_{}_{}",
+        safe_name,
+        std::process::id(),
+        &suffix[..8]
+    );
+    let pool = mysql::Pool::new(limited_mysql_pool_url(&base_url).as_str()).unwrap();
+    let mut conn = pool.get_conn().unwrap();
+    conn.query_drop(format!("create database `{}`", db_name))
+        .unwrap();
+    let separator = if base_url.contains('?') { '&' } else { '?' };
+    let store_url = format!(
+        "{}/{}{}pool_min=0&pool_max=1",
+        base_url.trim_end_matches('/'),
+        db_name,
+        separator
+    );
+    Some((
+        MysqlTransferStore::open(&store_url).unwrap(),
+        store_url,
+        base_url,
+        db_name,
+    ))
+}
+
+fn drop_mysql_database(base_url: &str, db_name: &str) {
+    let pool = mysql::Pool::new(limited_mysql_pool_url(base_url).as_str()).unwrap();
+    let mut conn = pool.get_conn().unwrap();
+    conn.query_drop(format!("drop database if exists `{}`", db_name))
+        .unwrap();
+}
+
+fn create_mysql_database(base_url: &str, db_name: &str) {
+    let pool = mysql::Pool::new(limited_mysql_pool_url(base_url).as_str()).unwrap();
+    let mut conn = pool.get_conn().unwrap();
+    conn.query_drop(format!("create database `{}`", db_name))
+        .unwrap();
+}
+
+fn limited_mysql_pool_url(url: &str) -> String {
+    let separator = if url.contains('?') { '&' } else { '?' };
+    format!("{url}{separator}pool_min=0&pool_max=1")
+}
+
+fn metric_value(output: &str, metric: &str, labels: &[&str]) -> Option<f64> {
+    output.lines().find_map(|line| {
+        if !line.starts_with(metric) || labels.iter().any(|label| !line.contains(label)) {
+            return None;
+        }
+        line.split_whitespace().last()?.parse::<f64>().ok()
+    })
+}
+
+fn job(job_id: &str) -> TransferJobRecord {
+    TransferJobRecord {
+        job_key: format!("Load:s3://bucket/{job_id}:/{job_id}"),
+        job_id: job_id.to_string(),
+        run_id: 1,
+        kind: TransferKind::Load,
+        source_path: format!("s3://bucket/{job_id}"),
+        target_path: format!("/{job_id}"),
+        command_json: "{}".to_string(),
+        mount_snapshot_json: "{}".to_string(),
+        secret_ref_json: "{}".to_string(),
+        cluster_snapshot_version: 1,
+        cv_metadata_epoch: None,
+        state: TransferState::Pending,
+        owner: String::new(),
+        lease_epoch: 0,
+        lease_expire_at: 0,
+        cancel_requested: false,
+        summary: TransferProgress::default(),
+        client_request_id: format!("req-{job_id}"),
+        submitter: "mysql-test".to_string(),
+        tenant: "default".to_string(),
+        created_at: 1,
+        updated_at: 1,
+    }
+}
+
+fn task(job_id: &str) -> TransferTaskRecord {
+    TransferTaskRecord {
+        job_id: job_id.to_string(),
+        run_id: 1,
+        task_id: "task-1".to_string(),
+        attempt_id: 0,
+        source_path: format!("s3://bucket/{job_id}"),
+        target_path: format!("/{job_id}"),
+        worker_id: 0,
+        worker_session_id: String::new(),
+        source_read_plan_json: String::new(),
+        report_target_json: String::new(),
+        state: TransferTaskState::Pending,
+        progress: TransferProgress::default(),
+        retry_count: 0,
+        attempt_started_at: 0,
+        last_report_at: 0,
+        stale_deadline_at: 0,
+        updated_at: 0,
+    }
+}
+
+#[test]
+fn mysql_finds_conflicting_active_transfer_by_target_path() {
+    let Some((store, _store_url, base_url, db_name)) = mysql_store("target-conflict") else {
+        return;
+    };
+    let mut parent = job("parent");
+    parent.target_path = "/a".to_string();
+    store.create_or_get_by_request_id(parent).unwrap();
+
+    let conflict = store
+        .find_conflicting_active_transfer("/a/child", "mysql-test", "req-other")
+        .unwrap()
+        .expect("child target should conflict with active parent target");
+    assert_eq!(conflict.job_id, "parent");
+
+    let replay = store
+        .find_conflicting_active_transfer("/a", "mysql-test", "req-parent")
+        .unwrap();
+    assert!(
+        replay.is_none(),
+        "same submitter request should be treated as idempotent replay"
+    );
+    drop(store);
+    drop_mysql_database(&base_url, &db_name);
+}
+
+#[test]
+fn mysql_root_target_conflicts_with_any_active_transfer() {
+    let Some((store, _store_url, base_url, db_name)) = mysql_store("root-target-conflict") else {
+        return;
+    };
+    let mut root = job("root");
+    root.target_path = "/".to_string();
+    store.create_or_get_by_request_id(root).unwrap();
+
+    let root_conflict = store
+        .find_conflicting_active_transfer("/any/path", "mysql-test", "req-third")
+        .unwrap()
+        .expect("root target should conflict with any target");
+    assert_eq!(root_conflict.job_id, "root");
+    drop(store);
+    drop_mysql_database(&base_url, &db_name);
+}
+
+#[test]
+fn mysql_submit_rejects_root_when_child_target_is_active() {
+    let Some((store, _store_url, base_url, db_name)) = mysql_store("child-before-root-conflict")
+    else {
+        return;
+    };
+    let mut parent = job("parent");
+    parent.target_path = "/a".to_string();
+    store.create_or_get_by_request_id(parent).unwrap();
+
+    let mut root = job("root");
+    root.target_path = "/".to_string();
+    let error = store.create_or_get_by_request_id(root).unwrap_err();
+    assert!(
+        matches!(error.kind(), ErrorKind::TransferTargetConflict),
+        "unexpected conflict error: {error}"
+    );
+    drop(store);
+    drop_mysql_database(&base_url, &db_name);
+}
+
+#[test]
+fn mysql_store_supports_backlog_lease_report_and_cleanup() {
+    let Some((store, store_url, base_url, db_name)) = mysql_store("store_semantics") else {
+        eprintln!("skip mysql store test: CURVINE_TRANSFER_MYSQL_URL is not set");
+        return;
+    };
+    let second_store = MysqlTransferStore::open(&store_url).unwrap();
+
+    store.create_or_get_by_request_id(job("pending")).unwrap();
+    let mut running = job("running");
+    running.state = TransferState::Running;
+    store.create_or_get_by_request_id(running).unwrap();
+    assert_eq!(store.count_active_transfers().unwrap(), 2);
+    assert_eq!(store.count_executing_transfers().unwrap(), 1);
+
+    let lease = store
+        .acquire_runnable_transfer("owner-a", 100, 10, 1)
+        .unwrap()
+        .unwrap();
+    assert_eq!(lease.job_id, "running");
+    assert_eq!(
+        store.get_transfer("pending").unwrap().unwrap().state,
+        TransferState::Pending
+    );
+    assert!(store
+        .acquire_runnable_transfer("owner-a", 100, 10, 1)
+        .unwrap()
+        .is_none());
+
+    let lease_a = store
+        .acquire_runnable_transfer("owner-a", 100, 10, 100)
+        .unwrap()
+        .unwrap();
+    assert_eq!(lease_a.job_id, "pending");
+    assert!(second_store
+        .acquire_runnable_transfer("owner-b", 100, 50, 100)
+        .unwrap()
+        .is_none());
+    let lease_b = second_store
+        .acquire_runnable_transfer("owner-b", 100, 111, 100)
+        .unwrap()
+        .unwrap();
+    assert_eq!(lease_b.job_id, "pending");
+    assert_eq!(lease_b.lease_epoch, lease_a.lease_epoch + 1);
+
+    assert!(!store
+        .update_transfer_state(TransferStateUpdate {
+            job_id: lease_a.job_id.clone(),
+            run_id: lease_a.run_id,
+            owner: lease_a.owner,
+            lease_epoch: lease_a.lease_epoch,
+            from_states: vec![TransferState::Pending],
+            to_state: TransferState::Planning,
+            message: "stale owner should not update".to_string(),
+            now_ms: 120,
+        })
+        .unwrap());
+    assert!(second_store
+        .update_transfer_state(TransferStateUpdate {
+            job_id: lease_b.job_id.clone(),
+            run_id: lease_b.run_id,
+            owner: lease_b.owner.clone(),
+            lease_epoch: lease_b.lease_epoch,
+            from_states: vec![TransferState::Planning],
+            to_state: TransferState::Planning,
+            message: "current owner may update".to_string(),
+            now_ms: 121,
+        })
+        .unwrap());
+
+    store.insert_tasks(vec![task("pending")]).unwrap();
+    assert!(store
+        .start_task_attempt(TaskAttemptStart {
+            job_id: "pending".to_string(),
+            run_id: 1,
+            owner: lease_b.owner.clone(),
+            lease_epoch: lease_b.lease_epoch,
+            task_id: "task-1".to_string(),
+            attempt_id: 1,
+            worker_id: 10,
+            worker_session_id: "session-a".to_string(),
+            report_target_json: "{}".to_string(),
+            now_ms: 130,
+            stale_deadline_at: 190,
+        })
+        .unwrap());
+    assert!(!store
+        .update_task_report(TransferTaskReport {
+            job_id: "pending".to_string(),
+            run_id: 1,
+            task_id: "task-1".to_string(),
+            attempt_id: 1,
+            worker_id: 10,
+            worker_session_id: "old-session".to_string(),
+            state: TransferTaskState::Running,
+            progress: TransferProgress::default(),
+            now_ms: 140,
+            stale_deadline_at: 200,
+        })
+        .unwrap());
+    assert!(store
+        .update_task_report(TransferTaskReport {
+            job_id: "pending".to_string(),
+            run_id: 1,
+            task_id: "task-1".to_string(),
+            attempt_id: 1,
+            worker_id: 10,
+            worker_session_id: "session-a".to_string(),
+            state: TransferTaskState::Completed,
+            progress: TransferProgress {
+                loaded_size: 10,
+                total_size: 10,
+                update_time: 150,
+                message: String::new(),
+            },
+            now_ms: 150,
+            stale_deadline_at: 210,
+        })
+        .unwrap());
+    assert_eq!(
+        store.get_transfer("pending").unwrap().unwrap().state,
+        TransferState::Completed
+    );
+
+    assert_eq!(store.purge_terminal_transfers(200, 100).unwrap(), 1);
+    assert!(store.get_transfer("pending").unwrap().is_none());
+    assert!(store.list_transfer_tasks("pending", 1).unwrap().is_empty());
+
+    drop(second_store);
+    drop(store);
+    drop_mysql_database(&base_url, &db_name);
+}
+
+#[test]
+fn mysql_acquire_pending_prefers_tenant_with_fewer_executing_jobs() {
+    let Some((store, _store_url, base_url, db_name)) = mysql_store("tenant_fairness") else {
+        eprintln!("skip mysql tenant fairness test: CURVINE_TRANSFER_MYSQL_URL is not set");
+        return;
+    };
+
+    let mut running = job("running-noisy");
+    running.target_path = "/running-noisy".to_string();
+    running.job_key = "Load:s3://bucket/running-noisy:/running-noisy".to_string();
+    running.tenant = "noisy".to_string();
+    running.state = TransferState::Running;
+    running.owner = "owner-running".to_string();
+    running.lease_expire_at = 1_000;
+    running.updated_at = 10;
+    store.create_or_get_by_request_id(running).unwrap();
+
+    let mut noisy_pending = job("pending-noisy");
+    noisy_pending.target_path = "/pending-noisy".to_string();
+    noisy_pending.job_key = "Load:s3://bucket/pending-noisy:/pending-noisy".to_string();
+    noisy_pending.tenant = "noisy".to_string();
+    noisy_pending.updated_at = 1;
+    store.create_or_get_by_request_id(noisy_pending).unwrap();
+
+    let mut quiet_pending = job("pending-quiet");
+    quiet_pending.target_path = "/pending-quiet".to_string();
+    quiet_pending.job_key = "Load:s3://bucket/pending-quiet:/pending-quiet".to_string();
+    quiet_pending.tenant = "quiet".to_string();
+    quiet_pending.updated_at = 100;
+    store.create_or_get_by_request_id(quiet_pending).unwrap();
+
+    let lease = store
+        .acquire_runnable_transfer("owner-a", 100, 200, 2)
+        .unwrap()
+        .unwrap();
+    assert_eq!(lease.job_id, "pending-quiet");
+
+    drop(store);
+    drop_mysql_database(&base_url, &db_name);
+}
+
+#[test]
+fn mysql_acquire_pending_with_builtin_fairness_prefers_tenant_without_executing_jobs() {
+    let Some((store, _store_url, base_url, db_name)) = mysql_store("tenant_fifo") else {
+        eprintln!("skip mysql tenant fifo test: CURVINE_TRANSFER_MYSQL_URL is not set");
+        return;
+    };
+
+    let mut running = job("running-noisy");
+    running.target_path = "/running-noisy".to_string();
+    running.job_key = "Load:s3://bucket/running-noisy:/running-noisy".to_string();
+    running.tenant = "noisy".to_string();
+    running.state = TransferState::Running;
+    running.owner = "owner-running".to_string();
+    running.lease_expire_at = 1_000;
+    running.updated_at = 10;
+    store.create_or_get_by_request_id(running).unwrap();
+
+    let mut noisy_pending = job("pending-noisy");
+    noisy_pending.target_path = "/pending-noisy".to_string();
+    noisy_pending.job_key = "Load:s3://bucket/pending-noisy:/pending-noisy".to_string();
+    noisy_pending.tenant = "noisy".to_string();
+    noisy_pending.updated_at = 1;
+    store.create_or_get_by_request_id(noisy_pending).unwrap();
+
+    let mut quiet_pending = job("pending-quiet");
+    quiet_pending.target_path = "/pending-quiet".to_string();
+    quiet_pending.job_key = "Load:s3://bucket/pending-quiet:/pending-quiet".to_string();
+    quiet_pending.tenant = "quiet".to_string();
+    quiet_pending.updated_at = 100;
+    store.create_or_get_by_request_id(quiet_pending).unwrap();
+
+    let lease = store
+        .acquire_runnable_transfer("owner-a", 100, 200, 2)
+        .unwrap()
+        .unwrap();
+    assert_eq!(lease.job_id, "pending-quiet");
+
+    drop(store);
+    drop_mysql_database(&base_url, &db_name);
+}
+
+#[test]
+fn mysql_list_tenant_summaries_counts_states_and_orders_active_tenants() {
+    let Some((store, _store_url, base_url, db_name)) = mysql_store("tenant_summary") else {
+        eprintln!("skip mysql tenant summary test: CURVINE_TRANSFER_MYSQL_URL is not set");
+        return;
+    };
+
+    for (job_id, tenant, state) in [
+        ("a-pending", "tenant-a", TransferState::Pending),
+        ("a-running", "tenant-a", TransferState::Running),
+        ("a-completed", "tenant-a", TransferState::Completed),
+        ("b-failed", "tenant-b", TransferState::Failed),
+        ("b-canceled", "tenant-b", TransferState::Canceled),
+        ("c-pending", "tenant-c", TransferState::Pending),
+    ] {
+        let mut job = job(job_id);
+        job.tenant = tenant.to_string();
+        job.state = state;
+        store.create_or_get_by_request_id(job).unwrap();
+    }
+
+    let summaries = store.list_tenant_summaries(10, 0).unwrap();
+    assert_eq!(summaries.len(), 3);
+    assert_eq!(summaries[0].tenant, "tenant-a");
+    assert_eq!(summaries[0].pending, 1);
+    assert_eq!(summaries[0].executing, 1);
+    assert_eq!(summaries[0].completed, 1);
+    assert_eq!(summaries[1].tenant, "tenant-c");
+    assert_eq!(summaries[2].tenant, "tenant-b");
+    assert_eq!(summaries[2].failed, 1);
+    assert_eq!(summaries[2].canceled, 1);
+
+    let page = store.list_tenant_summaries(1, 1).unwrap();
+    assert_eq!(page.len(), 1);
+    assert_eq!(page[0].tenant, "tenant-c");
+
+    drop(store);
+    drop_mysql_database(&base_url, &db_name);
+}
+
+#[test]
+fn mysql_start_task_attempt_rejects_cancel_requested_job() {
+    let Some((store, _store_url, base_url, db_name)) = mysql_store("cancel_start") else {
+        eprintln!("skip mysql cancel start test: CURVINE_TRANSFER_MYSQL_URL is not set");
+        return;
+    };
+    store.create_or_get_by_request_id(job("job-1")).unwrap();
+    store.insert_tasks(vec![task("job-1")]).unwrap();
+    let lease = store
+        .acquire_runnable_transfer("owner-a", 100, 10, 100)
+        .unwrap()
+        .unwrap();
+    assert!(store.request_cancel("job-1", 1, 11).unwrap());
+    assert_eq!(
+        store.get_transfer("job-1").unwrap().unwrap().state,
+        TransferState::Canceling
+    );
+
+    assert!(!store
+        .start_task_attempt(TaskAttemptStart {
+            job_id: "job-1".to_string(),
+            run_id: 1,
+            owner: lease.owner,
+            lease_epoch: lease.lease_epoch,
+            task_id: "task-1".to_string(),
+            attempt_id: 1,
+            worker_id: 10,
+            worker_session_id: "session-a".to_string(),
+            report_target_json: "{}".to_string(),
+            now_ms: 12,
+            stale_deadline_at: 72,
+        })
+        .unwrap());
+
+    let task = store.list_transfer_tasks("job-1", 1).unwrap().remove(0);
+    assert_eq!(task.state, TransferTaskState::Pending);
+
+    drop(store);
+    drop_mysql_database(&base_url, &db_name);
+}
+
+#[test]
+fn mysql_list_transfers_filters_by_submitter_and_tenant() {
+    let Some((store, _store_url, base_url, db_name)) = mysql_store("list_filter_tenant") else {
+        eprintln!("skip mysql list filter test: CURVINE_TRANSFER_MYSQL_URL is not set");
+        return;
+    };
+    let mut flink = job("flink");
+    flink.submitter = "flink".to_string();
+    flink.tenant = "tenant-a".to_string();
+    flink.updated_at = 30;
+    store.create_or_get_by_request_id(flink).unwrap();
+
+    let mut starrocks = job("starrocks");
+    starrocks.submitter = "starrocks".to_string();
+    starrocks.tenant = "tenant-b".to_string();
+    starrocks.updated_at = 20;
+    store.create_or_get_by_request_id(starrocks).unwrap();
+
+    let tenant_jobs = store
+        .list_transfers(curvine_common::state::TransferListFilter {
+            tenant: Some("tenant-a".to_string()),
+            limit: 10,
+            ..Default::default()
+        })
+        .unwrap();
+    assert_eq!(tenant_jobs.len(), 1);
+    assert_eq!(tenant_jobs[0].job_id, "flink");
+
+    let submitter_jobs = store
+        .list_transfers(curvine_common::state::TransferListFilter {
+            submitter: Some("starrocks".to_string()),
+            limit: 10,
+            ..Default::default()
+        })
+        .unwrap();
+    assert_eq!(submitter_jobs.len(), 1);
+    assert_eq!(submitter_jobs[0].job_id, "starrocks");
+
+    drop(store);
+    drop_mysql_database(&base_url, &db_name);
+}
+
+#[test]
+fn mysql_migrates_v2_schema_through_v3_and_v4() {
+    let base_url = match std::env::var("CURVINE_TRANSFER_MYSQL_URL") {
+        Ok(url) => url,
+        Err(_) => {
+            eprintln!("skip mysql v2 migration test: CURVINE_TRANSFER_MYSQL_URL is not set");
+            return;
+        }
+    };
+    let db_name = format!(
+        "cv_transfer_migrate_v2_{}_{}",
+        std::process::id(),
+        &Uuid::new_v4().simple().to_string()[..8]
+    );
+    create_mysql_database(&base_url, &db_name);
+    let separator = if base_url.contains('?') { '&' } else { '?' };
+    let store_url = format!(
+        "{}/{}{}pool_min=0&pool_max=1",
+        base_url.trim_end_matches('/'),
+        db_name,
+        separator
+    );
+    let pool = mysql::Pool::new(store_url.as_str()).unwrap();
+    let mut conn = pool.get_conn().unwrap();
+    conn.query_drop(
+        "create table transfer_schema_version (
+            id tinyint unsigned primary key,
+            version bigint unsigned not null,
+            updated_at bigint not null
+        )",
+    )
+    .unwrap();
+    conn.query_drop(
+        "insert into transfer_schema_version(id, version, updated_at) values (1, 2, 1)",
+    )
+    .unwrap();
+    conn.query_drop(
+        "create table transfer_jobs (
+            job_id varchar(128) primary key,
+            submitter varchar(255) not null,
+            client_request_id varchar(255) not null,
+            job_key varchar(1024) not null,
+            run_id bigint unsigned not null,
+            kind int not null,
+            state int not null,
+            owner varchar(255) not null,
+            lease_epoch bigint unsigned not null,
+            lease_expire_at bigint not null,
+            cancel_requested tinyint not null,
+            record_json longtext not null,
+            created_at bigint not null,
+            updated_at bigint not null,
+            unique key transfer_jobs_request_idx(submitter, client_request_id)
+        )",
+    )
+    .unwrap();
+    let mut legacy = job("legacy-v2");
+    legacy.submitter = "legacy-submitter".to_string();
+    legacy.tenant = "legacy-tenant".to_string();
+    legacy.target_path = "/legacy-target".to_string();
+    legacy.job_key = format!("Load:{}:{}", legacy.source_path, legacy.target_path);
+    let legacy_json = serde_json::to_string(&legacy).unwrap();
+    conn.exec_drop(
+        "insert into transfer_jobs (
+            job_id, submitter, client_request_id, job_key, run_id, kind, state,
+            owner, lease_epoch, lease_expire_at, cancel_requested, record_json, created_at, updated_at
+        ) values (
+            :job_id, :submitter, :client_request_id, :job_key, :run_id, :kind, :state,
+            :owner, :lease_epoch, :lease_expire_at, :cancel_requested, :record_json, :created_at, :updated_at
+        )",
+        params! {
+            "job_id" => &legacy.job_id,
+            "submitter" => &legacy.submitter,
+            "client_request_id" => &legacy.client_request_id,
+            "job_key" => &legacy.job_key,
+            "run_id" => legacy.run_id,
+            "kind" => legacy.kind as i32,
+            "state" => legacy.state as i32,
+            "owner" => &legacy.owner,
+            "lease_epoch" => legacy.lease_epoch,
+            "lease_expire_at" => legacy.lease_expire_at,
+            "cancel_requested" => legacy.cancel_requested,
+            "record_json" => legacy_json,
+            "created_at" => legacy.created_at,
+            "updated_at" => legacy.updated_at,
+        },
+    )
+    .unwrap();
+    drop(conn);
+
+    let store = MysqlTransferStore::open(&store_url).unwrap();
+    let migrated = store.get_transfer("legacy-v2").unwrap().unwrap();
+    assert_eq!(migrated.target_path, "/legacy-target");
+    let tenant_jobs = store
+        .list_transfers(curvine_common::state::TransferListFilter {
+            tenant: Some("legacy-tenant".to_string()),
+            limit: 10,
+            ..Default::default()
+        })
+        .unwrap();
+    assert_eq!(tenant_jobs.len(), 1);
+    assert_eq!(tenant_jobs[0].job_id, "legacy-v2");
+    assert!(store
+        .find_conflicting_active_transfer("/legacy-target/child", "other", "other-req")
+        .unwrap()
+        .is_some());
+
+    let mut conn = pool.get_conn().unwrap();
+    let version: u64 = conn
+        .exec_first(
+            "select version from transfer_schema_version where id = 1",
+            mysql::Params::Empty,
+        )
+        .unwrap()
+        .unwrap();
+    assert_eq!(version, 4);
+    assert!(mysql_column_exists(
+        &mut conn,
+        "transfer_jobs",
+        "target_path"
+    ));
+    assert!(mysql_column_exists(&mut conn, "transfer_jobs", "tenant"));
+
+    drop(store);
+    drop(conn);
+    drop_mysql_database(&base_url, &db_name);
+}
+
+#[test]
+fn mysql_migrates_v3_schema_and_backfills_tenant() {
+    let base_url = match std::env::var("CURVINE_TRANSFER_MYSQL_URL") {
+        Ok(url) => url,
+        Err(_) => {
+            eprintln!("skip mysql v3 migration test: CURVINE_TRANSFER_MYSQL_URL is not set");
+            return;
+        }
+    };
+    let db_name = format!(
+        "cv_transfer_migrate_v3_{}_{}",
+        std::process::id(),
+        &Uuid::new_v4().simple().to_string()[..8]
+    );
+    create_mysql_database(&base_url, &db_name);
+    let separator = if base_url.contains('?') { '&' } else { '?' };
+    let store_url = format!(
+        "{}/{}{}pool_min=0&pool_max=1",
+        base_url.trim_end_matches('/'),
+        db_name,
+        separator
+    );
+    let pool = mysql::Pool::new(store_url.as_str()).unwrap();
+    let mut conn = pool.get_conn().unwrap();
+    conn.query_drop(
+        "create table transfer_schema_version (
+            id tinyint unsigned primary key,
+            version bigint unsigned not null,
+            updated_at bigint not null
+        )",
+    )
+    .unwrap();
+    conn.query_drop(
+        "insert into transfer_schema_version(id, version, updated_at) values (1, 3, 1)",
+    )
+    .unwrap();
+    conn.query_drop(
+        "create table transfer_jobs (
+            job_id varchar(128) primary key,
+            submitter varchar(255) not null,
+            client_request_id varchar(255) not null,
+            job_key varchar(1024) not null,
+            target_path varchar(2048) not null,
+            run_id bigint unsigned not null,
+            kind int not null,
+            state int not null,
+            owner varchar(255) not null,
+            lease_epoch bigint unsigned not null,
+            lease_expire_at bigint not null,
+            cancel_requested tinyint not null,
+            record_json longtext not null,
+            created_at bigint not null,
+            updated_at bigint not null,
+            unique key transfer_jobs_request_idx(submitter, client_request_id)
+        )",
+    )
+    .unwrap();
+    let mut legacy = job("legacy");
+    legacy.submitter = "legacy-submitter".to_string();
+    legacy.tenant = "legacy-tenant".to_string();
+    let legacy_json = serde_json::to_string(&legacy).unwrap();
+    conn.exec_drop(
+        "insert into transfer_jobs (
+            job_id, submitter, client_request_id, job_key, target_path, run_id, kind, state,
+            owner, lease_epoch, lease_expire_at, cancel_requested, record_json, created_at, updated_at
+        ) values (
+            :job_id, :submitter, :client_request_id, :job_key, :target_path, :run_id, :kind, :state,
+            :owner, :lease_epoch, :lease_expire_at, :cancel_requested, :record_json, :created_at, :updated_at
+        )",
+        params! {
+            "job_id" => &legacy.job_id,
+            "submitter" => &legacy.submitter,
+            "client_request_id" => &legacy.client_request_id,
+            "job_key" => &legacy.job_key,
+            "target_path" => &legacy.target_path,
+            "run_id" => legacy.run_id,
+            "kind" => legacy.kind as i32,
+            "state" => legacy.state as i32,
+            "owner" => &legacy.owner,
+            "lease_epoch" => legacy.lease_epoch,
+            "lease_expire_at" => legacy.lease_expire_at,
+            "cancel_requested" => legacy.cancel_requested,
+            "record_json" => legacy_json,
+            "created_at" => legacy.created_at,
+            "updated_at" => legacy.updated_at,
+        },
+    )
+    .unwrap();
+    drop(conn);
+
+    let store = MysqlTransferStore::open(&store_url).unwrap();
+    let tenant_jobs = store
+        .list_transfers(curvine_common::state::TransferListFilter {
+            tenant: Some("legacy-tenant".to_string()),
+            limit: 10,
+            ..Default::default()
+        })
+        .unwrap();
+    assert_eq!(tenant_jobs.len(), 1);
+    assert_eq!(tenant_jobs[0].job_id, "legacy");
+
+    drop(store);
+    drop_mysql_database(&base_url, &db_name);
+}
+
+#[test]
+fn mysql_rejects_future_schema_without_creating_current_tables() {
+    let base_url = match std::env::var("CURVINE_TRANSFER_MYSQL_URL") {
+        Ok(url) => url,
+        Err(_) => {
+            eprintln!("skip mysql future schema test: CURVINE_TRANSFER_MYSQL_URL is not set");
+            return;
+        }
+    };
+    let db_name = format!(
+        "cv_transfer_future_schema_{}_{}",
+        std::process::id(),
+        &Uuid::new_v4().simple().to_string()[..8]
+    );
+    create_mysql_database(&base_url, &db_name);
+    let separator = if base_url.contains('?') { '&' } else { '?' };
+    let store_url = format!(
+        "{}/{}{}pool_min=0&pool_max=1",
+        base_url.trim_end_matches('/'),
+        db_name,
+        separator
+    );
+    let pool = mysql::Pool::new(store_url.as_str()).unwrap();
+    let mut conn = pool.get_conn().unwrap();
+    conn.query_drop(
+        "create table transfer_schema_version (
+            id tinyint unsigned primary key,
+            version bigint unsigned not null,
+            updated_at bigint not null
+        )",
+    )
+    .unwrap();
+    conn.query_drop(
+        "insert into transfer_schema_version(id, version, updated_at) values (1, 999, 1)",
+    )
+    .unwrap();
+    drop(conn);
+
+    let err = match MysqlTransferStore::open(&store_url) {
+        Ok(_) => panic!("future mysql schema unexpectedly opened"),
+        Err(err) => err.to_string(),
+    };
+    assert!(
+        err.contains("Unsupported mysql transfer schema version 999"),
+        "unexpected error: {err}"
+    );
+
+    let mut conn = pool.get_conn().unwrap();
+    assert!(!mysql_table_exists(&mut conn, "transfer_jobs"));
+    assert!(!mysql_table_exists(&mut conn, "transfer_tasks"));
+    drop(conn);
+    drop_mysql_database(&base_url, &db_name);
+}
+
+fn mysql_table_exists(conn: &mut mysql::PooledConn, table: &str) -> bool {
+    conn.exec_first::<String, _, _>(
+        "select table_name from information_schema.tables
+         where table_schema = database() and table_name = :table",
+        params! {
+            "table" => table,
+        },
+    )
+    .unwrap()
+    .is_some()
+}
+
+fn mysql_column_exists(conn: &mut mysql::PooledConn, table: &str, column: &str) -> bool {
+    conn.exec_first::<String, _, _>(
+        "select column_name from information_schema.columns
+         where table_schema = database()
+           and table_name = :table
+           and column_name = :column",
+        params! {
+            "table" => table,
+            "column" => column,
+        },
+    )
+    .unwrap()
+    .is_some()
+}
+
+#[test]
+fn mysql_acquire_enforces_execution_window_across_concurrent_store_handles() {
+    let Some((store, store_url, base_url, db_name)) = mysql_store("concurrent_acquire") else {
+        eprintln!("skip mysql concurrent acquire test: CURVINE_TRANSFER_MYSQL_URL is not set");
+        return;
+    };
+
+    for index in 0..8 {
+        store
+            .create_or_get_by_request_id(job(&format!("pending-{index}")))
+            .unwrap();
+    }
+    drop(store);
+
+    let workers = 8;
+    let barrier = Arc::new(Barrier::new(workers));
+    let mut handles = Vec::new();
+    for index in 0..workers {
+        let barrier = barrier.clone();
+        let store_url = store_url.clone();
+        handles.push(thread::spawn(move || {
+            let store = MysqlTransferStore::open(&store_url).unwrap();
+            barrier.wait();
+            store
+                .acquire_runnable_transfer(&format!("owner-{index}"), 1000, 10, 1)
+                .unwrap()
+                .map(|lease| lease.job_id)
+        }));
+    }
+
+    let acquired: Vec<_> = handles
+        .into_iter()
+        .filter_map(|handle| handle.join().unwrap())
+        .collect();
+    assert_eq!(
+        acquired.len(),
+        1,
+        "only one pending job may enter the execution window"
+    );
+
+    let reopened = MysqlTransferStore::open(&store_url).unwrap();
+    assert_eq!(reopened.count_active_transfers().unwrap(), 8);
+    assert_eq!(reopened.count_executing_transfers().unwrap(), 1);
+    let jobs = reopened
+        .list_transfers(curvine_common::state::TransferListFilter {
+            kind: None,
+            state: None,
+            limit: 100,
+            offset: 0,
+            ..Default::default()
+        })
+        .unwrap();
+    assert_eq!(
+        jobs.iter()
+            .filter(|job| job.state == TransferState::Planning)
+            .count(),
+        1
+    );
+    assert_eq!(
+        jobs.iter()
+            .filter(|job| job.state == TransferState::Pending)
+            .count(),
+        7
+    );
+
+    drop(reopened);
+    drop_mysql_database(&base_url, &db_name);
+}
+
+#[test]
+fn mysql_submit_accepts_concurrent_unique_backlog() {
+    let Some((store, store_url, base_url, db_name)) = mysql_store("submit_backlog") else {
+        eprintln!("skip mysql submit backlog test: CURVINE_TRANSFER_MYSQL_URL is not set");
+        return;
+    };
+    let workers = 8;
+    let jobs_per_worker = 8;
+    let service = Arc::new(TransferService::new(Arc::new(store)));
+    let barrier = Arc::new(Barrier::new(workers));
+
+    let handles = (0..workers)
+        .map(|worker| {
+            let service = service.clone();
+            let barrier = barrier.clone();
+            thread::spawn(move || {
+                barrier.wait();
+                for index in 0..jobs_per_worker {
+                    let request_id = format!("submit-backlog-{worker}-{index}");
+                    service
+                        .submit_transfer(SubmitTransferRequest {
+                            kind: TransferKindProto::TransferLoad as i32,
+                            source_path: format!("s3://bucket/{request_id}"),
+                            target_path: format!("/submit-backlog/{worker}/{index}"),
+                            client_request_id: request_id,
+                            submitter: "mysql-test".to_string(),
+                            tenant: "default".to_string(),
+                            command: Vec::new(),
+                            protocol_version: Some(1),
+                        })
+                        .unwrap();
+                }
+            })
+        })
+        .collect::<Vec<_>>();
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    drop(service);
+    let reopened = MysqlTransferStore::open(&store_url).unwrap();
+    assert_eq!(
+        reopened.count_active_transfers().unwrap(),
+        (workers * jobs_per_worker) as u64
+    );
+    drop(reopened);
+    drop_mysql_database(&base_url, &db_name);
+}
+
+#[test]
+fn mysql_submit_is_atomic_for_concurrent_idempotent_request() {
+    let Some((store, store_url, base_url, db_name)) = mysql_store("submit_idempotent") else {
+        eprintln!("skip mysql submit idempotent test: CURVINE_TRANSFER_MYSQL_URL is not set");
+        return;
+    };
+    let workers = 16;
+    let service = Arc::new(TransferService::new(Arc::new(store)));
+    let barrier = Arc::new(Barrier::new(workers));
+
+    let handles = (0..workers)
+        .map(|_| {
+            let service = service.clone();
+            let barrier = barrier.clone();
+            thread::spawn(move || {
+                barrier.wait();
+                service
+                    .submit_transfer(SubmitTransferRequest {
+                        kind: TransferKindProto::TransferLoad as i32,
+                        source_path: "s3://bucket/idempotent".to_string(),
+                        target_path: "/submit-idempotent".to_string(),
+                        client_request_id: "same-request".to_string(),
+                        submitter: "mysql-test".to_string(),
+                        tenant: "default".to_string(),
+                        command: Vec::new(),
+                        protocol_version: Some(1),
+                    })
+                    .unwrap()
+                    .job_id
+            })
+        })
+        .collect::<Vec<_>>();
+    let job_ids = handles
+        .into_iter()
+        .map(|handle| handle.join().unwrap())
+        .collect::<Vec<_>>();
+
+    assert!(job_ids.windows(2).all(|pair| pair[0] == pair[1]));
+    drop(service);
+    let reopened = MysqlTransferStore::open(&store_url).unwrap();
+    assert_eq!(reopened.count_active_transfers().unwrap(), 1);
+    drop(reopened);
+    drop_mysql_database(&base_url, &db_name);
+}
+
+#[test]
+fn mysql_submit_is_atomic_for_concurrent_target_conflict() {
+    let Some((store, store_url, base_url, db_name)) = mysql_store("submit_target_conflict") else {
+        eprintln!("skip mysql submit target conflict test: CURVINE_TRANSFER_MYSQL_URL is not set");
+        return;
+    };
+    let workers = 16;
+    let service = Arc::new(TransferService::new(Arc::new(store)));
+    let barrier = Arc::new(Barrier::new(workers));
+
+    let handles = (0..workers)
+        .map(|worker| {
+            let service = service.clone();
+            let barrier = barrier.clone();
+            thread::spawn(move || {
+                barrier.wait();
+                service.submit_transfer(SubmitTransferRequest {
+                    kind: TransferKindProto::TransferLoad as i32,
+                    source_path: format!("s3://bucket/conflict-{worker}"),
+                    target_path: "/submit-conflict".to_string(),
+                    client_request_id: format!("conflict-request-{worker}"),
+                    submitter: "mysql-test".to_string(),
+                    tenant: "default".to_string(),
+                    command: Vec::new(),
+                    protocol_version: Some(1),
+                })
+            })
+        })
+        .collect::<Vec<_>>();
+    let results = handles
+        .into_iter()
+        .map(|handle| handle.join().unwrap())
+        .collect::<Vec<_>>();
+
+    let accepted = results.iter().filter(|result| result.is_ok()).count();
+    let rejected = results
+        .iter()
+        .filter(|result| match result {
+            Ok(_) => false,
+            Err(err) => matches!(err.kind(), ErrorKind::TransferTargetConflict),
+        })
+        .count();
+    assert_eq!(accepted, 1);
+    assert_eq!(rejected, workers - 1);
+
+    drop(service);
+    let reopened = MysqlTransferStore::open(&store_url).unwrap();
+    assert_eq!(reopened.count_active_transfers().unwrap(), 1);
+    drop(reopened);
+    drop_mysql_database(&base_url, &db_name);
+}
+
+#[test]
+fn mysql_submit_is_atomic_for_concurrent_parent_child_target_conflict() {
+    let Some((store, store_url, base_url, db_name)) = mysql_store("submit_parent_child_conflict")
+    else {
+        eprintln!(
+            "skip mysql submit parent child conflict test: CURVINE_TRANSFER_MYSQL_URL is not set"
+        );
+        return;
+    };
+    let workers = 16;
+    let service = Arc::new(TransferService::new(Arc::new(store)));
+    let barrier = Arc::new(Barrier::new(workers));
+
+    let handles = (0..workers)
+        .map(|worker| {
+            let service = service.clone();
+            let barrier = barrier.clone();
+            thread::spawn(move || {
+                barrier.wait();
+                let target_path = if worker % 2 == 0 {
+                    "/submit-parent-child".to_string()
+                } else {
+                    "/submit-parent-child/child".to_string()
+                };
+                service.submit_transfer(SubmitTransferRequest {
+                    kind: TransferKindProto::TransferLoad as i32,
+                    source_path: format!("s3://bucket/parent-child-{worker}"),
+                    target_path,
+                    client_request_id: format!("parent-child-request-{worker}"),
+                    submitter: "mysql-test".to_string(),
+                    tenant: "default".to_string(),
+                    command: Vec::new(),
+                    protocol_version: Some(1),
+                })
+            })
+        })
+        .collect::<Vec<_>>();
+    let results = handles
+        .into_iter()
+        .map(|handle| handle.join().unwrap())
+        .collect::<Vec<_>>();
+
+    let accepted = results.iter().filter(|result| result.is_ok()).count();
+    let rejected = results
+        .iter()
+        .filter(|result| match result {
+            Ok(_) => false,
+            Err(err) => matches!(err.kind(), ErrorKind::TransferTargetConflict),
+        })
+        .count();
+    assert_eq!(accepted, 1);
+    assert_eq!(rejected, workers - 1);
+
+    drop(service);
+    let reopened = MysqlTransferStore::open(&store_url).unwrap();
+    assert_eq!(reopened.count_active_transfers().unwrap(), 1);
+    drop(reopened);
+    drop_mysql_database(&base_url, &db_name);
+}
+
+#[test]
+fn mysql_target_conflict_detects_deep_ancestor_without_reverse_like() {
+    let Some((store, _store_url, base_url, db_name)) = mysql_store("deep_ancestor_conflict") else {
+        eprintln!("skip mysql deep ancestor conflict test: CURVINE_TRANSFER_MYSQL_URL is not set");
+        return;
+    };
+    let mut parent = job("parent");
+    parent.target_path = "/a/b".to_string();
+    parent.job_key = "Load:s3://bucket/parent:/a/b".to_string();
+    store.create_or_get_by_request_id(parent).unwrap();
+
+    let conflict = store
+        .find_conflicting_active_transfer("/a/b/c/d", "test", "req-other")
+        .unwrap()
+        .expect("deep child target should conflict with active ancestor target");
+    assert_eq!(conflict.job_id, "parent");
+
+    drop(store);
+    drop_mysql_database(&base_url, &db_name);
+}
+
+#[test]
+fn mysql_rejects_same_job_key_with_different_command() {
+    let Some((store, _store_url, base_url, db_name)) = mysql_store("already_running") else {
+        eprintln!("skip mysql already running test: CURVINE_TRANSFER_MYSQL_URL is not set");
+        return;
+    };
+    store.create_or_get_by_request_id(job("first")).unwrap();
+
+    let mut second = job("second");
+    second.job_key = "Load:s3://bucket/first:/first".to_string();
+    second.source_path = "s3://bucket/first".to_string();
+    second.target_path = "/first".to_string();
+    second.client_request_id = "req-second".to_string();
+    second.command_json = "{\"overwrite\":true}".to_string();
+
+    let err = store.create_or_get_by_request_id(second).unwrap_err();
+    assert!(matches!(err.kind(), ErrorKind::TransferAlreadyRunning));
+
+    drop(store);
+    drop_mysql_database(&base_url, &db_name);
+}
+
+#[test]
+fn mysql_service_returns_store_error_when_database_disappears_at_runtime() {
+    let Some((store, store_url, base_url, db_name)) = mysql_store("runtime_unavailable") else {
+        eprintln!("skip mysql runtime unavailable test: CURVINE_TRANSFER_MYSQL_URL is not set");
+        return;
+    };
+    let service = TransferService::new(Arc::new(TransferStoreBackend::Mysql(store)));
+
+    drop_mysql_database(&base_url, &db_name);
+
+    let err = service
+        .submit_transfer(SubmitTransferRequest {
+            kind: TransferKindProto::TransferLoad as i32,
+            source_path: "s3://bucket/runtime-unavailable".to_string(),
+            target_path: "/runtime-unavailable".to_string(),
+            client_request_id: "runtime-unavailable".to_string(),
+            submitter: "mysql-test".to_string(),
+            tenant: "default".to_string(),
+            command: Vec::new(),
+            protocol_version: Some(1),
+        })
+        .unwrap_err();
+    assert!(matches!(err.kind(), ErrorKind::TransferStoreUnavailable));
+    let err = err.to_string();
+    assert!(
+        err.contains("transfer_jobs")
+            || err.contains("Unknown database")
+            || err.contains("doesn't exist")
+            || err.contains("No database selected"),
+        "unexpected runtime store error: {err}"
+    );
+    let unavailable_metrics = Metrics::text_output().unwrap();
+    assert_eq!(
+        metric_value(
+            &unavailable_metrics,
+            "transfer_store_unavailable",
+            &["backend=\"mysql\""]
+        ),
+        Some(1.0)
+    );
+    assert!(
+        metric_value(
+            &unavailable_metrics,
+            "transfer_store_unavailable_total",
+            &["backend=\"mysql\""]
+        )
+        .unwrap_or_default()
+            >= 1.0
+    );
+
+    create_mysql_database(&base_url, &db_name);
+    let restored_store = MysqlTransferStore::open(&store_url).unwrap();
+    drop(restored_store);
+
+    let recovered = service
+        .submit_transfer(SubmitTransferRequest {
+            kind: TransferKindProto::TransferLoad as i32,
+            source_path: "s3://bucket/runtime-recovered".to_string(),
+            target_path: "/runtime-recovered".to_string(),
+            client_request_id: "runtime-recovered".to_string(),
+            submitter: "mysql-test".to_string(),
+            tenant: "default".to_string(),
+            command: Vec::new(),
+            protocol_version: Some(1),
+        })
+        .unwrap();
+    assert_eq!(recovered.target_path, "/runtime-recovered");
+
+    let reopened = MysqlTransferStore::open(&store_url).unwrap();
+    assert_eq!(reopened.count_active_transfers().unwrap(), 1);
+    assert!(reopened.get_transfer(&recovered.job_id).unwrap().is_some());
+    let recovered_metrics = Metrics::text_output().unwrap();
+    assert!(
+        metric_value(
+            &recovered_metrics,
+            "transfer_store_unavailable_duration_us_total",
+            &["backend=\"mysql\""]
+        )
+        .unwrap_or_default()
+            > 0.0
+    );
+
+    let conflict = service
+        .submit_transfer(SubmitTransferRequest {
+            kind: TransferKindProto::TransferLoad as i32,
+            source_path: "s3://bucket/runtime-conflict".to_string(),
+            target_path: "/runtime-recovered".to_string(),
+            client_request_id: "runtime-conflict".to_string(),
+            submitter: "mysql-test".to_string(),
+            tenant: "default".to_string(),
+            command: Vec::new(),
+            protocol_version: Some(1),
+        })
+        .unwrap_err();
+    assert!(
+        matches!(conflict.kind(), ErrorKind::TransferTargetConflict),
+        "unexpected conflict error: {conflict}"
+    );
+    drop_mysql_database(&base_url, &db_name);
+}

--- a/curvine-server/tests/transfer/planner_test.rs
+++ b/curvine-server/tests/transfer/planner_test.rs
@@ -1,0 +1,274 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use curvine_client::file::CurvineFileSystem;
+use curvine_common::conf::{ClientConf, ClusterConf};
+use curvine_common::error::FsError;
+use curvine_common::fs::Path;
+use curvine_common::state::{
+    FileBlocks, FileStatus, MountOptions, TransferJobRecord, TransferKind, TransferProgress,
+    TransferState,
+};
+use curvine_common::FsResult;
+use curvine_server::common::UfsFactory;
+use curvine_server::transfer::{ClusterMetadataCache, CvMetadataReader, TransferPlanner};
+use futures::future::BoxFuture;
+use orpc::runtime::{AsyncRuntime, RpcRuntime};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+#[test]
+fn export_planning_retries_on_metadata_replica_epoch_change() {
+    let rt = Arc::new(AsyncRuntime::single());
+    let fs = CurvineFileSystem::with_rt(ClusterConf::default(), rt.clone()).unwrap();
+    let reader = Arc::new(EpochChangingReader {
+        epoch: AtomicU64::new(1),
+    });
+    let planner = TransferPlanner::new(
+        reader,
+        Arc::new(UfsFactory::with_rt(&ClientConf::default(), rt.clone())),
+        ClusterMetadataCache::new(fs),
+        ClientConf::default(),
+        10,
+        1,
+    );
+    let planned = rt.block_on(planner.plan(&export_job())).unwrap();
+    assert_eq!(planned.cv_metadata_epoch, Some(2));
+    assert_eq!(planned.tasks.len(), 1);
+}
+
+#[test]
+fn export_planning_uses_persisted_metadata_epoch() {
+    let rt = Arc::new(AsyncRuntime::single());
+    let mut job = export_job();
+    job.cv_metadata_epoch = Some(1);
+    let planner = export_planner(rt.clone(), Arc::new(RetainedEpochReader));
+    let planned = rt.block_on(planner.plan(&job)).unwrap();
+    assert_eq!(planned.cv_metadata_epoch, Some(1));
+    assert_eq!(planned.tasks.len(), 1);
+}
+
+#[test]
+fn export_missing_source_requeues_until_replica_covers_job_create_time() {
+    let rt = Arc::new(AsyncRuntime::single());
+    let planner = export_planner(rt.clone(), Arc::new(MissingSourceReader { covers: false }));
+    let err = match rt.block_on(planner.plan(&export_job())) {
+        Ok(_) => panic!("missing source before replica watermark should not plan successfully"),
+        Err(err) => err,
+    };
+    assert!(
+        matches!(err, FsError::InProgress(_)),
+        "missing source before replica watermark should requeue planning, got {err}"
+    );
+}
+
+#[test]
+fn export_missing_source_fails_after_replica_covers_job_create_time() {
+    let rt = Arc::new(AsyncRuntime::single());
+    let planner = export_planner(rt.clone(), Arc::new(MissingSourceReader { covers: true }));
+    let err = match rt.block_on(planner.plan(&export_job())) {
+        Ok(_) => panic!("missing source after replica watermark should not plan successfully"),
+        Err(err) => err,
+    };
+    assert!(
+        matches!(err, FsError::FileNotFound(_)),
+        "missing source after replica watermark should be real FileNotFound, got {err}"
+    );
+}
+
+fn export_planner(
+    rt: Arc<orpc::runtime::Runtime>,
+    reader: Arc<dyn CvMetadataReader>,
+) -> TransferPlanner {
+    let fs = CurvineFileSystem::with_rt(ClusterConf::default(), rt.clone()).unwrap();
+    TransferPlanner::new(
+        reader,
+        Arc::new(UfsFactory::with_rt(&ClientConf::default(), rt.clone())),
+        ClusterMetadataCache::new(fs),
+        ClientConf::default(),
+        10,
+        1,
+    )
+}
+
+fn export_job() -> TransferJobRecord {
+    let mount = MountOptions::builder()
+        .build()
+        .to_info(1, "/dst", "file:///tmp/transfer-target");
+    TransferJobRecord {
+        job_key: "Export:/src:file:///tmp/transfer-target".to_string(),
+        job_id: "job-export-epoch".to_string(),
+        run_id: 1,
+        kind: TransferKind::Export,
+        source_path: "/src".to_string(),
+        target_path: "file:///tmp/transfer-target".to_string(),
+        command_json: "{}".to_string(),
+        mount_snapshot_json: serde_json::to_string(&mount).unwrap(),
+        secret_ref_json: "{}".to_string(),
+        cluster_snapshot_version: 1,
+        cv_metadata_epoch: None,
+        state: TransferState::Planning,
+        owner: "owner-a".to_string(),
+        lease_epoch: 1,
+        lease_expire_at: 0,
+        cancel_requested: false,
+        summary: TransferProgress::default(),
+        client_request_id: "request-export-epoch".to_string(),
+        submitter: "test".to_string(),
+        tenant: "default".to_string(),
+        created_at: 1,
+        updated_at: 1,
+    }
+}
+
+struct MissingSourceReader {
+    covers: bool,
+}
+
+impl CvMetadataReader for MissingSourceReader {
+    fn current_epoch(&self) -> FsResult<Option<u64>> {
+        Ok(Some(1))
+    }
+
+    fn covers_time_ms(&self, _time_ms: i64) -> FsResult<bool> {
+        Ok(self.covers)
+    }
+
+    fn get_status<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, FsResult<FileStatus>> {
+        Box::pin(async move { Err(FsError::file_not_found(path.full_path())) })
+    }
+
+    fn list_status<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, FsResult<Vec<FileStatus>>> {
+        Box::pin(async move { Err(FsError::file_not_found(path.full_path())) })
+    }
+
+    fn get_block_locations<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, FsResult<FileBlocks>> {
+        Box::pin(async move { Err(FsError::file_not_found(path.full_path())) })
+    }
+}
+
+struct EpochChangingReader {
+    epoch: AtomicU64,
+}
+
+impl EpochChangingReader {
+    fn dir(path: &str) -> FileStatus {
+        let mut status = FileStatus::with_name(1, path.to_string(), true);
+        status.path = path.to_string();
+        status
+    }
+
+    fn file(path: &str) -> FileStatus {
+        let mut status = FileStatus::with_name(2, path.to_string(), false);
+        status.path = path.to_string();
+        status.is_complete = true;
+        status.len = 4;
+        status
+    }
+}
+
+impl CvMetadataReader for EpochChangingReader {
+    fn current_epoch(&self) -> FsResult<Option<u64>> {
+        Ok(Some(self.epoch.load(Ordering::SeqCst)))
+    }
+
+    fn get_status<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, FsResult<FileStatus>> {
+        Box::pin(async move { Ok(Self::dir(path.path())) })
+    }
+
+    fn list_status<'a>(&'a self, _path: &'a Path) -> BoxFuture<'a, FsResult<Vec<FileStatus>>> {
+        Box::pin(async move { Ok(vec![Self::file("/src/file.txt")]) })
+    }
+
+    fn get_block_locations<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, FsResult<FileBlocks>> {
+        Box::pin(async move {
+            self.epoch.store(2, Ordering::SeqCst);
+            Ok(FileBlocks::new(Self::file(path.path()), Vec::new()))
+        })
+    }
+}
+
+struct RetainedEpochReader;
+
+impl RetainedEpochReader {
+    fn dir(path: &str) -> FileStatus {
+        EpochChangingReader::dir(path)
+    }
+
+    fn file(path: &str) -> FileStatus {
+        EpochChangingReader::file(path)
+    }
+
+    fn require_epoch(epoch: Option<u64>) -> FsResult<()> {
+        if epoch == Some(1) {
+            Ok(())
+        } else {
+            Err(FsError::common(format!(
+                "expected retained epoch 1, got {:?}",
+                epoch
+            )))
+        }
+    }
+}
+
+impl CvMetadataReader for RetainedEpochReader {
+    fn current_epoch(&self) -> FsResult<Option<u64>> {
+        Ok(Some(2))
+    }
+
+    fn get_status<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, FsResult<FileStatus>> {
+        self.get_status_at_epoch(path, None)
+    }
+
+    fn get_status_at_epoch<'a>(
+        &'a self,
+        path: &'a Path,
+        epoch: Option<u64>,
+    ) -> BoxFuture<'a, FsResult<FileStatus>> {
+        Box::pin(async move {
+            Self::require_epoch(epoch)?;
+            Ok(Self::dir(path.path()))
+        })
+    }
+
+    fn list_status<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, FsResult<Vec<FileStatus>>> {
+        self.list_status_at_epoch(path, None)
+    }
+
+    fn list_status_at_epoch<'a>(
+        &'a self,
+        _path: &'a Path,
+        epoch: Option<u64>,
+    ) -> BoxFuture<'a, FsResult<Vec<FileStatus>>> {
+        Box::pin(async move {
+            Self::require_epoch(epoch)?;
+            Ok(vec![Self::file("/src/file.txt")])
+        })
+    }
+
+    fn get_block_locations<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, FsResult<FileBlocks>> {
+        self.get_block_locations_at_epoch(path, None)
+    }
+
+    fn get_block_locations_at_epoch<'a>(
+        &'a self,
+        path: &'a Path,
+        epoch: Option<u64>,
+    ) -> BoxFuture<'a, FsResult<FileBlocks>> {
+        Box::pin(async move {
+            Self::require_epoch(epoch)?;
+            Ok(FileBlocks::new(Self::file(path.path()), Vec::new()))
+        })
+    }
+}

--- a/curvine-server/tests/transfer/sqlite_store_test.rs
+++ b/curvine-server/tests/transfer/sqlite_store_test.rs
@@ -1,0 +1,736 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use curvine_common::error::ErrorKind;
+use curvine_common::state::{
+    TaskAttemptStart, TransferCommand, TransferJobRecord, TransferKind, TransferListFilter,
+    TransferProgress, TransferState, TransferStateUpdate, TransferTaskRecord, TransferTaskReport,
+    TransferTaskState,
+};
+use curvine_server::transfer::{SqliteTransferStore, TransferStore};
+use rusqlite::{params, Connection};
+
+fn sqlite_store(name: &str) -> SqliteTransferStore {
+    let path = std::env::temp_dir().join(format!(
+        "curvine-transfer-{name}-{}-{}.db",
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    ));
+    SqliteTransferStore::open(path).unwrap()
+}
+
+fn job(job_id: &str) -> TransferJobRecord {
+    TransferJobRecord {
+        job_key: format!("Load:s3://bucket/{job_id}:/{job_id}"),
+        job_id: job_id.to_string(),
+        run_id: 1,
+        kind: TransferKind::Load,
+        source_path: format!("s3://bucket/{job_id}"),
+        target_path: format!("/{job_id}"),
+        command_json: "{}".to_string(),
+        mount_snapshot_json: "{}".to_string(),
+        secret_ref_json: "{}".to_string(),
+        cluster_snapshot_version: 1,
+        cv_metadata_epoch: None,
+        state: TransferState::Pending,
+        owner: String::new(),
+        lease_epoch: 0,
+        lease_expire_at: 0,
+        cancel_requested: false,
+        summary: TransferProgress::default(),
+        client_request_id: format!("req-{job_id}"),
+        submitter: "test".to_string(),
+        tenant: "default".to_string(),
+        created_at: 1,
+        updated_at: 1,
+    }
+}
+
+fn task(job_id: &str) -> TransferTaskRecord {
+    TransferTaskRecord {
+        job_id: job_id.to_string(),
+        run_id: 1,
+        task_id: "task-1".to_string(),
+        attempt_id: 0,
+        source_path: format!("s3://bucket/{job_id}"),
+        target_path: format!("/{job_id}"),
+        worker_id: 0,
+        worker_session_id: String::new(),
+        source_read_plan_json: String::new(),
+        report_target_json: String::new(),
+        state: TransferTaskState::Pending,
+        progress: TransferProgress::default(),
+        retry_count: 0,
+        attempt_started_at: 0,
+        last_report_at: 0,
+        stale_deadline_at: 0,
+        updated_at: 0,
+    }
+}
+
+#[test]
+fn sqlite_finds_conflicting_active_transfer_by_target_path() {
+    let store = sqlite_store("target-conflict");
+    let mut parent = job("parent");
+    parent.target_path = "/a".to_string();
+    store.create_or_get_by_request_id(parent).unwrap();
+
+    let conflict = store
+        .find_conflicting_active_transfer("/a/child", "test", "req-other")
+        .unwrap()
+        .expect("child target should conflict with active parent target");
+    assert_eq!(conflict.job_id, "parent");
+
+    let replay = store
+        .find_conflicting_active_transfer("/a", "test", "req-parent")
+        .unwrap();
+    assert!(
+        replay.is_none(),
+        "same submitter request should be treated as idempotent replay"
+    );
+}
+
+#[test]
+fn sqlite_root_target_conflicts_with_any_active_transfer() {
+    let store = sqlite_store("root-target-conflict");
+    let mut root = job("root");
+    root.target_path = "/".to_string();
+    store.create_or_get_by_request_id(root).unwrap();
+
+    let root_conflict = store
+        .find_conflicting_active_transfer("/any/path", "test", "req-third")
+        .unwrap()
+        .expect("root target should conflict with any target");
+    assert_eq!(root_conflict.job_id, "root");
+}
+
+#[test]
+fn sqlite_submit_rejects_root_when_child_target_is_active() {
+    let store = sqlite_store("child-before-root-conflict");
+    let mut parent = job("parent");
+    parent.target_path = "/a".to_string();
+    store.create_or_get_by_request_id(parent).unwrap();
+
+    let mut root = job("root");
+    root.target_path = "/".to_string();
+    let error = store.create_or_get_by_request_id(root).unwrap_err();
+    assert!(
+        matches!(error.kind(), ErrorKind::TransferTargetConflict),
+        "unexpected conflict error: {error}"
+    );
+}
+
+#[test]
+fn sqlite_target_conflict_detects_deep_ancestor_without_reverse_like() {
+    let store = sqlite_store("deep-ancestor-conflict");
+    let mut parent = job("parent");
+    parent.target_path = "/a/b".to_string();
+    store.create_or_get_by_request_id(parent).unwrap();
+
+    let conflict = store
+        .find_conflicting_active_transfer("/a/b/c/d", "test", "req-other")
+        .unwrap()
+        .expect("deep child target should conflict with active ancestor target");
+    assert_eq!(conflict.job_id, "parent");
+}
+
+#[test]
+fn sqlite_rejects_same_job_key_with_different_command() {
+    let store = sqlite_store("already-running");
+    store.create_or_get_by_request_id(job("first")).unwrap();
+
+    let mut second = job("second");
+    second.job_key = "Load:s3://bucket/first:/first".to_string();
+    second.source_path = "s3://bucket/first".to_string();
+    second.target_path = "/first".to_string();
+    second.client_request_id = "req-second".to_string();
+    second.command_json = "{\"overwrite\":true}".to_string();
+
+    let err = store.create_or_get_by_request_id(second).unwrap_err();
+    assert!(matches!(err.kind(), ErrorKind::TransferAlreadyRunning));
+}
+
+#[test]
+fn sqlite_report_requires_current_attempt_and_worker_session() {
+    let store = sqlite_store("report-session");
+    store.create_or_get_by_request_id(job("job-1")).unwrap();
+    store.insert_tasks(vec![task("job-1")]).unwrap();
+    let lease = store
+        .acquire_runnable_transfer("owner-a", 100, 10, 100)
+        .unwrap()
+        .unwrap();
+    assert!(store
+        .start_task_attempt(TaskAttemptStart {
+            job_id: "job-1".to_string(),
+            run_id: 1,
+            owner: lease.owner,
+            lease_epoch: lease.lease_epoch,
+            task_id: "task-1".to_string(),
+            attempt_id: 3,
+            worker_id: 10,
+            worker_session_id: "session-a".to_string(),
+            report_target_json: "{}".to_string(),
+            now_ms: 10,
+            stale_deadline_at: 70,
+        })
+        .unwrap());
+
+    let mut report = TransferTaskReport {
+        job_id: "job-1".to_string(),
+        run_id: 1,
+        task_id: "task-1".to_string(),
+        attempt_id: 3,
+        worker_id: 10,
+        worker_session_id: "session-old".to_string(),
+        state: TransferTaskState::Running,
+        progress: TransferProgress {
+            loaded_size: 1,
+            total_size: 10,
+            update_time: 20,
+            message: String::new(),
+        },
+        now_ms: 20,
+        stale_deadline_at: 80,
+    };
+    assert!(!store.update_task_report(report.clone()).unwrap());
+
+    report.worker_session_id = "session-a".to_string();
+    assert!(store.update_task_report(report).unwrap());
+}
+
+#[test]
+fn sqlite_start_task_attempt_rejects_cancel_requested_job() {
+    let store = sqlite_store("cancel-start");
+    store.create_or_get_by_request_id(job("job-1")).unwrap();
+    store.insert_tasks(vec![task("job-1")]).unwrap();
+    let lease = store
+        .acquire_runnable_transfer("owner-a", 100, 10, 100)
+        .unwrap()
+        .unwrap();
+    assert!(store.request_cancel("job-1", 1, 11).unwrap());
+    assert_eq!(
+        store.get_transfer("job-1").unwrap().unwrap().state,
+        TransferState::Canceling
+    );
+
+    assert!(!store
+        .start_task_attempt(TaskAttemptStart {
+            job_id: "job-1".to_string(),
+            run_id: 1,
+            owner: lease.owner,
+            lease_epoch: lease.lease_epoch,
+            task_id: "task-1".to_string(),
+            attempt_id: 1,
+            worker_id: 10,
+            worker_session_id: "session-a".to_string(),
+            report_target_json: "{}".to_string(),
+            now_ms: 12,
+            stale_deadline_at: 72,
+        })
+        .unwrap());
+
+    let task = store.list_transfer_tasks("job-1", 1).unwrap().remove(0);
+    assert_eq!(task.state, TransferTaskState::Pending);
+}
+
+#[test]
+fn sqlite_stale_attempt_requires_current_owner_and_epoch() {
+    let store = sqlite_store("stale-owner");
+    store.create_or_get_by_request_id(job("job-1")).unwrap();
+    store.insert_tasks(vec![task("job-1")]).unwrap();
+    let lease = store
+        .acquire_runnable_transfer("owner-a", 100, 10, 100)
+        .unwrap()
+        .unwrap();
+    assert!(store
+        .start_task_attempt(TaskAttemptStart {
+            job_id: "job-1".to_string(),
+            run_id: 1,
+            owner: lease.owner.clone(),
+            lease_epoch: lease.lease_epoch,
+            task_id: "task-1".to_string(),
+            attempt_id: 1,
+            worker_id: 10,
+            worker_session_id: "session-a".to_string(),
+            report_target_json: "{}".to_string(),
+            now_ms: 20,
+            stale_deadline_at: 30,
+        })
+        .unwrap());
+
+    let stale = store
+        .mark_stale_attempts("job-1", 1, "owner-b", lease.lease_epoch, 40, 10)
+        .unwrap();
+    assert!(stale.is_empty());
+
+    let stale = store
+        .mark_stale_attempts("job-1", 1, &lease.owner, lease.lease_epoch, 40, 10)
+        .unwrap();
+    assert_eq!(stale.len(), 1);
+    assert_eq!(stale[0].task.state, TransferTaskState::Stale);
+    assert_eq!(stale[0].task.retry_count, 1);
+}
+
+#[test]
+fn sqlite_lease_takeover_waits_for_expiry_and_blocks_stale_owner() {
+    let store = sqlite_store("lease-takeover");
+    store.create_or_get_by_request_id(job("job-1")).unwrap();
+
+    let lease_a = store
+        .acquire_runnable_transfer("owner-a", 100, 10, 100)
+        .unwrap()
+        .unwrap();
+    assert_eq!(lease_a.owner, "owner-a");
+    assert_eq!(lease_a.lease_epoch, 1);
+
+    let not_expired = store
+        .acquire_runnable_transfer("owner-b", 100, 50, 100)
+        .unwrap();
+    assert!(not_expired.is_none());
+
+    let lease_b = store
+        .acquire_runnable_transfer("owner-b", 100, 111, 100)
+        .unwrap()
+        .unwrap();
+    assert_eq!(lease_b.owner, "owner-b");
+    assert_eq!(lease_b.lease_epoch, 2);
+
+    let stale_owner_update = TransferStateUpdate {
+        job_id: lease_a.job_id.clone(),
+        run_id: lease_a.run_id,
+        owner: lease_a.owner,
+        lease_epoch: lease_a.lease_epoch,
+        from_states: vec![TransferState::Pending],
+        to_state: TransferState::Planning,
+        message: "stale owner should not update".to_string(),
+        now_ms: 120,
+    };
+    assert!(!store.update_transfer_state(stale_owner_update).unwrap());
+
+    let current_owner_update = TransferStateUpdate {
+        job_id: lease_b.job_id,
+        run_id: lease_b.run_id,
+        owner: lease_b.owner,
+        lease_epoch: lease_b.lease_epoch,
+        from_states: vec![TransferState::Planning],
+        to_state: TransferState::Planning,
+        message: "current owner may update".to_string(),
+        now_ms: 121,
+    };
+    assert!(store.update_transfer_state(current_owner_update).unwrap());
+}
+
+#[test]
+fn sqlite_counts_only_active_transfers_and_finds_request_id() {
+    let store = sqlite_store("active-count");
+    let active = store.create_or_get_by_request_id(job("active")).unwrap();
+    let mut completed = job("completed");
+    completed.state = TransferState::Completed;
+    store.create_or_get_by_request_id(completed).unwrap();
+
+    assert_eq!(store.count_active_transfers().unwrap(), 1);
+
+    let by_request = store
+        .get_transfer_by_request(&active.submitter, &active.client_request_id)
+        .unwrap()
+        .unwrap();
+    assert_eq!(by_request.job_id, active.job_id);
+}
+
+#[test]
+fn sqlite_acquire_keeps_pending_backlog_when_execution_window_is_full() {
+    let store = sqlite_store("execution-window");
+    store.create_or_get_by_request_id(job("pending")).unwrap();
+
+    let mut running = job("running");
+    running.state = TransferState::Running;
+    store.create_or_get_by_request_id(running).unwrap();
+
+    let lease = store
+        .acquire_runnable_transfer("owner-a", 100, 10, 1)
+        .unwrap()
+        .unwrap();
+    assert_eq!(lease.job_id, "running");
+    assert!(store
+        .acquire_runnable_transfer("owner-a", 100, 10, 1)
+        .unwrap()
+        .is_none());
+    assert_eq!(
+        store.get_transfer("pending").unwrap().unwrap().state,
+        TransferState::Pending
+    );
+}
+
+#[test]
+fn sqlite_acquire_pending_prefers_tenant_with_fewer_executing_jobs() {
+    let store = sqlite_store("tenant-fairness");
+
+    let mut running = job("running-noisy");
+    running.target_path = "/running-noisy".to_string();
+    running.job_key = "Load:s3://bucket/running-noisy:/running-noisy".to_string();
+    running.tenant = "noisy".to_string();
+    running.state = TransferState::Running;
+    running.owner = "owner-running".to_string();
+    running.lease_expire_at = 1_000;
+    running.updated_at = 10;
+    store.create_or_get_by_request_id(running).unwrap();
+
+    let mut noisy_pending = job("pending-noisy");
+    noisy_pending.target_path = "/pending-noisy".to_string();
+    noisy_pending.job_key = "Load:s3://bucket/pending-noisy:/pending-noisy".to_string();
+    noisy_pending.tenant = "noisy".to_string();
+    noisy_pending.updated_at = 1;
+    store.create_or_get_by_request_id(noisy_pending).unwrap();
+
+    let mut quiet_pending = job("pending-quiet");
+    quiet_pending.target_path = "/pending-quiet".to_string();
+    quiet_pending.job_key = "Load:s3://bucket/pending-quiet:/pending-quiet".to_string();
+    quiet_pending.tenant = "quiet".to_string();
+    quiet_pending.updated_at = 100;
+    store.create_or_get_by_request_id(quiet_pending).unwrap();
+
+    let lease = store
+        .acquire_runnable_transfer("owner-a", 100, 200, 2)
+        .unwrap()
+        .unwrap();
+    assert_eq!(lease.job_id, "pending-quiet");
+}
+
+#[test]
+fn sqlite_acquire_pending_with_builtin_fairness_prefers_tenant_without_executing_jobs() {
+    let store = sqlite_store("tenant-fifo");
+
+    let mut running = job("running-noisy");
+    running.target_path = "/running-noisy".to_string();
+    running.job_key = "Load:s3://bucket/running-noisy:/running-noisy".to_string();
+    running.tenant = "noisy".to_string();
+    running.state = TransferState::Running;
+    running.owner = "owner-running".to_string();
+    running.lease_expire_at = 1_000;
+    running.updated_at = 10;
+    store.create_or_get_by_request_id(running).unwrap();
+
+    let mut noisy_pending = job("pending-noisy");
+    noisy_pending.target_path = "/pending-noisy".to_string();
+    noisy_pending.job_key = "Load:s3://bucket/pending-noisy:/pending-noisy".to_string();
+    noisy_pending.tenant = "noisy".to_string();
+    noisy_pending.updated_at = 1;
+    store.create_or_get_by_request_id(noisy_pending).unwrap();
+
+    let mut quiet_pending = job("pending-quiet");
+    quiet_pending.target_path = "/pending-quiet".to_string();
+    quiet_pending.job_key = "Load:s3://bucket/pending-quiet:/pending-quiet".to_string();
+    quiet_pending.tenant = "quiet".to_string();
+    quiet_pending.updated_at = 100;
+    store.create_or_get_by_request_id(quiet_pending).unwrap();
+
+    let lease = store
+        .acquire_runnable_transfer("owner-a", 100, 200, 2)
+        .unwrap()
+        .unwrap();
+    assert_eq!(lease.job_id, "pending-quiet");
+}
+
+#[test]
+fn sqlite_list_tenant_summaries_counts_states_and_orders_active_tenants() {
+    let store = sqlite_store("tenant-summary");
+    for (job_id, tenant, state) in [
+        ("a-pending", "tenant-a", TransferState::Pending),
+        ("a-running", "tenant-a", TransferState::Running),
+        ("a-completed", "tenant-a", TransferState::Completed),
+        ("b-failed", "tenant-b", TransferState::Failed),
+        ("b-canceled", "tenant-b", TransferState::Canceled),
+        ("c-pending", "tenant-c", TransferState::Pending),
+    ] {
+        let mut job = job(job_id);
+        job.tenant = tenant.to_string();
+        job.state = state;
+        store.create_or_get_by_request_id(job).unwrap();
+    }
+
+    let summaries = store.list_tenant_summaries(10, 0).unwrap();
+    assert_eq!(summaries.len(), 3);
+    assert_eq!(summaries[0].tenant, "tenant-a");
+    assert_eq!(summaries[0].pending, 1);
+    assert_eq!(summaries[0].executing, 1);
+    assert_eq!(summaries[0].completed, 1);
+    assert_eq!(summaries[1].tenant, "tenant-c");
+    assert_eq!(summaries[2].tenant, "tenant-b");
+    assert_eq!(summaries[2].failed, 1);
+    assert_eq!(summaries[2].canceled, 1);
+
+    let page = store.list_tenant_summaries(1, 1).unwrap();
+    assert_eq!(page.len(), 1);
+    assert_eq!(page[0].tenant, "tenant-c");
+}
+
+#[test]
+fn sqlite_purge_terminal_transfers_keeps_active_jobs() {
+    let store = sqlite_store("purge-terminal");
+    let mut active = job("active");
+    active.updated_at = 1;
+    store.create_or_get_by_request_id(active).unwrap();
+
+    let mut completed = job("completed");
+    completed.state = TransferState::Completed;
+    completed.updated_at = 1;
+    store.create_or_get_by_request_id(completed).unwrap();
+    store.insert_tasks(vec![task("completed")]).unwrap();
+
+    assert_eq!(store.purge_terminal_transfers(10, 100).unwrap(), 1);
+    assert!(store.get_transfer("active").unwrap().is_some());
+    assert!(store.get_transfer("completed").unwrap().is_none());
+    assert!(store
+        .list_transfer_tasks("completed", 1)
+        .unwrap()
+        .is_empty());
+}
+
+#[test]
+fn sqlite_list_transfers_filters_by_submitter_and_tenant() {
+    let store = sqlite_store("list-filter-tenant");
+    let mut flink = job("flink");
+    flink.submitter = "flink".to_string();
+    flink.tenant = "tenant-a".to_string();
+    flink.updated_at = 30;
+    store.create_or_get_by_request_id(flink).unwrap();
+
+    let mut starrocks = job("starrocks");
+    starrocks.submitter = "starrocks".to_string();
+    starrocks.tenant = "tenant-b".to_string();
+    starrocks.updated_at = 20;
+    store.create_or_get_by_request_id(starrocks).unwrap();
+
+    let tenant_jobs = store
+        .list_transfers(TransferListFilter {
+            tenant: Some("tenant-a".to_string()),
+            limit: 10,
+            ..Default::default()
+        })
+        .unwrap();
+    assert_eq!(tenant_jobs.len(), 1);
+    assert_eq!(tenant_jobs[0].job_id, "flink");
+
+    let submitter_jobs = store
+        .list_transfers(TransferListFilter {
+            submitter: Some("starrocks".to_string()),
+            limit: 10,
+            ..Default::default()
+        })
+        .unwrap();
+    assert_eq!(submitter_jobs.len(), 1);
+    assert_eq!(submitter_jobs[0].job_id, "starrocks");
+}
+
+#[test]
+fn sqlite_persists_unfinished_transfer_for_restart_recovery() {
+    let path = std::env::temp_dir().join(format!(
+        "curvine-transfer-restart-{}-{}.db",
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    ));
+    {
+        let store = SqliteTransferStore::open(&path).unwrap();
+        store.create_or_get_by_request_id(job("pending")).unwrap();
+        store.insert_tasks(vec![task("pending")]).unwrap();
+
+        let mut completed = job("completed");
+        completed.state = TransferState::Completed;
+        store.create_or_get_by_request_id(completed).unwrap();
+    }
+
+    let reopened = SqliteTransferStore::open(&path).unwrap();
+    let pending = reopened.get_transfer("pending").unwrap().unwrap();
+    assert_eq!(pending.state, TransferState::Pending);
+    assert_eq!(reopened.list_transfer_tasks("pending", 1).unwrap().len(), 1);
+
+    let lease = reopened
+        .acquire_runnable_transfer("owner-after-restart", 100, 10, 100)
+        .unwrap()
+        .unwrap();
+    assert_eq!(lease.job_id, "pending");
+    assert!(reopened
+        .acquire_runnable_transfer("owner-after-restart", 100, 10, 100)
+        .unwrap()
+        .is_none());
+}
+
+#[test]
+fn sqlite_migrates_v1_schema_and_backfills_target_path() {
+    let path = std::env::temp_dir().join(format!(
+        "curvine-transfer-migrate-v1-{}-{}.db",
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    ));
+    let command = TransferCommand {
+        kind: TransferKind::Load,
+        source_path: "s3://bucket/old".to_string(),
+        target_path: "/old-target".to_string(),
+        client_request_id: "req-old".to_string(),
+        submitter: "test".to_string(),
+        tenant: "default".to_string(),
+        options: Default::default(),
+    };
+    {
+        let conn = Connection::open(&path).unwrap();
+        conn.execute_batch(
+            "
+            create table transfer_schema_version (
+                id integer primary key check(id = 1),
+                version integer not null,
+                updated_at integer not null
+            );
+            insert into transfer_schema_version(id, version, updated_at) values (1, 1, 1);
+
+            create table transfer_jobs (
+                job_id text primary key,
+                job_key text not null,
+                run_id integer not null,
+                kind integer not null,
+                source_path text not null,
+                command_json text not null,
+                mount_snapshot_json text not null,
+                secret_ref_json text not null,
+                cluster_snapshot_version integer not null,
+                cv_metadata_epoch integer,
+                state integer not null,
+                owner text not null,
+                lease_epoch integer not null,
+                lease_expire_at integer not null,
+                cancel_requested integer not null,
+                summary_json text not null,
+                client_request_id text not null,
+                submitter text not null,
+                tenant text not null,
+                created_at integer not null,
+                updated_at integer not null
+            );
+            create table transfer_tasks (
+                job_id text not null,
+                run_id integer not null,
+                task_id text not null,
+                attempt_id integer not null,
+                source_path text not null,
+                target_path text not null,
+                worker_id integer not null,
+                worker_session_id text not null,
+                source_read_plan_json text not null,
+                report_target_json text not null,
+                state integer not null,
+                progress_json text not null,
+                retry_count integer not null,
+                attempt_started_at integer not null,
+                last_report_at integer not null,
+                stale_deadline_at integer not null,
+                updated_at integer not null,
+                primary key(job_id, run_id, task_id)
+            );
+            ",
+        )
+        .unwrap();
+        conn.execute(
+            "insert into transfer_jobs (
+                job_id, job_key, run_id, kind, source_path, command_json,
+                mount_snapshot_json, secret_ref_json, cluster_snapshot_version,
+                cv_metadata_epoch, state, owner, lease_epoch, lease_expire_at,
+                cancel_requested, summary_json, client_request_id, submitter,
+                tenant, created_at, updated_at
+            ) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14,
+                      ?15, ?16, ?17, ?18, ?19, ?20, ?21)",
+            params![
+                "old-job",
+                "Load:s3://bucket/old:/old-target",
+                1_i64,
+                TransferKind::Load as i32,
+                "s3://bucket/old",
+                serde_json::to_string(&command).unwrap(),
+                "{}",
+                "{}",
+                1_i64,
+                Option::<i64>::None,
+                TransferState::Pending as i32,
+                "",
+                0_i64,
+                0_i64,
+                0_i64,
+                serde_json::to_string(&TransferProgress::default()).unwrap(),
+                "req-old",
+                "test",
+                "default",
+                1_i64,
+                1_i64
+            ],
+        )
+        .unwrap();
+    }
+
+    let store = SqliteTransferStore::open(&path).unwrap();
+    let migrated = store.get_transfer("old-job").unwrap().unwrap();
+    assert_eq!(migrated.target_path, "/old-target");
+
+    let conn = Connection::open(&path).unwrap();
+    let version: i64 = conn
+        .query_row(
+            "select version from transfer_schema_version where id = 1",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(version, 2);
+}
+
+#[test]
+fn sqlite_rejects_future_schema_without_creating_current_tables() {
+    let path = std::env::temp_dir().join(format!(
+        "curvine-transfer-future-schema-{}-{}.db",
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    ));
+    {
+        let conn = Connection::open(&path).unwrap();
+        conn.execute_batch(
+            "
+            create table transfer_schema_version (
+                id integer primary key check(id = 1),
+                version integer not null,
+                updated_at integer not null
+            );
+            insert into transfer_schema_version(id, version, updated_at) values (1, 999, 1);
+            ",
+        )
+        .unwrap();
+    }
+
+    let err = match SqliteTransferStore::open(&path) {
+        Ok(_) => panic!("future sqlite schema unexpectedly opened"),
+        Err(err) => err.to_string(),
+    };
+    assert!(
+        err.contains("Unsupported sqlite transfer schema version 999"),
+        "unexpected error: {err}"
+    );
+
+    let conn = Connection::open(&path).unwrap();
+    assert!(!sqlite_table_exists(&conn, "transfer_jobs"));
+    assert!(!sqlite_table_exists(&conn, "transfer_tasks"));
+}
+
+fn sqlite_table_exists(conn: &Connection, table: &str) -> bool {
+    conn.query_row(
+        "select exists(select 1 from sqlite_master where type = 'table' and name = ?1)",
+        params![table],
+        |row| row.get::<_, bool>(0),
+    )
+    .unwrap()
+}

--- a/curvine-ufs/src/opendal.rs
+++ b/curvine-ufs/src/opendal.rs
@@ -738,6 +738,10 @@ impl FileSystem<OpendalWriter, OpendalReader> for OpendalFileSystem {
     async fn mkdir(&self, path: &Path, _create_parent: bool) -> FsResult<bool> {
         let object_path = self.get_dir_path(path)?;
 
+        if object_path == "/" {
+            return Ok(true);
+        }
+
         self.operator
             .create_dir(&object_path)
             .await

--- a/curvine-web/src/server/web_server.rs
+++ b/curvine-web/src/server/web_server.rs
@@ -22,10 +22,11 @@ use axum::Json;
 use log::{error, info};
 use orpc::io::net::{InetAddr, NetUtils};
 use orpc::runtime::{RpcRuntime, Runtime};
-use orpc::server::{ServerConf, ServerMonitor, ServerStateListener};
+use orpc::server::{ServerConf, ServerMonitor, ServerShutdownHandle, ServerStateListener};
 use orpc::CommonResult;
 use serde_json::json;
 use tokio::net::TcpListener;
+use tokio::sync::watch;
 use tower::ServiceBuilder;
 use tower_http::services::{ServeDir, ServeFile};
 use tower_http::trace::TraceLayer;
@@ -45,6 +46,8 @@ pub struct WebServer<S> {
     conf: ServerConf,
     address: InetAddr,
     monitor: ServerMonitor,
+    shutdown_tx: watch::Sender<bool>,
+    shutdown_rx: watch::Receiver<bool>,
 }
 
 impl<S> WebServer<S>
@@ -55,23 +58,29 @@ where
     pub fn new(conf: ServerConf, service: S) -> Self {
         let address = InetAddr::new(&conf.hostname, conf.port);
         let rt = Arc::new(conf.create_runtime());
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
         Self {
             rt,
             service,
             conf,
             address,
             monitor: ServerMonitor::new(),
+            shutdown_tx,
+            shutdown_rx,
         }
     }
 
     pub fn with_rt(rt: Arc<Runtime>, conf: ServerConf, service: S) -> Self {
         let address = InetAddr::new(&conf.hostname, conf.port);
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
         Self {
             rt,
             service,
             conf,
             address,
             monitor: ServerMonitor::new(),
+            shutdown_tx,
+            shutdown_rx,
         }
     }
 
@@ -111,6 +120,10 @@ where
             Self::start0(self).await;
         });
         listener
+    }
+
+    pub fn shutdown_handle(&self) -> ServerShutdownHandle {
+        ServerShutdownHandle::new(self.shutdown_tx.clone())
     }
 
     pub async fn wait_bind(
@@ -204,7 +217,12 @@ where
                         )
                     })),
             );
-        axum::serve(listener, app).await?;
+        let mut shutdown_rx = self.shutdown_rx.clone();
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async move {
+                wait_shutdown(&mut shutdown_rx).await;
+            })
+            .await?;
         Ok(())
     }
 
@@ -217,6 +235,17 @@ where
         );
         self.monitor.advance_running();
         self.serve_listener(listener).await
+    }
+}
+
+async fn wait_shutdown(rx: &mut watch::Receiver<bool>) {
+    loop {
+        if *rx.borrow() {
+            return;
+        }
+        if rx.changed().await.is_err() {
+            return;
+        }
     }
 }
 

--- a/etc/curvine-cluster.toml
+++ b/etc/curvine-cluster.toml
@@ -82,6 +82,11 @@ subnqn = "nqn.2024-01.io.curvine:subsystem2"
 # Customer service configuration.
 [client]
 
+[transfer]
+# Set to true to start the standalone Transfer service. Local SQLite storage,
+# replica metadata reader and localhost:9010 are inferred by default.
+enabled = false
+
 # fuse configuration
 [fuse]
 # Kernel-side metadata cache timeouts (milliseconds).

--- a/orpc/src/server/mod.rs
+++ b/orpc/src/server/mod.rs
@@ -17,6 +17,7 @@ pub use self::server_conf::ServerConf;
 
 mod rpc_server;
 pub use self::rpc_server::RpcServer;
+pub use self::rpc_server::ServerShutdownHandle;
 
 mod server_monitor;
 pub use self::server_monitor::*;

--- a/orpc/src/server/rpc_server.rs
+++ b/orpc/src/server/rpc_server.rs
@@ -23,6 +23,22 @@ use socket2::SockRef;
 use std::sync::{Arc, Mutex};
 use std::{env, thread};
 use tokio::net::TcpListener;
+use tokio::sync::watch;
+
+#[derive(Clone)]
+pub struct ServerShutdownHandle {
+    tx: watch::Sender<bool>,
+}
+
+impl ServerShutdownHandle {
+    pub fn new(tx: watch::Sender<bool>) -> Self {
+        Self { tx }
+    }
+
+    pub fn shutdown(&self) {
+        let _ = self.tx.send(true);
+    }
+}
 
 pub struct RpcServer<S> {
     rt: Arc<Runtime>,
@@ -31,6 +47,8 @@ pub struct RpcServer<S> {
     addr: InetAddr,
     monitor: ServerMonitor,
     shutdown_hook: Mutex<Vec<Box<dyn FnOnce() + Send + Sync + 'static>>>,
+    shutdown_tx: watch::Sender<bool>,
+    shutdown_rx: watch::Receiver<bool>,
 }
 
 impl<S> RpcServer<S>
@@ -44,6 +62,7 @@ where
         let addr = InetAddr::new(conf.hostname.clone(), conf.port);
         let rt = Arc::new(conf.create_runtime());
 
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
         RpcServer {
             rt,
             service,
@@ -51,12 +70,15 @@ where
             addr,
             monitor: ServerMonitor::new(),
             shutdown_hook: Mutex::new(vec![]),
+            shutdown_tx,
+            shutdown_rx,
         }
     }
 
     pub fn with_rt(rt: Arc<Runtime>, conf: ServerConf, service: S) -> Self {
         let addr = InetAddr::new(conf.hostname.clone(), conf.port);
 
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
         RpcServer {
             rt,
             service,
@@ -64,6 +86,8 @@ where
             addr,
             monitor: ServerMonitor::new(),
             shutdown_hook: Mutex::new(vec![]),
+            shutdown_tx,
+            shutdown_rx,
         }
     }
 
@@ -88,6 +112,7 @@ where
     // Start server asynchronously
     async fn start0(&self) {
         let ctrl_c = tokio::signal::ctrl_c();
+        let mut shutdown_rx = self.shutdown_rx.clone();
 
         #[cfg(target_os = "linux")]
         {
@@ -109,6 +134,10 @@ where
                 _ = unix_sig.recv()  => {
                       info!("Received SIGTERM, shutting down {} gracefully...", self.conf.name);
                 }
+
+                _ = wait_shutdown(&mut shutdown_rx) => {
+                    info!("Received programmatic shutdown, shutting down {}", self.conf.name);
+                }
             }
         }
 
@@ -123,6 +152,10 @@ where
 
                 _ = ctrl_c => {
                     info!("Receive ctrl_c signal, shutting down {}", self.conf.name);
+                }
+
+                _ = wait_shutdown(&mut shutdown_rx) => {
+                    info!("Received programmatic shutdown, shutting down {}", self.conf.name);
                 }
             }
         }
@@ -234,6 +267,10 @@ where
         state.push(Box::new(hook));
     }
 
+    pub fn shutdown_handle(&self) -> ServerShutdownHandle {
+        ServerShutdownHandle::new(self.shutdown_tx.clone())
+    }
+
     fn do_shutdown_hook(&self) {
         let mut state = self.shutdown_hook.lock().unwrap();
         let mut hooks = vec![];
@@ -252,5 +289,16 @@ where
     fn get_bind_addr(&self) -> String {
         let hostname = env::var(Self::ORPC_BIND_HOSTNAME).unwrap_or(self.addr.hostname.to_string());
         format!("{}:{}", hostname, self.addr.port)
+    }
+}
+
+async fn wait_shutdown(rx: &mut watch::Receiver<bool>) {
+    loop {
+        if *rx.borrow() {
+            return;
+        }
+        if rx.changed().await.is_err() {
+            return;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Run Load and Export jobs through the independently deployable `curvine-transfer` service instead of Master.
- Preserve partial-success task semantics and cache completed outputs for retry.
- Keep existing Worker registration, Master fault-injection, and runtime limits compatible with current `main`.

## Issue/Design
Related to #1238.

## Changes
| Area | Change |
| --- | --- |
| Protocol and configuration | Add Transfer RPCs, state model, inferred store configuration, and worker capabilities. |
| Service | Add durable SQLite/MySQL stores, scheduler, planner, metadata cache, metrics, and task reporting. |
| Client and Worker | Route CLI/client operations and Worker task outcomes through Transfer while retaining legacy compatibility. |
| Master | Publish metadata snapshots/deltas and reject legacy job APIs when Transfer is enabled. |
| Deployment | Add transfer binary, launcher, local-cluster support, and Docker startup. |
| Reliability | Add ownership fencing, transactional task updates, partial-success status, and human-readable errors. |
| Tests | Cover service, scheduler, CLI, persistent stores, and Master dispatch behavior. |

## Test Verified
- `cargo check -p curvine-common -p curvine-client -p curvine-server -p curvine-cli`
- `cargo test -p curvine-server --test transfer` (117 passed, 1 ignored)
- `cargo test -p curvine-cli --test transfer_cli_e2e_test transfer_cli_reads_real_transfer_service_state`
- `cargo test -p curvine-server --test master_fs_test` (30 passed)
- `cargo clippy -p curvine-common -p curvine-client -p curvine-server -p curvine-cli --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check github-https/main...HEAD`

## Dependencies
- None.