### PR TITLE
docs(skills): strengthen cv-submit-pr-review semantic checks (#1608)

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -41,7 +41,7 @@ rm -rf .claude/skills && ln -sfn ../.agents/skills .claude/skills
 | `cv-create-issue` | File GitHub issue |
 | `cv-handle-issue` | Fix issue (plan first, then code) |
 | `cv-create-pr` | Create / update PR |
-| `cv-submit-pr-review` | Review PR code content (find issues) |
+| `cv-submit-pr-review` | Review PR code: contracts, lifecycle, tests, performance |
 | `cv-address-pr-review` | Handle review comments |
 | `cv-run-workflow` | Dispatch GitHub Actions |
 | `cv-csi-test` | CSI driver integration testing |

--- a/.agents/skills/cv-submit-pr-review/SKILL.md
+++ b/.agents/skills/cv-submit-pr-review/SKILL.md
@@ -23,7 +23,7 @@ Use this skill when the user asks to:
 Review against these, not against generic taste:
 
 * [CONTRIBUTING.md](../../../CONTRIBUTING.md) — Rust style, tests, PR size
-* [.agents/rules/workflow.md](../../../rules/workflow.md) — issue / PR / review process
+* [.agents/rules/workflow.md](../../rules/workflow.md) — issue / PR / review process
 * Public crate contracts: `curvine-fs-api`, `curvine-ufs-api`, `curvine-storage-api`, `curvine-proto`
 * Existing patterns in the dirty crates (callers, lock order, error types)
 * CSI PRs: [cv-csi-test](../cv-csi-test/SKILL.md)

--- a/.agents/skills/cv-submit-pr-review/SKILL.md
+++ b/.agents/skills/cv-submit-pr-review/SKILL.md
@@ -1,51 +1,73 @@
 ---
 name: cv-submit-pr-review
-description: Perform a direct code review of a Curvine PR by reading the diff and changed files, analyzing correctness, safety, design, and performance impact on critical paths (data read/write, RPC message communication, metadata operations), and producing structured findings. Use when user asks to review a PR's code, do a code review, or check a PR before merge.
+description: Perform a direct code review of a Curvine PR against live base/head by mapping dirty crates, reading surrounding code, and checking correctness, safety, lifecycle, interface contracts, test strength, and performance on data I/O, RPC, and metadata paths. Use when user asks to review a PR's code, do a code review, or check a PR before merge.
 ---
 
-# Review PR Workflow
+# cv-submit-pr-review
+
+This skill is **guidance, not a complete checklist**. Verify the PR's live base and exact head, map dirty crates from the changed-file list, then read the diff and enough surrounding code to understand the design. The file list identifies paths and layers; it does not replace semantic review. Re-establish the base and re-read the diff after a retarget or merge.
+
+Prioritize correctness, lifecycle, safety, and broken required behavior over style. A short review with one substantiated blocker is better than a list of nits.
 
 ## When to Use
 
 Use this skill when the user asks to:
 
 * review a PR directly from its code changes
-
 * inspect the current branch PR or a specified PR number
-
 * draft review comments before posting them
-
 * submit drafted PR comments after confirmation
+
+## Sources of truth
+
+Review against these, not against generic taste:
+
+* [CONTRIBUTING.md](../../../CONTRIBUTING.md) — Rust style, tests, PR size
+* [.agents/rules/workflow.md](../../../rules/workflow.md) — issue / PR / review process
+* Public crate contracts: `curvine-fs-api`, `curvine-ufs-api`, `curvine-storage-api`, `curvine-proto`
+* Existing patterns in the dirty crates (callers, lock order, error types)
+* CSI PRs: [cv-csi-test](../cv-csi-test/SKILL.md)
+
+Treat disagreement with an existing design as a **design discussion**, not an automatic veto.
 
 ## Review Scope
 
 Focus **exclusively on code content**:
 
-|Dimension|What to check|
-|:----|:----|
-|Correctness|Logic errors, edge cases, off-by-one, None/null handling, error propagation|
-|Safety|Concurrency races, panics / unwrap in hot paths, unsafe blocks, resource leaks, lock ordering|
-|Design|Naming, module boundaries, abstractions, consistency with existing patterns|
-|Performance|Potential performance impact on critical paths: **data read/write** (block I/O patterns, extra buffer copies, sync/fsync frequency, read amplification), **message communication** (RPC payload size, serialization/deserialization overhead, extra network round trips, connection churn), and **metadata operations** (inode lookup cost, lock granularity and hold time, journal/rocksdb write amplification). Trace hot-path call chains to judge whether the change adds work per request/block/message. Any change likely to cause a significant performance regression **must** generate a comment with concrete improvement suggestions (e.g., batching, caching, avoiding copies, narrowing locks, async-ifying blocking calls).|
+| Dimension | What to check |
+| :---- | :---- |
+| Correctness | Logic errors, edge cases, off-by-one, None/null handling, error propagation |
+| Safety | Concurrency races, panics / unwrap in hot paths, unsafe blocks, resource leaks, lock ordering |
+| Lifecycle | Master/worker/fuse/CSI startup, heartbeat, failover, unmount, detach cleanup, cancellation during awaits |
+| Contracts | Both sides of changed proto/RPC, fs-api, ufs-api, storage-api, JNI/Python SDK; errors, ownership, compatibility |
+| Design | Naming, module boundaries, abstractions, consistency with existing patterns; challenge speculative generality |
+| Tests | Assertions fail on the intended regression; real entry path (client/fuse/CSI/CLI) where the bug lives |
+| Performance | Potential performance impact on critical paths: **data read/write** (block I/O patterns, extra buffer copies, sync/fsync frequency, read amplification), **message communication** (RPC payload size, serialization/deserialization overhead, extra network round trips, connection churn), and **metadata operations** (inode lookup cost, lock granularity and hold time, journal/rocksdb write amplification). Trace hot-path call chains to judge whether the change adds work per request/block/message. Any change likely to cause a significant performance regression **must** generate a comment with concrete improvement suggestions (e.g., batching, caching, avoiding copies, narrowing locks, async-ifying blocking calls). |
 
-**Ignore:** commit message quality, PR description wording, pure formatting nits (run `make format` separately).
+**Ignore:** commit message quality, PR description wording, pure formatting nits (run `make format` separately), and issues already enforced by a green gate (`cargo fmt`, clippy, PR title check, compile CI).
+
+Detailed Curvine-specific probes: [references/manual-checks.md](references/manual-checks.md).
+
+## Blocking requirements
+
+1. **Critical-path performance.** A likely regression on data I/O, RPC, or metadata **must** get a comment with a concrete improvement direction.
+2. **Docs match the code.** Public API, config defaults, proto/wire fields, errors, and user-visible behavior update the owning README/docs/comments in the same diff. Flag implementation narration and duplicated rationale.
+3. **Required evidence exists.** The author ran relevant local checks for the dirty crates (`make format`, targeted `cargo test`), and CI covers compile/test. Review the semantic gaps neither can detect.
+4. **Tests would catch the bug.** New behavior or a regression fix has an assertion that fails on the intended defect. Coverage is necessary but not evidence that the scenario is correct.
+5. **Safety on hot paths.** `unwrap` / panic, `unsafe`, lock-order inversion, leaked FDs/block handles, and incomplete detach cleanup are blockers.
+6. **Wire compatibility.** Breaking proto/RPC/SDK changes are called out with a migration path or an explicit compatibility decision.
 
 ## Communication Rules
 
 * Use English for all PR-facing communication.
-
 * Use concise, professional, actionable review comments.
-
+* State the **defect, location, impact, and evidence**. Place a localized defect inline on the tightest relevant diff range; use a PR-level comment for cross-cutting architecture, scope, or review-wide synthesis.
+* Separate **blockers** from **suggestions**. Omit issues already enforced by a green gate.
 * Do **not** reply to Copilot-generated comments.
-
 * Do **not** post any comment to GitHub until the user explicitly confirms.
-
 * Show drafted comments locally first.
-
 * Execute intermediate local analysis commands directly, including inline `python` / `python3` scripts used to parse API output, inspect diffs, or locate review anchors. Do **not** ask for confirmation for those local scripts.
-
 * Execute read-only GitHub CLI commands directly, including `gh pr view`, `gh pr diff`, and `gh api` GET requests used to inspect PR metadata, diffs, files, comments, or review state. Do **not** ask for confirmation for those read-only `gh` commands.
-
 * Ask for confirmation only before GitHub-side effects such as posting review comments or submitting a review.
 
 ## Step 1: Locate the Target PR
@@ -59,143 +81,156 @@ Otherwise, locate the PR for the current branch:
 ```bash
 git branch --show-current
 ```
-1. Try current-branch PR directly:
+
+2. Try current-branch PR directly:
 
 ```bash
 gh pr view --json number,url,headRefName,baseRefName,title
 ```
-1. If the previous command fails, query by head branch:
+
+3. If the previous command fails, query by head branch:
 
 ```bash
 gh pr list --head "$(git branch --show-current)" --json number,url,headRefName,baseRefName,title --limit 1
 ```
+
 If no PR is found, stop and ask the user whether to create one first.
+
 ## Step 2: Collect PR Context
 
-For PR number `<PR_NUMBER>`, collect:
+For PR number `<PR_NUMBER>`, collect the **live** base and head. Re-run this step after a retarget or merge; do not review a stale diff.
 
-1. PR metadata:
+1. PR metadata (include SHAs):
 
 ```bash
-gh pr view <PR_NUMBER> --json number,url,title,body,headRefName,baseRefName,reviews
+gh pr view <PR_NUMBER> --json number,url,title,body,headRefName,baseRefName,headRefOid,baseRefOid,reviews
 ```
-1. PR diff:
+
+2. PR diff against that head:
 
 ```bash
 gh pr diff <PR_NUMBER>
 ```
-1. Changed files:
+
+3. Changed files:
 
 ```bash
 gh api "repos/{owner}/{repo}/pulls/<PR_NUMBER>/files?per_page=100"
 ```
-1. Existing review comments, only to avoid duplicates:
+
+4. Existing review comments, only to avoid duplicates:
 
 ```bash
 gh api "repos/{owner}/{repo}/pulls/<PR_NUMBER>/comments?per_page=100"
 ```
 
+5. Map **dirty crates / layers** from the file list before reading code. Group paths into:
+
+| Layer | Typical paths |
+| ----- | ------------- |
+| Wire / public API | `crates/common/curvine-proto`, `*-api`, JNI/Python SDK |
+| Server | `curvine-master`, `curvine-worker`, `curvine-raft`, `curvine-rocksdb` |
+| Client / mount | `curvine-client`, `curvine-fuse`, CSI, CLI |
+| Tests / docs / CI | `curvine-tests`, `.github/`, `docs/`, `.agents/` |
+
+The map orients the review; it does not replace reading surrounding code.
 
 For each changed file, read the **full file** (not just the diff hunk) so you understand surrounding code, types, and call sites:
 
-
 1. Read the changed file in full
-
 2. Find callers / definitions of changed symbols (`SearchSymbol`, `Grep`)
-
 3. Check related module knowledge via `SearchMemory` for conventions and patterns
 
-
 Context prevents false positives — a change that looks wrong in isolation may be correct given surrounding code.
-
 
 Ignore comments authored by:
 
 * `Copilot`
-
 * `copilot-pull-request-reviewer[bot]`
 
 Do not review Copilot's review text itself. Review the native PR code content.
 
-
 ## Step 3: Review the Native PR Code
 
-Inspect the actual code changes and look for:
+Inspect the actual code changes using [references/manual-checks.md](references/manual-checks.md). At minimum look for:
 
-* correctness issues
-
-* regressions
-
-* performance regressions in critical paths — analyze whether the change adds overhead to data read/write, RPC message communication, or metadata operations; if the impact is significant, drafting a comment with improvement suggestions is mandatory
-
+* correctness issues and regressions
+* lifecycle / concurrency defects (races, cancellation, incomplete cleanup)
+* interface-contract mismatches (proto, fs-api, SDK both sides)
+* performance regressions in critical paths — if the impact is significant, drafting a comment with improvement suggestions is mandatory
 * missing validation or edge-case handling
-
-* unsafe or brittle logic
-
-* missing or insufficient tests
-
+* unsafe or brittle logic (`unwrap` on hot paths, `unsafe`, lock order)
+* missing or weak tests (assertion would not fail on the intended regression; tests skip the real entry path)
+* public-API expansion with a single internal caller
+* speculative generality or unrelated scope
 * maintainability issues worth commenting on
 
 Only draft comments that are specific and actionable.
 
- Do not manufacture comments just to increase comment count.
+Do not manufacture comments just to increase comment count.
 
 Prefer line-specific comments when possible.
 
- Use a general PR comment only for cross-file or high-level issues.
+Use a general PR comment only for cross-file or high-level issues.
 
 ## Step 4: Build a Local Draft Checklist
 
 Before posting anything, output a local checklist for the user.
 
- This checklist is only for the local chat.
+This checklist is only for the local chat.
 
- Do **not** post this table to GitHub.
+Do **not** post this table to GitHub.
 
 Use this template:
 
 ```markdown
-| draft_id | path | line | category | action | status | summary |
+| draft_id | path | line | severity | action | status | summary |
 |----------|------|------|----------|--------|--------|---------|
-| 1 | src/foo.rs | 42 | must-fix | draft-comment | todo | missing error handling |
+| 1 | src/foo.rs | 42 | blocker | draft-comment | todo | missing error handling on write path |
 | 2 | .github/workflows/build.yml | 88 | suggestion | draft-comment | todo | test failure path is swallowed |
 ```
+
+Severity values:
+
+* `blocker` — correctness, safety, lifecycle, or broken required behavior; would withhold merge
+* `must-fix` — clear defect that should land before merge
+* `suggestion` — optional design / maintainability improvement
+
 Status values:
+
 * `todo`: not drafted yet
-
 * `in-progress`: currently drafting
-
 * `done`: draft ready for user review
-
-* `skipped`: no comment needed
+* `skipped`: no comment needed (including green-gate / duplicate)
 
 ## Step 5: Draft the Review Comments Locally
 
 For each draft comment, include:
 
 * file path
-
 * target line if line-specific
-
+* severity
 * short issue summary
-
 * final English comment text
 
 Comment body requirements:
 
-* state the concrete issue
-
-* explain the impact briefly
-
+* state the concrete defect
+* give location (path / line / call chain)
+* explain impact briefly
+* cite evidence (surrounding code, missing test, both sides of an interface)
 * suggest a fix or direction
-
 * keep it short and professional
 
 Good example:
 
 ```plain
-This path can silently treat a failed test run as success because the step always exits 0 before the final status check. Consider failing immediately here or making the status propagation explicit so the workflow cannot report a false green result.
+This write path drops the RocksDB error and returns Ok, so a failed metadata persist
+can be acknowledged to the client. The call chain is create -> inode::commit ->
+rocks_store.put; a later restart will lose the inode. Propagate the error (or fail
+the RPC) here so the client retries instead of treating the create as durable.
 ```
+
 ## Step 6: Ask for Confirmation Before Posting
 
 After listing the local draft comments, stop and ask the user to confirm.
@@ -206,9 +241,9 @@ Do not submit anything to GitHub until the user explicitly says to proceed.
 
 When submitting GitHub comments from the shell, always pass the review body through a HEREDOC or another shell-safe quoted form. Do **not** embed raw backticks directly inside a double-quoted shell argument, because shell command substitution can corrupt the posted comment text.
 
-### Submit a line review comment
+Use the **current** PR head SHA from Step 2 (`headRefOid`). If the PR moved since the draft, re-collect context and re-anchor comments.
 
-Use the PR head commit SHA from `gh pr view <PR_NUMBER> --json commits` or PR detail metadata.
+### Submit a line review comment
 
 ```bash
 gh api \
@@ -223,6 +258,7 @@ EOF
   -F line=<LINE_NUMBER> \
   -f side='RIGHT'
 ```
+
 ### Submit a general PR review comment
 
 ```bash
@@ -231,41 +267,33 @@ General review comment text here
 EOF
 )"
 ```
+
 Post only the comments the user approved.
+
 ## Filters and Defaults
 
 * Ignore Copilot-generated comments unless the user explicitly asks to review or reply to them.
-
 * Avoid duplicating existing human review comments unless the new comment is materially clearer.
-
 * Prefer fewer high-signal comments over many low-value comments.
-
+* Omit issues already enforced by a green gate.
 * Do not make code changes as part of this workflow unless the user separately asks for fixes.
-
 
 ## Checklist
 
-- [ ]  PR located and diff collected
-
-- [ ]  Changed files read in full (not just hunks)
-
-- [ ]  Callers / definitions of changed symbols checked
-
-- [ ]  Module conventions verified (knowledge cards / existing patterns)
-
-- [ ]  Performance impact assessed for data read/write, RPC message communication, and metadata paths; significant regressions have mandatory comments with suggestions
-
-- [ ]  Findings table produced with severity per item
-
-- [ ]  User decided on next action (fix / post / discuss)
-
-- [ ]  Review posted only after explicit approval
+- [ ] Live base/head verified (re-checked after retarget or merge)
+- [ ] Dirty crates / layers mapped from the file list
+- [ ] Changed files read in full (not just hunks)
+- [ ] Callers / definitions of changed symbols checked
+- [ ] Module conventions verified (sources of truth / existing patterns)
+- [ ] Manual checks applied for contracts, lifecycle, consumer fit, test strength
+- [ ] Performance impact assessed for data read/write, RPC, and metadata paths; significant regressions have mandatory comments with suggestions
+- [ ] Findings table produced with severity (`blocker` / `must-fix` / `suggestion`)
+- [ ] User decided on next action (fix / post / discuss)
+- [ ] Review posted only after explicit approval
 
 ## Related
 
 * Handle existing reviewer comments → [cv-address-pr-review](../cv-address-pr-review/SKILL.md)
-
 * Fix findings and update PR → [cv-create-pr](../cv-create-pr/SKILL.md)
-
 * Review during issue fix → [cv-handle-issue](../cv-handle-issue/SKILL.md)
-
+* CSI-specific scenarios → [cv-csi-test](../cv-csi-test/SKILL.md)

--- a/.agents/skills/cv-submit-pr-review/references/manual-checks.md
+++ b/.agents/skills/cv-submit-pr-review/references/manual-checks.md
@@ -1,0 +1,69 @@
+# Manual review checks (Curvine)
+
+Use these probes after mapping dirty crates. They cover defects that a green CI gate and a hunk-only diff will miss. Skip checks that do not apply to the dirty layer.
+
+## Intent and interface contracts
+
+Trace **both sides** of every changed interface:
+
+* proto RPC request/response and error codes (`curvine-proto` ↔ master/worker/client)
+* `curvine-fs-api` / `curvine-ufs-api` / `curvine-storage-api` trait changes
+* JNI / Python SDK exports vs Rust implementation
+
+Confirm the implementation matches the PR intent, including errors, cancellation, ownership, and cleanup. A default that changed on one side only is a contract bug.
+
+## Lifecycle and concurrency
+
+For async setup, heartbeats, callbacks, FUSE requests, CSI MountPod, or teardown:
+
+* races before publishing state (inode visible before data durable, replica advertised before written)
+* cancellation / timeout during awaits
+* lock ordering and hold time (especially metadata + block maps)
+* complete detach cleanup (FUSE OFD locks, block handles, RocksDB snapshots, connections)
+* failover and restart: applied Raft index, worker heartbeat, client handshake/version fallback
+
+## Consumer fit and API surface
+
+Trace every current consumer of a changed public item. Flag:
+
+* consumer-specific behavior leaking into a shared API crate
+* the inverse: a new public method on `fs-api` / `ufs-api` / `storage-api` / proto whose only caller is one internal crate — prefer a private helper instead of expanding the public surface
+
+## Scope, ownership, and necessity
+
+Map each new abstraction, state machine, config option, defensive copy, and compatibility path to a **current** contract and production consumer. Challenge unrelated features and speculative generality ("we might need this later"). Keep the PR focused.
+
+## Configuration and public choices
+
+Ask what current-consumer evidence or prior art supports each new default, public operation, wire format, or imported external concept. Require an explicit choice or deferral when that evidence is absent. Silent default changes on heartbeat, replica, timeout, or cache policy are high-impact.
+
+## Enforcement
+
+Follow every denial path (ACL, quota, auth, path validation, set-id stripping) to the operation that executes it. Check alternate callers that can bypass a facade (direct master RPC, FUSE setattr bits, CLI, SDK).
+
+## Borrowed vs owned state
+
+Determine whether each retained value is borrowed or owned under the crate contract, then trace caches, metrics, listings, and query views to the authoritative source:
+
+* buffers and slices that outlive the read
+* block replica locations vs actual worker state
+* inode views vs journal/RocksDB
+* Raft applied index vs snapshot
+
+Stale cache after the owner mutated is a correctness bug, not a nit.
+
+## Bounds cover the final operation
+
+Locate the owner of the complete emitted or retained result, including wrappers and metadata. Probe tiny, exact, and oversized limits: block size, packet size, path length (including multibyte), proto message size, replica count.
+
+## Real entry path
+
+Tests should exercise the shipped client, FUSE, CSI, CLI, or worker where the bug lives. A unit test of an internal helper does not catch a broken proto default, JNI export, or MountPod mount option. CSI changes: follow [cv-csi-test](../../cv-csi-test/SKILL.md).
+
+## Test strength
+
+Assertions must fail on the intended regression and verify external state (file contents, RPC error, metrics, logs, disposal) rather than restating the implementation. Coverage is not evidence that the scenario is correct. Prefer a negative control: a deliberately invalid case fails through the real path.
+
+## Compatibility and versioning
+
+Heartbeat / handshake version fields, proto evolution, Java/Python SDK parity, and legacy fallback belong in the same review as the server change. A server that understands a new field while old clients break (or the reverse) is a blocker unless the PR documents a rollout.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ Usage notes:
 
 <skill>
 <name>cv-submit-pr-review</name>
-<description>Perform a direct code review of a Curvine PR by reading the diff and changed files, analyzing correctness, safety, design, and performance impact on critical paths (data read/write, RPC message communication, metadata operations), and producing structured findings. Use when user asks to review a PR's code, do a code review, or check a PR before merge.</description>
+<description>Perform a direct code review of a Curvine PR against live base/head by mapping dirty crates, reading surrounding code, and checking correctness, safety, lifecycle, interface contracts, test strength, and performance on data I/O, RPC, and metadata paths. Use when user asks to review a PR's code, do a code review, or check a PR before merge.</description>
 <location>project</location>
 </skill>
 


### PR DESCRIPTION
# Summary

Strengthen `cv-submit-pr-review` with DeepSeek-style semantic review guidance, adapted to Curvine. Reviews now verify live base/head, map dirty crates, and check contracts, lifecycle, test strength, and blocker vs nit — without changing the confirm-before-post workflow.

# Issue Describe / Design

Closes #1608

Source of absorbed practices: [dsh-code-review](https://github.com/deepseek-ai/deepseek-harness/blob/master/.agents/skills/dsh-code-review/SKILL.md)

**Design decisions and trade-offs:**
- Absorbed principles that transfer: guidance-not-checklist, live base/head, sources of truth, blocking requirements, both-sides interface tracing, lifecycle, consumer-fit/API surface, test strength, omit green-gate nits, defect+impact+evidence reporting, severity split.
- Did **not** copy DeepSeek-Harness-specific machinery: Agent Notes, type-equiv catalogs, pnpm `change-scope`, bilingual translation, plugin Loader/HMR, JSDoc prose gates.
- Kept SKILL.md as the workflow; moved long Curvine-specific probes to `references/manual-checks.md` so the skill stays loadable.
- Preserved existing Curvine strengths: performance dimensions (data I/O, RPC, metadata), Copilot ignore, local draft table, HEREDOC posting, user confirmation before GitHub side effects.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `.agents/skills/cv-submit-pr-review/SKILL.md` | Principles, sources of truth, blocking requirements, dirty-crate map, severity column, richer comment template | Reviewer agents follow a stricter semantic bar; posting still requires explicit user approval |
| `.agents/skills/cv-submit-pr-review/references/manual-checks.md` | Curvine-specific probes (RPC both sides, FUSE/CSI lifecycle, borrowed vs owned, bounds, real entry path) | None for runtime; loaded on demand during review |
| `AGENTS.md` | Sync skill `description` | Agent skill discovery text only |
| `.agents/README.md` | One-line skill summary | Docs only |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `git check-ignore` on new skill files | PASS | Files are tracked (`cv-*` exception) |
| Frontmatter `name` matches directory | PASS | `cv-submit-pr-review` |
| `AGENTS.md` description matches SKILL.md | PASS | Synced |
| Existing workflow preserved (locate, draft locally, confirm, HEREDOC) | PASS | Manual review of SKILL.md |
| `make format` | SKIP | Markdown-only change; full `make format` compiles the Rust workspace and is not needed |

# Dependencies

- Related PRs: None
- Related issues: #1608
- Blocks / blocked by: None

Made with [Cursor](https://cursor.com)