### PR TITLE
feat(transfer): add service configuration

### DIFF
--- a/crates/common/curvine-config/src/lib.rs
+++ b/crates/common/curvine-config/src/lib.rs
@@ -29,6 +29,9 @@ pub use self::fuse_conf::FuseConf;
 mod job_conf;
 pub use self::job_conf::JobConf;
 
+mod transfer_conf;
+pub use self::transfer_conf::*;
+
 mod ufs_conf;
 pub use self::ufs_conf::{UfsConf, UfsConfBuilder};
 

--- a/crates/common/curvine-config/src/transfer_conf.rs
+++ b/crates/common/curvine-config/src/transfer_conf.rs
@@ -1,0 +1,523 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{FsError, FsResult};
+use orpc::common::DurationUnit;
+use orpc::server::ServerConf;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum TransferStoreType {
+    Auto,
+    Memory,
+    Sqlite,
+    Mysql,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum TransferCvMetadataReaderType {
+    Auto,
+    Disabled,
+    Master,
+    Replica,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct TransferConf {
+    pub enabled: bool,
+    // Deprecated compatibility inputs normalize into store_url during init.
+    #[serde(skip_serializing)]
+    pub store_type: TransferStoreType,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub store_url: String,
+    pub hostname: String,
+    pub rpc_port: u16,
+    pub web_port: u16,
+    #[serde(skip, default = "TransferConf::default_io_threads")]
+    pub io_threads: usize,
+    #[serde(skip, default = "TransferConf::default_worker_threads")]
+    pub worker_threads: usize,
+    pub instance_id: String,
+    pub endpoints: Vec<String>,
+    #[serde(skip_serializing)]
+    pub sqlite_path: String,
+    #[serde(skip_serializing)]
+    pub mysql_url: String,
+    pub cv_metadata_reader: TransferCvMetadataReaderType,
+    #[serde(skip, default = "TransferConf::default_metadata_replica_max_entries")]
+    pub metadata_replica_max_entries: usize,
+    #[serde(skip)]
+    pub allow_submit_with_stale_snapshot: bool,
+    pub max_running_transfers: usize,
+    #[serde(skip, default = "TransferConf::default_max_tasks_per_transfer")]
+    pub max_tasks_per_transfer: usize,
+    #[serde(
+        skip,
+        default = "TransferConf::default_ufs_max_concurrency_per_endpoint"
+    )]
+    pub ufs_max_concurrency_per_endpoint: usize,
+    #[serde(skip, default = "TransferConf::default_task_max_retries")]
+    pub task_max_retries: usize,
+
+    #[serde(skip)]
+    pub task_report_interval: Duration,
+    #[serde(skip, default = "TransferConf::default_task_report_interval_str")]
+    pub task_report_interval_str: String,
+
+    #[serde(skip)]
+    pub task_stale_timeout: Duration,
+    #[serde(skip, default = "TransferConf::default_task_stale_timeout_str")]
+    pub task_stale_timeout_str: String,
+
+    #[serde(skip)]
+    pub lease_timeout: Duration,
+    #[serde(alias = "lease_timeout")]
+    pub lease_timeout_str: String,
+
+    #[serde(skip)]
+    pub cluster_snapshot_max_staleness: Duration,
+    #[serde(
+        skip,
+        default = "TransferConf::default_cluster_snapshot_max_staleness_str"
+    )]
+    pub cluster_snapshot_max_staleness_str: String,
+
+    #[serde(skip)]
+    pub terminal_retention: Duration,
+    #[serde(alias = "terminal_retention")]
+    pub terminal_retention_str: String,
+
+    #[serde(skip)]
+    pub metadata_replica_refresh_interval: Duration,
+    #[serde(
+        skip,
+        default = "TransferConf::default_metadata_replica_refresh_interval_str"
+    )]
+    pub metadata_replica_refresh_interval_str: String,
+
+    #[serde(skip)]
+    pub metadata_replica_max_staleness: Duration,
+    #[serde(
+        skip,
+        default = "TransferConf::default_metadata_replica_max_staleness_str"
+    )]
+    pub metadata_replica_max_staleness_str: String,
+}
+
+impl TransferConf {
+    pub const DEFAULT_TASK_REPORT_INTERVAL: &'static str = "10s";
+    pub const DEFAULT_TASK_STALE_TIMEOUT: &'static str = "60s";
+    pub const DEFAULT_LEASE_TIMEOUT: &'static str = "120s";
+    pub const DEFAULT_CLUSTER_SNAPSHOT_MAX_STALENESS: &'static str = "60s";
+    pub const DEFAULT_TERMINAL_RETENTION: &'static str = "168h";
+    pub const DEFAULT_METADATA_REPLICA_REFRESH_INTERVAL: &'static str = "30s";
+    pub const DEFAULT_METADATA_REPLICA_MAX_STALENESS: &'static str = "120s";
+    pub const DEFAULT_METADATA_REPLICA_MAX_ENTRIES: usize = 1_000_000;
+    pub const DEFAULT_METADATA_REPLICA_PAGE_SIZE: usize = 1000;
+    pub const DEFAULT_METADATA_REPLICA_HISTORY_SIZE: usize = 2;
+    pub const DEFAULT_MAX_PLANNING_TRANSFERS: usize = 8;
+    pub const DEFAULT_PLANNING_BATCH_SIZE: usize = 1000;
+    pub const DEFAULT_WORKER_DISPATCH_CONCURRENCY: usize = 256;
+    pub const DEFAULT_TASK_REPORT_QUEUE_SIZE: usize = 10_000;
+    pub const DEFAULT_TASK_PROBE_CONCURRENCY: usize = 64;
+    pub const DEFAULT_CLIENT_PENDING_QUEUE_SIZE: usize = 1024;
+    pub const DEFAULT_CLEANUP_BATCH_SIZE: usize = 1000;
+    pub const DEFAULT_RPC_PORT: u16 = 9010;
+    pub const DEFAULT_WEB_PORT: u16 = 9011;
+    pub const DEFAULT_IO_THREADS: usize = 4;
+    pub const DEFAULT_WORKER_THREADS: usize = 8;
+    pub const DEFAULT_MAX_TASKS_PER_TRANSFER: usize = 100_000;
+    pub const DEFAULT_UFS_MAX_CONCURRENCY_PER_ENDPOINT: usize = 32;
+    pub const DEFAULT_TASK_MAX_RETRIES: usize = 3;
+
+    pub fn init(&mut self) -> FsResult<()> {
+        self.infer_store_url();
+        if self.endpoints.is_empty() {
+            self.endpoints
+                .push(format!("{}:{}", self.hostname, self.rpc_port));
+        }
+        self.lease_timeout = DurationUnit::from_str(&self.lease_timeout_str)?.as_duration();
+        self.task_stale_timeout = Self::derive_task_stale_timeout(self.lease_timeout);
+        self.task_report_interval = Self::derive_task_report_interval(self.task_stale_timeout);
+        self.cluster_snapshot_max_staleness =
+            DurationUnit::from_str(&self.cluster_snapshot_max_staleness_str)?.as_duration();
+        self.terminal_retention =
+            DurationUnit::from_str(&self.terminal_retention_str)?.as_duration();
+        self.metadata_replica_refresh_interval =
+            DurationUnit::from_str(&self.metadata_replica_refresh_interval_str)?.as_duration();
+        self.metadata_replica_max_staleness =
+            DurationUnit::from_str(&self.metadata_replica_max_staleness_str)?.as_duration();
+        if !self.store_url.is_empty() && self.effective_store_type() == TransferStoreType::Auto {
+            return Err(FsError::common(
+                "transfer.store_url must use memory://, sqlite://, or mysql://",
+            ));
+        }
+        match self.effective_store_type() {
+            TransferStoreType::Sqlite if self.sqlite_store_path().is_empty() => {
+                return Err(FsError::common(
+                    "transfer.store_url=sqlite:// requires a database path",
+                ));
+            }
+            TransferStoreType::Mysql if self.mysql_store_url().is_empty() => {
+                return Err(FsError::common(
+                    "transfer.store_url=mysql:// requires a database URL",
+                ));
+            }
+            _ => {}
+        }
+        if self.enabled && self.effective_store_type() == TransferStoreType::Mysql {
+            self.validate_mysql_store()?;
+        }
+        if self.max_running_transfers == 0 {
+            return Err(FsError::common(
+                "transfer.max_running_transfers must be greater than 0",
+            ));
+        }
+        if self.ufs_max_concurrency_per_endpoint == 0 {
+            return Err(FsError::common(
+                "transfer.ufs_max_concurrency_per_endpoint must be greater than 0",
+            ));
+        }
+        if self.metadata_replica_max_entries == 0 {
+            return Err(FsError::common(
+                "transfer.metadata_replica_max_entries must be greater than 0",
+            ));
+        }
+        if self.cluster_snapshot_max_staleness.is_zero() {
+            return Err(FsError::common(
+                "transfer.cluster_snapshot_max_staleness must be greater than 0",
+            ));
+        }
+        if self.metadata_replica_refresh_interval.is_zero() {
+            return Err(FsError::common(
+                "transfer.metadata_replica_refresh_interval must be greater than 0",
+            ));
+        }
+        if self.metadata_replica_max_staleness.is_zero() {
+            return Err(FsError::common(
+                "transfer.metadata_replica_max_staleness must be greater than 0",
+            ));
+        }
+        if self.lease_timeout.is_zero() {
+            return Err(FsError::common(
+                "transfer.lease_timeout must be greater than 0",
+            ));
+        }
+        if self.max_tasks_per_transfer == 0 {
+            return Err(FsError::common(
+                "transfer.max_tasks_per_transfer must be greater than 0",
+            ));
+        }
+        Ok(())
+    }
+
+    fn infer_store_url(&mut self) {
+        if !self.store_url.is_empty() {
+            return;
+        }
+
+        self.store_url = match self.effective_store_type() {
+            TransferStoreType::Memory => "memory://".to_string(),
+            TransferStoreType::Sqlite => format!("sqlite://{}", self.sqlite_path),
+            TransferStoreType::Mysql => self.mysql_url.clone(),
+            TransferStoreType::Auto => String::new(),
+        };
+    }
+
+    pub fn effective_store_type(&self) -> TransferStoreType {
+        if !self.store_url.is_empty() {
+            return if self.store_url == "memory://" {
+                TransferStoreType::Memory
+            } else if self.store_url.starts_with("sqlite://") {
+                TransferStoreType::Sqlite
+            } else if self.store_url.starts_with("mysql://") {
+                TransferStoreType::Mysql
+            } else {
+                TransferStoreType::Auto
+            };
+        }
+        match self.store_type {
+            TransferStoreType::Auto if self.mysql_url.is_empty() => TransferStoreType::Sqlite,
+            TransferStoreType::Auto => TransferStoreType::Mysql,
+            store_type => store_type,
+        }
+    }
+
+    pub fn effective_cv_metadata_reader(&self) -> TransferCvMetadataReaderType {
+        match self.cv_metadata_reader {
+            TransferCvMetadataReaderType::Auto => TransferCvMetadataReaderType::Replica,
+            reader => reader,
+        }
+    }
+
+    pub fn sqlite_store_path(&self) -> &str {
+        self.store_url
+            .strip_prefix("sqlite://")
+            .unwrap_or(&self.sqlite_path)
+    }
+
+    pub fn mysql_store_url(&self) -> &str {
+        if self.store_url.starts_with("mysql://") {
+            &self.store_url
+        } else {
+            &self.mysql_url
+        }
+    }
+
+    fn validate_mysql_store(&self) -> FsResult<()> {
+        if self.effective_cv_metadata_reader() != TransferCvMetadataReaderType::Replica {
+            return Err(FsError::common(
+                "production transfer requires transfer.cv_metadata_reader=replica",
+            ));
+        }
+        if self.allow_submit_with_stale_snapshot {
+            return Err(FsError::common(
+                "production transfer forbids transfer.allow_submit_with_stale_snapshot=true",
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn max_executing_transfers(&self) -> u64 {
+        self.max_running_transfers as u64
+    }
+
+    fn default_io_threads() -> usize {
+        Self::DEFAULT_IO_THREADS
+    }
+
+    fn default_worker_threads() -> usize {
+        Self::DEFAULT_WORKER_THREADS
+    }
+
+    fn default_max_tasks_per_transfer() -> usize {
+        Self::DEFAULT_MAX_TASKS_PER_TRANSFER
+    }
+
+    fn default_ufs_max_concurrency_per_endpoint() -> usize {
+        Self::DEFAULT_UFS_MAX_CONCURRENCY_PER_ENDPOINT
+    }
+
+    fn default_task_max_retries() -> usize {
+        Self::DEFAULT_TASK_MAX_RETRIES
+    }
+
+    fn default_task_report_interval_str() -> String {
+        Self::DEFAULT_TASK_REPORT_INTERVAL.to_string()
+    }
+
+    fn default_task_stale_timeout_str() -> String {
+        Self::DEFAULT_TASK_STALE_TIMEOUT.to_string()
+    }
+
+    fn default_metadata_replica_max_entries() -> usize {
+        Self::DEFAULT_METADATA_REPLICA_MAX_ENTRIES
+    }
+
+    fn default_cluster_snapshot_max_staleness_str() -> String {
+        Self::DEFAULT_CLUSTER_SNAPSHOT_MAX_STALENESS.to_string()
+    }
+
+    fn default_metadata_replica_refresh_interval_str() -> String {
+        Self::DEFAULT_METADATA_REPLICA_REFRESH_INTERVAL.to_string()
+    }
+
+    fn default_metadata_replica_max_staleness_str() -> String {
+        Self::DEFAULT_METADATA_REPLICA_MAX_STALENESS.to_string()
+    }
+
+    pub fn metadata_replica_page_size(&self) -> usize {
+        Self::DEFAULT_METADATA_REPLICA_PAGE_SIZE
+    }
+
+    pub fn metadata_replica_history_size(&self) -> usize {
+        Self::DEFAULT_METADATA_REPLICA_HISTORY_SIZE
+    }
+
+    pub fn scheduler_workers(&self) -> usize {
+        Self::DEFAULT_MAX_PLANNING_TRANSFERS
+            .min(self.max_running_transfers.max(1))
+            .max(1)
+    }
+
+    pub fn planning_batch_size(&self) -> usize {
+        Self::DEFAULT_PLANNING_BATCH_SIZE
+    }
+
+    pub fn worker_dispatch_concurrency(&self) -> usize {
+        Self::DEFAULT_WORKER_DISPATCH_CONCURRENCY
+    }
+
+    pub fn task_report_queue_size(&self) -> usize {
+        Self::DEFAULT_TASK_REPORT_QUEUE_SIZE
+    }
+
+    pub fn task_probe_concurrency(&self) -> usize {
+        Self::DEFAULT_TASK_PROBE_CONCURRENCY
+    }
+
+    pub fn client_pending_queue_size(&self) -> usize {
+        Self::DEFAULT_CLIENT_PENDING_QUEUE_SIZE
+    }
+
+    pub fn cleanup_batch_size(&self) -> usize {
+        Self::DEFAULT_CLEANUP_BATCH_SIZE
+    }
+
+    fn derive_task_stale_timeout(lease_timeout: Duration) -> Duration {
+        lease_timeout.div_f64(2.0)
+    }
+
+    fn derive_task_report_interval(task_stale_timeout: Duration) -> Duration {
+        let derived = task_stale_timeout.div_f64(6.0);
+        let default = DurationUnit::from_str(Self::DEFAULT_TASK_REPORT_INTERVAL)
+            .expect("default transfer task report interval must be valid")
+            .as_duration();
+        derived.min(default).max(Duration::from_millis(1))
+    }
+
+    pub fn server_conf(&self, cluster_id: &str) -> ServerConf {
+        let mut conf = ServerConf::with_hostname(&self.hostname, self.rpc_port);
+        conf.name = format!("{}-transfer", cluster_id);
+        conf.io_threads = self.io_threads;
+        conf.worker_threads = self.worker_threads;
+        conf
+    }
+}
+
+impl Default for TransferConf {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            store_type: TransferStoreType::Auto,
+            store_url: String::new(),
+            hostname: "localhost".to_string(),
+            rpc_port: Self::DEFAULT_RPC_PORT,
+            web_port: Self::DEFAULT_WEB_PORT,
+            io_threads: Self::DEFAULT_IO_THREADS,
+            worker_threads: Self::DEFAULT_WORKER_THREADS,
+            instance_id: String::new(),
+            endpoints: vec![],
+            sqlite_path: "data/transfer/transfer.db".to_string(),
+            mysql_url: String::new(),
+            cv_metadata_reader: TransferCvMetadataReaderType::Auto,
+            metadata_replica_max_entries: Self::DEFAULT_METADATA_REPLICA_MAX_ENTRIES,
+            allow_submit_with_stale_snapshot: false,
+            max_running_transfers: 64,
+            max_tasks_per_transfer: Self::DEFAULT_MAX_TASKS_PER_TRANSFER,
+            ufs_max_concurrency_per_endpoint: Self::DEFAULT_UFS_MAX_CONCURRENCY_PER_ENDPOINT,
+            task_max_retries: Self::DEFAULT_TASK_MAX_RETRIES,
+            task_report_interval: Duration::default(),
+            task_report_interval_str: Self::DEFAULT_TASK_REPORT_INTERVAL.to_string(),
+            task_stale_timeout: Duration::default(),
+            task_stale_timeout_str: Self::DEFAULT_TASK_STALE_TIMEOUT.to_string(),
+            lease_timeout: Duration::default(),
+            lease_timeout_str: Self::DEFAULT_LEASE_TIMEOUT.to_string(),
+            cluster_snapshot_max_staleness: Duration::default(),
+            cluster_snapshot_max_staleness_str: Self::DEFAULT_CLUSTER_SNAPSHOT_MAX_STALENESS
+                .to_string(),
+            terminal_retention: Duration::default(),
+            terminal_retention_str: Self::DEFAULT_TERMINAL_RETENTION.to_string(),
+            metadata_replica_refresh_interval: Duration::default(),
+            metadata_replica_refresh_interval_str: Self::DEFAULT_METADATA_REPLICA_REFRESH_INTERVAL
+                .to_string(),
+            metadata_replica_max_staleness: Duration::default(),
+            metadata_replica_max_staleness_str: Self::DEFAULT_METADATA_REPLICA_MAX_STALENESS
+                .to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TransferConf, TransferCvMetadataReaderType, TransferStoreType};
+
+    #[test]
+    fn defaults_to_local_sqlite_with_a_local_endpoint() {
+        let mut conf = TransferConf {
+            enabled: true,
+            ..Default::default()
+        };
+
+        conf.init().unwrap();
+
+        assert_eq!(conf.effective_store_type(), TransferStoreType::Sqlite);
+        assert_eq!(conf.store_url, "sqlite://data/transfer/transfer.db");
+        assert_eq!(
+            conf.effective_cv_metadata_reader(),
+            TransferCvMetadataReaderType::Replica
+        );
+        assert_eq!(conf.endpoints, vec!["localhost:9010"]);
+    }
+
+    #[test]
+    fn mysql_url_selects_production_safe_defaults() {
+        let mut conf: TransferConf = toml::from_str(
+            r#"
+                enabled = true
+                store_url = "mysql://root:curvine@127.0.0.1:3306/curvine_transfer"
+            "#,
+        )
+        .unwrap();
+
+        conf.init().unwrap();
+
+        assert_eq!(conf.effective_store_type(), TransferStoreType::Mysql);
+        assert_eq!(
+            conf.store_url,
+            "mysql://root:curvine@127.0.0.1:3306/curvine_transfer"
+        );
+        assert_eq!(
+            conf.effective_cv_metadata_reader(),
+            TransferCvMetadataReaderType::Replica
+        );
+    }
+
+    #[test]
+    fn auto_mysql_rejects_development_metadata_reader() {
+        let mut conf = TransferConf {
+            enabled: true,
+            store_url: "mysql://root:curvine@127.0.0.1:3306/curvine_transfer".to_string(),
+            cv_metadata_reader: TransferCvMetadataReaderType::Master,
+            ..Default::default()
+        };
+
+        let err = conf.init().unwrap_err().to_string();
+
+        assert!(err.contains("requires transfer.cv_metadata_reader=replica"));
+    }
+
+    #[test]
+    fn accepts_memory_store_url_and_rejects_unknown_scheme() {
+        let mut memory = TransferConf {
+            enabled: true,
+            store_url: "memory://".to_string(),
+            ..Default::default()
+        };
+        memory.init().unwrap();
+        assert_eq!(memory.effective_store_type(), TransferStoreType::Memory);
+
+        let mut invalid = TransferConf {
+            enabled: true,
+            store_url: "postgres://transfer".to_string(),
+            ..Default::default()
+        };
+        let err = invalid.init().unwrap_err().to_string();
+        assert!(err.contains("transfer.store_url must use"));
+    }
+}

--- a/curvine-common/src/conf/cluster_conf.rs
+++ b/curvine-common/src/conf/cluster_conf.rs
@@ -15,7 +15,8 @@
 use crate::alloc::allocator_type_name;
 use crate::conf::CliConf;
 use crate::conf::{
-    ClientConf, FaultHttpConfig, FuseConf, JobConf, JournalConf, MasterConf, WorkerConf,
+    ClientConf, FaultHttpConfig, FuseConf, JobConf, JournalConf, MasterConf, TransferConf,
+    WorkerConf,
 };
 use crate::rocksdb::DBConf;
 use crate::version;
@@ -73,6 +74,8 @@ pub struct ClusterConf {
 
     pub job: JobConf,
 
+    pub transfer: TransferConf,
+
     pub cli: CliConf,
 }
 
@@ -124,7 +127,8 @@ impl ClusterConf {
             conf.master.hostname = ip.clone();
             conf.journal.hostname = ip.clone();
             conf.worker.hostname = ip.clone();
-            conf.client.hostname = ip;
+            conf.client.hostname = ip.clone();
+            conf.transfer.hostname = ip;
         } else {
             if let Ok(v) = env::var(Self::ENV_MASTER_HOSTNAME) {
                 conf.master.hostname = v.to_owned();
@@ -146,6 +150,7 @@ impl ClusterConf {
         conf.client.init()?;
         conf.fuse.init()?;
         conf.job.init()?;
+        conf.transfer.init()?;
 
         if conf.client.master_addrs.is_empty() {
             for peer in &mut conf.journal.journal_addrs {
@@ -288,6 +293,19 @@ impl ClusterConf {
         web_conf
     }
 
+    pub fn transfer_server_conf(&self) -> ServerConf {
+        self.transfer.server_conf(&self.cluster_id)
+    }
+
+    pub fn transfer_web_conf(&self) -> ServerConf {
+        let mut web_conf =
+            ServerConf::with_hostname(&self.transfer.hostname, self.transfer.web_port);
+        web_conf.name = format!("{}-transfer-web", self.cluster_id);
+        web_conf.io_threads = self.transfer.io_threads;
+        web_conf.worker_threads = self.transfer.worker_threads;
+        web_conf
+    }
+
     pub fn client_rpc_conf(&self) -> RpcConf {
         self.client.client_rpc_conf()
     }
@@ -385,6 +403,7 @@ impl Default for ClusterConf {
             client: Default::default(),
             fuse: FuseConf::default(),
             job: Default::default(),
+            transfer: Default::default(),
             cli: Default::default(),
         }
     }

--- a/curvine-common/src/conf/journal_conf.rs
+++ b/curvine-common/src/conf/journal_conf.rs
@@ -57,6 +57,14 @@ pub struct JournalConf {
     // How many entries are created after creating snapshots.
     pub snapshot_entries: u64,
 
+    // Internal ring buffer for Transfer metadata replica delta sync.
+    #[serde(
+        skip_serializing,
+        skip_deserializing,
+        default = "JournalConf::default_metadata_delta_log_capacity"
+    )]
+    pub metadata_delta_log_capacity: usize,
+
     pub snapshot_read_chunk_size: usize,
 
     // Network configuration between raft node communications.
@@ -118,6 +126,11 @@ pub struct JournalConf {
 
 impl JournalConf {
     pub const DEFAULT_NODE_ID: u64 = 0;
+    pub const DEFAULT_METADATA_DELTA_LOG_CAPACITY: usize = 100_000;
+
+    fn default_metadata_delta_log_capacity() -> usize {
+        Self::DEFAULT_METADATA_DELTA_LOG_CAPACITY
+    }
 
     // Create a test configuration, which will also randomly select a server port.
     pub fn with_test() -> Self {
@@ -229,6 +242,7 @@ impl Default for JournalConf {
             writer_flush_batch_ms: 10,
             snapshot_interval: "6h".to_string(),
             snapshot_entries: 1000000,
+            metadata_delta_log_capacity: Self::DEFAULT_METADATA_DELTA_LOG_CAPACITY,
             snapshot_read_chunk_size: 1024 * 1024,
 
             conn_retry_max_duration_ms: 0,

--- a/curvine-common/src/conf/mod.rs
+++ b/curvine-common/src/conf/mod.rs
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 pub use curvine_config::{
-    CliConf, ClientConf, ClientConfCliOverrides, FuseConf, JobConf, UfsConf, UfsConfBuilder,
+    CliConf, ClientConf, ClientConfCliOverrides, FuseConf, JobConf, TransferConf,
+    TransferCvMetadataReaderType, TransferStoreType, UfsConf, UfsConfBuilder,
 };
 
 pub use curvine_fault::FaultHttpConfig;


### PR DESCRIPTION
# Summary

Adds the minimal Transfer configuration and inferred local defaults.

# Issue Describe / Design

Part of the standalone Transfer service. This review layer is stacked deliberately so that protocol, metadata storage, scheduling, worker execution, client routing, and deployment can be reviewed independently.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `crates/common/curvine-config,curvine-common/src/conf` | Adds the minimal Transfer configuration and inferred local defaults. | New Transfer behavior; legacy behavior remains available unless Transfer is enabled. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo check -p curvine-server -p curvine-cli` | PASS | Rebased onto upstream main `497d078d`. |

# Dependencies

- Related PRs: #1342
- Related issues: #1040
- Blocks / blocked by: #1342