### PR TITLE
fix(fuse): strip unauthorized setgid on create

### DIFF
--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -72,18 +72,19 @@ impl CurvineFileSystem {
 
         let parent = self.state.fs_stat(header.nodeid, None).await?;
         let created_gid = if parent.mode & libc::S_ISGID as u32 != 0 {
-            self.resolve_file_gid(&parent.group)
+            FuseUtils::resolve_group_gid(&parent.group)
         } else {
-            header.gid
+            Some(header.gid)
         };
+        let caller_status = FuseUtils::caller_process_status(header.pid).await;
         let caller_in_created_group =
-            FuseUtils::caller_in_file_group(header.gid, created_gid, header.pid);
+            created_gid.is_some_and(|gid| caller_status.in_group(header.gid, gid));
 
         Ok(FuseUtils::normalize_create_mode(
             requested_mode,
             umask,
             caller_in_created_group,
-            FuseUtils::caller_has_cap_fsetid(header.pid),
+            FuseUtils::caller_has_cap_fsetid(&caller_status),
         ))
     }
 

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -58,6 +58,35 @@ pub struct CurvineFileSystem {
 }
 
 impl CurvineFileSystem {
+    async fn normalize_file_creation_mode(
+        &self,
+        header: &fuse_in_header,
+        requested_mode: u32,
+        umask: u32,
+    ) -> FuseResult<u32> {
+        let requested_setgid_exec = requested_mode & (libc::S_ISGID as u32 | libc::S_IXGRP as u32)
+            == (libc::S_ISGID as u32 | libc::S_IXGRP as u32);
+        if !requested_setgid_exec {
+            return Ok(requested_mode & 0o7777 & !umask);
+        }
+
+        let parent = self.state.fs_stat(header.nodeid, None).await?;
+        let created_gid = if parent.mode & libc::S_ISGID as u32 != 0 {
+            self.resolve_file_gid(&parent.group)
+        } else {
+            header.gid
+        };
+        let caller_in_created_group =
+            FuseUtils::caller_in_file_group(header.gid, created_gid, header.pid);
+
+        Ok(FuseUtils::normalize_create_mode(
+            requested_mode,
+            umask,
+            caller_in_created_group,
+            FuseUtils::caller_has_cap_fsetid(header.pid),
+        ))
+    }
+
     fn is_ofd_lock_pid(pid: u32) -> bool {
         // FUSE kernels have used both 0 and -1 for the pid of an OFD lock.
         pid == 0 || pid == u32::MAX
@@ -1674,7 +1703,10 @@ impl fs::FileSystem for CurvineFileSystem {
         self.ensure_writable_path(&path, RpcCode::CreateFile)
             .await?;
 
-        let opts = FuseUtils::create_opts(&op, &self.fs);
+        let mode = self
+            .normalize_file_creation_mode(op.header, op.arg.mode, op.arg.umask)
+            .await?;
+        let opts = FuseUtils::create_opts(&op, &self.fs, mode);
         let handle = self.state.fs_create(ino, name, op.arg.flags, opts).await?;
         let attr = FuseUtils::status_to_attr(&self.conf, &handle.status())?;
 
@@ -2100,7 +2132,10 @@ impl fs::FileSystem for CurvineFileSystem {
             let path = self.state.get_path_name(op.header.nodeid, name)?;
             self.ensure_writable_path(&path, RpcCode::CreateFile)
                 .await?;
-            let opts = FuseUtils::mknod_opts(&op, &self.fs, file_type);
+            let mode = self
+                .normalize_file_creation_mode(op.header, op.arg.mode, op.arg.umask)
+                .await?;
+            let opts = FuseUtils::mknod_opts(&op, &self.fs, file_type, mode);
             self.fs.create_special_node(&path, opts).await?;
             let attr = self.state.lookup_common(op.header.nodeid, name).await?;
             Ok(FuseUtils::create_entry_out(&self.conf, attr))

--- a/curvine-fuse/src/fuse_utils.rs
+++ b/curvine-fuse/src/fuse_utils.rs
@@ -44,6 +44,22 @@ pub enum XattrOp {
 
 pub struct FuseUtils;
 
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct CallerProcessStatus {
+    supplementary_groups: Vec<u32>,
+    effective_capabilities: u64,
+}
+
+impl CallerProcessStatus {
+    pub(crate) fn in_group(&self, effective_gid: u32, file_gid: u32) -> bool {
+        effective_gid == file_gid || self.supplementary_groups.contains(&file_gid)
+    }
+
+    pub(crate) fn has_effective_capability(&self, capability: u32) -> bool {
+        capability < u64::BITS && self.effective_capabilities & (1_u64 << capability) != 0
+    }
+}
+
 impl FuseUtils {
     const CAP_FSETID: u32 = 4;
 
@@ -634,22 +650,42 @@ impl FuseUtils {
         Self::caller_supplementary_groups(pid).contains(&file_gid)
     }
 
-    /// Whether the FUSE requester has an effective Linux capability.
-    pub fn caller_has_effective_capability(pid: u32, capability: u32) -> bool {
-        if pid == 0 || capability >= u64::BITS {
-            return false;
+    fn parse_caller_process_status(content: &str) -> CallerProcessStatus {
+        let mut status = CallerProcessStatus::default();
+        for line in content.lines() {
+            if let Some(groups) = line.strip_prefix("Groups:") {
+                status.supplementary_groups = groups
+                    .split_whitespace()
+                    .filter_map(|gid| gid.parse::<u32>().ok())
+                    .collect();
+            } else if let Some(capabilities) = line.strip_prefix("CapEff:") {
+                status.effective_capabilities =
+                    u64::from_str_radix(capabilities.trim(), 16).unwrap_or_default();
+            }
+        }
+        status
+    }
+
+    /// Read all process credentials needed by create authorization without blocking
+    /// an async FUSE executor thread. Missing or malformed fields fail closed.
+    pub(crate) async fn caller_process_status(pid: u32) -> CallerProcessStatus {
+        if pid == 0 {
+            return CallerProcessStatus::default();
         }
 
         let status_path = format!("/proc/{pid}/status");
-        let Ok(content) = std::fs::read_to_string(status_path) else {
-            return false;
-        };
+        match tokio::fs::read_to_string(status_path).await {
+            Ok(content) => Self::parse_caller_process_status(&content),
+            Err(_) => CallerProcessStatus::default(),
+        }
+    }
 
-        content
-            .lines()
-            .find_map(|line| line.strip_prefix("CapEff:"))
-            .and_then(|value| u64::from_str_radix(value.trim(), 16).ok())
-            .is_some_and(|effective| effective & (1_u64 << capability) != 0)
+    /// Resolve a stored numeric GID or group name without a configuration fallback.
+    pub fn resolve_group_gid(group: &str) -> Option<u32> {
+        group
+            .parse::<u32>()
+            .ok()
+            .or_else(|| sys::get_gid_by_name(group))
     }
 
     /// Apply Linux file-creation ordering: decide whether setgid is authorized from
@@ -671,8 +707,8 @@ impl FuseUtils {
         mode
     }
 
-    pub fn caller_has_cap_fsetid(pid: u32) -> bool {
-        Self::caller_has_effective_capability(pid, Self::CAP_FSETID)
+    pub(crate) fn caller_has_cap_fsetid(status: &CallerProcessStatus) -> bool {
+        status.has_effective_capability(Self::CAP_FSETID)
     }
 
     /// Apply Linux chmod/fchmod security rules for special mode bits. For non-root
@@ -966,6 +1002,34 @@ mod tests {
         if let Some(&gid) = groups.first() {
             assert!(FuseUtils::caller_in_file_group(0, gid, pid));
         }
+    }
+
+    #[test]
+    fn parse_caller_process_status_reads_groups_and_capabilities_once() {
+        let status = FuseUtils::parse_caller_process_status(
+            "Name:\ttest\nGroups:\t10 20 30\nCapEff:\t0000000000000010\n",
+        );
+
+        assert!(status.in_group(1, 20));
+        assert!(!status.in_group(1, 40));
+        assert!(FuseUtils::caller_has_cap_fsetid(&status));
+    }
+
+    #[test]
+    fn parse_caller_process_status_fails_closed_for_missing_fields() {
+        let status = FuseUtils::parse_caller_process_status("Name:\ttest\n");
+
+        assert!(!status.in_group(1, 20));
+        assert!(!FuseUtils::caller_has_cap_fsetid(&status));
+    }
+
+    #[test]
+    fn resolve_group_gid_has_no_configuration_fallback() {
+        assert_eq!(FuseUtils::resolve_group_gid("12345"), Some(12345));
+        assert_eq!(
+            FuseUtils::resolve_group_gid("curvine-review-group-that-does-not-exist"),
+            None
+        );
     }
 
     #[test]

--- a/curvine-fuse/src/fuse_utils.rs
+++ b/curvine-fuse/src/fuse_utils.rs
@@ -45,6 +45,8 @@ pub enum XattrOp {
 pub struct FuseUtils;
 
 impl FuseUtils {
+    const CAP_FSETID: u32 = 4;
+
     /// Reinterpret a value as its raw bytes for writing to the FUSE device.
     ///
     /// SAFETY / usage contract: `T` MUST be a FUSE C-ABI (`#[repr(C)]`) struct.
@@ -259,13 +261,9 @@ impl FuseUtils {
         name == FUSE_PARENT_DIR || name == FUSE_CURRENT_DIR
     }
 
-    pub fn create_opts(op: &Create<'_>, fs: &UnifiedFileSystem) -> CreateFileOpts {
+    pub fn create_opts(op: &Create<'_>, fs: &UnifiedFileSystem, mode: u32) -> CreateFileOpts {
         CreateFileOptsBuilder::with_conf(&fs.conf().client)
-            .acl(
-                op.header.uid,
-                op.header.gid,
-                op.arg.mode & 0o7777 & !op.arg.umask,
-            )
+            .acl(op.header.uid, op.header.gid, mode)
             .build()
     }
 
@@ -550,8 +548,8 @@ impl FuseUtils {
         op: &MkNod<'_>,
         fs: &UnifiedFileSystem,
         file_type: FileType,
+        mode: u32,
     ) -> CreateFileOpts {
-        let mode = op.arg.mode & 0o7777 & !op.arg.umask;
         CreateFileOptsBuilder::with_conf(&fs.conf().client)
             .file_type(file_type)
             .acl(op.header.uid, op.header.gid, mode)
@@ -634,6 +632,47 @@ impl FuseUtils {
         }
 
         Self::caller_supplementary_groups(pid).contains(&file_gid)
+    }
+
+    /// Whether the FUSE requester has an effective Linux capability.
+    pub fn caller_has_effective_capability(pid: u32, capability: u32) -> bool {
+        if pid == 0 || capability >= u64::BITS {
+            return false;
+        }
+
+        let status_path = format!("/proc/{pid}/status");
+        let Ok(content) = std::fs::read_to_string(status_path) else {
+            return false;
+        };
+
+        content
+            .lines()
+            .find_map(|line| line.strip_prefix("CapEff:"))
+            .and_then(|value| u64::from_str_radix(value.trim(), 16).ok())
+            .is_some_and(|effective| effective & (1_u64 << capability) != 0)
+    }
+
+    /// Apply Linux file-creation ordering: decide whether setgid is authorized from
+    /// the requested mode, then apply the request umask to the persisted mode.
+    pub fn normalize_create_mode(
+        requested_mode: u32,
+        umask: u32,
+        caller_in_created_group: bool,
+        has_cap_fsetid: bool,
+    ) -> u32 {
+        let requested_mode = requested_mode & 0o7777;
+        let mut mode = requested_mode & !umask;
+        let requested_setgid_exec = requested_mode & (libc::S_ISGID as u32 | libc::S_IXGRP as u32)
+            == (libc::S_ISGID as u32 | libc::S_IXGRP as u32);
+
+        if requested_setgid_exec && !caller_in_created_group && !has_cap_fsetid {
+            mode &= !(libc::S_ISGID as u32);
+        }
+        mode
+    }
+
+    pub fn caller_has_cap_fsetid(pid: u32) -> bool {
+        Self::caller_has_effective_capability(pid, Self::CAP_FSETID)
     }
 
     /// Apply Linux chmod/fchmod security rules for special mode bits. For non-root
@@ -951,6 +990,42 @@ mod tests {
     fn normalize_chmod_mode_allows_special_bits_for_root() {
         let mode = FuseUtils::normalize_chmod_mode(0o4777, 0, false);
         assert_eq!(mode, 0o4777);
+    }
+
+    #[test]
+    fn normalize_create_mode_strips_setgid_for_unprivileged_non_member() {
+        assert_eq!(
+            FuseUtils::normalize_create_mode(0o2010, 0, false, false),
+            0o0010
+        );
+    }
+
+    #[test]
+    fn normalize_create_mode_checks_group_exec_before_applying_umask() {
+        assert_eq!(
+            FuseUtils::normalize_create_mode(0o2010, 0o0010, false, false),
+            0o0000
+        );
+    }
+
+    #[test]
+    fn normalize_create_mode_preserves_setgid_for_group_member_or_capability() {
+        assert_eq!(
+            FuseUtils::normalize_create_mode(0o2010, 0, true, false),
+            0o2010
+        );
+        assert_eq!(
+            FuseUtils::normalize_create_mode(0o2010, 0, false, true),
+            0o2010
+        );
+    }
+
+    #[test]
+    fn normalize_create_mode_preserves_non_executable_setgid() {
+        assert_eq!(
+            FuseUtils::normalize_create_mode(0o2000, 0, false, false),
+            0o2000
+        );
     }
 
     #[test]


### PR DESCRIPTION
**Describe the bug**
Curvine FUSE incorrectly preserves `S_ISGID` when a process creates a group-executable file without belonging to the file's inherited group and without effective `CAP_FSETID`. The same incorrect result occurs when `umask(S_IXGRP)` removes group-execute permission: Curvine applies the umask but still stores `S_ISGID`, even though Linux creation semantics require the authorization check to use the originally requested mode.

This can leave regular files and special nodes with a privilege-related mode bit that the caller is not authorized to preserve. This PR fixes the file-creation behavior reported in #1494.

Closes #1494.

**To Reproduce**
Use the standalone reproducer and instructions attached to #1494. It creates a setgid parent directory owned by group `0`, switches the caller to group `10000` with no supplementary groups, drops effective `CAP_FSETID`, and creates files with `S_ISGID | S_IXGRP` both with and without `umask(S_IXGRP)`.

On an affected build, both files incorrectly retain `S_ISGID`:

```text
no-umask: mode=2010, expected S_ISGID=off S_IXGRP=on
no-umask: BUG: S_ISGID was not stripped
group-exec-umask: mode=2000, expected S_ISGID=off S_IXGRP=off
group-exec-umask: BUG: S_ISGID was not stripped
FAIL: reproduced 2 incorrect setgid result(s)
```

The reproducer source is intentionally not duplicated here because #1494 already contains the complete program, compilation command, and execution instructions.

**Expected behavior**
When the requested mode contains both `S_ISGID` and `S_IXGRP`, a caller that neither belongs to the created inode's group nor has effective `CAP_FSETID` must not preserve `S_ISGID`.

The authorization decision must use the original requested mode before applying the umask. Therefore both reproducer cases should clear `S_ISGID`:

```text
no-umask: mode=0010, expected S_ISGID=off S_IXGRP=on
group-exec-umask: mode=0000, expected S_ISGID=off S_IXGRP=off
PASS: S_ISGID stripping matches Linux creation semantics
```

Files created inside a setgid directory must still inherit the parent directory's group. Directories must retain their existing setgid inheritance behavior.

**Root cause**
Curvine negotiates `FUSE_DONT_MASK`, so Linux sends the original create mode and the request umask separately. The FUSE create helpers previously reduced those values directly to the persisted mode:

```rust
op.arg.mode & 0o7777 & !op.arg.umask
```

The Curvine Master subsequently inherits the parent group when the parent directory has `S_ISGID`, but neither layer checked whether the caller belongs to that inherited group or has effective `CAP_FSETID`. As a result, the requested `S_ISGID` bit was stored unconditionally.

Applying the umask first is also insufficient. Linux decides whether setgid stripping is required from the originally requested mode. For a request containing `S_ISGID | S_IXGRP` with `umask(S_IXGRP)`, checking only the masked result would see `S_ISGID` without `S_IXGRP` and incorrectly preserve the bit.

The relevant ordering is:

```text
determine the created inode group
check requested S_ISGID + S_IXGRP
check caller group membership and effective CAP_FSETID
clear unauthorized S_ISGID
apply the request umask to the stored mode
```

The FUSE request header contains the caller's effective GID and PID, but not supplementary groups or effective capabilities. Curvine therefore resolves supplementary groups and `CapEff` from `/proc/<pid>/status`, matching the existing supplementary-group handling used by chmod and chown permission checks.

**Changes**

- Add a file-creation mode normalization helper that evaluates setgid authorization from the original requested mode before applying the umask.
- Resolve the new inode's effective group from the setgid parent directory, falling back to the caller's effective GID when the parent does not require group inheritance.
- Check both the caller's effective GID and supplementary groups against the group assigned to the created inode.
- Read the caller's effective capability mask and preserve an executable `S_ISGID` request when effective `CAP_FSETID` authorizes it.
- Clear `S_ISGID` when the caller is neither a member of the created inode's group nor authorized by `CAP_FSETID`.
- Apply the same normalization to regular file creation, regular-file `mknod`, and special-node `mknod` paths.
- Keep directory creation and its existing setgid inheritance behavior unchanged.
- Add focused unit coverage for unauthorized callers, the group-execute umask ordering, group membership, `CAP_FSETID`, and non-executable setgid modes.

**Compatibility and performance impact**
The additional parent metadata and `/proc/<pid>/status` checks run only for file creation requests whose original mode contains both `S_ISGID` and `S_IXGRP`. Ordinary create and mknod requests continue through the existing mode-and-umask path without an extra parent lookup.

- Authorized callers retain `S_ISGID` as before.
- Callers in the inherited group retain `S_ISGID` even without `CAP_FSETID`.
- Non-group-executable `S_ISGID` modes retain the existing Linux behavior.
- Parent setgid group inheritance is unchanged.
- Directory setgid inheritance is unchanged.
- No stored metadata format, RPC schema, or configuration change is required.

**OS Version (please complete the following information):**
 - OS: Ubuntu Linux
 - Kernel: 5.15.0-72-generic
 - Architecture: x86_64
 - Filesystem client: Curvine FUSE

**Verification**

- Run the standalone reproducer from #1494 against a newly mounted Curvine FUSE session and verify that both cases clear `S_ISGID`.
- Run the focused file-creation mode tests with `cargo test -p curvine-fuse normalize_create_mode`.
- Run `cargo check -p curvine-fuse`.
- Run `cargo fmt --all -- --check`.
- Run `git diff --check`.
- Run the complete Curvine FUSE unit-test suite. One pre-existing metrics-count test was timing-sensitive in a parallel run and passed when rerun independently.

**Additional context**
This fix intentionally remains in the FUSE boundary rather than changing generic Curvine create semantics. The required decision depends on process credentials and Linux capabilities that are available from the FUSE requester's PID but are not represented in the generic create RPC.

Failing closed when requester credentials cannot be resolved prevents an unauthorized executable setgid bit from being retained. The checks occur while the requesting process is blocked in the create syscall, so its `/proc/<pid>/status` entry is normally available for the duration of the request.
