### PR TITLE
fix(build): restore native UFS client artifacts (#1243)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,8 +2,27 @@ curvine-libsdk/java/target/
 curvine-lancedb/target/
 target/
 **/target/
-# Keep .git directory for version info during build
-# **/.git/
+build/dist/
+build/.venv-python-sdk/
+build/testing/
+*.tar
+*.tar.gz
+*.tgz
+*.zip
+*.log
+.git/
+.claude/
+.codegraph/
+.cursor/
+.vscode/
+docs/
+**/node_modules/
+**/__pycache__/
+**/.pytest_cache/
+**/testing/
+curvine-libsdk/java/native/
+curvine-libsdk/python/native/
+curvine-libsdk/python/curvine_libsdk/_proto/*_pb2.py
 **/.staging/
 **/.summary/
 .debug/

--- a/build/build.sh
+++ b/build/build.sh
@@ -434,7 +434,7 @@ if should_build_package "tests"; then
 fi
 
 declare -a FEATURES=()
-declare -a CLIENT_SKIPPED_NATIVE_UFS=()
+declare -a CLIENT_SKIPPED_SERVER_NATIVE_FEATURES=()
 
 validate_feature_name() {
   local feature="$1"
@@ -458,26 +458,44 @@ add_feature() {
   FEATURES+=("$feature")
 }
 
-remember_skipped_native_ufs() {
-  local ufs="$1"
+remember_skipped_server_native_feature() {
+  local feature="$1"
   local existing
-  for existing in "${CLIENT_SKIPPED_NATIVE_UFS[@]}"; do
-    if [ "$existing" = "$ufs" ]; then
+  for existing in "${CLIENT_SKIPPED_SERVER_NATIVE_FEATURES[@]}"; do
+    if [ "$existing" = "$feature" ]; then
       return 0
     fi
   done
-  CLIENT_SKIPPED_NATIVE_UFS+=("$ufs")
+  CLIENT_SKIPPED_SERVER_NATIVE_FEATURES+=("$feature")
 }
 
-is_client_native_ufs() {
+is_native_ufs_selection() {
   case "$1" in
-    oss-hdfs|opendal-hdfs|opendal-hdfs-native)
+    oss-hdfs|opendal-hdfs|opendal-hdfs-native|curvine-client/oss-hdfs|curvine-client/opendal-hdfs|curvine-client/opendal-hdfs-native)
       return 0
       ;;
     *)
       return 1
       ;;
   esac
+}
+
+client_native_ufs_deps_allowed() {
+  local ufs
+  for ufs in "${UFS_TYPES[@]}"; do
+    if is_native_ufs_selection "$ufs"; then
+      return 0
+    fi
+  done
+
+  local feature
+  for feature in "${EXTRA_FEATURES[@]}"; do
+    if is_native_ufs_selection "$feature"; then
+      return 0
+    fi
+  done
+
+  return 1
 }
 
 append_ufs_feature() {
@@ -491,18 +509,23 @@ append_ufs_feature() {
       ;;
   esac
 
-  if { [ "$scope" = "client-safe" ] || [ "$scope" = "cli-minimal" ]; } && is_client_native_ufs "$ufs"; then
-    remember_skipped_native_ufs "$ufs"
-    return 0
-  fi
-
   case "$ufs" in
     oss-hdfs)
-      add_feature "curvine-client/oss-hdfs"
+      if [ "$scope" = "cli-minimal" ]; then
+        add_feature "curvine-cli/oss-hdfs"
+      else
+        add_feature "curvine-client/oss-hdfs"
+      fi
       ;;
     opendal-hdfs)
-      add_feature "curvine-client/opendal-hdfs"
-      add_feature "curvine-server/jni"
+      if [ "$scope" = "cli-minimal" ]; then
+        add_feature "curvine-cli/opendal-hdfs"
+      else
+        add_feature "curvine-client/opendal-hdfs"
+      fi
+      if [ "$scope" = "server-native" ] || [ "$scope" = "tests" ]; then
+        add_feature "curvine-server/jni"
+      fi
       ;;
     opendal-webhdfs)
       if [ "$scope" = "cli-minimal" ]; then
@@ -535,43 +558,47 @@ append_extra_features() {
   for feature in "${EXTRA_FEATURES[@]}"; do
     validate_feature_name "$feature" || exit 1
     case "$feature" in
-      oss-hdfs|opendal-hdfs|opendal-webhdfs|opendal-cos|opendal-hdfs-native)
+      oss-hdfs|opendal-s3|opendal-oss|opendal-gcs|opendal-azblob|opendal-cos|opendal-hdfs|opendal-webhdfs|opendal-hdfs-native)
         append_ufs_feature "$scope" "$feature"
         ;;
       jni|curvine-server/jni|curvine-ufs/jni)
         if [ "$scope" = "server-native" ] || [ "$scope" = "tests" ]; then
           add_feature "curvine-server/jni"
         else
