### PR TITLE
fix(raft): accept contiguous snapshots during recovery (#1601)

### DIFF
--- a/crates/metadata/curvine-raft/src/raft/storage/rocks_storage_core.rs
+++ b/crates/metadata/curvine-raft/src/raft/storage/rocks_storage_core.rs
@@ -223,12 +223,14 @@ impl RocksStorageCore {
         let meta = snapshot.get_metadata();
         let index = meta.index;
 
-        // Index is 0, indicating that there is no snapshot, but there may be log entry.
-        if index > LOG_START_INDEX && self.first_index() > index {
+        // A snapshot at first_index - 1 is contiguous with the retained log and
+        // is the normal state after compacting through the snapshot index. Only
+        // reject snapshots that leave a gap before the first retained entry.
+        let first_index = self.first_index();
+        if index > LOG_START_INDEX && first_index > index.saturating_add(1) {
             warn!(
                 "snapshot out of date: snapshot_index={}, first_index={}, skip apply",
-                index,
-                self.first_index()
+                index, first_index
             );
             return err_ext!(RaftError::raft(raft::Error::Store(
                 raft::StorageError::SnapshotOutOfDate

--- a/crates/metadata/curvine-raft/tests/rocks_storage_recovery_test.rs
+++ b/crates/metadata/curvine-raft/tests/rocks_storage_recovery_test.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use curvine_core_error::CommonResult;
-use curvine_raft::raft::storage::RocksStorageCore;
+use curvine_raft::raft::{storage::RocksStorageCore, RaftError};
 use curvine_raft::rocksdb::{DBConf, DBEngine, RocksUtils};
 use curvine_runtime::common::{FileUtils, Utils};
 use prost::Message;
@@ -41,6 +41,25 @@ fn assert_reseed_required(error: impl ToString, commit: u64, lower: u64, upper: 
         message.contains("Restore a consistent master meta+journal pair from a healthy voter"),
         "missing operator hint in error: {message}"
     );
+}
+
+fn persist_snapshot(conf: &DBConf, index: u64) {
+    let mut snapshot = Snapshot::default();
+    snapshot.mut_metadata().index = index;
+    snapshot.mut_metadata().term = 7;
+    let db = DBEngine::new(
+        conf.clone()
+            .add_cf(RocksStorageCore::CF_ENTRIES)
+            .add_cf(RocksStorageCore::CF_META),
+        false,
+    )
+    .unwrap();
+    db.put_cf(
+        RocksStorageCore::CF_META,
+        RocksStorageCore::SNAP_KEY,
+        snapshot.encode_to_vec(),
+    )
+    .unwrap();
 }
 
 #[test]
@@ -176,6 +195,60 @@ fn snapshot_install_compacts_the_durable_log_range() {
     assert_eq!(storage.init_state().unwrap().hard_state.commit, 3);
     assert_eq!(storage.first_index(), 4);
     assert_eq!(storage.last_index(), 3);
+}
+
+#[test]
+fn restart_accepts_snapshot_adjacent_to_first_retained_log() {
+    let conf = test_conf("snapshot-adjacent");
+    FileUtils::delete_path(&conf.base_dir, true).unwrap();
+
+    {
+        let mut storage = RocksStorageCore::new(conf.clone(), true);
+        let entries: Vec<_> = (1..=3)
+            .map(|index| Entry {
+                term: 7,
+                index,
+                ..Default::default()
+            })
+            .collect();
+        storage.append(&entries).unwrap();
+        storage.compact(3).unwrap();
+    }
+
+    persist_snapshot(&conf, 2);
+
+    let mut storage = RocksStorageCore::new(conf, false);
+    let persisted_snapshot = storage.last_snapshot().unwrap();
+    storage.apply_snapshot(persisted_snapshot).unwrap();
+    assert_eq!(storage.first_index(), 3);
+    assert_eq!(storage.last_index(), 3);
+}
+
+#[test]
+fn snapshot_with_gap_before_first_retained_log_is_rejected() {
+    let conf = test_conf("snapshot-gap");
+    FileUtils::delete_path(&conf.base_dir, true).unwrap();
+
+    {
+        let mut storage = RocksStorageCore::new(conf.clone(), true);
+        let entries: Vec<_> = (1..=4)
+            .map(|index| Entry {
+                term: 7,
+                index,
+                ..Default::default()
+            })
+            .collect();
+        storage.append(&entries).unwrap();
+        storage.compact(4).unwrap();
+    }
+
+    persist_snapshot(&conf, 2);
+
+    let mut storage = RocksStorageCore::new(conf, false);
+    let error: RaftError = storage
+        .apply_snapshot(storage.last_snapshot().unwrap())
+        .unwrap_err();
+    assert!(error.is_snapshot_out_of_date(), "unexpected error: {error}");
 }
 
 #[test]


### PR DESCRIPTION
# Summary
Fix the Raft follower restart failure reported in #1601 by accepting a persisted snapshot that is immediately followed by the first retained WAL entry.

# Issue Describe / Design
Closes #1601

Root cause: `RocksStorageCore::apply_snapshot` treated every `first_index > snapshot_index` relationship as `SnapshotOutOfDate`. The normal compacted state is `first_index = snapshot_index + 1`, so followers rejected a valid persisted snapshot during restart and could not rejoin the cluster.

Reproduction: persist snapshot index 2 with first retained log index 3, reopen the Rocks storage, and apply the persisted snapshot. The pre-fix code returned `SnapshotOutOfDate`.

Fix: reject only when `first_index > snapshot_index + 1`, which preserves protection against a real gap while allowing the valid contiguous boundary.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `crates/metadata/curvine-raft/src/raft/storage/rocks_storage_core.rs` | Correct the snapshot/WAL boundary validation | Valid contiguous snapshots are restored; real gaps remain rejected |
| `crates/metadata/curvine-raft/tests/rocks_storage_recovery_test.rs` | Add contiguous-recovery and gap-rejection regression tests | Test-only coverage |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-raft --test rocks_storage_recovery_test` | PASS | 8 tests |
| `cargo test -p curvine-raft` | PASS | 19 tests across 5 suites |
| `cargo test -p curvine-server --test journal_test` | PASS | 9 tests |
| `cargo clippy -p curvine-raft --tests -- -D warnings` | PASS | No warnings |
| `cargo fmt --all -- --check` | PASS | |

# Dependencies

- Related PRs: None
- Related issues: #1601
- Blocks / blocked by: None