### PR TITLE
docs(skills): add cv-test-report for Hextra Pages

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -45,6 +45,7 @@ rm -rf .claude/skills && ln -sfn ../.agents/skills .claude/skills
 | `cv-address-pr-review` | Handle review comments |
 | `cv-run-workflow` | Dispatch GitHub Actions |
 | `cv-csi-test` | CSI driver integration testing |
+| `cv-test-report` | Publish full-chain daily reports to the Hextra GH Pages site |
 
 ## Rules
 

--- a/.agents/skills/cv-add-skills/SKILL.md
+++ b/.agents/skills/cv-add-skills/SKILL.md
@@ -154,6 +154,7 @@ ls -la .github/skills .cursor/skills .claude/skills
 | `cv-address-pr-review` | PR |
 | `cv-run-workflow` | CI |
 | `cv-tasks-breakdown` | Planning |
+| `cv-test-report` | Testing — publish full-chain reports |
 
 ## Related
 

--- a/.agents/skills/cv-add-skills/SKILL.md
+++ b/.agents/skills/cv-add-skills/SKILL.md
@@ -45,7 +45,7 @@ AGENTS.md                           # skill registry (<available_skills>)
 | ---- | ------ |
 | Prefix | All versioned skills **must** start with `cv-` |
 | Location | Edit only `.agents/skills/cv-<name>/` |
-| Language | `description` and body in **English** |
+| Language | `description` and body in **English only**. No Chinese or other CJK. |
 | Git | Only `cv-*` dirs are tracked; other local skills are gitignored |
 | Registry | Every `cv-*` skill **must** appear in `AGENTS.md` |
 
@@ -138,7 +138,7 @@ ls -la .github/skills .cursor/skills .claude/skills
 - Add non-`cv-` skills to git (they belong in user global skills or local gitignored dirs)
 - Edit skills inside `.cursor/skills/` or `.claude/skills/` directly (symlinks)
 - Skip `AGENTS.md` registration
-- Use Chinese in `description` (body may reference Chinese project docs paths when needed)
+- Use Chinese or other CJK anywhere in a skill (`description`, body, templates, comments)
 - Create standalone setup scripts in the repo for skill management
 
 ## Current cv Skills (maintain this list when adding)

--- a/.agents/skills/cv-csi-test/SKILL.md
+++ b/.agents/skills/cv-csi-test/SKILL.md
@@ -190,7 +190,7 @@ See `scripts/test-suite.sh` for automated test script template.
 - [ ] Multiple pods can share same volume
 - [ ] CSI restart doesn't affect mounted volumes (MountPod mode)
 
-## 注意事项
-如果遇到Pod Terminating，最多等待2min，就要停止等待，并仔细检查pod删除卡主的原因，如果无法修复，可以采用--force的方式确保安全删除。
-- 测试集群的master addr为10.119.43.210:8995, 且只有一个。 
-- 测试之前需要将gchr镜像替换为10.119.43.210:5000/curvine-csi,  测试完成后总是要恢复为原始镜像。
+## Notes
+If a Pod is stuck in Terminating, wait at most 2 minutes, then inspect why deletion is blocked. If it cannot be fixed, use `--force` to delete it safely.
+- The test cluster has a single master at `10.119.43.210:8995`.
+- Before testing, replace the ghcr image with `10.119.43.210:5000/curvine-csi`. Always restore the original image after the test.

--- a/.agents/skills/cv-csi-test/references/components.md
+++ b/.agents/skills/cv-csi-test/references/components.md
@@ -8,10 +8,10 @@
 ├─────────────────────────────────────────────────────────────┤
 │  ┌──────────────────┐    ┌──────────────────────────────┐  │
 │  │  CSI Node Pod    │    │      MountPod                │  │
-│  │  (可重启)         │    │  (独立运行，持久化FUSE)       │  │
+│  │  (restartable)   │    │  (independent, persistent FUSE) │
 │  │                  │    │                              │  │
-│  │  - NodeService   │    │  - curvine-fuse 进程         │  │
-│  │  - MountPodMgr   │───▶│  - 挂载点: /mnt/curvine      │  │
+│  │  - NodeService   │    │  - curvine-fuse process      │  │
+│  │  - MountPodMgr   │───▶│  - mount: /mnt/curvine       │  │
 │  │                  │    │  - HostPath: Bidirectional   │  │
 │  └──────────────────┘    └──────────────────────────────┘  │
 │           │                         │                       │
@@ -118,8 +118,8 @@ parameters:
 
 **Path Generation:**
 ```
-实际挂载路径 = fs-path + "/" + pv-name
-示例: "/test-data/pvc-1234-5678-abcd"
+actual mount path = fs-path + "/" + pv-name
+example: "/test-data/pvc-1234-5678-abcd"
 ```
 
 ## MountPod Details

--- a/.agents/skills/cv-test-report/SKILL.md
+++ b/.agents/skills/cv-test-report/SKILL.md
@@ -87,7 +87,7 @@ Do not publish until a local Hugo build proves the HTML is valid. Goldmark + GFM
 | Rule | Why |
 | ---- | --- |
 | No `#` heading in the body | Duplicates the Hextra H1 |
-| No backticks anywhere in the body | Inline code next to CJK or `\|` often stays literal or eats spaces |
+| No backticks in the published post body | Inline code next to CJK or `\|` often stays literal or eats spaces |
 | No CJK characters | Site and skills are English-only |
 | Tokens use **bold**: **NO-GO**, **failed**, **40** | Renders in lists and tables |
 | Tables: spaces around every `\|` | `\| ITEM \|` not `\|ITEM\|` |
@@ -180,7 +180,7 @@ Expect `200`. Posts older than 30 days are removed on the next deploy.
 
 - Publish environment, paths, accounts, IPs, usernames, run IDs, or evidence URLs
 - Write a Test scope and environment or Evidence index section
-- Put `#` title, backticks, or CJK in the Markdown body
+- Put `#` title, backticks, or CJK in the published post body
 - Publish a table whose column counts do not match
 - Attach raw JSON/logs
 - Commit reports into `curvine` or `curvineio.github.io`
@@ -199,7 +199,7 @@ Expect `200`. Posts older than 30 days are removed on the next deploy.
 - [ ] Front matter has `linkTitle` and `weight: -YYYYMMDD`
 - [ ] GO/NO-GO uses `> [!TIP]` or `> [!CAUTION]`
 - [ ] H2/H3 order matches the template; no body H1
-- [ ] English only; no CJK; no backticks; tokens are **bold**
+- [ ] English only; no CJK; no backticks in the published post body; tokens are **bold**
 - [ ] Every table column count matches; Hugo HTML has `<table>` and `hextra-toc`, not `\| ITEM \|`
 - [ ] Results only; no env / path / IP / account / username
 - [ ] `rg` leak scan clean

--- a/.agents/skills/cv-test-report/SKILL.md
+++ b/.agents/skills/cv-test-report/SKILL.md
@@ -5,11 +5,11 @@ description: Publish Curvine full-chain daily test reports to the Hextra Hugo si
 
 # cv-test-report
 
