### PR TITLE
fix(fuse): stabilize session and random reads (#1291)

### DIFF
--- a/crates/client/curvine-client-core/src/file/fs_context.rs
+++ b/crates/client/curvine-client-core/src/file/fs_context.rs
@@ -182,6 +182,32 @@ impl FsContext {
         self.os_cache.clone()
     }
 
+    /// Build a context for random reads without allocating another RPC runtime or
+    /// connection pool. Random readers use smaller block reads and must not ask
+    /// workers or the local page cache to prefetch contiguous data.
+    pub(crate) fn with_random_read_options(&self, read_chunk_size: usize) -> Arc<Self> {
+        let mut conf = self.conf.clone();
+        conf.client.read_chunk_size = read_chunk_size;
+        conf.client.read_chunk_size_str = format!("{read_chunk_size}B");
+        conf.client.enable_read_ahead = false;
+        conf.client.read_ahead_len = 0;
+        conf.client.read_ahead_len_str = "0B".to_owned();
+
+        Arc::new(Self {
+            conf,
+            connector: self.connector.clone(),
+            client_addr: self.client_addr.clone(),
+            os_cache: CacheManager::new(
+                false,
+                0,
+                self.os_cache.drop_cache_len,
+                read_chunk_size as i64,
+            ),
+            failed_workers: self.failed_workers.clone(),
+            block_pool: self.block_pool.clone(),
+        })
+    }
+
     pub fn get_metrics<'a>() -> &'a ClientMetrics {
         CLIENT_METRICS.get().expect("client get metrics error!")
     }
@@ -265,5 +291,31 @@ impl FsContext {
     async fn metrics_report(context: &Arc<FsContext>) -> FsResult<()> {
         let metrics = ClientMetrics::encode()?;
         FsClient::new(context.clone()).metrics_report(metrics).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn random_read_context_uses_small_chunks_without_prefetch() {
+        let mut conf = ClusterConf::default();
+        conf.client.read_chunk_size_str = "512KB".to_owned();
+        conf.client.read_chunk_num = 8;
+        conf.client.init().unwrap();
+
+        let context = FsContext::new(conf).unwrap();
+        let random = context.with_random_read_options(128 * 1024);
+
+        assert_eq!(random.read_chunk_size(), 128 * 1024);
+        assert_eq!(random.conf.client.read_chunk_size_str, "131072B");
+        assert!(!random.conf.client.enable_read_ahead);
+        assert_eq!(random.conf.client.read_ahead_len, 0);
+        assert_eq!(random.conf.client.read_ahead_len_str, "0B");
+        assert!(!random.os_cache.enable);
+        assert_eq!(random.os_cache.chunk_size, 128 * 1024);
+        assert!(Arc::ptr_eq(&context.connector, &random.connector));
+        assert!(Arc::ptr_eq(&context.block_pool, &random.block_pool));
     }
 }

--- a/crates/client/curvine-client-core/src/file/fs_reader_buffer.rs
+++ b/crates/client/curvine-client-core/src/file/fs_reader_buffer.rs
@@ -29,6 +29,8 @@ use log::error;
 use std::sync::Arc;
 use tokio::sync::mpsc::Permit;
 
+const RANDOM_READ_CHUNK_SIZE_MAX: usize = 128 * 1024;
+
 // Control task type
 enum ReadTask {
     Seek(i64, CallSender<i8>),
@@ -231,8 +233,16 @@ impl FsReaderBuffer {
         let pos = 0;
         let len = file_blocks.status.len;
 
+        let random_context = if read_detector.enabled
+            && (chunk_size > RANDOM_READ_CHUNK_SIZE_MAX || conf.enable_read_ahead)
+        {
+            fs_context.with_random_read_options(chunk_size.min(RANDOM_READ_CHUNK_SIZE_MAX))
+        } else {
+            fs_context.clone()
+        };
+
         let base = FsReaderParallel::from_base(
-            FsReaderBase::new(path.clone(), fs_context.clone(), file_blocks.clone()),
+            FsReaderBase::new(path.clone(), random_context, file_blocks.clone()),
             read_detector.read_parallel() as usize,
             slice_size,
             vec![FileSlice::new(0, len)],
@@ -610,6 +620,53 @@ mod tests {
         assert!(reader.readers[..reader.base_reader_index]
             .iter()
             .all(ReaderAdapter::prefetch_not_started));
+    }
+
+    #[test]
+    fn random_base_reader_uses_small_chunks_without_prefetch() {
+        let mut conf = ClusterConf::default();
+        conf.client.enable_smart_prefetch = true;
+        conf.client.read_parallel = 1;
+        conf.client.read_chunk_size_str = "512KB".to_string();
+        conf.client.read_slice_size_str = "4MB".to_string();
+        conf.client.large_file_size_str = "1GB".to_string();
+        conf.client.init().unwrap();
+
+        let len = conf.client.read_slice_size;
+        let fs_context = Arc::new(FsContext::new(conf).unwrap());
+        let read_detector = ReadDetector::with_conf(&fs_context.conf().client, len);
+        let reader = FsReaderBuffer::new(
+            Path::from_str("/random-reader").unwrap(),
+            fs_context,
+            file_blocks(len),
+            read_detector,
+        )
+        .unwrap();
+
+        let ReaderAdapter::Base(random_reader) = &reader.readers[reader.base_reader_index] else {
+            panic!("random reader must be unbuffered")
+        };
+        let ReaderAdapter::Buffer(sequential_reader) = &reader.readers[0] else {
+            panic!("sequential reader must keep its prefetch buffer")
+        };
+
+        assert_eq!(random_reader.read_chunk_size(), RANDOM_READ_CHUNK_SIZE_MAX);
+        assert!(!random_reader.read_ahead_enabled());
+        assert_eq!(
+            sequential_reader
+                .prefetch
+                .as_ref()
+                .unwrap()
+                .reader
+                .read_chunk_size(),
+            512 * 1024
+        );
+        assert!(sequential_reader
+            .prefetch
+            .as_ref()
+            .unwrap()
+            .reader
+            .read_ahead_enabled());
     }
 
     #[test]

--- a/crates/client/curvine-client-core/src/file/fs_reader_buffer.rs
+++ b/crates/client/curvine-client-core/src/file/fs_reader_buffer.rs
@@ -172,6 +172,32 @@ impl ReaderAdapter {
             ReaderAdapter::Base(r) => r.seek(pos).await,
         }
     }
+
+    async fn resume(&mut self, pos: i64) -> FsResult<()> {
+        match self {
+            ReaderAdapter::Buffer(r) => {
+                r.seek(pos).await?;
+                r.pause(pos, false).await
+            }
+            ReaderAdapter::Base(r) => r.seek(pos).await,
+        }
+    }
+
+    #[cfg(test)]
+    fn pos(&self) -> i64 {
+        match self {
+            ReaderAdapter::Buffer(_) => unreachable!("test uses unbuffered readers"),
+            ReaderAdapter::Base(r) => r.pos(),
+        }
+    }
+
+    #[cfg(test)]
+    fn prefetch_not_started(&self) -> bool {
+        match self {
+            ReaderAdapter::Buffer(r) => r.prefetch.is_some(),
+            ReaderAdapter::Base(_) => false,
+        }
+    }
 }
 
 // Reader with buffer.
@@ -358,9 +384,7 @@ impl FsReaderBuffer {
             .record_read(start_pos, self.pos, &self.path);
 
         if is_changed && self.read_detector.is_sequential() {
-            for reader in &mut self.readers {
-                reader.pause(self.pos, false).await?;
-            }
+            self.resume_sequential_readers().await?;
         }
 
         Ok(bytes)
@@ -372,15 +396,28 @@ impl FsReaderBuffer {
         }
 
         self.read_detector.record_seek(&self.path);
-        for reader in &mut self.readers {
-            reader.seek(pos).await?;
+        if self.read_detector.is_random() {
+            // Random reads always select the base reader. Do not start and seek
+            // sequential prefetch readers that cannot serve this request.
+            self.readers[self.base_reader_index].seek(pos).await?;
+        } else {
+            for reader in &mut self.readers {
+                reader.seek(pos).await?;
 
-            if !self.read_detector.enabled {
-                reader.pause(pos, false).await?;
+                if !self.read_detector.enabled {
+                    reader.pause(pos, false).await?;
+                }
             }
         }
 
         self.pos = pos;
+        Ok(())
+    }
+
+    async fn resume_sequential_readers(&mut self) -> FsResult<()> {
+        for reader in &mut self.readers {
+            reader.resume(self.pos).await?;
+        }
         Ok(())
     }
 
@@ -464,7 +501,7 @@ impl FsReaderBuffer {
 mod tests {
     use super::*;
     use curvine_config::ClusterConf;
-    use curvine_model::FileStatus;
+    use curvine_model::{ExtendedBlock, FileStatus, LocatedBlock};
 
     fn sparse_file_blocks(len: i64) -> FileBlocks {
         FileBlocks::new(
@@ -476,6 +513,53 @@ mod tests {
             },
             vec![],
         )
+    }
+
+    fn file_blocks(len: i64) -> FileBlocks {
+        FileBlocks::new(
+            FileStatus {
+                id: 1,
+                len,
+                is_complete: true,
+                ..Default::default()
+            },
+            vec![LocatedBlock {
+                block: ExtendedBlock {
+                    id: 1,
+                    len,
+                    ..Default::default()
+                },
+                ..Default::default()
+            }],
+        )
+    }
+
+    fn reader_for_seek(
+        enable_smart_prefetch: bool,
+        read_chunk_num: usize,
+    ) -> (Arc<Runtime>, FsReaderBuffer) {
+        let mut conf = ClusterConf::default();
+        conf.client.enable_smart_prefetch = enable_smart_prefetch;
+        conf.client.read_parallel = 4;
+        conf.client.read_chunk_num = read_chunk_num;
+        conf.client.sequential_read_threshold = 1;
+        conf.client.read_chunk_size_str = "64KB".to_string();
+        conf.client.read_slice_size_str = "1MB".to_string();
+        conf.client.large_file_size_str = "1GB".to_string();
+        conf.client.init().unwrap();
+
+        let len = conf.client.read_slice_size * 4;
+        let fs_context = Arc::new(FsContext::new(conf).unwrap());
+        let rt = fs_context.clone_runtime();
+        let read_detector = ReadDetector::with_conf(&fs_context.conf().client, len);
+        let reader = FsReaderBuffer::new(
+            Path::from_str("/seek-reader").unwrap(),
+            fs_context,
+            file_blocks(len),
+            read_detector,
+        )
+        .unwrap();
+        (rt, reader)
     }
 
     #[test]
@@ -500,5 +584,74 @@ mod tests {
         rt.block_on(reader.seek(file_len)).unwrap();
         assert!(reader.read_detector.is_random());
         assert!(reader.get_reader().is_ok());
+    }
+
+    #[test]
+    fn random_seek_repositions_only_the_base_reader() {
+        let (rt, mut reader) = reader_for_seek(true, 1);
+
+        let seek_pos = 64 * 1024;
+        rt.block_on(reader.seek(seek_pos)).unwrap();
+
+        assert!(reader.read_detector.is_random());
+        for sequential_reader in &reader.readers[..reader.base_reader_index] {
+            assert_eq!(sequential_reader.pos(), 0);
+        }
+        assert_eq!(reader.readers[reader.base_reader_index].pos(), seek_pos);
+    }
+
+    #[test]
+    fn random_seek_does_not_start_sequential_prefetch() {
+        let (rt, mut reader) = reader_for_seek(true, 8);
+
+        rt.block_on(reader.seek(64 * 1024)).unwrap();
+
+        assert!(reader.read_detector.is_random());
+        assert!(reader.readers[..reader.base_reader_index]
+            .iter()
+            .all(ReaderAdapter::prefetch_not_started));
+    }
+
+    #[test]
+    fn seek_keeps_all_readers_aligned_without_smart_prefetch() {
+        let (rt, mut reader) = reader_for_seek(false, 1);
+
+        let seek_pos = 64 * 1024;
+        rt.block_on(reader.seek(seek_pos)).unwrap();
+
+        assert!(reader.read_detector.is_sequential());
+        for (index, sequential_reader) in reader.readers.iter().enumerate() {
+            let expected = if index == reader.base_reader_index {
+                seek_pos
+            } else {
+                seek_pos.max(index as i64 * reader.slice_size)
+            };
+            assert_eq!(sequential_reader.pos(), expected);
+        }
+    }
+
+    #[test]
+    fn sequential_transition_realigns_readers_after_a_random_seek() {
+        let (rt, mut reader) = reader_for_seek(true, 1);
+        let seek_pos = 64 * 1024;
+        let read_end = seek_pos + 64 * 1024;
+
+        rt.block_on(reader.seek(seek_pos)).unwrap();
+        assert!(reader.read_detector.is_random());
+        reader.pos = read_end;
+        assert!(reader
+            .read_detector
+            .record_read(seek_pos, read_end, &reader.path));
+        assert!(reader.read_detector.is_sequential());
+
+        rt.block_on(reader.resume_sequential_readers()).unwrap();
+        for (index, sequential_reader) in reader.readers.iter().enumerate() {
+            let expected = if index == reader.base_reader_index {
+                read_end
+            } else {
+                read_end.max(index as i64 * reader.slice_size)
+            };
+            assert_eq!(sequential_reader.pos(), expected);
+        }
     }
 }

--- a/crates/client/curvine-client-core/src/file/fs_reader_parallel.rs
+++ b/crates/client/curvine-client-core/src/file/fs_reader_parallel.rs
@@ -128,6 +128,21 @@ impl FsReaderParallel {
         self.parallel_id
     }
 
+    #[cfg(test)]
+    pub(crate) fn read_chunk_size(&self) -> usize {
+        self.inner.fs_context().read_chunk_size()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn read_ahead_enabled(&self) -> bool {
+        self.inner.fs_context().conf().client.enable_read_ahead
+    }
+
+    #[cfg(test)]
+    pub(crate) fn pos(&self) -> i64 {
+        self.inner.pos()
+    }
+
     pub async fn read(&mut self) -> FsResult<FileChunk> {
         match self.cur_idx {
             None => {

--- a/crates/client/curvine-client-core/src/file/fs_writer_base.rs
+++ b/crates/client/curvine-client-core/src/file/fs_writer_base.rs
@@ -215,6 +215,34 @@ impl FsWriterBase {
         }
     }
 
+    /// Finalize cached random-write blocks before an operation needs their
+    /// metadata on the master.
+    ///
+    /// `add_block` validates `file_len` against all block commits it receives.
+    /// A cached writer has already advanced the local file length but has not
+    /// produced that commit yet, so it must be finalized before appending a
+    /// later block.
+    async fn complete_cached_writers(&mut self) -> FsResult<()> {
+        let block_ids: Vec<_> = self.cache_writers.keys().copied().collect();
+        for block_id in block_ids {
+            // Keep each successful worker completion immediately recoverable.
+            // If a later writer fails, cancel() must submit this commit rather
+            // than treat the already-completed block as disposable.
+            let commit = self
+                .cache_writers
+                .get_mut(&block_id)
+                .expect("cached writer exists")
+                .complete()
+                .await?;
+            self.add_durable_commit(commit)?;
+        }
+
+        // Completed writers cannot be reused; a later random write reopens a
+        // staging writer from the committed block metadata.
+        self.cache_writers.clear();
+        Ok(())
+    }
+
     fn committed_len(&self) -> i64 {
         self.file_blocks
             .block_locs
@@ -311,28 +339,15 @@ impl FsWriterBase {
             self.cache_writers.insert(writer.block_id(), writer);
         };
 
-        let mut writer_commits = Vec::with_capacity(self.cache_writers.len());
-        for (_, writer) in self.cache_writers.iter_mut() {
-            // Always finalize on the worker. `only_flush` only keeps the master
-            // write lease open; it must still publish block data.
-            //
-            // A prior resize/flush may already have finalized an older
-            // generation. Later writes reopen as a staging rewrite while
-            // `get_readable_block` prefers the committed generation. Calling
-            // `flush()` here without `complete()` leaves that rewrite
-            // unpublished, so FUSE dirty-read / LTP ftest/pwrite see EIO or
-            // stale holes after sparse write-then-read.
-            let commit_block = writer.complete().await?;
-            writer_commits.push(commit_block);
-        }
-
-        for commit in writer_commits {
-            self.file_blocks.add_commit(commit)?;
-        }
-
-        // `complete()` ends the worker write session; drop handles so the next
-        // write reopens against the newly published generation.
-        self.cache_writers.clear();
+        // Always finalize on the worker. `only_flush` only keeps the master
+        // write lease open; it must still publish block data.
+        //
+        // A prior resize/flush may already have finalized an older generation.
+        // Later writes reopen as a staging rewrite while `get_readable_block`
+        // prefers the committed generation. Calling `flush()` here without
+        // `complete()` leaves that rewrite unpublished, so FUSE dirty-read /
+        // LTP ftest/pwrite see EIO or stale holes after sparse write-then-read.
+        self.complete_cached_writers().await?;
 
         let commit_blocks = self.file_blocks.take_commit_blocks();
         // From this point onward a request may have reached the master even if
@@ -413,6 +428,12 @@ impl FsWriterBase {
 
                     None => {
                         self.update_writer(None, false).await?;
+
+                        // The local length already includes bytes held by
+                        // cached random-write blocks. AddBlock validates its
+                        // file_len before allocating the next block, so submit
+                        // every cached block commit in that same request.
+                        self.complete_cached_writers().await?;
 
                         let commit_blocks = self.file_blocks.take_commit_blocks();
                         let last_block = self.file_blocks.last_block();

--- a/crates/common/curvine-config/src/fuse_conf.rs
+++ b/crates/common/curvine-config/src/fuse_conf.rs
@@ -105,6 +105,11 @@ pub struct FuseConf {
     // Read and write file request queue size, default is 0
     pub stream_channel_size: usize,
 
+    // Maximum number of independent readers opened lazily for one FUSE file
+    // handle. Readers are mutable because they retain block/cache state, so a
+    // request must never share a reader concurrently with another request.
+    pub per_handle_read_parallel: usize,
+
     // Mount the configuration, needs to be passed to the linux kernel.
     pub fuse_opts: Vec<String>,
 
@@ -245,9 +250,16 @@ impl FuseConf {
     /// Default FUSE BDI readahead window: 1 MiB (`1024` KB).
     pub const DEFAULT_MAX_READAHEAD_KB: u32 = 1024;
 
+    /// Preserve the legacy single-reader ordering per FUSE handle by default.
+    /// Higher values are an explicit throughput tuning for measured concurrent reads.
+    pub const DEFAULT_PER_HANDLE_READ_PARALLEL: usize = 1;
+
     pub fn init(&mut self) -> CommonResult<()> {
         if self.io_threads == 0 {
             return err_box!("fuse.io_threads must be > 0");
+        }
+        if self.per_handle_read_parallel == 0 {
+            return err_box!("fuse.per_handle_read_parallel must be > 0");
         }
         if self.mnt_number == 0 {
             return err_box!("fuse.mnt_number must be > 0");
@@ -537,6 +549,7 @@ impl Default for FuseConf {
             clone_fd: true,
             fuse_channel_size: 0,
             stream_channel_size: 0,
+            per_handle_read_parallel: Self::DEFAULT_PER_HANDLE_READ_PARALLEL,
             fuse_opts: vec![],
             readonly: false,
             umask: Self::DEFAULT_UMASK,
@@ -725,6 +738,27 @@ mod tests {
             "unexpected error: {}",
             err
         );
+    }
+
+    #[test]
+    fn init_rejects_zero_per_handle_read_parallel() {
+        let mut conf = FuseConf {
+            per_handle_read_parallel: 0,
+            ..Default::default()
+        };
+        let err = conf
+            .init()
+            .expect_err("zero per_handle_read_parallel must be rejected");
+        assert!(
+            err.to_string().contains("per_handle_read_parallel"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn default_preserves_single_reader_per_handle() {
+        assert_eq!(FuseConf::default().per_handle_read_parallel, 1);
     }
 
     #[test]

--- a/curvine-fuse/src/cli/mount_args.rs
+++ b/curvine-fuse/src/cli/mount_args.rs
@@ -65,6 +65,12 @@ pub struct FuseMountArgs {
     #[arg(long, help = "Stream channel size (optional)")]
     pub stream_channel_size: Option<usize>,
 
+    #[arg(
+        long,
+        help = "Maximum independent readers per FUSE file handle (optional)"
+    )]
+    pub per_handle_read_parallel: Option<usize>,
+
     #[arg(long, help = "Enable direct IO (optional)")]
     pub direct_io: Option<bool>,
 
@@ -219,6 +225,10 @@ impl FuseMountArgs {
 
         if let Some(stream_channel_size) = self.stream_channel_size {
             conf.fuse.stream_channel_size = stream_channel_size;
+        }
+
+        if let Some(per_handle_read_parallel) = self.per_handle_read_parallel {
+            conf.fuse.per_handle_read_parallel = per_handle_read_parallel;
         }
 
         if let Some(direct_io) = self.direct_io {
@@ -381,6 +391,16 @@ mod tests {
         );
 
         assert_eq!(conf.fuse.fuse_opts, vec!["ro"]);
+    }
+
+    #[test]
+    fn get_conf_cli_overrides_per_handle_read_parallel() {
+        let conf = get_conf(
+            "[fuse]\nio_threads = 1\nper_handle_read_parallel = 2\n",
+            &["--per-handle-read-parallel", "3"],
+        );
+
+        assert_eq!(conf.fuse.per_handle_read_parallel, 3);
     }
 
     #[test]

--- a/curvine-fuse/src/fs/fuse_reader.rs
+++ b/curvine-fuse/src/fs/fuse_reader.rs
@@ -15,62 +15,263 @@
 use crate::fs::operator::Read;
 use crate::fuse_metrics::{mono_now, FuseMetrics, IO_TYPE_READ};
 use crate::session::FuseResponse;
+use curvine_client::unified::UnifiedFileSystem;
 use curvine_client::unified::UnifiedReader;
 use curvine_config::FuseConf;
 use curvine_error::FsError;
 use curvine_error::FsResult;
-use curvine_fs_api::{Path, Reader};
+use curvine_fs_api::{FileSystem, Path, Reader};
 use curvine_model::FileStatus;
 use curvine_runtime::runtime::{RpcRuntime, Runtime};
-use curvine_runtime::sync::channel::{
-    AsyncChannel, AsyncReceiver, AsyncSender, CallChannel, CallSender,
-};
-use curvine_runtime::sync::ErrorMonitor;
-use log::{error, warn};
+use curvine_runtime::sync::channel::{AsyncChannel, AsyncReceiver, AsyncSender};
+use curvine_runtime::sync::{AsyncMutex, FastMutex};
+use log::warn;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
+use tokio::sync::{Notify, OwnedSemaphorePermit, Semaphore};
 
-enum ReadTask {
-    Read(i64, usize, FuseResponse),
-    Complete(CallSender<FsResult<()>>, Option<FuseResponse>),
+type ReaderOpenFuture = Pin<Box<dyn Future<Output = FsResult<UnifiedReader>> + Send>>;
+type ReaderOpener = Arc<dyn Fn(Path) -> ReaderOpenFuture + Send + Sync>;
+
+struct ReaderPoolState {
+    closing: bool,
+    in_flight: usize,
+    reader_count: usize,
+    opening_count: usize,
+    expansion_failed: bool,
+}
+
+struct ReaderPool {
+    available_sender: AsyncSender<UnifiedReader>,
+    available_receiver: AsyncMutex<AsyncReceiver<UnifiedReader>>,
+    opener: Option<ReaderOpener>,
+    path: Path,
+    max_readers: usize,
+    read_permits: Option<Arc<Semaphore>>,
+    state: FastMutex<ReaderPoolState>,
+    idle: Notify,
+}
+
+struct ReadLease {
+    pool: Arc<ReaderPool>,
+    _permit: Option<OwnedSemaphorePermit>,
+}
+
+impl Drop for ReadLease {
+    fn drop(&mut self) {
+        self.pool.finish_read();
+    }
+}
+
+impl ReaderPool {
+    fn new(conf: &FuseConf, opener: Option<ReaderOpener>, reader: UnifiedReader) -> Arc<Self> {
+        let max_readers = if opener.is_some() {
+            conf.per_handle_read_parallel
+        } else {
+            1
+        };
+        // The legacy reader had one active worker plus `stream_channel_size`
+        // queued requests. A pool has up to `max_readers` active requests, so
+        // preserve that queue bound without throttling the reader slots.
+        let read_permits = (conf.stream_channel_size != 0).then(|| {
+            Arc::new(Semaphore::new(
+                conf.stream_channel_size
+                    .saturating_add(max_readers)
+                    .min(Semaphore::MAX_PERMITS),
+            ))
+        });
+        let path = reader.path().clone();
+        let (available_sender, available_receiver) = AsyncChannel::new(0).split();
+        available_sender
+            .send_sync(reader)
+            .expect("new reader pool receiver must be alive");
+
+        Arc::new(Self {
+            available_sender,
+            available_receiver: AsyncMutex::new(available_receiver),
+            opener,
+            path,
+            max_readers,
+            read_permits,
+            state: FastMutex::new(ReaderPoolState {
+                closing: false,
+                in_flight: 0,
+                reader_count: 1,
+                opening_count: 0,
+                expansion_failed: false,
+            }),
+            idle: Notify::new(),
+        })
+    }
+
+    async fn begin_read(self: &Arc<Self>) -> FsResult<ReadLease> {
+        let permit = match &self.read_permits {
+            Some(permits) => Some(
+                permits
+                    .clone()
+                    .acquire_owned()
+                    .await
+                    .map_err(|_| FsError::common("FUSE reader is closing"))?,
+            ),
+            None => None,
+        };
+        let mut state = self.state.lock();
+        if state.closing {
+            return Err(FsError::common("FUSE reader is closing"));
+        }
+        state.in_flight += 1;
+        Ok(ReadLease {
+            pool: self.clone(),
+            _permit: permit,
+        })
+    }
+
+    fn finish_read(&self) {
+        let notify = {
+            let mut state = self.state.lock();
+            debug_assert!(state.in_flight > 0, "reader pool in-flight underflow");
+            state.in_flight -= 1;
+            state.closing && state.in_flight == 0
+        };
+        if notify {
+            self.idle.notify_waiters();
+        }
+    }
+
+    async fn try_take_available(&self) -> FsResult<Option<UnifiedReader>> {
+        Ok(self.available_receiver.lock().await.try_recv()?)
+    }
+
+    async fn acquire(&self) -> FsResult<UnifiedReader> {
+        if let Some(reader) = self.try_take_available().await? {
+            return Ok(reader);
+        }
+
+        let open_reader = {
+            let mut state = self.state.lock();
+            if !state.expansion_failed
+                && state.reader_count + state.opening_count < self.max_readers
+            {
+                state.opening_count += 1;
+                true
+            } else {
+                false
+            }
+        };
+
+        if open_reader {
+            let opener = self
+                .opener
+                .as_ref()
+                .expect("reader pool can grow only with an opener")
+                .clone();
+            let res = opener(self.path.clone()).await;
+            let mut state = self.state.lock();
+            state.opening_count -= 1;
+            match res {
+                Ok(reader) => {
+                    state.reader_count += 1;
+                    return Ok(reader);
+                }
+                Err(e) => {
+                    // The original reader remains valid for this open handle.
+                    // An opportunistic pool expansion must not turn a request
+                    // that could wait for it into a new read failure. Avoid
+                    // retrying a failing open for every concurrent request;
+                    // the next FUSE handle starts with a fresh pool.
+                    state.expansion_failed = true;
+                    warn!("failed to expand FUSE reader pool for {}: {}", self.path, e);
+                }
+            }
+        }
+
+        Ok(self.available_receiver.lock().await.recv_check().await?)
+    }
+
+    async fn release(&self, reader: UnifiedReader) -> FsResult<()> {
+        self.available_sender.send(reader).await?;
+        Ok(())
+    }
+
+    async fn close_and_take_all(&self) -> FsResult<Vec<UnifiedReader>> {
+        {
+            let mut state = self.state.lock();
+            if state.closing {
+                return Err(FsError::common("FUSE reader is already closing"));
+            }
+            state.closing = true;
+        }
+        if let Some(permits) = &self.read_permits {
+            permits.close();
+        }
+
+        loop {
+            let notified = self.idle.notified();
+            if self.state.lock().in_flight == 0 {
+                break;
+            }
+            notified.await;
+        }
+
+        let reader_count = self.state.lock().reader_count;
+        let mut receiver = self.available_receiver.lock().await;
+        let mut readers = Vec::with_capacity(reader_count);
+        for _ in 0..reader_count {
+            readers.push(receiver.recv_check().await?);
+        }
+        Ok(readers)
+    }
 }
 
 pub struct FuseReader {
     path: Path,
     len: i64,
-    sender: AsyncSender<ReadTask>,
-    err_monitor: Arc<ErrorMonitor<FsError>>,
+    pool: Arc<ReaderPool>,
+    rt: Arc<Runtime>,
     status: FileStatus,
+    path_type: &'static str,
+    metrics_enabled: bool,
 }
 
 impl FuseReader {
     pub fn new(conf: &FuseConf, rt: Arc<Runtime>, reader: UnifiedReader) -> Self {
+        Self::new_inner(conf, rt, None, reader)
+    }
+
+    pub fn new_with_filesystem(
+        conf: &FuseConf,
+        rt: Arc<Runtime>,
+        fs: UnifiedFileSystem,
+        reader: UnifiedReader,
+    ) -> Self {
+        let opener: ReaderOpener = Arc::new(move |path| {
+            let fs = fs.clone();
+            Box::pin(async move { fs.open(&path).await })
+        });
+        Self::new_inner(conf, rt, Some(opener), reader)
+    }
+
+    fn new_inner(
+        conf: &FuseConf,
+        rt: Arc<Runtime>,
+        opener: Option<ReaderOpener>,
+        reader: UnifiedReader,
+    ) -> Self {
         let path = reader.path().clone();
         let len = reader.len();
-        let err_monitor = Arc::new(ErrorMonitor::new());
-        let (sender, receiver) = AsyncChannel::new(conf.stream_channel_size).split();
         let status = reader.status().clone();
         let path_type = reader.path_type();
-        let metrics_enabled = conf.metrics_enabled;
-
-        let monitor = err_monitor.clone();
-        rt.spawn(async move {
-            let res = Self::read_future(reader, receiver, path_type, metrics_enabled).await;
-            match res {
-                Ok(_) => (),
-
-                Err(e) => {
-                    error!("fuse reader error: {}", e);
-                    monitor.set_error(e);
-                }
-            }
-        });
+        let pool = ReaderPool::new(conf, opener, reader);
 
         Self {
             path,
             len,
-            sender,
-            err_monitor,
+            pool,
+            rt,
             status,
+            path_type,
+            metrics_enabled: conf.metrics_enabled,
         }
     }
 
@@ -90,87 +291,91 @@ impl FuseReader {
         &self.status
     }
 
-    fn check_error(&self, e: FsError) -> FsError {
-        self.err_monitor.take_error().unwrap_or(e)
-    }
-
     pub async fn read(&self, op: Read<'_>, reply: FuseResponse) -> FsResult<()> {
-        let res = self
-            .sender
-            .send(ReadTask::Read(
-                op.arg.offset as i64,
-                op.arg.size as usize,
-                reply,
-            ))
-            .await
-            .map_err(|e| self.check_error(e.into()));
-        res
+        let lease = self.pool.begin_read().await?;
+        let pool = self.pool.clone();
+        let path_type = self.path_type;
+        let metrics_enabled = self.metrics_enabled;
+        let off = op.arg.offset as i64;
+        let len = op.arg.size as usize;
+        self.rt.spawn(async move {
+            Self::read_future(pool, off, len, reply, path_type, metrics_enabled).await;
+            drop(lease);
+        });
+        Ok(())
     }
 
     pub async fn complete(&self, reply: Option<FuseResponse>) -> FsResult<()> {
-        let fun = async {
-            let (rx, tx) = CallChannel::channel();
-            self.sender.send(ReadTask::Complete(rx, reply)).await?;
-            // Double `?`: unwrap the channel receive, then propagate the real
-            // backend complete result.
-            tx.receive().await??;
-            Ok::<(), FsError>(())
-        };
-        fun.await.map_err(|e| self.check_error(e))
+        let readers = self.pool.close_and_take_all().await?;
+        let mut error = None;
+        for mut reader in readers {
+            if let Err(e) = reader.complete().await {
+                error.get_or_insert(e);
+            }
+        }
+        let result = error.map_or(Ok(()), Err);
+
+        match reply {
+            Some(reply) => {
+                let result: Result<(), crate::FuseError> = result.map_err(Into::into);
+                if let Err(e) = reply.send_rep(result).await {
+                    warn!("failed to send FUSE reader complete reply: {}", e);
+                }
+                Ok(())
+            }
+            None => result,
+        }
     }
 
     async fn read_future(
-        mut reader: UnifiedReader,
-        mut req_receiver: AsyncReceiver<ReadTask>,
+        pool: Arc<ReaderPool>,
+        off: i64,
+        len: usize,
+        reply: FuseResponse,
         path_type: &'static str,
         metrics_enabled: bool,
-    ) -> FsResult<()> {
-        while let Some(task) = req_receiver.recv().await {
-            match task {
-                ReadTask::Read(off, len, reply) => {
-                    let io_start = if metrics_enabled {
-                        Some(mono_now())
-                    } else {
-                        None
-                    };
-                    let inflight = FuseMetrics::stream_io_guard(metrics_enabled, IO_TYPE_READ);
-                    let data = reader.fuse_read(off, len).await;
-                    drop(inflight);
+    ) {
+        let data = match pool.acquire().await {
+            Ok(mut reader) => {
+                let io_start = if metrics_enabled {
+                    Some(mono_now())
+                } else {
+                    None
+                };
+                let inflight = FuseMetrics::stream_io_guard(metrics_enabled, IO_TYPE_READ);
+                let data = reader.fuse_read(off, len).await;
+                drop(inflight);
 
-                    if let Some(start) = io_start {
-                        let ok = data.is_ok();
-                        // Actual bytes read (short reads count actual); requested
-                        // size is `len` (the request-size distribution).
-                        let bytes = data
-                            .as_ref()
-                            .map(|v| v.iter().map(|s| s.len() as u64).sum())
-                            .unwrap_or(0);
-                        FuseMetrics::get().record_stream_io(
-                            IO_TYPE_READ,
-                            path_type,
-                            ok,
-                            bytes,
-                            len as u64,
-                            start.elapsed().as_micros() as u64,
-                        );
-                    }
-
-                    if let Err(e) = reply.send_data(data.map_err(|x| x.into())).await {
-                        // Losing this reply receiver must not kill the shared worker.
-                        warn!("failed to send FUSE read reply: {}", e);
-                    }
+                if let Some(start) = io_start {
+                    let ok = data.is_ok();
+                    // Actual bytes read (short reads count actual); requested
+                    // size is `len` (the request-size distribution).
+                    let bytes = data
+                        .as_ref()
+                        .map(|v| v.iter().map(|s| s.len() as u64).sum())
+                        .unwrap_or(0);
+                    FuseMetrics::get().record_stream_io(
+                        IO_TYPE_READ,
+                        path_type,
+                        ok,
+                        bytes,
+                        len as u64,
+                        start.elapsed().as_micros() as u64,
+                    );
                 }
 
-                ReadTask::Complete(tx, reply) => {
-                    // Complete/release IO accounting lives at send_stream to avoid double-counting.
-                    let res = reader.complete().await;
-                    // Deliver the real backend result to the caller (tx) first,
-                    // then the kernel reply.
-                    crate::fs::deliver_stream_result(res, tx, reply).await?;
+                match pool.release(reader).await {
+                    Ok(()) => data,
+                    Err(e) => Err(e),
                 }
             }
+            Err(e) => Err(e),
+        };
+
+        if let Err(e) = reply.send_data(data.map_err(Into::into)).await {
+            // Losing this reply receiver must not terminate another request.
+            warn!("failed to send FUSE read reply: {}", e);
         }
-        Ok(())
     }
 }
 
@@ -189,6 +394,8 @@ mod tests {
     use curvine_runtime::runtime::AsyncRuntime;
     use curvine_runtime::sync::channel::AsyncChannel;
     use std::io::Write as _;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::time::{timeout, Duration};
 
     fn metrics_reply(rt: &AsyncRuntime) -> FuseResponse {
         FuseMetrics::ensure_init().unwrap();
@@ -223,6 +430,163 @@ mod tests {
             flags: 0,
             padding: 0,
         }
+    }
+
+    #[tokio::test]
+    async fn reader_pool_opens_lazily_and_stays_bounded() {
+        let path_buf = std::env::temp_dir().join(format!(
+            "fr_pool_{}_{}",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("unnamed")
+        ));
+        std::fs::write(&path_buf, b"reader-pool").unwrap();
+        let path = curvine_fs_api::Path::from_str(path_buf.to_str().unwrap()).unwrap();
+        let open_count = Arc::new(AtomicUsize::new(0));
+        let factory_path = path.clone();
+        let factory_count = open_count.clone();
+        let opener: ReaderOpener = Arc::new(move |_| {
+            let path = factory_path.clone();
+            let open_count = factory_count.clone();
+            Box::pin(async move {
+                open_count.fetch_add(1, Ordering::Relaxed);
+                Ok(UnifiedReader::Local(LocalReader::new(&path, 4096)?))
+            })
+        });
+        let conf = FuseConf {
+            per_handle_read_parallel: 2,
+            ..Default::default()
+        };
+        let initial = UnifiedReader::Local(LocalReader::new(&path, 4096).unwrap());
+        let pool = ReaderPool::new(&conf, Some(opener), initial);
+
+        let first = pool.acquire().await.unwrap();
+        assert_eq!(
+            open_count.load(Ordering::Relaxed),
+            0,
+            "initial reader is reused"
+        );
+
+        let second = pool.acquire().await.unwrap();
+        assert_eq!(
+            open_count.load(Ordering::Relaxed),
+            1,
+            "the second concurrent lease opens exactly one reader"
+        );
+
+        assert!(
+            timeout(Duration::from_millis(20), pool.acquire())
+                .await
+                .is_err(),
+            "pool must wait instead of opening beyond per_handle_read_parallel"
+        );
+
+        pool.release(first).await.unwrap();
+        let third = pool.acquire().await.unwrap();
+        assert_eq!(
+            open_count.load(Ordering::Relaxed),
+            1,
+            "an available reader is reused without another open"
+        );
+        pool.release(second).await.unwrap();
+        pool.release(third).await.unwrap();
+        let _ = std::fs::remove_file(&path_buf);
+    }
+
+    #[tokio::test]
+    async fn reader_pool_falls_back_when_expansion_fails() {
+        let path_buf = std::env::temp_dir().join(format!(
+            "fr_pool_fallback_{}_{}",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("unnamed")
+        ));
+        std::fs::write(&path_buf, b"reader-pool-fallback").unwrap();
+        let path = curvine_fs_api::Path::from_str(path_buf.to_str().unwrap()).unwrap();
+        let open_count = Arc::new(AtomicUsize::new(0));
+        let factory_count = open_count.clone();
+        let opener: ReaderOpener = Arc::new(move |_| {
+            let open_count = factory_count.clone();
+            Box::pin(async move {
+                open_count.fetch_add(1, Ordering::Relaxed);
+                Err(FsError::common("reader pool expansion failed"))
+            })
+        });
+        let conf = FuseConf {
+            per_handle_read_parallel: 2,
+            ..Default::default()
+        };
+        let initial = UnifiedReader::Local(LocalReader::new(&path, 4096).unwrap());
+        let pool = ReaderPool::new(&conf, Some(opener), initial);
+
+        let first = pool.acquire().await.unwrap();
+        let waiting_pool = pool.clone();
+        let waiting = tokio::spawn(async move { waiting_pool.acquire().await });
+        for _ in 0..20 {
+            if open_count.load(Ordering::Relaxed) == 1 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(
+            open_count.load(Ordering::Relaxed),
+            1,
+            "the waiting request first attempts one pool expansion"
+        );
+
+        pool.release(first).await.unwrap();
+        let second = timeout(Duration::from_secs(1), waiting)
+            .await
+            .expect("waiting request should fall back to the initial reader")
+            .unwrap()
+            .unwrap();
+        assert!(
+            pool.state.lock().expansion_failed,
+            "a failed expansion must disable retries for this handle"
+        );
+        pool.release(second).await.unwrap();
+        let _ = std::fs::remove_file(&path_buf);
+    }
+
+    #[tokio::test]
+    async fn reader_pool_preserves_stream_channel_backpressure() {
+        let path_buf = std::env::temp_dir().join(format!(
+            "fr_pool_backpressure_{}_{}",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("unnamed")
+        ));
+        std::fs::write(&path_buf, b"reader-pool-backpressure").unwrap();
+        let path = curvine_fs_api::Path::from_str(path_buf.to_str().unwrap()).unwrap();
+        let conf = FuseConf {
+            per_handle_read_parallel: 2,
+            stream_channel_size: 1,
+            ..Default::default()
+        };
+        let initial = UnifiedReader::Local(LocalReader::new(&path, 4096).unwrap());
+        let opener: ReaderOpener = Arc::new(|_| unreachable!());
+        let pool = ReaderPool::new(&conf, Some(opener), initial);
+
+        let first = pool.begin_read().await.unwrap();
+        let second = pool.begin_read().await.unwrap();
+        let third = pool.begin_read().await.unwrap();
+
+        let waiting_pool = pool.clone();
+        let mut waiting = tokio::spawn(async move { waiting_pool.begin_read().await });
+        assert!(
+            timeout(Duration::from_millis(20), &mut waiting)
+                .await
+                .is_err(),
+            "two active readers plus one queued request must apply backpressure"
+        );
+
+        drop(first);
+        drop(second);
+        drop(third);
+        drop(
+            timeout(Duration::from_secs(1), waiting)
+                .await
+                .unwrap()
+                .unwrap(),
+        );
+        let _ = std::fs::remove_file(&path_buf);
     }
 
     #[test]

--- a/curvine-fuse/src/fs/state/node_state.rs
+++ b/curvine-fuse/src/fs/state/node_state.rs
@@ -383,6 +383,13 @@ impl NodeState {
         Ok(())
     }
 
+    // With FUSE write-back caching, the kernel may issue a READ on an O_WRONLY
+    // handle to complete a partially written page. Curvine-backed write handles
+    // therefore need a reader even when userspace requested write-only access.
+    fn write_handle_needs_reader(mode: OpenFlags, write_back_cache: bool) -> bool {
+        mode == OpenFlags::RDWR || (mode == OpenFlags::WRONLY && write_back_cache)
+    }
+
     pub async fn new_handle(
         &self,
         ino: Option<u64>,
@@ -425,18 +432,18 @@ impl NodeState {
             }
         };
 
-        let reader = if mode == OpenFlags::RDWR {
-            if writer.is_ufs() {
+        let reader = if writer.is_ufs() {
+            if mode == OpenFlags::RDWR {
                 warn!(
                     "ufs {} -> {} does not support read-write mode for file opening, reader will be None",
                     path,
                     writer.path().full_path()
                 );
-                None
-            } else {
-                let reader = self.new_reader(path).await?;
-                Some(RawPtr::from_owned(reader))
             }
+            None
+        } else if Self::write_handle_needs_reader(mode, self.conf.write_back_cache) {
+            let reader = self.new_reader(path).await?;
+            Some(RawPtr::from_owned(reader))
         } else {
             None
         };
@@ -1304,7 +1311,7 @@ mod test {
     use curvine_fs_api::Writer;
     use curvine_fs_api::{ListStream, Path};
     use curvine_fs_api::{StateReader, StateWriter};
-    use curvine_model::FileStatus;
+    use curvine_model::{FileStatus, OpenFlags};
     use curvine_runtime::common::{FastHashMap, Utils};
     use curvine_runtime::runtime::{AsyncRuntime, RpcRuntime};
     use std::sync::Arc;
@@ -1366,6 +1373,19 @@ mod test {
 
         let (removed, did_remove) = NodeState::map_remove_handle(&mut map, 1, 99);
         assert!(removed.is_none() && !did_remove);
+    }
+
+    #[test]
+    fn writeback_write_only_curvine_handle_needs_reader() {
+        assert!(NodeState::write_handle_needs_reader(OpenFlags::RDWR, false));
+        assert!(NodeState::write_handle_needs_reader(
+            OpenFlags::WRONLY,
+            true
+        ));
+        assert!(!NodeState::write_handle_needs_reader(
+            OpenFlags::WRONLY,
+            false
+        ));
     }
 
     #[test]

--- a/curvine-fuse/src/fs/state/node_state.rs
+++ b/curvine-fuse/src/fs/state/node_state.rs
@@ -367,7 +367,12 @@ impl NodeState {
 
     pub async fn new_reader(&self, path: &Path) -> FuseResult<FuseReader> {
         let reader = self.fs.open(path).await?;
-        let reader = FuseReader::new(&self.conf, self.fs.clone_runtime(), reader);
+        let reader = FuseReader::new_with_filesystem(
+            &self.conf,
+            self.fs.clone_runtime(),
+            self.fs.clone(),
+            reader,
+        );
         Ok(reader)
     }
 

--- a/curvine-fuse/src/session/fuse_session.rs
+++ b/curvine-fuse/src/session/fuse_session.rs
@@ -37,6 +37,7 @@ use curvine_runtime::runtime::{RpcRuntime, Runtime};
 use curvine_sys as sys;
 use curvine_sys::version::GIT_VERSION;
 use curvine_sys::{RawIO, SignalKind, SignalWatch};
+use futures::future::select_all;
 use libc::{EAGAIN, EINTR, ENODEV, ENOENT};
 use log::{debug, error, info, warn};
 use std::collections::HashMap;
@@ -87,6 +88,27 @@ fn flatten_run_all_result(
     match result {
         Ok(inner) => inner,
         Err(err) => Err(err.into()),
+    }
+}
+
+/// A FUSE receiver or sender only exits after the mounted connection is no
+/// longer usable. Stop sibling tasks immediately instead of waiting for their
+/// response queues to drain after the kernel has aborted the connection.
+async fn finish_on_first_session_task(
+    handles: Vec<tokio::task::JoinHandle<CommonResult<()>>>,
+) -> CommonResult<()> {
+    if handles.is_empty() {
+        return Ok(());
+    }
+
+    let (result, _, remaining) = select_all(handles).await;
+    for handle in remaining {
+        handle.abort();
+    }
+
+    match result {
+        Ok(result) => result,
+        Err(error) => Err(error.into()),
     }
 }
 
@@ -366,7 +388,9 @@ impl<T: FileSystem> FuseSession<T> {
                 let handle = rt.spawn(async move {
                     if let Err(err) = receiver.start(shutdown_rx).await {
                         error!("fuse receiver exited with error: {}", err);
+                        return Err(err.into());
                     }
+                    Ok(())
                 });
                 handles.push(handle);
             }
@@ -375,18 +399,15 @@ impl<T: FileSystem> FuseSession<T> {
                 let handle = rt.spawn(async move {
                     if let Err(err) = sender.start().await {
                         error!("fuse sender exited with error: {}", err);
+                        return Err(err.into());
                     }
+                    Ok(())
                 });
                 handles.push(handle);
             }
         }
 
-        // Wait for all receiver/sender tasks to finish.
-        for handle in handles {
-            handle.await?;
-        }
-
-        Ok(())
+        finish_on_first_session_task(handles).await
     }
 
     async fn setup_mnts(conf: &FuseConf, fs: &T) -> CommonResult<Vec<FuseMnt>> {
@@ -630,7 +651,21 @@ mod cleanup_guard_tests {
 
 #[cfg(test)]
 mod run_all_shutdown_result_tests {
-    use super::flatten_run_all_result;
+    use super::{finish_on_first_session_task, flatten_run_all_result};
+    use curvine_core_error::{CommonError, CommonResult};
+    use curvine_runtime::runtime::{RpcRuntime, Runtime};
+    use std::future::pending;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    struct DropFlag(Arc<AtomicBool>);
+
+    impl Drop for DropFlag {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::Release);
+        }
+    }
 
     #[test]
     fn clean_inner_result_succeeds() {
@@ -658,5 +693,51 @@ mod run_all_shutdown_result_tests {
         let err = flatten_run_all_result(handle.await).expect_err("join error must be returned");
 
         assert!(err.to_string().contains("cancelled"));
+    }
+
+    #[tokio::test]
+    async fn first_finished_session_task_cancels_pending_sibling() {
+        let dropped = Arc::new(AtomicBool::new(false));
+        let rt = Runtime::new("fuse-session-test", 1, 1);
+        let mut handles = vec![];
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+
+        let pending_dropped = dropped.clone();
+        handles.push(rt.spawn(async move {
+            let _flag = DropFlag(pending_dropped);
+            let _ = started_tx.send(());
+            pending::<CommonResult<()>>().await
+        }));
+        started_rx.await.expect("pending sibling starts");
+        handles.push(rt.spawn(async { Ok::<(), CommonError>(()) }));
+
+        finish_on_first_session_task(handles)
+            .await
+            .expect("the completed session task succeeds");
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !dropped.load(Ordering::Acquire) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("pending sibling is cancelled");
+
+        tokio::task::spawn_blocking(move || drop(rt))
+            .await
+            .expect("test runtime shuts down");
+    }
+
+    #[tokio::test]
+    async fn first_finished_session_task_preserves_error() {
+        let handles = vec![tokio::spawn(async {
+            Err::<(), CommonError>(std::io::Error::other("receiver failed").into())
+        })];
+
+        let err = finish_on_first_session_task(handles)
+            .await
+            .expect_err("a failed session task must fail run_all");
+
+        assert_eq!(err.to_string(), "receiver failed");
     }
 }

--- a/curvine-tests/tests/cached_writer_append_test.rs
+++ b/curvine-tests/tests/cached_writer_append_test.rs
@@ -1,0 +1,65 @@
+// Copyright 2026 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bytes::BytesMut;
+use curvine_common::fs::{Path, Reader, Writer};
+use curvine_tests::Testing;
+use orpc::runtime::{AsyncRuntime, RpcRuntime};
+use std::sync::Arc;
+
+#[test]
+fn cached_random_writer_is_committed_before_append() {
+    let testing = Testing::builder()
+        .workers(1)
+        .mutate_conf(|conf| {
+            conf.log.level = "WARN".to_string();
+            conf.master.log.level = "WARN".to_string();
+            conf.master.audit_log.level = "WARN".to_string();
+            conf.worker.log.level = "WARN".to_string();
+            conf.fuse.log.level = "WARN".to_string();
+            conf.client.short_circuit = false;
+            conf.client.replicas = 1;
+            conf.client.block_size = 64;
+            conf.client.block_size_str = "64B".to_string();
+            conf.client.write_chunk_size = 64;
+            conf.client.write_chunk_size_str = "64B".to_string();
+            conf.client.max_cache_block_handles = 2;
+        })
+        .build()
+        .unwrap();
+    testing.start_cluster().unwrap();
+    let conf = testing.get_active_cluster_conf().unwrap();
+
+    let rt = Arc::new(AsyncRuntime::single());
+    let fs = testing.get_fs(Some(rt.clone()), Some(conf)).unwrap();
+
+    rt.block_on(async move {
+        let path = Path::from_str("/cached-writer-append.data").unwrap();
+        let mut writer = fs.create(&path, true).await.unwrap();
+
+        writer.write(&[0x5a; 128]).await.unwrap();
+        writer.seek(0).await.unwrap();
+        writer.seek(128).await.unwrap();
+        writer.write(b"tail").await.unwrap();
+        writer.complete().await.unwrap();
+
+        let mut reader = fs.open(&path).await.unwrap();
+        let mut actual = BytesMut::zeroed(132);
+        assert_eq!(reader.read_full(&mut actual).await.unwrap(), 132);
+        reader.complete().await.unwrap();
+
+        assert_eq!(&actual[..128], &[0x5a; 128]);
+        assert_eq!(&actual[128..], b"tail");
+    });
+}


### PR DESCRIPTION
# Summary

Stabilize the FUSE session lifecycle after a channel exits, preserve cached random-write data before appending, and make per-handle read parallelism explicit. This PR also reduces backend read amplification after a smart-prefetch reader enters random mode: the random base reader uses bounded block reads without read-ahead, while sequential readers retain the configured throughput-oriented behavior.

# Issue Describe / Design

Related to #1291.

A disconnected FUSE receiver or sender previously allowed sibling tasks to wait indefinitely. Separately, a single mutable reader serialized requests for the same FUSE handle, smart-prefetch random seeks started readers that could not serve the request, and cached writers could leave append metadata behind committed block state.

The session now exits on the first terminal channel task and aborts siblings. The read path lazily opens bounded independent readers per handle, with a default of one and a validated explicit override. Random seeks use only the base reader; when the detector returns to sequential mode, prefetch readers are aligned before resuming. Cached writers are finalized before append metadata is required.

The SSB 100G p16 gate measured `client_read_bytes / curvine_fuse_io_bytes_total = 3.30`: output trimming in FUSE cannot reduce that amplification because `BlockReadRequest.chunk_size` and worker read-ahead are fixed at `OpenBlock`. The incremental fix derives a random-reader-only `FsContext` with a 128 KiB maximum chunk and read-ahead disabled. It shares the existing RPC connector, client identity, failed-worker cache, and block connection pool, so it does not create runtimes, pools, or cleanup tasks. Sequential readers still use the original context.

No global lock behavior was changed. `fuse.per_handle_read_parallel=1` remains the compatibility default. The random-read change is deliberately bounded: it does not introduce a new user option or change the protocol. End-to-end performance is pending a rebuilt image.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-fuse/src/session/fuse_session.rs` | Stop sibling sender/receiver tasks when a session task exits; preserve the first terminal result. | A broken or unmounted FUSE connection terminates instead of retaining waiting tasks. |
| `curvine-fuse/src/fs/fuse_reader.rs` | Replace the shared reader worker with a bounded, lazy per-handle reader pool and pool-wait metrics. | Default remains single-reader; configured parallel reads use independent reader state. |
| `crates/common/curvine-config/src/fuse_conf.rs`, `curvine-fuse/src/cli/mount_args.rs` | Add `fuse.per_handle_read_parallel` and CLI override, validate nonzero values. | No behavior change without an explicit value. |
| `crates/client/curvine-client-core/src/file/fs_reader_buffer.rs` | Avoid sequential-prefetch fanout for random seeks; use a 128 KiB maximum random-reader block size and disable random-reader prefetch. | Sequential reader chunk size and prefetch behavior are unchanged. |
| `crates/client/curvine-client-core/src/file/fs_context.rs` | Derive the random-reader context while sharing connector, client identity, failed-worker cache, and block pool. | No additional RPC runtime, connection pool, or clean task. |
| `crates/client/curvine-client-core/src/file/fs_writer_base.rs`, `curvine-tests/tests/cached_writer_append_test.rs` | Finalize cached writers before append and cover the random-write then append sequence. | Prevents append metadata validation from observing incomplete cached block state. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-client-core` | PASS | 32 tests, including random base reader chunk/read-ahead isolation. |
| `cargo clippy -p curvine-client-core --tests -- -D warnings` | PASS | |
| `cargo test -p curvine-fuse fuse_read` | PASS | 7 tests. |
| `cargo test -p curvine-tests --test cached_writer_append_test` | PASS | Cached random write followed by append. |
| `cargo test -p curvine-fuse fuse_session` | PASS | 12 session lifecycle tests. |
| `cargo test -p curvine-config fuse_conf` | PASS | 38 configuration tests. |
| StarRocks SSB 100G Q4.2/Q4.3 p16 gate | BASELINE PASS | Before this commit: five successful runs each, medians 9.503s and 9.119s, stable output hashes, zero DataCache miss and write failure. The new random-read code has not yet been deployed, so this is not a performance claim. |

# Dependencies

- Related PRs: None
- Related issues: #1291
- Blocks / blocked by: Rebuilt Curvine image and SSB Q4.2/Q4.3 validation of the random-read change.
