### PR TITLE
docs(readme): add best practices link and remove star history

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ For more detailed information, please refer to:
 - [DeepWiki](https://deepwiki.com/CurvineIO/curvine)
 - [Commit convention](COMMIT_CONVENTION.md)
 - [Contribute guidelines](CONTRIBUTING.md)
+- [Best Practices](https://curvineio.github.io/docs/User-Manuals/best-practices)
 
 ## Roadmap 2026
 ![Evolution from Distributed Cache to AI Agent-Native Infrastructure ](https://github.com/CurvineIO/curvine/discussions/549)
@@ -263,7 +264,3 @@ Please read Curvine [Contribute guidelines](CONTRIBUTING.md)
 
 ## 📜 License
 Curvine is licensed under the ​**​[Apache License 2.0](LICENSE)​**.
-
-## Star History
-
-[![Star History Chart](https://api.star-history.com/svg?repos=CurvineIO/curvine&type=Date)](https://www.star-history.com/#CurvineIO/curvine&Date)

--- a/README_zh.md
+++ b/README_zh.md
@@ -248,7 +248,3 @@ Curvine 在高并发场景下表现优异，支持：
 ## 📜 许可证
 
 Curvine 采用 **[Apache License 2.0](LICENSE)** 开源协议授权。
-
-## 星标历史
-
-[![Star History Chart](https://api.star-history.com/svg?repos=CurvineIO/curvine&type=Date)](https://www.star-history.com/#CurvineIO/curvine&Date)


### PR DESCRIPTION
# Summary

Adds the Best Practices documentation link to the README resource list and removes the Star History section from both README files.

# Issue Describe / Design

- The [Best Practices](https://curvineio.github.io/docs/User-Manuals/best-practices) page in curvine-doc consolidates production deployment/configuration recommendations; it is now linked from the README documentation resources, directly below Contribute guidelines.
- The Star History chart is removed from `README.md` and `README_zh.md` as it is no longer desired on the project page.
- The use-case diagram referenced by the README (`curvine-scene.png` in curvine-doc) is redrawn in the companion PR CurvineIO/curvine-doc#81; no URL change is needed here since the referenced file path is unchanged.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `README.md` | Added Best Practices link; removed Star History section | Documentation-only |
| `README_zh.md` | Removed Star History section | Documentation-only |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| Best Practices URL reachable | PASS | https://curvineio.github.io/docs/User-Manuals/best-practices |
| Markdown structure check after edit | PASS | License section is now the last section |
| `make format` | SKIPPED | Markdown-only change; no Rust code touched |

# Dependencies

- Related PRs: CurvineIO/curvine-doc#81 (use-case diagram refresh)
- Related issues: None
- Blocks / blocked by: None