### PR TITLE
feat(worker): accept component info on data plane (#1527)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2897,6 +2897,7 @@ dependencies = [
  "log",
  "once_cell",
  "parking_lot",
+ "prost 0.11.9",
  "serde_json",
  "tokio",
 ]

--- a/crates/client/curvine-client-core/src/block/block_client.rs
+++ b/crates/client/curvine-client-core/src/block/block_client.rs
@@ -432,11 +432,14 @@ impl BlockClient {
             })
             .collect();
 
+        // Running frame: carries the file contents in the header, so it must
+        // stay lean — `component_info` is attached on the batch open/commit
+        // frames only, and the worker caches peer metadata from those.
         let header = FilesBatchWriteRequest {
             files: file_data,
             req_id,
             seq_id,
-            component_info: Some(self.component_info.clone()),
+            component_info: None,
         };
 
         let msg = Builder::new()

--- a/crates/client/curvine-client-core/src/block/block_client.rs
+++ b/crates/client/curvine-client-core/src/block/block_client.rs
@@ -30,8 +30,8 @@ use curvine_model::ProtoUtils;
 use curvine_model::{ExtendedBlock, StorageType, WorkerAddress};
 use curvine_proto::{
     BlockReadRequest, BlockReadResponse, BlockWriteRequest, BlockWriteResponse,
-    BlocksBatchCommitRequest, BlocksBatchWriteRequest, BlocksBatchWriteResponse, DataHeaderProto,
-    FileWriteData, FilesBatchWriteRequest,
+    BlocksBatchCommitRequest, BlocksBatchWriteRequest, BlocksBatchWriteResponse,
+    ComponentInfoProto, DataHeaderProto, FileWriteData, FilesBatchWriteRequest,
 };
 use curvine_rpc::client::RpcClient;
 use curvine_rpc::message::{Builder, Message, RequestStatus};
@@ -46,6 +46,11 @@ pub struct BlockClient {
     pool: Option<Arc<BlockClientPool>>,
     worker_addr: WorkerAddress,
     uptime: u64,
+    /// This client's structured component version, attached to data-plane
+    /// requests on the reserved 1000+ range so workers can identify the peer
+    /// per connection. Constant for the process, built once per client and
+    /// cloned into each request. Legacy workers ignore the unknown field.
+    component_info: ComponentInfoProto,
 }
 
 impl BlockClient {
@@ -57,6 +62,9 @@ impl BlockClient {
             pool: None,
             worker_addr,
             uptime: LocalTime::mills(),
+            component_info: ProtoUtils::component_version_to_pb(
+                &curvine_sys::version::component_version("client"),
+            ),
         }
     }
 
@@ -129,6 +137,7 @@ impl BlockClient {
             client_name: self.client_name.to_string(),
             chunk_size,
             pipeline_stream,
+            component_info: Some(self.component_info.clone()),
         };
 
         let msg = Builder::new()
@@ -209,6 +218,7 @@ impl BlockClient {
             off,
             block_size,
             client_name: self.client_name.to_string(),
+            component_info: Some(self.component_info.clone()),
             ..Default::default()
         };
 
@@ -250,6 +260,7 @@ impl BlockClient {
             enable_read_ahead: conf.enable_read_ahead,
             read_ahead_len: conf.read_ahead_len,
             drop_cache_len: conf.drop_cache_len,
+            component_info: Some(self.component_info.clone()),
         };
 
         let msg = Builder::new()
