### PR TITLE
feat(unified): add cache-mode write cache mirror

### DIFF
--- a/crates/adapters/curvine-ufs-opendal/tests/hdfs/hdfs_mount_integration_test.rs
+++ b/crates/adapters/curvine-ufs-opendal/tests/hdfs/hdfs_mount_integration_test.rs
@@ -83,6 +83,9 @@ mod mount_integration_tests {
                 replicas: None,
                 write_type: curvine_model::WriteType::CacheMode,
                 provider: None,
+                auto_cache: true,
+                access_mode: curvine_model::AccessMode::ReadOnly,
+                write_cache: false,
             };
 
             println!("Creating filesystem with MountInfo...");
@@ -271,6 +274,9 @@ mod mount_integration_tests {
                     replicas: None,
                     write_type: curvine_model::WriteType::CacheMode,
                     provider: None,
+                    auto_cache: true,
+                    access_mode: curvine_model::AccessMode::ReadOnly,
+                    write_cache: false,
                 };
 
                 match create_filesystem_from_mount(&mount_info) {
@@ -411,6 +417,9 @@ mod mount_integration_tests {
                 replicas: None,
                 write_type: curvine_model::WriteType::CacheMode,
                 provider: None,
+                auto_cache: true,
+                access_mode: curvine_model::AccessMode::ReadOnly,
+                write_cache: false,
             };
 
             let fs_v1 = create_filesystem_from_mount(&mount_info_v1)
@@ -460,6 +469,9 @@ mod mount_integration_tests {
                 replicas: None,
                 write_type: curvine_model::WriteType::CacheMode,
                 provider: None,
+                auto_cache: true,
+                access_mode: curvine_model::AccessMode::ReadOnly,
+                write_cache: false,
             };
 
             let fs_v2 = create_filesystem_from_mount(&mount_info_v2)

--- a/crates/client/curvine-unified-fs/src/unified/mod.rs
+++ b/crates/client/curvine-unified-fs/src/unified/mod.rs
@@ -39,9 +39,14 @@ pub use self::mount_cache::*;
 mod fallback_fs_reader;
 pub use self::fallback_fs_reader::FallbackFsReader;
 
+mod write_cache_writer;
+pub use self::write_cache_writer::WriteCacheWriter;
+
 #[allow(clippy::large_enum_variant)]
 pub enum UnifiedWriter {
     Cv(FsWriter),
+
+    WriteCache(Box<WriteCacheWriter>),
 
     #[cfg(feature = "opendal")]
     Opendal(OpendalWriter),
@@ -55,6 +60,8 @@ pub enum UnifiedWriter {
 impl_writer_for_enum! {
     enum UnifiedWriter {
         Cv(FsWriter),
+
+        WriteCache(Box<WriteCacheWriter>),
 
         #[cfg(feature = "opendal")]
         Opendal(OpendalWriter),
@@ -77,6 +84,8 @@ impl UnifiedWriter {
         match self {
             UnifiedWriter::Cv(_) => "curvine",
 
+            UnifiedWriter::WriteCache(_) => "ufs",
+
             #[cfg(feature = "opendal")]
             UnifiedWriter::Opendal(_) => "ufs",
 
@@ -84,6 +93,43 @@ impl UnifiedWriter {
             UnifiedWriter::OssHdfs(_) => "ufs",
 
             UnifiedWriter::Local(_) => "local",
+        }
+    }
+}
+
+#[allow(clippy::large_enum_variant)]
+pub enum UfsWriter {
+    #[cfg(feature = "opendal")]
+    Opendal(OpendalWriter),
+
+    #[cfg(feature = "oss-hdfs")]
+    OssHdfs(OssHdfsWriter),
+
+    Local(LocalWriter),
+}
+
+impl_writer_for_enum! {
+    enum UfsWriter {
+        #[cfg(feature = "opendal")]
+        Opendal(OpendalWriter),
+
+        #[cfg(feature = "oss-hdfs")]
+        OssHdfs(OssHdfsWriter),
+
+        Local(LocalWriter),
+    }
+}
+
+impl UfsWriter {
+    pub fn into_unified(self) -> UnifiedWriter {
+        match self {
+            #[cfg(feature = "opendal")]
+            UfsWriter::Opendal(writer) => UnifiedWriter::Opendal(writer),
+
+            #[cfg(feature = "oss-hdfs")]
+            UfsWriter::OssHdfs(writer) => UnifiedWriter::OssHdfs(writer),
+
+            UfsWriter::Local(writer) => UnifiedWriter::Local(writer),
         }
     }
 }
@@ -314,6 +360,27 @@ impl UfsFileSystem {
     pub fn with_mount(mnt: &MountInfo) -> FsResult<Self> {
         let path = Path::from_str(&mnt.ufs_path)?;
         Self::new(&path, mnt.properties.clone(), mnt.provider)
+    }
+
+    pub async fn create_ufs_writer(&self, path: &Path, overwrite: bool) -> FsResult<UfsWriter> {
+        match self {
+            #[cfg(feature = "opendal")]
+            UfsFileSystem::Opendal(inner) => {
+                let writer = inner.create(path, overwrite).await?;
+                Ok(UfsWriter::Opendal(writer))
+            }
+
+            #[cfg(feature = "oss-hdfs")]
+            UfsFileSystem::OssHdfs(inner) => {
+                let writer = inner.create(path, overwrite).await?;
+                Ok(UfsWriter::OssHdfs(writer))
+            }
+
+            UfsFileSystem::Local(inner) => {
+                let writer = inner.create(path, overwrite).await?;
+                Ok(UfsWriter::Local(writer))
+            }
+        }
     }
 
     /// Opens a UFS reader without wrapping it in UnifiedReader.

--- a/crates/client/curvine-unified-fs/src/unified/mod.rs
+++ b/crates/client/curvine-unified-fs/src/unified/mod.rs
@@ -121,6 +121,20 @@ impl_writer_for_enum! {
 }
 
 impl UfsWriter {
+    pub fn try_from_unified(writer: UnifiedWriter) -> Result<Self, Box<UnifiedWriter>> {
+        match writer {
+            #[cfg(feature = "opendal")]
+            UnifiedWriter::Opendal(writer) => Ok(UfsWriter::Opendal(writer)),
+
+            #[cfg(feature = "oss-hdfs")]
+            UnifiedWriter::OssHdfs(writer) => Ok(UfsWriter::OssHdfs(writer)),
+
+            UnifiedWriter::Local(writer) => Ok(UfsWriter::Local(writer)),
+
+            other => Err(Box::new(other)),
+        }
+    }
+
     pub fn into_unified(self) -> UnifiedWriter {
         match self {
             #[cfg(feature = "opendal")]
@@ -360,27 +374,6 @@ impl UfsFileSystem {
     pub fn with_mount(mnt: &MountInfo) -> FsResult<Self> {
         let path = Path::from_str(&mnt.ufs_path)?;
         Self::new(&path, mnt.properties.clone(), mnt.provider)
-    }
-
-    pub async fn create_ufs_writer(&self, path: &Path, overwrite: bool) -> FsResult<UfsWriter> {
-        match self {
-            #[cfg(feature = "opendal")]
-            UfsFileSystem::Opendal(inner) => {
-                let writer = inner.create(path, overwrite).await?;
-                Ok(UfsWriter::Opendal(writer))
-            }
-
-            #[cfg(feature = "oss-hdfs")]
-            UfsFileSystem::OssHdfs(inner) => {
-                let writer = inner.create(path, overwrite).await?;
-                Ok(UfsWriter::OssHdfs(writer))
-            }
-
-            UfsFileSystem::Local(inner) => {
-                let writer = inner.create(path, overwrite).await?;
-                Ok(UfsWriter::Local(writer))
-            }
-        }
     }
 
     /// Opens a UFS reader without wrapping it in UnifiedReader.

--- a/crates/client/curvine-unified-fs/src/unified/mount_cache.rs
+++ b/crates/client/curvine-unified-fs/src/unified/mount_cache.rs
@@ -364,6 +364,7 @@ mod tests {
             provider: Some(Provider::Opendal),
             auto_cache: true,
             access_mode: AccessMode::ReadOnly,
+            write_cache: false,
         }
     }
 

--- a/crates/client/curvine-unified-fs/src/unified/unified_filesystem.rs
+++ b/crates/client/curvine-unified-fs/src/unified/unified_filesystem.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{FallbackFsReader, MountCache, MountValue, UnifiedReader, UnifiedWriter};
+use crate::{
+    FallbackFsReader, MountCache, MountValue, UnifiedReader, UnifiedWriter, WriteCacheWriter,
+};
 use bytes::BytesMut;
 use curvine_client_core::file::{CurvineFileSystem, FsClient, FsContext, FsReader};
 use curvine_client_core::ClientMetrics;
@@ -55,6 +57,7 @@ pub struct UnifiedFileSystem {
     enable_read_ufs: bool,
     audit_logging_enabled: bool,
     async_cache_pending: Arc<DashSet<String>>,
+    write_cache_pending: Arc<DashSet<String>>,
     metrics: &'static ClientMetrics,
 }
 
@@ -74,6 +77,7 @@ impl UnifiedFileSystem {
             enable_read_ufs,
             audit_logging_enabled,
             async_cache_pending: Arc::new(DashSet::new()),
+            write_cache_pending: Arc::new(DashSet::new()),
             metrics: FsContext::get_metrics(),
         };
 
@@ -677,9 +681,35 @@ impl UnifiedFileSystem {
                     write_path = ufs_path.full_path().to_owned();
                     let ufs = mount.ufs()?;
                     if flags.append() {
-                        ufs.append(&ufs_path).await
+                        return ufs.append(&ufs_path).await;
+                    }
+
+                    let writer = ufs.create_ufs_writer(&ufs_path, flags.overwrite()).await?;
+
+                    if mount.info.write_cache_enabled() {
+                        let mirror_opts = mount.info.merge_create_opts(opts);
+                        match WriteCacheWriter::new(
+                            writer,
+                            self.cv.clone(),
+                            ufs,
+                            path.clone(),
+                            ufs_path.clone(),
+                            mirror_opts,
+                            self.write_cache_pending.clone(),
+                        )
+                        .await
+                        {
+                            Ok(writer) => Ok(UnifiedWriter::WriteCache(Box::new(writer))),
+                            Err((writer, e)) => {
+                                warn!(
+                                    "failed to open write cache mirror for cv_path={}, ufs_path={}: {}",
+                                    path, ufs_path, e
+                                );
+                                Ok(writer.into_unified())
+                            }
+                        }
                     } else {
-                        ufs.create(&ufs_path, flags.overwrite()).await
+                        Ok(writer.into_unified())
                     }
                 }
             }
@@ -988,7 +1018,15 @@ impl FileSystem<UnifiedWriter, UnifiedReader> for UnifiedFileSystem {
                     .inc();
 
                 if mount.info.auto_cache() {
-                    self.async_cache(&ufs_path)?;
+                    let ufs_key = ufs_path.clone_uri();
+                    if self.write_cache_pending.contains(&ufs_key) {
+                        debug!(
+                            "skip async cache for {} while write cache mirror is pending",
+                            ufs_path
+                        );
+                    } else {
+                        self.async_cache(&ufs_path)?;
+                    }
                 }
 
                 read_path = ufs_path.full_path().to_owned();

--- a/crates/client/curvine-unified-fs/src/unified/unified_filesystem.rs
+++ b/crates/client/curvine-unified-fs/src/unified/unified_filesystem.rs
@@ -57,7 +57,6 @@ pub struct UnifiedFileSystem {
     enable_read_ufs: bool,
     audit_logging_enabled: bool,
     async_cache_pending: Arc<DashSet<String>>,
-    write_cache_pending: Arc<DashSet<String>>,
     metrics: &'static ClientMetrics,
 }
 
@@ -77,7 +76,6 @@ impl UnifiedFileSystem {
             enable_read_ufs,
             audit_logging_enabled,
             async_cache_pending: Arc::new(DashSet::new()),
-            write_cache_pending: Arc::new(DashSet::new()),
             metrics: FsContext::get_metrics(),
         };
 
@@ -695,7 +693,6 @@ impl UnifiedFileSystem {
                             path.clone(),
                             ufs_path.clone(),
                             mirror_opts,
-                            self.write_cache_pending.clone(),
                         )
                         .await
                         {
@@ -1018,15 +1015,7 @@ impl FileSystem<UnifiedWriter, UnifiedReader> for UnifiedFileSystem {
                     .inc();
 
                 if mount.info.auto_cache() {
-                    let ufs_key = ufs_path.clone_uri();
-                    if self.write_cache_pending.contains(&ufs_key) {
-                        debug!(
-                            "skip async cache for {} while write cache mirror is pending",
-                            ufs_path
-                        );
-                    } else {
-                        self.async_cache(&ufs_path)?;
-                    }
+                    self.async_cache(&ufs_path)?;
                 }
 
                 read_path = ufs_path.full_path().to_owned();

--- a/crates/client/curvine-unified-fs/src/unified/unified_filesystem.rs
+++ b/crates/client/curvine-unified-fs/src/unified/unified_filesystem.rs
@@ -684,7 +684,7 @@ impl UnifiedFileSystem {
                         return ufs.append(&ufs_path).await;
                     }
 
-                    let writer = ufs.create_ufs_writer(&ufs_path, flags.overwrite()).await?;
+                    let writer = ufs.create(&ufs_path, flags.overwrite()).await?;
 
                     if mount.info.write_cache_enabled() {
                         let mirror_opts = mount.info.merge_create_opts(opts);
@@ -705,11 +705,11 @@ impl UnifiedFileSystem {
                                     "failed to open write cache mirror for cv_path={}, ufs_path={}: {}",
                                     path, ufs_path, e
                                 );
-                                Ok(writer.into_unified())
+                                Ok(writer)
                             }
                         }
                     } else {
-                        Ok(writer.into_unified())
+                        Ok(writer)
                     }
                 }
             }

--- a/crates/client/curvine-unified-fs/src/unified/write_cache_writer.rs
+++ b/crates/client/curvine-unified-fs/src/unified/write_cache_writer.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{UfsFileSystem, UfsWriter};
+use crate::{UfsFileSystem, UfsWriter, UnifiedWriter};
 use bytes::{Bytes, BytesMut};
 use curvine_client_core::file::{CurvineFileSystem, FsWriter};
 use curvine_error::{FsError, FsResult};
@@ -67,14 +67,23 @@ pub struct WriteCacheWriter {
 impl WriteCacheWriter {
     #[allow(clippy::too_many_arguments)]
     pub async fn new(
-        primary: UfsWriter,
+        primary: UnifiedWriter,
         cv: CurvineFileSystem,
         ufs: UfsFileSystem,
         cv_path: Path,
         ufs_path: Path,
         opts: CreateFileOpts,
         pending: Arc<DashSet<String>>,
-    ) -> Result<Self, (UfsWriter, FsError)> {
+    ) -> Result<Self, (UnifiedWriter, FsError)> {
+        let primary = match UfsWriter::try_from_unified(primary) {
+            Ok(primary) => primary,
+            Err(writer) => {
+                return Err((
+                    *writer,
+                    FsError::common("write cache requires a UFS writer primary"),
+                ))
+            }
+        };
         let chunk_size = primary.chunk_size();
         let pos = primary.pos();
         let path = primary.path().clone();
@@ -85,7 +94,7 @@ impl WriteCacheWriter {
             .set_overwrite(true);
         let cv_writer = match cv.open_with_opts(&cv_path, opts, cv_flags).await {
             Ok(writer) => writer,
-            Err(e) => return Err((primary, e)),
+            Err(e) => return Err((primary.into_unified(), e)),
         };
 
         let (tx, rx) = mpsc::channel(cv.conf().client.write_chunk_num.max(1));

--- a/crates/client/curvine-unified-fs/src/unified/write_cache_writer.rs
+++ b/crates/client/curvine-unified-fs/src/unified/write_cache_writer.rs
@@ -1,0 +1,392 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{UfsFileSystem, UfsWriter};
+use bytes::{Bytes, BytesMut};
+use curvine_client_core::file::{CurvineFileSystem, FsWriter};
+use curvine_error::{FsError, FsResult};
+use curvine_fs_api::{FileSystem, Path, Writer};
+use curvine_io::DataSlice;
+use curvine_model::{CreateFileOpts, FileAllocOpts, FileStatus, OpenFlags, SetAttrOpts};
+use curvine_runtime::runtime::RpcRuntime;
+use dashmap::DashSet;
+use log::{debug, warn};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::{mpsc, oneshot};
+use tokio::task::JoinHandle;
+use tokio::time;
+
+const WRITE_CACHE_COMPLETE_TIMEOUT: Duration = Duration::from_secs(30);
+
+enum MirrorTask {
+    Write {
+        pos: i64,
+        data: Bytes,
+    },
+    Flush,
+    Complete {
+        opts: Option<SetAttrOpts>,
+        tx: oneshot::Sender<FsResult<()>>,
+    },
+}
+
+struct MirrorState {
+    tx: mpsc::Sender<MirrorTask>,
+    handle: JoinHandle<()>,
+}
+
+pub struct WriteCacheWriter {
+    primary: UfsWriter,
+    cv: CurvineFileSystem,
+    ufs: UfsFileSystem,
+    cv_path: Path,
+    ufs_path: Path,
+    path: Path,
+    status: FileStatus,
+    pos: i64,
+    mirror_pos: i64,
+    chunk: BytesMut,
+    chunk_size: usize,
+    mirror: Option<MirrorState>,
+    pending: Arc<DashSet<String>>,
+    pending_key: String,
+}
+
+impl WriteCacheWriter {
+    #[allow(clippy::too_many_arguments)]
+    pub async fn new(
+        primary: UfsWriter,
+        cv: CurvineFileSystem,
+        ufs: UfsFileSystem,
+        cv_path: Path,
+        ufs_path: Path,
+        opts: CreateFileOpts,
+        pending: Arc<DashSet<String>>,
+    ) -> Result<Self, (UfsWriter, FsError)> {
+        let chunk_size = primary.chunk_size();
+        let pos = primary.pos();
+        let path = primary.path().clone();
+        let status = primary.status().clone();
+
+        let cv_flags = OpenFlags::new_write_only()
+            .set_create(true)
+            .set_overwrite(true);
+        let cv_writer = match cv.open_with_opts(&cv_path, opts, cv_flags).await {
+            Ok(writer) => writer,
+            Err(e) => return Err((primary, e)),
+        };
+
+        let (tx, rx) = mpsc::channel(cv.conf().client.write_chunk_num.max(1));
+        let pending_key = ufs_path.clone_uri();
+        pending.insert(pending_key.clone());
+
+        let handle = cv.fs_context_ref().rt().spawn(mirror_worker(
+            cv.clone(),
+            cv_path.clone(),
+            pending.clone(),
+            pending_key.clone(),
+            cv_writer,
+            rx,
+        ));
+
+        Ok(Self {
+            primary,
+            cv,
+            ufs,
+            cv_path,
+            ufs_path,
+            path,
+            status,
+            pos,
+            mirror_pos: pos,
+            chunk: BytesMut::with_capacity(chunk_size),
+            chunk_size,
+            mirror: Some(MirrorState { tx, handle }),
+            pending,
+            pending_key,
+        })
+    }
+
+    fn mirror_active(&self) -> bool {
+        self.mirror.is_some()
+    }
+
+    fn spawn_cleanup_cv(&self) {
+        let cv = self.cv.clone();
+        let cv_path = self.cv_path.clone();
+        self.cv
+            .fs_context_ref()
+            .rt()
+            .spawn(async move { cleanup_write_cache_file(cv, cv_path).await });
+    }
+
+    fn abandon_mirror(&mut self, reason: impl AsRef<str>) {
+        if let Some(mirror) = self.mirror.take() {
+            warn!(
+                "disable write cache mirror for cv_path={}, ufs_path={}: {}",
+                self.cv_path,
+                self.ufs_path,
+                reason.as_ref()
+            );
+            mirror.handle.abort();
+            self.pending.remove(&self.pending_key);
+            self.spawn_cleanup_cv();
+        }
+    }
+
+    fn mirror_attr(&self, opts: Option<SetAttrOpts>, ufs_mtime: i64) -> Option<SetAttrOpts> {
+        let mut opts = opts.unwrap_or_default();
+        opts.ufs_mtime = Some(ufs_mtime);
+        Some(opts)
+    }
+
+    async fn complete_mirror(&mut self, opts: Option<SetAttrOpts>) {
+        let Some(mirror) = self.mirror.take() else {
+            return;
+        };
+
+        let (tx, rx) = oneshot::channel();
+        if let Err(e) = mirror.tx.try_send(MirrorTask::Complete { opts, tx }) {
+            warn!(
+                "failed to enqueue write cache complete for cv_path={}, ufs_path={}: {}",
+                self.cv_path, self.ufs_path, e
+            );
+            mirror.handle.abort();
+            self.pending.remove(&self.pending_key);
+            self.spawn_cleanup_cv();
+            return;
+        }
+
+        match time::timeout(WRITE_CACHE_COMPLETE_TIMEOUT, rx).await {
+            Ok(Ok(Ok(()))) => {
+                debug!(
+                    "write cache mirror complete, cv_path={}, ufs_path={}",
+                    self.cv_path, self.ufs_path
+                );
+                let _ = mirror.handle.await;
+            }
+            Ok(Ok(Err(e))) => {
+                warn!(
+                    "write cache complete failed for cv_path={}, ufs_path={}: {}",
+                    self.cv_path, self.ufs_path, e
+                );
+            }
+            Ok(Err(e)) => {
+                warn!(
+                    "write cache worker stopped before complete for cv_path={}, ufs_path={}: {}",
+                    self.cv_path, self.ufs_path, e
+                );
+                self.pending.remove(&self.pending_key);
+                self.spawn_cleanup_cv();
+            }
+            Err(_) => {
+                warn!(
+                    "write cache complete timeout after {:?}, cv_path={}, ufs_path={}",
+                    WRITE_CACHE_COMPLETE_TIMEOUT, self.cv_path, self.ufs_path
+                );
+                mirror.handle.abort();
+                self.pending.remove(&self.pending_key);
+                self.spawn_cleanup_cv();
+            }
+        }
+    }
+
+    async fn enqueue_mirror_write(&mut self, pos: i64, data: Bytes) {
+        let Some(mirror) = self.mirror.as_ref() else {
+            return;
+        };
+
+        if let Err(e) = mirror.tx.try_send(MirrorTask::Write { pos, data }) {
+            self.abandon_mirror(format!("failed to enqueue mirror write: {}", e));
+        }
+    }
+
+    async fn enqueue_mirror_flush(&mut self) {
+        let Some(mirror) = self.mirror.as_ref() else {
+            return;
+        };
+
+        if let Err(e) = mirror.tx.try_send(MirrorTask::Flush) {
+            self.abandon_mirror(format!("failed to enqueue mirror flush: {}", e));
+        }
+    }
+}
+
+async fn cleanup_write_cache_file(cv: CurvineFileSystem, cv_path: Path) {
+    if let Err(e) = cv.delete(&cv_path, false).await {
+        if !matches!(e, FsError::FileNotFound(_)) {
+            warn!("failed to cleanup write cache mirror {}: {}", cv_path, e);
+        }
+    }
+}
+
+async fn mirror_worker(
+    cv: CurvineFileSystem,
+    cv_path: Path,
+    pending: Arc<DashSet<String>>,
+    pending_key: String,
+    mut writer: FsWriter,
+    mut rx: mpsc::Receiver<MirrorTask>,
+) {
+    let mut completed = false;
+
+    while let Some(task) = rx.recv().await {
+        match task {
+            MirrorTask::Write { pos, data } => {
+                if let Err(e) = writer.fuse_write(pos, DataSlice::Bytes(data)).await {
+                    warn!("write cache mirror write failed for {}: {}", cv_path, e);
+                    break;
+                }
+            }
+            MirrorTask::Flush => {
+                if let Err(e) = writer.flush().await {
+                    warn!("write cache mirror flush failed for {}: {}", cv_path, e);
+                    break;
+                }
+            }
+            MirrorTask::Complete { opts, tx } => {
+                let res = writer.complete_with_attr(opts).await;
+                completed = res.is_ok();
+                let _ = tx.send(res);
+                break;
+            }
+        }
+    }
+
+    if !completed {
+        let _ = writer.cancel().await;
+        cleanup_write_cache_file(cv, cv_path).await;
+    }
+
+    pending.remove(&pending_key);
+}
+
+impl Writer for WriteCacheWriter {
+    fn status(&self) -> &FileStatus {
+        &self.status
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn pos(&self) -> i64 {
+        self.pos
+    }
+
+    fn pos_mut(&mut self) -> &mut i64 {
+        &mut self.pos
+    }
+
+    fn chunk_mut(&mut self) -> &mut BytesMut {
+        &mut self.chunk
+    }
+
+    fn chunk_size(&self) -> usize {
+        self.chunk_size
+    }
+
+    async fn write_chunk(&mut self, chunk: DataSlice) -> FsResult<i64> {
+        let data = chunk.to_bytes();
+        if data.is_empty() {
+            return Ok(0);
+        }
+
+        let len = data.len() as i64;
+        let mirror_pos = self.mirror_pos;
+
+        if let Err(e) = self
+            .primary
+            .async_write(DataSlice::Bytes(data.clone()))
+            .await
+        {
+            self.abandon_mirror("ufs write failed");
+            return Err(e);
+        }
+
+        if self.mirror_active() {
+            self.enqueue_mirror_write(mirror_pos, data).await;
+            self.mirror_pos += len;
+        }
+
+        Ok(len)
+    }
+
+    async fn flush(&mut self) -> FsResult<()> {
+        self.flush_chunk().await?;
+        if let Err(e) = self.primary.flush().await {
+            self.abandon_mirror("ufs flush failed");
+            return Err(e);
+        }
+        if self.mirror_active() {
+            self.enqueue_mirror_flush().await;
+        }
+        Ok(())
+    }
+
+    async fn complete(&mut self) -> FsResult<()> {
+        self.complete_with_attr(None).await
+    }
+
+    async fn complete_with_attr(&mut self, opts: Option<SetAttrOpts>) -> FsResult<()> {
+        self.flush_chunk().await?;
+
+        if let Err(e) = self.primary.complete_with_attr(opts.clone()).await {
+            self.abandon_mirror("ufs complete failed");
+            return Err(e);
+        }
+
+        if self.mirror_active() {
+            match self.ufs.get_status(&self.ufs_path).await {
+                Ok(status) => {
+                    let opts = self.mirror_attr(opts, status.mtime);
+                    self.complete_mirror(opts).await;
+                }
+                Err(e) => {
+                    self.abandon_mirror(format!("failed to get ufs status after complete: {}", e));
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn cancel(&mut self) -> FsResult<()> {
+        self.chunk.clear();
+        let res = self.primary.cancel().await;
+        self.abandon_mirror("ufs writer canceled");
+        res
+    }
+
+    async fn seek(&mut self, pos: i64) -> FsResult<()> {
+        self.flush_chunk().await?;
+        if pos != self.pos {
+            self.abandon_mirror(format!(
+                "non-sequential write offset {}, expected {}",
+                pos, self.pos
+            ));
+            self.mirror_pos = pos;
+            self.primary.seek(pos).await?;
+            self.pos = pos;
+        }
+        Ok(())
+    }
+
+    async fn resize(&mut self, opts: FileAllocOpts) -> FsResult<()> {
+        self.flush_chunk().await?;
+        self.abandon_mirror("writer resized");
+        self.primary.resize(opts).await
+    }
+}

--- a/crates/client/curvine-unified-fs/src/unified/write_cache_writer.rs
+++ b/crates/client/curvine-unified-fs/src/unified/write_cache_writer.rs
@@ -20,15 +20,14 @@ use curvine_fs_api::{FileSystem, Path, Writer};
 use curvine_io::DataSlice;
 use curvine_model::{CreateFileOpts, FileAllocOpts, FileStatus, OpenFlags, SetAttrOpts};
 use curvine_runtime::runtime::RpcRuntime;
-use dashmap::DashSet;
 use log::{debug, warn};
-use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
 use tokio::time;
 
-const WRITE_CACHE_COMPLETE_TIMEOUT: Duration = Duration::from_secs(30);
+const WRITE_CACHE_ENQUEUE_TIMEOUT: Duration = Duration::from_secs(5);
+const WRITE_CACHE_COMPLETE_TIMEOUT: Duration = Duration::from_secs(5);
 
 enum MirrorTask {
     Write {
@@ -49,7 +48,6 @@ struct MirrorState {
 
 pub struct WriteCacheWriter {
     primary: UfsWriter,
-    cv: CurvineFileSystem,
     ufs: UfsFileSystem,
     cv_path: Path,
     ufs_path: Path,
@@ -60,12 +58,9 @@ pub struct WriteCacheWriter {
     chunk: BytesMut,
     chunk_size: usize,
     mirror: Option<MirrorState>,
-    pending: Arc<DashSet<String>>,
-    pending_key: String,
 }
 
 impl WriteCacheWriter {
-    #[allow(clippy::too_many_arguments)]
     pub async fn new(
         primary: UnifiedWriter,
         cv: CurvineFileSystem,
@@ -73,7 +68,6 @@ impl WriteCacheWriter {
         cv_path: Path,
         ufs_path: Path,
         opts: CreateFileOpts,
-        pending: Arc<DashSet<String>>,
     ) -> Result<Self, (UnifiedWriter, FsError)> {
         let primary = match UfsWriter::try_from_unified(primary) {
             Ok(primary) => primary,
@@ -92,27 +86,25 @@ impl WriteCacheWriter {
         let cv_flags = OpenFlags::new_write_only()
             .set_create(true)
             .set_overwrite(true);
-        let cv_writer = match cv.open_with_opts(&cv_path, opts, cv_flags).await {
+        let cv_writer = match cv
+            .open_with_opts(&cv_path, mirror_create_opts(opts), cv_flags)
+            .await
+        {
             Ok(writer) => writer,
             Err(e) => return Err((primary.into_unified(), e)),
         };
 
         let (tx, rx) = mpsc::channel(cv.conf().client.write_chunk_num.max(1));
-        let pending_key = ufs_path.clone_uri();
-        pending.insert(pending_key.clone());
 
         let handle = cv.fs_context_ref().rt().spawn(mirror_worker(
             cv.clone(),
             cv_path.clone(),
-            pending.clone(),
-            pending_key.clone(),
             cv_writer,
             rx,
         ));
 
         Ok(Self {
             primary,
-            cv,
             ufs,
             cv_path,
             ufs_path,
@@ -123,8 +115,6 @@ impl WriteCacheWriter {
             chunk: BytesMut::with_capacity(chunk_size),
             chunk_size,
             mirror: Some(MirrorState { tx, handle }),
-            pending,
-            pending_key,
         })
     }
 
@@ -132,26 +122,18 @@ impl WriteCacheWriter {
         self.mirror.is_some()
     }
 
-    fn spawn_cleanup_cv(&self) {
-        let cv = self.cv.clone();
-        let cv_path = self.cv_path.clone();
-        self.cv
-            .fs_context_ref()
-            .rt()
-            .spawn(async move { cleanup_write_cache_file(cv, cv_path).await });
-    }
-
     fn abandon_mirror(&mut self, reason: impl AsRef<str>) {
-        if let Some(mirror) = self.mirror.take() {
+        if let Some(_mirror) = self.mirror.take() {
             warn!(
                 "disable write cache mirror for cv_path={}, ufs_path={}: {}",
                 self.cv_path,
                 self.ufs_path,
                 reason.as_ref()
             );
-            mirror.handle.abort();
-            self.pending.remove(&self.pending_key);
-            self.spawn_cleanup_cv();
+            // Drop the sender so the worker drains, cancels the Curvine writer,
+            // and cleans up the partial mirror file before exiting. Aborting the
+            // task would drop `FsWriter` without `cancel()` (its `Drop` only
+            // logs), leaking server-side resources.
         }
     }
 
@@ -167,15 +149,30 @@ impl WriteCacheWriter {
         };
 
         let (tx, rx) = oneshot::channel();
-        if let Err(e) = mirror.tx.try_send(MirrorTask::Complete { opts, tx }) {
-            warn!(
-                "failed to enqueue write cache complete for cv_path={}, ufs_path={}: {}",
-                self.cv_path, self.ufs_path, e
-            );
-            mirror.handle.abort();
-            self.pending.remove(&self.pending_key);
-            self.spawn_cleanup_cv();
-            return;
+        match time::timeout(
+            WRITE_CACHE_ENQUEUE_TIMEOUT,
+            mirror.tx.send(MirrorTask::Complete { opts, tx }),
+        )
+        .await
+        {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                warn!(
+                    "failed to enqueue write cache complete for cv_path={}, ufs_path={}: {}",
+                    self.cv_path, self.ufs_path, e
+                );
+                // Worker already exited and ran its cancel/cleanup path.
+                return;
+            }
+            Err(_) => {
+                warn!(
+                    "write cache complete enqueue timed out for cv_path={}, ufs_path={}",
+                    self.cv_path, self.ufs_path
+                );
+                // Cooperative shutdown: the worker finishes the current op,
+                // then cancels the writer and cleans up.
+                return;
+            }
         }
 
         match time::timeout(WRITE_CACHE_COMPLETE_TIMEOUT, rx).await {
@@ -197,17 +194,15 @@ impl WriteCacheWriter {
                     "write cache worker stopped before complete for cv_path={}, ufs_path={}: {}",
                     self.cv_path, self.ufs_path, e
                 );
-                self.pending.remove(&self.pending_key);
-                self.spawn_cleanup_cv();
             }
             Err(_) => {
                 warn!(
                     "write cache complete timeout after {:?}, cv_path={}, ufs_path={}",
                     WRITE_CACHE_COMPLETE_TIMEOUT, self.cv_path, self.ufs_path
                 );
-                mirror.handle.abort();
-                self.pending.remove(&self.pending_key);
-                self.spawn_cleanup_cv();
+                // Cooperative: the worker keeps draining queued writes and
+                // completes (or cancels + cleans up) on its own in the
+                // background, so the Curvine writer is never dropped unclosed.
             }
         }
     }
@@ -217,8 +212,15 @@ impl WriteCacheWriter {
             return;
         };
 
-        if let Err(e) = mirror.tx.try_send(MirrorTask::Write { pos, data }) {
-            self.abandon_mirror(format!("failed to enqueue mirror write: {}", e));
+        match time::timeout(
+            WRITE_CACHE_ENQUEUE_TIMEOUT,
+            mirror.tx.send(MirrorTask::Write { pos, data }),
+        )
+        .await
+        {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => self.abandon_mirror(format!("mirror channel closed: {}", e)),
+            Err(_) => self.abandon_mirror("mirror enqueue timed out"),
         }
     }
 
@@ -227,10 +229,28 @@ impl WriteCacheWriter {
             return;
         };
 
-        if let Err(e) = mirror.tx.try_send(MirrorTask::Flush) {
-            self.abandon_mirror(format!("failed to enqueue mirror flush: {}", e));
+        match time::timeout(
+            WRITE_CACHE_ENQUEUE_TIMEOUT,
+            mirror.tx.send(MirrorTask::Flush),
+        )
+        .await
+        {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => self.abandon_mirror(format!("mirror channel closed: {}", e)),
+            Err(_) => self.abandon_mirror("mirror enqueue timed out"),
         }
     }
+}
+
+/// Build the create opts used to open the Curvine mirror target.
+///
+/// The in-flight mirror file must never look valid: until `complete_mirror`
+/// publishes the final UFS mtime, force `storage_policy.ufs_mtime = 0` so
+/// `cv_valid` rejects the partially mirrored file, regardless of what the
+/// caller passed (e.g. sync-write opts that already carry a UFS mtime).
+fn mirror_create_opts(mut opts: CreateFileOpts) -> CreateFileOpts {
+    opts.storage_policy.ufs_mtime = 0;
+    opts
 }
 
 async fn cleanup_write_cache_file(cv: CurvineFileSystem, cv_path: Path) {
@@ -244,8 +264,6 @@ async fn cleanup_write_cache_file(cv: CurvineFileSystem, cv_path: Path) {
 async fn mirror_worker(
     cv: CurvineFileSystem,
     cv_path: Path,
-    pending: Arc<DashSet<String>>,
-    pending_key: String,
     mut writer: FsWriter,
     mut rx: mpsc::Receiver<MirrorTask>,
 ) {
@@ -278,8 +296,6 @@ async fn mirror_worker(
         let _ = writer.cancel().await;
         cleanup_write_cache_file(cv, cv_path).await;
     }
-
-    pending.remove(&pending_key);
 }
 
 impl Writer for WriteCacheWriter {
@@ -397,5 +413,35 @@ impl Writer for WriteCacheWriter {
         self.flush_chunk().await?;
         self.abandon_mirror("writer resized");
         self.primary.resize(opts).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::mirror_create_opts;
+    use curvine_model::CreateFileOptsBuilder;
+
+    #[test]
+    fn mirror_create_opts_forces_zero_ufs_mtime() {
+        let opts = CreateFileOptsBuilder::new()
+            .ufs_mtime_len(12_345, 678)
+            .build();
+
+        let mirror = mirror_create_opts(opts);
+
+        assert_eq!(mirror.storage_policy.ufs_mtime, 0);
+    }
+
+    #[test]
+    fn mirror_create_opts_preserves_other_fields() {
+        let opts = CreateFileOptsBuilder::new()
+            .ufs_mtime_len(12_345, 678)
+            .build();
+
+        let mirror = mirror_create_opts(opts.clone());
+
+        assert_eq!(mirror.block_size, opts.block_size);
+        assert_eq!(mirror.replicas, opts.replicas);
+        assert_eq!(mirror.ufs_len, opts.ufs_len);
     }
 }

--- a/crates/common/curvine-model/src/mount.rs
+++ b/crates/common/curvine-model/src/mount.rs
@@ -527,6 +527,16 @@ impl MountOptionsBuilder {
         self
     }
 
+    /// Reset optional toggle fields to `None` so a mount `--update` preserves
+    /// existing values (`merge_with` keeps `None` fields) unless they were
+    /// explicitly provided.
+    pub fn update_only_explicit(mut self) -> Self {
+        self.auto_cache = None;
+        self.access_mode = None;
+        self.write_cache = None;
+        self
+    }
+
     pub fn build(self) -> MountOptions {
         MountOptions {
             update: self.update,
@@ -667,6 +677,39 @@ mod tests {
         assert!(!updated.auto_cache);
         assert_eq!(updated.access_mode, AccessMode::ReadWrite);
         assert!(updated.write_cache);
+    }
+
+    #[test]
+    fn test_update_only_explicit_preserves_existing_toggles() {
+        let info = MountInfo {
+            cv_path: "/mnt".to_string(),
+            ufs_path: "s3://b".to_string(),
+            auto_cache: false,
+            access_mode: AccessMode::ReadWrite,
+            write_cache: true,
+            ..Default::default()
+        };
+
+        // An update that omits the toggles must keep the existing values.
+        let merged = info.clone().merge_with(
+            MountOptions::builder()
+                .update(true)
+                .update_only_explicit()
+                .build(),
+        );
+        assert!(!merged.auto_cache);
+        assert_eq!(merged.access_mode, AccessMode::ReadWrite);
+        assert!(merged.write_cache);
+
+        // Explicitly provided values still apply.
+        let merged = info.merge_with(
+            MountOptions::builder()
+                .update(true)
+                .update_only_explicit()
+                .write_cache(false)
+                .build(),
+        );
+        assert!(!merged.write_cache);
     }
 
     #[test]

--- a/crates/common/curvine-model/src/mount.rs
+++ b/crates/common/curvine-model/src/mount.rs
@@ -83,6 +83,10 @@ impl AccessMode {
     pub fn is_read_only(&self) -> bool {
         matches!(self, AccessMode::ReadOnly)
     }
+
+    pub fn is_read_write(&self) -> bool {
+        matches!(self, AccessMode::ReadWrite)
+    }
 }
 
 impl TryFrom<&str> for AccessMode {
@@ -116,6 +120,7 @@ pub struct MountInfo {
     pub provider: Option<Provider>,
     pub auto_cache: bool,
     pub access_mode: AccessMode,
+    pub write_cache: bool,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -151,6 +156,47 @@ impl From<LegacyMountInfo> for MountInfo {
             provider: info.provider,
             auto_cache: true,
             access_mode: AccessMode::ReadOnly,
+            write_cache: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct LegacyMountInfoWithAutoCacheAccessMode {
+    cv_path: String,
+    ufs_path: String,
+    mount_id: u32,
+    properties: HashMap<String, String>,
+    ttl_ms: i64,
+    ttl_action: TtlAction,
+    read_verify_ufs: bool,
+    storage_type: Option<StorageType>,
+    block_size: Option<i64>,
+    replicas: Option<i32>,
+    write_type: WriteType,
+    provider: Option<Provider>,
+    auto_cache: bool,
+    access_mode: AccessMode,
+}
+
+impl From<LegacyMountInfoWithAutoCacheAccessMode> for MountInfo {
+    fn from(info: LegacyMountInfoWithAutoCacheAccessMode) -> Self {
+        Self {
+            cv_path: info.cv_path,
+            ufs_path: info.ufs_path,
+            mount_id: info.mount_id,
+            properties: info.properties,
+            ttl_ms: info.ttl_ms,
+            ttl_action: info.ttl_action,
+            read_verify_ufs: info.read_verify_ufs,
+            storage_type: info.storage_type,
+            block_size: info.block_size,
+            replicas: info.replicas,
+            write_type: info.write_type,
+            provider: info.provider,
+            auto_cache: info.auto_cache,
+            access_mode: info.access_mode,
+            write_cache: false,
         }
     }
 }
@@ -160,6 +206,14 @@ impl MountInfo {
         match bincode::deserialize::<Self>(bytes) {
             Ok(info) => Ok(info),
             Err(e) if Self::is_unexpected_eof(&e) => {
+                if let Ok(legacy) = bincode::DefaultOptions::new()
+                    .with_fixint_encoding()
+                    .reject_trailing_bytes()
+                    .deserialize::<LegacyMountInfoWithAutoCacheAccessMode>(bytes)
+                {
+                    return Ok(legacy.into());
+                }
+
                 let legacy: LegacyMountInfo = bincode::DefaultOptions::new()
                     .with_fixint_encoding()
                     .reject_trailing_bytes()
@@ -273,6 +327,10 @@ impl MountInfo {
         self.is_cache_mode() && self.access_mode.is_read_only()
     }
 
+    pub fn write_cache_enabled(&self) -> bool {
+        self.write_cache && self.is_cache_mode() && self.access_mode.is_read_write()
+    }
+
     pub fn merge_with(self, mnt_opt: MountOptions) -> MountInfo {
         let mut properties = self.properties;
 
@@ -299,6 +357,7 @@ impl MountInfo {
             provider: mnt_opt.provider.or(self.provider),
             auto_cache: mnt_opt.auto_cache.unwrap_or(self.auto_cache),
             access_mode: mnt_opt.access_mode.unwrap_or(self.access_mode),
+            write_cache: mnt_opt.write_cache.unwrap_or(self.write_cache),
         }
     }
 }
@@ -318,6 +377,7 @@ pub struct MountOptions {
     pub provider: Option<Provider>,
     pub auto_cache: Option<bool>,
     pub access_mode: Option<AccessMode>,
+    pub write_cache: Option<bool>,
 }
 
 impl MountOptions {
@@ -347,6 +407,7 @@ impl MountOptions {
             provider: self.provider,
             auto_cache: self.auto_cache.unwrap_or(true),
             access_mode: self.access_mode.unwrap_or_default(),
+            write_cache: self.write_cache.unwrap_or(false),
         }
     }
 }
@@ -366,6 +427,7 @@ pub struct MountOptionsBuilder {
     provider: Option<Provider>,
     auto_cache: Option<bool>,
     access_mode: Option<AccessMode>,
+    write_cache: Option<bool>,
 }
 
 impl MountOptionsBuilder {
@@ -376,6 +438,7 @@ impl MountOptionsBuilder {
             ttl_action: Some(TtlAction::Delete),
             auto_cache: Some(true),
             access_mode: Some(AccessMode::ReadOnly),
+            write_cache: Some(false),
             ..Default::default()
         }
     }
@@ -459,6 +522,11 @@ impl MountOptionsBuilder {
         self
     }
 
+    pub fn write_cache(mut self, write_cache: bool) -> Self {
+        self.write_cache = Some(write_cache);
+        self
+    }
+
     pub fn build(self) -> MountOptions {
         MountOptions {
             update: self.update,
@@ -474,6 +542,7 @@ impl MountOptionsBuilder {
             provider: self.provider,
             auto_cache: self.auto_cache,
             access_mode: self.access_mode,
+            write_cache: self.write_cache,
         }
     }
 }
@@ -569,6 +638,7 @@ mod tests {
         let info = MountOptions::builder().build().to_info(1, "/mnt", "s3://b");
         assert!(info.auto_cache);
         assert_eq!(info.access_mode, AccessMode::ReadOnly);
+        assert!(!info.write_cache);
     }
 
     #[test]
@@ -578,21 +648,25 @@ mod tests {
             ufs_path: "s3://b".to_string(),
             auto_cache: true,
             access_mode: AccessMode::ReadOnly,
+            write_cache: false,
             ..Default::default()
         };
 
         let unchanged = info.clone().merge_with(MountOptions::builder().build());
         assert!(unchanged.auto_cache);
         assert_eq!(unchanged.access_mode, AccessMode::ReadOnly);
+        assert!(!unchanged.write_cache);
 
         let updated = info.merge_with(
             MountOptions::builder()
                 .auto_cache(false)
                 .access_mode(AccessMode::ReadWrite)
+                .write_cache(true)
                 .build(),
         );
         assert!(!updated.auto_cache);
         assert_eq!(updated.access_mode, AccessMode::ReadWrite);
+        assert!(updated.write_cache);
     }
 
     #[test]

--- a/crates/common/curvine-model/src/proto_utils.rs
+++ b/crates/common/curvine-model/src/proto_utils.rs
@@ -590,6 +590,7 @@ impl ProtoUtils {
             provider: info.provider.map(|v| v.into()),
             auto_cache: Some(info.auto_cache),
             access_mode: Some(info.access_mode.into()),
+            write_cache: Some(info.write_cache),
         }
     }
 
@@ -609,6 +610,7 @@ impl ProtoUtils {
             provider: info.provider.map(|x| x.into()),
             auto_cache: info.auto_cache.unwrap_or(true),
             access_mode: info.access_mode.map(AccessMode::from).unwrap_or_default(),
+            write_cache: info.write_cache.unwrap_or(false),
         }
     }
 
@@ -627,6 +629,7 @@ impl ProtoUtils {
             provider: opts.provider.map(|v| v.into()),
             auto_cache: opts.auto_cache,
             access_mode: opts.access_mode.map(|v| v.into()),
+            write_cache: opts.write_cache,
         }
     }
 
@@ -645,6 +648,7 @@ impl ProtoUtils {
             provider: opts.provider.map(Provider::from),
             auto_cache: opts.auto_cache,
             access_mode: opts.access_mode.map(AccessMode::from),
+            write_cache: opts.write_cache,
         }
     }
 
@@ -766,6 +770,7 @@ mod tests {
             mount_id: 7,
             auto_cache: false,
             access_mode: AccessMode::ReadWrite,
+            write_cache: true,
             ..Default::default()
         };
 
@@ -774,6 +779,7 @@ mod tests {
 
         assert!(!round_trip.auto_cache);
         assert_eq!(round_trip.access_mode, AccessMode::ReadWrite);
+        assert!(round_trip.write_cache);
     }
 
     #[test]
@@ -781,6 +787,7 @@ mod tests {
         let opts = MountOptions::builder()
             .auto_cache(false)
             .access_mode(AccessMode::ReadWrite)
+            .write_cache(true)
             .build();
 
         let pb = ProtoUtils::mount_options_to_pb(opts);
@@ -788,6 +795,7 @@ mod tests {
 
         assert_eq!(round_trip.auto_cache, Some(false));
         assert_eq!(round_trip.access_mode, Some(AccessMode::ReadWrite));
+        assert_eq!(round_trip.write_cache, Some(true));
     }
 
     #[test]

--- a/crates/common/curvine-model/tests/mount_info_compat_test.rs
+++ b/crates/common/curvine-model/tests/mount_info_compat_test.rs
@@ -18,6 +18,24 @@ struct LegacyMountInfo {
     provider: Option<Provider>,
 }
 
+#[derive(Debug, Serialize)]
+struct LegacyMountInfoWithAutoCacheAccessMode {
+    cv_path: String,
+    ufs_path: String,
+    mount_id: u32,
+    properties: HashMap<String, String>,
+    ttl_ms: i64,
+    ttl_action: TtlAction,
+    read_verify_ufs: bool,
+    storage_type: Option<StorageType>,
+    block_size: Option<i64>,
+    replicas: Option<i32>,
+    write_type: WriteType,
+    provider: Option<Provider>,
+    auto_cache: bool,
+    access_mode: AccessMode,
+}
+
 fn legacy_mount_info() -> LegacyMountInfo {
     let mut properties = HashMap::new();
     properties.insert("k".to_string(), "v".to_string());
@@ -38,6 +56,26 @@ fn legacy_mount_info() -> LegacyMountInfo {
     }
 }
 
+fn legacy_mount_info_with_auto_cache_access_mode() -> LegacyMountInfoWithAutoCacheAccessMode {
+    let info = legacy_mount_info();
+    LegacyMountInfoWithAutoCacheAccessMode {
+        cv_path: info.cv_path,
+        ufs_path: info.ufs_path,
+        mount_id: info.mount_id,
+        properties: info.properties,
+        ttl_ms: info.ttl_ms,
+        ttl_action: info.ttl_action,
+        read_verify_ufs: info.read_verify_ufs,
+        storage_type: info.storage_type,
+        block_size: info.block_size,
+        replicas: info.replicas,
+        write_type: info.write_type,
+        provider: info.provider,
+        auto_cache: false,
+        access_mode: AccessMode::ReadWrite,
+    }
+}
+
 fn current_mount_info() -> MountInfo {
     let info = legacy_mount_info();
     MountInfo {
@@ -55,6 +93,7 @@ fn current_mount_info() -> MountInfo {
         provider: info.provider,
         auto_cache: true,
         access_mode: AccessMode::ReadOnly,
+        write_cache: false,
     }
 }
 
@@ -77,6 +116,17 @@ fn decode_persisted_mount_info_accepts_legacy_bytes() {
     assert_eq!(decoded.provider, Some(Provider::OssHdfs));
     assert!(decoded.auto_cache);
     assert_eq!(decoded.access_mode, AccessMode::ReadOnly);
+    assert!(!decoded.write_cache);
+}
+
+#[test]
+fn decode_persisted_mount_info_accepts_previous_current_bytes() {
+    let bytes = bincode::serialize(&legacy_mount_info_with_auto_cache_access_mode()).unwrap();
+    let decoded = MountInfo::decode_persisted(&bytes).unwrap();
+
+    assert!(!decoded.auto_cache);
+    assert_eq!(decoded.access_mode, AccessMode::ReadWrite);
+    assert!(!decoded.write_cache);
 }
 
 #[test]
@@ -84,12 +134,14 @@ fn decode_persisted_mount_info_keeps_current_fields() {
     let mut current = current_mount_info();
     current.auto_cache = false;
     current.access_mode = AccessMode::ReadWrite;
+    current.write_cache = true;
 
     let bytes = bincode::serialize(&current).unwrap();
     let decoded = MountInfo::decode_persisted(&bytes).unwrap();
 
     assert!(!decoded.auto_cache);
     assert_eq!(decoded.access_mode, AccessMode::ReadWrite);
+    assert!(decoded.write_cache);
     assert_eq!(decoded.cv_path, current.cv_path);
     assert_eq!(decoded.ufs_path, current.ufs_path);
     assert_eq!(decoded.mount_id, current.mount_id);

--- a/crates/common/curvine-proto/proto/mount.proto
+++ b/crates/common/curvine-proto/proto/mount.proto
@@ -22,6 +22,7 @@ message MountInfoProto {
     optional ProviderProto provider = 12;
     optional bool auto_cache = 13 [default = true];
     optional AccessModeProto access_mode = 14 [default = ACCESS_MODE_PROTO_READ_ONLY];
+    optional bool write_cache = 15 [default = false];
 }
 
 message MountOptionsProto {
@@ -38,6 +39,7 @@ message MountOptionsProto {
     optional ProviderProto provider = 12;
     optional bool auto_cache = 13;
     optional AccessModeProto access_mode = 14;
+    optional bool write_cache = 15;
 }
 
 enum ProviderProto {

--- a/crates/common/curvine-proto/src/display.rs
+++ b/crates/common/curvine-proto/src/display.rs
@@ -88,6 +88,7 @@ impl Display for GetMountTableResponse {
         let mut read_verify_ufs_width = 14;
         let mut auto_cache_width = 10;
         let mut access_mode_width = 11;
+        let mut write_cache_width = 11;
         let mut storage_width = 7;
         let mut ttl_action_width = 10;
         let mut provider_width = 8;
@@ -108,6 +109,14 @@ impl Display for GetMountTableResponse {
                 .len(),
             );
             access_mode_width = access_mode_width.max(access_mode_to_str(mnt.access_mode).len());
+            write_cache_width = write_cache_width.max(
+                if mnt.write_cache.unwrap_or(false) {
+                    "yes"
+                } else {
+                    "no"
+                }
+                .len(),
+            );
             storage_width = storage_width.max(storage_type_to_str(mnt.storage_type).len());
             ttl_action_width = ttl_action_width.max(ttl_action_to_str(mnt.ttl_action()).len());
             provider_width = provider_width.max(provider_to_str(mnt.provider).len());
@@ -120,6 +129,7 @@ impl Display for GetMountTableResponse {
         read_verify_ufs_width += 2;
         auto_cache_width += 2;
         access_mode_width += 2;
+        write_cache_width += 2;
         storage_width += 2;
         ttl_action_width += 2;
         provider_width += 2;
@@ -134,6 +144,7 @@ impl Display for GetMountTableResponse {
         write!(f, "{:-^width$}+", "", width = read_verify_ufs_width)?;
         write!(f, "{:-^width$}+", "", width = auto_cache_width)?;
         write!(f, "{:-^width$}+", "", width = access_mode_width)?;
+        write!(f, "{:-^width$}+", "", width = write_cache_width)?;
         write!(f, "{:-^width$}+", "", width = storage_width)?;
         write!(f, "{:-^width$}+", "", width = ttl_action_width)?;
         writeln!(f, "{:-^width$}+", "", width = provider_width)?;
@@ -166,6 +177,12 @@ impl Display for GetMountTableResponse {
             "Access Mode",
             width = access_mode_width - 1
         )?;
+        write!(
+            f,
+            " {:<width$}|",
+            "Write Cache",
+            width = write_cache_width - 1
+        )?;
         write!(f, " {:<width$}|", "Storage", width = storage_width - 1)?;
         write!(
             f,
@@ -183,6 +200,7 @@ impl Display for GetMountTableResponse {
         write!(f, "{:-^width$}+", "", width = read_verify_ufs_width)?;
         write!(f, "{:-^width$}+", "", width = auto_cache_width)?;
         write!(f, "{:-^width$}+", "", width = access_mode_width)?;
+        write!(f, "{:-^width$}+", "", width = write_cache_width)?;
         write!(f, "{:-^width$}+", "", width = storage_width)?;
         write!(f, "{:-^width$}+", "", width = ttl_action_width)?;
         writeln!(f, "{:-^width$}+", "", width = provider_width)?;
@@ -223,6 +241,16 @@ impl Display for GetMountTableResponse {
             write!(
                 f,
                 " {:<width$}|",
+                if mnt.write_cache.unwrap_or(false) {
+                    "yes"
+                } else {
+                    "no"
+                },
+                width = write_cache_width - 1
+            )?;
+            write!(
+                f,
+                " {:<width$}|",
                 storage_type_to_str(mnt.storage_type),
                 width = storage_width - 1
             )?;
@@ -248,6 +276,7 @@ impl Display for GetMountTableResponse {
         write!(f, "{:-^width$}+", "", width = read_verify_ufs_width)?;
         write!(f, "{:-^width$}+", "", width = auto_cache_width)?;
         write!(f, "{:-^width$}+", "", width = access_mode_width)?;
+        write!(f, "{:-^width$}+", "", width = write_cache_width)?;
         write!(f, "{:-^width$}+", "", width = storage_width)?;
         write!(f, "{:-^width$}+", "", width = ttl_action_width)?;
         writeln!(f, "{:-^width$}+", "", width = provider_width)?;

--- a/curvine-cli/src/cmds/mount.rs
+++ b/curvine-cli/src/cmds/mount.rs
@@ -89,7 +89,7 @@ pub struct MountCommand {
 
     #[arg(
         long = "write-cache",
-        help = "Whether cache_mode read_write writes should also mirror sequential create/overwrite data to Curvine. Values: true, false. Default for new mounts: false."
+        help = "Whether cache_mode read_write writes should also mirror sequential create/overwrite data to Curvine. Values: true, false. Default for new mounts: false. Omitted when used with --update."
     )]
     write_cache: Option<bool>,
 
@@ -539,7 +539,14 @@ impl MountCommand {
             TtlAction::Delete
         };
 
-        let mut opts = MountOptions::builder()
+        let mut opts = MountOptions::builder();
+        if self.update {
+            // On update, only explicitly provided optional fields are sent so
+            // omitted toggles (auto_cache/access_mode/write_cache) keep their
+            // existing mount values instead of being reset to defaults.
+            opts = opts.update_only_explicit();
+        }
+        let mut opts = opts
             .update(self.update)
             .set_properties(conf_map)
             .write_type(write_type)

--- a/curvine-cli/src/cmds/mount.rs
+++ b/curvine-cli/src/cmds/mount.rs
@@ -87,6 +87,12 @@ pub struct MountCommand {
     )]
     access_mode: Option<String>,
 
+    #[arg(
+        long = "write-cache",
+        help = "Whether cache_mode read_write writes should also mirror sequential create/overwrite data to Curvine. Values: true, false. Default for new mounts: false."
+    )]
+    write_cache: Option<bool>,
+
     #[arg(long, default_value_t = false)]
     check: bool,
 
@@ -563,6 +569,10 @@ impl MountCommand {
         if let Some(access_mode_str) = self.access_mode.as_ref() {
             let access_mode = AccessMode::try_from(access_mode_str.as_str())?;
             opts = opts.access_mode(access_mode);
+        }
+
+        if let Some(write_cache) = self.write_cache {
+            opts = opts.write_cache(write_cache);
         }
 
         Ok(opts.build())

--- a/curvine-libsdk/java/src/main/java/io/curvine/MountRequest.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/MountRequest.java
@@ -71,6 +71,7 @@ public final class MountRequest {
         private ProviderProto provider;
         private Boolean autoCache;
         private AccessModeProto accessMode;
+        private Boolean writeCache;
 
         private Builder() {
         }
@@ -157,6 +158,11 @@ public final class MountRequest {
             return this;
         }
 
+        public Builder writeCache(boolean writeCache) {
+            this.writeCache = writeCache;
+            return this;
+        }
+
         public MountRequest build() {
             String checkedUfsPath = requireText(ufsPath, "ufsPath");
             String checkedCvPath = requireText(cvPath, "cvPath");
@@ -170,7 +176,8 @@ public final class MountRequest {
                     .setWriteType(writeType)
                     .setAutoCache(autoCache == null || autoCache)
                     .setAccessMode(accessMode == null
-                            ? AccessModeProto.ACCESS_MODE_PROTO_READ_ONLY : accessMode);
+                            ? AccessModeProto.ACCESS_MODE_PROTO_READ_ONLY : accessMode)
+                    .setWriteCache(writeCache != null && writeCache);
             if (storageType != null) {
                 options.setStorageType(storageType);
             }

--- a/curvine-libsdk/java/src/main/java/io/curvine/MountRequest.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/MountRequest.java
@@ -176,8 +176,10 @@ public final class MountRequest {
                     .setWriteType(writeType)
                     .setAutoCache(autoCache == null || autoCache)
                     .setAccessMode(accessMode == null
-                            ? AccessModeProto.ACCESS_MODE_PROTO_READ_ONLY : accessMode)
-                    .setWriteCache(writeCache != null && writeCache);
+                            ? AccessModeProto.ACCESS_MODE_PROTO_READ_ONLY : accessMode);
+            if (writeCache != null) {
+                options.setWriteCache(writeCache);
+            }
             if (storageType != null) {
                 options.setStorageType(storageType);
             }

--- a/curvine-libsdk/java/src/test/java/io/curvine/MountRequestTest.java
+++ b/curvine-libsdk/java/src/test/java/io/curvine/MountRequestTest.java
@@ -44,6 +44,7 @@ public class MountRequestTest {
         Assert.assertTrue(request.getOptions().getAutoCache());
         Assert.assertEquals(
                 AccessModeProto.ACCESS_MODE_PROTO_READ_ONLY, request.getOptions().getAccessMode());
+        Assert.assertFalse(request.getOptions().getWriteCache());
         Assert.assertEquals(
                 "https://oss.example.com", request.getOptions().getAddPropertiesOrThrow("oss.endpoint"));
         Assert.assertFalse(request.getOptions().hasProvider());
@@ -66,6 +67,7 @@ public class MountRequestTest {
                 .provider(ProviderProto.PROVIDER_PROTO_OPENDAL)
                 .autoCache(false)
                 .accessMode(AccessModeProto.ACCESS_MODE_PROTO_READ_WRITE)
+                .writeCache(true)
                 .build();
 
         Assert.assertTrue(request.getOptions().getUpdate());
@@ -85,6 +87,7 @@ public class MountRequestTest {
         Assert.assertFalse(request.getOptions().getAutoCache());
         Assert.assertEquals(
                 AccessModeProto.ACCESS_MODE_PROTO_READ_WRITE, request.getOptions().getAccessMode());
+        Assert.assertTrue(request.getOptions().getWriteCache());
     }
 
     @Test

--- a/curvine-master/src/master/mount/mount_manager.rs
+++ b/curvine-master/src/master/mount/mount_manager.rs
@@ -59,6 +59,13 @@ impl MountManager {
     }
 
     fn normalize_mount_config(mount: &mut MountInfo) -> FsResult<()> {
+        if mount.write_cache && !mount.write_cache_enabled() {
+            return err_box!(
+                "write_cache requires cache_mode with read_write access_mode for mount {}",
+                mount.cv_path
+            );
+        }
+
         let path = Path::from_str(&mount.ufs_path)?;
         if !matches!(path.scheme(), Some("s3" | "s3a")) {
             return Ok(());
@@ -169,5 +176,54 @@ impl MountManager {
             entries.push(entry.clone());
         });
         Ok(entries)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MountManager;
+    use curvine_model::{AccessMode, MountInfo, MountOptions, WriteType};
+
+    fn mount_info(write_type: WriteType, access_mode: AccessMode, write_cache: bool) -> MountInfo {
+        MountOptions::builder()
+            .write_type(write_type)
+            .access_mode(access_mode)
+            .write_cache(write_cache)
+            .build()
+            .to_info(1, "/mnt", "file:///tmp/curvine-mount")
+    }
+
+    #[test]
+    fn normalize_mount_config_accepts_write_cache_for_cache_mode_read_write() {
+        let mut info = mount_info(WriteType::CacheMode, AccessMode::ReadWrite, true);
+
+        MountManager::normalize_mount_config(&mut info).unwrap();
+    }
+
+    #[test]
+    fn normalize_mount_config_rejects_write_cache_for_read_only_cache_mode() {
+        let mut info = mount_info(WriteType::CacheMode, AccessMode::ReadOnly, true);
+
+        let err = MountManager::normalize_mount_config(&mut info).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("write_cache requires cache_mode with read_write"));
+    }
+
+    #[test]
+    fn normalize_mount_config_rejects_write_cache_for_fs_mode() {
+        let mut info = mount_info(WriteType::FsMode, AccessMode::ReadWrite, true);
+
+        let err = MountManager::normalize_mount_config(&mut info).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("write_cache requires cache_mode with read_write"));
+    }
+
+    #[test]
+    fn normalize_mount_config_accepts_disabled_write_cache() {
+        let mut info = mount_info(WriteType::CacheMode, AccessMode::ReadOnly, false);
+
+        MountManager::normalize_mount_config(&mut info).unwrap();
     }
 }


### PR DESCRIPTION
# Summary

This PR adds a mount-level `write_cache` option for cache-mode read-write mounts. When enabled, sequential create/overwrite writes are committed to UFS first and mirrored to Curvine as a best-effort write cache. The feature targets SDK-mode usage; read-miss `auto_cache` remains a separate mechanism and is not coordinated with the mirror.

# Issue Describe / Design

No linked issue.

This feature keeps UFS as the source of truth while allowing selected cache-mode mounts to proactively populate Curvine on writes. The mirror path is intentionally best-effort: UFS write/complete failures fail the operation, while Curvine mirror failures, queue backpressure timeouts, and completion timeouts fall back to UFS success.

Design decisions and trade-offs:
- `write_cache` is mount-scoped for v1 and only valid with `cache_mode + read_write`.
- Append remains UFS-only.
- Non-sequential writes disable the mirror and continue through the existing UFS writer behavior.
- Mirror shutdown is cooperative: dropping the channel sender lets the worker `cancel()` the Curvine writer and clean up the partial file, avoiding leaked writers from task `abort()`.
- Mirror enqueues use a bounded 5s send timeout so fast UFS writers get backpressure instead of silently abandoning the mirror after a few chunks.
- Curvine mirror completion waits up to 5 seconds after UFS completes; on timeout the worker keeps draining and completes/cancels in the background.
- The mirrored CV file forces `storage_policy.ufs_mtime=0` until completion so a partially mirrored file can never pass `cv_valid`.
- An initial process-local `write_cache_pending` guard was removed per review: the client is stateless, and for SDK-mode usage read-miss auto_cache does not overlap with an in-flight mirror.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `crates/common/curvine-model` | Add `write_cache` to mount model, builder, proto conversion, and persisted decode compatibility; add `MountOptionsBuilder::update_only_explicit`. | Existing mounts decode with `write_cache=false`; `mount --update` preserves omitted toggles. |
| `crates/common/curvine-proto` | Add `write_cache` to mount proto and mount table display. | CLI/API mount display includes the new column. |
| `curvine-master` | Validate `write_cache` only for `cache_mode + read_write`. | Invalid mount configs are rejected. |
| `crates/client/curvine-unified-fs` | Add `WriteCacheWriter` with UFS-first mirroring, cooperative shutdown, bounded enqueue backpressure, 5s completion timeout, and forced `ufs_mtime=0` invariant. | Sequential create/overwrite can populate Curvine; append/random/resize preserve existing behavior. |
| `curvine-cli` | Add `--write-cache` mount option; update only sends explicitly provided optional toggle fields. | Users can enable write cache at mount creation/update without resetting omitted options. |
| `curvine-libsdk/java` | Add `MountRequest.Builder.writeCache`; writeCache is encoded only when explicitly provided. | Java clients can set the new mount option; updates preserve existing values when omitted. |
| Tests | Add/extend mount model, compatibility, Java builder, master validation, and mirror invariant tests. | Improves coverage for new mount option. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo clippy --release -p curvine-unified-fs -p curvine-model -p curvine-cli --all-targets -- --deny warnings --allow clippy::uninlined-format-args` | PASS | Mirrors pre-commit gate for touched crates. |
| `cargo test -p curvine-model --lib mount::` | PASS | Mount model/builder/merge coverage incl. `update_only_explicit`. |
| `cargo test -p curvine-unified-fs` | PASS | Includes new `mirror_create_opts` invariant tests. |
| `cargo test -p curvine-cli` | PASS | CLI mount parsing coverage. |
| `mvn -q -o test -Dtest=MountRequestTest` | PASS | Java builder coverage. |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None
