### PR TITLE
fix(unified-fs): use DeleteResult for delete stats (#1543)

### DIFF
--- a/crates/adapters/curvine-ufs-opendal/src/lib.rs
+++ b/crates/adapters/curvine-ufs-opendal/src/lib.rs
@@ -19,7 +19,7 @@ use curvine_error::FsError;
 use curvine_error::FsResult;
 use curvine_fs_api::{FileSystem, FsKind, ListStream, Path, Reader, Writer};
 use curvine_io::DataSlice;
-use curvine_model::{FileStatus, FileType, FreeResult, ListOptions, SetAttrOpts};
+use curvine_model::{DeleteResult, FileStatus, FileType, ListOptions, SetAttrOpts};
 use curvine_ufs_api::OpendalConf;
 #[cfg(feature = "opendal-oss")]
 use curvine_ufs_api::OssHdfsConf;
@@ -896,7 +896,7 @@ impl FileSystem<OpendalWriter, OpendalReader> for OpendalFileSystem {
         Ok(true)
     }
 
-    async fn delete(&self, path: &Path, recursive: bool) -> FsResult<FreeResult> {
+    async fn delete(&self, path: &Path, recursive: bool) -> FsResult<DeleteResult> {
         if path.is_root() {
             return err_box!("cannot delete root directory");
         }
@@ -944,7 +944,7 @@ impl FileSystem<OpendalWriter, OpendalReader> for OpendalFileSystem {
                 .map_err(|e| opendal_error("Failed to delete file", &object_path, e))?;
         }
 
-        Ok(FreeResult::default())
+        Ok(DeleteResult::default())
     }
 
     async fn get_status(&self, path: &Path) -> FsResult<FileStatus> {

--- a/crates/adapters/curvine-ufs-opendal/src/lib.rs
+++ b/crates/adapters/curvine-ufs-opendal/src/lib.rs
@@ -19,7 +19,7 @@ use curvine_error::FsError;
 use curvine_error::FsResult;
 use curvine_fs_api::{FileSystem, FsKind, ListStream, Path, Reader, Writer};
 use curvine_io::DataSlice;
-use curvine_model::{FileStatus, FileType, ListOptions, SetAttrOpts};
+use curvine_model::{FileStatus, FileType, FreeResult, ListOptions, SetAttrOpts};
 use curvine_ufs_api::OpendalConf;
 #[cfg(feature = "opendal-oss")]
 use curvine_ufs_api::OssHdfsConf;
@@ -896,7 +896,7 @@ impl FileSystem<OpendalWriter, OpendalReader> for OpendalFileSystem {
         Ok(true)
     }
 
-    async fn delete(&self, path: &Path, recursive: bool) -> FsResult<()> {
+    async fn delete(&self, path: &Path, recursive: bool) -> FsResult<FreeResult> {
         if path.is_root() {
             return err_box!("cannot delete root directory");
         }
@@ -944,7 +944,7 @@ impl FileSystem<OpendalWriter, OpendalReader> for OpendalFileSystem {
                 .map_err(|e| opendal_error("Failed to delete file", &object_path, e))?;
         }
 
-        Ok(())
+        Ok(FreeResult::default())
     }
 
     async fn get_status(&self, path: &Path) -> FsResult<FileStatus> {

--- a/crates/adapters/curvine-ufs-opendal/tests/hdfs/hdfs_integration_test.rs
+++ b/crates/adapters/curvine-ufs-opendal/tests/hdfs/hdfs_integration_test.rs
@@ -348,7 +348,7 @@ mod hdfs_tests {
             println!("Cleaning up directories...");
             for dir in [&sub_dir2, &sub_dir1, &base_dir] {
                 match fs.delete(dir, true).await {
-                    Ok(()) => println!("Deleted directory: {}", dir.full_path()),
+                    Ok(_) => println!("Deleted directory: {}", dir.full_path()),
                     Err(e) => println!("Failed to delete {}: {}", dir.full_path(), e),
                 }
             }

--- a/crates/adapters/curvine-ufs-oss-hdfs/src/oss_hdfs/oss_hdfs_filesystem.rs
+++ b/crates/adapters/curvine-ufs-oss-hdfs/src/oss_hdfs/oss_hdfs_filesystem.rs
@@ -19,7 +19,7 @@ use curvine_error::FsError;
 use curvine_error::FsResult;
 use curvine_fs_api::{FileSystem, FsKind, Path};
 use curvine_io::DataSlice;
-use curvine_model::{FileStatus, FileType, FreeResult, SetAttrOpts};
+use curvine_model::{DeleteResult, FileStatus, FileType, SetAttrOpts};
 use curvine_runtime::common::LocalTime;
 use curvine_ufs_api::{err_ufs, OssHdfsConf};
 use std::collections::HashMap;
@@ -774,7 +774,7 @@ impl FileSystem<OssHdfsWriter, OssHdfsReader> for OssHdfsFileSystem {
         Ok(true)
     }
 
-    async fn delete(&self, path: &Path, recursive: bool) -> FsResult<FreeResult> {
+    async fn delete(&self, path: &Path, recursive: bool) -> FsResult<DeleteResult> {
         let path_cstr = self.path_to_cstring(path)?;
         let ctx = Arc::new(CallbackCtx::<(JindoStatus, Option<String>)>::default());
         ctx.reset();
@@ -820,7 +820,7 @@ impl FileSystem<OssHdfsWriter, OssHdfsReader> for OssHdfsFileSystem {
         let (status, err) = ctx.wait().await?;
         Self::check_status_with_err(status, "Failed to delete", err)?;
 
-        Ok(FreeResult::default())
+        Ok(DeleteResult::default())
     }
 
     async fn get_status(&self, path: &Path) -> FsResult<FileStatus> {

--- a/crates/adapters/curvine-ufs-oss-hdfs/src/oss_hdfs/oss_hdfs_filesystem.rs
+++ b/crates/adapters/curvine-ufs-oss-hdfs/src/oss_hdfs/oss_hdfs_filesystem.rs
@@ -19,7 +19,7 @@ use curvine_error::FsError;
 use curvine_error::FsResult;
 use curvine_fs_api::{FileSystem, FsKind, Path};
 use curvine_io::DataSlice;
-use curvine_model::{FileStatus, FileType, SetAttrOpts};
+use curvine_model::{FileStatus, FileType, FreeResult, SetAttrOpts};
 use curvine_runtime::common::LocalTime;
 use curvine_ufs_api::{err_ufs, OssHdfsConf};
 use std::collections::HashMap;
@@ -774,7 +774,7 @@ impl FileSystem<OssHdfsWriter, OssHdfsReader> for OssHdfsFileSystem {
         Ok(true)
     }
 
-    async fn delete(&self, path: &Path, recursive: bool) -> FsResult<()> {
+    async fn delete(&self, path: &Path, recursive: bool) -> FsResult<FreeResult> {
         let path_cstr = self.path_to_cstring(path)?;
         let ctx = Arc::new(CallbackCtx::<(JindoStatus, Option<String>)>::default());
         ctx.reset();
@@ -820,7 +820,7 @@ impl FileSystem<OssHdfsWriter, OssHdfsReader> for OssHdfsFileSystem {
         let (status, err) = ctx.wait().await?;
         Self::check_status_with_err(status, "Failed to delete", err)?;
 
-        Ok(())
+        Ok(FreeResult::default())
     }
 
     async fn get_status(&self, path: &Path) -> FsResult<FileStatus> {

--- a/crates/client/curvine-client-core/src/file/curvine_filesystem.rs
+++ b/crates/client/curvine-client-core/src/file/curvine_filesystem.rs
@@ -23,7 +23,7 @@ use curvine_error::FsError;
 use curvine_error::FsResult;
 use curvine_fs_api::{FileSystem, FsKind, ListStream, Path, Reader, Writer};
 use curvine_model::ProtoUtils;
-use curvine_model::{CommitBlock, FreeResult, ListOptions};
+use curvine_model::{CommitBlock, DeleteResult, FreeResult, ListOptions};
 use curvine_model::{
     CreateFileOpts, CreateFileOptsBuilder, FileAllocOpts, FileBlocks, FileLock, FileStatus,
     MasterInfo, MkdirOpts, MkdirOptsBuilder, MountInfo, MountOptions, OpenFlags, RenameFlags,
@@ -183,7 +183,7 @@ impl CurvineFileSystem {
         self.fs_client.rename(src, dst, flags).await
     }
 
-    pub async fn delete(&self, path: &Path, recursive: bool) -> FsResult<FreeResult> {
+    pub async fn delete(&self, path: &Path, recursive: bool) -> FsResult<DeleteResult> {
         self.fs_client.delete(path, recursive).await
     }
 
@@ -563,7 +563,7 @@ impl FileSystem<FsWriter, FsReader> for CurvineFileSystem {
         self.rename(src, dst).await
     }
 
-    async fn delete(&self, path: &Path, recursive: bool) -> FsResult<FreeResult> {
+    async fn delete(&self, path: &Path, recursive: bool) -> FsResult<DeleteResult> {
         self.delete(path, recursive).await
     }
 

--- a/crates/client/curvine-client-core/src/file/curvine_filesystem.rs
+++ b/crates/client/curvine-client-core/src/file/curvine_filesystem.rs
@@ -187,6 +187,10 @@ impl CurvineFileSystem {
         self.fs_client.delete(path, recursive).await
     }
 
+    pub async fn delete_with_stats(&self, path: &Path, recursive: bool) -> FsResult<FreeResult> {
+        self.fs_client.delete_with_stats(path, recursive).await
+    }
+
     pub async fn free(&self, path: &Path, recursive: bool) -> FsResult<FreeResult> {
         self.fs_client.free(path, recursive).await
     }

--- a/crates/client/curvine-client-core/src/file/curvine_filesystem.rs
+++ b/crates/client/curvine-client-core/src/file/curvine_filesystem.rs
@@ -183,12 +183,8 @@ impl CurvineFileSystem {
         self.fs_client.rename(src, dst, flags).await
     }
 
-    pub async fn delete(&self, path: &Path, recursive: bool) -> FsResult<()> {
+    pub async fn delete(&self, path: &Path, recursive: bool) -> FsResult<FreeResult> {
         self.fs_client.delete(path, recursive).await
-    }
-
-    pub async fn delete_with_stats(&self, path: &Path, recursive: bool) -> FsResult<FreeResult> {
-        self.fs_client.delete_with_stats(path, recursive).await
     }
 
     pub async fn free(&self, path: &Path, recursive: bool) -> FsResult<FreeResult> {
@@ -567,7 +563,7 @@ impl FileSystem<FsWriter, FsReader> for CurvineFileSystem {
         self.rename(src, dst).await
     }
 
-    async fn delete(&self, path: &Path, recursive: bool) -> FsResult<()> {
+    async fn delete(&self, path: &Path, recursive: bool) -> FsResult<FreeResult> {
         self.delete(path, recursive).await
     }
 

--- a/crates/client/curvine-client-core/src/file/fs_client.rs
+++ b/crates/client/curvine-client-core/src/file/fs_client.rs
@@ -165,27 +165,14 @@ impl FsClient {
         Ok(rep_header.exists)
     }
 
-    pub async fn delete(&self, path: &Path, recursive: bool) -> FsResult<()> {
-        let header = DeleteRequest {
-            path: path.encode(),
-            recursive,
-        };
-
-        let _: DeleteResponse = self.rpc(RpcCode::Delete, header).await?;
-        Ok(())
-    }
-
-    pub async fn delete_with_stats(&self, path: &Path, recursive: bool) -> FsResult<FreeResult> {
+    pub async fn delete(&self, path: &Path, recursive: bool) -> FsResult<FreeResult> {
         let header = DeleteRequest {
             path: path.encode(),
             recursive,
         };
 
         let rep: DeleteResponse = self.rpc(RpcCode::Delete, header).await?;
-        match rep.res {
-            Some(res) => Ok(ProtoUtils::free_res_from_pb(res)),
-            None => err_box!("delete response missing free result"),
-        }
+        Ok(ProtoUtils::free_res_from_pb(rep.res))
     }
 
     pub async fn free(&self, path: &Path, recursive: bool) -> FsResult<FreeResult> {

--- a/crates/client/curvine-client-core/src/file/fs_client.rs
+++ b/crates/client/curvine-client-core/src/file/fs_client.rs
@@ -175,6 +175,19 @@ impl FsClient {
         Ok(())
     }
 
+    pub async fn delete_with_stats(&self, path: &Path, recursive: bool) -> FsResult<FreeResult> {
+        let header = DeleteRequest {
+            path: path.encode(),
+            recursive,
+        };
+
+        let rep: DeleteResponse = self.rpc(RpcCode::Delete, header).await?;
+        match rep.res {
+            Some(res) => Ok(ProtoUtils::free_res_from_pb(res)),
+            None => err_box!("delete response missing free result"),
+        }
+    }
+
     pub async fn free(&self, path: &Path, recursive: bool) -> FsResult<FreeResult> {
         let header = FreeRequest {
             path: path.encode(),

--- a/crates/client/curvine-client-core/src/file/fs_client.rs
+++ b/crates/client/curvine-client-core/src/file/fs_client.rs
@@ -172,7 +172,7 @@ impl FsClient {
         };
 
         let rep: DeleteResponse = self.rpc(RpcCode::Delete, header).await?;
-        Ok(ProtoUtils::delete_res_from_pb(rep.res))
+        Ok(ProtoUtils::delete_res_from_pb(rep.res.unwrap_or_default()))
     }
 
     pub async fn free(&self, path: &Path, recursive: bool) -> FsResult<FreeResult> {

--- a/crates/client/curvine-client-core/src/file/fs_client.rs
+++ b/crates/client/curvine-client-core/src/file/fs_client.rs
@@ -165,14 +165,14 @@ impl FsClient {
         Ok(rep_header.exists)
     }
 
-    pub async fn delete(&self, path: &Path, recursive: bool) -> FsResult<FreeResult> {
+    pub async fn delete(&self, path: &Path, recursive: bool) -> FsResult<DeleteResult> {
         let header = DeleteRequest {
             path: path.encode(),
             recursive,
         };
 
         let rep: DeleteResponse = self.rpc(RpcCode::Delete, header).await?;
-        Ok(ProtoUtils::free_res_from_pb(rep.res))
+        Ok(ProtoUtils::delete_res_from_pb(rep.res))
     }
 
     pub async fn free(&self, path: &Path, recursive: bool) -> FsResult<FreeResult> {

--- a/crates/client/curvine-unified-fs/src/unified/macros.rs
+++ b/crates/client/curvine-unified-fs/src/unified/macros.rs
@@ -449,7 +449,7 @@ macro_rules! impl_filesystem_for_enum {
                 &self,
                 path: &::curvine_fs_api::Path,
                 recursive: bool,
-            ) -> ::curvine_error::FsResult<::curvine_model::FreeResult> {
+            ) -> ::curvine_error::FsResult<::curvine_model::DeleteResult> {
                 match self {
                     $(
                         $(#[$cfg])*

--- a/crates/client/curvine-unified-fs/src/unified/macros.rs
+++ b/crates/client/curvine-unified-fs/src/unified/macros.rs
@@ -449,7 +449,7 @@ macro_rules! impl_filesystem_for_enum {
                 &self,
                 path: &::curvine_fs_api::Path,
                 recursive: bool,
-            ) -> ::curvine_error::FsResult<()> {
+            ) -> ::curvine_error::FsResult<::curvine_model::FreeResult> {
                 match self {
                     $(
                         $(#[$cfg])*

--- a/crates/client/curvine-unified-fs/src/unified/unified_filesystem.rs
+++ b/crates/client/curvine-unified-fs/src/unified/unified_filesystem.rs
@@ -309,7 +309,7 @@ impl UnifiedFileSystem {
         if path.path() == mount.cv_path && recursive {
             for status in self.cv.list_status(path).await? {
                 let child = Path::from_str(status.path)?;
-                match self.cv.delete_with_stats(&child, true).await {
+                match self.cv.delete(&child, true).await {
                     Ok(res) => {
                         total.inodes += res.inodes;
                         total.bytes += res.bytes;
@@ -321,7 +321,7 @@ impl UnifiedFileSystem {
                 }
             }
         } else {
-            total = self.cv.delete_with_stats(path, recursive).await?;
+            total = self.cv.delete(path, recursive).await?;
         }
 
         Ok(total)
@@ -1064,7 +1064,7 @@ impl FileSystem<UnifiedWriter, UnifiedReader> for UnifiedFileSystem {
         self.rename_with_flags(src, dst, RenameFlags::empty()).await
     }
 
-    async fn delete(&self, path: &Path, recursive: bool) -> FsResult<()> {
+    async fn delete(&self, path: &Path, recursive: bool) -> FsResult<FreeResult> {
         let fut = async {
             match self.get_mount_checked(path, RpcCode::Delete).await? {
                 None => self.cv.delete(path, recursive).await,
@@ -1077,16 +1077,21 @@ impl FileSystem<UnifiedWriter, UnifiedReader> for UnifiedFileSystem {
                         );
                     }
 
-                    mount.ufs()?.delete(&ufs_path, recursive).await?;
+                    let mut free_res = mount.ufs()?.delete(&ufs_path, recursive).await?;
 
                     // delete cache
-                    if let Err(e) = self.cv.delete(path, recursive).await {
-                        if !matches!(e, FsError::FileNotFound(_)) {
+                    match self.cv.delete(path, recursive).await {
+                        Ok(res) => {
+                            free_res.inodes += res.inodes;
+                            free_res.bytes += res.bytes;
+                        }
+                        Err(FsError::FileNotFound(_)) => {}
+                        Err(e) => {
                             warn!("failed to delete cache for {}: {}", path, e);
                         }
-                    };
+                    }
 
-                    Ok(())
+                    Ok(free_res)
                 }
             }
         };

--- a/crates/client/curvine-unified-fs/src/unified/unified_filesystem.rs
+++ b/crates/client/curvine-unified-fs/src/unified/unified_filesystem.rs
@@ -286,9 +286,9 @@ impl UnifiedFileSystem {
                 None => err_box!(
                     "the current path is not mounted to ufs, so the `free` command cannot be executed."
                 ),
-                // Cache mode: drop Curvine metadata without touching UFS.
-                // cv.free computes the released inode/byte stats and clears blocks,
-                // while cv.delete then removes the remaining Curvine inode.
+                // Cache mode: drop Curvine metadata and blocks via cv.delete.
+                // UFS is untouched; the returned DeleteResult is converted to
+                // FreeResult so the CLI can report inode/byte stats.
                 Some(mount) if mount.is_cache_mode() => {
                     self.free_cache_mode(path, &mount, recursive).await
                 }

--- a/crates/client/curvine-unified-fs/src/unified/unified_filesystem.rs
+++ b/crates/client/curvine-unified-fs/src/unified/unified_filesystem.rs
@@ -304,22 +304,27 @@ impl UnifiedFileSystem {
         mount: &MountInfo,
         recursive: bool,
     ) -> FsResult<FreeResult> {
-        let free_res = self.cv.free(path, recursive).await?;
+        let mut total = FreeResult::default();
 
         if path.path() == mount.cv_path && recursive {
             for status in self.cv.list_status(path).await? {
                 let child = Path::from_str(status.path)?;
-                if let Err(e) = self.cv.delete(&child, true).await {
-                    if !matches!(e, FsError::FileNotFound(_)) {
+                match self.cv.delete_with_stats(&child, true).await {
+                    Ok(res) => {
+                        total.inodes += res.inodes;
+                        total.bytes += res.bytes;
+                    }
+                    Err(FsError::FileNotFound(_)) => {}
+                    Err(e) => {
                         return Err(e);
                     }
                 }
             }
         } else {
-            self.cv.delete(path, recursive).await?;
+            total = self.cv.delete_with_stats(path, recursive).await?;
         }
 
-        Ok(free_res)
+        Ok(total)
     }
 
     pub async fn symlink(&self, target: &str, link: &Path, force: bool) -> FsResult<()> {

--- a/crates/client/curvine-unified-fs/src/unified/unified_filesystem.rs
+++ b/crates/client/curvine-unified-fs/src/unified/unified_filesystem.rs
@@ -25,9 +25,9 @@ use curvine_error::FsResult;
 use curvine_fs_api::{FileSystem, FsKind, ListStream, Path, Reader, RpcCode, Writer};
 use curvine_job_client::{JobMasterClient, TransferClient};
 use curvine_model::{
-    CreateFileOpts, FileAllocOpts, FileLock, FileStatus, FreeResult, JobStatus, ListOptions,
-    LoadJobCommand, MasterInfo, MkdirOpts, MkdirOptsBuilder, MountInfo, MountOptions, OpenFlags,
-    RenameFlags, SetAttrOpts, TransferCommand, TransferKind, TransferState,
+    CreateFileOpts, DeleteResult, FileAllocOpts, FileLock, FileStatus, FreeResult, JobStatus,
+    ListOptions, LoadJobCommand, MasterInfo, MkdirOpts, MkdirOptsBuilder, MountInfo, MountOptions,
+    OpenFlags, RenameFlags, SetAttrOpts, TransferCommand, TransferKind, TransferState,
 };
 use curvine_runtime::common::TimeSpent;
 use curvine_runtime::common::Utils;
@@ -311,6 +311,7 @@ impl UnifiedFileSystem {
                 let child = Path::from_str(status.path)?;
                 match self.cv.delete(&child, true).await {
                     Ok(res) => {
+                        let res: FreeResult = res.into();
                         total.inodes += res.inodes;
                         total.bytes += res.bytes;
                     }
@@ -321,7 +322,7 @@ impl UnifiedFileSystem {
                 }
             }
         } else {
-            total = self.cv.delete(path, recursive).await?;
+            total = self.cv.delete(path, recursive).await?.into();
         }
 
         Ok(total)
@@ -1064,7 +1065,7 @@ impl FileSystem<UnifiedWriter, UnifiedReader> for UnifiedFileSystem {
         self.rename_with_flags(src, dst, RenameFlags::empty()).await
     }
 
-    async fn delete(&self, path: &Path, recursive: bool) -> FsResult<FreeResult> {
+    async fn delete(&self, path: &Path, recursive: bool) -> FsResult<DeleteResult> {
         let fut = async {
             match self.get_mount_checked(path, RpcCode::Delete).await? {
                 None => self.cv.delete(path, recursive).await,
@@ -1077,13 +1078,13 @@ impl FileSystem<UnifiedWriter, UnifiedReader> for UnifiedFileSystem {
                         );
                     }
 
-                    let mut free_res = mount.ufs()?.delete(&ufs_path, recursive).await?;
+                    let mut delete_res = mount.ufs()?.delete(&ufs_path, recursive).await?;
 
                     // delete cache
                     match self.cv.delete(path, recursive).await {
                         Ok(res) => {
-                            free_res.inodes += res.inodes;
-                            free_res.bytes += res.bytes;
+                            delete_res.inodes += res.inodes;
+                            delete_res.bytes += res.bytes;
                         }
                         Err(FsError::FileNotFound(_)) => {}
                         Err(e) => {
@@ -1091,7 +1092,7 @@ impl FileSystem<UnifiedWriter, UnifiedReader> for UnifiedFileSystem {
                         }
                     }
 
-                    Ok(free_res)
+                    Ok(delete_res)
                 }
             }
         };

--- a/crates/client/curvine-unified-fs/src/unified/unified_filesystem.rs
+++ b/crates/client/curvine-unified-fs/src/unified/unified_filesystem.rs
@@ -286,10 +286,9 @@ impl UnifiedFileSystem {
                 None => err_box!(
                     "the current path is not mounted to ufs, so the `free` command cannot be executed."
                 ),
-                // Cache mode: drop Curvine metadata (and its blocks) via delete.
-                // Master delete already releases worker blocks; calling free first
-                // would only clear locs then delete the inode — redundant.
-                // Use cv.delete (not UnifiedFileSystem::delete) so UFS is untouched.
+                // Cache mode: drop Curvine metadata without touching UFS.
+                // cv.free computes the released inode/byte stats and clears blocks,
+                // while cv.delete then removes the remaining Curvine inode.
                 Some(mount) if mount.is_cache_mode() => {
                     self.free_cache_mode(path, &mount, recursive).await
                 }
@@ -305,6 +304,8 @@ impl UnifiedFileSystem {
         mount: &MountInfo,
         recursive: bool,
     ) -> FsResult<FreeResult> {
+        let free_res = self.cv.free(path, recursive).await?;
+
         if path.path() == mount.cv_path && recursive {
             for status in self.cv.list_status(path).await? {
                 let child = Path::from_str(status.path)?;
@@ -318,7 +319,7 @@ impl UnifiedFileSystem {
             self.cv.delete(path, recursive).await?;
         }
 
-        Ok(FreeResult::default())
+        Ok(free_res)
     }
 
     pub async fn symlink(&self, target: &str, link: &Path, force: bool) -> FsResult<()> {

--- a/crates/common/curvine-fs-api/src/filesystem.rs
+++ b/crates/common/curvine-fs-api/src/filesystem.rs
@@ -14,7 +14,7 @@
 
 use crate::fs::{FsKind, ListStream, Path};
 use crate::proto::{GetFileStatusResponse, ListOptionsResponse, ListStatusResponse};
-use crate::state::{FileStatus, FreeResult, ListOptions, SetAttrOpts};
+use crate::state::{DeleteResult, FileStatus, ListOptions, SetAttrOpts};
 use crate::utils::ProtoUtils;
 use crate::FsResult;
 use curvine_core_error::err_box;
@@ -36,7 +36,7 @@ pub trait FileSystem<Writer, Reader> {
 
     fn rename(&self, src: &Path, dst: &Path) -> impl Future<Output = FsResult<bool>>;
 
-    fn delete(&self, path: &Path, recursive: bool) -> impl Future<Output = FsResult<FreeResult>>;
+    fn delete(&self, path: &Path, recursive: bool) -> impl Future<Output = FsResult<DeleteResult>>;
 
     fn get_status(&self, path: &Path) -> impl Future<Output = FsResult<FileStatus>>;
 

--- a/crates/common/curvine-fs-api/src/filesystem.rs
+++ b/crates/common/curvine-fs-api/src/filesystem.rs
@@ -14,7 +14,7 @@
 
 use crate::fs::{FsKind, ListStream, Path};
 use crate::proto::{GetFileStatusResponse, ListOptionsResponse, ListStatusResponse};
-use crate::state::{FileStatus, ListOptions, SetAttrOpts};
+use crate::state::{FileStatus, FreeResult, ListOptions, SetAttrOpts};
 use crate::utils::ProtoUtils;
 use crate::FsResult;
 use curvine_core_error::err_box;
@@ -36,7 +36,7 @@ pub trait FileSystem<Writer, Reader> {
 
     fn rename(&self, src: &Path, dst: &Path) -> impl Future<Output = FsResult<bool>>;
 
-    fn delete(&self, path: &Path, recursive: bool) -> impl Future<Output = FsResult<()>>;
+    fn delete(&self, path: &Path, recursive: bool) -> impl Future<Output = FsResult<FreeResult>>;
 
     fn get_status(&self, path: &Path) -> impl Future<Output = FsResult<FileStatus>>;
 

--- a/crates/common/curvine-fs-api/src/local/local_filesystem.rs
+++ b/crates/common/curvine-fs-api/src/local/local_filesystem.rs
@@ -21,7 +21,7 @@ use async_stream::stream;
 use curvine_core_error::err_box;
 use curvine_error::FsError;
 use curvine_error::FsResult;
-use curvine_model::{FileStatus, ListOptions, SetAttrOpts};
+use curvine_model::{FileStatus, FreeResult, ListOptions, SetAttrOpts};
 use std::fs;
 
 #[derive(Clone)]
@@ -74,7 +74,7 @@ impl FileSystem<LocalWriter, LocalReader> for LocalFilesystem {
         Ok(true)
     }
 
-    async fn delete(&self, path: &Path, recursive: bool) -> FsResult<()> {
+    async fn delete(&self, path: &Path, recursive: bool) -> FsResult<FreeResult> {
         if path.path() == Path::SEPARATOR {
             return err_box!("Cannot delete root directory.");
         }
@@ -89,7 +89,7 @@ impl FileSystem<LocalWriter, LocalReader> for LocalFilesystem {
         } else {
             fs::remove_file(path.path())?;
         }
-        Ok(())
+        Ok(FreeResult::default())
     }
 
     async fn get_status(&self, path: &Path) -> FsResult<FileStatus> {

--- a/crates/common/curvine-fs-api/src/local/local_filesystem.rs
+++ b/crates/common/curvine-fs-api/src/local/local_filesystem.rs
@@ -21,7 +21,7 @@ use async_stream::stream;
 use curvine_core_error::err_box;
 use curvine_error::FsError;
 use curvine_error::FsResult;
-use curvine_model::{FileStatus, FreeResult, ListOptions, SetAttrOpts};
+use curvine_model::{DeleteResult, FileStatus, ListOptions, SetAttrOpts};
 use std::fs;
 
 #[derive(Clone)]
@@ -74,7 +74,7 @@ impl FileSystem<LocalWriter, LocalReader> for LocalFilesystem {
         Ok(true)
     }
 
-    async fn delete(&self, path: &Path, recursive: bool) -> FsResult<FreeResult> {
+    async fn delete(&self, path: &Path, recursive: bool) -> FsResult<DeleteResult> {
         if path.path() == Path::SEPARATOR {
             return err_box!("Cannot delete root directory.");
         }
@@ -89,7 +89,7 @@ impl FileSystem<LocalWriter, LocalReader> for LocalFilesystem {
         } else {
             fs::remove_file(path.path())?;
         }
-        Ok(FreeResult::default())
+        Ok(DeleteResult::default())
     }
 
     async fn get_status(&self, path: &Path) -> FsResult<FileStatus> {

--- a/crates/common/curvine-model/src/proto_utils.rs
+++ b/crates/common/curvine-model/src/proto_utils.rs
@@ -755,19 +755,12 @@ impl ProtoUtils {
         }
     }
 
-    pub fn delete_res_from_pb(res: DeleteResultProto) -> DeleteResult {
-        DeleteResult {
-            inodes: res.inodes as u64,
-            bytes: res.bytes as u64,
-            ..Default::default()
-        }
+    pub fn delete_res_from_pb(res: FreeResultProto) -> DeleteResult {
+        Self::free_res_from_pb(res).into()
     }
 
-    pub fn delete_res_to_pb(res: DeleteResult) -> DeleteResultProto {
-        DeleteResultProto {
-            inodes: res.inodes as i64,
-            bytes: res.bytes as i64,
-        }
+    pub fn delete_res_to_pb(res: DeleteResult) -> FreeResultProto {
+        Self::free_res_to_pb(res.into())
     }
 }
 

--- a/crates/common/curvine-model/src/proto_utils.rs
+++ b/crates/common/curvine-model/src/proto_utils.rs
@@ -754,6 +754,21 @@ impl ProtoUtils {
             bytes: res.bytes,
         }
     }
+
+    pub fn delete_res_from_pb(res: DeleteResultProto) -> DeleteResult {
+        DeleteResult {
+            inodes: res.inodes as u64,
+            bytes: res.bytes as u64,
+            ..Default::default()
+        }
+    }
+
+    pub fn delete_res_to_pb(res: DeleteResult) -> DeleteResultProto {
+        DeleteResultProto {
+            inodes: res.inodes as i64,
+            bytes: res.bytes as i64,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/common/curvine-model/src/result.rs
+++ b/crates/common/curvine-model/src/result.rs
@@ -29,3 +29,40 @@ impl FreeResult {
         self.blocks.extend(blocks);
     }
 }
+
+#[derive(Debug, Default)]
+pub struct DeleteResult {
+    pub inodes: u64,
+    pub bytes: u64,
+    pub blocks: HashMap<i64, Vec<BlockLocation>>,
+}
+
+impl DeleteResult {
+    pub fn new() -> Self {
+        Self {
+            inodes: 0,
+            bytes: 0,
+            blocks: Default::default(),
+        }
+    }
+}
+
+impl From<DeleteResult> for FreeResult {
+    fn from(value: DeleteResult) -> Self {
+        Self {
+            inodes: value.inodes as i64,
+            bytes: value.bytes as i64,
+            blocks: value.blocks,
+        }
+    }
+}
+
+impl From<FreeResult> for DeleteResult {
+    fn from(value: FreeResult) -> Self {
+        Self {
+            inodes: value.inodes as u64,
+            bytes: value.bytes as u64,
+            blocks: value.blocks,
+        }
+    }
+}

--- a/crates/common/curvine-model/src/result.rs
+++ b/crates/common/curvine-model/src/result.rs
@@ -32,6 +32,8 @@ impl FreeResult {
 
 #[derive(Debug, Default)]
 pub struct DeleteResult {
+    // Number of file inodes removed. Directories are excluded so the value is
+    // comparable with FreeResult stats produced by cache-mode free.
     pub inodes: u64,
     pub bytes: u64,
     pub blocks: HashMap<i64, Vec<BlockLocation>>,
@@ -50,8 +52,8 @@ impl DeleteResult {
 impl From<DeleteResult> for FreeResult {
     fn from(value: DeleteResult) -> Self {
         Self {
-            inodes: value.inodes as i64,
-            bytes: value.bytes as i64,
+            inodes: i64::try_from(value.inodes).unwrap_or(i64::MAX),
+            bytes: i64::try_from(value.bytes).unwrap_or(i64::MAX),
             blocks: value.blocks,
         }
     }
@@ -60,9 +62,42 @@ impl From<DeleteResult> for FreeResult {
 impl From<FreeResult> for DeleteResult {
     fn from(value: FreeResult) -> Self {
         Self {
-            inodes: value.inodes as u64,
-            bytes: value.bytes as u64,
+            inodes: u64::try_from(value.inodes).unwrap_or(0),
+            bytes: u64::try_from(value.bytes).unwrap_or(0),
             blocks: value.blocks,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn delete_result_to_free_result_clamps_large_counts() {
+        let delete_result = DeleteResult {
+            inodes: i64::MAX as u64 + 1,
+            bytes: u64::MAX,
+            blocks: HashMap::new(),
+        };
+
+        let free_result: FreeResult = delete_result.into();
+
+        assert_eq!(free_result.inodes, i64::MAX);
+        assert_eq!(free_result.bytes, i64::MAX);
+    }
+
+    #[test]
+    fn free_result_to_delete_result_ignores_negative_counts() {
+        let free_result = FreeResult {
+            inodes: -1,
+            bytes: -1,
+            blocks: HashMap::new(),
+        };
+
+        let delete_result: DeleteResult = free_result.into();
+
+        assert_eq!(delete_result.inodes, 0);
+        assert_eq!(delete_result.bytes, 0);
     }
 }

--- a/crates/common/curvine-proto/proto/common.proto
+++ b/crates/common/curvine-proto/proto/common.proto
@@ -217,11 +217,6 @@ message FreeResultProto {
     required int64 bytes = 3;
 }
 
-message DeleteResultProto {
-    required int64 inodes = 1;
-    required int64 bytes = 2;
-}
-
 message ListOptionsProto {
     optional int32 limit = 1;
     optional string start_after = 2;

--- a/crates/common/curvine-proto/proto/common.proto
+++ b/crates/common/curvine-proto/proto/common.proto
@@ -217,6 +217,11 @@ message FreeResultProto {
     required int64 bytes = 3;
 }
 
+message DeleteResultProto {
+    required int64 inodes = 1;
+    required int64 bytes = 2;
+}
+
 message ListOptionsProto {
     optional int32 limit = 1;
     optional string start_after = 2;

--- a/crates/common/curvine-proto/proto/master.proto
+++ b/crates/common/curvine-proto/proto/master.proto
@@ -90,7 +90,7 @@ message DeleteRequest {
 }
 
 message DeleteResponse {
-    optional FreeResultProto res = 1;
+    required FreeResultProto res = 1;
 }
 
 message FreeRequest {

--- a/crates/common/curvine-proto/proto/master.proto
+++ b/crates/common/curvine-proto/proto/master.proto
@@ -90,7 +90,7 @@ message DeleteRequest {
 }
 
 message DeleteResponse {
-    required FreeResultProto res = 1;
+    optional FreeResultProto res = 1;
 }
 
 message FreeRequest {

--- a/crates/common/curvine-proto/proto/master.proto
+++ b/crates/common/curvine-proto/proto/master.proto
@@ -90,7 +90,7 @@ message DeleteRequest {
 }
 
 message DeleteResponse {
-    required DeleteResultProto res = 1;
+    required FreeResultProto res = 1;
 }
 
 message FreeRequest {

--- a/crates/common/curvine-proto/proto/master.proto
+++ b/crates/common/curvine-proto/proto/master.proto
@@ -89,7 +89,9 @@ message DeleteRequest {
     required bool recursive = 2;
 }
 
-message DeleteResponse {}
+message DeleteResponse {
+    optional FreeResultProto res = 1;
+}
 
 message FreeRequest {
     required string path = 1;

--- a/crates/common/curvine-proto/proto/master.proto
+++ b/crates/common/curvine-proto/proto/master.proto
@@ -90,7 +90,7 @@ message DeleteRequest {
 }
 
 message DeleteResponse {
-    required FreeResultProto res = 1;
+    required DeleteResultProto res = 1;
 }
 
 message FreeRequest {

--- a/crates/sdk/curvine-libsdk-java/src/java/java_filesystem.rs
+++ b/crates/sdk/curvine-libsdk-java/src/java/java_filesystem.rs
@@ -20,7 +20,7 @@ use curvine_fs_api::proto::{
     GetJobStatusResponse, GetMountTableResponse, MountOptionsProto, SetAttrOptsProto,
     SubmitJobResponse,
 };
-use curvine_fs_api::state::{LoadJobCommand, SetAttrOpts};
+use curvine_fs_api::state::{FreeResult, LoadJobCommand, SetAttrOpts};
 use curvine_fs_api::utils::ProtoUtils;
 use curvine_sdk_core::blocking_job as job;
 use jni::objects::{JByteArray, JString};
@@ -128,7 +128,12 @@ impl JavaFilesystem {
         self.inner.rename(src, dst)
     }
 
-    pub fn delete(&self, env: &mut JNIEnv, path: JString, recursive: jboolean) -> FsResult<()> {
+    pub fn delete(
+        &self,
+        env: &mut JNIEnv,
+        path: JString,
+        recursive: jboolean,
+    ) -> FsResult<FreeResult> {
         let path = JavaUtils::jstring_to_string(env, &path)?;
         self.inner.delete(path, JavaUtils::jbool_to_bool(recursive))
     }

--- a/crates/sdk/curvine-libsdk-java/src/java/java_filesystem.rs
+++ b/crates/sdk/curvine-libsdk-java/src/java/java_filesystem.rs
@@ -20,7 +20,7 @@ use curvine_fs_api::proto::{
     GetJobStatusResponse, GetMountTableResponse, MountOptionsProto, SetAttrOptsProto,
     SubmitJobResponse,
 };
-use curvine_fs_api::state::{FreeResult, LoadJobCommand, SetAttrOpts};
+use curvine_fs_api::state::{DeleteResult, LoadJobCommand, SetAttrOpts};
 use curvine_fs_api::utils::ProtoUtils;
 use curvine_sdk_core::blocking_job as job;
 use jni::objects::{JByteArray, JString};
@@ -133,7 +133,7 @@ impl JavaFilesystem {
         env: &mut JNIEnv,
         path: JString,
         recursive: jboolean,
-    ) -> FsResult<FreeResult> {
+    ) -> FsResult<DeleteResult> {
         let path = JavaUtils::jstring_to_string(env, &path)?;
         self.inner.delete(path, JavaUtils::jbool_to_bool(recursive))
     }

--- a/crates/sdk/curvine-libsdk-python/src/python/python_filesystem.rs
+++ b/crates/sdk/curvine-libsdk-python/src/python/python_filesystem.rs
@@ -58,7 +58,7 @@ impl PythonFilesystem {
 
     //Delete file
     pub fn delete(&self, path: String, recursive: bool) -> FsResult<()> {
-        self.inner.delete(path, recursive)
+        self.inner.delete(path, recursive).map(|_| ())
     }
 
     //Get master information

--- a/crates/sdk/curvine-sdk-core/src/core/filesystem.rs
+++ b/crates/sdk/curvine-sdk-core/src/core/filesystem.rs
@@ -18,7 +18,7 @@ use bytes::BytesMut;
 use curvine_config::ClusterConf;
 use curvine_error::FsResult;
 use curvine_fs_api::{FileSystem, Path};
-use curvine_model::{FreeResult, MountInfo, MountOptions, SetAttrOpts};
+use curvine_model::{DeleteResult, FreeResult, MountInfo, MountOptions, SetAttrOpts};
 use curvine_runtime::runtime::RpcRuntime;
 
 pub struct LibFilesystem {
@@ -58,7 +58,7 @@ impl LibFilesystem {
             .block_on(async { self.inner().rename(&src_path, &dst_path).await })
     }
 
-    pub fn delete(&self, path: impl AsRef<str>, recursive: bool) -> FsResult<FreeResult> {
+    pub fn delete(&self, path: impl AsRef<str>, recursive: bool) -> FsResult<DeleteResult> {
         let path = Path::from_str(path)?;
         self.rt()
             .block_on(async { self.inner().delete(&path, recursive).await })

--- a/crates/sdk/curvine-sdk-core/src/core/filesystem.rs
+++ b/crates/sdk/curvine-sdk-core/src/core/filesystem.rs
@@ -58,7 +58,7 @@ impl LibFilesystem {
             .block_on(async { self.inner().rename(&src_path, &dst_path).await })
     }
 
-    pub fn delete(&self, path: impl AsRef<str>, recursive: bool) -> FsResult<()> {
+    pub fn delete(&self, path: impl AsRef<str>, recursive: bool) -> FsResult<FreeResult> {
         let path = Path::from_str(path)?;
         self.rt()
             .block_on(async { self.inner().delete(&path, recursive).await })

--- a/crates/sdk/curvine-sdk-core/src/filesystem.rs
+++ b/crates/sdk/curvine-sdk-core/src/filesystem.rs
@@ -17,7 +17,7 @@ use bytes::BytesMut;
 use curvine_client::unified::{UnifiedReader, UnifiedWriter};
 use curvine_error::FsResult;
 use curvine_fs_api::{FileSystem, Path};
-use curvine_model::FreeResult;
+use curvine_model::{DeleteResult, FreeResult};
 use std::sync::Arc;
 
 #[derive(Clone)]
@@ -45,7 +45,7 @@ impl FileSystemClient {
         self.unified().rename(&src_path, &dst_path).await
     }
 
-    pub async fn delete(&self, path: impl AsRef<str>, recursive: bool) -> FsResult<FreeResult> {
+    pub async fn delete(&self, path: impl AsRef<str>, recursive: bool) -> FsResult<DeleteResult> {
         let path = Path::from_str(path)?;
         self.unified().delete(&path, recursive).await
     }

--- a/crates/sdk/curvine-sdk-core/src/filesystem.rs
+++ b/crates/sdk/curvine-sdk-core/src/filesystem.rs
@@ -45,7 +45,7 @@ impl FileSystemClient {
         self.unified().rename(&src_path, &dst_path).await
     }
 
-    pub async fn delete(&self, path: impl AsRef<str>, recursive: bool) -> FsResult<()> {
+    pub async fn delete(&self, path: impl AsRef<str>, recursive: bool) -> FsResult<FreeResult> {
         let path = Path::from_str(path)?;
         self.unified().delete(&path, recursive).await
     }

--- a/crates/server/curvine-data-transfer/src/common/ufs_client.rs
+++ b/crates/server/curvine-data-transfer/src/common/ufs_client.rs
@@ -17,7 +17,7 @@
 use curvine_error::FsError;
 use curvine_error::FsResult;
 use curvine_fs_api::{CurvineURI, FileSystem, Path};
-use curvine_model::{FileStatus, FreeResult};
+use curvine_model::{DeleteResult, FileStatus};
 use curvine_ufs_api::fs::ufs_context::UFSContext;
 use curvine_unified_fs::{UfsFileSystem, UnifiedReader, UnifiedWriter};
 use std::sync::Arc;
@@ -87,7 +87,7 @@ impl UfsClient {
         self.fs.exists(path).await
     }
 
-    pub async fn delete(&self, path: &CurvineURI, recursive: bool) -> FsResult<FreeResult> {
+    pub async fn delete(&self, path: &CurvineURI, recursive: bool) -> FsResult<DeleteResult> {
         self.fs.delete(path, recursive).await
     }
 

--- a/crates/server/curvine-data-transfer/src/common/ufs_client.rs
+++ b/crates/server/curvine-data-transfer/src/common/ufs_client.rs
@@ -17,7 +17,7 @@
 use curvine_error::FsError;
 use curvine_error::FsResult;
 use curvine_fs_api::{CurvineURI, FileSystem, Path};
-use curvine_model::FileStatus;
+use curvine_model::{FileStatus, FreeResult};
 use curvine_ufs_api::fs::ufs_context::UFSContext;
 use curvine_unified_fs::{UfsFileSystem, UnifiedReader, UnifiedWriter};
 use std::sync::Arc;
@@ -87,7 +87,7 @@ impl UfsClient {
         self.fs.exists(path).await
     }
 
-    pub async fn delete(&self, path: &CurvineURI, recursive: bool) -> FsResult<()> {
+    pub async fn delete(&self, path: &CurvineURI, recursive: bool) -> FsResult<FreeResult> {
         self.fs.delete(path, recursive).await
     }
 

--- a/crates/server/curvine-data-transfer/src/worker/task/load_task_runner.rs
+++ b/crates/server/curvine-data-transfer/src/worker/task/load_task_runner.rs
@@ -420,13 +420,13 @@ impl LoadTaskRunner {
     async fn delete_temp_output(&self, temp_path: &Path) -> FsResult<()> {
         if temp_path.is_cv() {
             match self.fs.delete(temp_path, false).await {
-                Ok(()) | Err(FsError::FileNotFound(_)) => Ok(()),
+                Ok(_) | Err(FsError::FileNotFound(_)) => Ok(()),
                 Err(err) => Err(err),
             }
         } else {
             let ufs = self.get_ufs()?;
             match ufs.delete(temp_path, false).await {
-                Ok(()) | Err(FsError::FileNotFound(_)) => Ok(()),
+                Ok(_) | Err(FsError::FileNotFound(_)) => Ok(()),
                 Err(err) => Err(err),
             }
         }

--- a/curvine-fuse/src/fs/state/node_state.rs
+++ b/curvine-fuse/src/fs/state/node_state.rs
@@ -34,8 +34,8 @@ use curvine_error::FsError;
 use curvine_fs_api::{FileSystem, ListStream, Path};
 use curvine_fs_api::{StateReader, StateWriter};
 use curvine_model::{
-    CreateFileOpts, FileAllocOpts, FileStatus, ListOptions, MkdirOpts, OpenFlags, RenameFlags,
-    SetAttrOpts,
+    CreateFileOpts, FileAllocOpts, FileStatus, FreeResult, ListOptions, MkdirOpts, OpenFlags,
+    RenameFlags, SetAttrOpts,
 };
 use curvine_runtime::common::FastHashMap;
 use curvine_runtime::sync::{AsyncMutex, AsyncSharedMap, AtomicCounter, RwLockHashMap};
@@ -678,12 +678,12 @@ impl NodeState {
     pub fn complete_deferred_delete(
         &self,
         ino: u64,
-        delete_result: Result<(), FsError>,
+        delete_result: Result<FreeResult, FsError>,
     ) -> FuseResult<()> {
         // Keep the mark observable after failure; reclaiming it without another
         // FUSE request would need a background retry, which is not yet implemented.
         match delete_result {
-            Ok(()) | Err(FsError::FileNotFound(_)) => self.clear_mark_delete(ino),
+            Ok(_) | Err(FsError::FileNotFound(_)) => self.clear_mark_delete(ino),
             Err(e) => Err(e.into()),
         }
     }
@@ -705,7 +705,7 @@ impl NodeState {
         // not failed by ENOENT on a stale name.
         let Some(ino) = ino else {
             return match self.fs.delete(&path, false).await {
-                Ok(()) | Err(FsError::FileNotFound(_)) => Ok(()),
+                Ok(_) | Err(FsError::FileNotFound(_)) => Ok(()),
                 Err(e) => Err(e.into()),
             };
         };
@@ -728,7 +728,7 @@ impl NodeState {
                     .await?;
             }
             match self.fs.delete(&path, false).await {
-                Ok(()) | Err(FsError::FileNotFound(_)) => (),
+                Ok(_) | Err(FsError::FileNotFound(_)) => (),
                 Err(e) => {
                     self.restore_unlink_state(rollback)?;
                     return Err(e.into());
@@ -753,7 +753,7 @@ impl NodeState {
         }
 
         match self.fs.delete(&path, false).await {
-            Ok(()) => (),
+            Ok(_) => (),
             Err(FsError::FileNotFound(_)) => (),
             Err(e) => {
                 self.restore_unlink_state(rollback)?;

--- a/curvine-fuse/src/fs/state/node_state.rs
+++ b/curvine-fuse/src/fs/state/node_state.rs
@@ -34,7 +34,7 @@ use curvine_error::FsError;
 use curvine_fs_api::{FileSystem, ListStream, Path};
 use curvine_fs_api::{StateReader, StateWriter};
 use curvine_model::{
-    CreateFileOpts, FileAllocOpts, FileStatus, FreeResult, ListOptions, MkdirOpts, OpenFlags,
+    CreateFileOpts, DeleteResult, FileAllocOpts, FileStatus, ListOptions, MkdirOpts, OpenFlags,
     RenameFlags, SetAttrOpts,
 };
 use curvine_runtime::common::FastHashMap;
@@ -678,7 +678,7 @@ impl NodeState {
     pub fn complete_deferred_delete(
         &self,
         ino: u64,
-        delete_result: Result<FreeResult, FsError>,
+        delete_result: Result<DeleteResult, FsError>,
     ) -> FuseResult<()> {
         // Keep the mark observable after failure; reclaiming it without another
         // FUSE request would need a background retry, which is not yet implemented.

--- a/curvine-lancedb/src/object_store.rs
+++ b/curvine-lancedb/src/object_store.rs
@@ -1354,7 +1354,7 @@ impl CurvineObjectStore {
         dirs.sort_by(|left, right| right.full_path().len().cmp(&left.full_path().len()));
         for dir in dirs {
             match self.context.fs.delete(&dir, false).await {
-                Ok(()) => {}
+                Ok(_) => {}
                 Err(FsError::DirNotEmpty(_)) => {}
                 Err(e) if is_not_found_error(&e) => {}
                 Err(e) => return Err(fs_error_to_object_store(location, e)),
@@ -1407,7 +1407,7 @@ impl CurvineObjectStore {
             }
 
             match self.context.fs.delete(&dir, false).await {
-                Ok(()) => {}
+                Ok(_) => {}
                 Err(FsError::DirNotEmpty(_)) => break,
                 Err(e) if is_not_found_error(&e) => break,
                 Err(e) => return Err(fs_error_to_object_store(location, e)),

--- a/curvine-master/src/master/fs/delete_result.rs
+++ b/curvine-master/src/master/fs/delete_result.rs
@@ -12,31 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use curvine_model::BlockLocation;
-use std::collections::HashMap;
-
-#[derive(Debug)]
-pub struct DeleteResult {
-    // Number of inodes removed
-    pub(crate) inodes: u64,
-    // Bytes released by removed file inodes
-    pub(crate) bytes: u64,
-    // Which blocks need to be deleted
-    pub(crate) blocks: HashMap<i64, Vec<BlockLocation>>,
-}
-
-impl Default for DeleteResult {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl DeleteResult {
-    pub fn new() -> Self {
-        Self {
-            inodes: 0,
-            bytes: 0,
-            blocks: Default::default(),
-        }
-    }
-}
+pub use curvine_model::DeleteResult;

--- a/curvine-master/src/master/fs/delete_result.rs
+++ b/curvine-master/src/master/fs/delete_result.rs
@@ -19,6 +19,8 @@ use std::collections::HashMap;
 pub struct DeleteResult {
     // Number of inodes removed
     pub(crate) inodes: u64,
+    // Bytes released by removed file inodes
+    pub(crate) bytes: u64,
     // Which blocks need to be deleted
     pub(crate) blocks: HashMap<i64, Vec<BlockLocation>>,
 }
@@ -33,6 +35,7 @@ impl DeleteResult {
     pub fn new() -> Self {
         Self {
             inodes: 0,
+            bytes: 0,
             blocks: Default::default(),
         }
     }

--- a/curvine-master/src/master/fs/master_filesystem.rs
+++ b/curvine-master/src/master/fs/master_filesystem.rs
@@ -263,15 +263,33 @@ impl MasterFilesystem {
     }
 
     pub fn delete<T: AsRef<str>>(&self, path: T, recursive: bool) -> FsResult<bool> {
+        self.delete_with_stats(path, recursive).map(|_| true)
+    }
+
+    pub fn delete_with_stats<T: AsRef<str>>(
+        &self,
+        path: T,
+        recursive: bool,
+    ) -> FsResult<FreeResult> {
         let mut fs_dir = self.fs_dir.write();
         let inp = Self::resolve_path(&fs_dir, path.as_ref())?;
 
         let delete_result = fs_dir.delete(&inp, recursive)?;
+        let mut free_res = FreeResult {
+            inodes: delete_result.inodes as i64,
+            bytes: delete_result.bytes as i64,
+            blocks: delete_result.blocks,
+        };
+        drop(fs_dir);
 
         let mut worker_manager = self.worker_manager.write();
-        worker_manager.remove_blocks(&delete_result);
+        worker_manager.remove_blocks(&DeleteResult {
+            inodes: 0,
+            bytes: 0,
+            blocks: std::mem::take(&mut free_res.blocks),
+        });
 
-        Ok(true)
+        Ok(free_res)
     }
 
     pub fn free<T: AsRef<str>>(&self, path: T, recursive: bool) -> FsResult<FreeResult> {
@@ -284,6 +302,7 @@ impl MasterFilesystem {
         let mut worker_manager = self.worker_manager.write();
         worker_manager.remove_blocks(&DeleteResult {
             inodes: 0,
+            bytes: 0,
             blocks: std::mem::take(&mut free_res.blocks),
         });
 

--- a/curvine-master/src/master/fs/master_filesystem.rs
+++ b/curvine-master/src/master/fs/master_filesystem.rs
@@ -262,15 +262,7 @@ impl MasterFilesystem {
         self.mkdir_with_opts(path, opts)
     }
 
-    pub fn delete<T: AsRef<str>>(&self, path: T, recursive: bool) -> FsResult<bool> {
-        self.delete_with_stats(path, recursive).map(|_| true)
-    }
-
-    pub fn delete_with_stats<T: AsRef<str>>(
-        &self,
-        path: T,
-        recursive: bool,
-    ) -> FsResult<FreeResult> {
+    pub fn delete<T: AsRef<str>>(&self, path: T, recursive: bool) -> FsResult<FreeResult> {
         let mut fs_dir = self.fs_dir.write();
         let inp = Self::resolve_path(&fs_dir, path.as_ref())?;
 

--- a/curvine-master/src/master/fs/master_filesystem.rs
+++ b/curvine-master/src/master/fs/master_filesystem.rs
@@ -262,26 +262,21 @@ impl MasterFilesystem {
         self.mkdir_with_opts(path, opts)
     }
 
-    pub fn delete<T: AsRef<str>>(&self, path: T, recursive: bool) -> FsResult<FreeResult> {
+    pub fn delete<T: AsRef<str>>(&self, path: T, recursive: bool) -> FsResult<DeleteResult> {
         let mut fs_dir = self.fs_dir.write();
         let inp = Self::resolve_path(&fs_dir, path.as_ref())?;
 
-        let delete_result = fs_dir.delete(&inp, recursive)?;
-        let mut free_res = FreeResult {
-            inodes: delete_result.inodes as i64,
-            bytes: delete_result.bytes as i64,
-            blocks: delete_result.blocks,
-        };
+        let mut delete_res = fs_dir.delete(&inp, recursive)?;
         drop(fs_dir);
 
         let mut worker_manager = self.worker_manager.write();
         worker_manager.remove_blocks(&DeleteResult {
             inodes: 0,
             bytes: 0,
-            blocks: std::mem::take(&mut free_res.blocks),
+            blocks: std::mem::take(&mut delete_res.blocks),
         });
 
-        Ok(free_res)
+        Ok(delete_res)
     }
 
     pub fn free<T: AsRef<str>>(&self, path: T, recursive: bool) -> FsResult<FreeResult> {

--- a/curvine-master/src/master/master_handler.rs
+++ b/curvine-master/src/master/master_handler.rs
@@ -206,8 +206,12 @@ impl MasterHandler {
     }
 
     pub fn delete0(&self, req_id: i64, header: DeleteRequest) -> FsResult<bool> {
+        self.delete_with_stats0(req_id, header).map(|_| true)
+    }
+
+    pub fn delete_with_stats0(&self, req_id: i64, header: DeleteRequest) -> FsResult<FreeResult> {
         if self.check_is_retry(req_id)? {
-            return Ok(true);
+            return Ok(FreeResult::default());
         }
 
         let path = Path::from_str(&header.path)?;
@@ -217,7 +221,7 @@ impl MasterHandler {
             }
         }
 
-        let res = self.fs.delete(&header.path, header.recursive);
+        let res = self.fs.delete_with_stats(&header.path, header.recursive);
         self.set_req_cache(req_id, res)
     }
 
@@ -225,8 +229,10 @@ impl MasterHandler {
         let header: DeleteRequest = ctx.parse_header()?;
         ctx.set_audit(Some(header.path.to_string()), None);
 
-        self.delete0(ctx.msg.req_id(), header)?;
-        let rep_header = DeleteResponse::default();
+        let res = self.delete_with_stats0(ctx.msg.req_id(), header)?;
+        let rep_header = DeleteResponse {
+            res: Some(ProtoUtils::free_res_to_pb(res)),
+        };
         ctx.response(rep_header)
     }
 

--- a/curvine-master/src/master/master_handler.rs
+++ b/curvine-master/src/master/master_handler.rs
@@ -227,7 +227,7 @@ impl MasterHandler {
 
         let res = self.delete0(ctx.msg.req_id(), header)?;
         let rep_header = DeleteResponse {
-            res: ProtoUtils::delete_res_to_pb(res),
+            res: Some(ProtoUtils::delete_res_to_pb(res)),
         };
         ctx.response(rep_header)
     }

--- a/curvine-master/src/master/master_handler.rs
+++ b/curvine-master/src/master/master_handler.rs
@@ -26,8 +26,8 @@ use curvine_fs_api::Path;
 use curvine_fs_api::RpcCode;
 use curvine_model::ProtoUtils;
 use curvine_model::{
-    CreateFileOpts, DeleteBlockCmd, FileBlocks, FileStatus, FreeResult, HeartbeatStatus,
-    ListOptions, MasterInfo, OpenFlags, RenameFlags, WorkerCommand, WorkerInfo,
+    CreateFileOpts, DeleteBlockCmd, DeleteResult, FileBlocks, FileStatus, FreeResult,
+    HeartbeatStatus, ListOptions, MasterInfo, OpenFlags, RenameFlags, WorkerCommand, WorkerInfo,
 };
 use curvine_net::net::ConnState;
 use curvine_proto::*;
@@ -205,9 +205,9 @@ impl MasterHandler {
         ctx.response(rep_header)
     }
 
-    pub fn delete0(&self, req_id: i64, header: DeleteRequest) -> FsResult<FreeResult> {
+    pub fn delete0(&self, req_id: i64, header: DeleteRequest) -> FsResult<DeleteResult> {
         if self.check_is_retry(req_id)? {
-            return Ok(FreeResult::default());
+            return Ok(DeleteResult::default());
         }
 
         let path = Path::from_str(&header.path)?;
@@ -227,7 +227,7 @@ impl MasterHandler {
 
         let res = self.delete0(ctx.msg.req_id(), header)?;
         let rep_header = DeleteResponse {
-            res: ProtoUtils::free_res_to_pb(res),
+            res: ProtoUtils::delete_res_to_pb(res),
         };
         ctx.response(rep_header)
     }

--- a/curvine-master/src/master/master_handler.rs
+++ b/curvine-master/src/master/master_handler.rs
@@ -205,11 +205,7 @@ impl MasterHandler {
         ctx.response(rep_header)
     }
 
-    pub fn delete0(&self, req_id: i64, header: DeleteRequest) -> FsResult<bool> {
-        self.delete_with_stats0(req_id, header).map(|_| true)
-    }
-
-    pub fn delete_with_stats0(&self, req_id: i64, header: DeleteRequest) -> FsResult<FreeResult> {
+    pub fn delete0(&self, req_id: i64, header: DeleteRequest) -> FsResult<FreeResult> {
         if self.check_is_retry(req_id)? {
             return Ok(FreeResult::default());
         }
@@ -221,7 +217,7 @@ impl MasterHandler {
             }
         }
 
-        let res = self.fs.delete_with_stats(&header.path, header.recursive);
+        let res = self.fs.delete(&header.path, header.recursive);
         self.set_req_cache(req_id, res)
     }
 
@@ -229,9 +225,9 @@ impl MasterHandler {
         let header: DeleteRequest = ctx.parse_header()?;
         ctx.set_audit(Some(header.path.to_string()), None);
 
-        let res = self.delete_with_stats0(ctx.msg.req_id(), header)?;
+        let res = self.delete0(ctx.msg.req_id(), header)?;
         let rep_header = DeleteResponse {
-            res: Some(ProtoUtils::free_res_to_pb(res)),
+            res: ProtoUtils::free_res_to_pb(res),
         };
         ctx.response(rep_header)
     }

--- a/curvine-master/src/master/meta/store/inode_store.rs
+++ b/curvine-master/src/master/meta/store/inode_store.rs
@@ -157,7 +157,6 @@ impl InodeStore {
         while let Some((parent_id, edge_name, inode)) = stack.pop_front() {
             // Delete inode edges
             batch.delete_child(parent_id, &edge_name)?;
-            del_res.inodes += 1;
 
             match &inode {
                 InodeView::Dir(dir) => {
@@ -176,6 +175,7 @@ impl InodeStore {
                 _ => {
                     deleted_files += 1;
                     let res = self.decrement_inode_nlink(inode.id(), ctime, &mut batch)?;
+                    del_res.inodes += res.inodes;
                     del_res.bytes += res.bytes;
                     del_res.blocks.extend(res.blocks);
                 }
@@ -488,7 +488,8 @@ impl InodeStore {
 
                         // Collect block info
                         let locs = f.get_locs(self)?;
-                        del_res.bytes = f.get_locs_bytes(&locs) as u64;
+                        del_res.inodes = 1;
+                        del_res.bytes = u64::try_from(f.get_locs_bytes(&locs)).unwrap_or(0);
                         del_res.blocks.extend(locs);
 
                         self.ttl_bucket_list.remove(&inode_view);

--- a/curvine-master/src/master/meta/store/inode_store.rs
+++ b/curvine-master/src/master/meta/store/inode_store.rs
@@ -176,6 +176,7 @@ impl InodeStore {
                 _ => {
                     deleted_files += 1;
                     let res = self.decrement_inode_nlink(inode.id(), ctime, &mut batch)?;
+                    del_res.bytes += res.bytes;
                     del_res.blocks.extend(res.blocks);
                 }
             }
@@ -486,7 +487,9 @@ impl InodeStore {
                         batch.delete_inode(inode_id)?;
 
                         // Collect block info
-                        del_res.blocks.extend(f.get_locs(self)?);
+                        let locs = f.get_locs(self)?;
+                        del_res.bytes = f.get_locs_bytes(&locs) as u64;
+                        del_res.blocks.extend(locs);
 
                         self.ttl_bucket_list.remove(&inode_view);
                     } else {

--- a/curvine-server/tests/master_fs_test.rs
+++ b/curvine-server/tests/master_fs_test.rs
@@ -21,7 +21,7 @@ use curvine_model::MountOptions;
 use curvine_model::ProtoUtils;
 use curvine_model::{
     BlockLocation, BlockReportInfo, BlockReportList, BlockReportStatus, ClientAddress, CommitBlock,
-    CreateFileOpts, CreateFileOptsBuilder, FileAllocOpts, FreeResult, LocatedBlock,
+    CreateFileOpts, CreateFileOptsBuilder, DeleteResult, FileAllocOpts, LocatedBlock,
     MkdirOptsBuilder, StorageType, TtlAction, WorkerAddress, WorkerInfo,
 };
 use curvine_model::{OpenFlags, RenameFlags, SetAttrOptsBuilder};
@@ -1816,7 +1816,7 @@ fn delete_file_retry(handler: &mut MasterHandler) -> CommonResult<()> {
         recursive: false,
     };
 
-    let f1: FreeResult = handler.delete0(id, req.clone())?;
+    let f1: DeleteResult = handler.delete0(id, req.clone())?;
     assert_eq!(f1.inodes, 1);
 
     let f2 = handler.delete0(id, req.clone())?;

--- a/curvine-server/tests/master_fs_test.rs
+++ b/curvine-server/tests/master_fs_test.rs
@@ -1810,10 +1810,22 @@ fn delete_file_retry(handler: &mut MasterHandler) -> CommonResult<()> {
     let mut ctx = RpcContext::new(&msg);
     handler.mkdir(&mut ctx)?;
 
+    let create_req = CreateFileRequest {
+        path: "/delete_file_retry/child.log".to_string(),
+        flags: OpenFlags::new_create().value(),
+        ..Default::default()
+    };
+    let create_msg = Builder::new_rpc(RpcCode::CreateFile)
+        .req_id(Utils::req_id())
+        .proto_header(create_req)
+        .build();
+    let mut create_ctx = RpcContext::new(&create_msg);
+    handler.retry_check_create_file(&mut create_ctx)?;
+
     let id = Utils::req_id();
     let req = DeleteRequest {
         path: "/delete_file_retry".to_string(),
-        recursive: false,
+        recursive: true,
     };
 
     let f1: DeleteResult = handler.delete0(id, req.clone())?;

--- a/curvine-server/tests/master_fs_test.rs
+++ b/curvine-server/tests/master_fs_test.rs
@@ -21,8 +21,8 @@ use curvine_model::MountOptions;
 use curvine_model::ProtoUtils;
 use curvine_model::{
     BlockLocation, BlockReportInfo, BlockReportList, BlockReportStatus, ClientAddress, CommitBlock,
-    CreateFileOpts, CreateFileOptsBuilder, FileAllocOpts, LocatedBlock, MkdirOptsBuilder,
-    StorageType, TtlAction, WorkerAddress, WorkerInfo,
+    CreateFileOpts, CreateFileOptsBuilder, FileAllocOpts, FreeResult, LocatedBlock,
+    MkdirOptsBuilder, StorageType, TtlAction, WorkerAddress, WorkerInfo,
 };
 use curvine_model::{OpenFlags, RenameFlags, SetAttrOptsBuilder};
 use curvine_proto::{
@@ -1816,11 +1816,11 @@ fn delete_file_retry(handler: &mut MasterHandler) -> CommonResult<()> {
         recursive: false,
     };
 
-    let f1 = handler.delete0(id, req.clone())?;
-    assert!(f1);
+    let f1: FreeResult = handler.delete0(id, req.clone())?;
+    assert_eq!(f1.inodes, 1);
 
     let f2 = handler.delete0(id, req.clone())?;
-    assert!(f2);
+    assert_eq!(f2.inodes, 0);
 
     Ok(())
 }

--- a/curvine-tests/tests/write_cache_test.rs
+++ b/curvine-tests/tests/write_cache_test.rs
@@ -269,7 +269,15 @@ fn test_cache_mode_free() {
             .unwrap();
         assert!(mnt.ufs().unwrap().exists(&ufs_path).await.unwrap());
 
-        fs.free(&path, false).await.unwrap();
+        let free_res = fs.free(&path, false).await.unwrap();
+        assert!(
+            free_res.inodes > 0,
+            "cache mode free should report deleted inodes"
+        );
+        assert!(
+            free_res.bytes > 0,
+            "cache mode free should report released bytes"
+        );
 
         assert!(
             !fs.cv().exists(&path).await.unwrap(),
@@ -309,7 +317,15 @@ fn test_cache_mode_free_child_with_unified_disabled() {
             .unwrap();
 
         fs.disable_unified();
-        fs.free(&parent, true).await.unwrap();
+        let free_res = fs.free(&parent, true).await.unwrap();
+        assert!(
+            free_res.inodes > 0,
+            "cache-only cache mode free should report deleted inodes"
+        );
+        assert!(
+            free_res.bytes > 0,
+            "cache-only cache mode free should report released bytes"
+        );
 
         assert!(!fs.cv().exists(&path).await.unwrap());
         assert!(mount.ufs().unwrap().exists(&ufs_path).await.unwrap());


### PR DESCRIPTION
# Summary

Use a dedicated `DeleteResult` for the delete API so callers can report inode and byte statistics without conflating delete semantics with `free`. The delete RPC wire format stays compatible with existing clients: `DeleteResponse` continues to carry `FreeResultProto`, and new code converts it to/from `DeleteResult` at the protocol boundary.

# Issue Describe / Design

Closes #1543

- Root cause: cache-mode `free` called `cv.delete` and returned `FreeResult::default()`, so the CLI displayed zero inode and space statistics even though cache metadata and blocks were removed.
- Reproduction steps: mount a UFS directory in cache mode, cache at least one file, run `free`, and observe zero inode/space output.
- Fix approach: `delete` returns a dedicated `DeleteResult` across the master/client APIs. The SDK dispatch layer converts `DeleteResult` into `FreeResult` only for the free/CLI reporting path. `DeleteResponse.res` remains `FreeResultProto` on the wire, and the field is optional so a new client talking to an old master degrades to zero stats instead of failing.
- Stats semantics: `DeleteResult.inodes` counts file inodes only, matching `FreeResult` semantics from regular `free`.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `crates/common/curvine-model/src/result.rs` | Add shared `DeleteResult` with checked conversions to/from `FreeResult` | Delete API uses delete-specific result type |
| `crates/common/curvine-model/src/proto_utils.rs` | Convert `DeleteResult` to/from the existing `FreeResultProto` | Delete RPC wire format remains compatible with old clients |
| `crates/common/curvine-proto/proto/master.proto` | Keep `FreeResultProto` and make `DeleteResponse.res` optional | New clients can tolerate old masters with empty delete responses |
| `crates/common/curvine-fs-api/src/filesystem.rs` and local/UFS adapters | `delete` returns `DeleteResult` | All FS implementations align with the new result type |
| `curvine-master/src/master/fs/*` and `master_handler.rs` | Master delete returns `DeleteResult` and serializes it to the existing response type | CLI can receive non-zero delete stats without breaking old clients |
| `curvine-master/src/master/meta/store/inode_store.rs` | Count file inodes only and compute bytes from block locations with checked conversions | Delete stats match free semantics |
| `crates/client/curvine-client-core/*` and `curvine-unified-fs/*` | Delete APIs return `DeleteResult`; cache-mode `free` converts it to `FreeResult` | No `free + delete`, no compatibility wrapper |
| `crates/sdk/*` | Delete returns `DeleteResult`; language wrappers map to their existing external API | SDK users keep stable wrapper behavior |
| `curvine-server/tests/master_fs_test.rs` | Extend delete retry regression with a cached child file and recursive delete | Delete result stats are covered by tests |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `make format` | PASS | Formatting and clippy checks passed |
| `cargo check --workspace --all-targets` | PASS | Full workspace compile check |
| `cargo +1.92.0 test -p curvine-model result:: --lib` | PASS | New conversion tests passed |
| `cargo +1.92.0 test -p curvine-tests --test write_cache_test test_cache_mode_free -- --test-threads=1` | PASS | Cache-mode free regression passed |
| `cargo +1.92.0 test -p curvine-server --test master_fs_test test_rpc_retry_cache_for_idempotent_operations -- --test-threads=1` | PASS | Delete retry regression passed |
| `git diff --check` | PASS | No whitespace errors |

# Dependencies

- Related PRs: None
- Related issues: #1543
- Blocks / blocked by: None
