### PR TITLE
fix(build): fix build script failing on macOS due to sed incompatibility (#1379)

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -883,11 +883,8 @@ if [ $BUILD_PYTHON_SDK -eq 1 ]; then
   protoc -I"$PROTO_DIR" --python_out="$PROTO_PKG" "$PROTO_DIR"/*.proto
   for f in "$PROTO_PKG"/*_pb2.py; do
     if [ -f "$f" ]; then
-      if [[ "$OSTYPE" == "darwin"* ]]; then
-        sed -i '' -E 's/^import ([A-Za-z0-9_]+_pb2)( as .*)$/from . import \1\2/' "$f"
-      else
-        sed -i -E 's/^import ([A-Za-z0-9_]+_pb2)( as .*)$/from . import \1\2/' "$f"
-      fi
+      sed -i.bak -E 's/^import ([A-Za-z0-9_]+_pb2)( as .*)$/from . import \1\2/' "$f"
+      rm -f "$f.bak"
     fi
   done
 

--- a/build/build.sh
+++ b/build/build.sh
@@ -883,7 +883,11 @@ if [ $BUILD_PYTHON_SDK -eq 1 ]; then
   protoc -I"$PROTO_DIR" --python_out="$PROTO_PKG" "$PROTO_DIR"/*.proto
   for f in "$PROTO_PKG"/*_pb2.py; do
     if [ -f "$f" ]; then
-      sed -i -E 's/^import ([A-Za-z0-9_]+_pb2)( as .*)$/from . import \1\2/' "$f"
+      if [[ "$OSTYPE" == "darwin"* ]]; then
+        sed -i '' -E 's/^import ([A-Za-z0-9_]+_pb2)( as .*)$/from . import \1\2/' "$f"
+      else
+        sed -i -E 's/^import ([A-Za-z0-9_]+_pb2)( as .*)$/from . import \1\2/' "$f"
+      fi
     fi
   done
 


### PR DESCRIPTION
# Summary

Fix build script failing on macOS due to `sed` incompatibility between BSD and GNU implementations.

# Issue Describe / Design

Closes #1379

**Root cause**: `build/build.sh` uses `sed -i -E`, which is GNU sed syntax. macOS ships BSD sed, where `-i` requires an explicit backup extension argument. The command is parsed as `-i` with backup suffix `-E`, breaking `\1` backreferences.

See attached `man sed` screenshots confirming BSD sed behavior on macOS and Linux.
macOS:
<img width="1103" height="172" alt="image" src="https://github.com/user-attachments/assets/e7c0fc0d-8645-4df8-b8d6-2e0450e9067d" />
Linux:
<img width="726" height="95" alt="image" src="https://github.com/user-attachments/assets/cf6a86f4-7c16-44b8-9e6d-5d9c431cced4" />

**Fix**: Use the portable `sed -i.bak -E` form supported by BSD and GNU sed, then remove the generated backup file. This also works when the `sed` implementation found on `PATH` does not match the host OS.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `build/build.sh` | Use a portable sed in-place edit and clean up its backup | None |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| macOS: `./build/build.sh` | PASS | <img width="1236" height="280" alt="image" src="https://github.com/user-attachments/assets/61a5f6c1-1017-499c-96ff-a0ab65032c47" /> |
| `make format` | PASS | Includes repository pre-commit checks |
| `bash -n build/build.sh` | PASS | Shell syntax validation |
| BSD sed import rewrite and backup cleanup | PASS | Verified generated import output and removal of `.bak` file |

# Dependencies

- Related PRs: None
- Related issues: #1379
- Blocks / blocked by: None