### PR TITLE
fix(worker): materialize sparse block length after resize (#1390)

### DIFF
--- a/curvine-client-core/src/file/fs_writer_base.rs
+++ b/curvine-client-core/src/file/fs_writer_base.rs
@@ -513,6 +513,17 @@ impl FsWriterBase {
             self.complete().await?;
         }
 
+        // Capture pre-resize lengths so we can materialize sparse growth on
+        // already-committed worker blocks. Master extend may raise last-block
+        // logical len without alloc_opts (to avoid rewrite-on-every-boundary),
+        // which would otherwise leave worker files shorter than master metadata.
+        let prior_lens: std::collections::HashMap<i64, i64> = self
+            .file_blocks
+            .block_locs
+            .iter()
+            .map(|lb| (lb.block.id, lb.block.len))
+            .collect();
+
         // Step 2: Execute resize operation
         let file_blocks = self.fs_client.resize(&self.path, opts).await?;
         let mut file_blocks = WriteFileBlocks::new(file_blocks);
@@ -526,10 +537,14 @@ impl FsWriterBase {
             );
         }
 
-        // Step 3: If a block with written data triggers reassignment, request worker to reassign the block.
-        // At most one such block exists.
+        // Step 3: Materialize blocks that need worker updates after resize.
+        // - should_resize(): unplaced/assigned blocks with alloc_opts
+        // - committed blocks whose logical len grew: open+complete so the worker
+        //   staging file is extended to the new logical length (sparse holes)
         for lb in &mut file_blocks.block_locs {
-            if lb.should_resize() {
+            let prior_len = prior_lens.get(&lb.block.id).copied().unwrap_or(0);
+            let grew_committed = !lb.locs.is_empty() && lb.block.len > prior_len;
+            if lb.should_resize() || grew_committed {
                 let mut writer =
                     BlockWriter::new(self.fs_context.clone(), lb.clone(), 0, block_size).await?;
                 let commit_block = writer.complete().await?;

--- a/curvine-client-core/src/file/fs_writer_base.rs
+++ b/curvine-client-core/src/file/fs_writer_base.rs
@@ -513,17 +513,6 @@ impl FsWriterBase {
             self.complete().await?;
         }
 
-        // Capture pre-resize lengths so we can materialize sparse growth on
-        // already-committed worker blocks. Master extend may raise last-block
-        // logical len without alloc_opts (to avoid rewrite-on-every-boundary),
-        // which would otherwise leave worker files shorter than master metadata.
-        let prior_lens: std::collections::HashMap<i64, i64> = self
-            .file_blocks
-            .block_locs
-            .iter()
-            .map(|lb| (lb.block.id, lb.block.len))
-            .collect();
-
         // Step 2: Execute resize operation
         let file_blocks = self.fs_client.resize(&self.path, opts).await?;
         let mut file_blocks = WriteFileBlocks::new(file_blocks);
@@ -537,14 +526,10 @@ impl FsWriterBase {
             );
         }
 
-        // Step 3: Materialize blocks that need worker updates after resize.
-        // - should_resize(): unplaced/assigned blocks with alloc_opts
-        // - committed blocks whose logical len grew: open+complete so the worker
-        //   staging file is extended to the new logical length (sparse holes)
+        // Step 3: If a block with written data triggers reassignment, request worker to reassign the block.
+        // At most one such block exists.
         for lb in &mut file_blocks.block_locs {
-            let prior_len = prior_lens.get(&lb.block.id).copied().unwrap_or(0);
-            let grew_committed = !lb.locs.is_empty() && lb.block.len > prior_len;
-            if lb.should_resize() || grew_committed {
+            if lb.should_resize() {
                 let mut writer =
                     BlockWriter::new(self.fs_context.clone(), lb.clone(), 0, block_size).await?;
                 let commit_block = writer.complete().await?;

--- a/curvine-server/src/worker/block/block_store.rs
+++ b/curvine-server/src/worker/block/block_store.rs
@@ -84,12 +84,19 @@ impl BlockStore {
         layout.open_writer(&dir, meta, off).map_err(Into::into)
     }
 
-    pub fn open_reader(&self, meta: &BlockMeta, off: i64) -> CommonResult<BlockReadContext> {
+    pub fn open_reader(
+        &self,
+        meta: &BlockMeta,
+        off: i64,
+        logical_len: i64,
+    ) -> CommonResult<BlockReadContext> {
         let (layout, dir) = {
             let state = self.read()?;
             state.layout_for(meta)?
         };
-        layout.open_reader(&dir, meta, off).map_err(Into::into)
+        layout
+            .open_reader(&dir, meta, off, logical_len)
+            .map_err(Into::into)
     }
 
     pub fn short_circuit(&self, meta: &BlockMeta) -> CommonResult<Option<String>> {

--- a/curvine-server/src/worker/handler/read_handler.rs
+++ b/curvine-server/src/worker/handler/read_handler.rs
@@ -63,19 +63,22 @@ impl ReadHandler {
                 .ctx(format!("worker block store lookup failed: {}", e))
         })?;
 
+        // Master sparse ResizeFile may raise logical block len above the
+        // worker's physical file size. Serve the logical length and synthesize
+        // zeros for the sparse tail instead of rejecting the open.
+        let logical_len = context.len.max(meta.len);
         if context.off < 0 {
             return err_box!(
                 "Invalid read offset: {}, block length: {}",
                 context.off,
-                meta.len
+                logical_len
             );
         }
-        if context.off > meta.len {
+        if context.off > logical_len {
             return err_box!(
-                "The length of the requested data exceeds the maximum length of the block file, \
-            request off {}, file len {}",
+                "The length of the requested data exceeds the maximum length of the block file,             request off {}, file len {}",
                 context.off,
-                meta.len
+                logical_len
             );
         }
 
@@ -85,14 +88,15 @@ impl ReadHandler {
 
         if context.enable_read_ahead && context.read_ahead_len > Self::MAX_READ_AHEAD {
             return err_box!(
-                "The pre-read size exceeds the maximum value allowed by the system.\
-                 The current value is {}. The maximum allowed value is: {}",
+                "The pre-read size exceeds the maximum value allowed by the system.                 The current value is {}. The maximum allowed value is: {}",
                 context.read_ahead_len,
                 Self::MAX_READ_AHEAD
             );
         }
 
-        let sc_path = if context.short_circuit {
+        // Short-circuit local reads cannot synthesize sparse tails; force the
+        // remote path when logical length exceeds physical worker bytes.
+        let sc_path = if context.short_circuit && logical_len <= meta.len {
             self.store.short_circuit(&meta)?
         } else {
             None
@@ -101,7 +105,7 @@ impl ReadHandler {
         let (is_short_circuit, path, file) = if let Some(path) = sc_path {
             (true, path, None)
         } else {
-            let file = self.store.open_reader(&meta, context.off)?;
+            let file = self.store.open_reader(&meta, context.off, logical_len)?;
             let path = file.path().to_string();
             (false, path, Some(file))
         };
@@ -127,7 +131,7 @@ impl ReadHandler {
 
         let response = BlockReadResponse {
             id: context.block_id,
-            len: meta.len,
+            len: logical_len,
             path: ternary!(is_short_circuit, Some(path), None),
             storage_type: meta.storage_type().into(),
         };

--- a/curvine-server/src/worker/handler/read_handler.rs
+++ b/curvine-server/src/worker/handler/read_handler.rs
@@ -58,15 +58,29 @@ impl ReadHandler {
 
     pub fn open(&mut self, msg: &Message) -> FsResult<Message> {
         let context = ReadContext::from_req(msg)?;
+        let conf = Worker::get_conf()?;
+        let max_block_size = conf.master.max_block_size;
         let meta = self.store.get_block(context.block_id).map_err(|e| {
             FsError::block_not_found(context.block_id)
                 .ctx(format!("worker block store lookup failed: {}", e))
         })?;
 
         // Master sparse ResizeFile may raise logical block len above the
-        // worker's physical file size. Serve the logical length and synthesize
-        // zeros for the sparse tail instead of rejecting the open.
-        let logical_len = context.len.max(meta.len);
+        // worker's physical file size. Only synthesize a sparse tail when the
+        // client advertises a validated logical length above physical bytes.
+        let physical_len = meta.len;
+        let logical_len = if context.len > physical_len {
+            if context.len > max_block_size {
+                return err_box!(
+                    "Advertised block length {} exceeds max_block_size {}",
+                    context.len,
+                    max_block_size
+                );
+            }
+            context.len
+        } else {
+            physical_len
+        };
         if context.off < 0 {
             return err_box!(
                 "Invalid read offset: {}, block length: {}",
@@ -84,6 +98,14 @@ impl ReadHandler {
 
         if context.chunk_size <= 0 {
             return err_box!("chunk_size must be greater than 0");
+        }
+
+        if context.chunk_size as i64 > Self::MAX_READ_AHEAD {
+            return err_box!(
+                "chunk_size {} exceeds maximum allowed value {}",
+                context.chunk_size,
+                Self::MAX_READ_AHEAD
+            );
         }
 
         if context.enable_read_ahead && context.read_ahead_len > Self::MAX_READ_AHEAD {

--- a/curvine-server/src/worker/replication/worker_replication_manager.rs
+++ b/curvine-server/src/worker/replication/worker_replication_manager.rs
@@ -145,7 +145,9 @@ impl WorkerReplicationManager {
             target_capacity,
         )
         .await?;
-        let mut reader = self.block_store.open_reader(&block_meta, 0)?;
+        let mut reader = self
+            .block_store
+            .open_reader(&block_meta, 0, block_meta.len)?;
         let mut remaining = block_meta.len;
         while remaining > 0 {
             let size = remaining.min(self.replicate_chunk_size as i64);

--- a/curvine-server/src/worker/storage/block_io_context.rs
+++ b/curvine-server/src/worker/storage/block_io_context.rs
@@ -283,14 +283,23 @@ impl BlockReadContext {
             .device
             .read_region(enable_send_file, physical_chunk as i32)?;
         let got = region.len() as i64;
+        if got != physical_chunk {
+            return err_box!(
+                "short physical read: expected {}, got {}",
+                physical_chunk,
+                got
+            );
+        }
         self.block_pos += got;
-        if got == read_len {
+
+        let sparse_pad = read_len - physical_chunk;
+        if sparse_pad == 0 {
             return Ok(region);
         }
 
         let mut buf = Self::into_buffer(region)?;
         buf.resize(read_len as usize, 0);
-        self.block_pos += read_len - got;
+        self.block_pos += sparse_pad;
         Ok(DataSlice::buffer(buf))
     }
 
@@ -348,6 +357,22 @@ mod tests {
         assert_eq!(&bytes[..2], b"EF");
         assert_eq!(&bytes[2..], &[0u8; 4]);
         assert_eq!(ctx.block_pos(), 10);
+
+        let _ = remove_file(&path);
+        Ok(())
+    }
+
+    #[test]
+    fn read_context_rejects_short_physical_read() -> Result<(), Box<dyn std::error::Error>> {
+        let path = Utils::test_file();
+        ensure_parent(&path)?;
+        LocalFile::write_string(&path, "ABC", true)?;
+
+        let device = shared_read_device(&path)?;
+        // Advertise more physical bytes than exist on disk.
+        let mut ctx = BlockReadContext::with_physical(device, 0, 10, 10, 0)?;
+        let err = ctx.read_region(false, 5).unwrap_err().to_string();
+        assert!(err.contains("short physical read"));
 
         let _ = remove_file(&path);
         Ok(())

--- a/curvine-server/src/worker/storage/block_io_context.rs
+++ b/curvine-server/src/worker/storage/block_io_context.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use bytes::BytesMut;
 use orpc::io::{BlockIO, IOError, IOResult, LocalFile};
 use orpc::sys::DataSlice;
 use orpc::{err_box, try_err};
@@ -149,7 +150,11 @@ pub struct BlockReadContext {
     device: Box<dyn BlockIO>,
     /// Base offset of the block on the backing device (0 for file-backed blocks).
     device_base: i64,
+    /// Client-visible / master logical length for this open.
     block_size: i64,
+    /// Bytes physically present on the worker. When smaller than `block_size`,
+    /// reads past this offset return sparse zeros (post-resize master inflate).
+    physical_len: i64,
     block_pos: i64,
 }
 
@@ -157,28 +162,55 @@ impl BlockReadContext {
     /// Establish the invariant `device.pos() == device_base + block_pos` by
     /// unconditionally seeking the underlying device. Callers must not rely on
     /// the layout having pre-positioned the device.
-    pub fn new<D>(
+    pub fn new<D>(device: D, device_base: i64, block_size: i64, initial_off: i64) -> IOResult<Self>
+    where
+        D: BlockIO + 'static,
+    {
+        Self::with_physical(device, device_base, block_size, block_size, initial_off)
+    }
+
+    /// Open a reader whose logical length may exceed the physical worker bytes.
+    pub fn with_physical<D>(
         mut device: D,
         device_base: i64,
-        block_size: i64,
+        logical_len: i64,
+        physical_len: i64,
         initial_off: i64,
     ) -> IOResult<Self>
     where
         D: BlockIO + 'static,
     {
-        if initial_off < 0 || initial_off > block_size {
+        if logical_len < 0 || physical_len < 0 {
+            return err_box!(
+                "Invalid block lengths: logical={}, physical={}",
+                logical_len,
+                physical_len
+            );
+        }
+        if physical_len > logical_len {
+            return err_box!(
+                "physical_len {} cannot exceed logical_len {}",
+                physical_len,
+                logical_len
+            );
+        }
+        if initial_off < 0 || initial_off > logical_len {
             return err_box!(
                 "Invalid initial offset: {}, block length: {}",
                 initial_off,
-                block_size
+                logical_len
             );
         }
-        let absolute = absolute_offset(device_base, initial_off)?;
+        // Device seeks are clamped to the physical range; the sparse logical
+        // tail is synthesized as zeros in `read_region`.
+        let device_off = initial_off.min(physical_len);
+        let absolute = absolute_offset(device_base, device_off)?;
         try_err!(device.seek(absolute));
         Ok(Self {
             device: Box::new(device),
             device_base,
-            block_size,
+            block_size: logical_len,
+            physical_len,
             block_pos: initial_off,
         })
     }
@@ -200,11 +232,30 @@ impl BlockReadContext {
             );
         }
         if block_off != self.block_pos {
-            let absolute = absolute_offset(self.device_base, block_off)?;
+            let device_off = block_off.min(self.physical_len);
+            let absolute = absolute_offset(self.device_base, device_off)?;
             try_err!(self.device.seek(absolute));
             self.block_pos = block_off;
         }
         Ok(())
+    }
+
+    fn into_buffer(region: DataSlice) -> IOResult<BytesMut> {
+        match region {
+            DataSlice::Buffer(b) => Ok(b),
+            DataSlice::Bytes(b) => {
+                let mut buf = BytesMut::with_capacity(b.len());
+                buf.extend_from_slice(&b);
+                Ok(buf)
+            }
+            DataSlice::MemSlice(b) => {
+                let mut buf = BytesMut::with_capacity(b.len());
+                buf.extend_from_slice(b.as_slice());
+                Ok(buf)
+            }
+            DataSlice::Empty => Ok(BytesMut::new()),
+            DataSlice::IOSlice(_) => err_box!("Cannot materialize IOSlice for sparse pad"),
+        }
     }
 
     pub fn read_region(&mut self, enable_send_file: bool, len: i32) -> IOResult<DataSlice> {
@@ -217,10 +268,30 @@ impl BlockReadContext {
                 self.block_pos
             );
         }
-        let region = self.device.read_region(enable_send_file, read_len as i32)?;
-        // Advance by the bytes represented by the returned region.
-        self.block_pos += region.len() as i64;
-        Ok(region)
+
+        // Entirely past physical bytes: synthesize sparse zeros.
+        if self.block_pos >= self.physical_len {
+            self.block_pos += read_len;
+            return Ok(DataSlice::buffer(BytesMut::zeroed(read_len as usize)));
+        }
+
+        let physical_chunk = (self.physical_len - self.block_pos).min(read_len);
+        // send_file/IOSlice cannot be padded; force a buffered read when the
+        // logical request extends into the sparse tail.
+        let enable_send_file = enable_send_file && physical_chunk == read_len;
+        let region = self
+            .device
+            .read_region(enable_send_file, physical_chunk as i32)?;
+        let got = region.len() as i64;
+        self.block_pos += got;
+        if got == read_len {
+            return Ok(region);
+        }
+
+        let mut buf = Self::into_buffer(region)?;
+        buf.resize(read_len as usize, 0);
+        self.block_pos += read_len - got;
+        Ok(DataSlice::buffer(buf))
     }
 
     pub fn supports_send_file(&self) -> bool {
@@ -255,6 +326,30 @@ mod tests {
         if let Some(parent) = std::path::Path::new(path).parent() {
             std::fs::create_dir_all(parent)?;
         }
+        Ok(())
+    }
+
+    #[test]
+    fn read_context_sparse_logical_tail_returns_zeros() -> Result<(), Box<dyn std::error::Error>> {
+        let path = Utils::test_file();
+        ensure_parent(&path)?;
+        LocalFile::write_string(&path, "ABCDEF", true)?;
+
+        let device = shared_read_device(&path)?;
+        // Physical file is 6 bytes; logical open length is 10 (post-resize inflate).
+        let mut ctx = BlockReadContext::with_physical(device, 0, 10, 6, 4)?;
+        let region = ctx.read_region(false, 8)?;
+        let bytes = match &region {
+            DataSlice::Bytes(b) => &b[..],
+            DataSlice::Buffer(b) => &b[..],
+            other => panic!("unexpected slice variant: {:?}", other),
+        };
+        // remaining logical bytes from off=4 is 6, so request of 8 is clamped.
+        assert_eq!(&bytes[..2], b"EF");
+        assert_eq!(&bytes[2..], &[0u8; 4]);
+        assert_eq!(ctx.block_pos(), 10);
+
+        let _ = remove_file(&path);
         Ok(())
     }
 

--- a/curvine-server/src/worker/storage/layout/bdev_layout.rs
+++ b/curvine-server/src/worker/storage/layout/bdev_layout.rs
@@ -190,7 +190,14 @@ impl BlockLayout for BdevLayout {
         }
     }
 
-    fn open_reader(&self, dir: &VfsDir, meta: &BlockMeta, off: i64) -> IOResult<BlockReadContext> {
+    fn open_reader(
+        &self,
+        dir: &VfsDir,
+        meta: &BlockMeta,
+        off: i64,
+        _logical_len: i64,
+    ) -> IOResult<BlockReadContext> {
+        // Bdev blocks are fully allocated; do not synthesize a sparse logical tail.
         validate_open_offset(meta, off)?;
         #[cfg(feature = "spdk")]
         {

--- a/curvine-server/src/worker/storage/layout/bdev_layout.rs
+++ b/curvine-server/src/worker/storage/layout/bdev_layout.rs
@@ -195,18 +195,27 @@ impl BlockLayout for BdevLayout {
         dir: &VfsDir,
         meta: &BlockMeta,
         off: i64,
-        _logical_len: i64,
+        logical_len: i64,
     ) -> IOResult<BlockReadContext> {
-        // Bdev blocks are fully allocated; do not synthesize a sparse logical tail.
-        validate_open_offset(meta, off)?;
+        let physical_len = meta.len;
+        let logical_len = logical_len.max(physical_len);
+        if off < 0 || off > logical_len {
+            return err_box!(
+                "Invalid block offset: {}, block length: {}",
+                off,
+                logical_len
+            );
+        }
         #[cfg(feature = "spdk")]
         {
             let bdev_name = Self::bdev_name(dir)?;
             let base_offset = meta.bdev_offset;
-            let abs_offset = base_offset.checked_add(off).ok_or_else(|| {
+            // Seek within physical bytes; sparse logical tail is synthesized.
+            let device_off = off.min(physical_len);
+            let abs_offset = base_offset.checked_add(device_off).ok_or_else(|| {
                 IOError::from(format!(
                     "Block read offset overflow: base={}, offset={}",
-                    base_offset, off
+                    base_offset, device_off
                 ))
             })?;
             let abs_offset = u64::try_from(abs_offset).map_err(|_| {
@@ -215,20 +224,17 @@ impl BlockLayout for BdevLayout {
                     abs_offset
                 ))
             })?;
-            let max_len = 0.max(meta.len - off);
+            let max_len = physical_len - device_off;
             info!(
-                "Opening SPDK bdev '{}' for reading at offset {} (block {} base={}, max_len={})",
-                bdev_name, abs_offset, meta.id, base_offset, max_len
+                "Opening SPDK bdev '{}' for reading at offset {} (block {} base={}, physical_len={}, logical_len={}, max_len={})",
+                bdev_name, abs_offset, meta.id, base_offset, physical_len, logical_len, max_len
             );
-            if max_len == 0 {
-                return err_box!("Cannot open SPDK reader: no space remaining");
-            }
             let bdev = SpdkBdev::open_read(bdev_name, abs_offset, max_len)?;
-            BlockReadContext::new(bdev, base_offset, meta.len, off)
+            BlockReadContext::with_physical(bdev, base_offset, logical_len, physical_len, off)
         }
         #[cfg(not(feature = "spdk"))]
         {
-            let _ = (dir, meta, off);
+            let _ = (dir, meta, off, logical_len, physical_len);
             err_box!("SPDK support not compiled in")
         }
     }

--- a/curvine-server/src/worker/storage/layout/file_layout.rs
+++ b/curvine-server/src/worker/storage/layout/file_layout.rs
@@ -97,9 +97,13 @@ impl FileLayout {
         // Sparse seek-past-EOF resize can raise a committed block's logical
         // length on the master without rewriting worker bytes. A later partial
         // rewrite then completes with committed_len larger than the staging
-        // file size. Materialize that logical length (including holes) before
-        // the mismatch check so valid post-resize rewrites can finalize.
-        if committed_len >= 0 {
+        // file size. Only materialize that logical length for known rewrites;
+        // first writes must still match the staging file exactly.
+        let mut finalized_probe = meta.clone();
+        finalized_probe.state = BlockState::Finalized;
+        let active_path = Self::block_path(dir, &finalized_probe)?;
+        let is_rewrite = active_path.exists();
+        if is_rewrite && committed_len >= 0 {
             let current_len = staging_path.metadata()?.len() as i64;
             if committed_len > current_len {
                 OpenOptions::new()

--- a/curvine-server/src/worker/storage/layout/file_layout.rs
+++ b/curvine-server/src/worker/storage/layout/file_layout.rs
@@ -145,6 +145,20 @@ impl BlockLayout for FileLayout {
         committed_len: i64,
     ) -> CommonResult<BlockMeta> {
         let staging_path = Self::block_path(dir, meta)?;
+        // Sparse seek-past-EOF resize can raise a committed block's logical
+        // length on the master without rewriting worker bytes. A later partial
+        // rewrite then completes with committed_len larger than the staging
+        // file size. Materialize that logical length (including holes) before
+        // the mismatch check so valid post-resize rewrites can finalize.
+        if committed_len >= 0 {
+            let current_len = staging_path.metadata()?.len() as i64;
+            if committed_len > current_len {
+                OpenOptions::new()
+                    .write(true)
+                    .open(&staging_path)?
+                    .set_len(committed_len as u64)?;
+            }
+        }
         let final_meta = BlockMeta::with_final(meta, &staging_path)?;
         if final_meta.len() != committed_len {
             return err_box!(

--- a/curvine-server/src/worker/storage/layout/file_layout.rs
+++ b/curvine-server/src/worker/storage/layout/file_layout.rs
@@ -219,13 +219,29 @@ impl BlockLayout for FileLayout {
         BlockWriteContext::new(device, 0, meta.len, off)
     }
 
-    fn open_reader(&self, dir: &VfsDir, meta: &BlockMeta, off: i64) -> IOResult<BlockReadContext> {
-        validate_open_offset(meta, off)?;
-        let read_off = u64::try_from(off)
-            .map_err(|_| IOError::from(format!("Invalid read offset: {}", off)))?;
+    fn open_reader(
+        &self,
+        dir: &VfsDir,
+        meta: &BlockMeta,
+        off: i64,
+        logical_len: i64,
+    ) -> IOResult<BlockReadContext> {
+        let physical_len = meta.len;
+        let logical_len = logical_len.max(physical_len);
+        if off < 0 || off > logical_len {
+            return err_box!(
+                "Invalid block offset: {}, block length: {}",
+                off,
+                logical_len
+            );
+        }
+        // Seek within the physical file; sparse logical tail is synthesized.
+        let device_off = off.min(physical_len);
+        let read_off = u64::try_from(device_off)
+            .map_err(|_| IOError::from(format!("Invalid read offset: {}", device_off)))?;
         let file = Self::block_file(dir, meta)?;
         let device = LocalFile::with_read(file, read_off)?;
-        BlockReadContext::new(device, 0, meta.len, off)
+        BlockReadContext::with_physical(device, 0, logical_len, physical_len, off)
     }
 
     fn short_circuit(&self, dir: &VfsDir, meta: &BlockMeta) -> CommonResult<Option<String>> {

--- a/curvine-server/src/worker/storage/layout/mod.rs
+++ b/curvine-server/src/worker/storage/layout/mod.rs
@@ -64,7 +64,13 @@ pub trait BlockLayout {
 
     fn open_writer(&self, dir: &VfsDir, meta: &BlockMeta, off: i64) -> IOResult<BlockWriteContext>;
 
-    fn open_reader(&self, dir: &VfsDir, meta: &BlockMeta, off: i64) -> IOResult<BlockReadContext>;
+    fn open_reader(
+        &self,
+        dir: &VfsDir,
+        meta: &BlockMeta,
+        off: i64,
+        logical_len: i64,
+    ) -> IOResult<BlockReadContext>;
 
     /// Local path a co-located client can open directly, `Ok(None)` if the
     /// layout cannot expose one (e.g. raw bdev). Errors are propagated so
@@ -177,10 +183,16 @@ impl BlockLayout for BlockLayoutKind {
         }
     }
 
-    fn open_reader(&self, dir: &VfsDir, meta: &BlockMeta, off: i64) -> IOResult<BlockReadContext> {
+    fn open_reader(
+        &self,
+        dir: &VfsDir,
+        meta: &BlockMeta,
+        off: i64,
+        logical_len: i64,
+    ) -> IOResult<BlockReadContext> {
         match self {
-            Self::File(layout) => layout.open_reader(dir, meta, off),
-            Self::Bdev(layout) => layout.open_reader(dir, meta, off),
+            Self::File(layout) => layout.open_reader(dir, meta, off, logical_len),
+            Self::Bdev(layout) => layout.open_reader(dir, meta, off, logical_len),
         }
     }
 

--- a/curvine-server/src/worker/storage/vfs_dataset.rs
+++ b/curvine-server/src/worker/storage/vfs_dataset.rs
@@ -801,6 +801,55 @@ mod test {
         assert!(ds.committed_rewrites.is_empty());
         Ok(())
     }
+
+    #[test]
+    fn finalize_rewrite_materializes_sparse_committed_length() -> CommonResult<()> {
+        // Mirrors post-ResizeFile rewrite: master logical block len grows while
+        // the worker still holds a short committed copy; finalize must extend
+        // the staging file to the committed logical length.
+        // Dataset Mem dir is only 100B and rewrite reserves max(old, new).
+        let mut ds = create_data_set(true, "finalize-rewrite-sparse-len");
+        let mut block = ExtendedBlock::with_mem(1, "50B")?;
+        let writing = ds.open_block(&block)?;
+        let initial_path = {
+            let dir = ds.find_dir(writing.dir_id())?;
+            FileLayout::block_path(dir, &writing)?
+        };
+        std::fs::write(&initial_path, b"B".repeat(20))?;
+        block.len = 20;
+        let finalized = ds.finalize_block(&block)?;
+        let active_path = {
+            let dir = ds.find_dir(finalized.dir_id())?;
+            FileLayout::block_path(dir, &finalized)?
+        };
+
+        // Reopen for rewrite at a higher logical length (as after sparse resize),
+        // write only into the middle, then commit the full logical length.
+        block.len = 50;
+        let rewriting = ds.open_block(&block)?;
+        let staging_path = {
+            let dir = ds.find_dir(rewriting.dir_id())?;
+            FileLayout::block_path(dir, &rewriting)?
+        };
+        let mut staging = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&staging_path)?;
+        use std::io::{Seek, SeekFrom, Write};
+        staging.seek(SeekFrom::Start(20))?;
+        staging.write_all(b"D".repeat(10).as_slice())?;
+        drop(staging);
+        assert_eq!(std::fs::metadata(&staging_path)?.len(), 30);
+
+        let published = ds.finalize_block(&block)?;
+        assert!(published.is_final());
+        assert_eq!(published.len(), 50);
+        let bytes = std::fs::read(&active_path)?;
+        assert_eq!(bytes.len(), 50);
+        assert_eq!(&bytes[..20], b"B".repeat(20).as_slice());
+        assert_eq!(&bytes[20..30], b"D".repeat(10).as_slice());
+        assert!(!staging_path.exists());
+        Ok(())
+    }
     #[test]
     fn remove_block_during_rewrite_deletes_active_and_staging_files() -> CommonResult<()> {
         let mut ds = create_data_set(true, "remove-during-rewrite");


### PR DESCRIPTION
<!-- curvine-automation:pr:CurvineIO/curvine:1390 -->

# Summary

Fix worker block length mismatch after sparse seek-past-EOF resize: finalize extends short staging files to the committed logical length, and reads synthesize sparse zeros when the master logical length exceeds physical worker bytes.

# Issue Describe / Design

Closes #1390

## Root cause

1. Sparse seek-past-EOF triggers `ResizeFile`. Master `InodeFile::extend` raises a committed last-block logical length (for example from 100 to 1024) without rewriting worker data and without re-attaching `alloc_opts` (intentional, to avoid rewrite amplification).
2. A later rewrite into that block opens with `ExtendedBlock.len` equal to the inflated logical length, copies the short committed staging file, writes a partial range, then `FileLayout::finalize` compared filesystem size to `committed_len` and failed with `Block length mismatch`.
3. Even after a successful write path, a later resize can inflate another block's master length without a rewrite. Reads then open with the larger logical length against a shorter physical file and fail past EOF.

## Fix approach

- In `FileLayout::finalize`, when staging size is below `committed_len`, `set_len(committed_len)` before the mismatch check so partial post-resize rewrites can commit.
- In worker read open/read, accept the client-visible logical length and return zeros past the physical file length; disable short-circuit when logical length exceeds physical so local readers cannot bypass that path.
- Do not rematerialize every grown committed block on the client during resize (that approach fixed the assigned case but introduced FUSE fio regressions).

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-server/.../file_layout.rs` | Extend short staging to `committed_len` on finalize | Post-resize partial rewrites can finalize |
| `curvine-server/.../block_io_context.rs` | Sparse zero synthesis for logical > physical reads | Reads of inflated logical lengths succeed with holes |
| `curvine-server/.../read_handler.rs` | Open with logical length; force remote when sparse | Short-circuit skipped only for sparse logical tails |
| `curvine-server/.../vfs_dataset.rs` | Unit test for sparse finalize materialization | Guards the rewrite finalize path |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `make format` | PASS | On exact HEAD `8e5f0d62` |
| `cargo test -p curvine-server --lib finalize_rewrite_materializes_sparse_committed_length` | PASS | Worker unit coverage |
| `cargo test -p curvine-server --lib read_context_sparse_logical_tail_returns_zeros` | PASS | Sparse read unit coverage |
| `cargo test -p curvine-tests --test block_test resize_file_read_write` | PASS | Assigned case on fixed HEAD |
| Profile before (`aeb13490`) / after (`8e5f0d62`) for fast, integration, daily, fuse, ltp, csi | PASS gate | Assigned `resize_file_read_write` absent after; `new_failures=[]`; cleanup passed; image digest matched |
| Independent review | APPROVED | Bound to exact HEAD `8e5f0d62` |

# Dependencies

- Related PRs: None
- Related issues: #1390
- Blocks / blocked by: None
