### PR TITLE
fix(fuse): preserve getattr for unlinked inodes

### DIFF
--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -1395,7 +1395,7 @@ impl fs::FileSystem for CurvineFileSystem {
         self.check_traverse_permissions(op.header.nodeid, op.header)
             .await?;
 
-        let status = self.state.fs_stat(op.header.nodeid, None).await?;
+        let status = self.state.fs_stat_guarded(op.header.nodeid).await?;
 
         let mut fuse_attr = FuseUtils::status_to_attr(&self.conf, &status)?;
         fuse_attr.ino = op.header.nodeid;
@@ -1975,6 +1975,7 @@ impl fs::FileSystem for CurvineFileSystem {
         let path = self.state.get_path_common(op.header.nodeid, Some(name))?;
         self.ensure_writable_path(&path, RpcCode::Delete).await?;
 
+        let _guard = self.state.lock_path(&path).await;
         self.fs.delete(&path, false).await?;
         self.state.unlink(op.header.nodeid, name, false)?;
         self.state

--- a/curvine-fuse/src/fs/dcache/inode.rs
+++ b/curvine-fuse/src/fs/dcache/inode.rs
@@ -177,6 +177,10 @@ impl Inode {
         self.n_lookup == 0 && self.ref_ctr == 0 && !self.is_root()
     }
 
+    pub fn is_unlinked(&self) -> bool {
+        self.ref_ctr == 0 && !self.is_root()
+    }
+
     pub fn sub_link(&mut self, v: u32) {
         self.nlink = self.nlink.saturating_sub(v);
     }

--- a/curvine-fuse/src/fs/state/node_state.rs
+++ b/curvine-fuse/src/fs/state/node_state.rs
@@ -692,6 +692,7 @@ impl NodeState {
             let dir = self.dir_read();
             dir.get_path_name(parent, name)?
         };
+        let _guard = self.lock_path(&path).await;
 
         let ino = {
             let dir = self.dir_read();
@@ -1015,7 +1016,22 @@ impl NodeState {
         None
     }
 
+    fn unlinked_status(&self, ino: u64) -> Option<FileStatus> {
+        let dir = self.dir_read();
+        dir.get_inode(ino, None)
+            .filter(|inode| inode.is_unlinked())
+            .map(|inode| inode.clone_status())
+    }
+
     pub async fn fs_stat(&self, ino: u64, name: Option<&str>) -> FuseResult<FileStatus> {
+        // An unlinked inode can remain addressable by nodeid until the kernel
+        // releases its lookup/open references. Its former path no longer exists.
+        if name.is_none() {
+            if let Some(status) = self.unlinked_status(ino) {
+                return Ok(status);
+            }
+        }
+
         if let Some(status) = self.get_cached_status(ino, name, false)? {
             return Ok(status);
         }
@@ -1025,6 +1041,25 @@ impl NodeState {
 
         self.cache_resolved_status(ino, name, &status);
 
+        Ok(status)
+    }
+
+    pub async fn fs_stat_guarded(&self, ino: u64) -> FuseResult<FileStatus> {
+        if let Some(status) = self.unlinked_status(ino) {
+            return Ok(status);
+        }
+        if let Some(status) = self.get_cached_status(ino, None, false)? {
+            return Ok(status);
+        }
+
+        let path = self.get_path(ino)?;
+        let _guard = self.lock_path(&path).await;
+        if let Some(status) = self.unlinked_status(ino) {
+            return Ok(status);
+        }
+
+        let status = self.fs.get_status(&path).await?;
+        self.cache_resolved_status(ino, None, &status);
         Ok(status)
     }
 
@@ -1619,6 +1654,53 @@ mod test {
             .get_cached_status(FUSE_ROOT_ID, None, false)
             .unwrap()
             .is_none());
+    }
+
+    #[test]
+    fn guarded_fs_stat_observes_concurrent_directory_unlink() {
+        let rt = Arc::new(AsyncRuntime::single());
+        rt.block_on(async {
+            let mut conf = ClusterConf::default();
+            conf.fuse.enable_meta_cache = true;
+            conf.fuse.metrics_enabled = false;
+            let fs = UnifiedFileSystem::with_rt(conf, rt.clone()).unwrap();
+            let state = Arc::new(NodeState::new(fs).unwrap());
+
+            let ino = {
+                let mut dir = state.dir_write();
+                let mut status = FileStatus::with_name(42, "gone".to_string(), true);
+                status.mode = 0o755;
+                status.nlink = 2;
+                let ino = dir.lookup(FUSE_ROOT_ID, "gone", status, true).unwrap().ino;
+                dir.get_inode_mut_check(ino, None).unwrap().invalid_cache();
+                ino
+            };
+
+            let path = state.get_path(ino).unwrap();
+            let guard = state.lock_path(&path).await;
+            let task_state = state.clone();
+            let stat_task = tokio::spawn(async move { task_state.fs_stat_guarded(ino).await });
+            tokio::task::yield_now().await;
+
+            state
+                .dir_write()
+                .unlink(FUSE_ROOT_ID, "gone", false)
+                .unwrap();
+            drop(guard);
+
+            let status = stat_task.await.unwrap().unwrap();
+            assert!(status.is_dir);
+            assert_eq!(status.mode, 0o755);
+            assert_eq!(status.nlink, 1);
+            assert_eq!(
+                state
+                    .dir_read()
+                    .get_inode_check(ino, None)
+                    .unwrap()
+                    .n_lookup,
+                1
+            );
+        });
     }
 
     #[test]


### PR DESCRIPTION
# Summary

Fix a FUSE metadata race where `GETATTR` can return `ENOENT` for an inode that has been unlinked from its directory but is still referenced by the kernel.

The failure is most visible when one process removes a directory while another process still uses that directory as its current working directory. Linux may continue addressing the retained inode by nodeid until its lookup or open references are released. Curvine instead reconstructed the inode's former path and queried the Master after that path had already been deleted.

This caused `chdir("..")` from the retained directory to fail before the kernel could traverse to its parent.

# Failure Signature

The concurrent directory stress workload failed in the five-process, one-process-per-directory configuration:

```text
*** TEST 2 -p 5 -n 1 -f <count>
    dirstress failed
```

The detailed error was:

```text
Cannot chdir out of working directory: No such file or directory
```

The syscall ordering showed one process removing the shared working directory while another process was still inside it:

```text
process A: chdir("..")        = 0
process A: rmdir("stressdir") = 0
process B: chdir("..")        = -1 ENOENT
```

FUSE received `GETATTR` for process B's retained current-directory nodeid. The request failed because Curvine queried the deleted backend path instead of the retained inode:

```text
FUSE_RMDIR   -> success
FUSE_GETATTR -> ENOENT: /.../stressdir not found
```

# Reproducer

Run the dirstress configuration directly on a Curvine FUSE mount:

```bash
mkdir -p /curvine-test/dirstress-repro
/root/ljy/xfstests/src/dirstress \
  -d /curvine-test/dirstress-repro \
  -s 1786961284 \
  -f 1000 \
  -p 5 \
  -n 1
```

The same workload is covered by `generic/011`.

# Root Cause

Curvine keeps an inode in the dcache while the kernel still owns lookup or open references. Removing the final directory entry drops the inode's dentry reference count to zero, but the inode remains addressable by nodeid until the kernel sends the matching `FORGET` or releases its handle.

Two gaps caused the failure.

## Unlinked inode attributes depended on the deleted path

`NodeState::fs_stat` used cached attributes only while the normal metadata-cache entry was valid. Directory mutations invalidate that cache entry. A later `GETATTR(nodeid)` therefore reconstructed the inode's former pathname and sent `GetStatus` to the Master.

Once `rmdir` had removed the path, the Master correctly returned `ENOENT`, even though the kernel was still allowed to address the retained inode itself.

## Backend deletion and dcache detachment were not ordered with GETATTR

FUSE metadata requests run in independent asynchronous tasks. `rmdir` deleted the backend path before detaching the local dentry, while `GETATTR` could issue a path-based status request concurrently.

Even when `GETATTR` rechecked the dcache, it could pass the check immediately before deletion and reach the Master after the path was gone.

# Changes

- Identify retained unlinked inodes by their zero dentry reference count.
- Return the inode's preserved `FileStatus` for nodeid-based status requests after the final directory entry has been removed.
- Keep named lookup and named status paths unchanged so a deleted pathname cannot be revived from stale dcache state.
- Add a guarded nodeid status path for FUSE `GETATTR`.
- Serialize cache-miss `GETATTR`, `unlink`, and `rmdir` transitions with the existing striped path lock.
- Recheck the unlinked state after acquiring the path lock so a waiting `GETATTR` observes a concurrent deletion without querying the former path.
- Add a regression test that pauses `GETATTR` on the path lock, unlinks the directory, and verifies that the retained inode attributes are returned.

# Correctness Notes

The fixed behavior separates inode lifetime from pathname lifetime:

```text
directory entry removed
        |
        +-- named LOOKUP/stat -> ENOENT
        |
        +-- retained nodeid GETATTR -> preserved inode attributes
                                      until FORGET/release
```

The cached-status exception is limited to inodes with no remaining dentry references. Existing linked paths continue to use normal metadata-cache and Master refresh behavior.

The path lock closes both possible orderings:

```text
GETATTR first: refresh status, then deletion proceeds
delete first:  detach inode, then GETATTR returns retained attributes
```

# Concurrency And Performance Impact

- No global lock is added; the existing striped path-lock table is reused.
- Metadata-cache hits return before acquiring the path lock.
- Only cache-miss `GETATTR` requests serialize with deletion for the same lock stripe.
- Unrelated paths remain concurrent except for existing stripe collisions.
- No RPC schema, persisted metadata, or configuration change is required.

# Verification

Formatting and patch validation:

```text
cargo fmt --all -- --check
git diff --check
```

Curvine FUSE unit tests:

```text
cargo test -p curvine-fuse --lib -- --test-threads=1

test result: ok. 427 passed; 0 failed; 0 ignored
```

Release build:

```text
cargo build --release -p curvine-fuse \
  --no-default-features \
  --features fuse3,curvine-client/opendal-s3,curvine-alloc/jemalloc
```

The final release binary passed ten consecutive runs of the affected xfstest:

```text
generic/011      PASS
generic/011      PASS
generic/011      PASS
generic/011      PASS
generic/011      PASS
generic/011      PASS
generic/011      PASS
generic/011      PASS
generic/011      PASS
generic/011      PASS

TOTAL: 10
PASS:  10
FAIL:  0
```

# Scope

This change fixes retained-inode `GETATTR` ordering with `unlink` and `rmdir`. It does not change ordinary path lookup semantics or keep deleted names visible.
