### PR TITLE
feat(compat): expose compatibility metrics and CLI worker version stats (#1527)

### DIFF
--- a/curvine-cli/src/cmds/node.rs
+++ b/curvine-cli/src/cmds/node.rs
@@ -326,19 +326,18 @@ impl NodeCommand {
         let mut legacy_count: u32 = 0;
 
         for worker in workers {
-            // Prefer structured component_info
-            if let Some(component_info) = worker["component_info"].as_object() {
-                if let Some(version) = component_info
-                    .get("release_version")
-                    .and_then(|v| v.as_str())
-                {
-                    if !version.is_empty() {
-                        *version_counts.entry(version.to_string()).or_insert(0) += 1;
-                        continue;
-                    }
-                }
-                // component_info exists but empty -> treat as legacy
-                legacy_count += 1;
+            // Prefer structured component_info.release_version (T7+). When
+            // component_info is present but release_version is missing or
+            // empty (partially-upgraded / malformed payloads), fall back to
+            // the legacy software_version display string.
+            let release_version = worker["component_info"]
+                .as_object()
+                .and_then(|ci| ci.get("release_version"))
+                .and_then(|v| v.as_str())
+                .filter(|v| !v.is_empty());
+
+            if let Some(version) = release_version {
+                *version_counts.entry(version.to_string()).or_insert(0) += 1;
             } else {
                 // Fall back to legacy software_version
                 let sv = worker["software_version"].as_str().unwrap_or("unknown");
@@ -384,8 +383,8 @@ impl NodeCommand {
 struct VersionCounts {
     /// Map of display version -> worker count. BTreeMap keeps output stable.
     versions: BTreeMap<String, u32>,
-    /// Workers with no usable version data (empty component_info or missing
-    /// release version).
+    /// Workers with no usable version data (no structured release_version and
+    /// no usable legacy software_version).
     legacy_count: u32,
 }
 
@@ -444,14 +443,39 @@ mod tests {
     }
 
     #[test]
-    fn count_worker_versions_treats_empty_component_info_as_legacy() {
-        // component_info present but without a release_version must not
-        // override the legacy software_version fallback; it counts as legacy.
+    fn count_worker_versions_falls_back_when_component_info_lacks_release_version() {
+        // component_info present but without a usable release_version must
+        // fall back to the legacy software_version display string instead of
+        // counting the worker as legacy.
+        let workers = vec![
+            serde_json::json!({
+                "address": {"hostname": "worker-host", "rpc_port": 1234},
+                "status": "Live",
+                "software_version": "0.2.0-test",
+                "component_info": {}
+            }),
+            serde_json::json!({
+                "address": {"hostname": "worker-host2", "rpc_port": 1235},
+                "status": "Live",
+                "software_version": "0.2.0-test",
+                "component_info": {"component": "worker", "release_version": ""}
+            }),
+        ];
+
+        let counts = NodeCommand::count_worker_versions(&workers);
+
+        assert_eq!(counts.versions.get("legacy (0.2.0-test)"), Some(&2));
+        assert_eq!(counts.legacy_count, 0);
+    }
+
+    #[test]
+    fn count_worker_versions_counts_legacy_when_no_version_data_at_all() {
+        // component_info present but release_version unusable, and no legacy
+        // software_version either -> legacy.
         let workers = vec![serde_json::json!({
             "address": {"hostname": "worker-host", "rpc_port": 1234},
             "status": "Live",
-            "software_version": "0.2.0-test",
-            "component_info": {}
+            "component_info": {"component": "worker", "release_version": ""}
         })];
 
         let counts = NodeCommand::count_worker_versions(&workers);

--- a/curvine-cli/src/cmds/node.rs
+++ b/curvine-cli/src/cmds/node.rs
@@ -19,6 +19,7 @@ use curvine_config::ClusterConf;
 use curvine_core_error::{err_box, CommonResult};
 use curvine_runtime::common::ByteUnit;
 use reqwest::Client;
+use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -29,6 +30,10 @@ pub struct NodeCommand {
     /// list all nodes
     #[arg(long, short = 'l')]
     list: bool,
+
+    /// show version distribution across all workers
+    #[arg(long)]
+    versions: bool,
 
     /// add decommission node
     #[arg(long)]
@@ -274,7 +279,90 @@ impl NodeCommand {
         Ok(())
     }
 
+    // Handle showing version distribution across workers
+    async fn handle_versions(&self, client: Arc<FsClient>, conf: &ClusterConf) -> CommonResult<()> {
+        let url = "/api/workers";
+        let response = handle_rpc_result(self.http_get(client.clone(), conf, url)).await;
+
+        // Parse JSON response
+        let workers_map: HashMap<String, Vec<serde_json::Value>> = serde_json::from_str(&response)?;
+
+        let live_workers = workers_map.get("live_workers").cloned().unwrap_or_default();
+
+        let version_counts = Self::count_worker_versions(&live_workers);
+
+        println!("Version Distribution:");
+        println!("{}", "-".repeat(40));
+
+        let mut total: u32 = 0;
+        for (version, count) in &version_counts.versions {
+            println!("  {:<20}: {} worker(s)", version, count);
+            total += *count;
+        }
+
+        if version_counts.legacy_count > 0 {
+            println!(
+                "  {:<20}: {} worker(s)",
+                "legacy (no version)", version_counts.legacy_count
+            );
+            total += version_counts.legacy_count;
+        }
+
+        println!("{}", "-".repeat(40));
+        println!("  {:<20}: {} worker(s)", "total", total);
+
+        Ok(())
+    }
+
+    /// Count worker release-version distribution from the `/api/workers` JSON
+    /// payload.
+    ///
+    /// Prefers the structured `component_info.release_version` reported on
+    /// heartbeat (T7+); falls back to the legacy `software_version` display
+    /// string. Workers with no useful version data count as `legacy_count`.
+    fn count_worker_versions(workers: &[serde_json::Value]) -> VersionCounts {
+        // Count version distribution: release_version (from component_info) -> count
+        let mut version_counts: BTreeMap<String, u32> = BTreeMap::new();
+        let mut legacy_count: u32 = 0;
+
+        for worker in workers {
+            // Prefer structured component_info
+            if let Some(component_info) = worker["component_info"].as_object() {
+                if let Some(version) = component_info
+                    .get("release_version")
+                    .and_then(|v| v.as_str())
+                {
+                    if !version.is_empty() {
+                        *version_counts.entry(version.to_string()).or_insert(0) += 1;
+                        continue;
+                    }
+                }
+                // component_info exists but empty -> treat as legacy
+                legacy_count += 1;
+            } else {
+                // Fall back to legacy software_version
+                let sv = worker["software_version"].as_str().unwrap_or("unknown");
+                if sv.is_empty() || sv == "unknown" {
+                    legacy_count += 1;
+                } else {
+                    *version_counts
+                        .entry(format!("legacy ({})", sv))
+                        .or_insert(0) += 1;
+                }
+            }
+        }
+
+        VersionCounts {
+            versions: version_counts,
+            legacy_count,
+        }
+    }
+
     pub async fn execute(&self, client: Arc<FsClient>, conf: ClusterConf) -> CommonResult<()> {
+        if self.versions {
+            return self.handle_versions(client, &conf).await;
+        }
+
         if self.list {
             return self.handle_list(client, &conf).await;
         }
@@ -288,5 +376,87 @@ impl NodeCommand {
         }
 
         Ok(())
+    }
+}
+
+/// Release-version distribution across live workers, as counted by
+/// [`NodeCommand::count_worker_versions`].
+struct VersionCounts {
+    /// Map of display version -> worker count. BTreeMap keeps output stable.
+    versions: BTreeMap<String, u32>,
+    /// Workers with no usable version data (empty component_info or missing
+    /// release version).
+    legacy_count: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn worker_with_component_info(version: &str) -> serde_json::Value {
+        serde_json::json!({
+            "address": {"hostname": "worker-host", "rpc_port": 1234},
+            "status": "Live",
+            "software_version": "0.0.0-old",
+            "component_info": {
+                "component": "worker",
+                "release_version": version,
+                "protocol_version": 1
+            }
+        })
+    }
+
+    fn worker_with_legacy_software_version(version: &str) -> serde_json::Value {
+        serde_json::json!({
+            "address": {"hostname": "worker-host", "rpc_port": 1234},
+            "status": "Live",
+            "software_version": version
+        })
+    }
+
+    #[test]
+    fn count_worker_versions_prefers_structured_component_info() {
+        let workers = vec![
+            worker_with_component_info("0.4.0-alpha"),
+            worker_with_component_info("0.4.0-alpha"),
+            worker_with_component_info("0.4.0-beta"),
+        ];
+
+        let counts = NodeCommand::count_worker_versions(&workers);
+
+        assert_eq!(counts.versions.get("0.4.0-alpha"), Some(&2));
+        assert_eq!(counts.versions.get("0.4.0-beta"), Some(&1));
+        assert_eq!(counts.legacy_count, 0);
+    }
+
+    #[test]
+    fn count_worker_versions_falls_back_to_legacy_software_version() {
+        let workers = vec![
+            worker_with_legacy_software_version("0.3.0-test"),
+            worker_with_legacy_software_version("0.3.0-test"),
+            worker_with_legacy_software_version("unknown"),
+        ];
+
+        let counts = NodeCommand::count_worker_versions(&workers);
+
+        assert_eq!(counts.versions.get("legacy (0.3.0-test)"), Some(&2));
+        assert_eq!(counts.legacy_count, 1);
+    }
+
+    #[test]
+    fn count_worker_versions_treats_empty_component_info_as_legacy() {
+        // component_info present but without a release_version must not
+        // override the legacy software_version fallback; it counts as legacy.
+        let workers = vec![serde_json::json!({
+            "address": {"hostname": "worker-host", "rpc_port": 1234},
+            "status": "Live",
+            "software_version": "0.2.0-test",
+            "component_info": {}
+        })];
+
+        let counts = NodeCommand::count_worker_versions(&workers);
+
+        assert!(counts.versions.is_empty());
+        assert_eq!(counts.legacy_count, 1);
     }
 }

--- a/curvine-master/src/master/master_handler.rs
+++ b/curvine-master/src/master/master_handler.rs
@@ -505,6 +505,7 @@ impl MasterHandler {
                 self.compatibility_policy.mode,
                 self.compatibility_policy
                     .check_client(req.component_info.as_ref()),
+                self.metrics,
             )?;
         }
         let fs = self.fs.clone();
@@ -616,6 +617,7 @@ impl MasterHandler {
                 self.compatibility_policy.mode,
                 self.compatibility_policy
                     .check_worker(header.component_info.as_ref()),
+                self.metrics,
             )?;
         }
         let cmds = Self::process_worker_heartbeat(self.fs.clone(), header)?;
@@ -644,7 +646,24 @@ impl MasterHandler {
         warned: &DashMap<String, CompatibilityVerdict>,
         mode: CompatibilityMode,
         verdict: CompatibilityVerdict,
+        metrics: &MasterMetrics,
     ) -> FsResult<()> {
+        // Record the compatibility verdict as a metric.
+        let verdict_label = Self::verdict_label(&verdict);
+        let is_worker = dedup_key.starts_with("worker:");
+        if is_worker {
+            let worker_id = &dedup_key["worker:".len()..];
+            metrics
+                .compat_worker_verdict
+                .with_label_values(&[worker_id, verdict_label])
+                .set(1);
+        } else {
+            metrics
+                .compat_client_verdict
+                .with_label_values(&[dedup_key, verdict_label])
+                .set(1);
+        }
+
         if !verdict.rejects(mode) {
             if !verdict.is_compatible() {
                 // Warn on the first occurrence and whenever the verdict
@@ -664,12 +683,30 @@ impl MasterHandler {
             }
             return Ok(());
         }
+        // Enforce-mode rejection: record the counter and return the error.
+        metrics
+            .compat_enforce_rejected_total
+            .with_label_values(&[peer, verdict_label])
+            .inc();
         err_box!(
             "{} rejected by compatibility policy: {}; upgrade the {} or set master.compatibility.mode = \"diagnose\" to allow it",
             peer,
             verdict.describe(),
             peer
         )
+    }
+
+    /// Short human-readable label for a compatibility verdict, used as a
+    /// Prometheus label value in compat_*_verdict and compat_enforce_rejected_total.
+    fn verdict_label(verdict: &CompatibilityVerdict) -> &'static str {
+        match verdict {
+            CompatibilityVerdict::Compatible => "compatible",
+            CompatibilityVerdict::MissingInfo => "missing_info",
+            CompatibilityVerdict::Blocked(_) => "blocked",
+            CompatibilityVerdict::ProtocolMismatch { .. } => "protocol_mismatch",
+            CompatibilityVerdict::VersionTooOld { .. } => "version_too_old",
+            CompatibilityVerdict::VersionUnknown { .. } => "version_unknown",
+        }
     }
 
     fn process_worker_heartbeat(
@@ -1246,7 +1283,8 @@ mod tests {
             "worker:7",
             &warned,
             policy.mode,
-            verdict.clone()
+            verdict.clone(),
+            test_metrics()
         )
         .is_ok());
         assert!(warned.contains_key("worker:7"));
@@ -1258,7 +1296,8 @@ mod tests {
             "worker:7",
             &warned,
             policy.mode,
-            verdict.clone()
+            verdict.clone(),
+            test_metrics()
         )
         .is_ok());
 
@@ -1273,7 +1312,8 @@ mod tests {
             "worker:7",
             &warned,
             policy.mode,
-            different.clone()
+            different.clone(),
+            test_metrics()
         )
         .is_ok());
         assert_eq!(warned.get("worker:7").as_deref(), Some(&different));
@@ -1312,7 +1352,8 @@ mod tests {
             "worker:7",
             &warned,
             policy.mode,
-            verdict
+            verdict,
+            test_metrics()
         )
         .is_ok());
 
@@ -1323,7 +1364,8 @@ mod tests {
             "worker:7",
             &warned,
             policy.mode,
-            verdict
+            verdict,
+            test_metrics()
         )
         .is_ok());
     }
@@ -1348,6 +1390,7 @@ mod tests {
             &warned,
             policy.mode,
             verdict,
+            test_metrics(),
         )
         .unwrap_err();
         let msg = format!("{}", err);
@@ -1369,9 +1412,99 @@ mod tests {
             &warned,
             policy.mode,
             verdict,
+            test_metrics(),
         )
         .unwrap_err();
         assert!(format!("{}", err).contains("client rejected"));
+    }
+
+    #[test]
+    fn compatibility_metrics_record_verdicts_and_rejections() {
+        // Worker verdicts are recorded per peer in compat_worker_verdict and
+        // enforce-mode rejections bump compat_enforce_rejected_total.
+        let metrics = test_metrics();
+
+        let policy = CompatibilityPolicy {
+            mode: CompatibilityMode::Enforce,
+            min_worker_version: Some("0.2.0".parse().unwrap()),
+            ..Default::default()
+        };
+        let incompatible = ComponentInfoProto {
+            release_version: Some("0.1.0".to_string()),
+            protocol_version: Some(1),
+            ..sample_component_info()
+        };
+        let verdict = policy.check_worker(Some(&incompatible));
+        let warned = DashMap::new();
+
+        // A compatible worker records the compatible verdict.
+        MasterHandler::check_peer_compatibility(
+            "worker",
+            "worker:7",
+            &warned,
+            CompatibilityMode::Diagnose,
+            CompatibilityVerdict::Compatible,
+            metrics,
+        )
+        .unwrap();
+        assert_eq!(
+            metrics
+                .compat_worker_verdict
+                .with_label_values(&["7", "compatible"])
+                .get(),
+            1
+        );
+
+        // An enforce-mode rejection (too-old worker) bumps the counter and
+        // records the verdict gauge. A unique component label keeps this test
+        // isolated from other tests that also land in the version_too_old
+        // series (metrics are process-global and tests run in parallel).
+        let before = metrics
+            .compat_enforce_rejected_total
+            .with_label_values(&["worker-test", "version_too_old"])
+            .get();
+        let err = MasterHandler::check_peer_compatibility(
+            "worker-test",
+            "worker:8",
+            &warned,
+            policy.mode,
+            verdict,
+            metrics,
+        )
+        .unwrap_err();
+        assert!(format!("{}", err).contains("rejected by compatibility policy"));
+        assert_eq!(
+            metrics
+                .compat_enforce_rejected_total
+                .with_label_values(&["worker-test", "version_too_old"])
+                .get(),
+            before + 1
+        );
+        assert_eq!(
+            metrics
+                .compat_worker_verdict
+                .with_label_values(&["8", "version_too_old"])
+                .get(),
+            1
+        );
+
+        // Client verdicts use the client gauge.
+        MasterHandler::check_peer_compatibility(
+            "client",
+            "client:10.0.0.1",
+            &warned,
+            CompatibilityMode::Diagnose,
+            CompatibilityVerdict::MissingInfo,
+            metrics,
+        )
+        .unwrap();
+        assert_eq!(
+            metrics
+                .compat_client_verdict
+                .with_label_values(&["client:10.0.0.1", "missing_info"])
+                .get(),
+            1
+        );
     }
 
     #[test]
