### PR TITLE
feat(release): validate and inject release versions (#1527)

### DIFF
--- a/.github/workflows/build-java-sdk.yml
+++ b/.github/workflows/build-java-sdk.yml
@@ -156,6 +156,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Validate release tag vs Cargo version
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        run: |
+          bash build/validate-release-version.sh "${GITHUB_REF_NAME}"
+
       - name: Download all native library artifacts
         uses: actions/download-artifact@v4
         with:
@@ -189,13 +194,15 @@ jobs:
 
       - name: Build JAR with Maven
         run: |
-          cd curvine-libsdk/java
-          
-          # Update version in pom.xml if needed
+          # Inject the release/tag version into pom.xml before packaging. The
+          # Java package version is derived from the tag by CI, never maintained
+          # by hand, so the jar always matches the release.
+          . ./build/version.sh
           VERSION="${{ steps.version.outputs.version }}"
-          sed -i "s/<version>0.1.0<\/version>/<version>${VERSION}<\/version>/" pom.xml
+          set_pom_version curvine-libsdk/java/pom.xml "${VERSION}"
           
           # Generate protobuf code and package
+          cd curvine-libsdk/java
           mvn protobuf:compile package -DskipTests -B
           
           echo "Built JAR files:"
@@ -301,11 +308,13 @@ jobs:
           mkdir -p curvine-libsdk/java/native
           cp native-artifacts/*.so curvine-libsdk/java/native/
           
-          cd curvine-libsdk/java
-          
-          # Update version
+          # Inject the release version into pom.xml (same helper as the package
+          # step; set_pom_version is idempotent).
+          . ./build/version.sh
           VERSION="${{ needs.package-jar.outputs.version }}"
-          sed -i "s/<version>0.1.0<\/version>/<version>${VERSION}<\/version>/" pom.xml
+          set_pom_version curvine-libsdk/java/pom.xml "${VERSION}"
+          
+          cd curvine-libsdk/java
           
           # Add distribution management for GitHub Packages
           sed -i '/<\/project>/i \

--- a/.github/workflows/build-runtime-image.yml
+++ b/.github/workflows/build-runtime-image.yml
@@ -32,6 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.meta.outputs.tag }}
+      build_version: ${{ steps.meta.outputs.build_version }}
       push_image: ${{ steps.meta.outputs.push_image }}
       ghcr_image: ${{ steps.meta.outputs.ghcr_image }}
       docker_image: ${{ steps.meta.outputs.docker_image }}
@@ -58,6 +59,14 @@ jobs:
           
           echo "tag=${TAG}" >> $GITHUB_OUTPUT
           echo "push_image=${PUSH_IMAGE}" >> $GITHUB_OUTPUT
+
+          # BUILD_VERSION is injected into the binaries and image labels so the
+          # runtime image reports the same release version as the tag.
+          BUILD_VERSION="$TAG"
+          if [[ "${TAG}" == v* ]]; then
+            BUILD_VERSION="${TAG#v}"
+          fi
+          echo "build_version=${BUILD_VERSION}" >> $GITHUB_OUTPUT
           
           # Generate image names
           GHCR_IMAGE="ghcr.io/curvineio/curvine"
@@ -122,6 +131,7 @@ jobs:
           shm-size: 2g
           build-args: |
             REPO_URL=https://github.com/${{ github.repository }}
+            BUILD_VERSION=${{ needs.prepare.outputs.build_version }}
       
       - name: Build summary for ${{ matrix.arch }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,12 @@ jobs:
           target
         key: rocky9-cargo-${{ hashFiles('**/Cargo.lock') }}
 
+    - name: Validate release tag vs Cargo version
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+      run: |
+        bash build/validate-release-version.sh "${GITHUB_REF_NAME}"
+        echo "Release tag ${GITHUB_REF_NAME} matches Cargo workspace version"
+
     - name: Build and package
       env:
         RELEASE_VERSION: ${{ github.ref_name }}
@@ -47,6 +53,19 @@ jobs:
         BUILD_VERSION="${RELEASE_VERSION#v}"
         export BUILD_VERSION
         make dist ARGS='--ufs opendal-s3 --ufs opendal-oss --ufs opendal-azblob --ufs opendal-gcs --ufs opendal-hdfs --ufs opendal-webhdfs --ufs oss-hdfs'
+
+    - name: Verify injected artifact versions
+      env:
+        RELEASE_VERSION: ${{ github.ref_name }}
+      run: |
+        BUILD_VERSION="${RELEASE_VERSION#v}"
+        # build.sh injects BUILD_VERSION into the java pom when the SDK jar is
+        # built; the dist build-version file is written from the same value.
+        bash build/validate-release-version.sh "${RELEASE_VERSION}" \
+          --pom curvine-libsdk/java/pom.xml
+        grep -qx "version=${BUILD_VERSION}" build/dist/build-version \
+          && echo "build-version file: ok (version=${BUILD_VERSION})"
+        echo "Injected artifact versions verified for ${RELEASE_VERSION}"
 
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4

--- a/.github/workflows/trigger-helm-release.yml
+++ b/.github/workflows/trigger-helm-release.yml
@@ -54,6 +54,17 @@ jobs:
           echo "Release tag: $TAG"
           echo "Source commit: $SHA"
 
+      - name: Validate release tag vs Cargo version
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.meta.outputs.tag }}
+          fetch-depth: 1
+
+      - name: Check release tag consistency
+        run: |
+          bash build/validate-release-version.sh "${{ steps.meta.outputs.tag }}"
+          echo "Release tag ${{ steps.meta.outputs.tag }} matches Cargo workspace version"
+
       - name: Wait for runtime and CSI image workflows
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build/build.sh
+++ b/build/build.sh
@@ -888,7 +888,12 @@ fi
 
 if [ $BUILD_JAVA_SDK -eq 1 ]; then
   # Native library was copied immediately after the java-sdk cargo build.
