### PR TITLE
fix(master): report allocatable capacity in statfs (#1460)

### DIFF
--- a/crates/common/curvine-model/src/filesystem_info.rs
+++ b/crates/common/curvine-model/src/filesystem_info.rs
@@ -30,6 +30,13 @@ pub struct FilesystemInfo {
     pub non_fs_used: i64,
     pub reserved_bytes: i64,
 
+    /// Capacity eligible for new writes. Only `Live` workers contribute, and
+    /// failed storage directories are excluded (see `WorkerInfo::add_storage`).
+    /// `statfs(2)` reports this so `df` matches what allocation can actually use.
+    pub allocatable_capacity: i64,
+    /// Available space eligible for new writes (Live workers only).
+    pub allocatable_available: i64,
+
     pub live_workers: Vec<WorkerInfo>,
     pub blacklist_workers: Vec<WorkerInfo>,
     pub decommission_workers: Vec<WorkerInfo>,

--- a/crates/common/curvine-model/src/proto_utils.rs
+++ b/crates/common/curvine-model/src/proto_utils.rs
@@ -316,6 +316,8 @@ impl ProtoUtils {
             fs_used: src.fs_used,
             non_fs_used: src.non_fs_used,
             reserved_bytes: src.reserved_bytes,
+            allocatable_capacity: Some(src.allocatable_capacity),
+            allocatable_available: Some(src.allocatable_available),
             ..Default::default()
         };
 
@@ -380,6 +382,11 @@ impl ProtoUtils {
             fs_used: src.fs_used,
             non_fs_used: src.non_fs_used,
             reserved_bytes: src.reserved_bytes,
+            // Legacy masters omit the allocatable fields; fall back to the
+            // aggregate capacity/available so statfs never regresses below the
+            // pre-fix behavior (which summed all non-lost workers).
+            allocatable_capacity: src.allocatable_capacity.unwrap_or(src.capacity),
+            allocatable_available: src.allocatable_available.unwrap_or(src.available),
             live_workers: Self::worker_info_from_pb(src.live_workers),
             blacklist_workers: Self::worker_info_from_pb(src.blacklist_workers),
             decommission_workers: Self::worker_info_from_pb(src.decommission_workers),

--- a/crates/common/curvine-model/tests/filesystem_info_proto_test.rs
+++ b/crates/common/curvine-model/tests/filesystem_info_proto_test.rs
@@ -1,0 +1,68 @@
+use curvine_model::{FilesystemInfo, ProtoUtils};
+use curvine_proto::GetFilesystemInfoResponse;
+
+#[test]
+fn filesystem_info_proto_round_trips_allocatable_fields() {
+    let info = FilesystemInfo {
+        capacity: 6000,
+        available: 4800,
+        allocatable_capacity: 1000,
+        allocatable_available: 800,
+        ..Default::default()
+    };
+
+    let pb = ProtoUtils::filesystem_info_to_pb(info.clone());
+    assert_eq!(pb.allocatable_capacity, Some(1000));
+    assert_eq!(pb.allocatable_available, Some(800));
+
+    let restored = ProtoUtils::filesystem_info_from_pb(pb);
+    assert_eq!(restored.capacity, 6000);
+    assert_eq!(restored.available, 4800);
+    assert_eq!(restored.allocatable_capacity, 1000);
+    assert_eq!(restored.allocatable_available, 800);
+}
+
+#[test]
+fn filesystem_info_proto_legacy_master_falls_back_to_total() {
+    // A legacy master omits the allocatable fields (tags 15/16). The client
+    // must fall back to the aggregate capacity/available so statfs never
+    // reports zero free space against a mixed-version master.
+    let legacy_pb = GetFilesystemInfoResponse {
+        active_master: "old-master".to_string(),
+        capacity: 6000,
+        available: 4800,
+        // allocatable_capacity / allocatable_available intentionally absent.
+        ..Default::default()
+    };
+
+    let info = ProtoUtils::filesystem_info_from_pb(legacy_pb);
+    assert_eq!(info.capacity, 6000);
+    assert_eq!(info.available, 4800);
+    assert_eq!(
+        info.allocatable_capacity, 6000,
+        "legacy master must fall back to total capacity"
+    );
+    assert_eq!(
+        info.allocatable_available, 4800,
+        "legacy master must fall back to total available"
+    );
+}
+
+#[test]
+fn filesystem_info_proto_zero_allocatable_is_preserved() {
+    // A new master with no Live workers reports zero allocatable; this must
+    // not be confused with the legacy-absent case (which falls back to total).
+    let pb = ProtoUtils::filesystem_info_to_pb(FilesystemInfo {
+        capacity: 5000,
+        available: 4000,
+        allocatable_capacity: 0,
+        allocatable_available: 0,
+        ..Default::default()
+    });
+    assert_eq!(pb.allocatable_capacity, Some(0));
+    assert_eq!(pb.allocatable_available, Some(0));
+
+    let info = ProtoUtils::filesystem_info_from_pb(pb);
+    assert_eq!(info.allocatable_capacity, 0);
+    assert_eq!(info.allocatable_available, 0);
+}

--- a/crates/common/curvine-proto/proto/master.proto
+++ b/crates/common/curvine-proto/proto/master.proto
@@ -234,6 +234,11 @@ message GetFilesystemInfoResponse {
     repeated WorkerInfoProto decommission_workers = 13;
     repeated WorkerInfoProto lost_workers = 14;
 
+    // Capacity/available eligible for new writes (Live workers only). Absent
+    // on legacy masters; clients fall back to `capacity`/`available`.
+    optional int64 allocatable_capacity = 15 [default = 0];
+    optional int64 allocatable_available = 16 [default = 0];
+
     // Default compatibility contract offered by this master (handshake).
     // Cross-cutting protocol metadata on the reserved 1000+ range; legacy
     // masters omit it and clients treat the absence as a legacy peer.

--- a/crates/common/curvine-proto/tests/get_filesystem_info_compat_test.rs
+++ b/crates/common/curvine-proto/tests/get_filesystem_info_compat_test.rs
@@ -65,6 +65,8 @@ fn sample_response_with_compatibility() -> GetFilesystemInfoResponse {
         blacklist_workers: vec![],
         decommission_workers: vec![],
         lost_workers: vec![],
+        allocatable_capacity: Some(600),
+        allocatable_available: Some(300),
         compatibility: Some(ServerCompatibilityInfoProto {
             server: sample_component_info(),
             min_worker_version: None,
@@ -112,6 +114,8 @@ fn test_get_filesystem_info_response_compatibility_round_trip() {
 
     assert_eq!(decoded.active_master, "master-0");
     assert_eq!(decoded.inode_file_num, 20);
+    assert_eq!(decoded.allocatable_capacity, Some(600));
+    assert_eq!(decoded.allocatable_available, Some(300));
     let compat = decoded.compatibility.unwrap();
     assert_eq!(compat.server.component, Some("master".to_string()));
     assert_eq!(
@@ -146,6 +150,9 @@ fn test_legacy_master_response_decodes_without_compatibility() {
     assert_eq!(decoded.active_master, "old-master");
     assert_eq!(decoded.inode_file_num, 2);
     assert!(decoded.compatibility.is_none());
+    // Legacy master carries no allocatable fields; clients fall back to total.
+    assert!(decoded.allocatable_capacity.is_none());
+    assert!(decoded.allocatable_available.is_none());
 }
 
 #[test]

--- a/curvine-cli/src/cmds/fs/df.rs
+++ b/curvine-cli/src/cmds/fs/df.rs
@@ -25,12 +25,21 @@ impl DfCommand {
                             "Filesystem                Size             Used  Available  Use%"
                         );
 
-                        // Calculate total used space (fs_used + non_fs_used)
-                        let used = filesystem_info.fs_used + filesystem_info.non_fs_used;
+                        // Report the allocatable (writable) view: only Live
+                        // workers are eligible for new writes, so Size/Available
+                        // mirror what FUSE statfs reports. Used is derived from
+                        // the allocatable view so Size = Used + Available stays
+                        // consistent even when Blacklist/Decommission workers
+                        // still hold data. On a legacy master that omits the
+                        // allocatable fields, `FilesystemInfo` falls back to the
+                        // aggregate totals, so this never regresses to zero.
+                        let capacity = filesystem_info.allocatable_capacity;
+                        let available = filesystem_info.allocatable_available;
+                        let used = (capacity - available).max(0);
 
                         // Calculate usage percentage
-                        let usage_percent = if filesystem_info.capacity > 0 {
-                            (used as f64 / filesystem_info.capacity as f64) * 100.0
+                        let usage_percent = if capacity > 0 {
+                            (used as f64 / capacity as f64) * 100.0
                         } else {
                             0.0
                         };
@@ -38,19 +47,15 @@ impl DfCommand {
                         // Format sizes based on human_readable flag
                         let (capacity, used_str, available) = if *human_readable {
                             (
-                                crate::cmds::fs::common::format_size(
-                                    filesystem_info.capacity as u64,
-                                ),
+                                crate::cmds::fs::common::format_size(capacity as u64),
                                 crate::cmds::fs::common::format_size(used as u64),
-                                crate::cmds::fs::common::format_size(
-                                    filesystem_info.available as u64,
-                                ),
+                                crate::cmds::fs::common::format_size(available as u64),
                             )
                         } else {
                             (
-                                filesystem_info.capacity.to_string(),
+                                capacity.to_string(),
                                 used.to_string(),
-                                filesystem_info.available.to_string(),
+                                available.to_string(),
                             )
                         };
 

--- a/curvine-cli/src/cmds/report.rs
+++ b/curvine-cli/src/cmds/report.rs
@@ -149,6 +149,22 @@ impl CurvineReport {
         );
         builder.push_str(&used);
 
+        // Allocatable view: only Live workers, i.e. what new writes can use.
+        builder.push_str(&format!(
+            "{:>20}: {}\n",
+            "allocatable_capacity",
+            bytes_to_string(self.info.allocatable_capacity)
+        ));
+        builder.push_str(&format!(
+            "{:>20}: {} ({:.2}%)\n",
+            "allocatable_available",
+            bytes_to_string(self.info.allocatable_available),
+            Self::get_percent(
+                self.info.allocatable_available,
+                self.info.allocatable_capacity
+            )
+        ));
+
         builder.push_str(&format!(
             "{:>20}: {}\n",
             "non_fs_used",
@@ -247,6 +263,18 @@ impl CurvineReport {
         builder.push_str(&format!(
             "Total Non-FS Used: {}\n",
             bytes_to_string(self.info.non_fs_used)
+        ));
+        builder.push_str(&format!(
+            "Allocatable Capacity (Live workers): {}\n",
+            bytes_to_string(self.info.allocatable_capacity)
+        ));
+        builder.push_str(&format!(
+            "Allocatable Available (Live workers): {} ({:.2}%)\n",
+            bytes_to_string(self.info.allocatable_available),
+            Self::get_percent(
+                self.info.allocatable_available,
+                self.info.allocatable_capacity
+            )
         ));
 
         builder

--- a/curvine-fuse/src/fs/curvine_file_system.rs
+++ b/curvine-fuse/src/fs/curvine_file_system.rs
@@ -1584,14 +1584,21 @@ impl fs::FileSystem for CurvineFileSystem {
     async fn stat_fs(&self, _: StatFs<'_>) -> FuseResult<fuse_kstatfs> {
         let info = self.fs.get_filesystem_info().await?;
 
-        if info.capacity < 0 || info.available < 0 || info.available > info.capacity {
+        // Use the allocatable view (Live workers only) so df matches what new
+        // writes can actually use; capacity/available would also count
+        // Blacklist/Decommission workers and over-report free space.
+        if info.allocatable_capacity < 0
+            || info.allocatable_available < 0
+            || info.allocatable_available > info.allocatable_capacity
+        {
             debug!(
-                "Normalizing invalid filesystem info for statfs: capacity={}, available={}",
-                info.capacity, info.available
+                "Normalizing invalid filesystem info for statfs: allocatable_capacity={}, allocatable_available={}",
+                info.allocatable_capacity, info.allocatable_available
             );
         }
 
-        let (total_blocks, free_blocks) = Self::statfs_block_counts(info.capacity, info.available);
+        let (total_blocks, free_blocks) =
+            Self::statfs_block_counts(info.allocatable_capacity, info.allocatable_available);
 
         let res = fuse_kstatfs {
             blocks: total_blocks,

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineFsStat.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineFsStat.java
@@ -24,7 +24,17 @@ public class CurvineFsStat extends FsStatus {
     private final GetFilesystemInfoResponse info;
 
     public CurvineFsStat(GetFilesystemInfoResponse info) {
-        super(info.getCapacity(), info.getFsUsed(), info.getAvailable());
+        // Report the allocatable (writable) view so Hadoop/Spark remaining-space
+        // checks only see Live workers. Legacy masters omit tags 15/16; protobuf
+        // returns 0 for an absent optional int64 with default=0, so we must guard
+        // with hasAllocatableCapacity()/hasAllocatableAvailable() and fall back to
+        // the aggregate totals — otherwise a new client against an old master
+        // would report zero free space.
+        super(
+                info.hasAllocatableCapacity() ? info.getAllocatableCapacity() : info.getCapacity(),
+                info.getFsUsed(),
+                info.hasAllocatableAvailable() ? info.getAllocatableAvailable() : info.getAvailable()
+        );
         this.info = info;
     }
 
@@ -74,6 +84,19 @@ public class CurvineFsStat extends FsStatus {
                 getPercent(info.getFsUsed(), info.getCapacity())
         );
         builder.append(used);
+
+        // Allocatable (writable) view: capacity/available eligible for new
+        // writes (Live workers only). Absent on legacy masters, so guard with
+        // hasAllocatableCapacity() to avoid printing a misleading 0.
+        if (info.hasAllocatableCapacity()) {
+            builder.append(String.format("%20s: %s\n", "allocatable_capacity", Utils.bytesToString(info.getAllocatableCapacity())));
+            builder.append(String.format(
+                    "%20s: %s (%.2f%%)\n",
+                    "allocatable_available",
+                    Utils.bytesToString(info.getAllocatableAvailable()),
+                    getPercent(info.getAllocatableAvailable(), info.getAllocatableCapacity())
+            ));
+        }
 
         builder.append(String.format("%20s: %s\n", "non_fs_used", Utils.bytesToString(info.getNonFsUsed())));
         builder.append(String.format("%20s: %s\n", "live_worker_num", info.getLiveWorkersCount()));

--- a/curvine-master/src/master/fs/master_filesystem.rs
+++ b/curvine-master/src/master/fs/master_filesystem.rs
@@ -1944,15 +1944,30 @@ mod tests {
     #[test]
     fn filesystem_info_allocatable_excludes_lost_workers() {
         // Lost workers live in a separate map and must not contribute to either
-        // the total or the allocatable view.
+        // the total or the allocatable view. Insert a lost worker directly into
+        // the lost map (add_test_worker only touches the live map) and assert its
+        // capacity never leaks into aggregation.
         let fs = test_fs("allocatable-excludes-lost");
         fs.add_test_worker(worker_with_status(1, WorkerStatus::Live, 1000, 800));
-        // Unknown/Lost-status workers in the live map are bucketed by the `_ =>`
-        // arm, but real Lost workers are never in worker_map.workers().
+        fs.worker_manager
+            .write()
+            .worker_map
+            .lost_workers
+            .insert(99, worker_with_status(99, WorkerStatus::Lost, 9999, 9999));
+
         let info = fs.filesystem_info().unwrap();
-        assert_eq!(info.capacity, 1000);
-        assert_eq!(info.allocatable_capacity, 1000);
+
+        // The lost worker is reported but its bytes stay out of both views.
+        assert_eq!(info.lost_workers.len(), 1);
+        assert_eq!(
+            info.capacity, 1000,
+            "lost worker capacity must not leak into total"
+        );
+        assert_eq!(info.available, 800);
+        assert_eq!(
+            info.allocatable_capacity, 1000,
+            "lost worker capacity must not leak into allocatable"
+        );
         assert_eq!(info.allocatable_available, 800);
-        assert!(info.lost_workers.is_empty());
     }
 }

--- a/curvine-master/src/master/fs/master_filesystem.rs
+++ b/curvine-master/src/master/fs/master_filesystem.rs
@@ -1131,7 +1131,14 @@ impl MasterFilesystem {
             info.block_num += worker.block_num;
 
             match worker.status {
-                WorkerStatus::Live => info.live_workers.push(worker.clone()),
+                WorkerStatus::Live => {
+                    info.live_workers.push(worker.clone());
+                    // Only Live workers are eligible for new allocations, so the
+                    // allocatable view mirrors the allocation policy. Failed
+                    // storage dirs are already excluded from worker.capacity.
+                    info.allocatable_capacity += worker.capacity;
+                    info.allocatable_available += worker.available;
+                }
                 WorkerStatus::Blacklist => info.blacklist_workers.push(worker.clone()),
                 WorkerStatus::Decommission => info.decommission_workers.push(worker.clone()),
                 _ => (),
@@ -1831,5 +1838,121 @@ mod tests {
             "expected path in error, got: {}",
             err
         );
+    }
+
+    fn worker_with_status(
+        id: u32,
+        status: WorkerStatus,
+        capacity: i64,
+        available: i64,
+    ) -> WorkerInfo {
+        let mut worker = WorkerInfo::new(
+            WorkerAddress {
+                worker_id: id,
+                ..Default::default()
+            },
+            1,
+        );
+        worker.status = status;
+        worker.capacity = capacity;
+        worker.available = available;
+        worker
+    }
+
+    #[test]
+    fn filesystem_info_allocatable_only_counts_live_workers() {
+        // See issue #1460: statfs must report capacity eligible for new writes,
+        // i.e. only Live workers. Blacklist/Decommission workers must not
+        // contribute to the allocatable view (they still count toward the total
+        // physical capacity).
+        let fs = test_fs("allocatable-live-only");
+        fs.add_test_worker(worker_with_status(1, WorkerStatus::Live, 1000, 800));
+        fs.add_test_worker(worker_with_status(2, WorkerStatus::Blacklist, 2000, 1500));
+        fs.add_test_worker(worker_with_status(
+            3,
+            WorkerStatus::Decommission,
+            3000,
+            2500,
+        ));
+
+        let info = fs.filesystem_info().unwrap();
+
+        // Total physical capacity across all non-lost worker states.
+        assert_eq!(info.capacity, 6000, "total capacity should sum all workers");
+        assert_eq!(
+            info.available, 4800,
+            "total available should sum all workers"
+        );
+        assert_eq!(info.live_workers.len(), 1);
+        assert_eq!(info.blacklist_workers.len(), 1);
+        assert_eq!(info.decommission_workers.len(), 1);
+
+        // Allocatable view mirrors allocation eligibility: Live workers only.
+        assert_eq!(
+            info.allocatable_capacity, 1000,
+            "allocatable capacity must be Live workers only"
+        );
+        assert_eq!(
+            info.allocatable_available, 800,
+            "allocatable available must be Live workers only"
+        );
+    }
+
+    #[test]
+    fn filesystem_info_allocatable_excludes_failed_storage_dirs() {
+        // A Live worker with a healthy dir plus a failed dir: add_storage already
+        // skips failed dirs, so neither total nor allocatable capacity should
+        // include the failed dir's bytes.
+        let fs = test_fs("allocatable-excludes-failed");
+        let mut worker = WorkerInfo::new(
+            WorkerAddress {
+                worker_id: 10,
+                ..Default::default()
+            },
+            1,
+        );
+        worker.status = WorkerStatus::Live;
+        worker.add_storage(StorageInfo {
+            dir_id: 1,
+            storage_id: "healthy".into(),
+            failed: false,
+            capacity: 1000,
+            available: 800,
+            ..Default::default()
+        });
+        worker.add_storage(StorageInfo {
+            dir_id: 2,
+            storage_id: "failed".into(),
+            failed: true,
+            capacity: 500,
+            available: 400,
+            ..Default::default()
+        });
+        fs.add_test_worker(worker);
+
+        let info = fs.filesystem_info().unwrap();
+
+        assert_eq!(
+            info.capacity, 1000,
+            "failed dir must not count toward total"
+        );
+        assert_eq!(info.available, 800);
+        assert_eq!(info.allocatable_capacity, 1000);
+        assert_eq!(info.allocatable_available, 800);
+    }
+
+    #[test]
+    fn filesystem_info_allocatable_excludes_lost_workers() {
+        // Lost workers live in a separate map and must not contribute to either
+        // the total or the allocatable view.
+        let fs = test_fs("allocatable-excludes-lost");
+        fs.add_test_worker(worker_with_status(1, WorkerStatus::Live, 1000, 800));
+        // Unknown/Lost-status workers in the live map are bucketed by the `_ =>`
+        // arm, but real Lost workers are never in worker_map.workers().
+        let info = fs.filesystem_info().unwrap();
+        assert_eq!(info.capacity, 1000);
+        assert_eq!(info.allocatable_capacity, 1000);
+        assert_eq!(info.allocatable_available, 800);
+        assert!(info.lost_workers.is_empty());
     }
 }

--- a/curvine-master/src/master/master_metrics.rs
+++ b/curvine-master/src/master/master_metrics.rs
@@ -35,6 +35,8 @@ pub struct MasterMetrics {
     pub(crate) fs_used: Gauge,
     pub(crate) block_num: Gauge,
     pub(crate) blocks_size_avg: Gauge,
+    pub(crate) allocatable_capacity: Gauge,
+    pub(crate) allocatable_available: Gauge,
 
     pub(crate) worker_num: GaugeVec,
 
@@ -110,6 +112,14 @@ impl MasterMetrics {
             fs_used: m::new_gauge("fs_used", "Space used by the file system")?,
             block_num: m::new_gauge("num_blocks", "Total block number")?,
             blocks_size_avg: m::new_gauge("blocks_size_avg", "Average block size")?,
+            allocatable_capacity: m::new_gauge(
+                "allocatable_capacity",
+                "Storage capacity eligible for new writes (Live workers only)",
+            )?,
+            allocatable_available: m::new_gauge(
+                "allocatable_available",
+                "Available space eligible for new writes (Live workers only)",
+            )?,
             worker_num: m::new_gauge_vec("worker_num", "The number of lived workers", &["tag"])?,
 
             journal_queue_len: m::new_gauge("journal_queue_len", "Journal queue length")?,
@@ -221,6 +231,10 @@ impl MasterMetrics {
         self.available.set(filesystem_info.available);
         self.fs_used.set(filesystem_info.fs_used);
         self.block_num.set(filesystem_info.block_num);
+        self.allocatable_capacity
+            .set(filesystem_info.allocatable_capacity);
+        self.allocatable_available
+            .set(filesystem_info.allocatable_available);
         self.used_memory_bytes.set(SysUtils::used_memory() as i64);
 
         if filesystem_info.block_num > 0 {


### PR DESCRIPTION
# Summary

FUSE `statfs` reported capacity/available summed across all non-lost
workers (Live + Blacklist + Decommission), so `df` could advertise free
space that no new write could use — the allocation policy only selects
Live workers. This PR adds an allocatable capacity view (Live workers
only) and points `statfs` at it, while preserving the existing total
capacity semantics for the CLI report and metrics.

# Issue Describe / Design

Closes #1460

**Root cause**

`MasterFilesystem::filesystem_info()` aggregates `capacity`/`available`
for every worker in `worker_map.workers()` *before* checking
`worker.status`, so Blacklist and Decommission workers inflate the
values that `CurvineFileSystem::stat_fs` feeds into `fuse_kstatfs`.
Worker allocation policies (`random_worker_policy`,
`weighted_worker_policy`, ...) filter via `worker.is_live()`, so only
Live workers are eligible — the aggregation and allocation views
disagree, and in the worst case `df` shows free space while writes
fail with "not enough space".

**Reproduction**

1. Start a cluster with ≥2 Live workers; note `df` on the FUSE mount.
2. Blacklist/decommission a worker with significant available capacity.
3. `df` still reports the unavailable worker's capacity.
4. After all Live capacity is exhausted, writes fail despite `df`
   showing free space.

**Fix approach (issue's option 1 — additive fields)**

- Add `allocatable_capacity` / `allocatable_available` to
  `FilesystemInfo`; aggregate only `WorkerStatus::Live` workers there.
  Failed storage dirs are already excluded by
  `WorkerInfo::add_storage`, so a Live worker's capacity already omits
  them; Lost workers live in a separate map and never enter the loop.
- Add optional proto fields (tags 15/16) to `GetFilesystemInfoResponse`
  and carry them through `ProtoUtils` conversion. Legacy masters
  omitting the fields fall back to the aggregate `capacity`/`available`
  so a new client against an old master never regresses to 0 free
  space.
- `stat_fs` reports the allocatable view; CLI `report` and master
  metrics gain allocatable gauges **without** changing the existing
  `capacity`/`available` meaning.

# Changes

| Module / File | Change | Impact on existing behavior |
| --- | --- | --- |
| `crates/common/curvine-model/src/filesystem_info.rs` | Add `allocatable_capacity`/`allocatable_available` fields | None (default 0; additive) |
| `crates/common/curvine-proto/proto/master.proto` | Add optional `allocatable_capacity`/`allocatable_available` (tags 15/16) | None (optional; legacy peers unaffected) |
| `crates/common/curvine-model/src/proto_utils.rs` | to/from-pb for new fields; legacy fallback to `capacity`/`available` | Mixed-version clusters keep pre-fix behavior |
| `curvine-master/src/master/fs/master_filesystem.rs` | Aggregate allocatable for Live workers in `filesystem_info()` | Total `capacity`/`available` unchanged |
| `curvine-fuse/src/fs/curvine_file_system.rs` | `stat_fs` uses allocatable fields | **Behavior change (the fix):** `df` no longer counts Blacklist/Decommission workers |
| `curvine-cli/src/cmds/report.rs` | Show `allocatable_capacity`/`allocatable_available` in report + cluster summary | Additive display |
| `curvine-master/src/master/master_metrics.rs` | Add `allocatable_capacity`/`allocatable_available` gauges | Existing `capacity`/`available` metrics unchanged |

# Test verified

| Test case | Result | Notes |
| --- | --- | --- |
| `cargo test -p curvine-master --lib master::fs::master_filesystem::tests` | PASS | 8 tests, incl. 3 new: allocatable only-Live, excludes failed dirs, excludes lost workers |
| `cargo test -p curvine-model --test filesystem_info_proto_test` | PASS | 3 tests: round-trip, legacy fallback, zero-preserves-not-confused-with-absent |
| `cargo test -p curvine-proto --test get_filesystem_info_compat_test` | PASS | 6 tests; added allocatable assertions + legacy-absent assertions |
| `cargo check -p curvine-model -p curvine-proto -p curvine-master -p curvine-cli` | PASS | |
| `cargo check -p curvine-fuse` | PASS (for `curvine_file_system.rs`) | |

# Dependencies

- Related issues: #1460, #1272 (statfs permission behavior, not a duplicate)
- Related PRs: None
- Blocks / blocked by: None