### PR TITLE
ci(deps): enforce client dependency guardrails (#1243)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Dependency boundary guardrails
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          scripts/check-deps.sh --mode report
+          make check-client-deps
 
       - name: API crate dependency boundary check
         run: |
@@ -107,6 +107,11 @@ jobs:
           
           echo "After build, disk usage:"
           df -h
+
+      - name: Minimal client artifact dependency guardrails
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          make check-minimal-artifact-deps
 
       # - name: Run unit tests (skip UFS-dependent tests in CI)
       #   env:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help check-env check-api-crate-deps format format-csi build cargo docker-build docker-build-compile docker-compile docker-build-spdk-target docker-compose-spdk docker-compose-spdk-down all dist dist-only
+.PHONY: help check-env check-client-deps check-api-crate-deps check-minimal-artifact-deps format format-csi build cargo docker-build docker-build-compile docker-compile docker-build-spdk-target docker-compose-spdk docker-compose-spdk-down all dist dist-only
 
 # Default target when running 'make' without arguments
 .DEFAULT_GOAL := help
@@ -20,7 +20,9 @@ help:
 	@echo ""
 	@echo "Environment:"
 	@echo "  make check-env                   - Check build environment dependencies"
+	@echo "  make check-client-deps           - Enforce client-side dependency boundary guardrails"
 	@echo "  make check-api-crate-deps        - Enforce lightweight API/domain crate dependency boundaries"
+	@echo "  make check-minimal-artifact-deps - Enforce runtime deps on built minimal client artifacts"
 	@echo ""
 	@echo "Building:"
 	@echo "  make build ARGS='<args>'         - Build with specific arguments passed to build.sh"
@@ -78,9 +80,17 @@ help:
 check-env:
 	$(SHELL_CMD) build/check-env.sh $(filter --skip-java-sdk --skip-python-sdk,$(ARGS))
 
+# 1.1. Enforce current client dependency boundaries
+check-client-deps:
+	$(SHELL_CMD) scripts/check-deps.sh --mode ci
+
 # 1.1. Enforce lightweight API/domain crate dependency boundaries
 check-api-crate-deps:
 	$(SHELL_CMD) scripts/check-api-crate-deps.sh
+
+# 1.2. Enforce runtime dependency boundaries for built minimal artifacts
+check-minimal-artifact-deps:
+	$(SHELL_CMD) scripts/check-minimal-artifact-deps.sh
 
 # 2. Format the project
 format:

--- a/build/build.sh
+++ b/build/build.sh
@@ -727,6 +727,13 @@ check_minimal_artifact_deps() {
     exit 1
   fi
 
+  local native_storage_pattern='librocksdb'
+  if grep -E "$native_storage_pattern" <<<"$needed" >/dev/null; then
+    echo "Error: ${label} contains native storage runtime dependencies forbidden for client artifacts:" >&2
+    echo "$needed" >&2
+    exit 1
+  fi
+
   local native_ufs_pattern='libjindosdk|libhdfs|libjvm|libjli'
   if ! client_native_ufs_deps_allowed && grep -E "$native_ufs_pattern" <<<"$needed" >/dev/null; then
     echo "Error: ${label} contains native UFS runtime dependencies but no native --ufs/feature was requested:" >&2

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -11,13 +11,24 @@ This directory may still contain other non-test scripts (e.g. perf).
 
 ```bash
 scripts/check-deps.sh --mode report
+scripts/check-deps.sh --mode ci
 scripts/check-deps.sh --mode final
 ```
 
 `report` mode is useful during migration because known violations are printed as
-warnings. `final` mode is the P7 gate and fails if internal dependencies on
-`curvine-common` / `orpc` or forbidden heavy paths remain. The check also keeps
-`curvine-tests` as an opt-in test harness by rejecting normal production
-dependencies on that package. `curvine-tests` itself is excluded from production
-facade dependency checks because its server/client/FUSE dependencies are only
-allowed behind explicit test commands.
+warnings. `ci` mode is the current enforceable gate for already-migrated client
+paths: `curvine-client-core`, minimal `curvine-cli`, minimal Java/Python SDKs,
+the SPDK/RDMA feature-unification check, and production reverse dependencies on
+`curvine-tests`. Remaining `curvine-common` / `orpc` facade users and the
+current `curvine-fuse` final-tree debt stay visible as warnings until the P7
+cleanup removes them. `final` mode is the P7 gate and fails if internal
+dependencies on `curvine-common` / `orpc` or forbidden heavy paths remain.
+
+`check-minimal-artifact-deps.sh` inspects built client artifacts with `readelf`,
+`llvm-readelf`, or `otool` and fails if minimal client artifacts dynamically
+link RDMA/SPDK, Jindo/HDFS/JVM, or native storage libraries.
+
+```bash
+scripts/check-minimal-artifact-deps.sh
+scripts/check-minimal-artifact-deps.sh --artifact curvine-cli=target/debug/curvine-cli
+```

--- a/scripts/check-deps.sh
+++ b/scripts/check-deps.sh
@@ -11,14 +11,16 @@ MODE="report"
 
 usage() {
   cat <<'EOF'
-Usage: scripts/check-deps.sh [--mode report|final]
+Usage: scripts/check-deps.sh [--mode report|ci|final]
 
 Modes:
-  report  Print current dependency boundary violations and exit 0.
-  final   Fail if final forbidden dependencies remain.
+  report  Print dependency boundary violations and exit 0.
+  ci      Enforce the current client-side dependency policy used by CI.
+  final   Fail if P7 final forbidden dependencies remain.
 
 Examples:
   scripts/check-deps.sh --mode report
+  scripts/check-deps.sh --mode ci
   scripts/check-deps.sh --mode final
 EOF
 }
@@ -47,7 +49,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 case "$MODE" in
-  report|final) ;;
+  report|ci|final) ;;
   *)
     echo "Invalid mode: $MODE" >&2
     usage >&2
