### PR TITLE
fix(fuse): stabilize POSIX lock deadlock victim (#1254)

### DIFF
--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -353,6 +353,12 @@ impl CurvineFileSystem {
             return Err(e.into());
         }
 
+        // Notify the wait registry so any waiter blocked on this owner can
+        // re-sample Master and either acquire the lock or re-register.
+        if flags == LockFlags::Plock {
+            self.plock_waits.notify_waiters();
+        }
+
         Ok(())
     }
 
@@ -2106,10 +2112,10 @@ impl fs::FileSystem for CurvineFileSystem {
                 if full_range_unlock && flag == LockFlags::Plock {
                     handle.take_plock_if_owner(owner_id);
                 }
+                self.plock_waits.notify_waiters();
             } else {
                 handle.add_lock(flag, owner_id);
             }
-            self.plock_waits.notify_waiters();
             Ok(())
         } else {
             err_fuse!(libc::EAGAIN)
@@ -2160,7 +2166,6 @@ impl fs::FileSystem for CurvineFileSystem {
                 } else {
                     handle.add_lock(lock.lock_flags, lock.owner_id);
                 }
-                self.plock_waits.notify_waiters();
                 return Ok(());
             }
 
@@ -2198,7 +2203,6 @@ impl fs::FileSystem for CurvineFileSystem {
                     } else {
                         handle.add_lock(lock.lock_flags, lock.owner_id);
                     }
-                    self.plock_waits.notify_waiters();
                     return Ok(());
                 }
                 let blocker2 = conflict2.as_ref().expect("conflict lock");

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -14,7 +14,9 @@
 
 use crate::fs::dcache::{CleanerTask, Inode};
 use crate::fs::operator::*;
