### PR TITLE
fix(master): preserve journal order for committed rename

### DIFF
--- a/curvine-master/src/master/fs/master_filesystem.rs
+++ b/curvine-master/src/master/fs/master_filesystem.rs
@@ -14,7 +14,7 @@
 
 use crate::master::fs::context::ValidateAddBlock;
 use crate::master::fs::policy::ChooseContext;
-use crate::master::journal::JournalSystem;
+use crate::master::journal::{JournalSystem, MetadataCommand};
 use crate::master::meta::inode::{InodeFile, InodePath, InodePtr, InodeView, PATH_SEPARATOR};
 use crate::master::meta::{CacheInvalidationResult, FsDir};
 
@@ -334,6 +334,12 @@ impl MasterFilesystem {
         let src = src.as_ref();
         let dst = dst.as_ref();
 
+        if self.master_monitor.is_active() {
+            if let Some(result) = self.rename_committed(src, dst, flags)? {
+                return Ok(result);
+            }
+        }
+
         let mut fs_dir = self.fs_dir.write();
         let src_inp = Self::resolve_path(&fs_dir, src)?;
         let dst_inp = Self::resolve_path(&fs_dir, dst)?;
@@ -374,6 +380,50 @@ impl MasterFilesystem {
         }
 
         Ok(true)
+    }
+
+    fn rename_committed(&self, src: &str, dst: &str, flags: RenameFlags) -> FsResult<Option<bool>> {
+        let (command, writer) = {
+            let fs_dir = self.fs_dir.write();
+            let src_inp = Self::resolve_path(&fs_dir, src)?;
+            let dst_inp = Self::resolve_path(&fs_dir, dst)?;
+
+            if src_inp.is_root() {
+                return err_box!("Cannot rename root path");
+            }
+
+            if src == dst {
+                return Ok(Some(false));
+            }
+
+            if let Some(rest) = dst.strip_prefix(src) {
+                if rest.starts_with(PATH_SEPARATOR) {
+                    return err_ext!(FsError::invalid_argument(format!(
+                        "cannot rename {} to {}: destination is under source",
+                        src, dst
+                    )));
+                }
+            }
+
+            if dst_inp.get_last_inode().is_some() {
+                return Ok(None);
+            }
+            Self::check_parent(&dst_inp)?;
+
+            let entry = fs_dir.prepare_rename_command(
+                &src_inp,
+                &dst_inp,
+                LocalTime::mills() as i64,
+                flags,
+            )?;
+            (
+                MetadataCommand::Rename(entry),
+                fs_dir.journal_writer.clone(),
+            )
+        };
+
+        writer.commit_metadata_commands(vec![command])?;
+        Ok(Some(true))
     }
 
     pub fn create<T: AsRef<str>>(&self, path: T, create_parent: bool) -> FsResult<FileStatus> {

--- a/curvine-master/src/master/fs/master_filesystem.rs
+++ b/curvine-master/src/master/fs/master_filesystem.rs
@@ -334,7 +334,7 @@ impl MasterFilesystem {
         let src = src.as_ref();
         let dst = dst.as_ref();
 
-        if self.master_monitor.is_active() {
+        if self.master_monitor.is_active() && !flags.exchange_mode() {
             if let Some(result) = self.rename_committed(src, dst, flags)? {
                 return Ok(result);
             }

--- a/curvine-master/src/master/journal/entry.rs
+++ b/curvine-master/src/master/journal/entry.rs
@@ -502,9 +502,9 @@ pub struct JournalEnvelope {
 }
 
 impl JournalEnvelope {
-    pub fn encode(batch: JournalCommandBatch) -> CommonResult<Vec<u8>> {
+    pub fn encode(batch: &JournalCommandBatch) -> CommonResult<Vec<u8>> {
         let mut bytes = JOURNAL_ENVELOPE_MAGIC.to_vec();
-        bytes.extend(SerdeUtils::serialize(&Self {
+        bytes.extend(SerdeUtils::serialize(&JournalEnvelopeRef {
             version: JOURNAL_ENVELOPE_VERSION,
             batch,
         })?);
@@ -529,6 +529,12 @@ impl JournalEnvelope {
         }
         Ok(DecodedJournalBatch::Versioned(envelope.batch))
     }
+}
+
+#[derive(Serialize)]
+struct JournalEnvelopeRef<'a> {
+    version: u16,
+    batch: &'a JournalCommandBatch,
 }
 
 pub enum DecodedJournalBatch {

--- a/curvine-master/src/master/journal/entry.rs
+++ b/curvine-master/src/master/journal/entry.rs
@@ -605,6 +605,10 @@ impl JournalCommandBatch {
     pub fn is_empty(&self) -> bool {
         self.commands.is_empty()
     }
+    pub fn next(&mut self) {
+        self.seq_id += 1;
+        self.commands.clear();
+    }
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -647,6 +651,7 @@ impl JournalCommand {
 pub enum MetadataCommand {
     Mkdir(MkdirEntry),
     CreateFile(CreateFileEntry),
+    Rename(RenameEntry),
 }
 
 impl MetadataCommand {
@@ -658,6 +663,10 @@ impl MetadataCommand {
             MetadataCommand::CreateFile(entry) => {
                 vec![CvMetadataChange::single(entry.op_id, &entry.path)]
             }
+            MetadataCommand::Rename(entry) => vec![
+                CvMetadataChange::subtree(entry.op_id, &entry.src),
+                CvMetadataChange::subtree(entry.op_id, &entry.dst),
+            ],
         }
     }
 
@@ -665,6 +674,7 @@ impl MetadataCommand {
         match self {
             MetadataCommand::Mkdir(entry) => entry.op_id,
             MetadataCommand::CreateFile(entry) => entry.op_id,
+            MetadataCommand::Rename(entry) => entry.op_id,
         }
     }
 
@@ -672,6 +682,7 @@ impl MetadataCommand {
         match self {
             MetadataCommand::Mkdir(entry) => entry.rpc_id,
             MetadataCommand::CreateFile(entry) => entry.rpc_id,
+            MetadataCommand::Rename(entry) => entry.rpc_id,
         }
     }
 
@@ -679,6 +690,7 @@ impl MetadataCommand {
         match self {
             MetadataCommand::Mkdir(entry) => Some(entry.dir.id),
             MetadataCommand::CreateFile(entry) => Some(entry.file.id),
+            MetadataCommand::Rename(_) => None,
         }
     }
 

--- a/curvine-master/src/master/journal/journal_loader.rs
+++ b/curvine-master/src/master/journal/journal_loader.rs
@@ -687,6 +687,7 @@ impl JournalLoader {
                 Ok(())
             }
             MetadataCommand::CreateFile(entry) => self.create_file(entry.clone()),
+            MetadataCommand::Rename(entry) => self.rename(entry.clone()),
         }
     }
 
@@ -702,6 +703,11 @@ impl JournalLoader {
         match command {
             MetadataCommand::Mkdir(entry) => self.ufs_loader.mkdir(entry).await,
             MetadataCommand::CreateFile(_) => Ok(()),
+            MetadataCommand::Rename(entry) => {
+                self.ufs_loader
+                    .apply_entry(&JournalEntry::Rename(entry.clone()))
+                    .await
+            }
         }
     }
 

--- a/curvine-master/src/master/journal/journal_writer.rs
+++ b/curvine-master/src/master/journal/journal_writer.rs
@@ -136,12 +136,12 @@ impl JournalWriter {
                     self.metrics.journal_queue_len.dec();
                     batch.push_legacy(entry);
                     if force {
-                        self.propose_command_batch(batch)?;
+                        self.propose_command_batch(&batch)?;
                         self.metrics.journal_flush_count.inc();
                         self.metrics
                             .journal_flush_time
                             .inc_by(spend.used_us() as i64);
-                        batch = JournalCommandBatch::new(seq_id);
+                        batch.next();
                     }
                 }
                 JournalWriteRequest::Metadata(_, _) => {
@@ -152,7 +152,7 @@ impl JournalWriter {
         for command in commands {
             batch.push_metadata(command);
         }
-        self.propose_command_batch(batch)?;
+        self.propose_command_batch(&batch)?;
 
         self.metrics.journal_flush_count.inc();
         self.metrics
@@ -161,7 +161,7 @@ impl JournalWriter {
         Ok(())
     }
 
-    pub(crate) fn propose_command_batch(&self, batch: JournalCommandBatch) -> FsResult<()> {
+    pub(crate) fn propose_command_batch(&self, batch: &JournalCommandBatch) -> FsResult<()> {
         let bytes = JournalEnvelope::encode(batch)?;
         self.client.block_on_send_propose(bytes)?;
         Ok(())

--- a/curvine-master/src/master/journal/journal_writer.rs
+++ b/curvine-master/src/master/journal/journal_writer.rs
@@ -29,16 +29,21 @@ use curvine_runtime::sync::channel::{BlockingChannel, BlockingReceiver, Blocking
 use curvine_runtime::sync::AtomicCounter;
 use log::{debug, info, warn};
 use std::collections::VecDeque;
-use std::sync::Mutex;
+use std::sync::{mpsc, Mutex};
+
+pub(crate) enum JournalWriteRequest {
+    Legacy(JournalEntry),
+    Metadata(Vec<MetadataCommand>, mpsc::SyncSender<FsResult<()>>),
+}
 
 // Write metadata operation logs.
 pub struct JournalWriter {
     enable: bool,
     node_id: u64,
     client: RaftClient,
-    sender: BlockingSender<JournalEntry>,
+    sender: BlockingSender<JournalWriteRequest>,
     metrics: &'static MasterMetrics,
-    receiver: Option<Mutex<BlockingReceiver<JournalEntry>>>,
+    receiver: Option<Mutex<BlockingReceiver<JournalWriteRequest>>>,
     metadata_delta_log: Mutex<MetadataDeltaLog>,
 
     snapshot_entries: u64,
@@ -82,7 +87,7 @@ impl JournalWriter {
 
     fn send_inner(&self, entry: JournalEntry) -> FsResult<()> {
         debug!("send_entry {:?}", entry);
-        self.sender.send(entry)?;
+        self.sender.send(JournalWriteRequest::Legacy(entry))?;
         self.metrics.journal_queue_len.inc();
         Ok(())
     }
@@ -95,19 +100,67 @@ impl JournalWriter {
             return Ok(());
         }
 
+        if let Some(receiver) = self.receiver.as_ref() {
+            return self.commit_metadata_commands_for_test(receiver, commands);
+        }
+
+        let (tx, rx) = mpsc::sync_channel(1);
+        self.sender
+            .send(JournalWriteRequest::Metadata(commands, tx))?;
+        self.metrics.journal_queue_len.inc();
+        match rx.recv() {
+            Ok(res) => res,
+            Err(e) => err_box!("metadata journal sender dropped response: {}", e),
+        }
+    }
+
+    fn commit_metadata_commands_for_test(
+        &self,
+        receiver: &Mutex<BlockingReceiver<JournalWriteRequest>>,
+        commands: Vec<MetadataCommand>,
+    ) -> FsResult<()> {
         let spend = TimeSpent::new();
         let seq_id = commands[0].op_id();
         let mut batch = JournalCommandBatch::new(seq_id);
+        let receiver = match receiver.lock() {
+            Ok(receiver) => receiver,
+            Err(e) => return err_box!("failed to lock journal test receiver: {}", e),
+        };
+        while let Ok(req) = receiver.try_recv() {
+            match req {
+                JournalWriteRequest::Legacy(entry) => {
+                    let force = matches!(entry, JournalEntry::Snapshot(_));
+                    self.metrics.journal_queue_len.dec();
+                    batch.push_legacy(entry);
+                    if force {
+                        self.propose_command_batch(batch)?;
+                        self.metrics.journal_flush_count.inc();
+                        self.metrics
+                            .journal_flush_time
+                            .inc_by(spend.used_us() as i64);
+                        batch = JournalCommandBatch::new(seq_id);
+                    }
+                }
+                JournalWriteRequest::Metadata(_, _) => {
+                    return err_box!("unexpected queued metadata command in test journal writer");
+                }
+            }
+        }
         for command in commands {
             batch.push_metadata(command);
         }
-        let bytes = JournalEnvelope::encode(batch)?;
-        self.client.block_on_send_propose(bytes)?;
+        self.propose_command_batch(batch)?;
 
         self.metrics.journal_flush_count.inc();
         self.metrics
             .journal_flush_time
             .inc_by(spend.used_us() as i64);
+        Ok(())
+    }
+
+    pub(crate) fn propose_command_batch(&self, batch: JournalCommandBatch) -> FsResult<()> {
+        let bytes = JournalEnvelope::encode(batch)?;
+        self.client.block_on_send_propose(bytes)?;
         Ok(())
     }
 
@@ -433,7 +486,8 @@ impl JournalWriter {
             index,
         };
         self.metrics.journal_queue_len.inc();
-        self.sender.send(JournalEntry::UfsApplied(entry))?;
+        self.sender
+            .send(JournalWriteRequest::Legacy(JournalEntry::UfsApplied(entry)))?;
 
         Ok(())
     }
@@ -462,7 +516,14 @@ impl JournalWriter {
             }
         };
         while let Ok(v) = receiver.try_recv() {
-            entries.push(v);
+            match v {
+                JournalWriteRequest::Legacy(entry) => entries.push(entry),
+                JournalWriteRequest::Metadata(_, ack) => {
+                    let _ = ack.send(err_box!(
+                        "unexpected queued metadata command while taking journal entries"
+                    ));
+                }
+            }
         }
         entries
     }

--- a/curvine-master/src/master/journal/journal_writer.rs
+++ b/curvine-master/src/master/journal/journal_writer.rs
@@ -683,14 +683,14 @@ mod tests {
             .expect("snapshot entry should be enqueued");
 
         match entry {
-            JournalEntry::Snapshot(entry) => {
+            JournalWriteRequest::Legacy(JournalEntry::Snapshot(entry)) => {
                 assert!(
                     Path::new(&entry.dir).exists(),
                     "checkpoint should remain after successful handoff: {}",
                     entry.dir
                 );
             }
-            other => panic!("expected snapshot entry, got {:?}", other),
+            _ => panic!("expected snapshot entry"),
         }
 
         Ok(())

--- a/curvine-master/src/master/journal/journal_writer.rs
+++ b/curvine-master/src/master/journal/journal_writer.rs
@@ -31,6 +31,9 @@ use log::{debug, info, warn};
 use std::collections::VecDeque;
 use std::sync::{mpsc, Mutex};
 
+// The legacy entry is the hot path. Keeping it inline avoids a heap allocation
+// for every normal journal write.
+#[allow(clippy::large_enum_variant)]
 pub(crate) enum JournalWriteRequest {
     Legacy(JournalEntry),
     Metadata(Vec<MetadataCommand>, mpsc::SyncSender<FsResult<()>>),

--- a/curvine-master/src/master/journal/sender_task.rs
+++ b/curvine-master/src/master/journal/sender_task.rs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::master::journal::{JournalBatch, JournalEntry};
+use super::journal_writer::JournalWriteRequest;
+use crate::master::journal::{JournalCommandBatch, JournalEntry};
 use crate::master::{Master, MasterMetrics};
 use curvine_config::JournalConf;
 use curvine_core_error::CommonResult;
 use curvine_error::FsResult;
 use curvine_raft::raft::RaftClient;
-use curvine_runtime::common::SerdeUtils;
 use curvine_runtime::common::{LocalTime, TimeSpent};
 use curvine_runtime::sync::channel::BlockingReceiver;
 use std::sync::mpsc::RecvTimeoutError;
@@ -27,7 +27,7 @@ use std::time::Duration;
 
 pub struct SenderTask {
     pub(crate) client: RaftClient,
-    pub(crate) batch: JournalBatch,
+    pub(crate) batch: JournalCommandBatch,
     pub(crate) flush_batch_ms: u64,
     pub(crate) flush_batch_size: u64,
     pub(crate) last_flush_ms: u64,
@@ -38,7 +38,7 @@ impl SenderTask {
     pub fn new(client: RaftClient, conf: &JournalConf, batch_seq_id: u64) -> CommonResult<Self> {
         let sender = Self {
             client,
-            batch: JournalBatch::new(batch_seq_id),
+            batch: JournalCommandBatch::new(batch_seq_id),
             flush_batch_ms: conf.writer_flush_batch_ms,
             flush_batch_size: conf.writer_flush_batch_size,
             last_flush_ms: LocalTime::mills(),
@@ -49,7 +49,7 @@ impl SenderTask {
     }
 
     // Start a thread to execute sender task
-    pub fn spawn(self, receiver: BlockingReceiver<JournalEntry>) -> FsResult<()> {
+    pub(crate) fn spawn(self, receiver: BlockingReceiver<JournalWriteRequest>) -> FsResult<()> {
         let poll = Duration::from_millis(self.flush_batch_ms);
         let name = "journal-writer".to_string();
         let task = self;
@@ -63,7 +63,7 @@ impl SenderTask {
     }
 
     fn loop0(
-        receiver: BlockingReceiver<JournalEntry>,
+        receiver: BlockingReceiver<JournalWriteRequest>,
         poll: Duration,
         mut task: SenderTask,
     ) -> FsResult<()> {
@@ -81,12 +81,31 @@ impl SenderTask {
         }
     }
 
-    pub fn handle(&mut self, entry: Option<JournalEntry>) -> FsResult<()> {
-        let force = if let Some(v) = entry {
-            let force = matches!(v, JournalEntry::Snapshot(_));
-            self.batch.push(v);
-            self.metrics.journal_queue_len.dec();
-            force
+    pub(crate) fn handle(&mut self, req: Option<JournalWriteRequest>) -> FsResult<()> {
+        let force = if let Some(req) = req {
+            match req {
+                JournalWriteRequest::Legacy(entry) => {
+                    let force = matches!(entry, JournalEntry::Snapshot(_));
+                    self.batch.push_legacy(entry);
+                    self.metrics.journal_queue_len.dec();
+                    force
+                }
+                JournalWriteRequest::Metadata(commands, ack) => {
+                    for command in commands {
+                        self.batch.push_metadata(command);
+                    }
+                    self.metrics.journal_queue_len.dec();
+                    let res = self.flush_pending();
+                    let err = res.as_ref().err().map(ToString::to_string);
+                    if ack.send(res).is_err() {
+                        log::warn!("metadata journal receiver dropped response");
+                    }
+                    if let Some(err) = err {
+                        return err_box!("{}", err);
+                    }
+                    return Ok(());
+                }
+            }
         } else {
             false
         };
@@ -114,7 +133,7 @@ impl SenderTask {
 
         let spend = TimeSpent::new();
 
-        let bytes = SerdeUtils::serialize(&self.batch)?;
+        let bytes = crate::master::journal::JournalEnvelope::encode(self.batch.clone())?;
         self.client.block_on_send_propose(bytes)?;
 
         self.metrics.journal_flush_count.inc();

--- a/curvine-master/src/master/journal/sender_task.rs
+++ b/curvine-master/src/master/journal/sender_task.rs
@@ -16,7 +16,7 @@ use super::journal_writer::JournalWriteRequest;
 use crate::master::journal::{JournalCommandBatch, JournalEntry};
 use crate::master::{Master, MasterMetrics};
 use curvine_config::JournalConf;
-use curvine_core_error::CommonResult;
+use curvine_core_error::{err_box, CommonResult};
 use curvine_error::FsResult;
 use curvine_raft::raft::RaftClient;
 use curvine_runtime::common::{LocalTime, TimeSpent};

--- a/curvine-master/src/master/journal/sender_task.rs
+++ b/curvine-master/src/master/journal/sender_task.rs
@@ -133,7 +133,7 @@ impl SenderTask {
 
         let spend = TimeSpent::new();
 
-        let bytes = crate::master::journal::JournalEnvelope::encode(self.batch.clone())?;
+        let bytes = crate::master::journal::JournalEnvelope::encode(&self.batch)?;
         self.client.block_on_send_propose(bytes)?;
 
         self.metrics.journal_flush_count.inc();

--- a/curvine-master/src/master/journal/tests/journal_loader_test.rs
+++ b/curvine-master/src/master/journal/tests/journal_loader_test.rs
@@ -43,7 +43,7 @@ fn metadata_batch_is_applied_after_versioned_journal_upgrade() -> CommonResult<(
     let entry = Entry {
         term: 1,
         index: 1,
-        data: JournalEnvelope::encode(batch)?,
+        data: JournalEnvelope::encode(&batch)?,
         ..Default::default()
     };
 

--- a/curvine-master/src/master/meta/fs_dir.rs
+++ b/curvine-master/src/master/meta/fs_dir.rs
@@ -505,6 +505,8 @@ impl FsDir {
             dst: dst_inp.path().to_string(),
             mtime,
             flags: flags.value(),
+            src_inode_id: 0,
+            dst_inode_id: 0,
         })
     }
 

--- a/curvine-master/src/master/meta/fs_dir.rs
+++ b/curvine-master/src/master/meta/fs_dir.rs
@@ -14,7 +14,7 @@
 
 use crate::master::fs::{BlockInodeState, DeleteResult};
 use crate::master::journal::{
-    CreateFileEntry, JournalEntry, JournalWriter, MetadataCommand, MkdirEntry,
+    CreateFileEntry, JournalEntry, JournalWriter, MetadataCommand, MkdirEntry, RenameEntry,
 };
 use crate::master::meta::inode::ttl::TtlBucketList;
 use crate::master::meta::inode::InodeView::{Dir, File, FileEntry};
@@ -473,6 +473,39 @@ impl FsDir {
             exchange_pre_swap_ids,
         )?;
         Ok(res)
+    }
+
+    pub(crate) fn prepare_rename_command(
+        &self,
+        src_inp: &InodePath,
+        dst_inp: &InodePath,
+        mtime: i64,
+        flags: RenameFlags,
+    ) -> FsResult<RenameEntry> {
+        if src_inp.get_last_inode().is_none() {
+            return err_ext!(FsError::file_not_found(src_inp.path()));
+        }
+        if dst_inp.get_last_inode().is_some() {
+            return err_box!(
+                "committed rename currently requires an absent destination: {}",
+                dst_inp.path()
+            );
+        }
+        if flags.exchange_mode() {
+            return err_box!("Rename failed, because exchange mode is not supported");
+        }
+        if dst_inp.get_inode(-2).is_none() {
+            return err_box!("Parent {} does not exist", dst_inp.get_parent_path());
+        }
+
+        Ok(RenameEntry {
+            op_id: self.next_op_id(),
+            rpc_id: 0,
+            src: src_inp.path().to_string(),
+            dst: dst_inp.path().to_string(),
+            mtime,
+            flags: flags.value(),
+        })
     }
 
     pub(crate) fn unprotected_rename(

--- a/curvine-server/tests/journal_test.rs
+++ b/curvine-server/tests/journal_test.rs
@@ -239,7 +239,7 @@ fn replay_accepts_versioned_legacy_journal_batch() -> CommonResult<()> {
 }
 
 #[test]
-fn active_namespace_creation_replicates_without_legacy_writer_queue() -> CommonResult<()> {
+fn active_namespace_changes_replicate_without_legacy_writer_queue() -> CommonResult<()> {
     Master::init_test_metrics();
 
     let port1 = NetUtils::hold_available_port();
@@ -289,6 +289,7 @@ fn active_namespace_creation_replicates_without_legacy_writer_queue() -> CommonR
 
     active.mkdir("/committed-dir", false)?;
     active.create("/committed-file", false)?;
+    active.rename("/committed-file", "/renamed-file", RenameFlags::empty())?;
     let parent_opts = MkdirOptsBuilder::new()
         .group("parent-group".to_string())
         .mode(0o2775)
@@ -308,7 +309,7 @@ fn active_namespace_creation_replicates_without_legacy_writer_queue() -> CommonR
     assert!(delta
         .entries
         .iter()
-        .any(|entry| entry.path == "/committed-file"));
+        .any(|entry| entry.path == "/renamed-file"));
     assert_eq!(
         active.file_status("/setgid-parent/child")?.group,
         "parent-group"
@@ -317,15 +318,16 @@ fn active_namespace_creation_replicates_without_legacy_writer_queue() -> CommonR
     assert!(
         !legacy_entries.iter().any(|entry| matches!(
             entry,
-            JournalEntry::Mkdir(_) | JournalEntry::CreateFile(_)
+            JournalEntry::Mkdir(_) | JournalEntry::CreateFile(_) | JournalEntry::Rename(_)
         )),
-        "active namespace creation must not emit legacy local-first namespace journal entries: {legacy_entries:?}"
+        "active namespace changes must not emit legacy local-first namespace journal entries: {legacy_entries:?}"
     );
 
     let deadline = std::time::Instant::now() + Duration::from_secs(60);
     loop {
         if standby.file_status("/committed-dir").is_ok()
-            && standby.file_status("/committed-file").is_ok()
+            && standby.file_status("/renamed-file").is_ok()
+            && standby.file_status("/committed-file").is_err()
             && standby.file_status("/setgid-parent/child").is_ok()
         {
             assert_eq!(
@@ -335,7 +337,7 @@ fn active_namespace_creation_replicates_without_legacy_writer_queue() -> CommonR
             return Ok(());
         }
         if std::time::Instant::now() >= deadline {
-            return err_box!("standby did not apply committed namespace creation");
+            return err_box!("standby did not apply committed namespace changes");
         }
         thread::sleep(Duration::from_millis(100));
     }

--- a/curvine-server/tests/journal_test.rs
+++ b/curvine-server/tests/journal_test.rs
@@ -227,7 +227,7 @@ fn replay_accepts_versioned_legacy_journal_batch() -> CommonResult<()> {
     let raft_entry = Entry {
         term: 1,
         index: 1,
-        data: JournalEnvelope::encode(batch)?,
+        data: JournalEnvelope::encode(&batch)?,
         ..Default::default()
     };
 
@@ -321,6 +321,23 @@ fn active_namespace_changes_replicate_without_legacy_writer_queue() -> CommonRes
             JournalEntry::Mkdir(_) | JournalEntry::CreateFile(_) | JournalEntry::Rename(_)
         )),
         "active namespace changes must not emit legacy local-first namespace journal entries: {legacy_entries:?}"
+    );
+
+    active.create("/exchange-a", false)?;
+    active.create("/exchange-b", false)?;
+    let exchange_a = active.file_status("/exchange-a")?.id;
+    let exchange_b = active.file_status("/exchange-b")?.id;
+    active.rename("/exchange-a", "/exchange-b", RenameFlags::EXCHANGE)?;
+    assert_eq!(active.file_status("/exchange-a")?.id, exchange_b);
+    assert_eq!(active.file_status("/exchange-b")?.id, exchange_a);
+    assert!(
+        active
+            .fs_dir
+            .read()
+            .take_entries()
+            .iter()
+            .any(|entry| matches!(entry, JournalEntry::Rename(_))),
+        "active EXCHANGE rename must fall back to the legacy journal path"
     );
 
     let deadline = std::time::Instant::now() + Duration::from_secs(60);


### PR DESCRIPTION
## Summary
Commit active-Master rename through the versioned Raft journal before applying it to the namespace.

## Issue/Design
This is the rename-specific slice of #1552. Rename touches both source and destination and must not be applied locally before its ordered command is committed. The writer now carries a synchronous acknowledgement for committed metadata commands, so the client returns only after the batch reaches Raft.

## Changes
| Area | Change |
| --- | --- |
| Rename path | Prepare a deterministic rename command and commit it before applying the namespace mutation. |
| Journal sender | Support synchronous metadata-command requests while preserving batched legacy journal entries. |
| Replay | Apply committed rename locally on all voters, then replay UFS only on the active Master. |
| Test | Extend the two-Master integration test to verify rename replication and absence of legacy local-first entries. |

## Test verified
- `cargo fmt --check -- curvine-master/src/master/fs/master_filesystem.rs curvine-master/src/master/journal/entry.rs curvine-master/src/master/journal/journal_loader.rs curvine-master/src/master/journal/journal_writer.rs curvine-master/src/master/journal/sender_task.rs curvine-master/src/master/meta/fs_dir.rs curvine-server/tests/journal_test.rs`
- `CARGO_TARGET_DIR=/mnt/data/curvine/.build/pr-1552-split/rename-commit cargo test -q -p curvine-server --test journal_test`
- `CARGO_TARGET_DIR=/mnt/data/curvine/.build/pr-1552-split/rename-commit cargo clippy -q -p curvine-server --test journal_test -- -D warnings`
- `git diff --check`

## Dependencies
Stacked on #1559. Merge after #1559.