### PR TITLE
fix(fuse): reject unsupported mount options (#1399)

### DIFF
--- a/crates/common/curvine-config/src/fuse_conf.rs
+++ b/crates/common/curvine-config/src/fuse_conf.rs
@@ -105,7 +105,13 @@ pub struct FuseConf {
     // Read and write file request queue size, default is 0
     pub stream_channel_size: usize,
 
-    // Mount the configuration, needs to be passed to the linux kernel.
+    // Mount options for Curvine's direct Linux FUSE backend. Supported VFS
+    // pairs are `ro`/`rw`, `nodev`/`dev`, `nosuid`/`suid`, `noexec`/`exec`,
+    // `noatime`/`atime`, and `sync`/`async`; `dirsync` is also supported.
+    // Supported FUSE-side options are `allow_other`, `default_permissions`, and
+    // `big_write` (negotiated through FUSE_INIT). Opposite options conflict.
+    // Legacy libfuse options `auto_unmount`, `allow_root`, and `max_write` are
+    // not supported in this field by the direct mount backend.
     pub fuse_opts: Vec<String>,
 
     // Mount the whole FUSE filesystem read-only at the kernel level.
@@ -287,8 +293,6 @@ impl FuseConf {
                 self.max_background
             );
         }
-
-        self.fuse_opts = Self::normalize_fuse_opts(&self.fuse_opts)?;
 
         self.attr_ttl = Duration::from_millis(self.attr_timeout_ms);
         self.entry_ttl = Duration::from_millis(self.entry_timeout_ms);
@@ -480,7 +484,7 @@ impl FuseConf {
         args
     }
 
-    fn normalize_fuse_opts(opts: &[String]) -> CommonResult<Vec<String>> {
+    fn normalized_fuse_opts(opts: &[String]) -> CommonResult<Vec<String>> {
         let mut normalized = Vec::new();
 
         for entry in opts {
@@ -500,10 +504,15 @@ impl FuseConf {
 
                 let option = match name {
                     "ro"
+                    | "rw"
                     | "nodev"
+                    | "dev"
                     | "nosuid"
+                    | "suid"
                     | "noexec"
+                    | "exec"
                     | "noatime"
+                    | "atime"
                     | "dirsync"
                     | "sync"
                     | "allow_other"
@@ -530,6 +539,16 @@ impl FuseConf {
                 };
 
                 let conflicting_option = match option.as_str() {
+                    "ro" => Some("rw"),
+                    "rw" => Some("ro"),
+                    "nodev" => Some("dev"),
+                    "dev" => Some("nodev"),
+                    "nosuid" => Some("suid"),
+                    "suid" => Some("nosuid"),
+                    "noexec" => Some("exec"),
+                    "exec" => Some("noexec"),
+                    "noatime" => Some("atime"),
+                    "atime" => Some("noatime"),
                     "sync" => Some("async"),
                     "async" => Some("sync"),
                     _ => None,
@@ -553,11 +572,21 @@ impl FuseConf {
         Ok(normalized)
     }
 
+    /// Normalize and validate mount options after config-file values, CLI
+    /// overrides, and defaults have been merged for the FUSE process. Generic
+    /// cluster loading deliberately does not call this method because master and
+    /// worker processes do not consume FUSE mount options.
+    pub fn normalize_fuse_opts(&mut self) -> CommonResult<()> {
+        self.fuse_opts = Self::normalized_fuse_opts(&self.fuse_opts)?;
+        Ok(())
+    }
+
     /// Appends options that belong in the FUSE mount data string. Linux VFS
-    /// options (`ro`, `nodev`, `nosuid`, `noexec`, `noatime`, `dirsync`, and
-    /// `sync`) are deliberately handled as `mount(2)` flags by the raw backend.
+    /// options (`ro`/`rw`, `nodev`/`dev`, `nosuid`/`suid`, `noexec`/`exec`,
+    /// `noatime`/`atime`, `dirsync`, and `sync`/`async`) are deliberately handled
+    /// as `mount(2)` flags, or as the absence of a flag, by the raw backend.
     pub fn set_fuse_opts(&self, mount_options: &mut String) -> CommonResult<()> {
-        let opts = Self::normalize_fuse_opts(&self.fuse_opts)?;
+        let opts = Self::normalized_fuse_opts(&self.fuse_opts)?;
         let mut default_permissions_added = false;
 
         // The kernel can distinguish an executable load from a normal read while
@@ -570,12 +599,13 @@ impl FuseConf {
 
         for opt in opts {
             match opt.as_str() {
-                // VFS options are converted to mount(2) flags in fuse_pure.rs.
-                // `async` is the default absence of MS_SYNCHRONOUS. `big_write`
-                // is negotiated through FUSE_INIT and is already in
-                // SUPPORTED_INIT_FLAGS, so neither belongs in kernel mount data.
-                "ro" | "nodev" | "nosuid" | "noexec" | "noatime" | "dirsync" | "sync" | "async"
-                | "big_write" => {}
+                // VFS options are converted to mount(2) flags in fuse_pure.rs;
+                // positive/default forms such as `rw` and `async` mean the
+                // corresponding restrictive flag is absent. `big_write` is
+                // negotiated through FUSE_INIT and is already in
+                // SUPPORTED_INIT_FLAGS. None belongs in kernel mount data.
+                "ro" | "rw" | "nodev" | "dev" | "nosuid" | "suid" | "noexec" | "exec"
+                | "noatime" | "atime" | "dirsync" | "sync" | "async" | "big_write" => {}
                 "default_permissions" => {
                     if !default_permissions_added {
                         mount_options.push_str(",default_permissions");
@@ -586,7 +616,7 @@ impl FuseConf {
                     mount_options.push(',');
                     mount_options.push_str(&opt);
                 }
-                // normalize_fuse_opts rejects unsupported and unknown options.
+                // normalized_fuse_opts rejects unsupported and unknown options.
                 _ => unreachable!("validated FUSE mount option: {}", opt),
             }
         }
@@ -933,31 +963,33 @@ max_readahead_kb = 1024
     }
 
     #[test]
-    fn init_normalizes_comma_separated_fuse_options() {
+    fn normalize_fuse_opts_splits_comma_separated_options() {
         let mut conf = FuseConf {
             fuse_opts: vec![" allow_other , nodev ".to_string()],
             ..Default::default()
         };
 
-        conf.init().expect("supported options must be accepted");
+        conf.normalize_fuse_opts()
+            .expect("supported options must be accepted");
 
         assert_eq!(conf.fuse_opts, vec!["allow_other", "nodev"]);
     }
 
     #[test]
-    fn init_deduplicates_normalized_fuse_options() {
+    fn normalize_fuse_opts_deduplicates_options() {
         let mut conf = FuseConf {
             fuse_opts: vec!["allow_other,nodev".to_string(), "nodev".to_string()],
             ..Default::default()
         };
 
-        conf.init().expect("supported options must be accepted");
+        conf.normalize_fuse_opts()
+            .expect("supported options must be accepted");
 
         assert_eq!(conf.fuse_opts, vec!["allow_other", "nodev"]);
     }
 
     #[test]
-    fn init_rejects_conflicting_sync_and_async_options() {
+    fn normalize_fuse_opts_rejects_conflicting_sync_and_async_options() {
         let cases: &[&[&str]] = &[
             &["sync,async"],
             &["async,sync"],
@@ -972,7 +1004,7 @@ max_readahead_kb = 1024
             };
 
             let err = conf
-                .init()
+                .normalize_fuse_opts()
                 .expect_err("sync and async must not be accepted together");
             let message = err.to_string();
             assert!(message.contains("sync"), "unexpected error: {}", err);
@@ -982,13 +1014,15 @@ max_readahead_kb = 1024
     }
 
     #[test]
-    fn init_rejects_unknown_fuse_option_with_name() {
+    fn normalize_fuse_opts_rejects_unknown_option_with_name() {
         let mut conf = FuseConf {
             fuse_opts: vec!["allow_other,unknown_option".to_string()],
             ..Default::default()
         };
 
-        let err = conf.init().expect_err("unknown option must be rejected");
+        let err = conf
+            .normalize_fuse_opts()
+            .expect_err("unknown option must be rejected");
         assert!(
             err.to_string().contains("unknown_option"),
             "unexpected error: {}",
@@ -997,14 +1031,14 @@ max_readahead_kb = 1024
     }
 
     #[test]
-    fn init_rejects_auto_unmount_as_unsupported() {
+    fn normalize_fuse_opts_rejects_auto_unmount_as_unsupported() {
         let mut conf = FuseConf {
             fuse_opts: vec!["auto_unmount".to_string()],
             ..Default::default()
         };
 
         let err = conf
-            .init()
+            .normalize_fuse_opts()
             .expect_err("auto_unmount is not implemented by the direct backend");
         let message = err.to_string();
         assert!(
@@ -1020,7 +1054,7 @@ max_readahead_kb = 1024
     }
 
     #[test]
-    fn init_rejects_unimplemented_fuse_options_with_name() {
+    fn normalize_fuse_opts_rejects_unimplemented_options_with_name() {
         for option in ["allow_root", "max_write=131072"] {
             let mut conf = FuseConf {
                 fuse_opts: vec![option.to_string()],
@@ -1028,7 +1062,7 @@ max_readahead_kb = 1024
             };
 
             let err = conf
-                .init()
+                .normalize_fuse_opts()
                 .expect_err("unimplemented option must be rejected");
             let message = err.to_string();
             assert!(

--- a/crates/common/curvine-config/src/fuse_conf.rs
+++ b/crates/common/curvine-config/src/fuse_conf.rs
@@ -288,6 +288,8 @@ impl FuseConf {
             );
         }
 
+        self.fuse_opts = Self::normalize_fuse_opts(&self.fuse_opts)?;
+
         self.attr_ttl = Duration::from_millis(self.attr_timeout_ms);
         self.entry_ttl = Duration::from_millis(self.entry_timeout_ms);
         self.negative_ttl = Duration::from_millis(self.negative_timeout_ms);
@@ -478,13 +480,70 @@ impl FuseConf {
         args
     }
 
-    pub fn set_fuse_opts(&self, mount_options: &mut String) {
-        let mut ro_added = false;
-        let mut default_permissions_added = false;
-        if self.readonly {
-            mount_options.push_str(",ro");
-            ro_added = true;
+    fn normalize_fuse_opts(opts: &[String]) -> CommonResult<Vec<String>> {
+        let mut normalized = Vec::new();
+
+        for entry in opts {
+            for raw_opt in entry.split(',') {
+                let raw_opt = raw_opt.trim();
+                if raw_opt.is_empty() {
+                    return err_box!(
+                        "FUSE mount option is empty in '{}'; remove empty comma-separated entries",
+                        entry
+                    );
+                }
+
+                let (name, value) = match raw_opt.split_once('=') {
+                    Some((name, value)) => (name.trim(), Some(value.trim())),
+                    None => (raw_opt, None),
+                };
+
+                let option = match name {
+                    "ro"
+                    | "nodev"
+                    | "nosuid"
+                    | "noexec"
+                    | "noatime"
+                    | "dirsync"
+                    | "sync"
+                    | "allow_other"
+                    | "default_permissions"
+                    | "async"
+                    | "big_write" => {
+                        if value.is_some() {
+                            return err_box!(
+                                "FUSE mount option '{}' does not accept a value",
+                                raw_opt
+                            );
+                        }
+                        name.to_string()
+                    }
+                    // These names are known FUSE/libfuse options, but the direct
+                    // mount backend cannot implement their required semantics.
+                    "allow_root" | "max_write" | "auto_unmount" => {
+                        return err_box!(
+                            "FUSE mount option '{}' is recognized but not supported by the direct mount backend",
+                            raw_opt
+                        );
+                    }
+                    _ => return err_box!("Unknown FUSE mount option '{}'", raw_opt),
+                };
+
+                if !normalized.contains(&option) {
+                    normalized.push(option);
+                }
+            }
         }
+
+        Ok(normalized)
+    }
+
+    /// Appends options that belong in the FUSE mount data string. Linux VFS
+    /// options (`ro`, `nodev`, `nosuid`, `noexec`, `noatime`, `dirsync`, and
+    /// `sync`) are deliberately handled as `mount(2)` flags by the raw backend.
+    pub fn set_fuse_opts(&self, mount_options: &mut String) -> CommonResult<()> {
+        let opts = Self::normalize_fuse_opts(&self.fuse_opts)?;
+        let mut default_permissions_added = false;
 
         // The kernel can distinguish an executable load from a normal read while
         // FUSE_OPEN only exposes O_RDONLY for both. Keep permission enforcement in
@@ -494,34 +553,30 @@ impl FuseConf {
             default_permissions_added = true;
         }
 
-        self.fuse_opts.iter().for_each(|opt| match opt.as_str() {
-            "ro" => {
-                if !ro_added {
-                    mount_options.push_str(",ro");
-                    ro_added = true;
+        for opt in opts {
+            match opt.as_str() {
+                // VFS options are converted to mount(2) flags in fuse_pure.rs.
+                // `async` is the default absence of MS_SYNCHRONOUS. `big_write`
+                // is negotiated through FUSE_INIT and is already in
+                // SUPPORTED_INIT_FLAGS, so neither belongs in kernel mount data.
+                "ro" | "nodev" | "nosuid" | "noexec" | "noatime" | "dirsync" | "sync" | "async"
+                | "big_write" => {}
+                "default_permissions" => {
+                    if !default_permissions_added {
+                        mount_options.push_str(",default_permissions");
+                        default_permissions_added = true;
+                    }
                 }
-            }
-            "default_permissions" => {
-                if !default_permissions_added {
-                    mount_options.push_str(",default_permissions");
-                    default_permissions_added = true;
+                "allow_other" => {
+                    mount_options.push(',');
+                    mount_options.push_str(&opt);
                 }
+                // normalize_fuse_opts rejects unsupported and unknown options.
+                _ => unreachable!("validated FUSE mount option: {}", opt),
             }
-            "allow_other" => {
-                mount_options.push_str(",allow_other");
-            }
-            "allow_root" => {
-                mount_options.push_str(",allow_root");
-            }
-            "async" => {
-                mount_options.push_str(",async");
-            }
-            _ => {}
-        });
-    }
+        }
 
-    pub fn auto_umount(&self) -> bool {
-        self.fuse_opts.iter().any(|s| s == "auto_unmount")
+        Ok(())
     }
 }
 
@@ -863,30 +918,128 @@ max_readahead_kb = 1024
     }
 
     #[test]
-    fn readonly_adds_ro_mount_option() {
-        let conf = FuseConf {
-            readonly: true,
+    fn init_normalizes_comma_separated_fuse_options() {
+        let mut conf = FuseConf {
+            fuse_opts: vec![" allow_other , nodev ".to_string()],
             ..Default::default()
         };
-        let mut mount_options = String::new();
-        conf.set_fuse_opts(&mut mount_options);
-        assert!(mount_options.split(',').any(|opt| opt == "ro"));
+
+        conf.init().expect("supported options must be accepted");
+
+        assert_eq!(conf.fuse_opts, vec!["allow_other", "nodev"]);
     }
 
     #[test]
-    fn readonly_does_not_duplicate_ro_mount_option() {
-        let conf = FuseConf {
-            readonly: true,
-            fuse_opts: vec!["ro".to_string()],
+    fn init_deduplicates_normalized_fuse_options() {
+        let mut conf = FuseConf {
+            fuse_opts: vec!["allow_other,nodev".to_string(), "nodev".to_string()],
             ..Default::default()
         };
-        let mut mount_options = String::new();
-        conf.set_fuse_opts(&mut mount_options);
 
-        assert_eq!(
-            mount_options.split(',').filter(|opt| *opt == "ro").count(),
-            1
+        conf.init().expect("supported options must be accepted");
+
+        assert_eq!(conf.fuse_opts, vec!["allow_other", "nodev"]);
+    }
+
+    #[test]
+    fn init_rejects_unknown_fuse_option_with_name() {
+        let mut conf = FuseConf {
+            fuse_opts: vec!["allow_other,unknown_option".to_string()],
+            ..Default::default()
+        };
+
+        let err = conf.init().expect_err("unknown option must be rejected");
+        assert!(
+            err.to_string().contains("unknown_option"),
+            "unexpected error: {}",
+            err
         );
+    }
+
+    #[test]
+    fn init_rejects_auto_unmount_as_unsupported() {
+        let mut conf = FuseConf {
+            fuse_opts: vec!["auto_unmount".to_string()],
+            ..Default::default()
+        };
+
+        let err = conf
+            .init()
+            .expect_err("auto_unmount is not implemented by the direct backend");
+        let message = err.to_string();
+        assert!(
+            message.contains("auto_unmount"),
+            "unexpected error: {}",
+            err
+        );
+        assert!(
+            message.contains("direct mount backend"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn init_rejects_unimplemented_fuse_options_with_name() {
+        for option in ["allow_root", "max_write=131072"] {
+            let mut conf = FuseConf {
+                fuse_opts: vec![option.to_string()],
+                ..Default::default()
+            };
+
+            let err = conf
+                .init()
+                .expect_err("unimplemented option must be rejected");
+            let message = err.to_string();
+            assert!(
+                message.contains(option),
+                "error must include '{}': {}",
+                option,
+                err
+            );
+            assert!(
+                message.contains("direct mount backend"),
+                "unexpected error: {}",
+                err
+            );
+        }
+    }
+
+    #[test]
+    fn vfs_options_do_not_enter_fuse_mount_data() {
+        let mut conf = FuseConf {
+            readonly: true,
+            fuse_opts: vec!["ro,nodev,nosuid,noexec,noatime,dirsync,sync".to_string()],
+            check_permission: false,
+            ..Default::default()
+        };
+        conf.init().expect("supported VFS options must be accepted");
+        let mut mount_options = String::new();
+
+        conf.set_fuse_opts(&mut mount_options)
+            .expect("validated options must build mount data");
+
+        assert!(mount_options.is_empty());
+    }
+
+    #[test]
+    fn supported_fuse_parameters_enter_mount_data() {
+        let mut conf = FuseConf {
+            fuse_opts: vec!["allow_other,async,big_write".to_string()],
+            check_permission: false,
+            ..Default::default()
+        };
+        conf.init()
+            .expect("supported FUSE parameters must be accepted");
+        let mut mount_options = String::new();
+
+        conf.set_fuse_opts(&mut mount_options)
+            .expect("validated options must build mount data");
+
+        assert!(mount_options.split(',').any(|item| item == "allow_other"));
+        assert!(!mount_options
+            .split(',')
+            .any(|item| matches!(item, "async" | "big_write")));
     }
 
     #[test]
@@ -896,7 +1049,8 @@ max_readahead_kb = 1024
             ..Default::default()
         };
         let mut mount_options = String::new();
-        conf.set_fuse_opts(&mut mount_options);
+        conf.set_fuse_opts(&mut mount_options)
+            .expect("default config must build mount data");
 
         assert_eq!(
             mount_options
@@ -915,7 +1069,8 @@ max_readahead_kb = 1024
             ..Default::default()
         };
         let mut mount_options = String::new();
-        conf.set_fuse_opts(&mut mount_options);
+        conf.set_fuse_opts(&mut mount_options)
+            .expect("supported option must build mount data");
 
         assert_eq!(
             mount_options
@@ -933,7 +1088,8 @@ max_readahead_kb = 1024
             ..Default::default()
         };
         let mut mount_options = String::new();
-        conf.set_fuse_opts(&mut mount_options);
+        conf.set_fuse_opts(&mut mount_options)
+            .expect("default config must build mount data");
 
         assert!(!mount_options
             .split(',')

--- a/crates/common/curvine-config/src/fuse_conf.rs
+++ b/crates/common/curvine-config/src/fuse_conf.rs
@@ -529,6 +529,21 @@ impl FuseConf {
                     _ => return err_box!("Unknown FUSE mount option '{}'", raw_opt),
                 };
 
+                let conflicting_option = match option.as_str() {
+                    "sync" => Some("async"),
+                    "async" => Some("sync"),
+                    _ => None,
+                };
+                if let Some(conflicting_option) = conflicting_option {
+                    if normalized.iter().any(|item| item == conflicting_option) {
+                        return err_box!(
+                            "FUSE mount options '{}' and '{}' conflict; specify only one",
+                            conflicting_option,
+                            raw_opt
+                        );
+                    }
+                }
+
                 if !normalized.contains(&option) {
                     normalized.push(option);
                 }
@@ -939,6 +954,31 @@ max_readahead_kb = 1024
         conf.init().expect("supported options must be accepted");
 
         assert_eq!(conf.fuse_opts, vec!["allow_other", "nodev"]);
+    }
+
+    #[test]
+    fn init_rejects_conflicting_sync_and_async_options() {
+        let cases: &[&[&str]] = &[
+            &["sync,async"],
+            &["async,sync"],
+            &["sync", "async"],
+            &["async", "sync"],
+        ];
+
+        for options in cases {
+            let mut conf = FuseConf {
+                fuse_opts: options.iter().map(|option| option.to_string()).collect(),
+                ..Default::default()
+            };
+
+            let err = conf
+                .init()
+                .expect_err("sync and async must not be accepted together");
+            let message = err.to_string();
+            assert!(message.contains("sync"), "unexpected error: {}", err);
+            assert!(message.contains("async"), "unexpected error: {}", err);
+            assert!(message.contains("conflict"), "unexpected error: {}", err);
+        }
     }
 
     #[test]

--- a/crates/common/curvine-config/src/fuse_conf.rs
+++ b/crates/common/curvine-config/src/fuse_conf.rs
@@ -109,7 +109,8 @@ pub struct FuseConf {
     // pairs are `ro`/`rw`, `nodev`/`dev`, `nosuid`/`suid`, `noexec`/`exec`,
     // `noatime`/`atime`, and `sync`/`async`; `dirsync` is also supported.
     // Supported FUSE-side options are `allow_other`, `default_permissions`, and
-    // `big_write` (negotiated through FUSE_INIT). Opposite options conflict.
+    // `big_write` (negotiated through FUSE_INIT). Opposite options conflict, and
+    // explicit `rw` also conflicts with `readonly = true`.
     // Legacy libfuse options `auto_unmount`, `allow_root`, and `max_write` are
     // not supported in this field by the direct mount backend.
     pub fuse_opts: Vec<String>,
@@ -572,12 +573,24 @@ impl FuseConf {
         Ok(normalized)
     }
 
+    fn validate_fuse_opts_against_config(&self, opts: &[String]) -> CommonResult<()> {
+        if self.readonly && opts.iter().any(|option| option == "rw") {
+            return err_box!(
+                "FUSE mount option 'rw' conflicts with fuse.readonly=true; remove 'rw' or disable fuse.readonly"
+            );
+        }
+
+        Ok(())
+    }
+
     /// Normalize and validate mount options after config-file values, CLI
     /// overrides, and defaults have been merged for the FUSE process. Generic
     /// cluster loading deliberately does not call this method because master and
     /// worker processes do not consume FUSE mount options.
     pub fn normalize_fuse_opts(&mut self) -> CommonResult<()> {
-        self.fuse_opts = Self::normalized_fuse_opts(&self.fuse_opts)?;
+        let opts = Self::normalized_fuse_opts(&self.fuse_opts)?;
+        self.validate_fuse_opts_against_config(&opts)?;
+        self.fuse_opts = opts;
         Ok(())
     }
 
@@ -587,6 +600,7 @@ impl FuseConf {
     /// as `mount(2)` flags, or as the absence of a flag, by the raw backend.
     pub fn set_fuse_opts(&self, mount_options: &mut String) -> CommonResult<()> {
         let opts = Self::normalized_fuse_opts(&self.fuse_opts)?;
+        self.validate_fuse_opts_against_config(&opts)?;
         let mut default_permissions_added = false;
 
         // The kernel can distinguish an executable load from a normal read while
@@ -1011,6 +1025,23 @@ max_readahead_kb = 1024
             assert!(message.contains("async"), "unexpected error: {}", err);
             assert!(message.contains("conflict"), "unexpected error: {}", err);
         }
+    }
+
+    #[test]
+    fn normalize_fuse_opts_rejects_rw_when_readonly_is_enabled() {
+        let mut conf = FuseConf {
+            readonly: true,
+            fuse_opts: vec!["rw".to_string()],
+            ..Default::default()
+        };
+
+        let err = conf
+            .normalize_fuse_opts()
+            .expect_err("rw must conflict with fuse.readonly=true");
+        let message = err.to_string();
+        assert!(message.contains("rw"), "unexpected error: {message}");
+        assert!(message.contains("readonly"), "unexpected error: {message}");
+        assert!(message.contains("conflict"), "unexpected error: {message}");
     }
 
     #[test]

--- a/curvine-fuse/src/cli/mount_args.rs
+++ b/curvine-fuse/src/cli/mount_args.rs
@@ -320,6 +320,7 @@ impl FuseMountArgs {
         }
 
         conf.fuse.init()?;
+        conf.fuse.normalize_fuse_opts()?;
 
         Ok(conf)
     }
@@ -342,10 +343,11 @@ mod tests {
     use super::FuseMountArgs;
     use clap::Parser;
     use curvine_config::ClusterConf;
+    use curvine_core_error::CommonResult;
     use curvine_runtime::common::Utils;
     use std::fs;
 
-    fn get_conf(config: &str, extra_args: &[&str]) -> ClusterConf {
+    fn try_get_conf(config: &str, extra_args: &[&str]) -> CommonResult<ClusterConf> {
         let conf_path = Utils::temp_file();
         fs::write(&conf_path, config).expect("write test config");
 
@@ -355,7 +357,11 @@ mod tests {
         let result = args.get_conf();
         let _ = fs::remove_file(&conf_path);
 
-        result.expect("load mount configuration")
+        result
+    }
+
+    fn get_conf(config: &str, extra_args: &[&str]) -> ClusterConf {
+        try_get_conf(config, extra_args).expect("load mount configuration")
     }
 
     #[test]
@@ -376,6 +382,64 @@ mod tests {
         );
 
         assert_eq!(conf.fuse.fuse_opts, vec!["ro"]);
+    }
+
+    #[test]
+    fn get_conf_cli_fuse_opts_replace_unsupported_config_fuse_opts() {
+        let conf = get_conf(
+            "[fuse]\nio_threads = 1\nfuse_opts = [\"auto_unmount\"]\n",
+            &["--options", "allow_other"],
+        );
+
+        assert_eq!(conf.fuse.fuse_opts, vec!["allow_other"]);
+    }
+
+    #[test]
+    fn get_conf_rejects_unsupported_config_fuse_opts_without_cli_override() {
+        let err = try_get_conf(
+            "[fuse]\nio_threads = 1\nfuse_opts = [\"auto_unmount\"]\n",
+            &[],
+        )
+        .expect_err("unsupported config option must fail at the FUSE boundary");
+
+        assert!(err.to_string().contains("auto_unmount"));
+    }
+
+    #[test]
+    fn get_conf_accepts_positive_vfs_options() {
+        let conf = get_conf(
+            "[fuse]\nio_threads = 1\n",
+            &["--options", "rw,dev,suid,exec,atime"],
+        );
+
+        assert_eq!(
+            conf.fuse.fuse_opts,
+            vec!["rw", "dev", "suid", "exec", "atime"]
+        );
+    }
+
+    #[test]
+    fn get_conf_rejects_conflicting_vfs_option_pairs() {
+        for options in [
+            "ro,rw",
+            "rw,ro",
+            "nodev,dev",
+            "dev,nodev",
+            "nosuid,suid",
+            "suid,nosuid",
+            "noexec,exec",
+            "exec,noexec",
+            "noatime,atime",
+            "atime,noatime",
+        ] {
+            let err = try_get_conf("[fuse]\nio_threads = 1\n", &["--options", options])
+                .expect_err("opposite VFS options must conflict");
+            let message = err.to_string();
+            for option in options.split(',') {
+                assert!(message.contains(option), "unexpected error: {message}");
+            }
+            assert!(message.contains("conflict"), "unexpected error: {message}");
+        }
     }
 
     #[test]

--- a/curvine-fuse/src/cli/mount_args.rs
+++ b/curvine-fuse/src/cli/mount_args.rs
@@ -419,6 +419,20 @@ mod tests {
     }
 
     #[test]
+    fn get_conf_rejects_rw_when_readonly_is_enabled() {
+        let err = try_get_conf(
+            "[fuse]\nio_threads = 1\n",
+            &["--readonly", "--options", "rw"],
+        )
+        .expect_err("rw must conflict with --readonly");
+
+        let message = err.to_string();
+        assert!(message.contains("rw"), "unexpected error: {message}");
+        assert!(message.contains("readonly"), "unexpected error: {message}");
+        assert!(message.contains("conflict"), "unexpected error: {message}");
+    }
+
+    #[test]
     fn get_conf_rejects_conflicting_vfs_option_pairs() {
         for options in [
             "ro,rw",

--- a/curvine-fuse/src/cli/mount_args.rs
+++ b/curvine-fuse/src/cli/mount_args.rs
@@ -326,17 +326,12 @@ impl FuseMountArgs {
 
     pub fn default_mnt_opts() -> Vec<String> {
         if cfg!(feature = "fuse3") {
-            vec![
-                "allow_other".to_string(),
-                "async".to_string(),
-                "auto_unmount".to_string(),
-            ]
+            vec!["allow_other".to_string(), "async".to_string()]
         } else {
             vec![
                 "allow_other".to_string(),
                 "async".to_string(),
                 "big_write".to_string(),
-                "max_write=131072".to_string(),
             ]
         }
     }
@@ -366,17 +361,17 @@ mod tests {
     #[test]
     fn get_conf_preserves_config_fuse_opts_without_cli_override() {
         let conf = get_conf(
-            "[fuse]\nio_threads = 1\nfuse_opts = [\"allow_root\", \"ro\"]\n",
+            "[fuse]\nio_threads = 1\nfuse_opts = [\"allow_other\", \"ro\"]\n",
             &[],
         );
 
-        assert_eq!(conf.fuse.fuse_opts, vec!["allow_root", "ro"]);
+        assert_eq!(conf.fuse.fuse_opts, vec!["allow_other", "ro"]);
     }
 
     #[test]
     fn get_conf_cli_fuse_opts_replace_config_fuse_opts() {
         let conf = get_conf(
-            "[fuse]\nio_threads = 1\nfuse_opts = [\"allow_root\"]\n",
+            "[fuse]\nio_threads = 1\nfuse_opts = [\"allow_other\"]\n",
             &["--options", "ro"],
         );
 
@@ -388,6 +383,25 @@ mod tests {
         let conf = get_conf("[fuse]\nio_threads = 1\n", &[]);
 
         assert_eq!(conf.fuse.fuse_opts, FuseMountArgs::default_mnt_opts());
+    }
+
+    #[test]
+    fn get_conf_normalizes_comma_separated_cli_fuse_opts() {
+        let conf = get_conf(
+            "[fuse]\nio_threads = 1\nfuse_opts = [\"allow_other\"]\n",
+            &["--options", "allow_other,nodev"],
+        );
+
+        assert_eq!(conf.fuse.fuse_opts, vec!["allow_other", "nodev"]);
+    }
+
+    #[test]
+    fn default_fuse3_options_do_not_include_auto_unmount() {
+        if cfg!(feature = "fuse3") {
+            assert!(!FuseMountArgs::default_mnt_opts()
+                .iter()
+                .any(|option| option == "auto_unmount"));
+        }
     }
 
     #[test]

--- a/curvine-fuse/src/raw/fuse_pure.rs
+++ b/curvine-fuse/src/raw/fuse_pure.rs
@@ -97,10 +97,40 @@ pub fn options_to_flag(mount_option: &str) -> libc::c_ulong {
     flags
 }
 
-pub fn fuse_mount_pure(mnt: &Path, conf: &FuseConf) -> IOResult<RawIO> {
-    if conf.auto_umount() {
-        // TODO: handle auto umount
+fn build_mount_options(
+    fd: RawIO,
+    mountpoint_mode: u32,
+    conf: &FuseConf,
+) -> IOResult<(String, libc::c_ulong)> {
+    let mut mount_options = format!(
+        "fd={},rootmode={:o},user_id={},group_id={}",
+        fd,
+        mountpoint_mode,
+        getuid(),
+        getgid()
+    );
+    conf.set_fuse_opts(&mut mount_options)?;
+
+    // Set the FUSE subtype so /proc/mounts reports `type fuse.curvinefs` instead of
+    // the generic `type fuse` (same mechanism sshfs uses for `fuse.sshfs`). `c_type`
+    // stays "fuse" (the only registered kernel FUSE fs type); the Linux kernel FUSE
+    // module parses `subtype=` from this mount data and sets sb->s_subtype.
+    mount_options.push_str(",subtype=curvinefs");
+
+    // VFS options belong in the mount(2) flag argument, not in FUSE mount data.
+    let mut vfs_options = conf.fuse_opts.join(",");
+    if conf.readonly {
+        if !vfs_options.is_empty() {
+            vfs_options.push(',');
+        }
+        vfs_options.push_str("ro");
     }
+    let flags = options_to_flag(&vfs_options);
+
+    Ok((mount_options, flags))
+}
+
+pub fn fuse_mount_pure(mnt: &Path, conf: &FuseConf) -> IOResult<RawIO> {
     let res = fuse_mount_sys(mnt, conf);
     match res {
         Ok(fd) => Ok(fd),
@@ -129,23 +159,7 @@ fn fuse_mount_sys(mnt: &Path, conf: &FuseConf) -> IOResult<RawIO> {
     // SAFETY: open returned a fresh descriptor whose ownership is transferred here.
     // Keep ownership until mount succeeds so every failure path closes /dev/fuse.
     let fd = unsafe { OwnedFd::from_raw_fd(fd) };
-    let mut flags = 0;
-    let mut mount_options = format!(
-        "fd={},rootmode={:o},user_id={},group_id={}",
-        fd.as_raw_fd(),
-        mountpoint_mode,
-        getuid(),
-        getgid()
-    );
-    conf.set_fuse_opts(&mut mount_options);
-    // Set the FUSE subtype so /proc/mounts reports `type fuse.curvinefs` instead of
-    // the generic `type fuse` (same mechanism sshfs uses for `fuse.sshfs`). `c_type`
-    // below stays "fuse" (the only registered kernel FUSE fs type); the Linux kernel
-    // FUSE module parses `subtype=` from this mount data and sets sb->s_subtype, and
-    // the VFS then reports the type as `fuse.<subtype>`. Hardcoded to match the source
-    // name above (c_source = "curvinefs").
-    mount_options.push_str(",subtype=curvinefs");
-    flags |= options_to_flag(mount_options.as_str());
+    let (mount_options, flags) = build_mount_options(fd.as_raw_fd(), mountpoint_mode, conf)?;
     info!("sys-mount options: {}; flags: 0x{:x}", mount_options, flags);
 
     // Default name is "/dev/fuse", then use the subtype, and lastly prefer the name
@@ -387,15 +401,83 @@ pub fn fuse_umount_pure(mnt: &Path) -> IOResult<()> {
 #[cfg(test)]
 mod tests {
     use super::{
-        complete_mount, describe_fuse_device_error, describe_mount_error,
-        describe_mountpoint_error, describe_unmount_error, mountpoint_mode, path_to_cstring,
+        build_mount_options, complete_mount, describe_fuse_device_error, describe_mount_error,
+        describe_mountpoint_error, describe_unmount_error, mountpoint_mode, options_to_flag,
+        path_to_cstring,
     };
+    use curvine_config::FuseConf;
     use curvine_io::IOError;
     use std::ffi::OsStr;
     use std::fs::{self, File};
     use std::os::unix::ffi::OsStrExt;
     use std::os::unix::io::{AsRawFd, OwnedFd};
     use std::path::{Path, PathBuf};
+
+    #[test]
+    fn mount_builder_maps_security_options_to_vfs_flags() {
+        let mut conf = FuseConf {
+            fuse_opts: vec!["nodev,nosuid,noexec".to_string()],
+            check_permission: false,
+            ..Default::default()
+        };
+        conf.init().expect("supported options must initialize");
+
+        let (mount_data, flags) =
+            build_mount_options(10, 0o40755, &conf).expect("build mount arguments");
+
+        assert_eq!(flags & libc::MS_NODEV, libc::MS_NODEV);
+        assert_eq!(flags & libc::MS_NOSUID, libc::MS_NOSUID);
+        assert_eq!(flags & libc::MS_NOEXEC, libc::MS_NOEXEC);
+        assert!(!mount_data
+            .split(',')
+            .any(|option| matches!(option, "nodev" | "nosuid" | "noexec")));
+    }
+
+    #[test]
+    fn mount_builder_keeps_fuse_parameters_in_mount_data() {
+        let mut conf = FuseConf {
+            fuse_opts: vec!["allow_other,async,big_write".to_string()],
+            check_permission: false,
+            ..Default::default()
+        };
+        conf.init().expect("supported options must initialize");
+
+        let (mount_data, flags) =
+            build_mount_options(10, 0o40755, &conf).expect("build mount arguments");
+
+        assert_eq!(flags, 0);
+        assert!(mount_data.split(',').any(|item| item == "allow_other"));
+        assert!(!mount_data
+            .split(',')
+            .any(|item| matches!(item, "async" | "big_write")));
+        assert!(mount_data
+            .split(',')
+            .any(|item| item == "subtype=curvinefs"));
+    }
+
+    #[test]
+    fn readonly_sets_vfs_flag_without_polluting_mount_data() {
+        let conf = FuseConf {
+            readonly: true,
+            check_permission: false,
+            ..Default::default()
+        };
+
+        let (mount_data, flags) =
+            build_mount_options(10, 0o40755, &conf).expect("build mount arguments");
+
+        assert_eq!(flags & libc::MS_RDONLY, libc::MS_RDONLY);
+        assert!(!mount_data.split(',').any(|item| item == "ro"));
+    }
+
+    #[test]
+    fn ro_flag_does_not_match_rootmode_parameter() {
+        assert_eq!(options_to_flag("fd=10,rootmode=40755"), 0);
+        assert_eq!(
+            options_to_flag("fd=10,rootmode=40755,ro") & libc::MS_RDONLY,
+            libc::MS_RDONLY
+        );
+    }
 
     #[test]
     fn failed_mount_closes_fuse_fd() {

--- a/curvine-fuse/src/raw/fuse_pure.rs
+++ b/curvine-fuse/src/raw/fuse_pure.rs
@@ -414,9 +414,9 @@ mod tests {
     use std::path::{Path, PathBuf};
 
     #[test]
-    fn mount_builder_maps_security_options_to_vfs_flags() {
+    fn mount_builder_maps_all_supported_vfs_options_to_flags() {
         let mut conf = FuseConf {
-            fuse_opts: vec!["nodev,nosuid,noexec".to_string()],
+            fuse_opts: vec!["ro,nodev,nosuid,noexec,noatime,dirsync,sync".to_string()],
             check_permission: false,
             ..Default::default()
         };
@@ -425,12 +425,36 @@ mod tests {
         let (mount_data, flags) =
             build_mount_options(10, 0o40755, &conf).expect("build mount arguments");
 
+        assert_eq!(flags & libc::MS_RDONLY, libc::MS_RDONLY);
         assert_eq!(flags & libc::MS_NODEV, libc::MS_NODEV);
         assert_eq!(flags & libc::MS_NOSUID, libc::MS_NOSUID);
         assert_eq!(flags & libc::MS_NOEXEC, libc::MS_NOEXEC);
-        assert!(!mount_data
-            .split(',')
-            .any(|option| matches!(option, "nodev" | "nosuid" | "noexec")));
+        assert_eq!(flags & libc::MS_NOATIME, libc::MS_NOATIME);
+        assert_eq!(flags & libc::MS_DIRSYNC, libc::MS_DIRSYNC);
+        assert_eq!(flags & libc::MS_SYNCHRONOUS, libc::MS_SYNCHRONOUS);
+        assert!(!mount_data.split(',').any(|option| {
+            matches!(
+                option,
+                "ro" | "nodev" | "nosuid" | "noexec" | "noatime" | "dirsync" | "sync"
+            )
+        }));
+    }
+
+    #[test]
+    fn mount_builder_treats_positive_vfs_options_as_noops() {
+        let conf = FuseConf {
+            fuse_opts: vec!["rw,dev,suid,exec,atime,async".to_string()],
+            check_permission: false,
+            ..Default::default()
+        };
+
+        let (mount_data, flags) =
+            build_mount_options(10, 0o40755, &conf).expect("build mount arguments");
+
+        assert_eq!(flags, 0);
+        assert!(!mount_data.split(',').any(|option| {
+            matches!(option, "rw" | "dev" | "suid" | "exec" | "atime" | "async")
+        }));
     }
 
     #[test]

--- a/curvine-fuse/src/raw/fuse_pure.rs
+++ b/curvine-fuse/src/raw/fuse_pure.rs
@@ -458,6 +458,23 @@ mod tests {
     }
 
     #[test]
+    fn mount_builder_rejects_rw_when_readonly_is_enabled() {
+        let conf = FuseConf {
+            readonly: true,
+            fuse_opts: vec!["rw".to_string()],
+            check_permission: false,
+            ..Default::default()
+        };
+
+        let err = build_mount_options(10, 0o40755, &conf)
+            .expect_err("rw must conflict with fuse.readonly=true");
+        let message = err.to_string();
+        assert!(message.contains("rw"), "unexpected error: {message}");
+        assert!(message.contains("readonly"), "unexpected error: {message}");
+        assert!(message.contains("conflict"), "unexpected error: {message}");
+    }
+
+    #[test]
     fn mount_builder_keeps_fuse_parameters_in_mount_data() {
         let mut conf = FuseConf {
             fuse_opts: vec!["allow_other,async,big_write".to_string()],
@@ -483,6 +500,7 @@ mod tests {
     fn readonly_sets_vfs_flag_without_polluting_mount_data() {
         let conf = FuseConf {
             readonly: true,
+            fuse_opts: vec!["ro".to_string()],
             check_permission: false,
             ..Default::default()
         };

--- a/curvine-tests/benchmark/master-stress/deployment-metadata-stable.yaml
+++ b/curvine-tests/benchmark/master-stress/deployment-metadata-stable.yaml
@@ -83,12 +83,8 @@ data:
     fi
     echo "[bootstrap] $(ls -l /dev/fuse)"
 
-    if ! command -v fusermount3 >/dev/null 2>&1 && ! command -v fusermount >/dev/null 2>&1; then
-      echo "WARN: neither fusermount3 nor fusermount found in PATH; auto_unmount may misbehave" >&2
-    fi
-
     # Drop allow_other for single-user container mounts; avoids fuse.conf edge cases.
-    CURVINE_FUSE_EXTRA=(--options async --options auto_unmount)
+    CURVINE_FUSE_EXTRA=(--options async)
     if [ "${FUSE_USE_DEFAULT_OPTS:-0}" = 1 ]; then
       CURVINE_FUSE_EXTRA=()
     fi

--- a/curvine-tests/benchmark/master-stress/deployment-metadata-stress.yaml
+++ b/curvine-tests/benchmark/master-stress/deployment-metadata-stress.yaml
@@ -110,7 +110,7 @@ data:
       exit 1
     fi
 
-    CURVINE_FUSE_EXTRA=(--options async --options auto_unmount)
+    CURVINE_FUSE_EXTRA=(--options async)
     if [ "${FUSE_USE_DEFAULT_OPTS:-0}" = 1 ]; then
       CURVINE_FUSE_EXTRA=()
     fi

--- a/curvine-tests/benchmark/master-stress/deployment.yaml
+++ b/curvine-tests/benchmark/master-stress/deployment.yaml
@@ -75,12 +75,8 @@ data:
     fi
     echo "[bootstrap] $(ls -l /dev/fuse)"
 
-    if ! command -v fusermount3 >/dev/null 2>&1 && ! command -v fusermount >/dev/null 2>&1; then
-      echo "WARN: neither fusermount3 nor fusermount found in PATH; auto_unmount may misbehave" >&2
-    fi
-
     # Drop allow_other for single-user container mounts; avoids fuse.conf edge cases.
-    CURVINE_FUSE_EXTRA=(--options async --options auto_unmount)
+    CURVINE_FUSE_EXTRA=(--options async)
     if [ "${FUSE_USE_DEFAULT_OPTS:-0}" = 1 ]; then
       CURVINE_FUSE_EXTRA=()
     fi


### PR DESCRIPTION
# Summary

Reject FUSE mount options that Curvine's direct mount backend cannot implement instead of silently ignoring them. Normalize options after CLI/config merging, separate Linux VFS flags from FUSE mount data, and reject conflicting positive/negative options both within `fuse_opts` and across the `readonly` configuration field.

# Issue Describe / Design

Closes #1399

## Root cause

Curvine previously treated `fuse_opts` as opaque strings. Comma-separated values were not normalized, several Linux VFS options were appended to FUSE mount data rather than converted into `mount(2)` flags, and unknown or unimplemented options could be accepted without taking effect. In addition, accepting both `sync` and `async` left `MS_SYNCHRONOUS` enabled whenever `sync` was present, silently ignoring `async`.

The explicit `readonly` field is stored separately from `fuse_opts`. After `rw` became a supported positive VFS option, `readonly = true` could still append `ro` during raw mount construction and silently override an explicit `rw` request.

## Reproduction

1. Pass comma-separated options such as `--options nodev,nosuid,noexec` or a known but unimplemented option such as `auto_unmount`.
2. The old path could accept the input while not applying the requested semantics.
3. Pass `--options sync,async`; both options were accepted even though the resulting mount remained synchronous.
4. Pass `--readonly --options rw`, or configure `readonly = true` with `fuse_opts = ["rw"]`; the mount silently became read-only instead of reporting the conflict.

## Fix approach

- Split and trim comma-separated options and deduplicate supported options in order.
- Validate against an explicit support table after CLI options have replaced config-file options, and include the offending option in errors.
- Reject known but unimplemented direct-mount options.
- Convert VFS options to `mount(2)` flags while keeping FUSE parameters in mount data.
- Accept standard positive VFS forms (`rw`, `dev`, `suid`, `exec`, and `atime`) as explicit defaults.
- Reject opposite pairs such as `ro`/`rw`, `nodev`/`dev`, and `sync`/`async`, preserving both option names in the conflict error.
- Reject explicit `rw` when `fuse.readonly=true`, both during final configuration normalization and during the defensive mount-time validation.
- Remove unsupported defaults and benchmark usages.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `crates/common/curvine-config/src/fuse_conf.rs` | Normalize and validate mount options at the FUSE boundary; support positive VFS forms; reject opposite pairs and `rw` with `readonly=true` | Non-FUSE services can load shared legacy config; invalid final mount options and cross-field conflicts fail explicitly |
| `curvine-fuse/src/cli/mount_args.rs` | Merge config/CLI/default options before final validation and remove unsupported defaults | CLI `--options` can replace legacy config values as documented; `--readonly --options rw` fails before mounting |
| `curvine-fuse/src/raw/fuse_pure.rs` | Separate VFS mount flags from FUSE mount data and retain defensive conflict validation | Security/read-only options use the correct kernel interface; direct callers cannot silently override `rw` with `readonly` |
| `curvine-tests/benchmark/master-stress/*.yaml` | Remove unsupported `auto_unmount` usage | Benchmark deployments use only implemented mount options |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo fmt --all -- --check` | PASS | Local and Ubuntu checkout |
| `git diff --check github/main...HEAD` | PASS | No whitespace errors |
| `cargo test -p curvine-config --lib` | PASS | Ubuntu, 61 passed |
| `cargo test -p curvine-fuse --no-default-features --features fuse2 cli::mount_args --lib` | PASS | Ubuntu, 11 passed |
| `cargo test -p curvine-fuse --no-default-features --features fuse2 raw::fuse_pure::tests --lib` | PASS | Ubuntu, 17 passed |
| `cargo test -p curvine-fuse --no-default-features --features fuse3 cli::mount_args --lib` | PASS | Ubuntu, 11 passed |
| `cargo clippy -p curvine-config --lib --no-deps -- -D warnings` | PASS | Local and Ubuntu checkout |

Linux FUSE verification is listed above. The macOS FUSE test target retains the existing platform-gating compile failure because `fuse_mount_pure` is Linux-only.

# Dependencies

- Related PRs: None
- Related issues: #1399
- Blocks / blocked by: None
