### PR TITLE
fix(worker): correct sparse buffered block reads

### DIFF
--- a/crates/adapters/curvine-storage-local/src/block_io_context.rs
+++ b/crates/adapters/curvine-storage-local/src/block_io_context.rs
@@ -284,10 +284,20 @@ impl BlockReadContext {
             .read_region(enable_send_file, physical_chunk as i32)?;
         let got = region.len() as i64;
         if got != physical_chunk {
+            let live_len = self
+                .device
+                .as_local()
+                .and_then(|file| file.metadata().ok())
+                .map(|meta| meta.len() as i64);
             return err_box!(
-                "short physical read: expected {}, got {}",
+                "short physical read: expected {}, got {}, block_pos {}, device_pos {}, physical_len {}, device_len {}, live_len {:?}",
                 physical_chunk,
-                got
+                got,
+                self.block_pos,
+                self.device.pos(),
+                self.physical_len,
+                self.device.len(),
+                live_len
             );
         }
         self.block_pos += got;
@@ -304,7 +314,10 @@ impl BlockReadContext {
     }
 
     pub fn supports_send_file(&self) -> bool {
-        self.device.supports_send_file()
+        // Keep sparse sessions buffered even when the requested region is
+        // currently inside physical bytes. A deferred sendfile can otherwise
+        // race with block-generation replacement and expose pre-truncate data.
+        self.physical_len == self.block_size && self.device.supports_send_file()
     }
 
     pub fn as_local_mut(&mut self) -> Option<&mut LocalFile> {
@@ -347,6 +360,7 @@ mod tests {
         let device = shared_read_device(&path)?;
         // Physical file is 6 bytes; logical open length is 10 (post-resize inflate).
         let mut ctx = BlockReadContext::with_physical(device, 0, 10, 6, 4)?;
+        assert!(!ctx.supports_send_file());
         let region = ctx.read_region(false, 8)?;
         let bytes = match &region {
             DataSlice::Bytes(b) => &b[..],

--- a/crates/adapters/curvine-storage-local/src/layout/file_layout.rs
+++ b/crates/adapters/curvine-storage-local/src/layout/file_layout.rs
@@ -16,7 +16,7 @@ use crate::layout::{validate_open_offset, BlockLayout};
 use crate::{BlockMeta, BlockState};
 use crate::{BlockReadContext, BlockWriteContext, VfsDir};
 use curvine_core_error::{err_box, try_err, CommonResult};
-use curvine_io::{IOError, IOResult, LocalFile};
+use curvine_io::{IOResult, LocalFile};
 use curvine_model::ExtendedBlock;
 #[cfg(test)]
 use curvine_runtime::common::ByteUnit;
@@ -261,7 +261,12 @@ impl BlockLayout for FileLayout {
         off: i64,
         logical_len: i64,
     ) -> IOResult<BlockReadContext> {
-        let physical_len = meta.len;
+        let file = Self::block_file(dir, meta)?;
+        // Block metadata can briefly retain the pre-resize length while a new
+        // active generation is already published. The opened file is the
+        // source of truth for bytes that can be read physically.
+        let device = LocalFile::with_read(file, 0)?;
+        let physical_len = device.len();
         let logical_len = logical_len.max(physical_len);
         if off < 0 || off > logical_len {
             return err_box!(
@@ -270,12 +275,6 @@ impl BlockLayout for FileLayout {
                 logical_len
             );
         }
-        // Seek within the physical file; sparse logical tail is synthesized.
-        let device_off = off.min(physical_len);
-        let read_off = u64::try_from(device_off)
-            .map_err(|_| IOError::from(format!("Invalid read offset: {}", device_off)))?;
-        let file = Self::block_file(dir, meta)?;
-        let device = LocalFile::with_read(file, read_off)?;
         BlockReadContext::with_physical(device, 0, logical_len, physical_len, off)
     }
 

--- a/crates/adapters/curvine-storage-local/src/layout/file_layout.rs
+++ b/crates/adapters/curvine-storage-local/src/layout/file_layout.rs
@@ -265,9 +265,9 @@ impl BlockLayout for FileLayout {
         // Block metadata can briefly retain the pre-resize length while a new
         // active generation is already published. The opened file is the
         // source of truth for bytes that can be read physically.
-        let device = LocalFile::with_read(file, 0)?;
-        let physical_len = device.len();
-        let logical_len = logical_len.max(physical_len);
+        let inner = OpenOptions::new().read(true).open(&file)?;
+        let device = LocalFile::from_file(&file, inner)?;
+        let physical_len = device.len().min(logical_len);
         if off < 0 || off > logical_len {
             return err_box!(
                 "Invalid block offset: {}, block length: {}",

--- a/crates/adapters/curvine-storage-local/src/vfs_dataset.rs
+++ b/crates/adapters/curvine-storage-local/src/vfs_dataset.rs
@@ -727,12 +727,14 @@ impl Dataset for VfsDataset {
 
 #[cfg(test)]
 mod test {
-    use crate::{BlockMeta, BlockState};
     use crate::{
-        Dataset, DirList, DirState, FileLayout, SpdkMetaStore, StorageVersion, VfsDataset, VfsDir,
+        BlockLayout, Dataset, DirList, DirState, FileLayout, SpdkMetaStore, StorageVersion,
+        VfsDataset, VfsDir,
     };
+    use crate::{BlockMeta, BlockState};
     use curvine_config::{ClusterConf, WorkerConf};
     use curvine_core_error::CommonResult;
+    use curvine_io::DataSlice;
     use curvine_model::{ExtendedBlock, FileType, StorageType};
     use curvine_runtime::common::FileUtils;
     use curvine_runtime::sync::AtomicLong;
@@ -1101,6 +1103,31 @@ mod test {
         assert!(!staging_path.exists());
         Ok(())
     }
+
+    #[test]
+    fn file_reader_uses_open_file_length_when_metadata_is_stale() -> CommonResult<()> {
+        let mut ds = create_data_set(true, "reader-stale-physical-len");
+        let mut block = ExtendedBlock::with_mem(1, "50B")?;
+        let writing = ds.open_block(&block)?;
+        ds.write_test_data(&writing, "20B")?;
+        block.len = 20;
+        let finalized = ds.finalize_block(&block)?;
+
+        let mut stale = finalized.clone();
+        stale.len = 50;
+        let dir = ds.find_dir(stale.dir_id())?;
+        let mut reader = FileLayout.open_reader(dir, &stale, 0, 50)?;
+        let region = reader.read_region(false, 50)?;
+        let bytes = match region {
+            DataSlice::Buffer(bytes) => bytes,
+            other => panic!("expected buffered sparse read, got {other:?}"),
+        };
+
+        assert_eq!(&bytes[..20], b"A".repeat(20).as_slice());
+        assert!(bytes[20..].iter().all(|byte| *byte == 0));
+        Ok(())
+    }
+
     #[test]
     fn remove_block_during_rewrite_deletes_active_and_staging_files() -> CommonResult<()> {
         let mut ds = create_data_set(true, "remove-during-rewrite");

--- a/crates/adapters/curvine-storage-local/src/vfs_dataset.rs
+++ b/crates/adapters/curvine-storage-local/src/vfs_dataset.rs
@@ -1129,6 +1129,28 @@ mod test {
     }
 
     #[test]
+    fn file_reader_clamps_physical_file_to_logical_length() -> CommonResult<()> {
+        let mut ds = create_data_set(true, "reader-logical-length-boundary");
+        let mut block = ExtendedBlock::with_mem(1, "50B")?;
+        let writing = ds.open_block(&block)?;
+        ds.write_test_data(&writing, "50B")?;
+        block.len = 50;
+        let finalized = ds.finalize_block(&block)?;
+
+        let dir = ds.find_dir(finalized.dir_id())?;
+        let mut reader = FileLayout.open_reader(dir, &finalized, 0, 20)?;
+        let region = reader.read_region(false, 50)?;
+        let bytes = match region {
+            DataSlice::Buffer(bytes) => bytes,
+            other => panic!("expected bounded buffered read, got {other:?}"),
+        };
+
+        assert_eq!(bytes.len(), 20);
+        assert_eq!(&bytes[..], b"A".repeat(20).as_slice());
+        Ok(())
+    }
+
+    #[test]
     fn remove_block_during_rewrite_deletes_active_and_staging_files() -> CommonResult<()> {
         let mut ds = create_data_set(true, "remove-during-rewrite");
         let mut block = ExtendedBlock::with_mem(1, "100B")?;

--- a/crates/core/curvine-io/src/block_io.rs
+++ b/crates/core/curvine-io/src/block_io.rs
@@ -277,6 +277,7 @@ mod test {
         assert_eq!(reader.len(), data.len() as i64);
         let region = reader.read_region(false, data.len() as i32)?;
         assert_eq!(region.len(), data.len());
+        assert_eq!(reader.pos(), data.len() as i64);
 
         // Verify data integrity
         let mut buf = vec![0u8; data.len()];

--- a/crates/core/curvine-io/src/local_file.rs
+++ b/crates/core/curvine-io/src/local_file.rs
@@ -143,16 +143,21 @@ impl LocalFile {
 
         #[cfg(target_os = "linux")]
         let region = if enable_send_file {
-            DataSlice::IOSlice(RawIOSlice::new(
+            let region = DataSlice::IOSlice(RawIOSlice::new(
                 curvine_sys::get_raw_io(self)?,
                 Some(self.pos),
                 chunk as usize,
-            ))
+            ));
+            // sendfile consumes the explicit RawIOSlice offset later, so keep
+            // the logical device position in sync here.
+            self.pos += chunk;
+            region
         } else {
             DataSlice::Buffer(self.read_full(Some(self.pos), chunk as usize)?)
         };
 
-        self.pos += chunk;
+        // Buffered reads advance through read_full/read_all. Advancing again
+        // here would skip one chunk on every subsequent read.
         Ok(region)
     }
 

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -3092,10 +3092,10 @@ mod tests {
     use super::CurvineFileSystem;
     use crate::{
         fuse_init_flag_names, FUSE_ATOMIC_O_TRUNC, FUSE_BIG_WRITES, FUSE_DO_READDIRPLUS,
-        FUSE_EXPORT_SUPPORT, FUSE_FLOCK_LOCKS, FUSE_HAS_IOCTL_DIR, FUSE_KERNEL_MINOR_VERSION,
-        FUSE_KERNEL_VERSION, FUSE_MAX_PAGES, FUSE_POSIX_ACL, FUSE_POSIX_LOCKS, FUSE_SETXATTR_EXT,
-        FUSE_SPLICE_MOVE, FUSE_SPLICE_READ, FUSE_SPLICE_WRITE, FUSE_WRITEBACK_CACHE,
-        SUPPORTED_INIT_FLAGS,
+        FUSE_EXPLICIT_INVAL_DATA, FUSE_EXPORT_SUPPORT, FUSE_FLOCK_LOCKS, FUSE_HAS_IOCTL_DIR,
+        FUSE_KERNEL_MINOR_VERSION, FUSE_KERNEL_VERSION, FUSE_MAX_PAGES, FUSE_POSIX_ACL,
+        FUSE_POSIX_LOCKS, FUSE_SETXATTR_EXT, FUSE_SPLICE_MOVE, FUSE_SPLICE_READ, FUSE_SPLICE_WRITE,
+        FUSE_WRITEBACK_CACHE, SUPPORTED_INIT_FLAGS,
     };
 
     #[test]
@@ -3174,6 +3174,18 @@ mod tests {
             out & FUSE_SETXATTR_EXT,
             0,
             "the decoder only supports the 8-byte SETXATTR compatibility layout"
+        );
+    }
+
+    #[test]
+    fn explicit_data_invalidation_is_not_advertised() {
+        let conf = init_conf(false, false);
+        let out = CurvineFileSystem::negotiate_out_flags(FUSE_EXPLICIT_INVAL_DATA, &conf);
+
+        assert_eq!(
+            out & FUSE_EXPLICIT_INVAL_DATA,
+            0,
+            "page-cache invalidation is currently delegated to the kernel"
         );
     }
 

--- a/curvine-fuse/src/lib.rs
+++ b/curvine-fuse/src/lib.rs
@@ -173,8 +173,9 @@ pub const FUSE_ATOMIC_O_TRUNC: u32 = 1 << 3;
 ///
 /// Deliberately EXCLUDED (never advertised): FUSE_ATOMIC_O_TRUNC (open does not
 /// truncate), FUSE_POSIX_ACL (no ACL handling), FUSE_HAS_IOCTL_DIR (no ioctl),
-/// FUSE_SETXATTR_EXT (the decoder currently accepts only the 8-byte compatible
-/// request layout).
+/// FUSE_EXPLICIT_INVAL_DATA (writes and resize do not issue explicit page-cache
+/// invalidations), FUSE_SETXATTR_EXT (the decoder currently accepts only the
+/// 8-byte compatible request layout).
 pub const SUPPORTED_INIT_FLAGS: u32 = FUSE_ASYNC_READ
     | FUSE_BIG_WRITES
     | FUSE_ASYNC_DIO
@@ -195,7 +196,6 @@ pub const SUPPORTED_INIT_FLAGS: u32 = FUSE_ASYNC_READ
     | FUSE_ABORT_ERROR
     | FUSE_CACHE_SYMLINKS
     | FUSE_NO_OPENDIR_SUPPORT
-    | FUSE_EXPLICIT_INVAL_DATA
     | FUSE_HANDLE_KILLPRIV_V2;
 
 /// Human-readable FUSE init-capability names; unknown bits are kept as hex.

--- a/curvine-worker/src/worker/block/block_store.rs
+++ b/curvine-worker/src/worker/block/block_store.rs
@@ -250,7 +250,7 @@ impl BlockStore {
     /// Returns a local path only while no finalize publication is in progress.
     /// A finalizing file can be atomically renamed before a co-located client
     /// opens the returned path, so callers must use `open_reader_by_id` then.
-    pub fn short_circuit_by_id(&self, id: i64) -> CommonResult<Option<(BlockMeta, String)>> {
+    pub fn short_circuit_by_id(&self, id: i64) -> CommonResult<Option<(BlockMeta, String, i64)>> {
         let state = self.read()?;
         if matches!(
             state.get_block(id).map(BlockMeta::state),
@@ -263,7 +263,11 @@ impl BlockStore {
             .ok_or_else(|| curvine_core_error::err_msg!(format!("block {} not exists", id)))?
             .clone();
         let (layout, dir) = state.layout_for(&meta)?;
-        Ok(layout.short_circuit(&dir, &meta)?.map(|path| (meta, path)))
+        let Some(path) = layout.short_circuit(&dir, &meta)? else {
+            return Ok(None);
+        };
+        let physical_len = std::fs::metadata(&path)?.len() as i64;
+        Ok(Some((meta, path, physical_len)))
     }
 
     pub fn short_circuit(&self, meta: &BlockMeta) -> CommonResult<Option<String>> {
@@ -559,6 +563,27 @@ mod tests {
     }
 
     #[test]
+    fn short_circuit_reports_live_file_length() -> CommonResult<()> {
+        let store = create_store_with_capacity("short-circuit-live-length", "16MB")?;
+        let block = ExtendedBlock::with_mem(1, "50B")?;
+        let finalized = finalize_block(&store, &block)?;
+        let path = store
+            .short_circuit(&finalized)?
+            .expect("file layout must expose a local path");
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(path)?
+            .set_len(20)?;
+
+        let (meta, _, physical_len) = store
+            .short_circuit_by_id(block.id)?
+            .expect("finalized file must support short-circuit reads");
+        assert_eq!(meta.len(), 50);
+        assert_eq!(physical_len, 20);
+        Ok(())
+    }
+
+    #[test]
     fn reader_opened_before_publish_keeps_committed_generation() -> CommonResult<()> {
         let store = create_store_with_capacity("finalize-reader-generation", "16MB")?;
         let block = ExtendedBlock::with_mem(1, "4B")?;
@@ -580,11 +605,11 @@ mod tests {
             .expect("rewrite finalize must reserve");
         let plan = reservation.prepare(block.len)?;
 
-        let (_, mut committed_reader) = store.open_reader_by_id(block.id, 0, 0)?;
+        let (_, mut committed_reader) = store.open_reader_by_id(block.id, 0, block.len)?;
         store.write()?.publish_file_finalize(&reservation, plan)?;
         assert_eq!(read_bytes(&mut committed_reader, 4)?, b"old!");
 
-        let (_, mut published_reader) = store.open_reader_by_id(block.id, 0, 0)?;
+        let (_, mut published_reader) = store.open_reader_by_id(block.id, 0, block.len)?;
         assert_eq!(read_bytes(&mut published_reader, 4)?, b"new!");
         Ok(())
     }

--- a/curvine-worker/src/worker/handler/read_handler.rs
+++ b/curvine-worker/src/worker/handler/read_handler.rs
@@ -41,6 +41,10 @@ pub struct ReadHandler {
 impl ReadHandler {
     pub const MAX_READ_AHEAD: i64 = 16 * 1024 * 1024;
 
+    fn can_short_circuit(logical_len: i64, physical_len: i64) -> bool {
+        physical_len >= logical_len
+    }
+
     pub fn new(store: BlockStore) -> CommonResult<Self> {
         let metrics = Worker::get_metrics()?;
         let conf = Worker::get_conf()?;
@@ -60,27 +64,21 @@ impl ReadHandler {
         let context = ReadContext::from_req(msg)?;
         let conf = Worker::get_conf()?;
         let max_block_size = conf.master.max_block_size;
-        let meta = self.store.get_block(context.block_id).map_err(|e| {
+        self.store.get_block(context.block_id).map_err(|e| {
             FsError::block_not_found(context.block_id)
                 .ctx(format!("worker block store lookup failed: {}", e))
         })?;
 
-        // Master sparse ResizeFile may raise logical block len above the
-        // worker's physical file size. Only synthesize a sparse tail when the
-        // client advertises a validated logical length above physical bytes.
-        let physical_len = meta.len;
-        let logical_len = if context.len > physical_len {
-            if context.len > max_block_size {
-                return err_box!(
-                    "Advertised block length {} exceeds max_block_size {}",
-                    context.len,
-                    max_block_size
-                );
-            }
-            context.len
-        } else {
-            physical_len
-        };
+        // The Master/client length is the logical boundary. Worker metadata
+        // may briefly describe an older physical generation.
+        let logical_len = context.len;
+        if logical_len < 0 || logical_len > max_block_size {
+            return err_box!(
+                "Advertised block length {} is outside 0..={}",
+                logical_len,
+                max_block_size
+            );
+        }
         if context.off < 0 {
             return err_box!(
                 "Invalid read offset: {}, block length: {}",
@@ -118,13 +116,15 @@ impl ReadHandler {
 
         // Short-circuit local reads cannot synthesize sparse tails; force the
         // remote path when logical length exceeds physical worker bytes.
-        let sc_path = if context.short_circuit && logical_len <= meta.len {
-            self.store.short_circuit_by_id(context.block_id)?
+        let sc_path = if context.short_circuit {
+            self.store
+                .short_circuit_by_id(context.block_id)?
+                .filter(|(_, _, physical_len)| Self::can_short_circuit(logical_len, *physical_len))
         } else {
             None
         };
 
-        let (meta, is_short_circuit, path, file) = if let Some((meta, path)) = sc_path {
+        let (meta, is_short_circuit, path, file) = if let Some((meta, path, _)) = sc_path {
             (meta, true, path, None)
         } else {
             let (meta, file) =
@@ -240,5 +240,16 @@ impl ReadHandler {
 
             _ => err_box!("Unsupported request type"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ReadHandler;
+
+    #[test]
+    fn short_circuit_requires_live_physical_coverage() {
+        assert!(ReadHandler::can_short_circuit(20, 50));
+        assert!(!ReadHandler::can_short_circuit(50, 20));
     }
 }


### PR DESCRIPTION
# Summary

Fix stale data and short reads after a file is truncated down and later grown again.

Curvine Worker reads may need to synthesize a zero-filled sparse tail when the Master-visible logical block length is larger than the bytes currently materialized in the active block file. The affected path trusted the cached `BlockMeta.len` as the physical file length and could continue through `sendfile`, even when the active file was shorter. When the read fell back to the buffered path, `LocalFile::read_region` advanced its internal position twice, causing later chunks to read from the wrong offset or fail with a short physical read.

The combined failure surfaced in the following xfstests:

- `generic/075`: buffered `fsx` coverage.
- `generic/091`: direct I/O with sub-block and buffered I/O coverage.
- `generic/112`: asynchronous I/O variant of the buffered `fsx` coverage.
- `generic/263`: direct I/O mixed with sub-block buffered I/O.

All four tests now pass. 

# Failure Signature

In `generic/091`, operation 4948 read data from a region that had been removed by truncate and later exposed as a hole:

```text
4894 TRUNCATE DOWN 0x79000 -> 0x2f000
4923 TRUNCATE DOWN 0x59000 -> 0xf000
4924 WRITE hole 0x3c000..0x41fff
4937 COPY ... -> 0x3b000..0x3dfff
4940 TRUNCATE UP 0x42000 -> 0x4d000
4948 READ 0x2f000..0x38fff
```

The hole should read as zero, but fsx reported data from an earlier operation:

```text
READ BAD DATA: offset = 0x2f000, size = 0xa000
0x35000 GOOD=0 BAD=operation 63 data
```

The same read path could also fail with a short physical read:

```text
short physical read: expected 131072, got 114688
```

# Minimal Reproducer

Run `generic/091` against a Curvine FUSE mount:

```bash
printf '%s\n' generic/091 > /tmp/curvine-target-091.tests

CURVINE_XFSTESTS_LOCK=/tmp/curvinedevtests-xfstests-fix.lock \
CURVINE_TEST_FS_PATH=/xfstests-fix-test \
CURVINE_SCRATCH_FS_PATH=/xfstests-fix-scratch \
bash /root/ljy/curvinedevtests/xfstests/suites/generic-supported/run.sh \
  --xfstests-root /opt/xfstests \
  --curvine-dist /root/ljy/curvine/build/dist \
  --test-mnt /tmp/curvine-test-fix \
  --scratch-mnt /tmp/curvine-scratch-fix \
  --test-list /tmp/curvine-target-091.tests \
  --timeout 300 \
  --manage-cluster
```

Before the fix, fsx either reported old data in a post-truncate hole or failed with `EIO` after the Worker detected a short physical read.

After the fix:

```text
generic/091      PASS     rc=0   duration=13s
```

# Root Cause

There were two interacting read-path defects.

## Stale metadata was treated as physical file length

`FileLayout::open_reader` used `BlockMeta.len` for both the logical length and the number of bytes physically available from the active block file:

```rust
let physical_len = meta.len;
let logical_len = logical_len.max(physical_len);
```

During truncate, sparse growth, and block-generation publication, the cached Worker metadata can temporarily describe the previous length while the active file already has a different length. A stale-high value caused the read context to request physical bytes beyond the end of the opened file. It could also allow the deferred `sendfile` path to represent bytes that should have been synthesized as zeros.

The opened file descriptor is the authoritative source for physical bytes. Master/client metadata remains the source for the logical block length visible to the caller.

## Buffered reads advanced `LocalFile.pos` twice

`LocalFile::read_full` calls `read_all`, which advances `self.pos`, but `read_region` also advanced `self.pos` after `read_full` returned:

```text
read_region
  -> read_full
     -> read_all
        -> self.pos += bytes_read
  -> self.pos += chunk
```

Each buffered chunk therefore moved the internal device position twice while `BlockReadContext.block_pos` moved once. Subsequent reads used the wrong physical offset and eventually returned stale data, a short chunk, or `EIO`.

# Changes

- Open the active block file before determining physical length and use the opened `LocalFile::len()` as the physical read boundary.
- Keep the client/Master-advertised block length as the logical boundary and synthesize zeros between the physical and logical ends.
- Disable `sendfile` for the entire read session when physical and logical lengths differ, ensuring sparse data is materialized through the buffered zero-fill path.
- Advance `LocalFile.pos` explicitly only for `sendfile`; buffered reads already advance through `read_full` and `read_all`.
- Preserve strict short-read validation and include block position, device position, cached length, and live file length in the error message.
- Stop advertising `FUSE_EXPLICIT_INVAL_DATA` until Curvine issues complete explicit page-cache invalidations for write and resize operations.
- Add regression coverage for stale-high block metadata, sparse zero-filled tails, sendfile eligibility, and single-step buffered position advancement.

# Correctness Notes

The fixed read model separates logical and physical length:

```text
logical length  = length visible to the client
physical length = length obtained from the opened block file

[ physical data ][ zero-filled sparse tail ]
0                                             logical length
```

For a sparse session:

- Reads below the physical boundary come from the opened file.
- Reads crossing the boundary buffer the physical prefix and append zeros.
- Reads entirely above the physical boundary return zeros.
- The block-relative and device positions advance exactly once per physical byte read.
- `sendfile` is used only when the complete logical block is physically materialized.

Removing `FUSE_EXPLICIT_INVAL_DATA` does not disable normal kernel cache coherency. It avoids promising that userspace will explicitly invalidate every affected page while the implementation still relies on the kernel's automatic invalidation behavior.

# Verification

Targeted unit tests:

```text
cargo test -p curvine-io block_device_local_write_read_roundtrip
cargo test -p curvine-storage-local file_reader_uses_open_file_length_when_metadata_is_stale
cargo test -p curvine-storage-local read_context_sparse_logical_tail_returns_zeros
cargo test -p curvine-fuse explicit_data_invalidation_is_not_advertised
```

Release builds:

```text
cargo build --release -p curvine-fuse \
  --no-default-features \
  --features fuse3,curvine-client/opendal-s3,curvine-alloc/jemalloc
cargo build --release -p curvine-server
```

xfstests results:

```text
generic/075      PASS     rc=0   duration=14s
generic/091      PASS     rc=0   duration=13s
generic/112      PASS     rc=0   duration=15s
generic/263      PASS     rc=0   duration=8s
```

Formatting and patch validation:

```text
cargo fmt --all
git diff --check
```

# Scope

This change fixes truncate/sparse-growth data correctness in the Worker and FUSE read path.
