### PR TITLE
fix(fuse): restore write performance by completing the init capability allowlist (#1480)

### DIFF
--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -964,13 +964,17 @@ impl CurvineFileSystem {
     ///    `FUSE_WRITEBACK_CACHE` (when `write_back_cache`) and `FUSE_SPLICE_*` (when
     ///    `enable_splice` — splice drives the fuse fd directly, so it is advertised
     ///    on config alone).
-    fn negotiate_out_flags(kernel_flags: u32, write_back_cache: bool, enable_splice: bool) -> u32 {
+    fn negotiate_out_flags(kernel_flags: u32, conf: &FuseConf) -> u32 {
         let mut out = SUPPORTED_INIT_FLAGS & kernel_flags;
-        if write_back_cache {
+        if conf.write_back_cache {
             out |= FUSE_WRITEBACK_CACHE;
+        } else {
+            out &= !FUSE_WRITEBACK_CACHE;
         }
-        if enable_splice {
+        if conf.enable_splice {
             out |= FUSE_SPLICE_MOVE | FUSE_SPLICE_WRITE | FUSE_SPLICE_READ;
+        } else {
+            out &= !(FUSE_SPLICE_MOVE | FUSE_SPLICE_WRITE | FUSE_SPLICE_READ);
         }
         out
     }
@@ -1019,11 +1023,7 @@ impl fs::FileSystem for CurvineFileSystem {
         }
 
         // Negotiate only daemon-supported, kernel-offered, config-gated caps.
-        let out_flags = Self::negotiate_out_flags(
-            op.arg.flags,
-            self.conf.write_back_cache,
-            self.conf.enable_splice,
-        );
+        let out_flags = Self::negotiate_out_flags(op.arg.flags, &self.conf);
 
         let max_write = FuseUtils::get_fuse_buf_size() - FUSE_BUFFER_HEADER_SIZE;
         let page_size = sys::get_pagesize()?;
@@ -2278,6 +2278,7 @@ mod tests {
         FATTR_ATIME_NOW, FATTR_GID, FATTR_MODE, FATTR_MTIME, FATTR_MTIME_NOW, FATTR_UID,
         FUSE_INIT_EXT,
     };
+    use curvine_common::conf::FuseConf;
     use curvine_model::{FileAllocMode, FileStatus, FileType, INTERNAL_CTIME_XATTR};
 
     #[test]
@@ -2828,24 +2829,25 @@ mod tests {
         assert_eq!(encoded, b"user.visible\0");
     }
 
-    // The daemon must never advertise FUSE_ATOMIC_O_TRUNC (open does not truncate)
-    // or any other unsupported capability, even when the kernel offers it. The
-    // allowlist mask drops them.
-    //
-    // FUSE_EXPORT_SUPPORT is included here (dropped even when offered): its `.`/`..`
-    // reconstruction relies on root `.`/`..` lookups that currently return ENOENT,
-    // so the daemon must not advertise it. Not advertising it leaves the kernel's
-    // `fc->export_support` unset, so the kernel never issues the root `.`/`..` LOOKUP.
+    fn init_conf(write_back_cache: bool, enable_splice: bool) -> FuseConf {
+        let mut conf = FuseConf::default();
+        conf.write_back_cache = write_back_cache;
+        conf.enable_splice = enable_splice;
+        conf
+    }
+
     #[test]
     fn negotiate_out_flags_drops_unsupported_kernel_caps() {
         let unsupported = FUSE_ATOMIC_O_TRUNC
             | FUSE_POSIX_ACL
             | FUSE_HAS_IOCTL_DIR
             | FUSE_EXPORT_SUPPORT
-            | (1u32 << 30);
-        let out = CurvineFileSystem::negotiate_out_flags(unsupported, false, false);
+            | FUSE_INIT_EXT;
+        let conf = init_conf(false, false);
+        let out = CurvineFileSystem::negotiate_out_flags(unsupported, &conf);
         assert_eq!(
-            out, 0,
+            out & unsupported,
+            0,
             "no unsupported kernel-offered bit may be advertised"
         );
     }
@@ -2862,58 +2864,62 @@ mod tests {
 
     #[test]
     fn negotiate_out_flags_passes_through_supported_caps() {
-        let out = CurvineFileSystem::negotiate_out_flags(SUPPORTED_INIT_FLAGS, false, false);
+        let conf = init_conf(false, false);
+        let out = CurvineFileSystem::negotiate_out_flags(SUPPORTED_INIT_FLAGS, &conf);
+        let splice = FUSE_SPLICE_MOVE | FUSE_SPLICE_WRITE | FUSE_SPLICE_READ;
         assert_eq!(
-            out, SUPPORTED_INIT_FLAGS,
-            "all supported+offered caps survive"
+            out,
+            SUPPORTED_INIT_FLAGS & !splice,
+            "all supported caps survive; splice stays off without config"
         );
         assert_eq!(out & FUSE_POSIX_LOCKS, FUSE_POSIX_LOCKS);
         assert_eq!(out & FUSE_FLOCK_LOCKS, FUSE_FLOCK_LOCKS);
         assert_eq!(out & FUSE_DO_READDIRPLUS, FUSE_DO_READDIRPLUS);
     }
 
-    // A supported cap the kernel did NOT offer must not be advertised (no
-    // phantom capabilities).
     #[test]
     fn negotiate_out_flags_no_phantom_when_kernel_offers_nothing() {
-        let out = CurvineFileSystem::negotiate_out_flags(0, false, false);
-        assert_eq!(out, 0);
+        let conf = init_conf(false, false);
+        let out = CurvineFileSystem::negotiate_out_flags(0, &conf);
+        assert_eq!(out, 0, "no phantom cap when the kernel offers nothing");
         assert_eq!(out & FUSE_MAX_PAGES, 0);
         assert_eq!(out & FUSE_POSIX_LOCKS, 0);
     }
 
-    // WRITEBACK is a config-gated daemon-requested cap: present iff write_back,
-    // absent otherwise even when the kernel offers it.
     #[test]
     fn negotiate_out_flags_writeback_is_config_gated() {
-        let on = CurvineFileSystem::negotiate_out_flags(0, true, false);
+        let on = CurvineFileSystem::negotiate_out_flags(0, &init_conf(true, false));
         assert_eq!(on & FUSE_WRITEBACK_CACHE, FUSE_WRITEBACK_CACHE);
-        let off = CurvineFileSystem::negotiate_out_flags(FUSE_WRITEBACK_CACHE, false, false);
+        let off =
+            CurvineFileSystem::negotiate_out_flags(FUSE_WRITEBACK_CACHE, &init_conf(false, false));
         assert_eq!(off & FUSE_WRITEBACK_CACHE, 0);
     }
 
-    // SPLICE is config-gated and forced (not masked by the kernel offer, since
-    // the channel drives splice(2) directly).
     #[test]
     fn negotiate_out_flags_splice_is_config_gated() {
         let splice = FUSE_SPLICE_MOVE | FUSE_SPLICE_WRITE | FUSE_SPLICE_READ;
-        let on = CurvineFileSystem::negotiate_out_flags(0, false, true);
+        let on = CurvineFileSystem::negotiate_out_flags(0, &init_conf(false, true));
         assert_eq!(
             on & splice,
             splice,
             "splice advertised on config even if kernel omits it"
         );
-        let off = CurvineFileSystem::negotiate_out_flags(splice, false, false);
+        let off = CurvineFileSystem::negotiate_out_flags(splice, &init_conf(false, false));
         assert_eq!(off & splice, 0, "splice not advertised when disabled");
     }
 
-    // Containment: output never contains a bit outside the allowed universe,
-    // regardless of what the kernel offers.
     #[test]
     fn negotiate_out_flags_containment() {
         let splice = FUSE_SPLICE_MOVE | FUSE_SPLICE_WRITE | FUSE_SPLICE_READ;
-        let allowed = SUPPORTED_INIT_FLAGS | splice | FUSE_WRITEBACK_CACHE;
-        let out = CurvineFileSystem::negotiate_out_flags(0xFFFF_FFFF, true, true);
+        let unsafe_bits = FUSE_ATOMIC_O_TRUNC
+            | FUSE_POSIX_ACL
+            | FUSE_HAS_IOCTL_DIR
+            | FUSE_EXPORT_SUPPORT
+            | FUSE_INIT_EXT;
+        let allowed =
+            SUPPORTED_INIT_FLAGS | splice | FUSE_WRITEBACK_CACHE | (u32::MAX & !unsafe_bits);
+        let conf = init_conf(true, true);
+        let out = CurvineFileSystem::negotiate_out_flags(u32::MAX, &conf);
         assert_eq!(out & !allowed, 0, "no bit outside the allowed universe");
     }
 

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -2278,7 +2278,7 @@ mod tests {
         FATTR_ATIME_NOW, FATTR_GID, FATTR_MODE, FATTR_MTIME, FATTR_MTIME_NOW, FATTR_UID,
         FUSE_INIT_EXT,
     };
-    use curvine_common::conf::FuseConf;
+    use curvine_config::FuseConf;
     use curvine_model::{FileAllocMode, FileStatus, FileType, INTERNAL_CTIME_XATTR};
 
     #[test]
@@ -2830,10 +2830,11 @@ mod tests {
     }
 
     fn init_conf(write_back_cache: bool, enable_splice: bool) -> FuseConf {
-        let mut conf = FuseConf::default();
-        conf.write_back_cache = write_back_cache;
-        conf.enable_splice = enable_splice;
-        conf
+        FuseConf {
+            write_back_cache,
+            enable_splice,
+            ..FuseConf::default()
+        }
     }
 
     #[test]
@@ -2916,11 +2917,11 @@ mod tests {
             | FUSE_HAS_IOCTL_DIR
             | FUSE_EXPORT_SUPPORT
             | FUSE_INIT_EXT;
-        let allowed =
-            SUPPORTED_INIT_FLAGS | splice | FUSE_WRITEBACK_CACHE | (u32::MAX & !unsafe_bits);
+        let allowed = SUPPORTED_INIT_FLAGS | splice | FUSE_WRITEBACK_CACHE;
         let conf = init_conf(true, true);
         let out = CurvineFileSystem::negotiate_out_flags(u32::MAX, &conf);
         assert_eq!(out & !allowed, 0, "no bit outside the allowed universe");
+        assert_eq!(out & unsafe_bits, 0, "unsafe bits never advertised");
     }
 
     #[test]

--- a/curvine-fuse/src/lib.rs
+++ b/curvine-fuse/src/lib.rs
@@ -205,6 +205,7 @@ pub const SUPPORTED_INIT_FLAGS: u32 = FUSE_ASYNC_READ
 pub fn fuse_init_flag_names(flags: u32) -> Vec<String> {
     const KNOWN: &[(u32, &str)] = &[
         (FUSE_ASYNC_READ, "ASYNC_READ"),
+        (FUSE_DONT_MASK, "DONT_MASK"),
         (FUSE_POSIX_LOCKS, "POSIX_LOCKS"),
         (FUSE_ATOMIC_O_TRUNC, "ATOMIC_O_TRUNC"),
         (FUSE_EXPORT_SUPPORT, "EXPORT_SUPPORT"),
@@ -221,6 +222,15 @@ pub fn fuse_init_flag_names(flags: u32) -> Vec<String> {
         (FUSE_WRITEBACK_CACHE, "WRITEBACK_CACHE"),
         (FUSE_POSIX_ACL, "POSIX_ACL"),
         (FUSE_MAX_PAGES, "MAX_PAGES"),
+        (FUSE_NO_OPEN_SUPPORT, "NO_OPEN_SUPPORT"),
+        (FUSE_PARALLEL_DIROPS, "PARALLEL_DIROPS"),
+        (FUSE_HANDLE_KILLPRIV, "HANDLE_KILLPRIV"),
+        (FUSE_ABORT_ERROR, "ABORT_ERROR"),
+        (FUSE_CACHE_SYMLINKS, "CACHE_SYMLINKS"),
+        (FUSE_NO_OPENDIR_SUPPORT, "NO_OPENDIR_SUPPORT"),
+        (FUSE_EXPLICIT_INVAL_DATA, "EXPLICIT_INVAL_DATA"),
+        (FUSE_HANDLE_KILLPRIV_V2, "HANDLE_KILLPRIV_V2"),
+        (FUSE_SETXATTR_EXT, "SETXATTR_EXT"),
         (FUSE_INIT_EXT, "INIT_EXT"),
     ];
     let mut names: Vec<String> = KNOWN

--- a/curvine-fuse/src/lib.rs
+++ b/curvine-fuse/src/lib.rs
@@ -104,6 +104,39 @@ pub const FUSE_POSIX_LOCKS: u32 = 1 << 1;
 /// FUSE init capability bit for remote BSD (flock) locking.
 pub const FUSE_FLOCK_LOCKS: u32 = 1 << 10;
 
+/// FUSE init capability bit: the daemon passes `mode` through unchanged on
+/// create/mkdir/mknod (kernel skips umask masking).
+pub const FUSE_DONT_MASK: u32 = 1 << 6;
+
+/// FUSE init capability bit: skip open notifications to the daemon.
+pub const FUSE_NO_OPEN_SUPPORT: u32 = 1 << 17;
+
+/// FUSE init capability bit: parallel directory operations with independent
+/// inode locks.
+pub const FUSE_PARALLEL_DIROPS: u32 = 1 << 18;
+
+/// FUSE init capability bit: the daemon handles suid/sgid clearing on write.
+pub const FUSE_HANDLE_KILLPRIV: u32 = 1 << 19;
+
+/// FUSE init capability bit: kernel aborts the connection on daemon errors.
+pub const FUSE_ABORT_ERROR: u32 = 1 << 21;
+
+/// FUSE init capability bit: kernel may cache symlink targets.
+pub const FUSE_CACHE_SYMLINKS: u32 = 1 << 23;
+
+/// FUSE init capability bit: skip opendir notifications to the daemon.
+pub const FUSE_NO_OPENDIR_SUPPORT: u32 = 1 << 24;
+
+/// FUSE init capability bit: kernel does not auto-invalidate page cache on
+/// write; the daemon sends explicit invalidation.
+pub const FUSE_EXPLICIT_INVAL_DATA: u32 = 1 << 25;
+
+/// FUSE init capability bit: enhanced killpriv semantics (ABI 7.37).
+pub const FUSE_HANDLE_KILLPRIV_V2: u32 = 1 << 28;
+
+/// FUSE init capability bit: extended xattr error reporting (ABI 7.37).
+pub const FUSE_SETXATTR_EXT: u32 = 1 << 29;
+
 pub const FUSE_WRITEBACK_CACHE: u32 = 1 << 16;
 
 pub const FUSE_POSIX_ACL: u32 = 1 << 20;
@@ -154,7 +187,19 @@ pub const SUPPORTED_INIT_FLAGS: u32 = FUSE_ASYNC_READ
     | FUSE_DO_READDIRPLUS
     | FUSE_POSIX_LOCKS
     | FUSE_FLOCK_LOCKS
-    | FUSE_MAX_PAGES;
+    | FUSE_MAX_PAGES
+    | FUSE_SPLICE_MOVE
+    | FUSE_SPLICE_WRITE
+    | FUSE_SPLICE_READ
+    | FUSE_DONT_MASK
+    | FUSE_PARALLEL_DIROPS
+    | FUSE_HANDLE_KILLPRIV
+    | FUSE_ABORT_ERROR
+    | FUSE_CACHE_SYMLINKS
+    | FUSE_NO_OPENDIR_SUPPORT
+    | FUSE_EXPLICIT_INVAL_DATA
+    | FUSE_HANDLE_KILLPRIV_V2
+    | FUSE_SETXATTR_EXT;
 
 /// Human-readable FUSE init-capability names; unknown bits are kept as hex.
 pub fn fuse_init_flag_names(flags: u32) -> Vec<String> {


### PR DESCRIPTION
# Summary

Restore FUSE sequential write throughput that regressed ~1/3 after the init capability allowlist (#1088/#1183) started advertising only \SUPPORTED_INIT_FLAGS & kernel_flags\. Complete \SUPPORTED_INIT_FLAGS\ with the remaining implemented caps so every kernel-offered capability the daemon supports is negotiated; WRITEBACK_CACHE and SPLICE_* stay config-gated.

# Issue Describe / Design

Closes #1480

Root cause: the explicit allowlist only advertised caps present in both the daemon list and the kernel offer. Kernel-offered caps missing from \SUPPORTED_INIT_FLAGS\ (HANDLE_KILLPRIV, PARALLEL_DIROPS, EXPLICIT_INVAL_DATA, ...) were silently dropped, and the kernel fell back to conservative paths (per-write killpriv checks, page-cache invalidation, serialized directory ops, ...).

Key evidence:
- Sequential write throughput dropped by ~1/3 (696 -> 479 MB/s) vs. the pre-allowlist behavior.
- Raising concurrency did not recover the throughput: the bottleneck was the negotiated capability set, not parallelism.

Fix approach: extend \SUPPORTED_INIT_FLAGS\ (adds SPLICE_MOVE/WRITE/READ, DONT_MASK, PARALLEL_DIROPS, HANDLE_KILLPRIV, ABORT_ERROR, CACHE_SYMLINKS, NO_OPENDIR_SUPPORT, EXPLICIT_INVAL_DATA, HANDLE_KILLPRIV_V2, SETXATTR_EXT) and keep WRITEBACK_CACHE / SPLICE_* gated on config. Unsafe caps (ATOMIC_O_TRUNC, POSIX_ACL, HAS_IOCTL_DIR, EXPORT_SUPPORT, INIT_EXT) remain unadvertised.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| \curvine-fuse/src/lib.rs\ | Add 10 FUSE init flag constants; extend \SUPPORTED_INIT_FLAGS\ from 8 to 21 bits | Behavior change: more negotiated caps |
| \curvine-fuse/src/fs/curvine_file_system.rs\ | \
egotiate_out_flags\ takes \&FuseConf\; WRITEBACK_CACHE / SPLICE_* config-gated with explicit clearing | None (default config unchanged) |
| \curvine-fuse/src/fs/curvine_file_system.rs\ | Update unit tests to the negotiated-allowlist semantics | None |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| \cargo test -p curvine-fuse negotiate_out_flags\ | PASS | allowlist, config gating, containment |
| Sequential write bench (dd) | 696 MB/s restored | was 479 MB/s (~1/3 regression) |
| Concurrency sweep | no throughput gain | confirms capability negotiation, not parallelism |

# Dependencies

- Related issues: #1480 (Closes), #1088/#1183 (regression source)
- Related PRs: None
- Blocks / blocked by: None