-Turn a full-chain / daily harness report into one Markdown post and publish it to [`CurvineIO/test-reports`](https://github.com/CurvineIO/test-reports). Live site: https://curvineio.github.io/test-reports/ (Hugo **Hextra**).
+Turn a full-chain / daily harness report into one Markdown post and publish it to [`CurvineIO/test-reports`](https://github.com/CurvineIO/test-reports). Live site: https://curvineio.github.io/test-reports/ (Hugo **Hextra**). Product GitHub: [`CurvineIO/curvine`](https://github.com/CurvineIO/curvine).
 
 One report = one Markdown file. Hextra builds the sidebar and in-page TOC. Posts older than 30 days are pruned on deploy.
 
-**Public posts express test results only.** They must not describe or identify the test environment.
+**Public posts express test results only, in English.** They must not describe or identify the test environment. Do not use Chinese or other CJK text.
 
 ## When to Use
 
@@ -22,7 +22,8 @@ One report = one Markdown file. Hextra builds the sidebar and in-page TOC. Posts
 
 | Item | Value |
 | ---- | ----- |
-| GitHub | `CurvineIO/test-reports` |
+| Product GitHub | [`CurvineIO/curvine`](https://github.com/CurvineIO/curvine) |
+| Pages repo | `CurvineIO/test-reports` |
 | Pages URL | `https://curvineio.github.io/test-reports/` |
 | Theme | Hextra (`github.com/imfing/hextra`, Hugo module) |
 | Post path | `content/reports/YYYY-MM-DD-<slug>.md` |
@@ -32,7 +33,7 @@ One report = one Markdown file. Hextra builds the sidebar and in-page TOC. Posts
 gh repo clone CurvineIO/test-reports /path/to/test-reports
 ```
 
-Do not put the site inside the `curvine` tree.
+Do not put the site inside the `curvine` tree. Site chrome GitHub links must point to `https://github.com/CurvineIO/curvine`.
 
 ## Forbidden in the published post (hard stop)
 
@@ -46,14 +47,15 @@ If any of the following appear, strip them or **do not publish**. Do not replace
 | Environment | cluster / CSI context names, machine types, client/server roles+addresses, image digests, harness SHAs, run directories, archive roots |
 | Secrets | tokens, kubeconfigs, passwords, keys |
 | Evidence handles | Run IDs, fingerprints, artifact URLs, log path columns |
+| Non-English copy | Chinese headings, table headers, alerts, or body text |
 
 **Allowed:** profile names, PASS/FAIL, counts, durations of a profile, GO/NO-GO, failure **case names**, one-line error text with paths/IPs removed, LTP suite stats, perf **numbers**, public GitHub Issue/PR numbers, Curvine **product** commit only if the user explicitly asks to name the tested revision (otherwise omit).
 
-Title may include the report calendar date. Do not include start/end timestamps, total wall time, or “where it ran”.
+Title may include the report calendar date. Do not include start/end timestamps, total wall time, or where it ran.
 
 ## Step 1: Collect the source (private)
 
-Read the raw harness report locally. Use env fields only to decide the post date and GO/NO-GO. Those fields stay out of the Markdown.
+Read the raw harness report locally. Use env fields only to decide the post date and GO/NO-GO. Those fields stay out of the Markdown. Translate source text into English before publishing.
 
 ## Step 2: Write the standard post
 
@@ -61,8 +63,8 @@ Copy [assets/daily-full-chain.md](assets/daily-full-chain.md). Hierarchy rules: 
 
 ```yaml
 ---
-title: "Curvine 全链路每日测试报告 - YYYY-MM-DD"
-linkTitle: "YYYY-MM-DD 全链路"
+title: "Curvine full-chain daily test report - YYYY-MM-DD"
+linkTitle: "YYYY-MM-DD full-chain"
 date: YYYY-MM-DDT00:00:00Z
 weight: -YYYYMMDD
 tags: [full-chain, daily, no-go]
@@ -73,7 +75,7 @@ tags: [full-chain, daily, no-go]
 - `weight` is `-YYYYMMDD` so the sidebar lists newest first.
 - Filename: `content/reports/YYYY-MM-DD-full-chain.md`.
 - Keep the H2/H3 order. Omit optional H3s that have no data.
-- Never drop H2 **质量结论** or **测试结果**.
+- Never drop H2 **Quality conclusion** or **Test results**.
 - **Do not put an H1 in the body.** Hextra already renders `title` as the page H1.
 - Lead GO / NO-GO with a GitHub alert: `> [!TIP]` for GO, `> [!CAUTION]` for NO-GO.
 - Table cells that are exactly `PASS` / `FAIL` / `pass` / `fail` / `degraded` / `NOT_RECORDED` get colored status dots automatically. Do not wrap them in backticks.
@@ -85,10 +87,11 @@ Do not publish until a local Hugo build proves the HTML is valid. Goldmark + GFM
 | Rule | Why |
 | ---- | --- |
 | No `#` heading in the body | Duplicates the Hextra H1 |
-| No backticks anywhere in the body | `` `token` `` next to CJK or `\|` often stays literal or eats spaces (`exit code`40``) |
+| No backticks anywhere in the body | Inline code next to CJK or `\|` often stays literal or eats spaces |
+| No CJK characters | Site and skills are English-only |
 | Tokens use **bold**: **NO-GO**, **failed**, **40** | Renders in lists and tables |
 | Tables: spaces around every `\|` | `\| ITEM \|` not `\|ITEM\|` |
-| Header cells = separator cells = every row | One missing `\| --- \|` dumps the whole table as a paragraph (this broke FIO 基准) |
+| Header cells = separator cells = every row | One missing `\| --- \|` dumps the whole table as a paragraph |
 | No `/` or `()` in table headers | Use `SPEED GiB/s`, `P50 ms`, `Sequential write 64KB` |
 | Blank line before and after each table | Required by GFM |
 | Table before/after is a heading or paragraph, not a list item | Lists swallow tables |
@@ -105,6 +108,8 @@ if re.search(r"^# ", body, re.M):
     sys.exit("H1 in body")
 if "`" in body:
     sys.exit("backticks in body")
+if re.search(r"[\u4e00-\u9fff]", body):
+    sys.exit("CJK in body")
 lines = body.splitlines()
 i = 0
 while i < len(lines):
@@ -174,11 +179,12 @@ Expect `200`. Posts older than 30 days are removed on the next deploy.
 ## Do Not
 
 - Publish environment, paths, accounts, IPs, usernames, run IDs, or evidence URLs
-- Write a “测试范围与环境” / “证据索引” section
-- Put `#` title or backticks in the Markdown body
+- Write a Test scope and environment or Evidence index section
+- Put `#` title, backticks, or CJK in the Markdown body
 - Publish a table whose column counts do not match
 - Attach raw JSON/logs
 - Commit reports into `curvine` or `curvineio.github.io`
+- Point site GitHub chrome at `CurvineIO/test-reports` (use `CurvineIO/curvine`)
 - Write the post for the old Paper theme (no body H1 is still required; Hextra adds `linkTitle`, `weight`, and GO/NO-GO alerts)
 - Treat a subset of green profiles as GO when any required profile failed
 
@@ -193,7 +199,7 @@ Expect `200`. Posts older than 30 days are removed on the next deploy.
 - [ ] Front matter has `linkTitle` and `weight: -YYYYMMDD`
 - [ ] GO/NO-GO uses `> [!TIP]` or `> [!CAUTION]`
 - [ ] H2/H3 order matches the template; no body H1
-- [ ] No backticks; tokens are **bold**
+- [ ] English only; no CJK; no backticks; tokens are **bold**
 - [ ] Every table column count matches; Hugo HTML has `<table>` and `hextra-toc`, not `\| ITEM \|`
 - [ ] Results only; no env / path / IP / account / username
 - [ ] `rg` leak scan clean

--- a/.agents/skills/cv-test-report/SKILL.md
+++ b/.agents/skills/cv-test-report/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: cv-test-report
+description: Publish Curvine full-chain daily test reports to the Hextra Hugo site at CurvineIO/test-reports, using a standard Markdown template with no environment or secret leakage. Use when the user asks to publish a test report, convert harness output to Markdown, or update CurvineIO/test-reports.
+---
+
+# cv-test-report
+
+Turn a full-chain / daily harness report into one Markdown post and publish it to [`CurvineIO/test-reports`](https://github.com/CurvineIO/test-reports). Live site: https://curvineio.github.io/test-reports/ (Hugo **Hextra**).
+
+One report = one Markdown file. Hextra builds the sidebar and in-page TOC. Posts older than 30 days are pruned on deploy.
+
+**Public posts express test results only.** They must not describe or identify the test environment.
+
+## When to Use
+
+- User asks to publish / upload / post a test report
+- User pastes a full-chain daily report and wants it on GH Pages
+- User asks to convert harness output into the standard report format
+- User mentions `test-reports`, `cv-test-report`, or the report site URL
+
+## Target repo
+
+| Item | Value |
+| ---- | ----- |
+| GitHub | `CurvineIO/test-reports` |
+| Pages URL | `https://curvineio.github.io/test-reports/` |
+| Theme | Hextra (`github.com/imfing/hextra`, Hugo module) |
+| Post path | `content/reports/YYYY-MM-DD-<slug>.md` |
+| Retention | 30 calendar days (filename / front-matter date) |
+
+```bash
+gh repo clone CurvineIO/test-reports /path/to/test-reports
+```
+
+Do not put the site inside the `curvine` tree.
+
+## Forbidden in the published post (hard stop)
+
+If any of the following appear, strip them or **do not publish**. Do not replace with aliases that still identify the environment (`reserved`, `internal-archive`, host roles, etc.).
+
+| Class | Examples (never publish) |
+| ----- | ------------------------ |
+| Paths | `/data/...`, `/var/lib/...`, `file://`, UNC, home dirs, `~/...` |
+| Accounts | Unix users, Git authors as operators, kube contexts, SSO names |
+| Network | IPv4/IPv6, hostnames, DNS, CIDR, VIP, `10.x` / `192.168.x` / `172.16.x` |
+| Environment | cluster / CSI context names, machine types, client/server roles+addresses, image digests, harness SHAs, run directories, archive roots |
+| Secrets | tokens, kubeconfigs, passwords, keys |
+| Evidence handles | Run IDs, fingerprints, artifact URLs, log path columns |
+
+**Allowed:** profile names, PASS/FAIL, counts, durations of a profile, GO/NO-GO, failure **case names**, one-line error text with paths/IPs removed, LTP suite stats, perf **numbers**, public GitHub Issue/PR numbers, Curvine **product** commit only if the user explicitly asks to name the tested revision (otherwise omit).
+
+Title may include the report calendar date. Do not include start/end timestamps, total wall time, or “where it ran”.
+
+## Step 1: Collect the source (private)
+
+Read the raw harness report locally. Use env fields only to decide the post date and GO/NO-GO. Those fields stay out of the Markdown.
+
+## Step 2: Write the standard post
+
+Copy [assets/daily-full-chain.md](assets/daily-full-chain.md). Hierarchy rules: [references/report-structure.md](references/report-structure.md).
+
+```yaml
+---
+title: "Curvine 全链路每日测试报告 - YYYY-MM-DD"
+linkTitle: "YYYY-MM-DD 全链路"
+date: YYYY-MM-DDT00:00:00Z
+weight: -YYYYMMDD
+tags: [full-chain, daily, no-go]
+---
+```
+
+- `date` must be in the past (Hugo skips future posts).
+- `weight` is `-YYYYMMDD` so the sidebar lists newest first.
+- Filename: `content/reports/YYYY-MM-DD-full-chain.md`.
+- Keep the H2/H3 order. Omit optional H3s that have no data.
+- Never drop H2 **质量结论** or **测试结果**.
+- **Do not put an H1 in the body.** Hextra already renders `title` as the page H1.
+- Lead GO / NO-GO with a GitHub alert: `> [!TIP]` for GO, `> [!CAUTION]` for NO-GO.
+- Table cells that are exactly `PASS` / `FAIL` / `pass` / `fail` / `degraded` / `NOT_RECORDED` get colored status dots automatically. Do not wrap them in backticks.
+
+## Markdown must render (hard stop)
+
+Do not publish until a local Hugo build proves the HTML is valid. Goldmark + GFM tables are strict.
+
+| Rule | Why |
+| ---- | --- |
+| No `#` heading in the body | Duplicates the Hextra H1 |
+| No backticks anywhere in the body | `` `token` `` next to CJK or `\|` often stays literal or eats spaces (`exit code`40``) |
+| Tokens use **bold**: **NO-GO**, **failed**, **40** | Renders in lists and tables |
+| Tables: spaces around every `\|` | `\| ITEM \|` not `\|ITEM\|` |
+| Header cells = separator cells = every row | One missing `\| --- \|` dumps the whole table as a paragraph (this broke FIO 基准) |
+| No `/` or `()` in table headers | Use `SPEED GiB/s`, `P50 ms`, `Sequential write 64KB` |
+| Blank line before and after each table | Required by GFM |
+| Table before/after is a heading or paragraph, not a list item | Lists swallow tables |
+
+Validate before commit (from `test-reports`):
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+import re, sys
+p = Path("content/reports/YYYY-MM-DD-full-chain.md")
+body = p.read_text().split("---", 2)[-1]
+if re.search(r"^# ", body, re.M):
+    sys.exit("H1 in body")
+if "`" in body:
+    sys.exit("backticks in body")
+lines = body.splitlines()
+i = 0
+while i < len(lines):
+    if re.match(r"^\| .+\|$", lines[i]) and i + 1 < len(lines) and re.match(r"^\|[-: |]+\|$", lines[i + 1]):
+        cells = lambda s: s.strip().strip("|").split("|")
+        h, sep = cells(lines[i]), cells(lines[i + 1])
+        if len(h) != len(sep):
+            sys.exit(f"header/sep {len(h)} vs {len(sep)}: {lines[i]}")
+        j = i + 2
+        while j < len(lines) and lines[j].startswith("|"):
+            if len(cells(lines[j])) != len(h):
+                sys.exit(f"row {len(cells(lines[j]))} vs {len(h)}: {lines[j]}")
+            j += 1
+        i = j
+        continue
+    i += 1
+print("markdown ok")
+PY
+hugo --gc --minify
+# built HTML must have exactly one H1, real <table>s, hextra-toc, and no leftover "| ITEM |"
+```
+
+If Hugo is not on PATH, use the repo `.tools/hugo`. First build needs Go (`hugo mod get`). Fail the publish if the script exits non-zero or the HTML contains `<p>\|`.
+
+## Step 3: Redact, then scan
+
+After filling the template, search the file for leaks:
+
+```bash
+rg -n -i \
+  -e '/data|/var/lib|file://|home/' \
+  -e '[0-9]{1,3}(\.[0-9]{1,3}){3}' \
+  -e 'sha256:|ecs\.|kube|CSI context' \
+  content/reports/YYYY-MM-DD-full-chain.md
+```
+
+Fix every hit that is not an explicit product commit the user asked to publish. Re-run until clean.
+
+Do not add `static/files/` attachments (they usually carry paths or env dumps).
+
+## Step 4: Publish
+
+From `test-reports` (confirm with the user before commit if this session is in `curvine`):
+
+```bash
+git checkout main
+git pull --ff-only
+git add content/reports/YYYY-MM-DD-full-chain.md
+git commit -m "$(cat <<'EOF'
+docs: add full-chain report YYYY-MM-DD
+
+EOF
+)"
+git push origin main
+```
+
+## Step 5: Verify
+
+```bash
+gh run watch --repo CurvineIO/test-reports --exit-status
+curl -sS -o /dev/null -w '%{http_code}\n' \
+  https://curvineio.github.io/test-reports/reports/YYYY-MM-DD-full-chain/
+```
+
+Expect `200`. Posts older than 30 days are removed on the next deploy.
+
+## Do Not
+
+- Publish environment, paths, accounts, IPs, usernames, run IDs, or evidence URLs
+- Write a “测试范围与环境” / “证据索引” section
+- Put `#` title or backticks in the Markdown body
+- Publish a table whose column counts do not match
+- Attach raw JSON/logs
+- Commit reports into `curvine` or `curvineio.github.io`
+- Write the post for the old Paper theme (no body H1 is still required; Hextra adds `linkTitle`, `weight`, and GO/NO-GO alerts)
+- Treat a subset of green profiles as GO when any required profile failed
+
+## Related
+
+- [cv-create-issue](../cv-create-issue/SKILL.md) — product regression after attribution
+- [cv-csi-test](../cv-csi-test/SKILL.md) — CSI profile meaning
+- [cv-add-skills](../cv-add-skills/SKILL.md) — skill layout
+
+## Checklist
+
+- [ ] Front matter has `linkTitle` and `weight: -YYYYMMDD`
+- [ ] GO/NO-GO uses `> [!TIP]` or `> [!CAUTION]`
+- [ ] H2/H3 order matches the template; no body H1
+- [ ] No backticks; tokens are **bold**
+- [ ] Every table column count matches; Hugo HTML has `<table>` and `hextra-toc`, not `\| ITEM \|`
+- [ ] Results only; no env / path / IP / account / username
+- [ ] `rg` leak scan clean
+- [ ] No attachments
+- [ ] Pushed to `CurvineIO/test-reports` `main`
+- [ ] Pages URL returns 200

--- a/.agents/skills/cv-test-report/assets/daily-full-chain.md
+++ b/.agents/skills/cv-test-report/assets/daily-full-chain.md
@@ -1,153 +1,153 @@
 ---
-title: "Curvine 全链路每日测试报告 - YYYY-MM-DD"
-linkTitle: "YYYY-MM-DD 全链路"
+title: "Curvine full-chain daily test report - YYYY-MM-DD"
+linkTitle: "YYYY-MM-DD full-chain"
 date: YYYY-MM-DDT00:00:00Z
 weight: -YYYYMMDD
 tags: [full-chain, daily, no-go]
 ---
 
-## 质量结论
+## Quality conclusion
 
-### 执行摘要
+### Executive summary
 
 > [!CAUTION]
-> 发布决策：**GO / NO-GO**。流水线结果 **PASS / FAIL**；执行 N 个 profile，P 个通过，F 个失败。
+> Release decision: **GO / NO-GO**. Pipeline **PASS / FAIL**; ran N profiles, P passed, F failed.
 
-存在阻断性失败，当前提交不得作为可发布版本；需完成归因、修复和定向回归后重新执行全链路测试。
+A blocking failure exists. This revision is not releasable. Finish attribution, fix, and targeted regression, then rerun the full-chain tests.
 
-### 质量门禁
+### Quality gates
 
-| 门禁 | 标准 | 实际 | 结论 |
+| Gate | Criterion | Actual | Verdict |
 | --- | --- | --- | --- |
-| 全链路结果 | 所有必跑 profile 通过 | P/N 通过 | PASS / FAIL |
-| 失败归因 | 失败项已分类 | F 个失败 | PASS / 待逐项确认 |
-| 资源清理 | 所有 profile cleanup 成功 | C/N | PASS / FAIL |
+| Full-chain result | All required profiles passed | P/N passed | PASS / FAIL |
+| Failure attribution | Failures classified | F failures | PASS / pending per-item |
+| Resource cleanup | All profile cleanups succeeded | C/N | PASS / FAIL |
 
-### 结论
+### Conclusion
 
-本次全链路测试未通过，按失败分类进入产品修复、Harness 修复或环境治理。
+This full-chain run did not pass. Route by failure class into product fix, harness fix, or environment work.
 
-未完成归因的 profile：fuse。
+Unattributed failed profile: fuse.
 
-## 测试结果
+## Test results
 
-### Profile 汇总
+### Profile summary
 
-| Profile | Preflight | 结果 | 耗时 | 分类 | Cleanup |
+| Profile | Preflight | Result | Duration | Class | Cleanup |
 | --- | --- | --- | --- | --- | --- |
 | fast | PASS | PASS | 1m 35s | passed | passed |
 | fuse | PASS | FAIL | 2m 56s | unknown_failure | passed |
 
 ### LTP
 
-- 状态：**completed**
-- 已完成 suite：N
-- 待运行 suite：0
-- 测试统计：P passed / F real failed / S skipped / E report-consistency errors
+- Status: **completed**
+- Suites completed: N
+- Suites remaining: 0
+- Stats: P passed / F real failed / S skipped / E report-consistency errors
 
-| Suite | 状态 | Passed | Real failed | Skipped | Report errors | Return code |
+| Suite | Status | Passed | Real failed | Skipped | Report errors | Return code |
 | --- | --- | ---: | ---: | ---: | ---: | ---: |
 | smoketest | passed | 12 | 0 | 1 | 0 | 0 |
 
-#### 失败与异常用例
+#### Failed and abnormal cases
 
-未解析到 TFAIL/TBROK。
+No TFAIL/TBROK parsed.
 
-### 性能基准
+### Performance
 
 > [!NOTE]
-> 门禁策略：**仅报告，不阻断** 全链路结果；低于 baseline 时标黄/标红供人工跟进。
+> Gate policy: **report only, non-blocking** for the full-chain result. Mark yellow/red vs baseline for human follow-up.
 
-- 状态：**failed**
-- 门禁模式：**report_only**
+- Status: **failed**
+- Gate mode: **report_only**
 
-#### 元数据性能（本次）
+#### Metadata performance (this run)
 
-| ITEM | VALUE | AVG COST | P50 ms | P95 ms | P99 ms | MAX ms | SAMPLES | ERRORS | 状态 |
+| ITEM | VALUE | AVG COST | P50 ms | P95 ms | P99 ms | MAX ms | SAMPLES | ERRORS | Status |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
 | Create file | 21392.01 ops/s | 1.86 ms/op | 2.05 | 4.09 | 4.09 | 162.66 | 200000 | 0 | pass |
 
-#### FIO 读写性能（本次）
+#### FIO read/write (this run)
 
-| ITEM | SPEED GiB/s | IOPS | AVG COST | P50 ms | P95 ms | P99 ms | MAX ms | SAMPLES | ERRORS | 状态 |
+| ITEM | SPEED GiB/s | IOPS | AVG COST | P50 ms | P95 ms | P99 ms | MAX ms | SAMPLES | ERRORS | Status |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
 | Sequential write 64KB | 1.70 | 27840.27 | 9.00 ms/op | 8.98 | 10.55 | 11.47 | 18.43 | 262144 | 0 | pass |
 
-#### 元数据性能基准
+#### Metadata performance baseline
 
 | ITEM | VALUE | AVG COST | P50 ms | P95 ms | P99 ms | MAX ms | SAMPLES | ERRORS |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
 | Create file | 21668.74 ops/s | 1.84 ms/op | 2.05 | 4.09 | 4.09 | 188.88 | 200000 | 0 |
 
-#### FIO 读写性能基准
+#### FIO read/write baseline
 
 | ITEM | SPEED GiB/s | IOPS | AVG COST | P50 ms | P95 ms | P99 ms | MAX ms | SAMPLES | ERRORS |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
 | Sequential write 64KB | 1.71 | 28084.85 | 8.89 ms/op | 8.85 | 10.29 | 10.94 | 16.58 | 262144 | 0 |
 
-## 失败与归因
+## Failures and attribution
 
-### 失败分析
+### Failure analysis
 
 #### fuse
 
-- 测试目标：FUSE 挂载、文件 I/O 与 FIO 回归
-- 预期结果：挂载可读写，I/O 语义正确且无 EIO
-- 实际结果：exit code **40**；持续或预分配写入出现 EIO 或 ENOSPC
-- 业务影响：阻断全链路质量门禁
-- 分类：**unknown_failure**
-- 失败层：**test**
-- 根因置信度：低
-- Cleanup：**passed**
-- 下一步：由 fuse-owner 完成归因
+- Goal: FUSE mount, file I/O, and FIO regression
+- Expected: Mount is readable/writable; I/O semantics are correct; no EIO
+- Actual: exit code **40**; sustained or preallocated writes returned EIO or ENOSPC
+- Impact: Blocks the full-chain quality gate
+- Class: **unknown_failure**
+- Failure layer: **test**
+- Root-cause confidence: low
+- Cleanup: **passed**
+- Next step: fuse-owner completes attribution
 
-### 失败用例摘要
+### Failed case summary
 
-| 用例 | Suite / Package | 状态 | 关键错误 | 根因组 |
+| Case | Suite / Package | Status | Key error | Root group |
 | --- | --- | --- | --- | --- |
 | FIO Sequential Write Test (256KB blocks) | fio / fuse | FAIL | FIO Sequential Write test failed | g-fuse-write-eio |
 
-### 失败用例对账
+### Failed case reconciliation
 
-| Profile | 报告失败数 | 源失败数 | 差异 | 解释 |
+| Profile | Reported failures | Source failures | Delta | Notes |
 | --- | ---: | ---: | ---: | --- |
-| fuse | 6 | 6 | +0 | 数量一致 |
+| fuse | 6 | 6 | +0 | Counts match |
 
-### 共性根因组
+### Common root-cause groups
 
-归因覆盖率：**6/6（100.0%）**。
+Attribution coverage: **6/6 (100.0%)**.
 
 #### P1 g-fuse-write-eio
 
-- Profiles：fuse
-- 根因语义：假设 FUSE 或后端存储返回 EIO 或 ENOSPC
-- 建议：对齐首次 EIO 时间点并核对 worker 与 master ERROR
-- 唯一逻辑失败：6
-- 模型分类：**unknown_failure**；置信度：**medium**；Issue：**needs_human**
-- 验证方案：修复后重跑 fuse profile
-- FIO Sequential Write Test (256KB blocks)（fuse）：FIO Sequential Write test failed
+- Profiles: fuse
+- Hypothesis: FUSE or backend storage returned EIO or ENOSPC
+- Recommendation: Align the first EIO timestamp and check worker and master ERROR logs
+- Unique logical failures: 6
+- Model class: **unknown_failure**; confidence: **medium**; Issue: **needs_human**
+- Verification: Rerun the fuse profile after the fix
+- FIO Sequential Write Test (256KB blocks) (fuse): FIO Sequential Write test failed
 
-### 全部失败用例
+### All failed cases
 
-| 用例 | Suite / Package | 状态 | 关键错误 | 根因组 |
+| Case | Suite / Package | Status | Key error | Root group |
 | --- | --- | --- | --- | --- |
 | FIO Sequential Write Test (256KB blocks) | fio / fuse | FAIL | FIO Sequential Write test failed | g-fuse-write-eio |
 
-## 闭环
+## Follow-up
 
-### 缺陷与修复
+### Defects and fixes
 
-- GitHub Issue：**needs_human**
-- GitHub PR：**pending_fix_review**
+- GitHub Issue: **needs_human**
+- GitHub PR: **pending_fix_review**
 
-### 风险
+### Risks
 
-- 局部 profile 通过不能替代全链路 NO-GO。
-- 未完成归因的 profile：fuse。
+- A subset of green profiles does not override a full-chain NO-GO.
+- Unattributed failed profile: fuse.
 
-### 后续行动
+### Next actions
 
-| 优先级 | 角色 | 行动 | 完成标准 |
+| Priority | Role | Action | Done when |
 | --- | --- | --- | --- |
-| P0 | fuse-owner | 完成归因、建 Issue、修复并定向回归 | fuse 通过，Issue 与 PR 完整 |
-| P0 | 测试负责人 | 重跑全链路并更新报告 | 必跑 profile 全部通过 |
+| P0 | fuse-owner | Finish attribution, file an Issue, fix, and run targeted regression | fuse passes; Issue and PR complete |
+| P0 | test-owner | Rerun the full chain and update the report | All required profiles pass |

--- a/.agents/skills/cv-test-report/assets/daily-full-chain.md
+++ b/.agents/skills/cv-test-report/assets/daily-full-chain.md
@@ -1,0 +1,153 @@
+---
+title: "Curvine 全链路每日测试报告 - YYYY-MM-DD"
+linkTitle: "YYYY-MM-DD 全链路"
+date: YYYY-MM-DDT00:00:00Z
+weight: -YYYYMMDD
+tags: [full-chain, daily, no-go]
+---
+
+## 质量结论
+
+### 执行摘要
+
+> [!CAUTION]
+> 发布决策：**GO / NO-GO**。流水线结果 **PASS / FAIL**；执行 N 个 profile，P 个通过，F 个失败。
+
+存在阻断性失败，当前提交不得作为可发布版本；需完成归因、修复和定向回归后重新执行全链路测试。
+
+### 质量门禁
+
+| 门禁 | 标准 | 实际 | 结论 |
+| --- | --- | --- | --- |
+| 全链路结果 | 所有必跑 profile 通过 | P/N 通过 | PASS / FAIL |
+| 失败归因 | 失败项已分类 | F 个失败 | PASS / 待逐项确认 |
+| 资源清理 | 所有 profile cleanup 成功 | C/N | PASS / FAIL |
+
+### 结论
+
+本次全链路测试未通过，按失败分类进入产品修复、Harness 修复或环境治理。
+
+未完成归因的 profile：fuse。
+
+## 测试结果
+
+### Profile 汇总
+
+| Profile | Preflight | 结果 | 耗时 | 分类 | Cleanup |
+| --- | --- | --- | --- | --- | --- |
+| fast | PASS | PASS | 1m 35s | passed | passed |
+| fuse | PASS | FAIL | 2m 56s | unknown_failure | passed |
+
+### LTP
+
+- 状态：**completed**
+- 已完成 suite：N
+- 待运行 suite：0
+- 测试统计：P passed / F real failed / S skipped / E report-consistency errors
+
+| Suite | 状态 | Passed | Real failed | Skipped | Report errors | Return code |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| smoketest | passed | 12 | 0 | 1 | 0 | 0 |
+
+#### 失败与异常用例
+
+未解析到 TFAIL/TBROK。
+
+### 性能基准
+
+> [!NOTE]
+> 门禁策略：**仅报告，不阻断** 全链路结果；低于 baseline 时标黄/标红供人工跟进。
+
+- 状态：**failed**
+- 门禁模式：**report_only**
+
+#### 元数据性能（本次）
+
+| ITEM | VALUE | AVG COST | P50 ms | P95 ms | P99 ms | MAX ms | SAMPLES | ERRORS | 状态 |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| Create file | 21392.01 ops/s | 1.86 ms/op | 2.05 | 4.09 | 4.09 | 162.66 | 200000 | 0 | pass |
+
+#### FIO 读写性能（本次）
+
+| ITEM | SPEED GiB/s | IOPS | AVG COST | P50 ms | P95 ms | P99 ms | MAX ms | SAMPLES | ERRORS | 状态 |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| Sequential write 64KB | 1.70 | 27840.27 | 9.00 ms/op | 8.98 | 10.55 | 11.47 | 18.43 | 262144 | 0 | pass |
+
+#### 元数据性能基准
+
+| ITEM | VALUE | AVG COST | P50 ms | P95 ms | P99 ms | MAX ms | SAMPLES | ERRORS |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Create file | 21668.74 ops/s | 1.84 ms/op | 2.05 | 4.09 | 4.09 | 188.88 | 200000 | 0 |
+
+#### FIO 读写性能基准
+
+| ITEM | SPEED GiB/s | IOPS | AVG COST | P50 ms | P95 ms | P99 ms | MAX ms | SAMPLES | ERRORS |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Sequential write 64KB | 1.71 | 28084.85 | 8.89 ms/op | 8.85 | 10.29 | 10.94 | 16.58 | 262144 | 0 |
+
+## 失败与归因
+
+### 失败分析
+
+#### fuse
+
+- 测试目标：FUSE 挂载、文件 I/O 与 FIO 回归
+- 预期结果：挂载可读写，I/O 语义正确且无 EIO
+- 实际结果：exit code **40**；持续或预分配写入出现 EIO 或 ENOSPC
+- 业务影响：阻断全链路质量门禁
+- 分类：**unknown_failure**
+- 失败层：**test**
+- 根因置信度：低
+- Cleanup：**passed**
+- 下一步：由 fuse-owner 完成归因
+
+### 失败用例摘要
+
+| 用例 | Suite / Package | 状态 | 关键错误 | 根因组 |
+| --- | --- | --- | --- | --- |
+| FIO Sequential Write Test (256KB blocks) | fio / fuse | FAIL | FIO Sequential Write test failed | g-fuse-write-eio |
+
+### 失败用例对账
+
+| Profile | 报告失败数 | 源失败数 | 差异 | 解释 |
+| --- | ---: | ---: | ---: | --- |
+| fuse | 6 | 6 | +0 | 数量一致 |
+
+### 共性根因组
+
+归因覆盖率：**6/6（100.0%）**。
+
+#### P1 g-fuse-write-eio
+
+- Profiles：fuse
+- 根因语义：假设 FUSE 或后端存储返回 EIO 或 ENOSPC
+- 建议：对齐首次 EIO 时间点并核对 worker 与 master ERROR
+- 唯一逻辑失败：6
+- 模型分类：**unknown_failure**；置信度：**medium**；Issue：**needs_human**
+- 验证方案：修复后重跑 fuse profile
+- FIO Sequential Write Test (256KB blocks)（fuse）：FIO Sequential Write test failed
+
+### 全部失败用例
+
+| 用例 | Suite / Package | 状态 | 关键错误 | 根因组 |
+| --- | --- | --- | --- | --- |
+| FIO Sequential Write Test (256KB blocks) | fio / fuse | FAIL | FIO Sequential Write test failed | g-fuse-write-eio |
+
+## 闭环
+
+### 缺陷与修复
+
+- GitHub Issue：**needs_human**
+- GitHub PR：**pending_fix_review**
+
+### 风险
+
+- 局部 profile 通过不能替代全链路 NO-GO。
+- 未完成归因的 profile：fuse。
+
+### 后续行动
+
+| 优先级 | 角色 | 行动 | 完成标准 |
+| --- | --- | --- | --- |
+| P0 | fuse-owner | 完成归因、建 Issue、修复并定向回归 | fuse 通过，Issue 与 PR 完整 |
+| P0 | 测试负责人 | 重跑全链路并更新报告 | 必跑 profile 全部通过 |

--- a/.agents/skills/cv-test-report/references/report-structure.md
+++ b/.agents/skills/cv-test-report/references/report-structure.md
@@ -1,0 +1,140 @@
+# Full-chain daily report structure
+
+Public Markdown uses **four H2 groups**. Related content is H3 (and H4 under perf). Do not add a fifth H2 for environment or evidence.
+
+Body language follows the source (usually Chinese). Headings below are canonical.
+
+The post contains **results only**. No test paths, host accounts, IPs, usernames, cluster names, machine types, image digests, harness revisions, run IDs, or archive locations.
+
+## Front matter
+
+| Field | Required | Notes |
+| ----- | -------- | ----- |
+| `title` | yes | Calendar date only, no clock and no host |
+| `linkTitle` | yes | Short sidebar label, e.g. `YYYY-MM-DD 全链路` |
+| `date` | yes | `YYYY-MM-DDT00:00:00Z` (must not be in the future) |
+| `weight` | yes | `-YYYYMMDD` so Hextra lists newest first |
+| `tags` | yes | `full-chain` or profile name, plus `go` or `no-go` |
+
+## Heading tree
+
+The page H1 comes from front matter `title` only. Body starts at H2. Hextra draws the right-hand TOC from H2–H4.
+
+```text
+## 质量结论
+  ### 执行摘要
+  ### 质量门禁
+  ### 结论
+## 测试结果
+  ### Profile 汇总
+  ### LTP          (omit if ltp not run)
+  ### 性能基准      (omit if perf not run)
+    #### 元数据性能（本次）
+    #### FIO 读写性能（本次）
+    #### 元数据性能基准
+    #### FIO 读写性能基准
+## 失败与归因       (omit entire H2 if all required profiles passed)
+  ### 失败分析
+    #### {profile}   (one per failed required profile)
+  ### 失败用例摘要
+  ### 失败用例对账
+  ### 共性根因组
+  ### 全部失败用例
+## 闭环
+  ### 缺陷与修复
+  ### 风险
+  ### 后续行动
+```
+
+| H2 | Required | Omit when |
+| -- | -------- | --------- |
+| 质量结论 | yes | never |
+| 测试结果 | yes | never |
+| 失败与归因 | if any required profile failed | all required profiles passed |
+| 闭环 | yes | never |
+
+Do **not** create: 测试范围与环境, 证据索引, 执行节点, 集群信息.
+
+Do **not** use backticks. Do **not** write a body `#` heading. Tables must be GFM with matching column counts (see SKILL.md “Markdown must render”).
+
+## 质量结论
+
+### 执行摘要
+
+Lead with a GitHub alert, then counts.
+
+```markdown
+> [!CAUTION]
+> 发布决策：**NO-GO**。流水线结果 **FAIL**；执行 N 个 profile，P 个通过，F 个失败。
+```
+
+Use `> [!TIP]` when the decision is **GO**.
+
+- **GO**: every required profile passed (perf `report_only` yellow/red does not block).
+- **NO-GO**: any required profile failed, or cleanup failed when cleanup is a gate.
+
+No wall-clock window, no commit list, no “where it ran”.
+
+### 质量门禁
+
+| 门禁 | 标准 | 实际 | 结论 |
+| ---- | ---- | ---- | ---- |
+| 全链路结果 | 所有必跑 profile 通过 | `{passed}/{total}` 通过 | PASS / FAIL |
+| 失败归因 | 失败项已分类 | `{n}` 个失败 | PASS / 待逐项确认 |
+| 资源清理 | 所有 profile cleanup 成功 | `{passed}/{total}` | PASS / FAIL |
+
+### 结论
+
+One short paragraph. List unattributed failed profiles by **profile name** only.
+
+## 测试结果
+
+### Profile 汇总
+
+`Profile | Preflight | 结果 | 耗时 | 分类 | Cleanup`
+
+No Run ID column. 结果 is PASS/FAIL. 分类 is `passed` / `unknown_failure` / `product_regression` / …
+
+### LTP
+
+Suite status plus `passed / real failed / skipped / report-consistency errors`, then per-suite counts. No summary-file path.
+
+### 性能基准
+
+Gate mode (`report_only` vs blocking), then number tables only. No client, server, instance type, pipeline SHA, or file names.
+
+## 失败与归因
+
+### 失败分析 / #### {profile}
+
+Keep: 测试目标, 预期, 实际（exit code + symptom）, 业务影响, 分类, 失败层, 根因置信度, Cleanup, 下一步（role, not a person）.
+
+Drop: Evidence, Fingerprint, 最小复现 that names commits/images/hosts, log excerpts that contain paths or IPs.
+
+### 失败用例摘要 / 全部失败用例
+
+`用例 | Suite/Package | 状态 | 关键错误 | 根因组`
+
+No 日志 / Fingerprint columns. Error text must not contain paths or addresses.
+
+### 失败用例对账
+
+`Profile | 报告失败数 | 源失败数 | 差异 | 解释`
+
+### 共性根因组
+
+Coverage `{attributed}/{total}`. Each group: profiles, hypothesis (no host/disk paths), 建议, unique count, class, Issue (`needs_human` / `#n`), 验证方案, member **case names**.
+
+## 闭环
+
+### 缺陷与修复
+
+Public GitHub Issue/PR numbers only. No internal ticket hosts, no operator names.
+
+### 风险
+
+NO-GO cannot be waived by a green subset. Name unattributed **profiles**. Do not say evidence is node-local or how to fetch logs.
+
+### 后续行动
+
+`优先级 | 角色 | 行动 | 完成标准` — 角色 is a function (`fuse-owner`, `测试负责人`), never a username.

--- a/.agents/skills/cv-test-report/references/report-structure.md
+++ b/.agents/skills/cv-test-report/references/report-structure.md
@@ -55,7 +55,7 @@ The page H1 comes from front matter `title` only. Body starts at H2. Hextra draw
 
 Do **not** create: Test scope and environment, Evidence index, Execution nodes, Cluster info.
 
-Do **not** use backticks. Do **not** write a body `#` heading. Do **not** use CJK. Tables must be GFM with matching column counts (see SKILL.md “Markdown must render”).
+Do **not** use backticks in the published post body (skill docs may still use them for literals). Do **not** write a body `#` heading. Do **not** use CJK. Tables must be GFM with matching column counts (see SKILL.md “Markdown must render”).
 
 ## Quality conclusion
 

--- a/.agents/skills/cv-test-report/references/report-structure.md
+++ b/.agents/skills/cv-test-report/references/report-structure.md
@@ -2,7 +2,7 @@
 
 Public Markdown uses **four H2 groups**. Related content is H3 (and H4 under perf). Do not add a fifth H2 for environment or evidence.
 
-Body language follows the source (usually Chinese). Headings below are canonical.
+Body language is **English only**. Headings below are canonical.
 
 The post contains **results only**. No test paths, host accounts, IPs, usernames, cluster names, machine types, image digests, harness revisions, run IDs, or archive locations.
 
@@ -11,7 +11,7 @@ The post contains **results only**. No test paths, host accounts, IPs, usernames
 | Field | Required | Notes |
 | ----- | -------- | ----- |
 | `title` | yes | Calendar date only, no clock and no host |
-| `linkTitle` | yes | Short sidebar label, e.g. `YYYY-MM-DD 全链路` |
+| `linkTitle` | yes | Short sidebar label, e.g. `YYYY-MM-DD full-chain` |
 | `date` | yes | `YYYY-MM-DDT00:00:00Z` (must not be in the future) |
 | `weight` | yes | `-YYYYMMDD` so Hextra lists newest first |
 | `tags` | yes | `full-chain` or profile name, plus `go` or `no-go` |
@@ -21,51 +21,51 @@ The post contains **results only**. No test paths, host accounts, IPs, usernames
 The page H1 comes from front matter `title` only. Body starts at H2. Hextra draws the right-hand TOC from H2–H4.
 
 ```text
-## 质量结论
-  ### 执行摘要
-  ### 质量门禁
-  ### 结论
-## 测试结果
-  ### Profile 汇总
+## Quality conclusion
+  ### Executive summary
+  ### Quality gates
+  ### Conclusion
+## Test results
+  ### Profile summary
   ### LTP          (omit if ltp not run)
-  ### 性能基准      (omit if perf not run)
-    #### 元数据性能（本次）
-    #### FIO 读写性能（本次）
-    #### 元数据性能基准
-    #### FIO 读写性能基准
-## 失败与归因       (omit entire H2 if all required profiles passed)
-  ### 失败分析
+  ### Performance  (omit if perf not run)
+    #### Metadata performance (this run)
+    #### FIO read/write (this run)
+    #### Metadata performance baseline
+    #### FIO read/write baseline
+## Failures and attribution  (omit entire H2 if all required profiles passed)
+  ### Failure analysis
     #### {profile}   (one per failed required profile)
-  ### 失败用例摘要
-  ### 失败用例对账
-  ### 共性根因组
-  ### 全部失败用例
-## 闭环
-  ### 缺陷与修复
-  ### 风险
-  ### 后续行动
+  ### Failed case summary
+  ### Failed case reconciliation
+  ### Common root-cause groups
+  ### All failed cases
+## Follow-up
+  ### Defects and fixes
+  ### Risks
+  ### Next actions
 ```
 
 | H2 | Required | Omit when |
 | -- | -------- | --------- |
-| 质量结论 | yes | never |
-| 测试结果 | yes | never |
-| 失败与归因 | if any required profile failed | all required profiles passed |
-| 闭环 | yes | never |
+| Quality conclusion | yes | never |
+| Test results | yes | never |
+| Failures and attribution | if any required profile failed | all required profiles passed |
+| Follow-up | yes | never |
 
-Do **not** create: 测试范围与环境, 证据索引, 执行节点, 集群信息.
+Do **not** create: Test scope and environment, Evidence index, Execution nodes, Cluster info.
 
-Do **not** use backticks. Do **not** write a body `#` heading. Tables must be GFM with matching column counts (see SKILL.md “Markdown must render”).
+Do **not** use backticks. Do **not** write a body `#` heading. Do **not** use CJK. Tables must be GFM with matching column counts (see SKILL.md “Markdown must render”).
 
-## 质量结论
+## Quality conclusion
 
-### 执行摘要
+### Executive summary
 
 Lead with a GitHub alert, then counts.
 
 ```markdown
 > [!CAUTION]
-> 发布决策：**NO-GO**。流水线结果 **FAIL**；执行 N 个 profile，P 个通过，F 个失败。
+> Release decision: **NO-GO**. Pipeline **FAIL**; ran N profiles, P passed, F failed.
 ```
 
 Use `> [!TIP]` when the decision is **GO**.
@@ -73,68 +73,68 @@ Use `> [!TIP]` when the decision is **GO**.
 - **GO**: every required profile passed (perf `report_only` yellow/red does not block).
 - **NO-GO**: any required profile failed, or cleanup failed when cleanup is a gate.
 
-No wall-clock window, no commit list, no “where it ran”.
+No wall-clock window, no commit list, no where it ran.
 
-### 质量门禁
+### Quality gates
 
-| 门禁 | 标准 | 实际 | 结论 |
-| ---- | ---- | ---- | ---- |
-| 全链路结果 | 所有必跑 profile 通过 | `{passed}/{total}` 通过 | PASS / FAIL |
-| 失败归因 | 失败项已分类 | `{n}` 个失败 | PASS / 待逐项确认 |
-| 资源清理 | 所有 profile cleanup 成功 | `{passed}/{total}` | PASS / FAIL |
+| Gate | Criterion | Actual | Verdict |
+| ---- | --------- | ------ | ------- |
+| Full-chain result | All required profiles passed | `{passed}/{total}` passed | PASS / FAIL |
+| Failure attribution | Failures classified | `{n}` failures | PASS / pending per-item |
+| Resource cleanup | All profile cleanups succeeded | `{passed}/{total}` | PASS / FAIL |
 
-### 结论
+### Conclusion
 
 One short paragraph. List unattributed failed profiles by **profile name** only.
 
-## 测试结果
+## Test results
 
-### Profile 汇总
+### Profile summary
 
-`Profile | Preflight | 结果 | 耗时 | 分类 | Cleanup`
+`Profile | Preflight | Result | Duration | Class | Cleanup`
 
-No Run ID column. 结果 is PASS/FAIL. 分类 is `passed` / `unknown_failure` / `product_regression` / …
+No Run ID column. Result is PASS/FAIL. Class is `passed` / `unknown_failure` / `product_regression` / …
 
 ### LTP
 
 Suite status plus `passed / real failed / skipped / report-consistency errors`, then per-suite counts. No summary-file path.
 
-### 性能基准
+### Performance
 
 Gate mode (`report_only` vs blocking), then number tables only. No client, server, instance type, pipeline SHA, or file names.
 
-## 失败与归因
+## Failures and attribution
 
-### 失败分析 / #### {profile}
+### Failure analysis / #### {profile}
 
-Keep: 测试目标, 预期, 实际（exit code + symptom）, 业务影响, 分类, 失败层, 根因置信度, Cleanup, 下一步（role, not a person）.
+Keep: Goal, Expected, Actual (exit code + symptom), Impact, Class, Failure layer, Root-cause confidence, Cleanup, Next step (role, not a person).
 
-Drop: Evidence, Fingerprint, 最小复现 that names commits/images/hosts, log excerpts that contain paths or IPs.
+Drop: Evidence, Fingerprint, minimal repro that names commits/images/hosts, log excerpts that contain paths or IPs.
 
-### 失败用例摘要 / 全部失败用例
+### Failed case summary / All failed cases
 
-`用例 | Suite/Package | 状态 | 关键错误 | 根因组`
+`Case | Suite/Package | Status | Key error | Root group`
 
-No 日志 / Fingerprint columns. Error text must not contain paths or addresses.
+No log / Fingerprint columns. Error text must not contain paths or addresses.
 
-### 失败用例对账
+### Failed case reconciliation
 
-`Profile | 报告失败数 | 源失败数 | 差异 | 解释`
+`Profile | Reported failures | Source failures | Delta | Notes`
 
-### 共性根因组
+### Common root-cause groups
 
-Coverage `{attributed}/{total}`. Each group: profiles, hypothesis (no host/disk paths), 建议, unique count, class, Issue (`needs_human` / `#n`), 验证方案, member **case names**.
+Coverage `{attributed}/{total}`. Each group: profiles, hypothesis (no host/disk paths), recommendation, unique count, class, Issue (`needs_human` / `#n`), verification plan, member **case names**.
 
-## 闭环
+## Follow-up
 
-### 缺陷与修复
+### Defects and fixes
 
-Public GitHub Issue/PR numbers only. No internal ticket hosts, no operator names.
+Public GitHub Issue/PR numbers only, on [`CurvineIO/curvine`](https://github.com/CurvineIO/curvine). No internal ticket hosts, no operator names.
 
-### 风险
+### Risks
 
 NO-GO cannot be waived by a green subset. Name unattributed **profiles**. Do not say evidence is node-local or how to fetch logs.
 
-### 后续行动
+### Next actions
 
-`优先级 | 角色 | 行动 | 完成标准` — 角色 is a function (`fuse-owner`, `测试负责人`), never a username.
+`Priority | Role | Action | Done when` — Role is a function (`fuse-owner`, `test-owner`), never a username.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,12 @@ Usage notes:
 <location>project</location>
 </skill>
 
+<skill>
+<name>cv-test-report</name>
+<description>Publish Curvine full-chain daily test reports to the Hextra Hugo site at CurvineIO/test-reports, using a standard Markdown template with no environment or secret leakage. Use when the user asks to publish a test report, convert harness output to Markdown, or update CurvineIO/test-reports.</description>
+<location>project</location>
+</skill>
+
 </available_skills>
 <!-- SKILLS_TABLE_END -->
 


### PR DESCRIPTION
# Summary

Add the `cv-test-report` project skill so agents can publish result-only full-chain reports to the Hextra Hugo site at `CurvineIO/test-reports`.

# Issue Describe / Design

No linked issue. The live site is already on Hextra; this skill records front matter, Markdown render rules, leak scan, and verify steps for that theme.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `.agents/skills/cv-test-report/` | New skill, Hextra template, heading tree | None |
| `AGENTS.md` | Register `cv-test-report` | None |
| `.agents/README.md` | List the new skill | None |
| `.agents/skills/cv-add-skills/SKILL.md` | Add skill to the maintained list | None |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| Registry description matches SKILL.md frontmatter | PASS | |
| `git check-ignore` on skill path | PASS | Skill is tracked |
| Live Hextra site already deployed | PASS | https://curvineio.github.io/test-reports/ |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None