### PR TITLE
feat(compat): add compatibility checker with diagnose/enforce policy (#1527)

### DIFF
--- a/crates/common/curvine-config/src/compatibility_conf.rs
+++ b/crates/common/curvine-config/src/compatibility_conf.rs
@@ -1,0 +1,139 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Compatibility policy configuration shared by master and worker.
+//!
+//! Defaults are intentionally lenient: `mode = "diagnose"` with no version
+//! bounds and no blocked versions, so old components are never rejected
+//! without explicit configuration.
+
+use curvine_model::{CompatibilityMode, CompatibilityPolicy};
+use curvine_sys::version::ReleaseVersion;
+use serde::{Deserialize, Serialize};
+
+/// Compatibility enforcement configuration.
+///
+/// Only `mode`, `min_*` bounds and `blocked_versions` are operator-tunable;
+/// the protocol version range is a product contract carried by the code
+/// constants (`PROTOCOL_VERSION` / `MIN_PROTOCOL_VERSION`), so a misconfigured
+/// deployment cannot silently widen the wire protocol.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct CompatibilityConf {
+    /// Enforcement mode: `"diagnose"` (default, lenient) or `"enforce"`.
+    pub mode: String,
+    /// Lowest worker release version accepted by the master. Empty = not
+    /// enforced.
+    pub min_worker_version: String,
+    /// Lowest client release version accepted. Empty = not enforced.
+    pub min_client_version: String,
+    /// Release versions explicitly rejected regardless of mode (emergency
+    /// backstop). Empty by default.
+    pub blocked_versions: Vec<String>,
+}
+
+impl Default for CompatibilityConf {
+    fn default() -> Self {
+        Self {
+            mode: "diagnose".to_string(),
+            min_worker_version: String::new(),
+            min_client_version: String::new(),
+            blocked_versions: vec![],
+        }
+    }
+}
+
+impl CompatibilityConf {
+    /// Build a [`CompatibilityPolicy`] from this config. Unknown mode strings
+    /// and unparseable version bounds degrade to the lenient default (diagnose
+    /// / not enforced) instead of failing closed.
+    pub fn to_policy(&self) -> CompatibilityPolicy {
+        CompatibilityPolicy {
+            mode: CompatibilityMode::parse(&self.mode).unwrap_or_default(),
+            protocol_version: curvine_sys::version::PROTOCOL_VERSION,
+            min_protocol_version: curvine_sys::version::MIN_PROTOCOL_VERSION,
+            min_worker_version: parse_version_opt(&self.min_worker_version),
+            min_client_version: parse_version_opt(&self.min_client_version),
+            blocked_versions: self
+                .blocked_versions
+                .iter()
+                .filter_map(|v| ReleaseVersion::parse(v).ok())
+                .collect(),
+        }
+    }
+}
+
+fn parse_version_opt(s: &str) -> Option<ReleaseVersion> {
+    if s.trim().is_empty() {
+        None
+    } else {
+        ReleaseVersion::parse(s.trim()).ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_conf_is_lenient_diagnose_without_bounds() {
+        let policy = CompatibilityConf::default().to_policy();
+        assert_eq!(policy.mode, CompatibilityMode::Diagnose);
+        assert!(policy.min_worker_version.is_none());
+        assert!(policy.min_client_version.is_none());
+        assert!(policy.blocked_versions.is_empty());
+        assert_eq!(
+            policy.protocol_version,
+            curvine_sys::version::PROTOCOL_VERSION
+        );
+    }
+
+    #[test]
+    fn explicit_enforce_and_bounds_are_honored() {
+        let conf = CompatibilityConf {
+            mode: "enforce".to_string(),
+            min_worker_version: "0.2.0".to_string(),
+            min_client_version: "0.1.5".to_string(),
+            blocked_versions: vec!["0.2.5".to_string()],
+        };
+        let policy = conf.to_policy();
+        assert_eq!(policy.mode, CompatibilityMode::Enforce);
+        assert_eq!(
+            policy.min_worker_version,
+            Some(ReleaseVersion::parse("0.2.0").unwrap())
+        );
+        assert_eq!(
+            policy.min_client_version,
+            Some(ReleaseVersion::parse("0.1.5").unwrap())
+        );
+        assert_eq!(
+            policy.blocked_versions,
+            vec![ReleaseVersion::parse("0.2.5").unwrap()]
+        );
+    }
+
+    #[test]
+    fn invalid_mode_and_bounds_degrade_to_lenient() {
+        let conf = CompatibilityConf {
+            mode: "enforc".to_string(),
+            min_worker_version: "not-a-version".to_string(),
+            min_client_version: String::new(),
+            blocked_versions: vec!["junk".to_string()],
+        };
+        let policy = conf.to_policy();
+        assert_eq!(policy.mode, CompatibilityMode::Diagnose);
+        assert!(policy.min_worker_version.is_none());
+        assert!(policy.blocked_versions.is_empty());
+    }
+}

--- a/crates/common/curvine-config/src/lib.rs
+++ b/crates/common/curvine-config/src/lib.rs
@@ -28,6 +28,9 @@ pub use self::journal_conf::JournalConf;
 mod master_conf;
 pub use self::master_conf::MasterConf;
 
+mod compatibility_conf;
+pub use self::compatibility_conf::CompatibilityConf;
+
 mod worker_conf;
 pub use self::worker_conf::{WorkerConf, WorkerDataDir};
 

--- a/crates/common/curvine-config/src/master_conf.rs
+++ b/crates/common/curvine-config/src/master_conf.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{ClusterConf, DBConf};
+use crate::{ClusterConf, CompatibilityConf, DBConf};
 use curvine_core_error::{err_box, CommonResult};
 use curvine_runtime::common::{ByteUnit, DurationUnit, LogConf, Utils};
 use curvine_runtime::runtime::GroupExecutor;
@@ -135,6 +135,10 @@ pub struct MasterConf {
 
     pub conn_limit: usize,
     pub global_limit: usize,
+
+    /// Version compatibility policy (diagnose by default; enforce only when
+    /// explicitly configured).
+    pub compatibility: CompatibilityConf,
 
     #[serde(default = "MasterConf::rocksdb_default")]
     pub rocksdb: DBConf,
@@ -336,6 +340,8 @@ impl Default for MasterConf {
 
             conn_limit: 8,
             global_limit: 4096,
+
+            compatibility: Default::default(),
 
             rocksdb,
         };

--- a/crates/common/curvine-config/src/worker_conf.rs
+++ b/crates/common/curvine-config/src/worker_conf.rs
@@ -15,7 +15,7 @@
 #![allow(clippy::should_implement_trait)]
 
 use crate::state::StorageType;
-use crate::ClusterConf;
+use crate::{ClusterConf, CompatibilityConf};
 use curvine_core_error::{err_box, CommonResult};
 use curvine_io::SpdkConf;
 use curvine_runtime::common::{ByteUnit, DurationUnit, FileUtils, LogConf, Utils};
@@ -163,6 +163,10 @@ pub struct WorkerConf {
     pub block_replication_concurrency_limit: usize,
     pub block_replication_chunk_size: usize,
 
+    /// Version compatibility policy (diagnose by default; enforce only when
+    /// explicitly configured).
+    pub compatibility: CompatibilityConf,
+
     // SPDK over NVMe-oF/RDMA configuration.
     pub spdk_disk: SpdkConf,
 }
@@ -209,6 +213,7 @@ impl Default for WorkerConf {
             pipe_pool_idle_time: 0,
             block_replication_concurrency_limit: 100,
             block_replication_chunk_size: 1024 * 1024,
+            compatibility: Default::default(),
             spdk_disk: SpdkConf::default(),
         }
     }

--- a/crates/common/curvine-config/src/worker_conf.rs
+++ b/crates/common/curvine-config/src/worker_conf.rs
@@ -15,7 +15,7 @@
 #![allow(clippy::should_implement_trait)]
 
 use crate::state::StorageType;
-use crate::{ClusterConf, CompatibilityConf};
+use crate::ClusterConf;
 use curvine_core_error::{err_box, CommonResult};
 use curvine_io::SpdkConf;
 use curvine_runtime::common::{ByteUnit, DurationUnit, FileUtils, LogConf, Utils};
@@ -163,10 +163,6 @@ pub struct WorkerConf {
     pub block_replication_concurrency_limit: usize,
     pub block_replication_chunk_size: usize,
 
-    /// Version compatibility policy (diagnose by default; enforce only when
-    /// explicitly configured).
-    pub compatibility: CompatibilityConf,
-
     // SPDK over NVMe-oF/RDMA configuration.
     pub spdk_disk: SpdkConf,
 }
@@ -213,7 +209,6 @@ impl Default for WorkerConf {
             pipe_pool_idle_time: 0,
             block_replication_concurrency_limit: 100,
             block_replication_chunk_size: 1024 * 1024,
-            compatibility: Default::default(),
             spdk_disk: SpdkConf::default(),
         }
     }

