### PR TITLE
fix(java-sdk): route load client through transfer (#1288)

### DIFF
--- a/crates/sdk/curvine-sdk-core/src/filesystem_conf.rs
+++ b/crates/sdk/curvine-sdk-core/src/filesystem_conf.rs
@@ -316,4 +316,44 @@ mod tests {
             vec!["transfer-0:9010", "transfer-1:9010"]
         );
     }
+
+    #[test]
+    fn parses_transfer_routing_from_java_toml() {
+        let conf = FilesystemConf::from_str(
+            r#"
+                master_addrs = "master-0:8995"
+                client_hostname = "java-client"
+                io_threads = 16
+                worker_threads = 16
+                replicas = 1
+                block_size = "128MB"
+                write_chunk_size = "128KB"
+                write_chunk_num = 8
+                read_chunk_size = "128KB"
+                read_chunk_num = 8
+                read_parallel = 1
+                read_slice_size = "0"
+                read_ahead_len = "0"
+                drop_cache_len = "1MB"
+                storage_type = "disk"
+                ttl_ms = "0"
+                ttl_action = "none"
+                small_file_size = "4MB"
+                large_file_size = "10GB"
+
+                [transfer]
+                enabled = true
+                endpoints = ["transfer-0:9010", "transfer-1:9010"]
+            "#,
+        )
+        .unwrap();
+
+        let cluster = conf.into_cluster_conf().unwrap();
+
+        assert!(cluster.transfer.enabled);
+        assert_eq!(
+            cluster.transfer.endpoints,
+            vec!["transfer-0:9010", "transfer-1:9010"]
+        );
+    }
 }

--- a/crates/sdk/curvine-sdk-core/src/filesystem_conf.rs
+++ b/crates/sdk/curvine-sdk-core/src/filesystem_conf.rs
@@ -14,7 +14,7 @@
 
 #![allow(clippy::should_implement_trait)]
 
-use curvine_config::{ClientConf, ClusterConf};
+use curvine_config::{ClientConf, ClusterConf, TransferConf};
 use curvine_core_error::{err_box, try_err};
 use curvine_error::FsResult;
 use curvine_net::net::InetAddr;
