### PR TITLE
feat(transfer): add protocol and domain state

### DIFF
--- a/crates/common/curvine-error/src/fs_error.rs
+++ b/crates/common/curvine-error/src/fs_error.rs
@@ -69,6 +69,10 @@ pub enum ErrorKind {
     ReadOnly = 30,
     NoAvailableWorker = 31,
     NoLocalPath = 32,
+    TransferOverloaded = 33,
+    TransferStoreUnavailable = 34,
+    TransferAlreadyRunning = 35,
+    TransferTargetConflict = 36,
 
     #[num_enum(default)]
     Common = 10000,
@@ -206,6 +210,22 @@ pub enum FsError {
     #[error("{0}")]
     JobNotFound(ErrorImpl<StringError>),
 
+    // Transfer service or client-side transfer queue is overloaded.
+    #[error("{0}")]
+    TransferOverloaded(ErrorImpl<StringError>),
+
+    // Transfer state store is unavailable or failed a backend operation.
+    #[error("{0}")]
+    TransferStoreUnavailable(ErrorImpl<StringError>),
+
+    // A transfer with the same job key is already running with incompatible options.
+    #[error("{0}")]
+    TransferAlreadyRunning(ErrorImpl<StringError>),
+
+    // A non-terminal transfer already owns the same target path tree.
+    #[error("{0}")]
+    TransferTargetConflict(ErrorImpl<StringError>),
+
     // Other errors that are not defined.
     #[error("{0}")]
     Common(ErrorImpl<StringError>),
@@ -242,6 +262,10 @@ impl FsError {
         Self::InProgress(ErrorImpl::with_source(msg.into()))
     }
 
+    pub fn in_progress_msg(msg: impl Into<String>) -> Self {
+        Self::InProgress(ErrorImpl::with_source(msg.into().into()))
+    }
+
     pub fn file_not_found(path: impl AsRef<str>) -> Self {
         let msg = format!("File {} not found", path.as_ref());
         Self::FileNotFound(ErrorImpl::with_source(msg.into()))
@@ -270,6 +294,22 @@ impl FsError {
     pub fn job_not_found(job_id: impl AsRef<str>) -> Self {
         let msg = format!("Job {} not found", job_id.as_ref());
         Self::JobNotFound(ErrorImpl::with_source(msg.into()))
+    }
+
+    pub fn transfer_overloaded(msg: impl Into<String>) -> Self {
+        Self::TransferOverloaded(ErrorImpl::with_source(msg.into().into()))
+    }
+
+    pub fn transfer_store_unavailable(msg: impl Into<String>) -> Self {
+        Self::TransferStoreUnavailable(ErrorImpl::with_source(msg.into().into()))
+    }
+
+    pub fn transfer_already_running(msg: impl Into<String>) -> Self {
+        Self::TransferAlreadyRunning(ErrorImpl::with_source(msg.into().into()))
+    }
+
+    pub fn transfer_target_conflict(msg: impl Into<String>) -> Self {
+        Self::TransferTargetConflict(ErrorImpl::with_source(msg.into().into()))
     }
 
     pub fn file_exists(path: impl AsRef<str>) -> Self {
@@ -412,6 +452,10 @@ impl FsError {
             FsError::NoAvailableWorker(_) => ErrorKind::NoAvailableWorker,
             FsError::NoLocalPath(_) => ErrorKind::NoLocalPath,
             FsError::JobNotFound(_) => ErrorKind::JobNotFound,
+            FsError::TransferOverloaded(_) => ErrorKind::TransferOverloaded,
+            FsError::TransferStoreUnavailable(_) => ErrorKind::TransferStoreUnavailable,
+            FsError::TransferAlreadyRunning(_) => ErrorKind::TransferAlreadyRunning,
+            FsError::TransferTargetConflict(_) => ErrorKind::TransferTargetConflict,
             FsError::Common(_) => ErrorKind::Common,
         }
     }
@@ -556,6 +600,10 @@ impl ErrorExt for FsError {
             FsError::NoAvailableWorker(e) => FsError::NoAvailableWorker(e.ctx(ctx)),
             FsError::NoLocalPath(e) => FsError::NoLocalPath(e.ctx(ctx)),
             FsError::JobNotFound(e) => FsError::JobNotFound(e.ctx(ctx)),
+            FsError::TransferOverloaded(e) => FsError::TransferOverloaded(e.ctx(ctx)),
+            FsError::TransferStoreUnavailable(e) => FsError::TransferStoreUnavailable(e.ctx(ctx)),
+            FsError::TransferAlreadyRunning(e) => FsError::TransferAlreadyRunning(e.ctx(ctx)),
+            FsError::TransferTargetConflict(e) => FsError::TransferTargetConflict(e.ctx(ctx)),
             FsError::Common(e) => FsError::Common(e.ctx(ctx)),
         }
     }
@@ -594,6 +642,10 @@ impl ErrorExt for FsError {
             FsError::NoAvailableWorker(e) => e.encode(ErrorKind::NoAvailableWorker),
             FsError::NoLocalPath(e) => e.encode(ErrorKind::NoLocalPath),
             FsError::JobNotFound(e) => e.encode(ErrorKind::JobNotFound),
+            FsError::TransferOverloaded(e) => e.encode(ErrorKind::TransferOverloaded),
+            FsError::TransferStoreUnavailable(e) => e.encode(ErrorKind::TransferStoreUnavailable),
+            FsError::TransferAlreadyRunning(e) => e.encode(ErrorKind::TransferAlreadyRunning),
+            FsError::TransferTargetConflict(e) => e.encode(ErrorKind::TransferTargetConflict),
             FsError::Common(e) => e.encode(ErrorKind::Common),
         }
     }
@@ -635,6 +687,12 @@ impl ErrorExt for FsError {
             ErrorKind::NoAvailableWorker => FsError::NoAvailableWorker(de.into_string()),
             ErrorKind::NoLocalPath => FsError::NoLocalPath(de.into_string()),
             ErrorKind::JobNotFound => FsError::JobNotFound(de.into_string()),
+            ErrorKind::TransferOverloaded => FsError::TransferOverloaded(de.into_string()),
+            ErrorKind::TransferStoreUnavailable => {
+                FsError::TransferStoreUnavailable(de.into_string())
+            }
+            ErrorKind::TransferAlreadyRunning => FsError::TransferAlreadyRunning(de.into_string()),
+            ErrorKind::TransferTargetConflict => FsError::TransferTargetConflict(de.into_string()),
             ErrorKind::Common => FsError::Common(de.into_string()),
         }
     }
@@ -730,5 +788,49 @@ mod tests {
         let decoded = FsError::decode(bytes);
         assert!(matches!(decoded.kind(), ErrorKind::NoAvailableWorker));
         assert!(matches!(decoded, FsError::NoAvailableWorker(_)));
+    }
+
+    #[test]
+    pub fn transfer_overloaded_round_trip_test() {
+        let error = FsError::transfer_overloaded("transfer task report queue is full");
+
+        assert!(matches!(error.kind(), ErrorKind::TransferOverloaded));
+        let bytes = error.encode();
+        let decoded = FsError::decode(bytes);
+        assert!(matches!(decoded, FsError::TransferOverloaded(_)));
+        assert!(decoded.to_string().contains("queue is full"));
+    }
+
+    #[test]
+    pub fn transfer_store_unavailable_round_trip_test() {
+        let error = FsError::transfer_store_unavailable("mysql transfer store error");
+
+        assert!(matches!(error.kind(), ErrorKind::TransferStoreUnavailable));
+        let bytes = error.encode();
+        let decoded = FsError::decode(bytes);
+        assert!(matches!(decoded, FsError::TransferStoreUnavailable(_)));
+        assert!(decoded.to_string().contains("mysql transfer store error"));
+    }
+
+    #[test]
+    pub fn transfer_already_running_round_trip_test() {
+        let error = FsError::transfer_already_running("same job key has different command");
+
+        assert!(matches!(error.kind(), ErrorKind::TransferAlreadyRunning));
+        let bytes = error.encode();
+        let decoded = FsError::decode(bytes);
+        assert!(matches!(decoded, FsError::TransferAlreadyRunning(_)));
+        assert!(decoded.to_string().contains("different command"));
+    }
+
+    #[test]
+    pub fn transfer_target_conflict_round_trip_test() {
+        let error = FsError::transfer_target_conflict("target /a conflicts with active transfer");
+
+        assert!(matches!(error.kind(), ErrorKind::TransferTargetConflict));
+        let bytes = error.encode();
+        let decoded = FsError::decode(bytes);
+        assert!(matches!(decoded, FsError::TransferTargetConflict(_)));
+        assert!(decoded.to_string().contains("/a"));
     }
 }

