### PR TITLE
fix(ufs): support root S3 mounts

### DIFF
--- a/curvine-ufs/src/opendal.rs
+++ b/curvine-ufs/src/opendal.rs
@@ -738,6 +738,10 @@ impl FileSystem<OpendalWriter, OpendalReader> for OpendalFileSystem {
     async fn mkdir(&self, path: &Path, _create_parent: bool) -> FsResult<bool> {
         let object_path = self.get_dir_path(path)?;
 
+        if object_path == "/" {
+            return Ok(true);
+        }
+
         self.operator
             .create_dir(&object_path)
             .await


### PR DESCRIPTION
# Summary

Support mounting an S3 bucket root without requiring a path suffix.

# Issue Describe / Design

Independent compatibility fix.

An S3 bucket root has an empty object key and already exists as the bucket. Creating `/` through OpenDAL is neither required nor portable across S3-compatible backends, so the UFS treats that one mkdir operation as successful. Non-root directory creation is unchanged.

# Changes

| Module / File | Change | Impact on existing behavior |
| --- | --- | --- |
| `curvine-ufs/src/opendal.rs` | Treat an object-store root mkdir as an existing directory. | Bucket-root mounts resolve without creating a synthetic root object. |

# Test verified

| Test case | Result | Notes |
| --- | --- | --- |
| `cargo check -p curvine-ufs` | PASS | |
| GitHub build | PASS | Full CI passed. |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None