### PR TITLE
fix(transfer): finalize task outcomes and scheduling

### DIFF
--- a/crates/common/curvine-model/src/job.rs
+++ b/crates/common/curvine-model/src/job.rs
@@ -247,7 +247,10 @@ pub struct TransferTaskReportInfo {
     pub attempt_id: u64,
     pub worker_id: u32,
     pub worker_session_id: String,
+    #[serde(default)]
     pub report_target: String,
+    #[serde(default)]
+    pub report_endpoints: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/common/curvine-model/src/lib.rs
+++ b/crates/common/curvine-model/src/lib.rs
@@ -43,7 +43,7 @@ mod heartbeat_status;
 pub use self::heartbeat_status::HeartbeatStatus;
 
 mod worker_info;
-pub use self::worker_info::WorkerInfo;
+pub use self::worker_info::{TransferWorkerCapabilities, WorkerInfo};
 
 mod worker_node_tree;
 pub use self::worker_node_tree::WorkerNodeTree;

--- a/crates/common/curvine-model/src/transfer.rs
+++ b/crates/common/curvine-model/src/transfer.rs
@@ -67,13 +67,17 @@ pub enum TransferState {
     Completed = 6,
     Failed = 7,
     Canceled = 8,
+    PartialSuccess = 9,
 }
 
 impl TransferState {
     pub fn is_terminal(self) -> bool {
         matches!(
             self,
-            TransferState::Completed | TransferState::Failed | TransferState::Canceled
+            TransferState::Completed
+                | TransferState::Failed
+                | TransferState::Canceled
+                | TransferState::PartialSuccess
         )
     }
 
@@ -247,9 +251,21 @@ pub struct TransferTaskRecord {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TransferTaskSummary {
     pub progress: TransferProgress,
+    pub counts: TransferTaskCounts,
     pub has_task: bool,
     pub has_failed: bool,
     pub all_completed: bool,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct TransferTaskCounts {
+    pub pending: u64,
+    pub running: u64,
+    pub completed: u64,
+    pub failed: u64,
+    pub canceled: u64,
+    pub stale: u64,
+    pub completed_size: i64,
 }
 
 pub fn summarize_transfer_tasks<'a>(
@@ -261,6 +277,7 @@ pub fn summarize_transfer_tasks<'a>(
             update_time,
             ..Default::default()
         },
+        counts: TransferTaskCounts::default(),
         has_task: false,
         has_failed: false,
         all_completed: true,
@@ -275,6 +292,18 @@ pub fn summarize_transfer_tasks<'a>(
         summary.all_completed &= task.state == TransferTaskState::Completed;
         summary.progress.loaded_size += task.progress.loaded_size;
         summary.progress.total_size += task.progress.total_size;
+
+        match task.state {
+            TransferTaskState::Pending => summary.counts.pending += 1,
+            TransferTaskState::Running => summary.counts.running += 1,
+            TransferTaskState::Completed => {
+                summary.counts.completed += 1;
+                summary.counts.completed_size += task.progress.loaded_size.max(0);
+            }
+            TransferTaskState::Failed => summary.counts.failed += 1,
+            TransferTaskState::Canceled => summary.counts.canceled += 1,
+            TransferTaskState::Stale => summary.counts.stale += 1,
+        }
 
         if !task.progress.message.is_empty() {
             last_message = task.progress.message.clone();
@@ -379,6 +408,7 @@ pub struct TransferTenantSummary {
     pub completed: u64,
     pub failed: u64,
     pub canceled: u64,
+    pub partial_success: u64,
     pub total: u64,
 }
 

--- a/curvine-common/proto/transfer.proto
+++ b/curvine-common/proto/transfer.proto
@@ -19,6 +19,7 @@ enum TransferStateProto {
   TRANSFER_COMPLETED = 6;
   TRANSFER_FAILED = 7;
   TRANSFER_CANCELED = 8;
+  TRANSFER_PARTIAL_SUCCESS = 9;
 }
 
 enum TransferTaskStateProto {
@@ -48,6 +49,16 @@ message TransferTaskStatusProto {
   required TransferProgressProto progress = 8;
   required uint32 retry_count = 9;
   required int64 updated_at = 10;
+}
+
+message TransferTaskSummaryProto {
+  required uint64 pending = 1;
+  required uint64 running = 2;
+  required uint64 completed = 3;
+  required uint64 failed = 4;
+  required uint64 canceled = 5;
+  required uint64 stale = 6;
+  required int64 completed_size = 7;
 }
 
 message TransferJobStatusProto {
@@ -109,6 +120,7 @@ message GetTransferStatusResponse {
   optional uint64 lease_epoch = 15;
   optional int64 lease_expire_at = 16;
   optional uint64 cv_metadata_epoch = 17;
+  optional TransferTaskSummaryProto task_summary = 18;
 }
 
 message ListTransfersRequest {
@@ -133,6 +145,7 @@ message TransferTenantSummaryProto {
   required uint64 failed = 5;
   required uint64 canceled = 6;
   required uint64 total = 7;
+  required uint64 partial_success = 8;
 }
 
 message ListTransferTenantsRequest {
@@ -168,6 +181,7 @@ message WatchTransferResponse {
   optional uint64 lease_epoch = 13;
   optional int64 lease_expire_at = 14;
   optional uint64 cv_metadata_epoch = 15;
+  optional TransferTaskSummaryProto task_summary = 16;
 }
 
 message CancelTransferRequest {

--- a/curvine-server/src/transfer/backend.rs
+++ b/curvine-server/src/transfer/backend.rs
@@ -15,15 +15,14 @@
 use curvine_common::error::FsError;
 use curvine_common::state::{
     StaleTaskAttempt, TaskAttemptStart, TransferJobRecord, TransferLease, TransferListFilter,
-    TransferState, TransferStateUpdate, TransferTaskRecord, TransferTaskReport, TransferTaskState,
-    TransferTenantSummary,
+    TransferStateUpdate, TransferTaskRecord, TransferTaskReport, TransferTenantSummary,
 };
 use curvine_common::FsResult;
 use std::time::Instant;
 
 use crate::transfer::{
     MemoryTransferStore, MysqlTransferStore, SqliteTransferStore, TransferMetrics,
-    TransferRequeueUpdate, TransferStore,
+    TransferPlannedTasks, TransferRequeueUpdate, TransferStore, TransferTaskStateUpdate,
 };
 
 pub enum TransferStoreBackend {
@@ -217,26 +216,6 @@ impl TransferStore for TransferStoreBackend {
         })
     }
 
-    fn set_transfer_state(
-        &self,
-        job_id: &str,
-        run_id: u64,
-        state: TransferState,
-        message: impl Into<String>,
-        now_ms: i64,
-    ) -> FsResult<bool> {
-        let message = message.into();
-        self.record_store_operation("set_transfer_state", || match self {
-            Self::Memory(store) => {
-                store.set_transfer_state(job_id, run_id, state, message.clone(), now_ms)
-            }
-            Self::Sqlite(store) => {
-                store.set_transfer_state(job_id, run_id, state, message.clone(), now_ms)
-            }
-            Self::Mysql(store) => store.set_transfer_state(job_id, run_id, state, message, now_ms),
-        })
-    }
-
     fn requeue_transfer(&self, update: TransferRequeueUpdate) -> FsResult<bool> {
         self.record_store_operation("requeue_transfer", || match self {
             Self::Memory(store) => store.requeue_transfer(update),
@@ -290,25 +269,19 @@ impl TransferStore for TransferStoreBackend {
         })
     }
 
-    fn update_task_state(
-        &self,
-        job_id: &str,
-        run_id: u64,
-        task_id: &str,
-        state: TransferTaskState,
-        message: impl Into<String>,
-        now_ms: i64,
-    ) -> FsResult<bool> {
+    fn persist_planned_tasks(&self, update: TransferPlannedTasks) -> FsResult<bool> {
+        self.record_store_operation("persist_planned_tasks", || match self {
+            Self::Memory(store) => store.persist_planned_tasks(update),
+            Self::Sqlite(store) => store.persist_planned_tasks(update),
+            Self::Mysql(store) => store.persist_planned_tasks(update),
+        })
+    }
+
+    fn update_task_state(&self, update: TransferTaskStateUpdate) -> FsResult<bool> {
         self.record_store_operation("update_task_state", || match self {
-            Self::Memory(store) => {
-                store.update_task_state(job_id, run_id, task_id, state, message, now_ms)
-            }
-            Self::Sqlite(store) => {
-                store.update_task_state(job_id, run_id, task_id, state, message, now_ms)
-            }
-            Self::Mysql(store) => {
-                store.update_task_state(job_id, run_id, task_id, state, message, now_ms)
-            }
+            Self::Memory(store) => store.update_task_state(update),
+            Self::Sqlite(store) => store.update_task_state(update),
+            Self::Mysql(store) => store.update_task_state(update),
         })
     }
 
@@ -347,15 +320,39 @@ impl TransferStore for TransferStoreBackend {
         })
     }
 
-    fn list_recoverable_tasks(
+    fn list_stale_running_tasks(
         &self,
         job_id: &str,
         run_id: u64,
+        stale_before_ms: i64,
+        limit: usize,
     ) -> FsResult<Vec<TransferTaskRecord>> {
-        self.record_store_operation("list_recoverable_tasks", || match self {
-            Self::Memory(store) => store.list_recoverable_tasks(job_id, run_id),
-            Self::Sqlite(store) => store.list_recoverable_tasks(job_id, run_id),
-            Self::Mysql(store) => store.list_recoverable_tasks(job_id, run_id),
+        self.record_store_operation("list_stale_running_tasks", || match self {
+            Self::Memory(store) => {
+                store.list_stale_running_tasks(job_id, run_id, stale_before_ms, limit)
+            }
+            Self::Sqlite(store) => {
+                store.list_stale_running_tasks(job_id, run_id, stale_before_ms, limit)
+            }
+            Self::Mysql(store) => {
+                store.list_stale_running_tasks(job_id, run_id, stale_before_ms, limit)
+            }
+        })
+    }
+
+    fn has_failed_tasks(&self, job_id: &str, run_id: u64) -> FsResult<bool> {
+        self.record_store_operation("has_failed_tasks", || match self {
+            Self::Memory(store) => store.has_failed_tasks(job_id, run_id),
+            Self::Sqlite(store) => store.has_failed_tasks(job_id, run_id),
+            Self::Mysql(store) => store.has_failed_tasks(job_id, run_id),
+        })
+    }
+
+    fn has_recoverable_tasks(&self, job_id: &str, run_id: u64) -> FsResult<bool> {
+        self.record_store_operation("has_recoverable_tasks", || match self {
+            Self::Memory(store) => store.has_recoverable_tasks(job_id, run_id),
+            Self::Sqlite(store) => store.has_recoverable_tasks(job_id, run_id),
+            Self::Mysql(store) => store.has_recoverable_tasks(job_id, run_id),
         })
     }
 

--- a/curvine-server/src/transfer/cluster_cache.rs
+++ b/curvine-server/src/transfer/cluster_cache.rs
@@ -74,7 +74,7 @@ impl ClusterMetadataCache {
         let snapshot = self.snapshot();
         if snapshot.updated_at <= 0 {
             return Err(FsError::common(
-                "Transfer cluster metadata is unavailable; retry shortly",
+                "Cluster metadata is unavailable; retry shortly",
             ));
         }
         self.check_snapshot_fresh(&snapshot)
@@ -158,15 +158,13 @@ impl ClusterMetadataCache {
     ) -> FsResult<MountSnapshot> {
         let snapshot = self.snapshot();
         if snapshot.mounts.is_empty() {
-            return Err(FsError::common(
-                "Transfer cluster mount snapshot is unavailable; retry shortly",
-            ));
+            return Err(FsError::common("Cluster mount snapshot is unavailable"));
         }
         self.check_snapshot_fresh(&snapshot)?;
         self.matching_mount_snapshot(kind, source, target, &snapshot)
             .ok_or_else(|| {
                 FsError::common(format!(
-                    "No mount can serve {:?} from {} to {}",
+                    "No mount found for {:?}: {} -> {}",
                     kind,
                     source.full_path(),
                     target.full_path()
@@ -206,14 +204,14 @@ impl ClusterMetadataCache {
         snapshot: &ClusterSnapshot,
     ) -> Option<MountSnapshot> {
         let source_text = if source.is_cv() {
-            source.path().to_string()
+            source.path()
         } else {
-            source.full_path().to_string()
+            source.full_path()
         };
         let target_text = if target.is_cv() {
-            target.path().to_string()
+            target.path()
         } else {
-            target.full_path().to_string()
+            target.full_path()
         };
 
         snapshot
@@ -221,12 +219,12 @@ impl ClusterMetadataCache {
             .iter()
             .find(|mount| match kind {
                 TransferKind::Load => {
-                    source_text.starts_with(&mount.ufs_path)
-                        && target_text.starts_with(&mount.cv_path)
+                    Path::has_prefix(source_text, &mount.ufs_path)
+                        && Path::has_prefix(target_text, &mount.cv_path)
                 }
                 TransferKind::Export => {
-                    source_text.starts_with(&mount.cv_path)
-                        && target_text.starts_with(&mount.ufs_path)
+                    Path::has_prefix(source_text, &mount.cv_path)
+                        && Path::has_prefix(target_text, &mount.ufs_path)
                 }
             })
             .cloned()
@@ -296,7 +294,7 @@ impl ClusterMetadataCache {
         let staleness_ms = (LocalTime::mills() as i64).saturating_sub(updated_at);
         if staleness_ms > max_staleness_ms {
             return Err(FsError::common(
-                "Transfer cluster metadata is stale; retry shortly",
+                "Cluster metadata snapshot is stale; retry shortly",
             ));
         }
         Ok(())

--- a/curvine-server/src/transfer/handler.rs
+++ b/curvine-server/src/transfer/handler.rs
@@ -25,7 +25,7 @@ use curvine_common::FsResult;
 use orpc::handler::MessageHandler;
 use orpc::message::{Builder, Message};
 
-use crate::transfer::{progress_to_proto, TransferService, TransferStore};
+use crate::transfer::{progress_to_proto, task_summary_to_proto, TransferService, TransferStore};
 
 pub struct TransferHandler<S> {
     service: TransferService<S>,
@@ -52,7 +52,7 @@ where
 
     fn get_transfer_status(&self, msg: &Message) -> FsResult<Message> {
         let req: GetTransferStatusRequest = msg.parse_header()?;
-        let (job, tasks, next_page_token) =
+        let (job, task_summary, tasks, next_page_token) =
             self.service
                 .get_transfer_status(&req.job_id, req.page_size, req.page_token)?;
         let response = GetTransferStatusResponse {
@@ -73,6 +73,7 @@ where
             lease_epoch: Some(job.lease_epoch),
             lease_expire_at: Some(job.lease_expire_at),
             cv_metadata_epoch: job.cv_metadata_epoch,
+            task_summary: Some(task_summary_to_proto(task_summary)),
         };
         Ok(Builder::success(msg).proto_header(response).build())
     }
@@ -102,7 +103,7 @@ where
 
     fn watch_transfer(&self, msg: &Message) -> FsResult<Message> {
         let req: WatchTransferRequest = msg.parse_header()?;
-        let (job, tasks, next_page_token, changed) = self.service.watch_transfer(
+        let (job, task_summary, tasks, next_page_token, changed) = self.service.watch_transfer(
             &req.job_id,
             req.since_updated_at,
             req.page_size,
@@ -124,6 +125,7 @@ where
             lease_epoch: Some(job.lease_epoch),
             lease_expire_at: Some(job.lease_expire_at),
             cv_metadata_epoch: job.cv_metadata_epoch,
+            task_summary: Some(task_summary_to_proto(task_summary)),
         };
         Ok(Builder::success(msg).proto_header(response).build())
     }

--- a/curvine-server/src/transfer/memory_store.rs
+++ b/curvine-server/src/transfer/memory_store.rs
@@ -16,14 +16,17 @@ use std::collections::HashMap;
 
 use curvine_common::error::FsError;
 use curvine_common::state::{
-    summarize_transfer_tasks, StaleTaskAttempt, TaskAttemptStart, TransferJobRecord, TransferLease,
-    TransferListFilter, TransferState, TransferStateUpdate, TransferTaskRecord, TransferTaskReport,
-    TransferTaskState, TransferTenantSummary,
+    StaleTaskAttempt, TaskAttemptStart, TransferJobRecord, TransferLease, TransferListFilter,
+    TransferState, TransferStateUpdate, TransferTaskRecord, TransferTaskReport, TransferTaskState,
+    TransferTenantSummary,
 };
 use curvine_common::FsResult;
 use parking_lot::Mutex;
 
-use crate::transfer::{TransferRequeueUpdate, TransferStore};
+use crate::transfer::{
+    apply_task_report_progress, TransferPlannedTasks, TransferRequeueUpdate, TransferStore,
+    TransferTaskStateUpdate,
+};
 
 #[derive(Default)]
 pub struct MemoryTransferStore {
@@ -359,6 +362,7 @@ impl TransferStore for MemoryTransferStore {
         if job.run_id != run_id
             || job.owner != owner
             || job.lease_epoch != lease_epoch
+            || job.lease_expire_at <= now_ms
             || job.state.is_terminal()
         {
             return Ok(false);
@@ -377,6 +381,7 @@ impl TransferStore for MemoryTransferStore {
         if job.run_id != update.run_id
             || job.owner != update.owner
             || job.lease_epoch != update.lease_epoch
+            || job.lease_expire_at <= update.now_ms
             || !update.from_states.contains(&job.state)
         {
             return Ok(false);
@@ -388,29 +393,6 @@ impl TransferStore for MemoryTransferStore {
         Ok(true)
     }
 
-    fn set_transfer_state(
-        &self,
-        job_id: &str,
-        run_id: u64,
-        state: TransferState,
-        message: impl Into<String>,
-        now_ms: i64,
-    ) -> FsResult<bool> {
-        let mut inner = self.inner.lock();
-        let Some(job) = inner.jobs.get_mut(job_id) else {
-            return Ok(false);
-        };
-        if job.run_id != run_id {
-            return Ok(false);
-        }
-
-        job.state = state;
-        job.summary.message = message.into();
-        job.summary.update_time = now_ms;
-        job.updated_at = now_ms;
-        Ok(true)
-    }
-
     fn requeue_transfer(&self, update: TransferRequeueUpdate) -> FsResult<bool> {
         let mut inner = self.inner.lock();
         let Some(job) = inner.jobs.get_mut(&update.job_id) else {
@@ -419,6 +401,7 @@ impl TransferStore for MemoryTransferStore {
         if job.run_id != update.run_id
             || job.owner != update.owner
             || job.lease_epoch != update.lease_epoch
+            || job.lease_expire_at <= update.now_ms
             || job.state != TransferState::Planning
         {
             return Ok(false);
@@ -449,6 +432,7 @@ impl TransferStore for MemoryTransferStore {
         if job.run_id != run_id
             || job.owner != owner
             || job.lease_epoch != lease_epoch
+            || job.lease_expire_at <= now_ms
             || job.state.is_terminal()
         {
             return Ok(false);
@@ -474,25 +458,58 @@ impl TransferStore for MemoryTransferStore {
         Ok(())
     }
 
-    fn update_task_state(
-        &self,
-        job_id: &str,
-        run_id: u64,
-        task_id: &str,
-        state: TransferTaskState,
-        message: impl Into<String>,
-        now_ms: i64,
-    ) -> FsResult<bool> {
+    fn persist_planned_tasks(&self, update: TransferPlannedTasks) -> FsResult<bool> {
         let mut inner = self.inner.lock();
-        let key = (job_id.to_string(), run_id, task_id.to_string());
+        let valid_owner = inner.jobs.get(&update.job_id).is_some_and(|job| {
+            job.run_id == update.run_id
+                && job.owner == update.owner
+                && job.lease_epoch == update.lease_epoch
+                && job.lease_expire_at > update.now_ms
+                && job.state == TransferState::Planning
+        });
+        if !valid_owner {
+            return Ok(false);
+        }
+        for task in update.tasks {
+            let key = (task.job_id.clone(), task.run_id, task.task_id.clone());
+            inner.tasks.entry(key).or_insert(task);
+        }
+        let job = inner
+            .jobs
+            .get_mut(&update.job_id)
+            .ok_or_else(|| FsError::job_not_found(&update.job_id))?;
+        job.state = TransferState::Dispatching;
+        job.summary.message = update.message;
+        job.summary.update_time = update.now_ms;
+        job.updated_at = update.now_ms;
+        Ok(true)
+    }
+
+    fn update_task_state(&self, update: TransferTaskStateUpdate) -> FsResult<bool> {
+        let mut inner = self.inner.lock();
+        let Some(job) = inner.jobs.get(&update.job_id) else {
+            return Ok(false);
+        };
+        if job.run_id != update.run_id
+            || job.owner != update.owner
+            || job.lease_epoch != update.lease_epoch
+            || job.lease_expire_at <= update.now_ms
+            || job.state.is_terminal()
+        {
+            return Ok(false);
+        }
+        let key = (update.job_id, update.run_id, update.task_id);
         let Some(task) = inner.tasks.get_mut(&key) else {
             return Ok(false);
         };
+        if !update.from_states.is_empty() && !update.from_states.contains(&task.state) {
+            return Ok(false);
+        }
 
-        task.state = state;
-        task.progress.message = message.into();
-        task.progress.update_time = now_ms;
-        task.updated_at = now_ms;
+        task.state = update.state;
+        task.progress.message = update.message;
+        task.progress.update_time = update.now_ms;
+        task.updated_at = update.now_ms;
         Ok(true)
     }
 
@@ -529,7 +546,11 @@ impl TransferStore for MemoryTransferStore {
         let Some(job) = inner.jobs.get(job_id) else {
             return Ok(Vec::new());
         };
-        if job.run_id != run_id || job.owner != owner || job.lease_epoch != lease_epoch {
+        if job.run_id != run_id
+            || job.owner != owner
+            || job.lease_epoch != lease_epoch
+            || job.lease_expire_at <= now_ms
+        {
             return Ok(Vec::new());
         }
 
@@ -553,10 +574,12 @@ impl TransferStore for MemoryTransferStore {
         Ok(stale)
     }
 
-    fn list_recoverable_tasks(
+    fn list_stale_running_tasks(
         &self,
         job_id: &str,
         run_id: u64,
+        stale_before_ms: i64,
+        limit: usize,
     ) -> FsResult<Vec<TransferTaskRecord>> {
         Ok(self
             .inner
@@ -566,15 +589,33 @@ impl TransferStore for MemoryTransferStore {
             .filter(|task| {
                 task.job_id == job_id
                     && task.run_id == run_id
-                    && matches!(
-                        task.state,
-                        TransferTaskState::Pending
-                            | TransferTaskState::Running
-                            | TransferTaskState::Stale
-                    )
+                    && task.state == TransferTaskState::Running
+                    && task.stale_deadline_at < stale_before_ms
             })
+            .take(limit)
             .cloned()
             .collect())
+    }
+
+    fn has_failed_tasks(&self, job_id: &str, run_id: u64) -> FsResult<bool> {
+        Ok(self.inner.lock().tasks.values().any(|task| {
+            task.job_id == job_id
+                && task.run_id == run_id
+                && task.state == TransferTaskState::Failed
+        }))
+    }
+
+    fn has_recoverable_tasks(&self, job_id: &str, run_id: u64) -> FsResult<bool> {
+        Ok(self.inner.lock().tasks.values().any(|task| {
+            task.job_id == job_id
+                && task.run_id == run_id
+                && matches!(
+                    task.state,
+                    TransferTaskState::Pending
+                        | TransferTaskState::Running
+                        | TransferTaskState::Stale
+                )
+        }))
     }
 
     fn start_task_attempt(&self, start: TaskAttemptStart) -> FsResult<bool> {
@@ -585,6 +626,7 @@ impl TransferStore for MemoryTransferStore {
         if job.run_id != start.run_id
             || job.owner != start.owner
             || job.lease_epoch != start.lease_epoch
+            || job.lease_expire_at <= start.now_ms
             || job.cancel_requested
             || job.state.is_terminal()
         {
@@ -616,7 +658,7 @@ impl TransferStore for MemoryTransferStore {
     fn update_task_report(&self, report: TransferTaskReport) -> FsResult<bool> {
         let mut inner = self.inner.lock();
         let key = (report.job_id, report.run_id, report.task_id);
-        let (task_job_id, task_state) = {
+        let (task_job_id, previous_progress) = {
             let Some(task) = inner.tasks.get_mut(&key) else {
                 return Ok(false);
             };
@@ -628,36 +670,23 @@ impl TransferStore for MemoryTransferStore {
                 return Ok(false);
             }
 
+            let previous_progress = task.progress.clone();
             task.state = report.state;
-            task.progress = report.progress;
+            task.progress = report.progress.clone();
             task.last_report_at = report.now_ms;
             task.stale_deadline_at = report.stale_deadline_at;
             task.updated_at = report.now_ms;
-            (task.job_id.clone(), task.state)
+            (task.job_id.clone(), previous_progress)
         };
 
-        let summary = summarize_transfer_tasks(
-            inner
-                .tasks
-                .values()
-                .filter(|task| task.job_id == task_job_id && task.run_id == report.run_id),
-            report.now_ms,
-        );
-        let has_failed = summary.has_failed;
-        let all_completed = summary.all_completed;
-        let has_task = summary.has_task;
-        let progress = summary.progress;
-
         if let Some(job) = inner.jobs.get_mut(&task_job_id) {
-            job.summary = progress;
+            apply_task_report_progress(
+                &mut job.summary,
+                &previous_progress,
+                &report.progress,
+                report.now_ms,
+            );
             job.updated_at = report.now_ms;
-            if has_failed {
-                job.state = TransferState::Failed;
-            } else if has_task && all_completed {
-                job.state = TransferState::Completed;
-            } else if task_state == TransferTaskState::Completed {
-                job.state = TransferState::Running;
-            }
         }
         Ok(true)
     }
@@ -691,6 +720,9 @@ fn add_job_to_tenant_summary(
         TransferState::Completed => summary.completed = summary.completed.saturating_add(1),
         TransferState::Failed => summary.failed = summary.failed.saturating_add(1),
         TransferState::Canceled => summary.canceled = summary.canceled.saturating_add(1),
+        TransferState::PartialSuccess => {
+            summary.partial_success = summary.partial_success.saturating_add(1)
+        }
     }
 }
 

--- a/curvine-server/src/transfer/mod.rs
+++ b/curvine-server/src/transfer/mod.rs
@@ -32,7 +32,7 @@ mod planner;
 pub use self::planner::{PlannedTransfer, TransferPlanner};
 
 mod service;
-pub use self::service::{progress_to_proto, TransferService};
+pub use self::service::{progress_to_proto, task_summary_to_proto, TransferService};
 
 mod scheduler;
 pub use self::scheduler::TransferScheduler;
@@ -45,6 +45,26 @@ pub use self::router_handler::TransferRouterHandler;
 
 mod transfer_server;
 pub use self::transfer_server::TransferServer;
+
+pub(crate) fn apply_task_report_progress(
+    summary: &mut curvine_common::state::TransferProgress,
+    previous: &curvine_common::state::TransferProgress,
+    current: &curvine_common::state::TransferProgress,
+    now_ms: i64,
+) {
+    summary.loaded_size = summary
+        .loaded_size
+        .saturating_sub(previous.loaded_size)
+        .saturating_add(current.loaded_size)
+        .max(0);
+    summary.total_size = summary
+        .total_size
+        .saturating_sub(previous.total_size)
+        .saturating_add(current.total_size)
+        .max(0);
+    summary.update_time = now_ms;
+    summary.message = current.message.clone();
+}
 
 pub(crate) fn transfer_failure_message(
     kind: curvine_common::state::TransferKind,

--- a/curvine-server/src/transfer/mysql_store.rs
+++ b/curvine-server/src/transfer/mysql_store.rs
@@ -14,21 +14,25 @@
 
 use curvine_common::error::FsError;
 use curvine_common::state::{
-    summarize_transfer_tasks, StaleTaskAttempt, TaskAttemptStart, TransferJobRecord, TransferLease,
-    TransferListFilter, TransferState, TransferStateUpdate, TransferTaskRecord, TransferTaskReport,
-    TransferTaskState, TransferTenantSummary,
+    StaleTaskAttempt, TaskAttemptStart, TransferJobRecord, TransferLease, TransferListFilter,
+    TransferState, TransferStateUpdate, TransferTaskRecord, TransferTaskReport, TransferTaskState,
+    TransferTenantSummary,
 };
 use curvine_common::FsResult;
 use mysql::prelude::*;
 use mysql::{params, Params, Pool, PooledConn, TxOpts, Value as MysqlValue};
 
-use crate::transfer::{TransferRequeueUpdate, TransferStore};
+use crate::transfer::{
+    apply_task_report_progress, TransferPlannedTasks, TransferRequeueUpdate, TransferStore,
+    TransferTaskStateUpdate,
+};
 
 const TRANSFER_SCHEMA_VERSION: u64 = 4;
 const TRANSFER_SCHEMA_V3: u64 = 3;
 
 type TenantSummaryRow = (
     String,
+    Option<u64>,
     Option<u64>,
     Option<u64>,
     Option<u64>,
@@ -118,7 +122,7 @@ impl TransferStore for MysqlTransferStore {
     fn list_active_transfers(&self) -> FsResult<Vec<TransferJobRecord>> {
         select_jobs(
             &mut self.conn()?,
-            "select record_json from transfer_jobs where state not in (6, 7, 8)",
+            "select record_json from transfer_jobs where state not in (6, 7, 8, 9)",
             Params::Empty,
         )
     }
@@ -140,7 +144,7 @@ impl TransferStore for MysqlTransferStore {
     fn count_active_transfers(&self) -> FsResult<u64> {
         self.conn()?
             .exec_first::<u64, _, _>(
-                "select count(*) from transfer_jobs where state not in (6, 7, 8)",
+                "select count(*) from transfer_jobs where state not in (6, 7, 8, 9)",
                 Params::Empty,
             )
             .map_err(mysql_err)?
@@ -184,6 +188,7 @@ impl TransferStore for MysqlTransferStore {
                         sum(case when state = 6 then 1 else 0 end) as completed,
                         sum(case when state = 7 then 1 else 0 end) as failed,
                         sum(case when state = 8 then 1 else 0 end) as canceled,
+                        sum(case when state = 9 then 1 else 0 end) as partial_success,
                         count(*) as total
                  from transfer_jobs
                  group by tenant
@@ -195,13 +200,23 @@ impl TransferStore for MysqlTransferStore {
                     "limit" => limit as u64,
                     "offset" => offset as u64,
                 },
-                |(tenant, pending, executing, completed, failed, canceled, total): TenantSummaryRow| TransferTenantSummary {
+                |(
+                    tenant,
+                    pending,
+                    executing,
+                    completed,
+                    failed,
+                    canceled,
+                    partial_success,
+                    total,
+                ): TenantSummaryRow| TransferTenantSummary {
                     tenant,
                     pending: pending.unwrap_or_default(),
                     executing: executing.unwrap_or_default(),
                     completed: completed.unwrap_or_default(),
                     failed: failed.unwrap_or_default(),
                     canceled: canceled.unwrap_or_default(),
+                    partial_success: partial_success.unwrap_or_default(),
                     total,
                 },
             )
@@ -219,7 +234,7 @@ impl TransferStore for MysqlTransferStore {
         let job_ids: Vec<String> = tx
             .exec(
                 "select job_id from transfer_jobs
-                 where state in (6, 7, 8) and updated_at < :older_than_ms
+                 where state in (6, 7, 8, 9) and updated_at < :older_than_ms
                  order by updated_at asc
                  limit :limit",
                 params! {
@@ -235,7 +250,7 @@ impl TransferStore for MysqlTransferStore {
             )
             .map_err(mysql_err)?;
             tx.exec_drop(
-                "delete from transfer_jobs where job_id = :job_id and state in (6, 7, 8)",
+                "delete from transfer_jobs where job_id = :job_id and state in (6, 7, 8, 9)",
                 params! { "job_id" => job_id },
             )
             .map_err(mysql_err)?;
@@ -249,16 +264,25 @@ impl TransferStore for MysqlTransferStore {
     }
 
     fn request_cancel(&self, job_id: &str, run_id: u64, now_ms: i64) -> FsResult<bool> {
-        let mut job = match self.get_transfer(job_id)? {
+        let mut conn = self.conn()?;
+        let mut tx = conn
+            .start_transaction(TxOpts::default())
+            .map_err(mysql_err)?;
+        let mut job = match select_job_by_id_for_update(&mut tx, job_id)? {
             Some(job) if job.run_id == run_id && !job.state.is_terminal() => job,
-            _ => return Ok(false),
+            _ => {
+                tx.commit().map_err(mysql_err)?;
+                return Ok(false);
+            }
         };
         job.cancel_requested = true;
         job.state = TransferState::Canceling;
         job.summary.message = "cancel requested".to_string();
         job.summary.update_time = now_ms;
         job.updated_at = now_ms;
-        exec_update_job(&mut self.conn()?, &job)
+        let updated = exec_update_job(&mut tx, &job)?;
+        tx.commit().map_err(mysql_err)?;
+        Ok(updated)
     }
 
     fn acquire_runnable_transfer(
@@ -380,20 +404,30 @@ impl TransferStore for MysqlTransferStore {
         lease_ms: i64,
         now_ms: i64,
     ) -> FsResult<bool> {
-        let mut job = match self.get_transfer(job_id)? {
+        let mut conn = self.conn()?;
+        let mut tx = conn
+            .start_transaction(TxOpts::default())
+            .map_err(mysql_err)?;
+        let mut job = match select_job_by_id_for_update(&mut tx, job_id)? {
             Some(job)
                 if job.run_id == run_id
                     && job.owner == owner
                     && job.lease_epoch == lease_epoch
+                    && job.lease_expire_at > now_ms
                     && !job.state.is_terminal() =>
             {
                 job
             }
-            _ => return Ok(false),
+            _ => {
+                tx.commit().map_err(mysql_err)?;
+                return Ok(false);
+            }
         };
         job.lease_expire_at = now_ms.saturating_add(lease_ms);
         job.updated_at = now_ms;
-        exec_update_job(&mut self.conn()?, &job)
+        let updated = exec_update_job(&mut tx, &job)?;
+        tx.commit().map_err(mysql_err)?;
+        Ok(updated)
     }
 
     fn update_transfer_state(&self, update: TransferStateUpdate) -> FsResult<bool> {
@@ -406,6 +440,7 @@ impl TransferStore for MysqlTransferStore {
                 if job.run_id == update.run_id
                     && job.owner == update.owner
                     && job.lease_epoch == update.lease_epoch
+                    && job.lease_expire_at > update.now_ms
                     && update.from_states.contains(&job.state) =>
             {
                 job
@@ -424,25 +459,6 @@ impl TransferStore for MysqlTransferStore {
         Ok(updated)
     }
 
-    fn set_transfer_state(
-        &self,
-        job_id: &str,
-        run_id: u64,
-        state: TransferState,
-        message: impl Into<String>,
-        now_ms: i64,
-    ) -> FsResult<bool> {
-        let mut job = match self.get_transfer(job_id)? {
-            Some(job) if job.run_id == run_id => job,
-            _ => return Ok(false),
-        };
-        job.state = state;
-        job.summary.message = message.into();
-        job.summary.update_time = now_ms;
-        job.updated_at = now_ms;
-        exec_update_job(&mut self.conn()?, &job)
-    }
-
     fn requeue_transfer(&self, update: TransferRequeueUpdate) -> FsResult<bool> {
         let mut conn = self.conn()?;
         let mut tx = conn
@@ -453,6 +469,7 @@ impl TransferStore for MysqlTransferStore {
                 if job.run_id == update.run_id
                     && job.owner == update.owner
                     && job.lease_epoch == update.lease_epoch
+                    && job.lease_expire_at > update.now_ms
                     && job.state == TransferState::Planning =>
             {
                 job
@@ -491,6 +508,7 @@ impl TransferStore for MysqlTransferStore {
                 if job.run_id == run_id
                     && job.owner == owner
                     && job.lease_epoch == lease_epoch
+                    && job.lease_expire_at > now_ms
                     && !job.state.is_terminal()
                     && job
                         .cv_metadata_epoch
@@ -522,24 +540,81 @@ impl TransferStore for MysqlTransferStore {
         Ok(())
     }
 
-    fn update_task_state(
-        &self,
-        job_id: &str,
-        run_id: u64,
-        task_id: &str,
-        state: TransferTaskState,
-        message: impl Into<String>,
-        now_ms: i64,
-    ) -> FsResult<bool> {
-        let mut task = match select_task(&mut self.conn()?, job_id, run_id, task_id)? {
-            Some(task) => task,
-            None => return Ok(false),
+    fn persist_planned_tasks(&self, update: TransferPlannedTasks) -> FsResult<bool> {
+        let mut conn = self.conn()?;
+        let mut tx = conn
+            .start_transaction(TxOpts::default())
+            .map_err(mysql_err)?;
+        let mut job = match select_job_by_id_for_update(&mut tx, &update.job_id)? {
+            Some(job)
+                if job.run_id == update.run_id
+                    && job.owner == update.owner
+                    && job.lease_epoch == update.lease_epoch
+                    && job.lease_expire_at > update.now_ms
+                    && job.state == TransferState::Planning =>
+            {
+                job
+            }
+            _ => {
+                tx.commit().map_err(mysql_err)?;
+                return Ok(false);
+            }
         };
-        task.state = state;
-        task.progress.message = message.into();
-        task.progress.update_time = now_ms;
-        task.updated_at = now_ms;
-        exec_update_task(&mut self.conn()?, &task)
+        for task in update.tasks {
+            insert_task(&mut tx, &task)?;
+        }
+        job.state = TransferState::Dispatching;
+        job.summary.message = update.message;
+        job.summary.update_time = update.now_ms;
+        job.updated_at = update.now_ms;
+        let updated = exec_update_job(&mut tx, &job)?;
+        tx.commit().map_err(mysql_err)?;
+        Ok(updated)
+    }
+
+    fn update_task_state(&self, update: TransferTaskStateUpdate) -> FsResult<bool> {
+        let mut conn = self.conn()?;
+        let mut tx = conn
+            .start_transaction(TxOpts::default())
+            .map_err(mysql_err)?;
+        match select_job_by_id_for_update(&mut tx, &update.job_id)? {
+            Some(job)
+                if job.run_id == update.run_id
+                    && job.owner == update.owner
+                    && job.lease_epoch == update.lease_epoch
+                    && job.lease_expire_at > update.now_ms
+                    && !job.state.is_terminal() =>
+            {
+                job
+            }
+            _ => {
+                tx.commit().map_err(mysql_err)?;
+                return Ok(false);
+            }
+        };
+        let mut task = match select_task_for_update(
+            &mut tx,
+            &update.job_id,
+            update.run_id,
+            &update.task_id,
+        )? {
+            Some(task) => task,
+            None => {
+                tx.commit().map_err(mysql_err)?;
+                return Ok(false);
+            }
+        };
+        if !update.from_states.is_empty() && !update.from_states.contains(&task.state) {
+            tx.commit().map_err(mysql_err)?;
+            return Ok(false);
+        }
+        task.state = update.state;
+        task.progress.message = update.message;
+        task.progress.update_time = update.now_ms;
+        task.updated_at = update.now_ms;
+        let updated = exec_update_task(&mut tx, &task)?;
+        tx.commit().map_err(mysql_err)?;
+        Ok(updated)
     }
 
     fn claim_pending_tasks(
@@ -574,12 +649,13 @@ impl TransferStore for MysqlTransferStore {
             .exec_first(
                 "select 1 from transfer_jobs
                  where job_id = :job_id and run_id = :run_id and owner = :owner
-                   and lease_epoch = :lease_epoch",
+                   and lease_epoch = :lease_epoch and lease_expire_at > :now_ms",
                 params! {
                     "job_id" => job_id,
                     "run_id" => run_id,
                     "owner" => owner,
                     "lease_epoch" => lease_epoch,
+                    "now_ms" => now_ms,
                 },
             )
             .map_err(mysql_err)?;
@@ -617,22 +693,62 @@ impl TransferStore for MysqlTransferStore {
         Ok(stale)
     }
 
-    fn list_recoverable_tasks(
+    fn list_stale_running_tasks(
         &self,
         job_id: &str,
         run_id: u64,
+        stale_before_ms: i64,
+        limit: usize,
     ) -> FsResult<Vec<TransferTaskRecord>> {
         let rows: Vec<String> = self
             .conn()?
             .exec(
                 "select record_json from transfer_tasks
-                 where job_id = :job_id and run_id = :run_id and state in (1, 2, 6)",
-                params! { "job_id" => job_id, "run_id" => run_id },
+                 where job_id = :job_id and run_id = :run_id and state = 2
+                   and stale_deadline_at < :stale_before_ms
+                 order by stale_deadline_at asc
+                 limit :limit",
+                params! {
+                    "job_id" => job_id,
+                    "run_id" => run_id,
+                    "stale_before_ms" => stale_before_ms,
+                    "limit" => limit as u64,
+                },
             )
             .map_err(mysql_err)?;
         rows.into_iter()
             .map(|row| serde_json::from_str(&row).map_err(json_err))
             .collect()
+    }
+
+    fn has_failed_tasks(&self, job_id: &str, run_id: u64) -> FsResult<bool> {
+        let result: Option<u8> = self
+            .conn()?
+            .exec_first(
+                "select 1 from transfer_tasks
+                 where job_id = :job_id and run_id = :run_id and state = :state
+                 limit 1",
+                params! {
+                    "job_id" => job_id,
+                    "run_id" => run_id,
+                    "state" => TransferTaskState::Failed as i32,
+                },
+            )
+            .map_err(mysql_err)?;
+        Ok(result.is_some())
+    }
+
+    fn has_recoverable_tasks(&self, job_id: &str, run_id: u64) -> FsResult<bool> {
+        let result: Option<u8> = self
+            .conn()?
+            .exec_first(
+                "select 1 from transfer_tasks
+                 where job_id = :job_id and run_id = :run_id and state in (1, 2, 6)
+                 limit 1",
+                params! { "job_id" => job_id, "run_id" => run_id },
+            )
+            .map_err(mysql_err)?;
+        Ok(result.is_some())
     }
 
     fn start_task_attempt(&self, start: TaskAttemptStart) -> FsResult<bool> {
@@ -647,6 +763,7 @@ impl TransferStore for MysqlTransferStore {
         if job.run_id != start.run_id
             || job.owner != start.owner
             || job.lease_epoch != start.lease_epoch
+            || job.lease_expire_at <= start.now_ms
             || job.cancel_requested
             || job.state.is_terminal()
         {
@@ -687,6 +804,13 @@ impl TransferStore for MysqlTransferStore {
         let mut tx = conn
             .start_transaction(TxOpts::default())
             .map_err(mysql_err)?;
+        let mut job = match select_job_by_id_for_update(&mut tx, &report.job_id)? {
+            Some(job) if job.run_id == report.run_id => job,
+            _ => {
+                tx.commit().map_err(mysql_err)?;
+                return Ok(false);
+            }
+        };
         let mut task = match select_task_for_update(
             &mut tx,
             &report.job_id,
@@ -706,13 +830,21 @@ impl TransferStore for MysqlTransferStore {
                 return Ok(false);
             }
         };
+        let previous_progress = task.progress.clone();
         task.state = report.state;
-        task.progress = report.progress;
+        task.progress = report.progress.clone();
         task.last_report_at = report.now_ms;
         task.stale_deadline_at = report.stale_deadline_at;
         task.updated_at = report.now_ms;
         exec_update_task(&mut tx, &task)?;
-        update_job_summary(&mut tx, &report.job_id, report.run_id, report.now_ms)?;
+        apply_task_report_progress(
+            &mut job.summary,
+            &previous_progress,
+            &report.progress,
+            report.now_ms,
+        );
+        job.updated_at = report.now_ms;
+        exec_update_job(&mut tx, &job)?;
         tx.commit().map_err(mysql_err)?;
         Ok(true)
     }
@@ -1001,7 +1133,7 @@ fn select_non_terminal_job_by_key(
     select_job(
         conn,
         "select record_json from transfer_jobs
-         where job_key = :job_key and state not in (6, 7, 8)
+         where job_key = :job_key and state not in (6, 7, 8, 9)
          limit 1",
         params! { "job_key" => job_key },
     )
@@ -1017,7 +1149,7 @@ fn select_conflicting_active_transfer(
     let exact_or_child = select_job(
         conn,
         "select record_json from transfer_jobs
-         where state not in (6, 7, 8)
+         where state not in (6, 7, 8, 9)
            and not (submitter = :submitter and client_request_id = :client_request_id)
            and (
                target_path = :target_path
@@ -1041,7 +1173,7 @@ fn select_conflicting_active_transfer(
         let ancestor_conflict = select_job(
             conn,
             "select record_json from transfer_jobs
-             where state not in (6, 7, 8)
+             where state not in (6, 7, 8, 9)
                and not (submitter = :submitter and client_request_id = :client_request_id)
                and target_path = :target_path
              limit 1
@@ -1149,24 +1281,6 @@ fn list_filter_mysql_params(filter: &TransferListFilter) -> (String, Vec<MysqlVa
     }
 }
 
-fn select_task(
-    conn: &mut impl Queryable,
-    job_id: &str,
-    run_id: u64,
-    task_id: &str,
-) -> FsResult<Option<TransferTaskRecord>> {
-    let value: Option<String> = conn
-        .exec_first(
-            "select record_json from transfer_tasks
-             where job_id = :job_id and run_id = :run_id and task_id = :task_id",
-            params! { "job_id" => job_id, "run_id" => run_id, "task_id" => task_id },
-        )
-        .map_err(mysql_err)?;
-    value
-        .map(|json| serde_json::from_str(&json).map_err(json_err))
-        .transpose()
-}
-
 fn select_task_for_update(
     conn: &mut impl Queryable,
     job_id: &str,
@@ -1248,26 +1362,6 @@ fn exec_update_task(conn: &mut impl Queryable, task: &TransferTaskRecord) -> FsR
 fn exec_affected(conn: &mut impl Queryable, sql: &str, params: mysql::Params) -> FsResult<u64> {
     let result = conn.exec_iter(sql, params).map_err(mysql_err)?;
     Ok(result.affected_rows())
-}
-
-fn update_job_summary(
-    conn: &mut impl Queryable,
-    job_id: &str,
-    run_id: u64,
-    now_ms: i64,
-) -> FsResult<()> {
-    let tasks = select_tasks(conn, job_id, run_id, None, None)?;
-    let mut job = select_job_by_id(conn, job_id)?.ok_or_else(|| FsError::job_not_found(job_id))?;
-    let summary = summarize_transfer_tasks(&tasks, now_ms);
-    job.summary = summary.progress;
-    job.updated_at = now_ms;
-    if summary.has_failed {
-        job.state = TransferState::Failed;
-    } else if summary.has_task && summary.all_completed {
-        job.state = TransferState::Completed;
-    }
-    let _ = exec_update_job(conn, &job)?;
-    Ok(())
 }
 
 fn job_params(job: &TransferJobRecord) -> FsResult<mysql::Params> {

--- a/curvine-server/src/transfer/planner.rs
+++ b/curvine-server/src/transfer/planner.rs
@@ -152,8 +152,9 @@ impl TransferPlanner {
 
             if tasks.len() > self.max_tasks_per_transfer {
                 return err_box!(
-                    "Transfer {} contains more files than the service allows; reduce the source scope",
-                    job.job_id
+                    "Transfer {} files exceeds {}",
+                    job.job_id,
+                    self.max_tasks_per_transfer
                 );
             }
         }
@@ -214,23 +215,8 @@ impl TransferPlanner {
         Ok(epoch_before != epoch_after)
     }
 
-    fn load_job_info(&self, job: &TransferJobRecord, mount: &MountInfo) -> LoadJobInfo {
-        let overwrite = transfer_command(job)
-            .map(|command| command.overwrite())
-            .unwrap_or(true);
-        LoadJobInfo {
-            job_id: job.job_id.clone(),
-            source_path: job.source_path.clone(),
-            target_path: job.target_path.clone(),
-            replicas: mount.replicas.unwrap_or(self.client_conf.replicas),
-            block_size: mount.block_size.unwrap_or(self.client_conf.block_size),
-            storage_type: mount.storage_type.unwrap_or(self.client_conf.storage_type),
-            ttl_ms: mount.ttl_ms,
-            ttl_action: mount.ttl_action,
-            mount_info: mount.clone(),
-            create_time: job.created_at,
-            overwrite: Some(overwrite),
-        }
+    pub(crate) fn load_job_info(&self, job: &TransferJobRecord, mount: &MountInfo) -> LoadJobInfo {
+        load_job_info(job, mount, &self.client_conf)
     }
 
     async fn get_status(
@@ -331,6 +317,29 @@ impl TransferPlanner {
     }
 }
 
+pub(crate) fn load_job_info(
+    job: &TransferJobRecord,
+    mount: &MountInfo,
+    client_conf: &ClientConf,
+) -> LoadJobInfo {
+    let overwrite = transfer_command(job)
+        .map(|command| command.overwrite())
+        .unwrap_or(true);
+    LoadJobInfo {
+        job_id: job.job_id.clone(),
+        source_path: job.source_path.clone(),
+        target_path: job.target_path.clone(),
+        replicas: mount.replicas.unwrap_or(client_conf.replicas),
+        block_size: mount.block_size.unwrap_or(client_conf.block_size),
+        storage_type: mount.storage_type.unwrap_or(client_conf.storage_type),
+        ttl_ms: mount.ttl_ms,
+        ttl_action: mount.ttl_action,
+        mount_info: mount.clone(),
+        create_time: job.created_at,
+        overwrite: Some(overwrite),
+    }
+}
+
 struct UfsEndpointLimiter {
     max_per_endpoint: usize,
     semaphores: Mutex<HashMap<String, Arc<Semaphore>>>,
@@ -353,12 +362,10 @@ impl UfsEndpointLimiter {
                 .or_insert_with(|| Arc::new(Semaphore::new(self.max_per_endpoint)))
                 .clone()
         };
-        semaphore.acquire_owned().await.map_err(|err| {
-            FsError::common(format!(
-                "Failed to acquire UFS endpoint planning permit: {}",
-                err
-            ))
-        })
+        semaphore
+            .acquire_owned()
+            .await
+            .map_err(|_| FsError::common("Transfer planning is stopping; retry shortly"))
     }
 }
 

--- a/curvine-server/src/transfer/router_handler.rs
+++ b/curvine-server/src/transfer/router_handler.rs
@@ -95,7 +95,7 @@ async fn readyz(
         );
         return (
             StatusCode::SERVICE_UNAVAILABLE,
-            "not ready: cluster metadata is unavailable\n".to_string(),
+            format!("not ready: {err}\n"),
         );
     }
 

--- a/curvine-server/src/transfer/scheduler.rs
+++ b/curvine-server/src/transfer/scheduler.rs
@@ -14,15 +14,15 @@
 
 use crate::common::UfsFactory;
 use crate::transfer::{
-    is_store_unavailable_error, job_mount_snapshot, transfer_failure_message, TransferPlanner,
-    TransferRequeueUpdate, TransferStore,
+    is_store_unavailable_error, job_mount_snapshot, transfer_failure_message, TransferPlannedTasks,
+    TransferPlanner, TransferRequeueUpdate, TransferStore, TransferTaskStateUpdate,
 };
 use curvine_common::conf::TransferConf;
 use curvine_common::error::FsError;
 use curvine_common::state::{
-    summarize_transfer_tasks, LoadJobInfo, LoadTaskInfo, TaskAttemptStart, TransferCommand,
-    TransferJobRecord, TransferLease, TransferProgress, TransferState, TransferStateUpdate,
-    TransferTaskRecord, TransferTaskReport, TransferTaskReportInfo, TransferTaskState, WorkerInfo,
+    summarize_transfer_tasks, LoadJobInfo, LoadTaskInfo, TaskAttemptStart, TransferJobRecord,
+    TransferLease, TransferProgress, TransferState, TransferStateUpdate, TransferTaskRecord,
+    TransferTaskReport, TransferTaskReportInfo, TransferTaskState, WorkerInfo,
 };
 use curvine_common::FsResult;
 use futures::stream::{self, StreamExt, TryStreamExt};
@@ -46,7 +46,7 @@ pub struct TransferScheduler<S> {
     cache: ClusterMetadataCache,
     factory: Arc<UfsFactory>,
     owner: String,
-    report_target: String,
+    report_endpoints: Vec<String>,
     conf: TransferConf,
     worker_cursor: Arc<AtomicUsize>,
     last_cleanup_ms: Arc<AtomicU64>,
@@ -60,7 +60,7 @@ impl<S> Clone for TransferScheduler<S> {
             cache: self.cache.clone(),
             factory: self.factory.clone(),
             owner: self.owner.clone(),
-            report_target: self.report_target.clone(),
+            report_endpoints: self.report_endpoints.clone(),
             conf: self.conf.clone(),
             worker_cursor: self.worker_cursor.clone(),
             last_cleanup_ms: self.last_cleanup_ms.clone(),
@@ -78,7 +78,7 @@ where
         cache: ClusterMetadataCache,
         factory: Arc<UfsFactory>,
         owner: String,
-        report_target: String,
+        report_endpoints: Vec<String>,
         conf: TransferConf,
     ) -> Self {
         Self {
@@ -87,7 +87,7 @@ where
             cache,
             factory,
             owner,
-            report_target,
+            report_endpoints,
             conf,
             worker_cursor: Arc::new(AtomicUsize::new(0)),
             last_cleanup_ms: Arc::new(AtomicU64::new(0)),
@@ -150,7 +150,10 @@ where
             TransferState::Canceling => {
                 self.cancel_transfer(&job, &lease).await?;
             }
-            TransferState::Completed | TransferState::Failed | TransferState::Canceled => {}
+            TransferState::Completed
+            | TransferState::Failed
+            | TransferState::Canceled
+            | TransferState::PartialSuccess => {}
         }
         Ok(())
     }
@@ -252,6 +255,8 @@ where
                 });
                 self.fail_transfer(
                     &job,
+                    &lease,
+                    &[TransferState::Planning],
                     transfer_failure_message(job.kind, &job.source_path, &job.target_path, &err),
                 )?;
                 return Err(err);
@@ -277,11 +282,12 @@ where
         }
 
         if planned.tasks.is_empty() {
-            self.set_transfer_state(
+            self.transition(
                 &job,
+                &lease,
+                &[TransferState::Planning],
                 TransferState::Completed,
                 "transfer has no file tasks",
-                now_ms(),
             )?;
             record_metric(|metrics| {
                 metrics.inc_planning(transfer_kind_label(job.kind), "empty");
@@ -292,16 +298,27 @@ where
         }
 
         let task_count = planned.tasks.len();
-        self.store.insert_tasks(planned.tasks)?;
-        self.set_transfer_state(
-            &job,
-            TransferState::Dispatching,
-            format!("planned total_size={}", planned.total_size),
-            now_ms(),
-        )?;
+        let total_size = planned.total_size;
+        let job_info = planned.job_info;
+        let persisted = self.store.persist_planned_tasks(TransferPlannedTasks {
+            job_id: job.job_id.clone(),
+            run_id: job.run_id,
+            owner: lease.owner.clone(),
+            lease_epoch: lease.lease_epoch,
+            tasks: planned.tasks,
+            message: format!("planned total_size={total_size}"),
+            now_ms: now_ms(),
+        })?;
+        if !persisted {
+            warn!(
+                "stop planning transfer {} because owner {} lease epoch {} is stale",
+                job.job_id, lease.owner, lease.lease_epoch
+            );
+            return Ok(());
+        }
         debug!(
             "transfer {} planned with job info source={}, target={}",
-            job.job_id, planned.job_info.source_path, planned.job_info.target_path
+            job.job_id, job_info.source_path, job_info.target_path
         );
         record_metric(|metrics| {
             metrics.inc_planning(transfer_kind_label(job.kind), "success");
@@ -343,6 +360,8 @@ where
                     }
                     self.fail_transfer(
                         &job,
+                        &lease,
+                        &[TransferState::Dispatching],
                         transfer_failure_message(
                             job.kind,
                             &job.source_path,
@@ -435,7 +454,7 @@ where
             let job_info = job_info.clone();
             let owner = lease.owner.clone();
             let lease_epoch = lease.lease_epoch;
-            let report_target = self.report_target.clone();
+            let report_endpoints = self.report_endpoints.clone();
             let task_stale_timeout_ms = duration_ms(self.conf.task_stale_timeout);
             async move {
                 dispatch_one(DispatchTaskRequest {
@@ -447,7 +466,7 @@ where
                     lease_epoch,
                     task,
                     worker,
-                    report_target,
+                    report_endpoints,
                     task_stale_timeout_ms,
                 })
                 .await
@@ -464,36 +483,7 @@ where
         job: &TransferJobRecord,
         mount: &curvine_common::state::MountInfo,
     ) -> curvine_common::state::LoadJobInfo {
-        let overwrite = transfer_command(job)
-            .map(|command| command.overwrite())
-            .unwrap_or(true);
-        curvine_common::state::LoadJobInfo {
-            job_id: job.job_id.clone(),
-            source_path: job.source_path.clone(),
-            target_path: job.target_path.clone(),
-            replicas: mount.replicas.unwrap_or(self.conf_default_replicas()),
-            block_size: mount.block_size.unwrap_or(self.conf_default_block_size()),
-            storage_type: mount
-                .storage_type
-                .unwrap_or(self.conf_default_storage_type()),
-            ttl_ms: mount.ttl_ms,
-            ttl_action: mount.ttl_action,
-            mount_info: mount.clone(),
-            create_time: job.created_at,
-            overwrite: Some(overwrite),
-        }
-    }
-
-    fn conf_default_replicas(&self) -> i32 {
-        curvine_common::conf::ClientConf::default().replicas
-    }
-
-    fn conf_default_block_size(&self) -> i64 {
-        curvine_common::conf::ClientConf::default().block_size
-    }
-
-    fn conf_default_storage_type(&self) -> curvine_common::state::StorageType {
-        curvine_common::conf::ClientConf::default().storage_type
+        self.planner.load_job_info(job, mount)
     }
 
     async fn check_running_transfer(
@@ -513,30 +503,42 @@ where
         )?;
         for attempt in stale {
             if attempt.task.retry_count as usize > self.conf.task_max_retries {
-                self.store.update_task_state(
-                    &attempt.task.job_id,
-                    attempt.task.run_id,
-                    &attempt.task.task_id,
-                    TransferTaskState::Failed,
-                    "transfer task did not report progress before the retry limit was reached; check Transfer worker health",
-                    now,
-                )?;
-                self.fail_transfer(
-                    &job,
-                    "transfer task did not report progress before the retry limit was reached; check Transfer worker health",
-                )?;
+                if !self.store.update_task_state(TransferTaskStateUpdate {
+                    job_id: attempt.task.job_id.clone(),
+                    run_id: attempt.task.run_id,
+                    owner: lease.owner.clone(),
+                    lease_epoch: lease.lease_epoch,
+                    task_id: attempt.task.task_id.clone(),
+                    from_states: vec![TransferTaskState::Stale],
+                    state: TransferTaskState::Failed,
+                    message: "transfer task did not report progress before the retry limit was reached; check Transfer worker health".to_string(),
+                    now_ms: now,
+                })? {
+                    return Ok(());
+                }
+                self.finish_failed_transfer(&job, &lease).await?;
                 record_metric(|metrics| metrics.inc_stale_retry("exhausted"));
                 return Ok(());
             }
-            self.store.update_task_state(
-                &attempt.task.job_id,
-                attempt.task.run_id,
-                &attempt.task.task_id,
-                TransferTaskState::Pending,
-                "retry stale task attempt",
-                now,
-            )?;
+            if !self.store.update_task_state(TransferTaskStateUpdate {
+                job_id: attempt.task.job_id.clone(),
+                run_id: attempt.task.run_id,
+                owner: lease.owner.clone(),
+                lease_epoch: lease.lease_epoch,
+                task_id: attempt.task.task_id.clone(),
+                from_states: vec![TransferTaskState::Stale],
+                state: TransferTaskState::Pending,
+                message: "retry stale task attempt".to_string(),
+                now_ms: now,
+            })? {
+                return Ok(());
+            }
             record_metric(|metrics| metrics.inc_stale_retry("scheduled"));
+        }
+
+        if self.store.has_failed_tasks(&job.job_id, job.run_id)? {
+            self.finish_failed_transfer(&job, &lease).await?;
+            return Ok(());
         }
 
         if !self
@@ -544,31 +546,18 @@ where
             .claim_pending_tasks(&job.job_id, job.run_id, 1)?
             .is_empty()
         {
-            self.set_transfer_state(
+            self.transition(
                 &job,
+                &lease,
+                &[TransferState::Running],
                 TransferState::Dispatching,
                 "redispatch stale tasks",
-                now,
             )?;
             self.dispatch_pending_tasks(job, lease).await?;
             return Ok(());
         }
 
-        let tasks = self.store.list_transfer_tasks(&job.job_id, job.run_id)?;
-        if tasks.is_empty() {
-            return Ok(());
-        }
-
-        let summary = summarize_transfer_tasks(&tasks, now);
-        if summary.has_failed {
-            self.fail_transfer(&job, summary.progress.message)?;
-            return Ok(());
-        }
-
-        if summary.all_completed {
-            self.set_transfer_state(&job, TransferState::Completed, "all tasks completed", now)?;
-            record_metric(|metrics| metrics.inc_terminal("completed", "all_tasks_completed"));
-        } else {
+        if self.store.has_recoverable_tasks(&job.job_id, job.run_id)? {
             let renewed = self.store.renew_lease(
                 &lease.job_id,
                 lease.run_id,
@@ -580,18 +569,28 @@ where
             record_metric(|metrics| {
                 metrics.inc_lease_renew(if renewed { "success" } else { "stale" })
             });
+        } else {
+            let _ = self.transition(
+                &job,
+                &lease,
+                &[TransferState::Running],
+                TransferState::Completed,
+                "all tasks completed",
+            )?;
+            record_metric(|metrics| metrics.inc_terminal("completed", "all_tasks_completed"));
         }
         Ok(())
     }
 
     async fn probe_stale_running_tasks(&self, job: &TransferJobRecord, now: i64) -> FsResult<()> {
-        let tasks = self.store.list_recoverable_tasks(&job.job_id, job.run_id)?;
+        let tasks = self.store.list_stale_running_tasks(
+            &job.job_id,
+            job.run_id,
+            now,
+            self.conf.task_probe_concurrency(),
+        )?;
         let workers = self.cache.live_workers().unwrap_or_default();
-        for task in tasks
-            .into_iter()
-            .filter(|task| task.state == TransferTaskState::Running && task.stale_deadline_at < now)
-            .take(self.conf.task_probe_concurrency())
-        {
+        for task in tasks {
             let Some(worker) = workers.iter().find(|worker| {
                 worker.worker_id() == task.worker_id
                     && worker.worker_session_id == task.worker_session_id
@@ -641,22 +640,89 @@ where
     async fn cancel_transfer(
         &self,
         job: &TransferJobRecord,
-        _lease: &TransferLease,
+        lease: &TransferLease,
+    ) -> FsResult<()> {
+        self.stop_recoverable_tasks(job, lease, "transfer canceled")
+            .await?;
+
+        let _ = self.transition(
+            job,
+            lease,
+            &[TransferState::Canceling],
+            TransferState::Canceled,
+            "transfer canceled",
+        )?;
+        record_metric(|metrics| metrics.inc_terminal("canceled", "cancel_requested"));
+        Ok(())
+    }
+
+    async fn finish_failed_transfer(
+        &self,
+        job: &TransferJobRecord,
+        lease: &TransferLease,
+    ) -> FsResult<()> {
+        self.stop_recoverable_tasks(job, lease, "transfer stopped after a task failed")
+            .await?;
+        let tasks = self.store.list_transfer_tasks(&job.job_id, job.run_id)?;
+        let summary = summarize_transfer_tasks(&tasks, now_ms());
+        let state = if summary.counts.completed > 0 {
+            TransferState::PartialSuccess
+        } else {
+            TransferState::Failed
+        };
+        let message = if state == TransferState::PartialSuccess {
+            format!(
+                "{}; {} file(s) completed and remain cached",
+                summary.progress.message, summary.counts.completed
+            )
+        } else {
+            summary.progress.message
+        };
+        let _ = self.transition(job, lease, &[TransferState::Running], state, message)?;
+        record_metric(|metrics| {
+            metrics.inc_terminal(
+                if state == TransferState::PartialSuccess {
+                    "partial_success"
+                } else {
+                    "failed"
+                },
+                "task_failed",
+            )
+        });
+        Ok(())
+    }
+
+    async fn stop_recoverable_tasks(
+        &self,
+        job: &TransferJobRecord,
+        lease: &TransferLease,
+        message: &str,
     ) -> FsResult<()> {
         let tasks = self.store.list_transfer_tasks(&job.job_id, job.run_id)?;
         let mut workers = HashSet::new();
         for task in tasks {
+            if !matches!(
+                task.state,
+                TransferTaskState::Pending | TransferTaskState::Running | TransferTaskState::Stale
+            ) {
+                continue;
+            }
             if task.worker_id != 0 {
                 workers.insert(task.worker_id);
             }
-            self.store.update_task_state(
-                &task.job_id,
-                task.run_id,
-                &task.task_id,
-                TransferTaskState::Canceled,
-                "transfer canceled",
-                now_ms(),
-            )?;
+            if !self.store.update_task_state(TransferTaskStateUpdate {
+                job_id: task.job_id.clone(),
+                run_id: task.run_id,
+                owner: lease.owner.clone(),
+                lease_epoch: lease.lease_epoch,
+                task_id: task.task_id,
+                from_states: vec![task.state],
+                state: TransferTaskState::Canceled,
+                message: message.to_string(),
+                now_ms: now_ms(),
+            })? {
+                continue;
+            }
         }
 
         let live_workers = match self.cache.live_workers() {
@@ -685,8 +751,6 @@ where
             }
         }
 
-        self.set_transfer_state(job, TransferState::Canceled, "transfer canceled", now_ms())?;
-        record_metric(|metrics| metrics.inc_terminal("canceled", "cancel_requested"));
         Ok(())
     }
 
@@ -731,42 +795,16 @@ where
         Ok(updated)
     }
 
-    fn set_transfer_state(
+    fn fail_transfer(
         &self,
         job: &TransferJobRecord,
-        to_state: TransferState,
+        lease: &TransferLease,
+        from_states: &[TransferState],
         message: impl Into<String>,
-        now_ms: i64,
-    ) -> FsResult<bool> {
-        let message = message.into();
-        let updated = self.store.set_transfer_state(
-            &job.job_id,
-            job.run_id,
-            to_state,
-            message.clone(),
-            now_ms,
-        )?;
-        if updated {
-            info!(
-                "transfer state set job_id={} run_id={} kind={:?} tenant={} owner={} lease_epoch={} from={:?} to={:?} message={}",
-                job.job_id,
-                job.run_id,
-                job.kind,
-                job.tenant,
-                job.owner,
-                job.lease_epoch,
-                job.state,
-                to_state,
-                message
-            );
-        }
-        Ok(updated)
-    }
-
-    fn fail_transfer(&self, job: &TransferJobRecord, message: impl Into<String>) -> FsResult<()> {
+    ) -> FsResult<()> {
         let message = message.into();
         error!("transfer {} failed: {}", job.job_id, message);
-        self.set_transfer_state(job, TransferState::Failed, message, now_ms())?;
+        let _ = self.transition(job, lease, from_states, TransferState::Failed, message)?;
         record_metric(|metrics| metrics.inc_terminal("failed", "error"));
         Ok(())
     }
@@ -781,7 +819,7 @@ struct DispatchTaskRequest<S> {
     lease_epoch: u64,
     task: TransferTaskRecord,
     worker: WorkerInfo,
-    report_target: String,
+    report_endpoints: Vec<String>,
     task_stale_timeout_ms: i64,
 }
 
@@ -798,7 +836,7 @@ where
         lease_epoch,
         task,
         worker,
-        report_target,
+        report_endpoints,
         task_stale_timeout_ms,
     } = request;
     let now = now_ms();
@@ -816,13 +854,14 @@ where
     let started = store.start_task_attempt(TaskAttemptStart {
         job_id: task.job_id.clone(),
         run_id: task.run_id,
-        owner,
+        owner: owner.clone(),
         lease_epoch,
         task_id: task.task_id.clone(),
         attempt_id,
         worker_id: worker.worker_id(),
         worker_session_id: worker.worker_session_id.clone(),
-        report_target_json: report_target.clone(),
+        report_target_json: serde_json::to_string(&report_endpoints)
+            .map_err(|_| FsError::common("Unable to prepare transfer report endpoints"))?,
         now_ms: now,
         stale_deadline_at: now.saturating_add(task_stale_timeout_ms),
     })?;
@@ -843,7 +882,8 @@ where
             attempt_id,
             worker_id: worker.worker_id(),
             worker_session_id: worker.worker_session_id.clone(),
-            report_target,
+            report_target: report_endpoints.first().cloned().unwrap_or_default(),
+            report_endpoints,
         }),
     };
 
@@ -855,14 +895,19 @@ where
                 "worker {} rejected transfer task {} attempt {} before accepting it: {}",
                 worker, task.task_id, attempt_id, reason
             );
-            store.update_task_state(
-                &task.job_id,
-                task.run_id,
-                &task.task_id,
-                TransferTaskState::Pending,
-                format!("worker rejected task before accept: {}", reason),
-                now_ms(),
-            )?;
+            if !store.update_task_state(TransferTaskStateUpdate {
+                job_id: task.job_id.clone(),
+                run_id: task.run_id,
+                owner,
+                lease_epoch,
+                task_id: task.task_id.clone(),
+                from_states: vec![TransferTaskState::Running],
+                state: TransferTaskState::Pending,
+                message: format!("worker rejected task before accept: {}", reason),
+                now_ms: now_ms(),
+            })? {
+                return Ok(false);
+            }
             if let Err(err) = cache.refresh().await {
                 warn!(
                     "refresh cluster metadata after worker rejection failed: {}",
@@ -888,15 +933,6 @@ fn now_ms() -> i64 {
 
 fn duration_ms(duration: Duration) -> i64 {
     i64::try_from(duration.as_millis()).unwrap_or(i64::MAX)
-}
-
-fn transfer_command(job: &TransferJobRecord) -> FsResult<TransferCommand> {
-    serde_json::from_str(&job.command_json).map_err(|_| {
-        FsError::common(format!(
-            "Stored transfer command for job {} is invalid",
-            job.job_id
-        ))
-    })
 }
 
 fn transfer_task_state(state: i32) -> TransferTaskState {

--- a/curvine-server/src/transfer/service.rs
+++ b/curvine-server/src/transfer/service.rs
@@ -22,11 +22,12 @@ use curvine_common::proto::{
     ListTransferTenantsRequest, ListTransferTenantsResponse, ListTransfersRequest,
     ListTransfersResponse, SubmitTransferRequest, TransferJobStatusProto, TransferKindProto,
     TransferProgressProto, TransferTaskReportRequest, TransferTaskStateProto,
-    TransferTaskStatusProto, TransferTenantSummaryProto,
+    TransferTaskStatusProto, TransferTaskSummaryProto, TransferTenantSummaryProto,
 };
 use curvine_common::state::{
-    TransferCommand, TransferJobRecord, TransferKind, TransferListFilter, TransferProgress,
-    TransferState, TransferTaskRecord, TransferTaskReport, TransferTaskState,
+    summarize_transfer_tasks, TransferCommand, TransferJobRecord, TransferKind, TransferListFilter,
+    TransferProgress, TransferState, TransferTaskCounts, TransferTaskRecord, TransferTaskReport,
+    TransferTaskState,
 };
 use curvine_common::utils::SerdeUtils;
 use curvine_common::FsResult;
@@ -41,6 +42,20 @@ const PROGRESS_REPORT_COALESCE_BATCH: usize = 256;
 const TRANSFER_PROTOCOL_VERSION: u32 = 1;
 const DEFAULT_LIST_PAGE_SIZE: usize = 20;
 const MAX_LIST_PAGE_SIZE: usize = 1000;
+
+type TransferStatusPage = (
+    TransferJobRecord,
+    TransferTaskCounts,
+    Vec<TransferTaskStatusProto>,
+    Option<String>,
+);
+type TransferWatchPage = (
+    TransferJobRecord,
+    TransferTaskCounts,
+    Vec<TransferTaskStatusProto>,
+    Option<String>,
+    bool,
+);
 
 pub struct TransferService<S> {
     store: Arc<S>,
@@ -146,15 +161,15 @@ where
         let client_request_id = if req.client_request_id.is_empty() {
             Uuid::new_v4().to_string()
         } else {
-            req.client_request_id
+            req.client_request_id.clone()
         };
         let mut command = TransferCommand {
             kind,
             source_path: req.source_path.clone(),
             target_path: req.target_path.clone(),
-            client_request_id,
-            submitter: req.submitter,
-            tenant: req.tenant,
+            client_request_id: client_request_id.clone(),
+            submitter: req.submitter.clone(),
+            tenant: req.tenant.clone(),
             options: Default::default(),
         };
         if !req.command.is_empty() {
@@ -162,15 +177,24 @@ where
             if command.kind != kind
                 || command.source_path != req.source_path
                 || command.target_path != req.target_path
+                || command.client_request_id != client_request_id
+                || command.submitter != req.submitter
+                || command.tenant != req.tenant
             {
                 return Err(FsError::common(format!(
-                    "Transfer command payload does not match request fields: request kind={:?}, source={}, target={}; payload kind={:?}, source={}, target={}",
+                    "Transfer command payload does not match request identity fields: request kind={:?}, source={}, target={}, client request id={}, submitter={}, tenant={}; payload kind={:?}, source={}, target={}, client request id={}, submitter={}, tenant={}",
                     kind,
                     req.source_path,
                     req.target_path,
+                    client_request_id,
+                    req.submitter,
+                    req.tenant,
                     command.kind,
                     command.source_path,
-                    command.target_path
+                    command.target_path,
+                    command.client_request_id,
+                    command.submitter,
+                    command.tenant,
                 )));
             }
         }
@@ -251,9 +275,12 @@ where
 
     pub fn retry_transfer(&self, job_id: &str) -> FsResult<TransferJobRecord> {
         let job = self.get_transfer(job_id)?;
-        if !matches!(job.state, TransferState::Failed | TransferState::Canceled) {
+        if !matches!(
+            job.state,
+            TransferState::Failed | TransferState::Canceled | TransferState::PartialSuccess
+        ) {
             return Err(FsError::common(format!(
-                "Only failed or canceled transfers can be retried; job {} is currently {}",
+                "Only failed, canceled, or partially successful transfers can be retried; job {} is currently {}",
                 job_id,
                 transfer_state_name(job.state)
             )));
@@ -278,15 +305,12 @@ where
         job_id: &str,
         page_size: Option<u32>,
         page_token: Option<String>,
-    ) -> FsResult<(
-        TransferJobRecord,
-        Vec<TransferTaskStatusProto>,
-        Option<String>,
-    )> {
+    ) -> FsResult<TransferStatusPage> {
         let job = self.get_transfer(job_id)?;
-        let (tasks, next_page_token) =
-            self.page_tasks(&job.job_id, job.run_id, page_size, page_token)?;
-        Ok((job, tasks, next_page_token))
+        let tasks = self.store.list_transfer_tasks(&job.job_id, job.run_id)?;
+        let counts = summarize_transfer_tasks(&tasks, now_ms()).counts;
+        let (tasks, next_page_token) = self.page_tasks(tasks, page_size, page_token)?;
+        Ok((job, counts, tasks, next_page_token))
     }
 
     pub fn list_transfers(&self, req: ListTransfersRequest) -> FsResult<ListTransfersResponse> {
@@ -337,6 +361,7 @@ where
                     failed: summary.failed,
                     canceled: summary.canceled,
                     total: summary.total,
+                    partial_success: summary.partial_success,
                 })
                 .collect(),
             next_page_token,
@@ -349,18 +374,13 @@ where
         since_updated_at: Option<u64>,
         page_size: Option<u32>,
         page_token: Option<String>,
-    ) -> FsResult<(
-        TransferJobRecord,
-        Vec<TransferTaskStatusProto>,
-        Option<String>,
-        bool,
-    )> {
-        let (job, tasks, next_page_token) =
+    ) -> FsResult<TransferWatchPage> {
+        let (job, counts, tasks, next_page_token) =
             self.get_transfer_status(job_id, page_size, page_token)?;
         let changed = since_updated_at
             .map(|since| job.updated_at as u64 > since)
             .unwrap_or(true);
-        Ok((job, tasks, next_page_token, changed))
+        Ok((job, counts, tasks, next_page_token, changed))
     }
 
     pub fn request_cancel(&self, job_id: &str, run_id: Option<u64>) -> FsResult<TransferState> {
@@ -394,12 +414,10 @@ where
 
     fn page_tasks(
         &self,
-        job_id: &str,
-        run_id: u64,
+        mut tasks: Vec<TransferTaskRecord>,
         page_size: Option<u32>,
         page_token: Option<String>,
     ) -> FsResult<(Vec<TransferTaskStatusProto>, Option<String>)> {
-        let mut tasks = self.store.list_transfer_tasks(job_id, run_id)?;
         tasks.sort_by(|left, right| left.task_id.cmp(&right.task_id));
         let offset = parse_page_token(page_token)?;
         let page_size = page_size.unwrap_or(0) as usize;
@@ -727,6 +745,7 @@ fn transfer_state(state: i32) -> FsResult<TransferState> {
         6 => Ok(TransferState::Completed),
         7 => Ok(TransferState::Failed),
         8 => Ok(TransferState::Canceled),
+        9 => Ok(TransferState::PartialSuccess),
         _ => Err(FsError::common(format!("Unknown transfer state {}", state))),
     }
 }
@@ -741,6 +760,7 @@ fn transfer_state_name(state: TransferState) -> &'static str {
         TransferState::Completed => "Completed",
         TransferState::Failed => "Failed",
         TransferState::Canceled => "Canceled",
+        TransferState::PartialSuccess => "PartialSuccess",
     }
 }
 
@@ -823,6 +843,18 @@ pub fn progress_to_proto(value: TransferProgress) -> TransferProgressProto {
         total_size: value.total_size,
         update_time: value.update_time,
         message: value.message,
+    }
+}
+
+pub fn task_summary_to_proto(value: TransferTaskCounts) -> TransferTaskSummaryProto {
+    TransferTaskSummaryProto {
+        pending: value.pending,
+        running: value.running,
+        completed: value.completed,
+        failed: value.failed,
+        canceled: value.canceled,
+        stale: value.stale,
+        completed_size: value.completed_size,
     }
 }
 

--- a/curvine-server/src/transfer/sqlite_store.rs
+++ b/curvine-server/src/transfer/sqlite_store.rs
@@ -14,10 +14,9 @@
 
 use curvine_common::error::FsError;
 use curvine_common::state::{
-    summarize_transfer_tasks, StaleTaskAttempt, TaskAttemptStart, TransferCommand,
-    TransferJobRecord, TransferKind, TransferLease, TransferListFilter, TransferProgress,
-    TransferState, TransferStateUpdate, TransferTaskRecord, TransferTaskReport, TransferTaskState,
-    TransferTenantSummary,
+    StaleTaskAttempt, TaskAttemptStart, TransferCommand, TransferJobRecord, TransferKind,
+    TransferLease, TransferListFilter, TransferProgress, TransferState, TransferStateUpdate,
+    TransferTaskRecord, TransferTaskReport, TransferTaskState, TransferTenantSummary,
 };
 use curvine_common::FsResult;
 use parking_lot::Mutex;
@@ -27,7 +26,10 @@ use rusqlite::{
 use std::fs;
 use std::path::Path;
 
-use crate::transfer::{TransferRequeueUpdate, TransferStore};
+use crate::transfer::{
+    apply_task_report_progress, TransferPlannedTasks, TransferRequeueUpdate, TransferStore,
+    TransferTaskStateUpdate,
+};
 
 const TRANSFER_SCHEMA_VERSION: i64 = 2;
 
@@ -121,7 +123,7 @@ impl TransferStore for SqliteTransferStore {
     fn list_active_transfers(&self) -> FsResult<Vec<TransferJobRecord>> {
         let conn = self.conn.lock();
         let mut stmt = conn
-            .prepare(job_select_sql("where state not in (6, 7, 8)").as_str())
+            .prepare(job_select_sql("where state not in (6, 7, 8, 9)").as_str())
             .map_err(sqlite_err)?;
         let rows = stmt.query_map([], sqlite_job_row).map_err(sqlite_err)?;
         collect_sqlite_rows(rows)
@@ -145,7 +147,7 @@ impl TransferStore for SqliteTransferStore {
         self.conn
             .lock()
             .query_row(
-                "select count(*) from transfer_jobs where state not in (6, 7, 8)",
+                "select count(*) from transfer_jobs where state not in (6, 7, 8, 9)",
                 [],
                 |row| row.get::<_, i64>(0),
             )
@@ -197,6 +199,7 @@ impl TransferStore for SqliteTransferStore {
                         sum(case when state = 6 then 1 else 0 end) as completed,
                         sum(case when state = 7 then 1 else 0 end) as failed,
                         sum(case when state = 8 then 1 else 0 end) as canceled,
+                        sum(case when state = 9 then 1 else 0 end) as partial_success,
                         count(*) as total
                  from transfer_jobs
                  group by tenant
@@ -225,7 +228,7 @@ impl TransferStore for SqliteTransferStore {
             let mut stmt = tx
                 .prepare(
                     "select job_id from transfer_jobs
-                     where state in (6, 7, 8) and updated_at < ?1
+                     where state in (6, 7, 8, 9) and updated_at < ?1
                      order by updated_at asc
                      limit ?2",
                 )
@@ -244,7 +247,7 @@ impl TransferStore for SqliteTransferStore {
             )
             .map_err(sqlite_err)?;
             tx.execute(
-                "delete from transfer_jobs where job_id = ?1 and state in (6, 7, 8)",
+                "delete from transfer_jobs where job_id = ?1 and state in (6, 7, 8, 9)",
                 params![job_id],
             )
             .map_err(sqlite_err)?;
@@ -276,7 +279,7 @@ impl TransferStore for SqliteTransferStore {
         let Some(summary_json) = tx
             .query_row(
                 "select summary_json from transfer_jobs
-                 where job_id = ?1 and run_id = ?2 and state not in (6, 7, 8)",
+                 where job_id = ?1 and run_id = ?2 and state not in (6, 7, 8, 9)",
                 params![job_id, run_id as i64],
                 |row| row.get::<_, String>(0),
             )
@@ -295,7 +298,7 @@ impl TransferStore for SqliteTransferStore {
             .execute(
                 "update transfer_jobs
                  set cancel_requested = 1, state = ?3, summary_json = ?4, updated_at = ?5
-                 where job_id = ?1 and run_id = ?2 and state not in (6, 7, 8)",
+                 where job_id = ?1 and run_id = ?2 and state not in (6, 7, 8, 9)",
                 params![
                     job_id,
                     run_id as i64,
@@ -442,7 +445,7 @@ impl TransferStore for SqliteTransferStore {
                 "update transfer_jobs
                  set lease_expire_at = ?6, updated_at = ?7
                  where job_id = ?1 and run_id = ?2 and owner = ?3 and lease_epoch = ?4
-                   and state not in (6, 7, 8)",
+                   and state not in (6, 7, 8, 9) and lease_expire_at > ?7",
                 params![
                     job_id,
                     run_id as i64,
@@ -463,21 +466,31 @@ impl TransferStore for SqliteTransferStore {
             "update transfer_jobs
              set state = ?1, summary_json = ?2, updated_at = ?3
              where job_id = ?4 and run_id = ?5 and owner = ?6 and lease_epoch = ?7
-               and state in ({states})"
+               and lease_expire_at > ?3 and state in ({states})"
         );
-        let summary = transfer_progress_json(&TransferProgress {
-            message: update.message,
-            update_time: update.now_ms,
-            ..Default::default()
-        })?;
-        let affected = self
-            .conn
-            .lock()
+        let mut conn = self.conn.lock();
+        let tx = conn.transaction().map_err(sqlite_err)?;
+        let Some(job) = tx
+            .query_row(
+                job_select_sql("where job_id = ?1").as_str(),
+                params![&update.job_id],
+                sqlite_job_row,
+            )
+            .optional()
+            .map_err(sqlite_err)?
+        else {
+            tx.commit().map_err(sqlite_err)?;
+            return Ok(false);
+        };
+        let mut summary = job.summary;
+        summary.message = update.message;
+        summary.update_time = update.now_ms;
+        let affected = tx
             .execute(
                 &sql,
                 params![
                     update.to_state as i32,
-                    summary,
+                    transfer_progress_json(&summary)?,
                     update.now_ms,
                     update.job_id,
                     update.run_id as i64,
@@ -486,39 +499,7 @@ impl TransferStore for SqliteTransferStore {
                 ],
             )
             .map_err(sqlite_err)?;
-        Ok(affected > 0)
-    }
-
-    fn set_transfer_state(
-        &self,
-        job_id: &str,
-        run_id: u64,
-        state: TransferState,
-        message: impl Into<String>,
-        now_ms: i64,
-    ) -> FsResult<bool> {
-        let mut job = match self.get_transfer(job_id)? {
-            Some(job) if job.run_id == run_id => job,
-            _ => return Ok(false),
-        };
-        job.state = state;
-        job.summary.message = message.into();
-        job.summary.update_time = now_ms;
-        let affected = self
-            .conn
-            .lock()
-            .execute(
-                "update transfer_jobs set state = ?1, summary_json = ?2, updated_at = ?3
-                 where job_id = ?4 and run_id = ?5",
-                params![
-                    state as i32,
-                    transfer_progress_json(&job.summary)?,
-                    now_ms,
-                    job_id,
-                    run_id as i64
-                ],
-            )
-            .map_err(sqlite_err)?;
+        tx.commit().map_err(sqlite_err)?;
         Ok(affected > 0)
     }
 
@@ -535,7 +516,7 @@ impl TransferStore for SqliteTransferStore {
                 "update transfer_jobs
                  set state = ?1, owner = '', lease_expire_at = ?2, summary_json = ?3, updated_at = ?4
                  where job_id = ?5 and run_id = ?6 and owner = ?7 and lease_epoch = ?8
-                   and state = ?9",
+                   and lease_expire_at > ?4 and state = ?9",
                 params![
                     TransferState::Pending as i32,
                     update.next_attempt_at_ms,
@@ -568,7 +549,7 @@ impl TransferStore for SqliteTransferStore {
                 "update transfer_jobs
                  set cv_metadata_epoch = ?1, updated_at = ?2
                  where job_id = ?3 and run_id = ?4 and owner = ?5 and lease_epoch = ?6
-                   and state not in (6, 7, 8)
+                   and lease_expire_at > ?2 and state not in (6, 7, 8, 9)
                    and (cv_metadata_epoch is null or cv_metadata_epoch = ?1)",
                 params![
                     cv_metadata_epoch as i64,
@@ -593,45 +574,96 @@ impl TransferStore for SqliteTransferStore {
         Ok(())
     }
 
-    fn update_task_state(
-        &self,
-        job_id: &str,
-        run_id: u64,
-        task_id: &str,
-        state: TransferTaskState,
-        message: impl Into<String>,
-        now_ms: i64,
-    ) -> FsResult<bool> {
-        let mut progress = TransferProgress {
-            message: message.into(),
-            update_time: now_ms,
+    fn persist_planned_tasks(&self, update: TransferPlannedTasks) -> FsResult<bool> {
+        let mut conn = self.conn.lock();
+        let tx = conn.transaction().map_err(sqlite_err)?;
+        let summary = transfer_progress_json(&TransferProgress {
+            message: update.message,
+            update_time: update.now_ms,
             ..Default::default()
-        };
-        if let Some(task) = self
-            .list_transfer_tasks(job_id, run_id)?
-            .into_iter()
-            .find(|task| task.task_id == task_id)
-        {
-            progress.loaded_size = task.progress.loaded_size;
-            progress.total_size = task.progress.total_size;
-        }
-        let affected = self
-            .conn
-            .lock()
+        })?;
+        let affected = tx
             .execute(
-                "update transfer_tasks set state = ?1, progress_json = ?2, updated_at = ?3
-                 where job_id = ?4 and run_id = ?5 and task_id = ?6",
+                "update transfer_jobs
+                 set state = ?1, summary_json = ?2, updated_at = ?3
+                 where job_id = ?4 and run_id = ?5 and owner = ?6 and lease_epoch = ?7
+                   and lease_expire_at > ?3 and state = ?8",
                 params![
-                    state as i32,
-                    transfer_progress_json(&progress)?,
-                    now_ms,
-                    job_id,
-                    run_id as i64,
-                    task_id
+                    TransferState::Dispatching as i32,
+                    summary,
+                    update.now_ms,
+                    update.job_id,
+                    update.run_id as i64,
+                    update.owner,
+                    update.lease_epoch as i64,
+                    TransferState::Planning as i32,
                 ],
             )
             .map_err(sqlite_err)?;
-        Ok(affected > 0)
+        if affected == 0 {
+            tx.commit().map_err(sqlite_err)?;
+            return Ok(false);
+        }
+        for task in update.tasks {
+            insert_task(&tx, &task)?;
+        }
+        tx.commit().map_err(sqlite_err)?;
+        Ok(true)
+    }
+
+    fn update_task_state(&self, update: TransferTaskStateUpdate) -> FsResult<bool> {
+        let mut conn = self.conn.lock();
+        let tx = conn.transaction().map_err(sqlite_err)?;
+        let Some(job) = tx
+            .query_row(
+                job_select_sql("where job_id = ?1").as_str(),
+                params![&update.job_id],
+                sqlite_job_row,
+            )
+            .optional()
+            .map_err(sqlite_err)?
+        else {
+            tx.commit().map_err(sqlite_err)?;
+            return Ok(false);
+        };
+        if job.run_id != update.run_id
+            || job.owner != update.owner
+            || job.lease_epoch != update.lease_epoch
+            || job.lease_expire_at <= update.now_ms
+            || job.state.is_terminal()
+        {
+            tx.commit().map_err(sqlite_err)?;
+            return Ok(false);
+        }
+        let Some(mut task) = tx
+            .query_row(
+                "select job_id, run_id, task_id, attempt_id, source_path, target_path,
+                        worker_id, worker_session_id, source_read_plan_json, report_target_json,
+                        state, progress_json, retry_count, attempt_started_at, last_report_at,
+                        stale_deadline_at, updated_at
+                 from transfer_tasks
+                 where job_id = ?1 and run_id = ?2 and task_id = ?3",
+                params![&update.job_id, update.run_id as i64, &update.task_id],
+                sqlite_task_row,
+            )
+            .optional()
+            .map_err(sqlite_err)?
+        else {
+            tx.commit().map_err(sqlite_err)?;
+            return Ok(false);
+        };
+        if !update.from_states.is_empty() && !update.from_states.contains(&task.state) {
+            tx.commit().map_err(sqlite_err)?;
+            return Ok(false);
+        }
+
+        task.state = update.state;
+        task.progress.message = update.message;
+        task.progress.update_time = update.now_ms;
+        task.updated_at = update.now_ms;
+        update_task_record(&tx, &task)?;
+        tx.commit().map_err(sqlite_err)?;
+        Ok(true)
     }
 
     fn claim_pending_tasks(
@@ -676,8 +708,9 @@ impl TransferStore for SqliteTransferStore {
         let valid_owner: Option<i64> = tx
             .query_row(
                 "select 1 from transfer_jobs
-                 where job_id = ?1 and run_id = ?2 and owner = ?3 and lease_epoch = ?4",
-                params![job_id, run_id as i64, owner, lease_epoch as i64],
+                 where job_id = ?1 and run_id = ?2 and owner = ?3 and lease_epoch = ?4
+                   and lease_expire_at > ?5",
+                params![job_id, run_id as i64, owner, lease_epoch as i64, now_ms],
                 |row| row.get(0),
             )
             .optional()
@@ -723,10 +756,12 @@ impl TransferStore for SqliteTransferStore {
         Ok(stale)
     }
 
-    fn list_recoverable_tasks(
+    fn list_stale_running_tasks(
         &self,
         job_id: &str,
         run_id: u64,
+        stale_before_ms: i64,
+        limit: usize,
     ) -> FsResult<Vec<TransferTaskRecord>> {
         let conn = self.conn.lock();
         let mut stmt = conn
@@ -736,13 +771,46 @@ impl TransferStore for SqliteTransferStore {
                         state, progress_json, retry_count, attempt_started_at, last_report_at,
                         stale_deadline_at, updated_at
                  from transfer_tasks
-                 where job_id = ?1 and run_id = ?2 and state in (1, 2, 6)",
+                 where job_id = ?1 and run_id = ?2 and state = 2 and stale_deadline_at < ?3
+                 order by stale_deadline_at asc
+                 limit ?4",
             )
             .map_err(sqlite_err)?;
         let rows = stmt
-            .query_map(params![job_id, run_id as i64], sqlite_task_row)
+            .query_map(
+                params![job_id, run_id as i64, stale_before_ms, limit as i64],
+                sqlite_task_row,
+            )
             .map_err(sqlite_err)?;
         collect_sqlite_rows(rows)
+    }
+
+    fn has_failed_tasks(&self, job_id: &str, run_id: u64) -> FsResult<bool> {
+        self.conn
+            .lock()
+            .query_row(
+                "select exists(
+                     select 1 from transfer_tasks
+                      where job_id = ?1 and run_id = ?2 and state = ?3
+                 )",
+                params![job_id, run_id as i64, TransferTaskState::Failed as i32],
+                |row| row.get(0),
+            )
+            .map_err(sqlite_err)
+    }
+
+    fn has_recoverable_tasks(&self, job_id: &str, run_id: u64) -> FsResult<bool> {
+        self.conn
+            .lock()
+            .query_row(
+                "select exists(
+                     select 1 from transfer_tasks
+                      where job_id = ?1 and run_id = ?2 and state in (1, 2, 6)
+                 )",
+                params![job_id, run_id as i64],
+                |row| row.get(0),
+            )
+            .map_err(sqlite_err)
     }
 
     fn start_task_attempt(&self, start: TaskAttemptStart) -> FsResult<bool> {
@@ -759,7 +827,7 @@ impl TransferStore for SqliteTransferStore {
                        select 1 from transfer_jobs
                         where job_id = ?7 and run_id = ?8 and owner = ?10
                           and lease_epoch = ?11 and cancel_requested = 0
-                          and state not in (6, 7, 8)
+                          and lease_expire_at > ?5 and state not in (6, 7, 8, 9)
                    )",
                 params![
                     start.attempt_id as i64,
@@ -782,6 +850,31 @@ impl TransferStore for SqliteTransferStore {
     fn update_task_report(&self, report: TransferTaskReport) -> FsResult<bool> {
         let mut conn = self.conn.lock();
         let tx = conn.transaction().map_err(sqlite_err)?;
+        let previous = tx
+            .query_row(
+                "select job_id, run_id, task_id, attempt_id, source_path, target_path,
+                        worker_id, worker_session_id, source_read_plan_json, report_target_json,
+                        state, progress_json, retry_count, attempt_started_at, last_report_at,
+                        stale_deadline_at, updated_at
+                 from transfer_tasks
+                 where job_id = ?1 and run_id = ?2 and task_id = ?3",
+                params![report.job_id, report.run_id as i64, report.task_id],
+                sqlite_task_row,
+            )
+            .optional()
+            .map_err(sqlite_err)?;
+        let Some(previous) = previous else {
+            tx.commit().map_err(sqlite_err)?;
+            return Ok(false);
+        };
+        if previous.attempt_id != report.attempt_id
+            || previous.worker_id != report.worker_id
+            || previous.worker_session_id != report.worker_session_id
+            || !previous.state.is_running()
+        {
+            tx.commit().map_err(sqlite_err)?;
+            return Ok(false);
+        }
         let affected = tx
             .execute(
                 "update transfer_tasks
@@ -807,8 +900,32 @@ impl TransferStore for SqliteTransferStore {
             tx.commit().map_err(sqlite_err)?;
             return Ok(false);
         }
-
-        update_job_summary(&tx, &report.job_id, report.run_id, report.now_ms)?;
+        let mut job = tx
+            .query_row(
+                job_select_sql("where job_id = ?1").as_str(),
+                params![report.job_id],
+                sqlite_job_row,
+            )
+            .optional()
+            .map_err(sqlite_err)?
+            .ok_or_else(|| FsError::job_not_found(&report.job_id))?;
+        apply_task_report_progress(
+            &mut job.summary,
+            &previous.progress,
+            &report.progress,
+            report.now_ms,
+        );
+        tx.execute(
+            "update transfer_jobs set summary_json = ?1, updated_at = ?2
+             where job_id = ?3 and run_id = ?4",
+            params![
+                transfer_progress_json(&job.summary)?,
+                report.now_ms,
+                report.job_id,
+                report.run_id as i64,
+            ],
+        )
+        .map_err(sqlite_err)?;
         tx.commit().map_err(sqlite_err)?;
         Ok(true)
     }
@@ -993,8 +1110,9 @@ fn migrate_sqlite_schema_v1_to_v2(conn: &Connection) -> FsResult<()> {
         .collect::<Result<Vec<_>, _>>()
         .map_err(sqlite_err)?;
     for (job_id, command_json) in rows {
-        let command: TransferCommand = serde_json::from_str(&command_json)
-            .map_err(|err| FsError::common(format!("Invalid transfer command json: {}", err)))?;
+        let command: TransferCommand = serde_json::from_str(&command_json).map_err(|_| {
+            FsError::common("Stored transfer command is invalid and cannot be migrated")
+        })?;
         conn.execute(
             "update transfer_jobs set target_path = ?1 where job_id = ?2",
             params![command.target_path, job_id],
@@ -1114,7 +1232,7 @@ fn select_non_terminal_job_by_key(
     job_key: &str,
 ) -> FsResult<Option<TransferJobRecord>> {
     conn.query_row(
-        job_select_sql("where job_key = ?1 and state not in (6, 7, 8) limit 1").as_str(),
+        job_select_sql("where job_key = ?1 and state not in (6, 7, 8, 9) limit 1").as_str(),
         params![job_key],
         sqlite_job_row,
     )
@@ -1128,26 +1246,20 @@ fn select_conflicting_active_transfer(
     submitter: &str,
     client_request_id: &str,
 ) -> FsResult<Option<TransferJobRecord>> {
-    let (child_lower, child_upper) = child_path_bounds(target_path);
+    let child_prefix = format!("{}/%", target_path.trim_end_matches('/'));
     let exact_or_child = conn
         .query_row(
             job_select_sql(
-                "where state not in (6, 7, 8)
+                "where state not in (6, 7, 8, 9)
                and not (submitter = ?2 and client_request_id = ?3)
                and (
                    target_path = ?1
-                   or (target_path >= ?4 and target_path < ?5)
+                   or target_path like ?4
                )
              limit 1",
             )
             .as_str(),
-            params![
-                target_path,
-                submitter,
-                client_request_id,
-                child_lower,
-                child_upper
-            ],
+            params![target_path, submitter, client_request_id, child_prefix],
             sqlite_job_row,
         )
         .optional()
@@ -1160,7 +1272,7 @@ fn select_conflicting_active_transfer(
         let ancestor_conflict = conn
             .query_row(
                 job_select_sql(
-                    "where state not in (6, 7, 8)
+                    "where state not in (6, 7, 8, 9)
                        and not (submitter = ?2 and client_request_id = ?3)
                        and target_path = ?1
                      limit 1",
@@ -1205,28 +1317,6 @@ fn ancestor_paths(target_path: &str) -> Vec<String> {
         ancestors.push(current.clone());
     }
     ancestors
-}
-
-fn child_path_bounds(target_path: &str) -> (String, String) {
-    let lower = if target_path == "/" {
-        "/".to_string()
-    } else {
-        format!("{}/", target_path.trim_end_matches('/'))
-    };
-    let upper = lexicographic_successor(&lower).unwrap_or_else(|| "\u{10ffff}".to_string());
-    (lower, upper)
-}
-
-fn lexicographic_successor(value: &str) -> Option<String> {
-    let mut bytes = value.as_bytes().to_vec();
-    for index in (0..bytes.len()).rev() {
-        if bytes[index] < u8::MAX {
-            bytes[index] += 1;
-            bytes.truncate(index + 1);
-            return String::from_utf8(bytes).ok();
-        }
-    }
-    None
 }
 
 fn sqlite_job_row(row: &Row<'_>) -> rusqlite::Result<TransferJobRecord> {
@@ -1314,61 +1404,9 @@ fn sqlite_tenant_summary_row(row: &Row<'_>) -> rusqlite::Result<TransferTenantSu
         completed: row.get::<_, i64>(3)? as u64,
         failed: row.get::<_, i64>(4)? as u64,
         canceled: row.get::<_, i64>(5)? as u64,
-        total: row.get::<_, i64>(6)? as u64,
+        partial_success: row.get::<_, i64>(6)? as u64,
+        total: row.get::<_, i64>(7)? as u64,
     })
-}
-
-fn update_job_summary(conn: &Connection, job_id: &str, run_id: u64, now_ms: i64) -> FsResult<()> {
-    let tasks = {
-        let mut stmt = conn
-            .prepare(
-                "select job_id, run_id, task_id, attempt_id, source_path, target_path,
-                        worker_id, worker_session_id, source_read_plan_json, report_target_json,
-                        state, progress_json, retry_count, attempt_started_at, last_report_at,
-                        stale_deadline_at, updated_at
-                 from transfer_tasks where job_id = ?1 and run_id = ?2",
-            )
-            .map_err(sqlite_err)?;
-        let rows = stmt
-            .query_map(params![job_id, run_id as i64], sqlite_task_row)
-            .map_err(sqlite_err)?;
-        collect_sqlite_rows(rows)?
-    };
-    let summary = summarize_transfer_tasks(&tasks, now_ms);
-    let state = if summary.has_failed {
-        Some(TransferState::Failed)
-    } else if summary.has_task && summary.all_completed {
-        Some(TransferState::Completed)
-    } else {
-        None
-    };
-    if let Some(state) = state {
-        conn.execute(
-            "update transfer_jobs set state = ?1, summary_json = ?2, updated_at = ?3
-             where job_id = ?4 and run_id = ?5",
-            params![
-                state as i32,
-                transfer_progress_json(&summary.progress)?,
-                now_ms,
-                job_id,
-                run_id as i64
-            ],
-        )
-        .map_err(sqlite_err)?;
-    } else {
-        conn.execute(
-            "update transfer_jobs set summary_json = ?1, updated_at = ?2
-             where job_id = ?3 and run_id = ?4",
-            params![
-                transfer_progress_json(&summary.progress)?,
-                now_ms,
-                job_id,
-                run_id as i64
-            ],
-        )
-        .map_err(sqlite_err)?;
-    }
-    Ok(())
 }
 
 fn collect_sqlite_rows<T>(rows: impl Iterator<Item = rusqlite::Result<T>>) -> FsResult<Vec<T>> {

--- a/curvine-server/src/transfer/store.rs
+++ b/curvine-server/src/transfer/store.rs
@@ -14,7 +14,7 @@
 
 use curvine_common::state::{
     StaleTaskAttempt, TaskAttemptStart, TransferJobRecord, TransferLease, TransferListFilter,
-    TransferState, TransferStateUpdate, TransferTaskRecord, TransferTaskReport, TransferTaskState,
+    TransferStateUpdate, TransferTaskRecord, TransferTaskReport, TransferTaskState,
     TransferTenantSummary,
 };
 use curvine_common::FsResult;
@@ -84,15 +84,6 @@ pub trait TransferStore: Send + Sync + 'static {
 
     fn update_transfer_state(&self, update: TransferStateUpdate) -> FsResult<bool>;
 
-    fn set_transfer_state(
-        &self,
-        job_id: &str,
-        run_id: u64,
-        state: TransferState,
-        message: impl Into<String>,
-        now_ms: i64,
-    ) -> FsResult<bool>;
-
     fn requeue_transfer(&self, update: TransferRequeueUpdate) -> FsResult<bool>;
 
     fn set_transfer_cv_metadata_epoch(
@@ -107,15 +98,9 @@ pub trait TransferStore: Send + Sync + 'static {
 
     fn insert_tasks(&self, tasks: Vec<TransferTaskRecord>) -> FsResult<()>;
 
-    fn update_task_state(
-        &self,
-        job_id: &str,
-        run_id: u64,
-        task_id: &str,
-        state: TransferTaskState,
-        message: impl Into<String>,
-        now_ms: i64,
-    ) -> FsResult<bool>;
+    fn persist_planned_tasks(&self, update: TransferPlannedTasks) -> FsResult<bool>;
+
+    fn update_task_state(&self, update: TransferTaskStateUpdate) -> FsResult<bool>;
 
     fn claim_pending_tasks(
         &self,
@@ -134,11 +119,17 @@ pub trait TransferStore: Send + Sync + 'static {
         limit: usize,
     ) -> FsResult<Vec<StaleTaskAttempt>>;
 
-    fn list_recoverable_tasks(
+    fn list_stale_running_tasks(
         &self,
         job_id: &str,
         run_id: u64,
+        stale_before_ms: i64,
+        limit: usize,
     ) -> FsResult<Vec<TransferTaskRecord>>;
+
+    fn has_failed_tasks(&self, job_id: &str, run_id: u64) -> FsResult<bool>;
+
+    fn has_recoverable_tasks(&self, job_id: &str, run_id: u64) -> FsResult<bool>;
 
     fn start_task_attempt(&self, start: TaskAttemptStart) -> FsResult<bool>;
 
@@ -152,5 +143,27 @@ pub struct TransferRequeueUpdate {
     pub lease_epoch: u64,
     pub message: String,
     pub next_attempt_at_ms: i64,
+    pub now_ms: i64,
+}
+
+pub struct TransferPlannedTasks {
+    pub job_id: String,
+    pub run_id: u64,
+    pub owner: String,
+    pub lease_epoch: u64,
+    pub tasks: Vec<TransferTaskRecord>,
+    pub message: String,
+    pub now_ms: i64,
+}
+
+pub struct TransferTaskStateUpdate {
+    pub job_id: String,
+    pub run_id: u64,
+    pub owner: String,
+    pub lease_epoch: u64,
+    pub task_id: String,
+    pub from_states: Vec<TransferTaskState>,
+    pub state: TransferTaskState,
+    pub message: String,
     pub now_ms: i64,
 }

--- a/curvine-server/src/transfer/transfer_server.rs
+++ b/curvine-server/src/transfer/transfer_server.rs
@@ -100,12 +100,6 @@ impl TransferServer {
         if !conf.transfer.enabled {
             return Err(FsError::common("curvine-transfer requires transfer.enabled=true").into());
         }
-        if conf.transfer.endpoints.is_empty() {
-            return Err(FsError::common(
-                "curvine-transfer requires transfer.endpoints to route worker task reports",
-            )
-            .into());
-        }
         Logger::init(conf.master.log.clone());
         let _ = TransferMetrics::get()?;
         conf.print();
@@ -163,10 +157,6 @@ impl TransferServer {
         } else {
             conf.transfer.instance_id.clone()
         };
-        let report_target =
-            conf.transfer.endpoints.first().cloned().unwrap_or_else(|| {
-                format!("{}:{}", conf.transfer.hostname, conf.transfer.rpc_port)
-            });
         let planner = TransferPlanner::new(
             cv_metadata.clone(),
             factory.clone(),
@@ -175,13 +165,21 @@ impl TransferServer {
             conf.transfer.max_tasks_per_transfer,
             conf.transfer.ufs_max_concurrency_per_endpoint,
         );
+        let report_endpoints = if conf.transfer.endpoints.is_empty() {
+            vec![format!(
+                "{}:{}",
+                conf.transfer.hostname, conf.transfer.rpc_port
+            )]
+        } else {
+            conf.transfer.endpoints.clone()
+        };
         let scheduler = TransferScheduler::new(
             store.clone(),
             planner,
             cache.clone(),
             factory,
             owner,
-            report_target,
+            report_endpoints,
             conf.transfer.clone(),
         );
 


### PR DESCRIPTION
# Summary

Preserves partial outcomes, retry ownership, and terminal scheduling semantics across protocol and stores.

# Issue Describe / Design

Part of the standalone Transfer service. This review layer is stacked deliberately so that protocol, metadata storage, scheduling, worker execution, client routing, and deployment can be reviewed independently.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `crates/common/curvine-model/src/transfer.rs,curvine-server/src/transfer` | Preserves partial outcomes, retry ownership, and terminal scheduling semantics across protocol and stores. | New Transfer behavior; legacy behavior remains available unless Transfer is enabled. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo check -p curvine-server -p curvine-cli` | PASS | Rebased onto upstream main `497d078d`. |

# Dependencies

- Related PRs: #1352
- Related issues: #1040
- Blocks / blocked by: #1352