### PR TITLE
fix(ci): enforce minimal RDMA guardrails (#1243)

### DIFF
--- a/README_zh.md
+++ b/README_zh.md
@@ -64,17 +64,18 @@
 
 ### 🦀 Rust API (原生集成推荐)
 
-```
-use curvine_common::conf::ClusterConf;
-use curvine_common::fs::Path;
+```rust
+use curvine_config::ClusterConf;
+use curvine_fs_api::{FileSystem, Path};
+use curvine_unified_fs::UnifiedFileSystem;
 use std::sync::Arc;
 
-let conf = ClusterConf::from(conf_path);
+let conf = ClusterConf::from(conf_path)?;
 let rt = Arc::new(conf.client_rpc_conf().create_runtime());
-let fs = CurvineFileSystem::with_rt(conf, rt)?;
+let fs = UnifiedFileSystem::with_rt(conf, rt)?;
 
 let path = Path::from_str("/dir")?;
-fs.mkdir(&path).await?;
+fs.mkdir(&path, true).await?;
 ```
 
 ### 📌 FUSE (用户空间文件系统)
@@ -141,6 +142,10 @@ make build ARGS="-p core"
 
 # 编译fuse和核心模块
 make build ARGS="-p core -p fuse"
+
+# 编译 server-native SPDK/RDMA 支持。curvine-cli 和 curvine-fuse
+# 会按客户端安全 profile 单独构建，避免被 server-native feature 污染。
+make build ARGS="-p core -p fuse --spdk-rdma --spdk-dir /opt/spdk"
 ```
 
 
@@ -158,6 +163,9 @@ sh build/build.sh -p core
 
 # 编译fuse和核心模块
 sh build/build.sh -p core -p fuse
+
+# 只编译 server-native SPDK/RDMA artifact
+sh build/build.sh -p server --spdk-rdma --spdk-dir /opt/spdk
 ```
 
 构建镜像：

--- a/build/build.sh
+++ b/build/build.sh
@@ -720,9 +720,9 @@ check_minimal_artifact_deps() {
 
   local needed
   needed="$(artifact_dynamic_entries "$inspector" "$artifact")"
-  local server_native_pattern='libibverbs\.so|librdmacm\.so|libspdk|librte_'
+  local server_native_pattern='libibverbs\.so|librdmacm\.so|libspdk|libdpdk|librte_'
   if grep -E "$server_native_pattern" <<<"$needed" >/dev/null; then
-    echo "Error: ${label} contains server-native RDMA/SPDK runtime dependencies forbidden for client artifacts:" >&2
+    echo "Error: ${label} contains server-native RDMA/SPDK runtime dependencies forbidden for minimal client artifacts:" >&2
     echo "$needed" >&2
     exit 1
   fi

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -29,4 +29,9 @@ link RDMA/SPDK, Jindo/HDFS/JVM, or native storage libraries.
 ```bash
 scripts/check-minimal-artifact-deps.sh
 scripts/check-minimal-artifact-deps.sh --artifact curvine-cli=target/debug/curvine-cli
+scripts/check-minimal-artifact-deps.sh --allow-rdma-spdk --artifact curvine-fuse-rdma=target/release/curvine-fuse
 ```
+
+Use `--allow-rdma-spdk` only for explicitly RDMA/SPDK-enabled client or FUSE
+artifacts. The default mode remains the guard for minimal/non-RDMA client
+artifacts.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -33,5 +33,6 @@ scripts/check-minimal-artifact-deps.sh --allow-rdma-spdk --artifact curvine-fuse
 ```
 
 Use `--allow-rdma-spdk` only for explicitly RDMA/SPDK-enabled client or FUSE
-artifacts. The default mode remains the guard for minimal/non-RDMA client
-artifacts.
+artifacts. It requires explicit `--artifact` arguments; the implicit default
+artifact set always stays strict. The default mode remains the guard for
+minimal/non-RDMA client artifacts.

--- a/scripts/check-deps.sh
+++ b/scripts/check-deps.sh
@@ -191,32 +191,35 @@ check_tree_forbidden() {
 
 check_mixed_spdk_feature_risk() {
   # After orpc removal, SPDK lives on curvine-storage-spdk / curvine-worker.
-  # Enabling server SPDK in a workspace that also builds CLI must not pull
-  # curvine-storage-spdk into the CLI package tree via feature unification.
-  local packages
+  # In a mixed CLI + server feature resolution, server SPDK is legal, but it
+  # must not make the minimal CLI reverse-depend on curvine-storage-spdk.
+  local reverse_deps
   local err
   err="$(mktemp)"
 
-  if packages="$(
+  if reverse_deps="$(
     cargo tree \
       --no-default-features \
       --features curvine-server/spdk-rdma,curvine-alloc/system \
       -p curvine-cli \
+      -p curvine-server \
       -e normal \
+      -i curvine-storage-spdk \
       --prefix none \
       -f '{p}' 2>"$err" \
       | awk '{print $1}' \
       | sed '/^$/d' \
       | sort -u
   )"; then
-    if grep -qx 'curvine-storage-spdk' <<<"$packages"; then
-      record_violation "mixed-spdk-feature-risk" "server spdk-rdma feature pulls curvine-storage-spdk into the CLI dependency tree" ci
+    if grep -qx 'curvine-cli' <<<"$reverse_deps"; then
+      record_violation "mixed-spdk-feature-risk" "server spdk-rdma feature makes curvine-cli reverse-depend on curvine-storage-spdk:
+$reverse_deps" ci
     else
       record_ok "mixed-spdk-feature-risk"
     fi
   else
-    echo "SKIP [mixed-spdk-feature-risk] cargo tree command failed, likely because legacy features were removed:"
-    sed 's/^/  /' "$err"
+    record_violation "mixed-spdk-feature-risk" "cargo tree command failed while checking CLI/server SPDK isolation:
+$(sed 's/^/  /' "$err")" ci
   fi
 
   rm -f "$err"

--- a/scripts/check-minimal-artifact-deps.sh
+++ b/scripts/check-minimal-artifact-deps.sh
@@ -6,14 +6,19 @@ set -euo pipefail
 
 usage() {
   cat <<'EOF'
-Usage: scripts/check-minimal-artifact-deps.sh [--allow-missing] [--artifact LABEL=PATH] [PATH ...]
+Usage: scripts/check-minimal-artifact-deps.sh [--allow-missing] [--allow-rdma-spdk] [--artifact LABEL=PATH] [PATH ...]
 
-With no artifacts, the script checks known Curvine outputs in target/{debug,release}
-and build/dist/lib. Explicit artifacts must exist unless --allow-missing is set.
+By default this enforces minimal/non-RDMA client artifacts. With no artifacts,
+the script checks known Curvine outputs in target/{debug,release} and
+build/dist/lib. Explicit artifacts must exist unless --allow-missing is set.
+
+Use --allow-rdma-spdk only for explicitly RDMA/SPDK-enabled client or FUSE
+artifacts; native UFS and storage-library checks remain enforced.
 EOF
 }
 
 allow_missing=0
+allow_rdma_spdk=0
 declare -a artifact_specs=()
 using_defaults=0
 
@@ -21,6 +26,10 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --allow-missing)
       allow_missing=1
+      shift
+      ;;
+    --allow-rdma-spdk)
+      allow_rdma_spdk=1
       shift
       ;;
     --artifact)
