### PR TITLE
refactor(orpc): decouple infrastructure layer boundaries (#1243)

### DIFF
--- a/curvine-fuse/src/fuse_utils.rs
+++ b/curvine-fuse/src/fuse_utils.rs
@@ -226,7 +226,7 @@ impl FuseUtils {
             if let Err(ce) = sys::close(clone_fd) {
                 log::warn!("fuse_clone_fd: close leaked fd {} failed: {}", clone_fd, ce);
             }
-            return Err(e);
+            return Err(e.into());
         }
 
         Ok(clone_fd)

--- a/curvine-fuse/src/session/channel/fuse_receiver.rs
+++ b/curvine-fuse/src/session/channel/fuse_receiver.rs
@@ -186,7 +186,7 @@ impl<T: FileSystem> FuseReceiver<T> {
                 // Recoverable (real errno): the loop may `continue` to the next
                 // frame, so drain the stale bytes that would otherwise poison it.
                 Self::drain_pipe(pipe2);
-                return Err(err);
+                return Err(err.into());
             }
         };
         if write_len != read_len {
@@ -208,7 +208,7 @@ impl<T: FileSystem> FuseReceiver<T> {
                 Ok(n) if n > 0 => continue,
                 Ok(_) => break,
                 Err(err) => {
-                    if err.raw_error().raw_os_error() == Some(EINTR) {
+                    if err.raw_os_error() == Some(EINTR) {
                         continue;
                     }
                     break;

--- a/curvine-fuse/src/session/channel/fuse_sender.rs
+++ b/curvine-fuse/src/session/channel/fuse_sender.rs
@@ -224,12 +224,12 @@ impl<T: FileSystem> FuseSender<T> {
         let (len, iovec) = rep.as_iovec()?;
         if let Err(e) = pipe2.write_iov(len, &iovec).await {
             Self::drain_pipe(pipe2);
-            return Err(e);
+            return Err(e.into());
         }
 
         if let Err(e) = pipe2.read_io(&self.kernel_fd, len).await {
             Self::drain_pipe(pipe2);
-            return Err(e);
+            return Err(e.into());
         }
 
         Ok(())
@@ -246,7 +246,7 @@ impl<T: FileSystem> FuseSender<T> {
                 Ok(n) if n > 0 => continue,
                 Ok(_) => break, // EOF
                 Err(e) => {
-                    if e.raw_error().raw_os_error() == Some(libc::EINTR) {
+                    if e.raw_os_error() == Some(libc::EINTR) {
                         continue; // interrupted; retry
                     }
                     // EAGAIN/EWOULDBLOCK: pipe is empty; any other error: stop.

--- a/curvine-server/src/worker/storage/vfs_dir.rs
+++ b/curvine-server/src/worker/storage/vfs_dir.rs
@@ -298,7 +298,7 @@ impl VfsDir {
         if self.storage_type == StorageType::SpdkDisk {
             return Ok(());
         }
-        self.stats.check_dir()
+        Ok(self.stats.check_dir()?)
     }
 
     pub(super) fn allocation_size(&self, requested_bytes: i64) -> Option<i64> {

--- a/orpc/src/handler/rpc_frame.rs
+++ b/orpc/src/handler/rpc_frame.rs
@@ -104,7 +104,7 @@ impl RpcFrame {
             }
 
             DataSlice::IOSlice(io) => {
-                sys::send_file_full(self, io.raw_io(), io.off(), io.len()).await?;
+                self.send_file_full(io.raw_io(), io.off(), io.len()).await?;
                 Ok(())
             }
 
@@ -118,6 +118,31 @@ impl RpcFrame {
                 Ok(())
             }
         }
+    }
+
+    async fn send_file_full(
+        &self,
+        fd_in: sys::RawIO,
+        mut off: Option<i64>,
+        len: usize,
+    ) -> IOResult<()> {
+        let fd_out = sys::get_raw_io(self)?;
+        let mut remaining = len;
+        while remaining > 0 {
+            let result = self
+                .async_write(|| {
+                    sys::send_file(fd_in, fd_out, off.as_mut(), remaining).map_err(Into::into)
+                })
+                .await;
+
+            match result {
+                Ok(0) => return err_box!("send_file returned 0"),
+                Ok(transferred) => remaining -= transferred as usize,
+                Err(error) if error.is_would_block() => continue,
+                Err(error) => return Err(error),
+            }
+        }
+        Ok(())
     }
 
     pub fn io(&self) -> &TcpStream {

--- a/orpc/src/io/local_file.rs
+++ b/orpc/src/io/local_file.rs
@@ -286,7 +286,7 @@ impl LocalFile {
 
     pub fn actual_size(&self) -> IOResult<u64> {
         let meta = self.inner.metadata()?;
-        Ok(sys::file_actual_size(meta)?)
+        sys::file_actual_size(meta).map_err(Into::into)
     }
 
     pub fn metadata(&self) -> IOResult<Metadata> {

--- a/orpc/src/io/local_file.rs
+++ b/orpc/src/io/local_file.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::io::IOResult;
-use crate::sys::{self, CacheManager, DataSlice, ReadAheadTask};
+use crate::sys::{self, CacheManager, DataSlice, RawIOSlice, ReadAheadTask};
 use crate::{err_box, try_err};
 use bytes::BytesMut;
 use serde::de::DeserializeOwned;
@@ -110,7 +110,19 @@ impl LocalFile {
             );
         }
 
-        let region = DataSlice::from_file(self, enable_send_file, Some(self.pos), chunk as i32)?;
+        #[cfg(not(target_os = "linux"))]
+        let region = DataSlice::Buffer(self.read_full(Some(self.pos), chunk as usize)?);
+
+        #[cfg(target_os = "linux")]
+        let region = if enable_send_file {
+            DataSlice::IOSlice(RawIOSlice::new(
+                sys::get_raw_io(self)?,
+                Some(self.pos),
+                chunk as usize,
+            ))
+        } else {
+            DataSlice::Buffer(self.read_full(Some(self.pos), chunk as usize)?)
+        };
 
         self.pos += chunk;
         Ok(region)
@@ -274,7 +286,7 @@ impl LocalFile {
 
     pub fn actual_size(&self) -> IOResult<u64> {
         let meta = self.inner.metadata()?;
-        sys::file_actual_size(meta)
+        Ok(sys::file_actual_size(meta)?)
     }
 
     pub fn metadata(&self) -> IOResult<Metadata> {

--- a/orpc/src/io/retry/time_bounded_retry.rs
+++ b/orpc/src/io/retry/time_bounded_retry.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::client::ClientConf;
 use std::time::{Duration, Instant};
 
 #[derive(Debug)]
@@ -86,14 +85,6 @@ impl TimeBondedRetryBuilder {
             min_sleep,
             max_sleep,
         }
-    }
-
-    pub fn from_conf(conf: &ClientConf) -> Self {
-        Self::new(
-            Duration::from_millis(conf.io_retry_max_duration_ms),
-            Duration::from_millis(conf.io_retry_min_sleep_ms),
-            Duration::from_millis(conf.io_retry_max_sleep_ms),
-        )
     }
 
     pub fn build(&self) -> TimeBondedRetry {

--- a/orpc/src/sys/cache_manager.rs
+++ b/orpc/src/sys/cache_manager.rs
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::io::IOResult;
 use crate::sys;
-use crate::sys::CInt;
+use crate::sys::{CInt, SysResult};
 use std::fs::File;
 
 const LONG_READ_THRESHOLD_LEN: i64 = 256 * 1024;
@@ -24,7 +23,7 @@ const LONG_READ_THRESHOLD_LEN: i64 = 256 * 1024;
 pub struct ReadAheadTask {
     off: i64,
     len: i64,
-    handle: IOResult<CInt>,
+    handle: SysResult<CInt>,
     last_read_off: i64,
 }
 

--- a/orpc/src/sys/data_slice.rs
+++ b/orpc/src/sys/data_slice.rs
@@ -14,14 +14,9 @@
 
 #![allow(unused, clippy::should_implement_trait)]
 
-use crate::handler::RpcFrame;
-use crate::io::{IOResult, LocalFile};
-use crate::sys;
 use crate::sys::DataSlice::{Buffer, Bytes, Empty, IOSlice, MemSlice};
 use crate::sys::{RawIO, RawIOSlice, RawVec};
-use crate::CommonResult;
 use bytes::{Buf, Bytes as TBytes, BytesMut};
-use std::fs::File;
 
 /// A data fragment, which represents a portion of the data on top of an IO stream.
 /// In many cases, in order to reduce memory copying, data reading and writing will not occur when creating data fragments.
@@ -79,60 +74,6 @@ impl DataSlice {
 
     pub fn is_empty(&self) -> bool {
         self.len() == 0
-    }
-
-    // Create a network data fragment.
-    pub async fn from_frame(frame: &mut RpcFrame, enable_splice: bool, len: i32) -> IOResult<Self> {
-        if len <= 0 {
-            return Ok(Empty);
-        }
-
-        #[cfg(not(target_os = "linux"))]
-        {
-            let buf = frame.read_full(len).await?;
-            Ok(Buffer(buf))
-        }
-
-        #[cfg(target_os = "linux")]
-        {
-            if enable_splice {
-                let fd = sys::get_raw_io(frame)?;
-                Ok(IOSlice(RawIOSlice::new(fd, None, len as usize)))
-            } else {
-                let buf = frame.read_full(len).await?;
-                Ok(Buffer(buf))
-            }
-        }
-    }
-
-    // Create a file data fragment.
-    // Usually created in business threads, it is a synchronization function.
-    pub fn from_file(
-        file: &mut LocalFile,
-        enable_send_file: bool,
-        off: Option<i64>,
-        len: i32,
-    ) -> CommonResult<Self> {
-        if len <= 0 {
-            return Ok(Empty);
-        }
-
-        #[cfg(not(target_os = "linux"))]
-        {
-            let buf = file.read_full(off, len as usize)?;
-            Ok(Buffer(buf))
-        }
-
-        #[cfg(target_os = "linux")]
-        {
-            if enable_send_file {
-                let fd = sys::get_raw_io(file)?;
-                Ok(IOSlice(RawIOSlice::new(fd, off, len as usize)))
-            } else {
-                let buf = file.read_full(off, len as usize)?;
-                Ok(Buffer(buf))
-            }
-        }
     }
 
     pub fn to_error_msg(&self) -> String {

--- a/orpc/src/sys/ffi_utils.rs
+++ b/orpc/src/sys/ffi_utils.rs
@@ -14,24 +14,27 @@
 
 #![allow(clippy::not_unsafe_ptr_arg_deref, unused)]
 
-use crate::io::IOResult;
-use crate::sys::{CChar, CStr, CString};
+use crate::sys::{CChar, CStr, CString, SysResult};
 use std::ffi::OsStr;
 
 pub struct FFIUtils;
 
 impl FFIUtils {
-    pub fn ptr_to_string(ptr: *const CChar) -> IOResult<String> {
+    pub fn ptr_to_string(ptr: *const CChar) -> SysResult<String> {
         if ptr.is_null() {
             return Ok("".to_string());
         }
 
-        let str = unsafe { CStr::from_ptr(ptr).to_str()? };
+        let str = unsafe {
+            CStr::from_ptr(ptr)
+                .to_str()
+                .map_err(std::io::Error::other)?
+        };
         Ok(str.to_string())
     }
 
     // iAfter into_raw, Rust will not recycle memory and needs to be manually released by itself
-    pub fn string_to_ptr(str: impl AsRef<str>) -> IOResult<*mut CChar> {
+    pub fn string_to_ptr(str: impl AsRef<str>) -> SysResult<*mut CChar> {
         let string = CString::new(str.as_ref())?;
         Ok(string.into_raw())
     }

--- a/orpc/src/sys/fs_stats.rs
+++ b/orpc/src/sys/fs_stats.rs
@@ -81,7 +81,11 @@ impl FsStats {
         let m = self.path.metadata()?;
 
         if !m.is_dir() || m.permissions().readonly() {
-            return sys_error!("Directory is not writable: {:?}", self.path());
+            return sys_error!(
+                std::io::ErrorKind::PermissionDenied,
+                "Directory is not writable: {:?}",
+                self.path()
+            );
         }
 
         let new_device_id = sys::get_device_id(self.path());

--- a/orpc/src/sys/fs_stats.rs
+++ b/orpc/src/sys/fs_stats.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{err_box, sys, try_err, try_log, CommonResult};
+use crate::sys::{self, SysResult};
 use log::warn;
 use std::path::{Path, PathBuf};
 
@@ -61,15 +61,15 @@ impl FsStats {
     }
 
     pub fn total_space(&self) -> u64 {
-        try_log!(fs2::total_space(self.path()), 0)
+        Self::space_or_zero(fs2::total_space(self.path()))
     }
 
     pub fn free_space(&self) -> u64 {
-        try_log!(fs2::free_space(self.path()), 0)
+        Self::space_or_zero(fs2::free_space(self.path()))
     }
 
     pub fn available_space(&self) -> u64 {
-        try_log!(fs2::available_space(self.path()), 0)
+        Self::space_or_zero(fs2::available_space(self.path()))
     }
 
     pub fn used_space(&self) -> u64 {
@@ -77,11 +77,11 @@ impl FsStats {
         used.unwrap_or(0)
     }
 
-    pub fn check_dir(&self) -> CommonResult<()> {
-        let m = try_err!(self.path.metadata());
+    pub fn check_dir(&self) -> SysResult<()> {
+        let m = self.path.metadata()?;
 
         if !m.is_dir() || m.permissions().readonly() {
-            return err_box!("Directory is not writable: {:?}", self.path());
+            return sys_error!("Directory is not writable: {:?}", self.path());
         }
 
         let new_device_id = sys::get_device_id(self.path());
@@ -92,11 +92,20 @@ impl FsStats {
 
         Ok(())
     }
+
+    fn space_or_zero(result: SysResult<u64>) -> u64 {
+        match result {
+            Ok(value) => value,
+            Err(error) => {
+                warn!("{}", error);
+                0
+            }
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::common::ByteUnit;
     use crate::sys::FsStats;
 
     #[test]
@@ -105,10 +114,10 @@ mod tests {
         println!(
             "path = {:?}, total_space = {}, free_space = {}, available_space = {}, len = {}",
             fs.path(),
-            ByteUnit::byte_to_string(fs.total_space()),
-            ByteUnit::byte_to_string(fs.free_space()),
-            ByteUnit::byte_to_string(fs.available_space()),
-            ByteUnit::byte_to_string(fs.len()),
+            fs.total_space(),
+            fs.free_space(),
+            fs.available_space(),
+            fs.len(),
         )
     }
 }

--- a/orpc/src/sys/fs_stats.rs
+++ b/orpc/src/sys/fs_stats.rs
@@ -80,7 +80,15 @@ impl FsStats {
     pub fn check_dir(&self) -> SysResult<()> {
         let m = self.path.metadata()?;
 
-        if !m.is_dir() || m.permissions().readonly() {
+        if !m.is_dir() {
+            return sys_error!(
+                std::io::ErrorKind::NotADirectory,
+                "Not a directory: {:?}",
+                self.path()
+            );
+        }
+
+        if m.permissions().readonly() {
             return sys_error!(
                 std::io::ErrorKind::PermissionDenied,
                 "Directory is not writable: {:?}",

--- a/orpc/src/sys/mod.rs
+++ b/orpc/src/sys/mod.rs
@@ -18,26 +18,27 @@ pub type SysResult<T> = std::io::Result<T>;
 // failure has a category callers can branch on (unsupported platform, bad argument, EOF).
 macro_rules! sys_error {
     ($kind:path, $message:literal) => {
-        Err(std::io::Error::new($kind, $message))
+        Err(::std::io::Error::new($kind, $message))
     };
     ($kind:path, $format:literal, $($arg:expr),+ $(,)?) => {
-        Err(std::io::Error::new($kind, format!($format, $($arg),+)))
+        Err(::std::io::Error::new($kind, format!($format, $($arg),+)))
     };
     ($message:expr) => {
-        Err(std::io::Error::other($message))
+        Err(::std::io::Error::other($message))
     };
     ($format:expr, $($arg:expr),+ $(,)?) => {
-        Err(std::io::Error::other(format!($format, $($arg),+)))
+        Err(::std::io::Error::other(format!($format, $($arg),+)))
     };
 }
 
+// Fully qualified paths keep the expansion independent of what the call site imports.
 macro_rules! sys_call {
     ($expression:expr) => {{
         let result = $expression;
-        if result as CInt <= ERRNO_SENTINEL {
-            Err(std::io::Error::last_os_error())
+        if result as $crate::sys::CInt <= $crate::sys::ERRNO_SENTINEL {
+            Err(::std::io::Error::last_os_error())
         } else {
-            Ok(result as CInt)
+            Ok(result as $crate::sys::CInt)
         }
     }};
 }

--- a/orpc/src/sys/mod.rs
+++ b/orpc/src/sys/mod.rs
@@ -12,6 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub type SysResult<T> = std::io::Result<T>;
+
+macro_rules! sys_error {
+    ($message:expr) => {
+        Err(std::io::Error::other($message))
+    };
+    ($format:expr, $($arg:expr),+ $(,)?) => {
+        Err(std::io::Error::other(format!($format, $($arg),+)))
+    };
+}
+
+macro_rules! sys_call {
+    ($expression:expr) => {{
+        let result = $expression;
+        if result as CInt <= ERRNO_SENTINEL {
+            Err(std::io::Error::last_os_error())
+        } else {
+            Ok(result as CInt)
+        }
+    }};
+}
+
 mod sys_libc;
 pub use self::sys_libc::*;
 

--- a/orpc/src/sys/mod.rs
+++ b/orpc/src/sys/mod.rs
@@ -14,7 +14,15 @@
 
 pub type SysResult<T> = std::io::Result<T>;
 
+// `Other` is reserved for opaque failures; pass an explicit `ErrorKind` whenever the
+// failure has a category callers can branch on (unsupported platform, bad argument, EOF).
 macro_rules! sys_error {
+    ($kind:path, $message:literal) => {
+        Err(std::io::Error::new($kind, $message))
+    };
+    ($kind:path, $format:literal, $($arg:expr),+ $(,)?) => {
+        Err(std::io::Error::new($kind, format!($format, $($arg),+)))
+    };
     ($message:expr) => {
         Err(std::io::Error::other($message))
     };
@@ -32,6 +40,26 @@ macro_rules! sys_call {
             Ok(result as CInt)
         }
     }};
+}
+
+/// Build a new iovec that skips the first `offset` bytes of `iov`, so a partially
+/// completed vectored transfer can be resumed with the remaining bytes only.
+pub fn skip_iov_bytes<'a>(
+    iov: &'a [std::io::IoSlice<'a>],
+    mut offset: usize,
+) -> Vec<std::io::IoSlice<'a>> {
+    let mut result = Vec::with_capacity(iov.len());
+    for slice in iov {
+        if offset == 0 {
+            result.push(std::io::IoSlice::new(&slice[..]));
+        } else if slice.len() <= offset {
+            offset -= slice.len();
+        } else {
+            result.push(std::io::IoSlice::new(&slice[offset..]));
+            offset = 0;
+        }
+    }
+    result
 }
 
 mod sys_libc;

--- a/orpc/src/sys/pipe/async_fd.rs
+++ b/orpc/src/sys/pipe/async_fd.rs
@@ -14,11 +14,8 @@
 
 #![allow(unused)]
 
-use crate::err_box;
-use crate::io::IOResult;
 use crate::sys::pipe::BorrowedFd;
-use crate::sys::{CInt, RawIO};
-use crate::{io_loop_check, sys};
+use crate::sys::{self, CInt, RawIO, SysResult};
 use std::io::IoSlice;
 use tokio::io::Interest;
 
@@ -38,7 +35,7 @@ type AsyncInner = tokio::io::unix::AsyncFd<BorrowedFd>;
 pub struct AsyncFd(AsyncInner);
 
 impl AsyncFd {
-    pub fn new(fd: BorrowedFd) -> IOResult<AsyncFd> {
+    pub fn new(fd: BorrowedFd) -> SysResult<AsyncFd> {
         #[cfg(not(target_os = "linux"))]
         {
             Ok(AsyncFd(fd))
@@ -47,7 +44,7 @@ impl AsyncFd {
         #[cfg(target_os = "linux")]
         {
             if fd.is_blocking() {
-                err_box!("Blocking pipes cannot use async io")
+                sys_error!("Blocking pipes cannot use async io")
             } else {
                 let async_fd = UnixAsyncFd::new(fd)?;
                 Ok(AsyncFd(async_fd))
@@ -55,7 +52,7 @@ impl AsyncFd {
         }
     }
 
-    pub fn create(fd: BorrowedFd) -> IOResult<Option<AsyncFd>> {
+    pub fn create(fd: BorrowedFd) -> SysResult<Option<AsyncFd>> {
         if fd.is_blocking() {
             Ok(None)
         } else {
@@ -76,10 +73,10 @@ impl AsyncFd {
         }
     }
 
-    pub async fn writable(&self) -> IOResult<()> {
+    pub async fn writable(&self) -> SysResult<()> {
         #[cfg(not(target_os = "linux"))]
         {
-            err_box!("unsupported operation")
+            sys_error!("unsupported operation")
         }
 
         #[cfg(target_os = "linux")]
@@ -89,10 +86,10 @@ impl AsyncFd {
         }
     }
 
-    pub async fn readable(&self) -> IOResult<()> {
+    pub async fn readable(&self) -> SysResult<()> {
         #[cfg(not(target_os = "linux"))]
         {
-            err_box!("unsupported operation")
+            sys_error!("unsupported operation")
         }
 
         #[cfg(target_os = "linux")]
@@ -105,31 +102,25 @@ impl AsyncFd {
     pub async fn async_io<R>(
         &self,
         interest: Interest,
-        mut f: impl FnMut(&BorrowedFd) -> IOResult<R>,
-    ) -> IOResult<R> {
+        mut f: impl FnMut(&BorrowedFd) -> SysResult<R>,
+    ) -> SysResult<R> {
         #[cfg(not(target_os = "linux"))]
         {
-            err_box!("unsupported operation")
+            sys_error!("unsupported operation")
         }
 
         #[cfg(target_os = "linux")]
         {
-            let res = self
-                .0
-                .async_io(interest, |inner| match f(inner) {
-                    Ok(res) => Ok(res),
-                    Err(e) => Err(e.into_raw()),
-                })
-                .await?;
+            let res = self.0.async_io(interest, |inner| f(inner)).await?;
             Ok(res)
         }
     }
 
-    pub async fn async_write<R>(&self, f: impl FnMut(&BorrowedFd) -> IOResult<R>) -> IOResult<R> {
+    pub async fn async_write<R>(&self, f: impl FnMut(&BorrowedFd) -> SysResult<R>) -> SysResult<R> {
         self.async_io(Interest::WRITABLE, f).await
     }
 
-    pub async fn async_read<R>(&self, f: impl FnMut(&BorrowedFd) -> IOResult<R>) -> IOResult<R> {
+    pub async fn async_read<R>(&self, f: impl FnMut(&BorrowedFd) -> SysResult<R>) -> SysResult<R> {
         self.async_io(Interest::READABLE, f).await
     }
 
@@ -147,12 +138,17 @@ impl AsyncFd {
     }
 
     // Write data into fd.
-    pub async fn write_iov(&self, len: usize, iov: &[IoSlice<'_>]) -> IOResult<()> {
+    pub async fn write_iov(&self, len: usize, iov: &[IoSlice<'_>]) -> SysResult<()> {
         let len = len as CInt;
         loop {
             let res = self.async_write(|fd| sys::writev(fd.fd(), iov)).await;
 
-            io_loop_check!(res, len)?;
+            match res {
+                Ok(written) if written == len => break,
+                Ok(written) => return sys_error!("writev returned {}, expected {}", written, len),
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => continue,
+                Err(error) => return Err(error),
+            }
         }
 
         Ok(())

--- a/orpc/src/sys/pipe/async_fd.rs
+++ b/orpc/src/sys/pipe/async_fd.rs
@@ -16,7 +16,7 @@
 
 use crate::sys::pipe::BorrowedFd;
 use crate::sys::{self, CInt, RawIO, SysResult};
-use std::io::IoSlice;
+use std::io::{ErrorKind, IoSlice};
 use tokio::io::Interest;
 
 #[cfg(target_os = "linux")]
@@ -44,7 +44,10 @@ impl AsyncFd {
         #[cfg(target_os = "linux")]
         {
             if fd.is_blocking() {
-                sys_error!("Blocking pipes cannot use async io")
+                sys_error!(
+                    ErrorKind::InvalidInput,
+                    "Blocking pipes cannot use async io"
+                )
             } else {
                 let async_fd = UnixAsyncFd::new(fd)?;
                 Ok(AsyncFd(async_fd))
@@ -76,7 +79,7 @@ impl AsyncFd {
     pub async fn writable(&self) -> SysResult<()> {
         #[cfg(not(target_os = "linux"))]
         {
-            sys_error!("unsupported operation")
+            sys_error!(ErrorKind::Unsupported, "unsupported operation")
         }
 
         #[cfg(target_os = "linux")]
@@ -89,7 +92,7 @@ impl AsyncFd {
     pub async fn readable(&self) -> SysResult<()> {
         #[cfg(not(target_os = "linux"))]
         {
-            sys_error!("unsupported operation")
+            sys_error!(ErrorKind::Unsupported, "unsupported operation")
         }
 
         #[cfg(target_os = "linux")]
@@ -106,7 +109,7 @@ impl AsyncFd {
     ) -> SysResult<R> {
         #[cfg(not(target_os = "linux"))]
         {
-            sys_error!("unsupported operation")
+            sys_error!(ErrorKind::Unsupported, "unsupported operation")
         }
 
         #[cfg(target_os = "linux")]
@@ -137,16 +140,25 @@ impl AsyncFd {
         }
     }
 
-    // Write data into fd.
+    // Write data into fd. A short writev is normal on non-blocking fds, so the
+    // remaining iovec view is advanced and the write resumed until `len` bytes land.
     pub async fn write_iov(&self, len: usize, iov: &[IoSlice<'_>]) -> SysResult<()> {
-        let len = len as CInt;
-        loop {
-            let res = self.async_write(|fd| sys::writev(fd.fd(), iov)).await;
+        let mut written = 0usize;
+        while written < len {
+            let res = if written == 0 {
+                self.async_write(|fd| sys::writev(fd.fd(), iov)).await
+            } else {
+                let remaining = sys::skip_iov_bytes(iov, written);
+                self.async_write(|fd| sys::writev(fd.fd(), &remaining))
+                    .await
+            };
 
             match res {
-                Ok(written) if written == len => break,
-                Ok(written) => return sys_error!("writev returned {}, expected {}", written, len),
-                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => continue,
+                Ok(0) => {
+                    return sys_error!(ErrorKind::WriteZero, "writev returned 0");
+                }
+                Ok(transferred) => written += transferred as usize,
+                Err(error) if error.kind() == ErrorKind::WouldBlock => continue,
                 Err(error) => return Err(error),
             }
         }

--- a/orpc/src/sys/pipe/owned_fd.rs
+++ b/orpc/src/sys/pipe/owned_fd.rs
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::io::IOResult;
 use crate::sys;
-use crate::sys::RawIO;
+use crate::sys::{RawIO, SysResult};
 
 #[cfg(target_os = "linux")]
 use std::os::unix::io::{AsRawFd, RawFd};
@@ -40,7 +39,7 @@ impl OwnedFd {
         BorrowedFd::new(self.0)
     }
 
-    pub fn set_blocking(&self, blocking: bool) -> IOResult<()> {
+    pub fn set_blocking(&self, blocking: bool) -> SysResult<()> {
         sys::set_pipe_blocking(self.0, blocking)
     }
 }

--- a/orpc/src/sys/pipe/pipe2.rs
+++ b/orpc/src/sys/pipe/pipe2.rs
@@ -15,7 +15,7 @@
 use crate::sys::pipe::{AsyncFd, PipeFd, PipePool, PipeReader, PipeWriter};
 use crate::sys::{self, CInt, RawIO, SysResult};
 use log::warn;
-use std::io::IoSlice;
+use std::io::{ErrorKind, IoSlice};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -76,14 +76,14 @@ impl Pipe2 {
 
     pub async fn readable(&self) -> SysResult<()> {
         match self.reader.async_fd() {
-            None => sys_error!("Unsupported operation"),
+            None => sys_error!(ErrorKind::Unsupported, "Unsupported operation"),
             Some(v) => v.readable().await,
         }
     }
 
     pub async fn writable(&self) -> SysResult<()> {
         match self.writer.async_fd() {
-            None => sys_error!("Unsupported operation"),
+            None => sys_error!(ErrorKind::Unsupported, "Unsupported operation"),
             Some(v) => v.writable().await,
         }
     }
@@ -110,6 +110,7 @@ impl Pipe2 {
     pub async fn write_iov(&self, len: usize, iov: &[IoSlice<'_>]) -> SysResult<()> {
         if len > self.buf_size {
             return sys_error!(
+                ErrorKind::InvalidInput,
                 "write_iov: data size {} exceeds pipe buffer size {}",
                 len,
                 self.buf_size
@@ -123,13 +124,13 @@ impl Pipe2 {
                     .async_write(|fd| sys::vm_splice(fd.fd(), iov))
                     .await?
             } else {
-                let cur_iov = Self::skip_iov_bytes(iov, written);
+                let cur_iov = sys::skip_iov_bytes(iov, written);
                 self.writer
                     .async_write(|fd| sys::vm_splice(fd.fd(), &cur_iov))
                     .await?
             };
             if res == 0 {
-                return sys_error!("vmsplice returned 0");
+                return sys_error!(ErrorKind::WriteZero, "vmsplice returned 0");
             }
             written += res as usize;
         }
@@ -142,6 +143,7 @@ impl Pipe2 {
     pub async fn read_io(&self, fd_out: &AsyncFd, len: usize) -> SysResult<()> {
         if len > self.buf_size {
             return sys_error!(
+                ErrorKind::InvalidInput,
                 "read_io: request size {} exceeds pipe buffer size {}",
                 len,
                 self.buf_size
@@ -158,7 +160,7 @@ impl Pipe2 {
             let res =
                 Self::splice_retry(|| sys::splice(fd_in, None, fd_out, None, remaining)).await?;
             if res == 0 {
-                return sys_error!("splice returned 0");
+                return sys_error!(ErrorKind::UnexpectedEof, "splice returned 0");
             }
             remaining -= res as usize;
         }
@@ -233,23 +235,6 @@ impl Pipe2 {
 
     pub fn take_fd(&mut self) -> PipeFd {
         self.pipe_fd.take().unwrap()
-    }
-
-    /// Build a new iovec that skips the first `offset` bytes from `iov`.
-    /// Used by `write_iov` to resume a partially completed vmsplice transfer.
-    fn skip_iov_bytes<'a>(iov: &'a [IoSlice<'a>], mut offset: usize) -> Vec<IoSlice<'a>> {
-        let mut result = Vec::with_capacity(iov.len());
-        for slice in iov {
-            if offset == 0 {
-                result.push(IoSlice::new(&slice[..]));
-            } else if slice.len() <= offset {
-                offset -= slice.len();
-            } else {
-                result.push(IoSlice::new(&slice[offset..]));
-                offset = 0;
-            }
-        }
-        result
     }
 }
 

--- a/orpc/src/sys/pipe/pipe2.rs
+++ b/orpc/src/sys/pipe/pipe2.rs
@@ -12,10 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::io::IOResult;
 use crate::sys::pipe::{AsyncFd, PipeFd, PipePool, PipeReader, PipeWriter};
-use crate::sys::{CInt, RawIO};
-use crate::{err_box, sys};
+use crate::sys::{self, CInt, RawIO, SysResult};
 use log::warn;
 use std::io::IoSlice;
 use std::sync::Arc;
@@ -42,7 +40,7 @@ pub struct Pipe2 {
 }
 
 impl Pipe2 {
-    pub fn new(pipe_fd: PipeFd) -> IOResult<Self> {
+    pub fn new(pipe_fd: PipeFd) -> SysResult<Self> {
         let writer = PipeWriter::new(pipe_fd.write.as_borrowed())?;
         let reader = PipeReader::new(pipe_fd.read.as_borrowed())?;
         let pipe2 = Self {
@@ -76,16 +74,16 @@ impl Pipe2 {
         self.buf_size
     }
 
-    pub async fn readable(&self) -> IOResult<()> {
+    pub async fn readable(&self) -> SysResult<()> {
         match self.reader.async_fd() {
-            None => err_box!("Unsupported operation"),
+            None => sys_error!("Unsupported operation"),
             Some(v) => v.readable().await,
         }
     }
 
-    pub async fn writable(&self) -> IOResult<()> {
+    pub async fn writable(&self) -> SysResult<()> {
         match self.writer.async_fd() {
-            None => err_box!("Unsupported operation"),
+            None => sys_error!("Unsupported operation"),
             Some(v) => v.writable().await,
         }
     }
@@ -100,7 +98,7 @@ impl Pipe2 {
         fd_in: &AsyncFd,
         mut off_in: Option<i64>,
         len: usize,
-    ) -> IOResult<usize> {
+    ) -> SysResult<usize> {
         let fd_out = self.writer.raw_fd();
         let res = fd_in
             .async_read(|fd| sys::splice(fd.fd(), off_in.as_mut(), fd_out, None, len))
@@ -109,9 +107,9 @@ impl Pipe2 {
     }
 
     // Write IoSlice data into the pipeline, iov -> pipe writer.
-    pub async fn write_iov(&self, len: usize, iov: &[IoSlice<'_>]) -> IOResult<()> {
+    pub async fn write_iov(&self, len: usize, iov: &[IoSlice<'_>]) -> SysResult<()> {
         if len > self.buf_size {
-            return err_box!(
+            return sys_error!(
                 "write_iov: data size {} exceeds pipe buffer size {}",
                 len,
                 self.buf_size
@@ -131,7 +129,7 @@ impl Pipe2 {
                     .await?
             };
             if res == 0 {
-                return err_box!("vmsplice returned 0");
+                return sys_error!("vmsplice returned 0");
             }
             written += res as usize;
         }
@@ -141,9 +139,9 @@ impl Pipe2 {
     // Read data in the pipeline, write to the io object, pipe reader -> fd out.
     // Loops to completion: a partial splice (short transfer under SPLICE_F_NONBLOCK)
     // is retried until all bytes are transferred, preventing pipe poisoning (issue #965).
-    pub async fn read_io(&self, fd_out: &AsyncFd, len: usize) -> IOResult<()> {
+    pub async fn read_io(&self, fd_out: &AsyncFd, len: usize) -> SysResult<()> {
         if len > self.buf_size {
-            return err_box!(
+            return sys_error!(
                 "read_io: request size {} exceeds pipe buffer size {}",
                 len,
                 self.buf_size
@@ -160,7 +158,7 @@ impl Pipe2 {
             let res =
                 Self::splice_retry(|| sys::splice(fd_in, None, fd_out, None, remaining)).await?;
             if res == 0 {
-                return err_box!("splice returned 0");
+                return sys_error!("splice returned 0");
             }
             remaining -= res as usize;
         }
@@ -179,7 +177,7 @@ impl Pipe2 {
     // While it keeps hitting EAGAIN it logs a warning every
     // SPLICE_RETRY_WARN_INTERVAL so the otherwise-silent HOL-blocked sender is
     // visible in the field before the watchdog lands.
-    async fn splice_retry(mut f: impl FnMut() -> IOResult<CInt>) -> IOResult<CInt> {
+    async fn splice_retry(mut f: impl FnMut() -> SysResult<CInt>) -> SysResult<CInt> {
         let mut delay = SPLICE_RETRY_MIN;
         // Set on the first EAGAIN; measures how long this call has been stalled
         // on continuous would-block. (Ok / real errors return, so there is no
@@ -190,11 +188,11 @@ impl Pipe2 {
             match f() {
                 Ok(res) => return Ok(res),
                 Err(e) => {
-                    let os = e.raw_error().raw_os_error();
+                    let os = e.raw_os_error();
                     if os == Some(libc::EINTR) {
                         continue;
                     }
-                    if e.is_would_block() {
+                    if e.kind() == std::io::ErrorKind::WouldBlock {
                         let stalled = match eagain_since {
                             Some(start) => start.elapsed(),
                             None => {
@@ -221,7 +219,7 @@ impl Pipe2 {
     }
 
     // Read the data of the pipeline into buf, pipe read -> buf
-    pub async fn read_buf(&self, buf: &mut [u8]) -> IOResult<usize> {
+    pub async fn read_buf(&self, buf: &mut [u8]) -> SysResult<usize> {
         let res = self.reader.async_read(|fd| sys::read(fd.fd(), buf)).await?;
         Ok(res as usize)
     }
@@ -269,17 +267,16 @@ impl Drop for Pipe2 {
 #[cfg(all(test, target_os = "linux"))]
 mod tests {
     use super::Pipe2;
-    use crate::io::{IOError, IOResult};
-    use crate::sys::CInt;
+    use crate::sys::{CInt, SysResult};
     use std::cell::Cell;
     use std::io;
 
-    fn eagain() -> IOError {
-        IOError::new(io::Error::from_raw_os_error(libc::EAGAIN))
+    fn eagain() -> io::Error {
+        io::Error::from_raw_os_error(libc::EAGAIN)
     }
 
-    fn eintr() -> IOError {
-        IOError::new(io::Error::from_raw_os_error(libc::EINTR))
+    fn eintr() -> io::Error {
+        io::Error::from_raw_os_error(libc::EINTR)
     }
 
     // Regression for #1215: on a permanently level-writable fd (/dev/fuse), the
@@ -290,7 +287,7 @@ mod tests {
     #[tokio::test]
     async fn splice_retry_retries_eagain_until_ok() {
         let calls = Cell::new(0u32);
-        let f = || -> IOResult<CInt> {
+        let f = || -> SysResult<CInt> {
             let n = calls.get();
             calls.set(n + 1);
             // First 5 attempts report EAGAIN (would-block), then succeed.
@@ -312,7 +309,7 @@ mod tests {
     #[tokio::test]
     async fn splice_retry_retries_eintr() {
         let calls = Cell::new(0u32);
-        let f = || -> IOResult<CInt> {
+        let f = || -> SysResult<CInt> {
             let n = calls.get();
             calls.set(n + 1);
             if n < 3 {
@@ -331,9 +328,8 @@ mod tests {
     // forever. Uses EPIPE (broken pipe), a real splice failure mode.
     #[tokio::test]
     async fn splice_retry_propagates_real_error() {
-        let f =
-            || -> IOResult<CInt> { Err(IOError::new(io::Error::from_raw_os_error(libc::EPIPE))) };
+        let f = || -> SysResult<CInt> { Err(io::Error::from_raw_os_error(libc::EPIPE)) };
         let err = Pipe2::splice_retry(f).await.unwrap_err();
-        assert_eq!(err.raw_error().raw_os_error(), Some(libc::EPIPE));
+        assert_eq!(err.raw_os_error(), Some(libc::EPIPE));
     }
 }

--- a/orpc/src/sys/pipe/pipe_fd.rs
+++ b/orpc/src/sys/pipe/pipe_fd.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::io::IOResult;
 use crate::sys;
 use crate::sys::pipe::OwnedFd;
+use crate::sys::SysResult;
 
 #[derive(Debug)]
 pub struct PipeFd {
@@ -24,7 +24,7 @@ pub struct PipeFd {
 }
 
 impl PipeFd {
-    pub fn new(buf_size: usize, read_blocking: bool, write_blocking: bool) -> IOResult<Self> {
+    pub fn new(buf_size: usize, read_blocking: bool, write_blocking: bool) -> SysResult<Self> {
         let [read_fd, write_fd] = sys::pipe2(buf_size)?;
         sys::set_pipe_blocking(read_fd, read_blocking)?;
         sys::set_pipe_blocking(write_fd, write_blocking)?;

--- a/orpc/src/sys/pipe/pipe_pool.rs
+++ b/orpc/src/sys/pipe/pipe_pool.rs
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::io::IOResult;
 use crate::sync::AtomicLen;
 use crate::sys::pipe::{Pipe2, PipeFd};
-use crate::sys::PIPE_BUF;
+use crate::sys::{SysResult, PIPE_BUF};
 use log::warn;
 use std::collections::LinkedList;
 use std::sync::Mutex;
@@ -63,7 +62,7 @@ impl PipePool {
         }
     }
 
-    pub fn acquire(&self) -> IOResult<Option<Pipe2>> {
+    pub fn acquire(&self) -> SysResult<Option<Pipe2>> {
         if cfg!(not(target_os = "linux")) {
             return Ok(None);
         }

--- a/orpc/src/sys/pipe/pipe_reader.rs
+++ b/orpc/src/sys/pipe/pipe_reader.rs
@@ -12,10 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::err_box;
-use crate::io::IOResult;
 use crate::sys::pipe::{AsyncFd, BorrowedFd};
-use crate::sys::RawIO;
+use crate::sys::{RawIO, SysResult};
 
 // Read data from the pipeline.
 pub struct PipeReader {
@@ -24,16 +22,16 @@ pub struct PipeReader {
 }
 
 impl PipeReader {
-    pub fn new(fd: BorrowedFd) -> IOResult<Self> {
+    pub fn new(fd: BorrowedFd) -> SysResult<Self> {
         let async_fd = AsyncFd::create(fd)?;
         Ok(Self { fd, async_fd })
     }
 
-    pub async fn async_read<R>(&self, f: impl FnMut(&BorrowedFd) -> IOResult<R>) -> IOResult<R> {
+    pub async fn async_read<R>(&self, f: impl FnMut(&BorrowedFd) -> SysResult<R>) -> SysResult<R> {
         if let Some(fd) = &self.async_fd {
             fd.async_read(f).await
         } else {
-            err_box!("fd is not an asynchronous {}", self.raw_fd())
+            sys_error!("fd is not asynchronous: {}", self.raw_fd())
         }
     }
 

--- a/orpc/src/sys/pipe/pipe_reader.rs
+++ b/orpc/src/sys/pipe/pipe_reader.rs
@@ -31,7 +31,11 @@ impl PipeReader {
         if let Some(fd) = &self.async_fd {
             fd.async_read(f).await
         } else {
-            sys_error!("fd is not asynchronous: {}", self.raw_fd())
+            sys_error!(
+                std::io::ErrorKind::InvalidInput,
+                "fd is not asynchronous: {}",
+                self.raw_fd()
+            )
         }
     }
 

--- a/orpc/src/sys/pipe/pipe_writer.rs
+++ b/orpc/src/sys/pipe/pipe_writer.rs
@@ -12,11 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::err_box;
-use crate::handler::RpcFrame;
-use crate::io::IOResult;
 use crate::sys::pipe::{AsyncFd, BorrowedFd};
-use crate::sys::{self, RawIO};
+use crate::sys::{RawIO, SysResult};
 
 // Write data into the pipeline.
 pub struct PipeWriter {
@@ -25,13 +22,9 @@ pub struct PipeWriter {
 }
 
 impl PipeWriter {
-    pub fn new(fd: BorrowedFd) -> IOResult<Self> {
+    pub fn new(fd: BorrowedFd) -> SysResult<Self> {
         let async_fd = AsyncFd::create(fd)?;
         Ok(Self { fd, async_fd })
-    }
-
-    pub async fn splice_in(&self, io: &RpcFrame, len: usize) -> IOResult<()> {
-        sys::splice_in_full(io, None, self.raw_fd(), None, len).await
     }
 
     pub fn raw_fd(&self) -> RawIO {
@@ -50,11 +43,11 @@ impl PipeWriter {
         self.async_fd.take().map(|x| x.deregister())
     }
 
-    pub async fn async_write<R>(&self, f: impl FnMut(&BorrowedFd) -> IOResult<R>) -> IOResult<R> {
+    pub async fn async_write<R>(&self, f: impl FnMut(&BorrowedFd) -> SysResult<R>) -> SysResult<R> {
         if let Some(fd) = &self.async_fd {
             fd.async_write(f).await
         } else {
-            err_box!("fd is not an asynchronous {}", self.raw_fd())
+            sys_error!("fd is not asynchronous: {}", self.raw_fd())
         }
     }
 }

--- a/orpc/src/sys/pipe/pipe_writer.rs
+++ b/orpc/src/sys/pipe/pipe_writer.rs
@@ -47,7 +47,11 @@ impl PipeWriter {
         if let Some(fd) = &self.async_fd {
             fd.async_write(f).await
         } else {
-            sys_error!("fd is not asynchronous: {}", self.raw_fd())
+            sys_error!(
+                std::io::ErrorKind::InvalidInput,
+                "fd is not asynchronous: {}",
+                self.raw_fd()
+            )
         }
     }
 }

--- a/orpc/src/sys/signal.rs
+++ b/orpc/src/sys/signal.rs
@@ -103,7 +103,11 @@ impl SignalWatch {
                     Ok(async move { ctrl_c.await.ok() }.boxed())
                 }
                 _ => {
-                    sys_error!("signal {:?} not supported on non-Linux platforms", kind)
+                    sys_error!(
+                        std::io::ErrorKind::Unsupported,
+                        "signal {:?} not supported on non-Linux platforms",
+                        kind
+                    )
                 }
             }
         }
@@ -113,7 +117,10 @@ impl SignalWatch {
         kinds: &[SignalKind],
     ) -> SysResult<Vec<(SignalKind, BoxFuture<'static, Option<()>>)>> {
         if kinds.is_empty() {
-            return sys_error!("no signals to create futures for");
+            return sys_error!(
+                std::io::ErrorKind::InvalidInput,
+                "no signals to create futures for"
+            );
         }
 
         let mut futures = Vec::with_capacity(kinds.len());
@@ -129,7 +136,7 @@ impl SignalWatch {
         let fut = Self::signal_future(target)?;
         match fut.await {
             Some(_) => Ok(target),
-            None => sys_error!("signal stream closed"),
+            None => sys_error!(std::io::ErrorKind::BrokenPipe, "signal stream closed"),
         }
     }
 
@@ -152,7 +159,7 @@ impl SignalWatch {
             let ((kind, opt), _, _) = select_all(futures).await;
             match opt {
                 Some(_) => Ok(kind),
-                None => sys_error!("signal stream closed"),
+                None => sys_error!(std::io::ErrorKind::BrokenPipe, "signal stream closed"),
             }
         }
 

--- a/orpc/src/sys/signal.rs
+++ b/orpc/src/sys/signal.rs
@@ -14,8 +14,7 @@
 
 #![allow(unused)]
 
-use crate::err_box;
-use crate::io::IOResult;
+use crate::sys::SysResult;
 use futures::future::{select_all, BoxFuture};
 use futures::FutureExt;
 use std::future::Future;
@@ -78,7 +77,7 @@ impl std::fmt::Display for SignalKind {
 pub struct SignalWatch;
 
 impl SignalWatch {
-    fn signal_future(kind: SignalKind) -> IOResult<BoxFuture<'static, Option<()>>> {
+    fn signal_future(kind: SignalKind) -> SysResult<BoxFuture<'static, Option<()>>> {
         #[cfg(target_os = "linux")]
         {
             use tokio::signal::unix::{signal, SignalKind as TokioSignalKind};
@@ -104,7 +103,7 @@ impl SignalWatch {
                     Ok(async move { ctrl_c.await.ok() }.boxed())
                 }
                 _ => {
-                    err_box!("signal {:?} not supported on non-Linux platforms", kind)
+                    sys_error!("signal {:?} not supported on non-Linux platforms", kind)
                 }
             }
         }
@@ -112,9 +111,9 @@ impl SignalWatch {
 
     fn signal_futures(
         kinds: &[SignalKind],
-    ) -> IOResult<Vec<(SignalKind, BoxFuture<'static, Option<()>>)>> {
+    ) -> SysResult<Vec<(SignalKind, BoxFuture<'static, Option<()>>)>> {
         if kinds.is_empty() {
-            return err_box!("no signals to create futures for");
+            return sys_error!("no signals to create futures for");
         }
 
         let mut futures = Vec::with_capacity(kinds.len());
@@ -126,15 +125,15 @@ impl SignalWatch {
         Ok(futures)
     }
 
-    pub async fn wait_one(target: SignalKind) -> IOResult<SignalKind> {
+    pub async fn wait_one(target: SignalKind) -> SysResult<SignalKind> {
         let fut = Self::signal_future(target)?;
         match fut.await {
             Some(_) => Ok(target),
-            None => err_box!("signal stream closed"),
+            None => sys_error!("signal stream closed"),
         }
     }
 
-    pub async fn wait_quit() -> IOResult<SignalKind> {
+    pub async fn wait_quit() -> SysResult<SignalKind> {
         #[cfg(target_os = "linux")]
         {
             let quit_signals = [
@@ -153,7 +152,7 @@ impl SignalWatch {
             let ((kind, opt), _, _) = select_all(futures).await;
             match opt {
                 Some(_) => Ok(kind),
-                None => err_box!("signal stream closed"),
+                None => sys_error!("signal stream closed"),
             }
         }
 

--- a/orpc/src/sys/sys_libc.rs
+++ b/orpc/src/sys/sys_libc.rs
@@ -14,11 +14,7 @@
 
 #![allow(unused, clippy::not_unsafe_ptr_arg_deref)]
 
-use crate::err_box;
-use crate::handler::RpcFrame;
-use crate::io::{IOResult, LocalFile};
 use crate::sys::*;
-use crate::{err_io, err_msg, try_err, try_option};
 use fs2::FileExt;
 use std::ffi::{CStr, CString};
 use std::fs;
@@ -34,34 +30,34 @@ use std::os::unix::io::AsRawFd;
 
 // Get the file descriptor of an io object (file, network), and for non-linux systems, an error is returned.
 #[cfg(target_os = "linux")]
-pub fn get_raw_io<T>(io: &T) -> IOResult<CInt>
+pub fn get_raw_io<T>(io: &T) -> SysResult<CInt>
 where
     T: AsRawFd,
 {
-    err_io!(io.as_raw_fd())
+    Ok(io.as_raw_fd())
 }
 
 #[cfg(not(target_os = "linux"))]
-pub fn get_raw_io<T>(_: &T) -> IOResult<CInt> {
-    err_box!("Unsupported os")
+pub fn get_raw_io<T>(_: &T) -> SysResult<CInt> {
+    sys_error!("Unsupported os")
 }
 
-pub fn close(raw_io: RawIO) -> IOResult<()> {
+pub fn close(raw_io: RawIO) -> SysResult<()> {
     #[cfg(not(target_os = "linux"))]
     {
-        err_box!("Unsupported close raw id {}", raw_io)
+        sys_error!("Unsupported close raw id {}", raw_io)
     }
 
     #[cfg(target_os = "linux")]
     {
         unsafe {
-            err_io!(libc::close(raw_io))?;
+            sys_call!(libc::close(raw_io))?;
         }
         Ok(())
     }
 }
 
-pub fn close_raw_io(raw_io: RawIO) -> IOResult<()> {
+pub fn close_raw_io(raw_io: RawIO) -> SysResult<()> {
     close(raw_io)
 }
 
@@ -73,10 +69,15 @@ pub fn close_raw_io(raw_io: RawIO) -> IOResult<()> {
 //     offset: *mut off_t,
 //     count: size_t
 // ) -> ssize_t
-pub fn send_file(fd_in: RawIO, fd_out: RawIO, off: Option<&mut i64>, len: usize) -> IOResult<CInt> {
+pub fn send_file(
+    fd_in: RawIO,
+    fd_out: RawIO,
+    off: Option<&mut i64>,
+    len: usize,
+) -> SysResult<CInt> {
     #[cfg(not(target_os = "linux"))]
     {
-        err_box!("unsupported operation")
+        sys_error!("unsupported operation")
     }
 
     #[cfg(target_os = "linux")]
@@ -86,40 +87,8 @@ pub fn send_file(fd_in: RawIO, fd_out: RawIO, off: Option<&mut i64>, len: usize)
             None => std::ptr::null_mut(),
         };
         let res = unsafe { libc::sendfile(fd_out, fd_in, off, len as libc::size_t) };
-        err_io!(res)
+        sys_call!(res)
     }
-}
-
-pub async fn send_file_full(
-    io_out: &RpcFrame,
-    fd_in: RawIO,
-    mut off: Option<i64>,
-    len: usize,
-) -> IOResult<()> {
-    let fd_out = get_raw_io(io_out)?;
-    let mut remaining = len;
-    while remaining > 0 {
-        let res = io_out
-            .async_write(|| send_file(fd_in, fd_out, off.as_mut(), remaining))
-            .await;
-
-        match res {
-            Ok(transferred) => {
-                if transferred == 0 {
-                    return err_box!("send_file return 0");
-                }
-                remaining -= transferred as usize;
-            }
-
-            Err(e) if e.is_would_block() => {
-                continue;
-            }
-
-            Err(e) => return Err(e),
-        }
-    }
-
-    Ok(())
 }
 
 // Linux splice function to copy data between 2 FDs.
@@ -138,10 +107,10 @@ pub fn splice(
     fd_out: RawIO,
     off_out: Option<&mut i64>,
     len: usize,
-) -> IOResult<CInt> {
+) -> SysResult<CInt> {
     #[cfg(not(target_os = "linux"))]
     {
-        err_box!("unsupported operation")
+        sys_error!("unsupported operation")
     }
 
     #[cfg(target_os = "linux")]
@@ -165,7 +134,7 @@ pub fn splice(
                 libc::SPLICE_F_NONBLOCK | libc::SPLICE_F_MOVE,
             )
         };
-        err_io!(res)
+        sys_call!(res)
     }
 }
 
@@ -175,41 +144,14 @@ pub fn splice_out_full(
     fd_out: RawIO,
     mut off_out: Option<i64>,
     len: usize,
-) -> IOResult<()> {
+) -> SysResult<()> {
     let mut remaining = len;
     while remaining > 0 {
         let transferred = splice(fd_in, off_in.as_mut(), fd_out, off_out.as_mut(), remaining)?;
         if transferred == 0 {
-            return err_box!("unsupported operation");
+            return sys_error!("unsupported operation");
         }
         remaining -= transferred as usize;
-    }
-
-    Ok(())
-}
-
-pub async fn splice_in_full(
-    io_in: &RpcFrame,
-    mut off_in: Option<i64>,
-    fd_out: RawIO,
-    mut off_out: Option<i64>,
-    len: usize,
-) -> IOResult<()> {
-    let fd_in = get_raw_io(io_in)?;
-
-    let mut remaining = len;
-    while remaining > 0 {
-        let write_res = io_in
-            .async_read(|| splice(fd_in, off_in.as_mut(), fd_out, off_out.as_mut(), remaining))
-            .await;
-
-        match write_res {
-            Ok(transferred) => remaining -= transferred as usize,
-
-            Err(e) if e.is_would_block() => continue,
-
-            Err(e) => return Err(e),
-        }
     }
 
     Ok(())
@@ -232,32 +174,32 @@ pub fn pipe_is_blocking(fd: RawIO) -> bool {
 }
 
 // Modify the pipeline blocking mode.
-pub fn set_pipe_blocking(fd: RawIO, blocking: bool) -> IOResult<()> {
+pub fn set_pipe_blocking(fd: RawIO, blocking: bool) -> SysResult<()> {
     #[cfg(not(target_os = "linux"))]
     {
-        err_box!("unsupported operation")
+        sys_error!("unsupported operation")
     }
 
     #[cfg(target_os = "linux")]
     {
         unsafe {
-            let status_flags = err_io!(libc::fcntl(fd, libc::F_GETFL))?;
+            let status_flags = sys_call!(libc::fcntl(fd, libc::F_GETFL))?;
             let res = if blocking {
                 libc::fcntl(fd, libc::F_SETFL, status_flags & !libc::O_NONBLOCK)
             } else {
                 libc::fcntl(fd, libc::F_SETFL, status_flags | libc::O_NONBLOCK)
             };
 
-            err_io!(res)?;
+            sys_call!(res)?;
             Ok(())
         }
     }
 }
 
-pub fn pipe2(size: usize) -> IOResult<[RawIO; 2]> {
+pub fn pipe2(size: usize) -> SysResult<[RawIO; 2]> {
     #[cfg(not(target_os = "linux"))]
     {
-        err_box!("unsupported operation")
+        sys_error!("unsupported operation")
     }
 
     #[cfg(target_os = "linux")]
@@ -268,16 +210,16 @@ pub fn pipe2(size: usize) -> IOResult<[RawIO; 2]> {
                 fds.as_mut_ptr() as *mut libc::c_int,
                 libc::O_CLOEXEC | libc::O_NONBLOCK,
             );
-            err_io!(res)?;
+            sys_call!(res)?;
 
             let set_buf_res = libc::fcntl(fds[1], libc::F_SETPIPE_SZ, size);
-            err_io!(set_buf_res)?;
+            sys_call!(set_buf_res)?;
 
             let set_buf_res = libc::fcntl(fds[0], libc::F_SETPIPE_SZ, size);
-            err_io!(set_buf_res)?;
+            sys_call!(set_buf_res)?;
 
             if (set_buf_res as usize) < size {
-                return err_box!(
+                return sys_error!(
                     "Failed to set pipe size, expected: {}, actual: {}",
                     size,
                     set_buf_res
@@ -296,7 +238,7 @@ pub fn pipe2(size: usize) -> IOResult<[RawIO; 2]> {
 //     len: off_t,
 //     advise: c_int
 // ) -> c_int
-pub fn read_ahead(file: &std::fs::File, off: i64, len: i64) -> IOResult<CInt> {
+pub fn read_ahead(file: &std::fs::File, off: i64, len: i64) -> SysResult<CInt> {
     #[cfg(not(target_os = "linux"))]
     {
         Ok(0)
@@ -312,12 +254,12 @@ pub fn read_ahead(file: &std::fs::File, off: i64, len: i64) -> IOResult<CInt> {
                 len as libc::off_t,
                 libc::POSIX_FADV_WILLNEED,
             );
-            err_io!(res)
+            sys_call!(res)
         }
     }
 }
 
-pub fn is_tmpfs(file_path: &str) -> IOResult<bool> {
+pub fn is_tmpfs(file_path: &str) -> SysResult<bool> {
     #[cfg(not(target_os = "linux"))]
     {
         Ok(false)
@@ -326,13 +268,13 @@ pub fn is_tmpfs(file_path: &str) -> IOResult<bool> {
     #[cfg(target_os = "linux")]
     {
         let path = match std::ffi::CString::new(file_path) {
-            Err(e) => return err_box!("CString::new {}", e),
+            Err(e) => return sys_error!("CString::new {}", e),
             Ok(v) => v,
         };
 
         unsafe {
             let mut stat: libc::statfs = std::mem::zeroed();
-            err_io!(libc::statfs(path.as_ptr(), &mut stat))?;
+            sys_call!(libc::statfs(path.as_ptr(), &mut stat))?;
             Ok(stat.f_type == libc::TMPFS_MAGIC)
         }
     }
@@ -345,10 +287,10 @@ pub fn thread_name() -> String {
         .to_string()
 }
 
-pub fn read(fd: RawIO, buf: &mut [u8]) -> IOResult<CInt> {
+pub fn read(fd: RawIO, buf: &mut [u8]) -> SysResult<CInt> {
     #[cfg(not(target_os = "linux"))]
     {
-        err_box!("unsupported operation")
+        sys_error!("unsupported operation")
     }
 
     #[cfg(target_os = "linux")]
@@ -358,11 +300,11 @@ pub fn read(fd: RawIO, buf: &mut [u8]) -> IOResult<CInt> {
             libc::read(fd, buf.as_ptr() as *mut c_void, buf.len() as size_t)
         };
 
-        err_io!(res)
+        sys_call!(res)
     }
 }
 
-pub fn read_full(fd: RawIO, buf: &mut [u8]) -> IOResult<()> {
+pub fn read_full(fd: RawIO, buf: &mut [u8]) -> SysResult<()> {
     let mut remaining = buf.len();
     let mut off = 0;
 
@@ -375,10 +317,10 @@ pub fn read_full(fd: RawIO, buf: &mut [u8]) -> IOResult<()> {
     Ok(())
 }
 
-pub fn writev(fd: RawIO, bufs: &[IoSlice<'_>]) -> IOResult<CInt> {
+pub fn writev(fd: RawIO, bufs: &[IoSlice<'_>]) -> SysResult<CInt> {
     #[cfg(not(target_os = "linux"))]
     {
-        err_box!("unsupported operation")
+        sys_error!("unsupported operation")
     }
 
     #[cfg(target_os = "linux")]
@@ -386,7 +328,7 @@ pub fn writev(fd: RawIO, bufs: &[IoSlice<'_>]) -> IOResult<CInt> {
         let res =
             unsafe { libc::writev(fd, bufs.as_ptr() as *const libc::iovec, bufs.len() as CInt) };
 
-        err_io!(res)
+        sys_call!(res)
     }
 }
 
@@ -420,10 +362,10 @@ pub fn get_gid() -> u32 {
 //     nr_segs: size_t,
 //     flags: c_uint
 // ) -> ssize_t
-pub fn vm_splice(fd: RawIO, iov: &[IoSlice<'_>]) -> IOResult<CInt> {
+pub fn vm_splice(fd: RawIO, iov: &[IoSlice<'_>]) -> SysResult<CInt> {
     #[cfg(not(target_os = "linux"))]
     {
-        err_box!("unsupported operation")
+        sys_error!("unsupported operation")
     }
 
     #[cfg(target_os = "linux")]
@@ -437,7 +379,7 @@ pub fn vm_splice(fd: RawIO, iov: &[IoSlice<'_>]) -> IOResult<CInt> {
             )
         };
 
-        err_io!(res)
+        sys_call!(res)
     }
 }
 
@@ -446,16 +388,16 @@ pub fn vm_splice(fd: RawIO, iov: &[IoSlice<'_>]) -> IOResult<CInt> {
 //     oflag: c_int,
 //     ...
 // ) -> c_int
-pub fn open(path: &CString, flag: i32) -> IOResult<RawIO> {
+pub fn open(path: &CString, flag: i32) -> SysResult<RawIO> {
     #[cfg(not(target_os = "linux"))]
     {
-        err_box!("unsupported operation")
+        sys_error!("unsupported operation")
     }
 
     #[cfg(target_os = "linux")]
     {
         let res = unsafe { libc::open(path.as_ptr(), flag | libc::O_CLOEXEC) };
-        err_io!(res)
+        sys_call!(res)
     }
 }
 
@@ -464,44 +406,44 @@ pub fn open(path: &CString, flag: i32) -> IOResult<RawIO> {
 //     request: c_ulong,
 //     ...
 // ) -> c_int
-pub fn ioctl(fd: RawIO, request: u64, arg: *mut libc::c_void) -> IOResult<CInt> {
+pub fn ioctl(fd: RawIO, request: u64, arg: *mut libc::c_void) -> SysResult<CInt> {
     #[cfg(not(target_os = "linux"))]
     {
-        err_box!("unsupported operation")
+        sys_error!("unsupported operation")
     }
 
     #[cfg(target_os = "linux")]
     {
         let res = unsafe { libc::ioctl(fd, request, arg) };
-        err_io!(res)
+        sys_call!(res)
     }
 }
 
-pub fn dup(fd: RawIO) -> IOResult<RawIO> {
+pub fn dup(fd: RawIO) -> SysResult<RawIO> {
     #[cfg(not(target_os = "linux"))]
     {
-        err_box!("unsupported operation")
+        sys_error!("unsupported operation")
     }
 
     #[cfg(target_os = "linux")]
     {
         let res = unsafe { libc::dup(fd) };
-        err_io!(res)
+        sys_call!(res)
     }
 }
 
 // Get the page size.
 // pub unsafe extern "C" fn sysconf(name: c_int) -> c_long
-pub fn get_pagesize() -> IOResult<usize> {
+pub fn get_pagesize() -> SysResult<usize> {
     #[cfg(not(target_os = "linux"))]
     {
-        err_box!("unsupported operation")
+        sys_error!("unsupported operation")
     }
 
     #[cfg(target_os = "linux")]
     {
         let res = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
-        err_io!(res)?;
+        sys_call!(res)?;
         Ok(res as usize)
     }
 }
@@ -618,14 +560,14 @@ pub fn get_groupname_by_gid(gid: u32) -> Option<String> {
 //     fd: c_int,
 //     length: off64_t,
 // ) -> c_int
-pub fn ftruncate(file: &fs::File, len: i64) -> IOResult<()> {
+pub fn ftruncate(file: &fs::File, len: i64) -> SysResult<()> {
     #[cfg(target_os = "linux")]
     {
         unsafe {
             let fd = get_raw_io(file)?;
             let result = libc::ftruncate64(fd, len as libc::off64_t);
 
-            err_io!(result)?;
+            sys_call!(result)?;
             Ok(())
         }
     }
@@ -643,14 +585,14 @@ pub fn ftruncate(file: &fs::File, len: i64) -> IOResult<()> {
 //     offset: off64_t,
 //     len: off64_t,
 // ) -> c_int
-pub fn fallocate(file: &fs::File, off: i64, len: i64, mode: i32) -> IOResult<()> {
+pub fn fallocate(file: &fs::File, off: i64, len: i64, mode: i32) -> SysResult<()> {
     #[cfg(target_os = "linux")]
     {
         unsafe {
             let fd = get_raw_io(file)?;
             let result = libc::fallocate64(fd, mode, off as libc::off64_t, len as libc::off64_t);
 
-            err_io!(result)?;
+            sys_call!(result)?;
             Ok(())
         }
     }
@@ -665,7 +607,7 @@ pub fn fallocate(file: &fs::File, off: i64, len: i64, mode: i32) -> IOResult<()>
 /// Get the actual size of the file
 /// - If there are no holes in the file, returns the logical file size
 /// - If there are holes, returns the actual disk space occupied
-pub fn file_actual_size(metadata: Metadata) -> IOResult<u64> {
+pub fn file_actual_size(metadata: Metadata) -> SysResult<u64> {
     // 4k
     // 1G
     let logical_size = metadata.len();
@@ -690,28 +632,28 @@ pub fn file_actual_size(metadata: Metadata) -> IOResult<u64> {
     }
 }
 
-pub fn fcntl_get(fd: RawIO) -> IOResult<CInt> {
+pub fn fcntl_get(fd: RawIO) -> SysResult<CInt> {
     #[cfg(target_os = "linux")]
     {
         let res = unsafe { libc::fcntl(fd, libc::F_GETFD) };
-        err_io!(res)
+        sys_call!(res)
     }
 
     #[cfg(not(target_os = "linux"))]
     {
-        err_box!("unsupported operation")
+        sys_error!("unsupported operation")
     }
 }
 
-pub fn fcntl_set(fd: RawIO, flags: CInt) -> IOResult<CInt> {
+pub fn fcntl_set(fd: RawIO, flags: CInt) -> SysResult<CInt> {
     #[cfg(target_os = "linux")]
     {
         let res = unsafe { libc::fcntl(fd, libc::F_SETFD, flags) };
-        err_io!(res)
+        sys_call!(res)
     }
 
     #[cfg(not(target_os = "linux"))]
     {
-        err_box!("unsupported operation")
+        sys_error!("unsupported operation")
     }
 }

--- a/orpc/src/sys/sys_libc.rs
+++ b/orpc/src/sys/sys_libc.rs
@@ -19,7 +19,7 @@ use fs2::FileExt;
 use std::ffi::{CStr, CString};
 use std::fs;
 use std::fs::Metadata;
-use std::io::IoSlice;
+use std::io::{ErrorKind, IoSlice};
 use std::path::Path;
 
 #[cfg(target_os = "linux")]
@@ -39,13 +39,17 @@ where
 
 #[cfg(not(target_os = "linux"))]
 pub fn get_raw_io<T>(_: &T) -> SysResult<CInt> {
-    sys_error!("Unsupported os")
+    sys_error!(ErrorKind::Unsupported, "Unsupported os")
 }
 
 pub fn close(raw_io: RawIO) -> SysResult<()> {
     #[cfg(not(target_os = "linux"))]
     {
-        sys_error!("Unsupported close raw id {}", raw_io)
+        sys_error!(
+            ErrorKind::Unsupported,
+            "Unsupported close raw id {}",
+            raw_io
+        )
     }
 
     #[cfg(target_os = "linux")]
@@ -77,7 +81,7 @@ pub fn send_file(
 ) -> SysResult<CInt> {
     #[cfg(not(target_os = "linux"))]
     {
-        sys_error!("unsupported operation")
+        sys_error!(ErrorKind::Unsupported, "unsupported operation")
     }
 
     #[cfg(target_os = "linux")]
@@ -110,7 +114,7 @@ pub fn splice(
 ) -> SysResult<CInt> {
     #[cfg(not(target_os = "linux"))]
     {
-        sys_error!("unsupported operation")
+        sys_error!(ErrorKind::Unsupported, "unsupported operation")
     }
 
     #[cfg(target_os = "linux")]
@@ -149,7 +153,7 @@ pub fn splice_out_full(
     while remaining > 0 {
         let transferred = splice(fd_in, off_in.as_mut(), fd_out, off_out.as_mut(), remaining)?;
         if transferred == 0 {
-            return sys_error!("unsupported operation");
+            return sys_error!(ErrorKind::UnexpectedEof, "splice returned 0");
         }
         remaining -= transferred as usize;
     }
@@ -177,7 +181,7 @@ pub fn pipe_is_blocking(fd: RawIO) -> bool {
 pub fn set_pipe_blocking(fd: RawIO, blocking: bool) -> SysResult<()> {
     #[cfg(not(target_os = "linux"))]
     {
-        sys_error!("unsupported operation")
+        sys_error!(ErrorKind::Unsupported, "unsupported operation")
     }
 
     #[cfg(target_os = "linux")]
@@ -199,7 +203,7 @@ pub fn set_pipe_blocking(fd: RawIO, blocking: bool) -> SysResult<()> {
 pub fn pipe2(size: usize) -> SysResult<[RawIO; 2]> {
     #[cfg(not(target_os = "linux"))]
     {
-        sys_error!("unsupported operation")
+        sys_error!(ErrorKind::Unsupported, "unsupported operation")
     }
 
     #[cfg(target_os = "linux")]
@@ -254,7 +258,13 @@ pub fn read_ahead(file: &std::fs::File, off: i64, len: i64) -> SysResult<CInt> {
                 len as libc::off_t,
                 libc::POSIX_FADV_WILLNEED,
             );
-            sys_call!(res)
+            // posix_fadvise reports failure by returning a positive errno directly instead
+            // of returning -1 and setting errno, so `sys_call!` must not be used here.
+            if res == 0 {
+                Ok(0)
+            } else {
+                Err(std::io::Error::from_raw_os_error(res))
+            }
         }
     }
 }
@@ -268,7 +278,7 @@ pub fn is_tmpfs(file_path: &str) -> SysResult<bool> {
     #[cfg(target_os = "linux")]
     {
         let path = match std::ffi::CString::new(file_path) {
-            Err(e) => return sys_error!("CString::new {}", e),
+            Err(e) => return sys_error!(ErrorKind::InvalidInput, "CString::new {}", e),
             Ok(v) => v,
         };
 
@@ -290,7 +300,7 @@ pub fn thread_name() -> String {
 pub fn read(fd: RawIO, buf: &mut [u8]) -> SysResult<CInt> {
     #[cfg(not(target_os = "linux"))]
     {
-        sys_error!("unsupported operation")
+        sys_error!(ErrorKind::Unsupported, "unsupported operation")
     }
 
     #[cfg(target_os = "linux")]
@@ -320,7 +330,7 @@ pub fn read_full(fd: RawIO, buf: &mut [u8]) -> SysResult<()> {
 pub fn writev(fd: RawIO, bufs: &[IoSlice<'_>]) -> SysResult<CInt> {
     #[cfg(not(target_os = "linux"))]
     {
-        sys_error!("unsupported operation")
+        sys_error!(ErrorKind::Unsupported, "unsupported operation")
     }
 
     #[cfg(target_os = "linux")]
@@ -365,7 +375,7 @@ pub fn get_gid() -> u32 {
 pub fn vm_splice(fd: RawIO, iov: &[IoSlice<'_>]) -> SysResult<CInt> {
     #[cfg(not(target_os = "linux"))]
     {
-        sys_error!("unsupported operation")
+        sys_error!(ErrorKind::Unsupported, "unsupported operation")
     }
 
     #[cfg(target_os = "linux")]
@@ -391,7 +401,7 @@ pub fn vm_splice(fd: RawIO, iov: &[IoSlice<'_>]) -> SysResult<CInt> {
 pub fn open(path: &CString, flag: i32) -> SysResult<RawIO> {
     #[cfg(not(target_os = "linux"))]
     {
-        sys_error!("unsupported operation")
+        sys_error!(ErrorKind::Unsupported, "unsupported operation")
     }
 
     #[cfg(target_os = "linux")]
@@ -409,7 +419,7 @@ pub fn open(path: &CString, flag: i32) -> SysResult<RawIO> {
 pub fn ioctl(fd: RawIO, request: u64, arg: *mut libc::c_void) -> SysResult<CInt> {
     #[cfg(not(target_os = "linux"))]
     {
-        sys_error!("unsupported operation")
+        sys_error!(ErrorKind::Unsupported, "unsupported operation")
     }
 
     #[cfg(target_os = "linux")]
@@ -422,7 +432,7 @@ pub fn ioctl(fd: RawIO, request: u64, arg: *mut libc::c_void) -> SysResult<CInt>
 pub fn dup(fd: RawIO) -> SysResult<RawIO> {
     #[cfg(not(target_os = "linux"))]
     {
-        sys_error!("unsupported operation")
+        sys_error!(ErrorKind::Unsupported, "unsupported operation")
     }
 
     #[cfg(target_os = "linux")]
@@ -437,7 +447,7 @@ pub fn dup(fd: RawIO) -> SysResult<RawIO> {
 pub fn get_pagesize() -> SysResult<usize> {
     #[cfg(not(target_os = "linux"))]
     {
-        sys_error!("unsupported operation")
+        sys_error!(ErrorKind::Unsupported, "unsupported operation")
     }
 
     #[cfg(target_os = "linux")]
@@ -641,7 +651,7 @@ pub fn fcntl_get(fd: RawIO) -> SysResult<CInt> {
 
     #[cfg(not(target_os = "linux"))]
     {
-        sys_error!("unsupported operation")
+        sys_error!(ErrorKind::Unsupported, "unsupported operation")
     }
 }
 
@@ -654,6 +664,6 @@ pub fn fcntl_set(fd: RawIO, flags: CInt) -> SysResult<CInt> {
 
     #[cfg(not(target_os = "linux"))]
     {
-        sys_error!("unsupported operation")
+        sys_error!(ErrorKind::Unsupported, "unsupported operation")
     }
 }

--- a/orpc/src/sys/sys_libc.rs
+++ b/orpc/src/sys/sys_libc.rs
@@ -224,6 +224,7 @@ pub fn pipe2(size: usize) -> SysResult<[RawIO; 2]> {
 
             if (set_buf_res as usize) < size {
                 return sys_error!(
+                    ErrorKind::InvalidInput,
                     "Failed to set pipe size, expected: {}, actual: {}",
                     size,
                     set_buf_res


### PR DESCRIPTION
# Summary

Decouple low-level `sys` primitives from upper-layer RPC/IO types so subsequent orpc infrastructure extractions can proceed without circular crate dependencies.

# Issue Describe / Design

Related to #1243

This is the first stacked PR in the orpc infrastructure extraction series. Low-level system APIs previously depended on `IOError`, `RpcFrame`, and `LocalFile`, which would create circular dependencies among `curvine-sys`, `curvine-io`, and `orpc-rpc` after extraction.

Design decisions:
- Introduce `SysResult` (`std::io::Result`) for low-level sys APIs so `sys` no longer depends on `io::IOError`.
- Move `send_file_full` specialization from `sys` into `RpcFrame`.
- Move file-slice construction into `LocalFile` instead of `DataSlice::from_file`.
- Remove unused `DataSlice::from_frame` / `DataSlice::from_file` helpers that pulled RPC/IO types into `sys`.
- Remove `TimeBondedRetryBuilder::from_conf(ClientConf)` so retry no longer depends on the client layer (`ClientConf` already builds retry policies via `TimeBondedRetry::new` / `TimeBondedRetryBuilder::new`).

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `orpc/src/sys/**` | Switch sys APIs to `SysResult`; remove RPC/IO reverse deps | Call sites convert `std::io::Error` via `Into`/`?` where needed |
| `orpc/src/handler/rpc_frame.rs` | Host `send_file_full` locally | Behavior preserved |
| `orpc/src/io/local_file.rs` | Inline `DataSlice` construction for sendfile path | Behavior preserved |
| `orpc/src/io/retry/time_bounded_retry.rs` | Drop `from_conf(ClientConf)` | No callers; `ClientConf` already uses duration-based constructors |
| `curvine-fuse/**`, `curvine-server/**` | Adapt to `SysResult` error type | Equivalent error conversion |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `make format` | PASS | format + workspace release clippy |
| `cargo test -p orpc` | PASS | unit, integration, and doc tests |
| `git diff --check` | PASS | |

# Dependencies

- Related PRs: #1334 (orpc-error), #1340 (SPDK adapter)
- Related issues: #1243
- Blocks / blocked by: Base for subsequent stacked extraction PRs (runtime/sys/io/net/rpc)

Made with [Cursor](https://cursor.com)