### PR TITLE
fix(fuse): synchronize concurrent reader refresh

### DIFF
--- a/curvine-fuse/src/fs/state/backend_handle.rs
+++ b/curvine-fuse/src/fs/state/backend_handle.rs
@@ -22,8 +22,7 @@ use curvine_core_error::err_box;
 use curvine_fs_api::Path;
 use curvine_fs_api::{StateReader, StateWriter};
 use curvine_model::{CreateFileOptsBuilder, FileStatus, LockFlags, OpenFlags};
-use curvine_runtime::sync::AtomicCounter;
-use curvine_sys::RawPtr;
+use curvine_runtime::sync::AsyncMutex;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -56,33 +55,44 @@ pub struct BackendHandle {
     pub ino: u64,
     pub fh: u64,
 
-    pub reader: Option<RawPtr<FuseReader>>,
+    reader: Option<AsyncMutex<ReaderState>>,
     pub writer: Option<Arc<FuseWriter>>, // Writer uses Arc for global sharing
     /// Open-time file status snapshot. Guarded by a lock because the read path
     /// refreshes it in place after a dirty-read reopen (`read()` takes `&self`).
     status: std::sync::RwLock<FileStatus>,
 
     fh_locks: std::sync::Mutex<HandleLock>,
+}
 
-    read_ver: AtomicCounter,
+struct ReaderState {
+    reader: Arc<FuseReader>,
+    read_ver: u64,
+}
+
+impl ReaderState {
+    fn new(reader: Arc<FuseReader>) -> Self {
+        Self {
+            reader,
+            read_ver: 0,
+        }
+    }
 }
 
 impl BackendHandle {
     pub fn new(
         ino: u64,
         fh: u64,
-        reader: Option<RawPtr<FuseReader>>,
+        reader: Option<Arc<FuseReader>>,
         writer: Option<Arc<FuseWriter>>,
         status: FileStatus,
     ) -> Self {
         Self {
             ino,
             fh,
-            reader,
+            reader: reader.map(|reader| AsyncMutex::new(ReaderState::new(reader))),
             writer,
             status: std::sync::RwLock::new(status),
             fh_locks: std::sync::Mutex::new(HandleLock::default()),
-            read_ver: AtomicCounter::new(0),
         }
     }
 
@@ -125,10 +135,15 @@ impl BackendHandle {
             );
         }
 
