### PR TITLE
fix(fuse): support FUSE_IOCTL_RETRY for FS_IOC_GET/SETFLAGS (#1287)

### DIFF
--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -1004,18 +1004,46 @@ impl fs::FileSystem for CurvineFileSystem {
     async fn ioctl(&self, op: Ioctl<'_>) -> FuseResult<BytesMut> {
         let path = self.state.get_path(op.header.nodeid)?;
         let mut status = self.state.fs_stat(op.header.nodeid, None).await?;
-        let flag_bytes = FuseUtils::ioctl_flag_bytes() as u32;
+        let preferred = FuseUtils::ioctl_flag_bytes() as u32;
+        let min_flag_bytes = 4u32;
+        let unrestricted = (op.arg.flags & FUSE_IOCTL_UNRESTRICTED) != 0;
         let (result, out_flags) = match op.arg.cmd {
             FuseUtils::FS_IOC_GETFLAGS => {
-                if op.arg.out_size < flag_bytes {
-                    return err_fuse!(libc::EINVAL, "ioctl out buffer too small");
+                if op.arg.out_size < min_flag_bytes {
+                    // Empty unrestricted/first-pass ioctl: ask kernel to retry.
+                    if unrestricted || op.arg.out_size == 0 {
+                        return Ok(FuseUtils::build_ioctl_retry(
+                            op.arg.arg,
+                            0,
+                            preferred as u64,
+                        ));
+                    }
+                    return err_fuse!(
+                        libc::EINVAL,
+                        "ioctl out buffer too small (flags={:#x} out_size={})",
+                        op.arg.flags,
+                        op.arg.out_size
+                    );
                 }
                 (0, FuseUtils::file_flags_from_status(&status))
             }
             FuseUtils::FS_IOC_SETFLAGS => {
                 self.ensure_writable_path(&path, RpcCode::SetAttr).await?;
-                if op.arg.in_size < flag_bytes {
-                    return err_fuse!(libc::EINVAL, "ioctl in buffer too small");
+                if op.arg.in_size < min_flag_bytes || op.in_data.len() < min_flag_bytes as usize {
+                    if (unrestricted || op.arg.in_size == 0) && op.arg.in_size < preferred {
+                        return Ok(FuseUtils::build_ioctl_retry(
+                            op.arg.arg,
+                            preferred as u64,
+                            0,
+                        ));
+                    }
+                    return err_fuse!(
+                        libc::EINVAL,
+                        "ioctl in buffer too small (flags={:#x} in_size={} data_len={})",
+                        op.arg.flags,
+                        op.arg.in_size,
+                        op.in_data.len()
+                    );
                 }
                 let requested = FuseUtils::decode_ioctl_file_flags(op.in_data)?;
                 let new_flags = FuseUtils::normalize_ioctl_file_flags(requested);

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -1009,15 +1009,17 @@ impl fs::FileSystem for CurvineFileSystem {
         let unrestricted = (op.arg.flags & FUSE_IOCTL_UNRESTRICTED) != 0;
         let (result, out_flags) = match op.arg.cmd {
             FuseUtils::FS_IOC_GETFLAGS => {
+                // FUSE_IOCTL_RETRY is only legal for unrestricted ioctls;
+                // restricted undersized buffers must return EINVAL (kernel
+                // rejects retry in restricted mode with -EIO).
+                if unrestricted && op.arg.out_size < preferred {
+                    return Ok(FuseUtils::build_ioctl_retry(
+                        op.arg.arg,
+                        0,
+                        preferred as u64,
+                    ));
+                }
                 if op.arg.out_size < min_flag_bytes {
-                    // Empty unrestricted/first-pass ioctl: ask kernel to retry.
-                    if unrestricted || op.arg.out_size == 0 {
-                        return Ok(FuseUtils::build_ioctl_retry(
-                            op.arg.arg,
-                            0,
-                            preferred as u64,
-                        ));
-                    }
                     return err_fuse!(
                         libc::EINVAL,
                         "ioctl out buffer too small (flags={:#x} out_size={})",
@@ -1029,14 +1031,15 @@ impl fs::FileSystem for CurvineFileSystem {
             }
             FuseUtils::FS_IOC_SETFLAGS => {
                 self.ensure_writable_path(&path, RpcCode::SetAttr).await?;
+                // Same ABI rule as GETFLAGS: never emit RETRY unless unrestricted.
+                if unrestricted && op.arg.in_size < preferred {
+                    return Ok(FuseUtils::build_ioctl_retry(
+                        op.arg.arg,
+                        preferred as u64,
+                        0,
+                    ));
+                }
                 if op.arg.in_size < min_flag_bytes || op.in_data.len() < min_flag_bytes as usize {
-                    if (unrestricted || op.arg.in_size == 0) && op.arg.in_size < preferred {
-                        return Ok(FuseUtils::build_ioctl_retry(
-                            op.arg.arg,
-                            preferred as u64,
-                            0,
-                        ));
-                    }
                     return err_fuse!(
                         libc::EINVAL,
                         "ioctl in buffer too small (flags={:#x} in_size={} data_len={})",

--- a/curvine-fuse/src/fuse_utils.rs
+++ b/curvine-fuse/src/fuse_utils.rs
@@ -15,7 +15,9 @@
 #![allow(unused_variables)]
 
 use crate::fs::operator::{Create, MkDir, MkNod};
-use crate::raw::fuse_abi::{fuse_attr, fuse_entry_out, fuse_setattr_in};
+use crate::raw::fuse_abi::{
+    fuse_attr, fuse_entry_out, fuse_ioctl_iovec, fuse_ioctl_out, fuse_setattr_in, FUSE_IOCTL_RETRY,
+};
 use crate::*;
 use bytes::BytesMut;
 use curvine_client::unified::UnifiedFileSystem;
@@ -359,22 +361,15 @@ impl FuseUtils {
     }
 
     pub fn decode_ioctl_file_flags(data: &[u8]) -> FuseResult<u32> {
-        let nbytes = Self::ioctl_flag_bytes();
-        if data.len() < nbytes {
-            return err_fuse!(libc::EINVAL, "ioctl in buffer too small");
+        // Prefer native long width, but accept 4-byte payloads used by
+        // FS_IOC32_* and by LTP helpers that store flags in an `int`.
+        if data.len() >= 8 {
+            Ok(i64::from_ne_bytes(data[..8].try_into().unwrap()) as u32)
+        } else if data.len() >= 4 {
+            Ok(u32::from_ne_bytes(data[..4].try_into().unwrap()))
+        } else {
+            err_fuse!(libc::EINVAL, "ioctl in buffer too small")
         }
-        let value = match nbytes {
-            8 => i64::from_ne_bytes(data[..8].try_into().unwrap()) as u32,
-            4 => u32::from_ne_bytes(data[..4].try_into().unwrap()),
-            _ => {
-                return err_fuse!(
-                    libc::EINVAL,
-                    "unsupported ioctl flag transfer size {}",
-                    nbytes
-                );
-            }
-        };
-        Ok(value)
     }
 
     pub fn append_ioctl_file_flags(buf: &mut BytesMut, flags: u32, out_size: u32) {
@@ -389,6 +384,35 @@ impl FuseUtils {
         if want > copy {
             buf.resize(buf.len() + (want - copy), 0);
         }
+    }
+
+    /// Build a `FUSE_IOCTL_RETRY` reply that asks the kernel to transfer
+    /// `in_len`/`out_len` bytes at the userspace pointer `arg_ptr`.
+    pub fn build_ioctl_retry(arg_ptr: u64, in_len: u64, out_len: u64) -> BytesMut {
+        let in_iovs = u32::from(in_len > 0);
+        let out_iovs = u32::from(out_len > 0);
+        let out = fuse_ioctl_out {
+            result: 0,
+            flags: FUSE_IOCTL_RETRY,
+            in_iovs,
+            out_iovs,
+        };
+        let mut buf = BytesMut::from(Self::struct_as_bytes(&out));
+        if in_len > 0 {
+            let iov = fuse_ioctl_iovec {
+                base: arg_ptr,
+                len: in_len,
+            };
+            buf.extend_from_slice(Self::struct_as_bytes(&iov));
+        }
+        if out_len > 0 {
+            let iov = fuse_ioctl_iovec {
+                base: arg_ptr,
+                len: out_len,
+            };
+            buf.extend_from_slice(Self::struct_as_bytes(&iov));
+        }
+        buf
     }
 
     pub fn file_open_flags(conf: &FuseConf, keep_cache: bool) -> u32 {
@@ -705,7 +729,9 @@ impl FuseUtils {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::raw::fuse_abi::fuse_setattr_in;
+    use crate::raw::fuse_abi::{
+        fuse_ioctl_iovec, fuse_ioctl_out, fuse_setattr_in, FUSE_IOCTL_RETRY,
+    };
     use curvine_common::state::INTERNAL_CTIME_XATTR;
 
     #[test]
@@ -1138,6 +1164,50 @@ mod tests {
         FuseUtils::append_ioctl_file_flags(&mut buf, flags, FuseUtils::ioctl_flag_bytes() as u32);
         assert_eq!(buf.len(), FuseUtils::ioctl_flag_bytes());
         assert_eq!(FuseUtils::decode_ioctl_file_flags(&buf).unwrap(), flags);
+    }
+
+    #[test]
+    fn ioctl_file_flags_decode_accepts_four_byte_int_payload() {
+        let flags = FS_IMMUTABLE_FL | FS_APPEND_FL;
+        let bytes = flags.to_ne_bytes();
+        assert_eq!(FuseUtils::decode_ioctl_file_flags(&bytes).unwrap(), flags);
+    }
+
+    #[test]
+    fn ioctl_retry_reply_includes_out_iovec_for_getflags() {
+        let arg_ptr = 0xdead_beef_u64;
+        let nbytes = FuseUtils::ioctl_flag_bytes() as u64;
+        let buf = FuseUtils::build_ioctl_retry(arg_ptr, 0, nbytes);
+        let out_size = std::mem::size_of::<fuse_ioctl_out>();
+        let iov_size = std::mem::size_of::<fuse_ioctl_iovec>();
+        assert_eq!(buf.len(), out_size + iov_size);
+
+        let out: fuse_ioctl_out = unsafe { std::ptr::read(buf.as_ptr() as *const fuse_ioctl_out) };
+        assert_eq!(out.result, 0);
+        assert_eq!(out.flags, FUSE_IOCTL_RETRY);
+        assert_eq!(out.in_iovs, 0);
+        assert_eq!(out.out_iovs, 1);
+
+        let iov: fuse_ioctl_iovec =
+            unsafe { std::ptr::read(buf[out_size..].as_ptr() as *const fuse_ioctl_iovec) };
+        assert_eq!(iov.base, arg_ptr);
+        assert_eq!(iov.len, nbytes);
+    }
+
+    #[test]
+    fn ioctl_retry_reply_includes_in_iovec_for_setflags() {
+        let arg_ptr = 0x1234_5678_u64;
+        let nbytes = FuseUtils::ioctl_flag_bytes() as u64;
+        let buf = FuseUtils::build_ioctl_retry(arg_ptr, nbytes, 0);
+        let out_size = std::mem::size_of::<fuse_ioctl_out>();
+        let out: fuse_ioctl_out = unsafe { std::ptr::read(buf.as_ptr() as *const fuse_ioctl_out) };
+        assert_eq!(out.flags, FUSE_IOCTL_RETRY);
+        assert_eq!(out.in_iovs, 1);
+        assert_eq!(out.out_iovs, 0);
+        let iov: fuse_ioctl_iovec =
+            unsafe { std::ptr::read(buf[out_size..].as_ptr() as *const fuse_ioctl_iovec) };
+        assert_eq!(iov.base, arg_ptr);
+        assert_eq!(iov.len, nbytes);
     }
 
     #[test]

--- a/curvine-fuse/src/raw/fuse_abi.rs
+++ b/curvine-fuse/src/raw/fuse_abi.rs
@@ -351,6 +351,11 @@ pub struct fuse_lseek_in {
     pub padding: u64,
 }
 
+/// Request flag: ioctl is not restricted to `_IOC_*` size transfers; retry allowed.
+pub const FUSE_IOCTL_UNRESTRICTED: u32 = 1 << 1;
+/// Reply flag: kernel should retry the ioctl with the provided iovecs.
+pub const FUSE_IOCTL_RETRY: u32 = 1 << 2;
+
 #[repr(C)]
 #[derive(Debug, Default)]
 pub struct fuse_ioctl_in {
@@ -360,6 +365,13 @@ pub struct fuse_ioctl_in {
     pub arg: u64,
     pub in_size: u32,
     pub out_size: u32,
+}
+
+#[repr(C)]
+#[derive(Debug, Default)]
+pub struct fuse_ioctl_iovec {
+    pub base: u64,
+    pub len: u64,
 }
 
 #[repr(C)]


### PR DESCRIPTION
<!-- curvine-automation:pr:CurvineIO/curvine:1287 -->

# Summary

Make Curvine FUSE honor `FUSE_IOCTL_RETRY` for unrestricted `FS_IOC_GETFLAGS` / `FS_IOC_SETFLAGS` when the first ioctl packet arrives without a usable flags buffer, and accept the 4-byte `int` payloads used by LTP `setxattr03`.

# Issue Describe / Design

Closes #1287

## Root cause

After file-flag ioctl support landed, LTP `setxattr03` still failed with `EINVAL` when setting the immutable flag. Unrestricted FUSE ioctl starts with an empty or undersized buffer; the previous path rejected that first packet as `EINVAL` instead of returning `FUSE_IOCTL_RETRY` with a `fuse_ioctl_iovec` describing the required in/out buffers. LTP also stores flags in a 4-byte `int`, which must be accepted alongside `sizeof(c_long)`.

## Reproduction steps

1. Mount Curvine FUSE.
2. Run the focused security/system xattr reproducer (covers `setxattr03` immutable / append-only).
3. Observe immutable setup fail with `EINVAL` on the unfixed SHA; pass after this change.

## Fix approach

- Add `FUSE_IOCTL_UNRESTRICTED` / `FUSE_IOCTL_RETRY` and `fuse_ioctl_iovec` ABI helpers.
- On empty / undersized GET/SETFLAGS buffers, reply with retry iovecs sized for `sizeof(c_long)`.
- Decode successful flag payloads of at least 4 bytes so LTP `int` flags work.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-fuse/src/raw/fuse_abi.rs` | Add ioctl retry/unrestricted flags and `fuse_ioctl_iovec` | New ABI constants/layout only |
| `curvine-fuse/src/fuse_utils.rs` | Build retry replies; accept ≥4-byte flag decode; unit tests | Behavior change: empty ioctl returns retry instead of EINVAL |
| `curvine-fuse/src/fs/curvine_file_system.rs` | GET/SETFLAGS empty-buffer retry and 4-byte success path | Behavior change: immutable/append-only setup via ioctl succeeds |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `make format` | PASS | Exact HEAD `a569012087b94dae2796f4a6305323f9c23062a5` |
| `cargo test -p curvine-fuse ioctl_` | PASS | Retry layout and 4-byte decode |
| Focused xattr/`setxattr03` reproducer (before ×2 on FUSE) | PASS (reproduced) | Stable `EINVAL` on baseline SHA `4ef12b9d6ba5dac09d63dd26400b5b09682be4fd` |
| Same reproducer on non-FUSE reference FS ×1 | PASS | Environment/LTP case not broken |
| Same reproducer after fix ×3 on FUSE | PASS | All 4/4 cases |
| Full originating `ltp` profile on exact fixed HEAD | PASS | `setxattr03` absent; no new failure identities vs baseline |

# Dependencies

- Related PRs: #1266
- Related issues: #1287
- Blocks / blocked by: None
