### PR TITLE
feat(master): version committed journal commands

### DIFF
--- a/curvine-master/src/master/journal/entry.rs
+++ b/curvine-master/src/master/journal/entry.rs
@@ -28,7 +28,7 @@ pub(crate) struct CvMetadataChange {
     pub(crate) include_subtree: bool,
 }
 
-pub const JOURNAL_ENVELOPE_MAGIC: &[u8; 8] = b"CVJNL001";
+pub const JOURNAL_ENVELOPE_MAGIC: &[u8; 8] = b"CVJNLHDR";
 pub const JOURNAL_ENVELOPE_VERSION: u16 = 1;
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -548,14 +548,41 @@ impl DecodedJournalBatch {
         self.len() == 0
     }
 
-    pub fn into_commands(self) -> Vec<JournalCommand> {
+    pub fn contains_metadata_commands(&self) -> bool {
+        matches!(
+            self,
+            DecodedJournalBatch::Versioned(batch)
+                if batch
+                    .commands
+                    .iter()
+                    .any(|command| matches!(command, JournalCommand::Metadata(_)))
+        )
+    }
+
+    pub fn into_commands(self) -> JournalCommandIter {
         match self {
-            DecodedJournalBatch::Legacy(batch) => batch
-                .batch
-                .into_iter()
-                .map(JournalCommand::Legacy)
-                .collect(),
-            DecodedJournalBatch::Versioned(batch) => batch.commands,
+            DecodedJournalBatch::Legacy(batch) => {
+                JournalCommandIter::Legacy(batch.batch.into_iter())
+            }
+            DecodedJournalBatch::Versioned(batch) => {
+                JournalCommandIter::Versioned(batch.commands.into_iter())
+            }
+        }
+    }
+}
+
+pub enum JournalCommandIter {
+    Legacy(std::vec::IntoIter<JournalEntry>),
+    Versioned(std::vec::IntoIter<JournalCommand>),
+}
+
+impl Iterator for JournalCommandIter {
+    type Item = JournalCommand;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            JournalCommandIter::Legacy(entries) => entries.next().map(JournalCommand::Legacy),
+            JournalCommandIter::Versioned(commands) => commands.next(),
         }
     }
 }

