### PR TITLE
fix(raft): advance applied index for leader no-op

### DIFF
--- a/crates/metadata/curvine-raft/src/raft/raft_node.rs
+++ b/crates/metadata/curvine-raft/src/raft/raft_node.rs
@@ -704,12 +704,8 @@ where
         client_send: &mut HashMap<i64, Callback>,
     ) -> RaftResult<()> {
         for entry in entries {
-            if entry.get_data().is_empty() {
-                continue;
-            }
-
             let is_conf_change = matches!(entry.get_entry_type(), EntryType::EntryConfChange);
-            let should_respond = self.is_leader();
+            let should_respond = self.is_leader() && !entry.get_data().is_empty();
             let (entry_index, entry_term, entry_context) = if should_respond {
                 (entry.index, entry.term, Some(entry.get_context().to_vec()))
             } else {
@@ -717,6 +713,9 @@ where
             };
             let rep_msg = if is_conf_change {
                 let rep = self.apply_config_change(&entry)?;
+                self.storage
+                    .apply_propose(false, ApplyMsg::new_entry(entry))
+                    .await?;
                 Builder::new_rpc(RaftCode::ConfChange)
                     .response(ResponseStatus::Success)
                     .proto_header(rep)

--- a/crates/metadata/curvine-raft/src/raft/storage/hash_app_storage.rs
+++ b/crates/metadata/curvine-raft/src/raft/storage/hash_app_storage.rs
@@ -19,6 +19,7 @@ use crate::rocksdb::DBEngine;
 use crate::utils::SerdeUtils;
 use curvine_core_error::{try_err, try_option_ref, CommonResult};
 use curvine_runtime::common::LocalTime;
+use raft::eraftpb::EntryType;
 use raft::StateRole;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -91,9 +92,11 @@ where
         }
         let (entry, ack) = msg.into_entry_with_ack()?;
         let result = (|| -> RaftResult<()> {
-            let mut map = self.write()?;
-            let pairs: (K, V) = SerdeUtils::deserialize(&entry.data)?;
-            map.insert(pairs.0, pairs.1);
+            if entry.get_entry_type() == EntryType::EntryNormal && !entry.data.is_empty() {
+                let mut map = self.write()?;
+                let pairs: (K, V) = SerdeUtils::deserialize(&entry.data)?;
+                map.insert(pairs.0, pairs.1);
+            }
 
             self.fsm_state.lock().unwrap().applied = AppliedIndex {
                 term: entry.term,
@@ -205,11 +208,13 @@ where
         }
         let (entry, ack) = msg.into_entry_with_ack()?;
         let result = (|| -> RaftResult<()> {
-            let db = self.lock()?;
-            let pairs: (K, V) = SerdeUtils::deserialize(&entry.data)?;
-            let k = SerdeUtils::serialize(&pairs.0)?;
-            let v = SerdeUtils::serialize(&pairs.1)?;
-            db.put(k, v)?;
+            if entry.get_entry_type() == EntryType::EntryNormal && !entry.data.is_empty() {
+                let db = self.lock()?;
+                let pairs: (K, V) = SerdeUtils::deserialize(&entry.data)?;
+                let k = SerdeUtils::serialize(&pairs.0)?;
+                let v = SerdeUtils::serialize(&pairs.1)?;
+                db.put(k, v)?;
+            }
 
             self.fsm_state.lock().unwrap().applied = AppliedIndex {
                 term: entry.term,

--- a/crates/metadata/curvine-raft/tests/raft_node_test.rs
+++ b/crates/metadata/curvine-raft/tests/raft_node_test.rs
@@ -31,7 +31,10 @@ use curvine_runtime::common::{FileUtils, Logger, Utils};
 use curvine_runtime::runtime::{AsyncRuntime, RpcRuntime, Runtime};
 use prost::bytes::BytesMut;
 use prost::Message;
-use raft::eraftpb::{ConfState, Entry, HardState, Message as RaftMessage, MessageType, Snapshot};
+use raft::eraftpb::{
+    ConfChange, ConfState, Entry, EntryType, HardState, Message as RaftMessage, MessageType,
+    Snapshot,
+};
 use raft::{Config, RawNode};
 use raft::{GetEntriesContext, RaftState, StateRole, Storage, StorageError};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -170,8 +173,10 @@ impl TestKvAppStorage {
     }
 
     fn apply_entry(&self, entry: Entry) -> RaftResult<()> {
-        let pair: (String, String) = SerdeUtils::deserialize(&entry.data)?;
-        self.map.write().unwrap().insert(pair.0, pair.1);
+        if entry.get_entry_type() == EntryType::EntryNormal && !entry.data.is_empty() {
+            let pair: (String, String) = SerdeUtils::deserialize(&entry.data)?;
+            self.map.write().unwrap().insert(pair.0, pair.1);
+        }
         self.fsm_state.lock().unwrap().applied = curvine_raft::proto::raft::AppliedIndex {
             term: entry.term,
             index: entry.index,
@@ -257,6 +262,16 @@ impl BlockingApplyAppStorage {
     }
 
     async fn apply_entry(&self, entry: Entry, wait: bool) -> RaftResult<()> {
+        if entry.get_entry_type() != EntryType::EntryNormal || entry.data.is_empty() {
+            self.fsm_state.lock().unwrap().applied = curvine_raft::proto::raft::AppliedIndex {
+                term: entry.term,
+                index: entry.index,
+                op_id: 0,
+                rpc_id: 0,
+            };
+            return Ok(());
+        }
+
         let pair: (String, String) = SerdeUtils::deserialize(&entry.data)?;
         self.started.store(true, Ordering::SeqCst);
         self.started_notify.notify_one();
@@ -456,6 +471,40 @@ fn malformed_propose_request_does_not_stop_raft_node() -> CommonResult<()> {
     Ok(())
 }
 
+#[test]
+fn committed_leader_noop_advances_app_storage_applied_index() -> CommonResult<()> {
+    Logger::default();
+
+    let mut conf = JournalConf::with_test();
+    conf.journal_dir = format!("../testing/leader-noop-{}", Utils::rand_id());
+    FileUtils::delete_path(&conf.journal_dir, true)?;
+
+    let rt = conf.create_runtime();
+    let store = TestKvAppStorage::default();
+    let raft = RaftJournal::new(
+        rt.clone(),
+        RocksLogStorage::from_conf(&conf, true),
+        store.clone(),
+        conf.clone(),
+        RoleMonitor::new(),
+    );
+    let mut listener = rt.block_on(raft.run())?;
+    rt.block_on(listener.wait_leader())?;
+
+    rt.block_on(async {
+        tokio::time::timeout(std::time::Duration::from_secs(3), async {
+            while store.get_fsm_state().applied.index == 0 {
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("committed leader no-op should reach app storage");
+    });
+
+    FileUtils::delete_path(&conf.journal_dir, true)?;
+    Ok(())
+}
+
 /// AppStorage that already has local applied state and refuses empty snapshot installs.
 #[derive(Clone)]
 struct PopulatedRefuseEmptySnapshotAppStorage {
@@ -583,7 +632,7 @@ fn propose_response_waits_until_committed_entry_is_applied() -> CommonResult<()>
 }
 
 #[test]
-fn kv_app_storages_accept_scan_control_messages() -> CommonResult<()> {
+fn kv_app_storages_accept_non_data_entries() -> CommonResult<()> {
     let rt = AsyncRuntime::single();
     let applied = curvine_raft::proto::raft::AppliedIndex {
         term: 1,
@@ -593,11 +642,49 @@ fn kv_app_storages_accept_scan_control_messages() -> CommonResult<()> {
 
     let hash: HashAppStorage<String, String> = HashAppStorage::new();
     rt.block_on(hash.apply(true, ApplyMsg::new_scan(applied.clone())))?;
+    rt.block_on(hash.apply(
+        true,
+        ApplyMsg::new_entry(Entry {
+            term: 1,
+            index: 2,
+            ..Default::default()
+        }),
+    ))?;
+    rt.block_on(hash.apply(
+        true,
+        ApplyMsg::new_entry(Entry {
+            term: 1,
+            index: 3,
+            entry_type: EntryType::EntryConfChange as i32,
+            data: ConfChange::default().encode_to_vec(),
+            ..Default::default()
+        }),
+    ))?;
+    assert_eq!(hash.get_fsm_state().applied.index, 3);
 
     let dir = Utils::test_sub_dir(format!("rocks-app-storage-scan-{}", Utils::rand_id()));
     FileUtils::delete_path(&dir, true)?;
     let rocks: RocksAppStorage<String, String> = RocksAppStorage::new(&dir);
     rt.block_on(rocks.apply(true, ApplyMsg::new_scan(applied)))?;
+    rt.block_on(rocks.apply(
+        true,
+        ApplyMsg::new_entry(Entry {
+            term: 1,
+            index: 2,
+            ..Default::default()
+        }),
+    ))?;
+    rt.block_on(rocks.apply(
+        true,
+        ApplyMsg::new_entry(Entry {
+            term: 1,
+            index: 3,
+            entry_type: EntryType::EntryConfChange as i32,
+            data: ConfChange::default().encode_to_vec(),
+            ..Default::default()
+        }),
+    ))?;
+    assert_eq!(rocks.get_fsm_state().applied.index, 3);
     drop(rocks);
     FileUtils::delete_path(&dir, true)?;
 

--- a/curvine-master/src/master/journal/journal_loader.rs
+++ b/curvine-master/src/master/journal/journal_loader.rs
@@ -32,7 +32,7 @@ use curvine_runtime::common::{FileUtils, TimeSpent};
 use curvine_runtime::runtime::{RpcRuntime, Runtime};
 use curvine_runtime::sync::channel::{AsyncChannel, AsyncReceiver, AsyncSender, CallChannel};
 use log::{debug, error, info, warn};
-use raft::eraftpb::Entry;
+use raft::eraftpb::{Entry, EntryType};
 use raft::StateRole;
 use std::path::Path;
 use std::sync::{Arc, Mutex, MutexGuard};
@@ -226,9 +226,9 @@ impl JournalLoader {
             return Ok(());
         }
 
-        // Raft appends an empty no-op entry when a leader is elected. It has no
-        // metadata mutation, but still advances the committed apply high-water mark.
-        if entry.data.is_empty() {
+        // Empty leader no-ops and configuration entries have no metadata mutation,
+        // but still advance the committed apply high-water mark.
+        if entry.get_entry_type() != EntryType::EntryNormal || entry.data.is_empty() {
             let mut applied = if is_leader {
                 cur.ufs_applied
             } else {

--- a/curvine-master/src/master/journal/journal_loader.rs
+++ b/curvine-master/src/master/journal/journal_loader.rs
@@ -229,7 +229,14 @@ impl JournalLoader {
         // Raft appends an empty no-op entry when a leader is elected. It has no
         // metadata mutation, but still advances the committed apply high-water mark.
         if entry.data.is_empty() {
-            self.set_applied(is_leader, Self::build_applied(entry), false)?;
+            let mut applied = if is_leader {
+                cur.ufs_applied
+            } else {
+                cur.applied
+            };
+            applied.term = entry.term;
+            applied.index = entry.index;
+            self.set_applied(is_leader, applied, false)?;
             return Ok(());
         }
 

--- a/curvine-master/src/master/journal/journal_loader.rs
+++ b/curvine-master/src/master/journal/journal_loader.rs
@@ -216,10 +216,6 @@ impl JournalLoader {
         entry: &Entry,
         skip_ufs_error: bool,
     ) -> CommonResult<()> {
-        if entry.data.is_empty() {
-            return Ok(());
-        }
-
         let cur = self.fsm_state_snapshot()?;
         let role_applied = ternary!(is_leader, cur.ufs_applied.index, cur.applied.index);
         if entry.index <= role_applied {
@@ -227,6 +223,13 @@ impl JournalLoader {
                 "skip entry index {}, term {}, fsm_state {:?}",
                 entry.index, entry.term, cur
             );
+            return Ok(());
+        }
+
+        // Raft appends an empty no-op entry when a leader is elected. It has no
+        // metadata mutation, but still advances the committed apply high-water mark.
+        if entry.data.is_empty() {
+            self.set_applied(is_leader, Self::build_applied(entry), false)?;
             return Ok(());
         }
 

--- a/curvine-server/tests/journal_test.rs
+++ b/curvine-server/tests/journal_test.rs
@@ -32,7 +32,8 @@ use curvine_server::master::journal::{
 };
 use curvine_server::master::{Master, MountManager};
 use log::info;
-use raft::eraftpb::Entry;
+use prost::Message;
+use raft::eraftpb::{ConfChange, Entry, EntryType};
 use raft::StateRole;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -196,6 +197,35 @@ fn leader_promotion_advances_applied_index_over_committed_noop() -> CommonResult
     assert_eq!(state.ufs_applied.index, 2);
     assert_eq!(state.ufs_applied.op_id, expected_op_id);
     assert_eq!(state.ufs_applied.rpc_id, expected_rpc_id);
+    Ok(())
+}
+
+#[test]
+fn leader_promotion_advances_over_committed_configuration_entry() -> CommonResult<()> {
+    Master::init_test_metrics();
+
+    let mut conf = ClusterConf {
+        testing: true,
+        ..Default::default()
+    };
+    conf.change_test_meta_dir(format!("promotion-conf-change-{}", Utils::rand_str(6)));
+    let journal_system = JournalSystem::from_conf(&conf)?;
+    let loader = journal_system.journal_loader();
+
+    journal_system.append_committed_entry_for_test(Entry {
+        term: 1,
+        index: 1,
+        entry_type: EntryType::EntryConfChange as i32,
+        data: ConfChange::default().encode_to_vec(),
+        ..Default::default()
+    })?;
+
+    AsyncRuntime::single().block_on(async { loader.role_change(StateRole::Leader).await })?;
+    AsyncRuntime::single().block_on(async { loader.role_change(StateRole::Follower).await })?;
+
+    let state = loader.get_fsm_state();
+    assert_eq!(state.applied.index, 1);
+    assert_eq!(state.ufs_applied.index, 1);
     Ok(())
 }
 

--- a/curvine-server/tests/journal_test.rs
+++ b/curvine-server/tests/journal_test.rs
@@ -143,6 +143,30 @@ fn leader_promotion_applies_committed_metadata_before_returning() -> CommonResul
 }
 
 #[test]
+fn leader_promotion_advances_applied_index_over_committed_noop() -> CommonResult<()> {
+    Master::init_test_metrics();
+
+    let mut conf = ClusterConf {
+        testing: true,
+        ..Default::default()
+    };
+    conf.change_test_meta_dir(format!("promotion-noop-{}", Utils::rand_str(6)));
+    let journal_system = JournalSystem::from_conf(&conf)?;
+    let loader = journal_system.journal_loader();
+
+    journal_system.append_committed_entry_for_test(Entry {
+        term: 1,
+        index: 1,
+        ..Default::default()
+    })?;
+
+    AsyncRuntime::single().block_on(async { loader.role_change(StateRole::Leader).await })?;
+
+    assert_eq!(loader.get_fsm_state().applied.index, 1);
+    Ok(())
+}
+
+#[test]
 fn follower_replay_rejects_duplicate_allocated_inode_id() -> CommonResult<()> {
     Master::init_test_metrics();
 

--- a/curvine-server/tests/journal_test.rs
+++ b/curvine-server/tests/journal_test.rs
@@ -146,23 +146,56 @@ fn leader_promotion_applies_committed_metadata_before_returning() -> CommonResul
 fn leader_promotion_advances_applied_index_over_committed_noop() -> CommonResult<()> {
     Master::init_test_metrics();
 
+    let mut source_conf = ClusterConf {
+        testing: true,
+        ..Default::default()
+    };
+    source_conf.change_test_meta_dir(format!("promotion-noop-source-{}", Utils::rand_str(6)));
+    let source_fs = JournalSystem::fs_only_for_test(&source_conf)?;
+    source_fs.mkdir("/before-noop", false)?;
+    let metadata_entry = source_fs
+        .fs_dir
+        .read()
+        .take_entries()
+        .into_iter()
+        .next()
+        .expect("mkdir must emit a journal entry");
+    let expected_op_id = metadata_entry.op_id();
+    let expected_rpc_id = metadata_entry.rpc_id();
+
     let mut conf = ClusterConf {
         testing: true,
         ..Default::default()
     };
-    conf.change_test_meta_dir(format!("promotion-noop-{}", Utils::rand_str(6)));
+    conf.change_test_meta_dir(format!("promotion-noop-target-{}", Utils::rand_str(6)));
     let journal_system = JournalSystem::from_conf(&conf)?;
     let loader = journal_system.journal_loader();
 
+    let mut batch = JournalBatch::new(1);
+    batch.push(metadata_entry);
     journal_system.append_committed_entry_for_test(Entry {
         term: 1,
         index: 1,
+        data: SerdeUtils::serialize(&batch)?,
+        ..Default::default()
+    })?;
+    journal_system.append_committed_entry_for_test(Entry {
+        term: 1,
+        index: 2,
         ..Default::default()
     })?;
 
     AsyncRuntime::single().block_on(async { loader.role_change(StateRole::Leader).await })?;
+    // Queue a role change behind the leader UFS replay scan and wait for it as a barrier.
+    AsyncRuntime::single().block_on(async { loader.role_change(StateRole::Follower).await })?;
 
-    assert_eq!(loader.get_fsm_state().applied.index, 1);
+    let state = loader.get_fsm_state();
+    assert_eq!(state.applied.index, 2);
+    assert_eq!(state.applied.op_id, expected_op_id);
+    assert_eq!(state.applied.rpc_id, expected_rpc_id);
+    assert_eq!(state.ufs_applied.index, 2);
+    assert_eq!(state.ufs_applied.op_id, expected_op_id);
+    assert_eq!(state.ufs_applied.rpc_id, expected_rpc_id);
     Ok(())
 }
 


### PR DESCRIPTION
# Summary

Prevent a Master from stopping during leader promotion when the committed Raft log contains entries without metadata mutations, including empty leader no-ops and Raft configuration changes.

Raft appends an empty no-op entry whenever a node becomes leader. The metadata apply path correctly skipped the entry because it contains no namespace mutation, but it also left `fsm_state.applied` unchanged. The leader-promotion fence introduced by #1557 requires the metadata applied index to reach the committed Raft index before publishing leadership. On a fresh single-node cluster, the first no-op can be committed at index 1 while metadata remains applied at index 0, so promotion fails and the Raft node exits.

Non-data entries now advance the metadata apply high-water mark without attempting to deserialize or execute a journal batch. They are also dispatched through the normal committed-entry path, so the application state remains current when a no-op commits after the initial promotion scan. Leader promotion can therefore distinguish "no metadata mutation" from "not applied" and complete safely.

# Minimal Reproducer

Start a fresh single-node Master with an empty journal and wait for its first election. A single-node quorum can commit the leader no-op immediately:

```text
initial state: committed=0, metadata_applied=0
first election: append and commit empty no-op at index=1
```

Before the fix, committed-entry processing skipped the empty entry, and the promotion fence later observed:

```text
metadata catch-up stopped before committed raft index: applied=0, commit=1
raft node stop: metadata catch-up stopped before committed raft index: applied=0, commit=1
```

The Raft task then advanced its role state to `Exit`. `MasterServer::start()` could not observe a Leader or Follower state and returned an error after the role listener closed, causing the Master process to exit.

The same condition can be reproduced directly by appending an empty committed entry to a fresh `JournalSystem` and invoking `role_change(StateRole::Leader)`. Before the fix, role change returns the metadata catch-up error; after the fix, it succeeds with `fsm_state.applied.index == 1`.

# Root Cause

Leader promotion was fenced on the committed Raft index:

```text
Raft commits leader no-op at index 1
  -> apply_committed_entries() skips empty data
  -> metadata applied index remains 0
  -> role_change(Leader)
  -> catch_up_committed_metadata()
  -> scan sees the no-op but apply0() returns without updating applied
  -> metadata_applied(0) < committed(1)
  -> promotion fails and the Raft node exits
```

An empty Raft entry is a no-op only at the application-data layer. It still occupies a real committed log index and must advance the application state machine's applied high-water mark. Treating it as completely invisible breaks the invariant checked by the leader-promotion fence.

Raft configuration entries have the same application-layer property: their protobuf payload is consumed by Raft rather than the metadata journal. Promotion replay must advance their applied index without passing that payload to `JournalBatch::deserialize_compat`.

The old early return also happened before the stale-entry check. Updating the applied index unconditionally at that point would risk moving the high-water mark backwards when replay encounters an already-applied empty entry.

# Changes

- Check the current role-specific applied index before handling an empty entry, so stale no-op entries remain safely ignored.
- Dispatch empty normal entries and committed configuration entries to `AppStorage` even when no client response is required.
- Deserialize journal batches only for non-empty `EntryNormal` entries; advance `fsm_state.applied` for no-op and configuration entries without changing namespace metadata.
- Advance both metadata and UFS applied high-water marks when an empty entry is replayed through the leader path, preserving the existing `set_applied` semantics.
- Add a regression test that commits an empty entry, promotes the node to Leader, and verifies that promotion succeeds with the applied index advanced to the committed index.
- Keep the existing committed-metadata promotion test to verify that non-empty journal replay behavior remains unchanged.

# Deployment Note

This change does not add or modify configuration. Existing journal data remains compatible.

The fix changes only how committed empty Raft entries update in-memory and persisted FSM progress during replay. Empty entries still perform no namespace or UFS mutation. Masters affected by the first-election failure need to be rebuilt and restarted with the fixed version; no journal cleanup or metadata migration is required.

The behavior applies to both fresh elections and later leader promotions where the local committed range contains Raft no-op entries that are newer than the metadata applied high-water mark.

# Verification

- `cargo test -p curvine-server --test journal_test leader_promotion` passes: `3 passed`.
- `leader_promotion_advances_applied_index_over_committed_noop` verifies that an empty committed entry advances `fsm_state.applied` and no longer blocks leader promotion.
- `leader_promotion_advances_over_committed_configuration_entry` verifies that Raft configuration entries advance both promotion high-water marks without journal deserialization.
- `committed_leader_noop_advances_app_storage_applied_index` verifies that a no-op committed through the normal Raft path reaches application storage.
- `leader_promotion_applies_committed_metadata_before_returning` continues to verify ordered replay of non-empty committed metadata before leadership is published.
- `cargo test -p curvine-raft` passes.
- The complete `journal_test` suite passes: `9 passed`.
- `make format` passes, including workspace release checks.
- `git diff --check` passes.