-  # Build java package
+  # Build java package. In release builds, inject the release version into the
+  # pom so the jar artifact matches the tag; local builds (no BUILD_VERSION)
+  # keep the source pom untouched.
+  if [ -n "${BUILD_VERSION:-}" ]; then
+    set_pom_version "$FS_HOME/curvine-libsdk/java/pom.xml" "$BUILD_VERSION"
+  fi
   cd "$FS_HOME"/curvine-libsdk/java
   mvn protobuf:compile package -DskipTests -P${TARGET_DIR}
   if [ $? -ne 0 ]; then
@@ -958,6 +963,13 @@ if [ $BUILD_PYTHON_SDK -eq 1 ]; then
 
   echo "Building Python wheel (maturin) into ${DIST_DIR}/lib ..."
   cd "$FS_HOME/crates/sdk/curvine-libsdk-python"
+  # In release builds, point the workspace version at the release version so
+  # the dynamic pyproject version (maturin) produces a wheel named after the
+  # tag. The patch only happens when BUILD_VERSION is set, so local builds are
+  # unaffected.
+  if [ -n "${BUILD_VERSION:-}" ]; then
+    set_workspace_version "$FS_HOME/Cargo.toml" "$BUILD_VERSION"
+  fi
   PY_SDK_FEATURES="$(libsdk_features "extension-module")" || exit 1
   echo "maturin features: ${PY_SDK_FEATURES}"
   "${MATURIN_CMD[@]}" build --no-default-features \

