### PR TITLE
fix(raft): restore durable snapshot recovery

### DIFF
--- a/crates/metadata/curvine-raft/src/raft/storage/rocks_storage_core.rs
+++ b/crates/metadata/curvine-raft/src/raft/storage/rocks_storage_core.rs
@@ -150,8 +150,6 @@ impl RocksStorageCore {
     }
 
     pub fn set_hard_state(&mut self, hs: HardState) -> RaftResult<()> {
-        self.validate_hard_state_commit(hs.commit)?;
-
         let mut batch = StoreWriteBatch::new(&self.db);
         batch.set_state(&hs)?;
         batch.commit()?;
@@ -161,8 +159,6 @@ impl RocksStorageCore {
     }
 
     pub fn set_hard_state_commit(&mut self, commit: u64) -> RaftResult<()> {
-        self.validate_hard_state_commit(commit)?;
-
         let mut hard_state = self.raft_state.hard_state.clone();
         hard_state.set_commit(commit);
 

--- a/crates/metadata/curvine-raft/src/raft/storage/rocks_storage_core.rs
+++ b/crates/metadata/curvine-raft/src/raft/storage/rocks_storage_core.rs
@@ -15,7 +15,7 @@
 use crate::proto::raft::SnapshotData;
 use crate::raft::{RaftError, RaftResult, LOG_START_INDEX};
 use crate::rocksdb::{DBConf, DBEngine, RocksUtils, WriteBatch};
-use curvine_core_error::{err_box, err_ext, CommonResult};
+use curvine_core_error::{err_box, err_ext, CommonResult, ErrorExt};
 use log::warn;
 use prost::Message;
 use raft::eraftpb::{ConfState, Entry, HardState, Snapshot, SnapshotMetadata};
@@ -28,6 +28,7 @@ pub struct RocksStorageCore {
     db: DBEngine,
     first_index: Option<u64>,
     last_index: Option<u64>,
+    init_error: Option<String>,
 
     pub(crate) trigger_snap_unavailable: bool,
     pub(crate) trigger_log_unavailable: bool,
@@ -42,6 +43,7 @@ impl RocksStorageCore {
     // Save index range。
     pub const INDEX_KEY: &'static [u8] = &[0x02u8];
     pub const STATE_KEY: &'static [u8] = &[0x03u8];
+    pub const CONF_STATE_KEY: &'static [u8] = &[0x04u8];
 
     pub fn new(conf: DBConf, format: bool) -> Self {
         let conf = conf
@@ -56,25 +58,69 @@ impl RocksStorageCore {
             db,
             first_index: None,
             last_index: None,
+            init_error: None,
             trigger_snap_unavailable: false,
             trigger_log_unavailable: false,
             get_entries_context: None,
         };
 
-        if let Some((first, last)) = core.get_index_range().unwrap() {
-            core.first_index = Some(first);
-            core.last_index = Some(last);
-        }
-
-        if let Some(data) = core.db.get_cf(Self::CF_META, Self::STATE_KEY).unwrap() {
-            core.raft_state.hard_state = HardState::decode(data.as_ref()).unwrap_or_default();
+        if let Err(error) = core.load_persisted_state() {
+            core.init_error = Some(error.to_string());
         }
 
         core
     }
 
     pub fn init_state(&mut self) -> RaftResult<RaftState> {
+        if let Some(error) = &self.init_error {
+            return err_box!(
+                "invalid local raft storage: {}. Restore a consistent master meta+journal pair from a healthy voter; do not restart this voter from an empty, partial, or corrupted local directory.",
+                error
+            );
+        }
+        self.validate_hard_state_commit(self.raft_state.hard_state.commit)?;
         Ok(self.raft_state.clone())
+    }
+
+    fn load_persisted_state(&mut self) -> RaftResult<()> {
+        if let Some((first, last)) = self
+            .get_index_range()
+            .map_err(|error| error.ctx("failed to decode raft index range"))?
+        {
+            self.first_index = Some(first);
+            self.last_index = Some(last);
+        }
+
+        if let Some(data) = self
+            .db
+            .get_cf(Self::CF_META, Self::STATE_KEY)
+            .map_err(|error| RaftError::from(error).ctx("failed to read raft hard state"))?
+        {
+            self.raft_state.hard_state = HardState::decode(data.as_ref())
+                .map_err(|error| RaftError::from(error).ctx("failed to decode raft hard state"))?;
+        }
+
+        if let Some(data) = self
+            .db
+            .get_cf(Self::CF_META, Self::SNAP_KEY)
+            .map_err(|error| RaftError::from(error).ctx("failed to read raft snapshot"))?
+        {
+            let snapshot = Snapshot::decode(data.as_ref())
+                .map_err(|error| RaftError::from(error).ctx("failed to decode raft snapshot"))?;
+            self.snapshot_metadata = snapshot.get_metadata().clone();
+            self.raft_state.conf_state = snapshot.get_metadata().get_conf_state().clone();
+        }
+
+        if let Some(data) = self
+            .db
+            .get_cf(Self::CF_META, Self::CONF_STATE_KEY)
+            .map_err(|error| RaftError::from(error).ctx("failed to read raft conf state"))?
+        {
+            self.raft_state.conf_state = ConfState::decode(data.as_ref())
+                .map_err(|error| RaftError::from(error).ctx("failed to decode raft conf state"))?;
+        }
+
+        Ok(())
     }
 
     // Get the entry of the specified index
@@ -104,22 +150,45 @@ impl RocksStorageCore {
     }
 
     pub fn set_hard_state(&mut self, hs: HardState) -> RaftResult<()> {
-        self.raft_state.hard_state = hs.clone();
+        self.validate_hard_state_commit(hs.commit)?;
 
         let mut batch = StoreWriteBatch::new(&self.db);
         batch.set_state(&hs)?;
         batch.commit()?;
 
+        self.raft_state.hard_state = hs;
         Ok(())
     }
 
     pub fn set_hard_state_commit(&mut self, commit: u64) -> RaftResult<()> {
-        self.mut_hard_state().set_commit(commit);
+        self.validate_hard_state_commit(commit)?;
+
+        let mut hard_state = self.raft_state.hard_state.clone();
+        hard_state.set_commit(commit);
 
         let mut batch = StoreWriteBatch::new(&self.db);
-        batch.set_state(&self.raft_state.hard_state)?;
+        batch.set_state(&hard_state)?;
         batch.commit()?;
 
+        self.raft_state.hard_state = hard_state;
+        Ok(())
+    }
+
+    fn validate_hard_state_commit(&self, commit: u64) -> RaftResult<()> {
+        let snapshot_index = self.snapshot_metadata.index;
+        let first_index = self.first_index();
+        let lower_bound = first_index.saturating_sub(1);
+        let last_index = self.last_index();
+        if commit < lower_bound || commit > last_index {
+            return err_box!(
+                "invalid local raft storage: hard_state.commit={} is outside durable range [{}, {}], first_index={}, snapshot_index={}. Restore a consistent master meta+journal pair from a healthy voter; do not restart this voter from an empty or partial local directory.",
+                commit,
+                lower_bound,
+                last_index,
+                first_index,
+                snapshot_index
+            );
+        }
         Ok(())
     }
 
@@ -132,6 +201,10 @@ impl RocksStorageCore {
     }
 
     pub fn set_conf_state(&mut self, cs: ConfState) -> RaftResult<()> {
+        let mut batch = StoreWriteBatch::new(&self.db);
+        batch.set_conf_state(&cs)?;
+        batch.commit()?;
+
         self.raft_state.conf_state = cs;
         Ok(())
     }
@@ -154,7 +227,7 @@ impl RocksStorageCore {
         let meta = snapshot.get_metadata();
         let index = meta.index;
 
-        // Index is 0, indicating that there is no snapshot, but there may be log entry
+        // Index is 0, indicating that there is no snapshot, but there may be log entry.
         if index > LOG_START_INDEX && self.first_index() > index {
             warn!(
                 "snapshot out of date: snapshot_index={}, first_index={}, skip apply",
@@ -166,15 +239,35 @@ impl RocksStorageCore {
             )));
         }
 
+        let mut hard_state = self.raft_state.hard_state.clone();
+        hard_state.term = cmp::max(hard_state.term, meta.term);
+        hard_state.commit = cmp::max(hard_state.commit, index);
+
+        let mut batch = StoreWriteBatch::new(&self.db);
+        let mut new_range = None;
+
         // Non-initialized snapshots need to be saved.
         if index > LOG_START_INDEX {
-            self.db
-                .put_cf(Self::CF_META, Self::SNAP_KEY, snapshot.encode_to_vec())?;
-        }
+            let next_index = index.saturating_add(1);
+            let old_first = self.first_index();
+            let old_last = self.last_index();
+            let new_last = cmp::max(old_last, index);
 
+            batch.delete_entry(old_first, next_index)?;
+            batch.append_index_range(next_index, new_last)?;
+            batch.append_snapshot(&snapshot)?;
+            batch.set_state(&hard_state)?;
+            new_range = Some((next_index, new_last));
+        }
+        batch.set_conf_state(meta.get_conf_state())?;
+        batch.commit()?;
+
+        if let Some((first_index, last_index)) = new_range {
+            self.first_index = Some(first_index);
+            self.last_index = Some(last_index);
+        }
         self.snapshot_metadata = meta.clone();
-        self.raft_state.hard_state.term = cmp::max(self.raft_state.hard_state.term, meta.term);
-        self.raft_state.hard_state.commit = cmp::max(self.raft_state.hard_state.commit, index);
+        self.raft_state.hard_state = hard_state;
         self.raft_state.conf_state = meta.get_conf_state().clone();
 
         Ok(())
@@ -421,6 +514,15 @@ impl<'a> StoreWriteBatch<'a> {
             RocksStorageCore::CF_META,
             RocksStorageCore::SNAP_KEY,
             snapshot.encode_to_vec(),
+        )?;
+        Ok(())
+    }
+
+    fn set_conf_state(&mut self, state: &ConfState) -> CommonResult<()> {
+        self.0.put_cf(
+            RocksStorageCore::CF_META,
+            RocksStorageCore::CONF_STATE_KEY,
+            state.encode_to_vec(),
         )?;
         Ok(())
     }

--- a/crates/metadata/curvine-raft/tests/rocks_storage_recovery_test.rs
+++ b/crates/metadata/curvine-raft/tests/rocks_storage_recovery_test.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use curvine_core_error::CommonResult;
 use curvine_raft::raft::storage::RocksStorageCore;
 use curvine_raft::rocksdb::{DBConf, DBEngine, RocksUtils};
 use curvine_runtime::common::{FileUtils, Utils};
@@ -43,17 +44,24 @@ fn assert_reseed_required(error: impl ToString, commit: u64, lower: u64, upper: 
 }
 
 #[test]
-fn hard_state_cannot_commit_past_the_durable_log_tail() {
-    let conf = test_conf("commit-tail");
-    let mut storage = RocksStorageCore::new(conf, true);
-    let error = storage
-        .set_hard_state(HardState {
-            term: 7,
-            vote: 1,
-            commit: 42,
-        })
-        .unwrap_err();
-    assert_reseed_required(error, 42, 0, 0);
+fn hard_state_can_precede_entries_within_one_ready() -> CommonResult<()> {
+    let conf = test_conf("commit-before-append");
+    let mut storage = RocksStorageCore::new(conf.clone(), true);
+    storage.set_hard_state(HardState {
+        term: 7,
+        vote: 1,
+        commit: 1,
+    })?;
+    storage.append(&[Entry {
+        term: 7,
+        index: 1,
+        ..Default::default()
+    }])?;
+    drop(storage);
+
+    let mut reopened = RocksStorageCore::new(conf, false);
+    assert_eq!(reopened.init_state()?.hard_state.commit, 1);
+    Ok(())
 }
 
 #[test]

--- a/crates/metadata/curvine-raft/tests/rocks_storage_recovery_test.rs
+++ b/crates/metadata/curvine-raft/tests/rocks_storage_recovery_test.rs
@@ -1,0 +1,221 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use curvine_raft::raft::storage::RocksStorageCore;
+use curvine_raft::rocksdb::{DBConf, DBEngine, RocksUtils};
+use curvine_runtime::common::{FileUtils, Utils};
+use prost::Message;
+use raft::eraftpb::{Entry, HardState, Snapshot};
+
+fn test_conf(name: &str) -> DBConf {
+    DBConf::new(Utils::test_sub_dir(format!(
+        "rocks-storage-recovery-{}-{}",
+        name,
+        Utils::rand_str(6)
+    )))
+}
+
+fn assert_reseed_required(error: impl ToString, commit: u64, lower: u64, upper: u64) {
+    let message = error.to_string();
+    assert!(
+        message.contains(&format!("hard_state.commit={commit}")),
+        "missing commit in error: {message}"
+    );
+    assert!(
+        message.contains(&format!("[{lower}, {upper}]")),
+        "missing durable range in error: {message}"
+    );
+    assert!(
+        message.contains("Restore a consistent master meta+journal pair from a healthy voter"),
+        "missing operator hint in error: {message}"
+    );
+}
+
+#[test]
+fn hard_state_cannot_commit_past_the_durable_log_tail() {
+    let conf = test_conf("commit-tail");
+    let mut storage = RocksStorageCore::new(conf, true);
+    let error = storage
+        .set_hard_state(HardState {
+            term: 7,
+            vote: 1,
+            commit: 42,
+        })
+        .unwrap_err();
+    assert_reseed_required(error, 42, 0, 0);
+}
+
+#[test]
+fn startup_rejects_a_hard_state_beyond_the_durable_log_tail() {
+    let conf = test_conf("startup");
+    FileUtils::delete_path(&conf.base_dir, true).unwrap();
+
+    let db = DBEngine::new(
+        conf.clone()
+            .add_cf(RocksStorageCore::CF_ENTRIES)
+            .add_cf(RocksStorageCore::CF_META),
+        true,
+    )
+    .unwrap();
+    db.put_cf(
+        RocksStorageCore::CF_META,
+        RocksStorageCore::STATE_KEY,
+        HardState {
+            term: 7,
+            vote: 1,
+            commit: 42,
+        }
+        .encode_to_vec(),
+    )
+    .unwrap();
+    drop(db);
+
+    let error = RocksStorageCore::new(conf, false).init_state().unwrap_err();
+    assert_reseed_required(error, 42, 0, 0);
+}
+
+#[test]
+fn startup_rejects_a_hard_state_below_the_compacted_prefix() {
+    let conf = test_conf("startup-lower-bound");
+    FileUtils::delete_path(&conf.base_dir, true).unwrap();
+
+    let db = DBEngine::new(
+        conf.clone()
+            .add_cf(RocksStorageCore::CF_ENTRIES)
+            .add_cf(RocksStorageCore::CF_META),
+        true,
+    )
+    .unwrap();
+    db.put_cf(
+        RocksStorageCore::CF_META,
+        RocksStorageCore::INDEX_KEY,
+        RocksUtils::u64_u64_to_bytes(101, 110),
+    )
+    .unwrap();
+    db.put_cf(
+        RocksStorageCore::CF_META,
+        RocksStorageCore::STATE_KEY,
+        HardState {
+            term: 7,
+            vote: 1,
+            commit: 99,
+        }
+        .encode_to_vec(),
+    )
+    .unwrap();
+    drop(db);
+
+    let error = RocksStorageCore::new(conf, false).init_state().unwrap_err();
+    assert_reseed_required(error, 99, 100, 110);
+}
+
+#[test]
+fn snapshot_only_storage_restarts_at_the_snapshot_index() {
+    let conf = test_conf("snapshot-only");
+    FileUtils::delete_path(&conf.base_dir, true).unwrap();
+
+    {
+        let mut storage = RocksStorageCore::new(conf.clone(), true);
+        let mut snapshot = Snapshot::default();
+        snapshot.mut_metadata().index = 100;
+        snapshot.mut_metadata().term = 7;
+        snapshot.mut_metadata().mut_conf_state().voters = vec![1, 2, 3];
+        storage.apply_snapshot(snapshot).unwrap();
+    }
+
+    let mut storage = RocksStorageCore::new(conf, false);
+    let state = storage.init_state().unwrap();
+    assert_eq!(state.hard_state.commit, 100);
+    assert_eq!(state.conf_state.voters, vec![1, 2, 3]);
+    assert_eq!(storage.first_index(), 101);
+    assert_eq!(storage.last_index(), 100);
+}
+
+#[test]
+fn snapshot_install_compacts_the_durable_log_range() {
+    let conf = test_conf("snapshot-compacts-range");
+    FileUtils::delete_path(&conf.base_dir, true).unwrap();
+
+    {
+        let mut storage = RocksStorageCore::new(conf.clone(), true);
+        let entries: Vec<_> = (1..=3)
+            .map(|index| Entry {
+                term: 7,
+                index,
+                ..Default::default()
+            })
+            .collect();
+        storage.append(&entries).unwrap();
+
+        let mut snapshot = Snapshot::default();
+        snapshot.mut_metadata().index = 3;
+        snapshot.mut_metadata().term = 7;
+        storage.apply_snapshot(snapshot).unwrap();
+    }
+
+    let mut storage = RocksStorageCore::new(conf, false);
+    assert_eq!(storage.init_state().unwrap().hard_state.commit, 3);
+    assert_eq!(storage.first_index(), 4);
+    assert_eq!(storage.last_index(), 3);
+}
+
+#[test]
+fn startup_rejects_corrupt_persisted_raft_metadata() {
+    let cases = [
+        (
+            "index-range",
+            RocksStorageCore::INDEX_KEY,
+            "failed to decode raft index range",
+        ),
+        (
+            "hard-state",
+            RocksStorageCore::STATE_KEY,
+            "failed to decode raft hard state",
+        ),
+        (
+            "snapshot",
+            RocksStorageCore::SNAP_KEY,
+            "failed to decode raft snapshot",
+        ),
+        (
+            "conf-state",
+            RocksStorageCore::CONF_STATE_KEY,
+            "failed to decode raft conf state",
+        ),
+    ];
+
+    for (name, key, expected) in cases {
+        let conf = test_conf(name);
+        FileUtils::delete_path(&conf.base_dir, true).unwrap();
+        let db = DBEngine::new(
+            conf.clone()
+                .add_cf(RocksStorageCore::CF_ENTRIES)
+                .add_cf(RocksStorageCore::CF_META),
+            true,
+        )
+        .unwrap();
+        db.put_cf(RocksStorageCore::CF_META, key, [0xff]).unwrap();
+        drop(db);
+
+        let error = RocksStorageCore::new(conf, false)
+            .init_state()
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains(expected), "{name}: {error}");
+        assert!(
+            error.contains("corrupted local directory"),
+            "{name}: {error}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
Persist and restore the full local Raft recovery state so a voter restarted after snapshot compaction does not lose its durable progress.

## Issue/Design
This is one bounded part of #1551 and supersedes the RocksStorageCore portion of #1552. A snapshot previously updated in-memory progress while the restart path restored only the log range and hard state. A snapshot-only or compacted-log restart could therefore reconstruct an inconsistent durable range.

## Changes
| Area | Change |
| --- | --- |
| Raft storage | Load the persisted snapshot and membership configuration before serving the Raft state. |
| Atomicity | Persist snapshot, compacted range, hard state, and conf state in one RocksDB write batch, then update memory. |
| Recovery validation | During storage initialization, reject corrupt records and hard-state commits outside the durable range. Do not perform that range check while persisting a Ready, because its HardState can legitimately precede entries in the same Ready. |
| Tests | Add restart, compaction, corruption, range-validation, and HardState-before-append recovery coverage in the curvine-raft test module. |

## Test verified
- `cargo fmt --check -- crates/metadata/curvine-raft/src/raft/storage/rocks_storage_core.rs crates/metadata/curvine-raft/tests/rocks_storage_recovery_test.rs`
- `cargo test -q -p curvine-raft --test rocks_storage_recovery_test`
- `cargo clippy -q -p curvine-raft --all-targets -- --deny=warnings --allow clippy::uninlined-format-args`
- `git diff --check`

## Dependencies
None. This PR is independently mergeable.