### PR TITLE
feat(metrics): add master active connection gauge (#770)

### DIFF
--- a/curvine-server/src/master/master_handler.rs
+++ b/curvine-server/src/master/master_handler.rs
@@ -61,6 +61,7 @@ impl MasterHandler {
         actor_rt: Arc<Runtime>,
         metrics: &'static MasterMetrics,
     ) -> Self {
+        metrics.active_connections.inc();
         Self {
             fs,
             retry_cache,
@@ -728,6 +729,12 @@ impl MasterHandler {
                 .with_label_values(&[&code_label])
                 .observe(used_us as f64);
         };
+    }
+}
+
+impl Drop for MasterHandler {
+    fn drop(&mut self) {
+        self.metrics.active_connections.dec();
     }
 }
 

--- a/curvine-server/src/master/master_metrics.rs
+++ b/curvine-server/src/master/master_metrics.rs
@@ -28,6 +28,7 @@ use std::fmt::{Debug, Formatter};
 pub struct MasterMetrics {
     pub(crate) rpc_request_total_count: Counter,
     pub(crate) rpc_request_total_time: Counter,
+    pub(crate) active_connections: Gauge,
 
     pub(crate) capacity: Gauge,
     pub(crate) available: Gauge,
@@ -89,6 +90,10 @@ impl MasterMetrics {
             rpc_request_total_time: m::new_counter(
                 "rpc_request_time",
                 "Rpc request time duration(ms)",
+            )?,
+            active_connections: m::new_gauge(
+                "master_active_connections",
+                "Number of active RPC connections to master",
             )?,
 
             capacity: m::new_gauge("capacity", "Total storage capacity")?,


### PR DESCRIPTION
# Summary

Adds a Master-side Prometheus gauge for active RPC client connections.

# Issue Describe / Design

Closes #770

Current limitation:

- Master metrics did not expose the current number of active RPC client connections.
- During high-concurrency stress testing, it is inconvenient to observe Master-side connection pressure from the metrics endpoint.
- Curvine workers and user-facing clients both connect to the Master through the RPC client path, so this metric uses the transport-layer RPC client connection lifecycle.

Design:

- Add `master_active_connections` as a Prometheus gauge in `MasterMetrics`.
- Increment the gauge when a `MasterHandler` is created.
- Decrement the gauge when `MasterHandler` is dropped.
- Avoid inferring user-client vs worker identity from RPC codes, because the current connection layer does not have a reliable connection-level role and it may be better to keep the PR small.

# Changes

| Module / File                                 | Change                                                                    | Impact on existing behavior                                                   |
| :-------------------------------------------- | :------------------------------------------------------------------------ | :---------------------------------------------------------------------------- |
| `curvine-server/src/master/master_metrics.rs` | Add `master_active_connections` gauge.                                    | Exposes active Master RPC client connection count through Prometheus metrics. |
| `curvine-server/src/master/master_handler.rs` | Increment the gauge on handler creation and decrement it on handler drop. | Tracks connection lifecycle without changing existing RPC behavior.           |

- This metric reflects active RPC client connections observed at the Master transport layer. For user-client concurrency stress testing, operators can record the baseline value before the test and subtract it from the value observed during the test to estimate the additional client connection pressure.

## Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| Local Rust validation | PASS | Ran `PROTOC=/tmp/curvine-protoc cargo fmt --all`, `PROTOC=/tmp/curvine-protoc cargo check -p curvine-server`, and `PROTOC=/tmp/curvine-protoc cargo clippy -p curvine-server --all-targets -- -D warnings` successfully. |
| Local Master + Curvine `FsClient` connection lifecycle verification | PASS | Baseline value was `0`. After starting two Curvine `FsClient` hold processes, `master_active_connections` increased to `2`. After stopping one client, it decreased to `1`; after stopping both clients, it returned to `0`. | 
<img width="1532" height="258" alt="20260728-142353" src="https://github.com/user-attachments/assets/aef46f21-20dd-4b5b-98cb-07339901b5d4" />

# Dependencies

- Related PRs: None
- Related issues: #770
- Blocks / blocked by: None

