### PR TITLE
fix(fuse): invalidate parent metadata after directory mutations

### DIFF
--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -17,7 +17,8 @@ use crate::fs::operator::*;
 use crate::fs::plock_wait_registry::{LockOwner, PlockWaitGuard, PlockWaitRegistry};
 use crate::fs::state::{FileHandle, NodeState};
 use crate::fuse_metrics::{
-    ReaddirTimer, INVAL_REASON_FLUSH, INVAL_REASON_FSYNC, INVAL_REASON_RELEASE, INVAL_REASON_RESIZE,
+    ReaddirTimer, INVAL_REASON_FLUSH, INVAL_REASON_FSYNC, INVAL_REASON_MKDIR, INVAL_REASON_RELEASE,
+    INVAL_REASON_RENAME, INVAL_REASON_RESIZE, INVAL_REASON_RMDIR,
 };
 use crate::raw::fuse_abi::*;
 use crate::raw::FuseDirentList;
@@ -245,7 +246,14 @@ impl CurvineFileSystem {
 
         self.state
             .fs_rename(old_id, old_name, new_dir, new_name, flags)
-            .await
+            .await?;
+
+        self.state.invalid_cache(old_id, None, INVAL_REASON_RENAME);
+        if new_dir != old_id {
+            self.state.invalid_cache(new_dir, None, INVAL_REASON_RENAME);
+        }
+
+        Ok(())
     }
 
     fn parse_rename2_flags(flags: u32) -> FuseResult<RenameFlags> {
@@ -1496,6 +1504,7 @@ impl fs::FileSystem for CurvineFileSystem {
 
         let opts = FuseUtils::mkdir_opts(&op, &self.fs);
         let attr = self.state.fs_mkdir(ino, name, opts).await?;
+        self.state.invalid_cache(ino, None, INVAL_REASON_MKDIR);
         Ok(FuseUtils::create_entry_out(&self.conf, attr))
     }
 
@@ -1858,6 +1867,8 @@ impl fs::FileSystem for CurvineFileSystem {
 
         self.fs.delete(&path, false).await?;
         self.state.unlink(op.header.nodeid, name, false)?;
+        self.state
+            .invalid_cache(op.header.nodeid, None, INVAL_REASON_RMDIR);
 
         Ok(())
     }

--- a/curvine-fuse/src/fs/state/node_state.rs
+++ b/curvine-fuse/src/fs/state/node_state.rs
@@ -1414,6 +1414,41 @@ mod test {
     }
 
     #[test]
+    fn invalidating_parent_status_drops_stale_nlink() {
+        let rt = Arc::new(AsyncRuntime::single());
+        let mut conf = ClusterConf::default();
+        conf.fuse.enable_meta_cache = true;
+        conf.fuse.metrics_enabled = false;
+        let fs = UnifiedFileSystem::with_rt(conf, rt).unwrap();
+        let state = NodeState::new(fs).unwrap();
+
+        state.cache_resolved_status(
+            FUSE_ROOT_ID,
+            None,
+            &FileStatus {
+                is_dir: true,
+                nlink: 3,
+                mode: 0o755,
+                ..Default::default()
+            },
+        );
+        assert_eq!(
+            state
+                .get_cached_status(FUSE_ROOT_ID, None, false)
+                .unwrap()
+                .unwrap()
+                .nlink,
+            3
+        );
+
+        state.invalid_cache(FUSE_ROOT_ID, None, crate::fuse_metrics::INVAL_REASON_RMDIR);
+        assert!(state
+            .get_cached_status(FUSE_ROOT_ID, None, false)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
     fn handle_chokepoints_inc_dec_their_own_gauge_only() {
         crate::FuseMetrics::ensure_init().unwrap();
         let mx = crate::FuseMetrics::get();


### PR DESCRIPTION
# Summary

Fix stale parent-directory metadata in Curvine FUSE when `enable_meta_cache = true`.

Directory mutations such as `mkdir`, `rmdir`, and `rename` change metadata on their parent directories. In particular, adding or removing a subdirectory changes the parent's link count (`st_nlink`). Curvine updated the namespace on the Master and its directory-entry cache, but kept the old parent `FileStatus` in the FUSE metadata cache.

As a result, a `stat()` immediately after a successful mutation could return a stale parent link count until the metadata cache expired. This caused the LTP `linkat02`, `rename06`, and `mkdirat01` cases to fail during cleanup because the test harness used the stale link count to decide whether to call `unlink()` or `rmdir()`.

# Minimal Reproducer

```c
// Reproduce stale parent-directory nlink with Curvine FUSE metadata caching.
#define _GNU_SOURCE

#include <errno.h>
#include <limits.h>
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <sys/stat.h>
#include <unistd.h>

static void die(const char *what)
{
    fprintf(stderr, "%s: %s\n", what, strerror(errno));
    exit(2);
}

int main(int argc, char **argv)
{
    char parent[PATH_MAX];
    char child[PATH_MAX];
    struct stat st;
    mode_t mode;

    if (argc != 2) {
        fprintf(stderr, "usage: %s <curvine-mount>\n", argv[0]);
        return 2;
    }

    if (snprintf(parent, sizeof(parent), "%s/nlink-cache-XXXXXX", argv[1]) >=
        (int)sizeof(parent)) {
        fprintf(stderr, "mount path is too long\n");
        return 2;
    }

    if (!mkdtemp(parent))
        die("mkdtemp parent");

    if (snprintf(child, sizeof(child), "%s/child", parent) >=
        (int)sizeof(child))
        die("build child path");

    if (mkdir(child, 0700) == -1)
        die("mkdir child");

    if (stat(parent, &st) == -1)
        die("initial stat parent");

    /* Refresh the cached parent status from Master without changing its mode. */
    mode = st.st_mode & 07777;
    if (chmod(parent, mode) == -1)
        die("chmod parent");
    if (stat(parent, &st) == -1)
        die("refreshed stat parent");

    printf("before rmdir: parent nlink=%lu (expected 3)\n",
           (unsigned long)st.st_nlink);

    if (rmdir(child) == -1)
        die("rmdir child");
    if (stat(parent, &st) == -1)
        die("stat parent after rmdir");

    printf("after rmdir:  parent nlink=%lu (expected 2)\n",
           (unsigned long)st.st_nlink);

    if (rmdir(parent) == -1)
        die("cleanup parent");

    if (st.st_nlink != 2) {
        fprintf(stderr, "BUG reproduced: stale parent nlink remained %lu\n",
                (unsigned long)st.st_nlink);
        return 1;
    }

    puts("PASS: parent nlink was refreshed after rmdir");
    return 0;
}
```

Run it on a Curvine FUSE mount with metadata caching enabled:

```bash
gcc /tmp/meta_cache_parent_nlink.c -o /tmp/meta_cache_parent_nlink
/tmp/meta_cache_parent_nlink /mnt/curvine
```

Before the fix, the parent status remained cached after `rmdir()`:

```text
before rmdir: parent nlink=3 (expected 3)
after rmdir:  parent nlink=3 (expected 2)
BUG reproduced: stale parent nlink remained 3
```

After the fix, the second `stat()` resolves the updated status:

```text
before rmdir: parent nlink=3 (expected 3)
after rmdir:  parent nlink=2 (expected 2)
PASS: parent nlink was refreshed after rmdir
```

# Root Cause

Curvine maintains a FUSE-side metadata cache keyed by inode and path. A parent directory status can therefore remain cached independently of the directory entry that was created, removed, or renamed below it.

The affected mutation paths behaved as follows:

1. The Master successfully applied `mkdir`, `rmdir`, or `rename`.
2. Curvine updated the relevant directory-entry state.
3. The cached `FileStatus` for the parent inode was not invalidated.
4. A subsequent `getattr`/`stat` hit the stale parent status instead of reading the new link count from the Master.

Invalidating only the child name is insufficient because the stale value is stored on the parent inode itself. The parent must be invalidated with no child name so the next status lookup misses the cache.

For cross-directory renames, both the source and destination parents may change and must be invalidated.

# Changes

- Invalidate the parent inode metadata cache after a successful `mkdir`.
- Invalidate the parent inode metadata cache after a successful `rmdir` and directory-entry state update.
- Invalidate the source parent after a successful `rename`/`rename2`.
- Invalidate the destination parent as well when a rename crosses directories.
- Use operation-specific invalidation reasons for FUSE cache metrics.
- Add a regression test proving that parent invalidation removes a cached stale `nlink` value when metadata caching is enabled.

# Verification

- `cargo test -p curvine-fuse invalidating_parent_status_drops_stale_nlink -- --nocapture`
- `cargo test -p curvine-fuse -- --test-threads=1`
  - 357 passed, 0 failed.
- `cargo build --release -p curvine-fuse`
- Run the minimal reproducer with `enable_meta_cache = true`.
  - Parent `nlink` changes from 3 to 2 after `rmdir`.
- Run the affected LTP cases on `/mnt/curvine`:

  ```bash
  ./runltp -p -q \
    -l /tmp/syscalls-jfs-three-fixed.result.log \
    -o /tmp/syscalls-jfs-three-fixed.output.log \
    -d /mnt/curvine \
    -f syscalls-jfs \
    -s '^\(linkat02\|rename06\|mkdirat01\)[[:space:]]'
  ```

  Result: `linkat02`, `rename06`, and `mkdirat01` all pass.
