### PR TITLE
fix(master): commit namespace creation before metadata apply

### DIFF
--- a/curvine-master/src/master/fs/master_filesystem.rs
+++ b/curvine-master/src/master/fs/master_filesystem.rs
@@ -432,7 +432,7 @@ impl MasterFilesystem {
         let last_inode = inp.get_last_inode();
         if let Some(inode) = &last_inode {
             if inode.is_dir() {
-                return err_box!("{}  already exists as a dir", inp.path());
+                return err_box!("{} already exists as a dir", inp.path());
             }
 
             if flags.exclusive() {
@@ -473,7 +473,7 @@ impl MasterFilesystem {
             let last_inode = inp.get_last_inode();
             if let Some(inode) = &last_inode {
                 if inode.is_dir() {
-                    return err_box!("{}  already exists as a dir", inp.path());
+                    return err_box!("{} already exists as a dir", inp.path());
                 }
 
                 if flags.exclusive() {

--- a/curvine-master/src/master/fs/master_filesystem.rs
+++ b/curvine-master/src/master/fs/master_filesystem.rs
@@ -222,8 +222,13 @@ impl MasterFilesystem {
     }
 
     pub fn mkdir_with_opts<T: AsRef<str>>(&self, path: T, opts: MkdirOpts) -> FsResult<FileStatus> {
+        let path = path.as_ref();
+        if self.master_monitor.is_active() {
+            return self.mkdir_with_opts_committed(path, opts);
+        }
+
         let mut fs_dir = self.fs_dir.write();
-        let inp = Self::resolve_path(&fs_dir, path.as_ref())?;
+        let inp = Self::resolve_path(&fs_dir, path)?;
 
         // Creation of root directory is not allowed
         if inp.is_root() {
@@ -255,6 +260,41 @@ impl MasterFilesystem {
         );
         let status = last.to_file_status(inp.path())?;
         Ok(status)
+    }
+
+    fn mkdir_with_opts_committed(&self, path: &str, opts: MkdirOpts) -> FsResult<FileStatus> {
+        let (commands, writer) = {
+            let fs_dir = self.fs_dir.write();
+            let inp = Self::resolve_path(&fs_dir, path)?;
+
+            if inp.is_root() {
+                return err_box!("Not allowed to create existing root path: {}", inp.path());
+            }
+
+            if inp.is_full() {
+                if opts.create_parent {
+                    if let Some(last_inode) = inp.get_last_inode() {
+                        if last_inode.is_dir() {
+                            let status = last_inode.to_file_status(inp.path())?;
+                            return Ok(status);
+                        }
+                    }
+                }
+                return err_ext!(FsError::file_exists(inp.path()));
+            }
+
+            if !opts.create_parent {
+                Self::check_parent(&inp)?;
+            }
+
+            (
+                fs_dir.prepare_mkdir_commands(inp, opts)?,
+                fs_dir.journal_writer.clone(),
+            )
+        };
+
+        writer.commit_metadata_commands(commands)?;
+        self.file_status(path)
     }
 
     pub fn mkdir<T: AsRef<str>>(&self, path: T, create_parent: bool) -> FsResult<FileStatus> {
@@ -382,6 +422,10 @@ impl MasterFilesystem {
             );
         }
 
+        if self.master_monitor.is_active() {
+            return self.create_with_opts_committed(path, opts, flags);
+        }
+
         let mut fs_dir = self.fs_dir.write();
         let inp = Self::resolve_path(&fs_dir, path)?;
 
@@ -414,6 +458,50 @@ impl MasterFilesystem {
         let status = fs_dir.file_status(&inp)?;
 
         Ok(status)
+    }
+
+    fn create_with_opts_committed(
+        &self,
+        path: &str,
+        opts: CreateFileOpts,
+        flags: OpenFlags,
+    ) -> FsResult<FileStatus> {
+        let (commands, writer) = {
+            let mut fs_dir = self.fs_dir.write();
+            let inp = Self::resolve_path(&fs_dir, path)?;
+
+            let last_inode = inp.get_last_inode();
+            if let Some(inode) = &last_inode {
+                if inode.is_dir() {
+                    return err_box!("{}  already exists as a dir", inp.path());
+                }
+
+                if flags.exclusive() {
+                    return err_ext!(FsError::file_exists(inp.path()));
+                }
+            }
+
+            if !opts.create_parent {
+                Self::check_parent(&inp)?;
+            }
+
+            if last_inode.is_some() {
+                if flags.overwrite() {
+                    self.truncate(&mut fs_dir, &inp, opts)?;
+                } else {
+                    return err_ext!(FsError::file_exists(inp.path()));
+                }
+                return fs_dir.file_status(&inp);
+            }
+
+            (
+                fs_dir.prepare_create_file_commands(inp, opts)?,
+                fs_dir.journal_writer.clone(),
+            )
+        };
+
+        writer.commit_metadata_commands(commands)?;
+        self.file_status(path)
     }
 
     pub fn open_file<T: AsRef<str>>(

--- a/curvine-master/src/master/journal/entry.rs
+++ b/curvine-master/src/master/journal/entry.rs
@@ -548,17 +548,6 @@ impl DecodedJournalBatch {
         self.len() == 0
     }
 
-    pub fn contains_metadata_commands(&self) -> bool {
-        matches!(
-            self,
-            DecodedJournalBatch::Versioned(batch)
-                if batch
-                    .commands
-                    .iter()
-                    .any(|command| matches!(command, JournalCommand::Metadata(_)))
-        )
-    }
-
     pub fn into_commands(self) -> JournalCommandIter {
         match self {
             DecodedJournalBatch::Legacy(batch) => {
@@ -661,6 +650,17 @@ pub enum MetadataCommand {
 }
 
 impl MetadataCommand {
+    pub(crate) fn cv_metadata_changes(&self) -> Vec<CvMetadataChange> {
+        match self {
+            MetadataCommand::Mkdir(entry) => {
+                vec![CvMetadataChange::single(entry.op_id, &entry.path)]
+            }
+            MetadataCommand::CreateFile(entry) => {
+                vec![CvMetadataChange::single(entry.op_id, &entry.path)]
+            }
+        }
+    }
+
     pub fn op_id(&self) -> u64 {
         match self {
             MetadataCommand::Mkdir(entry) => entry.op_id,

--- a/curvine-master/src/master/journal/journal_loader.rs
+++ b/curvine-master/src/master/journal/journal_loader.rs
@@ -231,13 +231,11 @@ impl JournalLoader {
         }
 
         let batch = JournalEnvelope::decode(&entry.data)?;
-        if batch.contains_metadata_commands() {
-            return err_box!("unsupported committed metadata command batch");
-        }
         let batch_len = batch.len();
         let mut snapshot = None;
         let mut applied = Self::build_applied(entry);
         let mut has_ufs_affecting = false;
+        let mut applied_metadata_commands = Vec::new();
 
         for (seq, command) in batch.into_commands().enumerate() {
             applied.op_id = command.op_id();
@@ -302,30 +300,40 @@ impl JournalLoader {
                 }
 
                 JournalCommand::Metadata(command) => {
-                    let res = self
-                        .apply_metadata_command(is_leader, command.clone())
-                        .await;
-
-                    if let Err(e) = res {
-                        if is_leader && skip_ufs_error {
+                    self.apply_metadata_namespace(&command)?;
+                    match self.apply_metadata_ufs(is_leader, &command).await {
+                        Ok(()) => {
+                            if is_leader {
+                                applied_metadata_commands.push(command);
+                            }
+                        }
+                        Err(e) if is_leader && skip_ufs_error => {
                             error!(
                                 "skip failed committed metadata command after retries, entry index={}, term={}, command={:?}, error={}",
                                 entry.index, entry.term, command, e
                             );
+                            applied_metadata_commands.push(command);
                             continue;
                         }
-
-                        return err_box!(
-                            "failed to apply committed metadata command: {:?}: {}",
-                            command,
-                            e
-                        );
+                        Err(e) => {
+                            return err_box!(
+                                "failed to apply committed metadata command: {:?}: {}",
+                                command,
+                                e
+                            );
+                        }
                     }
                 }
             }
         }
 
         self.set_applied(is_leader, applied, has_ufs_affecting)?;
+        if is_leader && !applied_metadata_commands.is_empty() {
+            let fs_dir = self.fs_dir.read();
+            fs_dir
+                .journal_writer
+                .on_metadata_commands_applied(&fs_dir, &applied_metadata_commands);
+        }
 
         if let Some(e) = snapshot {
             let snap_data = self.create_snapshot0(Some(e.dir.to_string()))?;
@@ -672,21 +680,28 @@ impl JournalLoader {
         fs_dir.store.apply_cache_invalidations(entry.inodes)
     }
 
-    async fn apply_metadata_command(
-        &self,
-        is_leader: bool,
-        command: MetadataCommand,
-    ) -> CommonResult<()> {
+    fn apply_metadata_namespace(&self, command: &MetadataCommand) -> CommonResult<()> {
         match command {
             MetadataCommand::Mkdir(entry) => {
                 self.mkdir(entry.clone())?;
-                if is_leader {
-                    self.ufs_loader.mkdir(&entry).await
-                } else {
-                    Ok(())
-                }
+                Ok(())
             }
-            MetadataCommand::CreateFile(entry) => self.create_file(entry),
+            MetadataCommand::CreateFile(entry) => self.create_file(entry.clone()),
+        }
+    }
+
+    async fn apply_metadata_ufs(
+        &self,
+        is_leader: bool,
+        command: &MetadataCommand,
+    ) -> CommonResult<()> {
+        if !is_leader {
+            return Ok(());
+        }
+
+        match command {
+            MetadataCommand::Mkdir(entry) => self.ufs_loader.mkdir(entry).await,
+            MetadataCommand::CreateFile(_) => Ok(()),
         }
     }
 

--- a/curvine-master/src/master/journal/journal_loader.rs
+++ b/curvine-master/src/master/journal/journal_loader.rs
@@ -302,7 +302,25 @@ impl JournalLoader {
                 }
 
                 JournalCommand::Metadata(command) => {
-                    return err_box!("unsupported committed metadata command: {:?}", command);
+                    let res = self
+                        .apply_metadata_command(is_leader, command.clone())
+                        .await;
+
+                    if let Err(e) = res {
+                        if is_leader && skip_ufs_error {
+                            error!(
+                                "skip failed committed metadata command after retries, entry index={}, term={}, command={:?}, error={}",
+                                entry.index, entry.term, command, e
+                            );
+                            continue;
+                        }
+
+                        return err_box!(
+                            "failed to apply committed metadata command: {:?}: {}",
+                            command,
+                            e
+                        );
+                    }
                 }
             }
         }
@@ -652,6 +670,24 @@ impl JournalLoader {
     fn cache_invalidation(&self, entry: CacheInvalidationEntry) -> CommonResult<()> {
         let fs_dir = self.fs_dir.write();
         fs_dir.store.apply_cache_invalidations(entry.inodes)
+    }
+
+    async fn apply_metadata_command(
+        &self,
+        is_leader: bool,
+        command: MetadataCommand,
+    ) -> CommonResult<()> {
+        match command {
+            MetadataCommand::Mkdir(entry) => {
+                self.mkdir(entry.clone())?;
+                if is_leader {
+                    self.ufs_loader.mkdir(&entry).await
+                } else {
+                    Ok(())
+                }
+            }
+            MetadataCommand::CreateFile(entry) => self.create_file(entry),
+        }
     }
 
     fn mkdir(&self, entry: MkdirEntry) -> CommonResult<()> {

--- a/curvine-master/src/master/journal/journal_writer.rs
+++ b/curvine-master/src/master/journal/journal_writer.rs
@@ -121,25 +121,63 @@ impl JournalWriter {
     }
 
     fn record_metadata_delta(&self, entry: &JournalEntry) {
-        let changes = entry.cv_metadata_changes();
+        self.record_metadata_changes(entry.cv_metadata_changes());
+    }
+
+    fn record_metadata_changes(&self, changes: Vec<CvMetadataChange>) {
         if changes.is_empty() {
             return;
         }
         self.metadata_delta_log.lock().unwrap().push(changes);
     }
 
+    pub(crate) fn on_metadata_commands_applied(
+        &self,
+        fs_dir: &FsDir,
+        commands: &[MetadataCommand],
+    ) {
+        if !self.enable || commands.is_empty() {
+            return;
+        }
+
+        for command in commands {
+            self.record_metadata_changes(command.cv_metadata_changes());
+        }
+        if let Err(e) = self.maybe_emit_snapshot_after(fs_dir, commands.len() as u64) {
+            warn!(
+                "failed to emit snapshot after committed metadata batch: {}",
+                e
+            );
+        }
+    }
+
     fn maybe_emit_snapshot(&self, fs_dir: &FsDir) -> FsResult<()> {
+        self.maybe_emit_snapshot_after(fs_dir, 1)
+    }
+
+    fn maybe_emit_snapshot_after(&self, fs_dir: &FsDir, applied_entries: u64) -> FsResult<()> {
         if self.snapshot_entries == 0 {
             return Ok(());
         }
 
-        let entries = self.entries_since_snapshot.add_and_get(1);
+        let mut previous = self.entries_since_snapshot.get();
+        let entries = loop {
+            let current = previous.saturating_add(applied_entries);
+            let next = if current < self.snapshot_entries {
+                current
+            } else {
+                current % self.snapshot_entries
+            };
+            if self.entries_since_snapshot.compare_and_set(previous, next) {
+                break current;
+            }
+            previous = self.entries_since_snapshot.get();
+        };
         if entries < self.snapshot_entries {
             return Ok(());
         }
 
         let now = LocalTime::mills();
-        self.entries_since_snapshot.set(0);
         let dir = match fs_dir.store.create_checkpoint(now) {
             Ok(d) => d,
             Err(e) => {

--- a/curvine-master/src/master/journal/journal_writer.rs
+++ b/curvine-master/src/master/journal/journal_writer.rs
@@ -24,7 +24,7 @@ use curvine_error::FsResult;
 use curvine_model::{CommitBlock, FileLock, MountInfo, RenameFlags, SetAttrOpts};
 use curvine_raft::conf::JournalConfExt;
 use curvine_raft::raft::RaftClient;
-use curvine_runtime::common::{FileUtils, LocalTime};
+use curvine_runtime::common::{FileUtils, LocalTime, TimeSpent};
 use curvine_runtime::sync::channel::{BlockingChannel, BlockingReceiver, BlockingSender};
 use curvine_runtime::sync::AtomicCounter;
 use log::{debug, info, warn};
@@ -35,6 +35,7 @@ use std::sync::Mutex;
 pub struct JournalWriter {
     enable: bool,
     node_id: u64,
+    client: RaftClient,
     sender: BlockingSender<JournalEntry>,
     metrics: &'static MasterMetrics,
     receiver: Option<Mutex<BlockingReceiver<JournalEntry>>>,
@@ -59,7 +60,7 @@ impl JournalWriter {
 
         let receiver = if !testing {
             // Start the send log thread.
-            let task = SenderTask::new(client, conf, 0)?;
+            let task = SenderTask::new(client.clone(), conf, 0)?;
             task.spawn(receiver)?;
             None
         } else {
@@ -69,6 +70,7 @@ impl JournalWriter {
         Ok(Self {
             enable: conf.enable,
             node_id,
+            client,
             sender,
             metrics,
             receiver,
@@ -82,6 +84,30 @@ impl JournalWriter {
         debug!("send_entry {:?}", entry);
         self.sender.send(entry)?;
         self.metrics.journal_queue_len.inc();
+        Ok(())
+    }
+
+    pub fn commit_metadata_commands(&self, commands: Vec<MetadataCommand>) -> FsResult<()> {
+        if !self.enable {
+            return Ok(());
+        }
+        if commands.is_empty() {
+            return Ok(());
+        }
+
+        let spend = TimeSpent::new();
+        let seq_id = commands[0].op_id();
+        let mut batch = JournalCommandBatch::new(seq_id);
+        for command in commands {
+            batch.push_metadata(command);
+        }
+        let bytes = JournalEnvelope::encode(batch)?;
+        self.client.block_on_send_propose(bytes)?;
+
+        self.metrics.journal_flush_count.inc();
+        self.metrics
+            .journal_flush_time
+            .inc_by(spend.used_us() as i64);
         Ok(())
     }
 

--- a/curvine-master/src/master/journal/tests/journal_loader_test.rs
+++ b/curvine-master/src/master/journal/tests/journal_loader_test.rs
@@ -8,7 +8,7 @@ use curvine_runtime::runtime::{AsyncRuntime, RpcRuntime};
 use raft::eraftpb::Entry;
 
 #[test]
-fn metadata_batch_is_rejected_before_legacy_commands_are_applied() -> CommonResult<()> {
+fn metadata_batch_is_applied_after_versioned_journal_upgrade() -> CommonResult<()> {
     Master::init_test_metrics();
 
     let mut source_conf = ClusterConf {
@@ -18,17 +18,17 @@ fn metadata_batch_is_rejected_before_legacy_commands_are_applied() -> CommonResu
     source_conf.change_test_meta_dir(format!("metadata-batch-source-{}", Utils::rand_str(6)));
     let source_fs = JournalSystem::fs_only_for_test(&source_conf)?;
     source_fs.mkdir("/legacy", false)?;
-    let legacy = source_fs
+    let metadata = source_fs
         .fs_dir
         .read()
         .take_entries()
         .into_iter()
         .next()
+        .map(|entry| match entry {
+            JournalEntry::Mkdir(entry) => MetadataCommand::Mkdir(entry),
+            _ => unreachable!("mkdir must emit a mkdir journal entry"),
+        })
         .expect("mkdir must emit a journal entry");
-    let metadata = match legacy.clone() {
-        JournalEntry::Mkdir(entry) => MetadataCommand::Mkdir(entry),
-        _ => unreachable!("mkdir must emit a mkdir journal entry"),
-    };
 
     let mut target_conf = ClusterConf {
         testing: true,
@@ -39,7 +39,6 @@ fn metadata_batch_is_rejected_before_legacy_commands_are_applied() -> CommonResu
     let target_fs = target.fs();
 
     let mut batch = JournalCommandBatch::new(1);
-    batch.push_legacy(legacy);
     batch.push_metadata(metadata);
     let entry = Entry {
         term: 1,
@@ -48,18 +47,14 @@ fn metadata_batch_is_rejected_before_legacy_commands_are_applied() -> CommonResu
         ..Default::default()
     };
 
-    let err = AsyncRuntime::single()
-        .block_on(async {
-            target
-                .journal_loader()
-                .apply(true, ApplyMsg::new_entry(entry))
-                .await
-        })
-        .expect_err("metadata commands are not supported by this journal version");
-    assert!(err
-        .to_string()
-        .contains("unsupported committed metadata command batch"));
-    assert!(target_fs.file_status("/legacy").is_err());
+    AsyncRuntime::single().block_on(async {
+        target
+            .journal_loader()
+            .apply(false, ApplyMsg::new_entry(entry))
+            .await
+    })?;
+    let status = target_fs.file_status("/legacy");
+    assert!(status.is_ok(), "metadata mkdir replay failed: {status:?}");
 
     Ok(())
 }

--- a/curvine-master/src/master/journal/tests/journal_loader_test.rs
+++ b/curvine-master/src/master/journal/tests/journal_loader_test.rs
@@ -50,7 +50,7 @@ fn metadata_batch_is_applied_after_versioned_journal_upgrade() -> CommonResult<(
     AsyncRuntime::single().block_on(async {
         target
             .journal_loader()
-            .apply(false, ApplyMsg::new_entry(entry))
+            .apply(true, ApplyMsg::new_entry(entry))
             .await
     })?;
     let status = target_fs.file_status("/legacy");

--- a/curvine-master/src/master/meta/fs_dir.rs
+++ b/curvine-master/src/master/meta/fs_dir.rs
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 use crate::master::fs::{BlockInodeState, DeleteResult};
-use crate::master::journal::{JournalEntry, JournalWriter};
+use crate::master::journal::{
+    CreateFileEntry, JournalEntry, JournalWriter, MetadataCommand, MkdirEntry,
+};
 use crate::master::meta::inode::ttl::TtlBucketList;
 use crate::master::meta::inode::InodeView::{Dir, File, FileEntry};
 use crate::master::meta::inode::*;
@@ -198,6 +200,91 @@ impl FsDir {
         }
 
         Ok(inp)
+    }
+
+    pub(crate) fn prepare_mkdir_commands(
+        &self,
+        mut inp: InodePath,
+        opts: MkdirOpts,
+    ) -> FsResult<Vec<MetadataCommand>> {
+        let mut commands = vec![];
+        if inp.is_full() || inp.is_root() {
+            return Ok(commands);
+        }
+
+        if opts.create_parent {
+            let parent_opts = opts.parent_opts();
+            while inp.existing_len() + 1 < inp.len() {
+                commands.push(MetadataCommand::Mkdir(
+                    self.prepare_mkdir_command(&mut inp, parent_opts.clone())?,
+                ));
+            }
+        }
+
+        if !inp.is_full() && !inp.is_root() {
+            commands.push(MetadataCommand::Mkdir(
+                self.prepare_mkdir_command(&mut inp, opts)?,
+            ));
+        }
+
+        Ok(commands)
+    }
+
+    fn prepare_mkdir_command(
+        &self,
+        inp: &mut InodePath,
+        mut opts: MkdirOpts,
+    ) -> FsResult<MkdirEntry> {
+        let pos = inp.existing_len() - 1;
+        let name = inp.get_component(pos + 1)?.to_string();
+
+        Self::apply_setgid_directory_inheritance(inp, &mut opts)?;
+
+        let dir = InodeDir::with_opts(self.next_inode_id()?, LocalTime::mills() as i64, opts);
+        inp.append(InodePtr::from_owned(InodeView::new_dir(name, dir.clone())))?;
+
+        Ok(MkdirEntry {
+            op_id: self.next_op_id(),
+            rpc_id: 0,
+            path: inp.get_valid_parent_path(),
+            dir,
+        })
+    }
+
+    pub(crate) fn prepare_create_file_commands(
+        &self,
+        mut inp: InodePath,
+        opts: CreateFileOpts,
+    ) -> FsResult<Vec<MetadataCommand>> {
+        if inp.get_last_inode().is_some() {
+            return err_ext!(FsError::file_exists(inp.path()));
+        }
+
+        let mut commands = vec![];
+        if opts.create_parent {
+            let dir_opts = opts.dir_opts();
+            while inp.existing_len() + 1 < inp.len() {
+                commands.push(MetadataCommand::Mkdir(
+                    self.prepare_mkdir_command(&mut inp, dir_opts.clone())?,
+                ));
+            }
+        }
+
+        let name = inp.name().to_string();
+        let path = inp.path().to_string();
+        let file = InodeFile::with_opts(self.next_inode_id()?, LocalTime::mills() as i64, opts);
+        inp.append(InodePtr::from_owned(InodeView::new_file(
+            name,
+            file.clone(),
+        )))?;
+
+        commands.push(MetadataCommand::CreateFile(CreateFileEntry {
+            op_id: self.next_op_id(),
+            rpc_id: 0,
+            path,
+            file,
+        }));
+        Ok(commands)
     }
 
     // Delete files or directories

--- a/curvine-master/src/master/meta/fs_dir.rs
+++ b/curvine-master/src/master/meta/fs_dir.rs
@@ -185,6 +185,14 @@ impl FsDir {
         }
     }
 
+    fn apply_setgid_directory_inheritance(inp: &InodePath, opts: &mut MkdirOpts) -> FsResult<()> {
+        if let Some(group) = Self::setgid_parent_group(inp)? {
+            opts.group = group;
+            opts.mode |= MODE_SETGID;
+        }
+        Ok(())
+    }
+
     // Create all previous directories that may be missing on the path.
     fn create_parent_dir(&mut self, mut inp: InodePath, opts: MkdirOpts) -> FsResult<InodePath> {
         let mut index = inp.existing_len();

--- a/curvine-master/src/master/meta/fs_dir.rs
+++ b/curvine-master/src/master/meta/fs_dir.rs
@@ -262,7 +262,7 @@ impl FsDir {
     pub(crate) fn prepare_create_file_commands(
         &self,
         mut inp: InodePath,
-        opts: CreateFileOpts,
+        mut opts: CreateFileOpts,
     ) -> FsResult<Vec<MetadataCommand>> {
         if inp.get_last_inode().is_some() {
             return err_ext!(FsError::file_exists(inp.path()));
@@ -276,6 +276,10 @@ impl FsDir {
                     self.prepare_mkdir_command(&mut inp, dir_opts.clone())?,
                 ));
             }
+        }
+
+        if let Some(group) = Self::setgid_parent_group(&inp)? {
+            opts.group = group;
         }
 
         let name = inp.name().to_string();

--- a/curvine-server/tests/journal_test.rs
+++ b/curvine-server/tests/journal_test.rs
@@ -16,8 +16,8 @@ use curvine_config::ClusterConf;
 use curvine_core_error::{err_box, CommonResult};
 use curvine_fs_api::CurvineURI;
 use curvine_model::{
-    BlockLocation, ClientAddress, CommitBlock, CreateFileOpts, MountOptions, OpenFlags,
-    RenameFlags, WorkerInfo, WriteType,
+    BlockLocation, ClientAddress, CommitBlock, CreateFileOpts, CreateFileOptsBuilder,
+    MkdirOptsBuilder, MountOptions, OpenFlags, RenameFlags, WorkerInfo, WriteType,
 };
 use curvine_net::net::NetUtils;
 use curvine_raft::proto::raft::{AppliedIndex, FsmState, SnapshotData, SnapshotFileList};
@@ -289,6 +289,30 @@ fn active_namespace_creation_replicates_without_legacy_writer_queue() -> CommonR
 
     active.mkdir("/committed-dir", false)?;
     active.create("/committed-file", false)?;
+    let parent_opts = MkdirOptsBuilder::new()
+        .group("parent-group".to_string())
+        .mode(0o2775)
+        .build();
+    active.mkdir_with_opts("/setgid-parent", parent_opts)?;
+    let file_opts = CreateFileOptsBuilder::new()
+        .group("file-group".to_string())
+        .build();
+    active.create_with_opts("/setgid-parent/child", file_opts, OpenFlags::new_create())?;
+
+    let delta = active.cv_metadata_delta_page(0, None, None, 32)?;
+    assert!(!delta.full_snapshot_required);
+    assert!(delta
+        .entries
+        .iter()
+        .any(|entry| entry.path == "/committed-dir"));
+    assert!(delta
+        .entries
+        .iter()
+        .any(|entry| entry.path == "/committed-file"));
+    assert_eq!(
+        active.file_status("/setgid-parent/child")?.group,
+        "parent-group"
+    );
     let legacy_entries = active.fs_dir.read().take_entries();
     assert!(
         !legacy_entries.iter().any(|entry| matches!(
@@ -302,7 +326,12 @@ fn active_namespace_creation_replicates_without_legacy_writer_queue() -> CommonR
     loop {
         if standby.file_status("/committed-dir").is_ok()
             && standby.file_status("/committed-file").is_ok()
+            && standby.file_status("/setgid-parent/child").is_ok()
         {
+            assert_eq!(
+                standby.file_status("/setgid-parent/child")?.group,
+                "parent-group"
+            );
             return Ok(());
         }
         if std::time::Instant::now() >= deadline {

--- a/curvine-server/tests/journal_test.rs
+++ b/curvine-server/tests/journal_test.rs
@@ -238,6 +238,80 @@ fn replay_accepts_versioned_legacy_journal_batch() -> CommonResult<()> {
     Ok(())
 }
 
+#[test]
+fn active_namespace_creation_replicates_without_legacy_writer_queue() -> CommonResult<()> {
+    Master::init_test_metrics();
+
+    let port1 = NetUtils::hold_available_port();
+    let port2 = NetUtils::hold_available_port();
+
+    let mut conf = ClusterConf {
+        testing: true,
+        ..Default::default()
+    };
+    conf.journal.writer_flush_batch_size = 1;
+    conf.journal.writer_flush_batch_ms = 10;
+    conf.journal.raft_tick_interval_ms = 100;
+    conf.journal.raft_check_quorum = false;
+    conf.journal.journal_addrs = vec![
+        RaftPeer::new(port1 as NodeId, &conf.master.hostname, port1),
+        RaftPeer::new(port2 as NodeId, &conf.master.hostname, port2),
+    ];
+
+    conf.change_test_meta_dir("active-committed-namespace-1");
+    conf.journal.rpc_port = port1;
+    let js1 = JournalSystem::from_conf(&conf)?;
+    let fs1 = MasterFilesystem::with_js(&conf, &js1);
+    let monitor1 = js1.master_monitor();
+
+    conf.change_test_meta_dir("active-committed-namespace-2");
+    conf.journal.rpc_port = port2;
+    let js2 = JournalSystem::from_conf(&conf)?;
+    let fs2 = MasterFilesystem::with_js(&conf, &js2);
+    let monitor2 = js2.master_monitor();
+
+    js1.start_blocking()?;
+    js2.start_blocking()?;
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(60);
+    let (active, standby) = loop {
+        if monitor1.is_active() {
+            break (fs1.clone(), fs2.clone());
+        }
+        if monitor2.is_active() {
+            break (fs2.clone(), fs1.clone());
+        }
+        if std::time::Instant::now() >= deadline {
+            return err_box!("Not found active master");
+        }
+        thread::sleep(Duration::from_millis(100));
+    };
+
+    active.mkdir("/committed-dir", false)?;
+    active.create("/committed-file", false)?;
+    let legacy_entries = active.fs_dir.read().take_entries();
+    assert!(
+        !legacy_entries.iter().any(|entry| matches!(
+            entry,
+            JournalEntry::Mkdir(_) | JournalEntry::CreateFile(_)
+        )),
+        "active namespace creation must not emit legacy local-first namespace journal entries: {legacy_entries:?}"
+    );
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(60);
+    loop {
+        if standby.file_status("/committed-dir").is_ok()
+            && standby.file_status("/committed-file").is_ok()
+        {
+            return Ok(());
+        }
+        if std::time::Instant::now() >= deadline {
+            return err_box!("standby did not apply committed namespace creation");
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+}
+
 // First start a master and perform the operation; then start 1 stand by, manually replay the log to check consistency.
 #[test]
 fn test_journal_replay_consistency_between_leader_and_follower() -> CommonResult<()> {


### PR DESCRIPTION
## Summary
Commit active-Master `mkdir` and new-file creation through Raft before changing local namespace metadata.

## Issue/Design
This is the namespace-creation slice of #1552. Local-first namespace mutations can allocate an inode before the committed log has ordered the mutation across voters. This PR prepares deterministic commands, commits them, then lets ordered journal apply mutate the namespace.

## Changes
| Area | Change |
| --- | --- |
| Active namespace creation | Route `mkdir` and new file creation through committed metadata commands. |
| Command preparation | Allocate inode/op IDs once while resolving the namespace, without locally applying the mutation. |
| Journal execution | Apply committed `Mkdir` and `CreateFile` commands on followers and the active Master. |
| Test | Exercise a two-Master election and verify namespace creation replicates without legacy local-first entries. |

## Test verified
- `cargo fmt --check -- curvine-master/src/master/fs/master_filesystem.rs curvine-master/src/master/journal/journal_loader.rs curvine-master/src/master/journal/journal_writer.rs curvine-master/src/master/meta/fs_dir.rs curvine-server/tests/journal_test.rs`
- `CARGO_TARGET_DIR=/mnt/data/curvine/.build/pr-1552-split/namespace-creation cargo test -q -p curvine-server --test journal_test`
- `CARGO_TARGET_DIR=/mnt/data/curvine/.build/pr-1552-split/namespace-creation cargo clippy -q -p curvine-server --test journal_test -- -D warnings`
- `git diff --check`

## Dependencies
Stacked on #1558, which introduces the versioned committed-command envelope. Merge after #1558.