### PR TITLE
feat(proto): extend GetFilesystemInfo handshake with version fields (#1527)

### DIFF
--- a/crates/common/curvine-model/src/proto_utils.rs
+++ b/crates/common/curvine-model/src/proto_utils.rs
@@ -16,6 +16,7 @@ use crate::proto::*;
 use crate::state::*;
 use crate::worker_info::TransferWorkerCapabilities;
 use curvine_core_error::{try_err, CommonResult};
+use curvine_sys::version::ComponentVersion;
 use prost::bytes::BytesMut;
 use prost::Message;
 use std::fmt::Debug;
@@ -382,6 +383,34 @@ impl ProtoUtils {
             blacklist_workers: Self::worker_info_from_pb(src.blacklist_workers),
             decommission_workers: Self::worker_info_from_pb(src.decommission_workers),
             lost_workers: Self::worker_info_from_pb(src.lost_workers),
+        }
+    }
+
+    /// Convert a structured component version into its wire representation for
+    /// handshake metadata (component_info / compatibility payloads).
+    pub fn component_version_to_pb(src: &ComponentVersion) -> ComponentInfoProto {
+        ComponentInfoProto {
+            component: Some(src.component.clone()),
+            release_version: Some(src.release_version.clone()),
+            git_commit: Some(src.git_commit.clone()),
+            git_tag: Some(src.git_tag.clone()),
+            git_branch: Some(src.git_branch.clone()),
+            protocol_version: Some(src.protocol_version),
+            min_protocol_version: Some(src.min_protocol_version),
+            capabilities: src.capabilities.clone(),
+        }
+    }
+
+    /// Build the default compatibility contract a master advertises during the
+    /// GetFilesystemInfo handshake: the master's own version plus a lenient
+    /// diagnose policy. Legacy peers without the field keep working untouched.
+    pub fn default_master_compatibility_to_pb(
+        src: &ComponentVersion,
+    ) -> ServerCompatibilityInfoProto {
+        ServerCompatibilityInfoProto {
+            server: Self::component_version_to_pb(src),
+            compatibility_mode: CompatibilityModeProto::Diagnose as i32,
+            ..Default::default()
         }
     }
 
