### PR TITLE
feat(fuse): set FUSE subtype so mount reports `fuse.curvinefs` (#1510)

### DIFF
--- a/curvine-fuse/src/raw/fuse_pure.rs
+++ b/curvine-fuse/src/raw/fuse_pure.rs
@@ -141,6 +141,13 @@ fn fuse_mount_sys(mnt: &Path, conf: &FuseConf) -> IOResult<RawIO> {
         getgid()
     );
     conf.set_fuse_opts(&mut mount_options);
+    // Set the FUSE subtype so /proc/mounts reports `type fuse.curvinefs` instead of the
+    // generic `type fuse` (same mechanism sshfs uses for `fuse.sshfs`). `c_type` below
+    // stays "fuse" (the only registered kernel FUSE fs type); the kernel FUSE module
+    // parses `subtype=` from this mount data and sets sb->s_subtype, and the VFS then
+    // reports the type as `fuse.<subtype>`. Hardcoded to match the existing `curvinefs`
+    // source name above (c_source = "curvinefs").
+    mount_options.push_str(",subtype=curvinefs");
     flags |= options_to_flag(mount_options.as_str());
     info!("sys-mount options: {}; flags: 0x{:x}", mount_options, flags);
 

--- a/curvine-fuse/src/raw/fuse_pure.rs
+++ b/curvine-fuse/src/raw/fuse_pure.rs
@@ -143,11 +143,16 @@ fn fuse_mount_sys(mnt: &Path, conf: &FuseConf) -> IOResult<RawIO> {
     conf.set_fuse_opts(&mut mount_options);
     // Set the FUSE subtype so /proc/mounts reports `type fuse.curvinefs` instead of the
     // generic `type fuse` (same mechanism sshfs uses for `fuse.sshfs`). `c_type` below
-    // stays "fuse" (the only registered kernel FUSE fs type); the kernel FUSE module
-    // parses `subtype=` from this mount data and sets sb->s_subtype, and the VFS then
-    // reports the type as `fuse.<subtype>`. Hardcoded to match the existing `curvinefs`
-    // source name above (c_source = "curvinefs").
-    mount_options.push_str(",subtype=curvinefs");
+    // stays "fuse" (the only registered kernel FUSE fs type); the Linux kernel FUSE
+    // module parses `subtype=` from this mount data and sets sb->s_subtype, and the VFS
+    // then reports the type as `fuse.<subtype>`. `subtype=` is a Linux-only FUSE
+    // mount-data option, so it is gated to Linux here to preserve the existing macOS
+    // mount data (macFUSE does not recognize this field). Hardcoded to match the
+    // existing `curvinefs` source name above (c_source = "curvinefs").
+    #[cfg(target_os = "linux")]
+    {
+        mount_options.push_str(",subtype=curvinefs");
+    }
     flags |= options_to_flag(mount_options.as_str());
     info!("sys-mount options: {}; flags: 0x{:x}", mount_options, flags);
 


### PR DESCRIPTION
# Summary

`curvine-fuse` mounts currently report the generic filesystem type `fuse` in
`/proc/mounts`, making curvine mounts indistinguishable from other FUSE filesystems.
This PR sets the FUSE subtype to `curvinefs` so the VFS reports the type as
`fuse.curvinefs` (same mechanism `sshfs` uses for `fuse.sshfs`), letting operators
identify and filter curvine mounts (`findmnt -t fuse.curvinefs`). The append is
gated to Linux (`#[cfg(target_os = "linux")]`) so the existing macOS mount data is
preserved unchanged.

# Issue Describe / Design

Closes #1510

The Linux kernel FUSE module parses `subtype=` from the mount data string, sets
`sb->s_subtype`, and the VFS renders the type as `fuse.<subtype>`. We append
`,subtype=curvinefs` to the mount options in `fuse_mount_sys`, gated to Linux via
`#[cfg(target_os = "linux")]` so the existing macOS mount data is preserved
(macFUSE does not recognize `subtype=`). `c_type` stays `"fuse"` (the only
registered kernel FUSE fs type); the value is hardcoded to match the existing
`c_source = "curvinefs"`.

Before: `curvinefs on /cv_fuse type fuse (...)`
After:  `curvinefs on /cv_fuse type fuse.curvinefs (...)` (Linux only)

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-fuse/src/raw/fuse_pure.rs` | Append `,subtype=curvinefs` to the FUSE mount data in `fuse_mount_sys`, gated with `#[cfg(target_os = "linux")]` | Only the reported filesystem **type** string changes on Linux (`fuse` → `fuse.curvinefs`). No change to mount semantics, options parsing, or BDI/read-ahead handling. The BDI mountinfo parser keys on `major:minor`/mount_point, not the type field, so it is unaffected. macOS mount data is untouched (the append is compiled out). |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo fmt --check -p curvine-fuse` | PASS | Rust 1.92.0; no formatting diffs |
| `cargo build -p curvine-fuse` (Linux) | PASS | `dev` profile, 0 errors; the `#[cfg(target_os = "linux")]` block compiles and `subtype=curvinefs` is still appended |
| `cargo test -p curvine-fuse` (Linux) | PASS | 380 tests; all pass in isolation. One `fuse_writer` concurrency assertion (`io_size_bytes observed once`) is timing-flaky under full-suite load — passes 3/3 in isolation; unrelated to the subtype change. Incl. the BDI `/proc/self/mountinfo` parser unit tests, which key on `major:minor`/mount_point (not the type field) |
| `cargo clippy -p curvine-fuse` | PASS | 0 warnings |
| `cargo check -p curvine-fuse` (macOS / darwin) | PASS | Compiles cleanly; the `subtype=curvinefs` append is compiled out via `#[cfg(target_os = "linux")]`, so the macOS mount data is unchanged |
| Runtime `/proc/mounts` reports `fuse.curvinefs` (Linux) | PASS | Verified on a 3-node curvine cluster (tikv-nxxy03/04-1/05, master RPC `:8995`). The deployed **unpatched** binary mounts `/curvine-fuse` as `type fuse`; the **patched** binary mounts `/tmp/cv_subtype_test` as `type fuse.curvinefs`. The `sys-mount options` log line shows `...,async,subtype=curvinefs`; smoke test through the mount (`ls`/write/read/delete) succeeded. Linux behavior is unchanged by the follow-up `#[cfg]` gating. The existing cluster mount was left untouched (still `type fuse`). |

# Dependencies

- Related issues: #1510
- Related PRs: None
- Blocks / blocked by: None
