### PR TITLE
feat(version): add component version JSON output (#1527)

### DIFF
--- a/.github/workflows/build-csi-image.yml
+++ b/.github/workflows/build-csi-image.yml
@@ -38,6 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.meta.outputs.tag }}
+      build_version: ${{ steps.meta.outputs.build_version }}
       push_image: ${{ steps.meta.outputs.push_image }}
       ghcr_image: ${{ steps.meta.outputs.ghcr_image }}
       docker_image: ${{ steps.meta.outputs.docker_image }}
@@ -64,6 +65,12 @@ jobs:
           
           echo "tag=${TAG}" >> $GITHUB_OUTPUT
           echo "push_image=${PUSH_IMAGE}" >> $GITHUB_OUTPUT
+
+          BUILD_VERSION="$TAG"
+          if [[ "${TAG}" == v* ]]; then
+            BUILD_VERSION="${TAG#v}"
+          fi
+          echo "build_version=${BUILD_VERSION}" >> $GITHUB_OUTPUT
           
           # Generate image names for CSI
           GHCR_IMAGE="ghcr.io/curvineio/curvine-csi"
@@ -130,6 +137,7 @@ jobs:
             GOPROXY=https://goproxy.cn,direct
             TARGETARCH=${{ matrix.arch }}
             TARGETOS=linux
+            BUILD_VERSION=${{ needs.prepare.outputs.build_version }}
       
       - name: Build summary for ${{ matrix.arch }}
         run: |
@@ -257,4 +265,3 @@ jobs:
           else
             echo "**Note:** Image was built but not pushed (push_image=false)" >> $GITHUB_STEP_SUMMARY
           fi
