### PR TITLE
fix(transfer): recover orphan Stale tasks that never finish jobs (#1595)

### DIFF
--- a/crates/server/curvine-data-transfer/src/transfer/backend.rs
+++ b/crates/server/curvine-data-transfer/src/transfer/backend.rs
@@ -16,7 +16,8 @@ use curvine_error::FsError;
 use curvine_error::FsResult;
 use curvine_model::{
     StaleTaskAttempt, TaskAttemptStart, TransferJobRecord, TransferLease, TransferListFilter,
-    TransferStateUpdate, TransferTaskRecord, TransferTaskReport, TransferTenantSummary,
+    TransferStateUpdate, TransferTaskRecord, TransferTaskReport, TransferTaskState,
+    TransferTenantSummary,
 };
 use std::time::Instant;
 
@@ -393,6 +394,22 @@ impl TransferStore for TransferStoreBackend {
             Self::Mysql(store) => {
                 store.list_stale_running_tasks(job_id, run_id, stale_before_ms, limit)
             }
+        })
+    }
+
+    fn list_tasks_by_state(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        state: TransferTaskState,
+        limit: usize,
+    ) -> FsResult<Vec<TransferTaskRecord>> {
+        self.record_store_operation("list_tasks_by_state", || match self {
+            Self::Memory(store) => store.list_tasks_by_state(job_id, run_id, state, limit),
+            #[cfg(feature = "transfer-store-sqlite")]
+            Self::Sqlite(store) => store.list_tasks_by_state(job_id, run_id, state, limit),
+            #[cfg(feature = "transfer-store-mysql")]
+            Self::Mysql(store) => store.list_tasks_by_state(job_id, run_id, state, limit),
         })
     }
 

--- a/crates/server/curvine-data-transfer/src/transfer/memory_store.rs
+++ b/crates/server/curvine-data-transfer/src/transfer/memory_store.rs
@@ -617,9 +617,7 @@ impl TransferStore for MemoryTransferStore {
             .lock()
             .tasks
             .values()
-            .filter(|task| {
-                task.job_id == job_id && task.run_id == run_id && task.state == state
-            })
+            .filter(|task| task.job_id == job_id && task.run_id == run_id && task.state == state)
             .cloned()
             .collect();
         tasks.sort_by_key(|task| task.updated_at);

--- a/crates/server/curvine-data-transfer/src/transfer/memory_store.rs
+++ b/crates/server/curvine-data-transfer/src/transfer/memory_store.rs
@@ -605,6 +605,28 @@ impl TransferStore for MemoryTransferStore {
             .collect())
     }
 
