### PR TITLE
test(workspace): make curvine-tests opt-in (#1243)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,10 @@ members = [
     "crates/sdk/curvine-libsdk-java",
     "crates/sdk/curvine-libsdk-python",
     "curvine-lancedb",
-    'curvine-tests',
+    # Top-level integration/regression harness. It remains a workspace member so
+    # explicit test commands keep working, but it is intentionally opt-in via
+    # default-members because it pulls server/client/FUSE/native test paths.
+    "curvine-tests",
     "curvine-fuse",
     "curvine-web",
     "curvine-ufs",
@@ -58,6 +61,8 @@ members = [
 
 # Mirror members here unless a crate is intentionally opt-in.
 # curvine-lancedb stays opt-in because it pulls heavy Lance/Arrow dependencies.
+# curvine-tests stays opt-in because it pulls whole-cluster integration,
+# FUSE, and optional external storage dependencies for explicit test runs.
 default-members = [
     "orpc",
     "crates/infra/curvine-fault",
@@ -89,7 +94,6 @@ default-members = [
     "crates/client/curvine-bench",
     "curvine-client",
     "curvine-libsdk",
-    "curvine-tests",
     "curvine-fuse",
     "curvine-web",
     "curvine-ufs",
@@ -142,6 +146,8 @@ curvine-libsdk-python = { path = "crates/sdk/curvine-libsdk-python" }
 curvine-server = { path = "curvine-server" }
 curvine-lancedb = { path = "curvine-lancedb" }
 curvine-ufs = { path = "curvine-ufs" }
+# Test harness dependency entry is for explicit test/dev tooling only.
+# Production crates must not add normal dependencies on curvine-tests.
 curvine-tests = { path = "curvine-tests" }
 curvine-fuse = { path = "curvine-fuse" }
 curvine-web = { path = "curvine-web" }

--- a/curvine-tests/Cargo.toml
+++ b/curvine-tests/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
 name = "curvine-tests"
 version = "0.1.0"
+description = "Curvine integration and regression test harness"
 edition = "2021"
+publish = false
+
+# This package is an opt-in test harness, not a production crate. Its normal
+# dependencies may include server/client/FUSE paths used by integration tests.
 
 [features]
 # Enable OSS-HDFS backend specific tests / code paths (Jindo-based).

--- a/curvine-tests/README.md
+++ b/curvine-tests/README.md
@@ -2,6 +2,21 @@
 
 Regression test server and Portal for Curvine (build-server). Test results are written under `curvine-tests/regression_result/` (gitignored).
 
+## Layering Decision
+
+`curvine-tests` remains a top-level workspace member and is the canonical
+repository-wide integration/regression test harness. It owns the regression
+server, Docker image, whole-cluster test helpers, and cross-product test entry
+points, so moving it under a production crate layer such as `crates/client` or
+`crates/server` would make the layer boundary less clear.
+
+The package is intentionally excluded from workspace `default-members`. It may
+depend on server, client, FUSE, native storage, and optional external backend
+paths only for explicit commands such as `cargo test -p curvine-tests` or the
+`curvine-tests` regression image. Production crates must not add normal
+dependencies on `curvine-tests`; verify with `cargo tree -i curvine-tests
+--workspace` and `scripts/check-deps.sh --mode report`.
+
 ## Local Run
 
 From the **project root** (so that `curvine-tests/regression` and project code are visible):

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -16,4 +16,8 @@ scripts/check-deps.sh --mode final
 
 `report` mode is useful during migration because known violations are printed as
 warnings. `final` mode is the P7 gate and fails if internal dependencies on
-`curvine-common` / `orpc` or forbidden heavy paths remain.
+`curvine-common` / `orpc` or forbidden heavy paths remain. The check also keeps
+`curvine-tests` as an opt-in test harness by rejecting normal production
+dependencies on that package. `curvine-tests` itself is excluded from production
+facade dependency checks because its server/client/FUSE dependencies are only
+allowed behind explicit test commands.

--- a/scripts/check-deps.sh
+++ b/scripts/check-deps.sh
@@ -101,7 +101,9 @@ check_facade_direct_deps() {
   local facade_deps
   facade_deps="$(
     awk -F '\t' '
-      ($2 == "curvine-common" || $2 == "orpc") && $1 != $2 {
+      # curvine-tests is an opt-in integration harness; protect production crates
+      # with check_testing_harness_reverse_deps instead.
+      ($2 == "curvine-common" || $2 == "orpc") && $1 != $2 && $1 != "curvine-tests" {
         print $1 " -> " $2
       }
     ' <<<"$direct_internal_deps"
@@ -112,6 +114,28 @@ check_facade_direct_deps() {
 $facade_deps"
   else
     record_ok "facade-direct-deps"
+  fi
+}
+
+check_testing_harness_reverse_deps() {
+  local testing_normal_deps
+  testing_normal_deps="$(
+    jq -r '
+      .packages[]
+      | select(.source == null) as $pkg
+      | $pkg.dependencies[]
+      | select(.path != null)
+      | select(.name == "curvine-tests" and (.kind == null))
+      | select($pkg.name != "curvine-tests")
+      | $pkg.name + " -> curvine-tests"
+    ' <<<"$metadata" | sort
+  )"
+
+  if [[ -n "$testing_normal_deps" ]]; then
+    record_violation "testing-harness-normal-deps" "production crates must not depend on curvine-tests:
+$testing_normal_deps"
+  else
+    record_ok "testing-harness-normal-deps"
   fi
 }
 
@@ -196,6 +220,7 @@ echo "Dependency boundary check mode: $MODE"
 echo
 
 check_facade_direct_deps
+check_testing_harness_reverse_deps
 check_tree_forbidden "curvine-cli-final-tree" "$common_client_forbidden" -p curvine-cli
 check_tree_forbidden "curvine-fuse-final-tree" "$common_client_forbidden" -p curvine-fuse
 check_tree_forbidden "curvine-libsdk-java-min-final-tree" "$libsdk_java_forbidden" -p curvine-libsdk --no-default-features --features java-sdk


### PR DESCRIPTION
# Summary

Keep `curvine-tests` as the top-level repository integration/regression test package, but make it opt-in for default workspace builds. This keeps whole-cluster and regression test entrypoints available without pulling their server, client, FUSE, and native test dependencies into the default workspace member set.

# Issue Describe / Design

Related to #1243

Design decisions and trade-offs:
- `curvine-tests` stays at the repository top level because it owns cross-product regression scripts, Docker image entrypoints, and cluster-level test helpers rather than a single production crate layer.
- The package is removed from `workspace.default-members` so default cargo workspace commands do not implicitly compile its heavy test dependency surface.
- `scripts/check-deps.sh` now excludes the test package itself from production facade dependency checks, while rejecting normal production dependencies on `curvine-tests`.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `Cargo.toml` | Keep `curvine-tests` as a workspace member and remove it from `default-members` with comments documenting the opt-in boundary. | Default workspace cargo commands no longer include `curvine-tests`; explicit `-p curvine-tests` commands still work. |
| `curvine-tests/Cargo.toml` | Mark the package as unpublished and document that its dependencies are for explicit integration/regression tests. | No runtime behavior change. |
| `curvine-tests/README.md` | Document the long-term top-level placement decision and verification commands. | Documentation only. |
| `scripts/check-deps.sh` | Add a reverse dependency check so production crates cannot add normal dependencies on `curvine-tests`; exclude the test package from production facade checks. | Future dependency reports make the `curvine-tests` exception explicit. |
| `scripts/README.md` | Document the `curvine-tests` dependency check scope. | Documentation only. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `make format` | PASS | Required project formatting/pre-commit gate. |
| `cargo metadata --format-version 1 --no-deps` | PASS | 44 workspace members, 34 default members. |
| `cargo metadata --format-version 1 --no-deps \| jq -r '.workspace_default_members[] \| select(contains("curvine-tests"))'` | PASS | Produced no output, confirming `curvine-tests` is not a default member. |
| `cargo check -p curvine-tests --all-targets` | PASS | Final run after formatting completed successfully. |
| `cargo tree -i curvine-tests --workspace --depth 2` | PASS | Shows no reverse production dependency; only the package itself is printed. |
| `cargo tree -p curvine-tests --depth 1` | PASS | Audited direct heavy test dependencies including `curvine-server`, `curvine-client`, Linux `curvine-fuse`, `curvine-common`, and `orpc`. |
| `scripts/check-deps.sh --mode report` | PASS | The new reverse dependency check is OK; existing migration warnings remain for other facade/FUSE paths. |

# Dependencies

- Related PRs: None
- Related issues: #1243
- Blocks / blocked by: None
