### PR TITLE
fix(test): restore parallel load fault hooks and mount test configs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2163,6 +2163,7 @@ dependencies = [
  "curvine-config",
  "curvine-core-error",
  "curvine-error",
+ "curvine-fault",
  "curvine-fs-api",
  "curvine-job-client",
  "curvine-metrics",

--- a/crates/server/curvine-data-transfer/Cargo.toml
+++ b/crates/server/curvine-data-transfer/Cargo.toml
@@ -15,6 +15,7 @@ transfer-server = [
     "transfer-store-sqlite",
     "transfer-store-mysql",
 ]
+fault-injection = ["curvine-fault/http-server"]
 opendal = ["curvine-unified-fs/opendal"]
 opendal-s3 = ["opendal", "curvine-unified-fs/opendal-s3"]
 opendal-oss = ["opendal", "curvine-unified-fs/opendal-oss"]
@@ -43,6 +44,7 @@ curvine-job-client = { workspace = true }
 curvine-metrics = { workspace = true }
 curvine-unified-fs = { workspace = true }
 curvine-ufs-api = { workspace = true }
+curvine-fault = { workspace = true }
 curvine-web = { workspace = true, optional = true }
 prost = { workspace = true }
 bytes = { workspace = true }

--- a/crates/server/curvine-data-transfer/src/lib.rs
+++ b/crates/server/curvine-data-transfer/src/lib.rs
@@ -21,5 +21,11 @@ pub mod worker;
 mod job_worker_client;
 pub use self::job_worker_client::JobWorkerClient;
 
+#[cfg(feature = "fault-injection")]
+pub(crate) use curvine_fault::fault_point;
+
+#[cfg(not(feature = "fault-injection"))]
+pub(crate) use curvine_fault::__noop_fault_point as fault_point;
+
 mod rpc_context;
 pub use self::rpc_context::RpcContext;

--- a/crates/server/curvine-data-transfer/src/worker/task/load_task_runner.rs
+++ b/crates/server/curvine-data-transfer/src/worker/task/load_task_runner.rs
@@ -216,9 +216,11 @@ impl LoadTaskRunner {
             && target_path.is_cv()
             && self.max_parallel_streams() > 1
         {
-            let src_len = self.get_ufs()?.get_status(&source_path).await?.len;
-            if self.effective_streams(src_len) > 1 {
-                return self.run_parallel(&source_path, &target_path, src_len).await;
+            let initial_source = self.get_ufs()?.get_status(&source_path).await?;
+            if self.effective_streams(initial_source.len) > 1 {
+                return self
+                    .run_parallel(&source_path, &target_path, &initial_source)
+                    .await;
             }
         }
 
@@ -848,8 +850,9 @@ impl LoadTaskRunner {
         &self,
         source_path: &Path,
         target_path: &Path,
-        src_len: i64,
+        initial_source: &FileStatus,
     ) -> FsResult<bool> {
+        let src_len = initial_source.len;
         let streams = self.effective_streams(src_len);
         let block_size = self.task.info.job.block_size.max(1);
         let seg = Self::segment_len(src_len, streams, block_size);
@@ -992,7 +995,18 @@ impl LoadTaskRunner {
             );
         }
 
-        let ufs_mtime = self.get_ufs()?.get_status(source_path).await?.mtime;
+        let final_source = self.get_ufs()?.get_status(source_path).await?;
+        if final_source.len != initial_source.len || final_source.mtime != initial_source.mtime {
+            return err_box!(format!(
+                "Task {} parallel load source changed during transfer (initial len={}, initial mtime={}, final len={}, final mtime={}); refusing to mark cache valid",
+                self.task.info.task_id,
+                initial_source.len,
+                initial_source.mtime,
+                final_source.len,
+                final_source.mtime,
+            ));
+        }
+        let ufs_mtime = initial_source.mtime;
         let attr_opts = SetAttrOptsBuilder::new().ufs_mtime(ufs_mtime).build();
         self.fs.set_attr(target_path, attr_opts).await?;
 
@@ -1062,12 +1076,116 @@ fn xattr_equals(status: &FileStatus, key: &str, expected: &[u8]) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::rename_ufs_output;
+    use super::{rename_ufs_output, LoadTaskRunner};
     use curvine_fs_api::Path;
     use curvine_runtime::runtime::{AsyncRuntime, RpcRuntime};
     use curvine_unified_fs::UfsFileSystem;
     use std::collections::HashMap;
     use std::fs;
+
+    const MB: i64 = 1024 * 1024;
+
+    // Reproduce the exact planning loop run_parallel uses, so tests exercise the
+    // real offset/len math (block alignment + last-segment clamp), which is the
+    // most error-prone part of the fan-out.
+    fn plan(src_len: i64, streams: usize, block_size: i64) -> Vec<(i64, i64)> {
+        let seg = LoadTaskRunner::segment_len(src_len, streams, block_size);
+        let mut ranges = Vec::new();
+        for i in 0..streams {
+            let off = i as i64 * seg;
+            if off >= src_len {
+                break;
+            }
+            let len = seg.min(src_len - off);
+            ranges.push((off, len));
+        }
+        ranges
+    }
+
+    #[test]
+    fn segment_len_is_block_aligned() {
+        let seg = LoadTaskRunner::segment_len(10 * 1024 * MB, 8, 4 * MB);
+        assert_eq!(
+            seg % (4 * MB),
+            0,
+            "segment must be a multiple of block_size"
+        );
+        assert!(seg >= 10 * 1024 * MB / 8);
+    }
+
+    #[test]
+    fn segment_len_rounds_up_to_block_multiple() {
+        let seg = LoadTaskRunner::segment_len(100 * MB, 3, 4 * MB);
+        assert_eq!(seg, 36 * MB);
+        assert_eq!(seg % (4 * MB), 0);
+    }
+
+    #[test]
+    fn segment_len_never_below_block_size() {
+        let seg = LoadTaskRunner::segment_len(1, 8, 4 * MB);
+        assert_eq!(seg, 4 * MB);
+    }
+
+    #[test]
+    fn segment_len_handles_zero_streams_and_block() {
+        assert_eq!(LoadTaskRunner::segment_len(1000, 0, 0), 1000);
+    }
+
+    #[test]
+    fn plan_ranges_are_contiguous_disjoint_and_cover_whole_file() {
+        for &(src_len, streams, block_size) in &[
+            (10 * 1024 * MB, 8, 4 * MB),
+            (100 * MB, 3, 4 * MB),
+            (7 * MB + 123, 4, 4 * MB),
+            (4 * MB, 8, 4 * MB),
+            (1, 8, 4 * MB),
+        ] {
+            let ranges = plan(src_len, streams, block_size);
+            assert!(!ranges.is_empty(), "must produce at least one range");
+            assert_eq!(ranges[0].0, 0);
+            let mut expected_off = 0;
+            for (off, len) in &ranges {
+                assert_eq!(*off, expected_off, "gap/overlap at {}", off);
+                assert!(*len > 0, "empty segment");
+                expected_off += len;
+            }
+            assert_eq!(
+                expected_off, src_len,
+                "ranges must cover exactly [0,{})",
+                src_len
+            );
+            for (off, _) in &ranges {
+                assert_eq!(*off % block_size, 0, "segment start not block-aligned");
+            }
+        }
+    }
+
+    #[test]
+    fn plan_does_not_over_allocate_streams_for_small_files() {
+        let ranges = plan(4 * MB, 8, 4 * MB);
+        assert_eq!(ranges.len(), 1);
+        assert_eq!(ranges[0], (0, 4 * MB));
+    }
+
+    #[test]
+    fn stream_count_grows_with_size_and_caps() {
+        let min = 256 * MB;
+        let cap = 8;
+        assert_eq!(LoadTaskRunner::stream_count(100 * MB, min, cap), 1);
+        assert_eq!(LoadTaskRunner::stream_count(min - 1, min, cap), 1);
+        assert_eq!(LoadTaskRunner::stream_count(512 * MB, min, cap), 2);
+        assert_eq!(LoadTaskRunner::stream_count(1024 * MB, min, cap), 4);
+        assert_eq!(LoadTaskRunner::stream_count(2048 * MB, min, cap), 8);
+        assert_eq!(LoadTaskRunner::stream_count(200 * 1024 * MB, min, cap), 8);
+    }
+
+    #[test]
+    fn stream_count_defensive_bounds() {
+        assert_eq!(LoadTaskRunner::stream_count(0, 256 * MB, 8), 1);
+        assert_eq!(LoadTaskRunner::stream_count(-5, 256 * MB, 8), 1);
+        assert_eq!(LoadTaskRunner::stream_count(1024 * MB, 0, 8), 8);
+        assert_eq!(LoadTaskRunner::stream_count(1024 * MB, 256 * MB, 0), 1);
+    }
 
     #[test]
     fn failed_ufs_rename_keeps_existing_target() {

--- a/crates/server/curvine-data-transfer/src/worker/task/load_task_runner.rs
+++ b/crates/server/curvine-data-transfer/src/worker/task/load_task_runner.rs
@@ -23,10 +23,11 @@ use curvine_job_client::JobMasterClient;
 use curvine_job_client::TransferClient;
 use curvine_model::transfer_failure_message;
 use curvine_model::{
-    CreateFileOptsBuilder, FileBlocks, FileStatus, JobTaskProgress, JobTaskState,
+    CreateFileOptsBuilder, FileAllocOpts, FileBlocks, FileStatus, JobTaskProgress, JobTaskState,
     SetAttrOptsBuilder, TRANSFER_TEMP_PATH_MARKER,
 };
 use curvine_runtime::common::{LocalTime, TimeSpent};
+use curvine_runtime::runtime::{JoinHandle, RpcRuntime};
 use curvine_unified_fs::{UfsFileSystem, UnifiedReader, UnifiedWriter};
 use log::{debug, error, info, warn};
 use std::sync::Arc;
@@ -141,7 +142,7 @@ impl LoadTaskRunner {
     }
 
     pub async fn run(&self) -> bool {
-        match self.run0().await {
+        let remove_task = match self.run0().await {
             Ok(remove_task) => remove_task,
             Err(e) => {
                 if self.task.is_cancel() {
@@ -182,7 +183,18 @@ impl LoadTaskRunner {
                 }
                 true
             }
+        };
+
+        crate::fault_point! {
+            async,
+            name: "worker.load_task.after_run",
+            description: "After a worker load task runner has fully exited",
+            context: {
+                "task_id" => self.task.info.task_id.clone(),
+            },
         }
+
+        remove_task
     }
 
     async fn run0(&self) -> FsResult<bool> {
@@ -196,6 +208,19 @@ impl LoadTaskRunner {
 
         self.task
             .update_state(JobTaskState::Loading, "Task started");
+
+        let source_path = Path::from_str(&self.task.info.source_path)?;
+        let target_path = Path::from_str(&self.task.info.target_path)?;
+        if self.task.info.transfer_report.is_none()
+            && !source_path.is_cv()
+            && target_path.is_cv()
+            && self.max_parallel_streams() > 1
+        {
+            let src_len = self.get_ufs()?.get_status(&source_path).await?.len;
+            if self.effective_streams(src_len) > 1 {
+                return self.run_parallel(&source_path, &target_path, src_len).await;
+            }
+        }
 
         let mut stream = self.create_stream().await?;
         if self.task.is_cancel() {
@@ -765,6 +790,239 @@ impl LoadTaskRunner {
             self.master_client
                 .report_task(&task.job.job_id, &task.task_id, progress)
                 .await
+        }
+    }
+
+    /// Upper bound on the number of independent reader+writer streams a large
+    /// UFS->CV load may fan out into.
+    fn max_parallel_streams(&self) -> usize {
+        self.task
+            .info
+            .job
+            .mount_info
+            .properties
+            .get("load_task.parallel_streams")
+            .and_then(|v| v.parse::<usize>().ok())
+            .unwrap_or(8)
+            .max(1)
+    }
+
+    fn min_bytes_per_stream(&self) -> i64 {
+        self.task
+            .info
+            .job
+            .mount_info
+            .properties
+            .get("load_task.min_bytes_per_stream")
+            .and_then(|v| v.parse::<i64>().ok())
+            .unwrap_or(256 * 1024 * 1024)
+            .max(1)
+    }
+
+    fn effective_streams(&self, src_len: i64) -> usize {
+        Self::stream_count(
+            src_len,
+            self.min_bytes_per_stream(),
+            self.max_parallel_streams(),
+        )
+    }
+
+    fn stream_count(src_len: i64, min_bytes: i64, cap: usize) -> usize {
+        let min_bytes = min_bytes.max(1);
+        let cap = cap.max(1);
+        let by_size = (src_len / min_bytes).max(0) as usize;
+        by_size.clamp(1, cap)
+    }
+
+    fn segment_len(src_len: i64, streams: usize, block_size: i64) -> i64 {
+        let streams = streams.max(1) as i64;
+        let block_size = block_size.max(1);
+        let raw = (src_len + streams - 1) / streams;
+        let aligned = ((raw + block_size - 1) / block_size) * block_size;
+        aligned.max(block_size)
+    }
+
+    const READ_CHUNK_BYTES: i64 = 16 * 1024 * 1024;
+
+    async fn run_parallel(
+        &self,
+        source_path: &Path,
+        target_path: &Path,
+        src_len: i64,
+    ) -> FsResult<bool> {
+        let streams = self.effective_streams(src_len);
+        let block_size = self.task.info.job.block_size.max(1);
+        let seg = Self::segment_len(src_len, streams, block_size);
+        let spend = TimeSpent::new();
+        let deadline_ms = LocalTime::mills() + self.task_timeout_ms;
+
+        {
+            let mut owner = self.create_unified(target_path).await?;
+            owner.resize(FileAllocOpts::with_truncate(src_len)).await?;
+            drop(owner);
+        }
+
+        let task_timeout_ms = self.task_timeout_ms;
+        let mut handles = Vec::with_capacity(streams);
+        for i in 0..streams {
+            let off = i as i64 * seg;
+            if off >= src_len {
+                break;
+            }
+            let len = seg.min(src_len - off);
+            let ufs = self.get_ufs()?;
+            let fs = self.fs.clone();
+            let src = source_path.clone();
+            let dst = target_path.clone();
+            let rt = self.fs.clone_runtime();
+            let task = self.task.clone();
+            handles.push(rt.spawn(async move {
+                let mut reader = ufs.open(&src).await?;
+                reader.seek(off).await?;
+                let mut writer = fs.open_for_write(&dst, false).await?;
+                writer.seek(off).await?;
+
+                crate::fault_point! {
+                    async,
+                    name: "worker.load_task.parallel.before_segment_copy",
+                    description: "After a parallel load segment opens its streams and before it copies data",
+                    context: {
+                        "task_id" => task.info.task_id.clone(),
+                        "stream_index" => i as i64,
+                        "segment_offset" => off,
+                        "segment_len" => len,
+                    },
+                }
+
+                let mut remaining = len;
+                while remaining > 0 {
+                    if task.is_cancel() {
+                        let _ = writer.cancel().await;
+                        return FsResult::Ok(0);
+                    }
+                    if LocalTime::mills() > deadline_ms {
+                        let _ = writer.cancel().await;
+                        return err_box!(
+                            "Task {} exceed timeout {} ms (segment [{}, {}))",
+                            task.info.task_id,
+                            task_timeout_ms,
+                            off,
+                            off + len
+                        );
+                    }
+                    let want = remaining.min(Self::READ_CHUNK_BYTES) as usize;
+                    let chunk = reader.async_read(Some(want)).await?;
+                    if chunk.is_empty() {
+                        break;
+                    }
+                    remaining -= chunk.len() as i64;
+                    writer.async_write(chunk).await?;
+                }
+                if remaining != 0 {
+                    let _ = writer.cancel().await;
+                    return err_box!(
+                        "short read on segment [{}, {}): {} bytes missing (source shorter than stat len?)",
+                        off,
+                        off + len,
+                        remaining
+                    );
+                }
+                writer.complete().await?;
+                reader.complete().await?;
+                FsResult::Ok(len)
+            }));
+        }
+
+        let mut written: i64 = 0;
+        for idx in 0..handles.len() {
+            if self.task.is_cancel() {
+                info!(
+                    "transfer task canceled during parallel load: {}",
+                    self.log_context()
+                );
+                Self::abort_remaining(&handles, idx);
+                return self.finish_canceled().await;
+            }
+            crate::fault_point! {
+                async,
+                name: "worker.load_task.parallel.before_join_await",
+                description: "After the parent cancellation check and before awaiting a parallel load stream",
+                context: {
+                    "task_id" => self.task.info.task_id.clone(),
+                    "stream_index" => idx as i64,
+                },
+            }
+            match (&mut handles[idx]).await {
+                Ok(Ok(n)) => {
+                    written += n;
+                    self.update_progress(written, src_len, false).await;
+                }
+                Ok(Err(e)) => {
+                    Self::abort_remaining(&handles, idx + 1);
+                    return Err(e);
+                }
+                Err(e) => {
+                    Self::abort_remaining(&handles, idx + 1);
+                    return err_box!("parallel load join error: {}", e);
+                }
+            }
+            if spend.used_ms() > self.task_timeout_ms {
+                Self::abort_remaining(&handles, idx + 1);
+                return err_box!(
+                    "Task {} exceed timeout {} ms",
+                    self.task.info.task_id,
+                    self.task_timeout_ms
+                );
+            }
+        }
+
+        if self.task.is_cancel() {
+            info!(
+                "transfer task canceled after parallel load: {}",
+                self.log_context()
+            );
+            return self.finish_canceled().await;
+        }
+        if written != src_len {
+            return err_box!(
+                "Task {} parallel load incomplete: wrote {} of {} bytes; refusing to mark cache valid",
+                self.task.info.task_id,
+                written,
+                src_len
+            );
+        }
+
+        let ufs_mtime = self.get_ufs()?.get_status(source_path).await?.mtime;
+        let attr_opts = SetAttrOptsBuilder::new().ufs_mtime(ufs_mtime).build();
+        self.fs.set_attr(target_path, attr_opts).await?;
+
+        if let Err(err) = self.update_progress0(written, src_len, true).await {
+            if self.task.info.transfer_report.is_some() {
+                warn!(
+                    "final transfer task report failed, keep task for scheduler probe: {} err={}",
+                    self.log_context(),
+                    err
+                );
+                return Ok(false);
+            }
+            return Err(err);
+        }
+
+        info!(
+            "transfer task completed (parallel x{}): {} ufs_mtime={} copied_bytes={} task_cost_ms={}",
+            streams,
+            self.log_context(),
+            ufs_mtime,
+            written,
+            spend.used_ms(),
+        );
+
+        Ok(true)
+    }
+
+    fn abort_remaining(handles: &[JoinHandle<FsResult<i64>>], from: usize) {
+        for h in handles.iter().skip(from) {
+            h.abort();
         }
     }
 }

--- a/curvine-server/Cargo.toml
+++ b/curvine-server/Cargo.toml
@@ -22,6 +22,7 @@ fault-injection = [
     "curvine-fault/http-server",
     "curvine-master/fault-injection",
     "curvine-worker/fault-injection",
+    "curvine-data-transfer/fault-injection",
 ]
 
 [dependencies]

--- a/curvine-tests/tests/mount_test.rs
+++ b/curvine-tests/tests/mount_test.rs
@@ -83,28 +83,30 @@ fn test_mount_umount_s3_hdfs_and_path_mapping() -> CommonResult<()> {
         }
 
         let configs = get_s3_test_config().await;
-        let mnt_opt = MountOptions::builder().set_properties(configs).build();
-        let mount_resp = client.mount(&s3_path, &s3_mnt_path, mnt_opt.clone()).await;
+        let s3_mnt_opt = MountOptions::builder().set_properties(configs).build();
+        let mount_resp = client
+            .mount(&s3_path, &s3_mnt_path, s3_mnt_opt.clone())
+            .await;
         info!("S3 MountResp: {:?}", mount_resp);
         assert!(mount_resp.is_ok(), "mount should success");
 
         let mount_resp = client
-            .mount(&s3_path7, &s3_mnt_path7, mnt_opt.clone())
+            .mount(&s3_path7, &s3_mnt_path7, s3_mnt_opt.clone())
             .await;
         info!("S3 MountResp: {:?}", mount_resp);
         assert!(mount_resp.is_ok(), "mount should success",);
 
         let configs = get_hdfs_test_config().await;
-        let mnt_opt = MountOptions::builder().set_properties(configs).build();
+        let hdfs_mnt_opt = MountOptions::builder().set_properties(configs).build();
         let mount_resp = client
-            .mount(&hdfs_path, &hdfs_mnt_path, mnt_opt.clone())
+            .mount(&hdfs_path, &hdfs_mnt_path, hdfs_mnt_opt.clone())
             .await;
         info!("Hdfs MountResp: {:?}", mount_resp);
         assert!(mount_resp.is_ok(), "mount should success");
 
         // forbidden mount to root
         let mount_resp = client
-            .mount(&hdfs_path2, &hdfs_mnt_path2, mnt_opt.clone())
+            .mount(&hdfs_path2, &hdfs_mnt_path2, hdfs_mnt_opt.clone())
             .await;
         info!("Hdfs MountResp: {:?}", mount_resp);
         assert!(mount_resp.is_err(), "mount should failed");
@@ -134,36 +136,38 @@ fn test_mount_umount_s3_hdfs_and_path_mapping() -> CommonResult<()> {
         info!("target_path: {:?}", target_path);
 
         // monut s3 again
-        let mount_resp = client.mount(&s3_path, &s3_mnt_path, mnt_opt.clone()).await;
-        info!("MountResp: {:?}", mount_resp);
-        assert!(mount_resp.is_err(), "{}", mount_resp.unwrap_err());
-
         let mount_resp = client
-            .mount(&s3_path2, &s3_mnt_path2, mnt_opt.clone())
+            .mount(&s3_path, &s3_mnt_path, s3_mnt_opt.clone())
             .await;
         info!("MountResp: {:?}", mount_resp);
         assert!(mount_resp.is_err(), "{}", mount_resp.unwrap_err());
 
         let mount_resp = client
-            .mount(&s3_path3, &s3_mnt_path3, mnt_opt.clone())
+            .mount(&s3_path2, &s3_mnt_path2, s3_mnt_opt.clone())
             .await;
         info!("MountResp: {:?}", mount_resp);
         assert!(mount_resp.is_err(), "{}", mount_resp.unwrap_err());
 
         let mount_resp = client
-            .mount(&s3_path4, &s3_mnt_path4, mnt_opt.clone())
+            .mount(&s3_path3, &s3_mnt_path3, s3_mnt_opt.clone())
             .await;
         info!("MountResp: {:?}", mount_resp);
         assert!(mount_resp.is_err(), "{}", mount_resp.unwrap_err());
 
         let mount_resp = client
-            .mount(&s3_path5, &s3_mnt_path5, mnt_opt.clone())
+            .mount(&s3_path4, &s3_mnt_path4, s3_mnt_opt.clone())
             .await;
         info!("MountResp: {:?}", mount_resp);
         assert!(mount_resp.is_err(), "{}", mount_resp.unwrap_err());
 
         let mount_resp = client
-            .mount(&s3_path6, &s3_mnt_path6, mnt_opt.clone())
+            .mount(&s3_path5, &s3_mnt_path5, s3_mnt_opt.clone())
+            .await;
+        info!("MountResp: {:?}", mount_resp);
+        assert!(mount_resp.is_err(), "{}", mount_resp.unwrap_err());
+
+        let mount_resp = client
+            .mount(&s3_path6, &s3_mnt_path6, s3_mnt_opt.clone())
             .await;
         info!("MountResp: {:?}", mount_resp);
         assert!(mount_resp.is_ok(), "{}", "mount should success");

--- a/curvine-worker/Cargo.toml
+++ b/curvine-worker/Cargo.toml
@@ -18,6 +18,7 @@ spdk-rdma = [
 ]
 fault-injection = [
     "curvine-fault/http-server",
+    "curvine-data-transfer/fault-injection",
 ]
 
 [dependencies]


### PR DESCRIPTION
<!-- curvine-automation:pr:CurvineIO/curvine:0 -->

# Summary

Restore parallel UFS-to-Curvine load execution and the fault-injection hooks required by regression tests, and fix mount integration tests that reused HDFS mount options for S3 remount scenarios.

# Issue Describe / Design

This is a test-infrastructure repair for two daily/integration regressions:

- `canceled_final_parallel_stream_does_not_mark_cache_valid` failed because parallel load fault points were removed from the authoritative data-transfer runner while the test remained.
- `test_mount_umount_s3_hdfs_and_path_mapping` failed because `mnt_opt` was shadowed with HDFS properties and later S3 mounts reused the wrong configuration after S3 endpoint validation became mandatory.

**Root cause**
- Load-task refactor dropped parallel fan-out and fault catalog entries still referenced by `load_task_runner_fault_test`.
- Mount test used one `mnt_opt` variable for both backends.

**Fix approach**
- Reintroduce parallel load in `curvine-data-transfer` with cancellation guards that avoid stamping partial files as cache-valid.
- Wire fault injection through `curvine-data-transfer` and `curvine-worker` feature flags.
- Split mount options into `s3_mnt_opt` and `hdfs_mnt_opt`.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `crates/server/curvine-data-transfer/src/worker/task/load_task_runner.rs` | Restore parallel UFS→CV load and fault hooks | Large-file UFS→CV loads can fan out again; fault tests can inject delays |
| `crates/server/curvine-data-transfer/Cargo.toml`, `src/lib.rs` | Add fault-injection feature wiring | No runtime change unless fault injection is enabled |
| `curvine-server/Cargo.toml`, `curvine-worker/Cargo.toml` | Propagate fault-injection feature | Enables worker fault catalog registration |
| `curvine-tests/tests/mount_test.rs` | Use separate S3/HDFS mount option builders | Test-only fix; product mount validation unchanged |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `make format` | PASS | |
| `cargo test -p curvine-server --features fault-injection --test load_task_runner_fault_test canceled_final_parallel_stream_does_not_mark_cache_valid` | PASS | Exact HEAD `fd9ab2d2` |
| Profile `integration` after run `20260805T041242Z-482d4afa` | PASS | Original daily/integration failures absent |
| Profile `daily` after run `20260805T041938Z-ed72b5d2` | PASS | Original daily/integration failures absent |
| Profile `fast` after run `20260805T041805Z-5c7516c2` | PASS | |
| Profile `csi` after run `20260805T051927Z-2d3472da` | PASS | |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None
