### PR TITLE
feat(transfer): add local transfer stores

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,17 +21,6 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom 0.2.16",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
@@ -222,7 +211,7 @@ version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c8955af33b25f3b175ee10af580577280b4bd01f7e823d94c7cdef7cf8c9aef"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
@@ -380,7 +369,7 @@ version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68bf3e3efbd1278f770d67e5dc410257300b161b93baedb3aae836144edcaf4b"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
@@ -1284,30 +1273,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "borsh"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
-dependencies = [
- "borsh-derive",
- "bytes",
- "cfg_aliases",
-]
-
-[[package]]
-name = "borsh-derive"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae8fb4fb5740e4b2c4884ff95f5f32f5e8479db1e8fd8eb49ddbe09eb09bb7c"
-dependencies = [
- "once_cell",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1329,47 +1294,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "btoi"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd6407f73a9b8b6162d8a2ef999fe6afd7cc15902ebf42c5cd296addf17e0ad"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "bufstream"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40e38929add23cdf8a366df9b0e088953150724bcbe5fc330b0d8eb3b328eec8"
-
-[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
-
-[[package]]
-name = "bytecheck"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
-dependencies = [
- "bytecheck_derive",
- "ptr_meta",
- "simdutf8",
-]
-
-[[package]]
-name = "bytecheck_derive"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "bytecount"
@@ -2018,14 +1946,12 @@ dependencies = [
  "comfy-table",
  "curvine-client",
  "curvine-common",
- "curvine-server",
  "curvine-ufs",
  "orpc",
  "reqwest 0.12.25",
  "serde",
  "serde_json",
  "tokio",
- "toml",
 ]
 
 [[package]]
@@ -2232,7 +2158,6 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
- "crossbeam",
  "curvine-client",
  "curvine-common",
  "curvine-fault",
@@ -2246,7 +2171,6 @@ dependencies = [
  "log",
  "lru 0.16.1",
  "mini-moka",
- "mysql",
  "num_enum",
  "once_cell",
  "orpc",
@@ -2495,7 +2419,7 @@ version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d551054acec0398ca604512310b77ce05c46f66e54b54d48200a686e385cca4e"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "arrow",
  "arrow-ipc",
  "chrono",
@@ -2719,7 +2643,7 @@ version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b644f9cf696df9233ce6958b9807666d78563b56f923267474dd6c07795f1f8f"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "arrow",
  "datafusion-common",
  "datafusion-doc",
@@ -2740,7 +2664,7 @@ version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1de2deaaabe8923ce9ea9f29c47bbb4ee14f67ea2fe1ab5398d9bbebcf86e56"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "arrow",
  "datafusion-common",
  "datafusion-expr-common",
@@ -2850,7 +2774,7 @@ version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d48022b8af9988c1d852644f9e8b5584c490659769a550c5e8d39457a1da0a5"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "arrow",
  "datafusion-common",
  "datafusion-expr",
@@ -2888,7 +2812,7 @@ version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147253ca3e6b9d59c162de64c02800973018660e13340dd1886dd038d17ac429"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "arrow",
  "chrono",
  "datafusion-common",
@@ -2923,7 +2847,7 @@ version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68253dc0ee5330aa558b2549c9b0da5af9fc17d753ae73022939014ad616fc28"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "arrow",
  "arrow-ord",
  "arrow-schema",
@@ -3065,17 +2989,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "derive_utils"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "362f47930db19fe7735f527e6595e4900316b893ebf6d48ad3d31be928d57dd6"
-dependencies = [
- "proc-macro2",
- "quote",
  "syn 2.0.117",
 ]
 
@@ -3433,21 +3346,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "foreign_vec"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3460,68 +3358,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "frunk"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28aef0f9aa070bce60767c12ba9cb41efeaf1a2bc6427f87b7d83f11239a16d7"
-dependencies = [
- "frunk_core 0.4.4",
- "frunk_derives",
- "frunk_proc_macros",
- "serde",
-]
-
-[[package]]
-name = "frunk_core"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "476eeaa382e3462b84da5d6ba3da97b5786823c2d0d3a0d04ef088d073da225c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "frunk_core"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bd3c9ba2e323e8b19e77f15873f60974a7d82f89b80e50c53be44b8b92927c1"
-
-[[package]]
-name = "frunk_derives"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0b4095fc99e1d858e5b8c7125d2638372ec85aa0fe6c807105cf10b0265ca6c"
-dependencies = [
- "frunk_proc_macro_helpers",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "frunk_proc_macro_helpers"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b70229a1347a20d4af9c06116cc452acef34f798668c6b69e97dd5c8a88052bd"
-dependencies = [
- "frunk_core 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "frunk_proc_macros"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c63fe4306e13ece9d1ac23ce02f121ffefd42ae876ad03ec2caf07232bde3023"
-dependencies = [
- "frunk_core 0.5.0",
- "frunk_proc_macro_helpers",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -3989,9 +3825,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.8",
-]
 
 [[package]]
 name = "hashbrown"
@@ -3999,7 +3832,7 @@ version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "allocator-api2",
  "rayon",
 ]
@@ -4579,15 +4412,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-enum"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de9008599afe8527a8c9d70423437363b321649161e98473f433de802d76107"
-dependencies = [
- "derive_utils",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5122,7 +4946,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
- "twox-hash 2.1.2",
+ "twox-hash",
  "uuid",
 ]
 
@@ -5308,7 +5132,7 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce0f4d7f739dc30608fe8b202cbb40986c2937e1a5a189f98fb06d7b8543156a"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "arrow",
  "arrow-array",
  "arrow-cast",
@@ -5693,7 +5517,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90071f8077f8e40adfc4b7fe9cd495ce316263f19e75c2211eeff3fdf475a3d9"
 dependencies = [
- "twox-hash 2.1.2",
+ "twox-hash",
 ]
 
 [[package]]
@@ -5948,114 +5772,6 @@ name = "murmurhash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
-
-[[package]]
-name = "mysql"
-version = "25.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6ad644efb545e459029b1ffa7c969d830975bd76906820913247620df10050b"
-dependencies = [
- "bufstream",
- "bytes",
- "crossbeam",
- "flate2",
- "io-enum",
- "libc",
- "lru 0.12.5",
- "mysql_common",
- "named_pipe",
- "native-tls",
- "pem",
- "percent-encoding",
- "serde",
- "serde_json",
- "socket2 0.5.10",
- "twox-hash 1.6.3",
- "url",
-]
-
-[[package]]
-name = "mysql-common-derive"
-version = "0.31.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63c3512cf11487168e0e9db7157801bf5273be13055a9cc95356dc9e0035e49c"
-dependencies = [
- "darling",
- "heck 0.5.0",
- "num-bigint",
- "proc-macro-crate",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "termcolor",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "mysql_common"
-version = "0.32.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478b0ff3f7d67b79da2b96f56f334431aef65e15ba4b29dd74a4236e29582bdc"
-dependencies = [
- "base64 0.21.7",
- "bigdecimal",
- "bindgen",
- "bitflags 2.10.0",
- "bitvec",
- "btoi",
- "byteorder",
- "bytes",
- "cc",
- "cmake",
- "crc32fast",
- "flate2",
- "frunk",
- "lazy_static",
- "mysql-common-derive",
- "num-bigint",
- "num-traits",
- "rand 0.8.5",
- "regex",
- "rust_decimal",
- "saturating",
- "serde",
- "serde_json",
- "sha1",
- "sha2",
- "smallvec",
- "subprocess",
- "thiserror 1.0.69",
- "time",
- "uuid",
- "zstd",
-]
-
-[[package]]
-name = "named_pipe"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad9c443cce91fc3e12f017290db75dde490d685cdaaf508d7159d7cf41f0eb2b"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
 
 [[package]]
 name = "ndarray"
@@ -6378,47 +6094,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
-dependencies = [
- "bitflags 2.10.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.117"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -6814,7 +6493,7 @@ version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "725b09f2b5ef31279b66e27bbab63c58d49d8f6696b66b1f46c7eaab95e80f75"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "atoi",
  "atoi_simd",
  "bytemuck",
@@ -6875,7 +6554,7 @@ version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "465f70d3e96b6d0b1a43c358ba451286b8c8bd56696feff020d65702aa33e35c"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "bitflags 2.10.0",
  "bytemuck",
  "chrono",
@@ -6919,7 +6598,7 @@ version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2c8589e418cbe4a48228d64b2a8a40284a82ec3c98817c0c2bcc0267701338b"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "atoi_simd",
  "bytes",
  "chrono",
@@ -6949,7 +6628,7 @@ version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2632b1af668e2058d5f8f916d8fbde3cac63d03ae29a705f598e41dcfeb7f"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "bitflags 2.10.0",
  "glob",
  "once_cell",
@@ -6972,7 +6651,7 @@ version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efdbdb4d9a92109bc2e0ce8e17af5ae8ab643bb5b7ee9d1d74f0aeffd1fbc95f"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "argminmax",
  "base64 0.21.7",
  "bytemuck",
@@ -7002,7 +6681,7 @@ version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b421d2196f786fdfe162db614c8485f8308fe41575d4de634a39bbe460d1eb6a"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "base64 0.21.7",
  "ethnum",
  "num-traits",
@@ -7046,7 +6725,7 @@ version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fb8e2302e20c44defd5be8cad9c96e75face63c3a5f609aced8c4ec3b3ac97d"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "bytemuck",
  "chrono-tz 0.8.6",
  "hashbrown 0.14.5",
@@ -7122,7 +6801,7 @@ version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c760b6c698cfe2fbbbd93d6cfb408db14ececfe1d92445dae2229ce1b5b21ae8"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "bytemuck",
  "hashbrown 0.14.5",
  "indexmap 2.14.0",
@@ -7409,26 +7088,6 @@ checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
 dependencies = [
  "ar_archive_writer",
  "cc",
-]
-
-[[package]]
-name = "ptr_meta"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
-dependencies = [
- "ptr_meta_derive",
-]
-
-[[package]]
-name = "ptr_meta_derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -7781,7 +7440,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e47a395bdb55442b883c89062d6bcff25dc90fa5f8369af81e0ac6d49d78cf81"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "brotli",
  "paste",
  "rand 0.9.2",
@@ -7957,15 +7616,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
-name = "rend"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
-dependencies = [
- "bytecheck",
-]
-
-[[package]]
 name = "reqsign"
 version = "0.16.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8115,35 +7765,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rkyv"
-version = "0.7.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
-dependencies = [
- "bitvec",
- "bytecheck",
- "bytes",
- "hashbrown 0.12.3",
- "ptr_meta",
- "rend",
- "rkyv_derive",
- "seahash",
- "tinyvec",
- "uuid",
-]
-
-[[package]]
-name = "rkyv_derive"
-version = "0.7.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "roaring"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8235,23 +7856,6 @@ checksum = "e46a2036019fdb888131db7a4c847a1063a7493f971ed94ea82c67eada63ca54"
 dependencies = [
  "serde",
  "serde_derive",
-]
-
-[[package]]
-name = "rust_decimal"
-version = "1.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be2a24f50780bc85f09cc6ac299bdf1424302742d77221106859c9d8b102126a"
-dependencies = [
- "arrayvec",
- "borsh",
- "bytes",
- "num-traits",
- "rand 0.8.5",
- "rkyv",
- "serde",
- "serde_json",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -8433,12 +8037,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "saturating"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ece8e78b2f38ec51c51f5d475df0a7187ba5111b2a28bdc761ee05b075d40a71"
-
-[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8503,12 +8101,6 @@ dependencies = [
  "ring",
  "untrusted",
 ]
-
-[[package]]
-name = "seahash"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "secrecy"
@@ -9069,16 +8661,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "subprocess"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c56e8662b206b9892d7a5a3f2ecdbcb455d3d6b259111373b7e08b8055158a8"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9390,15 +8972,6 @@ dependencies = [
  "once_cell",
  "rustix 1.0.8",
  "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]
@@ -9882,17 +9455,6 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "twox-hash"
-version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
-dependencies = [
- "cfg-if",
- "rand 0.8.5",
- "static_assertions",
-]
-
-[[package]]
-name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
@@ -10137,7 +9699,6 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
- "serde",
  "wasm-bindgen-macro",
 ]
 

--- a/curvine-server/Cargo.toml
+++ b/curvine-server/Cargo.toml
@@ -51,6 +51,7 @@ url = { workspace = true }
 parking_lot = { workspace = true }
 lru = { workspace = true }
 byteorder = { workspace = true }
+rusqlite = { workspace = true }
 
 [dev-dependencies]
 curvine-fault = { workspace = true, features = ["http-client"] }

--- a/curvine-server/src/transfer/memory_store.rs
+++ b/curvine-server/src/transfer/memory_store.rs
@@ -1,0 +1,735 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+
+use curvine_common::error::FsError;
+use curvine_common::state::{
+    summarize_transfer_tasks, StaleTaskAttempt, TaskAttemptStart, TransferJobRecord, TransferLease,
+    TransferListFilter, TransferState, TransferStateUpdate, TransferTaskRecord, TransferTaskReport,
+    TransferTaskState, TransferTenantSummary,
+};
+use curvine_common::FsResult;
+use parking_lot::Mutex;
+
+use crate::transfer::{TransferRequeueUpdate, TransferStore};
+
+#[derive(Default)]
+pub struct MemoryTransferStore {
+    inner: Mutex<MemoryTransferState>,
+}
+
+#[derive(Default)]
+struct MemoryTransferState {
+    jobs: HashMap<String, TransferJobRecord>,
+    request_index: HashMap<(String, String), String>,
+    tasks: HashMap<(String, u64, String), TransferTaskRecord>,
+}
+
+impl MemoryTransferStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl TransferStore for MemoryTransferStore {
+    fn check_available(&self) -> FsResult<()> {
+        Ok(())
+    }
+
+    fn create_or_get_by_request_id(&self, job: TransferJobRecord) -> FsResult<TransferJobRecord> {
+        self.create_or_get_by_request_id_checked(job)
+    }
+
+    fn create_or_get_by_request_id_checked(
+        &self,
+        job: TransferJobRecord,
+    ) -> FsResult<TransferJobRecord> {
+        let mut inner = self.inner.lock();
+        let request_key = (job.submitter.clone(), job.client_request_id.clone());
+        if let Some(job_id) = inner.request_index.get(&request_key) {
+            return inner
+                .jobs
+                .get(job_id)
+                .cloned()
+                .ok_or_else(|| FsError::job_not_found(job_id));
+        }
+
+        if let Some(existing) = inner
+            .jobs
+            .values()
+            .find(|existing| existing.job_key == job.job_key && !existing.state.is_terminal())
+        {
+            if existing.command_json == job.command_json {
+                return Ok(existing.clone());
+            }
+            return Err(FsError::transfer_already_running(format!(
+                "job_key {} has running job {} with different command",
+                existing.job_key, existing.job_id
+            )));
+        }
+
+        if let Some(existing) = inner.jobs.values().find(|existing| {
+            !(existing.state.is_terminal()
+                || (existing.submitter == job.submitter
+                    && existing.client_request_id == job.client_request_id))
+                && target_paths_conflict(&existing.target_path, &job.target_path)
+        }) {
+            return Err(FsError::transfer_target_conflict(format!(
+                "target {} conflicts with active transfer {} target {}",
+                job.target_path, existing.job_id, existing.target_path
+            )));
+        }
+
+        inner.request_index.insert(request_key, job.job_id.clone());
+        inner.jobs.insert(job.job_id.clone(), job.clone());
+        Ok(job)
+    }
+
+    fn get_transfer(&self, job_id: &str) -> FsResult<Option<TransferJobRecord>> {
+        Ok(self.inner.lock().jobs.get(job_id).cloned())
+    }
+
+    fn get_transfer_by_request(
+        &self,
+        submitter: &str,
+        client_request_id: &str,
+    ) -> FsResult<Option<TransferJobRecord>> {
+        let inner = self.inner.lock();
+        let Some(job_id) = inner
+            .request_index
+            .get(&(submitter.to_string(), client_request_id.to_string()))
+        else {
+            return Ok(None);
+        };
+        Ok(inner.jobs.get(job_id).cloned())
+    }
+
+    fn list_active_transfers(&self) -> FsResult<Vec<TransferJobRecord>> {
+        Ok(self
+            .inner
+            .lock()
+            .jobs
+            .values()
+            .filter(|job| !job.state.is_terminal())
+            .cloned()
+            .collect())
+    }
+
+    fn find_conflicting_active_transfer(
+        &self,
+        target_path: &str,
+        submitter: &str,
+        client_request_id: &str,
+    ) -> FsResult<Option<TransferJobRecord>> {
+        Ok(self
+            .inner
+            .lock()
+            .jobs
+            .values()
+            .find(|job| {
+                !(job.state.is_terminal()
+                    || (job.submitter == submitter && job.client_request_id == client_request_id))
+                    && target_paths_conflict(target_path, &job.target_path)
+            })
+            .cloned())
+    }
+
+    fn count_active_transfers(&self) -> FsResult<u64> {
+        Ok(self
+            .inner
+            .lock()
+            .jobs
+            .values()
+            .filter(|job| !job.state.is_terminal())
+            .count() as u64)
+    }
+
+    fn count_executing_transfers(&self) -> FsResult<u64> {
+        Ok(self
+            .inner
+            .lock()
+            .jobs
+            .values()
+            .filter(|job| job.state.is_executing())
+            .count() as u64)
+    }
+
+    fn list_transfers(&self, filter: TransferListFilter) -> FsResult<Vec<TransferJobRecord>> {
+        let mut jobs: Vec<_> = self
+            .inner
+            .lock()
+            .jobs
+            .values()
+            .filter(|job| filter.kind.is_none_or(|kind| job.kind == kind))
+            .filter(|job| filter.state.is_none_or(|state| job.state == state))
+            .filter(|job| {
+                filter
+                    .submitter
+                    .as_ref()
+                    .is_none_or(|submitter| job.submitter == *submitter)
+            })
+            .filter(|job| {
+                filter
+                    .tenant
+                    .as_ref()
+                    .is_none_or(|tenant| job.tenant == *tenant)
+            })
+            .cloned()
+            .collect();
+        jobs.sort_by(|left, right| {
+            right
+                .updated_at
+                .cmp(&left.updated_at)
+                .then_with(|| right.created_at.cmp(&left.created_at))
+                .then_with(|| right.job_id.cmp(&left.job_id))
+        });
+        Ok(jobs
+            .into_iter()
+            .skip(filter.offset)
+            .take(filter.limit)
+            .collect())
+    }
+
+    fn list_tenant_summaries(
+        &self,
+        limit: usize,
+        offset: usize,
+    ) -> FsResult<Vec<TransferTenantSummary>> {
+        let inner = self.inner.lock();
+        let mut summaries = HashMap::<String, TransferTenantSummary>::new();
+        for job in inner.jobs.values() {
+            add_job_to_tenant_summary(&mut summaries, job);
+        }
+        Ok(sorted_tenant_summaries(summaries, limit, offset))
+    }
+
+    fn purge_terminal_transfers(&self, older_than_ms: i64, limit: usize) -> FsResult<usize> {
+        if limit == 0 {
+            return Ok(0);
+        }
+        let mut inner = self.inner.lock();
+        let job_ids = inner
+            .jobs
+            .values()
+            .filter(|job| job.state.is_terminal() && job.updated_at < older_than_ms)
+            .take(limit)
+            .map(|job| job.job_id.clone())
+            .collect::<Vec<_>>();
+        for job_id in &job_ids {
+            inner.jobs.remove(job_id);
+            inner
+                .request_index
+                .retain(|_, indexed_job_id| indexed_job_id != job_id);
+            inner
+                .tasks
+                .retain(|(task_job_id, _, _), _| task_job_id != job_id);
+        }
+        Ok(job_ids.len())
+    }
+
+    fn list_transfer_tasks(&self, job_id: &str, run_id: u64) -> FsResult<Vec<TransferTaskRecord>> {
+        Ok(self
+            .inner
+            .lock()
+            .tasks
+            .values()
+            .filter(|task| task.job_id == job_id && task.run_id == run_id)
+            .cloned()
+            .collect())
+    }
+
+    fn request_cancel(&self, job_id: &str, run_id: u64, now_ms: i64) -> FsResult<bool> {
+        let mut inner = self.inner.lock();
+        let Some(job) = inner.jobs.get_mut(job_id) else {
+            return Ok(false);
+        };
+        if job.run_id != run_id || job.state.is_terminal() {
+            return Ok(false);
+        }
+        job.cancel_requested = true;
+        job.state = TransferState::Canceling;
+        job.summary.message = "cancel requested".to_string();
+        job.summary.update_time = now_ms;
+        job.updated_at = now_ms;
+        Ok(true)
+    }
+
+    fn acquire_runnable_transfer(
+        &self,
+        owner: &str,
+        lease_ms: i64,
+        now_ms: i64,
+        max_executing_transfers: u64,
+    ) -> FsResult<Option<TransferLease>> {
+        let mut inner = self.inner.lock();
+        let executing = inner
+            .jobs
+            .values()
+            .filter(|job| job.state.is_executing())
+            .count() as u64;
+        let candidate_id = inner
+            .jobs
+            .values()
+            .filter(|job| {
+                job.owner == owner
+                    && matches!(job.state, TransferState::Running | TransferState::Canceling)
+                    && job.lease_expire_at > now_ms
+                    && job.updated_at < now_ms
+            })
+            .min_by_key(|job| job.updated_at)
+            .map(|job| job.job_id.clone())
+            .or_else(|| {
+                inner
+                    .jobs
+                    .values()
+                    .filter(|job| {
+                        job.state.is_runnable()
+                            && job.state != TransferState::Pending
+                            && job.lease_expire_at <= now_ms
+                    })
+                    .min_by_key(|job| job.updated_at)
+                    .map(|job| job.job_id.clone())
+            })
+            .or_else(|| {
+                if executing >= max_executing_transfers {
+                    return None;
+                }
+                inner
+                    .jobs
+                    .values()
+                    .filter(|job| {
+                        job.state == TransferState::Pending && job.lease_expire_at <= now_ms
+                    })
+                    .min_by_key(|job| {
+                        let executing_for_tenant = executing_for_tenant(&inner, &job.tenant);
+                        let tenant_pressure = u64::from(executing_for_tenant > 0);
+                        (tenant_pressure, job.updated_at, job.job_id.clone())
+                    })
+                    .map(|job| job.job_id.clone())
+            });
+        let Some(candidate_id) = candidate_id else {
+            return Ok(None);
+        };
+        let Some(job) = inner.jobs.get_mut(&candidate_id) else {
+            return Ok(None);
+        };
+
+        if job.state == TransferState::Pending {
+            job.state = TransferState::Planning;
+            job.summary.message = "acquired for planning".to_string();
+            job.summary.update_time = now_ms;
+        }
+        job.owner = owner.to_string();
+        job.lease_epoch = job.lease_epoch.saturating_add(1);
+        job.lease_expire_at = now_ms.saturating_add(lease_ms);
+        job.updated_at = now_ms;
+        Ok(Some(TransferLease {
+            job_id: job.job_id.clone(),
+            run_id: job.run_id,
+            owner: job.owner.clone(),
+            lease_epoch: job.lease_epoch,
+        }))
+    }
+
+    fn renew_lease(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        owner: &str,
+        lease_epoch: u64,
+        lease_ms: i64,
+        now_ms: i64,
+    ) -> FsResult<bool> {
+        let mut inner = self.inner.lock();
+        let Some(job) = inner.jobs.get_mut(job_id) else {
+            return Ok(false);
+        };
+        if job.run_id != run_id
+            || job.owner != owner
+            || job.lease_epoch != lease_epoch
+            || job.state.is_terminal()
+        {
+            return Ok(false);
+        }
+
+        job.lease_expire_at = now_ms.saturating_add(lease_ms);
+        job.updated_at = now_ms;
+        Ok(true)
+    }
+
+    fn update_transfer_state(&self, update: TransferStateUpdate) -> FsResult<bool> {
+        let mut inner = self.inner.lock();
+        let Some(job) = inner.jobs.get_mut(&update.job_id) else {
+            return Ok(false);
+        };
+        if job.run_id != update.run_id
+            || job.owner != update.owner
+            || job.lease_epoch != update.lease_epoch
+            || !update.from_states.contains(&job.state)
+        {
+            return Ok(false);
+        }
+
+        job.state = update.to_state;
+        job.summary.message = update.message;
+        job.updated_at = update.now_ms;
+        Ok(true)
+    }
+
+    fn set_transfer_state(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        state: TransferState,
+        message: impl Into<String>,
+        now_ms: i64,
+    ) -> FsResult<bool> {
+        let mut inner = self.inner.lock();
+        let Some(job) = inner.jobs.get_mut(job_id) else {
+            return Ok(false);
+        };
+        if job.run_id != run_id {
+            return Ok(false);
+        }
+
+        job.state = state;
+        job.summary.message = message.into();
+        job.summary.update_time = now_ms;
+        job.updated_at = now_ms;
+        Ok(true)
+    }
+
+    fn requeue_transfer(&self, update: TransferRequeueUpdate) -> FsResult<bool> {
+        let mut inner = self.inner.lock();
+        let Some(job) = inner.jobs.get_mut(&update.job_id) else {
+            return Ok(false);
+        };
+        if job.run_id != update.run_id
+            || job.owner != update.owner
+            || job.lease_epoch != update.lease_epoch
+            || job.state != TransferState::Planning
+        {
+            return Ok(false);
+        }
+
+        job.state = TransferState::Pending;
+        job.owner.clear();
+        job.lease_expire_at = update.next_attempt_at_ms;
+        job.summary.message = update.message;
+        job.summary.update_time = update.now_ms;
+        job.updated_at = update.now_ms;
+        Ok(true)
+    }
+
+    fn set_transfer_cv_metadata_epoch(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        owner: &str,
+        lease_epoch: u64,
+        cv_metadata_epoch: u64,
+        now_ms: i64,
+    ) -> FsResult<bool> {
+        let mut inner = self.inner.lock();
+        let Some(job) = inner.jobs.get_mut(job_id) else {
+            return Ok(false);
+        };
+        if job.run_id != run_id
+            || job.owner != owner
+            || job.lease_epoch != lease_epoch
+            || job.state.is_terminal()
+        {
+            return Ok(false);
+        }
+        if job
+            .cv_metadata_epoch
+            .is_some_and(|existing| existing != cv_metadata_epoch)
+        {
+            return Ok(false);
+        }
+
+        job.cv_metadata_epoch = Some(cv_metadata_epoch);
+        job.updated_at = now_ms;
+        Ok(true)
+    }
+
+    fn insert_tasks(&self, tasks: Vec<TransferTaskRecord>) -> FsResult<()> {
+        let mut inner = self.inner.lock();
+        for task in tasks {
+            let key = (task.job_id.clone(), task.run_id, task.task_id.clone());
+            inner.tasks.entry(key).or_insert(task);
+        }
+        Ok(())
+    }
+
+    fn update_task_state(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        task_id: &str,
+        state: TransferTaskState,
+        message: impl Into<String>,
+        now_ms: i64,
+    ) -> FsResult<bool> {
+        let mut inner = self.inner.lock();
+        let key = (job_id.to_string(), run_id, task_id.to_string());
+        let Some(task) = inner.tasks.get_mut(&key) else {
+            return Ok(false);
+        };
+
+        task.state = state;
+        task.progress.message = message.into();
+        task.progress.update_time = now_ms;
+        task.updated_at = now_ms;
+        Ok(true)
+    }
+
+    fn claim_pending_tasks(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        limit: usize,
+    ) -> FsResult<Vec<TransferTaskRecord>> {
+        let inner = self.inner.lock();
+        Ok(inner
+            .tasks
+            .values()
+            .filter(|task| {
+                task.job_id == job_id
+                    && task.run_id == run_id
+                    && task.state == TransferTaskState::Pending
+            })
+            .take(limit)
+            .cloned()
+            .collect())
+    }
+
+    fn mark_stale_attempts(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        owner: &str,
+        lease_epoch: u64,
+        now_ms: i64,
+        limit: usize,
+    ) -> FsResult<Vec<StaleTaskAttempt>> {
+        let mut inner = self.inner.lock();
+        let Some(job) = inner.jobs.get(job_id) else {
+            return Ok(Vec::new());
+        };
+        if job.run_id != run_id || job.owner != owner || job.lease_epoch != lease_epoch {
+            return Ok(Vec::new());
+        }
+
+        let mut stale = Vec::new();
+        for task in inner.tasks.values_mut().filter(|task| {
+            task.job_id == job_id
+                && task.run_id == run_id
+                && task.state == TransferTaskState::Running
+                && task.stale_deadline_at < now_ms
+        }) {
+            task.state = TransferTaskState::Stale;
+            task.retry_count = task.retry_count.saturating_add(1);
+            task.progress.message = "task stale timeout".to_string();
+            task.progress.update_time = now_ms;
+            task.updated_at = now_ms;
+            stale.push(StaleTaskAttempt { task: task.clone() });
+            if stale.len() >= limit {
+                break;
+            }
+        }
+        Ok(stale)
+    }
+
+    fn list_recoverable_tasks(
+        &self,
+        job_id: &str,
+        run_id: u64,
+    ) -> FsResult<Vec<TransferTaskRecord>> {
+        Ok(self
+            .inner
+            .lock()
+            .tasks
+            .values()
+            .filter(|task| {
+                task.job_id == job_id
+                    && task.run_id == run_id
+                    && matches!(
+                        task.state,
+                        TransferTaskState::Pending
+                            | TransferTaskState::Running
+                            | TransferTaskState::Stale
+                    )
+            })
+            .cloned()
+            .collect())
+    }
+
+    fn start_task_attempt(&self, start: TaskAttemptStart) -> FsResult<bool> {
+        let mut inner = self.inner.lock();
+        let Some(job) = inner.jobs.get(&start.job_id) else {
+            return Ok(false);
+        };
+        if job.run_id != start.run_id
+            || job.owner != start.owner
+            || job.lease_epoch != start.lease_epoch
+            || job.cancel_requested
+            || job.state.is_terminal()
+        {
+            return Ok(false);
+        }
+        let key = (start.job_id, start.run_id, start.task_id);
+        let Some(task) = inner.tasks.get_mut(&key) else {
+            return Ok(false);
+        };
+        if !matches!(
+            task.state,
+            TransferTaskState::Pending | TransferTaskState::Stale
+        ) {
+            return Ok(false);
+        }
+
+        task.attempt_id = start.attempt_id;
+        task.worker_id = start.worker_id;
+        task.worker_session_id = start.worker_session_id;
+        task.report_target_json = start.report_target_json;
+        task.state = TransferTaskState::Running;
+        task.attempt_started_at = start.now_ms;
+        task.last_report_at = start.now_ms;
+        task.stale_deadline_at = start.stale_deadline_at;
+        task.updated_at = start.now_ms;
+        Ok(true)
+    }
+
+    fn update_task_report(&self, report: TransferTaskReport) -> FsResult<bool> {
+        let mut inner = self.inner.lock();
+        let key = (report.job_id, report.run_id, report.task_id);
+        let (task_job_id, task_state) = {
+            let Some(task) = inner.tasks.get_mut(&key) else {
+                return Ok(false);
+            };
+            if task.attempt_id != report.attempt_id
+                || task.worker_id != report.worker_id
+                || task.worker_session_id != report.worker_session_id
+                || !task.state.is_running()
+            {
+                return Ok(false);
+            }
+
+            task.state = report.state;
+            task.progress = report.progress;
+            task.last_report_at = report.now_ms;
+            task.stale_deadline_at = report.stale_deadline_at;
+            task.updated_at = report.now_ms;
+            (task.job_id.clone(), task.state)
+        };
+
+        let summary = summarize_transfer_tasks(
+            inner
+                .tasks
+                .values()
+                .filter(|task| task.job_id == task_job_id && task.run_id == report.run_id),
+            report.now_ms,
+        );
+        let has_failed = summary.has_failed;
+        let all_completed = summary.all_completed;
+        let has_task = summary.has_task;
+        let progress = summary.progress;
+
+        if let Some(job) = inner.jobs.get_mut(&task_job_id) {
+            job.summary = progress;
+            job.updated_at = report.now_ms;
+            if has_failed {
+                job.state = TransferState::Failed;
+            } else if has_task && all_completed {
+                job.state = TransferState::Completed;
+            } else if task_state == TransferTaskState::Completed {
+                job.state = TransferState::Running;
+            }
+        }
+        Ok(true)
+    }
+}
+
+fn executing_for_tenant(inner: &MemoryTransferState, tenant: &str) -> u64 {
+    inner
+        .jobs
+        .values()
+        .filter(|job| job.tenant == tenant && job.state.is_executing())
+        .count() as u64
+}
+
+fn add_job_to_tenant_summary(
+    summaries: &mut HashMap<String, TransferTenantSummary>,
+    job: &TransferJobRecord,
+) {
+    let summary = summaries
+        .entry(job.tenant.clone())
+        .or_insert_with(|| TransferTenantSummary {
+            tenant: job.tenant.clone(),
+            ..Default::default()
+        });
+    summary.total = summary.total.saturating_add(1);
+    match job.state {
+        TransferState::Pending => summary.pending = summary.pending.saturating_add(1),
+        TransferState::Planning
+        | TransferState::Dispatching
+        | TransferState::Running
+        | TransferState::Canceling => summary.executing = summary.executing.saturating_add(1),
+        TransferState::Completed => summary.completed = summary.completed.saturating_add(1),
+        TransferState::Failed => summary.failed = summary.failed.saturating_add(1),
+        TransferState::Canceled => summary.canceled = summary.canceled.saturating_add(1),
+    }
+}
+
+fn sorted_tenant_summaries(
+    summaries: HashMap<String, TransferTenantSummary>,
+    limit: usize,
+    offset: usize,
+) -> Vec<TransferTenantSummary> {
+    let mut values = summaries.into_values().collect::<Vec<_>>();
+    values.sort_by(|left, right| {
+        right
+            .active()
+            .cmp(&left.active())
+            .then_with(|| right.total.cmp(&left.total))
+            .then_with(|| left.tenant.cmp(&right.tenant))
+    });
+    values.into_iter().skip(offset).take(limit).collect()
+}
+
+fn target_paths_conflict(left: &str, right: &str) -> bool {
+    let left = normalize_target_path(left);
+    let right = normalize_target_path(right);
+    if left == "/" || right == "/" {
+        return true;
+    }
+    left == right
+        || left
+            .strip_prefix(&right)
+            .is_some_and(|suffix| suffix.starts_with('/'))
+        || right
+            .strip_prefix(&left)
+            .is_some_and(|suffix| suffix.starts_with('/'))
+}
+
+fn normalize_target_path(path: &str) -> String {
+    let trimmed = path.trim_end_matches('/');
+    if trimmed.is_empty() {
+        "/".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}

--- a/curvine-server/src/transfer/mod.rs
+++ b/curvine-server/src/transfer/mod.rs
@@ -12,14 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod common;
-pub mod master;
-pub mod test;
-pub mod transfer;
-pub mod worker;
+mod store;
+pub use self::store::*;
 
-#[cfg(feature = "fault-injection")]
-pub(crate) use curvine_fault::fault_point;
+mod memory_store;
+pub use self::memory_store::MemoryTransferStore;
 
-#[cfg(not(feature = "fault-injection"))]
-pub(crate) use curvine_fault::__noop_fault_point as fault_point;
+mod sqlite_store;
+pub use self::sqlite_store::SqliteTransferStore;

--- a/curvine-server/src/transfer/sqlite_store.rs
+++ b/curvine-server/src/transfer/sqlite_store.rs
@@ -1,0 +1,1372 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use curvine_common::error::FsError;
+use curvine_common::state::{
+    summarize_transfer_tasks, StaleTaskAttempt, TaskAttemptStart, TransferCommand,
+    TransferJobRecord, TransferKind, TransferLease, TransferListFilter, TransferProgress,
+    TransferState, TransferStateUpdate, TransferTaskRecord, TransferTaskReport, TransferTaskState,
+    TransferTenantSummary,
+};
+use curvine_common::FsResult;
+use parking_lot::Mutex;
+use rusqlite::{
+    params, params_from_iter, types::Value as SqliteValue, Connection, OptionalExtension, Row,
+};
+use std::fs;
+use std::path::Path;
+
+use crate::transfer::{TransferRequeueUpdate, TransferStore};
+
+const TRANSFER_SCHEMA_VERSION: i64 = 2;
+
+pub struct SqliteTransferStore {
+    conn: Mutex<Connection>,
+}
+
+impl SqliteTransferStore {
+    pub fn open(path: impl AsRef<Path>) -> FsResult<Self> {
+        if let Some(parent) = path.as_ref().parent() {
+            fs::create_dir_all(parent).map_err(|err| {
+                FsError::common(format!(
+                    "Failed to create sqlite transfer store directory {}: {}",
+                    parent.display(),
+                    err
+                ))
+            })?;
+        }
+        let conn = Connection::open(path.as_ref()).map_err(sqlite_err)?;
+        init_schema(&conn)?;
+        Ok(Self {
+            conn: Mutex::new(conn),
+        })
+    }
+}
+
+impl TransferStore for SqliteTransferStore {
+    fn check_available(&self) -> FsResult<()> {
+        self.conn
+            .lock()
+            .query_row("select 1", [], |_| Ok(()))
+            .map_err(sqlite_err)
+    }
+
+    fn create_or_get_by_request_id(&self, job: TransferJobRecord) -> FsResult<TransferJobRecord> {
+        self.create_or_get_by_request_id_checked(job)
+    }
+
+    fn create_or_get_by_request_id_checked(
+        &self,
+        job: TransferJobRecord,
+    ) -> FsResult<TransferJobRecord> {
+        let mut conn = self.conn.lock();
+        let tx = conn.transaction().map_err(sqlite_err)?;
+        if let Some(existing) = select_job_by_request(&tx, &job.submitter, &job.client_request_id)?
+        {
+            tx.commit().map_err(sqlite_err)?;
+            return Ok(existing);
+        }
+
+        if let Some(existing) = select_non_terminal_job_by_key(&tx, &job.job_key)? {
+            if existing.command_json == job.command_json {
+                tx.commit().map_err(sqlite_err)?;
+                return Ok(existing);
+            }
+            return Err(FsError::transfer_already_running(format!(
+                "job_key {} has running job {} with different command",
+                existing.job_key, existing.job_id
+            )));
+        }
+
+        if let Some(existing) = select_conflicting_active_transfer(
+            &tx,
+            &job.target_path,
+            &job.submitter,
+            &job.client_request_id,
+        )? {
+            return Err(FsError::transfer_target_conflict(format!(
+                "target {} conflicts with active transfer {} target {}",
+                job.target_path, existing.job_id, existing.target_path
+            )));
+        }
+
+        insert_job(&tx, &job)?;
+        tx.commit().map_err(sqlite_err)?;
+        Ok(job)
+    }
+
+    fn get_transfer(&self, job_id: &str) -> FsResult<Option<TransferJobRecord>> {
+        select_job_by_id(&self.conn.lock(), job_id)
+    }
+
+    fn get_transfer_by_request(
+        &self,
+        submitter: &str,
+        client_request_id: &str,
+    ) -> FsResult<Option<TransferJobRecord>> {
+        select_job_by_request(&self.conn.lock(), submitter, client_request_id)
+    }
+
+    fn list_active_transfers(&self) -> FsResult<Vec<TransferJobRecord>> {
+        let conn = self.conn.lock();
+        let mut stmt = conn
+            .prepare(job_select_sql("where state not in (6, 7, 8)").as_str())
+            .map_err(sqlite_err)?;
+        let rows = stmt.query_map([], sqlite_job_row).map_err(sqlite_err)?;
+        collect_sqlite_rows(rows)
+    }
+
+    fn find_conflicting_active_transfer(
+        &self,
+        target_path: &str,
+        submitter: &str,
+        client_request_id: &str,
+    ) -> FsResult<Option<TransferJobRecord>> {
+        select_conflicting_active_transfer(
+            &self.conn.lock(),
+            target_path,
+            submitter,
+            client_request_id,
+        )
+    }
+
+    fn count_active_transfers(&self) -> FsResult<u64> {
+        self.conn
+            .lock()
+            .query_row(
+                "select count(*) from transfer_jobs where state not in (6, 7, 8)",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .map(|count| count as u64)
+            .map_err(sqlite_err)
+    }
+
+    fn count_executing_transfers(&self) -> FsResult<u64> {
+        self.conn
+            .lock()
+            .query_row(
+                "select count(*) from transfer_jobs where state in (2, 3, 4, 5)",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .map(|count| count as u64)
+            .map_err(sqlite_err)
+    }
+
+    fn list_transfers(&self, filter: TransferListFilter) -> FsResult<Vec<TransferJobRecord>> {
+        let conn = self.conn.lock();
+        let (where_sql, values) = list_filter_sqlite_params(&filter);
+        let sql = job_select_sql(&format!(
+            "{where_sql}
+             order by updated_at desc, created_at desc, job_id desc
+             limit ? offset ?"
+        ));
+        let mut values = values;
+        values.push(SqliteValue::Integer(filter.limit as i64));
+        values.push(SqliteValue::Integer(filter.offset as i64));
+        let mut stmt = conn.prepare(sql.as_str()).map_err(sqlite_err)?;
+        let rows = stmt
+            .query_map(params_from_iter(values), sqlite_job_row)
+            .map_err(sqlite_err)?;
+        collect_sqlite_rows(rows)
+    }
+
+    fn list_tenant_summaries(
+        &self,
+        limit: usize,
+        offset: usize,
+    ) -> FsResult<Vec<TransferTenantSummary>> {
+        let conn = self.conn.lock();
+        let mut stmt = conn
+            .prepare(
+                "select tenant,
+                        sum(case when state = 1 then 1 else 0 end) as pending,
+                        sum(case when state in (2, 3, 4, 5) then 1 else 0 end) as executing,
+                        sum(case when state = 6 then 1 else 0 end) as completed,
+                        sum(case when state = 7 then 1 else 0 end) as failed,
+                        sum(case when state = 8 then 1 else 0 end) as canceled,
+                        count(*) as total
+                 from transfer_jobs
+                 group by tenant
+                 order by (sum(case when state in (1, 2, 3, 4, 5) then 1 else 0 end)) desc,
+                          count(*) desc,
+                          tenant asc
+                 limit ?1 offset ?2",
+            )
+            .map_err(sqlite_err)?;
+        let rows = stmt
+            .query_map(
+                params![limit as i64, offset as i64],
+                sqlite_tenant_summary_row,
+            )
+            .map_err(sqlite_err)?;
+        collect_sqlite_rows(rows)
+    }
+
+    fn purge_terminal_transfers(&self, older_than_ms: i64, limit: usize) -> FsResult<usize> {
+        if limit == 0 {
+            return Ok(0);
+        }
+        let mut conn = self.conn.lock();
+        let tx = conn.transaction().map_err(sqlite_err)?;
+        let job_ids = {
+            let mut stmt = tx
+                .prepare(
+                    "select job_id from transfer_jobs
+                     where state in (6, 7, 8) and updated_at < ?1
+                     order by updated_at asc
+                     limit ?2",
+                )
+                .map_err(sqlite_err)?;
+            let rows = stmt
+                .query_map(params![older_than_ms, limit as i64], |row| {
+                    row.get::<_, String>(0)
+                })
+                .map_err(sqlite_err)?;
+            collect_sqlite_rows(rows)?
+        };
+        for job_id in &job_ids {
+            tx.execute(
+                "delete from transfer_tasks where job_id = ?1",
+                params![job_id],
+            )
+            .map_err(sqlite_err)?;
+            tx.execute(
+                "delete from transfer_jobs where job_id = ?1 and state in (6, 7, 8)",
+                params![job_id],
+            )
+            .map_err(sqlite_err)?;
+        }
+        tx.commit().map_err(sqlite_err)?;
+        Ok(job_ids.len())
+    }
+
+    fn list_transfer_tasks(&self, job_id: &str, run_id: u64) -> FsResult<Vec<TransferTaskRecord>> {
+        let conn = self.conn.lock();
+        let mut stmt = conn
+            .prepare(
+                "select job_id, run_id, task_id, attempt_id, source_path, target_path,
+                        worker_id, worker_session_id, source_read_plan_json, report_target_json,
+                        state, progress_json, retry_count, attempt_started_at, last_report_at,
+                        stale_deadline_at, updated_at
+                 from transfer_tasks where job_id = ?1 and run_id = ?2",
+            )
+            .map_err(sqlite_err)?;
+        let rows = stmt
+            .query_map(params![job_id, run_id as i64], sqlite_task_row)
+            .map_err(sqlite_err)?;
+        collect_sqlite_rows(rows)
+    }
+
+    fn request_cancel(&self, job_id: &str, run_id: u64, now_ms: i64) -> FsResult<bool> {
+        let mut conn = self.conn.lock();
+        let tx = conn.transaction().map_err(sqlite_err)?;
+        let Some(summary_json) = tx
+            .query_row(
+                "select summary_json from transfer_jobs
+                 where job_id = ?1 and run_id = ?2 and state not in (6, 7, 8)",
+                params![job_id, run_id as i64],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .map_err(sqlite_err)?
+        else {
+            tx.commit().map_err(sqlite_err)?;
+            return Ok(false);
+        };
+        let mut summary: TransferProgress =
+            serde_json::from_str(&summary_json).map_err(|err| FsError::common(err.to_string()))?;
+        summary.message = "cancel requested".to_string();
+        summary.update_time = now_ms;
+        let summary_json = transfer_progress_json(&summary)?;
+        let affected = tx
+            .execute(
+                "update transfer_jobs
+                 set cancel_requested = 1, state = ?3, summary_json = ?4, updated_at = ?5
+                 where job_id = ?1 and run_id = ?2 and state not in (6, 7, 8)",
+                params![
+                    job_id,
+                    run_id as i64,
+                    TransferState::Canceling as i32,
+                    summary_json,
+                    now_ms
+                ],
+            )
+            .map_err(sqlite_err)?;
+        tx.commit().map_err(sqlite_err)?;
+        Ok(affected > 0)
+    }
+
+    fn acquire_runnable_transfer(
+        &self,
+        owner: &str,
+        lease_ms: i64,
+        now_ms: i64,
+        max_executing_transfers: u64,
+    ) -> FsResult<Option<TransferLease>> {
+        let mut conn = self.conn.lock();
+        let tx = conn.transaction().map_err(sqlite_err)?;
+        let executing = tx
+            .query_row(
+                "select count(*) from transfer_jobs where state in (2, 3, 4, 5)",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .map_err(sqlite_err)? as u64;
+        let mut candidate: Option<(String, i64, i64, i64)> = tx
+            .query_row(
+                "select job_id, run_id, lease_epoch, state
+                 from transfer_jobs
+                 where owner = ?1 and state in (4, 5) and lease_expire_at > ?2 and updated_at < ?2
+                 order by updated_at asc
+                 limit 1",
+                params![owner, now_ms],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .optional()
+            .map_err(sqlite_err)?;
+        if candidate.is_none() {
+            candidate = tx
+                .query_row(
+                    "select job_id, run_id, lease_epoch, state
+                 from transfer_jobs
+                 where state in (2, 3, 4, 5) and lease_expire_at <= ?1
+                 order by updated_at asc
+                 limit 1",
+                    params![now_ms],
+                    |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+                )
+                .optional()
+                .map_err(sqlite_err)?;
+        }
+        if candidate.is_none() && executing < max_executing_transfers {
+            candidate = tx
+                .query_row(
+                    "select pending.job_id, pending.run_id, pending.lease_epoch, pending.state
+                     from transfer_jobs pending
+                     where pending.state = 1 and pending.lease_expire_at <= ?1
+                     order by case when exists (
+                         select 1 from transfer_jobs executing
+                         where executing.tenant = pending.tenant and executing.state in (2, 3, 4, 5)
+                         limit 1
+                     ) then 1 else 0 end asc,
+                     pending.updated_at asc, pending.job_id asc
+                     limit 1",
+                    params![now_ms],
+                    |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+                )
+                .optional()
+                .map_err(sqlite_err)?;
+        }
+        let Some((job_id, run_id, lease_epoch, state)) = candidate else {
+            tx.commit().map_err(sqlite_err)?;
+            return Ok(None);
+        };
+
+        let new_epoch = lease_epoch.saturating_add(1);
+        let new_state = if state == TransferState::Pending as i64 {
+            TransferState::Planning as i32
+        } else {
+            state as i32
+        };
+        let summary_json = if state == TransferState::Pending as i64 {
+            transfer_progress_json(&TransferProgress {
+                update_time: now_ms,
+                message: "acquired for planning".to_string(),
+                ..Default::default()
+            })?
+        } else {
+            tx.query_row(
+                "select summary_json from transfer_jobs where job_id = ?1",
+                params![job_id],
+                |row| row.get::<_, String>(0),
+            )
+            .map_err(sqlite_err)?
+        };
+        let affected = tx
+            .execute(
+                "update transfer_jobs
+                 set state = ?1, owner = ?2, lease_epoch = ?3, lease_expire_at = ?4,
+                     summary_json = ?5, updated_at = ?6
+                 where job_id = ?7 and run_id = ?8 and lease_epoch = ?9",
+                params![
+                    new_state,
+                    owner,
+                    new_epoch,
+                    now_ms.saturating_add(lease_ms),
+                    summary_json,
+                    now_ms,
+                    job_id,
+                    run_id,
+                    lease_epoch
+                ],
+            )
+            .map_err(sqlite_err)?;
+        tx.commit().map_err(sqlite_err)?;
+        if affected == 0 {
+            return Ok(None);
+        }
+        Ok(Some(TransferLease {
+            job_id,
+            run_id: run_id as u64,
+            owner: owner.to_string(),
+            lease_epoch: new_epoch as u64,
+        }))
+    }
+
+    fn renew_lease(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        owner: &str,
+        lease_epoch: u64,
+        lease_ms: i64,
+        now_ms: i64,
+    ) -> FsResult<bool> {
+        let affected = self
+            .conn
+            .lock()
+            .execute(
+                "update transfer_jobs
+                 set lease_expire_at = ?6, updated_at = ?7
+                 where job_id = ?1 and run_id = ?2 and owner = ?3 and lease_epoch = ?4
+                   and state not in (6, 7, 8)",
+                params![
+                    job_id,
+                    run_id as i64,
+                    owner,
+                    lease_epoch as i64,
+                    lease_ms,
+                    now_ms.saturating_add(lease_ms),
+                    now_ms
+                ],
+            )
+            .map_err(sqlite_err)?;
+        Ok(affected > 0)
+    }
+
+    fn update_transfer_state(&self, update: TransferStateUpdate) -> FsResult<bool> {
+        let states = state_list(&update.from_states);
+        let sql = format!(
+            "update transfer_jobs
+             set state = ?1, summary_json = ?2, updated_at = ?3
+             where job_id = ?4 and run_id = ?5 and owner = ?6 and lease_epoch = ?7
+               and state in ({states})"
+        );
+        let summary = transfer_progress_json(&TransferProgress {
+            message: update.message,
+            update_time: update.now_ms,
+            ..Default::default()
+        })?;
+        let affected = self
+            .conn
+            .lock()
+            .execute(
+                &sql,
+                params![
+                    update.to_state as i32,
+                    summary,
+                    update.now_ms,
+                    update.job_id,
+                    update.run_id as i64,
+                    update.owner,
+                    update.lease_epoch as i64
+                ],
+            )
+            .map_err(sqlite_err)?;
+        Ok(affected > 0)
+    }
+
+    fn set_transfer_state(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        state: TransferState,
+        message: impl Into<String>,
+        now_ms: i64,
+    ) -> FsResult<bool> {
+        let mut job = match self.get_transfer(job_id)? {
+            Some(job) if job.run_id == run_id => job,
+            _ => return Ok(false),
+        };
+        job.state = state;
+        job.summary.message = message.into();
+        job.summary.update_time = now_ms;
+        let affected = self
+            .conn
+            .lock()
+            .execute(
+                "update transfer_jobs set state = ?1, summary_json = ?2, updated_at = ?3
+                 where job_id = ?4 and run_id = ?5",
+                params![
+                    state as i32,
+                    transfer_progress_json(&job.summary)?,
+                    now_ms,
+                    job_id,
+                    run_id as i64
+                ],
+            )
+            .map_err(sqlite_err)?;
+        Ok(affected > 0)
+    }
+
+    fn requeue_transfer(&self, update: TransferRequeueUpdate) -> FsResult<bool> {
+        let summary = transfer_progress_json(&TransferProgress {
+            message: update.message,
+            update_time: update.now_ms,
+            ..Default::default()
+        })?;
+        let affected = self
+            .conn
+            .lock()
+            .execute(
+                "update transfer_jobs
+                 set state = ?1, owner = '', lease_expire_at = ?2, summary_json = ?3, updated_at = ?4
+                 where job_id = ?5 and run_id = ?6 and owner = ?7 and lease_epoch = ?8
+                   and state = ?9",
+                params![
+                    TransferState::Pending as i32,
+                    update.next_attempt_at_ms,
+                    summary,
+                    update.now_ms,
+                    update.job_id,
+                    update.run_id as i64,
+                    update.owner,
+                    update.lease_epoch as i64,
+                    TransferState::Planning as i32
+                ],
+            )
+            .map_err(sqlite_err)?;
+        Ok(affected > 0)
+    }
+
+    fn set_transfer_cv_metadata_epoch(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        owner: &str,
+        lease_epoch: u64,
+        cv_metadata_epoch: u64,
+        now_ms: i64,
+    ) -> FsResult<bool> {
+        let affected = self
+            .conn
+            .lock()
+            .execute(
+                "update transfer_jobs
+                 set cv_metadata_epoch = ?1, updated_at = ?2
+                 where job_id = ?3 and run_id = ?4 and owner = ?5 and lease_epoch = ?6
+                   and state not in (6, 7, 8)
+                   and (cv_metadata_epoch is null or cv_metadata_epoch = ?1)",
+                params![
+                    cv_metadata_epoch as i64,
+                    now_ms,
+                    job_id,
+                    run_id as i64,
+                    owner,
+                    lease_epoch as i64
+                ],
+            )
+            .map_err(sqlite_err)?;
+        Ok(affected > 0)
+    }
+
+    fn insert_tasks(&self, tasks: Vec<TransferTaskRecord>) -> FsResult<()> {
+        let mut conn = self.conn.lock();
+        let tx = conn.transaction().map_err(sqlite_err)?;
+        for task in tasks {
+            insert_task(&tx, &task)?;
+        }
+        tx.commit().map_err(sqlite_err)?;
+        Ok(())
+    }
+
+    fn update_task_state(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        task_id: &str,
+        state: TransferTaskState,
+        message: impl Into<String>,
+        now_ms: i64,
+    ) -> FsResult<bool> {
+        let mut progress = TransferProgress {
+            message: message.into(),
+            update_time: now_ms,
+            ..Default::default()
+        };
+        if let Some(task) = self
+            .list_transfer_tasks(job_id, run_id)?
+            .into_iter()
+            .find(|task| task.task_id == task_id)
+        {
+            progress.loaded_size = task.progress.loaded_size;
+            progress.total_size = task.progress.total_size;
+        }
+        let affected = self
+            .conn
+            .lock()
+            .execute(
+                "update transfer_tasks set state = ?1, progress_json = ?2, updated_at = ?3
+                 where job_id = ?4 and run_id = ?5 and task_id = ?6",
+                params![
+                    state as i32,
+                    transfer_progress_json(&progress)?,
+                    now_ms,
+                    job_id,
+                    run_id as i64,
+                    task_id
+                ],
+            )
+            .map_err(sqlite_err)?;
+        Ok(affected > 0)
+    }
+
+    fn claim_pending_tasks(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        limit: usize,
+    ) -> FsResult<Vec<TransferTaskRecord>> {
+        let conn = self.conn.lock();
+        let mut stmt = conn
+            .prepare(
+                "select job_id, run_id, task_id, attempt_id, source_path, target_path,
+                        worker_id, worker_session_id, source_read_plan_json, report_target_json,
+                        state, progress_json, retry_count, attempt_started_at, last_report_at,
+                        stale_deadline_at, updated_at
+                 from transfer_tasks
+                 where job_id = ?1 and run_id = ?2 and state = 1
+                 order by updated_at asc
+                 limit ?3",
+            )
+            .map_err(sqlite_err)?;
+        let rows = stmt
+            .query_map(
+                params![job_id, run_id as i64, limit as i64],
+                sqlite_task_row,
+            )
+            .map_err(sqlite_err)?;
+        collect_sqlite_rows(rows)
+    }
+
+    fn mark_stale_attempts(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        owner: &str,
+        lease_epoch: u64,
+        now_ms: i64,
+        limit: usize,
+    ) -> FsResult<Vec<StaleTaskAttempt>> {
+        let mut conn = self.conn.lock();
+        let tx = conn.transaction().map_err(sqlite_err)?;
+        let valid_owner: Option<i64> = tx
+            .query_row(
+                "select 1 from transfer_jobs
+                 where job_id = ?1 and run_id = ?2 and owner = ?3 and lease_epoch = ?4",
+                params![job_id, run_id as i64, owner, lease_epoch as i64],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(sqlite_err)?;
+        if valid_owner.is_none() {
+            tx.commit().map_err(sqlite_err)?;
+            return Ok(Vec::new());
+        }
+
+        let tasks = {
+            let mut stmt = tx
+                .prepare(
+                    "select job_id, run_id, task_id, attempt_id, source_path, target_path,
+                            worker_id, worker_session_id, source_read_plan_json, report_target_json,
+                            state, progress_json, retry_count, attempt_started_at, last_report_at,
+                            stale_deadline_at, updated_at
+                     from transfer_tasks
+                     where job_id = ?1 and run_id = ?2 and state = 2 and stale_deadline_at < ?3
+                     order by stale_deadline_at asc
+                     limit ?4",
+                )
+                .map_err(sqlite_err)?;
+            let rows = stmt
+                .query_map(
+                    params![job_id, run_id as i64, now_ms, limit as i64],
+                    sqlite_task_row,
+                )
+                .map_err(sqlite_err)?;
+            collect_sqlite_rows(rows)?
+        };
+
+        let mut stale = Vec::with_capacity(tasks.len());
+        for mut task in tasks {
+            task.state = TransferTaskState::Stale;
+            task.retry_count = task.retry_count.saturating_add(1);
+            task.progress.message = "task stale timeout".to_string();
+            task.progress.update_time = now_ms;
+            task.updated_at = now_ms;
+            update_task_record(&tx, &task)?;
+            stale.push(StaleTaskAttempt { task });
+        }
+        tx.commit().map_err(sqlite_err)?;
+        Ok(stale)
+    }
+
+    fn list_recoverable_tasks(
+        &self,
+        job_id: &str,
+        run_id: u64,
+    ) -> FsResult<Vec<TransferTaskRecord>> {
+        let conn = self.conn.lock();
+        let mut stmt = conn
+            .prepare(
+                "select job_id, run_id, task_id, attempt_id, source_path, target_path,
+                        worker_id, worker_session_id, source_read_plan_json, report_target_json,
+                        state, progress_json, retry_count, attempt_started_at, last_report_at,
+                        stale_deadline_at, updated_at
+                 from transfer_tasks
+                 where job_id = ?1 and run_id = ?2 and state in (1, 2, 6)",
+            )
+            .map_err(sqlite_err)?;
+        let rows = stmt
+            .query_map(params![job_id, run_id as i64], sqlite_task_row)
+            .map_err(sqlite_err)?;
+        collect_sqlite_rows(rows)
+    }
+
+    fn start_task_attempt(&self, start: TaskAttemptStart) -> FsResult<bool> {
+        let affected = self
+            .conn
+            .lock()
+            .execute(
+                "update transfer_tasks
+                 set attempt_id = ?1, worker_id = ?2, worker_session_id = ?3,
+                     report_target_json = ?4, state = 2, attempt_started_at = ?5,
+                     last_report_at = ?5, stale_deadline_at = ?6, updated_at = ?5
+                 where job_id = ?7 and run_id = ?8 and task_id = ?9 and state in (1, 6)
+                   and exists (
+                       select 1 from transfer_jobs
+                        where job_id = ?7 and run_id = ?8 and owner = ?10
+                          and lease_epoch = ?11 and cancel_requested = 0
+                          and state not in (6, 7, 8)
+                   )",
+                params![
+                    start.attempt_id as i64,
+                    start.worker_id as i64,
+                    start.worker_session_id,
+                    start.report_target_json,
+                    start.now_ms,
+                    start.stale_deadline_at,
+                    start.job_id,
+                    start.run_id as i64,
+                    start.task_id,
+                    start.owner,
+                    start.lease_epoch as i64
+                ],
+            )
+            .map_err(sqlite_err)?;
+        Ok(affected > 0)
+    }
+
+    fn update_task_report(&self, report: TransferTaskReport) -> FsResult<bool> {
+        let mut conn = self.conn.lock();
+        let tx = conn.transaction().map_err(sqlite_err)?;
+        let affected = tx
+            .execute(
+                "update transfer_tasks
+                 set state = ?1, progress_json = ?2, last_report_at = ?3,
+                     stale_deadline_at = ?4, updated_at = ?3
+                 where job_id = ?5 and run_id = ?6 and task_id = ?7 and attempt_id = ?8
+                   and worker_id = ?9 and worker_session_id = ?10 and state in (1, 2)",
+                params![
+                    report.state as i32,
+                    transfer_progress_json(&report.progress)?,
+                    report.now_ms,
+                    report.stale_deadline_at,
+                    report.job_id,
+                    report.run_id as i64,
+                    report.task_id,
+                    report.attempt_id as i64,
+                    report.worker_id as i64,
+                    report.worker_session_id
+                ],
+            )
+            .map_err(sqlite_err)?;
+        if affected == 0 {
+            tx.commit().map_err(sqlite_err)?;
+            return Ok(false);
+        }
+
+        update_job_summary(&tx, &report.job_id, report.run_id, report.now_ms)?;
+        tx.commit().map_err(sqlite_err)?;
+        Ok(true)
+    }
+}
+
+fn update_task_record(conn: &Connection, task: &TransferTaskRecord) -> FsResult<bool> {
+    let affected = conn
+        .execute(
+            "update transfer_tasks
+             set attempt_id = ?1, worker_id = ?2, worker_session_id = ?3,
+                 source_read_plan_json = ?4, report_target_json = ?5, state = ?6,
+                 progress_json = ?7, retry_count = ?8, attempt_started_at = ?9,
+                 last_report_at = ?10, stale_deadline_at = ?11, updated_at = ?12
+             where job_id = ?13 and run_id = ?14 and task_id = ?15",
+            params![
+                task.attempt_id as i64,
+                task.worker_id as i64,
+                task.worker_session_id,
+                task.source_read_plan_json,
+                task.report_target_json,
+                task.state as i32,
+                transfer_progress_json(&task.progress)?,
+                task.retry_count as i64,
+                task.attempt_started_at,
+                task.last_report_at,
+                task.stale_deadline_at,
+                task.updated_at,
+                task.job_id,
+                task.run_id as i64,
+                task.task_id
+            ],
+        )
+        .map_err(sqlite_err)?;
+    Ok(affected > 0)
+}
+
+fn init_schema(conn: &Connection) -> FsResult<()> {
+    conn.execute_batch(
+        "
+        create table if not exists transfer_schema_version (
+            id integer primary key check(id = 1),
+            version integer not null,
+            updated_at integer not null
+        );
+        insert or ignore into transfer_schema_version(id, version, updated_at)
+            values (1, 2, strftime('%s', 'now') * 1000);
+        ",
+    )
+    .map_err(sqlite_err)?;
+    let version = conn
+        .query_row(
+            "select version from transfer_schema_version where id = 1",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .map_err(sqlite_err)?;
+    migrate_schema(conn, version)?;
+    create_base_tables(conn)?;
+    create_indexes(conn)?;
+    Ok(())
+}
+
+fn create_base_tables(conn: &Connection) -> FsResult<()> {
+    conn.execute_batch(
+        "
+        create table if not exists transfer_jobs (
+            job_id text primary key,
+            job_key text not null,
+            run_id integer not null,
+            kind integer not null,
+            source_path text not null,
+            target_path text not null,
+            command_json text not null,
+            mount_snapshot_json text not null,
+            secret_ref_json text not null,
+            cluster_snapshot_version integer not null,
+            cv_metadata_epoch integer,
+            state integer not null,
+            owner text not null,
+            lease_epoch integer not null,
+            lease_expire_at integer not null,
+            cancel_requested integer not null,
+            summary_json text not null,
+            client_request_id text not null,
+            submitter text not null,
+            tenant text not null,
+            created_at integer not null,
+            updated_at integer not null
+        );
+        create table if not exists transfer_tasks (
+            job_id text not null,
+            run_id integer not null,
+            task_id text not null,
+            attempt_id integer not null,
+            source_path text not null,
+            target_path text not null,
+            worker_id integer not null,
+            worker_session_id text not null,
+            source_read_plan_json text not null,
+            report_target_json text not null,
+            state integer not null,
+            progress_json text not null,
+            retry_count integer not null,
+            attempt_started_at integer not null,
+            last_report_at integer not null,
+            stale_deadline_at integer not null,
+            updated_at integer not null,
+            primary key(job_id, run_id, task_id)
+        );
+        ",
+    )
+    .map_err(sqlite_err)?;
+    Ok(())
+}
+
+fn create_indexes(conn: &Connection) -> FsResult<()> {
+    conn.execute_batch(
+        "
+        create unique index if not exists transfer_jobs_request_idx
+            on transfer_jobs(submitter, client_request_id);
+        create index if not exists transfer_jobs_job_key_state_idx
+            on transfer_jobs(job_key, state);
+        create index if not exists transfer_jobs_state_lease_idx
+            on transfer_jobs(state, lease_expire_at);
+        create index if not exists transfer_jobs_owner_state_updated_idx
+            on transfer_jobs(owner, state, updated_at);
+        create index if not exists transfer_jobs_target_state_idx
+            on transfer_jobs(target_path, state);
+        create index if not exists transfer_jobs_tenant_state_updated_idx
+            on transfer_jobs(tenant, state, updated_at);
+        create index if not exists transfer_jobs_submitter_state_updated_idx
+            on transfer_jobs(submitter, state, updated_at);
+        create index if not exists transfer_tasks_job_state_idx
+            on transfer_tasks(job_id, run_id, state);
+        create index if not exists transfer_tasks_worker_idx
+            on transfer_tasks(worker_id, worker_session_id, state);
+        create index if not exists transfer_tasks_stale_idx
+            on transfer_tasks(state, stale_deadline_at);
+        ",
+    )
+    .map_err(sqlite_err)?;
+    Ok(())
+}
+
+fn migrate_schema(conn: &Connection, version: i64) -> FsResult<()> {
+    if version == 1 {
+        migrate_sqlite_schema_v1_to_v2(conn)?;
+        conn.execute(
+            "update transfer_schema_version
+             set version = ?1, updated_at = strftime('%s', 'now') * 1000
+             where id = 1",
+            params![TRANSFER_SCHEMA_VERSION],
+        )
+        .map_err(sqlite_err)?;
+        return Ok(());
+    }
+    if version != TRANSFER_SCHEMA_VERSION {
+        return Err(FsError::common(format!(
+            "Unsupported sqlite transfer schema version {}, expected {}",
+            version, TRANSFER_SCHEMA_VERSION
+        )));
+    }
+    Ok(())
+}
+
+fn migrate_sqlite_schema_v1_to_v2(conn: &Connection) -> FsResult<()> {
+    if !sqlite_column_exists(conn, "transfer_jobs", "target_path")? {
+        conn.execute(
+            "alter table transfer_jobs add column target_path text not null default ''",
+            [],
+        )
+        .map_err(sqlite_err)?;
+    }
+    let mut stmt = conn
+        .prepare("select job_id, command_json from transfer_jobs where target_path = ''")
+        .map_err(sqlite_err)?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })
+        .map_err(sqlite_err)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(sqlite_err)?;
+    for (job_id, command_json) in rows {
+        let command: TransferCommand = serde_json::from_str(&command_json)
+            .map_err(|err| FsError::common(format!("Invalid transfer command json: {}", err)))?;
+        conn.execute(
+            "update transfer_jobs set target_path = ?1 where job_id = ?2",
+            params![command.target_path, job_id],
+        )
+        .map_err(sqlite_err)?;
+    }
+    Ok(())
+}
+
+fn sqlite_column_exists(conn: &Connection, table: &str, column: &str) -> FsResult<bool> {
+    let mut stmt = conn
+        .prepare(format!("pragma table_info({table})").as_str())
+        .map_err(sqlite_err)?;
+    let columns = stmt
+        .query_map([], |row| row.get::<_, String>(1))
+        .map_err(sqlite_err)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(sqlite_err)?;
+    Ok(columns.iter().any(|name| name == column))
+}
+
+fn insert_job(conn: &Connection, job: &TransferJobRecord) -> FsResult<()> {
+    conn.execute(
+        "insert into transfer_jobs (
+            job_id, job_key, run_id, kind, source_path, target_path, command_json,
+            mount_snapshot_json, secret_ref_json, cluster_snapshot_version, cv_metadata_epoch,
+            state, owner, lease_epoch, lease_expire_at, cancel_requested, summary_json,
+            client_request_id, submitter, tenant, created_at, updated_at
+        ) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16,
+                  ?17, ?18, ?19, ?20, ?21, ?22)",
+        params![
+            job.job_id,
+            job.job_key,
+            job.run_id as i64,
+            job.kind as i32,
+            job.source_path,
+            job.target_path,
+            job.command_json,
+            job.mount_snapshot_json,
+            job.secret_ref_json,
+            job.cluster_snapshot_version as i64,
+            job.cv_metadata_epoch.map(|v| v as i64),
+            job.state as i32,
+            job.owner,
+            job.lease_epoch as i64,
+            job.lease_expire_at,
+            if job.cancel_requested { 1_i64 } else { 0_i64 },
+            transfer_progress_json(&job.summary)?,
+            job.client_request_id,
+            job.submitter,
+            job.tenant,
+            job.created_at,
+            job.updated_at
+        ],
+    )
+    .map_err(sqlite_err)?;
+    Ok(())
+}
+
+fn insert_task(conn: &Connection, task: &TransferTaskRecord) -> FsResult<()> {
+    conn.execute(
+        "insert or ignore into transfer_tasks (
+            job_id, run_id, task_id, attempt_id, source_path, target_path, worker_id,
+            worker_session_id, source_read_plan_json, report_target_json, state, progress_json,
+            retry_count, attempt_started_at, last_report_at, stale_deadline_at, updated_at
+        ) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
+        params![
+            task.job_id,
+            task.run_id as i64,
+            task.task_id,
+            task.attempt_id as i64,
+            task.source_path,
+            task.target_path,
+            task.worker_id as i64,
+            task.worker_session_id,
+            task.source_read_plan_json,
+            task.report_target_json,
+            task.state as i32,
+            transfer_progress_json(&task.progress)?,
+            task.retry_count as i64,
+            task.attempt_started_at,
+            task.last_report_at,
+            task.stale_deadline_at,
+            task.updated_at
+        ],
+    )
+    .map_err(sqlite_err)?;
+    Ok(())
+}
+
+fn select_job_by_id(conn: &Connection, job_id: &str) -> FsResult<Option<TransferJobRecord>> {
+    conn.query_row(
+        job_select_sql("where job_id = ?1").as_str(),
+        params![job_id],
+        sqlite_job_row,
+    )
+    .optional()
+    .map_err(sqlite_err)
+}
+
+fn select_job_by_request(
+    conn: &Connection,
+    submitter: &str,
+    client_request_id: &str,
+) -> FsResult<Option<TransferJobRecord>> {
+    conn.query_row(
+        job_select_sql("where submitter = ?1 and client_request_id = ?2").as_str(),
+        params![submitter, client_request_id],
+        sqlite_job_row,
+    )
+    .optional()
+    .map_err(sqlite_err)
+}
+
+fn select_non_terminal_job_by_key(
+    conn: &Connection,
+    job_key: &str,
+) -> FsResult<Option<TransferJobRecord>> {
+    conn.query_row(
+        job_select_sql("where job_key = ?1 and state not in (6, 7, 8) limit 1").as_str(),
+        params![job_key],
+        sqlite_job_row,
+    )
+    .optional()
+    .map_err(sqlite_err)
+}
+
+fn select_conflicting_active_transfer(
+    conn: &Connection,
+    target_path: &str,
+    submitter: &str,
+    client_request_id: &str,
+) -> FsResult<Option<TransferJobRecord>> {
+    let child_prefix = format!("{}/%", target_path.trim_end_matches('/'));
+    let exact_or_child = conn
+        .query_row(
+            job_select_sql(
+                "where state not in (6, 7, 8)
+               and not (submitter = ?2 and client_request_id = ?3)
+               and (
+                   target_path = ?1
+                   or target_path like ?4
+               )
+             limit 1",
+            )
+            .as_str(),
+            params![target_path, submitter, client_request_id, child_prefix],
+            sqlite_job_row,
+        )
+        .optional()
+        .map_err(sqlite_err)?;
+    if exact_or_child.is_some() {
+        return Ok(exact_or_child);
+    }
+
+    for ancestor in ancestor_paths(target_path) {
+        let ancestor_conflict = conn
+            .query_row(
+                job_select_sql(
+                    "where state not in (6, 7, 8)
+                       and not (submitter = ?2 and client_request_id = ?3)
+                       and target_path = ?1
+                     limit 1",
+                )
+                .as_str(),
+                params![ancestor, submitter, client_request_id],
+                sqlite_job_row,
+            )
+            .optional()
+            .map_err(sqlite_err)?;
+        if ancestor_conflict.is_some() {
+            return Ok(ancestor_conflict);
+        }
+    }
+    Ok(None)
+}
+
+fn job_select_sql(where_sql: &str) -> String {
+    format!(
+        "select job_id, job_key, run_id, kind, source_path, target_path, command_json,
+                mount_snapshot_json, secret_ref_json, cluster_snapshot_version, cv_metadata_epoch,
+                state, owner, lease_epoch, lease_expire_at, cancel_requested, summary_json,
+                client_request_id, submitter, tenant, created_at, updated_at
+         from transfer_jobs {where_sql}"
+    )
+}
+
+fn ancestor_paths(target_path: &str) -> Vec<String> {
+    if target_path == "/" {
+        return Vec::new();
+    }
+    let mut ancestors = vec!["/".to_string()];
+    let trimmed = target_path.trim_matches('/');
+    let mut current = String::new();
+    let mut parts = trimmed.split('/').peekable();
+    while let Some(part) = parts.next() {
+        if parts.peek().is_none() {
+            break;
+        }
+        current.push('/');
+        current.push_str(part);
+        ancestors.push(current.clone());
+    }
+    ancestors
+}
+
+fn sqlite_job_row(row: &Row<'_>) -> rusqlite::Result<TransferJobRecord> {
+    let summary_json: String = row.get(16)?;
+    Ok(TransferJobRecord {
+        job_id: row.get(0)?,
+        job_key: row.get(1)?,
+        run_id: row.get::<_, i64>(2)? as u64,
+        kind: TransferKind::from(row.get::<_, i32>(3)?),
+        source_path: row.get(4)?,
+        target_path: row.get(5)?,
+        command_json: row.get(6)?,
+        mount_snapshot_json: row.get(7)?,
+        secret_ref_json: row.get(8)?,
+        cluster_snapshot_version: row.get::<_, i64>(9)? as u64,
+        cv_metadata_epoch: row.get::<_, Option<i64>>(10)?.map(|v| v as u64),
+        state: TransferState::from(row.get::<_, i32>(11)?),
+        owner: row.get(12)?,
+        lease_epoch: row.get::<_, i64>(13)? as u64,
+        lease_expire_at: row.get(14)?,
+        cancel_requested: row.get::<_, i64>(15)? != 0,
+        summary: serde_json::from_str(&summary_json).unwrap_or_default(),
+        client_request_id: row.get(17)?,
+        submitter: row.get(18)?,
+        tenant: row.get(19)?,
+        created_at: row.get(20)?,
+        updated_at: row.get(21)?,
+    })
+}
+
+fn list_filter_sqlite_params(filter: &TransferListFilter) -> (String, Vec<SqliteValue>) {
+    let mut clauses = Vec::new();
+    let mut values = Vec::new();
+    if let Some(kind) = filter.kind {
+        clauses.push("kind = ?");
+        values.push(SqliteValue::Integer(kind as i32 as i64));
+    }
+    if let Some(state) = filter.state {
+        clauses.push("state = ?");
+        values.push(SqliteValue::Integer(state as i32 as i64));
+    }
+    if let Some(submitter) = &filter.submitter {
+        clauses.push("submitter = ?");
+        values.push(SqliteValue::Text(submitter.clone()));
+    }
+    if let Some(tenant) = &filter.tenant {
+        clauses.push("tenant = ?");
+        values.push(SqliteValue::Text(tenant.clone()));
+    }
+    if clauses.is_empty() {
+        (String::new(), values)
+    } else {
+        (format!("where {}", clauses.join(" and ")), values)
+    }
+}
+
+fn sqlite_task_row(row: &Row<'_>) -> rusqlite::Result<TransferTaskRecord> {
+    let progress_json: String = row.get(11)?;
+    Ok(TransferTaskRecord {
+        job_id: row.get(0)?,
+        run_id: row.get::<_, i64>(1)? as u64,
+        task_id: row.get(2)?,
+        attempt_id: row.get::<_, i64>(3)? as u64,
+        source_path: row.get(4)?,
+        target_path: row.get(5)?,
+        worker_id: row.get::<_, i64>(6)? as u32,
+        worker_session_id: row.get(7)?,
+        source_read_plan_json: row.get(8)?,
+        report_target_json: row.get(9)?,
+        state: TransferTaskState::from(row.get::<_, i32>(10)?),
+        progress: serde_json::from_str(&progress_json).unwrap_or_default(),
+        retry_count: row.get::<_, i64>(12)? as u32,
+        attempt_started_at: row.get(13)?,
+        last_report_at: row.get(14)?,
+        stale_deadline_at: row.get(15)?,
+        updated_at: row.get(16)?,
+    })
+}
+
+fn sqlite_tenant_summary_row(row: &Row<'_>) -> rusqlite::Result<TransferTenantSummary> {
+    Ok(TransferTenantSummary {
+        tenant: row.get(0)?,
+        pending: row.get::<_, i64>(1)? as u64,
+        executing: row.get::<_, i64>(2)? as u64,
+        completed: row.get::<_, i64>(3)? as u64,
+        failed: row.get::<_, i64>(4)? as u64,
+        canceled: row.get::<_, i64>(5)? as u64,
+        total: row.get::<_, i64>(6)? as u64,
+    })
+}
+
+fn update_job_summary(conn: &Connection, job_id: &str, run_id: u64, now_ms: i64) -> FsResult<()> {
+    let tasks = {
+        let mut stmt = conn
+            .prepare(
+                "select job_id, run_id, task_id, attempt_id, source_path, target_path,
+                        worker_id, worker_session_id, source_read_plan_json, report_target_json,
+                        state, progress_json, retry_count, attempt_started_at, last_report_at,
+                        stale_deadline_at, updated_at
+                 from transfer_tasks where job_id = ?1 and run_id = ?2",
+            )
+            .map_err(sqlite_err)?;
+        let rows = stmt
+            .query_map(params![job_id, run_id as i64], sqlite_task_row)
+            .map_err(sqlite_err)?;
+        collect_sqlite_rows(rows)?
+    };
+    let summary = summarize_transfer_tasks(&tasks, now_ms);
+    let state = if summary.has_failed {
+        Some(TransferState::Failed)
+    } else if summary.has_task && summary.all_completed {
+        Some(TransferState::Completed)
+    } else {
+        None
+    };
+    if let Some(state) = state {
+        conn.execute(
+            "update transfer_jobs set state = ?1, summary_json = ?2, updated_at = ?3
+             where job_id = ?4 and run_id = ?5",
+            params![
+                state as i32,
+                transfer_progress_json(&summary.progress)?,
+                now_ms,
+                job_id,
+                run_id as i64
+            ],
+        )
+        .map_err(sqlite_err)?;
+    } else {
+        conn.execute(
+            "update transfer_jobs set summary_json = ?1, updated_at = ?2
+             where job_id = ?3 and run_id = ?4",
+            params![
+                transfer_progress_json(&summary.progress)?,
+                now_ms,
+                job_id,
+                run_id as i64
+            ],
+        )
+        .map_err(sqlite_err)?;
+    }
+    Ok(())
+}
+
+fn collect_sqlite_rows<T>(rows: impl Iterator<Item = rusqlite::Result<T>>) -> FsResult<Vec<T>> {
+    let mut values = Vec::new();
+    for row in rows {
+        values.push(row.map_err(sqlite_err)?);
+    }
+    Ok(values)
+}
+
+fn transfer_progress_json(progress: &TransferProgress) -> FsResult<String> {
+    serde_json::to_string(progress)
+        .map_err(|_| FsError::common("Unable to encode transfer progress"))
+}
+
+fn state_list(states: &[TransferState]) -> String {
+    states
+        .iter()
+        .map(|state| (*state as i32).to_string())
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn sqlite_err(err: rusqlite::Error) -> FsError {
+    log::warn!("transfer SQLite store operation failed: {}", err);
+    FsError::transfer_store_unavailable(
+        "Transfer metadata store is unavailable; verify transfer.store_url and local disk health",
+    )
+}

--- a/curvine-server/src/transfer/store.rs
+++ b/curvine-server/src/transfer/store.rs
@@ -1,0 +1,156 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use curvine_common::state::{
+    StaleTaskAttempt, TaskAttemptStart, TransferJobRecord, TransferLease, TransferListFilter,
+    TransferState, TransferStateUpdate, TransferTaskRecord, TransferTaskReport, TransferTaskState,
+    TransferTenantSummary,
+};
+use curvine_common::FsResult;
+
+pub trait TransferStore: Send + Sync + 'static {
+    fn check_available(&self) -> FsResult<()>;
+
+    fn create_or_get_by_request_id(&self, job: TransferJobRecord) -> FsResult<TransferJobRecord>;
+
+    fn create_or_get_by_request_id_checked(
+        &self,
+        job: TransferJobRecord,
+    ) -> FsResult<TransferJobRecord>;
+
+    fn get_transfer(&self, job_id: &str) -> FsResult<Option<TransferJobRecord>>;
+
+    fn get_transfer_by_request(
+        &self,
+        submitter: &str,
+        client_request_id: &str,
+    ) -> FsResult<Option<TransferJobRecord>>;
+
+    fn list_active_transfers(&self) -> FsResult<Vec<TransferJobRecord>>;
+
+    fn find_conflicting_active_transfer(
+        &self,
+        target_path: &str,
+        submitter: &str,
+        client_request_id: &str,
+    ) -> FsResult<Option<TransferJobRecord>>;
+
+    fn count_active_transfers(&self) -> FsResult<u64>;
+
+    fn count_executing_transfers(&self) -> FsResult<u64>;
+
+    fn list_transfers(&self, filter: TransferListFilter) -> FsResult<Vec<TransferJobRecord>>;
+
+    fn list_tenant_summaries(
+        &self,
+        limit: usize,
+        offset: usize,
+    ) -> FsResult<Vec<TransferTenantSummary>>;
+
+    fn purge_terminal_transfers(&self, older_than_ms: i64, limit: usize) -> FsResult<usize>;
+
+    fn list_transfer_tasks(&self, job_id: &str, run_id: u64) -> FsResult<Vec<TransferTaskRecord>>;
+
+    fn request_cancel(&self, job_id: &str, run_id: u64, now_ms: i64) -> FsResult<bool>;
+
+    fn acquire_runnable_transfer(
+        &self,
+        owner: &str,
+        lease_ms: i64,
+        now_ms: i64,
+        max_executing_transfers: u64,
+    ) -> FsResult<Option<TransferLease>>;
+
+    fn renew_lease(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        owner: &str,
+        lease_epoch: u64,
+        lease_ms: i64,
+        now_ms: i64,
+    ) -> FsResult<bool>;
+
+    fn update_transfer_state(&self, update: TransferStateUpdate) -> FsResult<bool>;
+
+    fn set_transfer_state(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        state: TransferState,
+        message: impl Into<String>,
+        now_ms: i64,
+    ) -> FsResult<bool>;
+
+    fn requeue_transfer(&self, update: TransferRequeueUpdate) -> FsResult<bool>;
+
+    fn set_transfer_cv_metadata_epoch(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        owner: &str,
+        lease_epoch: u64,
+        cv_metadata_epoch: u64,
+        now_ms: i64,
+    ) -> FsResult<bool>;
+
+    fn insert_tasks(&self, tasks: Vec<TransferTaskRecord>) -> FsResult<()>;
+
+    fn update_task_state(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        task_id: &str,
+        state: TransferTaskState,
+        message: impl Into<String>,
+        now_ms: i64,
+    ) -> FsResult<bool>;
+
+    fn claim_pending_tasks(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        limit: usize,
+    ) -> FsResult<Vec<TransferTaskRecord>>;
+
+    fn mark_stale_attempts(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        owner: &str,
+        lease_epoch: u64,
+        now_ms: i64,
+        limit: usize,
+    ) -> FsResult<Vec<StaleTaskAttempt>>;
+
+    fn list_recoverable_tasks(
+        &self,
+        job_id: &str,
+        run_id: u64,
+    ) -> FsResult<Vec<TransferTaskRecord>>;
+
+    fn start_task_attempt(&self, start: TaskAttemptStart) -> FsResult<bool>;
+
+    fn update_task_report(&self, report: TransferTaskReport) -> FsResult<bool>;
+}
+
+pub struct TransferRequeueUpdate {
+    pub job_id: String,
+    pub run_id: u64,
+    pub owner: String,
+    pub lease_epoch: u64,
+    pub message: String,
+    pub next_attempt_at_ms: i64,
+    pub now_ms: i64,
+}

--- a/curvine-server/tests/transfer_store_test.rs
+++ b/curvine-server/tests/transfer_store_test.rs
@@ -1,0 +1,87 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use curvine_common::error::ErrorKind;
+use curvine_common::state::{TransferJobRecord, TransferKind, TransferProgress, TransferState};
+use curvine_server::transfer::{MemoryTransferStore, SqliteTransferStore, TransferStore};
+
+fn job(id: &str, request_id: &str, target: &str) -> TransferJobRecord {
+    TransferJobRecord {
+        job_key: format!("Load:s3://bucket/{id}:{target}"),
+        job_id: id.to_string(),
+        run_id: 1,
+        kind: TransferKind::Load,
+        source_path: format!("s3://bucket/{id}"),
+        target_path: target.to_string(),
+        command_json: "{}".to_string(),
+        mount_snapshot_json: "{}".to_string(),
+        secret_ref_json: "{}".to_string(),
+        cluster_snapshot_version: 1,
+        cv_metadata_epoch: None,
+        state: TransferState::Pending,
+        owner: String::new(),
+        lease_epoch: 0,
+        lease_expire_at: 0,
+        cancel_requested: false,
+        summary: TransferProgress::default(),
+        client_request_id: request_id.to_string(),
+        submitter: "test".to_string(),
+        tenant: "default".to_string(),
+        created_at: 1,
+        updated_at: 1,
+    }
+}
+
+fn assert_store_contract<S: TransferStore>(store: &S) {
+    let first = job("job-1", "request-1", "/target");
+    let created = store.create_or_get_by_request_id(first.clone()).unwrap();
+    assert_eq!(created.job_id, first.job_id);
+
+    let replay = store.create_or_get_by_request_id(first).unwrap();
+    assert_eq!(replay.job_id, "job-1");
+
+    let err = store
+        .create_or_get_by_request_id(job("job-2", "request-2", "/target/child"))
+        .unwrap_err();
+    assert!(
+        matches!(err.kind(), ErrorKind::TransferTargetConflict),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn memory_store_enforces_request_and_target_contracts() {
+    assert_store_contract(&MemoryTransferStore::new());
+}
+
+#[test]
+fn sqlite_store_persists_submitted_transfer() {
+    let path = std::env::temp_dir().join(format!(
+        "curvine-transfer-store-{}-{}.db",
+        std::process::id(),
+        orpc::common::LocalTime::mills()
+    ));
+
+    {
+        let store = SqliteTransferStore::open(&path).unwrap();
+        assert_store_contract(&store);
+    }
+
+    let reopened = SqliteTransferStore::open(&path).unwrap();
+    assert_eq!(
+        reopened.get_transfer("job-1").unwrap().unwrap().target_path,
+        "/target"
+    );
+    let _ = std::fs::remove_file(path);
+}


### PR DESCRIPTION
# Summary

Adds in-memory and SQLite implementations of the transfer persistence contract. This PR deliberately stops at local persistence; scheduling, MySQL storage, and client or worker routing remain in follow-up PRs.

# Issue Describe / Design

Related to #1238 and the load-job isolation design.

The store owns request-id idempotency and target-path conflict checks. SQLite persists submitted transfers across process restarts, while the memory store is suitable for local and test deployment. Keeping these implementations separate from scheduling avoids coupling persistence rollout to task ownership and retry policy.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-server/src/transfer` | Adds store contract plus memory and SQLite implementations. | None until a later scheduler selects a transfer store. |
| `curvine-server/Cargo.toml` | Adds the existing workspace `rusqlite` dependency. | Enables local SQLite persistence. |
| `Cargo.lock` | Records the resolved SQLite dependency graph and removes unreachable legacy packages. | Reproducible locked builds. |
| `curvine-server/tests/transfer_store_test.rs` | Covers idempotency, target conflicts, and SQLite reopen persistence. | Test coverage only. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test --locked -p curvine-server --test transfer_store_test` | PASS | 2 tests passed. |

# Dependencies

- Related PRs: #1326
- Related issues: #1238
- Blocks / blocked by: Blocked by #1326; blocks the scheduler and MySQL store PRs.