### PR TITLE
fix(fuse): reply EPROTO for malformed request payloads (#1523)

### DIFF
--- a/curvine-fuse/src/session/channel/fuse_receiver.rs
+++ b/curvine-fuse/src/session/channel/fuse_receiver.rs
@@ -293,13 +293,15 @@ impl<T: FileSystem> FuseReceiver<T> {
         rep: FuseResponse,
     ) -> FuseResult<()> {
         let metrics_enabled = rep.metrics.is_some();
-        // Parse failure here is after the ctx exists: finish it early (no reply).
-        // No stable errno for a parse error, so tag the catch-all "other".
+        // The frame header is already trusted here, so complete a malformed payload
+        // with EPROTO instead of leaving the kernel waiting for this unique.
         let operator = match req.parse_operator() {
             Ok(op) => op,
             Err(err) => {
-                rep.finish_early(err.errno(), "other");
-                return Err(err);
+                return rep
+                    .send_parse_error("other", err.to_string())
+                    .await
+                    .map_err(Into::into);
             }
         };
 
@@ -561,10 +563,17 @@ impl<T: FileSystem> FuseReceiver<T> {
         req: &FuseRequest,
         reply: &FuseResponse,
     ) -> FuseResult<()> {
-        // Parse failure here is after the ctx exists: finish it early (no reply).
+        // The frame header is already trusted here, so complete a malformed payload
+        // with EPROTO instead of leaving the kernel waiting for this unique.
         let operator = match req.parse_operator() {
             Ok(op) => op,
             Err(err) => {
+                if req.expects_reply() {
+                    return reply
+                        .send_parse_error("other", err.to_string())
+                        .await
+                        .map_err(Into::into);
+                }
                 reply.finish_early(err.errno(), "other");
                 return Err(err);
             }
@@ -885,6 +894,7 @@ mod tests {
         const OP_STATFS: u32 = 17;
         const OP_ACCESS: u32 = 34;
         const OP_INTERRUPT: u32 = 36;
+        const OP_BATCH_FORGET: u32 = 42;
 
         fn make_request(opcode: u32, unique: u64, nodeid: u64, payload: &[u8]) -> FuseRequest {
             let header = fuse_in_header {
@@ -1035,6 +1045,65 @@ mod tests {
             );
         }
 
+        #[tokio::test]
+        async fn malformed_lookup_replies_eproto_once() {
+            let unique = 1012;
+            let pending = FastDashMap::default();
+            let request = make_request(OP_LOOKUP, unique, 1, b"missing-nul");
+            let (reply, mut rx) = metrics_reply(unique, "Lookup");
+
+            let result =
+                super::super::FuseReceiver::dispatch_meta(&pending, &fs(), &request, &reply).await;
+
+            assert!(
+                result.is_ok(),
+                "a trusted-header payload error is completed by its EPROTO reply"
+            );
+            match rx.try_recv().unwrap().expect("one EPROTO reply task") {
+                FuseTask::RequestReply {
+                    data,
+                    status,
+                    errno,
+                    ..
+                } => {
+                    assert_eq!(status, FuseReqStatus::Error);
+                    assert_eq!(errno, libc::EPROTO);
+                    assert_eq!(data.header().unique, unique);
+                    assert_eq!(data.header().error, -libc::EPROTO);
+                }
+                _ => panic!("expected RequestReply"),
+            }
+            assert!(
+                rx.try_recv().unwrap().is_none(),
+                "malformed LOOKUP must enqueue exactly one reply"
+            );
+        }
+
+        #[tokio::test]
+        async fn malformed_lookup_replies_eproto_when_metrics_are_disabled() {
+            let unique = 1013;
+            let pending = FastDashMap::default();
+            let request = make_request(OP_LOOKUP, unique, 1, b"missing-nul");
+            let (tx, mut rx) = AsyncChannel::new(16).split();
+            let reply = FuseResponse::new_reply(unique, tx, false, None);
+
+            let result =
+                super::super::FuseReceiver::dispatch_meta(&pending, &fs(), &request, &reply).await;
+
+            assert!(result.is_ok());
+            match rx.try_recv().unwrap().expect("one EPROTO reply task") {
+                FuseTask::Reply(data) => {
+                    assert_eq!(data.header().unique, unique);
+                    assert_eq!(data.header().error, -libc::EPROTO);
+                }
+                _ => panic!("metrics-disabled reply must use FuseTask::Reply"),
+            }
+            assert!(
+                rx.try_recv().unwrap().is_none(),
+                "metrics-disabled malformed LOOKUP must enqueue exactly one reply"
+            );
+        }
+
         // No-reply Forget still records an operation sample (status from
         // finish_no_reply) and enqueues no reply task.
         #[tokio::test]
@@ -1059,6 +1128,32 @@ mod tests {
                 rx.try_recv().unwrap().is_none(),
                 "Forget is no-reply: no task enqueued"
             );
+        }
+
+        #[tokio::test]
+        async fn malformed_no_reply_opcodes_still_enqueue_nothing() {
+            let pending = FastDashMap::default();
+            let cases = [
+                (OP_FORGET, 1013, "Forget"),
+                (OP_INTERRUPT, 1014, "Interrupt"),
+                (OP_BATCH_FORGET, 1015, "BatchForget"),
+            ];
+
+            for (opcode, unique, label) in cases {
+                let request = make_request(opcode, unique, 1, &[]);
+                let (reply, mut rx) = metrics_reply(unique, label);
+
+                let result =
+                    super::super::FuseReceiver::dispatch_meta(&pending, &fs(), &request, &reply)
+                        .await;
+
+                assert!(result.is_err(), "malformed {label} reports its parse error");
+                assert_eq!(reply.metrics_op_status(), Some(FuseReqStatus::Error));
+                assert!(
+                    rx.try_recv().unwrap().is_none(),
+                    "malformed {label} must remain protocol no-reply"
+                );
+            }
         }
 
         #[tokio::test]
@@ -1360,7 +1455,7 @@ mod tests {
             let pending: Arc<FastDashMap<u64, Arc<tokio::sync::Notify>>> =
                 Arc::new(FastDashMap::default());
             let pending2 = pending.clone();
-            let (reply, _rx) = metrics_reply(2002, "SetLkW");
+            let (reply, mut rx) = metrics_reply(2002, "SetLkW");
 
             // Opcode routes through dispatch_meta_interrupt (timer created), but the
             // empty payload makes parse_operator's get_struct::<fuse_lk_in> fail.
@@ -1369,7 +1464,22 @@ mod tests {
                 super::super::FuseReceiver::dispatch_meta_interrupt(fs, pending, malformed, reply)
                     .await;
 
-            assert!(res.is_err(), "malformed SETLKW returns the parse Err");
+            assert!(
+                res.is_ok(),
+                "malformed SETLKW is completed by its EPROTO reply"
+            );
+            match rx.try_recv().unwrap().expect("one EPROTO reply task") {
+                FuseTask::RequestReply { data, errno, .. } => {
+                    assert_eq!(errno, libc::EPROTO);
+                    assert_eq!(data.header().unique, 2002);
+                    assert_eq!(data.header().error, -libc::EPROTO);
+                }
+                _ => panic!("expected RequestReply"),
+            }
+            assert!(
+                rx.try_recv().ok().flatten().is_none(),
+                "malformed SETLKW must enqueue exactly one reply"
+            );
             assert!(
                 !polled.load(Ordering::SeqCst),
                 "set_lkw must NOT be called for a malformed SETLKW (parse failed first)"
@@ -1482,7 +1592,7 @@ mod tests {
             fuse_flush_in, fuse_fsync_in, fuse_in_header, fuse_read_in, fuse_release_in,
             fuse_write_in,
         };
-        use crate::session::{FuseRequest, FuseResponse};
+        use crate::session::{FuseRequest, FuseResponse, FuseTask};
         use crate::FuseUtils;
         use bytes::{BufMut, BytesMut};
         use curvine_runtime::runtime::{AsyncRuntime, RpcRuntime};
@@ -1691,11 +1801,10 @@ mod tests {
             dispatch_one(false, write_request(7105));
         }
 
-        // A malformed stream request whose `parse_operator()` fails AFTER the ctx was
-        // built must finish the ctx early (drop guard, record decode error) and NOT enter
-        // the RAII scope. Pins that no early return/await sits between ctx and scope.
+        // A malformed stream request whose header is already trusted completes with
+        // exactly one EPROTO reply without entering the dispatch/lifecycle scopes.
         #[test]
-        fn malformed_stream_request_finishes_early_without_dispatch_or_lifecycle() {
+        fn malformed_stream_request_replies_eproto_without_dispatch_or_lifecycle() {
             use crate::fuse_metrics::{FuseReqCtx, FuseReqKind, FuseReqLabels, DECODE_PHASE_PARSE};
             FuseMetrics::ensure_init().unwrap();
             let mx = FuseMetrics::get();
@@ -1715,7 +1824,6 @@ mod tests {
             rt.block_on(async {
                 let fs = Arc::new(TestFileSystem::new(curvine_config::FuseConf::default()));
                 let (tx, mut rx) = AsyncChannel::new(16).split();
-                let drainer = tokio::spawn(async move { while rx.recv().await.is_some() {} });
 
                 let active_g = curvine_metrics::Metrics::new_gauge(
                     "ss_malformed_active_7201".to_string(),
@@ -1735,21 +1843,38 @@ mod tests {
                 .await;
 
                 assert!(
-                    res.is_err(),
-                    "malformed stream request returns the parse Err"
+                    res.is_ok(),
+                    "malformed stream request is completed by its EPROTO reply"
                 );
-                // Active guard released by finish_early — no leak.
+                let task = rx.try_recv().unwrap().expect("one EPROTO reply task");
+                match &task {
+                    FuseTask::RequestReply { data, errno, .. } => {
+                        assert_eq!(*errno, libc::EPROTO);
+                        assert_eq!(data.header().unique, 7201);
+                        assert_eq!(data.header().error, -libc::EPROTO);
+                    }
+                    _ => panic!("expected RequestReply"),
+                }
+                assert_eq!(
+                    active_g.get(),
+                    1,
+                    "the active guard travels with the reply until Sender completion"
+                );
+                drop(task);
                 assert_eq!(
                     active_g.get(),
                     0,
-                    "parse failure finishes the ctx early and drops the active guard"
+                    "dropping the reply releases the active guard"
                 );
-                drainer.abort();
+                assert!(
+                    rx.try_recv().ok().flatten().is_none(),
+                    "malformed stream request enqueues exactly one reply"
+                );
             });
 
             // "No io_dispatch/lifecycle sample on parse failure" is STRUCTURAL: the RAII
             // scope exists only after `parse_operator()` succeeds, so an Err returns via
-            // `finish_early` first. Only the decode error shows here (shared → lower bound).
+            // the parse-reply path first. Only the decode error shows here (shared → lower bound).
             assert!(
                 mx.decode_errors_total
                     .with_label_values(&[DECODE_PHASE_PARSE, "other"])

--- a/curvine-fuse/src/session/fuse_request.rs
+++ b/curvine-fuse/src/session/fuse_request.rs
@@ -103,7 +103,7 @@ impl FuseRequest {
     pub fn expects_reply(&self) -> bool {
         !matches!(
             self.opcode,
-            FUSE_FORGET | FUSE_BATCH_FORGET | FUSE_INTERRUPT
+            FUSE_FORGET | FUSE_BATCH_FORGET | FUSE_INTERRUPT | FUSE_NOTIFY_REPLY
         )
     }
 
@@ -432,6 +432,27 @@ mod tests {
             Err(err) => err,
         };
         assert!(err.to_string().contains("length mismatch"));
+    }
+
+    #[test]
+    fn expects_reply_classifies_every_protocol_no_reply_opcode() {
+        for opcode in [
+            FUSE_FORGET,
+            FUSE_BATCH_FORGET,
+            FUSE_INTERRUPT,
+            FUSE_NOTIFY_REPLY,
+        ] {
+            let header = header(opcode, FUSE_IN_HEADER_LEN);
+            let request = FuseRequest::from_bytes(request_bytes(&header, &[])).unwrap();
+            assert!(
+                !request.expects_reply(),
+                "{opcode:?} must not produce a response frame"
+            );
+        }
+
+        let header = header(FUSE_LOOKUP, FUSE_IN_HEADER_LEN);
+        let request = FuseRequest::from_bytes(request_bytes(&header, &[])).unwrap();
+        assert!(request.expects_reply(), "LOOKUP requires a response frame");
     }
 
     #[test]

--- a/curvine-fuse/src/session/fuse_request.rs
+++ b/curvine-fuse/src/session/fuse_request.rs
@@ -100,6 +100,13 @@ impl FuseRequest {
         )
     }
 
+    pub fn expects_reply(&self) -> bool {
+        !matches!(
+            self.opcode,
+            FUSE_FORGET | FUSE_BATCH_FORGET | FUSE_INTERRUPT
+        )
+    }
+
     pub fn should_audit(&self) -> bool {
         !matches!(self.opcode, FUSE_READ | FUSE_WRITE)
     }

--- a/curvine-fuse/src/session/fuse_response.rs
+++ b/curvine-fuse/src/session/fuse_response.rs
@@ -420,7 +420,7 @@ impl FuseResponse {
         }
     }
 
-    /// Finish a request that errored before any reply, using a parse reason instead of errno.
+    /// Finish a no-reply request whose opcode payload could not be decoded.
     pub(crate) fn finish_early(&self, errno: i32, reason: &'static str) {
         if let Some(slot) = &self.metrics {
             {
@@ -439,6 +439,27 @@ impl FuseResponse {
             // Parse failed after ctx creation: record decode error, not `requests_total`.
             FuseMetrics::get().record_parse_error(reason);
         }
+    }
+
+    /// Complete a request whose header was decoded but whose opcode payload was malformed.
+    pub(crate) async fn send_parse_error(
+        &self,
+        reason: &'static str,
+        message: String,
+    ) -> IOResult<()> {
+        if let Some(slot) = &self.metrics {
+            {
+                let mut m = slot.lock();
+                m.parse_reason = Some(reason);
+            }
+            FuseMetrics::get().record_parse_error(reason);
+        }
+
+        let error: FuseResult<()> = Err(FuseError::from_errno_msg(
+            libc::EPROTO,
+            format!("Malformed FUSE request payload: {message}").into(),
+        ));
+        self.send_rep(error).await
     }
 
     pub async fn send_rep<T: Debug, E: Into<FuseError> + Debug>(
@@ -957,9 +978,8 @@ mod tests {
         );
     }
 
-    // T8: parse-after-ctx early finish — `finish_early` (the API the receiver
-    // calls when `parse_operator()` fails after the ctx exists) drops the guard,
-    // marks finished, and enqueues NO task. No requests_total would be emitted.
+    // T8: malformed no-reply operator — `finish_early` drops the guard, marks
+    // the metrics slot finished, and enqueues NO task. No requests_total is emitted.
     #[tokio::test]
     async fn t8_finish_early_drops_guard_no_task() {
         init_metrics();
@@ -1523,7 +1543,7 @@ mod tests {
         );
     }
 
-    // B4 / test 8: parse-after-ctx early finish emits decode_errors_total
+    // B4 / test 8: malformed no-reply early finish emits decode_errors_total
     // {phase=parse,reason=other} once and NO requests_total.
     #[tokio::test]
     async fn finish_early_emits_decode_error_not_requests_total() {


### PR DESCRIPTION
# Summary

Reply with `EPROTO` when a trusted FUSE request header is followed by a malformed opcode payload, preventing reply-requiring requests from waiting indefinitely. Preserve protocol no-reply behavior for `FORGET`, `BATCH_FORGET`, `INTERRUPT`, and `FUSE_NOTIFY_REPLY`.

# Issue Describe / Design

Closes #1523
Closes #1532

Root cause:

- Metadata and stream dispatch call `parse_operator()` after the request header has already been validated.
- On payload decoding failure, the previous implementation called `finish_early()` and returned the parsing error.
- `finish_early()` only completed metrics bookkeeping and did not enqueue a response for the kernel.

Reproduction:

1. Submit a request with a valid header, opcode, and `unique`.
2. Use a malformed payload such as a non-NUL-terminated `LOOKUP` name or a short `READ` argument.
3. Observe that no response task is queued.

Fix approach:

- Add a parse-error response path that records the decoding error and sends exactly one `-EPROTO` response.
- Classify every protocol no-reply operation explicitly and keep its existing behavior.
- Leave untrusted header/frame failures session-fatal.
- Preserve pending-request cleanup and lifecycle behavior for interruptible `SETLKW`.
- Complement #1512: that PR accepts a valid LOOKUP name followed by rename-race remnants, while this PR guarantees an error response when an opcode payload is genuinely malformed.

Real `/dev/fuse` testing boundary:

- A normal Linux syscall cannot make the kernel emit a deliberately malformed FUSE opcode payload, so the receiver-level tests use exact raw frames to cover the response invariant.
- A real mount test requires kernel fault injection or a feature-gated receiver corruption hook. That broader test harness is tracked separately in #1537 so this bug fix does not introduce a production fault-injection surface.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `session/fuse_request.rs` | Classify requests that expect a reply, including all protocol no-reply opcodes | No change for valid reply-requiring requests |
| `session/fuse_response.rs` | Add the `EPROTO` payload parse-error response path | Malformed reply-requiring requests now complete |
| `session/channel/fuse_receiver.rs` | Use the response path in metadata and stream dispatch and add regression coverage | Prevents request hangs while preserving no-reply semantics |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-fuse --lib expects_reply_classifies_every_protocol_no_reply_opcode -- --test-threads=1` | PASS | 1/1; review follow-up |
| `cargo test -p curvine-fuse --lib malformed_ -- --test-threads=1` | PASS | 5/5 |
| `cargo test -p curvine-fuse --lib --offline -- --test-threads=1` | PASS | 395/395 on remote Linux before the review-only classification addition |
| `cargo fmt --all -- --check` | PASS | Review follow-up formatting check |

# Dependencies

- Related PRs: #1369, #1512
- Related issues: #1523, #1532, #1537
- Blocks / blocked by: None
