### PR TITLE
fix(fuse): make session init metric observable

### DIFF
--- a/curvine-fuse/src/cli/mount_run.rs
+++ b/curvine-fuse/src/cli/mount_run.rs
@@ -14,6 +14,7 @@
 
 use crate::cli::FuseRuntimeArgs;
 use crate::fs::CurvineFileSystem;
+use crate::fuse_metrics::FuseMetrics;
 use crate::session::FuseSession;
 use crate::web_server::WebServer;
 use curvine_config::FuseConf;
@@ -62,13 +63,21 @@ pub fn run_mount(args: FuseRuntimeArgs) -> CommonResult<()> {
 
         let node_state = fs.state().clone();
         let web_port = conf.web_port;
-        let mut session = FuseSession::new(fuse_rt.clone(), fs, conf).await?;
-
-        fuse_rt.spawn(async move {
-            if let Err(e) = WebServer::start(web_port, node_state).await {
-                log::error!("Failed to start metrics server: {}", e);
+        // Start metrics before session construction so Prometheus can observe
+        // the lifecycle counter's zero baseline during startup.
+        FuseMetrics::init_session_metrics();
+        match WebServer::bind(web_port).await {
+            Ok(listener) => {
+                fuse_rt.spawn(async move {
+                    if let Err(e) = WebServer::serve(listener, node_state).await {
+                        log::error!("Failed to start metrics server: {}", e);
+                    }
+                });
             }
-        });
+            Err(e) => log::error!("Failed to start metrics server: {}", e),
+        }
+
+        let mut session = FuseSession::new(fuse_rt.clone(), fs, conf).await?;
 
         session.run().await
     })?;

