### PR TITLE
feat(master): add metadata snapshot journal

### DIFF
--- a/curvine-server/src/master/fs/master_filesystem.rs
+++ b/curvine-server/src/master/fs/master_filesystem.rs
@@ -32,8 +32,32 @@ use orpc::runtime::GroupExecutor;
 use orpc::sync::ArcRwLock;
 use orpc::{err_box, err_ext, try_option, CommonResult};
 use parking_lot::Mutex;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
+
+pub struct CvMetadataSnapshotEntry {
+    pub status: FileStatus,
+    pub blocks: Option<FileBlocks>,
+}
+
+pub struct CvMetadataSnapshotPage {
+    pub entries: Vec<CvMetadataSnapshotEntry>,
+    pub next_page_token: Option<String>,
+    pub epoch: u64,
+}
+
+pub struct CvMetadataDeltaEntry {
+    pub path: String,
+    pub entry: Option<CvMetadataSnapshotEntry>,
+}
+
+pub struct CvMetadataDeltaPage {
+    pub entries: Vec<CvMetadataDeltaEntry>,
+    pub next_page_token: Option<String>,
+    pub from_epoch: u64,
+    pub to_epoch: u64,
+    pub full_snapshot_required: bool,
+}
 
 #[derive(Clone)]
 pub struct MasterFilesystem {
@@ -54,6 +78,23 @@ pub(crate) enum BlockInodeState {
     File,
     Missing,
     NotFile,
+}
+
+fn child_snapshot_path(parent: &str, child_name: &str) -> String {
+    if parent == "/" {
+        format!("/{child_name}")
+    } else {
+        format!("{parent}/{child_name}")
+    }
+}
+
+fn snapshot_token_in_subtree(token: &str, subtree_path: &str) -> bool {
+    token == subtree_path
+        || (subtree_path != "/"
+            && token
+                .strip_prefix(subtree_path)
+                .map(|rest| rest.starts_with(PATH_SEPARATOR))
+                .unwrap_or(false))
 }
 
 struct FullBlockReportState {
@@ -686,6 +727,279 @@ impl MasterFilesystem {
         };
 
         Ok(locate_blocks)
+    }
+
+    pub fn cv_metadata_snapshot_page(
+        &self,
+        page_token: Option<String>,
+        page_size: usize,
+    ) -> FsResult<CvMetadataSnapshotPage> {
+        if page_size == 0 {
+            return err_box!("cv metadata snapshot page_size must be greater than 0");
+        }
+
+        let fs_dir = self.fs_dir.read();
+        let epoch = fs_dir.op_id.get();
+        let start_after = page_token.filter(|token| !token.is_empty());
+        let mut entries = Vec::with_capacity(page_size.saturating_add(1));
+        self.collect_cv_metadata_snapshot_page(
+            &fs_dir,
+            fs_dir.root_dir(),
+            "/",
+            start_after.as_deref(),
+            page_size.saturating_add(1),
+            &mut entries,
+        )?;
+
+        let next_page_token = if entries.len() > page_size {
+            let token = entries
+                .get(page_size.saturating_sub(1))
+                .map(|entry| entry.status.path.clone());
+            entries.truncate(page_size);
+            token
+        } else {
+            None
+        };
+
+        Ok(CvMetadataSnapshotPage {
+            entries,
+            next_page_token,
+            epoch,
+        })
+    }
+
+    pub fn cv_metadata_delta_page(
+        &self,
+        from_epoch: u64,
+        target_epoch: Option<u64>,
+        page_token: Option<String>,
+        page_size: usize,
+    ) -> FsResult<CvMetadataDeltaPage> {
+        if page_size == 0 {
+            return err_box!("cv metadata delta page_size must be greater than 0");
+        }
+
+        let fs_dir = self.fs_dir.read();
+        let current_epoch = fs_dir.op_id.get();
+        let to_epoch = target_epoch.unwrap_or(current_epoch);
+        if to_epoch > current_epoch {
+            return err_box!(
+                "cv metadata delta target_epoch {} is newer than current epoch {}",
+                to_epoch,
+                current_epoch
+            );
+        }
+        if from_epoch > to_epoch {
+            return err_box!(
+                "cv metadata delta from_epoch {} is newer than target epoch {}",
+                from_epoch,
+                to_epoch
+            );
+        }
+        if target_epoch.is_some() && to_epoch < current_epoch {
+            return Ok(CvMetadataDeltaPage {
+                entries: Vec::new(),
+                next_page_token: None,
+                from_epoch,
+                to_epoch,
+                full_snapshot_required: true,
+            });
+        }
+        if from_epoch == to_epoch {
+            return Ok(CvMetadataDeltaPage {
+                entries: Vec::new(),
+                next_page_token: None,
+                from_epoch,
+                to_epoch,
+                full_snapshot_required: false,
+            });
+        }
+
+        let Some(changes) = fs_dir
+            .journal_writer
+            .cv_metadata_changes_since(from_epoch, to_epoch)
+        else {
+            return Ok(CvMetadataDeltaPage {
+                entries: Vec::new(),
+                next_page_token: None,
+                from_epoch,
+                to_epoch,
+                full_snapshot_required: true,
+            });
+        };
+
+        let mut changed_paths = BTreeMap::new();
+        for change in changes {
+            changed_paths
+                .entry(change.path)
+                .and_modify(|include_subtree| *include_subtree |= change.include_subtree)
+                .or_insert(change.include_subtree);
+        }
+
+        let mut delta_entries = BTreeMap::new();
+        for (path, include_subtree) in changed_paths {
+            if include_subtree {
+                self.collect_cv_metadata_delta_subtree(&fs_dir, &path, &mut delta_entries)?;
+            } else {
+                let entry = self.cv_metadata_entry_for_path(&fs_dir, &path)?;
+                delta_entries.insert(path, entry);
+            }
+        }
+
+        let start_after = page_token.filter(|token| !token.is_empty());
+        let mut page_entries = Vec::with_capacity(page_size.saturating_add(1));
+        for (path, entry) in delta_entries {
+            if start_after
+                .as_deref()
+                .map(|token| path.as_str() <= token)
+                .unwrap_or(false)
+            {
+                continue;
+            }
+            page_entries.push(CvMetadataDeltaEntry { path, entry });
+            if page_entries.len() > page_size {
+                break;
+            }
+        }
+
+        let next_page_token = if page_entries.len() > page_size {
+            let token = page_entries
+                .get(page_size.saturating_sub(1))
+                .map(|entry| entry.path.clone());
+            page_entries.truncate(page_size);
+            token
+        } else {
+            None
+        };
+
+        Ok(CvMetadataDeltaPage {
+            entries: page_entries,
+            next_page_token,
+            from_epoch,
+            to_epoch,
+            full_snapshot_required: false,
+        })
+    }
+
+    fn collect_cv_metadata_delta_subtree(
+        &self,
+        fs_dir: &FsDir,
+        path: &str,
+        entries: &mut BTreeMap<String, Option<CvMetadataSnapshotEntry>>,
+    ) -> FsResult<()> {
+        let Some(entry) = self.cv_metadata_entry_for_path(fs_dir, path)? else {
+            entries.insert(path.to_string(), None);
+            return Ok(());
+        };
+
+        let is_dir = entry.status.is_dir;
+        entries.insert(path.to_string(), Some(entry));
+        if !is_dir {
+            return Ok(());
+        }
+
+        let inp = Self::resolve_path(fs_dir, path)?;
+        let Some(inode) = inp.get_last_inode() else {
+            return Ok(());
+        };
+        let resolved = self.resolve_snapshot_inode(fs_dir, &inode)?;
+        if let InodeView::Dir(dir) = resolved {
+            for child in dir.children_iter() {
+                let child_path = child_snapshot_path(path, child.name());
+                self.collect_cv_metadata_delta_subtree(fs_dir, &child_path, entries)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn cv_metadata_entry_for_path(
+        &self,
+        fs_dir: &FsDir,
+        path: &str,
+    ) -> FsResult<Option<CvMetadataSnapshotEntry>> {
+        let inp = match Self::resolve_path(fs_dir, path) {
+            Ok(inp) => inp,
+            Err(_) => return Ok(None),
+        };
+        let Some(inode) = inp.get_last_inode() else {
+            return Ok(None);
+        };
+        let resolved = self.resolve_snapshot_inode(fs_dir, &inode)?;
+        let status = resolved.to_file_status(path)?;
+        let blocks = if let Ok(file) = resolved.as_file_ref() {
+            Some(FileBlocks::new(
+                status.clone(),
+                self.get_block_locs(path, fs_dir, file)?,
+            ))
+        } else {
+            None
+        };
+        Ok(Some(CvMetadataSnapshotEntry { status, blocks }))
+    }
+
+    fn collect_cv_metadata_snapshot_page(
+        &self,
+        fs_dir: &FsDir,
+        inode: &InodeView,
+        path: &str,
+        start_after: Option<&str>,
+        limit: usize,
+        entries: &mut Vec<CvMetadataSnapshotEntry>,
+    ) -> FsResult<()> {
+        if entries.len() >= limit {
+            return Ok(());
+        }
+        if let Some(token) = start_after {
+            if path != "/" && token > path && !snapshot_token_in_subtree(token, path) {
+                return Ok(());
+            }
+        }
+
+        let resolved = self.resolve_snapshot_inode(fs_dir, inode)?;
+        if start_after.map(|token| path > token).unwrap_or(true) {
+            let status = resolved.to_file_status(path)?;
+            let blocks = if let Ok(file) = resolved.as_file_ref() {
+                Some(FileBlocks::new(
+                    status.clone(),
+                    self.get_block_locs(path, fs_dir, file)?,
+                ))
+            } else {
+                None
+            };
+            entries.push(CvMetadataSnapshotEntry { status, blocks });
+            if entries.len() >= limit {
+                return Ok(());
+            }
+        }
+
+        if let InodeView::Dir(dir) = resolved {
+            for child in dir.children_iter() {
+                let child_path = child_snapshot_path(path, child.name());
+                self.collect_cv_metadata_snapshot_page(
+                    fs_dir,
+                    child,
+                    &child_path,
+                    start_after,
+                    limit,
+                    entries,
+                )?;
+                if entries.len() >= limit {
+                    return Ok(());
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn resolve_snapshot_inode(&self, fs_dir: &FsDir, inode: &InodeView) -> FsResult<InodeView> {
+        if let InodeView::FileEntry(entry) = inode {
+            return fs_dir
+                .store
+                .get_inode(entry.id, Some(&entry.name))?
+                .ok_or_else(|| FsError::file_not_found(entry.name.clone()));
+        }
+        Ok(inode.clone())
     }
 
     pub fn master_info(&self) -> FsResult<MasterInfo> {

--- a/curvine-server/src/master/journal/entry.rs
+++ b/curvine-server/src/master/journal/entry.rs
@@ -17,6 +17,13 @@ use crate::master::meta::BlockMeta;
 use curvine_common::state::{CommitBlock, FileLock, MountInfo, SetAttrOpts};
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Clone)]
+pub(crate) struct CvMetadataChange {
+    pub(crate) op_id: u64,
+    pub(crate) path: String,
+    pub(crate) include_subtree: bool,
+}
+
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct MkdirEntry {
     pub(crate) op_id: u64,
@@ -244,6 +251,52 @@ impl JournalEntry {
             JournalEntry::Symlink(e) => Some(e.new_inode.id),
             JournalEntry::SetLocks(e) => Some(e.ino),
             _ => None,
+        }
+    }
+
+    pub(crate) fn cv_metadata_changes(&self) -> Vec<CvMetadataChange> {
+        match self {
+            JournalEntry::Mkdir(e) => vec![CvMetadataChange::single(e.op_id, &e.path)],
+            JournalEntry::CreateFile(e) => vec![CvMetadataChange::single(e.op_id, &e.path)],
+            JournalEntry::ReopenFile(e) => vec![CvMetadataChange::single(e.op_id, &e.path)],
+            JournalEntry::OverWriteFile(e) => vec![CvMetadataChange::single(e.op_id, &e.path)],
+            JournalEntry::AddBlock(e) => vec![CvMetadataChange::single(e.op_id, &e.path)],
+            JournalEntry::CompleteFile(e) => vec![CvMetadataChange::single(e.op_id, &e.path)],
+            JournalEntry::Rename(e) => vec![
+                CvMetadataChange::subtree(e.op_id, &e.src),
+                CvMetadataChange::subtree(e.op_id, &e.dst),
+            ],
+            JournalEntry::Delete(e) => vec![CvMetadataChange::subtree(e.op_id, &e.path)],
+            JournalEntry::SetAttr(e) => vec![CvMetadataChange::single(e.op_id, &e.path)],
+            JournalEntry::Symlink(e) => vec![CvMetadataChange::single(e.op_id, &e.link)],
+            JournalEntry::Link(e) => vec![
+                CvMetadataChange::single(e.op_id, &e.src_path),
+                CvMetadataChange::single(e.op_id, &e.dst_path),
+            ],
+            JournalEntry::Free(e) => vec![CvMetadataChange::subtree(e.op_id, &e.path)],
+            JournalEntry::Mount(_)
+            | JournalEntry::UnMount(_)
+            | JournalEntry::SetLocks(_)
+            | JournalEntry::UfsApplied(_)
+            | JournalEntry::Snapshot(_) => Vec::new(),
+        }
+    }
+}
+
+impl CvMetadataChange {
+    fn single(op_id: u64, path: &str) -> Self {
+        Self {
+            op_id,
+            path: path.to_string(),
+            include_subtree: false,
+        }
+    }
+
+    fn subtree(op_id: u64, path: &str) -> Self {
+        Self {
+            op_id,
+            path: path.to_string(),
+            include_subtree: true,
         }
     }
 }

--- a/curvine-server/src/master/journal/journal_writer.rs
+++ b/curvine-server/src/master/journal/journal_writer.rs
@@ -27,6 +27,7 @@ use orpc::common::LocalTime;
 use orpc::err_box;
 use orpc::sync::channel::{BlockingChannel, BlockingReceiver, BlockingSender};
 use orpc::sync::AtomicCounter;
+use std::collections::VecDeque;
 use std::sync::Mutex;
 
 // Write metadata operation logs.
@@ -36,9 +37,17 @@ pub struct JournalWriter {
     sender: BlockingSender<JournalEntry>,
     metrics: &'static MasterMetrics,
     receiver: Option<Mutex<BlockingReceiver<JournalEntry>>>,
+    metadata_delta_log: Mutex<MetadataDeltaLog>,
 
     snapshot_entries: u64,
     entries_since_snapshot: AtomicCounter,
+}
+
+#[derive(Default)]
+struct MetadataDeltaLog {
+    capacity: usize,
+    low_watermark: u64,
+    changes: VecDeque<CvMetadataChange>,
 }
 
 impl JournalWriter {
@@ -62,6 +71,7 @@ impl JournalWriter {
             sender,
             metrics,
             receiver,
+            metadata_delta_log: Mutex::new(MetadataDeltaLog::new(conf.metadata_delta_log_capacity)),
             snapshot_entries: conf.snapshot_entries,
             entries_since_snapshot: AtomicCounter::new(0),
         })
@@ -76,10 +86,19 @@ impl JournalWriter {
 
     fn send(&self, fs_dir: &FsDir, entry: JournalEntry) -> FsResult<()> {
         if self.enable {
+            self.record_metadata_delta(&entry);
             self.send_inner(entry)?;
             self.maybe_emit_snapshot(fs_dir)?;
         }
         Ok(())
+    }
+
+    fn record_metadata_delta(&self, entry: &JournalEntry) {
+        let changes = entry.cv_metadata_changes();
+        if changes.is_empty() {
+            return;
+        }
+        self.metadata_delta_log.lock().unwrap().push(changes);
     }
 
     fn maybe_emit_snapshot(&self, fs_dir: &FsDir) -> FsResult<()> {
@@ -349,5 +368,50 @@ impl JournalWriter {
             entries.push(v);
         }
         entries
+    }
+
+    pub(crate) fn cv_metadata_changes_since(
+        &self,
+        from_epoch: u64,
+        to_epoch: u64,
+    ) -> Option<Vec<CvMetadataChange>> {
+        let log = self.metadata_delta_log.lock().unwrap();
+        if from_epoch < log.low_watermark {
+            return None;
+        }
+        Some(
+            log.changes
+                .iter()
+                .filter(|change| change.op_id > from_epoch && change.op_id <= to_epoch)
+                .cloned()
+                .collect(),
+        )
+    }
+}
+
+impl MetadataDeltaLog {
+    fn new(capacity: usize) -> Self {
+        Self {
+            capacity,
+            low_watermark: 0,
+            changes: VecDeque::with_capacity(capacity.min(1024)),
+        }
+    }
+
+    fn push(&mut self, changes: Vec<CvMetadataChange>) {
+        if self.capacity == 0 {
+            if let Some(max_op_id) = changes.iter().map(|change| change.op_id).max() {
+                self.low_watermark = self.low_watermark.max(max_op_id);
+            }
+            return;
+        }
+        for change in changes {
+            self.changes.push_back(change);
+            while self.changes.len() > self.capacity {
+                if let Some(evicted) = self.changes.pop_front() {
+                    self.low_watermark = self.low_watermark.max(evicted.op_id);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
# Summary

Adds the Master-side metadata change journal and paginated snapshot/delta readers needed by a transfer metadata replica. This PR only builds the read model; it does not expose new RPC endpoints yet.

# Issue Describe / Design

Related to the load-job isolation design.

Filesystem mutations are translated into path-level metadata changes held in a bounded in-memory journal. A replica can request a full snapshot or a delta up to a fixed epoch; when history is no longer retained, the API explicitly requires a full snapshot rather than returning an incomplete delta.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `master/journal/entry.rs` | Derives metadata changes from filesystem journal entries. | No external behavior until RPC exposure. |
| `master/journal/journal_writer.rs` | Keeps a bounded metadata delta log with a low watermark. | Provides deterministic fallback to full snapshots. |
| `master/fs/master_filesystem.rs` | Adds paginated metadata snapshot and delta readers. | No existing API behavior changed. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo fmt --all -- --check` | PASS | No formatting changes required. |
| `cargo check --locked -p curvine-server` | PASS | Validates Master and journal integration. |

# Dependencies

- Related PRs: #1328
- Related issues: None
- Blocks / blocked by: Blocked by #1328; blocks the metadata RPC and replica-reader PRs.