### PR TITLE
feat(transfer): add metadata reader and planner

### DIFF
--- a/curvine-server/src/transfer/cv_metadata_reader.rs
+++ b/curvine-server/src/transfer/cv_metadata_reader.rs
@@ -1,0 +1,748 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use curvine_client::file::CurvineFileSystem;
+use curvine_common::error::FsError;
+use curvine_common::fs::Path;
+use curvine_common::state::{FileBlocks, FileStatus};
+use curvine_common::utils::ProtoUtils;
+use curvine_common::FsResult;
+use futures::future::BoxFuture;
+use log::{info, warn};
+use orpc::common::LocalTime;
+use parking_lot::RwLock;
+use std::collections::{HashMap, VecDeque};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use crate::transfer::{MetadataReplicaRefreshObservation, TransferMetrics};
+
+pub trait CvMetadataReader: Send + Sync + 'static {
+    fn current_epoch(&self) -> FsResult<Option<u64>>;
+
+    fn current_refresh_time_ms(&self) -> FsResult<Option<i64>> {
+        Ok(None)
+    }
+
+    fn covers_time_ms(&self, _time_ms: i64) -> FsResult<bool> {
+        Ok(true)
+    }
+
+    fn get_status<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, FsResult<FileStatus>>;
+
+    fn get_status_at_epoch<'a>(
+        &'a self,
+        path: &'a Path,
+        _epoch: Option<u64>,
+    ) -> BoxFuture<'a, FsResult<FileStatus>> {
+        self.get_status(path)
+    }
+
+    fn list_status<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, FsResult<Vec<FileStatus>>>;
+
+    fn list_status_at_epoch<'a>(
+        &'a self,
+        path: &'a Path,
+        _epoch: Option<u64>,
+    ) -> BoxFuture<'a, FsResult<Vec<FileStatus>>> {
+        self.list_status(path)
+    }
+
+    fn get_block_locations<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, FsResult<FileBlocks>>;
+
+    fn get_block_locations_at_epoch<'a>(
+        &'a self,
+        path: &'a Path,
+        _epoch: Option<u64>,
+    ) -> BoxFuture<'a, FsResult<FileBlocks>> {
+        self.get_block_locations(path)
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct DisabledCvMetadataReader;
+
+impl DisabledCvMetadataReader {
+    fn disabled_error(path: &Path) -> FsError {
+        FsError::common(format!(
+            "CV metadata reader is disabled for {}; configure a production metadata replica, or explicitly enable transfer.cv_metadata_reader=master for development only",
+            path.full_path()
+        ))
+    }
+}
+
+impl CvMetadataReader for DisabledCvMetadataReader {
+    fn current_epoch(&self) -> FsResult<Option<u64>> {
+        Ok(None)
+    }
+
+    fn current_refresh_time_ms(&self) -> FsResult<Option<i64>> {
+        Ok(None)
+    }
+
+    fn covers_time_ms(&self, _time_ms: i64) -> FsResult<bool> {
+        Ok(false)
+    }
+
+    fn get_status<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, FsResult<FileStatus>> {
+        Box::pin(async move { Err(Self::disabled_error(path)) })
+    }
+
+    fn list_status<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, FsResult<Vec<FileStatus>>> {
+        Box::pin(async move { Err(Self::disabled_error(path)) })
+    }
+
+    fn get_block_locations<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, FsResult<FileBlocks>> {
+        Box::pin(async move { Err(Self::disabled_error(path)) })
+    }
+}
+
+#[derive(Clone)]
+pub struct MasterCvMetadataReader {
+    fs: CurvineFileSystem,
+}
+
+impl MasterCvMetadataReader {
+    pub fn new(fs: CurvineFileSystem) -> Self {
+        Self { fs }
+    }
+}
+
+impl CvMetadataReader for MasterCvMetadataReader {
+    fn current_epoch(&self) -> FsResult<Option<u64>> {
+        Ok(None)
+    }
+
+    fn current_refresh_time_ms(&self) -> FsResult<Option<i64>> {
+        Ok(None)
+    }
+
+    fn get_status<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, FsResult<FileStatus>> {
+        Box::pin(async move { self.fs.get_status(path).await })
+    }
+
+    fn list_status<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, FsResult<Vec<FileStatus>>> {
+        Box::pin(async move { self.fs.list_status(path).await })
+    }
+
+    fn get_block_locations<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, FsResult<FileBlocks>> {
+        Box::pin(async move { self.fs.get_block_locations(path).await })
+    }
+}
+
+#[derive(Clone)]
+pub struct MetadataReplicaReader {
+    inner: Arc<MetadataReplicaInner>,
+}
+
+struct MetadataReplicaInner {
+    fs: CurvineFileSystem,
+    state: RwLock<MetadataReplicaState>,
+    max_entries: usize,
+    page_size: usize,
+    history_size: usize,
+    max_staleness: Duration,
+}
+
+#[derive(Clone, Default)]
+struct MetadataReplicaState {
+    current: MetadataReplicaSnapshot,
+    history: VecDeque<MetadataReplicaSnapshot>,
+}
+
+#[derive(Clone, Default)]
+struct MetadataReplicaSnapshot {
+    version: u64,
+    refresh_time_ms: i64,
+    statuses: HashMap<String, FileStatus>,
+    children: HashMap<String, Vec<FileStatus>>,
+    blocks: HashMap<String, FileBlocks>,
+}
+
+impl MetadataReplicaReader {
+    pub fn new(
+        fs: CurvineFileSystem,
+        max_entries: usize,
+        page_size: usize,
+        history_size: usize,
+        max_staleness: Duration,
+    ) -> Self {
+        Self {
+            inner: Arc::new(MetadataReplicaInner {
+                fs,
+                state: RwLock::new(MetadataReplicaState::default()),
+                max_entries,
+                page_size,
+                history_size,
+                max_staleness,
+            }),
+        }
+    }
+
+    pub fn start_refresh_loop(&self, interval: Duration, stop: Arc<AtomicBool>) {
+        let reader = self.clone();
+        tokio::spawn(async move {
+            while !stop.load(Ordering::Relaxed) {
+                if wait_or_stopped(interval, &stop).await {
+                    break;
+                }
+                if let Err(err) = reader.refresh().await {
+                    warn!("metadata replica refresh failed: {}", err);
+                }
+            }
+        });
+    }
+
+    pub async fn refresh(&self) -> FsResult<u64> {
+        let start = Instant::now();
+        match self.refresh_delta(start).await {
+            Ok(Some(version)) => return Ok(version),
+            Ok(None) => {}
+            Err(err) => {
+                warn!(
+                    "metadata replica delta refresh failed, falling back to full snapshot: {}",
+                    err
+                );
+            }
+        }
+        self.refresh_full(start).await
+    }
+
+    async fn refresh_delta(&self, start: Instant) -> FsResult<Option<u64>> {
+        let mut snapshot = {
+            let state = self.inner.state.read();
+            if state.current.refresh_time_ms <= 0 {
+                return Ok(None);
+            }
+            state.current.clone()
+        };
+        let from_epoch = snapshot.version;
+        let mut target_epoch = None;
+        let mut page_token = None;
+        let mut page_count = 0usize;
+        loop {
+            let page = self
+                .inner
+                .fs
+                .get_cv_metadata_delta_page(
+                    from_epoch,
+                    target_epoch,
+                    page_token.clone(),
+                    Some(self.inner.page_size as u32),
+                )
+                .await?;
+            page_count = page_count.saturating_add(1);
+            if page.full_snapshot_required {
+                return Ok(None);
+            }
+            if page.from_epoch != from_epoch {
+                return Err(FsError::common(format!(
+                    "Metadata replica delta from_epoch mismatch: expected={}, actual={}",
+                    from_epoch, page.from_epoch
+                )));
+            }
+            if let Some(epoch) = target_epoch {
+                if epoch != page.to_epoch {
+                    return Err(FsError::common(format!(
+                        "Metadata replica delta target epoch changed during refresh: expected={}, actual={}",
+                        epoch, page.to_epoch
+                    )));
+                }
+            } else {
+                target_epoch = Some(page.to_epoch);
+            }
+
+            for entry in page.entries {
+                apply_delta_entry(&mut snapshot, entry)?;
+            }
+
+            match page.next_page_token {
+                Some(next) if Some(next.clone()) != page_token => page_token = Some(next),
+                Some(next) => {
+                    return Err(FsError::common(format!(
+                        "Metadata replica delta page token did not advance: {}",
+                        next
+                    )));
+                }
+                None => break,
+            }
+        }
+
+        rebuild_snapshot_children(&mut snapshot);
+        self.check_entry_limit(snapshot.statuses.len())?;
+        let version = target_epoch.unwrap_or(from_epoch);
+        snapshot.version = version;
+        let entries = snapshot.statuses.len();
+        let refresh_time_ms = LocalTime::mills() as i64;
+        snapshot.refresh_time_ms = refresh_time_ms;
+        self.publish_snapshot(snapshot);
+        record_replica_refresh(
+            "success",
+            start,
+            Some(version),
+            Some(entries),
+            Some(self.inner.page_size),
+            Some(page_count),
+            Some(refresh_time_ms),
+        );
+        info!(
+            "metadata replica delta refreshed: from_epoch={}, version={}, entries={}",
+            from_epoch, version, entries
+        );
+        Ok(Some(version))
+    }
+
+    async fn refresh_full(&self, start: Instant) -> FsResult<u64> {
+        let mut snapshot = MetadataReplicaSnapshot::default();
+
+        let mut page_token = None;
+        let mut expected_epoch = None;
+        let mut page_count = 0usize;
+        loop {
+            let page = match self
+                .inner
+                .fs
+                .get_cv_metadata_snapshot_page(
+                    page_token.clone(),
+                    Some(self.inner.page_size as u32),
+                )
+                .await
+            {
+                Ok(page) => page,
+                Err(err) => {
+                    record_replica_refresh(
+                        "failure",
+                        start,
+                        expected_epoch,
+                        Some(snapshot.statuses.len()),
+                        Some(self.inner.page_size),
+                        Some(page_count),
+                        None,
+                    );
+                    return Err(err);
+                }
+            };
+            page_count = page_count.saturating_add(1);
+
+            if let Some(epoch) = expected_epoch {
+                if epoch != page.epoch {
+                    record_replica_refresh(
+                        "failure",
+                        start,
+                        Some(epoch),
+                        Some(snapshot.statuses.len()),
+                        Some(self.inner.page_size),
+                        Some(page_count),
+                        None,
+                    );
+                    return Err(FsError::common(format!(
+                        "Metadata replica snapshot epoch changed during refresh: expected={}, actual={}",
+                        epoch, page.epoch
+                    )));
+                }
+            } else {
+                expected_epoch = Some(page.epoch);
+            }
+
+            for entry in page.entries {
+                let status = ProtoUtils::file_status_from_pb(entry.status);
+                let path = match Path::from_str(&status.path) {
+                    Ok(path) => path,
+                    Err(err) => {
+                        record_replica_refresh(
+                            "failure",
+                            start,
+                            expected_epoch,
+                            Some(snapshot.statuses.len()),
+                            Some(self.inner.page_size),
+                            Some(page_count),
+                            None,
+                        );
+                        return Err(replica_error(err));
+                    }
+                };
+                let key = normalized_cv_key(&path);
+                if status.is_dir {
+                    snapshot.children.entry(key.clone()).or_default();
+                } else if let Some(blocks) = entry.blocks {
+                    snapshot
+                        .blocks
+                        .insert(key.clone(), ProtoUtils::file_blocks_from_pb(blocks));
+                }
+
+                if key != "/" {
+                    let parent_key = parent_cv_key(&key);
+                    snapshot
+                        .children
+                        .entry(parent_key)
+                        .or_default()
+                        .push(status.clone());
+                }
+                snapshot.statuses.insert(key, status);
+                if let Err(err) = self.check_entry_limit(snapshot.statuses.len()) {
+                    record_replica_refresh(
+                        "failure",
+                        start,
+                        expected_epoch,
+                        Some(snapshot.statuses.len()),
+                        Some(self.inner.page_size),
+                        Some(page_count),
+                        None,
+                    );
+                    return Err(err);
+                }
+            }
+
+            match page.next_page_token {
+                Some(next) if Some(next.clone()) != page_token => page_token = Some(next),
+                Some(next) => {
+                    record_replica_refresh(
+                        "failure",
+                        start,
+                        expected_epoch,
+                        Some(snapshot.statuses.len()),
+                        Some(self.inner.page_size),
+                        Some(page_count),
+                        None,
+                    );
+                    return Err(FsError::common(format!(
+                        "Metadata replica snapshot page token did not advance: {}",
+                        next
+                    )));
+                }
+                None => break,
+            }
+        }
+
+        if !snapshot.statuses.contains_key("/") {
+            record_replica_refresh(
+                "failure",
+                start,
+                expected_epoch,
+                Some(0),
+                Some(self.inner.page_size),
+                Some(page_count),
+                None,
+            );
+            return Err(FsError::common(
+                "Metadata replica snapshot did not include root entry",
+            ));
+        }
+        for children in snapshot.children.values_mut() {
+            children.sort_by(|left, right| left.name.cmp(&right.name));
+        }
+
+        let current_version = self.inner.state.read().current.version;
+        snapshot.version = expected_epoch.unwrap_or_else(|| current_version.saturating_add(1));
+        let version = snapshot.version;
+        let entries = snapshot.statuses.len();
+        let refresh_time_ms = LocalTime::mills() as i64;
+        snapshot.refresh_time_ms = refresh_time_ms;
+        self.publish_snapshot(snapshot);
+        record_replica_refresh(
+            "success",
+            start,
+            Some(version),
+            Some(entries),
+            Some(self.inner.page_size),
+            Some(page_count),
+            Some(refresh_time_ms),
+        );
+        info!(
+            "metadata replica refreshed: version={}, entries={}",
+            version, entries
+        );
+        Ok(version)
+    }
+
+    fn publish_snapshot(&self, snapshot: MetadataReplicaSnapshot) {
+        let mut guard = self.inner.state.write();
+        let previous = std::mem::replace(&mut guard.current, snapshot);
+        if previous.refresh_time_ms > 0 && previous.version != guard.current.version {
+            guard.history.push_front(previous);
+            let max_previous = self.inner.history_size.saturating_sub(1);
+            while guard.history.len() > max_previous {
+                guard.history.pop_back();
+            }
+        }
+    }
+
+    fn check_entry_limit(&self, entries: usize) -> FsResult<()> {
+        if entries > self.inner.max_entries {
+            return Err(FsError::common(format!(
+                "Metadata replica entry limit exceeded: entries={}, limit={}",
+                entries, self.inner.max_entries
+            )));
+        }
+        Ok(())
+    }
+
+    fn check_snapshot_fresh(&self, snapshot: &MetadataReplicaSnapshot) -> FsResult<()> {
+        if snapshot.refresh_time_ms <= 0 {
+            return Err(FsError::common(
+                "Metadata replica is not ready; wait for initial refresh",
+            ));
+        }
+        let now_ms = LocalTime::mills() as i64;
+        let max_staleness_ms = self.inner.max_staleness.as_millis().min(i64::MAX as u128) as i64;
+        let staleness_ms = now_ms.saturating_sub(snapshot.refresh_time_ms);
+        if staleness_ms > max_staleness_ms {
+            return Err(FsError::common(format!(
+                "Metadata replica is stale: staleness_ms={}, max_staleness_ms={}, version={}",
+                staleness_ms, max_staleness_ms, snapshot.version
+            )));
+        }
+        Ok(())
+    }
+
+    fn with_snapshot_at_epoch<T>(
+        &self,
+        epoch: Option<u64>,
+        path: &Path,
+        f: impl FnOnce(&MetadataReplicaSnapshot, &str) -> FsResult<T>,
+    ) -> FsResult<T> {
+        let key = normalized_cv_key(path);
+        let state = self.inner.state.read();
+        let snapshot = match epoch {
+            Some(epoch) if state.current.version != epoch => state
+                .history
+                .iter()
+                .find(|snapshot| snapshot.version == epoch)
+                .ok_or_else(|| {
+                    FsError::common(format!(
+                        "CV metadata replica epoch {} is no longer available for {}",
+                        epoch,
+                        path.full_path()
+                    ))
+                })?,
+            _ => &state.current,
+        };
+        self.check_snapshot_fresh(snapshot)?;
+        f(snapshot, &key)
+    }
+}
+
+impl CvMetadataReader for MetadataReplicaReader {
+    fn current_epoch(&self) -> FsResult<Option<u64>> {
+        let state = self.inner.state.read();
+        self.check_snapshot_fresh(&state.current)?;
+        Ok(Some(state.current.version))
+    }
+
+    fn current_refresh_time_ms(&self) -> FsResult<Option<i64>> {
+        let state = self.inner.state.read();
+        self.check_snapshot_fresh(&state.current)?;
+        Ok(Some(state.current.refresh_time_ms))
+    }
+
+    fn covers_time_ms(&self, time_ms: i64) -> FsResult<bool> {
+        let state = self.inner.state.read();
+        self.check_snapshot_fresh(&state.current)?;
+        Ok(state.current.refresh_time_ms >= time_ms)
+    }
+
+    fn get_status<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, FsResult<FileStatus>> {
+        self.get_status_at_epoch(path, None)
+    }
+
+    fn get_status_at_epoch<'a>(
+        &'a self,
+        path: &'a Path,
+        epoch: Option<u64>,
+    ) -> BoxFuture<'a, FsResult<FileStatus>> {
+        Box::pin(async move {
+            self.with_snapshot_at_epoch(epoch, path, |snapshot, key| {
+                snapshot
+                    .statuses
+                    .get(key)
+                    .cloned()
+                    .ok_or_else(|| FsError::file_not_found(path.full_path()))
+            })
+        })
+    }
+
+    fn list_status<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, FsResult<Vec<FileStatus>>> {
+        self.list_status_at_epoch(path, None)
+    }
+
+    fn list_status_at_epoch<'a>(
+        &'a self,
+        path: &'a Path,
+        epoch: Option<u64>,
+    ) -> BoxFuture<'a, FsResult<Vec<FileStatus>>> {
+        Box::pin(async move {
+            self.with_snapshot_at_epoch(epoch, path, |snapshot, key| {
+                let status = snapshot
+                    .statuses
+                    .get(key)
+                    .ok_or_else(|| FsError::file_not_found(path.full_path()))?;
+                if !status.is_dir {
+                    return Err(FsError::common(format!(
+                        "Path {} is not a directory",
+                        path.full_path()
+                    )));
+                }
+                Ok(snapshot.children.get(key).cloned().unwrap_or_default())
+            })
+        })
+    }
+
+    fn get_block_locations<'a>(&'a self, path: &'a Path) -> BoxFuture<'a, FsResult<FileBlocks>> {
+        self.get_block_locations_at_epoch(path, None)
+    }
+
+    fn get_block_locations_at_epoch<'a>(
+        &'a self,
+        path: &'a Path,
+        epoch: Option<u64>,
+    ) -> BoxFuture<'a, FsResult<FileBlocks>> {
+        Box::pin(async move {
+            self.with_snapshot_at_epoch(epoch, path, |snapshot, key| {
+                snapshot
+                    .blocks
+                    .get(key)
+                    .cloned()
+                    .ok_or_else(|| FsError::file_not_found(path.full_path()))
+            })
+        })
+    }
+}
+
+async fn wait_or_stopped(interval: Duration, stop: &AtomicBool) -> bool {
+    let deadline = Instant::now() + interval;
+    while !stop.load(Ordering::Relaxed) {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return false;
+        }
+        tokio::time::sleep(remaining.min(Duration::from_millis(100))).await;
+    }
+    true
+}
+
+fn normalized_cv_key(path: &Path) -> String {
+    let text = path.path().trim_end_matches('/');
+    if text.is_empty() {
+        "/".to_string()
+    } else {
+        text.to_string()
+    }
+}
+
+fn parent_cv_key(key: &str) -> String {
+    match key.rsplit_once('/') {
+        Some(("", _)) | None => "/".to_string(),
+        Some((parent, _)) => parent.to_string(),
+    }
+}
+
+fn apply_delta_entry(
+    snapshot: &mut MetadataReplicaSnapshot,
+    entry: curvine_common::proto::CvMetadataDeltaEntryProto,
+) -> FsResult<()> {
+    let path = Path::from_str(&entry.path).map_err(replica_error)?;
+    let key = normalized_cv_key(&path);
+    match entry.entry {
+        Some(entry) => {
+            let status = ProtoUtils::file_status_from_pb(entry.status);
+            if status.is_dir {
+                snapshot.children.entry(key.clone()).or_default();
+                snapshot.blocks.remove(&key);
+            } else if let Some(blocks) = entry.blocks {
+                snapshot
+                    .blocks
+                    .insert(key.clone(), ProtoUtils::file_blocks_from_pb(blocks));
+                snapshot.children.remove(&key);
+            } else {
+                snapshot.blocks.remove(&key);
+                snapshot.children.remove(&key);
+            }
+            snapshot.statuses.insert(key, status);
+        }
+        None => remove_snapshot_subtree(snapshot, &key),
+    }
+    Ok(())
+}
+
+fn remove_snapshot_subtree(snapshot: &mut MetadataReplicaSnapshot, key: &str) {
+    let prefix = if key == "/" {
+        "/".to_string()
+    } else {
+        format!("{key}/")
+    };
+    let removed: Vec<String> = snapshot
+        .statuses
+        .keys()
+        .filter(|path| path.as_str() == key || path.starts_with(&prefix))
+        .cloned()
+        .collect();
+    for path in removed {
+        snapshot.statuses.remove(&path);
+        snapshot.children.remove(&path);
+        snapshot.blocks.remove(&path);
+    }
+}
+
+fn rebuild_snapshot_children(snapshot: &mut MetadataReplicaSnapshot) {
+    snapshot.children.clear();
+    let mut statuses: Vec<FileStatus> = snapshot.statuses.values().cloned().collect();
+    statuses.sort_by(|left, right| left.path.cmp(&right.path));
+    for status in statuses {
+        let Ok(path) = Path::from_str(&status.path) else {
+            continue;
+        };
+        let key = normalized_cv_key(&path);
+        if status.is_dir {
+            snapshot.children.entry(key.clone()).or_default();
+        }
+        if key != "/" {
+            let parent_key = parent_cv_key(&key);
+            snapshot
+                .children
+                .entry(parent_key)
+                .or_default()
+                .push(status);
+        }
+    }
+    for children in snapshot.children.values_mut() {
+        children.sort_by(|left, right| left.name.cmp(&right.name));
+    }
+}
+
+fn record_replica_refresh(
+    result: &str,
+    start: Instant,
+    version: Option<u64>,
+    entries: Option<usize>,
+    page_size: Option<usize>,
+    pages: Option<usize>,
+    refresh_time_ms: Option<i64>,
+) {
+    if let Ok(metrics) = TransferMetrics::get() {
+        metrics.observe_metadata_replica_refresh(MetadataReplicaRefreshObservation {
+            result,
+            elapsed_us: start.elapsed().as_micros(),
+            version,
+            entries,
+            page_size,
+            pages,
+            refresh_time_ms,
+        });
+    }
+}
+
+fn replica_error(err: impl std::fmt::Display) -> FsError {
+    FsError::common(format!("Metadata replica refresh failed: {}", err))
+}