@@ -116,6 +116,17 @@ pub struct FilesystemConf {
     pub large_file_size: String,
     pub max_read_parallel: i64,
     pub sequential_read_threshold: u64,
+
+    /// Client-side Transfer routing only. Service-side store and scheduler settings remain
+    /// owned by the Transfer process configuration.
+    pub transfer: TransferClientConf,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(default)]
+pub struct TransferClientConf {
+    pub enabled: bool,
+    pub endpoints: Vec<String>,
 }
 
 impl FilesystemConf {
@@ -272,9 +283,37 @@ impl FilesystemConf {
         let mut cluster = ClusterConf {
             client,
             log,
+            transfer: TransferConf {
+                enabled: self.transfer.enabled,
+                endpoints: self.transfer.endpoints,
+                ..Default::default()
+            },
             ..Default::default()
         };
         cluster.client.init()?;
+        cluster.transfer.init()?;
         Ok(cluster)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{FilesystemConf, TransferClientConf};
+
+    #[test]
+    fn keeps_transfer_routing_in_cluster_conf() {
+        let mut conf = FilesystemConf::with_master_addrs(["master-0:8995"]).unwrap();
+        conf.transfer = TransferClientConf {
+            enabled: true,
+            endpoints: vec!["transfer-0:9010".to_string(), "transfer-1:9010".to_string()],
+        };
+
+        let cluster = conf.into_cluster_conf().unwrap();
+
+        assert!(cluster.transfer.enabled);
+        assert_eq!(
+            cluster.transfer.endpoints,
+            vec!["transfer-0:9010", "transfer-1:9010"]
+        );
     }
 }

--- a/curvine-libsdk/README.md
+++ b/curvine-libsdk/README.md
@@ -113,6 +113,32 @@ JDK **8**, Maven **≥ 3.8.1**. From workspace root, **`make build`** (with **`j
 
 **`cannot allocate memory in static TLS block`** (large JNI `.so` + glibc): load from a real **`build/dist/lib`** path first (`CurvineNative` scans `java.library.path` entries); if it still fails, try preloading **`LD_PRELOAD`** with the same **`libcurvine_libsdk_<os>_<arch>_64.so`**, or use a host/OS image validated for Curvine JNI.
 
+### Transfer load routing
+
+When the cluster has Transfer enabled, configure the Java client with the same switch and the
+reachable Transfer service addresses. `CurvineLoadClient` then keeps its existing submit/status/
+cancel API while routing those requests to Transfer instead of the legacy Master Job API:
+
+```java
+Configuration conf = new Configuration();
+conf.set("fs.cv.master_addrs", "master-0:8995,master-1:8995");
+conf.set("fs.cv.transfer.enabled", "true");
+conf.set("fs.cv.transfer.endpoints", "transfer-0:9010,transfer-1:9010");
+
+try (CurvineLoadClient client = CurvineLoadClient.from(conf)) {
+    LoadJobResult job = client.submitLoad(LoadJobRequest.builder()
+            .sourcePath("s3://bucket/model/v1")
+            .targetPath("/bucket/model/v1")
+            .build());
+    LoadJobStatus status = client.getJobStatus(job.getJobId());
+}
+```
+
+`fs.cv.transfer.endpoints` is a comma-separated list and is independent from Master addresses.
+It must point to the externally reachable Transfer service endpoint; the client does not infer it
+from Master nodes. With `fs.cv.transfer.enabled=false` (the default), the same API remains
+compatible with the legacy Master LoadJob service.
+
 ---
 
 ## Local dev (without `make`)

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineLoadClient.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineLoadClient.java
@@ -36,6 +36,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * when {@code true}, requests go to the standalone Transfer service and responses
  * are mapped back to the existing {@link LoadJobResult} / {@link LoadJobStatus}
  * surface; when {@code false} (default), requests use the legacy Master LoadJob API.
+ * For a Hadoop {@link Configuration}, set {@code fs.cv.transfer.enabled=true} and
+ * {@code fs.cv.transfer.endpoints=transfer-0:9010,transfer-1:9010}. Transfer endpoints
+ * are independent from Master addresses and must be reachable from the Java process.
  *
  * <pre>{@code
  * try (CurvineLoadClient client = CurvineLoadClient.from(conf)) {

--- a/curvine-libsdk/java/src/main/java/io/curvine/FilesystemConf.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/FilesystemConf.java
@@ -91,6 +91,10 @@ public class FilesystemConf {
 
     public int sync_check_log_tick = 3;
 
+    // Transfer service routing. Endpoints are comma-separated host:port values.
+    public boolean transfer_enabled = false;
+    public String transfer_endpoints = "";
+
     public boolean enable_block_conn_pool = true;
     public int block_conn_idle_size = 128;
     public long block_conn_idle_time_ms = 60 * 1000;
@@ -130,6 +134,9 @@ public class FilesystemConf {
         }
 
         for(Field field : getClass().getDeclaredFields())  {
+            if (isTransferField(field)) {
+                continue;
+            }
             String key = String.format("%s.%s", PREFIX, field.getName());
             String value = conf.get(key);
 
@@ -156,13 +163,22 @@ public class FilesystemConf {
                     throw new RuntimeException("Unsupported Type: " + fieldType);
             }
         }
+
+        String transferEnabled = conf.get(PREFIX + ".transfer.enabled");
+        if (transferEnabled != null) {
+            transfer_enabled = Boolean.parseBoolean(transferEnabled);
+        }
+        String transferEndpoints = conf.get(PREFIX + ".transfer.endpoints");
+        if (transferEndpoints != null) {
+            transfer_endpoints = transferEndpoints;
+        }
     }
 
     public String toToml() throws IllegalAccessException {
         StringBuilder builder = new StringBuilder();
         for(Field field : getClass().getDeclaredFields()) {
             field.setAccessible(true);
-            if (Modifier.isStatic(field.getModifiers())) {
+            if (Modifier.isStatic(field.getModifiers()) || isTransferField(field)) {
                 continue;
             }
 
@@ -185,7 +201,37 @@ public class FilesystemConf {
             builder.append(String.format("%s = %s\n", field.getName(), value));
         }
 
+        builder.append("\n[transfer]\n");
+        builder.append("enabled = ").append(transfer_enabled).append("\n");
+        builder.append("endpoints = [");
+        boolean first = true;
+        for (String endpoint : transfer_endpoints.split(",")) {
+            String trimmed = endpoint.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            if (!first) {
+                builder.append(", ");
+            }
+            builder.append('"').append(escapeTomlString(trimmed)).append('"');
+            first = false;
+        }
+        builder.append("]\n");
+
         return builder.toString();
+    }
+
+    private static boolean isTransferField(Field field) {
+        return "transfer_enabled".equals(field.getName())
+                || "transfer_endpoints".equals(field.getName());
+    }
+
+    private static String escapeTomlString(String value) {
+        return value.replace("\\", "\\\\")
+                .replace("\"", "\\\"")
+                .replace("\r", "\\r")
+                .replace("\n", "\\n")
+                .replace("\t", "\\t");
     }
 
     private String getClientHostname() {
@@ -252,6 +298,8 @@ public class FilesystemConf {
                 ", sync_check_interval_max_ms=" + sync_check_interval_max_ms +
                 ", max_sync_wait_timeout_ms=" + max_sync_wait_timeout_ms +
                 ", sync_check_log_tick=" + sync_check_log_tick +
+                ", transfer_enabled=" + transfer_enabled +
+                ", transfer_endpoints='" + transfer_endpoints + '\'' +
                 ", enable_block_conn_pool=" + enable_block_conn_pool +
                 ", block_conn_idle_size=" + block_conn_idle_size +
                 ", block_conn_idle_time_ms=" + block_conn_idle_time_ms +

--- a/curvine-libsdk/java/src/test/java/io/curvine/LoadJobClientTest.java
+++ b/curvine-libsdk/java/src/test/java/io/curvine/LoadJobClientTest.java
@@ -18,6 +18,7 @@ import io.curvine.proto.GetJobStatusResponse;
 import io.curvine.proto.JobTaskProgressProto;
 import io.curvine.proto.JobTaskStateProto;
 import io.curvine.proto.SubmitJobResponse;
+import org.apache.hadoop.conf.Configuration;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -118,5 +119,19 @@ public class LoadJobClientTest {
         long start = System.nanoTime();
         CurvineLoadClient.sleepNanos(500_000L); // 0.5ms
         Assert.assertTrue(System.nanoTime() - start >= 500_000L);
+    }
+
+    @Test
+    public void filesystemConfSerializesTransferRouting() throws IllegalAccessException {
+        Configuration conf = new Configuration(false);
+        conf.set("fs.cv.master_addrs", "master-0:8995");
+        conf.set("fs.cv.transfer.enabled", "true");
+        conf.set("fs.cv.transfer.endpoints", "transfer-0:9010, transfer-1:9010");
+
+        String toml = new FilesystemConf(conf).toToml();
+
+        Assert.assertTrue(toml.contains("[transfer]"));
+        Assert.assertTrue(toml.contains("enabled = true"));
+        Assert.assertTrue(toml.contains("endpoints = [\"transfer-0:9010\", \"transfer-1:9010\"]"));
     }
 }


### PR DESCRIPTION
# Summary

Make the Java Load SDK honor the Transfer routing configuration. Java callers retain the existing submit/status/cancel API while Transfer-enabled clusters route those requests to the standalone Transfer service.

# Issue Describe / Design

Related to #1288 and the standalone Transfer architecture in #1324.

Root cause: the Java `FilesystemConf` serializer omitted the `[transfer]` section, and the JNI-side `FilesystemConf::into_cluster_conf()` constructed the default disabled Transfer configuration. Consequently, Java clients always used the legacy Master Job API even when Transfer was enabled.

The fix exposes only the client routing inputs, `enabled` and `endpoints`, and maps them into `ClusterConf`. Store, scheduler, and other service-only settings remain owned by the Transfer deployment.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-libsdk/java/.../FilesystemConf.java` | Read `fs.cv.transfer.enabled` and comma-separated `fs.cv.transfer.endpoints`; serialize them as `[transfer]`. | Transfer-enabled Java clients use Transfer; disabled clients keep legacy Master behavior. |
| `crates/sdk/curvine-sdk-core/src/filesystem_conf.rs` | Preserve Java Transfer routing settings in `ClusterConf`. | Enables existing Transfer compatibility routing in JNI. |
| `curvine-libsdk/java/.../CurvineLoadClient.java`, `curvine-libsdk/README.md` | Document the required client configuration. | No API change. |
| Java and Rust tests | Cover Java TOML serialization and Rust configuration mapping. | Regression coverage. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo fmt --check` | PASS | |
| `cargo test -p curvine-sdk-core filesystem_conf::tests::keeps_transfer_routing_in_cluster_conf` | PASS | 1 passed |
| `mvn -q -Dtest=LoadJobClientTest test` | PASS | |
| `cargo build -p curvine-libsdk --no-default-features --features java-sdk --lib` | PASS | JNI binding compiled from this change. |
| Live Java Transfer status probe | PASS | Transfer returned `JobNotFound` while Master was intentionally unreachable, proving the Java request used the Transfer endpoint. |

# Dependencies

- Related PRs: #1324
- Related issues: #1288, #1238
- Blocks / blocked by: None