### PR TITLE
docs: add Slack community badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 </p>
 
 [![CNCF Landscape](https://img.shields.io/badge/CNCF%20Landscape-5699C6)](https://landscape.cncf.io/?item=runtime--cloud-native-storage--curvine)
+[![Join our Slack Community](https://img.shields.io/badge/Slack-Join%20our%20Community-4A154B?logo=slack&logoColor=white)](https://join.slack.com/t/curvineio/shared_invite/zt-4673r43cn-prajma_q5ZI3BUxuaY5kiQ)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Rust](https://img.shields.io/badge/Rust-1.86%2B-orange)](https://www.rust-lang.org)
 


### PR DESCRIPTION
## Summary
- Add a Join our Slack Community badge to README.md.
- Link the badge to the Curvine Slack invite.

## Testing
- Not run; README-only change.
- Repository pre-push checks passed.