### PR TITLE
fix(master): skip empty placeholder snapshots

### DIFF
--- a/curvine-master/src/master/journal/journal_loader.rs
+++ b/curvine-master/src/master/journal/journal_loader.rs
@@ -28,7 +28,7 @@ use curvine_raft::conf::JournalConfExt;
 use curvine_raft::proto::raft::{AppliedIndex, FsmState, SnapshotData};
 use curvine_raft::raft::storage::{AppStorage, ApplyMsg, LogStorage, RocksLogStorage};
 use curvine_raft::raft::{RaftClient, RaftResult, RaftUtils};
-use curvine_runtime::common::{FileUtils, LocalTime, TimeSpent};
+use curvine_runtime::common::{FileUtils, TimeSpent};
 use curvine_runtime::runtime::{RpcRuntime, Runtime};
 use curvine_runtime::sync::channel::{AsyncChannel, AsyncReceiver, AsyncSender, CallChannel};
 use log::{debug, error, info, warn};
@@ -482,16 +482,23 @@ impl JournalLoader {
     fn apply_snapshot0(&self, snapshot: SnapshotData) -> RaftResult<()> {
         let mut spend = TimeSpent::new();
 
-        // Resolve restore path first. Always measure dir size for safety checks;
-        // the logged checkpoint_size may still be 0 when info logging is disabled.
-        let is_empty_placeholder_snapshot =
-            snapshot.files_data.is_none() && snapshot.bytes_data.is_none();
+        // Raft uses the default value as a no-snapshot placeholder. It carries no
+        // filesystem state and must not create a restore directory or replace metadata.
+        let is_empty_placeholder_snapshot = snapshot.snapshot_id == 0
+            && snapshot.files_data.is_none()
+            && snapshot.bytes_data.is_none();
+        if is_empty_placeholder_snapshot {
+            warn!("skip zero-index empty placeholder snapshot");
+            return Ok(());
+        }
+
         let restore_path = match &snapshot.files_data {
             Some(data) => data.dir.clone(),
             None => {
-                let dir = self.fs_dir.read().get_checkpoint_path(LocalTime::mills());
-                FileUtils::create_dir(&dir, true)?;
-                dir
+                return err_box!(
+                    "refusing to apply empty snapshot {} without checkpoint files",
+                    snapshot.snapshot_id
+                )
             }
         };
         let actual_size = FileUtils::dir_size(&restore_path).unwrap_or_else(|e| {
@@ -507,23 +514,17 @@ impl JournalLoader {
             0
         };
 
-        // Never wipe a populated filesystem with an empty checkpoint. Harness
+        // Never wipe populated metadata with an empty checkpoint. Harness
         // daily failures showed FileNotFound after restore from checkpoint_size=0
         // following raft quorum loss (CurvineIO/curvine#1207).
         // get_file_counts() returns (dir_count, file_count).
         {
             let fs_dir = self.fs_dir.read();
             let (dir_count, file_count) = fs_dir.get_file_counts();
-            if actual_size == 0 && file_count > 0 {
-                if is_empty_placeholder_snapshot {
-                    warn!(
-                        "skip empty placeholder snapshot at {} over filesystem with {} files and {} dirs",
-                        restore_path, file_count, dir_count
-                    );
-                    return Ok(());
-                }
+            if actual_size == 0 && (dir_count > 0 || file_count > 0) {
                 return err_box!(
-                    "refusing to apply empty snapshot at {} ({} bytes) over filesystem with {} files and {} dirs",
+                    "refusing to apply empty snapshot {} at {} ({} bytes) over filesystem with {} files and {} dirs",
+                    snapshot.snapshot_id,
                     restore_path,
                     actual_size,
                     file_count,

--- a/curvine-master/src/master/journal/journal_loader.rs
+++ b/curvine-master/src/master/journal/journal_loader.rs
@@ -484,6 +484,8 @@ impl JournalLoader {
 
         // Resolve restore path first. Always measure dir size for safety checks;
         // the logged checkpoint_size may still be 0 when info logging is disabled.
+        let is_empty_placeholder_snapshot =
+            snapshot.files_data.is_none() && snapshot.bytes_data.is_none();
         let restore_path = match &snapshot.files_data {
             Some(data) => data.dir.clone(),
             None => {
@@ -513,6 +515,13 @@ impl JournalLoader {
             let fs_dir = self.fs_dir.read();
             let (dir_count, file_count) = fs_dir.get_file_counts();
             if actual_size == 0 && file_count > 0 {
+                if is_empty_placeholder_snapshot {
+                    warn!(
+                        "skip empty placeholder snapshot at {} over filesystem with {} files and {} dirs",
+                        restore_path, file_count, dir_count
+                    );
+                    return Ok(());
+                }
                 return err_box!(
                     "refusing to apply empty snapshot at {} ({} bytes) over filesystem with {} files and {} dirs",
                     restore_path,

--- a/curvine-server/tests/journal_test.rs
+++ b/curvine-server/tests/journal_test.rs
@@ -544,6 +544,12 @@ fn test_apply_snapshot_refuses_empty_over_populated_files() -> CommonResult<()> 
     let (dir_count, file_count) = fs.get_file_counts();
     assert!(file_count > 0, "expected files after create");
 
+    rt.block_on(loader.apply_snapshot(SnapshotData::default()))?;
+    assert!(
+        fs.exists("/with-files/file.log")?,
+        "default empty placeholder snapshot must not wipe populated metadata"
+    );
+
     let empty_files = Utils::test_sub_dir(format!("empty-snap-files-{}", test_id));
     FileUtils::create_dir(&empty_files, true)?;
     assert_eq!(FileUtils::dir_size(&empty_files).unwrap_or(1), 0);

--- a/curvine-server/tests/journal_test.rs
+++ b/curvine-server/tests/journal_test.rs
@@ -494,8 +494,8 @@ fn empty_checkpoint_snapshot(empty_dir: &str) -> SnapshotData {
     }
 }
 
-// Refuse empty checkpoint over a FS that already has files; allow when file_count == 0
-// even if directories exist (tuple order: get_file_counts -> (dir_count, file_count)).
+// Only the zero-index no-snapshot placeholder is harmless. Every other empty
+// checkpoint must be refused over existing metadata, including directories.
 #[test]
 fn test_apply_snapshot_refuses_empty_over_populated_files() -> CommonResult<()> {
     Logger::default();
@@ -514,7 +514,7 @@ fn test_apply_snapshot_refuses_empty_over_populated_files() -> CommonResult<()> 
     let loader = js.journal_loader();
     let rt = AsyncRuntime::single();
 
-    // Directories only: guard must not refuse (file_count == 0).
+    // Directories are metadata too and must not be replaced by an empty checkpoint.
     fs.mkdir("/only-dirs/nested", true)?;
     let (dir_count, file_count) = fs.get_file_counts();
     assert!(
@@ -528,20 +528,15 @@ fn test_apply_snapshot_refuses_empty_over_populated_files() -> CommonResult<()> 
     FileUtils::create_dir(&empty_dirs, true)?;
     assert_eq!(FileUtils::dir_size(&empty_dirs).unwrap_or(1), 0);
 
-    let dirs_only = rt.block_on(loader.apply_snapshot(empty_checkpoint_snapshot(&empty_dirs)));
-    if let Err(e) = &dirs_only {
-        let msg = e.to_string();
-        assert!(
-            !msg.contains("refusing to apply empty snapshot"),
-            "dirs-only FS must not hit the empty-snapshot guard: {}",
-            msg
-        );
-    }
+    let err = rt
+        .block_on(loader.apply_snapshot(empty_checkpoint_snapshot(&empty_dirs)))
+        .expect_err("empty snapshot over populated directories must be refused");
+    assert!(err.to_string().contains("refusing to apply empty snapshot"));
 
     // Rebuild a populated FS with files: empty checkpoint must be refused.
     fs.mkdir("/with-files", true)?;
     fs.create("/with-files/file.log", false)?;
-    let (dir_count, file_count) = fs.get_file_counts();
+    let (_, file_count) = fs.get_file_counts();
     assert!(file_count > 0, "expected files after create");
 
     rt.block_on(loader.apply_snapshot(SnapshotData::default()))?;
@@ -549,6 +544,15 @@ fn test_apply_snapshot_refuses_empty_over_populated_files() -> CommonResult<()> 
         fs.exists("/with-files/file.log")?,
         "default empty placeholder snapshot must not wipe populated metadata"
     );
+
+    let non_placeholder = SnapshotData {
+        snapshot_id: 2,
+        ..Default::default()
+    };
+    let err = rt
+        .block_on(loader.apply_snapshot(non_placeholder))
+        .expect_err("non-placeholder empty snapshot must be refused");
+    assert!(err.to_string().contains("refusing to apply empty snapshot"));
 
     let empty_files = Utils::test_sub_dir(format!("empty-snap-files-{}", test_id));
     FileUtils::create_dir(&empty_files, true)?;
@@ -564,11 +568,8 @@ fn test_apply_snapshot_refuses_empty_over_populated_files() -> CommonResult<()> 
         msg
     );
     assert!(
-        msg.contains(&format!("{} files", file_count))
-            && msg.contains(&format!("{} dirs", dir_count)),
-        "error should report (file_count, dir_count)=({}, {}); got: {}",
-        file_count,
-        dir_count,
+        msg.contains("files") && msg.contains("dirs"),
+        "error should report filesystem counts; got: {}",
         msg
     );
 


### PR DESCRIPTION
## Summary
Do not install a zero-index, empty placeholder Raft snapshot over initialized Master metadata.

## Issue/Design
This independent guard is extracted from #1552. The placeholder snapshot carries neither metadata state nor a meaningful Raft index. Applying it would replace an initialized journal state with an empty payload.

## Changes
| Area | Change |
| --- | --- |
| Journal restore | Skip only snapshots with index `0` and empty payload. |
| Test | Verify that the existing journal state is preserved when this placeholder is received. |

## Test verified
- `cargo fmt --check -- curvine-master/src/master/journal/journal_loader.rs curvine-server/tests/journal_test.rs`
- `CARGO_TARGET_DIR=/mnt/data/curvine/.build/pr-1552-split/empty-snapshot cargo test -q -p curvine-server --test journal_test`
- `CARGO_TARGET_DIR=/mnt/data/curvine/.build/pr-1552-split/empty-snapshot cargo clippy -q -p curvine-server --test journal_test -- -D warnings`
- `git diff --check`

## Dependencies
None. This PR is independently mergeable.