### PR TITLE
fix(cli): remove unnecessary u32 casts in fs ls/stat permission formatting (#1517)

### DIFF
--- a/curvine-cli/src/cmds/fs/ls.rs
+++ b/curvine-cli/src/cmds/fs/ls.rs
@@ -320,7 +320,7 @@ async fn print_file_entry(
     config: &PrintConfig,
 ) -> CommonResult<()> {
     let file_type = if file.is_dir { "d" } else { "-" };
-    let permissions = crate::cmds::fs::common::format_permission(file.mode as u32);
+    let permissions = crate::cmds::fs::common::format_permission(file.mode);
     let replicas = if file.is_dir {
         "-"
     } else {

--- a/curvine-cli/src/cmds/fs/stat.rs
+++ b/curvine-cli/src/cmds/fs/stat.rs
@@ -68,7 +68,7 @@ impl StatCommand {
                         println!(
                             "Permission: {}{}",
                             if status.is_dir { "d" } else { "-" },
-                            crate::cmds::fs::common::format_permission(status.mode as u32)
+                            crate::cmds::fs::common::format_permission(status.mode)
                         );
                         println!("Owner: {}", status.owner);
                         println!("Group: {}", status.group);


### PR DESCRIPTION
# Summary

Remove redundant `as u32` casts when formatting filesystem permissions in `cv fs ls` and `cv fs stat`. PR #1507 introduced these casts even though `FileStatus.mode` is already `u32`, which triggers `clippy::unnecessary_cast` with `-D warnings` and blocks the fast profile build gate.

# Issue Describe / Design

Closes #1517

**Root cause:** PR #1507 refactored permission display to call `format_permission(file.mode as u32)` and `format_permission(status.mode as u32)`, but `mode` is already `u32`.

**Reproduction:** `cargo clippy -p curvine-cli -- -D warnings` on upstream/main at `6c298c7b` reports two `unnecessary_cast` errors at `ls.rs:323` and `stat.rs:71`.

**Fix approach:** Pass `file.mode` and `status.mode` directly to `format_permission` without redundant casts.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-cli/src/cmds/fs/ls.rs` | Remove redundant `as u32` cast in permission formatting | None; same permission strings displayed |
| `curvine-cli/src/cmds/fs/stat.rs` | Remove redundant `as u32` cast in permission formatting | None; same permission strings displayed |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `make format` | PASS | Includes full-workspace clippy with `-D warnings` |
| `cargo clippy -p curvine-cli -- -D warnings` | PASS | Original failure signature no longer reproduces |
| fast profile | PASS | Build gate on fixed HEAD `192f276d` |
| integration profile | PASS | No new failures vs archived baseline |
| daily profile | PASS | No new failures vs archived baseline |
| fuse profile | PASS | No new failures vs archived baseline |
| ltp profile | PASS | No new failures vs archived baseline |
| csi profile | PASS | No new failures vs archived baseline |

# Dependencies

- Related PRs: #1507 (introduced redundant casts)
- Related issues: #1517
- Blocks / blocked by: None

<!-- curvine-automation -->