+    fn list_tasks_by_state(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        state: TransferTaskState,
+        limit: usize,
+    ) -> FsResult<Vec<TransferTaskRecord>> {
+        let mut tasks: Vec<_> = self
+            .inner
+            .lock()
+            .tasks
+            .values()
+            .filter(|task| {
+                task.job_id == job_id && task.run_id == run_id && task.state == state
+            })
+            .cloned()
+            .collect();
+        tasks.sort_by_key(|task| task.updated_at);
+        tasks.truncate(limit);
+        Ok(tasks)
+    }
+
     fn has_failed_tasks(&self, job_id: &str, run_id: u64) -> FsResult<bool> {
         Ok(self.inner.lock().tasks.values().any(|task| {
             task.job_id == job_id

--- a/crates/server/curvine-data-transfer/src/transfer/mysql_store.rs
+++ b/crates/server/curvine-data-transfer/src/transfer/mysql_store.rs
@@ -727,6 +727,16 @@ impl TransferStore for MysqlTransferStore {
             .collect()
     }
 
+    fn list_tasks_by_state(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        state: TransferTaskState,
+        limit: usize,
+    ) -> FsResult<Vec<TransferTaskRecord>> {
+        select_tasks(&mut self.conn()?, job_id, run_id, Some(state), Some(limit))
+    }
+
     fn has_failed_tasks(&self, job_id: &str, run_id: u64) -> FsResult<bool> {
         let result: Option<u8> = self
             .conn()?

--- a/crates/server/curvine-data-transfer/src/transfer/scheduler.rs
+++ b/crates/server/curvine-data-transfer/src/transfer/scheduler.rs
@@ -504,7 +504,7 @@ where
     ) -> FsResult<()> {
         let now = now_ms();
         self.probe_stale_running_tasks(&job, now).await?;
-        let stale = self.store.mark_stale_attempts(
+        let _ = self.store.mark_stale_attempts(
             &job.job_id,
             job.run_id,
             &lease.owner,
@@ -512,14 +512,21 @@ where
             now,
             self.conf.task_probe_concurrency(),
         )?;
-        for attempt in stale {
-            if attempt.task.retry_count as usize > self.conf.task_max_retries {
+        // Recover all Stale tasks (newly marked + orphan leftovers from CAS races).
+        let stale_tasks = self.store.list_tasks_by_state(
+            &job.job_id,
+            job.run_id,
+            TransferTaskState::Stale,
+            self.conf.task_probe_concurrency(),
+        )?;
+        for task in stale_tasks {
+            if task.retry_count as usize > self.conf.task_max_retries {
                 if !self.store.update_task_state(TransferTaskStateUpdate {
-                    job_id: attempt.task.job_id.clone(),
-                    run_id: attempt.task.run_id,
+                    job_id: task.job_id.clone(),
+                    run_id: task.run_id,
                     owner: lease.owner.clone(),
                     lease_epoch: lease.lease_epoch,
-                    task_id: attempt.task.task_id.clone(),
+                    task_id: task.task_id.clone(),
                     from_states: vec![TransferTaskState::Stale],
                     state: TransferTaskState::Failed,
                     message: "transfer task did not report progress before the retry limit was reached; check Transfer worker health".to_string(),
@@ -532,11 +539,11 @@ where
                 return Ok(());
             }
             if !self.store.update_task_state(TransferTaskStateUpdate {
-                job_id: attempt.task.job_id.clone(),
-                run_id: attempt.task.run_id,
+                job_id: task.job_id.clone(),
+                run_id: task.run_id,
                 owner: lease.owner.clone(),
                 lease_epoch: lease.lease_epoch,
-                task_id: attempt.task.task_id.clone(),
+                task_id: task.task_id.clone(),
                 from_states: vec![TransferTaskState::Stale],
                 state: TransferTaskState::Pending,
                 message: "retry stale task attempt".to_string(),

--- a/crates/server/curvine-data-transfer/src/transfer/sqlite_store.rs
+++ b/crates/server/curvine-data-transfer/src/transfer/sqlite_store.rs
@@ -791,6 +791,35 @@ impl TransferStore for SqliteTransferStore {
         collect_sqlite_rows(rows)
     }
 
+    fn list_tasks_by_state(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        state: TransferTaskState,
+        limit: usize,
+    ) -> FsResult<Vec<TransferTaskRecord>> {
+        let conn = self.conn.lock();
+        let mut stmt = conn
+            .prepare(
+                "select job_id, run_id, task_id, attempt_id, source_path, target_path,
+                        worker_id, worker_session_id, source_read_plan_json, report_target_json,
+                        state, progress_json, retry_count, attempt_started_at, last_report_at,
+                        stale_deadline_at, updated_at
+                 from transfer_tasks
+                 where job_id = ?1 and run_id = ?2 and state = ?3
+                 order by updated_at asc
+                 limit ?4",
+            )
+            .map_err(sqlite_err)?;
+        let rows = stmt
+            .query_map(
+                params![job_id, run_id as i64, state as i32, limit as i64],
+                sqlite_task_row,
+            )
+            .map_err(sqlite_err)?;
+        collect_sqlite_rows(rows)
+    }
+
     fn has_failed_tasks(&self, job_id: &str, run_id: u64) -> FsResult<bool> {
         self.conn
             .lock()

--- a/crates/server/curvine-data-transfer/src/transfer/store.rs
+++ b/crates/server/curvine-data-transfer/src/transfer/store.rs
@@ -127,6 +127,15 @@ pub trait TransferStore: Send + Sync + 'static {
         limit: usize,
     ) -> FsResult<Vec<TransferTaskRecord>>;
 
+    /// List tasks in the given state for a job run, oldest-updated first, capped by `limit`.
+    fn list_tasks_by_state(
+        &self,
+        job_id: &str,
+        run_id: u64,
+        state: TransferTaskState,
+        limit: usize,
+    ) -> FsResult<Vec<TransferTaskRecord>>;
+
     fn has_failed_tasks(&self, job_id: &str, run_id: u64) -> FsResult<bool>;
 
     fn has_recoverable_tasks(&self, job_id: &str, run_id: u64) -> FsResult<bool>;


### PR DESCRIPTION
# Summary

Fix Transfer Load jobs that stay `Running` forever after progress reaches 100% because leftover `Stale` tasks are never requeued or failed. After `mark_stale_attempts`, each Running tick now sweeps all `state=Stale` tasks (limit-capped) and recovers them the same way as freshly marked ones.

# Issue Describe / Design

Closes #1595

**Root cause**
`check_running_transfer` only recovered Stale tasks returned by the current tick's `mark_stale_attempts`. Orphan Stale tasks left by concurrent CAS / lease races (or failed `Stale → Pending/Failed` updates) were never listed again, so the job could not drain and finish.

**Reproduction (production)**
- Job `90e96a48-c61d-4ea8-8f60-95cfc8e289ae`: `State=Running`, progress 100%, `3965 completed / 0 running / 35 stale`, stuck for ~3 days.

**Fix approach (P2)**
1. Keep `mark_stale_attempts` as `Running → Stale`.
2. Add `list_tasks_by_state(..., Stale, limit)` and recover all listed Stale tasks: retry exhausted → `Failed`, else → `Pending`.
3. Existing `claim_pending_tasks` → `Dispatching` → redispatch path unchanged.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `transfer/scheduler.rs` | After `mark_stale_attempts`, recover via `list_tasks_by_state(Stale)` instead of only the mark result set | Behavior change: orphan Stale tasks self-heal on later ticks |
| `transfer/store.rs` | Add `list_tasks_by_state` trait method | None for callers that do not use it |
| `transfer/memory_store.rs` | Implement `list_tasks_by_state` | Same |
| `transfer/sqlite_store.rs` | Implement `list_tasks_by_state` | Same |
| `transfer/mysql_store.rs` | Implement `list_tasks_by_state` via `select_tasks` | Same |
| `transfer/backend.rs` | Dispatch `list_tasks_by_state` to backends | Same |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo check -p curvine-data-transfer --features transfer-store-sqlite,transfer-store-mysql` | PASS | Compiles with Memory/Sqlite/Mysql store backends |

# Dependencies

- Related PRs: None
- Related issues: #1595
- Blocks / blocked by: None

Made with [Cursor](https://cursor.com)