--- a/crates/common/curvine-model/src/compatibility.rs
+++ b/crates/common/curvine-model/src/compatibility.rs
@@ -97,6 +97,10 @@ pub enum CompatibilityVerdict {
     /// Peer's release version is older than the configured minimum for its
     /// role.
     VersionTooOld { peer: String, min: String },
+    /// Peer sent `component_info` but its release version is missing, empty or
+    /// unparseable, so it cannot be verified against a configured minimum.
+    /// Allowed in diagnose mode; rejected in enforce mode.
+    VersionUnknown { peer: String },
 }
 
 impl CompatibilityVerdict {
@@ -114,9 +118,10 @@ impl CompatibilityVerdict {
         match self {
             Self::Compatible => false,
             Self::Blocked(_) => true,
-            Self::MissingInfo | Self::ProtocolMismatch { .. } | Self::VersionTooOld { .. } => {
-                mode == CompatibilityMode::Enforce
-            }
+            Self::MissingInfo
+            | Self::ProtocolMismatch { .. }
+            | Self::VersionTooOld { .. }
+            | Self::VersionUnknown { .. } => mode == CompatibilityMode::Enforce,
         }
     }
 
@@ -133,6 +138,13 @@ impl CompatibilityVerdict {
             }
             Self::VersionTooOld { peer, min } => {
                 format!("release version {peer} is older than the minimum supported {min}")
+            }
+            Self::VersionUnknown { peer } => {
+                if peer.is_empty() {
+                    "peer release version is missing and cannot be verified".to_string()
+                } else {
+                    format!("release version {peer} cannot be parsed and verified")
+                }
             }
         }
     }
