### PR TITLE
fix(fuse): tighten request parsing and audit classification (#1091)

### DIFF
--- a/curvine-fuse/src/fs/operator.rs
+++ b/curvine-fuse/src/fs/operator.rs
@@ -139,6 +139,7 @@ pub struct Lookup<'a> {
 #[derive(Debug)]
 pub struct GetAttr<'a> {
     pub header: &'a fuse_in_header,
+    pub arg: &'a fuse_getattr_in,
 }
 
 #[derive(Debug)]

--- a/curvine-fuse/src/lib.rs
+++ b/curvine-fuse/src/lib.rs
@@ -76,6 +76,11 @@ pub const FUSE_PATH_MAX_DEPTH: usize = 4096;
 /// `fuse_init_out.max_pages` carries the per-request page count.
 pub const FUSE_MAX_PAGES: u32 = 1 << 22;
 
+/// Kernel sends the extended 64-byte `fuse_init_in` request introduced in ABI 7.36.
+/// Curvine negotiates ABI 7.31 and does not advertise this bit in the reply, but it must
+/// consume the extended request sent by newer kernels before negotiating down.
+pub const FUSE_INIT_EXT: u32 = 1 << 30;
+
 pub const FUSE_BIG_WRITES: u32 = 1 << 5;
 
 pub const FUSE_ASYNC_READ: u32 = 1 << 0;
@@ -170,6 +175,7 @@ pub fn fuse_init_flag_names(flags: u32) -> Vec<String> {
         (FUSE_WRITEBACK_CACHE, "WRITEBACK_CACHE"),
         (FUSE_POSIX_ACL, "POSIX_ACL"),
         (FUSE_MAX_PAGES, "MAX_PAGES"),
+        (FUSE_INIT_EXT, "INIT_EXT"),
     ];
     let mut names: Vec<String> = KNOWN
         .iter()

--- a/curvine-fuse/src/raw/fuse_abi.rs
+++ b/curvine-fuse/src/raw/fuse_abi.rs
@@ -54,6 +54,14 @@ pub struct fuse_init_in {
     pub flags: u32,
 }
 
