### PR TITLE
fix(rocksdb): flush all column families before checkpoint

### DIFF
--- a/crates/adapters/curvine-rocksdb/src/rocksdb/db_engine.rs
+++ b/crates/adapters/curvine-rocksdb/src/rocksdb/db_engine.rs
@@ -278,7 +278,13 @@ impl DBEngine {
     pub fn flush_mem(&self, sync: bool) -> CommonResult<()> {
         let mut opts = FlushOptions::default();
         opts.set_wait(sync);
-        self.db.flush_opt(&opts)?;
+        let cfs = self
+            .conf
+            .family_list
+            .iter()
+            .map(|cf| self.cf(cf))
+            .collect::<CommonResult<Vec<_>>>()?;
+        self.db.flush_cfs_opt(&cfs, &opts)?;
         Ok(())
     }
 

--- a/crates/adapters/curvine-rocksdb/tests/rocks_db_test.rs
+++ b/crates/adapters/curvine-rocksdb/tests/rocks_db_test.rs
@@ -64,6 +64,30 @@ fn test_rocksdb_checkpoint_and_restore_functionality() -> CommonResult<()> {
     Ok(())
 }
 
+#[test]
+fn test_rocksdb_checkpoint_flushes_all_column_families() -> CommonResult<()> {
+    let base_dir = Utils::test_sub_dir(format!("rocks_multi_cf_checkpoint_{}", Utils::rand_str(6)));
+    FileUtils::delete_path(&base_dir, true)?;
+
+    let conf = DBConf::new(&base_dir)
+        .set_disable_wal(true)
+        .add_cf("cf1")
+        .add_cf("cf2");
+    let mut db = DBEngine::new(conf, true)?;
+    db.put_cf("cf1", b"k1", b"v1")?;
+    db.put_cf("cf2", b"k2", b"v2")?;
+
+    let checkpoint = db.create_checkpoint(1)?;
+    db.put_cf("cf1", b"late", b"late")?;
+    db.restore(checkpoint)?;
+
+    assert_eq!(db.get_cf("cf1", b"k1")?, Some(b"v1".to_vec()));
+    assert_eq!(db.get_cf("cf2", b"k2")?, Some(b"v2".to_vec()));
+    assert!(db.get_cf("cf1", b"late")?.is_none());
+
+    Ok(())
+}
+
 fn to_vec(iter: RocksIterator) -> Vec<String> {
     let mut vec = vec![];
     for item in iter {


### PR DESCRIPTION
## Summary
Flush every configured column family before creating a RocksDB checkpoint.

## Issue/Design
This is an independent durability correction extracted from #1552. `DB::flush_opt` only flushes the default column family, while Curvine metadata is stored in named column families. A checkpoint created with WAL disabled could therefore omit recently written metadata.

## Changes
| Area | Change |
| --- | --- |
| Checkpoint preparation | Resolve every configured column family and invoke RocksDB `flush_cfs_opt`. |
| Test | Write to two named column families with WAL disabled, checkpoint, restore, and verify both values remain. |

## Test verified
- `cargo fmt --check -- crates/adapters/curvine-rocksdb/src/rocksdb/db_engine.rs crates/adapters/curvine-rocksdb/tests/rocks_db_test.rs`
- `CARGO_TARGET_DIR=/mnt/data/curvine/.build/pr-1552-split/rocksdb-checkpoint cargo test -q -p curvine-rocksdb --test rocks_db_test`
- `CARGO_TARGET_DIR=/mnt/data/curvine/.build/pr-1552-split/rocksdb-checkpoint cargo clippy -q -p curvine-rocksdb --test rocks_db_test -- -D warnings`
- `git diff --check`

## Dependencies
None. This PR is independently mergeable.