@@ -70,8 +72,9 @@ failures=0
 record_violation() {
   local label="$1"
   local detail="$2"
+  local gate="${3:-final}"
 
-  if [[ "$MODE" == "final" ]]; then
+  if [[ "$MODE" == "final" || ( "$MODE" == "$gate" && "$gate" != "final" ) ]]; then
     echo "FAIL [$label] $detail"
     failures=$((failures + 1))
   else
@@ -111,7 +114,7 @@ check_facade_direct_deps() {
 
   if [[ -n "$facade_deps" ]]; then
     record_violation "facade-direct-deps" "internal crates still depend on curvine-common/orpc:
-$facade_deps"
+$facade_deps" final
   else
     record_ok "facade-direct-deps"
   fi
@@ -133,7 +136,7 @@ check_testing_harness_reverse_deps() {
 
   if [[ -n "$testing_normal_deps" ]]; then
     record_violation "testing-harness-normal-deps" "production crates must not depend on curvine-tests:
-$testing_normal_deps"
+$testing_normal_deps" ci
   else
     record_ok "testing-harness-normal-deps"
   fi
@@ -149,7 +152,8 @@ tree_packages() {
 check_tree_forbidden() {
   local label="$1"
   local forbidden_csv="$2"
-  shift 2
+  local gate="$3"
+  shift 3
 
   local packages
   packages="$(tree_packages "$@")"
@@ -164,7 +168,7 @@ check_tree_forbidden() {
   done
 
   if ((${#found[@]} > 0)); then
-    record_violation "$label" "forbidden packages found: ${found[*]}"
+    record_violation "$label" "forbidden packages found: ${found[*]}" "$gate"
   else
     record_ok "$label"
   fi
@@ -200,7 +204,7 @@ check_mixed_spdk_feature_risk() {
       }
       END { exit found ? 0 : 1 }
     ' <<<"$output"; then
-      record_violation "mixed-spdk-feature-risk" "server spdk-rdma feature still enables SPDK features on shared orpc during a mixed CLI/server cargo tree"
+      record_violation "mixed-spdk-feature-risk" "server spdk-rdma feature still enables SPDK features on shared orpc during a mixed CLI/server cargo tree" ci
     else
       record_ok "mixed-spdk-feature-risk"
     fi
@@ -212,29 +216,35 @@ check_mixed_spdk_feature_risk() {
   rm -f "$err"
 }
 
-common_client_forbidden="curvine-common,orpc,curvine-ufs,opendal,rocksdb,raft,curvine-storage-spdk,curvine-rocksdb,curvine-raft,curvine-ufs-oss-hdfs,curvine-hdfs-jni"
-libsdk_java_forbidden="curvine-common,orpc,curvine-ufs,opendal,rocksdb,raft,pyo3,curvine-storage-spdk,curvine-rocksdb,curvine-raft,curvine-ufs-oss-hdfs,curvine-hdfs-jni"
-libsdk_python_forbidden="curvine-common,orpc,curvine-ufs,opendal,rocksdb,raft,jni,curvine-storage-spdk,curvine-rocksdb,curvine-raft,curvine-ufs-oss-hdfs,curvine-hdfs-jni"
+client_heavy_forbidden="curvine-ufs,curvine-ufs-opendal,curvine-ufs-oss-hdfs,curvine-hdfs-jni,curvine-storage-spdk,curvine-rocksdb,curvine-raft,opendal,rocksdb,librocksdb-sys,raft,raft-proto"
+common_client_forbidden="curvine-common,orpc,${client_heavy_forbidden}"
+libsdk_java_forbidden="curvine-common,orpc,${client_heavy_forbidden},pyo3"
+libsdk_python_forbidden="curvine-common,orpc,${client_heavy_forbidden},jni"
+fuse_current_forbidden="curvine-storage-spdk,curvine-ufs-oss-hdfs,curvine-hdfs-jni"
 
 echo "Dependency boundary check mode: $MODE"
 echo
 
 check_facade_direct_deps
 check_testing_harness_reverse_deps
-check_tree_forbidden "curvine-cli-final-tree" "$common_client_forbidden" -p curvine-cli
-check_tree_forbidden "curvine-fuse-final-tree" "$common_client_forbidden" -p curvine-fuse
-check_tree_forbidden "curvine-libsdk-java-min-final-tree" "$libsdk_java_forbidden" -p curvine-libsdk --no-default-features --features java-sdk
-check_tree_forbidden "curvine-libsdk-python-min-final-tree" "$libsdk_python_forbidden" -p curvine-libsdk --no-default-features --features python-sdk
+check_tree_forbidden "curvine-client-core-final-tree" "$common_client_forbidden" ci -p curvine-client-core
+check_tree_forbidden "curvine-cli-final-tree" "$common_client_forbidden" ci -p curvine-cli --no-default-features
+check_tree_forbidden "curvine-fuse-native-client-tree" "$fuse_current_forbidden" ci -p curvine-fuse --no-default-features
+check_tree_forbidden "curvine-fuse-final-tree" "$common_client_forbidden" final -p curvine-fuse
+check_tree_forbidden "curvine-libsdk-java-min-final-tree" "$libsdk_java_forbidden" ci -p curvine-libsdk --no-default-features --features java-sdk
+check_tree_forbidden "curvine-libsdk-python-min-final-tree" "$libsdk_python_forbidden" ci -p curvine-libsdk --no-default-features --features python-sdk
 check_mixed_spdk_feature_risk
 
 echo
-if [[ "$MODE" == "final" && "$failures" -gt 0 ]]; then
+if [[ "$failures" -gt 0 ]]; then
   echo "Dependency boundary check failed with $failures violation(s)."
   exit 1
 fi
 
 if [[ "$MODE" == "report" ]]; then
   echo "Report mode completed. Warnings are expected until the migration reaches the relevant DAG layer."
+elif [[ "$MODE" == "ci" ]]; then
+  echo "CI dependency boundary check passed. Final-mode warnings remain explicit migration exceptions."
 else
   echo "Final dependency boundary check passed."
 fi

--- a/scripts/check-minimal-artifact-deps.sh
+++ b/scripts/check-minimal-artifact-deps.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+#
+# Runtime dependency checks for minimal client-side artifacts.
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/check-minimal-artifact-deps.sh [--allow-missing] [--artifact LABEL=PATH] [PATH ...]
+
+With no artifacts, the script checks known Curvine outputs in target/{debug,release}
+and build/dist/lib. Explicit artifacts must exist unless --allow-missing is set.
+EOF
+}
+
+allow_missing=0
+declare -a artifact_specs=()
+using_defaults=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --allow-missing)
+      allow_missing=1
+      shift
+      ;;
+    --artifact)
+      if [[ $# -lt 2 ]]; then
+        echo "--artifact requires LABEL=PATH" >&2
+        usage >&2
+        exit 2
+      fi
+      artifact_specs+=("$2")
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    -*)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+    *)
+      artifact_specs+=("$1")
+      shift
+      ;;
+  esac
+done
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+for bin in grep sed; do
+  if ! command -v "$bin" >/dev/null 2>&1; then
+    echo "Missing required command: $bin" >&2
+    exit 2
+  fi
+done
+
+if [[ ${#artifact_specs[@]} -eq 0 ]]; then
+  using_defaults=1
+  artifact_specs=(
+    "curvine-cli=target/debug/curvine-cli"
+    "curvine-fuse=target/debug/curvine-fuse"
+    "curvine-libsdk=target/debug/libcurvine_libsdk.so"
+    "curvine-libsdk-python=target/debug/libcurvine_libsdk_python.so"
+    "curvine-cli=target/release/curvine-cli"
+    "curvine-fuse=target/release/curvine-fuse"
+    "curvine-libsdk=target/release/libcurvine_libsdk.so"
+    "curvine-libsdk-python=target/release/libcurvine_libsdk_python.so"
+    "curvine-cli=build/dist/lib/curvine-cli"
+    "curvine-fuse=build/dist/lib/curvine-fuse"
+    "curvine-libsdk=build/dist/lib/libcurvine_libsdk.so"
+    "curvine-libsdk-python=build/dist/lib/libcurvine_libsdk_python.so"
+  )
+fi
+
+artifact_dynamic_entries() {
+  local inspector="$1"
+  local artifact="$2"
+
+  case "$inspector" in
+    readelf)
+      readelf -d "$artifact" 2>/dev/null | grep -E 'NEEDED|RPATH|RUNPATH' || true
+      ;;
+    llvm-readelf)
+      llvm-readelf -d "$artifact" 2>/dev/null | grep -E 'NEEDED|RPATH|RUNPATH' || true
+      ;;
+    otool)
+      otool -L "$artifact" 2>/dev/null || true
+      ;;
+  esac
+}
+
+artifact_inspector() {
+  local artifact="$1"
+
+  if command -v readelf >/dev/null 2>&1 && readelf -h "$artifact" >/dev/null 2>&1; then
+    echo "readelf"
+  elif command -v llvm-readelf >/dev/null 2>&1 && llvm-readelf -h "$artifact" >/dev/null 2>&1; then
+    echo "llvm-readelf"
+  elif command -v otool >/dev/null 2>&1 && otool -hv "$artifact" >/dev/null 2>&1; then
+    echo "otool"
+  fi
+}
+
+forbidden_pattern='libibverbs\.so|librdmacm\.so|libspdk|libdpdk|librte_|libjindosdk|libhdfs|libjvm|libjli|librocksdb'
+checked=0
+failures=0
+
+for spec in "${artifact_specs[@]}"; do
+  label="$spec"
+  artifact="$spec"
+  if [[ "$spec" == *=* ]]; then
+    label="${spec%%=*}"
+    artifact="${spec#*=}"
+  else
+    label="${artifact##*/}"
+  fi
+
+  if [[ ! -e "$artifact" ]]; then
+    if [[ "$allow_missing" -eq 1 || "$using_defaults" -eq 1 ]]; then
+      echo "SKIP [$label] missing artifact: $artifact"
+      continue
+    fi
+    echo "FAIL [$label] missing artifact: $artifact" >&2
+    failures=$((failures + 1))
+    continue
+  fi
+
+  inspector="$(artifact_inspector "$artifact")"
+  if [[ -z "$inspector" ]]; then
+    echo "SKIP [$label] artifact is not inspectable by readelf/llvm-readelf/otool: $artifact"
+    continue
+  fi
+
+  checked=$((checked + 1))
+  needed="$(artifact_dynamic_entries "$inspector" "$artifact")"
+  if grep -E "$forbidden_pattern" <<<"$needed" >/dev/null; then
+    echo "FAIL [$label] forbidden native runtime dependency found in $artifact" >&2
+    echo "$needed" | sed 's/^/  /' >&2
+    failures=$((failures + 1))
+  else
+    echo "OK   [$label] runtime dependencies"
+  fi
+done
+
+if ((failures > 0)); then
+  echo "Minimal artifact runtime dependency check failed with $failures violation(s)." >&2
+  exit 1
+fi
+
+if ((checked == 0)); then
+  echo "No inspectable artifacts found. Build minimal client artifacts before running this gate." >&2
+  exit 2
+fi
+
+echo "Minimal artifact runtime dependency check passed."


### PR DESCRIPTION
# Summary

Enforce the current client-side dependency guardrails for the #1243 crate reorganization work. CI now fails on already-migrated client-core, CLI, minimal SDK, test-harness reverse dependency, and SPDK/RDMA feature-unification regressions, while still reporting the remaining facade/FUSE migration debt explicitly.

# Issue Describe / Design

Related to #1243

This PR turns the dependency policy from report-only output into an enforceable CI gate for the client-side paths that have already been migrated. The stricter P7-style final policy remains available as `scripts/check-deps.sh --mode final`, but current known migration exceptions stay visible as warnings under `--mode ci` until the remaining facade and FUSE dependency debt is removed.

Design decisions:
- Keep `report`, `ci`, and `final` as separate modes so current CI can fail on regressions without hiding known final-state exceptions.
- Add `curvine-client-core` to the enforced negative dependency tree checks.
- Split FUSE checks into a current native-client gate and a stricter final-tree warning.
- Add a standalone runtime artifact dependency gate that inspects built client artifacts with `readelf`, `llvm-readelf`, or `otool`.
- Wire the enforceable dependency gate and artifact gate into the main build workflow.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `scripts/check-deps.sh` | Adds `ci` mode, client-core checks, stronger deny lists, and explicit current-vs-final FUSE handling. | CI can now fail on client-side dependency regressions while still surfacing final-state warnings. |
| `scripts/check-minimal-artifact-deps.sh` | Adds a standalone runtime dependency inspector for minimal client artifacts. | Fails if built client artifacts dynamically link forbidden RDMA/SPDK, Jindo/HDFS/JVM, or native storage libraries. |
| `Makefile` | Adds `check-client-deps` and `check-minimal-artifact-deps` targets. | Provides stable local and CI entry points. |
| `.github/workflows/build.yml` | Runs `make check-client-deps` instead of report-only mode and checks artifact runtime dependencies after build. | Pull requests now gate these dependency boundaries in CI. |
| `build/build.sh` | Extends existing client artifact runtime checks to reject dynamic RocksDB links. | Build packaging catches native storage runtime leaks in client artifacts. |
| `scripts/README.md` | Documents report/CI/final modes and artifact dependency checks. | Clarifies the enforced policy and remaining exceptions. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `make format` | PASS | Ran project-required formatting and clippy gates. |
| `cargo metadata --format-version 1 --no-deps` | PASS | Workspace metadata resolves. |
| `make check-client-deps` | PASS | Enforces current client policy; final facade/FUSE exceptions remain WARN-only. |
| `scripts/check-deps.sh --mode final` | EXPECTED FAIL | Still fails on remaining `curvine-common` / `orpc` facade users and the current FUSE final-tree debt. |
| `make check-api-crate-deps` | PASS | Lightweight API/domain crate checks pass. |
| `cargo build -p curvine-cli -p curvine-fuse -p curvine-libsdk` | PASS | Built CLI, FUSE, and default Java SDK artifacts for runtime dependency inspection. |
| `cargo build -p curvine-libsdk --no-default-features --features python-sdk` | PASS | Built the minimal Python SDK profile. |
| `make check-minimal-artifact-deps` | PASS | `curvine-cli`, `curvine-fuse`, and `libcurvine_libsdk.so` have no forbidden dynamic native dependencies. |
| `cargo check -p curvine-client-core -p curvine-cli --all-targets --no-default-features` | PASS | Minimal client-core and CLI targets. |
| `cargo check -p curvine-libsdk --no-default-features --features java-sdk` | PASS | Minimal Java SDK profile. |
| `cargo check -p curvine-libsdk --no-default-features --features python-sdk` | PASS | Minimal Python SDK profile. |
| `git diff --check HEAD~1..HEAD` | PASS | No whitespace errors in the committed diff. |

# Dependencies

- Related PRs: #1446, #1459, #1464, #1466
- Related issues: #1243
- Blocks / blocked by: None
