### PR TITLE
refactor(rpc): rename GetMasterInfo to GetFilesystemInfo (#1575)

### DIFF
--- a/crates/client/curvine-client-core/src/file/curvine_filesystem.rs
+++ b/crates/client/curvine-client-core/src/file/curvine_filesystem.rs
@@ -26,7 +26,7 @@ use curvine_model::ProtoUtils;
 use curvine_model::{CommitBlock, DeleteResult, FreeResult, ListOptions};
 use curvine_model::{
     CreateFileOpts, CreateFileOptsBuilder, FileAllocOpts, FileBlocks, FileLock, FileStatus,
-    MasterInfo, MkdirOpts, MkdirOptsBuilder, MountInfo, MountOptions, OpenFlags, RenameFlags,
+    FilesystemInfo, MkdirOpts, MkdirOptsBuilder, MountInfo, MountOptions, OpenFlags, RenameFlags,
     SetAttrOpts,
 };
 use curvine_proto::{GetCvMetadataDeltaPageResponse, GetCvMetadataSnapshotPageResponse};
@@ -286,12 +286,12 @@ impl CurvineFileSystem {
         self.fs_client.get_block_locations(path).await
     }
 
-    pub async fn get_master_info(&self) -> FsResult<MasterInfo> {
-        self.fs_client.get_master_info().await
+    pub async fn get_filesystem_info(&self) -> FsResult<FilesystemInfo> {
+        self.fs_client.get_filesystem_info().await
     }
 
-    pub async fn get_master_info_bytes(&self) -> FsResult<BytesMut> {
-        self.fs_client.get_master_info_bytes().await
+    pub async fn get_filesystem_info_bytes(&self) -> FsResult<BytesMut> {
+        self.fs_client.get_filesystem_info_bytes().await
     }
 
     pub async fn get_mount_table(&self) -> FsResult<Vec<MountInfo>> {

--- a/crates/client/curvine-client-core/src/file/fs_client.rs
+++ b/crates/client/curvine-client-core/src/file/fs_client.rs
@@ -531,14 +531,14 @@ impl FsClient {
         self.rpc(RpcCode::GetCvMetadataDeltaPage, header).await
     }
 
-    pub async fn get_master_info(&self) -> FsResult<MasterInfo> {
+    pub async fn get_filesystem_info(&self) -> FsResult<FilesystemInfo> {
         let header = GetFilesystemInfoRequest::default();
         let rep: GetFilesystemInfoResponse = self.rpc(RpcCode::GetFilesystemInfo, header).await?;
-        let res = ProtoUtils::master_info_from_pb(rep);
+        let res = ProtoUtils::filesystem_info_from_pb(rep);
         Ok(res)
     }
 
-    pub async fn get_master_info_bytes(&self) -> FsResult<BytesMut> {
+    pub async fn get_filesystem_info_bytes(&self) -> FsResult<BytesMut> {
         let header = GetFilesystemInfoRequest::default();
         self.rpc_bytes(RpcCode::GetFilesystemInfo, header).await
     }

--- a/crates/client/curvine-client-core/src/file/fs_client.rs
+++ b/crates/client/curvine-client-core/src/file/fs_client.rs
@@ -532,15 +532,15 @@ impl FsClient {
     }
 
     pub async fn get_master_info(&self) -> FsResult<MasterInfo> {
-        let header = GetMasterInfoRequest::default();
-        let rep: GetMasterInfoResponse = self.rpc(RpcCode::GetMasterInfo, header).await?;
+        let header = GetFilesystemInfoRequest::default();
+        let rep: GetFilesystemInfoResponse = self.rpc(RpcCode::GetFilesystemInfo, header).await?;
         let res = ProtoUtils::master_info_from_pb(rep);
         Ok(res)
     }
 
     pub async fn get_master_info_bytes(&self) -> FsResult<BytesMut> {
-        let header = GetMasterInfoRequest::default();
-        self.rpc_bytes(RpcCode::GetMasterInfo, header).await
+        let header = GetFilesystemInfoRequest::default();
+        self.rpc_bytes(RpcCode::GetFilesystemInfo, header).await
     }
 
     pub async fn mount(

--- a/crates/client/curvine-unified-fs/src/unified/unified_filesystem.rs
+++ b/crates/client/curvine-unified-fs/src/unified/unified_filesystem.rs
@@ -204,12 +204,12 @@ impl UnifiedFileSystem {
 
     pub async fn get_master_info(&self) -> FsResult<MasterInfo> {
         let fut = async { self.cv.get_master_info().await };
-        self.track("GetMasterInfo", "", "", fut).await
+        self.track("GetFilesystemInfo", "", "", fut).await
     }
 
     pub async fn get_master_info_bytes(&self) -> FsResult<BytesMut> {
         let fut = async { self.cv.get_master_info_bytes().await };
-        self.track("GetMasterInfo", "", "", fut).await
+        self.track("GetFilesystemInfo", "", "", fut).await
     }
 
     pub async fn mount(&self, ufs_path: &Path, cv_path: &Path, opts: MountOptions) -> FsResult<()> {

--- a/crates/client/curvine-unified-fs/src/unified/unified_filesystem.rs
+++ b/crates/client/curvine-unified-fs/src/unified/unified_filesystem.rs
@@ -25,8 +25,8 @@ use curvine_error::FsResult;
 use curvine_fs_api::{FileSystem, FsKind, ListStream, Path, Reader, RpcCode, Writer};
 use curvine_job_client::{JobMasterClient, TransferClient};
 use curvine_model::{
-    CreateFileOpts, DeleteResult, FileAllocOpts, FileLock, FileStatus, FreeResult, JobStatus,
-    ListOptions, LoadJobCommand, MasterInfo, MkdirOpts, MkdirOptsBuilder, MountInfo, MountOptions,
+    CreateFileOpts, DeleteResult, FileAllocOpts, FileLock, FileStatus, FilesystemInfo, FreeResult,
+    JobStatus, ListOptions, LoadJobCommand, MkdirOpts, MkdirOptsBuilder, MountInfo, MountOptions,
     OpenFlags, RenameFlags, SetAttrOpts, TransferCommand, TransferKind, TransferState,
 };
 use curvine_runtime::common::TimeSpent;
@@ -202,13 +202,13 @@ impl UnifiedFileSystem {
         }
     }
 
-    pub async fn get_master_info(&self) -> FsResult<MasterInfo> {
-        let fut = async { self.cv.get_master_info().await };
+    pub async fn get_filesystem_info(&self) -> FsResult<FilesystemInfo> {
+        let fut = async { self.cv.get_filesystem_info().await };
         self.track("GetFilesystemInfo", "", "", fut).await
     }
 
-    pub async fn get_master_info_bytes(&self) -> FsResult<BytesMut> {
-        let fut = async { self.cv.get_master_info_bytes().await };
+    pub async fn get_filesystem_info_bytes(&self) -> FsResult<BytesMut> {
+        let fut = async { self.cv.get_filesystem_info_bytes().await };
         self.track("GetFilesystemInfo", "", "", fut).await
     }
 

--- a/crates/common/curvine-fs-api/src/rpc_code.rs
+++ b/crates/common/curvine-fs-api/src/rpc_code.rs
@@ -35,7 +35,7 @@ pub enum RpcCode {
     AddBlock = 11,
     CompleteFile = 12,
     GetBlockLocations = 13,
-    GetMasterInfo = 14,
+    GetFilesystemInfo = 14,
     SetAttr = 15,
     Symlink = 16,
     Link = 17,

--- a/crates/common/curvine-model/src/filesystem_info.rs
+++ b/crates/common/curvine-model/src/filesystem_info.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 #[serde(default)]
-pub struct MasterInfo {
+pub struct FilesystemInfo {
     pub active_master: String,
     pub journal_nodes: Vec<String>,
 
@@ -36,7 +36,7 @@ pub struct MasterInfo {
     pub lost_workers: Vec<WorkerInfo>,
 }
 
-impl MasterInfo {
+impl FilesystemInfo {
     pub fn journal_nodes_count(&self) -> usize {
         self.journal_nodes.len()
     }

--- a/crates/common/curvine-model/src/lib.rs
+++ b/crates/common/curvine-model/src/lib.rs
@@ -68,8 +68,8 @@ pub use self::block_info::*;
 mod file_status;
 pub use self::file_status::{FileStatus, INTERNAL_CTIME_XATTR};
 
-mod master_info;
-pub use self::master_info::MasterInfo;
+mod filesystem_info;
+pub use self::filesystem_info::FilesystemInfo;
 
 mod worker_command;
 pub use self::worker_command::*;

--- a/crates/common/curvine-model/src/proto_utils.rs
+++ b/crates/common/curvine-model/src/proto_utils.rs
@@ -303,8 +303,8 @@ impl ProtoUtils {
         }
     }
 
-    pub fn master_info_to_pb(src: MasterInfo) -> GetMasterInfoResponse {
-        let mut pb = GetMasterInfoResponse {
+    pub fn master_info_to_pb(src: MasterInfo) -> GetFilesystemInfoResponse {
+        let mut pb = GetFilesystemInfoResponse {
             active_master: src.active_master,
             journal_nodes: src.journal_nodes,
             inode_dir_num: src.inode_dir_num,
@@ -366,7 +366,7 @@ impl ProtoUtils {
         pb
     }
 
-    pub fn master_info_from_pb(src: GetMasterInfoResponse) -> MasterInfo {
+    pub fn master_info_from_pb(src: GetFilesystemInfoResponse) -> MasterInfo {
         MasterInfo {
             active_master: src.active_master,
             journal_nodes: src.journal_nodes,

--- a/crates/common/curvine-model/src/proto_utils.rs
+++ b/crates/common/curvine-model/src/proto_utils.rs
@@ -303,7 +303,7 @@ impl ProtoUtils {
         }
     }
 
-    pub fn master_info_to_pb(src: MasterInfo) -> GetFilesystemInfoResponse {
+    pub fn filesystem_info_to_pb(src: FilesystemInfo) -> GetFilesystemInfoResponse {
         let mut pb = GetFilesystemInfoResponse {
             active_master: src.active_master,
             journal_nodes: src.journal_nodes,
@@ -366,8 +366,8 @@ impl ProtoUtils {
         pb
     }
 
-    pub fn master_info_from_pb(src: GetFilesystemInfoResponse) -> MasterInfo {
-        MasterInfo {
+    pub fn filesystem_info_from_pb(src: GetFilesystemInfoResponse) -> FilesystemInfo {
+        FilesystemInfo {
             active_master: src.active_master,
             journal_nodes: src.journal_nodes,
             inode_dir_num: src.inode_dir_num,

--- a/crates/common/curvine-proto/proto/master.proto
+++ b/crates/common/curvine-proto/proto/master.proto
@@ -209,12 +209,12 @@ message GetBlockLocationsResponse {
     required FileBlocksProto blocks = 1;
 }
 
-// Request master profile information.
-message GetMasterInfoRequest {
+// Request filesystem-wide information (statfs backend).
+message GetFilesystemInfoRequest {
 
 }
 
-message GetMasterInfoResponse {
+message GetFilesystemInfoResponse {
     required string active_master = 1;
     repeated string journal_nodes = 2;
 

--- a/crates/sdk/curvine-libsdk-java/src/java/java_abi.rs
+++ b/crates/sdk/curvine-libsdk-java/src/java/java_abi.rs
@@ -270,13 +270,13 @@ pub unsafe extern "C" fn Java_io_curvine_CurvineNative_delete(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn Java_io_curvine_CurvineNative_getMasterInfo(
+pub unsafe extern "C" fn Java_io_curvine_CurvineNative_getFilesystemInfo(
     mut env: JNIEnv,
     _this: JObject,
     fs_ptr: *mut JavaFilesystem,
 ) -> jarray {
     let fs = &*fs_ptr;
-    java_err2!(env, fs.get_master_info(&mut env))
+    java_err2!(env, fs.get_filesystem_info(&mut env))
 }
 
 #[no_mangle]

--- a/crates/sdk/curvine-libsdk-java/src/java/java_filesystem.rs
+++ b/crates/sdk/curvine-libsdk-java/src/java/java_filesystem.rs
@@ -138,8 +138,8 @@ impl JavaFilesystem {
         self.inner.delete(path, JavaUtils::jbool_to_bool(recursive))
     }
 
-    pub fn get_master_info(&self, env: &mut JNIEnv) -> FsResult<jarray> {
-        let status = self.inner.get_master_info()?;
+    pub fn get_filesystem_info(&self, env: &mut JNIEnv) -> FsResult<jarray> {
+        let status = self.inner.get_filesystem_info()?;
         let byte_arr = JavaUtils::new_jarray(env, &status)?;
         Ok(byte_arr)
     }

--- a/crates/sdk/curvine-libsdk-python/src/python/python_abi.rs
+++ b/crates/sdk/curvine-libsdk-python/src/python/python_abi.rs
@@ -184,13 +184,13 @@ pub fn python_io_curvine_curvine_native_delete(
 }
 
 #[pyfunction]
-pub fn python_io_curvine_curvine_native_get_master_info<'py>(
+pub fn python_io_curvine_curvine_native_get_filesystem_info<'py>(
     ptr: usize,
     py: Python<'py>,
 ) -> PyResult<Bound<'py, PyBytes>> {
     let fs_ptr = ptr as *mut PythonFilesystem;
     let fs = unsafe { &*fs_ptr };
-    let status = fs.get_master_info().map_err(|e| e.into_py_err())?;
+    let status = fs.get_filesystem_info().map_err(|e| e.into_py_err())?;
     let bytes_data = status.freeze().to_vec();
     Ok(PyBytes::new(py, &bytes_data))
 }
@@ -282,7 +282,7 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
         m
     )?)?;
     m.add_function(wrap_pyfunction!(
-        python_io_curvine_curvine_native_get_master_info,
+        python_io_curvine_curvine_native_get_filesystem_info,
         m
     )?)?;
 

--- a/crates/sdk/curvine-libsdk-python/src/python/python_filesystem.rs
+++ b/crates/sdk/curvine-libsdk-python/src/python/python_filesystem.rs
@@ -61,7 +61,7 @@ impl PythonFilesystem {
         self.inner.delete(path, recursive).map(|_| ())
     }
 
-    //Get master information
+    //Get filesystem information
     pub fn get_filesystem_info(&self) -> FsResult<BytesMut> {
         let status = self.inner.get_filesystem_info()?;
         Ok(status)

--- a/crates/sdk/curvine-libsdk-python/src/python/python_filesystem.rs
+++ b/crates/sdk/curvine-libsdk-python/src/python/python_filesystem.rs
@@ -62,8 +62,8 @@ impl PythonFilesystem {
     }
 
     //Get master information
-    pub fn get_master_info(&self) -> FsResult<BytesMut> {
-        let status = self.inner.get_master_info()?;
+    pub fn get_filesystem_info(&self) -> FsResult<BytesMut> {
+        let status = self.inner.get_filesystem_info()?;
         Ok(status)
     }
 }

--- a/crates/sdk/curvine-sdk-core/src/core/filesystem.rs
+++ b/crates/sdk/curvine-sdk-core/src/core/filesystem.rs
@@ -121,6 +121,13 @@ impl LibFilesystem {
             .block_on(async { self.inner().get_filesystem_info_bytes().await })
     }
 
+    #[deprecated(
+        note = "renamed to get_filesystem_info; returns whole-filesystem stats, not master-process info"
+    )]
+    pub fn get_master_info(&self) -> FsResult<BytesMut> {
+        self.get_filesystem_info()
+    }
+
     pub fn get_mount_info(&self, path: impl AsRef<str>) -> FsResult<BytesMut> {
         let path = Path::from_str(path)?;
         self.rt()

--- a/crates/sdk/curvine-sdk-core/src/core/filesystem.rs
+++ b/crates/sdk/curvine-sdk-core/src/core/filesystem.rs
@@ -116,9 +116,9 @@ impl LibFilesystem {
         ))
     }
 
-    pub fn get_master_info(&self) -> FsResult<BytesMut> {
+    pub fn get_filesystem_info(&self) -> FsResult<BytesMut> {
         self.rt()
-            .block_on(async { self.inner().get_master_info_bytes().await })
+            .block_on(async { self.inner().get_filesystem_info_bytes().await })
     }
 
     pub fn get_mount_info(&self, path: impl AsRef<str>) -> FsResult<BytesMut> {

--- a/crates/sdk/curvine-sdk-core/src/core/master.rs
+++ b/crates/sdk/curvine-sdk-core/src/core/master.rs
@@ -14,11 +14,11 @@
 
 use crate::core::Session;
 use curvine_error::FsResult;
-use curvine_model::MasterInfo;
+use curvine_model::FilesystemInfo;
 use curvine_runtime::runtime::RpcRuntime;
 
-pub fn get_master_info(session: &Session) -> FsResult<MasterInfo> {
+pub fn get_filesystem_info(session: &Session) -> FsResult<FilesystemInfo> {
     session
         .runtime()
-        .block_on(async { session.unified().get_master_info().await })
+        .block_on(async { session.unified().get_filesystem_info().await })
 }

--- a/crates/sdk/curvine-sdk-core/src/core/master.rs
+++ b/crates/sdk/curvine-sdk-core/src/core/master.rs
@@ -22,3 +22,10 @@ pub fn get_filesystem_info(session: &Session) -> FsResult<FilesystemInfo> {
         .runtime()
         .block_on(async { session.unified().get_filesystem_info().await })
 }
+
+#[deprecated(
+    note = "renamed to get_filesystem_info; returns whole-filesystem stats, not master-process info"
+)]
+pub fn get_master_info(session: &Session) -> FsResult<FilesystemInfo> {
+    get_filesystem_info(session)
+}

--- a/crates/sdk/curvine-sdk-core/src/master.rs
+++ b/crates/sdk/curvine-sdk-core/src/master.rs
@@ -31,6 +31,13 @@ impl MasterClient {
         self.session.unified().get_filesystem_info().await
     }
 
+    #[deprecated(
+        note = "renamed to get_filesystem_info; returns whole-filesystem stats, not master-process info"
+    )]
+    pub async fn get_master_info(&self) -> FsResult<FilesystemInfo> {
+        self.get_filesystem_info().await
+    }
+
     /// Returns total and available capacity in a single RPC.
     pub async fn capacity_stats(&self) -> FsResult<(i64, i64)> {
         let info = self.get_filesystem_info().await?;

--- a/crates/sdk/curvine-sdk-core/src/master.rs
+++ b/crates/sdk/curvine-sdk-core/src/master.rs
@@ -14,7 +14,7 @@
 
 use crate::core::Session;
 use curvine_error::FsResult;
-use curvine_model::MasterInfo;
+use curvine_model::FilesystemInfo;
 use std::sync::Arc;
 
 #[derive(Clone)]
@@ -27,25 +27,25 @@ impl MasterClient {
         Self { session }
     }
 
-    pub async fn get_master_info(&self) -> FsResult<MasterInfo> {
-        self.session.unified().get_master_info().await
+    pub async fn get_filesystem_info(&self) -> FsResult<FilesystemInfo> {
+        self.session.unified().get_filesystem_info().await
     }
 
     /// Returns total and available capacity in a single RPC.
     pub async fn capacity_stats(&self) -> FsResult<(i64, i64)> {
-        let info = self.get_master_info().await?;
+        let info = self.get_filesystem_info().await?;
         Ok((info.capacity, info.available))
     }
 
     /// Returns total cluster capacity. Issues its own RPC; prefer [`Self::capacity_stats`]
-    /// or [`Self::get_master_info`] when multiple fields are needed.
+    /// or [`Self::get_filesystem_info`] when multiple fields are needed.
     pub async fn capacity(&self) -> FsResult<i64> {
-        Ok(self.get_master_info().await?.capacity)
+        Ok(self.get_filesystem_info().await?.capacity)
     }
 
     /// Returns available cluster capacity. Issues its own RPC; prefer [`Self::capacity_stats`]
-    /// or [`Self::get_master_info`] when multiple fields are needed.
+    /// or [`Self::get_filesystem_info`] when multiple fields are needed.
     pub async fn available(&self) -> FsResult<i64> {
-        Ok(self.get_master_info().await?.available)
+        Ok(self.get_filesystem_info().await?.available)
     }
 }

--- a/crates/server/curvine-data-transfer/src/transfer/cluster_cache.rs
+++ b/crates/server/curvine-data-transfer/src/transfer/cluster_cache.rs
@@ -118,7 +118,7 @@ impl ClusterMetadataCache {
 
     async fn refresh_inner(&self) -> FsResult<()> {
         let mounts = self.fs.get_mount_table().await?;
-        let master = self.fs.get_master_info().await?;
+        let master = self.fs.get_filesystem_info().await?;
         let mut workers = master.live_workers;
         {
             let mut rejected = self.rejected_worker_sessions.write();

--- a/crates/server/curvine-data-transfer/src/transfer/cluster_cache.rs
+++ b/crates/server/curvine-data-transfer/src/transfer/cluster_cache.rs
@@ -118,8 +118,8 @@ impl ClusterMetadataCache {
 
     async fn refresh_inner(&self) -> FsResult<()> {
         let mounts = self.fs.get_mount_table().await?;
-        let master = self.fs.get_filesystem_info().await?;
-        let mut workers = master.live_workers;
+        let fs_info = self.fs.get_filesystem_info().await?;
+        let mut workers = fs_info.live_workers;
         {
             let mut rejected = self.rejected_worker_sessions.write();
             rejected.retain(|(worker_id, worker_session_id)| {

--- a/curvine-cli/src/cmds/fs/df.rs
+++ b/curvine-cli/src/cmds/fs/df.rs
@@ -18,19 +18,19 @@ impl DfCommand {
         match self {
             DfCommand::Df { human_readable, .. } => {
                 // Get master info from the filesystem
-                match client.get_master_info().await {
-                    Ok(master_info) => {
+                match client.get_filesystem_info().await {
+                    Ok(filesystem_info) => {
                         // Format similar to HDFS df output
                         println!(
                             "Filesystem                Size             Used  Available  Use%"
                         );
 
                         // Calculate total used space (fs_used + non_fs_used)
-                        let used = master_info.fs_used + master_info.non_fs_used;
+                        let used = filesystem_info.fs_used + filesystem_info.non_fs_used;
 
                         // Calculate usage percentage
-                        let usage_percent = if master_info.capacity > 0 {
-                            (used as f64 / master_info.capacity as f64) * 100.0
+                        let usage_percent = if filesystem_info.capacity > 0 {
+                            (used as f64 / filesystem_info.capacity as f64) * 100.0
                         } else {
                             0.0
                         };
@@ -38,21 +38,29 @@ impl DfCommand {
                         // Format sizes based on human_readable flag
                         let (capacity, used_str, available) = if *human_readable {
                             (
-                                crate::cmds::fs::common::format_size(master_info.capacity as u64),
+                                crate::cmds::fs::common::format_size(
+                                    filesystem_info.capacity as u64,
+                                ),
                                 crate::cmds::fs::common::format_size(used as u64),
-                                crate::cmds::fs::common::format_size(master_info.available as u64),
+                                crate::cmds::fs::common::format_size(
+                                    filesystem_info.available as u64,
+                                ),
                             )
                         } else {
                             (
-                                master_info.capacity.to_string(),
+                                filesystem_info.capacity.to_string(),
                                 used.to_string(),
-                                master_info.available.to_string(),
+                                filesystem_info.available.to_string(),
                             )
                         };
 
                         println!(
                             "curvine://{}  {:>15}  {:>15}  {:>15}  {:.1}%",
-                            master_info.active_master, capacity, used_str, available, usage_percent
+                            filesystem_info.active_master,
+                            capacity,
+                            used_str,
+                            available,
+                            usage_percent
                         );
 
                         Ok(())

--- a/curvine-cli/src/cmds/fs/df.rs
+++ b/curvine-cli/src/cmds/fs/df.rs
@@ -17,7 +17,7 @@ impl DfCommand {
     pub async fn execute(&self, client: UnifiedFileSystem) -> CommonResult<()> {
         match self {
             DfCommand::Df { human_readable, .. } => {
-                // Get master info from the filesystem
+                // Get filesystem info from the filesystem
                 match client.get_filesystem_info().await {
                     Ok(filesystem_info) => {
                         // Format similar to HDFS df output
@@ -66,7 +66,7 @@ impl DfCommand {
                         Ok(())
                     }
                     Err(e) => {
-                        eprintln!("Error getting master info: {}", e);
+                        eprintln!("Error getting filesystem info: {}", e);
                         Err(e.into())
                     }
                 }

--- a/curvine-cli/src/cmds/node.rs
+++ b/curvine-cli/src/cmds/node.rs
@@ -56,8 +56,8 @@ impl NodeCommand {
         path: &str,
     ) -> CommonResult<String> {
         // Get master address and web port
-        let master_info = client.get_master_info().await?;
-        let master_parts: Vec<&str> = master_info.active_master.split(':').collect();
+        let filesystem_info = client.get_filesystem_info().await?;
+        let master_parts: Vec<&str> = filesystem_info.active_master.split(':').collect();
         let master_host = master_parts[0];
         let web_port = conf.master.web_port;
 

--- a/curvine-cli/src/cmds/report.rs
+++ b/curvine-cli/src/cmds/report.rs
@@ -15,7 +15,7 @@
 use crate::util::*;
 use clap::{Parser, Subcommand};
 use curvine_core_error::CommonResult;
-use curvine_model::{MasterInfo, WorkerInfo};
+use curvine_model::{FilesystemInfo, WorkerInfo};
 use curvine_unified_fs::UnifiedFileSystem;
 use serde::Serialize;
 
@@ -44,7 +44,7 @@ pub enum ReportSubCommand {
 
 impl ReportCommand {
     pub async fn execute(&self, fs: UnifiedFileSystem) -> CommonResult<()> {
-        let rep = handle_rpc_result(fs.get_master_info()).await;
+        let rep = handle_rpc_result(fs.get_filesystem_info()).await;
         let report = CurvineReport { info: rep };
         match &self.action {
             Some(action) => match action {
@@ -80,7 +80,7 @@ impl ReportCommand {
 }
 
 struct CurvineReport {
-    info: MasterInfo,
+    info: FilesystemInfo,
 }
 
 #[derive(Serialize)]
@@ -95,7 +95,7 @@ struct FluidReportSummary {
 }
 
 impl CurvineReport {
-    // Serialize the MasterInfo to JSON
+    // Serialize the FilesystemInfo to JSON
     pub fn to_json(&self) -> String {
         match serde_json::to_string_pretty(&self.info) {
             Ok(json) => json,
@@ -471,7 +471,7 @@ mod tests {
             ..Default::default()
         };
         let report = CurvineReport {
-            info: MasterInfo {
+            info: FilesystemInfo {
                 live_workers: vec![worker],
                 ..Default::default()
             },

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -1571,7 +1571,7 @@ impl fs::FileSystem for CurvineFileSystem {
 
     // Get file system profile information.
     async fn stat_fs(&self, _: StatFs<'_>) -> FuseResult<fuse_kstatfs> {
-        let info = self.fs.get_master_info().await?;
+        let info = self.fs.get_filesystem_info().await?;
 
         let block_size = 4 * ByteUnit::KB as u32;
         let total_blocks = (info.capacity / block_size as i64) as u64;

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineFileSystem.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineFileSystem.java
@@ -449,7 +449,7 @@ public class CurvineFileSystem extends FileSystem {
             statistics.incrementReadOps(1);
         }
 
-        byte[] bytes = libFs.getMasterInfo();
+        byte[] bytes = libFs.getFilesystemInfo();
         GetFilesystemInfoResponse info = GetFilesystemInfoResponse.parseFrom(bytes);
         return new CurvineFsStat(info);
     }

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineFileSystem.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineFileSystem.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
 import io.curvine.exception.CurvineException;
 import io.curvine.proto.FileStatusProto;
 import io.curvine.proto.GetFileStatusResponse;
-import io.curvine.proto.GetMasterInfoResponse;
+import io.curvine.proto.GetFilesystemInfoResponse;
 import io.curvine.proto.GetMountInfoResponse;
 import io.curvine.proto.ListStatusResponse;
 import io.curvine.proto.MountInfoProto;
@@ -450,7 +450,7 @@ public class CurvineFileSystem extends FileSystem {
         }
 
         byte[] bytes = libFs.getMasterInfo();
-        GetMasterInfoResponse info = GetMasterInfoResponse.parseFrom(bytes);
+        GetFilesystemInfoResponse info = GetFilesystemInfoResponse.parseFrom(bytes);
         return new CurvineFsStat(info);
     }
 

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineFsMount.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineFsMount.java
@@ -136,8 +136,8 @@ public class CurvineFsMount {
         checkError(CurvineNative.delete(nativeHandle, path, recursive));
     }
 
-    public byte[] getMasterInfo() throws IOException {
-        byte[] bytes = CurvineNative.getMasterInfo(nativeHandle);
+    public byte[] getFilesystemInfo() throws IOException {
+        byte[] bytes = CurvineNative.getFilesystemInfo(nativeHandle);
         checkError(bytes);
         return bytes;
     }

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineFsMount.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineFsMount.java
@@ -142,6 +142,16 @@ public class CurvineFsMount {
         return bytes;
     }
 
+    /**
+     * @deprecated renamed to {@link #getFilesystemInfo()}; this RPC returns
+     * whole-filesystem statistics, not master-process information. Kept for
+     * source compatibility and will be removed in a future release.
+     */
+    @Deprecated
+    public byte[] getMasterInfo() throws IOException {
+        return getFilesystemInfo();
+    }
+
     public byte[] getMountInfo(String path) throws IOException {
         byte[] bytes = CurvineNative.getMountInfo(nativeHandle, path);
         checkError(bytes);

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineFsStat.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineFsStat.java
@@ -15,20 +15,20 @@
 package io.curvine;
 
 import io.curvine.bench.Utils;
-import io.curvine.proto.GetMasterInfoResponse;
+import io.curvine.proto.GetFilesystemInfoResponse;
 import io.curvine.proto.WorkerInfoProto;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.fs.FsStatus;
 
 public class CurvineFsStat extends FsStatus {
-    private final GetMasterInfoResponse info;
+    private final GetFilesystemInfoResponse info;
 
-    public CurvineFsStat(GetMasterInfoResponse info) {
+    public CurvineFsStat(GetFilesystemInfoResponse info) {
         super(info.getCapacity(), info.getFsUsed(), info.getAvailable());
         this.info = info;
     }
 
-    public GetMasterInfoResponse getInfo() {
+    public GetFilesystemInfoResponse getInfo() {
         return info;
     }
 

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineNative.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineNative.java
@@ -329,7 +329,7 @@ public class CurvineNative {
 
     public static native long delete(long nativeHandle, String path, boolean recursive) throws IOException;
 
-    public static native byte[] getMasterInfo(long nativeHandle) throws IOException;
+    public static native byte[] getFilesystemInfo(long nativeHandle) throws IOException;
 
     public static native byte[] getMountInfo(long nativeHandle, String path) throws IOException;
 

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineNative.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineNative.java
@@ -331,6 +331,17 @@ public class CurvineNative {
 
     public static native byte[] getFilesystemInfo(long nativeHandle) throws IOException;
 
+    /**
+     * @deprecated renamed to {@link #getFilesystemInfo(long)}; this RPC returns
+     * whole-filesystem statistics, not master-process information. Kept as a
+     * non-native forwarder for source compatibility; will be removed in a
+     * future release.
+     */
+    @Deprecated
+    public static byte[] getMasterInfo(long nativeHandle) throws IOException {
+        return getFilesystemInfo(nativeHandle);
+    }
+
     public static native byte[] getMountInfo(long nativeHandle, String path) throws IOException;
 
     /** Create or update a UFS mount with a serialized {@code MountOptionsProto}. */

--- a/curvine-libsdk/python/curvinefs/curvineClient.py
+++ b/curvine-libsdk/python/curvinefs/curvineClient.py
@@ -9,7 +9,7 @@ import curvine_libsdk
 from curvine_libsdk._proto.common_pb2 import FileStatusProto
 from curvine_libsdk._proto.master_pb2 import (
     GetFileStatusResponse,
-    GetMasterInfoResponse,
+    GetFilesystemInfoResponse,
     ListStatusResponse,
 )
 
@@ -112,7 +112,7 @@ class CurvineClient:
             status_bytes = curvine_libsdk.python_io_curvine_curvine_native_get_master_info(self.file_system_ptr)
         except Exception as e:
             raise IOError(f"Native get master information failed: {e}")
-        status = GetMasterInfoResponse()
+        status = GetFilesystemInfoResponse()
         status.ParseFromString(status_bytes)
         status_dict = {
             "active_master": status.active_master,

--- a/curvine-libsdk/python/curvinefs/curvineClient.py
+++ b/curvine-libsdk/python/curvinefs/curvineClient.py
@@ -4,6 +4,7 @@ This module provides the CurvineClient class which serves as the primary
 interface for interacting with the Curvine distributed file system.
 """
 from typing import Any, Dict, List, Optional, Union
+import warnings
 
 import curvine_libsdk
 from curvine_libsdk._proto.common_pb2 import FileStatusProto
@@ -131,6 +132,20 @@ class CurvineClient:
             "lost_workers": list(status.lost_workers),
         }
         return status_dict
+
+    def get_master_info(self) -> Dict[str, Any]:
+        """Deprecated alias of :meth:`get_filesystem_info`.
+
+        The RPC returns whole-filesystem statistics, not master-process
+        information. Kept for source compatibility; will be removed in a
+        future release.
+        """
+        warnings.warn(
+            "get_master_info() is deprecated, use get_filesystem_info()",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.get_filesystem_info()
 
     def mkdir(self, path: str, create_parents: bool) -> None:
         """Create a directory.

--- a/curvine-libsdk/python/curvinefs/curvineClient.py
+++ b/curvine-libsdk/python/curvinefs/curvineClient.py
@@ -107,12 +107,12 @@ class CurvineClient:
                 - lost_workers: List of lost workers
 
         Raises:
-            IOError: If getting master info fails.
+            IOError: If getting filesystem info fails.
         """
         try:
             status_bytes = curvine_libsdk.python_io_curvine_curvine_native_get_filesystem_info(self.file_system_ptr)
         except Exception as e:
-            raise IOError(f"Native get master information failed: {e}")
+            raise IOError(f"Native get filesystem information failed: {e}")
         status = GetFilesystemInfoResponse()
         status.ParseFromString(status_bytes)
         status_dict = {

--- a/curvine-libsdk/python/curvinefs/curvineClient.py
+++ b/curvine-libsdk/python/curvinefs/curvineClient.py
@@ -85,7 +85,7 @@ class CurvineClient:
         }
         return file_status_dict
 
-    def get_master_info(self) -> Dict[str, Any]:
+    def get_filesystem_info(self) -> Dict[str, Any]:
         """Get information about the Curvine cluster.
 
         Returns:
@@ -109,7 +109,7 @@ class CurvineClient:
             IOError: If getting master info fails.
         """
         try:
-            status_bytes = curvine_libsdk.python_io_curvine_curvine_native_get_master_info(self.file_system_ptr)
+            status_bytes = curvine_libsdk.python_io_curvine_curvine_native_get_filesystem_info(self.file_system_ptr)
         except Exception as e:
             raise IOError(f"Native get master information failed: {e}")
         status = GetFilesystemInfoResponse()

--- a/curvine-libsdk/python/curvinefs/curvineFileSystem.py
+++ b/curvine-libsdk/python/curvinefs/curvineFileSystem.py
@@ -11,6 +11,7 @@ from urllib.parse import urlsplit
 
 import curvinefs.curvineClient as curvine_client
 import os
+import warnings
 
 
 class CurvineFileSystem(AbstractFileSystem):
@@ -639,6 +640,15 @@ class CurvineFileSystem(AbstractFileSystem):
             Dictionary containing cluster information.
         """
         return self.client.get_filesystem_info()
+
+    def get_master_info(self) -> Dict[str, Any]:
+        """Deprecated alias of :meth:`get_filesystem_info`."""
+        warnings.warn(
+            "get_master_info() is deprecated, use get_filesystem_info()",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.get_filesystem_info()
 
     def close(self) -> None:
         """Close the file system connection."""

--- a/curvine-libsdk/python/curvinefs/curvineFileSystem.py
+++ b/curvine-libsdk/python/curvinefs/curvineFileSystem.py
@@ -632,13 +632,13 @@ class CurvineFileSystem(AbstractFileSystem):
         path = self._format_path(path)
         return self.client.get_file_status(path)
 
-    def get_master_info(self) -> Dict[str, Any]:
+    def get_filesystem_info(self) -> Dict[str, Any]:
         """Get information about the Curvine cluster.
 
         Returns:
             Dictionary containing cluster information.
         """
-        return self.client.get_master_info()
+        return self.client.get_filesystem_info()
 
     def close(self) -> None:
         """Close the file system connection."""

--- a/curvine-libsdk/python/test/curvineFileSystemTest.py
+++ b/curvine-libsdk/python/test/curvineFileSystemTest.py
@@ -28,8 +28,8 @@ class Test(unittest.TestCase):
         print("------------------------------------------------")
 
         
-        master_status = fs.get_filesystem_info()
-        print("Master information:",master_status)
+        filesystem_status = fs.get_filesystem_info()
+        print("Filesystem information:",filesystem_status)
         print("------------------------------------------------")
 
         writer = fs.create(test_path+"/a.txt", True)

--- a/curvine-libsdk/python/test/curvineFileSystemTest.py
+++ b/curvine-libsdk/python/test/curvineFileSystemTest.py
@@ -28,7 +28,7 @@ class Test(unittest.TestCase):
         print("------------------------------------------------")
 
         
-        master_status = fs.get_master_info()
+        master_status = fs.get_filesystem_info()
         print("Master information:",master_status)
         print("------------------------------------------------")
 

--- a/curvine-libsdk/python/test/test_curvine_sdk.py
+++ b/curvine-libsdk/python/test/test_curvine_sdk.py
@@ -544,6 +544,21 @@ class TestCurvineFileSystem(unittest.TestCase):
         mock_client_instance.get_filesystem_info.assert_called_once()
 
     @patch("curvinefs.curvineFileSystem.curvine_client")
+    def test_get_master_info_deprecated_alias(self, mock_curvine_client: MagicMock) -> None:
+        """Deprecated get_master_info() forwards to get_filesystem_info() and warns."""
+        mock_client_instance = MagicMock()
+        mock_curvine_client.CurvineClient.return_value = mock_client_instance
+        mock_info = {"active_master": "node1", "capacity": 1000000}
+        mock_client_instance.get_filesystem_info.return_value = mock_info
+
+        fs = CurvineFileSystem(self.config_path, self.write_chunk_size, self.write_chunk_num)
+        with self.assertWarns(DeprecationWarning):
+            result = fs.get_master_info()
+
+        self.assertEqual(result, mock_info)
+        mock_client_instance.get_filesystem_info.assert_called_once()
+
+    @patch("curvinefs.curvineFileSystem.curvine_client")
     def test_close(self, mock_curvine_client: MagicMock) -> None:
         """Test close."""
         mock_client_instance = MagicMock()

--- a/curvine-libsdk/python/test/test_curvine_sdk.py
+++ b/curvine-libsdk/python/test/test_curvine_sdk.py
@@ -530,18 +530,18 @@ class TestCurvineFileSystem(unittest.TestCase):
         mock_client_instance.get_file_status.assert_called_once_with("/test/file.txt")
 
     @patch("curvinefs.curvineFileSystem.curvine_client")
-    def test_get_master_info(self, mock_curvine_client: MagicMock) -> None:
-        """Test get_master_info."""
+    def test_get_filesystem_info(self, mock_curvine_client: MagicMock) -> None:
+        """Test get_filesystem_info."""
         mock_client_instance = MagicMock()
         mock_curvine_client.CurvineClient.return_value = mock_client_instance
         mock_info = {"active_master": "node1", "capacity": 1000000}
-        mock_client_instance.get_master_info.return_value = mock_info
+        mock_client_instance.get_filesystem_info.return_value = mock_info
 
         fs = CurvineFileSystem(self.config_path, self.write_chunk_size, self.write_chunk_num)
-        result = fs.get_master_info()
+        result = fs.get_filesystem_info()
 
         self.assertEqual(result, mock_info)
-        mock_client_instance.get_master_info.assert_called_once()
+        mock_client_instance.get_filesystem_info.assert_called_once()
 
     @patch("curvinefs.curvineFileSystem.curvine_client")
     def test_close(self, mock_curvine_client: MagicMock) -> None:

--- a/curvine-master/src/master/fs/heartbeat_checker.rs
+++ b/curvine-master/src/master/fs/heartbeat_checker.rs
@@ -130,7 +130,7 @@ impl LoopTask for HeartbeatChecker {
             }
         }
 
-        if let Ok(info) = self.fs.master_info() {
+        if let Ok(info) = self.fs.filesystem_info() {
             self.quota_manager.detector(Some(info));
         };
 

--- a/curvine-master/src/master/fs/master_filesystem.rs
+++ b/curvine-master/src/master/fs/master_filesystem.rs
@@ -1106,9 +1106,9 @@ impl MasterFilesystem {
         Ok(inode.clone())
     }
 
-    pub fn master_info(&self) -> FsResult<MasterInfo> {
+    pub fn filesystem_info(&self) -> FsResult<FilesystemInfo> {
         let metrics = Master::get_metrics()?;
-        let mut info = MasterInfo {
+        let mut info = FilesystemInfo {
             inode_dir_num: metrics.inode_dir_num.get(),
             inode_file_num: metrics.inode_file_num.get(),
             ..Default::default()

--- a/curvine-master/src/master/master_handler.rs
+++ b/curvine-master/src/master/master_handler.rs
@@ -26,8 +26,8 @@ use curvine_fs_api::Path;
 use curvine_fs_api::RpcCode;
 use curvine_model::ProtoUtils;
 use curvine_model::{
-    CreateFileOpts, DeleteBlockCmd, DeleteResult, FileBlocks, FileStatus, FreeResult,
-    HeartbeatStatus, ListOptions, MasterInfo, OpenFlags, RenameFlags, WorkerCommand, WorkerInfo,
+    CreateFileOpts, DeleteBlockCmd, DeleteResult, FileBlocks, FileStatus, FilesystemInfo,
+    FreeResult, HeartbeatStatus, ListOptions, OpenFlags, RenameFlags, WorkerCommand, WorkerInfo,
 };
 use curvine_net::net::ConnState;
 use curvine_proto::*;
@@ -467,7 +467,7 @@ impl MasterHandler {
             Self::process_get_filesystem_info(fs)
         })
         .await?;
-        let rep_header = ProtoUtils::master_info_to_pb(info);
+        let rep_header = ProtoUtils::filesystem_info_to_pb(info);
         ctx.response(rep_header)
     }
 
@@ -536,8 +536,8 @@ impl MasterHandler {
         ctx.response(response)
     }
 
-    fn process_get_filesystem_info(fs: MasterFilesystem) -> FsResult<MasterInfo> {
-        fs.master_info()
+    fn process_get_filesystem_info(fs: MasterFilesystem) -> FsResult<FilesystemInfo> {
+        fs.filesystem_info()
     }
 
     pub fn worker_heartbeat(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
@@ -1034,7 +1034,7 @@ mod tests {
 
         MasterHandler::process_worker_heartbeat(fs.clone(), header).unwrap();
 
-        let info = fs.master_info().unwrap();
+        let info = fs.filesystem_info().unwrap();
         let worker = info
             .live_workers
             .iter()

--- a/curvine-master/src/master/master_handler.rs
+++ b/curvine-master/src/master/master_handler.rs
@@ -460,11 +460,11 @@ impl MasterHandler {
         rx.await?
     }
 
-    async fn async_get_master_info(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
-        let _: GetMasterInfoRequest = ctx.parse_header()?;
+    async fn async_get_filesystem_info(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
+        let _: GetFilesystemInfoRequest = ctx.parse_header()?;
         let fs = self.fs.clone();
         let info = Self::run_master_rpc_task(self.control_rpc_executor.clone(), move || {
-            Self::process_get_master_info(fs)
+            Self::process_get_filesystem_info(fs)
         })
         .await?;
         let rep_header = ProtoUtils::master_info_to_pb(info);
@@ -536,7 +536,7 @@ impl MasterHandler {
         ctx.response(response)
     }
 
-    fn process_get_master_info(fs: MasterFilesystem) -> FsResult<MasterInfo> {
+    fn process_get_filesystem_info(fs: MasterFilesystem) -> FsResult<MasterInfo> {
         fs.master_info()
     }
 
@@ -854,7 +854,7 @@ impl MessageHandler for MasterHandler {
                 | RpcCode::GetJobStatus
                 | RpcCode::CancelJob
                 | RpcCode::ReportTask
-                | RpcCode::GetMasterInfo
+                | RpcCode::GetFilesystemInfo
                 | RpcCode::GetCvMetadataSnapshotPage
                 | RpcCode::GetCvMetadataDeltaPage
         )
@@ -965,7 +965,7 @@ impl MessageHandler for MasterHandler {
                 RpcCode::GetJobStatus => self.job_handler.get_load_status(ctx),
                 RpcCode::CancelJob => self.job_handler.cancel_job(ctx).await,
                 RpcCode::ReportTask => self.job_handler.task_report(ctx),
-                RpcCode::GetMasterInfo => self.async_get_master_info(ctx).await,
+                RpcCode::GetFilesystemInfo => self.async_get_filesystem_info(ctx).await,
                 RpcCode::GetCvMetadataSnapshotPage => {
                     self.async_get_cv_metadata_snapshot_page(ctx).await
                 }
@@ -987,7 +987,7 @@ impl MessageHandler for MasterHandler {
         let code = RpcCode::from(msg.code());
         if matches!(
             code,
-            RpcCode::WorkerHeartbeat | RpcCode::WorkerBlockReport | RpcCode::GetMasterInfo
+            RpcCode::WorkerHeartbeat | RpcCode::WorkerBlockReport | RpcCode::GetFilesystemInfo
         ) {
             Some(&self.actor_rt)
         } else {

--- a/curvine-master/src/master/master_metrics.rs
+++ b/curvine-master/src/master/master_metrics.rs
@@ -191,15 +191,15 @@ impl MasterMetrics {
     }
 
     pub fn text_output(&self, fs: MasterFilesystem) -> CommonResult<String> {
-        let master_info = fs.master_info()?;
-        self.capacity.set(master_info.capacity);
-        self.available.set(master_info.available);
-        self.fs_used.set(master_info.fs_used);
-        self.block_num.set(master_info.block_num);
+        let filesystem_info = fs.filesystem_info()?;
+        self.capacity.set(filesystem_info.capacity);
+        self.available.set(filesystem_info.available);
+        self.fs_used.set(filesystem_info.fs_used);
+        self.block_num.set(filesystem_info.block_num);
         self.used_memory_bytes.set(SysUtils::used_memory() as i64);
 
-        if master_info.block_num > 0 {
-            let avg_size = master_info.fs_used / master_info.block_num;
+        if filesystem_info.block_num > 0 {
+            let avg_size = filesystem_info.fs_used / filesystem_info.block_num;
             self.blocks_size_avg.set(avg_size);
         }
 
@@ -218,16 +218,16 @@ impl MasterMetrics {
 
         self.worker_num
             .with_label_values(&["live"])
-            .set(master_info.live_workers.len() as i64);
+            .set(filesystem_info.live_workers.len() as i64);
         self.worker_num
             .with_label_values(&["blacklist"])
-            .set(master_info.blacklist_workers.len() as i64);
+            .set(filesystem_info.blacklist_workers.len() as i64);
         self.worker_num
             .with_label_values(&["decommission"])
-            .set(master_info.decommission_workers.len() as i64);
+            .set(filesystem_info.decommission_workers.len() as i64);
         self.worker_num
             .with_label_values(&["lost"])
-            .set(master_info.lost_workers.len() as i64);
+            .set(filesystem_info.lost_workers.len() as i64);
 
         Metrics::text_output()
     }

--- a/curvine-master/src/master/quota/quota_manager.rs
+++ b/curvine-master/src/master/quota/quota_manager.rs
@@ -22,7 +22,7 @@ use crate::master::quota::eviction::types::EvictPlan;
 use crate::master::quota::eviction::EvictionConf;
 use crate::master::quota::eviction::EvictionMode;
 use crate::master::Master;
-use curvine_model::MasterInfo;
+use curvine_model::FilesystemInfo;
 use curvine_runtime::runtime::{RpcRuntime, Runtime};
 use parking_lot::RwLock;
 use tokio::sync::mpsc;
@@ -33,7 +33,7 @@ pub struct QuotaManager {
     fs: MasterFilesystem,
     evictor: Arc<dyn Evictor>,
     ttl_executor: RwLock<Option<InodeTtlExecutor>>,
-    tx: Sender<Option<MasterInfo>>,
+    tx: Sender<Option<FilesystemInfo>>,
 }
 
 impl QuotaManager {
@@ -44,8 +44,10 @@ impl QuotaManager {
         rt: Arc<Runtime>,
         testing: bool,
     ) -> Arc<Self> {
-        let (tx, mut rx): (Sender<Option<MasterInfo>>, Receiver<Option<MasterInfo>>) =
-            mpsc::channel(1024);
+        let (tx, mut rx): (
+            Sender<Option<FilesystemInfo>>,
+            Receiver<Option<FilesystemInfo>>,
+        ) = mpsc::channel(1024);
 
         let manager = Arc::new(QuotaManager {
             evictor,
@@ -78,11 +80,11 @@ impl QuotaManager {
         self.eviction_conf.enable_quota_eviction
     }
 
-    pub fn detector(&self, info: Option<MasterInfo>) {
+    pub fn detector(&self, info: Option<FilesystemInfo>) {
         let _ = self.tx.try_send(info);
     }
 
-    fn handle_trigger(&self, cluster_info: Option<MasterInfo>) {
+    fn handle_trigger(&self, cluster_info: Option<FilesystemInfo>) {
         if !self.is_eviction_enabled() {
             return;
         }
@@ -100,7 +102,7 @@ impl QuotaManager {
             .set(self.evictor.cache_size() as i64);
 
         let Some(info) = cluster_info else {
-            log::warn!("cluster-evict: failed to fetch master_info");
+            log::warn!("cluster-evict: failed to fetch filesystem_info");
             return;
         };
 

--- a/curvine-master/src/master/router_handler.rs
+++ b/curvine-master/src/master/router_handler.rs
@@ -116,28 +116,28 @@ async fn overview(
     let fs = &instance.fs;
     let conf = &instance.conf;
     let start_time = &instance.start_time;
-    let master_info = fs.master_info()?;
+    let filesystem_info = fs.filesystem_info()?;
 
     let (files_total, dir_total) = {
         let (f, d) = fs.get_file_counts();
         (f as usize, d as usize)
     };
 
-    let expected_capacity = master_info.available + master_info.fs_used;
-    if master_info.capacity != expected_capacity {
+    let expected_capacity = filesystem_info.available + filesystem_info.fs_used;
+    if filesystem_info.capacity != expected_capacity {
         log::warn!(
             "Capacity inconsistency detected: capacity={}, available={}, fs_used={}, expected_capacity={}",
-            master_info.capacity,
-            master_info.available,
-            master_info.fs_used,
+            filesystem_info.capacity,
+            filesystem_info.available,
+            filesystem_info.fs_used,
             expected_capacity
         );
     } else {
         log::debug!(
             "Capacity consistency verified: capacity={}, available={}, fs_used={}",
-            master_info.capacity,
-            master_info.available,
-            master_info.fs_used
+            filesystem_info.capacity,
+            filesystem_info.available,
+            filesystem_info.fs_used
         );
     }
 
@@ -147,12 +147,12 @@ async fn overview(
         "cluster_id": conf.cluster_id,
         "master_addr": conf.master_addr().to_string(),
         "start_time": start_time,
-        "live_workers": master_info.live_workers.len(),
-        "lost_workers": master_info.lost_workers.len(),
-        "available": master_info.available,
-        "capacity": master_info.capacity,
-        "fs_used": master_info.fs_used,
-        "reserved_bytes": master_info.reserved_bytes,
+        "live_workers": filesystem_info.live_workers.len(),
+        "lost_workers": filesystem_info.lost_workers.len(),
+        "available": filesystem_info.available,
+        "capacity": filesystem_info.capacity,
+        "fs_used": filesystem_info.fs_used,
+        "reserved_bytes": filesystem_info.reserved_bytes,
         "files_total": files_total,
         "dir_total": dir_total,
         "master_state": master_state,

--- a/curvine-server/src/test/mini_cluster.rs
+++ b/curvine-server/src/test/mini_cluster.rs
@@ -217,7 +217,7 @@ impl MiniCluster {
 
         while LocalTime::mills() <= wait_time {
             retry_count += 1;
-            let info = match fs.get_master_info().await {
+            let info = match fs.get_filesystem_info().await {
                 Ok(info) => info,
                 Err(e) => {
                     return Err(e);

--- a/curvine-server/tests/master_fs_test.rs
+++ b/curvine-server/tests/master_fs_test.rs
@@ -27,7 +27,7 @@ use curvine_model::{
 use curvine_model::{OpenFlags, RenameFlags, SetAttrOptsBuilder};
 use curvine_proto::{
     CompleteFileRequest, CompleteFileResponse, CreateFileRequest, DeleteRequest,
-    GetMasterInfoRequest, MkdirOptsProto, MkdirRequest, RenameRequest,
+    GetFilesystemInfoRequest, MkdirOptsProto, MkdirRequest, RenameRequest,
 };
 use curvine_raft::conf::JournalConf;
 use curvine_raft::raft::storage::{AppStorage, ApplyMsg};
@@ -307,7 +307,7 @@ fn control_plane_requests_use_the_async_handler() {
         RpcCode::GetJobStatus,
         RpcCode::CancelJob,
         RpcCode::ReportTask,
-        RpcCode::GetMasterInfo,
+        RpcCode::GetFilesystemInfo,
         RpcCode::GetCvMetadataSnapshotPage,
         RpcCode::GetCvMetadataDeltaPage,
     ] {
@@ -337,8 +337,8 @@ fn control_plane_requests_use_the_async_handler() {
 fn sync_rpc_to_standby_returns_rpc_error_response() -> CommonResult<()> {
     let _serial = master_fs_test_serial();
     let handler = new_handler();
-    let msg = Builder::new_rpc(RpcCode::GetMasterInfo)
-        .proto_header(GetMasterInfoRequest::default())
+    let msg = Builder::new_rpc(RpcCode::GetFilesystemInfo)
+        .proto_header(GetFilesystemInfoRequest::default())
         .build();
 
     let response = handler.handle(&msg)?;

--- a/curvine-tests/tests/block_test.rs
+++ b/curvine-tests/tests/block_test.rs
@@ -186,7 +186,7 @@ fn _abort() -> CommonResult<()> {
     let path = Path::from_str("/file-abort.log")?;
 
     rt.block_on(async move {
-        let before = fs.get_master_info().await?.available;
+        let before = fs.get_filesystem_info().await?.available;
         let mut writer = fs.create(&path, true).await?;
         writer.write("123".as_bytes()).await?;
         writer.flush().await?;
@@ -195,7 +195,7 @@ fn _abort() -> CommonResult<()> {
         fs.delete(&path, false).await?;
 
         tokio::time::sleep(Duration::from_secs(10)).await;
-        let after = fs.get_master_info().await?.available;
+        let after = fs.get_filesystem_info().await?.available;
 
         println!("before {}, after {}", before, after);
         assert_eq!(before, after);

--- a/curvine-tests/tests/fs_test.rs
+++ b/curvine-tests/tests/fs_test.rs
@@ -139,8 +139,8 @@ fn run_filesystem_end_to_end_operations_on_cluster(
         list_files(&fs).await?;
         println!("list_files done");
 
-        get_master_info(&fs).await?;
-        println!("get_master_info done");
+        get_filesystem_info(&fs).await?;
+        println!("get_filesystem_info done");
 
         add_block(&fs).await?;
         println!("add_block done");
@@ -556,8 +556,8 @@ async fn add_block(fs: &CurvineFileSystem) -> CommonResult<()> {
     Ok(())
 }
 
-async fn get_master_info(fs: &CurvineFileSystem) -> CommonResult<()> {
-    let res = fs.get_master_info().await?;
+async fn get_filesystem_info(fs: &CurvineFileSystem) -> CommonResult<()> {
+    let res = fs.get_filesystem_info().await?;
     info!("master info {:#?}", res);
     Ok(())
 }
@@ -653,11 +653,11 @@ async fn test_fs_used(fs: &CurvineFileSystem) -> CommonResult<()> {
     info!("=== Testing FS Used - Creating files with data ===");
 
     // Get initial state
-    let initial_master_info = fs.get_master_info().await?;
+    let initial_filesystem_info = fs.get_filesystem_info().await?;
     info!(
         "Initial FS Used: {} bytes ({:.2} MB)",
-        initial_master_info.fs_used,
-        initial_master_info.fs_used as f64 / 1024.0 / 1024.0
+        initial_filesystem_info.fs_used,
+        initial_filesystem_info.fs_used as f64 / 1024.0 / 1024.0
     );
 
     // Create files and write data, ensuring data is flushed to storage
@@ -678,7 +678,7 @@ async fn test_fs_used(fs: &CurvineFileSystem) -> CommonResult<()> {
         );
 
         // Check status after creating each file
-        let current_info = fs.get_master_info().await?;
+        let current_info = fs.get_filesystem_info().await?;
         info!("After file {}: FS Used = {} bytes", i, current_info.fs_used);
     }
 
@@ -686,7 +686,7 @@ async fn test_fs_used(fs: &CurvineFileSystem) -> CommonResult<()> {
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
     // Get master info to check fs_used
-    let after_small_files_info = fs.get_master_info().await?;
+    let after_small_files_info = fs.get_filesystem_info().await?;
     info!(
         "After creating small files - FS Used: {} bytes ({:.2} MB)",
         after_small_files_info.fs_used,
@@ -714,34 +714,35 @@ async fn test_fs_used(fs: &CurvineFileSystem) -> CommonResult<()> {
     tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
 
     // Get master info again
-    let final_master_info = fs.get_master_info().await?;
+    let final_filesystem_info = fs.get_filesystem_info().await?;
     info!(
         "Final FS Used: {} bytes ({:.2} MB)",
-        final_master_info.fs_used,
-        final_master_info.fs_used as f64 / 1024.0 / 1024.0
+        final_filesystem_info.fs_used,
+        final_filesystem_info.fs_used as f64 / 1024.0 / 1024.0
     );
 
     // Output detailed capacity information
     info!("=== Final Capacity Information ===");
     info!(
         "Capacity: {} bytes ({:.2} GB)",
-        final_master_info.capacity,
-        final_master_info.capacity as f64 / 1024.0 / 1024.0 / 1024.0
+        final_filesystem_info.capacity,
+        final_filesystem_info.capacity as f64 / 1024.0 / 1024.0 / 1024.0
     );
     info!(
         "Available: {} bytes ({:.2} GB)",
-        final_master_info.available,
-        final_master_info.available as f64 / 1024.0 / 1024.0 / 1024.0
+        final_filesystem_info.available,
+        final_filesystem_info.available as f64 / 1024.0 / 1024.0 / 1024.0
     );
     info!(
         "FS Used: {} bytes ({:.2} MB)",
-        final_master_info.fs_used,
-        final_master_info.fs_used as f64 / 1024.0 / 1024.0
+        final_filesystem_info.fs_used,
+        final_filesystem_info.fs_used as f64 / 1024.0 / 1024.0
     );
 
     // Calculate non_fs_used
-    let non_fs_used =
-        final_master_info.capacity - final_master_info.available - final_master_info.fs_used;
+    let non_fs_used = final_filesystem_info.capacity
+        - final_filesystem_info.available
+        - final_filesystem_info.fs_used;
     info!(
         "Non-FS Used: {} bytes ({:.2} GB)",
         non_fs_used,
@@ -749,30 +750,34 @@ async fn test_fs_used(fs: &CurvineFileSystem) -> CommonResult<()> {
     );
 
     // Verify capacity consistency
-    let total_accounted = final_master_info.available + final_master_info.fs_used + non_fs_used;
+    let total_accounted =
+        final_filesystem_info.available + final_filesystem_info.fs_used + non_fs_used;
     info!(
         "Consistency check: {} + {} + {} = {}",
-        final_master_info.available, final_master_info.fs_used, non_fs_used, total_accounted
+        final_filesystem_info.available,
+        final_filesystem_info.fs_used,
+        non_fs_used,
+        total_accounted
     );
-    info!("Expected capacity: {}", final_master_info.capacity);
+    info!("Expected capacity: {}", final_filesystem_info.capacity);
 
-    if total_accounted == final_master_info.capacity {
+    if total_accounted == final_filesystem_info.capacity {
         info!("✅ Capacity consistency check PASSED");
     } else {
         info!(
             "❌ Capacity consistency check FAILED - difference: {}",
-            (total_accounted - final_master_info.capacity).abs()
+            (total_accounted - final_filesystem_info.capacity).abs()
         );
     }
 
     // Verify fs_used is not negative
     assert!(
-        final_master_info.fs_used >= 0,
+        final_filesystem_info.fs_used >= 0,
         "FS Used should not be negative"
     );
 
     // If fs_used is still 0, output debug information but don't fail the test
-    if final_master_info.fs_used == 0 {
+    if final_filesystem_info.fs_used == 0 {
         info!("⚠️  WARNING: FS Used is still 0. This might indicate:");
         info!("   1. Data is not yet committed to block storage");
         info!("   2. Test cluster might be using different storage mechanism");
@@ -780,7 +785,7 @@ async fn test_fs_used(fs: &CurvineFileSystem) -> CommonResult<()> {
     } else {
         info!(
             "✅ FS Used has non-zero value: {} bytes",
-            final_master_info.fs_used
+            final_filesystem_info.fs_used
         );
     }
 

--- a/curvine-tests/tests/fs_test.rs
+++ b/curvine-tests/tests/fs_test.rs
@@ -558,7 +558,7 @@ async fn add_block(fs: &CurvineFileSystem) -> CommonResult<()> {
 
 async fn get_filesystem_info(fs: &CurvineFileSystem) -> CommonResult<()> {
     let res = fs.get_filesystem_info().await?;
-    info!("master info {:#?}", res);
+    info!("filesystem info {:#?}", res);
     Ok(())
 }
 
@@ -685,7 +685,7 @@ async fn test_fs_used(fs: &CurvineFileSystem) -> CommonResult<()> {
     // Wait for storage system to process
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
-    // Get master info to check fs_used
+    // Get filesystem info to check fs_used
     let after_small_files_info = fs.get_filesystem_info().await?;
     info!(
         "After creating small files - FS Used: {} bytes ({:.2} MB)",
@@ -713,7 +713,7 @@ async fn test_fs_used(fs: &CurvineFileSystem) -> CommonResult<()> {
     // Wait for storage system to update
     tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
 
-    // Get master info again
+    // Get filesystem info again
     let final_filesystem_info = fs.get_filesystem_info().await?;
     info!(
         "Final FS Used: {} bytes ({:.2} MB)",


### PR DESCRIPTION
# Summary

Rename the `GetMasterInfo` RPC to `GetFilesystemInfo`, **end to end** — the RPC/proto/enum, the internal handler methods, the business method chain, the domain struct, and the Java/Python SDK surface. The old name was misleading: the response carries whole-filesystem statistics (`capacity`, `available`, `fs_used`, `inode_dir_num`, `inode_file_num`, `block_num`, worker lists) and is the backend for `statfs(2)` / `df`, not master-process information.

# Issue Describe / Design

Closes #1575

Design decisions:
- **Wire-compatible.** The `RpcCode` discriminant stays `14` and all proto field numbers are unchanged, so mixed-version nodes keep interoperating and existing encoded messages stay valid.
- **Full rename (no half-measure).** An earlier revision kept the `MasterInfo` struct and the `get_master_info()` methods to preserve the SDK surface, but that left an inconsistency: methods named `get_master_info` whose bodies already tracked `"GetFilesystemInfo"` and returned a struct describing the whole filesystem. This PR renames the method chain and the domain type too, so names match behavior throughout.
- **Observability note.** The `track()` label changes from `"GetMasterInfo"` to `"GetFilesystemInfo"`; any Prometheus dashboard / audit query keying on the old label must be updated.
- **Scope kept minimal.** A full audit of the 53-entry `RpcCode` enum found only this one name to be misleading (see #1575). `GetBlockLocations` and other HDFS-lineage terms are accurate and left untouched.

# Changes

| Module / File | Change | Impact |
| ------------- | ------ | ------ |
| `curvine-fs-api/src/rpc_code.rs` | `GetMasterInfo = 14` → `GetFilesystemInfo = 14` | None (value unchanged) |
| `curvine-proto/proto/master.proto` | `GetMasterInfo{Request,Response}` → `GetFilesystemInfo{...}` + comment | None (field numbers unchanged) |
| `curvine-model/src/master_info.rs` → `filesystem_info.rs` | `MasterInfo` struct → `FilesystemInfo` | Domain type rename |
| `curvine-model/src/proto_utils.rs` | `master_info_to_pb`/`from_pb` → `filesystem_info_to_pb`/`from_pb` | None |
| `curvine-master/.../master_handler.rs`, `master_filesystem.rs`, `master_metrics.rs`, `router_handler.rs`, `quota_manager.rs`, `heartbeat_checker.rs` | dispatch arms, `async_get_filesystem_info`/`process_get_filesystem_info`, `MasterFilesystem::filesystem_info()`, local usages | None |
| `curvine-client-core/.../fs_client.rs`, `curvine_filesystem.rs` | `get_filesystem_info[_bytes]()` methods + renamed types | Client method rename |
| `curvine-unified-fs/.../unified_filesystem.rs` | `get_filesystem_info[_bytes]()` + `track("GetFilesystemInfo")` | Metrics/audit label rename |
| `curvine-cli` (`node.rs`, `fs/df.rs`, `report.rs`), `curvine-fuse`, `curvine-data-transfer`, tests, `mini_cluster.rs` | call-site renames | None |
| `curvine-libsdk/java/.../CurvineFileSystem.java`, `CurvineFsMount.java`, `CurvineNative.java`, `CurvineFsStat.java` | `getFilesystemInfo()` + JNI symbol + renamed generated proto class | **Breaking (Java SDK)** |
| `curvine-libsdk/python/.../curvineClient.py`, `curvineFileSystem.py`, tests | `get_filesystem_info()` + renamed native export | **Breaking (Python SDK)** |
| `curvine-libsdk-java/src/java/java_abi.rs`, `java_filesystem.rs`; `curvine-libsdk-python/src/python/python_abi.rs`, `python_filesystem.rs`; `curvine-sdk-core/.../master.rs`, `core/master.rs`, `core/filesystem.rs` | Rust JNI/PyO3 export names + sdk-core public methods | **Breaking (SDK)** |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo build` of all touched Rust crates | PASS | in-container, proto regenerated, no warnings |
| `cargo +1.92.0 fmt --all -- --check` | PASS | 0 diffs (CI fmt gate) |
| repo-wide grep `master_info` / `MasterInfo` / `getMasterInfo` | PASS | 0 residual code references |

Note: `curvine-libsdk-python` fails to build in the dev container due to a pre-existing pyo3 `abi3-py38` vs container Python 3.7 mismatch, unrelated to this rename (the Python source edits are mechanical symbol renames verified by grep).

# Dependencies

- Related issues: #1575