### PR TITLE
feat(spdk): introduce spdk qpair observability metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2699,6 +2699,7 @@ dependencies = [
  "crossbeam",
  "curvine-core-error",
  "curvine-io",
+ "curvine-metrics",
  "curvine-runtime",
  "libc",
  "log",

--- a/crates/adapters/curvine-storage-spdk/Cargo.toml
+++ b/crates/adapters/curvine-storage-spdk/Cargo.toml
@@ -12,6 +12,7 @@ spdk-rdma = ["spdk"]
 
 [dependencies]
 curvine-core-error = { workspace = true }
+curvine-metrics = { workspace = true }
 curvine-runtime = { workspace = true }
 curvine-io = { workspace = true }
 bytes = { workspace = true }

--- a/crates/adapters/curvine-storage-spdk/src/lib.rs
+++ b/crates/adapters/curvine-storage-spdk/src/lib.rs
@@ -21,6 +21,8 @@ pub mod spdk_env;
 #[cfg(feature = "spdk")]
 pub mod spdk_ffi;
 #[cfg(feature = "spdk")]
+mod spdk_metrics;
+#[cfg(feature = "spdk")]
 pub mod spdk_poller;
 
 #[cfg(all(test, feature = "spdk"))]

--- a/crates/adapters/curvine-storage-spdk/src/spdk_bdev_test.rs
+++ b/crates/adapters/curvine-storage-spdk/src/spdk_bdev_test.rs
@@ -11,6 +11,7 @@ use std::sync::{atomic::AtomicBool, Arc, Condvar, Mutex};
 use std::thread;
 use std::time::Duration;
 static INIT: Once = Once::new();
+use std::sync::atomic::AtomicUsize;
 
 /// Initialize SPDK env once for all tests.
 fn get_spdk_env() -> &'static SpdkEnv {
@@ -200,6 +201,9 @@ fn spdk_full_lifecycle() {
         let p = QpairPool {
             inner: Mutex::new(HashMap::new()),
             ctrl_state: Mutex::new(HashMap::new()),
+            total_active: AtomicUsize::new(0),
+            total_limit: AtomicUsize::new(0),
+            total_cached: AtomicUsize::new(0),
             notify: Condvar::new(),
             max_per_ctrlr: 2,
             shutdown: AtomicBool::new(false),
@@ -239,6 +243,9 @@ fn spdk_full_lifecycle() {
         let p = Arc::new(QpairPool {
             inner: Mutex::new(HashMap::new()),
             ctrl_state: Mutex::new(HashMap::new()),
+            total_active: AtomicUsize::new(0),
+            total_limit: AtomicUsize::new(0),
+            total_cached: AtomicUsize::new(0),
             notify: Condvar::new(),
             max_per_ctrlr: 16,
             shutdown: AtomicBool::new(false),

--- a/crates/adapters/curvine-storage-spdk/src/spdk_env.rs
+++ b/crates/adapters/curvine-storage-spdk/src/spdk_env.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "spdk")]
 
 use crate::spdk_ffi;
+use crate::spdk_metrics;
 use crate::spdk_poller::{CtrlHandle, PollerConfig};
 use crate::spdk_poller::{IoRequest, SpdkPoller};
 use curvine_core_error::{err_box, err_msg, CommonResult};
@@ -39,6 +40,12 @@ pub struct QpairPool {
     pub(crate) inner: Mutex<HashMap<usize, Vec<*mut spdk_ffi::spdk_nvme_qpair>>>,
     /// Per-controller active count and max limit, keyed by controller pointer.
     pub(crate) ctrl_state: Mutex<HashMap<usize, CtrlQpairState>>,
+    /// Aggregate active qpair reservations across controllers.
+    pub(crate) total_active: AtomicUsize,
+    /// Aggregate qpair reservation limit across controllers.
+    pub(crate) total_limit: AtomicUsize,
+    /// Aggregate cached idle qpairs across controllers.
+    pub(crate) total_cached: AtomicUsize,
     /// Idle cache limit per controller (soft — excess freed on release).
     pub(crate) max_per_ctrlr: usize,
     /// Wakes blocked acquirers when a qpair is released.
@@ -54,6 +61,9 @@ unsafe impl Sync for QpairPool {}
 impl QpairPool {
     /// Default max idle qpairs per controller (soft cache limit).
     const DEFAULT_MAX_PER_CTRLR: usize = 16;
+    /// Minimum qpair acquire wait recorded in the histogram. Tiny waits are skipped
+    /// to keep observability overhead low on the qpair contention path.
+    const QPAIR_WAIT_METRIC_MIN: Duration = Duration::from_micros(100);
     /// Default qpair acquire timeout, used when SpdkConf does not set `qpair_acquire_timeout`.
     #[cfg(test)]
     const DEFAULT_QPAIR_ACQUIRE_TIMEOUT: Duration = Duration::from_secs(30);
@@ -67,6 +77,9 @@ impl QpairPool {
         Self {
             inner: Mutex::new(HashMap::new()),
             ctrl_state: Mutex::new(HashMap::new()),
+            total_active: AtomicUsize::new(0),
+            total_limit: AtomicUsize::new(0),
+            total_cached: AtomicUsize::new(0),
             max_per_ctrlr: Self::DEFAULT_MAX_PER_CTRLR,
             notify: Condvar::new(),
             shutdown: AtomicBool::new(false),
@@ -85,6 +98,8 @@ impl QpairPool {
             ctrlr_ptr as *const ()
         );
         state.insert(ctrlr_ptr, CtrlQpairState::new(limit));
+        let total_limit = self.total_limit.fetch_add(limit, Ordering::AcqRel) + limit;
+        spdk_metrics::set_qpair_limit(total_limit);
         if limit == 0 {
             warn!(
                 "QpairPool: ctrlr {:p} registered with max_active=0 (0 negotiated IO queues)",
@@ -95,6 +110,12 @@ impl QpairPool {
                 "QpairPool: registered ctrlr {:p} with max_active={}",
                 ctrlr_ptr as *const (), limit
             );
+        }
+    }
+
+    fn record_qpair_wait_if_needed(wait: Duration) {
+        if wait >= Self::QPAIR_WAIT_METRIC_MIN {
+            spdk_metrics::record_qpair_wait(wait);
         }
     }
 
@@ -123,6 +144,7 @@ impl QpairPool {
                     .compare_exchange_weak(cur, cur + 1, Ordering::AcqRel, Ordering::Relaxed)
                     .is_ok()
                 {
+                    self.total_active.fetch_add(1, Ordering::AcqRel);
                     return true;
                 }
             }
@@ -150,6 +172,7 @@ impl QpairPool {
                 return;
             }
             s.active.fetch_sub(1, Ordering::AcqRel);
+            self.total_active.fetch_sub(1, Ordering::AcqRel);
         } else {
             warn!(
                 "QpairPool: release_reservation for unregistered ctrlr {:p} \
@@ -172,24 +195,31 @@ impl QpairPool {
             reserved = true;
             if self.shutdown.load(Ordering::Acquire) {
                 self.release_reservation(key);
+                spdk_metrics::record_qpair_acquire("shutdown");
                 return err_box!(
                     "QpairPool: shutdown in progress, acquire rejected for ctrlr {:p}",
                     ctrlr
                 );
             }
             let mut pool = self.inner.lock().unwrap_or_else(|p| p.into_inner());
-            if let Some(stack) = pool.get_mut(&key) {
-                if let Some(qpair) = stack.pop() {
-                    log::trace!(
-                        "QpairPool: reusing cached qpair for ctrlr {:p} (pool size now {})",
-                        ctrlr,
-                        stack.len()
-                    );
-                    return Ok(qpair);
-                }
+            let cached = pool.get_mut(&key).and_then(|stack| {
+                let qpair = stack.pop()?;
+                self.total_cached.fetch_sub(1, Ordering::AcqRel);
+                Some((qpair, stack.len()))
+            });
+            if let Some((qpair, stack_len)) = cached {
+                drop(pool);
+                spdk_metrics::record_qpair_acquire("cached");
+                log::trace!(
+                    "QpairPool: reusing cached qpair for ctrlr {:p} (pool size now {})",
+                    ctrlr,
+                    stack_len
+                );
+                return Ok(qpair);
             }
             // No cached qpair - fall through to slow path with slot already reserved
         } else {
+            spdk_metrics::record_qpair_contention();
             log::trace!(
                 "QpairPool: fast path blocked for ctrlr {:p} (at capacity)",
                 ctrlr,
@@ -198,6 +228,7 @@ impl QpairPool {
 
         // Slow path: block if at this controller's capacity, then allocate
         let deadline = Instant::now() + self.qpair_acquire_timeout;
+        let mut total_wait = Duration::ZERO;
         let mut pool = self.inner.lock().unwrap_or_else(|p| p.into_inner());
         loop {
             // CAS reserve before pool check — active must increment before returning cached qpair.
@@ -209,14 +240,20 @@ impl QpairPool {
 
             if reserved {
                 // Slot reserved - check pool for a cached qpair to reuse
-                if let Some(stack) = pool.get_mut(&key) {
-                    if let Some(qpair) = stack.pop() {
-                        log::trace!(
-                            "QpairPool: reusing cached qpair for ctrlr {:p} after wait",
-                            ctrlr,
-                        );
-                        return Ok(qpair);
-                    }
+                let cached = pool.get_mut(&key).and_then(|stack| {
+                    let qpair = stack.pop()?;
+                    self.total_cached.fetch_sub(1, Ordering::AcqRel);
+                    Some(qpair)
+                });
+                if let Some(qpair) = cached {
+                    drop(pool);
+                    Self::record_qpair_wait_if_needed(total_wait);
+                    spdk_metrics::record_qpair_acquire("cached");
+                    log::trace!(
+                        "QpairPool: reusing cached qpair for ctrlr {:p} after wait",
+                        ctrlr,
+                    );
+                    return Ok(qpair);
                 }
                 // No cached qpair - break out and allocate a new one via FFI
                 break;
@@ -224,6 +261,9 @@ impl QpairPool {
 
             // at this controller's capacity - wait for a release
             if self.shutdown.load(Ordering::Acquire) {
+                drop(pool);
+                Self::record_qpair_wait_if_needed(total_wait);
+                spdk_metrics::record_qpair_acquire("shutdown");
                 return err_box!(
                     "QpairPool: shutdown in progress, acquire rejected for ctrlr {:p}",
                     ctrlr
@@ -231,6 +271,9 @@ impl QpairPool {
             }
             let now = Instant::now();
             if now >= deadline {
+                drop(pool);
+                Self::record_qpair_wait_if_needed(total_wait);
+                spdk_metrics::record_qpair_acquire("timeout");
                 return err_box!(
                     "QpairPool: timeout after {:?} waiting for qpair on ctrlr {:p} \
                      This indicates qpair exhaustion under high concurrency. \
@@ -241,18 +284,22 @@ impl QpairPool {
             }
             let remaining = deadline.duration_since(now);
             log::trace!("QpairPool: ctrlr {:p} at capacity, waiting...", ctrlr,);
+            let wait_start = Instant::now();
             pool = self
                 .notify
                 .wait_timeout(pool, remaining)
                 .unwrap_or_else(|p| p.into_inner())
                 .0;
+            total_wait += wait_start.elapsed();
             // TODO: check shutdown here to avoid a full qpair_acquire_timeout delay if notify_all() was missed
         }
 
         // Slot reserved (by fast path or slow path) - allocate the qpair
         drop(pool);
+        Self::record_qpair_wait_if_needed(total_wait);
         if self.shutdown.load(Ordering::Acquire) {
             self.release_reservation(key);
+            spdk_metrics::record_qpair_acquire("shutdown");
             return err_box!(
                 "QpairPool: shutdown in progress, acquire rejected for ctrlr {:p}",
                 ctrlr
@@ -262,6 +309,7 @@ impl QpairPool {
         if qpair.is_null() {
             self.release_reservation(key);
             self.notify.notify_one();
+            spdk_metrics::record_qpair_acquire("alloc_failed");
             return err_box!(
                 "QpairPool: failed to allocate I/O qpair for ctrlr {:p}. \
                  This may indicate qpair exhaustion under high concurrency. \
@@ -270,6 +318,7 @@ impl QpairPool {
             );
         }
         log::trace!("QpairPool: allocated new qpair for ctrlr {:p}", ctrlr);
+        spdk_metrics::record_qpair_acquire("allocated");
         Ok(qpair)
     }
     /// Return qpair to pool for reuse.
@@ -280,7 +329,7 @@ impl QpairPool {
         qpair: *mut spdk_ffi::spdk_nvme_qpair,
     ) {
         let key = ctrlr as usize;
-        {
+        let release_result = {
             let mut pool = self.inner.lock().unwrap_or_else(|p| p.into_inner());
             let stack = pool.entry(key).or_default();
             if stack.len() >= self.max_per_ctrlr {
@@ -292,16 +341,21 @@ impl QpairPool {
                     ctrlr,
                     self.max_per_ctrlr
                 );
+                "freed_pool_full"
             } else {
                 stack.push(qpair);
+                self.total_cached.fetch_add(1, Ordering::AcqRel);
+                let stack_len = stack.len();
                 log::trace!(
                     "QpairPool: returned qpair to pool for ctrlr {:p} ({}/{})",
                     ctrlr,
-                    stack.len(),
+                    stack_len,
                     self.max_per_ctrlr
                 );
+                "cached"
             }
-        } // inner lock dropped here
+        }; // inner lock dropped here
+        spdk_metrics::record_qpair_release(release_result);
         self.release_reservation(key);
         self.notify.notify_one(); // safe to call without holding inner lock
     }
@@ -309,6 +363,7 @@ impl QpairPool {
     /// qpairs are tracked by their owners and will be released normally.
     pub(crate) fn drain_all(&self) {
         self.shutdown.store(true, Ordering::Release);
+        spdk_metrics::record_qpair_shutdown();
         let mut pool = self.inner.lock().unwrap_or_else(|p| p.into_inner());
         let mut total = 0usize;
         for (_ctrlr_key, qpairs) in pool.drain() {
@@ -320,6 +375,8 @@ impl QpairPool {
         if total > 0 {
             info!("QpairPool: freed {} cached qpair(s) during shutdown", total);
         }
+        self.total_cached.store(0, Ordering::Release);
+        spdk_metrics::set_qpair_cached(0);
         // Warn if there are still active (in-flight) qpairs - these are not freed here,
         // they are tracked by their SpdkBdev owners and will be released via drop().
         for state in self
@@ -338,6 +395,14 @@ impl QpairPool {
             }
         }
         self.notify.notify_all();
+    }
+
+    pub(crate) fn publish_metrics(&self) {
+        // TODO: Add per-controller saturation and wait metrics once controllers have
+        // stable, bounded-cardinality labels; keep the current metrics aggregate.
+        spdk_metrics::set_qpair_active(self.total_active.load(Ordering::Acquire));
+        spdk_metrics::set_qpair_cached(self.total_cached.load(Ordering::Acquire));
+        spdk_metrics::set_qpair_limit(self.total_limit.load(Ordering::Acquire));
     }
 }
 // Global singleton
@@ -704,6 +769,11 @@ impl SpdkEnv {
         self.conf.targets.len()
     }
 
+    /// Publish SPDK gauges derived from internal atomics before metrics are scraped.
+    pub fn publish_metrics(&self) {
+        self.qpair_pool.publish_metrics();
+    }
+
     /// Names of all discovered bdevs.
     pub fn bdev_names(&self) -> Vec<String> {
         self.bdevs.iter().map(|b| b.name.clone()).collect()
@@ -1048,14 +1118,20 @@ mod test {
             .entry(key)
             .or_default()
             .push(fake(key));
+        pool.total_cached.fetch_add(1, Ordering::AcqRel);
     }
     fn pop(pool: &QpairPool, key: usize) -> bool {
-        pool.inner
+        let popped = pool
+            .inner
             .lock()
             .unwrap()
             .get_mut(&key)
             .and_then(|v| v.pop())
-            .is_some()
+            .is_some();
+        if popped {
+            pool.total_cached.fetch_sub(1, Ordering::AcqRel);
+        }
+        popped
     }
     fn cnt(pool: &QpairPool, key: usize) -> usize {
         pool.inner.lock().unwrap().get(&key).map_or(0, |v| v.len())
@@ -1342,6 +1418,31 @@ mod test {
         // timed-out acquire never reserved, so it must not over-release.
         let (active, _) = p.controller_stats(ctrlr as usize);
         assert_eq!(active, 1);
+    }
+
+    #[test]
+    fn qpair_metrics_are_exported() {
+        let p = QpairPool::with_qpair_acquire_timeout(Duration::from_millis(10));
+        let ctrlr = 0x1000usize as *mut spdk_ffi::spdk_nvme_ctrlr;
+        p.register_limit(ctrlr as usize, 1);
+
+        assert!(p.try_reserve(ctrlr as usize));
+
+        let result = p.acquire(ctrlr);
+        assert!(result.is_err());
+
+        p.drain_all();
+        p.publish_metrics();
+
+        let output = curvine_metrics::Metrics::text_output().unwrap();
+        assert!(output.contains("spdk_qpair_acquire_total"));
+        assert!(output.contains("result=\"timeout\""));
+        assert!(output.contains("spdk_qpair_acquire_wait_us_bucket"));
+        assert!(output.contains("spdk_qpair_contention_total"));
+        assert!(output.contains("spdk_qpair_active"));
+        assert!(output.contains("spdk_qpair_limit"));
+        assert!(output.contains("spdk_qpair_cached"));
+        assert!(output.contains("spdk_qpair_shutdown_total"));
     }
 
     #[test]

--- a/crates/adapters/curvine-storage-spdk/src/spdk_env.rs
+++ b/crates/adapters/curvine-storage-spdk/src/spdk_env.rs
@@ -1492,13 +1492,12 @@ mod test {
         p.publish_metrics();
 
         let output = curvine_metrics::Metrics::text_output().unwrap();
-        assert!(output.contains("spdk_qpair_acquire_total"));
-        assert!(output.contains("result=\"timeout\""));
+        assert!(output.contains("spdk_qpair_acquire_total{result=\"timeout\"}"));
         assert!(output.contains("spdk_qpair_acquire_wait_us_bucket"));
         assert!(output.contains("spdk_qpair_contention_total"));
-        assert!(output.contains("spdk_qpair_active"));
-        assert!(output.contains("spdk_qpair_limit"));
-        assert!(output.contains("spdk_qpair_cached"));
+        assert!(output.contains("spdk_qpair_active 1"));
+        assert!(output.contains("spdk_qpair_limit 1"));
+        assert!(output.contains("spdk_qpair_cached 0"));
         assert!(output.contains("spdk_qpair_shutdown_total"));
     }
 

--- a/crates/adapters/curvine-storage-spdk/src/spdk_env.rs
+++ b/crates/adapters/curvine-storage-spdk/src/spdk_env.rs
@@ -36,6 +36,13 @@ impl CtrlQpairState {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum QpairReserveResult {
+    Reserved,
+    AtCapacity,
+    Unregistered,
+}
+
 pub struct QpairPool {
     pub(crate) inner: Mutex<HashMap<usize, Vec<*mut spdk_ffi::spdk_nvme_qpair>>>,
     /// Per-controller active count and max limit, keyed by controller pointer.
@@ -131,21 +138,20 @@ impl QpairPool {
 
     // TODO: Arc<CtrlQpairState> + #[repr(align(64))] - eliminate ctrl_state Mutex from CAS, prevent false sharing
     /// Atomically reserve a slot for this controller.
-    /// Returns true if reserved (active < max_active), false at capacity.
-    pub(crate) fn try_reserve(&self, ctrlr_ptr: usize) -> bool {
+    pub(crate) fn try_reserve(&self, ctrlr_ptr: usize) -> QpairReserveResult {
         let state = self.ctrl_state.lock().unwrap_or_else(|p| p.into_inner());
         if let Some(s) = state.get(&ctrlr_ptr) {
             loop {
                 let cur = s.active.load(Ordering::Acquire);
                 if cur >= s.max_active {
-                    return false;
+                    return QpairReserveResult::AtCapacity;
                 }
                 if s.active
                     .compare_exchange_weak(cur, cur + 1, Ordering::AcqRel, Ordering::Relaxed)
                     .is_ok()
                 {
                     self.total_active.fetch_add(1, Ordering::AcqRel);
-                    return true;
+                    return QpairReserveResult::Reserved;
                 }
             }
         } else {
@@ -153,7 +159,7 @@ impl QpairPool {
                 "QpairPool: try_reserve called for unregistered ctrlr {:p}",
                 ctrlr_ptr as *const ()
             );
-            false
+            QpairReserveResult::Unregistered
         }
     }
 
@@ -191,39 +197,48 @@ impl QpairPool {
         let mut reserved = false;
 
         // Fast path: check capacity, then try pool without blocking
-        if self.try_reserve(key) {
-            reserved = true;
-            if self.shutdown.load(Ordering::Acquire) {
-                self.release_reservation(key);
-                spdk_metrics::record_qpair_acquire("shutdown");
+        match self.try_reserve(key) {
+            QpairReserveResult::Reserved => {
+                reserved = true;
+                if self.shutdown.load(Ordering::Acquire) {
+                    self.release_reservation(key);
+                    spdk_metrics::record_qpair_acquire("shutdown");
+                    return err_box!(
+                        "QpairPool: shutdown in progress, acquire rejected for ctrlr {:p}",
+                        ctrlr
+                    );
+                }
+                let mut pool = self.inner.lock().unwrap_or_else(|p| p.into_inner());
+                let cached = pool.get_mut(&key).and_then(|stack| {
+                    let qpair = stack.pop()?;
+                    self.total_cached.fetch_sub(1, Ordering::AcqRel);
+                    Some((qpair, stack.len()))
+                });
+                if let Some((qpair, stack_len)) = cached {
+                    drop(pool);
+                    spdk_metrics::record_qpair_acquire("cached");
+                    log::trace!(
+                        "QpairPool: reusing cached qpair for ctrlr {:p} (pool size now {})",
+                        ctrlr,
+                        stack_len
+                    );
+                    return Ok(qpair);
+                }
+                // No cached qpair - fall through to slow path with slot already reserved
+            }
+            QpairReserveResult::AtCapacity => {
+                spdk_metrics::record_qpair_contention();
+                log::trace!(
+                    "QpairPool: fast path blocked for ctrlr {:p} (at capacity)",
+                    ctrlr,
+                );
+            }
+            QpairReserveResult::Unregistered => {
                 return err_box!(
-                    "QpairPool: shutdown in progress, acquire rejected for ctrlr {:p}",
+                    "QpairPool: acquire called for unregistered ctrlr {:p}",
                     ctrlr
                 );
             }
-            let mut pool = self.inner.lock().unwrap_or_else(|p| p.into_inner());
-            let cached = pool.get_mut(&key).and_then(|stack| {
-                let qpair = stack.pop()?;
-                self.total_cached.fetch_sub(1, Ordering::AcqRel);
-                Some((qpair, stack.len()))
-            });
-            if let Some((qpair, stack_len)) = cached {
-                drop(pool);
-                spdk_metrics::record_qpair_acquire("cached");
-                log::trace!(
-                    "QpairPool: reusing cached qpair for ctrlr {:p} (pool size now {})",
-                    ctrlr,
-                    stack_len
-                );
-                return Ok(qpair);
-            }
-            // No cached qpair - fall through to slow path with slot already reserved
-        } else {
-            spdk_metrics::record_qpair_contention();
-            log::trace!(
-                "QpairPool: fast path blocked for ctrlr {:p} (at capacity)",
-                ctrlr,
-            );
         }
 
         // Slow path: block if at this controller's capacity, then allocate
@@ -233,8 +248,17 @@ impl QpairPool {
         loop {
             // CAS reserve before pool check — active must increment before returning cached qpair.
             if !reserved {
-                if self.try_reserve(key) {
-                    reserved = true;
+                match self.try_reserve(key) {
+                    QpairReserveResult::Reserved => reserved = true,
+                    QpairReserveResult::AtCapacity => {}
+                    QpairReserveResult::Unregistered => {
+                        drop(pool);
+                        Self::record_qpair_wait_if_needed(total_wait);
+                        return err_box!(
+                            "QpairPool: acquire called for unregistered ctrlr {:p}",
+                            ctrlr
+                        );
+                    }
                 }
             }
 
@@ -360,10 +384,12 @@ impl QpairPool {
         self.notify.notify_one(); // safe to call without holding inner lock
     }
     /// Free all pooled qpairs. Only frees cached (idle) qpairs - active/in-flight
-    /// qpairs are tracked by their owners and will be released normally.
+    /// qpairs are tracked by their owners and will be released normally. Repeated
+    /// calls still drain late releases, but only the first shutdown transition is counted.
     pub(crate) fn drain_all(&self) {
-        self.shutdown.store(true, Ordering::Release);
-        spdk_metrics::record_qpair_shutdown();
+        if !self.shutdown.swap(true, Ordering::AcqRel) {
+            spdk_metrics::record_qpair_shutdown();
+        }
         let mut pool = self.inner.lock().unwrap_or_else(|p| p.into_inner());
         let mut total = 0usize;
         for (_ctrlr_key, qpairs) in pool.drain() {
@@ -1223,17 +1249,22 @@ mod test {
         p.register_limit(ctrlr as usize, 2);
 
         // Reserve up to limit
-        assert!(p.try_reserve(ctrlr as usize));
-        assert!(p.try_reserve(ctrlr as usize));
+        assert_eq!(p.try_reserve(ctrlr as usize), QpairReserveResult::Reserved);
+        assert_eq!(p.try_reserve(ctrlr as usize), QpairReserveResult::Reserved);
         let (active, _) = p.controller_stats(ctrlr as usize);
         assert_eq!(active, 2);
 
         // At limit — should fail
-        assert!(!p.try_reserve(ctrlr as usize));
+        assert_eq!(
+            p.try_reserve(ctrlr as usize),
+            QpairReserveResult::AtCapacity
+        );
 
         // Release one — should succeed again
         p.release_reservation(ctrlr as usize);
-        assert!(p.try_reserve(ctrlr as usize));
+        assert_eq!(p.try_reserve(ctrlr as usize), QpairReserveResult::Reserved);
+
+        assert_eq!(p.try_reserve(0x2000), QpairReserveResult::Unregistered);
     }
 
     #[test]
@@ -1245,7 +1276,7 @@ mod test {
         p.register_limit(ctrlr as usize, 4);
 
         // Reserve a slot (simulating acquire path)
-        assert!(p.try_reserve(ctrlr as usize)); // active = 1
+        assert_eq!(p.try_reserve(ctrlr as usize), QpairReserveResult::Reserved); // active = 1
         let (active, _) = p.controller_stats(ctrlr as usize);
         assert_eq!(active, 1);
 
@@ -1265,9 +1296,9 @@ mod test {
         p.register_limit(ctrlr as usize, 4);
 
         // Reserve 3 slots
-        assert!(p.try_reserve(ctrlr as usize));
-        assert!(p.try_reserve(ctrlr as usize));
-        assert!(p.try_reserve(ctrlr as usize));
+        assert_eq!(p.try_reserve(ctrlr as usize), QpairReserveResult::Reserved);
+        assert_eq!(p.try_reserve(ctrlr as usize), QpairReserveResult::Reserved);
+        assert_eq!(p.try_reserve(ctrlr as usize), QpairReserveResult::Reserved);
         let (active, _) = p.controller_stats(ctrlr as usize);
         assert_eq!(active, 3);
 
@@ -1315,7 +1346,7 @@ mod test {
         p.register_limit(ctrlr as usize, 1);
 
         // Fill capacity directly
-        assert!(p.try_reserve(ctrlr as usize)); // active = 1
+        assert_eq!(p.try_reserve(ctrlr as usize), QpairReserveResult::Reserved); // active = 1
 
         // Spawn a thread that releases after a delay
         let p2 = Arc::clone(&p);
@@ -1348,7 +1379,7 @@ mod test {
         p.register_limit(ctrlr as usize, 1);
 
         // Fill capacity so acquire enters slow path
-        assert!(p.try_reserve(ctrlr as usize)); // active = 1
+        assert_eq!(p.try_reserve(ctrlr as usize), QpairReserveResult::Reserved); // active = 1
 
         // Simulate shutdown
         p.drain_all();
@@ -1389,13 +1420,39 @@ mod test {
     }
 
     #[test]
+    fn acquire_rejects_unregistered_controller_immediately() {
+        let p = QpairPool::with_qpair_acquire_timeout(Duration::from_secs(1));
+        let ctrlr = 0x1000usize as *mut spdk_ffi::spdk_nvme_ctrlr;
+
+        let msg = p
+            .acquire(ctrlr)
+            .expect_err("unregistered controller should be rejected")
+            .to_string();
+
+        assert!(msg.contains("unregistered"), "unexpected error: {}", msg);
+    }
+
+    #[test]
+    fn repeated_drain_keeps_shutdown_set() {
+        let p = QpairPool::new();
+
+        assert!(!p.shutdown.load(Ordering::Acquire));
+        p.drain_all();
+        assert!(p.shutdown.load(Ordering::Acquire));
+
+        // A repeated drain remains safe and does not create a new shutdown transition.
+        p.drain_all();
+        assert!(p.shutdown.load(Ordering::Acquire));
+    }
+
+    #[test]
     fn acquire_times_out_after_configured_timeout() {
         let p = QpairPool::with_qpair_acquire_timeout(Duration::from_millis(200));
         let ctrlr = 0x1000usize as *mut spdk_ffi::spdk_nvme_ctrlr;
         p.register_limit(ctrlr as usize, 1);
 
         // Fill capacity so acquire blocks on the slow path
-        assert!(p.try_reserve(ctrlr as usize)); // active = 1
+        assert_eq!(p.try_reserve(ctrlr as usize), QpairReserveResult::Reserved); // active = 1
 
         // No one releases - acquire must return Err after the configured timeout.
         let start = Instant::now();
@@ -1426,7 +1483,7 @@ mod test {
         let ctrlr = 0x1000usize as *mut spdk_ffi::spdk_nvme_ctrlr;
         p.register_limit(ctrlr as usize, 1);
 
-        assert!(p.try_reserve(ctrlr as usize));
+        assert_eq!(p.try_reserve(ctrlr as usize), QpairReserveResult::Reserved);
 
         let result = p.acquire(ctrlr);
         assert!(result.is_err());

--- a/crates/adapters/curvine-storage-spdk/src/spdk_metrics.rs
+++ b/crates/adapters/curvine-storage-spdk/src/spdk_metrics.rs
@@ -1,0 +1,138 @@
+#![cfg(feature = "spdk")]
+
+use curvine_core_error::CommonResult;
+use curvine_metrics::{Counter, Gauge, Histogram, Metrics as m};
+use log::warn;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+pub(crate) struct SpdkMetrics {
+    qpair_acquire_cached: Counter,
+    qpair_acquire_allocated: Counter,
+    qpair_acquire_timeout: Counter,
+    qpair_acquire_shutdown: Counter,
+    qpair_acquire_alloc_failed: Counter,
+    qpair_acquire_wait_us: Histogram,
+    qpair_contention_total: Counter,
+    qpair_active: Gauge,
+    qpair_limit: Gauge,
+    qpair_cached: Gauge,
+    qpair_release_cached: Counter,
+    qpair_release_freed_pool_full: Counter,
+    qpair_shutdown_total: Counter,
+}
+
+static SPDK_METRICS: OnceLock<Option<SpdkMetrics>> = OnceLock::new();
+
+impl SpdkMetrics {
+    fn new() -> CommonResult<Self> {
+        let qpair_acquire_total = m::new_counter_vec(
+            "spdk_qpair_acquire_total",
+            "Total SPDK qpair acquire attempts by result",
+            &["result"],
+        )?;
+        let qpair_release_total = m::new_counter_vec(
+            "spdk_qpair_release_total",
+            "Total SPDK qpair releases by result",
+            &["result"],
+        )?;
+
+        Ok(Self {
+            qpair_acquire_cached: qpair_acquire_total.with_label_values(&["cached"]),
+            qpair_acquire_allocated: qpair_acquire_total.with_label_values(&["allocated"]),
+            qpair_acquire_timeout: qpair_acquire_total.with_label_values(&["timeout"]),
+            qpair_acquire_shutdown: qpair_acquire_total.with_label_values(&["shutdown"]),
+            qpair_acquire_alloc_failed: qpair_acquire_total.with_label_values(&["alloc_failed"]),
+            qpair_acquire_wait_us: m::new_histogram_with_buckets(
+                "spdk_qpair_acquire_wait_us",
+                "Microseconds spent waiting for an SPDK qpair slot",
+                &[
+                    100.0, 500.0, 1000.0, 5000.0, 10000.0, 50000.0, 100000.0, 500000.0, 1000000.0,
+                    5000000.0, 30000000.0,
+                ],
+            )?,
+            qpair_contention_total: m::new_counter(
+                "spdk_qpair_contention_total",
+                "Number of SPDK qpair acquire attempts blocked by controller qpair capacity",
+            )?,
+            qpair_active: m::new_gauge(
+                "spdk_qpair_active",
+                "Current active SPDK qpair reservations across controllers",
+            )?,
+            qpair_limit: m::new_gauge(
+                "spdk_qpair_limit",
+                "Configured SPDK qpair reservation limit across controllers",
+            )?,
+            qpair_cached: m::new_gauge(
+                "spdk_qpair_cached",
+                "Current cached idle SPDK qpairs across controllers",
+            )?,
+            qpair_release_cached: qpair_release_total.with_label_values(&["cached"]),
+            qpair_release_freed_pool_full: qpair_release_total
+                .with_label_values(&["freed_pool_full"]),
+            qpair_shutdown_total: m::new_counter(
+                "spdk_qpair_shutdown_total",
+                "Total SPDK qpair pool shutdown drains",
+            )?,
+        })
+    }
+}
+
+fn with_metrics<F>(f: F)
+where
+    F: FnOnce(&SpdkMetrics),
+{
+    let metrics = SPDK_METRICS.get_or_init(|| match SpdkMetrics::new() {
+        Ok(metrics) => Some(metrics),
+        Err(err) => {
+            warn!("failed to register SPDK metrics: {}", err);
+            None
+        }
+    });
+    if let Some(metrics) = metrics.as_ref() {
+        f(metrics);
+    }
+}
+
+pub(crate) fn record_qpair_acquire(result: &'static str) {
+    with_metrics(|m| match result {
+        "cached" => m.qpair_acquire_cached.inc(),
+        "allocated" => m.qpair_acquire_allocated.inc(),
+        "timeout" => m.qpair_acquire_timeout.inc(),
+        "shutdown" => m.qpair_acquire_shutdown.inc(),
+        "alloc_failed" => m.qpair_acquire_alloc_failed.inc(),
+        _ => {}
+    });
+}
+
+pub(crate) fn record_qpair_wait(duration: Duration) {
+    with_metrics(|m| m.qpair_acquire_wait_us.observe(duration.as_micros() as f64));
+}
+
+pub(crate) fn record_qpair_contention() {
+    with_metrics(|m| m.qpair_contention_total.inc());
+}
+
+pub(crate) fn set_qpair_active(value: usize) {
+    with_metrics(|m| m.qpair_active.set(value as i64));
+}
+
+pub(crate) fn set_qpair_limit(value: usize) {
+    with_metrics(|m| m.qpair_limit.set(value as i64));
+}
+
+pub(crate) fn set_qpair_cached(value: usize) {
+    with_metrics(|m| m.qpair_cached.set(value as i64));
+}
+
+pub(crate) fn record_qpair_release(result: &'static str) {
+    with_metrics(|m| match result {
+        "cached" => m.qpair_release_cached.inc(),
+        "freed_pool_full" => m.qpair_release_freed_pool_full.inc(),
+        _ => {}
+    });
+}
+
+pub(crate) fn record_qpair_shutdown() {
+    with_metrics(|m| m.qpair_shutdown_total.inc());
+}

--- a/crates/adapters/curvine-storage-spdk/src/spdk_metrics.rs
+++ b/crates/adapters/curvine-storage-spdk/src/spdk_metrics.rs
@@ -129,7 +129,7 @@ pub(crate) fn record_qpair_release(result: &'static str) {
     with_metrics(|m| match result {
         "cached" => m.qpair_release_cached.inc(),
         "freed_pool_full" => m.qpair_release_freed_pool_full.inc(),
-        _ => {}
+        _ => warn!("unknown spdk qpair release result label: {}", result),
     });
 }
 

--- a/crates/adapters/curvine-storage-spdk/src/spdk_metrics.rs
+++ b/crates/adapters/curvine-storage-spdk/src/spdk_metrics.rs
@@ -101,7 +101,7 @@ pub(crate) fn record_qpair_acquire(result: &'static str) {
         "timeout" => m.qpair_acquire_timeout.inc(),
         "shutdown" => m.qpair_acquire_shutdown.inc(),
         "alloc_failed" => m.qpair_acquire_alloc_failed.inc(),
-        _ => {}
+        _ => warn!("unknown spdk qpair acquire result label: {}", result),
     });
 }
 

--- a/curvine-worker/src/worker/worker_metrics.rs
+++ b/curvine-worker/src/worker/worker_metrics.rs
@@ -116,6 +116,11 @@ impl WorkerMetrics {
 
         self.store_total_disks.set(state.storage_count() as i64);
 
+        #[cfg(feature = "spdk")]
+        if let Some(env) = curvine_storage_spdk::SpdkEnv::global_including_shutdown() {
+            env.publish_metrics();
+        }
+
         Metrics::text_output()
     }
 }


### PR DESCRIPTION
# Summary

- Adds aggregate qpair observability metrics to track acquisition, release, and contention patterns across the SPDK environment.
- Resolves #1076

# Key Changes

- crates/adapters/curvine-storage-spdk/src/spdk_metrics.rs
   + Qpair acquisition counters: `cached`, `allocated`, `timeout`, `shutdown`, `alloc_failed`
   + Qpair release counters: `cached`, `freed_pool_full`
   + Acquisition wait-time histogram (100µs minimum bucket)
   + Aggregate gauges: active, configured, cached qpairs
   + Contention counter and pool shutdown tracking
   + Lazy metric registration with graceful failure handling

- crates/adapters/curvine-storage-spdk/src/spdk_env.rs
   + Record acquisition outcomes on all success/failure paths
   + Accumulate wait duration per acquisition attempt (≥100µs recorded)
   + Track contention on controller capacity blocking
   + Maintain aggregate active, limit, and cached qpair counts
   + Record release outcomes and shutdown drain operations
   + Publish current gauges for metric collection
   + Added qpair metrics validation tests

- curvine-worker/src/worker/worker_metrics.rs
   + Publish SPDK qpair gauges before generating worker metric output
   + Expose metrics via existing Prometheus endpoint

# Impact

- Enables diagnosis of qpair exhaustion and tuning of `io_queues` and `qpair_acquire_timeout`
- Aggregate metrics per worker process across all controllers
- Minimal overhead to qpair acquisition/release paths
- Foundation for future per-controller metrics

# Future Works
- Add per-controller metrics to identify saturated NVMe targets.