--- a/curvine-master/src/master/journal/entry.rs
+++ b/curvine-master/src/master/journal/entry.rs
@@ -544,6 +544,10 @@ impl DecodedJournalBatch {
         }
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     pub fn into_commands(self) -> Vec<JournalCommand> {
         match self {
             DecodedJournalBatch::Legacy(batch) => batch
@@ -580,6 +584,10 @@ impl JournalCommandBatch {
 
     pub fn len(&self) -> usize {
         self.commands.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.commands.is_empty()
     }
 }
 

--- a/curvine-master/src/master/journal/entry.rs
+++ b/curvine-master/src/master/journal/entry.rs
@@ -28,6 +28,9 @@ pub(crate) struct CvMetadataChange {
     pub(crate) include_subtree: bool,
 }
 
+pub const JOURNAL_ENVELOPE_MAGIC: &[u8; 8] = b"CVJNL001";
+pub const JOURNAL_ENVELOPE_VERSION: u16 = 1;
+
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct MkdirEntry {
     pub(crate) op_id: u64,
@@ -489,5 +492,162 @@ impl From<LegacyJournalEntry> for JournalEntry {
             LegacyJournalEntry::UfsApplied(entry) => Self::UfsApplied(entry),
             LegacyJournalEntry::Snapshot(entry) => Self::Snapshot(entry),
         }
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct JournalEnvelope {
+    pub version: u16,
+    pub batch: JournalCommandBatch,
+}
+
+impl JournalEnvelope {
+    pub fn encode(batch: JournalCommandBatch) -> CommonResult<Vec<u8>> {
+        let mut bytes = JOURNAL_ENVELOPE_MAGIC.to_vec();
+        bytes.extend(SerdeUtils::serialize(&Self {
+            version: JOURNAL_ENVELOPE_VERSION,
+            batch,
+        })?);
+        Ok(bytes)
+    }
+
+    pub fn decode(bytes: &[u8]) -> CommonResult<DecodedJournalBatch> {
+        if !bytes.starts_with(JOURNAL_ENVELOPE_MAGIC) {
+            return Ok(DecodedJournalBatch::Legacy(
+                JournalBatch::deserialize_compat(bytes)?,
+            ));
+        }
+
+        let envelope: JournalEnvelope =
+            SerdeUtils::deserialize(&bytes[JOURNAL_ENVELOPE_MAGIC.len()..])?;
+        if envelope.version != JOURNAL_ENVELOPE_VERSION {
+            return err_box!(
+                "unsupported journal envelope version {}, expected {}",
+                envelope.version,
+                JOURNAL_ENVELOPE_VERSION
+            );
+        }
+        Ok(DecodedJournalBatch::Versioned(envelope.batch))
+    }
+}
+
+pub enum DecodedJournalBatch {
+    Legacy(JournalBatch),
+    Versioned(JournalCommandBatch),
+}
+
+impl DecodedJournalBatch {
+    pub fn len(&self) -> usize {
+        match self {
+            DecodedJournalBatch::Legacy(batch) => batch.len(),
+            DecodedJournalBatch::Versioned(batch) => batch.len(),
+        }
+    }
+
+    pub fn into_commands(self) -> Vec<JournalCommand> {
+        match self {
+            DecodedJournalBatch::Legacy(batch) => batch
+                .batch
+                .into_iter()
+                .map(JournalCommand::Legacy)
+                .collect(),
+            DecodedJournalBatch::Versioned(batch) => batch.commands,
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct JournalCommandBatch {
+    pub seq_id: u64,
+    pub commands: Vec<JournalCommand>,
+}
+
+impl JournalCommandBatch {
+    pub fn new(seq_id: u64) -> Self {
+        Self {
+            seq_id,
+            commands: vec![],
+        }
+    }
+
+    pub fn push_legacy(&mut self, entry: JournalEntry) {
+        self.commands.push(JournalCommand::Legacy(entry))
+    }
+
+    pub fn push_metadata(&mut self, command: MetadataCommand) {
+        self.commands.push(JournalCommand::Metadata(command))
+    }
+
+    pub fn len(&self) -> usize {
+        self.commands.len()
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub enum JournalCommand {
+    Legacy(JournalEntry),
+    Metadata(MetadataCommand),
+}
+
+impl JournalCommand {
+    pub fn op_id(&self) -> u64 {
+        match self {
+            JournalCommand::Legacy(entry) => entry.op_id(),
+            JournalCommand::Metadata(command) => command.op_id(),
+        }
+    }
+
+    pub fn rpc_id(&self) -> i64 {
+        match self {
+            JournalCommand::Legacy(entry) => entry.rpc_id(),
+            JournalCommand::Metadata(command) => command.rpc_id(),
+        }
+    }
+
+    pub fn inode_id(&self) -> Option<i64> {
+        match self {
+            JournalCommand::Legacy(entry) => entry.inode_id(),
+            JournalCommand::Metadata(command) => command.inode_id(),
+        }
+    }
+
+    pub fn allocated_inode_id(&self) -> Option<i64> {
+        match self {
+            JournalCommand::Legacy(entry) => entry.allocated_inode_id(),
+            JournalCommand::Metadata(command) => command.allocated_inode_id(),
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub enum MetadataCommand {
+    Mkdir(MkdirEntry),
+    CreateFile(CreateFileEntry),
+}
+
+impl MetadataCommand {
+    pub fn op_id(&self) -> u64 {
+        match self {
+            MetadataCommand::Mkdir(entry) => entry.op_id,
+            MetadataCommand::CreateFile(entry) => entry.op_id,
+        }
+    }
+
+    pub fn rpc_id(&self) -> i64 {
+        match self {
+            MetadataCommand::Mkdir(entry) => entry.rpc_id,
+            MetadataCommand::CreateFile(entry) => entry.rpc_id,
+        }
+    }
+
+    pub fn inode_id(&self) -> Option<i64> {
+        match self {
+            MetadataCommand::Mkdir(entry) => Some(entry.dir.id),
+            MetadataCommand::CreateFile(entry) => Some(entry.file.id),
+        }
+    }
+
+    pub fn allocated_inode_id(&self) -> Option<i64> {
+        self.inode_id()
     }
 }

--- a/curvine-master/src/master/journal/journal_loader.rs
+++ b/curvine-master/src/master/journal/journal_loader.rs
@@ -231,18 +231,17 @@ impl JournalLoader {
         }
 
         let batch = JournalEnvelope::decode(&entry.data)?;
+        if batch.contains_metadata_commands() {
+            return err_box!("unsupported committed metadata command batch");
+        }
         let batch_len = batch.len();
         let mut snapshot = None;
         let mut applied = Self::build_applied(entry);
         let mut has_ufs_affecting = false;
 
-        for (seq, command) in batch.into_commands().into_iter().enumerate() {
+        for (seq, command) in batch.into_commands().enumerate() {
             applied.op_id = command.op_id();
             applied.rpc_id = command.rpc_id();
-
-            if matches!(&command, JournalCommand::Metadata(_)) {
-                return err_box!("unsupported committed metadata command: {:?}", command);
-            }
 
             match &command {
                 JournalCommand::Legacy(JournalEntry::Snapshot(e))

--- a/curvine-master/src/master/journal/journal_loader.rs
+++ b/curvine-master/src/master/journal/journal_loader.rs
@@ -230,67 +230,81 @@ impl JournalLoader {
             return Ok(());
         }
 
-        let batch = JournalBatch::deserialize_compat(&entry.data)?;
+        let batch = JournalEnvelope::decode(&entry.data)?;
         let batch_len = batch.len();
         let mut snapshot = None;
         let mut applied = Self::build_applied(entry);
         let mut has_ufs_affecting = false;
 
-        for (seq, op_entry) in batch.batch.into_iter().enumerate() {
-            applied.op_id = op_entry.op_id();
-            applied.rpc_id = op_entry.rpc_id();
+        for (seq, command) in batch.into_commands().into_iter().enumerate() {
+            applied.op_id = command.op_id();
+            applied.rpc_id = command.rpc_id();
 
-            match op_entry {
-                JournalEntry::Snapshot(e) if is_leader && e.node_id == self.node_id => {
+            if matches!(&command, JournalCommand::Metadata(_)) {
+                return err_box!("unsupported committed metadata command: {:?}", command);
+            }
+
+            match &command {
+                JournalCommand::Legacy(JournalEntry::Snapshot(e))
+                    if is_leader && e.node_id == self.node_id =>
+                {
                     if seq + 1 != batch_len {
                         return err_box!("snapshot should be the last entry");
                     }
-                    snapshot.replace(e);
+                    snapshot.replace(e.clone());
                     continue;
                 }
 
-                JournalEntry::CacheInvalidation(_) | JournalEntry::UfsApplied(_) => (),
+                JournalCommand::Legacy(JournalEntry::CacheInvalidation(_))
+                | JournalCommand::Legacy(JournalEntry::UfsApplied(_)) => (),
 
                 _ => has_ufs_affecting = true,
             }
 
-            {
+            if !is_leader {
                 let fs_dir = self.fs_dir.read();
-                if !is_leader {
-                    if let Some(inode_id) = op_entry.allocated_inode_id() {
-                        let last_inode_id = fs_dir.last_inode_id();
-                        if inode_id <= last_inode_id {
-                            return err_box!(
-                                "refusing duplicate inode allocation during follower replay: inode_id={}, last_inode_id={}, journal={:?}",
-                                inode_id,
-                                last_inode_id,
-                                op_entry
-                            );
-                        }
+                if let Some(inode_id) = command.allocated_inode_id() {
+                    let last_inode_id = fs_dir.last_inode_id();
+                    if inode_id <= last_inode_id {
+                        return err_box!(
+                            "refusing duplicate inode allocation during follower replay: inode_id={}, last_inode_id={}, raft_index={}, journal={:?}",
+                            inode_id,
+                            last_inode_id,
+                            entry.index,
+                            command
+                        );
                     }
                 }
-                fs_dir.update_op_id(op_entry.op_id());
-                if let Some(inode_id) = op_entry.inode_id() {
+                fs_dir.update_op_id(command.op_id());
+                if let Some(inode_id) = command.inode_id() {
                     fs_dir.update_last_inode_id(inode_id)?;
                 }
             }
 
-            let res = if is_leader {
-                self.ufs_loader.apply_entry(&op_entry).await
-            } else {
-                self.apply_entry(op_entry.clone())
-            };
+            match command {
+                JournalCommand::Legacy(op_entry) => {
+                    let res = if is_leader {
+                        self.ufs_loader.apply_entry(&op_entry).await
+                    } else {
+                        self.apply_entry(op_entry.clone())
+                    };
 
-            if let Err(e) = res {
-                if is_leader && skip_ufs_error {
-                    error!(
-                        "skip failed UFS replay after retries, entry index={}, term={}, journal={:?}, error={}",
-                        entry.index, entry.term, op_entry, e
-                    );
-                    continue;
+                    if let Err(e) = res {
+                        if is_leader && skip_ufs_error {
+                            error!(
+                                "skip failed UFS replay after retries, entry index={}, term={}, journal={:?}, error={}",
+                                entry.index, entry.term, op_entry, e
+                            );
+                            continue;
+                        }
+
+                        return err_box!("failed to apply journal: {:?}: {}", op_entry, e);
+                    }
                 }
 
-                return err_box!("failed to apply journal: {:?}: {}", op_entry, e);
+                JournalCommand::Metadata(command) => {
+                    return err_box!("unsupported committed metadata command: {:?}", command);
+                }
             }
         }
 
@@ -387,6 +401,7 @@ impl JournalLoader {
         }
         Ok(())
     }
+
     async fn next_apply_msg(
         &self,
         receiver: &mut AsyncReceiver<ApplyMsg>,
@@ -430,8 +445,8 @@ impl JournalLoader {
                 ApplyMsg::RoleChange((role, tx)) => {
                     let result = async {
                         if role == StateRole::Leader {
-                            // Publish leadership only after committed namespace mutations
-                            // have advanced local metadata high-water marks.
+                            // Do not publish leadership until every committed namespace
+                            // mutation has advanced the metadata ID high-water marks.
                             self.catch_up_committed_metadata().await?;
                             is_leader = true;
                             let ufs_applied = self.get_ufs_applied()?;

--- a/curvine-master/src/master/journal/mod.rs
+++ b/curvine-master/src/master/journal/mod.rs
@@ -33,3 +33,7 @@ pub use self::ufs_loader::UfsLoader;
 #[cfg(test)]
 #[path = "tests/journal_entry_compat_test.rs"]
 mod journal_entry_compat_test;
+
+#[cfg(test)]
+#[path = "tests/journal_loader_test.rs"]
+mod journal_loader_test;

--- a/curvine-master/src/master/journal/tests/journal_loader_test.rs
+++ b/curvine-master/src/master/journal/tests/journal_loader_test.rs
@@ -1,0 +1,65 @@
+use super::*;
+use crate::master::Master;
+use curvine_config::ClusterConf;
+use curvine_core_error::CommonResult;
+use curvine_raft::raft::storage::{AppStorage, ApplyMsg};
+use curvine_runtime::common::Utils;
+use curvine_runtime::runtime::{AsyncRuntime, RpcRuntime};
+use raft::eraftpb::Entry;
+
+#[test]
+fn metadata_batch_is_rejected_before_legacy_commands_are_applied() -> CommonResult<()> {
+    Master::init_test_metrics();
+
+    let mut source_conf = ClusterConf {
+        testing: true,
+        ..Default::default()
+    };
+    source_conf.change_test_meta_dir(format!("metadata-batch-source-{}", Utils::rand_str(6)));
+    let source_fs = JournalSystem::fs_only_for_test(&source_conf)?;
+    source_fs.mkdir("/legacy", false)?;
+    let legacy = source_fs
+        .fs_dir
+        .read()
+        .take_entries()
+        .into_iter()
+        .next()
+        .expect("mkdir must emit a journal entry");
+    let metadata = match legacy.clone() {
+        JournalEntry::Mkdir(entry) => MetadataCommand::Mkdir(entry),
+        _ => unreachable!("mkdir must emit a mkdir journal entry"),
+    };
+
+    let mut target_conf = ClusterConf {
+        testing: true,
+        ..Default::default()
+    };
+    target_conf.change_test_meta_dir(format!("metadata-batch-target-{}", Utils::rand_str(6)));
+    let target = JournalSystem::from_conf(&target_conf)?;
+    let target_fs = target.fs();
+
+    let mut batch = JournalCommandBatch::new(1);
+    batch.push_legacy(legacy);
+    batch.push_metadata(metadata);
+    let entry = Entry {
+        term: 1,
+        index: 1,
+        data: JournalEnvelope::encode(batch)?,
+        ..Default::default()
+    };
+
+    let err = AsyncRuntime::single()
+        .block_on(async {
+            target
+                .journal_loader()
+                .apply(true, ApplyMsg::new_entry(entry))
+                .await
+        })
+        .expect_err("metadata commands are not supported by this journal version");
+    assert!(err
+        .to_string()
+        .contains("unsupported committed metadata command batch"));
+    assert!(target_fs.file_status("/legacy").is_err());
+
+    Ok(())
+}

--- a/curvine-server/tests/journal_test.rs
+++ b/curvine-server/tests/journal_test.rs
@@ -28,7 +28,8 @@ use curvine_runtime::common::{FileUtils, Logger, TimeSpent, Utils};
 use curvine_runtime::runtime::{AsyncRuntime, RpcRuntime};
 use curvine_server::master::fs::MasterFilesystem;
 use curvine_server::master::journal::{
-    JournalBatch, JournalEntry, JournalLoader, JournalSystem, UfsLoader,
+    JournalBatch, JournalCommandBatch, JournalEntry, JournalEnvelope, JournalLoader, JournalSystem,
+    UfsLoader,
 };
 use curvine_server::master::{Master, MountManager};
 use log::info;
@@ -190,6 +191,50 @@ fn follower_replay_rejects_duplicate_allocated_inode_id() -> CommonResult<()> {
     assert!(err
         .to_string()
         .contains("refusing duplicate inode allocation during follower replay"));
+    Ok(())
+}
+
+#[test]
+fn replay_accepts_versioned_legacy_journal_batch() -> CommonResult<()> {
+    Master::init_test_metrics();
+
+    let mut source_conf = ClusterConf {
+        testing: true,
+        ..Default::default()
+    };
+    source_conf.change_test_meta_dir(format!("versioned-source-{}", Utils::rand_str(6)));
+    let source_fs = JournalSystem::fs_only_for_test(&source_conf)?;
+    source_fs.mkdir("/versioned-legacy", false)?;
+    let entry = source_fs
+        .fs_dir
+        .read()
+        .take_entries()
+        .into_iter()
+        .next()
+        .expect("mkdir must emit a journal entry");
+
+    let mut target_conf = ClusterConf {
+        testing: true,
+        ..Default::default()
+    };
+    target_conf.change_test_meta_dir(format!("versioned-target-{}", Utils::rand_str(6)));
+    let target = JournalSystem::from_conf(&target_conf)?;
+    let target_fs = target.fs();
+    let loader = target.journal_loader();
+
+    let mut batch = JournalCommandBatch::new(1);
+    batch.push_legacy(entry);
+    let raft_entry = Entry {
+        term: 1,
+        index: 1,
+        data: JournalEnvelope::encode(batch)?,
+        ..Default::default()
+    };
+
+    AsyncRuntime::single()
+        .block_on(async { loader.apply(true, ApplyMsg::new_entry(raft_entry)).await })?;
+
+    assert!(target_fs.file_status("/versioned-legacy").is_ok());
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
Add a versioned journal envelope while retaining read compatibility with existing legacy journal batches.

## Issue/Design
This is the protocol-layer extraction from #1552. Commit-before-apply metadata commands require an explicit journal wire format. The envelope has a stable magic prefix and version number; legacy serialized batches remain decodable.

## Changes
| Area | Change |
| --- | --- |
| Wire format | Add `JournalEnvelope`, `JournalCommandBatch`, and versioned command variants. |
| Compatibility | Decode legacy batches when the magic prefix is absent. |
| Safety | Reject unknown envelope versions and unsupported metadata commands until their execution PRs are merged. |
| Test | Replay a versioned envelope carrying an unchanged legacy command. |

## Test verified
- `cargo fmt --check -- curvine-master/src/master/journal/entry.rs curvine-master/src/master/journal/journal_loader.rs curvine-master/src/master/journal/journal_system.rs`
- `CARGO_TARGET_DIR=/mnt/data/curvine/.build/pr-1552-split/journal-versioning cargo test -q -p curvine-server --test journal_test`
- `CARGO_TARGET_DIR=/mnt/data/curvine/.build/pr-1552-split/journal-versioning cargo clippy -q -p curvine-server --test journal_test -- -D warnings`
- `git diff --check`

## Dependencies
Stacked on #1557 for the Leader promotion fence. Merge after #1557.