### PR TITLE
fix(config): move default web ports off 9000 to avoid conflicts

### DIFF
--- a/crates/common/curvine-config/src/cluster_conf.rs
+++ b/crates/common/curvine-config/src/cluster_conf.rs
@@ -81,9 +81,9 @@ impl ClusterConf {
     pub const DEFAULT_MASTER_PORT: u16 = 8995;
     pub const DEFAULT_RAFT_PORT: u16 = 8996;
     pub const DEFAULT_WORKER_PORT: u16 = 8997;
-    pub const DEFAULT_MASTER_WEB_PORT: u16 = 9000;
-    pub const DEFAULT_WORKER_WEB_PORT: u16 = 9001;
-    pub const DEFAULT_FUSE_WEB_PORT: u16 = 9002;
+    pub const DEFAULT_MASTER_WEB_PORT: u16 = 9001;
+    pub const DEFAULT_WORKER_WEB_PORT: u16 = 9002;
+    pub const DEFAULT_FUSE_WEB_PORT: u16 = 9003;
 
     pub const ENV_MASTER_HOSTNAME: &'static str = "CURVINE_MASTER_HOSTNAME";
     pub const ENV_WORKER_HOSTNAME: &'static str = "CURVINE_WORKER_HOSTNAME";

--- a/crates/common/curvine-config/src/fuse_conf.rs
+++ b/crates/common/curvine-config/src/fuse_conf.rs
@@ -547,7 +547,7 @@ impl Default for FuseConf {
             negative_timeout_ms: FuseConf::DEFAULT_NEGATIVE_TIMEOUT_MS,
             attr_timeout_ms: FuseConf::DEFAULT_ATTR_TIMEOUT_MS,
             remember: false,
-            web_port: crate::DEFAULT_FUSE_WEB_PORT,
+            web_port: crate::ClusterConf::DEFAULT_FUSE_WEB_PORT,
 
             max_background: 256,
             congestion_threshold: 192,

--- a/crates/common/curvine-config/src/lib.rs
+++ b/crates/common/curvine-config/src/lib.rs
@@ -15,7 +15,6 @@
 pub use curvine_error::{FsError, FsResult};
 
 pub const DEFAULT_HOSTNAME: &str = "localhost";
-pub const DEFAULT_FUSE_WEB_PORT: u16 = 9002;
 
 mod db_conf;
 pub use self::db_conf::DBConf;


### PR DESCRIPTION
# Summary

Shift default web ports for master/worker/fuse from 9000/9001/9002 to 9001/9002/9003, freeing port 9000 which is commonly occupied by other services. Also unify the fuse web port constant so the new value actually takes effect.

# Issue Describe / Design

The default web ports previously started at 9000, which conflicts with other services commonly binding to port 9000 (e.g. PHP-FPM, SonarQube, macOS AirPlay). Ports are shifted by one to avoid the conflict.

A duplicate `DEFAULT_FUSE_WEB_PORT` existed at the crate level (`lib.rs`, value 9002) and `FuseConf` referenced it instead of `ClusterConf::DEFAULT_FUSE_WEB_PORT`, so the changed constant in `cluster_conf.rs` was not effective. The duplicate definition is removed and `FuseConf` now references `ClusterConf::DEFAULT_FUSE_WEB_PORT` to keep a single source of truth.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `crates/common/curvine-config/src/cluster_conf.rs` | Master/worker/fuse web port defaults: 9000/9001/9002 → 9001/9002/9003 | behavior change: default web ports shifted by one |
| `crates/common/curvine-config/src/fuse_conf.rs` | `web_port` now uses `ClusterConf::DEFAULT_FUSE_WEB_PORT` | behavior change: fuse web port default becomes 9003 (was 9002) |
| `crates/common/curvine-config/src/lib.rs` | Remove duplicate `DEFAULT_FUSE_WEB_PORT` constant | None (single source of truth) |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo check -p curvine-config` | NOT RUN | Windows local env lacks Unix-only `nix::ifaddrs`; compile skipped per user |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None