-        let reader = match &self.reader {
-            Some(v) => v,
+        let reader_state = match &self.reader {
+            Some(reader) => reader,
             None => return err_fuse!(libc::EIO),
         };
+
+        // Serialize refresh state per file handle. The Arc cloned below keeps the
+        // selected reader alive until this request has entered its channel, even
+        // if a later request replaces the handle's current reader.
+        let mut reader_state = reader_state.lock().await;
 
         if let Some(writer) = state.find_writer(self.ino).await {
             // `write_ver` advances only after a write/resize is successfully queued.
@@ -143,18 +158,20 @@ impl BackendHandle {
             // Pin read_ver to the flushed snapshot; later writes leave write_ver
             // ahead so the next read publishes again.
             if let Some(target_ver) = writer
-                .publish_dirty_read_snapshot(self.read_ver.get())
+                .publish_dirty_read_snapshot(reader_state.read_ver)
                 .await?
             {
-                let path = reader.path().clone();
+                let path = reader_state.reader.path().clone();
                 let new_reader = state.new_reader(&path).await?;
                 // Refresh status from the reopened reader before installing it.
                 self.refresh_status(new_reader.status().clone());
-                reader.replace(new_reader);
-                self.read_ver.set(target_ver);
+                reader_state.reader = Arc::new(new_reader);
+                reader_state.read_ver = target_ver;
             }
         }
 
+        let reader = reader_state.reader.clone();
+        drop(reader_state);
         reader.read(op, reply).await?;
         Ok(())
     }
@@ -312,7 +329,7 @@ impl BackendHandle {
 
         let reader = if has_reader {
             let reader = state.new_reader(&path).await?;
-            Some(RawPtr::from_owned(reader))
+            Some(Arc::new(reader))
         } else {
             None
         };
@@ -320,12 +337,11 @@ impl BackendHandle {
         let handle = Self {
             ino,
             fh,
-            reader,
+            reader: reader.map(|reader| AsyncMutex::new(ReaderState::new(reader))),
             writer,
             status: std::sync::RwLock::new(status),
 
             fh_locks: std::sync::Mutex::new(locks),
-            read_ver: AtomicCounter::new(0),
         };
         Ok(handle)
     }
@@ -334,6 +350,71 @@ impl BackendHandle {
 #[cfg(test)]
 mod tests {
     use super::BackendHandle;
+
+    #[test]
+    fn replaced_reader_stays_alive_while_request_holds_arc() {
+        use crate::fs::FuseReader;
+        use curvine_client::unified::UnifiedReader;
+        use curvine_config::FuseConf;
+        use curvine_fs_api::local::LocalReader;
+        use curvine_fs_api::Path;
+        use curvine_model::FileStatus;
+        use curvine_runtime::runtime::{AsyncRuntime, RpcRuntime};
+        use std::io::Write as _;
+        use std::sync::Arc;
+
+        let path_buf = std::env::temp_dir().join(format!(
+            "backend_handle_reader_arc_{}_{}",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("test")
+        ));
+        {
+            let mut file = std::fs::File::create(&path_buf).unwrap();
+            file.write_all(b"reader lifetime").unwrap();
+        }
+        let path = Path::from_str(path_buf.to_str().unwrap()).unwrap();
+        let runtime = Arc::new(AsyncRuntime::single());
+        let make_reader = || {
+            Arc::new(FuseReader::new(
+                &FuseConf::default(),
+                runtime.clone(),
+                UnifiedReader::Local(LocalReader::new(&path, 4096).unwrap()),
+            ))
+        };
+
+        let original = make_reader();
+        let original_weak = Arc::downgrade(&original);
+        let handle = BackendHandle::new(
+            1,
+            10,
+            Some(original.clone()),
+            None,
+            FileStatus::with_name(1, "f".into(), false),
+        );
+        drop(original);
+
+        runtime.block_on(async {
+            let mut state = handle.reader.as_ref().unwrap().lock().await;
+            let in_flight = state.reader.clone();
+            state.reader = make_reader();
+            drop(state);
+
+            assert!(
+                original_weak.upgrade().is_some(),
+                "an in-flight request must retain the reader replaced on the handle"
+            );
+            drop(in_flight);
+            assert!(
+                original_weak.upgrade().is_none(),
+                "the replaced reader is released after the in-flight request drops its Arc"
+            );
+        });
+
+        // FuseReader workers retain the runtime handle; avoid dropping a Tokio
+        // runtime from a test async context while those tasks wind down.
+        std::mem::forget(runtime);
+        let _ = std::fs::remove_file(path_buf);
+    }
 
     // Reject offsets that would wrap negative when cast to i64.
     #[test]

--- a/curvine-fuse/src/fs/state/backend_handle.rs
+++ b/curvine-fuse/src/fs/state/backend_handle.rs
@@ -143,6 +143,9 @@ impl BackendHandle {
         // Serialize refresh state per file handle. The Arc cloned below keeps the
         // selected reader alive until this request has entered its channel, even
         // if a later request replaces the handle's current reader.
+        // Keep this lock across snapshot publication and reader reopen/install;
+        // releasing it between those awaits lets concurrent refreshes install
+        // readers for different snapshots and reintroduces the lifetime race.
         let mut reader_state = reader_state.lock().await;
 
         if let Some(writer) = state.find_writer(self.ino).await {
@@ -364,9 +367,9 @@ mod tests {
         use std::sync::Arc;
 
         let path_buf = std::env::temp_dir().join(format!(
-            "backend_handle_reader_arc_{}_{}",
+            "backend_handle_reader_arc_{}_{:?}",
             std::process::id(),
-            std::thread::current().name().unwrap_or("test")
+            std::thread::current().id()
         ));
         {
             let mut file = std::fs::File::create(&path_buf).unwrap();

--- a/curvine-fuse/src/fs/state/file_handle.rs
+++ b/curvine-fuse/src/fs/state/file_handle.rs
@@ -21,7 +21,6 @@ use crate::{err_fuse, FuseResult};
 use curvine_core_error::err_box;
 use curvine_fs_api::{StateReader, StateWriter};
 use curvine_model::{FileAllocOpts, FileStatus, LockFlags};
-use curvine_sys::RawPtr;
 use std::sync::Arc;
 
 pub enum FileHandle {
@@ -34,7 +33,7 @@ impl FileHandle {
     pub fn new_backend(
         ino: u64,
         fh: u64,
-        reader: Option<RawPtr<FuseReader>>,
+        reader: Option<Arc<FuseReader>>,
         writer: Option<Arc<FuseWriter>>,
         status: FileStatus,
     ) -> Self {

--- a/curvine-fuse/src/fs/state/node_state.rs
+++ b/curvine-fuse/src/fs/state/node_state.rs
@@ -39,7 +39,6 @@ use curvine_model::{
 };
 use curvine_runtime::common::FastHashMap;
 use curvine_runtime::sync::{AsyncMutex, AsyncSharedMap, AtomicCounter, RwLockHashMap};
-use curvine_sys::RawPtr;
 use futures::stream::{self, StreamExt};
 use log::{debug, error, info, warn};
 use std::borrow::Cow;
@@ -442,7 +441,7 @@ impl NodeState {
             };
             status.id = ino as i64;
             let handle = self
-                .insert_handle_with_writer(ino, Some(RawPtr::from_owned(reader)), None, status)
+                .insert_handle_with_writer(ino, Some(Arc::new(reader)), None, status)
                 .await;
             return Ok(handle);
         }
@@ -475,7 +474,7 @@ impl NodeState {
                 None
             } else {
                 let reader = self.new_reader(path).await?;
-                Some(RawPtr::from_owned(reader))
+                Some(Arc::new(reader))
             }
         } else {
             None
@@ -494,7 +493,7 @@ impl NodeState {
     async fn insert_handle_with_writer(
         &self,
         ino: u64,
-        reader: Option<RawPtr<FuseReader>>,
+        reader: Option<Arc<FuseReader>>,
         writer: Option<Arc<FuseWriter>>,
         status: FileStatus,
     ) -> Arc<FileHandle> {


### PR DESCRIPTION
**Describe the bug**
Curvine FUSE can panic or return a short buffered read when concurrent reads on the same file handle race with direct writes that trigger a dirty-reader refresh. `BackendHandle` stores its `FuseReader` behind an unsynchronized `RawPtr`, then replaces the pointed-to reader after publishing a writer snapshot. Multiple read requests can access, replace, or drop the same reader concurrently, corrupting the Tokio mpsc channel lifecycle.

The observed FUSE process failure is:

```text
thread 'curvine-fuse' panicked at tokio-1.48.0/src/sync/mpsc/chan.rs:324:13:
assertion failed: self.inner.semaphore.is_idle()
```

Once the daemon exits, outstanding or subsequent reads may return a short result, `EIO`, or `ENOTCONN`. This PR fixes the unsafe reader ownership and refresh race reported in #1498.

Closes #1498.

**To Reproduce**
Use the standalone reproducer and instructions attached to #1498. It shares one buffered-read file descriptor across multiple threads while an AIO direct writer repeatedly updates the same file, concentrating concurrent requests on one FUSE handle.

On an affected build, the test may report a short read or a disconnected mount:

```text
buffered pread returned <short-length>, expected 655360
```

or:

```text
buffered pread failed: Transport endpoint is not connected
```

The Curvine FUSE log then contains the Tokio mpsc assertion shown above. The reproducer source is intentionally not duplicated here because #1498 already contains the complete program, compilation command, and execution instructions.

**Expected behavior**
Concurrent buffered reads and direct writes must not race the lifetime of the per-handle reader. Every read request must retain a valid `FuseReader` until its task has entered that reader's channel, even when another request refreshes the handle to a newer writer snapshot.

The standalone reproducer should run for the requested duration without short reads, channel errors, FUSE panics, or mount disconnection:

```text
Running 20 concurrent buffered readers and one AIO direct writer for 60 seconds
PASS: completed <reads> reads and <writes> writes without disconnect
```

**Root cause**
The previous `BackendHandle` representation kept the reader and its snapshot version as independent, unsynchronized fields:

```rust
pub reader: Option<RawPtr<FuseReader>>,
read_ver: AtomicCounter,
```

When a read observed a newer shared writer version, it performed this sequence:

```text
publish dirty writer snapshot
open a new FuseReader
replace the value behind RawPtr
update read_ver
send the read through the selected reader
```

`RawPtr::replace()` uses `std::ptr::replace` without synchronization, while `RawPtr<T>` is unconditionally marked `Send` and `Sync`. Concurrent reads on one handle can therefore interleave as follows:

```text
Read A obtains the old raw reader pointer
Read B replaces the pointed-to FuseReader
Read B drops the old reader and its channel receiver
Read A accesses the replaced value or sends through a corrupted channel
```

Two refresh requests can also publish and install different snapshots while independently updating `read_ver`. The pointer mutation is a Rust data race and undefined behavior; the Tokio semaphore assertion is one observed consequence rather than the underlying defect.

Serializing only the writer-side snapshot publication is insufficient. The per-handle reader selection, reopen, installation, and snapshot-version update must form one synchronized state transition, and an in-flight request must retain ownership of the selected reader after leaving that critical section.

**Changes**

- Replace `RawPtr<FuseReader>` with reference-counted `Arc<FuseReader>` ownership.
- Store the current reader and `read_ver` together in a per-handle `ReaderState`.
- Guard `ReaderState` with an asynchronous mutex so snapshot publication, reader reopen, reader installation, and version advancement are serialized for one file handle.
- Clone the selected reader's `Arc` before releasing the refresh lock, allowing the request to safely enqueue work after a later refresh replaces the handle's current reader.
- Release the refresh lock before calling `FuseReader::read()`, preserving concurrent read submission instead of serializing backend reads.
- Use the same safe reader representation when opening and restoring file handles.
- Add a reader-lifetime regression test proving that replacing the handle's current reader does not drop the old reader while an in-flight request still owns an `Arc`.

The resulting read path is:

```text
lock per-handle ReaderState
check and publish the writer snapshot
reopen and install a reader when the version changed
clone Arc<FuseReader> for this request
unlock ReaderState
enqueue the read through the retained reader
```

**Concurrency and performance impact**
The new mutex protects only refresh bookkeeping and reader selection. It is not held while the backend read executes or while the queued request waits for its FUSE reply.

- Reads using the same handle may briefly serialize while checking or refreshing the writer snapshot.
- Normal read tasks remain concurrently enqueueable after cloning the selected reader.
- Different file handles use independent locks.
- Replaced readers stay alive only while existing requests retain them and are released automatically afterward.
- No global filesystem or path lock is introduced.

**OS Version (please complete the following information):**
 - OS: Ubuntu Linux
 - Kernel: 5.15.0-72-generic
 - Architecture: x86_64
 - Filesystem client: Curvine FUSE
 - Tokio version: 1.48.0

**Verification**

- Run the standalone concurrent-read reproducer from #1498 and verify that it completes without a short read, channel error, or FUSE disconnect.
- Run the affected concurrent buffered-read/direct-write scenario repeatedly. An isolated Curvine cluster produced 10 consecutive successful runs, each completing in approximately 31-32 seconds:

```text
TOTAL:    10
PASS:     10
FAIL:     0
TIMEOUT:  0
```

- Run the reader replacement lifetime unit test.
- Run `cargo test -p curvine-fuse --lib -- --test-threads=1`.
- Run `cargo check -p curvine-fuse`.
- Run `cargo clippy -p curvine-fuse --all-targets -- -D warnings`.
- Run `cargo fmt --all -- --check`.
- Run `git diff --check`.
- Run `make all`.

**Additional context**
The earlier writer-side `publish_dirty_read_snapshot()` serialization prevents a flush from overtaking an in-progress write enqueue, but it does not protect mutable reader ownership inside `BackendHandle`. This PR keeps that writer ordering and adds the missing per-handle reader-state synchronization.

The fix deliberately avoids modifying the generic `RawPtr` implementation. Other uses may have different ownership constraints, while `BackendHandle` specifically needs shared lifetime management across asynchronous read requests. Using `Arc<FuseReader>` at this boundary makes that lifetime explicit and removes the unsafe pointer operation from the affected path.
