### PR TITLE
fix(build): route server UFS features through data transfer

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -517,6 +517,8 @@ append_ufs_feature() {
     oss-hdfs)
       if [ "$scope" = "cli-minimal" ]; then
         add_feature "curvine-cli/oss-hdfs"
+      elif [ "$scope" = "server-native" ]; then
+        add_feature "curvine-data-transfer/oss-hdfs"
       else
         add_feature "curvine-client/oss-hdfs"
       fi
@@ -524,6 +526,8 @@ append_ufs_feature() {
     opendal-hdfs)
       if [ "$scope" = "cli-minimal" ]; then
         add_feature "curvine-cli/opendal-hdfs"
+      elif [ "$scope" = "server-native" ]; then
+        add_feature "curvine-data-transfer/opendal-hdfs"
       else
         add_feature "curvine-client/opendal-hdfs"
       fi
@@ -534,6 +538,8 @@ append_ufs_feature() {
     opendal-webhdfs)
       if [ "$scope" = "cli-minimal" ]; then
         add_feature "curvine-cli/opendal-webhdfs"
+      elif [ "$scope" = "server-native" ]; then
+        add_feature "curvine-data-transfer/opendal-webhdfs"
       else
         add_feature "curvine-client/opendal-webhdfs"
       fi
@@ -541,6 +547,8 @@ append_ufs_feature() {
     *)
       if [ "$scope" = "cli-minimal" ]; then
         add_feature "curvine-cli/$ufs"
+      elif [ "$scope" = "server-native" ]; then
+        add_feature "curvine-data-transfer/$ufs"
       else
         add_feature "curvine-client/$ufs"
       fi


### PR DESCRIPTION
# Summary

Route server-native UFS feature selection through `curvine-data-transfer` while preserving the existing client and CLI feature mappings.

# Issue Describe / Design

The server crate split moved UFS composition for server builds into `curvine-data-transfer`, but the release build script continued to pass `curvine-client/<backend>` features to the server-only Cargo invocation. Cargo rejected those features because `curvine-server` no longer exposes the client composition path.

This change selects `curvine-data-transfer/<backend>` for the server-native scope. Test and client scopes continue to use `curvine-client/<backend>`, and the CLI scope continues to use `curvine-cli/<backend>`.

# Changes

| Area | Change | Impact |
| --- | --- | --- |
| `build/build.sh` | Map server-native OSS-HDFS and OpenDAL backend features to `curvine-data-transfer` | Server-only release builds resolve UFS features against the crate that now owns server transfer composition |
| `build/build.sh` | Preserve existing mappings for test, client, and CLI scopes | Client-facing artifact behavior remains unchanged |

# Test verified

| Test case | Result |
| --- | --- |
| `bash -n build/build.sh` | PASS |
| Cargo metadata with `curvine-data-transfer/opendal-s3,curvine-common/jemalloc` | PASS |
| `make format` | PASS |
| `cargo build --release -p curvine-server --no-default-features --features curvine-data-transfer/opendal-s3,curvine-common/jemalloc` | PASS |

# Dependencies

- Related PRs: #1280, #1388, #1455
- Blocks / blocked by: None