--- a/build/tests/test_release_version.sh
+++ b/build/tests/test_release_version.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2025 OPPO.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$ROOT/version.sh"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+# --- tag_to_release_version -------------------------------------------------
+actual="$(tag_to_release_version "v0.4.0-alpha")"
+[ "$actual" = "0.4.0-alpha" ] || fail "tag_to_release_version v0.4.0-alpha, got $actual"
+actual="$(tag_to_release_version "v0.2.0")"
+[ "$actual" = "0.2.0" ] || fail "tag_to_release_version v0.2.0, got $actual"
+
+# --- set_workspace_version --------------------------------------------------
+cat > "$TMP_DIR/Cargo.toml" <<'EOF'
+[workspace.package]
+  version = "0.2.0"
+EOF
+
+set_workspace_version "$TMP_DIR/Cargo.toml" "0.4.0-alpha"
+actual="$(get_workspace_version "$TMP_DIR/Cargo.toml")"
+[ "$actual" = "0.4.0-alpha" ] || fail "set_workspace_version result, got $actual"
+# Empty version must be rejected (subshell: ${":?} terminates the shell)
+if ( set +e; set_workspace_version "$TMP_DIR/Cargo.toml" "" ) >/dev/null 2>&1; then
+  fail "expected empty version to fail"
+fi
+
+# --- get_pom_version / set_pom_version --------------------------------------
+cat > "$TMP_DIR/pom.xml" <<'EOF'
+<project>
+  <groupId>io.curvine</groupId>
+  <artifactId>curvine-hadoop</artifactId>
+  <version>0.2.0</version>
+  <dependencies>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.25</version>
+    </dependency>
+  </dependencies>
+</project>
+EOF
+
+actual="$(get_pom_version "$TMP_DIR/pom.xml")"
+[ "$actual" = "0.2.0" ] || fail "get_pom_version, got $actual"
+
+set_pom_version "$TMP_DIR/pom.xml" "0.3.1-rc1"
+actual="$(get_pom_version "$TMP_DIR/pom.xml")"
+[ "$actual" = "0.3.1-rc1" ] || fail "set_pom_version result, got $actual"
+# Dependency version must be untouched
+grep -q "<version>1.7.25</version>" "$TMP_DIR/pom.xml" || fail "dependency version was modified"
+
+# --- get_python_version / set_python_version --------------------------------
+cat > "$TMP_DIR/pyproject-static.toml" <<'EOF'
+[project]
+name = "curvine_libsdk"
+version = "0.1.0"
+EOF
+
+actual="$(get_python_version "$TMP_DIR/pyproject-static.toml")"
+[ "$actual" = "0.1.0" ] || fail "get_python_version, got $actual"
+
+set_python_version "$TMP_DIR/pyproject-static.toml" "0.4.0-alpha"
+actual="$(get_python_version "$TMP_DIR/pyproject-static.toml")"
+[ "$actual" = "0.4.0-alpha" ] || fail "set_python_version result, got $actual"
+
+# Dynamic pyproject has no static version to report
+cat > "$TMP_DIR/pyproject-dynamic.toml" <<'EOF'
+[project]
+name = "curvine_libsdk"
+dynamic = ["version"]
+EOF
+actual="$(get_python_version "$TMP_DIR/pyproject-dynamic.toml")"
+[ -z "$actual" ] || fail "dynamic pyproject should have no static version, got $actual"
+
+# --- validate-release-version.sh (end to end) --------------------------------
+VALIDATE="$ROOT/validate-release-version.sh"
+cat > "$TMP_DIR/release-Cargo.toml" <<'EOF'
+[workspace.package]
+version = "0.4.0-alpha"
+EOF
+
+# Re-align the fixtures mutated by the helper tests above
+set_pom_version "$TMP_DIR/pom.xml" "0.4.0-alpha"
+set_python_version "$TMP_DIR/pyproject-static.toml" "0.4.0-alpha"
+
+# PASS: tag matches Cargo
+"$VALIDATE" "v0.4.0-alpha" --cargo "$TMP_DIR/release-Cargo.toml" >/dev/null 2>&1 \
+  || fail "validate should pass for matching tag"
+
+# PASS: with pom and pyproject already aligned
+"$VALIDATE" "v0.4.0-alpha" \
+  --cargo "$TMP_DIR/release-Cargo.toml" \
+  --pom "$TMP_DIR/pom.xml" \
+  --pyproject "$TMP_DIR/pyproject-static.toml" >/dev/null 2>&1 \
+  || fail "validate should pass for aligned pom and pyproject"
+
+# FAIL: tag does not match Cargo
+if "$VALIDATE" "v1.2.3" --cargo "$TMP_DIR/release-Cargo.toml" >/dev/null 2>&1; then
+  fail "validate should fail for mismatched tag"
+fi
+
+# FAIL: invalid tag shape
+if "$VALIDATE" "1.2.3" --cargo "$TMP_DIR/release-Cargo.toml" >/dev/null 2>&1; then
+  fail "validate should fail for tag without v prefix"
+fi
+if "$VALIDATE" "vabc" --cargo "$TMP_DIR/release-Cargo.toml" >/dev/null 2>&1; then
+  fail "validate should fail for non-semver tag"
+fi
+
+# FAIL: pom not aligned
+set_pom_version "$TMP_DIR/pom.xml" "0.3.1-rc1"
+if "$VALIDATE" "v0.4.0-alpha" \
+  --cargo "$TMP_DIR/release-Cargo.toml" \
+  --pom "$TMP_DIR/pom.xml" >/dev/null 2>&1; then
+  fail "validate should fail when pom version differs from tag"
+fi
+
+# PASS: dynamic pyproject still validates (version inherited from workspace)
+"$VALIDATE" "v0.4.0-alpha" \
+  --cargo "$TMP_DIR/release-Cargo.toml" \
+  --pyproject "$TMP_DIR/pyproject-dynamic.toml" >/dev/null 2>&1 \
+  || fail "validate should pass for dynamic pyproject"
+
+# FAIL: static pyproject not aligned
+set_python_version "$TMP_DIR/pyproject-static.toml" "0.1.0"
+if "$VALIDATE" "v0.4.0-alpha" \
+  --cargo "$TMP_DIR/release-Cargo.toml" \
+  --pyproject "$TMP_DIR/pyproject-static.toml" >/dev/null 2>&1; then
+  fail "validate should fail when pyproject version differs from tag"
+fi
+
+# --- dry-run output ---------------------------------------------------------
+OUT="$("$VALIDATE" "v0.4.0-alpha" --cargo "$TMP_DIR/release-Cargo.toml" --dry-run)"
+echo "$OUT" | grep -q "BUILD_VERSION=0.4.0-alpha" || fail "dry-run should list BUILD_VERSION"
+echo "$OUT" | grep -q "set_workspace_version" || fail "dry-run should list workspace injection"
+
+echo "release version validation: ok"

--- a/build/tests/test_release_version.sh
+++ b/build/tests/test_release_version.sh
@@ -44,6 +44,11 @@ EOF
 set_workspace_version "$TMP_DIR/Cargo.toml" "0.4.0-alpha"
 actual="$(get_workspace_version "$TMP_DIR/Cargo.toml")"
 [ "$actual" = "0.4.0-alpha" ] || fail "set_workspace_version result, got $actual"
+# Idempotent: setting the same version again must not touch the file
+before_cksum="$(cksum "$TMP_DIR/Cargo.toml" | awk '{print $1 $2}')"
+set_workspace_version "$TMP_DIR/Cargo.toml" "0.4.0-alpha"
+after_cksum="$(cksum "$TMP_DIR/Cargo.toml" | awk '{print $1 $2}')"
+[ "$before_cksum" = "$after_cksum" ] || fail "set_workspace_version rewrote an unchanged Cargo.toml"
 # Empty version must be rejected (subshell: ${":?} terminates the shell)
 if ( set +e; set_workspace_version "$TMP_DIR/Cargo.toml" "" ) >/dev/null 2>&1; then
   fail "expected empty version to fail"
@@ -73,6 +78,11 @@ actual="$(get_pom_version "$TMP_DIR/pom.xml")"
 [ "$actual" = "0.3.1-rc1" ] || fail "set_pom_version result, got $actual"
 # Dependency version must be untouched
 grep -q "<version>1.7.25</version>" "$TMP_DIR/pom.xml" || fail "dependency version was modified"
+# Idempotent: setting the same version again must not touch the file
+before_cksum="$(cksum "$TMP_DIR/pom.xml" | awk '{print $1 $2}')"
+set_pom_version "$TMP_DIR/pom.xml" "0.3.1-rc1"
+after_cksum="$(cksum "$TMP_DIR/pom.xml" | awk '{print $1 $2}')"
+[ "$before_cksum" = "$after_cksum" ] || fail "set_pom_version rewrote an unchanged pom.xml"
 
 # --- get_python_version / set_python_version --------------------------------
 cat > "$TMP_DIR/pyproject-static.toml" <<'EOF'
