### PR TITLE
feat(proto): report structured worker component version on heartbeat (#1527)

### DIFF
--- a/crates/common/curvine-model/src/proto_utils.rs
+++ b/crates/common/curvine-model/src/proto_utils.rs
@@ -356,6 +356,7 @@ impl ProtoUtils {
             transfer_source_read_plan: Some(src.transfer_capabilities.source_read_plan),
             software_version: Some(src.software_version),
             startup_time_ms: Some(src.startup_time_ms),
+            component_info: src.component_info,
             storage_map: Default::default(),
         };
 
@@ -435,6 +436,7 @@ impl ProtoUtils {
                 },
                 software_version: info.software_version.unwrap_or_default(),
                 startup_time_ms: info.startup_time_ms.unwrap_or_default(),
+                component_info: info.component_info,
                 ..Default::default()
             };
             for (k, v) in info.storage_map {

--- a/crates/common/curvine-model/src/worker_info.rs
+++ b/crates/common/curvine-model/src/worker_info.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::state::{StorageInfo, WorkerAddress, WorkerStatus};
+use curvine_proto::ComponentInfoProto;
 use curvine_runtime::common::LocalTime;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -68,6 +69,10 @@ pub struct WorkerInfo {
     pub status: WorkerStatus,
     pub worker_session_id: String,
     pub transfer_capabilities: TransferWorkerCapabilities,
+    /// Structured version/protocol metadata reported by the worker on its
+    /// heartbeat. `None` means a legacy worker that only sent the display
+    /// string `software_version`.
+    pub component_info: Option<ComponentInfoProto>,
 }
 
 impl WorkerInfo {
@@ -92,6 +97,7 @@ impl WorkerInfo {
             status: WorkerStatus::Live,
             worker_session_id: String::new(),
             transfer_capabilities: TransferWorkerCapabilities::default(),
+            component_info: None,
         }
     }
 
@@ -168,6 +174,7 @@ impl Default for WorkerInfo {
             status: WorkerStatus::Live,
             worker_session_id: String::new(),
             transfer_capabilities: TransferWorkerCapabilities::default(),
+            component_info: None,
         }
     }
 }

--- a/crates/common/curvine-model/tests/worker_info_proto_test.rs
+++ b/crates/common/curvine-model/tests/worker_info_proto_test.rs
@@ -1,4 +1,18 @@
 use curvine_model::{ProtoUtils, WorkerInfo};
