### PR TITLE
fix(fuse): make FUSE startup failures actionable

### DIFF
--- a/build/bin/curvine-fuse.sh
+++ b/build/bin/curvine-fuse.sh
@@ -14,40 +14,97 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Execute fuse mount with parameter passthrough
-
-# Default mount point
+BIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)"
 MNT_PATH=/curvine-fuse
 
-# Process arguments in a single loop
-for arg in "$@"; do
-    if [[ "$arg" == "--help" ]] || [[ "$arg" == "-h" ]]; then
-        . "$(cd "`dirname "$0"`"; pwd)"/../conf/curvine-env.sh
-        ${CURVINE_HOME}/lib/curvine-fuse --help
-        exit 0
+is_mountpoint() {
+    local path="$1"
+    local mountinfo="${2:-/proc/self/mountinfo}"
+    local mount_id parent major_minor root mount_path mount_options
+
+    while read -r mount_id parent major_minor root mount_path mount_options; do
+        # Linux mountinfo escapes path whitespace and backslashes as octal
+        # sequences. Decode in-place so trailing newlines remain lossless.
+        mount_path=${mount_path//\\040/ }
+        mount_path=${mount_path//\\011/$'\t'}
+        mount_path=${mount_path//\\012/$'\n'}
+        mount_path=${mount_path//\\134/$'\\'}
+        if [[ "$mount_path" == "$path" ]]; then
+            return 0
+        fi
+    done < "$mountinfo"
+
+    return 1
+}
+
+prepare_mount_path() {
+    if is_mountpoint "$MNT_PATH"; then
+        echo "Refusing to touch mounted path ${MNT_PATH}. Stop or unmount the existing FUSE mount first." >&2
+        return 1
     fi
 
-    if [[ "$arg" == "--version-json" ]] || [[ "$arg" == "--version" ]] || [[ "$arg" == "-V" ]]; then
-        . "$(cd "`dirname "$0"`"; pwd)"/../conf/curvine-env.sh
-        ${CURVINE_HOME}/lib/curvine-fuse "$arg"
-        exit 0
+    if [ -e "$MNT_PATH" ] && [ ! -d "$MNT_PATH" ]; then
+        echo "FUSE mount path exists but is not a directory: ${MNT_PATH}" >&2
+        return 1
     fi
-    
-    # Extract mount path from arguments if specified
-    if [[ "$arg" == --mnt-path=* ]]; then
-        MNT_PATH="${arg#*=}"
-    elif [[ "$arg" == "--mnt-path" ]]; then
-        next_is_path=true
-        continue
-    elif [[ "$next_is_path" == true ]]; then
-        MNT_PATH="$arg"
-        next_is_path=false
-    fi
-done
 
-mkdir -p "$MNT_PATH"
+    mkdir -p "$MNT_PATH"
+}
 
-echo "Starting curvine-fuse with arguments: $*"
+main() {
+    local arg
+    MNT_PATH=/curvine-fuse
 
-# Pass all arguments to launch-process.sh
-"$(cd "$(dirname "$0")"; pwd)"/launch-process.sh fuse "$@"
+    for arg in "$@"; do
+        if [[ "$arg" == "--help" ]] || [[ "$arg" == "-h" ]]; then
+            . "${BIN_DIR}/../conf/curvine-env.sh"
+            "${CURVINE_HOME}/lib/curvine-fuse" --help
+            exit 0
+        fi
+        if [[ "$arg" == "--version-json" ]] || [[ "$arg" == "--version" ]] || [[ "$arg" == "-V" ]]; then
+            . "${BIN_DIR}/../conf/curvine-env.sh"
+            "${CURVINE_HOME}/lib/curvine-fuse" "$arg"
+            exit 0
+        fi
+    done
+
+    ACTION=${1:-}
+    shift || true
+    PARAMS=("$@")
+
+    local i
+    for ((i = 0; i < ${#PARAMS[@]}; i++)); do
+        arg=${PARAMS[$i]}
+        if [[ "$arg" == --mnt-path=* ]]; then
+            MNT_PATH="${arg#*=}"
+        elif [[ "$arg" == "--mnt-path" ]] && (( i + 1 < ${#PARAMS[@]} )); then
+            MNT_PATH=${PARAMS[$((i + 1))]}
+        fi
+    done
+
+    case "$ACTION" in
+        start)
+            prepare_mount_path || exit 1
+            echo "Starting curvine-fuse with arguments: ${PARAMS[*]}"
+            exec "${BIN_DIR}/launch-process.sh" fuse start "${PARAMS[@]}"
+            ;;
+        restart)
+            "${BIN_DIR}/launch-process.sh" fuse stop "${PARAMS[@]}" || exit $?
+            sleep 1
+            prepare_mount_path || exit 1
+            echo "Starting curvine-fuse with arguments: ${PARAMS[*]}"
+            exec "${BIN_DIR}/launch-process.sh" fuse start "${PARAMS[@]}"
+            ;;
+        stop|reload)
+            exec "${BIN_DIR}/launch-process.sh" fuse "$ACTION" "${PARAMS[@]}"
+            ;;
+        *)
+            echo "Usage: $0 [start|stop|restart|reload] [FUSE options]" >&2
+            exit 1
+            ;;
+    esac
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/build/bin/launch-process.sh
+++ b/build/bin/launch-process.sh
@@ -20,12 +20,11 @@
 
 SERVICE_NAME=$1
 ACTION=$2
-PARAMS="${@:3}"
+PARAMS=("${@:3}")
 
 PID_FILE=${CURVINE_HOME}/${SERVICE_NAME}.pid
 GRACEFULLY_TIMEOUT=15
 RELOAD_LOCK_FILE=${CURVINE_HOME}/${SERVICE_NAME}.reload.lock
-
 LOG_DIR=${CURVINE_HOME}/logs
 OUT_FILE=${LOG_DIR}/${SERVICE_NAME}.out
 
@@ -34,17 +33,34 @@ if [ -z "$CURVINE_CONF_FILE" ]; then
   export CURVINE_CONF_FILE=$CURVINE_HOME/conf/curvine-cluster.toml
 fi
 
-mkdir -p ${LOG_DIR}
+if ! mkdir -p "${LOG_DIR}"; then
+  echo "Failed to create Curvine log directory: ${LOG_DIR}" >&2
+  exit 1
+fi
 
-cd ${CURVINE_HOME}
+cd "${CURVINE_HOME}"
+
+has_fuse_conf_arg() {
+  local arg
+  for arg in "${PARAMS[@]}"; do
+    case "${arg}" in
+      --conf|--conf=*|-c|-c=*|-c?*)
+        return 0
+        ;;
+    esac
+  done
+  return 1
+}
 
 check() {
   if [ -f "${PID_FILE}" ]; then
-    local PID=`cat ${PID_FILE}`
-    if kill -0 ${PID} > /dev/null 2>&1; then
+    local PID
+    PID=$(cat "${PID_FILE}")
+    if kill -0 "${PID}" > /dev/null 2>&1; then
       echo "${SERVICE_NAME} running, pid=${PID}. Please execute stop first"
       exit 1
     fi
+    rm -f "${PID_FILE}"
   fi
 }
 
@@ -54,16 +70,17 @@ start() {
     name="unknown"
     if [[ "$SERVICE_NAME" = "worker" ]] || [[ "$SERVICE_NAME" = "master" ]] || [[ "$SERVICE_NAME" = "transfer" ]]; then
       name="curvine-server"
-      nohup ${CURVINE_HOME}/lib/curvine-server \
+      nohup "${CURVINE_HOME}/lib/curvine-server" \
       --service ${SERVICE_NAME} \
-      --conf ${CURVINE_CONF_FILE} \
-      > ${OUT_FILE} 2>&1 < /dev/null  &
+      --conf "${CURVINE_CONF_FILE}" \
+      > "${OUT_FILE}" 2>&1 < /dev/null  &
     elif [[ "$SERVICE_NAME" = "fuse" ]]; then
        name="curvine-fuse"
-       nohup ${CURVINE_HOME}/lib/curvine-fuse \
-       $PARAMS \
-       --conf ${CURVINE_CONF_FILE} \
-       > ${OUT_FILE} 2>&1 < /dev/null  &
+       local fuse_args=("${CURVINE_HOME}/lib/curvine-fuse" "${PARAMS[@]}")
+       if ! has_fuse_conf_arg; then
+         fuse_args+=(--conf "${CURVINE_CONF_FILE}")
+       fi
+       nohup "${fuse_args[@]}" > "${OUT_FILE}" 2>&1 < /dev/null &
     else
        echo "Unknown service"
        exit
@@ -73,13 +90,15 @@ start() {
     sleep 3
 
     if [[ $(ps -p "${NEW_PID}" -o comm=) =~ $name ]]; then
-        echo ${NEW_PID} > ${PID_FILE}
+        echo "${NEW_PID}" > "${PID_FILE}"
         echo "${SERVICE_NAME} start success, pid=${NEW_PID}"
     else
-      echo "${SERVICE_NAME} start fail"
+      echo "${SERVICE_NAME} start failed; inspect ${OUT_FILE}" >&2
+      tail -n 80 "${OUT_FILE}" >&2 || true
+      return 1
     fi
 
-    head ${OUT_FILE}
+    head "${OUT_FILE}"
 }
 
 waitPid() {
@@ -99,16 +118,17 @@ waitPid() {
 
 stop() {
   if [ -f "${PID_FILE}" ]; then
-    local PID=`cat ${PID_FILE}`
-    if kill -0 $PID > /dev/null 2>&1; then
+    local PID
+    PID=$(cat "${PID_FILE}")
+    if kill -0 "$PID" > /dev/null 2>&1; then
       echo "stopping ${SERVICE_NAME}"
 
-      kill ${PID}
-      waitPid $PID;
+      kill "${PID}"
+      waitPid "$PID";
 
-      if kill -0 $PID > /dev/null 2>&1; then
-        echo "shuffle worker: ${SERVICE_NAME} did not stop gracefully after $GRACEFULLY_TIMEOUT seconds: killing with kill -9"
-        kill -9 $PID
+      if kill -0 "$PID" > /dev/null 2>&1; then
+        echo "${SERVICE_NAME} did not stop gracefully after ${GRACEFULLY_TIMEOUT} seconds; sending SIGKILL"
+        kill -9 "$PID"
       else
         echo "${SERVICE_NAME} stop gracefully"
       fi
@@ -133,13 +153,13 @@ reload() {
       exit 1
     else
       # Stale lock file, remove it
-      rm -f ${RELOAD_LOCK_FILE}
+      rm -f "${RELOAD_LOCK_FILE}"
     fi
   fi
   
   # Create lock file
-  echo $$ > ${RELOAD_LOCK_FILE}
-  trap "rm -f ${RELOAD_LOCK_FILE}" EXIT
+  echo $$ > "${RELOAD_LOCK_FILE}"
+  trap 'rm -f "${RELOAD_LOCK_FILE}"' EXIT
   
   if [ -f "${PID_FILE}" ]; then
     local OLD_PID=`cat ${PID_FILE}`
@@ -225,4 +245,4 @@ case $1 in
 esac
 }
 
-run ${ACTION}
+run "${ACTION}"

--- a/build/tests/test_curvine_fuse.sh
+++ b/build/tests/test_curvine_fuse.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 OPPO.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+FIXTURE="$(mktemp)"
+trap 'rm -f "$FIXTURE"' EXIT
+
+cat > "$FIXTURE" <<'EOF'
+1 2 0:1 / /mnt/fuse\040data rw - fuse.curvinefs curvinefs rw
+2 3 0:1 / /mnt/fuse\011tab rw - fuse.curvinefs curvinefs rw
+3 4 0:1 / /mnt/fuse\012newline rw - fuse.curvinefs curvinefs rw
+4 5 0:1 / /mnt/fuse\134backslash rw - fuse.curvinefs curvinefs rw
+EOF
+
+# Source the production script without executing its action dispatcher.
+source "$ROOT/build/bin/curvine-fuse.sh"
+
+is_mountpoint "/mnt/fuse data" "$FIXTURE"
+is_mountpoint $'/mnt/fuse\ttab' "$FIXTURE"
+is_mountpoint $'/mnt/fuse\nnewline' "$FIXTURE"
+is_mountpoint '/mnt/fuse\backslash' "$FIXTURE"
+
+if is_mountpoint "/mnt/not-mounted" "$FIXTURE"; then
+    echo "unexpectedly matched an absent mountpoint" >&2
+    exit 1
+fi
+
+echo "curvine fuse mountinfo escaping: ok"

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -992,6 +992,15 @@ impl CurvineFileSystem {
         (major, minor) >= FUSE_MIN_ABI
     }
 
+    fn unsupported_abi_message(major: u32, minor: u32) -> String {
+        format!(
+            "The kernel FUSE protocol ABI {major}.{minor} is unsupported; Curvine requires >= {FUSE_KERNEL_VERSION}.{FUSE_KERNEL_MINOR_VERSION}. \
+             This ABI is supplied by the running kernel, not the userspace fuse/fuse3 package. \
+             Use a host kernel that reports FUSE ABI >= {FUSE_KERNEL_VERSION}.{FUSE_KERNEL_MINOR_VERSION}, \
+             or use the Curvine CLI/SDK without FUSE."
+        )
+    }
+
     /// The INIT reply for a kernel whose major ABI is newer than the daemon's: advertise only the
     /// daemon's own `(major, minor)` with no negotiated flags, and leave every other field zeroed.
     fn version_only_init_out() -> fuse_init_out {
@@ -1006,14 +1015,8 @@ impl CurvineFileSystem {
 impl fs::FileSystem for CurvineFileSystem {
     async fn init(&self, op: Init<'_>) -> FuseResult<fuse_init_out> {
         if !Self::abi_supported(op.arg.major, op.arg.minor) {
-            return err_fuse!(
-                libc::EPROTO,
-                "unsupported FUSE ABI {}.{}: curvine requires >= {}.{}",
-                op.arg.major,
-                op.arg.minor,
-                FUSE_KERNEL_VERSION,
-                FUSE_KERNEL_MINOR_VERSION
-            );
+            let message = Self::unsupported_abi_message(op.arg.major, op.arg.minor);
+            return err_fuse!(libc::EPROTO, "{}", message);
         }
 
         // Newer kernel major: reply with our version only and negotiate no flags.
@@ -3089,6 +3092,17 @@ mod tests {
     #[test]
     fn advertised_timestamp_granularity_matches_millisecond_storage() {
         assert_eq!(super::FUSE_TIME_GRANULARITY_NS, 1_000_000);
+    }
+
+    #[test]
+    fn unsupported_abi_message_explains_kernel_requirement() {
+        let message = CurvineFileSystem::unsupported_abi_message(7, 22);
+
+        assert!(message.contains("kernel FUSE protocol ABI 7.22"));
+        assert!(message.contains("requires >= 7.31"));
+        assert!(message.contains("userspace fuse/fuse3 package"));
+        assert!(message.contains("running kernel"));
+        assert!(message.contains("CLI/SDK without FUSE"));
     }
 
     // Higher-major short reply (mirrors libfuse `_do_init`'s `arg->major > 7`

--- a/curvine-fuse/src/fuse_error.rs
+++ b/curvine-fuse/src/fuse_error.rs
@@ -42,6 +42,13 @@ impl FuseError {
         Self::new(normalize_errno(errno), error)
     }
 
+    /// Preserve an OS errno for daemon startup failures without changing the
+    /// established EIO normalization used by runtime request paths.
+    pub(crate) fn from_startup_io_error(value: IOError) -> Self {
+        let errno = value.raw_error().raw_os_error().unwrap_or(libc::EIO);
+        Self::from_errno_msg(errno, value.into())
+    }
+
     pub(crate) fn errno(&self) -> i32 {
         self.errno
     }
@@ -198,6 +205,7 @@ pub(crate) fn splice_errno_label(errno: i32) -> &'static str {
 mod tests {
     use super::{errno_label, splice_errno_label, FuseError};
     use curvine_error::FsError;
+    use curvine_io::IOError;
 
     // Display prints the errno NUMBER first, then the message ("errno 2: ...").
     #[test]
@@ -238,6 +246,15 @@ mod tests {
         let err: FuseError = FsError::read_only("/mnt/ro").into();
         assert_eq!(err.errno, libc::EROFS);
         assert_eq!(errno_label(err.errno), "EROFS");
+    }
+
+    #[test]
+    fn startup_io_error_preserves_os_errno() {
+        let error = IOError::from(std::io::Error::from_raw_os_error(libc::EPERM));
+        let error = FuseError::from_startup_io_error(error);
+
+        assert_eq!(error.errno, libc::EPERM);
+        assert!(error.to_string().contains("Operation not permitted"));
     }
 
     #[test]

--- a/curvine-fuse/src/raw/fuse_pure.rs
+++ b/curvine-fuse/src/raw/fuse_pure.rs
@@ -105,23 +105,15 @@ pub fn fuse_mount_pure(mnt: &Path, conf: &FuseConf) -> IOResult<RawIO> {
     match res {
         Ok(fd) => Ok(fd),
         Err(e) => {
-            error!("fuse mount sys failed; path {:?}, err {:?}", mnt, e);
-            // Preserve the original mount error captured by `fuse_mount_sys`
-            // (e.g. the real EACCES/ENOENT/EBUSY errno). Do NOT re-read
-            // `std::io::Error::last_os_error()` here: intervening operations
-            // such as logging can clobber `errno`, turning a specific mount
-            // failure into a generic error and losing useful diagnostics.
-            Err(IOError::with_ctx(
-                e.into_raw(),
-                format!("({}:{})", file!(), line!()),
-            ))
+            error!("fuse mount sys failed; path {:?}, err {}", mnt, e);
+            Err(e)
         }
     }
 }
 
 fn fuse_mount_sys(mnt: &Path, conf: &FuseConf) -> IOResult<RawIO> {
     let fuse_device_name = "/dev/fuse";
-    let mountpoint_mode = File::open(mnt)?.metadata()?.permissions().mode();
+    let mountpoint_mode = mountpoint_mode(mnt)?;
 
     // Auto unmount requests must be sent to fusermount binary
     let path = CString::new(fuse_device_name).unwrap();
@@ -129,8 +121,9 @@ fn fuse_mount_sys(mnt: &Path, conf: &FuseConf) -> IOResult<RawIO> {
     let fd = match res {
         Ok(fd) => fd,
         Err(e) => {
-            error!("Open fuse device failed, {}, err {:?}", fuse_device_name, e);
-            return Err(std::io::Error::from(ErrorKind::Other).into());
+            let error = describe_fuse_device_error(e.into());
+            error!("Open fuse device failed, {}: {}", fuse_device_name, error);
+            return Err(error);
         }
     };
     // SAFETY: open returned a fresh descriptor whose ownership is transferred here.
@@ -160,29 +153,176 @@ fn fuse_mount_sys(mnt: &Path, conf: &FuseConf) -> IOResult<RawIO> {
     let c_mountpoint = path_to_cstring(mnt)?;
 
     let result = unsafe {
-        let c_options = CString::new(mount_options.clone()).unwrap();
-        let c_type = CString::new("fuse").unwrap();
-        libc::mount(
-            c_source.as_ptr(),
-            c_mountpoint.as_ptr(),
-            c_type.as_ptr(),
-            flags,
-            c_options.as_ptr() as *const libc::c_void,
-        )
+        #[cfg(target_os = "linux")]
+        {
+            let c_options = CString::new(mount_options.clone()).unwrap();
+            let c_type = CString::new("fuse").unwrap();
+            libc::mount(
+                c_source.as_ptr(),
+                c_mountpoint.as_ptr(),
+                c_type.as_ptr(),
+                flags,
+                c_options.as_ptr() as *const libc::c_void,
+            )
+        }
+        #[cfg(target_os = "macos")]
+        {
+            let c_options = CString::new(mount_options.as_str()).unwrap();
+            libc::mount(
+                c_source.as_ptr(),
+                c_mountpoint.as_ptr(),
+                flags as i32,
+                c_options.as_ptr() as *mut libc::c_void,
+            )
+        }
     };
 
-    complete_mount(fd, result, mnt)
+    complete_mount(fd, result, mnt, &mount_options)
 }
 
-fn complete_mount(fd: OwnedFd, result: libc::c_int, mnt: &Path) -> IOResult<RawIO> {
-    if result != 0 {
-        let error = std::io::Error::last_os_error();
-        error!(
-            "Mount fuse failed, {} with result {}",
+fn describe_mount_error(mnt: &Path, mount_options: &str, error: IOError) -> IOError {
+    let raw_error = error.into_raw();
+    let context = match raw_error.raw_os_error() {
+        Some(libc::EINVAL) => format!(
+            "FUSE mount request was rejected by the kernel (EINVAL). EINVAL alone does not identify the rejected argument. \
+             Mount path: {}. Options: {}. Inspect `dmesg -T | tail -n 80`, then retry with a minimal `--options` list to isolate legacy-kernel incompatibilities.",
             mnt.display(),
-            result
+            mount_options
+        ),
+        Some(libc::EACCES) | Some(libc::EPERM) => format!(
+            "FUSE mount permission was denied by the kernel ({}). Mount path: {}. Options: {}. \
+             Ensure /dev/fuse is available and the runtime is allowed to mount FUSE (for containers: CAP_SYS_ADMIN plus the platform's FUSE device and security-policy allowance).",
+            raw_error,
+            mnt.display(),
+            mount_options
+        ),
+        Some(libc::EBUSY) => format!(
+            "FUSE mount point {} is busy or already mounted (EBUSY). Stop or unmount the existing mount before retrying; use mount-table tooling rather than accessing an unhealthy mount path. Options: {}.",
+            mnt.display(),
+            mount_options
+        ),
+        Some(libc::ENOENT) => format!(
+            "FUSE mount point {} disappeared before the kernel mounted it (ENOENT). Recreate the directory and verify the path remains available. Options: {}.",
+            mnt.display(),
+            mount_options
+        ),
+        Some(libc::ENOTDIR) => format!(
+            "FUSE mount point {} is no longer a directory (ENOTDIR). Select an empty directory as --mnt-path. Options: {}.",
+            mnt.display(),
+            mount_options
+        ),
+        Some(libc::ENODEV) => format!(
+            "FUSE mount failed because the kernel FUSE device/driver is unavailable (ENODEV). \
+             Confirm /dev/fuse exists and the host has the fuse kernel module loaded. Mount path: {}. Options: {}.",
+            mnt.display(),
+            mount_options
+        ),
+        _ => format!(
+            "FUSE mount syscall failed. Mount path: {}. Options: {}. \
+             Inspect `dmesg -T | tail -n 80` for the kernel-side reason.",
+            mnt.display(),
+            mount_options
+        ),
+    };
+    IOError::with_ctx(raw_error, context)
+}
+
+fn mountpoint_mode(mnt: &Path) -> IOResult<u32> {
+    // Preserve the prior File::open permission check; this only adds diagnostics.
+    let metadata =
+        File::open(mnt).map_err(|error| describe_mountpoint_error("inspect", mnt, error.into()))?;
+    let metadata = metadata
+        .metadata()
+        .map_err(|error| describe_mountpoint_error("inspect", mnt, error.into()))?;
+    if !metadata.is_dir() {
+        let error = IOError::from(std::io::Error::from_raw_os_error(libc::ENOTDIR));
+        return Err(describe_mountpoint_error("inspect", mnt, error));
+    }
+    Ok(metadata.permissions().mode())
+}
+
+fn describe_mountpoint_error(stage: &str, mnt: &Path, error: IOError) -> IOError {
+    let raw_error = error.into_raw();
+    let context = match raw_error.raw_os_error() {
+        Some(libc::ENOENT) => format!(
+            "FUSE mount point {} does not exist. Create an empty directory and ensure the mounting user can access it.",
+            mnt.display()
+        ),
+        Some(libc::ENOTDIR) => format!(
+            "FUSE mount point {} is not a directory. Select an empty directory as --mnt-path.",
+            mnt.display()
+        ),
+        Some(libc::EACCES) | Some(libc::EPERM) => format!(
+            "Cannot access FUSE mount point {}. Check directory ownership, execute permission, and container volume policy.",
+            mnt.display()
+        ),
+        _ => format!(
+            "Cannot {stage} FUSE mount point {}. Check the path and its filesystem health.",
+            mnt.display()
+        ),
+    };
+    IOError::with_ctx(raw_error, context)
+}
+
+fn describe_fuse_device_error(error: IOError) -> IOError {
+    let raw_error = error.into_raw();
+    let context = match raw_error.raw_os_error() {
+        Some(libc::ENOENT) | Some(libc::ENODEV) => {
+            "FUSE device /dev/fuse is unavailable. Confirm the host has the fuse kernel module loaded and that the runtime receives the device assignment.".to_string()
+        }
+        Some(libc::EACCES) | Some(libc::EPERM) => {
+            "Access to FUSE device /dev/fuse was denied. Check device permissions and, in containers, the FUSE device assignment and security policy.".to_string()
+        }
+        _ => "Unable to open FUSE device /dev/fuse. Check device availability and runtime permissions."
+            .to_string(),
+    };
+    IOError::with_ctx(raw_error, context)
+}
+
+fn describe_unmount_error(mnt: &Path, error: IOError) -> IOError {
+    let raw_error = error.into_raw();
+    let context = match raw_error.raw_os_error() {
+        Some(libc::EBUSY) => format!(
+            "FUSE unmount of {} is busy (EBUSY). Stop processes using the mount, then retry the unmount; avoid probing an unhealthy mount path.",
+            mnt.display()
+        ),
+        Some(libc::EINVAL) => format!(
+            "FUSE unmount of {} was rejected because it is not a mounted filesystem (EINVAL). Inspect the mount table before retrying.",
+            mnt.display()
+        ),
+        Some(libc::ENOENT) => format!(
+            "FUSE unmount path {} no longer exists (ENOENT). Inspect the mount table for stale mount state.",
+            mnt.display()
+        ),
+        Some(libc::EACCES) | Some(libc::EPERM) => format!(
+            "FUSE unmount of {} was denied ({}). Check runtime mount permissions and container security policy.",
+            mnt.display(),
+            raw_error
+        ),
+        _ => format!(
+            "FUSE unmount syscall failed for {}. Inspect `dmesg -T | tail -n 80` and the mount table for the kernel-side reason.",
+            mnt.display()
+        ),
+    };
+    IOError::with_ctx(raw_error, context)
+}
+
+fn complete_mount(
+    fd: OwnedFd,
+    result: libc::c_int,
+    mnt: &Path,
+    mount_options: &str,
+) -> IOResult<RawIO> {
+    if result != 0 {
+        let error = IOError::from(std::io::Error::last_os_error());
+        let error = describe_mount_error(mnt, mount_options, error);
+        error!(
+            "Mount fuse failed, {} with result {}: {}",
+            mnt.display(),
+            result,
+            error
         );
-        return Err(error.into());
+        return Err(error);
     }
     info!("Mounted at {}", mnt.display());
     Ok(fd.into_raw_fd())
@@ -212,54 +352,42 @@ pub fn fuse_umount_pure(mnt: &Path) -> IOResult<()> {
     if result == 0 {
         return Ok(());
     }
-
-    // Capture the direct unmount errno immediately, before any other syscall
-    // (e.g. spawning fusermount) can clobber `errno`.
-    let direct_err = std::io::Error::last_os_error();
+    // Capture and contextualize the direct errno before probing the fallback.
+    let direct_error = describe_unmount_error(mnt, IOError::from(std::io::Error::last_os_error()));
+    let direct_message = direct_error.to_string();
+    let direct_raw = direct_error.into_raw();
+    let fusermount_bin = detect_fusermount_bin();
     info!(
         "direct umount2 failed for {:?}: {}; falling back to fusermount",
-        mnt, direct_err
+        mnt, direct_message
     );
 
-    let mut builder = Command::new(detect_fusermount_bin());
+    let mut builder = Command::new(&fusermount_bin);
     builder.stdout(Stdio::piped()).stderr(Stdio::piped());
     builder.arg("-u").arg("-q").arg("-z").arg("--").arg(mnt);
 
     let output = match builder.output() {
         Ok(output) => output,
         Err(spawn_err) => {
-            // Both the direct unmount and spawning the fallback failed; surface
-            // the original unmount error together with the spawn failure.
-            return Err(IOError::with_ctx(
-                std::io::Error::new(
-                    spawn_err.kind(),
-                    format!(
-                        "umount {:?} failed (direct: {}; fusermount spawn: {})",
-                        mnt, direct_err, spawn_err
-                    ),
-                ),
-                format!("({}:{})", file!(), line!()),
-            ));
+            let message = format!(
+                "{direct_message} FUSE unmount fallback {fusermount_bin} could not start: {spawn_err}"
+            );
+            error!("{}", message);
+            return Err(IOError::with_ctx(direct_raw, message));
         }
     };
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         let stdout = String::from_utf8_lossy(&output.stdout);
-        error!(
-            "fusermount unmount failed for {:?}: status={}, stderr={}, stdout={}",
-            mnt, output.status, stderr, stdout
+        let message = format!(
+            "{direct_message} FUSE unmount fallback {fusermount_bin} failed with status {}. stdout: {} stderr: {}",
+            output.status,
+            stdout.trim(),
+            stderr.trim()
         );
-        return Err(IOError::with_ctx(
-            std::io::Error::other(format!(
-                "umount {:?} failed (direct: {}; fusermount exit {}: {})",
-                mnt,
-                direct_err,
-                output.status,
-                stderr.trim()
-            )),
-            format!("({}:{})", file!(), line!()),
-        ));
+        error!("{}", message);
+        return Err(IOError::with_ctx(direct_raw, message));
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -271,9 +399,13 @@ pub fn fuse_umount_pure(mnt: &Path) -> IOResult<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{complete_mount, path_to_cstring};
+    use super::{
+        complete_mount, describe_fuse_device_error, describe_mount_error,
+        describe_mountpoint_error, describe_unmount_error, mountpoint_mode, path_to_cstring,
+    };
+    use curvine_io::IOError;
     use std::ffi::OsStr;
-    use std::fs::File;
+    use std::fs::{self, File};
     use std::os::unix::ffi::OsStrExt;
     use std::os::unix::io::{AsRawFd, OwnedFd};
     use std::path::{Path, PathBuf};
@@ -283,7 +415,7 @@ mod tests {
         let fd: OwnedFd = File::open("/dev/null").expect("open test fd").into();
         let raw_fd = fd.as_raw_fd();
 
-        assert!(complete_mount(fd, -1, Path::new("/invalid-mount")).is_err());
+        assert!(complete_mount(fd, -1, Path::new("/invalid-mount"), "").is_err());
 
         let result = unsafe { libc::fcntl(raw_fd, libc::F_GETFD) };
         assert_eq!(result, -1, "failed mount must close the owned FUSE fd");
@@ -298,8 +430,8 @@ mod tests {
         let fd: OwnedFd = File::open("/dev/null").expect("open test fd").into();
         let raw_fd = fd.as_raw_fd();
 
-        let returned_fd =
-            complete_mount(fd, 0, Path::new("/test-mount")).expect("successful mount transfers fd");
+        let returned_fd = complete_mount(fd, 0, Path::new("/test-mount"), "")
+            .expect("successful mount transfers fd");
 
         assert_eq!(returned_fd, raw_fd);
         assert_ne!(unsafe { libc::fcntl(returned_fd, libc::F_GETFD) }, -1);
@@ -336,5 +468,87 @@ mod tests {
 
         let err = path_to_cstring(&path).expect_err("embedded NUL must be an error");
         assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn invalid_mount_options_error_preserves_errno_and_explains_next_steps() {
+        let error = IOError::from(std::io::Error::from_raw_os_error(libc::EINVAL));
+        let error = describe_mount_error(
+            Path::new("/curvine-fuse"),
+            "fd=10,rootmode=40755,async",
+            error,
+        );
+
+        assert_eq!(error.raw_error().raw_os_error(), Some(libc::EINVAL));
+        let message = error.to_string();
+        assert!(message.contains("rejected by the kernel (EINVAL)"));
+        assert!(message.contains("fd=10,rootmode=40755,async"));
+        assert!(message.contains("dmesg -T | tail -n 80"));
+        assert!(message.contains("minimal `--options` list"));
+    }
+
+    #[test]
+    fn unavailable_fuse_device_error_preserves_errno_and_explains_requirement() {
+        let error = IOError::from(std::io::Error::from_raw_os_error(libc::ENOENT));
+        let error = describe_fuse_device_error(error);
+
+        assert_eq!(error.raw_error().raw_os_error(), Some(libc::ENOENT));
+        let message = error.to_string();
+        assert!(message.contains("/dev/fuse is unavailable"));
+        assert!(message.contains("fuse kernel module"));
+        assert!(message.contains("device assignment"));
+    }
+
+    #[test]
+    fn missing_mountpoint_error_preserves_errno_and_explains_requirement() {
+        let error = IOError::from(std::io::Error::from_raw_os_error(libc::ENOENT));
+        let error = describe_mountpoint_error("inspect", Path::new("/curvine-fuse"), error);
+
+        assert_eq!(error.raw_error().raw_os_error(), Some(libc::ENOENT));
+        let message = error.to_string();
+        assert!(message.contains("mount point /curvine-fuse"));
+        assert!(message.contains("does not exist"));
+        assert!(message.contains("empty directory"));
+    }
+
+    #[test]
+    fn file_mountpoint_is_rejected_before_mount() {
+        let path = std::env::temp_dir().join(format!(
+            "curvine-fuse-mountpoint-file-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system clock is after the Unix epoch")
+                .as_nanos()
+        ));
+        File::create(&path).expect("create file mountpoint fixture");
+
+        let error = mountpoint_mode(&path).expect_err("file must not be accepted as a mountpoint");
+        let _ = fs::remove_file(&path);
+
+        assert_eq!(error.raw_error().raw_os_error(), Some(libc::ENOTDIR));
+        assert!(error.to_string().contains("is not a directory"));
+    }
+
+    #[test]
+    fn busy_mountpoint_error_preserves_errno_and_explains_next_steps() {
+        let error = IOError::from(std::io::Error::from_raw_os_error(libc::EBUSY));
+        let error = describe_mount_error(Path::new("/curvine-fuse"), "fd=10", error);
+
+        assert_eq!(error.raw_error().raw_os_error(), Some(libc::EBUSY));
+        let message = error.to_string();
+        assert!(message.contains("busy or already mounted"));
+        assert!(message.contains("Stop or unmount"));
+    }
+
+    #[test]
+    fn busy_unmount_error_preserves_errno_and_explains_next_steps() {
+        let error = IOError::from(std::io::Error::from_raw_os_error(libc::EBUSY));
+        let error = describe_unmount_error(Path::new("/curvine-fuse"), error);
+
+        assert_eq!(error.raw_error().raw_os_error(), Some(libc::EBUSY));
+        let message = error.to_string();
+        assert!(message.contains("unmount of /curvine-fuse is busy"));
+        assert!(message.contains("Stop processes using the mount"));
     }
 }

--- a/curvine-fuse/src/session/channel/fuse_receiver.rs
+++ b/curvine-fuse/src/session/channel/fuse_receiver.rs
@@ -20,6 +20,7 @@ use crate::fuse_metrics::{
     FuseReqKind, FuseReqLabels, FuseReqStatus, RECEIVE_ACTION_CONTINUE, RECEIVE_ACTION_EXIT,
 };
 use crate::raw::fuse_abi::fuse_out_header;
+use crate::session::channel::{new_splice_pipe, SplicePipeSetupError};
 use crate::session::{FuseOpCode, FuseRequest, FuseResponse, FuseTask};
 use crate::{err_fuse, FuseResult, FUSE_IN_HEADER_LEN};
 use bytes::BytesMut;
@@ -29,7 +30,7 @@ use curvine_runtime::runtime::{RpcRuntime, Runtime};
 use curvine_runtime::sync::channel::AsyncSender;
 use curvine_runtime::sync::FastDashMap;
 use curvine_sys as sys;
-use curvine_sys::pipe::{AsyncFd, Pipe2, PipeFd};
+use curvine_sys::pipe::{AsyncFd, Pipe2};
 use libc::{EAGAIN, ECONNABORTED, EINTR, ENODEV, ENOENT};
 use log::{debug, error, info, warn};
 use std::sync::Arc;
@@ -98,7 +99,7 @@ pub struct FuseReceiver<T> {
 
 impl<T: FileSystem> FuseReceiver<T> {
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn new(
+    pub(super) fn new(
         fs: Arc<T>,
         rt: Arc<Runtime>,
         kernel_fd: Arc<AsyncFd>,
@@ -109,9 +110,9 @@ impl<T: FileSystem> FuseReceiver<T> {
         metrics_enabled: bool,
         pending_requests: Arc<FastDashMap<u64, Arc<Notify>>>,
         enable_splice: bool,
-    ) -> IOResult<Self> {
+    ) -> Result<Self, SplicePipeSetupError> {
         let pipe2 = if enable_splice {
-            Some(Pipe2::new(PipeFd::new(buf_size, false, false)?)?)
+            Some(new_splice_pipe(buf_size)?)
         } else {
             None
         };

--- a/curvine-fuse/src/session/channel/fuse_sender.rs
+++ b/curvine-fuse/src/session/channel/fuse_sender.rs
@@ -17,6 +17,7 @@ use crate::fuse_metrics::{
     mono_now, ActiveGuard, FuseMetrics, FuseReqStatus, WriteOutcome, NOTIFY_SUCCESS,
     NOTIFY_WRITE_FAILED,
 };
+use crate::session::channel::{new_splice_pipe, SplicePipeSetupError};
 use crate::session::{FuseTask, ResponseData};
 use crate::FuseResult;
 use curvine_core_error::{err_box, try_option_ref};
@@ -25,7 +26,7 @@ use curvine_metrics::Gauge;
 use curvine_runtime::runtime::Runtime;
 use curvine_runtime::sync::channel::AsyncReceiver;
 use curvine_sys as sys;
-use curvine_sys::pipe::{AsyncFd, Pipe2, PipeFd};
+use curvine_sys::pipe::{AsyncFd, Pipe2};
 use log::{info, warn};
 use std::sync::Arc;
 
@@ -47,7 +48,7 @@ pub struct FuseSender<T> {
 
 impl<T: FileSystem> FuseSender<T> {
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn new(
+    pub(super) fn new(
         fs: Arc<T>,
         rt: Arc<Runtime>,
         kernel_fd: Arc<AsyncFd>,
@@ -58,9 +59,9 @@ impl<T: FileSystem> FuseSender<T> {
         mnt: &str,
         idx: usize,
         metrics_enabled: bool,
-    ) -> IOResult<Self> {
+    ) -> Result<Self, SplicePipeSetupError> {
         let pipe2 = if enable_splice {
-            Some(Pipe2::new(PipeFd::new(buf_size, false, false)?)?)
+            Some(new_splice_pipe(buf_size)?)
         } else {
             None
         };

--- a/curvine-fuse/src/session/channel/mod.rs
+++ b/curvine-fuse/src/session/channel/mod.rs
@@ -14,11 +14,14 @@
 
 use crate::fs::FileSystem;
 use crate::session::FuseMnt;
-use crate::{FuseResult, FuseUtils, FUSE_BUFFER_HEADER_SIZE};
+use crate::{FuseError, FuseResult, FuseUtils, FUSE_BUFFER_HEADER_SIZE};
 use curvine_config::FuseConf;
+use curvine_core_error::err_msg;
+use curvine_io::IOError;
 use curvine_runtime::runtime::Runtime;
 use curvine_runtime::sync::channel::AsyncChannel;
 use curvine_runtime::sync::FastDashMap;
+use curvine_sys::pipe::{Pipe2, PipeFd};
 use std::sync::Arc;
 
 mod fuse_receiver;
@@ -30,6 +33,26 @@ pub use self::fuse_sender::FuseSender;
 pub struct FuseChannel<T> {
     pub senders: Vec<FuseSender<T>>,
     pub receivers: Vec<FuseReceiver<T>>,
+}
+
+#[derive(Debug)]
+pub(super) enum SplicePipeSetupError {
+    Capacity(IOError),
+    AsyncRegistration(IOError),
+}
+
+impl SplicePipeSetupError {
+    fn io_error(&self) -> &IOError {
+        match self {
+            Self::Capacity(error) | Self::AsyncRegistration(error) => error,
+        }
+    }
+}
+
+pub(super) fn new_splice_pipe(buf_size: usize) -> Result<Pipe2, SplicePipeSetupError> {
+    let pipe_fd = PipeFd::new(buf_size, false, false)
+        .map_err(|error| SplicePipeSetupError::Capacity(error.into()))?;
+    Pipe2::new(pipe_fd).map_err(|error| SplicePipeSetupError::AsyncRegistration(error.into()))
 }
 
 impl<T: FileSystem> FuseChannel<T> {
@@ -61,7 +84,8 @@ impl<T: FileSystem> FuseChannel<T> {
                 &mnt_label,
                 idx,
                 conf.metrics_enabled,
-            )?;
+            )
+            .map_err(|err| splice_pipe_error("sender", err, buf_size))?;
 
             let receiver = FuseReceiver::new(
                 fs.clone(),
@@ -74,12 +98,135 @@ impl<T: FileSystem> FuseChannel<T> {
                 conf.metrics_enabled,
                 pending_requests.clone(),
                 conf.enable_splice,
-            )?;
+            )
+            .map_err(|err| splice_pipe_error("receiver", err, buf_size))?;
 
             senders.push(sender);
             receivers.push(receiver);
         }
 
         Ok(Self { senders, receivers })
+    }
+}
+
+fn splice_pipe_error(
+    component: &str,
+    error: SplicePipeSetupError,
+    requested_size: usize,
+) -> FuseError {
+    let errno = error
+        .io_error()
+        .raw_error()
+        .raw_os_error()
+        .unwrap_or(libc::EIO);
+    let message = splice_pipe_error_message(component, &error, requested_size, pipe_max_size());
+    FuseError::from_errno_msg(errno, err_msg!("{}", message).into())
+}
+
+fn splice_pipe_error_message(
+    component: &str,
+    error: &SplicePipeSetupError,
+    requested_size: usize,
+    pipe_max_size: Option<usize>,
+) -> String {
+    let limit = pipe_max_size
+        .map(|value| format!(", /proc/sys/fs/pipe-max-size={value}"))
+        .unwrap_or_else(|| ", /proc/sys/fs/pipe-max-size is unavailable".to_string());
+
+    match error {
+        SplicePipeSetupError::Capacity(error)
+            if error.raw_error().raw_os_error() == Some(libc::EPERM) =>
+        {
+            format!(
+                "FUSE mount succeeded, but zero-copy splice {component} pipe setup failed: F_SETPIPE_SZ was denied while requesting {requested_size} bytes{limit}. \
+                 This commonly occurs in a restricted container. Grant CAP_SYS_RESOURCE, raise the host pipe-max-size, \
+                 or disable zero-copy FUSE splice with [fuse] enable_splice = false. Original error: {error}"
+            )
+        }
+        SplicePipeSetupError::Capacity(error) => format!(
+            "FUSE mount succeeded, but zero-copy splice {component} pipe capacity setup failed while requesting {requested_size} bytes{limit}. \
+             Pipe creation or capacity initialization error: {error}"
+        ),
+        SplicePipeSetupError::AsyncRegistration(error) => format!(
+            "FUSE mount succeeded, but zero-copy splice {component} pipe asynchronous I/O registration failed after pipe setup. \
+             This is not a pipe-capacity failure. Original error: {error}"
+        ),
+    }
+}
+
+fn pipe_max_size() -> Option<usize> {
+    std::fs::read_to_string("/proc/sys/fs/pipe-max-size")
+        .ok()?
+        .trim()
+        .parse()
+        .ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{splice_pipe_error, splice_pipe_error_message, SplicePipeSetupError};
+    use curvine_io::IOError;
+
+    #[test]
+    fn pipe_capacity_permission_error_explains_container_remediation() {
+        let error = SplicePipeSetupError::Capacity(IOError::from(
+            std::io::Error::from_raw_os_error(libc::EPERM),
+        ));
+        let message = splice_pipe_error_message("sender", &error, 1_052_672, Some(1_048_576));
+
+        assert!(message.contains("mount succeeded"), "message: {message}");
+        assert!(message.contains("sender"), "message: {message}");
+        assert!(message.contains("F_SETPIPE_SZ"), "message: {message}");
+        assert!(message.contains("1052672"), "message: {message}");
+        assert!(message.contains("1048576"), "message: {message}");
+        assert!(message.contains("CAP_SYS_RESOURCE"), "message: {message}");
+        assert!(
+            message.contains("enable_splice = false"),
+            "message: {message}"
+        );
+    }
+
+    #[test]
+    fn splice_pipe_error_preserves_errno_and_diagnostic() {
+        let error = SplicePipeSetupError::Capacity(IOError::from(
+            std::io::Error::from_raw_os_error(libc::EPERM),
+        ));
+        let fuse_error = splice_pipe_error("receiver", error, 1_052_672);
+
+        assert_eq!(fuse_error.errno, libc::EPERM);
+        let message = fuse_error.error.to_string();
+        assert!(message.contains("mount succeeded"), "message: {message}");
+        assert!(message.contains("receiver"), "message: {message}");
+        assert!(message.contains("CAP_SYS_RESOURCE"), "message: {message}");
+    }
+
+    #[test]
+    fn async_pipe_registration_error_does_not_claim_capacity_denial() {
+        let error = SplicePipeSetupError::AsyncRegistration(IOError::from(
+            std::io::Error::from_raw_os_error(libc::EPERM),
+        ));
+        let message = splice_pipe_error_message("receiver", &error, 1_052_672, Some(1_048_576));
+
+        assert!(
+            message.contains("asynchronous I/O registration"),
+            "message: {message}"
+        );
+        assert!(
+            !message.contains("F_SETPIPE_SZ was denied"),
+            "message: {message}"
+        );
+        assert!(!message.contains("CAP_SYS_RESOURCE"), "message: {message}");
+    }
+
+    #[test]
+    fn generic_pipe_capacity_error_does_not_claim_linux_fcntl_failure() {
+        let error = SplicePipeSetupError::Capacity(IOError::from(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "unsupported operation",
+        )));
+        let message = splice_pipe_error_message("sender", &error, 1_052_672, None);
+
+        assert!(message.contains("Pipe creation or capacity initialization"));
+        assert!(!message.contains("F_SETPIPE_SZ"), "message: {message}");
     }
 }

--- a/curvine-fuse/src/session/fuse_mnt.rs
+++ b/curvine-fuse/src/session/fuse_mnt.rs
@@ -25,7 +25,7 @@ use crate::raw::fuse_mount_pure;
 use crate::raw::fuse_umount_pure;
 use crate::{FuseUtils, FUSE_CLONE_FD_MIN_VERSION, UNIX_KERNEL_VERSION};
 use curvine_config::FuseConf;
-use curvine_io::IOResult;
+use curvine_io::{IOError, IOResult};
 use curvine_sys as sys;
 use curvine_sys::pipe::{AsyncFd, BorrowedFd, OwnedFd};
 use curvine_sys::{CString, RawIO};
@@ -56,7 +56,9 @@ impl FuseMnt {
             clone_fds: Mutex::new(vec![]),
             auto_unmount: true,
         };
-        sys::set_pipe_blocking(mnt.fd, false)?;
+        sys::set_pipe_blocking(mnt.fd, false).map_err(|error| {
+            describe_fuse_fd_error("set mounted FUSE fd nonblocking", mnt.fd, error.into())
+        })?;
         info!("fuse mount success, path {:?}, fd {}", mnt.path, mnt.fd);
         Ok(mnt)
     }
@@ -76,15 +78,25 @@ impl FuseMnt {
                      source fd {}, cause: {}",
                         kernel_version.0, kernel_version.1, self.fd, e
                     );
-                    sys::dup(self.fd)?
+                    sys::dup(self.fd).map_err(|error| {
+                        describe_fuse_fd_error(
+                            "duplicate FUSE fd after clone fallback",
+                            self.fd,
+                            error.into(),
+                        )
+                    })?
                 }
             }
         } else {
-            sys::dup(self.fd)?
+            sys::dup(self.fd).map_err(|error| {
+                describe_fuse_fd_error("duplicate FUSE fd", self.fd, error.into())
+            })?
         };
 
         let new_fd = OwnedFd::new(clone_fd);
-        new_fd.set_blocking(false)?;
+        new_fd.set_blocking(false).map_err(|error| {
+            describe_fuse_fd_error("set task FUSE fd nonblocking", clone_fd, error.into())
+        })?;
 
         let borrowed = new_fd.as_borrowed();
         // fd is recycled by FuseMnt and saved here.
@@ -96,13 +108,41 @@ impl FuseMnt {
     // Get an async fd for reading and writing data.
     pub fn create_async_task_fd(&self, clone: bool) -> IOResult<Arc<AsyncFd>> {
         let fd = self.create_task_fd(clone)?;
-        let fd = Arc::new(AsyncFd::new(fd)?);
+        let raw_fd = fd.fd();
+        let fd = Arc::new(AsyncFd::new(fd).map_err(|error| {
+            describe_fuse_fd_error(
+                "register task FUSE fd for asynchronous I/O",
+                raw_fd,
+                error.into(),
+            )
+        })?);
         Ok(fd)
     }
 
     pub fn auto_unmount(&mut self, auto_unmount: bool) {
         self.auto_unmount = auto_unmount;
     }
+}
+
+pub(super) fn describe_fuse_fd_error(stage: &str, fd: RawIO, error: IOError) -> IOError {
+    let raw_error = error.into_raw();
+    let remediation = match raw_error.raw_os_error() {
+        Some(libc::EBADF) => "The FUSE fd is invalid or closed; check for an interrupted mount or stale restore state.",
+        Some(libc::EMFILE) | Some(libc::ENFILE) => {
+            "The process or system file-descriptor limit is exhausted; raise the relevant nofile limit."
+        }
+        Some(libc::EPERM) | Some(libc::EACCES) => {
+            "The runtime lacks permission for this FUSE fd operation; check container security policy and device access."
+        }
+        Some(libc::EINVAL) => {
+            "The kernel rejected this FUSE fd operation; verify kernel FUSE support and the mounted connection state."
+        }
+        _ => "Inspect the FUSE fd state and the kernel log for the underlying failure.",
+    };
+    IOError::with_ctx(
+        raw_error,
+        format!("FUSE {stage} failed for fd={fd}. {remediation}"),
+    )
 }
 
 impl Drop for FuseMnt {
@@ -122,7 +162,7 @@ impl Drop for FuseMnt {
 
 #[cfg(all(test, target_os = "linux"))]
 mod tests {
-    use super::FuseMnt;
+    use super::{describe_fuse_fd_error, FuseMnt};
     use curvine_config::FuseConf;
     use std::path::PathBuf;
 
@@ -155,5 +195,17 @@ mod tests {
             FuseMnt::from_fd(missing_path("fd"), &conf, -1).is_err(),
             "an invalid FUSE fd must return an error instead of panicking"
         );
+    }
+
+    #[test]
+    fn fuse_fd_error_preserves_errno_and_identifies_stage() {
+        let error = curvine_io::IOError::from(std::io::Error::from_raw_os_error(libc::EBADF));
+        let error = describe_fuse_fd_error("create nonblocking task fd", 42, error);
+
+        assert_eq!(error.raw_error().raw_os_error(), Some(libc::EBADF));
+        let message = error.to_string();
+        assert!(message.contains("create nonblocking task fd"));
+        assert!(message.contains("fd=42"));
+        assert!(message.contains("invalid or closed"));
     }
 }

--- a/curvine-fuse/src/session/fuse_session.rs
+++ b/curvine-fuse/src/session/fuse_session.rs
@@ -14,6 +14,7 @@
 
 #![allow(unused_variables, unused)]
 
+use super::fuse_mnt::describe_fuse_fd_error;
 use crate::fs::operator::FuseOperator;
 use crate::fs::FileSystem;
 use crate::fuse_metrics::{
@@ -26,9 +27,9 @@ use crate::raw::fuse_abi::*;
 use crate::session::channel::{FuseChannel, FuseReceiver, FuseSender};
 use crate::session::FuseRequest;
 use crate::session::{FuseMnt, FuseResponse};
-use crate::{err_fuse, FuseResult};
+use crate::{err_fuse, FuseError, FuseResult};
 use curvine_config::{ClusterConf, FuseConf};
-use curvine_core_error::{err_box, err_msg, CommonResult};
+use curvine_core_error::CommonResult;
 use curvine_fs_api::{StateReader, StateWriter};
 use curvine_io::IOResult;
 use curvine_runtime::common::CommonUtils;
@@ -389,14 +390,14 @@ impl<T: FileSystem> FuseSession<T> {
         Ok(())
     }
 
-    async fn setup_mnts(conf: &FuseConf, fs: &T) -> CommonResult<Vec<FuseMnt>> {
+    async fn setup_mnts(conf: &FuseConf, fs: &T) -> FuseResult<Vec<FuseMnt>> {
         if let Ok(state_file) = std::env::var(Self::STATE_PATH) {
             Self::restore(&state_file, conf, fs).await
         } else {
             let mut mnts = vec![];
             let all_mnt_paths = conf.get_all_mnt_path()?;
             for path in all_mnt_paths {
-                mnts.push(FuseMnt::new(path, conf)?);
+                mnts.push(FuseMnt::new(path, conf).map_err(FuseError::from_startup_io_error)?);
             }
             Ok(mnts)
         }
@@ -428,11 +429,23 @@ impl<T: FileSystem> FuseSession<T> {
             for mut mnt in mnts {
                 mnt.auto_unmount(false);
 
-                let flags = sys::fcntl_get(mnt.fd)?;
+                let flags = sys::fcntl_get(mnt.fd).map_err(|error| {
+                    describe_fuse_fd_error(
+                        "read FUSE fd flags for reload persistence",
+                        mnt.fd,
+                        error.into(),
+                    )
+                })?;
                 // Propagate the F_SETFD failure: if clearing FD_CLOEXEC fails the
                 // persisted fd cannot be inherited by the child, so the persist must
                 // fail rather than silently report success with an unusable state file.
-                sys::fcntl_set(mnt.fd, flags & !libc::FD_CLOEXEC)?;
+                sys::fcntl_set(mnt.fd, flags & !libc::FD_CLOEXEC).map_err(|error| {
+                    describe_fuse_fd_error(
+                        "clear FD_CLOEXEC for reload persistence",
+                        mnt.fd,
+                        error.into(),
+                    )
+                })?;
 
                 fds.insert(mnt.fd, mnt.path.to_string_lossy().to_string());
             }
@@ -465,7 +478,7 @@ impl<T: FileSystem> FuseSession<T> {
         Ok(())
     }
 
-    async fn restore(file: &str, conf: &FuseConf, fs: &T) -> CommonResult<Vec<FuseMnt>> {
+    async fn restore(file: &str, conf: &FuseConf, fs: &T) -> FuseResult<Vec<FuseMnt>> {
         let enabled = conf.metrics_enabled;
         let result = Self::restore_inner(file, conf, fs, enabled).await;
         if enabled {
@@ -484,27 +497,47 @@ impl<T: FileSystem> FuseSession<T> {
         conf: &FuseConf,
         fs: &T,
         enabled: bool,
-    ) -> CommonResult<Vec<FuseMnt>> {
+    ) -> FuseResult<Vec<FuseMnt>> {
         // If environment variable exists, restore state information from state file
         let mut mnts = vec![];
-        let mut reader = StateReader::new(file)?;
+        let mut reader = StateReader::new(file).map_err(FuseError::from_startup_io_error)?;
         let ts = TimeSpent::new();
         info!("restore: task started, path={}", reader.path());
 
         {
             let stage = StateStageTimer::start(enabled, false, STATE_STAGE_MOUNT_FDS);
             // Read and process mount point file descriptors
-            let fds: HashMap<RawIO, String> = reader.read_struct()?;
+            let fds: HashMap<RawIO, String> = reader
+                .read_struct()
+                .map_err(FuseError::from_startup_io_error)?;
             info!("restore: read mount fds {:?}", fds);
             if fds.is_empty() {
-                return err_box!("no fd found in state file {}", reader.path());
+                return Err(FuseError::from(format!(
+                    "no fd found in state file {}",
+                    reader.path()
+                )));
             }
             for (fd, path) in fds {
-                let flags = sys::fcntl_get(fd)?;
-                sys::fcntl_set(fd, flags | libc::FD_CLOEXEC)?;
+                let flags = sys::fcntl_get(fd).map_err(|error| {
+                    FuseError::from_startup_io_error(describe_fuse_fd_error(
+                        "read FUSE fd flags during reload restore",
+                        fd,
+                        error.into(),
+                    ))
+                })?;
+                sys::fcntl_set(fd, flags | libc::FD_CLOEXEC).map_err(|error| {
+                    FuseError::from_startup_io_error(describe_fuse_fd_error(
+                        "set FD_CLOEXEC during reload restore",
+                        fd,
+                        error.into(),
+                    ))
+                })?;
 
                 let path_buf = PathBuf::from(path);
-                mnts.push(FuseMnt::from_fd(path_buf, conf, fd)?);
+                mnts.push(
+                    FuseMnt::from_fd(path_buf, conf, fd)
+                        .map_err(FuseError::from_startup_io_error)?,
+                );
             }
             if let Some(stage) = stage {
                 stage.success();

--- a/curvine-fuse/tests/fuse_mount_e2e.rs
+++ b/curvine-fuse/tests/fuse_mount_e2e.rs
@@ -1,0 +1,169 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg(target_os = "linux")]
+
+use curvine_config::FuseConf;
+use curvine_fuse::raw::{fuse_mount_pure, fuse_umount_pure};
+use curvine_fuse::FuseUtils;
+use curvine_sys::pipe::PipeFd;
+use std::path::{Path, PathBuf};
+
+const CAP_SYS_ADMIN: u32 = 21;
+const CAP_SYS_RESOURCE: u32 = 24;
+
+struct MountGuard {
+    path: PathBuf,
+    fd: Option<std::os::fd::RawFd>,
+}
+
+impl MountGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, fd: None }
+    }
+}
+
+impl Drop for MountGuard {
+    fn drop(&mut self) {
+        if self.fd.is_some() && mountpoint_present(&self.path) {
+            let _ = fuse_umount_pure(&self.path);
+        }
+        if let Some(fd) = self.fd.take() {
+            unsafe { libc::close(fd) };
+        }
+        let _ = std::fs::remove_dir(&self.path);
+    }
+}
+
+fn mountpoint_present(path: &Path) -> bool {
+    let target = path.to_string_lossy();
+    std::fs::read_to_string("/proc/self/mountinfo")
+        .expect("read mount table")
+        .lines()
+        .any(|line| line.split_whitespace().nth(4) == Some(target.as_ref()))
+}
+
+fn has_effective_capability(capability: u32) -> bool {
+    let status = std::fs::read_to_string("/proc/self/status").expect("read process status");
+    let cap_eff = status
+        .lines()
+        .find_map(|line| line.strip_prefix("CapEff:\t"))
+        .expect("find CapEff")
+        .trim();
+    let cap_eff = u64::from_str_radix(cap_eff, 16).expect("parse CapEff");
+    cap_eff & (1_u64 << capability) != 0
+}
+
+#[test]
+#[ignore = "requires CAP_SYS_ADMIN and an assigned /dev/fuse device"]
+fn raw_mount_unmount_round_trip() {
+    assert!(
+        has_effective_capability(CAP_SYS_ADMIN),
+        "test requires CAP_SYS_ADMIN"
+    );
+
+    let path = std::env::temp_dir().join(format!(
+        "curvine-fuse-e2e-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock is after the Unix epoch")
+            .as_nanos()
+    ));
+    std::fs::create_dir(&path).expect("create isolated mount point");
+    let mut guard = MountGuard::new(path);
+
+    let fd = fuse_mount_pure(&guard.path, &FuseConf::default())
+        .expect("raw FUSE mount must succeed in the privileged E2E environment");
+    guard.fd = Some(fd);
+    assert!(
+        mountpoint_present(&guard.path),
+        "successful mount must appear in /proc/self/mountinfo"
+    );
+
+    let _ = fuse_umount_pure(&guard.path);
+    assert!(
+        !mountpoint_present(&guard.path),
+        "FUSE unmount must remove the mount-table entry"
+    );
+}
+
+#[test]
+#[ignore = "requires /dev/fuse but must run without CAP_SYS_ADMIN"]
+fn unprivileged_mount_reports_permission_remediation() {
+    assert!(
+        !has_effective_capability(CAP_SYS_ADMIN),
+        "test requires CAP_SYS_ADMIN to be absent"
+    );
+
+    let path = std::env::temp_dir().join(format!(
+        "curvine-fuse-denied-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock is after the Unix epoch")
+            .as_nanos()
+    ));
+    std::fs::create_dir(&path).expect("create isolated mount point");
+    let mut guard = MountGuard::new(path);
+
+    let error = match fuse_mount_pure(&guard.path, &FuseConf::default()) {
+        Ok(fd) => {
+            guard.fd = Some(fd);
+            panic!("an unprivileged process must not be allowed to mount FUSE");
+        }
+        Err(error) => error,
+    };
+
+    assert!(
+        matches!(
+            error.raw_error().raw_os_error(),
+            Some(libc::EPERM) | Some(libc::EACCES)
+        ),
+        "expected EPERM or EACCES, got {error}"
+    );
+    let message = error.to_string();
+    assert!(message.contains("CAP_SYS_ADMIN"), "message: {message}");
+    assert!(message.contains("security-policy"), "message: {message}");
+}
+
+#[test]
+#[ignore = "requires a restricted runtime with pipe-max-size below Curvine's FUSE buffer"]
+fn restricted_splice_pipe_growth_returns_eperm() {
+    assert!(
+        !has_effective_capability(CAP_SYS_RESOURCE),
+        "test requires CAP_SYS_RESOURCE to be absent"
+    );
+
+    let requested_size = FuseUtils::get_fuse_buf_size();
+    let pipe_max_size = std::fs::read_to_string("/proc/sys/fs/pipe-max-size")
+        .expect("read pipe-max-size")
+        .trim()
+        .parse::<usize>()
+        .expect("parse pipe-max-size");
+    assert!(
+        requested_size > pipe_max_size,
+        "test requires requested FUSE buffer {requested_size} > pipe-max-size {pipe_max_size}"
+    );
+
+    let error = match PipeFd::new(requested_size, false, false) {
+        Ok(_) => panic!("restricted runtime unexpectedly grew pipe to {requested_size} bytes"),
+        Err(error) => error,
+    };
+    assert_eq!(
+        error.raw_os_error(),
+        Some(libc::EPERM),
+        "expected EPERM from F_SETPIPE_SZ, got {error}"
+    );
+}


### PR DESCRIPTION
# Summary

Make FUSE startup failures actionable while preserving mount, splice, and runtime data-path behavior. Preserve the original OS errno through daemon startup so callers and scripts no longer see only generic EIO.

# Issue Describe / Design

Related issue: None.

Root cause: several startup failures either lost their original errno during conversion to FuseError or reported low-level context without actionable remediation. This included kernel ABI mismatch, mount syscall and device failures, restricted-container splice-pipe setup, and reload FD restoration.

Reproduction: a kernel advertising FUSE ABI 7.22 fails the protocol handshake; a restricted container can mount FUSE successfully but fail F_SETPIPE_SZ with EPERM while creating Curvine splice pipes; a container without CAP_SYS_ADMIN fails the mount syscall.

Fix approach: add diagnostics and preserve errno only on daemon startup and restore paths. Do not change enable_splice defaults, mount options, request-path EIO normalization, or introduce automatic fallback behavior.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| curvine-fuse startup and raw mount | Add ABI, mountpoint, /dev/fuse, mount syscall, unmount, splice-pipe, and FD-stage diagnostics | Failure output only; raw errno is preserved for startup |
| Fuse error/session boundary | Keep startup and reload errno without changing request-path EIO normalization | Runtime request behavior unchanged |
| FUSE launch scripts | Preflight mount targets, decode Linux mountinfo path escapes before duplicate-mount checks, keep version passthrough, avoid duplicate config injection, and surface daemon startup logs | Startup failures are returned to callers |
| FUSE E2E tests | Add opt-in privileged and restricted-runtime coverage | No default test-environment requirement |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| make format | PASS | Includes workspace release Clippy and formatting |
| cargo test -p curvine-fuse -- --test-threads=1 | PASS | 414 passed, 3 opt-in tests ignored |
| raw_mount_unmount_round_trip | PASS | Executed with CAP_SYS_ADMIN and /dev/fuse |
| unprivileged_mount_reports_permission_remediation | PASS | Executed without CAP_SYS_ADMIN |
| restricted_splice_pipe_growth_returns_eperm | PASS | Executed without CAP_SYS_RESOURCE |
| bash -n build/bin/curvine-fuse.sh build/bin/launch-process.sh build/tests/test_curvine_fuse.sh | PASS | Script syntax |
| bash build/tests/test_curvine_fuse.sh | PASS | mountinfo space, tab, newline, and backslash escaping |
| Current-branch runtime image in isolated Kubernetes pod | NOT RUN | Current kube context was unreachable; no cluster mutation performed |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None