### PR TITLE
fix(ufs): validate and normalize S3 mount configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2417,6 +2417,7 @@ dependencies = [
  "curvine-fault",
  "curvine-metrics",
  "curvine-rocksdb",
+ "curvine-ufs-api",
  "curvine-unified-fs",
  "curvine-web",
  "dashmap 5.5.3",
@@ -2683,6 +2684,7 @@ dependencies = [
  "orpc-error",
  "orpc-runtime",
  "tokio",
+ "url",
 ]
 
 [[package]]

--- a/crates/adapters/curvine-ufs-opendal/src/lib.rs
+++ b/crates/adapters/curvine-ufs-opendal/src/lib.rs
@@ -308,6 +308,12 @@ impl OpendalFileSystem {
             .scheme()
             .ok_or_else(|| FsError::invalid_path(path.full_path(), "Missing scheme"))?;
 
+        let conf = if matches!(scheme, "s3" | "s3a") {
+            curvine_ufs_api::S3Conf::canonicalize_properties(conf)?
+        } else {
+            conf
+        };
+
         let bucket_or_container = path
             .authority()
             .ok_or_else(|| {

--- a/crates/adapters/curvine-ufs-opendal/src/lib.rs
+++ b/crates/adapters/curvine-ufs-opendal/src/lib.rs
@@ -471,9 +471,7 @@ impl OpendalFileSystem {
                 // empty token, gets the same page back, and loops forever (mount/list hangs).
                 // Setting `s3.list_objects_version=v1` switches to ListObjects v1, whose lister
                 // falls back to using the last object key as the marker and advances correctly.
-                if resolve_disable_list_objects_v2(
-                    conf.get("s3.list_objects_version").map(|s| s.as_str()),
-                )? {
+                if curvine_ufs_api::S3Conf::uses_list_objects_v1(&conf)? {
                     builder = builder.disable_list_objects_v2();
                 }
 
@@ -1025,61 +1023,5 @@ impl FileSystem<OpendalWriter, OpendalReader> for OpendalFileSystem {
             });
 
         Ok(ListStream::new(stream))
-    }
-}
-
-/// Resolve the `s3.list_objects_version` mount option into "should disable ListObjectsV2".
-///
-/// Accepted values (case-insensitive, surrounding whitespace ignored):
-/// - unset / empty / `v2` -> use ListObjects V2 (OpenDAL default) -> returns `false`
-/// - `v1` -> fall back to ListObjects V1 -> returns `true`
-///
-/// Any other value is rejected with an `invalid_argument` error (POSIX EINVAL).
-#[cfg(feature = "opendal-s3")]
-fn resolve_disable_list_objects_v2(value: Option<&str>) -> FsResult<bool> {
-    match value.map(|v| v.trim().to_ascii_lowercase()).as_deref() {
-        None | Some("") | Some("v2") => Ok(false),
-        Some("v1") => Ok(true),
-        Some(other) => Err(FsError::invalid_argument(format!(
-            "Invalid s3.list_objects_version '{}': expected 'v1' or 'v2'",
-            other
-        ))),
-    }
-}
-
-#[cfg(all(test, feature = "opendal-s3"))]
-mod list_objects_version_tests {
-    use super::resolve_disable_list_objects_v2;
-
-    #[test]
-    fn defaults_to_v2_when_unset_or_empty() {
-        assert!(!resolve_disable_list_objects_v2(None).unwrap());
-        assert!(!resolve_disable_list_objects_v2(Some("")).unwrap());
-        assert!(!resolve_disable_list_objects_v2(Some("   ")).unwrap());
-    }
-
-    #[test]
-    fn v2_keeps_default() {
-        assert!(!resolve_disable_list_objects_v2(Some("v2")).unwrap());
-        assert!(!resolve_disable_list_objects_v2(Some("V2")).unwrap());
-        assert!(!resolve_disable_list_objects_v2(Some("  v2 ")).unwrap());
-    }
-
-    #[test]
-    fn v1_disables_v2() {
-        assert!(resolve_disable_list_objects_v2(Some("v1")).unwrap());
-        assert!(resolve_disable_list_objects_v2(Some("V1")).unwrap());
-        assert!(resolve_disable_list_objects_v2(Some(" v1 ")).unwrap());
-    }
-
-    #[test]
-    fn rejects_invalid_values() {
-        for bad in ["1", "2", "v3", "true", "list-v1", "foo"] {
-            let err = resolve_disable_list_objects_v2(Some(bad)).unwrap_err();
-            assert!(
-                err.to_string().contains("s3.list_objects_version"),
-                "unexpected error for {bad:?}: {err}"
-            );
-        }
     }
 }

--- a/crates/common/curvine-ufs-api/Cargo.toml
+++ b/crates/common/curvine-ufs-api/Cargo.toml
@@ -16,6 +16,7 @@ bytes = { workspace = true }
 futures = { workspace = true }
 log = { workspace = true }
 fastrand = { workspace = true }
+url = { workspace = true }
 
 
 [features]

--- a/crates/common/curvine-ufs-api/src/conf.rs
+++ b/crates/common/curvine-ufs-api/src/conf.rs
@@ -17,6 +17,7 @@ use orpc_runtime::common::DurationUnit;
 use std::collections::HashMap;
 use std::ops::Deref;
 use std::time::Duration;
+use url::Url;
 
 pub struct ConfMap(HashMap<String, String>);
 
@@ -38,7 +39,15 @@ impl ConfMap {
         match value.trim().to_lowercase().as_str() {
             "true" => Ok(true),
             "false" => Ok(false),
-            _ => err_box!("Invalid boolean string"),
+            _ => err_box!("{} must be true or false", key),
+        }
+    }
+
+    pub fn get_bool_or(&self, key: &str, default: bool) -> CommonResult<bool> {
+        if self.0.contains_key(key) {
+            self.get_bool(key)
+        } else {
+            Ok(default)
         }
     }
 
@@ -50,12 +59,28 @@ impl ConfMap {
             .map_err(|_| format!("Invalid u32 value for key '{}': {}", key, value).into())
     }
 
+    pub fn get_u32_or(&self, key: &str, default: u32) -> CommonResult<u32> {
+        if self.0.contains_key(key) {
+            self.get_u32(key)
+        } else {
+            Ok(default)
+        }
+    }
+
     pub fn get_u64(&self, key: &str) -> CommonResult<u64> {
         let value = self.get_string(key)?;
         value
             .trim()
             .parse::<u64>()
             .map_err(|_| format!("Invalid u64 value for key '{}': {}", key, value).into())
+    }
+
+    pub fn get_u64_or(&self, key: &str, default: u64) -> CommonResult<u64> {
+        if self.0.contains_key(key) {
+            self.get_u64(key)
+        } else {
+            Ok(default)
+        }
     }
 }
 
@@ -100,6 +125,7 @@ impl S3Conf {
     pub const SECRET_KEY: &'static str = "s3.credentials.secret";
     pub const REGION_NAME: &'static str = "s3.region_name";
     pub const FORCE_PATH_STYLE: &'static str = "s3.force.path.style";
+    pub const LIST_OBJECTS_VERSION: &'static str = "s3.list_objects_version";
     pub const RETRY_TIMES: &'static str = "s3.retry_times";
     pub const CONNECT_TIMEOUT: &'static str = "s3.connect_timeout";
     pub const READ_TIMEOUT: &'static str = "s3.read_timeout";
@@ -108,29 +134,65 @@ impl S3Conf {
     pub const DEFAULT_CONNECT_TIMEOUT: &'static str = "30s";
     pub const DEFAULT_READ_TIMEOUT: &'static str = "120s";
 
+    pub fn validate_region(properties: &HashMap<String, String>) -> CommonResult<()> {
+        Self::required_property(properties, Self::REGION_NAME)
+    }
+
+    pub fn validate(properties: &HashMap<String, String>) -> CommonResult<()> {
+        Self::with_map(properties.clone())?;
+        Self::uses_list_objects_v1(properties)?;
+        OpendalConf::from_map(properties)?;
+        Ok(())
+    }
+
+    pub fn uses_list_objects_v1(properties: &HashMap<String, String>) -> CommonResult<bool> {
+        match properties
+            .get(Self::LIST_OBJECTS_VERSION)
+            .map(|value| value.trim().to_ascii_lowercase())
+            .as_deref()
+        {
+            None | Some("") | Some("v2") => Ok(false),
+            Some("v1") => Ok(true),
+            Some(value) => err_box!(
+                "s3.list_objects_version must be 'v1' or 'v2', got '{}'",
+                value
+            ),
+        }
+    }
+
+    fn required_property(properties: &HashMap<String, String>, key: &str) -> CommonResult<()> {
+        if properties
+            .get(key)
+            .is_some_and(|value| !value.trim().is_empty())
+        {
+            Ok(())
+        } else {
+            err_box!("{} is required", key)
+        }
+    }
+
     pub fn with_map(properties: HashMap<String, String>) -> CommonResult<Self> {
         let map = ConfMap::new(properties);
 
+        Self::required_property(&map.0, Self::ENDPOINT)?;
         let endpoint_url = map.get_string(Self::ENDPOINT)?;
-        if !endpoint_url.starts_with("http://") && !endpoint_url.starts_with("https://") {
-            return err_box!("s3.endpoint_url must start with http:// or https://");
+        let endpoint = Url::parse(&endpoint_url)
+            .map_err(|_| "s3.endpoint_url must be an absolute http(s) URL with a host")?;
+        if !matches!(endpoint.scheme(), "http" | "https") || endpoint.host_str().is_none() {
+            return err_box!("s3.endpoint_url must be an absolute http(s) URL with a host");
         }
 
+        Self::required_property(&map.0, Self::ACCESS_KEY)?;
         let access_key = map.get_string(Self::ACCESS_KEY)?;
+        Self::required_property(&map.0, Self::SECRET_KEY)?;
         let secret_key = map.get_string(Self::SECRET_KEY)?;
 
-        let region_name = if endpoint_url.contains("amazonaws.com") {
-            map.get_string(Self::REGION_NAME)?
-        } else {
-            map.get_string(Self::REGION_NAME)
-                .unwrap_or("undefined".to_string())
-        };
+        Self::validate_region(&map.0)?;
+        let region_name = map.get_string(Self::REGION_NAME)?;
 
-        let force_path_style = map.get_bool(Self::FORCE_PATH_STYLE).unwrap_or(false);
+        let force_path_style = map.get_bool_or(Self::FORCE_PATH_STYLE, false)?;
 
-        let retry_times = map
-            .get_u32(Self::RETRY_TIMES)
-            .unwrap_or(Self::DEFAULT_RETRY_TIMES);
+        let retry_times = map.get_u32_or(Self::RETRY_TIMES, Self::DEFAULT_RETRY_TIMES)?;
 
         let connect_timeout = map
             .get_string(Self::CONNECT_TIMEOUT)
@@ -177,9 +239,7 @@ impl OpendalConf {
     pub fn from_map(properties: &HashMap<String, String>) -> CommonResult<Self> {
         let map = ConfMap::new(properties.clone());
 
-        let retry_times = map
-            .get_u32(Self::RETRY_TIMES)
-            .unwrap_or(Self::DEFAULT_RETRY_TIMES);
+        let retry_times = map.get_u32_or(Self::RETRY_TIMES, Self::DEFAULT_RETRY_TIMES)?;
 
         let connect_timeout_str = map
             .get_string(Self::CONNECT_TIMEOUT)
@@ -191,13 +251,11 @@ impl OpendalConf {
             .unwrap_or(Self::DEFAULT_READ_TIMEOUT.to_string());
         let read_timeout = DurationUnit::from_str(&read_timeout_str)?.as_duration();
 
-        let retry_interval_ms = map
-            .get_u64(Self::RETRY_INTERVAL_MS)
-            .unwrap_or(Self::DEFAULT_RETRY_INTERVAL_MS);
+        let retry_interval_ms =
+            map.get_u64_or(Self::RETRY_INTERVAL_MS, Self::DEFAULT_RETRY_INTERVAL_MS)?;
 
-        let retry_max_delay_ms = map
-            .get_u64(Self::RETRY_MAX_DELAY_MS)
-            .unwrap_or(Self::DEFAULT_RETRY_MAX_DELAY_MS);
+        let retry_max_delay_ms =
+            map.get_u64_or(Self::RETRY_MAX_DELAY_MS, Self::DEFAULT_RETRY_MAX_DELAY_MS)?;
 
         // read_chunk_size and read_concurrent are intentionally NOT user-tunable
         // via mount properties: benchmarking showed the defaults saturate the
@@ -342,5 +400,110 @@ mod opendal_conf_tests {
         let conf = OpendalConf::from_map(&props).unwrap();
         assert_eq!(conf.read_chunk_size, OpendalConf::DEFAULT_READ_CHUNK_SIZE);
         assert_eq!(conf.read_concurrent, OpendalConf::DEFAULT_READ_CONCURRENT);
+    }
+}
+
+#[cfg(test)]
+mod s3_conf_tests {
+    use super::S3Conf;
+    use std::collections::HashMap;
+
+    #[test]
+    fn requires_non_empty_region() {
+        let mut properties = HashMap::new();
+
+        assert!(S3Conf::validate_region(&properties).is_err());
+
+        properties.insert(S3Conf::REGION_NAME.to_string(), "  ".to_string());
+        assert!(S3Conf::validate_region(&properties).is_err());
+
+        properties.insert(S3Conf::REGION_NAME.to_string(), "cn-test-1".to_string());
+        assert!(S3Conf::validate_region(&properties).is_ok());
+    }
+
+    #[test]
+    fn rejects_empty_credentials() {
+        let mut properties = HashMap::from([
+            (
+                S3Conf::ENDPOINT.to_string(),
+                "http://s3.example.com".to_string(),
+            ),
+            (S3Conf::ACCESS_KEY.to_string(), " ".to_string()),
+            (S3Conf::SECRET_KEY.to_string(), "secret-key".to_string()),
+            (S3Conf::REGION_NAME.to_string(), "cn-test-1".to_string()),
+        ]);
+
+        let err = S3Conf::with_map(properties.clone()).expect_err("empty access key must fail");
+        assert!(err.to_string().contains(S3Conf::ACCESS_KEY));
+
+        properties.insert(S3Conf::ACCESS_KEY.to_string(), "access-key".to_string());
+        properties.insert(S3Conf::SECRET_KEY.to_string(), " ".to_string());
+        let err = S3Conf::with_map(properties).expect_err("empty secret key must fail");
+        assert!(err.to_string().contains(S3Conf::SECRET_KEY));
+    }
+
+    #[test]
+    fn list_objects_v2_is_the_default() {
+        let mut properties = HashMap::new();
+        assert!(!S3Conf::uses_list_objects_v1(&properties).unwrap());
+
+        properties.insert(S3Conf::LIST_OBJECTS_VERSION.to_string(), "  ".to_string());
+        assert!(!S3Conf::uses_list_objects_v1(&properties).unwrap());
+
+        properties.insert(S3Conf::LIST_OBJECTS_VERSION.to_string(), "V2".to_string());
+        assert!(!S3Conf::uses_list_objects_v1(&properties).unwrap());
+    }
+
+    #[test]
+    fn list_objects_v1_is_supported() {
+        let properties =
+            HashMap::from([(S3Conf::LIST_OBJECTS_VERSION.to_string(), " v1 ".to_string())]);
+
+        assert!(S3Conf::uses_list_objects_v1(&properties).unwrap());
+    }
+
+    #[test]
+    fn rejects_invalid_list_objects_version() {
+        let properties =
+            HashMap::from([(S3Conf::LIST_OBJECTS_VERSION.to_string(), "v3".to_string())]);
+
+        let err = S3Conf::uses_list_objects_v1(&properties)
+            .expect_err("invalid ListObjects version must fail");
+        assert!(err.to_string().contains(S3Conf::LIST_OBJECTS_VERSION));
+    }
+
+    #[test]
+    fn rejects_invalid_optional_values() {
+        let mut properties = HashMap::from([
+            (
+                S3Conf::ENDPOINT.to_string(),
+                "http://s3.example.com".to_string(),
+            ),
+            (S3Conf::ACCESS_KEY.to_string(), "access-key".to_string()),
+            (S3Conf::SECRET_KEY.to_string(), "secret-key".to_string()),
+            (S3Conf::REGION_NAME.to_string(), "cn-test-1".to_string()),
+            (S3Conf::FORCE_PATH_STYLE.to_string(), "maybe".to_string()),
+        ]);
+
+        let err = S3Conf::validate(&properties).expect_err("invalid bool must fail");
+        assert!(err.to_string().contains(S3Conf::FORCE_PATH_STYLE));
+
+        properties.insert(S3Conf::FORCE_PATH_STYLE.to_string(), "true".to_string());
+        properties.insert("opendal.retry_times".to_string(), "many".to_string());
+        let err = S3Conf::validate(&properties).expect_err("invalid retry count must fail");
+        assert!(err.to_string().contains("opendal.retry_times"));
+    }
+
+    #[test]
+    fn rejects_endpoint_without_host() {
+        let properties = HashMap::from([
+            (S3Conf::ENDPOINT.to_string(), "http://".to_string()),
+            (S3Conf::ACCESS_KEY.to_string(), "access-key".to_string()),
+            (S3Conf::SECRET_KEY.to_string(), "secret-key".to_string()),
+            (S3Conf::REGION_NAME.to_string(), "cn-test-1".to_string()),
+        ]);
+
+        let err = S3Conf::validate(&properties).expect_err("endpoint without host must fail");
+        assert!(err.to_string().contains(S3Conf::ENDPOINT));
     }
 }

--- a/crates/common/curvine-ufs-api/src/conf.rs
+++ b/crates/common/curvine-ufs-api/src/conf.rs
@@ -124,6 +124,9 @@ impl S3Conf {
     pub const ACCESS_KEY: &'static str = "s3.credentials.access";
     pub const SECRET_KEY: &'static str = "s3.credentials.secret";
     pub const REGION_NAME: &'static str = "s3.region_name";
+    pub const LEGACY_ACCESS_KEY: &'static str = "s3.access_key";
+    pub const LEGACY_SECRET_KEY: &'static str = "s3.secret_key";
+    pub const LEGACY_REGION_NAME: &'static str = "s3.region";
     pub const FORCE_PATH_STYLE: &'static str = "s3.force.path.style";
     pub const LIST_OBJECTS_VERSION: &'static str = "s3.list_objects_version";
     pub const RETRY_TIMES: &'static str = "s3.retry_times";
@@ -139,10 +142,38 @@ impl S3Conf {
     }
 
     pub fn validate(properties: &HashMap<String, String>) -> CommonResult<()> {
-        Self::with_map(properties.clone())?;
-        Self::uses_list_objects_v1(properties)?;
-        OpendalConf::from_map(properties)?;
+        let conf = Self::with_map(properties.clone())?;
+        Self::uses_list_objects_v1(&conf.properties)?;
+        OpendalConf::from_map(&conf.properties)?;
         Ok(())
+    }
+
+    /// Convert the S3 property names used by older clients into the mount schema.
+    pub fn canonicalize_properties(
+        mut properties: HashMap<String, String>,
+    ) -> CommonResult<HashMap<String, String>> {
+        for (legacy, canonical) in [
+            (Self::LEGACY_ACCESS_KEY, Self::ACCESS_KEY),
+            (Self::LEGACY_SECRET_KEY, Self::SECRET_KEY),
+            (Self::LEGACY_REGION_NAME, Self::REGION_NAME),
+        ] {
+            let Some(value) = properties.remove(legacy) else {
+                continue;
+            };
+
+            if let Some(canonical_value) = properties.get(canonical) {
+                if canonical_value != &value {
+                    return err_box!(
+                        "conflicting S3 configuration: both {} and {} are set",
+                        legacy,
+                        canonical
+                    );
+                }
+            } else {
+                properties.insert(canonical.to_string(), value);
+            }
+        }
+        Ok(properties)
     }
 
     pub fn uses_list_objects_v1(properties: &HashMap<String, String>) -> CommonResult<bool> {
@@ -172,7 +203,7 @@ impl S3Conf {
     }
 
     pub fn with_map(properties: HashMap<String, String>) -> CommonResult<Self> {
-        let map = ConfMap::new(properties);
+        let map = ConfMap::new(Self::canonicalize_properties(properties)?);
 
         Self::required_property(&map.0, Self::ENDPOINT)?;
         let endpoint_url = map.get_string(Self::ENDPOINT)?;
@@ -440,6 +471,52 @@ mod s3_conf_tests {
         properties.insert(S3Conf::SECRET_KEY.to_string(), " ".to_string());
         let err = S3Conf::with_map(properties).expect_err("empty secret key must fail");
         assert!(err.to_string().contains(S3Conf::SECRET_KEY));
+    }
+
+    #[test]
+    fn canonicalizes_legacy_s3_properties() {
+        let properties = HashMap::from([
+            (
+                S3Conf::ENDPOINT.to_string(),
+                "http://s3.example.com".to_string(),
+            ),
+            (
+                S3Conf::LEGACY_ACCESS_KEY.to_string(),
+                "access-key".to_string(),
+            ),
+            (
+                S3Conf::LEGACY_SECRET_KEY.to_string(),
+                "secret-key".to_string(),
+            ),
+            (
+                S3Conf::LEGACY_REGION_NAME.to_string(),
+                "cn-test-1".to_string(),
+            ),
+        ]);
+
+        let conf = S3Conf::with_map(properties).expect("legacy S3 configuration must work");
+        assert_eq!(conf.access_key, "access-key");
+        assert_eq!(conf.secret_key, "secret-key");
+        assert_eq!(conf.region_name, "cn-test-1");
+        assert!(!conf.properties.contains_key(S3Conf::LEGACY_ACCESS_KEY));
+        assert!(!conf.properties.contains_key(S3Conf::LEGACY_SECRET_KEY));
+        assert!(!conf.properties.contains_key(S3Conf::LEGACY_REGION_NAME));
+    }
+
+    #[test]
+    fn rejects_conflicting_legacy_and_canonical_property() {
+        let properties = HashMap::from([
+            (
+                S3Conf::LEGACY_REGION_NAME.to_string(),
+                "cn-test-1".to_string(),
+            ),
+            (S3Conf::REGION_NAME.to_string(), "cn-test-2".to_string()),
+        ]);
+
+        let err = S3Conf::canonicalize_properties(properties)
+            .expect_err("conflicting S3 property names must fail");
+        assert!(err.to_string().contains(S3Conf::LEGACY_REGION_NAME));
+        assert!(err.to_string().contains(S3Conf::REGION_NAME));
     }
 
     #[test]

--- a/curvine-cli/src/util.rs
+++ b/curvine-cli/src/util.rs
@@ -38,7 +38,7 @@ pub fn validate_path_and_configs(
     match scheme.as_deref() {
         Some("s3") => {
             validate_s3_path(path)?;
-            S3Conf::with_map(configs.clone())?;
+            S3Conf::validate(configs)?;
             Ok(())
         }
         Some(_) => Ok(()), // No special validation for other schemes

--- a/curvine-master/Cargo.toml
+++ b/curvine-master/Cargo.toml
@@ -15,7 +15,8 @@ curvine-metrics = { workspace = true }
 curvine-rocksdb = { workspace = true }
 curvine-error = { workspace = true, features = ["axum-response"] }
 curvine-data-transfer = { workspace = true, features = ["opendal-s3"] }
-curvine-unified-fs = { workspace = true, features = ["opendal-s3"] }
+curvine-unified-fs = { workspace = true }
+curvine-ufs-api = { workspace = true }
 curvine-web = { workspace = true }
 curvine-fault = { workspace = true }
 prost = { workspace = true }

--- a/curvine-master/src/master/mount/mount_manager.rs
+++ b/curvine-master/src/master/mount/mount_manager.rs
@@ -58,12 +58,19 @@ impl MountManager {
         Ok(true)
     }
 
-    fn validate_mount_config(mount: &MountInfo) -> FsResult<()> {
+    fn normalize_mount_config(mount: &mut MountInfo) -> FsResult<()> {
         let path = Path::from_str(&mount.ufs_path)?;
-        if path.scheme() != Some("s3") {
+        if !matches!(path.scheme(), Some("s3" | "s3a")) {
             return Ok(());
         }
 
+        let properties = std::mem::take(&mut mount.properties);
+        mount.properties = S3Conf::canonicalize_properties(properties).map_err(|err| {
+            FsError::common(format!(
+                "Invalid mount configuration for {}: {}",
+                mount.ufs_path, err
+            ))
+        })?;
         S3Conf::validate(&mount.properties).map_err(|err| {
             FsError::common(format!(
                 "Invalid mount configuration for {}: {}",
@@ -87,12 +94,14 @@ impl MountManager {
             Some(id) => id,
             None => self.mount_table.assign_mount_id()?,
         };
-        let mount = mnt_opt.clone().to_info(assign_id, mount_path, ufs_path);
-        Self::validate_mount_config(&mount)?;
+        let mut mount = mnt_opt.clone().to_info(assign_id, mount_path, ufs_path);
+        Self::normalize_mount_config(&mut mount)?;
         let _ = self.create_mount_point(mount_path)?;
 
+        let mut normalized_options = mnt_opt.clone();
+        normalized_options.add_properties = mount.properties;
         self.mount_table
-            .add_mount(assign_id, mount_path, ufs_path, mnt_opt)
+            .add_mount(assign_id, mount_path, ufs_path, &normalized_options)
     }
 
     fn update_mount(&self, cv_path: &str, mnt_opt: &MountOptions) -> FsResult<()> {
@@ -100,8 +109,8 @@ impl MountManager {
         let Some(existing) = self.get_mount_info(&path)? else {
             return err_box!("mount point {} not found for update", cv_path);
         };
-        let merged = existing.merge_with(mnt_opt.clone());
-        Self::validate_mount_config(&merged)?;
+        let mut merged = existing.merge_with(mnt_opt.clone());
+        Self::normalize_mount_config(&mut merged)?;
 
         self.mount_table.update_mount(merged)
     }

--- a/curvine-master/src/master/mount/mount_manager.rs
+++ b/curvine-master/src/master/mount/mount_manager.rs
@@ -20,9 +20,9 @@ use curvine_common::error::FsError;
 use curvine_common::fs::{self, CurvineURI, Path};
 use curvine_common::state::{MkdirOpts, MountInfo, MountOptions};
 use curvine_common::FsResult;
+use curvine_ufs_api::S3Conf;
 use log::info;
 use orpc::err_box;
-use std::collections::HashMap;
 
 pub struct MountManager {
     master_fs: MasterFilesystem,
@@ -58,6 +58,20 @@ impl MountManager {
         Ok(true)
     }
 
+    fn validate_mount_config(mount: &MountInfo) -> FsResult<()> {
+        let path = Path::from_str(&mount.ufs_path)?;
+        if path.scheme() != Some("s3") {
+            return Ok(());
+        }
+
+        S3Conf::validate(&mount.properties).map_err(|err| {
+            FsError::common(format!(
+                "Invalid mount configuration for {}: {}",
+                mount.ufs_path, err
+            ))
+        })
+    }
+
     /// same baseuri of ufs can only mount once
     ///
     /// ufs_uri maybe scheme://authority/xxxx/yyy,
@@ -69,12 +83,13 @@ impl MountManager {
         ufs_path: &str,
         mnt_opt: &MountOptions,
     ) -> FsResult<()> {
-        let _ = self.create_mount_point(mount_path)?;
-
         let assign_id = match mnt_id {
             Some(id) => id,
             None => self.mount_table.assign_mount_id()?,
         };
+        let mount = mnt_opt.clone().to_info(assign_id, mount_path, ufs_path);
+        Self::validate_mount_config(&mount)?;
+        let _ = self.create_mount_point(mount_path)?;
 
         self.mount_table
             .add_mount(assign_id, mount_path, ufs_path, mnt_opt)
@@ -86,6 +101,7 @@ impl MountManager {
             return err_box!("mount point {} not found for update", cv_path);
         };
         let merged = existing.merge_with(mnt_opt.clone());
+        Self::validate_mount_config(&merged)?;
 
         self.mount_table.update_mount(merged)
     }

--- a/curvine-server/tests/master_fs_test.rs
+++ b/curvine-server/tests/master_fs_test.rs
@@ -1821,6 +1821,45 @@ fn test_reject_s3_mount_without_region_before_persist() -> CommonResult<()> {
 }
 
 #[test]
+fn test_legacy_s3_mount_properties_are_canonicalized_before_persist() -> CommonResult<()> {
+    let _serial = master_fs_test_serial();
+    let (fs, js, _loader, _js2, _fs2) = setup_pair("canonicalize-legacy-s3-mount");
+    let mnt_mgr = js.mount_manager();
+    let mount_path = "/mnt/s3";
+    let mount = Path::from_str(mount_path)?;
+    let opts = MountOptions::builder()
+        .add_property("s3.endpoint_url", "http://s3.example.com")
+        .add_property("s3.access_key", "access-key")
+        .add_property("s3.secret_key", "secret-key")
+        .add_property("s3.region", "cn-test-1")
+        .build();
+
+    mnt_mgr.mount(None, mount_path, "s3://bucket/path", &opts)?;
+
+    let properties = &mnt_mgr
+        .get_mount_info(&mount)?
+        .expect("mount must be stored")
+        .properties;
+    assert_eq!(
+        properties.get("s3.region_name").map(String::as_str),
+        Some("cn-test-1")
+    );
+    assert_eq!(
+        properties.get("s3.credentials.access").map(String::as_str),
+        Some("access-key")
+    );
+    assert_eq!(
+        properties.get("s3.credentials.secret").map(String::as_str),
+        Some("secret-key")
+    );
+    assert!(!properties.contains_key("s3.region"));
+    assert!(!properties.contains_key("s3.access_key"));
+    assert!(!properties.contains_key("s3.secret_key"));
+    assert!(fs.exists(mount_path)?);
+    Ok(())
+}
+
+#[test]
 fn test_reject_invalid_s3_mount_config_before_persist() -> CommonResult<()> {
     let _serial = master_fs_test_serial();
     let (fs, js, _loader, _js2, _fs2) = setup_pair("reject-invalid-s3-mount-config");

--- a/curvine-server/tests/master_fs_test.rs
+++ b/curvine-server/tests/master_fs_test.rs
@@ -14,8 +14,8 @@
 
 use curvine_common::conf::{ClusterConf, MasterConf};
 use curvine_common::error::FsError;
-use curvine_common::fs::CurvineURI;
 use curvine_common::fs::RpcCode;
+use curvine_common::fs::{CurvineURI, Path};
 use curvine_common::proto::{
     CompleteFileRequest, CompleteFileResponse, CreateFileRequest, DeleteRequest,
     GetMasterInfoRequest, MkdirOptsProto, MkdirRequest, RenameRequest,
@@ -1794,6 +1794,92 @@ fn test_idempotent_unmount() -> CommonResult<()> {
     mnt_mgr.umount("/mnt/test")?;
     replay_all_then_duplicate_last(&js, &loader)?;
     assert_eq!(fs.sum_hash()?, fs2.sum_hash()?);
+    Ok(())
+}
+
+#[test]
+fn test_reject_s3_mount_without_region_before_persist() -> CommonResult<()> {
+    let _serial = master_fs_test_serial();
+    let (fs, js, _loader, _js2, _fs2) = setup_pair("reject-s3-mount-without-region");
+    let mnt_mgr = js.mount_manager();
+    let mount_path = "/mnt/s3";
+    let mount = Path::from_str(mount_path)?;
+    let opts = MountOptions::builder()
+        .add_property("s3.endpoint_url", "http://s3.example.com")
+        .add_property("s3.credentials.access", "access-key")
+        .add_property("s3.credentials.secret", "secret-key")
+        .build();
+
+    let err = mnt_mgr
+        .mount(None, mount_path, "s3://bucket/path", &opts)
+        .expect_err("S3 mount without s3.region_name must be rejected");
+
+    assert!(err.to_string().contains("s3.region_name"));
+    assert!(mnt_mgr.get_mount_info(&mount)?.is_none());
+    assert!(!fs.exists(mount_path)?);
+    Ok(())
+}
+
+#[test]
+fn test_reject_invalid_s3_mount_config_before_persist() -> CommonResult<()> {
+    let _serial = master_fs_test_serial();
+    let (fs, js, _loader, _js2, _fs2) = setup_pair("reject-invalid-s3-mount-config");
+    let mnt_mgr = js.mount_manager();
+    let mount_path = "/mnt/s3";
+    let mount = Path::from_str(mount_path)?;
+    let opts = MountOptions::builder()
+        .add_property("s3.endpoint_url", "http://s3.example.com")
+        .add_property("s3.credentials.access", "access-key")
+        .add_property("s3.credentials.secret", "secret-key")
+        .add_property("s3.region_name", "cn-test-1")
+        .add_property("s3.list_objects_version", "v3")
+        .build();
+
+    let err = mnt_mgr
+        .mount(None, mount_path, "s3://bucket/path", &opts)
+        .expect_err("invalid S3 provider configuration must be rejected");
+
+    assert!(err.to_string().contains("s3.list_objects_version"));
+    assert!(mnt_mgr.get_mount_info(&mount)?.is_none());
+    assert!(!fs.exists(mount_path)?);
+    Ok(())
+}
+
+#[test]
+fn test_reject_invalid_s3_mount_update_before_persist() -> CommonResult<()> {
+    let _serial = master_fs_test_serial();
+    let (_fs, js, _loader, _js2, _fs2) = setup_pair("reject-invalid-s3-mount-update");
+    let mnt_mgr = js.mount_manager();
+    let mount_path = "/mnt/s3";
+    let mount = Path::from_str(mount_path)?;
+    let region = "cn-test-1";
+    let opts = MountOptions::builder()
+        .add_property("s3.endpoint_url", "http://s3.example.com")
+        .add_property("s3.credentials.access", "access-key")
+        .add_property("s3.credentials.secret", "secret-key")
+        .add_property("s3.region_name", region)
+        .build();
+
+    mnt_mgr.unprotected_add_mount(opts.clone().to_info(1, mount_path, "s3://bucket/path"))?;
+
+    let update = MountOptions::builder()
+        .update(true)
+        .add_property("s3.list_objects_version", "v3")
+        .build();
+    let err = mnt_mgr
+        .mount(None, mount_path, "s3://bucket/path", &update)
+        .expect_err("invalid S3 mount update must be rejected");
+
+    assert!(err.to_string().contains("s3.list_objects_version"));
+    assert_eq!(
+        mnt_mgr
+            .get_mount_info(&mount)?
+            .expect("valid S3 mount must remain stored")
+            .properties
+            .get("s3.region_name")
+            .map(String::as_str),
+        Some(region)
+    );
     Ok(())
 }
 


### PR DESCRIPTION
# Summary

Reject invalid S3/S3A mount configurations before Master persists cluster metadata, and normalize legacy S3 property names into the canonical mount schema. Existing legacy records remain readable because the OpenDAL adapter normalizes their properties at runtime.

# Issue Describe / Design

Related to None.

Root cause: mount callers could persist raw S3 properties without validating the backend configuration. Legacy `s3.region`, `s3.access_key`, and `s3.secret_key` did not match the runtime OpenDAL keys, so a mount could be accepted and later fail during operator creation with an unhelpful missing-region error.

Reproduction: create an S3 mount with a missing or malformed canonical property, or with only the legacy property names; later UFS access or Load fails when the S3 operator is created.

Fix approach: centralize S3 validation in `S3Conf`, normalize legacy names before Master persists a create or update, validate before creating the Curvine mount directory, and apply the same normalization at the OpenDAL boundary for existing persisted mounts. Conflicting legacy and canonical values fail without exposing credentials.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `crates/common/curvine-ufs-api` | Validate required S3 values, endpoint URL, numeric options, and ListObjects version; normalize legacy keys. | Invalid S3 mounts fail at mount time. |
| `curvine-master` | Normalize and validate S3/S3A mount data before persistence for create and update. | No mount directory or metadata is left by a rejected request. |
| `curvine-ufs-opendal` | Normalize legacy S3/S3A properties before creating OpenDAL operators. | Existing legacy mount records remain usable. |
| `curvine-server/tests/master_fs_test.rs` | Cover rejected create/update and canonical persistence. | Regression coverage only. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-ufs-api` | PASS | 12 tests passed. |
| `cargo test -p curvine-server --test master_fs_test` | PASS | Includes mount persistence regression coverage. |
| `cargo check -p curvine-ufs-opendal --features opendal-s3` | PASS | S3 adapter feature build. |
| `cargo fmt --check` | PASS | |
| `git diff --check` | PASS | |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None