--- a/curvine-fuse/src/cli/mount_run.rs
+++ b/curvine-fuse/src/cli/mount_run.rs
@@ -65,7 +65,9 @@ pub fn run_mount(args: FuseRuntimeArgs) -> CommonResult<()> {
         let web_port = conf.web_port;
         // Start metrics before session construction so Prometheus can observe
         // the lifecycle counter's zero baseline during startup.
-        FuseMetrics::init_session_metrics();
+        if conf.metrics_enabled {
+            FuseMetrics::init_session_metrics();
+        }
         match WebServer::bind(web_port).await {
             Ok(listener) => {
                 fuse_rt.spawn(async move {

--- a/curvine-fuse/src/fuse_metrics.rs
+++ b/curvine-fuse/src/fuse_metrics.rs
@@ -228,6 +228,16 @@ impl FuseMetrics {
             .expect("FuseMetrics not initialized; call ensure_init from CurvineFileSystem::new")
     }
 
+    /// Create lifecycle counter children before the metrics endpoint starts.
+    /// This exposes a zero baseline so Prometheus can observe a later init result.
+    pub(crate) fn init_session_metrics() {
+        Self::with(|m| {
+            for result in [SESSION_INIT_SUCCESS, SESSION_INIT_ERROR] {
+                let _ = m.session_init_total.with_label_values(&[result]);
+            }
+        });
+    }
+
     pub(crate) fn with<F: FnOnce(&Self)>(f: F) {
         if let Some(m) = FUSE_METRICS.get() {
             f(m);
@@ -2716,6 +2726,26 @@ mod tests {
         // the gauge must be in {0,1}.
         let v = mx.kernel_fd_health.get();
         assert!(v == 0 || v == 1, "health gauge is binary");
+    }
+
+    #[test]
+    fn init_session_metrics_exports_zero_baselines_without_incrementing() {
+        FuseMetrics::ensure_init().unwrap();
+        let mx = FuseMetrics::get();
+        let success = mx
+            .session_init_total
+            .with_label_values(&[SESSION_INIT_SUCCESS]);
+        let error = mx
+            .session_init_total
+            .with_label_values(&[SESSION_INIT_ERROR]);
+        let before = (success.get(), error.get());
+
+        FuseMetrics::init_session_metrics();
+
+        assert_eq!((success.get(), error.get()), before);
+        let output = m::text_output().unwrap();
+        assert!(output.contains("curvine_fuse_session_init_total{result=\"success\"}"));
+        assert!(output.contains("curvine_fuse_session_init_total{result=\"error\"}"));
     }
 
     // The `if enabled { emit }` gate is deterministic against an isolated counter —

--- a/curvine-fuse/src/fuse_metrics.rs
+++ b/curvine-fuse/src/fuse_metrics.rs
@@ -232,10 +232,14 @@ impl FuseMetrics {
     /// This exposes a zero baseline so Prometheus can observe a later init result.
     pub(crate) fn init_session_metrics() {
         Self::with(|m| {
-            for result in [SESSION_INIT_SUCCESS, SESSION_INIT_ERROR] {
-                let _ = m.session_init_total.with_label_values(&[result]);
-            }
+            Self::init_session_metric_children(&m.session_init_total);
         });
+    }
+
+    fn init_session_metric_children(counter: &CounterVec) {
+        for result in [SESSION_INIT_SUCCESS, SESSION_INIT_ERROR] {
+            let _ = counter.with_label_values(&[result]);
+        }
     }
 
     pub(crate) fn with<F: FnOnce(&Self)>(f: F) {
@@ -2729,7 +2733,24 @@ mod tests {
     }
 
     #[test]
-    fn init_session_metrics_exports_zero_baselines_without_incrementing() {
+    fn init_session_metric_children_exports_zero_baselines() {
+        let metric_name = "test_fuse_session_init_zero_baselines_unique";
+        let counter = m::new_counter_vec(metric_name, "test counter", &["result"]).unwrap();
+        let before = m::text_output().unwrap();
+        assert!(
+            !before.contains(metric_name),
+            "CounterVec has no exported children before label initialization"
+        );
+
+        FuseMetrics::init_session_metric_children(&counter);
+
+        let output = m::text_output().unwrap();
+        assert!(output.contains(&format!("{metric_name}{{result=\"success\"}} 0")));
+        assert!(output.contains(&format!("{metric_name}{{result=\"error\"}} 0")));
+    }
+
+    #[test]
+    fn init_session_metrics_does_not_increment_existing_children() {
         FuseMetrics::ensure_init().unwrap();
         let mx = FuseMetrics::get();
         let success = mx
@@ -2743,9 +2764,6 @@ mod tests {
         FuseMetrics::init_session_metrics();
 
         assert_eq!((success.get(), error.get()), before);
-        let output = m::text_output().unwrap();
-        assert!(output.contains("curvine_fuse_session_init_total{result=\"success\"}"));
-        assert!(output.contains("curvine_fuse_session_init_total{result=\"error\"}"));
     }
 
     // The `if enabled { emit }` gate is deterministic against an isolated counter —

--- a/curvine-fuse/src/web_server.rs
+++ b/curvine-fuse/src/web_server.rs
@@ -28,7 +28,17 @@ use std::sync::Arc;
 pub struct WebServer;
 
 impl WebServer {
-    pub async fn start(port: u16, state: Arc<NodeState>) -> curvine_core_error::CommonResult<()> {
+    pub async fn bind(port: u16) -> curvine_core_error::CommonResult<tokio::net::TcpListener> {
+        let addr = SocketAddr::from(([0, 0, 0, 0], port));
+        let listener = tokio::net::TcpListener::bind(addr).await?;
+        log::info!("FUSE metrics server listening on {}", addr);
+        Ok(listener)
+    }
+
+    pub async fn serve(
+        listener: tokio::net::TcpListener,
+        state: Arc<NodeState>,
+    ) -> curvine_core_error::CommonResult<()> {
         let app = Router::new()
             .route("/metrics", get(metrics_handler))
             .route("/healthz", get(|| async { "ok" }))
@@ -36,12 +46,13 @@ impl WebServer {
             .route("/details", get(details_handler))
             .with_state(state);
 
-        let addr = SocketAddr::from(([0, 0, 0, 0], port));
-        log::info!("FUSE metrics server listening on {}", addr);
-
-        let listener = tokio::net::TcpListener::bind(addr).await?;
         axum::serve(listener, app).await?;
         Ok(())
+    }
+
+    pub async fn start(port: u16, state: Arc<NodeState>) -> curvine_core_error::CommonResult<()> {
+        let listener = Self::bind(port).await?;
+        Self::serve(listener, state).await
     }
 }
 

--- a/etc/grafana/curvine-fuse-dashboard.json
+++ b/etc/grafana/curvine-fuse-dashboard.json
@@ -5052,7 +5052,7 @@
         {
           "id": 78,
           "type": "stat",
-          "title": "Session init/shutdown (range)",
+          "title": "Current session init / shutdowns (range)",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
@@ -5069,7 +5069,7 @@
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "sum by(result)(increase(curvine_fuse_session_init_total{instance=~\"$instance\"}[$__range]))",
+              "expr": "sum by(result)(curvine_fuse_session_init_total{instance=~\"$instance\"})",
               "refId": "A",
               "legendFormat": "init {{result}}"
             },
@@ -5104,7 +5104,7 @@
             "textMode": "auto",
             "orientation": "auto"
           },
-          "description": "Low-freq lifecycle events, increase over range. No status-grouped zero-fill (would inject a label-less 0); No data means no init/shutdown events in the selected range."
+          "description": "Init shows the current process' recorded initialization result (the success/error child is pre-created at zero before session construction). Shutdown shows low-frequency shutdown events as an increase over the selected range; a shutdown may be missed if the process exits before the next scrape."
         },
         {
           "id": 79,


### PR DESCRIPTION
# Summary

Make the FUSE session initialization metric meaningful after process startup.

Previously, `curvine_fuse_session_init_total` was first created and incremented while `FuseSession::new` was running, before the metrics HTTP server started. Prometheus therefore usually saw the counter for the first time at `1`. Since there was no observable `0 -> 1` transition, the Grafana panel's `increase()` query commonly displayed zero even when a FUSE session had just initialized successfully.

This change exposes zero-valued `success` and `error` series before session construction, starts the metrics listener before initialization, and changes the dashboard to show the current process initialization result directly.

# Failure Signature

The `Session init/shutdown (range)` Grafana panel continued to show zero across a FUSE service startup:

```text
init success = 0
init error   = 0
```

The exported metric after startup was valid:

```text
curvine_fuse_session_init_total{result="success"} 1
```

However, Prometheus first observed the series at `1`, so the range query had no earlier sample from which to calculate the increment:

```promql
increase(curvine_fuse_session_init_total[$__range])
```

A restart could also look like `1 -> stale -> 1` rather than a counter transition within one process, leaving the panel at zero.

# Reproducer

Start a Curvine FUSE process while Prometheus is scraping its metrics endpoint, then inspect the session lifecycle panel:

```bash
bash build/dist/bin/curvine-fuse.sh start
```

Compare the raw series with the range increase:

```promql
curvine_fuse_session_init_total
```

```promql
increase(curvine_fuse_session_init_total[$__range])
```

Before this change, the raw series could report `success=1` while the panel based on `increase()` still reported zero.

# Root Cause

The metric publication order did not match Prometheus counter semantics for a one-shot startup event.

## The init counter was recorded before the scrape endpoint existed

`FuseSession::new` records exactly one initialization result:

```text
session construction succeeds -> result="success" increments to 1
session construction fails    -> result="error" increments to 1
```

The metrics server was spawned only after `FuseSession::new` returned. Prometheus could not scrape the counter while it was zero and normally discovered it only after the increment had already happened.

## The label children did not exist until first use

Prometheus `CounterVec` children are created lazily. Until a result label was incremented, neither the `success` nor the `error` series was exported. There was therefore no explicit zero baseline available during startup.

## `increase()` cannot infer an event before the first sample

Prometheus can calculate a counter increase only from samples it has observed. A first sample of `1` does not prove that the increment happened within the selected range, and process-local counters reset when the FUSE process restarts.

For this metric, the reliable post-startup meaning is the current process's recorded initialization result, not a historical event count reconstructed across process lifetimes.

# Changes

- Split the metrics web server lifecycle into `WebServer::bind` and `WebServer::serve` while retaining the existing `WebServer::start` wrapper.
- Pre-create `session_init_total{result="success"}` and `session_init_total{result="error"}` at zero without incrementing either counter.
- Bind and spawn the metrics server before constructing `FuseSession` so the zero baseline can be scraped during initialization.
- Preserve the previous non-fatal behavior when the metrics port cannot be bound: log the error and continue the FUSE mount.
- Keep recording exactly one `success` or `error` result from `FuseSession::new`.
- Change the Grafana init query from a range `increase()` to the current counter value.
- Rename and document the panel so the different init and shutdown semantics are explicit.
- Add a unit test verifying that both zero-valued result series are exported without being incremented.

# Correctness Notes

The initialization series now has the following process-local state transition:

```text
before FuseSession::new
    success = 0
    error   = 0
          |
          +-- initialization succeeds -> success = 1, error = 0
          |
          +-- initialization fails    -> success = 0, error = 1
```

The dashboard query is now:

```promql
sum by(result)(curvine_fuse_session_init_total{instance=~"$instance"})
```

For one selected instance, this reports the current FUSE process's initialization outcome. For multiple selected instances, it reports how many currently scraped processes expose each result.

Starting the endpoint earlier creates an observable zero baseline when initialization overlaps a Prometheus scrape, but correctness no longer depends on catching that short interval because the panel reads the current result directly.

Shutdown remains range-based:

```promql
sum by(reason)(increase(curvine_fuse_session_shutdown_total[$__range]))
```

A process-local pull metric cannot guarantee that a final shutdown increment is scraped before the endpoint disappears. The panel description now calls out this limitation instead of implying complete shutdown-event accounting.

# Concurrency And Performance Impact

- Two counter children are created once during startup; there is no per-request overhead.
- The metrics listener is bound and its serve task is spawned earlier in the same runtime.
- Session construction and normal FUSE request handling are unchanged.
- Failure to bind the monitoring port remains non-fatal to the mount.
- No RPC schema, persisted state, or configuration change is required.

# Verification

Formatting, dashboard JSON, and patch validation:

```text
cargo fmt --check
jq empty etc/grafana/curvine-fuse-dashboard.json
git diff --check
```

Compilation check:

```text
cargo check -p curvine-fuse

Finished `dev` profile successfully
```

Targeted lifecycle metric test:

```text
cargo test -p curvine-fuse \
  init_session_metrics_exports_zero_baselines_without_incrementing \
  --lib

test result: ok. 1 passed; 0 failed; 0 ignored
```

The full FUSE library test run completed with 445 passing tests and one failure in an unrelated writer metric assertion caused by parallel tests sharing the global metrics registry. The affected test passed when rerun in isolation:

```text
cargo test -p curvine-fuse \
  fs::fuse_writer::tests::task_body_integration::local_writer_task_body_observes_io_with_local_path_type \
  --lib -- --exact

test result: ok. 1 passed; 0 failed; 0 ignored
```

# Scope

This change fixes the observability and dashboard meaning of FUSE session initialization. It does not turn process-local lifecycle counters into durable event storage, and it cannot guarantee collection of shutdown events after the metrics endpoint has disappeared.
