### PR TITLE
fix(fuse): track multiple POSIX lock owners per shared handle (#1363)

### DIFF
--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -248,12 +248,19 @@ impl CurvineFileSystem {
         flags == 0
     }
 
-    fn to_file_lock(&self, arg: &fuse_lk_in) -> FileLock {
+    fn to_file_lock(&self, arg: &fuse_lk_in, header_pid: u32) -> FileLock {
         let client_id = self.fs.cv().fs_context().clone_client_name();
+        // Prefer the flock pid from the kernel request; fall back to the FUSE
+        // header pid when the kernel leaves lk.pid unset (common on some paths).
+        let pid = if arg.lk.pid != 0 {
+            arg.lk.pid
+        } else {
+            header_pid
+        };
         FileLock {
             client_id,
             owner_id: arg.owner,
-            pid: arg.lk.pid,
+            pid,
             lock_type: LockType::from(arg.lk.typ as u8),
             lock_flags: LockFlags::from(arg.lk_flags as u8),
             start: arg.lk.start,
@@ -263,16 +270,29 @@ impl CurvineFileSystem {
     }
 
     async fn fs_unlock(&self, handler: &FileHandle, flags: LockFlags) -> FuseResult<()> {
-        if let Some(owner_id) = handler.remove_lock(flags) {
-            if let Err(e) = self.fs_unlock_owner(handler, flags, owner_id).await {
-                // Preserve the owner locally when the backend unlock fails so a
-                // retained handle can retry the cleanup.
-                handler.add_lock(flags, owner_id);
-                return Err(e);
+        match flags {
+            LockFlags::Plock => {
+                let owners = handler.drain_plock_owners();
+                for owner_id in owners {
+                    if let Err(e) = self.fs_unlock_owner(handler, flags, owner_id).await {
+                        // Preserve remaining owners locally when unlock fails so a
+                        // retained handle can retry the cleanup.
+                        handler.add_lock(flags, owner_id);
+                        return Err(e);
+                    }
+                }
+                Ok(())
+            }
+            LockFlags::Flock => {
+                if let Some(owner_id) = handler.remove_lock(flags) {
+                    if let Err(e) = self.fs_unlock_owner(handler, flags, owner_id).await {
+                        handler.add_lock(flags, owner_id);
+                        return Err(e);
+                    }
+                }
+                Ok(())
             }
         }
-
-        Ok(())
     }
 
     async fn fs_unlock_owner(
@@ -1854,7 +1874,7 @@ impl fs::FileSystem for CurvineFileSystem {
 
     async fn get_lk(&self, op: GetLk<'_>) -> FuseResult<fuse_lk_out> {
         let path = self.state.get_path(op.header.nodeid)?;
-        let lock = self.to_file_lock(op.arg);
+        let lock = self.to_file_lock(op.arg, op.header.pid);
 
         self.state.fs_fsync(op.header.nodeid, None).await?;
 
@@ -1883,12 +1903,22 @@ impl fs::FileSystem for CurvineFileSystem {
 
         self.state.fs_fsync(op.header.nodeid, None).await?;
 
-        let lock = self.to_file_lock(op.arg);
+        let lock = self.to_file_lock(op.arg, op.header.pid);
         let (flag, owner_id) = (lock.lock_flags, lock.owner_id);
+        let is_unlock = lock.lock_type == LockType::UnLock;
+        let full_range_unlock = is_unlock && lock.start == 0 && lock.end == u64::MAX;
 
         let conflict = self.fs.set_lock(&path, lock).await?;
         if conflict.is_none() {
-            handle.add_lock(flag, owner_id);
+            if is_unlock {
+                // Full-range unlock drops this owner from handle bookkeeping so a
+                // later FUSE_FLUSH does not need to talk to Master again.
+                if full_range_unlock && flag == LockFlags::Plock {
+                    handle.take_plock_if_owner(owner_id);
+                }
+            } else {
+                handle.add_lock(flag, owner_id);
+            }
             Ok(())
         } else {
             err_fuse!(libc::EAGAIN)
@@ -1910,16 +1940,15 @@ impl fs::FileSystem for CurvineFileSystem {
         let mut ticks: u64 = 0;
         let time = TimeSpent::new();
 
-        let lock = self.to_file_lock(op.arg);
+        let lock = self.to_file_lock(op.arg, op.header.pid);
         let wait_guard = PlockWaitGuard::new(
             self.plock_waits.clone(),
             LockOwner::new(lock.client_id.clone(), lock.owner_id),
         );
         loop {
-            wait_guard.clear_blocked_by();
-
             let conflict = self.fs.set_lock(&path, lock.clone()).await?;
             if conflict.is_none() {
+                wait_guard.clear_blocked_by();
                 handle.add_lock(lock.lock_flags, lock.owner_id);
                 return Ok(());
             }

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -269,19 +269,32 @@ impl CurvineFileSystem {
         }
     }
 
+    /// Linux FUSE whole-file fcntl ranges commonly use end = OFFSET_MAX
+    /// (`i64::MAX as u64`). Master full-clear and `fs_unlock_owner` use `u64::MAX`.
+    fn is_lock_to_eof(end: u64) -> bool {
+        end == u64::MAX || end == i64::MAX as u64
+    }
+
+    fn is_full_range_unlock(lock: &FileLock) -> bool {
+        lock.lock_type == LockType::UnLock && lock.start == 0 && Self::is_lock_to_eof(lock.end)
+    }
+
     async fn fs_unlock(&self, handler: &FileHandle, flags: LockFlags) -> FuseResult<()> {
         match flags {
             LockFlags::Plock => {
                 let owners = handler.drain_plock_owners();
+                let mut result = Ok(());
                 for owner_id in owners {
-                    if let Err(e) = self.fs_unlock_owner(handler, flags, owner_id).await {
-                        // Preserve remaining owners locally when unlock fails so a
-                        // retained handle can retry the cleanup.
+                    let unlock_result = self.fs_unlock_owner(handler, flags, owner_id).await;
+                    if unlock_result.is_err() {
+                        // Preserve failed owners locally for retry, but keep
+                        // best-effort unlocking the remainder (same spirit as
+                        // release flock/plock retain_first_error handling).
                         handler.add_lock(flags, owner_id);
-                        return Err(e);
                     }
+                    Self::retain_first_error(&mut result, unlock_result);
                 }
-                Ok(())
+                result
             }
             LockFlags::Flock => {
                 if let Some(owner_id) = handler.remove_lock(flags) {
@@ -1903,10 +1916,14 @@ impl fs::FileSystem for CurvineFileSystem {
 
         self.state.fs_fsync(op.header.nodeid, None).await?;
 
-        let lock = self.to_file_lock(op.arg, op.header.pid);
+        let mut lock = self.to_file_lock(op.arg, op.header.pid);
         let (flag, owner_id) = (lock.lock_flags, lock.owner_id);
         let is_unlock = lock.lock_type == LockType::UnLock;
-        let full_range_unlock = is_unlock && lock.start == 0 && lock.end == u64::MAX;
+        let full_range_unlock = Self::is_full_range_unlock(&lock);
+        if full_range_unlock {
+            // Align OFFSET_MAX whole-file unlocks with Master full-clear / fs_unlock_owner.
+            lock.end = u64::MAX;
+        }
 
         let conflict = self.fs.set_lock(&path, lock).await?;
         if conflict.is_none() {
@@ -1940,7 +1957,12 @@ impl fs::FileSystem for CurvineFileSystem {
         let mut ticks: u64 = 0;
         let time = TimeSpent::new();
 
-        let lock = self.to_file_lock(op.arg, op.header.pid);
+        let mut lock = self.to_file_lock(op.arg, op.header.pid);
+        let is_unlock = lock.lock_type == LockType::UnLock;
+        let full_range_unlock = Self::is_full_range_unlock(&lock);
+        if full_range_unlock {
+            lock.end = u64::MAX;
+        }
         let wait_guard = PlockWaitGuard::new(
             self.plock_waits.clone(),
             LockOwner::new(lock.client_id.clone(), lock.owner_id),
@@ -1949,7 +1971,13 @@ impl fs::FileSystem for CurvineFileSystem {
             let conflict = self.fs.set_lock(&path, lock.clone()).await?;
             if conflict.is_none() {
                 wait_guard.clear_blocked_by();
-                handle.add_lock(lock.lock_flags, lock.owner_id);
+                if is_unlock {
+                    if full_range_unlock && lock.lock_flags == LockFlags::Plock {
+                        handle.take_plock_if_owner(lock.owner_id);
+                    }
+                } else {
+                    handle.add_lock(lock.lock_flags, lock.owner_id);
+                }
                 return Ok(());
             }
 
@@ -1984,6 +2012,34 @@ mod tests {
     use crate::fs::dcache::Inode;
     use crate::{FATTR_ATIME_NOW, FATTR_GID, FATTR_MODE, FATTR_MTIME, FATTR_MTIME_NOW, FATTR_UID};
     use curvine_common::state::{FileAllocMode, FileStatus, FileType, INTERNAL_CTIME_XATTR};
+
+    #[test]
+    fn full_range_unlock_accepts_kernel_offset_max_and_u64_max() {
+        use super::CurvineFileSystem;
+        use curvine_common::state::{FileLock, LockType};
+
+        assert!(CurvineFileSystem::is_lock_to_eof(u64::MAX));
+        assert!(CurvineFileSystem::is_lock_to_eof(i64::MAX as u64));
+        assert!(!CurvineFileSystem::is_lock_to_eof(i64::MAX as u64 - 1));
+
+        let mut lock = FileLock {
+            lock_type: LockType::UnLock,
+            start: 0,
+            end: i64::MAX as u64,
+            ..Default::default()
+        };
+        assert!(CurvineFileSystem::is_full_range_unlock(&lock));
+
+        lock.end = u64::MAX;
+        assert!(CurvineFileSystem::is_full_range_unlock(&lock));
+
+        lock.end = 100;
+        assert!(!CurvineFileSystem::is_full_range_unlock(&lock));
+
+        lock.end = u64::MAX;
+        lock.start = 1;
+        assert!(!CurvineFileSystem::is_full_range_unlock(&lock));
+    }
 
     #[test]
     fn userspace_open_checks_only_unambiguous_write_modes() {

--- a/curvine-fuse/src/fs/plock_wait_registry.rs
+++ b/curvine-fuse/src/fs/plock_wait_registry.rs
@@ -64,10 +64,14 @@ impl PlockWaitRegistry {
         Self::reaches_waiter(&map, waiter, blocked_by)
     }
 
-    /// Atomically check for a wait cycle and register `waiter -> blocked_by`.
+    /// Atomically replace `waiter -> blocked_by` and detect a wait cycle.
     /// Returns true when the edge would close a cycle (EDEADLK).
     pub fn try_register_blocked_by(&self, waiter: LockOwner, blocked_by: LockOwner) -> bool {
         let mut map = self.waiters.lock().expect("plock wait registry poisoned");
+        // Drop any prior edge for this waiter before walking the graph so a
+        // stale self-edge cannot create a false cycle, and so the new blocker
+        // is published atomically with the deadlock check.
+        map.remove(&waiter);
         if Self::reaches_waiter(&map, &waiter, &blocked_by) {
             return true;
         }

--- a/curvine-fuse/src/fs/state/backend_handle.rs
+++ b/curvine-fuse/src/fs/state/backend_handle.rs
@@ -24,12 +24,31 @@ use orpc::err_box;
 use orpc::sync::AtomicCounter;
 use orpc::sys::RawPtr;
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::sync::Arc;
 
+/// Per-handle lock-owner bookkeeping.
+///
+/// POSIX locks are keyed by FUSE `lock_owner`. After `fork`, parent and child can
+/// share one FUSE fh while using distinct lock_owners, so plock owners are a set.
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct HandleLock {
     pub flock_owner_id: Option<u64>,
-    pub plock_owner_id: Option<u64>,
+    /// Active POSIX lock_owners that acquired a lock through this handle.
+    #[serde(default)]
+    pub plock_owners: HashSet<u64>,
+    /// Legacy single-owner field kept for state restore compatibility.
+    #[serde(default)]
+    plock_owner_id: Option<u64>,
+}
+
+impl HandleLock {
+    /// Merge legacy `plock_owner_id` into `plock_owners` after deserialize.
+    fn migrate_legacy_plock_owner(&mut self) {
+        if let Some(owner) = self.plock_owner_id.take() {
+            self.plock_owners.insert(owner);
+        }
+    }
 }
 
 pub struct BackendHandle {
@@ -182,13 +201,14 @@ impl BackendHandle {
         *self.status.write().unwrap() = status;
     }
 
-    // Add lock, only save the owner_id of the first lock
+    /// Record that `owner_id` holds a lock of `lock_flags` on this handle.
     pub fn add_lock(&self, lock_flags: LockFlags, owner_id: u64) {
         let mut fh_locks = self.fh_locks.lock().unwrap();
+        fh_locks.migrate_legacy_plock_owner();
 
         match lock_flags {
             LockFlags::Plock => {
-                fh_locks.plock_owner_id.get_or_insert(owner_id);
+                fh_locks.plock_owners.insert(owner_id);
             }
 
             LockFlags::Flock => {
@@ -197,22 +217,41 @@ impl BackendHandle {
         }
     }
 
+    /// Remove and return one tracked owner for `typ`.
+    ///
+    /// For POSIX locks, prefer [`Self::take_plock_if_owner`] or
+    /// [`Self::drain_plock_owners`] when the caller knows the owner set.
     pub fn remove_lock(&self, typ: LockFlags) -> Option<u64> {
         let mut fh_locks = self.fh_locks.lock().unwrap();
+        fh_locks.migrate_legacy_plock_owner();
 
         match typ {
-            LockFlags::Plock => fh_locks.plock_owner_id.take(),
+            LockFlags::Plock => {
+                let owner = fh_locks.plock_owners.iter().copied().next()?;
+                fh_locks.plock_owners.remove(&owner);
+                Some(owner)
+            }
 
             LockFlags::Flock => fh_locks.flock_owner_id.take(),
         }
     }
 
+    /// Remove `owner_id` from the POSIX owner set when present.
     pub fn take_plock_if_owner(&self, owner_id: u64) -> Option<u64> {
         let mut fh_locks = self.fh_locks.lock().unwrap();
-        match fh_locks.plock_owner_id {
-            Some(tracked) if tracked == owner_id => fh_locks.plock_owner_id.take(),
-            _ => None,
+        fh_locks.migrate_legacy_plock_owner();
+        if fh_locks.plock_owners.remove(&owner_id) {
+            Some(owner_id)
+        } else {
+            None
         }
+    }
+
+    /// Drain every tracked POSIX lock_owner (used on handle release).
+    pub fn drain_plock_owners(&self) -> Vec<u64> {
+        let mut fh_locks = self.fh_locks.lock().unwrap();
+        fh_locks.migrate_legacy_plock_owner();
+        fh_locks.plock_owners.drain().collect()
     }
 
     pub async fn persist(&self, writer: &mut StateWriter) -> FuseResult<()> {
@@ -225,7 +264,8 @@ impl BackendHandle {
         writer.write_struct(&self.writer.is_some())?;
         writer.write_struct(&self.reader.is_some())?;
 
-        let locks = self.fh_locks.lock().unwrap();
+        let mut locks = self.fh_locks.lock().unwrap();
+        locks.migrate_legacy_plock_owner();
         writer.write_struct(&*locks)?;
 
         Ok(())
@@ -245,7 +285,8 @@ impl BackendHandle {
                 status.path
             );
         }
-        let locks: HandleLock = reader.read_struct()?;
+        let mut locks: HandleLock = reader.read_struct()?;
+        locks.migrate_legacy_plock_owner();
 
         let path = Path::from_str(&status.path)?;
         let writer = if has_writer {
@@ -347,5 +388,59 @@ mod tests {
             "status().len must reflect the reopened file, not the open-time 100"
         );
         assert_eq!(handle.status().mtime, 20);
+    }
+
+    #[test]
+    fn plock_tracks_multiple_owners_on_shared_handle() {
+        use curvine_common::state::{FileStatus, LockFlags};
+
+        let handle = BackendHandle::new(
+            1,
+            10,
+            None,
+            None,
+            FileStatus::with_name(1, "f".into(), false),
+        );
+        handle.add_lock(LockFlags::Plock, 11);
+        handle.add_lock(LockFlags::Plock, 22);
+
+        assert_eq!(handle.take_plock_if_owner(22), Some(22));
+        assert_eq!(handle.take_plock_if_owner(22), None);
+        assert_eq!(handle.take_plock_if_owner(11), Some(11));
+        assert!(handle.drain_plock_owners().is_empty());
+    }
+
+    #[test]
+    fn drain_plock_owners_returns_all_tracked_owners() {
+        use curvine_common::state::{FileStatus, LockFlags};
+
+        let handle = BackendHandle::new(
+            1,
+            10,
+            None,
+            None,
+            FileStatus::with_name(1, "f".into(), false),
+        );
+        handle.add_lock(LockFlags::Plock, 7);
+        handle.add_lock(LockFlags::Plock, 8);
+        let mut owners = handle.drain_plock_owners();
+        owners.sort_unstable();
+        assert_eq!(owners, vec![7, 8]);
+        assert!(handle.drain_plock_owners().is_empty());
+    }
+
+    #[test]
+    fn legacy_single_plock_owner_migrates_into_set() {
+        use super::HandleLock;
+        use std::collections::HashSet;
+
+        let mut locks = HandleLock {
+            flock_owner_id: None,
+            plock_owners: HashSet::new(),
+            plock_owner_id: Some(99),
+        };
+        locks.migrate_legacy_plock_owner();
+        assert!(locks.plock_owners.contains(&99));
+        assert!(locks.plock_owner_id.is_none());
     }
 }

--- a/curvine-fuse/src/fs/state/file_handle.rs
+++ b/curvine-fuse/src/fs/state/file_handle.rs
@@ -113,6 +113,12 @@ impl FileHandle {
         }
     }
 
+    pub fn drain_plock_owners(&self) -> Vec<u64> {
+        match self {
+            FileHandle::Backend(h) => h.drain_plock_owners(),
+        }
+    }
+
     pub async fn resize(&self, opts: FileAllocOpts) -> FuseResult<()> {
         match self {
             FileHandle::Backend(h) => {


### PR DESCRIPTION
<!-- curvine-automation:pr:CurvineIO/curvine:1363 -->

# Summary

Fix POSIX advisory lock ownership tracking for fork-shared FUSE file handles so flush/close unlocks every recorded owner, and tighten SETLKW wait-edge registration to avoid clearing the blocked-by edge before the next lock attempt.

# Issue Describe / Design

Closes #1363

## Root cause

1. `BackendHandle` stored a single optional plock owner. After `fork()`, parent and child share the same FUSE file handle; only the first owner was recorded, so a later `FUSE_FLUSH`/`release` could skip Master unlock for the other process and leave a stale `RDLCK` (LTP `fcntl14` / `fcntl14_64`: parent `EAGAIN`, `GETLK` `pid=0`).
2. `set_lkw` cleared the blocked-by edge before re-registering on each retry, widening the window where deadlock edges were missing (LTP `fcntl17` / `fcntl17_64`).

## Fix approach

- Track multiple plock owners per handle (`HashSet`), with legacy single-owner migration.
- On flush, unlock the flush request owner when present; on release, drain and unlock all owners.
- Full-range `F_UNLCK` drops owner tracking; unlock paths no longer re-add owners.
- Prefer `header.pid` when building lock identity for GETLK consistency.
- Register SETLKW wait edges atomically (replace previous edge) without clearing at the start of each loop iteration.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-fuse/src/fs/state/backend_handle.rs` | Multi-owner `plock_owners` set, legacy migrate, drain helpers | Behavior change: all recorded owners unlock on release |
| `curvine-fuse/src/fs/state/file_handle.rs` | Forward `drain_plock_owners` | None beyond handle API |
| `curvine-fuse/src/fs/curvine_file_system.rs` | Multi-owner unlock, flush/release, GETLK pid fallback, SETLKW loop | Behavior change: correct unlock/deadlock edge handling |
| `curvine-fuse/src/fs/plock_wait_registry.rs` | Atomic `try_register_blocked_by` edge replace | Behavior change: narrower deadlock-detection race |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-fuse --lib plock_` | PASS | Multi-owner / legacy migration unit tests |
| `make format` | PASS | fmt + clippy project gates |
| Focused LTP fcntl lock reproducer ×2 on tested SHA | PASS (reproduced) | `fcntl14` failures matched prior signature |
| Same reproducer ×1 on non-FUSE reference FS | PASS | Rules out LTP/env-only failure |
| Same reproducer ×3 on fixed HEAD | PASS | All attempts green |
| Full LTP profile on fixed HEAD | PASS for assigned cases | `fcntl14` / `fcntl17` / `fcntl17_64` absent; no new attributed failures vs baseline |

# Dependencies

- Related PRs: historical #1230, #1263, #1339 (merged; complementary lock semantics work)
- Related issues: #1363
- Blocks / blocked by: None

<!-- curvine-automation: issue=1363 head=fix/fuse-fcntl-lock-semantics -->