@@ -87,6 +97,11 @@ actual="$(get_python_version "$TMP_DIR/pyproject-static.toml")"
 set_python_version "$TMP_DIR/pyproject-static.toml" "0.4.0-alpha"
 actual="$(get_python_version "$TMP_DIR/pyproject-static.toml")"
 [ "$actual" = "0.4.0-alpha" ] || fail "set_python_version result, got $actual"
+# Idempotent: setting the same version again must not touch the file
+before_cksum="$(cksum "$TMP_DIR/pyproject-static.toml" | awk '{print $1 $2}')"
+set_python_version "$TMP_DIR/pyproject-static.toml" "0.4.0-alpha"
+after_cksum="$(cksum "$TMP_DIR/pyproject-static.toml" | awk '{print $1 $2}')"
+[ "$before_cksum" = "$after_cksum" ] || fail "set_python_version rewrote an unchanged pyproject.toml"
 
 # Dynamic pyproject has no static version to report
 cat > "$TMP_DIR/pyproject-dynamic.toml" <<'EOF'

--- a/build/validate-release-version.sh
+++ b/build/validate-release-version.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2025 OPPO.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Release version consistency gate.
+#
+# The git tag (vX.Y.Z[-pre]) is the release anchor. Before artifacts are
+# built and published, the tag must match the version declared in the Cargo
+# workspace ([workspace.package].version). Java pom and Python pyproject
+# versions are injected from the tag by the release CI, so they are optional
+# checks here: --pom requires them to already equal the release version while
+# --pyproject accepts a dynamic version that inherits the workspace.
+#
+# Usage:
+#   build/validate-release-version.sh <tag> [options]
+#
+# Options:
+#   --cargo PATH       Cargo.toml to check (default: <repo root>/Cargo.toml)
+#   --pom PATH         also require the Java pom.xml project version to match
+#   --pyproject PATH   also check the Python pyproject.toml version
+#   --dry-run          print the injection plan (what the release CI would
+#                      apply) without modifying any file
+#
+# Exit codes: 0 = consistent, 1 = mismatch or invalid tag.
+
+set -euo pipefail
+
+FS_HOME="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$FS_HOME/build/version.sh"
+
+CARGO_TOML="${CARGO_TOML:-$FS_HOME/Cargo.toml}"
+POM_PATH=""
+PYPROJECT_PATH=""
+DRY_RUN=0
+
+usage() {
+  sed -n 's/^# \{0,1\}//p' "${BASH_SOURCE[0]}" | sed -n '/^Usage:/,/^Exit codes:/p'
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --cargo)
+      CARGO_TOML="${2:?--cargo requires a path}"
+      shift 2
+      ;;
+    --cargo=*)
+      CARGO_TOML="${1#*=}"
+      shift
+      ;;
+    --pom)
+      POM_PATH="${2:?--pom requires a path}"
+      shift 2
+      ;;
+    --pom=*)
+      POM_PATH="${1#*=}"
+      shift
+      ;;
+    --pyproject)
+      PYPROJECT_PATH="${2:?--pyproject requires a path}"
+      shift 2
+      ;;
+    --pyproject=*)
+      PYPROJECT_PATH="${1#*=}"
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    -*)
+      echo "unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+    *)
+      if [ -n "${TAG:-}" ]; then
+        echo "unexpected positional argument: $1" >&2
+        usage >&2
+        exit 2
+      fi
+      TAG="$1"
+      shift
+      ;;
+  esac
+done
+
+if [ -z "${TAG:-}" ]; then
+  echo "error: a release tag is required (e.g. v0.4.0-alpha)" >&2
+  usage >&2
+  exit 2
+fi
+
+# --- tag shape -------------------------------------------------------------
+if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+  echo "error: invalid release tag '$TAG' (expected vX.Y.Z[-pre], e.g. v0.4.0-alpha)" >&2
+  exit 1
+fi
+
+RELEASE_VERSION="$(tag_to_release_version "$TAG")"
+failures=0
+
+# --- Cargo workspace version (primary, hand-maintained source) ------------
+if [ ! -f "$CARGO_TOML" ]; then
+  echo "error: Cargo.toml not found: $CARGO_TOML" >&2
+  exit 2
+fi
+
+CARGO_VERSION="$(get_workspace_version "$CARGO_TOML")"
+if [ -z "$CARGO_VERSION" ]; then
+  echo "error: could not read [workspace.package].version from $CARGO_TOML" >&2
+  exit 1
+fi
+
+if [ "$CARGO_VERSION" != "$RELEASE_VERSION" ]; then
+  echo "FAIL tag/Cargo mismatch: tag=$TAG, release version=$RELEASE_VERSION, Cargo version=$CARGO_VERSION" >&2
+  failures=1
+fi
+
+# --- Java pom (optional; injected by the release CI) -----------------------
+POM_VERSION=""
+if [ -n "$POM_PATH" ]; then
+  if [ ! -f "$POM_PATH" ]; then
+    echo "error: pom.xml not found: $POM_PATH" >&2
+    exit 2
+  fi
+  POM_VERSION="$(get_pom_version "$POM_PATH")"
+  if [ "$POM_VERSION" != "$RELEASE_VERSION" ]; then
+    echo "FAIL tag/pom mismatch: release version=$RELEASE_VERSION, pom version=$POM_VERSION" >&2
+    failures=1
+  fi
+fi
+
+# --- Python pyproject (optional; dynamic inherits the workspace) -----------
+PYTHON_VERSION=""
+if [ -n "$PYPROJECT_PATH" ]; then
+  if [ ! -f "$PYPROJECT_PATH" ]; then
+    echo "error: pyproject.toml not found: $PYPROJECT_PATH" >&2
+    exit 2
+  fi
+  PYTHON_VERSION="$(get_python_version "$PYPROJECT_PATH")"
+  if [ -z "$PYTHON_VERSION" ]; then
+    echo "note: pyproject version is dynamic, wheel version inherits the Cargo workspace version" >&2
+  elif [ "$PYTHON_VERSION" != "$RELEASE_VERSION" ]; then
+    echo "FAIL tag/python mismatch: release version=$RELEASE_VERSION, pyproject version=$PYTHON_VERSION" >&2
+    failures=1
+  fi
+fi
+
+if [ "$failures" -ne 0 ]; then
+  echo "release version validation failed for tag $TAG" >&2
+  exit 1
+fi
+
+echo "PASS release tag $TAG is consistent (release version $RELEASE_VERSION)"
+
+# --- dry-run: show what the release CI will inject -------------------------
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo
+  echo "Injection plan (dry-run, no files changed):"
+  echo "  BUILD_VERSION=$RELEASE_VERSION"
+  echo "    -> binaries (curvine-sys build.rs), build-version file"
+  echo "  set_workspace_version $CARGO_TOML $RELEASE_VERSION"
+  echo "    -> Python SDK wheel version (maturin dynamic version)"
+  if [ -n "$POM_PATH" ]; then
+    echo "  set_pom_version $POM_PATH $RELEASE_VERSION"
+    echo "    -> Java SDK jar version"
+  fi
+fi

