### PR TITLE
feat(mds): add standalone service scaffold

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2492,6 +2492,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "curvine-mds"
+version = "0.2.0"
+dependencies = [
+ "curvine-config",
+ "curvine-core-error",
+ "curvine-runtime",
+ "log",
+ "tokio",
+]
+
+[[package]]
 name = "curvine-metrics"
 version = "0.2.0"
 dependencies = [
@@ -2683,6 +2694,7 @@ dependencies = [
  "curvine-io",
  "curvine-job-client",
  "curvine-master",
+ "curvine-mds",
  "curvine-model",
  "curvine-net",
  "curvine-proto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ members = [
     "crates/adapters/curvine-ufs-oss-hdfs",
     "crates/adapters/curvine-hdfs-jni",
     "crates/server/curvine-data-transfer",
+    "curvine-mds",
     "curvine-master",
     "curvine-worker",
     "curvine-server",
@@ -83,6 +84,7 @@ default-members = [
     "crates/metadata/curvine-raft",
     "crates/adapters/curvine-storage-local",
     "crates/server/curvine-data-transfer",
+    "curvine-mds",
     "curvine-master",
     "curvine-worker",
     "curvine-server",
@@ -120,6 +122,7 @@ curvine-ufs-opendal = { path = "crates/adapters/curvine-ufs-opendal" }
 curvine-ufs-oss-hdfs = { path = "crates/adapters/curvine-ufs-oss-hdfs" }
 curvine-hdfs-jni = { path = "crates/adapters/curvine-hdfs-jni" }
 curvine-data-transfer = { path = "crates/server/curvine-data-transfer" }
+curvine-mds = { path = "curvine-mds" }
 curvine-fault = { path = "crates/core/curvine-fault" }
 curvine-metrics = { path = "crates/core/curvine-metrics" }
 curvine-error = { path = "crates/common/curvine-error" }

--- a/build/bin/curvine-mds.sh
+++ b/build/bin/curvine-mds.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+#
+# Copyright 2025 OPPO.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+BIN_DIR="$(cd "`dirname "$0"`"; pwd)"
+if [[ "$1" == "--version-json" ]] || [[ "$1" == "--version" ]] || [[ "$1" == "-V" ]]; then
+  source "${BIN_DIR}/../conf/curvine-env.sh"
+  "${CURVINE_HOME}/lib/curvine-server" --service mds "$1"
+  exit $?
+fi
+
+"${BIN_DIR}"/launch-process.sh mds $1

--- a/build/bin/launch-process.sh
+++ b/build/bin/launch-process.sh
@@ -68,7 +68,7 @@ start() {
     check
 
     name="unknown"
-    if [[ "$SERVICE_NAME" = "worker" ]] || [[ "$SERVICE_NAME" = "master" ]] || [[ "$SERVICE_NAME" = "transfer" ]]; then
+    if [[ "$SERVICE_NAME" = "worker" ]] || [[ "$SERVICE_NAME" = "master" ]] || [[ "$SERVICE_NAME" = "mds" ]] || [[ "$SERVICE_NAME" = "transfer" ]]; then
       name="curvine-server"
       nohup "${CURVINE_HOME}/lib/curvine-server" \
       --service ${SERVICE_NAME} \

--- a/crates/common/curvine-config/src/cluster_conf.rs
+++ b/crates/common/curvine-config/src/cluster_conf.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::{
-    CliConf, ClientConf, DBConf, FuseConf, JobConf, JournalConf, MasterConf, TransferConf,
+    CliConf, ClientConf, DBConf, FuseConf, JobConf, JournalConf, MasterConf, MdsConf, TransferConf,
     WorkerConf,
 };
 use curvine_core_error::{err_box, try_err, CommonResult};
@@ -50,6 +50,8 @@ pub struct ClusterConf {
     pub net_interface: String,
 
     pub master: MasterConf,
+
+    pub mds: MdsConf,
 
     // Log synchronization configuration.
     pub journal: JournalConf,
@@ -96,6 +98,7 @@ impl ClusterConf {
         conf.normalize_whitespace();
         conf.apply_hostname_overrides()?;
         conf.master.init()?;
+        conf.mds.init()?;
         conf.client.init()?;
         conf.fuse.init()?;
         conf.job.init()?;
@@ -328,6 +331,22 @@ impl ClusterConf {
         web_conf
     }
 
+    pub fn mds_server_conf(&self) -> ServerConf {
+        let mut conf = ServerConf::with_hostname(&self.mds.hostname, self.mds.rpc_port);
+        conf.name = format!("{}-mds", self.cluster_id);
+        conf.io_threads = self.mds.io_threads;
+        conf.worker_threads = self.mds.worker_threads;
+        conf
+    }
+
+    pub fn mds_web_conf(&self) -> ServerConf {
+        let mut conf = ServerConf::with_hostname(&self.mds.hostname, self.mds.web_port);
+        conf.name = format!("{}-mds", self.cluster_id);
+        conf.io_threads = self.mds.io_threads;
+        conf.worker_threads = self.mds.worker_threads;
+        conf
+    }
+
     pub fn worker_addr(&self) -> InetAddr {
         InetAddr::new(self.worker.hostname.clone(), self.worker.rpc_port)
     }
@@ -494,6 +513,7 @@ impl Default for ClusterConf {
             cluster_id: "curvine".to_string(),
             net_interface: String::new(),
             master: Default::default(),
+            mds: Default::default(),
             journal: Default::default(),
             worker: Default::default(),
             fault_injection: Default::default(),
@@ -679,7 +699,24 @@ mod tests {
         let conf = ClusterConf::from(path).unwrap();
 
         assert_eq!(conf.master.rpc_port, ClusterConf::DEFAULT_MASTER_PORT);
+        assert!(!conf.mds.enabled);
         assert!(!conf.client.master_addrs.is_empty());
+    }
+
+    #[test]
+    fn legacy_config_without_mds_uses_disabled_defaults() {
+        let conf: ClusterConf = toml::from_str(
+            r#"
+                cluster_id = "legacy"
+
+                [master]
+            "#,
+        )
+        .unwrap();
+
+        assert!(!conf.mds.enabled);
+        assert_eq!(conf.mds.rpc_port, crate::MdsConf::DEFAULT_RPC_PORT);
+        assert_eq!(conf.mds.web_port, crate::MdsConf::DEFAULT_WEB_PORT);
     }
 
     #[test]

--- a/crates/common/curvine-config/src/cluster_conf.rs
+++ b/crates/common/curvine-config/src/cluster_conf.rs
@@ -88,6 +88,7 @@ impl ClusterConf {
     pub const DEFAULT_FUSE_WEB_PORT: u16 = 9003;
 
     pub const ENV_MASTER_HOSTNAME: &'static str = "CURVINE_MASTER_HOSTNAME";
+    pub const ENV_MDS_HOSTNAME: &'static str = "CURVINE_MDS_HOSTNAME";
     pub const ENV_WORKER_HOSTNAME: &'static str = "CURVINE_WORKER_HOSTNAME";
     pub const ENV_CLIENT_HOSTNAME: &'static str = "CURVINE_CLIENT_HOSTNAME";
     pub const ENV_TRANSFER_HOSTNAME: &'static str = "CURVINE_TRANSFER_HOSTNAME";
@@ -98,7 +99,9 @@ impl ClusterConf {
         conf.normalize_whitespace();
         conf.apply_hostname_overrides()?;
         conf.master.init()?;
-        conf.mds.init()?;
+        if conf.mds.enabled {
+            conf.mds.init()?;
+        }
         conf.client.init()?;
         conf.fuse.init()?;
         conf.job.init()?;
@@ -126,6 +129,7 @@ impl ClusterConf {
     fn normalize_whitespace(&mut self) {
         self.net_interface = self.net_interface.trim().to_string();
         self.master.hostname = self.master.hostname.trim().to_string();
+        self.mds.hostname = self.mds.hostname.trim().to_string();
         self.journal.hostname = self.journal.hostname.trim().to_string();
         self.worker.hostname = self.worker.hostname.trim().to_string();
         self.client.hostname = self.client.hostname.trim().to_string();
@@ -170,6 +174,7 @@ impl ClusterConf {
             // eprintln! to make the warning visible on stderr.
             for env_key in [
                 Self::ENV_MASTER_HOSTNAME,
+                Self::ENV_MDS_HOSTNAME,
                 Self::ENV_WORKER_HOSTNAME,
                 Self::ENV_CLIENT_HOSTNAME,
                 Self::ENV_TRANSFER_HOSTNAME,
@@ -184,6 +189,7 @@ impl ClusterConf {
             }
 
             self.master.hostname = ip.clone();
+            self.mds.hostname = ip.clone();
             self.journal.hostname = ip.clone();
             self.worker.hostname = ip.clone();
             self.client.hostname = ip.clone();
@@ -198,6 +204,10 @@ impl ClusterConf {
             // Apply worker hostname from environment variable (used by worker process)
             if let Ok(v) = env::var(Self::ENV_WORKER_HOSTNAME) {
                 self.worker.hostname = v.trim().to_string();
+            }
+
+            if let Ok(v) = env::var(Self::ENV_MDS_HOSTNAME) {
+                self.mds.hostname = v.trim().to_string();
             }
 
             // Apply client hostname from environment variable
@@ -329,22 +339,6 @@ impl ClusterConf {
         web_conf.io_threads = self.master.io_threads;
         web_conf.worker_threads = self.master.worker_threads;
         web_conf
-    }
-
-    pub fn mds_server_conf(&self) -> ServerConf {
-        let mut conf = ServerConf::with_hostname(&self.mds.hostname, self.mds.rpc_port);
-        conf.name = format!("{}-mds", self.cluster_id);
-        conf.io_threads = self.mds.io_threads;
-        conf.worker_threads = self.mds.worker_threads;
-        conf
-    }
-
-    pub fn mds_web_conf(&self) -> ServerConf {
-        let mut conf = ServerConf::with_hostname(&self.mds.hostname, self.mds.web_port);
-        conf.name = format!("{}-mds", self.cluster_id);
-        conf.io_threads = self.mds.io_threads;
-        conf.worker_threads = self.mds.worker_threads;
-        conf
     }
 
     pub fn worker_addr(&self) -> InetAddr {
@@ -705,7 +699,13 @@ mod tests {
 
     #[test]
     fn legacy_config_without_mds_uses_disabled_defaults() {
-        let conf: ClusterConf = toml::from_str(
+        let path = std::env::temp_dir().join(format!(
+            "curvine-legacy-conf-{}-{}.toml",
+            std::process::id(),
+            Utils::rand_str(6)
+        ));
+        std::fs::write(
+            &path,
             r#"
                 cluster_id = "legacy"
 
@@ -713,10 +713,59 @@ mod tests {
             "#,
         )
         .unwrap();
+        let conf = ClusterConf::from(path.to_str().unwrap()).unwrap();
+        let _ = std::fs::remove_file(&path);
 
         assert!(!conf.mds.enabled);
         assert_eq!(conf.mds.rpc_port, crate::MdsConf::DEFAULT_RPC_PORT);
         assert_eq!(conf.mds.web_port, crate::MdsConf::DEFAULT_WEB_PORT);
+    }
+
+    #[test]
+    fn disabled_mds_skips_validation() {
+        let path = std::env::temp_dir().join(format!(
+            "curvine-disabled-mds-conf-{}-{}.toml",
+            std::process::id(),
+            Utils::rand_str(6)
+        ));
+        std::fs::write(
+            &path,
+            r#"
+                [mds]
+                enabled = false
+                hostname = " "
+                rpc_port = 0
+            "#,
+        )
+        .unwrap();
+        let conf = ClusterConf::from(path.to_str().unwrap()).unwrap();
+        let _ = std::fs::remove_file(&path);
+
+        assert!(!conf.mds.enabled);
+    }
+
+    #[test]
+    fn enabled_mds_is_validated() {
+        let path = std::env::temp_dir().join(format!(
+            "curvine-enabled-mds-conf-{}-{}.toml",
+            std::process::id(),
+            Utils::rand_str(6)
+        ));
+        std::fs::write(
+            &path,
+            r#"
+                [mds]
+                enabled = true
+                rpc_port = 0
+            "#,
+        )
+        .unwrap();
+        let err = ClusterConf::from(path.to_str().unwrap())
+            .expect_err("enabled MDS must validate its configuration")
+            .to_string();
+        let _ = std::fs::remove_file(&path);
+
+        assert!(err.contains("mds.rpc_port must be greater than zero"));
     }
 
     #[test]

--- a/crates/common/curvine-config/src/lib.rs
+++ b/crates/common/curvine-config/src/lib.rs
@@ -28,6 +28,9 @@ pub use self::journal_conf::JournalConf;
 mod master_conf;
 pub use self::master_conf::MasterConf;
 
+mod mds_conf;
+pub use self::mds_conf::MdsConf;
+
 mod compatibility_conf;
 pub use self::compatibility_conf::CompatibilityConf;
 

--- a/crates/common/curvine-config/src/mds_conf.rs
+++ b/crates/common/curvine-config/src/mds_conf.rs
@@ -1,0 +1,94 @@
+use curvine_core_error::{err_box, CommonResult};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct MdsConf {
+    pub enabled: bool,
+    pub hostname: String,
+    pub rpc_port: u16,
+    pub web_port: u16,
+    pub io_threads: usize,
+    pub worker_threads: usize,
+    pub conn_limit: usize,
+    pub global_limit: usize,
+}
+
+impl MdsConf {
+    pub const DEFAULT_RPC_PORT: u16 = 8998;
+    pub const DEFAULT_WEB_PORT: u16 = 9004;
+
+    pub fn init(&mut self) -> CommonResult<()> {
+        self.hostname = self.hostname.trim().to_string();
+        if self.hostname.is_empty() {
+            return err_box!("mds.hostname must not be empty");
+        }
+        if self.rpc_port == 0 {
+            return err_box!("mds.rpc_port must be greater than zero");
+        }
+        if self.web_port == 0 {
+            return err_box!("mds.web_port must be greater than zero");
+        }
+        if self.rpc_port == self.web_port {
+            return err_box!("mds.rpc_port and mds.web_port must be different");
+        }
+        if self.io_threads == 0 {
+            return err_box!("mds.io_threads must be greater than zero");
+        }
+        if self.worker_threads == 0 {
+            return err_box!("mds.worker_threads must be greater than zero");
+        }
+        if self.conn_limit == 0 {
+            return err_box!("mds.conn_limit must be greater than zero");
+        }
+        if self.global_limit == 0 {
+            return err_box!("mds.global_limit must be greater than zero");
+        }
+        Ok(())
+    }
+}
+
+impl Default for MdsConf {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            hostname: "localhost".to_string(),
+            rpc_port: Self::DEFAULT_RPC_PORT,
+            web_port: Self::DEFAULT_WEB_PORT,
+            io_threads: 4,
+            worker_threads: 8,
+            conn_limit: 10_000,
+            global_limit: 100_000,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_are_disabled_and_valid() {
+        let mut conf = MdsConf::default();
+        conf.init().unwrap();
+
+        assert!(!conf.enabled);
+        assert_eq!(conf.rpc_port, MdsConf::DEFAULT_RPC_PORT);
+        assert_eq!(conf.web_port, MdsConf::DEFAULT_WEB_PORT);
+    }
+
+    #[test]
+    fn rejects_invalid_ports() {
+        let mut conf = MdsConf {
+            rpc_port: 0,
+            ..Default::default()
+        };
+        assert!(conf.init().is_err());
+
+        let mut conf = MdsConf {
+            web_port: MdsConf::DEFAULT_RPC_PORT,
+            ..Default::default()
+        };
+        assert!(conf.init().is_err());
+    }
+}

--- a/crates/common/curvine-config/src/mds_conf.rs
+++ b/crates/common/curvine-config/src/mds_conf.rs
@@ -1,4 +1,5 @@
 use curvine_core_error::{err_box, CommonResult};
+use curvine_runtime::common::LogConf;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -10,8 +11,7 @@ pub struct MdsConf {
     pub web_port: u16,
     pub io_threads: usize,
     pub worker_threads: usize,
-    pub conn_limit: usize,
-    pub global_limit: usize,
+    pub log: LogConf,
 }
 
 impl MdsConf {
@@ -38,12 +38,6 @@ impl MdsConf {
         if self.worker_threads == 0 {
             return err_box!("mds.worker_threads must be greater than zero");
         }
-        if self.conn_limit == 0 {
-            return err_box!("mds.conn_limit must be greater than zero");
-        }
-        if self.global_limit == 0 {
-            return err_box!("mds.global_limit must be greater than zero");
-        }
         Ok(())
     }
 }
@@ -57,8 +51,7 @@ impl Default for MdsConf {
             web_port: Self::DEFAULT_WEB_PORT,
             io_threads: 4,
             worker_threads: 8,
-            conn_limit: 10_000,
-            global_limit: 100_000,
+            log: Default::default(),
         }
     }
 }

--- a/crates/common/curvine-config/src/mds_conf.rs
+++ b/crates/common/curvine-config/src/mds_conf.rs
@@ -51,7 +51,10 @@ impl Default for MdsConf {
             web_port: Self::DEFAULT_WEB_PORT,
             io_threads: 4,
             worker_threads: 8,
-            log: Default::default(),
+            log: LogConf {
+                file_name: "mds.log".to_string(),
+                ..Default::default()
+            },
         }
     }
 }
@@ -68,6 +71,7 @@ mod tests {
         assert!(!conf.enabled);
         assert_eq!(conf.rpc_port, MdsConf::DEFAULT_RPC_PORT);
         assert_eq!(conf.web_port, MdsConf::DEFAULT_WEB_PORT);
+        assert_eq!(conf.log.file_name, "mds.log");
     }
 
     #[test]

--- a/curvine-docker/deploy/entrypoint.sh
+++ b/curvine-docker/deploy/entrypoint.sh
@@ -46,7 +46,7 @@ if is_fluid_mode "${1:-}"; then
 fi
 
 # Start the curvine service process
-# Service type: master, worker, transfer
+# Service type: master, worker, mds, transfer
 SERVER_TYPE=${1:-master}
 
 # Operation type: start, stop, restart

--- a/curvine-docker/deploy/entrypoint.sh
+++ b/curvine-docker/deploy/entrypoint.sh
@@ -178,7 +178,7 @@ restart_service() {
 set_hosts
 
 case "$SERVER_TYPE" in
-  (master|worker|transfer)
+  (master|worker|mds|transfer)
     case "$ACTION_TYPE" in
       start)
         start_service "$SERVER_TYPE"

--- a/curvine-docker/deploy/example/conf/curvine-cluster.toml
+++ b/curvine-docker/deploy/example/conf/curvine-cluster.toml
@@ -23,6 +23,14 @@ meta_dir = "./data/meta"
 audit_logging_enabled = true
 log = { level = "info", log_dir = "./logs", file_name = "master.log" }
 
+# Optional standalone stateless metadata service. It is disabled by default;
+# start it with `curvine-server --service mds` only after enabling this flag.
+[mds]
+enabled = false
+hostname = "0.0.0.0"
+rpc_port = 8998
+web_port = 9004
+
 [journal]
 rpc_port = 8996
 journal_addrs = [

--- a/curvine-docker/deploy/example/conf/curvine-cluster.toml
+++ b/curvine-docker/deploy/example/conf/curvine-cluster.toml
@@ -5,7 +5,7 @@ cluster_id = "curvine"
 
 # Network interface (e.g. "eth0") used to auto-resolve this node's local IPv4.
 # When set (non-empty), on startup the resolved IPv4 is applied to the
-# master/journal/worker/client hostnames, and the CURVINE_*_HOSTNAME env vars
+# master/mds/journal/worker/client hostnames, and the CURVINE_*_HOSTNAME env vars
 # are ignored. When empty (the default), hostnames come from the config below
 # and may be overridden by the CURVINE_*_HOSTNAME env vars.
 #
@@ -27,9 +27,9 @@ log = { level = "info", log_dir = "./logs", file_name = "master.log" }
 # start it with `curvine-server --service mds` only after enabling this flag.
 [mds]
 enabled = false
-hostname = "0.0.0.0"
 rpc_port = 8998
 web_port = 9004
+log = { level = "info", log_dir = "./logs", file_name = "mds.log" }
 
 [journal]
 rpc_port = 8996

--- a/curvine-mds/Cargo.toml
+++ b/curvine-mds/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "curvine-mds"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+curvine-config = { workspace = true }
+curvine-core-error = { workspace = true }
+curvine-runtime = { workspace = true }
+log = { workspace = true }
+tokio = { workspace = true }

--- a/curvine-mds/src/lib.rs
+++ b/curvine-mds/src/lib.rs
@@ -1,0 +1,3 @@
+mod server;
+
+pub use server::Mds;

--- a/curvine-mds/src/server.rs
+++ b/curvine-mds/src/server.rs
@@ -1,5 +1,6 @@
 use curvine_config::ClusterConf;
 use curvine_core_error::{err_box, CommonResult};
+use curvine_runtime::common::Logger;
 use curvine_runtime::runtime::{AsyncRuntime, RpcRuntime, Runtime};
 use log::info;
 use std::sync::Arc;
@@ -13,10 +14,12 @@ pub struct Mds {
 }
 
 impl Mds {
-    pub fn with_conf(conf: ClusterConf) -> CommonResult<Self> {
+    pub fn with_conf(mut conf: ClusterConf) -> CommonResult<Self> {
         if !conf.mds.enabled {
             return err_box!("mds service is disabled; set mds.enabled=true to start it");
         }
+        conf.mds.init()?;
+        Logger::init(conf.mds.log.clone());
 
         let rt = Arc::new(AsyncRuntime::new(
             "mds",
@@ -37,14 +40,7 @@ impl Mds {
     }
 
     pub async fn start(&mut self) -> CommonResult<()> {
-        info!(
-            "curvine-mds started: cluster_id={}, rpc_addr={}:{}, web_addr={}:{}",
-            self.conf.cluster_id,
-            self.conf.mds.hostname,
-            self.conf.mds.rpc_port,
-            self.conf.mds.hostname,
-            self.conf.mds.web_port
-        );
+        info!("curvine-mds started: cluster_id={}", self.conf.cluster_id);
         Ok(())
     }
 

--- a/curvine-mds/src/server.rs
+++ b/curvine-mds/src/server.rs
@@ -1,0 +1,118 @@
+use curvine_config::ClusterConf;
+use curvine_core_error::{err_box, CommonResult};
+use curvine_runtime::runtime::{AsyncRuntime, RpcRuntime, Runtime};
+use log::info;
+use std::sync::Arc;
+use tokio::sync::watch;
+
+pub struct Mds {
+    conf: ClusterConf,
+    rt: Arc<Runtime>,
+    shutdown_tx: watch::Sender<bool>,
+    shutdown_rx: watch::Receiver<bool>,
+}
+
+impl Mds {
+    pub fn with_conf(conf: ClusterConf) -> CommonResult<Self> {
+        if !conf.mds.enabled {
+            return err_box!("mds service is disabled; set mds.enabled=true to start it");
+        }
+
+        let rt = Arc::new(AsyncRuntime::new(
+            "mds",
+            conf.mds.io_threads,
+            conf.mds.worker_threads,
+        ));
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        Ok(Self {
+            conf,
+            rt,
+            shutdown_tx,
+            shutdown_rx,
+        })
+    }
+
+    pub fn conf(&self) -> &ClusterConf {
+        &self.conf
+    }
+
+    pub async fn start(&mut self) -> CommonResult<()> {
+        info!(
+            "curvine-mds started: cluster_id={}, rpc_addr={}:{}, web_addr={}:{}",
+            self.conf.cluster_id,
+            self.conf.mds.hostname,
+            self.conf.mds.rpc_port,
+            self.conf.mds.hostname,
+            self.conf.mds.web_port
+        );
+        Ok(())
+    }
+
+    pub fn shutdown(&self) {
+        let _ = self.shutdown_tx.send(true);
+    }
+
+    async fn wait_for_shutdown(&mut self) -> CommonResult<()> {
+        if *self.shutdown_rx.borrow() {
+            return Ok(());
+        }
+
+        #[cfg(unix)]
+        {
+            use tokio::signal::unix::{signal, SignalKind};
+
+            let mut terminate = signal(SignalKind::terminate())?;
+            tokio::select! {
+                result = tokio::signal::ctrl_c() => result?,
+                _ = terminate.recv() => {},
+                result = self.shutdown_rx.changed() => {
+                    result.map_err(|error| curvine_core_error::CommonError::from(error.to_string()))?;
+                }
+            }
+        }
+
+        #[cfg(not(unix))]
+        tokio::select! {
+            result = tokio::signal::ctrl_c() => result?,
+            result = self.shutdown_rx.changed() => {
+                result.map_err(|error| curvine_core_error::CommonError::from(error.to_string()))?;
+            }
+        }
+
+        info!("curvine-mds stopped: cluster_id={}", self.conf.cluster_id);
+        Ok(())
+    }
+
+    pub fn block_on_start(mut self) -> CommonResult<()> {
+        let rt = self.rt.clone();
+        rt.block_on(async move {
+            self.start().await?;
+            self.wait_for_shutdown().await
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn refuses_to_start_when_disabled() {
+        let conf = ClusterConf::default();
+        assert!(Mds::with_conf(conf).is_err());
+    }
+
+    #[test]
+    fn starts_and_stops_with_explicit_shutdown() {
+        let mut conf = ClusterConf::default();
+        conf.mds.enabled = true;
+        let mut mds = Mds::with_conf(conf).unwrap();
+        mds.shutdown();
+
+        let rt = mds.rt.clone();
+        rt.block_on(async move {
+            mds.start().await.unwrap();
+            mds.wait_for_shutdown().await.unwrap();
+        });
+    }
+}

--- a/curvine-server/Cargo.toml
+++ b/curvine-server/Cargo.toml
@@ -38,6 +38,7 @@ curvine-alloc = { workspace = true }
 curvine-model = { workspace = true }
 curvine-runtime = { workspace = true }
 curvine-master = { workspace = true }
+curvine-mds = { workspace = true }
 curvine-worker = { workspace = true }
 curvine-error = { workspace = true, features = ["axum-response"] }
 curvine-fault = { workspace = true }

--- a/curvine-server/src/bin/curvine-server.rs
+++ b/curvine-server/src/bin/curvine-server.rs
@@ -18,6 +18,7 @@ use curvine_config::ClusterConf;
 use curvine_core_error::{err_box, CommonResult};
 use curvine_data_transfer::transfer::TransferServer;
 use curvine_master::master::Master;
+use curvine_mds::Mds;
 use curvine_runtime::common::{LocalTime, Utils};
 use curvine_sys::version;
 use curvine_worker::Worker;
@@ -57,6 +58,11 @@ fn main() -> CommonResult<()> {
             worker.block_on_start()?;
         }
 
+        ServiceType::Mds => {
+            let mds = Mds::with_conf(conf)?;
+            mds.block_on_start()?;
+        }
+
         ServiceType::Transfer => {
             let transfer = TransferServer::with_conf(conf)?;
             transfer.block_on_start()?;
@@ -86,6 +92,7 @@ impl ServerArgs {
         match self.service.to_lowercase().as_str() {
             "master" => "master",
             "worker" => "worker",
+            "mds" => "mds",
             "transfer" => "data-transfer",
             _ => "server",
         }
@@ -96,6 +103,7 @@ impl ServerArgs {
         match service.as_str() {
             "master" => Ok(ServiceType::Master),
             "worker" => Ok(ServiceType::Worker),
+            "mds" => Ok(ServiceType::Mds),
             "transfer" => Ok(ServiceType::Transfer),
             v => err_box!("Unsupported service type: {}", v),
         }
@@ -104,7 +112,9 @@ impl ServerArgs {
     pub fn get_conf(&self, service: &ServiceType) -> CommonResult<ClusterConf> {
         match service {
             ServiceType::Transfer => ClusterConf::from_transfer(&self.conf),
-            ServiceType::Master | ServiceType::Worker => ClusterConf::from(&self.conf),
+            ServiceType::Master | ServiceType::Worker | ServiceType::Mds => {
+                ClusterConf::from(&self.conf)
+            }
         }
     }
 }
@@ -112,6 +122,7 @@ impl ServerArgs {
 pub enum ServiceType {
     Master,
     Worker,
+    Mds,
     Transfer,
 }
 
@@ -136,5 +147,14 @@ mod tests {
 
         assert!(args.version_json);
         assert_eq!(args.component_name(), "server");
+    }
+
+    #[test]
+    fn accepts_mds_service() {
+        let args = ServerArgs::try_parse_from(["curvine-server", "--service", "mds"])
+            .expect("mds service should parse");
+
+        assert!(matches!(args.get_service().unwrap(), ServiceType::Mds));
+        assert_eq!(args.component_name(), "mds");
     }
 }

--- a/curvine-server/src/lib.rs
+++ b/curvine-server/src/lib.rs
@@ -27,4 +27,5 @@ pub mod storage {
 
 pub use curvine_data_transfer as data_transfer;
 pub use curvine_master::master;
+pub use curvine_mds as mds;
 pub use curvine_worker as worker;

--- a/etc/curvine-cluster.toml
+++ b/etc/curvine-cluster.toml
@@ -53,6 +53,14 @@ log = { level = "info", log_dir = "stdout", file_name = "master.log" }
 # min_client_version = "0.1.0"
 # blocked_versions = ["0.2.5"]
 
+# Optional standalone stateless metadata service. Disabled by default; start it
+# with `curvine-server --service mds` after enabling this flag.
+[mds]
+enabled = false
+hostname = "localhost"
+rpc_port = 8998
+web_port = 9004
+
 
 # masta ha raft configuration.
 [journal]

--- a/etc/curvine-cluster.toml
+++ b/etc/curvine-cluster.toml
@@ -7,7 +7,7 @@ format_worker = false
 
 # Network interface (e.g. "eth0") used to auto-resolve this node's local IPv4.
 # When set (non-empty), on startup the resolved IPv4 is applied to the
-# master/journal/worker/client hostnames, and the CURVINE_*_HOSTNAME env vars
+# master/mds/journal/worker/client hostnames, and the CURVINE_*_HOSTNAME env vars
 # are ignored. When empty (the default), hostnames come from the config below
 # and may be overridden by the CURVINE_*_HOSTNAME env vars.
 #
@@ -57,9 +57,9 @@ log = { level = "info", log_dir = "stdout", file_name = "master.log" }
 # with `curvine-server --service mds` after enabling this flag.
 [mds]
 enabled = false
-hostname = "localhost"
 rpc_port = 8998
 web_port = 9004
+log = { level = "info", log_dir = "stdout", file_name = "mds.log" }
 
 
 # masta ha raft configuration.


### PR DESCRIPTION
# Summary

Add the initial standalone `curvine-mds` service scaffold. The service is opt-in and disabled by default, so existing Master, Worker, and client behavior remains unchanged.

# Issue Describe / Design

This is the first implementation step of the stateless MDS design. It establishes an independent crate and process lifecycle before metadata storage, RPC handlers, service discovery, or client routing are introduced.

Design decisions:
- Keep stateless MDS separate from `curvine-master`.
- Use runtime configuration instead of a Cargo feature.
- Preserve backward compatibility by defaulting `mds.enabled` to `false` when the section is absent.
- Expose `curvine-server --service mds` without adding placeholder metadata RPC handlers.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-mds` | Add standalone MDS crate with lifecycle and graceful shutdown scaffold | None unless explicitly enabled and started |
| `curvine-config` | Add `MdsConf`, validation, server configuration helpers, and compatibility tests | Existing configurations default to MDS disabled |
| `curvine-server` | Add the `mds` service option and version component name | Existing service options are unchanged |
| `Cargo.toml` / `Cargo.lock` | Register the new workspace crate and dependency | Build graph only |
| Configuration examples | Add disabled `[mds]` sections | No runtime behavior change |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo fmt --all -- --check` | PASS | |
| `git diff --check` | PASS | |
| `CARGO_TARGET_DIR=/tmp/curvine-mds-target cargo test -p curvine-config mds_conf::tests` | PASS | 2 tests |
| `CARGO_TARGET_DIR=/tmp/curvine-mds-target cargo test -p curvine-config legacy_config_without_mds_uses_disabled_defaults` | PASS | Backward compatibility |
| `CARGO_TARGET_DIR=/tmp/curvine-mds-target cargo test -p curvine-config loads_workspace_cluster_config` | PASS | Example config parsing |
| `CARGO_TARGET_DIR=/tmp/curvine-mds-target cargo test -p curvine-mds` | PASS | 2 tests |
| `CARGO_TARGET_DIR=/tmp/curvine-mds-target cargo test -p curvine-server --bin curvine-server` | PASS | 3 CLI tests |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None