### PR TITLE
fix(fuse): prevent statfs signed capacity overflow (#1463)

### DIFF
--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -1584,6 +1584,13 @@ impl fs::FileSystem for CurvineFileSystem {
     async fn stat_fs(&self, _: StatFs<'_>) -> FuseResult<fuse_kstatfs> {
         let info = self.fs.get_filesystem_info().await?;
 
+        if info.capacity < 0 || info.available < 0 || info.available > info.capacity {
+            debug!(
+                "Normalizing invalid filesystem info for statfs: capacity={}, available={}",
+                info.capacity, info.available
+            );
+        }
+
         let (total_blocks, free_blocks) = Self::statfs_block_counts(info.capacity, info.available);
 
         let res = fuse_kstatfs {

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -49,6 +49,8 @@ use std::ffi::OsStr;
 use std::sync::Arc;
 
 const FUSE_TIME_GRANULARITY_NS: u32 = 1_000_000;
+/// Fragment size used by FUSE statfs block counters.
+const STATFS_FRAGMENT_SIZE: u32 = 4 * ByteUnit::KB as u32;
 
 pub struct CurvineFileSystem {
     fs: UnifiedFileSystem,
@@ -91,6 +93,15 @@ impl CurvineFileSystem {
     fn is_ofd_lock_pid(pid: u32) -> bool {
         // FUSE kernels have used both 0 and -1 for the pid of an OFD lock.
         pid == 0 || pid == u32::MAX
+    }
+
+    fn statfs_block_counts(capacity: i64, available: i64) -> (u64, u64) {
+        let capacity = u64::try_from(capacity).unwrap_or(0);
+        let available = u64::try_from(available).unwrap_or(0).min(capacity);
+        let fragment_size = u64::from(STATFS_FRAGMENT_SIZE);
+
+        // Report only complete fragments, preserving the existing rounding behavior.
+        (capacity / fragment_size, available / fragment_size)
     }
 
     pub fn new(conf: ClusterConf, rt: Arc<Runtime>) -> FuseResult<Self> {
@@ -1573,9 +1584,7 @@ impl fs::FileSystem for CurvineFileSystem {
     async fn stat_fs(&self, _: StatFs<'_>) -> FuseResult<fuse_kstatfs> {
         let info = self.fs.get_filesystem_info().await?;
 
-        let block_size = 4 * ByteUnit::KB as u32;
-        let total_blocks = (info.capacity / block_size as i64) as u64;
-        let free_blocks = (info.available / block_size as i64) as u64;
+        let (total_blocks, free_blocks) = Self::statfs_block_counts(info.capacity, info.available);
 
         let res = fuse_kstatfs {
             blocks: total_blocks,
@@ -1583,9 +1592,9 @@ impl fs::FileSystem for CurvineFileSystem {
             bavail: free_blocks,
             files: FUSE_UNKNOWN_INODES,
             ffree: FUSE_UNKNOWN_INODES,
-            bsize: block_size,
+            bsize: STATFS_FRAGMENT_SIZE,
             namelen: FUSE_MAX_NAME_LENGTH as u32,
-            frsize: block_size,
+            frsize: STATFS_FRAGMENT_SIZE,
             padding: 0,
             spare: [0; 6],
         };
@@ -2425,6 +2434,60 @@ mod tests {
             pid,
             padding: 0,
         }
+    }
+
+    #[test]
+    fn statfs_block_counts_normalize_invalid_values() {
+        use super::CurvineFileSystem;
+
+        let cases = [
+            (-4096, 0, (0, 0)),
+            (8192, -4096, (2, 0)),
+            (-4096, 8192, (0, 0)),
+            (4096, 8192, (1, 1)),
+        ];
+
+        for (capacity, available, expected) in cases {
+            let actual = CurvineFileSystem::statfs_block_counts(capacity, available);
+            assert_eq!(
+                actual, expected,
+                "capacity={capacity}, available={available}"
+            );
+            assert!(actual.1 <= actual.0);
+        }
+    }
+
+    #[test]
+    fn statfs_block_counts_round_down_to_complete_fragments() {
+        use super::CurvineFileSystem;
+
+        let cases = [
+            (0, 0, (0, 0)),
+            (1, 1, (0, 0)),
+            (4095, 4095, (0, 0)),
+            (4096, 4096, (1, 1)),
+            (4097, 4097, (1, 1)),
+            (16384, 8192, (4, 2)),
+        ];
+
+        for (capacity, available, expected) in cases {
+            assert_eq!(
+                CurvineFileSystem::statfs_block_counts(capacity, available),
+                expected,
+                "capacity={capacity}, available={available}"
+            );
+        }
+    }
+
+    #[test]
+    fn statfs_block_counts_handle_i64_max_without_overflow() {
+        use super::{CurvineFileSystem, STATFS_FRAGMENT_SIZE};
+
+        let expected = u64::try_from(i64::MAX).unwrap() / u64::from(STATFS_FRAGMENT_SIZE);
+        let actual = CurvineFileSystem::statfs_block_counts(i64::MAX, i64::MAX);
+
+        assert_eq!(actual, (expected, expected));
+        assert!(actual.1 <= actual.0);
     }
 
     #[test]


### PR DESCRIPTION
# Summary

Prevent FUSE `statfs` from wrapping invalid signed capacity values into huge unsigned block counts. The change also guarantees that reported available/free blocks never exceed total blocks while preserving the existing 4 KiB round-down behavior.

# Issue Describe / Design

Closes #1463

## Root cause

`MasterInfo.capacity` and `MasterInfo.available` are signed `i64` byte counts, but `fuse_kstatfs` stores block counts as `u64`. The previous implementation divided the signed values and then used unchecked `as u64` casts. Negative values therefore wrapped to very large positive block counts, and an inconsistent `available > capacity` response could produce `bavail`/`bfree` greater than `blocks`.

## Reproduction

- `capacity = -4096` produced `(-1_i64) as u64`, a value near `u64::MAX`.
- `capacity = 4096`, `available = 8192` reported more free blocks than total blocks.

## Fix approach

- Define the 4 KiB statfs fragment size as an explicit constant.
- Convert signed values with checked `u64::try_from`, mapping invalid negative inputs to zero.
- Clamp available bytes to validated total capacity before converting to block counts.
- Keep the previous behavior of reporting only complete 4 KiB fragments.
- Emit a conditional `debug!` log with the raw values when invalid master-side filesystem information is normalized.
- Add focused tests for negative, zero, inconsistent, sub-fragment, normal, and `i64::MAX` inputs.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-fuse/src/fs/curvine_file_system.rs` | Add validated statfs block conversion, boundary tests, and conditional diagnostics for normalized values | Valid non-negative inputs retain existing round-down behavior; invalid inputs are normalized conservatively, logged at debug level, and block-count invariants are enforced |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `make format` | PASS | Linux container |
| `cargo clippy -p curvine-fuse --lib --tests -- --deny warnings --allow clippy::uninlined-format-args` | PASS | `node4` |
| `cargo fmt --check` + `cargo test -p curvine-fuse statfs_block_counts --lib` | PASS | `node3`; 3 passed |
| `cargo fmt --check` + `cargo test -p curvine-fuse statfs_block_counts --lib` | PASS | `node4`; 3 passed |
| `cargo fmt --check` + `cargo test -p curvine-fuse statfs_block_counts --lib` | PASS | `node5`; 3 passed |
| `cargo test -p curvine-fuse --lib` | BASELINE FAILURE | Both this branch and unmodified `github/main` reproduce the same unrelated parallel metrics assertion in `local_writer_task_body_observes_io_with_local_path_type`; the test passes when run alone |

# Dependencies

- Related PRs: None
- Related issues: #1463
- Blocks / blocked by: None