@@ -1403,5 +1536,11 @@ mod tests {
             min_protocol_version: Some(1),
             capabilities: vec!["transfer".to_string()],
         }
+    }
+
+    /// Shared metrics instance for compatibility metric tests.
+    fn test_metrics() -> &'static MasterMetrics {
+        Master::init_test_metrics();
+        Master::get_metrics().unwrap()
     }
 }

--- a/curvine-master/src/master/master_handler.rs
+++ b/curvine-master/src/master/master_handler.rs
@@ -648,20 +648,26 @@ impl MasterHandler {
         verdict: CompatibilityVerdict,
         metrics: &MasterMetrics,
     ) -> FsResult<()> {
-        // Record the compatibility verdict as a metric.
+        // Record the compatibility verdict as a metric. Only one verdict
+        // label per peer is active at a time, so set the current label to 1
+        // and clear every other label for the peer; otherwise a peer whose
+        // verdict changes over time leaves stale series stuck at 1.
         let verdict_label = Self::verdict_label(&verdict);
         let is_worker = dedup_key.starts_with("worker:");
-        if is_worker {
-            let worker_id = &dedup_key["worker:".len()..];
-            metrics
-                .compat_worker_verdict
-                .with_label_values(&[worker_id, verdict_label])
-                .set(1);
-        } else {
-            metrics
-                .compat_client_verdict
-                .with_label_values(&[dedup_key, verdict_label])
-                .set(1);
+        for label in Self::VERDICT_LABELS {
+            let active = if label == verdict_label { 1 } else { 0 };
+            if is_worker {
+                let worker_id = &dedup_key["worker:".len()..];
+                metrics
+                    .compat_worker_verdict
+                    .with_label_values(&[worker_id, label])
+                    .set(active);
+            } else {
+                metrics
+                    .compat_client_verdict
+                    .with_label_values(&[dedup_key, label])
+                    .set(active);
+            }
         }
 
         if !verdict.rejects(mode) {
@@ -695,6 +701,19 @@ impl MasterHandler {
             peer
         )
     }
+
+    /// All verdict label values for the compat_*_verdict gauge vectors, kept
+    /// in sync with [`Self::verdict_label`]. Only one label per peer is active
+    /// at a time: recording a verdict sets the current label to 1 and clears
+    /// every other label for that peer.
+    const VERDICT_LABELS: [&str; 6] = [
+        "compatible",
+        "missing_info",
+        "blocked",
+        "protocol_mismatch",
+        "version_too_old",
+        "version_unknown",
+    ];
 
     /// Short human-readable label for a compatibility verdict, used as a
     /// Prometheus label value in compat_*_verdict and compat_enforce_rejected_total.
@@ -1437,10 +1456,12 @@ mod tests {
         let verdict = policy.check_worker(Some(&incompatible));
         let warned = DashMap::new();
 
-        // A compatible worker records the compatible verdict.
+        // A compatible worker records the compatible verdict. Unique peer ids
+        // keep this test isolated: metrics are process-global and other tests
+        // also exercise worker:7 / worker:8 concurrently.
         MasterHandler::check_peer_compatibility(
             "worker",
-            "worker:7",
+            "worker:700",
             &warned,
             CompatibilityMode::Diagnose,
             CompatibilityVerdict::Compatible,
@@ -1450,9 +1471,38 @@ mod tests {
         assert_eq!(
             metrics
                 .compat_worker_verdict
-                .with_label_values(&["7", "compatible"])
+                .with_label_values(&["700", "compatible"])
                 .get(),
             1
+        );
+
+        // When a peer's verdict changes, the previous label must be cleared:
+        // only one label per peer is active at a time.
+        MasterHandler::check_peer_compatibility(
+            "worker",
+            "worker:700",
+            &warned,
+            CompatibilityMode::Diagnose,
+            CompatibilityVerdict::VersionTooOld {
+                peer: "0.1.0".to_string(),
+                min: "0.2.0".to_string(),
+            },
+            metrics,
+        )
+        .unwrap();
+        assert_eq!(
+            metrics
+                .compat_worker_verdict
+                .with_label_values(&["700", "version_too_old"])
+                .get(),
+            1
+        );
+        assert_eq!(
+            metrics
+                .compat_worker_verdict
+                .with_label_values(&["700", "compatible"])
+                .get(),
+            0
         );
 
         // An enforce-mode rejection (too-old worker) bumps the counter and
@@ -1465,7 +1515,7 @@ mod tests {
             .get();
         let err = MasterHandler::check_peer_compatibility(
             "worker-test",
-            "worker:8",
+            "worker:701",
             &warned,
             policy.mode,
             verdict,
@@ -1483,7 +1533,7 @@ mod tests {
         assert_eq!(
             metrics
                 .compat_worker_verdict
-                .with_label_values(&["8", "version_too_old"])
+                .with_label_values(&["701", "version_too_old"])
                 .get(),
             1
         );

--- a/curvine-master/src/master/master_metrics.rs
+++ b/curvine-master/src/master/master_metrics.rs
@@ -75,6 +75,15 @@ pub struct MasterMetrics {
     pub(crate) fs_dir_stalled: Gauge,
     pub(crate) fs_dir_stall_total: Counter,
     pub(crate) fs_dir_probe_acquire_us: Gauge,
+
+    // Compatibility metrics.
+    // Per-verdict gauge: 1 for the current verdict of each worker/client
+    // (compatible, missing_info, blocked, protocol_mismatch, version_too_old,
+    // version_unknown). Only one label per peer is active at a time.
+    pub(crate) compat_worker_verdict: GaugeVec,
+    pub(crate) compat_client_verdict: GaugeVec,
+    // Total number of enforce-mode rejections, labelled by component and verdict.
+    pub(crate) compat_enforce_rejected_total: CounterVec,
 }
 
 impl MasterMetrics {
@@ -184,6 +193,22 @@ impl MasterMetrics {
             fs_dir_probe_acquire_us: m::new_gauge(
                 "fs_dir_probe_acquire_us",
                 "Latency in microseconds of the last fs_dir watchdog read-lock probe",
+            )?,
+
+            compat_worker_verdict: m::new_gauge_vec(
+                "compat_worker_verdict",
+                "Current compatibility verdict per worker, labelled by worker_id and verdict",
+                &["worker_id", "verdict"],
+            )?,
+            compat_client_verdict: m::new_gauge_vec(
+                "compat_client_verdict",
+                "Current compatibility verdict per client, labelled by client_addr and verdict",
+                &["client_addr", "verdict"],
+            )?,
+            compat_enforce_rejected_total: m::new_counter_vec(
+                "compat_enforce_rejected_total",
+                "Total number of enforce-mode compatibility rejections, labelled by component and verdict",
+                &["component", "verdict"],
             )?,
         };
 


### PR DESCRIPTION
# Summary

Adds the observability companion for the compatibility checker and version
reporting introduced in the 0.4.x series: the master now exposes per-peer
compatibility verdicts and enforce-mode rejections as Prometheus metrics, and
the CLI can summarize the release-version distribution across live workers.

# Issue Describe / Design

Related to #1527 (component version management) — sub-task T12 deliverables:
compatibility matrix, CLI worker version statistics, observability metrics.

Design decisions:

- Metrics are recorded at the single point where compatibility verdicts are
  already evaluated (`MasterHandler::check_peer_compatibility`), so every
  worker heartbeat and client handshake is observable without touching each
  call site.
- Verdicts are exposed as `GaugeVec`s per peer (label set = peer id + verdict),
  so a mixed-version cluster shows exactly which peers are legacy or
  incompatible at a glance; `compat_enforce_rejected_total` counts rejections
  for alerting.
- The CLI version statistic prefers the structured `component_info` reported on
  heartbeat (T7+) and falls back to the legacy `software_version` string, so it
  works against both new and old workers.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-master/src/master/master_metrics.rs` | Add `compat_worker_verdict`, `compat_client_verdict` gauge vectors and `compat_enforce_rejected_total` counter vector | None (new metrics only) |
| `curvine-master/src/master/master_handler.rs` | Record verdicts and rejections in `check_peer_compatibility`; add `verdict_label` helper | None (diagnose/enforce behavior unchanged) |
| `curvine-cli/src/cmds/node.rs` | Add `cv node --versions` with `count_worker_versions` + unit tests | None (new command only) |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `make format` | PASS | clippy + fmt |
| `cargo test -p curvine-master --lib master_handler` | PASS | 8 tests incl. `compatibility_metrics_record_verdicts_and_rejections` |
| `cargo test -p curvine-cli` | PASS | 28 tests incl. 3 new `count_worker_versions` tests |
| `cargo check -p curvine-master -p curvine-cli` | PASS | |

# Dependencies

- Related PRs: None
- Related issues: #1527
- Blocks / blocked by: None