### PR TITLE
fix(master): clean up legacy path terminal load jobs (#1028)

### DIFF
--- a/crates/common/curvine-config/src/job_conf.rs
+++ b/crates/common/curvine-config/src/job_conf.rs
@@ -34,6 +34,12 @@ pub struct JobConf {
     #[serde(alias = "job_cleanup_ttl")]
     pub job_cleanup_ttl_str: String,
 
+    // How long terminal load jobs stay queryable in the legacy master JobStore.
+    #[serde(skip)]
+    pub terminal_retention: Duration,
+    #[serde(alias = "terminal_retention")]
+    pub terminal_retention_str: String,
+
     // Maximum number of files allowed to be loaded by a job
     pub job_max_files: usize,
 
@@ -77,6 +83,7 @@ pub struct JobConf {
 impl JobConf {
     pub const DEFAULT_JOB_LIFE_TTL: &'static str = "24h";
     pub const DEFAULT_JOB_CLEANUP_TTL_STR: &'static str = "10m";
+    pub const DEFAULT_TERMINAL_RETENTION: &'static str = "10m";
     pub const DEFAULT_JOB_MAX_FILES: usize = 100000;
     pub const DEFAULT_MASTER_MAX_CONCURRENT_LOAD_JOBS: usize = 16;
     pub const DEFAULT_MASTER_MAX_BACKGROUND_LOAD_JOBS: usize = 1024;
@@ -91,6 +98,8 @@ impl JobConf {
     pub fn init(&mut self) -> FsResult<()> {
         self.job_life_ttl = DurationUnit::from_str(&self.job_life_ttl_str)?.as_duration();
         self.job_cleanup_ttl = DurationUnit::from_str(&self.job_cleanup_ttl_str)?.as_duration();
+        self.terminal_retention =
+            DurationUnit::from_str(&self.terminal_retention_str)?.as_duration();
         self.task_timeout = DurationUnit::from_str(&self.task_timeout_str)?.as_duration();
         self.task_report_interval =
             DurationUnit::from_str(&self.task_report_interval_str)?.as_duration();
@@ -123,6 +132,9 @@ impl Default for JobConf {
 
             job_cleanup_ttl: Default::default(),
             job_cleanup_ttl_str: Self::DEFAULT_JOB_CLEANUP_TTL_STR.to_string(),
+
+            terminal_retention: Default::default(),
+            terminal_retention_str: Self::DEFAULT_TERMINAL_RETENTION.to_string(),
 
             job_max_files: Self::DEFAULT_JOB_MAX_FILES,
             master_max_concurrent_load_jobs: Self::DEFAULT_MASTER_MAX_CONCURRENT_LOAD_JOBS,

--- a/crates/common/curvine-config/tests/job_conf_test.rs
+++ b/crates/common/curvine-config/tests/job_conf_test.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use curvine_config::JobConf;
+use std::time::Duration;
 
 #[test]
 fn default_master_load_job_runtime_conf_is_valid() {
@@ -36,6 +37,7 @@ fn default_master_load_job_runtime_conf_is_valid() {
         conf.master_failed_load_job_retry_interval_str,
         JobConf::DEFAULT_MASTER_FAILED_LOAD_JOB_RETRY_INTERVAL
     );
+    assert_eq!(conf.terminal_retention, Duration::from_secs(10 * 60));
 }
 
 #[test]

--- a/curvine-master/src/master/job/job_manager.rs
+++ b/curvine-master/src/master/job/job_manager.rs
@@ -14,7 +14,7 @@
 
 use crate::common::UfsFactory;
 use crate::master::fs::MasterFilesystem;
-use crate::master::{JobStore, LoadJobRunner, MountManager};
+use crate::master::{JobContext, JobStore, LoadJobRunner, MountManager};
 use core::time::Duration;
 use curvine_config::ClusterConf;
 use curvine_core_error::{err_box, err_ext, CommonResult};
@@ -297,6 +297,40 @@ struct JobCleanupTask {
     terminal_retention_ms: i64,
 }
 
+struct ExpiredJob {
+    job_id: String,
+    run_id: u64,
+}
+
+impl JobCleanupTask {
+    fn is_expired(&self, job: &JobContext, now: i64) -> bool {
+        let state: JobTaskState = job.state.state();
+        let expired_at = if state.is_finish() {
+            let terminal_at = if job.progress.update_time > 0 {
+                job.progress.update_time
+            } else {
+                job.info.create_time
+            };
+            terminal_at.saturating_add(self.terminal_retention_ms)
+        } else {
+            job.info.create_time.saturating_add(self.running_ttl_ms)
+        };
+
+        now > expired_at
+    }
+
+    fn remove_expired_job(&self, expired_job: ExpiredJob) -> FsResult<()> {
+        let now = LocalTime::mills() as i64;
+        if let Some(v) = self.jobs.remove_job_if(&expired_job.job_id, |job| {
+            job.run_id == expired_job.run_id && self.is_expired(job, now)
+        })? {
+            debug!("Removing expired job: {:?}", v.1.info);
+        }
+
+        Ok(())
+    }
+}
+
 impl LoopTask for JobCleanupTask {
     type Error = FsError;
 
@@ -306,27 +340,16 @@ impl LoopTask for JobCleanupTask {
         let now = LocalTime::mills() as i64;
         for entry in self.jobs.iter() {
             let job = entry.value();
-            let state: JobTaskState = job.state.state();
-            let expired_at = if state.is_finish() {
-                let terminal_at = if job.progress.update_time > 0 {
-                    job.progress.update_time
-                } else {
-                    job.info.create_time
-                };
-                terminal_at.saturating_add(self.terminal_retention_ms)
-            } else {
-                job.info.create_time.saturating_add(self.running_ttl_ms)
-            };
-
-            if now > expired_at {
-                jobs_to_remove.push(job.info.job_id.clone());
+            if self.is_expired(job, now) {
+                jobs_to_remove.push(ExpiredJob {
+                    job_id: job.info.job_id.clone(),
+                    run_id: job.run_id,
+                });
             }
         }
 
-        for job_id in jobs_to_remove {
-            if let Some(v) = self.jobs.remove_job(&job_id)? {
-                debug!("Removing expired job: {:?}", v.1.info);
-            }
+        for expired_job in jobs_to_remove {
+            self.remove_expired_job(expired_job)?;
         }
 
         Ok(())
@@ -345,7 +368,6 @@ fn duration_ms(duration: Duration) -> i64 {
 mod tests {
     use super::super::job_store::JobCallback;
     use super::*;
-    use crate::master::JobContext;
     use curvine_config::ClientConf;
     use curvine_model::MountInfo;
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -452,6 +474,52 @@ mod tests {
         store.update_state(job_id, JobTaskState::Failed, "fresh failure")?;
 
         assert_eq!(calls.load(Ordering::Relaxed), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn cleanup_does_not_remove_replaced_job_with_same_id() -> FsResult<()> {
+        let store = JobStore::new();
+        let job_id = "replaced-job";
+        let now = LocalTime::mills() as i64;
+        let old = now - 20_000;
+
+        store.insert(
+            job_id.to_string(),
+            test_job_context(job_id, JobTaskState::Completed, old, old),
+        );
+
+        let expired_job = ExpiredJob {
+            job_id: job_id.to_string(),
+            run_id: 1,
+        };
+
+        let mut fresh_job = test_job_context(job_id, JobTaskState::Pending, now, 0);
+        fresh_job.run_id = 2;
+        store.insert(job_id.to_string(), fresh_job);
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let callback_calls = calls.clone();
+        store.register_callback(
+            job_id.to_string(),
+            JobCallback::new(move |_, _, _, _| {
+                callback_calls.fetch_add(1, Ordering::Relaxed);
+            }),
+        )?;
+
+        let cleanup = JobCleanupTask {
+            jobs: store.clone(),
+            running_ttl_ms: 60_000,
+            terminal_retention_ms: 1_000,
+        };
+        cleanup.remove_expired_job(expired_job)?;
+
+        let job = store.get(job_id).expect("fresh job should not be removed");
+        assert_eq!(job.run_id, 2);
+        drop(job);
+
+        store.update_state(job_id, JobTaskState::Failed, "fresh failure")?;
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
         Ok(())
     }
 }

--- a/curvine-master/src/master/job/job_manager.rs
+++ b/curvine-master/src/master/job/job_manager.rs
@@ -42,6 +42,7 @@ pub struct JobManager {
     transfer_enabled: bool,
     job_life_ttl: Duration,
     job_cleanup_ttl: Duration,
+    terminal_retention: Duration,
     job_max_files: usize,
     run_seq: Arc<AtomicCounter>,
     load_job_semaphore: Arc<Semaphore>,
@@ -65,6 +66,7 @@ impl JobManager {
             transfer_enabled: conf.transfer.enabled,
             job_life_ttl: conf.job.job_life_ttl,
             job_cleanup_ttl: conf.job.job_cleanup_ttl,
+            terminal_retention: conf.job.terminal_retention,
             job_max_files: conf.job.job_max_files,
             run_seq: Arc::new(AtomicCounter::new(0)),
             load_job_semaphore: Arc::new(Semaphore::new(conf.job.master_max_concurrent_load_jobs)),
@@ -74,12 +76,14 @@ impl JobManager {
     /// Start the job manager
     pub fn start(&self) -> CommonResult<()> {
         let cleanup_interval = self.job_cleanup_ttl.as_millis() as u64;
-        let ttl_ms = self.job_life_ttl.as_millis() as i64;
+        let running_ttl_ms = duration_ms(self.job_life_ttl);
+        let terminal_retention_ms = duration_ms(self.terminal_retention);
 
         let executor = ScheduledExecutor::new("job_cleanup", cleanup_interval);
         executor.start(JobCleanupTask {
             jobs: self.jobs.clone(),
-            ttl_ms,
+            running_ttl_ms,
+            terminal_retention_ms,
         })?;
 
         info!("JobManager started");
@@ -289,7 +293,8 @@ impl JobManager {
 
 struct JobCleanupTask {
     jobs: JobStore,
-    ttl_ms: i64,
+    running_ttl_ms: i64,
+    terminal_retention_ms: i64,
 }
 
 impl LoopTask for JobCleanupTask {
@@ -301,13 +306,25 @@ impl LoopTask for JobCleanupTask {
         let now = LocalTime::mills() as i64;
         for entry in self.jobs.iter() {
             let job = entry.value();
-            if now > self.ttl_ms + job.info.create_time {
+            let state: JobTaskState = job.state.state();
+            let expired_at = if state.is_finish() {
+                let terminal_at = if job.progress.update_time > 0 {
+                    job.progress.update_time
+                } else {
+                    job.info.create_time
+                };
+                terminal_at.saturating_add(self.terminal_retention_ms)
+            } else {
+                job.info.create_time.saturating_add(self.running_ttl_ms)
+            };
+
+            if now > expired_at {
                 jobs_to_remove.push(job.info.job_id.clone());
             }
         }
 
         for job_id in jobs_to_remove {
-            if let Some(v) = self.jobs.remove(&job_id) {
+            if let Some(v) = self.jobs.remove_job(&job_id)? {
                 debug!("Removing expired job: {:?}", v.1.info);
             }
         }
@@ -317,5 +334,124 @@ impl LoopTask for JobCleanupTask {
 
     fn terminate(&self) -> bool {
         false
+    }
+}
+
+fn duration_ms(duration: Duration) -> i64 {
+    i64::try_from(duration.as_millis()).unwrap_or(i64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::job_store::JobCallback;
+    use super::*;
+    use crate::master::JobContext;
+    use curvine_config::ClientConf;
+    use curvine_model::MountInfo;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    fn test_job_context(
+        job_id: &str,
+        state: JobTaskState,
+        create_time: i64,
+        update_time: i64,
+    ) -> JobContext {
+        let command = LoadJobCommand::builder("file://source").build();
+        let mount = MountInfo::default();
+        let mut job = JobContext::with_conf(
+            &command,
+            job_id.to_string(),
+            "file://source".to_string(),
+            "/mnt/source".to_string(),
+            &mount,
+            &ClientConf::default(),
+            1,
+        );
+        job.info.create_time = create_time;
+        job.progress.update_time = update_time;
+        job.state.advance_state(state, true);
+        job
+    }
+
+    #[test]
+    fn cleanup_uses_short_retention_for_terminal_jobs() -> FsResult<()> {
+        let store = JobStore::new();
+        let now = LocalTime::mills() as i64;
+        let old = now - 20_000;
+
+        store.insert(
+            "old-completed".to_string(),
+            test_job_context("old-completed", JobTaskState::Completed, old, old),
+        );
+        store.insert(
+            "old-failed".to_string(),
+            test_job_context("old-failed", JobTaskState::Failed, old, old),
+        );
+        store.insert(
+            "old-canceled".to_string(),
+            test_job_context("old-canceled", JobTaskState::Canceled, old, old),
+        );
+        store.insert(
+            "old-running".to_string(),
+            test_job_context("old-running", JobTaskState::Loading, old, old),
+        );
+        store.insert(
+            "recent-completed".to_string(),
+            test_job_context("recent-completed", JobTaskState::Completed, old, now),
+        );
+
+        let cleanup = JobCleanupTask {
+            jobs: store.clone(),
+            running_ttl_ms: 60_000,
+            terminal_retention_ms: 1_000,
+        };
+        cleanup.run()?;
+
+        assert!(store.get("old-completed").is_none());
+        assert!(store.get("old-failed").is_none());
+        assert!(store.get("old-canceled").is_none());
+        assert!(store.get("old-running").is_some());
+        assert!(store.get("recent-completed").is_some());
+        Ok(())
+    }
+
+    #[test]
+    fn cleanup_removes_callbacks_with_expired_job() -> FsResult<()> {
+        let store = JobStore::new();
+        let job_id = "callback-job";
+        let now = LocalTime::mills() as i64;
+        let old = now - 20_000;
+
+        store.insert(
+            job_id.to_string(),
+            test_job_context(job_id, JobTaskState::Failed, old, old),
+        );
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let callback_calls = calls.clone();
+        store.register_callback(
+            job_id.to_string(),
+            JobCallback::new(move |_, _, _, _| {
+                callback_calls.fetch_add(1, Ordering::Relaxed);
+            }),
+        )?;
+
+        let cleanup = JobCleanupTask {
+            jobs: store.clone(),
+            running_ttl_ms: 60_000,
+            terminal_retention_ms: 1_000,
+        };
+        cleanup.run()?;
+        assert!(store.get(job_id).is_none());
+
+        store.insert(
+            job_id.to_string(),
+            test_job_context(job_id, JobTaskState::Pending, now, 0),
+        );
+        store.update_state(job_id, JobTaskState::Failed, "fresh failure")?;
+
+        assert_eq!(calls.load(Ordering::Relaxed), 0);
+        Ok(())
     }
 }

--- a/curvine-master/src/master/job/job_store.rs
+++ b/curvine-master/src/master/job/job_store.rs
@@ -17,7 +17,7 @@ use curvine_core_error::err_box;
 use curvine_error::FsResult;
 use curvine_model::{JobTaskProgress, JobTaskState};
 use curvine_runtime::sync::FastDashMap;
-use log::{debug, error};
+use log::{debug, error, warn};
 use std::collections::HashMap;
 use std::ops::Deref;
 use std::sync::{Arc, RwLock};
@@ -219,7 +219,14 @@ impl JobStore {
     pub fn remove_callbacks(&self, job_id: &str) -> FsResult<()> {
         let mut callbacks = match self.callbacks.write() {
             Ok(callbacks) => callbacks,
-            Err(e) => return err_box!("failed to remove job callbacks for {}: {}", job_id, e),
+            Err(e) => {
+                warn!(
+                    "job callback registry was poisoned while removing callbacks for {}, recovering",
+                    job_id
+                );
+                self.callbacks.clear_poison();
+                e.into_inner()
+            }
         };
         callbacks.remove(job_id);
         Ok(())

--- a/curvine-master/src/master/job/job_store.rs
+++ b/curvine-master/src/master/job/job_store.rs
@@ -232,8 +232,15 @@ impl JobStore {
         Ok(())
     }
 
-    pub fn remove_job(&self, job_id: &str) -> FsResult<Option<(String, JobContext)>> {
-        let removed = self.jobs.remove(job_id);
+    pub fn remove_job_if<F>(
+        &self,
+        job_id: &str,
+        should_remove: F,
+    ) -> FsResult<Option<(String, JobContext)>>
+    where
+        F: FnOnce(&JobContext) -> bool,
+    {
+        let removed = self.jobs.remove_if(job_id, |_, job| should_remove(job));
         if removed.is_some() {
             self.remove_callbacks(job_id)?;
         }

--- a/curvine-master/src/master/job/job_store.rs
+++ b/curvine-master/src/master/job/job_store.rs
@@ -224,6 +224,14 @@ impl JobStore {
         callbacks.remove(job_id);
         Ok(())
     }
+
+    pub fn remove_job(&self, job_id: &str) -> FsResult<Option<(String, JobContext)>> {
+        let removed = self.jobs.remove(job_id);
+        if removed.is_some() {
+            self.remove_callbacks(job_id)?;
+        }
+        Ok(removed)
+    }
 }
 
 impl Deref for JobStore {


### PR DESCRIPTION
# Summary

Bounds terminal job retention in the legacy Master LoadJob path to prevent completed, failed, or canceled jobs from staying in Master memory until the full job life TTL.

# Issue Describe / Design

Closes #1028

Root cause:

- Legacy Master LoadJobs are stored in Master-side `JobStore`.
- The cleanup task previously used `job_life_ttl` for all jobs, including terminal states.
- With the default `job_life_ttl` of 24h, many auto-cache or load jobs can remain in Master memory long after completion, causing memory growth under high-volume cache-miss workloads.

Relation to #1040:

- #1040 introduces the Transfer direction, where Load/Export execution is moved out of Master when `transfer.enabled = true`.
- This PR does not change the Transfer path.
- **This PR fixes the legacy Master LoadJob path that is still used when** `transfer.enabled = false`.
- Since the existing LoadJob API surface is still present, terminal job retention should remain bounded for clusters that have not enabled Transfer yet.

Fix approach:

- Add `job.terminal_retention` for terminal legacy LoadJobs, defaulting to `10m`.
- Keep running/non-terminal jobs protected by the existing `job_life_ttl`.
- Use the job progress update time as the terminal timestamp, with create time as a defensive fallback.
- Remove registered callbacks when an expired job is removed from `JobStore`.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `crates/common/curvine-config/src/job_conf.rs` | Add `terminal_retention` config for legacy Master LoadJobs. | Terminal job retention can be configured independently from `job_life_ttl`; existing configs keep working through defaults. |
| `curvine-master/src/master/job/job_manager.rs` | Clean terminal jobs using `terminal_retention`, while preserving `job_life_ttl` for running jobs. | Completed/Failed/Canceled legacy LoadJobs are reclaimed earlier; running jobs keep the previous behavior. |
| `curvine-master/src/master/job/job_store.rs` | Add removal path that clears both job entries and callbacks. | Avoids retaining callbacks after expired jobs are cleaned. |
| `crates/common/curvine-config/tests/job_conf_test.rs` / `curvine-master/src/master/job/job_manager.rs` | Add regression coverage for config parsing, terminal cleanup, running-job retention, and callback cleanup. | Protects the cleanup behavior from regressions. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| Local Rust validation | PASS | Ran formatting, targeted unit tests, package check, clippy, and diff whitespace check successfully. |
| Local legacy LoadJob cleanup verification | PASS | Started local Master and Worker with `transfer.enabled = false`, shortened cleanup intervals only for manual testing, submitted a legacy `cv load` job from a mounted `file://` path, and verified the terminal job is removed from `load-status` after the retention window. |
<img width="1666" height="782" alt="image" src="https://github.com/user-attachments/assets/8f00e849-bef9-470f-86f6-661328cb3f66" />



# Dependencies

- Related PRs: None
- Related issues: #1028, #1040
- Blocks / blocked by: None