### PR TITLE
fix(client): fall back to remote block reads

### DIFF
--- a/crates/client/curvine-client-core/src/block/block_reader.rs
+++ b/crates/client/curvine-client-core/src/block/block_reader.rs
@@ -184,7 +184,7 @@ impl BlockReader {
             let short_circuit = short_circuit && fs_context.is_local_worker(loc);
             let res: FsResult<ReaderAdapter> = {
                 if short_circuit {
-                    match BlockReaderLocal::new(
+                    match BlockReaderLocal::open(
                         fs_context.clone(),
                         block.clone(),
                         loc.clone(),

--- a/crates/client/curvine-client-core/src/block/block_reader.rs
+++ b/crates/client/curvine-client-core/src/block/block_reader.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::block::block_reader::ReaderAdapter::{Hole, Local, Remote};
+use crate::block::block_reader_local::LocalReaderOpen;
 use crate::block::{BlockReaderHole, BlockReaderLocal, BlockReaderRemote};
 use crate::file::FsContext;
 use curvine_core_error::CommonResult;
@@ -183,20 +184,23 @@ impl BlockReader {
             let short_circuit = short_circuit && fs_context.is_local_worker(loc);
             let res: FsResult<ReaderAdapter> = {
                 if short_circuit {
-                    let reader = BlockReaderLocal::new(
+                    match BlockReaderLocal::new(
                         fs_context.clone(),
                         block.clone(),
                         loc.clone(),
                         off,
                         len,
                     )
-                    .await?;
-                    Ok(Local(reader))
+                    .await
+                    {
+                        Ok(LocalReaderOpen::Local(reader)) => Ok(Local(reader)),
+                        Ok(LocalReaderOpen::Remote(reader)) => Ok(Remote(reader)),
+                        Err(e) => Err(e),
+                    }
                 } else {
-                    let reader =
-                        BlockReaderRemote::new(&fs_context, block.clone(), loc.clone(), off, len)
-                            .await?;
-                    Ok(Remote(reader))
+                    BlockReaderRemote::new(&fs_context, block.clone(), loc.clone(), off, len)
+                        .await
+                        .map(Remote)
                 }
             };
             match res {

--- a/crates/client/curvine-client-core/src/block/block_reader_local.rs
+++ b/crates/client/curvine-client-core/src/block/block_reader_local.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::block::BlockClient;
+use crate::block::{BlockClient, BlockReaderRemote};
 use crate::file::FsContext;
 use bytes::BytesMut;
-use curvine_core_error::{err_box, try_option};
+use curvine_core_error::err_box;
 use curvine_error::FsError;
 use curvine_error::FsResult;
 use curvine_io::LocalFile;
@@ -41,14 +41,33 @@ pub struct BlockReaderLocal {
     chunk_size: usize,
 }
 
+pub(crate) enum LocalReaderOpen {
+    Local(BlockReaderLocal),
+    Remote(BlockReaderRemote),
+}
+
+enum ReadOpenMode {
+    Local(String),
+    Remote,
+}
+
+impl ReadOpenMode {
+    fn from_path(path: Option<String>) -> Self {
+        match path {
+            Some(path) => Self::Local(path),
+            None => Self::Remote,
+        }
+    }
+}
+
 impl BlockReaderLocal {
-    pub async fn new(
+    pub(crate) async fn new(
         fs_context: Arc<FsContext>,
         block: ExtendedBlock,
         addr: WorkerAddress,
         off: i64,
         len: i64,
-    ) -> FsResult<Self> {
+    ) -> FsResult<LocalReaderOpen> {
         let req_id = Utils::req_id();
         let seq_id = 0;
 
@@ -66,8 +85,25 @@ impl BlockReaderLocal {
             )
             .await?;
 
-        let path = try_option!(read_context.path);
-        let file = LocalFile::with_read(&path, off as u64)?;
+        let path = match ReadOpenMode::from_path(read_context.path) {
+            ReadOpenMode::Local(path) => path,
+            ReadOpenMode::Remote => {
+                // The worker can reject short-circuit mode when it must synthesize a
+                // sparse logical tail. Reuse the already-open remote read session.
+                return Ok(LocalReaderOpen::Remote(BlockReaderRemote::from_opened(
+                    client, block, addr, off, len, req_id, seq_id,
+                )));
+            }
+        };
+        let file = match LocalFile::with_read(&path, off as u64) {
+            Ok(file) => file,
+            Err(e) => {
+                // Do not return a connection with an active read session to the pool.
+                let mut client = client;
+                client.clear_pool();
+                return Err(e.into());
+            }
+        };
 
         let reader = Self {
             rt: fs_context.clone_runtime(),
@@ -84,7 +120,7 @@ impl BlockReaderLocal {
             chunk_size,
         };
 
-        Ok(reader)
+        Ok(LocalReaderOpen::Local(reader))
     }
 
     fn next_seq_id(&mut self) -> i32 {
@@ -169,5 +205,26 @@ impl BlockReaderLocal {
 
     pub fn worker_address(&self) -> &WorkerAddress {
         &self.worker_address
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ReadOpenMode;
+
+    #[test]
+    fn missing_short_circuit_path_selects_remote_mode() {
+        assert!(matches!(
+            ReadOpenMode::from_path(None),
+            ReadOpenMode::Remote
+        ));
+    }
+
+    #[test]
+    fn returned_short_circuit_path_selects_local_mode() {
+        assert!(matches!(
+            ReadOpenMode::from_path(Some("/data/block".to_string())),
+            ReadOpenMode::Local(path) if path == "/data/block"
+        ));
     }
 }

--- a/crates/client/curvine-client-core/src/block/block_reader_local.rs
+++ b/crates/client/curvine-client-core/src/block/block_reader_local.rs
@@ -46,16 +46,61 @@ pub(crate) enum LocalReaderOpen {
     Remote(BlockReaderRemote),
 }
 
-enum ReadOpenMode {
-    Local(String),
-    Remote,
+enum AdoptedRead<C, L, R> {
+    Local { client: C, file: L },
+    Remote(R),
 }
 
-impl ReadOpenMode {
-    fn from_path(path: Option<String>) -> Self {
-        match path {
-            Some(path) => Self::Local(path),
-            None => Self::Remote,
+trait ReadSessionCleanup {
+    async fn finish_read(
+        &mut self,
+        block: &ExtendedBlock,
+        req_id: i64,
+        seq_id: i32,
+    ) -> FsResult<()>;
+
+    fn prevent_pool_reuse(&mut self);
+}
+
+impl ReadSessionCleanup for BlockClient {
+    async fn finish_read(
+        &mut self,
+        block: &ExtendedBlock,
+        req_id: i64,
+        seq_id: i32,
+    ) -> FsResult<()> {
+        self.read_commit(block, req_id, seq_id).await
+    }
+
+    fn prevent_pool_reuse(&mut self) {
+        self.clear_pool();
+    }
+}
+
+async fn adopt_opened_session<C, L, R, E>(
+    mut client: C,
+    path: Option<String>,
+    block: &ExtendedBlock,
+    req_id: i64,
+    seq_id: i32,
+    open_local: impl FnOnce(&str) -> Result<L, E>,
+    open_remote: impl FnOnce(C) -> R,
+) -> Result<AdoptedRead<C, L, R>, E>
+where
+    C: ReadSessionCleanup,
+{
+    let Some(path) = path else {
+        return Ok(AdoptedRead::Remote(open_remote(client)));
+    };
+
+    match open_local(&path) {
+        Ok(file) => Ok(AdoptedRead::Local { client, file }),
+        Err(e) => {
+            // Release the Worker read context promptly, but never allow a failed
+            // local open to return an uncertain session to the connection pool.
+            let _ = client.finish_read(block, req_id, seq_id + 1).await;
+            client.prevent_pool_reuse();
+            Err(e)
         }
     }
 }
@@ -85,24 +130,32 @@ impl BlockReaderLocal {
             )
             .await?;
 
-        let path = match ReadOpenMode::from_path(read_context.path) {
-            ReadOpenMode::Local(path) => path,
-            ReadOpenMode::Remote => {
-                // The worker can reject short-circuit mode when it must synthesize a
-                // sparse logical tail. Reuse the already-open remote read session.
-                return Ok(LocalReaderOpen::Remote(BlockReaderRemote::from_opened(
-                    client, block, addr, off, len, req_id, seq_id,
-                )));
-            }
-        };
-        let file = match LocalFile::with_read(&path, off as u64) {
-            Ok(file) => file,
-            Err(e) => {
-                // Do not return a connection with an active read session to the pool.
-                let mut client = client;
-                client.clear_pool();
-                return Err(e.into());
-            }
+        let opened = adopt_opened_session(
+            client,
+            read_context.path,
+            &block,
+            req_id,
+            seq_id,
+            |path| LocalFile::with_read(path, off as u64),
+            |client| {
+                BlockReaderRemote::from_opened(
+                    client,
+                    block.clone(),
+                    addr.clone(),
+                    off,
+                    len,
+                    req_id,
+                    seq_id,
+                )
+            },
+        )
+        .await?;
+
+        let (client, file) = match opened {
+            AdoptedRead::Local { client, file } => (client, file),
+            // The worker can reject short-circuit mode when it must synthesize a
+            // sparse logical tail. Reuse the already-open remote read session.
+            AdoptedRead::Remote(reader) => return Ok(LocalReaderOpen::Remote(reader)),
         };
 
         let reader = Self {
@@ -210,21 +263,99 @@ impl BlockReaderLocal {
 
 #[cfg(test)]
 mod tests {
-    use super::ReadOpenMode;
+    use super::{adopt_opened_session, AdoptedRead, ReadSessionCleanup};
+    use curvine_error::{FsError, FsResult};
+    use curvine_model::{ExtendedBlock, FileType, StorageType};
 
-    #[test]
-    fn missing_short_circuit_path_selects_remote_mode() {
-        assert!(matches!(
-            ReadOpenMode::from_path(None),
-            ReadOpenMode::Remote
-        ));
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    #[derive(Debug)]
+    struct FakeClient {
+        id: u64,
+        finish_called: Arc<AtomicBool>,
+        prevent_pool_reuse_called: Arc<AtomicBool>,
+        fail_finish: bool,
     }
 
-    #[test]
-    fn returned_short_circuit_path_selects_local_mode() {
-        assert!(matches!(
-            ReadOpenMode::from_path(Some("/data/block".to_string())),
-            ReadOpenMode::Local(path) if path == "/data/block"
-        ));
+    impl FakeClient {
+        fn new(id: u64) -> Self {
+            Self {
+                id,
+                finish_called: Arc::new(AtomicBool::new(false)),
+                prevent_pool_reuse_called: Arc::new(AtomicBool::new(false)),
+                fail_finish: false,
+            }
+        }
+    }
+
+    impl ReadSessionCleanup for FakeClient {
+        async fn finish_read(
+            &mut self,
+            _block: &ExtendedBlock,
+            _req_id: i64,
+            _seq_id: i32,
+        ) -> FsResult<()> {
+            self.finish_called.store(true, Ordering::SeqCst);
+            if self.fail_finish {
+                Err(FsError::common("injected read_commit failure"))
+            } else {
+                Ok(())
+            }
+        }
+
+        fn prevent_pool_reuse(&mut self) {
+            self.prevent_pool_reuse_called.store(true, Ordering::SeqCst);
+        }
+    }
+
+    fn test_block() -> ExtendedBlock {
+        ExtendedBlock::new(1, 4096, StorageType::Disk, FileType::File)
+    }
+
+    #[tokio::test]
+    async fn missing_short_circuit_path_adopts_the_opened_session() {
+        let opened = adopt_opened_session(
+            FakeClient::new(42),
+            None,
+            &test_block(),
+            100,
+            0,
+            |_| -> Result<(), &'static str> { panic!("local open must not be attempted") },
+            |client| client,
+        )
+        .await
+        .unwrap();
+
+        match opened {
+            AdoptedRead::Remote(client) => {
+                assert_eq!(client.id, 42);
+                assert!(!client.finish_called.load(Ordering::SeqCst));
+                assert!(!client.prevent_pool_reuse_called.load(Ordering::SeqCst));
+            }
+            AdoptedRead::Local { .. } => panic!("missing path must adopt remote mode"),
+        }
+    }
+
+    #[tokio::test]
+    async fn local_open_failure_finishes_session_and_prevents_pool_reuse() {
+        let mut client = FakeClient::new(42);
+        client.fail_finish = true;
+        let finish_called = client.finish_called.clone();
+        let prevent_pool_reuse_called = client.prevent_pool_reuse_called.clone();
+        let result = adopt_opened_session(
+            client,
+            Some("/missing/block".to_string()),
+            &test_block(),
+            100,
+            0,
+            |_| -> Result<(), &'static str> { Err("injected local open failure") },
+            |client| client,
+        )
+        .await;
+
+        assert!(matches!(result, Err("injected local open failure")));
+        assert!(finish_called.load(Ordering::SeqCst));
+        assert!(prevent_pool_reuse_called.load(Ordering::SeqCst));
     }
 }

--- a/crates/client/curvine-client-core/src/block/block_reader_local.rs
+++ b/crates/client/curvine-client-core/src/block/block_reader_local.rs
@@ -61,7 +61,7 @@ impl ReadOpenMode {
 }
 
 impl BlockReaderLocal {
-    pub(crate) async fn new(
+    pub(crate) async fn open(
         fs_context: Arc<FsContext>,
         block: ExtendedBlock,
         addr: WorkerAddress,

--- a/crates/client/curvine-client-core/src/block/block_reader_remote.rs
+++ b/crates/client/curvine-client-core/src/block/block_reader_remote.rs
@@ -56,7 +56,27 @@ impl BlockReaderRemote {
             )
             .await?;
 
-        let reader = Self {
+        Ok(Self::from_opened(
+            client,
+            block,
+            worker_address,
+            off,
+            len,
+            req_id,
+            seq_id,
+        ))
+    }
+
+    pub(crate) fn from_opened(
+        client: BlockClient,
+        block: ExtendedBlock,
+        worker_address: WorkerAddress,
+        off: i64,
+        len: i64,
+        req_id: i64,
+        seq_id: i32,
+    ) -> Self {
+        Self {
             client,
             block,
             worker_address,
@@ -65,9 +85,7 @@ impl BlockReaderRemote {
             req_id,
             seq_id,
             header: None,
-        };
-
-        Ok(reader)
+        }
     }
 
     fn next_seq_id(&mut self) -> i32 {


### PR DESCRIPTION
# Summary

Fix Curvine client reads when a local Worker declines short-circuit mode and serves the block through the remote read path instead.

Short-circuit reads normally return a local block path that the client opens directly. For sparse files created by operations such as truncate growth or fallocate, the logical block length can exceed the physical file length on the Worker. The Worker must synthesize zero-filled sparse data in that situation, so it correctly disables short-circuit mode and returns a remote read session without a local path.

The client still tried to construct `BlockReaderLocal`, treated the missing path as an initialization error, and returned `EIO` to the caller. Mapped reads could surface the same failure as `SIGBUS`. The fix reuses the already-open Worker connection as a `BlockReaderRemote` and preserves replica fallback when reader initialization fails.

# Minimal Reproducer

Run on a Curvine FUSE mount with `client.short_circuit = true` and a Worker colocated with the FUSE client:

```c
#define _GNU_SOURCE

#include <errno.h>
#include <fcntl.h>
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <sys/mman.h>
#include <sys/stat.h>
#include <sys/types.h>
#include <unistd.h>

#define FILE_SIZE 5120
#define TRUNC_SIZE 2048
#define TAIL_SIZE (FILE_SIZE - TRUNC_SIZE)

static void die(const char *operation)
{
    fprintf(stderr, "%s: %s\n", operation, strerror(errno));
    exit(EXIT_FAILURE);
}

static void write_all(int fd, const void *buffer, size_t length, off_t offset)
{
    const unsigned char *data = buffer;

    while (length > 0) {
        ssize_t written = pwrite(fd, data, length, offset);
        if (written < 0)
            die("pwrite");
        if (written == 0) {
            fprintf(stderr, "pwrite returned zero\n");
            exit(EXIT_FAILURE);
        }

        data += written;
        offset += written;
        length -= (size_t)written;
    }
}

static void read_all(int fd, void *buffer, size_t length, off_t offset)
{
    unsigned char *data = buffer;

    while (length > 0) {
        ssize_t bytes = pread(fd, data, length, offset);
        if (bytes < 0)
            die("pread");
        if (bytes == 0) {
            fprintf(stderr, "unexpected EOF at offset %lld\n",
                    (long long)offset);
            exit(EXIT_FAILURE);
        }

        data += bytes;
        offset += bytes;
        length -= (size_t)bytes;
    }
}

int main(int argc, char **argv)
{
    unsigned char initial[FILE_SIZE];
    unsigned char result[FILE_SIZE];
    unsigned char *mapping;
    int fd;
    size_t i;

    if (argc != 2) {
        fprintf(stderr, "usage: %s <file-on-curvine-mount>\n", argv[0]);
        return EXIT_FAILURE;
    }

    memset(initial, 'X', sizeof(initial));

    fd = open(argv[1], O_CREAT | O_TRUNC | O_RDWR, 0644);
    if (fd < 0)
        die("open");

    if (ftruncate(fd, FILE_SIZE) < 0)
        die("initial ftruncate");

    write_all(fd, initial, sizeof(initial), 0);

    mapping = mmap(NULL, FILE_SIZE, PROT_READ | PROT_WRITE,
                   MAP_SHARED, fd, 0);
    if (mapping == MAP_FAILED)
        die("mmap");

    memset(mapping + TRUNC_SIZE, 'Z', TAIL_SIZE);

    if (ftruncate(fd, TRUNC_SIZE) < 0)
        die("truncate down");

    if (ftruncate(fd, FILE_SIZE) < 0)
        die("truncate up");

    memset(mapping + TRUNC_SIZE, 'Y', TAIL_SIZE);

    if (msync(mapping, FILE_SIZE, MS_SYNC) < 0)
        die("msync");

    if (munmap(mapping, FILE_SIZE) < 0)
        die("munmap");

    if (fsync(fd) < 0)
        die("fsync");

    if (close(fd) < 0)
        die("close");

    fd = open(argv[1], O_RDONLY);
    if (fd < 0)
        die("reopen");

    read_all(fd, result, sizeof(result), 0);

    if (close(fd) < 0)
        die("close after read");

    for (i = 0; i < TRUNC_SIZE; i++) {
        if (result[i] != 'X') {
            fprintf(stderr,
                    "data mismatch at offset %zu: expected X, got 0x%02x\n",
                    i, result[i]);
            return EXIT_FAILURE;
        }
    }

    for (i = TRUNC_SIZE; i < FILE_SIZE; i++) {
        if (result[i] != 'Y') {
            fprintf(stderr,
                    "data mismatch at offset %zu: expected Y, got 0x%02x\n",
                    i, result[i]);
            return EXIT_FAILURE;
        }
    }

    puts("PASS: truncate/mmap data read successfully");

    if (unlink(argv[1]) < 0)
        die("unlink");

    return EXIT_SUCCESS;
}
```

Compile and run:

```bash
gcc -O2 -Wall -Wextra \
  /tmp/curvine_short_circuit_sparse.c \
  -o /tmp/curvine_short_circuit_sparse

/tmp/curvine_short_circuit_sparse \
  /mnt/curvine/short-circuit-sparse-repro
```

Before the fix, `pread`, `msync`, or a mapped access could fail with `EIO` or `SIGBUS`:

```text
pread: Input/output error
```

The Worker log shows that it selected a remote block reader because the logical length exceeded the physical block length, while the client failed when the response did not contain a short-circuit path.

After the fix, the program completes successfully:

```text
PASS: truncate/mmap data read successfully
```

# Root Cause

Reader selection was made twice with inconsistent assumptions:

1. `BlockReader::get_reader` selected `BlockReaderLocal` because short-circuit mode was enabled and the target Worker was local.
2. The Worker inspected the actual block state and disabled short-circuit mode when the logical block length exceeded the physical file length, because a direct local file read cannot synthesize the sparse tail.
3. The Worker opened a remote read session and returned `path = None`.
4. `BlockReaderLocal::new` required `path` to be present and converted `None` into an initialization error.
5. The error propagated through an inner `.await?`, bypassing the existing per-replica retry loop and reaching FUSE as `EIO`.

Simply opening a second remote connection is unsafe because the first connection already owns an active Worker read session and would otherwise be returned to the connection pool in that state. The fallback must reuse the client, request ID, sequence ID, offset, and length from the session that the Worker already opened.

# Changes

- Allow local reader initialization to return either a short-circuit reader or a remote reader.
- Reuse the already-open Worker read session when the short-circuit response does not contain a local path.
- Add `BlockReaderRemote::from_opened` so the remote adapter can adopt the existing connection and request state without issuing a duplicate open RPC.
- Keep local and remote reader initialization errors inside the per-replica retry loop instead of propagating them through an inner `.await?`.
- Prevent a connection with an active read session from returning to the pool when opening the local block file fails.
- Add unit tests for local-path and missing-path reader mode selection.

# Verification

- `cargo fmt --all -- --check`
- `cargo test -p curvine-client-core --lib`
  - 23 passed, 0 failed.
- `cargo check -p curvine-fuse`
- `cargo build --release -p curvine-fuse`
- Compile the minimal reproducer with `gcc -O2 -Wall -Wextra`.
- Run the reproducer against a Curvine FUSE mount with short-circuit reads enabled.
  - The full file is read without `EIO` or `SIGBUS`.
  - The data before the truncate boundary remains unchanged.
  - The mapped data written after truncate growth is returned correctly.
