### PR TITLE
fix(fuse): require file owner for setattr gid changes (#1548)

### DIFF
--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -822,7 +822,20 @@ impl CurvineFileSystem {
             }
         }
 
+        // Changing the group is also privileged for non-root: caller must own the
+        // file *and* belong to the target group (POSIX chown). Membership alone is
+        // not sufficient — #1500 dropped the owner gate and allowed non-owners who
+        // share the target group to chgrp (ACL bypass / setuid strip).
+        // See CurvineIO/curvine#1548 (originally gongxun0928/curvine#18).
         if let Some(gid) = target_gid {
+            if gid != file_gid && caller_uid != file_uid {
+                return err_fuse!(
+                    libc::EPERM,
+                    "setattr gid change denied: caller uid {} is not file owner (uid {})",
+                    caller_uid,
+                    file_uid
+                );
+            }
             if gid != file_gid && !FuseUtils::caller_in_file_group(caller_gid, gid, caller_pid) {
                 return err_fuse!(
                     libc::EPERM,
@@ -2682,6 +2695,23 @@ mod tests {
             Some(100),
         )
         .unwrap();
+    }
+
+    /// Issue #18 / gongxun0928#18: non-owner who is a member of the *target* group must
+    /// still get EPERM (owner gate ∧ group membership).
+    #[test]
+    fn setattr_permission_denies_non_owner_gid_change_even_if_in_target_group() {
+        let err = super::CurvineFileSystem::check_setattr_permission(
+            true,
+            &hdr(2000, 3000, 0),
+            1000, // file owned by another user
+            100,  // current file gid
+            FATTR_GID,
+            None,
+            Some(3000), // caller primary gid — membership OK, ownership not
+        )
+        .unwrap_err();
+        assert_eq!(err.errno(), libc::EPERM);
     }
 
     #[test]


### PR DESCRIPTION
# Summary

Restore the POSIX owner gate for effective `FATTR_GID` changes in `check_setattr_permission` (owner ∧ in-target-group). After #1500, membership alone was sufficient, allowing non-owners to `chgrp` into their group (ACL bypass / setuid strip).

Closes #1548

# Issue Describe / Design

Related fork issue: https://github.com/gongxun0928/curvine/issues/18

## Root cause

Introduced by `6c298c7` (#1500). While fixing pjdfstest owner `chown(path, -1, gid)`, the FATTR_GID **owner gate** was removed and only group-membership remained.

**Before (#1500):** owner check then membership.  
**After (#1500, buggy):** membership only → non-owner in target group allowed.

## Reproduction

**Unit:** `check_setattr_permission(true, hdr(2000,3000), file_uid=1000, file_gid=100, FATTR_GID, None, Some(3000))` → was `Ok(())`, expected `EPERM`.

**FUSE E2E:** with userspace permission path (no kernel `default_permissions`), alice `0640` `alice:staff`; bob in `bobsgroup` runs `os.chown(path, -1, bob_gid)` → succeeded before fix.

Note: default mounts force `default_permissions`, so the kernel may EPERM first and hide the userspace bug.

## Fix approach

Require `caller_uid == file_uid` before allowing an effective gid change; keep membership check; preserve root / `check_permission=false` short-circuit and #1500 owner uid-noop + gid paths.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-fuse/src/fs/curvine_file_system.rs` | Restore owner gate for effective FATTR_GID; add regression test | Behavior change: non-owner gid change → `EPERM` even if in target group |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-fuse setattr_permission` | PASS | Includes `denies_non_owner_gid_change_even_if_in_target_group` |
| E2E non-owner `os.chown(-1,gid)` without `default_permissions` | PASS | EPERM after fix |
| E2E owner supplementary-group chown (#1500) | PASS | Still OK |
| E2E `chown(-1,-1)` preserves S_ISUID | PASS | |

# Dependencies

- Related PRs: #1547 (independent same-gid S_ISUID fix)
- Related issues: #1548; fork https://github.com/gongxun0928/curvine/issues/18
- Blocks / blocked by: None