@@ -105,7 +114,9 @@ artifact_inspector() {
   fi
 }
 
-forbidden_pattern='libibverbs\.so|librdmacm\.so|libspdk|libdpdk|librte_|libjindosdk|libhdfs|libjvm|libjli|librocksdb'
+rdma_spdk_pattern='libibverbs\.so|librdmacm\.so|libspdk|libdpdk|librte_'
+native_ufs_pattern='libjindosdk|libhdfs|libjvm|libjli'
+native_storage_pattern='librocksdb'
 checked=0
 failures=0
 
@@ -137,13 +148,28 @@ for spec in "${artifact_specs[@]}"; do
 
   checked=$((checked + 1))
   needed="$(artifact_dynamic_entries "$inspector" "$artifact")"
-  if grep -E "$forbidden_pattern" <<<"$needed" >/dev/null; then
-    echo "FAIL [$label] forbidden native runtime dependency found in $artifact" >&2
+  if [[ "$allow_rdma_spdk" -eq 0 ]] && grep -E "$rdma_spdk_pattern" <<<"$needed" >/dev/null; then
+    echo "FAIL [$label] RDMA/SPDK runtime dependency found in minimal/non-RDMA artifact: $artifact" >&2
     echo "$needed" | sed 's/^/  /' >&2
     failures=$((failures + 1))
