### PR TITLE
perf(master): skip unconsumed flush block snapshots (#1322)

### DIFF
--- a/curvine-client-core/src/file/fs_client.rs
+++ b/curvine-client-core/src/file/fs_client.rs
@@ -35,6 +35,12 @@ pub struct FsClient {
     connector: Arc<ClusterConnector>,
 }
 
+struct CompleteFileOptions {
+    only_flush: bool,
+    set_attr_opts: Option<SetAttrOpts>,
+    return_file_blocks: bool,
+}
+
 impl FsClient {
     pub fn new(context: Arc<FsContext>) -> Self {
         let connector = context.connector.clone();
@@ -359,8 +365,18 @@ impl FsClient {
         only_flush: bool,
         set_attr_opts: Option<SetAttrOpts>,
     ) -> FsResult<Option<FileBlocks>> {
-        self.complete_file0(path, None, len, commit_blocks, only_flush, set_attr_opts)
-            .await
+        self.complete_file0(
+            path,
+            None,
+            len,
+            commit_blocks,
+            CompleteFileOptions {
+                only_flush,
+                set_attr_opts,
+                return_file_blocks: true,
+            },
+        )
+        .await
     }
 
     pub async fn complete_file_by_id(
@@ -377,10 +393,35 @@ impl FsClient {
             Some(inode_id),
             len,
             commit_blocks,
-            only_flush,
-            set_attr_opts,
+            CompleteFileOptions {
+                only_flush,
+                set_attr_opts,
+                return_file_blocks: true,
+            },
         )
         .await
+    }
+
+    pub(crate) async fn flush_file_by_id(
+        &self,
+        path: &Path,
+        inode_id: i64,
+        len: i64,
+        commit_blocks: impl IntoIterator<Item = CommitBlock>,
+    ) -> FsResult<()> {
+        self.complete_file0(
+            path,
+            Some(inode_id),
+            len,
+            commit_blocks,
+            CompleteFileOptions {
+                only_flush: true,
+                set_attr_opts: None,
+                return_file_blocks: false,
+            },
+        )
+        .await
+        .map(|_| ())
     }
 
     // File writing is completed.
@@ -390,8 +431,7 @@ impl FsClient {
         inode_id: Option<i64>,
         len: i64,
         commit_blocks: impl IntoIterator<Item = CommitBlock>,
-        only_flush: bool,
-        set_attr_opts: Option<SetAttrOpts>,
+        options: CompleteFileOptions,
     ) -> FsResult<Option<FileBlocks>> {
         let commit_blocks = commit_blocks
             .into_iter()
@@ -403,12 +443,17 @@ impl FsClient {
             len,
             client_name: self.context().clone_client_name(),
             commit_blocks,
-            only_flush,
+            only_flush: options.only_flush,
             inode_id,
-            set_attr_opts: set_attr_opts.map(ProtoUtils::set_attr_opts_to_pb),
+            set_attr_opts: options.set_attr_opts.map(ProtoUtils::set_attr_opts_to_pb),
+            return_file_blocks: Some(options.return_file_blocks),
         };
 
-        let operation = if only_flush { "Flush" } else { "Complete" };
+        let operation = if options.only_flush {
+            "Flush"
+        } else {
+            "Complete"
+        };
         let rep: CompleteFileResponse =
             FsContext::metrics_track(operation, self.rpc(RpcCode::CompleteFile, header)).await?;
 
@@ -434,6 +479,7 @@ impl FsClient {
                     only_flush,
                     inode_id: None,
                     set_attr_opts: None,
+                    return_file_blocks: Some(false),
                 }
             })
             .collect();

--- a/curvine-client-core/src/file/fs_writer_base.rs
+++ b/curvine-client-core/src/file/fs_writer_base.rs
@@ -274,13 +274,11 @@ impl FsWriterBase {
             let committed_len = self.committed_len();
             let result = self
                 .fs_client
-                .complete_file_by_id(
+                .flush_file_by_id(
                     &self.path,
                     self.file_blocks.status.id,
                     committed_len,
                     commit_blocks.clone(),
-                    true,
-                    None,
                 )
                 .await;
             if let Err(e) = result {

--- a/curvine-common/proto/master.proto
+++ b/curvine-common/proto/master.proto
@@ -189,6 +189,8 @@ message CompleteFileRequest {
     required bool only_flush = 5 [default = false];
     optional int64 inode_id = 6;
     optional SetAttrOptsProto set_attr_opts = 7;
+    // Omitted by legacy clients to preserve the historical full snapshot response.
+    optional bool return_file_blocks = 8 [default = true];
 }
 
 message CompleteFileResponse {

--- a/curvine-server/src/master/fs/master_filesystem.rs
+++ b/curvine-server/src/master/fs/master_filesystem.rs
@@ -59,6 +59,12 @@ pub struct CvMetadataDeltaPage {
     pub full_snapshot_required: bool,
 }
 
+struct CompleteFileOptions {
+    only_flush: bool,
+    return_file_blocks: bool,
+    set_attr_opts: Option<SetAttrOpts>,
+}
+
 #[derive(Clone)]
 pub struct MasterFilesystem {
     pub fs_dir: SyncFsDir,
@@ -659,6 +665,53 @@ impl MasterFilesystem {
         only_flush: bool,
         set_attr_opts: Option<SetAttrOpts>,
     ) -> FsResult<Option<FileBlocks>> {
+        self.complete_file0(
+            path,
+            inode_id,
+            len,
+            commit_blocks,
+            client_name,
+            CompleteFileOptions {
+                only_flush,
+                return_file_blocks: true,
+                set_attr_opts,
+            },
+        )
+    }
+
+    /// Flushes file metadata without building the full block-location snapshot.
+    pub fn flush_file<T: AsRef<str>>(
+        &self,
+        path: T,
+        inode_id: Option<i64>,
+        len: i64,
+        commit_blocks: Vec<CommitBlock>,
+        client_name: T,
+    ) -> FsResult<()> {
+        self.complete_file0(
+            path,
+            inode_id,
+            len,
+            commit_blocks,
+            client_name,
+            CompleteFileOptions {
+                only_flush: true,
+                return_file_blocks: false,
+                set_attr_opts: None,
+            },
+        )
+        .map(|_| ())
+    }
+
+    fn complete_file0<T: AsRef<str>>(
+        &self,
+        path: T,
+        inode_id: Option<i64>,
+        len: i64,
+        commit_blocks: Vec<CommitBlock>,
+        client_name: T,
+        options: CompleteFileOptions,
+    ) -> FsResult<Option<FileBlocks>> {
         let path = path.as_ref();
         let mut fs_dir = self.fs_dir.write();
         let mut inode = Self::resolve_file_inode(&fs_dir, path, inode_id)?;
@@ -668,18 +721,18 @@ impl MasterFilesystem {
             len,
             commit_blocks,
             client_name,
-            only_flush,
-            set_attr_opts,
+            options.only_flush,
+            options.set_attr_opts,
         )?;
 
-        if only_flush {
+        if options.only_flush && options.return_file_blocks {
             let file = inode.as_file_ref()?;
             let locs = self.get_block_locs(path, &fs_dir, file)?;
             let status = inode.to_file_status(path)?;
-            Ok(Some(FileBlocks::new(status, locs)))
-        } else {
-            Ok(None)
+            return Ok(Some(FileBlocks::new(status, locs)));
         }
+
+        Ok(None)
     }
 
     pub fn get_file_blocks(

--- a/curvine-server/src/master/master_handler.rs
+++ b/curvine-server/src/master/master_handler.rs
@@ -323,25 +323,45 @@ impl MasterHandler {
         };
         ctx.set_audit(Some(audit_path), None);
 
-        let commit_blocks = req
-            .commit_blocks
-            .into_iter()
-            .map(ProtoUtils::commit_block_from_pb)
-            .collect();
-        let file_blocks = self.fs.complete_file(
-            req.path,
-            req.inode_id,
-            req.len,
-            commit_blocks,
-            req.client_name,
-            req.only_flush,
-            req.set_attr_opts.map(ProtoUtils::set_attr_opts_from_pb),
-        )?;
+        let return_file_blocks = req.return_file_blocks.unwrap_or(true);
+        let file_blocks = self.complete_file0(req, return_file_blocks)?;
         let rep_header = CompleteFileResponse {
             result: true,
             file_blocks: file_blocks.map(ProtoUtils::file_blocks_to_pb),
         };
         ctx.response(rep_header)
+    }
+
+    fn complete_file0(
+        &self,
+        req: CompleteFileRequest,
+        return_file_blocks: bool,
+    ) -> FsResult<Option<FileBlocks>> {
+        let commit_blocks = req
+            .commit_blocks
+            .into_iter()
+            .map(ProtoUtils::commit_block_from_pb)
+            .collect();
+        if req.only_flush && !return_file_blocks {
+            self.fs.flush_file(
+                req.path,
+                req.inode_id,
+                req.len,
+                commit_blocks,
+                req.client_name,
+            )?;
+            Ok(None)
+        } else {
+            self.fs.complete_file(
+                req.path,
+                req.inode_id,
+                req.len,
+                commit_blocks,
+                req.client_name,
+                req.only_flush,
+                req.set_attr_opts.map(ProtoUtils::set_attr_opts_from_pb),
+            )
+        }
     }
 
     pub fn create_files_batch(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
@@ -399,25 +419,9 @@ impl MasterHandler {
     pub fn complete_files_batch(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let header: CompleteFilesBatchRequest = ctx.parse_header()?;
 
-        let mut results = Vec::new();
+        let mut results = Vec::with_capacity(header.requests.len());
         for req in header.requests {
-            let commit_blocks = req
-                .commit_blocks
-                .into_iter()
-                .map(ProtoUtils::commit_block_from_pb)
-                .collect();
-            let result = self
-                .fs
-                .complete_file(
-                    req.path,
-                    req.inode_id,
-                    req.len,
-                    commit_blocks,
-                    req.client_name,
-                    req.only_flush,
-                    req.set_attr_opts.map(ProtoUtils::set_attr_opts_from_pb),
-                )
-                .is_ok();
+            let result = self.complete_file0(req, false).is_ok();
             results.push(result);
         }
 

--- a/curvine-server/tests/master_fs_test.rs
+++ b/curvine-server/tests/master_fs_test.rs
@@ -17,18 +17,18 @@ use curvine_common::error::FsError;
 use curvine_common::fs::CurvineURI;
 use curvine_common::fs::RpcCode;
 use curvine_common::proto::{
-    CreateFileRequest, DeleteRequest, GetMasterInfoRequest, MkdirOptsProto, MkdirRequest,
-    RenameRequest,
+    CompleteFileRequest, CompleteFileResponse, CreateFileRequest, DeleteRequest,
+    GetMasterInfoRequest, MkdirOptsProto, MkdirRequest, RenameRequest,
 };
 use curvine_common::raft::storage::{AppStorage, ApplyMsg};
 use curvine_common::state::MountOptions;
 use curvine_common::state::{
     BlockLocation, BlockReportInfo, BlockReportList, BlockReportStatus, ClientAddress, CommitBlock,
-    CreateFileOpts, CreateFileOptsBuilder, FileAllocOpts, MkdirOptsBuilder, StorageType, TtlAction,
-    WorkerAddress, WorkerInfo,
+    CreateFileOpts, CreateFileOptsBuilder, FileAllocOpts, LocatedBlock, MkdirOptsBuilder,
+    StorageType, TtlAction, WorkerAddress, WorkerInfo,
 };
 use curvine_common::state::{OpenFlags, RenameFlags, SetAttrOptsBuilder};
-use curvine_common::utils::SerdeUtils;
+use curvine_common::utils::{ProtoUtils, SerdeUtils};
 use curvine_server::master::fs::{FsRetryCache, MasterFilesystem, OperationStatus};
 use curvine_server::master::journal::{JournalBatch, JournalEntry, JournalLoader, JournalSystem};
 use curvine_server::master::meta::inode::ttl::InodeTtlExecutor;
@@ -43,6 +43,7 @@ use orpc::message::Builder;
 use orpc::message::ResponseStatus;
 use orpc::runtime::{AsyncRuntime, GroupExecutor, RpcRuntime};
 use orpc::CommonResult;
+use prost::Message as ProtoMessage;
 use raft::eraftpb::Entry;
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
@@ -157,6 +158,51 @@ fn file_counts(fs: &MasterFilesystem) -> (i64, i64) {
 
 fn new_handler() -> MasterHandler {
     new_handler_for_test("retry")
+}
+
+fn full_commit(block: &LocatedBlock, len: i64) -> CommitBlock {
+    CommitBlock {
+        block_id: block.id,
+        block_len: len,
+        locations: block
+            .locs
+            .iter()
+            .map(|worker| BlockLocation::new(worker.worker_id, block.storage_type))
+            .collect(),
+    }
+}
+
+fn prepare_flush_file(
+    fs: &MasterFilesystem,
+    path: &str,
+    client: &ClientAddress,
+    blocks: usize,
+) -> CommonResult<(i64, CommitBlock)> {
+    let status = fs.create(path, true)?;
+    let mut last: Option<LocatedBlock> = None;
+
+    for index in 0..blocks {
+        let commits = last
+            .as_ref()
+            .map(|block| vec![full_commit(block, status.block_size)])
+            .unwrap_or_default();
+        let last_block = last.as_ref().map(|block| block.block.clone());
+        last = Some(fs.add_block(
+            path,
+            None,
+            client.clone(),
+            commits,
+            vec![],
+            index as i64 * status.block_size,
+            last_block,
+        )?);
+    }
+
+    let last = last.expect("benchmark requires at least one block");
+    Ok((
+        blocks as i64 * status.block_size,
+        full_commit(&last, status.block_size),
+    ))
 }
 
 fn new_handler_for_test(test_name: &str) -> MasterHandler {
@@ -1832,6 +1878,135 @@ fn resize_rejects_extreme_file_size() {
 
     let status = fs.file_status("/extreme.log").unwrap();
     assert_eq!(status.len, 0);
+}
+
+#[test]
+fn only_flush_persists_block_without_returning_file_snapshot() -> CommonResult<()> {
+    let _serial = master_fs_test_serial();
+    let fs = new_fs(true, "only-flush-no-snapshot");
+    let path = "/only-flush-no-snapshot.log";
+    let client = ClientAddress::default();
+    let status = fs.create(path, false)?;
+    let block = fs.add_block(path, None, client.clone(), vec![], vec![], 0, None)?;
+    let commit = full_commit(&block, status.block_size);
+
+    fs.flush_file(
+        path,
+        None,
+        status.block_size,
+        vec![commit],
+        client.client_name.as_str(),
+    )?;
+
+    let file_blocks = fs.get_block_locations(path)?;
+    assert_eq!(file_blocks.block_locs.len(), 1);
+    assert_eq!(file_blocks.block_locs[0].block.len, status.block_size);
+
+    let legacy_response = fs.complete_file(
+        path,
+        None,
+        status.block_size,
+        vec![],
+        client.client_name.as_str(),
+        true,
+        None,
+    )?;
+    assert_eq!(legacy_response.unwrap().block_locs.len(), 1);
+    Ok(())
+}
+
+#[test]
+fn handler_only_flush_without_snapshot_persists_block() -> CommonResult<()> {
+    let _serial = master_fs_test_serial();
+    let handler = new_handler_for_test("handler-only-flush-no-snapshot");
+    let fs = handler.clone_fs();
+    let path = "/handler-only-flush-no-snapshot.log";
+    let client = ClientAddress::default();
+    let status = fs.create(path, false)?;
+    let block = fs.add_block(path, None, client.clone(), vec![], vec![], 0, None)?;
+    let req = CompleteFileRequest {
+        path: path.to_string(),
+        len: status.block_size,
+        client_name: client.client_name.clone(),
+        commit_blocks: vec![ProtoUtils::commit_block_to_pb(full_commit(
+            &block,
+            status.block_size,
+        ))],
+        only_flush: true,
+        inode_id: None,
+        set_attr_opts: None,
+        return_file_blocks: Some(false),
+    };
+    let msg = Builder::new_rpc(RpcCode::CompleteFile)
+        .proto_header(req)
+        .build();
+    let mut ctx = RpcContext::new(&msg);
+
+    let response = handler.complete_file(&mut ctx)?;
+    let header: CompleteFileResponse = response.parse_header()?;
+    assert!(header.result);
+    assert!(header.file_blocks.is_none());
+
+    let file_blocks = fs.get_block_locations(path)?;
+    assert_eq!(file_blocks.block_locs.len(), 1);
+    assert_eq!(file_blocks.block_locs[0].block.len, status.block_size);
+    Ok(())
+}
+
+#[test]
+#[ignore = "manual benchmark: run with --ignored --nocapture"]
+fn measure_only_flush_file_blocks_snapshot() -> CommonResult<()> {
+    const BLOCKS: usize = 4096;
+
+    let _serial = master_fs_test_serial();
+    let fs = new_fs(true, "only-flush-snapshot-bench");
+    let client = ClientAddress::default();
+
+    let (legacy_len, legacy_commit) =
+        prepare_flush_file(&fs, "/flush-bench/legacy", &client, BLOCKS)?;
+    let legacy_started = std::time::Instant::now();
+    let legacy_response = fs.complete_file(
+        "/flush-bench/legacy",
+        None,
+        legacy_len,
+        vec![legacy_commit],
+        client.client_name.as_str(),
+        true,
+        None,
+    )?;
+    let legacy_elapsed = legacy_started.elapsed();
+    let legacy_blocks = legacy_response
+        .as_ref()
+        .map(|blocks| blocks.block_locs.len())
+        .unwrap_or_default();
+    let legacy_bytes = legacy_response
+        .as_ref()
+        .map(|blocks| ProtoUtils::file_blocks_to_pb(blocks.clone()).encoded_len())
+        .unwrap_or_default();
+
+    let (opt_in_len, opt_in_commit) =
+        prepare_flush_file(&fs, "/flush-bench/opt-in", &client, BLOCKS)?;
+    let opt_in_started = std::time::Instant::now();
+    let opt_in_result = fs.flush_file(
+        "/flush-bench/opt-in",
+        None,
+        opt_in_len,
+        vec![opt_in_commit],
+        client.client_name.as_str(),
+    );
+    let opt_in_elapsed = opt_in_started.elapsed();
+    opt_in_result?;
+    let opt_in_blocks = 0;
+    let opt_in_bytes = 0;
+
+    assert_eq!(legacy_blocks, BLOCKS);
+    assert_eq!(opt_in_blocks, 0);
+    eprintln!(
+        "ONLY_FLUSH_FILE_BLOCKS_BENCH blocks={BLOCKS} legacy_us={} legacy_bytes={legacy_bytes} opt_in_us={} opt_in_bytes={opt_in_bytes}",
+        legacy_elapsed.as_micros(),
+        opt_in_elapsed.as_micros(),
+    );
+    Ok(())
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Avoid building full block-location snapshots for flush requests whose caller does not consume them. This shortens the Master write-lock critical section for large files while preserving normal complete and flush responses.

## Issue / Design

Related to #1322.

The optional return_file_blocks protocol flag lets an internal no-result flush opt out of the FileBlocks snapshot. Legacy clients omit the field and receive the historical response.

This branch is rebased on #1386. Field 7 remains set_attr_opts; return_file_blocks is field 8. Public complete APIs always request FileBlocks because only_flush callers use that response to refresh local block state. The no-snapshot path is limited to the internal cleanup flush and batch requests, where the response is not observable. Batch requests now explicitly send false rather than relying on the legacy default.

## Changes

| Area | Change |
| --- | --- |
| master.proto | Add optional return_file_blocks field 8 with legacy-compatible default true |
| FsClient and FsWriterBase | Add internal no-result flush request while retaining set_attr and public complete behavior |
| MasterFilesystem and MasterHandler | Skip FileBlocks construction only for eligible flushes |
| master_fs_test | Cover persistence, Handler wire contract, compatibility, and the 4096-block benchmark |

## Test verified

- make format, including workspace release clippy: PASS
- cargo test -p curvine-server --test master_fs_test -- --test-threads=1: PASS, 34 passed, 1 ignored
- cargo test -p curvine-client-core: PASS, 25 passed
- cargo test -p curvine-server --test lock_order_deadlock_stress_test -- --nocapture --test-threads=1: PASS, 4000 add-block and 4000 block-report operations completed
- 4096-block flush benchmark: PASS, 21.688 ms to 1.890 ms; response payload 184414 B to 0 B

## Dependencies

- Integrates with #1386 complete_with_attr changes.
- Ranged block-location reads remain outside this PR.