### PR TITLE
feat(transfer): add store backend and cluster cache

### DIFF
--- a/curvine-server/src/transfer/backend.rs
+++ b/curvine-server/src/transfer/backend.rs
@@ -1,0 +1,439 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use curvine_common::error::FsError;
+use curvine_common::state::{
+    StaleTaskAttempt, TaskAttemptStart, TransferJobRecord, TransferLease, TransferListFilter,
+    TransferState, TransferStateUpdate, TransferTaskRecord, TransferTaskReport, TransferTaskState,
+    TransferTenantSummary,
+};
+use curvine_common::FsResult;
+use std::time::Instant;
+
+use crate::transfer::{
+    MemoryTransferStore, MysqlTransferStore, SqliteTransferStore, TransferMetrics,
+    TransferRequeueUpdate, TransferStore,
+};
+
+pub enum TransferStoreBackend {
+    Memory(MemoryTransferStore),
+    Sqlite(SqliteTransferStore),
+    Mysql(MysqlTransferStore),
+}
+
+impl TransferStore for TransferStoreBackend {
+    fn check_available(&self) -> FsResult<()> {
+        self.record_store_operation("check_available", || match self {
+            Self::Memory(store) => store.check_available(),
+            Self::Sqlite(store) => store.check_available(),
+            Self::Mysql(store) => store.check_available(),
+        })
+    }
+
+    fn create_or_get_by_request_id(&self, job: TransferJobRecord) -> FsResult<TransferJobRecord> {
+        self.record_store_operation("create_or_get_by_request_id", || match self {
+            Self::Memory(store) => store.create_or_get_by_request_id(job),
+            Self::Sqlite(store) => store.create_or_get_by_request_id(job),
+            Self::Mysql(store) => store.create_or_get_by_request_id(job),
+        })
+    }
+
+    fn create_or_get_by_request_id_checked(
+        &self,
+        job: TransferJobRecord,
+    ) -> FsResult<TransferJobRecord> {
+        self.record_store_operation("create_or_get_by_request_id_checked", || match self {
+            Self::Memory(store) => store.create_or_get_by_request_id_checked(job),
+            Self::Sqlite(store) => store.create_or_get_by_request_id_checked(job),
+            Self::Mysql(store) => store.create_or_get_by_request_id_checked(job),
+        })
+    }
+
+    fn get_transfer(&self, job_id: &str) -> FsResult<Option<TransferJobRecord>> {
+        self.record_store_operation("get_transfer", || match self {
+            Self::Memory(store) => store.get_transfer(job_id),
+            Self::Sqlite(store) => store.get_transfer(job_id),
+            Self::Mysql(store) => store.get_transfer(job_id),
+        })
+    }
+
+    fn get_transfer_by_request(
+        &self,
+        submitter: &str,
+        client_request_id: &str,
+    ) -> FsResult<Option<TransferJobRecord>> {
+        self.record_store_operation("get_transfer_by_request", || match self {
+            Self::Memory(store) => store.get_transfer_by_request(submitter, client_request_id),
+            Self::Sqlite(store) => store.get_transfer_by_request(submitter, client_request_id),
+            Self::Mysql(store) => store.get_transfer_by_request(submitter, client_request_id),
+        })
+    }
+
+    fn list_active_transfers(&self) -> FsResult<Vec<TransferJobRecord>> {
+        self.record_store_operation("list_active_transfers", || match self {
+            Self::Memory(store) => store.list_active_transfers(),
+            Self::Sqlite(store) => store.list_active_transfers(),
+            Self::Mysql(store) => store.list_active_transfers(),
+        })
+    }
+
+    fn find_conflicting_active_transfer(
+        &self,
+        target_path: &str,
+        submitter: &str,
+        client_request_id: &str,
+    ) -> FsResult<Option<TransferJobRecord>> {
+        self.record_store_operation("find_conflicting_active_transfer", || match self {
+            Self::Memory(store) => {
+                store.find_conflicting_active_transfer(target_path, submitter, client_request_id)
+            }
+            Self::Sqlite(store) => {
+                store.find_conflicting_active_transfer(target_path, submitter, client_request_id)
+            }
+            Self::Mysql(store) => {
+                store.find_conflicting_active_transfer(target_path, submitter, client_request_id)
+            }
+        })
+    }
+
+    fn count_active_transfers(&self) -> FsResult<u64> {
+        self.record_store_operation("count_active_transfers", || match self {
+            Self::Memory(store) => store.count_active_transfers(),
+            Self::Sqlite(store) => store.count_active_transfers(),
+            Self::Mysql(store) => store.count_active_transfers(),
+        })
+    }
+
+    fn count_executing_transfers(&self) -> FsResult<u64> {
+        self.record_store_operation("count_executing_transfers", || match self {
+            Self::Memory(store) => store.count_executing_transfers(),
+            Self::Sqlite(store) => store.count_executing_transfers(),
+            Self::Mysql(store) => store.count_executing_transfers(),
+        })
+    }
+
+    fn list_transfers(&self, filter: TransferListFilter) -> FsResult<Vec<TransferJobRecord>> {
+        self.record_store_operation("list_transfers", || match self {
+            Self::Memory(store) => store.list_transfers(filter),
+            Self::Sqlite(store) => store.list_transfers(filter),
+            Self::Mysql(store) => store.list_transfers(filter),
+        })
+    }
+
+    fn list_tenant_summaries(
+        &self,
+        limit: usize,
+        offset: usize,
+    ) -> FsResult<Vec<TransferTenantSummary>> {
+        self.record_store_operation("list_tenant_summaries", || match self {
+            Self::Memory(store) => store.list_tenant_summaries(limit, offset),
+            Self::Sqlite(store) => store.list_tenant_summaries(limit, offset),
+            Self::Mysql(store) => store.list_tenant_summaries(limit, offset),
+        })
+    }
+
+    fn purge_terminal_transfers(&self, older_than_ms: i64, limit: usize) -> FsResult<usize> {
+        self.record_store_operation("purge_terminal_transfers", || match self {
+            Self::Memory(store) => store.purge_terminal_transfers(older_than_ms, limit),
+            Self::Sqlite(store) => store.purge_terminal_transfers(older_than_ms, limit),
+            Self::Mysql(store) => store.purge_terminal_transfers(older_than_ms, limit),
+        })
+    }
+
+    fn list_transfer_tasks(&self, job_id: &str, run_id: u64) -> FsResult<Vec<TransferTaskRecord>> {
+        self.record_store_operation("list_transfer_tasks", || match self {
+            Self::Memory(store) => store.list_transfer_tasks(job_id, run_id),
+            Self::Sqlite(store) => store.list_transfer_tasks(job_id, run_id),
+            Self::Mysql(store) => store.list_transfer_tasks(job_id, run_id),
+        })
+    }
+
+    fn request_cancel(&self, job_id: &str, run_id: u64, now_ms: i64) -> FsResult<bool> {
+        self.record_store_operation("request_cancel", || match self {
+            Self::Memory(store) => store.request_cancel(job_id, run_id, now_ms),
+            Self::Sqlite(store) => store.request_cancel(job_id, run_id, now_ms),
+            Self::Mysql(store) => store.request_cancel(job_id, run_id, now_ms),
+        })
+    }
+
+    fn acquire_runnable_transfer(
+        &self,
+        owner: &str,
+        lease_ms: i64,
+        now_ms: i64,
+        max_executing_transfers: u64,
+    ) -> FsResult<Option<TransferLease>> {
+        self.record_store_operation("acquire_runnable_transfer", || match self {
+            Self::Memory(store) => {
+                store.acquire_runnable_transfer(owner, lease_ms, now_ms, max_executing_transfers)
+            }
+            Self::Sqlite(store) => {
+                store.acquire_runnable_transfer(owner, lease_ms, now_ms, max_executing_transfers)
+            }
+            Self::Mysql(store) => {
+                store.acquire_runnable_transfer(owner, lease_ms, now_ms, max_executing_transfers)
+            }
+        })
+    }
+
+    fn renew_lease(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        owner: &str,
+        lease_epoch: u64,
+        lease_ms: i64,
+        now_ms: i64,
+    ) -> FsResult<bool> {
+        self.record_store_operation("renew_lease", || match self {
+            Self::Memory(store) => {
+                store.renew_lease(job_id, run_id, owner, lease_epoch, lease_ms, now_ms)
+            }
+            Self::Sqlite(store) => {
+                store.renew_lease(job_id, run_id, owner, lease_epoch, lease_ms, now_ms)
+            }
+            Self::Mysql(store) => {
+                store.renew_lease(job_id, run_id, owner, lease_epoch, lease_ms, now_ms)
+            }
+        })
+    }
+
+    fn update_transfer_state(&self, update: TransferStateUpdate) -> FsResult<bool> {
+        self.record_store_operation("update_transfer_state", || match self {
+            Self::Memory(store) => store.update_transfer_state(update),
+            Self::Sqlite(store) => store.update_transfer_state(update),
+            Self::Mysql(store) => store.update_transfer_state(update),
+        })
+    }
+
+    fn set_transfer_state(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        state: TransferState,
+        message: impl Into<String>,
+        now_ms: i64,
+    ) -> FsResult<bool> {
+        let message = message.into();
+        self.record_store_operation("set_transfer_state", || match self {
+            Self::Memory(store) => {
+                store.set_transfer_state(job_id, run_id, state, message.clone(), now_ms)
+            }
+            Self::Sqlite(store) => {
+                store.set_transfer_state(job_id, run_id, state, message.clone(), now_ms)
+            }
+            Self::Mysql(store) => store.set_transfer_state(job_id, run_id, state, message, now_ms),
+        })
+    }
+
+    fn requeue_transfer(&self, update: TransferRequeueUpdate) -> FsResult<bool> {
+        self.record_store_operation("requeue_transfer", || match self {
+            Self::Memory(store) => store.requeue_transfer(update),
+            Self::Sqlite(store) => store.requeue_transfer(update),
+            Self::Mysql(store) => store.requeue_transfer(update),
+        })
+    }
+
+    fn set_transfer_cv_metadata_epoch(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        owner: &str,
+        lease_epoch: u64,
+        cv_metadata_epoch: u64,
+        now_ms: i64,
+    ) -> FsResult<bool> {
+        self.record_store_operation("set_transfer_cv_metadata_epoch", || match self {
+            Self::Memory(store) => store.set_transfer_cv_metadata_epoch(
+                job_id,
+                run_id,
+                owner,
+                lease_epoch,
+                cv_metadata_epoch,
+                now_ms,
+            ),
+            Self::Sqlite(store) => store.set_transfer_cv_metadata_epoch(
+                job_id,
+                run_id,
+                owner,
+                lease_epoch,
+                cv_metadata_epoch,
+                now_ms,
+            ),
+            Self::Mysql(store) => store.set_transfer_cv_metadata_epoch(
+                job_id,
+                run_id,
+                owner,
+                lease_epoch,
+                cv_metadata_epoch,
+                now_ms,
+            ),
+        })
+    }
+
+    fn insert_tasks(&self, tasks: Vec<TransferTaskRecord>) -> FsResult<()> {
+        self.record_store_operation("insert_tasks", || match self {
+            Self::Memory(store) => store.insert_tasks(tasks),
+            Self::Sqlite(store) => store.insert_tasks(tasks),
+            Self::Mysql(store) => store.insert_tasks(tasks),
+        })
+    }
+
+    fn update_task_state(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        task_id: &str,
+        state: TransferTaskState,
+        message: impl Into<String>,
+        now_ms: i64,
+    ) -> FsResult<bool> {
+        self.record_store_operation("update_task_state", || match self {
+            Self::Memory(store) => {
+                store.update_task_state(job_id, run_id, task_id, state, message, now_ms)
+            }
+            Self::Sqlite(store) => {
+                store.update_task_state(job_id, run_id, task_id, state, message, now_ms)
+            }
+            Self::Mysql(store) => {
+                store.update_task_state(job_id, run_id, task_id, state, message, now_ms)
+            }
+        })
+    }
+
+    fn claim_pending_tasks(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        limit: usize,
+    ) -> FsResult<Vec<TransferTaskRecord>> {
+        self.record_store_operation("claim_pending_tasks", || match self {
+            Self::Memory(store) => store.claim_pending_tasks(job_id, run_id, limit),
+            Self::Sqlite(store) => store.claim_pending_tasks(job_id, run_id, limit),
+            Self::Mysql(store) => store.claim_pending_tasks(job_id, run_id, limit),
+        })
+    }
+
+    fn mark_stale_attempts(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        owner: &str,
+        lease_epoch: u64,
+        now_ms: i64,
+        limit: usize,
+    ) -> FsResult<Vec<StaleTaskAttempt>> {
+        self.record_store_operation("mark_stale_attempts", || match self {
+            Self::Memory(store) => {
+                store.mark_stale_attempts(job_id, run_id, owner, lease_epoch, now_ms, limit)
+            }
+            Self::Sqlite(store) => {
+                store.mark_stale_attempts(job_id, run_id, owner, lease_epoch, now_ms, limit)
+            }
+            Self::Mysql(store) => {
+                store.mark_stale_attempts(job_id, run_id, owner, lease_epoch, now_ms, limit)
+            }
+        })
+    }
+
+    fn list_recoverable_tasks(
+        &self,
+        job_id: &str,
+        run_id: u64,
+    ) -> FsResult<Vec<TransferTaskRecord>> {
+        self.record_store_operation("list_recoverable_tasks", || match self {
+            Self::Memory(store) => store.list_recoverable_tasks(job_id, run_id),
+            Self::Sqlite(store) => store.list_recoverable_tasks(job_id, run_id),
+            Self::Mysql(store) => store.list_recoverable_tasks(job_id, run_id),
+        })
+    }
+
+    fn start_task_attempt(&self, start: TaskAttemptStart) -> FsResult<bool> {
+        self.record_store_operation("start_task_attempt", || match self {
+            Self::Memory(store) => store.start_task_attempt(start),
+            Self::Sqlite(store) => store.start_task_attempt(start),
+            Self::Mysql(store) => store.start_task_attempt(start),
+        })
+    }
+
+    fn update_task_report(&self, report: TransferTaskReport) -> FsResult<bool> {
+        self.record_store_operation("update_task_report", || match self {
+            Self::Memory(store) => store.update_task_report(report),
+            Self::Sqlite(store) => store.update_task_report(report),
+            Self::Mysql(store) => store.update_task_report(report),
+        })
+    }
+}
+
+impl TransferStoreBackend {
+    pub fn backend_label(&self) -> &'static str {
+        match self {
+            Self::Memory(_) => "memory",
+            Self::Sqlite(_) => "sqlite",
+            Self::Mysql(_) => "mysql",
+        }
+    }
+
+    fn record_store_operation<T>(
+        &self,
+        operation: &'static str,
+        f: impl FnOnce() -> FsResult<T>,
+    ) -> FsResult<T> {
+        let start = Instant::now();
+        let result = f();
+        if let Ok(metrics) = TransferMetrics::get() {
+            let backend = self.backend_label();
+            metrics.observe_store_operation(
+                backend,
+                operation,
+                if result.is_ok() { "success" } else { "error" },
+                start.elapsed().as_micros(),
+            );
+            if is_store_unavailable_result(&result) {
+                metrics.record_store_unavailable(backend, operation);
+            } else {
+                metrics.record_store_available(backend);
+            }
+        }
+        result
+    }
+}
+
+fn is_store_unavailable_result<T>(result: &FsResult<T>) -> bool {
+    let Err(err) = result else {
+        return false;
+    };
+    is_store_unavailable_error(err)
+}
+
+pub(crate) fn is_store_unavailable_error(err: &FsError) -> bool {
+    if matches!(
+        err.kind(),
+        curvine_common::error::ErrorKind::IO
+            | curvine_common::error::ErrorKind::TransferStoreUnavailable
+    ) {
+        return true;
+    }
+
+    let message = err.to_string();
+    message.contains("sqlite transfer store error:")
+        || message.contains("mysql transfer store error:")
+        || message.contains("Unknown database")
+        || message.contains("No database selected")
+        || message.contains("doesn't exist")
+        || message.contains("Can't connect")
+        || message.contains("Connection refused")
+        || message.contains("Lost connection")
+        || message.contains("server has gone away")
+}

