### PR TITLE
feat(libsdk): add Java SDK set_attr support (#1385)

### DIFF
--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineFileSystem.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineFileSystem.java
@@ -363,17 +363,77 @@ public class CurvineFileSystem extends FileSystem {
         return statuses;
     }
 
+    /**
+     * Update file or directory attributes using the native {@code set_attr} RPC.
+     *
+     * @return updated Hadoop {@link FileStatus} for the target path
+     */
+    public FileStatus setAttr(Path path, SetAttrOpts opts) throws IOException {
+        return applySetAttr(path, opts, true);
+    }
+
+    private FileStatus applySetAttr(Path path, SetAttrOpts opts, boolean countWriteOp) throws IOException {
+        if (countWriteOp && statistics != null) {
+            statistics.incrementWriteOps(1);
+        }
+        byte[] bytes = libFs.setAttr(formatPath(path), opts);
+        GetFileStatusResponse proto = GetFileStatusResponse.parseFrom(bytes);
+        return toHadoop(proto.getStatus(), path);
+    }
+
+    @Override
+    public void setOwner(Path path, String username, String groupname) throws IOException {
+        if (statistics != null) {
+            statistics.incrementWriteOps(1);
+        }
+        SetAttrOpts.Builder builder = SetAttrOpts.builder();
+        if (username != null) {
+            builder.owner(username);
+        }
+        if (groupname != null) {
+            builder.group(groupname);
+        }
+        applySetAttr(path, builder.build(), false);
+    }
+
+    @Override
+    public void setPermission(Path path, FsPermission permission) throws IOException {
+        if (statistics != null) {
+            statistics.incrementWriteOps(1);
+        }
+        applySetAttr(
+                path,
+                SetAttrOpts.builder().mode(permission.toShort() & 0xFFFF).build(),
+                false);
+    }
+
+    @Override
+    public void setTimes(Path path, long mtime, long atime) throws IOException {
+        if (statistics != null) {
+            statistics.incrementWriteOps(1);
+        }
+        SetAttrOpts.Builder builder = SetAttrOpts.builder();
+        if (mtime >= 0) {
+            builder.mtime(mtime);
+        }
+        if (atime >= 0) {
+            builder.atime(atime);
+        }
+        applySetAttr(path, builder.build(), false);
+    }
+
     public FileStatus toHadoop(FileStatusProto proto, Path path) {
+        FsPermission permission = new FsPermission((short) proto.getMode());
         return new org.apache.hadoop.fs.FileStatus(
                 proto.getLen(),
                 proto.getIsDir(),
-                proto.getReplicas(),
+                (short) proto.getReplicas(),
                 proto.getBlockSize(),
                 proto.getMtime(),
                 proto.getAtime(),
-                FsPermission.getDefault(),
-                System.getProperty("user.name"),
-                System.getProperty("user.group"),
+                permission,
+                proto.getOwner(),
+                proto.getGroup(),
                 makeQualified(path)
         );
     }

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineFsMount.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineFsMount.java
@@ -15,6 +15,7 @@
 package io.curvine;
 
 import java.io.IOException;
+import java.util.Objects;
 import java.util.Optional;
 
 import io.curvine.exception.CurvineException;
@@ -110,6 +111,13 @@ public class CurvineFsMount {
 
     public byte[] getFileStatus(String path) throws IOException {
         byte[] bytes = CurvineNative.getFileStatus(nativeHandle, path);
+        checkError(bytes);
+        return bytes;
+    }
+
+    public byte[] setAttr(String path, SetAttrOpts opts) throws IOException {
+        Objects.requireNonNull(opts, "opts");
+        byte[] bytes = CurvineNative.setAttr(nativeHandle, path, opts.toByteArray());
         checkError(bytes);
         return bytes;
     }

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineNative.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineNative.java
@@ -319,6 +319,10 @@ public class CurvineNative {
 
     public static native byte[] getFileStatus(long nativeHandle, String path) throws IOException;
 
+    /** Apply attribute updates and return serialized {@code GetFileStatusResponse} bytes. */
+    public static native byte[] setAttr(
+            long nativeHandle, String path, byte[] setAttrOptions) throws IOException;
+
     public static native byte[] listStatus(long nativeHandle, String path) throws IOException;
 
     public static native long rename(long nativeHandle, String src, String dst) throws IOException;

--- a/curvine-libsdk/java/src/main/java/io/curvine/SetAttrOpts.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/SetAttrOpts.java
@@ -1,0 +1,178 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.curvine;
+
+import com.google.protobuf.ByteString;
+import io.curvine.proto.SetAttrOptsProto;
+import io.curvine.proto.TtlActionProto;
+
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/** Immutable options for Curvine {@code set_attr}. */
+public final class SetAttrOpts {
+    private final SetAttrOptsProto proto;
+
+    private SetAttrOpts(SetAttrOptsProto proto) {
+        this.proto = proto;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public SetAttrOptsProto toProto() {
+        return proto;
+    }
+
+    public byte[] toByteArray() {
+        return proto.toByteArray();
+    }
+
+    public static final class Builder {
+        private boolean recursive;
+        private Integer replicas;
+        private String owner;
+        private String group;
+        private Integer mode;
+        private Long atime;
+        private Long mtime;
+        private Long ttlMs;
+        private TtlActionProto ttlAction;
+        private final Map<String, byte[]> addXAttr = new LinkedHashMap<>();
+        private final java.util.List<String> removeXAttr = new java.util.ArrayList<>();
+        private Long ufsMtime;
+
+        private Builder() {
+        }
+
+        public Builder recursive(boolean recursive) {
+            this.recursive = recursive;
+            return this;
+        }
+
+        public Builder replicas(int replicas) {
+            this.replicas = replicas;
+            return this;
+        }
+
+        public Builder owner(String owner) {
+            this.owner = requireText(owner, "owner");
+            return this;
+        }
+
+        public Builder group(String group) {
+            this.group = requireText(group, "group");
+            return this;
+        }
+
+        public Builder mode(int mode) {
+            this.mode = mode;
+            return this;
+        }
+
+        public Builder atime(long atime) {
+            this.atime = atime;
+            return this;
+        }
+
+        public Builder mtime(long mtime) {
+            this.mtime = mtime;
+            return this;
+        }
+
+        public Builder ttlMs(long ttlMs) {
+            this.ttlMs = ttlMs;
+            return this;
+        }
+
+        public Builder ttlAction(TtlActionProto ttlAction) {
+            this.ttlAction = Objects.requireNonNull(ttlAction, "ttlAction");
+            return this;
+        }
+
+        public Builder addXAttr(String key, byte[] value) {
+            addXAttr.put(requireText(key, "xattr key"), Objects.requireNonNull(value, "value"));
+            return this;
+        }
+
+        public Builder addXAttr(String key, String value) {
+            return addXAttr(key, value.getBytes(StandardCharsets.UTF_8));
+        }
+
+        public Builder removeXAttr(String key) {
+            removeXAttr.add(requireText(key, "xattr key"));
+            return this;
+        }
+
+        public Builder ufsMtime(long ufsMtime) {
+            this.ufsMtime = ufsMtime;
+            return this;
+        }
+
+        public SetAttrOpts build() {
+            SetAttrOptsProto.Builder options = SetAttrOptsProto.newBuilder()
+                    .setRecursive(recursive)
+                    .putAllAddXAttr(toByteStringMap(addXAttr))
+                    .addAllRemoveXAttr(removeXAttr);
+            if (replicas != null) {
+                options.setReplicas(replicas);
+            }
+            if (owner != null) {
+                options.setOwner(owner);
+            }
+            if (group != null) {
+                options.setGroup(group);
+            }
+            if (mode != null) {
+                options.setMode(mode);
+            }
+            if (atime != null) {
+                options.setAtime(atime);
+            }
+            if (mtime != null) {
+                options.setMtime(mtime);
+            }
+            if (ttlMs != null) {
+                options.setTtlMs(ttlMs);
+            }
+            if (ttlAction != null) {
+                options.setTtlAction(ttlAction);
+            }
+            if (ufsMtime != null) {
+                options.setUfsMtime(ufsMtime);
+            }
+            return new SetAttrOpts(options.build());
+        }
+
+        private static Map<String, ByteString> toByteStringMap(Map<String, byte[]> values) {
+            Map<String, ByteString> encoded = new LinkedHashMap<>();
+            for (Map.Entry<String, byte[]> entry : values.entrySet()) {
+                encoded.put(entry.getKey(), ByteString.copyFrom(entry.getValue()));
+            }
+            return encoded;
+        }
+
+        private static String requireText(String value, String field) {
+            if (value == null || value.trim().isEmpty()) {
+                throw new IllegalArgumentException(field + " cannot be empty");
+            }
+            return value.trim();
+        }
+    }
+}

--- a/curvine-libsdk/java/src/test/java/io/curvine/CurvineFileSystemTest.java
+++ b/curvine-libsdk/java/src/test/java/io/curvine/CurvineFileSystemTest.java
@@ -16,7 +16,9 @@ package io.curvine;
 
 import io.curvine.bench.Utils;
 import io.curvine.proto.MountInfoProto;
+import io.curvine.proto.TtlActionProto;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.fs.*;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.*;
@@ -53,6 +55,53 @@ public class CurvineFileSystemTest {
         Path path = new Path("s3://flink/xuen-test");
         Optional<MountInfoProto> mountPoint = ((CurvineFileSystem) fs).getMountInfo(path);
         System.out.println("mount point: " + mountPoint);
+    }
+
+    @Test
+    public void setAttr() throws Exception {
+        CurvineFileSystem cvFs = (CurvineFileSystem) fs;
+        Path root = new Path("/set-attr-test");
+        Path child = new Path(root, "child.txt");
+        fs.mkdirs(root);
+        fs.create(child, true).close();
+
+        long mtime = 1_700_000_000_000L;
+        FileStatus updated = cvFs.setAttr(
+                root,
+                SetAttrOpts.builder()
+                        .recursive(true)
+                        .owner("attr-owner")
+                        .group("attr-group")
+                        .mode(0755)
+                        .mtime(mtime)
+                        .ttlMs(60_000L)
+                        .ttlAction(TtlActionProto.TTL_ACTION_PROTO_DELETE)
+                        .replicas(2)
+                        .addXAttr("attr1", "value1")
+                        .build());
+        assert updated.getOwner().equals("attr-owner");
+        assert updated.getGroup().equals("attr-group");
+        assert updated.getPermission().equals(new FsPermission((short) 0755));
+
+        FileStatus childStatus = fs.getFileStatus(child);
+        assert childStatus.getOwner().equals("attr-owner");
+        assert childStatus.getGroup().equals("attr-group");
+
+        cvFs.setPermission(child, new FsPermission((short) 0600));
+        assert fs.getFileStatus(child).getPermission().equals(new FsPermission((short) 0600));
+
+        cvFs.setOwner(child, "child-owner", "child-group");
+        FileStatus ownerStatus = fs.getFileStatus(child);
+        assert ownerStatus.getOwner().equals("child-owner");
+        assert ownerStatus.getGroup().equals("child-group");
+
+        long newMtime = mtime + 5_000L;
+        cvFs.setTimes(child, newMtime, newMtime + 1_000L);
+        FileStatus timeStatus = fs.getFileStatus(child);
+        assert timeStatus.getModificationTime() == newMtime;
+        assert timeStatus.getAccessTime() == newMtime + 1_000L;
+
+        fs.delete(root, true);
     }
 
     @Test

--- a/curvine-libsdk/java/src/test/java/io/curvine/CurvineFileSystemToHadoopTest.java
+++ b/curvine-libsdk/java/src/test/java/io/curvine/CurvineFileSystemToHadoopTest.java
@@ -1,0 +1,77 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.curvine;
+
+import io.curvine.proto.FileStatusProto;
+import io.curvine.proto.FileTypeProto;
+import io.curvine.proto.StoragePolicyProto;
+import io.curvine.proto.StorageStateProto;
+import io.curvine.proto.StorageTypeProto;
+import io.curvine.proto.TtlActionProto;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.net.URI;
+
+public class CurvineFileSystemToHadoopTest {
+
+    @Test
+    public void toHadoopMapsOwnerGroupAndModeFromProto() throws Exception {
+        CurvineFileSystem fs = new CurvineFileSystem();
+        fs.setConf(new Configuration());
+        Field uriField = CurvineFileSystem.class.getDeclaredField("uri");
+        uriField.setAccessible(true);
+        uriField.set(fs, URI.create("cv://localhost"));
+
+        FileStatusProto proto = FileStatusProto.newBuilder()
+                .setId(1)
+                .setPath("/demo/file")
+                .setName("file")
+                .setIsDir(false)
+                .setMtime(1_700_000_000_000L)
+                .setAtime(1_700_000_001_000L)
+                .setChildrenNum(0)
+                .setIsComplete(true)
+                .setLen(42)
+                .setReplicas(2)
+                .setBlockSize(128L * 1024L * 1024L)
+                .setFileType(FileTypeProto.FILE_TYPE_PROTO_FILE)
+                .setStoragePolicy(StoragePolicyProto.newBuilder()
+                        .setStorageType(StorageTypeProto.STORAGE_TYPE_PROTO_DISK)
+                        .setTtlMs(0)
+                        .setTtlAction(TtlActionProto.TTL_ACTION_PROTO_NONE)
+                        .setUfsMtime(0)
+                        .setState(StorageStateProto.STORAGE_STATE_PROTO_CV)
+                        .build())
+                .setOwner("alice")
+                .setGroup("staff")
+                .setMode(0644)
+                .setNlink(1)
+                .build();
+
+        FileStatus status = fs.toHadoop(proto, new Path("/demo/file"));
+        Assert.assertEquals("alice", status.getOwner());
+        Assert.assertEquals("staff", status.getGroup());
+        Assert.assertEquals(new FsPermission((short) 0644), status.getPermission());
+        Assert.assertEquals(42, status.getLen());
+        Assert.assertEquals(1_700_000_000_000L, status.getModificationTime());
+        Assert.assertEquals(1_700_000_001_000L, status.getAccessTime());
+    }
+}

--- a/curvine-libsdk/java/src/test/java/io/curvine/SetAttrOptsTest.java
+++ b/curvine-libsdk/java/src/test/java/io/curvine/SetAttrOptsTest.java
@@ -1,0 +1,67 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.curvine;
+
+import io.curvine.proto.SetAttrOptsProto;
+import io.curvine.proto.TtlActionProto;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+
+public class SetAttrOptsTest {
+
+    @Test
+    public void builderEncodesAllSetAttrOptions() throws Exception {
+        SetAttrOpts opts = SetAttrOpts.builder()
+                .recursive(true)
+                .replicas(3)
+                .owner("alice")
+                .group("staff")
+                .mode(0755)
+                .atime(1_700_000_000_000L)
+                .mtime(1_700_000_001_000L)
+                .ttlMs(60_000L)
+                .ttlAction(TtlActionProto.TTL_ACTION_PROTO_DELETE)
+                .addXAttr("attr1", "value1")
+                .removeXAttr("attr2")
+                .ufsMtime(1_700_000_002_000L)
+                .build();
+
+        SetAttrOptsProto proto = SetAttrOptsProto.parseFrom(opts.toByteArray());
+        Assert.assertTrue(proto.getRecursive());
+        Assert.assertEquals(3, proto.getReplicas());
+        Assert.assertEquals("alice", proto.getOwner());
+        Assert.assertEquals("staff", proto.getGroup());
+        Assert.assertEquals(0755, proto.getMode());
+        Assert.assertEquals(1_700_000_000_000L, proto.getAtime());
+        Assert.assertEquals(1_700_000_001_000L, proto.getMtime());
+        Assert.assertEquals(60_000L, proto.getTtlMs());
+        Assert.assertEquals(TtlActionProto.TTL_ACTION_PROTO_DELETE, proto.getTtlAction());
+        Assert.assertArrayEquals(
+                "value1".getBytes(StandardCharsets.UTF_8),
+                proto.getAddXAttrOrThrow("attr1").toByteArray());
+        Assert.assertEquals("attr2", proto.getRemoveXAttr(0));
+        Assert.assertEquals(1_700_000_002_000L, proto.getUfsMtime());
+    }
+
+    @Test
+    public void builderDefaultsToNonRecursive() {
+        SetAttrOpts opts = SetAttrOpts.builder().owner("bob").build();
+        Assert.assertFalse(opts.toProto().getRecursive());
+        Assert.assertEquals("bob", opts.toProto().getOwner());
+        Assert.assertFalse(opts.toProto().hasGroup());
+    }
+}

--- a/curvine-libsdk/src/core/filesystem.rs
+++ b/curvine-libsdk/src/core/filesystem.rs
@@ -17,7 +17,7 @@ use crate::{LibFsReader, LibFsWriter};
 use bytes::BytesMut;
 use curvine_common::conf::ClusterConf;
 use curvine_common::fs::{FileSystem, Path};
-use curvine_common::state::{FreeResult, MountInfo, MountOptions};
+use curvine_common::state::{FreeResult, MountInfo, MountOptions, SetAttrOpts};
 use curvine_common::FsResult;
 use orpc::runtime::RpcRuntime;
 
@@ -68,6 +68,14 @@ impl LibFilesystem {
         let path = Path::from_str(path)?;
         self.rt()
             .block_on(async { self.inner().get_status_bytes(&path).await })
+    }
+
+    pub fn set_attr(&self, path: impl AsRef<str>, opts: SetAttrOpts) -> FsResult<BytesMut> {
+        let path = Path::from_str(path)?;
+        self.rt().block_on(async {
+            self.inner().set_attr(&path, opts).await?;
+            self.inner().get_status_bytes(&path).await
+        })
     }
 
     pub fn list_status(&self, path: impl AsRef<str>) -> FsResult<BytesMut> {

--- a/curvine-libsdk/src/java/java_abi.rs
+++ b/curvine-libsdk/src/java/java_abi.rs
@@ -221,6 +221,18 @@ pub unsafe extern "C" fn Java_io_curvine_CurvineNative_getFileStatus(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn Java_io_curvine_CurvineNative_setAttr(
+    mut env: JNIEnv,
+    _this: JObject,
+    fs_ptr: *mut JavaFilesystem,
+    path: JString,
+    options: JByteArray,
+) -> jarray {
+    let fs = &*fs_ptr;
+    java_err2!(env, fs.set_attr(&mut env, path, options))
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn Java_io_curvine_CurvineNative_listStatus(
     mut env: JNIEnv,
     _this: JObject,

--- a/curvine-libsdk/src/java/java_filesystem.rs
+++ b/curvine-libsdk/src/java/java_filesystem.rs
@@ -17,9 +17,11 @@ use crate::java::JavaUtils;
 use crate::{FilesystemConf, LibFilesystem, LibFsReader, LibFsWriter};
 use curvine_common::error::FsError;
 use curvine_common::proto::{
-    GetJobStatusResponse, GetMountTableResponse, MountOptionsProto, SubmitJobResponse,
+    GetJobStatusResponse, GetMountTableResponse, MountOptionsProto, SetAttrOptsProto,
+    SubmitJobResponse,
 };
 use curvine_common::state::LoadJobCommand;
+use curvine_common::state::SetAttrOpts;
 use curvine_common::utils::ProtoUtils;
 use curvine_common::FsResult;
 use jni::objects::{JByteArray, JString};
@@ -38,6 +40,14 @@ fn decode_mount_options(bytes: &[u8]) -> FsResult<curvine_common::state::MountOp
     }
     let options = try_err!(MountOptionsProto::decode(bytes));
     Ok(ProtoUtils::mount_options_from_pb(options))
+}
+
+fn decode_set_attr_options(bytes: &[u8]) -> FsResult<SetAttrOpts> {
+    if bytes.is_empty() {
+        return err_box!("set attr options cannot be empty");
+    }
+    let options = try_err!(SetAttrOptsProto::decode(bytes));
+    Ok(ProtoUtils::set_attr_opts_from_pb(options))
 }
 
 impl JavaFilesystem {
@@ -85,6 +95,23 @@ impl JavaFilesystem {
         let path = JavaUtils::jstring_to_string(env, &path)?;
         let status = self.inner.get_status(path)?;
 
+        let byte_arr = JavaUtils::new_jarray(env, &status)?;
+        Ok(byte_arr)
+    }
+
+    pub fn set_attr(
+        &self,
+        env: &mut JNIEnv,
+        path: JString,
+        options: JByteArray,
+    ) -> FsResult<jarray> {
+        let path = JavaUtils::jstring_to_string(env, &path)?;
+        let options = env
+            .convert_byte_array(&options)
+            .map_err(FsError::from_error)?;
+        let status = self
+            .inner
+            .set_attr(path, decode_set_attr_options(&options)?)?;
         let byte_arr = JavaUtils::new_jarray(env, &status)?;
         Ok(byte_arr)
     }
@@ -234,11 +261,19 @@ impl JavaFilesystem {
 
 #[cfg(test)]
 mod tests {
-    use super::decode_mount_options;
+    use super::{decode_mount_options, decode_set_attr_options};
 
     #[test]
     fn rejects_empty_mount_options() {
         let error = decode_mount_options(&[]).unwrap_err();
         assert!(error.to_string().contains("mount options cannot be empty"));
+    }
+
+    #[test]
+    fn rejects_empty_set_attr_options() {
+        let error = decode_set_attr_options(&[]).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("set attr options cannot be empty"));
     }
 }


### PR DESCRIPTION
## Summary

Add end-to-end `set_attr` support to the Java SDK (`curvine-libsdk`), exposing the existing master RPC through JNI and Hadoop-compatible FileSystem APIs.

## Issue Describe / Design

Closes #1385

- JNI accepts serialized `SetAttrOptsProto` bytes (same pattern as mount options) and returns updated `GetFileStatusResponse` bytes.
- New `SetAttrOpts` Java builder covers recursive, owner/group/mode, atime/mtime, TTL, xattr, replicas, and ufs_mtime.
- `CurvineFileSystem` implements Hadoop `setOwner`, `setPermission`, and `setTimes` via `set_attr`.
- `toHadoop` now maps real owner/group/mode from `FileStatusProto` (no compatibility switch).

## Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-libsdk/src/core/filesystem.rs` | Add `set_attr` wrapper | None (new API) |
| `curvine-libsdk/src/java/java_filesystem.rs`, `java_abi.rs` | JNI `setAttr` binding | None (new API) |
| `SetAttrOpts.java`, `CurvineNative.java`, `CurvineFsMount.java` | Java/native API surface | None (new API) |
| `CurvineFileSystem.java` | `setAttr`, Hadoop overrides, `toHadoop` fix | `getFileStatus`/`listStatus` now return proto owner/group/mode |
| Tests | `SetAttrOptsTest`, `CurvineFileSystemToHadoopTest`, integration `setAttr` | None |

## Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `make format` | PASS | |
| `cargo test -p curvine-libsdk --features java-sdk` | PASS | |
| `mvn test -Dtest=SetAttrOptsTest,CurvineFileSystemToHadoopTest,MountRequestTest` | PASS | Unit tests |
| `CurvineFileSystemTest#setAttr` | Not run | Requires live Curvine master |

## Dependencies

- Related PRs: None
- Related issues: #1385
- Blocks / blocked by: None

Made with [Cursor](https://cursor.com)