### PR TITLE
refactor(ufs): split shared UFS API crate (#1243)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2037,7 +2037,7 @@ dependencies = [
  "curvine-job-client",
  "curvine-model",
  "curvine-proto",
- "curvine-ufs",
+ "curvine-ufs-api",
  "curvine-unified-fs",
  "mimalloc",
  "orpc",
@@ -2416,7 +2416,7 @@ dependencies = [
  "curvine-error",
  "curvine-fault",
  "curvine-storage-spdk",
- "curvine-ufs",
+ "curvine-ufs-api",
  "curvine-web",
  "dashmap 5.5.3",
  "futures",
@@ -2498,7 +2498,7 @@ dependencies = [
  "curvine-fuse",
  "curvine-lancedb",
  "curvine-server",
- "curvine-ufs",
+ "curvine-ufs-api",
  "futures",
  "lance-io",
  "log",
@@ -2515,6 +2515,13 @@ dependencies = [
 
 [[package]]
 name = "curvine-ufs"
+version = "0.2.0"
+dependencies = [
+ "curvine-ufs-api",
+]
+
+[[package]]
+name = "curvine-ufs-api"
 version = "0.2.0"
 dependencies = [
  "async-trait",
@@ -2538,7 +2545,7 @@ dependencies = [
  "curvine-fs-api",
  "curvine-hdfs-jni",
  "curvine-model",
- "curvine-ufs",
+ "curvine-ufs-api",
  "futures",
  "log",
  "opendal",
@@ -2556,7 +2563,7 @@ dependencies = [
  "curvine-error",
  "curvine-fs-api",
  "curvine-model",
- "curvine-ufs",
+ "curvine-ufs-api",
  "futures",
  "log",
  "orpc",
@@ -2575,7 +2582,6 @@ dependencies = [
  "curvine-job-client",
  "curvine-model",
  "curvine-proto",
- "curvine-ufs",
  "curvine-ufs-opendal",
  "curvine-ufs-oss-hdfs",
  "dashmap 5.5.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "crates/common/curvine-model",
     "crates/common/curvine-fs-api",
     "crates/common/curvine-storage-api",
+    "crates/common/curvine-ufs-api",
     "crates/common/curvine-config",
     "crates/infra/orpc-error",
     "crates/infra/orpc-runtime",
@@ -58,6 +59,7 @@ default-members = [
     "crates/common/curvine-model",
     "crates/common/curvine-fs-api",
     "crates/common/curvine-storage-api",
+    "crates/common/curvine-ufs-api",
     "crates/common/curvine-config",
     "crates/infra/orpc-error",
     "crates/infra/orpc-runtime",
@@ -104,6 +106,7 @@ curvine-proto = { path = "crates/common/curvine-proto" }
 curvine-model = { path = "crates/common/curvine-model" }
 curvine-fs-api = { path = "crates/common/curvine-fs-api" }
 curvine-storage-api = { path = "crates/common/curvine-storage-api" }
+curvine-ufs-api = { path = "crates/common/curvine-ufs-api" }
 curvine-config = { path = "crates/common/curvine-config" }
 curvine-common = { path = "curvine-common" }
 curvine-common-macros = { path = "curvine-common/macros" }

--- a/crates/adapters/curvine-ufs-opendal/Cargo.toml
+++ b/crates/adapters/curvine-ufs-opendal/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-curvine-ufs = { workspace = true }
+curvine-ufs-api = { workspace = true }
 curvine-error = { workspace = true }
 curvine-fs-api = { workspace = true }
 curvine-model = { workspace = true }

--- a/crates/adapters/curvine-ufs-opendal/src/lib.rs
+++ b/crates/adapters/curvine-ufs-opendal/src/lib.rs
@@ -17,10 +17,10 @@ use curvine_error::FsError;
 use curvine_error::FsResult;
 use curvine_fs_api::{FileSystem, FsKind, ListStream, Path, Reader, Writer};
 use curvine_model::{FileStatus, FileType, ListOptions, SetAttrOpts};
-use curvine_ufs::OpendalConf;
+use curvine_ufs_api::OpendalConf;
 #[cfg(feature = "opendal-oss")]
-use curvine_ufs::OssHdfsConf;
-use curvine_ufs::{err_ufs, FOLDER_SUFFIX};
+use curvine_ufs_api::OssHdfsConf;
+use curvine_ufs_api::{err_ufs, FOLDER_SUFFIX};
 use futures::future::ready;
 use futures::stream::TryStreamExt;
 use futures::StreamExt;

--- a/crates/adapters/curvine-ufs-opendal/tests/README.md
+++ b/crates/adapters/curvine-ufs-opendal/tests/README.md
@@ -51,18 +51,18 @@ The S3 test includes the following aspects:
 Run all S3 tests with the following command:
 
 ```bash
-cargo test -p curvine-ufs --test s3
+cargo test -p curvine-ufs-opendal --test s3
 ```
 
 Or run a specific test:
 
 ```bash
 # Run only basic operation tests
-cargo test -p curvine-ufs --test s3_tests
+cargo test -p curvine-ufs-opendal --test s3_tests
 
 # Run only zero copy tests
-cargo test -p curvine-ufs --test zero_copy_transfer_tests
+cargo test -p curvine-ufs-opendal --test zero_copy_transfer_tests
 
 # Run concurrent tests only
-cargo test -p curvine-ufs --test concurrent_s3_tests
+cargo test -p curvine-ufs-opendal --test concurrent_s3_tests
 ```

--- a/crates/adapters/curvine-ufs-opendal/tests/hdfs/hdfs_integration_test.rs
+++ b/crates/adapters/curvine-ufs-opendal/tests/hdfs/hdfs_integration_test.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /*
-Complete HDFS integration tests for curvine-ufs
+Complete HDFS integration tests for curvine-ufs-opendal
 
 This file contains comprehensive HDFS tests:
 1. Native HDFS test with full read/write operations
@@ -24,21 +24,21 @@ This file contains comprehensive HDFS tests:
 ### Test WebHDFS only:
 ```bash
 export WEBHDFS_ENDPOINT=http://127.0.0.1:50070
-cargo test --features opendal-webhdfs -p curvine-ufs --test hdfs_integration_test -- --ignored
+cargo test --features opendal-webhdfs -p curvine-ufs-opendal --test hdfs_integration_test -- --ignored
 ```
 
 ### Test both HDFS and WebHDFS:
 ```bash
 export HDFS_NAMENODE=hdfs://test-hdfs
 export WEBHDFS_ENDPOINT=http://127.0.0.1:50070
-cargo test --features opendal-hdfs,opendal-webhdfs -p curvine-ufs --test hdfs_integration_test -- --ignored
+cargo test --features opendal-hdfs,opendal-webhdfs -p curvine-ufs-opendal --test hdfs_integration_test -- --ignored
 ```
 */
 
 #[cfg(any(feature = "opendal-hdfs", feature = "opendal-webhdfs"))]
 mod hdfs_tests {
     use curvine_common::fs::{FileSystem, Path, Reader, Writer};
-    use curvine_ufs::opendal::OpendalFileSystem;
+    use curvine_ufs_opendal::OpendalFileSystem;
     use std::collections::HashMap;
     use std::env;
 

--- a/crates/adapters/curvine-ufs-opendal/tests/hdfs/hdfs_mount_integration_test.rs
+++ b/crates/adapters/curvine-ufs-opendal/tests/hdfs/hdfs_mount_integration_test.rs
@@ -25,14 +25,14 @@
 //! ### Test HDFS mount integration:
 //! ```bash
 //! export HDFS_NAMENODE=hdfs://test-hdfs
-//! cargo test --features opendal-hdfs,jni -p curvine-ufs --test hdfs_mount_integration_test -- --ignored
+//! cargo test --features opendal-hdfs,jni -p curvine-ufs-opendal --test hdfs_mount_integration_test -- --ignored
 //! ```
 
 #[cfg(any(feature = "opendal-hdfs", feature = "opendal-webhdfs"))]
 mod mount_integration_tests {
     use curvine_common::fs::{FileSystem, Path, Reader, Writer};
     use curvine_common::state::{MountInfo, TtlAction};
-    use curvine_ufs::opendal::OpendalFileSystem;
+    use curvine_ufs_opendal::OpendalFileSystem;
     use std::collections::HashMap;
     use std::env;
 

--- a/crates/adapters/curvine-ufs-opendal/tests/s3_fs.rs
+++ b/crates/adapters/curvine-ufs-opendal/tests/s3_fs.rs
@@ -18,7 +18,7 @@ mod s3_tests {
 
     use curvine_common::fs::{FileSystem, Path, Reader, Writer};
     use curvine_common::state::FileStatus;
-    use curvine_ufs::opendal::OpendalFileSystem;
+    use curvine_ufs_opendal::OpendalFileSystem;
     use orpc::common::{FileUtils, Utils};
     use orpc::runtime::{AsyncRuntime, RpcRuntime};
     use orpc::CommonResult;

--- a/crates/adapters/curvine-ufs-oss-hdfs/src/oss_hdfs/oss_hdfs_filesystem.rs
+++ b/crates/adapters/curvine-ufs-oss-hdfs/src/oss_hdfs/oss_hdfs_filesystem.rs
@@ -18,7 +18,7 @@ use curvine_error::FsError;
 use curvine_error::FsResult;
 use curvine_fs_api::{FileSystem, FsKind, Path};
 use curvine_model::{FileStatus, FileType, SetAttrOpts};
-use curvine_ufs::{err_ufs, OssHdfsConf};
+use curvine_ufs_api::{err_ufs, OssHdfsConf};
 use orpc::common::LocalTime;
 use orpc::error::ErrorExt;
 use orpc::sys::DataSlice;

--- a/crates/adapters/curvine-ufs-oss-hdfs/tests/oss_hdfs/integration_tests.rs
+++ b/crates/adapters/curvine-ufs-oss-hdfs/tests/oss_hdfs/integration_tests.rs
@@ -17,8 +17,8 @@ mod tests {
     use super::super::test_utils::{create_test_conf, create_test_path, get_test_bucket};
     use curvine_common::fs::{FileSystem, Path, Reader, Writer};
     use curvine_common::state::SetAttrOpts;
-    use curvine_ufs::oss_hdfs::OssHdfsFileSystem;
-    use curvine_ufs::OssHdfsConf;
+    use curvine_ufs_oss_hdfs::OssHdfsFileSystem;
+    use curvine_ufs_api::OssHdfsConf;
     use orpc::sys::DataSlice;
     use std::collections::HashMap;
     use std::sync::Arc;

--- a/crates/adapters/curvine-ufs-oss-hdfs/tests/oss_hdfs/test_utils.rs
+++ b/crates/adapters/curvine-ufs-oss-hdfs/tests/oss_hdfs/test_utils.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use curvine_common::fs::Path;
-use curvine_ufs::OssHdfsConf;
+use curvine_ufs_api::OssHdfsConf;
 use std::collections::HashMap;
 use std::time::{SystemTime, UNIX_EPOCH};
 

--- a/crates/client/curvine-unified-fs/Cargo.toml
+++ b/crates/client/curvine-unified-fs/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 [dependencies]
 curvine-client-core = { workspace = true }
 curvine-job-client = { workspace = true }
-curvine-ufs = { workspace = true }
 curvine-ufs-opendal = { workspace = true, optional = true }
 curvine-ufs-oss-hdfs = { workspace = true, optional = true }
 curvine-config = { workspace = true }

--- a/crates/common/curvine-ufs-api/Cargo.toml
+++ b/crates/common/curvine-ufs-api/Cargo.toml
@@ -1,26 +1,21 @@
 [package]
-name = "curvine-ufs-oss-hdfs"
+name = "curvine-ufs-api"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 
 [dependencies]
-curvine-ufs-api = { workspace = true }
+orpc = { workspace = true }
 curvine-config = { workspace = true }
 curvine-error = { workspace = true }
 curvine-fs-api = { workspace = true }
-curvine-model = { workspace = true }
+tokio = { workspace = true }
 async-trait = { workspace = true }
 bytes = { workspace = true }
 futures = { workspace = true }
 log = { workspace = true }
-orpc = { workspace = true }
-tokio = { workspace = true }
+fastrand = { workspace = true }
 
-[build-dependencies]
-cc = "1.1"
 
 [features]
 default = []
-oss-hdfs = []
-oss-hdfs-ffi-test = ["oss-hdfs"]

--- a/crates/common/curvine-ufs-api/src/conf.rs
+++ b/crates/common/curvine-ufs-api/src/conf.rs
@@ -1,0 +1,346 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use orpc::common::DurationUnit;
+use orpc::{err_box, CommonResult};
+use std::collections::HashMap;
+use std::ops::Deref;
+use std::time::Duration;
+
+pub struct ConfMap(HashMap<String, String>);
+
+impl ConfMap {
+    pub fn new(map: HashMap<String, String>) -> Self {
+        Self(map)
+    }
+
+    pub fn get_string(&self, key: &str) -> CommonResult<String> {
+        if let Some(v) = self.0.get(key) {
+            Ok(v.clone())
+        } else {
+            err_box!("{} cannot be empty", key)
+        }
+    }
+
+    pub fn get_bool(&self, key: &str) -> CommonResult<bool> {
+        let value = self.get_string(key)?;
+        match value.trim().to_lowercase().as_str() {
+            "true" => Ok(true),
+            "false" => Ok(false),
+            _ => err_box!("Invalid boolean string"),
+        }
+    }
+
+    pub fn get_u32(&self, key: &str) -> CommonResult<u32> {
+        let value = self.get_string(key)?;
+        value
+            .trim()
+            .parse::<u32>()
+            .map_err(|_| format!("Invalid u32 value for key '{}': {}", key, value).into())
+    }
+
+    pub fn get_u64(&self, key: &str) -> CommonResult<u64> {
+        let value = self.get_string(key)?;
+        value
+            .trim()
+            .parse::<u64>()
+            .map_err(|_| format!("Invalid u64 value for key '{}': {}", key, value).into())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct S3Conf {
+    pub endpoint_url: String,
+    pub access_key: String,
+    pub secret_key: String,
+    pub region_name: String,
+    pub force_path_style: bool,
+
+    pub retry_times: u32,
+    pub connect_timeout: Duration,
+    pub read_timeout: Duration,
+
+    pub properties: HashMap<String, String>,
+}
+
+/// Unified OpenDAL configuration for timeout and retry settings
+/// Uses the same default values as S3Conf for consistency
+#[derive(Debug, Clone)]
+pub struct OpendalConf {
+    pub retry_times: u32,
+    pub connect_timeout: Duration,
+    pub read_timeout: Duration,
+    pub retry_interval_ms: u64,
+    pub retry_max_delay_ms: u64,
+    /// Per-request read buffer size (bytes) for the object reader. Also the size
+    /// of each concurrent range chunk when `read_concurrent > 1`. Internal
+    /// constant (not user-tunable); defaults to [`Self::DEFAULT_READ_CHUNK_SIZE`].
+    pub read_chunk_size: usize,
+    /// Number of concurrent range requests issued against a single object while
+    /// reading. Internal constant (not user-tunable); defaults to
+    /// [`Self::DEFAULT_READ_CONCURRENT`]. Parallelism for large loads is driven
+    /// instead by the outer fan-out (`load_task.parallel_streams`).
+    pub read_concurrent: usize,
+}
+
+impl S3Conf {
+    pub const ENDPOINT: &'static str = "s3.endpoint_url";
+    pub const ACCESS_KEY: &'static str = "s3.credentials.access";
+    pub const SECRET_KEY: &'static str = "s3.credentials.secret";
+    pub const REGION_NAME: &'static str = "s3.region_name";
+    pub const FORCE_PATH_STYLE: &'static str = "s3.force.path.style";
+    pub const RETRY_TIMES: &'static str = "s3.retry_times";
+    pub const CONNECT_TIMEOUT: &'static str = "s3.connect_timeout";
+    pub const READ_TIMEOUT: &'static str = "s3.read_timeout";
+
+    pub const DEFAULT_RETRY_TIMES: u32 = 3;
+    pub const DEFAULT_CONNECT_TIMEOUT: &'static str = "30s";
+    pub const DEFAULT_READ_TIMEOUT: &'static str = "120s";
+
+    pub fn with_map(properties: HashMap<String, String>) -> CommonResult<Self> {
+        let map = ConfMap::new(properties);
+
+        let endpoint_url = map.get_string(Self::ENDPOINT)?;
+        if !endpoint_url.starts_with("http://") && !endpoint_url.starts_with("https://") {
+            return err_box!("s3.endpoint_url must start with http:// or https://");
+        }
+
+        let access_key = map.get_string(Self::ACCESS_KEY)?;
+        let secret_key = map.get_string(Self::SECRET_KEY)?;
+
+        let region_name = if endpoint_url.contains("amazonaws.com") {
+            map.get_string(Self::REGION_NAME)?
+        } else {
+            map.get_string(Self::REGION_NAME)
+                .unwrap_or("undefined".to_string())
+        };
+
+        let force_path_style = map.get_bool(Self::FORCE_PATH_STYLE).unwrap_or(false);
+
+        let retry_times = map
+            .get_u32(Self::RETRY_TIMES)
+            .unwrap_or(Self::DEFAULT_RETRY_TIMES);
+
+        let connect_timeout = map
+            .get_string(Self::CONNECT_TIMEOUT)
+            .unwrap_or(Self::DEFAULT_CONNECT_TIMEOUT.to_string());
+        let connect_timeout = DurationUnit::from_str(&connect_timeout)?.as_duration();
+
+        let read_timeout = map
+            .get_string(Self::READ_TIMEOUT)
+            .unwrap_or(Self::DEFAULT_READ_TIMEOUT.to_string());
+        let read_timeout = DurationUnit::from_str(&read_timeout)?.as_duration();
+
+        Ok(Self {
+            endpoint_url,
+            access_key,
+            secret_key,
+            region_name,
+            force_path_style,
+            retry_times,
+            connect_timeout,
+            read_timeout,
+            properties: map.0,
+        })
+    }
+}
+
+impl OpendalConf {
+    // Configuration keys
+    pub const RETRY_TIMES: &'static str = "opendal.retry_times";
+    pub const CONNECT_TIMEOUT: &'static str = "opendal.connect_timeout";
+    pub const READ_TIMEOUT: &'static str = "opendal.read_timeout";
+    pub const RETRY_INTERVAL_MS: &'static str = "opendal.retry_interval_ms";
+    pub const RETRY_MAX_DELAY_MS: &'static str = "opendal.retry_max_delay_ms";
+
+    // Default values - using S3Conf defaults for consistency
+    pub const DEFAULT_RETRY_TIMES: u32 = S3Conf::DEFAULT_RETRY_TIMES; // 3
+    pub const DEFAULT_CONNECT_TIMEOUT: &'static str = S3Conf::DEFAULT_CONNECT_TIMEOUT; // "30s"
+    pub const DEFAULT_READ_TIMEOUT: &'static str = S3Conf::DEFAULT_READ_TIMEOUT; // "120s"
+    pub const DEFAULT_RETRY_INTERVAL_MS: u64 = 1000; // 1 second
+    pub const DEFAULT_RETRY_MAX_DELAY_MS: u64 = 10000; // 10 seconds
+    pub const DEFAULT_READ_CHUNK_SIZE: usize = 16 * 1024 * 1024; // 16 MiB
+    pub const DEFAULT_READ_CONCURRENT: usize = 2; // 2 parallel range requests per object
+
+    /// Create OpendalConf from configuration map
+    pub fn from_map(properties: &HashMap<String, String>) -> CommonResult<Self> {
+        let map = ConfMap::new(properties.clone());
+
+        let retry_times = map
+            .get_u32(Self::RETRY_TIMES)
+            .unwrap_or(Self::DEFAULT_RETRY_TIMES);
+
+        let connect_timeout_str = map
+            .get_string(Self::CONNECT_TIMEOUT)
+            .unwrap_or(Self::DEFAULT_CONNECT_TIMEOUT.to_string());
+        let connect_timeout = DurationUnit::from_str(&connect_timeout_str)?.as_duration();
+
+        let read_timeout_str = map
+            .get_string(Self::READ_TIMEOUT)
+            .unwrap_or(Self::DEFAULT_READ_TIMEOUT.to_string());
+        let read_timeout = DurationUnit::from_str(&read_timeout_str)?.as_duration();
+
+        let retry_interval_ms = map
+            .get_u64(Self::RETRY_INTERVAL_MS)
+            .unwrap_or(Self::DEFAULT_RETRY_INTERVAL_MS);
+
+        let retry_max_delay_ms = map
+            .get_u64(Self::RETRY_MAX_DELAY_MS)
+            .unwrap_or(Self::DEFAULT_RETRY_MAX_DELAY_MS);
+
+        // read_chunk_size and read_concurrent are intentionally NOT user-tunable
+        // via mount properties: benchmarking showed the defaults saturate the
+        // link, and the outer parallel-load fan-out (load_task.parallel_streams)
+        // is the knob that matters. Kept as internal constants.
+        //
+        // NOTE: this is a silent behavior change. These used to be per-mount
+        // tunables (legacy keys `opendal.read_chunk_size_in_bytes` /
+        // `opendal.read_concurrent`). Existing mounts that still carry those keys
+        // are now ignored -- not rejected -- so the values below always win.
+        let read_chunk_size = Self::DEFAULT_READ_CHUNK_SIZE.max(1);
+        let read_concurrent = Self::DEFAULT_READ_CONCURRENT.max(1);
+
+        Ok(Self {
+            retry_times,
+            connect_timeout,
+            read_timeout,
+            retry_interval_ms,
+            retry_max_delay_ms,
+            read_chunk_size,
+            read_concurrent,
+        })
+    }
+
+    pub fn total_timeout_ms(&self) -> u64 {
+        self.connect_timeout.as_millis() as u64 + self.read_timeout.as_millis() as u64
+    }
+}
+
+impl Deref for S3Conf {
+    type Target = HashMap<String, String>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.properties
+    }
+}
+
+/// OSS-HDFS configuration (JindoSDK).
+///
+/// Notes:
+/// - User-facing configuration keys use `oss.*` format (without `fs.` prefix).
+/// - JindoSDK internal configuration keys use `fs.oss.*` format (with `fs.` prefix).
+/// - This config struct is used by the `oss://` UFS implementation (`oss_hdfs` module).
+#[derive(Debug, Clone)]
+pub struct OssHdfsConf {
+    pub endpoint_url: String,
+    pub access_key: String,
+    pub secret_key: String,
+    pub region_name: Option<String>,
+    pub data_endpoint: Option<String>,
+    pub second_level_domain_enable: bool,
+    pub data_lake_storage_enable: bool,
+    pub properties: HashMap<String, String>,
+}
+
+impl OssHdfsConf {
+    // User-facing configuration keys (without fs. prefix)
+    pub const USER_ENDPOINT: &'static str = "oss.endpoint";
+    pub const USER_ACCESS_KEY_ID: &'static str = "oss.accessKeyId";
+    pub const USER_ACCESS_KEY_SECRET: &'static str = "oss.accessKeySecret";
+    pub const USER_REGION: &'static str = "oss.region";
+    pub const USER_DATA_ENDPOINT: &'static str = "oss.data.endpoint";
+    pub const USER_SECOND_LEVEL_DOMAIN_ENABLE: &'static str = "oss.second.level.domain.enable";
+    pub const USER_DATA_LAKE_STORAGE_ENABLE: &'static str = "oss.data.lake.storage.enable";
+
+    // JindoSDK internal configuration keys (with fs. prefix)
+    pub const ENDPOINT: &'static str = "fs.oss.endpoint";
+    pub const ACCESS_KEY_ID: &'static str = "fs.oss.accessKeyId";
+    pub const ACCESS_KEY_SECRET: &'static str = "fs.oss.accessKeySecret";
+    pub const REGION: &'static str = "fs.oss.region";
+    pub const DATA_ENDPOINT: &'static str = "fs.oss.data.endpoint";
+    pub const SECOND_LEVEL_DOMAIN_ENABLE: &'static str = "fs.oss.second.level.domain.enable";
+    pub const DATA_LAKE_STORAGE_ENABLE: &'static str = "fs.oss.data.lake.storage.enable";
+
+    // Default values
+    pub const DEFAULT_SECOND_LEVEL_DOMAIN_ENABLE: bool = true;
+    pub const DEFAULT_DATA_LAKE_STORAGE_ENABLE: bool = true;
+
+    /// Create OssHdfsConf from configuration map
+    /// Uses user-facing configuration keys (oss.*) for reading from config map
+    pub fn with_map(properties: HashMap<String, String>) -> CommonResult<Self> {
+        let map = ConfMap::new(properties);
+
+        let endpoint_url = map.get_string(Self::USER_ENDPOINT)?;
+        let access_key = map.get_string(Self::USER_ACCESS_KEY_ID)?;
+        let secret_key = map.get_string(Self::USER_ACCESS_KEY_SECRET)?;
+        let region_name = map.get_string(Self::USER_REGION).ok();
+        let data_endpoint = map.get_string(Self::USER_DATA_ENDPOINT).ok();
+        let second_level_domain_enable = map
+            .get_bool(Self::USER_SECOND_LEVEL_DOMAIN_ENABLE)
+            .unwrap_or(Self::DEFAULT_SECOND_LEVEL_DOMAIN_ENABLE);
+        let data_lake_storage_enable = map
+            .get_bool(Self::USER_DATA_LAKE_STORAGE_ENABLE)
+            .unwrap_or(Self::DEFAULT_DATA_LAKE_STORAGE_ENABLE);
+
+        Ok(Self {
+            endpoint_url,
+            access_key,
+            secret_key,
+            region_name,
+            data_endpoint,
+            second_level_domain_enable,
+            data_lake_storage_enable,
+            properties: map.0,
+        })
+    }
+}
+
+impl Deref for OssHdfsConf {
+    type Target = HashMap<String, String>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.properties
+    }
+}
+
+#[cfg(test)]
+mod opendal_conf_tests {
+    use super::OpendalConf;
+    use std::collections::HashMap;
+
+    #[test]
+    fn defaults_when_unset() {
+        let conf = OpendalConf::from_map(&HashMap::new()).unwrap();
+        assert_eq!(conf.read_chunk_size, OpendalConf::DEFAULT_READ_CHUNK_SIZE);
+        assert_eq!(conf.read_concurrent, OpendalConf::DEFAULT_READ_CONCURRENT);
+        // Locks in the tuned defaults (16 MiB chunk, 2 concurrent range GETs).
+        assert_eq!(conf.read_chunk_size, 16 * 1024 * 1024);
+        assert_eq!(conf.read_concurrent, 2);
+    }
+
+    #[test]
+    fn read_tuning_is_not_user_overridable() {
+        // read_chunk_size / read_concurrent are internal constants now: any mount
+        // property with those (legacy) keys must be ignored, not applied.
+        let mut props = HashMap::new();
+        props.insert(
+            "opendal.read_chunk_size_in_bytes".to_string(),
+            "1024".to_string(),
+        );
+        props.insert("opendal.read_concurrent".to_string(), "32".to_string());
+        let conf = OpendalConf::from_map(&props).unwrap();
+        assert_eq!(conf.read_chunk_size, OpendalConf::DEFAULT_READ_CHUNK_SIZE);
+        assert_eq!(conf.read_concurrent, OpendalConf::DEFAULT_READ_CONCURRENT);
+    }
+}

--- a/crates/common/curvine-ufs-api/src/fs/buffer_transfer.rs
+++ b/crates/common/curvine-ufs-api/src/fs/buffer_transfer.rs
@@ -1,0 +1,408 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![allow(unused)]
+
+use async_trait::async_trait;
+use bytes::{Bytes, BytesMut};
+use core::time::Duration;
+use std::io::Result as IoResult;
+use std::io::{Error, ErrorKind};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use tokio::time::Instant;
+
+/// Smart pointer-wrapped buffer pool provides efficient memory multiplexing mechanism
+///
+/// Buffer pool features:
+/// -Dynamic expansion mechanism: Create a specified number of buffers during initialization, and retain the maximum specified number
+/// -Backpressure processing: automatically yield waits when the buffer is insufficient to avoid excessive memory use
+/// -Memory security: Use Arc<Mutex<>> to ensure thread safety
+/// -Intelligent cleanup: automatically discard the excess buffer when the maximum number exceeds
+#[derive(Clone)]
+struct BufferPool {
+    /// Use bytes::BytesMut as a variable buffer type to ensure thread safety through Arc<Mutex<>>
+    inner: Arc<tokio::sync::Mutex<Vec<BytesMut>>>,
+    /// Size of each buffer (bytes)
+    chunk_size: usize,
+    /// The maximum number of buffers reserved in the buffer pool
+    max_buffers: usize,
+}
+impl BufferPool {
+    /// Create a new buffer pool
+    ///
+    /// Pre-allocate a specified number of buffers during initialization, each buffer has the same size.
+    /// The buffer pool limits the maximum number of buffers to prevent overuse of memory.
+    ///
+    /// Optimization points:
+    /// -Pre-allocate buffers to reduce runtime allocation overhead
+    /// -Use capacity prompts to optimize memory allocation of internal Vec
+    ///
+    /// # Parameters
+    /// -`chunk_size`: Size (bytes) of each buffer
+    /// -`initial_buffers`: Number of initial pre-allocated buffers
+    /// -`max_buffers`: Maximum number of buffers reserved in the buffer pool
+    ///
+    /// # Returns
+    /// Return a new BufferPool instance
+    fn new(chunk_size: usize, initial_buffers: usize, max_buffers: usize) -> Self {
+        // Verify parameters
+        let initial_buffers = initial_buffers.min(max_buffers);
+        let chunk_size = chunk_size.max(1024); // Make sure the buffer is at least 1KB in size
+
+        // Preallocate buffers
+        let mut buffers = Vec::with_capacity(initial_buffers);
+        for _ in 0..initial_buffers {
+            buffers.push(BytesMut::with_capacity(chunk_size));
+        }
+
+        BufferPool {
+            inner: Arc::new(tokio::sync::Mutex::new(buffers)),
+            chunk_size,
+            max_buffers,
+        }
+    }
+
+    /// Get the buffer (zero copy key)
+    ///
+    /// This method tries to get an available buffer from the buffer pool. If the buffer pool is empty and the maximum capacity is not reached,
+    /// Create a new buffer. If the maximum capacity has been reached, wait until a buffer is available.
+    ///
+    /// Optimization points:
+    /// -Use scope to limit the lock's holding time
+    /// -Release the lock before waiting to reduce lock competition
+    /// -Use more efficient backpressure mechanism
+    ///
+    /// # Returns
+    /// Returns an available BytesMut buffer
+    async fn acquire(&self) -> BytesMut {
+        loop {
+            // Use scope to limit the lock's holding time
+            {
+                let mut guard = self.inner.lock().await;
+
+                // Try to get an existing buffer from the buffer pool
+                if let Some(mut buf) = guard.pop() {
+                    buf.clear();
+                    return buf;
+                }
+
+                // Dynamic expansion (no more than the maximum value)
+                if guard.len() < self.max_buffers {
+                    return BytesMut::with_capacity(self.chunk_size);
+                }
+
+                // The lock will be automatically released at the end of the scope
+            }
+
+            // Trigger back pressure: Wait after releasing the lock, reducing lock competition
+            tokio::task::yield_now().await;
+
+            // Add short delays to avoid over-consumption of CPU
+            if fastrand::bool() {
+                tokio::time::sleep(Duration::from_micros(10)).await;
+            }
+        }
+    }
+
+    /// Return the buffer to the buffer pool
+    ///
+    /// If the buffer pool does not reach the maximum capacity, return the buffer to the pool;
+    /// Otherwise, discard it directly to prevent memory bloating.
+    ///
+    /// Optimization points:
+    /// -Use scope to limit the lock's holding time
+    /// -Check the buffer size in advance to avoid unnecessary lock acquisition
+    ///
+    /// # Parameters
+    /// -`buf`: Buffer to be returned
+    async fn release(&self, mut buf: BytesMut) {
+        // If the buffer capacity does not match, discard it
+        if buf.capacity() != self.chunk_size {
+            return;
+        }
+
+        // Use scope to limit the lock's holding time
+        let mut guard = self.inner.lock().await;
+        if guard.len() < self.max_buffers {
+            buf.clear();
+            guard.push(buf);
+        }
+        // Discard directly when the maximum value exceeds it to prevent memory bloating
+    }
+
+    /// Get the current state of the buffer pool
+    ///
+    /// # Returns
+    /// Return a tuple (current number of buffers, maximum number of buffers)
+    async fn stats(&self) -> (usize, usize) {
+        let guard = self.inner.lock().await;
+        (guard.len(), self.max_buffers)
+    }
+}
+
+// Modified asynchronous reading trait
+#[async_trait]
+pub trait AsyncChunkReader: Send + Sync {
+    async fn read_chunk(&mut self, buf: &mut BytesMut) -> IoResult<usize>;
+    fn content_length(&self) -> u64;
+    fn mtime(&self) -> i64;
+    async fn read(&mut self, offset: u64, length: u64) -> IoResult<Bytes>;
+}
+
+//Modified asynchronous write trait
+#[async_trait]
+pub trait AsyncChunkWriter: Send + Sync {
+    async fn write_chunk(&mut self, data: Bytes) -> IoResult<()>;
+    async fn flush(&mut self) -> IoResult<()>;
+}
+
+/// Transfer progress callback type
+///
+/// Parameters:
+/// -Number of bytes transmitted
+/// -Total bytes
+///
+/// Return value:
+/// -true: Continue transmission
+/// -false: Cancel the transfer
+pub type ProgressCallback = Box<dyn Fn(u64, u64) -> bool + Send + Sync + 'static>;
+
+/// Zero copy file transfer implementation
+///
+/// Core features:
+/// -Memory multiplexing mechanism based on buffer pools to avoid frequent memory allocation
+/// -Completely decoupled read and write operations, improving throughput throughput through concurrent tasks
+/// -Automatic backpressure control to prevent excessive memory consumption
+/// -Complete error handling and resource cleaning mechanism
+/// -Support transmission progress callback and cancellation operations
+///
+/// Design points:
+/// -Use Arc<Mutex<W>> to implement thread-safe sharing of writers
+/// -Implement concurrent task count control through Semaphore
+/// -BufferPool provides intelligent buffer lifecycle management
+/// -Use tokio::spawn to achieve true asynchronous parallel processing
+/// -Support cancellation of operations during transmission
+pub struct BufferFileTransfer<R, W> {
+    reader: R,
+    writer: Arc<tokio::sync::Mutex<W>>,
+    buffer_pool: BufferPool,
+    // Progress callback
+    progress_callback: Option<ProgressCallback>,
+    // Cancel sign
+    canceled: Arc<AtomicBool>,
+}
+
+impl<R, W> BufferFileTransfer<R, W>
+where
+    R: AsyncChunkReader + Send + 'static,
+    W: AsyncChunkWriter + Send + 'static,
+{
+    pub fn new(reader: R, writer: W, chunk_size: usize, max_buffers: usize) -> Self {
+        let buffer_pool = BufferPool::new(chunk_size, 4, max_buffers);
+        Self {
+            reader,
+            writer: Arc::new(tokio::sync::Mutex::new(writer)),
+            buffer_pool,
+            progress_callback: None,
+            canceled: Arc::new(AtomicBool::new(false)),
+        }
+    }
+    /// Set the progress callback function
+    pub fn with_progress_callback<F>(mut self, callback: F) -> Self
+    where
+        F: Fn(u64, u64) -> bool + Send + Sync + 'static,
+    {
+        self.progress_callback = Some(Box::new(callback));
+        self
+    }
+
+    /// Cancel the current transfer
+    pub fn cancel(&self) {
+        self.canceled.store(true, Ordering::SeqCst);
+    }
+
+    /// Check if it has been cancelled
+    fn is_canceled(&self) -> bool {
+        self.canceled.load(Ordering::SeqCst)
+    }
+
+    /// Calling progress callback
+    fn call_progress(&self, transferred: u64, total: u64) -> bool {
+        if let Some(ref callback) = self.progress_callback {
+            // Call back, if false is returned, the transfer is canceled
+            if !callback(transferred, total) {
+                self.cancel();
+                return false;
+            }
+        }
+
+        // Check the cancel flag
+        !self.is_canceled()
+    }
+
+    pub async fn do_transfer(mut self) -> IoResult<(u64, u64)> {
+        let total_size = self.reader.content_length();
+        let mut transferred = 0u64;
+
+        // Collect all task handles
+        let mut tasks = Vec::new();
+        // Last progress report time
+        let mut last_progress_time = Instant::now();
+        // Progress Report Interval (milliseconds)
+        let progress_interval_ms = 5000; // 5000ms
+
+        // Initial progress report
+        if !self.call_progress(0, total_size) {
+            return Ok((0, total_size)); // User Cancel
+        }
+
+        while transferred < total_size {
+            // Check if it has been cancelled
+            if self.is_canceled() {
+                return Ok((transferred, total_size));
+            }
+
+            // Get the buffer
+            let mut buffer = self.buffer_pool.acquire().await;
+
+            // Read data
+            let read_bytes = self.reader.read_chunk(&mut buffer).await?;
+            if read_bytes == 0 {
+                break; // Reading is complete
+            }
+
+            transferred += read_bytes as u64;
+
+            // Update progress
+            let now = Instant::now();
+            if now.duration_since(last_progress_time).as_millis() >= progress_interval_ms as u128 {
+                if !self.call_progress(transferred, total_size) {
+                    // Callback returns false, cancels transmission
+                    break;
+                }
+                last_progress_time = now;
+            }
+
+            // Only split the actual read parts to avoid unnecessary memory allocation
+            let data = buffer.split_to(read_bytes).freeze();
+
+            // Check if it has been cancelled
+            if self.is_canceled() {
+                break;
+            }
+
+            // Clone Arc to move to closure
+            let writer_clone = self.writer.clone();
+            let pool_clone = self.buffer_pool.clone();
+            let canceled_clone = self.canceled.clone();
+
+            // Start asynchronous write task and no longer limit the number of concurrency
+            let task = tokio::spawn(async move {
+                // Check if it has been cancelled
+                if canceled_clone.load(Ordering::SeqCst) {
+                    return Ok(()); // Cancel write
+                }
+
+                let result = async {
+                    let mut writer = writer_clone.lock().await;
+                    writer.write_chunk(data).await
+                }
+                .await;
+
+                // Return the buffer
+                pool_clone.release(buffer).await;
+
+                // Return result
+                result
+            });
+
+            tasks.push(task);
+        }
+
+        // Wait for all write tasks to complete and collect results
+        let results = futures::future::join_all(tasks).await;
+
+        // Process the task result, but ignore the error if canceled
+        if !self.is_canceled() {
+            for result in results {
+                match result {
+                    Ok(write_result) => {
+                        // If the write error occurs, the first error will be returned
+                        write_result?
+                    }
+                    Err(e) => {
+                        // The task itself fails (such as panic)
+                        return Err(Error::other(format!(
+                            "The write task failed to execute: {}",
+                            e
+                        )));
+                    }
+                }
+            }
+
+            // Finally refresh the writer
+            let mut writer = self.writer.lock().await;
+            writer.flush().await?;
+        }
+
+        // Final progress report
+        self.call_progress(transferred, total_size);
+
+        Ok((transferred, total_size))
+    }
+}
+
+/// Extended ZeroCopyFileTransfer to add extra functionality
+impl<R, W> BufferFileTransfer<R, W>
+where
+    R: AsyncChunkReader + Send + 'static,
+    W: AsyncChunkWriter + Send + 'static,
+{
+    /// Perform transmission and return details (number of bytes transmitted, total number of bytes)
+    pub async fn execute_transfer_with_stats(self) -> IoResult<(u64, u64)> {
+        self.do_transfer().await
+    }
+}
+
+#[async_trait]
+impl AsyncChunkReader for Box<dyn AsyncChunkReader + Send> {
+    async fn read_chunk(&mut self, buf: &mut BytesMut) -> IoResult<usize> {
+        (**self).read_chunk(buf).await
+    }
+
+    fn content_length(&self) -> u64 {
+        (**self).content_length()
+    }
+
+    fn mtime(&self) -> i64 {
+        (**self).mtime()
+    }
+
+    async fn read(&mut self, offset: u64, length: u64) -> IoResult<Bytes> {
+        (**self).read(offset, length).await
+    }
+}
+
+// Implement AsyncChunkWriter trait for Box<dyn AsyncChunkWriter + Send>
+#[async_trait]
+impl AsyncChunkWriter for Box<dyn AsyncChunkWriter + Send> {
+    async fn write_chunk(&mut self, data: Bytes) -> IoResult<()> {
+        (**self).write_chunk(data).await
+    }
+
+    async fn flush(&mut self) -> IoResult<()> {
+        (**self).flush().await
+    }
+}

--- a/crates/common/curvine-ufs-api/src/fs/channel_transfer.rs
+++ b/crates/common/curvine-ufs-api/src/fs/channel_transfer.rs
@@ -1,0 +1,313 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::fs::{AsyncChunkReader, AsyncChunkWriter, ProgressCallback};
+use bytes::{Bytes, BytesMut};
+use orpc::sync::channel::{AsyncChannel, AsyncReceiver, AsyncSender};
+use std::io::Error;
+use std::io::Result as IoResult;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use tokio::time::Instant;
+
+/// Channel-based file transfer implementation
+///
+/// Core features:
+/// - Uses tokio's mpsc channel to directly pass data chunks, reducing memory copying
+/// - Completely decoupled read/write operations through producer-consumer pattern to improve throughput
+/// - Automatic backpressure control by limiting channel capacity to prevent excessive memory consumption
+/// - Comprehensive error handling and resource cleanup mechanisms
+/// - Supports transfer progress callbacks and cancellation operations
+///
+/// Design points:
+/// - Uses bounded channel to implement automatic backpressure control
+/// - Reader and writer run in independent asynchronous tasks
+/// - Supports cancellation during transfer process
+/// - No buffer pool needed, directly passes data chunks to reduce memory copying
+pub struct ChannelFileTransfer<R, W> {
+    reader: R,
+    writer: W,
+    // Chunk size in bytes
+    chunk_size: usize,
+    // Channel capacity (number of buffers)
+    channel_capacity: usize,
+    // Progress callback
+    progress_callback: Option<ProgressCallback>,
+    // Cancellation flag
+    canceled: Arc<AtomicBool>,
+}
+
+impl<R, W> ChannelFileTransfer<R, W>
+where
+    R: AsyncChunkReader + Send + 'static,
+    W: AsyncChunkWriter + Send + 'static,
+{
+    /// Creates a new Channel-based file transfer instance
+    ///
+    /// # Parameters
+    /// - `reader`: Reader implementing AsyncChunkReader
+    /// - `writer`: Writer implementing AsyncChunkWriter
+    /// - `chunk_size`: Size of data chunks in bytes
+    /// - `channel_capacity`: Channel capacity, controls maximum number of concurrent data chunks
+    ///
+    /// # Returns
+    /// Returns a configured ChannelFileTransfer instance
+    pub fn new(reader: R, writer: W, chunk_size: usize, channel_capacity: usize) -> Self {
+        Self {
+            reader,
+            writer,
+            chunk_size,
+            channel_capacity: channel_capacity.max(4),
+            progress_callback: None,
+            canceled: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// Creates a transfer instance with default configuration
+    pub fn with_defaults(reader: R, writer: W) -> Self {
+        Self::new(reader, writer, 64 * 1024, 16) // Default: 64KB chunks, 16 buffers
+    }
+
+    /// Sets the chunk size
+    pub fn with_chunk_size(mut self, chunk_size: usize) -> Self {
+        self.chunk_size = chunk_size.max(4096); // Minimum 4KB
+        self
+    }
+
+    /// Sets the channel capacity
+    pub fn with_channel_capacity(mut self, capacity: usize) -> Self {
+        self.channel_capacity = capacity.max(4); // Minimum 4
+        self
+    }
+
+    /// Sets the progress callback function
+    pub fn with_progress_callback<F>(mut self, callback: F) -> Self
+    where
+        F: Fn(u64, u64) -> bool + Send + Sync + 'static,
+    {
+        self.progress_callback = Some(Box::new(callback));
+        self
+    }
+
+    /// Cancels the current transfer
+    pub fn cancel(&self) {
+        self.canceled.store(true, Ordering::SeqCst);
+    }
+
+    /// Checks if the transfer has been cancelled
+    fn is_canceled(&self) -> bool {
+        self.canceled.load(Ordering::SeqCst)
+    }
+
+    /// Calls the progress callback
+    fn call_progress(&self, transferred: u64, total: u64) -> bool {
+        if let Some(ref callback) = self.progress_callback {
+            // Call the callback, if it returns false, cancel the transfer
+            if !callback(transferred, total) {
+                self.cancel();
+                return false;
+            }
+        }
+
+        // Check cancellation flag
+        !self.is_canceled()
+    }
+
+    /// Executes the transfer and returns detailed information (bytes transferred, total bytes)
+    pub async fn execute_transfer_with_stats(self) -> IoResult<(u64, u64)> {
+        self.do_transfer().await
+    }
+
+    /// Executes the file transfer
+    ///
+    /// Core implementation:
+    /// 1. Creates a bounded channel as a data conduit between reader and writer
+    /// 2. Launches independent read and write tasks
+    /// 3. Read task reads data from reader and sends to channel
+    /// 4. Write task receives data from channel and writes to writer
+    /// 5. Automatically implements backpressure control through channel
+    /// 6. Supports progress callbacks and cancellation operations
+    ///
+    /// # Returns
+    /// Returns a tuple (bytes transferred, total bytes)
+    pub async fn do_transfer(mut self) -> IoResult<(u64, u64)> {
+        let total_size = self.reader.content_length();
+
+        // Create bounded channel with specified buffer capacity
+        let channel = AsyncChannel::<(Bytes, usize)>::new(self.channel_capacity);
+        let (tx, rx) = channel.split();
+
+        // Create progress reporting channel
+        let progress_channel = AsyncChannel::<u64>::new(16);
+        let (progress_tx, mut progress_rx) = progress_channel.split();
+
+        // Initial progress report
+        if !self.call_progress(0, total_size) {
+            return Ok((0, total_size)); // User cancelled
+        }
+
+        // Clone cancellation flag for reader task
+        let reader_canceled = self.canceled.clone();
+
+        // Start reader task
+        let reader_handle = tokio::spawn(async move {
+            Self::reader_task(
+                self.reader,
+                tx,
+                self.chunk_size,
+                reader_canceled,
+                progress_tx,
+            )
+            .await
+        });
+
+        // Clone cancellation flag for writer task
+        let writer_canceled = self.canceled.clone();
+
+        // Start writer task
+        let writer_handle =
+            tokio::spawn(async move { Self::writer_task(self.writer, rx, writer_canceled).await });
+
+        // Progress callback flag and function
+        let progress_callback = self.progress_callback.take();
+        let canceled = self.canceled.clone();
+
+        // Handle progress updates
+        let mut last_reported = 0u64;
+        while let Some(transferred) = progress_rx.recv().await {
+            last_reported = transferred;
+
+            // Call progress callback
+            if let Some(ref callback) = progress_callback {
+                if !callback(transferred, total_size) {
+                    canceled.store(true, Ordering::SeqCst);
+                    break;
+                }
+            }
+
+            // Check if cancelled
+            if canceled.load(Ordering::SeqCst) {
+                break;
+            }
+        }
+
+        // Wait for reader task to complete
+        let read_result = reader_handle.await.unwrap_or_else(|e| {
+            Err(Error::other(format!("Reader task execution failed: {}", e)))
+        })?;
+
+        // Wait for writer task to complete
+        writer_handle.await.unwrap_or_else(|e| {
+            Err(Error::other(format!("Writer task execution failed: {}", e)))
+        })?;
+
+        // Final progress report (if different from last report)
+        if let Some(ref callback) = progress_callback {
+            if read_result.0 > last_reported {
+                let _ = callback(read_result.0, total_size);
+            }
+        }
+
+        // Return transfer result
+        Ok((read_result.0, total_size))
+    }
+
+    /// Reader task: reads data from reader and sends to channel
+    async fn reader_task(
+        mut reader: R,
+        tx: AsyncSender<(Bytes, usize)>,
+        chunk_size: usize,
+        canceled: Arc<AtomicBool>,
+        progress_tx: AsyncSender<u64>,
+    ) -> IoResult<(u64, u64)> {
+        let mut transferred = 0u64;
+        let total_size = reader.content_length();
+
+        // Last progress report time
+        let mut last_progress_time = Instant::now();
+        // Progress report interval (milliseconds)
+        let progress_interval_ms = 1000 * 5;
+
+        // Create buffer
+        let mut buffer = BytesMut::with_capacity(chunk_size);
+
+        loop {
+            // Check if cancelled
+            if canceled.load(Ordering::SeqCst) {
+                break;
+            }
+            buffer.clear(); // Clear buffer for reuse
+                            // Read data
+            let read_bytes = reader.read_chunk(&mut buffer).await?;
+            if read_bytes == 0 {
+                break; // Reading complete
+            }
+
+            transferred += read_bytes as u64;
+
+            // Periodically send progress reports
+            let now = Instant::now();
+            if now.duration_since(last_progress_time).as_millis() >= progress_interval_ms as u128 {
+                // Send progress info, ignore errors (if receiver is closed)
+                let _ = progress_tx.send(transferred).await;
+                last_progress_time = now;
+            }
+
+            // Only split the actually read portion to avoid unnecessary memory allocation
+            let data = buffer.split_to(read_bytes).freeze();
+
+            // Check if cancelled
+            if canceled.load(Ordering::SeqCst) {
+                break;
+            }
+
+            // Send data to channel
+            // If receiver is closed, it means the writer task has ended, we should end too
+            if tx.send((data, read_bytes)).await.is_err() {
+                break;
+            }
+        }
+
+        // Send final progress
+        let _ = progress_tx.send(transferred).await;
+
+        // Return transfer result
+        Ok((transferred, total_size))
+    }
+
+    /// Writer task: receives data from channel and writes to writer
+    async fn writer_task(
+        mut writer: W,
+        mut rx: AsyncReceiver<(Bytes, usize)>,
+        canceled: Arc<AtomicBool>,
+    ) -> IoResult<()> {
+        // Receive and process data until channel closes or cancellation
+        while let Some((data, _size)) = rx.recv().await {
+            // Check if cancelled
+            if canceled.load(Ordering::SeqCst) {
+                break;
+            }
+
+            // Write data
+            writer.write_chunk(data).await?;
+        }
+
+        // If not cancelled, flush the writer
+        if !canceled.load(Ordering::SeqCst) {
+            writer.flush().await?
+        }
+
+        Ok(())
+    }
+}

--- a/crates/common/curvine-ufs-api/src/fs/mod.rs
+++ b/crates/common/curvine-ufs-api/src/fs/mod.rs
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Compatibility facade for the split `curvine-ufs-api` crate.
+mod buffer_transfer;
+pub use crate::fs::buffer_transfer::*;
 
-pub use curvine_ufs_api::*;
+pub mod channel_transfer;
+
+pub mod ufs_context;
+pub use self::ufs_context::UFSContext;

--- a/crates/common/curvine-ufs-api/src/fs/ufs_context.rs
+++ b/crates/common/curvine-ufs-api/src/fs/ufs_context.rs
@@ -1,0 +1,47 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![allow(unused)]
+
+use curvine_config::UfsConf;
+use curvine_fs_api::Path;
+use std::collections::HashMap;
+
+pub struct UFSContext {
+    conf: UfsConf,
+    path: Path,
+    mount_id: String,
+}
+
+impl UFSContext {
+    pub fn new(path: &Path, conf: UfsConf) -> Self {
+        UFSContext {
+            path: path.clone(),
+            conf,
+            mount_id: "".to_string(),
+        }
+    }
+
+    pub fn s3a_config(&self) -> &HashMap<String, String> {
+        self.conf.get_config()
+    }
+
+    pub fn conf(&self) -> &UfsConf {
+        &self.conf
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}

--- a/crates/common/curvine-ufs-api/src/lib.rs
+++ b/crates/common/curvine-ufs-api/src/lib.rs
@@ -12,6 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Compatibility facade for the split `curvine-ufs-api` crate.
+//! Shared UFS config, context, and transfer primitives for clients and adapters.
 
-pub use curvine_ufs_api::*;
+pub mod fs;
+
+mod ufs_utils;
+pub use self::ufs_utils::UfsUtils;
+
+mod conf;
+pub use self::conf::*;
+
+pub const FOLDER_SUFFIX: &str = "/";
+
+#[macro_export]
+macro_rules! err_ufs {
+    ($e:expr) => ({
+        Err(orpc::err_msg!($e).into())
+    });
+
+    ($f:tt, $($arg:expr),+) => ({
+        orpc::err_box!(format!($f, $($arg),+))
+    });
+}

--- a/crates/common/curvine-ufs-api/src/ufs_utils.rs
+++ b/crates/common/curvine-ufs-api/src/ufs_utils.rs
@@ -1,0 +1,65 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::err_ufs;
+use crate::FOLDER_SUFFIX;
+use curvine_error::FsResult;
+use curvine_fs_api::Path;
+
+pub struct UfsUtils;
+
+impl UfsUtils {
+    pub fn get_bucket_key(path: &Path) -> FsResult<(&str, &str)> {
+        let bucket = match path.authority() {
+            Some(v) => v,
+            None => return err_ufs!("UFS URI missing bucket name: {}", path.full_path()),
+        };
+
+        let key = match path.path().strip_prefix('/') {
+            Some(v) => v,
+            None => return err_ufs!("Path {} invalid", path.full_path()),
+        };
+
+        Ok((bucket, key))
+    }
+
+    // Create a directory object; the key of the directory object in S3 ends with /
+    pub fn dir_key(key: &str) -> String {
+        if key.is_empty() {
+            "".to_string()
+        } else if key.ends_with(FOLDER_SUFFIX) {
+            key.to_string()
+        } else {
+            format!("{}{}", key, FOLDER_SUFFIX)
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::UfsUtils;
+
+    #[test]
+    fn get_bucket_key() {
+        let path = "s3://bucket/path".into();
+        let (bucket, key) = UfsUtils::get_bucket_key(&path).unwrap();
+        assert_eq!(bucket, "bucket");
+        assert_eq!(key, "path");
+
+        let path = "s3://bucket/".into();
+        let (bucket, key) = UfsUtils::get_bucket_key(&path).unwrap();
+        assert_eq!(bucket, "bucket");
+        assert_eq!(key, "");
+    }
+}

--- a/curvine-cli/Cargo.toml
+++ b/curvine-cli/Cargo.toml
@@ -10,7 +10,7 @@ curvine-client-core = { workspace = true }
 curvine-job-client = { workspace = true }
 curvine-unified-fs = { workspace = true }
 curvine-bench = { workspace = true }
-curvine-ufs = { workspace = true }
+curvine-ufs-api = { workspace = true }
 curvine-config = { workspace = true }
 curvine-error = { workspace = true }
 curvine-fs-api = { workspace = true }

--- a/curvine-cli/src/util.rs
+++ b/curvine-cli/src/util.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use curvine_ufs::S3Conf;
+use curvine_ufs_api::S3Conf;
 use orpc::{err_box, CommonResult};
 use std::collections::HashMap;
 use std::fmt::Display;

--- a/curvine-docker/compile/Dockerfile_rocky9_cached
+++ b/curvine-docker/compile/Dockerfile_rocky9_cached
@@ -134,7 +134,7 @@ COPY Cargo.toml ./
 COPY Cargo.lock ./
 
 # Create workspace member structure and generate minimal config files (merged into single RUN to reduce layers)
-RUN mkdir -p curvine-common/src curvine-server/src curvine-client/src curvine-libsdk/src curvine-tests/src curvine-fuse/src curvine-web/src curvine-ufs/src curvine-cli/src orpc/src && \
+RUN mkdir -p curvine-common/src curvine-server/src curvine-client/src curvine-libsdk/src curvine-tests/src curvine-fuse/src curvine-web/src curvine-ufs/src curvine-cli/src orpc/src crates/common/curvine-ufs-api/src && \
     echo '[package]\nname = "curvine-common"\nversion = "0.1.0"\nedition = "2021"' > curvine-common/Cargo.toml && \
     echo '[package]\nname = "curvine-server"\nversion = "0.1.0"\nedition = "2021"' > curvine-server/Cargo.toml && \
     echo '[package]\nname = "curvine-client"\nversion = "0.1.0"\nedition = "2021"' > curvine-client/Cargo.toml && \
@@ -143,6 +143,7 @@ RUN mkdir -p curvine-common/src curvine-server/src curvine-client/src curvine-li
     echo '[package]\nname = "curvine-fuse"\nversion = "0.1.0"\nedition = "2021"' > curvine-fuse/Cargo.toml && \
     echo '[package]\nname = "curvine-web"\nversion = "0.1.0"\nedition = "2021"' > curvine-web/Cargo.toml && \
     echo '[package]\nname = "curvine-ufs"\nversion = "0.1.0"\nedition = "2021"' > curvine-ufs/Cargo.toml && \
+    echo '[package]\nname = "curvine-ufs-api"\nversion = "0.1.0"\nedition = "2021"' > crates/common/curvine-ufs-api/Cargo.toml && \
     echo '[package]\nname = "curvine-cli"\nversion = "0.1.0"\nedition = "2021"' > curvine-cli/Cargo.toml && \
     echo '[package]\nname = "orpc"\nversion = "0.1.0"\nedition = "2021"' > orpc/Cargo.toml && \
     echo 'fn main() {}' > curvine-common/src/lib.rs && \
@@ -153,6 +154,7 @@ RUN mkdir -p curvine-common/src curvine-server/src curvine-client/src curvine-li
     echo 'fn main() {}' > curvine-fuse/src/main.rs && \
     echo 'fn main() {}' > curvine-web/src/lib.rs && \
     echo 'fn main() {}' > curvine-ufs/src/lib.rs && \
+    echo 'fn main() {}' > crates/common/curvine-ufs-api/src/lib.rs && \
     echo 'fn main() {}' > curvine-cli/src/main.rs && \
     echo 'fn main() {}' > orpc/src/lib.rs
 

--- a/curvine-server/Cargo.toml
+++ b/curvine-server/Cargo.toml
@@ -22,7 +22,7 @@ curvine-error = { workspace = true, features = ["axum-response"] }
 curvine-fault = { workspace = true }
 curvine-storage-spdk = { workspace = true, optional = true }
 curvine-client = { workspace = true, features = ["job-client", "unified", "opendal-s3"] }
-curvine-ufs = { workspace = true }
+curvine-ufs-api = { workspace = true }
 curvine-web = { workspace = true }
 prost = { workspace = true }
 bincode = { workspace = true }

--- a/curvine-server/src/common/ufs_client.rs
+++ b/curvine-server/src/common/ufs_client.rs
@@ -19,7 +19,7 @@ use curvine_common::error::FsError;
 use curvine_common::fs::{CurvineURI, FileSystem, Path};
 use curvine_common::state::FileStatus;
 use curvine_common::FsResult;
-use curvine_ufs::fs::ufs_context::UFSContext;
+use curvine_ufs_api::fs::ufs_context::UFSContext;
 use std::sync::Arc;
 
 #[derive(Clone)]

--- a/curvine-server/src/common/ufs_manager.rs
+++ b/curvine-server/src/common/ufs_manager.rs
@@ -19,7 +19,7 @@ use curvine_common::fs::{CurvineURI, Path};
 use curvine_common::state::MountInfo;
 use curvine_common::utils::ProtoUtils;
 use curvine_common::FsResult;
-use curvine_ufs::fs::ufs_context::UFSContext;
+use curvine_ufs_api::fs::ufs_context::UFSContext;
 use log::info;
 use orpc::err_box;
 use std::collections::HashMap;

--- a/curvine-tests/Cargo.toml
+++ b/curvine-tests/Cargo.toml
@@ -27,7 +27,7 @@ curvine-common = { workspace = true }
 curvine-server = { workspace = true }
 curvine-client = { workspace = true, features = ["job-client", "unified", "opendal-s3"] }
 curvine-lancedb = { workspace = true, optional = true }
-curvine-ufs = { workspace = true }
+curvine-ufs-api = { workspace = true }
 tokio  = { workspace = true }
 tracing = { workspace = true }
 tracing-appender = { workspace = true }

--- a/curvine-tests/tests/fallback_read_test.rs
+++ b/curvine-tests/tests/fallback_read_test.rs
@@ -482,7 +482,7 @@ fn test_tc14_seek_after_ufs_fallback() {
 ///     -- --exact --nocapture
 /// ```
 ///
-/// Property keys map to `S3Conf` in curvine-ufs/src/conf.rs. `s3.endpoint_url`
+/// Property keys map to `S3Conf` in curvine-ufs-api/src/conf.rs. `s3.endpoint_url`
 /// MUST start with http:// or https://. `s3.region_name` is required by the
 /// OpenDAL S3 builder (omitting it fails with "region is missing"). If output
 /// shows "WARNING: UFS_TEST_PATH not set", the env vars did not take effect.

--- a/curvine-ufs/Cargo.toml
+++ b/curvine-ufs/Cargo.toml
@@ -5,17 +5,7 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-orpc = { workspace = true }
-curvine-config = { workspace = true }
-curvine-error = { workspace = true }
-curvine-fs-api = { workspace = true }
-tokio = { workspace = true }
-async-trait = { workspace = true }
-bytes = { workspace = true }
-futures = { workspace = true }
-log = { workspace = true }
-fastrand = { workspace = true }
-
+curvine-ufs-api = { workspace = true }
 
 [features]
 default = []

--- a/scripts/check-api-crate-deps.sh
+++ b/scripts/check-api-crate-deps.sh
@@ -20,6 +20,7 @@ crates=(
   curvine-model
   curvine-fs-api
   curvine-storage-api
+  curvine-ufs-api
   curvine-config
 )
 


### PR DESCRIPTION
# Summary

Split shared UFS configuration, context, and transfer primitives into a new `curvine-ufs-api` crate. The top-level `curvine-ufs` crate is now a thin compatibility facade, while CLI/SDK minimum profiles can avoid depending on that facade or the heavy UFS adapter crates.

# Issue Describe / Design

Related to #1243

Design decisions and trade-offs:
- `curvine-ufs-api` owns shared UFS API/config types such as `S3Conf`, `OpendalConf`, `OssHdfsConf`, transfer helpers, and `UFSContext`.
- `curvine-ufs` remains as a re-export facade to preserve existing crate compatibility.
- OpenDAL and OSS-HDFS implementations remain in optional adapter crates, so the minimum CLI/SDK profiles do not compile adapter dependencies unless an adapter feature is selected.
- Server-side role crate splitting is intentionally left out of this change.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `crates/common/curvine-ufs-api` | Added shared UFS API/config crate from the previous `curvine-ufs` contents. | No behavior change; provides a lighter dependency target. |
| `curvine-ufs` | Reduced to a compatibility re-export facade over `curvine-ufs-api`. | Existing `curvine-ufs` users remain source-compatible. |
| `curvine-cli`, `curvine-unified-fs`, SDK path | Rewired minimum-profile dependencies away from the top-level facade. | Minimum CLI/SDK profiles no longer include `curvine-ufs` or UFS adapters. |
| UFS adapter crates and server UFS references | Repointed shared config/context imports to `curvine-ufs-api`. | Adapter behavior is unchanged. |
| Build/check scripts and Docker cache stub | Registered the new workspace member and API dependency check. | Keeps local checks and Docker dependency caching aligned. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `make format` | PASS | Re-run after final edits and again after commit. |
| `cargo metadata --format-version 1 --no-deps` | PASS | Exact HEAD. |
| `cargo check -p curvine-cli --no-default-features` | PASS | Exact HEAD. |
| `cargo check -p curvine-libsdk --no-default-features --features java-sdk` | PASS | Exact HEAD. |
| `cargo check -p curvine-libsdk --no-default-features --features python-sdk` | PASS | Exact HEAD. |
| `scripts/check-api-crate-deps.sh` | PASS | Includes `curvine-ufs-api`. |
| `cargo tree` forbidden-package check for minimum CLI/Java SDK/Python SDK profiles | PASS | No `curvine-ufs`, UFS adapters, OpenDAL, RocksDB, raft, SPDK, or HDFS JNI packages. |

# Dependencies

- Related PRs: #1443, #1444
- Related issues: #1243
- Blocks / blocked by: None