--- a/curvine-server/src/transfer/job_snapshot.rs
+++ b/curvine-server/src/transfer/job_snapshot.rs
@@ -1,0 +1,42 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::transfer::ClusterMetadataCache;
+use curvine_common::error::FsError;
+use curvine_common::fs::Path;
+use curvine_common::state::{MountInfo, TransferJobRecord};
+use curvine_common::FsResult;
+
+pub fn job_mount_snapshot(
+    job: &TransferJobRecord,
+    cache: &ClusterMetadataCache,
+) -> FsResult<MountInfo> {
+    if !is_empty_snapshot(&job.mount_snapshot_json) {
+        return serde_json::from_str(&job.mount_snapshot_json).map_err(|_| {
+            FsError::common(format!(
+                "Stored transfer mount snapshot for job {} is invalid",
+                job.job_id
+            ))
+        });
+    }
+
+    let source = Path::from_str(&job.source_path)?;
+    let target = Path::from_str(&job.target_path)?;
+    cache.find_mount(job.kind, &source, &target)
+}
+
+fn is_empty_snapshot(value: &str) -> bool {
+    let value = value.trim();
+    value.is_empty() || value == "{}"
+}

--- a/curvine-server/src/transfer/mod.rs
+++ b/curvine-server/src/transfer/mod.rs
@@ -18,3 +18,14 @@ pub use self::backend::TransferStoreBackend;
 
 mod cluster_cache;
 pub use self::cluster_cache::ClusterMetadataCache;
