### PR TITLE
feat(client): add complete_with_attr to Writer trait for merged set_attr on file complete

### DIFF
--- a/crates/common/curvine-fs-api/src/writer.rs
+++ b/crates/common/curvine-fs-api/src/writer.rs
@@ -104,12 +104,21 @@ pub trait Writer {
 
     fn complete(&mut self) -> impl Future<Output = FsResult<()>>;
 
+    /// Completes the write operation and optionally applies file attributes.
+    ///
+    /// # Default Implementation
+    ///
+    /// The default implementation **ignores** `opts` and simply calls [`complete()`](Writer::complete).
+    /// Backends that support atomic attribute setting on complete should override this method.
+    ///
+    /// Callers should not assume attributes were applied unless the backend explicitly
+    /// supports this method.
     fn complete_with_attr(
         &mut self,
         opts: Option<SetAttrOpts>,
     ) -> impl Future<Output = FsResult<()>> {
         async move {
-            let _ = &opts;
+            drop(opts);
             self.complete().await
         }
     }

--- a/crates/common/curvine-fs-api/src/writer.rs
+++ b/crates/common/curvine-fs-api/src/writer.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::fs::Path;
-use crate::state::{FileAllocOpts, FileStatus};
+use crate::state::{FileAllocOpts, FileStatus, SetAttrOpts};
 use crate::FsResult;
 use bytes::{BufMut, BytesMut};
 use orpc::err_box;
@@ -103,6 +103,16 @@ pub trait Writer {
     fn flush(&mut self) -> impl Future<Output = FsResult<()>>;
 
     fn complete(&mut self) -> impl Future<Output = FsResult<()>>;
+
+    fn complete_with_attr(
+        &mut self,
+        opts: Option<SetAttrOpts>,
+    ) -> impl Future<Output = FsResult<()>> {
+        async move {
+            let _ = &opts;
+            self.complete().await
+        }
+    }
 
     fn cancel(&mut self) -> impl Future<Output = FsResult<()>>;
 

--- a/curvine-client-core/src/file/fs_client.rs
+++ b/curvine-client-core/src/file/fs_client.rs
@@ -357,8 +357,9 @@ impl FsClient {
         len: i64,
         commit_blocks: impl IntoIterator<Item = CommitBlock>,
         only_flush: bool,
+        set_attr_opts: Option<SetAttrOpts>,
     ) -> FsResult<Option<FileBlocks>> {
-        self.complete_file0(path, None, len, commit_blocks, only_flush)
+        self.complete_file0(path, None, len, commit_blocks, only_flush, set_attr_opts)
             .await
     }
 
@@ -369,9 +370,17 @@ impl FsClient {
         len: i64,
         commit_blocks: impl IntoIterator<Item = CommitBlock>,
         only_flush: bool,
+        set_attr_opts: Option<SetAttrOpts>,
     ) -> FsResult<Option<FileBlocks>> {
-        self.complete_file0(path, Some(inode_id), len, commit_blocks, only_flush)
-            .await
+        self.complete_file0(
+            path,
+            Some(inode_id),
+            len,
+            commit_blocks,
+            only_flush,
+            set_attr_opts,
+        )
+        .await
     }
 
     // File writing is completed.
@@ -382,6 +391,7 @@ impl FsClient {
         len: i64,
         commit_blocks: impl IntoIterator<Item = CommitBlock>,
         only_flush: bool,
+        set_attr_opts: Option<SetAttrOpts>,
     ) -> FsResult<Option<FileBlocks>> {
         let commit_blocks = commit_blocks
             .into_iter()
@@ -395,6 +405,7 @@ impl FsClient {
             commit_blocks,
             only_flush,
             inode_id,
+            set_attr_opts: set_attr_opts.map(ProtoUtils::set_attr_opts_to_pb),
         };
 
         let operation = if only_flush { "Flush" } else { "Complete" };
@@ -422,6 +433,7 @@ impl FsClient {
                     commit_blocks,
                     only_flush,
                     inode_id: None,
+                    set_attr_opts: None,
                 }
             })
             .collect();

--- a/curvine-client-core/src/file/fs_writer.rs
+++ b/curvine-client-core/src/file/fs_writer.rs
@@ -16,7 +16,7 @@ use crate::file::{FsContext, FsWriterBase, FsWriterBuffer};
 use bytes::BytesMut;
 use curvine_error::FsResult;
 use curvine_fs_api::{Path, Writer};
-use curvine_model::{FileAllocOpts, FileBlocks, FileStatus};
+use curvine_model::{FileAllocOpts, FileBlocks, FileStatus, SetAttrOpts};
 use log::debug;
 use orpc::common::ByteUnit;
 use orpc::sys::DataSlice;
@@ -119,6 +119,11 @@ impl Writer for FsWriter {
         self.flush_chunk().await?;
         // The flush operation will be automatically called internally, so flush is not needed here.
         self.inner.complete().await
+    }
+
+    async fn complete_with_attr(&mut self, opts: Option<SetAttrOpts>) -> FsResult<()> {
+        self.flush_chunk().await?;
+        self.inner.complete_with_attr(opts).await
     }
 
     async fn cancel(&mut self) -> FsResult<()> {

--- a/curvine-client-core/src/file/fs_writer_base.rs
+++ b/curvine-client-core/src/file/fs_writer_base.rs
@@ -17,7 +17,9 @@ use crate::file::{FsClient, FsContext};
 use curvine_error::FsError;
 use curvine_error::FsResult;
 use curvine_fs_api::Path;
-use curvine_model::{CommitBlock, FileAllocOpts, FileBlocks, FileStatus, WriteFileBlocks};
+use curvine_model::{
+    CommitBlock, FileAllocOpts, FileBlocks, FileStatus, SetAttrOpts, WriteFileBlocks,
+};
 use fxhash::FxHasher;
 use linked_hash_map::LinkedHashMap;
 use log::warn;
@@ -165,7 +167,7 @@ impl FsWriterBase {
     }
 
     pub async fn flush(&mut self) -> FsResult<()> {
-        self.complete0(true).await?;
+        self.complete0(true, None).await?;
         Ok(())
     }
 
@@ -178,7 +180,12 @@ impl FsWriterBase {
     // Write is completed, perform the following operations
     // 1. Submit the last block.
     pub async fn complete(&mut self) -> FsResult<()> {
-        self.complete0(false).await?;
+        self.complete0(false, None).await?;
+        Ok(())
+    }
+
+    pub async fn complete_with_attr(&mut self, opts: Option<SetAttrOpts>) -> FsResult<()> {
+        self.complete0(false, opts).await?;
         Ok(())
     }
 
@@ -269,6 +276,7 @@ impl FsWriterBase {
                     committed_len,
                     commit_blocks.clone(),
                     true,
+                    None,
                 )
                 .await;
             if let Err(e) = result {
@@ -288,7 +296,11 @@ impl FsWriterBase {
         }
     }
 
-    async fn complete0(&mut self, only_flush: bool) -> FsResult<Option<FileBlocks>> {
+    async fn complete0(
+        &mut self,
+        only_flush: bool,
+        set_attr_opts: Option<SetAttrOpts>,
+    ) -> FsResult<Option<FileBlocks>> {
         if let Some(writer) = self.cur_writer.take() {
             self.cache_writers.insert(writer.block_id(), writer);
         };
@@ -329,6 +341,7 @@ impl FsWriterBase {
                 self.len,
                 commit_blocks.clone(),
                 only_flush,
+                set_attr_opts,
             )
             .await;
         if result.is_err() {

--- a/curvine-client-core/src/file/fs_writer_buffer.rs
+++ b/curvine-client-core/src/file/fs_writer_buffer.rs
@@ -16,7 +16,7 @@ use crate::file::FsWriterBase;
 use curvine_error::FsError;
 use curvine_error::FsResult;
 use curvine_fs_api::Path;
-use curvine_model::{FileAllocOpts, FileBlocks, FileStatus};
+use curvine_model::{FileAllocOpts, FileBlocks, FileStatus, SetAttrOpts};
 use log::error;
 use orpc::io::IOError;
 use orpc::runtime::RpcRuntime;
@@ -28,7 +28,7 @@ use std::sync::Arc;
 // Control task type
 enum WriterTask {
     Flush(CallSender<i8>),
-    Complete((bool, CallSender<i8>)),
+    Complete((bool, Option<SetAttrOpts>, CallSender<i8>)),
     Cancel(CallSender<FsResult<()>>),
     Seek((i64, CallSender<i8>)),
     Resize((FileAllocOpts, CallSender<FileBlocks>)),
@@ -73,10 +73,14 @@ impl BufferChannel {
     }
 
     async fn complete(&mut self) -> FsResult<()> {
+        self.complete_with_attr(None).await
+    }
+
+    async fn complete_with_attr(&mut self, opts: Option<SetAttrOpts>) -> FsResult<()> {
         let fun = async {
             let (tx, rx) = CallChannel::channel();
             self.task_sender
-                .send(WriterTask::Complete((false, tx)))
+                .send(WriterTask::Complete((false, opts, tx)))
                 .await?;
             rx.receive().await?;
             Ok::<(), IOError>(())
@@ -210,6 +214,10 @@ impl FsWriterBuffer {
         self.writer.complete().await
     }
 
+    pub async fn complete_with_attr(&mut self, opts: Option<SetAttrOpts>) -> FsResult<()> {
+        self.writer.complete_with_attr(opts).await
+    }
+
     pub async fn flush(&mut self) -> FsResult<()> {
         self.writer.flush().await
     }
@@ -253,11 +261,11 @@ impl FsWriterBuffer {
                         cx.send(1)?;
                     }
 
-                    WriterTask::Complete((_, tx)) => {
+                    WriterTask::Complete((_, opts, tx)) => {
                         while let Some(chunk) = chunk_receiver.try_recv()? {
                             writer.write(chunk).await?;
                         }
-                        writer.complete().await?;
+                        writer.complete_with_attr(opts).await?;
                         tx.send(1)?;
                         return Ok(());
                     }

--- a/curvine-common/proto/master.proto
+++ b/curvine-common/proto/master.proto
@@ -188,6 +188,7 @@ message CompleteFileRequest {
     repeated CommitBlockProto commit_blocks = 4;
     required bool only_flush = 5 [default = false];
     optional int64 inode_id = 6;
+    optional SetAttrOptsProto set_attr_opts = 7;
 }
 
 message CompleteFileResponse {

--- a/curvine-fuse/src/fs/fuse_writer.rs
+++ b/curvine-fuse/src/fs/fuse_writer.rs
@@ -20,7 +20,7 @@ use curvine_client::unified::UnifiedWriter;
 use curvine_common::conf::FuseConf;
 use curvine_common::error::FsError;
 use curvine_common::fs::{Path, Writer};
-use curvine_common::state::{FileAllocOpts, FileStatus};
+use curvine_common::state::{FileAllocOpts, FileStatus, SetAttrOpts};
 use curvine_common::FsResult;
 use log::{error, warn};
 use orpc::common::LocalTime;
@@ -33,7 +33,11 @@ use std::sync::Arc;
 enum WriteTask {
     Write(i64, Bytes, Option<FuseResponse>),
     Flush(CallSender<FsResult<()>>, Option<FuseResponse>),
-    Complete(CallSender<FsResult<()>>, Option<FuseResponse>),
+    Complete(
+        CallSender<FsResult<()>>,
+        Option<FuseResponse>,
+        Option<SetAttrOpts>,
+    ),
     Resize(CallSender<FsResult<()>>, FileAllocOpts),
 }
 
@@ -158,9 +162,17 @@ impl FuseWriter {
     }
 
     pub async fn complete(&self, reply: Option<FuseResponse>) -> FsResult<()> {
+        self.complete_with_attr(reply, None).await
+    }
+
+    pub async fn complete_with_attr(
+        &self,
+        reply: Option<FuseResponse>,
+        set_attr_opts: Option<SetAttrOpts>,
+    ) -> FsResult<()> {
         let fun = async {
             let (rx, tx) = CallChannel::channel();
-            self.send_queued_task(WriteTask::Complete(rx, reply))
+            self.send_queued_task(WriteTask::Complete(rx, reply, set_attr_opts))
                 .await?;
             // Double `?`: the outer unwraps the channel receive, the inner
             // propagates the real backend complete result.
@@ -229,7 +241,7 @@ impl FuseWriter {
 
         // Abort only before any durability boundary may have published the data.
         let cleanup_result = if preserve_on_exit {
-            writer.complete().await
+            writer.complete_with_attr(None).await
         } else {
             writer.cancel().await
         };
@@ -322,9 +334,9 @@ impl FuseWriter {
                     crate::fs::deliver_stream_result(res, tx, reply).await?;
                 }
 
-                WriteTask::Complete(tx, reply) => {
+                WriteTask::Complete(tx, reply, opts) => {
                     *preserve_on_exit = true;
-                    let res = writer.complete().await;
+                    let res = writer.complete_with_attr(opts).await;
                     *completed = res.is_ok();
                     crate::fs::deliver_stream_result(res, tx, reply).await?;
                 }
@@ -474,7 +486,7 @@ mod tests {
         let (result_tx, result_rx) = CallChannel::channel::<FsResult<()>>();
         sender
             .send(QueuedWriteTask {
-                task: WriteTask::Complete(result_tx, None),
+                task: WriteTask::Complete(result_tx, None, None),
                 queue_guard: None,
             })
             .await

--- a/curvine-server/src/master/fs/master_filesystem.rs
+++ b/curvine-server/src/master/fs/master_filesystem.rs
@@ -607,6 +607,7 @@ impl MasterFilesystem {
         Ok(located)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn complete_file<T: AsRef<str>>(
         &self,
         path: T,
@@ -615,6 +616,7 @@ impl MasterFilesystem {
         commit_blocks: Vec<CommitBlock>,
         client_name: T,
         only_flush: bool,
+        set_attr_opts: Option<SetAttrOpts>,
     ) -> FsResult<Option<FileBlocks>> {
         let path = path.as_ref();
         let mut fs_dir = self.fs_dir.write();
@@ -626,6 +628,7 @@ impl MasterFilesystem {
             commit_blocks,
             client_name,
             only_flush,
+            set_attr_opts,
         )?;
 
         if only_flush {

--- a/curvine-server/src/master/master_handler.rs
+++ b/curvine-server/src/master/master_handler.rs
@@ -330,6 +330,7 @@ impl MasterHandler {
             commit_blocks,
             req.client_name,
             req.only_flush,
+            req.set_attr_opts.map(ProtoUtils::set_attr_opts_from_pb),
         )?;
         let rep_header = CompleteFileResponse {
             result: true,
@@ -409,6 +410,7 @@ impl MasterHandler {
                     commit_blocks,
                     req.client_name,
                     req.only_flush,
+                    req.set_attr_opts.map(ProtoUtils::set_attr_opts_from_pb),
                 )
                 .is_ok();
             results.push(result);

--- a/curvine-server/src/master/meta/fs_dir.rs
+++ b/curvine-server/src/master/meta/fs_dir.rs
@@ -585,6 +585,7 @@ impl FsDir {
         Ok(block)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn complete_file(
         &mut self,
         path: impl AsRef<str>,
@@ -593,11 +594,17 @@ impl FsDir {
         commit_block: Vec<CommitBlock>,
         client_name: impl AsRef<str>,
         only_flush: bool,
+        set_attr_opts: Option<SetAttrOpts>,
     ) -> FsResult<bool> {
         let file = inode.as_file_mut()?;
+        let id = file.id();
         file.complete(len, &commit_block, client_name, only_flush)?;
 
-        self.evictor.on_access(file.id());
+        if let Some(opts) = set_attr_opts {
+            inode.set_attr(opts)?;
+        }
+
+        self.evictor.on_access(id);
 
         self.store
             .apply_complete_file(inode.as_ref(), &commit_block)?;

--- a/curvine-server/src/master/meta/fs_dir.rs
+++ b/curvine-server/src/master/meta/fs_dir.rs
@@ -600,8 +600,12 @@ impl FsDir {
         let id = file.id();
         file.complete(len, &commit_block, client_name, only_flush)?;
 
-        if let Some(opts) = set_attr_opts {
-            inode.set_attr(opts)?;
+        // Only apply set_attr_opts on real complete/close, not on flush.
+        // Flush semantics should remain narrow (durability only).
+        if !only_flush {
+            if let Some(opts) = set_attr_opts {
+                inode.set_attr(opts)?;
+            }
         }
 
         self.evictor.on_access(id);

--- a/curvine-server/src/master/meta/store/inode_store.rs
+++ b/curvine-server/src/master/meta/store/inode_store.rs
@@ -268,7 +268,13 @@ impl InodeStore {
             }
         }
 
-        batch.commit()
+        batch.commit()?;
+
+        // Refresh TTL index in case set_attr_opts changed ttl_ms/ttl_action or
+        // file.complete() advanced mtime (TTL expiration = mtime + ttl_ms).
+        self.ttl_bucket_list.add(file);
+
+        Ok(())
     }
 
     pub fn apply_overwrite_file(&self, file: &InodeView) -> CommonResult<()> {

--- a/curvine-server/tests/journal_test.rs
+++ b/curvine-server/tests/journal_test.rs
@@ -277,6 +277,7 @@ fn run(fs_leader: &MasterFilesystem, worker: &WorkerInfo) -> CommonResult<()> {
         vec![commit],
         &address.client_name,
         false,
+        None,
     )?;
 
     // File renaming
@@ -298,7 +299,7 @@ fn run(fs_leader: &MasterFilesystem, worker: &WorkerInfo) -> CommonResult<()> {
         block_len: 10,
         locations: vec![BlockLocation::with_id(worker.worker_id())],
     };
-    fs_leader.complete_file(path, None, 10, vec![commit], "", false)?;
+    fs_leader.complete_file(path, None, 10, vec![commit], "", false, None)?;
 
     let commit = CommitBlock {
         block_id: block.block.id,
@@ -310,7 +311,7 @@ fn run(fs_leader: &MasterFilesystem, worker: &WorkerInfo) -> CommonResult<()> {
         CreateFileOpts::with_create(true),
         OpenFlags::new_create(),
     )?;
-    fs_leader.complete_file(path, None, 13, vec![commit], "", false)?;
+    fs_leader.complete_file(path, None, 13, vec![commit], "", false, None)?;
 
     Ok(())
 }

--- a/curvine-server/tests/master_fs_test.rs
+++ b/curvine-server/tests/master_fs_test.rs
@@ -1337,6 +1337,7 @@ fn complete_file_retry(fs: &MasterFilesystem) -> CommonResult<()> {
         vec![commit.clone()],
         &addr.client_name,
         false,
+        None,
     );
     assert!(f1.is_ok());
 
@@ -1347,6 +1348,7 @@ fn complete_file_retry(fs: &MasterFilesystem) -> CommonResult<()> {
         vec![commit.clone()],
         &addr.client_name,
         false,
+        None,
     );
     assert!(f2.is_ok());
 
@@ -1969,6 +1971,69 @@ fn located_block_has_spdk_reflects_worker_reported_storage_type() -> CommonResul
             "has_spdk should be true when any replica reports SpdkDisk"
         );
     }
+
+    Ok(())
+}
+
+#[test]
+fn complete_file_with_set_attr_applies_attributes() -> CommonResult<()> {
+    let _serial = master_fs_test_serial();
+    let fs = new_fs(true, "complete-with-attr");
+    let path = "/complete_with_attr.log";
+    let addr = ClientAddress::default();
+
+    // Create file and add a block
+    let _status = fs.create(path, false)?;
+    let block = fs.add_block(path, None, addr.clone(), vec![], vec![], 0, None)?;
+
+    let commit = CommitBlock {
+        block_id: block.block.id,
+        block_len: block.block.len,
+        locations: vec![BlockLocation::with_id(block.locs[0].worker_id)],
+    };
+
+    // Complete the file with SetAttrOpts — owner, group, mode, mtime, xattr
+    let custom_mtime: i64 = 1_000_000;
+    let opts = SetAttrOptsBuilder::new()
+        .owner("alice")
+        .group("dev")
+        .mode(0o644)
+        .mtime(custom_mtime)
+        .add_x_attr("user.tag".to_string(), b"v1".to_vec())
+        .build();
+
+    fs.complete_file(
+        path,
+        None,
+        block.block.len,
+        vec![commit],
+        &addr.client_name,
+        false,
+        Some(opts),
+    )?;
+
+    // Verify the attributes were applied
+    let result = fs.file_status(path)?;
+    assert!(result.is_complete, "file should be complete");
+    assert_eq!(
+        result.owner, "alice",
+        "owner should be set by complete_file"
+    );
+    assert_eq!(result.group, "dev", "group should be set by complete_file");
+    assert_eq!(
+        result.mode & 0o777,
+        0o644,
+        "mode should be set by complete_file"
+    );
+    assert_eq!(
+        result.mtime, custom_mtime,
+        "mtime should be overridden by set_attr_opts"
+    );
+    assert_eq!(
+        result.x_attr.get("user.tag"),
+        Some(&b"v1".to_vec()),
+        "xattr should be set by complete_file"
+    );
 
     Ok(())
 }

--- a/curvine-unified-fs/src/unified/macros.rs
+++ b/curvine-unified-fs/src/unified/macros.rs
@@ -108,6 +108,18 @@ macro_rules! impl_writer_for_enum {
                 }
             }
 
+            async fn complete_with_attr(
+                &mut self,
+                opts: Option<::curvine_model::SetAttrOpts>,
+            ) -> ::curvine_error::FsResult<()> {
+                match self {
+                    $(
+                        $(#[$cfg])*
+                        Self::$variant(v) => v.complete_with_attr(opts).await,
+                    )+
+                }
+            }
+
             async fn cancel(&mut self) -> ::curvine_error::FsResult<()> {
                 match self {
                     $(


### PR DESCRIPTION
# Summary

Add \complete_with_attr\ method to the Writer trait, allowing file attributes to be set atomically when completing a file write operation. This merges the \set_attr\ operation with \complete_file\, reducing two store writes and two journal entries to one each.

**Note:** This PR provides the API/RPC plumbing. FUSE attr-on-complete integration will be a follow-up PR.

# Issue Describe / Design

This optimization improves write performance by:
- Adding \complete_with_attr(opts: Option<SetAttrOpts>)\ to the Writer trait
- Passing \set_attr_opts\ through the client RPC to master
- Applying attributes directly to the inode during \complete_file\ on the server side
- Attribute order: first \ile.complete()\ sets length/mtime/ctime, then \set_attr(opts)\ overrides user-specified owner/group/mode/mtime/xattr
- TTL bucket index is refreshed in \pply_complete_file\ to handle TTL changes
- \set_attr_opts\ is ignored when \only_flush=true\ to keep flush semantics narrow

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| \crates/common/curvine-fs-api/src/writer.rs\ | Add \complete_with_attr\ to Writer trait with doc comments | New method with default impl calling \complete()\ |
| \curvine-client-core/src/file/fs_client.rs\ | Add \set_attr_opts\ param to \complete_file_by_id\ | None |
| \curvine-client-core/src/file/fs_writer*.rs\ | Implement \complete_with_attr\ in writer stack | None |
| \curvine-common/proto/master.proto\ | Add \set_attr_opts\ field to CompleteFileRequest | Protocol extension |
| \curvine-fuse/src/fs/fuse_writer.rs\ | Plumb \complete_with_attr\ through write task queue | API ready, FUSE integration follow-up |
| \curvine-server/src/master/meta/fs_dir.rs\ | Handle \set_attr_opts\ in complete_file, ignore on flush | Merged attr setting |
| \curvine-server/src/master/meta/store/inode_store.rs\ | Refresh TTL bucket in \pply_complete_file\ | TTL index consistency |
| \curvine-unified-fs/src/unified/macros.rs\ | Add \complete_with_attr\ to enum macro | None |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| \cargo test -p curvine-server master_fs_test\ | PASS | Includes new complete_with_attr test |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None