### PR TITLE
feat(cli): route load and export through transfer

### DIFF
--- a/curvine-cli/src/cmds/export.rs
+++ b/curvine-cli/src/cmds/export.rs
@@ -15,9 +15,11 @@
 use crate::cmds::LoadStatusCommand;
 use crate::util::*;
 use clap::Parser;
-use curvine_client::rpc::JobMasterClient;
-use curvine_common::state::LoadJobCommand;
-use orpc::CommonResult;
+use curvine_client::rpc::{JobMasterClient, TransferClient};
+use curvine_client::unified::UnifiedFileSystem;
+use curvine_common::fs::Path;
+use curvine_common::state::{LoadJobCommand, TransferCommand, TransferKind};
+use orpc::{err_box, CommonResult};
 
 #[derive(Parser, Debug)]
 pub struct ExportCommand {
@@ -27,10 +29,14 @@ pub struct ExportCommand {
     /// Watch export job status after submission
     #[arg(long, short = 'w')]
     watch: bool,
+
+    /// Do not overwrite an existing target file
+    #[arg(long = "no-overwrite", default_value_t = true, action = clap::ArgAction::SetFalse)]
+    overwrite: bool,
 }
 
 impl ExportCommand {
-    pub async fn execute(&self, client: JobMasterClient) -> CommonResult<()> {
+    pub async fn execute_legacy(&self, client: JobMasterClient) -> CommonResult<()> {
         if self.path.trim().is_empty() {
             eprintln!("Error: Path cannot be empty");
             std::process::exit(1);
@@ -55,6 +61,60 @@ impl ExportCommand {
                 LoadStatusCommand::new(rep.job_id.clone(), false, "1s".to_string());
 
             status_command.execute(client).await?;
+        }
+
+        Ok(())
+    }
+
+    pub async fn execute_transfer(
+        &self,
+        fs: UnifiedFileSystem,
+        transfer_client: TransferClient,
+    ) -> CommonResult<()> {
+        if self.path.trim().is_empty() {
+            eprintln!("Error: Path cannot be empty");
+            std::process::exit(1);
+        }
+
+        println!("\nExporting Curvine file to UFS");
+        println!("Source path: {}", self.path);
+
+        let source = Path::from_str(&self.path)?;
+        if !source.is_cv() {
+            return err_box!("export source must be a Curvine path: {}", self.path);
+        }
+        let target = match fs.toggle_path(&source, true).await? {
+            Some(target) => target,
+            None => return err_box!("{} is not mounted", self.path),
+        };
+        if target.is_cv() {
+            return err_box!("export target must be a UFS path: {}", target.full_path());
+        }
+
+        let mut command = TransferCommand {
+            kind: TransferKind::Export,
+            source_path: source.clone_uri(),
+            target_path: target.clone_uri(),
+            client_request_id: TransferCommand::default_client_request_id(
+                TransferKind::Export,
+                source.clone_uri(),
+                target.clone_uri(),
+            ),
+            submitter: "curvine-cli".to_string(),
+            tenant: String::new(),
+            options: Default::default(),
+        };
+        command.set_overwrite(self.overwrite);
+        let rep = handle_rpc_result(transfer_client.submit(command)).await;
+        println!("Job ID: {}", rep.job_id);
+        println!("Target path: {}", target.full_path());
+        println!("State: {}", rep.state);
+
+        if self.watch {
+            let status_command = LoadStatusCommand::new(rep.job_id, false, "1s".to_string());
+            status_command
+                .execute_transfer_only(transfer_client)
+                .await?;
         }
 
         Ok(())

--- a/curvine-cli/src/cmds/export.rs
+++ b/curvine-cli/src/cmds/export.rs
@@ -45,7 +45,9 @@ impl ExportCommand {
         println!("\nExporting Curvine file to mounted UFS");
         println!("Source path: {}", self.path);
 
-        let command = LoadJobCommand::builder(&self.path).build();
+        let command = LoadJobCommand::builder(&self.path)
+            .overwrite(self.overwrite)
+            .build();
         let rep = handle_rpc_result(client.submit_export_job(command)).await;
 
         println!("\nExport job submitted successfully");

--- a/curvine-cli/src/cmds/load.rs
+++ b/curvine-cli/src/cmds/load.rs
@@ -15,9 +15,11 @@
 use crate::cmds::LoadStatusCommand;
 use crate::util::*;
 use clap::Parser;
-use curvine_client::rpc::JobMasterClient;
-use curvine_common::state::LoadJobCommand;
-use orpc::CommonResult;
+use curvine_client::rpc::{JobMasterClient, TransferClient};
+use curvine_client::unified::UnifiedFileSystem;
+use curvine_common::fs::Path;
+use curvine_common::state::{LoadJobCommand, TransferCommand, TransferKind};
+use orpc::{err_box, CommonResult};
 
 #[derive(Parser, Debug)]
 pub struct LoadCommand {
@@ -30,10 +32,14 @@ pub struct LoadCommand {
     /// Watch load job status after submission
     #[arg(long, short = 'w')]
     watch: bool,
+
+    /// Do not overwrite an existing target file
+    #[arg(long = "no-overwrite", default_value_t = true, action = clap::ArgAction::SetFalse)]
+    overwrite: bool,
 }
 
 impl LoadCommand {
-    pub async fn execute(&self, client: JobMasterClient) -> CommonResult<()> {
+    pub async fn execute_legacy(&self, client: JobMasterClient) -> CommonResult<()> {
         if self.source_path.trim().is_empty() {
             eprintln!("Error: Path cannot be empty");
             std::process::exit(1);
@@ -47,7 +53,7 @@ impl LoadCommand {
             std::process::exit(1);
         }
 
-        println!("\n Loading file to Curvine");
+        println!("\nLoading file to Curvine");
         println!("Source path: {}", self.source_path);
         if let Some(target_path) = &self.target_path {
             println!("Target path: {}", target_path);
@@ -65,8 +71,82 @@ impl LoadCommand {
         if self.watch {
             let status_command =
                 LoadStatusCommand::new(rep.job_id.clone(), false, "1s".to_string());
-
             status_command.execute(client).await?;
+        }
+
+        Ok(())
+    }
+
+    pub async fn execute_transfer(
+        &self,
+        fs: UnifiedFileSystem,
+        transfer_client: TransferClient,
+    ) -> CommonResult<()> {
+        if self.source_path.trim().is_empty() {
+            eprintln!("Error: Path cannot be empty");
+            std::process::exit(1);
+        }
+        if self
+            .target_path
+            .as_ref()
+            .is_some_and(|target_path| target_path.trim().is_empty())
+        {
+            eprintln!("Error: Target path cannot be empty");
+            std::process::exit(1);
+        }
+
+        println!("\nLoading file to Curvine");
+        println!("Source path: {}", self.source_path);
+        if let Some(target_path) = &self.target_path {
+            println!("Target path: {}", target_path);
+        }
+
+        let input = Path::from_str(&self.source_path)?;
+        let (source, target) = if let Some(target_path) = &self.target_path {
+            (input, Path::from_str(target_path)?)
+        } else {
+            let peer = match fs.toggle_path(&input, true).await? {
+                Some(peer) => peer,
+                None => return err_box!("{} is not mounted", self.source_path),
+            };
+            if input.is_cv() {
+                (peer, input)
+            } else {
+                (input, peer)
+            }
+        };
+        if source.is_cv() || !target.is_cv() {
+            return err_box!(
+                "load requires a UFS source and Curvine target: {} -> {}",
+                source.full_path(),
+                target.full_path()
+            );
+        }
+        let mut command = TransferCommand {
+            kind: TransferKind::Load,
+            source_path: source.clone_uri(),
+            target_path: target.clone_uri(),
+            client_request_id: TransferCommand::default_client_request_id(
+                TransferKind::Load,
+                source.clone_uri(),
+                target.clone_uri(),
+            ),
+            submitter: "curvine-cli".to_string(),
+            tenant: String::new(),
+            options: Default::default(),
+        };
+        command.set_overwrite(self.overwrite);
+        let rep = handle_rpc_result(transfer_client.submit(command)).await;
+        println!("Job ID: {}", rep.job_id);
+        println!("Target path: {}", target.full_path());
+        println!("State: {}", rep.state);
+
+        if self.watch {
+            let status_command = LoadStatusCommand::new(rep.job_id, false, "1s".to_string());
+
+            status_command
+                .execute_transfer_only(transfer_client)
+                .await?;
         }
 
         Ok(())

--- a/curvine-cli/src/cmds/load.rs
+++ b/curvine-cli/src/cmds/load.rs
@@ -59,7 +59,7 @@ impl LoadCommand {
             println!("Target path: {}", target_path);
         }
 
-        let command_builder = LoadJobCommand::builder(&self.source_path);
+        let command_builder = LoadJobCommand::builder(&self.source_path).overwrite(self.overwrite);
         let command = if let Some(target_path) = &self.target_path {
             command_builder.target_path(target_path).build()
         } else {

--- a/curvine-cli/src/cmds/load_cancel.rs
+++ b/curvine-cli/src/cmds/load_cancel.rs
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 use clap::Parser;
-use curvine_client::rpc::JobMasterClient;
+use curvine_client::rpc::{JobMasterClient, TransferClient};
+use curvine_common::state::TransferState;
 use orpc::CommonResult;
 
 use crate::util::*;
@@ -25,7 +26,6 @@ pub struct CancelLoadCommand {
 
 impl CancelLoadCommand {
     pub async fn execute(&self, client: JobMasterClient) -> CommonResult<()> {
-        // Verify the task ID
         if self.job_id.trim().is_empty() {
             eprintln!("Error: Job ID cannot be empty");
             std::process::exit(1);
@@ -34,10 +34,42 @@ impl CancelLoadCommand {
         println!("\nCancelling load job");
         println!("┌─────────────────────────────────");
         println!("│ Job ID: {}", self.job_id);
-
         handle_rpc_result(client.cancel_job(&self.job_id)).await;
-        println!("│ ✅ Job cancelled successfully");
+        println!("│ Job cancelled successfully");
         println!("└─────────────────────────────────");
         Ok(())
+    }
+
+    pub async fn execute_transfer_only(&self, transfer_client: TransferClient) -> CommonResult<()> {
+        if self.job_id.trim().is_empty() {
+            eprintln!("Error: Job ID cannot be empty");
+            std::process::exit(1);
+        }
+
+        println!("\nCancelling transfer job");
+        println!("┌─────────────────────────────────");
+        println!("│ Job ID: {}", self.job_id);
+        let response = handle_rpc_result(transfer_client.cancel(&self.job_id, None)).await;
+        print_transfer_cancel_result(response.state);
+        println!("└─────────────────────────────────");
+        Ok(())
+    }
+}
+
+fn print_transfer_cancel_result(state: i32) {
+    let state = TransferState::from(state);
+    match state {
+        TransferState::Canceling | TransferState::Canceled => {
+            println!("│ ✅ Job cancel request accepted");
+            println!("│ State: {:?}", state);
+        }
+        TransferState::Completed | TransferState::Failed | TransferState::PartialSuccess => {
+            println!("│ ℹ️ Job is already terminal");
+            println!("│ State: {:?}", state);
+        }
+        _ => {
+            println!("│ ✅ Job cancel request accepted");
+            println!("│ State: {:?}", state);
+        }
     }
 }

--- a/curvine-cli/src/cmds/load_status.rs
+++ b/curvine-cli/src/cmds/load_status.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use clap::Parser;
-use curvine_client::rpc::JobMasterClient;
-use curvine_common::state::JobTaskState;
+use curvine_client::rpc::{JobMasterClient, TransferClient};
+use curvine_common::state::{JobTaskState, TransferState};
 use orpc::CommonResult;
 
 use crate::util::*;
@@ -38,8 +38,9 @@ impl LoadStatusCommand {
             watch: Some(watch),
         }
     }
+
     pub async fn execute(&self, client: JobMasterClient) -> CommonResult<()> {
-        println!("\n Checking status for {}", self.job_id);
+        println!("\nChecking status for {}", self.job_id);
 
         if let Some(watch_interval) = &self.watch {
             self.watch_status(client, watch_interval).await
@@ -50,13 +51,44 @@ impl LoadStatusCommand {
         }
     }
 
-    /// keep watch job status
-    ///
-    /// # Arguments
-    /// * `client` - LoadClient Instance
-    /// * `interval_str` - Example：5s, 1m
     async fn watch_status(&self, client: JobMasterClient, interval_str: &str) -> CommonResult<()> {
-        // Resolution refresh interval
+        let duration = parse_duration(interval_str).unwrap_or_else(|_| {
+            eprintln!("Error: Invalid watch interval format: {}", interval_str);
+            std::process::exit(1);
+        });
+
+        loop {
+            let status = handle_rpc_result(client.get_job_status(&self.job_id)).await;
+            println!("{}", status);
+            if matches!(
+                status.state,
+                JobTaskState::Completed | JobTaskState::Failed | JobTaskState::Canceled
+            ) {
+                break;
+            }
+            tokio::time::sleep(duration).await;
+        }
+
+        Ok(())
+    }
+
+    pub async fn execute_transfer_only(&self, transfer_client: TransferClient) -> CommonResult<()> {
+        println!("\n Checking status for {}", self.job_id);
+
+        if let Some(watch_interval) = &self.watch {
+            self.watch_transfer_status(transfer_client, watch_interval)
+                .await
+        } else {
+            print_transfer_status(&transfer_client, &self.job_id).await?;
+            Ok(())
+        }
+    }
+
+    async fn watch_transfer_status(
+        &self,
+        transfer_client: TransferClient,
+        interval_str: &str,
+    ) -> CommonResult<()> {
         let duration = parse_duration(interval_str).unwrap_or_else(|_| {
             eprintln!("❌ Error: Invalid watch interval format: {}", interval_str);
             eprintln!("    Supported formats: <number>s (seconds), <number>m (minutes)");
@@ -65,7 +97,7 @@ impl LoadStatusCommand {
         });
 
         println!(
-            "Watching job status (refresh every {}). Press Ctrl+C to stop.",
+            "Watching transfer status (refresh every {}). Press Ctrl+C to stop.",
             format_duration(&duration)
         );
 
@@ -85,13 +117,8 @@ impl LoadStatusCommand {
             );
             println!("Press Ctrl+C to stop watching.");
 
-            let status = handle_rpc_result(client.get_job_status(&self.job_id)).await;
-            println!("{}", status);
-
-            if status.state == JobTaskState::Completed
-                || status.state == JobTaskState::Failed
-                || status.state == JobTaskState::Canceled
-            {
+            let state = print_transfer_status(&transfer_client, &self.job_id).await?;
+            if state.is_terminal() {
                 break;
             }
 
@@ -100,4 +127,32 @@ impl LoadStatusCommand {
 
         Ok(())
     }
+}
+
+async fn print_transfer_status(
+    client: &TransferClient,
+    job_id: &str,
+) -> CommonResult<TransferState> {
+    let status = handle_rpc_result(client.status(job_id)).await;
+    let state = TransferState::from(status.state);
+    println!("Job ID: {}", status.job_id);
+    println!("Run ID: {}", status.run_id);
+    println!("State: {:?}", state);
+    println!(
+        "Progress: {} / {}, message={}",
+        bytes_to_string(status.progress.loaded_size.max(0)),
+        bytes_to_string(status.progress.total_size.max(0)),
+        status.progress.message
+    );
+    if let Some(summary) = status.task_summary {
+        println!(
+            "Tasks: {} completed, {} failed, {} running, {} pending; {} cached",
+            summary.completed,
+            summary.failed,
+            summary.running,
+            summary.pending,
+            bytes_to_string(summary.completed_size.max(0)),
+        );
+    }
+    Ok(state)
 }

--- a/curvine-cli/src/cmds/mod.rs
+++ b/curvine-cli/src/cmds/mod.rs
@@ -21,6 +21,7 @@ mod load_status;
 mod mount;
 mod node;
 mod report;
+pub mod transfer;
 mod umount;
 
 pub use bench::BenchCommand;
@@ -32,4 +33,5 @@ pub use load_status::LoadStatusCommand;
 pub use mount::MountCommand;
 pub use node::NodeCommand;
 pub use report::ReportCommand;
+pub use transfer::TransferCommand;
 pub use umount::UnMountCommand;

--- a/curvine-cli/src/cmds/mount.rs
+++ b/curvine-cli/src/cmds/mount.rs
@@ -289,7 +289,7 @@ impl MountCommand {
         if !configs.is_empty() {
             println!("Configuration:");
             for (key, value) in &configs {
-                println!("  {} = {}", key, value);
+                println!("  {} = {}", key, display_config_value(key, value));
             }
             println!("\n");
         }
@@ -299,7 +299,7 @@ impl MountCommand {
 
         if !self.update && self.check_path_consist && ufs_path.authority_path() != cv_path.path() {
             return err_box!(
-                "with --check-path, ufs path and cv path must be consistent. ufs: {}, cv: {}",
+                "with --check-path-consist, UFS and Curvine paths must match. UFS: {}, Curvine: {}",
                 ufs_path.authority_path(),
                 cv_path.path()
             );
@@ -314,11 +314,19 @@ impl MountCommand {
             &ufs_path,
             mnt_opts.add_properties.clone(),
             mnt_opts.provider,
-        )?;
-        if let Err(e) = ufs.list_status(&ufs_path).await {
-            eprintln!("Error: {}", e);
-            std::process::exit(1);
-        }
+        )
+        .map_err(|_| {
+            FsError::common(format!(
+                "Unable to initialize UFS {}. Verify the URI, mount configuration, and credentials.",
+                ufs_path.full_path()
+            ))
+        })?;
+        ufs.list_status(&ufs_path).await.map_err(|_| {
+            FsError::common(format!(
+                "Unable to access UFS {}. Verify the endpoint, credentials, and network connectivity.",
+                ufs_path.full_path()
+            ))
+        })?;
 
         handle_rpc_result(fs.mount(&ufs_path, &cv_path, mnt_opts)).await;
         println!("│ ✅️ mount success.");
@@ -559,4 +567,24 @@ impl MountCommand {
 
         Ok(opts.build())
     }
+}
+
+fn display_config_value<'a>(key: &str, value: &'a str) -> &'a str {
+    if is_sensitive_config_key(key) {
+        "******"
+    } else {
+        value
+    }
+}
+
+fn is_sensitive_config_key(key: &str) -> bool {
+    let key = key.to_ascii_lowercase();
+    key.contains("credential")
+        || key.contains("secret")
+        || key.contains("token")
+        || key.contains("password")
+        || key.contains("access_key")
+        || key.ends_with(".access")
+        || key.ends_with(".ak")
+        || key.ends_with(".sk")
 }

--- a/curvine-cli/src/cmds/transfer.rs
+++ b/curvine-cli/src/cmds/transfer.rs
@@ -1,0 +1,836 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+
+use clap::{Parser, Subcommand, ValueEnum};
+use comfy_table::{presets::ASCII_MARKDOWN, Table};
+use curvine_client::rpc::TransferClient;
+use curvine_common::proto::{
+    CancelTransferResponse, GetTransferStatusResponse, ListTransferTenantsResponse,
+    ListTransfersResponse, SubmitTransferResponse, TransferJobStatusProto, TransferTaskStatusProto,
+    TransferTenantSummaryProto,
+};
+use curvine_common::state::{TransferKind, TransferState};
+use orpc::{err_box, CommonResult};
+
+use crate::util::{bytes_to_string, handle_rpc_result, parse_duration};
+
+#[derive(Parser, Debug)]
+pub struct TransferCommand {
+    #[command(subcommand)]
+    command: TransferSubCommand,
+}
+
+#[derive(Subcommand, Debug)]
+enum TransferSubCommand {
+    /// List transfer jobs
+    List(TransferListCommand),
+
+    /// Show one transfer job; add --verbose for task details
+    Status(TransferStatusCommand),
+
+    /// Show task page for one transfer job
+    Tasks(TransferTasksCommand),
+
+    /// Cancel one transfer job
+    Cancel(TransferCancelCommand),
+
+    /// Retry a failed, canceled, or partially successful transfer as a new job
+    Retry(TransferRetryCommand),
+
+    /// Summarize transfer jobs by tenant
+    Tenants(TransferTenantsCommand),
+}
+
+#[derive(Parser, Debug)]
+pub struct TransferListCommand {
+    #[arg(long)]
+    kind: Option<TransferKindArg>,
+
+    #[arg(long)]
+    state: Option<TransferStateArg>,
+
+    #[arg(long)]
+    submitter: Option<String>,
+
+    #[arg(long)]
+    tenant: Option<String>,
+
+    #[arg(long, default_value_t = 20)]
+    limit: u32,
+
+    #[arg(long)]
+    page_token: Option<String>,
+
+    #[arg(long)]
+    all: bool,
+
+    #[arg(long, value_enum, default_value_t = OutputFormat::Table)]
+    format: OutputFormat,
+
+    #[arg(long)]
+    full_id: bool,
+
+    #[arg(long, short = 'v')]
+    verbose: bool,
+}
+
+#[derive(Parser, Debug)]
+pub struct TransferStatusCommand {
+    job_id: String,
+
+    #[arg(long, short = 'v')]
+    verbose: bool,
+
+    #[arg(long, short = 'w')]
+    watch: bool,
+
+    #[arg(long, default_value = "1s")]
+    interval: String,
+
+    #[arg(long, default_value_t = 20)]
+    limit: u32,
+
+    #[arg(long)]
+    page_token: Option<String>,
+
+    #[arg(long)]
+    all: bool,
+
+    #[arg(long, value_enum, default_value_t = OutputFormat::Table)]
+    format: OutputFormat,
+
+    #[arg(long)]
+    full_id: bool,
+}
+
+#[derive(Parser, Debug)]
+pub struct TransferTasksCommand {
+    job_id: String,
+
+    #[arg(long, short = 'v')]
+    verbose: bool,
+
+    #[arg(long, default_value_t = 50)]
+    limit: u32,
+
+    #[arg(long)]
+    page_token: Option<String>,
+
+    #[arg(long)]
+    all: bool,
+
+    #[arg(long, value_enum, default_value_t = OutputFormat::Table)]
+    format: OutputFormat,
+
+    #[arg(long)]
+    full_id: bool,
+}
+
+#[derive(Parser, Debug)]
+pub struct TransferCancelCommand {
+    job_id: String,
+
+    #[arg(long)]
+    run_id: Option<u64>,
+
+    #[arg(long, value_enum, default_value_t = OutputFormat::Table)]
+    format: OutputFormat,
+}
+
+#[derive(Parser, Debug)]
+pub struct TransferRetryCommand {
+    job_id: String,
+
+    #[arg(long, value_enum, default_value_t = OutputFormat::Table)]
+    format: OutputFormat,
+}
+
+#[derive(Parser, Debug)]
+pub struct TransferTenantsCommand {
+    #[arg(long, default_value_t = 20)]
+    limit: u32,
+
+    #[arg(long)]
+    page_token: Option<String>,
+
+    #[arg(long)]
+    all: bool,
+
+    #[arg(long, value_enum, default_value_t = OutputFormat::Table)]
+    format: OutputFormat,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum TransferKindArg {
+    Load,
+    Export,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum TransferStateArg {
+    Pending,
+    Planning,
+    Dispatching,
+    Running,
+    Canceling,
+    Completed,
+    Failed,
+    Canceled,
+    PartialSuccess,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum, PartialEq, Eq)]
+pub enum OutputFormat {
+    Table,
+    Json,
+}
+
+impl TransferCommand {
+    pub async fn execute(&self, client: TransferClient) -> CommonResult<()> {
+        match &self.command {
+            TransferSubCommand::List(cmd) => cmd.execute(client).await,
+            TransferSubCommand::Status(cmd) => cmd.execute(client).await,
+            TransferSubCommand::Tasks(cmd) => cmd.execute(client).await,
+            TransferSubCommand::Cancel(cmd) => cmd.execute(client).await,
+            TransferSubCommand::Retry(cmd) => cmd.execute(client).await,
+            TransferSubCommand::Tenants(cmd) => cmd.execute(client).await,
+        }
+    }
+}
+
+impl TransferListCommand {
+    async fn execute(&self, client: TransferClient) -> CommonResult<()> {
+        let response = list_transfer_pages(
+            &client,
+            self.kind.map(TransferKind::from),
+            self.state.map(TransferState::from),
+            self.submitter.clone(),
+            self.tenant.clone(),
+            self.limit,
+            self.page_token.clone(),
+            self.all,
+        )
+        .await?;
+        if self.format == OutputFormat::Json {
+            println!("{}", serde_json::to_string_pretty(&response)?);
+            return Ok(());
+        }
+        print_jobs_table(&response.jobs, self.full_id, self.verbose);
+        print_next_page(response.next_page_token.as_deref());
+        Ok(())
+    }
+}
+
+impl TransferStatusCommand {
+    async fn execute(&self, client: TransferClient) -> CommonResult<()> {
+        if self.watch && self.format == OutputFormat::Json {
+            return err_box!("--watch only supports --format table");
+        }
+        let interval = self
+            .watch
+            .then(|| parse_watch_interval(&self.interval))
+            .transpose()?;
+        let include_tasks = self.verbose || self.format == OutputFormat::Json;
+        let mut first = true;
+        loop {
+            let response = status_transfer_pages(
+                &client,
+                &self.job_id,
+                if include_tasks { self.limit } else { 0 },
+                include_tasks.then(|| self.page_token.clone()).flatten(),
+                include_tasks && self.all,
+            )
+            .await?;
+            if self.format == OutputFormat::Json {
+                println!("{}", serde_json::to_string_pretty(&response)?);
+                return Ok(());
+            }
+            if !first {
+                println!();
+            }
+            first = false;
+            let job = status_to_job(&response);
+            print_status_summary(&job, response.task_summary.as_ref(), self.verbose);
+            if self.verbose {
+                print_tasks_table(&response.tasks, self.full_id, true);
+                print_next_page(response.next_page_token.as_deref());
+            }
+            if !self.watch || transfer_is_terminal(response.state) {
+                return Ok(());
+            }
+            if let Some(interval) = interval {
+                tokio::time::sleep(interval).await;
+            }
+        }
+    }
+}
+
+impl TransferTasksCommand {
+    async fn execute(&self, client: TransferClient) -> CommonResult<()> {
+        let response = status_transfer_pages(
+            &client,
+            &self.job_id,
+            self.limit,
+            self.page_token.clone(),
+            self.all,
+        )
+        .await?;
+        if self.format == OutputFormat::Json {
+            println!("{}", serde_json::to_string_pretty(&response.tasks)?);
+            return Ok(());
+        }
+        print_tasks_table(&response.tasks, self.full_id, self.verbose);
+        print_next_page(response.next_page_token.as_deref());
+        Ok(())
+    }
+}
+
+impl TransferCancelCommand {
+    async fn execute(&self, client: TransferClient) -> CommonResult<()> {
+        let response = handle_rpc_result(client.cancel(&self.job_id, self.run_id)).await;
+        println!("{}", render_cancel_response(&response, self.format)?);
+        Ok(())
+    }
+}
+
+impl TransferRetryCommand {
+    async fn execute(&self, client: TransferClient) -> CommonResult<()> {
+        let response = handle_rpc_result(client.retry(&self.job_id)).await;
+        println!(
+            "{}",
+            render_retry_response(&self.job_id, &response, self.format)?
+        );
+        Ok(())
+    }
+}
+
+impl TransferTenantsCommand {
+    async fn execute(&self, client: TransferClient) -> CommonResult<()> {
+        let response =
+            list_tenant_pages(&client, self.limit, self.page_token.clone(), self.all).await?;
+        if self.format == OutputFormat::Json {
+            println!("{}", serde_json::to_string_pretty(&response)?);
+            return Ok(());
+        }
+        print_tenants_table(&response.tenants);
+        print_next_page(response.next_page_token.as_deref());
+        Ok(())
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn list_transfer_pages(
+    client: &TransferClient,
+    kind: Option<TransferKind>,
+    state: Option<TransferState>,
+    submitter: Option<String>,
+    tenant: Option<String>,
+    limit: u32,
+    page_token: Option<String>,
+    all: bool,
+) -> CommonResult<ListTransfersResponse> {
+    validate_all_page_limit(limit, all)?;
+    let mut response = handle_rpc_result(client.list(
+        kind,
+        state,
+        submitter.clone(),
+        tenant.clone(),
+        Some(limit),
+        page_token.clone(),
+    ))
+    .await;
+    if !all {
+        return Ok(response);
+    }
+
+    let mut previous_token = page_token;
+    while let Some(next_token) = response.next_page_token.clone() {
+        ensure_page_advanced(previous_token.as_deref(), &next_token)?;
+        let mut next = handle_rpc_result(client.list(
+            kind,
+            state,
+            submitter.clone(),
+            tenant.clone(),
+            Some(limit),
+            Some(next_token.clone()),
+        ))
+        .await;
+        response.jobs.append(&mut next.jobs);
+        previous_token = Some(next_token);
+        response.next_page_token = next.next_page_token;
+    }
+    Ok(response)
+}
+
+async fn status_transfer_pages(
+    client: &TransferClient,
+    job_id: &str,
+    limit: u32,
+    page_token: Option<String>,
+    all: bool,
+) -> CommonResult<GetTransferStatusResponse> {
+    validate_all_page_limit(limit, all)?;
+    let mut response =
+        handle_rpc_result(client.status_page(job_id, Some(limit), page_token.clone())).await;
+    if !all {
+        return Ok(response);
+    }
+
+    let mut previous_token = page_token;
+    while let Some(next_token) = response.next_page_token.clone() {
+        ensure_page_advanced(previous_token.as_deref(), &next_token)?;
+        let mut next =
+            handle_rpc_result(client.status_page(job_id, Some(limit), Some(next_token.clone())))
+                .await;
+        response.tasks.append(&mut next.tasks);
+        previous_token = Some(next_token);
+        response.next_page_token = next.next_page_token;
+    }
+    Ok(response)
+}
+
+async fn list_tenant_pages(
+    client: &TransferClient,
+    limit: u32,
+    page_token: Option<String>,
+    all: bool,
+) -> CommonResult<ListTransferTenantsResponse> {
+    validate_all_page_limit(limit, all)?;
+    let mut response =
+        handle_rpc_result(client.list_tenants(Some(limit), page_token.clone())).await;
+    if !all {
+        return Ok(response);
+    }
+
+    let mut previous_token = page_token;
+    while let Some(next_token) = response.next_page_token.clone() {
+        ensure_page_advanced(previous_token.as_deref(), &next_token)?;
+        let mut next =
+            handle_rpc_result(client.list_tenants(Some(limit), Some(next_token.clone()))).await;
+        response.tenants.append(&mut next.tenants);
+        previous_token = Some(next_token);
+        response.next_page_token = next.next_page_token;
+    }
+    Ok(response)
+}
+
+fn validate_all_page_limit(limit: u32, all: bool) -> CommonResult<()> {
+    if all && limit == 0 {
+        return err_box!("--all requires --limit to be greater than 0");
+    }
+    Ok(())
+}
+
+fn ensure_page_advanced(previous: Option<&str>, next: &str) -> CommonResult<()> {
+    if previous == Some(next) {
+        return err_box!("Transfer service returned the same next_page_token: {next}");
+    }
+    Ok(())
+}
+
+fn parse_watch_interval(value: &str) -> CommonResult<Duration> {
+    let interval = match parse_duration(value) {
+        Ok(interval) => interval,
+        Err(err) => return err_box!("Invalid --interval {}: {}", value, err),
+    };
+    if interval.is_zero() {
+        return err_box!("--interval must be greater than zero");
+    }
+    Ok(interval)
+}
+
+fn status_to_job(response: &GetTransferStatusResponse) -> TransferJobStatusProto {
+    TransferJobStatusProto {
+        job_id: response.job_id.clone(),
+        run_id: response.run_id,
+        kind: response.kind.unwrap_or_default(),
+        state: response.state,
+        source_path: response.source_path.clone().unwrap_or_default(),
+        target_path: response.target_path.clone().unwrap_or_default(),
+        progress: response.progress.clone(),
+        submitter: response.submitter.clone().unwrap_or_default(),
+        tenant: response.tenant.clone().unwrap_or_default(),
+        created_at: response.created_at.unwrap_or_default(),
+        updated_at: response.updated_at.unwrap_or_default(),
+        owner: response.owner.clone(),
+        lease_epoch: response.lease_epoch,
+        lease_expire_at: response.lease_expire_at,
+        cv_metadata_epoch: response.cv_metadata_epoch,
+    }
+}
+
+pub fn render_cancel_response(
+    response: &CancelTransferResponse,
+    format: OutputFormat,
+) -> CommonResult<String> {
+    if format == OutputFormat::Json {
+        return Ok(serde_json::to_string_pretty(response)?);
+    }
+    let mut table = md_table();
+    table.set_header(["JOB ID", "STATE"]);
+    table.add_row([
+        response.job_id.clone(),
+        state_name(response.state).to_string(),
+    ]);
+    Ok(table.to_string())
+}
+
+pub fn render_retry_response(
+    original_job_id: &str,
+    response: &SubmitTransferResponse,
+    format: OutputFormat,
+) -> CommonResult<String> {
+    if format == OutputFormat::Json {
+        return Ok(serde_json::to_string_pretty(response)?);
+    }
+    let mut table = md_table();
+    table.set_header(["RETRY OF", "NEW JOB ID", "STATE"]);
+    table.add_row([
+        short_id(original_job_id),
+        response.job_id.clone(),
+        state_name(response.state).to_string(),
+    ]);
+    Ok(table.to_string())
+}
+
+impl From<TransferKindArg> for TransferKind {
+    fn from(value: TransferKindArg) -> Self {
+        match value {
+            TransferKindArg::Load => TransferKind::Load,
+            TransferKindArg::Export => TransferKind::Export,
+        }
+    }
+}
+
+impl From<TransferStateArg> for TransferState {
+    fn from(value: TransferStateArg) -> Self {
+        match value {
+            TransferStateArg::Pending => TransferState::Pending,
+            TransferStateArg::Planning => TransferState::Planning,
+            TransferStateArg::Dispatching => TransferState::Dispatching,
+            TransferStateArg::Running => TransferState::Running,
+            TransferStateArg::Canceling => TransferState::Canceling,
+            TransferStateArg::Completed => TransferState::Completed,
+            TransferStateArg::Failed => TransferState::Failed,
+            TransferStateArg::Canceled => TransferState::Canceled,
+            TransferStateArg::PartialSuccess => TransferState::PartialSuccess,
+        }
+    }
+}
+
+fn print_jobs_table(jobs: &[TransferJobStatusProto], full_id: bool, verbose: bool) {
+    let mut table = md_table();
+    if verbose {
+        table.set_header([
+            "JOB ID", "KIND", "STATE", "PROGRESS", "OWNER", "CV EPOCH", "SOURCE", "TARGET",
+            "UPDATED", "MESSAGE",
+        ]);
+    } else {
+        table.set_header([
+            "JOB ID", "KIND", "STATE", "PROGRESS", "SOURCE", "TARGET", "UPDATED",
+        ]);
+    }
+    for job in jobs {
+        let mut row = vec![
+            display_id(&job.job_id, full_id),
+            kind_name(job.kind).to_string(),
+            state_name(job.state).to_string(),
+            progress_text(job.progress.loaded_size, job.progress.total_size),
+        ];
+        if verbose {
+            row.push(owner_text(job.owner.as_deref()));
+            row.push(
+                job.cv_metadata_epoch
+                    .map(|epoch| epoch.to_string())
+                    .unwrap_or_else(|| "-".to_string()),
+            );
+        }
+        row.push(truncate_middle(
+            &job.source_path,
+            if verbose { 36 } else { 28 },
+        ));
+        row.push(truncate_middle(
+            &job.target_path,
+            if verbose { 36 } else { 28 },
+        ));
+        row.push(format_timestamp(job.updated_at));
+        if verbose {
+            row.push(truncate_middle(&job.progress.message, 32));
+        }
+        table.add_row(row);
+    }
+    println!("{table}");
+}
+
+fn print_status_summary(
+    job: &TransferJobStatusProto,
+    task_summary: Option<&curvine_common::proto::TransferTaskSummaryProto>,
+    verbose: bool,
+) {
+    let mut table = md_table();
+    table.set_header(["FIELD", "VALUE"]);
+    table.add_row(["Job ID".to_string(), job.job_id.clone()]);
+    table.add_row(["Run".to_string(), job.run_id.to_string()]);
+    if job.kind != 0 {
+        table.add_row(["Kind".to_string(), kind_name(job.kind).to_string()]);
+    }
+    table.add_row(["State".to_string(), state_name(job.state).to_string()]);
+    table.add_row([
+        "Progress".to_string(),
+        progress_text(job.progress.loaded_size, job.progress.total_size),
+    ]);
+    if let Some(summary) = task_summary {
+        table.add_row(["Tasks".to_string(), task_summary_text(summary)]);
+    }
+    if !job.progress.message.is_empty() {
+        table.add_row(["Message".to_string(), job.progress.message.clone()]);
+    }
+    if !job.source_path.is_empty() {
+        table.add_row(["Source".to_string(), job.source_path.clone()]);
+    }
+    if !job.target_path.is_empty() {
+        table.add_row(["Target".to_string(), job.target_path.clone()]);
+    }
+    table.add_row(["Updated".to_string(), format_timestamp(job.updated_at)]);
+    if verbose {
+        if !job.submitter.is_empty() {
+            table.add_row(["Submitter".to_string(), job.submitter.clone()]);
+        }
+        if !job.tenant.is_empty() {
+            table.add_row(["Tenant".to_string(), job.tenant.clone()]);
+        }
+        if let Some(owner) = &job.owner {
+            if !owner.is_empty() {
+                table.add_row(["Owner".to_string(), owner.clone()]);
+            }
+        }
+        if let Some(epoch) = job.lease_epoch {
+            table.add_row(["Lease".to_string(), epoch.to_string()]);
+        }
+        if let Some(expire_at) = job.lease_expire_at {
+            table.add_row(["Lease Expires".to_string(), format_timestamp(expire_at)]);
+        }
+        if let Some(epoch) = job.cv_metadata_epoch {
+            table.add_row(["CV Metadata Epoch".to_string(), epoch.to_string()]);
+        }
+        table.add_row(["Created".to_string(), format_timestamp(job.created_at)]);
+    }
+    println!("{table}");
+}
+
+fn print_tasks_table(tasks: &[TransferTaskStatusProto], full_id: bool, verbose: bool) {
+    let mut table = md_table();
+    if verbose {
+        table.set_header([
+            "TASK ID", "ATTEMPT", "STATE", "PROGRESS", "WORKER", "SESSION", "RETRY", "MESSAGE",
+            "SOURCE", "TARGET",
+        ]);
+    } else {
+        table.set_header([
+            "TASK ID", "STATE", "PROGRESS", "WORKER", "RETRY", "SOURCE", "TARGET",
+        ]);
+    }
+    for task in tasks {
+        let mut row = vec![
+            display_id(&task.task_id, full_id),
+            task_state_name(task.state).to_string(),
+            progress_text(task.progress.loaded_size, task.progress.total_size),
+            task.worker_id.to_string(),
+            task.retry_count.to_string(),
+        ];
+        if verbose {
+            row.insert(1, task.attempt_id.to_string());
+            row.insert(5, display_id(&task.worker_session_id, full_id));
+            row.push(truncate_middle(&task.progress.message, 28));
+        }
+        row.push(truncate_middle(
+            &task.source_path,
+            if verbose { 36 } else { 28 },
+        ));
+        row.push(truncate_middle(
+            &task.target_path,
+            if verbose { 36 } else { 28 },
+        ));
+        table.add_row(row);
+    }
+    println!("{table}");
+}
+
+fn print_tenants_table(tenants: &[TransferTenantSummaryProto]) {
+    let mut table = md_table();
+    table.set_header([
+        "TENANT",
+        "PENDING",
+        "EXECUTING",
+        "COMPLETED",
+        "FAILED",
+        "CANCELED",
+        "PARTIAL",
+        "TOTAL",
+    ]);
+    for tenant in tenants {
+        table.add_row([
+            if tenant.tenant.is_empty() {
+                "<default>".to_string()
+            } else {
+                tenant.tenant.clone()
+            },
+            tenant.pending.to_string(),
+            tenant.executing.to_string(),
+            tenant.completed.to_string(),
+            tenant.failed.to_string(),
+            tenant.canceled.to_string(),
+            tenant.partial_success.to_string(),
+            tenant.total.to_string(),
+        ]);
+    }
+    println!("{table}");
+}
+
+fn task_summary_text(summary: &curvine_common::proto::TransferTaskSummaryProto) -> String {
+    let mut parts = vec![
+        format!("{} completed", summary.completed),
+        format!("{} failed", summary.failed),
+        format!("{} running", summary.running),
+    ];
+    if summary.pending > 0 {
+        parts.push(format!("{} pending", summary.pending));
+    }
+    if summary.canceled > 0 {
+        parts.push(format!("{} canceled", summary.canceled));
+    }
+    if summary.stale > 0 {
+        parts.push(format!("{} stale", summary.stale));
+    }
+    parts.push(format!(
+        "{} cached",
+        bytes_to_string(summary.completed_size.max(0))
+    ));
+    parts.join(", ")
+}
+
+fn print_next_page(next_page_token: Option<&str>) {
+    if let Some(token) = next_page_token {
+        println!("More results: use --page-token {token}");
+    }
+}
+
+fn md_table() -> Table {
+    let mut table = Table::new();
+    table.load_preset(ASCII_MARKDOWN);
+    table
+}
+
+fn short_id(value: &str) -> String {
+    value.chars().take(12).collect()
+}
+
+fn display_id(value: &str, full_id: bool) -> String {
+    if full_id {
+        value.to_string()
+    } else {
+        short_id(value)
+    }
+}
+
+fn owner_text(owner: Option<&str>) -> String {
+    match owner {
+        Some(value) if !value.is_empty() => short_id(value),
+        _ => String::new(),
+    }
+}
+
+fn truncate_middle(value: &str, max_len: usize) -> String {
+    let char_len = value.chars().count();
+    if char_len <= max_len {
+        return value.to_string();
+    }
+    if max_len <= 3 {
+        return value.chars().take(max_len).collect();
+    }
+    let keep = (max_len - 3) / 2;
+    let tail = max_len - 3 - keep;
+    let head: String = value.chars().take(keep).collect();
+    let mut tail_chars: Vec<char> = value.chars().rev().take(tail).collect();
+    tail_chars.reverse();
+    let tail_text: String = tail_chars.into_iter().collect();
+    format!("{head}...{tail_text}")
+}
+
+fn progress_text(loaded: i64, total: i64) -> String {
+    if total <= 0 {
+        return bytes_to_string(loaded.max(0));
+    }
+    let loaded = loaded.max(0);
+    let percentage = (loaded as f64 / total as f64 * 100.0).clamp(0.0, 100.0);
+    format!(
+        "{} / {} ({percentage:.0}%)",
+        bytes_to_string(loaded),
+        bytes_to_string(total)
+    )
+}
+
+fn format_timestamp(timestamp_ms: i64) -> String {
+    if timestamp_ms <= 0 {
+        return "-".to_string();
+    }
+    let Some(timestamp) = chrono::DateTime::from_timestamp_millis(timestamp_ms) else {
+        return "-".to_string();
+    };
+    timestamp
+        .with_timezone(&chrono::Local)
+        .format("%Y-%m-%d %H:%M:%S")
+        .to_string()
+}
+
+fn transfer_is_terminal(state: i32) -> bool {
+    matches!(state, 6..=9)
+}
+
+fn kind_name(kind: i32) -> &'static str {
+    match kind {
+        1 => "Load",
+        2 => "Export",
+        _ => "Unknown",
+    }
+}
+
+fn state_name(state: i32) -> &'static str {
+    match state {
+        1 => "Pending",
+        2 => "Planning",
+        3 => "Dispatching",
+        4 => "Running",
+        5 => "Canceling",
+        6 => "Completed",
+        7 => "Failed",
+        8 => "Canceled",
+        9 => "PartialSuccess",
+        _ => "Unknown",
+    }
+}
+
+fn task_state_name(state: i32) -> &'static str {
+    match state {
+        1 => "Pending",
+        2 => "Running",
+        3 => "Completed",
+        4 => "Failed",
+        5 => "Canceled",
+        6 => "Stale",
+        _ => "Unknown",
+    }
+}

--- a/curvine-cli/src/commands.rs
+++ b/curvine-cli/src/commands.rs
@@ -36,12 +36,24 @@ pub enum Commands {
     Export(ExportCommand),
 
     /// Query loading task status
-    #[command(name = "load-status")]
+    #[command(name = "load-status", hide = true)]
     LoadStatus(LoadStatusCommand),
 
+    /// Query transfer task status
+    #[command(name = "transfer-status", hide = true)]
+    TransferStatus(LoadStatusCommand),
+
     /// Cancel loading task
-    #[command(name = "cancel-load")]
+    #[command(name = "cancel-load", hide = true)]
     CancelLoad(CancelLoadCommand),
+
+    /// Cancel transfer task
+    #[command(name = "cancel-transfer", hide = true)]
+    CancelTransfer(CancelLoadCommand),
+
+    /// Manage transfer jobs
+    #[command(name = "transfer")]
+    Transfer(TransferCommand),
 
     /// mount ufs to curvine
     #[command(name = "mount")]

--- a/curvine-cli/src/main.rs
+++ b/curvine-cli/src/main.rs
@@ -18,7 +18,7 @@ mod util;
 
 use clap::Parser;
 use commands::Commands;
-use curvine_client::rpc::JobMasterClient;
+use curvine_client::rpc::{JobMasterClient, TransferClient};
 use curvine_client::unified::UnifiedFileSystem;
 use curvine_common::conf::ClusterConf;
 use curvine_common::version;
@@ -33,12 +33,7 @@ use std::sync::Arc;
 #[command(author, version = version::VERSION, about, long_about = None)]
 pub struct CurvineArgs {
     /// Configuration file path (optional)
-    #[arg(
-        short,
-        long,
-        help = "Configuration file path (optional)",
-        global = true
-    )]
+    #[arg(long, help = "Configuration file path (optional)", global = true)]
     pub conf: Option<String>,
 
     /// Master address list (e.g., 'm1:8995,m2:8995')
@@ -173,16 +168,57 @@ fn main() -> CommonResult<()> {
     let curvine_fs = UnifiedFileSystem::with_rt(conf.clone(), rt.clone())?;
     let fs_client = curvine_fs.fs_client();
     let load_client = JobMasterClient::new(fs_client.clone());
+    let transfer_client = if conf.transfer.enabled {
+        Some(TransferClient::with_rt(&conf, rt.clone())?)
+    } else {
+        None
+    };
 
     rt.block_on(async move {
         let result = match args.command {
             Commands::Bench(cmd) => cmd.execute(curvine_fs, conf_source.clone()).await,
             Commands::Fs(cmd) => cmd.execute(curvine_fs).await,
             Commands::Report(cmd) => cmd.execute(curvine_fs).await,
-            Commands::Load(cmd) => cmd.execute(load_client).await,
-            Commands::Export(cmd) => cmd.execute(load_client).await,
-            Commands::LoadStatus(cmd) => cmd.execute(load_client).await,
-            Commands::CancelLoad(cmd) => cmd.execute(load_client).await,
+            Commands::Load(cmd) => match transfer_client.clone() {
+                Some(transfer_client) => cmd.execute_transfer(curvine_fs.clone(), transfer_client).await,
+                None => cmd.execute_legacy(load_client.clone()).await,
+            },
+            Commands::Export(cmd) => match transfer_client.clone() {
+                Some(transfer_client) => cmd.execute_transfer(curvine_fs.clone(), transfer_client).await,
+                None => cmd.execute_legacy(load_client.clone()).await,
+            },
+            Commands::LoadStatus(cmd) => match transfer_client.clone() {
+                Some(transfer_client) => cmd.execute_transfer_only(transfer_client).await,
+                None => cmd.execute(load_client.clone()).await,
+            },
+            Commands::TransferStatus(cmd) => {
+                let Some(transfer_client) = transfer_client.clone() else {
+                    return err_box!(
+                        "transfer-status requires transfer.enabled=true and a running transfer service"
+                    );
+                };
+                cmd.execute_transfer_only(transfer_client).await
+            }
+            Commands::CancelLoad(cmd) => match transfer_client.clone() {
+                Some(transfer_client) => cmd.execute_transfer_only(transfer_client).await,
+                None => cmd.execute(load_client.clone()).await,
+            },
+            Commands::CancelTransfer(cmd) => {
+                let Some(transfer_client) = transfer_client.clone() else {
+                    return err_box!(
+                        "cancel-transfer requires transfer.enabled=true and a running transfer service"
+                    );
+                };
+                cmd.execute_transfer_only(transfer_client).await
+            }
+            Commands::Transfer(cmd) => {
+                let Some(transfer_client) = transfer_client.clone() else {
+                    return err_box!(
+                        "transfer requires transfer.enabled=true and a running transfer service"
+                    );
+                };
+                cmd.execute(transfer_client).await
+            }
             Commands::Mount(cmd) => cmd.execute(curvine_fs).await,
             Commands::UnMount(cmd) => cmd.execute(fs_client).await,
             Commands::Node(cmd) => cmd.execute(fs_client, conf.clone()).await,
@@ -210,5 +246,22 @@ mod tests {
             .expect("export command should parse");
 
         assert!(matches!(args.command, Commands::Export(_)));
+    }
+
+    #[test]
+    fn mount_accepts_config_without_conf_short_option_collision() {
+        let args = CurvineArgs::try_parse_from([
+            "curvine",
+            "--conf",
+            "curvine-cluster.toml",
+            "mount",
+            "s3://bucket/path",
+            "/bucket/path",
+            "-c",
+            "s3.endpoint_url=http://127.0.0.1:9000",
+        ])
+        .expect("mount config should use -c while cluster config uses --conf");
+
+        assert!(matches!(args.command, Commands::Mount(_)));
     }
 }


### PR DESCRIPTION
# Summary

Routes normal cv load/export commands through Transfer, adds transfer operations, and preserves mount -c configuration syntax.

# Issue Describe / Design

Part of the standalone Transfer service. This review layer is stacked deliberately so that protocol, metadata storage, scheduling, worker execution, client routing, and deployment can be reviewed independently.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-cli/src` | Routes normal cv load/export commands through Transfer, adds transfer operations, and preserves mount -c configuration syntax. | New Transfer behavior; legacy behavior remains available unless Transfer is enabled. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-cli --bin curvine-cli; MinIO load/export e2e` | PASS | Rebased onto upstream main `497d078d`. |

# Dependencies

- Related PRs: #1355
- Related issues: #1040
- Blocks / blocked by: #1355