### PR TITLE
fix(worker): acknowledge block deletion after physical removal

### DIFF
--- a/crates/adapters/curvine-storage-local/src/vfs_dataset.rs
+++ b/crates/adapters/curvine-storage-local/src/vfs_dataset.rs
@@ -82,7 +82,12 @@ impl RemovedBlockState {
         Ok(())
     }
 
-    pub fn release_space(&self) {
+    pub fn release(&self) {
+        self.layout.release(&self.dir, &self.meta);
+        if let Some(committed) = self.committed.as_ref() {
+            self.layout.release(&self.dir, committed);
+        }
+
         self.dir
             .release_space(self.meta.is_final(), self.meta.physical_bytes());
         if let Some(committed) = self.committed.as_ref() {
@@ -480,21 +485,17 @@ impl VfsDataset {
     }
 
     pub fn remove_block_state_by_id(&mut self, id: i64) -> CommonResult<RemovedBlockState> {
-        let meta = match self.meta.remove(id) {
+        let meta = match self.meta.get(id).cloned() {
             None => return err_box!("Not found block {}", id),
             Some(meta) => meta,
         };
-        let committed = self.committed_rewrites.remove(&id);
         let layout = self.layouts.get(meta.storage_type()).clone();
         let dir = match self.dir_list.get_dir(meta.dir_id()) {
             None => return err_box!("No storage directory found: {:?}", meta.dir_id()),
             Some(dir) => dir.clone(),
         };
-
-        layout.release(&dir, &meta);
-        if let Some(committed) = committed.as_ref() {
-            layout.release(&dir, committed);
-        }
+        let meta = self.meta.remove(id).expect("block metadata must exist");
+        let committed = self.committed_rewrites.remove(&id);
 
         Ok(RemovedBlockState {
             meta,
@@ -504,10 +505,21 @@ impl VfsDataset {
         })
     }
 
+    pub fn restore_removed_block(&mut self, removed: RemovedBlockState) {
+        let id = removed.meta.id();
+        self.meta.put(removed.meta);
+        if let Some(committed) = removed.committed {
+            self.committed_rewrites.insert(id, committed);
+        }
+    }
+
     pub(crate) fn remove_block_by_id(&mut self, id: i64) -> CommonResult<BlockMeta> {
         let removed = self.remove_block_state_by_id(id)?;
-        removed.deallocate()?;
-        removed.release_space();
+        if let Err(e) = removed.deallocate() {
+            self.restore_removed_block(removed);
+            return Err(e);
+        }
+        removed.release();
         Ok(removed.meta)
     }
 
@@ -871,7 +883,7 @@ mod test {
         Ok(())
     }
     #[test]
-    fn failed_file_deallocate_keeps_capacity_reserved() -> CommonResult<()> {
+    fn failed_file_deallocate_keeps_block_and_capacity_reserved() -> CommonResult<()> {
         let mut ds = create_data_set(true, "deallocate-failure");
         let block = ExtendedBlock::with_mem(1, "100B")?;
         let available = ds.available();
@@ -884,10 +896,13 @@ mod test {
         std::fs::write(block_path.join("child"), b"data")?;
 
         assert!(ds.abort_block(&block).is_err());
-        assert!(ds.get_block(block.id).is_none());
+        assert!(ds.get_block(block.id).is_some());
         assert_eq!(ds.available(), available - 100);
 
         FileUtils::delete_path(block_path, true)?;
+        ds.abort_block(&block)?;
+        assert!(ds.get_block(block.id).is_none());
+        assert_eq!(ds.available(), available);
         Ok(())
     }
     #[test]

--- a/curvine-worker/src/worker/block/block_actor.rs
+++ b/curvine-worker/src/worker/block/block_actor.rs
@@ -22,7 +22,7 @@ use curvine_runtime::common::TimeSpent;
 use curvine_runtime::runtime::ScheduledExecutor;
 use curvine_runtime::runtime::{GroupExecutor, Runtime};
 use curvine_runtime::sync::StateCtl;
-use dashmap::DashMap;
+use dashmap::{DashMap, DashSet};
 use log::info;
 use std::sync::Arc;
 
@@ -44,6 +44,7 @@ pub struct BlockActor {
     // 1. Block file deletion report.
     // 2. Add a new block.
     report_blocks: Arc<DashMap<i64, BlockReportInfo>>,
+    pending_deletes: Arc<DashSet<i64>>,
 }
 
 impl BlockActor {
@@ -82,6 +83,7 @@ impl BlockActor {
             worker_ctl,
             block_report_limit,
             report_blocks: Arc::new(DashMap::new()),
+            pending_deletes: Arc::new(DashSet::new()),
         })
     }
 
@@ -105,6 +107,7 @@ impl BlockActor {
             self.client.clone(),
             self.store.clone(),
             self.report_blocks.clone(),
+            self.pending_deletes.clone(),
             self.heartbeat_interval_ms,
         )?;
         Ok(())
@@ -128,6 +131,7 @@ impl BlockActor {
                 self.store.clone(),
                 cmds,
                 self.report_blocks.clone(),
+                self.pending_deletes.clone(),
             );
             return Ok(0);
         }
@@ -144,6 +148,7 @@ impl BlockActor {
                 self.store.clone(),
                 cmds,
                 self.report_blocks.clone(),
+                self.pending_deletes.clone(),
             );
             off = end;
         }
@@ -157,6 +162,7 @@ impl BlockActor {
         client: MasterClient,
         store: BlockStore,
         report_blocks: Arc<DashMap<i64, BlockReportInfo>>,
+        pending_deletes: Arc<DashSet<i64>>,
         heartbeat_interval_ms: u64,
     ) -> CommonResult<()> {
         let scheduler = ScheduledExecutor::new("worker-heartbeat", heartbeat_interval_ms);
@@ -167,6 +173,7 @@ impl BlockActor {
             client,
             store,
             report_blocks,
+            pending_deletes,
         };
 
         scheduler.start(task)?;

--- a/curvine-worker/src/worker/block/block_store.rs
+++ b/curvine-worker/src/worker/block/block_store.rs
@@ -296,19 +296,33 @@ impl BlockStore {
     }
 
     // Asynchronously delete block.
-    pub fn async_remove_block(&self, id: i64) -> CommonResult<BlockMeta> {
+    pub fn async_remove_block(&self, id: i64) -> CommonResult<Option<BlockMeta>> {
         let _block_lock = self.block_lock(id, "remove");
         let removed = self.with_dataset_write("remove", |state| {
-            let remove_result = state.remove_block_state_by_id(id);
+            let remove_result = match state.get_block(id) {
+                Some(_) => state.remove_block_state_by_id(id).map(Some),
+                None => Ok(None),
+            };
             // Heartbeat increments this counter before scheduling the task.
             // Consume it even when metadata removal reports an error.
             state.decrement_blocks_to_delete();
             remove_result
         })?;
 
-        removed.deallocate()?;
-        removed.release_space();
-        Ok(removed.meta)
+        let Some(removed) = removed else {
+            return Ok(None);
+        };
+
+        if let Err(e) = removed.deallocate() {
+            self.with_dataset_write("restore", |state| {
+                state.restore_removed_block(removed);
+                Ok(())
+            })?;
+            return Err(e);
+        }
+
+        removed.release();
+        Ok(Some(removed.meta))
     }
 
     // Get all storage information and check whether the storage directory is normal.
@@ -329,6 +343,8 @@ mod tests {
     use curvine_io::DataSlice;
     use curvine_runtime::common::FileUtils;
     use std::io::Write;
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::PathBuf;
     use std::sync::{Arc, Barrier};
     use std::thread;
     use std::time::Instant;
@@ -365,18 +381,45 @@ mod tests {
         Ok(())
     }
 
+    struct DeleteDenied {
+        parent: PathBuf,
+        permissions: std::fs::Permissions,
+    }
+
+    impl Drop for DeleteDenied {
+        fn drop(&mut self) {
+            let _ = std::fs::set_permissions(&self.parent, self.permissions.clone());
+        }
+    }
+
+    fn deny_block_delete(store: &BlockStore) -> CommonResult<DeleteDenied> {
+        let mut block = ExtendedBlock::with_id(1);
+        block.len = 100;
+        let meta = finalize_block(store, &block)?;
+        let path = store.short_circuit(&meta)?.unwrap();
+        let parent = PathBuf::from(path).parent().unwrap().to_path_buf();
+        let permissions = std::fs::metadata(&parent)?.permissions();
+        let mut readonly = permissions.clone();
+        readonly.set_mode(0o500);
+        std::fs::set_permissions(&parent, readonly)?;
+        Ok(DeleteDenied {
+            parent,
+            permissions,
+        })
+    }
+
     #[test]
     fn async_remove_missing_block_releases_delete_count() -> CommonResult<()> {
         let store = create_store("missing-block")?;
         store.read()?.increment_blocks_to_delete();
 
-        assert!(store.async_remove_block(1).is_err());
+        assert!(store.async_remove_block(1)?.is_none());
         assert_eq!(store.read()?.num_blocks_to_delete(), 0);
         Ok(())
     }
 
     #[test]
-    fn async_remove_invalid_dir_releases_delete_count() -> CommonResult<()> {
+    fn async_remove_invalid_dir_keeps_block_for_retry() -> CommonResult<()> {
         let store = create_store("invalid-dir")?;
         {
             let mut state = store.write()?;
@@ -388,8 +431,33 @@ mod tests {
 
         assert!(store.async_remove_block(1).is_err());
         let state = store.read()?;
-        assert!(state.get_block(1).is_none());
+        assert!(state.get_block(1).is_some());
         assert_eq!(state.num_blocks_to_delete(), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn async_remove_deallocate_error_keeps_block_for_retry() -> CommonResult<()> {
+        let store = create_store("deallocate-error")?;
+        let _delete_denied = deny_block_delete(&store)?;
+        store.read()?.increment_blocks_to_delete();
+
+        let result = store.async_remove_block(1);
+        assert!(result.is_err());
+        let state = store.read()?;
+        assert!(state.get_block(1).is_some());
+        assert_eq!(state.num_blocks_to_delete(), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn remove_deallocate_error_keeps_block_for_retry() -> CommonResult<()> {
+        let store = create_store("remove-deallocate-error")?;
+        let _delete_denied = deny_block_delete(&store)?;
+
+        let result = store.remove_block(1);
+        assert!(result.is_err());
+        assert!(store.read()?.get_block(1).is_some());
         Ok(())
     }
 

--- a/curvine-worker/src/worker/block/heartbeat_task.rs
+++ b/curvine-worker/src/worker/block/heartbeat_task.rs
@@ -21,7 +21,7 @@ use curvine_model::{BlockReportInfo, HeartbeatStatus, WorkerCommand};
 use curvine_rpc::server::ServerState;
 use curvine_runtime::runtime::{GroupExecutor, LoopTask};
 use curvine_runtime::sync::StateCtl;
-use dashmap::DashMap;
+use dashmap::{DashMap, DashSet};
 use log::{error, warn};
 use std::sync::Arc;
 
@@ -31,6 +31,7 @@ pub struct HeartbeatTask {
     pub(crate) client: MasterClient,
     pub(crate) store: BlockStore,
     pub(crate) report_blocks: Arc<DashMap<i64, BlockReportInfo>>,
+    pub(crate) pending_deletes: Arc<DashSet<i64>>,
 }
 
 impl HeartbeatTask {
@@ -40,12 +41,13 @@ impl HeartbeatTask {
         store: BlockStore,
         cmds: Vec<WorkerCommand>,
         report_blocks: Arc<DashMap<i64, BlockReportInfo>>,
+        pending_deletes: Arc<DashSet<i64>>,
     ) {
         for cmd in cmds {
             match cmd {
                 WorkerCommand::DeleteBlock(c) => {
                     for block in c.blocks {
-                        if report_blocks.contains_key(&block) {
+                        if !pending_deletes.insert(block) {
                             continue;
                         }
 
@@ -53,25 +55,38 @@ impl HeartbeatTask {
                             .write()
                             .map(|state| state.increment_blocks_to_delete())
                         {
+                            pending_deletes.remove(&block);
                             error!("failed to mark block {} deleting: {}", block, e);
                             continue;
                         }
 
-                        // Whether or not it is successfully deleted, it is marked as deleted
-                        report_blocks.insert(block, BlockReportInfo::with_deleted(block, 0));
-
                         let store1 = store.clone();
-                        let res = executor.spawn(move || {
-                            match store1.async_remove_block(block) {
-                                Ok(v) => v.len,
-                                Err(e) => {
-                                    warn!("async_remove_block {}: {}", block, e);
-                                    0
-                                }
-                            };
+                        let report_blocks1 = report_blocks.clone();
+                        let pending_deletes1 = pending_deletes.clone();
+                        let res = executor.spawn(move || match store1.async_remove_block(block) {
+                            Ok(Some(meta)) => {
+                                report_blocks1
+                                    .insert(block, BlockReportInfo::with_deleted(block, meta.len));
+                            }
+                            Ok(None) => {
+                                report_blocks1
+                                    .insert(block, BlockReportInfo::with_deleted(block, 0));
+                            }
+                            Err(e) => {
+                                warn!("async_remove_block {}: {}", block, e);
+                                pending_deletes1.remove(&block);
+                            }
                         });
 
-                        if let Err(e) = &res {
+                        if let Err(e) = res {
+                            pending_deletes.remove(&block);
+                            match store.write() {
+                                Ok(state) => state.decrement_blocks_to_delete(),
+                                Err(err) => error!(
+                                    "failed to clear deleting state for block {}: {}",
+                                    block, err
+                                ),
+                            }
                             warn!("{}", e);
                         }
                     }
@@ -101,6 +116,14 @@ impl HeartbeatTask {
             self.report_blocks.insert(block.id, block);
         }
     }
+
+    fn acknowledge_reports(&self, blocks: &[BlockReportInfo]) {
+        for block in blocks {
+            if block.status == curvine_model::BlockReportStatus::Deleted {
+                self.pending_deletes.remove(&block.id);
+            }
+        }
+    }
 }
 
 impl LoopTask for HeartbeatTask {
@@ -124,6 +147,7 @@ impl LoopTask for HeartbeatTask {
                     self.store.clone(),
                     cmds,
                     self.report_blocks.clone(),
+                    self.pending_deletes.clone(),
                 );
             }
 
@@ -143,12 +167,14 @@ impl LoopTask for HeartbeatTask {
         let res = self.client.incr_block_report(&report_blocks);
         match res {
             Ok(v) => {
+                self.acknowledge_reports(&report_blocks);
                 let cmds = ProtoUtils::worker_cmd_from_pb(v.cmds);
                 Self::delete_block_task(
                     self.executor.clone(),
                     self.store.clone(),
                     cmds,
                     self.report_blocks.clone(),
+                    self.pending_deletes.clone(),
                 );
             }
 

--- a/curvine-worker/src/worker/block/mod.rs
+++ b/curvine-worker/src/worker/block/mod.rs
@@ -25,3 +25,7 @@ pub use self::block_actor::BlockActor;
 
 mod heartbeat_task;
 pub use self::heartbeat_task::HeartbeatTask;
+
+#[cfg(test)]
+#[path = "tests/heartbeat_task_test.rs"]
+mod heartbeat_task_test;

--- a/curvine-worker/src/worker/block/tests/heartbeat_task_test.rs
+++ b/curvine-worker/src/worker/block/tests/heartbeat_task_test.rs
@@ -1,0 +1,97 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::{BlockStore, HeartbeatTask};
+use crate::worker::storage::Dataset;
+use curvine_config::{ClusterConf, WorkerConf};
+use curvine_core_error::CommonResult;
+use curvine_model::{BlockReportStatus, DeleteBlockCmd, WorkerCommand};
+use curvine_runtime::runtime::GroupExecutor;
+use dashmap::{DashMap, DashSet};
+use std::sync::{mpsc, Arc};
+use std::thread;
+use std::time::{Duration, Instant};
+
+fn create_store() -> CommonResult<BlockStore> {
+    let conf = ClusterConf {
+        format_worker: true,
+        worker: WorkerConf {
+            dir_reserved: "0".to_string(),
+            data_dir: vec!["[MEM:1KB]../testing/heartbeat-task".to_string()],
+            ..WorkerConf::default()
+        },
+        ..ClusterConf::default()
+    };
+    BlockStore::new("test", &conf)
+}
+
+#[test]
+fn report_is_emitted_only_after_delete_completes() -> CommonResult<()> {
+    let store = create_store()?;
+    let executor = Arc::new(GroupExecutor::new("heartbeat-task-test", 1, 2));
+    let reports = Arc::new(DashMap::new());
+    let pending = Arc::new(DashSet::new());
+    let (started_tx, started_rx) = mpsc::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+
+    executor.spawn(move || {
+        started_tx.send(()).unwrap();
+        release_rx.recv().unwrap();
+    })?;
+    started_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+
+    HeartbeatTask::delete_block_task(
+        executor.clone(),
+        store.clone(),
+        vec![WorkerCommand::DeleteBlock(DeleteBlockCmd {
+            blocks: vec![1],
+        })],
+        reports.clone(),
+        pending.clone(),
+    );
+
+    // The master repeats DeleteBlock until it accepts the Deleted report.
+    // A repeated command must not queue or count the same deletion twice.
+    HeartbeatTask::delete_block_task(
+        executor.clone(),
+        store.clone(),
+        vec![WorkerCommand::DeleteBlock(DeleteBlockCmd {
+            blocks: vec![1],
+        })],
+        reports.clone(),
+        pending.clone(),
+    );
+
+    assert!(reports.is_empty(), "report must wait for physical deletion");
+    assert!(pending.contains(&1));
+    assert_eq!(store.read()?.num_blocks_to_delete(), 1);
+    release_tx.send(()).unwrap();
+
+    let deadline = Instant::now() + Duration::from_secs(1);
+    while !reports.contains_key(&1) && Instant::now() < deadline {
+        thread::sleep(Duration::from_millis(10));
+    }
+
+    let report = reports.get(&1).expect("missing deleted report");
+    assert_eq!(report.status, BlockReportStatus::Deleted);
+    assert_eq!(store.read()?.num_blocks_to_delete(), 0);
+    assert!(
+        pending.contains(&1),
+        "pending state is cleared after master ACK"
+    );
+    // GroupExecutor's Drop waits for its worker threads; leaking this test-only
+    // executor lets the process shutdown reclaim the idle thread deterministically.
+    std::mem::forget(executor);
+    Ok(())
+}


### PR DESCRIPTION
# Summary

Report a block as `Deleted` only after its local backing resource is physically removed. A failed local deletion now preserves metadata and capacity accounting so the Master can resend the deletion command on a later heartbeat.

# Issue Describe / Design

Root cause: the Worker emitted `Deleted` before its asynchronous file removal finished. The Master therefore removed the pending deletion command even when local deletion failed, leaving an unreachable block and unreleased capacity on the Worker.

Reproduction: make block deallocation fail after the Master sends `DeleteBlock`. The former Worker implementation reported `Deleted` immediately, so the Master stopped retrying although the block remained locally allocated.

Fix approach: track in-flight deletions per block, remove the block outside the dataset lock, and enqueue `Deleted` only on success or an already-absent block. On deallocation failure, restore dataset metadata and retain capacity. The in-flight marker remains until the Master accepts the incremental report, which coalesces repeated commands without losing retries.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-worker/src/worker/block/heartbeat_task.rs` | Delay `Deleted` reports, coalesce repeated delete commands, and retain pending state until report ACK. | Failed deletion is retried instead of being falsely acknowledged. |
| `curvine-worker/src/worker/block/block_store.rs` | Return explicit absent/success states and restore metadata after failed physical deletion. | Missing blocks remain idempotent; failed blocks remain retryable. |
| `crates/adapters/curvine-storage-local/src/vfs_dataset.rs` | Separate physical deallocation from layout/capacity release and add restoration support. | File and SPDK capacity are released only after physical success. |
| `curvine-worker/src/worker/block/block_actor.rs` | Share pending deletion state with heartbeat and full-report paths. | Control-plane state only. |
| `curvine-worker/src/worker/block/tests/heartbeat_task_test.rs` | Cover delayed report, duplicate command coalescing, and pending state before ACK. | Test only. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo fmt --check` | PASS | |
| `cargo test -p curvine-worker --lib` | PASS | 11 passed, 1 ignored. |
| `cargo test -p curvine-storage-local` | PASS | 50 passed. |
| `cargo check -p curvine-worker` | PASS | |
| `git diff --check` | PASS | |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None