-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2063,9 +2063,11 @@ dependencies = [
 name = "curvine-client"
 version = "0.2.0"
 dependencies = [
+ "clap",
  "curvine-bench",
  "curvine-client-core",
  "curvine-job-client",
+ "curvine-sys",
  "curvine-unified-fs",
 ]
 
@@ -2717,6 +2719,8 @@ dependencies = [
  "libc",
  "log",
  "nix",
+ "serde",
+ "serde_json",
  "sysinfo",
  "tokio",
 ]

--- a/build/bin/curvine-fuse.sh
+++ b/build/bin/curvine-fuse.sh
@@ -26,6 +26,12 @@ for arg in "$@"; do
         ${CURVINE_HOME}/lib/curvine-fuse --help
         exit 0
     fi
+
+    if [[ "$arg" == "--version-json" ]] || [[ "$arg" == "--version" ]] || [[ "$arg" == "-V" ]]; then
+        . "$(cd "`dirname "$0"`"; pwd)"/../conf/curvine-env.sh
+        ${CURVINE_HOME}/lib/curvine-fuse "$arg"
+        exit 0
+    fi
     
     # Extract mount path from arguments if specified
     if [[ "$arg" == --mnt-path=* ]]; then

--- a/build/bin/curvine-master.sh
+++ b/build/bin/curvine-master.sh
@@ -16,4 +16,11 @@
 # limitations under the License.
 #
 
-"$(cd "`dirname "$0"`"; pwd)"/launch-process.sh master $1
+BIN_DIR="$(cd "`dirname "$0"`"; pwd)"
+if [[ "$1" == "--version-json" ]] || [[ "$1" == "--version" ]] || [[ "$1" == "-V" ]]; then
+  source "${BIN_DIR}/../conf/curvine-env.sh"
+  "${CURVINE_HOME}/lib/curvine-server" --service master "$1"
+  exit $?
+fi
+
+"${BIN_DIR}"/launch-process.sh master $1

--- a/build/bin/curvine-transfer.sh
+++ b/build/bin/curvine-transfer.sh
@@ -16,4 +16,11 @@
 # limitations under the License.
 #
 
-"$(cd "`dirname "$0"`"; pwd)"/launch-process.sh transfer $1
+BIN_DIR="$(cd "`dirname "$0"`"; pwd)"
+if [[ "$1" == "--version-json" ]] || [[ "$1" == "--version" ]] || [[ "$1" == "-V" ]]; then
+  source "${BIN_DIR}/../conf/curvine-env.sh"
+  "${CURVINE_HOME}/lib/curvine-server" --service transfer "$1"
+  exit $?
+fi
+
+"${BIN_DIR}"/launch-process.sh transfer $1

--- a/build/bin/curvine-worker.sh
+++ b/build/bin/curvine-worker.sh
@@ -16,4 +16,11 @@
 # limitations under the License.
 #
 
-"$(cd "`dirname "$0"`"; pwd)"/launch-process.sh worker $1
+BIN_DIR="$(cd "`dirname "$0"`"; pwd)"
+if [[ "$1" == "--version-json" ]] || [[ "$1" == "--version" ]] || [[ "$1" == "-V" ]]; then
+  source "${BIN_DIR}/../conf/curvine-env.sh"
+  "${CURVINE_HOME}/lib/curvine-server" --service worker "$1"
+  exit $?
+fi
+
+"${BIN_DIR}"/launch-process.sh worker $1

--- a/build/build.sh
+++ b/build/build.sh
@@ -420,7 +420,8 @@ fi
 
 if should_build_package "client"; then
   CLIENT_RUST_BUILD_ARGS+=("-p" "curvine-client")
-  # COPY_TARGETS+=("curvine-client")
+  COPY_TARGETS+=("curvine-client")
+  CLIENT_ARTIFACT_CHECK_TARGETS+=("curvine-client")
 fi
 
 if should_build_package "cli"; then

--- a/crates/core/curvine-sys/Cargo.toml
+++ b/crates/core/curvine-sys/Cargo.toml
@@ -13,5 +13,7 @@ futures = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
 nix = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 sysinfo = { workspace = true }
 tokio = { workspace = true }

--- a/crates/core/curvine-sys/src/version.rs
+++ b/crates/core/curvine-sys/src/version.rs
@@ -15,6 +15,71 @@
 // Include the version constants generated at build time
 include!(concat!(env!("OUT_DIR"), "/version.rs"));
 
+use serde::{Deserialize, Serialize};
+
+/// Initial Curvine component protocol version.
+pub const PROTOCOL_VERSION: u32 = 1;
+
+/// Lowest Curvine component protocol version accepted by this build.
+pub const MIN_PROTOCOL_VERSION: u32 = 1;
+
+/// Structured version metadata emitted by every Curvine component.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ComponentVersion {
+    pub component: String,
+    pub release_version: String,
+    pub git_commit: String,
+    pub git_tag: String,
+    pub git_branch: String,
+    pub protocol_version: u32,
+    pub min_protocol_version: u32,
+    pub capabilities: Vec<String>,
+}
+
+impl ComponentVersion {
+    pub fn new(component: impl Into<String>) -> Self {
+        Self {
+            component: component.into(),
+            release_version: PKG_VERSION.to_string(),
+            git_commit: GIT_VERSION.to_string(),
+            git_tag: GIT_TAG.to_string(),
+            git_branch: GIT_BRANCH.to_string(),
+            protocol_version: PROTOCOL_VERSION,
+            min_protocol_version: MIN_PROTOCOL_VERSION,
+            capabilities: Vec::new(),
+        }
+    }
+
+    pub fn to_json_pretty(&self) -> serde_json::Result<String> {
+        serde_json::to_string_pretty(self)
+    }
+
+    pub fn display_version(&self) -> String {
+        let mut source = String::new();
+        if !self.git_tag.is_empty() && self.git_tag != "unknown" {
+            source = format!(", tag: {}", self.git_tag);
+        } else if !self.git_branch.is_empty()
+            && self.git_branch != "unknown"
+            && self.git_branch != "HEAD"
+        {
+            source = format!(", branch: {}", self.git_branch);
+        }
+
+        format!(
+            "{} (commit: {}{})",
+            self.release_version, self.git_commit, source
+        )
+    }
+}
+
+pub fn component_version(component: impl Into<String>) -> ComponentVersion {
+    ComponentVersion::new(component)
+}
+
+pub fn component_version_json(component: impl Into<String>) -> serde_json::Result<String> {
+    component_version(component).to_json_pretty()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -35,5 +100,39 @@ mod tests {
             assert_eq!(PKG_VERSION, build_version);
             assert_eq!(VERSION, build_version);
         }
+    }
+
+    #[test]
+    fn component_version_json_uses_stable_schema() {
+        let json = component_version_json("cli").unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(value["component"], "cli");
+        assert_eq!(value["release_version"], PKG_VERSION);
+        assert_eq!(value["git_commit"], GIT_VERSION);
+        assert_eq!(value["git_tag"], GIT_TAG);
+        assert_eq!(value["git_branch"], GIT_BRANCH);
+        assert_eq!(value["protocol_version"], PROTOCOL_VERSION);
+        assert_eq!(value["min_protocol_version"], MIN_PROTOCOL_VERSION);
+        assert!(value["capabilities"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn component_version_display_prefers_tag_over_branch() {
+        let version = ComponentVersion {
+            component: "master".to_string(),
+            release_version: "0.2.0".to_string(),
+            git_commit: "abcdef1".to_string(),
+            git_tag: "v0.2.0".to_string(),
+            git_branch: "main".to_string(),
+            protocol_version: PROTOCOL_VERSION,
+            min_protocol_version: MIN_PROTOCOL_VERSION,
+            capabilities: Vec::new(),
+        };
+
+        assert_eq!(
+            version.display_version(),
+            "0.2.0 (commit: abcdef1, tag: v0.2.0)"
+        );
     }
 }

--- a/curvine-cli/src/main.rs
+++ b/curvine-cli/src/main.rs
@@ -36,8 +36,7 @@ use std::sync::Arc;
     author,
     version = env!("CARGO_PKG_VERSION"),
     about,
-    long_about = None,
-    arg_required_else_help = true
+    long_about = None
 )]
 pub struct CurvineArgs {
     /// Print the component version in JSON format and exit
@@ -286,6 +285,14 @@ mod tests {
             .expect("version json should parse without subcommand");
 
         assert!(args.version_json);
+        assert!(args.command.is_none());
+    }
+
+    #[test]
+    fn bare_invocation_parses_so_custom_missing_subcommand_path_runs() {
+        let args = CurvineArgs::try_parse_from(["curvine"])
+            .expect("bare invocation should parse so main can emit MissingSubcommand");
+
         assert!(args.command.is_none());
     }
 

--- a/curvine-cli/src/main.rs
+++ b/curvine-cli/src/main.rs
@@ -17,7 +17,7 @@ mod cmds;
 mod commands;
 mod util;
 
-use clap::Parser;
+use clap::{error::ErrorKind, CommandFactory, Parser};
 use commands::Commands;
 use curvine_config::ClusterConf;
 use curvine_core_error::{err_box, CommonResult};
@@ -26,13 +26,24 @@ use curvine_job_client::TransferClient;
 use curvine_net::net::InetAddr;
 use curvine_runtime::common::{Logger, Utils};
 use curvine_runtime::runtime::RpcRuntime;
+use curvine_sys::version;
 use curvine_unified_fs::UnifiedFileSystem;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 #[derive(Parser, Debug)]
-#[command(author, version = env!("CARGO_PKG_VERSION"), about, long_about = None)]
+#[command(
+    author,
+    version = env!("CARGO_PKG_VERSION"),
+    about,
+    long_about = None,
+    arg_required_else_help = true
+)]
 pub struct CurvineArgs {
+    /// Print the component version in JSON format and exit
+    #[arg(long, global = true)]
+    pub version_json: bool,
+
     /// Configuration file path (optional)
     #[arg(long, help = "Configuration file path (optional)", global = true)]
     pub conf: Option<String>,
@@ -46,7 +57,7 @@ pub struct CurvineArgs {
     pub master_addrs: Option<String>,
 
     #[command(subcommand)]
-    command: Commands,
+    command: Option<Commands>,
 }
 
 pub struct ConfLoadResult {
@@ -157,14 +168,31 @@ impl CurvineArgs {
 
 fn main() -> CommonResult<()> {
     let args = CurvineArgs::parse();
+    if args.version_json {
+        let json = match version::component_version_json("cli") {
+            Ok(json) => json,
+            Err(e) => return err_box!("Failed to serialize component version: {}", e),
+        };
+        println!("{}", json);
+        return Ok(());
+    }
+    if args.command.is_none() {
+        CurvineArgs::command()
+            .error(
+                ErrorKind::MissingSubcommand,
+                "a subcommand is required unless --version-json is provided",
+            )
+            .exit();
+    }
+
     Utils::set_panic_exit_hook();
 
-    if matches!(args.command, Commands::Version) {
+    if matches!(args.command, Some(Commands::Version)) {
         println!("curvine-cli {}", env!("CARGO_PKG_VERSION"));
         return Ok(());
     }
 
-    let enable_default_discovery = matches!(args.command, Commands::Bench(_));
+    let enable_default_discovery = matches!(args.command, Some(Commands::Bench(_)));
     let conf_load = args.get_conf_with_source(enable_default_discovery)?;
     let conf = conf_load.conf;
     let conf_source = conf_load.source;
@@ -182,22 +210,22 @@ fn main() -> CommonResult<()> {
 
     rt.block_on(async move {
         let result = match args.command {
-            Commands::Bench(cmd) => cmd.execute(curvine_fs, conf_source.clone()).await,
-            Commands::Fs(cmd) => cmd.execute(curvine_fs).await,
-            Commands::Report(cmd) => cmd.execute(curvine_fs).await,
-            Commands::Load(cmd) => match transfer_client.clone() {
+            Some(Commands::Bench(cmd)) => cmd.execute(curvine_fs, conf_source.clone()).await,
+            Some(Commands::Fs(cmd)) => cmd.execute(curvine_fs).await,
+            Some(Commands::Report(cmd)) => cmd.execute(curvine_fs).await,
+            Some(Commands::Load(cmd)) => match transfer_client.clone() {
                 Some(transfer_client) => cmd.execute_transfer(curvine_fs.clone(), transfer_client).await,
                 None => cmd.execute_legacy(load_client.clone()).await,
             },
-            Commands::Export(cmd) => match transfer_client.clone() {
+            Some(Commands::Export(cmd)) => match transfer_client.clone() {
                 Some(transfer_client) => cmd.execute_transfer(curvine_fs.clone(), transfer_client).await,
                 None => cmd.execute_legacy(load_client.clone()).await,
             },
-            Commands::LoadStatus(cmd) => match transfer_client.clone() {
+            Some(Commands::LoadStatus(cmd)) => match transfer_client.clone() {
                 Some(transfer_client) => cmd.execute_transfer_only(transfer_client).await,
                 None => cmd.execute(load_client.clone()).await,
             },
-            Commands::TransferStatus(cmd) => {
+            Some(Commands::TransferStatus(cmd)) => {
                 let Some(transfer_client) = transfer_client.clone() else {
                     return err_box!(
                         "transfer-status requires transfer.enabled=true and a running transfer service"
@@ -205,11 +233,11 @@ fn main() -> CommonResult<()> {
                 };
                 cmd.execute_transfer_only(transfer_client).await
             }
-            Commands::CancelLoad(cmd) => match transfer_client.clone() {
+            Some(Commands::CancelLoad(cmd)) => match transfer_client.clone() {
                 Some(transfer_client) => cmd.execute_transfer_only(transfer_client).await,
                 None => cmd.execute(load_client.clone()).await,
             },
-            Commands::CancelTransfer(cmd) => {
+            Some(Commands::CancelTransfer(cmd)) => {
                 let Some(transfer_client) = transfer_client.clone() else {
                     return err_box!(
                         "cancel-transfer requires transfer.enabled=true and a running transfer service"
@@ -217,7 +245,7 @@ fn main() -> CommonResult<()> {
                 };
                 cmd.execute_transfer_only(transfer_client).await
             }
-            Commands::Transfer(cmd) => {
+            Some(Commands::Transfer(cmd)) => {
                 let Some(transfer_client) = transfer_client.clone() else {
                     return err_box!(
                         "transfer requires transfer.enabled=true and a running transfer service"
@@ -225,10 +253,10 @@ fn main() -> CommonResult<()> {
                 };
                 cmd.execute(transfer_client).await
             }
-            Commands::Mount(cmd) => cmd.execute(curvine_fs).await,
-            Commands::UnMount(cmd) => cmd.execute(fs_client).await,
-            Commands::Node(cmd) => cmd.execute(fs_client, conf.clone()).await,
-            Commands::Version => Ok(()),
+            Some(Commands::Mount(cmd)) => cmd.execute(curvine_fs).await,
+            Some(Commands::UnMount(cmd)) => cmd.execute(fs_client).await,
+            Some(Commands::Node(cmd)) => cmd.execute(fs_client, conf.clone()).await,
+            Some(Commands::Version) | None => Ok(()),
         };
 
         if let Err(e) = &result {
@@ -249,7 +277,16 @@ mod tests {
         let args = CurvineArgs::try_parse_from(["curvine", "export", "/mnt/file", "--watch"])
             .expect("export command should parse");
 
-        assert!(matches!(args.command, Commands::Export(_)));
+        assert!(matches!(args.command, Some(Commands::Export(_))));
+    }
+
+    #[test]
+    fn version_json_does_not_require_subcommand() {
+        let args = CurvineArgs::try_parse_from(["curvine", "--version-json"])
+            .expect("version json should parse without subcommand");
+
+        assert!(args.version_json);
+        assert!(args.command.is_none());
     }
 
     #[test]
@@ -267,6 +304,6 @@ mod tests {
         ])
         .expect("mount config should use -c while cluster config uses --conf");
 
-        assert!(matches!(args.command, Commands::Mount(_)));
+        assert!(matches!(args.command, Some(Commands::Mount(_))));
     }
 }

--- a/curvine-client/Cargo.toml
+++ b/curvine-client/Cargo.toml
@@ -11,6 +11,8 @@ curvine-client-core = { workspace = true }
 curvine-job-client = { workspace = true, optional = true }
 curvine-unified-fs = { workspace = true, optional = true }
 curvine-bench = { workspace = true, optional = true }
+curvine-sys = { workspace = true }
+clap = { workspace = true }
 
 [features]
 default = []

--- a/curvine-client/src/main.rs
+++ b/curvine-client/src/main.rs
@@ -1,0 +1,50 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use clap::Parser;
+use curvine_sys::version;
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "curvine-client",
+    version = version::VERSION,
+    arg_required_else_help = true
+)]
+struct ClientArgs {
+    /// Print the component version in JSON format and exit
+    #[arg(long)]
+    version_json: bool,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = ClientArgs::parse();
+    if args.version_json {
+        println!("{}", version::component_version_json("client")?);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn version_json_parses_without_other_args() {
+        let args = ClientArgs::try_parse_from(["curvine-client", "--version-json"])
+            .expect("client version json should parse");
+
+        assert!(args.version_json);
+    }
+}

--- a/curvine-csi/Dockerfile
+++ b/curvine-csi/Dockerfile
@@ -65,7 +65,8 @@ RUN echo "Building Curvine from source..." && \
 
 # Build CSI binary with version info
 RUN cd /workspace/curvine-csi && \
-    VERSION=$(grep '^version =' /workspace/Cargo.toml | head -1 | sed 's/^version = "\(.*\)"/\1/') && \
+    . /workspace/build/version.sh && \
+    VERSION=$(get_build_version /workspace/Cargo.toml) && \
     GIT_COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown") && \
     GIT_TAG=$(git describe --tags --exact-match HEAD 2>/dev/null || echo "") && \
     GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "") && \

--- a/curvine-csi/Dockerfile
+++ b/curvine-csi/Dockerfile
@@ -7,6 +7,9 @@ ARG GOPROXY
 # The compile image has ENTRYPOINT ["/bin/bash", "-c"] which can interfere with RUN
 ENTRYPOINT []
 
+# version.sh uses bash features such as local, so RUN steps must use bash.
+SHELL ["/bin/bash", "-c"]
+
 # Set GOPROXY environment variable (Go is already installed in compile image)
 ENV GOPROXY=${GOPROXY:-https://proxy.golang.org}
 

--- a/curvine-csi/Dockerfile
+++ b/curvine-csi/Dockerfile
@@ -2,6 +2,7 @@
 FROM ghcr.io/curvineio/curvine-compile:ubuntu24.04 AS builder
 
 ARG GOPROXY
+ARG BUILD_VERSION
 
 # Override ENTRYPOINT to ensure RUN commands execute correctly
 # The compile image has ENTRYPOINT ["/bin/bash", "-c"] which can interfere with RUN

--- a/curvine-csi/pkg/csi/fuse_cli.go
+++ b/curvine-csi/pkg/csi/fuse_cli.go
@@ -44,10 +44,10 @@ var rejectedVolumeParameterKeys = map[string]struct{}{
 
 // volumeParameterDenylist blocks keys that are CSI-internal or not valid fuse flags.
 var volumeParameterDenylist = map[string]struct{}{
-	"csi.storage.k8s.io/ephemeral": {},
-	"csi.storage.k8s.io/pod.name":  {},
-	"csi.storage.k8s.io/pod.namespace": {},
-	"csi.storage.k8s.io/pod.uid":   {},
+	"csi.storage.k8s.io/ephemeral":           {},
+	"csi.storage.k8s.io/pod.name":            {},
+	"csi.storage.k8s.io/pod.namespace":       {},
+	"csi.storage.k8s.io/pod.uid":             {},
 	"csi.storage.k8s.io/serviceAccount.name": {},
 }
 

--- a/curvine-csi/pkg/csi/fuse_cli_test.go
+++ b/curvine-csi/pkg/csi/fuse_cli_test.go
@@ -36,7 +36,7 @@ func TestCollectPassthroughParams(t *testing.T) {
 	}
 	publishContext := map[string]string{
 		"entry-timeout": "1.0",
-		"io-threads":      "8",
+		"io-threads":    "8",
 	}
 
 	got := CollectPassthroughParams(volumeContext, publishContext)

--- a/curvine-csi/pkg/csi/fuse_validate_test.go
+++ b/curvine-csi/pkg/csi/fuse_validate_test.go
@@ -17,7 +17,9 @@ package csi
 import (
 	"context"
 	"errors"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"reflect"
 	"testing"
 	"time"
@@ -98,11 +100,12 @@ func TestStatusFromValidateConfigErrorMapsMissingBinaryToInternal(t *testing.T) 
 }
 
 func TestExecFuseValidateConfigMapsSubprocessKillToDeadlineExceeded(t *testing.T) {
-	if _, err := exec.LookPath("yes"); err != nil {
-		t.Skip("yes not available")
+	fuseBinaryPath := filepath.Join(t.TempDir(), "curvine-fuse-sleep")
+	if err := os.WriteFile(fuseBinaryPath, []byte("#!/bin/sh\nsleep 5\n"), 0755); err != nil {
+		t.Fatalf("write fake fuse binary: %v", err)
 	}
 
-	t.Setenv("FUSE_BINARY_PATH", "yes")
+	t.Setenv("FUSE_BINARY_PATH", fuseBinaryPath)
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
 

--- a/curvine-csi/pkg/csi/node.go
+++ b/curvine-csi/pkg/csi/node.go
@@ -655,4 +655,3 @@ func buildMountOptions(request *csi.NodePublishVolumeRequest, requestID string) 
 	}
 	return ""
 }
-

--- a/curvine-csi/pkg/csi/version.go
+++ b/curvine-csi/pkg/csi/version.go
@@ -29,29 +29,35 @@ var (
 	buildDate     = "unknown"
 )
 
-// VersionInfo struct
-type VersionInfo struct {
-	DriverVersion string `json:"DriverVersion"`
-	GitCommit     string `json:"GitCommit"`
-	GitTag        string `json:"GitTag,omitempty"`
-	GitBranch     string `json:"GitBranch,omitempty"`
-	BuildDate     string `json:"BuildDate"`
-	GoVersion     string `json:"GoVersion"`
-	Compiler      string `json:"Compiler"`
-	Platform      string `json:"Platform"`
+const (
+	componentName      = "csi"
+	protocolVersion    = 1
+	minProtocolVersion = 1
+)
+
+// ComponentVersion is the machine-readable version schema shared by Curvine components.
+type ComponentVersion struct {
+	Component          string   `json:"component"`
+	ReleaseVersion     string   `json:"release_version"`
+	GitCommit          string   `json:"git_commit"`
+	GitTag             string   `json:"git_tag"`
+	GitBranch          string   `json:"git_branch"`
+	ProtocolVersion    int      `json:"protocol_version"`
+	MinProtocolVersion int      `json:"min_protocol_version"`
+	Capabilities       []string `json:"capabilities"`
 }
 
-// GetVersion returns VersionInfo
-func GetVersion() VersionInfo {
-	return VersionInfo{
-		DriverVersion: driverVersion,
-		GitCommit:     gitCommit,
-		GitTag:        gitTag,
-		GitBranch:     gitBranch,
-		BuildDate:     buildDate,
-		GoVersion:     runtime.Version(),
-		Compiler:      runtime.Compiler,
-		Platform:      fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+// GetVersion returns the shared ComponentVersion schema.
+func GetVersion() ComponentVersion {
+	return ComponentVersion{
+		Component:          componentName,
+		ReleaseVersion:     normalizedReleaseVersion(),
+		GitCommit:          normalizedGitCommit(),
+		GitTag:             gitTag,
+		GitBranch:          normalizedGitBranch(),
+		ProtocolVersion:    protocolVersion,
+		MinProtocolVersion: minProtocolVersion,
+		Capabilities:       []string{},
 	}
 }
 
@@ -68,22 +74,44 @@ func GetVersionJSON() (string, error) {
 // GetVersionString returns a simple version string: "version (commit: commit-id, tag/branch: name)"
 // This format matches other Curvine components for consistency
 func GetVersionString() string {
-	version := driverVersion
-	if version == "" || version == "unknown" {
-		version = "dev"
-	}
-	commit := gitCommit
-	if commit == "" || commit == "unknown" {
-		commit = "unknown"
-	}
+	version := GetVersion()
 
 	// Build source info: prefer tag over branch
 	sourceInfo := ""
-	if gitTag != "" && gitTag != "unknown" {
-		sourceInfo = fmt.Sprintf(", tag: %s", gitTag)
-	} else if gitBranch != "" && gitBranch != "unknown" && gitBranch != "HEAD" {
-		sourceInfo = fmt.Sprintf(", branch: %s", gitBranch)
+	if version.GitTag != "" && version.GitTag != "unknown" {
+		sourceInfo = fmt.Sprintf(", tag: %s", version.GitTag)
+	} else if version.GitBranch != "" && version.GitBranch != "unknown" && version.GitBranch != "HEAD" {
+		sourceInfo = fmt.Sprintf(", branch: %s", version.GitBranch)
 	}
 
-	return fmt.Sprintf("%s (commit: %s%s)", version, commit, sourceInfo)
+	return fmt.Sprintf("%s (commit: %s%s)", version.ReleaseVersion, version.GitCommit, sourceInfo)
+}
+
+func GetRuntimeVersionMetadata() map[string]string {
+	return map[string]string{
+		"go-version": runtime.Version(),
+		"compiler":   runtime.Compiler,
+		"platform":   fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}
+
+func normalizedReleaseVersion() string {
+	if driverVersion == "" || driverVersion == "unknown" {
+		return "dev"
+	}
+	return driverVersion
+}
+
+func normalizedGitCommit() string {
+	if gitCommit == "" {
+		return "unknown"
+	}
+	return gitCommit
+}
+
+func normalizedGitBranch() string {
+	if gitBranch == "HEAD" {
+		return ""
+	}
+	return gitBranch
 }

--- a/curvine-csi/pkg/csi/version_test.go
+++ b/curvine-csi/pkg/csi/version_test.go
@@ -1,0 +1,58 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package csi
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestGetVersionJSONUsesComponentVersionSchema(t *testing.T) {
+	versionJSON, err := GetVersionJSON()
+	if err != nil {
+		t.Fatalf("GetVersionJSON() returned error: %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(versionJSON), &decoded); err != nil {
+		t.Fatalf("version JSON should be valid JSON: %v", err)
+	}
+
+	expectedKeys := []string{
+		"component",
+		"release_version",
+		"git_commit",
+		"git_tag",
+		"git_branch",
+		"protocol_version",
+		"min_protocol_version",
+		"capabilities",
+	}
+	for _, key := range expectedKeys {
+		if _, ok := decoded[key]; !ok {
+			t.Fatalf("version JSON missing key %q: %s", key, versionJSON)
+		}
+	}
+
+	if decoded["component"] != componentName {
+		t.Fatalf("component = %v, want %s", decoded["component"], componentName)
+	}
+	if decoded["DriverVersion"] != nil {
+		t.Fatalf("version JSON should use shared snake_case schema: %s", versionJSON)
+	}
+	if capabilities, ok := decoded["capabilities"].([]any); !ok || len(capabilities) != 0 {
+		t.Fatalf("capabilities = %#v, want empty JSON array", decoded["capabilities"])
+	}
+}

--- a/curvine-fuse/src/bin/curvine-fuse.rs
+++ b/curvine-fuse/src/bin/curvine-fuse.rs
@@ -14,7 +14,7 @@
 
 use clap::Parser;
 use curvine_alloc as _;
-use curvine_core_error::CommonResult;
+use curvine_core_error::{err_box, CommonResult};
 use curvine_fuse::cli::{
     run_list_config_flags, run_mount, run_validate_config, FuseCli, FuseSubcommand,
 };
@@ -23,6 +23,15 @@ use curvine_fuse::cli::{
 // umount -f /curvine-fuse; cargo run --bin curvine-fuse -- --conf /server/conf/curvine-cluster.toml
 fn main() -> CommonResult<()> {
     let cli = FuseCli::parse();
+    if cli.version_json {
+        let json = match curvine_sys::version::component_version_json("fuse") {
+            Ok(json) => json,
+            Err(e) => return err_box!("Failed to serialize component version: {}", e),
+        };
+        println!("{}", json);
+        return Ok(());
+    }
+
     match &cli.cmd {
         None | Some(FuseSubcommand::Mount(_)) => run_mount(cli.resolve_runtime_args()),
         Some(FuseSubcommand::ValidateConfig(_)) => run_validate_config(cli.resolve_runtime_args()),

--- a/curvine-fuse/src/cli/fuse_cli.rs
+++ b/curvine-fuse/src/cli/fuse_cli.rs
@@ -41,6 +41,10 @@ pub struct ListConfigFlagsArgs {
     args_conflicts_with_subcommands = true
 )]
 pub struct FuseCli {
+    /// Print the component version in JSON format and exit
+    #[arg(long, global = true)]
+    pub version_json: bool,
+
     #[command(subcommand)]
     pub cmd: Option<FuseSubcommand>,
 
@@ -206,6 +210,14 @@ mod tests {
         let err =
             FuseCli::try_parse_from(["curvine-fuse", "--io-threads", "4", "mount"]).unwrap_err();
         assert!(err.to_string().contains("cannot be used with"));
+    }
+
+    #[test]
+    fn version_json_parses_without_mount_args() {
+        let cli = FuseCli::try_parse_from(["curvine-fuse", "--version-json"]).unwrap();
+
+        assert!(cli.version_json);
+        assert!(cli.cmd.is_none());
     }
 
     #[test]

--- a/curvine-server/src/bin/curvine-server.rs
+++ b/curvine-server/src/bin/curvine-server.rs
@@ -24,6 +24,15 @@ use curvine_worker::Worker;
 
 fn main() -> CommonResult<()> {
     let args: ServerArgs = ServerArgs::parse();
+    if args.version_json {
+        let json = match version::component_version_json(args.component_name()) {
+            Ok(json) => json,
+            Err(e) => return err_box!("Failed to serialize component version: {}", e),
+        };
+        println!("{}", json);
+        return Ok(());
+    }
+
     println!(
         "datetime: {}, git version: {}, args: {:#?}",
         LocalTime::now_datetime(),
@@ -60,6 +69,9 @@ fn main() -> CommonResult<()> {
 #[derive(Debug, Parser, Clone)]
 #[command(version = version::VERSION)]
 pub struct ServerArgs {
+    #[arg(long, help = "Print the component version in JSON format and exit")]
+    version_json: bool,
+
     // Start the worker or the master
     #[arg(long, default_value = "")]
     service: String,
@@ -70,6 +82,15 @@ pub struct ServerArgs {
 }
 
 impl ServerArgs {
+    pub fn component_name(&self) -> &'static str {
+        match self.service.to_lowercase().as_str() {
+            "master" => "master",
+            "worker" => "worker",
+            "transfer" => "data-transfer",
+            _ => "server",
+        }
+    }
+
     pub fn get_service(&self) -> CommonResult<ServiceType> {
         let service = self.service.to_lowercase();
         match service.as_str() {
@@ -89,4 +110,28 @@ pub enum ServiceType {
     Master,
     Worker,
     Transfer,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn version_json_accepts_service_component() {
+        let args =
+            ServerArgs::try_parse_from(["curvine-server", "--service", "master", "--version-json"])
+                .expect("server version json should parse");
+
+        assert!(args.version_json);
+        assert_eq!(args.component_name(), "master");
+    }
+
+    #[test]
+    fn version_json_without_service_uses_server_component() {
+        let args = ServerArgs::try_parse_from(["curvine-server", "--version-json"])
+            .expect("server version json should parse without service");
+
+        assert!(args.version_json);
+        assert_eq!(args.component_name(), "server");
+    }
 }


### PR DESCRIPTION
# Summary

Add a shared `ComponentVersion` JSON schema and wire `--version-json` through Curvine server, client, CLI, FUSE, and CSI entrypoints.

The new output is additive: existing startup paths and existing human-readable version behavior remain unchanged.

# Issue Describe / Design

Related to #1527.

Design decisions:
- `curvine-sys::version` is the single Rust source for `ComponentVersion`, using the fields `component`, `release_version`, `git_commit`, `git_tag`, `git_branch`, `protocol_version`, `min_protocol_version`, and `capabilities`.
- `curvine-server --service master|worker --version-json` maps the shared server binary to the runtime component name.
- `curvine-client` now has a minimal version-query binary so the client component can be validated independently.
- Packaged service wrappers forward version queries directly to the underlying binaries instead of entering start/stop handling.
- CSI now emits the same snake_case schema and uses the shared workspace version helper in its Docker build.

Compatibility risk is low because all changes are additive and version-json paths exit before service startup, mount, or config loading.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `crates/core/curvine-sys/src/version.rs` | Added `ComponentVersion`, protocol constants, JSON helper, and schema tests. | None; existing version constants remain available. |
| `curvine-server/src/bin/curvine-server.rs` | Added `--version-json` and service-to-component mapping for master, worker, and data-transfer. | None; normal service startup is unchanged. |
| `curvine-client/src/main.rs` | Added a minimal client binary for `--version-json`. | Additive; existing client library exports are unchanged. |
| `curvine-cli/src/main.rs` | Added top-level `--version-json` while preserving missing-subcommand behavior. | None for existing subcommands and `version` output. |
| `curvine-fuse/src/bin/curvine-fuse.rs`, `curvine-fuse/src/cli/fuse_cli.rs` | Added `--version-json` before mount/config flows. | None; mount and validation flows are unchanged. |
| `build/bin/*.sh` | Forward version queries from packaged master, worker, transfer, and fuse wrappers. | None for start/stop/restart/reload commands. |
| `curvine-csi/pkg/csi/version.go` | Replaced CSI JSON version output with the shared `ComponentVersion` schema. | `--version-json` schema changes to the shared format; CSI `--version` and identity metadata remain. |
| `curvine-csi/pkg/csi/fuse_validate_test.go` | Made timeout test use a temporary sleep script instead of `yes`. | Test-only stability fix. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-sys` | PASS | 16 tests passed. |
| `cargo test -p curvine-cli version_json_does_not_require_subcommand` | PASS | Confirms bare `--version-json` parsing. |
| `cargo test -p curvine-server version_json` | PASS | Confirms master/server component mapping. |
| `cargo test -p curvine-fuse version_json_parses_without_mount_args` | PASS | Confirms FUSE does not enter mount parsing. |
| `cargo test -p curvine-client version_json_parses_without_other_args` | PASS | Confirms new client version binary. |
| `go test ./...` in `curvine-csi` | PASS | CSI package tests passed. |
| `make format-csi` | PASS | gofmt/go vet path passed. |
| `make format` | PASS | Final required project gate passed after all changes. |
| `git diff --check` | PASS | No whitespace errors. |
| `cargo run -p curvine-cli -- --version-json` | PASS | Output matches shared schema. |
| `cargo run -p curvine-client -- --version-json` | PASS | Output matches shared schema. |
| `cargo run -p curvine-server -- --service master --version-json` | PASS | Output component is `master`. |
| `cargo run -p curvine-server -- --service worker --version-json` | PASS | Output component is `worker`. |
| `cargo run -p curvine-fuse -- --version-json` | PASS | Output component is `fuse`. |
| `go run . --version-json` in `curvine-csi` | PASS | Output component is `csi`. |

# Dependencies

- Related PRs: #1529
- Related issues: #1527
- Blocks / blocked by: None

## Review follow-up

Addressed Copilot review comments:
- `curvine-cli/src/main.rs`: removed `arg_required_else_help` so bare `curvine` reaches the manual `MissingSubcommand` error path; added regression test.
- `curvine-csi/Dockerfile`: set `SHELL ["/bin/bash", "-c"]` so `version.sh` is sourced under bash.

Additional verification:
- `make format` PASS
- `cargo test -p curvine-cli` PASS
- bare `curvine` invocation returns the custom `MissingSubcommand` error PASS
- `curvine --version-json` still parses and emits the shared schema PASS
- `git diff --check` PASS