-  else
-    echo "OK   [$label] runtime dependencies"
+    continue
   fi
+
+  if grep -E "$native_storage_pattern" <<<"$needed" >/dev/null; then
+    echo "FAIL [$label] native storage runtime dependency found in minimal client artifact: $artifact" >&2
+    echo "$needed" | sed 's/^/  /' >&2
+    failures=$((failures + 1))
+    continue
+  fi
+
+  if grep -E "$native_ufs_pattern" <<<"$needed" >/dev/null; then
+    echo "FAIL [$label] native UFS runtime dependency found in minimal client artifact: $artifact" >&2
+    echo "$needed" | sed 's/^/  /' >&2
+    failures=$((failures + 1))
+    continue
+  fi
+
+  echo "OK   [$label] runtime dependencies"
 done
 
 if ((failures > 0)); then
@@ -156,4 +182,8 @@ if ((checked == 0)); then
   exit 2
 fi
 
-echo "Minimal artifact runtime dependency check passed."
+if [[ "$allow_rdma_spdk" -eq 1 ]]; then
+  echo "Runtime dependency check passed with explicit RDMA/SPDK dependencies allowed."
+else
+  echo "Minimal/non-RDMA artifact runtime dependency check passed."
+fi

--- a/scripts/check-minimal-artifact-deps.sh
+++ b/scripts/check-minimal-artifact-deps.sh
@@ -13,7 +13,9 @@ the script checks known Curvine outputs in target/{debug,release} and
 build/dist/lib. Explicit artifacts must exist unless --allow-missing is set.
 
 Use --allow-rdma-spdk only for explicitly RDMA/SPDK-enabled client or FUSE
-artifacts; native UFS and storage-library checks remain enforced.
+artifacts, and only with explicit --artifact or PATH arguments. It is rejected
+for the implicit default artifact set; native UFS and storage-library checks
+remain enforced.
 EOF
 }
 
