### PR TITLE
feat(transfer): add standalone service runtime

### DIFF
--- a/curvine-server/src/transfer/handler.rs
+++ b/curvine-server/src/transfer/handler.rs
@@ -1,0 +1,175 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use curvine_common::error::FsError;
+use curvine_common::fs::RpcCode;
+use curvine_common::proto::{
+    CancelTransferRequest, CancelTransferResponse, GetTransferStatusRequest,
+    GetTransferStatusResponse, ListTransferTenantsRequest, ListTransfersRequest,
+    RetryTransferRequest, SubmitTransferRequest, SubmitTransferResponse, TransferTaskReportRequest,
+    TransferTaskReportResponse, WatchTransferRequest, WatchTransferResponse,
+};
+use curvine_common::state::TransferState;
+use curvine_common::FsResult;
+use orpc::handler::MessageHandler;
+use orpc::message::{Builder, Message};
+
+use crate::transfer::{progress_to_proto, TransferService, TransferStore};
+
+pub struct TransferHandler<S> {
+    service: TransferService<S>,
+}
+
+impl<S> TransferHandler<S>
+where
+    S: TransferStore,
+{
+    pub fn new(service: TransferService<S>) -> Self {
+        Self { service }
+    }
+
+    fn submit_transfer(&self, msg: &Message) -> FsResult<Message> {
+        let req: SubmitTransferRequest = msg.parse_header()?;
+        let job = self.service.submit_transfer(req)?;
+        let response = SubmitTransferResponse {
+            job_id: job.job_id,
+            run_id: job.run_id,
+            state: transfer_state_code(job.state),
+        };
+        Ok(Builder::success(msg).proto_header(response).build())
+    }
+
+    fn get_transfer_status(&self, msg: &Message) -> FsResult<Message> {
+        let req: GetTransferStatusRequest = msg.parse_header()?;
+        let (job, tasks, next_page_token) =
+            self.service
+                .get_transfer_status(&req.job_id, req.page_size, req.page_token)?;
+        let response = GetTransferStatusResponse {
+            job_id: job.job_id,
+            run_id: job.run_id,
+            state: transfer_state_code(job.state),
+            progress: progress_to_proto(job.summary),
+            tasks,
+            next_page_token,
+            kind: Some(job.kind as i32),
+            source_path: Some(job.source_path),
+            target_path: Some(job.target_path),
+            submitter: Some(job.submitter),
+            tenant: Some(job.tenant),
+            created_at: Some(job.created_at),
+            updated_at: Some(job.updated_at),
+            owner: Some(job.owner),
+            lease_epoch: Some(job.lease_epoch),
+            lease_expire_at: Some(job.lease_expire_at),
+            cv_metadata_epoch: job.cv_metadata_epoch,
+        };
+        Ok(Builder::success(msg).proto_header(response).build())
+    }
+
+    fn retry_transfer(&self, msg: &Message) -> FsResult<Message> {
+        let req: RetryTransferRequest = msg.parse_header()?;
+        let job = self.service.retry_transfer(&req.job_id)?;
+        let response = SubmitTransferResponse {
+            job_id: job.job_id,
+            run_id: job.run_id,
+            state: transfer_state_code(job.state),
+        };
+        Ok(Builder::success(msg).proto_header(response).build())
+    }
+
+    fn list_transfers(&self, msg: &Message) -> FsResult<Message> {
+        let req: ListTransfersRequest = msg.parse_header()?;
+        let response = self.service.list_transfers(req)?;
+        Ok(Builder::success(msg).proto_header(response).build())
+    }
+
+    fn list_transfer_tenants(&self, msg: &Message) -> FsResult<Message> {
+        let req: ListTransferTenantsRequest = msg.parse_header()?;
+        let response = self.service.list_tenant_summaries(req)?;
+        Ok(Builder::success(msg).proto_header(response).build())
+    }
+
+    fn watch_transfer(&self, msg: &Message) -> FsResult<Message> {
+        let req: WatchTransferRequest = msg.parse_header()?;
+        let (job, tasks, next_page_token, changed) = self.service.watch_transfer(
+            &req.job_id,
+            req.since_updated_at,
+            req.page_size,
+            req.page_token,
+        )?;
+        let response = WatchTransferResponse {
+            job_id: job.job_id,
+            run_id: job.run_id,
+            state: transfer_state_code(job.state),
+            progress: progress_to_proto(job.summary),
+            tasks,
+            next_page_token,
+            updated_at: job.updated_at,
+            changed,
+            kind: Some(job.kind as i32),
+            source_path: Some(job.source_path),
+            target_path: Some(job.target_path),
+            owner: Some(job.owner),
+            lease_epoch: Some(job.lease_epoch),
+            lease_expire_at: Some(job.lease_expire_at),
+            cv_metadata_epoch: job.cv_metadata_epoch,
+        };
+        Ok(Builder::success(msg).proto_header(response).build())
+    }
+
+    fn cancel_transfer(&self, msg: &Message) -> FsResult<Message> {
+        let req: CancelTransferRequest = msg.parse_header()?;
+        let state = self.service.request_cancel(&req.job_id, req.run_id)?;
+        let response = CancelTransferResponse {
+            job_id: req.job_id,
+            state: transfer_state_code(state),
+        };
+        Ok(Builder::success(msg).proto_header(response).build())
+    }
+
+    fn report_task(&self, msg: &Message) -> FsResult<Message> {
+        let req: TransferTaskReportRequest = msg.parse_header()?;
+        let accepted = self.service.report_task(req)?;
+        let response = TransferTaskReportResponse { accepted };
+        Ok(Builder::success(msg).proto_header(response).build())
+    }
+}
+
+impl<S> MessageHandler for TransferHandler<S>
+where
+    S: TransferStore,
+{
+    type Error = FsError;
+
+    fn handle(&self, msg: &Message) -> FsResult<Message> {
+        match RpcCode::from(msg.code()) {
+            RpcCode::SubmitTransfer => self.submit_transfer(msg),
+            RpcCode::GetTransferStatus => self.get_transfer_status(msg),
+            RpcCode::RetryTransfer => self.retry_transfer(msg),
+            RpcCode::ListTransfers => self.list_transfers(msg),
+            RpcCode::WatchTransfer => self.watch_transfer(msg),
+            RpcCode::CancelTransfer => self.cancel_transfer(msg),
+            RpcCode::ReportTransferTask => self.report_task(msg),
+            RpcCode::ListTransferTenants => self.list_transfer_tenants(msg),
+            code => Err(FsError::common(format!(
+                "Unsupported transfer rpc code {}",
+                code
+            ))),
+        }
+    }
+}
+
+fn transfer_state_code(state: TransferState) -> i32 {
+    state as i32
+}

