### PR TITLE
fix(fuse): preserve referenced inodes during cache eviction

### DIFF
--- a/curvine-fuse/src/fs/dcache/dir_tree.rs
+++ b/curvine-fuse/src/fs/dcache/dir_tree.rs
@@ -1267,6 +1267,40 @@ mod test {
         );
     }
 
+    /// A failed deferred delete keeps `mark_delete` set for later retry or
+    /// persisted-state recovery. TTL cleanup must not silently discard it.
+    #[test]
+    fn clear_keeps_expired_pending_delete_until_completion() {
+        let mut tree = DirTree::default();
+        let ino = tree
+            .lookup(FUSE_ROOT_ID, "pending", file_st("pending", 900), true)
+            .unwrap()
+            .ino;
+        tree.forget(ino, 1).unwrap();
+        tree.unlink(FUSE_ROOT_ID, "pending", true).unwrap();
+        tree.get_inode_mut(ino, None).unwrap().last_access = 0;
+
+        tree.clear(|_| false);
+
+        assert!(
+            tree.pending_delete(ino),
+            "TTL cleanup must preserve pending deferred-delete state"
+        );
+        assert!(
+            tree.get_dir_check(FUSE_ROOT_ID)
+                .unwrap()
+                .is_deleted_child("pending"),
+            "the deleted-child marker must remain available for completion"
+        );
+
+        tree.clear_mark_delete(ino).unwrap();
+        tree.clear(|_| false);
+        assert!(
+            tree.get_inode(ino, None::<&str>).is_none(),
+            "completed deferred-delete state may be evicted after TTL expiry"
+        );
+    }
+
     /// Regression: unstable backend ids must not allocate fresh ids repeatedly.
     #[test]
     fn next_id_diverges_when_backend_id_unassigned() {

--- a/curvine-fuse/src/fs/dcache/dir_tree.rs
+++ b/curvine-fuse/src/fs/dcache/dir_tree.rs
@@ -1112,8 +1112,8 @@ mod test {
         assert!(t.get_inode(dst, None).is_none());
     }
 
-    /// `clear` evicts expired inodes but skips: open handles, not yet TTL-expired entries,
-    /// dirs with cached children, root.
+    /// `clear` evicts expired inodes only after the kernel lookup reference is released,
+    /// while still skipping open handles, fresh entries, directories with cached children, and root.
     #[test]
     fn clear_evicts_expired_inodes_and_respects_all_constraints() {
         use std::time::Duration;
@@ -1124,7 +1124,7 @@ mod test {
         };
         let mut t = DirTree::new(conf);
 
-        // Case 1: expired, ref_ctr=0, no handles → should be evicted
+        // Case 1: expired, ref_ctr=0, but n_lookup=1 → kept until FORGET
         // Simulates unlinked file (ref_ctr=0) while kernel still holds dentry (n_lookup=1):
         // should_unref() false, no FORGET yet, inode still in dcache.
         let f1 = t
@@ -1143,12 +1143,12 @@ mod test {
             .ino;
         // Do not zero last_access: clear() does not consult ref_ctr; expiry is last_access-based.
 
-        // Case 3: expired, ref_ctr=0, but open handle → not evicted
+        // Case 3: expired with n_lookup=0, but open handle → not evicted
         let f3 = t
             .lookup(FUSE_ROOT_ID, "f3", file_st("f3", 0), true)
             .unwrap()
             .ino;
-        t.unlink(FUSE_ROOT_ID, "f3", false).unwrap();
+        t.forget(f3, 1).unwrap();
         t.get_inode_mut(f3, None).unwrap().last_access = 0;
 
         // Case 4: ref_ctr=0 but not expired → not evicted
@@ -1159,7 +1159,7 @@ mod test {
         t.unlink(FUSE_ROOT_ID, "f4", false).unwrap();
         // last_access is fresh; within 60s TTL
 
-        // Case 5: expired empty dir, ref_ctr=0 → evicted
+        // Case 5: expired empty dir with n_lookup=1 → kept until FORGET
         let d1 = t
             .lookup(FUSE_ROOT_ID, "d1", dir_st("d1", 500), true)
             .unwrap()
@@ -1167,22 +1167,38 @@ mod test {
         t.unlink(FUSE_ROOT_ID, "d1", false).unwrap(); // like rmdir; DirEntry.children empty
         t.get_inode_mut(d1, None).unwrap().last_access = 0;
 
-        // Case 6: expired dir with ref_ctr=0 but cached children → not evicted
+        // Case 6: expired dir with n_lookup=0 but cached children → not evicted
         // Evicting would orphan cached children and break path reconstruction.
         let d2 = t
             .lookup(FUSE_ROOT_ID, "d2", dir_st("d2", 600), true)
             .unwrap()
             .ino;
         t.lookup(d2, "child", file_st("child", 0), true).unwrap(); // d2.children has "child"
-        t.get_inode_mut(d2, None).unwrap().ref_ctr = 0; // simulate unlinked dir inode
+        t.forget(d2, 1).unwrap();
         t.get_inode_mut(d2, None).unwrap().last_access = 0;
+
+        // Case 7: expired file after FORGET → evicted
+        let f5 = t
+            .lookup(FUSE_ROOT_ID, "f5", file_st("f5", 0), true)
+            .unwrap()
+            .ino;
+        t.forget(f5, 1).unwrap();
+        t.get_inode_mut(f5, None).unwrap().last_access = 0;
+
+        // Case 8: expired empty directory after FORGET → evicted
+        let d3 = t
+            .lookup(FUSE_ROOT_ID, "d3", dir_st("d3", 800), true)
+            .unwrap()
+            .ino;
+        t.forget(d3, 1).unwrap();
+        t.get_inode_mut(d3, None).unwrap().last_access = 0;
 
         // Run clear; treat f3 as having an open handle
         t.clear(|ino| ino == f3);
 
         assert!(
-            t.get_inode(f1, None::<&str>).is_none(),
-            "f1 should be evicted"
+            t.get_inode(f1, None::<&str>).is_some(),
+            "f1 should stay until the kernel sends FORGET"
         );
         assert!(
             t.get_inode(f2, None::<&str>).is_some(),
@@ -1197,12 +1213,20 @@ mod test {
             "f4 should stay (not expired)"
         );
         assert!(
-            t.get_inode(d1, None::<&str>).is_none(),
-            "d1 should be evicted (empty dir)"
+            t.get_inode(d1, None::<&str>).is_some(),
+            "d1 should stay until the kernel sends FORGET"
         );
         assert!(
             t.get_inode(d2, None::<&str>).is_some(),
             "d2 should stay (has cached children)"
+        );
+        assert!(
+            t.get_inode(f5, None::<&str>).is_none(),
+            "f5 should be evicted after FORGET"
+        );
+        assert!(
+            t.get_inode(d3, None::<&str>).is_none(),
+            "d3 should be evicted after FORGET"
         );
         assert!(
             t.get_inode(FUSE_ROOT_ID, None::<&str>).is_some(),
@@ -1215,12 +1239,31 @@ mod test {
             .lookup(FUSE_ROOT_ID, "fx", file_st("fx", 0), true)
             .unwrap()
             .ino;
-        t0.unlink(FUSE_ROOT_ID, "fx", false).unwrap();
+        t0.forget(fx, 1).unwrap();
         t0.get_inode_mut(fx, None).unwrap().last_access = 0;
         t0.clear(|_| false);
         assert!(
             t0.get_inode(fx, None::<&str>).is_none(),
             "cache_ttl=0 still evicts when last_access + ttl <= now"
+        );
+    }
+
+    /// The kernel may continue addressing an inode by nodeid until it sends FORGET.
+    /// TTL expiry alone must not discard that mapping.
+    #[test]
+    fn clear_keeps_expired_inode_with_kernel_lookup_reference() {
+        let mut tree = DirTree::default();
+        let ino = tree
+            .lookup(FUSE_ROOT_ID, "held", dir_st("held", 700), true)
+            .unwrap()
+            .ino;
+        tree.get_inode_mut(ino, None).unwrap().last_access = 0;
+
+        tree.clear(|_| false);
+
+        assert!(
+            tree.get_inode(ino, None::<&str>).is_some(),
+            "an inode with an outstanding kernel lookup reference must stay addressable"
         );
     }
 

--- a/curvine-fuse/src/fs/dcache/inode.rs
+++ b/curvine-fuse/src/fs/dcache/inode.rs
@@ -206,6 +206,9 @@ impl Inode {
         // The kernel may continue issuing requests by nodeid until it balances
         // every LOOKUP/READDIRPLUS reference with FORGET.
         !self.is_root()
+            // A failed deferred delete must remain observable until cleanup
+            // succeeds or reports that the backend entry is already absent.
+            && !self.mark_delete
             && self.n_lookup == 0
             && self.last_access + ttl < LocalTime::mills()
             && self.dir.as_ref().is_none_or(|d| d.children.is_empty())

--- a/curvine-fuse/src/fs/dcache/inode.rs
+++ b/curvine-fuse/src/fs/dcache/inode.rs
@@ -203,7 +203,10 @@ impl Inode {
     }
 
     pub fn can_evict(&self, ttl: u64) -> bool {
+        // The kernel may continue issuing requests by nodeid until it balances
+        // every LOOKUP/READDIRPLUS reference with FORGET.
         !self.is_root()
+            && self.n_lookup == 0
             && self.last_access + ttl < LocalTime::mills()
             && self.dir.as_ref().is_none_or(|d| d.children.is_empty())
     }

--- a/curvine-fuse/src/fs/state/node_state.rs
+++ b/curvine-fuse/src/fs/state/node_state.rs
@@ -597,12 +597,17 @@ impl NodeState {
     }
 
     pub fn has_open_handles(&self, ino: u64) -> bool {
-        let lock = self.handles.read();
-        if let Some(map) = lock.get(&ino) {
-            !map.is_empty()
-        } else {
-            false
+        // Both OPEN and OPENDIR handles keep the inode addressable until their
+        // corresponding RELEASE/RELEASEDIR request.
+        {
+            let lock = self.handles.read();
+            if lock.get(&ino).is_some_and(|map| !map.is_empty()) {
+                return true;
+            }
         }
+
+        let lock = self.dir_handles.read();
+        lock.get(&ino).is_some_and(|map| !map.is_empty())
     }
 
     pub fn clear_mark_delete(&self, ino: u64) -> FuseResult<()> {
@@ -1382,6 +1387,49 @@ mod test {
         assert!(NodeState::map_remove_handle(&mut map, 2, 21).1);
         assert!(map.get(&2).is_none());
         assert!(!NodeState::map_remove_handle(&mut map, 2, 99).1);
+    }
+
+    #[test]
+    fn clear_keeps_expired_inode_until_directory_handle_is_released() {
+        crate::FuseMetrics::ensure_init().unwrap();
+        let rt = Arc::new(AsyncRuntime::single());
+        let mut conf = ClusterConf::default();
+        conf.fuse.node_cache_ttl = std::time::Duration::from_secs(60);
+        let fs = UnifiedFileSystem::with_rt(conf, rt).unwrap();
+        let state = NodeState::new(fs).unwrap();
+        let ino = {
+            let mut tree = state.dir_write();
+            let ino = tree
+                .lookup(
+                    FUSE_ROOT_ID,
+                    "d",
+                    FileStatus::with_name(2, "d".to_string(), true),
+                    true,
+                )
+                .unwrap()
+                .ino;
+            tree.forget(ino, 1).unwrap();
+            tree.get_inode_mut(ino, None).unwrap().last_access = 0;
+            ino
+        };
+
+        {
+            let mut handles = state.dir_handles.write();
+            NodeState::insert_dir_handle_locked(&mut handles, ino, 20, dir_handle(ino, 20));
+        }
+
+        state.clear().unwrap();
+        assert!(
+            state.dir_read().get_inode(ino, None::<&str>).is_some(),
+            "an open directory handle must keep an expired inode addressable"
+        );
+
+        state.remove_dir_handle(ino, 20).unwrap();
+        state.clear().unwrap();
+        assert!(
+            state.dir_read().get_inode(ino, None::<&str>).is_none(),
+            "the expired inode should be evicted after its directory handle is released"
+        );
     }
 
     #[test]


### PR DESCRIPTION
# Summary

Prevent the FUSE inode cache cleaner from evicting inode mappings that are still referenced by the kernel, retained by an open directory handle, or carrying a pending deferred-delete state.

# Issue Describe / Design

## Root cause

`Inode::can_evict` only checked the root inode, cache TTL, and cached directory children. It did not check `n_lookup`, so an inode could be evicted before the kernel balanced its LOOKUP/READDIRPLUS references with FORGET.

`NodeState::has_open_handles` only checked file handles. An inode with an active OPENDIR handle could therefore be evicted before RELEASEDIR.

A failed deferred delete leaves `mark_delete` set so cleanup can be retried or recovered from persisted state. TTL cleanup did not consider that marker, so it could silently discard the pending-delete inode after `n_lookup` and handle references reached zero.

## Reproduction

1. Set `node_cache_timeout` to 2 seconds and disable entry/attribute caching.
2. Keep a non-root directory as the current working directory, or keep an OPENDIR file descriptor open.
3. Wait for the inode cleaner.
4. `stat .` returns ENOENT before FORGET or RELEASEDIR is observed.

The deferred-delete variant marks an unlinked inode for backend cleanup, expires its TTL, and runs the cleaner before deferred deletion completes. Without the follow-up guard, the pending state is evicted.

## Fix approach

- Require `n_lookup == 0` before an inode can be evicted.
- Treat both file and directory handles as active inode users.
- Exclude `mark_delete` inodes from TTL eviction until `clear_mark_delete` records completion.
- Keep `ref_ctr` out of the eviction condition so ordinary linked dentry cache entries can still expire after FORGET.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-fuse/src/fs/dcache/inode.rs` | Require `n_lookup == 0` and `mark_delete == false` in `can_evict` | Referenced nodeids and pending deferred deletes remain observable until their lifecycle completes |
| `curvine-fuse/src/fs/state/node_state.rs` | Include directory handles in `has_open_handles` | OPENDIR inodes remain cached until RELEASEDIR |
| `curvine-fuse/src/fs/dcache/dir_tree.rs` | Add lookup-reference, post-FORGET, and pending-delete completion/eviction coverage | Test-only |
| `curvine-fuse/src/fs/state/node_state.rs` | Add directory-handle cleaner regression coverage | Test-only |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| Remote Linux `cargo test -p curvine-fuse fs::dcache::dir_tree::test --lib -- --test-threads=1` | PASS | 29/29 on the exact reviewed file contents; includes pending-delete retention before completion and eviction afterward |
| `cargo test -p curvine-fuse clear_keeps_expired_inode_until_directory_handle_is_released --lib` | PASS | Directory handle retained until release |
| Local and remote Linux `cargo fmt --all -- --check` | PASS | |
| Local and remote Linux `cargo check -p curvine-fuse` | PASS | |
| `cargo test -p curvine-fuse --lib` | PARTIAL | 342 passed; 6 unrelated macOS/platform-sensitive tests failed |
| `make format` | BASELINE BLOCKED | Full-workspace macOS clippy is blocked by existing recursion-limit errors and RocksDB C++ standard-library header failures; unrelated auto-fixes were reverted |
| Linux `/dev/fuse` fixed-binary E2E | PASS | Commit `ad137e0c`: held cwd and directory-handle inode remained `1099 -> 1099` across multiple TTL cycles, `stat .` succeeded, and unmount returned 0. Evidence: `/lpai/curvine-lookup-validation-20260804/e2e/lookup_validation_1785830728_879473/summary.log`. The review follow-up commit only adds the independent `mark_delete` eviction guard. |

Remote review-follow-up logs are stored at `/lpai/curvine-pr1485-review-20260805/evidence/dir-tree-test.log` and `/lpai/curvine-pr1485-review-20260805/evidence/cargo-check.log`.

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None
