### PR TITLE
docs(skills): add performance impact dimension to cv-submit-pr-review

### DIFF
--- a/.agents/skills/cv-submit-pr-review/SKILL.md
+++ b/.agents/skills/cv-submit-pr-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cv-submit-pr-review
-description: Perform a direct code review of a Curvine PR by reading the diff and changed files, analyzing correctness, safety, and design issues, and producing structured findings. Use when user asks to review a PR's code, do a code review, or check a PR before merge.
+description: Perform a direct code review of a Curvine PR by reading the diff and changed files, analyzing correctness, safety, design, and performance impact on critical paths (data read/write, RPC message communication, metadata operations), and producing structured findings. Use when user asks to review a PR's code, do a code review, or check a PR before merge.
 ---
 
 # Review PR Workflow
@@ -26,7 +26,7 @@ Focus **exclusively on code content**:
 |Correctness|Logic errors, edge cases, off-by-one, None/null handling, error propagation|
 |Safety|Concurrency races, panics / unwrap in hot paths, unsafe blocks, resource leaks, lock ordering|
 |Design|Naming, module boundaries, abstractions, consistency with existing patterns|
-|Comments|Header doc-comments on a method, function, or class that exceed **3 lines**; excessive inline comments that merely restate code instead of explaining intent. Flag any single-item header comment block longer than 3 lines as a `suggestion`-level finding and ask the author to trim it (move detail into the body or remove redundant lines).|
+|Performance|Potential performance impact on critical paths: **data read/write** (block I/O patterns, extra buffer copies, sync/fsync frequency, read amplification), **message communication** (RPC payload size, serialization/deserialization overhead, extra network round trips, connection churn), and **metadata operations** (inode lookup cost, lock granularity and hold time, journal/rocksdb write amplification). Trace hot-path call chains to judge whether the change adds work per request/block/message. Any change likely to cause a significant performance regression **must** generate a comment with concrete improvement suggestions (e.g., batching, caching, avoiding copies, narrowing locks, async-ifying blocking calls).|
 
 **Ignore:** commit message quality, PR description wording, pure formatting nits (run `make format` separately).
 
@@ -125,6 +125,8 @@ Inspect the actual code changes and look for:
 * correctness issues
 
 * regressions
+
+* performance regressions in critical paths — analyze whether the change adds overhead to data read/write, RPC message communication, or metadata operations; if the impact is significant, drafting a comment with improvement suggestions is mandatory
 
 * missing validation or edge-case handling
 
@@ -250,6 +252,8 @@ Post only the comments the user approved.
 - [ ]  Callers / definitions of changed symbols checked
 
 - [ ]  Module conventions verified (knowledge cards / existing patterns)
+
+- [ ]  Performance impact assessed for data read/write, RPC message communication, and metadata paths; significant regressions have mandatory comments with suggestions
 
 - [ ]  Findings table produced with severity per item
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ Usage notes:
 
 <skill>
 <name>cv-submit-pr-review</name>
-<description>Perform a direct code review of a Curvine PR by reading the diff and changed files, analyzing correctness, safety, and design issues, and producing structured findings. Use when user asks to review a PR's code, do a code review, or check a PR before merge.</description>
+<description>Perform a direct code review of a Curvine PR by reading the diff and changed files, analyzing correctness, safety, design, and performance impact on critical paths (data read/write, RPC message communication, metadata operations), and producing structured findings. Use when user asks to review a PR's code, do a code review, or check a PR before merge.</description>
 <location>project</location>
 </skill>
 


### PR DESCRIPTION
# Summary

Updates the `cv-submit-pr-review` agent skill: removes the 3-line limit on header doc-comments from the review scope, and adds performance impact analysis as a first-class review dimension covering data read/write, RPC message communication, and metadata paths, with mandatory review comments for significant regressions. Also syncs the skill description in the AGENTS.md registry.

# Issue Describe / Design

None — internal agent skill refinement.

Design decisions:
- The 3-line header doc-comment limit produced low-value nitpick findings, so the `Comments` dimension is removed from the review scope entirely.
- Performance is added as a review dimension alongside correctness, safety, and design because Curvine is a performance-sensitive distributed filesystem: PRs can regress block I/O throughput, RPC latency, or metadata operation cost without breaking correctness.
- Significant performance regressions **must** produce a review comment with concrete improvement suggestions (batching, caching, avoiding copies, narrowing locks, async-ifying blocking calls), making the requirement enforceable rather than advisory.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `.agents/skills/cv-submit-pr-review/SKILL.md` | Removed the `Comments` dimension (3-line header doc-comment limit) from Review Scope; added `Performance` dimension covering data read/write (block I/O patterns, buffer copies, sync frequency), message communication (RPC payload size, serialization overhead, extra round trips), and metadata operations (inode lookup cost, lock granularity, journal/rocksdb write amplification); added performance bullet to Step 3 review items; added checklist entry; updated frontmatter description | Review behavior change: no longer flags >3-line header comments; reviews must now assess performance impact on critical paths and comment on significant regressions |
| `AGENTS.md` | Synced the `cv-submit-pr-review` registry description with the new performance dimension | Skill catalog text only; no behavior change |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| Documentation-only change (Markdown skill definitions) | PASS | No Rust/Go code affected; `make format` not applicable |
| Verified `.cursor/skills`, `.claude/skills`, `.github/skills` are symlinks to `.agents/skills` | PASS | SKILL.md changes propagate automatically, no extra copies to update |
| Verified AGENTS.md registry description matches SKILL.md frontmatter description | PASS | Manual diff review of both files |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None