### PR TITLE
feat(worker): negotiate client-worker compatibility per connection (#1527)

### DIFF
--- a/crates/client/curvine-client-core/src/file/fs_client.rs
+++ b/crates/client/curvine-client-core/src/file/fs_client.rs
@@ -574,7 +574,11 @@ impl FsClient {
         // never rejected.
         self.context
             .set_master_handshake(MasterHandshake::from_response(&rep));
-        Ok(ProtoUtils::filesystem_info_from_pb(rep))
+        let info = ProtoUtils::filesystem_info_from_pb(rep);
+        // Cache the live-worker versions for the T10 client-side worker
+        // pre-check before data connections are opened.
+        self.context.set_live_workers(&info.live_workers);
+        Ok(info)
     }
 
     /// Client-master version handshake: report this client's `component_info`
@@ -637,6 +641,10 @@ impl FsClient {
         if let Ok(rep) = GetFilesystemInfoResponse::decode(bytes.as_ref()) {
             self.context
                 .set_master_handshake(MasterHandshake::from_response(&rep));
+            // Cache the live-worker versions for the T10 client-side worker
+            // pre-check before data connections are opened.
+            let info = ProtoUtils::filesystem_info_from_pb(rep);
+            self.context.set_live_workers(&info.live_workers);
         }
         Ok(bytes)
     }

--- a/crates/client/curvine-client-core/src/file/fs_context.rs
+++ b/crates/client/curvine-client-core/src/file/fs_context.rs
@@ -13,14 +13,14 @@
 // limitations under the License.
 
 use crate::block::{BlockClient, BlockClientPool};
-use crate::file::{FsClient, MasterHandshake};
+use crate::file::{FsClient, MasterHandshake, WorkerPrecheck};
 use crate::ClientMetrics;
 use curvine_config::ClusterConf;
 use curvine_error::FsResult;
 use curvine_io::CacheManager;
 use curvine_io::IOResult;
 use curvine_model::ProtoUtils;
-use curvine_model::{ClientAddress, WorkerAddress};
+use curvine_model::{ClientAddress, WorkerAddress, WorkerInfo};
 use curvine_net::net::NetUtils;
 use curvine_proto::ClientAddressProto;
 use curvine_rpc::client::{ClientConf, ClusterConnector};
@@ -32,6 +32,7 @@ use log::warn;
 use moka::policy::EvictionPolicy;
 use moka::sync::{Cache, CacheBuilder};
 use once_cell::sync::OnceCell;
+use std::collections::HashMap;
 use std::future::Future;
 use std::hash::BuildHasherDefault;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -58,6 +59,15 @@ pub struct FsContext {
     // inline: FsContext itself is only ever shared behind an `Arc`, so the
     // interior-mutable FastRwLock needs no extra heap allocation.
     master_handshake: FastRwLock<MasterHandshake>,
+    // Last-known live workers reported by the master on GetFilesystemInfo,
+    // keyed by worker_id. Used by the T10 client-side worker pre-check to
+    // evaluate a worker's structured version before opening a data connection.
+    live_workers: FastRwLock<HashMap<u32, WorkerInfo>>,
+    // Client-side worker pre-check (diagnose-only): evaluates a worker's
+    // version/protocol/capabilities against the client's own supported range
+    // plus the master-advertised bounds, and warns (never rejects) when a
+    // worker looks incompatible.
+    worker_precheck: FastRwLock<WorkerPrecheck>,
     // Whether this session has already reported its component_info to the
     // master. Handshake metadata is sent once per mount/session; the flag
     // keeps GetFilesystemInfo (which backs FUSE statfs and may be called
@@ -124,6 +134,8 @@ impl FsContext {
             failed_workers: exclude_workers,
             block_pool,
             master_handshake: FastRwLock::new(MasterHandshake::default()),
+            live_workers: FastRwLock::new(HashMap::new()),
+            worker_precheck: FastRwLock::new(WorkerPrecheck::default()),
             handshake_reported: AtomicBool::new(false),
             handshake_lock: tokio::sync::Mutex::new(()),
             handshake_started: AtomicBool::new(false),
@@ -137,8 +149,10 @@ impl FsContext {
 
     /// Cache the master's advertised version / protocol / capabilities from
     /// the client-master handshake. A master without a compatibility contract
-    /// is recorded as legacy and never rejected.
+    /// is recorded as legacy and never rejected. The worker pre-check bounds
+    /// are refreshed from the same contract.
     pub fn set_master_handshake(&self, handshake: MasterHandshake) {
+        self.worker_precheck.write().refresh(&handshake);
         *self.master_handshake.write() = handshake;
     }
 
@@ -205,7 +219,36 @@ impl FsContext {
         addr.is_local(&self.client_addr.hostname)
     }
 
+    /// Replace the cached live-worker view reported by the master. Called on
+    /// every successful GetFilesystemInfo so the T10 worker pre-check has the
+    /// freshest worker versions before opening data connections.
+    pub fn set_live_workers(&self, workers: &[WorkerInfo]) {
+        let mut map = self.live_workers.write();
+        map.clear();
+        for worker in workers {
+            map.insert(worker.worker_id(), worker.clone());
+        }
+    }
+
+    /// Run the diagnose-only worker pre-check for a worker the client is about
+    /// to open a data connection to. Uses the last-known version the master
+    /// reported; workers the master has not reported (or legacy workers
+    /// without `component_info`) are allowed silently and enforcement is left
+    /// to the worker side. Never rejects — T10 acceptance: default is log /
+    /// pre-check only. The worker is evaluated under the read guard so no
+    /// `WorkerInfo` clone is needed on the connection hot path.
+    fn precheck_worker(&self, addr: &WorkerAddress) {
+        let workers = self.live_workers.read();
+        let Some(worker) = workers.get(&addr.worker_id) else {
+            return;
+        };
+        self.worker_precheck.read().warn_if_incompatible(worker);
+    }
+
     pub async fn block_client(&self, addr: &WorkerAddress) -> IOResult<BlockClient> {
+        // T10: pre-check the worker's version/protocol before opening a data
+        // connection (diagnose-only; logs mismatches, never refuses).
+        self.precheck_worker(addr);
         let client = self
             .connector
             .create_client(&addr.inet_addr(), false)

--- a/crates/client/curvine-client-core/src/file/mod.rs
+++ b/crates/client/curvine-client-core/src/file/mod.rs
@@ -21,6 +21,9 @@ pub use self::fs_client::FsClient;
 mod handshake;
 pub use self::handshake::MasterHandshake;
 
+mod worker_precheck;
+pub use self::worker_precheck::WorkerPrecheck;
+
 mod fs_writer_base;
 pub use self::fs_writer_base::FsWriterBase;
 

--- a/crates/client/curvine-client-core/src/file/worker_precheck.rs
+++ b/crates/client/curvine-client-core/src/file/worker_precheck.rs
@@ -134,7 +134,7 @@ impl WorkerPrecheck {
         let changed = self
             .warned
             .get(&worker.worker_id())
-            .map(|last| *last != verdict)
+            .map(|last| last.value() != &verdict)
             .unwrap_or(true);
         if changed {
             self.warned.insert(worker.worker_id(), verdict.clone());

--- a/crates/client/curvine-client-core/src/file/worker_precheck.rs
+++ b/crates/client/curvine-client-core/src/file/worker_precheck.rs
@@ -1,0 +1,373 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Client-side worker pre-check (T10).
+//!
+//! Before the client opens a data connection to a worker, it pre-checks the
+//! worker's structured version (`component_info`) that the master reported on
+//! the `GetFilesystemInfo` handshake (`live_workers`):
+//!
+//! - **protocol layer**: the worker's `protocol_version` must fall inside the
+//!   client's own supported range `[MIN_PROTOCOL_VERSION, PROTOCOL_VERSION]`;
+//! - **version layer**: the worker's release version must not be older than
+//!   the `min_worker_version` the master advertises (when the master reports
+//!   one);
+//! - **blocked versions**: the master-advertised blocklist is mirrored so a
+//!   known-bad worker is surfaced immediately.
+//!
+//! The pre-check is **diagnose-only** by design (acceptance for T10): an
+//! incompatible worker is logged (deduped per worker and per verdict change)
+//! but never rejected. A worker whose version is unknown (legacy worker that
+//! never reported `component_info`) is allowed to connect — enforcement is
+//! left to the worker's own diagnose/enforce policy on the data plane.
+
+use crate::file::MasterHandshake;
+use curvine_model::WorkerInfo;
+use curvine_model::{CompatibilityMode, CompatibilityPolicy, CompatibilityVerdict};
+use curvine_runtime::sync::FastDashMap;
+use curvine_sys::version::ReleaseVersion;
+use log::warn;
+
+/// Client-side worker pre-check policy and per-worker warning dedup state.
+///
+/// The policy is rebuilt whenever the client-master handshake refreshes: the
+/// client's own protocol range is constant for the process, while the
+/// `min_worker_version` / `blocked_versions` bounds come from the master's
+/// advertised compatibility contract. The mode is always `diagnose`: the
+/// pre-check never rejects, it only surfaces mismatches to the operator.
+pub struct WorkerPrecheck {
+    /// The diagnose-only evaluation policy.
+    policy: CompatibilityPolicy,
+    /// Per-worker (worker_id) last-warned verdict, so repeated connections to
+    /// an incompatible worker warn on the first occurrence and again only when
+    /// the verdict changes.
+    warned: FastDashMap<u32, CompatibilityVerdict>,
+}
+
+impl Default for WorkerPrecheck {
+    fn default() -> Self {
+        Self {
+            policy: Self::diagnose_policy(None, Vec::new()),
+            warned: FastDashMap::default(),
+        }
+    }
+}
+
+impl WorkerPrecheck {
+    /// Build the diagnose-only pre-check policy from the client's own protocol
+    /// range plus the master-advertised worker bounds.
+    fn diagnose_policy(
+        min_worker_version: Option<ReleaseVersion>,
+        blocked_versions: Vec<ReleaseVersion>,
+    ) -> CompatibilityPolicy {
+        CompatibilityPolicy {
+            mode: CompatibilityMode::Diagnose,
+            protocol_version: curvine_sys::version::PROTOCOL_VERSION,
+            min_protocol_version: curvine_sys::version::MIN_PROTOCOL_VERSION,
+            min_worker_version,
+            min_client_version: None,
+            blocked_versions,
+        }
+    }
+
+    /// Refresh the pre-check bounds from the latest client-master handshake.
+    /// A legacy master (no compatibility contract) resets the bounds to
+    /// none/empty so nothing is flagged without an explicit contract.
+    pub fn refresh(&mut self, handshake: &MasterHandshake) {
+        let compat = handshake.compatibility();
+        let min_worker_version = compat
+            .and_then(|c| c.min_worker_version.as_deref())
+            .and_then(|v| ReleaseVersion::parse(v).ok());
+        let blocked_versions = compat
+            .map(|c| {
+                c.blocked_versions
+                    .iter()
+                    .filter_map(|v| ReleaseVersion::parse(v).ok())
+                    .collect()
+            })
+            .unwrap_or_default();
+        self.policy = Self::diagnose_policy(min_worker_version, blocked_versions);
+    }
+
+    /// Evaluate a worker's structured version against the pre-check policy.
+    /// `None` (or a worker without `component_info`) means the worker version
+    /// is unknown: allowed, since enforcement is left to the worker side.
+    pub fn check_worker(&self, worker: &WorkerInfo) -> CompatibilityVerdict {
+        self.policy.check_worker(worker.component_info.as_ref())
+    }
+
+    /// Whether evaluating a worker can produce a non-trivial verdict. Mirrors
+    /// the master's hot-path avoidance: with no bounds/blocklist and a worker
+    /// that reported no component info, the evaluation cannot change anything.
+    pub fn should_evaluate(&self, worker: &WorkerInfo) -> bool {
+        self.policy.should_evaluate(worker.component_info.is_some())
+    }
+
+    /// Run the pre-check for a worker and warn on the first occurrence of an
+    /// incompatible verdict (and whenever the verdict changes). Never rejects:
+    /// this is a diagnose-only pre-check.
+    pub fn warn_if_incompatible(&self, worker: &WorkerInfo) {
+        if !self.should_evaluate(worker) {
+            return;
+        }
+        let verdict = self.check_worker(worker);
+        if verdict.is_compatible() {
+            // The worker is compatible again; forget any previous warning so a
+            // future incompatibility is surfaced.
+            self.warned.remove(&worker.worker_id());
+            return;
+        }
+        let changed = self
+            .warned
+            .get(&worker.worker_id())
+            .map(|last| *last != verdict)
+            .unwrap_or(true);
+        if changed {
+            self.warned.insert(worker.worker_id(), verdict.clone());
+            warn!(
+                "worker {} pre-check: {} (worker {}:{})",
+                worker.worker_id(),
+                verdict.describe(),
+                worker.address.hostname,
+                worker.address.rpc_port
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use curvine_model::WorkerAddress;
+    use curvine_proto::{ComponentInfoProto, ServerCompatibilityInfoProto};
+    use curvine_sys::version::ReleaseVersion;
+
+    fn worker_info(id: u32, component_info: Option<ComponentInfoProto>) -> WorkerInfo {
+        WorkerInfo {
+            address: WorkerAddress {
+                worker_id: id,
+                ip_addr: "127.0.0.1".to_string(),
+                rpc_port: 6666,
+                ..Default::default()
+            },
+            component_info,
+            ..Default::default()
+        }
+    }
+
+    fn worker_component_info(release_version: &str, protocol_version: u32) -> ComponentInfoProto {
+        ComponentInfoProto {
+            component: Some("worker".to_string()),
+            release_version: Some(release_version.to_string()),
+            git_commit: Some("abc".to_string()),
+            git_tag: Some(String::new()),
+            git_branch: Some("main".to_string()),
+            protocol_version: Some(protocol_version),
+            min_protocol_version: Some(protocol_version),
+            capabilities: vec!["batch-write".to_string()],
+        }
+    }
+
+    fn handshake_with(min_worker_version: Option<&str>, blocked: &[&str]) -> MasterHandshake {
+        MasterHandshake::from_response(&curvine_proto::GetFilesystemInfoResponse {
+            compatibility: Some(ServerCompatibilityInfoProto {
+                server: worker_component_info("0.4.0-alpha", 1),
+                min_worker_version: min_worker_version.map(|s| s.to_string()),
+                min_client_version: None,
+                compatibility_mode: 0,
+                blocked_versions: blocked.iter().map(|s| s.to_string()).collect(),
+            }),
+            ..Default::default()
+        })
+    }
+
+    #[test]
+    fn default_precheck_never_flags_compatible_or_legacy_workers() {
+        // Acceptance: with no explicit contract, nothing is rejected — a
+        // compatible worker and a legacy worker both stay compatible.
+        let precheck = WorkerPrecheck::default();
+
+        let compatible = worker_info(1, Some(worker_component_info("0.2.0", 1)));
+        assert_eq!(
+            precheck.check_worker(&compatible),
+            CompatibilityVerdict::Compatible
+        );
+
+        let legacy = worker_info(2, None);
+        assert_eq!(
+            precheck.check_worker(&legacy),
+            CompatibilityVerdict::MissingInfo
+        );
+        // Diagnose-only: missing info never rejects.
+        assert!(!precheck
+            .check_worker(&legacy)
+            .rejects(CompatibilityMode::Diagnose));
+    }
+
+    #[test]
+    fn protocol_mismatch_worker_is_flagged_but_never_rejected() {
+        // 新 worker + 旧 client (from the client's perspective): a worker
+        // speaking protocol 2 against a client that only supports 1 is
+        // ProtocolMismatch — warned, but the connection is still allowed.
+        let precheck = WorkerPrecheck::default();
+        let new_worker = worker_info(1, Some(worker_component_info("0.4.0", 2)));
+
+        assert_eq!(
+            precheck.check_worker(&new_worker),
+            CompatibilityVerdict::ProtocolMismatch {
+                peer: 2,
+                min: 1,
+                max: 1
+            }
+        );
+        assert!(!precheck
+            .check_worker(&new_worker)
+            .rejects(CompatibilityMode::Diagnose));
+    }
+
+    #[test]
+    fn master_min_worker_version_flags_old_worker() {
+        // 旧 worker + 新 client: with the master advertising min_worker_version
+        // = 0.2.0, an older worker (0.1.5) is flagged VersionTooOld but never
+        // rejected by the pre-check.
+        let mut precheck = WorkerPrecheck::default();
+        precheck.refresh(&handshake_with(Some("0.2.0"), &[]));
+
+        let old_worker = worker_info(1, Some(worker_component_info("0.1.5", 1)));
+        assert_eq!(
+            precheck.check_worker(&old_worker),
+            CompatibilityVerdict::VersionTooOld {
+                peer: "0.1.5".to_string(),
+                min: "0.2.0".to_string()
+            }
+        );
+        assert!(!precheck
+            .check_worker(&old_worker)
+            .rejects(CompatibilityMode::Diagnose));
+
+        // An at-minimum worker passes.
+        let ok_worker = worker_info(2, Some(worker_component_info("0.2.0", 1)));
+        assert_eq!(
+            precheck.check_worker(&ok_worker),
+            CompatibilityVerdict::Compatible
+        );
+    }
+
+    #[test]
+    fn master_blocked_versions_are_flagged() {
+        let mut precheck = WorkerPrecheck::default();
+        precheck.refresh(&handshake_with(None, &["0.2.5"]));
+
+        let blocked_worker = worker_info(1, Some(worker_component_info("0.2.5", 1)));
+        assert_eq!(
+            precheck.check_worker(&blocked_worker),
+            CompatibilityVerdict::Blocked("0.2.5".to_string())
+        );
+        // The pre-check surfaces the blocked worker as a warning (it is
+        // recorded for dedup), but never refuses the connection: the hook is
+        // diagnose-only.
+        precheck.warn_if_incompatible(&blocked_worker);
+        assert!(precheck.warned.contains_key(&1));
+    }
+
+    #[test]
+    fn refresh_resets_bounds_on_legacy_handshake() {
+        // A legacy master (no compatibility contract) resets the bounds so no
+        // worker is flagged.
+        let mut precheck = WorkerPrecheck::default();
+        precheck.refresh(&handshake_with(Some("0.2.0"), &["0.2.5"]));
+        assert_eq!(
+            precheck.check_worker(&worker_info(1, Some(worker_component_info("0.1.5", 1)))),
+            CompatibilityVerdict::VersionTooOld {
+                peer: "0.1.5".to_string(),
+                min: "0.2.0".to_string()
+            }
+        );
+
+        precheck.refresh(&MasterHandshake::legacy());
+        assert_eq!(
+            precheck.check_worker(&worker_info(1, Some(worker_component_info("0.1.5", 1)))),
+            CompatibilityVerdict::Compatible
+        );
+    }
+
+    #[test]
+    fn legacy_worker_version_is_unknown_and_allowed() {
+        // 旧 worker without component_info: unknown, allowed — enforcement is
+        // left to the worker side (diagnose/enforce).
+        let precheck = WorkerPrecheck::default();
+        let legacy = worker_info(7, None);
+        assert_eq!(
+            precheck.check_worker(&legacy),
+            CompatibilityVerdict::MissingInfo
+        );
+        assert!(!precheck.should_evaluate(&legacy));
+    }
+
+    #[test]
+    fn warn_dedup_tracks_verdict_changes_per_worker() {
+        // The dedup map records the last warned verdict; a compatible worker
+        // clears its entry so a later incompatibility is surfaced again.
+        let precheck = WorkerPrecheck::default();
+        let worker = worker_info(1, Some(worker_component_info("0.4.0", 2)));
+
+        // Incompatible (protocol mismatch) -> recorded.
+        precheck.warn_if_incompatible(&worker);
+        assert!(precheck.warned.contains_key(&1));
+
+        // Same verdict again -> unchanged, no re-warn.
+        precheck.warn_if_incompatible(&worker);
+        assert_eq!(
+            precheck.warned.get(&1).map(|v| v.clone()),
+            Some(CompatibilityVerdict::ProtocolMismatch {
+                peer: 2,
+                min: 1,
+                max: 1
+            })
+        );
+
+        // Compatible worker -> entry cleared.
+        let ok_worker = worker_info(1, Some(worker_component_info("0.4.0", 1)));
+        precheck.warn_if_incompatible(&ok_worker);
+        assert!(!precheck.warned.contains_key(&1));
+    }
+
+    #[test]
+    fn release_version_bound_parsing_is_lenient() {
+        // Unparseable master bounds degrade to none instead of failing closed.
+        let mut precheck = WorkerPrecheck::default();
+        let handshake = MasterHandshake::from_response(&curvine_proto::GetFilesystemInfoResponse {
+            compatibility: Some(ServerCompatibilityInfoProto {
+                server: worker_component_info("0.4.0-alpha", 1),
+                min_worker_version: Some("not-a-version".to_string()),
+                min_client_version: None,
+                compatibility_mode: 0,
+                blocked_versions: vec!["junk".to_string()],
+            }),
+            ..Default::default()
+        });
+        precheck.refresh(&handshake);
+        assert_eq!(
+            precheck.check_worker(&worker_info(1, Some(worker_component_info("0.1.5", 1)))),
+            CompatibilityVerdict::Compatible
+        );
+    }
+
+    #[test]
+    fn release_version_ordering_matches_policy() {
+        let v = |s: &str| ReleaseVersion::parse(s).unwrap();
+        assert!(v("0.1.5") < v("0.2.0"));
+        assert!(v("0.2.0") < v("0.4.0-alpha"));
+    }
+}

--- a/crates/client/curvine-client-core/src/file/worker_precheck.rs
+++ b/crates/client/curvine-client-core/src/file/worker_precheck.rs
@@ -82,8 +82,11 @@ impl WorkerPrecheck {
     }
 
     /// Refresh the pre-check bounds from the latest client-master handshake.
-    /// A legacy master (no compatibility contract) resets the bounds to
-    /// none/empty so nothing is flagged without an explicit contract.
+    /// A legacy master (no compatibility contract) resets the version bounds
+    /// and blocklist to none/empty, so no worker is flagged on version grounds
+    /// without an explicit contract. The client's own protocol-range check
+    /// still runs for every worker that reports `component_info`, regardless
+    /// of the handshake.
     pub fn refresh(&mut self, handshake: &MasterHandshake) {
         let compat = handshake.compatibility();
         let min_worker_version = compat

--- a/crates/common/curvine-config/src/worker_conf.rs
+++ b/crates/common/curvine-config/src/worker_conf.rs
@@ -15,7 +15,7 @@
 #![allow(clippy::should_implement_trait)]
 
 use crate::state::StorageType;
-use crate::ClusterConf;
+use crate::{ClusterConf, CompatibilityConf};
 use curvine_core_error::{err_box, CommonResult};
 use curvine_io::SpdkConf;
 use curvine_runtime::common::{ByteUnit, DurationUnit, FileUtils, LogConf, Utils};
@@ -165,6 +165,12 @@ pub struct WorkerConf {
 
     // SPDK over NVMe-oF/RDMA configuration.
     pub spdk_disk: SpdkConf,
+
+    /// Version compatibility policy applied to client peers on data-plane
+    /// connections (diagnose by default; enforce only when explicitly
+    /// configured). `min_worker_version` is ignored for a worker; the client
+    /// bound `min_client_version` and `blocked_versions` are what apply.
+    pub compatibility: CompatibilityConf,
 }
 
 impl WorkerConf {
@@ -210,6 +216,7 @@ impl Default for WorkerConf {
             block_replication_concurrency_limit: 100,
             block_replication_chunk_size: 1024 * 1024,
             spdk_disk: SpdkConf::default(),
+            compatibility: CompatibilityConf::default(),
         }
     }
 }

--- a/curvine-server/tests/worker_test.rs
+++ b/curvine-server/tests/worker_test.rs
@@ -21,8 +21,8 @@ use curvine_model::{ExtendedBlock, FileAllocOpts, FileType, StorageType};
 use curvine_net::net::NetUtils;
 use curvine_proto::{
     BlockReadRequest, BlockReadResponse, BlockWriteRequest, BlockWriteResponse,
-    BlocksBatchCommitRequest, BlocksBatchWriteRequest, BlocksBatchWriteResponse, DataHeaderProto,
-    FileWriteData, FilesBatchWriteRequest,
+    BlocksBatchCommitRequest, BlocksBatchWriteRequest, BlocksBatchWriteResponse,
+    ComponentInfoProto, DataHeaderProto, FileWriteData, FilesBatchWriteRequest,
 };
 use curvine_rpc::message::{Builder, Message, RequestStatus};
 use curvine_runtime::common::Utils;
@@ -541,6 +541,124 @@ fn test_worker_fault_http_control_plane_e2e() -> CommonResult<()> {
     let write_ck = block_write(healthy_block, &conf)?;
     let read_ck = block_read(healthy_block, &conf)?;
     assert_eq!(write_ck, read_ck);
+    Ok(())
+}
+
+fn old_client_component_info() -> ComponentInfoProto {
+    ComponentInfoProto {
+        component: Some("client".to_string()),
+        release_version: Some("0.1.0".to_string()),
+        git_commit: Some("abc".to_string()),
+        git_tag: Some(String::new()),
+        git_branch: Some("main".to_string()),
+        protocol_version: Some(1),
+        min_protocol_version: Some(1),
+        capabilities: vec![],
+    }
+}
+
+fn start_worker_with_compatibility(mode: &str, min_client_version: &str) -> ClusterConf {
+    let mut conf = ClusterConf::default();
+    conf.worker.rpc_port = NetUtils::hold_available_port();
+    conf.worker.web_port = NetUtils::hold_available_port();
+    conf.worker.data_dir = vec![format!(
+        "[MEM:10MB]../testing/worker-compat-{}-{}",
+        mode,
+        Utils::req_id().abs()
+    )];
+    conf.worker.compatibility.mode = mode.to_string();
+    conf.worker.compatibility.min_client_version = min_client_version.to_string();
+    conf.client.init().unwrap();
+
+    let server = Worker::with_conf(conf.clone()).unwrap();
+    thread::spawn(move || server.start_standalone());
+    conf
+}
+
+#[test]
+fn test_worker_enforce_mode_rejects_old_client_on_first_open_frame() -> CommonResult<()> {
+    // 旧 client + 协议不匹配: a worker explicitly configured to enforce
+    // min_client_version rejects an older client on its first data-plane open
+    // frame with an explicit error carrying both versions.
+    let conf = start_worker_with_compatibility("enforce", "99.0.0");
+    let client = conf.worker_sync_client()?;
+
+    let block_id = Utils::req_id().abs();
+    let block = ExtendedBlock::new(
+        block_id,
+        CHUNK_SIZE as i64,
+        StorageType::Disk,
+        FileType::File,
+    );
+    let request = BlockWriteRequest {
+        block: ProtoUtils::extend_block_to_pb(block),
+        off: 0,
+        block_size: CHUNK_SIZE as i64,
+        short_circuit: false,
+        client_name: "old-client".to_string(),
+        chunk_size: CHUNK_SIZE,
+        pipeline_stream: Vec::new(),
+        component_info: Some(old_client_component_info()),
+    };
+    let open = Builder::new()
+        .code(RpcCode::WriteBlock)
+        .request(RequestStatus::Open)
+        .req_id(Utils::req_id())
+        .seq_id(0)
+        .proto_header(request)
+        .build();
+
+    let err = client.rpc_check(open).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("0.1.0"),
+        "error should name the peer version: {msg}"
+    );
+    assert!(
+        msg.contains("99.0.0"),
+        "error should name the minimum: {msg}"
+    );
+    assert!(
+        msg.contains("diagnose"),
+        "error should suggest diagnose mode: {msg}"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_worker_diagnose_mode_allows_old_client_on_data_plane() -> CommonResult<()> {
+    // Acceptance: 默认不拒绝. Even with an explicit (low) min_client_version,
+    // a diagnose-mode worker warns but allows the old client's open frame.
+    let conf = start_worker_with_compatibility("diagnose", "99.0.0");
+    let client = conf.worker_sync_client()?;
+
+    let block_id = Utils::req_id().abs();
+    let block = ExtendedBlock::new(
+        block_id,
+        CHUNK_SIZE as i64,
+        StorageType::Disk,
+        FileType::File,
+    );
+    let request = BlockWriteRequest {
+        block: ProtoUtils::extend_block_to_pb(block),
+        off: 0,
+        block_size: CHUNK_SIZE as i64,
+        short_circuit: false,
+        client_name: "old-client".to_string(),
+        chunk_size: CHUNK_SIZE,
+        pipeline_stream: Vec::new(),
+        component_info: Some(old_client_component_info()),
+    };
+    let req_id = Utils::req_id();
+    let open = Builder::new()
+        .code(RpcCode::WriteBlock)
+        .request(RequestStatus::Open)
+        .req_id(req_id)
+        .seq_id(0)
+        .proto_header(request)
+        .build();
+    // The open frame must succeed: diagnose warns but never rejects.
+    let _: BlockWriteResponse = client.rpc_check(open)?.parse_header()?;
     Ok(())
 }
 

--- a/curvine-worker/src/worker/handler/worker_handler.rs
+++ b/curvine-worker/src/worker/handler/worker_handler.rs
@@ -20,7 +20,7 @@ use curvine_core_error::err_box;
 use curvine_error::FsError;
 use curvine_error::FsResult;
 use curvine_fs_api::RpcCode;
-use curvine_model::LoadTaskInfo;
+use curvine_model::{CompatibilityPolicy, LoadTaskInfo};
 use curvine_proto::*;
 use curvine_rpc::handler::MessageHandler;
 use curvine_rpc::message::{Builder, Message, RequestStatus, ResponseStatus};
@@ -57,6 +57,11 @@ pub struct WorkerHandler {
     /// protocol negotiation on top of it happens in the client-worker
     /// compatibility layer (T10).
     pub connection_peer: FastMutex<ConnectionPeer>,
+    /// Compatibility policy applied to client peers on this data connection.
+    /// Built once per worker from `worker.compatibility` config; diagnose by
+    /// default so old clients are never rejected without explicit
+    /// configuration.
+    pub compatibility_policy: CompatibilityPolicy,
 }
 
 impl MessageHandler for WorkerHandler {
@@ -78,8 +83,9 @@ impl MessageHandler for WorkerHandler {
         let code = RpcCode::from(msg.code());
         // Record the client's component info on this connection (best-effort;
         // running data frames carry no version payload and legacy clients omit
-        // the field entirely).
-        self.record_peer_component_info(msg);
+        // the field entirely). In enforce mode an incompatible peer is
+        // rejected here, on the first data-plane open frame.
+        self.record_peer_component_info(msg)?;
 
         match code {
             RpcCode::SubmitTask => self.task_submit(msg),
@@ -177,35 +183,90 @@ impl WorkerHandler {
         }
     }
 
-    /// Resolve and record the client's `component_info` for this connection.
-    /// Resolution happens exactly once, from the first data-plane open frame:
-    /// a new client carries `component_info` on it (`Known`), a legacy client
-    /// does not (`Legacy`). After resolution the worker never parses another
-    /// header for peer metadata, so at most one frame per connection pays the
-    /// decode cost (the business handlers decode the same headers anyway).
-    /// Legacy/unknown peers are never rejected.
-    fn record_peer_component_info(&self, msg: &Message) {
+    /// Resolve and record the client's `component_info` for this connection,
+    /// then evaluate the resolved peer against this worker's compatibility
+    /// policy. Resolution happens exactly once, from the first data-plane open
+    /// frame: a new client carries `component_info` on it (`Known`), a legacy
+    /// client does not (`Legacy`). After resolution the worker never parses
+    /// another header for peer metadata, so at most one frame per connection
+    /// pays the decode cost (the business handlers decode the same headers
+    /// anyway).
+    ///
+    /// Compatibility handling (T10):
+    /// - `diagnose` (default): record a warning for incompatible peers and
+    ///   allow the request, so old clients are never rejected without explicit
+    ///   configuration;
+    /// - `enforce`: reject the first data-plane open frame with an explicit
+    ///   error. The evaluation is skipped entirely when the policy cannot be
+    ///   acted upon (default diagnose with no bounds/blocklist and a legacy
+    ///   peer that reported nothing), mirroring the master's hot-path
+    ///   avoidance.
+    fn record_peer_component_info(&self, msg: &Message) -> FsResult<()> {
         let mut peer = self.connection_peer.lock();
         if !matches!(*peer, ConnectionPeer::Unknown) {
-            return;
+            return Ok(());
         }
         let Some(resolved) = Self::resolve_connection_peer(msg) else {
-            return;
+            return Ok(());
         };
+        // Evaluate the resolved peer (Known or Legacy) against the policy
+        // BEFORE committing it to the connection. Diagnose mode logs a warning
+        // for incompatible peers and allows the request; enforce mode rejects
+        // the first open frame. Evaluating first keeps the rejection airtight:
+        // an enforce-rejected peer is never committed, so a retried frame is
+        // resolved and evaluated again and stays rejected. The evaluation is
+        // skipped when it could not change the outcome (default diagnose, no
+        // bounds/blocklist, legacy peer with no component info) to avoid log
+        // spam on every legacy connection.
+        let peer_is_known = matches!(&resolved, ConnectionPeer::Known(_));
+        if self.compatibility_policy.should_evaluate(peer_is_known) {
+            Self::evaluate_peer(&self.compatibility_policy, &resolved)?;
+        }
         match resolved {
             ConnectionPeer::Known(info) => {
                 info!(
-                    "peer component info on data connection: component={}, release_version={}, protocol_version={:?}, min_protocol_version={:?}",
+                    "peer component info on data connection: component={}, release_version={}, protocol_version={:?}, min_protocol_version={:?}, capabilities={:?}",
                     info.component.as_deref().unwrap_or("unknown"),
                     info.release_version.as_deref().unwrap_or("unknown"),
                     info.protocol_version,
                     info.min_protocol_version,
+                    info.capabilities,
                 );
                 *peer = ConnectionPeer::Known(info);
             }
             ConnectionPeer::Legacy => *peer = ConnectionPeer::Legacy,
             ConnectionPeer::Unknown => unreachable!("resolution always yields Known or Legacy"),
         }
+        Ok(())
+    }
+
+    /// Evaluate a resolved connection peer against the worker's compatibility
+    /// policy. `diagnose` (default) logs a warning and allows the request;
+    /// `enforce` rejects with an explicit error describing the actual peer
+    /// version, the expected bound and the upgrade suggestion. Pure, so the
+    /// diagnose/enforce decision is unit-testable without a full
+    /// `WorkerHandler`. `Unknown` peers never evaluate.
+    fn evaluate_peer(policy: &CompatibilityPolicy, peer: &ConnectionPeer) -> FsResult<()> {
+        let info = match peer {
+            ConnectionPeer::Known(info) => Some(info),
+            ConnectionPeer::Legacy => None,
+            ConnectionPeer::Unknown => return Ok(()),
+        };
+        let verdict = policy.check_client(info);
+        if verdict.is_compatible() {
+            return Ok(());
+        }
+        if verdict.rejects(policy.mode) {
+            return err_box!(
+                "client rejected by compatibility policy: {}; upgrade the client or set worker.compatibility.mode = \"diagnose\" to allow it",
+                verdict.describe()
+            );
+        }
+        log::warn!(
+            "client peer on data connection incompatible (diagnose): {}",
+            verdict.describe()
+        );
+        Ok(())
     }
 
     /// The component info recorded for the peer on this connection. `None`
@@ -216,6 +277,21 @@ impl WorkerHandler {
             ConnectionPeer::Known(info) => Some(info.clone()),
             ConnectionPeer::Unknown | ConnectionPeer::Legacy => None,
         }
+    }
+
+    /// Capabilities declared by the peer on this connection, empty for
+    /// unresolved or legacy clients. Feature-level negotiation token: a
+    /// feature is enabled only when both the worker and the peer declare it.
+    pub fn peer_capabilities(&self) -> Vec<String> {
+        match &*self.connection_peer.lock() {
+            ConnectionPeer::Known(info) => info.capabilities.clone(),
+            ConnectionPeer::Unknown | ConnectionPeer::Legacy => Vec::new(),
+        }
+    }
+
+    /// Whether the peer on this connection declared the given capability.
+    pub fn peer_declares_capability(&self, feature: &str) -> bool {
+        self.peer_capabilities().iter().any(|c| c == feature)
     }
 
     fn get_handler<'a>(
@@ -649,5 +725,130 @@ mod tests {
         };
         let msg = build_msg(RpcCode::QueryTransferTask, RequestStatus::Open, header);
         assert_eq!(WorkerHandler::resolve_connection_peer(&msg), None);
+    }
+
+    // ---- T10: per-connection peer compatibility evaluation ----
+
+    use curvine_model::{CompatibilityMode, CompatibilityPolicy};
+    use curvine_sys::version::ReleaseVersion;
+
+    fn version(v: &str) -> ReleaseVersion {
+        ReleaseVersion::parse(v).unwrap()
+    }
+
+    fn client_info(release_version: &str, protocol_version: u32) -> ComponentInfoProto {
+        ComponentInfoProto {
+            component: Some("client".to_string()),
+            release_version: Some(release_version.to_string()),
+            git_commit: Some("abc".to_string()),
+            git_tag: Some(String::new()),
+            git_branch: Some("main".to_string()),
+            protocol_version: Some(protocol_version),
+            min_protocol_version: Some(protocol_version),
+            capabilities: vec!["batch-write".to_string()],
+        }
+    }
+
+    fn default_policy() -> CompatibilityPolicy {
+        CompatibilityPolicy::default()
+    }
+
+    #[test]
+    fn compatible_peer_is_allowed_under_default_policy() {
+        // Default worker policy (diagnose, no bounds): a new client that
+        // reports a compatible protocol version is accepted in both modes.
+        let policy = default_policy();
+        let peer = ConnectionPeer::Known(client_info("0.4.0-alpha", 1));
+        assert!(WorkerHandler::evaluate_peer(&policy, &peer).is_ok());
+        // Even under enforce, the default policy carries no bounds, so nothing
+        // is rejected.
+        let enforce = CompatibilityPolicy {
+            mode: CompatibilityMode::Enforce,
+            ..default_policy()
+        };
+        assert!(WorkerHandler::evaluate_peer(&enforce, &peer).is_ok());
+    }
+
+    #[test]
+    fn protocol_mismatch_is_warned_in_diagnose_and_rejected_in_enforce() {
+        // 协议不匹配: a client speaking protocol 2 against a worker that only
+        // supports protocol 1.
+        let policy = default_policy();
+        let peer = ConnectionPeer::Known(client_info("0.4.0", 2));
+        // diagnose: allowed (only a warning is logged).
+        assert!(WorkerHandler::evaluate_peer(&policy, &peer).is_ok());
+        // enforce: rejected with an explicit error describing the mismatch.
+        let enforce = CompatibilityPolicy {
+            mode: CompatibilityMode::Enforce,
+            ..default_policy()
+        };
+        let err = WorkerHandler::evaluate_peer(&enforce, &peer).unwrap_err();
+        assert!(err.to_string().contains("protocol version 2"));
+        assert!(err.to_string().contains("diagnose"));
+    }
+
+    #[test]
+    fn old_client_version_is_warned_in_diagnose_and_rejected_in_enforce() {
+        // 旧 client: an explicitly configured min_client_version rejects an
+        // older client only in enforce mode; diagnose allows it with a
+        // warning.
+        let policy = CompatibilityPolicy {
+            mode: CompatibilityMode::Diagnose,
+            min_client_version: Some(version("0.2.0")),
+            ..default_policy()
+        };
+        let old_client = ConnectionPeer::Known(client_info("0.1.5", 1));
+        assert!(WorkerHandler::evaluate_peer(&policy, &old_client).is_ok());
+
+        let enforce = CompatibilityPolicy {
+            mode: CompatibilityMode::Enforce,
+            min_client_version: Some(version("0.2.0")),
+            ..default_policy()
+        };
+        let err = WorkerHandler::evaluate_peer(&enforce, &old_client).unwrap_err();
+        assert!(err.to_string().contains("0.1.5"));
+        assert!(err.to_string().contains("0.2.0"));
+    }
+
+    #[test]
+    fn legacy_peer_is_allowed_in_diagnose_and_rejected_in_enforce() {
+        // 新 worker + 旧 client: a legacy client that never reported
+        // component_info is allowed under diagnose (the default) and rejected
+        // only when the worker is explicitly configured to enforce.
+        let policy = default_policy();
+        assert!(WorkerHandler::evaluate_peer(&policy, &ConnectionPeer::Legacy).is_ok());
+
+        let enforce = CompatibilityPolicy {
+            mode: CompatibilityMode::Enforce,
+            ..default_policy()
+        };
+        let err = WorkerHandler::evaluate_peer(&enforce, &ConnectionPeer::Legacy).unwrap_err();
+        assert!(err.to_string().contains("no component version info"));
+    }
+
+    #[test]
+    fn blocked_version_is_always_rejected_regardless_of_mode() {
+        // Blocked versions are an explicit operator backstop: rejected even in
+        // diagnose mode.
+        let policy = CompatibilityPolicy {
+            blocked_versions: vec![version("0.2.5")],
+            ..default_policy()
+        };
+        let blocked = ConnectionPeer::Known(client_info("0.2.5", 1));
+        let err = WorkerHandler::evaluate_peer(&policy, &blocked).unwrap_err();
+        assert!(err.to_string().contains("blocked"));
+
+        let enforce = CompatibilityPolicy {
+            mode: CompatibilityMode::Enforce,
+            blocked_versions: vec![version("0.2.5")],
+            ..default_policy()
+        };
+        assert!(WorkerHandler::evaluate_peer(&enforce, &blocked).is_err());
+    }
+
+    #[test]
+    fn unknown_peer_never_evaluates() {
+        let policy = default_policy();
+        assert!(WorkerHandler::evaluate_peer(&policy, &ConnectionPeer::Unknown).is_ok());
     }
 }

--- a/curvine-worker/src/worker/handler/worker_handler.rs
+++ b/curvine-worker/src/worker/handler/worker_handler.rs
@@ -43,6 +43,17 @@ pub enum ConnectionPeer {
     Known(ComponentInfoProto),
 }
 
+impl ConnectionPeer {
+    /// Whether the peer declared the given capability. Allocation-free, so it
+    /// is safe on a hot path; `Unknown`/`Legacy` peers declare nothing.
+    pub fn declares_capability(&self, feature: &str) -> bool {
+        match self {
+            ConnectionPeer::Known(info) => info.capabilities.iter().any(|c| c == feature),
+            ConnectionPeer::Unknown | ConnectionPeer::Legacy => false,
+        }
+    }
+}
+
 pub struct WorkerHandler {
     pub store: BlockStore,
     pub handler: FastMutex<Option<BlockHandler>>,
@@ -58,10 +69,11 @@ pub struct WorkerHandler {
     /// compatibility layer (T10).
     pub connection_peer: FastMutex<ConnectionPeer>,
     /// Compatibility policy applied to client peers on this data connection.
-    /// Built once per worker from `worker.compatibility` config; diagnose by
-    /// default so old clients are never rejected without explicit
-    /// configuration.
-    pub compatibility_policy: CompatibilityPolicy,
+    /// Built once per worker from `worker.compatibility` config and shared
+    /// with every per-connection handler through an `Arc` (no per-connection
+    /// deep copy); diagnose by default so old clients are never rejected
+    /// without explicit configuration.
+    pub compatibility_policy: Arc<CompatibilityPolicy>,
 }
 
 impl MessageHandler for WorkerHandler {
@@ -282,6 +294,8 @@ impl WorkerHandler {
     /// Capabilities declared by the peer on this connection, empty for
     /// unresolved or legacy clients. Feature-level negotiation token: a
     /// feature is enabled only when both the worker and the peer declare it.
+    /// Returns a snapshot for observability; hot-path capability checks should
+    /// use [`Self::peer_declares_capability`], which avoids this allocation.
     pub fn peer_capabilities(&self) -> Vec<String> {
         match &*self.connection_peer.lock() {
             ConnectionPeer::Known(info) => info.capabilities.clone(),
@@ -290,8 +304,10 @@ impl WorkerHandler {
     }
 
     /// Whether the peer on this connection declared the given capability.
+    /// Allocation-free: inspects the locked connection peer directly instead
+    /// of cloning the capabilities vector, so it is safe on a hot path.
     pub fn peer_declares_capability(&self, feature: &str) -> bool {
-        self.peer_capabilities().iter().any(|c| c == feature)
+        self.connection_peer.lock().declares_capability(feature)
     }
 
     fn get_handler<'a>(
@@ -850,5 +866,16 @@ mod tests {
     fn unknown_peer_never_evaluates() {
         let policy = default_policy();
         assert!(WorkerHandler::evaluate_peer(&policy, &ConnectionPeer::Unknown).is_ok());
+    }
+
+    #[test]
+    fn peer_capability_check_is_allocation_free_and_accurate() {
+        // Capability negotiation: a feature is declared only when the peer
+        // actually lists it; legacy/unknown peers declare nothing.
+        let peer = ConnectionPeer::Known(client_info("0.4.0", 1));
+        assert!(peer.declares_capability("batch-write"));
+        assert!(!peer.declares_capability("short-circuit"));
+        assert!(!ConnectionPeer::Legacy.declares_capability("batch-write"));
+        assert!(!ConnectionPeer::Unknown.declares_capability("batch-write"));
     }
 }

--- a/curvine-worker/src/worker/handler/worker_handler.rs
+++ b/curvine-worker/src/worker/handler/worker_handler.rs
@@ -20,7 +20,7 @@ use curvine_core_error::err_box;
 use curvine_error::FsError;
 use curvine_error::FsResult;
 use curvine_fs_api::RpcCode;
-use curvine_model::{CompatibilityPolicy, LoadTaskInfo};
+use curvine_model::{CompatibilityPolicy, CompatibilityVerdict, LoadTaskInfo};
 use curvine_proto::*;
 use curvine_rpc::handler::MessageHandler;
 use curvine_rpc::message::{Builder, Message, RequestStatus, ResponseStatus};
@@ -270,8 +270,9 @@ impl WorkerHandler {
         }
         if verdict.rejects(policy.mode) {
             return err_box!(
-                "client rejected by compatibility policy: {}; upgrade the client or set worker.compatibility.mode = \"diagnose\" to allow it",
-                verdict.describe()
+                "client rejected by compatibility policy: {}; {}",
+                verdict.describe(),
+                Self::rejection_hint(&verdict)
             );
         }
         log::warn!(
@@ -279,6 +280,19 @@ impl WorkerHandler {
             verdict.describe()
         );
         Ok(())
+    }
+
+    /// Operator guidance appended to a rejection error. Most verdicts are
+    /// mode-dependent, so the hint points at the diagnose/enforce switch;
+    /// blocked versions reject regardless of mode, so the hint must point at
+    /// the blocklist instead of a mode change that would not help.
+    fn rejection_hint(verdict: &CompatibilityVerdict) -> &'static str {
+        match verdict {
+            CompatibilityVerdict::Blocked(_) => {
+                "remove the version from worker.compatibility.blocked_versions to allow it"
+            }
+            _ => "upgrade the client or set worker.compatibility.mode = \"diagnose\" to allow it",
+        }
     }
 
     /// The component info recorded for the peer on this connection. `None`
@@ -845,14 +859,24 @@ mod tests {
     #[test]
     fn blocked_version_is_always_rejected_regardless_of_mode() {
         // Blocked versions are an explicit operator backstop: rejected even in
-        // diagnose mode.
+        // diagnose mode. The rejection hint must point at the blocklist, not
+        // at the diagnose/enforce switch (which would not help for Blocked).
         let policy = CompatibilityPolicy {
             blocked_versions: vec![version("0.2.5")],
             ..default_policy()
         };
         let blocked = ConnectionPeer::Known(client_info("0.2.5", 1));
         let err = WorkerHandler::evaluate_peer(&policy, &blocked).unwrap_err();
-        assert!(err.to_string().contains("blocked"));
+        let msg = err.to_string();
+        assert!(msg.contains("blocked"));
+        assert!(
+            msg.contains("blocked_versions"),
+            "blocked rejection should point at the blocklist: {msg}"
+        );
+        assert!(
+            !msg.contains("diagnose"),
+            "blocked rejection must not suggest switching to diagnose: {msg}"
+        );
 
         let enforce = CompatibilityPolicy {
             mode: CompatibilityMode::Enforce,

--- a/curvine-worker/src/worker/worker_server.rs
+++ b/curvine-worker/src/worker/worker_server.rs
@@ -22,7 +22,7 @@ use curvine_config::ClusterConf;
 use curvine_core_error::StringError;
 use curvine_core_error::{CommonError, CommonResult};
 use curvine_fault::FaultHttpControl;
-use curvine_model::{HeartbeatStatus, WorkerAddress};
+use curvine_model::{CompatibilityPolicy, HeartbeatStatus, WorkerAddress};
 use curvine_net::net::ConnState;
 use curvine_rpc::handler::HandlerService;
 use curvine_rpc::server::{RpcServer, ServerStateListener};
@@ -50,6 +50,10 @@ pub struct WorkerService {
     rt: Arc<Runtime>,
     replication_manager: Arc<WorkerReplicationManager>,
     fault_http: FaultHttpControl,
+    /// Compatibility policy applied to client peers on data-plane connections.
+    /// Built once from `worker.compatibility` config (diagnose by default) and
+    /// shared by every per-connection `WorkerHandler`.
+    compatibility_policy: CompatibilityPolicy,
 }
 
 impl WorkerService {
@@ -74,6 +78,7 @@ impl WorkerService {
             rt,
             replication_manager,
             fault_http,
+            compatibility_policy: conf.worker.compatibility.to_policy(),
         };
         Ok(ws)
     }
@@ -98,6 +103,7 @@ impl HandlerService for WorkerService {
             task_manager: self.task_manager.clone(),
             rt: self.rt.clone(),
             replication_handler: WorkerReplicationHandler::new(&self.replication_manager),
+            compatibility_policy: self.compatibility_policy.clone(),
         }
     }
 }

--- a/curvine-worker/src/worker/worker_server.rs
+++ b/curvine-worker/src/worker/worker_server.rs
@@ -52,8 +52,9 @@ pub struct WorkerService {
     fault_http: FaultHttpControl,
     /// Compatibility policy applied to client peers on data-plane connections.
     /// Built once from `worker.compatibility` config (diagnose by default) and
-    /// shared by every per-connection `WorkerHandler`.
-    compatibility_policy: CompatibilityPolicy,
+    /// shared by every per-connection `WorkerHandler` through an `Arc`, so
+    /// handlers share the policy without deep-copying it per connection.
+    compatibility_policy: Arc<CompatibilityPolicy>,
 }
 
 impl WorkerService {
@@ -78,7 +79,7 @@ impl WorkerService {
             rt,
             replication_manager,
             fault_http,
-            compatibility_policy: conf.worker.compatibility.to_policy(),
+            compatibility_policy: Arc::new(conf.worker.compatibility.to_policy()),
         };
         Ok(ws)
     }


### PR DESCRIPTION
# Summary

Implements the T10 step of the component version-management plan (#1527): client-worker protocol negotiation and pre-check. The worker evaluates the client peer's structured version (already recorded per connection in T9) against its `[worker.compatibility]` policy on the first data-plane open frame — warn in `diagnose` (default), reject in `enforce` (explicit config only). The client caches the live-worker versions the master reports on `GetFilesystemInfo` and pre-checks a worker's protocol/version/capabilities before opening a data connection (diagnose-only, never refuses). Default behavior unchanged: old components are never rejected, only logged / pre-checked.

# Issue Describe / Design

Closes #1527

Design decisions (from the version-management design, sections 8.3–8.5 and 10.2):

- **Worker side**: reuse the per-connection `ConnectionPeer` cache from T9. The check runs exactly once, on the first data-plane open frame, before the peer is committed — so an enforce-rejected peer is never recorded and a retried frame is evaluated again and stays rejected. `diagnose` (default) logs a warning and allows the request; `enforce` rejects with an explicit error naming the peer version, the expected bound and the upgrade suggestion. A legacy client (no `component_info`) is allowed under `diagnose` and rejected only under `enforce`, mirroring the master-side policy.
- **Worker config**: new `[worker.compatibility]` section reusing the shared `CompatibilityConf` (`mode` / `min_client_version` / `blocked_versions`; `min_worker_version` is ignored for a worker). Defaults stay lenient: `diagnose`, no bounds, no blocklist.
- **Client side**: `FsContext` caches the live workers (with structured `component_info`) from every successful `GetFilesystemInfo`, and `WorkerPrecheck` evaluates a worker's `protocol_version` against the client's own supported range plus the master-advertised `min_worker_version` / `blocked_versions` before a data connection is opened. The pre-check is **diagnose-only by design** (T10 acceptance): incompatible workers are warned once per worker per verdict change, never rejected. Workers the master has not reported, or legacy workers without `component_info`, are allowed silently — enforcement is left to the worker's own diagnose/enforce policy.
- Capabilities are logged at peer resolution on the worker and exposed via `peer_capabilities()` / `peer_declares_capability()` for future feature-level negotiation (a feature is enabled only when both peers declare it).

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `crates/common/curvine-config/src/worker_conf.rs` | Add `compatibility: CompatibilityConf` to `WorkerConf` (default diagnose) | None (config default) |
| `curvine-worker/src/worker/worker_server.rs` | Build the worker `CompatibilityPolicy` once from config and pass it to every per-connection `WorkerHandler` | None |
| `curvine-worker/src/worker/handler/worker_handler.rs` | Evaluate the resolved connection peer against the policy on the first data-plane open frame; diagnose warns / enforce rejects; log and expose peer capabilities | None by default (diagnose); explicit `enforce` config rejects incompatible clients |
| `crates/client/curvine-client-core/src/file/worker_precheck.rs` | New `WorkerPrecheck`: diagnose-only client-side worker pre-check (protocol range + master-advertised bounds) with per-worker warn dedup | None (log only) |
| `crates/client/curvine-client-core/src/file/fs_context.rs` | Cache master-reported live workers; run the pre-check before opening a data connection (`block_client`) | None (log only) |
| `crates/client/curvine-client-core/src/file/fs_client.rs` | Populate the live-worker cache from `GetFilesystemInfo` (typed and raw-bytes paths) | None |
| `curvine-server/tests/worker_test.rs` | Integration tests: enforce worker rejects an old client on the first open frame; diagnose worker allows the same old client | Test only |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-client-core --lib` (incl. new `worker_precheck` tests) | PASS | 39 passed |
| `cargo test -p curvine-worker --lib` (incl. new peer evaluation tests) | PASS | 27 passed, 1 ignored |
| `cargo test -p curvine-server --test worker_test` (incl. new enforce/diagnose integration tests) | PASS | 8 passed |
| `cargo test -p curvine-config --lib` | PASS | 54 passed |
| `cargo test -p curvine-model --lib` (compat) | PASS | 14 passed |
| `make format` (fmt + clippy `--deny warnings --all-targets`) | PASS | exit 0 |

Coverage for the T10 acceptance criteria:
- 旧 worker + 新 client: `master_min_worker_version_flags_old_worker` (worker below the master-advertised minimum is flagged but never rejected); default pre-check leaves compatible/legacy workers untouched.
- 新 worker + 旧 client: `protocol_mismatch_worker_is_flagged_but_never_rejected` (client side) and `legacy_peer_is_allowed_in_diagnose_and_rejected_in_enforce` (worker side).
- 协议不匹配: `protocol_mismatch_is_warned_in_diagnose_and_rejected_in_enforce` (worker unit), plus integration `test_worker_enforce_mode_rejects_old_client_on_first_open_frame` / `test_worker_diagnose_mode_allows_old_client_on_data_plane`.
- Acceptance "默认不拒绝": `test_worker_diagnose_mode_allows_old_client_on_data_plane` and the default-policy unit tests assert incompatible/legacy peers are allowed.

# Dependencies

- Related PRs: #1587 (T9 worker data-plane component info), #1585 (T8 compat checker), #1582 (T6 client-master handshake), #1581 (T5 GetMasterInfo extension), #1584 (T7 worker heartbeat version)
- Related issues: #1527
- Blocks / blocked by: builds on T9 (merged); T12 (compatibility matrix / observability) depends on this PR