### PR TITLE
build(build): resolve workspace version and support BUILD_VERSION override (#1527)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,8 @@ jobs:
       env:
         RELEASE_VERSION: ${{ github.ref_name }}
       run: |
+        BUILD_VERSION="${RELEASE_VERSION#v}"
+        export BUILD_VERSION
         make dist ARGS='--ufs opendal-s3 --ufs opendal-oss --ufs opendal-azblob --ufs opendal-gcs --ufs opendal-hdfs --ufs opendal-webhdfs --ufs oss-hdfs'
 
     - name: Upload build artifacts

--- a/build/build.sh
+++ b/build/build.sh
@@ -23,6 +23,9 @@ set -e
 # ./build release, release mode.
 FS_HOME="$(cd "`dirname "$0"`/.."; pwd)"
 
+# Shared version helpers used by build packaging and by version tests.
+source "$FS_HOME/build/version.sh"
+
 # Check if cargo is available
 if ! command -v cargo &> /dev/null; then
     echo "Error: cargo is not installed or not in PATH" >&2
@@ -136,6 +139,7 @@ print_help() {
   echo "  --skip-java-sdk        Skip Java SDK compilation (useful for Docker builds)"
   echo "  --skip-python-sdk      Skip Python SDK compilation (useful for Docker builds)"
   echo "  -h, --help            Show this help message"
+  echo "  BUILD_VERSION=<ver>   Override the package version used for artifacts and build-version"
   echo
   echo "Examples:"
   echo "  $0                                      # Build all packages in release mode with opendal-s3"
@@ -164,7 +168,7 @@ fi
 ARCH_NAME=$(get_arch_name)
 OS_VERSION=$(get_os_version)
 FUSE_VERSION=$(get_fuse_version)
-CURVINE_VERSION=$(grep '^version =' "$FS_HOME/Cargo.toml" | sed 's/^version = "\(.*\)"/\1/')
+CURVINE_VERSION=$(get_build_version "$FS_HOME/Cargo.toml")
 
 # Package Directory
 DIST_DIR="$FS_HOME/build/dist"

--- a/build/tests/test_workspace_version.sh
+++ b/build/tests/test_workspace_version.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2025 OPPO.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$ROOT/version.sh"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+cat > "$TMP_DIR/Cargo.toml" <<'EOF'
+[workspace.package]
+  version = "0.2.0"
+EOF
+
+actual="$(get_build_version "$TMP_DIR/Cargo.toml")"
+if [ "$actual" != "0.2.0" ]; then
+  echo "expected workspace version 0.2.0, got $actual" >&2
+  exit 1
+fi
+
+BUILD_VERSION="0.3.0-alpha" actual="$(get_build_version "$TMP_DIR/Cargo.toml")"
+if [ "$actual" != "0.3.0-alpha" ]; then
+  echo "expected BUILD_VERSION override 0.3.0-alpha, got $actual" >&2
+  exit 1
+fi
+
+echo "workspace version resolution: ok"

--- a/build/tests/test_workspace_version.sh
+++ b/build/tests/test_workspace_version.sh
@@ -40,5 +40,29 @@ if [ "$actual" != "0.3.0-alpha" ]; then
   echo "expected BUILD_VERSION override 0.3.0-alpha, got $actual" >&2
   exit 1
 fi
+unset BUILD_VERSION
+
+BUILD_VERSION="" actual="$(get_build_version "$TMP_DIR/Cargo.toml")"
+if [ "$actual" != "0.2.0" ]; then
+  echo "expected empty BUILD_VERSION to fall back to 0.2.0, got $actual" >&2
+  exit 1
+fi
+unset BUILD_VERSION
+
+cat > "$TMP_DIR/missing-version.toml" <<'EOF'
+[workspace.package]
+name = "curvine"
+EOF
+
+if actual="$(get_build_version "$TMP_DIR/missing-version.toml" 2>"$TMP_DIR/missing-version.err")"; then
+  echo "expected missing workspace version to fail, got $actual" >&2
+  exit 1
+fi
+
+if ! grep -q "failed to resolve \\[workspace.package\\].version" "$TMP_DIR/missing-version.err"; then
+  echo "expected missing workspace version error, got:" >&2
+  cat "$TMP_DIR/missing-version.err" >&2
+  exit 1
+fi
 
 echo "workspace version resolution: ok"

--- a/build/version.sh
+++ b/build/version.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2025 OPPO.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Read the version declared in [workspace.package]. The key can be indented,
+# so a plain `grep '^version ='` is not reliable for every Cargo.toml layout.
+get_workspace_version() {
+  local cargo_toml="${1:?Cargo.toml path required}"
+  awk '
+    /^\[workspace\.package\]/ { in_workspace = 1; next }
+    /^\[/ { in_workspace = 0 }
+    in_workspace && /^[[:space:]]*version[[:space:]]*=/ {
+      sub(/^[[:space:]]*version[[:space:]]*=[[:space:]]*"/, "")
+      sub(/".*/, "")
+      print
+      exit
+    }
+  ' "$cargo_toml"
+}
+
+# BUILD_VERSION is the release/CI override. Without it, fall back to the
+# Cargo workspace version so local builds still produce a stable package name.
+get_build_version() {
+  local cargo_toml="${1:?Cargo.toml path required}"
+  if [ -n "${BUILD_VERSION:-}" ]; then
+    printf '%s\n' "$BUILD_VERSION"
+    return 0
+  fi
+  local version
+  version="$(get_workspace_version "$cargo_toml")"
+  printf '%s\n' "${version:-unknown}"
+}

--- a/build/version.sh
+++ b/build/version.sh
@@ -41,6 +41,13 @@ get_build_version() {
     return 0
   fi
   local version
-  version="$(get_workspace_version "$cargo_toml")"
-  printf '%s\n' "${version:-unknown}"
+  if ! version="$(get_workspace_version "$cargo_toml")"; then
+    echo "failed to read workspace version from $cargo_toml" >&2
+    return 1
+  fi
+  if [ -z "$version" ]; then
+    echo "failed to resolve [workspace.package].version from $cargo_toml" >&2
+    return 1
+  fi
+  printf '%s\n' "$version"
 }

--- a/crates/core/curvine-sys/build.rs
+++ b/crates/core/curvine-sys/build.rs
@@ -18,11 +18,15 @@ use std::{env, fs, str};
 
 fn main() {
     emit_git_rerun_if_changed();
+    println!("cargo:rerun-if-env-changed=BUILD_VERSION");
 
     let base = env::var("OUT_DIR").unwrap_or_else(|_| ".".to_string());
     let ver_file = format!("{}/version.rs", base);
     let commit = get_git_head_commit();
-    let pkg_version = env::var("CARGO_PKG_VERSION").unwrap_or_else(|_| "unknown".to_string());
+    let build_version = env::var("BUILD_VERSION").ok().filter(|v| !v.is_empty());
+    let pkg_version = build_version
+        .clone()
+        .unwrap_or_else(|| env::var("CARGO_PKG_VERSION").unwrap_or_else(|_| "unknown".to_string()));
     let git_tag = get_git_tag();
     let git_branch = get_git_branch();
 
@@ -36,7 +40,9 @@ fn main() {
     };
 
     // Build full version string
-    let full_version = if !source_info.is_empty() {
+    let full_version = if let Some(build_version) = build_version {
+        build_version
+    } else if !source_info.is_empty() {
         format!("{} (commit: {}, {})", pkg_version, commit, source_info)
     } else {
         format!("{} (commit: {})", pkg_version, commit)
@@ -46,7 +52,7 @@ fn main() {
         r#"/// Git commit ID (short)
 pub static GIT_VERSION: &str = "{}";
 
-/// Package version from Cargo.toml
+/// Package version from Cargo.toml, or BUILD_VERSION when provided
 pub static PKG_VERSION: &str = "{}";
 
 /// Git tag (if built from a tag)
@@ -55,7 +61,7 @@ pub static GIT_TAG: &str = "{}";
 /// Git branch (if not built from a tag)
 pub static GIT_BRANCH: &str = "{}";
 
-/// Full version string: "version (commit: commit-id, tag/branch: name)"
+/// Full version string. BUILD_VERSION overrides the package-derived string.
 pub static VERSION: &str = "{}";
 "#,
         commit, pkg_version, git_tag, git_branch, full_version

--- a/crates/core/curvine-sys/src/version.rs
+++ b/crates/core/curvine-sys/src/version.rs
@@ -14,3 +14,23 @@
 
 // Include the version constants generated at build time
 include!(concat!(env!("OUT_DIR"), "/version.rs"));
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn version_constants_are_available() {
+        assert!(!PKG_VERSION.is_empty());
+        assert!(!GIT_VERSION.is_empty());
+        assert!(!VERSION.is_empty());
+    }
+
+    #[test]
+    fn build_version_override_is_honored_when_set() {
+        if let Ok(build_version) = std::env::var("BUILD_VERSION") {
+            assert_eq!(PKG_VERSION, build_version);
+            assert_eq!(VERSION, build_version);
+        }
+    }
+}

--- a/crates/core/curvine-sys/src/version.rs
+++ b/crates/core/curvine-sys/src/version.rs
@@ -29,6 +29,9 @@ mod tests {
     #[test]
     fn build_version_override_is_honored_when_set() {
         if let Ok(build_version) = std::env::var("BUILD_VERSION") {
+            if build_version.is_empty() {
+                return;
+            }
             assert_eq!(PKG_VERSION, build_version);
             assert_eq!(VERSION, build_version);
         }


### PR DESCRIPTION
<!-- curvine-automation:pr:CurvineIO/curvine:1527 -->

# Summary

Resolve the Cargo workspace version during packaging and allow builds to override the artifact version with `BUILD_VERSION`. Release builds now derive `BUILD_VERSION` from the pushed tag, keeping packaged artifacts and generated Rust version constants aligned with the release version.

# Issue Describe / Design

Related to #1527.

This PR implements the first version-management step:

- The previous `grep '^version ='` did not match the indented `[workspace.package] version`, so `build/build.sh` could resolve the wrong package version.
- `BUILD_VERSION` is now the explicit release/CI override for packaging and generated version constants.
- Release workflow derives `BUILD_VERSION` from the tag name and strips the leading `v` before `make dist`.
- Missing or unparseable `[workspace.package].version` now fails instead of publishing artifacts with an `unknown` version.
- When `BUILD_VERSION` is not set, behavior falls back to the Cargo workspace version, so existing local builds remain stable.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `.github/workflows/release.yml` | Export `BUILD_VERSION` from the release tag before `make dist` | Release artifacts and generated binary version output follow the tag version |
| `build/version.sh` | Parse workspace version, apply non-empty `BUILD_VERSION`, and fail when workspace version cannot be resolved | Invalid workspace metadata now fails the build instead of producing `unknown` artifacts |
| `build/build.sh` | Use `get_build_version` instead of root-level `grep`; document `BUILD_VERSION` in help | Local build version now resolves from `[workspace.package] version` |
| `crates/core/curvine-sys/build.rs` | Rebuild when `BUILD_VERSION` changes; override `PKG_VERSION` and `VERSION` | Generated version constants honor release override |
| `crates/core/curvine-sys/src/version.rs` | Add version constant tests and ignore empty `BUILD_VERSION` in override assertions | None |
| `build/tests/test_workspace_version.sh` | Add workspace version, override, empty override fallback, and missing version tests | None |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `bash build/tests/test_workspace_version.sh` | PASS | workspace version, `BUILD_VERSION` override, empty override fallback, missing version failure |
| `cargo test -p curvine-sys` | PASS | 14 passed |
| `make format` | PASS | pre-commit and clippy checks clean |
| `git diff --check origin/main...HEAD` | PASS | no whitespace errors |

# Dependencies

- Related PRs: None
- Related issues: #1527
- Blocks / blocked by: None