--- a/build/validate-release-version.sh
+++ b/build/validate-release-version.sh
@@ -35,7 +35,8 @@
 #   --dry-run          print the injection plan (what the release CI would
 #                      apply) without modifying any file
 #
-# Exit codes: 0 = consistent, 1 = mismatch or invalid tag.
+# Exit codes: 0 = consistent, 1 = mismatch or invalid tag, 2 = usage/argument
+# error or missing input file.
 
 set -euo pipefail
 

--- a/build/version.sh
+++ b/build/version.sh
@@ -65,14 +65,31 @@ tag_to_release_version() {
 set_workspace_version() {
   local cargo_toml="${1:?Cargo.toml path required}"
   local version="${2:?version required}"
-  awk -v new_version="$version" '
+  local current
+  current="$(get_workspace_version "$cargo_toml")" || {
+    echo "failed to read workspace version from $cargo_toml" >&2
+    return 1
+  }
+  if [ -z "$current" ]; then
+    echo "failed to resolve [workspace.package].version from $cargo_toml" >&2
+    return 1
+  fi
+  if [ "$current" = "$version" ]; then
+    return 0
+  fi
+  if ! awk -v new_version="$version" '
     /^\[[^]]*\]/ { in_workspace = ($0 ~ /^\[workspace\.package\]/) ? 1 : 0 }
     in_workspace && /^[[:space:]]*version[[:space:]]*=/ {
       sub(/^[[:space:]]*version[[:space:]]*=[[:space:]]*".*"/, "version = \"" new_version "\"")
       in_workspace = 0
     }
     { print }
-  ' "$cargo_toml" > "${cargo_toml}.tmp" && mv "${cargo_toml}.tmp" "$cargo_toml"
+  ' "$cargo_toml" > "${cargo_toml}.tmp"; then
+    rm -f "${cargo_toml}.tmp"
+    echo "failed to update workspace version in $cargo_toml" >&2
+    return 1
+  fi
+  mv "${cargo_toml}.tmp" "$cargo_toml"
   local actual
   if ! actual="$(get_workspace_version "$cargo_toml")"; then
     echo "failed to verify workspace version after update in $cargo_toml" >&2
@@ -106,14 +123,31 @@ get_pom_version() {
 set_pom_version() {
   local pom="${1:?pom.xml path required}"
   local version="${2:?version required}"
-  awk -v new_version="$version" '
+  local current
+  current="$(get_pom_version "$pom")" || {
+    echo "failed to read pom version from $pom" >&2
+    return 1
+  }
+  if [ -z "$current" ]; then
+    echo "failed to resolve project version from $pom" >&2
+    return 1
+  fi
+  if [ "$current" = "$version" ]; then
+    return 0
+  fi
+  if ! awk -v new_version="$version" '
     /<artifactId>/ { if (!seen_artifact) { seen_artifact = 1; artifact_line = NR } }
     seen_artifact && !done && NR > artifact_line && /<version>[^<]*<\/version>/ {
       sub(/<version>[^<]*<\/version>/, "<version>" new_version "</version>")
       done = 1
     }
     { print }
-  ' "$pom" > "${pom}.tmp" && mv "${pom}.tmp" "$pom"
+  ' "$pom" > "${pom}.tmp"; then
+    rm -f "${pom}.tmp"
+    echo "failed to update pom version in $pom" >&2
+    return 1
+  fi
+  mv "${pom}.tmp" "$pom"
   local actual
   if ! actual="$(get_pom_version "$pom")"; then
     echo "failed to verify pom version after update in $pom" >&2
@@ -149,14 +183,27 @@ get_python_version() {
 set_python_version() {
   local pyproject="${1:?pyproject.toml path required}"
   local version="${2:?version required}"
-  awk -v new_version="$version" '
+  local current
+  current="$(get_python_version "$pyproject")" || {
+    echo "failed to read python version from $pyproject" >&2
+    return 1
+  }
+  if [ "$current" = "$version" ]; then
+    return 0
+  fi
+  if ! awk -v new_version="$version" '
     /^\[[^]]*\]/ { in_project = ($0 ~ /^\[project\]/) ? 1 : 0 }
     in_project && /^version[[:space:]]*=/ {
       sub(/^[[:space:]]*version[[:space:]]*=[[:space:]]*".*/, "version = \"" new_version "\"")
       in_project = 0
     }
     { print }
-  ' "$pyproject" > "${pyproject}.tmp" && mv "${pyproject}.tmp" "$pyproject"
+  ' "$pyproject" > "${pyproject}.tmp"; then
+    rm -f "${pyproject}.tmp"
+    echo "failed to update python version in $pyproject" >&2
+    return 1
+  fi
+  mv "${pyproject}.tmp" "$pyproject"
   local actual
   if ! actual="$(get_python_version "$pyproject")"; then
     echo "failed to verify python version after update in $pyproject" >&2

--- a/build/version.sh
+++ b/build/version.sh
@@ -51,3 +51,119 @@ get_build_version() {
   fi
   printf '%s\n' "$version"
 }
+
+# Strip the leading `v` from a release tag. Tags are the release anchor, so
+# v0.4.0-alpha becomes the release version 0.4.0-alpha.
+tag_to_release_version() {
+  local tag="${1:?tag required}"
+  printf '%s\n' "${tag#v}"
+}
+
+# Overwrite the version declared in [workspace.package]. Used by the release
+# build to drive Python SDK packaging (maturin with dynamic version reads the
+# Cargo workspace version). Local builds without BUILD_VERSION never call this.
+set_workspace_version() {
+  local cargo_toml="${1:?Cargo.toml path required}"
+  local version="${2:?version required}"
+  awk -v new_version="$version" '
+    /^\[[^]]*\]/ { in_workspace = ($0 ~ /^\[workspace\.package\]/) ? 1 : 0 }
+    in_workspace && /^[[:space:]]*version[[:space:]]*=/ {
+      sub(/^[[:space:]]*version[[:space:]]*=[[:space:]]*".*"/, "version = \"" new_version "\"")
+      in_workspace = 0
+    }
+    { print }
+  ' "$cargo_toml" > "${cargo_toml}.tmp" && mv "${cargo_toml}.tmp" "$cargo_toml"
+  local actual
+  if ! actual="$(get_workspace_version "$cargo_toml")"; then
+    echo "failed to verify workspace version after update in $cargo_toml" >&2
+    return 1
+  fi
+  if [ "$actual" != "$version" ]; then
+    echo "expected workspace version $version after update, got $actual" >&2
+    return 1
+  fi
+}
+
+# Read the Maven project version. The project version is the <version> element
+# that directly follows the project's <artifactId> in pom.xml (dependency
+# versions appear later and must not be picked up).
+get_pom_version() {
+  local pom="${1:?pom.xml path required}"
+  awk '
+    /<artifactId>/ { if (!seen_artifact) { seen_artifact = 1; artifact_line = NR } }
+    seen_artifact && !done && NR > artifact_line && /<version>[^<]*<\/version>/ {
+      line = $0
+      sub(/.*<version>/, "", line)
+      sub(/<\/version>.*/, "", line)
+      print line
+      exit
+    }
+  ' "$pom"
+}
+
+# Overwrite the Maven project version in pom.xml. The release CI injects the
+# tag version here because Java package versions are not maintained by hand.
+set_pom_version() {
+  local pom="${1:?pom.xml path required}"
+  local version="${2:?version required}"
+  awk -v new_version="$version" '
+    /<artifactId>/ { if (!seen_artifact) { seen_artifact = 1; artifact_line = NR } }
+    seen_artifact && !done && NR > artifact_line && /<version>[^<]*<\/version>/ {
+      sub(/<version>[^<]*<\/version>/, "<version>" new_version "</version>")
+      done = 1
+    }
+    { print }
+  ' "$pom" > "${pom}.tmp" && mv "${pom}.tmp" "$pom"
+  local actual
+  if ! actual="$(get_pom_version "$pom")"; then
+    echo "failed to verify pom version after update in $pom" >&2
+    return 1
+  fi
+  if [ "$actual" != "$version" ]; then
+    echo "expected pom version $version after update, got $actual" >&2
+    return 1
+  fi
+}
+
+# Read the Python SDK package version from pyproject.toml. Since 1.x, maturin
+# derives the wheel version from Cargo when the project declares
+# `dynamic = ["version"]`; in that case no static [project].version exists and
+# this returns an empty string (the version is inherited from the workspace).
+get_python_version() {
+  local pyproject="${1:?pyproject.toml path required}"
+  awk '
+    /^\[project\]/ { in_project = 1; next }
+    /^\[/ { in_project = 0 }
+    in_project && /^version[[:space:]]*=/ {
+      sub(/^[[:space:]]*version[[:space:]]*=[[:space:]]*"/, "")
+      sub(/".*/, "")
+      print
+      exit
+    }
+  ' "$pyproject"
+}
+
+# Overwrite the static [project].version in pyproject.toml. Only meaningful for
+# projects with a pinned version; the Curvine Python SDK uses dynamic version,
+# so the release flow drives it through set_workspace_version instead.
+set_python_version() {
+  local pyproject="${1:?pyproject.toml path required}"
+  local version="${2:?version required}"
+  awk -v new_version="$version" '
+    /^\[[^]]*\]/ { in_project = ($0 ~ /^\[project\]/) ? 1 : 0 }
+    in_project && /^version[[:space:]]*=/ {
+      sub(/^[[:space:]]*version[[:space:]]*=[[:space:]]*".*/, "version = \"" new_version "\"")
+      in_project = 0
+    }
+    { print }
+  ' "$pyproject" > "${pyproject}.tmp" && mv "${pyproject}.tmp" "$pyproject"
+  local actual
+  if ! actual="$(get_python_version "$pyproject")"; then
+    echo "failed to verify python version after update in $pyproject" >&2
+    return 1
+  fi
+  if [ "$actual" != "$version" ]; then
+    echo "expected python version $version after update, got $actual" >&2
+    return 1
+  fi
+}

--- a/crates/sdk/curvine-libsdk-python/pyproject.toml
+++ b/crates/sdk/curvine-libsdk-python/pyproject.toml
@@ -10,7 +10,10 @@ features = ["extension-module"]
 
 [project]
 name = "curvine_libsdk"
-version = "0.1.0"
+# Version is inherited from the Cargo workspace ([workspace.package].version)
+# via maturin's dynamic version support, so the wheel always matches the
+# component release version instead of drifting from it.
+dynamic = ["version"]
 requires-python = ">=3.6"
 dependencies = [
     "protobuf>=3.19,<6",

--- a/curvine-csi/Dockerfile
+++ b/curvine-csi/Dockerfile
@@ -14,6 +14,11 @@ SHELL ["/bin/bash", "-c"]
 # Set GOPROXY environment variable (Go is already installed in compile image)
 ENV GOPROXY=${GOPROXY:-https://proxy.golang.org}
 
+# Make the release version visible to every RUN in this stage so build.sh
+# (get_build_version) and the CSI -ldflags injection produce tag-aligned
+# versions for the binaries packed into the image.
+ENV BUILD_VERSION=${BUILD_VERSION}
+
 # Ensure environment variables are set (from compile image)
 # Go toolchain is already included: PATH="/usr/local/go/bin:...", GOPATH=/go, GOROOT=/usr/local/go
 ENV PATH="/root/.cargo/bin:/app/protoc/bin:/app/maven/bin:/usr/local/go/bin:${PATH}"
@@ -94,6 +99,13 @@ RUN mkdir -p /build-output && \
     echo "  conf/: $(ls -1 /build-output/conf 2>/dev/null | wc -l) files"
 
 FROM ubuntu:24.04
+
+# BUILD_VERSION is passed from the release CI (tag without the v prefix, e.g.
+# 0.4.0-alpha) and is baked into the CSI binary via -ldflags in the builder
+# stage. Expose it again here for the image metadata label so the published
+# image records the same release version as the tag.
+ARG BUILD_VERSION
+LABEL org.opencontainers.image.version="${BUILD_VERSION}"
 
 # Set non-interactive mode for apt
 ENV DEBIAN_FRONTEND=noninteractive

--- a/curvine-docker/deploy/Dockerfile_rocky9
+++ b/curvine-docker/deploy/Dockerfile_rocky9
@@ -69,6 +69,14 @@ ARG REPO_URL=https://github.com/curvineio/curvine
 LABEL org.opencontainers.image.source="${REPO_URL}"
 LABEL org.opencontainers.image.description="Curvine Native Kubernetes Runtime Image"
 
+# BUILD_VERSION drives the version reported by binaries and the build-version
+# file inside the image. It is set by the release CI from the git tag (vX.Y.Z
+# -> X.Y.Z); local image builds leave it empty and fall back to the workspace
+# version / git describe.
+ARG BUILD_VERSION
+ENV BUILD_VERSION=${BUILD_VERSION}
+LABEL org.opencontainers.image.version="${BUILD_VERSION}"
+
 # Override ENTRYPOINT to ensure RUN commands execute correctly
 # The compile image has ENTRYPOINT ["/bin/bash", "-c"] which can interfere with RUN
 ENTRYPOINT []
@@ -150,6 +158,9 @@ RUN mkdir -p /build-output && \
 
 # Runtime stage
 FROM runtime-base AS runtime
+
+ARG BUILD_VERSION
+LABEL org.opencontainers.image.version="${BUILD_VERSION}"
 
 RUN --mount=type=cache,sharing=locked,target=/var/cache/dnf \
     dnf install -y --allowerasing \


### PR DESCRIPTION
# Summary

Add a release version consistency gate and unify version injection so that the release tag (`vX.Y.Z[-pre]`), the Cargo workspace version, binaries, images, Helm, Java and Python SDK artifacts all report the same version. This is task T11 of the #1527 version-management plan (depends on T1: workspace version parsing / BUILD_VERSION, and T3: `--version-json`).

# Issue Describe / Design

Closes #1527

The release chain previously had no automated proof that the tag matched the Cargo workspace version, the Java pom version injection in CI used a brittle `sed` that only matched `0.1.0` (it stopped working once the pom moved to `0.2.0`), the runtime Docker image never passed `BUILD_VERSION`, and the Python wheel version was hardcoded to the stale `0.1.0` instead of following the workspace.

Design (from the #1527 version-management design):

- The git tag is the release anchor: `vX.Y.Z[-pre]` -> release version `X.Y.Z[-pre]`.
- Cargo `[workspace.package].version` is the single hand-maintained source; it must equal the tag at release time.
- Java pom, Python wheel, images and Helm derive their version from the tag via CI; none are maintained by hand.
- Injection only happens when `BUILD_VERSION` is set, so local builds are completely unaffected.

Implementation:

- New `build/validate-release-version.sh` validates the tag shape and the tag == Cargo workspace version, with optional Java pom / Python pyproject checks and a `--dry-run` injection plan.
- `build/version.sh` gains `tag_to_release_version`, `set_workspace_version`, `get/set_pom_version` and `get/set_python_version` helpers (with round-trip verification after each write).
- `build/build.sh` injects `BUILD_VERSION` into the Java pom and into the workspace version (for the maturin dynamic version) only when `BUILD_VERSION` is present.
- `release.yml` gates the build on the tag/Cargo validation and verifies the injected pom + `build-version` file after the build.
- `build-java-sdk.yml` validates the tag and switches from the brittle sed to `set_pom_version`.
- Runtime and CSI image builds pass `BUILD_VERSION` as a build arg, export it during the build, and add `org.opencontainers.image.version` labels.
- `trigger-helm-release.yml` validates the tag before dispatching the Helm release to `curvine-helm` (the chart there already derives `version`/`appVersion` from the dispatched tag).
- `crates/sdk/curvine-libsdk-python/pyproject.toml` uses `dynamic = ["version"]` so the wheel version inherits the Cargo workspace/release version (verified: maturin 1.14.1 derives the wheel name from Cargo with dynamic version; pre-release tags normalize per PEP 440, e.g. `0.4.0-alpha` -> `0.4.0a0`).

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `build/version.sh` | Add release helpers: `tag_to_release_version`, `set_workspace_version`, `get/set_pom_version`, `get/set_python_version` | None for local builds; helpers are only invoked by CI/release paths |
| `build/validate-release-version.sh` (new) | Tag vs Cargo version gate with optional pom/pyproject checks and `--dry-run` injection plan | New script; no impact on existing behavior |
| `build/tests/test_release_version.sh` (new) | Unit tests for the new helpers and the validation script | New tests |
| `build/build.sh` | Inject `BUILD_VERSION` into the Java pom and workspace version when building the Java/Python SDKs | None for local builds (`BUILD_VERSION` unset) |
| `.github/workflows/release.yml` | Validate tag == Cargo before build; verify injected pom + build-version after build | Release builds fail fast on a mismatched tag |
| `.github/workflows/build-java-sdk.yml` | Validate tag; replace `sed` pom version with `set_pom_version` | Java jar version now always matches the tag (previously the sed no-op'd once pom left 0.1.0) |
| `.github/workflows/build-runtime-image.yml` | Compute and pass `BUILD_VERSION` build arg | Release images report the tag version in binaries/labels |
| `curvine-docker/deploy/Dockerfile_rocky9` | `ARG/ENV BUILD_VERSION`, `org.opencontainers.image.version` label | None for local image builds (empty arg falls back to workspace/git describe) |
| `curvine-csi/Dockerfile` | Export `BUILD_VERSION` in the builder stage, add version label | CSI image binaries already received it via ldflags; label is new metadata |
| `.github/workflows/trigger-helm-release.yml` | Validate tag vs Cargo before dispatching Helm release | Helm dispatch is blocked for mismatched tags |
| `crates/sdk/curvine-libsdk-python/pyproject.toml` | `version = "0.1.0"` -> `dynamic = ["version"]` | Python wheel version follows the workspace/release version (0.2.0 dev / tag version at release) instead of the stale 0.1.0 |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `bash build/tests/test_release_version.sh` | PASS | covers tag parsing, workspace/pom/pyproject set+get, validation PASS/FAIL paths, dynamic pyproject, dry-run output |
| `bash build/tests/test_workspace_version.sh` | PASS | regression for T1 version.sh behavior |
| `bash build/validate-release-version.sh v0.2.0` | PASS | real repo: tag matches current workspace version |
| `bash build/validate-release-version.sh v1.2.3` | FAIL (expected) | mismatched tag correctly rejected with clear message |
| `bash build/validate-release-version.sh v0.2.0 --dry-run` | PASS | prints injection plan (BUILD_VERSION, set_workspace_version, set_pom_version) |
| pom injection on a copy of the real `curvine-libsdk/java/pom.xml` | PASS | project version updated, dependency versions untouched |
| maturin dynamic version behavior | PASS | verified with maturin 1.14.1: wheel name follows Cargo version; pre-release normalized per PEP 440 |
| `make format` | PASS | rustfmt + clippy (no Rust changes staged; pre-commit skipped Rust checks) |
| Workflow YAML parse | PASS | all 5 touched workflows parse cleanly |

# Dependencies

- Related PRs: #1529 (T1), #1534 (T3)
- Related issues: #1527
- Blocks / blocked by: None (T12 docs task follows independently)