### PR TITLE
fix(opendal): declare logging dependency (#1361)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2496,6 +2496,7 @@ dependencies = [
  "curvine-model",
  "curvine-ufs",
  "futures",
+ "log",
  "opendal",
  "orpc",
 ]

--- a/crates/adapters/curvine-ufs-opendal/Cargo.toml
+++ b/crates/adapters/curvine-ufs-opendal/Cargo.toml
@@ -11,6 +11,7 @@ curvine-fs-api = { workspace = true }
 curvine-model = { workspace = true }
 bytes = { workspace = true }
 futures = { workspace = true }
+log = { workspace = true }
 opendal = { version = "0.55" }
 orpc = { workspace = true }
 


### PR DESCRIPTION
# Summary

Fixes the OpenDAL HDFS Native build failure caused by missing direct linkage to the `log` crate.

# Issue Describe / Design

Related to #1361.

Root cause: the extracted `curvine-ufs-opendal` crate uses `log::debug!` in the HDFS Native configuration path but its manifest did not declare `log`. This only appears when `opendal-hdfs-native` is enabled, including the runtime Docker image build.

Fix approach: declare the existing workspace `log` dependency and update the lockfile.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `crates/adapters/curvine-ufs-opendal/Cargo.toml` | Declare workspace `log` dependency | Restores feature build; no runtime behavior change |
| `Cargo.lock` | Record direct crate dependency | Lockfile consistency |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo fmt --all -- --check` | PASS | |
| `CARGO_TARGET_DIR=/tmp/curvine-opendal-log-hotfix-target RUSTC_WRAPPER= cargo check -p curvine-ufs-opendal --features opendal-hdfs-native` | PASS | Reproduces the feature combination that failed in `make docker-build` |

# Dependencies

- Related PRs: #1361
- Related issues: None
- Blocks / blocked by: None