### PR TITLE
feat(report): show worker version and startup time (#587)

### DIFF
--- a/crates/common/curvine-model/src/proto_utils.rs
+++ b/crates/common/curvine-model/src/proto_utils.rs
@@ -353,6 +353,8 @@ impl ProtoUtils {
             transfer_query_task: Some(src.transfer_capabilities.query_task),
             transfer_attempt_safe_output: Some(src.transfer_capabilities.attempt_safe_output),
             transfer_source_read_plan: Some(src.transfer_capabilities.source_read_plan),
+            software_version: Some(src.software_version),
+            startup_time_ms: Some(src.startup_time_ms),
             storage_map: Default::default(),
         };
 
@@ -402,6 +404,8 @@ impl ProtoUtils {
                     attempt_safe_output: info.transfer_attempt_safe_output.unwrap_or(false),
                     source_read_plan: info.transfer_source_read_plan.unwrap_or(false),
                 },
+                software_version: info.software_version.unwrap_or_default(),
+                startup_time_ms: info.startup_time_ms.unwrap_or_default(),
                 ..Default::default()
             };
             for (k, v) in info.storage_map {

--- a/crates/common/curvine-model/src/worker_info.rs
+++ b/crates/common/curvine-model/src/worker_info.rs
@@ -55,6 +55,8 @@ pub struct WorkerInfo {
     pub address: WorkerAddress,
     #[serde(default = "WorkerInfo::default_weight")]
     pub weight: u32,
+    pub software_version: String,
+    pub startup_time_ms: u64,
     pub capacity: i64,
     pub available: i64,
     pub fs_used: i64,
@@ -77,6 +79,8 @@ impl WorkerInfo {
         Self {
             address: addr,
             weight,
+            software_version: String::new(),
+            startup_time_ms: 0,
             capacity: 0,
             available: 0,
             fs_used: 0,
@@ -151,6 +155,8 @@ impl Default for WorkerInfo {
         Self {
             address,
             weight: Self::default_weight(),
+            software_version: String::new(),
+            startup_time_ms: 0,
             capacity: 1 << 30,
             available: 1 << 30,
             fs_used: 0,

--- a/curvine-cli/src/cmds/report.rs
+++ b/curvine-cli/src/cmds/report.rs
@@ -14,7 +14,7 @@
 
 use crate::util::*;
 use clap::{Parser, Subcommand};
-use curvine_model::MasterInfo;
+use curvine_model::{MasterInfo, WorkerInfo};
 use curvine_unified_fs::UnifiedFileSystem;
 use orpc::CommonResult;
 use serde::Serialize;
@@ -182,12 +182,13 @@ impl CurvineReport {
         for i in 0..self.info.live_workers.len() {
             if let Some(worker) = self.info.get_live_worker(i) {
                 let str = format!(
-                    "{}:{},{}/{} ({:.2}%)",
+                    "{}:{},{}/{} ({:.2}%){}",
                     worker.address.hostname,
                     worker.address.rpc_port,
                     bytes_to_string(worker.available),
                     bytes_to_string(worker.capacity),
-                    Self::get_percent(worker.available, worker.capacity)
+                    Self::get_percent(worker.available, worker.capacity),
+                    Self::worker_detail_suffix(worker),
                 );
                 if i == 0 {
                     builder.push_str(&format!("{}\n", str));
@@ -205,7 +206,12 @@ impl CurvineReport {
         builder.push_str(&format!("{:>20}: ", "lost_worker_list"));
         for i in 0..self.info.lost_workers.len() {
             if let Some(worker) = self.info.get_lost_worker(i) {
-                let str = format!("{}:{}", worker.address.hostname, worker.address.rpc_port,);
+                let str = format!(
+                    "{}:{}{}",
+                    worker.address.hostname,
+                    worker.address.rpc_port,
+                    Self::worker_detail_suffix(worker),
+                );
 
                 if i == 0 {
                     builder.push_str(&format!("{}\n", str));
@@ -381,6 +387,39 @@ impl CurvineReport {
             return 0.0;
         }
         (numerator as f64 / denominator as f64) * 100.0
+    }
+
+    fn worker_detail_suffix(worker: &WorkerInfo) -> String {
+        let mut details = vec![];
+        if !worker.software_version.is_empty() {
+            details.push(format!("version={}", worker.software_version));
+        }
+        if worker.startup_time_ms > 0 {
+            details.push(format!(
+                "startup_time={}",
+                Self::format_epoch_ms(worker.startup_time_ms)
+            ));
+        }
+
+        if details.is_empty() {
+            String::new()
+        } else {
+            format!(", {}", details.join(", "))
+        }
+    }
+
+    fn format_epoch_ms(timestamp_ms: u64) -> String {
+        let Ok(timestamp_ms) = i64::try_from(timestamp_ms) else {
+            return "-".to_string();
+        };
+        let Some(datetime) = chrono::DateTime::from_timestamp_millis(timestamp_ms) else {
+            return "-".to_string();
+        };
+
+        datetime
+            .with_timezone(&chrono::Local)
+            .format("%Y-%m-%d %H:%M:%S")
+            .to_string()
     }
 }
 

--- a/curvine-cli/src/cmds/report.rs
+++ b/curvine-cli/src/cmds/report.rs
@@ -447,3 +447,43 @@ fn fluid_bytes_to_string(size: i64) -> String {
 
     format!("{value:.2}{unit}")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use curvine_model::WorkerAddress;
+
+    #[test]
+    fn simple_report_renders_worker_report_fields() {
+        let startup_time_ms = 123_456;
+        let worker = WorkerInfo {
+            address: WorkerAddress {
+                worker_id: 7,
+                hostname: "worker-host".to_string(),
+                ip_addr: "127.0.0.1".to_string(),
+                rpc_port: 1234,
+                web_port: 5678,
+            },
+            software_version: "0.1.0-test".to_string(),
+            startup_time_ms,
+            capacity: 1024,
+            available: 512,
+            ..Default::default()
+        };
+        let report = CurvineReport {
+            info: MasterInfo {
+                live_workers: vec![worker],
+                ..Default::default()
+            },
+        };
+
+        let output = report.simple(true);
+
+        assert!(output.contains("worker-host:1234"));
+        assert!(output.contains("version=0.1.0-test"));
+        assert!(output.contains(&format!(
+            "startup_time={}",
+            CurvineReport::format_epoch_ms(startup_time_ms)
+        )));
+    }
+}

--- a/curvine-common/proto/common.proto
+++ b/curvine-common/proto/common.proto
@@ -176,6 +176,8 @@ message WorkerInfoProto {
     optional bool transfer_query_task = 13 [default = false];
     optional bool transfer_attempt_safe_output = 14 [default = false];
     optional bool transfer_source_read_plan = 15 [default = false];
+    optional string software_version = 16 [default = ""];
+    optional uint64 startup_time_ms = 17 [default = 0];
 }
 
 message FileAllocOptsProto {

--- a/curvine-common/tests/worker_info_proto_test.rs
+++ b/curvine-common/tests/worker_info_proto_test.rs
@@ -5,21 +5,31 @@ use curvine_common::utils::ProtoUtils;
 fn worker_info_proto_preserves_weight() {
     let worker = WorkerInfo {
         weight: 42,
+        software_version: "0.1.0-test".to_string(),
+        startup_time_ms: 123_456,
         ..Default::default()
     };
 
     let proto = ProtoUtils::worker_info_to_pb(worker);
     assert_eq!(proto.weight, Some(42));
+    assert_eq!(proto.software_version.as_deref(), Some("0.1.0-test"));
+    assert_eq!(proto.startup_time_ms, Some(123_456));
 
     let restored = ProtoUtils::worker_info_from_pb(vec![proto]);
     assert_eq!(restored[0].weight, 42);
+    assert_eq!(restored[0].software_version, "0.1.0-test");
+    assert_eq!(restored[0].startup_time_ms, 123_456);
 }
 
 #[test]
 fn worker_info_proto_defaults_missing_weight() {
     let mut proto = ProtoUtils::worker_info_to_pb(WorkerInfo::default());
     proto.weight = None;
+    proto.software_version = None;
+    proto.startup_time_ms = None;
 
     let restored = ProtoUtils::worker_info_from_pb(vec![proto]);
     assert_eq!(restored[0].weight, WorkerInfo::default_weight());
+    assert!(restored[0].software_version.is_empty());
+    assert_eq!(restored[0].startup_time_ms, 0);
 }

--- a/curvine-server/src/master/fs/state/worker_map.rs
+++ b/curvine-server/src/master/fs/state/worker_map.rs
@@ -82,12 +82,15 @@ impl WorkerMap {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn insert(
         &mut self,
         addr: WorkerAddress,
         weight: u32,
         worker_session_id: String,
         transfer_capabilities: TransferWorkerCapabilities,
+        software_version: String,
+        startup_time_ms: u64,
         storages: Vec<StorageInfo>,
     ) -> FsResult<()> {
         self.ensure_worker_id_addr(&addr)?;
@@ -104,6 +107,8 @@ impl WorkerMap {
         let mut info = WorkerInfo::new(addr, weight);
         info.worker_session_id = worker_session_id;
         info.transfer_capabilities = transfer_capabilities;
+        info.software_version = software_version;
+        info.startup_time_ms = startup_time_ms;
         let worker_id = info.worker_id();
         for item in storages {
             info.add_storage(item);

--- a/curvine-server/src/master/fs/worker_manager.rs
+++ b/curvine-server/src/master/fs/worker_manager.rs
@@ -57,6 +57,8 @@ impl WorkerManager {
         weight: u32,
         worker_session_id: String,
         transfer_capabilities: TransferWorkerCapabilities,
+        software_version: String,
+        startup_time_ms: u64,
         storages: Vec<StorageInfo>,
     ) -> FsResult<Vec<WorkerCommand>> {
         // The cluster id must match to prevent misregistration.
@@ -101,6 +103,8 @@ impl WorkerManager {
             weight,
             worker_session_id,
             transfer_capabilities,
+            software_version,
+            startup_time_ms,
             storages,
         )?;
         Ok(cmds)

--- a/curvine-server/src/master/master_handler.rs
+++ b/curvine-server/src/master/master_handler.rs
@@ -993,3 +993,52 @@ impl MessageHandler for MasterHandler {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::master::journal::JournalSystem;
+    use curvine_common::state::WorkerAddress;
+    use orpc::common::Utils;
+
+    #[test]
+    fn process_worker_heartbeat_stores_worker_report_fields() {
+        Master::init_test_metrics();
+        let test_name = Utils::rand_str(6);
+        let mut conf = ClusterConf::format();
+        conf.testing = true;
+        conf.journal.enable = false;
+        conf.master.meta_dir =
+            Utils::test_sub_dir(format!("master-handler-test/meta-{}", test_name));
+        conf.journal.journal_dir =
+            Utils::test_sub_dir(format!("master-handler-test/journal-{}", test_name));
+
+        let fs = JournalSystem::fs_only_for_test(&conf).unwrap();
+        let address = WorkerAddress {
+            worker_id: 7,
+            hostname: "worker-host".to_string(),
+            ip_addr: "127.0.0.1".to_string(),
+            rpc_port: 1234,
+            web_port: 5678,
+        };
+        let header = WorkerHeartbeatRequest {
+            status: HeartbeatStatus::Running.into(),
+            cluster_id: conf.cluster_id.clone(),
+            address: ProtoUtils::worker_address_to_pb(&address),
+            software_version: "0.1.0-test".to_string(),
+            fs_ctime: 123_456,
+            ..Default::default()
+        };
+
+        MasterHandler::process_worker_heartbeat(fs.clone(), header).unwrap();
+
+        let info = fs.master_info().unwrap();
+        let worker = info
+            .live_workers
+            .iter()
+            .find(|worker| worker.address.worker_id == address.worker_id)
+            .unwrap();
+        assert_eq!(worker.software_version, "0.1.0-test");
+        assert_eq!(worker.startup_time_ms, 123_456);
+    }
+}

--- a/curvine-server/src/master/master_handler.rs
+++ b/curvine-server/src/master/master_handler.rs
@@ -574,6 +574,8 @@ impl MasterHandler {
                 attempt_safe_output: header.transfer_attempt_safe_output.unwrap_or(false),
                 source_read_plan: header.transfer_source_read_plan.unwrap_or(false),
             },
+            header.software_version,
+            u64::try_from(header.fs_ctime).unwrap_or_default(),
             ProtoUtils::storage_info_list_from_pb(header.storages),
         )?;
         Ok(cmds)

--- a/curvine-server/src/worker/block/block_actor.rs
+++ b/curvine-server/src/worker/block/block_actor.rs
@@ -54,6 +54,7 @@ impl BlockActor {
         worker_session_id: String,
         store: BlockStore,
         worker_ctl: StateCtl,
+        startup_time_ms: u64,
     ) -> CommonResult<BlockActor> {
         let context = FsContext::with_rt(conf.clone(), rt)?;
         let context = Arc::new(context);
@@ -64,6 +65,7 @@ impl BlockActor {
             worker_addr,
             conf.worker.weight,
             worker_session_id,
+            startup_time_ms,
         );
         let executor = GroupExecutor::new(
             "worker-block-executor",

--- a/curvine-server/src/worker/block/master_client.rs
+++ b/curvine-server/src/worker/block/master_client.rs
@@ -20,6 +20,7 @@ use curvine_common::state::{
     BlockReportInfo, HeartbeatStatus, StorageInfo, TransferWorkerCapabilities, WorkerAddress,
 };
 use curvine_common::utils::ProtoUtils;
+use curvine_common::version;
 use orpc::CommonResult;
 use std::sync::Arc;
 
@@ -34,6 +35,8 @@ pub struct MasterClient {
     pub(crate) worker_addr: WorkerAddress,
     pub(crate) worker_weight: u32,
     pub(crate) worker_session_id: String,
+    pub(crate) software_version: String,
+    pub(crate) startup_time_ms: u64,
 }
 
 impl MasterClient {
@@ -44,6 +47,7 @@ impl MasterClient {
         worker_addr: WorkerAddress,
         worker_weight: u32,
         worker_session_id: impl Into<String>,
+        startup_time_ms: u64,
     ) -> Self {
         // Directly reused file system client service.
         let fs_client = FsClient::new(context);
@@ -54,6 +58,8 @@ impl MasterClient {
             worker_addr,
             worker_weight,
             worker_session_id: worker_session_id.into(),
+            software_version: version::VERSION.to_string(),
+            startup_time_ms,
         }
     }
 
@@ -76,6 +82,8 @@ impl MasterClient {
             transfer_query_task: Some(transfer_capabilities.query_task),
             transfer_attempt_safe_output: Some(transfer_capabilities.attempt_safe_output),
             transfer_source_read_plan: Some(transfer_capabilities.source_read_plan),
+            software_version: self.software_version.clone(),
+            fs_ctime: self.startup_time_ms as i64,
             ..Default::default()
         };
         for item in storages {

--- a/curvine-server/src/worker/worker_server.rs
+++ b/curvine-server/src/worker/worker_server.rs
@@ -212,6 +212,7 @@ impl Worker {
             rpc_port: net_addr.port as u32,
             web_port: conf.worker.web_port as u32,
         };
+        let start_ms = LocalTime::mills();
         let block_actor = BlockActor::new(
             rt.clone(),
             &conf,
@@ -219,6 +220,7 @@ impl Worker {
             worker_session_id,
             block_store.clone(),
             rpc_server.new_state_ctl(),
+            start_ms,
         )?;
 
         let master_client = block_actor.client.clone();
@@ -239,7 +241,7 @@ impl Worker {
         });
 
         let worker = Self {
-            start_ms: LocalTime::mills(),
+            start_ms,
             worker_id,
             addr,
             rpc_server: Some(rpc_server),


### PR DESCRIPTION
# Summary

Adds worker software version and startup time to `cv report`.

# Issue Describe / Design

Closes #587

Current limitation:

- `cv report` did not expose worker software version.
- `cv report` did not show worker startup time, making it harder to inspect worker runtime state from the CLI.
- Worker heartbeat already reaches Master periodically, so this PR uses the existing heartbeat path to propagate this metadata.

Design:

- Record worker startup time during worker initialization.
- Send worker software version and startup time in worker heartbeat.
- Store these fields in Master-side `WorkerInfo`.
- Return the fields through `GetMasterInfo` and display them in `cv report`.

# Changes

| Module / File                                                                                             | Change                                                                                                                                                                                | Impact on existing behavior                                                                          |
| :-------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :--------------------------------------------------------------------------------------------------- |
| `curvine-server/src/worker/worker_server.rs` / `block_actor.rs` / `master_client.rs`                      | Record worker startup time once during worker initialization, keep it in the worker heartbeat client, and send worker software version plus startup time in `WorkerHeartbeatRequest`. | Adds worker runtime metadata to the existing heartbeat path without changing heartbeat control flow. |
| `curvine-server/src/master/master_handler.rs` / `worker_manager.rs` / `worker_map.rs`                     | Parse worker version and startup time from heartbeat and store them in Master-side `WorkerInfo`.                                                                                      | Master worker state now tracks software version and startup time for live/lost workers.              |
| `crates/common/curvine-model/src/worker_info.rs` / `proto_utils.rs` / `curvine-common/proto/common.proto` | Add worker version/startup-time fields to the model, proto schema, and conversion logic.                                                                                              | `GetMasterInfo` can return the new worker metadata while missing fields still default safely.        |
| `curvine-cli/src/cmds/report.rs` / `curvine-common/tests/worker_info_proto_test.rs`                       | Display worker version/startup time in `cv report` and cover proto roundtrip/default behavior in tests.                                                                               | `cv report all` shows additional worker runtime information.                                         |

# Test verified

| Test case                                      | Result | Notes                                                                                                                                                                                                                                                                       |
| ---------------------------------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| Local Rust validation                          | PASS   | Ran `cargo fmt --all --check`, `cargo check -p curvine-server -p curvine-cli`, `cargo test -p curvine-common --test worker_info_proto_test`, `cargo clippy -p curvine-common -p curvine-server -p curvine-cli --all-targets`, and `git diff --cached --check` successfully. |
| Local Master + Worker `cv report` verification | PASS   | Started a local Master and Worker, verified `cv report all` shows `version=...` and `startup_time=...`; then restarted the Worker and verified `cv report all` shows an updated `startup_time` while the version remains present.                                           |

<img width="1250" height="510" alt="image" src="https://github.com/user-attachments/assets/ef05c89d-c8ee-4db8-a535-a213aa6cfc4e" />
Restarted:
<img width="1286" height="514" alt="image" src="https://github.com/user-attachments/assets/a425d22b-2821-41e8-a327-f7068d67efe4" />


# Dependencies

- Related PRs: None
- Related issues: #587
- Blocks / blocked by: None