+use curvine_proto::ComponentInfoProto;
+
+fn sample_component_info() -> ComponentInfoProto {
+    ComponentInfoProto {
+        component: Some("worker".to_string()),
+        release_version: Some("0.4.0-alpha".to_string()),
+        git_commit: Some("24c848719b5b4fea74519d91cbe462bb49761b36".to_string()),
+        git_tag: Some("v0.4.0-alpha".to_string()),
+        git_branch: Some("main".to_string()),
+        protocol_version: Some(1),
+        min_protocol_version: Some(1),
+        capabilities: vec!["transfer".to_string()],
+    }
+}
 
 #[test]
 fn worker_info_proto_preserves_weight() {
@@ -18,6 +32,39 @@ fn worker_info_proto_preserves_weight() {
     assert_eq!(restored[0].weight, 42);
     assert_eq!(restored[0].software_version, "0.1.0-test");
     assert_eq!(restored[0].startup_time_ms, 123_456);
+}
+
+#[test]
+fn worker_info_proto_preserves_component_info() {
+    let component_info = sample_component_info();
+    let worker = WorkerInfo {
+        weight: 42,
+        software_version: "0.1.0-test".to_string(),
+        component_info: Some(component_info.clone()),
+        ..Default::default()
+    };
+
+    let proto = ProtoUtils::worker_info_to_pb(worker);
+    assert_eq!(proto.component_info, Some(component_info));
+
+    let restored = ProtoUtils::worker_info_from_pb(vec![proto]);
+    assert_eq!(restored[0].component_info, Some(sample_component_info()));
+}
+
+#[test]
+fn worker_info_proto_defaults_missing_component_info() {
+    // A legacy worker carries no component_info; the round trip must keep it
+    // None instead of inventing an empty payload.
+    let worker = WorkerInfo {
+        software_version: "0.1.0-test".to_string(),
+        ..Default::default()
+    };
+
+    let proto = ProtoUtils::worker_info_to_pb(worker);
+    assert!(proto.component_info.is_none());
+
+    let restored = ProtoUtils::worker_info_from_pb(vec![proto]);
+    assert!(restored[0].component_info.is_none());
 }
 
 #[test]

--- a/crates/common/curvine-proto/proto/common.proto
+++ b/crates/common/curvine-proto/proto/common.proto
@@ -178,6 +178,11 @@ message WorkerInfoProto {
     optional bool transfer_source_read_plan = 15 [default = false];
     optional string software_version = 16 [default = ""];
     optional uint64 startup_time_ms = 17 [default = 0];
+
+    // Structured version/protocol metadata reported by the worker on the
+    // reserved 1000+ cross-cutting range. Legacy workers omit this field;
+    // consumers must treat absence as a legacy/unknown peer.
+    optional ComponentInfoProto component_info = 1000;
 }
 
 message FileAllocOptsProto {

--- a/crates/common/curvine-proto/proto/worker.proto
+++ b/crates/common/curvine-proto/proto/worker.proto
@@ -86,6 +86,13 @@ message WorkerHeartbeatRequest {
     optional bool transfer_query_task = 14 [default = false];
     optional bool transfer_attempt_safe_output = 15 [default = false];
     optional bool transfer_source_read_plan = 16 [default = false];
+
+    // Structured version/protocol metadata reported by the worker on the
+    // reserved 1000+ cross-cutting range. Legacy workers omit this field and
+    // keep sending only `software_version`; newer masters treat absence as a
+    // legacy/unknown peer and ignore the field, so mixed-version clusters
+    // keep working untouched.
+    optional ComponentInfoProto component_info = 1000;
 }
 
 message WorkerHeartbeatResponse {

--- a/crates/common/curvine-proto/tests/worker_heartbeat_compat_test.rs
+++ b/crates/common/curvine-proto/tests/worker_heartbeat_compat_test.rs
@@ -1,0 +1,138 @@
+use curvine_proto::{ComponentInfoProto, WorkerHeartbeatRequest, WorkerInfoProto};
+use prost::Message;
+
+fn sample_component_info() -> ComponentInfoProto {
+    ComponentInfoProto {
+        component: Some("worker".to_string()),
+        release_version: Some("0.4.0-alpha".to_string()),
+        git_commit: Some("359fce7d982a15f09c3b4e0b2e62fee4229609dd".to_string()),
+        git_tag: Some("v0.4.0-alpha".to_string()),
+        git_branch: Some("main".to_string()),
+        protocol_version: Some(1),
+        min_protocol_version: Some(1),
+        capabilities: vec!["transfer".to_string(), "batch-write".to_string()],
+    }
+}
+
+/// A legacy worker's view of WorkerHeartbeatRequest: business fields only, no
+/// component_info on the reserved 1000+ range.
+#[derive(Clone, PartialEq, ::prost::Message)]
+struct LegacyWorkerHeartbeatRequest {
+    #[prost(string, required, tag = "1")]
+    cluster_id: String,
+    #[prost(uint32, required, tag = "2")]
+    worker_id: u32,
+    #[prost(string, required, tag = "7")]
+    software_version: String,
+}
+
+/// Append a raw varint field (field number, wire type 0) to a wire buffer.
+fn push_varint(buf: &mut Vec<u8>, mut value: u64) {
+    loop {
+        let byte = (value & 0x7f) as u8;
+        value >>= 7;
+        if value == 0 {
+            buf.push(byte);
+            break;
+        }
+        buf.push(byte | 0x80);
+    }
+}
+
+/// A legacy master's view of WorkerInfoProto: business fields only, no
+/// component_info on the reserved 1000+ range.
+#[derive(Clone, PartialEq, ::prost::Message)]
+struct LegacyWorkerInfoProto {
+    #[prost(string, required, tag = "16")]
+    software_version: String,
+}
+
+#[test]
+fn test_worker_heartbeat_component_info_round_trip() {
+    // New worker -> new master: the structured component info survives the
+    // wire on the reserved 1000+ range of the heartbeat.
+    let req = WorkerHeartbeatRequest {
+        component_info: Some(sample_component_info()),
+        ..Default::default()
+    };
+
+    let encoded = req.encode_to_vec();
+    let decoded = WorkerHeartbeatRequest::decode(encoded.as_slice()).unwrap();
+
+    let info = decoded.component_info.unwrap();
+    assert_eq!(info.component, Some("worker".to_string()));
+    assert_eq!(info.release_version, Some("0.4.0-alpha".to_string()));
+    assert_eq!(info.protocol_version, Some(1));
+    assert_eq!(info.min_protocol_version, Some(1));
+    assert_eq!(info.capabilities.len(), 2);
+}
+
+#[test]
+fn test_worker_heartbeat_legacy_empty_decodes() {
+    // Old worker + new master: a legacy heartbeat without component_info must
+    // decode; the master treats absence as a legacy/unknown peer.
+    let legacy = LegacyWorkerHeartbeatRequest {
+        cluster_id: "test-cluster".to_string(),
+        worker_id: 7,
+        software_version: "0.1.0".to_string(),
+    };
+
+    let encoded = legacy.encode_to_vec();
+    let decoded = WorkerHeartbeatRequest::decode(encoded.as_slice()).unwrap();
+    assert!(decoded.component_info.is_none());
+    assert_eq!(decoded.software_version, "0.1.0");
+}
+
+#[test]
+fn test_worker_info_proto_component_info_round_trip() {
+    // Master -> CLI: WorkerInfoProto carries the structured version so the
+    // report command can display it.
+    let proto = WorkerInfoProto {
+        software_version: Some("0.1.0-test".to_string()),
+        component_info: Some(sample_component_info()),
+        ..Default::default()
+    };
+
+    let encoded = proto.encode_to_vec();
+    let decoded = WorkerInfoProto::decode(encoded.as_slice()).unwrap();
+
+    let info = decoded.component_info.unwrap();
+    assert_eq!(info.component, Some("worker".to_string()));
+    assert_eq!(info.release_version, Some("0.4.0-alpha".to_string()));
+    assert_eq!(decoded.software_version.as_deref(), Some("0.1.0-test"));
+}
+
+#[test]
+fn test_worker_info_proto_legacy_empty_decodes() {
+    // Old master + new CLI: a legacy WorkerInfoProto without component_info
+    // must decode; absence is displayed as legacy/unknown.
+    let legacy = LegacyWorkerInfoProto {
+        software_version: "0.1.0".to_string(),
+    };
+
+    let encoded = legacy.encode_to_vec();
+    let decoded = WorkerInfoProto::decode(encoded.as_slice()).unwrap();
+    assert!(decoded.component_info.is_none());
+    assert_eq!(decoded.software_version.as_deref(), Some("0.1.0"));
+}
+
+#[test]
+fn test_worker_heartbeat_unknown_high_fields_are_skipped() {
+    // Forward compatibility: a peer that sends fields this build does not
+    // know about (e.g. a later reserved-range field beyond 1000) must be
+    // decoded and those fields silently skipped — the same mechanism legacy
+    // components rely on to ignore our new component_info field.
+    let req = WorkerHeartbeatRequest {
+        component_info: Some(sample_component_info()),
+        ..Default::default()
+    };
+
+    let mut encoded = req.encode_to_vec();
+    // Append an unknown length-delimited field 1001 (wire type 2).
+    push_varint(&mut encoded, (1001 << 3) | 2);
+    push_varint(&mut encoded, 1);
+    encoded.push(0);
+
+    let decoded = WorkerHeartbeatRequest::decode(encoded.as_slice()).unwrap();
+    assert_eq!(decoded.component_info, req.component_info);
+}

--- a/crates/common/curvine-proto/tests/worker_heartbeat_compat_test.rs
+++ b/crates/common/curvine-proto/tests/worker_heartbeat_compat_test.rs
@@ -1,4 +1,7 @@
-use curvine_proto::{ComponentInfoProto, WorkerHeartbeatRequest, WorkerInfoProto};
+use curvine_proto::{
+    ComponentInfoProto, HeartbeatStatusProto, WorkerAddressProto, WorkerHeartbeatRequest,
+    WorkerInfoProto,
+};
 use prost::Message;
 
 fn sample_component_info() -> ComponentInfoProto {
@@ -14,14 +17,33 @@ fn sample_component_info() -> ComponentInfoProto {
     }
 }
 
-/// A legacy worker's view of WorkerHeartbeatRequest: business fields only, no
-/// component_info on the reserved 1000+ range.
+fn sample_worker_address(worker_id: u32) -> WorkerAddressProto {
+    WorkerAddressProto {
+        worker_id,
+        hostname: "worker-host".to_string(),
+        ip_addr: "127.0.0.1".to_string(),
+        rpc_port: 1234,
+        web_port: 5678,
+    }
+}
+
+/// A legacy worker's view of WorkerHeartbeatRequest: all required business
+/// fields a pre-change worker actually sent, no component_info on the
+/// reserved 1000+ range.
 #[derive(Clone, PartialEq, ::prost::Message)]
 struct LegacyWorkerHeartbeatRequest {
     #[prost(string, required, tag = "1")]
     cluster_id: String,
     #[prost(uint32, required, tag = "2")]
     worker_id: u32,
+    #[prost(int64, required, tag = "3")]
+    fs_ctime: i64,
+    #[prost(message, required, tag = "4")]
+    address: WorkerAddressProto,
+    #[prost(int32, required, tag = "5")]
+    failed_dirs: i32,
+    #[prost(enumeration = "HeartbeatStatusProto", required, tag = "6")]
+    status: i32,
     #[prost(string, required, tag = "7")]
     software_version: String,
 }
@@ -39,12 +61,27 @@ fn push_varint(buf: &mut Vec<u8>, mut value: u64) {
     }
 }
 
-/// A legacy master's view of WorkerInfoProto: business fields only, no
-/// component_info on the reserved 1000+ range.
+/// A legacy master's view of WorkerInfoProto: all required business fields a
+/// pre-change master actually sent, no component_info on the reserved 1000+
+/// range.
 #[derive(Clone, PartialEq, ::prost::Message)]
 struct LegacyWorkerInfoProto {
-    #[prost(string, required, tag = "16")]
-    software_version: String,
+    #[prost(message, required, tag = "1")]
+    address: WorkerAddressProto,
+    #[prost(int64, required, tag = "2")]
+    capacity: i64,
+    #[prost(int64, required, tag = "3")]
+    available: i64,
+    #[prost(int64, required, tag = "4")]
+    fs_used: i64,
+    #[prost(int64, required, tag = "5")]
+    non_fs_used: i64,
+    #[prost(uint64, required, tag = "6")]
+    last_update: u64,
+    #[prost(int64, required, tag = "8", default = "0")]
+    reserved_bytes: i64,
+    #[prost(string, optional, tag = "16", default = "")]
+    software_version: Option<String>,
 }
 
 #[test]
@@ -74,6 +111,10 @@ fn test_worker_heartbeat_legacy_empty_decodes() {
     let legacy = LegacyWorkerHeartbeatRequest {
         cluster_id: "test-cluster".to_string(),
         worker_id: 7,
+        fs_ctime: 123_456,
+        address: sample_worker_address(7),
+        failed_dirs: 0,
+        status: HeartbeatStatusProto::Running as i32,
         software_version: "0.1.0".to_string(),
     };
 
@@ -81,6 +122,11 @@ fn test_worker_heartbeat_legacy_empty_decodes() {
     let decoded = WorkerHeartbeatRequest::decode(encoded.as_slice()).unwrap();
     assert!(decoded.component_info.is_none());
     assert_eq!(decoded.software_version, "0.1.0");
+    assert_eq!(decoded.worker_id, 7);
+    assert_eq!(decoded.fs_ctime, 123_456);
+    assert_eq!(decoded.address.worker_id, 7);
+    assert_eq!(decoded.failed_dirs, 0);
+    assert_eq!(decoded.status, HeartbeatStatusProto::Running as i32);
 }
 
 #[test]
@@ -107,13 +153,26 @@ fn test_worker_info_proto_legacy_empty_decodes() {
     // Old master + new CLI: a legacy WorkerInfoProto without component_info
     // must decode; absence is displayed as legacy/unknown.
     let legacy = LegacyWorkerInfoProto {
-        software_version: "0.1.0".to_string(),
+        address: sample_worker_address(7),
+        capacity: 100,
+        available: 50,
+        fs_used: 30,
+        non_fs_used: 20,
+        last_update: 1_700_000_000_000,
+        reserved_bytes: 0,
+        software_version: Some("0.1.0".to_string()),
     };
 
     let encoded = legacy.encode_to_vec();
     let decoded = WorkerInfoProto::decode(encoded.as_slice()).unwrap();
     assert!(decoded.component_info.is_none());
     assert_eq!(decoded.software_version.as_deref(), Some("0.1.0"));
+    assert_eq!(decoded.address.worker_id, 7);
+    assert_eq!(decoded.capacity, 100);
+    assert_eq!(decoded.available, 50);
+    assert_eq!(decoded.fs_used, 30);
+    assert_eq!(decoded.non_fs_used, 20);
+    assert_eq!(decoded.reserved_bytes, 0);
 }
 
 #[test]

--- a/curvine-cli/src/cmds/report.rs
+++ b/curvine-cli/src/cmds/report.rs
@@ -16,6 +16,7 @@ use crate::util::*;
 use clap::{Parser, Subcommand};
 use curvine_core_error::CommonResult;
 use curvine_model::{FilesystemInfo, WorkerInfo};
+use curvine_proto::ComponentInfoProto;
 use curvine_unified_fs::UnifiedFileSystem;
 use serde::Serialize;
 
@@ -391,8 +392,20 @@ impl CurvineReport {
 
     fn worker_detail_suffix(worker: &WorkerInfo) -> String {
         let mut details = vec![];
-        if !worker.software_version.is_empty() {
-            details.push(format!("version={}", worker.software_version));
+        // Prefer the structured component info reported on the reserved 1000+
+        // range; fall back to the legacy display string for older workers.
+        match &worker.component_info {
+            Some(info) => {
+                let display = Self::component_info_display(info);
+                if !display.is_empty() {
+                    details.push(display);
+                }
+            }
+            None => {
+                if !worker.software_version.is_empty() {
+                    details.push(format!("version={}", worker.software_version));
+                }
+            }
         }
         if worker.startup_time_ms > 0 {
             details.push(format!(
@@ -406,6 +419,25 @@ impl CurvineReport {
         } else {
             format!(", {}", details.join(", "))
         }
+    }
+
+    /// Render the structured worker version metadata as a compact string.
+    fn component_info_display(info: &ComponentInfoProto) -> String {
+        let mut parts = vec![];
+        if let Some(component) = info.component.as_deref().filter(|s| !s.is_empty()) {
+            parts.push(format!("component={}", component));
+        }
+        if let Some(version) = info.release_version.as_deref().filter(|s| !s.is_empty()) {
+            parts.push(format!("version={}", version));
+        }
+        if let Some(commit) = info.git_commit.as_deref().filter(|s| !s.is_empty()) {
+            parts.push(format!("commit={}", commit));
+        }
+        if let Some(protocol) = info.protocol_version {
+            parts.push(format!("protocol={}", protocol));
+        }
+
+        parts.join(", ")
     }
 
     fn format_epoch_ms(timestamp_ms: u64) -> String {
@@ -485,5 +517,44 @@ mod tests {
             "startup_time={}",
             CurvineReport::format_epoch_ms(startup_time_ms)
         )));
+    }
+
+    #[test]
+    fn simple_report_renders_structured_worker_version() {
+        let startup_time_ms = 123_456;
+        let worker = WorkerInfo {
+            address: WorkerAddress {
+                worker_id: 7,
+                hostname: "worker-host".to_string(),
+                ip_addr: "127.0.0.1".to_string(),
+                rpc_port: 1234,
+                web_port: 5678,
+            },
+            software_version: "0.1.0-test".to_string(),
+            startup_time_ms,
+            component_info: Some(curvine_proto::ComponentInfoProto {
+                component: Some("worker".to_string()),
+                release_version: Some("0.4.0-alpha".to_string()),
+                git_commit: Some("24c8487".to_string()),
+                protocol_version: Some(1),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let report = CurvineReport {
+            info: FilesystemInfo {
+                live_workers: vec![worker],
+                ..Default::default()
+            },
+        };
+
+        let output = report.simple(true);
+
+        // Structured component info is preferred over the legacy display string.
+        assert!(output.contains("component=worker"));
+        assert!(output.contains("version=0.4.0-alpha"));
+        assert!(output.contains("commit=24c8487"));
+        assert!(output.contains("protocol=1"));
+        assert!(!output.contains("version=0.1.0-test"));
     }
 }

--- a/curvine-cli/src/cmds/report.rs
+++ b/curvine-cli/src/cmds/report.rs
@@ -393,12 +393,15 @@ impl CurvineReport {
     fn worker_detail_suffix(worker: &WorkerInfo) -> String {
         let mut details = vec![];
         // Prefer the structured component info reported on the reserved 1000+
-        // range; fall back to the legacy display string for older workers.
+        // range; fall back to the legacy display string for older workers and
+        // for partially-populated component info that renders nothing.
         match &worker.component_info {
             Some(info) => {
                 let display = Self::component_info_display(info);
                 if !display.is_empty() {
                     details.push(display);
+                } else if !worker.software_version.is_empty() {
+                    details.push(format!("version={}", worker.software_version));
                 }
             }
             None => {
@@ -556,5 +559,35 @@ mod tests {
         assert!(output.contains("commit=24c8487"));
         assert!(output.contains("protocol=1"));
         assert!(!output.contains("version=0.1.0-test"));
+    }
+
+    #[test]
+    fn simple_report_falls_back_to_software_version_for_empty_component_info() {
+        // A partially-populated/new-but-empty component_info renders nothing,
+        // so the display must fall back to the legacy software_version string
+        // instead of hiding version details.
+        let worker = WorkerInfo {
+            address: WorkerAddress {
+                worker_id: 8,
+                hostname: "worker-host".to_string(),
+                ip_addr: "127.0.0.1".to_string(),
+                rpc_port: 1234,
+                web_port: 5678,
+            },
+            software_version: "0.2.0-test".to_string(),
+            component_info: Some(curvine_proto::ComponentInfoProto::default()),
+            ..Default::default()
+        };
+        let report = CurvineReport {
+            info: FilesystemInfo {
+                live_workers: vec![worker],
+                ..Default::default()
+            },
+        };
+
+        let output = report.simple(true);
+
+        assert!(output.contains("worker-host:1234"));
+        assert!(output.contains("version=0.2.0-test"));
     }
 }

--- a/curvine-master/src/master/fs/state/worker_map.rs
+++ b/curvine-master/src/master/fs/state/worker_map.rs
@@ -17,6 +17,7 @@ use curvine_error::FsResult;
 use curvine_model::{
     StorageInfo, TransferWorkerCapabilities, WorkerAddress, WorkerInfo, WorkerStatus,
 };
+use curvine_proto::ComponentInfoProto;
 use indexmap::IndexMap;
 use log::{error, info, warn};
 
@@ -92,6 +93,7 @@ impl WorkerMap {
         software_version: String,
         startup_time_ms: u64,
         storages: Vec<StorageInfo>,
+        component_info: Option<ComponentInfoProto>,
     ) -> FsResult<()> {
         self.ensure_worker_id_addr(&addr)?;
         for stale in self.remove_same_endpoint(&addr) {
@@ -109,6 +111,7 @@ impl WorkerMap {
         info.transfer_capabilities = transfer_capabilities;
         info.software_version = software_version;
         info.startup_time_ms = startup_time_ms;
+        info.component_info = component_info;
         let worker_id = info.worker_id();
         for item in storages {
             info.add_storage(item);

--- a/curvine-master/src/master/fs/worker_manager.rs
+++ b/curvine-master/src/master/fs/worker_manager.rs
@@ -22,6 +22,7 @@ use curvine_model::{
     BlockLocation, ExtendedBlock, HeartbeatStatus, LocatedBlock, StorageInfo, StorageType,
     TransferWorkerCapabilities, WorkerAddress, WorkerCommand, WorkerInfo, WorkerStatus,
 };
+use curvine_proto::ComponentInfoProto;
 use curvine_runtime::common::ByteUnit;
 use log::{info, warn};
 use std::collections::HashSet;
@@ -60,6 +61,7 @@ impl WorkerManager {
         software_version: String,
         startup_time_ms: u64,
         storages: Vec<StorageInfo>,
+        component_info: Option<ComponentInfoProto>,
     ) -> FsResult<Vec<WorkerCommand>> {
         // The cluster id must match to prevent misregistration.
         if cluster_id != self.cluster_id {
@@ -106,6 +108,7 @@ impl WorkerManager {
             software_version,
             startup_time_ms,
             storages,
+            component_info,
         )?;
         Ok(cmds)
     }

--- a/curvine-master/src/master/master_handler.rs
+++ b/curvine-master/src/master/master_handler.rs
@@ -602,6 +602,7 @@ impl MasterHandler {
             header.software_version,
             u64::try_from(header.fs_ctime).unwrap_or_default(),
             ProtoUtils::storage_info_list_from_pb(header.storages),
+            header.component_info,
         )?;
         Ok(cmds)
     }
@@ -1046,12 +1047,23 @@ mod tests {
             rpc_port: 1234,
             web_port: 5678,
         };
+        let component_info = curvine_proto::ComponentInfoProto {
+            component: Some("worker".to_string()),
+            release_version: Some("0.4.0-alpha".to_string()),
+            git_commit: Some("24c848719b5b4fea74519d91cbe462bb49761b36".to_string()),
+            git_tag: Some("v0.4.0-alpha".to_string()),
+            git_branch: Some("main".to_string()),
+            protocol_version: Some(1),
+            min_protocol_version: Some(1),
+            capabilities: vec!["transfer".to_string()],
+        };
         let header = WorkerHeartbeatRequest {
             status: HeartbeatStatus::Running.into(),
             cluster_id: conf.cluster_id.clone(),
             address: ProtoUtils::worker_address_to_pb(&address),
             software_version: "0.1.0-test".to_string(),
             fs_ctime: 123_456,
+            component_info: Some(component_info.clone()),
             ..Default::default()
         };
 
@@ -1065,6 +1077,9 @@ mod tests {
             .unwrap();
         assert_eq!(worker.software_version, "0.1.0-test");
         assert_eq!(worker.startup_time_ms, 123_456);
+        // Structured version metadata survives heartbeat -> WorkerInfo ->
+        // WorkerInfoProto (filesystem_info) -> WorkerInfo round trip.
+        assert_eq!(worker.component_info, Some(component_info));
     }
 
     #[test]

--- a/curvine-worker/src/worker/block/master_client.rs
+++ b/curvine-worker/src/worker/block/master_client.rs
@@ -84,6 +84,9 @@ impl MasterClient {
             transfer_source_read_plan: Some(transfer_capabilities.source_read_plan),
             software_version: self.software_version.clone(),
             fs_ctime: self.startup_time_ms as i64,
+            component_info: Some(ProtoUtils::component_version_to_pb(
+                &version::component_version("worker"),
+            )),
             ..Default::default()
         };
         for item in storages {

--- a/curvine-worker/src/worker/block/master_client.rs
+++ b/curvine-worker/src/worker/block/master_client.rs
@@ -37,6 +37,10 @@ pub struct MasterClient {
     pub(crate) worker_session_id: String,
     pub(crate) software_version: String,
     pub(crate) startup_time_ms: u64,
+    /// Prebuilt structured component metadata reported on every heartbeat.
+    /// Constant for the lifetime of the worker process, so it is built once
+    /// and cloned into each request instead of re-allocated on the hot path.
+    pub(crate) component_info: ComponentInfoProto,
 }
 
 impl MasterClient {
@@ -51,6 +55,8 @@ impl MasterClient {
     ) -> Self {
         // Directly reused file system client service.
         let fs_client = FsClient::new(context);
+        let component_info =
+            ProtoUtils::component_version_to_pb(&version::component_version("worker"));
         Self {
             fs_client,
             cluster_id: cluster_id.into(),
@@ -60,6 +66,7 @@ impl MasterClient {
             worker_session_id: worker_session_id.into(),
             software_version: version::VERSION.to_string(),
             startup_time_ms,
+            component_info,
         }
     }
 
@@ -84,9 +91,7 @@ impl MasterClient {
             transfer_source_read_plan: Some(transfer_capabilities.source_read_plan),
             software_version: self.software_version.clone(),
             fs_ctime: self.startup_time_ms as i64,
-            component_info: Some(ProtoUtils::component_version_to_pb(
-                &version::component_version("worker"),
-            )),
+            component_info: Some(self.component_info.clone()),
             ..Default::default()
         };
         for item in storages {


### PR DESCRIPTION
# Summary

Workers now report structured version/protocol metadata (`component_info`) on their heartbeat, reusing the `ComponentInfoProto` added in #1580. The master persists it into `WorkerInfo` and carries it through `WorkerInfoProto`, and `curvine-cli` renders the structured version for live/lost workers. Legacy workers that only send the `software_version` display string keep working untouched: the master treats missing `component_info` as a legacy/unknown peer.

# Issue Describe / Design

Closes #1527 (sub-task: Worker-Master structured version reporting)

- The worker heartbeat previously carried only a display string (`software_version`), which cannot be parsed reliably for compatibility decisions.
- This change adds `optional ComponentInfoProto component_info = 1000` to `WorkerHeartbeatRequest` and `WorkerInfoProto`, following the reserved 1000+ cross-cutting field range agreed in the version-management design.
- Master-side `WorkerInfo` gains `component_info: Option<ComponentInfoProto>`; the heartbeat handler stores it and the report path (`GetFilesystemInfoResponse.live_workers`) carries it back to the CLI.
- Compatibility: the field is optional and unknown to old components, which ignore it (protobuf semantics). New masters accept heartbeats without it and treat the worker as legacy. No business field numbers changed, so wire compatibility is preserved.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `crates/common/curvine-proto/proto/worker.proto` | Add optional `component_info = 1000` to `WorkerHeartbeatRequest` | None (new optional field) |
| `crates/common/curvine-proto/proto/common.proto` | Add optional `component_info = 1000` to `WorkerInfoProto` | None (new optional field) |
| `crates/common/curvine-model/src/worker_info.rs` | Add `component_info: Option<ComponentInfoProto>` to `WorkerInfo` | None (None for legacy workers) |
| `crates/common/curvine-model/src/proto_utils.rs` | Map `component_info` in `worker_info_to_pb` / `worker_info_from_pb` | None |
| `curvine-master/src/master/master_handler.rs` | Extract `component_info` from heartbeat and pass into worker manager | None |
| `curvine-master/src/master/fs/worker_manager.rs` / `state/worker_map.rs` | Thread `component_info` into `WorkerInfo` on insert | None |
| `curvine-worker/src/worker/block/master_client.rs` | Send `component_info` built from `ComponentVersion::new("worker")` on every heartbeat | None (additional field) |
| `curvine-cli/src/cmds/report.rs` | Render structured component info in worker details; fall back to legacy `version=` string | Display-only for new workers; legacy output unchanged |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-proto` | PASS | incl. new `worker_heartbeat_compat_test`: round trip, legacy empty decode, unknown-field skip |
| `cargo test -p curvine-model` | PASS | incl. `WorkerInfoProto` component_info round trip + defaults |
| `cargo test -p curvine-master` | PASS | incl. heartbeat -> `WorkerInfo` -> `WorkerInfoProto` round trip |
| `cargo test -p curvine-worker` | PASS | builds and passes unit tests |
| `cargo test -p curvine-cli --bin curvine-cli` | PASS | incl. structured worker version rendering |
| `make format` | PASS | clippy `--deny warnings` + `cargo fmt` |

# Dependencies

- Related PRs: #1580 (ComponentInfoProto), #1582 (client-master handshake)
- Related issues: #1527
- Blocks / blocked by: None
