### PR TITLE
fix(fuse): do not clear S_ISUID on same-uid/same-gid chown (#1549)

### DIFF
--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -787,12 +787,24 @@ impl CurvineFileSystem {
         Self::permission_mask_allows(permission_bits, mask)
     }
 
+    /// True when normalized chown targets differ from the file's current uid/gid.
+    fn chown_effectively_changes(
+        target_uid: Option<u32>,
+        target_gid: Option<u32>,
+        file_uid: u32,
+        file_gid: u32,
+    ) -> bool {
+        target_uid.is_some_and(|u| u != file_uid) || target_gid.is_some_and(|g| g != file_gid)
+    }
+
     /// POSIX permission model for SETATTR issued by a non-root caller.
     ///
     /// `target_uid`/`target_gid` are the *normalized* chown targets: the caller is expected
     /// to have already dropped the `(uid_t)-1` / `(gid_t)-1` "keep current" sentinels to
-    /// `None` (see `CurvineFileSystem::set_attr`). Therefore a `Some(_)` here always denotes
-    /// a genuine ownership change request, and we no longer need to inspect the raw
+    /// `None` (see `CurvineFileSystem::set_attr`). Therefore a `Some(_)` here means the FATTR
+    /// bit is set and the value is not the (uid_t/gid_t)-1 sentinel; it may still equal the
+    /// current id and be a no-op for the suid/sgid side effect (see
+    /// `chown_effectively_changes`). We no longer need to inspect the raw
     /// FATTR_UID/FATTR_GID bits or special-case `u32::MAX`.
     fn check_setattr_permission(
         check_permission: bool,
@@ -1404,11 +1416,9 @@ impl fs::FileSystem for CurvineFileSystem {
             }
         }
 
-        // Apply chown suid/sgid rules only when owner or group actually changes on a
-        // regular file. Note we check the normalized opts here rather than op.arg.valid
-        // so that (uid_t)-1 sentinels — which appear on the wire as FATTR_UID/FATTR_GID
-        // but do not change ownership — don't trigger the side effect.
-        let chown_effective = opts.owner.is_some() || opts.group.is_some();
+        // Clear setuid/setgid only when uid/gid actually change (not same-id no-ops).
+        let chown_effective =
+            Self::chown_effectively_changes(target_uid, target_gid, file_uid, file_gid);
         if chown_effective && cur_status.file_type == FileType::File {
             let mut new_mode = if let Some(mode) = opts.mode {
                 mode
@@ -2696,6 +2706,29 @@ mod tests {
             None,
         )
         .unwrap();
+    }
+
+    /// Same-id chown targets must not count as an ownership change.
+    #[test]
+    fn chown_effectively_changes_ignores_same_uid_gid_and_absent_targets() {
+        use super::CurvineFileSystem as CFS;
+        assert!(!CFS::chown_effectively_changes(None, None, 1000, 100));
+        assert!(!CFS::chown_effectively_changes(Some(1000), None, 1000, 100));
+        assert!(!CFS::chown_effectively_changes(None, Some(100), 1000, 100));
+        assert!(!CFS::chown_effectively_changes(
+            Some(1000),
+            Some(100),
+            1000,
+            100
+        ));
+        assert!(CFS::chown_effectively_changes(Some(2000), None, 1000, 100));
+        assert!(CFS::chown_effectively_changes(None, Some(200), 1000, 100));
+        assert!(CFS::chown_effectively_changes(
+            Some(1000),
+            Some(200),
+            1000,
+            100
+        ));
     }
 
     /// pjdfstest chown/00.t regression: owner may keep uid unchanged and move gid to a


### PR DESCRIPTION
# Summary

After #1500, `chown(path, -1, file_gid)` (same gid as the file) still cleared `S_ISUID` because the setuid-clearing side effect treated any present `opts.group` as an ownership change. This PR clears setuid/setgid only when the normalized uid/gid targets actually differ from the file's current ids.

Closes #1549

# Issue Describe / Design

Related fork issue: https://github.com/gongxun0928/curvine/issues/19

## Root cause

#1500 correctly dropped `(uid_t/gid_t)-1` sentinels to `None` so `chown(-1, -1)` no longer clears setuid. But for a same-gid update the wire still carries `FATTR_GID` with the current gid; `fuse_setattr_to_opts` sets `opts.group = Some(...)`, and:

```rust
let chown_effective = opts.owner.is_some() || opts.group.is_some();
```

treated that as an effective chown and cleared `S_ISUID`. POSIX: unchanged uid/gid is a no-op and must not clear set-id bits.

## Reproduction

1. Mount Curvine FUSE (`check_permission=true`).
2. As file owner, create a regular file and `chmod 4755` (setuid set).
3. Run `os.chown(path, -1, current_gid)` where `current_gid` is already the file's group.
4. Before this PR: mode loses `S_ISUID` (`0o104755` → `0o100755`).
5. Control: `os.chown(path, -1, -1)` already preserved setuid after #1500.

## Fix approach

Compute effectiveness from the already-normalized numeric targets vs current file ids:

```rust
fn chown_effectively_changes(target_uid, target_gid, file_uid, file_gid) -> bool {
    target_uid.is_some_and(|u| u != file_uid) || target_gid.is_some_and(|g| g != file_gid)
}
```

Use that for the setuid/setgid clearing gate. Real uid/gid changes still clear set-id bits; directories remain unaffected (`FileType::File` guard unchanged).

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-fuse/src/fs/curvine_file_system.rs` | Add `chown_effectively_changes`; use it for `chown_effective`; regression unit test | Behavior change: same-uid/same-gid setattr no longer clears `S_ISUID`/`S_ISGID`. Real chown and `chown(-1,-1)` unchanged. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-fuse --lib chown_effectively_changes` | PASS | New helper cases |
| `cargo test -p curvine-fuse --lib setattr_permission` | PASS | Includes #1500 owner / keep-current paths |
| E2E: same-gid `os.chown(-1, staff)` on `4755` file | PASS | Setuid preserved after fix |
| E2E: real gid change via supplementary group | PASS | Setuid still cleared (POSIX) |
| E2E: `chown(-1, -1)` | PASS | Setuid preserved |

# Dependencies

- Related PRs: #1546 (independent owner-gate fix)
- Related issues: #1549; fork https://github.com/gongxun0928/curvine/issues/19
- Blocks / blocked by: None