--- a/curvine-server/src/transfer/mod.rs
+++ b/curvine-server/src/transfer/mod.rs
@@ -37,6 +37,15 @@ pub use self::service::{progress_to_proto, TransferService};
 mod scheduler;
 pub use self::scheduler::TransferScheduler;
 
+mod handler;
+pub use self::handler::TransferHandler;
+
+mod router_handler;
+pub use self::router_handler::TransferRouterHandler;
+
+mod transfer_server;
+pub use self::transfer_server::TransferServer;
+
 pub(crate) fn transfer_failure_message(
     kind: curvine_common::state::TransferKind,
     source_path: &str,

--- a/curvine-server/src/transfer/router_handler.rs
+++ b/curvine-server/src/transfer/router_handler.rs
@@ -1,0 +1,138 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use axum::http::StatusCode;
+use axum::routing::get;
+use axum::Router;
+use curvine_web::router::RouterHandler;
+use log::warn;
+use orpc::common::Metrics;
+
+use crate::transfer::{
+    ClusterMetadataCache, CvMetadataReader, TransferService, TransferStoreBackend,
+};
+
+pub struct TransferRouterHandler {
+    ready: Arc<AtomicBool>,
+    store_backend: &'static str,
+    service: TransferService<TransferStoreBackend>,
+    cluster_cache: ClusterMetadataCache,
+    cv_metadata: Option<Arc<dyn CvMetadataReader>>,
+}
+
+impl TransferRouterHandler {
+    pub fn new(
+        ready: Arc<AtomicBool>,
+        store_backend: &'static str,
+        service: TransferService<TransferStoreBackend>,
+        cluster_cache: ClusterMetadataCache,
+        cv_metadata: Option<Arc<dyn CvMetadataReader>>,
+    ) -> Self {
+        Self {
+            ready,
+            store_backend,
+            service,
+            cluster_cache,
+            cv_metadata,
+        }
+    }
+}
+
+async fn metrics() -> String {
+    Metrics::text_output().unwrap_or_else(|err| {
+        warn!("failed to encode transfer metrics: {}", err);
+        "metrics unavailable\n".to_string()
+    })
+}
+
+async fn healthz() -> &'static str {
+    "ok\n"
+}
+
+async fn readyz(
+    ready: Arc<AtomicBool>,
+    store_backend: &'static str,
+    service: TransferService<TransferStoreBackend>,
+    cluster_cache: ClusterMetadataCache,
+    cv_metadata: Option<Arc<dyn CvMetadataReader>>,
+) -> (StatusCode, String) {
+    if !ready.load(Ordering::Relaxed) {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "not ready: starting\n".to_string(),
+        );
+    }
+
+    if let Err(err) = service.check_store_available() {
+        warn!(
+            "transfer readiness check failed for {store_backend} store: {}",
+            err
+        );
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            format!("not ready: {store_backend} transfer metadata store is unavailable\n"),
+        );
+    }
+
+    if let Err(err) = cluster_cache.check_ready() {
+        warn!(
+            "transfer readiness check failed for cluster metadata: {}",
+            err
+        );
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "not ready: cluster metadata is unavailable\n".to_string(),
+        );
+    }
+
+    if let Some(reader) = cv_metadata {
+        if let Err(err) = reader.current_epoch() {
+            warn!("transfer readiness check failed for CV metadata: {}", err);
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "not ready: Curvine metadata is unavailable\n".to_string(),
+            );
+        }
+    }
+
+    (StatusCode::OK, "ok\n".to_string())
+}
+
+impl RouterHandler for TransferRouterHandler {
+    fn router(&self) -> Router {
+        let ready = self.ready.clone();
+        let store_backend = self.store_backend;
+        let service = self.service.clone();
+        let cluster_cache = self.cluster_cache.clone();
+        let cv_metadata = self.cv_metadata.clone();
+        Router::new()
+            .route("/healthz", get(healthz))
+            .route(
+                "/readyz",
+                get(move || {
+                    readyz(
+                        ready.clone(),
+                        store_backend,
+                        service.clone(),
+                        cluster_cache.clone(),
+                        cv_metadata.clone(),
+                    )
+                }),
+            )
+            .route("/metrics", get(metrics))
+    }
+}

