### PR TITLE
chore(deploy): run transfer as an independent service

### DIFF
--- a/build/bin/curvine-transfer.sh
+++ b/build/bin/curvine-transfer.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+#
+# Copyright 2025 OPPO.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"$(cd "`dirname "$0"`"; pwd)"/launch-process.sh transfer $1

--- a/build/bin/launch-process.sh
+++ b/build/bin/launch-process.sh
@@ -52,7 +52,7 @@ start() {
     check
 
     name="unknown"
-    if [[ "$SERVICE_NAME" = "worker" ]] || [[ "$SERVICE_NAME" = "master" ]]; then
+    if [[ "$SERVICE_NAME" = "worker" ]] || [[ "$SERVICE_NAME" = "master" ]] || [[ "$SERVICE_NAME" = "transfer" ]]; then
       name="curvine-server"
       nohup ${CURVINE_HOME}/lib/curvine-server \
       --service ${SERVICE_NAME} \

--- a/build/bin/local-cluster.sh
+++ b/build/bin/local-cluster.sh
@@ -150,13 +150,62 @@ wait_service_ready() {
     return 1
 }
 
+read_bool() {
+    local section=$1
+    local key=$2
+    local default_value=$3
+    local conf_file="${CURVINE_CONF_FILE:-$CURVINE_HOME/conf/curvine-cluster.toml}"
+
+    if [ ! -f "$conf_file" ]; then
+        echo "$default_value"
+        return
+    fi
+
+    awk -v section="[$section]" -v key="$key" -v default_value="$default_value" '
+        /^[[:space:]]*\[/ {
+            line = $0
+            sub(/[[:space:]]*#.*/, "", line)
+            gsub(/[[:space:]]/, "", line)
+            in_section = (line == section)
+        }
+        in_section {
+            line = $0
+            sub(/[[:space:]]*#.*/, "", line)
+            gsub(/[[:space:]]/, "", line)
+            if (line ~ "^" key "=") {
+                sub(/^[^=]*=/, "", line)
+                print line
+                found = 1
+                exit
+            }
+        }
+        END {
+            if (!found) {
+                print default_value
+            }
+        }
+    ' "$conf_file"
+}
+
+transfer_enabled() {
+    [ "$(read_bool "transfer" "enabled" "false")" = "true" ]
+}
+
+active_services() {
+    local services=("${SERVICES[@]}")
+    if transfer_enabled || [ -f "$CURVINE_HOME/transfer.pid" ]; then
+        services+=("transfer")
+    fi
+    echo "${services[@]}"
+}
+
 # Start all services
 start_all() {
     print_info "Starting Curvine local cluster..."
     
     # Check if there is already a service running
     local running=false
-    for service in "${SERVICES[@]}"; do
+    for service in $(active_services); do
         if [ -f "$CURVINE_HOME/${service}.pid" ]; then
             local pid=$(cat "$CURVINE_HOME/${service}.pid")
             if kill -0 "$pid" > /dev/null 2>&1; then
@@ -173,6 +222,7 @@ start_all() {
     
     local master_port=$(read_rpc_port "master" 8995)
     local worker_port=$(read_rpc_port "worker" 8997)
+    local transfer_port=$(read_rpc_port "transfer" 9010)
 
     print_info "Starting master..."
     "$BIN_DIR/curvine-master.sh" start
@@ -181,6 +231,12 @@ start_all() {
     print_info "Starting worker..."
     "$BIN_DIR/curvine-worker.sh" start
     wait_service_ready "worker" "$worker_port" 60 || return 1
+
+    if transfer_enabled; then
+        print_info "Starting transfer..."
+        "$BIN_DIR/curvine-transfer.sh" start
+        wait_service_ready "transfer" "$transfer_port" 60 || return 1
+    fi
     
     print_info "All services started. Use 'status' to check cluster status."
 }
@@ -190,8 +246,9 @@ stop_all() {
     print_info "Stopping Curvine local cluster..."
     
     # Stop service in reverse order
-    for (( idx=${#SERVICES[@]}-1 ; idx>=0 ; idx--)) ; do
-        service="${SERVICES[idx]}"
+    local services=($(active_services))
+    for (( idx=${#services[@]}-1 ; idx>=0 ; idx--)) ; do
+        service="${services[idx]}"
         print_info "Stopping $service..."
         "$BIN_DIR/curvine-${service}.sh" stop
         sleep 1
@@ -199,7 +256,7 @@ stop_all() {
     
     # Check if any service is still running
     local still_running=false
-    for service in "${SERVICES[@]}"; do
+    for service in "${services[@]}"; do
         if [ -f "$CURVINE_HOME/${service}.pid" ]; then
             local pid=$(cat "$CURVINE_HOME/${service}.pid")
             if kill -0 "$pid" > /dev/null 2>&1; then
@@ -212,7 +269,7 @@ stop_all() {
     if [ "$still_running" = true ] && [ "$1" = "force" ]; then
         print_warn "Force killing remaining processes..."
         pkill -9 -f "curvine"
-        for service in "${SERVICES[@]}"; do
+        for service in "${services[@]}"; do
             if [ -f "$CURVINE_HOME/${service}.pid" ]; then
                 rm -f "$CURVINE_HOME/${service}.pid"
             fi
@@ -234,9 +291,10 @@ restart_all() {
 show_status() {
     print_info "Curvine local cluster status:"
     echo "-----------------------------------"
+    local services=($(active_services))
     
     local all_running=true
-    for service in "${SERVICES[@]}"; do
+    for service in "${services[@]}"; do
         echo -n "$service: "
         if ! check_service_status "$service"; then
             all_running=false

--- a/build/bin/restart-all.sh
+++ b/build/bin/restart-all.sh
@@ -56,6 +56,47 @@ read_rpc_port() {
     ' "$conf_file"
 }
 
+read_bool() {
+    local section=$1
+    local key=$2
+    local default_value=$3
+    local conf_file="${CURVINE_CONF_FILE:-${BIN_DIR}/../conf/curvine-cluster.toml}"
+
+    if [ ! -f "$conf_file" ]; then
+        echo "$default_value"
+        return
+    fi
+
+    awk -v section="[$section]" -v key="$key" -v default_value="$default_value" '
+        /^[[:space:]]*\[/ {
+            line = $0
+            sub(/[[:space:]]*#.*/, "", line)
+            gsub(/[[:space:]]/, "", line)
+            in_section = (line == section)
+        }
+        in_section {
+            line = $0
+            sub(/[[:space:]]*#.*/, "", line)
+            gsub(/[[:space:]]/, "", line)
+            if (line ~ "^" key "=") {
+                sub(/^[^=]*=/, "", line)
+                print line
+                found = 1
+                exit
+            }
+        }
+        END {
+            if (!found) {
+                print default_value
+            }
+        }
+    ' "$conf_file"
+}
+
+transfer_enabled() {
+    [ "$(read_bool "transfer" "enabled" "false")" = "true" ]
+}
+
 # Function to wait for a process to start
 wait_for_process() {
     local service_name=$1
@@ -122,6 +163,7 @@ sleep 3
 
 MASTER_PORT=$(read_rpc_port "master" 8995)
 WORKER_PORT=$(read_rpc_port "worker" 8997)
+TRANSFER_PORT=$(read_rpc_port "transfer" 9010)
 
 # Start master and worker services
 ${BIN_DIR}/curvine-master.sh start
@@ -133,6 +175,12 @@ ${BIN_DIR}/curvine-worker.sh start
 # Wait for master and worker to start
 wait_for_process "worker" || exit 1
 wait_for_port "worker" "$WORKER_PORT" 60 || exit 1
+
+if transfer_enabled; then
+    ${BIN_DIR}/curvine-transfer.sh start
+    wait_for_process "transfer" || exit 1
+    wait_for_port "transfer" "$TRANSFER_PORT" 60 || exit 1
+fi
 
 # Start fuse service
 ${BIN_DIR}/curvine-fuse.sh start

--- a/curvine-docker/deploy/Dockerfile_rocky9
+++ b/curvine-docker/deploy/Dockerfile_rocky9
@@ -207,7 +207,9 @@ WORKDIR $APP_HOME
 # 8997: Worker RPC
 # 9000: Master Web UI
 # 9001: Worker Web UI / Master Web1
-EXPOSE 8995 8996 8997 9000 9001
+# 9010: Transfer RPC
+# 9011: Transfer Web UI
+EXPOSE 8995 8996 8997 9000 9001 9010 9011
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["master", "start"]

--- a/curvine-docker/deploy/Dockerfile_ubuntu24
+++ b/curvine-docker/deploy/Dockerfile_ubuntu24
@@ -116,7 +116,7 @@ RUN ARCH=$(uname -m) && \
 
 ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 
-# Runtime image only needs master/worker runtime binaries, CLI/FUSE helpers, and WebUI.
+# Runtime image contains master, worker and transfer service binaries, CLI/FUSE helpers, and WebUI.
 # Override with --build-arg BUILD_ARGS="..." when building SDKs, WebUI, tests, or alternate UFS sets.
 ARG BUILD_ARGS="-p server -p client -p cli -p fuse -p web --skip-java-sdk --skip-python-sdk --ufs opendal-s3 --ufs opendal-oss --ufs opendal-azblob --ufs opendal-gcs --ufs opendal-hdfs --ufs opendal-webhdfs --ufs oss-hdfs"
 
@@ -277,7 +277,9 @@ WORKDIR $APP_HOME
 # 8997: Worker RPC
 # 9000: Master Web UI
 # 9001: Worker Web UI / Master Web1
-EXPOSE 8995 8996 8997 9000 9001
+# 9010: Transfer RPC
+# 9011: Transfer Web UI
+EXPOSE 8995 8996 8997 9000 9001 9010 9011
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["master", "start"]

--- a/curvine-docker/deploy/entrypoint.sh
+++ b/curvine-docker/deploy/entrypoint.sh
@@ -46,7 +46,7 @@ if is_fluid_mode "${1:-}"; then
 fi
 
 # Start the curvine service process
-# Service type: master, worker
+# Service type: master, worker, transfer
 SERVER_TYPE=${1:-master}
 
 # Operation type: start, stop, restart
@@ -178,7 +178,7 @@ restart_service() {
 set_hosts
 
 case "$SERVER_TYPE" in
-  (master|worker)
+  (master|worker|transfer)
     case "$ACTION_TYPE" in
       start)
         start_service "$SERVER_TYPE"

--- a/curvine-docker/deploy/spdk/curvine-cluster-spdk.toml
+++ b/curvine-docker/deploy/spdk/curvine-cluster-spdk.toml
@@ -62,6 +62,9 @@ subnqn = "nqn.2026-05.curvine:cnode1"
 [client]
 short_circuit = false
 
+[transfer]
+enabled = true
+
 # fuse configuration  
 [fuse]  
   

--- a/curvine-docker/deploy/spdk/docker-compose.yml
+++ b/curvine-docker/deploy/spdk/docker-compose.yml
@@ -74,3 +74,23 @@ services:
         condition: service_healthy
     command: ["worker", "start"]
     restart: unless-stopped
+
+  # ============================================================
+  # Curvine Transfer
+  # ============================================================
+  transfer:
+    build:
+      context: ../../..
+      dockerfile: curvine-docker/deploy/Dockerfile_rocky9
+      args:
+        BUILD_ARGS: "${BUILD_ARGS}"
+    network_mode: "host"
+    volumes:
+      - ${CURVINE_CONF_FILE:-./curvine-cluster-spdk.toml}:/app/curvine/conf/curvine-cluster.toml
+    depends_on:
+      master:
+        condition: service_started
+      worker:
+        condition: service_started
+    command: ["transfer", "start"]
+    restart: unless-stopped

--- a/curvine-server/src/bin/curvine-server.rs
+++ b/curvine-server/src/bin/curvine-server.rs
@@ -16,6 +16,7 @@ use clap::Parser;
 use curvine_common::conf::ClusterConf;
 use curvine_common::version;
 use curvine_server::master::Master;
+use curvine_server::transfer::TransferServer;
 use curvine_server::worker::Worker;
 use orpc::common::{LocalTime, Utils};
 use orpc::{err_box, CommonResult};
@@ -45,6 +46,11 @@ fn main() -> CommonResult<()> {
             let worker = Worker::with_conf(conf)?;
             worker.block_on_start()?;
         }
+
+        ServiceType::Transfer => {
+            let transfer = TransferServer::with_conf(conf)?;
+            transfer.block_on_start()?;
+        }
     }
 
     Ok(())
@@ -68,6 +74,7 @@ impl ServerArgs {
         match service.as_str() {
             "master" => Ok(ServiceType::Master),
             "worker" => Ok(ServiceType::Worker),
+            "transfer" => Ok(ServiceType::Transfer),
             v => err_box!("Unsupported service type: {}", v),
         }
     }
@@ -80,4 +87,5 @@ impl ServerArgs {
 pub enum ServiceType {
     Master,
     Worker,
+    Transfer,
 }

--- a/etc/curvine-cluster.toml
+++ b/etc/curvine-cluster.toml
@@ -82,6 +82,11 @@ subnqn = "nqn.2024-01.io.curvine:subsystem2"
 # Customer service configuration.
 [client]
 
+[transfer]
+# Set to true to start the standalone Transfer service. Local SQLite storage,
+# replica metadata reader and localhost:9010 are inferred by default.
+enabled = false
+
 # fuse configuration
 [fuse]
 # Kernel-side metadata cache timeouts (milliseconds).


### PR DESCRIPTION
# Summary

Adds service role startup, local lifecycle support, Docker entrypoint support, and SPDK compose deployment.

# Issue Describe / Design

Part of the standalone Transfer service. This review layer is stacked deliberately so that protocol, metadata storage, scheduling, worker execution, client routing, and deployment can be reviewed independently.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `build/bin,curvine-docker/deploy,etc/curvine-cluster.toml` | Adds service role startup, local lifecycle support, Docker entrypoint support, and SPDK compose deployment. | New Transfer behavior; legacy behavior remains available unless Transfer is enabled. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo check -p curvine-server -p curvine-cli; bash -n deployment scripts` | PASS | Rebased onto upstream main `497d078d`. |

# Dependencies

- Related PRs: #1356
- Related issues: #1040
- Blocks / blocked by: #1356