### PR TITLE
fix(cli): format fs stat permissions from mode

### DIFF
--- a/curvine-cli/src/cmds/fs/common.rs
+++ b/curvine-cli/src/cmds/fs/common.rs
@@ -66,6 +66,52 @@ pub fn format_size(size: u64) -> String {
     }
 }
 
+/// Formats Unix permission bits to a rwx string.
+pub fn format_permission(mode: u32) -> String {
+    let mode = mode & 0o7777;
+
+    let user_read = if mode & 0o400 != 0 { 'r' } else { '-' };
+    let user_write = if mode & 0o200 != 0 { 'w' } else { '-' };
+    let user_exec = match (mode & 0o4000 != 0, mode & 0o100 != 0) {
+        (true, true) => 's',
+        (true, false) => 'S',
+        (false, true) => 'x',
+        (false, false) => '-',
+    };
+
+    let group_read = if mode & 0o040 != 0 { 'r' } else { '-' };
+    let group_write = if mode & 0o020 != 0 { 'w' } else { '-' };
+    let group_exec = match (mode & 0o2000 != 0, mode & 0o010 != 0) {
+        (true, true) => 's',
+        (true, false) => 'S',
+        (false, true) => 'x',
+        (false, false) => '-',
+    };
+
+    let other_read = if mode & 0o004 != 0 { 'r' } else { '-' };
+    let other_write = if mode & 0o002 != 0 { 'w' } else { '-' };
+    let other_exec = match (mode & 0o1000 != 0, mode & 0o001 != 0) {
+        (true, true) => 't',
+        (true, false) => 'T',
+        (false, true) => 'x',
+        (false, false) => '-',
+    };
+
+    [
+        user_read,
+        user_write,
+        user_exec,
+        group_read,
+        group_write,
+        group_exec,
+        other_read,
+        other_write,
+        other_exec,
+    ]
+    .iter()
+    .collect()
+}
+
 /// Formats a Unix epoch timestamp in milliseconds using the local timezone.
 pub fn format_epoch_ms_local(timestamp_ms: i64, fmt: &str) -> String {
     if timestamp_ms <= 0 {
@@ -80,4 +126,25 @@ pub fn format_epoch_ms_local(timestamp_ms: i64, fmt: &str) -> String {
         .with_timezone(&chrono::Local)
         .format(fmt)
         .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_permission;
+
+    #[test]
+    fn test_format_permission() {
+        assert_eq!(format_permission(0o755), "rwxr-xr-x");
+        assert_eq!(format_permission(0o777), "rwxrwxrwx");
+        assert_eq!(format_permission(0o644), "rw-r--r--");
+        assert_eq!(format_permission(0o600), "rw-------");
+        assert_eq!(format_permission(0o000), "---------");
+
+        assert_eq!(format_permission(0o4755), "rwsr-xr-x");
+        assert_eq!(format_permission(0o4644), "rwSr--r--");
+        assert_eq!(format_permission(0o2775), "rwxrwsr-x");
+        assert_eq!(format_permission(0o2664), "rw-rwSr--");
+        assert_eq!(format_permission(0o1755), "rwxr-xr-t");
+        assert_eq!(format_permission(0o1666), "rw-rw-rwT");
+    }
 }

--- a/curvine-cli/src/cmds/fs/ls.rs
+++ b/curvine-cli/src/cmds/fs/ls.rs
@@ -320,26 +320,7 @@ async fn print_file_entry(
     config: &PrintConfig,
 ) -> CommonResult<()> {
     let file_type = if file.is_dir { "d" } else { "-" };
-    let mut mode = file.mode & 0o777;
-    let mut permissions = String::new();
-    while mode > 0 {
-        if mode & 0o1 != 0 {
-            permissions.insert(0, 'x');
-        } else {
-            permissions.insert(0, '-');
-        }
-        if mode & 0o2 != 0 {
-            permissions.insert(0, 'w');
-        } else {
-            permissions.insert(0, '-');
-        }
-        if mode & 0o4 != 0 {
-            permissions.insert(0, 'r');
-        } else {
-            permissions.insert(0, '-');
-        }
-        mode >>= 3;
-    }
+    let permissions = crate::cmds::fs::common::format_permission(file.mode as u32);
     let replicas = if file.is_dir {
         "-"
     } else {

--- a/curvine-cli/src/cmds/fs/stat.rs
+++ b/curvine-cli/src/cmds/fs/stat.rs
@@ -66,8 +66,9 @@ impl StatCommand {
                         println!("Modification time: {}", formatted_mtime);
                         println!("Ufs Modification time: {}", formatted_ufs_mtime);
                         println!(
-                            "Permission: {}rwxr-xr-x",
-                            if status.is_dir { "d" } else { "-" }
+                            "Permission: {}{}",
+                            if status.is_dir { "d" } else { "-" },
+                            crate::cmds::fs::common::format_permission(status.mode as u32)
                         );
                         println!("Owner: {}", status.owner);
                         println!("Group: {}", status.group);


### PR DESCRIPTION
## Summary

`cv fs stat` previously printed a hard-coded `rwxr-xr-x` permission string, so chmod changes were not reflected in stat output.

This patch adds a shared fs CLI permission formatter based on `FileStatus.mode` and uses it in both `stat` and `ls` output.

Fixes #1191.

Thanks @zztaki for reporting the issue.

## Scope

This only changes CLI-side permission formatting. It does not change chmod, FUSE, or metadata semantics.

## Tests

- `cargo fmt`
- `cargo test -p curvine-cli test_format_permission`
- `cargo check -p curvine-cli`

Manual verification on a dev Curvine cluster:
- regular bits: `777`, `755`, `000`

- `cv fs chmod 777 /tmp/stat-mode-dir`
  - `cv fs stat /tmp/stat-mode-dir` prints `Permission: drwxrwxrwx`
  - `cv fs ls -l /tmp` prints `drwxrwxrwx`
<img width="2254" height="1432" alt="777" src="https://github.com/user-attachments/assets/7be8b204-e9bb-4574-b80f-a907ef74efb3" />

- `cv fs chmod 755 /tmp/stat-mode-dir`
  - `cv fs stat /tmp/stat-mode-dir` prints `Permission: drwxr-xr-x`
  - `cv fs ls -l /tmp` prints `drwxr-xr-x`
  
<img width="2242" height="1416" alt="755" src="https://github.com/user-attachments/assets/1ae0733f-73fe-4dbf-b19a-ecc8ed45989c" />

- `cv fs chmod 000 /tmp/stat-mode-dir`
  - `cv fs stat /tmp/stat-mode-dir` prints `Permission: d---------`
  - `cv fs ls -l /tmp` prints `d---------`
<img width="2460" height="1422" alt="000" src="https://github.com/user-attachments/assets/e0efdf2f-2adf-469e-aaed-75a60e147b09" />

- special bits:
  - `2775` -> `drwxrwsr-x`
  - `1755` -> `drwxr-xr-t`
  - `2664` -> `drw-rwSr--`
  - `4755` -> `drwsr-xr-x`
  - `1666` -> `drw-rw-rwT`

