### PR TITLE
fix(oss-hdfs): correct async start-status checks (#1376)

### DIFF
--- a/crates/adapters/curvine-ufs-oss-hdfs/src/oss_hdfs/oss_hdfs_filesystem.rs
+++ b/crates/adapters/curvine-ufs-oss-hdfs/src/oss_hdfs/oss_hdfs_filesystem.rs
@@ -556,7 +556,11 @@ impl FileSystem<OssHdfsWriter, OssHdfsReader> for OssHdfsFileSystem {
                 unsafe {
                     jindo_writer_free(writer_handle.as_raw());
                 }
-                Self::check_status(start_status, "Failed to start async writer tell")?;
+                Self::check_status_with_err(
+                    start_status,
+                    "Failed to start async writer tell",
+                    None,
+                )?;
             }
         }
 
@@ -626,10 +630,7 @@ impl FileSystem<OssHdfsWriter, OssHdfsReader> for OssHdfsFileSystem {
                     status
                 })
                 .await?;
-            match start_status {
-                JindoStatus::Ok => {}
-                _ => Self::check_status(start_status, "Failed to start async exists")?,
-            }
+            Self::check_status(start_status, "Failed to start async exists")?;
         }
 
         let (status, exists, err) = ctx.wait().await?;


### PR DESCRIPTION
# Summary

Fixes a compile regression introduced while preserving immediate Jindo async-start errors.

# Issue Describe / Design

Related to #1376.

Root cause: the async filesystem wrapper now returns `JindoStartStatus`, but two call sites still treated it as `JindoStatus`. One direct writer call also passed a raw status to the wrapper-specific checker.

Fix approach: preserve the captured error for wrapped filesystem calls and use the raw-status checker for the direct writer call.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `crates/adapters/curvine-ufs-oss-hdfs/src/oss_hdfs/oss_hdfs_filesystem.rs` | Correct the two async start-status checks | Restores compilation; error propagation semantics remain unchanged |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo fmt --all -- --check` | PASS | |
| `CARGO_TARGET_DIR=/tmp/curvine-oss-hdfs-hotfix-target RUSTC_WRAPPER= cargo check -p curvine-ufs-oss-hdfs` | PASS | Isolated from concurrent local Cargo builds |

# Dependencies

- Related PRs: #1376
- Related issues: None
- Blocks / blocked by: None