### PR TITLE
feat(client): add master handshake with legacy fallback (#1527)

### DIFF
--- a/crates/client/curvine-client-core/src/file/curvine_filesystem.rs
+++ b/crates/client/curvine-client-core/src/file/curvine_filesystem.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::block::BatchBlockWriter;
-use crate::file::{FsClient, FsContext, FsReader, FsWriter, FsWriterBase};
+use crate::file::{FsClient, FsContext, FsReader, FsWriter, FsWriterBase, MasterHandshake};
 use crate::ClientMetrics;
 use async_stream::stream;
 use bytes::BytesMut;
@@ -288,6 +288,19 @@ impl CurvineFileSystem {
 
     pub async fn get_filesystem_info(&self) -> FsResult<FilesystemInfo> {
         self.fs_client.get_filesystem_info().await
+    }
+
+    /// Client-master version handshake: report this client's `component_info`
+    /// and cache the master's advertised version / protocol / capabilities.
+    pub async fn handshake(&self) -> FsResult<MasterHandshake> {
+        self.fs_client.handshake().await
+    }
+
+    /// Cached master handshake (version / protocol / capabilities). Before the
+    /// first handshake and against legacy masters this reports a legacy peer,
+    /// which is never rejected.
+    pub fn master_handshake(&self) -> MasterHandshake {
+        self.fs_client.master_handshake()
     }
 
     pub async fn get_filesystem_info_bytes(&self) -> FsResult<BytesMut> {

--- a/crates/client/curvine-client-core/src/file/fs_client.rs
+++ b/crates/client/curvine-client-core/src/file/fs_client.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::file::FsContext;
+use crate::file::{FsContext, MasterHandshake};
 use bytes::BytesMut;
 use curvine_config::{ClientConf, ClusterConf, UfsConf, UfsConfBuilder};
 use curvine_core_error::err_box;
@@ -532,10 +532,40 @@ impl FsClient {
     }
 
     pub async fn get_filesystem_info(&self) -> FsResult<FilesystemInfo> {
-        let header = GetFilesystemInfoRequest::default();
+        let header = GetFilesystemInfoRequest {
+            // Client-master handshake: report this client's structured version
+            // on the reserved 1000+ range. Legacy masters skip the unknown
+            // field and legacy clients omit it entirely.
+            component_info: Some(Self::handshake_request_component_info()),
+        };
         let rep: GetFilesystemInfoResponse = self.rpc(RpcCode::GetFilesystemInfo, header).await?;
-        let res = ProtoUtils::filesystem_info_from_pb(rep);
-        Ok(res)
+        // Cache the master's advertised version / protocol / capabilities; a
+        // master without a compatibility contract is recorded as legacy and
+        // never rejected.
+        self.context
+            .set_master_handshake(MasterHandshake::from_response(&rep));
+        Ok(ProtoUtils::filesystem_info_from_pb(rep))
+    }
+
+    /// Client-master version handshake: report this client's `component_info`
+    /// and cache the master's advertised version / protocol / capabilities.
+    /// Returns the cached handshake; a master without a compatibility
+    /// contract is reported as a legacy peer and is never rejected.
+    pub async fn handshake(&self) -> FsResult<MasterHandshake> {
+        let _ = self.get_filesystem_info().await?;
+        Ok(self.master_handshake())
+    }
+
+    /// Cached master handshake (version / protocol / capabilities). Before the
+    /// first handshake and against legacy masters this reports a legacy peer,
+    /// which is never rejected.
+    pub fn master_handshake(&self) -> MasterHandshake {
+        self.context.master_handshake()
+    }
+
+    /// Build the client's own `component_info` payload for the handshake.
+    fn handshake_request_component_info() -> ComponentInfoProto {
+        ProtoUtils::component_version_to_pb(&curvine_sys::version::component_version("client"))
     }
 
     pub async fn get_filesystem_info_bytes(&self) -> FsResult<BytesMut> {
@@ -750,5 +780,45 @@ impl FsClient {
 
     pub fn client_addr(&self) -> &ClientAddress {
         &self.context.client_addr
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use curvine_proto::GetFilesystemInfoRequest;
+
+    #[test]
+    fn handshake_request_carries_client_component_info() {
+        // A new client reports its own structured version during the
+        // handshake so the master can diagnose mixed-version clusters.
+        let info = FsClient::handshake_request_component_info();
+        let req = GetFilesystemInfoRequest {
+            component_info: Some(info),
+        };
+
+        let encoded = req.encode_to_vec();
+        let decoded = GetFilesystemInfoRequest::decode(encoded.as_slice()).unwrap();
+        let decoded_info = decoded.component_info.unwrap();
+        assert_eq!(decoded_info.component.as_deref(), Some("client"));
+        assert_eq!(decoded_info.protocol_version, Some(1));
+        assert_eq!(decoded_info.min_protocol_version, Some(1));
+    }
+
+    #[test]
+    fn handshake_request_is_backward_compatible() {
+        // The request only adds an optional field on the reserved 1000+ range:
+        // a legacy master's view of the message (no component_info) must
+        // decode the payload and ignore the unknown field.
+        #[derive(Clone, PartialEq, ::prost::Message)]
+        struct LegacyGetFilesystemInfoRequest {}
+
+        let req = GetFilesystemInfoRequest {
+            component_info: Some(FsClient::handshake_request_component_info()),
+        };
+        let encoded = req.encode_to_vec();
+
+        let legacy = LegacyGetFilesystemInfoRequest::decode(encoded.as_slice()).unwrap();
+        assert_eq!(legacy, LegacyGetFilesystemInfoRequest {});
     }
 }

--- a/crates/client/curvine-client-core/src/file/fs_client.rs
+++ b/crates/client/curvine-client-core/src/file/fs_client.rs
@@ -25,6 +25,7 @@ use curvine_proto::*;
 use curvine_rpc::client::ClusterConnector;
 use curvine_rpc::message::MessageBuilder;
 use curvine_runtime::runtime::RpcRuntime;
+use log::warn;
 use prost::Message as PMessage;
 use std::collections::LinkedList;
 use std::sync::Arc;
@@ -39,6 +40,30 @@ struct CompleteFileOptions {
     only_flush: bool,
     set_attr_opts: Option<SetAttrOpts>,
     return_file_blocks: bool,
+}
+
+/// RAII guard for a claimed one-time handshake report. Resets the claim when
+/// dropped without being committed, so a cancelled or failed in-flight
+/// `GetFilesystemInfo` future never permanently suppresses `component_info`
+/// reporting.
+struct HandshakeReportGuard<'a> {
+    context: &'a FsContext,
+    committed: bool,
+}
+
+impl HandshakeReportGuard<'_> {
+    /// Mark the report as delivered; the one-time claim stays set.
+    fn commit(&mut self) {
+        self.committed = true;
+    }
+}
+
+impl Drop for HandshakeReportGuard<'_> {
+    fn drop(&mut self) {
+        if !self.committed {
+            self.context.reset_handshake_report();
+        }
+    }
 }
 
 impl FsClient {
@@ -538,19 +563,12 @@ impl FsClient {
         // later calls omit the payload; the response is still parsed and
         // cached on every call. Legacy masters skip the unknown field and
         // legacy clients omit it entirely.
-        let (header, report_component) = self.get_filesystem_info_request();
+        let (header, mut guard) = self.get_filesystem_info_request();
         let rep: GetFilesystemInfoResponse =
-            match self.rpc(RpcCode::GetFilesystemInfo, header).await {
-                Ok(rep) => rep,
-                Err(e) => {
-                    // The reporting request never reached the master: allow a
-                    // later retry to report the handshake.
-                    if report_component {
-                        self.context.reset_handshake_report();
-                    }
-                    return Err(e);
-                }
-            };
+            self.raw_rpc(RpcCode::GetFilesystemInfo, header).await?;
+        // The report reached the master: keep the one-time claim. On error or
+        // cancellation the guard's drop resets it so a later call can report.
+        guard.commit();
         // Cache the master's advertised version / protocol / capabilities; a
         // master without a compatibility contract is recorded as legacy and
         // never rejected.
@@ -565,6 +583,9 @@ impl FsClient {
     /// contract is reported as a legacy peer and is never rejected.
     pub async fn handshake(&self) -> FsResult<MasterHandshake> {
         let _ = self.get_filesystem_info().await?;
+        // Mark the one-time lazy handshake as done so the first ordinary RPC
+        // does not re-run it (FUSE mount performs this eagerly at startup).
+        self.context.mark_handshake_started();
         Ok(self.master_handshake())
     }
 
@@ -584,10 +605,10 @@ impl FsClient {
     /// `component_info` only on the first call per session (the handshake).
     /// Both the typed and the raw-bytes RPC paths share this so every
     /// GetFilesystemInfo caller reports the client version exactly once;
-    /// frequent statfs queries stay lean. Returns the request plus whether
-    /// `component_info` was attached, so the caller can reset the flag when
-    /// the request fails before reaching the master.
-    fn get_filesystem_info_request(&self) -> (GetFilesystemInfoRequest, bool) {
+    /// frequent statfs queries stay lean. The returned guard holds the claim
+    /// and resets it on drop unless committed, so a cancelled or failed
+    /// in-flight request never permanently suppresses reporting.
+    fn get_filesystem_info_request(&self) -> (GetFilesystemInfoRequest, HandshakeReportGuard<'_>) {
         let report_component = self.context.claim_handshake_report();
         let header = if report_component {
             GetFilesystemInfoRequest {
@@ -596,20 +617,28 @@ impl FsClient {
         } else {
             GetFilesystemInfoRequest::default()
         };
-        (header, report_component)
+        let guard = HandshakeReportGuard {
+            context: &self.context,
+            committed: !report_component,
+        };
+        (header, guard)
     }
 
     pub async fn get_filesystem_info_bytes(&self) -> FsResult<BytesMut> {
-        let (header, report_component) = self.get_filesystem_info_request();
-        match self.rpc_bytes(RpcCode::GetFilesystemInfo, header).await {
-            Ok(bytes) => Ok(bytes),
-            Err(e) => {
-                if report_component {
-                    self.context.reset_handshake_report();
-                }
-                Err(e)
-            }
+        let (header, mut guard) = self.get_filesystem_info_request();
+        let bytes = self
+            .raw_rpc_bytes(RpcCode::GetFilesystemInfo, header)
+            .await?;
+        guard.commit();
+        // Decode the response so bytes-only callers (e.g. SDK paths) also
+        // cache the master's compatibility contract instead of staying at the
+        // default legacy handshake. Best-effort: the raw bytes are returned
+        // regardless.
+        if let Ok(rep) = GetFilesystemInfoResponse::decode(bytes.as_ref()) {
+            self.context
+                .set_master_handshake(MasterHandshake::from_response(&rep));
         }
+        Ok(bytes)
     }
 
     pub async fn mount(
@@ -794,18 +823,66 @@ impl FsClient {
         T: PMessage + Default,
         R: PMessage + Default,
     {
+        // Best-effort one-time handshake before the first ordinary master RPC
+        // so every client path (CLI, SDK, data-transfer, direct
+        // CurvineFileSystem/UnifiedFileSystem users) reports component_info
+        // and caches the master's compatibility contract, not only FUSE
+        // mount. GetFilesystemInfo is the handshake itself and must not
+        // recurse.
+        if code != RpcCode::GetFilesystemInfo {
+            self.ensure_handshake().await;
+        }
+        self.raw_rpc(code, header).await
+    }
+
+    pub async fn rpc_bytes(&self, code: RpcCode, header: impl PMessage) -> FsResult<BytesMut> {
+        if code != RpcCode::GetFilesystemInfo {
+            self.ensure_handshake().await;
+        }
+        self.raw_rpc_bytes(code, header).await
+    }
+
+    /// Raw typed master RPC without the lazy handshake guard; the handshake
+    /// itself (GetFilesystemInfo) uses this to avoid recursing into
+    /// [`Self::ensure_handshake`].
+    async fn raw_rpc<T, R>(&self, code: RpcCode, header: T) -> FsResult<R>
+    where
+        T: PMessage + Default,
+        R: PMessage + Default,
+    {
         self.connector
             .proto_rpc::<T, R, FsError>(code, header)
             .await
     }
 
-    pub async fn rpc_bytes(&self, code: RpcCode, header: impl PMessage) -> FsResult<BytesMut> {
+    /// Raw bytes master RPC without the lazy handshake guard; see
+    /// [`Self::raw_rpc`].
+    async fn raw_rpc_bytes(&self, code: RpcCode, header: impl PMessage) -> FsResult<BytesMut> {
         let msg = MessageBuilder::new_rpc(code).proto_header(header).build();
 
         let msg = self.connector.rpc::<FsError>(msg).await?;
         match msg.header {
             None => Ok(BytesMut::new()),
             Some(v) => Ok(v),
+        }
+    }
+
+    /// Run the client-master handshake once per session before the first
+    /// ordinary master RPC, best-effort: a failure only logs a warning and
+    /// the caller's RPC proceeds with legacy assumptions (nothing is ever
+    /// rejected by default). Skipped when a GetFilesystemInfo request already
+    /// went out (the typed/bytes paths populate the same cache).
+    async fn ensure_handshake(&self) {
+        if self.context.handshake_started() || self.context.handshake_reported() {
+            return;
+        }
+        let _guard = self.context.handshake_lock().lock().await;
+        if self.context.handshake_started() || self.context.handshake_reported() {
+            return;
+        }
+        self.context.mark_handshake_started();
+        if let Err(e) = self.handshake().await {
+            warn!("client-master handshake failed: {e}; continuing with legacy assumptions");
         }
     }
 

--- a/crates/client/curvine-client-core/src/file/fs_client.rs
+++ b/crates/client/curvine-client-core/src/file/fs_client.rs
@@ -532,13 +532,32 @@ impl FsClient {
     }
 
     pub async fn get_filesystem_info(&self) -> FsResult<FilesystemInfo> {
-        let header = GetFilesystemInfoRequest {
-            // Client-master handshake: report this client's structured version
-            // on the reserved 1000+ range. Legacy masters skip the unknown
-            // field and legacy clients omit it entirely.
-            component_info: Some(Self::handshake_request_component_info()),
+        // Attach this client's component_info only on the first
+        // GetFilesystemInfo per session (the handshake). GetFilesystemInfo
+        // backs FUSE statfs and may be called frequently by the kernel, so
+        // later calls omit the payload; the response is still parsed and
+        // cached on every call. Legacy masters skip the unknown field and
+        // legacy clients omit it entirely.
+        let report_component = self.context.claim_handshake_report();
+        let header = if report_component {
+            GetFilesystemInfoRequest {
+                component_info: Some(Self::handshake_request_component_info()),
+            }
+        } else {
+            GetFilesystemInfoRequest::default()
         };
-        let rep: GetFilesystemInfoResponse = self.rpc(RpcCode::GetFilesystemInfo, header).await?;
+        let rep: GetFilesystemInfoResponse =
+            match self.rpc(RpcCode::GetFilesystemInfo, header).await {
+                Ok(rep) => rep,
+                Err(e) => {
+                    // The reporting request never reached the master: allow a
+                    // later retry to report the handshake.
+                    if report_component {
+                        self.context.reset_handshake_report();
+                    }
+                    return Err(e);
+                }
+            };
         // Cache the master's advertised version / protocol / capabilities; a
         // master without a compatibility contract is recorded as legacy and
         // never rejected.

--- a/crates/client/curvine-client-core/src/file/fs_client.rs
+++ b/crates/client/curvine-client-core/src/file/fs_client.rs
@@ -538,14 +538,7 @@ impl FsClient {
         // later calls omit the payload; the response is still parsed and
         // cached on every call. Legacy masters skip the unknown field and
         // legacy clients omit it entirely.
-        let report_component = self.context.claim_handshake_report();
-        let header = if report_component {
-            GetFilesystemInfoRequest {
-                component_info: Some(Self::handshake_request_component_info()),
-            }
-        } else {
-            GetFilesystemInfoRequest::default()
-        };
+        let (header, report_component) = self.get_filesystem_info_request();
         let rep: GetFilesystemInfoResponse =
             match self.rpc(RpcCode::GetFilesystemInfo, header).await {
                 Ok(rep) => rep,
@@ -587,9 +580,36 @@ impl FsClient {
         ProtoUtils::component_version_to_pb(&curvine_sys::version::component_version("client"))
     }
 
+    /// Build a `GetFilesystemInfo` request, attaching this client's
+    /// `component_info` only on the first call per session (the handshake).
+    /// Both the typed and the raw-bytes RPC paths share this so every
+    /// GetFilesystemInfo caller reports the client version exactly once;
+    /// frequent statfs queries stay lean. Returns the request plus whether
+    /// `component_info` was attached, so the caller can reset the flag when
+    /// the request fails before reaching the master.
+    fn get_filesystem_info_request(&self) -> (GetFilesystemInfoRequest, bool) {
+        let report_component = self.context.claim_handshake_report();
+        let header = if report_component {
+            GetFilesystemInfoRequest {
+                component_info: Some(Self::handshake_request_component_info()),
+            }
+        } else {
+            GetFilesystemInfoRequest::default()
+        };
+        (header, report_component)
+    }
+
     pub async fn get_filesystem_info_bytes(&self) -> FsResult<BytesMut> {
-        let header = GetFilesystemInfoRequest::default();
-        self.rpc_bytes(RpcCode::GetFilesystemInfo, header).await
+        let (header, report_component) = self.get_filesystem_info_request();
+        match self.rpc_bytes(RpcCode::GetFilesystemInfo, header).await {
+            Ok(bytes) => Ok(bytes),
+            Err(e) => {
+                if report_component {
+                    self.context.reset_handshake_report();
+                }
+                Err(e)
+            }
+        }
     }
 
     pub async fn mount(

--- a/crates/client/curvine-client-core/src/file/fs_context.rs
+++ b/crates/client/curvine-client-core/src/file/fs_context.rs
@@ -63,6 +63,13 @@ pub struct FsContext {
     // keeps GetFilesystemInfo (which backs FUSE statfs and may be called
     // frequently) from carrying the payload on every request.
     handshake_reported: AtomicBool,
+    // Guards the one-time lazy handshake: the first ordinary master RPC of a
+    // session runs the client-master handshake first (best-effort), so every
+    // client path (CLI, SDK, data-transfer, FUSE, direct
+    // CurvineFileSystem/UnifiedFileSystem users) reports component_info and
+    // caches the master's compatibility contract — not only FUSE mount.
+    handshake_lock: tokio::sync::Mutex<()>,
+    handshake_started: AtomicBool,
 }
 
 impl FsContext {
@@ -118,6 +125,8 @@ impl FsContext {
             block_pool,
             master_handshake: FastRwLock::new(MasterHandshake::default()),
             handshake_reported: AtomicBool::new(false),
+            handshake_lock: tokio::sync::Mutex::new(()),
+            handshake_started: AtomicBool::new(false),
         };
         Ok(context)
     }
@@ -154,6 +163,30 @@ impl FsContext {
     /// master).
     pub(crate) fn reset_handshake_report(&self) {
         self.handshake_reported.store(false, Ordering::Relaxed);
+    }
+
+    /// Whether a `GetFilesystemInfo` request has already gone out this session
+    /// (component_info reported once). Lets the lazy handshake skip re-running
+    /// when the typed/bytes GetFilesystemInfo path already populated the
+    /// cache.
+    pub(crate) fn handshake_reported(&self) -> bool {
+        self.handshake_reported.load(Ordering::Relaxed)
+    }
+
+    /// Lock guarding the one-time lazy handshake execution.
+    pub(crate) fn handshake_lock(&self) -> &tokio::sync::Mutex<()> {
+        &self.handshake_lock
+    }
+
+    /// Whether the one-time lazy handshake has already been attempted.
+    pub(crate) fn handshake_started(&self) -> bool {
+        self.handshake_started.load(Ordering::Relaxed)
+    }
+
+    /// Mark the one-time lazy handshake as attempted (used by the explicit
+    /// `handshake()` so the first ordinary RPC does not re-run it).
+    pub(crate) fn mark_handshake_started(&self) {
+        self.handshake_started.store(true, Ordering::Relaxed);
     }
 
     pub fn conf(&self) -> &ClusterConf {

--- a/crates/client/curvine-client-core/src/file/fs_context.rs
+++ b/crates/client/curvine-client-core/src/file/fs_context.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::block::{BlockClient, BlockClientPool};
-use crate::file::FsClient;
+use crate::file::{FsClient, MasterHandshake};
 use crate::ClientMetrics;
 use curvine_config::ClusterConf;
 use curvine_error::FsResult;
@@ -26,6 +26,7 @@ use curvine_proto::ClientAddressProto;
 use curvine_rpc::client::{ClientConf, ClusterConnector};
 use curvine_runtime::common::{TimeSpent, Utils};
 use curvine_runtime::runtime::{RpcRuntime, Runtime};
+use curvine_runtime::sync::FastRwLock;
 use fxhash::FxHasher;
 use log::warn;
 use moka::policy::EvictionPolicy;
@@ -49,6 +50,11 @@ pub struct FsContext {
     pub(crate) os_cache: CacheManager,
     pub(crate) failed_workers: Cache<u32, WorkerAddress, BuildHasherDefault<FxHasher>>,
     pub(crate) block_pool: Arc<BlockClientPool>,
+    // Client-master handshake result: the master's advertised version /
+    // protocol / capabilities (or a legacy marker when the master does not
+    // advertise a compatibility contract). Populated by the first
+    // GetFilesystemInfo call and shared by every FsClient clone.
+    master_handshake: Arc<FastRwLock<MasterHandshake>>,
 }
 
 impl FsContext {
@@ -102,12 +108,26 @@ impl FsContext {
             os_cache,
             failed_workers: exclude_workers,
             block_pool,
+            master_handshake: Arc::new(FastRwLock::new(MasterHandshake::default())),
         };
         Ok(context)
     }
 
     pub fn clone_client_name(&self) -> String {
         self.client_addr.client_name.clone()
+    }
+
+    /// Cache the master's advertised version / protocol / capabilities from
+    /// the client-master handshake. A master without a compatibility contract
+    /// is recorded as legacy and never rejected.
+    pub fn set_master_handshake(&self, handshake: MasterHandshake) {
+        *self.master_handshake.write() = handshake;
+    }
+
+    /// Cached master handshake. Defaults to a legacy peer before the first
+    /// successful handshake so no component is rejected by default.
+    pub fn master_handshake(&self) -> MasterHandshake {
+        self.master_handshake.read().clone()
     }
 
     pub fn conf(&self) -> &ClusterConf {

--- a/crates/client/curvine-client-core/src/file/fs_context.rs
+++ b/crates/client/curvine-client-core/src/file/fs_context.rs
@@ -34,6 +34,7 @@ use moka::sync::{Cache, CacheBuilder};
 use once_cell::sync::OnceCell;
 use std::future::Future;
 use std::hash::BuildHasherDefault;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Weak};
 use std::time::Duration;
 
@@ -55,6 +56,11 @@ pub struct FsContext {
     // advertise a compatibility contract). Populated by the first
     // GetFilesystemInfo call and shared by every FsClient clone.
     master_handshake: Arc<FastRwLock<MasterHandshake>>,
+    // Whether this session has already reported its component_info to the
+    // master. Handshake metadata is sent once per mount/session; the flag
+    // keeps GetFilesystemInfo (which backs FUSE statfs and may be called
+    // frequently) from carrying the payload on every request.
+    handshake_reported: Arc<AtomicBool>,
 }
 
 impl FsContext {
@@ -109,6 +115,7 @@ impl FsContext {
             failed_workers: exclude_workers,
             block_pool,
             master_handshake: Arc::new(FastRwLock::new(MasterHandshake::default())),
+            handshake_reported: Arc::new(AtomicBool::new(false)),
         };
         Ok(context)
     }
@@ -128,6 +135,23 @@ impl FsContext {
     /// successful handshake so no component is rejected by default.
     pub fn master_handshake(&self) -> MasterHandshake {
         self.master_handshake.read().clone()
+    }
+
+    /// Atomically claim the one-time right to attach this client's
+    /// `component_info` to a `GetFilesystemInfo` request. Returns `true` only
+    /// for the first caller per session, so handshake metadata is reported
+    /// once and frequent statfs queries stay lean. On a failed RPC the caller
+    /// should call [`Self::reset_handshake_report`] so a later retry can
+    /// still report.
+    pub(crate) fn claim_handshake_report(&self) -> bool {
+        !self.handshake_reported.swap(true, Ordering::Relaxed)
+    }
+
+    /// Allow a later `GetFilesystemInfo` call to report the handshake again
+    /// (used when the first reporting request failed before reaching the
+    /// master).
+    pub(crate) fn reset_handshake_report(&self) {
+        self.handshake_reported.store(false, Ordering::Relaxed);
     }
 
     pub fn conf(&self) -> &ClusterConf {

--- a/crates/client/curvine-client-core/src/file/fs_context.rs
+++ b/crates/client/curvine-client-core/src/file/fs_context.rs
@@ -54,13 +54,15 @@ pub struct FsContext {
     // Client-master handshake result: the master's advertised version /
     // protocol / capabilities (or a legacy marker when the master does not
     // advertise a compatibility contract). Populated by the first
-    // GetFilesystemInfo call and shared by every FsClient clone.
-    master_handshake: Arc<FastRwLock<MasterHandshake>>,
+    // GetFilesystemInfo call and shared by every FsClient clone. Stored
+    // inline: FsContext itself is only ever shared behind an `Arc`, so the
+    // interior-mutable FastRwLock needs no extra heap allocation.
+    master_handshake: FastRwLock<MasterHandshake>,
     // Whether this session has already reported its component_info to the
     // master. Handshake metadata is sent once per mount/session; the flag
     // keeps GetFilesystemInfo (which backs FUSE statfs and may be called
     // frequently) from carrying the payload on every request.
-    handshake_reported: Arc<AtomicBool>,
+    handshake_reported: AtomicBool,
 }
 
 impl FsContext {
@@ -114,8 +116,8 @@ impl FsContext {
             os_cache,
             failed_workers: exclude_workers,
             block_pool,
-            master_handshake: Arc::new(FastRwLock::new(MasterHandshake::default())),
-            handshake_reported: Arc::new(AtomicBool::new(false)),
+            master_handshake: FastRwLock::new(MasterHandshake::default()),
+            handshake_reported: AtomicBool::new(false),
         };
         Ok(context)
     }

--- a/crates/client/curvine-client-core/src/file/handshake.rs
+++ b/crates/client/curvine-client-core/src/file/handshake.rs
@@ -27,14 +27,19 @@ use curvine_proto::{
 };
 
 /// Cached outcome of the client-master version handshake.
+///
+/// Fields are private: instances can only be built through [`Self::default`],
+/// [`Self::legacy`] or [`Self::from_response`], which guarantee that a legacy
+/// handshake never carries a compatibility contract (and vice versa), so
+/// external code cannot construct inconsistent states.
 #[derive(Clone, Debug)]
 pub struct MasterHandshake {
     /// Whether the peer master is a legacy component (it did not advertise a
     /// compatibility contract). Legacy peers are never rejected; the client
     /// degrades to the pre-handshake behavior for them.
-    pub legacy: bool,
+    legacy: bool,
     /// The compatibility contract advertised by the master, when present.
-    pub compatibility: Option<ServerCompatibilityInfoProto>,
+    compatibility: Option<ServerCompatibilityInfoProto>,
 }
 
 impl Default for MasterHandshake {
@@ -46,6 +51,17 @@ impl Default for MasterHandshake {
 }
 
 impl MasterHandshake {
+    /// Whether the peer master is a legacy component (no compatibility
+    /// contract advertised). Legacy peers are never rejected.
+    pub fn is_legacy(&self) -> bool {
+        self.legacy
+    }
+
+    /// The compatibility contract advertised by the master, when present.
+    pub fn compatibility(&self) -> Option<&ServerCompatibilityInfoProto> {
+        self.compatibility.as_ref()
+    }
+
     /// Handshake against a legacy master that did not advertise a
     /// compatibility contract.
     pub fn legacy() -> Self {
@@ -57,7 +73,8 @@ impl MasterHandshake {
 
     /// Parse the handshake from a `GetFilesystemInfo` response. Absence of the
     /// `compatibility` field means the master is a legacy peer and the client
-    /// must not reject it.
+    /// must not reject it. The returned handshake always satisfies the
+    /// invariant `is_legacy() == compatibility().is_none()`.
     pub fn from_response(rep: &GetFilesystemInfoResponse) -> Self {
         match &rep.compatibility {
             Some(compatibility) => Self {
@@ -152,8 +169,8 @@ mod tests {
         // Before any handshake the client must assume a legacy peer: nothing
         // is rejected by default.
         let hs = MasterHandshake::default();
-        assert!(hs.legacy);
-        assert!(hs.compatibility.is_none());
+        assert!(hs.is_legacy());
+        assert!(hs.compatibility().is_none());
         assert_eq!(hs.compatibility_mode(), CompatibilityModeProto::Diagnose);
     }
 
@@ -161,11 +178,8 @@ mod tests {
     fn new_master_response_is_cached_as_non_legacy() {
         let hs = MasterHandshake::from_response(&response_with_compatibility());
 
-        assert!(!hs.legacy);
-        let compat = hs
-            .compatibility
-            .as_ref()
-            .expect("compatibility must be cached");
+        assert!(!hs.is_legacy());
+        let compat = hs.compatibility().expect("compatibility must be cached");
         assert_eq!(compat.server.component.as_deref(), Some("master"));
         assert_eq!(hs.compatibility_mode(), CompatibilityModeProto::Diagnose);
     }
@@ -193,8 +207,8 @@ mod tests {
         // the client treats the peer as legacy and exposes no version data.
         let hs = MasterHandshake::from_response(&legacy_response());
 
-        assert!(hs.legacy);
-        assert!(hs.compatibility.is_none());
+        assert!(hs.is_legacy());
+        assert!(hs.compatibility().is_none());
         assert!(hs.master_version().is_none());
         assert_eq!(hs.protocol_version(), None);
         assert_eq!(hs.min_protocol_version(), None);
@@ -205,21 +219,19 @@ mod tests {
     #[test]
     fn unknown_compatibility_mode_is_treated_as_diagnose() {
         // An unset (0 / UNKNOWN) or invalid mode must stay lenient: the client
-        // never fails closed on a master it does not understand.
-        let mut compat = sample_compatibility();
-        compat.compatibility_mode = 0;
-        let hs = MasterHandshake {
-            legacy: false,
-            compatibility: Some(compat),
-        };
+        // never fails closed on a master it does not understand. Both cases
+        // are exercised through from_response so the constructed handshake
+        // keeps its invariants.
+        let mut rep = response_with_compatibility();
+        rep.compatibility.as_mut().unwrap().compatibility_mode = 0;
+        let hs = MasterHandshake::from_response(&rep);
+        assert!(!hs.is_legacy());
         assert_eq!(hs.compatibility_mode(), CompatibilityModeProto::Diagnose);
 
-        let mut compat = sample_compatibility();
-        compat.compatibility_mode = 99;
-        let hs = MasterHandshake {
-            legacy: false,
-            compatibility: Some(compat),
-        };
+        let mut rep = response_with_compatibility();
+        rep.compatibility.as_mut().unwrap().compatibility_mode = 99;
+        let hs = MasterHandshake::from_response(&rep);
+        assert!(!hs.is_legacy());
         assert_eq!(hs.compatibility_mode(), CompatibilityModeProto::Diagnose);
     }
 }

--- a/crates/client/curvine-client-core/src/file/handshake.rs
+++ b/crates/client/curvine-client-core/src/file/handshake.rs
@@ -1,0 +1,225 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Client-master version handshake and legacy fallback.
+//!
+//! During initialization the client reports its own structured version on the
+//! `GetFilesystemInfo` request (`component_info`) and caches the master's
+//! advertised version / protocol / capabilities from the `compatibility`
+//! field of the response. A master that does not advertise a compatibility
+//! contract is treated as a **legacy** peer: it carries no version metadata
+//! and is never rejected, so existing clusters keep working untouched.
+
+use curvine_proto::{
+    CompatibilityModeProto, ComponentInfoProto, GetFilesystemInfoResponse,
+    ServerCompatibilityInfoProto,
+};
+
+/// Cached outcome of the client-master version handshake.
+#[derive(Clone, Debug)]
+pub struct MasterHandshake {
+    /// Whether the peer master is a legacy component (it did not advertise a
+    /// compatibility contract). Legacy peers are never rejected; the client
+    /// degrades to the pre-handshake behavior for them.
+    pub legacy: bool,
+    /// The compatibility contract advertised by the master, when present.
+    pub compatibility: Option<ServerCompatibilityInfoProto>,
+}
+
+impl Default for MasterHandshake {
+    fn default() -> Self {
+        // Until a handshake completes (and against legacy masters) assume a
+        // legacy peer so no component is ever rejected by default.
+        Self::legacy()
+    }
+}
+
+impl MasterHandshake {
+    /// Handshake against a legacy master that did not advertise a
+    /// compatibility contract.
+    pub fn legacy() -> Self {
+        Self {
+            legacy: true,
+            compatibility: None,
+        }
+    }
+
+    /// Parse the handshake from a `GetFilesystemInfo` response. Absence of the
+    /// `compatibility` field means the master is a legacy peer and the client
+    /// must not reject it.
+    pub fn from_response(rep: &GetFilesystemInfoResponse) -> Self {
+        match &rep.compatibility {
+            Some(compatibility) => Self {
+                legacy: false,
+                compatibility: Some(compatibility.clone()),
+            },
+            None => Self::legacy(),
+        }
+    }
+
+    /// The master's structured component version, when advertised.
+    pub fn master_version(&self) -> Option<&ComponentInfoProto> {
+        self.compatibility.as_ref().map(|c| &c.server)
+    }
+
+    /// The protocol version the master speaks, when advertised.
+    pub fn protocol_version(&self) -> Option<u32> {
+        self.master_version().and_then(|v| v.protocol_version)
+    }
+
+    /// The lowest protocol version the master accepts, when advertised.
+    pub fn min_protocol_version(&self) -> Option<u32> {
+        self.master_version().and_then(|v| v.min_protocol_version)
+    }
+
+    /// Capabilities advertised by the master, when any.
+    pub fn capabilities(&self) -> &[String] {
+        self.master_version()
+            .map(|v| v.capabilities.as_slice())
+            .unwrap_or(&[])
+    }
+
+    /// Compatibility mode the master advertises. An unset/unknown mode is
+    /// treated as `DIAGNOSE` (lenient) per the proto contract, so a handshake
+    /// never rejects peers by default.
+    pub fn compatibility_mode(&self) -> CompatibilityModeProto {
+        match self.compatibility.as_ref().map(|c| c.compatibility_mode) {
+            Some(mode) if mode == CompatibilityModeProto::Enforce as i32 => {
+                CompatibilityModeProto::Enforce
+            }
+            // Diagnose, unset (0 / UNKNOWN) and unknown values stay lenient.
+            _ => CompatibilityModeProto::Diagnose,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use curvine_proto::GetFilesystemInfoResponse;
+
+    fn sample_component_info() -> ComponentInfoProto {
+        ComponentInfoProto {
+            component: Some("master".to_string()),
+            release_version: Some("0.4.0-alpha".to_string()),
+            git_commit: Some("359fce7d982a15f09c3b4e0b2e62fee4229609dd".to_string()),
+            git_tag: Some("v0.4.0-alpha".to_string()),
+            git_branch: Some("main".to_string()),
+            protocol_version: Some(1),
+            min_protocol_version: Some(1),
+            capabilities: vec!["transfer".to_string(), "batch-write".to_string()],
+        }
+    }
+
+    fn sample_compatibility() -> ServerCompatibilityInfoProto {
+        ServerCompatibilityInfoProto {
+            server: sample_component_info(),
+            min_worker_version: None,
+            min_client_version: None,
+            compatibility_mode: CompatibilityModeProto::Diagnose as i32,
+            blocked_versions: vec![],
+        }
+    }
+
+    fn response_with_compatibility() -> GetFilesystemInfoResponse {
+        GetFilesystemInfoResponse {
+            active_master: "master-0".to_string(),
+            compatibility: Some(sample_compatibility()),
+            ..Default::default()
+        }
+    }
+
+    fn legacy_response() -> GetFilesystemInfoResponse {
+        GetFilesystemInfoResponse {
+            active_master: "old-master".to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn default_handshake_is_legacy_and_never_rejects() {
+        // Before any handshake the client must assume a legacy peer: nothing
+        // is rejected by default.
+        let hs = MasterHandshake::default();
+        assert!(hs.legacy);
+        assert!(hs.compatibility.is_none());
+        assert_eq!(hs.compatibility_mode(), CompatibilityModeProto::Diagnose);
+    }
+
+    #[test]
+    fn new_master_response_is_cached_as_non_legacy() {
+        let hs = MasterHandshake::from_response(&response_with_compatibility());
+
+        assert!(!hs.legacy);
+        let compat = hs
+            .compatibility
+            .as_ref()
+            .expect("compatibility must be cached");
+        assert_eq!(compat.server.component.as_deref(), Some("master"));
+        assert_eq!(hs.compatibility_mode(), CompatibilityModeProto::Diagnose);
+    }
+
+    #[test]
+    fn master_version_protocol_and_capabilities_are_exposed() {
+        let hs = MasterHandshake::from_response(&response_with_compatibility());
+
+        assert_eq!(hs.protocol_version(), Some(1));
+        assert_eq!(hs.min_protocol_version(), Some(1));
+        assert_eq!(
+            hs.capabilities(),
+            &["transfer".to_string(), "batch-write".to_string()]
+        );
+        assert_eq!(
+            hs.master_version()
+                .and_then(|v| v.release_version.as_deref()),
+            Some("0.4.0-alpha")
+        );
+    }
+
+    #[test]
+    fn legacy_master_response_is_legacy_without_metadata() {
+        // Old master + new client: the response has no compatibility field, so
+        // the client treats the peer as legacy and exposes no version data.
+        let hs = MasterHandshake::from_response(&legacy_response());
+
+        assert!(hs.legacy);
+        assert!(hs.compatibility.is_none());
+        assert!(hs.master_version().is_none());
+        assert_eq!(hs.protocol_version(), None);
+        assert_eq!(hs.min_protocol_version(), None);
+        assert!(hs.capabilities().is_empty());
+        assert_eq!(hs.compatibility_mode(), CompatibilityModeProto::Diagnose);
+    }
+
+    #[test]
+    fn unknown_compatibility_mode_is_treated_as_diagnose() {
+        // An unset (0 / UNKNOWN) or invalid mode must stay lenient: the client
+        // never fails closed on a master it does not understand.
+        let mut compat = sample_compatibility();
+        compat.compatibility_mode = 0;
+        let hs = MasterHandshake {
+            legacy: false,
+            compatibility: Some(compat),
+        };
+        assert_eq!(hs.compatibility_mode(), CompatibilityModeProto::Diagnose);
+
+        let mut compat = sample_compatibility();
+        compat.compatibility_mode = 99;
+        let hs = MasterHandshake {
+            legacy: false,
+            compatibility: Some(compat),
+        };
+        assert_eq!(hs.compatibility_mode(), CompatibilityModeProto::Diagnose);
+    }
+}

--- a/crates/client/curvine-client-core/src/file/mod.rs
+++ b/crates/client/curvine-client-core/src/file/mod.rs
@@ -18,6 +18,9 @@ pub use self::curvine_filesystem::*;
 mod fs_client;
 pub use self::fs_client::FsClient;
 
+mod handshake;
+pub use self::handshake::MasterHandshake;
+
 mod fs_writer_base;
 pub use self::fs_writer_base::FsWriterBase;
 

--- a/crates/client/curvine-unified-fs/src/unified/unified_filesystem.rs
+++ b/crates/client/curvine-unified-fs/src/unified/unified_filesystem.rs
@@ -16,7 +16,9 @@ use crate::{
     FallbackFsReader, MountCache, MountValue, UnifiedReader, UnifiedWriter, WriteCacheWriter,
 };
 use bytes::BytesMut;
-use curvine_client_core::file::{CurvineFileSystem, FsClient, FsContext, FsReader};
+use curvine_client_core::file::{
+    CurvineFileSystem, FsClient, FsContext, FsReader, MasterHandshake,
+};
 use curvine_client_core::ClientMetrics;
 use curvine_config::ClusterConf;
 use curvine_core_error::{err_box, err_ext};
@@ -262,6 +264,20 @@ impl UnifiedFileSystem {
     pub async fn get_filesystem_info(&self) -> FsResult<FilesystemInfo> {
         let fut = async { self.cv.get_filesystem_info().await };
         self.track("GetFilesystemInfo", "", "", fut).await
+    }
+
+    /// Client-master version handshake: report this client's `component_info`
+    /// and cache the master's advertised version / protocol / capabilities.
+    pub async fn handshake(&self) -> FsResult<MasterHandshake> {
+        let fut = async { self.cv.handshake().await };
+        self.track("GetFilesystemInfo", "", "", fut).await
+    }
+
+    /// Cached master handshake (version / protocol / capabilities). Before the
+    /// first handshake and against legacy masters this reports a legacy peer,
+    /// which is never rejected.
+    pub fn master_handshake(&self) -> MasterHandshake {
+        self.cv.master_handshake()
     }
 
     pub async fn get_filesystem_info_bytes(&self) -> FsResult<BytesMut> {

--- a/curvine-fuse/src/cli/mount_run.rs
+++ b/curvine-fuse/src/cli/mount_run.rs
@@ -22,7 +22,7 @@ use curvine_error::FsError;
 use curvine_fs_api::{FileSystem, Path};
 use curvine_runtime::common::Logger;
 use curvine_runtime::runtime::{AsyncRuntime, RpcRuntime};
-use log::info;
+use log::{info, warn};
 use std::sync::Arc;
 
 /// Runs the default mount command using the given CLI arguments.
@@ -48,6 +48,15 @@ pub fn run_mount(args: FuseRuntimeArgs) -> CommonResult<()> {
     rt.block_on(async move {
         let fs = CurvineFileSystem::new(cluster_conf, fuse_rt.clone())?;
         let conf = fs.conf().clone();
+
+        // Client-master version handshake: report this client's component_info
+        // and cache the master's advertised version / protocol / capabilities.
+        // A master without a compatibility contract is a legacy peer and is
+        // never rejected; a failed handshake degrades to legacy assumptions
+        // instead of blocking the mount.
+        if let Err(e) = fs.fs().handshake().await {
+            warn!("client-master handshake failed: {e}; continuing with legacy assumptions");
+        }
 
         ensure_fs_path_exists(&fs, &conf).await?;
 

--- a/curvine-tests/tests/cluster_test.rs
+++ b/curvine-tests/tests/cluster_test.rs
@@ -168,3 +168,61 @@ fn test_client_handshake_accepts_legacy_master_response() -> CommonResult<()> {
     );
     Ok(())
 }
+
+#[test]
+fn test_bytes_first_get_filesystem_info_caches_handshake() -> CommonResult<()> {
+    // Bytes-first regression: the raw-bytes GetFilesystemInfo path is the
+    // very first master RPC of the session and must still cache the master's
+    // compatibility contract (not stay at the default legacy handshake).
+    let testing = Testing::builder().default().build()?;
+    testing.start_cluster()?;
+    let conf = testing.get_active_cluster_conf()?;
+
+    let rt = Arc::new(AsyncRuntime::single());
+    let fs = testing.get_fs(Some(rt.clone()), Some(conf))?;
+
+    rt.block_on(async move {
+        let bytes = fs.fs_client().get_filesystem_info_bytes().await?;
+        assert!(!bytes.is_empty());
+
+        let hs = fs.master_handshake();
+        assert!(
+            !hs.is_legacy(),
+            "bytes-first GetFilesystemInfo must cache the handshake"
+        );
+        assert!(hs.compatibility().is_some());
+        assert_eq!(hs.protocol_version(), Some(1));
+        Ok::<(), CommonError>(())
+    })?;
+
+    Ok(())
+}
+
+#[test]
+fn test_lazy_handshake_before_first_ordinary_rpc() -> CommonResult<()> {
+    // A session that goes straight to an ordinary master RPC (no explicit
+    // GetFilesystemInfo) must still run the handshake once before the first
+    // RPC and cache the master's compatibility contract.
+    let testing = Testing::builder().default().build()?;
+    testing.start_cluster()?;
+    let conf = testing.get_active_cluster_conf()?;
+
+    let rt = Arc::new(AsyncRuntime::single());
+    let fs = testing.get_fs(Some(rt.clone()), Some(conf))?;
+
+    rt.block_on(async move {
+        let path = Path::from_str("/lazy_handshake_test")?;
+        fs.mkdir(&path, true).await.map_err(CommonError::from)?;
+
+        let hs = fs.master_handshake();
+        assert!(
+            !hs.is_legacy(),
+            "first ordinary master RPC must run the handshake"
+        );
+        assert!(hs.compatibility().is_some());
+        assert_eq!(hs.protocol_version(), Some(1));
+        Ok::<(), CommonError>(())
+    })?;
+
+    Ok(())
+}

--- a/curvine-tests/tests/cluster_test.rs
+++ b/curvine-tests/tests/cluster_test.rs
@@ -115,12 +115,11 @@ fn test_client_master_handshake_on_cluster() -> CommonResult<()> {
 
         let hs = fs.master_handshake();
         assert!(
-            !hs.legacy,
+            !hs.is_legacy(),
             "a new master must advertise a compatibility contract"
         );
         let compat = hs
-            .compatibility
-            .as_ref()
+            .compatibility()
             .expect("master compatibility must be cached after the handshake");
         assert_eq!(compat.server.component.as_deref(), Some("master"));
         assert_eq!(hs.protocol_version(), Some(1));
@@ -130,9 +129,11 @@ fn test_client_master_handshake_on_cluster() -> CommonResult<()> {
             curvine_model::proto::CompatibilityModeProto::Diagnose
         );
 
-        // A second handshake is idempotent and keeps the cached contract.
+        // A second handshake is idempotent and keeps the cached contract;
+        // component_info is reported only once per session (the flag is
+        // already claimed), which also keeps statfs queries lean.
         let hs2 = fs.handshake().await?;
-        assert_eq!(hs2.compatibility, hs.compatibility);
+        assert_eq!(hs2.compatibility(), hs.compatibility());
         Ok::<(), CommonError>(())
     })?;
 
@@ -158,8 +159,8 @@ fn test_client_handshake_accepts_legacy_master_response() -> CommonResult<()> {
     assert!(legacy_response.compatibility.is_none());
 
     let hs = MasterHandshake::from_response(&legacy_response);
-    assert!(hs.legacy);
-    assert!(hs.compatibility.is_none());
+    assert!(hs.is_legacy());
+    assert!(hs.compatibility().is_none());
     assert!(hs.master_version().is_none());
     assert_eq!(
         hs.compatibility_mode(),

--- a/curvine-tests/tests/cluster_test.rs
+++ b/curvine-tests/tests/cluster_test.rs
@@ -96,3 +96,74 @@ async fn write(fs: &CurvineFileSystem, path: &Path) -> CommonResult<FileBlocks> 
     let locs = fs.get_block_locations(path).await?;
     Ok(locs)
 }
+
+#[test]
+fn test_client_master_handshake_on_cluster() -> CommonResult<()> {
+    // New client handshake against a new master: the client reports its own
+    // component_info and caches the master's advertised version / protocol /
+    // capabilities from the GetFilesystemInfo compatibility contract.
+    let testing = Testing::builder().default().build()?;
+    testing.start_cluster()?;
+    let conf = testing.get_active_cluster_conf()?;
+
+    let rt = Arc::new(AsyncRuntime::single());
+    let fs = testing.get_fs(Some(rt.clone()), Some(conf))?;
+
+    rt.block_on(async move {
+        let info = fs.get_filesystem_info().await?;
+        assert!(!info.active_master.is_empty());
+
+        let hs = fs.master_handshake();
+        assert!(
+            !hs.legacy,
+            "a new master must advertise a compatibility contract"
+        );
+        let compat = hs
+            .compatibility
+            .as_ref()
+            .expect("master compatibility must be cached after the handshake");
+        assert_eq!(compat.server.component.as_deref(), Some("master"));
+        assert_eq!(hs.protocol_version(), Some(1));
+        assert_eq!(hs.min_protocol_version(), Some(1));
+        assert_eq!(
+            hs.compatibility_mode(),
+            curvine_model::proto::CompatibilityModeProto::Diagnose
+        );
+
+        // A second handshake is idempotent and keeps the cached contract.
+        let hs2 = fs.handshake().await?;
+        assert_eq!(hs2.compatibility, hs.compatibility);
+        Ok::<(), CommonError>(())
+    })?;
+
+    Ok(())
+}
+
+#[test]
+fn test_client_handshake_accepts_legacy_master_response() -> CommonResult<()> {
+    // Legacy master + new client: a response without a compatibility contract
+    // (a legacy master encodes only business fields and none of the reserved
+    // 1000+ handshake fields) must be treated as a legacy peer and never
+    // rejected. The client-side parsing the FsClient runs after every
+    // GetFilesystemInfo RPC is fed the same response shape a legacy master
+    // produces; wire-level decode of such a payload is covered by the proto
+    // compat tests in curvine-proto.
+    use curvine_client::file::MasterHandshake;
+    use curvine_model::proto::GetFilesystemInfoResponse;
+
+    let legacy_response = GetFilesystemInfoResponse {
+        active_master: "old-master".to_string(),
+        ..Default::default()
+    };
+    assert!(legacy_response.compatibility.is_none());
+
+    let hs = MasterHandshake::from_response(&legacy_response);
+    assert!(hs.legacy);
+    assert!(hs.compatibility.is_none());
+    assert!(hs.master_version().is_none());
+    assert_eq!(
+        hs.compatibility_mode(),
+        curvine_model::proto::CompatibilityModeProto::Diagnose
+    );
+    Ok(())
+}


### PR DESCRIPTION
# Summary

Adds the client side of the client-master version handshake (T6 of the version management design #1527): the client reports its own `component_info` on `GetFilesystemInfo` and caches the master's advertised version / protocol / capabilities from the response `compatibility` contract, with a legacy fallback that never rejects old components.

# Issue Describe / Design

Related to #1527 (sub-task T6, depends on T5 #1581).

Design (from `version-management-design.md` / GitHub issue #1527):

- `FsClient::get_filesystem_info` now sends `GetFilesystemInfoRequest.component_info` (built from this client's `ComponentVersion` via the T4/T5 `ProtoUtils::component_version_to_pb` helper) on the reserved 1000+ range. Legacy masters skip the unknown field; legacy clients simply omit it.
- The response's `compatibility` contract (T5) is parsed into a `MasterHandshake` and cached in `FsContext`, shared by all `FsClient` clones: the master's component version, protocol version, min protocol version, capabilities and compatibility mode.
- Legacy fallback: a master that does not advertise a `compatibility` field is treated as a **legacy peer** — no version metadata and never rejected. The cache defaults to legacy before the first successful handshake, an unset/unknown compatibility mode maps to `DIAGNOSE` (lenient), and a failed handshake RPC at FUSE mount time degrades to legacy assumptions with a warning instead of blocking the mount.
- A new `handshake()` API performs the handshake explicitly (used at FUSE mount initialization) and `master_handshake()` exposes the cached contract; both are exposed through `FsClient`, the core `CurvineFileSystem`, and `UnifiedFileSystem`.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `crates/client/curvine-client-core/src/file/handshake.rs` | New `MasterHandshake` type: parses the GetFilesystemInfo response, exposes master version / protocol / capabilities / compatibility mode, and treats absence of `compatibility` (and unset/unknown modes) as legacy — never rejects | None (new type + unit tests) |
| `crates/client/curvine-client-core/src/file/fs_context.rs` | Cache the handshake result in `FsContext` (shared by every `FsClient` clone), defaulting to legacy | None (new field, defaults to legacy) |
| `crates/client/curvine-client-core/src/file/fs_client.rs` | `get_filesystem_info` reports the client's `component_info` and caches the master handshake; new `handshake()` / `master_handshake()` APIs | None (request gains one optional field; response parse unchanged) |
| `crates/client/curvine-client-core/src/file/curvine_filesystem.rs` | Delegate `handshake()` / `master_handshake()` | None |
| `crates/client/curvine-unified-fs/src/unified/unified_filesystem.rs` | Delegate `handshake()` / `master_handshake()` | None |
| `curvine-fuse/src/cli/mount_run.rs` | Perform the handshake at mount initialization; on RPC failure warn and continue with legacy assumptions | None (one extra RPC at startup; failure is non-fatal) |
| `curvine-tests/tests/cluster_test.rs` | New cluster integration tests: new-client handshake against a live master, legacy-master fallback | None (test-only) |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-client-core` | PASS | 30 tests (7 new: handshake parsing/legacy/default + request building/backward-compat) |
| `cargo test -p curvine-proto` | PASS | 6 legacy wire-compat tests (new client + legacy master, legacy client + new master, both directions) still pass |
| `cargo test -p curvine-model --lib` | PASS | 23 tests |
| `cargo test -p curvine-tests --test cluster_test` | PASS | 3 tests (2 new handshake integration tests against a live MiniCluster) |
| `cargo clippy --release --all-targets -- --deny warnings` | PASS | via `make format` |
| `make format` (clippy `--deny warnings` + `cargo fmt`) | PASS | |

# Dependencies

- Related PRs: #1581 (T5 handshake fields — dependency, merged); #1580 (T4 proto messages — merged)
- Related issues: #1527
- Blocks / blocked by: blocked by #1581 (merged); unblocks T10 (client-worker protocol negotiation pre-check)
