### PR TITLE
chore(fuse): cap channel comments at 3 lines

### DIFF
--- a/curvine-fuse/src/session/channel/fuse_receiver.rs
+++ b/curvine-fuse/src/session/channel/fuse_receiver.rs
@@ -283,11 +283,9 @@ impl<T: FileSystem> FuseReceiver<T> {
         Self::send_stream_dispatch(&self.fs, req, rep).await
     }
 
-    /// Stream dispatch + IO attribution core, factored out of `send_stream` so
-    /// tests can drive it with a hand-built `FuseResponse` — no `FuseReceiver`/
-    /// `kernel_fd`/`Pipe2`/reactor. The metrics gate is derived solely from
-    /// `rep.metrics.is_some()` (not a separate flag), so a "metrics but no ctx"
-    /// split-brain state is unrepresentable.
+    /// Stream dispatch + IO attribution core, factored out of `send_stream` so tests
+    /// can drive it with a hand-built `FuseResponse`. The metrics gate derives solely
+    /// from `rep.metrics.is_some()`, so a "metrics but no ctx" state is unrepresentable.
     async fn send_stream_dispatch(
         fs: &Arc<T>,
         req: FuseRequest,
@@ -308,13 +306,9 @@ impl<T: FileSystem> FuseReceiver<T> {
         // failure finishes the original ctx once rather than double-counting.
         let err_rep = rep.clone();
 
-        // IO attribution timers, armed before the match so they also cover the
-        // error-reply enqueue below. One is `Some` per stream opcode: read/write ->
-        // io_dispatch timer, flush/fsync/release -> lifecycle scope.
-        //
-        // ⚠ INVARIANT: no `.await` / early return between `parse_operator()` and
-        // these two scopes — `stream_lifecycle_scope` counts the attempt and arms
-        // its guard atomically, so a suspension here would unbalance the family.
+        // IO attribution timers, armed before the match so they cover the error-reply
+        // enqueue too (one Some per stream opcode). ⚠ INVARIANT: after parse succeeds, no
+        // `.await`/early return before these scopes — the lifecycle scope arms its guard atomically.
         let _dispatch = if metrics_enabled {
             dispatch_io_type(req.opcode()).map(FuseMetrics::io_dispatch_timer)
         } else {
@@ -530,10 +524,9 @@ impl<T: FileSystem> FuseReceiver<T> {
         let mut pending_request =
             PendingRequestGuard::register(pending_requests.clone(), req.unique(), notify.clone());
 
-        // These RAII timers wrap the WHOLE interruptible-request scope and are
-        // built before the `select!`, so an interrupt that wins before `set_lkw()`
-        // is polled still records a sample. So this measures request duration, NOT
-        // lock-acquisition time (backpressure inflates it; a parse failure is ~0).
+        // Built before the `select!` so they wrap the WHOLE interruptible scope: an
+        // interrupt winning before `set_lkw()` is polled still records. Measures
+        // request duration, NOT lock-acquisition time (backpressure inflates it).
         let _setlkw_inflight = FuseMetrics::setlkw_inflight_guard(reply.metrics.is_some());
         let _setlkw_wait = FuseMetrics::setlkw_wait_timer(reply.metrics.is_some());
 
@@ -658,10 +651,9 @@ impl<T: FileSystem> FuseReceiver<T> {
 
             FuseOperator::Ioctl(op) => reply.send_buf(fs.ioctl(op).await).await,
 
-            // Named variants, NOT a `_` wildcard: a new `FuseOperator` left unwired
-            // then fails to compile (this would have caught the RENAME2 half-wiring).
-            // Tag Unsupported: NOT_SUPPORTED -> `unknown_opcode`, else
-            // `unimplemented_opcode`. See `FuseOpCode::expected_dispatch`.
+            // Named variants, NOT a `_` wildcard, so a new unwired `FuseOperator` fails
+            // to compile (caught the RENAME2 half-wiring). Tag: NOT_SUPPORTED ->
+            // `unknown_opcode`, else `unimplemented_opcode`.
             FuseOperator::Notimplemented
             | FuseOperator::Read(_)
             | FuseOperator::Write(_)
@@ -859,10 +851,9 @@ mod tests {
             make_request(OP_INTERRUPT, unique, 0, FuseUtils::struct_as_bytes(&arg))
         }
 
-        // A reply with a live metrics slot, wired to a real channel. `opcode` MUST
-        // match the request's opcode: labels are derived from it, so a mismatch
-        // routes `request_duration_us` to a different child and silently misses the
-        // assertion.
+        // A reply with a live metrics slot, wired to a real channel. `opcode` MUST match
+        // the request's: labels derive from it, so a mismatch routes to a different
+        // `request_duration_us` child and silently misses the assertion.
         fn metrics_reply(
             unique: u64,
             opcode: &'static str,
@@ -1269,10 +1260,9 @@ mod tests {
             );
         }
 
-        // Justifies hoisting the timer OUT of `set_lkw()`: a malformed SETLKW fails
-        // parse before `set_lkw()` is ever called, yet the timer (created in
-        // dispatch_meta_interrupt before the `select!`) still records a sample on
-        // drop. With the timer inside `set_lkw()` this path would record nothing.
+        // Justifies hoisting the timer OUT of `set_lkw()`: a malformed SETLKW fails parse
+        // before `set_lkw()` runs, yet the timer (built before the `select!`) still
+        // records on drop. Inside `set_lkw()` this path would record nothing.
         #[tokio::test]
         async fn malformed_setlkw_records_wait_sample_without_set_lkw() {
             FuseMetrics::ensure_init().unwrap();
@@ -1394,10 +1384,9 @@ mod tests {
         }
     }
 
-    // Drive the real `send_stream_dispatch` (needs only `&fs` + a pre-built
-    // `FuseResponse`, no fd/Pipe2/reactor). `TestFileSystem` returns ENOSYS without
-    // replying, so each op exercises the pre-dispatch-error path: the error reply is
-    // enqueued INSIDE the dispatch/lifecycle RAII scope — the boundary under test.
+    // Drive the real `send_stream_dispatch` with only `&fs` + a pre-built `FuseResponse`.
+    // `TestFileSystem` returns ENOSYS without replying, so each op exercises the
+    // pre-dispatch-error path: the error reply is enqueued INSIDE the RAII scope under test.
     mod send_stream_integration {
         use crate::fs::TestFileSystem;
         use crate::fuse_metrics::{
@@ -1476,13 +1465,9 @@ mod tests {
             )
         }
 
-        // Drive ONE stream op through `send_stream_dispatch`. FD-free on purpose:
-        // reaching dispatch via a real `FuseReceiver` drags in a `Pipe2` whose Drop
-        // deregisters from the reactor after closing its fds, aborting with `IO
-        // Safety violation` under the parallel harness. Assertions use LOWER BOUNDS,
-        // not exact deltas — the process-global io_type labels are shared and a
-        // concurrent test can also bump them.
-        // `with_metrics_ctx` toggles the metrics gate (`rep.metrics.is_some()`).
+        // Drive ONE stream op through `send_stream_dispatch`, FD-free (a real `FuseReceiver`
+        // drags in a `Pipe2` whose Drop aborts with `IO Safety violation`). Assertions use
+        // LOWER BOUNDS (io_type labels are process-global). `with_metrics_ctx` toggles the gate.
         fn dispatch_one(with_metrics_ctx: bool, req: FuseRequest) {
             use crate::fuse_metrics::{FuseReqCtx, FuseReqKind, FuseReqLabels};
             FuseMetrics::ensure_init().unwrap();
@@ -1611,10 +1596,9 @@ mod tests {
             );
         }
 
-        // SMOKE test: each stream family runs end-to-end with metrics off. It does
-        // NOT prove "emits nothing" (the shared io_type labels make `== before`
-        // flaky) — the deterministic no-emission guarantee lives in the `*_gate`
-        // unit tests.
+        // SMOKE test: each stream family runs end-to-end with metrics off. Does NOT
+        // prove "emits nothing" (shared io_type labels make `== before` flaky) — that
+        // guarantee lives in the `*_gate` unit tests.
         #[test]
         fn disabled_send_stream_runs_clean_for_all_families() {
             dispatch_one(false, flush_request(7101));
@@ -1624,11 +1608,9 @@ mod tests {
             dispatch_one(false, write_request(7105));
         }
 
-        // A malformed stream request whose `parse_operator()` fails AFTER the ctx
-        // was built: the parse failure must finish the ctx early (drop the active
-        // guard, record the parse decode error) and must NOT enter the
-        // dispatch/lifecycle RAII scope. Pins that nobody inserts an early
-        // return/await between ctx creation and the scope.
+        // A malformed stream request whose `parse_operator()` fails AFTER the ctx was
+        // built must finish the ctx early (drop guard, record decode error) and NOT enter
+        // the RAII scope. Pins that no early return/await sits between ctx and scope.
         #[test]
         fn malformed_stream_request_finishes_early_without_dispatch_or_lifecycle() {
             use crate::fuse_metrics::{FuseReqCtx, FuseReqKind, FuseReqLabels, DECODE_PHASE_PARSE};
@@ -1684,11 +1666,9 @@ mod tests {
                 drainer.abort();
             });
 
-            // "No io_dispatch/lifecycle sample on parse failure" is STRUCTURAL: the
-            // RAII scope is created only after `parse_operator()` succeeds, so an Err
-            // parse returns via `finish_early` before it exists (proven by the
-            // res.is_err() + guard-dropped asserts above). Only the decode error is
-            // observable here; decode_errors_total is shared, so assert a lower bound.
+            // "No io_dispatch/lifecycle sample on parse failure" is STRUCTURAL: the RAII
+            // scope exists only after `parse_operator()` succeeds, so an Err returns via
+            // `finish_early` first. Only the decode error shows here (shared → lower bound).
             assert!(
                 mx.decode_errors_total
                     .with_label_values(&[DECODE_PHASE_PARSE, "other"])
@@ -1699,10 +1679,9 @@ mod tests {
         }
     }
 
-    // When a stream op fails BEFORE replying (pre-dispatch error, e.g. a
-    // handle-lookup miss), `send_stream_dispatch` enqueues EXACTLY ONE error reply
-    // via its `if res.is_err() { err_rep.send_rep }` fallback, never double-replies.
-    // The per-test reply channel makes the `== 1` counts deterministic.
+    // When a stream op fails BEFORE replying (pre-dispatch error), `send_stream_dispatch`
+    // enqueues EXACTLY ONE error reply via its `if res.is_err()` fallback, never
+    // double-replies. The per-test reply channel makes the `== 1` counts deterministic.
     mod stream_error_coverage {
         use crate::err_fuse;
         use crate::fs::operator::{FSync, Flush, Read, Release, Write};
@@ -1752,10 +1731,9 @@ mod tests {
             }
         }
 
-        // `read` REPLIES via `reply` and THEN returns `Err`, proving the
-        // `if res.is_err() { err_rep.send_rep(res) }` fallback cannot double-reply
-        // end-to-end. `cfg(not(debug_assertions))` matches its only (release-only)
-        // user, so the mock is not "never constructed" in debug.
+        // `read` REPLIES and THEN returns `Err`, proving the `if res.is_err()` fallback
+        // cannot double-reply end-to-end. `cfg(not(debug_assertions))` matches its only
+        // (release-only) user, so the mock is not "never constructed" in debug.
         #[cfg(not(debug_assertions))]
         struct ReplyThenErrFs;
         #[cfg(not(debug_assertions))]
@@ -1819,12 +1797,9 @@ mod tests {
             )
         }
 
-        // Drive one stream op through `send_stream_dispatch` and return `(result,
-        // every enqueued FuseTask, the shared reply handle)`. FD-free; the handle
-        // lets the caller inspect the shared metrics slot (finished / active guard).
-        // Fully awaited on a single-thread runtime, so everything enqueued is already
-        // buffered in `rx` by the time it returns — we just drain synchronously,
-        // stopping on `Ok(Some)` so a closed channel (`Err`) can't panic the drain.
+        // Drive one stream op and return `(result, every enqueued FuseTask, the shared
+        // reply handle)`. FD-free. Single-thread runtime fully awaits, so all tasks are
+        // buffered in `rx` on return — drained synchronously, so a closed channel can't panic.
         fn dispatch_and_collect<F: FileSystem>(
             fs: Arc<F>,
             with_metrics_ctx: bool,
@@ -1937,10 +1912,9 @@ mod tests {
                 1,
                 "exactly one error reply on the disabled path"
             );
-            // Legacy Reply variant AND the same errno on the wire. The FUSE error
-            // frame encodes the errno negated (`ResponseData::create`: header.error =
-            // -errno), so a pre-dispatch EBADF surfaces as `-EBADF` — matching the
-            // enabled path's `errno == EBADF` check, just read off the raw frame.
+            // Legacy Reply variant AND the same errno on the wire. The FUSE error frame
+            // encodes the errno negated (header.error = -errno), so a pre-dispatch EBADF
+            // surfaces as `-EBADF` — the enabled path's check, read off the raw frame.
             match &tasks[0] {
                 FuseTask::Reply(d) => assert_eq!(
                     d.header.error, -ERRNO,
@@ -1955,12 +1929,9 @@ mod tests {
             }
         }
 
-        // End-to-end double-reply guard: an op that BOTH replies AND then returns Err
-        // makes the `err_rep` fallback a no-op, so the kernel gets one reply, not two.
-        // Drives the real `send_stream_dispatch` seam, not just the slot guard.
-        // Release-only: a genuine double reply trips `commit_reply_task`'s
-        // `debug_assert!(!finished)` in debug (see `double_reply_panics_in_debug` in
-        // fuse_response.rs); this asserts the release warn + no-op behavior.
+        // End-to-end double-reply guard: an op that BOTH replies AND returns Err makes
+        // the `err_rep` fallback a no-op, so the kernel gets one reply. Release-only: a
+        // genuine double reply trips `commit_reply_task`'s `debug_assert!(!finished)`.
         #[test]
         #[cfg(not(debug_assertions))]
         fn err_rep_fallback_after_a_reply_is_noop() {

--- a/curvine-fuse/src/session/channel/fuse_receiver.rs
+++ b/curvine-fuse/src/session/channel/fuse_receiver.rs
@@ -306,9 +306,9 @@ impl<T: FileSystem> FuseReceiver<T> {
         // failure finishes the original ctx once rather than double-counting.
         let err_rep = rep.clone();
 
-        // IO attribution timers, armed before the match so they cover the error-reply
-        // enqueue too (one Some per stream opcode). ⚠ INVARIANT: after parse succeeds, no
-        // `.await`/early return before these scopes — the lifecycle scope arms its guard atomically.
+        // IO attribution timers, armed before the match so they cover the error-reply enqueue
+        // too (one Some per stream opcode). ⚠ INVARIANT: after parse succeeds, no `.await`/
+        // early return before these scopes — the lifecycle scope arms its guard atomically.
         let _dispatch = if metrics_enabled {
             dispatch_io_type(req.opcode()).map(FuseMetrics::io_dispatch_timer)
         } else {

--- a/curvine-fuse/src/session/channel/fuse_sender.rs
+++ b/curvine-fuse/src/session/channel/fuse_sender.rs
@@ -203,13 +203,9 @@ impl<T: FileSystem> FuseSender<T> {
         }
     }
 
-    // Non-splice reply path. Uses AsyncFd::async_write (edge-triggered WRITABLE),
-    // the same readiness model that hangs the splice path — but writev to /dev/fuse
-    // does not hit that trap. The fuse device has no send-buffer watermark, so a
-    // well-formed reply never returns EAGAIN the way the SPLICE_F_NONBLOCK
-    // pipe->device transfer does; it fails with a real errno (e.g. ENOENT for an
-    // unknown request) instead. This is why enable_splice=false is a sound workaround
-    // and why splice_retry is intentionally NOT applied to writev.
+    // Non-splice reply path. The fuse device has no send-buffer watermark, so writev
+    // never returns EAGAIN like the SPLICE_F_NONBLOCK transfer does — it fails with a
+    // real errno. Hence enable_splice=false works and splice_retry is NOT applied here.
     pub async fn write(&mut self, rep: ResponseData) -> IOResult<()> {
         let (len, iovec) = rep.as_iovec()?;
         let written = self
@@ -239,10 +235,9 @@ impl<T: FileSystem> FuseSender<T> {
         Ok(())
     }
 
-    /// Drain residual bytes left in the pipe after a failed transfer, else stale
-    /// bytes at the head of the FIFO permanently poison every subsequent response.
-    /// EINTR is retried so a signal cannot leave the pipe partially filled; the loop
-    /// stops on EAGAIN/EWOULDBLOCK (empty) or EOF/any other error.
+    /// Drain residual bytes after a failed transfer, else stale bytes at the FIFO
+    /// head poison every subsequent response. EINTR is retried; the loop stops on
+    /// EAGAIN/EWOULDBLOCK (empty), EOF, or any other error.
     fn drain_pipe(pipe2: &Pipe2) {
         let fd = pipe2.read_raw_fd();
         let mut buf = [0u8; 8192];


### PR DESCRIPTION
## What

Follow-up to #1315. Further compresses the long comments in the two FUSE
channel files so no comment block exceeds 3 lines:

- `curvine-fuse/src/session/channel/fuse_receiver.rs`
- `curvine-fuse/src/session/channel/fuse_sender.rs`

## Why

#1315 trimmed redundant comments crate-wide but left several multi-line blocks
in these two hot-path files. This tightens them to a 3-line cap while keeping
the load-bearing "why", so the invariants stay documented without the bulk.

Load-bearing facts deliberately preserved:
- the parse-success → RAII-scope "no `.await`/early return" window invariant;
- the writev-vs-splice EAGAIN root cause (the fuse device has no send-buffer
  watermark, so writev fails with a real errno instead of EAGAIN — hence
  `enable_splice=false` is sound and `splice_retry` is not applied to writev);
- the pipe-poisoning `drain_pipe` invariant;
- the shared process-global metric-label rationale for lower-bound assertions.

## Scope

Comment-only. No code, string literals, log strings, or behavior changed.

## Verification

- `cargo fmt -p curvine-fuse -- --check` ✓
- `cargo clippy -p curvine-fuse --all-targets` ✓
- `cargo test -p curvine-fuse --lib -- --test-threads=1 session::channel::` → 30 passed ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)