-          remember_skipped_native_ufs "jni"
+          remember_skipped_server_native_feature "$feature"
         fi
         ;;
       spdk|curvine-server/spdk)
         if [ "$scope" = "server-native" ] || [ "$scope" = "tests" ]; then
           add_feature "curvine-server/spdk"
+        else
+          remember_skipped_server_native_feature "$feature"
         fi
         ;;
       spdk-rdma|curvine-server/spdk-rdma)
         if [ "$scope" = "server-native" ] || [ "$scope" = "tests" ]; then
           add_feature "curvine-server/spdk-rdma"
-        fi
-        ;;
-      curvine-ufs/oss-hdfs|curvine-ufs/opendal-hdfs|curvine-ufs/opendal-hdfs-native)
-        if [ "$scope" = "server-native" ] || [ "$scope" = "tests" ]; then
-          add_feature "curvine-client/${feature#curvine-ufs/}"
         else
-          remember_skipped_native_ufs "$feature"
+          remember_skipped_server_native_feature "$feature"
         fi
         ;;
-      curvine-client/oss-hdfs|curvine-client/opendal-hdfs|curvine-client/opendal-hdfs-native)
-        if [ "$scope" = "server-native" ] || [ "$scope" = "tests" ]; then
+      curvine-ufs/oss-hdfs|curvine-ufs/opendal-s3|curvine-ufs/opendal-oss|curvine-ufs/opendal-gcs|curvine-ufs/opendal-azblob|curvine-ufs/opendal-cos|curvine-ufs/opendal-hdfs|curvine-ufs/opendal-webhdfs|curvine-ufs/opendal-hdfs-native)
+        echo "Error: ${feature} does not enable the corresponding client adapter; use --ufs instead" >&2
+        exit 1
+        ;;
+      curvine-client/oss-hdfs|curvine-client/opendal-s3|curvine-client/opendal-oss|curvine-client/opendal-gcs|curvine-client/opendal-azblob|curvine-client/opendal-cos|curvine-client/opendal-hdfs|curvine-client/opendal-webhdfs|curvine-client/opendal-hdfs-native)
+        if [ "$scope" = "cli-minimal" ]; then
+          echo "Error: ${feature} does not enable the corresponding CLI adapter; use --ufs instead" >&2
+          exit 1
+        else
           add_feature "$feature"
-        else
-          remember_skipped_native_ufs "$feature"
         fi
         ;;
       curvine-server/*)
         if [ "$scope" = "server-native" ] || [ "$scope" = "tests" ]; then
           add_feature "$feature"
+        else
+          remember_skipped_server_native_feature "$feature"
         fi
         ;;
       *)
@@ -681,8 +708,16 @@ check_minimal_artifact_deps() {
 
   local needed
   needed="$(artifact_dynamic_entries "$inspector" "$artifact")"
-  if grep -E 'libibverbs\.so|librdmacm\.so|libspdk|librte_|libjindosdk|libhdfs|libjvm|libjli' <<<"$needed" >/dev/null; then
-    echo "Error: ${label} contains native server/storage runtime dependencies forbidden for minimal client artifacts:" >&2
+  local server_native_pattern='libibverbs\.so|librdmacm\.so|libspdk|librte_'
+  if grep -E "$server_native_pattern" <<<"$needed" >/dev/null; then
+    echo "Error: ${label} contains server-native RDMA/SPDK runtime dependencies forbidden for client artifacts:" >&2
+    echo "$needed" >&2
+    exit 1
+  fi
+
+  local native_ufs_pattern='libjindosdk|libhdfs|libjvm|libjli'
+  if ! client_native_ufs_deps_allowed && grep -E "$native_ufs_pattern" <<<"$needed" >/dev/null; then
+    echo "Error: ${label} contains native UFS runtime dependencies but no native --ufs/feature was requested:" >&2
     echo "$needed" >&2
     exit 1
   fi
@@ -702,10 +737,6 @@ libsdk_features() {
         return 1
         ;;
     esac
-    if is_client_native_ufs "$ufs"; then
-      remember_skipped_native_ufs "$ufs"
-      continue
-    fi
     features="${features},${ufs}"
   done
   echo "$features"
@@ -776,8 +807,8 @@ if [ $ENABLE_SPDK_RDMA -eq 1 ]; then
 fi
 TEST_FEATURES=("${FEATURES[@]}")
 
-if [ ${#CLIENT_SKIPPED_NATIVE_UFS[@]} -gt 0 ]; then
-  echo "Client-safe/minimal artifacts skip native server/storage features: ${CLIENT_SKIPPED_NATIVE_UFS[*]}"
+if [ ${#CLIENT_SKIPPED_SERVER_NATIVE_FEATURES[@]} -gt 0 ]; then
+  echo "Client artifacts skip server-native features: ${CLIENT_SKIPPED_SERVER_NATIVE_FEATURES[*]}"
 fi
 
 # Set SPDK_DIR environment variable for build.rs

--- a/curvine-docker/deploy/Dockerfile_rocky9
+++ b/curvine-docker/deploy/Dockerfile_rocky9
@@ -127,9 +127,13 @@ RUN echo "Building Curvine from source..." && \
     rm -rf /workspace/tmp
 
 # 9. Create output directory and copy build artifacts from build/dist
+ARG GIT_VERSION=unknown
 RUN mkdir -p /build-output && \
     echo "Copying build/dist contents to /build-output..." && \
     cp -r /workspace/build/dist/* /build-output/ && \
+    if [ -f "/build-output/build-version" ]; then \
+        sed -i "s/^commit=.*/commit=${GIT_VERSION}/" /build-output/build-version; \
+    fi && \
     # Verify critical files exist
     if [ ! -f "/build-output/bin/launch-process.sh" ]; then \
         echo "✗ ERROR: launch-process.sh not found in build/dist/bin" && \

