### PR TITLE
fix(fuse): preserve hard links and stabilize file locking (CUR-230)

### DIFF
--- a/crates/client/curvine-client-core/src/block/block_reader.rs
+++ b/crates/client/curvine-client-core/src/block/block_reader.rs
@@ -183,20 +183,36 @@ impl BlockReader {
             let short_circuit = short_circuit && fs_context.is_local_worker(loc);
             let res: FsResult<ReaderAdapter> = {
                 if short_circuit {
-                    let reader = BlockReaderLocal::new(
+                    let local = BlockReaderLocal::new(
                         fs_context.clone(),
                         block.clone(),
                         loc.clone(),
                         off,
                         len,
                     )
-                    .await?;
-                    Ok(Local(reader))
+                    .await;
+                    match local {
+                        Ok(reader) => Ok(Local(reader)),
+                        Err(e) => {
+                            warn!(
+                                "fail to create local block reader for {}, falling back to remote: {}",
+                                loc, e
+                            );
+                            BlockReaderRemote::new(
+                                &fs_context,
+                                block.clone(),
+                                loc.clone(),
+                                off,
+                                len,
+                            )
+                            .await
+                            .map(Remote)
+                        }
+                    }
                 } else {
-                    let reader =
-                        BlockReaderRemote::new(&fs_context, block.clone(), loc.clone(), off, len)
-                            .await?;
-                    Ok(Remote(reader))
+                    BlockReaderRemote::new(&fs_context, block.clone(), loc.clone(), off, len)
+                        .await
+                        .map(Remote)
                 }
             };
             match res {

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -56,6 +56,11 @@ pub struct CurvineFileSystem {
 }
 
 impl CurvineFileSystem {
+    fn is_ofd_lock_pid(pid: u32) -> bool {
+        // FUSE kernels have used both 0 and -1 for the pid of an OFD lock.
+        pid == 0 || pid == u32::MAX
+    }
+
     pub fn new(conf: ClusterConf, rt: Arc<Runtime>) -> FuseResult<Self> {
         FuseMetrics::ensure_init()?;
 
@@ -278,15 +283,11 @@ impl CurvineFileSystem {
         Ok(RenameFlags::from_bits(flags).unwrap_or(RenameFlags::empty()))
     }
 
-    fn to_file_lock(&self, arg: &fuse_lk_in, header_pid: u32) -> FileLock {
+    fn to_file_lock(&self, arg: &fuse_lk_in, _header_pid: u32) -> FileLock {
         let client_id = self.fs.cv().fs_context().clone_client_name();
-        // Prefer the flock pid from the kernel request; fall back to the FUSE
-        // header pid when the kernel leaves lk.pid unset (common on some paths).
-        let pid = if arg.lk.pid != 0 {
-            arg.lk.pid
-        } else {
-            header_pid
-        };
+        // Keep the kernel pid intact. OFD locks use either 0 or -1 depending on
+        // the kernel and are owned by the open file description, not a process.
+        let pid = arg.lk.pid;
         FileLock {
             client_id,
             owner_id: arg.owner,
@@ -2075,8 +2076,6 @@ impl fs::FileSystem for CurvineFileSystem {
         let path = self.state.get_path(op.header.nodeid)?;
         let lock = self.to_file_lock(op.arg, op.header.pid);
 
-        self.state.fs_fsync(op.header.nodeid, None).await?;
-
         let conflict = self.fs.get_lock(&path, lock).await?;
         let lk = match conflict {
             Some(lk) => fuse_file_lock {
@@ -2099,8 +2098,6 @@ impl fs::FileSystem for CurvineFileSystem {
         let path = self.state.get_path(op.header.nodeid)?;
         self.ensure_writable_path(&path, RpcCode::SetLock).await?;
         let handle = self.state.find_handle(op.header.nodeid, op.arg.fh)?;
-
-        self.state.fs_fsync(op.header.nodeid, None).await?;
 
         let mut lock = self.to_file_lock(op.arg, op.header.pid);
         let (flag, owner_id) = (lock.lock_flags, lock.owner_id);
@@ -2134,8 +2131,6 @@ impl fs::FileSystem for CurvineFileSystem {
         self.ensure_writable_path(&path, RpcCode::SetLock).await?;
         let handle = self.state.find_handle(op.header.nodeid, op.arg.fh)?;
 
-        self.state.fs_fsync(op.header.nodeid, None).await?;
-
         let conf = &self.fs.conf().client;
         let check_interval_min_ms = conf.sync_check_interval_min_ms;
         let check_interval_max_ms = conf.sync_check_interval_max_ms;
@@ -2144,6 +2139,9 @@ impl fs::FileSystem for CurvineFileSystem {
         let mut ticks: u64 = 0;
         let time = TimeSpent::new();
 
+        // Linux reports OFD locks with lk.pid == 0 or -1 and does not perform
+        // deadlock detection for F_OFD_SETLKW; keep them out of the POSIX wait graph.
+        let detect_deadlock = !Self::is_ofd_lock_pid(op.arg.lk.pid);
         let mut lock = self.to_file_lock(op.arg, op.header.pid);
         let is_unlock = lock.lock_type == LockType::UnLock;
         let full_range_unlock = Self::is_full_range_unlock(&lock);
@@ -2178,8 +2176,14 @@ impl fs::FileSystem for CurvineFileSystem {
             }
 
             let blocker = conflict.as_ref().expect("conflict lock");
-            let decision = wait_guard
-                .register_blocked_by(LockOwner::new(blocker.client_id.clone(), blocker.owner_id));
+            // An OFD blocker (pid == 0) does not represent a process wait edge,
+            // so a POSIX waiter blocked by it cannot close a POSIX deadlock cycle.
+            let decision = (detect_deadlock && !Self::is_ofd_lock_pid(blocker.pid)).then(|| {
+                wait_guard.register_blocked_by(LockOwner::new(
+                    blocker.client_id.clone(),
+                    blocker.owner_id,
+                ))
+            });
             debug!(
                 "plock SETLKW wait decision unique={} pid={} owner_id={} nodeid={} path={} range=[{},{}] blocker_pid={} blocker_owner_id={} blocker_range=[{},{}] decision={:?}",
                 op.header.unique,
@@ -2195,7 +2199,10 @@ impl fs::FileSystem for CurvineFileSystem {
                 blocker.end,
                 decision
             );
-            if decision.is_deadlock() {
+            if decision
+                .as_ref()
+                .is_some_and(PlockWaitDecision::is_process_deadlock)
+            {
                 // Cycle in the local wait graph. Re-sample Master once while
                 // keeping our edge published so a peer in a true multi-resource
                 // deadlock (LTP fcntl17) still observes the cycle. If the lock
@@ -2215,10 +2222,15 @@ impl fs::FileSystem for CurvineFileSystem {
                     return Ok(());
                 }
                 let blocker2 = conflict2.as_ref().expect("conflict lock");
-                let decision2 = wait_guard.register_blocked_by(LockOwner::new(
-                    blocker2.client_id.clone(),
-                    blocker2.owner_id,
-                ));
+                let decision2 = if !Self::is_ofd_lock_pid(blocker2.pid) {
+                    Some(wait_guard.register_blocked_by(LockOwner::new(
+                        blocker2.client_id.clone(),
+                        blocker2.owner_id,
+                    )))
+                } else {
+                    wait_guard.clear_blocked_by();
+                    None
+                };
                 debug!(
                     "plock SETLKW deadlock recheck unique={} pid={} owner_id={} nodeid={} path={} range=[{},{}] blocker_pid={} blocker_owner_id={} blocker_range=[{},{}] decision={:?}",
                     op.header.unique,
@@ -2234,19 +2246,21 @@ impl fs::FileSystem for CurvineFileSystem {
                     blocker2.end,
                     decision2
                 );
-                if let PlockWaitDecision::Deadlock { cycle, .. } = decision2 {
-                    debug!(
-                        "plock SETLKW returning EDEADLK unique={} pid={} owner_id={} nodeid={} path={} range=[{},{}] cycle={:?}",
-                        op.header.unique,
-                        lock.pid,
-                        lock.owner_id,
-                        op.header.nodeid,
-                        path,
-                        lock.start,
-                        lock.end,
-                        cycle
-                    );
-                    return err_fuse!(libc::EDEADLK);
+                if let Some(PlockWaitDecision::Deadlock { cycle, .. }) = decision2 {
+                    if cycle.spans_multiple_processes() {
+                        debug!(
+                            "plock SETLKW returning EDEADLK unique={} pid={} owner_id={} nodeid={} path={} range=[{},{}] cycle={:?}",
+                            op.header.unique,
+                            lock.pid,
+                            lock.owner_id,
+                            op.header.nodeid,
+                            path,
+                            lock.start,
+                            lock.end,
+                            cycle
+                        );
+                        return err_fuse!(libc::EDEADLK);
+                    }
                 }
             }
 
@@ -2832,17 +2846,9 @@ mod tests {
     // or any other unsupported capability, even when the kernel offers it. The
     // allowlist mask drops them.
     //
-    // FUSE_EXPORT_SUPPORT is included here (dropped even when offered): its `.`/`..`
-    // reconstruction relies on root `.`/`..` lookups that currently return ENOENT,
-    // so the daemon must not advertise it. Not advertising it leaves the kernel's
-    // `fc->export_support` unset, so the kernel never issues the root `.`/`..` LOOKUP.
     #[test]
     fn negotiate_out_flags_drops_unsupported_kernel_caps() {
-        let unsupported = FUSE_ATOMIC_O_TRUNC
-            | FUSE_POSIX_ACL
-            | FUSE_HAS_IOCTL_DIR
-            | FUSE_EXPORT_SUPPORT
-            | (1u32 << 30);
+        let unsupported = FUSE_ATOMIC_O_TRUNC | FUSE_POSIX_ACL | FUSE_HAS_IOCTL_DIR | (1u32 << 30);
         let out = CurvineFileSystem::negotiate_out_flags(unsupported, false, false);
         assert_eq!(
             out, 0,
@@ -2850,13 +2856,14 @@ mod tests {
         );
     }
 
-    // EXPORT_SUPPORT stays out: Curvine cannot serve kernel `.`/`..` handle reconstruction.
+    // Root `.`/`..` lookup reconstruction is supported, so kernel file handles
+    // remain valid across dcache eviction.
     #[test]
-    fn export_support_not_in_allowlist() {
+    fn export_support_is_in_allowlist() {
         assert_eq!(
             SUPPORTED_INIT_FLAGS & FUSE_EXPORT_SUPPORT,
-            0,
-            "FUSE_EXPORT_SUPPORT must not be advertised until root `.`/`..` lookup works"
+            FUSE_EXPORT_SUPPORT,
+            "FUSE_EXPORT_SUPPORT must be advertised when root lookup works"
         );
     }
 

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -2178,12 +2178,15 @@ impl fs::FileSystem for CurvineFileSystem {
             let blocker = conflict.as_ref().expect("conflict lock");
             // An OFD blocker (pid == 0) does not represent a process wait edge,
             // so a POSIX waiter blocked by it cannot close a POSIX deadlock cycle.
-            let decision = (detect_deadlock && !Self::is_ofd_lock_pid(blocker.pid)).then(|| {
-                wait_guard.register_blocked_by(LockOwner::new(
+            let decision = if detect_deadlock && !Self::is_ofd_lock_pid(blocker.pid) {
+                Some(wait_guard.register_blocked_by(LockOwner::new(
                     blocker.client_id.clone(),
                     blocker.owner_id,
-                ))
-            });
+                )))
+            } else {
+                wait_guard.clear_blocked_by();
+                None
+            };
             debug!(
                 "plock SETLKW wait decision unique={} pid={} owner_id={} nodeid={} path={} range=[{},{}] blocker_pid={} blocker_owner_id={} blocker_range=[{},{}] decision={:?}",
                 op.header.unique,

--- a/curvine-fuse/src/fs/dcache/dir_tree.rs
+++ b/curvine-fuse/src/fs/dcache/dir_tree.rs
@@ -28,6 +28,19 @@ use curvine_runtime::sync::AtomicCounter;
 use log::info;
 use std::collections::hash_map::Iter;
 
+/// Snapshot of dentry state before `unlink`, used to roll back local mutations when
+/// the master delete fails.
+#[derive(Debug, Clone)]
+pub struct UnlinkRollback {
+    pub ino: u64,
+    pub parent: u64,
+    pub name: String,
+    pub set_inode_mark_delete: bool,
+    pub canonical_parent: u64,
+    pub canonical_name: String,
+    pub repointed: bool,
+}
+
 pub struct DirTree {
     inodes: FastHashMap<u64, Inode>,
     id_creator: AtomicCounter,
@@ -271,20 +284,31 @@ impl DirTree {
         self.get_inode_mut_check(ino, None)
     }
 
-    pub fn unlink(&mut self, parent: u64, name: &str, mark_delete: bool) -> FuseResult<bool> {
+    pub fn unlink(
+        &mut self,
+        parent: u64,
+        name: &str,
+        mark_delete: bool,
+    ) -> FuseResult<(bool, UnlinkRollback)> {
         let ino = self.get_ino_check(parent, Some(name))?;
-        let (last_link, should_remove) = {
+        let (canonical_parent, canonical_name, was_canonical) = {
+            let inode = self.get_inode_check(ino, None)?;
+            let was_canonical = inode.parent == parent && inode.name == name;
+            (inode.parent, inode.name.clone(), was_canonical)
+        };
+        let (last_link, should_remove, set_inode_mark_delete) = {
             let inode = self.get_inode_mut_check(ino, None)?;
             // Only mark the whole inode deleted when removing its last link.
             // Otherwise remaining hardlink names would see is_deleted() and
             // LOOKUP would spuriously return ENOENT (LTP prot_hsymlinks cleanup).
             let last_link = inode.nlink <= 1;
-            if mark_delete && last_link {
+            let set_inode_mark_delete = mark_delete && last_link;
+            if set_inode_mark_delete {
                 inode.mark_delete = true;
             }
             inode.sub_ref(1);
             inode.sub_link(1);
-            (last_link, inode.should_unref())
+            (last_link, inode.should_unref(), set_inode_mark_delete)
         };
 
         // Remove directory entry; keep parent inode's `DirEntry` even when `children` is empty.
@@ -296,7 +320,8 @@ impl DirTree {
 
         // get_path(ino) is used for subsequent opens. If the canonical dentry
         // was removed, repoint it at one of the surviving hard-link names.
-        if !last_link {
+        let mut repointed = false;
+        if !last_link && was_canonical {
             let replacement = self.inodes.iter().find_map(|(parent_ino, parent_inode)| {
                 parent_inode.dir.as_ref().and_then(|entry| {
                     entry.children.iter().find_map(|(child_name, child_ino)| {
@@ -308,6 +333,7 @@ impl DirTree {
                 let inode = self.get_inode_mut_check(ino, None)?;
                 inode.parent = new_parent;
                 inode.name = new_name;
+                repointed = true;
             }
         }
 
@@ -315,7 +341,59 @@ impl DirTree {
             self.remove_inode(ino);
         }
 
-        Ok(last_link)
+        let rollback = UnlinkRollback {
+            ino,
+            parent,
+            name: name.to_owned(),
+            set_inode_mark_delete,
+            canonical_parent,
+            canonical_name,
+            repointed,
+        };
+        Ok((last_link, rollback))
+    }
+
+    pub fn restore_unlink(&mut self, rb: UnlinkRollback) -> FuseResult<()> {
+        if self.get_inode(rb.ino, None).is_none() {
+            return Ok(());
+        }
+
+        if rb.repointed {
+            let inode = self.get_inode_mut_check(rb.ino, None)?;
+            inode.parent = rb.canonical_parent;
+            inode.name = rb.canonical_name.clone();
+        }
+
+        {
+            let inode = self.get_inode_mut_check(rb.ino, None)?;
+            inode.add_ref(1);
+            inode.add_link(1);
+            inode.mark_delete = false;
+        }
+
+        let parent_dir = self.get_dir_mut_check(rb.parent)?;
+        parent_dir.add_child(rb.name, rb.ino);
+        Ok(())
+    }
+
+    pub fn canonical_matches(&self, ino: u64, parent: u64, name: &str) -> bool {
+        self.get_inode(ino, None)
+            .is_some_and(|inode| inode.parent == parent && inode.name == name)
+    }
+
+    pub fn repoint_canonical(&mut self, ino: u64, parent: u64, name: String) -> FuseResult<()> {
+        let inode = self.get_inode_mut_check(ino, None)?;
+        inode.parent = parent;
+        inode.name = name;
+        Ok(())
+    }
+
+    pub fn cached_dir_inos(&self) -> Vec<u64> {
+        self.inodes
+            .iter()
+            .filter(|(_, inode)| inode.status.is_dir)
+            .map(|(ino, _)| *ino)
+            .collect()
     }
 
     pub fn forget(&mut self, ino: u64, n_lookup: u64) -> FuseResult<()> {
@@ -1039,6 +1117,26 @@ mod test {
         assert!(surviving_path.contains("newdir"), "{surviving_path}");
         assert!(surviving_path.contains("newfile"));
         assert!(!surviving_path.contains("oldfile"));
+    }
+
+    #[test]
+    fn unlink_rollback_restores_dentry_and_link_count() {
+        let mut t = DirTree::default();
+        let mut st = file_st("f", 0);
+        st.nlink = 1;
+        let f = t.lookup(FUSE_ROOT_ID, "f", st, true).unwrap().ino;
+        let nlink_before = t.get_inode_check(f, None).unwrap().nlink;
+        let (_, rollback) = t.unlink(FUSE_ROOT_ID, "f", true).unwrap();
+        assert!(t.get_inode(FUSE_ROOT_ID, Some("f")).is_none());
+        assert_eq!(
+            t.get_inode_check(f, None).unwrap().nlink,
+            nlink_before.saturating_sub(1)
+        );
+
+        t.restore_unlink(rollback).unwrap();
+        assert_eq!(t.get_inode(FUSE_ROOT_ID, Some("f")).unwrap().ino, f);
+        assert_eq!(t.get_inode_check(f, None).unwrap().nlink, nlink_before);
+        assert!(!t.get_inode_check(f, None).unwrap().mark_delete);
     }
 
     /// Hard link: `link` adds ref_ctr; each `unlink` of a dirent subtracts ref_ctr; inode removed when zero (after forget if n_lookup).

--- a/curvine-fuse/src/fs/dcache/dir_tree.rs
+++ b/curvine-fuse/src/fs/dcache/dir_tree.rs
@@ -271,9 +271,9 @@ impl DirTree {
         self.get_inode_mut_check(ino, None)
     }
 
-    pub fn unlink(&mut self, parent: u64, name: &str, mark_delete: bool) -> FuseResult<()> {
+    pub fn unlink(&mut self, parent: u64, name: &str, mark_delete: bool) -> FuseResult<bool> {
         let ino = self.get_ino_check(parent, Some(name))?;
-        let should_remove = {
+        let (last_link, should_remove) = {
             let inode = self.get_inode_mut_check(ino, None)?;
             // Only mark the whole inode deleted when removing its last link.
             // Otherwise remaining hardlink names would see is_deleted() and
@@ -284,7 +284,7 @@ impl DirTree {
             }
             inode.sub_ref(1);
             inode.sub_link(1);
-            inode.should_unref()
+            (last_link, inode.should_unref())
         };
 
         // Remove directory entry; keep parent inode's `DirEntry` even when `children` is empty.
@@ -294,11 +294,28 @@ impl DirTree {
             dir.mark_deleted_child(name);
         }
 
+        // get_path(ino) is used for subsequent opens. If the canonical dentry
+        // was removed, repoint it at one of the surviving hard-link names.
+        if !last_link {
+            let replacement = self.inodes.iter().find_map(|(parent_ino, parent_inode)| {
+                parent_inode.dir.as_ref().and_then(|entry| {
+                    entry.children.iter().find_map(|(child_name, child_ino)| {
+                        (*child_ino == ino).then(|| (*parent_ino, child_name.clone()))
+                    })
+                })
+            });
+            if let Some((new_parent, new_name)) = replacement {
+                let inode = self.get_inode_mut_check(ino, None)?;
+                inode.parent = new_parent;
+                inode.name = new_name;
+            }
+        }
+
         if should_remove && !mark_delete {
             self.remove_inode(ino);
         }
 
-        Ok(())
+        Ok(last_link)
     }
 
     pub fn forget(&mut self, ino: u64, n_lookup: u64) -> FuseResult<()> {
@@ -1009,12 +1026,19 @@ mod test {
             .unwrap()
             .ino;
         let before = t.get_path(f).unwrap().full_path().to_string();
-        t.link(f, 501, "newfile", file_st("newfile", f as i64))
-            .unwrap();
+        let mut link_status = file_st("newfile", f as i64);
+        link_status.nlink = 2;
+        t.link(f, 501, "newfile", link_status).unwrap();
         let after = t.get_path(f).unwrap().full_path().to_string();
         assert_eq!(after, before);
         assert!(after.contains("olddir"));
         assert!(after.contains("oldfile"));
+
+        t.unlink(500, "oldfile", true).unwrap();
+        let surviving_path = t.get_path(f).unwrap().full_path().to_string();
+        assert!(surviving_path.contains("newdir"), "{surviving_path}");
+        assert!(surviving_path.contains("newfile"));
+        assert!(!surviving_path.contains("oldfile"));
     }
 
     /// Hard link: `link` adds ref_ctr; each `unlink` of a dirent subtracts ref_ctr; inode removed when zero (after forget if n_lookup).

--- a/curvine-fuse/src/fs/dcache/mod.rs
+++ b/curvine-fuse/src/fs/dcache/mod.rs
@@ -21,7 +21,7 @@ mod dir_entry;
 pub use self::dir_entry::DirEntry;
 
 mod dir_tree;
-pub use self::dir_tree::DirTree;
+pub use self::dir_tree::{DirTree, UnlinkRollback};
 
 mod cleaner_task;
 pub use self::cleaner_task::CleanerTask;

--- a/curvine-fuse/src/fs/fuse_writer.rs
+++ b/curvine-fuse/src/fs/fuse_writer.rs
@@ -178,7 +178,10 @@ impl FuseWriter {
     pub async fn flush(&self, reply: Option<FuseResponse>) -> FsResult<()> {
         let fun = async {
             let (rx, tx) = CallChannel::channel();
-            self.send_queued_task(WriteTask::Flush(rx, reply)).await?;
+            {
+                let _gate = self.enqueue_gate.lock().await;
+                self.send_queued_task(WriteTask::Flush(rx, reply)).await?;
+            }
             // Propagate backend flush failures even on reply=None paths.
             tx.receive().await??;
             Ok::<(), FsError>(())

--- a/curvine-fuse/src/fs/plock_wait_registry.rs
+++ b/curvine-fuse/src/fs/plock_wait_registry.rs
@@ -95,6 +95,18 @@ impl PlockDeadlockCycle {
             edges,
         }
     }
+
+    /// POSIX deadlock detection is process based. A cycle whose waiters all
+    /// report the same pid can be formed by independent OFD owners in one
+    /// process and must not be surfaced as EDEADLK.
+    pub fn spans_multiple_processes(&self) -> bool {
+        let Some(first) = self.edges.first() else {
+            return false;
+        };
+        self.edges
+            .iter()
+            .any(|edge| edge.info.pid != first.info.pid)
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -110,8 +122,16 @@ pub(crate) enum PlockWaitDecision {
 }
 
 impl PlockWaitDecision {
+    #[cfg(test)]
     pub fn is_deadlock(&self) -> bool {
         matches!(self, Self::Deadlock { .. })
+    }
+
+    pub fn is_process_deadlock(&self) -> bool {
+        matches!(
+            self,
+            Self::Deadlock { cycle, .. } if cycle.spans_multiple_processes()
+        )
     }
 }
 
@@ -345,6 +365,21 @@ mod tests {
         assert!(reg
             .register_blocked_by(b.clone(), a.clone(), wait_info(2))
             .is_deadlock());
+    }
+
+    #[test]
+    fn same_process_ofd_cycle_is_not_a_process_deadlock() {
+        let reg = PlockWaitRegistry::new();
+        let fd1 = LockOwner::new("c", 1);
+        let fd2 = LockOwner::new("c", 2);
+        let same_pid = |unique| LockWaitInfo::new(unique, 42, 1, "/locks", 0, 4);
+
+        assert!(!reg
+            .register_blocked_by(fd1.clone(), fd2.clone(), same_pid(1))
+            .is_process_deadlock());
+        let decision = reg.register_blocked_by(fd2, fd1, same_pid(2));
+        assert!(decision.is_deadlock());
+        assert!(!decision.is_process_deadlock());
     }
 
     #[test]

--- a/curvine-fuse/src/fs/state/node_state.rs
+++ b/curvine-fuse/src/fs/state/node_state.rs
@@ -24,7 +24,7 @@ use crate::fuse_metrics::{
 use crate::raw::fuse_abi::{fuse_attr, fuse_forget_one};
 use crate::{
     err_fuse, FuseError, FuseMetrics, FuseResult, FuseUtils, FUSE_CURRENT_DIR, FUSE_PARENT_DIR,
-    FUSE_PATH_SEPARATOR, FUSE_ROOT_ID, STATE_FILE_MAGIC, STATE_FILE_VERSION,
+    FUSE_ROOT_ID, STATE_FILE_MAGIC, STATE_FILE_VERSION,
 };
 use curvine_client::unified::UnifiedFileSystem;
 use curvine_config::ClusterConf;
@@ -279,7 +279,7 @@ impl NodeState {
     pub fn unlink(&self, ino: u64, name: &str, mark_delete: bool) -> FuseResult<bool> {
         let before = self.dir_read().inode_lens();
         let mut dir = self.dir_write();
-        let last_link = dir.unlink(ino, name, mark_delete)?;
+        let (last_link, _) = dir.unlink(ino, name, mark_delete)?;
         let after = dir.inode_lens();
         drop(dir);
         for _ in 0..before.saturating_sub(after) {
@@ -288,6 +288,51 @@ impl NodeState {
             });
         }
         Ok(last_link)
+    }
+
+    fn restore_unlink_state(&self, rollback: crate::fs::dcache::UnlinkRollback) -> FuseResult<()> {
+        self.dir_write().restore_unlink(rollback)
+    }
+
+    async fn repoint_canonical_from_master(
+        &self,
+        ino: u64,
+        removed_parent: u64,
+        removed_name: &str,
+    ) -> FuseResult<()> {
+        let (master_id, needs_repoint) = {
+            let dir = self.dir_read();
+            let Some(inode) = dir.get_inode(ino, None) else {
+                return Ok(());
+            };
+            let needs = dir.canonical_matches(ino, removed_parent, removed_name);
+            (inode.status.id, needs)
+        };
+        if !needs_repoint || master_id <= 0 {
+            return Ok(());
+        }
+
+        let dir_inos = self.dir_read().cached_dir_inos();
+        for dir_ino in dir_inos {
+            let path = match self.get_path_common(dir_ino, None) {
+                Ok(path) => path,
+                Err(_) => continue,
+            };
+            let statuses = match self.fs.list_status(&path).await {
+                Ok(statuses) => statuses,
+                Err(_) => continue,
+            };
+            for status in statuses {
+                if status.id == master_id
+                    && !(dir_ino == removed_parent && status.name == removed_name)
+                {
+                    let name = status.name.clone();
+                    self.dir_write().repoint_canonical(ino, dir_ino, name)?;
+                    return Ok(());
+                }
+            }
+        }
+        Ok(())
     }
 
     pub fn forget(&self, ino: u64, n_lookup: u64) -> FuseResult<()> {
@@ -662,10 +707,10 @@ impl NodeState {
 
         // Always mark for deletion and remove the directory entry first, and check
         // has_open_handles inside the same dir_write critical section.
-        let (has_handles, last_link) = {
+        let (has_handles, last_link, rollback) = {
             let mut dir = self.dir_write();
-            let last_link = dir.unlink(parent, name, true)?;
-            (self.has_open_handles(ino), last_link)
+            let (last_link, rollback) = dir.unlink(parent, name, true)?;
+            (self.has_open_handles(ino), last_link, rollback)
         };
 
         // Removing one of several hard links must reach the master immediately:
@@ -673,10 +718,14 @@ impl NodeState {
         // directory entry. Open handles do not require deferral while another
         // link still keeps the inode alive.
         if !last_link {
+            if !rollback.repointed && self.dir_read().canonical_matches(ino, parent, name) {
+                self.repoint_canonical_from_master(ino, parent, name)
+                    .await?;
+            }
             match self.fs.delete(&path, false).await {
                 Ok(()) | Err(FsError::FileNotFound(_)) => (),
                 Err(e) => {
-                    self.clear_unlink_state(ino, parent, name)?;
+                    self.restore_unlink_state(rollback)?;
                     return Err(e.into());
                 }
             }
@@ -702,7 +751,7 @@ impl NodeState {
             Ok(()) => (),
             Err(FsError::FileNotFound(_)) => (),
             Err(e) => {
-                self.clear_unlink_state(ino, parent, name)?;
+                self.restore_unlink_state(rollback)?;
                 return Err(e.into());
             }
         }
@@ -868,26 +917,34 @@ impl NodeState {
     }
 
     pub async fn fs_lookup(&self, ino: u64, name: &str) -> FuseResult<fuse_attr> {
+        if name == FUSE_CURRENT_DIR || name == FUSE_PARENT_DIR {
+            let dir = self.dir_read();
+            let inode = dir.get_inode_check(ino, None)?;
+            let to_root = inode.is_root()
+                || (name == FUSE_PARENT_DIR && dir.get_inode_check(inode.parent, None)?.is_root());
+            if to_root {
+                let root = dir.get_inode_check(FUSE_ROOT_ID, None)?;
+                if self.conf.metrics_enabled {
+                    FuseMetrics::with(|m| m.record_node_cache_lookup(CACHE_RESULT_HIT));
+                }
+                let mut attr = root.to_attr(&self.conf)?;
+                attr.ino = FUSE_ROOT_ID;
+                return Ok(attr);
+            }
+        }
+
         let (ino, cow_name) = if name == FUSE_CURRENT_DIR {
             let dir = self.dir_read();
             let inode = dir.get_inode_check(ino, None)?;
-            if inode.is_root() {
-                (FUSE_ROOT_ID, Cow::Owned(FUSE_PATH_SEPARATOR.to_owned()))
-            } else {
-                (inode.parent, Cow::Owned(inode.name.to_owned()))
-            }
+            (inode.parent, Cow::Owned(inode.name.to_owned()))
         } else if name == FUSE_PARENT_DIR {
             let dir = self.dir_read();
             let inode = dir.get_inode_check(ino, None)?;
-            if inode.is_root() {
-                (FUSE_ROOT_ID, Cow::Owned(FUSE_PATH_SEPARATOR.to_owned()))
-            } else {
-                let parent_inode = dir.get_inode_check(inode.parent, None)?;
-                (
-                    parent_inode.parent,
-                    Cow::Owned(parent_inode.name.to_owned()),
-                )
-            }
+            let parent_inode = dir.get_inode_check(inode.parent, None)?;
+            (
+                parent_inode.parent,
+                Cow::Owned(parent_inode.name.to_owned()),
+            )
         } else {
             (ino, Cow::Borrowed(name))
         };
@@ -1723,6 +1780,53 @@ mod test {
             .complete_deferred_delete(ino, Err(FsError::file_not_found("/pending")))
             .unwrap();
         assert!(!state.dir_read().pending_delete(ino));
+    }
+
+    #[test]
+    fn fs_lookup_root_dot_and_dotdot_returns_root_attr() {
+        let rt = Arc::new(AsyncRuntime::single());
+        rt.block_on(async {
+            let fs = UnifiedFileSystem::with_rt(ClusterConf::default(), rt.clone()).unwrap();
+            let state = NodeState::new(fs).unwrap();
+
+            let dot = state
+                .fs_lookup(FUSE_ROOT_ID, crate::FUSE_CURRENT_DIR)
+                .await
+                .unwrap();
+            let dotdot = state
+                .fs_lookup(FUSE_ROOT_ID, crate::FUSE_PARENT_DIR)
+                .await
+                .unwrap();
+            assert_eq!(dot.ino, FUSE_ROOT_ID);
+            assert_eq!(dotdot.ino, FUSE_ROOT_ID);
+        });
+    }
+
+    #[test]
+    fn fs_lookup_child_of_root_dotdot_returns_root_attr() {
+        let rt = Arc::new(AsyncRuntime::single());
+        rt.block_on(async {
+            let fs = UnifiedFileSystem::with_rt(ClusterConf::default(), rt.clone()).unwrap();
+            let state = NodeState::new(fs).unwrap();
+
+            let child_ino = {
+                let mut dir = state.dir_write();
+                dir.lookup(
+                    FUSE_ROOT_ID,
+                    "child",
+                    FileStatus::with_name(42, "child".to_string(), false),
+                    true,
+                )
+                .unwrap()
+                .ino
+            };
+
+            let parent = state
+                .fs_lookup(child_ino, crate::FUSE_PARENT_DIR)
+                .await
+                .unwrap();
+            assert_eq!(parent.ino, FUSE_ROOT_ID);
+        });
     }
 
     #[cfg(target_os = "linux")]

--- a/curvine-fuse/src/fs/state/node_state.rs
+++ b/curvine-fuse/src/fs/state/node_state.rs
@@ -24,7 +24,7 @@ use crate::fuse_metrics::{
 use crate::raw::fuse_abi::{fuse_attr, fuse_forget_one};
 use crate::{
     err_fuse, FuseError, FuseMetrics, FuseResult, FuseUtils, FUSE_CURRENT_DIR, FUSE_PARENT_DIR,
-    FUSE_ROOT_ID, STATE_FILE_MAGIC, STATE_FILE_VERSION,
+    FUSE_PATH_SEPARATOR, FUSE_ROOT_ID, STATE_FILE_MAGIC, STATE_FILE_VERSION,
 };
 use curvine_client::unified::UnifiedFileSystem;
 use curvine_config::ClusterConf;
@@ -276,10 +276,10 @@ impl NodeState {
         dir.get_inode(ino, name).is_some()
     }
 
-    pub fn unlink(&self, ino: u64, name: &str, mark_delete: bool) -> FuseResult<()> {
+    pub fn unlink(&self, ino: u64, name: &str, mark_delete: bool) -> FuseResult<bool> {
         let before = self.dir_read().inode_lens();
         let mut dir = self.dir_write();
-        dir.unlink(ino, name, mark_delete)?;
+        let last_link = dir.unlink(ino, name, mark_delete)?;
         let after = dir.inode_lens();
         drop(dir);
         for _ in 0..before.saturating_sub(after) {
@@ -287,7 +287,7 @@ impl NodeState {
                 Self::dec_gauges_lockstep(&m.inode_num, &m.inode_count);
             });
         }
-        Ok(())
+        Ok(last_link)
     }
 
     pub fn forget(&self, ino: u64, n_lookup: u64) -> FuseResult<()> {
@@ -662,11 +662,27 @@ impl NodeState {
 
         // Always mark for deletion and remove the directory entry first, and check
         // has_open_handles inside the same dir_write critical section.
-        let has_handles = {
+        let (has_handles, last_link) = {
             let mut dir = self.dir_write();
-            dir.unlink(parent, name, true)?;
-            self.has_open_handles(ino)
+            let last_link = dir.unlink(parent, name, true)?;
+            (self.has_open_handles(ino), last_link)
         };
+
+        // Removing one of several hard links must reach the master immediately:
+        // the master owns the authoritative nlink count and removes only this
+        // directory entry. Open handles do not require deferral while another
+        // link still keeps the inode alive.
+        if !last_link {
+            match self.fs.delete(&path, false).await {
+                Ok(()) | Err(FsError::FileNotFound(_)) => (),
+                Err(e) => {
+                    self.clear_unlink_state(ino, parent, name)?;
+                    return Err(e.into());
+                }
+            }
+            self.clear_unlink_state(ino, parent, name)?;
+            return Ok(());
+        }
 
         if has_handles {
             debug!("unlink ino={}, path={}: open handles, deferring", ino, path);
@@ -852,17 +868,26 @@ impl NodeState {
     }
 
     pub async fn fs_lookup(&self, ino: u64, name: &str) -> FuseResult<fuse_attr> {
-        // NOTE: the `.`/`..` branches below are BROKEN wherever they resolve through the root, because
-        // root's `parent` is the `0` sentinel and inode 0 does not exist.
         let (ino, cow_name) = if name == FUSE_CURRENT_DIR {
             let dir = self.dir_read();
             let inode = dir.get_inode_check(ino, None)?;
-            (inode.parent, Cow::Owned(inode.name.to_owned()))
+            if inode.is_root() {
+                (FUSE_ROOT_ID, Cow::Owned(FUSE_PATH_SEPARATOR.to_owned()))
+            } else {
+                (inode.parent, Cow::Owned(inode.name.to_owned()))
+            }
         } else if name == FUSE_PARENT_DIR {
             let dir = self.dir_read();
-            let parent_inode = dir.get_inode_check(ino, None)?;
-            let inode = dir.get_inode_check(parent_inode.parent, None)?;
-            (inode.parent, Cow::Owned(inode.name.to_owned()))
+            let inode = dir.get_inode_check(ino, None)?;
+            if inode.is_root() {
+                (FUSE_ROOT_ID, Cow::Owned(FUSE_PATH_SEPARATOR.to_owned()))
+            } else {
+                let parent_inode = dir.get_inode_check(inode.parent, None)?;
+                (
+                    parent_inode.parent,
+                    Cow::Owned(parent_inode.name.to_owned()),
+                )
+            }
         } else {
             (ino, Cow::Borrowed(name))
         };

--- a/curvine-fuse/src/lib.rs
+++ b/curvine-fuse/src/lib.rs
@@ -118,12 +118,11 @@ pub const FUSE_AUTO_INVAL_DATA: u32 = 1 << 12;
 /// Kernel exportfs support: enables `name_to_handle_at` / `open_by_handle_at` via
 /// `LOOKUP(nodeid, ".")` / `LOOKUP(nodeid, "..")` reconstruction.
 ///
-/// Deliberately NOT in `SUPPORTED_INIT_FLAGS` (see there): the reconstruction it
-/// promises relies on `NodeState::fs_lookup` handling `.`/`..` through the root,
-/// which today returns ENOENT wherever the resolution hits root's `0`-sentinel
-/// parent. Advertising the cap would expose a protocol path the daemon cannot
-/// satisfy. The constant is retained for `fuse_init_flag_names` (so an
-/// offered-but-not-enabled bit is logged).
+/// Advertised in `SUPPORTED_INIT_FLAGS` so that `name_to_handle_at` /
+/// `open_by_handle_at` remain usable after `drop_caches`. The kernel's
+/// `fuse_get_parent` / `fuse_get_dentry` short-circuit with `-ESTALE` when
+/// `fc->export_support` is unset, and `NodeState::fs_lookup` now handles root
+/// `.`/`..` correctly.
 pub const FUSE_EXPORT_SUPPORT: u32 = 1 << 4;
 
 /// Kernel init capability bit: the daemon handles O_TRUNC atomically inside
@@ -140,12 +139,7 @@ pub const FUSE_ATOMIC_O_TRUNC: u32 = 1 << 3;
 ///
 /// Deliberately EXCLUDED (never advertised): FUSE_ATOMIC_O_TRUNC (open does not
 /// truncate), FUSE_POSIX_ACL (no ACL handling), FUSE_HAS_IOCTL_DIR (no
-/// ioctl), FUSE_EXPORT_SUPPORT (its `.`/`..` reconstruction relies on root
-/// `.`/`..` lookups that currently return ENOENT — see `FUSE_EXPORT_SUPPORT`).
-/// Not advertising EXPORT_SUPPORT is sufficient to keep the broken root `.`/`..`
-/// path unreachable: the kernel's `fuse_get_parent` / `fuse_get_dentry` (the only
-/// sites that emit a `.`/`..` LOOKUP to the daemon) both short-circuit with
-/// `-ESTALE` when `fc->export_support` is unset.
+/// ioctl).
 pub const SUPPORTED_INIT_FLAGS: u32 = FUSE_ASYNC_READ
     | FUSE_BIG_WRITES
     | FUSE_ASYNC_DIO
@@ -154,7 +148,8 @@ pub const SUPPORTED_INIT_FLAGS: u32 = FUSE_ASYNC_READ
     | FUSE_DO_READDIRPLUS
     | FUSE_POSIX_LOCKS
     | FUSE_FLOCK_LOCKS
-    | FUSE_MAX_PAGES;
+    | FUSE_MAX_PAGES
+    | FUSE_EXPORT_SUPPORT;
 
 /// Human-readable FUSE init-capability names; unknown bits are kept as hex.
 pub fn fuse_init_flag_names(flags: u32) -> Vec<String> {

--- a/curvine-tests/regression/utils/cluster_utils.py
+++ b/curvine-tests/regression/utils/cluster_utils.py
@@ -103,11 +103,33 @@ def prepare_curvine_cluster(project_path, test_path='/curvine-fuse'):
             
             print("Curvine cluster started successfully")
             
-            # Wait a bit for cluster to be fully ready
-            print("Waiting for cluster to be ready...")
-            time.sleep(3)
-            
-            return True, ""
+            # A mounted FUSE endpoint is not sufficient: probe real I/O until
+            # the worker is registered and can serve the data path.
+            print("Waiting for cluster data path to be ready...")
+            deadline = time.time() + 120
+            probe_path = os.path.join(test_path, f".curvine-ready-{os.getpid()}")
+            last_error = "probe did not run"
+            while time.time() < deadline:
+                try:
+                    payload = b"curvine-ready" * 8192
+                    with open(probe_path, "wb") as probe:
+                        probe.write(payload)
+                        probe.flush()
+                        os.fsync(probe.fileno())
+                    with open(probe_path, "rb") as probe:
+                        if probe.read() != payload:
+                            raise OSError("read-back mismatch")
+                    os.unlink(probe_path)
+                    print("Cluster data path is ready")
+                    return True, ""
+                except OSError as exc:
+                    last_error = str(exc)
+                    try:
+                        os.unlink(probe_path)
+                    except OSError:
+                        pass
+                    time.sleep(2)
+            return False, f"Cluster mounted but data path was not ready: {last_error}"
         finally:
             os.chdir(original_cwd)
             

--- a/curvine-tests/regression/utils/cluster_utils.py
+++ b/curvine-tests/regression/utils/cluster_utils.py
@@ -105,31 +105,7 @@ def prepare_curvine_cluster(project_path, test_path='/curvine-fuse'):
             
             # A mounted FUSE endpoint is not sufficient: probe real I/O until
             # the worker is registered and can serve the data path.
-            print("Waiting for cluster data path to be ready...")
-            deadline = time.time() + 120
-            probe_path = os.path.join(test_path, f".curvine-ready-{os.getpid()}")
-            last_error = "probe did not run"
-            while time.time() < deadline:
-                try:
-                    payload = b"curvine-ready" * 8192
-                    with open(probe_path, "wb") as probe:
-                        probe.write(payload)
-                        probe.flush()
-                        os.fsync(probe.fileno())
-                    with open(probe_path, "rb") as probe:
-                        if probe.read() != payload:
-                            raise OSError("read-back mismatch")
-                    os.unlink(probe_path)
-                    print("Cluster data path is ready")
-                    return True, ""
-                except OSError as exc:
-                    last_error = str(exc)
-                    try:
-                        os.unlink(probe_path)
-                    except OSError:
-                        pass
-                    time.sleep(2)
-            return False, f"Cluster mounted but data path was not ready: {last_error}"
+            return probe_data_path_ready(test_path)
         finally:
             os.chdir(original_cwd)
             
@@ -139,6 +115,43 @@ def prepare_curvine_cluster(project_path, test_path='/curvine-fuse'):
         import traceback
         traceback.print_exc()
         return False, error_msg
+
+
+def probe_data_path_ready(test_path, deadline_seconds=120):
+    """Probe the mounted FUSE path until read/write I/O succeeds.
+
+    Args:
+        test_path: Mount point path to probe
+        deadline_seconds: Maximum seconds to wait (default: 120)
+
+    Returns:
+        tuple: (success: bool, error_message: str)
+    """
+    print("Waiting for cluster data path to be ready...")
+    deadline = time.time() + deadline_seconds
+    probe_path = os.path.join(test_path, f".curvine-ready-{os.getpid()}")
+    last_error = "probe did not run"
+    while time.time() < deadline:
+        try:
+            payload = b"curvine-ready" * 8192
+            with open(probe_path, "wb") as probe:
+                probe.write(payload)
+                probe.flush()
+                os.fsync(probe.fileno())
+            with open(probe_path, "rb") as probe:
+                if probe.read() != payload:
+                    raise OSError("read-back mismatch")
+            os.unlink(probe_path)
+            print("Cluster data path is ready")
+            return True, ""
+        except OSError as exc:
+            last_error = str(exc)
+            try:
+                os.unlink(probe_path)
+            except OSError:
+                pass
+            time.sleep(2)
+    return False, f"Cluster mounted but data path was not ready: {last_error}"
 
 
 def ensure_cluster_ready(project_path, test_path='/curvine-fuse', max_wait_seconds=10):
@@ -158,8 +171,8 @@ def ensure_cluster_ready(project_path, test_path='/curvine-fuse', max_wait_secon
     # First check if mount point is already ready
     is_mounted, mount_error = check_mount_point(test_path, max_wait_seconds=max_wait_seconds)
     if is_mounted:
-        print(f"Mount point {test_path} is already mounted and ready")
-        return True, ""
+        print(f"Mount point {test_path} is already mounted, probing data path...")
+        return probe_data_path_ready(test_path, deadline_seconds=max(max_wait_seconds, 120))
     
     # If not mounted, prepare the cluster
     print(f"Mount point {test_path} is not ready, preparing cluster...")
@@ -171,7 +184,11 @@ def ensure_cluster_ready(project_path, test_path='/curvine-fuse', max_wait_secon
     is_mounted, mount_error = check_mount_point(test_path, max_wait_seconds=max_wait_seconds)
     if not is_mounted:
         return False, f"Cluster prepared but mount point check failed: {mount_error}"
-    
+
+    success, probe_error = probe_data_path_ready(test_path, deadline_seconds=max(max_wait_seconds, 120))
+    if not success:
+        return False, probe_error
+
     print(f"Cluster is ready, mount point {test_path} is mounted")
     return True, ""
 


### PR DESCRIPTION
# Summary

Fix FUSE hard-link unlink semantics and export-support handle reconstruction, and stabilize concurrent advisory/OFD lock I/O so LTP fcntl36 and related lock tests pass without false EIO or EDEADLK.

Related to CUR-230. Closes #1486. Closes #1492.

# Issue Describe / Design

## Root cause

- Unlinking one name of a multi-link inode could leave stale canonical paths, incorrect nlink handling, and broken `name_to_handle_at` reconstruction after dentry cache eviction.
- Concurrent writes plus `fsync` could flush before all writes were queued, and advisory lock paths unnecessarily flushed file data.
- OFD locks (pid `0` / `-1`) were modeled as POSIX process wait edges, producing false deadlock detection; local short-circuit block reads could surface EIO when a local worker was temporarily unavailable.

## Fix approach

- Repoint surviving hard-link dentries, notify master on non-final unlinks, and enable `FUSE_EXPORT_SUPPORT` with working root `.`/`..` lookup.
- Serialize `FuseWriter::flush` behind the same enqueue gate as writes; remove data flush from lock RPC handlers.
- Exclude OFD waiters from the POSIX deadlock graph and only return `EDEADLK` for cross-process cycles.
- Fall back to remote block reads when local short-circuit reader creation fails.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-fuse/src/fs/dcache/dir_tree.rs` | Repoint inode after canonical hard-link unlink; keep `#1489` negative inode validation | Hard-link unlink correctness only |
| `curvine-fuse/src/fs/state/node_state.rs` | Master unlink for non-final links; root `.`/`..` lookup for export support | Hard-link + handle export paths |
| `curvine-fuse/src/lib.rs` | Advertise `FUSE_EXPORT_SUPPORT` | Enables kernel handle reconstruction after cache drop |
| `curvine-fuse/src/fs/fuse_writer.rs` | Gate flush behind write enqueue order | Fixes concurrent write/fsync ordering |
| `curvine-fuse/src/fs/curvine_file_system.rs` | Lock path flush removal; OFD/POSIX deadlock rules | Lock semantics only; no data-path regression |
| `curvine-fuse/src/fs/plock_wait_registry.rs` | Process-scoped deadlock detection | Fewer false `EDEADLK` on OFD tests |
| `crates/client/curvine-client-core/src/block/block_reader.rs` | Local→remote read fallback | Error-path only; avoids spurious EIO |
| `curvine-tests/regression/utils/cluster_utils.py` | Data-path readiness probe before FUSE tests | Test harness only |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| Harness `fast` profile | PASS | No new failures |
| Harness `integration` profile | PASS* | Two known baseline failures only |
| Harness `daily` profile | PASS* | Same two known baseline failures only |
| Harness `fuse` profile | PASS | No new failures |
| Harness `ltp` profile | PASS | `fcntl36` / `fcntl36_64` pass |
| Harness `csi` profile | PASS | No new failures |
| `cargo clippy -p curvine-fuse -p curvine-client-core` | PASS | Pre-PR check |
| Intermittent raft failure | N/A | Re-run cleared; treated as flake |

# Dependencies

- Related issues: #1486, #1492, CUR-230
- Blocks / blocked by: None
