### PR TITLE
fix(libsdk): make CurvineNative jar extract interrupt-safe (#1591)

### DIFF
--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineNative.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineNative.java
@@ -25,8 +25,6 @@ import java.io.*;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
-import java.nio.file.Files;
-import java.nio.file.StandardCopyOption;
 import java.util.regex.Pattern;
 
 public class CurvineNative {
@@ -258,11 +256,31 @@ public class CurvineNative {
         try (final InputStream is = CurvineNative.class.getClassLoader().getResourceAsStream(libraryName)) {
             if (is == null) {
                 throw new RuntimeException(libraryName + " was not found inside JAR.");
-            } else {
-                Files.copy(is, temp.toPath(), StandardCopyOption.REPLACE_EXISTING);
             }
+            copyUninterruptibly(is, temp);
         }
         return temp.getAbsolutePath();
+    }
+
+    /**
+     * Copy with {@code java.io} so {@link Thread#interrupt()} cannot abort the write via
+     * {@link java.nio.channels.ClosedByInterruptException} the way {@code Files.copy} /
+     * {@code FileChannel} can. Deletes {@code dest} if the copy fails so a truncated
+     * library is not later treated as valid.
+     */
+    private static void copyUninterruptibly(InputStream in, File dest) throws IOException {
+        try (FileOutputStream out = new FileOutputStream(dest)) {
+            byte[] buf = new byte[8192];
+            int n;
+            while ((n = in.read(buf)) >= 0) {
+                out.write(buf, 0, n);
+            }
+        } catch (IOException e) {
+            if (!dest.delete()) {
+                dest.deleteOnExit();
+            }
+            throw e;
+        }
     }
 
     public static File getWorkerDir() {


### PR DESCRIPTION
# Summary

Extract the Curvine JNI library from the jar with uninterruptible `java.io`
I/O so a Spark task interrupt cannot fail `CurvineNative` static
initialization and poison the executor JVM.

# Issue Describe / Design

Closes #1591

## Root cause

`CurvineNative.<clinit>` calls `load()` → `loadLibraryFromJar()`, which used
`Files.copy`. That API writes through an interruptible `FileChannel`. Spark
speculation interrupts the slow task thread; if the stack is in `Files.copy`,
it throws `ClosedByInterruptException` → `ExceptionInInitializerError`. The
class is then dead in that JVM. Later tasks get
`NoClassDefFoundError: CurvineNative` and retries stay on the poisoned
executor until the stage aborts.

## Reproduction

1. Spark job with `spark.speculation=true` that loads `CurvineNative` on
   executors.
2. A slow task is marked speculatable; the speculative attempt succeeds;
   attempt 0 is killed.
3. If the kill hits jar extract: `ClosedByInterruptException` at `Files.copy`
   during `<clinit>`, then repeated `NoClassDefFoundError` on that executor.

## Fix approach

Replace `Files.copy` with a private `copyUninterruptibly` helper that writes
via `FileOutputStream`. `java.io` writes are not aborted by
`Thread.interrupt()`, so `<clinit>` can finish. The interrupt flag stays set,
so the killed attempt still exits. A failed copy deletes the dest file to
avoid leaving a truncated `.so`.

`load()` is not wrapped with interrupt clear/restore: that does not cover an
interrupt that arrives during `FileChannel.write`.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-libsdk/java/src/main/java/io/curvine/CurvineNative.java` | `loadLibraryFromJar` copies with `java.io`; delete dest on failure | Interrupted threads can finish `<clinit>` instead of poisoning the JVM |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| Code review of `loadLibraryFromJar` / `copyUninterruptibly` | PASS | Dedicated unit test omitted: calling `CurvineNative` runs `<clinit>` and requires the JNI library |
| Spark job with speculation enabled | pending | Manual: killed attempt fails; same executor later tasks must not hit `NoClassDefFoundError: CurvineNative` |

# Dependencies

- Related PRs: None
- Related issues: #1591
- Blocks / blocked by: None
