### PR TITLE
fix(fuse): tolerate stale LOOKUP name tails

### DIFF
--- a/curvine-fuse/src/session/fuse_request.rs
+++ b/curvine-fuse/src/session/fuse_request.rs
@@ -138,10 +138,14 @@ impl FuseRequest {
                 FuseOperator::Init(Init { header, arg })
             }
 
-            FUSE_LOOKUP => FuseOperator::Lookup(Lookup {
-                header,
-                name: decoder.get_os_str()?,
-            }),
+            FUSE_LOOKUP => {
+                let name = decoder.get_os_str()?;
+                // A rename racing with dentry revalidation can leave bytes from the
+                // previous name after the first NUL. LOOKUP has exactly one name, so
+                // the first NUL remains its semantic boundary.
+                decoder.get_all()?;
+                FuseOperator::Lookup(Lookup { header, name })
+            }
 
             FUSE_ACCESS => FuseOperator::Access(Access {
                 header,
@@ -429,6 +433,27 @@ mod tests {
         let request = FuseRequest::from_bytes(request_bytes(&header, &[0])).unwrap();
         let err = request.parse_operator().unwrap_err();
         assert!(err.to_string().contains("Unexpected trailing request data"));
+    }
+
+    #[test]
+    fn lookup_uses_first_nul_terminated_name_when_rename_leaves_old_tail() {
+        let body = b"race-alt\0et\0";
+        let header = header(FUSE_LOOKUP, FUSE_IN_HEADER_LEN + body.len());
+        let request = FuseRequest::from_bytes(request_bytes(&header, body)).unwrap();
+
+        match request.parse_operator().unwrap() {
+            FuseOperator::Lookup(op) => assert_eq!(op.name, OsStr::new("race-alt")),
+            other => panic!("expected Lookup, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn lookup_still_requires_a_nul_terminated_name() {
+        let body = b"race-alt";
+        let header = header(FUSE_LOOKUP, FUSE_IN_HEADER_LEN + body.len());
+        let request = FuseRequest::from_bytes(request_bytes(&header, body)).unwrap();
+
+        assert!(request.parse_operator().is_err());
     }
 
     fn init_request(arg: &fuse_init_in, tail: Option<&fuse_init_in_ext_tail>) -> FuseRequest {


### PR DESCRIPTION
# Summary

Prevent FUSE LOOKUP requests from hanging when a rename race leaves bytes from the previous dentry name after the first NUL terminator.

LOOKUP now treats the first NUL as the semantic end of its single name while preserving strict frame-length and NUL-termination validation.

# Issue Describe / Design

Root cause:

- Linux 5.4 can expose a LOOKUP payload such as `race-alt\0et\0` when dentry revalidation races with renaming.
- Curvine decoded `race-alt` and then rejected the remaining `et\0` through the shared trailing-data check.
- The request ended without a normal response, potentially leaving the kernel requester blocked in `request_wait_answer`.

Fix:

- Consume the remaining LOOKUP payload after decoding its first NUL-terminated name.
- Continue rejecting requests without a NUL terminator.
- Keep trailing-data validation unchanged for every other opcode.

# Changes

| Module / File | Change | Impact |
| ------------- | ------ | ------ |
| `curvine-fuse/src/session/fuse_request.rs` | Treat the first NUL as LOOKUP's name boundary and add regression tests | LOOKUP tolerates rename-race remnants; other opcode parsing remains strict |

# Test verified

| Test case | Result |
| --------- | ------ |
| `cargo fmt --all -- --check` | PASS |
| LOOKUP parser tests | PASS, 16/16 |
| Metadata dispatch integration tests | PASS, 14/14 |
| Remote Linux serial `curvine-fuse` library tests | PASS, 382/382 |
| Remote real `/dev/fuse` LOOKUP/RENAME race | PASS: 100 bidirectional renames, 8 stat threads, 0 unexpected errors, 0 hangs, stable inode |

Note: the local macOS `make format` reached workspace Clippy but was blocked by existing `curvine-bench` recursion-depth and RocksDB C++ toolchain errors. Formatting passed, and the complete `curvine-fuse` library test suite passed remotely on Linux.

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None