--- a/curvine-server/src/transfer/transfer_server.rs
+++ b/curvine-server/src/transfer/transfer_server.rs
@@ -1,0 +1,259 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::common::UfsFactory;
+use curvine_client::file::CurvineFileSystem;
+use curvine_common::conf::{ClusterConf, TransferCvMetadataReaderType, TransferStoreType};
+use curvine_common::error::FsError;
+use curvine_web::server::{WebHandlerService, WebServer};
+use log::info;
+use orpc::common::Logger;
+use orpc::handler::HandlerService;
+use orpc::io::net::ConnState;
+use orpc::runtime::RpcRuntime;
+use orpc::server::{RpcServer, ServerStateListener};
+use orpc::CommonResult;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use crate::transfer::{
+    ClusterMetadataCache, CvMetadataReader, DisabledCvMetadataReader, MasterCvMetadataReader,
+    MemoryTransferStore, MetadataReplicaReader, MysqlTransferStore, SqliteTransferStore,
+    TransferHandler, TransferMetrics, TransferPlanner, TransferRouterHandler, TransferScheduler,
+    TransferService, TransferStoreBackend,
+};
+
+#[derive(Clone)]
+pub struct TransferRpcService {
+    service: TransferService<TransferStoreBackend>,
+    ready: Arc<AtomicBool>,
+    store_backend: &'static str,
+    cluster_cache: ClusterMetadataCache,
+    cv_metadata: Option<Arc<dyn CvMetadataReader>>,
+}
+
+impl TransferRpcService {
+    fn new(
+        service: TransferService<TransferStoreBackend>,
+        ready: Arc<AtomicBool>,
+        store_backend: &'static str,
+        cluster_cache: ClusterMetadataCache,
+        cv_metadata: Option<Arc<dyn CvMetadataReader>>,
+    ) -> Self {
+        Self {
+            service,
+            ready,
+            store_backend,
+            cluster_cache,
+            cv_metadata,
+        }
+    }
+}
+
+impl HandlerService for TransferRpcService {
+    type Item = TransferHandler<TransferStoreBackend>;
+
+    fn get_message_handler(&self, _: Option<ConnState>) -> Self::Item {
+        TransferHandler::new(self.service.clone())
+    }
+}
+
+impl WebHandlerService for TransferRpcService {
+    type Item = TransferRouterHandler;
+
+    fn get_handler(&self) -> Self::Item {
+        TransferRouterHandler::new(
+            self.ready.clone(),
+            self.store_backend,
+            self.service.clone(),
+            self.cluster_cache.clone(),
+            self.cv_metadata.clone(),
+        )
+    }
+}
+
+pub struct TransferServer {
+    rpc_server: RpcServer<TransferRpcService>,
+    web_server: WebServer<TransferRpcService>,
+    cluster_cache: ClusterMetadataCache,
+    scheduler: TransferScheduler<TransferStoreBackend>,
+    metadata_replica: Option<(MetadataReplicaReader, std::time::Duration)>,
+    ready: Arc<AtomicBool>,
+    stop: Arc<AtomicBool>,
+}
+
+impl TransferServer {
+    pub fn with_conf(conf: ClusterConf) -> CommonResult<Self> {
+        if !conf.transfer.enabled {
+            return Err(FsError::common("curvine-transfer requires transfer.enabled=true").into());
+        }
+        if conf.transfer.endpoints.is_empty() {
+            return Err(FsError::common(
+                "curvine-transfer requires transfer.endpoints to route worker task reports",
+            )
+            .into());
+        }
+        Logger::init(conf.master.log.clone());
+        let _ = TransferMetrics::get()?;
+        conf.print();
+
+        let rt = Arc::new(conf.transfer_server_conf().create_runtime());
+        let stop = Arc::new(AtomicBool::new(false));
+        let store = Arc::new(match conf.transfer.effective_store_type() {
+            TransferStoreType::Auto => unreachable!("resolved transfer store type cannot be auto"),
+            TransferStoreType::Memory => TransferStoreBackend::Memory(MemoryTransferStore::new()),
+            TransferStoreType::Sqlite => TransferStoreBackend::Sqlite(SqliteTransferStore::open(
+                conf.transfer.sqlite_store_path(),
+            )?),
+            TransferStoreType::Mysql => TransferStoreBackend::Mysql(MysqlTransferStore::open(
+                conf.transfer.mysql_store_url(),
+            )?),
+        });
+        let store_backend = store.backend_label();
+        let fs = CurvineFileSystem::with_rt(conf.clone(), rt.clone())?;
+        let factory = Arc::new(UfsFactory::with_rt(&conf.client, rt.clone()));
+        let cache = ClusterMetadataCache::with_snapshot_policy(
+            fs.clone(),
+            conf.transfer.cluster_snapshot_max_staleness,
+            conf.transfer.allow_submit_with_stale_snapshot,
+        );
+        cache.clone().start_refresh_loop(
+            Duration::from_millis(conf.client.mount_update_ttl_ms),
+            stop.clone(),
+        );
+        let mut metadata_replica = None;
+        let cv_metadata: Arc<dyn CvMetadataReader> =
+            match conf.transfer.effective_cv_metadata_reader() {
+                TransferCvMetadataReaderType::Auto => {
+                    unreachable!("resolved CV metadata reader cannot be auto")
+                }
+                TransferCvMetadataReaderType::Disabled => Arc::new(DisabledCvMetadataReader),
+                TransferCvMetadataReaderType::Master => Arc::new(MasterCvMetadataReader::new(fs)),
+                TransferCvMetadataReaderType::Replica => {
+                    let reader = MetadataReplicaReader::new(
+                        fs.clone(),
+                        conf.transfer.metadata_replica_max_entries,
+                        conf.transfer.metadata_replica_page_size(),
+                        conf.transfer.metadata_replica_history_size(),
+                        conf.transfer.metadata_replica_max_staleness,
+                    );
+                    metadata_replica = Some((
+                        reader.clone(),
+                        conf.transfer.metadata_replica_refresh_interval,
+                    ));
+                    Arc::new(reader)
+                }
+            };
+
+        let owner = if conf.transfer.instance_id.is_empty() {
+            uuid::Uuid::new_v4().to_string()
+        } else {
+            conf.transfer.instance_id.clone()
+        };
+        let report_target =
+            conf.transfer.endpoints.first().cloned().unwrap_or_else(|| {
+                format!("{}:{}", conf.transfer.hostname, conf.transfer.rpc_port)
+            });
+        let planner = TransferPlanner::new(
+            cv_metadata.clone(),
+            factory.clone(),
+            cache.clone(),
+            conf.client.clone(),
+            conf.transfer.max_tasks_per_transfer,
+            conf.transfer.ufs_max_concurrency_per_endpoint,
+        );
+        let scheduler = TransferScheduler::new(
+            store.clone(),
+            planner,
+            cache.clone(),
+            factory,
+            owner,
+            report_target,
+            conf.transfer.clone(),
+        );
+
+        let ready = Arc::new(AtomicBool::new(false));
+        let service = TransferRpcService::new(
+            TransferService::with_cache_and_report_queue(
+                store,
+                cache.clone(),
+                conf.transfer.task_stale_timeout,
+                conf.transfer.task_report_queue_size(),
+                conf.transfer.worker_threads,
+            )?,
+            ready.clone(),
+            store_backend,
+            cache.clone(),
+            Some(cv_metadata.clone()),
+        );
+        let rpc_server =
+            RpcServer::with_rt(rt.clone(), conf.transfer_server_conf(), service.clone());
+        let web_server = WebServer::with_rt(rt, conf.transfer_web_conf(), service);
+        let stop_on_rpc_stop = stop.clone();
+        rpc_server.add_shutdown_hook(move || {
+            stop_on_rpc_stop.store(true, Ordering::Relaxed);
+        });
+        Ok(Self {
+            rpc_server,
+            web_server,
+            cluster_cache: cache,
+            scheduler,
+            metadata_replica,
+            ready,
+            stop,
+        })
+    }
+
+    pub async fn start(self) -> CommonResult<ServerStateListener> {
+        let ready = self.ready.clone();
+        let web_name = self.web_server.server_name().to_string();
+        let bind_addr = self.web_server.resolve_bind_addr();
+        let mut web_status = self.web_server.start();
+        WebServer::<TransferRpcService>::wait_bind(&mut web_status, &web_name, &bind_addr).await?;
+
+        let result = async {
+            self.cluster_cache.refresh().await?;
+            if let Some((reader, refresh_interval)) = &self.metadata_replica {
+                reader.refresh().await?;
+                reader.start_refresh_loop(*refresh_interval, self.stop.clone());
+            }
+            self.scheduler
+                .start(self.rpc_server.clone_rt(), self.stop.clone());
+            info!("Starting curvine-transfer rpc server");
+            let mut rpc_status = self.rpc_server.start();
+            rpc_status.wait_running().await?;
+            ready.store(true, Ordering::Relaxed);
+            Ok(rpc_status)
+        }
+        .await;
+
+        if result.is_err() {
+            self.stop.store(true, Ordering::Relaxed);
+        }
+        result
+    }
+
+    pub fn block_on_start(self) -> CommonResult<()> {
+        let rt = self.rpc_server.clone_rt();
+        rt.block_on(async move {
+            let mut status = self.start().await?;
+            if let Err(err) = status.wait_stop().await {
+                log::warn!("curvine-transfer wait stop failed: {}", err);
+            }
+            Ok(())
+        })
+    }
+}


### PR DESCRIPTION
# Summary

Adds the standalone Transfer server runtime, handler, router, and role-specific server startup wiring.

# Issue Describe / Design

Client and Master-Worker RPC foundations were split into #1362 because metadata planning and scheduling consume them earlier. This PR stays after the scheduler and contains only runtime ownership and routing.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-server/src/transfer/transfer_server.rs`, `handler.rs`, `router_handler.rs` | Add the standalone Transfer process runtime and RPC routing. | New independent service role. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo clippy --all-targets --jobs 4 -- --deny=warnings --allow clippy::uninlined-format-args` | PASS | Run on the reconstructed branch. |

# Dependencies

- Related PRs: #1351, #1362
- Related issues: #1040
- Blocks / blocked by: #1353