### PR TITLE
feat(worker): execute transfer tasks

### DIFF
--- a/curvine-server/src/master/fs/state/worker_map.rs
+++ b/curvine-server/src/master/fs/state/worker_map.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use curvine_common::state::{StorageInfo, WorkerAddress, WorkerInfo, WorkerStatus};
+use curvine_common::state::{
+    StorageInfo, TransferWorkerCapabilities, WorkerAddress, WorkerInfo, WorkerStatus,
+};
 use curvine_common::FsResult;
 use indexmap::IndexMap;
 use log::{error, info, warn};
@@ -43,6 +45,30 @@ impl WorkerMap {
         self.lost_workers.swap_remove(&addr.worker_id);
     }
 
+    pub fn remove_same_endpoint(&mut self, addr: &WorkerAddress) -> Vec<WorkerInfo> {
+        let stale_worker_ids: Vec<u32> = self
+            .workers
+            .iter()
+            .filter_map(|(worker_id, worker)| {
+                if *worker_id != addr.worker_id && worker.address.same_endpoint(addr) {
+                    Some(*worker_id)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        let mut removed = Vec::with_capacity(stale_worker_ids.len());
+        for worker_id in stale_worker_ids {
+            if let Some(worker) = self.workers.swap_remove(&worker_id) {
+                self.lost_workers.swap_remove(&worker_id);
+                removed.push(worker);
+            }
+        }
+
+        removed
+    }
+
     pub fn ensure_worker_id_addr(&self, addr: &WorkerAddress) -> FsResult<()> {
         if let Some(v) = self.workers.get(&addr.worker_id) {
             if v.address != *addr {
@@ -60,13 +86,24 @@ impl WorkerMap {
         &mut self,
         addr: WorkerAddress,
         weight: u32,
+        worker_session_id: String,
+        transfer_capabilities: TransferWorkerCapabilities,
         storages: Vec<StorageInfo>,
     ) -> FsResult<()> {
         self.ensure_worker_id_addr(&addr)?;
+        for stale in self.remove_same_endpoint(&addr) {
+            warn!(
+                "Remove stale worker {} before registering {} on the same endpoint",
+                stale.simple_debug(),
+                addr
+            );
+        }
 
         // Register the worker and update the storage information.
         // @todo Heartbeat may be too simple and directly covers historical data.
         let mut info = WorkerInfo::new(addr, weight);
+        info.worker_session_id = worker_session_id;
+        info.transfer_capabilities = transfer_capabilities;
         let worker_id = info.worker_id();
         for item in storages {
             info.add_storage(item);
@@ -104,7 +141,18 @@ impl WorkerMap {
 
     // Delete blocks that have been offline
     pub fn remove_offline(&mut self, id: u32) -> Option<WorkerInfo> {
-        self.remove_expired(id)
+        let worker = match self.workers.swap_remove(&id) {
+            None => {
+                warn!("Not found worker {}", id);
+                return None;
+            }
+
+            Some(v) => v,
+        };
+
+        info!("remove offline worker {}", worker.address);
+        self.lost_workers.insert(id, worker.clone());
+        Some(worker)
     }
 
     pub fn workers(&self) -> &IndexMap<u32, WorkerInfo> {

--- a/curvine-server/src/master/fs/worker_manager.rs
+++ b/curvine-server/src/master/fs/worker_manager.rs
@@ -18,7 +18,7 @@ use crate::master::fs::DeleteResult;
 use curvine_common::conf::ClusterConf;
 use curvine_common::state::{
     BlockLocation, ExtendedBlock, HeartbeatStatus, LocatedBlock, StorageInfo, StorageType,
-    WorkerAddress, WorkerCommand, WorkerInfo, WorkerStatus,
+    TransferWorkerCapabilities, WorkerAddress, WorkerCommand, WorkerInfo, WorkerStatus,
 };
 use curvine_common::FsResult;
 use log::{info, warn};
@@ -48,12 +48,15 @@ impl WorkerManager {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn heartbeat(
         &mut self,
         cluster_id: &str,
         status: HeartbeatStatus,
         addr: WorkerAddress,
         weight: u32,
+        worker_session_id: String,
+        transfer_capabilities: TransferWorkerCapabilities,
         storages: Vec<StorageInfo>,
     ) -> FsResult<Vec<WorkerCommand>> {
         // The cluster id must match to prevent misregistration.
@@ -71,6 +74,13 @@ impl WorkerManager {
                 // Enforce the same worker_id ↔ address rule as insert() before remove(): a Start
                 // from a conflicting address must not evict the live registration.
                 self.worker_map.ensure_worker_id_addr(&addr)?;
+                for stale in self.worker_map.remove_same_endpoint(&addr) {
+                    warn!(
+                        "Remove stale worker {} on restart endpoint {}",
+                        stale.simple_debug(),
+                        addr
+                    );
+                }
                 // Same node restarting: clear the slot so we do not treat it as ready or run
                 // Running heartbeat bookkeeping until insert() on the next Running beat.
                 self.worker_map.remove(&addr);
@@ -86,7 +96,13 @@ impl WorkerManager {
             }
         };
 
-        self.worker_map.insert(addr, weight, storages)?;
+        self.worker_map.insert(
+            addr,
+            weight,
+            worker_session_id,
+            transfer_capabilities,
+            storages,
+        )?;
         Ok(cmds)
     }
 

--- a/curvine-server/src/master/job/job_manager.rs
+++ b/curvine-server/src/master/job/job_manager.rs
@@ -41,6 +41,7 @@ pub struct JobManager {
     master_fs: MasterFilesystem,
     factory: Arc<UfsFactory>,
     mount_manager: Arc<MountManager>,
+    transfer_enabled: bool,
     job_life_ttl: Duration,
     job_cleanup_ttl: Duration,
     job_max_files: usize,
@@ -63,6 +64,7 @@ impl JobManager {
             master_fs,
             factory,
             mount_manager,
+            transfer_enabled: conf.transfer.enabled,
             job_life_ttl: conf.job.job_life_ttl,
             job_cleanup_ttl: conf.job.job_cleanup_ttl,
             job_max_files: conf.job.job_max_files,
@@ -164,10 +166,20 @@ impl JobManager {
         &self.rt
     }
 
+    fn reject_legacy_submit(&self) -> FsResult<()> {
+        if self.transfer_enabled {
+            return err_box!(
+                "Legacy Master Load API is disabled because transfer is enabled; use the Transfer service"
+            );
+        }
+        Ok(())
+    }
+
     /// See `LoadJobRunner::submit_load_task` for the concurrency contract: concurrent
     /// submits for the same path while a load is running return the **existing** run’s
     /// result; the new command’s options are not applied (first submitter wins).
     pub async fn submit_load_job(&self, command: LoadJobCommand) -> FsResult<LoadJobResult> {
+        self.reject_legacy_submit()?;
         let source_path = Path::from_str(&command.source_path)?;
 
         // Check mount info for both UFS and CV paths. Public load jobs import
@@ -215,6 +227,7 @@ impl JobManager {
     }
 
     pub async fn submit_export_job(&self, command: LoadJobCommand) -> FsResult<LoadJobResult> {
+        self.reject_legacy_submit()?;
         let source_path = Path::from_str(&command.source_path)?;
 
         let mnt = if let Some(mnt) = self.mount_manager.get_mount_info(&source_path)? {

--- a/curvine-server/src/master/master_handler.rs
+++ b/curvine-server/src/master/master_handler.rs
@@ -559,6 +559,14 @@ impl MasterHandler {
             status,
             address,
             weight,
+            header.worker_session_id.unwrap_or_default(),
+            curvine_common::state::TransferWorkerCapabilities {
+                task_submit: header.transfer_task_submit.unwrap_or(false),
+                report_target: header.transfer_report_target.unwrap_or(false),
+                query_task: header.transfer_query_task.unwrap_or(false),
+                attempt_safe_output: header.transfer_attempt_safe_output.unwrap_or(false),
+                source_read_plan: header.transfer_source_read_plan.unwrap_or(false),
+            },
             ProtoUtils::storage_info_list_from_pb(header.storages),
         )?;
         Ok(cmds)

--- a/curvine-server/src/worker/block/block_actor.rs
+++ b/curvine-server/src/worker/block/block_actor.rs
@@ -51,6 +51,7 @@ impl BlockActor {
         rt: Arc<Runtime>,
         conf: &ClusterConf,
         worker_addr: WorkerAddress,
+        worker_session_id: String,
         store: BlockStore,
         worker_ctl: StateCtl,
     ) -> CommonResult<BlockActor> {
@@ -62,6 +63,7 @@ impl BlockActor {
             store.worker_id()?,
             worker_addr,
             conf.worker.weight,
+            worker_session_id,
         );
         let executor = GroupExecutor::new(
             "worker-block-executor",

--- a/curvine-server/src/worker/block/master_client.rs
+++ b/curvine-server/src/worker/block/master_client.rs
@@ -16,7 +16,9 @@ use crate::worker::block::{BlockMeta, BlockState};
 use curvine_client::file::{FsClient, FsContext};
 use curvine_common::fs::RpcCode;
 use curvine_common::proto::*;
-use curvine_common::state::{BlockReportInfo, HeartbeatStatus, StorageInfo, WorkerAddress};
+use curvine_common::state::{
+    BlockReportInfo, HeartbeatStatus, StorageInfo, TransferWorkerCapabilities, WorkerAddress,
+};
 use curvine_common::utils::ProtoUtils;
 use orpc::CommonResult;
 use std::sync::Arc;
@@ -31,6 +33,7 @@ pub struct MasterClient {
     pub(crate) worker_id: u32,
     pub(crate) worker_addr: WorkerAddress,
     pub(crate) worker_weight: u32,
+    pub(crate) worker_session_id: String,
 }
 
 impl MasterClient {
@@ -40,6 +43,7 @@ impl MasterClient {
         worker_id: u32,
         worker_addr: WorkerAddress,
         worker_weight: u32,
+        worker_session_id: impl Into<String>,
     ) -> Self {
         // Directly reused file system client service.
         let fs_client = FsClient::new(context);
@@ -49,6 +53,7 @@ impl MasterClient {
             worker_id,
             worker_addr,
             worker_weight,
+            worker_session_id: worker_session_id.into(),
         }
     }
 
@@ -58,12 +63,19 @@ impl MasterClient {
         status: HeartbeatStatus,
         storages: Vec<StorageInfo>,
     ) -> CommonResult<WorkerHeartbeatResponse> {
+        let transfer_capabilities = TransferWorkerCapabilities::current();
         let mut req = WorkerHeartbeatRequest {
             status: status.into(),
             cluster_id: self.cluster_id.clone(),
             worker_id: self.worker_id,
             address: ProtoUtils::worker_address_to_pb(&self.worker_addr),
             weight: Some(self.worker_weight),
+            worker_session_id: Some(self.worker_session_id.clone()),
+            transfer_task_submit: Some(transfer_capabilities.task_submit),
+            transfer_report_target: Some(transfer_capabilities.report_target),
+            transfer_query_task: Some(transfer_capabilities.query_task),
+            transfer_attempt_safe_output: Some(transfer_capabilities.attempt_safe_output),
+            transfer_source_read_plan: Some(transfer_capabilities.source_read_plan),
             ..Default::default()
         };
         for item in storages {

--- a/curvine-server/src/worker/handler/worker_handler.rs
+++ b/curvine-server/src/worker/handler/worker_handler.rs
@@ -57,6 +57,8 @@ impl MessageHandler for WorkerHandler {
         match code {
             RpcCode::SubmitTask => self.task_submit(msg),
 
+            RpcCode::QueryTransferTask => self.query_transfer_task(msg),
+
             RpcCode::CancelJob => self.cancel_job(msg),
 
             RpcCode::SubmitBlockReplicationJob => self.replication_handler.handle(msg),
@@ -125,11 +127,11 @@ impl WorkerHandler {
         let task: LoadTaskInfo = SerdeUtils::deserialize(&req.task_command)?;
         let task_id = task.task_id.clone();
 
-        self.task_manager.submit_task(task)?;
+        let submit = self.task_manager.submit_task(task)?;
         let response = SubmitTaskResponse {
             task_id,
-            accepted: Some(true),
-            reject_reason: None,
+            accepted: Some(submit.accepted),
+            reject_reason: Some(submit.reject_reason),
         };
 
         Ok(Builder::success(msg).proto_header(response).build())
@@ -139,5 +141,61 @@ impl WorkerHandler {
         let req: CancelJobRequest = msg.parse_header()?;
         self.task_manager.cancel_job(req.job_id)?;
         Ok(msg.success())
+    }
+
+    pub fn query_transfer_task(&self, msg: &Message) -> FsResult<Message> {
+        let req: QueryTransferTaskRequest = msg.parse_header()?;
+        let progress = self.task_manager.query_transfer_task(
+            &req.job_id,
+            &req.task_id,
+            req.run_id,
+            req.attempt_id,
+            &req.worker_session_id,
+        )?;
+
+        let response = match progress {
+            Some(progress) => QueryTransferTaskResponse {
+                found: true,
+                state: transfer_task_state_code(progress.state),
+                progress: TransferProgressProto {
+                    loaded_size: progress.loaded_size,
+                    total_size: progress.total_size,
+                    update_time: progress.update_time,
+                    message: progress.message,
+                },
+            },
+            None => QueryTransferTaskResponse {
+                found: false,
+                state: TransferTaskStateProto::TransferTaskFailed.into(),
+                progress: TransferProgressProto {
+                    loaded_size: 0,
+                    total_size: 0,
+                    update_time: 0,
+                    message: String::new(),
+                },
+            },
+        };
+        Ok(Builder::success(msg).proto_header(response).build())
+    }
+}
+
+fn transfer_task_state_code(state: curvine_common::state::JobTaskState) -> i32 {
+    match state {
+        curvine_common::state::JobTaskState::Pending
+        | curvine_common::state::JobTaskState::UNKNOWN => {
+            TransferTaskStateProto::TransferTaskPending.into()
+        }
+        curvine_common::state::JobTaskState::Loading => {
+            TransferTaskStateProto::TransferTaskRunning.into()
+        }
+        curvine_common::state::JobTaskState::Completed => {
+            TransferTaskStateProto::TransferTaskCompleted.into()
+        }
+        curvine_common::state::JobTaskState::Failed => {
+            TransferTaskStateProto::TransferTaskFailed.into()
+        }
+        curvine_common::state::JobTaskState::Canceled => {
+            TransferTaskStateProto::TransferTaskCanceled.into()
+        }
     }
 }

--- a/curvine-server/src/worker/task/load_task_runner.rs
+++ b/curvine-server/src/worker/task/load_task_runner.rs
@@ -13,30 +13,51 @@
 // limitations under the License.
 
 use crate::common::UfsFactory;
+use crate::transfer::transfer_failure_message;
 use crate::worker::task::TaskContext;
-use curvine_client::file::CurvineFileSystem;
+use curvine_client::file::{CurvineFileSystem, FsReader};
 use curvine_client::rpc::JobMasterClient;
+use curvine_client::rpc::TransferClient;
 use curvine_client::unified::{UfsFileSystem, UnifiedReader, UnifiedWriter};
 use curvine_common::error::FsError;
 use curvine_common::fs::{FileSystem, Path, Reader, Writer};
 use curvine_common::state::{
-    CreateFileOptsBuilder, FileAllocOpts, JobTaskState, SetAttrOptsBuilder,
+    CreateFileOptsBuilder, FileBlocks, FileStatus, JobTaskProgress, JobTaskState,
+    SetAttrOptsBuilder, TRANSFER_TEMP_PATH_MARKER,
 };
 use curvine_common::FsResult;
 use log::{error, info, warn};
 use orpc::common::{LocalTime, TimeSpent};
 use orpc::err_box;
-use orpc::runtime::RpcRuntime;
-use orpc::sys::DataSlice;
 use std::sync::Arc;
+use std::time::Duration;
+
+const TRANSFER_REPORT_TIMEOUT_MS: u64 = 5_000;
+const TRANSFER_COMMIT_JOB_ID_XATTR: &str = "curvine.transfer.job_id";
+const TRANSFER_COMMIT_RUN_ID_XATTR: &str = "curvine.transfer.run_id";
+const TRANSFER_COMMIT_TASK_ID_XATTR: &str = "curvine.transfer.task_id";
+const TRANSFER_COMMIT_SOURCE_PATH_XATTR: &str = "curvine.transfer.source_path";
 
 pub struct LoadTaskRunner {
     task: Arc<TaskContext>,
     fs: CurvineFileSystem,
     factory: Arc<UfsFactory>,
     master_client: JobMasterClient,
+    transfer_client: Option<TransferClient>,
     progress_interval_ms: u64,
     task_timeout_ms: u64,
+}
+
+struct CopyStream {
+    reader: UnifiedReader,
+    writer: UnifiedWriter,
+    final_path: Path,
+    temp_path: Option<Path>,
+}
+
+enum CommitTarget {
+    RenameTemp,
+    AlreadyCommitted,
 }
 
 impl LoadTaskRunner {
@@ -44,15 +65,45 @@ impl LoadTaskRunner {
         task: Arc<TaskContext>,
         fs: CurvineFileSystem,
         factory: Arc<UfsFactory>,
+        transfer_client: Option<TransferClient>,
         progress_interval_ms: u64,
         task_timeout_ms: u64,
     ) -> Self {
         let master_client = JobMasterClient::new(fs.fs_client());
+        let transfer_client = match task.info.transfer_report.as_ref() {
+            Some(report)
+                if report.report_endpoints.is_empty() && report.report_target.is_empty() =>
+            {
+                transfer_client
+            }
+            Some(report) => {
+                let report_endpoints = if report.report_endpoints.is_empty() {
+                    vec![report.report_target.clone()]
+                } else {
+                    report.report_endpoints.clone()
+                };
+                match TransferClient::with_report_endpoints(
+                    &fs.fs_context(),
+                    report_endpoints.clone(),
+                ) {
+                    Ok(client) => Some(client),
+                    Err(err) => {
+                        warn!(
+                            "transfer task {} has invalid report endpoints {:?}: {}",
+                            task.info.task_id, report_endpoints, err
+                        );
+                        None
+                    }
+                }
+            }
+            None => transfer_client,
+        };
         Self {
             task,
             fs,
             factory,
             master_client,
+            transfer_client,
             progress_interval_ms,
             task_timeout_ms,
         }
@@ -62,108 +113,149 @@ impl LoadTaskRunner {
         self.factory.get_ufs(&self.task.info.job.mount_info)
     }
 
-    pub async fn run(&self) {
-        if let Err(e) = self.run0().await {
-            // The data replication process fails, set the status and report to the master
-            error!("task {} execute failed: {}", self.task.info.task_id, e);
-            let progress = self.task.set_failed(e.to_string());
-            let res = self
-                .master_client
-                .report_task(
-                    self.task.info.job.job_id.clone(),
-                    self.task.info.task_id.clone(),
-                    progress,
-                )
-                .await;
+    pub async fn run(&self) -> bool {
+        match self.run0().await {
+            Ok(remove_task) => remove_task,
+            Err(e) => {
+                // The data replication process fails, set the status and report to the master
+                error!("task {} execute failed: {}", self.task.info.task_id, e);
+                let progress = self.task.set_failed(transfer_failure_message(
+                    match Path::from_str(&self.task.info.source_path) {
+                        Ok(source) if source.is_cv() => curvine_common::state::TransferKind::Export,
+                        _ => curvine_common::state::TransferKind::Load,
+                    },
+                    &self.task.info.source_path,
+                    &self.task.info.target_path,
+                    &e,
+                ));
+                let res = self.report_progress(progress).await;
 
-            if let Err(e) = res {
-                warn!("report task {}", e)
+                if let Err(e) = res {
+                    warn!("report task {}", e);
+                    return self.task.info.transfer_report.is_none();
+                }
+                true
             }
-        }
-
-        crate::fault_point! {
-            async,
-            name: "worker.load_task.after_run",
-            description: "After a worker load task runner has fully exited",
-            context: {
-                "task_id" => self.task.info.task_id.clone(),
-            },
         }
     }
 
-    async fn run0(&self) -> FsResult<()> {
+    async fn run0(&self) -> FsResult<bool> {
         if self.task.is_cancel() {
-            info!("task {} was cancelled", self.task.info.task_id);
-            return Ok(());
+            info!(
+                "task {} was cancelled before starting",
+                self.task.info.task_id
+            );
+            return Ok(true);
         }
+
         self.task
             .update_state(JobTaskState::Loading, "Task started");
 
-        // Fast path: UFS(e.g. S3) -> Curvine of a large file. A single OpenDAL
-        // reader does not scale by cranking its internal `.concurrent(N)`
-        // prefetch alone -- that knob only hides single-connection latency (a
-        // small value like 2 is enough to saturate one connection); pushing it
-        // higher plateaus because one reader still commits through one writer.
-        // The way to scale is N *independent* streams, each an independent reader
-        // pulling a disjoint byte range into its own writer, which scale
-        // near-linearly (measured on BOS S3, single node: 8 streams ~1.36 GB/s
-        // vs ~215 MB/s single stream, ~6x). So for a big UFS->CV load we fan out
-        // into N independent readers writing to N contiguous regions, instead of
-        // one serial stream.
-        let source_path = Path::from_str(&self.task.info.source_path)?;
-        let target_path = Path::from_str(&self.task.info.target_path)?;
-        if !source_path.is_cv() && target_path.is_cv() && self.max_parallel_streams() > 1 {
-            // Probe source length cheaply, then let effective_streams() decide
-            // the fan-out width from file size. A small file yields 1 stream, so
-            // we fall through to the serial path below.
-            let src_len = self.get_ufs()?.get_status(&source_path).await?.len;
-            if self.effective_streams(src_len) > 1 {
-                return self.run_parallel(&source_path, &target_path, src_len).await;
-            }
-        }
-
-        let (mut reader, mut writer) = self.create_stream().await?;
+        let mut stream = self.create_stream().await?;
         if self.task.is_cancel() {
             info!("task {} was cancelled", self.task.info.task_id);
-            return Ok(());
+            return self.cancel_stream(&mut stream).await;
         }
+        let Some((copied_bytes, reader_len, read_cost_ms, total_cost_ms)) =
+            (match self.copy_and_commit_stream(&mut stream).await {
+                Ok(result) => result,
+                Err(err) => {
+                    self.cleanup_failed_stream(&stream).await;
+                    return Err(err);
+                }
+            })
+        else {
+            return Ok(true);
+        };
+
+        let (cv_path, ufs_mtime) = if stream.final_path.is_cv() {
+            // ufs -> cv
+            (&stream.final_path, stream.reader.status().mtime)
+        } else {
+            // cv -> ufs
+            let ufs_status = self.get_ufs()?.get_status(&stream.final_path).await?;
+            (stream.reader.path(), ufs_status.mtime)
+        };
+
+        let mut attr_builder = SetAttrOptsBuilder::new().ufs_mtime(ufs_mtime);
+        if stream.final_path.is_cv() {
+            if let Some(report) = &self.task.info.transfer_report {
+                attr_builder = attr_builder
+                    .add_x_attr(
+                        TRANSFER_COMMIT_JOB_ID_XATTR,
+                        self.task.info.job.job_id.as_bytes().to_vec(),
+                    )
+                    .add_x_attr(
+                        TRANSFER_COMMIT_RUN_ID_XATTR,
+                        report.run_id.to_string().into_bytes(),
+                    )
+                    .add_x_attr(
+                        TRANSFER_COMMIT_TASK_ID_XATTR,
+                        self.task.info.task_id.as_bytes().to_vec(),
+                    )
+                    .add_x_attr(
+                        TRANSFER_COMMIT_SOURCE_PATH_XATTR,
+                        self.task.info.source_path.as_bytes().to_vec(),
+                    );
+            }
+        }
+        let attr_opts = attr_builder.build();
+        self.fs.set_attr(cv_path, attr_opts).await?;
+
+        if let Err(err) = self.update_progress0(copied_bytes, reader_len, true).await {
+            if self.task.info.transfer_report.is_some() {
+                warn!(
+                    "final transfer task report failed, keep task for scheduler probe: job={}, task={}, err={}",
+                    self.task.info.job.job_id, self.task.info.task_id, err
+                );
+                return Ok(false);
+            }
+            return Err(err);
+        }
+
+        info!(
+            "task {} completed, source_path {}, target_path {}, ufs_mtime:{}, copy bytes {}, read cost {} ms, task cost {} ms",
+            self.task.info.task_id,
+            self.task.info.source_path,
+            self.task.info.target_path,
+            ufs_mtime,
+            copied_bytes,
+            read_cost_ms,
+            total_cost_ms,
+        );
+
+        Ok(true)
+    }
+
+    async fn copy_and_commit_stream(
+        &self,
+        stream: &mut CopyStream,
+    ) -> FsResult<Option<(i64, i64, u64, u64)>> {
         let mut last_progress_time = LocalTime::mills();
         let mut read_cost_ms = 0;
         let mut total_cost_ms = 0;
 
-        // Pipelined copy: overlap "read next chunk from source" with "write the
-        // previously-read chunk to the target". The serial version read and wrote
-        // strictly alternately, so a slow high-latency source (e.g. S3 over a
-        // single connection) idled the writer and vice versa, capping throughput
-        // at ~1/(1/read + 1/write). By prefetching the next chunk concurrently
-        // with the current write via try_join!, effective throughput approaches
-        // max(read, write) instead of their harmonic-style sum. This needs no
-        // extra task/thread: both futures are polled on the same task.
-        let mut pending = reader.async_read(None).await?;
-
         loop {
             if self.task.is_cancel() {
                 info!("task {} was cancelled", self.task.info.task_id);
-                return Ok(());
-            }
-
-            if pending.is_empty() {
-                break;
+                self.cancel_stream(stream).await?;
+                return Ok(None);
             }
 
             let spend = TimeSpent::new();
-            // Read the next chunk while writing the current one.
-            let (next, ()) = tokio::try_join!(
-                reader.async_read(None),
-                writer.async_write(std::mem::replace(&mut pending, DataSlice::Empty)),
-            )?;
+            let chunk = stream.reader.async_read(None).await?;
             read_cost_ms += spend.used_ms();
+
+            if chunk.is_empty() {
+                break;
+            }
+
+            stream.writer.async_write(chunk).await?;
             total_cost_ms += spend.used_ms();
-            pending = next;
 
             if LocalTime::mills() > last_progress_time + self.progress_interval_ms {
                 last_progress_time = LocalTime::mills();
-                self.update_progress(writer.pos(), reader.len(), false)
+                self.update_progress(stream.writer.pos(), stream.reader.len(), false)
                     .await;
             }
 
@@ -176,375 +268,214 @@ impl LoadTaskRunner {
             }
         }
 
-        writer.complete().await?;
-        reader.complete().await?;
-
-        let (cv_path, ufs_mtime) = if writer.path().is_cv() {
-            // ufs -> cv
-            (writer.path(), reader.status().mtime)
-        } else {
-            // cv -> ufs
-            let ufs_status = self.get_ufs()?.get_status(writer.path()).await?;
-            (reader.path(), ufs_status.mtime)
-        };
-
-        let attr_opts = SetAttrOptsBuilder::new().ufs_mtime(ufs_mtime).build();
-        self.fs.set_attr(cv_path, attr_opts).await?;
-
-        self.update_progress(writer.pos(), reader.len(), true).await;
-
-        info!(
-            "task {} completed, source_path {}, target_path {}, ufs_mtime:{}, copy bytes {}, read cost {} ms, task cost {} ms",
-            self.task.info.task_id,
-            self.task.info.source_path,
-            self.task.info.target_path,
-            ufs_mtime,
-            writer.pos(),
+        stream.writer.complete().await?;
+        stream.reader.complete().await?;
+        let copied_bytes = stream.writer.pos();
+        let reader_len = stream.reader.len();
+        self.commit_output(stream).await?;
+        Ok(Some((
+            copied_bytes,
+            reader_len,
             read_cost_ms,
             total_cost_ms,
-        );
-
-        Ok(())
+        )))
     }
 
-    /// Upper bound on the number of independent reader+writer streams a large
-    /// UFS->CV load may fan out into. Read from the mount property
-    /// `load_task.parallel_streams` (per-bucket tunable), defaulting to 8.
-    /// Clamped to >= 1. This is a CAP: the actual stream count is derived from
-    /// file size by [`Self::effective_streams`].
-    fn max_parallel_streams(&self) -> usize {
-        self.task
-            .info
-            .job
-            .mount_info
-            .properties
-            .get("load_task.parallel_streams")
-            .and_then(|v| v.parse::<usize>().ok())
-            .unwrap_or(8)
-            .max(1)
+    async fn cleanup_failed_stream(&self, stream: &CopyStream) {
+        let Some(temp_path) = &stream.temp_path else {
+            return;
+        };
+        if let Err(err) = self.delete_temp_output(temp_path).await {
+            warn!(
+                "delete failed transfer temp output {} failed for task {}: {}",
+                temp_path.full_path(),
+                self.task.info.task_id,
+                err
+            );
+        }
     }
 
-    /// Minimum number of bytes a single stream must be responsible for before
-    /// fanning out is worthwhile. Each extra stream carries fixed setup cost
-    /// (UFS open, open_for_write RPC, per-block add_block, complete) that does
-    /// NOT shrink with file size, so a stream only pays off once it moves at
-    /// least this many bytes. Configurable via the mount property
-    /// `load_task.min_bytes_per_stream` (per-bucket tunable), defaulting to
-    /// 256 MiB. Clamped to >= 1.
-    ///
-    /// This subsumes the old boolean `load_task.parallel_threshold`: a file
-    /// smaller than this value yields `effective_streams == 1`, i.e. no fan-out.
-    fn min_bytes_per_stream(&self) -> i64 {
-        self.task
-            .info
-            .job
-            .mount_info
-            .properties
-            .get("load_task.min_bytes_per_stream")
-            .and_then(|v| v.parse::<i64>().ok())
-            .unwrap_or(256 * 1024 * 1024)
-            .max(1)
-    }
-
-    /// Derive the stream count for a load of `src_len` bytes, growing the count
-    /// with file size instead of always jumping to the cap. Fixed per-stream
-    /// setup cost (opens/RPCs/complete) is independent of file size, so a
-    /// mid-size file over-parallelized to the full cap can be slower than a
-    /// smaller fan-out. We give each stream at least `min_bytes_per_stream` and
-    /// clamp to `[1, max_parallel_streams]`:
-    ///
-    ///   effective = clamp(src_len / min_bytes_per_stream, 1, cap)
-    ///
-    /// Examples (min=256 MiB, cap=8): 100 MiB -> 1 stream (no fan-out),
-    /// 512 MiB -> 2, 1 GiB -> 4, 2 GiB -> 8, 200 GiB -> 8 (capped).
-    fn effective_streams(&self, src_len: i64) -> usize {
-        Self::stream_count(
-            src_len,
-            self.min_bytes_per_stream(),
-            self.max_parallel_streams(),
-        )
-    }
-
-    /// Pure fan-out width math (extracted for unit testing): give each stream at
-    /// least `min_bytes` bytes, clamp to `[1, cap]`. `min_bytes` and `cap` are
-    /// treated as >= 1.
-    fn stream_count(src_len: i64, min_bytes: i64, cap: usize) -> usize {
-        let min_bytes = min_bytes.max(1);
-        let cap = cap.max(1);
-        let by_size = (src_len / min_bytes).max(0) as usize;
-        by_size.clamp(1, cap)
-    }
-
-    /// Compute the per-stream segment length for a parallel load.
-    ///
-    /// The segment is `ceil(src_len / streams)` rounded UP to a whole number of
-    /// `block_size` blocks. Block alignment is a correctness requirement: each
-    /// stream gets its own writer, and the block is Curvine's unit of allocation
-    /// and commit — if two streams' ranges shared a block they would race on that
-    /// block. Rounding up guarantees stream `i` owns `[i*seg, (i+1)*seg)` with a
-    /// block boundary at every `seg`, so block sets are disjoint.
-    ///
-    /// Returns a value that is always >= `block_size` and a multiple of it (so
-    /// callers must still clamp the last segment to `src_len`). `streams` and
-    /// `block_size` are treated as >= 1.
-    fn segment_len(src_len: i64, streams: usize, block_size: i64) -> i64 {
-        let streams = streams.max(1) as i64;
-        let block_size = block_size.max(1);
-        let raw = (src_len + streams - 1) / streams;
-        let aligned = ((raw + block_size - 1) / block_size) * block_size;
-        aligned.max(block_size)
-    }
-
-    /// Per-`async_read` request size within a stream. Capped so a single read
-    /// doesn't try to buffer a whole (potentially multi-GiB) segment at once.
-    const READ_CHUNK_BYTES: i64 = 16 * 1024 * 1024;
-
-    /// Fan a large UFS->CV load into N independent streams, each of which opens
-    /// its OWN reader AND its OWN writer for a disjoint, block-aligned byte range
-    /// of the file, then reads-from-UFS and writes-to-Curvine that range end to
-    /// end. This is "multi-read + multi-write":
-    ///
-    /// - Read side: N independent UFS readers scale near-linearly (a single
-    ///   OpenDAL reader's internal `.concurrent()` prefetch does not).
-    /// - Write side: N independent Curvine writers scale near-linearly too; a
-    ///   single writer tops out around one block-writer's throughput.
-    ///
-    /// Correctness relies on three Curvine properties:
-    /// 1. `resize(src_len)` up front allocates every block, giving each full
-    ///    block length `block_size` and the final block the remainder, so
-    ///    `compute_len()` already sums to exactly `src_len`. The master-side
-    ///    `complete()` length check (`compute_len == file.len`) therefore holds
-    ///    no matter which writer commits when.
-    /// 2. Segments are rounded up to a whole number of `block_size` blocks, so no
-    ///    two writers ever touch the same block (the unit of allocation/commit).
-    /// 3. Curvine natively supports multiple concurrent writers on one file
-    ///    (`add_block` is idempotent on already-allocated blocks).
-    async fn run_parallel(
-        &self,
-        source_path: &Path,
-        target_path: &Path,
-        src_len: i64,
-    ) -> FsResult<()> {
-        let streams = self.effective_streams(src_len);
-        let block_size = self.task.info.job.block_size.max(1);
-        let seg = Self::segment_len(src_len, streams, block_size);
-        let spend = TimeSpent::new();
-        // Absolute deadline shared by every stream, so a single hung stream is
-        // caught mid-segment instead of only after the whole (multi-GiB) segment
-        // finishes. Same budget as the outer join-loop timeout check.
-        let deadline_ms = LocalTime::mills() + self.task_timeout_ms;
-
-        // Pre-create + resize the target to src_len so ALL blocks are allocated
-        // up front (see property 1 above). We drop the owner writer WITHOUT
-        // completing it: completing would clear the file's write feature; we only
-        // needed the resize to allocate blocks (they persist in master meta).
-        {
-            let mut owner = self.create_unified(target_path).await?;
-            owner.resize(FileAllocOpts::with_truncate(src_len)).await?;
-            drop(owner);
+    async fn cancel_stream(&self, stream: &mut CopyStream) -> FsResult<bool> {
+        if let Err(err) = stream.writer.cancel().await {
+            warn!(
+                "cancel transfer writer failed for task {} temp {:?}: {}",
+                self.task.info.task_id, stream.temp_path, err
+            );
         }
 
-        // Fan out: each stream reads its range from UFS and writes it to the
-        // (already allocated) target region with its own reader + writer.
-        let task_timeout_ms = self.task_timeout_ms;
-        let mut handles = Vec::with_capacity(streams);
-        for i in 0..streams {
-            let off = i as i64 * seg;
-            if off >= src_len {
-                break;
-            }
-            let len = seg.min(src_len - off);
-            let ufs = self.get_ufs()?;
-            let fs = self.fs.clone();
-            let src = source_path.clone();
-            let dst = target_path.clone();
-            let rt = self.fs.clone_runtime();
-            let task = self.task.clone();
-            handles.push(rt.spawn(async move {
-                let mut reader = ufs.open(&src).await?;
-                reader.seek(off).await?;
-                // open_for_write(overwrite=false): attach as an additional writer
-                // to the existing (resized) file without truncating it.
-                let mut writer = fs.open_for_write(&dst, false).await?;
-                writer.seek(off).await?;
-
-                crate::fault_point! {
-                    async,
-                    name: "worker.load_task.parallel.before_segment_copy",
-                    description: "After a parallel load segment opens its streams and before it copies data",
-                    context: {
-                        "task_id" => task.info.task_id.clone(),
-                        "stream_index" => i as i64,
-                        "segment_offset" => off,
-                        "segment_len" => len,
-                    },
-                }
-
-                let mut remaining = len;
-                while remaining > 0 {
-                    // Honor cancellation and the shared deadline INSIDE the
-                    // segment loop: a segment can be multiple GiB, so checking
-                    // only between segments would let a canceled/timed-out job
-                    // keep reading from UFS and committing blocks. On early exit
-                    // cancel the writer so it does not complete() a partial
-                    // segment onto the pre-resized target.
-                    if task.is_cancel() {
-                        let _ = writer.cancel().await;
-                        return FsResult::Ok(0);
-                    }
-                    if LocalTime::mills() > deadline_ms {
-                        let _ = writer.cancel().await;
-                        return err_box!(
-                            "Task {} exceed timeout {} ms (segment [{}, {}))",
-                            task.info.task_id,
-                            task_timeout_ms,
-                            off,
-                            off + len
-                        );
-                    }
-                    let want = remaining.min(Self::READ_CHUNK_BYTES) as usize;
-                    let chunk = reader.async_read(Some(want)).await?;
-                    if chunk.is_empty() {
-                        break;
-                    }
-                    remaining -= chunk.len() as i64;
-                    writer.async_write(chunk).await?;
-                }
-                // Guard against silent short writes: if the source returned EOF
-                // before its advertised length, the file would be left with a
-                // hole in this segment. Fail loudly instead of committing partial
-                // data that would later read back as corrupt.
-                if remaining != 0 {
-                    let _ = writer.cancel().await;
-                    return err_box!(
-                        "short read on segment [{}, {}): {} bytes missing (source shorter than stat len?)",
-                        off,
-                        off + len,
-                        remaining
-                    );
-                }
-                // All writers share one FsContext client_name, so whichever
-                // stream completes first clears the file's write feature while
-                // other streams may still be committing blocks. This is safe
-                // ONLY because of correctness property (1) above: resize()
-                // pre-allocated every block so compute_len == file.len already
-                // holds regardless of commit order. Do NOT "fix" this into
-                // per-stream client IDs -- it is intentional.
-                writer.complete().await?;
-                reader.complete().await?;
-                FsResult::Ok(len)
-            }));
-        }
-
-        // Join all streams. On ANY early exit (cancel, segment error, timeout)
-        // abort the handles we have not yet awaited: a task blocked in a UFS read
-        // never observes is_cancel() on its own, so without this it could keep
-        // reading and complete() onto the target after the job is done/failed.
-        let mut written: i64 = 0;
-        for idx in 0..handles.len() {
-            if self.task.is_cancel() {
-                info!("task {} was cancelled", self.task.info.task_id);
-                Self::abort_remaining(&handles, idx);
-                return Ok(());
-            }
-            crate::fault_point! {
-                async,
-                name: "worker.load_task.parallel.before_join_await",
-                description: "After the parent cancellation check and before awaiting a parallel load stream",
-                context: {
-                    "task_id" => self.task.info.task_id.clone(),
-                    "stream_index" => idx as i64,
-                },
-            }
-            match (&mut handles[idx]).await {
-                Ok(Ok(n)) => {
-                    written += n;
-                    self.update_progress(written, src_len, false).await;
-                }
-                Ok(Err(e)) => {
-                    Self::abort_remaining(&handles, idx + 1);
-                    return Err(e);
-                }
-                Err(e) => {
-                    Self::abort_remaining(&handles, idx + 1);
-                    return err_box!("parallel load join error: {}", e);
-                }
-            }
-            if spend.used_ms() > self.task_timeout_ms {
-                Self::abort_remaining(&handles, idx + 1);
-                return err_box!(
-                    "Task {} exceed timeout {} ms",
+        if let Some(temp_path) = &stream.temp_path {
+            if let Err(err) = self.delete_temp_output(temp_path).await {
+                warn!(
+                    "delete cancelled transfer temp output {} failed for task {}: {}",
+                    temp_path.full_path(),
                     self.task.info.task_id,
-                    self.task_timeout_ms
+                    err
                 );
             }
         }
 
-        // Cancellation may happen after the loop's pre-await check while the
-        // final stream is still running. That stream returns Ok(0), so recheck
-        // here before stamping the pre-resized target as a valid cache entry.
-        if self.task.is_cancel() {
-            info!("task {} was cancelled", self.task.info.task_id);
-            return Ok(());
-        }
-        if written != src_len {
-            return err_box!(
-                "Task {} parallel load incomplete: wrote {} of {} bytes; refusing to mark cache valid",
-                self.task.info.task_id,
-                written,
-                src_len
+        let progress = self.task.set_canceled("task canceled");
+        if let Err(err) = self.report_progress(progress).await {
+            info!(
+                "cancelled task report was not accepted, remove local task anyway: job={}, task={}, err={}",
+                self.task.info.job.job_id, self.task.info.task_id, err
             );
         }
-
-        // ufs -> cv: stamp the source mtime onto the cached file (cache validity).
-        let ufs_mtime = self.get_ufs()?.get_status(source_path).await?.mtime;
-        let attr_opts = SetAttrOptsBuilder::new().ufs_mtime(ufs_mtime).build();
-        self.fs.set_attr(target_path, attr_opts).await?;
-
-        self.update_progress(written, src_len, true).await;
-
-        info!(
-            "task {} completed (parallel x{}), source_path {}, target_path {}, ufs_mtime:{}, copy bytes {}, task cost {} ms",
-            self.task.info.task_id,
-            streams,
-            self.task.info.source_path,
-            self.task.info.target_path,
-            ufs_mtime,
-            written,
-            spend.used_ms(),
-        );
-
-        Ok(())
+        Ok(true)
     }
 
-    /// Abort every not-yet-awaited stream handle in `handles[from..]`. Called on
-    /// any early exit from the join loop so background streams stop reading UFS
-    /// and never complete() onto the target after the job is done/failed. Tokio
-    /// abort is best-effort (it fires at the next await point); combined with the
-    /// in-loop is_cancel()/deadline checks this bounds how long a stream can run
-    /// past the parent's decision to stop.
-    fn abort_remaining(handles: &[orpc::runtime::JoinHandle<FsResult<i64>>], from: usize) {
-        for h in handles.iter().skip(from) {
-            h.abort();
+    async fn delete_temp_output(&self, temp_path: &Path) -> FsResult<()> {
+        if temp_path.is_cv() {
+            match self.fs.delete(temp_path, false).await {
+                Ok(()) | Err(FsError::FileNotFound(_)) => Ok(()),
+                Err(err) => Err(err),
+            }
+        } else {
+            let ufs = self.get_ufs()?;
+            match ufs.delete(temp_path, false).await {
+                Ok(()) | Err(FsError::FileNotFound(_)) => Ok(()),
+                Err(err) => Err(err),
+            }
         }
     }
 
-    async fn create_stream(&self) -> FsResult<(UnifiedReader, UnifiedWriter)> {
+    async fn create_stream(&self) -> FsResult<CopyStream> {
         let source_path = Path::from_str(&self.task.info.source_path)?;
         let target_path = Path::from_str(&self.task.info.target_path)?;
+        let write_path = self.transfer_temp_path(&target_path)?;
 
         // Create reader (automatically selects filesystem based on scheme)
         let reader = self.open_unified(&source_path).await?;
 
         // Create writer (automatically selects filesystem based on scheme)
-        let writer = self.create_unified(&target_path).await?;
+        let writer = self.create_unified(&write_path).await?;
 
-        Ok((reader, writer))
+        Ok(CopyStream {
+            reader,
+            writer,
+            final_path: target_path,
+            temp_path: self.task.info.transfer_report.as_ref().map(|_| write_path),
+        })
+    }
+
+    fn transfer_temp_path(&self, target_path: &Path) -> FsResult<Path> {
+        let Some(report) = &self.task.info.transfer_report else {
+            return Ok(target_path.clone());
+        };
+        Ok(Path::from_str(format!(
+            "{}{}{}-{}-{}-{}",
+            target_path.full_path(),
+            TRANSFER_TEMP_PATH_MARKER,
+            self.task.info.job.job_id,
+            report.run_id,
+            self.task.info.task_id,
+            report.attempt_id
+        ))?)
+    }
+
+    async fn commit_output(&self, stream: &CopyStream) -> FsResult<()> {
+        let Some(temp_path) = &stream.temp_path else {
+            return Ok(());
+        };
+        let overwrite = self.task.info.job.overwrite.unwrap_or(false);
+        if stream.final_path.is_cv() {
+            match self
+                .validate_cv_commit_target(&stream.final_path, stream.reader.status(), overwrite)
+                .await?
+            {
+                CommitTarget::RenameTemp => {
+                    self.fs.rename(temp_path, &stream.final_path).await?;
+                }
+                CommitTarget::AlreadyCommitted => {
+                    if let Err(err) = self.fs.delete(temp_path, false).await {
+                        warn!(
+                            "delete redundant transfer temp output {} failed after idempotent commit check: {}",
+                            temp_path.full_path(),
+                            err
+                        );
+                    }
+                }
+            }
+        } else {
+            let ufs = self.get_ufs()?;
+            commit_ufs_output(&ufs, temp_path, &stream.final_path, overwrite).await?;
+        }
+        Ok(())
+    }
+
+    async fn validate_cv_commit_target(
+        &self,
+        path: &Path,
+        source_status: &FileStatus,
+        overwrite: bool,
+    ) -> FsResult<CommitTarget> {
+        match self.fs.get_status(path).await {
+            Ok(status) if status.is_dir => err_box!(
+                "Transfer target {} is a directory; refusing to overwrite directory with file",
+                path.full_path()
+            ),
+            Ok(status) if !overwrite => {
+                if self.is_committed_transfer_output(&status, source_status) {
+                    Ok(CommitTarget::AlreadyCommitted)
+                } else {
+                    Err(FsError::file_exists(path.full_path()))
+                }
+            }
+            Ok(_) => Ok(CommitTarget::RenameTemp),
+            Err(FsError::FileNotFound(_)) => Ok(CommitTarget::RenameTemp),
+            Err(err) => Err(err),
+        }
+    }
+
+    fn is_committed_transfer_output(
+        &self,
+        target_status: &FileStatus,
+        source_status: &FileStatus,
+    ) -> bool {
+        if target_status.len != source_status.len
+            || target_status.storage_policy.ufs_mtime != source_status.mtime
+        {
+            return false;
+        }
+        let Some(report) = &self.task.info.transfer_report else {
+            return false;
+        };
+
+        xattr_equals(
+            target_status,
+            TRANSFER_COMMIT_JOB_ID_XATTR,
+            self.task.info.job.job_id.as_bytes(),
+        ) && xattr_equals(
+            target_status,
+            TRANSFER_COMMIT_RUN_ID_XATTR,
+            report.run_id.to_string().as_bytes(),
+        ) && xattr_equals(
+            target_status,
+            TRANSFER_COMMIT_TASK_ID_XATTR,
+            self.task.info.task_id.as_bytes(),
+        ) && xattr_equals(
+            target_status,
+            TRANSFER_COMMIT_SOURCE_PATH_XATTR,
+            self.task.info.source_path.as_bytes(),
+        )
     }
 
     async fn open_unified(&self, path: &Path) -> FsResult<UnifiedReader> {
         if path.is_cv() {
-            let reader = self.fs.open(path).await?;
+            let reader = if self.task.info.source_read_plan_json.is_empty() {
+                self.fs.open(path).await?
+            } else {
+                let file_blocks: FileBlocks =
+                    serde_json::from_str(&self.task.info.source_read_plan_json).map_err(|err| {
+                        FsError::common(format!(
+                            "Invalid CV source read plan for task {} path {}: {}",
+                            self.task.info.task_id,
+                            path.full_path(),
+                            err
+                        ))
+                    })?;
+                FsReader::new(path.clone(), self.fs.fs_context(), file_blocks)?
+            };
             Ok(UnifiedReader::Cv(reader))
         } else {
             // UFS path
@@ -605,137 +536,127 @@ impl LoadTaskRunner {
         is_last: bool,
     ) -> FsResult<()> {
         let progress = self.task.update_progress(loaded_size, total_size, is_last);
-        let task = &self.task;
-
-        self.master_client
-            .report_task(&task.info.job.job_id, &task.info.task_id, progress)
-            .await
+        self.report_progress(progress).await
     }
+
+    async fn report_progress(&self, progress: JobTaskProgress) -> FsResult<()> {
+        let task = &self.task.info;
+        if let Some(report_info) = &task.transfer_report {
+            let Some(client) = &self.transfer_client else {
+                let report_endpoints = if report_info.report_endpoints.is_empty() {
+                    vec![report_info.report_target.clone()]
+                } else {
+                    report_info.report_endpoints.clone()
+                };
+                return err_box!(
+                    "Transfer task {} has no transfer client for report endpoints {:?}",
+                    task.task_id,
+                    report_endpoints
+                );
+            };
+            let accepted = tokio::time::timeout(
+                Duration::from_millis(TRANSFER_REPORT_TIMEOUT_MS),
+                client.report_task(&task.job.job_id, &task.task_id, report_info, progress),
+            )
+            .await
+            .map_err(|_| {
+                FsError::common(format!(
+                    "Transfer task report timed out after {} ms: job={}, task={}, attempt={}",
+                    TRANSFER_REPORT_TIMEOUT_MS,
+                    task.job.job_id,
+                    task.task_id,
+                    report_info.attempt_id
+                ))
+            })??;
+            if !accepted {
+                return err_box!(
+                    "Transfer task report rejected: job={}, task={}, attempt={}",
+                    task.job.job_id,
+                    task.task_id,
+                    report_info.attempt_id
+                );
+            }
+            Ok(())
+        } else {
+            self.master_client
+                .report_task(&task.job.job_id, &task.task_id, progress)
+                .await
+        }
+    }
+}
+
+async fn commit_ufs_output(
+    ufs: &UfsFileSystem,
+    temp_path: &Path,
+    final_path: &Path,
+    overwrite: bool,
+) -> FsResult<()> {
+    match ufs.get_status(final_path).await {
+        Ok(status) if status.is_dir => {
+            return err_box!(
+                "Transfer target {} is a directory; refusing to overwrite directory with file",
+                final_path.full_path()
+            );
+        }
+        Ok(_) if !overwrite => return Err(FsError::file_exists(final_path.full_path())),
+        Ok(_) | Err(FsError::FileNotFound(_)) => {}
+        Err(err) => return Err(err),
+    }
+
+    if let Some(parent) = final_path.parent()? {
+        ufs.mkdir(&parent, true).await?;
+    }
+    if !ufs.rename(temp_path, final_path).await? {
+        return err_box!(
+            "Transfer output rename did not commit {} to {}",
+            temp_path.full_path(),
+            final_path.full_path()
+        );
+    }
+    Ok(())
+}
+
+fn xattr_equals(status: &FileStatus, key: &str, expected: &[u8]) -> bool {
+    status
+        .x_attr
+        .get(key)
+        .map(|actual| actual.as_slice() == expected)
+        .unwrap_or(false)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::LoadTaskRunner;
-
-    const MB: i64 = 1024 * 1024;
-
-    // Reproduce the exact planning loop run_parallel uses, so tests exercise the
-    // real offset/len math (block alignment + last-segment clamp), which is the
-    // most error-prone part of the fan-out.
-    fn plan(src_len: i64, streams: usize, block_size: i64) -> Vec<(i64, i64)> {
-        let seg = LoadTaskRunner::segment_len(src_len, streams, block_size);
-        let mut ranges = Vec::new();
-        for i in 0..streams {
-            let off = i as i64 * seg;
-            if off >= src_len {
-                break;
-            }
-            let len = seg.min(src_len - off);
-            ranges.push((off, len));
-        }
-        ranges
-    }
+    use super::commit_ufs_output;
+    use curvine_client::unified::UfsFileSystem;
+    use curvine_common::fs::Path;
+    use orpc::runtime::{AsyncRuntime, RpcRuntime};
+    use std::collections::HashMap;
+    use std::fs;
 
     #[test]
-    fn segment_len_is_block_aligned() {
-        // 10 GiB, 8 streams, 4 MiB blocks: ceil(10Gi/8)=1280MiB, already aligned.
-        let seg = LoadTaskRunner::segment_len(10 * 1024 * MB, 8, 4 * MB);
+    fn failed_ufs_overwrite_commit_keeps_existing_target() {
+        let base_dir = std::env::temp_dir().join(format!(
+            "transfer-ufs-commit-{}-{}",
+            std::process::id(),
+            orpc::common::LocalTime::mills()
+        ));
+        fs::create_dir_all(&base_dir).unwrap();
+        let target = Path::from_str(format!("file://{}/target.txt", base_dir.display())).unwrap();
+        let missing_temp =
+            Path::from_str(format!("file://{}/missing-temp.txt", base_dir.display())).unwrap();
+        fs::write(base_dir.join("target.txt"), "original-target").unwrap();
+
+        let ufs = UfsFileSystem::new(&target, HashMap::new(), None).unwrap();
+        let rt = AsyncRuntime::single();
+        let err = rt
+            .block_on(commit_ufs_output(&ufs, &missing_temp, &target, true))
+            .unwrap_err();
+        assert!(err.to_string().contains("No such file") || err.to_string().contains("not found"));
         assert_eq!(
-            seg % (4 * MB),
-            0,
-            "segment must be a multiple of block_size"
+            fs::read_to_string(base_dir.join("target.txt")).unwrap(),
+            "original-target"
         );
-        assert!(seg >= 10 * 1024 * MB / 8);
-    }
 
-    #[test]
-    fn segment_len_rounds_up_to_block_multiple() {
-        // Non-block-multiple raw segment must round UP so writers never share a block.
-        // src=100MiB, 3 streams => raw ceil ≈ 33.34MiB; rounded up to a 4MiB
-        // multiple that is 36MiB (9 blocks).
-        let seg = LoadTaskRunner::segment_len(100 * MB, 3, 4 * MB);
-        assert_eq!(seg, 36 * MB);
-        assert_eq!(seg % (4 * MB), 0);
-    }
-
-    #[test]
-    fn segment_len_never_below_block_size() {
-        // Tiny file, many streams: segment must not collapse to 0.
-        let seg = LoadTaskRunner::segment_len(1, 8, 4 * MB);
-        assert_eq!(seg, 4 * MB);
-    }
-
-    #[test]
-    fn segment_len_handles_zero_streams_and_block() {
-        // Defensive: streams/block_size are clamped to >= 1, no divide-by-zero.
-        assert_eq!(LoadTaskRunner::segment_len(1000, 0, 0), 1000);
-    }
-
-    #[test]
-    fn plan_ranges_are_contiguous_disjoint_and_cover_whole_file() {
-        // The critical invariant: the union of all stream ranges must be exactly
-        // [0, src_len) with no gaps and no overlaps (else data is lost/corrupted).
-        for &(src_len, streams, block_size) in &[
-            (10 * 1024 * MB, 8, 4 * MB),
-            (100 * MB, 3, 4 * MB),
-            (7 * MB + 123, 4, 4 * MB), // not block-aligned total
-            (4 * MB, 8, 4 * MB),       // fewer effective streams than requested
-            (1, 8, 4 * MB),            // tiny file -> single stream
-        ] {
-            let ranges = plan(src_len, streams, block_size);
-            assert!(!ranges.is_empty(), "must produce at least one range");
-            // First starts at 0.
-            assert_eq!(ranges[0].0, 0);
-            // Contiguous + disjoint.
-            let mut expected_off = 0;
-            for (off, len) in &ranges {
-                assert_eq!(*off, expected_off, "gap/overlap at {}", off);
-                assert!(*len > 0, "empty segment");
-                expected_off += len;
-            }
-            // Covers exactly the whole file.
-            assert_eq!(
-                expected_off, src_len,
-                "ranges must cover exactly [0,{})",
-                src_len
-            );
-            // Every non-final segment start is block-aligned (disjoint block sets).
-            for (off, _) in &ranges {
-                assert_eq!(*off % block_size, 0, "segment start not block-aligned");
-            }
-        }
-    }
-
-    #[test]
-    fn plan_does_not_over_allocate_streams_for_small_files() {
-        // 4 MiB file with 8 requested streams and 4 MiB blocks: only 1 stream
-        // should actually get a range (the rest would start at/after EOF).
-        let ranges = plan(4 * MB, 8, 4 * MB);
-        assert_eq!(ranges.len(), 1);
-        assert_eq!(ranges[0], (0, 4 * MB));
-    }
-
-    #[test]
-    fn stream_count_grows_with_size_and_caps() {
-        let min = 256 * MB;
-        let cap = 8;
-        // Below min_bytes -> single stream (no fan-out), subsumes old threshold.
-        assert_eq!(LoadTaskRunner::stream_count(100 * MB, min, cap), 1);
-        assert_eq!(LoadTaskRunner::stream_count(min - 1, min, cap), 1);
-        // Grows linearly with size.
-        assert_eq!(LoadTaskRunner::stream_count(512 * MB, min, cap), 2);
-        assert_eq!(LoadTaskRunner::stream_count(1024 * MB, min, cap), 4);
-        assert_eq!(LoadTaskRunner::stream_count(2048 * MB, min, cap), 8);
-        // Clamped at the cap for very large files.
-        assert_eq!(LoadTaskRunner::stream_count(200 * 1024 * MB, min, cap), 8);
-    }
-
-    #[test]
-    fn stream_count_defensive_bounds() {
-        // Zero/negative length -> 1 (never 0), zero min_bytes/cap clamped to 1.
-        assert_eq!(LoadTaskRunner::stream_count(0, 256 * MB, 8), 1);
-        assert_eq!(LoadTaskRunner::stream_count(-5, 256 * MB, 8), 1);
-        assert_eq!(LoadTaskRunner::stream_count(1024 * MB, 0, 8), 8);
-        assert_eq!(LoadTaskRunner::stream_count(1024 * MB, 256 * MB, 0), 1);
+        let _ = fs::remove_dir_all(base_dir);
     }
 }

--- a/curvine-server/src/worker/task/load_task_runner.rs
+++ b/curvine-server/src/worker/task/load_task_runner.rs
@@ -37,6 +37,7 @@ const TRANSFER_COMMIT_JOB_ID_XATTR: &str = "curvine.transfer.job_id";
 const TRANSFER_COMMIT_RUN_ID_XATTR: &str = "curvine.transfer.run_id";
 const TRANSFER_COMMIT_TASK_ID_XATTR: &str = "curvine.transfer.task_id";
 const TRANSFER_COMMIT_SOURCE_PATH_XATTR: &str = "curvine.transfer.source_path";
+const TRANSFER_COMMIT_TARGET_PATH_XATTR: &str = "curvine.transfer.target_path";
 
 pub struct LoadTaskRunner {
     task: Arc<TaskContext>,
@@ -196,6 +197,10 @@ impl LoadTaskRunner {
                     .add_x_attr(
                         TRANSFER_COMMIT_SOURCE_PATH_XATTR,
                         self.task.info.source_path.as_bytes().to_vec(),
+                    )
+                    .add_x_attr(
+                        TRANSFER_COMMIT_TARGET_PATH_XATTR,
+                        self.task.info.target_path.as_bytes().to_vec(),
                     );
             }
         }
@@ -398,7 +403,24 @@ impl LoadTaskRunner {
             }
         } else {
             let ufs = self.get_ufs()?;
-            commit_ufs_output(&ufs, temp_path, &stream.final_path, overwrite).await?;
+            match self
+                .validate_ufs_commit_target(&ufs, &stream.final_path, overwrite)
+                .await?
+            {
+                CommitTarget::RenameTemp => {
+                    self.mark_ufs_commit_source(&stream.final_path).await?;
+                    rename_ufs_output(&ufs, temp_path, &stream.final_path).await?;
+                }
+                CommitTarget::AlreadyCommitted => {
+                    if let Err(err) = ufs.delete(temp_path, false).await {
+                        warn!(
+                            "delete redundant transfer temp output {} failed after idempotent commit check: {}",
+                            temp_path.full_path(),
+                            err
+                        );
+                    }
+                }
+            }
         }
         Ok(())
     }
@@ -437,27 +459,114 @@ impl LoadTaskRunner {
         {
             return false;
         }
+        self.has_transfer_commit_marker(target_status, None)
+    }
+
+    async fn validate_ufs_commit_target(
+        &self,
+        ufs: &UfsFileSystem,
+        path: &Path,
+        overwrite: bool,
+    ) -> FsResult<CommitTarget> {
+        match ufs.get_status(path).await {
+            Ok(status) if status.is_dir => err_box!(
+                "Transfer target {} is a directory; refusing to overwrite directory with file",
+                path.full_path()
+            ),
+            Ok(status) if !overwrite => {
+                let source_path = Path::from_str(&self.task.info.source_path)?;
+                let source_status = self.fs.get_status(&source_path).await?;
+                if self.is_committed_ufs_output(&status, source_status, path) {
+                    Ok(CommitTarget::AlreadyCommitted)
+                } else {
+                    Err(FsError::file_exists(path.full_path()))
+                }
+            }
+            Ok(_) => Ok(CommitTarget::RenameTemp),
+            Err(FsError::FileNotFound(_)) => Ok(CommitTarget::RenameTemp),
+            Err(err) => Err(err),
+        }
+    }
+
+    fn is_committed_ufs_output(
+        &self,
+        target_status: &FileStatus,
+        source_status: FileStatus,
+        target_path: &Path,
+    ) -> bool {
+        target_status.len == source_status.len
+            && self.has_transfer_commit_marker(&source_status, Some(target_path))
+    }
+
+    fn has_transfer_commit_marker(&self, status: &FileStatus, target_path: Option<&Path>) -> bool {
         let Some(report) = &self.task.info.transfer_report else {
             return false;
         };
-
         xattr_equals(
-            target_status,
+            status,
             TRANSFER_COMMIT_JOB_ID_XATTR,
             self.task.info.job.job_id.as_bytes(),
         ) && xattr_equals(
-            target_status,
+            status,
             TRANSFER_COMMIT_RUN_ID_XATTR,
             report.run_id.to_string().as_bytes(),
         ) && xattr_equals(
-            target_status,
+            status,
             TRANSFER_COMMIT_TASK_ID_XATTR,
             self.task.info.task_id.as_bytes(),
         ) && xattr_equals(
-            target_status,
+            status,
             TRANSFER_COMMIT_SOURCE_PATH_XATTR,
             self.task.info.source_path.as_bytes(),
-        )
+        ) && target_path.is_none_or(|path| {
+            xattr_equals(
+                status,
+                TRANSFER_COMMIT_TARGET_PATH_XATTR,
+                path.full_path().as_bytes(),
+            )
+        })
+    }
+
+    async fn mark_ufs_commit_source(&self, target_path: &Path) -> FsResult<()> {
+        if self.task.info.transfer_report.is_none() {
+            return Ok(());
+        }
+        let source_path = Path::from_str(&self.task.info.source_path)?;
+        if !source_path.is_cv() {
+            return err_box!(
+                "Transfer export source {} must be a Curvine path",
+                source_path.full_path()
+            );
+        }
+        let report = self.task.info.transfer_report.as_ref().unwrap();
+        self.fs
+            .set_attr(
+                &source_path,
+                SetAttrOptsBuilder::new()
+                    .add_x_attr(
+                        TRANSFER_COMMIT_JOB_ID_XATTR,
+                        self.task.info.job.job_id.as_bytes().to_vec(),
+                    )
+                    .add_x_attr(
+                        TRANSFER_COMMIT_RUN_ID_XATTR,
+                        report.run_id.to_string().into_bytes(),
+                    )
+                    .add_x_attr(
+                        TRANSFER_COMMIT_TASK_ID_XATTR,
+                        self.task.info.task_id.as_bytes().to_vec(),
+                    )
+                    .add_x_attr(
+                        TRANSFER_COMMIT_SOURCE_PATH_XATTR,
+                        self.task.info.source_path.as_bytes().to_vec(),
+                    )
+                    .add_x_attr(
+                        TRANSFER_COMMIT_TARGET_PATH_XATTR,
+                        target_path.full_path().as_bytes().to_vec(),
+                    )
+                    .build(),
+            )
+            .await
+            .map(|_| ())
     }
 
     async fn open_unified(&self, path: &Path) -> FsResult<UnifiedReader> {
@@ -585,24 +694,11 @@ impl LoadTaskRunner {
     }
 }
 
-async fn commit_ufs_output(
+async fn rename_ufs_output(
     ufs: &UfsFileSystem,
     temp_path: &Path,
     final_path: &Path,
-    overwrite: bool,
 ) -> FsResult<()> {
-    match ufs.get_status(final_path).await {
-        Ok(status) if status.is_dir => {
-            return err_box!(
-                "Transfer target {} is a directory; refusing to overwrite directory with file",
-                final_path.full_path()
-            );
-        }
-        Ok(_) if !overwrite => return Err(FsError::file_exists(final_path.full_path())),
-        Ok(_) | Err(FsError::FileNotFound(_)) => {}
-        Err(err) => return Err(err),
-    }
-
     if let Some(parent) = final_path.parent()? {
         ufs.mkdir(&parent, true).await?;
     }
@@ -626,7 +722,7 @@ fn xattr_equals(status: &FileStatus, key: &str, expected: &[u8]) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::commit_ufs_output;
+    use super::rename_ufs_output;
     use curvine_client::unified::UfsFileSystem;
     use curvine_common::fs::Path;
     use orpc::runtime::{AsyncRuntime, RpcRuntime};
@@ -634,7 +730,7 @@ mod tests {
     use std::fs;
 
     #[test]
-    fn failed_ufs_overwrite_commit_keeps_existing_target() {
+    fn failed_ufs_rename_keeps_existing_target() {
         let base_dir = std::env::temp_dir().join(format!(
             "transfer-ufs-commit-{}-{}",
             std::process::id(),
@@ -649,7 +745,7 @@ mod tests {
         let ufs = UfsFileSystem::new(&target, HashMap::new(), None).unwrap();
         let rt = AsyncRuntime::single();
         let err = rt
-            .block_on(commit_ufs_output(&ufs, &missing_temp, &target, true))
+            .block_on(rename_ufs_output(&ufs, &missing_temp, &target))
             .unwrap_err();
         assert!(err.to_string().contains("No such file") || err.to_string().contains("not found"));
         assert_eq!(

--- a/curvine-server/src/worker/task/task_context.rs
+++ b/curvine-server/src/worker/task/task_context.rs
@@ -37,7 +37,7 @@ impl TaskContext {
         self.state.state()
     }
 
-    fn progress(&self) -> MutexGuard<'_, JobTaskProgress> {
+    fn progress_lock(&self) -> MutexGuard<'_, JobTaskProgress> {
         match self.progress.lock() {
             Ok(progress) => progress,
             Err(e) => {
@@ -47,9 +47,35 @@ impl TaskContext {
         }
     }
 
+    pub fn progress(&self) -> JobTaskProgress {
+        let lock = self.progress_lock();
+        JobTaskProgress {
+            state: self.get_state(),
+            total_size: lock.total_size,
+            loaded_size: lock.loaded_size,
+            update_time: lock.update_time,
+            message: lock.message.clone(),
+        }
+    }
+
     pub fn set_failed(&self, message: impl Into<String>) -> JobTaskProgress {
-        let mut lock = self.progress();
+        let mut lock = self.progress_lock();
         self.state.set_state(JobTaskState::Failed);
+        lock.message = message.into();
+        lock.update_time = LocalTime::mills() as i64;
+
+        JobTaskProgress {
+            state: self.get_state(),
+            total_size: lock.total_size,
+            loaded_size: lock.loaded_size,
+            update_time: lock.update_time,
+            message: lock.message.clone(),
+        }
+    }
+
+    pub fn set_canceled(&self, message: impl Into<String>) -> JobTaskProgress {
+        let mut lock = self.progress_lock();
+        self.state.set_state(JobTaskState::Canceled);
         lock.message = message.into();
         lock.update_time = LocalTime::mills() as i64;
 
@@ -71,7 +97,7 @@ impl TaskContext {
     }
 
     pub fn update_state(&self, state: JobTaskState, message: impl Into<String>) {
-        let mut lock = self.progress();
+        let mut lock = self.progress_lock();
         if self.state.state::<JobTaskState>() == JobTaskState::Canceled
             && state != JobTaskState::Canceled
         {
@@ -88,7 +114,7 @@ impl TaskContext {
         total_size: i64,
         is_last: bool,
     ) -> JobTaskProgress {
-        let mut lock = self.progress();
+        let mut lock = self.progress_lock();
         if self.state.state::<JobTaskState>() == JobTaskState::Canceled {
             return JobTaskProgress {
                 state: JobTaskState::Canceled,

--- a/curvine-server/src/worker/task/task_manager.rs
+++ b/curvine-server/src/worker/task/task_manager.rs
@@ -16,8 +16,9 @@ use crate::common::UfsFactory;
 use crate::worker::task::load_task_runner::LoadTaskRunner;
 use crate::worker::task::{TaskContext, TaskStore};
 use curvine_client::file::{CurvineFileSystem, FsContext};
+use curvine_client::rpc::TransferClient;
 use curvine_common::conf::ClusterConf;
-use curvine_common::state::{JobTaskState, LoadTaskInfo};
+use curvine_common::state::{JobTaskProgress, LoadTaskInfo, TransferTaskReportInfo};
 use curvine_common::FsResult;
 use dashmap::mapref::entry::Entry;
 use log::{debug, info, warn};
@@ -30,9 +31,32 @@ pub struct TaskManager {
     fs: CurvineFileSystem,
     tasks: TaskStore,
     factory: Arc<UfsFactory>,
+    transfer_client: Option<TransferClient>,
+    worker_session_id: String,
     progress_interval_ms: u64,
     task_timeout_ms: u64,
     worker_task_semaphore: Arc<Semaphore>,
+}
+
+pub struct TaskSubmitResult {
+    pub accepted: bool,
+    pub reject_reason: String,
+}
+
+impl TaskSubmitResult {
+    fn accepted() -> Self {
+        Self {
+            accepted: true,
+            reject_reason: String::new(),
+        }
+    }
+
+    fn rejected(reason: impl Into<String>) -> Self {
+        Self {
+            accepted: false,
+            reject_reason: reason.into(),
+        }
+    }
 }
 
 impl TaskManager {
@@ -69,18 +93,25 @@ impl TaskManager {
     /// # Limit concurrent load tasks to prevent resource exhaustion
     /// worker_max_concurrent_tasks = 10
     /// ```
-    pub fn with_rt(rt: Arc<Runtime>, conf: &ClusterConf) -> FsResult<Self> {
+    pub fn with_rt(
+        rt: Arc<Runtime>,
+        conf: &ClusterConf,
+        worker_session_id: impl Into<String>,
+    ) -> FsResult<Self> {
         let mut new_conf = conf.clone();
         new_conf.client.hostname = "localhost".to_string();
 
         let fs = CurvineFileSystem::with_rt(new_conf, rt.clone())?;
         let factory = Arc::new(UfsFactory::with_rt(&conf.client, rt.clone()));
+        let transfer_client = TransferClient::with_context(&fs.fs_context()).ok();
         let worker_task_semaphore = Arc::new(Semaphore::new(conf.job.worker_max_concurrent_tasks));
         let mgr = Self {
             rt,
             fs,
             tasks: TaskStore::new(),
             factory,
+            transfer_client,
+            worker_session_id: worker_session_id.into(),
             progress_interval_ms: conf.job.task_report_interval.as_millis() as u64,
             task_timeout_ms: conf.job.task_timeout.as_millis() as u64,
             worker_task_semaphore,
@@ -128,14 +159,60 @@ impl TaskManager {
     ///    - Automatically releases the permit on completion
     ///    - Removes the map entry **only if it still points at its own
     ///      context** (a later `submit_task` may have superseded it)
-    pub fn submit_task(&self, task: LoadTaskInfo) -> FsResult<()> {
+    pub fn submit_task(&self, task: LoadTaskInfo) -> FsResult<TaskSubmitResult> {
+        if let Some(report) = &task.transfer_report {
+            if report.report_endpoints.is_empty()
+                && report.report_target.is_empty()
+                && self.transfer_client.is_none()
+            {
+                return Ok(TaskSubmitResult::rejected(format!(
+                    "Reject transfer task {} because no Transfer report endpoint is available",
+                    task.task_id
+                )));
+            }
+            if report.worker_session_id != self.worker_session_id {
+                return Ok(TaskSubmitResult::rejected(format!(
+                    "Reject transfer task {} for stale worker session {}, current session {}",
+                    task.task_id, report.worker_session_id, self.worker_session_id
+                )));
+            }
+        }
+
         let task_id = task.task_id.clone();
         let context = Arc::new(TaskContext::new(task));
 
         match self.tasks.entry(task_id.clone()) {
             Entry::Occupied(mut occ) => {
+                if let Some(new_report) = &context.info.transfer_report {
+                    let old_report = occ.get().info.transfer_report.as_ref();
+                    if let Some(old_report) = old_report {
+                        if old_report.run_id == new_report.run_id
+                            && old_report.attempt_id == new_report.attempt_id
+                        {
+                            debug!(
+                                "ignore duplicate transfer task submit {}, attempt {}",
+                                task_id, new_report.attempt_id
+                            );
+                            return Ok(TaskSubmitResult::accepted());
+                        }
+                        if old_report.run_id > new_report.run_id
+                            || (old_report.run_id == new_report.run_id
+                                && old_report.attempt_id > new_report.attempt_id)
+                        {
+                            return Ok(TaskSubmitResult::rejected(format!(
+                                "Reject stale transfer task {} run {} attempt {}, current run {} attempt {}",
+                                task_id,
+                                new_report.run_id,
+                                new_report.attempt_id,
+                                old_report.run_id,
+                                old_report.attempt_id
+                            )));
+                        }
+                    }
+                }
+
                 let old = occ.insert(context.clone());
-                old.update_state(JobTaskState::Canceled, "superseded by new submit");
+                old.set_canceled("superseded by new submit");
                 warn!(
                     "cancel duplicate task {} (source_path={})",
                     old.info.task_id, old.info.source_path
@@ -155,6 +232,7 @@ impl TaskManager {
             context.clone(),
             self.fs.clone(),
             self.factory.clone(),
+            self.transfer_client.clone(),
             self.progress_interval_ms,
             self.task_timeout_ms,
         );
@@ -165,9 +243,10 @@ impl TaskManager {
 
         // Spawn task with concurrency control
         self.rt.spawn(async move {
+            let mut remove_task = true;
             match semaphore.acquire().await {
                 Ok(permit) => {
-                    runner.run().await;
+                    remove_task = runner.run().await;
                     drop(permit);
                 }
                 Err(e) => {
@@ -175,10 +254,12 @@ impl TaskManager {
                 }
             }
 
-            let _ = tasks.remove_if(&task_id, |_, ctx| Arc::ptr_eq(ctx, &context_this));
+            if remove_task {
+                let _ = tasks.remove_if(&task_id, |_, ctx| Arc::ptr_eq(ctx, &context_this));
+            }
         });
 
-        Ok(())
+        Ok(TaskSubmitResult::accepted())
     }
 
     pub fn cancel_job(&self, job_id: impl AsRef<str>) -> FsResult<()> {
@@ -193,6 +274,31 @@ impl TaskManager {
         Ok(())
     }
 
+    pub fn query_transfer_task(
+        &self,
+        job_id: &str,
+        task_id: &str,
+        run_id: u64,
+        attempt_id: u64,
+        worker_session_id: &str,
+    ) -> FsResult<Option<JobTaskProgress>> {
+        let Some(task) = self.tasks.get(task_id) else {
+            return Ok(None);
+        };
+        if task.info.job.job_id != job_id {
+            return Ok(None);
+        }
+        if !transfer_report_matches(
+            task.info.transfer_report.as_ref(),
+            run_id,
+            attempt_id,
+            worker_session_id,
+        ) {
+            return Ok(None);
+        }
+        Ok(Some(task.progress()))
+    }
+
     pub fn get_fs_context(&self) -> Arc<FsContext> {
         self.fs.fs_context()
     }
@@ -200,4 +306,19 @@ impl TaskManager {
     pub fn available_worker_task_permits(&self) -> usize {
         self.worker_task_semaphore.available_permits()
     }
+}
+
+fn transfer_report_matches(
+    report: Option<&TransferTaskReportInfo>,
+    run_id: u64,
+    attempt_id: u64,
+    worker_session_id: &str,
+) -> bool {
+    matches!(
+        report,
+        Some(report)
+            if report.run_id == run_id
+                && report.attempt_id == attempt_id
+                && report.worker_session_id == worker_session_id
+    )
 }

--- a/curvine-server/src/worker/task/task_store.rs
+++ b/curvine-server/src/worker/task/task_store.rs
@@ -15,7 +15,7 @@
 use std::ops::Deref;
 use std::sync::Arc;
 
-use curvine_common::state::{JobTaskState, LoadTaskInfo};
+use curvine_common::state::LoadTaskInfo;
 use orpc::sync::FastDashMap;
 
 use crate::worker::task::TaskContext;
@@ -60,7 +60,7 @@ impl TaskStore {
     pub fn cancel(&self, job_id: impl AsRef<str>) -> Vec<Arc<TaskContext>> {
         let all_tasks = self.get_all_tasks(job_id);
         for context in all_tasks.iter() {
-            context.update_state(JobTaskState::Canceled, "canceled by master");
+            context.set_canceled("canceled by master");
             let _ = self.tasks.remove(&context.info.task_id);
         }
 

--- a/curvine-server/src/worker/worker_server.rs
+++ b/curvine-server/src/worker/worker_server.rs
@@ -24,6 +24,7 @@ use curvine_fault::FaultHttpControl;
 use curvine_web::server::{WebHandlerService, WebServer};
 use log::info;
 use once_cell::sync::OnceCell;
+use orpc::common::Utils;
 use orpc::common::{LocalTime, Logger};
 use orpc::error::StringError;
 use orpc::handler::HandlerService;
@@ -52,12 +53,16 @@ pub struct WorkerService {
 }
 
 impl WorkerService {
-    pub fn with_conf(conf: &ClusterConf, rt: Arc<Runtime>) -> CommonResult<Self> {
+    pub fn with_conf(
+        conf: &ClusterConf,
+        rt: Arc<Runtime>,
+        worker_session_id: String,
+    ) -> CommonResult<Self> {
         let fault_http = FaultHttpControl::from_env(&conf.fault_injection)
             .map_err(|error| CommonError::from(error.to_string()))?;
         let store: BlockStore = BlockStore::new(&conf.cluster_id, conf)?;
 
-        let task_manager = TaskManager::with_rt(rt.clone(), conf)?;
+        let task_manager = TaskManager::with_rt(rt.clone(), conf, worker_session_id)?;
 
         let replication_manager =
             WorkerReplicationManager::new(&store, &rt, conf, &task_manager.get_fs_context());
@@ -185,7 +190,9 @@ impl Worker {
         }
 
         let rt = Arc::new(conf.worker_server_conf().create_runtime());
-        let service: WorkerService = WorkerService::with_conf(&conf, rt.clone())?;
+        let worker_session_id = Utils::uuid();
+        let service: WorkerService =
+            WorkerService::with_conf(&conf, rt.clone(), worker_session_id.clone())?;
         let worker_id = service.store.worker_id()?;
 
         CLUSTER_CONF.get_or_init(|| conf.clone());
@@ -209,6 +216,7 @@ impl Worker {
             rt.clone(),
             &conf,
             addr.clone(),
+            worker_session_id,
             block_store.clone(),
             rpc_server.new_state_ctl(),
         )?;


### PR DESCRIPTION
# Summary

Registers Transfer-capable workers and executes/report tasks with attempt-safe outputs.

# Issue Describe / Design

Part of the standalone Transfer service. This review layer is stacked deliberately so that protocol, metadata storage, scheduling, worker execution, client routing, and deployment can be reviewed independently.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-server/src/worker,curvine-server/src/master` | Registers Transfer-capable workers and executes/report tasks with attempt-safe outputs. | New Transfer behavior; legacy behavior remains available unless Transfer is enabled. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `MinIO load e2e after rebase` | PASS | Rebased onto upstream main `497d078d`. |

# Dependencies

- Related PRs: #1353
- Related issues: #1040
- Blocks / blocked by: #1353