### PR TITLE
feat(transfer): add MySQL metadata store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,17 @@ dependencies = [
 
 [[package]]
 name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.16",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
@@ -211,7 +222,7 @@ version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c8955af33b25f3b175ee10af580577280b4bd01f7e823d94c7cdef7cf8c9aef"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
@@ -369,7 +380,7 @@ version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68bf3e3efbd1278f770d67e5dc410257300b161b93baedb3aae836144edcaf4b"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
@@ -1273,6 +1284,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a88b7ea17d208c4193f2c1e6de3c35fe71f98c96982d5ced308bdcc749ff6e1f"
+dependencies = [
+ "borsh-derive",
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8f347189c62a579b8cd5f80714efa178f52e461dc2e6d701d264f5ff22e566c"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1294,10 +1329,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "btoi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd6407f73a9b8b6162d8a2ef999fe6afd7cc15902ebf42c5cd296addf17e0ad"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "bufstream"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40e38929add23cdf8a366df9b0e088953150724bcbe5fc330b0d8eb3b328eec8"
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "bytecount"
@@ -2252,6 +2324,7 @@ dependencies = [
  "log",
  "lru 0.16.1",
  "mini-moka",
+ "mysql",
  "num_enum",
  "once_cell",
  "orpc",
@@ -2511,7 +2584,7 @@ version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d551054acec0398ca604512310b77ce05c46f66e54b54d48200a686e385cca4e"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow",
  "arrow-ipc",
  "chrono",
@@ -2735,7 +2808,7 @@ version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b644f9cf696df9233ce6958b9807666d78563b56f923267474dd6c07795f1f8f"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow",
  "datafusion-common",
  "datafusion-doc",
@@ -2756,7 +2829,7 @@ version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1de2deaaabe8923ce9ea9f29c47bbb4ee14f67ea2fe1ab5398d9bbebcf86e56"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow",
  "datafusion-common",
  "datafusion-expr-common",
@@ -2866,7 +2939,7 @@ version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d48022b8af9988c1d852644f9e8b5584c490659769a550c5e8d39457a1da0a5"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow",
  "datafusion-common",
  "datafusion-expr",
@@ -2904,7 +2977,7 @@ version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147253ca3e6b9d59c162de64c02800973018660e13340dd1886dd038d17ac429"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow",
  "chrono",
  "datafusion-common",
@@ -2939,7 +3012,7 @@ version = "52.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68253dc0ee5330aa558b2549c9b0da5af9fc17d753ae73022939014ad616fc28"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow",
  "arrow-ord",
  "arrow-schema",
@@ -3081,6 +3154,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_utils"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "362f47930db19fe7735f527e6595e4900316b893ebf6d48ad3d31be928d57dd6"
+dependencies = [
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -3438,6 +3522,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "foreign_vec"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3450,6 +3549,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "frunk"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28aef0f9aa070bce60767c12ba9cb41efeaf1a2bc6427f87b7d83f11239a16d7"
+dependencies = [
+ "frunk_core 0.4.4",
+ "frunk_derives",
+ "frunk_proc_macros",
+ "serde",
+]
+
+[[package]]
+name = "frunk_core"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "476eeaa382e3462b84da5d6ba3da97b5786823c2d0d3a0d04ef088d073da225c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "frunk_core"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bd3c9ba2e323e8b19e77f15873f60974a7d82f89b80e50c53be44b8b92927c1"
+
+[[package]]
+name = "frunk_derives"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0b4095fc99e1d858e5b8c7125d2638372ec85aa0fe6c807105cf10b0265ca6c"
+dependencies = [
+ "frunk_proc_macro_helpers",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "frunk_proc_macro_helpers"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b70229a1347a20d4af9c06116cc452acef34f798668c6b69e97dd5c8a88052bd"
+dependencies = [
+ "frunk_core 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "frunk_proc_macros"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c63fe4306e13ece9d1ac23ce02f121ffefd42ae876ad03ec2caf07232bde3023"
+dependencies = [
+ "frunk_core 0.5.0",
+ "frunk_proc_macro_helpers",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3917,6 +4078,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
 
 [[package]]
 name = "hashbrown"
@@ -3924,7 +4088,7 @@ version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "allocator-api2",
  "rayon",
 ]
@@ -4504,6 +4668,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-enum"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de9008599afe8527a8c9d70423437363b321649161e98473f433de802d76107"
+dependencies = [
+ "derive_utils",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5038,7 +5211,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
- "twox-hash",
+ "twox-hash 2.1.2",
  "uuid",
 ]
 
@@ -5224,7 +5397,7 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce0f4d7f739dc30608fe8b202cbb40986c2937e1a5a189f98fb06d7b8543156a"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow",
  "arrow-array",
  "arrow-cast",
@@ -5609,7 +5782,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90071f8077f8e40adfc4b7fe9cd495ce316263f19e75c2211eeff3fdf475a3d9"
 dependencies = [
- "twox-hash",
+ "twox-hash 2.1.2",
 ]
 
 [[package]]
@@ -5864,6 +6037,114 @@ name = "murmurhash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
+
+[[package]]
+name = "mysql"
+version = "25.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6ad644efb545e459029b1ffa7c969d830975bd76906820913247620df10050b"
+dependencies = [
+ "bufstream",
+ "bytes",
+ "crossbeam",
+ "flate2",
+ "io-enum",
+ "libc",
+ "lru 0.12.5",
+ "mysql_common",
+ "named_pipe",
+ "native-tls",
+ "pem",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+ "socket2 0.5.10",
+ "twox-hash 1.6.3",
+ "url",
+]
+
+[[package]]
+name = "mysql-common-derive"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63c3512cf11487168e0e9db7157801bf5273be13055a9cc95356dc9e0035e49c"
+dependencies = [
+ "darling",
+ "heck 0.5.0",
+ "num-bigint",
+ "proc-macro-crate",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "termcolor",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "mysql_common"
+version = "0.32.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478b0ff3f7d67b79da2b96f56f334431aef65e15ba4b29dd74a4236e29582bdc"
+dependencies = [
+ "base64 0.21.7",
+ "bigdecimal",
+ "bindgen",
+ "bitflags 2.10.0",
+ "bitvec",
+ "btoi",
+ "byteorder",
+ "bytes",
+ "cc",
+ "cmake",
+ "crc32fast",
+ "flate2",
+ "frunk",
+ "lazy_static",
+ "mysql-common-derive",
+ "num-bigint",
+ "num-traits",
+ "rand 0.8.5",
+ "regex",
+ "rust_decimal",
+ "saturating",
+ "serde",
+ "serde_json",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "subprocess",
+ "thiserror 1.0.69",
+ "time",
+ "uuid",
+ "zstd",
+]
+
+[[package]]
+name = "named_pipe"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad9c443cce91fc3e12f017290db75dde490d685cdaaf508d7159d7cf41f0eb2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
 
 [[package]]
 name = "ndarray"
@@ -6186,10 +6467,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -6607,7 +6925,7 @@ version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "725b09f2b5ef31279b66e27bbab63c58d49d8f6696b66b1f46c7eaab95e80f75"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "atoi",
  "atoi_simd",
  "bytemuck",
@@ -6668,7 +6986,7 @@ version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "465f70d3e96b6d0b1a43c358ba451286b8c8bd56696feff020d65702aa33e35c"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "bitflags 2.10.0",
  "bytemuck",
  "chrono",
@@ -6712,7 +7030,7 @@ version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2c8589e418cbe4a48228d64b2a8a40284a82ec3c98817c0c2bcc0267701338b"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "atoi_simd",
  "bytes",
  "chrono",
@@ -6742,7 +7060,7 @@ version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2632b1af668e2058d5f8f916d8fbde3cac63d03ae29a705f598e41dcfeb7f"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "bitflags 2.10.0",
  "glob",
  "once_cell",
@@ -6765,7 +7083,7 @@ version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efdbdb4d9a92109bc2e0ce8e17af5ae8ab643bb5b7ee9d1d74f0aeffd1fbc95f"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "argminmax",
  "base64 0.21.7",
  "bytemuck",
@@ -6795,7 +7113,7 @@ version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b421d2196f786fdfe162db614c8485f8308fe41575d4de634a39bbe460d1eb6a"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "base64 0.21.7",
  "ethnum",
  "num-traits",
@@ -6839,7 +7157,7 @@ version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fb8e2302e20c44defd5be8cad9c96e75face63c3a5f609aced8c4ec3b3ac97d"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "bytemuck",
  "chrono-tz 0.8.6",
  "hashbrown 0.14.5",
@@ -6915,7 +7233,7 @@ version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c760b6c698cfe2fbbbd93d6cfb408db14ececfe1d92445dae2229ce1b5b21ae8"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "bytemuck",
  "hashbrown 0.14.5",
  "indexmap 2.14.0",
@@ -7202,6 +7520,26 @@ checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
 dependencies = [
  "ar_archive_writer",
  "cc",
+]
+
+[[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -7554,7 +7892,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e47a395bdb55442b883c89062d6bcff25dc90fa5f8369af81e0ac6d49d78cf81"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "brotli",
  "paste",
  "rand 0.9.2",
@@ -7730,6 +8068,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "reqsign"
 version = "0.16.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7879,6 +8226,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rkyv"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "roaring"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7970,6 +8346,23 @@ checksum = "e46a2036019fdb888131db7a4c847a1063a7493f971ed94ea82c67eada63ca54"
 dependencies = [
  "serde",
  "serde_derive",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be2a24f50780bc85f09cc6ac299bdf1424302742d77221106859c9d8b102126a"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand 0.8.5",
+ "rkyv",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -8151,6 +8544,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "saturating"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece8e78b2f38ec51c51f5d475df0a7187ba5111b2a28bdc761ee05b075d40a71"
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8215,6 +8614,12 @@ dependencies = [
  "ring",
  "untrusted",
 ]
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "secrecy"
@@ -8775,6 +9180,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "subprocess"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c56e8662b206b9892d7a5a3f2ecdbcb455d3d6b259111373b7e08b8055158a8"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9086,6 +9501,15 @@ dependencies = [
  "once_cell",
  "rustix 1.0.8",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -9569,6 +9993,17 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "rand 0.8.5",
+ "static_assertions",
+]
+
+[[package]]
+name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
@@ -9813,6 +10248,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
+ "serde",
  "wasm-bindgen-macro",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ raft = { version = "0.7.0", features = ["prost-codec"], default-features = false
 trait-variant = "0.1.2"
 nix = { version = "0.30.1", features = ["ioctl", "user", "event"] }
 rusqlite = { version = "0.32.1", features = ["bundled"] }
+mysql = "25.0.1"
 
 # The most important library end
 

--- a/curvine-server/Cargo.toml
+++ b/curvine-server/Cargo.toml
@@ -41,6 +41,7 @@ mini-moka = { workspace = true }
 regex = { workspace = true }
 linked-hash-map = { workspace = true }
 rusqlite = { workspace = true }
+mysql = { workspace = true }
 dashmap = { workspace = true }
 axum = { workspace = true }
 serde_json = { workspace = true }

--- a/curvine-server/src/transfer/mod.rs
+++ b/curvine-server/src/transfer/mod.rs
@@ -6,3 +6,6 @@ pub use self::memory_store::MemoryTransferStore;
 
 mod sqlite_store;
 pub use self::sqlite_store::SqliteTransferStore;
+
+mod mysql_store;
+pub use self::mysql_store::MysqlTransferStore;

--- a/curvine-server/src/transfer/mysql_store.rs
+++ b/curvine-server/src/transfer/mysql_store.rs
@@ -1,0 +1,1329 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use curvine_common::error::FsError;
+use curvine_common::state::{
+    summarize_transfer_tasks, StaleTaskAttempt, TaskAttemptStart, TransferJobRecord, TransferLease,
+    TransferListFilter, TransferState, TransferStateUpdate, TransferTaskRecord, TransferTaskReport,
+    TransferTaskState, TransferTenantSummary,
+};
+use curvine_common::FsResult;
+use mysql::prelude::*;
+use mysql::{params, Params, Pool, PooledConn, TxOpts, Value as MysqlValue};
+
+use crate::transfer::{TransferRequeueUpdate, TransferStore};
+
+const TRANSFER_SCHEMA_VERSION: u64 = 4;
+const TRANSFER_SCHEMA_V3: u64 = 3;
+
+type TenantSummaryRow = (
+    String,
+    Option<u64>,
+    Option<u64>,
+    Option<u64>,
+    Option<u64>,
+    Option<u64>,
+    u64,
+);
+
+pub struct MysqlTransferStore {
+    pool: Pool,
+}
+
+impl MysqlTransferStore {
+    pub fn open(url: &str) -> FsResult<Self> {
+        let pool = Pool::new(url).map_err(mysql_err)?;
+        let mut conn = pool.get_conn().map_err(mysql_err)?;
+        init_schema(&mut conn)?;
+        Ok(Self { pool })
+    }
+
+    fn conn(&self) -> FsResult<PooledConn> {
+        self.pool.get_conn().map_err(mysql_err)
+    }
+}
+
+impl TransferStore for MysqlTransferStore {
+    fn check_available(&self) -> FsResult<()> {
+        self.conn()?.query_drop("select 1").map_err(mysql_err)
+    }
+
+    fn create_or_get_by_request_id(&self, job: TransferJobRecord) -> FsResult<TransferJobRecord> {
+        self.create_or_get_by_request_id_checked(job)
+    }
+
+    fn create_or_get_by_request_id_checked(
+        &self,
+        job: TransferJobRecord,
+    ) -> FsResult<TransferJobRecord> {
+        let mut conn = self.conn()?;
+        let mut tx = conn
+            .start_transaction(TxOpts::default())
+            .map_err(mysql_err)?;
+        if let Some(existing) =
+            select_job_by_request(&mut tx, &job.submitter, &job.client_request_id)?
+        {
+            tx.commit().map_err(mysql_err)?;
+            return Ok(existing);
+        }
+        if let Some(existing) = select_non_terminal_job_by_key(&mut tx, &job.job_key)? {
+            if existing.command_json == job.command_json {
+                tx.commit().map_err(mysql_err)?;
+                return Ok(existing);
+            }
+            return Err(FsError::transfer_already_running(format!(
+                "job_key {} has running job {} with different command",
+                existing.job_key, existing.job_id
+            )));
+        }
+        if let Some(existing) = select_conflicting_active_transfer(
+            &mut tx,
+            &job.target_path,
+            &job.submitter,
+            &job.client_request_id,
+        )? {
+            return Err(FsError::transfer_target_conflict(format!(
+                "target {} conflicts with active transfer {} target {}",
+                job.target_path, existing.job_id, existing.target_path
+            )));
+        }
+        insert_job(&mut tx, &job)?;
+        tx.commit().map_err(mysql_err)?;
+        Ok(job)
+    }
+
+    fn get_transfer(&self, job_id: &str) -> FsResult<Option<TransferJobRecord>> {
+        select_job_by_id(&mut self.conn()?, job_id)
+    }
+
+    fn get_transfer_by_request(
+        &self,
+        submitter: &str,
+        client_request_id: &str,
+    ) -> FsResult<Option<TransferJobRecord>> {
+        select_job_by_request(&mut self.conn()?, submitter, client_request_id)
+    }
+
+    fn list_active_transfers(&self) -> FsResult<Vec<TransferJobRecord>> {
+        select_jobs(
+            &mut self.conn()?,
+            "select record_json from transfer_jobs where state not in (6, 7, 8)",
+            Params::Empty,
+        )
+    }
+
+    fn find_conflicting_active_transfer(
+        &self,
+        target_path: &str,
+        submitter: &str,
+        client_request_id: &str,
+    ) -> FsResult<Option<TransferJobRecord>> {
+        select_conflicting_active_transfer(
+            &mut self.conn()?,
+            target_path,
+            submitter,
+            client_request_id,
+        )
+    }
+
+    fn count_active_transfers(&self) -> FsResult<u64> {
+        self.conn()?
+            .exec_first::<u64, _, _>(
+                "select count(*) from transfer_jobs where state not in (6, 7, 8)",
+                Params::Empty,
+            )
+            .map_err(mysql_err)?
+            .ok_or_else(|| FsError::common("Failed to count active transfer jobs"))
+    }
+
+    fn count_executing_transfers(&self) -> FsResult<u64> {
+        self.conn()?
+            .exec_first::<u64, _, _>(
+                "select count(*) from transfer_jobs where state in (2, 3, 4, 5)",
+                Params::Empty,
+            )
+            .map_err(mysql_err)?
+            .ok_or_else(|| FsError::common("Failed to count executing transfer jobs"))
+    }
+
+    fn list_transfers(&self, filter: TransferListFilter) -> FsResult<Vec<TransferJobRecord>> {
+        let mut conn = self.conn()?;
+        let (where_sql, mut values) = list_filter_mysql_params(&filter);
+        let sql = format!(
+            "select record_json from transfer_jobs
+             {where_sql}
+             order by updated_at desc, created_at desc, job_id desc
+             limit ? offset ?"
+        );
+        values.push(MysqlValue::from(filter.limit as u64));
+        values.push(MysqlValue::from(filter.offset as u64));
+        select_jobs(&mut conn, &sql, Params::Positional(values))
+    }
+
+    fn list_tenant_summaries(
+        &self,
+        limit: usize,
+        offset: usize,
+    ) -> FsResult<Vec<TransferTenantSummary>> {
+        self.conn()?
+            .exec_map(
+                "select tenant,
+                        sum(case when state = 1 then 1 else 0 end) as pending,
+                        sum(case when state in (2, 3, 4, 5) then 1 else 0 end) as executing,
+                        sum(case when state = 6 then 1 else 0 end) as completed,
+                        sum(case when state = 7 then 1 else 0 end) as failed,
+                        sum(case when state = 8 then 1 else 0 end) as canceled,
+                        count(*) as total
+                 from transfer_jobs
+                 group by tenant
+                 order by (sum(case when state in (1, 2, 3, 4, 5) then 1 else 0 end)) desc,
+                          count(*) desc,
+                          tenant asc
+                 limit :limit offset :offset",
+                params! {
+                    "limit" => limit as u64,
+                    "offset" => offset as u64,
+                },
+                |(tenant, pending, executing, completed, failed, canceled, total): TenantSummaryRow| TransferTenantSummary {
+                    tenant,
+                    pending: pending.unwrap_or_default(),
+                    executing: executing.unwrap_or_default(),
+                    completed: completed.unwrap_or_default(),
+                    failed: failed.unwrap_or_default(),
+                    canceled: canceled.unwrap_or_default(),
+                    total,
+                },
+            )
+            .map_err(mysql_err)
+    }
+
+    fn purge_terminal_transfers(&self, older_than_ms: i64, limit: usize) -> FsResult<usize> {
+        if limit == 0 {
+            return Ok(0);
+        }
+        let mut conn = self.conn()?;
+        let mut tx = conn
+            .start_transaction(TxOpts::default())
+            .map_err(mysql_err)?;
+        let job_ids: Vec<String> = tx
+            .exec(
+                "select job_id from transfer_jobs
+                 where state in (6, 7, 8) and updated_at < :older_than_ms
+                 order by updated_at asc
+                 limit :limit",
+                params! {
+                    "older_than_ms" => older_than_ms,
+                    "limit" => limit as u64,
+                },
+            )
+            .map_err(mysql_err)?;
+        for job_id in &job_ids {
+            tx.exec_drop(
+                "delete from transfer_tasks where job_id = :job_id",
+                params! { "job_id" => job_id },
+            )
+            .map_err(mysql_err)?;
+            tx.exec_drop(
+                "delete from transfer_jobs where job_id = :job_id and state in (6, 7, 8)",
+                params! { "job_id" => job_id },
+            )
+            .map_err(mysql_err)?;
+        }
+        tx.commit().map_err(mysql_err)?;
+        Ok(job_ids.len())
+    }
+
+    fn list_transfer_tasks(&self, job_id: &str, run_id: u64) -> FsResult<Vec<TransferTaskRecord>> {
+        select_tasks(&mut self.conn()?, job_id, run_id, None, None)
+    }
+
+    fn request_cancel(&self, job_id: &str, run_id: u64, now_ms: i64) -> FsResult<bool> {
+        let mut job = match self.get_transfer(job_id)? {
+            Some(job) if job.run_id == run_id && !job.state.is_terminal() => job,
+            _ => return Ok(false),
+        };
+        job.cancel_requested = true;
+        job.state = TransferState::Canceling;
+        job.summary.message = "cancel requested".to_string();
+        job.summary.update_time = now_ms;
+        job.updated_at = now_ms;
+        exec_update_job(&mut self.conn()?, &job)
+    }
+
+    fn acquire_runnable_transfer(
+        &self,
+        owner: &str,
+        lease_ms: i64,
+        now_ms: i64,
+        max_executing_transfers: u64,
+    ) -> FsResult<Option<TransferLease>> {
+        let mut conn = self.conn()?;
+        let mut tx = conn
+            .start_transaction(TxOpts::default())
+            .map_err(mysql_err)?;
+
+        tx.exec_first::<u64, _, _>(
+            "select version from transfer_schema_version where id = 1 for update",
+            Params::Empty,
+        )
+        .map_err(mysql_err)?
+        .ok_or_else(|| FsError::common("Missing mysql transfer schema version"))?;
+        let executing = tx
+            .exec_first::<u64, _, _>(
+                "select count(*) from transfer_jobs where state in (2, 3, 4, 5)",
+                Params::Empty,
+            )
+            .map_err(mysql_err)?
+            .ok_or_else(|| FsError::common("Failed to count executing transfer jobs"))?;
+        let mut job: Option<(String, u64, u64, i32)> = tx
+            .exec_first(
+                "select job_id, run_id, lease_epoch, state
+                 from transfer_jobs
+                 where owner = :owner and state in (4, 5) and lease_expire_at > :now_ms
+                   and updated_at < :now_ms
+                 order by updated_at asc
+                 limit 1",
+                params! { "owner" => owner, "now_ms" => now_ms },
+            )
+            .map_err(mysql_err)?;
+        if job.is_none() {
+            job = tx
+                .exec_first(
+                    "select job_id, run_id, lease_epoch, state
+                 from transfer_jobs
+                 where state in (2, 3, 4, 5) and lease_expire_at <= :now_ms
+                 order by updated_at asc
+                 limit 1",
+                    params! { "now_ms" => now_ms },
+                )
+                .map_err(mysql_err)?;
+        }
+        if job.is_none() && executing < max_executing_transfers {
+            job = tx
+                .exec_first(
+                    "select pending.job_id, pending.run_id, pending.lease_epoch, pending.state
+                     from transfer_jobs pending
+                     where pending.state = 1 and pending.lease_expire_at <= :now_ms
+                     order by case when exists (
+                         select 1 from transfer_jobs executing
+                         where executing.tenant = pending.tenant and executing.state in (2, 3, 4, 5)
+                         limit 1
+                     ) then 1 else 0 end asc,
+                     pending.updated_at asc, pending.job_id asc
+                     limit 1",
+                    params! { "now_ms" => now_ms },
+                )
+                .map_err(mysql_err)?;
+        }
+        let Some((job_id, run_id, lease_epoch, state)) = job else {
+            tx.commit().map_err(mysql_err)?;
+            return Ok(None);
+        };
+        let mut record =
+            select_job_by_id(&mut tx, &job_id)?.ok_or_else(|| FsError::job_not_found(&job_id))?;
+        if state == TransferState::Pending as i32 {
+            record.state = TransferState::Planning;
+            record.summary.message = "acquired for planning".to_string();
+            record.summary.update_time = now_ms;
+        }
+        record.owner = owner.to_string();
+        record.lease_epoch = lease_epoch.saturating_add(1);
+        record.lease_expire_at = now_ms.saturating_add(lease_ms);
+        record.updated_at = now_ms;
+        let affected = exec_affected(
+            &mut tx,
+            "update transfer_jobs
+             set state = :state, owner = :owner, lease_epoch = :new_epoch, lease_expire_at = :lease_expire_at,
+                 record_json = :record_json, updated_at = :updated_at
+             where job_id = :job_id and run_id = :run_id and lease_epoch = :old_epoch",
+            params! {
+                "state" => record.state as i32,
+                "owner" => owner,
+                "new_epoch" => record.lease_epoch,
+                "lease_expire_at" => record.lease_expire_at,
+                "record_json" => json(&record)?,
+                "updated_at" => now_ms,
+                "job_id" => &job_id,
+                "run_id" => run_id,
+                "old_epoch" => lease_epoch,
+            },
+        )?;
+        tx.commit().map_err(mysql_err)?;
+        if affected == 0 {
+            return Ok(None);
+        }
+        Ok(Some(TransferLease {
+            job_id,
+            run_id,
+            owner: owner.to_string(),
+            lease_epoch: record.lease_epoch,
+        }))
+    }
+
+    fn renew_lease(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        owner: &str,
+        lease_epoch: u64,
+        lease_ms: i64,
+        now_ms: i64,
+    ) -> FsResult<bool> {
+        let mut job = match self.get_transfer(job_id)? {
+            Some(job)
+                if job.run_id == run_id
+                    && job.owner == owner
+                    && job.lease_epoch == lease_epoch
+                    && !job.state.is_terminal() =>
+            {
+                job
+            }
+            _ => return Ok(false),
+        };
+        job.lease_expire_at = now_ms.saturating_add(lease_ms);
+        job.updated_at = now_ms;
+        exec_update_job(&mut self.conn()?, &job)
+    }
+
+    fn update_transfer_state(&self, update: TransferStateUpdate) -> FsResult<bool> {
+        let mut conn = self.conn()?;
+        let mut tx = conn
+            .start_transaction(TxOpts::default())
+            .map_err(mysql_err)?;
+        let mut job = match select_job_by_id_for_update(&mut tx, &update.job_id)? {
+            Some(job)
+                if job.run_id == update.run_id
+                    && job.owner == update.owner
+                    && job.lease_epoch == update.lease_epoch
+                    && update.from_states.contains(&job.state) =>
+            {
+                job
+            }
+            _ => {
+                tx.commit().map_err(mysql_err)?;
+                return Ok(false);
+            }
+        };
+        job.state = update.to_state;
+        job.summary.message = update.message;
+        job.summary.update_time = update.now_ms;
+        job.updated_at = update.now_ms;
+        let updated = exec_update_job(&mut tx, &job)?;
+        tx.commit().map_err(mysql_err)?;
+        Ok(updated)
+    }
+
+    fn set_transfer_state(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        state: TransferState,
+        message: impl Into<String>,
+        now_ms: i64,
+    ) -> FsResult<bool> {
+        let mut job = match self.get_transfer(job_id)? {
+            Some(job) if job.run_id == run_id => job,
+            _ => return Ok(false),
+        };
+        job.state = state;
+        job.summary.message = message.into();
+        job.summary.update_time = now_ms;
+        job.updated_at = now_ms;
+        exec_update_job(&mut self.conn()?, &job)
+    }
+
+    fn requeue_transfer(&self, update: TransferRequeueUpdate) -> FsResult<bool> {
+        let mut conn = self.conn()?;
+        let mut tx = conn
+            .start_transaction(TxOpts::default())
+            .map_err(mysql_err)?;
+        let mut job = match select_job_by_id_for_update(&mut tx, &update.job_id)? {
+            Some(job)
+                if job.run_id == update.run_id
+                    && job.owner == update.owner
+                    && job.lease_epoch == update.lease_epoch
+                    && job.state == TransferState::Planning =>
+            {
+                job
+            }
+            _ => {
+                tx.commit().map_err(mysql_err)?;
+                return Ok(false);
+            }
+        };
+        job.state = TransferState::Pending;
+        job.owner.clear();
+        job.lease_expire_at = update.next_attempt_at_ms;
+        job.summary.message = update.message;
+        job.summary.update_time = update.now_ms;
+        job.updated_at = update.now_ms;
+        let updated = exec_update_job(&mut tx, &job)?;
+        tx.commit().map_err(mysql_err)?;
+        Ok(updated)
+    }
+
+    fn set_transfer_cv_metadata_epoch(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        owner: &str,
+        lease_epoch: u64,
+        cv_metadata_epoch: u64,
+        now_ms: i64,
+    ) -> FsResult<bool> {
+        let mut conn = self.conn()?;
+        let mut tx = conn
+            .start_transaction(TxOpts::default())
+            .map_err(mysql_err)?;
+        let mut job = match select_job_by_id_for_update(&mut tx, job_id)? {
+            Some(job)
+                if job.run_id == run_id
+                    && job.owner == owner
+                    && job.lease_epoch == lease_epoch
+                    && !job.state.is_terminal()
+                    && job
+                        .cv_metadata_epoch
+                        .is_none_or(|existing| existing == cv_metadata_epoch) =>
+            {
+                job
+            }
+            _ => {
+                tx.commit().map_err(mysql_err)?;
+                return Ok(false);
+            }
+        };
+        job.cv_metadata_epoch = Some(cv_metadata_epoch);
+        job.updated_at = now_ms;
+        let updated = exec_update_job(&mut tx, &job)?;
+        tx.commit().map_err(mysql_err)?;
+        Ok(updated)
+    }
+
+    fn insert_tasks(&self, tasks: Vec<TransferTaskRecord>) -> FsResult<()> {
+        let mut conn = self.conn()?;
+        let mut tx = conn
+            .start_transaction(TxOpts::default())
+            .map_err(mysql_err)?;
+        for task in tasks {
+            insert_task(&mut tx, &task)?;
+        }
+        tx.commit().map_err(mysql_err)?;
+        Ok(())
+    }
+
+    fn update_task_state(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        task_id: &str,
+        state: TransferTaskState,
+        message: impl Into<String>,
+        now_ms: i64,
+    ) -> FsResult<bool> {
+        let mut task = match select_task(&mut self.conn()?, job_id, run_id, task_id)? {
+            Some(task) => task,
+            None => return Ok(false),
+        };
+        task.state = state;
+        task.progress.message = message.into();
+        task.progress.update_time = now_ms;
+        task.updated_at = now_ms;
+        exec_update_task(&mut self.conn()?, &task)
+    }
+
+    fn claim_pending_tasks(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        limit: usize,
+    ) -> FsResult<Vec<TransferTaskRecord>> {
+        select_tasks(
+            &mut self.conn()?,
+            job_id,
+            run_id,
+            Some(TransferTaskState::Pending),
+            Some(limit),
+        )
+    }
+
+    fn mark_stale_attempts(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        owner: &str,
+        lease_epoch: u64,
+        now_ms: i64,
+        limit: usize,
+    ) -> FsResult<Vec<StaleTaskAttempt>> {
+        let mut conn = self.conn()?;
+        let mut tx = conn
+            .start_transaction(TxOpts::default())
+            .map_err(mysql_err)?;
+        let valid_owner: Option<u8> = tx
+            .exec_first(
+                "select 1 from transfer_jobs
+                 where job_id = :job_id and run_id = :run_id and owner = :owner
+                   and lease_epoch = :lease_epoch",
+                params! {
+                    "job_id" => job_id,
+                    "run_id" => run_id,
+                    "owner" => owner,
+                    "lease_epoch" => lease_epoch,
+                },
+            )
+            .map_err(mysql_err)?;
+        if valid_owner.is_none() {
+            tx.commit().map_err(mysql_err)?;
+            return Ok(Vec::new());
+        }
+        let rows: Vec<String> = tx
+            .exec(
+                "select record_json from transfer_tasks
+                 where job_id = :job_id and run_id = :run_id and state = 2
+                   and stale_deadline_at < :now_ms
+                 order by stale_deadline_at asc
+                 limit :limit",
+                params! {
+                    "job_id" => job_id,
+                    "run_id" => run_id,
+                    "now_ms" => now_ms,
+                    "limit" => limit as u64,
+                },
+            )
+            .map_err(mysql_err)?;
+        let mut stale = Vec::with_capacity(rows.len());
+        for row in rows {
+            let mut task: TransferTaskRecord = serde_json::from_str(&row).map_err(json_err)?;
+            task.state = TransferTaskState::Stale;
+            task.retry_count = task.retry_count.saturating_add(1);
+            task.progress.message = "task stale timeout".to_string();
+            task.progress.update_time = now_ms;
+            task.updated_at = now_ms;
+            exec_update_task(&mut tx, &task)?;
+            stale.push(StaleTaskAttempt { task });
+        }
+        tx.commit().map_err(mysql_err)?;
+        Ok(stale)
+    }
+
+    fn list_recoverable_tasks(
+        &self,
+        job_id: &str,
+        run_id: u64,
+    ) -> FsResult<Vec<TransferTaskRecord>> {
+        let rows: Vec<String> = self
+            .conn()?
+            .exec(
+                "select record_json from transfer_tasks
+                 where job_id = :job_id and run_id = :run_id and state in (1, 2, 6)",
+                params! { "job_id" => job_id, "run_id" => run_id },
+            )
+            .map_err(mysql_err)?;
+        rows.into_iter()
+            .map(|row| serde_json::from_str(&row).map_err(json_err))
+            .collect()
+    }
+
+    fn start_task_attempt(&self, start: TaskAttemptStart) -> FsResult<bool> {
+        let mut conn = self.conn()?;
+        let mut tx = conn
+            .start_transaction(TxOpts::default())
+            .map_err(mysql_err)?;
+        let Some(job) = select_job_by_id_for_update(&mut tx, &start.job_id)? else {
+            tx.commit().map_err(mysql_err)?;
+            return Ok(false);
+        };
+        if job.run_id != start.run_id
+            || job.owner != start.owner
+            || job.lease_epoch != start.lease_epoch
+            || job.cancel_requested
+            || job.state.is_terminal()
+        {
+            tx.commit().map_err(mysql_err)?;
+            return Ok(false);
+        }
+        let mut task =
+            match select_task_for_update(&mut tx, &start.job_id, start.run_id, &start.task_id)? {
+                Some(task)
+                    if matches!(
+                        task.state,
+                        TransferTaskState::Pending | TransferTaskState::Stale
+                    ) =>
+                {
+                    task
+                }
+                _ => {
+                    tx.commit().map_err(mysql_err)?;
+                    return Ok(false);
+                }
+            };
+        task.attempt_id = start.attempt_id;
+        task.worker_id = start.worker_id;
+        task.worker_session_id = start.worker_session_id;
+        task.report_target_json = start.report_target_json;
+        task.state = TransferTaskState::Running;
+        task.attempt_started_at = start.now_ms;
+        task.last_report_at = start.now_ms;
+        task.stale_deadline_at = start.stale_deadline_at;
+        task.updated_at = start.now_ms;
+        let updated = exec_update_task(&mut tx, &task)?;
+        tx.commit().map_err(mysql_err)?;
+        Ok(updated)
+    }
+
+    fn update_task_report(&self, report: TransferTaskReport) -> FsResult<bool> {
+        let mut conn = self.conn()?;
+        let mut tx = conn
+            .start_transaction(TxOpts::default())
+            .map_err(mysql_err)?;
+        let mut task = match select_task_for_update(
+            &mut tx,
+            &report.job_id,
+            report.run_id,
+            &report.task_id,
+        )? {
+            Some(task)
+                if task.attempt_id == report.attempt_id
+                    && task.worker_id == report.worker_id
+                    && task.worker_session_id == report.worker_session_id
+                    && task.state.is_running() =>
+            {
+                task
+            }
+            _ => {
+                tx.commit().map_err(mysql_err)?;
+                return Ok(false);
+            }
+        };
+        task.state = report.state;
+        task.progress = report.progress;
+        task.last_report_at = report.now_ms;
+        task.stale_deadline_at = report.stale_deadline_at;
+        task.updated_at = report.now_ms;
+        exec_update_task(&mut tx, &task)?;
+        update_job_summary(&mut tx, &report.job_id, report.run_id, report.now_ms)?;
+        tx.commit().map_err(mysql_err)?;
+        Ok(true)
+    }
+}
+
+fn init_schema(conn: &mut PooledConn) -> FsResult<()> {
+    conn.query_drop(
+        "create table if not exists transfer_schema_version (
+            id tinyint unsigned primary key,
+            version bigint unsigned not null,
+            updated_at bigint not null
+        )",
+    )
+    .map_err(mysql_err)?;
+    let now_ms = orpc::common::LocalTime::mills();
+    conn.exec_drop(
+        "insert ignore into transfer_schema_version(id, version, updated_at)
+         values (1, :version, :updated_at)",
+        params! {
+            "version" => TRANSFER_SCHEMA_VERSION,
+            "updated_at" => now_ms,
+        },
+    )
+    .map_err(mysql_err)?;
+    let version = conn
+        .exec_first::<u64, _, _>(
+            "select version from transfer_schema_version where id = 1",
+            Params::Empty,
+        )
+        .map_err(mysql_err)?
+        .ok_or_else(|| FsError::common("Missing mysql transfer schema version"))?;
+    migrate_mysql_schema(conn, version, now_ms)?;
+
+    conn.query_drop(
+        "create table if not exists transfer_jobs (
+            job_id varchar(128) primary key,
+            submitter varchar(255) not null,
+            tenant varchar(255) not null,
+            client_request_id varchar(255) not null,
+            job_key varchar(1024) not null,
+            target_path varchar(2048) not null,
+            run_id bigint unsigned not null,
+            kind int not null,
+            state int not null,
+            owner varchar(255) not null,
+            lease_epoch bigint unsigned not null,
+            lease_expire_at bigint not null,
+            cancel_requested tinyint not null,
+            record_json longtext not null,
+            created_at bigint not null,
+            updated_at bigint not null,
+            unique key transfer_jobs_request_idx(submitter, client_request_id),
+            key transfer_jobs_job_key_state_idx(job_key(255), state),
+            key transfer_jobs_target_state_idx(target_path(255), state),
+            key transfer_jobs_state_lease_idx(state, lease_expire_at),
+            key transfer_jobs_owner_state_updated_idx(owner, state, updated_at),
+            key transfer_jobs_tenant_state_updated_idx(tenant, state, updated_at),
+            key transfer_jobs_submitter_state_updated_idx(submitter, state, updated_at)
+        )",
+    )
+    .map_err(mysql_err)?;
+    conn.query_drop(
+        "create table if not exists transfer_tasks (
+            job_id varchar(128) not null,
+            run_id bigint unsigned not null,
+            task_id varchar(255) not null,
+            state int not null,
+            attempt_id bigint unsigned not null,
+            worker_id bigint unsigned not null,
+            worker_session_id varchar(255) not null,
+            stale_deadline_at bigint not null,
+            record_json longtext not null,
+            updated_at bigint not null,
+            primary key(job_id, run_id, task_id),
+            key transfer_tasks_job_state_idx(job_id, run_id, state),
+            key transfer_tasks_worker_idx(worker_id, worker_session_id, state),
+            key transfer_tasks_stale_idx(state, stale_deadline_at)
+        )",
+    )
+    .map_err(mysql_err)?;
+    Ok(())
+}
+
+fn migrate_mysql_schema(conn: &mut PooledConn, mut version: u64, now_ms: u64) -> FsResult<()> {
+    if version > TRANSFER_SCHEMA_VERSION {
+        return Err(FsError::common(format!(
+            "Unsupported mysql transfer schema version {}, expected {}",
+            version, TRANSFER_SCHEMA_VERSION
+        )));
+    }
+    if version == 2 {
+        migrate_mysql_schema_v2_to_v3(conn)?;
+        update_mysql_schema_version(conn, TRANSFER_SCHEMA_V3, now_ms)?;
+        version = TRANSFER_SCHEMA_V3;
+    }
+    if version == TRANSFER_SCHEMA_V3 {
+        migrate_mysql_schema_v3_to_v4(conn)?;
+        update_mysql_schema_version(conn, TRANSFER_SCHEMA_VERSION, now_ms)?;
+    } else if version != TRANSFER_SCHEMA_VERSION {
+        return Err(FsError::common(format!(
+            "Unsupported mysql transfer schema version {}, expected {}",
+            version, TRANSFER_SCHEMA_VERSION
+        )));
+    }
+    Ok(())
+}
+
+fn migrate_mysql_schema_v2_to_v3(conn: &mut PooledConn) -> FsResult<()> {
+    if !mysql_column_exists(conn, "transfer_jobs", "target_path")? {
+        conn.query_drop(
+            "alter table transfer_jobs
+             add column target_path varchar(2048) not null default '' after job_key",
+        )
+        .map_err(mysql_err)?;
+    }
+    conn.query_drop(
+        "update transfer_jobs
+         set target_path = json_unquote(json_extract(record_json, '$.target_path'))
+         where target_path = ''",
+    )
+    .map_err(mysql_err)?;
+    create_mysql_target_index(conn)?;
+    Ok(())
+}
+
+fn migrate_mysql_schema_v3_to_v4(conn: &mut PooledConn) -> FsResult<()> {
+    if !mysql_column_exists(conn, "transfer_jobs", "tenant")? {
+        conn.query_drop(
+            "alter table transfer_jobs
+             add column tenant varchar(255) not null default '' after submitter",
+        )
+        .map_err(mysql_err)?;
+    }
+    conn.query_drop(
+        "update transfer_jobs
+         set tenant = coalesce(json_unquote(json_extract(record_json, '$.tenant')), '')
+         where tenant = ''",
+    )
+    .map_err(mysql_err)?;
+    create_mysql_list_indexes(conn)?;
+    Ok(())
+}
+
+fn update_mysql_schema_version(conn: &mut PooledConn, version: u64, now_ms: u64) -> FsResult<()> {
+    conn.exec_drop(
+        "update transfer_schema_version
+         set version = :version, updated_at = :updated_at
+         where id = 1",
+        params! {
+            "version" => version,
+            "updated_at" => now_ms,
+        },
+    )
+    .map_err(mysql_err)?;
+    Ok(())
+}
+
+fn create_mysql_target_index(conn: &mut PooledConn) -> FsResult<()> {
+    conn.query_drop(
+        "create index transfer_jobs_target_state_idx
+         on transfer_jobs(target_path(255), state)",
+    )
+    .or_else(|err| {
+        if mysql_error_code(&err) == Some(1061) {
+            Ok(())
+        } else {
+            Err(err)
+        }
+    })
+    .map_err(mysql_err)?;
+    Ok(())
+}
+
+fn create_mysql_list_indexes(conn: &mut PooledConn) -> FsResult<()> {
+    conn.query_drop(
+        "create index transfer_jobs_tenant_state_updated_idx
+         on transfer_jobs(tenant, state, updated_at)",
+    )
+    .or_else(|err| {
+        if mysql_error_code(&err) == Some(1061) {
+            Ok(())
+        } else {
+            Err(err)
+        }
+    })
+    .map_err(mysql_err)?;
+    conn.query_drop(
+        "create index transfer_jobs_submitter_state_updated_idx
+         on transfer_jobs(submitter, state, updated_at)",
+    )
+    .or_else(|err| {
+        if mysql_error_code(&err) == Some(1061) {
+            Ok(())
+        } else {
+            Err(err)
+        }
+    })
+    .map_err(mysql_err)?;
+    Ok(())
+}
+
+fn mysql_column_exists(conn: &mut PooledConn, table: &str, column: &str) -> FsResult<bool> {
+    conn.exec_first::<String, _, _>(
+        "select column_name from information_schema.columns
+         where table_schema = database()
+           and table_name = :table
+           and column_name = :column",
+        params! {
+            "table" => table,
+            "column" => column,
+        },
+    )
+    .map(|value| value.is_some())
+    .map_err(mysql_err)
+}
+
+fn insert_job(conn: &mut impl Queryable, job: &TransferJobRecord) -> FsResult<()> {
+    let _ = exec_affected(
+        conn,
+        "insert into transfer_jobs (
+            job_id, submitter, tenant, client_request_id, job_key, target_path, run_id, kind, state, owner, lease_epoch,
+            lease_expire_at, cancel_requested, record_json, created_at, updated_at
+        ) values (
+            :job_id, :submitter, :tenant, :client_request_id, :job_key, :target_path, :run_id, :kind, :state, :owner,
+            :lease_epoch, :lease_expire_at, :cancel_requested, :record_json, :created_at, :updated_at
+        )",
+        job_params(job)?,
+    )?;
+    Ok(())
+}
+
+fn insert_task(conn: &mut impl Queryable, task: &TransferTaskRecord) -> FsResult<()> {
+    let _ = exec_affected(
+        conn,
+        "insert ignore into transfer_tasks (
+            job_id, run_id, task_id, state, attempt_id, worker_id, worker_session_id,
+            stale_deadline_at, record_json, updated_at
+        ) values (
+            :job_id, :run_id, :task_id, :state, :attempt_id, :worker_id, :worker_session_id,
+            :stale_deadline_at, :record_json, :updated_at
+        )",
+        task_params(task)?,
+    )?;
+    Ok(())
+}
+
+fn select_job_by_id(
+    conn: &mut impl Queryable,
+    job_id: &str,
+) -> FsResult<Option<TransferJobRecord>> {
+    select_job(
+        conn,
+        "select record_json from transfer_jobs where job_id = :job_id",
+        params! { "job_id" => job_id },
+    )
+}
+
+fn select_job_by_id_for_update(
+    conn: &mut impl Queryable,
+    job_id: &str,
+) -> FsResult<Option<TransferJobRecord>> {
+    select_job(
+        conn,
+        "select record_json from transfer_jobs where job_id = :job_id for update",
+        params! { "job_id" => job_id },
+    )
+}
+
+fn select_job_by_request(
+    conn: &mut impl Queryable,
+    submitter: &str,
+    client_request_id: &str,
+) -> FsResult<Option<TransferJobRecord>> {
+    select_job(
+        conn,
+        "select record_json from transfer_jobs
+         where submitter = :submitter and client_request_id = :client_request_id",
+        params! { "submitter" => submitter, "client_request_id" => client_request_id },
+    )
+}
+
+fn select_non_terminal_job_by_key(
+    conn: &mut impl Queryable,
+    job_key: &str,
+) -> FsResult<Option<TransferJobRecord>> {
+    select_job(
+        conn,
+        "select record_json from transfer_jobs
+         where job_key = :job_key and state not in (6, 7, 8)
+         limit 1",
+        params! { "job_key" => job_key },
+    )
+}
+
+fn select_conflicting_active_transfer(
+    conn: &mut impl Queryable,
+    target_path: &str,
+    submitter: &str,
+    client_request_id: &str,
+) -> FsResult<Option<TransferJobRecord>> {
+    let (child_lower, child_upper) = child_path_bounds(target_path);
+    let exact_or_child = select_job(
+        conn,
+        "select record_json from transfer_jobs
+         where state not in (6, 7, 8)
+           and not (submitter = :submitter and client_request_id = :client_request_id)
+           and (
+               target_path = :target_path
+               or (target_path >= :child_lower and target_path < :child_upper)
+           )
+         limit 1
+         for update",
+        params! {
+            "target_path" => target_path,
+            "submitter" => submitter,
+            "client_request_id" => client_request_id,
+            "child_lower" => child_lower,
+            "child_upper" => child_upper,
+        },
+    )?;
+    if exact_or_child.is_some() {
+        return Ok(exact_or_child);
+    }
+
+    for ancestor in ancestor_paths(target_path) {
+        let ancestor_conflict = select_job(
+            conn,
+            "select record_json from transfer_jobs
+             where state not in (6, 7, 8)
+               and not (submitter = :submitter and client_request_id = :client_request_id)
+               and target_path = :target_path
+             limit 1
+             for update",
+            params! {
+                "target_path" => ancestor,
+                "submitter" => submitter,
+                "client_request_id" => client_request_id,
+            },
+        )?;
+        if ancestor_conflict.is_some() {
+            return Ok(ancestor_conflict);
+        }
+    }
+    Ok(None)
+}
+
+fn select_job(
+    conn: &mut impl Queryable,
+    sql: &str,
+    params: mysql::Params,
+) -> FsResult<Option<TransferJobRecord>> {
+    let value: Option<String> = conn.exec_first(sql, params).map_err(mysql_err)?;
+    value
+        .map(|json| serde_json::from_str(&json).map_err(json_err))
+        .transpose()
+}
+
+fn ancestor_paths(target_path: &str) -> Vec<String> {
+    if target_path == "/" {
+        return Vec::new();
+    }
+    let mut ancestors = vec!["/".to_string()];
+    let trimmed = target_path.trim_matches('/');
+    let mut current = String::new();
+    let mut parts = trimmed.split('/').peekable();
+    while let Some(part) = parts.next() {
+        if parts.peek().is_none() {
+            break;
+        }
+        current.push('/');
+        current.push_str(part);
+        ancestors.push(current.clone());
+    }
+    ancestors
+}
+
+fn child_path_bounds(target_path: &str) -> (String, String) {
+    let lower = if target_path == "/" {
+        "/".to_string()
+    } else {
+        format!("{}/", target_path.trim_end_matches('/'))
+    };
+    let upper = lexicographic_successor(&lower).unwrap_or_else(|| "\u{10ffff}".to_string());
+    (lower, upper)
+}
+
+fn lexicographic_successor(value: &str) -> Option<String> {
+    let mut bytes = value.as_bytes().to_vec();
+    for index in (0..bytes.len()).rev() {
+        if bytes[index] < u8::MAX {
+            bytes[index] += 1;
+            bytes.truncate(index + 1);
+            return String::from_utf8(bytes).ok();
+        }
+    }
+    None
+}
+
+fn select_jobs(
+    conn: &mut impl Queryable,
+    sql: &str,
+    params: mysql::Params,
+) -> FsResult<Vec<TransferJobRecord>> {
+    let values: Vec<String> = conn.exec(sql, params).map_err(mysql_err)?;
+    values
+        .into_iter()
+        .map(|json| serde_json::from_str(&json).map_err(json_err))
+        .collect()
+}
+
+fn list_filter_mysql_params(filter: &TransferListFilter) -> (String, Vec<MysqlValue>) {
+    let mut clauses = Vec::new();
+    let mut values = Vec::new();
+    if let Some(kind) = filter.kind {
+        clauses.push("kind = ?");
+        values.push(MysqlValue::from(kind as i32));
+    }
+    if let Some(state) = filter.state {
+        clauses.push("state = ?");
+        values.push(MysqlValue::from(state as i32));
+    }
+    if let Some(submitter) = &filter.submitter {
+        clauses.push("submitter = ?");
+        values.push(MysqlValue::from(submitter.as_str()));
+    }
+    if let Some(tenant) = &filter.tenant {
+        clauses.push("tenant = ?");
+        values.push(MysqlValue::from(tenant.as_str()));
+    }
+    if clauses.is_empty() {
+        (String::new(), values)
+    } else {
+        (format!("where {}", clauses.join(" and ")), values)
+    }
+}
+
+fn select_task(
+    conn: &mut impl Queryable,
+    job_id: &str,
+    run_id: u64,
+    task_id: &str,
+) -> FsResult<Option<TransferTaskRecord>> {
+    let value: Option<String> = conn
+        .exec_first(
+            "select record_json from transfer_tasks
+             where job_id = :job_id and run_id = :run_id and task_id = :task_id",
+            params! { "job_id" => job_id, "run_id" => run_id, "task_id" => task_id },
+        )
+        .map_err(mysql_err)?;
+    value
+        .map(|json| serde_json::from_str(&json).map_err(json_err))
+        .transpose()
+}
+
+fn select_task_for_update(
+    conn: &mut impl Queryable,
+    job_id: &str,
+    run_id: u64,
+    task_id: &str,
+) -> FsResult<Option<TransferTaskRecord>> {
+    let value: Option<String> = conn
+        .exec_first(
+            "select record_json from transfer_tasks
+             where job_id = :job_id and run_id = :run_id and task_id = :task_id
+             for update",
+            params! { "job_id" => job_id, "run_id" => run_id, "task_id" => task_id },
+        )
+        .map_err(mysql_err)?;
+    value
+        .map(|json| serde_json::from_str(&json).map_err(json_err))
+        .transpose()
+}
+
+fn select_tasks(
+    conn: &mut impl Queryable,
+    job_id: &str,
+    run_id: u64,
+    state: Option<TransferTaskState>,
+    limit: Option<usize>,
+) -> FsResult<Vec<TransferTaskRecord>> {
+    let mut sql =
+        "select record_json from transfer_tasks where job_id = :job_id and run_id = :run_id"
+            .to_string();
+    if state.is_some() {
+        sql.push_str(" and state = :state");
+    }
+    sql.push_str(" order by updated_at asc");
+    if limit.is_some() {
+        sql.push_str(" limit :limit");
+    }
+    let rows: Vec<String> = conn
+        .exec(
+            sql,
+            params! {
+                "job_id" => job_id,
+                "run_id" => run_id,
+                "state" => state.map(|s| s as i32),
+                "limit" => limit.map(|v| v as u64),
+            },
+        )
+        .map_err(mysql_err)?;
+    rows.into_iter()
+        .map(|json| serde_json::from_str(&json).map_err(json_err))
+        .collect()
+}
+
+fn exec_update_job(conn: &mut impl Queryable, job: &TransferJobRecord) -> FsResult<bool> {
+    let affected = exec_affected(
+        conn,
+        "update transfer_jobs
+         set tenant = :tenant, target_path = :target_path, kind = :kind, state = :state, owner = :owner, lease_epoch = :lease_epoch,
+             lease_expire_at = :lease_expire_at, cancel_requested = :cancel_requested,
+             record_json = :record_json, created_at = :created_at, updated_at = :updated_at
+         where job_id = :job_id and run_id = :run_id",
+        job_params(job)?,
+    )?;
+    Ok(affected > 0)
+}
+
+fn exec_update_task(conn: &mut impl Queryable, task: &TransferTaskRecord) -> FsResult<bool> {
+    let affected = exec_affected(
+        conn,
+        "update transfer_tasks
+         set state = :state, attempt_id = :attempt_id, worker_id = :worker_id,
+             worker_session_id = :worker_session_id, stale_deadline_at = :stale_deadline_at,
+             record_json = :record_json, updated_at = :updated_at
+         where job_id = :job_id and run_id = :run_id and task_id = :task_id",
+        task_params(task)?,
+    )?;
+    Ok(affected > 0)
+}
+
+fn exec_affected(conn: &mut impl Queryable, sql: &str, params: mysql::Params) -> FsResult<u64> {
+    let result = conn.exec_iter(sql, params).map_err(mysql_err)?;
+    Ok(result.affected_rows())
+}
+
+fn update_job_summary(
+    conn: &mut impl Queryable,
+    job_id: &str,
+    run_id: u64,
+    now_ms: i64,
+) -> FsResult<()> {
+    let tasks = select_tasks(conn, job_id, run_id, None, None)?;
+    let mut job = select_job_by_id(conn, job_id)?.ok_or_else(|| FsError::job_not_found(job_id))?;
+    let summary = summarize_transfer_tasks(&tasks, now_ms);
+    job.summary = summary.progress;
+    job.updated_at = now_ms;
+    if summary.has_failed {
+        job.state = TransferState::Failed;
+    } else if summary.has_task && summary.all_completed {
+        job.state = TransferState::Completed;
+    }
+    let _ = exec_update_job(conn, &job)?;
+    Ok(())
+}
+
+fn job_params(job: &TransferJobRecord) -> FsResult<mysql::Params> {
+    Ok(params! {
+        "job_id" => &job.job_id,
+        "submitter" => &job.submitter,
+        "tenant" => &job.tenant,
+        "client_request_id" => &job.client_request_id,
+        "job_key" => &job.job_key,
+        "target_path" => &job.target_path,
+        "run_id" => job.run_id,
+        "kind" => job.kind as i32,
+        "state" => job.state as i32,
+        "owner" => &job.owner,
+        "lease_epoch" => job.lease_epoch,
+        "lease_expire_at" => job.lease_expire_at,
+        "cancel_requested" => job.cancel_requested,
+        "record_json" => json(job)?,
+        "created_at" => job.created_at,
+        "updated_at" => job.updated_at,
+    })
+}
+
+fn task_params(task: &TransferTaskRecord) -> FsResult<mysql::Params> {
+    Ok(params! {
+        "job_id" => &task.job_id,
+        "run_id" => task.run_id,
+        "task_id" => &task.task_id,
+        "state" => task.state as i32,
+        "attempt_id" => task.attempt_id,
+        "worker_id" => task.worker_id,
+        "worker_session_id" => &task.worker_session_id,
+        "stale_deadline_at" => task.stale_deadline_at,
+        "record_json" => json(task)?,
+        "updated_at" => task.updated_at,
+    })
+}
+
+fn json<T: serde::Serialize>(value: &T) -> FsResult<String> {
+    serde_json::to_string(value).map_err(json_err)
+}
+
+fn json_err(_: serde_json::Error) -> FsError {
+    FsError::common("Transfer metadata store contains invalid data")
+}
+
+fn mysql_err(err: mysql::Error) -> FsError {
+    log::warn!("transfer MySQL store operation failed: {}", err);
+    FsError::transfer_store_unavailable(
+        "Transfer metadata store is unavailable; verify transfer.store_url and database connectivity",
+    )
+}
+
+fn mysql_error_code(err: &mysql::Error) -> Option<u16> {
+    match err {
+        mysql::Error::MySqlError(err) => Some(err.code),
+        _ => None,
+    }
+}


### PR DESCRIPTION
# Summary

Adds the MySQL Transfer metadata store for shared service deployments.

# Issue Describe / Design

Part of the standalone Transfer service. This review layer is stacked deliberately so that protocol, metadata storage, scheduling, worker execution, client routing, and deployment can be reviewed independently.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-server/src/transfer/mysql_store.rs` | Adds the MySQL Transfer metadata store for shared service deployments. | New Transfer behavior; legacy behavior remains available unless Transfer is enabled. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-server --test transfer mysql_` | PASS | Rebased onto upstream main `497d078d`. |

# Dependencies

- Related PRs: #1345
- Related issues: #1040
- Blocks / blocked by: #1345