### PR TITLE
fix(fuse): support renameat2 flags and fix false OFD SETLKW EDEADLK (#1305)

### DIFF
--- a/curvine-client-core/src/file/curvine_filesystem.rs
+++ b/curvine-client-core/src/file/curvine_filesystem.rs
@@ -25,7 +25,8 @@ use curvine_model::ProtoUtils;
 use curvine_model::{CommitBlock, FreeResult, ListOptions};
 use curvine_model::{
     CreateFileOpts, CreateFileOptsBuilder, FileAllocOpts, FileBlocks, FileLock, FileStatus,
-    MasterInfo, MkdirOpts, MkdirOptsBuilder, MountInfo, MountOptions, OpenFlags, SetAttrOpts,
+    MasterInfo, MkdirOpts, MkdirOptsBuilder, MountInfo, MountOptions, OpenFlags, RenameFlags,
+    SetAttrOpts,
 };
 use log::info;
 use log::warn;
@@ -169,7 +170,16 @@ impl CurvineFileSystem {
     }
 
     pub async fn rename(&self, src: &Path, dst: &Path) -> FsResult<bool> {
-        self.fs_client.rename(src, dst).await
+        self.rename_with_flags(src, dst, RenameFlags::empty()).await
+    }
+
+    pub async fn rename_with_flags(
+        &self,
+        src: &Path,
+        dst: &Path,
+        flags: RenameFlags,
+    ) -> FsResult<bool> {
+        self.fs_client.rename(src, dst, flags).await
     }
 
     pub async fn delete(&self, path: &Path, recursive: bool) -> FsResult<()> {

--- a/curvine-client-core/src/file/fs_client.rs
+++ b/curvine-client-core/src/file/fs_client.rs
@@ -179,11 +179,11 @@ impl FsClient {
         Ok(ProtoUtils::free_res_from_pb(rep.res))
     }
 
-    pub async fn rename(&self, src: &Path, dst: &Path) -> FsResult<bool> {
+    pub async fn rename(&self, src: &Path, dst: &Path, flags: RenameFlags) -> FsResult<bool> {
         let header = RenameRequest {
             src: src.encode(),
             dst: dst.encode(),
-            flags: RenameFlags::empty().value(),
+            flags: flags.value(),
         };
 
         let rep_header: RenameResponse = self.rpc(RpcCode::Rename, header).await?;

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -2132,7 +2132,34 @@ impl fs::FileSystem for CurvineFileSystem {
             if wait_guard
                 .register_blocked_by(LockOwner::new(blocker.client_id.clone(), blocker.owner_id))
             {
-                return err_fuse!(libc::EDEADLK);
+                // OFD multi-thread unlock/re-lock (LTP fcntl34) can transiently
+                // form a waiter↔prior-holder cycle in the local wait graph while
+                // the Master lock is already free or held by someone else.
+                // Drop the edge, re-sample once, and only then commit to EDEADLK
+                // so true multi-resource deadlocks (fcntl17) still fail fast.
+                wait_guard.clear_blocked_by();
+                let sleep_ms =
+                    check_interval_max_ms.min(check_interval_min_ms.saturating_mul(ticks + 1));
+                tokio::time::sleep(std::time::Duration::from_millis(sleep_ms)).await;
+                let conflict2 = self.fs.set_lock(&path, lock.clone()).await?;
+                if conflict2.is_none() {
+                    wait_guard.clear_blocked_by();
+                    if is_unlock {
+                        if full_range_unlock && lock.lock_flags == LockFlags::Plock {
+                            handle.take_plock_if_owner(lock.owner_id);
+                        }
+                    } else {
+                        handle.add_lock(lock.lock_flags, lock.owner_id);
+                    }
+                    return Ok(());
+                }
+                let blocker2 = conflict2.as_ref().expect("conflict lock");
+                if wait_guard.register_blocked_by(LockOwner::new(
+                    blocker2.client_id.clone(),
+                    blocker2.owner_id,
+                )) {
+                    return err_fuse!(libc::EDEADLK);
+                }
             }
 
             ticks += 1;

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -234,7 +234,7 @@ impl CurvineFileSystem {
             return err_fuse!(libc::ENAMETOOLONG);
         }
 
-        self.check_rename_permissions(header, old_id, old_name, new_dir)
+        self.check_rename_permissions(header, old_id, old_name, new_dir, new_name, flags)
             .await?;
 
         let (old_path, new_path) = self.state.get_path2(old_id, old_name, new_dir, new_name)?;
@@ -457,6 +457,8 @@ impl CurvineFileSystem {
         old_parent: u64,
         old_name: &str,
         new_parent: u64,
+        new_name: &str,
+        flags: RenameFlags,
     ) -> FuseResult<()> {
         if header.uid == 0 || !self.conf.check_permission {
             return Ok(());
@@ -465,20 +467,41 @@ impl CurvineFileSystem {
         let dir_mask = (libc::W_OK | libc::X_OK) as u32;
         self.check_permissions_on_node(header, old_parent, dir_mask)
             .await?;
-        if new_parent != old_parent {
+        let new_parent_status = if new_parent != old_parent {
             self.check_permissions_on_node(header, new_parent, dir_mask)
                 .await?;
-        }
+            self.state.fs_stat(new_parent, None).await?
+        } else {
+            self.state.fs_stat(old_parent, None).await?
+        };
+        let old_parent_status = if new_parent == old_parent {
+            new_parent_status.clone()
+        } else {
+            self.state.fs_stat(old_parent, None).await?
+        };
 
-        let parent_status = self.state.fs_stat(old_parent, None).await?;
-        if parent_status.mode & libc::S_ISVTX as u32 != 0 {
+        if old_parent_status.mode & libc::S_ISVTX as u32 != 0 {
             let file_status = self.state.fs_stat(old_parent, Some(old_name)).await?;
-            let parent_uid = self.resolve_file_uid(&parent_status.owner);
+            let parent_uid = self.resolve_file_uid(&old_parent_status.owner);
             let file_uid = self.resolve_file_uid(&file_status.owner);
             if header.uid != parent_uid && header.uid != file_uid {
                 return err_fuse!(
                     libc::EPERM,
                     "sticky directory: cannot rename file owned by another user"
+                );
+            }
+        }
+
+        let dest_exists =
+            flags.exchange_mode() || self.state.fs_stat(new_parent, Some(new_name)).await.is_ok();
+        if dest_exists && new_parent_status.mode & libc::S_ISVTX as u32 != 0 {
+            let dest_status = self.state.fs_stat(new_parent, Some(new_name)).await?;
+            let parent_uid = self.resolve_file_uid(&new_parent_status.owner);
+            let dest_uid = self.resolve_file_uid(&dest_status.owner);
+            if header.uid != parent_uid && header.uid != dest_uid {
+                return err_fuse!(
+                    libc::EPERM,
+                    "sticky directory: cannot rename over file owned by another user"
                 );
             }
         }
@@ -2149,7 +2172,13 @@ impl fs::FileSystem for CurvineFileSystem {
                     }
                     return Ok(());
                 }
-                return err_fuse!(libc::EDEADLK);
+                let blocker2 = conflict2.as_ref().expect("conflict lock");
+                if wait_guard.register_blocked_by(LockOwner::new(
+                    blocker2.client_id.clone(),
+                    blocker2.owner_id,
+                )) {
+                    return err_fuse!(libc::EDEADLK);
+                }
             }
 
             ticks += 1;

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -31,7 +31,7 @@ use curvine_common::error::FsError;
 use curvine_common::fs::{FileSystem, Path, RpcCode, StateReader, StateWriter};
 use curvine_common::state::{
     is_special_file_type, FileAllocMode, FileAllocOpts, FileLock, FileStatus, FileType, LockFlags,
-    LockType, OpenFlags, SetAttrOpts,
+    LockType, OpenFlags, RenameFlags, SetAttrOpts,
 };
 use curvine_common::MAX_FILE_SIZE;
 use log::{debug, info, warn};
@@ -221,16 +221,21 @@ impl CurvineFileSystem {
     /// Shared rename path resolution used by both `rename` and `rename2`.
     async fn rename_paths(
         &self,
+        header: &fuse_in_header,
         old_id: u64,
         old_name: &OsStr,
         new_dir: u64,
         new_name: &OsStr,
+        flags: RenameFlags,
     ) -> FuseResult<()> {
         let old_name = try_option!(old_name.to_str());
         let new_name = try_option!(new_name.to_str());
         if new_name.len() > FUSE_MAX_NAME_LENGTH {
             return err_fuse!(libc::ENAMETOOLONG);
         }
+
+        self.check_rename_permissions(header, old_id, old_name, new_dir)
+            .await?;
 
         let (old_path, new_path) = self.state.get_path2(old_id, old_name, new_dir, new_name)?;
         self.ensure_writable_path(&old_path, RpcCode::Rename)
@@ -239,13 +244,26 @@ impl CurvineFileSystem {
             .await?;
 
         self.state
-            .fs_rename(old_id, old_name, new_dir, new_name)
+            .fs_rename(old_id, old_name, new_dir, new_name, flags)
             .await
     }
 
-    /// Whether raw RENAME2 flags are supported, without truncating unknown high bits.
-    fn rename2_flags_supported(flags: u32) -> bool {
-        flags == 0
+    fn parse_rename2_flags(flags: u32) -> FuseResult<RenameFlags> {
+        const RENAME_NOREPLACE: u32 = 1;
+        const RENAME_EXCHANGE: u32 = 2;
+        const RENAME_WHITEOUT: u32 = 4;
+        const KNOWN: u32 = RENAME_NOREPLACE | RENAME_EXCHANGE | RENAME_WHITEOUT;
+
+        if flags & !KNOWN != 0 {
+            return err_fuse!(libc::EINVAL, "unsupported RENAME2 flags 0x{:x}", flags);
+        }
+        if flags & RENAME_WHITEOUT != 0 {
+            return err_fuse!(libc::EINVAL, "RENAME_WHITEOUT is not supported");
+        }
+        if flags & RENAME_NOREPLACE != 0 && flags & RENAME_EXCHANGE != 0 {
+            return err_fuse!(libc::EINVAL, "invalid RENAME2 flag combination");
+        }
+        Ok(RenameFlags::from_bits(flags).unwrap_or(RenameFlags::empty()))
     }
 
     fn to_file_lock(&self, arg: &fuse_lk_in, header_pid: u32) -> FileLock {
@@ -418,6 +436,54 @@ impl CurvineFileSystem {
     /// checks, but still validates X_OK against the file mode (see access(2)).
     fn posix_access_requires_mode_check(uid: u32, mask: u32) -> bool {
         uid != 0 || (mask & libc::X_OK as u32) != 0
+    }
+
+    async fn check_permissions_on_node(
+        &self,
+        header: &fuse_in_header,
+        nodeid: u64,
+        mask: u32,
+    ) -> FuseResult<()> {
+        if header.uid == 0 || !self.conf.check_permission {
+            return Ok(());
+        }
+        let status = self.state.fs_stat(nodeid, None).await?;
+        self.check_access_permissions(&status, header, mask)
+    }
+
+    async fn check_rename_permissions(
+        &self,
+        header: &fuse_in_header,
+        old_parent: u64,
+        old_name: &str,
+        new_parent: u64,
+    ) -> FuseResult<()> {
+        if header.uid == 0 || !self.conf.check_permission {
+            return Ok(());
+        }
+
+        let dir_mask = (libc::W_OK | libc::X_OK) as u32;
+        self.check_permissions_on_node(header, old_parent, dir_mask)
+            .await?;
+        if new_parent != old_parent {
+            self.check_permissions_on_node(header, new_parent, dir_mask)
+                .await?;
+        }
+
+        let parent_status = self.state.fs_stat(old_parent, None).await?;
+        if parent_status.mode & libc::S_ISVTX as u32 != 0 {
+            let file_status = self.state.fs_stat(old_parent, Some(old_name)).await?;
+            let parent_uid = self.resolve_file_uid(&parent_status.owner);
+            let file_uid = self.resolve_file_uid(&file_status.owner);
+            if header.uid != parent_uid && header.uid != file_uid {
+                return err_fuse!(
+                    libc::EPERM,
+                    "sticky directory: cannot rename file owned by another user"
+                );
+            }
+        }
+
+        Ok(())
     }
 
     async fn check_permissions(&self, header: &fuse_in_header, mask: u32) -> FuseResult<()> {
@@ -1773,22 +1839,28 @@ impl fs::FileSystem for CurvineFileSystem {
     }
 
     async fn rename(&self, op: Rename<'_>) -> FuseResult<()> {
-        self.rename_paths(op.header.nodeid, op.old_name, op.arg.newdir, op.new_name)
-            .await
+        self.rename_paths(
+            op.header,
+            op.header.nodeid,
+            op.old_name,
+            op.arg.newdir,
+            op.new_name,
+            RenameFlags::empty(),
+        )
+        .await
     }
 
     async fn rename2(&self, op: Rename2<'_>) -> FuseResult<()> {
-        // The FUSE-facing client rename path only issues flag-less renames, so
-        // NO_REPLACE/EXCHANGE/WHITEOUT are not plumbed through to the master RPC.
-        if !Self::rename2_flags_supported(op.arg.flags) {
-            return err_fuse!(
-                libc::ENOSYS,
-                "RENAME2 flags 0x{:x} not supported (flag-less rename only)",
-                op.arg.flags
-            );
-        }
-        self.rename_paths(op.header.nodeid, op.old_name, op.arg.newdir, op.new_name)
-            .await
+        let flags = Self::parse_rename2_flags(op.arg.flags)?;
+        self.rename_paths(
+            op.header,
+            op.header.nodeid,
+            op.old_name,
+            op.arg.newdir,
+            op.new_name,
+            flags,
+        )
+        .await
     }
 
     async fn batch_forget(&self, op: BatchForget<'_>) -> FuseResult<()> {
@@ -2781,16 +2853,17 @@ mod tests {
     }
 
     #[test]
-    fn rename2_flags_supported_only_accepts_zero() {
-        // Flag-less rename is the only supported form.
-        assert!(CurvineFileSystem::rename2_flags_supported(0));
-        // Known rename flags are rejected (client does not plumb them through).
-        assert!(!CurvineFileSystem::rename2_flags_supported(1)); // RENAME_NOREPLACE
-        assert!(!CurvineFileSystem::rename2_flags_supported(2)); // RENAME_EXCHANGE
-        assert!(!CurvineFileSystem::rename2_flags_supported(4)); // RENAME_WHITEOUT
-                                                                 // An unknown high bit must also be rejected — checked against the raw
-                                                                 // value, so it is not silently truncated away (the RenameFlags footgun).
-        assert!(!CurvineFileSystem::rename2_flags_supported(1 << 6));
+    fn parse_rename2_flags_accepts_supported_values() {
+        assert!(CurvineFileSystem::parse_rename2_flags(0).is_ok());
+        assert!(CurvineFileSystem::parse_rename2_flags(1).is_ok());
+        assert!(CurvineFileSystem::parse_rename2_flags(2).is_ok());
+    }
+
+    #[test]
+    fn parse_rename2_flags_rejects_unsupported_values() {
+        assert!(CurvineFileSystem::parse_rename2_flags(4).is_err());
+        assert!(CurvineFileSystem::parse_rename2_flags(3).is_err());
+        assert!(CurvineFileSystem::parse_rename2_flags(1 << 6).is_err());
     }
 
     mod readdir_termination {

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -2132,15 +2132,11 @@ impl fs::FileSystem for CurvineFileSystem {
             if wait_guard
                 .register_blocked_by(LockOwner::new(blocker.client_id.clone(), blocker.owner_id))
             {
-                // OFD multi-thread unlock/re-lock (LTP fcntl34) can transiently
-                // form a waiter↔prior-holder cycle in the local wait graph while
-                // the Master lock is already free or held by someone else.
-                // Drop the edge, re-sample once, and only then commit to EDEADLK
-                // so true multi-resource deadlocks (fcntl17) still fail fast.
-                wait_guard.clear_blocked_by();
-                let sleep_ms =
-                    check_interval_max_ms.min(check_interval_min_ms.saturating_mul(ticks + 1));
-                tokio::time::sleep(std::time::Duration::from_millis(sleep_ms)).await;
+                // Cycle in the local wait graph. Re-sample Master once while
+                // keeping our edge published so a peer in a true multi-resource
+                // deadlock (LTP fcntl17) still observes the cycle. If the lock
+                // is free now (OFD unlock/re-lock race, LTP fcntl34), acquire
+                // instead of returning a false EDEADLK.
                 let conflict2 = self.fs.set_lock(&path, lock.clone()).await?;
                 if conflict2.is_none() {
                     wait_guard.clear_blocked_by();
@@ -2153,13 +2149,7 @@ impl fs::FileSystem for CurvineFileSystem {
                     }
                     return Ok(());
                 }
-                let blocker2 = conflict2.as_ref().expect("conflict lock");
-                if wait_guard.register_blocked_by(LockOwner::new(
-                    blocker2.client_id.clone(),
-                    blocker2.owner_id,
-                )) {
-                    return err_fuse!(libc::EDEADLK);
-                }
+                return err_fuse!(libc::EDEADLK);
             }
 
             ticks += 1;

--- a/curvine-fuse/src/fs/dcache/dir_tree.rs
+++ b/curvine-fuse/src/fs/dcache/dir_tree.rs
@@ -352,6 +352,39 @@ impl DirTree {
         Ok(())
     }
 
+    pub fn exchange(
+        &mut self,
+        old_id: u64,
+        old_name: &str,
+        new_id: u64,
+        new_name: &str,
+    ) -> FuseResult<()> {
+        let old_ino = self.get_ino_check(old_id, Some(old_name))?;
+        let new_ino = self.get_ino_check(new_id, Some(new_name))?;
+        if old_ino == new_ino {
+            return Ok(());
+        }
+
+        self.get_dir_mut_check(old_id)?.remove_child(old_name);
+        self.get_dir_mut_check(new_id)?.remove_child(new_name);
+        self.get_dir_mut_check(old_id)?
+            .add_child(old_name.to_string(), new_ino);
+        self.get_dir_mut_check(new_id)?
+            .add_child(new_name.to_string(), old_ino);
+
+        {
+            let inode = self.get_inode_mut_check(old_ino, None)?;
+            inode.parent = new_id;
+            inode.name = new_name.to_string();
+        }
+        {
+            let inode = self.get_inode_mut_check(new_ino, None)?;
+            inode.parent = old_id;
+            inode.name = old_name.to_string();
+        }
+        Ok(())
+    }
+
     pub fn rename(
         &mut self,
         old_id: u64,

--- a/curvine-fuse/src/fs/plock_wait_registry.rs
+++ b/curvine-fuse/src/fs/plock_wait_registry.rs
@@ -66,17 +66,50 @@ impl PlockWaitRegistry {
 
     /// Atomically replace `waiter -> blocked_by` and detect a wait cycle.
     /// Returns true when the edge would close a cycle (EDEADLK).
+    ///
+    /// Edges are resolved to the root non-waiting owner (follow `blocked_by`'s
+    /// chain). That keeps the graph pointing at presumed holders and avoids
+    /// waiter↔waiter cycles that appear when an OFD/POSIX holder unlocks and
+    /// immediately re-enters `F_SETLKW` while another waiter still has a stale
+    /// edge to the previous holder (LTP `fcntl34` multi-thread OFD pattern).
     pub fn try_register_blocked_by(&self, waiter: LockOwner, blocked_by: LockOwner) -> bool {
         let mut map = self.waiters.lock().expect("plock wait registry poisoned");
         // Drop any prior edge for this waiter before walking the graph so a
         // stale self-edge cannot create a false cycle, and so the new blocker
         // is published atomically with the deadlock check.
         map.remove(&waiter);
-        if Self::reaches_waiter(&map, &waiter, &blocked_by) {
+
+        let root = match Self::root_blocker(&map, &waiter, &blocked_by) {
+            Ok(root) => root,
+            Err(()) => return true,
+        };
+        if Self::reaches_waiter(&map, &waiter, &root) {
             return true;
         }
-        map.insert(waiter, blocked_by);
+        map.insert(waiter, root);
         false
+    }
+
+    /// Follow wait edges from `blocked_by` until a non-waiter (presumed holder).
+    /// Returns `Err(())` when the existing graph already cycles through `waiter`.
+    fn root_blocker(
+        map: &HashMap<LockOwner, LockOwner>,
+        waiter: &LockOwner,
+        blocked_by: &LockOwner,
+    ) -> Result<LockOwner, ()> {
+        let mut root = blocked_by.clone();
+        let mut seen = HashSet::new();
+        while let Some(next) = map.get(&root).cloned() {
+            if &root == waiter || &next == waiter {
+                return Err(());
+            }
+            if !seen.insert(root.clone()) {
+                // Cycle among other waiters; treat as deadlock.
+                return Err(());
+            }
+            root = next;
+        }
+        Ok(root)
     }
 
     fn reaches_waiter(
@@ -193,5 +226,32 @@ mod tests {
         assert!(!guard.register_blocked_by(b.clone()));
         guard.clear_blocked_by();
         assert!(!reg.would_deadlock(&b, &a));
+    }
+
+    #[test]
+    fn resolves_edge_through_waiter_chain_to_holder() {
+        let reg = PlockWaitRegistry::new();
+        let holder = LockOwner::new("c", 1);
+        let mid = LockOwner::new("c", 2);
+        let waiter = LockOwner::new("c", 3);
+
+        // mid waits on holder; a new waiter blocked by mid should wait on holder.
+        assert!(!reg.try_register_blocked_by(mid.clone(), holder.clone()));
+        assert!(!reg.try_register_blocked_by(waiter.clone(), mid.clone()));
+        let map = reg.waiters.lock().unwrap();
+        assert_eq!(map.get(&waiter), Some(&holder));
+    }
+
+    #[test]
+    fn opposite_waiter_edges_still_detect_cycle_after_root_resolve() {
+        // Registry-level A↔B remains a cycle (fcntl17 needs this). The SETLKW
+        // path re-samples Master after a transient cycle so fcntl34 unlock/re-
+        // lock races do not surface EDEADLK to userspace.
+        let reg = PlockWaitRegistry::new();
+        let a = LockOwner::new("c", 10);
+        let b = LockOwner::new("c", 20);
+
+        assert!(!reg.try_register_blocked_by(a.clone(), b.clone()));
+        assert!(reg.try_register_blocked_by(b.clone(), a.clone()));
     }
 }

--- a/curvine-fuse/src/fs/state/node_state.rs
+++ b/curvine-fuse/src/fs/state/node_state.rs
@@ -31,7 +31,8 @@ use curvine_common::conf::{ClientConf, FuseConf};
 use curvine_common::error::FsError;
 use curvine_common::fs::{FileSystem, ListStream, Path, StateReader, StateWriter};
 use curvine_common::state::{
-    CreateFileOpts, FileAllocOpts, FileStatus, ListOptions, MkdirOpts, OpenFlags, SetAttrOpts,
+    CreateFileOpts, FileAllocOpts, FileStatus, ListOptions, MkdirOpts, OpenFlags, RenameFlags,
+    SetAttrOpts,
 };
 use curvine_config::ClusterConf;
 use futures::stream::{self, StreamExt};
@@ -1047,10 +1048,18 @@ impl NodeState {
         old_name: &str,
         new_id: u64,
         new_name: &str,
+        flags: RenameFlags,
     ) -> FuseResult<()> {
         let (old_path, new_path) = self.get_path2(old_id, old_name, new_id, new_name)?;
-        self.fs.rename(&old_path, &new_path).await?;
-        self.rename(old_id, old_name, new_id, new_name)
+        self.fs
+            .rename_with_flags(&old_path, &new_path, flags)
+            .await?;
+        if flags.exchange_mode() {
+            self.dir_write()
+                .exchange(old_id, old_name, new_id, new_name)
+        } else {
+            self.rename(old_id, old_name, new_id, new_name)
+        }
     }
 
     pub async fn fs_fsync(&self, parent: u64, name: Option<&str>) -> FuseResult<()> {

--- a/curvine-server/src/master/fs/master_filesystem.rs
+++ b/curvine-server/src/master/fs/master_filesystem.rs
@@ -302,6 +302,18 @@ impl MasterFilesystem {
             }
         }
 
+        // EXCHANGE also rejects src under dst (/a/b <-> /a would make /a its own descendant).
+        if flags.exchange_mode() {
+            if let Some(rest) = src.strip_prefix(dst) {
+                if rest.starts_with(PATH_SEPARATOR) {
+                    return err_ext!(FsError::invalid_argument(format!(
+                        "cannot exchange {} with {}: source is under destination",
+                        src, dst
+                    )));
+                }
+            }
+        }
+
         if let Some(del_res) = fs_dir.rename(&src_inp, &dst_inp, flags)? {
             let mut worker_manager = self.worker_manager.write();
             worker_manager.remove_blocks(&del_res);

--- a/curvine-server/src/master/journal/entry.rs
+++ b/curvine-server/src/master/journal/entry.rs
@@ -85,6 +85,11 @@ pub struct RenameEntry {
     pub(crate) dst: String,
     pub(crate) mtime: i64,
     pub(crate) flags: u32,
+    /// Pre-exchange inode ids for idempotent EXCHANGE replay (0 when absent / legacy).
+    #[serde(default)]
+    pub(crate) src_inode_id: i64,
+    #[serde(default)]
+    pub(crate) dst_inode_id: i64,
 }
 
 // delete

--- a/curvine-server/src/master/journal/journal_loader.rs
+++ b/curvine-server/src/master/journal/journal_loader.rs
@@ -700,6 +700,14 @@ impl JournalLoader {
             &dst_inp,
             entry.mtime,
             RenameFlags::new(entry.flags),
+            if RenameFlags::new(entry.flags).exchange_mode()
+                && entry.src_inode_id != 0
+                && entry.dst_inode_id != 0
+            {
+                Some((entry.src_inode_id, entry.dst_inode_id))
+            } else {
+                None
+            },
         )?;
 
         Ok(())

--- a/curvine-server/src/master/journal/journal_writer.rs
+++ b/curvine-server/src/master/journal/journal_writer.rs
@@ -223,7 +223,9 @@ impl JournalWriter {
         dst: P,
         mtime: i64,
         flags: RenameFlags,
+        exchange_pre_swap_ids: Option<(i64, i64)>,
     ) -> FsResult<()> {
+        let (src_inode_id, dst_inode_id) = exchange_pre_swap_ids.unwrap_or((0, 0));
         let entry = RenameEntry {
             op_id: fs_dir.next_op_id(),
             rpc_id: 0,
@@ -231,6 +233,8 @@ impl JournalWriter {
             dst: dst.as_ref().to_string(),
             mtime,
             flags: flags.value(),
+            src_inode_id,
+            dst_inode_id,
         };
         self.send(fs_dir, JournalEntry::Rename(entry))
     }

--- a/curvine-server/src/master/meta/fs_dir.rs
+++ b/curvine-server/src/master/meta/fs_dir.rs
@@ -326,13 +326,28 @@ impl FsDir {
         flags: RenameFlags,
     ) -> FsResult<Option<DeleteResult>> {
         let op_ms = LocalTime::mills();
-        let res = self.unprotected_rename(src_inp, dst_inp, op_ms as i64, flags)?;
+        let exchange_pre_swap_ids = if flags.exchange_mode() {
+            let src_id = src_inp
+                .get_last_inode()
+                .map(|inode| inode.id())
+                .unwrap_or(0);
+            let dst_id = dst_inp
+                .get_last_inode()
+                .map(|inode| inode.id())
+                .unwrap_or(0);
+            Some((src_id, dst_id))
+        } else {
+            None
+        };
+        let res =
+            self.unprotected_rename(src_inp, dst_inp, op_ms as i64, flags, exchange_pre_swap_ids)?;
         self.journal_writer.log_rename(
             self,
             src_inp.path(),
             dst_inp.path(),
             op_ms as i64,
             flags,
+            exchange_pre_swap_ids,
         )?;
         Ok(res)
     }
@@ -343,13 +358,14 @@ impl FsDir {
         dst_inp: &InodePath,
         mtime: i64,
         flags: RenameFlags,
+        exchange_pre_swap_ids: Option<(i64, i64)>,
     ) -> FsResult<Option<DeleteResult>> {
         let src_inode = match src_inp.get_last_inode() {
             None => return err_ext!(FsError::file_not_found(src_inp.path())),
             Some(v) => v,
         };
         if flags.exchange_mode() {
-            self.unprotected_exchange(src_inp, dst_inp, mtime)?;
+            self.unprotected_exchange(src_inp, dst_inp, mtime, exchange_pre_swap_ids)?;
             return Ok(None);
         }
 
@@ -420,6 +436,7 @@ impl FsDir {
         src_inp: &InodePath,
         dst_inp: &InodePath,
         mtime: i64,
+        pre_swap_ids: Option<(i64, i64)>,
     ) -> FsResult<()> {
         let src_inode = match src_inp.get_last_inode() {
             None => return err_ext!(FsError::file_not_found(src_inp.path())),
@@ -430,8 +447,31 @@ impl FsDir {
             Some(v) => v,
         };
 
-        if src_inode.id() == dst_inode.id() {
+        let src_id = src_inode.id();
+        let dst_id = dst_inode.id();
+
+        if src_id == dst_id {
             return Ok(());
+        }
+
+        if let Some((expected_src, expected_dst)) = pre_swap_ids {
+            if expected_src != 0 && expected_dst != 0 {
+                if src_id == expected_dst && dst_id == expected_src {
+                    return Ok(());
+                }
+                if src_id != expected_src || dst_id != expected_dst {
+                    warn!(
+                        "Exchange replay inode id mismatch at {} and {}: current ({}, {}), expected ({}, {})",
+                        src_inp.path(),
+                        dst_inp.path(),
+                        src_id,
+                        dst_id,
+                        expected_src,
+                        expected_dst
+                    );
+                    return Ok(());
+                }
+            }
         }
 
         let mut src_parent = match src_inp.get_inode(-2) {
@@ -456,6 +496,21 @@ impl FsDir {
 
         src_parent.update_mtime(mtime);
         dst_parent.update_mtime(mtime);
+
+        if src_parent.id() != dst_parent.id() {
+            let src_was_dir = src_inode.is_dir();
+            let dst_was_dir = dst_inode.is_dir();
+            if src_was_dir && !dst_was_dir {
+                src_parent.dec_nlink(mtime);
+            } else if !src_was_dir && dst_was_dir {
+                src_parent.incr_nlink(mtime);
+            }
+            if dst_was_dir && !src_was_dir {
+                dst_parent.dec_nlink(mtime);
+            } else if !dst_was_dir && src_was_dir {
+                dst_parent.incr_nlink(mtime);
+            }
+        }
 
         self.store.apply_exchange(
             src_parent.as_ref(),

--- a/curvine-server/src/master/meta/fs_dir.rs
+++ b/curvine-server/src/master/meta/fs_dir.rs
@@ -349,7 +349,8 @@ impl FsDir {
             Some(v) => v,
         };
         if flags.exchange_mode() {
-            return err_box!("Rename failed, because exchange mode is not supported");
+            self.unprotected_exchange(src_inp, dst_inp, mtime)?;
+            return Ok(None);
         }
 
         let mut src_parent = match src_inp.get_inode(-2) {
@@ -412,6 +413,65 @@ impl FsDir {
         let _ = dst_parent.add_child(new_inode)?;
 
         Ok(del_res)
+    }
+
+    fn unprotected_exchange(
+        &mut self,
+        src_inp: &InodePath,
+        dst_inp: &InodePath,
+        mtime: i64,
+    ) -> FsResult<()> {
+        let src_inode = match src_inp.get_last_inode() {
+            None => return err_ext!(FsError::file_not_found(src_inp.path())),
+            Some(v) => v,
+        };
+        let dst_inode = match dst_inp.get_last_inode() {
+            None => return err_ext!(FsError::file_not_found(dst_inp.path())),
+            Some(v) => v,
+        };
+
+        if src_inode.id() == dst_inode.id() {
+            return Ok(());
+        }
+
+        let mut src_parent = match src_inp.get_inode(-2) {
+            None => return err_box!("Parent not exists: {}", src_inp.path()),
+            Some(v) => v,
+        };
+        let mut dst_parent = match dst_inp.get_inode(-2) {
+            None => return err_box!("Parent not exists: {}", dst_inp.path()),
+            Some(v) => v,
+        };
+
+        let src_name = src_inp.name().to_string();
+        let dst_name = dst_inp.name().to_string();
+
+        let mut at_src = dst_inode.as_ref().clone();
+        at_src.change_name(src_name.clone());
+        at_src.set_parent_id(src_parent.id());
+
+        let mut at_dst = src_inode.as_ref().clone();
+        at_dst.change_name(dst_name.clone());
+        at_dst.set_parent_id(dst_parent.id());
+
+        src_parent.update_mtime(mtime);
+        dst_parent.update_mtime(mtime);
+
+        self.store.apply_exchange(
+            src_parent.as_ref(),
+            &src_name,
+            dst_parent.as_ref(),
+            &dst_name,
+            &at_src,
+            &at_dst,
+        )?;
+
+        let _ = src_parent.delete_child(src_inode.id(), &src_name)?;
+        let _ = dst_parent.delete_child(dst_inode.id(), &dst_name)?;
+        let _ = src_parent.add_child(at_src)?;
+        let _ = dst_parent.add_child(at_dst)?;
+
+        Ok(())
     }
 
     pub fn create_file(&mut self, mut inp: InodePath, opts: CreateFileOpts) -> FsResult<InodePath> {

--- a/curvine-server/src/master/meta/store/inode_store.rs
+++ b/curvine-server/src/master/meta/store/inode_store.rs
@@ -237,6 +237,31 @@ impl InodeStore {
         Ok(())
     }
 
+    pub fn apply_exchange(
+        &self,
+        src_parent: &InodeView,
+        src_name: &str,
+        dst_parent: &InodeView,
+        dst_name: &str,
+        at_src: &InodeView,
+        at_dst: &InodeView,
+    ) -> CommonResult<()> {
+        let mut batch = self.store.new_batch();
+
+        batch.delete_child(src_parent.id(), src_name)?;
+        batch.delete_child(dst_parent.id(), dst_name)?;
+        batch.write_inode(at_src)?;
+        batch.write_inode(at_dst)?;
+        batch.add_child(src_parent.id(), at_src.name(), at_src.id())?;
+        batch.add_child(dst_parent.id(), at_dst.name(), at_dst.id())?;
+        batch.write_inode(src_parent)?;
+        batch.write_inode(dst_parent)?;
+
+        batch.commit()?;
+
+        Ok(())
+    }
+
     pub fn apply_new_block(
         &self,
         file: &InodeView,

--- a/curvine-server/tests/master_fs_test.rs
+++ b/curvine-server/tests/master_fs_test.rs
@@ -986,6 +986,37 @@ fn rename_posix_semantics(fs: &MasterFilesystem) -> CommonResult<()> {
     assert_eq!(fs.file_status("/a/exchange_a")?.id, id_b);
     assert_eq!(fs.file_status("/a/exchange_b")?.id, id_a);
 
+    // EXCHANGE rejects src under dst (/a/b <-> /a would make /a its own descendant).
+    fs.mkdir("/a/ex_parent", true)?;
+    fs.mkdir("/a/ex_parent/child", true)?;
+    let err = fs
+        .rename("/a/ex_parent/child", "/a/ex_parent", RenameFlags::EXCHANGE)
+        .expect_err("exchange with src under dst must fail");
+    assert!(matches!(err, FsError::InvalidArgument(_)));
+    assert!(fs.exists("/a/ex_parent")?);
+    assert!(fs.exists("/a/ex_parent/child")?);
+
+    // Cross-parent EXCHANGE between directory and file adjusts parent nlink.
+    fs.mkdir("/a/ex_dir_parent", true)?;
+    fs.mkdir("/a/ex_file_parent", true)?;
+    fs.mkdir("/a/ex_dir_parent/dir_entry", true)?;
+    fs.create("/a/ex_file_parent/file_entry", true)?;
+    let dir_parent_nlink = fs.file_status("/a/ex_dir_parent")?.nlink;
+    let file_parent_nlink = fs.file_status("/a/ex_file_parent")?.nlink;
+    fs.rename(
+        "/a/ex_dir_parent/dir_entry",
+        "/a/ex_file_parent/file_entry",
+        RenameFlags::EXCHANGE,
+    )?;
+    assert_eq!(
+        fs.file_status("/a/ex_dir_parent")?.nlink,
+        dir_parent_nlink - 1
+    );
+    assert_eq!(
+        fs.file_status("/a/ex_file_parent")?.nlink,
+        file_parent_nlink + 1
+    );
+
     // src symlink, dst symlink -> overwrite existing symlink and keep dst deletable.
     fs.symlink("nobody", "/a/symbolic", false, 0o777)?;
     fs.rename("/a/symbolic", "/a/asymbolic", RenameFlags::empty())?;
@@ -1578,6 +1609,19 @@ fn test_idempotent_rename() -> CommonResult<()> {
     let (fs, js, loader, _js2, fs2) = setup_pair("rename");
     fs.mkdir("/src", false)?;
     fs.rename("/src", "/dst", RenameFlags::empty())?;
+    replay_all_then_duplicate_last(&js, &loader)?;
+    assert_eq!(fs.sum_hash()?, fs2.sum_hash()?);
+    Ok(())
+}
+
+#[test]
+fn test_idempotent_exchange_rename() -> CommonResult<()> {
+    let _serial = master_fs_test_serial();
+    let (fs, js, loader, _js2, fs2) = setup_pair("exchange-rename");
+    fs.mkdir("/a", true)?;
+    fs.create("/a/ex_a", true)?;
+    fs.create("/a/ex_b", true)?;
+    fs.rename("/a/ex_a", "/a/ex_b", RenameFlags::EXCHANGE)?;
     replay_all_then_duplicate_last(&js, &loader)?;
     assert_eq!(fs.sum_hash()?, fs2.sum_hash()?);
     Ok(())

--- a/curvine-server/tests/master_fs_test.rs
+++ b/curvine-server/tests/master_fs_test.rs
@@ -974,6 +974,14 @@ fn rename_posix_semantics(fs: &MasterFilesystem) -> CommonResult<()> {
     assert!(!fs.exists("/a/noreplace_src")?);
     assert!(fs.exists("/a/noreplace_new")?);
 
+    fs.create("/a/exchange_a", true)?;
+    fs.create("/a/exchange_b", true)?;
+    let id_a = fs.file_status("/a/exchange_a")?.id;
+    let id_b = fs.file_status("/a/exchange_b")?.id;
+    fs.rename("/a/exchange_a", "/a/exchange_b", RenameFlags::EXCHANGE)?;
+    assert_eq!(fs.file_status("/a/exchange_a")?.id, id_b);
+    assert_eq!(fs.file_status("/a/exchange_b")?.id, id_a);
+
     // src symlink, dst symlink -> overwrite existing symlink and keep dst deletable.
     fs.symlink("nobody", "/a/symbolic", false, 0o777)?;
     fs.rename("/a/symbolic", "/a/asymbolic", RenameFlags::empty())?;

--- a/curvine-unified-fs/src/unified/unified_filesystem.rs
+++ b/curvine-unified-fs/src/unified/unified_filesystem.rs
@@ -24,7 +24,7 @@ use curvine_job_client::JobMasterClient;
 use curvine_model::{
     CreateFileOpts, FileAllocOpts, FileLock, FileStatus, FreeResult, JobStatus, ListOptions,
     LoadJobCommand, MasterInfo, MkdirOpts, MkdirOptsBuilder, MountInfo, MountOptions, OpenFlags,
-    SetAttrOpts,
+    RenameFlags, SetAttrOpts,
 };
 use log::{debug, error, info, warn};
 use orpc::common::TimeSpent;
@@ -672,6 +672,38 @@ impl UnifiedFileSystem {
         };
         self.track("SetLock", path.path(), "", fut).await
     }
+
+    pub async fn rename_with_flags(
+        &self,
+        src: &Path,
+        dst: &Path,
+        flags: RenameFlags,
+    ) -> FsResult<bool> {
+        let fut = async {
+            let _ = self.get_mount_checked(dst, RpcCode::Rename).await?;
+            match self.get_mount_checked(src, RpcCode::Rename).await? {
+                None => self.cv.rename_with_flags(src, dst, flags).await,
+                Some((src_ufs, mount)) => {
+                    if !flags.is_empty() {
+                        return err_ext!(FsError::unsupported(
+                            "rename flags through unified mount"
+                        ));
+                    }
+                    let dst_ufs = mount.get_ufs_path(dst)?;
+                    let res = mount.ufs()?.rename(&src_ufs, &dst_ufs).await?;
+
+                    if let Err(e) = self.cv.delete(src, true).await {
+                        if !matches!(e, FsError::FileNotFound(_)) {
+                            warn!("failed to delete cache for {}: {}", src, e);
+                        }
+                    }
+
+                    Ok(res)
+                }
+            }
+        };
+        self.track("Rename", src.path(), dst.path(), fut).await
+    }
 }
 
 struct UnifiedUtils;
@@ -781,26 +813,7 @@ impl FileSystem<UnifiedWriter, UnifiedReader> for UnifiedFileSystem {
     }
 
     async fn rename(&self, src: &Path, dst: &Path) -> FsResult<bool> {
-        let fut = async {
-            let _ = self.get_mount_checked(dst, RpcCode::Rename).await?;
-            match self.get_mount_checked(src, RpcCode::Rename).await? {
-                None => self.cv.rename(src, dst).await,
-                Some((src_ufs, mount)) => {
-                    let dst_ufs = mount.get_ufs_path(dst)?;
-                    let res = mount.ufs()?.rename(&src_ufs, &dst_ufs).await?;
-
-                    // After rename, the file's mtime changes, making the cached data invalid
-                    if let Err(e) = self.cv.delete(src, true).await {
-                        if !matches!(e, FsError::FileNotFound(_)) {
-                            warn!("failed to delete cache for {}: {}", src, e);
-                        }
-                    }
-
-                    Ok(res)
-                }
-            }
-        };
-        self.track("Rename", src.path(), dst.path(), fut).await
+        self.rename_with_flags(src, dst, RenameFlags::empty()).await
     }
 
     async fn delete(&self, path: &Path, recursive: bool) -> FsResult<()> {


### PR DESCRIPTION
<!-- curvine-automation:pr:CurvineIO/curvine:1305 -->

# Summary

This PR fixes Curvine FUSE renameat2 semantics for `RENAME_NOREPLACE` / `RENAME_EXCHANGE` and sticky-bit / parent ACL checks required by LTP `renameat201` / `renameat202`. It also stops concurrent OFD `F_OFD_SETLKW` waiters from getting a false `EDEADLK` under multi-thread lock/unlock races (`fcntl34_64`) while preserving true multi-resource deadlock detection (`fcntl17` / `fcntl17_64`).

# Issue Describe / Design

Closes #1305

- Root cause (rename): FUSE rename did not honor renameat2 `NOREPLACE`/`EXCHANGE` flags and did not enforce sticky-directory / parent ACL constraints expected by POSIX rename tests.
- Root cause (OFD SETLKW): `PlockWaitRegistry` treated transient waiter↔prior-holder cycles during unlock/re-lock races as deadlock and returned `EDEADLK` incorrectly. Clearing the wait edge before re-sampling Master also weakened true deadlock detection.
- Fix approach: implement renameat2 flag handling and rename ACL checks in FUSE/Master paths; resolve wait-graph edges to the root non-waiter holder; on a cycle, re-sample Master once while keeping the wait edge so free locks can be acquired and true deadlocks still return `EDEADLK`.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-fuse/src/fs/curvine_file_system.rs` | renameat2 flag/ACL handling; SETLKW cycle confirm keeps wait edge | Behavior change: POSIX-aligned rename and OFD lock wait |
| `curvine-fuse/src/fs/plock_wait_registry.rs` | Resolve wait edges to root non-waiter | Behavior change: fewer false deadlocks |
| `curvine-fuse/src/fs/dcache/dir_tree.rs` | Directory tree support for rename paths | Supports corrected rename |
| `curvine-fuse/src/fs/state/node_state.rs` | Node state updates for rename/lock owners | Supports corrected rename/lock |
| `curvine-server/src/master/meta/fs_dir.rs` | Master rename ACL / flag checks | Behavior change: reject illegal renames |
| `curvine-server/src/master/meta/store/inode_store.rs` | Inode store helpers for rename checks | Supports Master checks |
| `curvine-client-core/src/file/curvine_filesystem.rs` | Client rename API plumbing | Passes flags through |
| `curvine-client-core/src/file/fs_client.rs` | Client RPC rename flags | Passes flags through |
| `curvine-unified-fs/src/unified/unified_filesystem.rs` | Unified FS rename flag forwarding | Passes flags through |
| `curvine-server/tests/master_fs_test.rs` | Master rename coverage | Test-only |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `make format` | PASS | Exact HEAD `84cda8a0037385e7bcefd8d83a72fae10ff236a5` |
| LTP `renameat201` | PASS | Assigned failure cleared on fixed HEAD |
| LTP `renameat202` | PASS | Assigned failure cleared on fixed HEAD |
| LTP `fcntl34_64` | PASS | False EDEADLK regression addressed |
| LTP `fcntl17` / `fcntl17_64` | PASS | True deadlock still returns EDEADLK |
| Profiles `fast`, `integration`, `daily`, `fuse`, `ltp`, `csi` | PASS gate | Compared against archived baseline; no new failure identities |

# Dependencies

- Related PRs: None
- Related issues: #1305
- Blocks / blocked by: None
