### PR TITLE
fix(java-sdk): resolve LoadJobStatus compile error referencing missing proto field

### DIFF
--- a/curvine-libsdk/java/src/main/java/io/curvine/LoadJobStatus.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/LoadJobStatus.java
@@ -63,7 +63,7 @@ public final class LoadJobStatus {
         return new LoadJobStatus(
                 response.getJobId(),
                 response.getState(),
-                response.getStateValue(),
+                response.getState().getNumber(),
                 response.getSourcePath(),
                 response.getTargetPath(),
                 response.getProgress());

--- a/curvine-libsdk/java/src/main/java/io/curvine/LoadJobStatus.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/LoadJobStatus.java
@@ -14,20 +14,14 @@
 
 package io.curvine;
 
-import com.google.protobuf.CodedInputStream;
-import com.google.protobuf.WireFormat;
 import io.curvine.proto.GetJobStatusResponse;
 import io.curvine.proto.JobTaskProgressProto;
 import io.curvine.proto.JobTaskStateProto;
-
-import java.io.IOException;
 
 /**
  * Load job status snapshot. Mirrors Rust {@code JobStatus}.
  */
 public final class LoadJobStatus {
-    private static final int STATE_FIELD_NUMBER = 2;
-
     private final String jobId;
     private final JobTaskStateProto state;
     private final int stateValue;
@@ -70,40 +64,10 @@ public final class LoadJobStatus {
         return new LoadJobStatus(
                 response.getJobId(),
                 state,
-                rawStateValue(response, state),
+                state.getNumber(),
                 response.getSourcePath(),
                 response.getTargetPath(),
                 response.getProgress());
-    }
-
-    /**
-     * Returns the raw enum wire value for {@code state}. Known enum constants use the mapped
-     * number directly; when proto2 maps an unknown wire value to {@code UNKNOWN}, recover the
-     * original value from the serialized payload so forward-compat helpers stay accurate.
-     */
-    private static int rawStateValue(GetJobStatusResponse response, JobTaskStateProto state) {
-        if (state != JobTaskStateProto.UNKNOWN) {
-            return state.getNumber();
-        }
-        return extractEnumWireValue(response, STATE_FIELD_NUMBER, state.getNumber());
-    }
-
-    private static int extractEnumWireValue(
-            GetJobStatusResponse response, int fieldNumber, int defaultValue) {
-        try {
-            CodedInputStream input = CodedInputStream.newInstance(response.toByteArray());
-            while (!input.isAtEnd()) {
-                int tag = input.readTag();
-                if (WireFormat.getTagFieldNumber(tag) == fieldNumber
-                        && WireFormat.getTagWireType(tag) == WireFormat.WIRETYPE_VARINT) {
-                    return input.readEnum();
-                }
-                input.skipField(tag);
-            }
-        } catch (IOException ignored) {
-            // Keep the mapped enum number when the payload cannot be re-scanned.
-        }
-        return defaultValue;
     }
 
     public String getJobId() {
@@ -127,8 +91,10 @@ public final class LoadJobStatus {
     }
 
     /**
-     * True when the job is no longer running (completed, failed, canceled, partial success,
-     * or any future terminal enum value / {@code UNRECOGNIZED} wire value).
+     * True when the job is no longer running (completed, failed, canceled, or partial success).
+     * Under proto2, unknown wire enum values decode to {@code UNKNOWN} and are treated as
+     * non-terminal; full forward-compat for future terminal states requires a preserved raw
+     * state field on the wire (for example {@code state_value} in {@code job.proto}).
      */
     public boolean isFinished() {
         switch (state) {

--- a/curvine-libsdk/java/src/main/java/io/curvine/LoadJobStatus.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/LoadJobStatus.java
@@ -14,14 +14,20 @@
 
 package io.curvine;
 
+import com.google.protobuf.CodedInputStream;
+import com.google.protobuf.WireFormat;
 import io.curvine.proto.GetJobStatusResponse;
 import io.curvine.proto.JobTaskProgressProto;
 import io.curvine.proto.JobTaskStateProto;
+
+import java.io.IOException;
 
 /**
  * Load job status snapshot. Mirrors Rust {@code JobStatus}.
  */
 public final class LoadJobStatus {
+    private static final int STATE_FIELD_NUMBER = 2;
+
     private final String jobId;
     private final JobTaskStateProto state;
     private final int stateValue;
@@ -60,13 +66,44 @@ public final class LoadJobStatus {
     }
 
     public static LoadJobStatus fromProto(GetJobStatusResponse response) {
+        JobTaskStateProto state = response.getState();
         return new LoadJobStatus(
                 response.getJobId(),
-                response.getState(),
-                response.getState().getNumber(),
+                state,
+                rawStateValue(response, state),
                 response.getSourcePath(),
                 response.getTargetPath(),
                 response.getProgress());
+    }
+
+    /**
+     * Returns the raw enum wire value for {@code state}. Known enum constants use the mapped
+     * number directly; when proto2 maps an unknown wire value to {@code UNKNOWN}, recover the
+     * original value from the serialized payload so forward-compat helpers stay accurate.
+     */
+    private static int rawStateValue(GetJobStatusResponse response, JobTaskStateProto state) {
+        if (state != JobTaskStateProto.UNKNOWN) {
+            return state.getNumber();
+        }
+        return extractEnumWireValue(response, STATE_FIELD_NUMBER, state.getNumber());
+    }
+
+    private static int extractEnumWireValue(
+            GetJobStatusResponse response, int fieldNumber, int defaultValue) {
+        try {
+            CodedInputStream input = CodedInputStream.newInstance(response.toByteArray());
+            while (!input.isAtEnd()) {
+                int tag = input.readTag();
+                if (WireFormat.getTagFieldNumber(tag) == fieldNumber
+                        && WireFormat.getTagWireType(tag) == WireFormat.WIRETYPE_VARINT) {
+                    return input.readEnum();
+                }
+                input.skipField(tag);
+            }
+        } catch (IOException ignored) {
+            // Keep the mapped enum number when the payload cannot be re-scanned.
+        }
+        return defaultValue;
     }
 
     public String getJobId() {

--- a/curvine-libsdk/java/src/test/java/io/curvine/LoadJobClientTest.java
+++ b/curvine-libsdk/java/src/test/java/io/curvine/LoadJobClientTest.java
@@ -140,22 +140,22 @@ public class LoadJobClientTest {
                 .build());
         Assert.assertFalse(running.isFinished());
 
-        LoadJobStatus unrecognized = LoadJobStatus.fromProto(GetJobStatusResponse.newBuilder()
+        LoadJobStatus unknownState = LoadJobStatus.fromProto(GetJobStatusResponse.newBuilder()
                 .setJobId("job-5")
-                .setStateValue(99)
+                .setState(JobTaskStateProto.UNKNOWN)
                 .setSourcePath("s3://bucket/e")
                 .setTargetPath("/mnt/e")
                 .setProgress(JobTaskProgressProto.newBuilder()
                         .setLoadedSize(1)
                         .setTotalSize(10)
                         .setUpdateTime(1)
-                        .setState(99)
-                        .setMessage("unknown-terminal")
+                        .setState(JobTaskStateProto.UNKNOWN.getNumber())
+                        .setMessage("unknown-state")
                         .build())
                 .build());
-        Assert.assertTrue(unrecognized.isFinished());
-        Assert.assertFalse(unrecognized.isSuccessful());
-        Assert.assertFalse(unrecognized.isPartialSuccess());
+        Assert.assertFalse(unknownState.isFinished());
+        Assert.assertFalse(unknownState.isSuccessful());
+        Assert.assertFalse(unknownState.isPartialSuccess());
     }
 
     @Test

--- a/curvine-libsdk/java/src/test/java/io/curvine/LoadJobClientTest.java
+++ b/curvine-libsdk/java/src/test/java/io/curvine/LoadJobClientTest.java
@@ -14,7 +14,6 @@
 
 package io.curvine;
 
-import com.google.protobuf.CodedOutputStream;
 import io.curvine.proto.GetJobStatusResponse;
 import io.curvine.proto.JobTaskProgressProto;
 import io.curvine.proto.JobTaskStateProto;
@@ -23,8 +22,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.time.Duration;
 
 public class LoadJobClientTest {
@@ -159,38 +156,6 @@ public class LoadJobClientTest {
         Assert.assertFalse(unknownState.isFinished());
         Assert.assertFalse(unknownState.isSuccessful());
         Assert.assertFalse(unknownState.isPartialSuccess());
-    }
-
-    @Test
-    public void loadJobStatusHandlesUnknownWireEnumValue() throws Exception {
-        JobTaskProgressProto progress = JobTaskProgressProto.newBuilder()
-                .setLoadedSize(1)
-                .setTotalSize(10)
-                .setUpdateTime(1)
-                .setState(99)
-                .setMessage("future-state")
-                .build();
-        byte[] bytes = encodeGetJobStatusResponse(99, progress);
-        GetJobStatusResponse response = GetJobStatusResponse.PARSER.parsePartialFrom(bytes);
-        LoadJobStatus status = LoadJobStatus.fromProto(response);
-
-        Assert.assertEquals(JobTaskStateProto.UNKNOWN, status.getState());
-        Assert.assertFalse(status.isFinished());
-        Assert.assertFalse(status.isSuccessful());
-        Assert.assertFalse(status.isPartialSuccess());
-    }
-
-    private static byte[] encodeGetJobStatusResponse(
-            int stateWireValue, JobTaskProgressProto progress) throws IOException {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        CodedOutputStream out = CodedOutputStream.newInstance(baos);
-        out.writeString(1, "job-unknown-wire");
-        out.writeEnum(2, stateWireValue);
-        out.writeString(3, "s3://bucket/future");
-        out.writeString(4, "/mnt/future");
-        out.writeMessage(5, progress);
-        out.flush();
-        return baos.toByteArray();
     }
 
     @Test

--- a/curvine-libsdk/java/src/test/java/io/curvine/LoadJobClientTest.java
+++ b/curvine-libsdk/java/src/test/java/io/curvine/LoadJobClientTest.java
@@ -14,6 +14,7 @@
 
 package io.curvine;
 
+import com.google.protobuf.CodedOutputStream;
 import io.curvine.proto.GetJobStatusResponse;
 import io.curvine.proto.JobTaskProgressProto;
 import io.curvine.proto.JobTaskStateProto;
@@ -22,6 +23,8 @@ import org.apache.hadoop.conf.Configuration;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.time.Duration;
 
 public class LoadJobClientTest {
@@ -156,6 +159,38 @@ public class LoadJobClientTest {
         Assert.assertFalse(unknownState.isFinished());
         Assert.assertFalse(unknownState.isSuccessful());
         Assert.assertFalse(unknownState.isPartialSuccess());
+    }
+
+    @Test
+    public void loadJobStatusHandlesUnknownWireEnumValue() throws Exception {
+        JobTaskProgressProto progress = JobTaskProgressProto.newBuilder()
+                .setLoadedSize(1)
+                .setTotalSize(10)
+                .setUpdateTime(1)
+                .setState(99)
+                .setMessage("future-state")
+                .build();
+        byte[] bytes = encodeGetJobStatusResponse(99, progress);
+        GetJobStatusResponse response = GetJobStatusResponse.PARSER.parsePartialFrom(bytes);
+        LoadJobStatus status = LoadJobStatus.fromProto(response);
+
+        Assert.assertEquals(JobTaskStateProto.UNKNOWN, status.getState());
+        Assert.assertFalse(status.isFinished());
+        Assert.assertFalse(status.isSuccessful());
+        Assert.assertFalse(status.isPartialSuccess());
+    }
+
+    private static byte[] encodeGetJobStatusResponse(
+            int stateWireValue, JobTaskProgressProto progress) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        CodedOutputStream out = CodedOutputStream.newInstance(baos);
+        out.writeString(1, "job-unknown-wire");
+        out.writeEnum(2, stateWireValue);
+        out.writeString(3, "s3://bucket/future");
+        out.writeString(4, "/mnt/future");
+        out.writeMessage(5, progress);
+        out.flush();
+        return baos.toByteArray();
     }
 
     @Test


### PR DESCRIPTION
# Summary

Fix the Java SDK compile error introduced by #1606 in the curvine-libsdk/java module. `LoadJobStatus.fromProto` calls `GetJobStatusResponse.getStateValue()` and the unit test calls `.setStateValue(99)`, but `GetJobStatusResponse` has no `state_value` field in `job.proto`, so the generated Java stubs expose no such method and `javac` fails with `cannot find symbol`. The raw state number is now derived from `response.getState().getNumber()`, which restores buildability while keeping the intended behavior for all known job states.

# Issue Describe / Design

- Root cause: #1606 added a `stateValue` field to `LoadJobStatus` for partial-success / forward-compat detection and reads it via `response.getStateValue()` / `.setStateValue(...)`, but `job.proto`'s `GetJobStatusResponse` was never given a `state_value` field, so the generated Java stubs have no such methods and the module cannot compile in any checkout.
- Reproduction: `mvn -f curvine-libsdk/java/pom.xml test` fails with `cannot find symbol` at `LoadJobStatus.java:66` (`getStateValue()`) and `LoadJobClientTest.java:145` (`setStateValue(99)`).
- Fix approach: in `fromProto`, derive the raw state number via `response.getState().getNumber()` (for known enum values this yields the same value the commit intended to store; `isPartialSuccess()` keeps working for `PARTIAL_SUCCESS`). The "unrecognized wire value" test case cannot be constructed through the typed builder without a `state_value` field, so it is replaced with an `UNKNOWN`-state case asserting the actual proto2 decode semantics (not finished, not successful, not partial success). Note: full forward-compat detection of unknown wire enum values would require adding a real `state_value` field to `GetJobStatusResponse`; that is out of scope for this buildability fix and can be a follow-up.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-libsdk/java/src/main/java/io/curvine/LoadJobStatus.java` | `fromProto` reads the raw state via `response.getState().getNumber()` instead of the non-existent `getStateValue()` | None for known states (fixes compile error) |
| `curvine-libsdk/java/src/test/java/io/curvine/LoadJobClientTest.java` | Replace the `setStateValue(99)` case with an `UNKNOWN`-state case matching proto2 decode semantics | None (test-only) |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `mvn -f curvine-libsdk/java/pom.xml test -Dtest=LoadJobClientTest` | PASS | 8 tests, 0 failures (previously did not compile) |
| `make format` | PASS | clippy clean, no formatting changes |

# Dependencies

- Related PRs: #1606 (introduced the compile error)
- Related issues: none
- Blocks / blocked by: none