### PR TITLE
refactor(io): extract generic I/O primitives (#1243)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2264,6 +2264,16 @@ dependencies = [
 [[package]]
 name = "curvine-io"
 version = "0.2.0"
+dependencies = [
+ "bytes",
+ "curvine-sys",
+ "orpc-error",
+ "orpc-runtime",
+ "serde",
+ "thiserror 1.0.69",
+ "tokio",
+ "toml",
+]
 
 [[package]]
 name = "curvine-job-client"
@@ -6692,6 +6702,7 @@ dependencies = [
  "chrono",
  "crc32fast",
  "crossbeam",
+ "curvine-io",
  "curvine-sys",
  "dashmap 5.5.3",
  "fs2",

--- a/crates/infra/curvine-io/Cargo.toml
+++ b/crates/infra/curvine-io/Cargo.toml
@@ -6,3 +6,11 @@ license.workspace = true
 description = "Curvine I/O primitive migration boundary."
 
 [dependencies]
+bytes = { workspace = true }
+curvine-sys = { workspace = true }
+orpc-error = { workspace = true }
+orpc-runtime = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+toml = { workspace = true }

--- a/crates/infra/curvine-io/src/block_io.rs
+++ b/crates/infra/curvine-io/src/block_io.rs
@@ -1,6 +1,4 @@
-use crate::io::IOResult;
-use crate::io::LocalFile;
-use crate::sys::DataSlice;
+use crate::{DataSlice, IOResult, LocalFile};
 use std::fmt::{Display, Formatter};
 
 // ---------------------------------------------------------------------------
@@ -51,6 +49,7 @@ pub trait BlockIO: Send {
 pub enum BlockDevice {
     Local(LocalFile),
 }
+
 /// Macro to delegate a method call to the inner variant.
 macro_rules! delegate {
     ($self:ident, $method:ident $(, $arg:expr)*) => {
@@ -59,34 +58,44 @@ macro_rules! delegate {
         }
     };
 }
+
 impl BlockIO for BlockDevice {
     fn read_region(&mut self, enable_send_file: bool, len: i32) -> IOResult<DataSlice> {
         delegate!(self, read_region, enable_send_file, len)
     }
+
     fn write_region(&mut self, region: &DataSlice) -> IOResult<()> {
         delegate!(self, write_region, region)
     }
+
     fn write_all(&mut self, buf: &[u8]) -> IOResult<()> {
         delegate!(self, write_all, buf)
     }
+
     fn read_all(&mut self, buf: &mut [u8]) -> IOResult<()> {
         delegate!(self, read_all, buf)
     }
+
     fn flush(&mut self) -> IOResult<()> {
         delegate!(self, flush)
     }
+
     fn seek(&mut self, pos: i64) -> IOResult<i64> {
         delegate!(self, seek, pos)
     }
+
     fn pos(&self) -> i64 {
         delegate!(self, pos)
     }
+
     fn len(&self) -> i64 {
         delegate!(self, len)
     }
+
     fn path(&self) -> &str {
         delegate!(self, path)
     }
+
     fn resize(&mut self, truncate: bool, off: i64, len: i64, mode: i32) -> IOResult<()> {
         delegate!(self, resize, truncate, off, len, mode)
     }
@@ -115,27 +124,32 @@ impl BlockIO for BlockDevice {
         BlockDevice::as_local_mut(self)
     }
 }
+
 impl BlockDevice {
     /// Whether this device supports OS page cache read-ahead.
     /// Only `LocalFile` supports this; SPDK bypasses kernel.
     pub fn supports_read_ahead(&self) -> bool {
         matches!(self, BlockDevice::Local(_))
     }
+
     /// Whether this device supports sendfile (zero-copy kernel=>socket).
     /// Only `LocalFile` supports this; SPDK uses userspace DMA buffers.
     pub fn supports_send_file(&self) -> bool {
         matches!(self, BlockDevice::Local(_))
     }
+
     /// Whether this device supports short-circuit local I/O (filesystem path).
     /// SPDK bdevs have no filesystem path.
     pub fn supports_short_circuit(&self) -> bool {
         matches!(self, BlockDevice::Local(_))
     }
+
     /// Whether this device supports resize (fallocate/truncate).
     /// SPDK blocks live in pre-allocated bdev extents; resize is meaningless.
     pub fn supports_resize(&self) -> bool {
         matches!(self, BlockDevice::Local(_))
     }
+
     /// Get the inner `LocalFile`, if this is a local device.
     #[allow(unreachable_patterns)]
     pub fn as_local(&self) -> Option<&LocalFile> {
@@ -144,6 +158,7 @@ impl BlockDevice {
             _ => None,
         }
     }
+
     /// Get the inner `LocalFile` mutably, if this is a local device.
     #[allow(unreachable_patterns)]
     pub fn as_local_mut(&mut self) -> Option<&mut LocalFile> {
@@ -153,6 +168,7 @@ impl BlockDevice {
         }
     }
 }
+
 impl Display for BlockDevice {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -160,37 +176,46 @@ impl Display for BlockDevice {
         }
     }
 }
+
 // Keep BlockIO impl for LocalFile for backward compatibility
 // (existing code that uses LocalFile directly as BlockIO).
-
 impl BlockIO for LocalFile {
     fn read_region(&mut self, enable_send_file: bool, len: i32) -> IOResult<DataSlice> {
         LocalFile::read_region(self, enable_send_file, len)
     }
+
     fn write_region(&mut self, region: &DataSlice) -> IOResult<()> {
         LocalFile::write_region(self, region)
     }
+
     fn write_all(&mut self, buf: &[u8]) -> IOResult<()> {
         LocalFile::write_all(self, buf)
     }
+
     fn read_all(&mut self, buf: &mut [u8]) -> IOResult<()> {
         LocalFile::read_all(self, buf)
     }
+
     fn flush(&mut self) -> IOResult<()> {
         LocalFile::flush(self)
     }
+
     fn seek(&mut self, pos: i64) -> IOResult<i64> {
         LocalFile::seek(self, pos)
     }
+
     fn pos(&self) -> i64 {
         LocalFile::pos(self)
     }
+
     fn len(&self) -> i64 {
         LocalFile::len(self)
     }
+
     fn path(&self) -> &str {
         LocalFile::path(self)
     }
+
     fn resize(&mut self, truncate: bool, off: i64, len: i64, mode: i32) -> IOResult<()> {
         LocalFile::resize(self, truncate, off, len, mode)
     }
@@ -223,8 +248,7 @@ impl BlockIO for LocalFile {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::common::Utils;
-    use crate::io::LocalFile;
+    use orpc_runtime::common::Utils;
     use std::fs::remove_file;
 
     #[test]

--- a/crates/infra/curvine-io/src/cache_manager.rs
+++ b/crates/infra/curvine-io/src/cache_manager.rs
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate as sys;
-use crate::{CInt, SysResult};
+use curvine_sys::{self, CInt, SysResult};
 use std::fs::File;
 
 const LONG_READ_THRESHOLD_LEN: i64 = 256 * 1024;
@@ -125,7 +124,7 @@ impl CacheManager {
                 None
             } else {
                 let handle = if is_sequential {
-                    sys::read_ahead(file, cur_pos, len)
+                    curvine_sys::read_ahead(file, cur_pos, len)
                 } else {
                     Ok(0)
                 };

--- a/crates/infra/curvine-io/src/data_slice.rs
+++ b/crates/infra/curvine-io/src/data_slice.rs
@@ -15,8 +15,8 @@
 #![allow(unused, clippy::should_implement_trait)]
 
 use crate::DataSlice::{Buffer, Bytes, Empty, IOSlice, MemSlice};
-use crate::{RawIO, RawIOSlice, RawVec};
 use bytes::{Buf, Bytes as TBytes, BytesMut};
+use curvine_sys::{RawIO, RawIOSlice, RawVec};
 
 /// A data fragment, which represents a portion of the data on top of an IO stream.
 /// In many cases, in order to reduce memory copying, data reading and writing will not occur when creating data fragments.
@@ -159,9 +159,9 @@ impl DataSlice {
 
     pub fn as_ptr(&self) -> *const u8 {
         match self {
-            Empty => std::ptr::null() as *const _,
+            Empty => std::ptr::null(),
             Buffer(s) => s.as_ptr(),
-            IOSlice(s) => panic!("Not support IOSlice"),
+            IOSlice(_) => panic!("Not support IOSlice"),
             MemSlice(s) => s.as_ptr(),
             Bytes(s) => s.as_ptr(),
         }

--- a/crates/infra/curvine-io/src/io_error.rs
+++ b/crates/infra/curvine-io/src/io_error.rs
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::error::{ErrorExt, ErrorImpl};
-use crate::CommonError;
 use bytes::BytesMut;
+use orpc_error::{CommonError, CommonErrorExt, ErrorExt, ErrorImpl};
 use std::error::Error;
 use std::ffi::NulError;
 use std::io;
@@ -142,6 +141,12 @@ impl From<String> for IOError {
 impl From<CommonError> for IOError {
     fn from(value: CommonError) -> Self {
         Self::create(value)
+    }
+}
+
+impl From<IOError> for CommonErrorExt {
+    fn from(value: IOError) -> Self {
+        Self::from(CommonError::from(value))
     }
 }
 

--- a/crates/infra/curvine-io/src/lib.rs
+++ b/crates/infra/curvine-io/src/lib.rs
@@ -12,4 +12,41 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// DataSlice, LocalFile, and block I/O primitives will migrate here from the compatibility facade.
+mod block_io;
+pub use self::block_io::{BlockDevice, BlockIO};
+
+mod cache_manager;
+pub use self::cache_manager::{CacheManager, ReadAheadTask};
+
+mod data_slice;
+pub use self::data_slice::DataSlice;
+
+mod io_error;
+pub use self::io_error::IOError;
+
+mod local_file;
+pub use self::local_file::LocalFile;
+
+pub type IOResult<T> = Result<T, IOError>;
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        BlockDevice, BlockIO, CacheManager, DataSlice, IOError, IOResult, LocalFile, ReadAheadTask,
+    };
+
+    #[test]
+    fn exports_generic_io_api() {
+        fn assert_send<T: Send>() {}
+
+        assert_send::<BlockDevice>();
+        assert_send::<CacheManager>();
+        assert_send::<DataSlice>();
+        assert_send::<IOError>();
+        assert_send::<LocalFile>();
+        assert_send::<ReadAheadTask>();
+
+        let _: Option<&dyn BlockIO> = None;
+        let _: IOResult<()> = Ok(());
+    }
+}

--- a/crates/infra/curvine-io/src/local_file.rs
+++ b/crates/infra/curvine-io/src/local_file.rs
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::io::IOResult;
-use crate::sys::{self, CacheManager, DataSlice, RawIOSlice, ReadAheadTask};
-use crate::{err_box, try_err};
+use crate::{CacheManager, DataSlice, IOError, IOResult, ReadAheadTask};
 use bytes::BytesMut;
+use curvine_sys::{self, RawIOSlice};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::fmt::{Display, Formatter};
@@ -26,6 +25,31 @@ use std::path::Path;
 
 #[cfg(target_os = "linux")]
 use std::os::unix::io::{AsRawFd, RawFd};
+
+macro_rules! err_box {
+    ($e:expr) => {{
+        let message = format!(
+            "[{}] ERROR: {}({}:{})",
+            curvine_sys::thread_name(),
+            $e,
+            file!(),
+            line!()
+        );
+        Err(IOError::create(message))
+    }};
+    ($f:tt, $($arg:expr),+) => {{
+        err_box!(format!($f, $($arg),+))
+    }};
+}
+
+macro_rules! try_err {
+    ($expr:expr) => {{
+        match $expr {
+            Ok(result) => result,
+            Err(error) => return err_box!(error),
+        }
+    }};
+}
 
 pub struct LocalFile {
     inner: fs::File,
@@ -38,7 +62,7 @@ pub struct LocalFile {
 
 impl LocalFile {
     pub fn new<T: AsRef<str>>(path: T, mut inner: fs::File) -> IOResult<Self> {
-        let is_tmpfs = sys::is_tmpfs(path.as_ref())?;
+        let is_tmpfs = curvine_sys::is_tmpfs(path.as_ref())?;
 
         let len = inner.metadata()?.len() as i64;
         let pos = inner.stream_position()? as i64;
@@ -116,7 +140,7 @@ impl LocalFile {
         #[cfg(target_os = "linux")]
         let region = if enable_send_file {
             DataSlice::IOSlice(RawIOSlice::new(
-                sys::get_raw_io(self)?,
+                curvine_sys::get_raw_io(self)?,
                 Some(self.pos),
                 chunk as usize,
             ))
@@ -275,9 +299,9 @@ impl LocalFile {
 
     pub fn resize(&mut self, truncate: bool, off: i64, len: i64, mode: i32) -> IOResult<()> {
         if truncate {
-            sys::ftruncate(&self.inner, len)?;
+            curvine_sys::ftruncate(&self.inner, len)?;
         } else {
-            sys::fallocate(&self.inner, off, len, mode)?;
+            curvine_sys::fallocate(&self.inner, off, len, mode)?;
         }
 
         self.len = self.inner.metadata()?.len() as i64;
@@ -286,7 +310,7 @@ impl LocalFile {
 
     pub fn actual_size(&self) -> IOResult<u64> {
         let meta = self.inner.metadata()?;
-        sys::file_actual_size(meta).map_err(Into::into)
+        curvine_sys::file_actual_size(meta).map_err(Into::into)
     }
 
     pub fn metadata(&self) -> IOResult<Metadata> {

--- a/crates/infra/curvine-sys/src/lib.rs
+++ b/crates/infra/curvine-sys/src/lib.rs
@@ -66,12 +66,6 @@ pub fn skip_iov_bytes<'a>(
 mod sys_libc;
 pub use self::sys_libc::*;
 
-mod cache_manager;
-pub use self::cache_manager::*;
-
-mod data_slice;
-pub use self::data_slice::DataSlice;
-
 pub mod pipe;
 
 mod fs_stats;

--- a/orpc/Cargo.toml
+++ b/orpc/Cargo.toml
@@ -8,6 +8,7 @@ description = "High-performance network communication framework."
 
 
 [dependencies]
+curvine-io = { workspace = true }
 curvine-sys = { workspace = true }
 orpc-error = { workspace = true }
 orpc-runtime = { workspace = true }

--- a/orpc/src/client/client_state.rs
+++ b/orpc/src/client/client_state.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::io::io_error::IOError;
 use crate::io::net::InetAddr;
+use crate::io::IOError;
 use crate::sync::StateCtl;
 use num_enum::{FromPrimitive, IntoPrimitive};
 use std::sync::Mutex;

--- a/orpc/src/io/mod.rs
+++ b/orpc/src/io/mod.rs
@@ -12,19 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub use curvine_io::{
+    BlockDevice, BlockIO, CacheManager, DataSlice, IOError, IOResult, LocalFile, ReadAheadTask,
+};
+
 pub mod net;
 pub mod retry;
-
-mod local_file;
-pub use self::local_file::LocalFile;
-
-pub mod io_error;
-pub use self::io_error::IOError;
-
-pub type IOResult<T> = Result<T, IOError>;
-
-pub mod block_io;
-pub use self::block_io::{BlockDevice, BlockIO};
 
 pub mod spdk_conf;
 pub use self::spdk_conf::{BdevInfo, NvmeTarget, SpdkConf};

--- a/orpc/src/io/mod.rs
+++ b/orpc/src/io/mod.rs
@@ -16,6 +16,17 @@ pub use curvine_io::{
     BlockDevice, BlockIO, CacheManager, DataSlice, IOError, IOResult, LocalFile, ReadAheadTask,
 };
 
+// `io_error` and `block_io` were public module paths before the `curvine-io`
+// extraction, so they stay reachable here even though `curvine-io` only
+// re-exports the items.
+pub mod io_error {
+    pub use curvine_io::IOError;
+}
+
+pub mod block_io {
+    pub use curvine_io::{BlockDevice, BlockIO};
+}
+
 pub mod net;
 pub mod retry;
 

--- a/orpc/src/lib.rs
+++ b/orpc/src/lib.rs
@@ -22,18 +22,10 @@ pub mod macros;
 pub mod message;
 pub mod server;
 pub mod sys {
+    pub use curvine_io::{CacheManager, DataSlice, ReadAheadTask};
     pub use curvine_sys::*;
 }
 pub mod test;
 
 pub use orpc_error::{CommonError, CommonResult, CommonResultExt};
 pub use orpc_runtime::{common, runtime, sync};
-
-// Kept in `orpc` (not next to `CommonErrorExt` in `orpc-error`): orphan rules
-// require a local uncovered type argument (`IOError`) to implement `From` for
-// the foreign `CommonErrorExt` type after the crate split.
-impl From<crate::io::IOError> for crate::error::CommonErrorExt {
-    fn from(value: crate::io::IOError) -> Self {
-        Self::from(CommonError::from(value))
-    }
-}

--- a/orpc/tests/facade_compat_test.rs
+++ b/orpc/tests/facade_compat_test.rs
@@ -1,0 +1,64 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Guards the public paths downstream crates used before the infrastructure
+// crates were split out of `orpc`. A failure here is a compatibility break.
+
+use orpc::io::block_io::{BlockDevice, BlockIO};
+use orpc::io::io_error::IOError;
+use orpc::io::net::{ConnState, InetAddr, NetAddress, NetUtils, NodeAddr};
+use orpc::io::retry::{LimitedRetry, RetryPolicy, TimeoutRetry};
+use orpc::io::spdk_conf::{BdevInfo, NvmeTarget, SpdkConf};
+use orpc::io::{IOResult, LocalFile};
+
+fn assert_send<T: Send>() {}
+
+#[test]
+fn legacy_io_error_path_is_preserved() {
+    assert_send::<IOError>();
+
+    let err = IOError::conn_reset();
+    assert!(!err.is_would_block());
+
+    let _: IOResult<()> = Ok(());
+}
+
+#[test]
+fn legacy_block_io_path_is_preserved() {
+    assert_send::<BlockDevice>();
+    assert_send::<LocalFile>();
+
+    let _: Option<&dyn BlockIO> = None;
+}
+
+#[test]
+fn legacy_net_and_retry_paths_are_preserved() {
+    assert_send::<InetAddr>();
+    assert_send::<NodeAddr>();
+    assert_send::<NetAddress>();
+    assert_send::<ConnState>();
+    assert_send::<NetUtils>();
+
+    assert_eq!(LimitedRetry::new(1, 1).count(), 0);
+    assert_send::<TimeoutRetry>();
+
+    let _: Option<&dyn RetryPolicy> = None;
+}
+
+#[test]
+fn legacy_spdk_conf_path_is_preserved() {
+    assert_send::<SpdkConf>();
+    assert_send::<NvmeTarget>();
+    assert_send::<BdevInfo>();
+}


### PR DESCRIPTION
<!-- curvine-automation:pr:CurvineIO/curvine:1243 -->

# Summary

Stage T4: move generic I/O primitives (`IOError`, `LocalFile`, `BlockIO`, `DataSlice`, `CacheManager`) into `crates/infra/curvine-io`, and restore legacy `orpc::io::io_error` / `orpc::io::block_io` public module paths.

# Issue Describe / Design

Related to #1243

- **Stage:** T4 (generic IO extraction + facade compat)
- **Merge order:** T2 → T3 → T4 → T5 → T6 → T7
- **Scope:** `curvine-io` crate; thin wrapper modules for `io_error` and `block_io`; `orpc/tests/facade_compat_test.rs` guards legacy paths.
- **Prerequisite:** T3.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `crates/infra/curvine-io/**` | Host generic IO primitives | None via facade |
| `orpc/src/io/mod.rs` | Re-export + legacy wrapper modules | Preserves `orpc::io::io_error::*` and `orpc::io::block_io::*` |
| `orpc/tests/facade_compat_test.rs` | Facade compile tests | Guards compatibility |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-io` | PASS | |
| `cargo test -p orpc --test facade_compat_test` | PASS | 4 tests |
| `make format` | PASS | |

# Dependencies

- Related PRs: T3 PR (after T2 #1421)
- Related issues: #1243
- Blocks / blocked by: Blocks T5–T7; blocked by T3
