### PR TITLE
fix(fuse): handle receiver shutdown channel closure (#1405)

### DIFF
--- a/curvine-fuse/src/session/channel/fuse_receiver.rs
+++ b/curvine-fuse/src/session/channel/fuse_receiver.rs
@@ -733,9 +733,47 @@ mod tests {
     use crate::fuse_metrics::{RECEIVE_ACTION_CONTINUE, RECEIVE_ACTION_EXIT};
     use bytes::BytesMut;
     use libc::{EAGAIN, ECONNABORTED, EINTR, EIO, ENODEV, ENOENT};
+    use orpc::runtime::{AsyncRuntime, RpcRuntime};
+    use orpc::sync::channel::AsyncChannel;
     use orpc::sync::FastDashMap;
+    use orpc::sys;
+    use orpc::sys::pipe::{AsyncFd, OwnedFd};
     use std::sync::Arc;
-    use tokio::sync::Notify;
+    use std::time::Duration;
+    use tokio::sync::{watch, Notify};
+
+    #[test]
+    fn receiver_exits_when_shutdown_channel_closes() {
+        let rt = Arc::new(AsyncRuntime::single());
+        rt.clone().block_on(async move {
+            let [read_fd, write_fd] = sys::pipe2(4096).unwrap();
+            let read_fd = OwnedFd::new(read_fd);
+            let _write_fd = OwnedFd::new(write_fd);
+            let kernel_fd = Arc::new(AsyncFd::new(read_fd.as_borrowed()).unwrap());
+            let (sender, _task_rx) = AsyncChannel::new(1).split();
+            let receiver = FuseReceiver::new(
+                Arc::new(TestFileSystem::new(Default::default())),
+                rt.clone(),
+                kernel_fd,
+                sender,
+                4096,
+                false,
+                false,
+                false,
+                Arc::new(FastDashMap::default()),
+                false,
+            )
+            .unwrap();
+            let (shutdown_tx, shutdown_rx) = watch::channel(false);
+            drop(shutdown_tx);
+
+            let result = tokio::time::timeout(Duration::from_secs(1), receiver.start(shutdown_rx))
+                .await
+                .expect("receiver must exit when the shutdown channel closes");
+
+            result.unwrap();
+        });
+    }
 
     #[test]
     fn receive_error_labels_classify_errno_and_action() {

--- a/curvine-fuse/src/session/channel/fuse_receiver.rs
+++ b/curvine-fuse/src/session/channel/fuse_receiver.rs
@@ -498,10 +498,17 @@ impl<T: FileSystem> FuseReceiver<T> {
                     }
                 }
 
-                _ = shutdown_rx.changed() => {
-                    if *shutdown_rx.borrow() {
-                        info!("receiver observed shutdown broadcast; exiting receive loop");
-                        break;
+                changed = shutdown_rx.changed() => {
+                    match changed {
+                        Ok(()) if *shutdown_rx.borrow() => {
+                            info!("receiver observed shutdown broadcast; exiting receive loop");
+                            break;
+                        }
+                        Ok(()) => {}
+                        Err(_) => {
+                            warn!("receiver shutdown channel closed; exiting receive loop");
+                            break;
+                        }
                     }
                 }
             }

--- a/curvine-fuse/src/session/fuse_session.rs
+++ b/curvine-fuse/src/session/fuse_session.rs
@@ -364,7 +364,7 @@ impl<T: FileSystem> FuseSession<T> {
                 let mut shutdown_rx = shutdown_rx.clone();
                 let handle = rt.spawn(async move {
                     if let Err(err) = receiver.start(shutdown_rx).await {
-                        error!("failed to accept, cause = {:?}", err);
+                        error!("fuse receiver exited with error: {}", err);
                     }
                 });
                 handles.push(handle);
@@ -373,7 +373,7 @@ impl<T: FileSystem> FuseSession<T> {
             for sender in channel.senders {
                 let handle = rt.spawn(async move {
                     if let Err(err) = sender.start().await {
-                        error!("failed to send, cause = {:?}", err);
+                        error!("fuse sender exited with error: {}", err);
                     }
                 });
                 handles.push(handle);


### PR DESCRIPTION
# Summary

Handle closure of the receiver shutdown watch channel explicitly and improve receiver/sender task failure logs.

# Issue Describe / Design

Related to #1405.

- Root cause: `watch::Receiver::changed()` returns immediately with an error after all senders are dropped. Ignoring that result can keep the receiver loop selecting the already-closed shutdown branch repeatedly.
- Reproduction: drop the session shutdown sender while a receiver is still running.
- Fix approach: log the unexpected channel closure once at warning level and exit the receive loop. Recoverable FUSE receive errors remain metric-only to avoid noisy duplicate logs, while terminal receiver/sender errors continue to be logged once by the session task wrapper with clearer messages.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-fuse/src/session/channel/fuse_receiver.rs` | Handle shutdown watch closure explicitly and exit the receive loop | Prevents a potential busy loop after shutdown sender loss |
| `curvine-fuse/src/session/fuse_session.rs` | Replace generic accept/send failure messages with receiver/sender-specific errors | Improves operational diagnostics without duplicate logs |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `make format` | PASS | Workspace formatting and pre-commit checks |
| `cargo test -p curvine-fuse session::channel::fuse_receiver::tests` | PASS | 29 tests passed |
| `cargo test -p curvine-fuse session::fuse_session::tests` | PASS | No matching unit tests; test binaries completed successfully |
| `cargo check -p curvine-fuse` | PASS | |

# Dependencies

- Related PRs: #1405
- Related issues: #1091
- Blocks / blocked by: None