+
+mod cv_metadata_reader;
+pub use self::cv_metadata_reader::{
+    CvMetadataReader, DisabledCvMetadataReader, MasterCvMetadataReader, MetadataReplicaReader,
+};
+
+mod job_snapshot;
+pub use self::job_snapshot::job_mount_snapshot;
+
+mod planner;
+pub use self::planner::{PlannedTransfer, TransferPlanner};

--- a/curvine-server/src/transfer/planner.rs
+++ b/curvine-server/src/transfer/planner.rs
@@ -1,0 +1,435 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::common::UfsFactory;
+use crate::transfer::{
+    job_mount_snapshot, ClusterMetadataCache, CvMetadataReader, TransferMetrics,
+};
+use curvine_common::conf::ClientConf;
+use curvine_common::error::FsError;
+use curvine_common::fs::{FileSystem, Path};
+use curvine_common::state::{
+    FileStatus, LoadJobInfo, MountInfo, TransferCommand, TransferJobRecord, TransferKind,
+    TransferTaskRecord, TransferTaskState,
+};
+use curvine_common::FsResult;
+use orpc::common::LocalTime;
+use orpc::err_box;
+use parking_lot::Mutex;
+use std::collections::{HashMap, VecDeque};
+use std::sync::Arc;
+use std::time::Instant;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+const MAX_EXPORT_EPOCH_PLAN_RETRIES: usize = 3;
+
+pub struct PlannedTransfer {
+    pub job_info: LoadJobInfo,
+    pub tasks: Vec<TransferTaskRecord>,
+    pub total_size: i64,
+    pub cv_metadata_epoch: Option<u64>,
+}
+
+#[derive(Clone)]
+pub struct TransferPlanner {
+    cv_metadata: Arc<dyn CvMetadataReader>,
+    factory: Arc<UfsFactory>,
+    cache: ClusterMetadataCache,
+    client_conf: ClientConf,
+    max_tasks_per_transfer: usize,
+    ufs_limiter: Arc<UfsEndpointLimiter>,
+}
+
+impl TransferPlanner {
+    pub fn new(
+        cv_metadata: Arc<dyn CvMetadataReader>,
+        factory: Arc<UfsFactory>,
+        cache: ClusterMetadataCache,
+        client_conf: ClientConf,
+        max_tasks_per_transfer: usize,
+        ufs_max_concurrency_per_endpoint: usize,
+    ) -> Self {
+        Self {
+            cv_metadata,
+            factory,
+            cache,
+            client_conf,
+            max_tasks_per_transfer,
+            ufs_limiter: Arc::new(UfsEndpointLimiter::new(ufs_max_concurrency_per_endpoint)),
+        }
+    }
+
+    pub async fn plan(&self, job: &TransferJobRecord) -> FsResult<PlannedTransfer> {
+        for attempt in 0..MAX_EXPORT_EPOCH_PLAN_RETRIES {
+            let cv_metadata_epoch = self.export_epoch_before_plan(job)?;
+            let planned = self.plan_once(job, cv_metadata_epoch).await?;
+            if !self.export_epoch_changed(job, cv_metadata_epoch)? {
+                return Ok(planned);
+            }
+            log::warn!(
+                "CV metadata replica epoch changed while planning export {}, retry {}/{}",
+                job.job_id,
+                attempt + 1,
+                MAX_EXPORT_EPOCH_PLAN_RETRIES
+            );
+        }
+        Err(FsError::common(format!(
+            "CV metadata replica epoch changed during export planning {} after {} retries",
+            job.job_id, MAX_EXPORT_EPOCH_PLAN_RETRIES
+        )))
+    }
+
+    async fn plan_once(
+        &self,
+        job: &TransferJobRecord,
+        cv_metadata_epoch: Option<u64>,
+    ) -> FsResult<PlannedTransfer> {
+        let source = Path::from_str(&job.source_path)?;
+        let target = Path::from_str(&job.target_path)?;
+        let mount = job_mount_snapshot(job, &self.cache)?;
+        let job_info = self.load_job_info(job, &mount);
+        let source_status = self
+            .get_status(job, &source, &mount, cv_metadata_epoch)
+            .await?;
+        if source_status.is_dir {
+            self.validate_directory_target(job, &target, &mount, cv_metadata_epoch)
+                .await?;
+        }
+
+        let mut tasks = Vec::new();
+        let mut total_size = 0;
+        let mut stack = VecDeque::new();
+        stack.push_back(source_status);
+
+        while let Some(status) = stack.pop_front() {
+            let path = Path::from_str(&status.path)?;
+            if status.is_dir {
+                for child in self
+                    .list_status(job, &path, &mount, cv_metadata_epoch)
+                    .await?
+                {
+                    stack.push_back(child);
+                }
+                continue;
+            }
+
+            let task_target = append_relative_path(&source, &target, &path)?;
+            let task_id = format!("{}_task_{}", job.job_id, tasks.len());
+            let source_read_plan_json = self
+                .source_read_plan_json(job, &path, cv_metadata_epoch)
+                .await?;
+            total_size += status.len;
+            tasks.push(TransferTaskRecord {
+                job_id: job.job_id.clone(),
+                run_id: job.run_id,
+                task_id,
+                attempt_id: 0,
+                source_path: path.clone_uri(),
+                target_path: task_target.clone_uri(),
+                worker_id: 0,
+                worker_session_id: String::new(),
+                source_read_plan_json,
+                report_target_json: String::new(),
+                state: TransferTaskState::Pending,
+                progress: Default::default(),
+                retry_count: 0,
+                attempt_started_at: 0,
+                last_report_at: 0,
+                stale_deadline_at: 0,
+                updated_at: LocalTime::mills() as i64,
+            });
+
+            if tasks.len() > self.max_tasks_per_transfer {
+                return err_box!(
+                    "Transfer {} contains more files than the service allows; reduce the source scope",
+                    job.job_id
+                );
+            }
+        }
+
+        Ok(PlannedTransfer {
+            job_info,
+            tasks,
+            total_size,
+            cv_metadata_epoch,
+        })
+    }
+
+    async fn validate_directory_target(
+        &self,
+        job: &TransferJobRecord,
+        target: &Path,
+        mount: &MountInfo,
+        cv_metadata_epoch: Option<u64>,
+    ) -> FsResult<()> {
+        match self.get_status(job, target, mount, cv_metadata_epoch).await {
+            Ok(status) if status.is_dir => Ok(()),
+            Ok(_) => err_box!(
+                "Transfer target {} is a file; refusing to transfer directory into file",
+                target.full_path()
+            ),
+            Err(FsError::FileNotFound(_)) => Ok(()),
+            Err(err) => Err(err),
+        }
+    }
+
+    fn export_epoch_before_plan(&self, job: &TransferJobRecord) -> FsResult<Option<u64>> {
+        if job.kind != TransferKind::Export {
+            return Ok(None);
+        }
+        let Some(epoch) = self.cv_metadata.current_epoch()? else {
+            return Ok(None);
+        };
+        Ok(Some(job.cv_metadata_epoch.unwrap_or(epoch)))
+    }
+
+    fn export_epoch_changed(
+        &self,
+        job: &TransferJobRecord,
+        epoch_before: Option<u64>,
+    ) -> FsResult<bool> {
+        if job.kind != TransferKind::Export {
+            return Ok(false);
+        }
+        if job.cv_metadata_epoch.is_some() {
+            return Ok(false);
+        }
+        let Some(epoch_before) = epoch_before else {
+            return Ok(false);
+        };
+        let Some(epoch_after) = self.cv_metadata.current_epoch()? else {
+            return Ok(false);
+        };
+        Ok(epoch_before != epoch_after)
+    }
+
+    fn load_job_info(&self, job: &TransferJobRecord, mount: &MountInfo) -> LoadJobInfo {
+        let overwrite = transfer_command(job)
+            .map(|command| command.overwrite())
+            .unwrap_or(true);
+        LoadJobInfo {
+            job_id: job.job_id.clone(),
+            source_path: job.source_path.clone(),
+            target_path: job.target_path.clone(),
+            replicas: mount.replicas.unwrap_or(self.client_conf.replicas),
+            block_size: mount.block_size.unwrap_or(self.client_conf.block_size),
+            storage_type: mount.storage_type.unwrap_or(self.client_conf.storage_type),
+            ttl_ms: mount.ttl_ms,
+            ttl_action: mount.ttl_action,
+            mount_info: mount.clone(),
+            create_time: job.created_at,
+            overwrite: Some(overwrite),
+        }
+    }
+
+    async fn get_status(
+        &self,
+        job: &TransferJobRecord,
+        path: &Path,
+        mount: &MountInfo,
+        cv_metadata_epoch: Option<u64>,
+    ) -> FsResult<FileStatus> {
+        let start = Instant::now();
+        if path.is_cv() {
+            let result = self
+                .cv_metadata
+                .get_status_at_epoch(path, cv_metadata_epoch)
+                .await;
+            record_metadata_operation("cv", "get_status", result.is_ok(), start);
+            result.map_err(|err| self.map_export_cv_not_found(job, path, err))
+        } else {
+            let _permit = self.ufs_limiter.acquire(mount).await?;
+            let result = match self.factory.get_ufs(mount) {
+                Ok(ufs) => ufs.get_status(path).await,
+                Err(err) => Err(err),
+            };
+            record_metadata_operation("ufs", "get_status", result.is_ok(), start);
+            result
+        }
+    }
+
+    fn map_export_cv_not_found(
+        &self,
+        job: &TransferJobRecord,
+        path: &Path,
+        err: FsError,
+    ) -> FsError {
+        if job.kind != TransferKind::Export || !matches!(err, FsError::FileNotFound(_)) {
+            return err;
+        }
+        match self.cv_metadata.covers_time_ms(job.created_at) {
+            Ok(false) => FsError::in_progress_msg(format!(
+                "CV metadata replica has not caught up for export {}: path={}, job_created_at={}",
+                job.job_id,
+                path.full_path(),
+                job.created_at
+            )),
+            Ok(true) => err,
+            Err(refresh_err) => refresh_err,
+        }
+    }
+
+    async fn list_status(
+        &self,
+        job: &TransferJobRecord,
+        path: &Path,
+        mount: &MountInfo,
+        cv_metadata_epoch: Option<u64>,
+    ) -> FsResult<Vec<FileStatus>> {
+        let start = Instant::now();
+        if path.is_cv() {
+            let result = self
+                .cv_metadata
+                .list_status_at_epoch(path, cv_metadata_epoch)
+                .await;
+            record_metadata_operation("cv", "list_status", result.is_ok(), start);
+            result.map_err(|err| self.map_export_cv_not_found(job, path, err))
+        } else {
+            let _permit = self.ufs_limiter.acquire(mount).await?;
+            let result = match self.factory.get_ufs(mount) {
+                Ok(ufs) => ufs.list_status(path).await,
+                Err(err) => Err(err),
+            };
+            record_metadata_operation("ufs", "list_status", result.is_ok(), start);
+            result
+        }
+    }
+
+    async fn source_read_plan_json(
+        &self,
+        job: &TransferJobRecord,
+        path: &Path,
+        cv_metadata_epoch: Option<u64>,
+    ) -> FsResult<String> {
+        if !path.is_cv() {
+            return Ok(String::new());
+        }
+        let start = Instant::now();
+        let blocks = self
+            .cv_metadata
+            .get_block_locations_at_epoch(path, cv_metadata_epoch)
+            .await;
+        record_metadata_operation("cv", "get_block_locations", blocks.is_ok(), start);
+        let blocks = blocks.map_err(|err| self.map_export_cv_not_found(job, path, err))?;
+        serde_json::to_string(&blocks).map_err(|_| {
+            FsError::common(format!(
+                "Unable to prepare the CV read plan for {}",
+                path.full_path()
+            ))
+        })
+    }
+}
+
+struct UfsEndpointLimiter {
+    max_per_endpoint: usize,
+    semaphores: Mutex<HashMap<String, Arc<Semaphore>>>,
+}
+
+impl UfsEndpointLimiter {
+    fn new(max_per_endpoint: usize) -> Self {
+        Self {
+            max_per_endpoint,
+            semaphores: Mutex::new(HashMap::new()),
+        }
+    }
+
+    async fn acquire(&self, mount: &MountInfo) -> FsResult<OwnedSemaphorePermit> {
+        let endpoint = ufs_endpoint_key(mount);
+        let semaphore = {
+            let mut semaphores = self.semaphores.lock();
+            semaphores
+                .entry(endpoint)
+                .or_insert_with(|| Arc::new(Semaphore::new(self.max_per_endpoint)))
+                .clone()
+        };
+        semaphore.acquire_owned().await.map_err(|err| {
+            FsError::common(format!(
+                "Failed to acquire UFS endpoint planning permit: {}",
+                err
+            ))
+        })
+    }
+}
+
+fn ufs_endpoint_key(mount: &MountInfo) -> String {
+    let Ok(path) = Path::from_str(&mount.ufs_path) else {
+        return mount.ufs_path.clone();
+    };
+    match path.scheme() {
+        Some("file") => "file://".to_string(),
+        Some(scheme) => format!("{}://{}", scheme, path.authority().unwrap_or("")),
+        None => mount.ufs_path.clone(),
+    }
+}
+
+fn record_metadata_operation(
+    source: &'static str,
+    operation: &'static str,
+    success: bool,
+    start: Instant,
+) {
+    if let Ok(metrics) = TransferMetrics::get() {
+        metrics.observe_metadata_operation(
+            source,
+            operation,
+            if success { "success" } else { "error" },
+            start.elapsed().as_micros(),
+        );
+    }
+}
+
+fn append_relative_path(source_root: &Path, target_root: &Path, source: &Path) -> FsResult<Path> {
+    let source_root_text = normalized_path_text(source_root);
+    let source_text = normalized_path_text(source);
+    let target_root_text = normalized_path_text(target_root);
+
+    let relative = if source_text == source_root_text {
+        ""
+    } else {
+        source_text
+            .strip_prefix(source_root_text.as_str())
+            .ok_or_else(|| {
+                FsError::common(format!(
+                    "Source path {} is not under transfer root {}",
+                    source.full_path(),
+                    source_root.full_path()
+                ))
+            })?
+            .trim_start_matches('/')
+    };
+
+    let target = if relative.is_empty() {
+        target_root_text
+    } else {
+        format!("{}/{}", target_root_text.trim_end_matches('/'), relative)
+    };
+    Ok(Path::from_str(target)?)
+}
+
+fn transfer_command(job: &TransferJobRecord) -> FsResult<TransferCommand> {
+    serde_json::from_str(&job.command_json).map_err(|_| {
+        FsError::common(format!(
+            "Stored transfer command for job {} is invalid",
+            job.job_id
+        ))
+    })
+}
+
+fn normalized_path_text(path: &Path) -> String {
+    if path.is_cv() {
+        path.path().trim_end_matches('/').to_string()
+    } else {
+        path.full_path().trim_end_matches('/').to_string()
+    }
+}


### PR DESCRIPTION
# Summary

Adds Curvine metadata reading and transfer task planning from fresh cluster snapshots.

# Issue Describe / Design

Part of the standalone Transfer service. This review layer is stacked deliberately so that protocol, metadata storage, scheduling, worker execution, client routing, and deployment can be reviewed independently.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-server/src/transfer/cv_metadata_reader.rs,curvine-server/src/transfer/planner.rs` | Adds Curvine metadata reading and transfer task planning from fresh cluster snapshots. | New Transfer behavior; legacy behavior remains available unless Transfer is enabled. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo check -p curvine-server -p curvine-cli` | PASS | Rebased onto upstream main `497d078d`. |

# Dependencies

- Related PRs: #1348
- Related issues: #1040
- Blocks / blocked by: #1348