### PR TITLE
fix(fuse): silence ENOTTY in fuse response logs

### DIFF
--- a/curvine-fuse/src/session/fuse_response.rs
+++ b/curvine-fuse/src/session/fuse_response.rs
@@ -196,7 +196,7 @@ impl FuseResponse {
         if self.debug
             || !matches!(
                 e.errno,
-                libc::ENOENT | libc::ENODATA | libc::ENOSYS | libc::ENOTEMPTY
+                libc::ENOENT | libc::ENODATA | libc::ENOSYS | libc::ENOTEMPTY | libc::ENOTTY
             )
         {
             warn!("send_rep unique {}: {}", self.unique, e);


### PR DESCRIPTION
# Summary

Treat `ENOTTY` as an expected errno in FUSE response error logging so routine unsupported-ioctl replies do not spam warn logs.

# Issue Describe / Design

No linked issue. `ENOTTY` is a normal outcome for unsupported ioctls; align it with `ENOENT`/`ENOSYS`/etc. in the non-warn errno set.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-fuse/src/session/fuse_response.rs` | Add `ENOTTY` to quiet errno list | Fewer warn logs for expected ENOTTY |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| Diff review | PASS | One-line errno match update |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None