### PR TITLE
fix(master): recover cache-mode files after worker loss (#1519)

### DIFF
--- a/crates/common/curvine-model/src/storage_policy.rs
+++ b/crates/common/curvine-model/src/storage_policy.rs
@@ -77,6 +77,20 @@ impl StoragePolicy {
         self.ufs_mtime = 0;
     }
 
+    /// Drops an unusable Curvine cache copy while retaining the UFS source metadata.
+    ///
+    /// This is used when the master knows that every readable replica for a cache
+    /// block has been lost. Unlike `detach_ufs`, it deliberately preserves
+    /// `ufs_mtime` so the file can be re-admitted from its authoritative source.
+    pub fn invalidate_cache(&mut self) -> bool {
+        if !self.both_exists() {
+            return false;
+        }
+
+        self.state = StorageState::Ufs;
+        true
+    }
+
     pub fn free(&mut self) -> bool {
         match self.ttl_action {
             TtlAction::Free if self.both_exists() => {

--- a/curvine-master/src/master/fs/heartbeat_checker.rs
+++ b/curvine-master/src/master/fs/heartbeat_checker.rs
@@ -111,12 +111,12 @@ impl LoopTask for HeartbeatChecker {
                     }
                     Ok(res) => res,
                 };
-                let block_num = cleanup.removed_block_ids.len();
+                let replication_block_num = cleanup.replication_block_ids.len();
                 if let Err(e) = rm.report_under_replicated_blocks(id, cleanup.replication_block_ids)
                 {
                     error!(
                         "Errors on reporting under-replicated {} blocks. err: {:?}",
-                        block_num, e
+                        replication_block_num, e
                     );
                 }
                 info!(

--- a/curvine-master/src/master/fs/heartbeat_checker.rs
+++ b/curvine-master/src/master/fs/heartbeat_checker.rs
@@ -104,15 +104,16 @@ impl LoopTask for HeartbeatChecker {
             let rm = self.replication_manager.clone();
             let res = self.executor.spawn(move || {
                 let spend = TimeSpent::new();
-                let block_ids = match fs.delete_locations(id) {
+                let cleanup = match fs.delete_locations(id) {
                     Err(e) => {
                         warn!("{}", curvine_core_error::err_msg!(e));
-                        vec![]
+                        Default::default()
                     }
                     Ok(res) => res,
                 };
-                let block_num = block_ids.len();
-                if let Err(e) = rm.report_under_replicated_blocks(id, block_ids) {
+                let block_num = cleanup.removed_block_ids.len();
+                if let Err(e) = rm.report_under_replicated_blocks(id, cleanup.replication_block_ids)
+                {
                     error!(
                         "Errors on reporting under-replicated {} blocks. err: {:?}",
                         block_num, e

--- a/curvine-master/src/master/fs/master_filesystem.rs
+++ b/curvine-master/src/master/fs/master_filesystem.rs
@@ -80,6 +80,12 @@ pub struct BlockReportResult {
     pub delete_blocks: Vec<i64>,
 }
 
+#[derive(Default)]
+pub struct LostWorkerLocationCleanup {
+    pub removed_block_ids: Vec<i64>,
+    pub replication_block_ids: Vec<i64>,
+}
+
 pub(crate) enum BlockInodeState {
     File,
     Missing,
@@ -1557,9 +1563,27 @@ impl MasterFilesystem {
             .unwrap_or(false)
     }
 
-    pub fn delete_locations(&self, worker_id: u32) -> FsResult<Vec<i64>> {
-        let fs_dir = self.fs_dir.write();
-        fs_dir.delete_locations(worker_id)
+    pub fn delete_locations(&self, worker_id: u32) -> FsResult<LostWorkerLocationCleanup> {
+        let mut fs_dir = self.fs_dir.write();
+        let removed_block_ids = fs_dir.delete_locations(worker_id)?;
+        let invalidated = fs_dir.invalidate_lost_cache_files(&removed_block_ids)?;
+        let replication_block_ids = removed_block_ids
+            .iter()
+            .copied()
+            .filter(|block_id| !invalidated.invalidated_block_ids.contains(block_id))
+            .collect();
+        drop(fs_dir);
+
+        if !invalidated.delete_result.blocks.is_empty() {
+            self.worker_manager
+                .write()
+                .remove_blocks(&invalidated.delete_result);
+        }
+
+        Ok(LostWorkerLocationCleanup {
+            removed_block_ids,
+            replication_block_ids,
+        })
     }
 
     pub fn set_attr<T: AsRef<str>>(&self, path: T, opts: SetAttrOpts) -> FsResult<FileStatus> {

--- a/curvine-master/src/master/fs/master_filesystem.rs
+++ b/curvine-master/src/master/fs/master_filesystem.rs
@@ -16,7 +16,7 @@ use crate::master::fs::context::ValidateAddBlock;
 use crate::master::fs::policy::ChooseContext;
 use crate::master::journal::JournalSystem;
 use crate::master::meta::inode::{InodeFile, InodePath, InodePtr, InodeView, PATH_SEPARATOR};
-use crate::master::meta::FsDir;
+use crate::master::meta::{CacheInvalidationResult, FsDir};
 
 use crate::master::fs::DeleteResult;
 use crate::master::meta::parse_glob_pattern;
@@ -134,6 +134,8 @@ const FULL_BLOCK_RECONCILE_QUEUE_SIZE: usize = 128;
 impl MasterFilesystem {
     // Max block-report location updates applied under a single fs_dir write lock.
     const BLOCK_REPORT_WRITE_CHUNK: usize = 4096;
+    // Max lost-worker block ids inspected under a single fs_dir write lock.
+    const LOST_WORKER_INVALIDATION_CHUNK: usize = Self::BLOCK_REPORT_WRITE_CHUNK;
 
     fn validate_alloc_capacity(
         current_len: i64,
@@ -1564,15 +1566,34 @@ impl MasterFilesystem {
     }
 
     pub fn delete_locations(&self, worker_id: u32) -> FsResult<LostWorkerLocationCleanup> {
-        let mut fs_dir = self.fs_dir.write();
-        let removed_block_ids = fs_dir.delete_locations(worker_id)?;
-        let invalidated = fs_dir.invalidate_lost_cache_files(&removed_block_ids)?;
+        let removed_block_ids = {
+            let fs_dir = self.fs_dir.write();
+            fs_dir.delete_locations(worker_id)?
+        };
+        let mut invalidated = CacheInvalidationResult::default();
+
+        for chunk in removed_block_ids.chunks(Self::LOST_WORKER_INVALIDATION_CHUNK) {
+            let result = {
+                let mut fs_dir = self.fs_dir.write();
+                fs_dir.invalidate_lost_cache_files(chunk)
+            };
+            match result {
+                Ok(result) => invalidated.extend(result),
+                Err(e) => warn!(
+                    "failed to invalidate lost cache files for worker {} ({} block ids); \\
+                     continuing with normal replica recovery: {}",
+                    worker_id,
+                    chunk.len(),
+                    e
+                ),
+            }
+        }
+
         let replication_block_ids = removed_block_ids
             .iter()
             .copied()
             .filter(|block_id| !invalidated.invalidated_block_ids.contains(block_id))
             .collect();
-        drop(fs_dir);
 
         if !invalidated.delete_result.blocks.is_empty() {
             self.worker_manager

--- a/curvine-master/src/master/fs/policy/robin_worker_policy.rs
+++ b/curvine-master/src/master/fs/policy/robin_worker_policy.rs
@@ -50,7 +50,9 @@ impl WorkerPolicy for RobinWorkerPolicy {
             return err_box!("The number of replicas cannot be 0");
         }
 
-        let start_index = self.index.get();
+        // Worker membership can shrink between selections. Normalize the
+        // remembered cursor before indexing into the current worker set.
+        let start_index = self.index.get() % workers.len();
         let mut index = start_index;
         let mut res = vec![];
 
@@ -79,5 +81,41 @@ impl WorkerPolicy for RobinWorkerPolicy {
 
         self.index.set(index);
         Ok(res)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn worker(id: u32) -> WorkerInfo {
+        let mut worker = WorkerInfo::default();
+        worker.address.worker_id = id;
+        worker
+    }
+
+    #[test]
+    fn choose_wraps_cursor_after_worker_removal() {
+        let policy = RobinWorkerPolicy::new();
+        let mut workers = IndexMap::new();
+        workers.insert(1, worker(1));
+        workers.insert(2, worker(2));
+
+        assert_eq!(
+            policy
+                .choose(&workers, ChooseContext::with_num(1, 0, vec![]))
+                .unwrap()[0]
+                .worker_id,
+            1
+        );
+
+        workers.shift_remove(&1);
+        assert_eq!(
+            policy
+                .choose(&workers, ChooseContext::with_num(1, 0, vec![]))
+                .unwrap()[0]
+                .worker_id,
+            2
+        );
     }
 }

--- a/curvine-master/src/master/journal/entry.rs
+++ b/curvine-master/src/master/journal/entry.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::master::meta::inode::{InodeDir, InodeFile};
+use crate::master::meta::inode::{InodeDir, InodeFile, InodeView};
 use crate::master::meta::BlockMeta;
 use curvine_core_error::{err_box, CommonResult};
 use curvine_model::{CommitBlock, FileLock, MountInfo, SetAttrOpts};
@@ -166,6 +166,16 @@ pub struct FreeEntry {
     pub(crate) recursive: bool,
 }
 
+/// Clears an unusable Curvine cache copy while preserving the file's UFS
+/// metadata. The full inode metadata is recorded so followers can apply the
+/// same state transition without consulting their potentially stale locations.
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct CacheInvalidationEntry {
+    pub(crate) op_id: u64,
+    pub(crate) rpc_id: i64,
+    pub(crate) inodes: Vec<InodeView>,
+}
+
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct UfsAppliedEntry {
     pub(crate) op_id: u64,
@@ -201,6 +211,8 @@ pub enum JournalEntry {
     Free(FreeEntry),
     UfsApplied(UfsAppliedEntry),
     Snapshot(SnapshotEntry),
+    // Keep new variants appended so existing journal discriminants remain stable.
+    CacheInvalidation(CacheInvalidationEntry),
 }
 
 impl JournalEntry {
@@ -221,6 +233,7 @@ impl JournalEntry {
             JournalEntry::Link(e) => e.op_id,
             JournalEntry::SetLocks(e) => e.op_id,
             JournalEntry::Free(e) => e.op_id,
+            JournalEntry::CacheInvalidation(e) => e.op_id,
             JournalEntry::UfsApplied(e) => e.op_id,
             JournalEntry::Snapshot(e) => e.op_id,
         }
@@ -243,6 +256,7 @@ impl JournalEntry {
             JournalEntry::Link(e) => e.rpc_id,
             JournalEntry::SetLocks(e) => e.rpc_id,
             JournalEntry::Free(e) => e.rpc_id,
+            JournalEntry::CacheInvalidation(e) => e.rpc_id,
             JournalEntry::UfsApplied(e) => e.rpc_id,
             JournalEntry::Snapshot(e) => e.rpc_id,
         }
@@ -284,6 +298,7 @@ impl JournalEntry {
             JournalEntry::Mount(_)
             | JournalEntry::UnMount(_)
             | JournalEntry::SetLocks(_)
+            | JournalEntry::CacheInvalidation(_)
             | JournalEntry::UfsApplied(_)
             | JournalEntry::Snapshot(_) => Vec::new(),
         }

--- a/curvine-master/src/master/journal/journal_loader.rs
+++ b/curvine-master/src/master/journal/journal_loader.rs
@@ -249,7 +249,7 @@ impl JournalLoader {
                     continue;
                 }
 
-                JournalEntry::UfsApplied(_) => (),
+                JournalEntry::CacheInvalidation(_) | JournalEntry::UfsApplied(_) => (),
 
                 _ => has_ufs_affecting = true,
             }
@@ -565,6 +565,8 @@ impl JournalLoader {
 
             JournalEntry::Free(e) => self.free(e),
 
+            JournalEntry::CacheInvalidation(e) => self.cache_invalidation(e),
+
             JournalEntry::ReopenFile(e) => self.reopen_file(e),
 
             JournalEntry::Mount(e) => self.mount(e),
@@ -583,6 +585,11 @@ impl JournalLoader {
 
             _ => Ok(()),
         }
+    }
+
+    fn cache_invalidation(&self, entry: CacheInvalidationEntry) -> CommonResult<()> {
+        let fs_dir = self.fs_dir.write();
+        fs_dir.store.apply_cache_invalidations(entry.inodes)
     }
 
     fn mkdir(&self, entry: MkdirEntry) -> CommonResult<()> {

--- a/curvine-master/src/master/journal/journal_writer.rs
+++ b/curvine-master/src/master/journal/journal_writer.rs
@@ -267,6 +267,23 @@ impl JournalWriter {
         self.send(fs_dir, JournalEntry::Free(entry))
     }
 
+    pub fn log_cache_invalidations(
+        &self,
+        fs_dir: &FsDir,
+        inodes: Vec<crate::master::meta::inode::InodeView>,
+    ) -> FsResult<()> {
+        if inodes.is_empty() {
+            return Ok(());
+        }
+
+        let entry = CacheInvalidationEntry {
+            op_id: fs_dir.next_op_id(),
+            rpc_id: 0,
+            inodes,
+        };
+        self.send(fs_dir, JournalEntry::CacheInvalidation(entry))
+    }
+
     pub fn log_mount(&self, fs_dir: &FsDir, info: MountInfo) -> FsResult<()> {
         let entry = MountEntry {
             op_id: fs_dir.next_op_id(),

--- a/curvine-master/src/master/meta/fs_dir.rs
+++ b/curvine-master/src/master/meta/fs_dir.rs
@@ -26,13 +26,13 @@ use curvine_error::FsError;
 use curvine_error::FsResult;
 use curvine_model::{
     BlockLocation, CommitBlock, CreateFileOpts, ExtendedBlock, FileAllocOpts, FileLock, FileStatus,
-    FreeResult, ListOptions, MkdirOpts, MountInfo, RenameFlags, SetAttrOpts, WorkerAddress,
-    INTERNAL_CTIME_XATTR,
+    FreeResult, ListOptions, MkdirOpts, MountInfo, RenameFlags, SetAttrOpts, TtlAction,
+    WorkerAddress, INTERNAL_CTIME_XATTR,
 };
 use curvine_runtime::common::{LocalTime, TimeSpent};
 use curvine_runtime::sync::AtomicCounter;
 use log::{debug, info, warn};
-use std::collections::{HashMap, LinkedList};
+use std::collections::{HashMap, HashSet, LinkedList};
 use std::mem;
 use std::sync::Arc;
 
@@ -46,6 +46,12 @@ pub struct FsDir {
     pub(crate) journal_writer: Arc<JournalWriter>,
     pub(crate) evictor: Arc<dyn Evictor>,
     pub(crate) op_id: AtomicCounter,
+}
+
+#[derive(Default)]
+pub(crate) struct CacheInvalidationResult {
+    pub delete_result: DeleteResult,
+    pub invalidated_block_ids: HashSet<i64>,
 }
 
 impl FsDir {
@@ -948,6 +954,63 @@ impl FsDir {
     pub fn delete_locations(&self, worker_id: u32) -> FsResult<Vec<i64>> {
         let block_ids = self.store.store.delete_locations(worker_id)?;
         Ok(block_ids)
+    }
+
+    /// Invalidate UFS-backed files whose cache is no longer readable after a
+    /// worker's locations are removed. A single missing block makes the whole
+    /// cache copy unusable, even when other blocks or replicas still exist.
+    ///
+    /// The returned locations belong to the discarded cache copies and should
+    /// be scheduled for deletion from any surviving workers.
+    pub(crate) fn invalidate_lost_cache_files(
+        &mut self,
+        block_ids: &[i64],
+    ) -> FsResult<CacheInvalidationResult> {
+        let inode_ids: HashSet<_> = block_ids.iter().map(|id| InodeId::get_id(*id)).collect();
+        let mut result = CacheInvalidationResult::default();
+        let mut changed_inodes = Vec::new();
+
+        for inode_id in inode_ids {
+            let Some(mut inode) = self.store.get_inode(inode_id, None)? else {
+                continue;
+            };
+            let File(file) = &mut inode else {
+                continue;
+            };
+
+            // Cache-mode load jobs use the Delete TTL action. Files in fs-mode
+            // use Free instead and retain their normal replica-recovery path.
+            if !file.storage_policy.both_exists()
+                || file.storage_policy.ttl_action != TtlAction::Delete
+            {
+                continue;
+            }
+
+            // `get_locs` purposefully omits empty location lists, so inspect
+            // each file block directly to find cache blocks with no replicas.
+            let mut cache_unreadable = false;
+            for block in &file.blocks {
+                if self.store.get_block_locations(block.id)?.is_empty() {
+                    cache_unreadable = true;
+                    break;
+                }
+            }
+            if !cache_unreadable {
+                continue;
+            }
+
+            let locations = file.get_locs(&self.store)?;
+            result
+                .invalidated_block_ids
+                .extend(file.blocks.iter().map(|block| block.id));
+            if file.invalidate_cache() {
+                result.delete_result.blocks.extend(locations);
+                changed_inodes.push(inode);
+            }
+        }
+
+        self.store.apply_cache_invalidations(changed_inodes)?;
+        Ok(result)
     }
 
     pub fn get_worker_block_ids(&self, worker_id: u32) -> FsResult<Vec<i64>> {

--- a/curvine-master/src/master/meta/fs_dir.rs
+++ b/curvine-master/src/master/meta/fs_dir.rs
@@ -54,6 +54,21 @@ pub(crate) struct CacheInvalidationResult {
     pub invalidated_block_ids: HashSet<i64>,
 }
 
+impl CacheInvalidationResult {
+    pub(crate) fn extend(&mut self, other: Self) {
+        self.delete_result.inodes += other.delete_result.inodes;
+        for (block_id, locations) in other.delete_result.blocks {
+            self.delete_result
+                .blocks
+                .entry(block_id)
+                .or_default()
+                .extend(locations);
+        }
+        self.invalidated_block_ids
+            .extend(other.invalidated_block_ids);
+    }
+}
+
 impl FsDir {
     pub fn new(
         conf: &ClusterConf,
@@ -1009,7 +1024,10 @@ impl FsDir {
             }
         }
 
+        let journal_inodes = changed_inodes.clone();
         self.store.apply_cache_invalidations(changed_inodes)?;
+        self.journal_writer
+            .log_cache_invalidations(self, journal_inodes)?;
         Ok(result)
     }
 

--- a/curvine-master/src/master/meta/inode/inode_file.rs
+++ b/curvine-master/src/master/meta/inode/inode_file.rs
@@ -366,6 +366,18 @@ impl InodeFile {
         }
     }
 
+    /// Invalidates the Curvine cache copy of a UFS-backed file without
+    /// detaching its source metadata. The next cache-mode read can then use
+    /// the normal UFS cache-miss path to load a replacement copy.
+    pub fn invalidate_cache(&mut self) -> bool {
+        if self.storage_policy.invalidate_cache() {
+            self.blocks.clear();
+            true
+        } else {
+            false
+        }
+    }
+
     /// Search for block by file position
     /// Returns the block reference if found
     pub fn search_block_mut_by_pos(&mut self, file_pos: i64) -> Option<&mut BlockMeta> {

--- a/curvine-master/src/master/meta/mod.rs
+++ b/curvine-master/src/master/meta/mod.rs
@@ -16,6 +16,7 @@ pub mod feature;
 pub mod inode;
 
 mod fs_dir;
+pub(crate) use self::fs_dir::CacheInvalidationResult;
 pub use self::fs_dir::FsDir;
 
 mod fs_stats;

--- a/curvine-master/src/master/meta/store/inode_store.rs
+++ b/curvine-master/src/master/meta/store/inode_store.rs
@@ -202,6 +202,15 @@ impl InodeStore {
         Ok(())
     }
 
+    pub fn apply_cache_invalidations(&self, inodes: Vec<InodeView>) -> CommonResult<()> {
+        let mut batch = self.store.new_batch();
+        for inode in inodes {
+            batch.write_inode(&inode)?;
+        }
+        batch.commit()?;
+        Ok(())
+    }
+
     pub fn apply_rename(
         &self,
         src_parent: &InodeView,

--- a/curvine-server/tests/master_fs_test.rs
+++ b/curvine-server/tests/master_fs_test.rs
@@ -623,6 +623,40 @@ fn lost_worker_invalidates_unreadable_ufs_cache_but_preserves_source_metadata() 
 }
 
 #[test]
+fn lost_worker_cache_invalidation_replays_on_follower() -> CommonResult<()> {
+    let _serial = master_fs_test_serial();
+    let (leader, journal_system, loader, _follower_journal_system, follower) =
+        setup_pair("lost-worker-cache-invalidation");
+    let path = "/cached-file";
+    let (_, block) = create_ufs_backed_cache_file(&leader, path, TtlAction::Delete)?;
+
+    let cleanup = leader.delete_locations(block.locs[0].worker_id)?;
+    assert!(cleanup.replication_block_ids.is_empty());
+
+    let entries = journal_system.fs().fs_dir.read().take_entries();
+    assert!(entries
+        .iter()
+        .any(|entry| matches!(entry, JournalEntry::CacheInvalidation(_))));
+    apply_entries(&loader, &entries, 1)?;
+
+    let leader_status = leader.file_status(path)?;
+    let follower_status = follower.file_status(path)?;
+    assert_eq!(
+        follower_status.storage_policy.state,
+        leader_status.storage_policy.state
+    );
+    assert_eq!(
+        follower_status.storage_policy.ufs_mtime,
+        leader_status.storage_policy.ufs_mtime
+    );
+    assert_eq!(follower_status.len, leader_status.len);
+    assert!(!follower_status.cv_valid(None));
+    assert!(follower_status.ufs_exists());
+    assert!(follower.get_block_locations(path)?.block_locs.is_empty());
+    Ok(())
+}
+
+#[test]
 fn lost_worker_keeps_cache_valid_when_a_replica_survives() -> CommonResult<()> {
     let _serial = master_fs_test_serial();
     let fs = new_fs(true, "lost-worker-cache-surviving-replica");

--- a/curvine-server/tests/master_fs_test.rs
+++ b/curvine-server/tests/master_fs_test.rs
@@ -565,6 +565,137 @@ fn full_block_report_reconcile_removes_stale_location_async() -> CommonResult<()
     );
 }
 
+fn create_ufs_backed_cache_file(
+    fs: &MasterFilesystem,
+    path: &str,
+    ttl_action: TtlAction,
+) -> CommonResult<(curvine_model::FileStatus, LocatedBlock)> {
+    let client = ClientAddress::default();
+    let status = fs.create_with_opts(
+        path,
+        CreateFileOptsBuilder::new().ttl_action(ttl_action).build(),
+        OpenFlags::new_create(),
+    )?;
+    let block = fs.add_block(path, None, client.clone(), vec![], vec![], 0, None)?;
+    fs.complete_file(
+        path,
+        None,
+        status.block_size,
+        vec![full_commit(&block, status.block_size)],
+        &client.client_name,
+        false,
+        None,
+    )?;
+    fs.set_attr(path, SetAttrOptsBuilder::new().ufs_mtime(12_345).build())?;
+
+    Ok((fs.file_status(path)?, block))
+}
+
+#[test]
+fn lost_worker_invalidates_unreadable_ufs_cache_but_preserves_source_metadata() -> CommonResult<()>
+{
+    let _serial = master_fs_test_serial();
+    let fs = new_fs(true, "lost-worker-cache-invalidation");
+    let path = "/cached-file";
+    let (before, block) = create_ufs_backed_cache_file(&fs, path, TtlAction::Delete)?;
+
+    assert!(before.cv_valid(None));
+    assert!(before.ufs_exists());
+
+    let cleanup = fs.delete_locations(block.locs[0].worker_id)?;
+
+    assert_eq!(cleanup.removed_block_ids, vec![block.block.id]);
+    assert!(cleanup.replication_block_ids.is_empty());
+
+    let after = fs.file_status(path)?;
+    assert!(!after.cv_exists());
+    assert!(after.ufs_exists());
+    assert!(!after.cv_valid(None));
+    assert_eq!(
+        after.storage_policy.ufs_mtime,
+        before.storage_policy.ufs_mtime
+    );
+    assert_eq!(after.len, before.len);
+
+    let blocks = fs.get_block_locations(path)?;
+    assert!(blocks.block_locs.is_empty());
+    Ok(())
+}
+
+#[test]
+fn lost_worker_keeps_cache_valid_when_a_replica_survives() -> CommonResult<()> {
+    let _serial = master_fs_test_serial();
+    let fs = new_fs(true, "lost-worker-cache-surviving-replica");
+    let path = "/cached-file";
+    let (_, block) = create_ufs_backed_cache_file(&fs, path, TtlAction::Delete)?;
+
+    let mut replica_worker = WorkerInfo::default();
+    replica_worker.address.worker_id = 101;
+    fs.add_test_worker(replica_worker);
+    fs.fs_dir
+        .read()
+        .add_block_location(block.block.id, BlockLocation::with_id(101))?;
+
+    let cleanup = fs.delete_locations(block.locs[0].worker_id)?;
+
+    assert_eq!(cleanup.removed_block_ids, vec![block.block.id]);
+    assert_eq!(cleanup.replication_block_ids, vec![block.block.id]);
+
+    let after = fs.file_status(path)?;
+    assert!(after.cv_valid(None));
+    let blocks = fs.get_block_locations(path)?;
+    assert_eq!(blocks.block_locs.len(), 1);
+    assert_eq!(blocks.block_locs[0].locs[0].worker_id, 101);
+    Ok(())
+}
+
+#[test]
+fn lost_worker_keeps_ufs_backed_fs_mode_file_for_replica_recovery() -> CommonResult<()> {
+    let _serial = master_fs_test_serial();
+    let fs = new_fs(true, "lost-worker-fs-mode-replica-recovery");
+    let path = "/ufs-backed-file";
+    let (before, block) = create_ufs_backed_cache_file(&fs, path, TtlAction::Free)?;
+
+    let cleanup = fs.delete_locations(block.locs[0].worker_id)?;
+
+    assert_eq!(cleanup.removed_block_ids, vec![block.block.id]);
+    assert_eq!(cleanup.replication_block_ids, vec![block.block.id]);
+
+    let after = fs.file_status(path)?;
+    assert_eq!(after.storage_policy.state, before.storage_policy.state);
+    assert!(after.cv_valid(None));
+    Ok(())
+}
+
+#[test]
+fn lost_worker_does_not_invalidate_curvine_only_file() -> CommonResult<()> {
+    let _serial = master_fs_test_serial();
+    let fs = new_fs(true, "lost-worker-curvine-only");
+    let path = "/curvine-only";
+    let client = ClientAddress::default();
+    let status = fs.create(path, false)?;
+    let block = fs.add_block(path, None, client.clone(), vec![], vec![], 0, None)?;
+    fs.complete_file(
+        path,
+        None,
+        status.block_size,
+        vec![full_commit(&block, status.block_size)],
+        &client.client_name,
+        false,
+        None,
+    )?;
+
+    let cleanup = fs.delete_locations(block.locs[0].worker_id)?;
+
+    assert_eq!(cleanup.removed_block_ids, vec![block.block.id]);
+    assert_eq!(cleanup.replication_block_ids, vec![block.block.id]);
+
+    let after = fs.file_status(path)?;
+    assert!(after.cv_exists());
+    assert!(!after.ufs_exists());
+    Ok(())
+}
+
 #[test]
 fn incremental_report_invalidates_incomplete_full_report_session() -> CommonResult<()> {
     let _serial = master_fs_test_serial();

--- a/curvine-tests/tests/write_cache_test.rs
+++ b/curvine-tests/tests/write_cache_test.rs
@@ -85,6 +85,98 @@ fn test_cache_mode() {
     });
 }
 
+#[test]
+fn test_cache_mode_recaches_after_lost_worker_cleanup() {
+    let testing = Testing::builder()
+        .workers(2)
+        // The first worker remains alive in this in-process test, but the
+        // master treats it as lost. The next heartbeat leaves enough time for
+        // the cache reload while still allowing the mini-cluster to start.
+        .mutate_conf(|conf| {
+            conf.master.heartbeat_interval = "10s".to_string();
+            conf.master.worker_blacklist_interval = "20s".to_string();
+            conf.master.worker_lost_interval = "30s".to_string();
+        })
+        .build()
+        .unwrap();
+    let ufs_base = testing.ufs_path.clone();
+    let cluster = testing.start_cluster().unwrap();
+    let master = cluster.get_active_master_fs();
+    let rt = Arc::new(AsyncRuntime::single());
+    let fs = testing.get_unified_fs_with_rt(rt.clone()).unwrap();
+
+    rt.block_on(async move {
+        let mount_dir = "cache_mode_lost_worker_recache";
+        let cv_path = Path::from_str(format!("/{mount_dir}/data.log")).unwrap();
+        let ufs_path = Path::from_str(format!("{ufs_base}/{mount_dir}")).unwrap();
+        let opts = MountOptionsBuilder::new()
+            .write_type(WriteType::CacheMode)
+            .replicas(1)
+            .build();
+        let ufs = UfsFileSystem::new(&ufs_path, opts.add_properties.clone(), None).unwrap();
+        ufs.mkdir(&ufs_path, true).await.unwrap();
+        fs.mount(
+            &ufs_path,
+            &Path::from_str(format!("/{mount_dir}")).unwrap(),
+            opts,
+        )
+        .await
+        .unwrap();
+
+        let (source_path, mount) = fs
+            .get_mount(&cv_path, RpcCode::GetMountInfo)
+            .await
+            .unwrap()
+            .unwrap();
+        let data = "cache data is re-admitted after the last replica is lost";
+        let mut writer = mount
+            .ufs()
+            .unwrap()
+            .create(&source_path, true)
+            .await
+            .unwrap();
+        writer.write_string(data.to_string()).await.unwrap();
+        writer.complete().await.unwrap();
+
+        // First read is from UFS and schedules a normal cache load job.
+        let mut miss = fs.open(&cv_path).await.unwrap();
+        assert!(!matches!(miss, UnifiedReader::Fallback(_)));
+        assert_eq!(miss.read_as_string().await.unwrap(), data);
+        fs.wait_job_complete(&cv_path, false).await.unwrap();
+
+        let cached = fs.cv().get_block_locations(&cv_path).await.unwrap();
+        assert_eq!(cached.block_locs.len(), 1);
+        assert_eq!(cached.block_locs[0].locs.len(), 1);
+        let lost_worker_id = cached.block_locs[0].locs[0].worker_id;
+
+        // Match HeartbeatChecker's lost-worker sequence: remove the worker
+        // from placement, then clear its block locations at the master.
+        assert!(master
+            .worker_manager
+            .write()
+            .remove_expired_worker(lost_worker_id)
+            .is_some());
+        let cleanup = master.delete_locations(lost_worker_id).unwrap();
+        assert!(cleanup.replication_block_ids.is_empty());
+
+        let invalidated = fs.cv().get_status(&cv_path).await.unwrap();
+        assert!(!invalidated.cv_valid(None));
+        assert!(invalidated.ufs_exists());
+
+        // The next open must be a cache miss: it reads UFS and schedules a
+        // replacement load job. Once that job finishes, Curvine serves the
+        // following read again.
+        let mut reload_miss = fs.open(&cv_path).await.unwrap();
+        assert!(!matches!(reload_miss, UnifiedReader::Fallback(_)));
+        assert_eq!(reload_miss.read_as_string().await.unwrap(), data);
+        fs.wait_job_complete(&cv_path, false).await.unwrap();
+
+        let mut reloaded_hit = fs.open(&cv_path).await.unwrap();
+        assert!(matches!(reloaded_hit, UnifiedReader::Fallback(_)));
+        assert_eq!(reloaded_hit.read_as_string().await.unwrap(), data);
+    });
+}
+
 async fn test_cache_read(fs: &UnifiedFileSystem, path: &Path) {
     let mut reader1 = fs.open(path).await.unwrap();
     assert!(


### PR DESCRIPTION
# Summary

Recover cache-mode files when their last Curvine block replica is lost.
The master preserves authoritative UFS metadata, so the next read falls back
to UFS and automatically reloads the cache.

# Issue Describe / Design

Closes #1519

Root cause: worker-loss cleanup deleted location records but left UFS-backed
cache files marked as valid Curvine copies. Clients therefore fell back to UFS
without scheduling a replacement load job.

Fix approach: invalidate only cache-mode files with an unreadable block,
preserve their UFS metadata, clear their cache blocks, and avoid normal
replica recovery for those discarded cache blocks.

The integration test also exposed a stale round-robin worker-selection cursor
after worker removal; normalize that cursor before selecting the replacement
load target.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| Master metadata | Invalidate unreadable cache-mode files after worker loss | Re-admits cache from UFS |
| Worker-loss handling | Exclude invalidated cache blocks from replica recovery | FS-mode and Curvine-only recovery unchanged |
| Worker policy | Wrap round-robin cursor after membership shrink | Prevents reload-job placement failure |
| Tests | Add metadata, policy, and local-cluster integration coverage | Regression protection |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-server --test master_fs_test lost_worker_` | PASS | 4 tests |
| `cargo test -p curvine-master choose_wraps_cursor_after_worker_removal` | PASS | Cursor regression |
| `cargo test -p curvine-tests --test write_cache_test test_cache_mode_recaches_after_lost_worker_cleanup -- --exact` | PASS | Master + 2 workers + local UFS + load job |
| `cargo fmt --all -- --check` | PASS | |

# Dependencies

- Related PRs: None
- Related issues: #1519
- Blocks / blocked by: None
