### PR TITLE
fix(fuse): stop advertising unsupported setxattr ext (#1513)

### DIFF
--- a/build/tests/scripts/curvine_xattr_hang_repro.c
+++ b/build/tests/scripts/curvine_xattr_hang_repro.c
@@ -1,0 +1,126 @@
+#define _GNU_SOURCE
+
+#include <fcntl.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <sys/xattr.h>
+#include <time.h>
+#include <unistd.h>
+
+static long elapsed_ms(const struct timespec *start)
+{
+    struct timespec now;
+
+    clock_gettime(CLOCK_MONOTONIC, &now);
+    return (now.tv_sec - start->tv_sec) * 1000L +
+           (now.tv_nsec - start->tv_nsec) / 1000000L;
+}
+
+static int run_child(const char *path)
+{
+    static const char data[] = "curvine xattr hang reproducer\n";
+    static const char value[] = "value";
+    int fd;
+
+    fd = open(path, O_CREAT | O_TRUNC | O_WRONLY, 0644);
+    if (fd < 0) {
+        perror("open");
+        return 2;
+    }
+
+    if (write(fd, data, sizeof(data) - 1) != (ssize_t)(sizeof(data) - 1)) {
+        perror("write");
+        close(fd);
+        return 2;
+    }
+
+    /* close() queues FUSE RELEASE; SETXATTR follows immediately. */
+    if (close(fd) < 0) {
+        perror("close");
+        return 2;
+    }
+
+    fprintf(stderr, "child: calling setxattr(%s)\n", path);
+    if (setxattr(path, "user.curvine_repro", value, sizeof(value) - 1, 0) < 0) {
+        perror("setxattr");
+        return 1;
+    }
+
+    fprintf(stderr, "child: setxattr returned successfully\n");
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+    const char *mountpoint;
+    int timeout_seconds = 10;
+    struct timespec start;
+    char path[4096];
+    pid_t child;
+    int status;
+
+    if (argc < 2 || argc > 3) {
+        fprintf(stderr, "Usage: %s MOUNTPOINT [TIMEOUT_SECONDS]\n", argv[0]);
+        return 2;
+    }
+
+    mountpoint = argv[1];
+    if (argc == 3) {
+        timeout_seconds = atoi(argv[2]);
+        if (timeout_seconds <= 0) {
+            fprintf(stderr, "TIMEOUT_SECONDS must be positive\n");
+            return 2;
+        }
+    }
+
+    if (snprintf(path, sizeof(path), "%s/xattr-hang-repro-%ld",
+                 mountpoint, (long)getpid()) >= (int)sizeof(path)) {
+        fprintf(stderr, "reproduction path is too long\n");
+        return 2;
+    }
+
+    child = fork();
+    if (child < 0) {
+        perror("fork");
+        return 2;
+    }
+    if (child == 0)
+        _exit(run_child(path));
+
+    clock_gettime(CLOCK_MONOTONIC, &start);
+    for (;;) {
+        pid_t result = waitpid(child, &status, WNOHANG);
+
+        if (result == child)
+            break;
+        if (result < 0) {
+            perror("waitpid");
+            return 2;
+        }
+        if (elapsed_ms(&start) >= timeout_seconds * 1000L) {
+            fprintf(stderr,
+                    "REPRODUCED: setxattr did not return within %d seconds "
+                    "(child pid %ld)\n",
+                    timeout_seconds, (long)child);
+            kill(child, SIGKILL);
+            waitpid(child, NULL, 0);
+            return 124;
+        }
+
+        usleep(10000);
+    }
+
+    if (WIFEXITED(status)) {
+        int rc = WEXITSTATUS(status);
+
+        if (rc == 0)
+            unlink(path);
+        return rc;
+    }
+
+    fprintf(stderr, "child terminated abnormally\n");
+    return 2;
+}

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -3003,8 +3003,9 @@ mod tests {
     use crate::{
         fuse_init_flag_names, FUSE_ATOMIC_O_TRUNC, FUSE_BIG_WRITES, FUSE_DO_READDIRPLUS,
         FUSE_EXPORT_SUPPORT, FUSE_FLOCK_LOCKS, FUSE_HAS_IOCTL_DIR, FUSE_KERNEL_MINOR_VERSION,
-        FUSE_KERNEL_VERSION, FUSE_MAX_PAGES, FUSE_POSIX_ACL, FUSE_POSIX_LOCKS, FUSE_SPLICE_MOVE,
-        FUSE_SPLICE_READ, FUSE_SPLICE_WRITE, FUSE_WRITEBACK_CACHE, SUPPORTED_INIT_FLAGS,
+        FUSE_KERNEL_VERSION, FUSE_MAX_PAGES, FUSE_POSIX_ACL, FUSE_POSIX_LOCKS, FUSE_SETXATTR_EXT,
+        FUSE_SPLICE_MOVE, FUSE_SPLICE_READ, FUSE_SPLICE_WRITE, FUSE_WRITEBACK_CACHE,
+        SUPPORTED_INIT_FLAGS,
     };
 
     #[test]
@@ -3060,13 +3061,34 @@ mod tests {
 
     #[test]
     fn negotiate_out_flags_drops_unsupported_kernel_caps() {
-        let unsupported = FUSE_ATOMIC_O_TRUNC | FUSE_POSIX_ACL | FUSE_HAS_IOCTL_DIR | FUSE_INIT_EXT;
+        let unsupported = FUSE_ATOMIC_O_TRUNC
+            | FUSE_POSIX_ACL
+            | FUSE_HAS_IOCTL_DIR
+            | FUSE_INIT_EXT
+            | FUSE_SETXATTR_EXT;
         let conf = init_conf(false, false);
         let out = CurvineFileSystem::negotiate_out_flags(unsupported, &conf);
         assert_eq!(
             out & unsupported,
             0,
             "no unsupported kernel-offered bit may be advertised"
+        );
+    }
+
+    #[test]
+    fn setxattr_ext_is_not_advertised() {
+        assert_eq!(
+            SUPPORTED_INIT_FLAGS & FUSE_SETXATTR_EXT,
+            0,
+            "the decoder only supports the legacy 8-byte SETXATTR request layout"
+        );
+
+        let out =
+            CurvineFileSystem::negotiate_out_flags(FUSE_SETXATTR_EXT, &init_conf(false, false));
+        assert_eq!(
+            out & FUSE_SETXATTR_EXT,
+            0,
+            "a kernel-offered SETXATTR_EXT capability must not be echoed"
         );
     }
 
@@ -3130,7 +3152,11 @@ mod tests {
     #[test]
     fn negotiate_out_flags_containment() {
         let splice = FUSE_SPLICE_MOVE | FUSE_SPLICE_WRITE | FUSE_SPLICE_READ;
-        let unsafe_bits = FUSE_ATOMIC_O_TRUNC | FUSE_POSIX_ACL | FUSE_HAS_IOCTL_DIR | FUSE_INIT_EXT;
+        let unsafe_bits = FUSE_ATOMIC_O_TRUNC
+            | FUSE_POSIX_ACL
+            | FUSE_HAS_IOCTL_DIR
+            | FUSE_INIT_EXT
+            | FUSE_SETXATTR_EXT;
         let allowed = SUPPORTED_INIT_FLAGS | splice | FUSE_WRITEBACK_CACHE;
         let conf = init_conf(true, true);
         let out = CurvineFileSystem::negotiate_out_flags(u32::MAX, &conf);

--- a/curvine-fuse/src/lib.rs
+++ b/curvine-fuse/src/lib.rs
@@ -134,7 +134,9 @@ pub const FUSE_EXPLICIT_INVAL_DATA: u32 = 1 << 25;
 /// FUSE init capability bit: enhanced killpriv semantics (ABI 7.37).
 pub const FUSE_HANDLE_KILLPRIV_V2: u32 = 1 << 28;
 
-/// FUSE init capability bit: extended xattr error reporting (ABI 7.37).
+/// FUSE init capability bit for the 16-byte SETXATTR request layout (ABI 7.33).
+/// The extended layout adds `setxattr_flags` and padding after the legacy
+/// `size`/`flags` fields.
 pub const FUSE_SETXATTR_EXT: u32 = 1 << 29;
 
 pub const FUSE_WRITEBACK_CACHE: u32 = 1 << 16;
@@ -171,8 +173,9 @@ pub const FUSE_ATOMIC_O_TRUNC: u32 = 1 << 3;
 /// every kernel-offered flag.
 ///
 /// Deliberately EXCLUDED (never advertised): FUSE_ATOMIC_O_TRUNC (open does not
-/// truncate), FUSE_POSIX_ACL (no ACL handling), FUSE_HAS_IOCTL_DIR (no
-/// ioctl).
+/// truncate), FUSE_POSIX_ACL (no ACL handling), FUSE_HAS_IOCTL_DIR (no ioctl),
+/// FUSE_SETXATTR_EXT (the decoder implements only the legacy 8-byte SETXATTR
+/// request layout).
 pub const SUPPORTED_INIT_FLAGS: u32 = FUSE_ASYNC_READ
     | FUSE_BIG_WRITES
     | FUSE_ASYNC_DIO
@@ -193,8 +196,7 @@ pub const SUPPORTED_INIT_FLAGS: u32 = FUSE_ASYNC_READ
     | FUSE_CACHE_SYMLINKS
     | FUSE_NO_OPENDIR_SUPPORT
     | FUSE_EXPLICIT_INVAL_DATA
-    | FUSE_HANDLE_KILLPRIV_V2
-    | FUSE_SETXATTR_EXT;
+    | FUSE_HANDLE_KILLPRIV_V2;
 
 /// Human-readable FUSE init-capability names; unknown bits are kept as hex.
 pub fn fuse_init_flag_names(flags: u32) -> Vec<String> {

--- a/curvine-fuse/src/session/channel/fuse_receiver.rs
+++ b/curvine-fuse/src/session/channel/fuse_receiver.rs
@@ -894,6 +894,7 @@ mod tests {
         const OP_GETATTR: u32 = 3;
         const OP_STATFS: u32 = 17;
         const OP_ACCESS: u32 = 34;
+        const OP_SETXATTR: u32 = 21;
         const OP_INTERRUPT: u32 = 36;
         const OP_BATCH_FORGET: u32 = 42;
 
@@ -938,6 +939,20 @@ mod tests {
         fn forget_request(unique: u64) -> FuseRequest {
             let arg = fuse_forget_in { nlookup: 1 };
             make_request(OP_FORGET, unique, 2, FuseUtils::struct_as_bytes(&arg))
+        }
+
+        fn extended_setxattr_request(unique: u64) -> FuseRequest {
+            // ABI 7.33 layout: size, flags, setxattr_flags, padding, name, value.
+            // Without FUSE_SETXATTR_EXT negotiation, Curvine intentionally decodes
+            // only the first 8 bytes and must reject the remaining extended fields.
+            let mut payload = BytesMut::new();
+            payload.put_u32_ne(5); // value size
+            payload.put_u32_ne(0); // XATTR_CREATE / XATTR_REPLACE flags
+            payload.put_u32_ne(0); // extended setxattr_flags
+            payload.put_u32_ne(0); // padding
+            payload.put_slice(b"user.curvine_test\0");
+            payload.put_slice(b"value");
+            make_request(OP_SETXATTR, unique, 2, &payload)
         }
 
         fn interrupt_request(unique: u64, interrupted_unique: u64) -> FuseRequest {
@@ -1077,6 +1092,34 @@ mod tests {
             assert!(
                 rx.try_recv().unwrap().is_none(),
                 "malformed LOOKUP must enqueue exactly one reply"
+            );
+        }
+
+        #[tokio::test]
+        async fn unnegotiated_extended_setxattr_replies_eproto_once() {
+            let unique = 1014;
+            let pending = FastDashMap::default();
+            let request = extended_setxattr_request(unique);
+            let (tx, mut rx) = AsyncChannel::new(16).split();
+            let reply = FuseResponse::new_reply(unique, tx, false, None);
+
+            let result =
+                super::super::FuseReceiver::dispatch_meta(&pending, &fs(), &request, &reply).await;
+
+            assert!(
+                result.is_ok(),
+                "an unexpected extended SETXATTR payload is completed by its EPROTO reply"
+            );
+            match rx.try_recv().unwrap().expect("one EPROTO reply task") {
+                FuseTask::Reply(data) => {
+                    assert_eq!(data.header().unique, unique);
+                    assert_eq!(data.header().error, -libc::EPROTO);
+                }
+                _ => panic!("metrics-disabled reply must use FuseTask::Reply"),
+            }
+            assert!(
+                rx.try_recv().unwrap().is_none(),
+                "malformed SETXATTR must enqueue exactly one reply"
             );
         }
 


### PR DESCRIPTION
# Summary

Stop advertising `FUSE_SETXATTR_EXT` until Curvine implements the Linux FUSE ABI 7.33 extended `SETXATTR` request layout. This keeps the kernel on the legacy 8-byte request header and prevents extended requests from being decoded with shifted name/value fields.

# Issue Describe / Design

Fixes #1513

## Root cause

Curvine included `FUSE_SETXATTR_EXT` in `SUPPORTED_INIT_FLAGS`, so a supporting Linux kernel could send the ABI 7.33 16-byte `SETXATTR` request header. The decoder still consumed the legacy 8-byte `size`/`flags` structure, causing the extra `setxattr_flags` and padding fields to be interpreted as the start of the xattr name and value.

## Reproduction

Mount Curvine FUSE on a kernel that offers `FUSE_SETXATTR_EXT`, then repeatedly call `setxattr` under a watchdog. Before this change, the operation can hang because Curvine advertises a request layout that it does not decode.

## Fix approach

Negotiate only capabilities Curvine fully implements: remove `FUSE_SETXATTR_EXT` from the INIT allowlist while retaining the compatible 8-byte decoder. Add capability, parser/error-path, and end-to-end regression coverage so the flag cannot be reintroduced accidentally without decoder support.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-fuse/src/lib.rs` | Correct the ABI documentation and remove `FUSE_SETXATTR_EXT` from `SUPPORTED_INIT_FLAGS` | Kernels use the compatible legacy `SETXATTR` layout |
| `curvine-fuse/src/fs/curvine_file_system.rs` | Add INIT negotiation regression coverage | No runtime impact |
| `curvine-fuse/src/session/channel/fuse_receiver.rs` | Add malformed/unnegotiated extended request coverage and verify a single `EPROTO` reply | No runtime behavior change beyond the capability negotiation fix |
| `build/tests/scripts/curvine_xattr_hang_repro.c` | Add a watchdog-based xattr hang reproducer | Test-only |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo fmt --all -- --check` | PASS | Ubuntu build host |
| `cargo check -p curvine-fuse` | PASS | Ubuntu build host |
| `cargo test -p curvine-fuse --lib -- --test-threads=1` | PASS | 417 passed, 0 failed |
| `setxattr_ext_is_not_advertised` | PASS | Capability regression test |
| `unnegotiated_extended_setxattr_replies_eproto_once` | PASS | Exactly one `EPROTO` reply |
| `setxattr_uses_compat_header_and_preserves_name_and_value` | PASS | Legacy header parsing |
| Watchdog reproducer | PASS | 20 consecutive runs on `dev-tikv-nxy03` |
| `setxattr` / `getxattr` / `listxattr` round trip | PASS | Value and visible xattr name verified on `dev-tikv-nxy03` |

A parallel full-library test run observed one pre-existing global metrics counter fluctuation in `local_writer_task_body_observes_io_with_local_path_type`; the test passed alone and the complete serial library suite passed with 417/417 tests.

# Dependencies

- Related PRs: None
- Related issues: #1513
- Blocks / blocked by: None
