### PR TITLE
fix(fuse): append at full block boundaries (#1291)

### DIFF
--- a/crates/client/curvine-client-core/src/file/fs_writer_base.rs
+++ b/crates/client/curvine-client-core/src/file/fs_writer_base.rs
@@ -50,6 +50,10 @@ pub struct FsWriterBase {
     durable_blocks: FastHashSet<i64>,
 }
 
+fn needs_append_block(file_blocks: &WriteFileBlocks, file_len: i64, pos: i64) -> bool {
+    pos > file_len || (pos == file_len && file_blocks.get_block(pos).is_none())
+}
+
 impl FsWriterBase {
     pub fn new(fs_context: Arc<FsContext>, path: Path, status: FileBlocks, pos: i64) -> Self {
         let fs_client = FsClient::new(fs_context.clone());
@@ -453,7 +457,7 @@ impl FsWriterBase {
             return err_box!("Cannot seek to negative position: {}", pos);
         } else if pos == self.pos() {
             return Ok(());
-        } else if pos > self.len {
+        } else if needs_append_block(&self.file_blocks, self.len, pos) {
             self.pos = pos;
             self.update_writer(None, true).await?;
             return Ok(());
@@ -562,5 +566,32 @@ impl FsWriterBase {
         );
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::needs_append_block;
+    use curvine_model::{
+        ExtendedBlock, FileBlocks, FileStatus, FileType, LocatedBlock, StorageType, WriteFileBlocks,
+    };
+
+    #[test]
+    fn append_at_full_block_boundary_needs_a_new_block() {
+        let block_size = 128 * 1024 * 1024;
+        let blocks = WriteFileBlocks::new(FileBlocks::new(
+            FileStatus {
+                len: block_size,
+                block_size,
+                ..Default::default()
+            },
+            vec![LocatedBlock::new(
+                ExtendedBlock::new(1, block_size, StorageType::Disk, FileType::File),
+                Vec::new(),
+            )],
+        ));
+
+        assert!(needs_append_block(&blocks, block_size, block_size));
+        assert!(!needs_append_block(&blocks, block_size - 1, block_size - 1));
     }
 }


### PR DESCRIPTION
# Summary

Fix Curvine FUSE writes that begin exactly at the logical EOF of a fully populated block. Previously, the writer looked up that offset as if it belonged to the previous block and returned `EIO`; it now follows the existing append path and allocates the next block when no block locator covers the EOF position.

# Issue Describe / Design

Related to #1291

## Root cause

`WriteFileBlocks::get_block` uses half-open block ranges and advances when `range.end <= pos`. At `pos == file_len == block_size`, a file with one full block has no locator for the next byte. `FsWriterBase::seek` only treated `pos > file_len` as an append, then called `get_block_check(pos)` for the equality case. That lookup failed and surfaced as FUSE `EIO`.

## Reproduction steps

1. Create a 128 MiB file, equal to the Curvine block size.
2. Write one 4 KiB page at offset 128 MiB.
3. Before this change, FUSE logs `Not found block for pos 134217728` and returns `EIO` on close.

## Fix approach

Use a local predicate for append allocation: preserve the existing `pos > file_len` behavior and additionally append only when `pos == file_len` has no block locator. A partial final block still accepts an EOF write through the existing in-block path; sparse writes keep their current behavior.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `crates/client/curvine-client-core/src/file/fs_writer_base.rs` | Allocate the next block for an EOF seek with no covering block locator; add a boundary regression test. | Fixes full-block append failure. Partial-block random writes and sparse writes are unchanged. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo fmt --all -- --check` | PASS | No formatting changes required. |
| `cargo test -p curvine-client-core append_at_full_block_boundary_needs_a_new_block` | PASS | Covers 128 MiB full-block boundary and partial-block EOF behavior. |
| `cargo test -p curvine-client-core` | PASS | 21 unit tests and 5 integration tests passed. |
| Local FUSE 128 MiB boundary reproduction | Reproduced before fix | Fixed-image deployment and repeat run are pending. |

# Dependencies

- Related PRs: None
- Related issues: #1291
- Blocks / blocked by: Local image packaging and cluster regression verification
