### PR TITLE
fix(master): commit attrs and empty deletes before apply

### DIFF
--- a/curvine-master/src/master/fs/master_filesystem.rs
+++ b/curvine-master/src/master/fs/master_filesystem.rs
@@ -303,8 +303,15 @@ impl MasterFilesystem {
     }
 
     pub fn delete<T: AsRef<str>>(&self, path: T, recursive: bool) -> FsResult<bool> {
+        let path = path.as_ref();
+        if self.master_monitor.is_active() {
+            if let Some(result) = self.delete_committed(path)? {
+                return Ok(result);
+            }
+        }
+
         let mut fs_dir = self.fs_dir.write();
-        let inp = Self::resolve_path(&fs_dir, path.as_ref())?;
+        let inp = Self::resolve_path(&fs_dir, path)?;
 
         let delete_result = fs_dir.delete(&inp, recursive)?;
 
@@ -312,6 +319,25 @@ impl MasterFilesystem {
         worker_manager.remove_blocks(&delete_result);
 
         Ok(true)
+    }
+
+    fn delete_committed(&self, path: &str) -> FsResult<Option<bool>> {
+        let (command, writer) = {
+            let fs_dir = self.fs_dir.write();
+            let inp = Self::resolve_path(&fs_dir, path)?;
+            let Some(entry) =
+                fs_dir.prepare_empty_dir_delete_command(&inp, LocalTime::mills() as i64)?
+            else {
+                return Ok(None);
+            };
+            (
+                MetadataCommand::Delete(entry),
+                fs_dir.journal_writer.clone(),
+            )
+        };
+
+        writer.commit_metadata_commands(vec![command])?;
+        Ok(Some(true))
     }
 
     pub fn free<T: AsRef<str>>(&self, path: T, recursive: bool) -> FsResult<FreeResult> {

--- a/curvine-master/src/master/fs/master_filesystem.rs
+++ b/curvine-master/src/master/fs/master_filesystem.rs
@@ -1746,9 +1746,29 @@ impl MasterFilesystem {
     }
 
     pub fn set_attr<T: AsRef<str>>(&self, path: T, opts: SetAttrOpts) -> FsResult<FileStatus> {
+        let path = path.as_ref();
+        if self.master_monitor.is_active() {
+            return self.set_attr_committed(path, opts);
+        }
+
         let mut fs_dir = self.fs_dir.write();
-        let inp = Self::resolve_path(&fs_dir, path.as_ref())?;
+        let inp = Self::resolve_path(&fs_dir, path)?;
         fs_dir.set_attr(inp, opts)
+    }
+
+    fn set_attr_committed(&self, path: &str, opts: SetAttrOpts) -> FsResult<FileStatus> {
+        let (command, writer) = {
+            let fs_dir = self.fs_dir.write();
+            let inp = Self::resolve_path(&fs_dir, path)?;
+            let entry = fs_dir.prepare_set_attr_command(&inp, opts)?;
+            (
+                MetadataCommand::SetAttr(entry),
+                fs_dir.journal_writer.clone(),
+            )
+        };
+
+        writer.commit_metadata_commands(vec![command])?;
+        self.file_status(path)
     }
 
     pub fn symlink<T: AsRef<str>>(

--- a/curvine-master/src/master/fs/master_filesystem.rs
+++ b/curvine-master/src/master/fs/master_filesystem.rs
@@ -31,7 +31,7 @@ use curvine_runtime::common::LocalTime;
 use curvine_runtime::runtime::GroupExecutor;
 use curvine_runtime::sync::ArcRwLock;
 use log::{error, info, warn};
-use parking_lot::Mutex;
+use parking_lot::{Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 
@@ -71,6 +71,9 @@ pub struct MasterFilesystem {
     pub worker_manager: SyncWorkerManager,
     pub master_monitor: MasterMonitor,
     pub conf: Arc<MasterConf>,
+    // Commit-first metadata changes hold the write side until local Raft apply
+    // completes. Legacy local-first writers use the shared side.
+    metadata_admission: Arc<RwLock<()>>,
     full_block_reports: Arc<Mutex<HashMap<u32, FullBlockReportState>>>,
     full_block_reconciles: Arc<Mutex<HashMap<u32, FullBlockReconcileState>>>,
     full_block_reconcile_executor: Arc<GroupExecutor>,
@@ -170,6 +173,7 @@ impl MasterFilesystem {
             worker_manager,
             master_monitor,
             conf: Arc::new(conf.master.clone()),
+            metadata_admission: Default::default(),
             full_block_reports: Default::default(),
             full_block_reconciles: Default::default(),
             full_block_reconcile_executor: Arc::new(GroupExecutor::new(
@@ -181,11 +185,13 @@ impl MasterFilesystem {
     }
 
     pub fn with_js(conf: &ClusterConf, js: &JournalSystem) -> Self {
+        let fs = js.fs();
         Self {
-            fs_dir: js.fs().fs_dir.clone(),
+            fs_dir: fs.fs_dir.clone(),
             worker_manager: js.worker_manager(),
             master_monitor: js.master_monitor(),
             conf: Arc::new(conf.master.clone()),
+            metadata_admission: fs.metadata_admission.clone(),
             full_block_reports: Default::default(),
             full_block_reconciles: Default::default(),
             full_block_reconcile_executor: Arc::new(GroupExecutor::new(
@@ -194,6 +200,18 @@ impl MasterFilesystem {
                 FULL_BLOCK_RECONCILE_QUEUE_SIZE,
             )),
         }
+    }
+
+    fn active_metadata_write_guard(&self) -> Option<RwLockWriteGuard<'_, ()>> {
+        self.master_monitor
+            .is_active()
+            .then(|| self.metadata_admission.write())
+    }
+
+    fn active_metadata_read_guard(&self) -> Option<RwLockReadGuard<'_, ()>> {
+        self.master_monitor
+            .is_active()
+            .then(|| self.metadata_admission.read())
     }
 
     pub fn check_parent(path: &InodePath) -> FsResult<()> {
@@ -223,10 +241,11 @@ impl MasterFilesystem {
 
     pub fn mkdir_with_opts<T: AsRef<str>>(&self, path: T, opts: MkdirOpts) -> FsResult<FileStatus> {
         let path = path.as_ref();
-        if self.master_monitor.is_active() {
+        if let Some(_admission) = self.active_metadata_write_guard() {
             return self.mkdir_with_opts_committed(path, opts);
         }
 
+        let _admission = self.active_metadata_read_guard();
         let mut fs_dir = self.fs_dir.write();
         let inp = Self::resolve_path(&fs_dir, path)?;
 
@@ -264,7 +283,7 @@ impl MasterFilesystem {
 
     fn mkdir_with_opts_committed(&self, path: &str, opts: MkdirOpts) -> FsResult<FileStatus> {
         let (commands, writer) = {
-            let fs_dir = self.fs_dir.write();
+            let fs_dir = self.fs_dir.read();
             let inp = Self::resolve_path(&fs_dir, path)?;
 
             if inp.is_root() {
@@ -304,12 +323,18 @@ impl MasterFilesystem {
 
     pub fn delete<T: AsRef<str>>(&self, path: T, recursive: bool) -> FsResult<bool> {
         let path = path.as_ref();
-        if self.master_monitor.is_active() {
+        let admission = self.active_metadata_write_guard();
+        if admission.is_some() {
             if let Some(result) = self.delete_committed(path)? {
                 return Ok(result);
             }
         }
 
+        let _legacy_admission = if admission.is_none() {
+            self.active_metadata_read_guard()
+        } else {
+            None
+        };
         let mut fs_dir = self.fs_dir.write();
         let inp = Self::resolve_path(&fs_dir, path)?;
 
@@ -323,7 +348,7 @@ impl MasterFilesystem {
 
     fn delete_committed(&self, path: &str) -> FsResult<Option<bool>> {
         let (command, writer) = {
-            let fs_dir = self.fs_dir.write();
+            let fs_dir = self.fs_dir.read();
             let inp = Self::resolve_path(&fs_dir, path)?;
             let Some(entry) =
                 fs_dir.prepare_empty_dir_delete_command(&inp, LocalTime::mills() as i64)?
@@ -360,12 +385,22 @@ impl MasterFilesystem {
         let src = src.as_ref();
         let dst = dst.as_ref();
 
-        if self.master_monitor.is_active() && !flags.exchange_mode() {
+        let admission = if flags.exchange_mode() {
+            None
+        } else {
+            self.active_metadata_write_guard()
+        };
+        if admission.is_some() {
             if let Some(result) = self.rename_committed(src, dst, flags)? {
                 return Ok(result);
             }
         }
 
+        let _legacy_admission = if admission.is_none() {
+            self.active_metadata_read_guard()
+        } else {
+            None
+        };
         let mut fs_dir = self.fs_dir.write();
         let src_inp = Self::resolve_path(&fs_dir, src)?;
         let dst_inp = Self::resolve_path(&fs_dir, dst)?;
@@ -410,7 +445,7 @@ impl MasterFilesystem {
 
     fn rename_committed(&self, src: &str, dst: &str, flags: RenameFlags) -> FsResult<Option<bool>> {
         let (command, writer) = {
-            let fs_dir = self.fs_dir.write();
+            let fs_dir = self.fs_dir.read();
             let src_inp = Self::resolve_path(&fs_dir, src)?;
             let dst_inp = Self::resolve_path(&fs_dir, dst)?;
 
@@ -498,10 +533,11 @@ impl MasterFilesystem {
             );
         }
 
-        if self.master_monitor.is_active() {
+        if let Some(_admission) = self.active_metadata_write_guard() {
             return self.create_with_opts_committed(path, opts, flags);
         }
 
+        let _admission = self.active_metadata_read_guard();
         let mut fs_dir = self.fs_dir.write();
         let inp = Self::resolve_path(&fs_dir, path)?;
 
@@ -1773,10 +1809,11 @@ impl MasterFilesystem {
 
     pub fn set_attr<T: AsRef<str>>(&self, path: T, opts: SetAttrOpts) -> FsResult<FileStatus> {
         let path = path.as_ref();
-        if self.master_monitor.is_active() {
+        if let Some(_admission) = self.active_metadata_write_guard() {
             return self.set_attr_committed(path, opts);
         }
 
+        let _admission = self.active_metadata_read_guard();
         let mut fs_dir = self.fs_dir.write();
         let inp = Self::resolve_path(&fs_dir, path)?;
         fs_dir.set_attr(inp, opts)
@@ -1784,7 +1821,7 @@ impl MasterFilesystem {
 
     fn set_attr_committed(&self, path: &str, opts: SetAttrOpts) -> FsResult<FileStatus> {
         let (command, writer) = {
-            let fs_dir = self.fs_dir.write();
+            let fs_dir = self.fs_dir.read();
             let inp = Self::resolve_path(&fs_dir, path)?;
             let entry = fs_dir.prepare_set_attr_command(&inp, opts)?;
             (
@@ -1816,6 +1853,7 @@ impl MasterFilesystem {
         owner: Option<String>,
         group: Option<String>,
     ) -> FsResult<()> {
+        let _admission = self.active_metadata_read_guard();
         let mut fs_dir = self.fs_dir.write();
         let target = target.as_ref().to_string();
         let link = Self::resolve_path(&fs_dir, link.as_ref())?;
@@ -1823,6 +1861,7 @@ impl MasterFilesystem {
     }
 
     pub fn link<T: AsRef<str>>(&self, src_path: T, dst_path: T) -> FsResult<()> {
+        let _admission = self.active_metadata_read_guard();
         let mut fs_dir = self.fs_dir.write();
         let src_path = Self::resolve_path(&fs_dir, src_path.as_ref())?;
         let dst_path = Self::resolve_path(&fs_dir, dst_path.as_ref())?;

--- a/curvine-master/src/master/journal/entry.rs
+++ b/curvine-master/src/master/journal/entry.rs
@@ -658,6 +658,7 @@ pub enum MetadataCommand {
     Mkdir(MkdirEntry),
     CreateFile(CreateFileEntry),
     Rename(RenameEntry),
+    SetAttr(SetAttrEntry),
 }
 
 impl MetadataCommand {
@@ -681,6 +682,7 @@ impl MetadataCommand {
             MetadataCommand::Mkdir(entry) => entry.op_id,
             MetadataCommand::CreateFile(entry) => entry.op_id,
             MetadataCommand::Rename(entry) => entry.op_id,
+            MetadataCommand::SetAttr(entry) => entry.op_id,
         }
     }
 
@@ -689,6 +691,7 @@ impl MetadataCommand {
             MetadataCommand::Mkdir(entry) => entry.rpc_id,
             MetadataCommand::CreateFile(entry) => entry.rpc_id,
             MetadataCommand::Rename(entry) => entry.rpc_id,
+            MetadataCommand::SetAttr(entry) => entry.rpc_id,
         }
     }
 
@@ -697,6 +700,7 @@ impl MetadataCommand {
             MetadataCommand::Mkdir(entry) => Some(entry.dir.id),
             MetadataCommand::CreateFile(entry) => Some(entry.file.id),
             MetadataCommand::Rename(_) => None,
+            MetadataCommand::SetAttr(_) => None,
         }
     }
 

--- a/curvine-master/src/master/journal/entry.rs
+++ b/curvine-master/src/master/journal/entry.rs
@@ -675,6 +675,12 @@ impl MetadataCommand {
                 CvMetadataChange::subtree(entry.op_id, &entry.src),
                 CvMetadataChange::subtree(entry.op_id, &entry.dst),
             ],
+            MetadataCommand::SetAttr(entry) => {
+                vec![CvMetadataChange::single(entry.op_id, &entry.path)]
+            }
+            MetadataCommand::Delete(entry) => {
+                vec![CvMetadataChange::subtree(entry.op_id, &entry.path)]
+            }
         }
     }
 

--- a/curvine-master/src/master/journal/entry.rs
+++ b/curvine-master/src/master/journal/entry.rs
@@ -659,6 +659,7 @@ pub enum MetadataCommand {
     CreateFile(CreateFileEntry),
     Rename(RenameEntry),
     SetAttr(SetAttrEntry),
+    Delete(DeleteEntry),
 }
 
 impl MetadataCommand {
@@ -683,6 +684,7 @@ impl MetadataCommand {
             MetadataCommand::CreateFile(entry) => entry.op_id,
             MetadataCommand::Rename(entry) => entry.op_id,
             MetadataCommand::SetAttr(entry) => entry.op_id,
+            MetadataCommand::Delete(entry) => entry.op_id,
         }
     }
 
@@ -692,6 +694,7 @@ impl MetadataCommand {
             MetadataCommand::CreateFile(entry) => entry.rpc_id,
             MetadataCommand::Rename(entry) => entry.rpc_id,
             MetadataCommand::SetAttr(entry) => entry.rpc_id,
+            MetadataCommand::Delete(entry) => entry.rpc_id,
         }
     }
 
@@ -701,6 +704,7 @@ impl MetadataCommand {
             MetadataCommand::CreateFile(entry) => Some(entry.file.id),
             MetadataCommand::Rename(_) => None,
             MetadataCommand::SetAttr(_) => None,
+            MetadataCommand::Delete(_) => None,
         }
     }
 

--- a/curvine-master/src/master/journal/journal_loader.rs
+++ b/curvine-master/src/master/journal/journal_loader.rs
@@ -688,6 +688,8 @@ impl JournalLoader {
             }
             MetadataCommand::CreateFile(entry) => self.create_file(entry.clone()),
             MetadataCommand::Rename(entry) => self.rename(entry.clone()),
+            MetadataCommand::SetAttr(entry) => self.set_attr(entry.clone()),
+            MetadataCommand::Delete(entry) => self.delete(entry.clone()),
         }
     }
 
@@ -708,17 +710,8 @@ impl JournalLoader {
                     .apply_entry(&JournalEntry::Rename(entry.clone()))
                     .await
             }
-            MetadataCommand::SetAttr(entry) => self.set_attr(entry),
-            MetadataCommand::Delete(entry) => {
-                self.delete(entry.clone())?;
-                if is_leader {
-                    self.ufs_loader
-                        .apply_entry(&JournalEntry::Delete(entry))
-                        .await
-                } else {
-                    Ok(())
-                }
-            }
+            MetadataCommand::SetAttr(_) => Ok(()),
+            MetadataCommand::Delete(entry) => self.ufs_loader.delete(entry).await,
         }
     }
 

--- a/curvine-master/src/master/journal/journal_loader.rs
+++ b/curvine-master/src/master/journal/journal_loader.rs
@@ -709,6 +709,16 @@ impl JournalLoader {
                     .await
             }
             MetadataCommand::SetAttr(entry) => self.set_attr(entry),
+            MetadataCommand::Delete(entry) => {
+                self.delete(entry.clone())?;
+                if is_leader {
+                    self.ufs_loader
+                        .apply_entry(&JournalEntry::Delete(entry))
+                        .await
+                } else {
+                    Ok(())
+                }
+            }
         }
     }
 

--- a/curvine-master/src/master/journal/journal_loader.rs
+++ b/curvine-master/src/master/journal/journal_loader.rs
@@ -708,6 +708,7 @@ impl JournalLoader {
                     .apply_entry(&JournalEntry::Rename(entry.clone()))
                     .await
             }
+            MetadataCommand::SetAttr(entry) => self.set_attr(entry),
         }
     }
 

--- a/curvine-master/src/master/meta/fs_dir.rs
+++ b/curvine-master/src/master/meta/fs_dir.rs
@@ -15,6 +15,7 @@
 use crate::master::fs::{BlockInodeState, DeleteResult};
 use crate::master::journal::{
     CreateFileEntry, JournalEntry, JournalWriter, MetadataCommand, MkdirEntry, RenameEntry,
+    SetAttrEntry,
 };
 use crate::master::meta::inode::ttl::TtlBucketList;
 use crate::master::meta::inode::InodeView::{Dir, File, FileEntry};
@@ -1214,6 +1215,36 @@ impl FsDir {
             None => return err_ext!(FsError::file_not_found(inp.path())),
         };
 
+        opts = Self::normalize_set_attr_opts(opts);
+        self.unprotected_set_attr(inode.clone(), opts.clone())?;
+        self.journal_writer.log_set_attr(self, &inp, opts)?;
+        Ok(inode.to_file_status(inp.path())?)
+    }
+
+    pub(crate) fn prepare_set_attr_command(
+        &self,
+        inp: &InodePath,
+        mut opts: SetAttrOpts,
+    ) -> FsResult<SetAttrEntry> {
+        let inode = match inp.get_last_inode() {
+            Some(v) => v,
+            None => return err_ext!(FsError::file_not_found(inp.path())),
+        };
+        if inode.is_file_entry() {
+            return err_box!("set_attr is not supported on unresolved FileEntry inodes; resolve/load the full inode before calling set_attr");
+        }
+
+        opts = Self::normalize_set_attr_opts(opts);
+
+        Ok(SetAttrEntry {
+            op_id: self.next_op_id(),
+            rpc_id: 0,
+            path: inp.path().to_string(),
+            opts,
+        })
+    }
+
+    fn normalize_set_attr_opts(mut opts: SetAttrOpts) -> SetAttrOpts {
         // Internal metadata is master-owned. Persist the operation timestamp in the
         // journal so replay restores it without changing the bincode inode layout.
         opts.add_x_attr.remove(INTERNAL_CTIME_XATTR);
@@ -1223,9 +1254,7 @@ impl FsDir {
             INTERNAL_CTIME_XATTR.to_string(),
             ctime.to_le_bytes().to_vec(),
         );
-        self.unprotected_set_attr(inode.clone(), opts.clone())?;
-        self.journal_writer.log_set_attr(self, &inp, opts)?;
-        Ok(inode.to_file_status(inp.path())?)
+        opts
     }
 
     pub fn unprotected_set_attr(&mut self, inode: InodePtr, opts: SetAttrOpts) -> FsResult<()> {

--- a/curvine-master/src/master/meta/fs_dir.rs
+++ b/curvine-master/src/master/meta/fs_dir.rs
@@ -14,8 +14,8 @@
 
 use crate::master::fs::{BlockInodeState, DeleteResult};
 use crate::master::journal::{
-    CreateFileEntry, JournalEntry, JournalWriter, MetadataCommand, MkdirEntry, RenameEntry,
-    SetAttrEntry,
+    CreateFileEntry, DeleteEntry, JournalEntry, JournalWriter, MetadataCommand, MkdirEntry,
+    RenameEntry, SetAttrEntry,
 };
 use crate::master::meta::inode::ttl::TtlBucketList;
 use crate::master::meta::inode::InodeView::{Dir, File, FileEntry};
@@ -321,6 +321,31 @@ impl FsDir {
             .log_delete(self, inp.path(), op_ms as i64)?;
 
         Ok(del_res)
+    }
+
+    pub(crate) fn prepare_empty_dir_delete_command(
+        &self,
+        inp: &InodePath,
+        mtime: i64,
+    ) -> FsResult<Option<DeleteEntry>> {
+        if inp.is_root() {
+            return err_box!("The root is not allowed to be deleted");
+        }
+
+        if inp.is_empty() || inp.get_last_inode().is_none() {
+            return err_ext!(FsError::file_not_found(inp.path()));
+        }
+
+        if !inp.is_empty_dir() {
+            return Ok(None);
+        }
+
+        Ok(Some(DeleteEntry {
+            op_id: self.next_op_id(),
+            rpc_id: 0,
+            path: inp.path().to_string(),
+            mtime,
+        }))
     }
 
     pub(crate) fn unprotected_delete(

--- a/curvine-server/tests/journal_test.rs
+++ b/curvine-server/tests/journal_test.rs
@@ -289,6 +289,7 @@ fn active_namespace_changes_replicate_without_legacy_writer_queue() -> CommonRes
     };
 
     active.mkdir("/committed-dir", false)?;
+    active.mkdir("/deleted-dir", false)?;
     active.create("/committed-file", false)?;
     active.rename("/committed-file", "/renamed-file", RenameFlags::empty())?;
     let parent_opts = MkdirOptsBuilder::new()
@@ -320,6 +321,7 @@ fn active_namespace_changes_replicate_without_legacy_writer_queue() -> CommonRes
         SetAttrOptsBuilder::new().owner("committed-owner").build(),
     )?;
     assert_eq!(status.owner, "committed-owner");
+    active.delete("/deleted-dir", false)?;
     let legacy_entries = active.fs_dir.read().take_entries();
     assert!(
         !legacy_entries.iter().any(|entry| matches!(
@@ -328,6 +330,7 @@ fn active_namespace_changes_replicate_without_legacy_writer_queue() -> CommonRes
                 | JournalEntry::CreateFile(_)
                 | JournalEntry::Rename(_)
                 | JournalEntry::SetAttr(_)
+                | JournalEntry::Delete(_)
         )),
         "active namespace changes must not emit legacy local-first namespace journal entries: {legacy_entries:?}"
     );
@@ -354,6 +357,7 @@ fn active_namespace_changes_replicate_without_legacy_writer_queue() -> CommonRes
         if standby.file_status("/committed-dir").is_ok()
             && standby.file_status("/committed-file").is_err()
             && standby.file_status("/setgid-parent/child").is_ok()
+            && standby.file_status("/deleted-dir").is_err()
         {
             assert_eq!(
                 standby.file_status("/setgid-parent/child")?.group,

--- a/curvine-server/tests/journal_test.rs
+++ b/curvine-server/tests/journal_test.rs
@@ -37,7 +37,7 @@ use log::info;
 use raft::eraftpb::Entry;
 use raft::StateRole;
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, Barrier};
 use std::thread;
 use std::time::Duration;
 
@@ -288,6 +288,35 @@ fn active_namespace_changes_replicate_without_legacy_writer_queue() -> CommonRes
         thread::sleep(Duration::from_millis(100));
     };
 
+    let barrier = Arc::new(Barrier::new(2));
+    let mut handles = vec![];
+    for _ in 0..2 {
+        let fs = active.clone();
+        let barrier = barrier.clone();
+        handles.push(thread::spawn(move || {
+            barrier.wait();
+            fs.create_with_opts(
+                "/exclusive-race",
+                CreateFileOpts::with_create(false),
+                OpenFlags::new_create().set_exclusive(true),
+            )
+            .map(|_| ())
+        }));
+    }
+    let mut successes = 0;
+    let mut failures = 0;
+    for handle in handles {
+        match handle
+            .join()
+            .expect("exclusive create thread must not panic")
+        {
+            Ok(()) => successes += 1,
+            Err(_) => failures += 1,
+        }
+    }
+    assert_eq!(successes, 1);
+    assert_eq!(failures, 1);
+
     active.mkdir("/committed-dir", false)?;
     active.mkdir("/deleted-dir", false)?;
     active.create("/committed-file", false)?;
@@ -302,16 +331,6 @@ fn active_namespace_changes_replicate_without_legacy_writer_queue() -> CommonRes
         .build();
     active.create_with_opts("/setgid-parent/child", file_opts, OpenFlags::new_create())?;
 
-    let delta = active.cv_metadata_delta_page(0, None, None, 32)?;
-    assert!(!delta.full_snapshot_required);
-    assert!(delta
-        .entries
-        .iter()
-        .any(|entry| entry.path == "/committed-dir"));
-    assert!(delta
-        .entries
-        .iter()
-        .any(|entry| entry.path == "/renamed-file"));
     assert_eq!(
         active.file_status("/setgid-parent/child")?.group,
         "parent-group"
@@ -322,6 +341,26 @@ fn active_namespace_changes_replicate_without_legacy_writer_queue() -> CommonRes
     )?;
     assert_eq!(status.owner, "committed-owner");
     active.delete("/deleted-dir", false)?;
+
+    let delta = active.cv_metadata_delta_page(0, None, None, 32)?;
+    assert!(!delta.full_snapshot_required);
+    assert!(delta
+        .entries
+        .iter()
+        .any(|entry| entry.path == "/committed-dir"));
+    assert_eq!(
+        delta
+            .entries
+            .iter()
+            .find(|entry| entry.path == "/renamed-file")
+            .and_then(|entry| entry.entry.as_ref())
+            .map(|entry| entry.status.owner.as_str()),
+        Some("committed-owner")
+    );
+    assert!(delta
+        .entries
+        .iter()
+        .any(|entry| entry.path == "/deleted-dir" && entry.entry.is_none()));
     let legacy_entries = active.fs_dir.read().take_entries();
     assert!(
         !legacy_entries.iter().any(|entry| matches!(
@@ -356,6 +395,7 @@ fn active_namespace_changes_replicate_without_legacy_writer_queue() -> CommonRes
     loop {
         if standby.file_status("/committed-dir").is_ok()
             && standby.file_status("/committed-file").is_err()
+            && standby.file_status("/exclusive-race").is_ok()
             && standby.file_status("/setgid-parent/child").is_ok()
             && standby.file_status("/deleted-dir").is_err()
         {

--- a/curvine-server/tests/journal_test.rs
+++ b/curvine-server/tests/journal_test.rs
@@ -17,7 +17,8 @@ use curvine_core_error::{err_box, CommonResult};
 use curvine_fs_api::CurvineURI;
 use curvine_model::{
     BlockLocation, ClientAddress, CommitBlock, CreateFileOpts, CreateFileOptsBuilder,
-    MkdirOptsBuilder, MountOptions, OpenFlags, RenameFlags, WorkerInfo, WriteType,
+    MkdirOptsBuilder, MountOptions, OpenFlags, RenameFlags, SetAttrOptsBuilder, WorkerInfo,
+    WriteType,
 };
 use curvine_net::net::NetUtils;
 use curvine_raft::proto::raft::{AppliedIndex, FsmState, SnapshotData, SnapshotFileList};
@@ -314,11 +315,19 @@ fn active_namespace_changes_replicate_without_legacy_writer_queue() -> CommonRes
         active.file_status("/setgid-parent/child")?.group,
         "parent-group"
     );
+    let status = active.set_attr(
+        "/renamed-file",
+        SetAttrOptsBuilder::new().owner("committed-owner").build(),
+    )?;
+    assert_eq!(status.owner, "committed-owner");
     let legacy_entries = active.fs_dir.read().take_entries();
     assert!(
         !legacy_entries.iter().any(|entry| matches!(
             entry,
-            JournalEntry::Mkdir(_) | JournalEntry::CreateFile(_) | JournalEntry::Rename(_)
+            JournalEntry::Mkdir(_)
+                | JournalEntry::CreateFile(_)
+                | JournalEntry::Rename(_)
+                | JournalEntry::SetAttr(_)
         )),
         "active namespace changes must not emit legacy local-first namespace journal entries: {legacy_entries:?}"
     );
@@ -343,7 +352,6 @@ fn active_namespace_changes_replicate_without_legacy_writer_queue() -> CommonRes
     let deadline = std::time::Instant::now() + Duration::from_secs(60);
     loop {
         if standby.file_status("/committed-dir").is_ok()
-            && standby.file_status("/renamed-file").is_ok()
             && standby.file_status("/committed-file").is_err()
             && standby.file_status("/setgid-parent/child").is_ok()
         {
@@ -351,7 +359,11 @@ fn active_namespace_changes_replicate_without_legacy_writer_queue() -> CommonRes
                 standby.file_status("/setgid-parent/child")?.group,
                 "parent-group"
             );
-            return Ok(());
+            if let Ok(status) = standby.file_status("/renamed-file") {
+                if status.owner == "committed-owner" {
+                    return Ok(());
+                }
+            }
         }
         if std::time::Instant::now() >= deadline {
             return err_box!("standby did not apply committed namespace changes");


### PR DESCRIPTION
## Summary
Commit active-Master attribute changes and empty-directory deletes before applying local metadata.

## Issue/Design
This is the small metadata-mutation slice of #1552. `set_attr` and an empty directory delete still changed active metadata before their operation had a committed Raft order. Both now use the existing versioned metadata-command path.

## Changes
| Area | Change |
| --- | --- |
| Attribute changes | Normalize and prepare `SetAttr` commands, then commit before apply. |
| Empty directory delete | Commit only the safe empty-directory delete case; recursive/non-empty deletion retains its existing path. |
| Replay | Apply commands on every voter and perform UFS side effects only on the active Master. |
| Test | Extend the two-Master integration test with owner update and empty-directory removal. |

## Test verified
- `cargo fmt --check -- curvine-master/src/master/fs/master_filesystem.rs curvine-master/src/master/journal/entry.rs curvine-master/src/master/journal/journal_loader.rs curvine-master/src/master/meta/fs_dir.rs curvine-server/tests/journal_test.rs`
- `CARGO_TARGET_DIR=/mnt/data/curvine/.build/pr-1552-split/attrs-delete cargo test -q -p curvine-server --test journal_test`
- `CARGO_TARGET_DIR=/mnt/data/curvine/.build/pr-1552-split/attrs-delete cargo clippy -q -p curvine-server --test journal_test -- -D warnings`
- `git diff --check`

## Dependencies
Stacked on #1560. Merge after #1560.