### PR TITLE
feat(libsdk): expose PartialSuccess load job state to clients

### DIFF
--- a/crates/client/curvine-job-client/src/lib.rs
+++ b/crates/client/curvine-job-client/src/lib.rs
@@ -170,7 +170,7 @@ impl JobMasterClient {
             match status.state {
                 JobTaskState::Completed => break,
 
-                JobTaskState::Failed | JobTaskState::Canceled => {
+                JobTaskState::Failed | JobTaskState::Canceled | JobTaskState::PartialSuccess => {
                     return err_box!(
                         "job {} {:?}: {}",
                         status.job_id,

--- a/crates/client/curvine-job-client/src/transfer_client.rs
+++ b/crates/client/curvine-job-client/src/transfer_client.rs
@@ -259,7 +259,8 @@ fn transfer_task_state_code(state: JobTaskState) -> i32 {
         JobTaskState::Pending | JobTaskState::UNKNOWN => 1,
         JobTaskState::Loading => 2,
         JobTaskState::Completed => 3,
-        JobTaskState::Failed => 4,
+        // Job-level PartialSuccess has no task-level counterpart; report as failed.
+        JobTaskState::Failed | JobTaskState::PartialSuccess => 4,
         JobTaskState::Canceled => 5,
     }
 }

--- a/crates/common/curvine-model/src/display.rs
+++ b/crates/common/curvine-model/src/display.rs
@@ -90,6 +90,7 @@ impl Display for JobStatus {
             JobTaskState::Completed => "🟢",
             JobTaskState::Failed => "🔴",
             JobTaskState::Canceled => "⚫",
+            JobTaskState::PartialSuccess => "🟡",
             JobTaskState::UNKNOWN => "Unknown",
         };
 

--- a/crates/common/curvine-model/src/job.rs
+++ b/crates/common/curvine-model/src/job.rs
@@ -41,13 +41,18 @@ pub enum JobTaskState {
     Completed = 3,
     Failed = 4,
     Canceled = 5,
+    /// Some sub-tasks succeeded and some failed (transfer load jobs).
+    PartialSuccess = 6,
 }
 
 impl JobTaskState {
     pub fn is_finish(&self) -> bool {
         matches!(
             self,
-            JobTaskState::Completed | JobTaskState::Failed | JobTaskState::Canceled
+            JobTaskState::Completed
+                | JobTaskState::Failed
+                | JobTaskState::Canceled
+                | JobTaskState::PartialSuccess
         )
     }
 

--- a/crates/common/curvine-proto/proto/job.proto
+++ b/crates/common/curvine-proto/proto/job.proto
@@ -15,6 +15,8 @@ enum JobTaskStateProto {
   COMPLETED = 3;
   FAILED = 4;
   CANCELED = 5;
+  // Terminal: some tasks succeeded and some failed (transfer load jobs).
+  PARTIAL_SUCCESS = 6;
 }
 
 enum JobTaskTypeProto {

--- a/crates/sdk/curvine-sdk-core/src/core/transfer_compat.rs
+++ b/crates/sdk/curvine-sdk-core/src/core/transfer_compat.rs
@@ -42,7 +42,8 @@ pub(crate) fn map_transfer_state(state: TransferState) -> JobTaskState {
         | TransferState::Running
         | TransferState::Canceling => JobTaskState::Loading,
         TransferState::Completed => JobTaskState::Completed,
-        TransferState::Failed | TransferState::PartialSuccess => JobTaskState::Failed,
+        TransferState::Failed => JobTaskState::Failed,
+        TransferState::PartialSuccess => JobTaskState::PartialSuccess,
         TransferState::Canceled => JobTaskState::Canceled,
     }
 }
@@ -305,7 +306,7 @@ mod tests {
         );
         assert_eq!(
             map_transfer_state(TransferState::PartialSuccess),
-            JobTaskState::Failed
+            JobTaskState::PartialSuccess
         );
     }
 

--- a/curvine-cli/src/cmds/load_status.rs
+++ b/curvine-cli/src/cmds/load_status.rs
@@ -60,13 +60,7 @@ impl LoadStatusCommand {
         loop {
             let status = handle_rpc_result(client.get_job_status(&self.job_id)).await;
             println!("{}", status);
-            if matches!(
-                status.state,
-                JobTaskState::Completed
-                    | JobTaskState::Failed
-                    | JobTaskState::Canceled
-                    | JobTaskState::PartialSuccess
-            ) {
+            if status.state.is_finish() {
                 break;
             }
             tokio::time::sleep(duration).await;

--- a/curvine-cli/src/cmds/load_status.rs
+++ b/curvine-cli/src/cmds/load_status.rs
@@ -62,7 +62,10 @@ impl LoadStatusCommand {
             println!("{}", status);
             if matches!(
                 status.state,
-                JobTaskState::Completed | JobTaskState::Failed | JobTaskState::Canceled
+                JobTaskState::Completed
+                    | JobTaskState::Failed
+                    | JobTaskState::Canceled
+                    | JobTaskState::PartialSuccess
             ) {
                 break;
             }

--- a/curvine-cli/src/cmds/load_status.rs
+++ b/curvine-cli/src/cmds/load_status.rs
@@ -15,7 +15,7 @@
 use clap::Parser;
 use curvine_core_error::CommonResult;
 use curvine_job_client::{JobMasterClient, TransferClient};
-use curvine_model::{JobTaskState, TransferState};
+use curvine_model::TransferState;
 
 use crate::util::*;
 

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineLoadClient.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineLoadClient.java
@@ -40,6 +40,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * {@code fs.cv.transfer.endpoints=transfer-0:9010,transfer-1:9010}. Transfer endpoints
  * are independent from Master addresses and must be reachable from the Java process.
  *
+ * <p><b>Upgrade note:</b> the Java jar and bundled native lib must be upgraded together.
+ * A newer native library may return job states (for example {@code PARTIAL_SUCCESS})
+ * that an older jar cannot classify, which causes {@link #waitJobComplete} to poll
+ * until timeout instead of returning promptly.
+ *
  * <pre>{@code
  * try (CurvineLoadClient client = CurvineLoadClient.from(conf)) {
  *     LoadJobResult result = client.submitLoad(

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineLoadClient.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineLoadClient.java
@@ -128,10 +128,15 @@ public final class CurvineLoadClient implements Closeable {
     /**
      * Poll job status until finished or timeout.
      *
+     * <p>Returns the final status when the job reaches {@code COMPLETED} or
+     * {@code PARTIAL_SUCCESS}. {@code FAILED} and {@code CANCELED} throw
+     * {@link IOException}. Callers should check {@link LoadJobStatus#isPartialSuccess()}
+     * (or {@link LoadJobStatus#getState()}) to decide how to handle partial success.
+     *
      * @param jobId        job id from {@link #submitLoad}
      * @param timeout      max wait duration
      * @param pollInterval sleep between status queries
-     * @return final status when the job reaches a terminal state
+     * @return final status when the job reaches a terminal success / partial-success state
      * @throws TimeoutException if the job is still running after {@code timeout}
      * @throws IOException      if the job fails / is canceled, or RPC fails
      */
@@ -153,7 +158,7 @@ public final class CurvineLoadClient implements Closeable {
         while (true) {
             status = getJobStatus(jobId);
             if (status.isFinished()) {
-                if (status.isSuccessful()) {
+                if (status.isSuccessful() || status.isPartialSuccess()) {
                     return status;
                 }
                 throw new IOException(

--- a/curvine-libsdk/java/src/main/java/io/curvine/LoadJobStatus.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/LoadJobStatus.java
@@ -73,11 +73,20 @@ public final class LoadJobStatus {
     public boolean isFinished() {
         return state == JobTaskStateProto.COMPLETED
                 || state == JobTaskStateProto.FAILED
-                || state == JobTaskStateProto.CANCELED;
+                || state == JobTaskStateProto.CANCELED
+                || state == JobTaskStateProto.PARTIAL_SUCCESS;
     }
 
     public boolean isSuccessful() {
         return state == JobTaskStateProto.COMPLETED;
+    }
+
+    /**
+     * True when some files/tasks succeeded and others failed.
+     * Callers should inspect progress message / retry failed items as needed.
+     */
+    public boolean isPartialSuccess() {
+        return state == JobTaskStateProto.PARTIAL_SUCCESS;
     }
 
     @Override

--- a/curvine-libsdk/java/src/main/java/io/curvine/LoadJobStatus.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/LoadJobStatus.java
@@ -32,6 +32,21 @@ public final class LoadJobStatus {
     public LoadJobStatus(
             String jobId,
             JobTaskStateProto state,
+            String sourcePath,
+            String targetPath,
+            JobTaskProgressProto progress) {
+        this(
+                jobId,
+                state,
+                state == null ? 0 : state.getNumber(),
+                sourcePath,
+                targetPath,
+                progress);
+    }
+
+    private LoadJobStatus(
+            String jobId,
+            JobTaskStateProto state,
             int stateValue,
             String sourcePath,
             String targetPath,

--- a/curvine-libsdk/java/src/main/java/io/curvine/LoadJobStatus.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/LoadJobStatus.java
@@ -24,6 +24,7 @@ import io.curvine.proto.JobTaskStateProto;
 public final class LoadJobStatus {
     private final String jobId;
     private final JobTaskStateProto state;
+    private final int stateValue;
     private final String sourcePath;
     private final String targetPath;
     private final JobTaskProgressProto progress;
@@ -31,11 +32,13 @@ public final class LoadJobStatus {
     public LoadJobStatus(
             String jobId,
             JobTaskStateProto state,
+            int stateValue,
             String sourcePath,
             String targetPath,
             JobTaskProgressProto progress) {
         this.jobId = jobId;
         this.state = state;
+        this.stateValue = stateValue;
         this.sourcePath = sourcePath;
         this.targetPath = targetPath;
         this.progress = progress;
@@ -45,6 +48,7 @@ public final class LoadJobStatus {
         return new LoadJobStatus(
                 response.getJobId(),
                 response.getState(),
+                response.getStateValue(),
                 response.getSourcePath(),
                 response.getTargetPath(),
                 response.getProgress());
@@ -70,11 +74,19 @@ public final class LoadJobStatus {
         return progress;
     }
 
+    /**
+     * True when the job is no longer running (completed, failed, canceled, partial success,
+     * or any future terminal enum value / {@code UNRECOGNIZED} wire value).
+     */
     public boolean isFinished() {
-        return state == JobTaskStateProto.COMPLETED
-                || state == JobTaskStateProto.FAILED
-                || state == JobTaskStateProto.CANCELED
-                || state == JobTaskStateProto.PARTIAL_SUCCESS;
+        switch (state) {
+            case PENDING:
+            case LOADING:
+            case UNKNOWN:
+                return false;
+            default:
+                return true;
+        }
     }
 
     public boolean isSuccessful() {
@@ -86,7 +98,8 @@ public final class LoadJobStatus {
      * Callers should inspect progress message / retry failed items as needed.
      */
     public boolean isPartialSuccess() {
-        return state == JobTaskStateProto.PARTIAL_SUCCESS;
+        return state == JobTaskStateProto.PARTIAL_SUCCESS
+                || stateValue == JobTaskStateProto.PARTIAL_SUCCESS.getNumber();
     }
 
     @Override

--- a/curvine-libsdk/java/src/test/java/io/curvine/LoadJobClientTest.java
+++ b/curvine-libsdk/java/src/test/java/io/curvine/LoadJobClientTest.java
@@ -106,6 +106,24 @@ public class LoadJobClientTest {
                 .build());
         Assert.assertTrue(failed.isFinished());
         Assert.assertFalse(failed.isSuccessful());
+        Assert.assertFalse(failed.isPartialSuccess());
+
+        LoadJobStatus partial = LoadJobStatus.fromProto(GetJobStatusResponse.newBuilder()
+                .setJobId("job-3")
+                .setState(JobTaskStateProto.PARTIAL_SUCCESS)
+                .setSourcePath("s3://bucket/c")
+                .setTargetPath("/mnt/c")
+                .setProgress(JobTaskProgressProto.newBuilder()
+                        .setLoadedSize(5)
+                        .setTotalSize(10)
+                        .setUpdateTime(1)
+                        .setState(JobTaskStateProto.PARTIAL_SUCCESS.getNumber())
+                        .setMessage("partial")
+                        .build())
+                .build());
+        Assert.assertTrue(partial.isFinished());
+        Assert.assertFalse(partial.isSuccessful());
+        Assert.assertTrue(partial.isPartialSuccess());
     }
 
     @Test

--- a/curvine-libsdk/java/src/test/java/io/curvine/LoadJobClientTest.java
+++ b/curvine-libsdk/java/src/test/java/io/curvine/LoadJobClientTest.java
@@ -139,6 +139,23 @@ public class LoadJobClientTest {
                         .build())
                 .build());
         Assert.assertFalse(running.isFinished());
+
+        LoadJobStatus unrecognized = LoadJobStatus.fromProto(GetJobStatusResponse.newBuilder()
+                .setJobId("job-5")
+                .setStateValue(99)
+                .setSourcePath("s3://bucket/e")
+                .setTargetPath("/mnt/e")
+                .setProgress(JobTaskProgressProto.newBuilder()
+                        .setLoadedSize(1)
+                        .setTotalSize(10)
+                        .setUpdateTime(1)
+                        .setState(99)
+                        .setMessage("unknown-terminal")
+                        .build())
+                .build());
+        Assert.assertTrue(unrecognized.isFinished());
+        Assert.assertFalse(unrecognized.isSuccessful());
+        Assert.assertFalse(unrecognized.isPartialSuccess());
     }
 
     @Test

--- a/curvine-libsdk/java/src/test/java/io/curvine/LoadJobClientTest.java
+++ b/curvine-libsdk/java/src/test/java/io/curvine/LoadJobClientTest.java
@@ -124,6 +124,21 @@ public class LoadJobClientTest {
         Assert.assertTrue(partial.isFinished());
         Assert.assertFalse(partial.isSuccessful());
         Assert.assertTrue(partial.isPartialSuccess());
+
+        LoadJobStatus running = LoadJobStatus.fromProto(GetJobStatusResponse.newBuilder()
+                .setJobId("job-4")
+                .setState(JobTaskStateProto.LOADING)
+                .setSourcePath("s3://bucket/d")
+                .setTargetPath("/mnt/d")
+                .setProgress(JobTaskProgressProto.newBuilder()
+                        .setLoadedSize(1)
+                        .setTotalSize(10)
+                        .setUpdateTime(1)
+                        .setState(JobTaskStateProto.LOADING.getNumber())
+                        .setMessage("running")
+                        .build())
+                .build());
+        Assert.assertFalse(running.isFinished());
     }
 
     @Test

--- a/curvine-master/src/master/job/job_context.rs
+++ b/curvine-master/src/master/job/job_context.rs
@@ -160,7 +160,11 @@ impl JobContext {
                         detail.task.task_id, detail.progress.message
                     )
                 }
-                _ => (),
+                JobTaskState::UNKNOWN
+                | JobTaskState::Pending
+                | JobTaskState::Loading
+                | JobTaskState::Canceled
+                | JobTaskState::PartialSuccess => (),
             }
         }
 

--- a/curvine-master/src/master/job/job_context.rs
+++ b/curvine-master/src/master/job/job_context.rs
@@ -164,6 +164,8 @@ impl JobContext {
                 | JobTaskState::Pending
                 | JobTaskState::Loading
                 | JobTaskState::Canceled
+                // Master update_progress still collapses mixed outcomes to Failed today;
+                // PartialSuccess is emitted only on the transfer path for now.
                 | JobTaskState::PartialSuccess => (),
             }
         }

--- a/curvine-master/src/master/job/job_manager.rs
+++ b/curvine-master/src/master/job/job_manager.rs
@@ -251,6 +251,7 @@ impl JobManager {
                 if state == JobTaskState::Completed
                     || state == JobTaskState::Failed
                     || state == JobTaskState::Canceled
+                    || state == JobTaskState::PartialSuccess
                 {
                     info!(
                         "job {} is already in final state {:?}, source_path: {}, target_path: {}",

--- a/curvine-master/src/master/job/job_manager.rs
+++ b/curvine-master/src/master/job/job_manager.rs
@@ -248,11 +248,7 @@ impl JobManager {
             if let Some(job) = self.jobs.get(job_id) {
                 let state: JobTaskState = job.state.state();
                 // Check whether it can be canceled
-                if state == JobTaskState::Completed
-                    || state == JobTaskState::Failed
-                    || state == JobTaskState::Canceled
-                    || state == JobTaskState::PartialSuccess
-                {
+                if state.is_finish() {
                     info!(
                         "job {} is already in final state {:?}, source_path: {}, target_path: {}",
                         job_id, state, job.info.source_path, job.info.target_path

--- a/curvine-worker/src/worker/handler/worker_handler.rs
+++ b/curvine-worker/src/worker/handler/worker_handler.rs
@@ -426,7 +426,10 @@ fn transfer_task_state_code(state: curvine_model::JobTaskState) -> i32 {
         curvine_model::JobTaskState::Completed => {
             TransferTaskStateProto::TransferTaskCompleted.into()
         }
-        curvine_model::JobTaskState::Failed => TransferTaskStateProto::TransferTaskFailed.into(),
+        // Job-level PartialSuccess has no task-level counterpart; report as failed.
+        curvine_model::JobTaskState::Failed | curvine_model::JobTaskState::PartialSuccess => {
+            TransferTaskStateProto::TransferTaskFailed.into()
+        }
         curvine_model::JobTaskState::Canceled => {
             TransferTaskStateProto::TransferTaskCanceled.into()
         }


### PR DESCRIPTION
# Summary

Load jobs that finish as transfer `PartialSuccess` were mapped to `JobTaskState::Failed` in libsdk. This PR adds `JobTaskState::PartialSuccess` / `JobTaskStateProto.PARTIAL_SUCCESS` and returns it to callers so they can decide how to handle a partially successful load.

# Issue Describe / Design

No linked issue.

- Transfer already has `TransferState::PartialSuccess`.
- SDK compatibility layer previously collapsed it to `Failed`.
- New job-task enum value is `PARTIAL_SUCCESS = 6` (additive, backward compatible).
- Java `getJobStatus` returns `PARTIAL_SUCCESS`; `waitJobComplete` returns the status for `COMPLETED` and `PARTIAL_SUCCESS` (callers use `isPartialSuccess()`). `FAILED` / `CANCELED` still throw.
- Rust `JobClient::wait_job_complete` still errors on `PartialSuccess` because that API returns `()`.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `crates/common/curvine-proto/proto/job.proto` | Add `PARTIAL_SUCCESS = 6` | Additive enum value |
| `crates/common/curvine-model/src/job.rs` | Add `JobTaskState::PartialSuccess`; include it in `is_finish()` | Terminal-state detection now includes partial success |
| `crates/sdk/curvine-sdk-core/src/core/transfer_compat.rs` | Map `TransferState::PartialSuccess` to `JobTaskState::PartialSuccess` | Status is no longer reported as Failed |
| `curvine-libsdk/java/.../LoadJobStatus.java` | `isFinished` includes partial success; add `isPartialSuccess()` | Callers can distinguish partial success |
| `curvine-libsdk/java/.../CurvineLoadClient.java` | `waitJobComplete` returns status on partial success | Previously would throw as Failed |
| `curvine-cli/src/cmds/load_status.rs` | Treat partial success as terminal for watch | Watch loop stops instead of polling forever |
| `crates/client/curvine-job-client/src/lib.rs` | Wait helper errors on `PartialSuccess` | Avoids hanging after mapping change |
| `curvine-master` / `curvine-worker` | Exhaustive match / cancel / task-state mapping | Compile-safe; task-level proto still maps to Failed |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo fmt --check` | PASS | Required CI gate |
| `cargo test -p curvine-sdk-core maps_transfer_states_to_job_task_states` | PASS | Mapping now expects `PartialSuccess` |
| `cargo check -p curvine-master -p curvine-worker -p curvine-cli --tests` | PASS | Exhaustive matches compile |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None

Made with [Cursor](https://cursor.com)