### PR TITLE
feat(libsdk): add Java mount lifecycle APIs (#1332)

### DIFF
--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineMountClient.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineMountClient.java
@@ -1,0 +1,144 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.curvine;
+
+import io.curvine.exception.CurvineException;
+import io.curvine.proto.GetMountInfoResponse;
+import io.curvine.proto.GetMountTableResponse;
+import io.curvine.proto.MountInfoProto;
+import org.apache.hadoop.conf.Configuration;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Explicit Java client for Curvine UFS mount lifecycle operations.
+ *
+ * <p>Mounting is intentionally separate from {@link CurvineLoadClient}: callers decide when
+ * cluster-wide UFS metadata is created, updated, or removed.
+ */
+public final class CurvineMountClient implements Closeable {
+    private static final long SUCCESS = 0;
+
+    private final long nativeHandle;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    private CurvineMountClient(long nativeHandle) {
+        this.nativeHandle = nativeHandle;
+    }
+
+    public static CurvineMountClient from(FilesystemConf conf) throws IOException {
+        Objects.requireNonNull(conf, "conf");
+        try {
+            long handle = CurvineNative.newFilesystem(conf.toToml());
+            if (handle < SUCCESS) {
+                throw CurvineException.create((int) handle, "failed to create CurvineMountClient");
+            }
+            return new CurvineMountClient(handle);
+        } catch (IllegalAccessException e) {
+            throw new IOException("failed to serialize FilesystemConf", e);
+        }
+    }
+
+    public static CurvineMountClient from(Configuration conf) throws IOException {
+        try {
+            return from(new FilesystemConf(conf));
+        } catch (IllegalAccessException e) {
+            throw new IOException("failed to build FilesystemConf", e);
+        }
+    }
+
+    /** Create or update a UFS mount. */
+    public void mount(MountRequest request) throws IOException {
+        ensureOpen();
+        Objects.requireNonNull(request, "request");
+        long errno = CurvineNative.mount(
+                nativeHandle,
+                request.getUfsPath(),
+                request.getCvPath(),
+                request.getOptions().toByteArray());
+        checkError(errno, "mount failed: " + request.getCvPath());
+    }
+
+    /** Remove the UFS mount at {@code cvPath}. */
+    public void unmount(String cvPath) throws IOException {
+        ensureOpen();
+        String path = requirePath(cvPath, "cvPath");
+        long errno = CurvineNative.unmount(nativeHandle, path);
+        checkError(errno, "unmount failed: " + path);
+    }
+
+    /** Find the mount that contains either a Curvine or UFS path. */
+    public Optional<MountInfoProto> getMountInfo(String path) throws IOException {
+        ensureOpen();
+        byte[] bytes = CurvineNative.getMountInfo(nativeHandle, requirePath(path, "path"));
+        checkBytes(bytes, "getMountInfo");
+        return parseMountInfo(bytes);
+    }
+
+    /** List every mount in the server's mount-table order. */
+    public List<MountInfoProto> listMounts() throws IOException {
+        ensureOpen();
+        byte[] bytes = CurvineNative.getMountTable(nativeHandle);
+        checkBytes(bytes, "getMountTable");
+        return parseMountTable(bytes);
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (!closed.compareAndSet(false, true)) {
+            return;
+        }
+        checkError(CurvineNative.closeFilesystem(nativeHandle), "close CurvineMountClient failed");
+    }
+
+    static Optional<MountInfoProto> parseMountInfo(byte[] bytes) throws IOException {
+        GetMountInfoResponse response = GetMountInfoResponse.parseFrom(bytes);
+        return response.hasMountInfo() ? Optional.of(response.getMountInfo()) : Optional.empty();
+    }
+
+    static List<MountInfoProto> parseMountTable(byte[] bytes) throws IOException {
+        return GetMountTableResponse.parseFrom(bytes).getMountTableList();
+    }
+
+    private void ensureOpen() throws IOException {
+        if (closed.get()) {
+            throw new IOException("CurvineMountClient is closed");
+        }
+    }
+
+    private static void checkError(long errno, String message) throws IOException {
+        if (errno < SUCCESS) {
+            throw CurvineException.create((int) errno, message);
+        }
+    }
+
+    private static void checkBytes(byte[] bytes, String operation) throws IOException {
+        if (bytes == null) {
+            throw new CurvineException("native " + operation + " call returned null");
+        }
+    }
+
+    private static String requirePath(String value, String field) {
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException(field + " cannot be empty");
+        }
+        return value.trim();
+    }
+}

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineNative.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineNative.java
@@ -329,6 +329,16 @@ public class CurvineNative {
 
     public static native byte[] getMountInfo(long nativeHandle, String path) throws IOException;
 
+    /** Create or update a UFS mount with a serialized {@code MountOptionsProto}. */
+    public static native long mount(
+            long nativeHandle, String ufsPath, String cvPath, byte[] mountOptions) throws IOException;
+
+    /** Remove a UFS mount by Curvine path. */
+    public static native long unmount(long nativeHandle, String cvPath) throws IOException;
+
+    /** Return a serialized {@code GetMountTableResponse} protobuf. */
+    public static native byte[] getMountTable(long nativeHandle) throws IOException;
+
     public static native String togglePath(long nativeHandle, String path, boolean checkCache) throws IOException;
 
     /**

--- a/curvine-libsdk/java/src/main/java/io/curvine/MountRequest.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/MountRequest.java
@@ -85,6 +85,13 @@ public final class MountRequest {
             return this;
         }
 
+        /**
+         * Select replacement-style update semantics for an existing mount.
+         *
+         * <p>All options in this request, including defaults for options not explicitly set,
+         * are sent to the master and can replace existing mount settings. Include each setting's
+         * current value in the request when it must be preserved.
+         */
         public Builder update(boolean update) {
             this.update = update;
             return this;

--- a/curvine-libsdk/java/src/main/java/io/curvine/MountRequest.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/MountRequest.java
@@ -1,0 +1,195 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.curvine;
+
+import io.curvine.proto.AccessModeProto;
+import io.curvine.proto.MountOptionsProto;
+import io.curvine.proto.ProviderProto;
+import io.curvine.proto.StorageTypeProto;
+import io.curvine.proto.TtlActionProto;
+import io.curvine.proto.WriteTypeProto;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/** Immutable request for creating or updating a Curvine UFS mount. */
+public final class MountRequest {
+    private static final long DEFAULT_TTL_MS = 7L * 24L * 60L * 60L * 1000L;
+
+    private final String ufsPath;
+    private final String cvPath;
+    private final MountOptionsProto options;
+
+    private MountRequest(String ufsPath, String cvPath, MountOptionsProto options) {
+        this.ufsPath = ufsPath;
+        this.cvPath = cvPath;
+        this.options = options;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public String getUfsPath() {
+        return ufsPath;
+    }
+
+    public String getCvPath() {
+        return cvPath;
+    }
+
+    public MountOptionsProto getOptions() {
+        return options;
+    }
+
+    public static final class Builder {
+        private String ufsPath;
+        private String cvPath;
+        private boolean update;
+        private final Map<String, String> addProperties = new LinkedHashMap<>();
+        private Long ttlMs;
+        private TtlActionProto ttlAction;
+        private boolean readVerifyUfs;
+        private StorageTypeProto storageType;
+        private Long blockSize;
+        private Integer replicas;
+        private final java.util.List<String> removeProperties = new java.util.ArrayList<>();
+        private WriteTypeProto writeType = WriteTypeProto.WRITE_TYPE_PROTO_CACHE_MODE;
+        private ProviderProto provider;
+        private Boolean autoCache;
+        private AccessModeProto accessMode;
+
+        private Builder() {
+        }
+
+        public Builder ufsPath(String ufsPath) {
+            this.ufsPath = ufsPath;
+            return this;
+        }
+
+        public Builder cvPath(String cvPath) {
+            this.cvPath = cvPath;
+            return this;
+        }
+
+        public Builder update(boolean update) {
+            this.update = update;
+            return this;
+        }
+
+        public Builder addProperty(String key, String value) {
+            addProperties.put(requireText(key, "property key"), Objects.requireNonNull(value, "value"));
+            return this;
+        }
+
+        public Builder ttlMs(long ttlMs) {
+            this.ttlMs = ttlMs;
+            return this;
+        }
+
+        public Builder ttlAction(TtlActionProto ttlAction) {
+            this.ttlAction = Objects.requireNonNull(ttlAction, "ttlAction");
+            return this;
+        }
+
+        public Builder readVerifyUfs(boolean readVerifyUfs) {
+            this.readVerifyUfs = readVerifyUfs;
+            return this;
+        }
+
+        public Builder storageType(StorageTypeProto storageType) {
+            this.storageType = Objects.requireNonNull(storageType, "storageType");
+            return this;
+        }
+
+        public Builder blockSize(long blockSize) {
+            this.blockSize = blockSize;
+            return this;
+        }
+
+        public Builder replicas(int replicas) {
+            this.replicas = replicas;
+            return this;
+        }
+
+        public Builder removeProperty(String key) {
+            removeProperties.add(requireText(key, "property key"));
+            return this;
+        }
+
+        public Builder writeType(WriteTypeProto writeType) {
+            this.writeType = Objects.requireNonNull(writeType, "writeType");
+            return this;
+        }
+
+        public Builder provider(ProviderProto provider) {
+            this.provider = Objects.requireNonNull(provider, "provider");
+            return this;
+        }
+
+        public Builder autoCache(boolean autoCache) {
+            this.autoCache = autoCache;
+            return this;
+        }
+
+        public Builder accessMode(AccessModeProto accessMode) {
+            this.accessMode = Objects.requireNonNull(accessMode, "accessMode");
+            return this;
+        }
+
+        public MountRequest build() {
+            String checkedUfsPath = requireText(ufsPath, "ufsPath");
+            String checkedCvPath = requireText(cvPath, "cvPath");
+            MountOptionsProto.Builder options = MountOptionsProto.newBuilder()
+                    .setUpdate(update)
+                    .putAllAddProperties(addProperties)
+                    .setTtlMs(ttlMs == null ? DEFAULT_TTL_MS : ttlMs)
+                    .setTtlAction(ttlAction == null ? defaultTtlAction(writeType) : ttlAction)
+                    .setReadVerifyUfs(readVerifyUfs)
+                    .addAllRemoveProperties(removeProperties)
+                    .setWriteType(writeType)
+                    .setAutoCache(autoCache == null || autoCache)
+                    .setAccessMode(accessMode == null
+                            ? AccessModeProto.ACCESS_MODE_PROTO_READ_ONLY : accessMode);
+            if (storageType != null) {
+                options.setStorageType(storageType);
+            }
+            if (blockSize != null) {
+                options.setBlockSize(blockSize);
+            }
+            if (replicas != null) {
+                options.setReplicas(replicas);
+            }
+            if (provider != null) {
+                options.setProvider(provider);
+            }
+            return new MountRequest(checkedUfsPath, checkedCvPath, options.build());
+        }
+
+        private static TtlActionProto defaultTtlAction(WriteTypeProto writeType) {
+            return writeType == WriteTypeProto.WRITE_TYPE_PROTO_FS_MODE
+                    ? TtlActionProto.TTL_ACTION_PROTO_FREE
+                    : TtlActionProto.TTL_ACTION_PROTO_DELETE;
+        }
+
+        private static String requireText(String value, String field) {
+            if (value == null || value.trim().isEmpty()) {
+                throw new IllegalArgumentException(field + " cannot be empty");
+            }
+            return value.trim();
+        }
+    }
+}

--- a/curvine-libsdk/java/src/test/java/io/curvine/CurvineMountClientTest.java
+++ b/curvine-libsdk/java/src/test/java/io/curvine/CurvineMountClientTest.java
@@ -1,0 +1,70 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.curvine;
+
+import io.curvine.proto.GetMountInfoResponse;
+import io.curvine.proto.GetMountTableResponse;
+import io.curvine.proto.MountInfoProto;
+import io.curvine.proto.TtlActionProto;
+import io.curvine.proto.WriteTypeProto;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+public class CurvineMountClientTest {
+
+    @Test
+    public void parsesPresentAndAbsentMountInfo() throws Exception {
+        MountInfoProto mount = mount("/data", "oss://bucket/data", 7);
+        Optional<MountInfoProto> present = CurvineMountClient.parseMountInfo(
+                GetMountInfoResponse.newBuilder().setMountInfo(mount).build().toByteArray());
+        Optional<MountInfoProto> absent = CurvineMountClient.parseMountInfo(
+                GetMountInfoResponse.getDefaultInstance().toByteArray());
+
+        Assert.assertTrue(present.isPresent());
+        Assert.assertEquals(mount, present.get());
+        Assert.assertFalse(absent.isPresent());
+    }
+
+    @Test
+    public void parsesMountTableInServerOrder() throws Exception {
+        MountInfoProto first = mount("/a", "oss://bucket/a", 1);
+        MountInfoProto second = mount("/b", "oss://bucket/b", 2);
+        List<MountInfoProto> mounts = CurvineMountClient.parseMountTable(
+                GetMountTableResponse.newBuilder()
+                        .addMountTable(first)
+                        .addMountTable(second)
+                        .build()
+                        .toByteArray());
+
+        Assert.assertEquals(2, mounts.size());
+        Assert.assertEquals(first, mounts.get(0));
+        Assert.assertEquals(second, mounts.get(1));
+    }
+
+    private static MountInfoProto mount(String cvPath, String ufsPath, int mountId) {
+        return MountInfoProto.newBuilder()
+                .setCvPath(cvPath)
+                .setUfsPath(ufsPath)
+                .setMountId(mountId)
+                .setTtlMs(60_000L)
+                .setTtlAction(TtlActionProto.TTL_ACTION_PROTO_DELETE)
+                .setReadVerifyUfs(false)
+                .setWriteType(WriteTypeProto.WRITE_TYPE_PROTO_CACHE_MODE)
+                .build();
+    }
+}

--- a/curvine-libsdk/java/src/test/java/io/curvine/MountRequestTest.java
+++ b/curvine-libsdk/java/src/test/java/io/curvine/MountRequestTest.java
@@ -1,0 +1,106 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.curvine;
+
+import io.curvine.proto.AccessModeProto;
+import io.curvine.proto.ProviderProto;
+import io.curvine.proto.StorageTypeProto;
+import io.curvine.proto.TtlActionProto;
+import io.curvine.proto.WriteTypeProto;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MountRequestTest {
+
+    @Test
+    public void builderUsesCacheModeDefaults() {
+        MountRequest request = MountRequest.builder()
+                .ufsPath("oss://bucket/data")
+                .cvPath("/data")
+                .addProperty("oss.endpoint", "https://oss.example.com")
+                .build();
+
+        Assert.assertEquals("oss://bucket/data", request.getUfsPath());
+        Assert.assertEquals("/data", request.getCvPath());
+        Assert.assertFalse(request.getOptions().getUpdate());
+        Assert.assertEquals(7L * 24L * 60L * 60L * 1000L, request.getOptions().getTtlMs());
+        Assert.assertEquals(
+                TtlActionProto.TTL_ACTION_PROTO_DELETE, request.getOptions().getTtlAction());
+        Assert.assertFalse(request.getOptions().getReadVerifyUfs());
+        Assert.assertEquals(
+                WriteTypeProto.WRITE_TYPE_PROTO_CACHE_MODE, request.getOptions().getWriteType());
+        Assert.assertTrue(request.getOptions().getAutoCache());
+        Assert.assertEquals(
+                AccessModeProto.ACCESS_MODE_PROTO_READ_ONLY, request.getOptions().getAccessMode());
+        Assert.assertEquals(
+                "https://oss.example.com", request.getOptions().getAddPropertiesOrThrow("oss.endpoint"));
+        Assert.assertFalse(request.getOptions().hasProvider());
+        Assert.assertFalse(request.getOptions().hasStorageType());
+    }
+
+    @Test
+    public void builderEncodesAllMountOptions() {
+        MountRequest request = MountRequest.builder()
+                .ufsPath("oss://bucket/data")
+                .cvPath("/data")
+                .update(true)
+                .ttlMs(60_000L)
+                .readVerifyUfs(true)
+                .storageType(StorageTypeProto.STORAGE_TYPE_PROTO_SSD)
+                .blockSize(16L * 1024L * 1024L)
+                .replicas(3)
+                .removeProperty("old.property")
+                .writeType(WriteTypeProto.WRITE_TYPE_PROTO_FS_MODE)
+                .provider(ProviderProto.PROVIDER_PROTO_OPENDAL)
+                .autoCache(false)
+                .accessMode(AccessModeProto.ACCESS_MODE_PROTO_READ_WRITE)
+                .build();
+
+        Assert.assertTrue(request.getOptions().getUpdate());
+        Assert.assertEquals(60_000L, request.getOptions().getTtlMs());
+        Assert.assertTrue(request.getOptions().getReadVerifyUfs());
+        Assert.assertEquals(
+                StorageTypeProto.STORAGE_TYPE_PROTO_SSD, request.getOptions().getStorageType());
+        Assert.assertEquals(16L * 1024L * 1024L, request.getOptions().getBlockSize());
+        Assert.assertEquals(3, request.getOptions().getReplicas());
+        Assert.assertEquals("old.property", request.getOptions().getRemoveProperties(0));
+        Assert.assertEquals(
+                WriteTypeProto.WRITE_TYPE_PROTO_FS_MODE, request.getOptions().getWriteType());
+        Assert.assertEquals(
+                TtlActionProto.TTL_ACTION_PROTO_FREE, request.getOptions().getTtlAction());
+        Assert.assertEquals(
+                ProviderProto.PROVIDER_PROTO_OPENDAL, request.getOptions().getProvider());
+        Assert.assertFalse(request.getOptions().getAutoCache());
+        Assert.assertEquals(
+                AccessModeProto.ACCESS_MODE_PROTO_READ_WRITE, request.getOptions().getAccessMode());
+    }
+
+    @Test
+    public void builderRejectsBlankPaths() {
+        assertInvalid("ufsPath", MountRequest.builder().cvPath("/data"));
+        assertInvalid("cvPath", MountRequest.builder().ufsPath("oss://bucket/data"));
+        assertInvalid("ufsPath", MountRequest.builder().ufsPath("  ").cvPath("/data"));
+        assertInvalid("cvPath", MountRequest.builder().ufsPath("oss://bucket/data").cvPath("  "));
+    }
+
+    private static void assertInvalid(String field, MountRequest.Builder builder) {
+        try {
+            builder.build();
+            Assert.fail("expected IllegalArgumentException");
+        } catch (IllegalArgumentException expected) {
+            Assert.assertTrue(expected.getMessage().contains(field));
+        }
+    }
+}

--- a/curvine-libsdk/src/core/filesystem.rs
+++ b/curvine-libsdk/src/core/filesystem.rs
@@ -17,7 +17,7 @@ use crate::{LibFsReader, LibFsWriter};
 use bytes::BytesMut;
 use curvine_common::conf::ClusterConf;
 use curvine_common::fs::{FileSystem, Path};
-use curvine_common::state::FreeResult;
+use curvine_common::state::{FreeResult, MountInfo, MountOptions};
 use curvine_common::FsResult;
 use orpc::runtime::RpcRuntime;
 
@@ -117,6 +117,29 @@ impl LibFilesystem {
         let path = Path::from_str(path)?;
         self.rt()
             .block_on(async { self.inner().get_mount_info_bytes(&path).await })
+    }
+
+    pub fn mount(
+        &self,
+        ufs_path: impl AsRef<str>,
+        cv_path: impl AsRef<str>,
+        opts: MountOptions,
+    ) -> FsResult<()> {
+        let ufs_path = Path::from_str(ufs_path)?;
+        let cv_path = Path::from_str(cv_path)?;
+        self.rt()
+            .block_on(async { self.inner().mount(&ufs_path, &cv_path, opts).await })
+    }
+
+    pub fn umount(&self, cv_path: impl AsRef<str>) -> FsResult<()> {
+        let cv_path = Path::from_str(cv_path)?;
+        self.rt()
+            .block_on(async { self.inner().umount(&cv_path).await })
+    }
+
+    pub fn get_mount_table(&self) -> FsResult<Vec<MountInfo>> {
+        self.rt()
+            .block_on(async { self.inner().get_mount_table().await })
     }
 
     pub fn toggle_path(&self, path: impl AsRef<str>, check_cache: bool) -> FsResult<Option<Path>> {

--- a/curvine-libsdk/src/java/java_abi.rs
+++ b/curvine-libsdk/src/java/java_abi.rs
@@ -16,7 +16,7 @@
 
 use crate::java::{JavaFilesystem, SUCCESS};
 use crate::{java_err, java_err2, LibFsReader, LibFsWriter};
-use jni::objects::{JLongArray, JObject, JString};
+use jni::objects::{JByteArray, JLongArray, JObject, JString};
 use jni::sys::{jarray, jboolean, jint, jlong};
 use jni::JNIEnv;
 use orpc::sys::FFIUtils;
@@ -276,6 +276,42 @@ pub unsafe extern "C" fn Java_io_curvine_CurvineNative_getMountInfo(
 ) -> jarray {
     let fs = &*fs_ptr;
     java_err2!(env, fs.get_mount_info(&mut env, path))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_io_curvine_CurvineNative_mount(
+    mut env: JNIEnv,
+    _this: JObject,
+    fs_ptr: *mut JavaFilesystem,
+    ufs_path: JString,
+    cv_path: JString,
+    options: JByteArray,
+) -> jlong {
+    let fs = &*fs_ptr;
+    java_err!(env, fs.mount(&mut env, ufs_path, cv_path, options));
+    SUCCESS
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_io_curvine_CurvineNative_unmount(
+    mut env: JNIEnv,
+    _this: JObject,
+    fs_ptr: *mut JavaFilesystem,
+    cv_path: JString,
+) -> jlong {
+    let fs = &*fs_ptr;
+    java_err!(env, fs.unmount(&mut env, cv_path));
+    SUCCESS
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_io_curvine_CurvineNative_getMountTable(
+    mut env: JNIEnv,
+    _this: JObject,
+    fs_ptr: *mut JavaFilesystem,
+) -> jarray {
+    let fs = &*fs_ptr;
+    java_err2!(env, fs.get_mount_table(&mut env))
 }
 
 #[no_mangle]

--- a/curvine-libsdk/src/java/java_filesystem.rs
+++ b/curvine-libsdk/src/java/java_filesystem.rs
@@ -25,11 +25,19 @@ use curvine_common::FsResult;
 use jni::objects::{JByteArray, JString};
 use jni::sys::{jarray, jboolean, jstring};
 use jni::JNIEnv;
-use orpc::try_err;
+use orpc::{err_box, try_err};
 use prost::Message;
 
 pub struct JavaFilesystem {
     inner: LibFilesystem,
+}
+
+fn decode_mount_options(bytes: &[u8]) -> FsResult<curvine_common::state::MountOptions> {
+    if bytes.is_empty() {
+        return err_box!("mount options cannot be empty");
+    }
+    let options = try_err!(MountOptionsProto::decode(bytes));
+    Ok(ProtoUtils::mount_options_from_pb(options))
 }
 
 impl JavaFilesystem {
@@ -125,12 +133,8 @@ impl JavaFilesystem {
         let options = env
             .convert_byte_array(&options)
             .map_err(FsError::from_error)?;
-        let options = try_err!(MountOptionsProto::decode(options.as_slice()));
-        self.inner.mount(
-            ufs_path,
-            cv_path,
-            ProtoUtils::mount_options_from_pb(options),
-        )
+        self.inner
+            .mount(ufs_path, cv_path, decode_mount_options(&options)?)
     }
 
     pub fn unmount(&self, env: &mut JNIEnv, cv_path: JString) -> FsResult<()> {
@@ -225,5 +229,16 @@ impl JavaFilesystem {
 
     pub fn cleanup(&self) {
         self.inner.cleanup()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::decode_mount_options;
+
+    #[test]
+    fn rejects_empty_mount_options() {
+        let error = decode_mount_options(&[]).unwrap_err();
+        assert!(error.to_string().contains("mount options cannot be empty"));
     }
 }

--- a/curvine-libsdk/src/java/java_filesystem.rs
+++ b/curvine-libsdk/src/java/java_filesystem.rs
@@ -15,13 +15,18 @@
 use crate::core::job;
 use crate::java::JavaUtils;
 use crate::{FilesystemConf, LibFilesystem, LibFsReader, LibFsWriter};
-use curvine_common::proto::{GetJobStatusResponse, SubmitJobResponse};
+use curvine_common::error::FsError;
+use curvine_common::proto::{
+    GetJobStatusResponse, GetMountTableResponse, MountOptionsProto, SubmitJobResponse,
+};
 use curvine_common::state::LoadJobCommand;
 use curvine_common::utils::ProtoUtils;
 use curvine_common::FsResult;
-use jni::objects::JString;
+use jni::objects::{JByteArray, JString};
 use jni::sys::{jarray, jboolean, jstring};
 use jni::JNIEnv;
+use orpc::try_err;
+use prost::Message;
 
 pub struct JavaFilesystem {
     inner: LibFilesystem,
@@ -106,6 +111,44 @@ impl JavaFilesystem {
         let bytes = self.inner.get_mount_info(path)?;
         let byte_arr = JavaUtils::new_jarray(env, &bytes)?;
         Ok(byte_arr)
+    }
+
+    pub fn mount(
+        &self,
+        env: &mut JNIEnv,
+        ufs_path: JString,
+        cv_path: JString,
+        options: JByteArray,
+    ) -> FsResult<()> {
+        let ufs_path = JavaUtils::jstring_to_string(env, &ufs_path)?;
+        let cv_path = JavaUtils::jstring_to_string(env, &cv_path)?;
+        let options = env
+            .convert_byte_array(&options)
+            .map_err(FsError::from_error)?;
+        let options = try_err!(MountOptionsProto::decode(options.as_slice()));
+        self.inner.mount(
+            ufs_path,
+            cv_path,
+            ProtoUtils::mount_options_from_pb(options),
+        )
+    }
+
+    pub fn unmount(&self, env: &mut JNIEnv, cv_path: JString) -> FsResult<()> {
+        let cv_path = JavaUtils::jstring_to_string(env, &cv_path)?;
+        self.inner.umount(cv_path)
+    }
+
+    pub fn get_mount_table(&self, env: &mut JNIEnv) -> FsResult<jarray> {
+        let response = GetMountTableResponse {
+            mount_table: self
+                .inner
+                .get_mount_table()?
+                .into_iter()
+                .map(ProtoUtils::mount_info_to_pb)
+                .collect(),
+        };
+        let bytes = ProtoUtils::encode(response)?;
+        Ok(JavaUtils::new_jarray(env, &bytes)?)
     }
 
     pub fn toggle_path(


### PR DESCRIPTION
# Summary

Adds an explicit Java UFS mount lifecycle client so applications can mount, inspect, and unmount through the SDK before submitting load jobs.

Mounting remains explicit: CurvineLoadClient does not create or update cluster-wide mount metadata.

# Issue Describe / Design

Related to #1332.

The Java SDK previously exposed load job lifecycle APIs but not the UFS mount lifecycle required by load. This change adds CurvineMountClient and MountRequest, reuses the existing MountOptionsProto and MountInfoProto protocol types, and bridges the existing master RPCs through libsdk JNI.

An implicit load-to-mount path was rejected because a load request must not silently mutate cluster-wide UFS metadata or credentials.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-libsdk/java` | Add CurvineMountClient, MountRequest, and contract tests | New explicit Java API only |
| `curvine-libsdk/src/core/filesystem.rs` | Expose mount, unmount, and mount-table wrappers | Reuses UnifiedFileSystem validation and cache refresh |
| `curvine-libsdk/src/java` | Add JNI bindings and protobuf bridge | No protocol or master behavior change |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo fmt --check` | PASS | |
| `cargo test -p curvine-libsdk` | PASS | 3 tests passed |
| `cargo clippy -p curvine-libsdk --all-targets -- --deny=warnings --allow clippy::uninlined_format_args` | PASS | |
| `mvn -B -ntp test -Dtest=MountRequestTest,CurvineMountClientTest,LoadJobClientTest` | PASS | 12 tests passed |
| `cargo build --release -p curvine-libsdk` | PASS | JNI symbols verified |
| `mvn -B -ntp package -DskipTests` | PASS | Java artifacts packaged |
| Full `mvn test` | BLOCKED | Existing JDK 21 CurvineNative reflection restriction plus local native library and localhost master prerequisites; failure occurs before mount APIs |

# Dependencies

- Related PRs: #1289
- Related issues: #1332
- Blocks / blocked by: Cluster E2E is pending an environment with the packaged native library and a reachable Curvine master.