### PR TITLE
fix(fuse): stop advertising unsupported setxattr extension

### DIFF
--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -3003,8 +3003,9 @@ mod tests {
     use crate::{
         fuse_init_flag_names, FUSE_ATOMIC_O_TRUNC, FUSE_BIG_WRITES, FUSE_DO_READDIRPLUS,
         FUSE_EXPORT_SUPPORT, FUSE_FLOCK_LOCKS, FUSE_HAS_IOCTL_DIR, FUSE_KERNEL_MINOR_VERSION,
-        FUSE_KERNEL_VERSION, FUSE_MAX_PAGES, FUSE_POSIX_ACL, FUSE_POSIX_LOCKS, FUSE_SPLICE_MOVE,
-        FUSE_SPLICE_READ, FUSE_SPLICE_WRITE, FUSE_WRITEBACK_CACHE, SUPPORTED_INIT_FLAGS,
+        FUSE_KERNEL_VERSION, FUSE_MAX_PAGES, FUSE_POSIX_ACL, FUSE_POSIX_LOCKS, FUSE_SETXATTR_EXT,
+        FUSE_SPLICE_MOVE, FUSE_SPLICE_READ, FUSE_SPLICE_WRITE, FUSE_WRITEBACK_CACHE,
+        SUPPORTED_INIT_FLAGS,
     };
 
     #[test]
@@ -3060,13 +3061,29 @@ mod tests {
 
     #[test]
     fn negotiate_out_flags_drops_unsupported_kernel_caps() {
-        let unsupported = FUSE_ATOMIC_O_TRUNC | FUSE_POSIX_ACL | FUSE_HAS_IOCTL_DIR | FUSE_INIT_EXT;
+        let unsupported = FUSE_ATOMIC_O_TRUNC
+            | FUSE_POSIX_ACL
+            | FUSE_HAS_IOCTL_DIR
+            | FUSE_INIT_EXT
+            | FUSE_SETXATTR_EXT;
         let conf = init_conf(false, false);
         let out = CurvineFileSystem::negotiate_out_flags(unsupported, &conf);
         assert_eq!(
             out & unsupported,
             0,
             "no unsupported kernel-offered bit may be advertised"
+        );
+    }
+
+    #[test]
+    fn setxattr_ext_is_not_advertised() {
+        let conf = init_conf(false, false);
+        let out = CurvineFileSystem::negotiate_out_flags(FUSE_SETXATTR_EXT, &conf);
+
+        assert_eq!(
+            out & FUSE_SETXATTR_EXT,
+            0,
+            "the decoder only supports the 8-byte SETXATTR compatibility layout"
         );
     }
 

--- a/curvine-fuse/src/lib.rs
+++ b/curvine-fuse/src/lib.rs
@@ -134,7 +134,8 @@ pub const FUSE_EXPLICIT_INVAL_DATA: u32 = 1 << 25;
 /// FUSE init capability bit: enhanced killpriv semantics (ABI 7.37).
 pub const FUSE_HANDLE_KILLPRIV_V2: u32 = 1 << 28;
 
-/// FUSE init capability bit: extended xattr error reporting (ABI 7.37).
+/// FUSE init capability bit: daemon accepts the extended 16-byte
+/// `fuse_setxattr_in` request layout.
 pub const FUSE_SETXATTR_EXT: u32 = 1 << 29;
 
 pub const FUSE_WRITEBACK_CACHE: u32 = 1 << 16;
@@ -171,8 +172,9 @@ pub const FUSE_ATOMIC_O_TRUNC: u32 = 1 << 3;
 /// every kernel-offered flag.
 ///
 /// Deliberately EXCLUDED (never advertised): FUSE_ATOMIC_O_TRUNC (open does not
-/// truncate), FUSE_POSIX_ACL (no ACL handling), FUSE_HAS_IOCTL_DIR (no
-/// ioctl).
+/// truncate), FUSE_POSIX_ACL (no ACL handling), FUSE_HAS_IOCTL_DIR (no ioctl),
+/// FUSE_SETXATTR_EXT (the decoder currently accepts only the 8-byte compatible
+/// request layout).
 pub const SUPPORTED_INIT_FLAGS: u32 = FUSE_ASYNC_READ
     | FUSE_BIG_WRITES
     | FUSE_ASYNC_DIO
@@ -193,8 +195,7 @@ pub const SUPPORTED_INIT_FLAGS: u32 = FUSE_ASYNC_READ
     | FUSE_CACHE_SYMLINKS
     | FUSE_NO_OPENDIR_SUPPORT
     | FUSE_EXPLICIT_INVAL_DATA
-    | FUSE_HANDLE_KILLPRIV_V2
-    | FUSE_SETXATTR_EXT;
+    | FUSE_HANDLE_KILLPRIV_V2;
 
 /// Human-readable FUSE init-capability names; unknown bits are kept as hex.
 pub fn fuse_init_flag_names(flags: u32) -> Vec<String> {


### PR DESCRIPTION
**Describe the bug**
Curvine FUSE advertises `FUSE_SETXATTR_EXT` during INIT even though its request decoder only supports the legacy 8-byte `fuse_setxattr_in` layout. Once the capability is negotiated, Linux sends the extended 16-byte request header, shifting the attribute name and value relative to the offsets expected by Curvine. The request therefore fails parsing before it reaches the xattr implementation.

PR #1533 hardened malformed-request handling so the kernel now receives `EPROTO` instead of waiting indefinitely. That change prevents the original `setxattr(2)` hang, but it does not restore xattr functionality: valid `setxattr(2)` calls still fail with `Protocol error` because the advertised capability and implemented ABI remain inconsistent.

This PR fixes the remaining functional regression reported in #1513 by stopping negotiation of `FUSE_SETXATTR_EXT`. The kernel consequently uses the 8-byte compatibility request layout that Curvine already decodes and supports.

Closes #1513.

**To Reproduce**
Use the standalone reproducer and instructions attached to #1513. On an affected build after PR #1533, the syscall no longer hangs but still fails:

```text
child: calling setxattr(/mnt/curvine/xattr-hang-repro-12345)
setxattr: Protocol error
```

The same protocol mismatch is visible through ordinary xattr tools:

```text
setfattr: /mnt/curvine/testfile: Protocol error
```

The reproducer source is intentionally not duplicated in this PR description because #1513 already contains the complete standalone program and execution instructions.

**Expected behavior**
Curvine must advertise only FUSE capabilities whose request ABI and semantics it implements. A normal `setxattr(2)` request should use the compatible layout, reach `CurvineFileSystem::set_xattr()`, and complete successfully:

```text
child: calling setxattr(/mnt/curvine/xattr-hang-repro-12345)
child: setxattr returned successfully
```

Removing `FUSE_SETXATTR_EXT` from the negotiated capability allowlist must not disable extended attributes. `setxattr`, `getxattr`, `listxattr`, and `removexattr` continue to use the existing Curvine implementation. `XATTR_CREATE` and `XATTR_REPLACE` also remain available through the compatibility request header.

**Root cause**
Linux defines two wire layouts for `FUSE_SETXATTR` requests. Without `FUSE_SETXATTR_EXT`, the kernel sends the first 8 bytes:

```c
#define FUSE_COMPAT_SETXATTR_IN_SIZE 8

struct fuse_setxattr_in_compat {
    uint32_t size;
    uint32_t flags;
};
```

After `FUSE_SETXATTR_EXT` is negotiated, it sends the complete 16-byte structure:

```c
struct fuse_setxattr_in {
    uint32_t size;
    uint32_t flags;
    uint32_t setxattr_flags;
    uint32_t padding;
};
```

Curvine currently defines and decodes only the compatibility form:

```rust
#[repr(C)]
pub struct fuse_setxattr_in {
    pub size: u32,
    pub flags: u32,
}
```

Commit `88cc9b2e` added `FUSE_SETXATTR_EXT` to `SUPPORTED_INIT_FLAGS` without adding session-aware decoding for the extended structure. The resulting request is interpreted as follows:

```text
Kernel request:
  [size][flags][setxattr_flags][padding][name\0][value]

Curvine decoder:
  [size][flags]                    -> compatibility header
              [setxattr_flags ...] -> name and value at incorrect offsets
```

The parser detects the malformed payload and rejects it. PR #1533 correctly turns that parser failure into an `EPROTO` reply, but every otherwise valid SETXATTR request still fails until the capability mismatch is removed.

`FUSE_SETXATTR_EXT` is not the switch that enables extended attributes. It only declares support for the extended request structure and its additional `setxattr_flags` field. The currently defined additional semantic is `FUSE_SETXATTR_ACL_KILL_SGID`, used when setting `system.posix_acl_access`. Curvine does not advertise `FUSE_POSIX_ACL`, so omitting `FUSE_SETXATTR_EXT` does not remove a currently supported Curvine feature.

**Changes**

- Remove `FUSE_SETXATTR_EXT` from `SUPPORTED_INIT_FLAGS` so Curvine no longer advertises an unsupported request ABI.
- Keep the capability constant and its human-readable name for protocol diagnostics and future implementation work.
- Clarify that the capability represents acceptance of the extended 16-byte SETXATTR request layout.
- Document `FUSE_SETXATTR_EXT` among the capabilities intentionally excluded from INIT negotiation.
- Extend the unsupported-capability negotiation test to cover `FUSE_SETXATTR_EXT`.
- Add a focused regression test asserting that a kernel-offered `FUSE_SETXATTR_EXT` bit is not returned by Curvine.
- Preserve the PR #1533 malformed-request reply path so unexpected protocol payloads continue to receive `EPROTO` instead of blocking the caller.

Full support for `FUSE_SETXATTR_EXT` can be implemented separately. That work must retain the negotiated INIT flags per FUSE session, select the 8-byte or 16-byte decoder from the negotiated state, validate the extended padding and flags, and implement or explicitly reject `FUSE_SETXATTR_ACL_KILL_SGID` before the capability is re-enabled.

**Compatibility impact**
This change does not disable xattrs and does not alter their stored representation. It restores the request format used before the regression:

- `user.*` xattrs continue to work.
- `XATTR_CREATE` and `XATTR_REPLACE` retain their existing behavior.
- `getxattr`, `listxattr`, and `removexattr` are unaffected.
- Kernels that offer `FUSE_SETXATTR_EXT` fall back to the protocol-defined 8-byte compatibility layout.
- POSIX ACL behavior is unaffected because Curvine does not currently advertise `FUSE_POSIX_ACL`.
- No data migration or configuration change is required.

**OS Version (please complete the following information):**
 - OS: Ubuntu Linux
 - Kernel: 5.15.0-72-generic
 - Architecture: x86_64
 - Filesystem client: Curvine FUSE

**Verification**

- Run the standalone reproducer from #1513 against a newly mounted Curvine FUSE session and verify that `setxattr(2)` succeeds rather than hanging or returning `EPROTO`.
- Verify that the negotiated INIT flags do not include `FUSE_SETXATTR_EXT` even when the kernel offers it.
- Verify compatibility SETXATTR decoding preserves the complete attribute name, binary value, and `XATTR_CREATE` or `XATTR_REPLACE` flags.
- Run `cargo test -p curvine-fuse --lib`.
- Run `cargo check -p curvine-fuse`.
- Run `cargo fmt --all -- --check`.
- Run `git diff --check`.

**Additional context**
PR #1533 remains an important defense-in-depth fix: after a FUSE request header has been accepted, every reply-bearing request must receive either a success response or an error response. This PR addresses the separate capability-negotiation error that caused valid SETXATTR requests to enter that malformed-request path in the first place.

The minimal safe fix is to stop advertising the extension while retaining the compatible ABI. Simply changing Curvine's request structure to 16 bytes would break kernels or sessions where `FUSE_SETXATTR_EXT` was not negotiated, because those requests legitimately contain only the 8-byte header. Supporting both forms therefore requires session-aware decoding and should not be mixed into this compatibility fix.
