### PR TITLE
fix(client): degrade auto-cache overload to UFS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2844,7 +2844,6 @@ dependencies = [
  "curvine-runtime",
  "curvine-ufs-opendal",
  "curvine-ufs-oss-hdfs",
- "dashmap 5.5.3",
  "log",
  "once_cell",
  "tokio",

--- a/crates/client/curvine-client-core/src/client_metrics.rs
+++ b/crates/client/curvine-client-core/src/client_metrics.rs
@@ -29,6 +29,7 @@ use std::future::Future;
 pub struct ClientMetrics {
     pub mount_cache_hits: CounterVec,
     pub mount_cache_misses: CounterVec,
+    pub async_cache_admission_skipped: CounterVec,
     pub last_value_map: FastDashMap<String, f64>,
 
     pub metadata_operation_duration: HistogramVec,
@@ -53,6 +54,11 @@ impl ClientMetrics {
                 "client_mount_cache_misses",
                 "mount cache miss count",
                 &["id"],
+            )?,
+            async_cache_admission_skipped: m::new_counter_vec(
+                "client_async_cache_admission_skipped",
+                "auto-cache admission requests skipped by reason",
+                &["reason"],
             )?,
 
             last_value_map: FastDashMap::default(),

--- a/crates/client/curvine-unified-fs/Cargo.toml
+++ b/crates/client/curvine-unified-fs/Cargo.toml
@@ -18,7 +18,6 @@ curvine-io = { workspace = true }
 curvine-core-error = { workspace = true }
 curvine-runtime = { workspace = true }
 bytes = { workspace = true }
-dashmap = { workspace = true }
 log = { workspace = true }
 once_cell = { workspace = true }
 tokio = { workspace = true }

--- a/crates/client/curvine-unified-fs/src/unified/unified_filesystem.rs
+++ b/crates/client/curvine-unified-fs/src/unified/unified_filesystem.rs
@@ -32,13 +32,13 @@ use curvine_model::{
 use curvine_runtime::common::TimeSpent;
 use curvine_runtime::common::Utils;
 use curvine_runtime::runtime::{RpcRuntime, Runtime};
-use dashmap::DashSet;
+use curvine_runtime::sync::FastMutex;
 use log::{debug, error, info, warn};
 use std::borrow::Cow;
+use std::collections::HashSet;
 use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tokio::time;
 
 const TRANSFER_SUBMIT_MAX_ATTEMPTS: usize = 3;
@@ -52,8 +52,7 @@ enum CacheValidity {
 
 #[derive(Clone)]
 struct AsyncCachePending {
-    paths: Arc<DashSet<String>>,
-    slots: Arc<Semaphore>,
+    paths: Arc<FastMutex<HashSet<String>>>,
     capacity: usize,
 }
 
@@ -65,43 +64,37 @@ enum AsyncCacheAdmission {
 
 struct AsyncCachePermit {
     path: String,
-    paths: Arc<DashSet<String>>,
-    _slot: OwnedSemaphorePermit,
+    paths: Arc<FastMutex<HashSet<String>>>,
 }
 
 impl AsyncCachePending {
     fn new(capacity: usize) -> Self {
         Self {
-            paths: Arc::new(DashSet::new()),
-            slots: Arc::new(Semaphore::new(capacity)),
+            paths: Arc::new(FastMutex::new(HashSet::new())),
             capacity,
         }
     }
 
     fn try_admit(&self, path: String) -> AsyncCacheAdmission {
-        if self.paths.contains(&path) {
+        let mut paths = self.paths.lock();
+        if paths.contains(&path) {
             return AsyncCacheAdmission::AlreadyPending;
         }
-
-        let slot = match self.slots.clone().try_acquire_owned() {
-            Ok(slot) => slot,
-            Err(_) => return AsyncCacheAdmission::Overloaded,
-        };
-        if !self.paths.insert(path.clone()) {
-            return AsyncCacheAdmission::AlreadyPending;
+        if paths.len() >= self.capacity {
+            return AsyncCacheAdmission::Overloaded;
         }
+        paths.insert(path.clone());
 
         AsyncCacheAdmission::Accepted(AsyncCachePermit {
             path,
             paths: self.paths.clone(),
-            _slot: slot,
         })
     }
 }
 
 impl Drop for AsyncCachePermit {
     fn drop(&mut self) {
-        self.paths.remove(&self.path);
+        self.paths.lock().remove(&self.path);
     }
 }
 
@@ -524,7 +517,7 @@ impl UnifiedFileSystem {
 
     pub fn async_cache(&self, source_path: &Path) -> FsResult<()> {
         let source_path = source_path.clone_uri();
-        let _pending = match self.async_cache_pending.try_admit(source_path.clone()) {
+        let pending_permit = match self.async_cache_pending.try_admit(source_path.clone()) {
             AsyncCacheAdmission::Accepted(pending) => pending,
             AsyncCacheAdmission::AlreadyPending => {
                 debug!("async cache request already pending for {}", source_path);
@@ -543,6 +536,7 @@ impl UnifiedFileSystem {
         let metrics = self.metrics;
 
         self.fs_context().rt().spawn(async move {
+            let _pending_permit = pending_permit;
             let time = TimeSpent::new();
             let res = fs.submit_async_cache(&source_path).await;
 
@@ -573,7 +567,6 @@ impl UnifiedFileSystem {
                     debug!("submitted async cache job {} for {}", job_id, source_path);
                 }
             }
-            drop(_pending);
         });
 
         Ok(())
@@ -1262,6 +1255,7 @@ impl FileSystem<UnifiedWriter, UnifiedReader> for UnifiedFileSystem {
 #[cfg(test)]
 mod tests {
     use super::{AsyncCacheAdmission, AsyncCachePending};
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
 
     #[test]
@@ -1292,16 +1286,26 @@ mod tests {
     fn async_cache_pending_deduplicates_concurrent_requests() {
         let pending = Arc::new(AsyncCachePending::new(32));
         let accepted = Arc::new(Mutex::new(Vec::new()));
+        let already_pending = Arc::new(AtomicUsize::new(0));
+        let overloaded = Arc::new(AtomicUsize::new(0));
         let mut threads = Vec::new();
 
         for _ in 0..32 {
             let pending = pending.clone();
             let accepted = accepted.clone();
+            let already_pending = already_pending.clone();
+            let overloaded = overloaded.clone();
             threads.push(std::thread::spawn(move || {
-                if let AsyncCacheAdmission::Accepted(permit) =
-                    pending.try_admit("ufs://bucket/same".to_string())
-                {
-                    accepted.lock().unwrap().push(permit);
+                match pending.try_admit("ufs://bucket/same".to_string()) {
+                    AsyncCacheAdmission::Accepted(permit) => {
+                        accepted.lock().unwrap().push(permit);
+                    }
+                    AsyncCacheAdmission::AlreadyPending => {
+                        already_pending.fetch_add(1, Ordering::Relaxed);
+                    }
+                    AsyncCacheAdmission::Overloaded => {
+                        overloaded.fetch_add(1, Ordering::Relaxed);
+                    }
                 }
             }));
         }
@@ -1310,5 +1314,7 @@ mod tests {
         }
 
         assert_eq!(accepted.lock().unwrap().len(), 1);
+        assert_eq!(already_pending.load(Ordering::Relaxed), 31);
+        assert_eq!(overloaded.load(Ordering::Relaxed), 0);
     }
 }

--- a/crates/client/curvine-unified-fs/src/unified/unified_filesystem.rs
+++ b/crates/client/curvine-unified-fs/src/unified/unified_filesystem.rs
@@ -38,6 +38,7 @@ use std::borrow::Cow;
 use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tokio::time;
 
 const TRANSFER_SUBMIT_MAX_ATTEMPTS: usize = 3;
@@ -50,13 +51,68 @@ enum CacheValidity {
 }
 
 #[derive(Clone)]
+struct AsyncCachePending {
+    paths: Arc<DashSet<String>>,
+    slots: Arc<Semaphore>,
+    capacity: usize,
+}
+
+enum AsyncCacheAdmission {
+    Accepted(AsyncCachePermit),
+    AlreadyPending,
+    Overloaded,
+}
+
+struct AsyncCachePermit {
+    path: String,
+    paths: Arc<DashSet<String>>,
+    _slot: OwnedSemaphorePermit,
+}
+
+impl AsyncCachePending {
+    fn new(capacity: usize) -> Self {
+        Self {
+            paths: Arc::new(DashSet::new()),
+            slots: Arc::new(Semaphore::new(capacity)),
+            capacity,
+        }
+    }
+
+    fn try_admit(&self, path: String) -> AsyncCacheAdmission {
+        if self.paths.contains(&path) {
+            return AsyncCacheAdmission::AlreadyPending;
+        }
+
+        let slot = match self.slots.clone().try_acquire_owned() {
+            Ok(slot) => slot,
+            Err(_) => return AsyncCacheAdmission::Overloaded,
+        };
+        if !self.paths.insert(path.clone()) {
+            return AsyncCacheAdmission::AlreadyPending;
+        }
+
+        AsyncCacheAdmission::Accepted(AsyncCachePermit {
+            path,
+            paths: self.paths.clone(),
+            _slot: slot,
+        })
+    }
+}
+
+impl Drop for AsyncCachePermit {
+    fn drop(&mut self) {
+        self.paths.remove(&self.path);
+    }
+}
+
+#[derive(Clone)]
 pub struct UnifiedFileSystem {
     cv: CurvineFileSystem,
     mount_cache: Arc<MountCache>,
     enable_unified: bool,
     enable_read_ufs: bool,
     audit_logging_enabled: bool,
-    async_cache_pending: Arc<DashSet<String>>,
+    async_cache_pending: AsyncCachePending,
     metrics: &'static ClientMetrics,
 }
 
@@ -67,6 +123,7 @@ impl UnifiedFileSystem {
         let enable_unified = conf.client.enable_unified_fs;
         let enable_read_ufs = conf.client.enable_rust_read_ufs;
         let audit_logging_enabled = conf.client.audit_logging_enabled;
+        let async_cache_pending_capacity = conf.transfer.client_pending_queue_size();
 
         let cv = CurvineFileSystem::with_rt(conf, rt.clone())?;
         let fs = UnifiedFileSystem {
@@ -75,7 +132,7 @@ impl UnifiedFileSystem {
             enable_unified,
             enable_read_ufs,
             audit_logging_enabled,
-            async_cache_pending: Arc::new(DashSet::new()),
+            async_cache_pending: AsyncCachePending::new(async_cache_pending_capacity),
             metrics: FsContext::get_metrics(),
         };
 
@@ -467,18 +524,20 @@ impl UnifiedFileSystem {
 
     pub fn async_cache(&self, source_path: &Path) -> FsResult<()> {
         let source_path = source_path.clone_uri();
-        if self.async_cache_pending.contains(&source_path) {
-            debug!("async cache request already pending for {}", source_path);
-            return Ok(());
-        }
-        let pending_capacity = self.cv.conf().transfer.client_pending_queue_size();
-        if self.async_cache_pending.len() >= pending_capacity {
-            return Err(FsError::transfer_overloaded(format!(
-                "client async cache pending queue is full, capacity={}",
-                pending_capacity
-            )));
-        }
-        self.async_cache_pending.insert(source_path.clone());
+        let _pending = match self.async_cache_pending.try_admit(source_path.clone()) {
+            AsyncCacheAdmission::Accepted(pending) => pending,
+            AsyncCacheAdmission::AlreadyPending => {
+                debug!("async cache request already pending for {}", source_path);
+                return Ok(());
+            }
+            AsyncCacheAdmission::Overloaded => {
+                warn!(
+                    "skip async cache request for {} because the client pending queue is full, capacity={}",
+                    source_path, self.async_cache_pending.capacity
+                );
+                return Ok(());
+            }
+        };
         let fs = self.clone();
         let log = self.audit_logging_enabled;
         let metrics = self.metrics;
@@ -514,7 +573,7 @@ impl UnifiedFileSystem {
                     debug!("submitted async cache job {} for {}", job_id, source_path);
                 }
             }
-            fs.async_cache_pending.remove(&source_path);
+            drop(_pending);
         });
 
         Ok(())
@@ -1039,7 +1098,11 @@ impl FileSystem<UnifiedWriter, UnifiedReader> for UnifiedFileSystem {
                     .inc();
 
                 if mount.info.auto_cache() {
-                    self.async_cache(&ufs_path)?;
+                    // Auto-cache is advisory: scheduling failures must not block the
+                    // foreground read from falling back to UFS.
+                    if let Err(err) = self.async_cache(&ufs_path) {
+                        warn!("skip async cache request for {}: {}", ufs_path, err);
+                    }
                 }
 
                 read_path = ufs_path.full_path().to_owned();
@@ -1193,5 +1256,59 @@ impl FileSystem<UnifiedWriter, UnifiedReader> for UnifiedFileSystem {
             Ok(())
         };
         self.track("SetAttr", path.path(), "", fut).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AsyncCacheAdmission, AsyncCachePending};
+    use std::sync::{Arc, Mutex};
+
+    #[test]
+    fn async_cache_pending_enforces_capacity_and_releases_slots() {
+        let pending = AsyncCachePending::new(1);
+        let first = match pending.try_admit("ufs://bucket/a".to_string()) {
+            AsyncCacheAdmission::Accepted(permit) => permit,
+            _ => panic!("first request should be accepted"),
+        };
+
+        assert!(matches!(
+            pending.try_admit("ufs://bucket/a".to_string()),
+            AsyncCacheAdmission::AlreadyPending
+        ));
+        assert!(matches!(
+            pending.try_admit("ufs://bucket/b".to_string()),
+            AsyncCacheAdmission::Overloaded
+        ));
+
+        drop(first);
+        assert!(matches!(
+            pending.try_admit("ufs://bucket/b".to_string()),
+            AsyncCacheAdmission::Accepted(_)
+        ));
+    }
+
+    #[test]
+    fn async_cache_pending_deduplicates_concurrent_requests() {
+        let pending = Arc::new(AsyncCachePending::new(32));
+        let accepted = Arc::new(Mutex::new(Vec::new()));
+        let mut threads = Vec::new();
+
+        for _ in 0..32 {
+            let pending = pending.clone();
+            let accepted = accepted.clone();
+            threads.push(std::thread::spawn(move || {
+                if let AsyncCacheAdmission::Accepted(permit) =
+                    pending.try_admit("ufs://bucket/same".to_string())
+                {
+                    accepted.lock().unwrap().push(permit);
+                }
+            }));
+        }
+        for thread in threads {
+            thread.join().unwrap();
+        }
+
+        assert_eq!(accepted.lock().unwrap().len(), 1);
     }
 }

--- a/crates/client/curvine-unified-fs/src/unified/unified_filesystem.rs
+++ b/crates/client/curvine-unified-fs/src/unified/unified_filesystem.rs
@@ -520,11 +520,19 @@ impl UnifiedFileSystem {
         let pending_permit = match self.async_cache_pending.try_admit(source_path.clone()) {
             AsyncCacheAdmission::Accepted(pending) => pending,
             AsyncCacheAdmission::AlreadyPending => {
+                self.metrics
+                    .async_cache_admission_skipped
+                    .with_label_values(&["already_pending"])
+                    .inc();
                 debug!("async cache request already pending for {}", source_path);
                 return Ok(());
             }
             AsyncCacheAdmission::Overloaded => {
-                warn!(
+                self.metrics
+                    .async_cache_admission_skipped
+                    .with_label_values(&["overloaded"])
+                    .inc();
+                debug!(
                     "skip async cache request for {} because the client pending queue is full, capacity={}",
                     source_path, self.async_cache_pending.capacity
                 );

--- a/crates/client/curvine-unified-fs/src/unified/unified_filesystem.rs
+++ b/crates/client/curvine-unified-fs/src/unified/unified_filesystem.rs
@@ -1347,14 +1347,30 @@ mod tests {
     }
 
     #[test]
-    fn async_cache_submit_slots_enforce_concurrency() {
-        let pending = AsyncCachePending::new(16, 2);
-        let first = pending.submit_slots.clone().try_acquire_owned().unwrap();
-        let second = pending.submit_slots.clone().try_acquire_owned().unwrap();
+    fn async_cache_pending_waiters_hold_admission_until_submission_finishes() {
+        let pending = AsyncCachePending::new(2, 1);
+        let first_pending = match pending.try_admit("ufs://bucket/a".to_string()) {
+            AsyncCacheAdmission::Accepted(permit) => permit,
+            _ => panic!("first path should be admitted"),
+        };
+        let second_pending = match pending.try_admit("ufs://bucket/b".to_string()) {
+            AsyncCacheAdmission::Accepted(permit) => permit,
+            _ => panic!("second path should wait within pending capacity"),
+        };
 
+        let first_submit = pending.submit_slots.clone().try_acquire_owned().unwrap();
         assert!(pending.submit_slots.clone().try_acquire_owned().is_err());
-        drop(first);
-        assert!(pending.submit_slots.clone().try_acquire_owned().is_ok());
-        drop(second);
+        assert_eq!(pending.paths.lock().len(), 2);
+
+        drop(first_submit);
+        let second_submit = pending.submit_slots.clone().try_acquire_owned().unwrap();
+        drop(second_submit);
+        assert_eq!(pending.paths.lock().len(), 2);
+
+        drop(first_pending);
+        assert!(!pending.paths.lock().contains("ufs://bucket/a"));
+        assert!(pending.paths.lock().contains("ufs://bucket/b"));
+        drop(second_pending);
+        assert!(pending.paths.lock().is_empty());
     }
 }

--- a/crates/client/curvine-unified-fs/src/unified/unified_filesystem.rs
+++ b/crates/client/curvine-unified-fs/src/unified/unified_filesystem.rs
@@ -39,6 +39,7 @@ use std::collections::HashSet;
 use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::sync::Semaphore;
 use tokio::time;
 
 const TRANSFER_SUBMIT_MAX_ATTEMPTS: usize = 3;
@@ -54,6 +55,7 @@ enum CacheValidity {
 struct AsyncCachePending {
     paths: Arc<FastMutex<HashSet<String>>>,
     capacity: usize,
+    submit_slots: Arc<Semaphore>,
 }
 
 enum AsyncCacheAdmission {
@@ -68,10 +70,11 @@ struct AsyncCachePermit {
 }
 
 impl AsyncCachePending {
-    fn new(capacity: usize) -> Self {
+    fn new(capacity: usize, submit_concurrency: usize) -> Self {
         Self {
             paths: Arc::new(FastMutex::new(HashSet::new())),
             capacity,
+            submit_slots: Arc::new(Semaphore::new(submit_concurrency)),
         }
     }
 
@@ -117,6 +120,7 @@ impl UnifiedFileSystem {
         let enable_read_ufs = conf.client.enable_rust_read_ufs;
         let audit_logging_enabled = conf.client.audit_logging_enabled;
         let async_cache_pending_capacity = conf.transfer.client_pending_queue_size();
+        let async_cache_submit_concurrency = conf.transfer.client_submit_concurrency();
 
         let cv = CurvineFileSystem::with_rt(conf, rt.clone())?;
         let fs = UnifiedFileSystem {
@@ -125,7 +129,10 @@ impl UnifiedFileSystem {
             enable_unified,
             enable_read_ufs,
             audit_logging_enabled,
-            async_cache_pending: AsyncCachePending::new(async_cache_pending_capacity),
+            async_cache_pending: AsyncCachePending::new(
+                async_cache_pending_capacity,
+                async_cache_submit_concurrency,
+            ),
             metrics: FsContext::get_metrics(),
         };
 
@@ -545,6 +552,19 @@ impl UnifiedFileSystem {
 
         self.fs_context().rt().spawn(async move {
             let _pending_permit = pending_permit;
+            let _submit_permit = match fs
+                .async_cache_pending
+                .submit_slots
+                .clone()
+                .acquire_owned()
+                .await
+            {
+                Ok(permit) => permit,
+                Err(err) => {
+                    warn!("async cache submit limiter closed unexpectedly: {}", err);
+                    return;
+                }
+            };
             let time = TimeSpent::new();
             let res = fs.submit_async_cache(&source_path).await;
 
@@ -1268,7 +1288,7 @@ mod tests {
 
     #[test]
     fn async_cache_pending_enforces_capacity_and_releases_slots() {
-        let pending = AsyncCachePending::new(1);
+        let pending = AsyncCachePending::new(1, 1);
         let first = match pending.try_admit("ufs://bucket/a".to_string()) {
             AsyncCacheAdmission::Accepted(permit) => permit,
             _ => panic!("first request should be accepted"),
@@ -1292,7 +1312,7 @@ mod tests {
 
     #[test]
     fn async_cache_pending_deduplicates_concurrent_requests() {
-        let pending = Arc::new(AsyncCachePending::new(32));
+        let pending = Arc::new(AsyncCachePending::new(32, 4));
         let accepted = Arc::new(Mutex::new(Vec::new()));
         let already_pending = Arc::new(AtomicUsize::new(0));
         let overloaded = Arc::new(AtomicUsize::new(0));
@@ -1324,5 +1344,17 @@ mod tests {
         assert_eq!(accepted.lock().unwrap().len(), 1);
         assert_eq!(already_pending.load(Ordering::Relaxed), 31);
         assert_eq!(overloaded.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn async_cache_submit_slots_enforce_concurrency() {
+        let pending = AsyncCachePending::new(16, 2);
+        let first = pending.submit_slots.clone().try_acquire_owned().unwrap();
+        let second = pending.submit_slots.clone().try_acquire_owned().unwrap();
+
+        assert!(pending.submit_slots.clone().try_acquire_owned().is_err());
+        drop(first);
+        assert!(pending.submit_slots.clone().try_acquire_owned().is_ok());
+        drop(second);
     }
 }

--- a/crates/common/curvine-config/src/transfer_conf.rs
+++ b/crates/common/curvine-config/src/transfer_conf.rs
@@ -53,6 +53,8 @@ pub struct TransferConf {
     #[serde(skip)]
     pub allow_submit_with_stale_snapshot: bool,
     pub max_running_transfers: usize,
+    /// Maximum number of distinct auto-cache requests waiting for client-side submission.
+    pub client_pending_queue_size: usize,
     #[serde(skip, default = "TransferConf::default_max_tasks_per_transfer")]
     pub max_tasks_per_transfer: usize,
     #[serde(
@@ -150,6 +152,11 @@ impl TransferConf {
         if self.max_running_transfers == 0 {
             return Err(FsError::common(
                 "transfer.max_running_transfers must be greater than 0",
+            ));
+        }
+        if self.client_pending_queue_size == 0 {
+            return Err(FsError::common(
+                "transfer.client_pending_queue_size must be greater than 0",
             ));
         }
         if self.ufs_max_concurrency_per_endpoint == 0 {
@@ -289,7 +296,7 @@ impl TransferConf {
     }
 
     pub fn client_pending_queue_size(&self) -> usize {
-        Self::DEFAULT_CLIENT_PENDING_QUEUE_SIZE
+        self.client_pending_queue_size
     }
 
     pub fn cleanup_batch_size(&self) -> usize {
@@ -338,6 +345,7 @@ impl Default for TransferConf {
             mysql_url: String::new(),
             allow_submit_with_stale_snapshot: false,
             max_running_transfers: 64,
+            client_pending_queue_size: Self::DEFAULT_CLIENT_PENDING_QUEUE_SIZE,
             max_tasks_per_transfer: Self::DEFAULT_MAX_TASKS_PER_TRANSFER,
             ufs_max_concurrency_per_endpoint: Self::DEFAULT_UFS_MAX_CONCURRENCY_PER_ENDPOINT,
             task_max_retries: Self::DEFAULT_TASK_MAX_RETRIES,
@@ -387,6 +395,25 @@ mod tests {
         .unwrap();
 
         assert_eq!(conf.log.file_name, "transfer-test.log");
+    }
+
+    #[test]
+    fn parses_client_pending_queue_size() {
+        let mut conf: TransferConf = toml::from_str("client_pending_queue_size = 2048").unwrap();
+        conf.init().unwrap();
+
+        assert_eq!(conf.client_pending_queue_size(), 2048);
+    }
+
+    #[test]
+    fn rejects_zero_client_pending_queue_size() {
+        let mut conf = TransferConf {
+            client_pending_queue_size: 0,
+            ..Default::default()
+        };
+
+        let err = conf.init().unwrap_err().to_string();
+        assert!(err.contains("transfer.client_pending_queue_size must be greater than 0"));
     }
 
     #[test]

--- a/crates/common/curvine-config/src/transfer_conf.rs
+++ b/crates/common/curvine-config/src/transfer_conf.rs
@@ -53,7 +53,8 @@ pub struct TransferConf {
     #[serde(skip)]
     pub allow_submit_with_stale_snapshot: bool,
     pub max_running_transfers: usize,
-    /// Maximum number of distinct auto-cache requests waiting for client-side submission.
+    /// Maximum number of distinct auto-cache requests waiting for or performing submission.
+    /// This includes requests waiting for a `client_submit_concurrency` permit.
     pub client_pending_queue_size: usize,
     /// Maximum number of client-side auto-cache submissions running concurrently.
     pub client_submit_concurrency: usize,

--- a/crates/common/curvine-config/src/transfer_conf.rs
+++ b/crates/common/curvine-config/src/transfer_conf.rs
@@ -55,6 +55,8 @@ pub struct TransferConf {
     pub max_running_transfers: usize,
     /// Maximum number of distinct auto-cache requests waiting for client-side submission.
     pub client_pending_queue_size: usize,
+    /// Maximum number of client-side auto-cache submissions running concurrently.
+    pub client_submit_concurrency: usize,
     #[serde(skip, default = "TransferConf::default_max_tasks_per_transfer")]
     pub max_tasks_per_transfer: usize,
     #[serde(
@@ -106,6 +108,7 @@ impl TransferConf {
     pub const DEFAULT_TASK_REPORT_QUEUE_SIZE: usize = 10_000;
     pub const DEFAULT_TASK_PROBE_CONCURRENCY: usize = 64;
     pub const DEFAULT_CLIENT_PENDING_QUEUE_SIZE: usize = 1024;
+    pub const DEFAULT_CLIENT_SUBMIT_CONCURRENCY: usize = 64;
     pub const DEFAULT_CLEANUP_BATCH_SIZE: usize = 1000;
     pub const DEFAULT_RPC_PORT: u16 = 9010;
     pub const DEFAULT_WEB_PORT: u16 = 9011;
@@ -157,6 +160,11 @@ impl TransferConf {
         if self.client_pending_queue_size == 0 {
             return Err(FsError::common(
                 "transfer.client_pending_queue_size must be greater than 0",
+            ));
+        }
+        if self.client_submit_concurrency == 0 {
+            return Err(FsError::common(
+                "transfer.client_submit_concurrency must be greater than 0",
             ));
         }
         if self.ufs_max_concurrency_per_endpoint == 0 {
@@ -299,6 +307,10 @@ impl TransferConf {
         self.client_pending_queue_size
     }
 
+    pub fn client_submit_concurrency(&self) -> usize {
+        self.client_submit_concurrency
+    }
+
     pub fn cleanup_batch_size(&self) -> usize {
         Self::DEFAULT_CLEANUP_BATCH_SIZE
     }
@@ -346,6 +358,7 @@ impl Default for TransferConf {
             allow_submit_with_stale_snapshot: false,
             max_running_transfers: 64,
             client_pending_queue_size: Self::DEFAULT_CLIENT_PENDING_QUEUE_SIZE,
+            client_submit_concurrency: Self::DEFAULT_CLIENT_SUBMIT_CONCURRENCY,
             max_tasks_per_transfer: Self::DEFAULT_MAX_TASKS_PER_TRANSFER,
             ufs_max_concurrency_per_endpoint: Self::DEFAULT_UFS_MAX_CONCURRENCY_PER_ENDPOINT,
             task_max_retries: Self::DEFAULT_TASK_MAX_RETRIES,
@@ -399,10 +412,17 @@ mod tests {
 
     #[test]
     fn parses_client_pending_queue_size() {
-        let mut conf: TransferConf = toml::from_str("client_pending_queue_size = 2048").unwrap();
+        let mut conf: TransferConf = toml::from_str(
+            r#"
+                client_pending_queue_size = 2048
+                client_submit_concurrency = 128
+            "#,
+        )
+        .unwrap();
         conf.init().unwrap();
 
         assert_eq!(conf.client_pending_queue_size(), 2048);
+        assert_eq!(conf.client_submit_concurrency(), 128);
     }
 
     #[test]
@@ -414,6 +434,17 @@ mod tests {
 
         let err = conf.init().unwrap_err().to_string();
         assert!(err.contains("transfer.client_pending_queue_size must be greater than 0"));
+    }
+
+    #[test]
+    fn rejects_zero_client_submit_concurrency() {
+        let mut conf = TransferConf {
+            client_submit_concurrency: 0,
+            ..Default::default()
+        };
+
+        let err = conf.init().unwrap_err().to_string();
+        assert!(err.contains("transfer.client_submit_concurrency must be greater than 0"));
     }
 
     #[test]

--- a/crates/sdk/curvine-sdk-core/src/filesystem_conf.rs
+++ b/crates/sdk/curvine-sdk-core/src/filesystem_conf.rs
@@ -122,11 +122,22 @@ pub struct FilesystemConf {
     pub transfer: TransferClientConf,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct TransferClientConf {
     pub enabled: bool,
     pub endpoints: Vec<String>,
+    pub client_pending_queue_size: usize,
+}
+
+impl Default for TransferClientConf {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            endpoints: vec![],
+            client_pending_queue_size: TransferConf::DEFAULT_CLIENT_PENDING_QUEUE_SIZE,
+        }
+    }
 }
 
 impl FilesystemConf {
@@ -286,6 +297,7 @@ impl FilesystemConf {
             transfer: TransferConf {
                 enabled: self.transfer.enabled,
                 endpoints: self.transfer.endpoints,
+                client_pending_queue_size: self.transfer.client_pending_queue_size,
                 ..Default::default()
             },
             ..Default::default()
@@ -306,6 +318,7 @@ mod tests {
         conf.transfer = TransferClientConf {
             enabled: true,
             endpoints: vec!["transfer-0:9010".to_string(), "transfer-1:9010".to_string()],
+            client_pending_queue_size: 2048,
         };
 
         let cluster = conf.into_cluster_conf().unwrap();
@@ -315,6 +328,7 @@ mod tests {
             cluster.transfer.endpoints,
             vec!["transfer-0:9010", "transfer-1:9010"]
         );
+        assert_eq!(cluster.transfer.client_pending_queue_size(), 2048);
     }
 
     #[test]
@@ -344,6 +358,7 @@ mod tests {
                 [transfer]
                 enabled = true
                 endpoints = ["transfer-0:9010", "transfer-1:9010"]
+                client_pending_queue_size = 4096
             "#,
         )
         .unwrap();
@@ -355,5 +370,6 @@ mod tests {
             cluster.transfer.endpoints,
             vec!["transfer-0:9010", "transfer-1:9010"]
         );
+        assert_eq!(cluster.transfer.client_pending_queue_size(), 4096);
     }
 }

--- a/crates/sdk/curvine-sdk-core/src/filesystem_conf.rs
+++ b/crates/sdk/curvine-sdk-core/src/filesystem_conf.rs
@@ -128,6 +128,7 @@ pub struct TransferClientConf {
     pub enabled: bool,
     pub endpoints: Vec<String>,
     pub client_pending_queue_size: usize,
+    pub client_submit_concurrency: usize,
 }
 
 impl Default for TransferClientConf {
@@ -136,6 +137,7 @@ impl Default for TransferClientConf {
             enabled: false,
             endpoints: vec![],
             client_pending_queue_size: TransferConf::DEFAULT_CLIENT_PENDING_QUEUE_SIZE,
+            client_submit_concurrency: TransferConf::DEFAULT_CLIENT_SUBMIT_CONCURRENCY,
         }
     }
 }
@@ -298,6 +300,7 @@ impl FilesystemConf {
                 enabled: self.transfer.enabled,
                 endpoints: self.transfer.endpoints,
                 client_pending_queue_size: self.transfer.client_pending_queue_size,
+                client_submit_concurrency: self.transfer.client_submit_concurrency,
                 ..Default::default()
             },
             ..Default::default()
@@ -319,6 +322,7 @@ mod tests {
             enabled: true,
             endpoints: vec!["transfer-0:9010".to_string(), "transfer-1:9010".to_string()],
             client_pending_queue_size: 2048,
+            client_submit_concurrency: 128,
         };
 
         let cluster = conf.into_cluster_conf().unwrap();
@@ -329,6 +333,7 @@ mod tests {
             vec!["transfer-0:9010", "transfer-1:9010"]
         );
         assert_eq!(cluster.transfer.client_pending_queue_size(), 2048);
+        assert_eq!(cluster.transfer.client_submit_concurrency(), 128);
     }
 
     #[test]
@@ -359,6 +364,7 @@ mod tests {
                 enabled = true
                 endpoints = ["transfer-0:9010", "transfer-1:9010"]
                 client_pending_queue_size = 4096
+                client_submit_concurrency = 256
             "#,
         )
         .unwrap();
@@ -371,5 +377,6 @@ mod tests {
             vec!["transfer-0:9010", "transfer-1:9010"]
         );
         assert_eq!(cluster.transfer.client_pending_queue_size(), 4096);
+        assert_eq!(cluster.transfer.client_submit_concurrency(), 256);
     }
 }

--- a/curvine-docker/deploy/example/conf/curvine-cluster.toml
+++ b/curvine-docker/deploy/example/conf/curvine-cluster.toml
@@ -56,6 +56,7 @@ enabled = false
 rpc_port = 9010
 web_port = 9011
 client_pending_queue_size = 1024
+client_submit_concurrency = 64
 log = { level = "info", log_dir = "./logs", file_name = "transfer.log" }
 
 [fuse]

--- a/curvine-docker/deploy/example/conf/curvine-cluster.toml
+++ b/curvine-docker/deploy/example/conf/curvine-cluster.toml
@@ -55,6 +55,7 @@ master_addrs = [
 enabled = false
 rpc_port = 9010
 web_port = 9011
+client_pending_queue_size = 1024
 log = { level = "info", log_dir = "./logs", file_name = "transfer.log" }
 
 [fuse]

--- a/curvine-docker/deploy/spdk/curvine-cluster-spdk.toml
+++ b/curvine-docker/deploy/spdk/curvine-cluster-spdk.toml
@@ -69,6 +69,7 @@ enabled = true
 rpc_port = 9010
 web_port = 9011
 client_pending_queue_size = 1024
+client_submit_concurrency = 64
 log = { level = "debug", log_dir = "stdout", file_name = "transfer.log" }
 
 # fuse configuration  

--- a/curvine-docker/deploy/spdk/curvine-cluster-spdk.toml
+++ b/curvine-docker/deploy/spdk/curvine-cluster-spdk.toml
@@ -68,6 +68,7 @@ short_circuit = false
 enabled = true
 rpc_port = 9010
 web_port = 9011
+client_pending_queue_size = 1024
 log = { level = "debug", log_dir = "stdout", file_name = "transfer.log" }
 
 # fuse configuration  

--- a/curvine-libsdk/java/src/main/java/io/curvine/FilesystemConf.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/FilesystemConf.java
@@ -94,6 +94,7 @@ public class FilesystemConf {
     // Transfer service routing. Endpoints are comma-separated host:port values.
     public boolean transfer_enabled = false;
     public String transfer_endpoints = "";
+    public int transfer_client_pending_queue_size = 1024;
 
     public boolean enable_block_conn_pool = true;
     public int block_conn_idle_size = 128;
@@ -172,6 +173,11 @@ public class FilesystemConf {
         if (transferEndpoints != null) {
             transfer_endpoints = transferEndpoints;
         }
+        String transferClientPendingQueueSize =
+                conf.get(PREFIX + ".transfer.client_pending_queue_size");
+        if (transferClientPendingQueueSize != null) {
+            transfer_client_pending_queue_size = Integer.parseInt(transferClientPendingQueueSize);
+        }
     }
 
     public String toToml() throws IllegalAccessException {
@@ -217,13 +223,17 @@ public class FilesystemConf {
             first = false;
         }
         builder.append("]\n");
+        builder.append("client_pending_queue_size = ")
+                .append(transfer_client_pending_queue_size)
+                .append("\n");
 
         return builder.toString();
     }
 
     private static boolean isTransferField(Field field) {
         return "transfer_enabled".equals(field.getName())
-                || "transfer_endpoints".equals(field.getName());
+                || "transfer_endpoints".equals(field.getName())
+                || "transfer_client_pending_queue_size".equals(field.getName());
     }
 
     private static String escapeTomlString(String value) {

--- a/curvine-libsdk/java/src/main/java/io/curvine/FilesystemConf.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/FilesystemConf.java
@@ -95,6 +95,7 @@ public class FilesystemConf {
     public boolean transfer_enabled = false;
     public String transfer_endpoints = "";
     public int transfer_client_pending_queue_size = 1024;
+    public int transfer_client_submit_concurrency = 64;
 
     public boolean enable_block_conn_pool = true;
     public int block_conn_idle_size = 128;
@@ -178,6 +179,11 @@ public class FilesystemConf {
         if (transferClientPendingQueueSize != null) {
             transfer_client_pending_queue_size = Integer.parseInt(transferClientPendingQueueSize);
         }
+        String transferClientSubmitConcurrency =
+                conf.get(PREFIX + ".transfer.client_submit_concurrency");
+        if (transferClientSubmitConcurrency != null) {
+            transfer_client_submit_concurrency = Integer.parseInt(transferClientSubmitConcurrency);
+        }
     }
 
     public String toToml() throws IllegalAccessException {
@@ -226,6 +232,9 @@ public class FilesystemConf {
         builder.append("client_pending_queue_size = ")
                 .append(transfer_client_pending_queue_size)
                 .append("\n");
+        builder.append("client_submit_concurrency = ")
+                .append(transfer_client_submit_concurrency)
+                .append("\n");
 
         return builder.toString();
     }
@@ -233,7 +242,8 @@ public class FilesystemConf {
     private static boolean isTransferField(Field field) {
         return "transfer_enabled".equals(field.getName())
                 || "transfer_endpoints".equals(field.getName())
-                || "transfer_client_pending_queue_size".equals(field.getName());
+                || "transfer_client_pending_queue_size".equals(field.getName())
+                || "transfer_client_submit_concurrency".equals(field.getName());
     }
 
     private static String escapeTomlString(String value) {

--- a/curvine-libsdk/java/src/test/java/io/curvine/LoadJobClientTest.java
+++ b/curvine-libsdk/java/src/test/java/io/curvine/LoadJobClientTest.java
@@ -128,6 +128,7 @@ public class LoadJobClientTest {
         conf.set("fs.cv.transfer.enabled", "true");
         conf.set("fs.cv.transfer.endpoints", "transfer-0:9010, transfer-1:9010");
         conf.set("fs.cv.transfer.client_pending_queue_size", "2048");
+        conf.set("fs.cv.transfer.client_submit_concurrency", "128");
 
         String toml = new FilesystemConf(conf).toToml();
 
@@ -135,5 +136,6 @@ public class LoadJobClientTest {
         Assert.assertTrue(toml.contains("enabled = true"));
         Assert.assertTrue(toml.contains("endpoints = [\"transfer-0:9010\", \"transfer-1:9010\"]"));
         Assert.assertTrue(toml.contains("client_pending_queue_size = 2048"));
+        Assert.assertTrue(toml.contains("client_submit_concurrency = 128"));
     }
 }

--- a/curvine-libsdk/java/src/test/java/io/curvine/LoadJobClientTest.java
+++ b/curvine-libsdk/java/src/test/java/io/curvine/LoadJobClientTest.java
@@ -127,11 +127,13 @@ public class LoadJobClientTest {
         conf.set("fs.cv.master_addrs", "master-0:8995");
         conf.set("fs.cv.transfer.enabled", "true");
         conf.set("fs.cv.transfer.endpoints", "transfer-0:9010, transfer-1:9010");
+        conf.set("fs.cv.transfer.client_pending_queue_size", "2048");
 
         String toml = new FilesystemConf(conf).toToml();
 
         Assert.assertTrue(toml.contains("[transfer]"));
         Assert.assertTrue(toml.contains("enabled = true"));
         Assert.assertTrue(toml.contains("endpoints = [\"transfer-0:9010\", \"transfer-1:9010\"]"));
+        Assert.assertTrue(toml.contains("client_pending_queue_size = 2048"));
     }
 }

--- a/etc/curvine-cluster.toml
+++ b/etc/curvine-cluster.toml
@@ -94,6 +94,7 @@ web_port = 9011
 # Maximum distinct auto-cache requests waiting for client-side submission.
 # When full, new cache requests are skipped and foreground reads continue from UFS.
 client_pending_queue_size = 1024
+client_submit_concurrency = 64
 log = { level = "info", log_dir = "stdout", file_name = "transfer.log" }
 
 # fuse configuration

--- a/etc/curvine-cluster.toml
+++ b/etc/curvine-cluster.toml
@@ -91,6 +91,9 @@ subnqn = "nqn.2024-01.io.curvine:subsystem2"
 enabled = false
 rpc_port = 9010
 web_port = 9011
+# Maximum distinct auto-cache requests waiting for client-side submission.
+# When full, new cache requests are skipped and foreground reads continue from UFS.
+client_pending_queue_size = 1024
 log = { level = "info", log_dir = "stdout", file_name = "transfer.log" }
 
 # fuse configuration


### PR DESCRIPTION
# Summary

Prevent auto-cache admission overload from failing foreground FUSE reads, make the client pending capacity configurable, and make concurrent admission and same-path deduplication race-free.

On a cache miss, the unified filesystem schedules an asynchronous load from UFS into Curvine and immediately falls back to reading the file from UFS. The cache load is an optimization and is not required to serve the current open. Curvine previously returned `TransferOverloaded` when 1024 distinct cache submissions were pending. That error escaped from `open()`, was mapped to the default FUSE `EIO`, and failed an otherwise valid UFS read.

The pending limit is now configured with `transfer.client_pending_queue_size`, defaults to 1024, and must be greater than zero. Concurrent client submissions are independently limited by `transfer.client_submit_concurrency`, which defaults to 64. When the pending limit is reached, Curvine skips the new cache request while the foreground open continues through UFS.

# Minimal Reproducer

Configure a small client-side pending capacity and an unreachable Transfer endpoint so that the first asynchronous submission remains pending during its retry backoff:

```toml
[transfer]
enabled = true
endpoints = ["127.0.0.1:19010"]
client_pending_queue_size = 1
client_submit_concurrency = 1
```

Mount a UFS directory with auto-cache enabled, create several files directly in the UFS source, and open them concurrently through the Curvine FUSE mount:

```bash
for i in $(seq 1 32); do
    printf 'file-%s\n' "$i" > "/path/to/ufs/source/file-$i"
done

seq 1 32 | xargs -P32 -I{} sh -c \
    'cat "/mnt/curvine/file-{}" >/dev/null'
```

Before the fix, the first miss occupied the only pending slot. Other misses returned `TransferOverloaded` from the client admission check. Because `UnifiedFileSystem::open()` propagated that result with `?`, FUSE converted the unmapped filesystem error to `EIO`, and some `cat` processes failed even though all source files were readable from UFS.

After the fix, the extra cache requests are skipped. All opens continue to UFS and complete successfully; a later cache miss can retry admission after a slot is released.

# Root Cause

Auto-cache scheduling was coupled to foreground open success:

```text
cache miss
  -> async_cache()
  -> pending count reaches 1024
  -> TransferOverloaded
  -> open() returns the error
  -> FUSE maps the unrecognized error to EIO
```

This violates the intended cache-mode behavior. The current request does not wait for the asynchronous load job and reads from UFS regardless, so failure to schedule the optional cache population must not fail the current open.

The old admission logic also used three separate concurrent operations:

```text
contains(path) -> len() < capacity -> insert(path)
```

Those operations were not atomic. Concurrent requests for the same path could both pass `contains()`, while concurrent requests for different paths could all pass the length check and exceed the configured limit. Server-side Transfer request idempotency can avoid creating duplicate jobs, but it does not prevent duplicate client RPC submissions or enforce the client pending bound.

Finally, the 1024 limit was exposed only through a getter that always returned a constant, so deployments could not tune admission capacity for their file count, Transfer latency, or expected cache-miss concurrency.

# Changes

- Add `transfer.client_pending_queue_size` with a default of 1024 and reject a zero value during configuration initialization.
- Add `transfer.client_submit_concurrency` with a default of 64 to bound simultaneous client submission and retry attempts independently from the pending queue.
- Propagate the setting through the SDK/Java filesystem configuration path.
- Propagate `fs.cv.transfer.client_pending_queue_size` and `fs.cv.transfer.client_submit_concurrency` through the Hadoop/Java `FilesystemConf` TOML generator.
- Add the setting to the standard, Docker example, and SPDK configuration templates.
- Replace the racy multi-step admission check with a short `FastMutex<HashSet>` critical section that atomically deduplicates paths, checks capacity, and records accepted requests.
- Hold an RAII admission permit for the full submission attempt, including retry backoff, and release the path marker on success, failure, cancellation, or task drop.
- Treat an already-pending or overloaded cache request as a successful best-effort outcome instead of returning `TransferOverloaded`.
- Count skipped auto-cache admissions by reason and keep per-path overload messages at debug level to avoid warning storms during scans.
- Isolate `open()` from any current or future auto-cache scheduling error so foreground reads still fall back to UFS.
- Add tests for configurable capacity and submit concurrency, zero-value validation, capacity enforcement, permit release, submit concurrency enforcement, and concurrent same-path deduplication.

# Deployment Note

Existing configurations remain compatible and continue to use the default capacity of 1024 when `client_pending_queue_size` is omitted.

`client_pending_queue_size` limits distinct auto-cache requests waiting for or performing client-side submission. `client_submit_concurrency` limits how many of those requests may concurrently perform UFS status lookup, Transfer RPC submission, and retry backoff. Neither setting controls the number of Transfer jobs executing on the server; `transfer.max_running_transfers` remains the server-side execution limit.

The admission tracker is created when the unified filesystem client starts. Changing either client-side setting therefore requires restarting the affected FUSE, Rust, or Java client process. The Master and Worker do not need to restart for this client-side behavior change. A standalone Transfer service only needs a restart if its shared configuration file is changed as part of the deployment.

When the queue is full, new cache population requests are deliberately dropped instead of being buffered without a bound. The foreground read is still served from UFS, and a later cache miss can submit the load after pending capacity is available.

# Verification

- `cargo test -p curvine-config -p curvine-client-core -p curvine-unified-fs -p curvine-sdk-core` passes.
- Auto-cache capacity, submit concurrency, and concurrent same-path deduplication tests pass.
- Transfer configuration parsing, defaulting, validation, and SDK propagation tests pass.
- `mvn -f curvine-libsdk/java/pom.xml -Dtest=LoadJobClientTest test` passes: `8 passed`.
- `cargo clippy -p curvine-config -p curvine-unified-fs -p curvine-sdk-core --tests -- -D warnings` passes.
- `make format` passes, including workspace release checks.
- `git diff --check` passes.