--- a/crates/common/curvine-fs-api/src/rpc_code.rs
+++ b/crates/common/curvine-fs-api/src/rpc_code.rs
@@ -49,6 +49,8 @@ pub enum RpcCode {
     CompleteFilesBatch = 25,
     Free = 26,
     ListOptions = 27,
+    GetCvMetadataSnapshotPage = 28,
+    GetCvMetadataDeltaPage = 29,
 
     // manager interface.
     Mount = 30,
@@ -62,6 +64,15 @@ pub enum RpcCode {
     CancelJob = 37,
     ReportTask = 38,
     SubmitTask = 39,
+    SubmitTransfer = 46,
+    GetTransferStatus = 47,
+    CancelTransfer = 48,
+    ReportTransferTask = 49,
+    QueryTransferTask = 50,
+    WatchTransfer = 51,
+    ListTransfers = 52,
+    ListTransferTenants = 53,
+    RetryTransfer = 54,
     WorkerHeartbeat = 40,
     WorkerBlockReport = 41,
 

--- a/crates/common/curvine-model/src/job.rs
+++ b/crates/common/curvine-model/src/job.rs
@@ -235,6 +235,19 @@ pub struct LoadTaskInfo {
     pub source_path: String,
     pub target_path: String,
     pub create_time: i64,
+    #[serde(default)]
+    pub source_read_plan_json: String,
+    #[serde(default)]
+    pub transfer_report: Option<TransferTaskReportInfo>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransferTaskReportInfo {
+    pub run_id: u64,
+    pub attempt_id: u64,
+    pub worker_id: u32,
+    pub worker_session_id: String,
+    pub report_target: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/common/curvine-model/src/lib.rs
+++ b/crates/common/curvine-model/src/lib.rs
@@ -92,6 +92,9 @@ pub use self::opts::*;
 mod job;
 pub use self::job::*;
 
+mod transfer;
+pub use self::transfer::*;
+
 mod metrics;
 pub use self::metrics::*;
 

--- a/crates/common/curvine-model/src/proto_utils.rs
+++ b/crates/common/curvine-model/src/proto_utils.rs
@@ -14,6 +14,7 @@
 
 use crate::proto::*;
 use crate::state::*;
+use crate::worker_info::TransferWorkerCapabilities;
 use orpc::{try_err, CommonResult};
 use prost::bytes::BytesMut;
 use prost::Message;
@@ -346,6 +347,12 @@ impl ProtoUtils {
             last_update: src.last_update,
             reserved_bytes: src.reserved_bytes,
             weight: Some(src.weight),
+            worker_session_id: Some(src.worker_session_id),
+            transfer_task_submit: Some(src.transfer_capabilities.task_submit),
+            transfer_report_target: Some(src.transfer_capabilities.report_target),
+            transfer_query_task: Some(src.transfer_capabilities.query_task),
+            transfer_attempt_safe_output: Some(src.transfer_capabilities.attempt_safe_output),
+            transfer_source_read_plan: Some(src.transfer_capabilities.source_read_plan),
             storage_map: Default::default(),
         };
 
@@ -387,6 +394,14 @@ impl ProtoUtils {
                 non_fs_used: info.non_fs_used,
                 reserved_bytes: info.reserved_bytes,
                 weight: info.weight.unwrap_or_else(WorkerInfo::default_weight),
+                worker_session_id: info.worker_session_id.unwrap_or_default(),
+                transfer_capabilities: TransferWorkerCapabilities {
+                    task_submit: info.transfer_task_submit.unwrap_or(false),
+                    report_target: info.transfer_report_target.unwrap_or(false),
+                    query_task: info.transfer_query_task.unwrap_or(false),
+                    attempt_safe_output: info.transfer_attempt_safe_output.unwrap_or(false),
+                    source_read_plan: info.transfer_source_read_plan.unwrap_or(false),
+                },
                 ..Default::default()
             };
             for (k, v) in info.storage_map {

--- a/crates/common/curvine-model/src/transfer.rs
+++ b/crates/common/curvine-model/src/transfer.rs
@@ -1,0 +1,394 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use num_enum::{FromPrimitive, IntoPrimitive};
+use orpc::common::Utils;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+pub const TRANSFER_TEMP_PATH_MARKER: &str = ".curvine-transfer-tmp-";
+
+pub fn is_transfer_temp_path(path: &str) -> bool {
+    path.contains(TRANSFER_TEMP_PATH_MARKER)
+}
+
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Hash,
+    IntoPrimitive,
+    FromPrimitive,
+    Serialize,
+    Deserialize,
+)]
+#[repr(i32)]
+pub enum TransferKind {
+    #[default]
+    Load = 1,
+    Export = 2,
+}
+
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Hash,
+    IntoPrimitive,
+    FromPrimitive,
+    Serialize,
+    Deserialize,
+)]
+#[repr(i32)]
+pub enum TransferState {
+    #[default]
+    Pending = 1,
+    Planning = 2,
+    Dispatching = 3,
+    Running = 4,
+    Canceling = 5,
+    Completed = 6,
+    Failed = 7,
+    Canceled = 8,
+}
+
+impl TransferState {
+    pub fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            TransferState::Completed | TransferState::Failed | TransferState::Canceled
+        )
+    }
+
+    pub fn is_runnable(self) -> bool {
+        matches!(
+            self,
+            TransferState::Pending
+                | TransferState::Planning
+                | TransferState::Dispatching
+                | TransferState::Running
+                | TransferState::Canceling
+        )
+    }
+
+    pub fn is_executing(self) -> bool {
+        matches!(
+            self,
+            TransferState::Planning
+                | TransferState::Dispatching
+                | TransferState::Running
+                | TransferState::Canceling
+        )
+    }
+}
+
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Hash,
+    IntoPrimitive,
+    FromPrimitive,
+    Serialize,
+    Deserialize,
+)]
+#[repr(i32)]
+pub enum TransferTaskState {
+    #[default]
+    Pending = 1,
+    Running = 2,
+    Completed = 3,
+    Failed = 4,
+    Canceled = 5,
+    Stale = 6,
+}
+
+impl TransferTaskState {
+    pub fn is_running(self) -> bool {
+        matches!(
+            self,
+            TransferTaskState::Pending | TransferTaskState::Running
+        )
+    }
+
+    pub fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            TransferTaskState::Completed
+                | TransferTaskState::Failed
+                | TransferTaskState::Canceled
+                | TransferTaskState::Stale
+        )
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TransferCommand {
+    pub kind: TransferKind,
+    pub source_path: String,
+    pub target_path: String,
+    pub client_request_id: String,
+    pub submitter: String,
+    pub tenant: String,
+    pub options: BTreeMap<String, String>,
+}
+
+impl TransferCommand {
+    pub const OVERWRITE_OPTION: &'static str = "overwrite";
+
+    pub fn job_key(&self) -> String {
+        format!("{:?}:{}:{}", self.kind, self.source_path, self.target_path)
+    }
+
+    pub fn default_client_request_id(
+        kind: TransferKind,
+        source_path: impl AsRef<str>,
+        target_path: impl AsRef<str>,
+    ) -> String {
+        format!(
+            "job_{}",
+            Utils::md5(format!(
+                "{:?}:{}:{}",
+                kind,
+                source_path.as_ref(),
+                target_path.as_ref()
+            ))
+        )
+    }
+
+    pub fn overwrite(&self) -> bool {
+        self.options
+            .get(Self::OVERWRITE_OPTION)
+            .and_then(|value| value.parse::<bool>().ok())
+            .unwrap_or(true)
+    }
+
+    pub fn set_overwrite(&mut self, overwrite: bool) {
+        self.options
+            .insert(Self::OVERWRITE_OPTION.to_string(), overwrite.to_string());
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TransferProgress {
+    pub loaded_size: i64,
+    pub total_size: i64,
+    pub update_time: i64,
+    pub message: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TransferJobRecord {
+    pub job_key: String,
+    pub job_id: String,
+    pub run_id: u64,
+    pub kind: TransferKind,
+    pub source_path: String,
+    pub target_path: String,
+    pub command_json: String,
+    pub mount_snapshot_json: String,
+    pub secret_ref_json: String,
+    pub cluster_snapshot_version: u64,
+    pub cv_metadata_epoch: Option<u64>,
+    pub state: TransferState,
+    pub owner: String,
+    pub lease_epoch: u64,
+    pub lease_expire_at: i64,
+    pub cancel_requested: bool,
+    pub summary: TransferProgress,
+    pub client_request_id: String,
+    pub submitter: String,
+    pub tenant: String,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TransferTaskRecord {
+    pub job_id: String,
+    pub run_id: u64,
+    pub task_id: String,
+    pub attempt_id: u64,
+    pub source_path: String,
+    pub target_path: String,
+    pub worker_id: u32,
+    pub worker_session_id: String,
+    pub source_read_plan_json: String,
+    pub report_target_json: String,
+    pub state: TransferTaskState,
+    pub progress: TransferProgress,
+    pub retry_count: u32,
+    pub attempt_started_at: i64,
+    pub last_report_at: i64,
+    pub stale_deadline_at: i64,
+    pub updated_at: i64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TransferTaskSummary {
+    pub progress: TransferProgress,
+    pub has_task: bool,
+    pub has_failed: bool,
+    pub all_completed: bool,
+}
+
+pub fn summarize_transfer_tasks<'a>(
+    tasks: impl IntoIterator<Item = &'a TransferTaskRecord>,
+    update_time: i64,
+) -> TransferTaskSummary {
+    let mut summary = TransferTaskSummary {
+        progress: TransferProgress {
+            update_time,
+            ..Default::default()
+        },
+        has_task: false,
+        has_failed: false,
+        all_completed: true,
+    };
+    let mut failed_count = 0;
+    let mut first_error = String::new();
+    let mut last_message = String::new();
+
+    for task in tasks {
+        summary.has_task = true;
+        summary.has_failed |= task.state == TransferTaskState::Failed;
+        summary.all_completed &= task.state == TransferTaskState::Completed;
+        summary.progress.loaded_size += task.progress.loaded_size;
+        summary.progress.total_size += task.progress.total_size;
+
+        if !task.progress.message.is_empty() {
+            last_message = task.progress.message.clone();
+        }
+        if task.state == TransferTaskState::Failed {
+            failed_count += 1;
+            if first_error.is_empty() && !task.progress.message.is_empty() {
+                first_error = task.progress.message.clone();
+            }
+        }
+    }
+
+    if failed_count > 0 {
+        if first_error.is_empty() {
+            first_error = "transfer task failed".to_string();
+        }
+        summary.progress.message = format!(
+            "{} transfer task(s) failed: {}",
+            failed_count,
+            normalize_summary_message(&first_error)
+        );
+    } else {
+        summary.progress.message = last_message;
+    }
+    summary
+}
+
+fn normalize_summary_message(message: &str) -> String {
+    message
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .chars()
+        .take(512)
+        .collect()
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TransferLease {
+    pub job_id: String,
+    pub run_id: u64,
+    pub owner: String,
+    pub lease_epoch: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TransferStateUpdate {
+    pub job_id: String,
+    pub run_id: u64,
+    pub owner: String,
+    pub lease_epoch: u64,
+    pub from_states: Vec<TransferState>,
+    pub to_state: TransferState,
+    pub message: String,
+    pub now_ms: i64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TaskAttemptStart {
+    pub job_id: String,
+    pub run_id: u64,
+    pub owner: String,
+    pub lease_epoch: u64,
+    pub task_id: String,
+    pub attempt_id: u64,
+    pub worker_id: u32,
+    pub worker_session_id: String,
+    pub report_target_json: String,
+    pub now_ms: i64,
+    pub stale_deadline_at: i64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TransferTaskReport {
+    pub job_id: String,
+    pub run_id: u64,
+    pub task_id: String,
+    pub attempt_id: u64,
+    pub worker_id: u32,
+    pub worker_session_id: String,
+    pub state: TransferTaskState,
+    pub progress: TransferProgress,
+    pub now_ms: i64,
+    pub stale_deadline_at: i64,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct TransferListFilter {
+    pub kind: Option<TransferKind>,
+    pub state: Option<TransferState>,
+    pub submitter: Option<String>,
+    pub tenant: Option<String>,
+    pub limit: usize,
+    pub offset: usize,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct TransferTenantSummary {
+    pub tenant: String,
+    pub pending: u64,
+    pub executing: u64,
+    pub completed: u64,
+    pub failed: u64,
+    pub canceled: u64,
+    pub total: u64,
+}
+
+impl TransferTenantSummary {
+    pub fn active(&self) -> u64 {
+        self.pending.saturating_add(self.executing)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StaleTaskAttempt {
+    pub task: TransferTaskRecord,
+}

--- a/crates/common/curvine-model/src/worker_address.rs
+++ b/crates/common/curvine-model/src/worker_address.rs
@@ -31,6 +31,12 @@ impl WorkerAddress {
         self.hostname == hostname
     }
 
+    pub fn same_endpoint(&self, other: &Self) -> bool {
+        self.hostname == other.hostname
+            && self.ip_addr == other.ip_addr
+            && self.rpc_port == other.rpc_port
+    }
+
     pub fn connect_addr(&self) -> String {
         format!("{}:{}", self.ip_addr, self.rpc_port)
     }

--- a/crates/common/curvine-model/src/worker_info.rs
+++ b/crates/common/curvine-model/src/worker_info.rs
@@ -18,6 +18,36 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct TransferWorkerCapabilities {
+    pub task_submit: bool,
+    pub report_target: bool,
+    pub query_task: bool,
+    pub attempt_safe_output: bool,
+    pub source_read_plan: bool,
+}
+
+impl TransferWorkerCapabilities {
+    pub fn current() -> Self {
+        Self {
+            task_submit: true,
+            report_target: true,
+            query_task: true,
+            attempt_safe_output: true,
+            source_read_plan: true,
+        }
+    }
+
+    pub fn supports_transfer(&self) -> bool {
+        self.task_submit
+            && self.report_target
+            && self.query_task
+            && self.attempt_safe_output
+            && self.source_read_plan
+    }
+}
+
 // Describes a worker, which is the basic unit of master management worker.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
@@ -34,6 +64,8 @@ pub struct WorkerInfo {
     pub block_num: i64,
     pub storage_map: HashMap<String, StorageInfo>,
     pub status: WorkerStatus,
+    pub worker_session_id: String,
+    pub transfer_capabilities: TransferWorkerCapabilities,
 }
 
 impl WorkerInfo {
@@ -54,6 +86,8 @@ impl WorkerInfo {
             last_update: LocalTime::mills(),
             storage_map: Default::default(),
             status: WorkerStatus::Live,
+            worker_session_id: String::new(),
+            transfer_capabilities: TransferWorkerCapabilities::default(),
         }
     }
 
@@ -126,6 +160,8 @@ impl Default for WorkerInfo {
             block_num: 0,
             storage_map: Default::default(),
             status: WorkerStatus::Live,
+            worker_session_id: String::new(),
+            transfer_capabilities: TransferWorkerCapabilities::default(),
         }
     }
 }

--- a/crates/common/curvine-proto/build.rs
+++ b/crates/common/curvine-proto/build.rs
@@ -24,6 +24,7 @@ fn main() {
         "master.proto",
         "worker.proto",
         "job.proto",
+        "transfer.proto",
         "mount.proto",
         "replication.proto",
     ];

--- a/curvine-common/proto/common.proto
+++ b/curvine-common/proto/common.proto
@@ -170,6 +170,12 @@ message WorkerInfoProto {
     map<string, StorageInfoProto> storage_map = 7;
     required int64 reserved_bytes = 8 [default = 0];
     optional uint32 weight = 9 [default = 1];
+    optional string worker_session_id = 10 [default = ""];
+    optional bool transfer_task_submit = 11 [default = false];
+    optional bool transfer_report_target = 12 [default = false];
+    optional bool transfer_query_task = 13 [default = false];
+    optional bool transfer_attempt_safe_output = 14 [default = false];
+    optional bool transfer_source_read_plan = 15 [default = false];
 }
 
 message FileAllocOptsProto {

--- a/curvine-common/proto/job.proto
+++ b/curvine-common/proto/job.proto
@@ -74,6 +74,8 @@ message SubmitTaskRequest {
 
 message SubmitTaskResponse {
   required string task_id = 1;
+  optional bool accepted = 2 [default = true];
+  optional string reject_reason = 3 [default = ""];
 }
 
 message TaskReportRequest {

--- a/curvine-common/proto/master.proto
+++ b/curvine-common/proto/master.proto
@@ -344,3 +344,38 @@ message ListOptionsRequest {
 message ListOptionsResponse {
     repeated FileStatusProto statuses = 1;
 }
+message CvMetadataSnapshotEntryProto {
+    required FileStatusProto status = 1;
+    optional FileBlocksProto blocks = 2;
+}
+
+message GetCvMetadataSnapshotPageRequest {
+    optional string page_token = 1;
+    optional uint32 page_size = 2 [default = 10000];
+}
+
+message GetCvMetadataSnapshotPageResponse {
+    repeated CvMetadataSnapshotEntryProto entries = 1;
+    optional string next_page_token = 2;
+    required uint64 epoch = 3;
+}
+
+message CvMetadataDeltaEntryProto {
+    required string path = 1;
+    optional CvMetadataSnapshotEntryProto entry = 2;
+}
+
+message GetCvMetadataDeltaPageRequest {
+    required uint64 from_epoch = 1;
+    optional uint64 target_epoch = 2;
+    optional string page_token = 3;
+    optional uint32 page_size = 4 [default = 10000];
+}
+
+message GetCvMetadataDeltaPageResponse {
+    repeated CvMetadataDeltaEntryProto entries = 1;
+    optional string next_page_token = 2;
+    required uint64 from_epoch = 3;
+    required uint64 to_epoch = 4;
+    required bool full_snapshot_required = 5;
+}

--- a/curvine-common/proto/transfer.proto
+++ b/curvine-common/proto/transfer.proto
@@ -1,0 +1,215 @@
+syntax = "proto2";
+package proto;
+
+option java_package = "io.curvine.proto";
+option java_multiple_files = true;
+option java_outer_classname = "TransferProto";
+
+enum TransferKindProto {
+  TRANSFER_LOAD = 1;
+  TRANSFER_EXPORT = 2;
+}
+
+enum TransferStateProto {
+  TRANSFER_PENDING = 1;
+  TRANSFER_PLANNING = 2;
+  TRANSFER_DISPATCHING = 3;
+  TRANSFER_RUNNING = 4;
+  TRANSFER_CANCELING = 5;
+  TRANSFER_COMPLETED = 6;
+  TRANSFER_FAILED = 7;
+  TRANSFER_CANCELED = 8;
+}
+
+enum TransferTaskStateProto {
+  TRANSFER_TASK_PENDING = 1;
+  TRANSFER_TASK_RUNNING = 2;
+  TRANSFER_TASK_COMPLETED = 3;
+  TRANSFER_TASK_FAILED = 4;
+  TRANSFER_TASK_CANCELED = 5;
+  TRANSFER_TASK_STALE = 6;
+}
+
+message TransferProgressProto {
+  required int64 loaded_size = 1;
+  required int64 total_size = 2;
+  required int64 update_time = 3;
+  required string message = 4;
+}
+
+message TransferTaskStatusProto {
+  required string task_id = 1;
+  required uint64 attempt_id = 2;
+  required string source_path = 3;
+  required string target_path = 4;
+  required uint32 worker_id = 5;
+  required string worker_session_id = 6;
+  required TransferTaskStateProto state = 7;
+  required TransferProgressProto progress = 8;
+  required uint32 retry_count = 9;
+  required int64 updated_at = 10;
+}
+
+message TransferJobStatusProto {
+  required string job_id = 1;
+  required uint64 run_id = 2;
+  required TransferKindProto kind = 3;
+  required TransferStateProto state = 4;
+  required string source_path = 5;
+  required string target_path = 6;
+  required TransferProgressProto progress = 7;
+  required string submitter = 8;
+  required string tenant = 9;
+  required int64 created_at = 10;
+  required int64 updated_at = 11;
+  optional string owner = 12;
+  optional uint64 lease_epoch = 13;
+  optional int64 lease_expire_at = 14;
+  optional uint64 cv_metadata_epoch = 15;
+}
+
+message SubmitTransferRequest {
+  required TransferKindProto kind = 1;
+  required string source_path = 2;
+  required string target_path = 3;
+  required string client_request_id = 4;
+  required string submitter = 5;
+  required string tenant = 6;
+  required bytes command = 7;
+  optional uint32 protocol_version = 8 [default = 1];
+}
+
+message SubmitTransferResponse {
+  required string job_id = 1;
+  required uint64 run_id = 2;
+  required TransferStateProto state = 3;
+}
+
+message GetTransferStatusRequest {
+  required string job_id = 1;
+  optional uint32 page_size = 2;
+  optional string page_token = 3;
+}
+
+message GetTransferStatusResponse {
+  required string job_id = 1;
+  required uint64 run_id = 2;
+  required TransferStateProto state = 3;
+  required TransferProgressProto progress = 4;
+  repeated TransferTaskStatusProto tasks = 5;
+  optional string next_page_token = 6;
+  optional TransferKindProto kind = 7;
+  optional string source_path = 8;
+  optional string target_path = 9;
+  optional string submitter = 10;
+  optional string tenant = 11;
+  optional int64 created_at = 12;
+  optional int64 updated_at = 13;
+  optional string owner = 14;
+  optional uint64 lease_epoch = 15;
+  optional int64 lease_expire_at = 16;
+  optional uint64 cv_metadata_epoch = 17;
+}
+
+message ListTransfersRequest {
+  optional TransferKindProto kind = 1;
+  optional TransferStateProto state = 2;
+  optional uint32 page_size = 3;
+  optional string page_token = 4;
+  optional string submitter = 5;
+  optional string tenant = 6;
+}
+
+message ListTransfersResponse {
+  repeated TransferJobStatusProto jobs = 1;
+  optional string next_page_token = 2;
+}
+
+message TransferTenantSummaryProto {
+  required string tenant = 1;
+  required uint64 pending = 2;
+  required uint64 executing = 3;
+  required uint64 completed = 4;
+  required uint64 failed = 5;
+  required uint64 canceled = 6;
+  required uint64 total = 7;
+}
+
+message ListTransferTenantsRequest {
+  optional uint32 page_size = 1;
+  optional string page_token = 2;
+}
+
+message ListTransferTenantsResponse {
+  repeated TransferTenantSummaryProto tenants = 1;
+  optional string next_page_token = 2;
+}
+
+message WatchTransferRequest {
+  required string job_id = 1;
+  optional uint64 since_updated_at = 2;
+  optional uint32 page_size = 3;
+  optional string page_token = 4;
+}
+
+message WatchTransferResponse {
+  required string job_id = 1;
+  required uint64 run_id = 2;
+  required TransferStateProto state = 3;
+  required TransferProgressProto progress = 4;
+  repeated TransferTaskStatusProto tasks = 5;
+  optional string next_page_token = 6;
+  required int64 updated_at = 7;
+  required bool changed = 8;
+  optional TransferKindProto kind = 9;
+  optional string source_path = 10;
+  optional string target_path = 11;
+  optional string owner = 12;
+  optional uint64 lease_epoch = 13;
+  optional int64 lease_expire_at = 14;
+  optional uint64 cv_metadata_epoch = 15;
+}
+
+message CancelTransferRequest {
+  required string job_id = 1;
+  optional uint64 run_id = 2;
+}
+
+message CancelTransferResponse {
+  required string job_id = 1;
+  required TransferStateProto state = 2;
+}
+
+message RetryTransferRequest {
+  required string job_id = 1;
+}
+
+message TransferTaskReportRequest {
+  required string job_id = 1;
+  required uint64 run_id = 2;
+  required string task_id = 3;
+  required uint64 attempt_id = 4;
+  required uint32 worker_id = 5;
+  required string worker_session_id = 6;
+  required TransferTaskStateProto state = 7;
+  required TransferProgressProto progress = 8;
+  optional uint32 protocol_version = 9 [default = 1];
+}
+
+message TransferTaskReportResponse {
+  required bool accepted = 1;
+}
+
+message QueryTransferTaskRequest {
+  required string job_id = 1;
+  required uint64 run_id = 2;
+  required string task_id = 3;
+  required uint64 attempt_id = 4;
+  required string worker_session_id = 5;
+}
+
+message QueryTransferTaskResponse {
+  required bool found = 1;
+  required TransferTaskStateProto state = 2;
+  required TransferProgressProto progress = 3;
+}

--- a/curvine-common/proto/worker.proto
+++ b/curvine-common/proto/worker.proto
@@ -80,6 +80,12 @@ message WorkerHeartbeatRequest {
     repeated StorageInfoProto storages = 8;
     repeated BlockReportInfoProto blocks = 9;
     optional uint32 weight = 10 [default = 1];
+    optional string worker_session_id = 11 [default = ""];
+    optional bool transfer_task_submit = 12 [default = false];
+    optional bool transfer_report_target = 13 [default = false];
+    optional bool transfer_query_task = 14 [default = false];
+    optional bool transfer_attempt_safe_output = 15 [default = false];
+    optional bool transfer_source_read_plan = 16 [default = false];
 }
 
 message WorkerHeartbeatResponse {

--- a/curvine-server/src/master/job/job_runner.rs
+++ b/curvine-server/src/master/job/job_runner.rs
@@ -692,6 +692,8 @@ impl LoadJobRunner {
                     source_path: source_path.clone_uri(),
                     target_path: target_path.clone_uri(),
                     create_time: LocalTime::mills() as i64,
+                    source_read_plan_json: String::new(),
+                    transfer_report: None,
                 };
                 tasks.insert(task_id.clone(), TaskDetail::new(task));
 

--- a/curvine-server/src/worker/handler/worker_handler.rs
+++ b/curvine-server/src/worker/handler/worker_handler.rs
@@ -126,7 +126,11 @@ impl WorkerHandler {
         let task_id = task.task_id.clone();
 
         self.task_manager.submit_task(task)?;
-        let response = SubmitTaskResponse { task_id };
+        let response = SubmitTaskResponse {
+            task_id,
+            accepted: Some(true),
+            reject_reason: None,
+        };
 
         Ok(Builder::success(msg).proto_header(response).build())
     }

--- a/curvine-server/src/worker/task/task_store.rs
+++ b/curvine-server/src/worker/task/task_store.rs
@@ -112,6 +112,8 @@ mod supersede_tests {
             source_path: "s".to_string(),
             target_path: "t".to_string(),
             create_time: 0,
+            source_read_plan_json: String::new(),
+            transfer_report: None,
         }
     }
 

--- a/curvine-server/tests/load_job_submit_test.rs
+++ b/curvine-server/tests/load_job_submit_test.rs
@@ -116,6 +116,8 @@ fn load_task(task_id: &str, job_id: &str) -> LoadTaskInfo {
         source_path: "file://source".to_string(),
         target_path: "/mnt/source".to_string(),
         create_time: 0,
+        source_read_plan_json: String::new(),
+        transfer_report: None,
     }
 }
 


### PR DESCRIPTION
# Summary

Adds Transfer RPC messages, domain state, RPC codes, and shared error vocabulary.

# Issue Describe / Design

Part of the standalone Transfer service. This review layer is stacked deliberately so that protocol, metadata storage, scheduling, worker execution, client routing, and deployment can be reviewed independently.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `crates/common,curvine-common/proto` | Adds Transfer RPC messages, domain state, RPC codes, and shared error vocabulary. | New Transfer behavior; legacy behavior remains available unless Transfer is enabled. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo check -p curvine-server -p curvine-cli` | PASS | Rebased onto upstream main `497d078d`. |

# Dependencies

- Related PRs: None
- Related issues: #1040
- Blocks / blocked by: None