### PR TITLE
fix(raft): fence leader promotion after metadata apply

### DIFF
--- a/crates/metadata/curvine-raft/proto/raft.proto
+++ b/crates/metadata/curvine-raft/proto/raft.proto
@@ -82,6 +82,7 @@ message ProposeRequest {
 }
 
 message ProposeResponse {
+    optional uint64 applied_index = 1;
 }
 
 message RaftRequest {

--- a/crates/metadata/curvine-raft/src/raft/raft_client.rs
+++ b/crates/metadata/curvine-raft/src/raft/raft_client.rs
@@ -76,9 +76,15 @@ impl RaftClient {
     }
 
     // Send application layer messages.
-    pub async fn send_propose(&self, data: Vec<u8>) -> RaftResult<()> {
+    pub async fn send_propose_response(&self, data: Vec<u8>) -> RaftResult<ProposeResponse> {
         let req = ProposeRequest { data };
-        let _: ProposeResponse = self.leader_rpc(RaftCode::Propose, req).await?;
+        let response: ProposeResponse = self.leader_rpc(RaftCode::Propose, req).await?;
+        Ok(response)
+    }
+
+    // Send application layer messages.
+    pub async fn send_propose(&self, data: Vec<u8>) -> RaftResult<()> {
+        self.send_propose_response(data).await?;
         Ok(())
     }
 

--- a/crates/metadata/curvine-raft/src/raft/raft_node.rs
+++ b/crates/metadata/curvine-raft/src/raft/raft_node.rs
@@ -463,22 +463,10 @@ where
         // Get the ready structure.
         let mut ready = self.raw.ready();
 
-        // If hard state changes, it needs to be saved.
-        if let Some(hs) = ready.hs() {
-            let store = self.raw.mut_store();
-            store.set_hard_state(hs)?;
-        }
-
         let soft_state = ready.ss().map(|ss| SoftState {
             leader_id: ss.leader_id,
             raft_state: ss.raft_state,
         });
-
-        // Get the message that needs to be sent to other nodes.
-        // Only the leader call returns true.
-        if !ready.messages().is_empty() {
-            self.send_messages(ready.take_messages()).await?;
-        }
 
         // Process snapshots.
         if *ready.snapshot() != Snapshot::default() {
@@ -486,11 +474,20 @@ where
                 .gen_apply_snapshot_job(ready.snapshot().clone())?;
         }
 
-        // Persist new log entries first so followers can be notified immediately
-        // via persisted_messages.  FSM apply of already-committed entries can
-        // happen afterwards without blocking the persistence pipeline.
+        // Persist entries before the HardState that may commit them. A crash may
+        // leave extra uncommitted entries, but must never leave commit past tail.
         if !ready.entries().is_empty() {
             self.storage.append(&ready.entries()[..])?;
+        }
+
+        if let Some(hs) = ready.hs() {
+            let store = self.raw.mut_store();
+            store.set_hard_state(hs)?;
+        }
+
+        // Raft messages may be sent only after their Ready state is durable.
+        if !ready.messages().is_empty() {
+            self.send_messages(ready.take_messages()).await?;
         }
 
         // Get the message that the leader has fallen into the disk and send these messages to other nodes.

--- a/crates/metadata/curvine-raft/src/raft/raft_node.rs
+++ b/crates/metadata/curvine-raft/src/raft/raft_node.rs
@@ -647,20 +647,13 @@ where
         req_id: i64,
         sender: Callback,
         response: ProposeResponse,
-        apply_done: Option<CallReceiver<RaftResult<()>>>,
+        apply_done: CallReceiver<RaftResult<()>>,
     ) {
         let response_msg = Builder::new_rpc(RaftCode::Propose)
             .response(ResponseStatus::Success)
             .proto_header(response)
             .req_id(req_id)
             .build();
-
-        let Some(apply_done) = apply_done else {
-            if sender.send(Ok(response_msg)).is_err() {
-                warn!("The client connection has been closed, req {}", req_id)
-            }
-            return;
-        };
 
         rt.spawn(async move {
             let result = match apply_done.receive().await {
@@ -731,6 +724,17 @@ where
                 let apply = self.apply_propose(entry, should_respond).await?;
                 if should_respond {
                     let Some(entry_context) = entry_context else {
+                        warn!(
+                            "leader committed entry has no response context, index {}, term {}",
+                            entry_index, entry_term
+                        );
+                        continue;
+                    };
+                    let Some(apply_done) = apply.apply_done else {
+                        warn!(
+                            "leader committed entry has no apply acknowledgement, index {}, term {}",
+                            entry_index, entry_term
+                        );
                         continue;
                     };
                     let req_id: i64 = match SerdeUtils::deserialize(&entry_context) {
@@ -749,7 +753,7 @@ where
                             req_id,
                             sender,
                             apply.response,
-                            apply.apply_done,
+                            apply_done,
                         ),
 
                         None => {

--- a/crates/metadata/curvine-raft/src/raft/raft_node.rs
+++ b/crates/metadata/curvine-raft/src/raft/raft_node.rs
@@ -20,11 +20,14 @@ use crate::raft::raft_error::RaftError;
 use crate::raft::storage::{AppStorage, ApplyMsg, LogStorage, PeerStorage};
 use crate::raft::*;
 use crate::utils::SerdeUtils;
+use curvine_core_error::ErrorExt;
+use curvine_io::DataSlice;
 use curvine_net::net::InetAddr;
 use curvine_rpc::client::dispatch::{Callback, Envelope};
 use curvine_rpc::message::{Builder, RefMessage, ResponseStatus};
 use curvine_runtime::common::{DurationUnit, LocalTime, TimeSpent};
 use curvine_runtime::runtime::{RpcRuntime, Runtime};
+use curvine_runtime::sync::channel::{CallChannel, CallReceiver};
 use log::{debug, error, info, warn};
 use prost::Message as PMessage;
 use raft::eraftpb::{ConfChange, Entry, EntryType, MessageType, Snapshot};
@@ -35,6 +38,11 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::time::{interval, MissedTickBehavior};
+
+struct ProposeApply {
+    response: ProposeResponse,
+    apply_done: Option<CallReceiver<RaftResult<()>>>,
+}
 
 pub struct RaftNode<A, B>
 where
@@ -610,11 +618,74 @@ where
         Ok(ConfChangeResponse::default())
     }
 
-    async fn apply_propose(&mut self, entry: Entry) -> RaftResult<ProposeResponse> {
-        self.storage
-            .apply_propose(false, ApplyMsg::new_entry(entry))
-            .await?;
-        Ok(ProposeResponse::default())
+    async fn apply_propose(
+        &mut self,
+        entry: Entry,
+        wait_for_response: bool,
+    ) -> RaftResult<ProposeApply> {
+        let applied_index = entry.index;
+        let apply_done = if wait_for_response {
+            let (tx, rx) = CallChannel::channel();
+            self.storage
+                .apply_propose(false, ApplyMsg::new_entry_with_ack(entry, tx))
+                .await?;
+            Some(rx)
+        } else {
+            self.storage
+                .apply_propose(false, ApplyMsg::new_entry(entry))
+                .await?;
+            None
+        };
+
+        Ok(ProposeApply {
+            response: ProposeResponse {
+                applied_index: Some(applied_index),
+            },
+            apply_done,
+        })
+    }
+
+    fn send_propose_response_after_apply(
+        rt: &Arc<Runtime>,
+        req_id: i64,
+        sender: Callback,
+        response: ProposeResponse,
+        apply_done: Option<CallReceiver<RaftResult<()>>>,
+    ) {
+        let response_msg = Builder::new_rpc(RaftCode::Propose)
+            .response(ResponseStatus::Success)
+            .proto_header(response)
+            .req_id(req_id)
+            .build();
+
+        let Some(apply_done) = apply_done else {
+            if sender.send(Ok(response_msg)).is_err() {
+                warn!("The client connection has been closed, req {}", req_id)
+            }
+            return;
+        };
+
+        rt.spawn(async move {
+            let result = match apply_done.receive().await {
+                Ok(Ok(())) => Ok(response_msg),
+                Ok(Err(error)) => Ok(Builder::new_rpc(RaftCode::Propose)
+                    .response(ResponseStatus::Error)
+                    .req_id(req_id)
+                    .data(DataSlice::Buffer(error.encode()))
+                    .build()),
+                Err(error) => {
+                    let error = RaftError::from(error);
+                    Ok(Builder::new_rpc(RaftCode::Propose)
+                        .response(ResponseStatus::Error)
+                        .req_id(req_id)
+                        .data(DataSlice::Buffer(error.encode()))
+                        .build())
+                }
+            };
+            if sender.send(result).is_err() {
+                warn!("The client connection has been closed, req {}", req_id)
+            }
+        });
     }
 
     // Whether you need to create a new snapshot.
@@ -660,10 +731,36 @@ where
                     .response(ResponseStatus::Success)
                     .proto_header(rep)
             } else {
-                let rep = self.apply_propose(entry).await?;
-                Builder::new_rpc(RaftCode::Propose)
-                    .response(ResponseStatus::Success)
-                    .proto_header(rep)
+                let apply = self.apply_propose(entry, should_respond).await?;
+                if should_respond {
+                    let Some(entry_context) = entry_context else {
+                        continue;
+                    };
+                    let req_id: i64 = match SerdeUtils::deserialize(&entry_context) {
+                        Ok(req_id) => req_id,
+                        Err(e) => {
+                            warn!(
+                                "failed to decode raft entry context for response, index {}, term {}: {}",
+                                entry_index, entry_term, e
+                            );
+                            continue;
+                        }
+                    };
+                    match client_send.remove(&req_id) {
+                        Some(sender) => Self::send_propose_response_after_apply(
+                            &self.rt,
+                            req_id,
+                            sender,
+                            apply.response,
+                            apply.apply_done,
+                        ),
+
+                        None => {
+                            warn!("Not found client for request {}", req_id)
+                        }
+                    };
+                }
+                continue;
             };
 
             // Followers only need to replay the message and do not need to respond to the customer service.

--- a/crates/metadata/curvine-raft/src/raft/storage/apply_msg.rs
+++ b/crates/metadata/curvine-raft/src/raft/storage/apply_msg.rs
@@ -20,6 +20,7 @@ use raft::StateRole;
 
 pub enum ApplyMsg {
     Entry(Entry),
+    EntryWithAck((Entry, CallSender<RaftResult<()>>)),
     Scan(AppliedIndex),
     CreateSnapshot(CallSender<RaftResult<SnapshotData>>),
     ApplySnapshot((CallSender<RaftResult<()>>, SnapshotData)),
@@ -32,6 +33,10 @@ impl ApplyMsg {
         ApplyMsg::Entry(entry)
     }
 
+    pub fn new_entry_with_ack(entry: Entry, ack: CallSender<RaftResult<()>>) -> Self {
+        ApplyMsg::EntryWithAck((entry, ack))
+    }
+
     pub fn new_scan(applied_index: AppliedIndex) -> ApplyMsg {
         ApplyMsg::Scan(applied_index)
     }
@@ -39,6 +44,15 @@ impl ApplyMsg {
     pub fn take_entry(self) -> Entry {
         match self {
             ApplyMsg::Entry(entry) => entry,
+            ApplyMsg::EntryWithAck((entry, _)) => entry,
+            _ => panic!("invalid entry"),
+        }
+    }
+
+    pub fn take_entry_with_ack(self) -> (Entry, Option<CallSender<RaftResult<()>>>) {
+        match self {
+            ApplyMsg::Entry(entry) => (entry, None),
+            ApplyMsg::EntryWithAck((entry, ack)) => (entry, Some(ack)),
             _ => panic!("invalid entry"),
         }
     }

--- a/crates/metadata/curvine-raft/src/raft/storage/apply_msg.rs
+++ b/crates/metadata/curvine-raft/src/raft/storage/apply_msg.rs
@@ -41,19 +41,11 @@ impl ApplyMsg {
         ApplyMsg::Scan(applied_index)
     }
 
-    pub fn take_entry(self) -> Entry {
+    pub fn into_entry_with_ack(self) -> RaftResult<(Entry, Option<CallSender<RaftResult<()>>>)> {
         match self {
-            ApplyMsg::Entry(entry) => entry,
-            ApplyMsg::EntryWithAck((entry, _)) => entry,
-            _ => panic!("invalid entry"),
-        }
-    }
-
-    pub fn take_entry_with_ack(self) -> (Entry, Option<CallSender<RaftResult<()>>>) {
-        match self {
-            ApplyMsg::Entry(entry) => (entry, None),
-            ApplyMsg::EntryWithAck((entry, ack)) => (entry, Some(ack)),
-            _ => panic!("invalid entry"),
+            ApplyMsg::Entry(entry) => Ok((entry, None)),
+            ApplyMsg::EntryWithAck((entry, ack)) => Ok((entry, Some(ack))),
+            _ => Err("expected raft entry apply message".to_string().into()),
         }
     }
 }

--- a/crates/metadata/curvine-raft/src/raft/storage/apply_msg.rs
+++ b/crates/metadata/curvine-raft/src/raft/storage/apply_msg.rs
@@ -24,7 +24,7 @@ pub enum ApplyMsg {
     Scan(AppliedIndex),
     CreateSnapshot(CallSender<RaftResult<SnapshotData>>),
     ApplySnapshot((CallSender<RaftResult<()>>, SnapshotData)),
-    RoleChange(StateRole),
+    RoleChange((StateRole, CallSender<RaftResult<()>>)),
     Shutdown(CallSender<()>),
 }
 

--- a/crates/metadata/curvine-raft/src/raft/storage/hash_app_storage.rs
+++ b/crates/metadata/curvine-raft/src/raft/storage/hash_app_storage.rs
@@ -86,19 +86,28 @@ where
     V: DeserializeOwned + Sized + Serialize + Clone + Send + Sync + 'static,
 {
     async fn apply(&self, _: bool, msg: ApplyMsg) -> RaftResult<()> {
-        let entry = msg.take_entry();
-        let mut map = self.write()?;
-        let pairs: (K, V) = SerdeUtils::deserialize(&entry.data)?;
-        map.insert(pairs.0, pairs.1);
+        let (entry, ack) = msg.take_entry_with_ack();
+        let result = (|| -> RaftResult<()> {
+            let mut map = self.write()?;
+            let pairs: (K, V) = SerdeUtils::deserialize(&entry.data)?;
+            map.insert(pairs.0, pairs.1);
 
-        self.fsm_state.lock().unwrap().applied = AppliedIndex {
-            term: entry.term,
-            index: entry.index,
-            op_id: 0,
-            rpc_id: 0,
-        };
+            self.fsm_state.lock().unwrap().applied = AppliedIndex {
+                term: entry.term,
+                index: entry.index,
+                op_id: 0,
+                rpc_id: 0,
+            };
 
-        Ok(())
+            Ok(())
+        })();
+
+        if let Some(tx) = ack {
+            let _ = tx.send(result);
+            Ok(())
+        } else {
+            result
+        }
     }
 
     fn get_fsm_state(&self) -> FsmState {
@@ -188,21 +197,30 @@ where
     V: Serialize + DeserializeOwned + Clone + Sync + Send + 'static,
 {
     async fn apply(&self, _: bool, msg: ApplyMsg) -> RaftResult<()> {
-        let entry = msg.take_entry();
-        let db = self.lock()?;
-        let pairs: (K, V) = SerdeUtils::deserialize(&entry.data)?;
-        let k = SerdeUtils::serialize(&pairs.0)?;
-        let v = SerdeUtils::serialize(&pairs.1)?;
-        db.put(k, v)?;
+        let (entry, ack) = msg.take_entry_with_ack();
+        let result = (|| -> RaftResult<()> {
+            let db = self.lock()?;
+            let pairs: (K, V) = SerdeUtils::deserialize(&entry.data)?;
+            let k = SerdeUtils::serialize(&pairs.0)?;
+            let v = SerdeUtils::serialize(&pairs.1)?;
+            db.put(k, v)?;
 
-        self.fsm_state.lock().unwrap().applied = AppliedIndex {
-            term: entry.term,
-            index: entry.index,
-            op_id: 0,
-            rpc_id: 0,
-        };
+            self.fsm_state.lock().unwrap().applied = AppliedIndex {
+                term: entry.term,
+                index: entry.index,
+                op_id: 0,
+                rpc_id: 0,
+            };
 
-        Ok(())
+            Ok(())
+        })();
+
+        if let Some(tx) = ack {
+            let _ = tx.send(result);
+            Ok(())
+        } else {
+            result
+        }
     }
 
     fn get_fsm_state(&self) -> FsmState {

--- a/crates/metadata/curvine-raft/src/raft/storage/hash_app_storage.rs
+++ b/crates/metadata/curvine-raft/src/raft/storage/hash_app_storage.rs
@@ -86,7 +86,10 @@ where
     V: DeserializeOwned + Sized + Serialize + Clone + Send + Sync + 'static,
 {
     async fn apply(&self, _: bool, msg: ApplyMsg) -> RaftResult<()> {
-        let (entry, ack) = msg.take_entry_with_ack();
+        if matches!(msg, ApplyMsg::Scan(_)) {
+            return Ok(());
+        }
+        let (entry, ack) = msg.into_entry_with_ack()?;
         let result = (|| -> RaftResult<()> {
             let mut map = self.write()?;
             let pairs: (K, V) = SerdeUtils::deserialize(&entry.data)?;
@@ -197,7 +200,10 @@ where
     V: Serialize + DeserializeOwned + Clone + Sync + Send + 'static,
 {
     async fn apply(&self, _: bool, msg: ApplyMsg) -> RaftResult<()> {
-        let (entry, ack) = msg.take_entry_with_ack();
+        if matches!(msg, ApplyMsg::Scan(_)) {
+            return Ok(());
+        }
+        let (entry, ack) = msg.into_entry_with_ack()?;
         let result = (|| -> RaftResult<()> {
             let db = self.lock()?;
             let pairs: (K, V) = SerdeUtils::deserialize(&entry.data)?;

--- a/crates/metadata/curvine-raft/tests/raft_node_test.rs
+++ b/crates/metadata/curvine-raft/tests/raft_node_test.rs
@@ -33,6 +33,7 @@ use prost::Message;
 use raft::eraftpb::{ConfState, Entry, HardState, Message as RaftMessage, MessageType, Snapshot};
 use raft::{Config, RawNode};
 use raft::{GetEntriesContext, RaftState, StateRole, Storage, StorageError};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::sync::{Mutex, RwLock};
 
@@ -166,20 +167,127 @@ impl TestKvAppStorage {
     fn get(&self, key: &str) -> Option<String> {
         self.map.read().unwrap().get(key).cloned()
     }
+
+    fn apply_entry(&self, entry: Entry) -> RaftResult<()> {
+        let pair: (String, String) = SerdeUtils::deserialize(&entry.data)?;
+        self.map.write().unwrap().insert(pair.0, pair.1);
+        self.fsm_state.lock().unwrap().applied = curvine_raft::proto::raft::AppliedIndex {
+            term: entry.term,
+            index: entry.index,
+            op_id: 0,
+            rpc_id: 0,
+        };
+        Ok(())
+    }
 }
 
 impl AppStorage for TestKvAppStorage {
     async fn apply(&self, _: bool, msg: curvine_raft::raft::storage::ApplyMsg) -> RaftResult<()> {
         match msg {
             curvine_raft::raft::storage::ApplyMsg::Entry(entry) => {
-                let pair: (String, String) = SerdeUtils::deserialize(&entry.data)?;
-                self.map.write().unwrap().insert(pair.0, pair.1);
-                self.fsm_state.lock().unwrap().applied = curvine_raft::proto::raft::AppliedIndex {
-                    term: entry.term,
-                    index: entry.index,
-                    op_id: 0,
-                    rpc_id: 0,
-                };
+                self.apply_entry(entry)?;
+            }
+            curvine_raft::raft::storage::ApplyMsg::EntryWithAck((entry, tx)) => {
+                let result = self.apply_entry(entry);
+                let _ = tx.send(result);
+            }
+            curvine_raft::raft::storage::ApplyMsg::Scan(applied) => {
+                self.fsm_state.lock().unwrap().applied = applied;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn get_fsm_state(&self) -> FsmState {
+        self.fsm_state.lock().unwrap().clone()
+    }
+
+    async fn role_change(&self, _: StateRole) -> RaftResult<()> {
+        Ok(())
+    }
+
+    async fn create_snapshot(&self) -> RaftResult<SnapshotData> {
+        Ok(SnapshotData {
+            snapshot_id: self.get_fsm_state().applied.index,
+            node_id: 0,
+            create_time: 0,
+            bytes_data: Some(Vec::new()),
+            files_data: None,
+            fsm_state: self.get_fsm_state(),
+        })
+    }
+
+    async fn apply_snapshot(&self, _: SnapshotData) -> RaftResult<()> {
+        Ok(())
+    }
+
+    fn snapshot_dir(&self, _: u64) -> RaftResult<String> {
+        Ok(String::new())
+    }
+}
+
+#[derive(Clone, Default)]
+struct BlockingApplyAppStorage {
+    map: Arc<RwLock<std::collections::HashMap<String, String>>>,
+    fsm_state: Arc<Mutex<FsmState>>,
+    started: Arc<AtomicBool>,
+    started_notify: Arc<tokio::sync::Notify>,
+    release: Arc<tokio::sync::Notify>,
+    completed: Arc<AtomicBool>,
+}
+
+impl BlockingApplyAppStorage {
+    fn get(&self, key: &str) -> Option<String> {
+        self.map.read().unwrap().get(key).cloned()
+    }
+
+    async fn apply_entry(&self, entry: Entry, wait: bool) -> RaftResult<()> {
+        let pair: (String, String) = SerdeUtils::deserialize(&entry.data)?;
+        self.started.store(true, Ordering::SeqCst);
+        self.started_notify.notify_one();
+        if wait {
+            self.release.notified().await;
+        }
+        self.map.write().unwrap().insert(pair.0, pair.1);
+        self.fsm_state.lock().unwrap().applied = curvine_raft::proto::raft::AppliedIndex {
+            term: entry.term,
+            index: entry.index,
+            op_id: 0,
+            rpc_id: 0,
+        };
+        Ok(())
+    }
+
+    async fn wait_started(&self) {
+        if self.started.load(Ordering::SeqCst) {
+            return;
+        }
+        self.started_notify.notified().await;
+    }
+
+    fn release_apply(&self) {
+        self.release.notify_waiters();
+    }
+
+    fn proposal_completed(&self) -> bool {
+        self.completed.load(Ordering::SeqCst)
+    }
+}
+
+impl AppStorage for BlockingApplyAppStorage {
+    async fn apply(
+        &self,
+        wait: bool,
+        msg: curvine_raft::raft::storage::ApplyMsg,
+    ) -> RaftResult<()> {
+        match msg {
+            curvine_raft::raft::storage::ApplyMsg::Entry(entry) => {
+                self.apply_entry(entry, wait).await?;
+            }
+            curvine_raft::raft::storage::ApplyMsg::EntryWithAck((entry, tx)) => {
+                let result = self.apply_entry(entry, true).await;
+                let _ = tx.send(result);
             }
             curvine_raft::raft::storage::ApplyMsg::Scan(applied) => {
                 self.fsm_state.lock().unwrap().applied = applied;
@@ -401,6 +509,57 @@ fn install_snapshot_skips_empty_app_snapshot_when_applied_index_nonzero() -> Com
         "empty app snapshot must not be applied when applied.index > 0"
     );
     assert_eq!(app.get_fsm_state().applied.index, 7);
+
+    Ok(())
+}
+
+#[test]
+fn propose_response_waits_until_committed_entry_is_applied() -> CommonResult<()> {
+    Logger::default();
+
+    let mut conf = JournalConf::with_test();
+    conf.journal_dir = format!("../testing/propose-apply-{}", Utils::rand_id());
+    FileUtils::delete_path(&conf.journal_dir, true)?;
+
+    let rt = conf.create_runtime();
+    let store = BlockingApplyAppStorage::default();
+    let raft = RaftJournal::new(
+        rt.clone(),
+        RocksLogStorage::from_conf(&conf, true),
+        store.clone(),
+        conf.clone(),
+        RoleMonitor::new(),
+    );
+    let mut listener = rt.block_on(raft.run())?;
+    rt.block_on(listener.wait_leader())?;
+
+    let client = RaftClient::from_conf(rt.clone(), &conf);
+    let msg = SerdeUtils::serialize(&("name".to_string(), "curvine".to_string()))?;
+    let completed = store.completed.clone();
+    let handle = rt.spawn(async move {
+        let result = client.send_propose_response(msg).await;
+        completed.store(true, Ordering::SeqCst);
+        result
+    });
+
+    rt.block_on(async {
+        tokio::time::timeout(std::time::Duration::from_secs(3), store.wait_started())
+            .await
+            .expect("committed entry should reach app storage apply");
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    });
+
+    assert!(
+        !store.proposal_completed(),
+        "propose RPC returned before the committed entry finished app storage apply"
+    );
+    assert_eq!(store.get("name"), None);
+
+    store.release_apply();
+    let response = rt.block_on(handle).unwrap()?;
+    assert!(response.applied_index.unwrap_or_default() > 0);
+    assert_eq!(store.get("name"), Some("curvine".to_string()));
+    FileUtils::delete_path(&conf.journal_dir, true)?;
 
     Ok(())
 }

--- a/crates/metadata/curvine-raft/tests/raft_node_test.rs
+++ b/crates/metadata/curvine-raft/tests/raft_node_test.rs
@@ -18,7 +18,8 @@ use curvine_core_error::CommonResult;
 use curvine_raft::conf::JournalConf;
 use curvine_raft::proto::raft::{FsmState, SnapshotData};
 use curvine_raft::raft::storage::{
-    AppStorage, HashAppStorage, LogStorage, MemLogStorage, RocksLogStorage,
+    AppStorage, ApplyMsg, HashAppStorage, LogStorage, MemLogStorage, RocksAppStorage,
+    RocksLogStorage,
 };
 use curvine_raft::raft::{
     RaftClient, RaftCode, RaftError, RaftJournal, RaftNode, RaftResult, RoleMonitor,
@@ -27,7 +28,7 @@ use curvine_raft::utils::SerdeUtils;
 use curvine_rpc::client::{ClientConf, RpcClient};
 use curvine_rpc::message::{Builder, ResponseStatus};
 use curvine_runtime::common::{FileUtils, Logger, Utils};
-use curvine_runtime::runtime::{RpcRuntime, Runtime};
+use curvine_runtime::runtime::{AsyncRuntime, RpcRuntime, Runtime};
 use prost::bytes::BytesMut;
 use prost::Message;
 use raft::eraftpb::{ConfState, Entry, HardState, Message as RaftMessage, MessageType, Snapshot};
@@ -227,14 +228,27 @@ impl AppStorage for TestKvAppStorage {
     }
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone)]
 struct BlockingApplyAppStorage {
     map: Arc<RwLock<std::collections::HashMap<String, String>>>,
     fsm_state: Arc<Mutex<FsmState>>,
     started: Arc<AtomicBool>,
     started_notify: Arc<tokio::sync::Notify>,
-    release: Arc<tokio::sync::Notify>,
+    release: Arc<tokio::sync::Semaphore>,
     completed: Arc<AtomicBool>,
+}
+
+impl Default for BlockingApplyAppStorage {
+    fn default() -> Self {
+        Self {
+            map: Arc::default(),
+            fsm_state: Arc::default(),
+            started: Arc::default(),
+            started_notify: Arc::default(),
+            release: Arc::new(tokio::sync::Semaphore::new(0)),
+            completed: Arc::default(),
+        }
+    }
 }
 
 impl BlockingApplyAppStorage {
@@ -247,7 +261,11 @@ impl BlockingApplyAppStorage {
         self.started.store(true, Ordering::SeqCst);
         self.started_notify.notify_one();
         if wait {
-            self.release.notified().await;
+            self.release
+                .clone()
+                .acquire_owned()
+                .await
+                .expect("test semaphore is never closed");
         }
         self.map.write().unwrap().insert(pair.0, pair.1);
         self.fsm_state.lock().unwrap().applied = curvine_raft::proto::raft::AppliedIndex {
@@ -267,7 +285,7 @@ impl BlockingApplyAppStorage {
     }
 
     fn release_apply(&self) {
-        self.release.notify_waiters();
+        self.release.add_permits(1);
     }
 
     fn proposal_completed(&self) -> bool {
@@ -560,6 +578,28 @@ fn propose_response_waits_until_committed_entry_is_applied() -> CommonResult<()>
     assert!(response.applied_index.unwrap_or_default() > 0);
     assert_eq!(store.get("name"), Some("curvine".to_string()));
     FileUtils::delete_path(&conf.journal_dir, true)?;
+
+    Ok(())
+}
+
+#[test]
+fn kv_app_storages_accept_scan_control_messages() -> CommonResult<()> {
+    let rt = AsyncRuntime::single();
+    let applied = curvine_raft::proto::raft::AppliedIndex {
+        term: 1,
+        index: 1,
+        ..Default::default()
+    };
+
+    let hash: HashAppStorage<String, String> = HashAppStorage::new();
+    rt.block_on(hash.apply(true, ApplyMsg::new_scan(applied.clone())))?;
+
+    let dir = Utils::test_sub_dir(format!("rocks-app-storage-scan-{}", Utils::rand_id()));
+    FileUtils::delete_path(&dir, true)?;
+    let rocks: RocksAppStorage<String, String> = RocksAppStorage::new(&dir);
+    rt.block_on(rocks.apply(true, ApplyMsg::new_scan(applied)))?;
+    drop(rocks);
+    FileUtils::delete_path(&dir, true)?;
 
     Ok(())
 }

--- a/curvine-master/src/master/journal/entry.rs
+++ b/curvine-master/src/master/journal/entry.rs
@@ -303,6 +303,15 @@ impl JournalEntry {
             | JournalEntry::Snapshot(_) => Vec::new(),
         }
     }
+
+    pub fn allocated_inode_id(&self) -> Option<i64> {
+        match self {
+            JournalEntry::Mkdir(e) => Some(e.dir.id),
+            JournalEntry::CreateFile(e) => Some(e.file.id),
+            JournalEntry::Symlink(e) => Some(e.new_inode.id),
+            _ => None,
+        }
+    }
 }
 
 impl CvMetadataChange {

--- a/curvine-master/src/master/journal/journal_loader.rs
+++ b/curvine-master/src/master/journal/journal_loader.rs
@@ -374,7 +374,7 @@ impl JournalLoader {
             .into();
         }
         Ok(())
-}
+    }
     async fn next_apply_msg(
         &self,
         receiver: &mut AsyncReceiver<ApplyMsg>,
@@ -415,20 +415,25 @@ impl JournalLoader {
                     retry_num = 0;
                 }
 
-                ApplyMsg::RoleChange(role) => {
-                    is_leader = role == StateRole::Leader;
-                    if is_leader {
-                        let ufs_applied = match self.get_ufs_applied() {
-                            Ok(ufs_applied) => ufs_applied,
-                            Err(e) => {
-                                Self::abort_on_fatal_apply_error(format!(
-                                    "failed to read fsm_state after leader role change: {}",
-                                    e
-                                ));
-                            }
-                        };
-                        info!("role changed to leader, scheduling UFS replay scan from ufs_applied: {:?}", ufs_applied);
-                        retry_msg.replace(ApplyMsg::new_scan(ufs_applied));
+                ApplyMsg::RoleChange((role, tx)) => {
+                    let result = async {
+                        if role == StateRole::Leader {
+                            // Publish leadership only after committed namespace mutations
+                            // have advanced local metadata high-water marks.
+                            self.catch_up_committed_metadata().await?;
+                            is_leader = true;
+                            let ufs_applied = self.get_ufs_applied()?;
+                            info!("metadata caught up for leader promotion, scheduling UFS replay from {:?}", ufs_applied);
+                            retry_msg.replace(ApplyMsg::new_scan(ufs_applied));
+                        } else {
+                            is_leader = false;
+                        }
+                        Ok(())
+                    }
+                    .await;
+
+                    if tx.send(result).is_err() {
+                        warn!("leader role-change acknowledgement receiver dropped");
                     }
                 }
 
@@ -965,10 +970,14 @@ impl AppStorage for JournalLoader {
 
     async fn role_change(&self, role: StateRole) -> RaftResult<()> {
         if !self.has_apply_worker {
+            if role == StateRole::Leader {
+                self.catch_up_committed_metadata().await?;
+            }
             return Ok(());
         }
-        self.sender.send(ApplyMsg::RoleChange(role)).await?;
-        Ok(())
+        let (tx, rx) = CallChannel::channel();
+        self.sender.send(ApplyMsg::RoleChange((role, tx))).await?;
+        rx.receive().await?
     }
 
     async fn create_snapshot(&self) -> RaftResult<SnapshotData> {

--- a/curvine-master/src/master/journal/journal_loader.rs
+++ b/curvine-master/src/master/journal/journal_loader.rs
@@ -256,6 +256,19 @@ impl JournalLoader {
 
             {
                 let fs_dir = self.fs_dir.read();
+                if !is_leader {
+                    if let Some(inode_id) = op_entry.allocated_inode_id() {
+                        let last_inode_id = fs_dir.last_inode_id();
+                        if inode_id <= last_inode_id {
+                            return err_box!(
+                                "refusing duplicate inode allocation during follower replay: inode_id={}, last_inode_id={}, journal={:?}",
+                                inode_id,
+                                last_inode_id,
+                                op_entry
+                            );
+                        }
+                    }
+                }
                 fs_dir.update_op_id(op_entry.op_id());
                 if let Some(inode_id) = op_entry.inode_id() {
                     fs_dir.update_last_inode_id(inode_id)?;
@@ -359,12 +372,12 @@ impl JournalLoader {
     }
 
     async fn catch_up_committed_metadata(&self) -> RaftResult<()> {
+        let committed = self.log_store.hard_state().commit;
         let applied = self.fsm_state_snapshot()?.applied;
         self.apply_msg(false, &ApplyMsg::new_scan(applied), false)
             .await?;
 
         let metadata_applied = self.fsm_state_snapshot()?.applied.index;
-        let committed = self.log_store.hard_state().commit;
         if metadata_applied < committed {
             return err_box!(
                 "metadata catch-up stopped before committed raft index: applied={}, commit={}",

--- a/curvine-master/src/master/journal/journal_loader.rs
+++ b/curvine-master/src/master/journal/journal_loader.rs
@@ -370,8 +370,7 @@ impl JournalLoader {
                 "metadata catch-up stopped before committed raft index: applied={}, commit={}",
                 metadata_applied,
                 committed
-            )
-            .into();
+            );
         }
         Ok(())
     }

--- a/curvine-master/src/master/journal/journal_loader.rs
+++ b/curvine-master/src/master/journal/journal_loader.rs
@@ -305,7 +305,7 @@ impl JournalLoader {
         skip_ufs_error: bool,
     ) -> CommonResult<()> {
         match msg {
-            ApplyMsg::Entry(entry) => {
+            ApplyMsg::Entry(entry) | ApplyMsg::EntryWithAck((entry, _)) => {
                 self.apply0(is_leader, entry, skip_ufs_error).await?;
                 Ok(())
             }
@@ -350,6 +350,31 @@ impl JournalLoader {
         }
     }
 
+    fn complete_entry_ack(msg: ApplyMsg, result: RaftResult<()>) {
+        if let ApplyMsg::EntryWithAck((_, tx)) = msg {
+            if let Err(e) = tx.send(result) {
+                warn!("send journal entry apply acknowledgement failed: {}", e);
+            }
+        }
+    }
+
+    async fn catch_up_committed_metadata(&self) -> RaftResult<()> {
+        let applied = self.fsm_state_snapshot()?.applied;
+        self.apply_msg(false, &ApplyMsg::new_scan(applied), false)
+            .await?;
+
+        let metadata_applied = self.fsm_state_snapshot()?.applied.index;
+        let committed = self.log_store.hard_state().commit;
+        if metadata_applied < committed {
+            return err_box!(
+                "metadata catch-up stopped before committed raft index: applied={}, commit={}",
+                metadata_applied,
+                committed
+            )
+            .into();
+        }
+        Ok(())
+}
     async fn next_apply_msg(
         &self,
         receiver: &mut AsyncReceiver<ApplyMsg>,
@@ -413,11 +438,15 @@ impl JournalLoader {
                 }
 
                 msg => match self.apply_msg(is_leader, &msg, false).await {
-                    Ok(_) => retry_num = 0,
+                    Ok(_) => {
+                        retry_num = 0;
+                        Self::complete_entry_ack(msg, Ok(()));
+                    }
 
                     Err(error) => {
                         if self.ignore_reply_error {
                             error!("apply entry failed(skip): {}", error);
+                            Self::complete_entry_ack(msg, Ok(()));
                         } else if is_leader {
                             retry_num += 1;
 
@@ -427,7 +456,7 @@ impl JournalLoader {
                                         "apply entry failed(retry_num={}), skipping failed UFS replay to keep master alive: {}",
                                         retry_num, error
                                     );
-                                    let continue_scan = matches!(msg, ApplyMsg::Scan(_));
+                                    let continue_scan = matches!(&msg, ApplyMsg::Scan(_));
                                     if let Err(skip_error) =
                                         self.apply_msg(is_leader, &msg, true).await
                                     {
@@ -439,6 +468,8 @@ impl JournalLoader {
                                     retry_num = 0;
                                     if continue_scan {
                                         retry_msg.replace(msg);
+                                    } else {
+                                        Self::complete_entry_ack(msg, Ok(()));
                                     }
                                 } else {
                                     Self::abort_on_fatal_apply_error(format!(
@@ -881,25 +912,45 @@ impl JournalLoader {
         rx.receive().await?;
         Ok(())
     }
+
+    async fn apply_direct(&self, msg: ApplyMsg) -> RaftResult<()> {
+        let result = if let Err(e) = self.apply_msg(false, &msg, false).await {
+            if self.ignore_reply_error {
+                error!("apply entry failed: {}", e);
+                Ok(())
+            } else {
+                Err(e.into())
+            }
+        } else {
+            Ok(())
+        };
+
+        if matches!(&msg, ApplyMsg::EntryWithAck(_)) {
+            Self::complete_entry_ack(msg, result);
+            Ok(())
+        } else {
+            result
+        }
+    }
 }
 
 impl AppStorage for JournalLoader {
     async fn apply(&self, wait: bool, msg: ApplyMsg) -> RaftResult<()> {
-        if wait || !self.has_apply_worker {
-            if let Err(e) = self.apply_msg(false, &msg, false).await {
-                if self.ignore_reply_error {
-                    error!("apply entry failed: {}", e);
-                    Ok(())
-                } else {
-                    Err(e.into())
-                }
-            } else {
-                Ok(())
-            }
-        } else {
-            self.sender.send(msg).await?;
-            Ok(())
+        if !self.has_apply_worker {
+            return self.apply_direct(msg).await;
         }
+
+        if matches!(&msg, ApplyMsg::EntryWithAck(_)) {
+            self.sender.send(msg).await?;
+            return Ok(());
+        }
+
+        if wait {
+            return self.apply_direct(msg).await;
+        }
+
+        self.sender.send(msg).await?;
+        Ok(())
     }
 
     fn get_fsm_state(&self) -> FsmState {

--- a/curvine-master/src/master/journal/journal_system.rs
+++ b/curvine-master/src/master/journal/journal_system.rs
@@ -360,6 +360,13 @@ impl JournalSystem {
         self.raft_journal.app_store().clone()
     }
 
+    #[doc(hidden)]
+    pub fn append_committed_entry_for_test(&self, entry: Entry) -> RaftResult<()> {
+        let index = entry.index;
+        self.raft_journal.log_store().append(&[entry])?;
+        self.raft_journal.log_store().set_hard_state_commit(index)
+    }
+
     pub fn state_listener(&self) -> RoleStateListener {
         self.raft_journal.new_state_listener()
     }
@@ -486,108 +493,6 @@ mod tests {
             );
         }
 
-        Ok(())
-    }
-
-    #[test]
-    fn promotion_applies_committed_metadata_before_returning() -> FsResult<()> {
-        Master::init_test_metrics();
-
-        let mut source_conf = ClusterConf {
-            testing: true,
-            ..Default::default()
-        };
-        source_conf.change_test_meta_dir(format!("promotion-source-{}", Utils::rand_str(6)));
-        let source_fs = JournalSystem::fs_only_for_test(&source_conf)?;
-        source_fs.mkdir("/committed-before-promotion", false)?;
-        let entry = source_fs
-            .fs_dir
-            .read()
-            .take_entries()
-            .into_iter()
-            .next()
-            .expect("mkdir must emit a journal entry");
-
-        let mut target_conf = ClusterConf {
-            testing: true,
-            ..Default::default()
-        };
-        target_conf.change_test_meta_dir(format!("promotion-target-{}", Utils::rand_str(6)));
-        let target = JournalSystem::from_conf(&target_conf)?;
-        let target_fs = target.fs();
-        let loader = target.journal_loader();
-
-        let mut batch = JournalBatch::new(1);
-        batch.push(entry);
-        let raft_entry = Entry {
-            term: 1,
-            index: 1,
-            data: SerdeUtils::serialize(&batch)?,
-            ..Default::default()
-        };
-        target.raft_journal.log_store().append(&[raft_entry])?;
-        target.raft_journal.log_store().set_hard_state_commit(1)?;
-
-        AsyncRuntime::single().block_on(async { loader.role_change(StateRole::Leader).await })?;
-
-        assert!(target_fs.file_status("/committed-before-promotion").is_ok());
-        Ok(())
-    }
-
-    #[test]
-    fn replay_rejects_duplicate_allocated_inode_id() -> FsResult<()> {
-        Master::init_test_metrics();
-
-        let mut source_conf = ClusterConf {
-            testing: true,
-            ..Default::default()
-        };
-        source_conf.change_test_meta_dir(format!("duplicate-id-source-{}", Utils::rand_str(6)));
-        let source_fs = JournalSystem::fs_only_for_test(&source_conf)?;
-        source_fs.mkdir("/first", false)?;
-        source_fs.mkdir("/second", false)?;
-        let mut entries = source_fs.fs_dir.read().take_entries();
-        let first = entries.remove(0);
-        let mut second = entries.remove(0);
-        let duplicated_id = match &first {
-            JournalEntry::Mkdir(entry) => entry.dir.id,
-            _ => unreachable!("mkdir must emit a Mkdir journal entry"),
-        };
-        match &mut second {
-            JournalEntry::Mkdir(entry) => entry.dir.id = duplicated_id,
-            _ => unreachable!("mkdir must emit a Mkdir journal entry"),
-        }
-
-        let mut target_conf = ClusterConf {
-            testing: true,
-            ..Default::default()
-        };
-        target_conf.change_test_meta_dir(format!("duplicate-id-target-{}", Utils::rand_str(6)));
-        let target = JournalSystem::from_conf(&target_conf)?;
-        let loader = target.journal_loader();
-
-        let mut first_batch = JournalBatch::new(1);
-        first_batch.push(first);
-        let first_entry = Entry {
-            term: 1,
-            index: 1,
-            data: SerdeUtils::serialize(&first_batch)?,
-            ..Default::default()
-        };
-        let mut second_batch = JournalBatch::new(2);
-        second_batch.push(second);
-        let second_entry = Entry {
-            term: 1,
-            index: 2,
-            data: SerdeUtils::serialize(&second_batch)?,
-            ..Default::default()
-        };
-
-        let result = AsyncRuntime::single().block_on(async {
-            loader.apply(true, ApplyMsg::new_entry(first_entry)).await?;
-            loader.apply(true, ApplyMsg::new_entry(second_entry)).await
-        });
-        assert!(result.is_err());
         Ok(())
     }
 }

--- a/curvine-master/src/master/journal/journal_system.rs
+++ b/curvine-master/src/master/journal/journal_system.rs
@@ -488,4 +488,106 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn promotion_applies_committed_metadata_before_returning() -> FsResult<()> {
+        Master::init_test_metrics();
+
+        let mut source_conf = ClusterConf {
+            testing: true,
+            ..Default::default()
+        };
+        source_conf.change_test_meta_dir(format!("promotion-source-{}", Utils::rand_str(6)));
+        let source_fs = JournalSystem::fs_only_for_test(&source_conf)?;
+        source_fs.mkdir("/committed-before-promotion", false)?;
+        let entry = source_fs
+            .fs_dir
+            .read()
+            .take_entries()
+            .into_iter()
+            .next()
+            .expect("mkdir must emit a journal entry");
+
+        let mut target_conf = ClusterConf {
+            testing: true,
+            ..Default::default()
+        };
+        target_conf.change_test_meta_dir(format!("promotion-target-{}", Utils::rand_str(6)));
+        let target = JournalSystem::from_conf(&target_conf)?;
+        let target_fs = target.fs();
+        let loader = target.journal_loader();
+
+        let mut batch = JournalBatch::new(1);
+        batch.push(entry);
+        let raft_entry = Entry {
+            term: 1,
+            index: 1,
+            data: SerdeUtils::serialize(&batch)?,
+            ..Default::default()
+        };
+        target.raft_journal.log_store().append(&[raft_entry])?;
+        target.raft_journal.log_store().set_hard_state_commit(1)?;
+
+        AsyncRuntime::single().block_on(async { loader.role_change(StateRole::Leader).await })?;
+
+        assert!(target_fs.file_status("/committed-before-promotion").is_ok());
+        Ok(())
+    }
+
+    #[test]
+    fn replay_rejects_duplicate_allocated_inode_id() -> FsResult<()> {
+        Master::init_test_metrics();
+
+        let mut source_conf = ClusterConf {
+            testing: true,
+            ..Default::default()
+        };
+        source_conf.change_test_meta_dir(format!("duplicate-id-source-{}", Utils::rand_str(6)));
+        let source_fs = JournalSystem::fs_only_for_test(&source_conf)?;
+        source_fs.mkdir("/first", false)?;
+        source_fs.mkdir("/second", false)?;
+        let mut entries = source_fs.fs_dir.read().take_entries();
+        let first = entries.remove(0);
+        let mut second = entries.remove(0);
+        let duplicated_id = match &first {
+            JournalEntry::Mkdir(entry) => entry.dir.id,
+            _ => unreachable!("mkdir must emit a Mkdir journal entry"),
+        };
+        match &mut second {
+            JournalEntry::Mkdir(entry) => entry.dir.id = duplicated_id,
+            _ => unreachable!("mkdir must emit a Mkdir journal entry"),
+        }
+
+        let mut target_conf = ClusterConf {
+            testing: true,
+            ..Default::default()
+        };
+        target_conf.change_test_meta_dir(format!("duplicate-id-target-{}", Utils::rand_str(6)));
+        let target = JournalSystem::from_conf(&target_conf)?;
+        let loader = target.journal_loader();
+
+        let mut first_batch = JournalBatch::new(1);
+        first_batch.push(first);
+        let first_entry = Entry {
+            term: 1,
+            index: 1,
+            data: SerdeUtils::serialize(&first_batch)?,
+            ..Default::default()
+        };
+        let mut second_batch = JournalBatch::new(2);
+        second_batch.push(second);
+        let second_entry = Entry {
+            term: 1,
+            index: 2,
+            data: SerdeUtils::serialize(&second_batch)?,
+            ..Default::default()
+        };
+
+        let result = AsyncRuntime::single().block_on(async {
+            loader.apply(true, ApplyMsg::new_entry(first_entry)).await?;
+            loader.apply(true, ApplyMsg::new_entry(second_entry)).await
+        });
+        assert!(result.is_err());
+        Ok(())
+    }
 }

--- a/curvine-server/tests/journal_test.rs
+++ b/curvine-server/tests/journal_test.rs
@@ -33,6 +33,7 @@ use curvine_server::master::journal::{
 use curvine_server::master::{Master, MountManager};
 use log::info;
 use raft::eraftpb::Entry;
+use raft::StateRole;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::thread;
@@ -96,6 +97,106 @@ fn new_test_ufs_uri(name: &str) -> CommonResult<CurvineURI> {
     ));
     std::fs::create_dir_all(&dir)?;
     CurvineURI::new(format!("file://{}/", dir.display()))
+}
+
+#[test]
+fn leader_promotion_applies_committed_metadata_before_returning() -> CommonResult<()> {
+    Master::init_test_metrics();
+
+    let mut source_conf = ClusterConf {
+        testing: true,
+        ..Default::default()
+    };
+    source_conf.change_test_meta_dir(format!("promotion-source-{}", Utils::rand_str(6)));
+    let source_fs = JournalSystem::fs_only_for_test(&source_conf)?;
+    source_fs.mkdir("/committed-before-promotion", false)?;
+    let entry = source_fs
+        .fs_dir
+        .read()
+        .take_entries()
+        .into_iter()
+        .next()
+        .expect("mkdir must emit a journal entry");
+
+    let mut target_conf = ClusterConf {
+        testing: true,
+        ..Default::default()
+    };
+    target_conf.change_test_meta_dir(format!("promotion-target-{}", Utils::rand_str(6)));
+    let target = JournalSystem::from_conf(&target_conf)?;
+    let target_fs = target.fs();
+    let loader = target.journal_loader();
+
+    let mut batch = JournalBatch::new(1);
+    batch.push(entry);
+    target.append_committed_entry_for_test(Entry {
+        term: 1,
+        index: 1,
+        data: SerdeUtils::serialize(&batch)?,
+        ..Default::default()
+    })?;
+
+    AsyncRuntime::single().block_on(async { loader.role_change(StateRole::Leader).await })?;
+
+    assert!(target_fs.file_status("/committed-before-promotion").is_ok());
+    Ok(())
+}
+
+#[test]
+fn replay_rejects_duplicate_allocated_inode_id() -> CommonResult<()> {
+    Master::init_test_metrics();
+
+    let mut source_conf = ClusterConf {
+        testing: true,
+        ..Default::default()
+    };
+    source_conf.change_test_meta_dir(format!("duplicate-id-source-{}", Utils::rand_str(6)));
+    let source_fs = JournalSystem::fs_only_for_test(&source_conf)?;
+    source_fs.mkdir("/first", false)?;
+    source_fs.mkdir("/second", false)?;
+    let mut entries = source_fs.fs_dir.read().take_entries();
+    let first = entries.remove(0);
+    let mut second = entries.remove(0);
+    let duplicated_id = match &first {
+        JournalEntry::Mkdir(entry) => entry.dir.id,
+        _ => unreachable!("mkdir must emit a Mkdir journal entry"),
+    };
+    match &mut second {
+        JournalEntry::Mkdir(entry) => entry.dir.id = duplicated_id,
+        _ => unreachable!("mkdir must emit a Mkdir journal entry"),
+    }
+
+    let mut target_conf = ClusterConf {
+        testing: true,
+        ..Default::default()
+    };
+    target_conf.change_test_meta_dir(format!("duplicate-id-target-{}", Utils::rand_str(6)));
+    let target = JournalSystem::from_conf(&target_conf)?;
+    let loader = target.journal_loader();
+
+    let mut first_batch = JournalBatch::new(1);
+    first_batch.push(first);
+    let first_entry = Entry {
+        term: 1,
+        index: 1,
+        data: SerdeUtils::serialize(&first_batch)?,
+        ..Default::default()
+    };
+    let mut second_batch = JournalBatch::new(2);
+    second_batch.push(second);
+    let second_entry = Entry {
+        term: 1,
+        index: 2,
+        data: SerdeUtils::serialize(&second_batch)?,
+        ..Default::default()
+    };
+
+    let result = AsyncRuntime::single().block_on(async {
+        loader.apply(true, ApplyMsg::new_entry(first_entry)).await?;
+        loader.apply(true, ApplyMsg::new_entry(second_entry)).await
+    });
+    assert!(result.is_err());
+    Ok(())
 }
 
 // First start a master and perform the operation; then start 1 stand by, manually replay the log to check consistency.

--- a/curvine-server/tests/journal_test.rs
+++ b/curvine-server/tests/journal_test.rs
@@ -142,63 +142,6 @@ fn leader_promotion_applies_committed_metadata_before_returning() -> CommonResul
     Ok(())
 }
 
-#[test]
-fn replay_rejects_duplicate_allocated_inode_id() -> CommonResult<()> {
-    Master::init_test_metrics();
-
-    let mut source_conf = ClusterConf {
-        testing: true,
-        ..Default::default()
-    };
-    source_conf.change_test_meta_dir(format!("duplicate-id-source-{}", Utils::rand_str(6)));
-    let source_fs = JournalSystem::fs_only_for_test(&source_conf)?;
-    source_fs.mkdir("/first", false)?;
-    source_fs.mkdir("/second", false)?;
-    let mut entries = source_fs.fs_dir.read().take_entries();
-    let first = entries.remove(0);
-    let mut second = entries.remove(0);
-    let duplicated_id = match &first {
-        JournalEntry::Mkdir(entry) => entry.dir.id,
-        _ => unreachable!("mkdir must emit a Mkdir journal entry"),
-    };
-    match &mut second {
-        JournalEntry::Mkdir(entry) => entry.dir.id = duplicated_id,
-        _ => unreachable!("mkdir must emit a Mkdir journal entry"),
-    }
-
-    let mut target_conf = ClusterConf {
-        testing: true,
-        ..Default::default()
-    };
-    target_conf.change_test_meta_dir(format!("duplicate-id-target-{}", Utils::rand_str(6)));
-    let target = JournalSystem::from_conf(&target_conf)?;
-    let loader = target.journal_loader();
-
-    let mut first_batch = JournalBatch::new(1);
-    first_batch.push(first);
-    let first_entry = Entry {
-        term: 1,
-        index: 1,
-        data: SerdeUtils::serialize(&first_batch)?,
-        ..Default::default()
-    };
-    let mut second_batch = JournalBatch::new(2);
-    second_batch.push(second);
-    let second_entry = Entry {
-        term: 1,
-        index: 2,
-        data: SerdeUtils::serialize(&second_batch)?,
-        ..Default::default()
-    };
-
-    let result = AsyncRuntime::single().block_on(async {
-        loader.apply(true, ApplyMsg::new_entry(first_entry)).await?;
-        loader.apply(true, ApplyMsg::new_entry(second_entry)).await
-    });
-    assert!(result.is_err());
-    Ok(())
-}
-
 // First start a master and perform the operation; then start 1 stand by, manually replay the log to check consistency.
 #[test]
 fn test_journal_replay_consistency_between_leader_and_follower() -> CommonResult<()> {

--- a/curvine-server/tests/journal_test.rs
+++ b/curvine-server/tests/journal_test.rs
@@ -142,6 +142,57 @@ fn leader_promotion_applies_committed_metadata_before_returning() -> CommonResul
     Ok(())
 }
 
+#[test]
+fn follower_replay_rejects_duplicate_allocated_inode_id() -> CommonResult<()> {
+    Master::init_test_metrics();
+
+    let mut source_conf = ClusterConf {
+        testing: true,
+        ..Default::default()
+    };
+    source_conf.change_test_meta_dir(format!("duplicate-id-source-{}", Utils::rand_str(6)));
+    let source_fs = JournalSystem::fs_only_for_test(&source_conf)?;
+    source_fs.mkdir("/source", false)?;
+    let source_entry = source_fs
+        .fs_dir
+        .read()
+        .take_entries()
+        .into_iter()
+        .next()
+        .expect("mkdir must emit a journal entry");
+    let inode_id = source_entry
+        .allocated_inode_id()
+        .expect("mkdir must allocate an inode id");
+
+    let mut target_conf = ClusterConf {
+        testing: true,
+        ..Default::default()
+    };
+    target_conf.change_test_meta_dir(format!("duplicate-id-target-{}", Utils::rand_str(6)));
+    let target = JournalSystem::from_conf(&target_conf)?;
+    let target_fs = target.fs();
+    target_fs.mkdir("/occupied", false)?;
+    assert_eq!(target_fs.last_inode_id(), inode_id);
+
+    let mut batch = JournalBatch::new(1);
+    batch.push(source_entry);
+    let entry = Entry {
+        term: 1,
+        index: 1,
+        data: SerdeUtils::serialize(&batch)?,
+        ..Default::default()
+    };
+    target.append_committed_entry_for_test(entry.clone())?;
+
+    let err = AsyncRuntime::single()
+        .block_on(async { target.journal_loader().role_change(StateRole::Leader).await })
+        .expect_err("follower replay must reject a reused inode id");
+    assert!(err
+        .to_string()
+        .contains("refusing duplicate inode allocation during follower replay"));
+    Ok(())
+}
+
 // First start a master and perform the operation; then start 1 stand by, manually replay the log to check consistency.
 #[test]
 fn test_journal_replay_consistency_between_leader_and_follower() -> CommonResult<()> {


### PR DESCRIPTION
## Summary
Make Raft durability, metadata application, and Leader publication occur in one strict order.

## Issue/Design
This independent protocol fix is extracted from #1552 and addresses #1551. A voter could become externally active before all committed journal entries had advanced the local metadata ID high-water marks. The next mutation could then reuse an inode ID.

## Changes
| Area | Change |
| --- | --- |
| Raft Ready | Persist entries before the HardState that commits them, and send messages only after persistence. |
| Proposal response | Wait for apply-worker acknowledgement before returning a Leader proposal response. |
| Leader promotion | Make `role_change(Leader)` wait until committed metadata is replayed; only then enable Leader UFS replay. |
| Invariant | Reject replay that allocates an inode ID at or below the local high-water mark. |
| Tests | Cover promotion with an unapplied committed entry and duplicate allocated inode detection. |

## Test verified
- `cargo fmt --check -- crates/metadata/curvine-raft/src/raft/raft_node.rs crates/metadata/curvine-raft/src/raft/storage/apply_msg.rs curvine-master/src/master/journal/entry.rs curvine-master/src/master/journal/journal_loader.rs curvine-master/src/master/journal/journal_system.rs crates/metadata/curvine-raft/tests/raft_node_test.rs`
- `CARGO_TARGET_DIR=/mnt/data/curvine/.build/pr-1552-split/ordered-apply cargo test -q -p curvine-raft --test raft_node_test -p curvine-server --test journal_test`
- `CARGO_TARGET_DIR=/mnt/data/curvine/.build/pr-1552-split/ordered-apply cargo clippy -q -p curvine-raft -p curvine-server --tests -- -D warnings`
- `git diff --check`

## Dependencies
None. This PR is independently mergeable.