@@ -766,8 +795,10 @@ impl ProtoUtils {
 
 #[cfg(test)]
 mod tests {
+    use crate::proto::CompatibilityModeProto;
     use crate::state::{AccessMode, FileStatus, MountInfo, MountOptions, INTERNAL_CTIME_XATTR};
     use crate::utils::ProtoUtils;
+    use curvine_sys::version::ComponentVersion;
     use std::collections::HashMap;
 
     #[test]
@@ -839,5 +870,62 @@ mod tests {
         let round_trip = ProtoUtils::file_status_from_pb(pb);
         assert_eq!(round_trip.ctime(), 1_000);
         assert!(!round_trip.x_attr.contains_key(INTERNAL_CTIME_XATTR));
+    }
+
+    #[test]
+    fn component_version_to_pb_maps_all_fields() {
+        let version = ComponentVersion {
+            component: "master".to_string(),
+            release_version: "0.4.0-alpha".to_string(),
+            git_commit: "359fce7d982a15f09c3b4e0b2e62fee4229609dd".to_string(),
+            git_tag: "v0.4.0-alpha".to_string(),
+            git_branch: "main".to_string(),
+            protocol_version: 1,
+            min_protocol_version: 1,
+            capabilities: vec!["transfer".to_string(), "batch-write".to_string()],
+        };
+
+        let pb = ProtoUtils::component_version_to_pb(&version);
+
+        assert_eq!(pb.component.as_deref(), Some("master"));
+        assert_eq!(pb.release_version.as_deref(), Some("0.4.0-alpha"));
+        assert_eq!(
+            pb.git_commit.as_deref(),
+            Some("359fce7d982a15f09c3b4e0b2e62fee4229609dd")
+        );
+        assert_eq!(pb.git_tag.as_deref(), Some("v0.4.0-alpha"));
+        assert_eq!(pb.git_branch.as_deref(), Some("main"));
+        assert_eq!(pb.protocol_version, Some(1));
+        assert_eq!(pb.min_protocol_version, Some(1));
+        assert_eq!(
+            pb.capabilities,
+            vec!["transfer".to_string(), "batch-write".to_string()]
+        );
+    }
+
+    #[test]
+    fn default_master_compatibility_embeds_server_and_is_diagnose() {
+        let version = ComponentVersion {
+            component: "master".to_string(),
+            release_version: "0.4.0-alpha".to_string(),
+            git_commit: "abc".to_string(),
+            git_tag: String::new(),
+            git_branch: "main".to_string(),
+            protocol_version: 1,
+            min_protocol_version: 1,
+            capabilities: vec![],
+        };
+
+        let pb = ProtoUtils::default_master_compatibility_to_pb(&version);
+
+        assert_eq!(pb.server.component.as_deref(), Some("master"));
+        assert_eq!(pb.server.release_version.as_deref(), Some("0.4.0-alpha"));
+        assert_eq!(
+            pb.compatibility_mode,
+            CompatibilityModeProto::Diagnose as i32
+        );
+        assert!(pb.min_worker_version.is_none());
+        assert!(pb.min_client_version.is_none());
+        assert!(pb.blocked_versions.is_empty());
     }
 }

--- a/crates/common/curvine-proto/proto/master.proto
+++ b/crates/common/curvine-proto/proto/master.proto
@@ -211,7 +211,9 @@ message GetBlockLocationsResponse {
 
 // Request filesystem-wide information (statfs backend).
 message GetFilesystemInfoRequest {
-
+    // Structured version of the requesting client (handshake). Cross-cutting
+    // protocol metadata on the reserved 1000+ range; legacy clients omit it.
+    optional ComponentInfoProto component_info = 1000;
 }
 
 message GetFilesystemInfoResponse {
@@ -231,6 +233,11 @@ message GetFilesystemInfoResponse {
     repeated WorkerInfoProto blacklist_workers = 12;
     repeated WorkerInfoProto decommission_workers = 13;
     repeated WorkerInfoProto lost_workers = 14;
+
+    // Default compatibility contract offered by this master (handshake).
+    // Cross-cutting protocol metadata on the reserved 1000+ range; legacy
+    // masters omit it and clients treat the absence as a legacy peer.
+    optional ServerCompatibilityInfoProto compatibility = 1000;
 }
 
 message SetAttrOptsProto {

--- a/crates/common/curvine-proto/tests/get_filesystem_info_compat_test.rs
+++ b/crates/common/curvine-proto/tests/get_filesystem_info_compat_test.rs
@@ -21,8 +21,10 @@ fn sample_component_info() -> ComponentInfoProto {
 #[derive(Clone, PartialEq, ::prost::Message)]
 struct LegacyGetFilesystemInfoRequest {}
 
-/// A legacy client's view of GetFilesystemInfoResponse: only business fields
-/// 1-14, no compatibility field on the reserved 1000+ range.
+/// A legacy client's view of GetFilesystemInfoResponse: business fields 1-10
+/// (the worker list fields 11-14 are omitted since the compatibility-skip
+/// behavior under test does not depend on them), no compatibility field on the
+/// reserved 1000+ range.
 #[derive(Clone, PartialEq, ::prost::Message)]
 struct LegacyGetFilesystemInfoResponse {
     #[prost(string, required, tag = "1")]

--- a/crates/common/curvine-proto/tests/get_filesystem_info_compat_test.rs
+++ b/crates/common/curvine-proto/tests/get_filesystem_info_compat_test.rs
@@ -1,0 +1,184 @@
+use curvine_proto::{
+    CompatibilityModeProto, ComponentInfoProto, GetFilesystemInfoRequest,
+    GetFilesystemInfoResponse, ServerCompatibilityInfoProto,
+};
+use prost::Message;
+
+fn sample_component_info() -> ComponentInfoProto {
+    ComponentInfoProto {
+        component: Some("master".to_string()),
+        release_version: Some("0.4.0-alpha".to_string()),
+        git_commit: Some("359fce7d982a15f09c3b4e0b2e62fee4229609dd".to_string()),
+        git_tag: Some("v0.4.0-alpha".to_string()),
+        git_branch: Some("main".to_string()),
+        protocol_version: Some(1),
+        min_protocol_version: Some(1),
+        capabilities: vec!["transfer".to_string(), "batch-write".to_string()],
+    }
+}
+
+/// A legacy client's view of GetFilesystemInfoRequest: no component_info field.
+#[derive(Clone, PartialEq, ::prost::Message)]
+struct LegacyGetFilesystemInfoRequest {}
+
+/// A legacy client's view of GetFilesystemInfoResponse: only business fields
+/// 1-14, no compatibility field on the reserved 1000+ range.
+#[derive(Clone, PartialEq, ::prost::Message)]
+struct LegacyGetFilesystemInfoResponse {
+    #[prost(string, required, tag = "1")]
+    active_master: String,
+    #[prost(string, repeated, tag = "2")]
+    journal_nodes: Vec<String>,
+    #[prost(int64, required, tag = "3")]
+    inode_dir_num: i64,
+    #[prost(int64, required, tag = "4")]
+    inode_file_num: i64,
+    #[prost(int64, required, tag = "5")]
+    block_num: i64,
+    #[prost(int64, required, tag = "6")]
+    capacity: i64,
+    #[prost(int64, required, tag = "7")]
+    available: i64,
+    #[prost(int64, required, tag = "8")]
+    fs_used: i64,
+    #[prost(int64, required, tag = "9")]
+    non_fs_used: i64,
+    #[prost(int64, required, tag = "10")]
+    reserved_bytes: i64,
+}
+
+fn sample_response_with_compatibility() -> GetFilesystemInfoResponse {
+    GetFilesystemInfoResponse {
+        active_master: "master-0".to_string(),
+        journal_nodes: vec!["master-0".to_string(), "master-1".to_string()],
+        inode_dir_num: 10,
+        inode_file_num: 20,
+        block_num: 30,
+        capacity: 1000,
+        available: 500,
+        fs_used: 300,
+        non_fs_used: 200,
+        reserved_bytes: 0,
+        live_workers: vec![],
+        blacklist_workers: vec![],
+        decommission_workers: vec![],
+        lost_workers: vec![],
+        compatibility: Some(ServerCompatibilityInfoProto {
+            server: sample_component_info(),
+            min_worker_version: None,
+            min_client_version: None,
+            compatibility_mode: CompatibilityModeProto::Diagnose as i32,
+            blocked_versions: vec![],
+        }),
+    }
+}
+
+#[test]
+fn test_get_filesystem_info_request_component_info_round_trip() {
+    // New client reports its own structured version on the reserved 1000+ range.
+    let req = GetFilesystemInfoRequest {
+        component_info: Some(sample_component_info()),
+    };
+
+    let encoded = req.encode_to_vec();
+    let decoded = GetFilesystemInfoRequest::decode(encoded.as_slice()).unwrap();
+
+    let info = decoded.component_info.unwrap();
+    assert_eq!(info.component, Some("master".to_string()));
+    assert_eq!(info.release_version, Some("0.4.0-alpha".to_string()));
+    assert_eq!(info.protocol_version, Some(1));
+    assert_eq!(info.min_protocol_version, Some(1));
+    assert_eq!(info.capabilities.len(), 2);
+}
+
+#[test]
+fn test_get_filesystem_info_request_legacy_empty_decodes() {
+    // A legacy client sends an empty request (no component_info). The new
+    // master must decode it fine and see no component info.
+    let encoded = LegacyGetFilesystemInfoRequest {}.encode_to_vec();
+    let decoded = GetFilesystemInfoRequest::decode(encoded.as_slice()).unwrap();
+    assert!(decoded.component_info.is_none());
+}
+
+#[test]
+fn test_get_filesystem_info_response_compatibility_round_trip() {
+    // New master -> new client: full handshake round-trips.
+    let rep = sample_response_with_compatibility();
+
+    let encoded = rep.encode_to_vec();
+    let decoded = GetFilesystemInfoResponse::decode(encoded.as_slice()).unwrap();
+
+    assert_eq!(decoded.active_master, "master-0");
+    assert_eq!(decoded.inode_file_num, 20);
+    let compat = decoded.compatibility.unwrap();
+    assert_eq!(compat.server.component, Some("master".to_string()));
+    assert_eq!(
+        compat.compatibility_mode,
+        CompatibilityModeProto::Diagnose as i32
+    );
+    assert!(compat.min_worker_version.is_none());
+    assert!(compat.min_client_version.is_none());
+    assert!(compat.blocked_versions.is_empty());
+}
+
+#[test]
+fn test_legacy_master_response_decodes_without_compatibility() {
+    // Old master + new client: a legacy response with only business fields
+    // (no compatibility) must decode; the client treats absence as legacy.
+    let legacy = LegacyGetFilesystemInfoResponse {
+        active_master: "old-master".to_string(),
+        journal_nodes: vec!["old-master".to_string()],
+        inode_dir_num: 1,
+        inode_file_num: 2,
+        block_num: 3,
+        capacity: 100,
+        available: 50,
+        fs_used: 30,
+        non_fs_used: 20,
+        reserved_bytes: 0,
+    };
+
+    let encoded = legacy.encode_to_vec();
+    let decoded = GetFilesystemInfoResponse::decode(encoded.as_slice()).unwrap();
+
+    assert_eq!(decoded.active_master, "old-master");
+    assert_eq!(decoded.inode_file_num, 2);
+    assert!(decoded.compatibility.is_none());
+}
+
+#[test]
+fn test_new_master_response_decoded_by_legacy_client() {
+    // New master + old client: the legacy client's struct does not know the
+    // compatibility field (1000); it must skip it and keep business fields.
+    let rep = sample_response_with_compatibility();
+    let encoded = rep.encode_to_vec();
+
+    let legacy = LegacyGetFilesystemInfoResponse::decode(encoded.as_slice()).unwrap();
+
+    assert_eq!(legacy.active_master, "master-0");
+    assert_eq!(
+        legacy.journal_nodes,
+        vec!["master-0".to_string(), "master-1".to_string()]
+    );
+    assert_eq!(legacy.inode_dir_num, 10);
+    assert_eq!(legacy.inode_file_num, 20);
+    assert_eq!(legacy.block_num, 30);
+    assert_eq!(legacy.capacity, 1000);
+    assert_eq!(legacy.available, 500);
+    assert_eq!(legacy.fs_used, 300);
+    assert_eq!(legacy.non_fs_used, 200);
+    assert_eq!(legacy.reserved_bytes, 0);
+}
+
+#[test]
+fn test_legacy_client_request_with_new_field_ignored() {
+    // Old master + new client: the new client's request carries component_info
+    // on field 1000; a legacy master (struct without that field) must skip it.
+    let req = GetFilesystemInfoRequest {
+        component_info: Some(sample_component_info()),
+    };
+    let encoded = req.encode_to_vec();
+
+    let legacy = LegacyGetFilesystemInfoRequest::decode(encoded.as_slice()).unwrap();
+    assert_eq!(legacy, LegacyGetFilesystemInfoRequest {});
+}

--- a/curvine-master/src/master/master_handler.rs
+++ b/curvine-master/src/master/master_handler.rs
@@ -49,6 +49,10 @@ pub struct MasterHandler {
     pub(crate) control_rpc_executor: Arc<GroupExecutor>,
     pub(crate) replication_handler: Option<MasterReplicationHandler>,
     pub(crate) actor_rt: Arc<Runtime>,
+    // Master's own version + default compatibility contract, built once at
+    // startup. GetFilesystemInfo backs statfs and is called frequently, so we
+    // reuse this instead of recomputing component_version() on every call.
+    master_compatibility: ServerCompatibilityInfoProto,
 }
 
 impl MasterHandler {
@@ -66,6 +70,10 @@ impl MasterHandler {
         metrics: &'static MasterMetrics,
     ) -> Self {
         metrics.active_connections.inc();
+        // Build the master's compatibility payload once; GetFilesystemInfo can
+        // be hot (statfs) and the underlying version metadata is immutable.
+        let master_version = curvine_sys::version::component_version("master");
+        let master_compatibility = ProtoUtils::default_master_compatibility_to_pb(&master_version);
         Self {
             fs,
             retry_cache,
@@ -77,6 +85,7 @@ impl MasterHandler {
             control_rpc_executor,
             replication_handler: Some(MasterReplicationHandler::new(replication_manager)),
             actor_rt,
+            master_compatibility,
         }
     }
 
@@ -467,20 +476,21 @@ impl MasterHandler {
             Self::process_get_filesystem_info(fs)
         })
         .await?;
-        let rep_header = Self::build_filesystem_info_response(info);
+        let rep_header = Self::build_filesystem_info_response(info, &self.master_compatibility);
         ctx.response(rep_header)
     }
 
     /// Build the GetFilesystemInfo response, attaching the master's own version
     /// and the default (lenient) compatibility contract on the reserved 1000+
     /// field range. Legacy clients that do not know the field simply skip it,
-    /// so this never breaks older peers.
-    fn build_filesystem_info_response(info: FilesystemInfo) -> GetFilesystemInfoResponse {
+    /// so this never breaks older peers. The compatibility payload is built
+    /// once at handler construction and reused across requests.
+    fn build_filesystem_info_response(
+        info: FilesystemInfo,
+        master_compatibility: &ServerCompatibilityInfoProto,
+    ) -> GetFilesystemInfoResponse {
         let mut rep_header = ProtoUtils::filesystem_info_to_pb(info);
-        let master_version = curvine_sys::version::component_version("master");
-        rep_header.compatibility = Some(ProtoUtils::default_master_compatibility_to_pb(
-            &master_version,
-        ));
+        rep_header.compatibility = Some(master_compatibility.clone());
         rep_header
     }
 
@@ -1071,7 +1081,12 @@ mod tests {
             ..Default::default()
         };
 
-        let rep = MasterHandler::build_filesystem_info_response(info);
+        // Derive expectations from component_version("master") so the test stays
+        // stable across BUILD_VERSION overrides and future protocol bumps.
+        let master_version = curvine_sys::version::component_version("master");
+        let master_compatibility = ProtoUtils::default_master_compatibility_to_pb(&master_version);
+
+        let rep = MasterHandler::build_filesystem_info_response(info, &master_compatibility);
 
         assert_eq!(rep.active_master, "master-0");
         assert_eq!(rep.inode_file_num, 5);
@@ -1081,9 +1096,12 @@ mod tests {
         assert_eq!(compat.server.component.as_deref(), Some("master"));
         assert_eq!(
             compat.server.release_version.as_deref(),
-            Some(env!("CARGO_PKG_VERSION"))
+            Some(master_version.release_version.as_str())
         );
-        assert_eq!(compat.server.protocol_version, Some(1));
+        assert_eq!(
+            compat.server.protocol_version,
+            Some(master_version.protocol_version)
+        );
         assert_eq!(
             compat.compatibility_mode,
             CompatibilityModeProto::Diagnose as i32

--- a/curvine-master/src/master/master_handler.rs
+++ b/curvine-master/src/master/master_handler.rs
@@ -467,8 +467,21 @@ impl MasterHandler {
             Self::process_get_filesystem_info(fs)
         })
         .await?;
-        let rep_header = ProtoUtils::filesystem_info_to_pb(info);
+        let rep_header = Self::build_filesystem_info_response(info);
         ctx.response(rep_header)
+    }
+
+    /// Build the GetFilesystemInfo response, attaching the master's own version
+    /// and the default (lenient) compatibility contract on the reserved 1000+
+    /// field range. Legacy clients that do not know the field simply skip it,
+    /// so this never breaks older peers.
+    fn build_filesystem_info_response(info: FilesystemInfo) -> GetFilesystemInfoResponse {
+        let mut rep_header = ProtoUtils::filesystem_info_to_pb(info);
+        let master_version = curvine_sys::version::component_version("master");
+        rep_header.compatibility = Some(ProtoUtils::default_master_compatibility_to_pb(
+            &master_version,
+        ));
+        rep_header
     }
 
     async fn async_get_cv_metadata_snapshot_page(
@@ -1042,5 +1055,39 @@ mod tests {
             .unwrap();
         assert_eq!(worker.software_version, "0.1.0-test");
         assert_eq!(worker.startup_time_ms, 123_456);
+    }
+
+    #[test]
+    fn build_filesystem_info_response_attaches_master_compatibility() {
+        let info = FilesystemInfo {
+            active_master: "master-0".to_string(),
+            inode_dir_num: 3,
+            inode_file_num: 5,
+            block_num: 7,
+            capacity: 1000,
+            available: 500,
+            fs_used: 300,
+            non_fs_used: 200,
+            ..Default::default()
+        };
+
+        let rep = MasterHandler::build_filesystem_info_response(info);
+
+        assert_eq!(rep.active_master, "master-0");
+        assert_eq!(rep.inode_file_num, 5);
+        let compat = rep
+            .compatibility
+            .expect("master must advertise compatibility");
+        assert_eq!(compat.server.component.as_deref(), Some("master"));
+        assert_eq!(
+            compat.server.release_version.as_deref(),
+            Some(env!("CARGO_PKG_VERSION"))
+        );
+        assert_eq!(compat.server.protocol_version, Some(1));
+        assert_eq!(
+            compat.compatibility_mode,
+            CompatibilityModeProto::Diagnose as i32
+        );
+        assert!(compat.blocked_versions.is_empty());
     }
 }


### PR DESCRIPTION
# Summary

Extends the client-master handshake (`GetFilesystemInfo`, formerly `GetMasterInfo`) with optional version/compatibility metadata on the reserved 1000+ field range (T5 of the version management design #1527). A new client can report its structured version in the request, and the master advertises its own version plus a default, lenient compatibility contract in the response — while legacy clients/masters without the new fields continue to work untouched.

# Issue Describe / Design

Related to #1527 (sub-task T5).

Design (from `version-management-design.md` / GitHub issue #1527):

- `GetFilesystemInfoRequest` gains `optional ComponentInfoProto component_info = 1000` so a new client can report its own structured version (component, release version, git provenance, protocol versions, capabilities) — the client-side reporting is consumed by the T6 handshake.
- `GetFilesystemInfoResponse` gains `optional ServerCompatibilityInfoProto compatibility = 1000`; the master fills it with its own `ComponentVersion` (embedded as `server`) and a default `DIAGNOSE` compatibility mode, so mixed-version clusters are never rejected by default.
- Both fields are purely additive on the reserved high field range: no existing field number, message or RPC frame changes, so old components ignore the unknown fields and keep working (verified by wire-level legacy-compat tests in both directions).

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `crates/common/curvine-proto/proto/master.proto` | Add optional `component_info = 1000` to `GetFilesystemInfoRequest`, optional `compatibility = 1000` to `GetFilesystemInfoResponse` | None (new optional fields only) |
| `crates/common/curvine-proto/tests/get_filesystem_info_compat_test.rs` | New protobuf round-trip + legacy wire-compat tests (new master + old client, old master + new client, both directions) | None (test-only) |
| `crates/common/curvine-model/src/proto_utils.rs` | Add `component_version_to_pb` and `default_master_compatibility_to_pb` conversion helpers + unit tests | None (new helpers only) |
| `curvine-master/src/master/master_handler.rs` | `async_get_filesystem_info` attaches the master's version + default compatibility contract to the response | None (new optional response field) |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-proto` | PASS | 22 tests (6 new compat tests + 16 existing) |
| `cargo test -p curvine-model` | PASS | 25 tests (2 new conversion tests) |
| `cargo test -p curvine-master --lib` | PASS | 94 tests (1 new handler test) |
| `cargo test -p curvine-server --test master_fs_test` | PASS | 50 tests |
| `cargo check --workspace` | PASS | |
| `make format` (clippy `--deny warnings` + `cargo fmt`) | PASS | |

# Dependencies

- Related PRs: #1580 (T4 common proto messages — dependency, merged)
- Related issues: #1527
- Blocks / blocked by: blocked by #1580 (merged); unblocks T6/T8
