### PR TITLE
fix(fuse): reject negative backend inode IDs

### DIFF
--- a/curvine-fuse/src/fs/dcache/dir_tree.rs
+++ b/curvine-fuse/src/fs/dcache/dir_tree.rs
@@ -160,10 +160,18 @@ impl DirTree {
         self.inodes.remove(&ino);
     }
 
-    pub fn next_id(&self, cv_id: i64) -> u64 {
+    fn validate_backend_id(cv_id: i64) -> FuseResult<()> {
+        if cv_id < 0 {
+            return err_fuse!(libc::EIO, "backend returned a negative inode id: {}", cv_id);
+        }
+        Ok(())
+    }
+
+    pub fn next_id(&self, cv_id: i64) -> FuseResult<u64> {
+        Self::validate_backend_id(cv_id)?;
         let cv_id = cv_id as u64;
         if cv_id > FUSE_ROOT_ID && cv_id != FUSE_UNKNOWN_INO && !self.inodes.contains_key(&cv_id) {
-            return cv_id;
+            return Ok(cv_id);
         }
 
         loop {
@@ -171,7 +179,7 @@ impl DirTree {
             if id == FUSE_ROOT_ID || id == FUSE_UNKNOWN_INO || self.inodes.contains_key(&id) {
                 continue;
             } else {
-                return id;
+                return Ok(id);
             }
         }
     }
@@ -193,6 +201,8 @@ impl DirTree {
         status: FileStatus,
         bump_kref: bool,
     ) -> FuseResult<&mut Inode> {
+        Self::validate_backend_id(status.id)?;
+
         let ino = match self.get_inode_mut(parent, Some(name)) {
             Some(inode) => {
                 // Path A: same (parent, name) dentry already cached.
@@ -242,7 +252,7 @@ impl DirTree {
 
                     // Path C: brand-new inode.
                     None => {
-                        let ino = self.next_id(status.id);
+                        let ino = self.next_id(status.id)?;
                         // Real LOOKUP / READDIRPLUS take a kernel lookup ref
                         // (n_lookup=1); plain READDIR takes none (n_lookup=0).
                         let n_lookup = if bump_kref { 1 } else { 0 };
@@ -1231,16 +1241,16 @@ mod test {
         let t = DirTree::default();
 
         // id == 0 (<= FUSE_ROOT_ID): both calls allocate, and must differ.
-        let a = t.next_id(0);
-        let b = t.next_id(0);
+        let a = t.next_id(0).unwrap();
+        let b = t.next_id(0).unwrap();
         assert_ne!(
             a, b,
             "two next_id(0) calls must return distinct inos (this is why create must not call next_ino twice)"
         );
 
         // id == FUSE_UNKNOWN_INO: same divergence.
-        let c = t.next_id(FUSE_UNKNOWN_INO as i64);
-        let d = t.next_id(FUSE_UNKNOWN_INO as i64);
+        let c = t.next_id(FUSE_UNKNOWN_INO as i64).unwrap();
+        let d = t.next_id(FUSE_UNKNOWN_INO as i64).unwrap();
         assert_ne!(
             c, d,
             "two next_id(FUSE_UNKNOWN_INO) calls must return distinct inos"
@@ -1252,9 +1262,43 @@ mod test {
             assert_ne!(id, FUSE_UNKNOWN_INO);
         }
 
+        // Negative values are invalid backend metadata, not unassigned ids.
+        for id in [-1, i64::MIN] {
+            assert_eq!(t.next_id(id).unwrap_err().errno, libc::EIO);
+        }
+
         // Stable backend ids are returned verbatim and stable across calls.
         let stable = 12_345_u64;
-        assert_eq!(t.next_id(stable as i64), stable);
-        assert_eq!(t.next_id(stable as i64), stable);
+        assert_eq!(t.next_id(stable as i64).unwrap(), stable);
+        assert_eq!(t.next_id(stable as i64).unwrap(), stable);
+    }
+
+    #[test]
+    fn lookup_rejects_negative_backend_inode_ids() {
+        let mut t = DirTree::default();
+
+        for (name, id) in [("minus-one", -1), ("min", i64::MIN)] {
+            let result = t.lookup(FUSE_ROOT_ID, name, file_st(name, id), true);
+            match result {
+                Ok(_) => panic!("negative backend inode id {id} must be rejected"),
+                Err(error) => assert_eq!(error.errno, libc::EIO),
+            }
+            assert!(t.get_inode(FUSE_ROOT_ID, Some(name)).is_none());
+        }
+
+        t.lookup(FUSE_ROOT_ID, "cached", file_st("cached", 12_345), true)
+            .unwrap();
+        let result = t.lookup(FUSE_ROOT_ID, "cached", file_st("cached", -1), true);
+        match result {
+            Ok(_) => panic!("a negative refresh id must not update a cached dentry"),
+            Err(error) => assert_eq!(error.errno, libc::EIO),
+        }
+        assert_eq!(
+            t.get_inode(FUSE_ROOT_ID, Some("cached"))
+                .unwrap()
+                .clone_status()
+                .id,
+            12_345
+        );
     }
 }

--- a/curvine-fuse/src/fs/state/node_state.rs
+++ b/curvine-fuse/src/fs/state/node_state.rs
@@ -178,7 +178,7 @@ impl NodeState {
         self.fh_creator.get()
     }
 
-    pub fn next_ino(&self, status: &FileStatus) -> u64 {
+    pub fn next_ino(&self, status: &FileStatus) -> FuseResult<u64> {
         self.dir_read().next_id(status.id)
     }
 
@@ -391,7 +391,10 @@ impl NodeState {
         if mode == OpenFlags::RDONLY {
             let reader = self.new_reader(path).await?;
             let mut status = reader.status().clone();
-            let ino = ino.unwrap_or(self.next_ino(&status));
+            let ino = match ino {
+                Some(ino) => ino,
+                None => self.next_ino(&status)?,
+            };
             status.id = ino as i64;
             let handle = self
                 .insert_handle_with_writer(ino, Some(RawPtr::from_owned(reader)), None, status)
@@ -411,7 +414,7 @@ impl NodeState {
             }
             None => {
                 let writer = self.new_writer(path, flags, opts).await?;
-                let ino = self.next_ino(writer.status());
+                let ino = self.next_ino(writer.status())?;
                 let writer = self.writers.insert::<FuseError>(ino, writer).await?;
                 (ino, writer)
             }
@@ -978,7 +981,7 @@ impl NodeState {
             let mut status = writer.status().clone();
             writer.complete(None).await?;
 
-            let child_ino = self.next_ino(&status);
+            let child_ino = self.next_ino(&status)?;
             status.id = child_ino as i64;
             let _ = self.lookup_status(ino, name, &status)?;
             return self.new_handle(Some(child_ino), &path, flags, opts).await;


### PR DESCRIPTION
# Summary

Reject negative backend inode IDs before converting `FileStatus.id` from `i64` to the FUSE `u64` node ID. This prevents malformed backend metadata from becoming large, valid-looking inode numbers in `NodeState` and kernel replies.

# Issue Describe / Design

Root cause: `DirTree::next_id` cast `FileStatus.id` directly from `i64` to `u64`. Negative values therefore wrapped into the upper half of the `u64` range, for example `-1` became `u64::MAX`, and could be cached or returned as FUSE node IDs.

Reproduction steps:

1. Return a `FileStatus` whose `id` is `-1` or `i64::MIN`.
2. Materialize or refresh the entry through `DirTree::lookup`, or allocate an inode through `NodeState::next_ino`.
3. Before this fix, the signed value was cast to a large `u64` node ID.

Fix approach: validate backend inode IDs centrally in `DirTree` before conversion and return `EIO` for negative values. Propagate allocation errors through `NodeState`, and validate before mutating an already cached dentry. Zero and `FUSE_UNKNOWN_INO` retain their existing local-allocation behavior.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-fuse/src/fs/dcache/dir_tree.rs` | Validate negative backend inode IDs, make `next_id` fallible, and add regression coverage for new and cached entries | Negative backend IDs now fail with `EIO`; nonnegative and locally allocated IDs are unchanged |
| `curvine-fuse/src/fs/state/node_state.rs` | Propagate fallible inode allocation through open/create paths | Prevents invalid backend IDs from entering handle state |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo fmt --all -- --check` | PASS | Local and remote Linux |
| `cargo test -p curvine-fuse fs::dcache::dir_tree::test --lib` | PASS | 28/28 tests |
| `cargo check -p curvine-fuse` | PASS | Local and remote Linux |
| `cargo test -p curvine-fuse --lib -- --test-threads=1` | PASS | Remote Linux, 361/361 tests |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None