### PR TITLE
feat(master): add metadata snapshot RPCs

### DIFF
--- a/curvine-client/src/file/curvine_filesystem.rs
+++ b/curvine-client/src/file/curvine_filesystem.rs
@@ -21,6 +21,7 @@ use curvine_common::alloc::allocator_type_name;
 use curvine_common::conf::ClusterConf;
 use curvine_common::error::FsError;
 use curvine_common::fs::{FileSystem, FsKind, ListStream, Path, Reader, Writer};
+use curvine_common::proto::{GetCvMetadataDeltaPageResponse, GetCvMetadataSnapshotPageResponse};
 use curvine_common::state::{CommitBlock, FreeResult, ListOptions};
 use curvine_common::state::{
     CreateFileOpts, CreateFileOptsBuilder, FileAllocOpts, FileBlocks, FileLock, FileStatus,
@@ -196,6 +197,28 @@ impl CurvineFileSystem {
 
     pub async fn list_status_bytes(&self, path: &Path) -> FsResult<BytesMut> {
         self.fs_client.list_status_bytes(path).await
+    }
+
+    pub async fn get_cv_metadata_snapshot_page(
+        &self,
+        page_token: Option<String>,
+        page_size: Option<u32>,
+    ) -> FsResult<GetCvMetadataSnapshotPageResponse> {
+        self.fs_client
+            .get_cv_metadata_snapshot_page(page_token, page_size)
+            .await
+    }
+
+    pub async fn get_cv_metadata_delta_page(
+        &self,
+        from_epoch: u64,
+        target_epoch: Option<u64>,
+        page_token: Option<String>,
+        page_size: Option<u32>,
+    ) -> FsResult<GetCvMetadataDeltaPageResponse> {
+        self.fs_client
+            .get_cv_metadata_delta_page(from_epoch, target_epoch, page_token, page_size)
+            .await
     }
 
     pub async fn list_options(&self, path: &Path, opts: ListOptions) -> FsResult<Vec<FileStatus>> {

--- a/curvine-client/src/file/fs_client.rs
+++ b/curvine-client/src/file/fs_client.rs
@@ -452,6 +452,34 @@ impl FsClient {
         Ok(res)
     }
 
+    pub async fn get_cv_metadata_snapshot_page(
+        &self,
+        page_token: Option<String>,
+        page_size: Option<u32>,
+    ) -> FsResult<GetCvMetadataSnapshotPageResponse> {
+        let header = GetCvMetadataSnapshotPageRequest {
+            page_token,
+            page_size,
+        };
+        self.rpc(RpcCode::GetCvMetadataSnapshotPage, header).await
+    }
+
+    pub async fn get_cv_metadata_delta_page(
+        &self,
+        from_epoch: u64,
+        target_epoch: Option<u64>,
+        page_token: Option<String>,
+        page_size: Option<u32>,
+    ) -> FsResult<GetCvMetadataDeltaPageResponse> {
+        let header = GetCvMetadataDeltaPageRequest {
+            from_epoch,
+            target_epoch,
+            page_token,
+            page_size,
+        };
+        self.rpc(RpcCode::GetCvMetadataDeltaPage, header).await
+    }
+
     pub async fn get_master_info_bytes(&self) -> FsResult<BytesMut> {
         let header = GetMasterInfoRequest::default();
         self.rpc_bytes(RpcCode::GetMasterInfo, header).await

--- a/curvine-client/src/rpc/mod.rs
+++ b/curvine-client/src/rpc/mod.rs
@@ -14,3 +14,6 @@
 
 mod job_master_client;
 pub use self::job_master_client::JobMasterClient;
+
+mod transfer_client;
+pub use self::transfer_client::TransferClient;

--- a/curvine-client/src/rpc/transfer_client.rs
+++ b/curvine-client/src/rpc/transfer_client.rs
@@ -1,0 +1,266 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use curvine_common::error::FsError;
+use curvine_common::fs::RpcCode;
+use curvine_common::proto::{
+    CancelTransferRequest, CancelTransferResponse, GetTransferStatusRequest,
+    GetTransferStatusResponse, ListTransferTenantsRequest, ListTransferTenantsResponse,
+    ListTransfersRequest, ListTransfersResponse, RetryTransferRequest, SubmitTransferRequest,
+    SubmitTransferResponse, TransferProgressProto, TransferTaskReportRequest,
+    TransferTaskReportResponse, WatchTransferRequest, WatchTransferResponse,
+};
+use curvine_common::state::{
+    JobTaskProgress, JobTaskState, TransferCommand, TransferKind, TransferState,
+    TransferTaskReportInfo,
+};
+use curvine_common::utils::SerdeUtils;
+use curvine_common::FsResult;
+use orpc::client::ClusterConnector;
+use orpc::io::net::NodeAddr;
+use orpc::runtime::Runtime;
+
+use crate::file::FsContext;
+
+const TRANSFER_PROTOCOL_VERSION: u32 = 1;
+
+#[derive(Clone)]
+pub struct TransferClient {
+    connector: Arc<ClusterConnector>,
+}
+
+impl TransferClient {
+    pub fn with_context(context: &Arc<FsContext>) -> FsResult<Self> {
+        Self::with_endpoints(
+            context.conf.client_rpc_conf(),
+            context.clone_runtime(),
+            transfer_endpoints(context),
+        )
+    }
+
+    pub fn with_endpoint(context: &Arc<FsContext>, endpoint: impl Into<String>) -> FsResult<Self> {
+        Self::with_report_endpoints(context, vec![endpoint.into()])
+    }
+
+    pub fn with_report_endpoints(
+        context: &Arc<FsContext>,
+        endpoints: Vec<String>,
+    ) -> FsResult<Self> {
+        Self::with_endpoints(
+            context.conf.client_rpc_conf(),
+            context.clone_runtime(),
+            endpoints,
+        )
+    }
+
+    pub fn with_rt(conf: &curvine_common::conf::ClusterConf, rt: Arc<Runtime>) -> FsResult<Self> {
+        Self::with_endpoints(
+            conf.client_rpc_conf(),
+            rt,
+            transfer_endpoints_from_conf(conf),
+        )
+    }
+
+    fn with_endpoints(
+        conf: orpc::client::ClientConf,
+        rt: Arc<Runtime>,
+        endpoints: Vec<String>,
+    ) -> FsResult<Self> {
+        let connector = ClusterConnector::with_rt(conf, rt);
+        for endpoint in endpoints {
+            connector.add_node(NodeAddr::from_str(endpoint)?)?;
+        }
+        Ok(Self {
+            connector: Arc::new(connector),
+        })
+    }
+
+    pub async fn submit(&self, command: TransferCommand) -> FsResult<SubmitTransferResponse> {
+        let req = SubmitTransferRequest {
+            kind: transfer_kind_code(command.kind),
+            source_path: command.source_path.clone(),
+            target_path: command.target_path.clone(),
+            client_request_id: command.client_request_id.clone(),
+            submitter: command.submitter.clone(),
+            tenant: command.tenant.clone(),
+            command: SerdeUtils::serialize_json(&command)?,
+            protocol_version: Some(TRANSFER_PROTOCOL_VERSION),
+        };
+        self.connector
+            .proto_rpc::<_, SubmitTransferResponse, FsError>(RpcCode::SubmitTransfer, req)
+            .await
+    }
+
+    pub async fn status(&self, job_id: impl AsRef<str>) -> FsResult<GetTransferStatusResponse> {
+        self.status_page(job_id, None, None).await
+    }
+
+    pub async fn retry(&self, job_id: impl AsRef<str>) -> FsResult<SubmitTransferResponse> {
+        let req = RetryTransferRequest {
+            job_id: job_id.as_ref().to_string(),
+        };
+        self.connector
+            .proto_rpc::<_, SubmitTransferResponse, FsError>(RpcCode::RetryTransfer, req)
+            .await
+    }
+
+    pub async fn status_page(
+        &self,
+        job_id: impl AsRef<str>,
+        page_size: Option<u32>,
+        page_token: Option<String>,
+    ) -> FsResult<GetTransferStatusResponse> {
+        let req = GetTransferStatusRequest {
+            job_id: job_id.as_ref().to_string(),
+            page_size,
+            page_token,
+        };
+        self.connector
+            .proto_rpc::<_, GetTransferStatusResponse, FsError>(RpcCode::GetTransferStatus, req)
+            .await
+    }
+
+    pub async fn list(
+        &self,
+        kind: Option<TransferKind>,
+        state: Option<TransferState>,
+        submitter: Option<String>,
+        tenant: Option<String>,
+        page_size: Option<u32>,
+        page_token: Option<String>,
+    ) -> FsResult<ListTransfersResponse> {
+        let req = ListTransfersRequest {
+            kind: kind.map(transfer_kind_code),
+            state: state.map(transfer_state_code),
+            page_size,
+            page_token,
+            submitter,
+            tenant,
+        };
+        self.connector
+            .proto_rpc::<_, ListTransfersResponse, FsError>(RpcCode::ListTransfers, req)
+            .await
+    }
+
+    pub async fn list_tenants(
+        &self,
+        page_size: Option<u32>,
+        page_token: Option<String>,
+    ) -> FsResult<ListTransferTenantsResponse> {
+        let req = ListTransferTenantsRequest {
+            page_size,
+            page_token,
+        };
+        self.connector
+            .proto_rpc::<_, ListTransferTenantsResponse, FsError>(RpcCode::ListTransferTenants, req)
+            .await
+    }
+
+    pub async fn watch(
+        &self,
+        job_id: impl AsRef<str>,
+        since_updated_at: Option<u64>,
+        page_size: Option<u32>,
+        page_token: Option<String>,
+    ) -> FsResult<WatchTransferResponse> {
+        let req = WatchTransferRequest {
+            job_id: job_id.as_ref().to_string(),
+            since_updated_at,
+            page_size,
+            page_token,
+        };
+        self.connector
+            .proto_rpc::<_, WatchTransferResponse, FsError>(RpcCode::WatchTransfer, req)
+            .await
+    }
+
+    pub async fn cancel(
+        &self,
+        job_id: impl AsRef<str>,
+        run_id: Option<u64>,
+    ) -> FsResult<CancelTransferResponse> {
+        let req = CancelTransferRequest {
+            job_id: job_id.as_ref().to_string(),
+            run_id,
+        };
+        self.connector
+            .proto_rpc::<_, CancelTransferResponse, FsError>(RpcCode::CancelTransfer, req)
+            .await
+    }
+
+    pub async fn report_task(
+        &self,
+        job_id: impl AsRef<str>,
+        task_id: impl AsRef<str>,
+        info: &TransferTaskReportInfo,
+        progress: JobTaskProgress,
+    ) -> FsResult<bool> {
+        let req = TransferTaskReportRequest {
+            job_id: job_id.as_ref().to_string(),
+            run_id: info.run_id,
+            task_id: task_id.as_ref().to_string(),
+            attempt_id: info.attempt_id,
+            worker_id: info.worker_id,
+            worker_session_id: info.worker_session_id.clone(),
+            state: transfer_task_state_code(progress.state),
+            progress: TransferProgressProto {
+                loaded_size: progress.loaded_size,
+                total_size: progress.total_size,
+                update_time: progress.update_time,
+                message: progress.message,
+            },
+            protocol_version: Some(TRANSFER_PROTOCOL_VERSION),
+        };
+        let response = self
+            .connector
+            .proto_rpc::<_, TransferTaskReportResponse, FsError>(RpcCode::ReportTransferTask, req)
+            .await?;
+        Ok(response.accepted)
+    }
+}
+
+fn transfer_endpoints(context: &Arc<FsContext>) -> Vec<String> {
+    transfer_endpoints_from_conf(&context.conf)
+}
+
+fn transfer_endpoints_from_conf(conf: &curvine_common::conf::ClusterConf) -> Vec<String> {
+    if conf.transfer.endpoints.is_empty() {
+        vec![format!(
+            "{}:{}",
+            conf.transfer.hostname, conf.transfer.rpc_port
+        )]
+    } else {
+        conf.transfer.endpoints.clone()
+    }
+}
+
+fn transfer_kind_code(kind: TransferKind) -> i32 {
+    kind as i32
+}
+
+fn transfer_state_code(state: TransferState) -> i32 {
+    state as i32
+}
+
+fn transfer_task_state_code(state: JobTaskState) -> i32 {
+    match state {
+        JobTaskState::Pending | JobTaskState::UNKNOWN => 1,
+        JobTaskState::Loading => 2,
+        JobTaskState::Completed => 3,
+        JobTaskState::Failed => 4,
+        JobTaskState::Canceled => 5,
+    }
+}

--- a/curvine-server/src/master/fs/master_filesystem.rs
+++ b/curvine-server/src/master/fs/master_filesystem.rs
@@ -32,8 +32,32 @@ use orpc::runtime::GroupExecutor;
 use orpc::sync::ArcRwLock;
 use orpc::{err_box, err_ext, try_option, CommonResult};
 use parking_lot::Mutex;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
+
+pub struct CvMetadataSnapshotEntry {
+    pub status: FileStatus,
+    pub blocks: Option<FileBlocks>,
+}
+
+pub struct CvMetadataSnapshotPage {
+    pub entries: Vec<CvMetadataSnapshotEntry>,
+    pub next_page_token: Option<String>,
+    pub epoch: u64,
+}
+
+pub struct CvMetadataDeltaEntry {
+    pub path: String,
+    pub entry: Option<CvMetadataSnapshotEntry>,
+}
+
+pub struct CvMetadataDeltaPage {
+    pub entries: Vec<CvMetadataDeltaEntry>,
+    pub next_page_token: Option<String>,
+    pub from_epoch: u64,
+    pub to_epoch: u64,
+    pub full_snapshot_required: bool,
+}
 
 #[derive(Clone)]
 pub struct MasterFilesystem {
@@ -54,6 +78,23 @@ pub(crate) enum BlockInodeState {
     File,
     Missing,
     NotFile,
+}
+
+fn child_snapshot_path(parent: &str, child_name: &str) -> String {
+    if parent == "/" {
+        format!("/{child_name}")
+    } else {
+        format!("{parent}/{child_name}")
+    }
+}
+
+fn snapshot_token_in_subtree(token: &str, subtree_path: &str) -> bool {
+    token == subtree_path
+        || (subtree_path != "/"
+            && token
+                .strip_prefix(subtree_path)
+                .map(|rest| rest.starts_with(PATH_SEPARATOR))
+                .unwrap_or(false))
 }
 
 struct FullBlockReportState {
@@ -708,6 +749,279 @@ impl MasterFilesystem {
         };
 
         Ok(locate_blocks)
+    }
+
+    pub fn cv_metadata_snapshot_page(
+        &self,
+        page_token: Option<String>,
+        page_size: usize,
+    ) -> FsResult<CvMetadataSnapshotPage> {
+        if page_size == 0 {
+            return err_box!("cv metadata snapshot page_size must be greater than 0");
+        }
+
+        let fs_dir = self.fs_dir.read();
+        let epoch = fs_dir.op_id.get();
+        let start_after = page_token.filter(|token| !token.is_empty());
+        let mut entries = Vec::with_capacity(page_size.saturating_add(1));
+        self.collect_cv_metadata_snapshot_page(
+            &fs_dir,
+            fs_dir.root_dir(),
+            "/",
+            start_after.as_deref(),
+            page_size.saturating_add(1),
+            &mut entries,
+        )?;
+
+        let next_page_token = if entries.len() > page_size {
+            let token = entries
+                .get(page_size.saturating_sub(1))
+                .map(|entry| entry.status.path.clone());
+            entries.truncate(page_size);
+            token
+        } else {
+            None
+        };
+
+        Ok(CvMetadataSnapshotPage {
+            entries,
+            next_page_token,
+            epoch,
+        })
+    }
+
+    pub fn cv_metadata_delta_page(
+        &self,
+        from_epoch: u64,
+        target_epoch: Option<u64>,
+        page_token: Option<String>,
+        page_size: usize,
+    ) -> FsResult<CvMetadataDeltaPage> {
+        if page_size == 0 {
+            return err_box!("cv metadata delta page_size must be greater than 0");
+        }
+
+        let fs_dir = self.fs_dir.read();
+        let current_epoch = fs_dir.op_id.get();
+        let to_epoch = target_epoch.unwrap_or(current_epoch);
+        if to_epoch > current_epoch {
+            return err_box!(
+                "cv metadata delta target_epoch {} is newer than current epoch {}",
+                to_epoch,
+                current_epoch
+            );
+        }
+        if from_epoch > to_epoch {
+            return err_box!(
+                "cv metadata delta from_epoch {} is newer than target epoch {}",
+                from_epoch,
+                to_epoch
+            );
+        }
+        if target_epoch.is_some() && to_epoch < current_epoch {
+            return Ok(CvMetadataDeltaPage {
+                entries: Vec::new(),
+                next_page_token: None,
+                from_epoch,
+                to_epoch,
+                full_snapshot_required: true,
+            });
+        }
+        if from_epoch == to_epoch {
+            return Ok(CvMetadataDeltaPage {
+                entries: Vec::new(),
+                next_page_token: None,
+                from_epoch,
+                to_epoch,
+                full_snapshot_required: false,
+            });
+        }
+
+        let Some(changes) = fs_dir
+            .journal_writer
+            .cv_metadata_changes_since(from_epoch, to_epoch)
+        else {
+            return Ok(CvMetadataDeltaPage {
+                entries: Vec::new(),
+                next_page_token: None,
+                from_epoch,
+                to_epoch,
+                full_snapshot_required: true,
+            });
+        };
+
+        let mut changed_paths = BTreeMap::new();
+        for change in changes {
+            changed_paths
+                .entry(change.path)
+                .and_modify(|include_subtree| *include_subtree |= change.include_subtree)
+                .or_insert(change.include_subtree);
+        }
+
+        let mut delta_entries = BTreeMap::new();
+        for (path, include_subtree) in changed_paths {
+            if include_subtree {
+                self.collect_cv_metadata_delta_subtree(&fs_dir, &path, &mut delta_entries)?;
+            } else {
+                let entry = self.cv_metadata_entry_for_path(&fs_dir, &path)?;
+                delta_entries.insert(path, entry);
+            }
+        }
+
+        let start_after = page_token.filter(|token| !token.is_empty());
+        let mut page_entries = Vec::with_capacity(page_size.saturating_add(1));
+        for (path, entry) in delta_entries {
+            if start_after
+                .as_deref()
+                .map(|token| path.as_str() <= token)
+                .unwrap_or(false)
+            {
+                continue;
+            }
+            page_entries.push(CvMetadataDeltaEntry { path, entry });
+            if page_entries.len() > page_size {
+                break;
+            }
+        }
+
+        let next_page_token = if page_entries.len() > page_size {
+            let token = page_entries
+                .get(page_size.saturating_sub(1))
+                .map(|entry| entry.path.clone());
+            page_entries.truncate(page_size);
+            token
+        } else {
+            None
+        };
+
+        Ok(CvMetadataDeltaPage {
+            entries: page_entries,
+            next_page_token,
+            from_epoch,
+            to_epoch,
+            full_snapshot_required: false,
+        })
+    }
+
+    fn collect_cv_metadata_delta_subtree(
+        &self,
+        fs_dir: &FsDir,
+        path: &str,
+        entries: &mut BTreeMap<String, Option<CvMetadataSnapshotEntry>>,
+    ) -> FsResult<()> {
+        let Some(entry) = self.cv_metadata_entry_for_path(fs_dir, path)? else {
+            entries.insert(path.to_string(), None);
+            return Ok(());
+        };
+
+        let is_dir = entry.status.is_dir;
+        entries.insert(path.to_string(), Some(entry));
+        if !is_dir {
+            return Ok(());
+        }
+
+        let inp = Self::resolve_path(fs_dir, path)?;
+        let Some(inode) = inp.get_last_inode() else {
+            return Ok(());
+        };
+        let resolved = self.resolve_snapshot_inode(fs_dir, &inode)?;
+        if let InodeView::Dir(dir) = resolved {
+            for child in dir.children_iter() {
+                let child_path = child_snapshot_path(path, child.name());
+                self.collect_cv_metadata_delta_subtree(fs_dir, &child_path, entries)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn cv_metadata_entry_for_path(
+        &self,
+        fs_dir: &FsDir,
+        path: &str,
+    ) -> FsResult<Option<CvMetadataSnapshotEntry>> {
+        let inp = match Self::resolve_path(fs_dir, path) {
+            Ok(inp) => inp,
+            Err(_) => return Ok(None),
+        };
+        let Some(inode) = inp.get_last_inode() else {
+            return Ok(None);
+        };
+        let resolved = self.resolve_snapshot_inode(fs_dir, &inode)?;
+        let status = resolved.to_file_status(path)?;
+        let blocks = if let Ok(file) = resolved.as_file_ref() {
+            Some(FileBlocks::new(
+                status.clone(),
+                self.get_block_locs(path, fs_dir, file)?,
+            ))
+        } else {
+            None
+        };
+        Ok(Some(CvMetadataSnapshotEntry { status, blocks }))
+    }
+
+    fn collect_cv_metadata_snapshot_page(
+        &self,
+        fs_dir: &FsDir,
+        inode: &InodeView,
+        path: &str,
+        start_after: Option<&str>,
+        limit: usize,
+        entries: &mut Vec<CvMetadataSnapshotEntry>,
+    ) -> FsResult<()> {
+        if entries.len() >= limit {
+            return Ok(());
+        }
+        if let Some(token) = start_after {
+            if path != "/" && token > path && !snapshot_token_in_subtree(token, path) {
+                return Ok(());
+            }
+        }
+
+        let resolved = self.resolve_snapshot_inode(fs_dir, inode)?;
+        if start_after.map(|token| path > token).unwrap_or(true) {
+            let status = resolved.to_file_status(path)?;
+            let blocks = if let Ok(file) = resolved.as_file_ref() {
+                Some(FileBlocks::new(
+                    status.clone(),
+                    self.get_block_locs(path, fs_dir, file)?,
+                ))
+            } else {
+                None
+            };
+            entries.push(CvMetadataSnapshotEntry { status, blocks });
+            if entries.len() >= limit {
+                return Ok(());
+            }
+        }
+
+        if let InodeView::Dir(dir) = resolved {
+            for child in dir.children_iter() {
+                let child_path = child_snapshot_path(path, child.name());
+                self.collect_cv_metadata_snapshot_page(
+                    fs_dir,
+                    child,
+                    &child_path,
+                    start_after,
+                    limit,
+                    entries,
+                )?;
+                if entries.len() >= limit {
+                    return Ok(());
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn resolve_snapshot_inode(&self, fs_dir: &FsDir, inode: &InodeView) -> FsResult<InodeView> {
+        if let InodeView::FileEntry(entry) = inode {
+            return fs_dir
+                .store
+                .get_inode(entry.id, Some(&entry.name))?
+                .ok_or_else(|| FsError::file_not_found(entry.name.clone()));
+        }
+        Ok(inode.clone())
     }
 
     pub fn master_info(&self) -> FsResult<MasterInfo> {

--- a/curvine-server/src/master/job/job_worker_client.rs
+++ b/curvine-server/src/master/job/job_worker_client.rs
@@ -41,13 +41,29 @@ impl JobWorkerClient {
         RpcUtils::proto_rpc(&self.client, self.timeout, code, header).await
     }
 
-    pub async fn submit_load_task(&self, task: LoadTaskInfo) -> FsResult<()> {
+    pub async fn submit_load_task_response(
+        &self,
+        task: LoadTaskInfo,
+    ) -> FsResult<SubmitTaskResponse> {
         let request = SubmitTaskRequest {
             task_type: JobTaskType::Load.into(),
             task_command: SerdeUtils::serialize(&task)?,
         };
 
-        let _: SubmitTaskResponse = self.rpc(RpcCode::SubmitTask, request).await?;
+        self.rpc(RpcCode::SubmitTask, request).await
+    }
+
+    pub async fn submit_load_task(&self, task: LoadTaskInfo) -> FsResult<()> {
+        let response = self.submit_load_task_response(task).await?;
+        if !response.accepted.unwrap_or(true) {
+            return Err(curvine_common::error::FsError::common(format!(
+                "Worker rejected load task {}: {}",
+                response.task_id,
+                response
+                    .reject_reason
+                    .unwrap_or_else(|| "no reason provided".to_string())
+            )));
+        }
         Ok(())
     }
 
@@ -58,5 +74,24 @@ impl JobWorkerClient {
 
         let _: CancelJobResponse = self.rpc(RpcCode::CancelJob, request).await?;
         Ok(())
+    }
+
+    pub async fn query_transfer_task(
+        &self,
+        job_id: impl AsRef<str>,
+        run_id: u64,
+        task_id: impl AsRef<str>,
+        attempt_id: u64,
+        worker_session_id: impl AsRef<str>,
+    ) -> FsResult<QueryTransferTaskResponse> {
+        let request = QueryTransferTaskRequest {
+            job_id: job_id.as_ref().to_string(),
+            run_id,
+            task_id: task_id.as_ref().to_string(),
+            attempt_id,
+            worker_session_id: worker_session_id.as_ref().to_string(),
+        };
+
+        self.rpc(RpcCode::QueryTransferTask, request).await
     }
 }

--- a/curvine-server/src/master/journal/entry.rs
+++ b/curvine-server/src/master/journal/entry.rs
@@ -17,6 +17,13 @@ use crate::master::meta::BlockMeta;
 use curvine_common::state::{CommitBlock, FileLock, MountInfo, SetAttrOpts};
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Clone)]
+pub(crate) struct CvMetadataChange {
+    pub(crate) op_id: u64,
+    pub(crate) path: String,
+    pub(crate) include_subtree: bool,
+}
+
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct MkdirEntry {
     pub(crate) op_id: u64,
@@ -244,6 +251,52 @@ impl JournalEntry {
             JournalEntry::Symlink(e) => Some(e.new_inode.id),
             JournalEntry::SetLocks(e) => Some(e.ino),
             _ => None,
+        }
+    }
+
+    pub(crate) fn cv_metadata_changes(&self) -> Vec<CvMetadataChange> {
+        match self {
+            JournalEntry::Mkdir(e) => vec![CvMetadataChange::single(e.op_id, &e.path)],
+            JournalEntry::CreateFile(e) => vec![CvMetadataChange::single(e.op_id, &e.path)],
+            JournalEntry::ReopenFile(e) => vec![CvMetadataChange::single(e.op_id, &e.path)],
+            JournalEntry::OverWriteFile(e) => vec![CvMetadataChange::single(e.op_id, &e.path)],
+            JournalEntry::AddBlock(e) => vec![CvMetadataChange::single(e.op_id, &e.path)],
+            JournalEntry::CompleteFile(e) => vec![CvMetadataChange::single(e.op_id, &e.path)],
+            JournalEntry::Rename(e) => vec![
+                CvMetadataChange::subtree(e.op_id, &e.src),
+                CvMetadataChange::subtree(e.op_id, &e.dst),
+            ],
+            JournalEntry::Delete(e) => vec![CvMetadataChange::subtree(e.op_id, &e.path)],
+            JournalEntry::SetAttr(e) => vec![CvMetadataChange::single(e.op_id, &e.path)],
+            JournalEntry::Symlink(e) => vec![CvMetadataChange::single(e.op_id, &e.link)],
+            JournalEntry::Link(e) => vec![
+                CvMetadataChange::single(e.op_id, &e.src_path),
+                CvMetadataChange::single(e.op_id, &e.dst_path),
+            ],
+            JournalEntry::Free(e) => vec![CvMetadataChange::subtree(e.op_id, &e.path)],
+            JournalEntry::Mount(_)
+            | JournalEntry::UnMount(_)
+            | JournalEntry::SetLocks(_)
+            | JournalEntry::UfsApplied(_)
+            | JournalEntry::Snapshot(_) => Vec::new(),
+        }
+    }
+}
+
+impl CvMetadataChange {
+    fn single(op_id: u64, path: &str) -> Self {
+        Self {
+            op_id,
+            path: path.to_string(),
+            include_subtree: false,
+        }
+    }
+
+    fn subtree(op_id: u64, path: &str) -> Self {
+        Self {
+            op_id,
+            path: path.to_string(),
+            include_subtree: true,
         }
     }
 }

--- a/curvine-server/src/master/journal/journal_writer.rs
+++ b/curvine-server/src/master/journal/journal_writer.rs
@@ -27,6 +27,7 @@ use orpc::common::LocalTime;
 use orpc::err_box;
 use orpc::sync::channel::{BlockingChannel, BlockingReceiver, BlockingSender};
 use orpc::sync::AtomicCounter;
+use std::collections::VecDeque;
 use std::sync::Mutex;
 
 // Write metadata operation logs.
@@ -36,9 +37,17 @@ pub struct JournalWriter {
     sender: BlockingSender<JournalEntry>,
     metrics: &'static MasterMetrics,
     receiver: Option<Mutex<BlockingReceiver<JournalEntry>>>,
+    metadata_delta_log: Mutex<MetadataDeltaLog>,
 
     snapshot_entries: u64,
     entries_since_snapshot: AtomicCounter,
+}
+
+#[derive(Default)]
+struct MetadataDeltaLog {
+    capacity: usize,
+    low_watermark: u64,
+    changes: VecDeque<CvMetadataChange>,
 }
 
 impl JournalWriter {
@@ -62,6 +71,7 @@ impl JournalWriter {
             sender,
             metrics,
             receiver,
+            metadata_delta_log: Mutex::new(MetadataDeltaLog::new(conf.metadata_delta_log_capacity)),
             snapshot_entries: conf.snapshot_entries,
             entries_since_snapshot: AtomicCounter::new(0),
         })
@@ -76,10 +86,19 @@ impl JournalWriter {
 
     fn send(&self, fs_dir: &FsDir, entry: JournalEntry) -> FsResult<()> {
         if self.enable {
+            self.record_metadata_delta(&entry);
             self.send_inner(entry)?;
             self.maybe_emit_snapshot(fs_dir)?;
         }
         Ok(())
+    }
+
+    fn record_metadata_delta(&self, entry: &JournalEntry) {
+        let changes = entry.cv_metadata_changes();
+        if changes.is_empty() {
+            return;
+        }
+        self.metadata_delta_log.lock().unwrap().push(changes);
     }
 
     fn maybe_emit_snapshot(&self, fs_dir: &FsDir) -> FsResult<()> {
@@ -349,5 +368,50 @@ impl JournalWriter {
             entries.push(v);
         }
         entries
+    }
+
+    pub(crate) fn cv_metadata_changes_since(
+        &self,
+        from_epoch: u64,
+        to_epoch: u64,
+    ) -> Option<Vec<CvMetadataChange>> {
+        let log = self.metadata_delta_log.lock().unwrap();
+        if from_epoch < log.low_watermark {
+            return None;
+        }
+        Some(
+            log.changes
+                .iter()
+                .filter(|change| change.op_id > from_epoch && change.op_id <= to_epoch)
+                .cloned()
+                .collect(),
+        )
+    }
+}
+
+impl MetadataDeltaLog {
+    fn new(capacity: usize) -> Self {
+        Self {
+            capacity,
+            low_watermark: 0,
+            changes: VecDeque::with_capacity(capacity.min(1024)),
+        }
+    }
+
+    fn push(&mut self, changes: Vec<CvMetadataChange>) {
+        if self.capacity == 0 {
+            if let Some(max_op_id) = changes.iter().map(|change| change.op_id).max() {
+                self.low_watermark = self.low_watermark.max(max_op_id);
+            }
+            return;
+        }
+        for change in changes {
+            self.changes.push_back(change);
+            while self.changes.len() > self.capacity {
+                if let Some(evicted) = self.changes.pop_front() {
+                    self.low_watermark = self.low_watermark.max(evicted.op_id);
+                }
+            }
+        }
     }
 }

--- a/curvine-server/src/master/master_handler.rs
+++ b/curvine-server/src/master/master_handler.rs
@@ -33,8 +33,10 @@ use orpc::err_box;
 use orpc::handler::MessageHandler;
 use orpc::io::net::ConnState;
 use orpc::message::Message;
-use orpc::runtime::Runtime;
+use orpc::runtime::{GroupExecutor, Runtime};
+use std::panic::{self, AssertUnwindSafe};
 use std::sync::Arc;
+use tokio::sync::oneshot;
 
 pub struct MasterHandler {
     pub(crate) fs: MasterFilesystem,
@@ -44,6 +46,7 @@ pub struct MasterHandler {
     pub(crate) conn_state: Option<ConnState>,
     pub(crate) job_handler: JobHandler,
     pub(crate) mount_manager: Arc<MountManager>,
+    pub(crate) control_rpc_executor: Arc<GroupExecutor>,
     pub(crate) replication_handler: Option<MasterReplicationHandler>,
     pub(crate) actor_rt: Arc<Runtime>,
 }
@@ -57,6 +60,7 @@ impl MasterHandler {
         conn_state: Option<ConnState>,
         mount_manager: Arc<MountManager>,
         job_handler: JobHandler,
+        control_rpc_executor: Arc<GroupExecutor>,
         replication_manager: Arc<MasterReplicationManager>,
         actor_rt: Arc<Runtime>,
         metrics: &'static MasterMetrics,
@@ -69,6 +73,7 @@ impl MasterHandler {
             conn_state,
             mount_manager,
             job_handler,
+            control_rpc_executor,
             replication_handler: Some(MasterReplicationHandler::new(replication_manager)),
             actor_rt,
         }
@@ -432,12 +437,94 @@ impl MasterHandler {
         fs.get_block_locations(path)
     }
 
-    pub fn get_master_info(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
-        let _: GetMasterInfoRequest = ctx.parse_header()?;
+    async fn run_master_rpc_task<T, F>(executor: Arc<GroupExecutor>, task: F) -> FsResult<T>
+    where
+        T: Send + 'static,
+        F: FnOnce() -> FsResult<T> + Send + 'static,
+    {
+        let (tx, rx) = oneshot::channel();
+        executor.try_spawn(move || {
+            let result = panic::catch_unwind(AssertUnwindSafe(task))
+                .unwrap_or_else(|_| err_box!("master control RPC task panicked"));
+            let _ = tx.send(result);
+        })?;
+        rx.await?
+    }
 
-        let info = Self::process_get_master_info(self.fs.clone())?;
+    async fn async_get_master_info(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+        let _: GetMasterInfoRequest = ctx.parse_header()?;
+        let fs = self.fs.clone();
+        let info = Self::run_master_rpc_task(self.control_rpc_executor.clone(), move || {
+            Self::process_get_master_info(fs)
+        })
+        .await?;
         let rep_header = ProtoUtils::master_info_to_pb(info);
         ctx.response(rep_header)
+    }
+
+    async fn async_get_cv_metadata_snapshot_page(
+        &self,
+        ctx: &mut RpcContext<'_>,
+    ) -> FsResult<Message> {
+        let req: GetCvMetadataSnapshotPageRequest = ctx.parse_header()?;
+        ctx.set_audit(Some("cv-metadata-snapshot".to_string()), None);
+        let fs = self.fs.clone();
+        let response = Self::run_master_rpc_task(self.control_rpc_executor.clone(), move || {
+            let page = fs.cv_metadata_snapshot_page(
+                req.page_token,
+                req.page_size.unwrap_or(10_000) as usize,
+            )?;
+            Ok(GetCvMetadataSnapshotPageResponse {
+                entries: page
+                    .entries
+                    .into_iter()
+                    .map(|entry| CvMetadataSnapshotEntryProto {
+                        status: ProtoUtils::file_status_to_pb(entry.status),
+                        blocks: entry.blocks.map(ProtoUtils::file_blocks_to_pb),
+                    })
+                    .collect(),
+                next_page_token: page.next_page_token,
+                epoch: page.epoch,
+            })
+        })
+        .await?;
+        ctx.response(response)
+    }
+
+    async fn async_get_cv_metadata_delta_page(
+        &self,
+        ctx: &mut RpcContext<'_>,
+    ) -> FsResult<Message> {
+        let req: GetCvMetadataDeltaPageRequest = ctx.parse_header()?;
+        ctx.set_audit(Some("cv-metadata-delta".to_string()), None);
+        let fs = self.fs.clone();
+        let response = Self::run_master_rpc_task(self.control_rpc_executor.clone(), move || {
+            let page = fs.cv_metadata_delta_page(
+                req.from_epoch,
+                req.target_epoch,
+                req.page_token,
+                req.page_size.unwrap_or(10_000) as usize,
+            )?;
+            Ok(GetCvMetadataDeltaPageResponse {
+                entries: page
+                    .entries
+                    .into_iter()
+                    .map(|entry| CvMetadataDeltaEntryProto {
+                        path: entry.path,
+                        entry: entry.entry.map(|entry| CvMetadataSnapshotEntryProto {
+                            status: ProtoUtils::file_status_to_pb(entry.status),
+                            blocks: entry.blocks.map(ProtoUtils::file_blocks_to_pb),
+                        }),
+                    })
+                    .collect(),
+                next_page_token: page.next_page_token,
+                from_epoch: page.from_epoch,
+                to_epoch: page.to_epoch,
+                full_snapshot_required: page.full_snapshot_required,
+            })
+        })
+        .await?;
+        ctx.response(response)
     }
 
     fn process_get_master_info(fs: MasterFilesystem) -> FsResult<MasterInfo> {
@@ -738,7 +825,13 @@ impl MessageHandler for MasterHandler {
         let code = RpcCode::from(msg.code());
         !matches!(
             code,
-            RpcCode::SubmitJob | RpcCode::GetJobStatus | RpcCode::CancelJob | RpcCode::ReportTask
+            RpcCode::SubmitJob
+                | RpcCode::GetJobStatus
+                | RpcCode::CancelJob
+                | RpcCode::ReportTask
+                | RpcCode::GetMasterInfo
+                | RpcCode::GetCvMetadataSnapshotPage
+                | RpcCode::GetCvMetadataDeltaPage
         )
     }
 
@@ -799,7 +892,6 @@ impl MessageHandler for MasterHandler {
                 // Worker related requests
                 RpcCode::WorkerHeartbeat => self.worker_heartbeat(ctx),
                 RpcCode::WorkerBlockReport => self.block_report(ctx),
-                RpcCode::GetMasterInfo => self.get_master_info(ctx),
 
                 RpcCode::ReportBlockReplicationResult => {
                     if let Some(ref replication_service) = self.replication_handler {
@@ -848,6 +940,11 @@ impl MessageHandler for MasterHandler {
                 RpcCode::GetJobStatus => self.job_handler.get_load_status(ctx),
                 RpcCode::CancelJob => self.job_handler.cancel_job(ctx).await,
                 RpcCode::ReportTask => self.job_handler.task_report(ctx),
+                RpcCode::GetMasterInfo => self.async_get_master_info(ctx).await,
+                RpcCode::GetCvMetadataSnapshotPage => {
+                    self.async_get_cv_metadata_snapshot_page(ctx).await
+                }
+                RpcCode::GetCvMetadataDeltaPage => self.async_get_cv_metadata_delta_page(ctx).await,
 
                 v => err_box!("unsupported operation {:?}", v),
             }

--- a/curvine-server/src/master/master_server.rs
+++ b/curvine-server/src/master/master_server.rs
@@ -23,7 +23,7 @@ use log::error;
 use orpc::common::{LocalTime, Logger};
 use orpc::handler::{HandlerService, LimitConf};
 use orpc::io::net::ConnState;
-use orpc::runtime::{AsyncRuntime, RpcRuntime, Runtime};
+use orpc::runtime::{AsyncRuntime, GroupExecutor, RpcRuntime, Runtime};
 use orpc::server::{RpcServer, ServerStateListener};
 use orpc::{err_box, CommonError, CommonResult};
 
@@ -46,6 +46,7 @@ pub struct MasterService {
     job_manager: Arc<JobManager>,
     rt: Arc<Runtime>,
     actor_rt: Arc<Runtime>,
+    control_rpc_executor: Arc<GroupExecutor>,
     replication_manager: Arc<MasterReplicationManager>,
     limit: LimitConf,
     metrics: &'static MasterMetrics,
@@ -70,6 +71,7 @@ impl MasterService {
             1,
             conf.master.actor_threads,
         ));
+        let control_rpc_executor = Arc::new(GroupExecutor::new("master-control-rpc", 2, 1024));
         let limit = LimitConf::new(conf.master.conn_limit, conf.master.global_limit);
         Self {
             conf,
@@ -79,6 +81,7 @@ impl MasterService {
             job_manager,
             rt,
             actor_rt,
+            control_rpc_executor,
             replication_manager,
             limit,
             metrics,
@@ -118,6 +121,7 @@ impl HandlerService for MasterService {
             client_state,
             self.mount_manager.clone(),
             JobHandler::new(self.job_manager.clone()),
+            self.control_rpc_executor.clone(),
             self.replication_manager.clone(),
             self.actor_rt.clone(),
             self.metrics,

--- a/curvine-server/tests/master_fs_test.rs
+++ b/curvine-server/tests/master_fs_test.rs
@@ -41,7 +41,7 @@ use orpc::handler::MessageHandler;
 use orpc::message::Builder;
 #[cfg(feature = "fault-injection")]
 use orpc::message::ResponseStatus;
-use orpc::runtime::{AsyncRuntime, RpcRuntime};
+use orpc::runtime::{AsyncRuntime, GroupExecutor, RpcRuntime};
 use orpc::CommonResult;
 use raft::eraftpb::Entry;
 use std::sync::{Arc, Mutex, OnceLock};
@@ -188,6 +188,7 @@ fn new_handler_for_test(test_name: &str) -> MasterHandler {
         rt.clone(),
         &conf,
     ));
+    let control_rpc_executor = Arc::new(GroupExecutor::new("master-handler-test", 1, 16));
     MasterHandler::new(
         &conf,
         fs,
@@ -195,6 +196,7 @@ fn new_handler_for_test(test_name: &str) -> MasterHandler {
         None,
         mount_manager,
         JobHandler::new(job_manager),
+        control_rpc_executor,
         replication_manager,
         rt,
         Master::get_metrics().expect("test master metrics should initialize"),
@@ -248,7 +250,7 @@ fn test_master_sync_and_async_rpc_points_follow_dispatch_paths() -> CommonResult
 }
 
 #[test]
-fn only_job_requests_use_the_async_handler() {
+fn control_plane_requests_use_the_async_handler() {
     let _serial = master_fs_test_serial();
     let handler = new_handler();
 
@@ -257,6 +259,9 @@ fn only_job_requests_use_the_async_handler() {
         RpcCode::GetJobStatus,
         RpcCode::CancelJob,
         RpcCode::ReportTask,
+        RpcCode::GetMasterInfo,
+        RpcCode::GetCvMetadataSnapshotPage,
+        RpcCode::GetCvMetadataDeltaPage,
     ] {
         let msg = Builder::new_rpc(code).build();
         assert!(
@@ -267,7 +272,6 @@ fn only_job_requests_use_the_async_handler() {
 
     for code in [
         RpcCode::GetBlockLocations,
-        RpcCode::GetMasterInfo,
         RpcCode::ListStatus,
         RpcCode::ListOptions,
         RpcCode::WorkerHeartbeat,


### PR DESCRIPTION
# Summary

Adds Master metadata journaling, a dedicated control RPC lane, and snapshot page RPCs.

# Issue Describe / Design

Part of the standalone Transfer service. This review layer is stacked deliberately so that protocol, metadata storage, scheduling, worker execution, client routing, and deployment can be reviewed independently.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-server/src/master/journal,curvine-server/src/master/master_handler.rs` | Adds Master metadata journaling, a dedicated control RPC lane, and snapshot page RPCs. | New Transfer behavior; legacy behavior remains available unless Transfer is enabled. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo check -p curvine-server -p curvine-cli` | PASS | Rebased onto upstream main `497d078d`. |

# Dependencies

- Related PRs: #1346
- Related issues: #1040
- Blocks / blocked by: #1346