### PR TITLE
perf(worker): move FileLayout I/O outside dataset lock (#1323)

### DIFF
--- a/curvine-server/src/worker/block/block_meta.rs
+++ b/curvine-server/src/worker/block/block_meta.rs
@@ -26,6 +26,8 @@ pub enum BlockState {
     Finalized = 0,
     Writing = 1,
     Recovering = 2,
+    Allocating = 3,
+    Finalizing = 4,
 }
 
 impl BlockState {
@@ -161,6 +163,10 @@ impl BlockMeta {
 
     pub fn is_active(&self) -> bool {
         matches!(self.state, BlockState::Finalized | BlockState::Writing)
+    }
+
+    pub fn is_transitioning(&self) -> bool {
+        matches!(self.state, BlockState::Allocating | BlockState::Finalizing)
     }
 
     pub fn dir_id(&self) -> u32 {

--- a/curvine-server/src/worker/block/block_store.rs
+++ b/curvine-server/src/worker/block/block_store.rs
@@ -12,18 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::worker::block::BlockMeta;
+use crate::worker::block::{BlockMeta, BlockState};
 use crate::worker::storage::{
     BlockDataset, BlockLayout, BlockReadContext, BlockWriteContext, Dataset,
 };
+use crate::worker::Worker;
 use curvine_common::conf::ClusterConf;
 use curvine_common::state::{ExtendedBlock, StorageInfo};
 use orpc::CommonResult;
+use parking_lot::{Mutex, MutexGuard};
 use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
+use std::time::{Duration, Instant};
+
+const BLOCK_LOCK_STRIPES: usize = 256;
 
 #[derive(Clone)]
 pub struct BlockStore {
     state: Arc<RwLock<BlockDataset>>,
+    block_locks: Arc<Vec<Mutex<()>>>,
 }
 
 impl BlockStore {
@@ -31,6 +37,7 @@ impl BlockStore {
         let dataset = BlockDataset::from_conf(cluster_id, conf)?;
         let block_store = BlockStore {
             state: Arc::new(RwLock::new(dataset)),
+            block_locks: Arc::new((0..BLOCK_LOCK_STRIPES).map(|_| Mutex::new(())).collect()),
         };
 
         Ok(block_store)
@@ -56,16 +63,138 @@ impl BlockStore {
         }
     }
 
+    fn block_lock(&self, id: i64, operation: &str) -> MutexGuard<'_, ()> {
+        let started = Instant::now();
+        let index = (id as u64 as usize) % self.block_locks.len();
+        let guard = self.block_locks[index].lock();
+        self.observe_stripe_lock_wait(operation, started.elapsed());
+        guard
+    }
+
+    fn with_dataset_write<T>(
+        &self,
+        operation: &str,
+        action: impl FnOnce(&mut BlockDataset) -> CommonResult<T>,
+    ) -> CommonResult<T> {
+        let waiting = Instant::now();
+        let mut state = self.write()?;
+        let wait_elapsed = waiting.elapsed();
+        let holding = Instant::now();
+        let result = action(&mut state);
+        let hold_elapsed = holding.elapsed();
+        drop(state);
+
+        self.observe_dataset_lock_wait(operation, wait_elapsed);
+        self.observe_dataset_lock_hold(operation, hold_elapsed);
+        result
+    }
+
+    fn observe_stripe_lock_wait(&self, operation: &str, elapsed: Duration) {
+        if let Ok(metrics) = Worker::get_metrics() {
+            metrics
+                .block_store_stripe_lock_wait_us
+                .with_label_values(&[operation])
+                .observe(elapsed.as_micros() as f64);
+        }
+    }
+
+    fn observe_dataset_lock_wait(&self, operation: &str, elapsed: Duration) {
+        if let Ok(metrics) = Worker::get_metrics() {
+            metrics
+                .block_dataset_write_lock_wait_us
+                .with_label_values(&[operation])
+                .observe(elapsed.as_micros() as f64);
+        }
+    }
+
+    fn observe_dataset_lock_hold(&self, operation: &str, elapsed: Duration) {
+        if let Ok(metrics) = Worker::get_metrics() {
+            metrics
+                .block_dataset_write_lock_hold_us
+                .with_label_values(&[operation])
+                .observe(elapsed.as_micros() as f64);
+        }
+    }
+
+    fn observe_file_layout_operation(&self, operation: &str, elapsed: Duration) {
+        if let Ok(metrics) = Worker::get_metrics() {
+            metrics
+                .file_layout_operation_us
+                .with_label_values(&[operation])
+                .observe(elapsed.as_micros() as f64);
+        }
+    }
+
     pub fn open_block(&self, block: &ExtendedBlock) -> CommonResult<BlockMeta> {
-        self.write()?.open_block(block)
+        let _block_lock = self.block_lock(block.id, "open");
+        let reservation =
+            self.with_dataset_write("open", |state| state.reserve_file_open(block))?;
+
+        let Some(reservation) = reservation else {
+            return self.with_dataset_write("open", |state| state.open_block(block));
+        };
+
+        let started = Instant::now();
+        let prepared = reservation.prepare(block);
+        self.observe_file_layout_operation("open", started.elapsed());
+        match prepared {
+            Ok(meta) => self
+                .with_dataset_write("open", |state| state.complete_file_open(&reservation, meta)),
+            Err(error) => {
+                if let Err(rollback) =
+                    self.with_dataset_write("open", |state| state.rollback_file_open(&reservation))
+                {
+                    log::error!(
+                        "failed to roll back block {} allocation after {}: {}",
+                        block.id,
+                        error,
+                        rollback
+                    );
+                }
+                Err(error)
+            }
+        }
     }
 
     pub fn finalize_block(&self, block: &ExtendedBlock) -> CommonResult<BlockMeta> {
-        self.write()?.finalize_block(block)
+        let _block_lock = self.block_lock(block.id, "finalize");
+        let reservation =
+            self.with_dataset_write("finalize", |state| state.reserve_file_finalize(block))?;
+
+        let Some(reservation) = reservation else {
+            return self.with_dataset_write("finalize", |state| state.finalize_block(block));
+        };
+
+        let started = Instant::now();
+        let plan = reservation.prepare(block.len);
+        self.observe_file_layout_operation("finalize", started.elapsed());
+        let result = match plan {
+            Ok(plan) => self.with_dataset_write("finalize", |state| {
+                state.publish_file_finalize(&reservation, plan)
+            }),
+            Err(error) => Err(error),
+        };
+        match result {
+            Ok(meta) => Ok(meta),
+            Err(error) => {
+                if let Err(rollback) = self.with_dataset_write("finalize", |state| {
+                    state.rollback_file_finalize(&reservation)
+                }) {
+                    log::error!(
+                        "failed to roll back block {} finalization after {}: {}",
+                        block.id,
+                        error,
+                        rollback
+                    );
+                }
+                Err(error)
+            }
+        }
     }
 
     pub fn abort_block(&self, block: &ExtendedBlock) -> CommonResult<()> {
-        self.write()?.abort_block(block)
+        let _block_lock = self.block_lock(block.id, "abort");
+        self.with_dataset_write("abort", |state| state.abort_block(block))
     }
 
     pub fn get_block(&self, id: i64) -> CommonResult<BlockMeta> {
@@ -92,6 +221,42 @@ impl BlockStore {
         layout.open_reader(&dir, meta, off).map_err(Into::into)
     }
 
+    /// Opens the currently readable generation while the dataset read lock is
+    /// held, so a finalize publish cannot replace its path before the FD opens.
+    pub fn open_reader_by_id(
+        &self,
+        id: i64,
+        off: i64,
+    ) -> CommonResult<(BlockMeta, BlockReadContext)> {
+        let state = self.read()?;
+        let meta = state
+            .get_readable_block(id)
+            .ok_or_else(|| orpc::err_msg!(format!("block {} not exists", id)))?
+            .clone();
+        let (layout, dir) = state.layout_for(&meta)?;
+        let reader = layout.open_reader(&dir, &meta, off)?;
+        Ok((meta, reader))
+    }
+
+    /// Returns a local path only while no finalize publication is in progress.
+    /// A finalizing file can be atomically renamed before a co-located client
+    /// opens the returned path, so callers must use `open_reader_by_id` then.
+    pub fn short_circuit_by_id(&self, id: i64) -> CommonResult<Option<(BlockMeta, String)>> {
+        let state = self.read()?;
+        if matches!(
+            state.get_block(id).map(BlockMeta::state),
+            Some(BlockState::Finalizing)
+        ) {
+            return Ok(None);
+        }
+        let meta = state
+            .get_readable_block(id)
+            .ok_or_else(|| orpc::err_msg!(format!("block {} not exists", id)))?
+            .clone();
+        let (layout, dir) = state.layout_for(&meta)?;
+        Ok(layout.short_circuit(&dir, &meta)?.map(|path| (meta, path)))
+    }
+
     pub fn short_circuit(&self, meta: &BlockMeta) -> CommonResult<Option<String>> {
         let (layout, dir) = {
             let state = self.read()?;
@@ -116,21 +281,21 @@ impl BlockStore {
     }
 
     pub fn remove_block(&self, id: i64) -> CommonResult<()> {
-        let mut state = self.write()?;
+        let _block_lock = self.block_lock(id, "remove");
         let block = ExtendedBlock::with_id(id);
-        state.remove_block(&block)
+        self.with_dataset_write("remove", |state| state.remove_block(&block))
     }
 
     // Asynchronously delete block.
     pub fn async_remove_block(&self, id: i64) -> CommonResult<BlockMeta> {
-        let removed = {
-            let mut state = self.write()?;
+        let _block_lock = self.block_lock(id, "remove");
+        let removed = self.with_dataset_write("remove", |state| {
             let remove_result = state.remove_block_state_by_id(id);
             // Heartbeat increments this counter before scheduling the task.
             // Consume it even when metadata removal reports an error.
             state.decrement_blocks_to_delete();
             remove_result
-        }?;
+        })?;
 
         removed.deallocate()?;
         removed.release_space();
@@ -149,20 +314,46 @@ impl BlockStore {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::worker::storage::Dataset;
+    use crate::worker::block::BlockState;
+    use crate::worker::storage::{Dataset, FileLayout};
     use curvine_common::conf::WorkerConf;
+    use orpc::common::FileUtils;
+    use orpc::sys::DataSlice;
+    use std::io::Write;
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+    use std::time::Instant;
 
     fn create_store(name: &str) -> CommonResult<BlockStore> {
+        create_store_with_capacity(name, "1KB")
+    }
+
+    fn create_store_with_capacity(name: &str, capacity: &str) -> CommonResult<BlockStore> {
         let conf = ClusterConf {
             format_worker: true,
             worker: WorkerConf {
                 dir_reserved: "0".to_string(),
-                data_dir: vec![format!("[MEM:1KB]../testing/block-store-{name}")],
+                data_dir: vec![format!("[MEM:{capacity}]../testing/block-store-{name}")],
                 ..WorkerConf::default()
             },
             ..ClusterConf::default()
         };
         BlockStore::new("test", &conf)
+    }
+
+    fn write_block(path: &str, bytes: usize) -> CommonResult<()> {
+        const CHUNK_SIZE: usize = 1024 * 1024;
+
+        let mut file = std::fs::File::create(path)?;
+        let chunk = vec![0_u8; CHUNK_SIZE];
+        let mut remaining = bytes;
+        while remaining > 0 {
+            let len = remaining.min(CHUNK_SIZE);
+            file.write_all(&chunk[..len])?;
+            remaining -= len;
+        }
+        file.sync_all()?;
+        Ok(())
     }
 
     #[test]
@@ -190,6 +381,222 @@ mod tests {
         let state = store.read()?;
         assert!(state.get_block(1).is_none());
         assert_eq!(state.num_blocks_to_delete(), 0);
+        Ok(())
+    }
+
+    fn finalize_block(store: &BlockStore, block: &ExtendedBlock) -> CommonResult<BlockMeta> {
+        let writing = store.open_block(block)?;
+        let path = store
+            .short_circuit(&writing)?
+            .expect("file layout must expose a local path");
+        write_block(&path, block.len as usize)?;
+        store.finalize_block(block)
+    }
+
+    fn read_bytes(reader: &mut BlockReadContext, len: i32) -> CommonResult<Vec<u8>> {
+        let slice = reader.read_region(false, len)?;
+        match slice {
+            DataSlice::Bytes(bytes) => Ok(bytes.to_vec()),
+            DataSlice::Buffer(bytes) => Ok(bytes.to_vec()),
+            other => orpc::err_box!("unexpected test read slice: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn failed_file_rewrite_restores_committed_block() -> CommonResult<()> {
+        let store = create_store_with_capacity("rewrite-rollback", "16MB")?;
+        let block = ExtendedBlock::with_mem(1, "1MB")?;
+        let finalized = finalize_block(&store, &block)?;
+        let available = store.read()?.available();
+        let (_, dir) = store.read()?.layout_for(&finalized)?;
+        let staging = BlockMeta::new(block.id, block.len, &dir);
+        let staging_path = FileLayout::block_path(&dir, &staging)?;
+        std::fs::create_dir(&staging_path)?;
+
+        assert!(store.open_block(&block).is_err());
+        let restored = store.get_block(block.id)?;
+        assert!(restored.is_final());
+        assert_eq!(restored.len(), finalized.len());
+        assert_eq!(store.read()?.available(), available);
+
+        FileUtils::delete_path(staging_path, true)?;
+        Ok(())
+    }
+
+    #[test]
+    fn file_rewrite_requires_capacity_for_committed_copy() -> CommonResult<()> {
+        let store = create_store_with_capacity("rewrite-capacity", "1MB")?;
+        let block = ExtendedBlock::with_mem(1, "1MB")?;
+        let finalized = finalize_block(&store, &block)?;
+        let available = store.read()?.available();
+
+        assert!(store.open_block(&block).is_err());
+        assert_eq!(store.get_block(block.id)?.state(), &BlockState::Finalized);
+        assert_eq!(store.get_block(block.id)?.len(), finalized.len());
+        assert_eq!(store.read()?.available(), available);
+        Ok(())
+    }
+
+    #[test]
+    fn failed_file_finalize_restores_writing_state() -> CommonResult<()> {
+        let store = create_store_with_capacity("finalize-rollback", "16MB")?;
+        let block = ExtendedBlock::with_mem(1, "1MB")?;
+        let writing = store.open_block(&block)?;
+        let staging_path = store
+            .short_circuit(&writing)?
+            .expect("file layout must expose a local path");
+        write_block(&staging_path, block.len as usize)?;
+
+        let (_, dir) = store.read()?.layout_for(&writing)?;
+        let mut final_meta = writing.clone();
+        final_meta.state = BlockState::Finalized;
+        let active_path = FileLayout::block_path(&dir, &final_meta)?;
+        std::fs::create_dir(&active_path)?;
+
+        assert!(store.finalize_block(&block).is_err());
+        assert_eq!(store.get_block(block.id)?.state(), &BlockState::Writing);
+
+        FileUtils::delete_path(&active_path, true)?;
+        assert!(store.finalize_block(&block)?.is_final());
+        Ok(())
+    }
+
+    #[test]
+    fn finalizing_new_block_remains_reportable_and_readable() -> CommonResult<()> {
+        let store = create_store_with_capacity("finalizing-report", "16MB")?;
+        let block = ExtendedBlock::with_mem(1, "1MB")?;
+        store.open_block(&block)?;
+
+        let reservation = store
+            .write()?
+            .reserve_file_finalize(&block)?
+            .expect("file block finalize must reserve");
+        let report = store.all_blocks()?;
+        assert_eq!(report.len(), 1);
+        assert_eq!(report[0].state(), &BlockState::Finalizing);
+        assert_eq!(store.get_block(block.id)?.state(), &BlockState::Finalizing);
+        assert!(store.short_circuit_by_id(block.id)?.is_none());
+
+        store.write()?.rollback_file_finalize(&reservation)?;
+        Ok(())
+    }
+
+    #[test]
+    fn reader_opened_before_publish_keeps_committed_generation() -> CommonResult<()> {
+        let store = create_store_with_capacity("finalize-reader-generation", "16MB")?;
+        let block = ExtendedBlock::with_mem(1, "4B")?;
+        let first = store.open_block(&block)?;
+        let first_path = store
+            .short_circuit(&first)?
+            .expect("file layout must expose a local path");
+        std::fs::write(first_path, b"old!")?;
+        store.finalize_block(&block)?;
+
+        let rewrite = store.open_block(&block)?;
+        let rewrite_path = store
+            .short_circuit(&rewrite)?
+            .expect("file layout must expose a local path");
+        std::fs::write(rewrite_path, b"new!")?;
+        let reservation = store
+            .write()?
+            .reserve_file_finalize(&block)?
+            .expect("rewrite finalize must reserve");
+        let plan = reservation.prepare(block.len)?;
+
+        let (_, mut committed_reader) = store.open_reader_by_id(block.id, 0)?;
+        store.write()?.publish_file_finalize(&reservation, plan)?;
+        assert_eq!(read_bytes(&mut committed_reader, 4)?, b"old!");
+
+        let (_, mut published_reader) = store.open_reader_by_id(block.id, 0)?;
+        assert_eq!(read_bytes(&mut published_reader, 4)?, b"new!");
+        Ok(())
+    }
+
+    #[test]
+    fn concurrent_open_of_same_block_keeps_single_writing_meta() -> CommonResult<()> {
+        const WRITERS: usize = 4;
+
+        let store = create_store_with_capacity("same-block-open", "16MB")?;
+        let block = ExtendedBlock::with_mem(1, "1MB")?;
+        let barrier = Arc::new(Barrier::new(WRITERS + 1));
+        let mut workers = Vec::with_capacity(WRITERS);
+        for _ in 0..WRITERS {
+            let store = store.clone();
+            let block = block.clone();
+            let barrier = barrier.clone();
+            workers.push(thread::spawn(move || {
+                barrier.wait();
+                store.open_block(&block)
+            }));
+        }
+
+        barrier.wait();
+        for worker in workers {
+            let meta = worker.join().expect("open worker panicked")?;
+            assert_eq!(meta.id(), block.id);
+            assert_eq!(meta.state(), &BlockState::Writing);
+        }
+
+        assert_eq!(store.all_blocks()?.len(), 1);
+        store.abort_block(&block)?;
+        assert!(store.all_blocks()?.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    #[ignore = "manual benchmark: run with --ignored --nocapture"]
+    fn measure_concurrent_file_rewrites() -> CommonResult<()> {
+        const BLOCKS: i64 = 4;
+        const BLOCK_BYTES: usize = 32 * 1024 * 1024;
+
+        let store = create_store_with_capacity("concurrent-rewrites", "1GB")?;
+        let blocks: Vec<ExtendedBlock> = (0..BLOCKS)
+            .map(|id| ExtendedBlock::with_mem(id, "32MB"))
+            .collect::<CommonResult<_>>()?;
+
+        for block in &blocks {
+            let meta = store.open_block(block)?;
+            let path = store
+                .short_circuit(&meta)?
+                .expect("file layout must expose a local path");
+            write_block(&path, BLOCK_BYTES)?;
+            store.finalize_block(block)?;
+        }
+
+        let barrier = Arc::new(Barrier::new(BLOCKS as usize + 1));
+        let mut workers = Vec::with_capacity(BLOCKS as usize);
+        for block in blocks.clone() {
+            let store = store.clone();
+            let barrier = barrier.clone();
+            workers.push(thread::spawn(move || {
+                barrier.wait();
+                let started = Instant::now();
+                let result = store.open_block(&block);
+                let elapsed = started.elapsed();
+                if result.is_ok() {
+                    store.abort_block(&block)?;
+                }
+                Ok::<_, orpc::CommonError>(elapsed)
+            }));
+        }
+
+        barrier.wait();
+        let started = Instant::now();
+        let elapsed: Vec<_> = workers
+            .into_iter()
+            .map(|worker| worker.join().expect("rewrite worker panicked"))
+            .collect::<CommonResult<_>>()?;
+        let wall_clock = started.elapsed();
+        let max_latency = elapsed
+            .into_iter()
+            .max()
+            .expect("benchmark has at least one block");
+
+        eprintln!(
+            "CONCURRENT_FILE_REWRITE_BENCH blocks={BLOCKS} bytes_per_block={BLOCK_BYTES} wall_clock_us={} max_open_us={}",
+            wall_clock.as_micros(),
+            max_latency.as_micros(),
+        );
         Ok(())
     }
 }

--- a/curvine-server/src/worker/block/master_client.rs
+++ b/curvine-server/src/worker/block/master_client.rs
@@ -104,8 +104,10 @@ impl MasterClient {
         for block in blocks {
             let status = match block.state {
                 BlockState::Finalized => BlockReportStatusProto::Finalized,
-                BlockState::Writing => BlockReportStatusProto::Writing,
-                BlockState::Recovering => BlockReportStatusProto::Writing,
+                BlockState::Writing
+                | BlockState::Recovering
+                | BlockState::Allocating
+                | BlockState::Finalizing => BlockReportStatusProto::Writing,
             };
             let info = BlockReportInfoProto {
                 id: block.id,

--- a/curvine-server/src/worker/handler/read_handler.rs
+++ b/curvine-server/src/worker/handler/read_handler.rs
@@ -93,17 +93,19 @@ impl ReadHandler {
         }
 
         let sc_path = if context.short_circuit {
-            self.store.short_circuit(&meta)?
+            self.store.short_circuit_by_id(context.block_id)?
         } else {
             None
         };
 
-        let (is_short_circuit, path, file) = if let Some(path) = sc_path {
-            (true, path, None)
+        let (meta, is_short_circuit, path, file) = if let Some((meta, path)) = sc_path {
+            (meta, true, path, None)
         } else {
-            let file = self.store.open_reader(&meta, context.off)?;
+            let (meta, file) = self
+                .store
+                .open_reader_by_id(context.block_id, context.off)?;
             let path = file.path().to_string();
-            (false, path, Some(file))
+            (meta, false, path, Some(file))
         };
         let label = if is_short_circuit { "local" } else { "remote" };
 

--- a/curvine-server/src/worker/replication/worker_replication_manager.rs
+++ b/curvine-server/src/worker/replication/worker_replication_manager.rs
@@ -120,7 +120,7 @@ impl WorkerReplicationManager {
             Ok(permit) => permit,
             Err(e) => return err_box!("replication semaphore closed: {}", e),
         };
-        let block_meta = self.block_store.get_block(job.block_id)?;
+        let (block_meta, mut reader) = self.block_store.open_reader_by_id(job.block_id, 0)?;
         if block_meta.state != BlockState::Finalized {
             return err_box!("Block: {} is not finalized", job.block_id);
         }
@@ -145,7 +145,6 @@ impl WorkerReplicationManager {
             target_capacity,
         )
         .await?;
-        let mut reader = self.block_store.open_reader(&block_meta, 0)?;
         let mut remaining = block_meta.len;
         while remaining > 0 {
             let size = remaining.min(self.replicate_chunk_size as i64);

--- a/curvine-server/src/worker/storage/layout/file_layout.rs
+++ b/curvine-server/src/worker/storage/layout/file_layout.rs
@@ -31,6 +31,18 @@ pub struct FileLayout;
 const ACTIVE_DIR: &str = "active";
 const STAGING_DIR: &str = "staging";
 
+pub(crate) struct FileFinalizePlan {
+    final_meta: BlockMeta,
+    staging_path: PathBuf,
+    active_path: PathBuf,
+}
+
+impl FileFinalizePlan {
+    pub(crate) fn final_meta(&self) -> &BlockMeta {
+        &self.final_meta
+    }
+}
+
 impl FileLayout {
     fn active_dir(dir: &VfsDir) -> PathBuf {
         dir.base_path().join(ACTIVE_DIR)
@@ -56,7 +68,10 @@ impl FileLayout {
                     .join(format!("b{}", d1))
                     .join(format!("b{}", d2))
             }
-            BlockState::Writing | BlockState::Recovering => Self::staging_dir(dir),
+            BlockState::Writing
+            | BlockState::Recovering
+            | BlockState::Allocating
+            | BlockState::Finalizing => Self::staging_dir(dir),
         };
 
         if path.exists() {
@@ -71,6 +86,35 @@ impl FileLayout {
 
     pub(crate) fn block_path(dir: &VfsDir, meta: &BlockMeta) -> CommonResult<PathBuf> {
         Ok(Self::block_dir(dir, meta)?.join(meta.state().get_name(meta.id())))
+    }
+
+    pub(crate) fn prepare_finalize(
+        dir: &VfsDir,
+        meta: &BlockMeta,
+        committed_len: i64,
+    ) -> CommonResult<FileFinalizePlan> {
+        let staging_path = Self::block_path(dir, meta)?;
+        let final_meta = BlockMeta::with_final(meta, &staging_path)?;
+        if final_meta.len() != committed_len {
+            return err_box!(
+                "Block {} length mismatch, expected: {}, actual: {}",
+                meta.id(),
+                committed_len,
+                final_meta.len()
+            );
+        }
+
+        let active_path = Self::block_path(dir, &final_meta)?;
+        Ok(FileFinalizePlan {
+            final_meta,
+            staging_path,
+            active_path,
+        })
+    }
+
+    pub(crate) fn publish_finalize(plan: FileFinalizePlan) -> CommonResult<BlockMeta> {
+        FileUtils::rename(plan.staging_path, plan.active_path)?;
+        Ok(plan.final_meta)
     }
 
     fn block_file(dir: &VfsDir, meta: &BlockMeta) -> CommonResult<String> {
@@ -125,10 +169,9 @@ impl BlockLayout for FileLayout {
                 );
             }
 
-            // This copy is intentionally serialized by the dataset write lock so
-            // the committed-to-staging transition cannot race another writer.
-            // Existing open readers keep using active; new metadata operations
-            // wait for the copy to finish.
+            // BlockStore reserves this rewrite before the copy and serializes
+            // same-block mutations. Existing readers keep using active while
+            // the staging copy runs outside the dataset write lock.
             if let Err(e) = fs::copy(&committed_path, &staging_path) {
                 let _ = fs::remove_file(&staging_path);
                 return Err(e.into());
@@ -144,20 +187,8 @@ impl BlockLayout for FileLayout {
         meta: &BlockMeta,
         committed_len: i64,
     ) -> CommonResult<BlockMeta> {
-        let staging_path = Self::block_path(dir, meta)?;
-        let final_meta = BlockMeta::with_final(meta, &staging_path)?;
-        if final_meta.len() != committed_len {
-            return err_box!(
-                "Block {} length mismatch, expected: {}, actual: {}",
-                meta.id(),
-                committed_len,
-                final_meta.len()
-            );
-        }
-
-        let active_path = Self::block_path(dir, &final_meta)?;
-        FileUtils::rename(staging_path, active_path)?;
-        Ok(final_meta)
+        let plan = Self::prepare_finalize(dir, meta, committed_len)?;
+        Self::publish_finalize(plan)
     }
 
     fn scan(&self, dir: &VfsDir) -> CommonResult<Vec<BlockMeta>> {

--- a/curvine-server/src/worker/storage/layout/mod.rs
+++ b/curvine-server/src/worker/storage/layout/mod.rs
@@ -16,6 +16,7 @@ mod bdev_layout;
 mod file_layout;
 
 pub use self::bdev_layout::BdevLayout;
+pub(crate) use self::file_layout::FileFinalizePlan;
 pub use self::file_layout::FileLayout;
 
 use crate::worker::block::BlockMeta;

--- a/curvine-server/src/worker/storage/vfs_dataset.rs
+++ b/curvine-server/src/worker/storage/vfs_dataset.rs
@@ -13,9 +13,10 @@
 // limitations under the License.
 
 use crate::worker::block::{BlockMeta, BlockState};
+use crate::worker::storage::layout::FileFinalizePlan;
 use crate::worker::storage::{
-    BlockLayout, BlockLayoutKind, BlockLayouts, Dataset, DirList, SpdkMetaStore, StorageRequest,
-    StorageVersion, VfsDir, VfsMetaStore,
+    BlockLayout, BlockLayoutKind, BlockLayouts, Dataset, DirList, FileLayout, SpdkMetaStore,
+    StorageRequest, StorageVersion, VfsDir, VfsMetaStore,
 };
 use curvine_common::conf::{ClusterConf, WorkerDataDir};
 use curvine_common::state::{ExtendedBlock, StorageInfo, StorageType};
@@ -43,6 +44,33 @@ pub(crate) struct RemovedBlockState {
     committed: Option<BlockMeta>,
     pub(crate) layout: BlockLayoutKind,
     pub(crate) dir: Arc<VfsDir>,
+}
+
+pub(crate) struct FileOpenReservation {
+    pending: BlockMeta,
+    committed: Option<BlockMeta>,
+    dir: Arc<VfsDir>,
+}
+
+impl FileOpenReservation {
+    pub(crate) fn prepare(&self, block: &ExtendedBlock) -> CommonResult<BlockMeta> {
+        match self.committed.as_ref() {
+            Some(committed) => FileLayout.prepare_write(&self.dir, committed, block),
+            None => FileLayout.allocate(&self.dir, block),
+        }
+    }
+}
+
+pub(crate) struct FileFinalizeReservation {
+    writing: BlockMeta,
+    pending: BlockMeta,
+    dir: Arc<VfsDir>,
+}
+
+impl FileFinalizeReservation {
+    pub(crate) fn prepare(&self, committed_len: i64) -> CommonResult<FileFinalizePlan> {
+        FileLayout::prepare_finalize(&self.dir, &self.pending, committed_len)
+    }
 }
 
 impl RemovedBlockState {
@@ -207,19 +235,226 @@ impl VfsDataset {
         self.meta
             .all_blocks()
             .into_iter()
-            .map(|meta| {
+            .filter_map(|meta| {
                 self.committed_rewrites
                     .get(&meta.id())
                     .cloned()
-                    .unwrap_or(meta)
+                    .or_else(|| (meta.state() != &BlockState::Allocating).then_some(meta))
             })
             .collect()
     }
 
     pub(crate) fn get_readable_block(&self, id: i64) -> Option<&BlockMeta> {
-        self.committed_rewrites
-            .get(&id)
-            .or_else(|| self.meta.get(id))
+        if let Some(committed) = self.committed_rewrites.get(&id) {
+            return Some(committed);
+        }
+        let meta = self.meta.get(id)?;
+        (meta.state() != &BlockState::Allocating).then_some(meta)
+    }
+
+    pub(crate) fn reserve_file_open(
+        &mut self,
+        block: &ExtendedBlock,
+    ) -> CommonResult<Option<FileOpenReservation>> {
+        if block.len < 0 {
+            return err_box!("Invalid file block size: {}", block.len);
+        }
+
+        match self.meta.get(block.id).cloned() {
+            Some(meta) => {
+                if meta.storage_type() == StorageType::SpdkDisk || !meta.is_final() {
+                    return Ok(None);
+                }
+
+                let dir = self
+                    .dir_list
+                    .get_dir(meta.dir_id())
+                    .ok_or_else(|| {
+                        orpc::err_msg!(format!("No storage directory found: {:?}", meta.dir_id()))
+                    })?
+                    .clone();
+                let required_bytes = meta.physical_bytes().max(block.len);
+                if required_bytes > dir.available() {
+                    return err_box!(
+                        "Not enough space in storage dir {} for block {} rewrite: need {}, available {}",
+                        meta.dir_id(),
+                        meta.id(),
+                        required_bytes,
+                        dir.available()
+                    );
+                }
+
+                let mut pending = BlockMeta::new(meta.id(), block.len, &dir);
+                pending.state = BlockState::Allocating;
+                pending.actual_len = required_bytes;
+                dir.reserve_space(false, required_bytes);
+                self.committed_rewrites.insert(meta.id(), meta.clone());
+                self.meta.put(pending.clone());
+
+                Ok(Some(FileOpenReservation {
+                    pending,
+                    committed: Some(meta),
+                    dir,
+                }))
+            }
+            None => {
+                if block.storage_type == StorageType::SpdkDisk {
+                    return Ok(None);
+                }
+
+                let dir = self
+                    .dir_list
+                    .choose_dir(StorageRequest::new(block.storage_type, block.len)?)?;
+                let mut pending = BlockMeta::with_tmp(block, &dir);
+                pending.state = BlockState::Allocating;
+                dir.reserve_space(false, pending.physical_bytes());
+                self.meta.put(pending.clone());
+
+                Ok(Some(FileOpenReservation {
+                    pending,
+                    committed: None,
+                    dir,
+                }))
+            }
+        }
+    }
+
+    pub(crate) fn complete_file_open(
+        &mut self,
+        reservation: &FileOpenReservation,
+        meta: BlockMeta,
+    ) -> CommonResult<BlockMeta> {
+        let pending = self.get_block_check(reservation.pending.id())?;
+        if pending.state() != &BlockState::Allocating {
+            return err_box!(
+                "block {} open reservation lost while in state {:?}",
+                pending.id(),
+                pending.state()
+            );
+        }
+        if meta.id() != pending.id() || meta.dir_id() != pending.dir_id() {
+            return err_box!(
+                "block {} open reservation returned different metadata",
+                pending.id()
+            );
+        }
+
+        self.meta.put(meta.clone());
+        Ok(meta)
+    }
+
+    pub(crate) fn rollback_file_open(
+        &mut self,
+        reservation: &FileOpenReservation,
+    ) -> CommonResult<()> {
+        let pending = self.meta.remove(reservation.pending.id()).ok_or_else(|| {
+            orpc::err_msg!(format!(
+                "block {} open reservation missing during rollback",
+                reservation.pending.id()
+            ))
+        })?;
+        if pending.state() != &BlockState::Allocating {
+            return err_box!(
+                "block {} open reservation changed to {:?} before rollback",
+                pending.id(),
+                pending.state()
+            );
+        }
+
+        reservation
+            .dir
+            .release_space(false, pending.physical_bytes());
+        if let Some(committed) = reservation.committed.as_ref() {
+            self.committed_rewrites.remove(&pending.id());
+            self.meta.put(committed.clone());
+        }
+        Ok(())
+    }
+
+    pub(crate) fn reserve_file_finalize(
+        &mut self,
+        block: &ExtendedBlock,
+    ) -> CommonResult<Option<FileFinalizeReservation>> {
+        let writing = self.get_block_check(block.id)?.clone();
+        if writing.storage_type() == StorageType::SpdkDisk
+            || writing.state() != &BlockState::Writing
+        {
+            return Ok(None);
+        }
+
+        let dir = self
+            .dir_list
+            .get_dir(writing.dir_id())
+            .ok_or_else(|| {
+                orpc::err_msg!(format!(
+                    "No storage directory found: {:?}",
+                    writing.dir_id()
+                ))
+            })?
+            .clone();
+        let mut pending = writing.clone();
+        pending.state = BlockState::Finalizing;
+        self.meta.put(pending.clone());
+        Ok(Some(FileFinalizeReservation {
+            writing,
+            pending,
+            dir,
+        }))
+    }
+
+    pub(crate) fn publish_file_finalize(
+        &mut self,
+        reservation: &FileFinalizeReservation,
+        plan: FileFinalizePlan,
+    ) -> CommonResult<BlockMeta> {
+        let pending = self.get_block_check(reservation.pending.id())?.clone();
+        if pending.state() != &BlockState::Finalizing {
+            return err_box!(
+                "block {} finalize reservation lost while in state {:?}",
+                pending.id(),
+                pending.state()
+            );
+        }
+        let final_meta = plan.final_meta();
+        if final_meta.id() != pending.id() || final_meta.dir_id() != pending.dir_id() {
+            return err_box!(
+                "block {} finalize plan returned different metadata",
+                pending.id()
+            );
+        }
+
+        // The plan already performed stat and directory preparation. Hold this
+        // lock only while the rename becomes visible and metadata is published.
+        let final_meta = FileLayout::publish_finalize(plan)?;
+        if let Some(committed) = self.committed_rewrites.remove(&pending.id()) {
+            reservation
+                .dir
+                .release_space(committed.is_final(), committed.physical_bytes());
+        }
+        reservation
+            .dir
+            .release_space(false, pending.physical_bytes());
+        reservation
+            .dir
+            .reserve_space(true, final_meta.physical_bytes());
+        self.meta.put(final_meta.clone());
+        Ok(final_meta)
+    }
+
+    pub(crate) fn rollback_file_finalize(
+        &mut self,
+        reservation: &FileFinalizeReservation,
+    ) -> CommonResult<()> {
+        let pending = self.get_block_check(reservation.pending.id())?;
+        if pending.state() != &BlockState::Finalizing {
+            return err_box!(
+                "block {} finalize reservation changed to {:?} before rollback",
+                pending.id(),
+                pending.state()
+            );
+        }
+        self.meta.put(reservation.writing.clone());
+        Ok(())
     }
 
     #[cfg(test)]
@@ -580,6 +815,8 @@ mod test {
         drop(ds);
         let ds = create_data_set(false, "init");
         assert_eq!(ds.num_blocks(), 11);
+        assert_eq!(ds.all_blocks().len(), 11);
+        assert!(ds.get_readable_block(1).is_some());
         Ok(())
     }
     #[test]

--- a/curvine-server/src/worker/worker_metrics.rs
+++ b/curvine-server/src/worker/worker_metrics.rs
@@ -14,7 +14,7 @@
 
 use crate::worker::block::BlockStore;
 use crate::worker::storage::Dataset;
-use orpc::common::{Counter, CounterVec, Gauge, Metrics as m, Metrics};
+use orpc::common::{Counter, CounterVec, Gauge, HistogramVec, Metrics as m, Metrics};
 use orpc::sys::SysUtils;
 use orpc::CommonResult;
 use std::fmt::{Debug, Formatter};
@@ -31,6 +31,11 @@ pub struct WorkerMetrics {
     pub(crate) read_time_us: Counter,
     pub(crate) read_count: Counter,
     pub(crate) read_blocks: CounterVec,
+
+    pub(crate) block_store_stripe_lock_wait_us: HistogramVec,
+    pub(crate) block_dataset_write_lock_wait_us: HistogramVec,
+    pub(crate) block_dataset_write_lock_hold_us: HistogramVec,
+    pub(crate) file_layout_operation_us: HistogramVec,
 
     pub(crate) capacity: Gauge,
     pub(crate) available: Gauge,
@@ -57,6 +62,27 @@ impl WorkerMetrics {
             read_time_us: m::new_counter("read_time_us", "Microseconds spent read")?,
             read_count: m::new_counter("read_count", "Number of reads")?,
             read_blocks: m::new_counter_vec("read_blocks", "read_blocks", &["type"])?,
+
+            block_store_stripe_lock_wait_us: m::new_histogram_vec(
+                "block_store_stripe_lock_wait_us",
+                "Microseconds waiting for a block-store stripe lock",
+                &["operation"],
+            )?,
+            block_dataset_write_lock_wait_us: m::new_histogram_vec(
+                "block_dataset_write_lock_wait_us",
+                "Microseconds waiting for the block-dataset write lock",
+                &["operation"],
+            )?,
+            block_dataset_write_lock_hold_us: m::new_histogram_vec(
+                "block_dataset_write_lock_hold_us",
+                "Microseconds holding the block-dataset write lock",
+                &["operation"],
+            )?,
+            file_layout_operation_us: m::new_histogram_vec(
+                "file_layout_operation_us",
+                "Microseconds spent in file-layout operations outside the dataset lock",
+                &["operation"],
+            )?,
 
             capacity: m::new_gauge("capacity", "Total storage capacity")?,
             available: m::new_gauge("available", "Total available space")?,


### PR DESCRIPTION
## Summary

Move FileLayout create, copy, and stat work outside the worker BlockDataset write lock. Keep only the atomic rename and metadata publication under the existing global lock.

## Issue / Design

Closes #1323.

A reservation publishes an internal Allocating or Finalizing state under the dataset lock. File preparation runs after that lock is released. Finalize first performs stat and path preparation outside the lock, then takes the short write lock for rename, capacity accounting, and metadata publication as one operation.

Per-block stripe locks serialize same-block mutations without replacing the existing global dataset lock. ReadHandler and replication now open the current generation while holding a dataset read lock, so rename cannot replace the selected path before its file descriptor opens. During Finalizing, short-circuit reads fall back to the server read path. Finalizing blocks remain visible to full reports as Writing; only Allocating blocks are hidden.

## Changes

| Area | Change |
| --- | --- |
| BlockStore | Two-phase file open/finalize flow, per-block stripe serialization, atomic current-generation reader open |
| VfsDataset | Reservation states, finalize publish with non-failing post-rename metadata accounting, stable report/read visibility |
| FileLayout | Split finalize preparation from atomic rename publish |
| Read and replication | Open the selected generation under the dataset read lock |
| Metrics | Record stripe wait, dataset lock wait/hold, and external FileLayout time |

## Test verified

- make format, including workspace release clippy: PASS
- cargo test -p curvine-server --lib -- --test-threads=1: PASS, 136 passed, 2 ignored
- BlockStore rollback, capacity, finalizing visibility, and reader-generation tests: PASS, 8 passed
- Manual real-file benchmark, four concurrent 32 MiB rewrites: old median 45.27 ms; final median 17.47 ms; about 2.6x faster

## Dependencies

None.