### PR TITLE
fix(cli): persist creator owner/group for fs-created paths (#1192)

### DIFF
--- a/curvine-cli/src/cmds/fs/common.rs
+++ b/curvine-cli/src/cmds/fs/common.rs
@@ -3,6 +3,14 @@ use curvine_core_error::CommonResult;
 use curvine_fs_api::{CurvineURI, FileSystem};
 use curvine_unified_fs::UnifiedFileSystem;
 
+pub fn current_process_acl(client: &UnifiedFileSystem) -> (u32, u32, u32) {
+    (
+        curvine_sys::get_uid(),
+        curvine_sys::get_gid(),
+        client.conf().client.get_mode(),
+    )
+}
+
 /// Calculates content summary (directory size, file count, directory count) on the client side
 pub async fn calculate_content_summary(
     client: &UnifiedFileSystem,

--- a/curvine-cli/src/cmds/fs/common.rs
+++ b/curvine-cli/src/cmds/fs/common.rs
@@ -3,10 +3,12 @@ use curvine_core_error::CommonResult;
 use curvine_fs_api::{CurvineURI, FileSystem};
 use curvine_unified_fs::UnifiedFileSystem;
 
-pub fn current_process_acl(client: &UnifiedFileSystem) -> (u32, u32, u32) {
+pub(super) fn current_process_acl(client: &UnifiedFileSystem) -> (String, String, u32) {
+    let uid = curvine_sys::get_uid();
+    let gid = curvine_sys::get_gid();
     (
-        curvine_sys::get_uid(),
-        curvine_sys::get_gid(),
+        curvine_sys::get_username_by_uid(uid).unwrap_or_else(|| uid.to_string()),
+        curvine_sys::get_groupname_by_gid(gid).unwrap_or_else(|| gid.to_string()),
         client.conf().client.get_mode(),
     )
 }

--- a/curvine-cli/src/cmds/fs/mkdir.rs
+++ b/curvine-cli/src/cmds/fs/mkdir.rs
@@ -24,10 +24,12 @@ impl MkdirCommand {
             MkdirCommand::Mkdir { path, parents } => {
                 println!("Creating directory: {} (parents: {})", path, parents);
                 let path = CurvineURI::new(path)?;
-                let (uid, gid, mode) = current_process_acl(&client);
+                let (owner, group, mode) = current_process_acl(&client);
                 let opts = MkdirOptsBuilder::with_conf(&client.conf().client)
                     .create_parent(*parents)
-                    .acl(uid, gid, mode)
+                    .owner(owner)
+                    .group(group)
+                    .mode(mode)
                     .build();
                 let _ = client.mkdir_with_opts(&path, opts).await?;
 

--- a/curvine-cli/src/cmds/fs/mkdir.rs
+++ b/curvine-cli/src/cmds/fs/mkdir.rs
@@ -1,8 +1,10 @@
 use clap::Subcommand;
 use curvine_core_error::CommonResult;
-use curvine_fs_api::{CurvineURI, FileSystem};
-use curvine_model::SetAttrOpts;
+use curvine_fs_api::CurvineURI;
+use curvine_model::MkdirOptsBuilder;
 use curvine_unified_fs::UnifiedFileSystem;
+
+use super::common::current_process_acl;
 
 #[derive(Subcommand, Debug)]
 pub enum MkdirCommand {
@@ -22,17 +24,12 @@ impl MkdirCommand {
             MkdirCommand::Mkdir { path, parents } => {
                 println!("Creating directory: {} (parents: {})", path, parents);
                 let path = CurvineURI::new(path)?;
-                let _ = client.mkdir(&path, *parents).await?;
-                let uid = curvine_sys::get_uid();
-                let gid = curvine_sys::get_gid();
-                let owner = curvine_sys::get_username_by_uid(uid);
-                let group = curvine_sys::get_groupname_by_gid(gid);
-                let opts = SetAttrOpts {
-                    owner,
-                    group,
-                    ..Default::default()
-                };
-                client.set_attr(&path, opts).await?;
+                let (uid, gid, mode) = current_process_acl(&client);
+                let opts = MkdirOptsBuilder::with_conf(&client.conf().client)
+                    .create_parent(*parents)
+                    .acl(uid, gid, mode)
+                    .build();
+                let _ = client.mkdir_with_opts(&path, opts).await?;
 
                 println!("Directory created successfully");
                 Ok(())

--- a/curvine-cli/src/cmds/fs/put.rs
+++ b/curvine-cli/src/cmds/fs/put.rs
@@ -112,12 +112,14 @@ impl PutCommand {
                 };
 
                 // Create writer for streaming upload
-                let (uid, gid, mode) = current_process_acl(&client);
+                let (owner, group, mode) = current_process_acl(&client);
                 let opts = client
                     .cv()
                     .create_opts_builder()
                     .create_parent(true)
-                    .acl(uid, gid, mode)
+                    .owner(owner)
+                    .group(group)
+                    .mode(mode)
                     .build();
                 let flags = OpenFlags::new_write_only()
                     .set_create(true)

--- a/curvine-cli/src/cmds/fs/put.rs
+++ b/curvine-cli/src/cmds/fs/put.rs
@@ -1,10 +1,13 @@
 use clap::Subcommand;
 use curvine_core_error::CommonResult;
 use curvine_fs_api::{CurvineURI, FileSystem, Writer};
+use curvine_model::OpenFlags;
 use curvine_unified_fs::UnifiedFileSystem;
 use std::path::PathBuf;
 use tokio::fs;
 use tokio::io::{AsyncReadExt, BufReader};
+
+use super::common::current_process_acl;
 
 #[derive(Subcommand, Debug)]
 pub enum PutCommand {
@@ -109,7 +112,17 @@ impl PutCommand {
                 };
 
                 // Create writer for streaming upload
-                match client.create(&remote_uri, true).await {
+                let (uid, gid, mode) = current_process_acl(&client);
+                let opts = client
+                    .cv()
+                    .create_opts_builder()
+                    .create_parent(true)
+                    .acl(uid, gid, mode)
+                    .build();
+                let flags = OpenFlags::new_write_only()
+                    .set_create(true)
+                    .set_overwrite(true);
+                match client.open_with_opts(&remote_uri, opts, flags).await {
                     Ok(mut writer) => {
                         let chunk_size = client.conf().client.write_chunk_size;
                         let mut buffer = vec![0; chunk_size];

--- a/curvine-cli/src/cmds/fs/touch.rs
+++ b/curvine-cli/src/cmds/fs/touch.rs
@@ -1,7 +1,10 @@
 use clap::Subcommand;
 use curvine_core_error::CommonResult;
 use curvine_fs_api::{CurvineURI, FileSystem, Writer};
+use curvine_model::OpenFlags;
 use curvine_unified_fs::UnifiedFileSystem;
+
+use super::common::current_process_acl;
 
 #[derive(Subcommand, Debug)]
 pub enum TouchCommand {
@@ -27,7 +30,15 @@ impl TouchCommand {
                     }
                     Err(_) => {
                         // File doesn't exist, create an empty file
-                        match client.create(&path, false).await {
+                        let (uid, gid, mode) = current_process_acl(&client);
+                        let opts = client
+                            .cv()
+                            .create_opts_builder()
+                            .create_parent(true)
+                            .acl(uid, gid, mode)
+                            .build();
+                        let flags = OpenFlags::new_write_only().set_create(true);
+                        match client.open_with_opts(&path, opts, flags).await {
                             Ok(mut writer) => {
                                 // Complete the write to create an empty file
                                 if let Err(e) = writer.complete().await {

--- a/curvine-cli/src/cmds/fs/touch.rs
+++ b/curvine-cli/src/cmds/fs/touch.rs
@@ -30,12 +30,14 @@ impl TouchCommand {
                     }
                     Err(_) => {
                         // File doesn't exist, create an empty file
-                        let (uid, gid, mode) = current_process_acl(&client);
+                        let (owner, group, mode) = current_process_acl(&client);
                         let opts = client
                             .cv()
                             .create_opts_builder()
                             .create_parent(true)
-                            .acl(uid, gid, mode)
+                            .owner(owner)
+                            .group(group)
+                            .mode(mode)
                             .build();
                         let flags = OpenFlags::new_write_only().set_create(true);
                         match client.open_with_opts(&path, opts, flags).await {

--- a/curvine-server/tests/master_fs_test.rs
+++ b/curvine-server/tests/master_fs_test.rs
@@ -950,6 +950,55 @@ fn create_file_inherits_setgid_parent_group() -> CommonResult<()> {
     Ok(())
 }
 
+#[test]
+fn mkdir_recursive_parents_persist_owner_group() -> CommonResult<()> {
+    let _serial = master_fs_test_serial();
+    let fs = new_fs(true, "mkdir-recursive-owner-group");
+
+    let opts = MkdirOptsBuilder::new()
+        .create_parent(true)
+        .owner("cli-owner".to_string())
+        .group("cli-group".to_string())
+        .build();
+    fs.mkdir_with_opts("/owner/parent/child", opts)?;
+
+    for path in ["/owner", "/owner/parent", "/owner/parent/child"] {
+        let status = fs.file_status(path)?;
+        assert_eq!("cli-owner", status.owner);
+        assert_eq!("cli-group", status.group);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn create_file_recursive_parents_persist_owner_group() -> CommonResult<()> {
+    let _serial = master_fs_test_serial();
+    let fs = new_fs(true, "create-file-recursive-owner-group");
+
+    let opts = CreateFileOptsBuilder::new()
+        .create_parent(true)
+        .owner("cli-owner".to_string())
+        .group("cli-group".to_string())
+        .build();
+    fs.create_with_opts(
+        "/owner/parent/file",
+        opts,
+        OpenFlags::new_create().set_overwrite(true),
+    )?;
+
+    for path in ["/owner", "/owner/parent"] {
+        let status = fs.file_status(path)?;
+        assert_eq!("cli-owner", status.owner);
+        assert_eq!("cli-group", status.group);
+    }
+    let file_status = fs.file_status("/owner/parent/file")?;
+    assert_eq!("cli-owner", file_status.owner);
+    assert_eq!("cli-group", file_status.group);
+
+    Ok(())
+}
+
 fn delete(fs: &MasterFilesystem) -> CommonResult<()> {
     let res1 = fs.delete("/a", false);
     assert!(res1.is_err());


### PR DESCRIPTION
# Summary

CLI fs creation commands now carry the current process owner, group, and mode in the initial mkdir/create metadata request. This fixes empty ACL metadata on recursively created parents and removes the extra `SetAttr` RPC for `fs mkdir`.

# Issue Describe / Design

Closes #1192

Root cause:
- `fs mkdir -p` used `MkdirOpts` without owner/group, then applied a separate `SetAttr` only to the final path.
- `fs put` and `fs touch` used `CreateFileOpts` without owner/group, including for auto-created parents.

Fix approach:
- Resolve the current process owner and group names with numeric-id fallback for container environments without passwd/group entries.
- Set owner, group, and mode explicitly on `MkdirOpts` for `fs mkdir` and on `CreateFileOpts` for `fs put` and `fs touch`.
- `FsDir::create_parent_dir` already propagates owner/group to newly created parents.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-cli/src/cmds/fs/common.rs` | Adds internal helper for current owner/group/mode with numeric fallback | None |
| `curvine-cli/src/cmds/fs/mkdir.rs` | Sets owner/group/mode on `MkdirOpts`, removes follow-up `SetAttr` | Newly created dirs persist creator owner/group |
| `curvine-cli/src/cmds/fs/put.rs` | Sets owner/group/mode on `CreateFileOpts` | Newly created files and parents persist creator owner/group |
| `curvine-cli/src/cmds/fs/touch.rs` | Sets owner/group/mode on `CreateFileOpts` | Newly created files and parents persist creator owner/group |
| `curvine-server/tests/master_fs_test.rs` | Adds recursive parent owner/group regression tests | None |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo check -p curvine-cli` | PASS | |
| `cargo test -p curvine-server --test master_fs_test recursive_parents_persist_owner_group` | PASS | 2 tests |
| `make format` | PASS | fmt + clippy |

# Dependencies

- Related PRs: None
- Related issues: #1192
- Blocks / blocked by: None