### PR TITLE
refactor(config): converge config discovery on ConfigLoader (#1619)

### DIFF
--- a/crates/common/curvine-config/src/fuse_conf.rs
+++ b/crates/common/curvine-config/src/fuse_conf.rs
@@ -422,9 +422,7 @@ impl FuseConf {
     /// Delegates to the workspace-wide [`crate::validation`] audit and filters
     /// to this section, so semantics stay in lockstep with full-document
     /// auditing (same skip-field and alias treatment).
-    /// Parses raw cluster TOML text and returns the unrecognized keys found
-    /// under the `[fuse]` table. Delegates to the workspace-wide
-    /// [`crate::validation`] audit and filters to this section.
+
     pub fn unrecognized_fuse_keys_from_toml(raw: &str) -> CommonResult<Vec<String>> {
         Ok(crate::validation::audit_unknown_keys(raw)?
             .into_iter()

--- a/crates/common/curvine-config/src/fuse_conf.rs
+++ b/crates/common/curvine-config/src/fuse_conf.rs
@@ -422,7 +422,6 @@ impl FuseConf {
     /// Delegates to the workspace-wide [`crate::validation`] audit and filters
     /// to this section, so semantics stay in lockstep with full-document
     /// auditing (same skip-field and alias treatment).
-
     pub fn unrecognized_fuse_keys_from_toml(raw: &str) -> CommonResult<Vec<String>> {
         Ok(crate::validation::audit_unknown_keys(raw)?
             .into_iter()

--- a/crates/common/curvine-config/src/pipeline.rs
+++ b/crates/common/curvine-config/src/pipeline.rs
@@ -732,6 +732,26 @@ mod tests {
         );
     }
 
+    // The server passes ServerArgs.conf, which defaults to "" — the
+    // empty-explicit contract is what makes bare local starts work. If the
+    // trim/empty filter regressed, discover(Some("")) would win with a
+    // nonexistent "--conf" path instead of falling through.
+    #[test]
+    fn empty_or_blank_explicit_path_does_not_win() {
+        for explicit in ["", "   "] {
+            let found = ConfigLoader::discover(Some(explicit));
+            assert!(
+                found.map(|f| f.source != "--conf").unwrap_or(true),
+                "empty explicit path must not be treated as --conf"
+            );
+            let configured = ConfigLoader::discover_configured(Some(explicit));
+            assert!(
+                configured.map(|f| f.source != "--conf").unwrap_or(true),
+                "empty explicit path must not be treated as --conf"
+            );
+        }
+    }
+
     #[test]
     fn discovery_prefers_explicit_over_env_var() {
         // Explicit path wins even when CURVINE_CONF_FILE is set; both are taken

--- a/curvine-cli/src/main.rs
+++ b/curvine-cli/src/main.rs
@@ -19,7 +19,7 @@ mod util;
 
 use clap::{error::ErrorKind, CommandFactory, Parser};
 use commands::Commands;
-use curvine_config::ClusterConf;
+use curvine_config::{ClusterConf, ConfigLoader};
 use curvine_core_error::{err_box, CommonResult};
 use curvine_job_client::JobMasterClient;
 use curvine_job_client::TransferClient;
@@ -28,7 +28,6 @@ use curvine_runtime::common::{Logger, Utils};
 use curvine_runtime::runtime::RpcRuntime;
 use curvine_sys::version;
 use curvine_unified_fs::UnifiedFileSystem;
-use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 #[derive(Parser, Debug)]
@@ -122,44 +121,19 @@ impl CurvineArgs {
     }
 
     fn resolve_conf_path(&self, enable_default_discovery: bool) -> Option<(String, String)> {
-        if let Some(path) = &self.conf {
-            return Some((path.clone(), "--conf".to_string()));
-        }
+        // Unified discovery shared with the server/fuse/sdk entrypoints:
+        // `--conf` > CURVINE_CONF_FILE > well-known locations. When default
+        // discovery is disabled, only explicitly configured sources apply.
+        let discovered = if enable_default_discovery {
+            ConfigLoader::discover(self.conf.as_deref())
+        } else {
+            ConfigLoader::discover_configured(self.conf.as_deref())
+        }?;
 
-        if let Ok(path) = std::env::var(ClusterConf::ENV_CONF_FILE) {
-            return Some((path, ClusterConf::ENV_CONF_FILE.to_string()));
-        }
-
-        if !enable_default_discovery {
-            return None;
-        }
-
-        let mut candidates = vec![
-            (PathBuf::from("curvine-cluster.toml"), "current directory"),
-            (
-                PathBuf::from("conf/curvine-cluster.toml"),
-                "current conf directory",
-            ),
-        ];
-
-        if let Some(home) = std::env::var_os("HOME") {
-            candidates.push((
-                PathBuf::from(home).join(".curvine/curvine-cluster.toml"),
-                "user config directory",
-            ));
-        }
-
-        if let Ok(curvine_home) = std::env::var("CURVINE_HOME") {
-            candidates.push((
-                Path::new(&curvine_home).join("conf/curvine-cluster.toml"),
-                "CURVINE_HOME",
-            ));
-        }
-
-        candidates
-            .into_iter()
-            .find(|(path, _)| path.exists())
-            .map(|(path, source)| (path.to_string_lossy().to_string(), source.to_string()))
+        Some((
+            discovered.path.to_string_lossy().to_string(),
+            discovered.source,
+        ))
     }
 }
 

--- a/curvine-lancedb/src/object_store.rs
+++ b/curvine-lancedb/src/object_store.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
-use std::env;
 use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
 use std::result::Result as StdResult;
 use std::sync::Arc;
@@ -24,7 +23,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use curvine_client::file::CurvineFileSystem;
-use curvine_config::ClusterConf;
+use curvine_config::{ClusterConf, ConfigLoader};
 use curvine_error::FsError;
 use curvine_fs_api::{Path as CurvinePath, Reader, Writer};
 use curvine_io::DataSlice;
@@ -185,11 +184,14 @@ fn resolve_curvine_conf(params: &ObjectStoreParams) -> Result<ClusterConf> {
         return cluster_conf_from_master_addrs(&master_addrs);
     }
 
-    if let Ok(conf_path) = env::var(ClusterConf::ENV_CONF_FILE) {
-        return ClusterConf::from(&conf_path).map_err(|e| {
+    // Same unified discovery as the other entrypoints, restricted to
+    // explicitly configured sources: the storage option (checked above) or the
+    // CURVINE_CONF_FILE environment variable.
+    if let Some(found) = ConfigLoader::discover_configured(None) {
+        return ClusterConf::from(found.as_str()).map_err(|e| {
             LanceError::invalid_input(format!(
                 "Failed to load Curvine configuration from '{}': {e}",
-                conf_path
+                found.as_str()
             ))
         });
     }
@@ -268,8 +270,8 @@ fn curvine_store_identity(
         ));
     }
 
-    if let Ok(conf_path) = env::var(ClusterConf::ENV_CONF_FILE) {
-        return curvine_conf_identity(&conf_path);
+    if let Some(found) = ConfigLoader::discover_configured(None) {
+        return curvine_conf_identity(found.as_str().as_ref());
     }
 
     curvine_absolute_path_str_from_uri(url)

--- a/curvine-server/src/bin/curvine-server.rs
+++ b/curvine-server/src/bin/curvine-server.rs
@@ -14,7 +14,7 @@
 
 use clap::Parser;
 use curvine_alloc as _;
-use curvine_config::{ConfigLoader, ClusterConf};
+use curvine_config::{ClusterConf, ConfigLoader};
 use curvine_core_error::{err_box, CommonResult};
 use curvine_data_transfer::transfer::TransferServer;
 use curvine_master::master::Master;
@@ -113,15 +113,17 @@ impl ServerArgs {
         // Unified discovery: `--conf` > CURVINE_CONF_FILE > well-known
         // locations (launch scripts export the env var; bare local runs fall
         // back to ./conf/curvine-cluster.toml).
-        let found = ConfigLoader::discover(Some(&self.conf))
-            .ok_or_else(|| -> curvine_core_error::CommonError {
+        let found = ConfigLoader::discover(Some(&self.conf)).ok_or_else(
+            || -> curvine_core_error::CommonError {
                 format!(
                     "no configuration file found: pass --conf or set {}, or place \
-                     curvine-cluster.toml in a well-known location",
-                    ClusterConf::ENV_CONF_FILE
+                     {} in {{./, ./conf/, ~/.curvine/, $CURVINE_HOME/conf/}}",
+                    ClusterConf::ENV_CONF_FILE,
+                    ConfigLoader::DEFAULT_FILE_NAME
                 )
                 .into()
-            })?;
+            },
+        )?;
         println!("Loading config from {} ({})", found.as_str(), found.source);
 
         let load = match service {
@@ -160,6 +162,27 @@ mod tests {
 
         assert!(args.version_json);
         assert_eq!(args.component_name(), "server");
+    }
+
+    #[test]
+    fn get_conf_loads_from_discovered_config() {
+        let tmpdir = std::env::temp_dir().join(format!("cv-test-srv-conf-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmpdir);
+        std::fs::create_dir_all(tmpdir.join("conf")).unwrap();
+        let conf_path = tmpdir.join("conf").join(ConfigLoader::DEFAULT_FILE_NAME);
+        std::fs::write(&conf_path, "[master]\nhostname = \"test-master\"\n").unwrap();
+
+        let args = ServerArgs::try_parse_from([
+            "curvine-server",
+            "--conf",
+            conf_path.to_str().unwrap(),
+            "--service",
+            "master",
+        ])
+        .expect("parse server args");
+        let conf = args.get_conf(&ServiceType::Master).unwrap();
+        assert_eq!(conf.master.hostname, "test-master");
+        let _ = std::fs::remove_dir_all(&tmpdir);
     }
 
     #[test]

--- a/curvine-server/src/bin/curvine-server.rs
+++ b/curvine-server/src/bin/curvine-server.rs
@@ -14,7 +14,7 @@
 
 use clap::Parser;
 use curvine_alloc as _;
-use curvine_config::ClusterConf;
+use curvine_config::{ConfigLoader, ClusterConf};
 use curvine_core_error::{err_box, CommonResult};
 use curvine_data_transfer::transfer::TransferServer;
 use curvine_master::master::Master;
@@ -110,12 +110,25 @@ impl ServerArgs {
     }
 
     pub fn get_conf(&self, service: &ServiceType) -> CommonResult<ClusterConf> {
-        match service {
-            ServiceType::Transfer => ClusterConf::from_transfer(&self.conf),
-            ServiceType::Master | ServiceType::Worker | ServiceType::Mds => {
-                ClusterConf::from(&self.conf)
-            }
-        }
+        // Unified discovery: `--conf` > CURVINE_CONF_FILE > well-known
+        // locations (launch scripts export the env var; bare local runs fall
+        // back to ./conf/curvine-cluster.toml).
+        let found = ConfigLoader::discover(Some(&self.conf))
+            .ok_or_else(|| -> curvine_core_error::CommonError {
+                format!(
+                    "no configuration file found: pass --conf or set {}, or place \
+                     curvine-cluster.toml in a well-known location",
+                    ClusterConf::ENV_CONF_FILE
+                )
+                .into()
+            })?;
+        println!("Loading config from {} ({})", found.as_str(), found.source);
+
+        let load = match service {
+            ServiceType::Transfer => ClusterConf::from_transfer,
+            ServiceType::Master | ServiceType::Worker | ServiceType::Mds => ClusterConf::from,
+        };
+        load(found.as_str())
     }
 }
 


### PR DESCRIPTION
# Summary

Fifth PR of the stacked series for #1619 (5/7). Converges config-file discovery on the shared `ConfigLoader`, removing the per-crate duplicates in the CLI, the server entrypoint, and curvine-lancedb.

# Issue Describe / Design

Related to #1619 (partial). Depends on the preceding stacked PRs.

- CLI: hand-rolled candidate list replaced by `ConfigLoader::discover` (identical order).
- lancedb: env fallback switched to `discover_configured` (explicit sources only), preserving its storage-option > master-addrs > env priority.
- server entrypoint: gains well-known-location fallback when launched without `--conf` or `CURVINE_CONF_FILE`.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-cli/src/main.rs` | Use `ConfigLoader::discover` | None (same candidates/order) |
| `curvine-server/src/bin/curvine-server.rs` | Discovery + clearer missing-config error | Improvement: falls back to well-known locations instead of failing on empty `--conf` |
| `curvine-lancedb/src/object_store.rs` | Env branch via `ConfigLoader::discover_configured` | None |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-cli` / `-p curvine-server` / `-p curvine-lancedb` | PASS | |

# Dependencies

- Related PRs: base #1624
- Related issues: #1619
