### PR TITLE
test(fuse): update INIT_EXT flag name expectation

### DIFF
--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -2204,7 +2204,10 @@ impl fs::FileSystem for CurvineFileSystem {
 #[cfg(test)]
 mod tests {
     use crate::fs::dcache::Inode;
-    use crate::{FATTR_ATIME_NOW, FATTR_GID, FATTR_MODE, FATTR_MTIME, FATTR_MTIME_NOW, FATTR_UID};
+    use crate::{
+        FATTR_ATIME_NOW, FATTR_GID, FATTR_MODE, FATTR_MTIME, FATTR_MTIME_NOW, FATTR_UID,
+        FUSE_INIT_EXT,
+    };
     use curvine_common::state::{FileAllocMode, FileStatus, FileType, INTERNAL_CTIME_XATTR};
 
     #[test]
@@ -2890,11 +2893,15 @@ mod tests {
         assert!(names.contains(&"DO_READDIRPLUS".to_string()));
         // Empty flags => empty list.
         assert!(fuse_init_flag_names(0).is_empty());
-        // An unknown bit is surfaced as a hex token, not silently dropped.
-        let unknown = 1u32 << 30;
-        let names = fuse_init_flag_names(FUSE_BIG_WRITES | unknown);
+        // FUSE_INIT_EXT is a known input-format capability and renders by name.
+        let names = fuse_init_flag_names(FUSE_BIG_WRITES | FUSE_INIT_EXT);
         assert!(names.contains(&"BIG_WRITES".to_string()));
-        assert!(names.iter().any(|n| n == "0x40000000"));
+        assert!(names.contains(&"INIT_EXT".to_string()));
+        // A bit not registered in the name map is surfaced as hex, not silently dropped.
+        let unknown = 1u32 << 31;
+        assert!(fuse_init_flag_names(unknown)
+            .iter()
+            .any(|n| n == "0x80000000"));
         // Keep EXPORT_SUPPORT in logging so offered-but-dropped bits render by name.
         assert!(fuse_init_flag_names(FUSE_EXPORT_SUPPORT).contains(&"EXPORT_SUPPORT".to_string()));
     }


### PR DESCRIPTION
# Summary

Update the FUSE INIT capability-name test to reflect that bit 30 is now registered as `FUSE_INIT_EXT`, while preserving coverage for the hexadecimal fallback of unmapped bits.

# Issue Describe / Design

No related issue.

Root cause:
The test still treated bit 30 (`0x40000000`) as unknown, but the production capability-name map now registers that bit as `INIT_EXT`.

Reproduction:
`cargo test -p curvine-fuse fuse_init_flag_names_maps_known_and_unknown --lib`

Fix approach:
Assert that `FUSE_INIT_EXT` renders as `INIT_EXT`, and use bit 31 to verify the hexadecimal fallback for an unmapped bit.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-fuse/src/fs/curvine_file_system.rs` | Update the INIT flag-name test data and expectations | None; test-only change |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-fuse fuse_init_flag_names_maps_known_and_unknown --lib` | PASS | 1 passed |
| `cargo test -p curvine-fuse init_ --lib` | PASS | 8 passed |
| `cargo fmt --package curvine-fuse -- --check` | PASS | |
| `cargo test -p curvine-fuse --lib` | PARTIAL | 333 passed; 5 unrelated permission/special-file tests failed independently |
| `make format` | BLOCKED | Full workspace clippy is blocked on local macOS by existing recursion-limit, RocksDB C++ header, and unrelated warning failures; the target file remains formatted |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None