@@ -170,6 +182,28 @@ impl Default for CompatibilityPolicy {
 }
 
 impl CompatibilityPolicy {
+    /// Whether evaluating a peer that reported the given component info can
+    /// have any effect on this policy.
+    ///
+    /// Returns `false` only in diagnose mode with no configured version bounds
+    /// and no blocklist and no peer component info: every such peer is allowed
+    /// (Compatible, or MissingInfo that diagnose permits), so the evaluation
+    /// would only emit warnings. Hot-path callers (statfs-backed
+    /// GetFilesystemInfo, frequent heartbeats) use this to skip evaluation and
+    /// avoid log spam and avoidable overhead.
+    pub fn should_evaluate(&self, has_component_info: bool) -> bool {
+        if self.mode == CompatibilityMode::Enforce {
+            return true;
+        }
+        // Diagnose mode: the evaluation is actionable only when the operator
+        // configured version bounds / a blocklist, or the peer actually
+        // reported component info that could be incompatible.
+        has_component_info
+            || self.min_worker_version.is_some()
+            || self.min_client_version.is_some()
+            || !self.blocked_versions.is_empty()
+    }
+
     /// Check a worker peer (master side).
     pub fn check_worker(&self, peer: Option<&ComponentInfoProto>) -> CompatibilityVerdict {
         self.check(peer, self.min_worker_version.as_ref())
@@ -210,19 +244,32 @@ impl CompatibilityPolicy {
         }
 
         // 3. Version range: peer.release_version >= min (when configured).
-        //    Unparseable peer versions are treated as unknown and skipped, so
-        //    the check stays lenient by default.
+        //    A peer that sends component_info without a parseable release
+        //    version cannot be verified against a configured minimum, so it is
+        //    treated as unknown rather than Compatible: diagnose allows it
+        //    (with a warning), enforce rejects it. This prevents a peer from
+        //    bypassing minimum-version enforcement by omitting its version.
         if let Some(min) = min_version {
-            if let Some(version) = peer.release_version.as_deref() {
-                match ReleaseVersion::parse(version) {
+            match peer.release_version.as_deref() {
+                None | Some("") => {
+                    return CompatibilityVerdict::VersionUnknown {
+                        peer: String::new(),
+                    };
+                }
+                Some(version) => match ReleaseVersion::parse(version) {
                     Ok(parsed) if parsed < *min => {
                         return CompatibilityVerdict::VersionTooOld {
                             peer: version.to_string(),
                             min: min.to_string(),
                         };
                     }
-                    _ => {}
-                }
+                    Ok(_) => {}
+                    Err(_) => {
+                        return CompatibilityVerdict::VersionUnknown {
+                            peer: version.to_string(),
+                        };
+                    }
+                },
             }
         }
 
@@ -392,8 +439,12 @@ mod tests {
     }
 
     #[test]
-    fn unparseable_peer_version_stays_lenient() {
-        let policy = policy();
+    fn unparseable_peer_version_is_unknown_when_min_configured() {
+        // With a minimum version configured, an unparseable release version
+        // cannot be verified and must not fall through to Compatible, or a
+        // peer could bypass minimum-version enforcement by sending a bogus
+        // version. diagnose allows it (warning); enforce rejects it.
+        let policy = policy(); // min_worker_version = 0.2.0
         let peer = ComponentInfoProto {
             release_version: Some("not-a-version".to_string()),
             protocol_version: Some(1),
@@ -401,7 +452,59 @@ mod tests {
         };
 
         let verdict = policy.check_worker(Some(&peer));
-        assert_eq!(verdict, CompatibilityVerdict::Compatible);
+        assert_eq!(
+            verdict,
+            CompatibilityVerdict::VersionUnknown {
+                peer: "not-a-version".to_string()
+            }
+        );
+        assert!(!verdict.rejects(CompatibilityMode::Diagnose));
+        assert!(verdict.rejects(CompatibilityMode::Enforce));
+    }
+
+    #[test]
+    fn missing_release_version_is_unknown_when_min_configured() {
+        // A peer that omits release_version entirely (None or empty) also
+        // cannot be verified against a configured minimum.
+        let policy = policy();
+        for release_version in [None, Some(String::new())] {
+            let peer = ComponentInfoProto {
+                release_version,
+                protocol_version: Some(1),
+                ..sample_worker_info()
+            };
+
+            let verdict = policy.check_worker(Some(&peer));
+            assert_eq!(
+                verdict,
+                CompatibilityVerdict::VersionUnknown {
+                    peer: String::new()
+                }
+            );
+            assert!(verdict.rejects(CompatibilityMode::Enforce));
+        }
+    }
+
+    #[test]
+    fn unknown_version_is_allowed_when_no_min_configured() {
+        // Without an explicit minimum, an unparseable/missing release version
+        // stays Compatible: old or unversioned components are never rejected
+        // by default.
+        let policy = CompatibilityPolicy {
+            min_worker_version: None,
+            ..Default::default()
+        };
+        for release_version in [Some("not-a-version".to_string()), None] {
+            let peer = ComponentInfoProto {
+                release_version,
+                protocol_version: Some(1),
+                ..sample_worker_info()
+            };
+            assert_eq!(
+                policy.check_worker(Some(&peer)),
+                CompatibilityVerdict::Compatible
+            );
+        }
     }
 
     #[test]
@@ -443,5 +546,38 @@ mod tests {
         assert!(!feature_enabled(&server, &peer, "short-circuit"));
         assert!(!feature_enabled(&server, &[], "transfer"));
         assert!(!feature_enabled(&[], &peer, "transfer"));
+    }
+
+    #[test]
+    fn should_evaluate_skips_only_unactionable_diagnose_peers() {
+        // Default diagnose policy with no bounds and no peer component info:
+        // evaluation is unactionable (Compatible or MissingInfo that diagnose
+        // allows), so hot paths skip it to avoid log spam.
+        let default_policy = CompatibilityPolicy::default();
+        assert!(!default_policy.should_evaluate(false));
+
+        // Enforce mode always evaluates.
+        let enforce = CompatibilityPolicy {
+            mode: CompatibilityMode::Enforce,
+            ..Default::default()
+        };
+        assert!(enforce.should_evaluate(false));
+
+        // Component info present -> actionable.
+        assert!(default_policy.should_evaluate(true));
+
+        // Configured bounds / blocklist -> actionable even without component
+        // info.
+        let bounded = CompatibilityPolicy {
+            min_worker_version: Some(version("0.2.0")),
+            ..Default::default()
+        };
+        assert!(bounded.should_evaluate(false));
+
+        let blocked = CompatibilityPolicy {
+            blocked_versions: vec![version("0.2.5")],
+            ..Default::default()
+        };
+        assert!(blocked.should_evaluate(false));
     }
 }

--- a/crates/common/curvine-model/src/compatibility.rs
+++ b/crates/common/curvine-model/src/compatibility.rs
@@ -1,0 +1,447 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Compatibility checker and diagnose/enforce policy.
+//!
+//! A server (master or worker) evaluates a peer's structured version report
+//! (`ComponentInfoProto`) against its own compatibility contract:
+//!
+//! - **protocol layer**: `server.min_protocol_version <= peer.protocol_version
+//!   <= server.protocol_version`;
+//! - **version layer**: the peer's release version must not be older than the
+//!   configured minimum for its role (`min_worker_version` / `min_client_version`);
+//! - **capability layer**: a feature is enabled only when both peers declare it;
+//! - **blocked versions**: an explicit operator backstop that always rejects.
+//!
+//! Enforcement mode:
+//! - `diagnose` (the default): record a warning and allow the request, so old
+//!   components are never rejected without explicit configuration;
+//! - `enforce`: reject incompatible requests with an explicit error. Only
+//!   reached when the operator explicitly sets `mode = "enforce"`.
+
+use curvine_proto::{CompatibilityModeProto, ComponentInfoProto};
+use curvine_sys::version::ReleaseVersion;
+
+/// Compatibility enforcement mode of a server.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CompatibilityMode {
+    /// Record warnings and allow the request (default, lenient).
+    #[default]
+    Diagnose,
+    /// Reject incompatible requests with an explicit error.
+    Enforce,
+}
+
+impl CompatibilityMode {
+    /// Parse a mode from its config string (`"diagnose"` / `"enforce"`).
+    /// Unknown values return `None` so callers can fall back to the lenient
+    /// default instead of failing closed.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "diagnose" => Some(Self::Diagnose),
+            "enforce" => Some(Self::Enforce),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Diagnose => "diagnose",
+            Self::Enforce => "enforce",
+        }
+    }
+
+    /// Map a wire mode to a Rust mode. `UNKNOWN` and any unrecognized value
+    /// stay lenient (`Diagnose`) per the proto contract, so a peer never fails
+    /// closed on a mode it does not understand.
+    pub fn from_proto(mode: i32) -> Self {
+        if mode == CompatibilityModeProto::Enforce as i32 {
+            Self::Enforce
+        } else {
+            Self::Diagnose
+        }
+    }
+
+    pub fn to_proto(self) -> CompatibilityModeProto {
+        match self {
+            Self::Diagnose => CompatibilityModeProto::Diagnose,
+            Self::Enforce => CompatibilityModeProto::Enforce,
+        }
+    }
+}
+
+/// Verdict of a compatibility check against a peer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CompatibilityVerdict {
+    /// Peer is fully compatible.
+    Compatible,
+    /// Peer sent no structured component info at all (legacy peer). Allowed in
+    /// diagnose mode; rejected in enforce mode.
+    MissingInfo,
+    /// Peer's release version is explicitly blocked by the operator. Always
+    /// rejected regardless of mode (explicit ops backstop).
+    Blocked(String),
+    /// Peer's protocol version is outside the server's supported range.
+    ProtocolMismatch { peer: u32, min: u32, max: u32 },
+    /// Peer's release version is older than the configured minimum for its
+    /// role.
+    VersionTooOld { peer: String, min: String },
+}
+
+impl CompatibilityVerdict {
+    pub fn is_compatible(&self) -> bool {
+        matches!(self, Self::Compatible)
+    }
+
+    /// Whether a request from this peer must be rejected under the given mode.
+    ///
+    /// Only blocked versions reject unconditionally: they are an explicit
+    /// operator emergency backstop. All other incompatibilities (missing info,
+    /// protocol mismatch, too-old version) are allowed in `diagnose` mode and
+    /// rejected only in `enforce` mode.
+    pub fn rejects(&self, mode: CompatibilityMode) -> bool {
+        match self {
+            Self::Compatible => false,
+            Self::Blocked(_) => true,
+            Self::MissingInfo | Self::ProtocolMismatch { .. } | Self::VersionTooOld { .. } => {
+                mode == CompatibilityMode::Enforce
+            }
+        }
+    }
+
+    /// Human-readable description used for warnings and error messages.
+    pub fn describe(&self) -> String {
+        match self {
+            Self::Compatible => "compatible".to_string(),
+            Self::MissingInfo => "peer reported no component version info (legacy)".to_string(),
+            Self::Blocked(version) => {
+                format!("release version {version} is blocked by compatibility policy")
+            }
+            Self::ProtocolMismatch { peer, min, max } => {
+                format!("protocol version {peer} outside supported range [{min}, {max}]")
+            }
+            Self::VersionTooOld { peer, min } => {
+                format!("release version {peer} is older than the minimum supported {min}")
+            }
+        }
+    }
+}
+
+/// Server-side compatibility contract used to evaluate peers.
+#[derive(Debug, Clone)]
+pub struct CompatibilityPolicy {
+    pub mode: CompatibilityMode,
+    /// Highest protocol version this server speaks.
+    pub protocol_version: u32,
+    /// Lowest protocol version this server accepts.
+    pub min_protocol_version: u32,
+    /// Lowest worker release version accepted (master side). `None` = not
+    /// enforced, so old components are never rejected by default.
+    pub min_worker_version: Option<ReleaseVersion>,
+    /// Lowest client release version accepted (master/worker side). `None` =
+    /// not enforced.
+    pub min_client_version: Option<ReleaseVersion>,
+    /// Release versions explicitly rejected regardless of mode.
+    pub blocked_versions: Vec<ReleaseVersion>,
+}
+
+impl Default for CompatibilityPolicy {
+    fn default() -> Self {
+        Self {
+            mode: CompatibilityMode::Diagnose,
+            protocol_version: curvine_sys::version::PROTOCOL_VERSION,
+            min_protocol_version: curvine_sys::version::MIN_PROTOCOL_VERSION,
+            min_worker_version: None,
+            min_client_version: None,
+            blocked_versions: vec![],
+        }
+    }
+}
+
+impl CompatibilityPolicy {
+    /// Check a worker peer (master side).
+    pub fn check_worker(&self, peer: Option<&ComponentInfoProto>) -> CompatibilityVerdict {
+        self.check(peer, self.min_worker_version.as_ref())
+    }
+
+    /// Check a client peer (master side).
+    pub fn check_client(&self, peer: Option<&ComponentInfoProto>) -> CompatibilityVerdict {
+        self.check(peer, self.min_client_version.as_ref())
+    }
+
+    fn check(
+        &self,
+        peer: Option<&ComponentInfoProto>,
+        min_version: Option<&ReleaseVersion>,
+    ) -> CompatibilityVerdict {
+        let Some(peer) = peer else {
+            return CompatibilityVerdict::MissingInfo;
+        };
+
+        // 1. Blocked versions: exact release version match, always rejected.
+        if let Some(version) = peer.release_version.as_deref() {
+            if let Ok(parsed) = ReleaseVersion::parse(version) {
+                if self.blocked_versions.contains(&parsed) {
+                    return CompatibilityVerdict::Blocked(version.to_string());
+                }
+            }
+        }
+
+        // 2. Protocol version: server.min_protocol_version <= peer.protocol_version
+        //    <= server.protocol_version.
+        let peer_protocol = peer.protocol_version.unwrap_or(1);
+        if peer_protocol < self.min_protocol_version || peer_protocol > self.protocol_version {
+            return CompatibilityVerdict::ProtocolMismatch {
+                peer: peer_protocol,
+                min: self.min_protocol_version,
+                max: self.protocol_version,
+            };
+        }
+
+        // 3. Version range: peer.release_version >= min (when configured).
+        //    Unparseable peer versions are treated as unknown and skipped, so
+        //    the check stays lenient by default.
+        if let Some(min) = min_version {
+            if let Some(version) = peer.release_version.as_deref() {
+                match ReleaseVersion::parse(version) {
+                    Ok(parsed) if parsed < *min => {
+                        return CompatibilityVerdict::VersionTooOld {
+                            peer: version.to_string(),
+                            min: min.to_string(),
+                        };
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        CompatibilityVerdict::Compatible
+    }
+}
+
+/// A feature is enabled only when **both** the server and the peer declare the
+/// capability. Capabilities are finer-grained than versions and take priority
+/// for feature negotiation (short-circuit, batch-write, transfer, ...).
+pub fn feature_enabled(
+    server_capabilities: &[String],
+    peer_capabilities: &[String],
+    feature: &str,
+) -> bool {
+    server_capabilities.iter().any(|c| c == feature)
+        && peer_capabilities.iter().any(|c| c == feature)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_worker_info() -> ComponentInfoProto {
+        ComponentInfoProto {
+            component: Some("worker".to_string()),
+            release_version: Some("0.4.0-alpha".to_string()),
+            git_commit: Some("24c848719b5b4fea74519d91cbe462bb49761b36".to_string()),
+            git_tag: Some("v0.4.0-alpha".to_string()),
+            git_branch: Some("main".to_string()),
+            protocol_version: Some(1),
+            min_protocol_version: Some(1),
+            capabilities: vec!["transfer".to_string(), "batch-write".to_string()],
+        }
+    }
+
+    fn version(v: &str) -> ReleaseVersion {
+        ReleaseVersion::parse(v).unwrap()
+    }
+
+    fn policy() -> CompatibilityPolicy {
+        CompatibilityPolicy {
+            mode: CompatibilityMode::Diagnose,
+            protocol_version: 1,
+            min_protocol_version: 1,
+            min_worker_version: Some(version("0.2.0")),
+            min_client_version: Some(version("0.2.0")),
+            blocked_versions: vec![version("0.2.5")],
+        }
+    }
+
+    #[test]
+    fn default_policy_is_lenient_and_never_rejects_old_components() {
+        // Acceptance: without explicit config, old components are not rejected.
+        let policy = CompatibilityPolicy::default();
+        let old_worker = ComponentInfoProto {
+            release_version: Some("0.1.0".to_string()),
+            protocol_version: Some(1),
+            ..sample_worker_info()
+        };
+
+        let verdict = policy.check_worker(Some(&old_worker));
+        assert_eq!(verdict, CompatibilityVerdict::Compatible);
+        assert!(!verdict.rejects(policy.mode));
+        // Enforce is only reachable with explicit config; even then the default
+        // policy carries no bounds, so nothing is rejected.
+        assert!(!verdict.rejects(CompatibilityMode::Enforce));
+    }
+
+    #[test]
+    fn compatible_worker_within_range_passes() {
+        let policy = policy();
+        let verdict = policy.check_worker(Some(&sample_worker_info()));
+        assert_eq!(verdict, CompatibilityVerdict::Compatible);
+        assert!(!verdict.rejects(policy.mode));
+        assert!(!verdict.rejects(CompatibilityMode::Enforce));
+    }
+
+    #[test]
+    fn incompatible_protocol_version_is_rejected_in_enforce_only() {
+        let policy = policy();
+        let peer = ComponentInfoProto {
+            release_version: Some("0.4.0".to_string()),
+            protocol_version: Some(2),
+            ..sample_worker_info()
+        };
+
+        let verdict = policy.check_worker(Some(&peer));
+        assert_eq!(
+            verdict,
+            CompatibilityVerdict::ProtocolMismatch {
+                peer: 2,
+                min: 1,
+                max: 1
+            }
+        );
+        // diagnose records a warning and allows.
+        assert!(!verdict.rejects(CompatibilityMode::Diagnose));
+        // enforce rejects with the explicit reason.
+        assert!(verdict.rejects(CompatibilityMode::Enforce));
+        assert!(verdict.describe().contains("protocol version 2"));
+    }
+
+    #[test]
+    fn too_old_worker_version_is_rejected_in_enforce_only() {
+        let policy = policy();
+        let peer = ComponentInfoProto {
+            release_version: Some("0.1.5".to_string()),
+            ..sample_worker_info()
+        };
+
+        let verdict = policy.check_worker(Some(&peer));
+        assert_eq!(
+            verdict,
+            CompatibilityVerdict::VersionTooOld {
+                peer: "0.1.5".to_string(),
+                min: "0.2.0".to_string()
+            }
+        );
+        assert!(!verdict.rejects(CompatibilityMode::Diagnose));
+        assert!(verdict.rejects(CompatibilityMode::Enforce));
+    }
+
+    #[test]
+    fn missing_info_is_allowed_in_diagnose_and_rejected_in_enforce() {
+        let policy = policy();
+        // A legacy worker sends no component_info at all.
+        let verdict = policy.check_worker(None);
+        assert_eq!(verdict, CompatibilityVerdict::MissingInfo);
+        assert!(!verdict.rejects(CompatibilityMode::Diagnose));
+        assert!(verdict.rejects(CompatibilityMode::Enforce));
+    }
+
+    #[test]
+    fn blocked_version_is_always_rejected_regardless_of_mode() {
+        let policy = policy();
+        let peer = ComponentInfoProto {
+            release_version: Some("0.2.5".to_string()),
+            ..sample_worker_info()
+        };
+
+        let verdict = policy.check_worker(Some(&peer));
+        assert_eq!(verdict, CompatibilityVerdict::Blocked("0.2.5".to_string()));
+        // Explicit ops backstop: rejects even in diagnose mode.
+        assert!(verdict.rejects(CompatibilityMode::Diagnose));
+        assert!(verdict.rejects(CompatibilityMode::Enforce));
+    }
+
+    #[test]
+    fn min_client_version_applies_to_client_peers() {
+        let policy = policy();
+        let old_client = ComponentInfoProto {
+            component: Some("client".to_string()),
+            release_version: Some("0.1.0".to_string()),
+            ..sample_worker_info()
+        };
+
+        let verdict = policy.check_client(Some(&old_client));
+        assert_eq!(
+            verdict,
+            CompatibilityVerdict::VersionTooOld {
+                peer: "0.1.0".to_string(),
+                min: "0.2.0".to_string()
+            }
+        );
+        assert!(verdict.rejects(CompatibilityMode::Enforce));
+    }
+
+    #[test]
+    fn unparseable_peer_version_stays_lenient() {
+        let policy = policy();
+        let peer = ComponentInfoProto {
+            release_version: Some("not-a-version".to_string()),
+            protocol_version: Some(1),
+            ..sample_worker_info()
+        };
+
+        let verdict = policy.check_worker(Some(&peer));
+        assert_eq!(verdict, CompatibilityVerdict::Compatible);
+    }
+
+    #[test]
+    fn mode_parsing_and_proto_round_trip() {
+        assert_eq!(
+            CompatibilityMode::parse("diagnose"),
+            Some(CompatibilityMode::Diagnose)
+        );
+        assert_eq!(
+            CompatibilityMode::parse("ENFORCE"),
+            Some(CompatibilityMode::Enforce)
+        );
+        assert_eq!(CompatibilityMode::parse("bogus"), None);
+        assert_eq!(CompatibilityMode::default(), CompatibilityMode::Diagnose);
+
+        // UNKNOWN (0) and unrecognized values stay lenient.
+        assert_eq!(
+            CompatibilityMode::from_proto(0),
+            CompatibilityMode::Diagnose
+        );
+        assert_eq!(
+            CompatibilityMode::from_proto(99),
+            CompatibilityMode::Diagnose
+        );
+        assert_eq!(CompatibilityMode::from_proto(2), CompatibilityMode::Enforce);
+
+        for mode in [CompatibilityMode::Diagnose, CompatibilityMode::Enforce] {
+            assert_eq!(CompatibilityMode::from_proto(mode.to_proto() as i32), mode);
+        }
+    }
+
+    #[test]
+    fn feature_enabled_requires_both_peers_to_declare_it() {
+        let server = vec!["transfer".to_string(), "batch-write".to_string()];
+        let peer = vec!["transfer".to_string()];
+
+        assert!(feature_enabled(&server, &peer, "transfer"));
+        assert!(!feature_enabled(&server, &peer, "batch-write"));
+        assert!(!feature_enabled(&server, &peer, "short-circuit"));
+        assert!(!feature_enabled(&server, &[], "transfer"));
+        assert!(!feature_enabled(&[], &peer, "transfer"));
+    }
+}

--- a/crates/common/curvine-model/src/lib.rs
+++ b/crates/common/curvine-model/src/lib.rs
@@ -116,6 +116,11 @@ pub use self::result::*;
 mod proto_utils;
 pub use self::proto_utils::ProtoUtils;
 
+mod compatibility;
+pub use self::compatibility::{
+    feature_enabled, CompatibilityMode, CompatibilityPolicy, CompatibilityVerdict,
+};
+
 mod display;
 
 pub mod error {

--- a/crates/common/curvine-model/src/proto_utils.rs
+++ b/crates/common/curvine-model/src/proto_utils.rs
@@ -415,6 +415,27 @@ impl ProtoUtils {
         }
     }
 
+    /// Build the compatibility contract a server advertises from its own
+    /// version and the configured compatibility policy. The advertised mode,
+    /// minimum bounds and blocked versions mirror the policy so peers learn
+    /// what the server accepts; the protocol version range stays a product
+    /// contract carried by the server's own version.
+    pub fn compatibility_to_pb(
+        src: &ComponentVersion,
+        policy: &crate::CompatibilityPolicy,
+    ) -> ServerCompatibilityInfoProto {
+        let mut pb = Self::default_master_compatibility_to_pb(src);
+        pb.compatibility_mode = policy.mode.to_proto() as i32;
+        pb.min_worker_version = policy.min_worker_version.as_ref().map(|v| v.to_string());
+        pb.min_client_version = policy.min_client_version.as_ref().map(|v| v.to_string());
+        pb.blocked_versions = policy
+            .blocked_versions
+            .iter()
+            .map(|v| v.to_string())
+            .collect();
+        pb
+    }
+
     pub fn worker_info_from_pb(workers: Vec<WorkerInfoProto>) -> Vec<WorkerInfo> {
         let mut vec = vec![];
         for info in workers {

--- a/curvine-master/src/master/master_handler.rs
+++ b/curvine-master/src/master/master_handler.rs
@@ -35,6 +35,7 @@ use curvine_proto::*;
 use curvine_rpc::handler::MessageHandler;
 use curvine_rpc::message::Message;
 use curvine_runtime::runtime::{GroupExecutor, Runtime};
+use dashmap::DashMap;
 use std::panic::{self, AssertUnwindSafe};
 use std::sync::Arc;
 use tokio::sync::oneshot;
@@ -58,6 +59,11 @@ pub struct MasterHandler {
     // evaluate worker heartbeats and client handshakes with diagnose/enforce
     // semantics (lenient diagnose by default).
     compatibility_policy: CompatibilityPolicy,
+    // Last compatibility verdict warned about per peer (worker id / client
+    // address). Diagnose-mode warnings are deduped so a persistently
+    // incompatible or legacy peer does not spam identical warnings on every
+    // heartbeat or statfs call.
+    compat_warned: DashMap<String, CompatibilityVerdict>,
 }
 
 impl MasterHandler {
@@ -97,6 +103,7 @@ impl MasterHandler {
             actor_rt,
             master_compatibility,
             compatibility_policy,
+            compat_warned: DashMap::new(),
         }
     }
 
@@ -493,6 +500,8 @@ impl MasterHandler {
         {
             Self::check_peer_compatibility(
                 "client",
+                &format!("client:{}", self.client_ip()),
+                &self.compat_warned,
                 self.compatibility_policy.mode,
                 self.compatibility_policy
                     .check_client(req.component_info.as_ref()),
@@ -602,6 +611,8 @@ impl MasterHandler {
         {
             Self::check_peer_compatibility(
                 "worker",
+                &format!("worker:{}", header.worker_id),
+                &self.compat_warned,
                 self.compatibility_policy.mode,
                 self.compatibility_policy
                     .check_worker(header.component_info.as_ref()),
@@ -621,14 +632,35 @@ impl MasterHandler {
     ///   explicit configuration.
     /// - `enforce`: reject with an explicit error describing the actual peer
     ///   version, the expected bound and the upgrade suggestion.
+    ///
+    /// Diagnose-mode warnings are deduped per peer: a persistently
+    /// incompatible or legacy peer (heartbeats run every few seconds, statfs
+    /// every call) warns on the first occurrence and again only when its
+    /// verdict changes, so repeated identical warnings do not flood
+    /// operational logs.
     fn check_peer_compatibility(
         peer: &str,
+        dedup_key: &str,
+        warned: &DashMap<String, CompatibilityVerdict>,
         mode: CompatibilityMode,
         verdict: CompatibilityVerdict,
     ) -> FsResult<()> {
         if !verdict.rejects(mode) {
             if !verdict.is_compatible() {
-                log::warn!("{} compatibility: {}", peer, verdict.describe());
+                // Warn on the first occurrence and whenever the verdict
+                // changes for this peer; suppress identical repeats.
+                let changed = warned
+                    .get(dedup_key)
+                    .map(|last| *last != verdict)
+                    .unwrap_or(true);
+                if changed {
+                    warned.insert(dedup_key.to_string(), verdict.clone());
+                    log::warn!("{} compatibility: {}", peer, verdict.describe());
+                }
+            } else {
+                // The peer is compatible again; forget the previous warning so
+                // a future incompatibility is surfaced.
+                warned.remove(dedup_key);
             }
             return Ok(());
         }
@@ -1193,6 +1225,64 @@ mod tests {
     }
 
     #[test]
+    fn diagnose_warnings_are_deduped_per_peer() {
+        // A persistently incompatible worker must not re-log the same warning
+        // on every heartbeat: only a verdict change emits a new warning.
+        let policy = CompatibilityPolicy {
+            mode: CompatibilityMode::Diagnose,
+            min_worker_version: Some("0.2.0".parse().unwrap()),
+            ..Default::default()
+        };
+        let warned = DashMap::new();
+        let verdict = policy.check_worker(Some(&ComponentInfoProto {
+            release_version: Some("0.1.0".to_string()),
+            protocol_version: Some(1),
+            ..sample_component_info()
+        }));
+
+        // First occurrence warns and records the verdict.
+        assert!(MasterHandler::check_peer_compatibility(
+            "worker",
+            "worker:7",
+            &warned,
+            policy.mode,
+            verdict.clone()
+        )
+        .is_ok());
+        assert!(warned.contains_key("worker:7"));
+
+        // Identical verdict on a later heartbeat does not warn again but is
+        // still allowed.
+        assert!(MasterHandler::check_peer_compatibility(
+            "worker",
+            "worker:7",
+            &warned,
+            policy.mode,
+            verdict.clone()
+        )
+        .is_ok());
+
+        // A different incompatible verdict for the same peer warns again.
+        let different = CompatibilityVerdict::ProtocolMismatch {
+            peer: 2,
+            min: 1,
+            max: 1,
+        };
+        assert!(MasterHandler::check_peer_compatibility(
+            "worker",
+            "worker:7",
+            &warned,
+            policy.mode,
+            different.clone()
+        )
+        .is_ok());
+        assert_eq!(warned.get("worker:7").as_deref(), Some(&different));
+
+        // A separate peer is tracked independently.
+        assert!(!warned.contains_key("worker:8"));
+    }
+
+    #[test]
     fn diagnose_mode_allows_incompatible_worker_heartbeat() {
         // Configure a minimum worker version so the peer is genuinely
         // incompatible (below the bound): diagnose mode must still allow the
@@ -1216,11 +1306,26 @@ mod tests {
                 min: "0.2.0".to_string()
             }
         );
-        assert!(MasterHandler::check_peer_compatibility("worker", policy.mode, verdict).is_ok());
+        let warned = DashMap::new();
+        assert!(MasterHandler::check_peer_compatibility(
+            "worker",
+            "worker:7",
+            &warned,
+            policy.mode,
+            verdict
+        )
+        .is_ok());
 
         // Legacy worker (no component_info): MissingInfo, allowed in diagnose.
         let verdict = policy.check_worker(None);
-        assert!(MasterHandler::check_peer_compatibility("worker", policy.mode, verdict).is_ok());
+        assert!(MasterHandler::check_peer_compatibility(
+            "worker",
+            "worker:7",
+            &warned,
+            policy.mode,
+            verdict
+        )
+        .is_ok());
     }
 
     #[test]
@@ -1236,8 +1341,15 @@ mod tests {
             ..sample_component_info()
         };
         let verdict = policy.check_worker(Some(&incompatible));
-        let err =
-            MasterHandler::check_peer_compatibility("worker", policy.mode, verdict).unwrap_err();
+        let warned = DashMap::new();
+        let err = MasterHandler::check_peer_compatibility(
+            "worker",
+            "worker:7",
+            &warned,
+            policy.mode,
+            verdict,
+        )
+        .unwrap_err();
         let msg = format!("{}", err);
         assert!(msg.contains("rejected by compatibility policy"), "{msg}");
         assert!(msg.contains("0.1.0"), "{msg}");
@@ -1250,8 +1362,15 @@ mod tests {
             ..Default::default()
         };
         let verdict = policy.check_client(None);
-        let err =
-            MasterHandler::check_peer_compatibility("client", policy.mode, verdict).unwrap_err();
+        let warned = DashMap::new();
+        let err = MasterHandler::check_peer_compatibility(
+            "client",
+            "client:127.0.0.1",
+            &warned,
+            policy.mode,
+            verdict,
+        )
+        .unwrap_err();
         assert!(format!("{}", err).contains("client rejected"));
     }
 

--- a/curvine-master/src/master/master_handler.rs
+++ b/curvine-master/src/master/master_handler.rs
@@ -482,16 +482,22 @@ impl MasterHandler {
 
     async fn async_get_filesystem_info(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let req: GetFilesystemInfoRequest = ctx.parse_header()?;
-        // Enforce the master compatibility policy against the client's
-        // structured version report (handshake). Legacy clients that do not
-        // send component_info produce a MissingInfo verdict: allowed in
-        // diagnose mode, rejected in enforce mode.
-        Self::check_peer_compatibility(
-            "client",
-            self.compatibility_policy.mode,
-            self.compatibility_policy
-                .check_client(req.component_info.as_ref()),
-        )?;
+        // GetFilesystemInfo backs statfs and is called frequently. Only
+        // evaluate the compatibility policy when the result can actually be
+        // acted upon (enforce mode, configured bounds/blocklist, or the client
+        // reported component_info); otherwise a legacy client would hit a
+        // MissingInfo verdict and log a warning on every statfs call.
+        if self
+            .compatibility_policy
+            .should_evaluate(req.component_info.is_some())
+        {
+            Self::check_peer_compatibility(
+                "client",
+                self.compatibility_policy.mode,
+                self.compatibility_policy
+                    .check_client(req.component_info.as_ref()),
+            )?;
+        }
         let fs = self.fs.clone();
         let info = Self::run_master_rpc_task(self.control_rpc_executor.clone(), move || {
             Self::process_get_filesystem_info(fs)
@@ -586,17 +592,21 @@ impl MasterHandler {
 
     pub fn worker_heartbeat(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let header: WorkerHeartbeatRequest = ctx.parse_header()?;
-        // Enforce the master compatibility policy against the worker's
-        // structured version report. Diagnose mode records a warning and
-        // allows the heartbeat (legacy workers without component_info stay
-        // compatible); enforce mode rejects incompatible workers with an
-        // explicit error.
-        Self::check_peer_compatibility(
-            "worker",
-            self.compatibility_policy.mode,
-            self.compatibility_policy
-                .check_worker(header.component_info.as_ref()),
-        )?;
+        // Evaluate the compatibility policy only when the result can actually
+        // be acted upon (enforce mode, configured bounds/blocklist, or the
+        // worker reported component_info); otherwise a legacy worker would hit
+        // a MissingInfo verdict and log a warning on every heartbeat.
+        if self
+            .compatibility_policy
+            .should_evaluate(header.component_info.is_some())
+        {
+            Self::check_peer_compatibility(
+                "worker",
+                self.compatibility_policy.mode,
+                self.compatibility_policy
+                    .check_worker(header.component_info.as_ref()),
+            )?;
+        }
         let cmds = Self::process_worker_heartbeat(self.fs.clone(), header)?;
         let rep_header = WorkerHeartbeatResponse {
             cmds: ProtoUtils::worker_cmd_to_pb(cmds),
@@ -1184,16 +1194,28 @@ mod tests {
 
     #[test]
     fn diagnose_mode_allows_incompatible_worker_heartbeat() {
-        // Default policy is diagnose: an incompatible worker is warned about
-        // but not rejected, and a legacy worker without component_info is
-        // allowed.
-        let policy = CompatibilityPolicy::default();
+        // Configure a minimum worker version so the peer is genuinely
+        // incompatible (below the bound): diagnose mode must still allow the
+        // request (logging a warning) instead of rejecting it. A legacy worker
+        // without component_info is also allowed.
+        let policy = CompatibilityPolicy {
+            mode: CompatibilityMode::Diagnose,
+            min_worker_version: Some("0.2.0".parse().unwrap()),
+            ..Default::default()
+        };
         let incompatible = ComponentInfoProto {
             release_version: Some("0.1.0".to_string()),
             protocol_version: Some(1),
             ..sample_component_info()
         };
         let verdict = policy.check_worker(Some(&incompatible));
+        assert_eq!(
+            verdict,
+            CompatibilityVerdict::VersionTooOld {
+                peer: "0.1.0".to_string(),
+                min: "0.2.0".to_string()
+            }
+        );
         assert!(MasterHandler::check_peer_compatibility("worker", policy.mode, verdict).is_ok());
 
         // Legacy worker (no component_info): MissingInfo, allowed in diagnose.

--- a/curvine-master/src/master/master_handler.rs
+++ b/curvine-master/src/master/master_handler.rs
@@ -26,8 +26,9 @@ use curvine_fs_api::Path;
 use curvine_fs_api::RpcCode;
 use curvine_model::ProtoUtils;
 use curvine_model::{
-    CreateFileOpts, DeleteBlockCmd, DeleteResult, FileBlocks, FileStatus, FilesystemInfo,
-    FreeResult, HeartbeatStatus, ListOptions, OpenFlags, RenameFlags, WorkerCommand, WorkerInfo,
+    CompatibilityMode, CompatibilityPolicy, CompatibilityVerdict, CreateFileOpts, DeleteBlockCmd,
+    DeleteResult, FileBlocks, FileStatus, FilesystemInfo, FreeResult, HeartbeatStatus, ListOptions,
+    OpenFlags, RenameFlags, WorkerCommand, WorkerInfo,
 };
 use curvine_net::net::ConnState;
 use curvine_proto::*;
@@ -49,10 +50,14 @@ pub struct MasterHandler {
     pub(crate) control_rpc_executor: Arc<GroupExecutor>,
     pub(crate) replication_handler: Option<MasterReplicationHandler>,
     pub(crate) actor_rt: Arc<Runtime>,
-    // Master's own version + default compatibility contract, built once at
-    // startup. GetFilesystemInfo backs statfs and is called frequently, so we
-    // reuse this instead of recomputing component_version() on every call.
+    // Master's own version + compatibility contract, built once at startup.
+    // GetFilesystemInfo backs statfs and is called frequently, so we reuse
+    // this instead of recomputing component_version() on every call.
     master_compatibility: ServerCompatibilityInfoProto,
+    // Compatibility policy derived from the master configuration. Used to
+    // evaluate worker heartbeats and client handshakes with diagnose/enforce
+    // semantics (lenient diagnose by default).
+    compatibility_policy: CompatibilityPolicy,
 }
 
 impl MasterHandler {
@@ -73,7 +78,12 @@ impl MasterHandler {
         // Build the master's compatibility payload once; GetFilesystemInfo can
         // be hot (statfs) and the underlying version metadata is immutable.
         let master_version = curvine_sys::version::component_version("master");
-        let master_compatibility = ProtoUtils::default_master_compatibility_to_pb(&master_version);
+        // The advertised contract and the enforcement policy both come from
+        // the configured compatibility section; defaults are lenient diagnose
+        // with no bounds, so old components are never rejected by default.
+        let compatibility_policy = conf.master.compatibility.to_policy();
+        let master_compatibility =
+            ProtoUtils::compatibility_to_pb(&master_version, &compatibility_policy);
         Self {
             fs,
             retry_cache,
@@ -86,6 +96,7 @@ impl MasterHandler {
             replication_handler: Some(MasterReplicationHandler::new(replication_manager)),
             actor_rt,
             master_compatibility,
+            compatibility_policy,
         }
     }
 
@@ -470,7 +481,17 @@ impl MasterHandler {
     }
 
     async fn async_get_filesystem_info(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
-        let _: GetFilesystemInfoRequest = ctx.parse_header()?;
+        let req: GetFilesystemInfoRequest = ctx.parse_header()?;
+        // Enforce the master compatibility policy against the client's
+        // structured version report (handshake). Legacy clients that do not
+        // send component_info produce a MissingInfo verdict: allowed in
+        // diagnose mode, rejected in enforce mode.
+        Self::check_peer_compatibility(
+            "client",
+            self.compatibility_policy.mode,
+            self.compatibility_policy
+                .check_client(req.component_info.as_ref()),
+        )?;
         let fs = self.fs.clone();
         let info = Self::run_master_rpc_task(self.control_rpc_executor.clone(), move || {
             Self::process_get_filesystem_info(fs)
@@ -565,11 +586,48 @@ impl MasterHandler {
 
     pub fn worker_heartbeat(&self, ctx: &mut RpcContext<'_>) -> FsResult<Message> {
         let header: WorkerHeartbeatRequest = ctx.parse_header()?;
+        // Enforce the master compatibility policy against the worker's
+        // structured version report. Diagnose mode records a warning and
+        // allows the heartbeat (legacy workers without component_info stay
+        // compatible); enforce mode rejects incompatible workers with an
+        // explicit error.
+        Self::check_peer_compatibility(
+            "worker",
+            self.compatibility_policy.mode,
+            self.compatibility_policy
+                .check_worker(header.component_info.as_ref()),
+        )?;
         let cmds = Self::process_worker_heartbeat(self.fs.clone(), header)?;
         let rep_header = WorkerHeartbeatResponse {
             cmds: ProtoUtils::worker_cmd_to_pb(cmds),
         };
         ctx.response(rep_header)
+    }
+
+    /// Evaluate a compatibility verdict against the configured mode.
+    ///
+    /// - `diagnose` (default): log a warning for non-compatible peers and
+    ///   allow the request, so old components are never rejected without
+    ///   explicit configuration.
+    /// - `enforce`: reject with an explicit error describing the actual peer
+    ///   version, the expected bound and the upgrade suggestion.
+    fn check_peer_compatibility(
+        peer: &str,
+        mode: CompatibilityMode,
+        verdict: CompatibilityVerdict,
+    ) -> FsResult<()> {
+        if !verdict.rejects(mode) {
+            if !verdict.is_compatible() {
+                log::warn!("{} compatibility: {}", peer, verdict.describe());
+            }
+            return Ok(());
+        }
+        err_box!(
+            "{} rejected by compatibility policy: {}; upgrade the {} or set master.compatibility.mode = \"diagnose\" to allow it",
+            peer,
+            verdict.describe(),
+            peer
+        )
     }
 
     fn process_worker_heartbeat(
@@ -1122,5 +1180,87 @@ mod tests {
             CompatibilityModeProto::Diagnose as i32
         );
         assert!(compat.blocked_versions.is_empty());
+    }
+
+    #[test]
+    fn diagnose_mode_allows_incompatible_worker_heartbeat() {
+        // Default policy is diagnose: an incompatible worker is warned about
+        // but not rejected, and a legacy worker without component_info is
+        // allowed.
+        let policy = CompatibilityPolicy::default();
+        let incompatible = ComponentInfoProto {
+            release_version: Some("0.1.0".to_string()),
+            protocol_version: Some(1),
+            ..sample_component_info()
+        };
+        let verdict = policy.check_worker(Some(&incompatible));
+        assert!(MasterHandler::check_peer_compatibility("worker", policy.mode, verdict).is_ok());
+
+        // Legacy worker (no component_info): MissingInfo, allowed in diagnose.
+        let verdict = policy.check_worker(None);
+        assert!(MasterHandler::check_peer_compatibility("worker", policy.mode, verdict).is_ok());
+    }
+
+    #[test]
+    fn enforce_mode_rejects_incompatible_worker_heartbeat() {
+        let policy = CompatibilityPolicy {
+            mode: CompatibilityMode::Enforce,
+            min_worker_version: Some("0.2.0".parse().unwrap()),
+            ..Default::default()
+        };
+        let incompatible = ComponentInfoProto {
+            release_version: Some("0.1.0".to_string()),
+            protocol_version: Some(1),
+            ..sample_component_info()
+        };
+        let verdict = policy.check_worker(Some(&incompatible));
+        let err =
+            MasterHandler::check_peer_compatibility("worker", policy.mode, verdict).unwrap_err();
+        let msg = format!("{}", err);
+        assert!(msg.contains("rejected by compatibility policy"), "{msg}");
+        assert!(msg.contains("0.1.0"), "{msg}");
+    }
+
+    #[test]
+    fn enforce_mode_rejects_legacy_client_without_component_info() {
+        let policy = CompatibilityPolicy {
+            mode: CompatibilityMode::Enforce,
+            ..Default::default()
+        };
+        let verdict = policy.check_client(None);
+        let err =
+            MasterHandler::check_peer_compatibility("client", policy.mode, verdict).unwrap_err();
+        assert!(format!("{}", err).contains("client rejected"));
+    }
+
+    #[test]
+    fn compatibility_to_pb_reflects_policy() {
+        let policy = CompatibilityPolicy {
+            mode: CompatibilityMode::Enforce,
+            min_worker_version: Some("0.2.0".parse().unwrap()),
+            blocked_versions: vec!["0.2.5".parse().unwrap()],
+            ..Default::default()
+        };
+        let master_version = curvine_sys::version::component_version("master");
+        let pb = ProtoUtils::compatibility_to_pb(&master_version, &policy);
+        assert_eq!(
+            pb.compatibility_mode,
+            CompatibilityModeProto::Enforce as i32
+        );
+        assert_eq!(pb.min_worker_version.as_deref(), Some("0.2.0"));
+        assert_eq!(pb.blocked_versions, vec!["0.2.5".to_string()]);
+    }
+
+    fn sample_component_info() -> ComponentInfoProto {
+        ComponentInfoProto {
+            component: Some("worker".to_string()),
+            release_version: Some("0.4.0-alpha".to_string()),
+            git_commit: Some("24c848719b5b4fea74519d91cbe462bb49761b36".to_string()),
+            git_tag: Some("v0.4.0-alpha".to_string()),
+            git_branch: Some("main".to_string()),
+            protocol_version: Some(1),
+            min_protocol_version: Some(1),
+            capabilities: vec!["transfer".to_string()],
+        }
     }
 }

--- a/etc/curvine-cluster.toml
+++ b/etc/curvine-cluster.toml
@@ -41,6 +41,12 @@ log = { level = "info", log_dir = "stdout", file_name = "master.log" }
 # mode: "diagnose" (default, allow with warnings) or "enforce" (reject
 # incompatible workers/clients). Bounds below are empty by default, meaning
 # old components are never rejected without explicit configuration.
+#
+# NOTE: enforce mode requires workers that report component_info on their
+# heartbeat (available since #1584). Workers built before #1584 do not send
+# component_info, so every heartbeat resolves to MissingInfo and enforce mode
+# rejects them - the cluster cannot form. Keep diagnose until the whole
+# worker fleet is upgraded.
 # [master.compatibility]
 # mode = "diagnose"
 # min_worker_version = "0.1.0"
@@ -67,11 +73,6 @@ data_dir = [
     "[DISK]testing/data",
 ]
 log = { level = "info", log_dir = "stdout", file_name = "worker.log" }
-
-# Version compatibility policy (used for client-worker data plane checks).
-# [worker.compatibility]
-# mode = "diagnose"
-# min_client_version = "0.1.0"
 
 # SPDK over NVMe-oF/RDMA configuration  
 [worker.spdk_disk]  

--- a/etc/curvine-cluster.toml
+++ b/etc/curvine-cluster.toml
@@ -37,6 +37,16 @@ meta_dir = "testing/meta"
 # worker_policy = "weighted"
 log = { level = "info", log_dir = "stdout", file_name = "master.log" }
 
+# Version compatibility policy.
+# mode: "diagnose" (default, allow with warnings) or "enforce" (reject
+# incompatible workers/clients). Bounds below are empty by default, meaning
+# old components are never rejected without explicit configuration.
+# [master.compatibility]
+# mode = "diagnose"
+# min_worker_version = "0.1.0"
+# min_client_version = "0.1.0"
+# blocked_versions = ["0.2.5"]
+
 
 # masta ha raft configuration.
 [journal]
@@ -57,6 +67,11 @@ data_dir = [
     "[DISK]testing/data",
 ]
 log = { level = "info", log_dir = "stdout", file_name = "worker.log" }
+
+# Version compatibility policy (used for client-worker data plane checks).
+# [worker.compatibility]
+# mode = "diagnose"
+# min_client_version = "0.1.0"
 
 # SPDK over NVMe-oF/RDMA configuration  
 [worker.spdk_disk]  


### PR DESCRIPTION
# Summary

Adds the component version compatibility checker with a `diagnose`/`enforce` strategy. A new `CompatibilityPolicy` in `curvine-model` evaluates a peer's structured version report (`ComponentInfoProto`) against the server contract by protocol version range, release version bounds, capabilities and `blocked_versions`. Both master and worker gain a `[*.compatibility]` config section; the master derives its advertised compatibility contract from the configured policy and enforces it on worker heartbeats and the `GetFilesystemInfo` client handshake. The default mode is lenient `diagnose` with no bounds, so old components are never rejected without explicit configuration.

# Issue Describe / Design

Closes #1527 (sub-task: compatibility checker and diagnose/enforce strategy)

- The version-management design (§5.3) defines the compatibility rules: `server.min_protocol_version <= peer.protocol_version <= server.protocol_version`, role-specific minimum release versions (`min_worker_version` / `min_client_version`), feature gating where a capability is enabled only when both peers declare it, and `blocked_versions` as an explicit ops emergency backstop.
- This change implements the checker as `curvine_model::CompatibilityPolicy` / `CompatibilityVerdict`. A verdict is `Compatible`, `MissingInfo` (legacy peer without structured info), `Blocked`, `ProtocolMismatch` or `VersionTooOld`; `rejects(mode)` only rejects blocked versions unconditionally, and rejects everything else only in `enforce` mode.
- Config: new `[master.compatibility]` / `[worker.compatibility]` sections (`mode`, `min_worker_version`, `min_client_version`, `blocked_versions`). Defaults are `mode = "diagnose"` with no bounds, so the acceptance criterion "无显式配置时不拒绝旧组件" (no explicit config → old components are not rejected) holds by construction.
- Master wiring: `MasterHandler` builds the policy from config, advertises it via `ServerCompatibilityInfoProto` (replacing the hardcoded diagnose default), and checks worker heartbeats and the client handshake. `diagnose` logs a warning and allows; `enforce` rejects with an explicit message including the actual peer version, the expected bound and an upgrade suggestion.
- Compatibility: all new fields/sections are optional with lenient defaults; legacy workers/clients without `component_info` map to `MissingInfo`, which `diagnose` allows. No wire format or business field numbers change.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `crates/common/curvine-model/src/compatibility.rs` | New: `CompatibilityMode`, `CompatibilityPolicy`, `CompatibilityVerdict`, `feature_enabled` capability helper | None |
| `crates/common/curvine-model/src/lib.rs` | Export the compatibility module | None |
| `crates/common/curvine-model/src/proto_utils.rs` | Add `compatibility_to_pb` building the advertised contract from a policy | None |
| `crates/common/curvine-config/src/compatibility_conf.rs` | New: `CompatibilityConf` with lenient defaults and `to_policy()` | None |
| `crates/common/curvine-config/src/master_conf.rs` / `worker_conf.rs` | Add `compatibility` section to `MasterConf` / `WorkerConf` | None (defaults to lenient diagnose) |
| `curvine-master/src/master/master_handler.rs` | Build policy from config; enforce on worker heartbeat + `GetFilesystemInfo` handshake; advertise policy contract | Behavior change only when `mode = "enforce"` is explicitly configured |
| `etc/curvine-cluster.toml` | Document `[master.compatibility]` / `[worker.compatibility]` sections | None |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-model` | PASS | incl. compatible / incompatible protocol / too-old version / missing info / blocked version / capability / mode parsing |
| `cargo test -p curvine-config` | PASS | incl. `CompatibilityConf` defaults, explicit bounds, invalid-input leniency |
| `cargo test -p curvine-master` | PASS | incl. diagnose allows incompatible worker + legacy client; enforce rejects with explicit error; advertised contract reflects policy |
| `cargo check --workspace` | PASS | full workspace builds |
| `make format` | PASS | clippy `--deny warnings` + `cargo fmt` |

# Dependencies

- Related PRs: #1580 (ComponentInfoProto / ServerCompatibilityInfoProto), #1581 (GetFilesystemInfo handshake fields), #1582 (client-master handshake), #1584 (worker-master structured version reporting)
- Related issues: #1527
- Blocks / blocked by: None