--- a/curvine-docker/deploy/Dockerfile_ubuntu24
+++ b/curvine-docker/deploy/Dockerfile_ubuntu24
@@ -183,9 +183,13 @@ RUN echo "Building Curvine from source..." && \
     rm -rf /workspace/tmp
 
 # 10. Create output directory and copy build artifacts from build/dist
+ARG GIT_VERSION=unknown
 RUN mkdir -p /build-output && \
     echo "Copying build/dist contents to /build-output..." && \
     cp -r /workspace/build/dist/* /build-output/ && \
+    if [ -f "/build-output/build-version" ]; then \
+        sed -i "s/^commit=.*/commit=${GIT_VERSION}/" /build-output/build-version; \
+    fi && \
     # Verify critical files exist
     if [ ! -f "/build-output/bin/launch-process.sh" ]; then \
         echo "✗ ERROR: launch-process.sh not found in build/dist/bin" && \

--- a/curvine-docker/deploy/build-image.sh
+++ b/curvine-docker/deploy/build-image.sh
@@ -99,11 +99,18 @@ build_image() {
     # Build Docker image directly from project root
     print_info "Building Docker image: $IMAGE_NAME:$IMAGE_TAG"
     print_warning "Note: Source build requires longer time, please be patient..."
+
+    GIT_VERSION="unknown"
+    if command -v git &> /dev/null && git -C "$PROJECT_ROOT" rev-parse --git-dir &> /dev/null; then
+        GIT_VERSION="$(git -C "$PROJECT_ROOT" rev-parse --short HEAD)"
+    fi
+    print_info "Using git version: $GIT_VERSION"
     
     # Build with project root as context
     # .dockerignore will filter out unnecessary files
     if ! docker build \
         --shm-size=2g \
+        --build-arg "GIT_VERSION=$GIT_VERSION" \
         -f "$SCRIPT_DIR/$DOCKERFILE_NAME" \
         -t "$IMAGE_NAME:$IMAGE_TAG" \
         "$PROJECT_ROOT"; then


### PR DESCRIPTION
# Summary

Restores explicitly requested native UFS backends in client, CLI, and SDK release artifacts while preserving #1361's explicit adapter boundaries and server-only native isolation.

# Issue Describe / Design

Related to #1243 and #1280.

Root cause: #1280's client-safety filter dropped requested native UFS features from client build scopes. After #1361, adapters are composed through dedicated `curvine-client`, `curvine-cli`, and UFS adapter crates, so the former feature routes cannot be reinstated verbatim.

This change:

- routes `--ufs oss-hdfs` and `--ufs opendal-hdfs` through their client or CLI composition features;
- retains server-native JNI, RDMA, SPDK, and DPDK exclusions from client artifacts;
- rejects raw `curvine-ufs/<backend>` feature strings because they do not enable their corresponding client adapter; callers must use `--ufs`;
- permits direct `curvine-client/<backend>` selections where the build scope can compose them;
- restores Docker release-image inputs and build contexts required by native UFS builds.

# Changes

| Area | Change |
| --- | --- |
| `build/build.sh` | Route native UFS into current client/CLI feature composition, preserve server-only feature exclusions, and reject incomplete raw UFS adapter features. |
| Docker build files | Restore native-library build inputs and release image contexts for Rocky 9 and Ubuntu 24. |

# Test verified

- `bash -n build/build.sh`
- `bash -n curvine-docker/deploy/build-image.sh`
- `git diff --check github-https/main..HEAD`
- `cargo tree -p curvine-cli --no-default-features --features curvine-cli/oss-hdfs`
- `cargo tree -p curvine-cli --no-default-features --features curvine-cli/opendal-hdfs`

The feature graphs include the intended CLI composition and their corresponding UFS adapters. Functional shell tests and a full native release build were not run at the requester's direction.

# Dependencies

- Related PRs: #1280, #1361
