### PR TITLE
feat(io): add pread and pwrite without moving the file offset

### DIFF
--- a/crates/core/curvine-io/src/local_file.rs
+++ b/crates/core/curvine-io/src/local_file.rs
@@ -26,6 +26,9 @@ use std::path::Path;
 #[cfg(target_os = "linux")]
 use std::os::unix::io::{AsRawFd, RawFd};
 
+#[cfg(unix)]
+use std::os::unix::fs::FileExt;
+
 macro_rules! err_box {
     ($e:expr) => {{
         let message = format!(
@@ -217,6 +220,65 @@ impl LocalFile {
         self.len == 0
     }
 
+    pub fn pread(&self, buf: &mut [u8], offset: u64) -> IOResult<usize> {
+        #[cfg(unix)]
+        {
+            let n = try_err!(self.inner.read_at(buf, offset));
+            Ok(n)
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = (buf, offset);
+            err_box!("pread is not supported on this platform")
+        }
+    }
+
+    pub fn pread_exact(&self, buf: &mut [u8], offset: u64) -> IOResult<()> {
+        #[cfg(unix)]
+        {
+            try_err!(self.inner.read_exact_at(buf, offset));
+            Ok(())
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = (buf, offset);
+            err_box!("pread is not supported on this platform")
+        }
+    }
+
+    pub fn pread_full(&self, offset: u64, len: usize) -> IOResult<BytesMut> {
+        let mut buf = BytesMut::with_capacity(len);
+        unsafe { buf.set_len(len) }
+        self.pread_exact(&mut buf, offset)?;
+        Ok(buf)
+    }
+
+    pub fn pwrite(&self, buf: &[u8], offset: u64) -> IOResult<usize> {
+        #[cfg(unix)]
+        {
+            let n = try_err!(self.inner.write_at(buf, offset));
+            Ok(n)
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = (buf, offset);
+            err_box!("pwrite is not supported on this platform")
+        }
+    }
+
+    pub fn pwrite_all(&self, buf: &[u8], offset: u64) -> IOResult<()> {
+        #[cfg(unix)]
+        {
+            try_err!(self.inner.write_all_at(buf, offset));
+            Ok(())
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = (buf, offset);
+            err_box!("pwrite is not supported on this platform")
+        }
+    }
+
     pub fn seek(&mut self, pos: i64) -> IOResult<i64> {
         if pos == self.pos {
             return Ok(pos);
@@ -336,5 +398,94 @@ impl Write for LocalFile {
 
     fn flush(&mut self) -> std::io::Result<()> {
         self.inner.flush()
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::LocalFile;
+    use curvine_runtime::common::Utils;
+    use std::fs::remove_file;
+
+    fn test_path() -> String {
+        let path = Utils::test_file();
+        if let Some(parent) = std::path::Path::new(&path).parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        path
+    }
+
+    #[test]
+    fn pread_pwrite_do_not_move_cursor() {
+        let path = test_path();
+        let file = LocalFile::with_write(&path, true).unwrap();
+
+        file.pwrite_all(b"hello world", 0).unwrap();
+        assert_eq!(file.pos(), 0);
+        assert_eq!(file.len(), 0, "pwrite must not update cached len");
+
+        let mut buf = [0u8; 5];
+        assert_eq!(file.pread(&mut buf, 6).unwrap(), 5);
+        assert_eq!(&buf, b"world");
+        assert_eq!(file.pos(), 0);
+
+        file.pwrite_all(b"RUST", 6).unwrap();
+        assert_eq!(file.pos(), 0);
+
+        let got = file.pread_full(0, 11).unwrap();
+        assert_eq!(&got[..], b"hello RUSTd");
+
+        remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn pwrite_does_not_update_cached_len() {
+        let path = test_path();
+        let mut file = LocalFile::with_write(&path, true).unwrap();
+        file.write_all(b"abc").unwrap();
+        assert_eq!(file.pos(), 3);
+        assert_eq!(file.len(), 3);
+
+        file.pwrite_all(b"xyz", 10).unwrap();
+        assert_eq!(file.pos(), 3, "pwrite must not move the cursor");
+        assert_eq!(file.len(), 3, "pwrite must not update cached len");
+
+        let got = file.pread_full(10, 3).unwrap();
+        assert_eq!(&got[..], b"xyz");
+
+        remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn pread_exact_fails_at_eof() {
+        let path = test_path();
+        let file = LocalFile::with_write(&path, true).unwrap();
+        file.pwrite_all(b"abc", 0).unwrap();
+
+        let mut buf = [0u8; 4];
+        assert!(file.pread_exact(&mut buf, 0).is_err());
+
+        remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn pread_pwrite_roundtrip_random_offsets() {
+        let path = test_path();
+        let file = LocalFile::with_write(&path, true).unwrap();
+
+        file.pwrite_all(&[1u8; 4096], 0).unwrap();
+        file.pwrite_all(&[2u8; 4096], 4096).unwrap();
+        file.pwrite_all(&[3u8; 100], 8192).unwrap();
+
+        let a = file.pread_full(0, 4096).unwrap();
+        let b = file.pread_full(4096, 4096).unwrap();
+        let c = file.pread_full(8192, 100).unwrap();
+        assert!(a.iter().all(|&x| x == 1));
+        assert!(b.iter().all(|&x| x == 2));
+        assert!(c.iter().all(|&x| x == 3));
+        assert_eq!(file.len(), 0, "pwrite must not update cached len");
+        assert_eq!(file.pos(), 0);
+
+        remove_file(&path).unwrap();
     }
 }

--- a/crates/core/curvine-sys/src/sys_libc.rs
+++ b/crates/core/curvine-sys/src/sys_libc.rs
@@ -328,6 +328,100 @@ pub fn read_full(fd: RawIO, buf: &mut [u8]) -> SysResult<()> {
     Ok(())
 }
 
+/// pub unsafe extern "C" fn pread64(
+///     fd: c_int,
+///     buf: *mut c_void,
+///     count: size_t,
+///     offset: off64_t,
+/// ) -> ssize_t
+///
+/// May return a short read. Use [`pread_full`] when `buf.len()` bytes are required.
+pub fn pread(fd: RawIO, buf: &mut [u8], offset: u64) -> SysResult<CInt> {
+    #[cfg(not(target_os = "linux"))]
+    {
+        sys_error!(ErrorKind::Unsupported, "unsupported operation")
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let res = unsafe {
+            libc::pread64(
+                fd,
+                buf.as_mut_ptr() as *mut libc::c_void,
+                buf.len() as libc::size_t,
+                offset as libc::off64_t,
+            )
+        };
+        sys_call!(res)
+    }
+}
+
+/// Loop [`pread`] until `buf` is filled or EOF/error. Does not move the fd offset.
+pub fn pread_full(fd: RawIO, buf: &mut [u8], offset: u64) -> SysResult<()> {
+    let mut remaining = buf.len();
+    let mut buf_off = 0;
+    let mut file_off = offset;
+
+    while remaining > 0 {
+        let read_len = pread(fd, &mut buf[buf_off..], file_off)? as usize;
+        if read_len == 0 {
+            return sys_error!(ErrorKind::UnexpectedEof, "pread returned 0");
+        }
+        remaining -= read_len;
+        buf_off += read_len;
+        file_off += read_len as u64;
+    }
+
+    Ok(())
+}
+
+/// pub unsafe extern "C" fn pwrite64(
+///     fd: c_int,
+///     buf: *const c_void,
+///     count: size_t,
+///     offset: off64_t,
+/// ) -> ssize_t
+///
+/// May return a short write. Use [`pwrite_full`] when all bytes must be written.
+pub fn pwrite(fd: RawIO, buf: &[u8], offset: u64) -> SysResult<CInt> {
+    #[cfg(not(target_os = "linux"))]
+    {
+        sys_error!(ErrorKind::Unsupported, "unsupported operation")
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let res = unsafe {
+            libc::pwrite64(
+                fd,
+                buf.as_ptr() as *const libc::c_void,
+                buf.len() as libc::size_t,
+                offset as libc::off64_t,
+            )
+        };
+        sys_call!(res)
+    }
+}
+
+/// Loop [`pwrite`] until `buf` is fully written. Does not move the fd offset.
+pub fn pwrite_full(fd: RawIO, buf: &[u8], offset: u64) -> SysResult<()> {
+    let mut remaining = buf.len();
+    let mut buf_off = 0;
+    let mut file_off = offset;
+
+    while remaining > 0 {
+        let write_len = pwrite(fd, &buf[buf_off..], file_off)? as usize;
+        if write_len == 0 {
+            return sys_error!(ErrorKind::WriteZero, "pwrite returned 0");
+        }
+        remaining -= write_len;
+        buf_off += write_len;
+        file_off += write_len as u64;
+    }
+
+    Ok(())
+}
+
 pub fn writev(fd: RawIO, bufs: &[IoSlice<'_>]) -> SysResult<CInt> {
     #[cfg(not(target_os = "linux"))]
     {
@@ -666,5 +760,104 @@ pub fn fcntl_set(fd: RawIO, flags: CInt) -> SysResult<CInt> {
     #[cfg(not(target_os = "linux"))]
     {
         sys_error!(ErrorKind::Unsupported, "unsupported operation")
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+    use curvine_runtime::common::Utils;
+    use std::fs::{remove_file, OpenOptions};
+    use std::io::Seek;
+    use std::os::unix::io::AsRawFd;
+
+    fn open_temp() -> (String, std::fs::File) {
+        let path = Utils::test_file();
+        if let Some(parent) = std::path::Path::new(&path).parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&path)
+            .unwrap();
+        (path, file)
+    }
+
+    #[test]
+    fn pread_pwrite_roundtrip_does_not_move_offset() {
+        let (path, mut file) = open_temp();
+        let fd = file.as_raw_fd();
+
+        pwrite_full(fd, b"hello world", 0).unwrap();
+        assert_eq!(file.stream_position().unwrap(), 0);
+
+        let mut buf = [0u8; 5];
+        assert_eq!(pread(fd, &mut buf, 6).unwrap(), 5);
+        assert_eq!(&buf, b"world");
+        assert_eq!(file.stream_position().unwrap(), 0);
+
+        pwrite_full(fd, b"RUST", 6).unwrap();
+        let mut got = [0u8; 11];
+        pread_full(fd, &mut got, 0).unwrap();
+        assert_eq!(&got, b"hello RUSTd");
+        assert_eq!(file.stream_position().unwrap(), 0);
+
+        remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn pread_may_return_short_at_eof() {
+        let (path, file) = open_temp();
+        let fd = file.as_raw_fd();
+        pwrite_full(fd, b"abc", 0).unwrap();
+
+        let mut buf = [0u8; 8];
+        assert_eq!(pread(fd, &mut buf, 0).unwrap(), 3);
+        assert_eq!(&buf[..3], b"abc");
+
+        remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn pread_full_reads_requested_length() {
+        let (path, file) = open_temp();
+        let fd = file.as_raw_fd();
+        pwrite_full(fd, &[1u8; 4096], 0).unwrap();
+        pwrite_full(fd, &[2u8; 100], 4096).unwrap();
+
+        let mut a = [0u8; 4096];
+        pread_full(fd, &mut a, 0).unwrap();
+        assert!(a.iter().all(|&x| x == 1));
+
+        let mut b = [0u8; 100];
+        pread_full(fd, &mut b, 4096).unwrap();
+        assert!(b.iter().all(|&x| x == 2));
+
+        remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn pread_full_eof_is_unexpected_eof() {
+        let (path, file) = open_temp();
+        let fd = file.as_raw_fd();
+        pwrite_full(fd, b"abc", 0).unwrap();
+
+        let mut buf = [0u8; 4];
+        let err = pread_full(fd, &mut buf, 0).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::UnexpectedEof);
+
+        remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn pread_full_empty_buf_succeeds() {
+        let (path, file) = open_temp();
+        let fd = file.as_raw_fd();
+        pread_full(fd, &mut [], 0).unwrap();
+        pwrite_full(fd, &[], 0).unwrap();
+        remove_file(&path).unwrap();
     }
 }

--- a/crates/core/runtime/src/common/utils.rs
+++ b/crates/core/runtime/src/common/utils.rs
@@ -26,6 +26,7 @@ use std::panic::AssertUnwindSafe;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 use std::{env, fs, panic, process, thread};
+use tokio_util::bytes::BytesMut;
 use uuid::Uuid;
 
 pub struct Utils;
@@ -68,6 +69,12 @@ impl Utils {
 
     pub fn murmur3(bytes: &[u8]) -> u32 {
         murmur3::murmur3_32(&mut Cursor::new(bytes), 104729).unwrap()
+    }
+
+    pub fn uninit_bytes_mut(len: usize) -> BytesMut {
+        let mut buf = BytesMut::with_capacity(len);
+        unsafe { buf.set_len(len) }
+        buf
     }
 
     pub fn crc32(buf: &[u8]) -> u32 {

--- a/crates/core/runtime/src/sync/mutex.rs
+++ b/crates/core/runtime/src/sync/mutex.rs
@@ -14,6 +14,7 @@
 
 use parking_lot::{Mutex, RwLock};
 use std::ops::Deref;
+use std::sync::{Mutex as StdSyncMutex, RwLock as StdSyncRwLock};
 
 pub struct FastMutex<T>(Mutex<T>);
 
@@ -41,6 +42,46 @@ impl<T> FastRwLock<T> {
 
 impl<T> Deref for FastRwLock<T> {
     type Target = RwLock<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+pub struct StdMutex<T>(StdSyncMutex<T>);
+
+impl<T> StdMutex<T> {
+    pub fn new(t: T) -> Self {
+        StdMutex(StdSyncMutex::new(t))
+    }
+}
+
+impl<T> Deref for StdMutex<T> {
+    type Target = StdSyncMutex<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+pub struct StdRwLock<T>(StdSyncRwLock<T>);
+
+impl<T> StdRwLock<T> {
+    pub fn new(t: T) -> Self {
+        StdRwLock(StdSyncRwLock::new(t))
+    }
+
+    pub fn write(&self) -> std::sync::RwLockWriteGuard<'_, T> {
+        self.0.write().unwrap()
+    }
+
+    pub fn read(&self) -> std::sync::RwLockReadGuard<'_, T> {
+        self.0.read().unwrap()
+    }
+}
+
+impl<T> Deref for StdRwLock<T> {
+    type Target = StdSyncRwLock<T>;
 
     fn deref(&self) -> &Self::Target {
         &self.0


### PR DESCRIPTION
# Summary

Add positional `pread`/`pwrite` APIs on `LocalFile` and Linux libc wrappers so callers can read or write at an explicit offset without moving the file cursor.

# Issue Describe / Design

No linked issue.

- Design: `pread`/`pwrite` (and full/exact helpers) do not update the fd offset or `LocalFile`'s cached `pos`/`len`.
- Linux path uses `pread64`/`pwrite64`; non-Linux returns unsupported.
- Also adds `StdMutex`/`StdRwLock` wrappers and `Utils::uninit_bytes_mut` used by the new path.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `crates/core/curvine-io/src/local_file.rs` | Add `pread`/`pwrite` helpers and unix tests | None for existing sequential I/O |
| `crates/core/curvine-sys/src/sys_libc.rs` | Add `pread`/`pwrite`/`*_full` libc wrappers and linux tests | None |
| `crates/core/runtime/src/common/utils.rs` | Add `Utils::uninit_bytes_mut` | None |
| `crates/core/runtime/src/sync/mutex.rs` | Add `StdMutex`/`StdRwLock` wrappers | None |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| Compile / unit tests | SKIP | Requested skip |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None