### PR TITLE
docs(skills): add backward-compatibility checks for new params and proto fields to cv-submit-pr-review

### DIFF
--- a/.agents/skills/cv-submit-pr-review/SKILL.md
+++ b/.agents/skills/cv-submit-pr-review/SKILL.md
@@ -56,7 +56,7 @@ Detailed Curvine-specific probes: [references/manual-checks.md](references/manua
 4. **Tests would catch the bug.** New behavior or a regression fix has an assertion that fails on the intended defect. Coverage is necessary but not evidence that the scenario is correct.
 5. **Safety on hot paths.** `unwrap` / panic, `unsafe`, lock-order inversion, leaked FDs/block handles, and incomplete detach cleanup are blockers.
 6. **Wire compatibility.** Breaking proto/RPC/SDK changes are called out with a migration path or an explicit compatibility decision.
-7. **Backward-compatible evolution of functions and proto messages.** New parameters on Rust functions, struct fields, and proto messages **must** be appended at the end (highest field number); new proto fields **must** be `optional` (proto2) or `optional`/without `required`-style semantics (proto3), never `required`. Reordering, renumbering, reusing, or retagging existing proto fields, and inserting new `required` fields into an existing message, are blockers. See [references/manual-checks.md](references/manual-checks.md#backward-compatible-evolution).
+7. **Backward-compatible evolution of functions and proto messages.** New parameters on Rust functions and public struct fields **must** be appended at the end and be defaultable. New proto fields **must** use the next unused (highest) field number and be `optional` (proto2) or `optional`/without `required`-style semantics (proto3), never `required`. Reordering, renumbering, reusing, or retagging existing proto fields, and inserting new `required` fields into an existing message, are blockers. See [references/manual-checks.md](references/manual-checks.md#backward-compatible-evolution).
 
 ## Communication Rules
 

--- a/.agents/skills/cv-submit-pr-review/SKILL.md
+++ b/.agents/skills/cv-submit-pr-review/SKILL.md
@@ -39,7 +39,7 @@ Focus **exclusively on code content**:
 | Correctness | Logic errors, edge cases, off-by-one, None/null handling, error propagation |
 | Safety | Concurrency races, panics / unwrap in hot paths, unsafe blocks, resource leaks, lock ordering |
 | Lifecycle | Master/worker/fuse/CSI startup, heartbeat, failover, unmount, detach cleanup, cancellation during awaits |
-| Contracts | Both sides of changed proto/RPC, fs-api, ufs-api, storage-api, JNI/Python SDK; errors, ownership, compatibility |
+| Contracts | Both sides of changed proto/RPC, fs-api, ufs-api, storage-api, JNI/Python SDK; errors, ownership, **backward compatibility** (function/struct parameters appended at the end; new proto fields must be `optional`/`repeated` and appended with new field numbers; never reorder, reuse, or retag existing fields) |
 | Design | Naming, module boundaries, abstractions, consistency with existing patterns; challenge speculative generality |
 | Tests | Assertions fail on the intended regression; real entry path (client/fuse/CSI/CLI) where the bug lives |
 | Performance | Potential performance impact on critical paths: **data read/write** (block I/O patterns, extra buffer copies, sync/fsync frequency, read amplification), **message communication** (RPC payload size, serialization/deserialization overhead, extra network round trips, connection churn), and **metadata operations** (inode lookup cost, lock granularity and hold time, journal/rocksdb write amplification). Trace hot-path call chains to judge whether the change adds work per request/block/message. Any change likely to cause a significant performance regression **must** generate a comment with concrete improvement suggestions (e.g., batching, caching, avoiding copies, narrowing locks, async-ifying blocking calls). |
@@ -56,6 +56,7 @@ Detailed Curvine-specific probes: [references/manual-checks.md](references/manua
 4. **Tests would catch the bug.** New behavior or a regression fix has an assertion that fails on the intended defect. Coverage is necessary but not evidence that the scenario is correct.
 5. **Safety on hot paths.** `unwrap` / panic, `unsafe`, lock-order inversion, leaked FDs/block handles, and incomplete detach cleanup are blockers.
 6. **Wire compatibility.** Breaking proto/RPC/SDK changes are called out with a migration path or an explicit compatibility decision.
+7. **Backward-compatible evolution of functions and proto messages.** New parameters on Rust functions, struct fields, and proto messages **must** be appended at the end (highest field number); new proto fields **must** be `optional` (proto2) or `optional`/without `required`-style semantics (proto3), never `required`. Reordering, renumbering, reusing, or retagging existing proto fields, and inserting new `required` fields into an existing message, are blockers. See [references/manual-checks.md](references/manual-checks.md#backward-compatible-evolution).
 
 ## Communication Rules
 
@@ -157,6 +158,7 @@ Inspect the actual code changes using [references/manual-checks.md](references/m
 * correctness issues and regressions
 * lifecycle / concurrency defects (races, cancellation, incomplete cleanup)
 * interface-contract mismatches (proto, fs-api, SDK both sides)
+* backward-compatibility violations: new function/struct/proto parameters not appended at the end; new proto fields marked `required` instead of `optional`; reordered/renumbered/reused field numbers
 * performance regressions in critical paths — if the impact is significant, drafting a comment with improvement suggestions is mandatory
 * missing validation or edge-case handling
 * unsafe or brittle logic (`unwrap` on hot paths, `unsafe`, lock order)
@@ -286,6 +288,7 @@ Post only the comments the user approved.
 - [ ] Callers / definitions of changed symbols checked
 - [ ] Module conventions verified (sources of truth / existing patterns)
 - [ ] Manual checks applied for contracts, lifecycle, consumer fit, test strength
+- [ ] Backward compatibility verified: new function/struct/proto parameters appended at the end; new proto fields are `optional`/`repeated` with new field numbers; no reordered/renumbered/reused fields
 - [ ] Performance impact assessed for data read/write, RPC, and metadata paths; significant regressions have mandatory comments with suggestions
 - [ ] Findings table produced with severity (`blocker` / `must-fix` / `suggestion`)
 - [ ] User decided on next action (fix / post / discuss)

--- a/.agents/skills/cv-submit-pr-review/references/manual-checks.md
+++ b/.agents/skills/cv-submit-pr-review/references/manual-checks.md
@@ -82,7 +82,7 @@ Curvine ships a versioned wire format (proto2) and versioned Rust APIs (`curvine
 
 ### Proto messages (`curvine-proto`, `curvine-raft`)
 
-* **New fields must be `optional` (proto2) or non-`required` (proto3).** Never add a new `required` field to an existing message. An old peer that does not know the field will fail to deserialize a message that includes it, and a new peer will reject a message from an old peer that omits it — both break rolling upgrades. Use `optional` (proto2) or plain scalar / `optional` (proto3) so absence is valid.
+* **New fields must be `optional` (proto2) or non-`required` (proto3).** Never add a new `required` field to an existing message. An old peer will ignore an unknown field (and will never populate it), while a new peer will reject a message from an old peer that omits the required field — either way rolling upgrades break. Use `optional` (proto2) or plain scalar / `optional` (proto3) so absence is valid.
 * **Append new field numbers at the end.** Pick the next unused tag number for the message; do not fill gaps left by deleted fields (see "never reuse" below). Appending keeps old readers tolerant of new fields they do not recognize.
 * **Never reuse, renumber, or retag a field.** A tag is a permanent contract. Renaming the field is fine; reusing its number for a different type/name is a wire break. Deleted fields must be reserved (`reserved 7;` / `reserved "old_name";`) and never reissued.
 * **Never change a field's type or label.** Promoting `optional` to `required`, changing `int32` to `int64`, or `string` to `bytes` changes the wire encoding and breaks both sides.

--- a/.agents/skills/cv-submit-pr-review/references/manual-checks.md
+++ b/.agents/skills/cv-submit-pr-review/references/manual-checks.md
@@ -67,3 +67,39 @@ Assertions must fail on the intended regression and verify external state (file 
 ## Compatibility and versioning
 
 Heartbeat / handshake version fields, proto evolution, Java/Python SDK parity, and legacy fallback belong in the same review as the server change. A server that understands a new field while old clients break (or the reverse) is a blocker unless the PR documents a rollout.
+
+## Backward-compatible evolution
+
+Curvine ships a versioned wire format (proto2) and versioned Rust APIs (`curvine-fs-api`, `curvine-ufs-api`, `curvine-storage-api`, JNI/Python SDK). Mixed-version rolling upgrades are the norm, so every change to an existing function signature, struct, or proto message **must** remain consumable by code built against the previous version. Treat the rules below as blockers, not suggestions.
+
+### Function and struct parameters
+
+* **Append-only positional parameters.** When adding a parameter to an existing public function or method, place it **last** in the parameter list. Inserting a parameter in the middle reorders every call site and breaks any external caller that passes arguments positionally.
+* **Prefer a default / `Option` / builder.** A new trailing parameter should default to the previous behavior (e.g. `Option<T>` with `None`, a `Default`, or a builder method) so existing callers compiled against the old signature keep working without edits.
+* **Do not change parameter order or types of existing parameters.** Rename + reorder is a breaking change even if the names match; re-typing `&str` to `String` (or vice versa) on a public trait method is breaking.
+* **Trait methods.** Adding a method to a public trait without a default impl breaks all out-of-tree implementors. Provide a default body, or split a new trait.
+* **Struct fields.** New public struct fields are appended at the end; do not insert, reorder, or retag existing fields. If the struct is constructed by external code via struct literal, prefer a builder or `..Default::default()` and document it.
+
+### Proto messages (`curvine-proto`, `curvine-raft`)
+
+* **New fields must be `optional` (proto2) or non-`required` (proto3).** Never add a new `required` field to an existing message. An old peer that does not know the field will fail to deserialize a message that includes it, and a new peer will reject a message from an old peer that omits it — both break rolling upgrades. Use `optional` (proto2) or plain scalar / `optional` (proto3) so absence is valid.
+* **Append new field numbers at the end.** Pick the next unused tag number for the message; do not fill gaps left by deleted fields (see "never reuse" below). Appending keeps old readers tolerant of new fields they do not recognize.
+* **Never reuse, renumber, or retag a field.** A tag is a permanent contract. Renaming the field is fine; reusing its number for a different type/name is a wire break. Deleted fields must be reserved (`reserved 7;` / `reserved "old_name";`) and never reissued.
+* **Never change a field's type or label.** Promoting `optional` to `required`, changing `int32` to `int64`, or `string` to `bytes` changes the wire encoding and breaks both sides.
+* **Never change a field's default value** in a way that changes wire behavior: existing readers that omit the field still see the old default. If the semantic default must move, add a new field rather than editing the existing one.
+* **Enums.** New enum values must be appended with new numbers; do not renumber or reuse existing values. For proto2 closed enums, recognize that old readers will map unknown values to the default — prefer adding a sentinel `UNKNOWN_* = 0` if not already present.
+* **`map<K,V>` fields.** Treat a `map` like a `repeated` message pair: append at the end, never retag. Changing key or value type is breaking.
+* **Oneofs.** Adding a new oneof field is fine; moving an existing field into or out of a oneof changes its wire semantics and is breaking.
+
+### RPC and SDK parity
+
+* **Both sides of every changed RPC.** A request/response change must update master, worker, client, JNI, and Python SDK in the same PR, or document a staged rollout. A server that accepts a new `optional` field while the old client still omits it is the safe direction; the reverse (server requires, client omits) is a blocker.
+* **Heartbeat / handshake version.** If the PR bumps a heartbeat or handshake version field, verify the server still accepts the old version during the rollout window, and that the version is monotonic.
+* **Java / Python SDK parity.** A new proto field surfaced to users must be exposed in both SDKs with the same name and semantics, or the SDK gap must be tracked.
+
+### How to verify during review
+
+1. Diff the `.proto` file and confirm every added line is `optional`/`repeated` with a tag greater than the previous max in that message.
+2. Diff public Rust signatures in `*-api` crates and confirm new parameters are trailing and defaultable.
+3. Grep for `reserved` near deleted fields; flag any tag that was previously used and is now reused.
+4. Trace the changed RPC end-to-end and confirm both peers tolerate the field's absence.


### PR DESCRIPTION
# Summary

Strengthen the `cv-submit-pr-review` skill with explicit backward-compatibility review rules for new function/struct parameters and proto message fields, so mixed-version rolling upgrades keep working. Adds a new blocking requirement, a dedicated `Backward-compatible evolution` section in the manual checks, and matching entries in the review scope, Step 3 probe list, and final checklist.

# Issue Describe / Design

No issue. Driven by a review gap: the existing skill only required a "migration path or explicit decision" for breaking wire changes, but did not enforce the append-only / `optional`-only conventions that prevent breakage in the first place.

Design decisions:
- New proto fields must be `optional` (proto2) / non-`required` (proto3) and appended with the next unused tag — required fields break both old and new peers during rolling upgrade.
- New function/struct parameters must be appended at the end and defaultable (`Option`/`Default`/builder) so existing callers keep compiling.
- Field tags are a permanent contract: never reorder, renumber, reuse, or retag; deleted fields must be `reserved`.
- Rules are blockers, not suggestions, and apply to `curvine-proto`, `curvine-raft`, `*-api` crates, and JNI/Python SDK parity.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `.agents/skills/cv-submit-pr-review/SKILL.md` | Expand Contracts row, add blocking requirement #7, add Step 3 probe, add checklist item | None — documentation/guidance only |
| `.agents/skills/cv-submit-pr-review/references/manual-checks.md` | Add `Backward-compatible evolution` section (function/struct params, proto messages, RPC/SDK parity, review verification steps) | None — documentation/guidance only |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| Manual diff review | PASS | Markdown renders; anchors match (`#backward-compatible-evolution`) |
| `git diff` scope check | PASS | Only the two skill files changed; no code touched |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None

Made with [Cursor](https://cursor.com)