### PR TITLE
fix(unified-fs): support cache-only free for mount children

### DIFF
--- a/crates/client/curvine-unified-fs/src/unified/unified_filesystem.rs
+++ b/crates/client/curvine-unified-fs/src/unified/unified_filesystem.rs
@@ -272,7 +272,17 @@ impl UnifiedFileSystem {
 
     pub async fn free(&self, path: &Path, recursive: bool) -> FsResult<FreeResult> {
         let fut = async {
-            match self.get_mount(path, RpcCode::Free).await? {
+            let mount = if self.enable_unified {
+                self.get_mount(path, RpcCode::Free)
+                    .await?
+                    .map(|(_, mount)| mount.info.clone())
+            } else {
+                // Cache-only commands still need the master's hierarchical mount
+                // lookup, but must not initialize or access a UFS client.
+                self.get_mount_info(path).await?
+            };
+
+            match mount {
                 None => err_box!(
                     "the current path is not mounted to ufs, so the `free` command cannot be executed."
                 ),
@@ -280,28 +290,35 @@ impl UnifiedFileSystem {
                 // Master delete already releases worker blocks; calling free first
                 // would only clear locs then delete the inode — redundant.
                 // Use cv.delete (not UnifiedFileSystem::delete) so UFS is untouched.
-                Some((_, mount)) if mount.info.is_cache_mode() => {
-                    if path.path() == mount.info.cv_path {
-                        if recursive {
-                            for status in self.cv.list_status(path).await? {
-                                let child = Path::from_str(status.path)?;
-                                if let Err(e) = self.cv.delete(&child, true).await {
-                                    if !matches!(e, FsError::FileNotFound(_)) {
-                                        return Err(e);
-                                    }
-                                }
-                            }
-                        }
-                    } else {
-                        self.cv.delete(path, recursive).await?;
-                    }
-
-                    Ok(FreeResult::default())
+                Some(mount) if mount.is_cache_mode() => {
+                    self.free_cache_mode(path, &mount, recursive).await
                 }
                 Some(_) => self.cv.free(path, recursive).await,
             }
         };
         self.track("Free", path.path(), "", fut).await
+    }
+
+    async fn free_cache_mode(
+        &self,
+        path: &Path,
+        mount: &MountInfo,
+        recursive: bool,
+    ) -> FsResult<FreeResult> {
+        if path.path() == mount.cv_path && recursive {
+            for status in self.cv.list_status(path).await? {
+                let child = Path::from_str(status.path)?;
+                if let Err(e) = self.cv.delete(&child, true).await {
+                    if !matches!(e, FsError::FileNotFound(_)) {
+                        return Err(e);
+                    }
+                }
+            }
+        } else {
+            self.cv.delete(path, recursive).await?;
+        }
+
+        Ok(FreeResult::default())
     }
 
     pub async fn symlink(&self, target: &str, link: &Path, force: bool) -> FsResult<()> {

--- a/curvine-tests/tests/write_cache_test.rs
+++ b/curvine-tests/tests/write_cache_test.rs
@@ -195,6 +195,43 @@ fn test_cache_mode_free() {
 }
 
 #[test]
+fn test_cache_mode_free_child_with_unified_disabled() {
+    let mut fs = get_fs();
+    let rt = fs.clone_runtime();
+    rt.block_on(async move {
+        mount(&fs, WriteType::CacheMode).await;
+
+        let parent = Path::from_str("/write_cache_CacheMode/cache_only_free").unwrap();
+        fs.mkdir(&parent, true).await.unwrap();
+        let path = Path::from_str("/write_cache_CacheMode/cache_only_free/child.log").unwrap();
+        let mut writer = fs.create(&path, true).await.unwrap();
+        writer.write_string("cache-only free").await.unwrap();
+        writer.complete().await.unwrap();
+        let _ = fs.open(&path).await.unwrap();
+        fs.wait_job_complete(&path, false).await.unwrap();
+
+        let (ufs_path, mount) = fs
+            .get_mount(&path, RpcCode::GetMountInfo)
+            .await
+            .unwrap()
+            .unwrap();
+
+        fs.disable_unified();
+        fs.free(&parent, true).await.unwrap();
+
+        assert!(!fs.cv().exists(&path).await.unwrap());
+        assert!(mount.ufs().unwrap().exists(&ufs_path).await.unwrap());
+        assert!(
+            fs.cv()
+                .exists(&Path::from_str("/write_cache_CacheMode").unwrap())
+                .await
+                .unwrap(),
+            "free must preserve the cache-mode mount point"
+        );
+    });
+}
+
+#[test]
 fn test_fs_mode_free() {
     let fs = get_fs();
     let rt = fs.clone_runtime();


### PR DESCRIPTION
# Summary

Allow `cv fs --cache-only free -r` to remove a child path under a CacheMode mount without creating a UFS client. This restores cache-only cleanup for mounted subtrees while preserving the UFS source and mount point.

# Issue Describe / Design

Root cause: `disable_unified()` made `UnifiedFileSystem::free` reject every mount lookup, including child paths that only need Curvine metadata. The Master already resolves mounts hierarchically, so the client can obtain `MountInfo` directly and retain the existing CacheMode semantics.

Reproduction: mount a CacheMode UFS path, cache data beneath it, call `cv fs --cache-only free -r <mount-child>`, and observe that the former implementation rejects the request before the cache-only delete reaches Curvine.

Fix approach: use the Master-only hierarchical mount lookup when unified access is disabled. For CacheMode, delete the requested Curvine child only; delete the root's children when the root itself is freed recursively. The implementation never invokes a UFS delete.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `crates/client/curvine-unified-fs/src/unified/unified_filesystem.rs` | Resolve mount metadata for cache-only free without UFS initialization and preserve root/child CacheMode semantics. | Enables a previously rejected cache-only child delete; UFS data remains untouched. |
| `curvine-tests/tests/write_cache_test.rs` | Add CacheMode mount-child cleanup coverage with unified access disabled. | Test only. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo fmt --check` | PASS | |
| `cargo test -p curvine-tests --test write_cache_test --no-run` | PASS | |
| `CARGO_TARGET_DIR=/tmp/curvine-cache-free-test RUST_TEST_THREADS=1 cargo test -p curvine-tests --test write_cache_test test_cache_mode_free_child_with_unified_disabled -- --exact` | PASS | Verifies cache-only recursive child free, UFS retention, and mount-root retention. |
| `git diff --check` | PASS | |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None