### PR TITLE
test(fuse): gate hot-reload and git-clone behind --extended

### DIFF
--- a/build/tests/fuse-test.sh
+++ b/build/tests/fuse-test.sh
@@ -46,6 +46,39 @@ FAILED_CMD_LIST=()
 JSON_TEST_RESULTS=()
 CURRENT_TEST_GROUP=""
 
+# Require a non-empty option value (rejects missing or next-flag-looking args).
+require_arg() {
+    local opt="$1"
+    local val="$2"
+    if [ -z "$val" ] || [[ "$val" == -* ]]; then
+        echo "Error: $opt requires a value" >&2
+        print_help
+        exit 1
+    fi
+}
+
+# Require option value to be exactly 0 or 1.
+require_01() {
+    local opt="$1"
+    local val="$2"
+    require_arg "$opt" "$val"
+    if [ "$val" != "0" ] && [ "$val" != "1" ]; then
+        echo "Error: $opt must be 0 or 1, got: $val" >&2
+        print_help
+        exit 1
+    fi
+}
+
+# Record an explicit SKIP entry for JSON regression reports.
+record_json_skip() {
+    local test_group="$1"
+    local test_name="$2"
+    local reason="${3:-skipped}"
+    if [ -n "$JSON_OUTPUT" ]; then
+        JSON_TEST_RESULTS+=("SKIP|$test_group|$test_name||$reason")
+    fi
+}
+
 # Print functions
 print_help() {
     cat << EOF
@@ -809,7 +842,8 @@ generate_json_report() {
         echo "  \"timestamp\": \"$timestamp\","
         echo "  \"test_config\": {"
         echo "    \"test_dir\": \"$(json_escape "$TEST_DIR")\","
-        echo "    \"cleanup\": \"$CLEANUP\""
+        echo "    \"cleanup\": \"$CLEANUP\","
+        echo "    \"extended\": \"$RUN_EXTENDED\""
         echo "  },"
         echo "  \"summary\": {"
         echo "    \"total_tests\": $TOTAL_TESTS,"
@@ -840,6 +874,10 @@ generate_json_report() {
             
             if [ "$status" = "FAIL" ] && [ -n "$error_msg" ]; then
                 echo -n ",\"error\": \"$(json_escape "$error_msg")\""
+            fi
+
+            if [ "$status" = "SKIP" ] && [ -n "$error_msg" ]; then
+                echo -n ",\"reason\": \"$(json_escape "$error_msg")\""
             fi
             
             echo -n "}"
@@ -1519,18 +1557,22 @@ main() {
     while [[ $# -gt 0 ]]; do
         case $1 in
             -t|--test-dir)
+                require_arg "$1" "${2-}"
                 TEST_DIR="$2"
                 shift 2
                 ;;
             --cleanup)
+                require_01 "$1" "${2-}"
                 CLEANUP="$2"
                 shift 2
                 ;;
             -e|--extended)
+                require_01 "$1" "${2-}"
                 RUN_EXTENDED="$2"
                 shift 2
                 ;;
             --json-output)
+                require_arg "$1" "${2-}"
                 JSON_OUTPUT="$2"
                 shift 2
                 ;;
@@ -1575,6 +1617,13 @@ main() {
     test_file_locks
     test_delayed_delete
     test_python_high_frequency_write
+    if [ "$RUN_EXTENDED" = "1" ]; then
+        test_fuse_reload
+    else
+        print_info "Extended test skipped (FUSE hot reload). Use --extended 1 to enable"
+        record_json_skip "Test 15: FUSE Hot Reload" "Testing FUSE hot reload functionality" \
+            "skipped; use --extended 1"
+    fi
     test_mmap
     test_pwrite_visibility
     test_rename
@@ -1587,10 +1636,11 @@ main() {
     test_symlink_owner
 
     if [ "$RUN_EXTENDED" = "1" ]; then
-        test_fuse_reload
         test_git_clone
     else
-        print_info "Extended tests skipped (FUSE hot reload, git clone). Use --extended 1 to enable"
+        print_info "Extended test skipped (git clone). Use --extended 1 to enable"
+        record_json_skip "Test 16: Git Clone Operations" "Git clone operations" \
+            "skipped; use --extended 1"
     fi
 
     print_info "All test functions completed"

--- a/build/tests/fuse-test.sh
+++ b/build/tests/fuse-test.sh
@@ -33,6 +33,7 @@ source "$SCRIPT_DIR/colors.sh"
 TEST_DIR="/curvine-fuse/fuse-test"
 CLEANUP="1"  # Cleanup test files by default
 JSON_OUTPUT=""  # JSON output file path (empty = disabled)
+RUN_EXTENDED="0"  # Run extended tests (FUSE hot reload, git clone); 0=disabled by default
 
 # Test results tracking
 TOTAL_TESTS=0
@@ -68,12 +69,18 @@ This script tests basic filesystem operations including:
   - Files created in setgid directories inherit the parent group
   - Symlink owner and group metadata
 
+Extended tests (disabled by default, enable with --extended 1):
+  - FUSE hot reload: SIGUSR1 restart keeps open file handles and data intact
+  - Git clone: cloning a repository and running git status
+
 For FIO performance tests, use fio-test.sh instead.
 
 OPTIONS:
     -t, --test-dir PATH       Test directory path (default: /curvine-fuse/fuse-test)
         --cleanup <0|1>       Cleanup test files after completion (default: 1)
                               0=keep files, 1=cleanup files
+    -e, --extended <0|1>     Run extended tests (FUSE hot reload, git clone) (default: 0)
+                              0=skip extended tests, 1=run extended tests
         --json-output PATH    Output test results to JSON file (for regression testing)
     -h, --help                Show this help message
 
@@ -89,6 +96,9 @@ EXAMPLES:
     
     # Output results to JSON file for regression testing
     $0 --json-output /tmp/fuse-test-results.json
+
+    # Run extended tests (FUSE hot reload and git clone)
+    $0 --extended 1
 
 EOF
 }
@@ -1315,7 +1325,7 @@ PYTHON_SCRIPT
     rm -f "$test_file" 2>/dev/null || true
 }
 
-# Test 15: FUSE hot reload test
+# Test 15: FUSE hot reload (restart) test
 test_fuse_reload() {
     CURRENT_TEST_GROUP="Test 15: FUSE Hot Reload"
     print_header "$CURRENT_TEST_GROUP"
@@ -1440,16 +1450,20 @@ test_lookup_enametoolong() {
     run_python_script_test \
         "Testing lookup on overlong names returns ENAMETOOLONG" \
         "lookup_enametoolong_repro.py" --dir "$TEST_DIR"
+}
+
 # Test 25: files created in setgid directories inherit the parent group
 test_setgid_group_inherit() {
-    CURRENT_TEST_GROUP="Test 24: Setgid Group Inheritance"
+    CURRENT_TEST_GROUP="Test 25: Setgid Group Inheritance"
     print_header "$CURRENT_TEST_GROUP"
     run_python_script_test \
         "Testing file group inheritance in setgid directories" \
         "setgid_group_inherit_repro.py" --dir "$TEST_DIR"
+}
+
 # Test 26: symlink owner/group metadata
 test_symlink_owner() {
-    CURRENT_TEST_GROUP="Test 24: Symlink Owner"
+    CURRENT_TEST_GROUP="Test 26: Symlink Owner"
     print_header "$CURRENT_TEST_GROUP"
     run_python_script_test \
         "Testing symlink owner and group metadata" \
@@ -1512,6 +1526,10 @@ main() {
                 CLEANUP="$2"
                 shift 2
                 ;;
+            -e|--extended)
+                RUN_EXTENDED="$2"
+                shift 2
+                ;;
             --json-output)
                 JSON_OUTPUT="$2"
                 shift 2
@@ -1532,6 +1550,7 @@ main() {
     
     echo "Test Directory: $TEST_DIR"
     echo "Cleanup Files:  $([ "$CLEANUP" = "1" ] && echo "Enabled" || echo "Disabled")"
+    echo "Extended Tests: $([ "$RUN_EXTENDED" = "1" ] && echo "Enabled" || echo "Disabled")"
     if [ -n "$JSON_OUTPUT" ]; then
         echo "JSON Output:    $JSON_OUTPUT"
     fi
@@ -1556,7 +1575,6 @@ main() {
     test_file_locks
     test_delayed_delete
     test_python_high_frequency_write
-    test_fuse_reload
     test_mmap
     test_pwrite_visibility
     test_rename
@@ -1568,7 +1586,12 @@ main() {
     test_setgid_group_inherit
     test_symlink_owner
 
-    test_git_clone
+    if [ "$RUN_EXTENDED" = "1" ]; then
+        test_fuse_reload
+        test_git_clone
+    else
+        print_info "Extended tests skipped (FUSE hot reload, git clone). Use --extended 1 to enable"
+    fi
 
     print_info "All test functions completed"
 


### PR DESCRIPTION
# Summary

Make expensive FUSE hot-reload and git-clone checks opt-in via `--extended 1`, so the default `fuse-test.sh` run stays faster and more stable. Review follow-up adds arg validation, restores reload test ordering, and records extended/SKIP in JSON reports.

# Issue Describe / Design

No linked issue. Default CI/manual runs skip extended suites; operators can still enable them explicitly. Also renumbers a couple of test group labels for consistency.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `build/tests/fuse-test.sh` | Add `--extended`; gate reload/git-clone | Default run no longer executes those two suites |
| `build/tests/fuse-test.sh` | Validate `--extended`/`--cleanup` as `0|1`; require values for path options | Clearer CLI errors on missing/invalid args |
| `build/tests/fuse-test.sh` | Gate `test_fuse_reload` in-place (Test 15); keep `test_git_clone` at end | Log/test order matches prior suite layout |
| `build/tests/fuse-test.sh` | Record `extended` in `test_config`; emit SKIP JSON entries when skipped | Regression reports can distinguish default vs extended coverage |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| Script diff review | PASS | Default `RUN_EXTENDED=0`; `--extended 1` restores previous coverage |
| Review comment fixes | PASS | Arg validation, in-place reload gate, JSON `extended` + SKIP entries |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None