### PR TITLE
fix(sdk): derive CurvineFsStat used from allocatable view (#1460)

### DIFF
--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineFsStat.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineFsStat.java
@@ -24,23 +24,10 @@ public class CurvineFsStat extends FsStatus {
     private final GetFilesystemInfoResponse info;
 
     public CurvineFsStat(GetFilesystemInfoResponse info) {
-        // Report the allocatable (writable) view so Hadoop/Spark remaining-space
-        // checks only see Live workers. Legacy masters omit tags 15/16; protobuf
-        // returns 0 for an absent optional int64 with default=0, so we must guard
-        // with hasAllocatableCapacity()/hasAllocatableAvailable() and fall back to
-        // the aggregate totals — otherwise a new client against an old master
-        // would report zero free space.
-        //
-        // Used is derived as Capacity - Remaining rather than info.getFsUsed()
-        // (which sums every non-lost worker, including Blacklist/Decommission).
-        // Capacity/Remaining are Live-only, so deriving Used keeps the FsStatus
-        // triple self-consistent (Used == Capacity - Remaining) even when
-        // non-writable workers still hold data — otherwise getUsed() could
-        // exceed getCapacity() - getRemaining() and report a misleading ratio.
-        // The master-reported total fs_used is still surfaced in simple().
-        long capacity = info.hasAllocatableCapacity() ? info.getAllocatableCapacity() : info.getCapacity();
-        long remaining = info.hasAllocatableAvailable() ? info.getAllocatableAvailable() : info.getAvailable();
-        super(capacity, Math.max(0, capacity - remaining), remaining);
+        // super(...) must be the first statement, so the allocatable fallback
+        // and used derivation live in static helpers below. See the comment on
+        // allocatableCapacity/allocatableAvailable for the rationale.
+        super(allocatableCapacity(info), allocatableUsed(info), allocatableRemaining(info));
         this.info = info;
     }
 
@@ -204,5 +191,34 @@ public class CurvineFsStat extends FsStatus {
         }
 
         return builder.toString();
+    }
+
+    // The allocatable (writable) view: capacity/available eligible for new
+    // writes (Live workers only). Legacy masters omit tags 15/16; protobuf
+    // returns 0 for an absent optional int64 with default=0, so we must guard
+    // with hasAllocatableCapacity()/hasAllocatableAvailable() and fall back to
+    // the aggregate totals — otherwise a new client against an old master
+    // would report zero free space.
+    //
+    // Used is derived as Capacity - Remaining rather than info.getFsUsed()
+    // (which sums every non-lost worker, including Blacklist/Decommission).
+    // Capacity/Remaining are Live-only, so deriving Used keeps the FsStatus
+    // triple self-consistent (Used == Capacity - Remaining) even when
+    // non-writable workers still hold data — otherwise getUsed() could
+    // exceed getCapacity() - getRemaining() and report a misleading ratio.
+    // The master-reported total fs_used is still surfaced in simple().
+    // These are static so they can run before super(...) completes.
+    private static long allocatableCapacity(GetFilesystemInfoResponse info) {
+        return info.hasAllocatableCapacity() ? info.getAllocatableCapacity() : info.getCapacity();
+    }
+
+    private static long allocatableRemaining(GetFilesystemInfoResponse info) {
+        return info.hasAllocatableAvailable() ? info.getAllocatableAvailable() : info.getAvailable();
+    }
+
+    private static long allocatableUsed(GetFilesystemInfoResponse info) {
+        long capacity = allocatableCapacity(info);
+        long remaining = allocatableRemaining(info);
+        return Math.max(0, capacity - remaining);
     }
 }

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineFsStat.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineFsStat.java
@@ -30,11 +30,17 @@ public class CurvineFsStat extends FsStatus {
         // with hasAllocatableCapacity()/hasAllocatableAvailable() and fall back to
         // the aggregate totals — otherwise a new client against an old master
         // would report zero free space.
-        super(
-                info.hasAllocatableCapacity() ? info.getAllocatableCapacity() : info.getCapacity(),
-                info.getFsUsed(),
-                info.hasAllocatableAvailable() ? info.getAllocatableAvailable() : info.getAvailable()
-        );
+        //
+        // Used is derived as Capacity - Remaining rather than info.getFsUsed()
+        // (which sums every non-lost worker, including Blacklist/Decommission).
+        // Capacity/Remaining are Live-only, so deriving Used keeps the FsStatus
+        // triple self-consistent (Used == Capacity - Remaining) even when
+        // non-writable workers still hold data — otherwise getUsed() could
+        // exceed getCapacity() - getRemaining() and report a misleading ratio.
+        // The master-reported total fs_used is still surfaced in simple().
+        long capacity = info.hasAllocatableCapacity() ? info.getAllocatableCapacity() : info.getCapacity();
+        long remaining = info.hasAllocatableAvailable() ? info.getAllocatableAvailable() : info.getAvailable();
+        super(capacity, Math.max(0, capacity - remaining), remaining);
         this.info = info;
     }
 