@@ -274,6 +285,7 @@ impl BlockClient {
     ) -> FsResult<()> {
         let request = BlockReadRequest {
             id: block.id,
+            component_info: Some(self.component_info.clone()),
             ..Default::default()
         };
 
@@ -334,6 +346,7 @@ impl BlockClient {
             chunk_size,
             short_circuit,
             client_name: self.client_name.to_string(),
+            component_info: Some(self.component_info.clone()),
         };
 
         let msg = Builder::new()
@@ -384,6 +397,7 @@ impl BlockClient {
             req_id,
             seq_id,
             cancel,
+            component_info: Some(self.component_info.clone()),
         };
 
         let status = if cancel {
@@ -422,6 +436,7 @@ impl BlockClient {
             files: file_data,
             req_id,
             seq_id,
+            component_info: Some(self.component_info.clone()),
         };
 
         let msg = Builder::new()
@@ -448,6 +463,7 @@ impl Drop for BlockClient {
                     pool: Some(pool.clone()),
                     worker_addr: std::mem::take(&mut self.worker_addr),
                     uptime: self.uptime,
+                    component_info: std::mem::take(&mut self.component_info),
                 };
 
                 pool.release(client);

--- a/crates/common/curvine-proto/proto/worker.proto
+++ b/crates/common/curvine-proto/proto/worker.proto
@@ -17,6 +17,12 @@ message BlockWriteRequest {
     required string client_name = 5 [default = ""];
     required int32 chunk_size = 6;
     repeated WorkerAddressProto pipeline_stream = 7;
+
+    // Structured version/protocol metadata reported by the client on the
+    // reserved 1000+ cross-cutting range. Legacy clients omit this field;
+    // workers treat absence as a legacy/unknown peer and ignore it, so
+    // mixed-version clusters keep working untouched.
+    optional ComponentInfoProto component_info = 1000;
 }
 
 message PipelineStatus {
@@ -44,6 +50,12 @@ message BlockReadRequest {
     required bool enable_read_ahead = 8 [default = true];
     required int64 read_ahead_len = 9 [default = 4194304];
     required int64 drop_cache_len = 10 [default = 1048576];
+
+    // Structured version/protocol metadata reported by the client on the
+    // reserved 1000+ cross-cutting range. Legacy clients omit this field;
+    // workers treat absence as a legacy/unknown peer and ignore it, so
+    // mixed-version clusters keep working untouched.
+    optional ComponentInfoProto component_info = 1000;
 }
 
 message BlockReadResponse {
@@ -157,6 +169,12 @@ message BlocksBatchWriteRequest {
     required int32 chunk_size = 6;
     required bool short_circuit = 7;
     required string client_name = 8;
+
+    // Structured version/protocol metadata reported by the client on the
+    // reserved 1000+ cross-cutting range. Legacy clients omit this field;
+    // workers treat absence as a legacy/unknown peer and ignore it, so
+    // mixed-version clusters keep working untouched.
+    optional ComponentInfoProto component_info = 1000;
 }
 
 
@@ -172,6 +190,12 @@ message BlocksBatchCommitRequest {
     required int64 req_id = 4;
     required int32 seq_id = 5;
     required bool cancel = 6;
+
+    // Structured version/protocol metadata reported by the client on the
+    // reserved 1000+ cross-cutting range. Legacy clients omit this field;
+    // workers treat absence as a legacy/unknown peer and ignore it, so
+    // mixed-version clusters keep working untouched.
+    optional ComponentInfoProto component_info = 1000;
 }
 
 message BlocksBatchCommitResponse {
@@ -182,6 +206,12 @@ message FilesBatchWriteRequest {
     repeated FileWriteData files = 1;
     required int64 req_id = 2;
     required int32 seq_id = 3;
+
+    // Structured version/protocol metadata reported by the client on the
+    // reserved 1000+ cross-cutting range. Legacy clients omit this field;
+    // workers treat absence as a legacy/unknown peer and ignore it, so
+    // mixed-version clusters keep working untouched.
+    optional ComponentInfoProto component_info = 1000;
 }
 
 message FileWriteData {

--- a/crates/common/curvine-proto/tests/proto_pipeline_test.rs
+++ b/crates/common/curvine-proto/tests/proto_pipeline_test.rs
@@ -34,6 +34,7 @@ fn test_block_write_request_round_trip_without_pipeline_stream() {
         client_name: "test-client".to_string(),
         chunk_size: 1024 * 1024,
         pipeline_stream: vec![],
+        component_info: None,
     };
 
     let encoded = request.encode_to_vec();
@@ -60,6 +61,7 @@ fn test_block_write_request_round_trip_with_pipeline_stream() {
         client_name: "test-client".to_string(),
         chunk_size: 1024 * 1024,
         pipeline_stream: pipeline_stream.clone(),
+        component_info: None,
     };
 
     let encoded = request.encode_to_vec();
@@ -172,6 +174,7 @@ fn test_default_values() {
         client_name: String::new(),
         chunk_size: 0,
         pipeline_stream: vec![],
+        component_info: None,
     };
 
     let encoded = request.encode_to_vec();

--- a/crates/common/curvine-proto/tests/worker_dataplane_compat_test.rs
+++ b/crates/common/curvine-proto/tests/worker_dataplane_compat_test.rs
@@ -1,0 +1,428 @@
+use curvine_proto::{
+    BlockReadRequest, BlockWriteRequest, BlocksBatchCommitRequest, BlocksBatchWriteRequest,
+    ComponentInfoProto, ExtendedBlockProto, FileTypeProto, FileWriteData, FilesBatchWriteRequest,
+    StorageTypeProto,
+};
+use prost::Message;
+
+fn sample_component_info() -> ComponentInfoProto {
+    ComponentInfoProto {
+        component: Some("client".to_string()),
+        release_version: Some("0.4.0-alpha".to_string()),
+        git_commit: Some("359fce7d982a15f09c3b4e0b2e62fee4229609dd".to_string()),
+        git_tag: Some("v0.4.0-alpha".to_string()),
+        git_branch: Some("main".to_string()),
+        protocol_version: Some(1),
+        min_protocol_version: Some(1),
+        capabilities: vec!["short-circuit".to_string(), "batch-write".to_string()],
+    }
+}
+
+fn sample_block() -> ExtendedBlockProto {
+    ExtendedBlockProto {
+        id: 42,
+        block_size: 4 * 1024 * 1024,
+        storage_type: StorageTypeProto::Mem as i32,
+        file_type: FileTypeProto::File as i32,
+        alloc_opts: None,
+    }
+}
+
+/// Append a raw varint field (field number, wire type 0) to a wire buffer.
+fn push_varint(buf: &mut Vec<u8>, mut value: u64) {
+    loop {
+        let byte = (value & 0x7f) as u8;
+        value >>= 7;
+        if value == 0 {
+            buf.push(byte);
+            break;
+        }
+        buf.push(byte | 0x80);
+    }
+}
+
+/// Append a length-delimited field (wire type 2) to a wire buffer.
+fn push_len_delimited(buf: &mut Vec<u8>, field: u32, payload: &[u8]) {
+    push_varint(buf, ((field as u64) << 3) | 2);
+    push_varint(buf, payload.len() as u64);
+    buf.extend_from_slice(payload);
+}
+
+// ---------------------------------------------------------------------------
+// Legacy wire views: the exact messages a pre-change client actually sent,
+// with no component_info on the reserved 1000+ range. Decoding these through
+// the new types must leave component_info = None (old client + new worker).
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+struct LegacyBlockWriteRequest {
+    #[prost(message, required, tag = "1")]
+    block: ExtendedBlockProto,
+    #[prost(int64, required, tag = "2")]
+    off: i64,
+    #[prost(int64, required, tag = "3")]
+    block_size: i64,
+    #[prost(bool, required, tag = "4")]
+    short_circuit: bool,
+    #[prost(string, required, tag = "5")]
+    client_name: String,
+    #[prost(int32, required, tag = "6")]
+    chunk_size: i32,
+    #[prost(message, repeated, tag = "7")]
+    pipeline_stream: Vec<curvine_proto::WorkerAddressProto>,
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+struct LegacyBlockReadRequest {
+    #[prost(int64, required, tag = "1")]
+    id: i64,
+    #[prost(int64, required, tag = "2")]
+    off: i64,
+    #[prost(int64, required, tag = "3")]
+    len: i64,
+    #[prost(int32, required, tag = "4")]
+    chunk_size: i32,
+    #[prost(bool, required, tag = "5")]
+    short_circuit: bool,
+    #[prost(bool, required, tag = "8")]
+    enable_read_ahead: bool,
+    #[prost(int64, required, tag = "9")]
+    read_ahead_len: i64,
+    #[prost(int64, required, tag = "10")]
+    drop_cache_len: i64,
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+struct LegacyBlocksBatchWriteRequest {
+    #[prost(message, repeated, tag = "1")]
+    blocks: Vec<ExtendedBlockProto>,
+    #[prost(int64, required, tag = "2")]
+    off: i64,
+    #[prost(int64, required, tag = "3")]
+    block_size: i64,
+    #[prost(int64, required, tag = "4")]
+    req_id: i64,
+    #[prost(int32, required, tag = "5")]
+    seq_id: i32,
+    #[prost(int32, required, tag = "6")]
+    chunk_size: i32,
+    #[prost(bool, required, tag = "7")]
+    short_circuit: bool,
+    #[prost(string, required, tag = "8")]
+    client_name: String,
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+struct LegacyBlocksBatchCommitRequest {
+    #[prost(message, repeated, tag = "1")]
+    blocks: Vec<ExtendedBlockProto>,
+    #[prost(int64, required, tag = "2")]
+    off: i64,
+    #[prost(int64, required, tag = "3")]
+    block_size: i64,
+    #[prost(int64, required, tag = "4")]
+    req_id: i64,
+    #[prost(int32, required, tag = "5")]
+    seq_id: i32,
+    #[prost(bool, required, tag = "6")]
+    cancel: bool,
+}
+
+#[derive(Clone, PartialEq, ::prost::Message)]
+struct LegacyFilesBatchWriteRequest {
+    #[prost(message, repeated, tag = "1")]
+    files: Vec<FileWriteData>,
+    #[prost(int64, required, tag = "2")]
+    req_id: i64,
+    #[prost(int32, required, tag = "3")]
+    seq_id: i32,
+}
+
+#[test]
+fn test_block_write_component_info_round_trip() {
+    // New client -> new worker: component info survives the wire on the
+    // reserved 1000+ range of BlockWriteRequest.
+    let req = BlockWriteRequest {
+        block: sample_block(),
+        off: 0,
+        block_size: 4 * 1024 * 1024,
+        short_circuit: true,
+        client_name: "client-1".to_string(),
+        chunk_size: 1 << 20,
+        pipeline_stream: vec![],
+        component_info: Some(sample_component_info()),
+    };
+
+    let encoded = req.encode_to_vec();
+    let decoded = BlockWriteRequest::decode(encoded.as_slice()).unwrap();
+
+    let info = decoded.component_info.unwrap();
+    assert_eq!(info.component, Some("client".to_string()));
+    assert_eq!(info.release_version, Some("0.4.0-alpha".to_string()));
+    assert_eq!(info.protocol_version, Some(1));
+    assert_eq!(decoded.client_name, "client-1");
+    assert_eq!(decoded.block.id, 42);
+    assert_eq!(decoded.off, 0);
+    assert_eq!(decoded.block_size, 4 * 1024 * 1024);
+}
+
+#[test]
+fn test_block_read_component_info_round_trip() {
+    // New client -> new worker: component info survives the wire on the
+    // reserved 1000+ range of BlockReadRequest.
+    let req = BlockReadRequest {
+        id: 42,
+        off: 0,
+        len: 4096,
+        chunk_size: 1 << 20,
+        short_circuit: false,
+        enable_read_ahead: true,
+        read_ahead_len: 4 * 1024 * 1024,
+        drop_cache_len: 1 << 20,
+        component_info: Some(sample_component_info()),
+    };
+
+    let encoded = req.encode_to_vec();
+    let decoded = BlockReadRequest::decode(encoded.as_slice()).unwrap();
+
+    let info = decoded.component_info.unwrap();
+    assert_eq!(info.component, Some("client".to_string()));
+    assert_eq!(info.protocol_version, Some(1));
+    assert_eq!(decoded.id, 42);
+    assert_eq!(decoded.len, 4096);
+    assert!(decoded.enable_read_ahead);
+    assert_eq!(decoded.read_ahead_len, 4 * 1024 * 1024);
+}
+
+#[test]
+fn test_blocks_batch_write_component_info_round_trip() {
+    // New client -> new worker: component info survives on BlocksBatchWriteRequest.
+    let req = BlocksBatchWriteRequest {
+        blocks: vec![sample_block(), sample_block()],
+        off: 0,
+        block_size: 4 * 1024 * 1024,
+        req_id: 7,
+        seq_id: 1,
+        chunk_size: 1 << 20,
+        short_circuit: true,
+        client_name: "client-1".to_string(),
+        component_info: Some(sample_component_info()),
+    };
+
+    let encoded = req.encode_to_vec();
+    let decoded = BlocksBatchWriteRequest::decode(encoded.as_slice()).unwrap();
+
+    let info = decoded.component_info.unwrap();
+    assert_eq!(info.component, Some("client".to_string()));
+    assert_eq!(info.release_version, Some("0.4.0-alpha".to_string()));
+    assert_eq!(decoded.blocks.len(), 2);
+    assert_eq!(decoded.req_id, 7);
+    assert_eq!(decoded.client_name, "client-1");
+}
+
+#[test]
+fn test_blocks_batch_commit_component_info_round_trip() {
+    // New client -> new worker: component info survives on BlocksBatchCommitRequest.
+    let req = BlocksBatchCommitRequest {
+        blocks: vec![sample_block()],
+        off: 0,
+        block_size: 4 * 1024 * 1024,
+        req_id: 7,
+        seq_id: 1,
+        cancel: false,
+        component_info: Some(sample_component_info()),
+    };
+
+    let encoded = req.encode_to_vec();
+    let decoded = BlocksBatchCommitRequest::decode(encoded.as_slice()).unwrap();
+
+    let info = decoded.component_info.unwrap();
+    assert_eq!(info.component, Some("client".to_string()));
+    assert_eq!(info.min_protocol_version, Some(1));
+    assert_eq!(decoded.blocks.len(), 1);
+    assert_eq!(decoded.req_id, 7);
+    assert!(!decoded.cancel);
+}
+
+#[test]
+fn test_files_batch_write_component_info_round_trip() {
+    // New client -> new worker: component info survives on FilesBatchWriteRequest.
+    let req = FilesBatchWriteRequest {
+        files: vec![FileWriteData {
+            path: "/dir/a".to_string(),
+            content: b"hello".to_vec(),
+        }],
+        req_id: 7,
+        seq_id: 2,
+        component_info: Some(sample_component_info()),
+    };
+
+    let encoded = req.encode_to_vec();
+    let decoded = FilesBatchWriteRequest::decode(encoded.as_slice()).unwrap();
+
+    let info = decoded.component_info.unwrap();
+    assert_eq!(info.component, Some("client".to_string()));
+    assert_eq!(info.capabilities.len(), 2);
+    assert_eq!(decoded.files.len(), 1);
+    assert_eq!(decoded.files[0].path, "/dir/a");
+    assert_eq!(decoded.files[0].content, b"hello".to_vec());
+    assert_eq!(decoded.req_id, 7);
+    assert_eq!(decoded.seq_id, 2);
+}
+
+#[test]
+fn test_block_write_legacy_client_decodes() {
+    // Old client + new worker: a legacy BlockWriteRequest without
+    // component_info must decode; the worker treats absence as a
+    // legacy/unknown peer.
+    let legacy = LegacyBlockWriteRequest {
+        block: sample_block(),
+        off: 1024,
+        block_size: 4 * 1024 * 1024,
+        short_circuit: true,
+        client_name: "legacy-client".to_string(),
+        chunk_size: 1 << 20,
+        pipeline_stream: vec![],
+    };
+
+    let encoded = legacy.encode_to_vec();
+    let decoded = BlockWriteRequest::decode(encoded.as_slice()).unwrap();
+
+    assert!(decoded.component_info.is_none());
+    assert_eq!(decoded.block.id, 42);
+    assert_eq!(decoded.off, 1024);
+    assert_eq!(decoded.block_size, 4 * 1024 * 1024);
+    assert!(decoded.short_circuit);
+    assert_eq!(decoded.client_name, "legacy-client");
+    assert_eq!(decoded.chunk_size, 1 << 20);
+    assert!(decoded.pipeline_stream.is_empty());
+}
+
+#[test]
+fn test_block_read_legacy_client_decodes() {
+    // Old client + new worker: a legacy BlockReadRequest without
+    // component_info must decode.
+    let legacy = LegacyBlockReadRequest {
+        id: 42,
+        off: 0,
+        len: 4096,
+        chunk_size: 1 << 20,
+        short_circuit: false,
+        enable_read_ahead: true,
+        read_ahead_len: 4 * 1024 * 1024,
+        drop_cache_len: 1 << 20,
+    };
+
+    let encoded = legacy.encode_to_vec();
+    let decoded = BlockReadRequest::decode(encoded.as_slice()).unwrap();
+
+    assert!(decoded.component_info.is_none());
+    assert_eq!(decoded.id, 42);
+    assert_eq!(decoded.off, 0);
+    assert_eq!(decoded.len, 4096);
+    assert_eq!(decoded.chunk_size, 1 << 20);
+    assert!(!decoded.short_circuit);
+    assert!(decoded.enable_read_ahead);
+    assert_eq!(decoded.read_ahead_len, 4 * 1024 * 1024);
+    assert_eq!(decoded.drop_cache_len, 1 << 20);
+}
+
+#[test]
+fn test_blocks_batch_write_legacy_client_decodes() {
+    // Old client + new worker: a legacy BlocksBatchWriteRequest without
+    // component_info must decode.
+    let legacy = LegacyBlocksBatchWriteRequest {
+        blocks: vec![sample_block()],
+        off: 0,
+        block_size: 4 * 1024 * 1024,
+        req_id: 7,
+        seq_id: 1,
+        chunk_size: 1 << 20,
+        short_circuit: true,
+        client_name: "legacy-client".to_string(),
+    };
+
+    let encoded = legacy.encode_to_vec();
+    let decoded = BlocksBatchWriteRequest::decode(encoded.as_slice()).unwrap();
+
+    assert!(decoded.component_info.is_none());
+    assert_eq!(decoded.blocks.len(), 1);
+    assert_eq!(decoded.blocks[0].id, 42);
+    assert_eq!(decoded.req_id, 7);
+    assert_eq!(decoded.seq_id, 1);
+    assert!(decoded.short_circuit);
+    assert_eq!(decoded.client_name, "legacy-client");
+}
+
+#[test]
+fn test_blocks_batch_commit_legacy_client_decodes() {
+    // Old client + new worker: a legacy BlocksBatchCommitRequest without
+    // component_info must decode.
+    let legacy = LegacyBlocksBatchCommitRequest {
+        blocks: vec![sample_block()],
+        off: 0,
+        block_size: 4 * 1024 * 1024,
+        req_id: 7,
+        seq_id: 1,
+        cancel: false,
+    };
+
+    let encoded = legacy.encode_to_vec();
+    let decoded = BlocksBatchCommitRequest::decode(encoded.as_slice()).unwrap();
+
+    assert!(decoded.component_info.is_none());
+    assert_eq!(decoded.blocks.len(), 1);
+    assert_eq!(decoded.req_id, 7);
+    assert_eq!(decoded.seq_id, 1);
+    assert!(!decoded.cancel);
+}
+
+#[test]
+fn test_files_batch_write_legacy_client_decodes() {
+    // Old client + new worker: a legacy FilesBatchWriteRequest without
+    // component_info must decode.
+    let legacy = LegacyFilesBatchWriteRequest {
+        files: vec![FileWriteData {
+            path: "/dir/a".to_string(),
+            content: b"hello".to_vec(),
+        }],
+        req_id: 7,
+        seq_id: 2,
+    };
+
+    let encoded = legacy.encode_to_vec();
+    let decoded = FilesBatchWriteRequest::decode(encoded.as_slice()).unwrap();
+
+    assert!(decoded.component_info.is_none());
+    assert_eq!(decoded.files.len(), 1);
+    assert_eq!(decoded.files[0].path, "/dir/a");
+    assert_eq!(decoded.files[0].content, b"hello".to_vec());
+    assert_eq!(decoded.req_id, 7);
+    assert_eq!(decoded.seq_id, 2);
+}
+
+#[test]
+fn test_dataplane_unknown_high_fields_are_skipped() {
+    // Forward compatibility: a peer that sends fields this build does not
+    // know about (e.g. a later reserved-range field beyond 1000) must be
+    // decoded and those fields silently skipped — the same mechanism legacy
+    // components rely on to ignore our new component_info field.
+    let req = BlockWriteRequest {
+        block: sample_block(),
+        off: 0,
+        block_size: 4 * 1024 * 1024,
+        short_circuit: true,
+        client_name: "client-1".to_string(),
+        chunk_size: 1 << 20,
+        pipeline_stream: vec![],
+        component_info: Some(sample_component_info()),
+    };
+
+    let mut encoded = req.encode_to_vec();
+    // Append an unknown length-delimited field 1001 (wire type 2).
+    push_len_delimited(&mut encoded, 1001, b"future-metadata");
+
+    let decoded = BlockWriteRequest::decode(encoded.as_slice()).unwrap();
+    assert_eq!(decoded.component_info, req.component_info);
+    assert_eq!(decoded.client_name, "client-1");
+}

--- a/curvine-server/tests/spdk_stress_test.rs
+++ b/curvine-server/tests/spdk_stress_test.rs
@@ -92,6 +92,7 @@ fn write_block(
         client_name: "stress".into(),
         chunk_size,
         pipeline_stream: vec![],
+        component_info: None,
     };
 
     let client = conf.worker_sync_client()?;
@@ -137,6 +138,7 @@ fn write_block(
         client_name: "stress".into(),
         chunk_size,
         pipeline_stream: vec![],
+        component_info: None,
     };
 
     let msg = Builder::new()

--- a/curvine-server/tests/spdk_worker_test.rs
+++ b/curvine-server/tests/spdk_worker_test.rs
@@ -74,6 +74,7 @@ fn spdk_block_write(id: i64, conf: &ClusterConf) -> CommonResult<u64> {
         client_name: "spdk-test".to_string(),
         chunk_size: CHUNK_SIZE,
         pipeline_stream: Vec::new(),
+        component_info: None,
     };
 
     let req_id = Utils::req_id();
@@ -124,6 +125,7 @@ fn spdk_block_write(id: i64, conf: &ClusterConf) -> CommonResult<u64> {
         client_name: "spdk-test".to_string(),
         chunk_size: CHUNK_SIZE,
         pipeline_stream: Vec::new(),
+        component_info: None,
     };
     let msg = Builder::new()
         .code(RpcCode::WriteBlock)

--- a/curvine-server/tests/worker_test.rs
+++ b/curvine-server/tests/worker_test.rs
@@ -131,6 +131,7 @@ fn test_worker_complete_oversized_block_aborts_pending_block() -> CommonResult<(
         client_name: "test".to_string(),
         chunk_size: CHUNK_SIZE,
         pipeline_stream: Vec::new(),
+        component_info: None,
     };
     let req_id = Utils::req_id();
 
@@ -204,6 +205,7 @@ fn test_worker_batch_short_circuit_complete_uses_open_context_without_server_fil
         chunk_size: CHUNK_SIZE,
         short_circuit: true,
         client_name: "test".to_string(),
+        component_info: None,
     };
     let open_msg = Builder::new()
         .code(RpcCode::WriteBlocksBatch)
@@ -230,6 +232,7 @@ fn test_worker_batch_short_circuit_complete_uses_open_context_without_server_fil
         req_id: open_req_id,
         seq_id: 1,
         cancel: false,
+        component_info: None,
     };
     let complete_msg = Builder::new()
         .code(RpcCode::WriteBlocksBatch)
@@ -268,6 +271,7 @@ fn test_worker_batch_short_circuit_complete_requires_open_connection() -> Common
         chunk_size: CHUNK_SIZE,
         short_circuit: true,
         client_name: "test".to_string(),
+        component_info: None,
     };
     let open_msg = Builder::new()
         .code(RpcCode::WriteBlocksBatch)
@@ -289,6 +293,7 @@ fn test_worker_batch_short_circuit_complete_requires_open_connection() -> Common
         req_id,
         seq_id: 1,
         cancel: false,
+        component_info: None,
     };
     let complete_msg = Builder::new()
         .code(RpcCode::WriteBlocksBatch)
@@ -326,6 +331,7 @@ fn test_worker_batch_remote_write_complete_and_read_back() -> CommonResult<()> {
         chunk_size: CHUNK_SIZE,
         short_circuit: false,
         client_name: "test".to_string(),
+        component_info: None,
     };
     let open_msg = Builder::new()
         .code(RpcCode::WriteBlocksBatch)
@@ -347,6 +353,7 @@ fn test_worker_batch_remote_write_complete_and_read_back() -> CommonResult<()> {
             .collect(),
         req_id,
         seq_id: 1,
+        component_info: None,
     };
     let write_msg = Builder::new()
         .code(RpcCode::WriteBlocksBatch)
@@ -400,6 +407,7 @@ fn test_worker_batch_remote_write_complete_and_read_back() -> CommonResult<()> {
         req_id,
         seq_id: 4,
         cancel: false,
+        component_info: None,
     };
     let complete_msg = Builder::new()
         .code(RpcCode::WriteBlocksBatch)
@@ -497,6 +505,7 @@ fn test_worker_fault_http_control_plane_e2e() -> CommonResult<()> {
         client_name: "fault-http-test".to_string(),
         chunk_size: CHUNK_SIZE,
         pipeline_stream: Vec::new(),
+        component_info: None,
     };
     let open = Builder::new()
         .code(RpcCode::WriteBlock)
@@ -546,6 +555,7 @@ fn block_write(id: i64, conf: &ClusterConf) -> CommonResult<u64> {
         client_name: "test".to_string(),
         chunk_size: CHUNK_SIZE,
         pipeline_stream: Vec::new(),
+        component_info: None,
     };
 
     let req_id = Utils::req_id();
@@ -612,6 +622,7 @@ fn test_worker_short_circuit_open_resizes_block_file() -> CommonResult<()> {
         client_name: "test".to_string(),
         chunk_size: CHUNK_SIZE,
         pipeline_stream: Vec::new(),
+        component_info: None,
     };
 
     let req_id = Utils::req_id();
@@ -645,6 +656,7 @@ fn test_worker_short_circuit_open_resizes_block_file() -> CommonResult<()> {
         client_name: "test".to_string(),
         chunk_size: CHUNK_SIZE,
         pipeline_stream: Vec::new(),
+        component_info: None,
     };
     let complete_msg = Builder::new()
         .code(RpcCode::WriteBlock)

--- a/curvine-worker/Cargo.toml
+++ b/curvine-worker/Cargo.toml
@@ -49,3 +49,6 @@ axum = { workspace = true }
 parking_lot = { workspace = true }
 bytes = { workspace = true }
 serde_json = { workspace = true }
+
+[dev-dependencies]
+prost = { workspace = true }

--- a/curvine-worker/src/worker/handler/batch_write_handler.rs
+++ b/curvine-worker/src/worker/handler/batch_write_handler.rs
@@ -83,8 +83,10 @@ impl BatchWriteHandler {
             let unique_req_id = msg.req_id() + i as i64;
             // Create a single BlockWriteRequest from the block; propagate the
             // client's component_info so the per-block open carries the same
-            // peer metadata as the outer batch frame.
-            let header = BlockWriteRequest {
+            // peer metadata as the outer batch frame. Named `block_header` (not
+            // `header`) so it cannot be confused with the outer
+            // BlocksBatchWriteRequest.
+            let block_header = BlockWriteRequest {
                 block: block_proto,
                 off: header.off,
                 block_size: header.block_size,
@@ -101,7 +103,7 @@ impl BatchWriteHandler {
                 .request(RequestStatus::Open)
                 .req_id(unique_req_id)
                 .seq_id(msg.seq_id())
-                .proto_header(header)
+                .proto_header(block_header)
                 .build();
 
             let response = match self.write_handler.open(&single_msg_req) {

--- a/curvine-worker/src/worker/handler/batch_write_handler.rs
+++ b/curvine-worker/src/worker/handler/batch_write_handler.rs
@@ -81,7 +81,9 @@ impl BatchWriteHandler {
 
         for (i, block_proto) in header.blocks.iter().cloned().enumerate() {
             let unique_req_id = msg.req_id() + i as i64;
-            // Create a single BlockWriteRequest from the block
+            // Create a single BlockWriteRequest from the block; propagate the
+            // client's component_info so the per-block open carries the same
+            // peer metadata as the outer batch frame.
             let header = BlockWriteRequest {
                 block: block_proto,
                 off: header.off,
@@ -90,6 +92,7 @@ impl BatchWriteHandler {
                 client_name: header.client_name.clone(),
                 chunk_size: header.chunk_size,
                 pipeline_stream: Vec::new(),
+                component_info: header.component_info.clone(),
             };
 
             // Create single request message for each block

--- a/curvine-worker/src/worker/handler/mod.rs
+++ b/curvine-worker/src/worker/handler/mod.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 mod worker_handler;
-pub use self::worker_handler::WorkerHandler;
+pub use self::worker_handler::{ConnectionPeer, WorkerHandler};
 
 mod write_handler;
 pub use self::write_handler::WriteHandler;

--- a/curvine-worker/src/worker/handler/worker_handler.rs
+++ b/curvine-worker/src/worker/handler/worker_handler.rs
@@ -134,9 +134,11 @@ impl WorkerHandler {
 
     /// Extract the optional `component_info` a client attached to a data-plane
     /// request, based on the RPC code / request status pair that determines the
-    /// wire message type. Running (data-carrying) frames use `DataHeaderProto`
-    /// and carry no component info; the client reports it on the open and
-    /// commit frames, so the first request on a connection carries it.
+    /// wire message type. The client reports `component_info` on the open and
+    /// commit frames only; running (data-carrying) frames use `DataHeaderProto`
+    /// or `FilesBatchWriteRequest` (whose header can embed large file contents)
+    /// and are deliberately skipped, so the hot path never decodes a large
+    /// header just to read peer metadata.
     fn extract_component_info(msg: &Message) -> Option<ComponentInfoProto> {
         match (RpcCode::from(msg.code()), msg.request_status()) {
             (
@@ -152,10 +154,6 @@ impl WorkerHandler {
                 .and_then(|req| req.component_info),
             (RpcCode::WriteBlocksBatch, RequestStatus::Open) => msg
                 .parse_header::<BlocksBatchWriteRequest>()
-                .ok()
-                .and_then(|req| req.component_info),
-            (RpcCode::WriteBlocksBatch, RequestStatus::Running) => msg
-                .parse_header::<FilesBatchWriteRequest>()
                 .ok()
                 .and_then(|req| req.component_info),
             (RpcCode::WriteBlocksBatch, RequestStatus::Complete | RequestStatus::Cancel) => msg
@@ -427,6 +425,10 @@ mod tests {
             Some(sample_component_info())
         );
 
+        // Running frames carry file contents in the header and are never
+        // parsed for peer metadata (peer cache is filled by open/commit
+        // frames); the client omits component_info here, so extraction must
+        // be None.
         let files_batch = FilesBatchWriteRequest {
             files: vec![FileWriteData {
                 path: "/dir/a".to_string(),
@@ -434,17 +436,14 @@ mod tests {
             }],
             req_id: 7,
             seq_id: 2,
-            component_info: Some(sample_component_info()),
+            component_info: None,
         };
         let running = build_msg(
             RpcCode::WriteBlocksBatch,
             RequestStatus::Running,
             files_batch,
         );
-        assert_eq!(
-            WorkerHandler::extract_component_info(&running),
-            Some(sample_component_info())
-        );
+        assert_eq!(WorkerHandler::extract_component_info(&running), None);
 
         let batch_commit = BlocksBatchCommitRequest {
             blocks: vec![sample_block()],

--- a/curvine-worker/src/worker/handler/worker_handler.rs
+++ b/curvine-worker/src/worker/handler/worker_handler.rs
@@ -27,8 +27,21 @@ use curvine_rpc::message::{Builder, Message, RequestStatus, ResponseStatus};
 use curvine_runtime::common::SerdeUtils;
 use curvine_runtime::runtime::Runtime;
 use curvine_runtime::sync::FastMutex;
-use log::{info, warn};
+use log::info;
 use std::sync::Arc;
+
+/// Connection-level peer metadata for a data connection, resolved exactly once
+/// from the first data-plane open frame.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ConnectionPeer {
+    /// No data-plane open frame inspected yet.
+    Unknown,
+    /// The client never reported component info (legacy/unknown peer).
+    Legacy,
+    /// The client's structured component info, recorded from the first
+    /// data-plane open frame that carried it.
+    Known(ComponentInfoProto),
+}
 
 pub struct WorkerHandler {
     pub store: BlockStore,
@@ -36,13 +49,14 @@ pub struct WorkerHandler {
     pub task_manager: Arc<TaskManager>,
     pub rt: Arc<Runtime>,
     pub replication_handler: WorkerReplicationHandler,
-    /// Connection-level peer metadata: the `component_info` the client on this
-    /// connection reported on the reserved 1000+ range of the first data-plane
-    /// request that carried it. `None` means a legacy client that never
-    /// reported component info. The worker only records the version here (T9);
+    /// Connection-level peer metadata, resolved once from the first data-plane
+    /// open frame on this connection. After resolution (Known or Legacy) the
+    /// worker stops parsing headers for peer metadata, so at most one frame
+    /// per connection pays the decode cost — the business handlers decode the
+    /// same headers anyway. The worker only records the version here (T9);
     /// protocol negotiation on top of it happens in the client-worker
     /// compatibility layer (T10).
-    pub peer_component_info: FastMutex<Option<ComponentInfoProto>>,
+    pub connection_peer: FastMutex<ConnectionPeer>,
 }
 
 impl MessageHandler for WorkerHandler {
@@ -98,37 +112,36 @@ impl MessageHandler for WorkerHandler {
     }
 }
 
-/// Outcome of feeding a peer's `component_info` into the connection cache.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum PeerRecordEvent {
-    /// The first component info seen on this connection.
-    First,
-    /// A different component info than the cached one (mid-connection
-    /// peer change, unexpected with connection reuse).
-    Changed,
-    /// The cached info already matches; nothing to do.
-    Unchanged,
-}
-
 impl WorkerHandler {
-    /// Pure connection-cache update: store `info` into `peer` and report
-    /// whether a log-worthy event occurred. Kept separate from the logging so
-    /// the connection-level peer cache behavior can be unit-tested without a
-    /// full `WorkerHandler`.
-    fn record_peer_component_info_state(
-        peer: &mut Option<ComponentInfoProto>,
-        info: ComponentInfoProto,
-    ) -> PeerRecordEvent {
-        match peer.as_ref() {
-            None => {
-                *peer = Some(info);
-                PeerRecordEvent::First
-            }
-            Some(existing) if existing != &info => {
-                *peer = Some(info);
-                PeerRecordEvent::Changed
-            }
-            _ => PeerRecordEvent::Unchanged,
+    /// Whether the RPC code belongs to the block data plane (the only codes
+    /// whose open frames carry peer metadata). Transfer/task control RPCs are
+    /// excluded so they never resolve the connection peer.
+    fn is_data_plane_code(code: RpcCode) -> bool {
+        matches!(
+            code,
+            RpcCode::WriteBlock | RpcCode::ReadBlock | RpcCode::WriteBlocksBatch
+        )
+    }
+
+    /// Decide the connection peer state for a frame, without mutating
+    /// anything. Returns `None` when the frame does not participate in peer
+    /// resolution (running/commit frames, non-data-plane RPCs); otherwise the
+    /// resolved state — `Known` when the open frame carried `component_info`,
+    /// `Legacy` when it did not. Pure, so the one-time resolution behavior is
+    /// unit-testable without a full `WorkerHandler`.
+    fn resolve_connection_peer(msg: &Message) -> Option<ConnectionPeer> {
+        // Resolution happens on the data-plane open frame only: it is the
+        // first frame a data connection carries and the only one guaranteed to
+        // report peer metadata. Running frames carry payload data and commit
+        // frames repeat metadata already seen on open, so they never resolve.
+        if msg.request_status() != RequestStatus::Open
+            || !Self::is_data_plane_code(RpcCode::from(msg.code()))
+        {
+            return None;
+        }
+        match Self::extract_component_info(msg) {
+            Some(info) => Some(ConnectionPeer::Known(info)),
+            None => Some(ConnectionPeer::Legacy),
         }
     }
 
@@ -164,43 +177,45 @@ impl WorkerHandler {
         }
     }
 
-    /// Record the client's `component_info` for this connection. The worker
-    /// only records the version (per the T9 contract): the first request that
-    /// carries it is logged and cached, a change mid-connection is warned and
-    /// re-recorded, and legacy clients that omit the field leave the cache
-    /// empty (treated as a legacy/unknown peer, never rejected).
+    /// Resolve and record the client's `component_info` for this connection.
+    /// Resolution happens exactly once, from the first data-plane open frame:
+    /// a new client carries `component_info` on it (`Known`), a legacy client
+    /// does not (`Legacy`). After resolution the worker never parses another
+    /// header for peer metadata, so at most one frame per connection pays the
+    /// decode cost (the business handlers decode the same headers anyway).
+    /// Legacy/unknown peers are never rejected.
     fn record_peer_component_info(&self, msg: &Message) {
-        let Some(info) = Self::extract_component_info(msg) else {
+        let mut peer = self.connection_peer.lock();
+        if !matches!(*peer, ConnectionPeer::Unknown) {
+            return;
+        }
+        let Some(resolved) = Self::resolve_connection_peer(msg) else {
             return;
         };
-        let mut peer = self.peer_component_info.lock();
-        match Self::record_peer_component_info_state(&mut peer, info) {
-            PeerRecordEvent::First => {
-                let cached = peer.as_ref().expect("peer cache just recorded");
+        match resolved {
+            ConnectionPeer::Known(info) => {
                 info!(
                     "peer component info on data connection: component={}, release_version={}, protocol_version={:?}, min_protocol_version={:?}",
-                    cached.component.as_deref().unwrap_or("unknown"),
-                    cached.release_version.as_deref().unwrap_or("unknown"),
-                    cached.protocol_version,
-                    cached.min_protocol_version,
+                    info.component.as_deref().unwrap_or("unknown"),
+                    info.release_version.as_deref().unwrap_or("unknown"),
+                    info.protocol_version,
+                    info.min_protocol_version,
                 );
+                *peer = ConnectionPeer::Known(info);
             }
-            PeerRecordEvent::Changed => {
-                let cached = peer.as_ref().expect("peer cache just re-recorded");
-                warn!(
-                    "peer component info changed on data connection: component={}, release_version={}",
-                    cached.component.as_deref().unwrap_or("unknown"),
-                    cached.release_version.as_deref().unwrap_or("unknown"),
-                );
-            }
-            PeerRecordEvent::Unchanged => {}
+            ConnectionPeer::Legacy => *peer = ConnectionPeer::Legacy,
+            ConnectionPeer::Unknown => unreachable!("resolution always yields Known or Legacy"),
         }
     }
 
     /// The component info recorded for the peer on this connection. `None`
-    /// means a legacy client that never reported component info on any request.
+    /// means the peer is unresolved or a legacy client that never reported
+    /// component info on any request.
     pub fn peer_component_info(&self) -> Option<ComponentInfoProto> {
-        self.peer_component_info.lock().clone()
+        match &*self.connection_peer.lock() {
+            ConnectionPeer::Known(info) => Some(info.clone()),
+            ConnectionPeer::Unknown | ConnectionPeer::Legacy => None,
+        }
     }
 
     fn get_handler<'a>(
@@ -314,7 +329,7 @@ fn transfer_task_state_code(state: curvine_model::JobTaskState) -> i32 {
 
 #[cfg(test)]
 mod tests {
-    use super::{BlockWriteRequest, PeerRecordEvent, WorkerHandler};
+    use super::{BlockWriteRequest, ConnectionPeer, WorkerHandler};
     use curvine_fs_api::RpcCode;
     use curvine_proto::{
         BlockReadRequest, BlocksBatchCommitRequest, BlocksBatchWriteRequest, ComponentInfoProto,
@@ -513,33 +528,126 @@ mod tests {
     }
 
     #[test]
-    fn peer_cache_records_first_change_and_keeps_unchanged() {
-        let mut peer = None;
-        let v1 = sample_component_info();
-
-        // First request on the connection records the peer version.
-        assert_eq!(
-            WorkerHandler::record_peer_component_info_state(&mut peer, v1.clone()),
-            PeerRecordEvent::First
-        );
-        assert_eq!(peer, Some(v1.clone()));
-
-        // Repeated requests with the same info are a no-op.
-        assert_eq!(
-            WorkerHandler::record_peer_component_info_state(&mut peer, v1.clone()),
-            PeerRecordEvent::Unchanged
-        );
-        assert_eq!(peer, Some(v1));
-
-        // A different peer version mid-connection is re-recorded.
-        let v2 = ComponentInfoProto {
-            release_version: Some("0.5.0".to_string()),
-            ..sample_component_info()
+    fn resolves_peer_from_data_plane_open_frames() {
+        // New client: the first write-block open frame carries component_info
+        // and resolves the connection peer to Known.
+        let header = BlockWriteRequest {
+            block: sample_block(),
+            off: 0,
+            block_size: 4 * 1024 * 1024,
+            short_circuit: true,
+            client_name: "client-1".to_string(),
+            chunk_size: 1 << 20,
+            pipeline_stream: vec![],
+            component_info: Some(sample_component_info()),
         };
+        let open = build_msg(RpcCode::WriteBlock, RequestStatus::Open, header);
         assert_eq!(
-            WorkerHandler::record_peer_component_info_state(&mut peer, v2.clone()),
-            PeerRecordEvent::Changed
+            WorkerHandler::resolve_connection_peer(&open),
+            Some(ConnectionPeer::Known(sample_component_info()))
         );
-        assert_eq!(peer, Some(v2));
+
+        // Batch open carries component_info too.
+        let batch_open = BlocksBatchWriteRequest {
+            blocks: vec![sample_block()],
+            off: 0,
+            block_size: 4 * 1024 * 1024,
+            req_id: 7,
+            seq_id: 1,
+            chunk_size: 1 << 20,
+            short_circuit: true,
+            client_name: "client-1".to_string(),
+            component_info: Some(sample_component_info()),
+        };
+        let open = build_msg(RpcCode::WriteBlocksBatch, RequestStatus::Open, batch_open);
+        assert_eq!(
+            WorkerHandler::resolve_connection_peer(&open),
+            Some(ConnectionPeer::Known(sample_component_info()))
+        );
+    }
+
+    #[test]
+    fn resolves_legacy_peer_from_open_frame_without_component_info() {
+        // Legacy client: the first write-block open frame has no component_info
+        // and resolves the connection peer to Legacy exactly once.
+        let header = BlockWriteRequest {
+            block: sample_block(),
+            off: 0,
+            block_size: 4 * 1024 * 1024,
+            short_circuit: true,
+            client_name: "legacy-client".to_string(),
+            chunk_size: 1 << 20,
+            pipeline_stream: vec![],
+            component_info: None,
+        };
+        let open = build_msg(RpcCode::WriteBlock, RequestStatus::Open, header);
+        assert_eq!(
+            WorkerHandler::resolve_connection_peer(&open),
+            Some(ConnectionPeer::Legacy)
+        );
+    }
+
+    #[test]
+    fn running_and_commit_frames_never_resolve_peer() {
+        // Running frames (DataHeaderProto / FilesBatchWriteRequest) and commit
+        // frames carry no peer metadata and must not resolve the connection,
+        // so the worker never decodes payload-bearing headers for peer info.
+        let running = build_msg(
+            RpcCode::WriteBlock,
+            RequestStatus::Running,
+            DataHeaderProto {
+                offset: 0,
+                flush: false,
+                is_last: false,
+            },
+        );
+        assert_eq!(WorkerHandler::resolve_connection_peer(&running), None);
+
+        let files_batch = FilesBatchWriteRequest {
+            files: vec![FileWriteData {
+                path: "/dir/a".to_string(),
+                content: b"hello".to_vec(),
+            }],
+            req_id: 7,
+            seq_id: 2,
+            component_info: None,
+        };
+        let running = build_msg(
+            RpcCode::WriteBlocksBatch,
+            RequestStatus::Running,
+            files_batch,
+        );
+        assert_eq!(WorkerHandler::resolve_connection_peer(&running), None);
+
+        let commit = build_msg(
+            RpcCode::WriteBlock,
+            RequestStatus::Complete,
+            BlockWriteRequest {
+                block: sample_block(),
+                off: 0,
+                block_size: 4 * 1024 * 1024,
+                short_circuit: false,
+                client_name: "client-1".to_string(),
+                chunk_size: 1 << 20,
+                pipeline_stream: vec![],
+                component_info: None,
+            },
+        );
+        assert_eq!(WorkerHandler::resolve_connection_peer(&commit), None);
+    }
+
+    #[test]
+    fn non_data_plane_rpcs_never_resolve_peer() {
+        // Task / transfer control RPCs are outside the data plane and must not
+        // touch the connection peer resolution.
+        let header = QueryTransferTaskRequest {
+            job_id: "job-1".to_string(),
+            task_id: "task-1".to_string(),
+            run_id: 0,
+            attempt_id: 0,
+            worker_session_id: String::new(),
+        };
+        let msg = build_msg(RpcCode::QueryTransferTask, RequestStatus::Open, header);
+        assert_eq!(WorkerHandler::resolve_connection_peer(&msg), None);
     }
 }

--- a/curvine-worker/src/worker/handler/worker_handler.rs
+++ b/curvine-worker/src/worker/handler/worker_handler.rs
@@ -27,6 +27,7 @@ use curvine_rpc::message::{Builder, Message, RequestStatus, ResponseStatus};
 use curvine_runtime::common::SerdeUtils;
 use curvine_runtime::runtime::Runtime;
 use curvine_runtime::sync::FastMutex;
+use log::{info, warn};
 use std::sync::Arc;
 
 pub struct WorkerHandler {
@@ -35,6 +36,13 @@ pub struct WorkerHandler {
     pub task_manager: Arc<TaskManager>,
     pub rt: Arc<Runtime>,
     pub replication_handler: WorkerReplicationHandler,
+    /// Connection-level peer metadata: the `component_info` the client on this
+    /// connection reported on the reserved 1000+ range of the first data-plane
+    /// request that carried it. `None` means a legacy client that never
+    /// reported component info. The worker only records the version here (T9);
+    /// protocol negotiation on top of it happens in the client-worker
+    /// compatibility layer (T10).
+    pub peer_component_info: FastMutex<Option<ComponentInfoProto>>,
 }
 
 impl MessageHandler for WorkerHandler {
@@ -54,6 +62,11 @@ impl MessageHandler for WorkerHandler {
         }
 
         let code = RpcCode::from(msg.code());
+        // Record the client's component info on this connection (best-effort;
+        // running data frames carry no version payload and legacy clients omit
+        // the field entirely).
+        self.record_peer_component_info(msg);
+
         match code {
             RpcCode::SubmitTask => self.task_submit(msg),
 
@@ -85,7 +98,113 @@ impl MessageHandler for WorkerHandler {
     }
 }
 
+/// Outcome of feeding a peer's `component_info` into the connection cache.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PeerRecordEvent {
+    /// The first component info seen on this connection.
+    First,
+    /// A different component info than the cached one (mid-connection
+    /// peer change, unexpected with connection reuse).
+    Changed,
+    /// The cached info already matches; nothing to do.
+    Unchanged,
+}
+
 impl WorkerHandler {
+    /// Pure connection-cache update: store `info` into `peer` and report
+    /// whether a log-worthy event occurred. Kept separate from the logging so
+    /// the connection-level peer cache behavior can be unit-tested without a
+    /// full `WorkerHandler`.
+    fn record_peer_component_info_state(
+        peer: &mut Option<ComponentInfoProto>,
+        info: ComponentInfoProto,
+    ) -> PeerRecordEvent {
+        match peer.as_ref() {
+            None => {
+                *peer = Some(info);
+                PeerRecordEvent::First
+            }
+            Some(existing) if existing != &info => {
+                *peer = Some(info);
+                PeerRecordEvent::Changed
+            }
+            _ => PeerRecordEvent::Unchanged,
+        }
+    }
+
+    /// Extract the optional `component_info` a client attached to a data-plane
+    /// request, based on the RPC code / request status pair that determines the
+    /// wire message type. Running (data-carrying) frames use `DataHeaderProto`
+    /// and carry no component info; the client reports it on the open and
+    /// commit frames, so the first request on a connection carries it.
+    fn extract_component_info(msg: &Message) -> Option<ComponentInfoProto> {
+        match (RpcCode::from(msg.code()), msg.request_status()) {
+            (
+                RpcCode::WriteBlock,
+                RequestStatus::Open | RequestStatus::Complete | RequestStatus::Cancel,
+            ) => msg
+                .parse_header::<BlockWriteRequest>()
+                .ok()
+                .and_then(|req| req.component_info),
+            (RpcCode::ReadBlock, RequestStatus::Open | RequestStatus::Complete) => msg
+                .parse_header::<BlockReadRequest>()
+                .ok()
+                .and_then(|req| req.component_info),
+            (RpcCode::WriteBlocksBatch, RequestStatus::Open) => msg
+                .parse_header::<BlocksBatchWriteRequest>()
+                .ok()
+                .and_then(|req| req.component_info),
+            (RpcCode::WriteBlocksBatch, RequestStatus::Running) => msg
+                .parse_header::<FilesBatchWriteRequest>()
+                .ok()
+                .and_then(|req| req.component_info),
+            (RpcCode::WriteBlocksBatch, RequestStatus::Complete | RequestStatus::Cancel) => msg
+                .parse_header::<BlocksBatchCommitRequest>()
+                .ok()
+                .and_then(|req| req.component_info),
+            _ => None,
+        }
+    }
+
+    /// Record the client's `component_info` for this connection. The worker
+    /// only records the version (per the T9 contract): the first request that
+    /// carries it is logged and cached, a change mid-connection is warned and
+    /// re-recorded, and legacy clients that omit the field leave the cache
+    /// empty (treated as a legacy/unknown peer, never rejected).
+    fn record_peer_component_info(&self, msg: &Message) {
+        let Some(info) = Self::extract_component_info(msg) else {
+            return;
+        };
+        let mut peer = self.peer_component_info.lock();
+        match Self::record_peer_component_info_state(&mut peer, info) {
+            PeerRecordEvent::First => {
+                let cached = peer.as_ref().expect("peer cache just recorded");
+                info!(
+                    "peer component info on data connection: component={}, release_version={}, protocol_version={:?}, min_protocol_version={:?}",
+                    cached.component.as_deref().unwrap_or("unknown"),
+                    cached.release_version.as_deref().unwrap_or("unknown"),
+                    cached.protocol_version,
+                    cached.min_protocol_version,
+                );
+            }
+            PeerRecordEvent::Changed => {
+                let cached = peer.as_ref().expect("peer cache just re-recorded");
+                warn!(
+                    "peer component info changed on data connection: component={}, release_version={}",
+                    cached.component.as_deref().unwrap_or("unknown"),
+                    cached.release_version.as_deref().unwrap_or("unknown"),
+                );
+            }
+            PeerRecordEvent::Unchanged => {}
+        }
+    }
+
+    /// The component info recorded for the peer on this connection. `None`
+    /// means a legacy client that never reported component info on any request.
+    pub fn peer_component_info(&self) -> Option<ComponentInfoProto> {
+        self.peer_component_info.lock().clone()
+    }
+
     fn get_handler<'a>(
         &self,
         msg: &Message,
@@ -192,5 +311,236 @@ fn transfer_task_state_code(state: curvine_model::JobTaskState) -> i32 {
         curvine_model::JobTaskState::Canceled => {
             TransferTaskStateProto::TransferTaskCanceled.into()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BlockWriteRequest, PeerRecordEvent, WorkerHandler};
+    use curvine_fs_api::RpcCode;
+    use curvine_proto::{
+        BlockReadRequest, BlocksBatchCommitRequest, BlocksBatchWriteRequest, ComponentInfoProto,
+        DataHeaderProto, ExtendedBlockProto, FileTypeProto, FileWriteData, FilesBatchWriteRequest,
+        QueryTransferTaskRequest, StorageTypeProto,
+    };
+    use curvine_rpc::message::{Builder, RequestStatus};
+
+    fn sample_component_info() -> ComponentInfoProto {
+        ComponentInfoProto {
+            component: Some("client".to_string()),
+            release_version: Some("0.4.0-alpha".to_string()),
+            git_commit: Some("359fce7d982a15f09c3b4e0b2e62fee4229609dd".to_string()),
+            git_tag: Some("v0.4.0-alpha".to_string()),
+            git_branch: Some("main".to_string()),
+            protocol_version: Some(1),
+            min_protocol_version: Some(1),
+            capabilities: vec!["short-circuit".to_string(), "batch-write".to_string()],
+        }
+    }
+
+    fn sample_block() -> ExtendedBlockProto {
+        ExtendedBlockProto {
+            id: 42,
+            block_size: 4 * 1024 * 1024,
+            storage_type: StorageTypeProto::Mem as i32,
+            file_type: FileTypeProto::File as i32,
+            alloc_opts: None,
+        }
+    }
+
+    fn build_msg(
+        code: RpcCode,
+        status: RequestStatus,
+        header: impl prost::Message,
+    ) -> curvine_rpc::message::Message {
+        Builder::new()
+            .code(code)
+            .request(status)
+            .req_id(1)
+            .seq_id(1)
+            .proto_header(header)
+            .build()
+    }
+
+    #[test]
+    fn extracts_component_info_from_block_write_open_and_commit() {
+        let header = BlockWriteRequest {
+            block: sample_block(),
+            off: 0,
+            block_size: 4 * 1024 * 1024,
+            short_circuit: true,
+            client_name: "client-1".to_string(),
+            chunk_size: 1 << 20,
+            pipeline_stream: vec![],
+            component_info: Some(sample_component_info()),
+        };
+
+        let open = build_msg(RpcCode::WriteBlock, RequestStatus::Open, header.clone());
+        assert_eq!(
+            WorkerHandler::extract_component_info(&open),
+            Some(sample_component_info())
+        );
+
+        let commit = build_msg(RpcCode::WriteBlock, RequestStatus::Complete, header);
+        assert_eq!(
+            WorkerHandler::extract_component_info(&commit),
+            Some(sample_component_info())
+        );
+    }
+
+    #[test]
+    fn extracts_component_info_from_block_read_open() {
+        let header = BlockReadRequest {
+            id: 42,
+            off: 0,
+            len: 4096,
+            chunk_size: 1 << 20,
+            short_circuit: false,
+            enable_read_ahead: true,
+            read_ahead_len: 4 * 1024 * 1024,
+            drop_cache_len: 1 << 20,
+            component_info: Some(sample_component_info()),
+        };
+        let open = build_msg(RpcCode::ReadBlock, RequestStatus::Open, header);
+        assert_eq!(
+            WorkerHandler::extract_component_info(&open),
+            Some(sample_component_info())
+        );
+    }
+
+    #[test]
+    fn extracts_component_info_from_batch_frames() {
+        let batch_open = BlocksBatchWriteRequest {
+            blocks: vec![sample_block()],
+            off: 0,
+            block_size: 4 * 1024 * 1024,
+            req_id: 7,
+            seq_id: 1,
+            chunk_size: 1 << 20,
+            short_circuit: true,
+            client_name: "client-1".to_string(),
+            component_info: Some(sample_component_info()),
+        };
+        let open = build_msg(RpcCode::WriteBlocksBatch, RequestStatus::Open, batch_open);
+        assert_eq!(
+            WorkerHandler::extract_component_info(&open),
+            Some(sample_component_info())
+        );
+
+        let files_batch = FilesBatchWriteRequest {
+            files: vec![FileWriteData {
+                path: "/dir/a".to_string(),
+                content: b"hello".to_vec(),
+            }],
+            req_id: 7,
+            seq_id: 2,
+            component_info: Some(sample_component_info()),
+        };
+        let running = build_msg(
+            RpcCode::WriteBlocksBatch,
+            RequestStatus::Running,
+            files_batch,
+        );
+        assert_eq!(
+            WorkerHandler::extract_component_info(&running),
+            Some(sample_component_info())
+        );
+
+        let batch_commit = BlocksBatchCommitRequest {
+            blocks: vec![sample_block()],
+            off: 0,
+            block_size: 4 * 1024 * 1024,
+            req_id: 7,
+            seq_id: 1,
+            cancel: false,
+            component_info: Some(sample_component_info()),
+        };
+        let complete = build_msg(
+            RpcCode::WriteBlocksBatch,
+            RequestStatus::Complete,
+            batch_commit,
+        );
+        assert_eq!(
+            WorkerHandler::extract_component_info(&complete),
+            Some(sample_component_info())
+        );
+    }
+
+    #[test]
+    fn running_data_frames_carry_no_component_info() {
+        // Running frames use DataHeaderProto (write/read data or batch flush)
+        // and carry no component info; extraction must be None so the worker
+        // does not spam the connection cache on the hot path.
+        let header = DataHeaderProto {
+            offset: 0,
+            flush: false,
+            is_last: false,
+        };
+        let running = build_msg(RpcCode::WriteBlock, RequestStatus::Running, header);
+        assert_eq!(WorkerHandler::extract_component_info(&running), None);
+    }
+
+    #[test]
+    fn legacy_client_without_component_info_extracts_none() {
+        // Old client: no component_info on the reserved 1000+ range. The
+        // worker records nothing and treats the peer as legacy/unknown.
+        let header = BlockWriteRequest {
+            block: sample_block(),
+            off: 0,
+            block_size: 4 * 1024 * 1024,
+            short_circuit: true,
+            client_name: "legacy-client".to_string(),
+            chunk_size: 1 << 20,
+            pipeline_stream: vec![],
+            component_info: None,
+        };
+        let open = build_msg(RpcCode::WriteBlock, RequestStatus::Open, header);
+        assert_eq!(WorkerHandler::extract_component_info(&open), None);
+    }
+
+    #[test]
+    fn non_data_plane_messages_extract_none() {
+        // Task / transfer control messages are outside the data plane; they
+        // must not touch the connection peer cache.
+        let header = QueryTransferTaskRequest {
+            job_id: "job-1".to_string(),
+            task_id: "task-1".to_string(),
+            run_id: 0,
+            attempt_id: 0,
+            worker_session_id: String::new(),
+        };
+        let msg = build_msg(RpcCode::QueryTransferTask, RequestStatus::Open, header);
+        assert_eq!(WorkerHandler::extract_component_info(&msg), None);
+    }
+
+    #[test]
+    fn peer_cache_records_first_change_and_keeps_unchanged() {
+        let mut peer = None;
+        let v1 = sample_component_info();
+
+        // First request on the connection records the peer version.
+        assert_eq!(
+            WorkerHandler::record_peer_component_info_state(&mut peer, v1.clone()),
+            PeerRecordEvent::First
+        );
+        assert_eq!(peer, Some(v1.clone()));
+
+        // Repeated requests with the same info are a no-op.
+        assert_eq!(
+            WorkerHandler::record_peer_component_info_state(&mut peer, v1.clone()),
+            PeerRecordEvent::Unchanged
+        );
+        assert_eq!(peer, Some(v1));
+
+        // A different peer version mid-connection is re-recorded.
+        let v2 = ComponentInfoProto {
+            release_version: Some("0.5.0".to_string()),
+            ..sample_component_info()
+        };
+        assert_eq!(
+            WorkerHandler::record_peer_component_info_state(&mut peer, v2.clone()),
+            PeerRecordEvent::Changed
+        );
+        assert_eq!(peer, Some(v2));
     }
 }

--- a/curvine-worker/src/worker/worker_server.rs
+++ b/curvine-worker/src/worker/worker_server.rs
@@ -94,6 +94,7 @@ impl HandlerService for WorkerService {
         WorkerHandler {
             store: self.store.clone(),
             handler: FastMutex::new(None),
+            peer_component_info: FastMutex::new(None),
             task_manager: self.task_manager.clone(),
             rt: self.rt.clone(),
             replication_handler: WorkerReplicationHandler::new(&self.replication_manager),

--- a/curvine-worker/src/worker/worker_server.rs
+++ b/curvine-worker/src/worker/worker_server.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::worker::block::{BlockActor, BlockStore};
-use crate::worker::handler::{WorkerHandler, WorkerRouterHandler};
+use crate::worker::handler::{ConnectionPeer, WorkerHandler, WorkerRouterHandler};
 use crate::worker::replication::worker_replication_handler::WorkerReplicationHandler;
 use crate::worker::replication::worker_replication_manager::WorkerReplicationManager;
 use crate::worker::task::TaskManager;
@@ -94,7 +94,7 @@ impl HandlerService for WorkerService {
         WorkerHandler {
             store: self.store.clone(),
             handler: FastMutex::new(None),
-            peer_component_info: FastMutex::new(None),
+            connection_peer: FastMutex::new(ConnectionPeer::Unknown),
             task_manager: self.task_manager.clone(),
             rt: self.rt.clone(),
             replication_handler: WorkerReplicationHandler::new(&self.replication_manager),


### PR DESCRIPTION
# Summary

Add an optional `component_info = 1000` field to the client-worker data-plane requests (`BlockWriteRequest`, `BlockReadRequest`, `BlocksBatchWriteRequest`, `BlocksBatchCommitRequest`, `FilesBatchWriteRequest`), reusing the existing `ComponentInfoProto`. The client attaches its structured version to every open/commit frame it sends to workers, and the worker records the peer's component info per connection (first request that carries it wins; a mid-connection change is logged and re-recorded). This is the T9 step of the component version-management plan (#1527): workers can now identify the version/protocol of the client on each data connection without breaking old components.

# Issue Describe / Design

Closes #1527

Design decisions (from the version-management design):
- Reuse the reserved `1000+` cross-cutting field range so existing business fields (1-999) stay untouched; legacy workers ignore the unknown field via standard protobuf semantics.
- The worker only records the peer version at the connection level (`WorkerHandler` is created per connection), leaving protocol negotiation / diagnose-enforce checks to the follow-up client-worker compatibility layer (T10).
- Legacy clients that omit `component_info` keep working: the worker treats absence as a legacy/unknown peer, records nothing and never rejects.
- Running (data-carrying) frames use `DataHeaderProto` and carry no version payload, so the client reports on open/commit frames and the worker caches on the first request.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `crates/common/curvine-proto/proto/worker.proto` | Add optional `component_info = 1000` to `BlockWriteRequest`, `BlockReadRequest`, `BlocksBatchWriteRequest`, `BlocksBatchCommitRequest`, `FilesBatchWriteRequest` | None (new optional field, old components ignore it) |
| `crates/client/curvine-client-core/src/block/block_client.rs` | Build the client's `component_info` once per `BlockClient` and attach it to all data-plane open/commit requests | None (new field only) |
| `curvine-worker/src/worker/handler/worker_handler.rs` | Connection-level peer cache: extract `component_info` from data-plane frames, record on first sight, expose `peer_component_info()` | None (record-only, diagnose by default) |
| `curvine-worker/src/worker/handler/batch_write_handler.rs` | Propagate `component_info` from the batch-open frame into the per-block internal `BlockWriteRequest` | None |
| `curvine-worker/src/worker/worker_server.rs` | Initialize the per-connection peer cache | None |
| `curvine-worker/Cargo.toml` | Add `prost` dev-dependency for handler unit tests | None |
| `crates/common/curvine-proto/tests/worker_dataplane_compat_test.rs` | New wire-level compat tests: round-trip with `component_info`, legacy client decode (old wire), unknown high-field skipping | Test only |
| `curvine-server/tests/worker_test.rs`, `spdk_stress_test.rs`, `spdk_worker_test.rs`, `crates/common/curvine-proto/tests/proto_pipeline_test.rs` | Set `component_info: None` in test request constructions | Test only |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-proto` (incl. new `worker_dataplane_compat_test`) | PASS | 30 passed |
| `cargo test -p curvine-client-core` | PASS | 35 passed |
| `cargo test -p curvine-worker --lib` (incl. new handler peer-cache tests) | PASS | 18 passed, 1 ignored |
| `cargo test -p curvine-model --lib` | PASS | 36 passed |
| `cargo check --workspace --all-targets` | PASS | |
| `make format` (fmt + clippy `--deny warnings --all-targets`) | PASS | exit 0 |

Coverage for the T9 acceptance criteria:
- New/old client requests: legacy wire decode tests for all five messages (old client -> new worker), plus round-trip tests with `component_info` (new client -> new worker).
- Connection-level peer cache: worker handler unit tests covering extraction from each data-plane frame, running frames carrying none, legacy/unknown peers, and first/unchanged/changed cache transitions.

# Dependencies

- Related PRs: #1585 (T8 compat checker), #1584 (T7 worker heartbeat version), #1582 (T6 client-master handshake), #1581 (T5 GetMasterInfo extension)
- Related issues: #1527
- Blocks / blocked by: blocked by T4 (proto messages, already merged); T10 builds on this PR
