### PR TITLE
fix(master): defer deletion of writing blocks (#1370)

### DIFF
--- a/curvine-server/src/master/fs/master_filesystem.rs
+++ b/curvine-server/src/master/fs/master_filesystem.rs
@@ -1232,6 +1232,8 @@ impl MasterFilesystem {
         for item in list.blocks {
             match item.status {
                 BlockReportStatus::Finalized | BlockReportStatus::Writing => {
+                    let defer_writing_delete =
+                        item.status == BlockReportStatus::Writing && !list.full_report;
                     let state = match self.block_inode_state(item.id) {
                         Ok(v) => v,
                         Err(e) => {
@@ -1241,6 +1243,18 @@ impl MasterFilesystem {
                     };
                     match state {
                         BlockInodeState::File => checked.push((item, Some(BlockInodeState::File))),
+                        BlockInodeState::Missing if defer_writing_delete => {
+                            warn!(
+                                "block_report deferred deletion for writing block {} on worker {} because its inode is missing",
+                                item.id, list.worker_id
+                            );
+                        }
+                        BlockInodeState::NotFile if defer_writing_delete => {
+                            warn!(
+                                "block_report deferred deletion for writing block {} on worker {} because its inode is not a file",
+                                item.id, list.worker_id
+                            );
+                        }
                         BlockInodeState::Missing => {
                             missing_blocks += 1;
                             delete_blocks.push(item.id);

--- a/curvine-server/tests/master_fs_test.rs
+++ b/curvine-server/tests/master_fs_test.rs
@@ -346,6 +346,90 @@ fn block_report_for_non_file_inode_schedules_worker_delete() -> CommonResult<()>
 }
 
 #[test]
+fn block_report_for_writing_non_file_inode_defers_worker_delete() -> CommonResult<()> {
+    let _serial = master_fs_test_serial();
+    let fs = new_fs(true, "block-report-writing-non-file");
+    fs.mkdir("/dir-block", true)?;
+    let dir_status = fs.file_status("/dir-block")?;
+    let block_id = InodeId::create_block_id(dir_status.id, 0)?;
+
+    let result = fs.block_report(
+        BlockReportList {
+            cluster_id: "curvine".into(),
+            worker_id: 0,
+            full_report: false,
+            total_len: 1,
+            blocks: vec![BlockReportInfo::new(
+                block_id,
+                BlockReportStatus::Writing,
+                StorageType::Disk,
+                1,
+            )],
+        },
+        None,
+    )?;
+
+    assert!(result.delete_blocks.is_empty());
+    Ok(())
+}
+
+#[test]
+fn block_report_for_writing_missing_inode_defers_worker_delete() -> CommonResult<()> {
+    let _serial = master_fs_test_serial();
+    let fs = new_fs(true, "block-report-writing-missing");
+    let file = fs.create("/missing", false)?;
+    fs.delete("/missing", false)?;
+    let block_id = InodeId::create_block_id(file.id, 0)?;
+
+    let result = fs.block_report(
+        BlockReportList {
+            cluster_id: "curvine".into(),
+            worker_id: 0,
+            full_report: false,
+            total_len: 1,
+            blocks: vec![BlockReportInfo::new(
+                block_id,
+                BlockReportStatus::Writing,
+                StorageType::Disk,
+                1,
+            )],
+        },
+        None,
+    )?;
+
+    assert!(result.delete_blocks.is_empty());
+    Ok(())
+}
+
+#[test]
+fn full_block_report_for_writing_missing_inode_schedules_worker_delete() -> CommonResult<()> {
+    let _serial = master_fs_test_serial();
+    let fs = new_fs(true, "full-block-report-writing-missing");
+    let file = fs.create("/missing", false)?;
+    fs.delete("/missing", false)?;
+    let block_id = InodeId::create_block_id(file.id, 0)?;
+
+    let result = fs.block_report(
+        BlockReportList {
+            cluster_id: "curvine".into(),
+            worker_id: 0,
+            full_report: true,
+            total_len: 1,
+            blocks: vec![BlockReportInfo::new(
+                block_id,
+                BlockReportStatus::Writing,
+                StorageType::Disk,
+                1,
+            )],
+        },
+        None,
+    )?;
+
+    assert_eq!(result.delete_blocks, vec![block_id]);
+    Ok(())
+}
+
+#[test]
 fn full_block_report_reconcile_removes_stale_location_async() -> CommonResult<()> {
     let _serial = master_fs_test_serial();
     let fs = new_fs(true, "full-block-reconcile-async");


### PR DESCRIPTION
# Summary

Protect in-flight Worker writes reported incrementally, while preserving full-report cleanup of stale Worker staging blocks.

# Issue Describe / Design

Closes #1370.

Root cause: the original fix deferred deletion for every `Writing` block whose inode was Missing or NotFile. Worker restart recovery reports local `Recovering` blocks as `Writing` in a full block report, so unowned staging blocks could remain indefinitely and consume capacity.

Reproduction: report a `Writing` block for a deleted file inode in a full block report. The previous implementation returned no DeleteBlock command.

Fix: defer deletion only for incremental `Writing` reports, where the Master must not remove an in-flight write. A full report continues through the existing Missing/NotFile deletion path, removing stale recovered staging blocks.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-server/src/master/fs/master_filesystem.rs` | Limit Writing-block deletion deferral to incremental reports | Full reports again delete Missing/NotFile orphan blocks; incremental write protection remains |
| `curvine-server/tests/master_fs_test.rs` | Cover Writing + Missing for incremental and full reports | Guards both sides of the report-mode contract |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-server --test master_fs_test -- --test-threads=1` | PASS | 35 passed |
| `make format` | PASS | Workspace formatting and release clippy checks |
| `git diff --check` | PASS | |

# Dependencies

- Related PRs: None
- Related issues: #1370, #1024
- Blocks / blocked by: None