--- a/curvine-libsdk/java/src/test/java/io/curvine/CurvineFsStatTest.java
+++ b/curvine-libsdk/java/src/test/java/io/curvine/CurvineFsStatTest.java
@@ -1,0 +1,101 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.curvine;
+
+import io.curvine.proto.GetFilesystemInfoResponse;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Locks in the CurvineFsStat invariant: the FsStatus triple
+ * (capacity, used, remaining) must be self-consistent on the Live-only
+ * allocatable view, i.e. {@code used == max(0, capacity - remaining)} and
+ * {@code used} must NOT fall back to the master's all-workers {@code fs_used}
+ * (which can exceed {@code capacity - remaining} when Blacklist/Decommission
+ * workers still hold data). Mirrors the Rust-side assertions in
+ * {@code get_filesystem_info_compat_test.rs} and the {@code cv df} path.
+ *
+ * <p>See https://github.com/CurvineIO/curvine/pull/1615 (follow-up to #1610).
+ */
+public class CurvineFsStatTest {
+
+    private static GetFilesystemInfoResponse.Builder baseResponse() {
+        // All proto2 required fields are populated so build() succeeds; the
+        // allocatable fields are left to each case to set (or omit).
+        return GetFilesystemInfoResponse.newBuilder()
+                .setActiveMaster("master:8995")
+                .setInodeDirNum(0)
+                .setInodeFileNum(0)
+                .setBlockNum(0)
+                .setNonFsUsed(0)
+                .setReservedBytes(0);
+    }
+
+    @Test
+    public void allocatableViewIsSelfConsistentAndIgnoresFsUsed() {
+        // capacity=1000/available=400 across ALL workers; allocatable_* are the
+        // Live-only subset (600/200). fs_used=300 is intentionally a distractor
+        // to prove getUsed() is derived from the allocatable view, not fs_used.
+        GetFilesystemInfoResponse info = baseResponse()
+                .setCapacity(1000)
+                .setAvailable(400)
+                .setFsUsed(300)
+                .setAllocatableCapacity(600)
+                .setAllocatableAvailable(200)
+                .build();
+
+        CurvineFsStat stat = new CurvineFsStat(info);
+
+        Assert.assertEquals(600, stat.getCapacity());
+        Assert.assertEquals(200, stat.getRemaining());
+        // used must be max(0, capacity - remaining) = 400, NOT fs_used (300).
+        Assert.assertEquals(400, stat.getUsed());
+        Assert.assertNotEquals(
+                "getUsed() must derive from the allocatable view, not fs_used",
+                info.getFsUsed(), stat.getUsed());
+        assertSelfConsistent(stat);
+    }
+
+    @Test
+    public void legacyMasterFallsBackToTotalAndStillDerivesUsed() {
+        // A legacy master omits the allocatable fields (tags 15/16). The stat
+        // must fall back to the aggregate capacity/available and still derive
+        // used = max(0, capacity - remaining) so it never reports zero free
+        // space against a mixed-version master.
+        GetFilesystemInfoResponse info = baseResponse()
+                .setCapacity(1000)
+                .setAvailable(400)
+                .setFsUsed(300)
+                // allocatable_capacity / allocatable_available intentionally absent.
+                .build();
+
+        Assert.assertFalse(info.hasAllocatableCapacity());
+        Assert.assertFalse(info.hasAllocatableAvailable());
+
+        CurvineFsStat stat = new CurvineFsStat(info);
+
+        Assert.assertEquals(1000, stat.getCapacity());
+        Assert.assertEquals(400, stat.getRemaining());
+        Assert.assertEquals(600, stat.getUsed());
+        assertSelfConsistent(stat);
+    }
+
+    private static void assertSelfConsistent(CurvineFsStat stat) {
+        long expectedUsed = Math.max(0, stat.getCapacity() - stat.getRemaining());
+        Assert.assertEquals(
+                "used must equal max(0, capacity - remaining)",
+                expectedUsed, stat.getUsed());
+    }
+}


### PR DESCRIPTION
# Summary

Follow-up to #1610 (which closed #1460). The merged `CurvineFsStat` constructor passed `info.getFsUsed()` as the Hadoop `FsStatus` used, while `Capacity` and `Remaining` already use the Live-only allocatable view. `fs_used` sums every non-lost worker (including Blacklist/Decommission), so when non-writable workers still hold data, `getUsed()` could exceed `getCapacity() - getRemaining()`, yielding a misleading usage ratio. This derives `used = max(0, capacity - remaining)` so the `FsStatus` triple is self-consistent.

# Issue Describe / Design

- Root cause: mixed scopes inside one FsStatus — used was all-workers, capacity/remaining were Live-only.
- Fix: derive used from the same allocatable view, mirroring the Rust cv df logic from #1610.
- Trade-off: FsStatus.getUsed() no longer equals the master-reported total fs_used; that value is still surfaced in simple() for the physical-usage view. Spark write decision uses getRemaining() (unchanged, already correct).

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| curvine-libsdk/java/.../CurvineFsStat.java | Constructor derives used = max(0, capacity - remaining) instead of info.getFsUsed() | FsStatus.getUsed() now Live-only-consistent; may differ from master total fs_used (still in simple()) |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| Java build (mvn) | pending CI | No local mvn; CI regenerates proto bindings and compiles CurvineFsStat |

# Dependencies

- Follow-up to: #1610 (merged)
- Related issues: #1460 (closed)