### PR TITLE
perf(fuse): drop direct_io default and keep kernel cache with permission check

### DIFF
--- a/curvine-fuse/src/cli/mount_args.rs
+++ b/curvine-fuse/src/cli/mount_args.rs
@@ -335,7 +335,6 @@ impl FuseMountArgs {
             vec![
                 "allow_other".to_string(),
                 "async".to_string(),
-                "direct_io".to_string(),
                 "big_write".to_string(),
                 "max_write=131072".to_string(),
             ]

--- a/curvine-fuse/src/fuse_utils.rs
+++ b/curvine-fuse/src/fuse_utils.rs
@@ -564,21 +564,23 @@ impl FuseUtils {
 
     /// Kernel dentry/attribute cache lifetimes for FUSE replies.
     ///
-    /// When userspace permission checks are enabled, timeouts must be zero so the
-    /// kernel revalidates after parent mode changes (e.g. chmod removing search).
-    /// Otherwise cached LOOKUP/GETATTR can skip path-prefix X_OK and report success
-    /// where POSIX requires EACCES (LTP lstat02/stat03/readlink03).
+    /// Returns the configured `entry_ttl`/`attr_ttl` regardless of
+    /// `check_permission`, trading cache freshness for performance: inside the
+    /// TTL the kernel reuses cached dentries/attrs, so a parent mode change
+    /// (e.g. chmod removing search) is invisible until the cache expires, and
+    /// path traversal may skip the userspace X_OK check where POSIX requires
+    /// EACCES (LTP lstat02/stat03/readlink03).
+    ///
+    /// For strict/POSIX semantics (full LTP compliance), mount with
+    /// `entry_timeout_ms = 0` and `attr_timeout_ms = 0` so every lookup/getattr
+    /// revalidates against the metadata service.
     pub fn kernel_cache_timeouts(conf: &FuseConf) -> (u64, u32, u64, u32) {
-        if conf.check_permission {
-            (0, 0, 0, 0)
-        } else {
-            (
-                conf.entry_ttl.as_secs(),
-                conf.entry_ttl.subsec_nanos(),
-                conf.attr_ttl.as_secs(),
-                conf.attr_ttl.subsec_nanos(),
-            )
-        }
+        (
+            conf.entry_ttl.as_secs(),
+            conf.entry_ttl.subsec_nanos(),
+            conf.attr_ttl.as_secs(),
+            conf.attr_ttl.subsec_nanos(),
+        )
     }
 
     pub fn create_entry_out(conf: &FuseConf, attr: fuse_attr) -> fuse_entry_out {
@@ -833,6 +835,22 @@ mod tests {
                 libc::EOPNOTSUPP
             );
         }
+    }
+
+    #[test]
+    fn kernel_cache_timeouts_ignore_check_permission() {
+        let conf = FuseConf::default();
+        assert!(conf.check_permission);
+
+        assert_eq!(
+            FuseUtils::kernel_cache_timeouts(&conf),
+            (
+                conf.entry_ttl.as_secs(),
+                conf.entry_ttl.subsec_nanos(),
+                conf.attr_ttl.as_secs(),
+                conf.attr_ttl.subsec_nanos(),
+            )
+        );
     }
 
     #[test]


### PR DESCRIPTION
# Summary

Stop forcing kernel entry/attr cache timeouts to zero whenever `check_permission` is enabled: with zero TTL every lookup/getattr round-trips to userspace and the metadata service, causing several-fold slower metadata-heavy reads. Also clean up the ineffective `direct_io` entry in the default mount options.

Kernel caching is restored by default; full LTP compliance remains available per-mount via explicit zero timeouts.

# Issue Describe / Design

No issue filed. Design analysis:

**1. direct_io default removal (ineffective-default cleanup)**
`direct_io` in `default_mnt_opts()` was never forwarded to the kernel mount: `FuseConf::set_fuse_opts()` only forwards an allowlist (`ro` / `default_permissions` / `allow_other` / `allow_root` / `async`) into the mount option string used by `fuse_mount_pure()`, and the kernel mount itself has no `direct_io` option anyway. Removing it is therefore a no-op cleanup, not a performance change. Per-open direct I/O remains available via the `conf.direct_io` field, which is the correct mechanism (`FUSE_FOPEN_DIRECT_IO` on the open reply).

**2. check_permission → kernel cache zeroing removal**
The previous `kernel_cache_timeouts()` returned `(0,0,0,0)` whenever `check_permission` was on, forcing every lookup/getattr into userspace and then into the metadata service — several-fold slower metadata-heavy reads. The function now returns the configured `entry_ttl`/`attr_ttl` unconditionally. This is the actual performance fix in this PR.

**3. Trade-off (FUSE design)**
With kernel caching enabled, some LTP attr-modification tests (e.g. lstat02/stat03/readlink03) fail: inside the entry/attr TTL the kernel reuses cached dentries/attrs, so a parent `chmod` removing search permission is invisible and path traversal does not reach userspace. This is an inherent FUSE cache-freshness vs performance trade-off, not a bug. The reliable way to pass all LTP tests remains `entry_timeout = 0` + `attr_timeout = 0` (+ `check_permission`), now achievable per-mount via CLI options instead of a hard-coded global default:
`--check-permission true --entry-timeout-ms 0 --attr-timeout-ms 0`

**4. Why not kernel invalidation notifications**
Write-path invalidation via `FUSE_NOTIFY_INVAL_INODE`/`FUSE_NOTIFY_INVAL_ENTRY` (`send_inode_out`/`send_entry_out`) is a known deadlock source in this project: see #910 (synchronous inode invalidation during request handling deadlocks when the kernel holds page locks) and #607 (send_inode_out calls removed from flush/complete to prevent deadlock). Additionally `FUSE_ASYNC_INVAL` is not negotiated in `SUPPORTED_INIT_FLAGS`, so such notifications would not be processed by the kernel anyway. Therefore notify-based invalidation is not a viable middle ground.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-fuse/src/cli/mount_args.rs` | Remove ineffective default `direct_io` mount option (fuse2 branch) | None: option was never forwarded to the kernel mount (set_fuse_opts allowlist); cleanup only |
| `curvine-fuse/src/fuse_utils.rs` | `kernel_cache_timeouts()` no longer zeroes entry/attr TTL when `check_permission` is on; refresh doc comment; add regression test | Behavior change: kernel metadata cache active with permission checking; some LTP attr-modification tests fail (inherent FUSE trade-off, see Design) |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `kernel_cache_timeouts_ignore_check_permission` (new unit test) | Not run locally | Follows project rule: no compile/test after code changes; asserts configured TTLs are returned even with `check_permission = true` |

# Dependencies

- Related PRs: #910, #607 (historical context for the invalidation deadlock)
- Related issues: None
- Blocks / blocked by: None