### PR TITLE
fix(fuse): order OFD lock cleanup with queries

### DIFF
--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -369,6 +369,18 @@ impl CurvineFileSystem {
         Ok(())
     }
 
+    /// Serialize one Master lock-state operation with close-time lock cleanup.
+    /// Blocking SETLKW retries acquire this guard per attempt, never while waiting.
+    async fn get_lock_ordered(&self, path: &Path, lock: FileLock) -> FuseResult<Option<FileLock>> {
+        let _guard = self.state.lock_path(path).await;
+        Ok(self.fs.get_lock(path, lock).await?)
+    }
+
+    async fn set_lock_ordered(&self, path: &Path, lock: FileLock) -> FuseResult<Option<FileLock>> {
+        let _guard = self.state.lock_path(path).await;
+        Ok(self.fs.set_lock(path, lock).await?)
+    }
+
     fn record_negative_entry(&self) {
         if self.conf.metrics_enabled {
             FuseMetrics::with(|m| m.record_negative_entry());
@@ -1731,6 +1743,8 @@ impl fs::FileSystem for CurvineFileSystem {
         // lock_owner on almost every FUSE_FLUSH/close; unconditional unlock
         // caused a Master SetLock+journal storm for Spark local-dirs (#1227).
         if op.arg.lock_owner != 0 && handle.take_plock_if_owner(op.arg.lock_owner).is_some() {
+            let path = Path::from_str(&handle.status().path)?;
+            let _guard = self.state.lock_path(&path).await;
             if let Err(e) = self
                 .fs_unlock_owner(&handle, LockFlags::Plock, op.arg.lock_owner)
                 .await
@@ -2115,7 +2129,7 @@ impl fs::FileSystem for CurvineFileSystem {
 
         self.state.fs_fsync(op.header.nodeid, None).await?;
 
-        let conflict = self.fs.get_lock(&path, lock).await?;
+        let conflict = self.get_lock_ordered(&path, lock).await?;
         let lk = match conflict {
             Some(lk) => fuse_file_lock {
                 start: lk.start,
@@ -2149,7 +2163,7 @@ impl fs::FileSystem for CurvineFileSystem {
             lock.end = u64::MAX;
         }
 
-        let conflict = self.fs.set_lock(&path, lock).await?;
+        let conflict = self.set_lock_ordered(&path, lock).await?;
         if conflict.is_none() {
             if is_unlock {
                 // Full-range unlock drops this owner from handle bookkeeping so a
@@ -2204,7 +2218,7 @@ impl fs::FileSystem for CurvineFileSystem {
             ),
         );
         loop {
-            let conflict = self.fs.set_lock(&path, lock.clone()).await?;
+            let conflict = self.set_lock_ordered(&path, lock.clone()).await?;
             if conflict.is_none() {
                 wait_guard.clear_blocked_by();
                 if is_unlock {
@@ -2254,7 +2268,7 @@ impl fs::FileSystem for CurvineFileSystem {
                 // deadlock (LTP fcntl17) still observes the cycle. If the lock
                 // is free now (OFD unlock/re-lock race, LTP fcntl34), acquire
                 // instead of returning a false EDEADLK.
-                let conflict2 = self.fs.set_lock(&path, lock.clone()).await?;
+                let conflict2 = self.set_lock_ordered(&path, lock.clone()).await?;
                 if conflict2.is_none() {
                     wait_guard.clear_blocked_by();
                     if is_unlock {

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -1743,7 +1743,13 @@ impl fs::FileSystem for CurvineFileSystem {
         // lock_owner on almost every FUSE_FLUSH/close; unconditional unlock
         // caused a Master SetLock+journal storm for Spark local-dirs (#1227).
         if op.arg.lock_owner != 0 && handle.take_plock_if_owner(op.arg.lock_owner).is_some() {
-            let path = Path::from_str(&handle.status().path)?;
+            let path = match Path::from_str(&handle.status().path) {
+                Ok(path) => path,
+                Err(e) => {
+                    handle.add_lock(LockFlags::Plock, op.arg.lock_owner);
+                    return Err(e.into());
+                }
+            };
             let _guard = self.state.lock_path(&path).await;
             if let Err(e) = self
                 .fs_unlock_owner(&handle, LockFlags::Plock, op.arg.lock_owner)


### PR DESCRIPTION
**Describe the bug**
Curvine FUSE can intermittently expose an open-file-description (OFD) lock after the final reference to the locked file description has been closed. A concurrent `F_OFD_GETLK` may still observe the old lock even though Linux requires OFD locks to be released when the final reference is closed.

This PR fixes the close-versus-lock-query ordering race reported in #1502.

Closes #1502.

**To Reproduce**
Use the standalone reproducer and instructions attached to #1502. The reproducer acquires an OFD write lock, closes the final shared descriptor through a `clone(CLONE_FILES)` child, and immediately queries the lock from a separate open file description.

On an affected build, repeated executions occasionally observe the stale write lock after `close(2)` has completed:

```text
run=087 rc=1 FAIL: stale OFD lock observed after close
run=186 rc=1 FAIL: stale OFD lock observed after close
pass=498 fail=2 errors=0
```

The reproducer source is intentionally not duplicated here because #1502 already contains the complete program, compilation command, execution loop, and local-filesystem control result.

**Expected behavior**
After the final reference to an OFD-locked open file description is closed, a later lock query from another open file description must observe `F_UNLCK`:

```text
PASS: OFD lock released before GETLK
```

Curvine must preserve the request ordering between close-time lock cleanup and subsequent Master lock-state reads or updates for the same file.

**Root cause**
FUSE `RELEASE` and metadata lock requests are dispatched independently. `RELEASE` already acquires Curvine's striped path lock and keeps it held while it removes the file handle and sends the final flock/plock unlock operations to the Master:

```text
RELEASE
  acquire path lock
  remove/close handle
  clear lock owners in Master
  release path lock
  reply to kernel
```

`GETLK`, `SETLK`, and `SETLKW` previously called the Master without acquiring that path lock. Their tasks could therefore interleave with an earlier `RELEASE` task:

```text
RELEASE task                    GETLK task
------------                    ----------
waiting to run/unlock           query Master
                                observe stale OFD lock
clear lock in Master
reply to close
```

The process-level synchronization in the reproducer orders the userspace lock query after `close(2)`, but Curvine's independent asynchronous request tasks did not preserve that ordering at the Master lock state.

The same ordering requirement applies to `FLUSH` when it performs POSIX lock-owner cleanup. Without serialization, a later lock query or update can overtake the cleanup RPC.

Holding one serialization guard throughout a blocking `SETLKW` wait would be unsafe. The unlock request needed to satisfy the waiter could require the same guard, causing a deadlock. The guard must cover only each individual Master lock-state attempt and be released before the retry wait.

**Changes**

- Add ordered Master lock helpers that acquire the existing striped path lock around one `get_lock` or `set_lock` RPC.
- Serialize `GETLK` with close-time lock cleanup for the same path.
- Serialize nonblocking `SETLK` operations with close-time lock cleanup.
- Acquire the path lock for each individual `SETLKW` Master attempt, then release it before waiting or retrying.
- Apply the same path ordering to `FLUSH` when it clears a recorded POSIX lock owner.
- Keep `RELEASE`'s existing path-lock scope across file-handle cleanup and final flock/plock unlock RPCs.
- Preserve existing lock-owner bookkeeping, deadlock detection, retry notification, and full-range unlock normalization.

The resulting blocking lock flow is:

```text
acquire path lock
attempt Master SETLKW operation
release path lock

if blocked:
  register/recheck deadlock state
  wait without the path lock
  retry
```

**Concurrency and performance impact**
The change introduces no global lock. Curvine continues to use its existing striped path-lock table.

- Lock-state RPCs for the same path are serialized with `RELEASE` and lock-cleaning `FLUSH` requests.
- Lock operations on different stripes remain concurrent.
- `SETLKW` does not hold the path lock while sleeping or waiting for another owner.
- The guard covers only one Master lock read or update at a time.
- Normal reads, writes, metadata lookups, and files without lock operations are unaffected.
- No RPC schema, stored metadata, or configuration change is required.

**OS Version (please complete the following information):**
 - OS: Ubuntu Linux
 - Kernel: 5.15.0-72-generic
 - Architecture: x86_64
 - Filesystem client: Curvine FUSE

**Verification**

- Build the updated Curvine FUSE binary and mount it at an isolated temporary mount point connected to the existing Curvine cluster.
- Run the standalone reproducer from #1502 for 500 iterations. The fixed build completed without stale locks or execution errors:

```text
pass=500 fail=0 errors=0
```

- Run `cargo test -p curvine-fuse --lib -- --test-threads=1`:

```text
test result: ok. 417 passed; 0 failed; 0 ignored
```

- Run `cargo check -p curvine-fuse`.
- Run `cargo fmt --all -- --check`.
- Run `git diff --check`.

**Additional context**
The fix uses the same path lock that `RELEASE` already holds, so it directly orders the Master lock operation that removes the OFD owner against later queries and updates. It does not rely on sleeps, retries after a stale result, or changing the Master lock model.

The lock is striped rather than one mutex per inode, so unrelated paths can collide on a stripe and briefly serialize. That behavior already exists for release and other protected operations; this PR extends the same ordering boundary only to remote lock-state RPCs.