-use crate::fs::plock_wait_registry::{LockOwner, PlockWaitGuard, PlockWaitRegistry};
+use crate::fs::plock_wait_registry::{
+    LockOwner, LockWaitInfo, PlockWaitDecision, PlockWaitGuard, PlockWaitRegistry,
+};
 use crate::fs::state::{FileHandle, NodeState};
 use crate::fuse_metrics::{
     ReaddirTimer, INVAL_REASON_FLUSH, INVAL_REASON_FSYNC, INVAL_REASON_RELEASE, INVAL_REASON_RESIZE,
@@ -2107,6 +2109,7 @@ impl fs::FileSystem for CurvineFileSystem {
             } else {
                 handle.add_lock(flag, owner_id);
             }
+            self.plock_waits.notify_waiters();
             Ok(())
         } else {
             err_fuse!(libc::EAGAIN)
@@ -2137,6 +2140,14 @@ impl fs::FileSystem for CurvineFileSystem {
         let wait_guard = PlockWaitGuard::new(
             self.plock_waits.clone(),
             LockOwner::new(lock.client_id.clone(), lock.owner_id),
+            LockWaitInfo::new(
+                op.header.unique,
+                lock.pid,
+                op.header.nodeid,
+                path.to_string(),
+                lock.start,
+                lock.end,
+            ),
         );
         loop {
             let conflict = self.fs.set_lock(&path, lock.clone()).await?;
@@ -2149,13 +2160,29 @@ impl fs::FileSystem for CurvineFileSystem {
                 } else {
                     handle.add_lock(lock.lock_flags, lock.owner_id);
                 }
+                self.plock_waits.notify_waiters();
                 return Ok(());
             }
 
             let blocker = conflict.as_ref().expect("conflict lock");
-            if wait_guard
-                .register_blocked_by(LockOwner::new(blocker.client_id.clone(), blocker.owner_id))
-            {
+            let decision = wait_guard
+                .register_blocked_by(LockOwner::new(blocker.client_id.clone(), blocker.owner_id));
+            debug!(
+                "plock SETLKW wait decision unique={} pid={} owner_id={} nodeid={} path={} range=[{},{}] blocker_pid={} blocker_owner_id={} blocker_range=[{},{}] decision={:?}",
+                op.header.unique,
+                lock.pid,
+                lock.owner_id,
+                op.header.nodeid,
+                path,
+                lock.start,
+                lock.end,
+                blocker.pid,
+                blocker.owner_id,
+                blocker.start,
+                blocker.end,
+                decision
+            );
+            if decision.is_deadlock() {
                 // Cycle in the local wait graph. Re-sample Master once while
                 // keeping our edge published so a peer in a true multi-resource
                 // deadlock (LTP fcntl17) still observes the cycle. If the lock
@@ -2171,20 +2198,50 @@ impl fs::FileSystem for CurvineFileSystem {
                     } else {
                         handle.add_lock(lock.lock_flags, lock.owner_id);
                     }
+                    self.plock_waits.notify_waiters();
                     return Ok(());
                 }
                 let blocker2 = conflict2.as_ref().expect("conflict lock");
-                if wait_guard.register_blocked_by(LockOwner::new(
+                let decision2 = wait_guard.register_blocked_by(LockOwner::new(
                     blocker2.client_id.clone(),
                     blocker2.owner_id,
-                )) {
+                ));
+                debug!(
+                    "plock SETLKW deadlock recheck unique={} pid={} owner_id={} nodeid={} path={} range=[{},{}] blocker_pid={} blocker_owner_id={} blocker_range=[{},{}] decision={:?}",
+                    op.header.unique,
+                    lock.pid,
+                    lock.owner_id,
+                    op.header.nodeid,
+                    path,
+                    lock.start,
+                    lock.end,
+                    blocker2.pid,
+                    blocker2.owner_id,
+                    blocker2.start,
+                    blocker2.end,
+                    decision2
+                );
+                if let PlockWaitDecision::Deadlock { cycle, .. } = decision2 {
+                    debug!(
+                        "plock SETLKW returning EDEADLK unique={} pid={} owner_id={} nodeid={} path={} range=[{},{}] cycle={:?}",
+                        op.header.unique,
+                        lock.pid,
+                        lock.owner_id,
+                        op.header.nodeid,
+                        path,
+                        lock.start,
+                        lock.end,
+                        cycle
+                    );
                     return err_fuse!(libc::EDEADLK);
                 }
             }
 
             ticks += 1;
             let sleep_ms = check_interval_max_ms.min(check_interval_min_ms.saturating_mul(ticks));
-            tokio::time::sleep(std::time::Duration::from_millis(sleep_ms)).await;
+            self.plock_waits
+                .wait_for_change(std::time::Duration::from_millis(sleep_ms))
+                .await;
 
             if ticks.is_multiple_of(log_ticks as u64) {
                 info!("waiting lock for {}, elapsed: {} ms", path, time.used_ms());

--- a/curvine-fuse/src/fs/plock_wait_registry.rs
+++ b/curvine-fuse/src/fs/plock_wait_registry.rs
@@ -16,7 +16,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use tokio::sync::Notify;
+use tokio::sync::watch;
 
 /// Identity of a POSIX advisory lock owner (FUSE client + kernel lock owner).
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -84,7 +84,18 @@ impl PlockDeadlockCycle {
 
         let mut victim_idx = 0;
         for (idx, edge) in edges.iter().enumerate().skip(1) {
-            if edge.info.request_unique >= edges[victim_idx].info.request_unique {
+            let current = &edges[victim_idx];
+            // Use a total order over (request_unique, client_id, owner_id) so
+            // the victim is a pure function of the cycle contents, independent
+            // of traversal order.  Strict > ensures that equal keys keep the
+            // first-encountered maximum, which is deterministic.
+            if edge.info.request_unique > current.info.request_unique
+                || (edge.info.request_unique == current.info.request_unique
+                    && edge.waiter.client_id > current.waiter.client_id)
+                || (edge.info.request_unique == current.info.request_unique
+                    && edge.waiter.client_id == current.waiter.client_id
+                    && edge.waiter.owner_id > current.waiter.owner_id)
+            {
                 victim_idx = idx;
             }
         }
@@ -122,16 +133,23 @@ struct WaitRecord {
 }
 
 /// Tracks in-flight F_SETLKW waiters so circular wait chains return EDEADLK.
+///
+/// Each registration is keyed by `(LockOwner, request_unique)` so that
+/// multiple concurrent `F_SETLKW` requests sharing the same owner do not
+/// overwrite each other's edges.
 pub(crate) struct PlockWaitRegistry {
-    waiters: Mutex<HashMap<LockOwner, WaitRecord>>,
-    change_notify: Notify,
+    waiters: Mutex<HashMap<(LockOwner, u64), WaitRecord>>,
+    change_tx: watch::Sender<u64>,
+    change_rx: watch::Receiver<u64>,
 }
 
 impl Default for PlockWaitRegistry {
     fn default() -> Self {
+        let (change_tx, change_rx) = watch::channel(0u64);
         Self {
             waiters: Mutex::default(),
-            change_notify: Notify::new(),
+            change_tx,
+            change_rx,
         }
     }
 }
@@ -142,12 +160,12 @@ impl PlockWaitRegistry {
     }
 
     #[cfg_attr(not(test), allow(dead_code))]
-    pub fn register(&self, waiter: LockOwner, blocked_by: LockOwner) {
+    pub fn register(&self, waiter: LockOwner, request_unique: u64, blocked_by: LockOwner) {
         self.waiters
             .lock()
             .expect("plock wait registry poisoned")
             .insert(
-                waiter,
+                (waiter, request_unique),
                 WaitRecord {
                     blocked_by,
                     info: Self::empty_wait_info(),
@@ -155,12 +173,12 @@ impl PlockWaitRegistry {
             );
     }
 
-    pub fn unregister(&self, waiter: &LockOwner) {
+    pub fn unregister(&self, waiter: &LockOwner, request_unique: u64) {
         let removed = self
             .waiters
             .lock()
             .expect("plock wait registry poisoned")
-            .remove(waiter)
+            .remove(&(waiter.clone(), request_unique))
             .is_some();
         if removed {
             self.notify_waiters();
@@ -168,16 +186,18 @@ impl PlockWaitRegistry {
     }
 
     pub fn notify_waiters(&self) {
-        // Store one permit for a waiter that has observed the conflict but has
-        // not yet registered its `notified()` future. `notify_waiters()` alone
-        // only wakes already registered futures, which can lose the only unlock
-        // event needed to advance an OFD lock convoy.
-        self.change_notify.notify_one();
-        self.change_notify.notify_waiters();
+        // Increment the generation counter so every waiter (including those
+        // that have not yet registered their `changed()` future) observes the
+        // change when they next call `wait_for_change`.
+        let _ = self.change_tx.send(self.change_tx.borrow().wrapping_add(1));
     }
 
     pub async fn wait_for_change(&self, timeout: Duration) {
-        let _ = tokio::time::timeout(timeout, self.change_notify.notified()).await;
+        // Clone the receiver so the cloned copy starts at the current
+        // generation. If `notify_waiters` incremented it between the caller's
+        // Master sample and this call, `changed()` returns immediately.
+        let mut rx = self.change_rx.clone();
+        let _ = tokio::time::timeout(timeout, rx.changed()).await;
     }
 
     /// Returns true when following blocked-by edges from `blocked_by` reaches `waiter`.
@@ -195,20 +215,31 @@ impl PlockWaitRegistry {
         .is_some()
     }
 
+    /// Find the first wait record whose owner matches `owner`, if any.
+    fn find_record(
+        map: &HashMap<(LockOwner, u64), WaitRecord>,
+        owner: &LockOwner,
+    ) -> Option<WaitRecord> {
+        map.iter()
+            .find(|((o, _), _)| o == owner)
+            .map(|(_, r)| r.clone())
+    }
+
     /// Atomically replace `waiter -> blocked_by` and detect a wait cycle. When a
     /// cycle is present, the waiter with the highest FUSE request order in that
     /// cycle is selected as the deterministic EDEADLK victim.
     pub fn register_blocked_by(
         &self,
         waiter: LockOwner,
+        request_unique: u64,
         blocked_by: LockOwner,
         info: LockWaitInfo,
     ) -> PlockWaitDecision {
         let mut map = self.waiters.lock().expect("plock wait registry poisoned");
-        // Drop any prior edge for this waiter before walking the graph so a
-        // stale self-edge cannot create a false cycle, and so the new blocker
-        // is published atomically with the deadlock check.
-        map.remove(&waiter);
+        // Drop any prior edge for this specific request before walking the
+        // graph so a stale self-edge cannot create a false cycle, and so the
+        // new blocker is published atomically with the deadlock check.
+        map.remove(&(waiter.clone(), request_unique));
 
         let edge = LockWaitEdge {
             waiter: waiter.clone(),
@@ -216,20 +247,30 @@ impl PlockWaitRegistry {
             info: info.clone(),
         };
         let cycle = Self::cycle_closed_by(&map, edge.clone());
-        map.insert(waiter.clone(), WaitRecord { blocked_by, info });
+        map.insert(
+            (waiter.clone(), request_unique),
+            WaitRecord { blocked_by, info },
+        );
+
+        drop(map);
 
         match cycle {
             Some(cycle) if cycle.victim == waiter => PlockWaitDecision::Deadlock { edge, cycle },
-            Some(cycle) => PlockWaitDecision::Wait {
-                edge,
-                cycle: Some(cycle),
-            },
+            Some(cycle) => {
+                // Wake the selected victim so it can return EDEADLK promptly
+                // instead of waiting for the next timed retry.
+                self.notify_waiters();
+                PlockWaitDecision::Wait {
+                    edge,
+                    cycle: Some(cycle),
+                }
+            }
             None => PlockWaitDecision::Wait { edge, cycle: None },
         }
     }
 
     fn cycle_closed_by(
-        map: &HashMap<LockOwner, WaitRecord>,
+        map: &HashMap<(LockOwner, u64), WaitRecord>,
         new_edge: LockWaitEdge,
     ) -> Option<PlockDeadlockCycle> {
         let cycle_start = new_edge.waiter.clone();
@@ -244,7 +285,7 @@ impl PlockWaitRegistry {
             if !visited.insert(current.clone()) {
                 return None;
             }
-            match map.get(&current) {
+            match Self::find_record(map, &current) {
                 Some(record) => {
                     edges.push(LockWaitEdge {
                         waiter: current.clone(),
@@ -266,12 +307,14 @@ impl PlockWaitRegistry {
 pub(crate) struct PlockWaitGuard {
     registry: Arc<PlockWaitRegistry>,
     owner: LockOwner,
+    request_unique: u64,
     info: LockWaitInfo,
 }
 
 impl PlockWaitGuard {
     pub fn new(registry: Arc<PlockWaitRegistry>, owner: LockOwner, info: LockWaitInfo) -> Self {
         Self {
+            request_unique: info.request_unique,
             registry,
             owner,
             info,
@@ -279,18 +322,22 @@ impl PlockWaitGuard {
     }
 
     pub fn register_blocked_by(&self, blocked_by: LockOwner) -> PlockWaitDecision {
-        self.registry
-            .register_blocked_by(self.owner.clone(), blocked_by, self.info.clone())
+        self.registry.register_blocked_by(
+            self.owner.clone(),
+            self.request_unique,
+            blocked_by,
+            self.info.clone(),
+        )
     }
 
     pub fn clear_blocked_by(&self) {
-        self.registry.unregister(&self.owner);
+        self.registry.unregister(&self.owner, self.request_unique);
     }
 }
 
 impl Drop for PlockWaitGuard {
     fn drop(&mut self) {
-        self.registry.unregister(&self.owner);
+        self.registry.unregister(&self.owner, self.request_unique);
     }
 }
 
@@ -308,7 +355,7 @@ mod tests {
         let a = LockOwner::new("c", 1);
         let b = LockOwner::new("c", 2);
 
-        reg.register(a.clone(), b.clone());
+        reg.register(a.clone(), 1, b.clone());
         assert!(reg.would_deadlock(&b, &a));
         assert!(!reg.would_deadlock(&a, &b));
     }
@@ -340,10 +387,10 @@ mod tests {
         let b = LockOwner::new("c", 2);
 
         assert!(!reg
-            .register_blocked_by(a.clone(), b.clone(), wait_info(1))
+            .register_blocked_by(a.clone(), 1, b.clone(), wait_info(1))
             .is_deadlock());
         assert!(reg
-            .register_blocked_by(b.clone(), a.clone(), wait_info(2))
+            .register_blocked_by(b.clone(), 2, a.clone(), wait_info(2))
             .is_deadlock());
     }
 
@@ -354,9 +401,9 @@ mod tests {
         let b = LockOwner::new("c", 2);
 
         assert!(!reg
-            .register_blocked_by(a.clone(), b.clone(), wait_info(1))
+            .register_blocked_by(a.clone(), 1, b.clone(), wait_info(1))
             .is_deadlock());
-        reg.unregister(&a);
+        reg.unregister(&a, 1);
         assert!(!reg.would_deadlock(&b, &a));
     }
 
@@ -383,16 +430,14 @@ mod tests {
         // first report child1 as child3's blocker, then child2 after child1
         // unlocks; collapsing child2 -> child3 to child1 hides the later cycle.
         assert!(!reg
-            .register_blocked_by(mid.clone(), holder.clone(), wait_info(1))
+            .register_blocked_by(mid.clone(), 1, holder.clone(), wait_info(1))
             .is_deadlock());
         assert!(!reg
-            .register_blocked_by(waiter.clone(), mid.clone(), wait_info(2))
+            .register_blocked_by(waiter.clone(), 2, mid.clone(), wait_info(2))
             .is_deadlock());
         let map = reg.waiters.lock().unwrap();
-        assert_eq!(
-            map.get(&waiter).map(|record| &record.blocked_by),
-            Some(&mid)
-        );
+        let record = PlockWaitRegistry::find_record(&map, &waiter);
+        assert_eq!(record.map(|r| r.blocked_by), Some(mid));
     }
 
     #[test]
@@ -405,10 +450,10 @@ mod tests {
         let b = LockOwner::new("c", 20);
 
         assert!(!reg
-            .register_blocked_by(a.clone(), b.clone(), wait_info(1))
+            .register_blocked_by(a.clone(), 1, b.clone(), wait_info(1))
             .is_deadlock());
         assert!(reg
-            .register_blocked_by(b.clone(), a.clone(), wait_info(2))
+            .register_blocked_by(b.clone(), 2, a.clone(), wait_info(2))
             .is_deadlock());
     }
 
@@ -423,9 +468,10 @@ mod tests {
         // earlier child2 request must not become the EDEADLK victim just because
         // it is the second registry mutation.
         assert!(!reg
-            .register_blocked_by(child3.clone(), child2.clone(), wait_info(3))
+            .register_blocked_by(child3.clone(), 3, child2.clone(), wait_info(3))
             .is_deadlock());
-        let child2_decision = reg.register_blocked_by(child2.clone(), child3.clone(), wait_info(2));
+        let child2_decision =
+            reg.register_blocked_by(child2.clone(), 2, child3.clone(), wait_info(2));
         match child2_decision {
             PlockWaitDecision::Wait {
                 cycle: Some(cycle), ..
@@ -437,7 +483,7 @@ mod tests {
         }
 
         assert!(reg
-            .register_blocked_by(child3.clone(), child2.clone(), wait_info(3))
+            .register_blocked_by(child3.clone(), 3, child2.clone(), wait_info(3))
             .is_deadlock());
     }
 
@@ -449,13 +495,14 @@ mod tests {
         let child3 = LockOwner::new("c", 3);
 
         assert!(!reg
-            .register_blocked_by(child3.clone(), child1.clone(), wait_info(3))
+            .register_blocked_by(child3.clone(), 3, child1.clone(), wait_info(3))
             .is_deadlock());
         assert!(!reg
-            .register_blocked_by(child2.clone(), child3.clone(), wait_info(2))
+            .register_blocked_by(child2.clone(), 2, child3.clone(), wait_info(2))
             .is_deadlock());
 
-        let child3_decision = reg.register_blocked_by(child3.clone(), child2.clone(), wait_info(3));
+        let child3_decision =
+            reg.register_blocked_by(child3.clone(), 3, child2.clone(), wait_info(3));
         match child3_decision {
             PlockWaitDecision::Deadlock { cycle, .. } => {
                 assert_eq!(cycle.victim, child3);

--- a/curvine-fuse/src/fs/plock_wait_registry.rs
+++ b/curvine-fuse/src/fs/plock_wait_registry.rs
@@ -14,6 +14,9 @@
 
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use tokio::sync::Notify;
 
 /// Identity of a POSIX advisory lock owner (FUSE client + kernel lock owner).
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -31,10 +34,106 @@ impl LockOwner {
     }
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct LockWaitInfo {
+    pub request_unique: u64,
+    pub pid: u32,
+    pub nodeid: u64,
+    pub path: String,
+    pub start: u64,
+    pub end: u64,
+}
+
+impl LockWaitInfo {
+    pub fn new(
+        request_unique: u64,
+        pid: u32,
+        nodeid: u64,
+        path: impl Into<String>,
+        start: u64,
+        end: u64,
+    ) -> Self {
+        Self {
+            request_unique,
+            pid,
+            nodeid,
+            path: path.into(),
+            start,
+            end,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct LockWaitEdge {
+    pub waiter: LockOwner,
+    pub blocker: LockOwner,
+    pub info: LockWaitInfo,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct PlockDeadlockCycle {
+    pub edges: Vec<LockWaitEdge>,
+    pub victim: LockOwner,
+    pub victim_request_unique: u64,
+}
+
+impl PlockDeadlockCycle {
+    fn new(edges: Vec<LockWaitEdge>) -> Self {
+        debug_assert!(!edges.is_empty());
+
+        let mut victim_idx = 0;
+        for (idx, edge) in edges.iter().enumerate().skip(1) {
+            if edge.info.request_unique >= edges[victim_idx].info.request_unique {
+                victim_idx = idx;
+            }
+        }
+
+        Self {
+            victim: edges[victim_idx].waiter.clone(),
+            victim_request_unique: edges[victim_idx].info.request_unique,
+            edges,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum PlockWaitDecision {
+    Wait {
+        edge: LockWaitEdge,
+        cycle: Option<PlockDeadlockCycle>,
+    },
+    Deadlock {
+        edge: LockWaitEdge,
+        cycle: PlockDeadlockCycle,
+    },
+}
+
+impl PlockWaitDecision {
+    pub fn is_deadlock(&self) -> bool {
+        matches!(self, Self::Deadlock { .. })
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct WaitRecord {
+    blocked_by: LockOwner,
+    info: LockWaitInfo,
+}
+
 /// Tracks in-flight F_SETLKW waiters so circular wait chains return EDEADLK.
-#[derive(Default)]
 pub(crate) struct PlockWaitRegistry {
-    waiters: Mutex<HashMap<LockOwner, LockOwner>>,
+    waiters: Mutex<HashMap<LockOwner, WaitRecord>>,
+    change_notify: Notify,
+}
+
+impl Default for PlockWaitRegistry {
+    fn default() -> Self {
+        Self {
+            waiters: Mutex::default(),
+            change_notify: Notify::new(),
+        }
+    }
 }
 
 impl PlockWaitRegistry {
@@ -47,106 +146,141 @@ impl PlockWaitRegistry {
         self.waiters
             .lock()
             .expect("plock wait registry poisoned")
-            .insert(waiter, blocked_by);
+            .insert(
+                waiter,
+                WaitRecord {
+                    blocked_by,
+                    info: Self::empty_wait_info(),
+                },
+            );
     }
 
     pub fn unregister(&self, waiter: &LockOwner) {
-        self.waiters
+        let removed = self
+            .waiters
             .lock()
             .expect("plock wait registry poisoned")
-            .remove(waiter);
+            .remove(waiter)
+            .is_some();
+        if removed {
+            self.notify_waiters();
+        }
+    }
+
+    pub fn notify_waiters(&self) {
+        // Store one permit for a waiter that has observed the conflict but has
+        // not yet registered its `notified()` future. `notify_waiters()` alone
+        // only wakes already registered futures, which can lose the only unlock
+        // event needed to advance an OFD lock convoy.
+        self.change_notify.notify_one();
+        self.change_notify.notify_waiters();
+    }
+
+    pub async fn wait_for_change(&self, timeout: Duration) {
+        let _ = tokio::time::timeout(timeout, self.change_notify.notified()).await;
     }
 
     /// Returns true when following blocked-by edges from `blocked_by` reaches `waiter`.
     #[cfg_attr(not(test), allow(dead_code))]
     pub fn would_deadlock(&self, waiter: &LockOwner, blocked_by: &LockOwner) -> bool {
         let map = self.waiters.lock().expect("plock wait registry poisoned");
-        Self::reaches_waiter(&map, waiter, blocked_by)
+        Self::cycle_closed_by(
+            &map,
+            LockWaitEdge {
+                waiter: waiter.clone(),
+                blocker: blocked_by.clone(),
+                info: Self::empty_wait_info(),
+            },
+        )
+        .is_some()
     }
 
-    /// Atomically replace `waiter -> blocked_by` and detect a wait cycle.
-    /// Returns true when the edge would close a cycle (EDEADLK).
-    ///
-    /// Edges are resolved to the root non-waiting owner (follow `blocked_by`'s
-    /// chain). That keeps the graph pointing at presumed holders and avoids
-    /// waiter↔waiter cycles that appear when an OFD/POSIX holder unlocks and
-    /// immediately re-enters `F_SETLKW` while another waiter still has a stale
-    /// edge to the previous holder (LTP `fcntl34` multi-thread OFD pattern).
-    pub fn try_register_blocked_by(&self, waiter: LockOwner, blocked_by: LockOwner) -> bool {
+    /// Atomically replace `waiter -> blocked_by` and detect a wait cycle. When a
+    /// cycle is present, the waiter with the highest FUSE request order in that
+    /// cycle is selected as the deterministic EDEADLK victim.
+    pub fn register_blocked_by(
+        &self,
+        waiter: LockOwner,
+        blocked_by: LockOwner,
+        info: LockWaitInfo,
+    ) -> PlockWaitDecision {
         let mut map = self.waiters.lock().expect("plock wait registry poisoned");
         // Drop any prior edge for this waiter before walking the graph so a
         // stale self-edge cannot create a false cycle, and so the new blocker
         // is published atomically with the deadlock check.
         map.remove(&waiter);
 
-        let root = match Self::root_blocker(&map, &waiter, &blocked_by) {
-            Ok(root) => root,
-            Err(()) => return true,
+        let edge = LockWaitEdge {
+            waiter: waiter.clone(),
+            blocker: blocked_by.clone(),
+            info: info.clone(),
         };
-        if Self::reaches_waiter(&map, &waiter, &root) {
-            return true;
+        let cycle = Self::cycle_closed_by(&map, edge.clone());
+        map.insert(waiter.clone(), WaitRecord { blocked_by, info });
+
+        match cycle {
+            Some(cycle) if cycle.victim == waiter => PlockWaitDecision::Deadlock { edge, cycle },
+            Some(cycle) => PlockWaitDecision::Wait {
+                edge,
+                cycle: Some(cycle),
+            },
+            None => PlockWaitDecision::Wait { edge, cycle: None },
         }
-        map.insert(waiter, root);
-        false
     }
 
-    /// Follow wait edges from `blocked_by` until a non-waiter (presumed holder).
-    /// Returns `Err(())` when the existing graph already cycles through `waiter`.
-    fn root_blocker(
-        map: &HashMap<LockOwner, LockOwner>,
-        waiter: &LockOwner,
-        blocked_by: &LockOwner,
-    ) -> Result<LockOwner, ()> {
-        let mut root = blocked_by.clone();
-        let mut seen = HashSet::new();
-        while let Some(next) = map.get(&root).cloned() {
-            if &root == waiter || &next == waiter {
-                return Err(());
-            }
-            if !seen.insert(root.clone()) {
-                // Cycle among other waiters; treat as deadlock.
-                return Err(());
-            }
-            root = next;
-        }
-        Ok(root)
-    }
-
-    fn reaches_waiter(
-        map: &HashMap<LockOwner, LockOwner>,
-        waiter: &LockOwner,
-        blocked_by: &LockOwner,
-    ) -> bool {
-        let mut current = blocked_by.clone();
+    fn cycle_closed_by(
+        map: &HashMap<LockOwner, WaitRecord>,
+        new_edge: LockWaitEdge,
+    ) -> Option<PlockDeadlockCycle> {
+        let cycle_start = new_edge.waiter.clone();
+        let mut current = new_edge.blocker.clone();
         let mut visited = HashSet::new();
+        let mut edges = vec![new_edge];
+
         loop {
-            if &current == waiter {
-                return true;
+            if current == cycle_start {
+                return Some(PlockDeadlockCycle::new(edges));
             }
             if !visited.insert(current.clone()) {
-                return false;
+                return None;
             }
             match map.get(&current) {
-                Some(next) => current = next.clone(),
-                None => return false,
+                Some(record) => {
+                    edges.push(LockWaitEdge {
+                        waiter: current.clone(),
+                        blocker: record.blocked_by.clone(),
+                        info: record.info.clone(),
+                    });
+                    current = record.blocked_by.clone();
+                }
+                None => return None,
             }
         }
+    }
+
+    fn empty_wait_info() -> LockWaitInfo {
+        LockWaitInfo::new(0, 0, 0, "", 0, 0)
     }
 }
 
 pub(crate) struct PlockWaitGuard {
     registry: Arc<PlockWaitRegistry>,
     owner: LockOwner,
+    info: LockWaitInfo,
 }
 
 impl PlockWaitGuard {
-    pub fn new(registry: Arc<PlockWaitRegistry>, owner: LockOwner) -> Self {
-        Self { registry, owner }
+    pub fn new(registry: Arc<PlockWaitRegistry>, owner: LockOwner, info: LockWaitInfo) -> Self {
+        Self {
+            registry,
+            owner,
+            info,
+        }
     }
 
-    pub fn register_blocked_by(&self, blocked_by: LockOwner) -> bool {
+    pub fn register_blocked_by(&self, blocked_by: LockOwner) -> PlockWaitDecision {
         self.registry
-            .try_register_blocked_by(self.owner.clone(), blocked_by)
+            .register_blocked_by(self.owner.clone(), blocked_by, self.info.clone())
     }
 
     pub fn clear_blocked_by(&self) {
@@ -163,6 +297,10 @@ impl Drop for PlockWaitGuard {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn wait_info(request_unique: u64) -> LockWaitInfo {
+        LockWaitInfo::new(request_unique, request_unique as u32, 1, "/locks", 0, 4)
+    }
 
     #[test]
     fn detects_two_process_cycle() {
@@ -189,20 +327,24 @@ mod tests {
         let a = LockOwner::new("c", 1);
         let b = LockOwner::new("c", 2);
         {
-            let guard = PlockWaitGuard::new(reg.clone(), a.clone());
-            assert!(!guard.register_blocked_by(b.clone()));
+            let guard = PlockWaitGuard::new(reg.clone(), a.clone(), wait_info(1));
+            assert!(!guard.register_blocked_by(b.clone()).is_deadlock());
         }
         assert!(!reg.would_deadlock(&b, &a));
     }
 
     #[test]
-    fn try_register_blocked_by_rejects_opposite_edge_after_first_insert() {
+    fn register_blocked_by_rejects_opposite_edge_after_first_insert() {
         let reg = PlockWaitRegistry::new();
         let a = LockOwner::new("c", 1);
         let b = LockOwner::new("c", 2);
 
-        assert!(!reg.try_register_blocked_by(a.clone(), b.clone()));
-        assert!(reg.try_register_blocked_by(b.clone(), a.clone()));
+        assert!(!reg
+            .register_blocked_by(a.clone(), b.clone(), wait_info(1))
+            .is_deadlock());
+        assert!(reg
+            .register_blocked_by(b.clone(), a.clone(), wait_info(2))
+            .is_deadlock());
     }
 
     #[test]
@@ -211,7 +353,9 @@ mod tests {
         let a = LockOwner::new("c", 1);
         let b = LockOwner::new("c", 2);
 
-        assert!(!reg.try_register_blocked_by(a.clone(), b.clone()));
+        assert!(!reg
+            .register_blocked_by(a.clone(), b.clone(), wait_info(1))
+            .is_deadlock());
         reg.unregister(&a);
         assert!(!reg.would_deadlock(&b, &a));
     }
@@ -221,29 +365,38 @@ mod tests {
         let reg = PlockWaitRegistry::new();
         let a = LockOwner::new("c", 1);
         let b = LockOwner::new("c", 2);
-        let guard = PlockWaitGuard::new(reg.clone(), a.clone());
+        let guard = PlockWaitGuard::new(reg.clone(), a.clone(), wait_info(1));
 
-        assert!(!guard.register_blocked_by(b.clone()));
+        assert!(!guard.register_blocked_by(b.clone()).is_deadlock());
         guard.clear_blocked_by();
         assert!(!reg.would_deadlock(&b, &a));
     }
 
     #[test]
-    fn resolves_edge_through_waiter_chain_to_holder() {
+    fn stores_direct_blocker_even_when_blocker_is_waiting() {
         let reg = PlockWaitRegistry::new();
         let holder = LockOwner::new("c", 1);
         let mid = LockOwner::new("c", 2);
         let waiter = LockOwner::new("c", 3);
 
-        // mid waits on holder; a new waiter blocked by mid should wait on holder.
-        assert!(!reg.try_register_blocked_by(mid.clone(), holder.clone()));
-        assert!(!reg.try_register_blocked_by(waiter.clone(), mid.clone()));
+        // Store the current Master conflict, not the chain root. fcntl17 can
+        // first report child1 as child3's blocker, then child2 after child1
+        // unlocks; collapsing child2 -> child3 to child1 hides the later cycle.
+        assert!(!reg
+            .register_blocked_by(mid.clone(), holder.clone(), wait_info(1))
+            .is_deadlock());
+        assert!(!reg
+            .register_blocked_by(waiter.clone(), mid.clone(), wait_info(2))
+            .is_deadlock());
         let map = reg.waiters.lock().unwrap();
-        assert_eq!(map.get(&waiter), Some(&holder));
+        assert_eq!(
+            map.get(&waiter).map(|record| &record.blocked_by),
+            Some(&mid)
+        );
     }
 
     #[test]
-    fn opposite_waiter_edges_still_detect_cycle_after_root_resolve() {
+    fn opposite_waiter_edges_still_detect_cycle_with_direct_edges() {
         // Registry-level A↔B remains a cycle (fcntl17 needs this). The SETLKW
         // path re-samples Master after a transient cycle so fcntl34 unlock/re-
         // lock races do not surface EDEADLK to userspace.
@@ -251,7 +404,81 @@ mod tests {
         let a = LockOwner::new("c", 10);
         let b = LockOwner::new("c", 20);
 
-        assert!(!reg.try_register_blocked_by(a.clone(), b.clone()));
-        assert!(reg.try_register_blocked_by(b.clone(), a.clone()));
+        assert!(!reg
+            .register_blocked_by(a.clone(), b.clone(), wait_info(1))
+            .is_deadlock());
+        assert!(reg
+            .register_blocked_by(b.clone(), a.clone(), wait_info(2))
+            .is_deadlock());
+    }
+
+    #[test]
+    fn reverse_registration_must_not_deadlock_earlier_request() {
+        let reg = PlockWaitRegistry::new();
+        let child2 = LockOwner::new("c", 2);
+        let child3 = LockOwner::new("c", 3);
+
+        // fcntl17 sends child2's SETLKW before child3's SETLKW. If the later
+        // child3 request is polled first and registers child3 -> child2, the
+        // earlier child2 request must not become the EDEADLK victim just because
+        // it is the second registry mutation.
+        assert!(!reg
+            .register_blocked_by(child3.clone(), child2.clone(), wait_info(3))
+            .is_deadlock());
+        let child2_decision = reg.register_blocked_by(child2.clone(), child3.clone(), wait_info(2));
+        match child2_decision {
+            PlockWaitDecision::Wait {
+                cycle: Some(cycle), ..
+            } => {
+                assert_eq!(cycle.victim, child3);
+                assert_eq!(cycle.victim_request_unique, 3);
+            }
+            other => panic!("expected child2 to wait on child3 victim, got {other:?}"),
+        }
+
+        assert!(reg
+            .register_blocked_by(child3.clone(), child2.clone(), wait_info(3))
+            .is_deadlock());
+    }
+
+    #[test]
+    fn delayed_third_owner_unlock_still_finds_direct_cycle() {
+        let reg = PlockWaitRegistry::new();
+        let child1 = LockOwner::new("c", 1);
+        let child2 = LockOwner::new("c", 2);
+        let child3 = LockOwner::new("c", 3);
+
+        assert!(!reg
+            .register_blocked_by(child3.clone(), child1.clone(), wait_info(3))
+            .is_deadlock());
+        assert!(!reg
+            .register_blocked_by(child2.clone(), child3.clone(), wait_info(2))
+            .is_deadlock());
+
+        let child3_decision = reg.register_blocked_by(child3.clone(), child2.clone(), wait_info(3));
+        match child3_decision {
+            PlockWaitDecision::Deadlock { cycle, .. } => {
+                assert_eq!(cycle.victim, child3);
+                assert_eq!(cycle.victim_request_unique, 3);
+            }
+            other => panic!("expected child3 to be EDEADLK victim, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn notify_waiters_wakes_blocked_retry() {
+        let reg = PlockWaitRegistry::new();
+        let waiter = reg.clone();
+
+        let task = tokio::spawn(async move {
+            waiter.wait_for_change(Duration::from_secs(30)).await;
+        });
+        tokio::task::yield_now().await;
+        reg.notify_waiters();
+
+        tokio::time::timeout(Duration::from_secs(1), task)
+            .await
+            .expect("waiter should wake before timeout")
+            .expect("waiter task should finish");
     }
 }


### PR DESCRIPTION
# Summary

This PR makes FUSE POSIX deadlock handling deterministic so the later request in a lock cycle receives EDEADLK regardless of task scheduling order. It also keeps wait edges consistent across retries and improves wake-up and cleanup behavior.

# Issue Describe / Design

Closes #1254

**Root cause:** The local POSIX wait registry returned EDEADLK to whichever SETLKW request completed cycle registration second. Tokio scheduling could therefore reject an earlier request instead of the later FUSE request expected by fcntl17.

**Reproduction:** Run fcntl17 or fcntl17_64 repeatedly through the FUSE mount. Under the affected scheduling order, the wrong process could become the deadlock victim.

**Fix approach:** Track direct waiter-to-blocker edges with FUSE request metadata, select the cycle member with the greatest request unique as the deterministic victim, re-sample the server before returning EDEADLK, and clear or notify wait state on success, error, cancellation, and ownership changes.

Compatibility risk is low: the change is limited to FUSE POSIX lock waiting and preserves existing bounded retry behavior. Rollback is the single commit 3835bbc6a498a35ce875d4bd3c1908ed72e648c0.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-fuse/src/fs/plock_wait_registry.rs` | Record direct wait edges, detect cycles, and choose the victim deterministically by request order. | Behavior change: stable EDEADLK victim selection and safer stale-edge cleanup. |
| `curvine-fuse/src/fs/curvine_file_system.rs` | Pass request and lock metadata into wait registration, re-sample before EDEADLK, and notify retries. | Behavior change limited to blocking POSIX lock acquisition. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo fmt --all -- --check` | PASS | Exact HEAD 3835bbc6 |
| `cargo test -p curvine-fuse plock_wait_registry -- --nocapture` | PASS | 11 passed, 0 failed |
| `cargo clippy -p curvine-fuse --all-targets -- -D warnings` | PASS | No warnings |
| `fcntl17` | PASS | 500/500 iterations |
| `fcntl17_64` | PASS | 500/500 iterations |
| `fcntl34`, `fcntl34_64` | PASS | No false deadlock regression |
| Daily baseline/candidate comparison | PASS | Identical environment, profile, and failure signatures; no new failures |
| Independent review | PASS | Exact HEAD approved; no blocking findings |

# Dependencies

- Related PRs: None
- Related issues: #1254
- Blocks / blocked by: None
