### PR TITLE
fix(fuse): readdir seekable offsets

### DIFF
--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -376,13 +376,17 @@ impl CurvineFileSystem {
         plus: bool,
     ) -> FuseResult<(FuseDirentList, u64)> {
         let handle = self.state.find_dir_handle(header.nodeid, arg.fh)?;
+        let path = Path::from_str(&handle.path)?;
 
         let mut res = FuseDirentList::new(arg);
         let mut index = arg.offset;
-        let mut batch = handle.get_batch(arg.offset as usize).await?;
+        let mut batch = handle
+            .get_batch(arg.offset as usize, || self.state.list_stream(&path))
+            .await?;
         {
             let mut dir = self.state.dir_write();
             while let Some(status) = batch.pop_front() {
+                let status = status.as_ref();
                 let attr = if status.name != FUSE_CURRENT_DIR && status.name != FUSE_PARENT_DIR {
                     // READDIRPLUS takes a kernel lookup ref (kernel caches the
                     // dentry and will send a FORGET); plain READDIR must not
@@ -394,22 +398,19 @@ impl CurvineFileSystem {
                     self.state.record_status_put();
                     attr
                 } else {
-                    FuseUtils::status_to_attr(&self.conf, &status)?
+                    FuseUtils::status_to_attr(&self.conf, status)?
                 };
 
                 let entry = FuseUtils::create_entry_out(&self.conf, attr);
                 // dirent `off` is the resume cookie = position of the NEXT entry.
                 // See `readdir_next_cookie` (the infinite-loop guard).
                 let next_off = Self::readdir_next_cookie(index);
-                if !res.add_dirent(plus, next_off, &status, entry) {
-                    batch.push_front(status);
+                if !res.add_dirent(plus, next_off, status, entry) {
                     break;
                 }
                 index += 1;
             }
         }
-        handle.set_buf(batch).await?;
-
         let entries = index.saturating_sub(arg.offset);
         Ok((res, entries))
     }
@@ -2832,7 +2833,12 @@ mod tests {
                         1000,
                         ListStream::from_vec(entries(names)),
                     );
-                    let batch = handle.get_batch(offset as usize).await.unwrap();
+                    let batch = handle
+                        .get_batch(offset as usize, || async {
+                            Ok(ListStream::from_vec(entries(names)))
+                        })
+                        .await
+                        .unwrap();
                     if batch.is_empty() {
                         return Ok(seen); // kernel sees 0 entries => readdir done
                     }
@@ -2901,7 +2907,12 @@ mod tests {
                 for _ in 0..max_rounds {
                     let handle =
                         DirHandle::new(1, 1, &path, 1000, ListStream::from_vec(entries(names)));
-                    let batch = handle.get_batch(offset as usize).await.unwrap();
+                    let batch = handle
+                        .get_batch(offset as usize, || async {
+                            Ok(ListStream::from_vec(entries(names)))
+                        })
+                        .await
+                        .unwrap();
                     if batch.is_empty() {
                         return Ok(seen); // kernel sees 0 entries => readdir done
                     }
@@ -2996,7 +3007,12 @@ mod tests {
                 let mut offset: u64 = 0;
 
                 for _ in 0..max_rounds {
-                    let mut batch = handle.get_batch(offset as usize).await.unwrap();
+                    let mut batch = handle
+                        .get_batch(offset as usize, || async {
+                            Ok(ListStream::from_vec(entries(names)))
+                        })
+                        .await
+                        .unwrap();
                     if batch.is_empty() {
                         return Ok(seen); // kernel sees 0 entries => readdir done
                     }
@@ -3017,9 +3033,6 @@ mod tests {
                             None => break,
                         }
                     }
-                    // Push the unemitted remainder back, exactly as the daemon does
-                    // when the kernel response buffer fills mid-batch.
-                    handle.set_buf(batch).await.unwrap();
                     offset = last_cookie;
                 }
                 Err(format!(

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -376,12 +376,12 @@ impl CurvineFileSystem {
         plus: bool,
     ) -> FuseResult<(FuseDirentList, u64)> {
         let handle = self.state.find_dir_handle(header.nodeid, arg.fh)?;
-        let path = Path::from_str(&handle.path)?;
+        let path = self.state.get_path(header.nodeid)?;
 
         let mut res = FuseDirentList::new(arg);
         let mut index = arg.offset;
         let mut batch = handle
-            .get_batch(arg.offset as usize, || self.state.list_stream(&path))
+            .get_batch(arg.offset as usize, &path, || self.state.list_stream(&path))
             .await?;
         {
             let mut dir = self.state.dir_write();
@@ -2834,7 +2834,7 @@ mod tests {
                         ListStream::from_vec(entries(names)),
                     );
                     let batch = handle
-                        .get_batch(offset as usize, || async {
+                        .get_batch(offset as usize, &path, || async {
                             Ok(ListStream::from_vec(entries(names)))
                         })
                         .await
@@ -2908,7 +2908,7 @@ mod tests {
                     let handle =
                         DirHandle::new(1, 1, &path, 1000, ListStream::from_vec(entries(names)));
                     let batch = handle
-                        .get_batch(offset as usize, || async {
+                        .get_batch(offset as usize, &path, || async {
                             Ok(ListStream::from_vec(entries(names)))
                         })
                         .await
@@ -3008,7 +3008,7 @@ mod tests {
 
                 for _ in 0..max_rounds {
                     let mut batch = handle
-                        .get_batch(offset as usize, || async {
+                        .get_batch(offset as usize, &path, || async {
                             Ok(ListStream::from_vec(entries(names)))
                         })
                         .await

--- a/curvine-fuse/src/fs/state/dir_handle.rs
+++ b/curvine-fuse/src/fs/state/dir_handle.rs
@@ -31,6 +31,7 @@ const CACHE_BATCHES: usize = 4;
 
 struct InnerStream {
     stream: ListStream,
+    stream_path: String,
     cache: VecDeque<Arc<FileStatus>>,
     base_off: usize,
     next_off: usize,
@@ -38,9 +39,10 @@ struct InnerStream {
 }
 
 impl InnerStream {
-    pub fn new(stream: ListStream) -> Self {
+    pub fn new(stream: ListStream, stream_path: String) -> Self {
         Self {
             stream,
+            stream_path,
             cache: VecDeque::new(),
             base_off: 0,
             next_off: 0,
@@ -72,11 +74,12 @@ pub struct DirHandle {
 
 impl DirHandle {
     pub fn new(ino: u64, fh: u64, path: &Path, limit: usize, stream: ListStream) -> Self {
+        let path = path.clone_uri();
         Self {
             ino,
             fh,
-            path: path.clone_uri(),
-            stream: Some(Mutex::new(InnerStream::new(stream))),
+            stream: Some(Mutex::new(InnerStream::new(stream, path.clone()))),
+            path,
             limit,
         }
     }
@@ -95,6 +98,7 @@ impl DirHandle {
     pub async fn get_batch<F, Fut>(
         &self,
         off: usize,
+        current_path: &Path,
         new_stream: F,
     ) -> FuseResult<VecDeque<Arc<FileStatus>>>
     where
@@ -102,11 +106,12 @@ impl DirHandle {
         Fut: Future<Output = FuseResult<ListStream>>,
     {
         let mut guard = self.guard().await?;
+        let current_path = current_path.full_path();
 
-        // Cookies older than the bounded window remain seekable by replaying the
-        // backend stream. The common forward path stays within the window.
-        if off < guard.base_off {
-            *guard = InnerStream::new(new_stream().await?);
+        // Rename keeps an open directory fd valid, so a stream bound to an old
+        // path must be rebuilt even when the requested cookie is still cached.
+        if guard.stream_path != current_path || off < guard.base_off {
+            *guard = InnerStream::new(new_stream().await?, current_path.to_string());
         }
 
         let target = off.saturating_add(self.limit);
@@ -131,7 +136,8 @@ impl DirHandle {
     }
 
     pub fn set_stream(&mut self, stream: ListStream) {
-        self.stream.replace(Mutex::new(InnerStream::new(stream)));
+        self.stream
+            .replace(Mutex::new(InnerStream::new(stream, self.path.clone())));
     }
 }
 
@@ -177,19 +183,40 @@ mod tests {
                 async { Ok::<_, FuseError>(ListStream::from_vec(test_entries())) }
             };
 
-            assert_eq!(names(handle.get_batch(0, fresh).await.unwrap()), ["a", "b"]);
-            assert_eq!(names(handle.get_batch(2, fresh).await.unwrap()), ["c", "d"]);
-            assert_eq!(names(handle.get_batch(4, fresh).await.unwrap()), ["e", "f"]);
-            assert_eq!(names(handle.get_batch(6, fresh).await.unwrap()), ["g", "h"]);
-            assert_eq!(names(handle.get_batch(8, fresh).await.unwrap()), ["i", "j"]);
-            assert!(handle.get_batch(10, fresh).await.unwrap().is_empty());
+            assert_eq!(
+                names(handle.get_batch(0, &path, fresh).await.unwrap()),
+                ["a", "b"]
+            );
+            assert_eq!(
+                names(handle.get_batch(2, &path, fresh).await.unwrap()),
+                ["c", "d"]
+            );
+            assert_eq!(
+                names(handle.get_batch(4, &path, fresh).await.unwrap()),
+                ["e", "f"]
+            );
+            assert_eq!(
+                names(handle.get_batch(6, &path, fresh).await.unwrap()),
+                ["g", "h"]
+            );
+            assert_eq!(
+                names(handle.get_batch(8, &path, fresh).await.unwrap()),
+                ["i", "j"]
+            );
+            assert!(handle.get_batch(10, &path, fresh).await.unwrap().is_empty());
 
             // Offset 2 is still in the retained four-batch window.
-            assert_eq!(names(handle.get_batch(2, fresh).await.unwrap()), ["c", "d"]);
+            assert_eq!(
+                names(handle.get_batch(2, &path, fresh).await.unwrap()),
+                ["c", "d"]
+            );
             assert_eq!(resets.get(), 0);
 
             // Offset 0 has fallen out of the window and is recovered by replay.
-            assert_eq!(names(handle.get_batch(0, fresh).await.unwrap()), ["a", "b"]);
+            assert_eq!(
+                names(handle.get_batch(0, &path, fresh).await.unwrap()),
+                ["a", "b"]
+            );
             assert_eq!(resets.get(), 1);
 
             let guard = handle.guard().await.unwrap();
@@ -211,15 +238,54 @@ mod tests {
                 async { Ok::<_, FuseError>(ListStream::from_vec(test_entries())) }
             };
 
-            assert_eq!(names(handle.get_batch(9, fresh).await.unwrap()), ["j"]);
+            assert_eq!(
+                names(handle.get_batch(9, &path, fresh).await.unwrap()),
+                ["j"]
+            );
             assert_eq!(resets.get(), 0);
 
-            assert_eq!(names(handle.get_batch(1, fresh).await.unwrap()), ["b", "c"]);
+            assert_eq!(
+                names(handle.get_batch(1, &path, fresh).await.unwrap()),
+                ["b", "c"]
+            );
             assert_eq!(resets.get(), 1);
 
             let guard = handle.guard().await.unwrap();
             assert!(guard.cache.len() <= handle.cache_limit());
             assert_eq!(guard.base_off, 0);
+        });
+    }
+
+    #[test]
+    fn rename_then_rewind_rebuilds_from_current_path() {
+        let rt = AsyncRuntime::single();
+        rt.block_on(async {
+            let old_path = Path::from_str("/old/d").unwrap();
+            let new_path = Path::from_str("/new/d").unwrap();
+            let handle = DirHandle::new(1, 1, &old_path, 2, ListStream::from_vec(test_entries()));
+            let resets = Cell::new(0);
+
+            let fresh = || {
+                resets.set(resets.get() + 1);
+                async { Ok::<_, FuseError>(ListStream::from_vec(test_entries())) }
+            };
+
+            assert_eq!(
+                names(handle.get_batch(8, &old_path, fresh).await.unwrap()),
+                ["i", "j"]
+            );
+            assert_eq!(resets.get(), 0);
+
+            // The inode is now reachable through a different path. Rewinding the
+            // still-open handle must rebuild from that path, not DirHandle.path.
+            assert_eq!(
+                names(handle.get_batch(0, &new_path, fresh).await.unwrap()),
+                ["a", "b"]
+            );
+            assert_eq!(resets.get(), 1);
+
+            let guard = handle.guard().await.unwrap();
+            assert_eq!(guard.stream_path, new_path.full_path());
         });
     }
 }

--- a/curvine-fuse/src/fs/state/dir_handle.rs
+++ b/curvine-fuse/src/fs/state/dir_handle.rs
@@ -16,25 +16,45 @@ use curvine_common::fs::{ListStream, Path};
 use curvine_common::state::FileStatus;
 use curvine_common::FsResult;
 use futures::StreamExt;
-use log::info;
 use orpc::err_box;
 use serde::{Deserialize, Serialize};
 use std::collections::VecDeque;
-use std::mem;
+use std::future::Future;
+use std::sync::Arc;
 use tokio::sync::{Mutex, MutexGuard};
+
+use crate::FuseResult;
+
+// Keep a few response batches for seekdir-heavy workloads while placing a
+// strict per-handle bound on retained FileStatus values.
+const CACHE_BATCHES: usize = 4;
 
 struct InnerStream {
     stream: ListStream,
-    buf: VecDeque<FileStatus>,
-    index: usize,
+    cache: VecDeque<Arc<FileStatus>>,
+    base_off: usize,
+    next_off: usize,
+    eof: bool,
 }
 
 impl InnerStream {
     pub fn new(stream: ListStream) -> Self {
         Self {
             stream,
-            buf: VecDeque::new(),
-            index: 0,
+            cache: VecDeque::new(),
+            base_off: 0,
+            next_off: 0,
+            eof: false,
+        }
+    }
+
+    fn push(&mut self, status: FileStatus, keep_from: usize, cache_limit: usize) {
+        self.cache.push_back(Arc::new(status));
+        self.next_off += 1;
+
+        while self.cache.len() > cache_limit && self.base_off < keep_from {
+            self.cache.pop_front();
+            self.base_off += 1;
         }
     }
 }
@@ -68,44 +88,138 @@ impl DirHandle {
         }
     }
 
-    pub async fn get_batch(&self, off: usize) -> FsResult<VecDeque<FileStatus>> {
-        let mut guard = self.guard().await?;
-
-        if off > 0 && guard.index == 0 {
-            info!(
-                "readdir {} skipping {} list entries (resume offset / inner index reset)",
-                self.path, off
-            );
-            while guard.index < off {
-                match guard.stream.next().await {
-                    Some(Ok(_)) => guard.index += 1,
-                    Some(Err(e)) => return Err(e),
-                    None => return Ok(VecDeque::new()),
-                }
-            }
-        }
-
-        while guard.buf.len() < self.limit {
-            match guard.stream.next().await {
-                Some(Ok(s)) => {
-                    guard.buf.push_back(s);
-                    guard.index += 1;
-                }
-                Some(Err(e)) => return Err(e),
-                None => break,
-            }
-        }
-
-        Ok(mem::take(&mut guard.buf))
+    fn cache_limit(&self) -> usize {
+        self.limit.saturating_mul(CACHE_BATCHES)
     }
 
-    pub async fn set_buf(&self, buf: VecDeque<FileStatus>) -> FsResult<()> {
+    pub async fn get_batch<F, Fut>(
+        &self,
+        off: usize,
+        new_stream: F,
+    ) -> FuseResult<VecDeque<Arc<FileStatus>>>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = FuseResult<ListStream>>,
+    {
         let mut guard = self.guard().await?;
-        guard.buf = buf;
-        Ok(())
+
+        // Cookies older than the bounded window remain seekable by replaying the
+        // backend stream. The common forward path stays within the window.
+        if off < guard.base_off {
+            *guard = InnerStream::new(new_stream().await?);
+        }
+
+        let target = off.saturating_add(self.limit);
+        let cache_limit = self.cache_limit();
+
+        while guard.next_off < target && !guard.eof {
+            match guard.stream.next().await {
+                Some(Ok(status)) => guard.push(status, off, cache_limit),
+                Some(Err(e)) => return Err(e.into()),
+                None => guard.eof = true,
+            }
+        }
+
+        let start = off.saturating_sub(guard.base_off);
+        Ok(guard
+            .cache
+            .iter()
+            .skip(start)
+            .take(self.limit)
+            .cloned()
+            .collect())
     }
 
     pub fn set_stream(&mut self, stream: ListStream) {
         self.stream.replace(Mutex::new(InnerStream::new(stream)));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DirHandle;
+    use crate::FuseError;
+    use curvine_common::fs::{ListStream, Path};
+    use curvine_common::state::FileStatus;
+    use orpc::runtime::{AsyncRuntime, RpcRuntime};
+    use std::cell::Cell;
+    use std::sync::Arc;
+
+    fn entries(names: &[&str]) -> Vec<FileStatus> {
+        names
+            .iter()
+            .enumerate()
+            .map(|(index, name)| FileStatus::with_name(index as i64 + 10, name.to_string(), false))
+            .collect()
+    }
+
+    fn test_entries() -> Vec<FileStatus> {
+        entries(&["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"])
+    }
+
+    fn names(batch: impl IntoIterator<Item = Arc<FileStatus>>) -> Vec<String> {
+        batch
+            .into_iter()
+            .map(|status| status.name.clone())
+            .collect()
+    }
+
+    #[test]
+    fn batches_support_backward_seek_and_rewind() {
+        let rt = AsyncRuntime::single();
+        rt.block_on(async {
+            let path = Path::from_str("/d").unwrap();
+            let handle = DirHandle::new(1, 1, &path, 2, ListStream::from_vec(test_entries()));
+            let resets = Cell::new(0);
+
+            let fresh = || {
+                resets.set(resets.get() + 1);
+                async { Ok::<_, FuseError>(ListStream::from_vec(test_entries())) }
+            };
+
+            assert_eq!(names(handle.get_batch(0, fresh).await.unwrap()), ["a", "b"]);
+            assert_eq!(names(handle.get_batch(2, fresh).await.unwrap()), ["c", "d"]);
+            assert_eq!(names(handle.get_batch(4, fresh).await.unwrap()), ["e", "f"]);
+            assert_eq!(names(handle.get_batch(6, fresh).await.unwrap()), ["g", "h"]);
+            assert_eq!(names(handle.get_batch(8, fresh).await.unwrap()), ["i", "j"]);
+            assert!(handle.get_batch(10, fresh).await.unwrap().is_empty());
+
+            // Offset 2 is still in the retained four-batch window.
+            assert_eq!(names(handle.get_batch(2, fresh).await.unwrap()), ["c", "d"]);
+            assert_eq!(resets.get(), 0);
+
+            // Offset 0 has fallen out of the window and is recovered by replay.
+            assert_eq!(names(handle.get_batch(0, fresh).await.unwrap()), ["a", "b"]);
+            assert_eq!(resets.get(), 1);
+
+            let guard = handle.guard().await.unwrap();
+            assert!(guard.cache.len() <= handle.cache_limit());
+            assert_eq!(guard.base_off, 0);
+        });
+    }
+
+    #[test]
+    fn fresh_stream_can_resume_from_nonzero_offset() {
+        let rt = AsyncRuntime::single();
+        rt.block_on(async {
+            let path = Path::from_str("/d").unwrap();
+            let handle = DirHandle::new(1, 1, &path, 2, ListStream::from_vec(test_entries()));
+            let resets = Cell::new(0);
+
+            let fresh = || {
+                resets.set(resets.get() + 1);
+                async { Ok::<_, FuseError>(ListStream::from_vec(test_entries())) }
+            };
+
+            assert_eq!(names(handle.get_batch(9, fresh).await.unwrap()), ["j"]);
+            assert_eq!(resets.get(), 0);
+
+            assert_eq!(names(handle.get_batch(1, fresh).await.unwrap()), ["b", "c"]);
+            assert_eq!(resets.get(), 1);
+
+            let guard = handle.guard().await.unwrap();
+            assert!(guard.cache.len() <= handle.cache_limit());
+            assert_eq!(guard.base_off, 0);
+        });
     }
 }

--- a/curvine-fuse/src/fs/state/dir_handle.rs
+++ b/curvine-fuse/src/fs/state/dir_handle.rs
@@ -135,7 +135,8 @@ impl DirHandle {
             .collect())
     }
 
-    pub fn set_stream(&mut self, stream: ListStream) {
+    pub fn set_stream(&mut self, path: &Path, stream: ListStream) {
+        self.path = path.clone_uri();
         self.stream
             .replace(Mutex::new(InnerStream::new(stream, self.path.clone())));
     }

--- a/curvine-fuse/src/fs/state/node_state.rs
+++ b/curvine-fuse/src/fs/state/node_state.rs
@@ -1147,6 +1147,10 @@ impl NodeState {
         Ok(ListStream::new(dots.chain(inner)))
     }
 
+    fn restored_dir_handle_path(&self, handle: &DirHandle) -> FuseResult<Path> {
+        self.get_path(handle.ino)
+    }
+
     pub async fn restore(&self, reader: &mut StateReader) -> FuseResult<()> {
         let metrics_enabled = self.conf.metrics_enabled;
 
@@ -1224,9 +1228,11 @@ impl NodeState {
                 let dir_handles_count = reader.read_len()?;
                 for _ in 0..dir_handles_count {
                     let mut handle = reader.read_struct::<DirHandle>()?;
-                    let path = Path::from_str(&handle.path)?;
+                    // DirHandle.path may be the original open-time path. The
+                    // restored dcache is authoritative after a rename.
+                    let path = self.restored_dir_handle_path(&handle)?;
                     let stream = self.list_stream(&path).await?;
-                    handle.set_stream(stream);
+                    handle.set_stream(&path, stream);
 
                     self.dir_handles
                         .write()
@@ -1489,6 +1495,89 @@ mod test {
                 result.is_err(),
                 "a corrupt file-handle record must fail the whole state restore"
             );
+        });
+    }
+
+    #[test]
+    fn persisted_dir_handle_resolves_path_after_ancestor_rename() {
+        let rt = Arc::new(AsyncRuntime::single());
+        let task_rt = rt.clone();
+
+        rt.block_on(async move {
+            crate::FuseMetrics::ensure_init().unwrap();
+            let fs = UnifiedFileSystem::with_rt(ClusterConf::default(), task_rt).unwrap();
+            let persisted_state = NodeState::new(fs.clone()).unwrap();
+            let restored_state = NodeState::new(fs).unwrap();
+
+            let dir_ino = {
+                let mut tree = persisted_state.dir_write();
+                let parent_ino = tree
+                    .lookup(
+                        FUSE_ROOT_ID,
+                        "old",
+                        FileStatus::with_name(10, "old".to_string(), true),
+                        false,
+                    )
+                    .unwrap()
+                    .ino;
+                tree.lookup(
+                    parent_ino,
+                    "d",
+                    FileStatus::with_name(11, "d".to_string(), true),
+                    false,
+                )
+                .unwrap()
+                .ino
+            };
+
+            let old_path = persisted_state.get_path(dir_ino).unwrap();
+            let handle = Arc::new(DirHandle::new(
+                dir_ino,
+                77,
+                &old_path,
+                16,
+                ListStream::new(futures::stream::empty()),
+            ));
+            persisted_state
+                .dir_handles
+                .write()
+                .entry(dir_ino)
+                .or_default()
+                .insert(handle.fh, handle);
+
+            persisted_state
+                .rename(FUSE_ROOT_ID, "old", FUSE_ROOT_ID, "new")
+                .unwrap();
+            assert_eq!(
+                persisted_state.get_path(dir_ino).unwrap().full_path(),
+                "/new/d"
+            );
+
+            let state_path = Utils::temp_file();
+            let _ = std::fs::remove_file(&state_path);
+            let mut writer = StateWriter::new(&state_path).unwrap();
+            persisted_state.persist(&mut writer).await.unwrap();
+            writer.flush().unwrap();
+            drop(writer);
+
+            let mut reader = StateReader::new(&state_path).unwrap();
+            let mut magic = [0u8; 4];
+            reader.read_exact(&mut magic).unwrap();
+            assert_eq!(&magic, crate::STATE_FILE_MAGIC);
+            assert_eq!(reader.read_len().unwrap(), crate::STATE_FILE_VERSION);
+            restored_state.dir_write().restore(&mut reader).unwrap();
+
+            assert_eq!(reader.read_len().unwrap(), 0, "no file handles persisted");
+            assert_eq!(reader.read_len().unwrap(), 1, "one dir handle persisted");
+            let persisted_handle = reader.read_struct::<DirHandle>().unwrap();
+            assert_eq!(persisted_handle.path, "/old/d");
+
+            let restored_path = restored_state
+                .restored_dir_handle_path(&persisted_handle)
+                .unwrap();
+            assert_eq!(restored_path.full_path(), "/new/d");
+            drop(reader);
+            let _ = std::fs::remove_file(&state_path);
         });
     }
 


### PR DESCRIPTION
**Summary**

Make FUSE directory offsets seekable after forward iteration, EOF, and backward `lseek()` while keeping per-directory-handle memory bounded.

Curvine previously backed each open directory with a forward-only `ListStream`. Sequential readdir calls worked, but entries that had already been consumed could no longer be recovered. Seeking to an earlier `d_off`, especially after reaching EOF, could therefore return the wrong entry or an empty result.

The fix adds a bounded sliding window to each directory handle. Recent entries are served directly from the window, while offsets older than the retained window rebuild and replay the backend stream. The window stores `Arc<FileStatus>` values so constructing a response batch only clones shared references instead of deeply cloning paths, names, and xattrs.

**Background**

Linux directory offsets are opaque resume cookies. Applications can save a position using `telldir()` or the `d_off` returned by `getdents64()`, then restore it with `seekdir()` or `lseek()` on the directory file descriptor.

This behavior is used by directory scanners, backup and synchronization tools, filesystem gateways, indexers, and applications that paginate or resume large directory walks. A directory implementation must therefore support more than strictly forward iteration: a previously returned cookie can be supplied again while the directory handle remains open.

**Root Cause**

The old `DirHandle` tracked:

```text
stream  forward-only backend ListStream
buf     entries fetched but not yet emitted
index   number of entries consumed from the stream
```

`get_batch()` moved the current buffer out of the handle, filled it by consuming the stream, and returned it to the caller. If the FUSE response buffer filled, the un-emitted suffix was written back with `set_buf()`.

This retained only the current response remainder. Entries successfully emitted in earlier calls were permanently discarded from the forward stream. For example:

```text
readdir(offset=0) -> a, b, c
readdir(offset=3) -> d, e, f
lseek(offset=1)
readdir(offset=1) -> expected b, c, d
```

At the final request, `b` and `c` were no longer available. Once the stream had reached EOF, the handle could not recover any historical position at all.

An initial implementation retained every consumed `FileStatus`, which restored seek behavior but made memory grow with the total number of entries visited by every open directory handle. It also deeply cloned up to `list_limit` statuses for each response batch.

**Changes**

- Replace the one-shot response buffer with a sliding history window containing `Arc<FileStatus>` entries.
- Track `base_off`, `next_off`, and EOF state so offsets can be translated into positions inside the retained window.
- Retain at most four readdir batches per directory handle:

  ```text
  cache_limit = list_limit * 4
  ```

- Serve forward reads and recent backward seeks directly from the retained window.
- Recreate and replay the backend `ListStream` when a requested cookie is older than the window.
- Remove `set_buf()`: entries not emitted because the kernel response buffer is full remain available in the sliding window and are selected by the next request's offset.
- Clone `Arc` references when building a batch instead of deeply cloning every `FileStatus`.
- Add focused regression tests for forward batching, EOF, window-local backward seeks, replay outside the window, rewind to zero, nonzero initial offsets, and the cache-size bound.

**Memory and Performance**

The retained history is bounded per open directory handle. With the default `list_limit=1000`, a handle keeps at most approximately 4000 directory statuses, regardless of the total directory size or how long the handle remains open. The cache is released when the kernel sends `RELEASEDIR` and Curvine drops the corresponding `DirHandle`.

Using four batches instead of one preserves locality for seek-heavy directory workloads. A one-batch prototype remained correct but caused the random-seek regression to increase from approximately 47 seconds to 141 seconds because most historical cookies required a complete replay. Four batches completed the same workload in approximately 42 seconds while retaining a strict entry-count limit.

Offsets older than the window still require replay from the start of the directory. Repeated long-distance random seeks in directories substantially larger than the window can therefore generate additional Master RPCs and CPU work. This is the intentional tradeoff for bounded handle memory without requiring a new persistent directory-cookie protocol.

**Concurrent Directory Changes**

Replaying an old offset creates a new view of the current directory. If entries are created, removed, or renamed between the original read and the replay, the ordering associated with a numerical cookie can change.

This change does not introduce directory snapshots or versioned cookies. It restores seek behavior for a stable directory and retains the usual Linux readdir limitations when a directory is modified concurrently.

**Verification**

- Focused `DirHandle` seek and bounded-cache tests pass: `2 passed`.
- FUSE readdir termination and split-response tests pass: `6 passed`.
- Full Curvine FUSE library test suite passes: `317 passed`.
- Directory offset, reverse-seek, and random-seek regression cases pass.
- The random-seek case completes in approximately 42 seconds with the bounded four-batch window.
- `make format` passes.
- Clippy passes with warnings denied.
- `git diff --check` passes.

**Deployment**

The change is entirely inside the FUSE client. Master and Worker protocols and persistent metadata formats are unchanged.

Deploy the updated `curvine-fuse` binary and restart or remount each FUSE mount that should use seekable directory offsets. Master and Worker processes do not need to be restarted solely for this change.