--- a/curvine-server/src/transfer/cluster_cache.rs
+++ b/curvine-server/src/transfer/cluster_cache.rs
@@ -1,0 +1,345 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use curvine_client::file::CurvineFileSystem;
+use curvine_common::error::FsError;
+use curvine_common::fs::Path;
+use curvine_common::state::{MountInfo, TransferKind, WorkerInfo};
+use curvine_common::FsResult;
+use log::warn;
+use orpc::common::LocalTime;
+use orpc::runtime::RpcRuntime;
+use parking_lot::{Mutex, RwLock};
+use std::collections::HashSet;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use crate::transfer::TransferMetrics;
+
+#[derive(Clone, Default)]
+pub struct ClusterSnapshot {
+    pub version: u64,
+    pub mounts: Vec<MountInfo>,
+    pub workers: Vec<WorkerInfo>,
+    pub updated_at: i64,
+}
+
+#[derive(Clone)]
+pub struct ClusterMetadataCache {
+    fs: CurvineFileSystem,
+    snapshot: Arc<RwLock<ClusterSnapshot>>,
+    rejected_worker_sessions: Arc<RwLock<HashSet<(u32, String)>>>,
+    refresh_lock: Arc<Mutex<()>>,
+    max_staleness: Duration,
+    allow_stale_snapshot: bool,
+}
+
+impl ClusterMetadataCache {
+    pub fn new(fs: CurvineFileSystem) -> Self {
+        Self::with_snapshot_policy(fs, Duration::MAX, true)
+    }
+
+    pub fn with_snapshot_policy(
+        fs: CurvineFileSystem,
+        max_staleness: Duration,
+        allow_stale_snapshot: bool,
+    ) -> Self {
+        Self {
+            fs,
+            snapshot: Arc::new(RwLock::new(ClusterSnapshot::default())),
+            rejected_worker_sessions: Arc::new(RwLock::new(HashSet::new())),
+            refresh_lock: Arc::new(Mutex::new(())),
+            max_staleness,
+            allow_stale_snapshot,
+        }
+    }
+
+    pub fn snapshot(&self) -> ClusterSnapshot {
+        self.snapshot.read().clone()
+    }
+
+    pub fn check_ready(&self) -> FsResult<()> {
+        let snapshot = self.snapshot();
+        if snapshot.updated_at <= 0 {
+            return Err(FsError::common(
+                "Transfer cluster metadata is unavailable; retry shortly",
+            ));
+        }
+        self.check_snapshot_fresh(&snapshot)
+    }
+
+    pub fn remove_worker_session(&self, worker_id: u32, worker_session_id: &str) {
+        self.rejected_worker_sessions
+            .write()
+            .insert((worker_id, worker_session_id.to_string()));
+        let mut snapshot = self.snapshot.write();
+        snapshot.workers.retain(|worker| {
+            !(worker.worker_id() == worker_id && worker.worker_session_id == worker_session_id)
+        });
+    }
+
+    pub async fn refresh(&self) -> FsResult<()> {
+        let start = Instant::now();
+        let result = self.refresh_inner().await;
+        let snapshot = self.snapshot();
+        let (live_workers, capable_workers) = worker_counts(&snapshot.workers);
+        if let Ok(metrics) = TransferMetrics::get() {
+            metrics.observe_cluster_snapshot_refresh(
+                if result.is_ok() { "success" } else { "failure" },
+                start.elapsed().as_micros(),
+                if result.is_ok() {
+                    Some(snapshot.version)
+                } else {
+                    None
+                },
+                if snapshot.updated_at > 0 {
+                    Some(snapshot.updated_at)
+                } else {
+                    None
+                },
+                Some(live_workers),
+                Some(capable_workers),
+            );
+        }
+        result
+    }
+
+    async fn refresh_inner(&self) -> FsResult<()> {
+        let mounts = self.fs.get_mount_table().await?;
+        let master = self.fs.get_master_info().await?;
+        let mut workers = master.live_workers;
+        {
+            let mut rejected = self.rejected_worker_sessions.write();
+            rejected.retain(|(worker_id, worker_session_id)| {
+                workers.iter().any(|worker| {
+                    worker.worker_id() == *worker_id
+                        && worker.worker_session_id == *worker_session_id
+                })
+            });
+            workers.retain(|worker| {
+                !rejected.contains(&(worker.worker_id(), worker.worker_session_id.clone()))
+            });
+        }
+        let mut snapshot = self.snapshot.write();
+        snapshot.version = snapshot.version.saturating_add(1);
+        snapshot.mounts = mounts;
+        snapshot.workers = workers;
+        snapshot.updated_at = LocalTime::mills() as i64;
+        Ok(())
+    }
+
+    pub fn find_mount(
+        &self,
+        kind: TransferKind,
+        source: &Path,
+        target: &Path,
+    ) -> FsResult<MountInfo> {
+        self.find_mount_with_version(kind, source, target)
+            .map(|snapshot| snapshot.mount)
+    }
+
+    pub fn find_mount_with_version(
+        &self,
+        kind: TransferKind,
+        source: &Path,
+        target: &Path,
+    ) -> FsResult<MountSnapshot> {
+        let snapshot = self.snapshot();
+        if snapshot.mounts.is_empty() {
+            return Err(FsError::common(
+                "Transfer cluster mount snapshot is unavailable; retry shortly",
+            ));
+        }
+        self.check_snapshot_fresh(&snapshot)?;
+        self.matching_mount_snapshot(kind, source, target, &snapshot)
+            .ok_or_else(|| {
+                FsError::common(format!(
+                    "No mount can serve {:?} from {} to {}",
+                    kind,
+                    source.full_path(),
+                    target.full_path()
+                ))
+            })
+    }
+
+    pub fn find_mount_with_refresh(
+        &self,
+        kind: TransferKind,
+        source: &Path,
+        target: &Path,
+    ) -> FsResult<MountSnapshot> {
+        let snapshot = self.snapshot();
+        self.check_snapshot_fresh(&snapshot)?;
+        if let Some(snapshot) = self.matching_mount_snapshot(kind, source, target, &snapshot) {
+            return Ok(snapshot);
+        }
+
+        let _guard = self.refresh_lock.lock();
+        let snapshot = self.snapshot();
+        self.check_snapshot_fresh(&snapshot)?;
+        if let Some(snapshot) = self.matching_mount_snapshot(kind, source, target, &snapshot) {
+            return Ok(snapshot);
+        }
+
+        // SubmitTransfer is synchronous and may run within a Tokio task.
+        self.refresh_blocking()?;
+        self.find_mount_with_version(kind, source, target)
+    }
+
+    fn matching_mount_snapshot(
+        &self,
+        kind: TransferKind,
+        source: &Path,
+        target: &Path,
+        snapshot: &ClusterSnapshot,
+    ) -> Option<MountSnapshot> {
+        let source_text = if source.is_cv() {
+            source.path().to_string()
+        } else {
+            source.full_path().to_string()
+        };
+        let target_text = if target.is_cv() {
+            target.path().to_string()
+        } else {
+            target.full_path().to_string()
+        };
+
+        snapshot
+            .mounts
+            .iter()
+            .find(|mount| match kind {
+                TransferKind::Load => {
+                    source_text.starts_with(&mount.ufs_path)
+                        && target_text.starts_with(&mount.cv_path)
+                }
+                TransferKind::Export => {
+                    source_text.starts_with(&mount.cv_path)
+                        && target_text.starts_with(&mount.ufs_path)
+                }
+            })
+            .cloned()
+            .map(|mount| MountSnapshot {
+                mount,
+                version: snapshot.version,
+            })
+    }
+
+    fn refresh_blocking(&self) -> FsResult<()> {
+        let cache = self.clone();
+        std::thread::scope(|scope| {
+            scope
+                .spawn(move || {
+                    let rt = cache.fs.clone_runtime();
+                    rt.block_on(cache.refresh())
+                })
+                .join()
+                .map_err(|_| FsError::common("Transfer cluster metadata refresh thread panicked"))?
+        })
+    }
+
+    pub fn live_workers(&self) -> FsResult<Vec<WorkerInfo>> {
+        let snapshot = self.snapshot();
+        self.check_snapshot_fresh(&snapshot)?;
+        let (live_count, capable_count) = worker_counts(&snapshot.workers);
+        if let Ok(metrics) = TransferMetrics::get() {
+            metrics.set_cluster_snapshot(
+                Some(snapshot.version),
+                if snapshot.updated_at > 0 {
+                    Some(snapshot.updated_at)
+                } else {
+                    None
+                },
+                Some(live_count),
+                Some(capable_count),
+            );
+        }
+        let workers: Vec<_> = snapshot
+            .workers
+            .into_iter()
+            .filter(|worker| {
+                worker.is_live()
+                    && !worker.worker_session_id.is_empty()
+                    && worker.transfer_capabilities.supports_transfer()
+            })
+            .collect();
+        if workers.is_empty() {
+            return Err(FsError::common(
+                "No live worker with required transfer capabilities is available",
+            ));
+        }
+        Ok(workers)
+    }
+
+    fn check_snapshot_fresh(&self, snapshot: &ClusterSnapshot) -> FsResult<()> {
+        if self.allow_stale_snapshot {
+            return Ok(());
+        }
+        let updated_at = snapshot.updated_at;
+        if updated_at <= 0 {
+            return Err(FsError::common(
+                "Transfer cluster metadata is unavailable; retry shortly",
+            ));
+        }
+        let max_staleness_ms = self.max_staleness.as_millis().min(i64::MAX as u128) as i64;
+        let staleness_ms = (LocalTime::mills() as i64).saturating_sub(updated_at);
+        if staleness_ms > max_staleness_ms {
+            return Err(FsError::common(
+                "Transfer cluster metadata is stale; retry shortly",
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn start_refresh_loop(self, interval: Duration, stop: Arc<AtomicBool>) {
+        let rt = self.fs.clone_runtime();
+        rt.spawn(async move {
+            while !stop.load(Ordering::Relaxed) {
+                if let Err(err) = self.refresh().await {
+                    warn!("refresh transfer cluster metadata failed: {}", err);
+                }
+                if wait_or_stopped(interval, &stop).await {
+                    break;
+                }
+            }
+        });
+    }
+}
+
+fn worker_counts(workers: &[WorkerInfo]) -> (usize, usize) {
+    let live = workers.iter().filter(|worker| worker.is_live()).count();
+    let capable = workers
+        .iter()
+        .filter(|worker| worker.is_live() && worker.transfer_capabilities.supports_transfer())
+        .count();
+    (live, capable)
+}
+
+async fn wait_or_stopped(interval: Duration, stop: &AtomicBool) -> bool {
+    let deadline = Instant::now() + interval;
+    while !stop.load(Ordering::Relaxed) {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return false;
+        }
+        tokio::time::sleep(remaining.min(Duration::from_millis(100))).await;
+    }
+    true
+}
+
+#[derive(Clone)]
+pub struct MountSnapshot {
+    pub mount: MountInfo,
+    pub version: u64,
+}

--- a/curvine-server/src/transfer/metrics.rs
+++ b/curvine-server/src/transfer/metrics.rs
@@ -1,0 +1,531 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use curvine_common::error::FsError;
+use curvine_common::FsResult;
+use once_cell::sync::OnceCell;
+use orpc::common::{Counter, CounterVec, Gauge, GaugeVec, HistogramVec, Metrics as m};
+use std::collections::HashMap;
+use std::fmt::{Debug, Formatter};
+use std::sync::Mutex;
+use std::time::Instant;
+
+static TRANSFER_METRICS: OnceCell<TransferMetrics> = OnceCell::new();
+
+pub struct TransferMetrics {
+    submit_total: CounterVec,
+    report_total: CounterVec,
+    report_queue_len: Gauge,
+    report_queue_len_by_lane: GaugeVec,
+    active_jobs: Gauge,
+    executing_jobs: Gauge,
+    pending_jobs: Gauge,
+    cleanup_purged_total: Counter,
+    acquire_total: CounterVec,
+    planning_total: CounterVec,
+    dispatch_total: CounterVec,
+    lease_renew_total: CounterVec,
+    stale_retry_total: CounterVec,
+    terminal_total: CounterVec,
+    store_operation_duration_us: HistogramVec,
+    store_operation_total: CounterVec,
+    store_unavailable: GaugeVec,
+    store_unavailable_total: CounterVec,
+    store_unavailable_duration_us_total: CounterVec,
+    store_unavailable_since: Mutex<HashMap<String, Instant>>,
+    metadata_operation_duration_us: HistogramVec,
+    metadata_operation_total: CounterVec,
+    metadata_replica_version: Gauge,
+    metadata_replica_entries: Gauge,
+    metadata_replica_page_size: Gauge,
+    metadata_replica_pages: Gauge,
+    metadata_replica_last_refresh_time_ms: Gauge,
+    metadata_replica_refresh_total: CounterVec,
+    metadata_replica_refresh_duration_us: HistogramVec,
+    cluster_snapshot_version: Gauge,
+    cluster_snapshot_staleness_ms: Gauge,
+    cluster_snapshot_live_workers: Gauge,
+    cluster_snapshot_capable_workers: Gauge,
+    cluster_snapshot_refresh_total: CounterVec,
+    cluster_snapshot_refresh_duration_us: HistogramVec,
+}
+
+pub struct MetadataReplicaRefreshObservation<'a> {
+    pub result: &'a str,
+    pub elapsed_us: u128,
+    pub version: Option<u64>,
+    pub entries: Option<usize>,
+    pub page_size: Option<usize>,
+    pub pages: Option<usize>,
+    pub refresh_time_ms: Option<i64>,
+}
+
+impl TransferMetrics {
+    pub fn get() -> FsResult<&'static Self> {
+        TRANSFER_METRICS.get_or_try_init(Self::new)
+    }
+
+    fn new() -> FsResult<Self> {
+        let metrics = Self {
+            submit_total: m::new_counter_vec(
+                "transfer_submit_total",
+                "Transfer submit requests by kind and result",
+                &["kind", "result"],
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            report_total: m::new_counter_vec(
+                "transfer_task_report_total",
+                "Transfer task report requests by result",
+                &["result"],
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            report_queue_len: m::new_gauge(
+                "transfer_task_report_queue_len",
+                "Current transfer task report queue length",
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            report_queue_len_by_lane: m::new_gauge_vec(
+                "transfer_task_report_queue_len_by_lane",
+                "Current transfer task report queue length by lane",
+                &["lane"],
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            active_jobs: m::new_gauge(
+                "transfer_active_jobs",
+                "Current non-terminal transfer jobs in TransferStore",
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            executing_jobs: m::new_gauge(
+                "transfer_executing_jobs",
+                "Current transfer jobs being planned, dispatched, running, or canceling",
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            pending_jobs: m::new_gauge(
+                "transfer_pending_jobs",
+                "Current pending transfer jobs waiting in TransferStore backlog",
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            cleanup_purged_total: m::new_counter(
+                "transfer_cleanup_purged_total",
+                "Total terminal transfer jobs purged by cleanup",
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            acquire_total: m::new_counter_vec(
+                "transfer_acquire_total",
+                "Transfer scheduler acquire attempts by result",
+                &["result"],
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            planning_total: m::new_counter_vec(
+                "transfer_planning_total",
+                "Transfer planning results by kind and result",
+                &["kind", "result"],
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            dispatch_total: m::new_counter_vec(
+                "transfer_dispatch_total",
+                "Transfer task dispatch results by result",
+                &["result"],
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            lease_renew_total: m::new_counter_vec(
+                "transfer_lease_renew_total",
+                "Transfer lease renew attempts by result",
+                &["result"],
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            stale_retry_total: m::new_counter_vec(
+                "transfer_stale_retry_total",
+                "Transfer stale task retry decisions by result",
+                &["result"],
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            terminal_total: m::new_counter_vec(
+                "transfer_terminal_total",
+                "Transfer terminal state transitions by state and reason",
+                &["state", "reason"],
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            store_operation_duration_us: m::new_histogram_vec_with_buckets(
+                "transfer_store_operation_duration_us",
+                "TransferStore operation latency in microseconds",
+                &["backend", "operation", "result"],
+                &[
+                    100.0,
+                    500.0,
+                    1_000.0,
+                    5_000.0,
+                    10_000.0,
+                    50_000.0,
+                    100_000.0,
+                    500_000.0,
+                    1_000_000.0,
+                ],
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            store_operation_total: m::new_counter_vec(
+                "transfer_store_operation_total",
+                "TransferStore operations by backend, operation, and result",
+                &["backend", "operation", "result"],
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            store_unavailable: m::new_gauge_vec(
+                "transfer_store_unavailable",
+                "Whether TransferStore backend is currently unavailable",
+                &["backend"],
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            store_unavailable_total: m::new_counter_vec(
+                "transfer_store_unavailable_total",
+                "TransferStore unavailable events by backend and operation",
+                &["backend", "operation"],
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            store_unavailable_duration_us_total: m::new_counter_vec(
+                "transfer_store_unavailable_duration_us_total",
+                "Total observed TransferStore unavailable duration in microseconds",
+                &["backend"],
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            store_unavailable_since: Mutex::new(HashMap::new()),
+            metadata_operation_duration_us: m::new_histogram_vec_with_buckets(
+                "transfer_metadata_operation_duration_us",
+                "Transfer planning metadata operation latency in microseconds",
+                &["source", "operation", "result"],
+                &[
+                    100.0,
+                    500.0,
+                    1_000.0,
+                    5_000.0,
+                    10_000.0,
+                    50_000.0,
+                    100_000.0,
+                    500_000.0,
+                    1_000_000.0,
+                    5_000_000.0,
+                ],
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            metadata_operation_total: m::new_counter_vec(
+                "transfer_metadata_operation_total",
+                "Transfer planning metadata operations by source, operation, and result",
+                &["source", "operation", "result"],
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            metadata_replica_version: m::new_gauge(
+                "transfer_metadata_replica_version",
+                "Current Transfer metadata replica snapshot version",
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            metadata_replica_entries: m::new_gauge(
+                "transfer_metadata_replica_entries",
+                "Current Transfer metadata replica entry count",
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            metadata_replica_page_size: m::new_gauge(
+                "transfer_metadata_replica_page_size",
+                "Configured Transfer metadata replica snapshot page size",
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            metadata_replica_pages: m::new_gauge(
+                "transfer_metadata_replica_pages",
+                "Pages read by the last Transfer metadata replica refresh",
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            metadata_replica_last_refresh_time_ms: m::new_gauge(
+                "transfer_metadata_replica_last_refresh_time_ms",
+                "Last successful Transfer metadata replica refresh timestamp in milliseconds",
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            metadata_replica_refresh_total: m::new_counter_vec(
+                "transfer_metadata_replica_refresh_total",
+                "Transfer metadata replica refresh attempts by result",
+                &["result"],
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            metadata_replica_refresh_duration_us: m::new_histogram_vec_with_buckets(
+                "transfer_metadata_replica_refresh_duration_us",
+                "Transfer metadata replica refresh latency in microseconds",
+                &["result"],
+                &[
+                    1_000.0,
+                    10_000.0,
+                    50_000.0,
+                    100_000.0,
+                    500_000.0,
+                    1_000_000.0,
+                    5_000_000.0,
+                    30_000_000.0,
+                    120_000_000.0,
+                ],
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            cluster_snapshot_version: m::new_gauge(
+                "transfer_cluster_snapshot_version",
+                "Current Transfer cluster metadata snapshot version",
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            cluster_snapshot_staleness_ms: m::new_gauge(
+                "transfer_cluster_snapshot_staleness_ms",
+                "Current Transfer cluster metadata snapshot staleness in milliseconds",
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            cluster_snapshot_live_workers: m::new_gauge(
+                "transfer_cluster_snapshot_live_workers",
+                "Current live workers in the Transfer cluster snapshot",
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            cluster_snapshot_capable_workers: m::new_gauge(
+                "transfer_cluster_snapshot_capable_workers",
+                "Current live workers with Transfer capabilities in the Transfer cluster snapshot",
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            cluster_snapshot_refresh_total: m::new_counter_vec(
+                "transfer_cluster_snapshot_refresh_total",
+                "Transfer cluster metadata snapshot refresh attempts by result",
+                &["result"],
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+            cluster_snapshot_refresh_duration_us: m::new_histogram_vec_with_buckets(
+                "transfer_cluster_snapshot_refresh_duration_us",
+                "Transfer cluster metadata snapshot refresh latency in microseconds",
+                &["result"],
+                &[
+                    100.0,
+                    500.0,
+                    1_000.0,
+                    5_000.0,
+                    10_000.0,
+                    50_000.0,
+                    100_000.0,
+                    500_000.0,
+                    1_000_000.0,
+                    5_000_000.0,
+                ],
+            )
+            .map_err(|err| FsError::common(err.to_string()))?,
+        };
+        for backend in ["memory", "sqlite", "mysql"] {
+            metrics
+                .store_unavailable
+                .with_label_values(&[backend])
+                .set(0);
+            metrics
+                .store_unavailable_duration_us_total
+                .with_label_values(&[backend])
+                .inc_by(0);
+        }
+        Ok(metrics)
+    }
+
+    pub fn inc_submit(&self, kind: &str, result: &str) {
+        self.submit_total.with_label_values(&[kind, result]).inc();
+    }
+
+    pub fn inc_report(&self, result: &str) {
+        self.report_total.with_label_values(&[result]).inc();
+    }
+
+    pub fn set_report_queue_len(&self, value: usize) {
+        self.report_queue_len.set(value as i64);
+    }
+
+    pub fn set_report_queue_len_by_lane(&self, progress: usize, terminal: usize) {
+        self.report_queue_len_by_lane
+            .with_label_values(&["progress"])
+            .set(progress as i64);
+        self.report_queue_len_by_lane
+            .with_label_values(&["terminal"])
+            .set(terminal as i64);
+    }
+
+    pub fn set_job_counts(&self, active: u64, executing: u64) {
+        let pending = active.saturating_sub(executing);
+        self.active_jobs.set(active as i64);
+        self.executing_jobs.set(executing as i64);
+        self.pending_jobs.set(pending as i64);
+    }
+
+    pub fn inc_cleanup_purged(&self, value: usize) {
+        if value > 0 {
+            self.cleanup_purged_total.inc_by(value as i64);
+        }
+    }
+
+    pub fn inc_acquire(&self, result: &str) {
+        self.acquire_total.with_label_values(&[result]).inc();
+    }
+
+    pub fn inc_planning(&self, kind: &str, result: &str) {
+        self.planning_total.with_label_values(&[kind, result]).inc();
+    }
+
+    pub fn inc_dispatch(&self, result: &str, value: usize) {
+        if value > 0 {
+            self.dispatch_total
+                .with_label_values(&[result])
+                .inc_by(value as i64);
+        }
+    }
+
+    pub fn inc_lease_renew(&self, result: &str) {
+        self.lease_renew_total.with_label_values(&[result]).inc();
+    }
+
+    pub fn inc_stale_retry(&self, result: &str) {
+        self.stale_retry_total.with_label_values(&[result]).inc();
+    }
+
+    pub fn inc_terminal(&self, state: &str, reason: &str) {
+        self.terminal_total
+            .with_label_values(&[state, reason])
+            .inc();
+    }
+
+    pub fn observe_store_operation(
+        &self,
+        backend: &str,
+        operation: &str,
+        result: &str,
+        elapsed_us: u128,
+    ) {
+        let labels = &[backend, operation, result];
+        self.store_operation_duration_us
+            .with_label_values(labels)
+            .observe(elapsed_us as f64);
+        self.store_operation_total.with_label_values(labels).inc();
+    }
+
+    pub fn record_store_unavailable(&self, backend: &str, operation: &str) {
+        self.store_unavailable.with_label_values(&[backend]).set(1);
+        self.store_unavailable_total
+            .with_label_values(&[backend, operation])
+            .inc();
+        if let Ok(mut unavailable_since) = self.store_unavailable_since.lock() {
+            unavailable_since
+                .entry(backend.to_string())
+                .or_insert_with(Instant::now);
+        }
+    }
+
+    pub fn record_store_available(&self, backend: &str) {
+        self.store_unavailable.with_label_values(&[backend]).set(0);
+        if let Ok(mut unavailable_since) = self.store_unavailable_since.lock() {
+            if let Some(start) = unavailable_since.remove(backend) {
+                let elapsed_us = start.elapsed().as_micros();
+                if elapsed_us > 0 {
+                    self.store_unavailable_duration_us_total
+                        .with_label_values(&[backend])
+                        .inc_by(elapsed_us.min(i64::MAX as u128) as i64);
+                }
+            }
+        }
+    }
+
+    pub fn is_store_unavailable(&self, backend: &str) -> bool {
+        self.store_unavailable_since
+            .lock()
+            .map(|unavailable_since| unavailable_since.contains_key(backend))
+            .unwrap_or(true)
+    }
+
+    pub fn observe_metadata_operation(
+        &self,
+        source: &str,
+        operation: &str,
+        result: &str,
+        elapsed_us: u128,
+    ) {
+        let labels = &[source, operation, result];
+        self.metadata_operation_duration_us
+            .with_label_values(labels)
+            .observe(elapsed_us as f64);
+        self.metadata_operation_total
+            .with_label_values(labels)
+            .inc();
+    }
+
+    pub fn observe_metadata_replica_refresh(&self, obs: MetadataReplicaRefreshObservation<'_>) {
+        self.metadata_replica_refresh_total
+            .with_label_values(&[obs.result])
+            .inc();
+        self.metadata_replica_refresh_duration_us
+            .with_label_values(&[obs.result])
+            .observe(obs.elapsed_us as f64);
+        if let Some(version) = obs.version {
+            self.metadata_replica_version.set(version as i64);
+        }
+        if let Some(entries) = obs.entries {
+            self.metadata_replica_entries.set(entries as i64);
+        }
+        if let Some(page_size) = obs.page_size {
+            self.metadata_replica_page_size.set(page_size as i64);
+        }
+        if let Some(pages) = obs.pages {
+            self.metadata_replica_pages.set(pages as i64);
+        }
+        if let Some(refresh_time_ms) = obs.refresh_time_ms {
+            self.metadata_replica_last_refresh_time_ms
+                .set(refresh_time_ms);
+        }
+    }
+
+    pub fn observe_cluster_snapshot_refresh(
+        &self,
+        result: &str,
+        elapsed_us: u128,
+        version: Option<u64>,
+        updated_at_ms: Option<i64>,
+        live_workers: Option<usize>,
+        capable_workers: Option<usize>,
+    ) {
+        self.cluster_snapshot_refresh_total
+            .with_label_values(&[result])
+            .inc();
+        self.cluster_snapshot_refresh_duration_us
+            .with_label_values(&[result])
+            .observe(elapsed_us as f64);
+        self.set_cluster_snapshot(version, updated_at_ms, live_workers, capable_workers);
+    }
+
+    pub fn set_cluster_snapshot(
+        &self,
+        version: Option<u64>,
+        updated_at_ms: Option<i64>,
+        live_workers: Option<usize>,
+        capable_workers: Option<usize>,
+    ) {
+        if let Some(version) = version {
+            self.cluster_snapshot_version.set(version as i64);
+        }
+        if let Some(updated_at_ms) = updated_at_ms {
+            let staleness_ms =
+                orpc::common::LocalTime::mills().saturating_sub(updated_at_ms.max(0) as u64);
+            self.cluster_snapshot_staleness_ms.set(staleness_ms as i64);
+        }
+        if let Some(live_workers) = live_workers {
+            self.cluster_snapshot_live_workers.set(live_workers as i64);
+        }
+        if let Some(capable_workers) = capable_workers {
+            self.cluster_snapshot_capable_workers
+                .set(capable_workers as i64);
+        }
+    }
+}
+
+impl Debug for TransferMetrics {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "TransferMetrics")
+    }
+}

--- a/curvine-server/src/transfer/mod.rs
+++ b/curvine-server/src/transfer/mod.rs
@@ -9,3 +9,12 @@ pub use self::sqlite_store::SqliteTransferStore;
 
 mod mysql_store;
 pub use self::mysql_store::MysqlTransferStore;
+
+mod metrics;
+pub use self::metrics::{MetadataReplicaRefreshObservation, TransferMetrics};
+
+mod backend;
+pub use self::backend::TransferStoreBackend;
+
+mod cluster_cache;
+pub use self::cluster_cache::ClusterMetadataCache;


### PR DESCRIPTION
# Summary

Adds store selection, Transfer metrics, and refreshable cluster mount metadata cache.

# Issue Describe / Design

The RPC foundations in #1362 are intentionally introduced first. This PR remains focused on the backend and cache, and no longer exports scheduler-only helpers before their first use.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-server/src/transfer/backend.rs`, `curvine-server/src/transfer/cluster_cache.rs` | Add Transfer store selection, metrics, and cluster metadata cache. | New Transfer behavior; legacy behavior remains available unless Transfer is enabled. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo clippy --all-targets --jobs 4 -- --deny=warnings --allow clippy::uninlined-format-args` | PASS | Run on the reconstructed branch. |

# Dependencies

- Related PRs: #1362
- Related issues: #1040
- Blocks / blocked by: #1349