### PR TITLE
fix(master): support mixed legacy journal replay (#1474)

### DIFF
--- a/curvine-master/src/master/journal/entry.rs
+++ b/curvine-master/src/master/journal/entry.rs
@@ -18,7 +18,7 @@ use curvine_core_error::{err_box, CommonResult};
 use curvine_model::{CommitBlock, FileLock, MountInfo, SetAttrOpts};
 use curvine_runtime::common::SerdeUtils;
 use log::debug;
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::io::Cursor;
 
 #[derive(Debug, Clone)]
@@ -318,19 +318,29 @@ impl JournalBatch {
     pub(crate) fn deserialize_compat(bytes: &[u8]) -> CommonResult<Self> {
         match SerdeUtils::deserialize(bytes) {
             Ok(batch) => Ok(batch),
-            Err(current_err) => match deserialize_legacy_batch(bytes) {
+            Err(current_err) => match deserialize_batch::<LegacyJournalBatch>(bytes) {
                 Ok(batch) => {
                     debug!(
-                        "replaying legacy journal batch with pre-extension entry schemas, seq_id={}",
+                        "replaying legacy journal batch with legacy rename schema, seq_id={}",
                         batch.seq_id
                     );
                     Ok(batch.into())
                 }
-                Err(legacy_err) => err_box!(
-                    "failed to deserialize journal batch with current or legacy schemas: current={}, legacy={}",
-                    current_err,
-                    legacy_err
-                ),
+                Err(legacy_err) => match deserialize_batch::<PreRecursiveJournalBatch>(bytes) {
+                    Ok(batch) => {
+                        debug!(
+                            "replaying legacy journal batch with legacy rename and free schemas, seq_id={}",
+                            batch.seq_id
+                        );
+                        Ok(batch.into())
+                    }
+                    Err(pre_recursive_err) => err_box!(
+                        "failed to deserialize journal batch with current or legacy schemas: current={}, legacy={}, pre_recursive={}",
+                        current_err,
+                        legacy_err,
+                        pre_recursive_err
+                    ),
+                },
             },
         }
     }
@@ -375,7 +385,8 @@ struct LegacyRenameEntry {
 
 // FreeEntry::recursive was appended in #721. Old bincode entries do not have
 // this field, so decoding them with the current type consumes the next entry's
-// enum tag as a bool.
+// enum tag as a bool. This schema is kept separate because batches written
+// after #721 can still contain the legacy RenameEntry layout.
 #[derive(Deserialize)]
 struct LegacyFreeEntry {
     op_id: u64,
@@ -400,7 +411,7 @@ enum LegacyJournalEntry {
     Symlink(SymlinkEntry),
     Link(LinkEntry),
     SetLocks(SetLocksEntry),
-    Free(LegacyFreeEntry),
+    Free(FreeEntry),
     UfsApplied(UfsAppliedEntry),
     Snapshot(SnapshotEntry),
 }
@@ -411,7 +422,34 @@ struct LegacyJournalBatch {
     batch: Vec<LegacyJournalEntry>,
 }
 
-fn deserialize_legacy_batch(bytes: &[u8]) -> CommonResult<LegacyJournalBatch> {
+#[derive(Deserialize)]
+enum PreRecursiveJournalEntry {
+    Mkdir(MkdirEntry),
+    CreateFile(CreateFileEntry),
+    ReopenFile(ReopenFileEntry),
+    OverWriteFile(OverWriteFileEntry),
+    AddBlock(AddBlockEntry),
+    CompleteFile(CompleteFileEntry),
+    Rename(LegacyRenameEntry),
+    Delete(DeleteEntry),
+    Mount(MountEntry),
+    UnMount(UnMountEntry),
+    SetAttr(SetAttrEntry),
+    Symlink(SymlinkEntry),
+    Link(LinkEntry),
+    SetLocks(SetLocksEntry),
+    Free(LegacyFreeEntry),
+    UfsApplied(UfsAppliedEntry),
+    Snapshot(SnapshotEntry),
+}
+
+#[derive(Deserialize)]
+struct PreRecursiveJournalBatch {
+    seq_id: u64,
+    batch: Vec<PreRecursiveJournalEntry>,
+}
+
+fn deserialize_batch<T: DeserializeOwned>(bytes: &[u8]) -> CommonResult<T> {
     let mut reader = Cursor::new(bytes);
     let batch = SerdeUtils::deserialize_from(&mut reader)?;
     if reader.position() != bytes.len() as u64 {
@@ -425,6 +463,50 @@ impl From<LegacyJournalBatch> for JournalBatch {
         Self {
             seq_id: batch.seq_id,
             batch: batch.batch.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<PreRecursiveJournalBatch> for JournalBatch {
+    fn from(batch: PreRecursiveJournalBatch) -> Self {
+        Self {
+            seq_id: batch.seq_id,
+            batch: batch
+                .batch
+                .into_iter()
+                .map(LegacyJournalEntry::from)
+                .map(JournalEntry::from)
+                .collect(),
+        }
+    }
+}
+
+impl From<PreRecursiveJournalEntry> for LegacyJournalEntry {
+    fn from(entry: PreRecursiveJournalEntry) -> Self {
+        match entry {
+            PreRecursiveJournalEntry::Mkdir(entry) => Self::Mkdir(entry),
+            PreRecursiveJournalEntry::CreateFile(entry) => Self::CreateFile(entry),
+            PreRecursiveJournalEntry::ReopenFile(entry) => Self::ReopenFile(entry),
+            PreRecursiveJournalEntry::OverWriteFile(entry) => Self::OverWriteFile(entry),
+            PreRecursiveJournalEntry::AddBlock(entry) => Self::AddBlock(entry),
+            PreRecursiveJournalEntry::CompleteFile(entry) => Self::CompleteFile(entry),
+            PreRecursiveJournalEntry::Rename(entry) => Self::Rename(entry),
+            PreRecursiveJournalEntry::Delete(entry) => Self::Delete(entry),
+            PreRecursiveJournalEntry::Mount(entry) => Self::Mount(entry),
+            PreRecursiveJournalEntry::UnMount(entry) => Self::UnMount(entry),
+            PreRecursiveJournalEntry::SetAttr(entry) => Self::SetAttr(entry),
+            PreRecursiveJournalEntry::Symlink(entry) => Self::Symlink(entry),
+            PreRecursiveJournalEntry::Link(entry) => Self::Link(entry),
+            PreRecursiveJournalEntry::SetLocks(entry) => Self::SetLocks(entry),
+            PreRecursiveJournalEntry::Free(entry) => Self::Free(FreeEntry {
+                op_id: entry.op_id,
+                rpc_id: entry.rpc_id,
+                path: entry.path,
+                mtime: entry.mtime,
+                recursive: false,
+            }),
+            PreRecursiveJournalEntry::UfsApplied(entry) => Self::UfsApplied(entry),
+            PreRecursiveJournalEntry::Snapshot(entry) => Self::Snapshot(entry),
         }
     }
 }
@@ -455,13 +537,7 @@ impl From<LegacyJournalEntry> for JournalEntry {
             LegacyJournalEntry::Symlink(entry) => Self::Symlink(entry),
             LegacyJournalEntry::Link(entry) => Self::Link(entry),
             LegacyJournalEntry::SetLocks(entry) => Self::SetLocks(entry),
-            LegacyJournalEntry::Free(entry) => Self::Free(FreeEntry {
-                op_id: entry.op_id,
-                rpc_id: entry.rpc_id,
-                path: entry.path,
-                mtime: entry.mtime,
-                recursive: false,
-            }),
+            LegacyJournalEntry::Free(entry) => Self::Free(entry),
             LegacyJournalEntry::UfsApplied(entry) => Self::UfsApplied(entry),
             LegacyJournalEntry::Snapshot(entry) => Self::Snapshot(entry),
         }

--- a/curvine-master/src/master/journal/entry.rs
+++ b/curvine-master/src/master/journal/entry.rs
@@ -321,13 +321,13 @@ impl JournalBatch {
             Err(current_err) => match deserialize_legacy_batch(bytes) {
                 Ok(batch) => {
                     debug!(
-                        "replaying legacy journal batch without rename exchange inode ids, seq_id={}",
+                        "replaying legacy journal batch with pre-extension entry schemas, seq_id={}",
                         batch.seq_id
                     );
                     Ok(batch.into())
                 }
                 Err(legacy_err) => err_box!(
-                    "failed to deserialize journal batch with current or legacy rename schema: current={}, legacy={}",
+                    "failed to deserialize journal batch with current or legacy schemas: current={}, legacy={}",
                     current_err,
                     legacy_err
                 ),
@@ -373,6 +373,17 @@ struct LegacyRenameEntry {
     flags: u32,
 }
 
+// FreeEntry::recursive was appended in #721. Old bincode entries do not have
+// this field, so decoding them with the current type consumes the next entry's
+// enum tag as a bool.
+#[derive(Deserialize)]
+struct LegacyFreeEntry {
+    op_id: u64,
+    rpc_id: i64,
+    path: String,
+    mtime: i64,
+}
+
 #[derive(Deserialize)]
 enum LegacyJournalEntry {
     Mkdir(MkdirEntry),
@@ -389,7 +400,7 @@ enum LegacyJournalEntry {
     Symlink(SymlinkEntry),
     Link(LinkEntry),
     SetLocks(SetLocksEntry),
-    Free(FreeEntry),
+    Free(LegacyFreeEntry),
     UfsApplied(UfsAppliedEntry),
     Snapshot(SnapshotEntry),
 }
@@ -444,7 +455,13 @@ impl From<LegacyJournalEntry> for JournalEntry {
             LegacyJournalEntry::Symlink(entry) => Self::Symlink(entry),
             LegacyJournalEntry::Link(entry) => Self::Link(entry),
             LegacyJournalEntry::SetLocks(entry) => Self::SetLocks(entry),
-            LegacyJournalEntry::Free(entry) => Self::Free(entry),
+            LegacyJournalEntry::Free(entry) => Self::Free(FreeEntry {
+                op_id: entry.op_id,
+                rpc_id: entry.rpc_id,
+                path: entry.path,
+                mtime: entry.mtime,
+                recursive: false,
+            }),
             LegacyJournalEntry::UfsApplied(entry) => Self::UfsApplied(entry),
             LegacyJournalEntry::Snapshot(entry) => Self::Snapshot(entry),
         }

--- a/curvine-master/src/master/journal/tests/journal_entry_compat_test.rs
+++ b/curvine-master/src/master/journal/tests/journal_entry_compat_test.rs
@@ -51,6 +51,28 @@ enum LegacyJournalEntry {
     Symlink(SymlinkEntry),
     Link(LinkEntry),
     SetLocks(SetLocksEntry),
+    Free(FreeEntry),
+    UfsApplied(UfsAppliedEntry),
+    Snapshot(SnapshotEntry),
+}
+
+#[derive(Serialize)]
+#[allow(dead_code)]
+enum PreRecursiveJournalEntry {
+    Mkdir(MkdirEntry),
+    CreateFile(CreateFileEntry),
+    ReopenFile(ReopenFileEntry),
+    OverWriteFile(OverWriteFileEntry),
+    AddBlock(AddBlockEntry),
+    CompleteFile(CompleteFileEntry),
+    Rename(LegacyRenameEntry),
+    Delete(DeleteEntry),
+    Mount(MountEntry),
+    UnMount(UnMountEntry),
+    SetAttr(SetAttrEntry),
+    Symlink(SymlinkEntry),
+    Link(LinkEntry),
+    SetLocks(SetLocksEntry),
     Free(LegacyFreeEntry),
     UfsApplied(UfsAppliedEntry),
     Snapshot(SnapshotEntry),
@@ -60,6 +82,12 @@ enum LegacyJournalEntry {
 struct LegacyJournalBatch {
     seq_id: u64,
     batch: Vec<LegacyJournalEntry>,
+}
+
+#[derive(Serialize)]
+struct PreRecursiveJournalBatch {
+    seq_id: u64,
+    batch: Vec<PreRecursiveJournalEntry>,
 }
 
 #[test]
@@ -128,6 +156,43 @@ fn current_rename_batch_keeps_exchange_inode_ids() {
 }
 
 #[test]
+fn legacy_rename_batch_keeps_current_free_schema() {
+    let legacy = LegacyJournalBatch {
+        seq_id: 44,
+        batch: vec![
+            LegacyJournalEntry::Rename(LegacyRenameEntry {
+                op_id: 9,
+                rpc_id: 11,
+                src: "/src".to_string(),
+                dst: "/dst".to_string(),
+                mtime: 13,
+                flags: 0,
+            }),
+            LegacyJournalEntry::Free(FreeEntry {
+                op_id: 10,
+                rpc_id: 12,
+                path: "/free".to_string(),
+                mtime: 14,
+                recursive: true,
+            }),
+        ],
+    };
+    let bytes = SerdeUtils::serialize(&legacy).unwrap();
+
+    assert!(SerdeUtils::deserialize::<JournalBatch>(&bytes).is_err());
+
+    let batch = JournalBatch::deserialize_compat(&bytes).unwrap();
+    let JournalEntry::Rename(rename) = &batch.batch[0] else {
+        panic!("expected rename journal entry");
+    };
+    assert_eq!(rename.src_inode_id, 0);
+    let JournalEntry::Free(free) = &batch.batch[1] else {
+        panic!("expected free journal entry");
+    };
+    assert!(free.recursive);
+}
+
+#[test]
 fn current_free_batch_keeps_recursive_flag() {
     let current = JournalBatch {
         seq_id: 44,
@@ -150,16 +215,16 @@ fn current_free_batch_keeps_recursive_flag() {
 
 #[test]
 fn legacy_free_batch_defaults_recursive_flag() {
-    let legacy = LegacyJournalBatch {
+    let legacy = PreRecursiveJournalBatch {
         seq_id: 45,
         batch: vec![
-            LegacyJournalEntry::Free(LegacyFreeEntry {
+            PreRecursiveJournalEntry::Free(LegacyFreeEntry {
                 op_id: 10,
                 rpc_id: 12,
                 path: "/free".to_string(),
                 mtime: 14,
             }),
-            LegacyJournalEntry::UfsApplied(UfsAppliedEntry {
+            PreRecursiveJournalEntry::UfsApplied(UfsAppliedEntry {
                 op_id: 11,
                 rpc_id: 13,
                 term: 2,

--- a/curvine-master/src/master/journal/tests/journal_entry_compat_test.rs
+++ b/curvine-master/src/master/journal/tests/journal_entry_compat_test.rs
@@ -27,6 +27,14 @@ struct LegacyRenameEntry {
 }
 
 #[derive(Serialize)]
+struct LegacyFreeEntry {
+    op_id: u64,
+    rpc_id: i64,
+    path: String,
+    mtime: i64,
+}
+
+#[derive(Serialize)]
 #[allow(dead_code)]
 enum LegacyJournalEntry {
     Mkdir(MkdirEntry),
@@ -43,7 +51,7 @@ enum LegacyJournalEntry {
     Symlink(SymlinkEntry),
     Link(LinkEntry),
     SetLocks(SetLocksEntry),
-    Free(FreeEntry),
+    Free(LegacyFreeEntry),
     UfsApplied(UfsAppliedEntry),
     Snapshot(SnapshotEntry),
 }
@@ -117,6 +125,63 @@ fn current_rename_batch_keeps_exchange_inode_ids() {
     };
     assert_eq!(entry.src_inode_id, 100);
     assert_eq!(entry.dst_inode_id, 200);
+}
+
+#[test]
+fn current_free_batch_keeps_recursive_flag() {
+    let current = JournalBatch {
+        seq_id: 44,
+        batch: vec![JournalEntry::Free(FreeEntry {
+            op_id: 9,
+            rpc_id: 11,
+            path: "/free".to_string(),
+            mtime: 13,
+            recursive: true,
+        })],
+    };
+    let bytes = SerdeUtils::serialize(&current).unwrap();
+
+    let batch = JournalBatch::deserialize_compat(&bytes).unwrap();
+    let JournalEntry::Free(entry) = &batch.batch[0] else {
+        panic!("expected free journal entry");
+    };
+    assert!(entry.recursive);
+}
+
+#[test]
+fn legacy_free_batch_defaults_recursive_flag() {
+    let legacy = LegacyJournalBatch {
+        seq_id: 45,
+        batch: vec![
+            LegacyJournalEntry::Free(LegacyFreeEntry {
+                op_id: 10,
+                rpc_id: 12,
+                path: "/free".to_string(),
+                mtime: 14,
+            }),
+            LegacyJournalEntry::UfsApplied(UfsAppliedEntry {
+                op_id: 11,
+                rpc_id: 13,
+                term: 2,
+                index: 15,
+            }),
+        ],
+    };
+    let bytes = SerdeUtils::serialize(&legacy).unwrap();
+
+    assert!(SerdeUtils::deserialize::<JournalBatch>(&bytes).is_err());
+
+    let batch = JournalBatch::deserialize_compat(&bytes).unwrap();
+    let JournalEntry::Free(entry) = &batch.batch[0] else {
+        panic!("expected free journal entry");
+    };
+    assert_eq!(entry.op_id, 10);
+    assert_eq!(entry.path, "/free");
+    assert!(!entry.recursive);
+    let JournalEntry::UfsApplied(entry) = &batch.batch[1] else {
+        panic!("expected ufs applied journal entry");
+    };
+    assert_eq!(entry.index, 15);
 }
 
 #[test]


### PR DESCRIPTION
# Summary

Restores Master startup when replaying historical Journal batches that mix legacy `RenameEntry` with either current or pre-#721 `FreeEntry` layouts. The compatibility layer now covers both schema generations without changing current Journal encoding.

# Issue Describe / Design

Related to #721 and #1474.

Root cause: bincode decodes struct fields positionally. #1474 added a legacy decoder for `RenameEntry`, but historical batches span two `FreeEntry` layouts: pre-#721 records omit `recursive`, while later records retain it. One legacy enum cannot decode both. A persistent Master recovered its checkpoint at index `8352274`, replayed to the batch beginning at `8465162`, then failed with `invalid u8 while decoding bool, found 15`.

Reproduction: serialize (1) legacy Rename plus current recursive Free, and (2) legacy Rename plus pre-#721 Free followed by `UfsApplied`, then call `JournalBatch::deserialize_compat`.

Fix approach: try schemas in chronological order: current; legacy Rename with current Free; legacy Rename with pre-#721 Free. The current schema always takes precedence, legacy decoding still requires full byte consumption, and old Free records map to `recursive: false`, the behavior before #721.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-master/src/master/journal/entry.rs` | Add distinct decoders for legacy Rename/current Free and legacy Rename/pre-recursive Free. | Historical Journal batches replay; current encoding and replay are unchanged. |
| `curvine-master/src/master/journal/tests/journal_entry_compat_test.rs` | Cover current Free, mixed historical schemas, pre-#721 Free, existing Rename compatibility, and trailing-byte rejection. | Regression protection only. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-master journal_entry_compat -- --test-threads=1` | PASS | 6 passed. |
| `cargo fmt --check` | PASS | |
| `cargo clippy -p curvine-master --all-targets -- -D warnings` | PASS | |
| `git diff --check` | PASS | |

# Dependencies

- Related PRs: #721, #1474
- Related issues: None
- Blocks / blocked by: Master recovery deployment using this image
