### PR TITLE
feat(master): local policy assigns remaining replicas by weight

### DIFF
--- a/curvine-master/src/master/fs/policy/local_worker_policy.rs
+++ b/curvine-master/src/master/fs/policy/local_worker_policy.rs
@@ -17,7 +17,10 @@ use curvine_core_error::{err_box, CommonResult};
 use curvine_model::{WorkerAddress, WorkerInfo};
 use indexmap::IndexMap;
 
-/// Local workers are preferred, and weighted policies are used if there are no local workers
+/// A local worker is preferred for the first replica, and the remaining replicas are assigned
+/// by the weighted policy. If no eligible local worker exists, all replicas are assigned by
+/// the weighted policy. Local workers with weight 0 are skipped so that drained nodes
+/// receive no new data.
 pub struct LocalWorkerPolicy {
     inner: WeightedWorkerPolicy,
 }
@@ -56,6 +59,7 @@ impl WorkerPolicy for LocalWorkerPolicy {
             if !ctx.exclude_workers.contains(id)
                 && worker.address.is_local(&ctx.client_host)
                 && worker.available > ctx.block_size
+                && worker.weight > 0
                 && worker.is_live()
             {
                 res.push(worker.address.clone());
@@ -66,11 +70,22 @@ impl WorkerPolicy for LocalWorkerPolicy {
 
         let replicas = ctx.replicas;
         if res.len() < replicas as usize {
-            let remote_res = self.inner.choose(workers, ctx)?;
-            for item in remote_res {
-                res.push(item);
-                if res.len() == replicas as usize {
-                    break;
+            match self.inner.choose(workers, ctx) {
+                Ok(remote_res) => {
+                    for item in remote_res {
+                        res.push(item);
+                        if res.len() == replicas as usize {
+                            break;
+                        }
+                    }
+                }
+                // The weighted policy errors when no remote worker is eligible. A local
+                // replica is still valid, so under-replicate instead of failing; keep
+                // the error when nothing was selected at all.
+                Err(e) => {
+                    if res.is_empty() {
+                        return Err(e);
+                    }
                 }
             }
         }
@@ -84,8 +99,118 @@ impl WorkerPolicy for LocalWorkerPolicy {
         count: Option<usize>,
         exclude_workers: Vec<u32>,
     ) -> CommonResult<Vec<WorkerAddress>> {
-        // Since you do not rely on block information, you cannot judge the local worker,
-        // and use the weighted strategy directly
+        // Without block or client context the local worker cannot be determined,
+        // so delegate directly to the weighted policy.
         self.inner.choose_workers(workers, count, exclude_workers)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use curvine_model::StoragePolicy;
+    use std::collections::HashSet;
+
+    fn worker_on(id: u32, weight: u32, hostname: &str) -> WorkerInfo {
+        WorkerInfo {
+            address: WorkerAddress {
+                worker_id: id,
+                hostname: hostname.to_string(),
+                ..Default::default()
+            },
+            weight,
+            capacity: 1024,
+            available: 1024,
+            ..Default::default()
+        }
+    }
+
+    fn ctx(client_host: &str, replicas: u16, block_size: i64) -> ChooseContext {
+        ChooseContext {
+            replicas,
+            block_size,
+            storage_policy: StoragePolicy::default(),
+            client_host: client_host.to_string(),
+            exclude_workers: HashSet::new(),
+        }
+    }
+
+    #[test]
+    fn local_first_then_weighted_remaining() {
+        let policy = LocalWorkerPolicy::new();
+        // Worker 1 has weight 0, so the weighted fallback can only pick worker 3.
+        let workers = IndexMap::from([
+            (1, worker_on(1, 0, "host-a")),
+            (2, worker_on(2, 1, "host-b")),
+            (3, worker_on(3, 1, "host-c")),
+        ]);
+
+        let selected = policy.choose(&workers, ctx("host-b", 2, 10)).unwrap();
+
+        assert_eq!(selected.len(), 2);
+        assert_eq!(selected[0].worker_id, 2);
+        assert_eq!(selected[1].worker_id, 3);
+    }
+
+    #[test]
+    fn under_replicates_when_no_eligible_remote_worker() {
+        let policy = LocalWorkerPolicy::new();
+        // Worker 1 is local; worker 2 has weight 0, so the weighted fallback
+        // finds no eligible remote worker and the local replica is kept alone.
+        let workers = IndexMap::from([
+            (1, worker_on(1, 1, "host-a")),
+            (2, worker_on(2, 0, "host-b")),
+        ]);
+
+        let selected = policy.choose(&workers, ctx("host-a", 2, 10)).unwrap();
+
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].worker_id, 1);
+    }
+
+    #[test]
+    fn no_local_worker_falls_back_to_weighted() {
+        let policy = LocalWorkerPolicy::new();
+        // Worker 2 has weight 0 and must never be selected by the weighted fallback.
+        let workers = IndexMap::from([
+            (1, worker_on(1, 1, "host-a")),
+            (2, worker_on(2, 0, "host-b")),
+            (3, worker_on(3, 1, "host-c")),
+        ]);
+
+        let selected = policy.choose(&workers, ctx("host-d", 2, 10)).unwrap();
+
+        assert_eq!(selected.len(), 2);
+        let ids: HashSet<u32> = selected.iter().map(|addr| addr.worker_id).collect();
+        assert_eq!(ids, HashSet::from([1, 3]));
+    }
+
+    #[test]
+    fn errors_when_no_worker_is_eligible() {
+        let policy = LocalWorkerPolicy::new();
+        // No local worker and every worker has weight 0: the weighted error propagates.
+        let workers = IndexMap::from([
+            (1, worker_on(1, 0, "host-a")),
+            (2, worker_on(2, 0, "host-b")),
+        ]);
+
+        let selected = policy.choose(&workers, ctx("host-c", 2, 10));
+
+        assert!(selected.is_err());
+    }
+
+    #[test]
+    fn skips_drained_local_worker() {
+        let policy = LocalWorkerPolicy::new();
+        // Worker 1 is local but drained (weight 0), so it must not receive any replica.
+        let workers = IndexMap::from([
+            (1, worker_on(1, 0, "host-a")),
+            (2, worker_on(2, 1, "host-b")),
+        ]);
+
+        let selected = policy.choose(&workers, ctx("host-a", 2, 10)).unwrap();
+
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].worker_id, 2);
     }
 }

--- a/curvine-master/src/master/fs/policy/local_worker_policy.rs
+++ b/curvine-master/src/master/fs/policy/local_worker_policy.rs
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::master::fs::policy::{ChooseContext, RobinWorkerPolicy, WorkerPolicy};
+use crate::master::fs::policy::{ChooseContext, WeightedWorkerPolicy, WorkerPolicy};
 use curvine_core_error::{err_box, CommonResult};
 use curvine_model::{WorkerAddress, WorkerInfo};
 use indexmap::IndexMap;
 
-/// Local workers are preferred, and polling policies are used if there are no local workers
+/// Local workers are preferred, and weighted policies are used if there are no local workers
 pub struct LocalWorkerPolicy {
-    inner: RobinWorkerPolicy,
+    inner: WeightedWorkerPolicy,
 }
 
 impl Default for LocalWorkerPolicy {
@@ -31,7 +31,7 @@ impl Default for LocalWorkerPolicy {
 impl LocalWorkerPolicy {
     pub fn new() -> Self {
         Self {
-            inner: RobinWorkerPolicy::new(),
+            inner: WeightedWorkerPolicy::new(),
         }
     }
 }
@@ -84,7 +84,8 @@ impl WorkerPolicy for LocalWorkerPolicy {
         count: Option<usize>,
         exclude_workers: Vec<u32>,
     ) -> CommonResult<Vec<WorkerAddress>> {
-        // Since you do not rely on block information, you cannot judge the local worker, and use the polling strategy directly
+        // Since you do not rely on block information, you cannot judge the local worker,
+        // and use the weighted strategy directly
         self.inner.choose_workers(workers, count, exclude_workers)
     }
 }

--- a/etc/curvine-cluster.toml
+++ b/etc/curvine-cluster.toml
@@ -34,6 +34,7 @@ auth_token_env = "CURVINE_FAULT_TOKEN"
 [master]
 meta_dir = "testing/meta"
 # Worker selection policy: local, robin, random, load_based, or weighted.
+# local prefers a local worker for the first replica and assigns the rest by weight.
 # worker_policy = "weighted"
 log = { level = "info", log_dir = "stdout", file_name = "master.log" }
 

--- a/etc/curvine-cluster.toml
+++ b/etc/curvine-cluster.toml
@@ -34,7 +34,7 @@ auth_token_env = "CURVINE_FAULT_TOKEN"
 [master]
 meta_dir = "testing/meta"
 # Worker selection policy: local, robin, random, load_based, or weighted.
-# local prefers a local worker for the first replica and assigns the rest by weight.
+# local prefers a local worker for the first replica and assigns the rest via the weighted policy.
 # worker_policy = "weighted"
 log = { level = "info", log_dir = "stdout", file_name = "master.log" }
 


### PR DESCRIPTION
# Summary

LocalWorkerPolicy keeps the local worker as the first replica, but now delegates the remaining replicas to WeightedWorkerPolicy instead of RobinWorkerPolicy, so extra replicas are distributed proportionally to `worker.weight` and nodes with weight 0 receive no new data.

# Issue Describe / Design

No related issue.

- Local-first selection is unchanged except for drain semantics: a local worker with weight 0 is now skipped as well, so a drained node receives no new replicas even from co-located clients.
- Remaining replicas previously rotated round-robin regardless of node capacity; weighted random selection lets operators steer replicas to higher-capacity nodes via `worker.weight` and drain a node by setting its weight to 0.
- Under-replication is preserved: when a local replica is selected but no eligible remote worker remains (single-node clusters, drained or dead peers), selection returns the local replica alone instead of failing, matching the previous RobinWorkerPolicy behavior and the WorkerManager contract. The weighted error still propagates when nothing was selected at all.
- `choose_workers` (no block context) keeps pure weighted behavior, since the local worker cannot be determined without `client_host`.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-master/src/master/fs/policy/local_worker_policy.rs` | Replace RobinWorkerPolicy fallback with WeightedWorkerPolicy; skip weight-0 local workers; under-replicate instead of failing when no remote worker is eligible | Behavior change: remaining replicas are weighted-random instead of round-robin; drained (weight 0) local nodes no longer receive the first replica |
| `etc/curvine-cluster.toml` | Document local policy semantics in the worker_policy comment | None |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `local_first_then_weighted_remaining` | Added | Local worker first; weight-0 remotes never chosen by the fallback |
| `under_replicates_when_no_eligible_remote_worker` | Added | Local selected + no eligible remote returns Ok([local]), not an error |
| `no_local_worker_falls_back_to_weighted` | Added | No local worker -> full weighted selection |
| `errors_when_no_worker_is_eligible` | Added | No local worker and all weight 0 -> error propagates |
| `skips_drained_local_worker` | Added | Weight-0 local worker receives no replica |
| `cargo test -p curvine-master` | Not run locally | Windows dev box cannot build platform dependencies; rely on CI |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None
