### PR TITLE
fix(config): trim whitespace in host:port address lists

### DIFF
--- a/crates/common/curvine-config/src/client_conf.rs
+++ b/crates/common/curvine-config/src/client_conf.rs
@@ -279,6 +279,11 @@ impl ClientConf {
     pub const DEFAULT_MAX_READ_PARALLEL: i64 = 8;
 
     pub fn init(&mut self) -> CommonResult<()> {
+        self.hostname = self.hostname.trim().to_string();
+        for addr in &mut self.master_addrs {
+            addr.hostname = addr.hostname.trim().to_string();
+        }
+
         if self.read_parallel <= 0 {
             self.read_parallel = Self::DEFAULT_READ_PARALLEL;
         }

--- a/crates/common/curvine-config/src/cluster_conf.rs
+++ b/crates/common/curvine-config/src/cluster_conf.rs
@@ -93,6 +93,7 @@ impl ClusterConf {
 
     pub fn from<T: AsRef<str>>(path: T) -> CommonResult<Self> {
         let mut conf = Self::read(path)?;
+        conf.normalize_whitespace();
         conf.apply_hostname_overrides()?;
         conf.master.init()?;
         conf.client.init()?;
@@ -106,6 +107,7 @@ impl ClusterConf {
     /// Load only the configuration needed by the standalone Transfer service.
     pub fn from_transfer<T: AsRef<str>>(path: T) -> CommonResult<Self> {
         let mut conf = Self::read(path)?;
+        conf.normalize_whitespace();
         conf.apply_transfer_hostname_overrides()?;
         conf.client.init()?;
         conf.transfer.init()?;
@@ -116,6 +118,35 @@ impl ClusterConf {
     fn read<T: AsRef<str>>(path: T) -> CommonResult<Self> {
         let str = try_err!(read_to_string(path.as_ref()));
         Ok(try_err!(toml::from_str::<Self>(&str)))
+    }
+
+    fn normalize_whitespace(&mut self) {
+        self.net_interface = self.net_interface.trim().to_string();
+        self.master.hostname = self.master.hostname.trim().to_string();
+        self.journal.hostname = self.journal.hostname.trim().to_string();
+        self.worker.hostname = self.worker.hostname.trim().to_string();
+        self.client.hostname = self.client.hostname.trim().to_string();
+        self.transfer.hostname = self.transfer.hostname.trim().to_string();
+        for addr in &mut self.client.master_addrs {
+            addr.hostname = addr.hostname.trim().to_string();
+        }
+        for peer in &mut self.journal.journal_addrs {
+            peer.hostname = peer.hostname.trim().to_string();
+        }
+        self.worker.data_dir = self
+            .worker
+            .data_dir
+            .iter()
+            .map(|dir| dir.trim().to_string())
+            .filter(|dir| !dir.is_empty())
+            .collect();
+        self.transfer.endpoints = self
+            .transfer
+            .endpoints
+            .iter()
+            .map(|endpoint| endpoint.trim().to_string())
+            .filter(|endpoint| !endpoint.is_empty())
+            .collect();
     }
 
     fn apply_hostname_overrides(&mut self) -> CommonResult<()> {
@@ -154,22 +185,23 @@ impl ClusterConf {
             self.transfer.hostname = ip;
         } else {
             if let Ok(v) = env::var(Self::ENV_MASTER_HOSTNAME) {
-                self.master.hostname = v.to_owned();
-                self.journal.hostname = v;
+                let hostname = v.trim().to_string();
+                self.master.hostname = hostname.clone();
+                self.journal.hostname = hostname;
             }
 
             // Apply worker hostname from environment variable (used by worker process)
             if let Ok(v) = env::var(Self::ENV_WORKER_HOSTNAME) {
-                self.worker.hostname = v;
+                self.worker.hostname = v.trim().to_string();
             }
 
             // Apply client hostname from environment variable
             if let Ok(v) = env::var(Self::ENV_CLIENT_HOSTNAME) {
-                self.client.hostname = v;
+                self.client.hostname = v.trim().to_string();
             }
 
             if let Ok(v) = env::var(Self::ENV_TRANSFER_HOSTNAME) {
-                self.transfer.hostname = v;
+                self.transfer.hostname = v.trim().to_string();
             }
         }
 
@@ -192,10 +224,10 @@ impl ClusterConf {
             self.transfer.hostname = ip;
         } else {
             if let Ok(v) = env::var(Self::ENV_CLIENT_HOSTNAME) {
-                self.client.hostname = v;
+                self.client.hostname = v.trim().to_string();
             }
             if let Ok(v) = env::var(Self::ENV_TRANSFER_HOSTNAME) {
-                self.transfer.hostname = v;
+                self.transfer.hostname = v.trim().to_string();
             }
         }
         Ok(())
@@ -541,6 +573,71 @@ mod tests {
         assert!(
             conf.check_master_hostname().is_err(),
             "local journal address absent from journal_addrs must error"
+        );
+    }
+
+    #[test]
+    fn trims_whitespace_in_hostname_config() {
+        let path = std::env::temp_dir().join(format!(
+            "curvine-trim-conf-{}-{}.toml",
+            std::process::id(),
+            Utils::rand_str(6)
+        ));
+        std::fs::write(
+            &path,
+            r#"
+                net_interface = " "
+
+                [master]
+                hostname = " master-01.example "
+
+                [journal]
+                hostname = " journal-01.example "
+                journal_addrs = [
+                    { id = 1, hostname = " journal-01.example ", port = 8996 },
+                    { id = 2, hostname = "journal-02.example", port = 8996 },
+                ]
+
+                [worker]
+                hostname = " worker-01.example "
+                data_dir = [" /data/curvine ", "/data/curvine2"]
+
+                [client]
+                hostname = " client-01.example "
+                master_addrs = [
+                    { hostname = " curvine-master-01.oppo.local", port = 8995 },
+                    { hostname = " curvine-master-02.oppo.local", port = 8995 },
+                    { hostname = "curvine-master-03.oppo.local", port = 8995 },
+                ]
+
+                [transfer]
+                hostname = " transfer-01.example "
+                endpoints = [" transfer-01.example:9010 ", "transfer-02.example:9010"]
+            "#,
+        )
+        .unwrap();
+
+        let conf = ClusterConf::from(path.to_str().unwrap()).unwrap();
+        let _ = std::fs::remove_file(&path);
+
+        assert_eq!(conf.net_interface, "");
+        assert_eq!(conf.master.hostname, "master-01.example");
+        assert_eq!(conf.journal.hostname, "journal-01.example");
+        assert_eq!(conf.journal.journal_addrs[0].hostname, "journal-01.example");
+        assert_eq!(conf.worker.hostname, "worker-01.example");
+        assert_eq!(
+            conf.worker.data_dir,
+            vec!["/data/curvine", "/data/curvine2"]
+        );
+        assert_eq!(conf.client.hostname, "client-01.example");
+        assert_eq!(
+            conf.client.master_addrs[1].hostname,
+            "curvine-master-02.oppo.local"
+        );
+        assert_eq!(conf.transfer.hostname, "transfer-01.example");
+        assert_eq!(
+            conf.transfer.endpoints,
+            vec!["transfer-01.example:9010", "transfer-02.example:9010"]
         );
     }
 

--- a/crates/common/curvine-config/src/cluster_conf.rs
+++ b/crates/common/curvine-config/src/cluster_conf.rs
@@ -140,12 +140,14 @@ impl ClusterConf {
             .map(|dir| dir.trim().to_string())
             .filter(|dir| !dir.is_empty())
             .collect();
+        // Trim only. Dropping empty tokens here would hide whitespace-only
+        // `transfer.endpoints` from TransferConf::init, which must reject them
+        // instead of silently defaulting to localhost.
         self.transfer.endpoints = self
             .transfer
             .endpoints
             .iter()
             .map(|endpoint| endpoint.trim().to_string())
-            .filter(|endpoint| !endpoint.is_empty())
             .collect();
     }
 
@@ -638,6 +640,33 @@ mod tests {
         assert_eq!(
             conf.transfer.endpoints,
             vec!["transfer-01.example:9010", "transfer-02.example:9010"]
+        );
+    }
+
+    #[test]
+    fn rejects_whitespace_only_transfer_endpoints() {
+        let path = std::env::temp_dir().join(format!(
+            "curvine-trim-endpoints-{}-{}.toml",
+            std::process::id(),
+            Utils::rand_str(6)
+        ));
+        std::fs::write(
+            &path,
+            r#"
+                [transfer]
+                endpoints = [" "]
+            "#,
+        )
+        .unwrap();
+
+        let err = ClusterConf::from_transfer(path.to_str().unwrap())
+            .expect_err("whitespace-only transfer endpoints must fail")
+            .to_string();
+        let _ = std::fs::remove_file(&path);
+
+        assert!(
+            err.contains("transfer.endpoints must contain host:port values"),
+            "unexpected error: {err}"
         );
     }
 

--- a/crates/common/curvine-config/src/raft_peer.rs
+++ b/crates/common/curvine-config/src/raft_peer.rs
@@ -14,16 +14,25 @@
 
 use curvine_net::net::InetAddr;
 use curvine_runtime::common::Utils;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::fmt::{Display, Formatter};
 
 pub type NodeId = u64;
+
+fn deserialize_trimmed_string<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = String::deserialize(deserializer)?;
+    Ok(value.trim().to_string())
+}
 
 // Represents a raft address
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(default)]
 pub struct RaftPeer {
     pub id: NodeId,
+    #[serde(default, deserialize_with = "deserialize_trimmed_string")]
     pub hostname: String,
     pub port: u16,
 }
@@ -65,5 +74,27 @@ impl Default for RaftPeer {
             hostname: "".to_string(),
             port: 0,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RaftPeer;
+    use curvine_net::net::InetAddr;
+
+    #[test]
+    fn serde_trims_hostname() {
+        let peer: RaftPeer = toml::from_str(
+            r#"
+                id = 1
+                hostname = " master1 "
+                port = 8996
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(peer.hostname, "master1");
+        assert_eq!(peer.to_addr().hostname, "master1");
+        assert_eq!(peer.to_addr(), InetAddr::new(" master1 ", 8996));
     }
 }

--- a/crates/common/curvine-config/src/raft_peer.rs
+++ b/crates/common/curvine-config/src/raft_peer.rs
@@ -32,13 +32,14 @@ impl RaftPeer {
     pub fn new<T: AsRef<str>>(id: NodeId, hostname: T, port: u16) -> Self {
         Self {
             id,
-            hostname: hostname.as_ref().to_string(),
+            hostname: hostname.as_ref().trim().to_string(),
             port,
         }
     }
 
     pub fn from_addr<T: AsRef<str>>(hostname: T, port: u16) -> Self {
-        let id = Self::create_id(format!("{}{}", hostname.as_ref(), port));
+        let hostname = hostname.as_ref().trim();
+        let id = Self::create_id(format!("{}{}", hostname, port));
         Self::new(id, hostname, port)
     }
 

--- a/crates/common/curvine-config/src/transfer_conf.rs
+++ b/crates/common/curvine-config/src/transfer_conf.rs
@@ -121,6 +121,13 @@ impl TransferConf {
     pub const DEFAULT_TASK_MAX_RETRIES: usize = 3;
 
     pub fn init(&mut self) -> FsResult<()> {
+        self.hostname = self.hostname.trim().to_string();
+        self.endpoints = self
+            .endpoints
+            .iter()
+            .map(|endpoint| endpoint.trim().to_string())
+            .filter(|endpoint| !endpoint.is_empty())
+            .collect();
         self.infer_store_url();
         if self.endpoints.is_empty() {
             self.endpoints

--- a/crates/common/curvine-config/src/transfer_conf.rs
+++ b/crates/common/curvine-config/src/transfer_conf.rs
@@ -122,6 +122,7 @@ impl TransferConf {
 
     pub fn init(&mut self) -> FsResult<()> {
         self.hostname = self.hostname.trim().to_string();
+        let had_configured_endpoints = !self.endpoints.is_empty();
         self.endpoints = self
             .endpoints
             .iter()
@@ -130,6 +131,11 @@ impl TransferConf {
             .collect();
         self.infer_store_url();
         if self.endpoints.is_empty() {
+            if had_configured_endpoints {
+                return Err(FsError::common(
+                    "transfer.endpoints must contain host:port values; whitespace-only entries are invalid",
+                ));
+            }
             self.endpoints
                 .push(format!("{}:{}", self.hostname, self.rpc_port));
         }
@@ -424,6 +430,20 @@ mod tests {
         assert_eq!(conf.rpc_port, TransferConf::DEFAULT_RPC_PORT);
         assert_eq!(conf.web_port, TransferConf::DEFAULT_WEB_PORT);
         assert_eq!(conf.log.file_name, "transfer.log");
+    }
+
+    #[test]
+    fn rejects_whitespace_only_endpoints() {
+        let mut conf = TransferConf {
+            endpoints: vec![" ".to_string()],
+            ..Default::default()
+        };
+
+        let err = conf.init().unwrap_err().to_string();
+        assert!(
+            err.contains("transfer.endpoints must contain host:port values"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/crates/common/curvine-config/src/worker_conf.rs
+++ b/crates/common/curvine-config/src/worker_conf.rs
@@ -57,6 +57,7 @@ impl WorkerDataDir {
     }
 
     pub fn from_str(str: &str) -> CommonResult<Self> {
+        let str = str.trim();
         let re = Regex::new(r"^\[([\w:]*)\](.+)$")?;
         let caps = match re.captures(str) {
             None => return Ok(Self::with_path(str)),
@@ -64,8 +65,8 @@ impl WorkerDataDir {
         };
 
         let prefix = caps.get(1).map_or("", |m| m.as_str());
-        let path = caps.get(2).map_or("", |m| m.as_str());
-        let arr = prefix.split(":").collect::<Vec<&str>>();
+        let path = caps.get(2).map_or("", |m| m.as_str()).trim();
+        let arr = prefix.split(':').map(str::trim).collect::<Vec<&str>>();
 
         if prefix.is_empty() || arr.is_empty() {
             // /dir
@@ -218,5 +219,17 @@ impl Default for WorkerConf {
             spdk_disk: SpdkConf::default(),
             compatibility: CompatibilityConf::default(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::WorkerDataDir;
+
+    #[test]
+    fn from_str_trims_path_and_prefix() {
+        let dir = WorkerDataDir::from_str("  [SSD:100MB] /data/curvine  ").unwrap();
+        assert!(dir.path_str().ends_with("/data/curvine"));
+        assert_eq!(dir.capacity, 100 * 1024 * 1024);
     }
 }

--- a/crates/core/net/src/net/inet_addr.rs
+++ b/crates/core/net/src/net/inet_addr.rs
@@ -16,15 +16,24 @@
 
 use crate::net::NetUtils;
 use curvine_io::IOResult;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::fmt::{Display, Formatter};
 use std::net::{SocketAddr, ToSocketAddrs};
 use std::vec::IntoIter;
+
+fn deserialize_trimmed_string<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = String::deserialize(deserializer)?;
+    Ok(value.trim().to_string())
+}
 
 // Create a socket address based on the hostname and port number.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize, Default)]
 #[serde(default)]
 pub struct InetAddr {
+    #[serde(default, deserialize_with = "deserialize_trimmed_string")]
     pub hostname: String,
     pub port: u16,
 }
@@ -32,7 +41,7 @@ pub struct InetAddr {
 impl InetAddr {
     pub fn new<T: Into<String>>(hostname: T, port: u16) -> Self {
         Self {
-            hostname: hostname.into(),
+            hostname: hostname.into().trim().to_string(),
             port,
         }
     }
@@ -53,19 +62,42 @@ impl InetAddr {
         (self.hostname.as_str(), self.port)
     }
 
-    pub fn from_str(addr: impl Into<String>) -> IOResult<Self> {
-        let addr = addr.into();
-        let list: Vec<&str> = addr.split(":").collect();
-        if list.len() != 2 {
-            return err_box!(
-                "Address {} failed to resolve, format should be ip:port",
+    pub fn from_str(addr: impl AsRef<str>) -> IOResult<Self> {
+        let addr = addr.as_ref().trim();
+        match addr.split_once(':') {
+            Some((hostname, port)) => {
+                let hostname = hostname.trim();
+                let port = port.trim();
+                if hostname.is_empty() || port.is_empty() || port.contains(':') {
+                    return err_box!(
+                        "Address {} failed to resolve, format should be host:port",
+                        addr
+                    );
+                }
+                Ok(Self::new(hostname, port.parse()?))
+            }
+            None => err_box!(
+                "Address {} failed to resolve, format should be host:port",
                 addr
-            );
+            ),
         }
-        let hostname = list[0].to_string();
-        let port: u16 = list[1].parse()?;
+    }
 
-        Ok(Self::new(hostname, port))
+    /// Parse a comma-separated `host:port` list, trimming whitespace around
+    /// each token. Empty tokens (from trailing or doubled commas) are skipped.
+    pub fn parse_list(addrs: impl AsRef<str>) -> IOResult<Vec<Self>> {
+        let mut result = Vec::new();
+        for node in addrs.as_ref().split(',') {
+            let node = node.trim();
+            if node.is_empty() {
+                continue;
+            }
+            result.push(Self::from_str(node)?);
+        }
+        if result.is_empty() {
+            return err_box!("Address list is empty, format should be host:port[,host:port...]");
+        }
+        Ok(result)
     }
 }
 
@@ -86,5 +118,51 @@ impl Display for InetAddr {
 impl From<SocketAddr> for InetAddr {
     fn from(value: SocketAddr) -> Self {
         Self::new(value.ip().to_string(), value.port())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::InetAddr;
+
+    #[test]
+    fn from_str_trims_hostname_and_port() {
+        let addr = InetAddr::from_str(" curvine-master-02.oppo.local:8995 ").unwrap();
+        assert_eq!(addr.hostname, "curvine-master-02.oppo.local");
+        assert_eq!(addr.port, 8995);
+    }
+
+    #[test]
+    fn new_trims_hostname() {
+        let addr = InetAddr::new(" curvine-master-02.oppo.local ", 8995);
+        assert_eq!(addr.hostname, "curvine-master-02.oppo.local");
+        assert_eq!(addr.port, 8995);
+    }
+
+    #[test]
+    fn parse_list_trims_mixed_comma_spacing() {
+        let addrs = InetAddr::parse_list(
+            "curvine-master-01.oppo.local:8995, curvine-master-02.oppo.local:8995,curvine-master-03.oppo.local:8995",
+        )
+        .unwrap();
+        assert_eq!(
+            addrs
+                .iter()
+                .map(|addr| addr.hostname.as_str())
+                .collect::<Vec<_>>(),
+            [
+                "curvine-master-01.oppo.local",
+                "curvine-master-02.oppo.local",
+                "curvine-master-03.oppo.local"
+            ]
+        );
+        assert!(addrs.iter().all(|addr| addr.port == 8995));
+    }
+
+    #[test]
+    fn parse_list_skips_empty_tokens() {
+        let addrs = InetAddr::parse_list("host-a:1,, host-b:2, ").unwrap();
+        assert_eq!(addrs[0], InetAddr::new("host-a", 1));
+        assert_eq!(addrs[1], InetAddr::new("host-b", 2));
     }
 }

--- a/crates/core/net/src/net/node_addr.rs
+++ b/crates/core/net/src/net/node_addr.rs
@@ -41,7 +41,7 @@ impl NodeAddr {
         Self::new(id, addr.hostname, addr.port)
     }
 
-    pub fn from_str(addr: impl Into<String>) -> IOResult<Self> {
+    pub fn from_str(addr: impl AsRef<str>) -> IOResult<Self> {
         let addr = InetAddr::from_str(addr)?;
         let id = Self::create_id(&addr.hostname, addr.port);
 

--- a/crates/sdk/curvine-sdk-core/src/filesystem_conf.rs
+++ b/crates/sdk/curvine-sdk-core/src/filesystem_conf.rs
@@ -197,7 +197,13 @@ impl FilesystemConf {
 
         let master_addrs = match InetAddr::parse_list(&self.master_addrs) {
             Ok(addrs) => addrs,
-            Err(_) => return err_box!("wrong format fs.cv.master_addrs {}", self.master_addrs),
+            Err(e) => {
+                return err_box!(
+                    "wrong format fs.cv.master_addrs {}: {}",
+                    self.master_addrs,
+                    e
+                );
+            }
         };
 
         let client = ClientConf {
@@ -332,6 +338,25 @@ mod tests {
                 "curvine-master-02.oppo.local",
                 "curvine-master-03.oppo.local"
             ]
+        );
+    }
+
+    #[test]
+    fn into_cluster_conf_includes_parse_error_for_invalid_master_addrs() {
+        let mut conf = FilesystemConf::with_master_addrs(["placeholder:8995"]).unwrap();
+        conf.master_addrs = "host-a:8995, host-b:not-a-port".to_string();
+
+        let err = conf
+            .into_cluster_conf()
+            .expect_err("invalid master_addrs must fail");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("wrong format fs.cv.master_addrs host-a:8995, host-b:not-a-port"),
+            "unexpected error: {msg}"
+        );
+        assert!(
+            msg.contains("invalid digit found in string"),
+            "parse error should be included: {msg}"
         );
     }
 

--- a/crates/sdk/curvine-sdk-core/src/filesystem_conf.rs
+++ b/crates/sdk/curvine-sdk-core/src/filesystem_conf.rs
@@ -191,24 +191,18 @@ impl FilesystemConf {
     }
 
     pub fn into_cluster_conf(self) -> FsResult<ClusterConf> {
-        let mut master_addrs = vec![];
-        if self.master_addrs.is_empty() {
+        if self.master_addrs.trim().is_empty() {
             return err_box!("fs.cv.master_addrs can not be empty");
         }
 
-        for node in self.master_addrs.split(",") {
-            let vec: Vec<&str> = node.split(":").collect();
-            if vec.len() != 2 {
-                return err_box!("wrong format fs.cv.master_addrs {}", self.master_addrs);
-            }
-            let hostname = vec[0].to_string();
-            let port: u16 = vec[1].parse()?;
-            master_addrs.push(InetAddr::new(hostname, port));
-        }
+        let master_addrs = match InetAddr::parse_list(&self.master_addrs) {
+            Ok(addrs) => addrs,
+            Err(_) => return err_box!("wrong format fs.cv.master_addrs {}", self.master_addrs),
+        };
 
         let client = ClientConf {
             master_addrs,
-            hostname: self.client_hostname,
+            hostname: self.client_hostname.trim().to_string(),
             io_threads: self.io_threads,
             worker_threads: self.worker_threads,
             replicas: self.replicas,
@@ -314,6 +308,32 @@ impl FilesystemConf {
 #[cfg(test)]
 mod tests {
     use super::{FilesystemConf, TransferClientConf};
+
+    #[test]
+    fn trims_whitespace_in_comma_separated_master_addrs() {
+        let mut conf = FilesystemConf::with_master_addrs(["placeholder:8995"]).unwrap();
+        // Production Hadoop/XML often inserts a space after only some commas.
+        // Without trim, only the padded hostname fails DNS, so a leader on that
+        // node looks like "all masters unavailable".
+        conf.master_addrs = "curvine-master-01.oppo.local:8995, curvine-master-02.oppo.local:8995,curvine-master-03.oppo.local:8995"
+            .to_string();
+
+        let cluster = conf.into_cluster_conf().unwrap();
+        let hostnames: Vec<&str> = cluster
+            .client
+            .master_addrs
+            .iter()
+            .map(|addr| addr.hostname.as_str())
+            .collect();
+        assert_eq!(
+            hostnames,
+            [
+                "curvine-master-01.oppo.local",
+                "curvine-master-02.oppo.local",
+                "curvine-master-03.oppo.local"
+            ]
+        );
+    }
 
     #[test]
     fn keeps_transfer_routing_in_cluster_conf() {

--- a/curvine-cli/src/main.rs
+++ b/curvine-cli/src/main.rs
@@ -97,18 +97,16 @@ impl CurvineArgs {
 
         // Priority 2: Override with CLI master_addrs if provided
         if let Some(master_addrs) = &self.master_addrs {
-            let mut vec = vec![];
-            for node in master_addrs.split(',') {
-                let tmp: Vec<&str> = node.split(':').collect();
-                if tmp.len() != 2 {
-                    return err_box!("Invalid master_addrs format: '{}'. Expected format: 'host1:port1,host2:port2'", master_addrs);
+            let vec = match InetAddr::parse_list(master_addrs) {
+                Ok(vec) => vec,
+                Err(e) => {
+                    return err_box!(
+                        "Invalid master_addrs format: '{}'. Expected format: 'host1:port1,host2:port2': {}",
+                        master_addrs,
+                        e
+                    );
                 }
-                let hostname = tmp[0].to_string();
-                let port: u16 = tmp[1]
-                    .parse()
-                    .map_err(|_| format!("Invalid port number in master_addrs: '{}'", tmp[1]))?;
-                vec.push(InetAddr::new(hostname, port));
-            }
+            };
             conf.client.master_addrs = vec;
             source = format!("{} + --master_addrs override", source);
         }

--- a/curvine-docker/fluid/config-parse.py
+++ b/curvine-docker/fluid/config-parse.py
@@ -261,6 +261,8 @@ exec {fuse_cmd}
         parsed_endpoints = []
         for endpoint in self._split_master_endpoints(endpoints):
             hostname, separator, port = endpoint.rpartition(':')
+            hostname = hostname.strip()
+            port = port.strip()
             if not separator or not hostname or not port:
                 raise ValueError(
                     f"Invalid master endpoint: {endpoint}, "

--- a/curvine-docker/fluid/tests/test_config_parse.py
+++ b/curvine-docker/fluid/tests/test_config_parse.py
@@ -64,6 +64,17 @@ class ConfigParseTest(unittest.TestCase):
         self.assertIn('hostname = "master-2"', rendered)
         self.assertIn('fs_path = "/starrocks/datacache"', rendered)
 
+    def test_master_endpoints_trim_mixed_comma_spacing(self):
+        parser = config_parse.ConfigParser()
+        parser.mount_options = {
+            "master-endpoints": "master-0:8995, master-1:8995,master-2:8995",
+        }
+        endpoints = parser.parse_master_endpoints()
+        self.assertEqual(
+            endpoints,
+            [("master-0", "8995"), ("master-1", "8995"), ("master-2", "8995")],
+        )
+
     def test_advanced_client_and_fuse_toml_options_are_rendered(self):
         rendered, script = self.run_parser({
             "mounts": [{

--- a/curvine-fuse/src/cli/mount_args.rs
+++ b/curvine-fuse/src/cli/mount_args.rs
@@ -298,16 +298,10 @@ impl FuseMountArgs {
         }
 
         if let Some(master_addrs) = &self.master_addrs {
-            let mut vec = vec![];
-            for node in master_addrs.split(",") {
-                let tmp: Vec<&str> = node.split(":").collect();
-                if tmp.len() != 2 {
-                    return err_box!("wrong format master_addrs {}", master_addrs);
-                }
-                let hostname = tmp[0].to_string();
-                let port: u16 = tmp[1].parse()?;
-                vec.push(InetAddr::new(hostname, port));
-            }
+            let vec = match InetAddr::parse_list(master_addrs) {
+                Ok(vec) => vec,
+                Err(_) => return err_box!("wrong format master_addrs {}", master_addrs),
+            };
             conf.client.master_addrs = vec;
         }
 

--- a/curvine-fuse/src/cli/mount_args.rs
+++ b/curvine-fuse/src/cli/mount_args.rs
@@ -300,7 +300,9 @@ impl FuseMountArgs {
         if let Some(master_addrs) = &self.master_addrs {
             let vec = match InetAddr::parse_list(master_addrs) {
                 Ok(vec) => vec,
-                Err(_) => return err_box!("wrong format master_addrs {}", master_addrs),
+                Err(e) => {
+                    return err_box!("wrong format master_addrs {}: {}", master_addrs, e);
+                }
             };
             conf.client.master_addrs = vec;
         }
@@ -405,6 +407,34 @@ mod tests {
             err.to_string().contains("fuse.io_threads must be > 0"),
             "unexpected error: {}",
             err
+        );
+    }
+
+    #[test]
+    fn get_conf_includes_parse_error_for_invalid_master_addrs() {
+        let conf_path = Utils::temp_file();
+        fs::write(&conf_path, "[fuse]\nio_threads = 1\n").expect("write test config");
+
+        let args = FuseMountArgs::try_parse_from([
+            "curvine-fuse",
+            "--conf",
+            &conf_path,
+            "--master-addrs",
+            "host-a:8995, host-b:not-a-port",
+        ])
+        .expect("parse mount arguments");
+        let result = args.get_conf();
+        let _ = fs::remove_file(&conf_path);
+
+        let err = result.expect_err("invalid master_addrs must fail");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("wrong format master_addrs host-a:8995, host-b:not-a-port"),
+            "unexpected error: {msg}"
+        );
+        assert!(
+            msg.contains("invalid digit found in string"),
+            "parse error should be included: {msg}"
         );
     }
 }

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineFileSystem.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineFileSystem.java
@@ -118,7 +118,7 @@ public class CurvineFileSystem extends FileSystem {
         return filesystemConf;
     }
 
-    private String getMasterAddrs(String name) throws IOException {
+    String getMasterAddrs(String name) throws IOException {
         String key = String.format("%s.%s.master_addrs", FilesystemConf.PREFIX, name);
         String addrs = getConf().get(key);
         if (StringUtils.isEmpty(addrs)) {

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineFileSystem.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineFileSystem.java
@@ -124,7 +124,7 @@ public class CurvineFileSystem extends FileSystem {
         if (StringUtils.isEmpty(addrs)) {
             throw new IOException(key + " not set");
         } else {
-            return addrs;
+            return FilesystemConf.normalizeCsv(addrs);
         }
     }
     @Override

--- a/curvine-libsdk/java/src/main/java/io/curvine/FilesystemConf.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/FilesystemConf.java
@@ -14,7 +14,6 @@
 
 package io.curvine;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -244,21 +243,6 @@ public class FilesystemConf {
         return builder.toString();
     }
 
-    private static String normalizeCsv(String value) {
-        StringBuilder builder = new StringBuilder();
-        for (String part : value.split(",")) {
-            String trimmed = part.trim();
-            if (trimmed.isEmpty()) {
-                continue;
-            }
-            if (builder.length() > 0) {
-                builder.append(',');
-            }
-            builder.append(trimmed);
-        }
-        return builder.toString();
-    }
-
     private static boolean isTransferField(Field field) {
         return "transfer_enabled".equals(field.getName())
                 || "transfer_endpoints".equals(field.getName())
@@ -274,15 +258,38 @@ public class FilesystemConf {
                 .replace("\t", "\\t");
     }
 
+    static String normalizeCsv(String value) {
+        StringBuilder builder = new StringBuilder();
+        for (String part : value.split(",")) {
+            String trimmed = part.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            if (builder.length() > 0) {
+                builder.append(',');
+            }
+            builder.append(trimmed);
+        }
+        return builder.toString();
+    }
+
+    static String trimEnvHostname(String hostname) {
+        if (hostname == null) {
+            return null;
+        }
+        String trimmed = hostname.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
     private String getClientHostname() {
         // In the k8s environment, POD_IP is used by default as client hostname
-        String hostname = System.getenv("POD_IP");
-        if (StringUtils.isEmpty(hostname)) {
+        String hostname = trimEnvHostname(System.getenv("POD_IP"));
+        if (hostname == null) {
             // Use CURVINE_CLIENT_HOSTNAME environment variable.
-            hostname = System.getenv(HOSTNAME_KEY);
+            hostname = trimEnvHostname(System.getenv(HOSTNAME_KEY));
         }
 
-        if (StringUtils.isNotEmpty(hostname)) {
+        if (hostname != null) {
             return hostname;
         } else {
             try {

--- a/curvine-libsdk/java/src/main/java/io/curvine/FilesystemConf.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/FilesystemConf.java
@@ -147,10 +147,15 @@ public class FilesystemConf {
             }
 
             field.setAccessible(true);
+            value = value.trim();
             String fieldType = field.getType().getName();
             switch (fieldType) {
                 case "java.lang.String":
-                    field.set(this, value);
+                    if ("master_addrs".equals(field.getName())) {
+                        field.set(this, normalizeCsv(value));
+                    } else {
+                        field.set(this, value);
+                    }
                     break;
                 case "int":
                     field.setInt(this, Integer.parseInt(value));
@@ -168,21 +173,21 @@ public class FilesystemConf {
 
         String transferEnabled = conf.get(PREFIX + ".transfer.enabled");
         if (transferEnabled != null) {
-            transfer_enabled = Boolean.parseBoolean(transferEnabled);
+            transfer_enabled = Boolean.parseBoolean(transferEnabled.trim());
         }
         String transferEndpoints = conf.get(PREFIX + ".transfer.endpoints");
         if (transferEndpoints != null) {
-            transfer_endpoints = transferEndpoints;
+            transfer_endpoints = normalizeCsv(transferEndpoints);
         }
         String transferClientPendingQueueSize =
                 conf.get(PREFIX + ".transfer.client_pending_queue_size");
         if (transferClientPendingQueueSize != null) {
-            transfer_client_pending_queue_size = Integer.parseInt(transferClientPendingQueueSize);
+            transfer_client_pending_queue_size = Integer.parseInt(transferClientPendingQueueSize.trim());
         }
         String transferClientSubmitConcurrency =
                 conf.get(PREFIX + ".transfer.client_submit_concurrency");
         if (transferClientSubmitConcurrency != null) {
-            transfer_client_submit_concurrency = Integer.parseInt(transferClientSubmitConcurrency);
+            transfer_client_submit_concurrency = Integer.parseInt(transferClientSubmitConcurrency.trim());
         }
     }
 
@@ -236,6 +241,21 @@ public class FilesystemConf {
                 .append(transfer_client_submit_concurrency)
                 .append("\n");
 
+        return builder.toString();
+    }
+
+    private static String normalizeCsv(String value) {
+        StringBuilder builder = new StringBuilder();
+        for (String part : value.split(",")) {
+            String trimmed = part.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            if (builder.length() > 0) {
+                builder.append(',');
+            }
+            builder.append(trimmed);
+        }
         return builder.toString();
     }
 

--- a/curvine-libsdk/java/src/test/java/io/curvine/LibFsTest.java
+++ b/curvine-libsdk/java/src/test/java/io/curvine/LibFsTest.java
@@ -51,11 +51,15 @@ public class LibFsTest {
     }
 
     @Test
-    public void namespacedMasterAddrsAreNormalized() {
-        // CurvineFileSystem.initialize overwrites constructor master_addrs with
-        // fs.cv.{ns}.master_addrs; that path must use the same CSV trim.
-        assert FilesystemConf.normalizeCsv("h1:8995, h2:8995,h3:8995")
-                .equals("h1:8995,h2:8995,h3:8995");
+    public void namespacedMasterAddrsAreNormalized() throws Exception {
+        // initialize() overwrites constructor master_addrs via getMasterAddrs(authority).
+        // Exercise that helper directly so a revert of normalizeCsv there fails the test.
+        CurvineFileSystem fs = new CurvineFileSystem();
+        Configuration conf = new Configuration();
+        conf.set("fs.cv.ns1.master_addrs", "h1:8995, h2:8995,h3:8995");
+        fs.setConf(conf);
+
+        assert fs.getMasterAddrs("ns1").equals("h1:8995,h2:8995,h3:8995");
     }
 
     @Test

--- a/curvine-libsdk/java/src/test/java/io/curvine/LibFsTest.java
+++ b/curvine-libsdk/java/src/test/java/io/curvine/LibFsTest.java
@@ -39,6 +39,18 @@ public class LibFsTest {
     }
 
     @Test
+    public void trimsMasterAddrsWhitespace() throws Exception {
+        Configuration conf = new Configuration();
+        conf.set("fs.cv.master_addrs", "localhost:9001, localhost:9002,localhost:9003");
+        conf.set("fs.cv.io_threads", " 16 ");
+
+        FilesystemConf filesystemConf = new FilesystemConf(conf);
+
+        assert filesystemConf.master_addrs.equals("localhost:9001,localhost:9002,localhost:9003");
+        assert filesystemConf.io_threads == 16;
+    }
+
+    @Test
     public void jni1() throws Exception {
         Configuration conf = new Configuration();
         conf.set("fs.cv.master_addrs", "localhost:6995");

--- a/curvine-libsdk/java/src/test/java/io/curvine/LibFsTest.java
+++ b/curvine-libsdk/java/src/test/java/io/curvine/LibFsTest.java
@@ -51,6 +51,21 @@ public class LibFsTest {
     }
 
     @Test
+    public void namespacedMasterAddrsAreNormalized() {
+        // CurvineFileSystem.initialize overwrites constructor master_addrs with
+        // fs.cv.{ns}.master_addrs; that path must use the same CSV trim.
+        assert FilesystemConf.normalizeCsv("h1:8995, h2:8995,h3:8995")
+                .equals("h1:8995,h2:8995,h3:8995");
+    }
+
+    @Test
+    public void clientHostnameEnvValuesAreTrimmed() {
+        assert FilesystemConf.trimEnvHostname(" 10.0.0.8 \n").equals("10.0.0.8");
+        assert FilesystemConf.trimEnvHostname("  ") == null;
+        assert FilesystemConf.trimEnvHostname(null) == null;
+    }
+
+    @Test
     public void jni1() throws Exception {
         Configuration conf = new Configuration();
         conf.set("fs.cv.master_addrs", "localhost:6995");

--- a/curvine-master/src/master/router_handler.rs
+++ b/curvine-master/src/master/router_handler.rs
@@ -212,7 +212,11 @@ async fn add_dcm(
     match params.get("workers") {
         None => err_box!("not params workers"),
         Some(v) => {
-            let list = v.split(",").map(|x| x.to_string()).collect();
+            let list = v
+                .split(",")
+                .map(|x| x.trim().to_string())
+                .filter(|x| !x.is_empty())
+                .collect();
             let res = wm.add_dcm(list);
             Ok(Json(res))
         }
@@ -236,7 +240,11 @@ async fn remove_dcm(
     match params.get("workers") {
         None => err_box!("not params workers"),
         Some(v) => {
-            let list = v.split(",").map(|x| x.to_string()).collect();
+            let list = v
+                .split(",")
+                .map(|x| x.trim().to_string())
+                .filter(|x| !x.is_empty())
+                .collect();
             let res = wm.remove_dcm(list);
             Ok(Json(res))
         }


### PR DESCRIPTION
# Summary

Trim whitespace when parsing comma-separated `host:port` lists and related hostname config. Mixed spacing after commas (common in Hadoop XML / CLI) previously left a leading space on some hostnames, so DNS failed for those nodes only. If that node was the Raft leader, clients treated the whole master set as unavailable even though the cluster was healthy.

# Issue Describe / Design

No tracking issue. Found in production.

- **Root cause:** `master_addrs` (and similar `host:port` lists) were split on `,` / `:` without `trim`. A value such as `h1:8995, h2:8995,h3:8995` produced hostname `" h2"`, which fails DNS. Followers still answered "Not a leader"; the padded leader never connected.
- **Reproduction:** Configure Java/CLI `master_addrs` with a space after only some commas; elect the padded node as leader; client reports all masters unavailable.
- **Fix approach:** Add `InetAddr::parse_list()` and trim at construction, serde, ClusterConf load, Java Hadoop config, Fluid endpoints, and DCM worker lists. Empty tokens are skipped.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `crates/core/net/src/net/inet_addr.rs` | Trim in `new`/`from_str`/serde; add `parse_list()` | Hostnames with surrounding whitespace are normalized |
| `crates/sdk/curvine-sdk-core/src/filesystem_conf.rs` | Parse `master_addrs` via `parse_list` | Java SDK HA list with mixed comma spacing works |
| `curvine-cli/src/main.rs`, `curvine-fuse/src/cli/mount_args.rs` | Use `parse_list` for `--master_addrs` | CLI/FUSE override no longer keeps leading spaces |
| `crates/common/curvine-config/src/cluster_conf.rs` | `normalize_whitespace()` on load; trim hostname env vars | TOML hostnames / `data_dir` / endpoints are trimmed |
| `client_conf.rs`, `raft_peer.rs`, `transfer_conf.rs`, `worker_conf.rs` | Trim hostnames, endpoints, data-dir paths | Same values with padding become valid |
| `curvine-libsdk/java/.../FilesystemConf.java` | Trim Hadoop values; normalize CSV `master_addrs` / transfer endpoints | XML whitespace no longer poisons native TOML |
| `curvine-docker/fluid/config-parse.py` | Strip hostname/port after split | ThinRuntime endpoints tolerate padding |
| `curvine-master/src/master/router_handler.rs` | Trim DCM worker CSV tokens | Query lists ignore empty/padded names |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-net --lib` | PASS | `parse_list` mixed spacing + empty tokens |
| `cargo test -p curvine-config --lib` | PASS | TOML hostname / data_dir / endpoints trim |
| `cargo test -p curvine-sdk-core --lib` | PASS | Production-style `master_addrs` string |
| `python3 -m unittest curvine-docker/fluid/tests/test_config_parse.py` | PASS | Fluid mixed comma spacing |
| `make format` | PASS | Pre-commit format + check |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None