@@ -56,6 +58,12 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+if [[ "$allow_rdma_spdk" -eq 1 && ${#artifact_specs[@]} -eq 0 ]]; then
+  echo "--allow-rdma-spdk requires explicit artifacts; refusing to relax the default minimal artifact set" >&2
+  usage >&2
+  exit 2
+fi
 
 ROOT="$(git rev-parse --show-toplevel)"
 cd "$ROOT"
@@ -156,14 +164,14 @@ for spec in "${artifact_specs[@]}"; do
   fi
 
   if grep -E "$native_storage_pattern" <<<"$needed" >/dev/null; then
-    echo "FAIL [$label] native storage runtime dependency found in minimal client artifact: $artifact" >&2
+    echo "FAIL [$label] native storage runtime dependency found in client artifact: $artifact" >&2
     echo "$needed" | sed 's/^/  /' >&2
     failures=$((failures + 1))
     continue
   fi
 
   if grep -E "$native_ufs_pattern" <<<"$needed" >/dev/null; then
-    echo "FAIL [$label] native UFS runtime dependency found in minimal client artifact: $artifact" >&2
+    echo "FAIL [$label] native UFS runtime dependency found in client artifact: $artifact" >&2
     echo "$needed" | sed 's/^/  /' >&2
     failures=$((failures + 1))
     continue


### PR DESCRIPTION
# Summary

This PR tightens the #1243 dependency guardrails so server-side SPDK/RDMA features cannot silently pollute the default CLI artifact, while still allowing explicitly RDMA/SPDK-enabled client or FUSE artifacts. It also updates the Chinese README to use the current split crate APIs.

# Issue Describe / Design

Closes #1243

Root cause:
- The `mixed-spdk-feature-risk` check only selected `curvine-cli` while passing `curvine-server/spdk-rdma`, so Cargo rejected the feature set and the script reported `SKIP`.
- The minimal artifact guard wording looked like a blanket client-side RDMA ban, even though explicit RDMA client/FUSE artifacts are valid.
- `README_zh.md` still referenced the removed `curvine_common::*` API.

Reproduction steps:
- Run `scripts/check-deps.sh --mode ci` before this change and observe `SKIP [mixed-spdk-feature-risk]`.

Fix approach:
- Restore mixed `curvine-cli + curvine-server` feature resolution and check `curvine-storage-spdk` reverse dependencies.
- Fail CI if the mixed check command fails instead of silently skipping.
- Add an explicit `--allow-rdma-spdk` mode for RDMA/SPDK-enabled artifact checks; it requires explicit artifacts and the implicit default set stays strict.
- Update Chinese README examples and build notes.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `scripts/check-deps.sh` | Uses reverse-dependency checking for `curvine-storage-spdk` in mixed CLI/server SPDK resolution | CI now catches real CLI pollution and no longer silently skips |
| `scripts/check-minimal-artifact-deps.sh` | Adds `--allow-rdma-spdk`, rejects it for the implicit default artifact set, separates RDMA/SPDK, native UFS, and native storage checks, and uses mode-agnostic failure wording | Default minimal checks remain strict; explicit RDMA artifacts can be checked without false failure |
| `build/build.sh` | Narrows error wording to minimal client artifacts and includes `libdpdk` in the SPDK native pattern | No build behavior change except clearer diagnostics |
| `README_zh.md` | Updates Rust API imports and SPDK/RDMA build notes | Documentation now matches split crates and current build profiles |
| `scripts/README.md` | Documents explicit RDMA/SPDK artifact check mode and the explicit-artifact requirement | Clarifies intended guard usage |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `bash -n scripts/check-deps.sh scripts/check-minimal-artifact-deps.sh build/build.sh` | PASS | Shell syntax |
| `scripts/check-deps.sh --mode ci` | PASS | `mixed-spdk-feature-risk` reports `OK`, not `SKIP` |
| `cargo tree --no-default-features --features curvine-server/spdk-rdma,curvine-alloc/system -p curvine-cli -p curvine-server -e normal -i curvine-storage-spdk --prefix none -f '{p}'` | PASS | Reverse deps do not include `curvine-cli` |
| `scripts/check-minimal-artifact-deps.sh --allow-missing` | PASS | Minimal/non-RDMA artifact guard |
| `scripts/check-minimal-artifact-deps.sh --allow-missing --allow-rdma-spdk --artifact smoke=/bin/ls` | PASS | Explicit allow mode smoke test |
| `scripts/check-minimal-artifact-deps.sh --allow-rdma-spdk` | PASS | Rejected with exit 2 unless explicit artifacts are supplied |
| `scripts/check-minimal-artifact-deps.sh --allow-rdma-spdk --artifact rdma=<tmp ELF>` | PASS | RDMA-only fixture passes in explicit allow mode |
| `scripts/check-minimal-artifact-deps.sh --allow-rdma-spdk --artifact storage=<tmp ELF>` | PASS | Native storage dependency still fails with "client artifact" wording |
| `scripts/check-minimal-artifact-deps.sh --allow-rdma-spdk --artifact ufs=<tmp ELF>` | PASS | Native UFS dependency still fails with "client artifact" wording |
| `rg "curvine_common::|curvine_common" README_zh.md` | PASS | No stale Chinese README API reference |
| `make format` | PASS | Project formatting/check workflow |
| `git diff --check` | PASS | Whitespace check |

# Dependencies

- Related PRs: None
- Related issues: #1243
- Blocks / blocked by: None
