### PR TITLE
fix(oss-hdfs): preserve async start errors (#1371)

### DIFF
--- a/curvine-ufs/ffi/jindosdk_ffi.cpp
+++ b/curvine-ufs/ffi/jindosdk_ffi.cpp
@@ -45,7 +45,6 @@ thread_local std::string g_last_error;
 
 static constexpr size_t kDefaultFilesystemStoreShards = 16;
 static constexpr size_t kMaxFilesystemStoreShards = 64;
-static constexpr int64_t kFilesystemStoreShardWaitTimeoutMs = 3 * 1000;
 static constexpr int64_t kFilesystemCloseWaitTimeoutMs = 30 * 1000;
 
 struct JindoFileSystemWrapper;
@@ -253,11 +252,7 @@ static bool acquire_operation_ctx(JindoFileSystemWrapper* wrapper, AsyncBase* c)
     }
 
     auto* shard = wrapper->store_shards[start].get();
-    if (!shard->mutex.try_lock_for(
-            std::chrono::milliseconds(kFilesystemStoreShardWaitTimeoutMs))) {
-        g_last_error = "Timed out waiting for OSS-HDFS store shard";
-        return false;
-    }
+    shard->mutex.lock();
 
     bool ok = prepare_store_shard_locked(wrapper, shard, c);
     if (!ok) {
@@ -1529,7 +1524,7 @@ JindoStatus jindo_reader_close_async(JindoReaderHandle reader, JindoStatusCallba
 }
 
 const char* jindo_get_last_error(void) {
-    return g_last_error.c_str();
+    return g_last_error.empty() ? nullptr : g_last_error.c_str();
 }
 
 void jindo_free(void* p) {
@@ -1543,10 +1538,6 @@ size_t jindo_test_default_filesystem_store_shards(void) {
 
 size_t jindo_test_max_filesystem_store_shards(void) {
     return kMaxFilesystemStoreShards;
-}
-
-int64_t jindo_test_filesystem_store_shard_wait_timeout_ms(void) {
-    return kFilesystemStoreShardWaitTimeoutMs;
 }
 
 bool jindo_test_is_reusable_operation_ctx(JindoStatus status) {

--- a/curvine-ufs/ffi/jindosdk_ffi.h
+++ b/curvine-ufs/ffi/jindosdk_ffi.h
@@ -142,7 +142,6 @@ void jindo_free(void* p);
 #ifdef CURVINE_OSS_HDFS_FFI_TEST
 size_t jindo_test_default_filesystem_store_shards(void);
 size_t jindo_test_max_filesystem_store_shards(void);
-int64_t jindo_test_filesystem_store_shard_wait_timeout_ms(void);
 bool jindo_test_is_reusable_operation_ctx(JindoStatus status);
 #endif
 

--- a/curvine-ufs/src/oss_hdfs/oss_hdfs_filesystem.rs
+++ b/curvine-ufs/src/oss_hdfs/oss_hdfs_filesystem.rs
@@ -64,6 +64,11 @@ struct OssHdfsFileSystemInner {
     conf: UfsConf,
 }
 
+struct JindoStartStatus {
+    status: JindoStatus,
+    error: Option<String>,
+}
+
 impl Drop for OssHdfsFileSystemInner {
     fn drop(&mut self) {
         if !self.fs_handle.is_null() {
@@ -235,10 +240,9 @@ impl OssHdfsFileSystem {
     }
 
     /// Execute a blocking JindoSDK filesystem operation outside Tokio worker threads.
-    async fn with_fs_handle_blocking<F, R>(&self, f: F) -> FsResult<R>
+    async fn with_fs_handle_blocking<F>(&self, f: F) -> FsResult<JindoStartStatus>
     where
-        F: FnOnce(*mut c_void) -> R + Send + 'static,
-        R: Send + 'static,
+        F: FnOnce(*mut c_void) -> JindoStatus + Send + 'static,
     {
         if self.inner.fs_handle.is_null() {
             return Err(FsError::common("Filesystem handle is null"));
@@ -249,14 +253,16 @@ impl OssHdfsFileSystem {
             if inner.fs_handle.is_null() {
                 return Err(FsError::common("Filesystem handle is null"));
             }
-            Ok(f(inner.fs_handle.as_raw()))
+            let status = f(inner.fs_handle.as_raw());
+            let error = (status != JindoStatus::Ok).then(jindo_last_error);
+            Ok(JindoStartStatus { status, error })
         })
         .await
         .map_err(|e| FsError::common(format!("OSS-HDFS blocking operation failed: {}", e)))?
     }
 
-    fn check_status(status: JindoStatus, operation: &str) -> FsResult<()> {
-        check_jindo_status(status, operation, None)
+    fn check_status(result: JindoStartStatus, operation: &str) -> FsResult<()> {
+        Self::check_status_with_err(result.status, operation, result.error)
     }
 
     fn check_status_with_err(

--- a/curvine-ufs/tests/oss_hdfs/ffi_pool_tests.rs
+++ b/curvine-ufs/tests/oss_hdfs/ffi_pool_tests.rs
@@ -14,8 +14,6 @@
 
 #[cfg(feature = "oss-hdfs-ffi-test")]
 mod tests {
-    use std::os::raw::c_longlong;
-
     #[repr(C)]
     #[derive(Clone, Copy)]
     enum JindoStatus {
@@ -28,7 +26,6 @@ mod tests {
     extern "C" {
         fn jindo_test_default_filesystem_store_shards() -> usize;
         fn jindo_test_max_filesystem_store_shards() -> usize;
-        fn jindo_test_filesystem_store_shard_wait_timeout_ms() -> c_longlong;
         fn jindo_test_is_reusable_operation_ctx(status: JindoStatus) -> bool;
     }
 
@@ -37,7 +34,6 @@ mod tests {
         unsafe {
             assert_eq!(jindo_test_default_filesystem_store_shards(), 16);
             assert_eq!(jindo_test_max_filesystem_store_shards(), 64);
-            assert_eq!(jindo_test_filesystem_store_shard_wait_timeout_ms(), 3_000);
         }
     }
 


### PR DESCRIPTION
# Summary

Keep OSS-HDFS async-start failures diagnosable across the blocking FFI boundary and replace the fixed shard-acquisition failure with back-pressure.

# Issue Describe / Design

Closes #1371.

Root cause: the native error slot is thread-local. Jindo start calls run in `spawn_blocking`, but the Rust status check ran after await on a Tokio worker and read a different, empty slot. Separately, a saturated shard pool returned a user-visible error after three seconds.

The Rust wrapper now captures the native error on the same blocking thread as the start call. Empty native errors return null so the existing Rust fallback produces a useful message. When all shards are busy, the FFI waits for a shard; that wait occurs in the existing blocking executor, not on a Tokio runtime worker.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-ufs/src/oss_hdfs/oss_hdfs_filesystem.rs` | Capture start status and error together on the blocking thread | Start failures retain their native cause |
| `curvine-ufs/ffi/jindosdk_ffi.cpp` | Return null for empty errors and wait for busy store shards | Removes false task failures caused by the fixed 3 second wait |
| `curvine-ufs/ffi/jindosdk_ffi.h`, `curvine-ufs/tests/oss_hdfs/ffi_pool_tests.rs` | Remove the obsolete timeout test hook | None |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo fmt --all -- --check` | PASS | |
| `git diff --check` | PASS | |
| `cargo check -p curvine-ufs --features oss-hdfs` | Blocked | Local environment does not provide JindoSDK header `jdo_api.h` |

# Dependencies

- Related PRs: #1357
- Related issues: #1371
- Blocks / blocked by: Blocked by #1357