+/// Tail of the extended 64-byte `fuse_init_in` sent by kernels using ABI 7.36+.
+#[repr(C)]
+#[derive(Debug, Default)]
+pub struct fuse_init_in_ext_tail {
+    pub flags2: u32,
+    pub unused: [u32; 11],
+}
+
 #[repr(C)]
 #[derive(Debug, Default)]
 pub struct fuse_init_out {

--- a/curvine-fuse/src/raw/fuse_abi.rs
+++ b/curvine-fuse/src/raw/fuse_abi.rs
@@ -194,6 +194,14 @@ pub struct fuse_write_out {
 
 #[repr(C)]
 #[derive(Debug, Default)]
+pub struct fuse_getattr_in {
+    pub getattr_flags: u32,
+    pub dummy: u32,
+    pub fh: u64,
+}
+
+#[repr(C)]
+#[derive(Debug, Default)]
 pub struct fuse_create_in {
     pub flags: u32,
     pub mode: u32,

--- a/curvine-fuse/src/session/channel/fuse_receiver.rs
+++ b/curvine-fuse/src/session/channel/fuse_receiver.rs
@@ -516,7 +516,7 @@ impl<T: FileSystem> FuseReceiver<T> {
         req: FuseRequest,
         reply: FuseResponse,
     ) -> FuseResult<()> {
-        if !req.is_interrupt() {
+        if !req.is_interruptible_wait() {
             return Self::dispatch_meta(&pending_requests, &fs, &req, &reply).await;
         }
 
@@ -819,7 +819,8 @@ mod tests {
             FuseMetrics, FuseReqCtx, FuseReqKind, FuseReqLabels, FuseReqStatus,
         };
         use crate::raw::fuse_abi::{
-            fuse_forget_in, fuse_fsync_in, fuse_in_header, fuse_interrupt_in, fuse_rename2_in,
+            fuse_forget_in, fuse_fsync_in, fuse_getattr_in, fuse_in_header, fuse_interrupt_in,
+            fuse_rename2_in,
         };
         use crate::session::{FuseRequest, FuseResponse, FuseTask};
         use crate::FuseUtils;
@@ -857,8 +858,12 @@ mod tests {
         }
 
         fn getattr_request(unique: u64) -> FuseRequest {
-            // GetAttr parses only the header (no arg read).
-            make_request(OP_GETATTR, unique, 1, &[])
+            make_request(
+                OP_GETATTR,
+                unique,
+                1,
+                FuseUtils::struct_as_bytes(&fuse_getattr_in::default()),
+            )
         }
 
         fn statfs_request(unique: u64) -> FuseRequest {

--- a/curvine-fuse/src/session/channel/fuse_receiver.rs
+++ b/curvine-fuse/src/session/channel/fuse_receiver.rs
@@ -435,7 +435,7 @@ impl<T: FileSystem> FuseReceiver<T> {
                                     req.opcode(),
                                 );
                             }
-                            if req.is_meta() {
+                            if req.should_audit() {
                                 self.audit(&req);
                             }
 

--- a/curvine-fuse/src/session/fuse_decoder.rs
+++ b/curvine-fuse/src/session/fuse_decoder.rs
@@ -67,6 +67,16 @@ impl<'a> FuseDecoder<'a> {
             return Ok(vec![]);
         }
 
+        let max_count = self.buf.len() / size_of::<T>();
+        if count > max_count {
+            return err_box!(
+                "Not enough data for {} structures: requested {}, available {}",
+                std::any::type_name::<T>(),
+                count,
+                max_count
+            );
+        }
+
         let mut res = Vec::with_capacity(count);
         for _ in 0..count {
             let item: &'a T = self.get_struct()?;
@@ -100,6 +110,14 @@ impl<'a> FuseDecoder<'a> {
         }
         self.get_slice(size)
     }
+
+    pub fn ensure_empty(&self) -> FuseResult<()> {
+        if self.buf.is_empty() {
+            Ok(())
+        } else {
+            err_box!("Unexpected trailing request data: {} bytes", self.buf.len())
+        }
+    }
 }
 
 #[cfg(test)]
@@ -122,5 +140,14 @@ pub mod tests {
         assert_eq!(coder.len(), 2);
 
         Ok(())
+    }
+
+    #[test]
+    fn ensure_empty_rejects_remaining_bytes() {
+        let mut decoder = FuseDecoder::new(&DATA);
+        decoder.get_slice(DATA.len() - 1).unwrap();
+
+        let err = decoder.ensure_empty().unwrap_err();
+        assert!(err.to_string().contains("1 bytes"));
     }
 }

--- a/curvine-fuse/src/session/fuse_request.rs
+++ b/curvine-fuse/src/session/fuse_request.rs
@@ -53,8 +53,20 @@ impl FuseRequest {
         }
 
         let header: &fuse_in_header = FuseDecoder::parse(&self.buf[..FUSE_IN_HEADER_LEN])?;
-        if self.buf.len() < header.len as usize {
-            return err_box!("Not enough data for arguments (short read).");
+        let declared_len = header.len as usize;
+        if declared_len < FUSE_IN_HEADER_LEN {
+            return err_box!(
+                "Invalid FUSE request length {}, expected at least {}",
+                declared_len,
+                FUSE_IN_HEADER_LEN
+            );
+        }
+        if self.buf.len() != declared_len {
+            return err_box!(
+                "FUSE request length mismatch, declared {}, actual {}",
+                declared_len,
+                self.buf.len()
+            );
         }
 
         Ok(header)
@@ -87,7 +99,7 @@ impl FuseRequest {
         )
     }
 
-    pub fn is_meta(&self) -> bool {
+    pub fn should_audit(&self) -> bool {
         !matches!(self.opcode, FUSE_READ | FUSE_WRITE)
     }
 
@@ -219,12 +231,10 @@ impl FuseRequest {
             }),
 
             FUSE_WRITE => {
-                let arg = decoder.get_struct()?;
-                FuseOperator::Write(Write {
-                    header,
-                    arg,
-                    data: self.get_write_bytes(arg.size as usize)?,
-                })
+                let arg: &fuse_write_in = decoder.get_struct()?;
+                let data = self.get_write_bytes(arg.size as usize)?;
+                let _ = decoder.get_bytes(arg.size as usize)?;
+                FuseOperator::Write(Write { header, arg, data })
             }
 
             FUSE_MKNOD => FuseOperator::MkNod(MkNod {
@@ -333,6 +343,10 @@ impl FuseRequest {
             _ => FuseOperator::Notimplemented,
         };
 
+        if !matches!(&op, FuseOperator::Notimplemented) {
+            decoder.ensure_empty()?;
+        }
+
         Ok(op)
     }
 }
@@ -352,10 +366,90 @@ impl Display for FuseRequest {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::raw::fuse_abi::fuse_setxattr_in;
+    use crate::raw::fuse_abi::{fuse_batch_forget_in, fuse_setxattr_in};
     use crate::FuseUtils;
     use bytes::BytesMut;
     use std::ffi::OsStr;
+
+    fn request_bytes(header: &fuse_in_header, body: &[u8]) -> Bytes {
+        let mut bytes = BytesMut::with_capacity(FUSE_IN_HEADER_LEN + body.len());
+        bytes.extend_from_slice(FuseUtils::struct_as_bytes(header));
+        bytes.extend_from_slice(body);
+        bytes.freeze()
+    }
+
+    fn header(opcode: FuseOpCode, len: usize) -> fuse_in_header {
+        fuse_in_header {
+            len: len as u32,
+            opcode: opcode as u32,
+            unique: 42,
+            nodeid: 7,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn rejects_declared_length_smaller_than_header() {
+        let header = header(FUSE_GETATTR, FUSE_IN_HEADER_LEN - 1);
+        let err = match FuseRequest::from_bytes(request_bytes(&header, &[])) {
+            Ok(_) => panic!("invalid declared length must be rejected"),
+            Err(err) => err,
+        };
+        assert!(err.to_string().contains("expected at least"));
+    }
+
+    #[test]
+    fn rejects_actual_length_different_from_declared_length() {
+        let header = header(FUSE_GETATTR, FUSE_IN_HEADER_LEN);
+        let err = match FuseRequest::from_bytes(request_bytes(&header, &[0])) {
+            Ok(_) => panic!("mismatched request length must be rejected"),
+            Err(err) => err,
+        };
+        assert!(err.to_string().contains("length mismatch"));
+    }
+
+    #[test]
+    fn rejects_trailing_body_for_fixed_size_operator() {
+        let header = header(FUSE_GETATTR, FUSE_IN_HEADER_LEN + 1);
+        let request = FuseRequest::from_bytes(request_bytes(&header, &[0])).unwrap();
+        let err = request.parse_operator().unwrap_err();
+        assert!(err.to_string().contains("Unexpected trailing request data"));
+    }
+
+    #[test]
+    fn rejects_batch_forget_count_larger_than_body() {
+        let arg = fuse_batch_forget_in {
+            count: u32::MAX,
+            dummy: 0,
+        };
+        let body = FuseUtils::struct_as_bytes(&arg);
+        let header = header(FUSE_BATCH_FORGET, FUSE_IN_HEADER_LEN + body.len());
+        let request = FuseRequest::from_bytes(request_bytes(&header, body)).unwrap();
+        let err = request.parse_operator().unwrap_err();
+        assert!(err.to_string().contains("requested 4294967295"));
+        assert!(err.to_string().contains("available 0"));
+    }
+
+    #[test]
+    fn audit_classification_excludes_only_read_and_write() {
+        for opcode in [FUSE_READ, FUSE_WRITE] {
+            let request = FuseRequest {
+                unique: 1,
+                opcode,
+                buf: Bytes::new(),
+            };
+            assert!(!request.should_audit(), "{opcode:?} should not be audited");
+        }
+
+        for opcode in [FUSE_FLUSH, FUSE_RELEASE, FUSE_FSYNC, FUSE_LOOKUP] {
+            let request = FuseRequest {
+                unique: 1,
+                opcode,
+                buf: Bytes::new(),
+            };
+            assert!(request.should_audit(), "{opcode:?} should be audited");
+        }
+    }
 
     #[test]
     fn setxattr_uses_compat_header_and_preserves_name_and_value() {

--- a/curvine-fuse/src/session/fuse_request.rs
+++ b/curvine-fuse/src/session/fuse_request.rs
@@ -14,12 +14,13 @@
 
 use crate::fs::operator::*;
 use crate::raw::fuse_abi::{
-    fuse_batch_forget_in, fuse_forget_one, fuse_in_header, fuse_ioctl_in, fuse_write_in,
+    fuse_batch_forget_in, fuse_forget_one, fuse_in_header, fuse_init_in, fuse_init_in_ext_tail,
+    fuse_ioctl_in, fuse_write_in,
 };
 use crate::session::fuse_decoder::FuseDecoder;
 use crate::session::FuseOpCode::{self, *};
 use crate::FuseResult;
-use crate::FUSE_IN_HEADER_LEN;
+use crate::{FUSE_INIT_EXT, FUSE_IN_HEADER_LEN};
 use bytes::Bytes;
 use orpc::{err_box, CommonResult};
 use std::fmt::{Display, Formatter};
@@ -113,10 +114,29 @@ impl FuseRequest {
         let header: &fuse_in_header = decoder.get_struct()?;
 
         let op = match self.opcode {
-            FUSE_INIT => FuseOperator::Init(Init {
-                header,
-                arg: decoder.get_struct()?,
-            }),
+            FUSE_INIT => {
+                let arg: &fuse_init_in = decoder.get_struct()?;
+                match decoder.len() {
+                    0 if arg.flags & FUSE_INIT_EXT == 0 => {}
+                    0 => return err_box!("FUSE_INIT_EXT set without extended init payload"),
+                    len if len == size_of::<fuse_init_in_ext_tail>() => {
+                        if arg.flags & FUSE_INIT_EXT == 0 {
+                            return err_box!(
+                                "Extended FUSE init payload received without FUSE_INIT_EXT"
+                            );
+                        }
+                        let _: &fuse_init_in_ext_tail = decoder.get_struct()?;
+                    }
+                    len => {
+                        return err_box!(
+                            "Invalid FUSE init extension length {}, expected 0 or {}",
+                            len,
+                            size_of::<fuse_init_in_ext_tail>()
+                        )
+                    }
+                }
+                FuseOperator::Init(Init { header, arg })
+            }
 
             FUSE_LOOKUP => FuseOperator::Lookup(Lookup {
                 header,
@@ -359,7 +379,8 @@ impl Display for FuseRequest {
 mod tests {
     use super::*;
     use crate::raw::fuse_abi::{
-        fuse_batch_forget_in, fuse_getattr_in, fuse_setxattr_in, fuse_write_in,
+        fuse_batch_forget_in, fuse_getattr_in, fuse_init_in, fuse_init_in_ext_tail,
+        fuse_setxattr_in, fuse_write_in,
     };
     use crate::FuseUtils;
     use bytes::BytesMut;
@@ -408,6 +429,115 @@ mod tests {
         let request = FuseRequest::from_bytes(request_bytes(&header, &[0])).unwrap();
         let err = request.parse_operator().unwrap_err();
         assert!(err.to_string().contains("Unexpected trailing request data"));
+    }
+
+    fn init_request(arg: &fuse_init_in, tail: Option<&fuse_init_in_ext_tail>) -> FuseRequest {
+        let mut body = BytesMut::new();
+        body.extend_from_slice(FuseUtils::struct_as_bytes(arg));
+        if let Some(tail) = tail {
+            body.extend_from_slice(FuseUtils::struct_as_bytes(tail));
+        }
+        let header = header(FUSE_INIT, FUSE_IN_HEADER_LEN + body.len());
+        FuseRequest::from_bytes(request_bytes(&header, &body)).unwrap()
+    }
+
+    #[test]
+    fn init_accepts_legacy_16_byte_payload() {
+        assert_eq!(size_of::<fuse_init_in>(), 16);
+
+        let request = init_request(
+            &fuse_init_in {
+                major: 7,
+                minor: 31,
+                max_readahead: 4096,
+                flags: 0,
+            },
+            None,
+        );
+
+        match request.parse_operator().unwrap() {
+            FuseOperator::Init(op) => {
+                assert_eq!(op.arg.minor, 31);
+            }
+            other => panic!("expected Init, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn init_accepts_extended_64_byte_payload() {
+        assert_eq!(size_of::<fuse_init_in_ext_tail>(), 48);
+
+        let request = init_request(
+            &fuse_init_in {
+                major: 7,
+                minor: 36,
+                max_readahead: 4096,
+                flags: FUSE_INIT_EXT,
+            },
+            Some(&fuse_init_in_ext_tail {
+                flags2: 0x12,
+                ..Default::default()
+            }),
+        );
+
+        match request.parse_operator().unwrap() {
+            FuseOperator::Init(op) => {
+                assert_eq!(op.arg.minor, 36);
+            }
+            other => panic!("expected Init, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn init_rejects_extension_flag_without_tail() {
+        let request = init_request(
+            &fuse_init_in {
+                major: 7,
+                minor: 36,
+                max_readahead: 4096,
+                flags: FUSE_INIT_EXT,
+            },
+            None,
+        );
+
+        let err = request.parse_operator().unwrap_err();
+        assert!(err.to_string().contains("without extended init payload"));
+    }
+
+    #[test]
+    fn init_rejects_extended_tail_without_flag() {
+        let request = init_request(
+            &fuse_init_in {
+                major: 7,
+                minor: 36,
+                max_readahead: 4096,
+                flags: 0,
+            },
+            Some(&fuse_init_in_ext_tail::default()),
+        );
+
+        let err = request.parse_operator().unwrap_err();
+        assert!(err.to_string().contains("without FUSE_INIT_EXT"));
+    }
+
+    #[test]
+    fn init_rejects_invalid_extension_length() {
+        let arg = fuse_init_in {
+            major: 7,
+            minor: 36,
+            max_readahead: 4096,
+            flags: FUSE_INIT_EXT,
+        };
+        let mut body = BytesMut::new();
+        body.extend_from_slice(FuseUtils::struct_as_bytes(&arg));
+        body.extend_from_slice(&[0; 4]);
+        let header = header(FUSE_INIT, FUSE_IN_HEADER_LEN + body.len());
+        let request = FuseRequest::from_bytes(request_bytes(&header, &body)).unwrap();
+
+        let err = request.parse_operator().unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("Invalid FUSE init extension length"));
     }
 
     #[test]

--- a/curvine-fuse/src/session/fuse_request.rs
+++ b/curvine-fuse/src/session/fuse_request.rs
@@ -88,7 +88,7 @@ impl FuseRequest {
         self.opcode
     }
 
-    pub fn is_interrupt(&self) -> bool {
+    pub fn is_interruptible_wait(&self) -> bool {
         matches!(self.opcode, FUSE_SETLKW)
     }
 
@@ -101,19 +101,6 @@ impl FuseRequest {
 
     pub fn should_audit(&self) -> bool {
         !matches!(self.opcode, FUSE_READ | FUSE_WRITE)
-    }
-
-    fn get_write_bytes(&self, size: usize) -> FuseResult<Bytes> {
-        let start = FUSE_IN_HEADER_LEN + size_of::<fuse_write_in>();
-        let end = start + size;
-        if end != self.buf.len() {
-            return err_box!(
-                "Abnormal data length, expected {}, actual {}",
-                end,
-                self.buf.len()
-            );
-        }
-        Ok(self.buf.slice(start..end))
     }
 
     pub fn get_header(&self) -> FuseResult<&fuse_in_header> {
@@ -141,7 +128,10 @@ impl FuseRequest {
                 arg: decoder.get_struct()?,
             }),
 
-            FUSE_GETATTR => FuseOperator::GetAttr(GetAttr { header }),
+            FUSE_GETATTR => FuseOperator::GetAttr(GetAttr {
+                header,
+                arg: decoder.get_struct()?,
+            }),
 
             FUSE_READLINK => FuseOperator::Readlink(Readlink { header }),
 
@@ -232,8 +222,10 @@ impl FuseRequest {
 
             FUSE_WRITE => {
                 let arg: &fuse_write_in = decoder.get_struct()?;
-                let data = self.get_write_bytes(arg.size as usize)?;
+                let data_start = self.buf.len() - decoder.len();
                 let _ = decoder.get_bytes(arg.size as usize)?;
+                let data_end = self.buf.len() - decoder.len();
+                let data = self.buf.slice(data_start..data_end);
                 FuseOperator::Write(Write { header, arg, data })
             }
 
@@ -366,7 +358,9 @@ impl Display for FuseRequest {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::raw::fuse_abi::{fuse_batch_forget_in, fuse_setxattr_in};
+    use crate::raw::fuse_abi::{
+        fuse_batch_forget_in, fuse_getattr_in, fuse_setxattr_in, fuse_write_in,
+    };
     use crate::FuseUtils;
     use bytes::BytesMut;
     use std::ffi::OsStr;
@@ -410,10 +404,51 @@ mod tests {
 
     #[test]
     fn rejects_trailing_body_for_fixed_size_operator() {
-        let header = header(FUSE_GETATTR, FUSE_IN_HEADER_LEN + 1);
+        let header = header(FUSE_STATFS, FUSE_IN_HEADER_LEN + 1);
         let request = FuseRequest::from_bytes(request_bytes(&header, &[0])).unwrap();
         let err = request.parse_operator().unwrap_err();
         assert!(err.to_string().contains("Unexpected trailing request data"));
+    }
+
+    #[test]
+    fn getattr_consumes_kernel_argument() {
+        assert_eq!(size_of::<fuse_getattr_in>(), 16);
+
+        let arg = fuse_getattr_in {
+            getattr_flags: 1,
+            dummy: 0,
+            fh: 99,
+        };
+        let body = FuseUtils::struct_as_bytes(&arg);
+        let header = header(FUSE_GETATTR, FUSE_IN_HEADER_LEN + body.len());
+        let request = FuseRequest::from_bytes(request_bytes(&header, body)).unwrap();
+
+        match request.parse_operator().unwrap() {
+            FuseOperator::GetAttr(op) => {
+                assert_eq!(op.arg.getattr_flags, 1);
+                assert_eq!(op.arg.fh, 99);
+            }
+            other => panic!("expected GetAttr, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn write_data_follows_decoder_cursor() {
+        let data = b"write-data";
+        let arg = fuse_write_in {
+            size: data.len() as u32,
+            ..Default::default()
+        };
+        let mut body = BytesMut::new();
+        body.extend_from_slice(FuseUtils::struct_as_bytes(&arg));
+        body.extend_from_slice(data);
+        let header = header(FUSE_WRITE, FUSE_IN_HEADER_LEN + body.len());
+        let request = FuseRequest::from_bytes(request_bytes(&header, &body)).unwrap();
+
+        match request.parse_operator().unwrap() {
+            FuseOperator::Write(op) => assert_eq!(&op.data[..], data),
+            other => panic!("expected Write, got {other:?}"),
+        }
     }
 
     #[test]
@@ -448,6 +483,28 @@ mod tests {
                 buf: Bytes::new(),
             };
             assert!(request.should_audit(), "{opcode:?} should be audited");
+        }
+    }
+
+    #[test]
+    fn only_setlkw_is_an_interruptible_wait() {
+        {
+            let opcode = FUSE_SETLKW;
+            let request = FuseRequest {
+                unique: 1,
+                opcode,
+                buf: Bytes::new(),
+            };
+            assert!(request.is_interruptible_wait());
+        }
+
+        for opcode in [FUSE_INTERRUPT, FUSE_SETLK, FUSE_READ] {
+            let request = FuseRequest {
+                unique: 1,
+                opcode,
+                buf: Bytes::new(),
+            };
+            assert!(!request.is_interruptible_wait(), "{opcode:?}");
         }
     }
 


### PR DESCRIPTION
# Summary

Tighten FUSE request parsing by enforcing declared frame boundaries, rejecting trailing request data, and validating batch-forget counts before allocation. Parse the Linux `fuse_getattr_in` argument, use the decoder cursor as the single source of truth for WRITE payloads, and clarify audit and interruptible-wait classifications.

# Issue Describe / Design

Related to #1091  
Closes #1392

Root causes:

- Request parsing accepted declared lengths smaller than the FUSE header and buffers whose actual length differed from `header.len`.
- Supported operators did not verify that the complete request body was consumed.
- `FUSE_BATCH_FORGET` allocated from an untrusted count before validating the remaining body.
- GETATTR ignored the required Linux `fuse_getattr_in` request argument.
- WRITE payload extraction recomputed a fixed offset independently from the decoder cursor.
- `is_meta` and `is_interrupt` did not describe their audit-only and interruptible-wait meanings.

Fix approach:

- Require a valid exact request-frame length.
- Reject trailing body data for supported operators.
- Validate structure counts before allocation.
- Add and parse the 16-byte Linux `fuse_getattr_in` structure.
- Slice WRITE data from the decoder-consumed range.
- Rename the request classifications without changing dispatch or audit behavior.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-fuse/src/session/fuse_request.rs` | Validate frames, require full body consumption, parse GETATTR arguments, and unify WRITE cursor use | Malformed requests are rejected earlier; valid GETATTR requests are parsed with their kernel argument |
| `curvine-fuse/src/session/fuse_decoder.rs` | Bound structure-array counts and add `ensure_empty` | Prevents excessive allocation and trailing data |
| `curvine-fuse/src/raw/fuse_abi.rs` | Add Linux `fuse_getattr_in` ABI structure | Aligns GETATTR parsing with Linux UAPI |
| `curvine-fuse/src/fs/operator.rs` | Carry the GETATTR argument in the operator | Makes GETATTR flags and optional fh available to handlers |
| `curvine-fuse/src/session/channel/fuse_receiver.rs` | Use explicit audit and interruptible-wait naming; update GETATTR test request | No dispatch or audit behavior change |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `make format` | PASS | Full repository pre-commit checks |
| `cargo test -p curvine-fuse session::fuse_request --no-fail-fast` | PASS | 9 request tests |
| `cargo test -p curvine-fuse session::fuse_decoder --no-fail-fast` | PASS | 2 decoder tests |
| GETATTR receiver dispatch integration test | PASS | Uses Linux `fuse_getattr_in` payload |
| `cargo test -p curvine-fuse --lib -- --test-threads=1` | PASS | 339 tests |
| `git diff --check` | PASS | No whitespace errors |

A parallel full test run before the follow-up commit had one existing global-metrics assertion observe cross-test counter increments; that test passed when rerun alone. The complete library suite passes with one test thread.

# Dependencies

- Related PRs: None
- Related issues: #1091, #1392
- Blocks / blocked by: None
