### PR TITLE
fix(master): replay legacy rename journal entries

### DIFF
--- a/curvine-master/src/master/journal/entry.rs
+++ b/curvine-master/src/master/journal/entry.rs
@@ -14,8 +14,12 @@
 
 use crate::master::meta::inode::{InodeDir, InodeFile};
 use crate::master::meta::BlockMeta;
+use curvine_core_error::{err_box, CommonResult};
 use curvine_model::{CommitBlock, FileLock, MountInfo, SetAttrOpts};
+use curvine_runtime::common::SerdeUtils;
+use log::debug;
 use serde::{Deserialize, Serialize};
+use std::io::Cursor;
 
 #[derive(Debug, Clone)]
 pub(crate) struct CvMetadataChange {
@@ -86,9 +90,7 @@ pub struct RenameEntry {
     pub(crate) mtime: i64,
     pub(crate) flags: u32,
     /// Pre-exchange inode ids for idempotent EXCHANGE replay (0 when absent / legacy).
-    #[serde(default)]
     pub(crate) src_inode_id: i64,
-    #[serde(default)]
     pub(crate) dst_inode_id: i64,
 }
 
@@ -313,6 +315,26 @@ pub struct JournalBatch {
 }
 
 impl JournalBatch {
+    pub(crate) fn deserialize_compat(bytes: &[u8]) -> CommonResult<Self> {
+        match SerdeUtils::deserialize(bytes) {
+            Ok(batch) => Ok(batch),
+            Err(current_err) => match deserialize_legacy_batch(bytes) {
+                Ok(batch) => {
+                    debug!(
+                        "replaying legacy journal batch without rename exchange inode ids, seq_id={}",
+                        batch.seq_id
+                    );
+                    Ok(batch.into())
+                }
+                Err(legacy_err) => err_box!(
+                    "failed to deserialize journal batch with current or legacy rename schema: current={}, legacy={}",
+                    current_err,
+                    legacy_err
+                ),
+            },
+        }
+    }
+
     pub fn new(seq_id: u64) -> Self {
         Self {
             seq_id,
@@ -335,5 +357,96 @@ impl JournalBatch {
     pub fn next(&mut self) {
         self.seq_id += 1;
         self.batch.clear();
+    }
+}
+
+// bincode encodes struct fields positionally, so appending fields to RenameEntry
+// cannot be made backward compatible with serde(default). Keep this schema only
+// for replaying entries written before exchange inode ids were introduced.
+#[derive(Deserialize)]
+struct LegacyRenameEntry {
+    op_id: u64,
+    rpc_id: i64,
+    src: String,
+    dst: String,
+    mtime: i64,
+    flags: u32,
+}
+
+#[derive(Deserialize)]
+enum LegacyJournalEntry {
+    Mkdir(MkdirEntry),
+    CreateFile(CreateFileEntry),
+    ReopenFile(ReopenFileEntry),
+    OverWriteFile(OverWriteFileEntry),
+    AddBlock(AddBlockEntry),
+    CompleteFile(CompleteFileEntry),
+    Rename(LegacyRenameEntry),
+    Delete(DeleteEntry),
+    Mount(MountEntry),
+    UnMount(UnMountEntry),
+    SetAttr(SetAttrEntry),
+    Symlink(SymlinkEntry),
+    Link(LinkEntry),
+    SetLocks(SetLocksEntry),
+    Free(FreeEntry),
+    UfsApplied(UfsAppliedEntry),
+    Snapshot(SnapshotEntry),
+}
+
+#[derive(Deserialize)]
+struct LegacyJournalBatch {
+    seq_id: u64,
+    batch: Vec<LegacyJournalEntry>,
+}
+
+fn deserialize_legacy_batch(bytes: &[u8]) -> CommonResult<LegacyJournalBatch> {
+    let mut reader = Cursor::new(bytes);
+    let batch = SerdeUtils::deserialize_from(&mut reader)?;
+    if reader.position() != bytes.len() as u64 {
+        return err_box!("legacy journal batch has trailing bytes");
+    }
+    Ok(batch)
+}
+
+impl From<LegacyJournalBatch> for JournalBatch {
+    fn from(batch: LegacyJournalBatch) -> Self {
+        Self {
+            seq_id: batch.seq_id,
+            batch: batch.batch.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<LegacyJournalEntry> for JournalEntry {
+    fn from(entry: LegacyJournalEntry) -> Self {
+        match entry {
+            LegacyJournalEntry::Mkdir(entry) => Self::Mkdir(entry),
+            LegacyJournalEntry::CreateFile(entry) => Self::CreateFile(entry),
+            LegacyJournalEntry::ReopenFile(entry) => Self::ReopenFile(entry),
+            LegacyJournalEntry::OverWriteFile(entry) => Self::OverWriteFile(entry),
+            LegacyJournalEntry::AddBlock(entry) => Self::AddBlock(entry),
+            LegacyJournalEntry::CompleteFile(entry) => Self::CompleteFile(entry),
+            LegacyJournalEntry::Rename(entry) => Self::Rename(RenameEntry {
+                op_id: entry.op_id,
+                rpc_id: entry.rpc_id,
+                src: entry.src,
+                dst: entry.dst,
+                mtime: entry.mtime,
+                flags: entry.flags,
+                src_inode_id: 0,
+                dst_inode_id: 0,
+            }),
+            LegacyJournalEntry::Delete(entry) => Self::Delete(entry),
+            LegacyJournalEntry::Mount(entry) => Self::Mount(entry),
+            LegacyJournalEntry::UnMount(entry) => Self::UnMount(entry),
+            LegacyJournalEntry::SetAttr(entry) => Self::SetAttr(entry),
+            LegacyJournalEntry::Symlink(entry) => Self::Symlink(entry),
+            LegacyJournalEntry::Link(entry) => Self::Link(entry),
+            LegacyJournalEntry::SetLocks(entry) => Self::SetLocks(entry),
+            LegacyJournalEntry::Free(entry) => Self::Free(entry),
+            LegacyJournalEntry::UfsApplied(entry) => Self::UfsApplied(entry),
+            LegacyJournalEntry::Snapshot(entry) => Self::Snapshot(entry),
+        }
     }
 }

--- a/curvine-master/src/master/journal/journal_loader.rs
+++ b/curvine-master/src/master/journal/journal_loader.rs
@@ -28,7 +28,6 @@ use curvine_raft::conf::JournalConfExt;
 use curvine_raft::proto::raft::{AppliedIndex, FsmState, SnapshotData};
 use curvine_raft::raft::storage::{AppStorage, ApplyMsg, LogStorage, RocksLogStorage};
 use curvine_raft::raft::{RaftClient, RaftResult, RaftUtils};
-use curvine_runtime::common::SerdeUtils;
 use curvine_runtime::common::{FileUtils, LocalTime, TimeSpent};
 use curvine_runtime::runtime::{RpcRuntime, Runtime};
 use curvine_runtime::sync::channel::{AsyncChannel, AsyncReceiver, AsyncSender, CallChannel};
@@ -231,7 +230,7 @@ impl JournalLoader {
             return Ok(());
         }
 
-        let batch: JournalBatch = SerdeUtils::deserialize(&entry.data)?;
+        let batch = JournalBatch::deserialize_compat(&entry.data)?;
         let batch_len = batch.len();
         let mut snapshot = None;
         let mut applied = Self::build_applied(entry);

--- a/curvine-master/src/master/journal/mod.rs
+++ b/curvine-master/src/master/journal/mod.rs
@@ -29,3 +29,7 @@ pub use self::sender_task::SenderTask;
 
 mod ufs_loader;
 pub use self::ufs_loader::UfsLoader;
+
+#[cfg(test)]
+#[path = "tests/journal_entry_compat_test.rs"]
+mod journal_entry_compat_test;

--- a/curvine-master/src/master/journal/tests/journal_entry_compat_test.rs
+++ b/curvine-master/src/master/journal/tests/journal_entry_compat_test.rs
@@ -1,0 +1,138 @@
+// Copyright 2026 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+use curvine_runtime::common::SerdeUtils;
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct LegacyRenameEntry {
+    op_id: u64,
+    rpc_id: i64,
+    src: String,
+    dst: String,
+    mtime: i64,
+    flags: u32,
+}
+
+#[derive(Serialize)]
+enum LegacyJournalEntry {
+    Mkdir(MkdirEntry),
+    CreateFile(CreateFileEntry),
+    ReopenFile(ReopenFileEntry),
+    OverWriteFile(OverWriteFileEntry),
+    AddBlock(AddBlockEntry),
+    CompleteFile(CompleteFileEntry),
+    Rename(LegacyRenameEntry),
+    Delete(DeleteEntry),
+    Mount(MountEntry),
+    UnMount(UnMountEntry),
+    SetAttr(SetAttrEntry),
+    Symlink(SymlinkEntry),
+    Link(LinkEntry),
+    SetLocks(SetLocksEntry),
+    Free(FreeEntry),
+    UfsApplied(UfsAppliedEntry),
+    Snapshot(SnapshotEntry),
+}
+
+#[derive(Serialize)]
+struct LegacyJournalBatch {
+    seq_id: u64,
+    batch: Vec<LegacyJournalEntry>,
+}
+
+#[test]
+fn legacy_rename_batch_uses_zero_exchange_inode_ids() {
+    let legacy = LegacyJournalBatch {
+        seq_id: 42,
+        batch: vec![
+            LegacyJournalEntry::Rename(LegacyRenameEntry {
+                op_id: 7,
+                rpc_id: 9,
+                src: "/src".to_string(),
+                dst: "/dst".to_string(),
+                mtime: 11,
+                flags: 0,
+            }),
+            LegacyJournalEntry::Delete(DeleteEntry {
+                op_id: 8,
+                rpc_id: 10,
+                path: "/deleted".to_string(),
+                mtime: 12,
+            }),
+        ],
+    };
+    let bytes = SerdeUtils::serialize(&legacy).unwrap();
+
+    assert!(SerdeUtils::deserialize::<JournalBatch>(&bytes).is_err());
+
+    let batch = JournalBatch::deserialize_compat(&bytes).unwrap();
+    assert_eq!(batch.seq_id, 42);
+    let JournalEntry::Rename(entry) = &batch.batch[0] else {
+        panic!("expected rename journal entry");
+    };
+    assert_eq!(entry.op_id, 7);
+    assert_eq!(entry.src_inode_id, 0);
+    assert_eq!(entry.dst_inode_id, 0);
+    let JournalEntry::Delete(entry) = &batch.batch[1] else {
+        panic!("expected delete journal entry");
+    };
+    assert_eq!(entry.op_id, 8);
+    assert_eq!(entry.path, "/deleted");
+}
+
+#[test]
+fn current_rename_batch_keeps_exchange_inode_ids() {
+    let current = JournalBatch {
+        seq_id: 43,
+        batch: vec![JournalEntry::Rename(RenameEntry {
+            op_id: 8,
+            rpc_id: 10,
+            src: "/src".to_string(),
+            dst: "/dst".to_string(),
+            mtime: 12,
+            flags: 2,
+            src_inode_id: 100,
+            dst_inode_id: 200,
+        })],
+    };
+    let bytes = SerdeUtils::serialize(&current).unwrap();
+
+    let batch = JournalBatch::deserialize_compat(&bytes).unwrap();
+    let JournalEntry::Rename(entry) = &batch.batch[0] else {
+        panic!("expected rename journal entry");
+    };
+    assert_eq!(entry.src_inode_id, 100);
+    assert_eq!(entry.dst_inode_id, 200);
+}
+
+#[test]
+fn legacy_rename_batch_rejects_trailing_bytes() {
+    let legacy = LegacyJournalBatch {
+        seq_id: 44,
+        batch: vec![LegacyJournalEntry::Rename(LegacyRenameEntry {
+            op_id: 9,
+            rpc_id: 11,
+            src: "/src".to_string(),
+            dst: "/dst".to_string(),
+            mtime: 13,
+            flags: 0,
+        })],
+    };
+    let mut bytes = SerdeUtils::serialize(&legacy).unwrap();
+    bytes.extend_from_slice(&[0, 0, 0, 0]);
+
+    assert!(JournalBatch::deserialize_compat(&bytes).is_err());
+}

--- a/curvine-master/src/master/journal/tests/journal_entry_compat_test.rs
+++ b/curvine-master/src/master/journal/tests/journal_entry_compat_test.rs
@@ -27,6 +27,7 @@ struct LegacyRenameEntry {
 }
 
 #[derive(Serialize)]
+#[allow(dead_code)]
 enum LegacyJournalEntry {
     Mkdir(MkdirEntry),
     CreateFile(CreateFileEntry),


### PR DESCRIPTION
# Summary

Restore compatibility for journal batches written before `RenameEntry` gained exchange inode IDs, allowing upgraded Masters to replay historical Raft entries.

# Issue Describe / Design

No existing issue.

Root cause: bincode serializes struct fields positionally. Appending two fields to the persisted `RenameEntry` made pre-change journal batches fail decoding during Master recovery; `serde(default)` cannot repair this binary layout.

Fix approach: decode the current format first. Only on failure, decode a narrowly scoped legacy batch schema with the old Rename layout and map its absent IDs to zero. The legacy decoder must consume all bytes, so corrupt or incompatible data cannot be silently accepted.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `journal/entry.rs` | Add strict legacy Rename batch decoder and conversion. | Historical Rename entries replay with zero exchange IDs; current format is unchanged. |
| `journal/journal_loader.rs` | Use compatibility decoding for journal batches. | Recovery accepts compatible historical entries. |
| `journal/tests/journal_entry_compat_test.rs` | Cover legacy, current, and trailing-byte cases. | Test only. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo fmt --all -- --check` | PASS | |
| `cargo test -p curvine-master --lib journal_entry_compat_test` | PASS | 3 tests. |
| Master rolling recovery | PASS | All 3 Masters reached Ready; a restarted Master restored its snapshot and replayed 5,293 journal entries. |
| Java JAR E2E | PASS | Used `/home/service/var/curvine-hadoop-0.2.2.jar` against live Master IPs: S3 cache-mode mount/query/unmount and Load submit/wait succeeded. |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None