### PR TITLE
feat(transfer): add protocol and configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,17 @@ dependencies = [
 
 [[package]]
 name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.16",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
@@ -211,7 +222,7 @@ version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c8955af33b25f3b175ee10af580577280b4bd01f7e823d94c7cdef7cf8c9aef"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
@@ -369,7 +380,7 @@ version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68bf3e3efbd1278f770d67e5dc410257300b161b93baedb3aae836144edcaf4b"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
@@ -1273,6 +1284,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
+dependencies = [
+ "borsh-derive",
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8fb4fb5740e4b2c4884ff95f5f32f5e8479db1e8fd8eb49ddbe09eb09bb7c"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1294,10 +1329,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "btoi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd6407f73a9b8b6162d8a2ef999fe6afd7cc15902ebf42c5cd296addf17e0ad"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "bufstream"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40e38929add23cdf8a366df9b0e088953150724bcbe5fc330b0d8eb3b328eec8"
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "bytecount"
@@ -1946,12 +2018,14 @@ dependencies = [
  "comfy-table",
  "curvine-client",
  "curvine-common",
+ "curvine-server",
  "curvine-ufs",
  "orpc",
  "reqwest 0.12.25",
  "serde",
  "serde_json",
  "tokio",
+ "toml",
 ]
 
 [[package]]
@@ -2158,6 +2232,7 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
+ "crossbeam",
  "curvine-client",
  "curvine-common",
  "curvine-fault",
@@ -2171,6 +2246,7 @@ dependencies = [
  "log",
  "lru 0.16.1",
  "mini-moka",
+ "mysql",
  "num_enum",
  "once_cell",
  "orpc",
@@ -2180,6 +2256,7 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "rocksdb",
+ "rusqlite",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -2418,7 +2495,7 @@ version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d551054acec0398ca604512310b77ce05c46f66e54b54d48200a686e385cca4e"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow",
  "arrow-ipc",
  "chrono",
@@ -2642,7 +2719,7 @@ version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b644f9cf696df9233ce6958b9807666d78563b56f923267474dd6c07795f1f8f"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow",
  "datafusion-common",
  "datafusion-doc",
@@ -2663,7 +2740,7 @@ version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1de2deaaabe8923ce9ea9f29c47bbb4ee14f67ea2fe1ab5398d9bbebcf86e56"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow",
  "datafusion-common",
  "datafusion-expr-common",
@@ -2773,7 +2850,7 @@ version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d48022b8af9988c1d852644f9e8b5584c490659769a550c5e8d39457a1da0a5"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow",
  "datafusion-common",
  "datafusion-expr",
@@ -2811,7 +2888,7 @@ version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147253ca3e6b9d59c162de64c02800973018660e13340dd1886dd038d17ac429"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow",
  "chrono",
  "datafusion-common",
@@ -2846,7 +2923,7 @@ version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68253dc0ee5330aa558b2549c9b0da5af9fc17d753ae73022939014ad616fc28"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow",
  "arrow-ord",
  "arrow-schema",
@@ -2988,6 +3065,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_utils"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "362f47930db19fe7735f527e6595e4900316b893ebf6d48ad3d31be928d57dd6"
+dependencies = [
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -3226,6 +3314,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
 name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3339,6 +3433,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "foreign_vec"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3351,6 +3460,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "frunk"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28aef0f9aa070bce60767c12ba9cb41efeaf1a2bc6427f87b7d83f11239a16d7"
+dependencies = [
+ "frunk_core 0.4.4",
+ "frunk_derives",
+ "frunk_proc_macros",
+ "serde",
+]
+
+[[package]]
+name = "frunk_core"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "476eeaa382e3462b84da5d6ba3da97b5786823c2d0d3a0d04ef088d073da225c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "frunk_core"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bd3c9ba2e323e8b19e77f15873f60974a7d82f89b80e50c53be44b8b92927c1"
+
+[[package]]
+name = "frunk_derives"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0b4095fc99e1d858e5b8c7125d2638372ec85aa0fe6c807105cf10b0265ca6c"
+dependencies = [
+ "frunk_proc_macro_helpers",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "frunk_proc_macro_helpers"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b70229a1347a20d4af9c06116cc452acef34f798668c6b69e97dd5c8a88052bd"
+dependencies = [
+ "frunk_core 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "frunk_proc_macros"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c63fe4306e13ece9d1ac23ce02f121ffefd42ae876ad03ec2caf07232bde3023"
+dependencies = [
+ "frunk_core 0.5.0",
+ "frunk_proc_macro_helpers",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3818,6 +3989,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
 
 [[package]]
 name = "hashbrown"
@@ -3825,7 +3999,7 @@ version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "allocator-api2",
  "rayon",
 ]
@@ -3859,6 +4033,15 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "hdfs-native"
@@ -4396,6 +4579,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-enum"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de9008599afe8527a8c9d70423437363b321649161e98473f433de802d76107"
+dependencies = [
+ "derive_utils",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4930,7 +5122,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
- "twox-hash",
+ "twox-hash 2.1.2",
  "uuid",
 ]
 
@@ -5116,7 +5308,7 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce0f4d7f739dc30608fe8b202cbb40986c2937e1a5a189f98fb06d7b8543156a"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow",
  "arrow-array",
  "arrow-cast",
@@ -5346,6 +5538,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5490,7 +5693,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90071f8077f8e40adfc4b7fe9cd495ce316263f19e75c2211eeff3fdf475a3d9"
 dependencies = [
- "twox-hash",
+ "twox-hash 2.1.2",
 ]
 
 [[package]]
@@ -5745,6 +5948,114 @@ name = "murmurhash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
+
+[[package]]
+name = "mysql"
+version = "25.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6ad644efb545e459029b1ffa7c969d830975bd76906820913247620df10050b"
+dependencies = [
+ "bufstream",
+ "bytes",
+ "crossbeam",
+ "flate2",
+ "io-enum",
+ "libc",
+ "lru 0.12.5",
+ "mysql_common",
+ "named_pipe",
+ "native-tls",
+ "pem",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+ "socket2 0.5.10",
+ "twox-hash 1.6.3",
+ "url",
+]
+
+[[package]]
+name = "mysql-common-derive"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63c3512cf11487168e0e9db7157801bf5273be13055a9cc95356dc9e0035e49c"
+dependencies = [
+ "darling",
+ "heck 0.5.0",
+ "num-bigint",
+ "proc-macro-crate",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "termcolor",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "mysql_common"
+version = "0.32.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478b0ff3f7d67b79da2b96f56f334431aef65e15ba4b29dd74a4236e29582bdc"
+dependencies = [
+ "base64 0.21.7",
+ "bigdecimal",
+ "bindgen",
+ "bitflags 2.10.0",
+ "bitvec",
+ "btoi",
+ "byteorder",
+ "bytes",
+ "cc",
+ "cmake",
+ "crc32fast",
+ "flate2",
+ "frunk",
+ "lazy_static",
+ "mysql-common-derive",
+ "num-bigint",
+ "num-traits",
+ "rand 0.8.5",
+ "regex",
+ "rust_decimal",
+ "saturating",
+ "serde",
+ "serde_json",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "subprocess",
+ "thiserror 1.0.69",
+ "time",
+ "uuid",
+ "zstd",
+]
+
+[[package]]
+name = "named_pipe"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad9c443cce91fc3e12f017290db75dde490d685cdaaf508d7159d7cf41f0eb2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
 
 [[package]]
 name = "ndarray"
@@ -6067,10 +6378,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -6466,7 +6814,7 @@ version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "725b09f2b5ef31279b66e27bbab63c58d49d8f6696b66b1f46c7eaab95e80f75"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "atoi",
  "atoi_simd",
  "bytemuck",
@@ -6527,7 +6875,7 @@ version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "465f70d3e96b6d0b1a43c358ba451286b8c8bd56696feff020d65702aa33e35c"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "bitflags 2.10.0",
  "bytemuck",
  "chrono",
@@ -6571,7 +6919,7 @@ version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2c8589e418cbe4a48228d64b2a8a40284a82ec3c98817c0c2bcc0267701338b"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "atoi_simd",
  "bytes",
  "chrono",
@@ -6601,7 +6949,7 @@ version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2632b1af668e2058d5f8f916d8fbde3cac63d03ae29a705f598e41dcfeb7f"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "bitflags 2.10.0",
  "glob",
  "once_cell",
@@ -6624,7 +6972,7 @@ version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efdbdb4d9a92109bc2e0ce8e17af5ae8ab643bb5b7ee9d1d74f0aeffd1fbc95f"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "argminmax",
  "base64 0.21.7",
  "bytemuck",
@@ -6654,7 +7002,7 @@ version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b421d2196f786fdfe162db614c8485f8308fe41575d4de634a39bbe460d1eb6a"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "base64 0.21.7",
  "ethnum",
  "num-traits",
@@ -6698,7 +7046,7 @@ version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fb8e2302e20c44defd5be8cad9c96e75face63c3a5f609aced8c4ec3b3ac97d"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "bytemuck",
  "chrono-tz 0.8.6",
  "hashbrown 0.14.5",
@@ -6774,7 +7122,7 @@ version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c760b6c698cfe2fbbbd93d6cfb408db14ececfe1d92445dae2229ce1b5b21ae8"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "bytemuck",
  "hashbrown 0.14.5",
  "indexmap 2.14.0",
@@ -7061,6 +7409,26 @@ checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
 dependencies = [
  "ar_archive_writer",
  "cc",
+]
+
+[[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -7413,7 +7781,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e47a395bdb55442b883c89062d6bcff25dc90fa5f8369af81e0ac6d49d78cf81"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "brotli",
  "paste",
  "rand 0.9.2",
@@ -7589,6 +7957,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "reqsign"
 version = "0.16.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7738,6 +8115,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rkyv"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "roaring"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7797,6 +8203,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.10.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rust-ini"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7815,6 +8235,23 @@ checksum = "e46a2036019fdb888131db7a4c847a1063a7493f971ed94ea82c67eada63ca54"
 dependencies = [
  "serde",
  "serde_derive",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be2a24f50780bc85f09cc6ac299bdf1424302742d77221106859c9d8b102126a"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand 0.8.5",
+ "rkyv",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -7996,6 +8433,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "saturating"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece8e78b2f38ec51c51f5d475df0a7187ba5111b2a28bdc761ee05b075d40a71"
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8060,6 +8503,12 @@ dependencies = [
  "ring",
  "untrusted",
 ]
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "secrecy"
@@ -8620,6 +9069,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "subprocess"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c56e8662b206b9892d7a5a3f2ecdbcb455d3d6b259111373b7e08b8055158a8"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8931,6 +9390,15 @@ dependencies = [
  "once_cell",
  "rustix 1.0.8",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -9414,6 +9882,17 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "rand 0.8.5",
+ "static_assertions",
+]
+
+[[package]]
+name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
@@ -9658,6 +10137,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
+ "serde",
  "wasm-bindgen-macro",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,8 @@ prost = "0.11.9"
 prost-build = "0.11.9"
 bincode = "1.3.3"
 serde_json = "1.0.125"
+rusqlite = { version = "0.32.1", features = ["bundled"] }
+mysql = "25.0.1"
 
 
 once_cell = "1.18.0"

--- a/curvine-common/build.rs
+++ b/curvine-common/build.rs
@@ -40,6 +40,7 @@ fn main() {
         "master.proto",
         "worker.proto",
         "job.proto",
+        "transfer.proto",
         "mount.proto",
         "replication.proto",
     ];

--- a/curvine-common/proto/common.proto
+++ b/curvine-common/proto/common.proto
@@ -170,6 +170,12 @@ message WorkerInfoProto {
     map<string, StorageInfoProto> storage_map = 7;
     required int64 reserved_bytes = 8 [default = 0];
     optional uint32 weight = 9 [default = 1];
+    optional string worker_session_id = 10 [default = ""];
+    optional bool transfer_task_submit = 11 [default = false];
+    optional bool transfer_report_target = 12 [default = false];
+    optional bool transfer_query_task = 13 [default = false];
+    optional bool transfer_attempt_safe_output = 14 [default = false];
+    optional bool transfer_source_read_plan = 15 [default = false];
 }
 
 message FileAllocOptsProto {

--- a/curvine-common/proto/job.proto
+++ b/curvine-common/proto/job.proto
@@ -74,6 +74,8 @@ message SubmitTaskRequest {
 
 message SubmitTaskResponse {
   required string task_id = 1;
+  optional bool accepted = 2 [default = true];
+  optional string reject_reason = 3 [default = ""];
 }
 
 message TaskReportRequest {

--- a/curvine-common/proto/master.proto
+++ b/curvine-common/proto/master.proto
@@ -344,3 +344,38 @@ message ListOptionsRequest {
 message ListOptionsResponse {
     repeated FileStatusProto statuses = 1;
 }
+message CvMetadataSnapshotEntryProto {
+    required FileStatusProto status = 1;
+    optional FileBlocksProto blocks = 2;
+}
+
+message GetCvMetadataSnapshotPageRequest {
+    optional string page_token = 1;
+    optional uint32 page_size = 2 [default = 10000];
+}
+
+message GetCvMetadataSnapshotPageResponse {
+    repeated CvMetadataSnapshotEntryProto entries = 1;
+    optional string next_page_token = 2;
+    required uint64 epoch = 3;
+}
+
+message CvMetadataDeltaEntryProto {
+    required string path = 1;
+    optional CvMetadataSnapshotEntryProto entry = 2;
+}
+
+message GetCvMetadataDeltaPageRequest {
+    required uint64 from_epoch = 1;
+    optional uint64 target_epoch = 2;
+    optional string page_token = 3;
+    optional uint32 page_size = 4 [default = 10000];
+}
+
+message GetCvMetadataDeltaPageResponse {
+    repeated CvMetadataDeltaEntryProto entries = 1;
+    optional string next_page_token = 2;
+    required uint64 from_epoch = 3;
+    required uint64 to_epoch = 4;
+    required bool full_snapshot_required = 5;
+}

--- a/curvine-common/proto/transfer.proto
+++ b/curvine-common/proto/transfer.proto
@@ -1,0 +1,215 @@
+syntax = "proto2";
+package proto;
+
+option java_package = "io.curvine.proto";
+option java_multiple_files = true;
+option java_outer_classname = "TransferProto";
+
+enum TransferKindProto {
+  TRANSFER_LOAD = 1;
+  TRANSFER_EXPORT = 2;
+}
+
+enum TransferStateProto {
+  TRANSFER_PENDING = 1;
+  TRANSFER_PLANNING = 2;
+  TRANSFER_DISPATCHING = 3;
+  TRANSFER_RUNNING = 4;
+  TRANSFER_CANCELING = 5;
+  TRANSFER_COMPLETED = 6;
+  TRANSFER_FAILED = 7;
+  TRANSFER_CANCELED = 8;
+}
+
+enum TransferTaskStateProto {
+  TRANSFER_TASK_PENDING = 1;
+  TRANSFER_TASK_RUNNING = 2;
+  TRANSFER_TASK_COMPLETED = 3;
+  TRANSFER_TASK_FAILED = 4;
+  TRANSFER_TASK_CANCELED = 5;
+  TRANSFER_TASK_STALE = 6;
+}
+
+message TransferProgressProto {
+  required int64 loaded_size = 1;
+  required int64 total_size = 2;
+  required int64 update_time = 3;
+  required string message = 4;
+}
+
+message TransferTaskStatusProto {
+  required string task_id = 1;
+  required uint64 attempt_id = 2;
+  required string source_path = 3;
+  required string target_path = 4;
+  required uint32 worker_id = 5;
+  required string worker_session_id = 6;
+  required TransferTaskStateProto state = 7;
+  required TransferProgressProto progress = 8;
+  required uint32 retry_count = 9;
+  required int64 updated_at = 10;
+}
+
+message TransferJobStatusProto {
+  required string job_id = 1;
+  required uint64 run_id = 2;
+  required TransferKindProto kind = 3;
+  required TransferStateProto state = 4;
+  required string source_path = 5;
+  required string target_path = 6;
+  required TransferProgressProto progress = 7;
+  required string submitter = 8;
+  required string tenant = 9;
+  required int64 created_at = 10;
+  required int64 updated_at = 11;
+  optional string owner = 12;
+  optional uint64 lease_epoch = 13;
+  optional int64 lease_expire_at = 14;
+  optional uint64 cv_metadata_epoch = 15;
+}
+
+message SubmitTransferRequest {
+  required TransferKindProto kind = 1;
+  required string source_path = 2;
+  required string target_path = 3;
+  required string client_request_id = 4;
+  required string submitter = 5;
+  required string tenant = 6;
+  required bytes command = 7;
+  optional uint32 protocol_version = 8 [default = 1];
+}
+
+message SubmitTransferResponse {
+  required string job_id = 1;
+  required uint64 run_id = 2;
+  required TransferStateProto state = 3;
+}
+
+message GetTransferStatusRequest {
+  required string job_id = 1;
+  optional uint32 page_size = 2;
+  optional string page_token = 3;
+}
+
+message GetTransferStatusResponse {
+  required string job_id = 1;
+  required uint64 run_id = 2;
+  required TransferStateProto state = 3;
+  required TransferProgressProto progress = 4;
+  repeated TransferTaskStatusProto tasks = 5;
+  optional string next_page_token = 6;
+  optional TransferKindProto kind = 7;
+  optional string source_path = 8;
+  optional string target_path = 9;
+  optional string submitter = 10;
+  optional string tenant = 11;
+  optional int64 created_at = 12;
+  optional int64 updated_at = 13;
+  optional string owner = 14;
+  optional uint64 lease_epoch = 15;
+  optional int64 lease_expire_at = 16;
+  optional uint64 cv_metadata_epoch = 17;
+}
+
+message ListTransfersRequest {
+  optional TransferKindProto kind = 1;
+  optional TransferStateProto state = 2;
+  optional uint32 page_size = 3;
+  optional string page_token = 4;
+  optional string submitter = 5;
+  optional string tenant = 6;
+}
+
+message ListTransfersResponse {
+  repeated TransferJobStatusProto jobs = 1;
+  optional string next_page_token = 2;
+}
+
+message TransferTenantSummaryProto {
+  required string tenant = 1;
+  required uint64 pending = 2;
+  required uint64 executing = 3;
+  required uint64 completed = 4;
+  required uint64 failed = 5;
+  required uint64 canceled = 6;
+  required uint64 total = 7;
+}
+
+message ListTransferTenantsRequest {
+  optional uint32 page_size = 1;
+  optional string page_token = 2;
+}
+
+message ListTransferTenantsResponse {
+  repeated TransferTenantSummaryProto tenants = 1;
+  optional string next_page_token = 2;
+}
+
+message WatchTransferRequest {
+  required string job_id = 1;
+  optional uint64 since_updated_at = 2;
+  optional uint32 page_size = 3;
+  optional string page_token = 4;
+}
+
+message WatchTransferResponse {
+  required string job_id = 1;
+  required uint64 run_id = 2;
+  required TransferStateProto state = 3;
+  required TransferProgressProto progress = 4;
+  repeated TransferTaskStatusProto tasks = 5;
+  optional string next_page_token = 6;
+  required int64 updated_at = 7;
+  required bool changed = 8;
+  optional TransferKindProto kind = 9;
+  optional string source_path = 10;
+  optional string target_path = 11;
+  optional string owner = 12;
+  optional uint64 lease_epoch = 13;
+  optional int64 lease_expire_at = 14;
+  optional uint64 cv_metadata_epoch = 15;
+}
+
+message CancelTransferRequest {
+  required string job_id = 1;
+  optional uint64 run_id = 2;
+}
+
+message CancelTransferResponse {
+  required string job_id = 1;
+  required TransferStateProto state = 2;
+}
+
+message RetryTransferRequest {
+  required string job_id = 1;
+}
+
+message TransferTaskReportRequest {
+  required string job_id = 1;
+  required uint64 run_id = 2;
+  required string task_id = 3;
+  required uint64 attempt_id = 4;
+  required uint32 worker_id = 5;
+  required string worker_session_id = 6;
+  required TransferTaskStateProto state = 7;
+  required TransferProgressProto progress = 8;
+  optional uint32 protocol_version = 9 [default = 1];
+}
+
+message TransferTaskReportResponse {
+  required bool accepted = 1;
+}
+
+message QueryTransferTaskRequest {
+  required string job_id = 1;
+  required uint64 run_id = 2;
+  required string task_id = 3;
+  required uint64 attempt_id = 4;
+  required string worker_session_id = 5;
+}
+
+message QueryTransferTaskResponse {
+  required bool found = 1;
+  required TransferTaskStateProto state = 2;
+  required TransferProgressProto progress = 3;
+}

--- a/curvine-common/proto/worker.proto
+++ b/curvine-common/proto/worker.proto
@@ -80,6 +80,12 @@ message WorkerHeartbeatRequest {
     repeated StorageInfoProto storages = 8;
     repeated BlockReportInfoProto blocks = 9;
     optional uint32 weight = 10 [default = 1];
+    optional string worker_session_id = 11 [default = ""];
+    optional bool transfer_task_submit = 12 [default = false];
+    optional bool transfer_report_target = 13 [default = false];
+    optional bool transfer_query_task = 14 [default = false];
+    optional bool transfer_attempt_safe_output = 15 [default = false];
+    optional bool transfer_source_read_plan = 16 [default = false];
 }
 
 message WorkerHeartbeatResponse {

--- a/curvine-common/src/conf/cluster_conf.rs
+++ b/curvine-common/src/conf/cluster_conf.rs
@@ -15,7 +15,8 @@
 use crate::alloc::allocator_type_name;
 use crate::conf::CliConf;
 use crate::conf::{
-    ClientConf, FaultHttpConfig, FuseConf, JobConf, JournalConf, MasterConf, WorkerConf,
+    ClientConf, FaultHttpConfig, FuseConf, JobConf, JournalConf, MasterConf, TransferConf,
+    WorkerConf,
 };
 use crate::rocksdb::DBConf;
 use crate::version;
@@ -73,6 +74,8 @@ pub struct ClusterConf {
 
     pub job: JobConf,
 
+    pub transfer: TransferConf,
+
     pub cli: CliConf,
 }
 
@@ -124,7 +127,8 @@ impl ClusterConf {
             conf.master.hostname = ip.clone();
             conf.journal.hostname = ip.clone();
             conf.worker.hostname = ip.clone();
-            conf.client.hostname = ip;
+            conf.client.hostname = ip.clone();
+            conf.transfer.hostname = ip;
         } else {
             if let Ok(v) = env::var(Self::ENV_MASTER_HOSTNAME) {
                 conf.master.hostname = v.to_owned();
@@ -146,6 +150,7 @@ impl ClusterConf {
         conf.client.init()?;
         conf.fuse.init()?;
         conf.job.init()?;
+        conf.transfer.init()?;
 
         if conf.client.master_addrs.is_empty() {
             for peer in &mut conf.journal.journal_addrs {
@@ -288,6 +293,19 @@ impl ClusterConf {
         web_conf
     }
 
+    pub fn transfer_server_conf(&self) -> ServerConf {
+        self.transfer.server_conf(&self.cluster_id)
+    }
+
+    pub fn transfer_web_conf(&self) -> ServerConf {
+        let mut web_conf =
+            ServerConf::with_hostname(&self.transfer.hostname, self.transfer.web_port);
+        web_conf.name = format!("{}-transfer-web", self.cluster_id);
+        web_conf.io_threads = self.transfer.io_threads;
+        web_conf.worker_threads = self.transfer.worker_threads;
+        web_conf
+    }
+
     pub fn client_rpc_conf(&self) -> RpcConf {
         self.client.client_rpc_conf()
     }
@@ -385,6 +403,7 @@ impl Default for ClusterConf {
             client: Default::default(),
             fuse: FuseConf::default(),
             job: Default::default(),
+            transfer: Default::default(),
             cli: Default::default(),
         }
     }

--- a/curvine-common/src/conf/journal_conf.rs
+++ b/curvine-common/src/conf/journal_conf.rs
@@ -57,6 +57,14 @@ pub struct JournalConf {
     // How many entries are created after creating snapshots.
     pub snapshot_entries: u64,
 
+    // Internal ring buffer for Transfer metadata replica delta sync.
+    #[serde(
+        skip_serializing,
+        skip_deserializing,
+        default = "JournalConf::default_metadata_delta_log_capacity"
+    )]
+    pub metadata_delta_log_capacity: usize,
+
     pub snapshot_read_chunk_size: usize,
 
     // Network configuration between raft node communications.
@@ -118,6 +126,11 @@ pub struct JournalConf {
 
 impl JournalConf {
     pub const DEFAULT_NODE_ID: u64 = 0;
+    pub const DEFAULT_METADATA_DELTA_LOG_CAPACITY: usize = 100_000;
+
+    fn default_metadata_delta_log_capacity() -> usize {
+        Self::DEFAULT_METADATA_DELTA_LOG_CAPACITY
+    }
 
     // Create a test configuration, which will also randomly select a server port.
     pub fn with_test() -> Self {
@@ -229,6 +242,7 @@ impl Default for JournalConf {
             writer_flush_batch_ms: 10,
             snapshot_interval: "6h".to_string(),
             snapshot_entries: 1000000,
+            metadata_delta_log_capacity: Self::DEFAULT_METADATA_DELTA_LOG_CAPACITY,
             snapshot_read_chunk_size: 1024 * 1024,
 
             conn_retry_max_duration_ms: 0,

--- a/curvine-common/src/conf/mod.rs
+++ b/curvine-common/src/conf/mod.rs
@@ -39,6 +39,9 @@ pub use self::ufs_conf::UfsConfBuilder;
 mod job_conf;
 pub use self::job_conf::JobConf;
 
+mod transfer_conf;
+pub use self::transfer_conf::*;
+
 mod cli_conf;
 pub use self::cli_conf::CliConf;
 

--- a/curvine-common/src/conf/transfer_conf.rs
+++ b/curvine-common/src/conf/transfer_conf.rs
@@ -1,0 +1,524 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::error::FsError;
+use crate::FsResult;
+use orpc::common::DurationUnit;
+use orpc::server::ServerConf;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum TransferStoreType {
+    Auto,
+    Memory,
+    Sqlite,
+    Mysql,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum TransferCvMetadataReaderType {
+    Auto,
+    Disabled,
+    Master,
+    Replica,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct TransferConf {
+    pub enabled: bool,
+    // Deprecated compatibility inputs normalize into store_url during init.
+    #[serde(skip_serializing)]
+    pub store_type: TransferStoreType,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub store_url: String,
+    pub hostname: String,
+    pub rpc_port: u16,
+    pub web_port: u16,
+    #[serde(skip, default = "TransferConf::default_io_threads")]
+    pub io_threads: usize,
+    #[serde(skip, default = "TransferConf::default_worker_threads")]
+    pub worker_threads: usize,
+    pub instance_id: String,
+    pub endpoints: Vec<String>,
+    #[serde(skip_serializing)]
+    pub sqlite_path: String,
+    #[serde(skip_serializing)]
+    pub mysql_url: String,
+    pub cv_metadata_reader: TransferCvMetadataReaderType,
+    #[serde(skip, default = "TransferConf::default_metadata_replica_max_entries")]
+    pub metadata_replica_max_entries: usize,
+    #[serde(skip)]
+    pub allow_submit_with_stale_snapshot: bool,
+    pub max_running_transfers: usize,
+    #[serde(skip, default = "TransferConf::default_max_tasks_per_transfer")]
+    pub max_tasks_per_transfer: usize,
+    #[serde(
+        skip,
+        default = "TransferConf::default_ufs_max_concurrency_per_endpoint"
+    )]
+    pub ufs_max_concurrency_per_endpoint: usize,
+    #[serde(skip, default = "TransferConf::default_task_max_retries")]
+    pub task_max_retries: usize,
+
+    #[serde(skip)]
+    pub task_report_interval: Duration,
+    #[serde(skip, default = "TransferConf::default_task_report_interval_str")]
+    pub task_report_interval_str: String,
+
+    #[serde(skip)]
+    pub task_stale_timeout: Duration,
+    #[serde(skip, default = "TransferConf::default_task_stale_timeout_str")]
+    pub task_stale_timeout_str: String,
+
+    #[serde(skip)]
+    pub lease_timeout: Duration,
+    #[serde(alias = "lease_timeout")]
+    pub lease_timeout_str: String,
+
+    #[serde(skip)]
+    pub cluster_snapshot_max_staleness: Duration,
+    #[serde(
+        skip,
+        default = "TransferConf::default_cluster_snapshot_max_staleness_str"
+    )]
+    pub cluster_snapshot_max_staleness_str: String,
+
+    #[serde(skip)]
+    pub terminal_retention: Duration,
+    #[serde(alias = "terminal_retention")]
+    pub terminal_retention_str: String,
+
+    #[serde(skip)]
+    pub metadata_replica_refresh_interval: Duration,
+    #[serde(
+        skip,
+        default = "TransferConf::default_metadata_replica_refresh_interval_str"
+    )]
+    pub metadata_replica_refresh_interval_str: String,
+
+    #[serde(skip)]
+    pub metadata_replica_max_staleness: Duration,
+    #[serde(
+        skip,
+        default = "TransferConf::default_metadata_replica_max_staleness_str"
+    )]
+    pub metadata_replica_max_staleness_str: String,
+}
+
+impl TransferConf {
+    pub const DEFAULT_TASK_REPORT_INTERVAL: &'static str = "10s";
+    pub const DEFAULT_TASK_STALE_TIMEOUT: &'static str = "60s";
+    pub const DEFAULT_LEASE_TIMEOUT: &'static str = "120s";
+    pub const DEFAULT_CLUSTER_SNAPSHOT_MAX_STALENESS: &'static str = "60s";
+    pub const DEFAULT_TERMINAL_RETENTION: &'static str = "168h";
+    pub const DEFAULT_METADATA_REPLICA_REFRESH_INTERVAL: &'static str = "30s";
+    pub const DEFAULT_METADATA_REPLICA_MAX_STALENESS: &'static str = "120s";
+    pub const DEFAULT_METADATA_REPLICA_MAX_ENTRIES: usize = 1_000_000;
+    pub const DEFAULT_METADATA_REPLICA_PAGE_SIZE: usize = 1000;
+    pub const DEFAULT_METADATA_REPLICA_HISTORY_SIZE: usize = 2;
+    pub const DEFAULT_MAX_PLANNING_TRANSFERS: usize = 8;
+    pub const DEFAULT_PLANNING_BATCH_SIZE: usize = 1000;
+    pub const DEFAULT_WORKER_DISPATCH_CONCURRENCY: usize = 256;
+    pub const DEFAULT_TASK_REPORT_QUEUE_SIZE: usize = 10_000;
+    pub const DEFAULT_TASK_PROBE_CONCURRENCY: usize = 64;
+    pub const DEFAULT_CLIENT_PENDING_QUEUE_SIZE: usize = 1024;
+    pub const DEFAULT_CLEANUP_BATCH_SIZE: usize = 1000;
+    pub const DEFAULT_RPC_PORT: u16 = 9010;
+    pub const DEFAULT_WEB_PORT: u16 = 9011;
+    pub const DEFAULT_IO_THREADS: usize = 4;
+    pub const DEFAULT_WORKER_THREADS: usize = 8;
+    pub const DEFAULT_MAX_TASKS_PER_TRANSFER: usize = 100_000;
+    pub const DEFAULT_UFS_MAX_CONCURRENCY_PER_ENDPOINT: usize = 32;
+    pub const DEFAULT_TASK_MAX_RETRIES: usize = 3;
+
+    pub fn init(&mut self) -> FsResult<()> {
+        self.infer_store_url();
+        if self.endpoints.is_empty() {
+            self.endpoints
+                .push(format!("{}:{}", self.hostname, self.rpc_port));
+        }
+        self.lease_timeout = DurationUnit::from_str(&self.lease_timeout_str)?.as_duration();
+        self.task_stale_timeout = Self::derive_task_stale_timeout(self.lease_timeout);
+        self.task_report_interval = Self::derive_task_report_interval(self.task_stale_timeout);
+        self.cluster_snapshot_max_staleness =
+            DurationUnit::from_str(&self.cluster_snapshot_max_staleness_str)?.as_duration();
+        self.terminal_retention =
+            DurationUnit::from_str(&self.terminal_retention_str)?.as_duration();
+        self.metadata_replica_refresh_interval =
+            DurationUnit::from_str(&self.metadata_replica_refresh_interval_str)?.as_duration();
+        self.metadata_replica_max_staleness =
+            DurationUnit::from_str(&self.metadata_replica_max_staleness_str)?.as_duration();
+        if !self.store_url.is_empty() && self.effective_store_type() == TransferStoreType::Auto {
+            return Err(FsError::common(
+                "transfer.store_url must use memory://, sqlite://, or mysql://",
+            ));
+        }
+        match self.effective_store_type() {
+            TransferStoreType::Sqlite if self.sqlite_store_path().is_empty() => {
+                return Err(FsError::common(
+                    "transfer.store_url=sqlite:// requires a database path",
+                ));
+            }
+            TransferStoreType::Mysql if self.mysql_store_url().is_empty() => {
+                return Err(FsError::common(
+                    "transfer.store_url=mysql:// requires a database URL",
+                ));
+            }
+            _ => {}
+        }
+        if self.enabled && self.effective_store_type() == TransferStoreType::Mysql {
+            self.validate_mysql_store()?;
+        }
+        if self.max_running_transfers == 0 {
+            return Err(FsError::common(
+                "transfer.max_running_transfers must be greater than 0",
+            ));
+        }
+        if self.ufs_max_concurrency_per_endpoint == 0 {
+            return Err(FsError::common(
+                "transfer.ufs_max_concurrency_per_endpoint must be greater than 0",
+            ));
+        }
+        if self.metadata_replica_max_entries == 0 {
+            return Err(FsError::common(
+                "transfer.metadata_replica_max_entries must be greater than 0",
+            ));
+        }
+        if self.cluster_snapshot_max_staleness.is_zero() {
+            return Err(FsError::common(
+                "transfer.cluster_snapshot_max_staleness must be greater than 0",
+            ));
+        }
+        if self.metadata_replica_refresh_interval.is_zero() {
+            return Err(FsError::common(
+                "transfer.metadata_replica_refresh_interval must be greater than 0",
+            ));
+        }
+        if self.metadata_replica_max_staleness.is_zero() {
+            return Err(FsError::common(
+                "transfer.metadata_replica_max_staleness must be greater than 0",
+            ));
+        }
+        if self.lease_timeout.is_zero() {
+            return Err(FsError::common(
+                "transfer.lease_timeout must be greater than 0",
+            ));
+        }
+        if self.max_tasks_per_transfer == 0 {
+            return Err(FsError::common(
+                "transfer.max_tasks_per_transfer must be greater than 0",
+            ));
+        }
+        Ok(())
+    }
+
+    fn infer_store_url(&mut self) {
+        if !self.store_url.is_empty() {
+            return;
+        }
+
+        self.store_url = match self.effective_store_type() {
+            TransferStoreType::Memory => "memory://".to_string(),
+            TransferStoreType::Sqlite => format!("sqlite://{}", self.sqlite_path),
+            TransferStoreType::Mysql => self.mysql_url.clone(),
+            TransferStoreType::Auto => String::new(),
+        };
+    }
+
+    pub fn effective_store_type(&self) -> TransferStoreType {
+        if !self.store_url.is_empty() {
+            return if self.store_url == "memory://" {
+                TransferStoreType::Memory
+            } else if self.store_url.starts_with("sqlite://") {
+                TransferStoreType::Sqlite
+            } else if self.store_url.starts_with("mysql://") {
+                TransferStoreType::Mysql
+            } else {
+                TransferStoreType::Auto
+            };
+        }
+        match self.store_type {
+            TransferStoreType::Auto if self.mysql_url.is_empty() => TransferStoreType::Sqlite,
+            TransferStoreType::Auto => TransferStoreType::Mysql,
+            store_type => store_type,
+        }
+    }
+
+    pub fn effective_cv_metadata_reader(&self) -> TransferCvMetadataReaderType {
+        match self.cv_metadata_reader {
+            TransferCvMetadataReaderType::Auto => TransferCvMetadataReaderType::Replica,
+            reader => reader,
+        }
+    }
+
+    pub fn sqlite_store_path(&self) -> &str {
+        self.store_url
+            .strip_prefix("sqlite://")
+            .unwrap_or(&self.sqlite_path)
+    }
+
+    pub fn mysql_store_url(&self) -> &str {
+        if self.store_url.starts_with("mysql://") {
+            &self.store_url
+        } else {
+            &self.mysql_url
+        }
+    }
+
+    fn validate_mysql_store(&self) -> FsResult<()> {
+        if self.effective_cv_metadata_reader() != TransferCvMetadataReaderType::Replica {
+            return Err(FsError::common(
+                "production transfer requires transfer.cv_metadata_reader=replica",
+            ));
+        }
+        if self.allow_submit_with_stale_snapshot {
+            return Err(FsError::common(
+                "production transfer forbids transfer.allow_submit_with_stale_snapshot=true",
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn max_executing_transfers(&self) -> u64 {
+        self.max_running_transfers as u64
+    }
+
+    fn default_io_threads() -> usize {
+        Self::DEFAULT_IO_THREADS
+    }
+
+    fn default_worker_threads() -> usize {
+        Self::DEFAULT_WORKER_THREADS
+    }
+
+    fn default_max_tasks_per_transfer() -> usize {
+        Self::DEFAULT_MAX_TASKS_PER_TRANSFER
+    }
+
+    fn default_ufs_max_concurrency_per_endpoint() -> usize {
+        Self::DEFAULT_UFS_MAX_CONCURRENCY_PER_ENDPOINT
+    }
+
+    fn default_task_max_retries() -> usize {
+        Self::DEFAULT_TASK_MAX_RETRIES
+    }
+
+    fn default_task_report_interval_str() -> String {
+        Self::DEFAULT_TASK_REPORT_INTERVAL.to_string()
+    }
+
+    fn default_task_stale_timeout_str() -> String {
+        Self::DEFAULT_TASK_STALE_TIMEOUT.to_string()
+    }
+
+    fn default_metadata_replica_max_entries() -> usize {
+        Self::DEFAULT_METADATA_REPLICA_MAX_ENTRIES
+    }
+
+    fn default_cluster_snapshot_max_staleness_str() -> String {
+        Self::DEFAULT_CLUSTER_SNAPSHOT_MAX_STALENESS.to_string()
+    }
+
+    fn default_metadata_replica_refresh_interval_str() -> String {
+        Self::DEFAULT_METADATA_REPLICA_REFRESH_INTERVAL.to_string()
+    }
+
+    fn default_metadata_replica_max_staleness_str() -> String {
+        Self::DEFAULT_METADATA_REPLICA_MAX_STALENESS.to_string()
+    }
+
+    pub fn metadata_replica_page_size(&self) -> usize {
+        Self::DEFAULT_METADATA_REPLICA_PAGE_SIZE
+    }
+
+    pub fn metadata_replica_history_size(&self) -> usize {
+        Self::DEFAULT_METADATA_REPLICA_HISTORY_SIZE
+    }
+
+    pub fn scheduler_workers(&self) -> usize {
+        Self::DEFAULT_MAX_PLANNING_TRANSFERS
+            .min(self.max_running_transfers.max(1))
+            .max(1)
+    }
+
+    pub fn planning_batch_size(&self) -> usize {
+        Self::DEFAULT_PLANNING_BATCH_SIZE
+    }
+
+    pub fn worker_dispatch_concurrency(&self) -> usize {
+        Self::DEFAULT_WORKER_DISPATCH_CONCURRENCY
+    }
+
+    pub fn task_report_queue_size(&self) -> usize {
+        Self::DEFAULT_TASK_REPORT_QUEUE_SIZE
+    }
+
+    pub fn task_probe_concurrency(&self) -> usize {
+        Self::DEFAULT_TASK_PROBE_CONCURRENCY
+    }
+
+    pub fn client_pending_queue_size(&self) -> usize {
+        Self::DEFAULT_CLIENT_PENDING_QUEUE_SIZE
+    }
+
+    pub fn cleanup_batch_size(&self) -> usize {
+        Self::DEFAULT_CLEANUP_BATCH_SIZE
+    }
+
+    fn derive_task_stale_timeout(lease_timeout: Duration) -> Duration {
+        lease_timeout.div_f64(2.0)
+    }
+
+    fn derive_task_report_interval(task_stale_timeout: Duration) -> Duration {
+        let derived = task_stale_timeout.div_f64(6.0);
+        let default = DurationUnit::from_str(Self::DEFAULT_TASK_REPORT_INTERVAL)
+            .expect("default transfer task report interval must be valid")
+            .as_duration();
+        derived.min(default).max(Duration::from_millis(1))
+    }
+
+    pub fn server_conf(&self, cluster_id: &str) -> ServerConf {
+        let mut conf = ServerConf::with_hostname(&self.hostname, self.rpc_port);
+        conf.name = format!("{}-transfer", cluster_id);
+        conf.io_threads = self.io_threads;
+        conf.worker_threads = self.worker_threads;
+        conf
+    }
+}
+
+impl Default for TransferConf {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            store_type: TransferStoreType::Auto,
+            store_url: String::new(),
+            hostname: "localhost".to_string(),
+            rpc_port: Self::DEFAULT_RPC_PORT,
+            web_port: Self::DEFAULT_WEB_PORT,
+            io_threads: Self::DEFAULT_IO_THREADS,
+            worker_threads: Self::DEFAULT_WORKER_THREADS,
+            instance_id: String::new(),
+            endpoints: vec![],
+            sqlite_path: "data/transfer/transfer.db".to_string(),
+            mysql_url: String::new(),
+            cv_metadata_reader: TransferCvMetadataReaderType::Auto,
+            metadata_replica_max_entries: Self::DEFAULT_METADATA_REPLICA_MAX_ENTRIES,
+            allow_submit_with_stale_snapshot: false,
+            max_running_transfers: 64,
+            max_tasks_per_transfer: Self::DEFAULT_MAX_TASKS_PER_TRANSFER,
+            ufs_max_concurrency_per_endpoint: Self::DEFAULT_UFS_MAX_CONCURRENCY_PER_ENDPOINT,
+            task_max_retries: Self::DEFAULT_TASK_MAX_RETRIES,
+            task_report_interval: Duration::default(),
+            task_report_interval_str: Self::DEFAULT_TASK_REPORT_INTERVAL.to_string(),
+            task_stale_timeout: Duration::default(),
+            task_stale_timeout_str: Self::DEFAULT_TASK_STALE_TIMEOUT.to_string(),
+            lease_timeout: Duration::default(),
+            lease_timeout_str: Self::DEFAULT_LEASE_TIMEOUT.to_string(),
+            cluster_snapshot_max_staleness: Duration::default(),
+            cluster_snapshot_max_staleness_str: Self::DEFAULT_CLUSTER_SNAPSHOT_MAX_STALENESS
+                .to_string(),
+            terminal_retention: Duration::default(),
+            terminal_retention_str: Self::DEFAULT_TERMINAL_RETENTION.to_string(),
+            metadata_replica_refresh_interval: Duration::default(),
+            metadata_replica_refresh_interval_str: Self::DEFAULT_METADATA_REPLICA_REFRESH_INTERVAL
+                .to_string(),
+            metadata_replica_max_staleness: Duration::default(),
+            metadata_replica_max_staleness_str: Self::DEFAULT_METADATA_REPLICA_MAX_STALENESS
+                .to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TransferConf, TransferCvMetadataReaderType, TransferStoreType};
+
+    #[test]
+    fn defaults_to_local_sqlite_with_a_local_endpoint() {
+        let mut conf = TransferConf {
+            enabled: true,
+            ..Default::default()
+        };
+
+        conf.init().unwrap();
+
+        assert_eq!(conf.effective_store_type(), TransferStoreType::Sqlite);
+        assert_eq!(conf.store_url, "sqlite://data/transfer/transfer.db");
+        assert_eq!(
+            conf.effective_cv_metadata_reader(),
+            TransferCvMetadataReaderType::Replica
+        );
+        assert_eq!(conf.endpoints, vec!["localhost:9010"]);
+    }
+
+    #[test]
+    fn mysql_url_selects_production_safe_defaults() {
+        let mut conf: TransferConf = toml::from_str(
+            r#"
+                enabled = true
+                store_url = "mysql://root:curvine@127.0.0.1:3306/curvine_transfer"
+            "#,
+        )
+        .unwrap();
+
+        conf.init().unwrap();
+
+        assert_eq!(conf.effective_store_type(), TransferStoreType::Mysql);
+        assert_eq!(
+            conf.store_url,
+            "mysql://root:curvine@127.0.0.1:3306/curvine_transfer"
+        );
+        assert_eq!(
+            conf.effective_cv_metadata_reader(),
+            TransferCvMetadataReaderType::Replica
+        );
+    }
+
+    #[test]
+    fn auto_mysql_rejects_development_metadata_reader() {
+        let mut conf = TransferConf {
+            enabled: true,
+            store_url: "mysql://root:curvine@127.0.0.1:3306/curvine_transfer".to_string(),
+            cv_metadata_reader: TransferCvMetadataReaderType::Master,
+            ..Default::default()
+        };
+
+        let err = conf.init().unwrap_err().to_string();
+
+        assert!(err.contains("requires transfer.cv_metadata_reader=replica"));
+    }
+
+    #[test]
+    fn accepts_memory_store_url_and_rejects_unknown_scheme() {
+        let mut memory = TransferConf {
+            enabled: true,
+            store_url: "memory://".to_string(),
+            ..Default::default()
+        };
+        memory.init().unwrap();
+        assert_eq!(memory.effective_store_type(), TransferStoreType::Memory);
+
+        let mut invalid = TransferConf {
+            enabled: true,
+            store_url: "postgres://transfer".to_string(),
+            ..Default::default()
+        };
+        let err = invalid.init().unwrap_err().to_string();
+        assert!(err.contains("transfer.store_url must use"));
+    }
+}

--- a/curvine-common/src/error/fs_error.rs
+++ b/curvine-common/src/error/fs_error.rs
@@ -67,6 +67,10 @@ pub enum ErrorKind {
     ReadOnly = 30,
     NoAvailableWorker = 31,
     NoLocalPath = 32,
+    TransferOverloaded = 33,
+    TransferStoreUnavailable = 34,
+    TransferAlreadyRunning = 35,
+    TransferTargetConflict = 36,
 
     #[num_enum(default)]
     Common = 10000,
@@ -204,6 +208,22 @@ pub enum FsError {
     #[error("{0}")]
     JobNotFound(ErrorImpl<StringError>),
 
+    // Transfer service or client-side transfer queue is overloaded.
+    #[error("{0}")]
+    TransferOverloaded(ErrorImpl<StringError>),
+
+    // Transfer state store is unavailable or failed a backend operation.
+    #[error("{0}")]
+    TransferStoreUnavailable(ErrorImpl<StringError>),
+
+    // A transfer with the same job key is already running with incompatible options.
+    #[error("{0}")]
+    TransferAlreadyRunning(ErrorImpl<StringError>),
+
+    // A non-terminal transfer already owns the same target path tree.
+    #[error("{0}")]
+    TransferTargetConflict(ErrorImpl<StringError>),
+
     // Other errors that are not defined.
     #[error("{0}")]
     Common(ErrorImpl<StringError>),
@@ -240,6 +260,10 @@ impl FsError {
         Self::InProgress(ErrorImpl::with_source(msg.into()))
     }
 
+    pub fn in_progress_msg(msg: impl Into<String>) -> Self {
+        Self::InProgress(ErrorImpl::with_source(msg.into().into()))
+    }
+
     pub fn file_not_found(path: impl AsRef<str>) -> Self {
         let msg = format!("File {} not found", path.as_ref());
         Self::FileNotFound(ErrorImpl::with_source(msg.into()))
@@ -268,6 +292,22 @@ impl FsError {
     pub fn job_not_found(job_id: impl AsRef<str>) -> Self {
         let msg = format!("Job {} not found", job_id.as_ref());
         Self::JobNotFound(ErrorImpl::with_source(msg.into()))
+    }
+
+    pub fn transfer_overloaded(msg: impl Into<String>) -> Self {
+        Self::TransferOverloaded(ErrorImpl::with_source(msg.into().into()))
+    }
+
+    pub fn transfer_store_unavailable(msg: impl Into<String>) -> Self {
+        Self::TransferStoreUnavailable(ErrorImpl::with_source(msg.into().into()))
+    }
+
+    pub fn transfer_already_running(msg: impl Into<String>) -> Self {
+        Self::TransferAlreadyRunning(ErrorImpl::with_source(msg.into().into()))
+    }
+
+    pub fn transfer_target_conflict(msg: impl Into<String>) -> Self {
+        Self::TransferTargetConflict(ErrorImpl::with_source(msg.into().into()))
     }
 
     pub fn file_exists(path: impl AsRef<str>) -> Self {
@@ -406,6 +446,10 @@ impl FsError {
             FsError::NoAvailableWorker(_) => ErrorKind::NoAvailableWorker,
             FsError::NoLocalPath(_) => ErrorKind::NoLocalPath,
             FsError::JobNotFound(_) => ErrorKind::JobNotFound,
+            FsError::TransferOverloaded(_) => ErrorKind::TransferOverloaded,
+            FsError::TransferStoreUnavailable(_) => ErrorKind::TransferStoreUnavailable,
+            FsError::TransferAlreadyRunning(_) => ErrorKind::TransferAlreadyRunning,
+            FsError::TransferTargetConflict(_) => ErrorKind::TransferTargetConflict,
             FsError::Common(_) => ErrorKind::Common,
         }
     }
@@ -555,6 +599,10 @@ impl ErrorExt for FsError {
             FsError::NoAvailableWorker(e) => FsError::NoAvailableWorker(e.ctx(ctx)),
             FsError::NoLocalPath(e) => FsError::NoLocalPath(e.ctx(ctx)),
             FsError::JobNotFound(e) => FsError::JobNotFound(e.ctx(ctx)),
+            FsError::TransferOverloaded(e) => FsError::TransferOverloaded(e.ctx(ctx)),
+            FsError::TransferStoreUnavailable(e) => FsError::TransferStoreUnavailable(e.ctx(ctx)),
+            FsError::TransferAlreadyRunning(e) => FsError::TransferAlreadyRunning(e.ctx(ctx)),
+            FsError::TransferTargetConflict(e) => FsError::TransferTargetConflict(e.ctx(ctx)),
             FsError::Common(e) => FsError::Common(e.ctx(ctx)),
         }
     }
@@ -593,6 +641,10 @@ impl ErrorExt for FsError {
             FsError::NoAvailableWorker(e) => e.encode(ErrorKind::NoAvailableWorker),
             FsError::NoLocalPath(e) => e.encode(ErrorKind::NoLocalPath),
             FsError::JobNotFound(e) => e.encode(ErrorKind::JobNotFound),
+            FsError::TransferOverloaded(e) => e.encode(ErrorKind::TransferOverloaded),
+            FsError::TransferStoreUnavailable(e) => e.encode(ErrorKind::TransferStoreUnavailable),
+            FsError::TransferAlreadyRunning(e) => e.encode(ErrorKind::TransferAlreadyRunning),
+            FsError::TransferTargetConflict(e) => e.encode(ErrorKind::TransferTargetConflict),
             FsError::Common(e) => e.encode(ErrorKind::Common),
         }
     }
@@ -634,6 +686,12 @@ impl ErrorExt for FsError {
             ErrorKind::NoAvailableWorker => FsError::NoAvailableWorker(de.into_string()),
             ErrorKind::NoLocalPath => FsError::NoLocalPath(de.into_string()),
             ErrorKind::JobNotFound => FsError::JobNotFound(de.into_string()),
+            ErrorKind::TransferOverloaded => FsError::TransferOverloaded(de.into_string()),
+            ErrorKind::TransferStoreUnavailable => {
+                FsError::TransferStoreUnavailable(de.into_string())
+            }
+            ErrorKind::TransferAlreadyRunning => FsError::TransferAlreadyRunning(de.into_string()),
+            ErrorKind::TransferTargetConflict => FsError::TransferTargetConflict(de.into_string()),
             ErrorKind::Common => FsError::Common(de.into_string()),
         }
     }
@@ -729,5 +787,49 @@ mod tests {
         let decoded = FsError::decode(bytes);
         assert!(matches!(decoded.kind(), ErrorKind::NoAvailableWorker));
         assert!(matches!(decoded, FsError::NoAvailableWorker(_)));
+    }
+
+    #[test]
+    pub fn transfer_overloaded_round_trip_test() {
+        let error = FsError::transfer_overloaded("transfer task report queue is full");
+
+        assert!(matches!(error.kind(), ErrorKind::TransferOverloaded));
+        let bytes = error.encode();
+        let decoded = FsError::decode(bytes);
+        assert!(matches!(decoded, FsError::TransferOverloaded(_)));
+        assert!(decoded.to_string().contains("queue is full"));
+    }
+
+    #[test]
+    pub fn transfer_store_unavailable_round_trip_test() {
+        let error = FsError::transfer_store_unavailable("mysql transfer store error");
+
+        assert!(matches!(error.kind(), ErrorKind::TransferStoreUnavailable));
+        let bytes = error.encode();
+        let decoded = FsError::decode(bytes);
+        assert!(matches!(decoded, FsError::TransferStoreUnavailable(_)));
+        assert!(decoded.to_string().contains("mysql transfer store error"));
+    }
+
+    #[test]
+    pub fn transfer_already_running_round_trip_test() {
+        let error = FsError::transfer_already_running("same job key has different command");
+
+        assert!(matches!(error.kind(), ErrorKind::TransferAlreadyRunning));
+        let bytes = error.encode();
+        let decoded = FsError::decode(bytes);
+        assert!(matches!(decoded, FsError::TransferAlreadyRunning(_)));
+        assert!(decoded.to_string().contains("different command"));
+    }
+
+    #[test]
+    pub fn transfer_target_conflict_round_trip_test() {
+        let error = FsError::transfer_target_conflict("target /a conflicts with active transfer");
+
+        assert!(matches!(error.kind(), ErrorKind::TransferTargetConflict));
+        let bytes = error.encode();
+        let decoded = FsError::decode(bytes);
+        assert!(matches!(decoded, FsError::TransferTargetConflict(_)));
+        assert!(decoded.to_string().contains("/a"));
     }
 }

--- a/curvine-common/src/fs/rpc_code.rs
+++ b/curvine-common/src/fs/rpc_code.rs
@@ -49,6 +49,8 @@ pub enum RpcCode {
     CompleteFilesBatch = 25,
     Free = 26,
     ListOptions = 27,
+    GetCvMetadataSnapshotPage = 28,
+    GetCvMetadataDeltaPage = 29,
 
     // manager interface.
     Mount = 30,
@@ -62,6 +64,15 @@ pub enum RpcCode {
     CancelJob = 37,
     ReportTask = 38,
     SubmitTask = 39,
+    SubmitTransfer = 46,
+    GetTransferStatus = 47,
+    CancelTransfer = 48,
+    ReportTransferTask = 49,
+    QueryTransferTask = 50,
+    WatchTransfer = 51,
+    ListTransfers = 52,
+    ListTransferTenants = 53,
+    RetryTransfer = 54,
     WorkerHeartbeat = 40,
     WorkerBlockReport = 41,
 

--- a/curvine-common/src/state/job.rs
+++ b/curvine-common/src/state/job.rs
@@ -235,6 +235,19 @@ pub struct LoadTaskInfo {
     pub source_path: String,
     pub target_path: String,
     pub create_time: i64,
+    #[serde(default)]
+    pub source_read_plan_json: String,
+    #[serde(default)]
+    pub transfer_report: Option<TransferTaskReportInfo>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransferTaskReportInfo {
+    pub run_id: u64,
+    pub attempt_id: u64,
+    pub worker_id: u32,
+    pub worker_session_id: String,
+    pub report_target: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/curvine-common/src/state/mod.rs
+++ b/curvine-common/src/state/mod.rs
@@ -22,7 +22,7 @@ mod heartbeat_status;
 pub use self::heartbeat_status::HeartbeatStatus;
 
 mod worker_info;
-pub use self::worker_info::WorkerInfo;
+pub use self::worker_info::{TransferWorkerCapabilities, WorkerInfo};
 
 mod worker_node_tree;
 pub use self::worker_node_tree::WorkerNodeTree;
@@ -70,6 +70,9 @@ pub use self::opts::*;
 
 mod job;
 pub use self::job::*;
+
+mod transfer;
+pub use self::transfer::*;
 
 mod metrics;
 pub use self::metrics::*;

--- a/curvine-common/src/state/transfer.rs
+++ b/curvine-common/src/state/transfer.rs
@@ -1,0 +1,392 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use num_enum::{FromPrimitive, IntoPrimitive};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+use crate::utils::CommonUtils;
+
+pub const TRANSFER_TEMP_PATH_MARKER: &str = ".curvine-transfer-tmp-";
+
+pub fn is_transfer_temp_path(path: &str) -> bool {
+    path.contains(TRANSFER_TEMP_PATH_MARKER)
+}
+
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Hash,
+    IntoPrimitive,
+    FromPrimitive,
+    Serialize,
+    Deserialize,
+)]
+#[repr(i32)]
+pub enum TransferKind {
+    #[default]
+    Load = 1,
+    Export = 2,
+}
+
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Hash,
+    IntoPrimitive,
+    FromPrimitive,
+    Serialize,
+    Deserialize,
+)]
+#[repr(i32)]
+pub enum TransferState {
+    #[default]
+    Pending = 1,
+    Planning = 2,
+    Dispatching = 3,
+    Running = 4,
+    Canceling = 5,
+    Completed = 6,
+    Failed = 7,
+    Canceled = 8,
+}
+
+impl TransferState {
+    pub fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            TransferState::Completed | TransferState::Failed | TransferState::Canceled
+        )
+    }
+
+    pub fn is_runnable(self) -> bool {
+        matches!(
+            self,
+            TransferState::Pending
+                | TransferState::Planning
+                | TransferState::Dispatching
+                | TransferState::Running
+                | TransferState::Canceling
+        )
+    }
+
+    pub fn is_executing(self) -> bool {
+        matches!(
+            self,
+            TransferState::Planning
+                | TransferState::Dispatching
+                | TransferState::Running
+                | TransferState::Canceling
+        )
+    }
+}
+
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Hash,
+    IntoPrimitive,
+    FromPrimitive,
+    Serialize,
+    Deserialize,
+)]
+#[repr(i32)]
+pub enum TransferTaskState {
+    #[default]
+    Pending = 1,
+    Running = 2,
+    Completed = 3,
+    Failed = 4,
+    Canceled = 5,
+    Stale = 6,
+}
+
+impl TransferTaskState {
+    pub fn is_running(self) -> bool {
+        matches!(
+            self,
+            TransferTaskState::Pending | TransferTaskState::Running
+        )
+    }
+
+    pub fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            TransferTaskState::Completed
+                | TransferTaskState::Failed
+                | TransferTaskState::Canceled
+                | TransferTaskState::Stale
+        )
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TransferCommand {
+    pub kind: TransferKind,
+    pub source_path: String,
+    pub target_path: String,
+    pub client_request_id: String,
+    pub submitter: String,
+    pub tenant: String,
+    pub options: BTreeMap<String, String>,
+}
+
+impl TransferCommand {
+    pub const OVERWRITE_OPTION: &'static str = "overwrite";
+
+    pub fn job_key(&self) -> String {
+        format!("{:?}:{}:{}", self.kind, self.source_path, self.target_path)
+    }
+
+    pub fn default_client_request_id(
+        kind: TransferKind,
+        source_path: impl AsRef<str>,
+        target_path: impl AsRef<str>,
+    ) -> String {
+        CommonUtils::create_job_id(format!(
+            "{:?}:{}:{}",
+            kind,
+            source_path.as_ref(),
+            target_path.as_ref()
+        ))
+    }
+
+    pub fn overwrite(&self) -> bool {
+        self.options
+            .get(Self::OVERWRITE_OPTION)
+            .and_then(|value| value.parse::<bool>().ok())
+            .unwrap_or(true)
+    }
+
+    pub fn set_overwrite(&mut self, overwrite: bool) {
+        self.options
+            .insert(Self::OVERWRITE_OPTION.to_string(), overwrite.to_string());
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TransferProgress {
+    pub loaded_size: i64,
+    pub total_size: i64,
+    pub update_time: i64,
+    pub message: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TransferJobRecord {
+    pub job_key: String,
+    pub job_id: String,
+    pub run_id: u64,
+    pub kind: TransferKind,
+    pub source_path: String,
+    pub target_path: String,
+    pub command_json: String,
+    pub mount_snapshot_json: String,
+    pub secret_ref_json: String,
+    pub cluster_snapshot_version: u64,
+    pub cv_metadata_epoch: Option<u64>,
+    pub state: TransferState,
+    pub owner: String,
+    pub lease_epoch: u64,
+    pub lease_expire_at: i64,
+    pub cancel_requested: bool,
+    pub summary: TransferProgress,
+    pub client_request_id: String,
+    pub submitter: String,
+    pub tenant: String,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TransferTaskRecord {
+    pub job_id: String,
+    pub run_id: u64,
+    pub task_id: String,
+    pub attempt_id: u64,
+    pub source_path: String,
+    pub target_path: String,
+    pub worker_id: u32,
+    pub worker_session_id: String,
+    pub source_read_plan_json: String,
+    pub report_target_json: String,
+    pub state: TransferTaskState,
+    pub progress: TransferProgress,
+    pub retry_count: u32,
+    pub attempt_started_at: i64,
+    pub last_report_at: i64,
+    pub stale_deadline_at: i64,
+    pub updated_at: i64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TransferTaskSummary {
+    pub progress: TransferProgress,
+    pub has_task: bool,
+    pub has_failed: bool,
+    pub all_completed: bool,
+}
+
+pub fn summarize_transfer_tasks<'a>(
+    tasks: impl IntoIterator<Item = &'a TransferTaskRecord>,
+    update_time: i64,
+) -> TransferTaskSummary {
+    let mut summary = TransferTaskSummary {
+        progress: TransferProgress {
+            update_time,
+            ..Default::default()
+        },
+        has_task: false,
+        has_failed: false,
+        all_completed: true,
+    };
+    let mut failed_count = 0;
+    let mut first_error = String::new();
+    let mut last_message = String::new();
+
+    for task in tasks {
+        summary.has_task = true;
+        summary.has_failed |= task.state == TransferTaskState::Failed;
+        summary.all_completed &= task.state == TransferTaskState::Completed;
+        summary.progress.loaded_size += task.progress.loaded_size;
+        summary.progress.total_size += task.progress.total_size;
+
+        if !task.progress.message.is_empty() {
+            last_message = task.progress.message.clone();
+        }
+        if task.state == TransferTaskState::Failed {
+            failed_count += 1;
+            if first_error.is_empty() && !task.progress.message.is_empty() {
+                first_error = task.progress.message.clone();
+            }
+        }
+    }
+
+    if failed_count > 0 {
+        if first_error.is_empty() {
+            first_error = "transfer task failed".to_string();
+        }
+        summary.progress.message = format!(
+            "{} transfer task(s) failed: {}",
+            failed_count,
+            normalize_summary_message(&first_error)
+        );
+    } else {
+        summary.progress.message = last_message;
+    }
+    summary
+}
+
+fn normalize_summary_message(message: &str) -> String {
+    message
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .chars()
+        .take(512)
+        .collect()
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TransferLease {
+    pub job_id: String,
+    pub run_id: u64,
+    pub owner: String,
+    pub lease_epoch: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TransferStateUpdate {
+    pub job_id: String,
+    pub run_id: u64,
+    pub owner: String,
+    pub lease_epoch: u64,
+    pub from_states: Vec<TransferState>,
+    pub to_state: TransferState,
+    pub message: String,
+    pub now_ms: i64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TaskAttemptStart {
+    pub job_id: String,
+    pub run_id: u64,
+    pub owner: String,
+    pub lease_epoch: u64,
+    pub task_id: String,
+    pub attempt_id: u64,
+    pub worker_id: u32,
+    pub worker_session_id: String,
+    pub report_target_json: String,
+    pub now_ms: i64,
+    pub stale_deadline_at: i64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TransferTaskReport {
+    pub job_id: String,
+    pub run_id: u64,
+    pub task_id: String,
+    pub attempt_id: u64,
+    pub worker_id: u32,
+    pub worker_session_id: String,
+    pub state: TransferTaskState,
+    pub progress: TransferProgress,
+    pub now_ms: i64,
+    pub stale_deadline_at: i64,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct TransferListFilter {
+    pub kind: Option<TransferKind>,
+    pub state: Option<TransferState>,
+    pub submitter: Option<String>,
+    pub tenant: Option<String>,
+    pub limit: usize,
+    pub offset: usize,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct TransferTenantSummary {
+    pub tenant: String,
+    pub pending: u64,
+    pub executing: u64,
+    pub completed: u64,
+    pub failed: u64,
+    pub canceled: u64,
+    pub total: u64,
+}
+
+impl TransferTenantSummary {
+    pub fn active(&self) -> u64 {
+        self.pending.saturating_add(self.executing)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StaleTaskAttempt {
+    pub task: TransferTaskRecord,
+}

--- a/curvine-common/src/state/worker_address.rs
+++ b/curvine-common/src/state/worker_address.rs
@@ -31,6 +31,12 @@ impl WorkerAddress {
         self.hostname == hostname
     }
 
+    pub fn same_endpoint(&self, other: &Self) -> bool {
+        self.hostname == other.hostname
+            && self.ip_addr == other.ip_addr
+            && self.rpc_port == other.rpc_port
+    }
+
     pub fn connect_addr(&self) -> String {
         format!("{}:{}", self.ip_addr, self.rpc_port)
     }

--- a/curvine-common/src/state/worker_info.rs
+++ b/curvine-common/src/state/worker_info.rs
@@ -18,6 +18,36 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct TransferWorkerCapabilities {
+    pub task_submit: bool,
+    pub report_target: bool,
+    pub query_task: bool,
+    pub attempt_safe_output: bool,
+    pub source_read_plan: bool,
+}
+
+impl TransferWorkerCapabilities {
+    pub fn current() -> Self {
+        Self {
+            task_submit: true,
+            report_target: true,
+            query_task: true,
+            attempt_safe_output: true,
+            source_read_plan: true,
+        }
+    }
+
+    pub fn supports_transfer(&self) -> bool {
+        self.task_submit
+            && self.report_target
+            && self.query_task
+            && self.attempt_safe_output
+            && self.source_read_plan
+    }
+}
+
 // Describes a worker, which is the basic unit of master management worker.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
@@ -34,6 +64,8 @@ pub struct WorkerInfo {
     pub block_num: i64,
     pub storage_map: HashMap<String, StorageInfo>,
     pub status: WorkerStatus,
+    pub worker_session_id: String,
+    pub transfer_capabilities: TransferWorkerCapabilities,
 }
 
 impl WorkerInfo {
@@ -54,6 +86,8 @@ impl WorkerInfo {
             last_update: LocalTime::mills(),
             storage_map: Default::default(),
             status: WorkerStatus::Live,
+            worker_session_id: String::new(),
+            transfer_capabilities: TransferWorkerCapabilities::default(),
         }
     }
 
@@ -126,6 +160,8 @@ impl Default for WorkerInfo {
             block_num: 0,
             storage_map: Default::default(),
             status: WorkerStatus::Live,
+            worker_session_id: String::new(),
+            transfer_capabilities: TransferWorkerCapabilities::default(),
         }
     }
 }

--- a/curvine-common/src/utils/proto_utils.rs
+++ b/curvine-common/src/utils/proto_utils.rs
@@ -346,6 +346,12 @@ impl ProtoUtils {
             last_update: src.last_update,
             reserved_bytes: src.reserved_bytes,
             weight: Some(src.weight),
+            worker_session_id: Some(src.worker_session_id),
+            transfer_task_submit: Some(src.transfer_capabilities.task_submit),
+            transfer_report_target: Some(src.transfer_capabilities.report_target),
+            transfer_query_task: Some(src.transfer_capabilities.query_task),
+            transfer_attempt_safe_output: Some(src.transfer_capabilities.attempt_safe_output),
+            transfer_source_read_plan: Some(src.transfer_capabilities.source_read_plan),
             storage_map: Default::default(),
         };
 
@@ -387,6 +393,14 @@ impl ProtoUtils {
                 non_fs_used: info.non_fs_used,
                 reserved_bytes: info.reserved_bytes,
                 weight: info.weight.unwrap_or_else(WorkerInfo::default_weight),
+                worker_session_id: info.worker_session_id.unwrap_or_default(),
+                transfer_capabilities: TransferWorkerCapabilities {
+                    task_submit: info.transfer_task_submit.unwrap_or(false),
+                    report_target: info.transfer_report_target.unwrap_or(false),
+                    query_task: info.transfer_query_task.unwrap_or(false),
+                    attempt_safe_output: info.transfer_attempt_safe_output.unwrap_or(false),
+                    source_read_plan: info.transfer_source_read_plan.unwrap_or(false),
+                },
                 ..Default::default()
             };
             for (k, v) in info.storage_map {

--- a/curvine-server/src/master/job/job_runner.rs
+++ b/curvine-server/src/master/job/job_runner.rs
@@ -692,6 +692,8 @@ impl LoadJobRunner {
                     source_path: source_path.clone_uri(),
                     target_path: target_path.clone_uri(),
                     create_time: LocalTime::mills() as i64,
+                    source_read_plan_json: String::new(),
+                    transfer_report: None,
                 };
                 tasks.insert(task_id.clone(), TaskDetail::new(task));
 

--- a/curvine-server/src/worker/handler/worker_handler.rs
+++ b/curvine-server/src/worker/handler/worker_handler.rs
@@ -126,7 +126,11 @@ impl WorkerHandler {
         let task_id = task.task_id.clone();
 
         self.task_manager.submit_task(task)?;
-        let response = SubmitTaskResponse { task_id };
+        let response = SubmitTaskResponse {
+            task_id,
+            accepted: Some(true),
+            reject_reason: None,
+        };
 
         Ok(Builder::success(msg).proto_header(response).build())
     }

--- a/curvine-server/src/worker/task/task_store.rs
+++ b/curvine-server/src/worker/task/task_store.rs
@@ -112,6 +112,8 @@ mod supersede_tests {
             source_path: "s".to_string(),
             target_path: "t".to_string(),
             create_time: 0,
+            source_read_plan_json: String::new(),
+            transfer_report: None,
         }
     }
 

--- a/curvine-server/tests/load_job_submit_test.rs
+++ b/curvine-server/tests/load_job_submit_test.rs
@@ -116,6 +116,8 @@ fn load_task(task_id: &str, job_id: &str) -> LoadTaskInfo {
         source_path: "file://source".to_string(),
         target_path: "/mnt/source".to_string(),
         create_time: 0,
+        source_read_plan_json: String::new(),
+        transfer_report: None,
     }
 }
 


### PR DESCRIPTION
# Summary
Define the Transfer service contract without starting the service itself.
This PR adds the public RPC schema, configuration, state model, and error surface consumed by later Transfer implementation PRs.

# Issue Describe / Design
Related to #1238.
The configuration retains compatibility inputs while normalizing runtime storage selection through `store_url`.

# Changes
| Module / File | Change | Impact on existing behavior |
| --- | --- | --- |
| `curvine-common/proto/transfer.proto` | Add Transfer request, status, and task-report messages. | New protocol only. |
| `curvine-common/src/conf/transfer_conf.rs` | Add Transfer configuration and validation. | Disabled by default. |
| `curvine-common/src/state/transfer.rs` | Add transfer state, task, and progress types. | New API surface only. |
| common protocol/state helpers | Add RPC codes, errors, and Worker capability fields. | Backward-compatible optional fields. |

# Test verified
| Test case | Result | Notes |
| --- | --- | --- |
| `cargo check -p curvine-common` | PASS | |

# Dependencies
- Related PRs: Blocks the Transfer persistence, metadata, scheduler, client, and deployment PRs.
- Related issues: #1238