### PR TITLE
feat(worker): log client address in block write logs

### DIFF
--- a/curvine-worker/src/worker/handler/batch_write_handler.rs
+++ b/curvine-worker/src/worker/handler/batch_write_handler.rs
@@ -38,14 +38,14 @@ pub struct BatchWriteHandler {
 }
 
 impl BatchWriteHandler {
-    pub fn new(store: BlockStore) -> CommonResult<Self> {
+    pub fn new(store: BlockStore, client_addr: String) -> CommonResult<Self> {
         let store_clone = store.clone();
         Ok(Self {
             store,
             context: None,
             file: None,
             is_commit: false,
-            write_handler: WriteHandler::new(store_clone)?,
+            write_handler: WriteHandler::new(store_clone, client_addr)?,
         })
     }
 

--- a/curvine-worker/src/worker/handler/block_handler.rs
+++ b/curvine-worker/src/worker/handler/block_handler.rs
@@ -27,13 +27,13 @@ pub enum BlockHandler {
 }
 
 impl BlockHandler {
-    pub fn new(code: RpcCode, store: BlockStore) -> CommonResult<Self> {
+    pub fn new(code: RpcCode, store: BlockStore, client_addr: String) -> CommonResult<Self> {
         let handler = match code {
-            RpcCode::WriteBlock => Writer(WriteHandler::new(store)?),
+            RpcCode::WriteBlock => Writer(WriteHandler::new(store, client_addr)?),
 
             RpcCode::ReadBlock => Reader(ReadHandler::new(store)?),
 
-            RpcCode::WriteBlocksBatch => BatchWriter(BatchWriteHandler::new(store)?),
+            RpcCode::WriteBlocksBatch => BatchWriter(BatchWriteHandler::new(store, client_addr)?),
 
             code => return err_box!("Unsupported request type: {:?}", code),
         };

--- a/curvine-worker/src/worker/handler/worker_handler.rs
+++ b/curvine-worker/src/worker/handler/worker_handler.rs
@@ -74,6 +74,7 @@ pub struct WorkerHandler {
     /// deep copy); diagnose by default so old clients are never rejected
     /// without explicit configuration.
     pub compatibility_policy: Arc<CompatibilityPolicy>,
+    pub client_addr: String,
 }
 
 impl MessageHandler for WorkerHandler {
@@ -337,7 +338,11 @@ impl WorkerHandler {
         };
 
         if need_new_handler {
-            let _ = handler.replace(BlockHandler::new(code, self.store.clone())?);
+            let _ = handler.replace(BlockHandler::new(
+                code,
+                self.store.clone(),
+                self.client_addr.clone(),
+            )?);
         }
 
         match handler.as_mut() {

--- a/curvine-worker/src/worker/handler/write_handler.rs
+++ b/curvine-worker/src/worker/handler/write_handler.rs
@@ -32,10 +32,11 @@ pub struct WriteHandler {
     pub(crate) is_commit: bool,
     pub(crate) io_slow_us: u64,
     pub(crate) metrics: &'static WorkerMetrics,
+    pub(crate) client_addr: String,
 }
 
 impl WriteHandler {
-    pub fn new(store: BlockStore) -> CommonResult<Self> {
+    pub fn new(store: BlockStore, client_addr: String) -> CommonResult<Self> {
         let conf = Worker::get_conf()?;
         let metrics = Worker::get_metrics()?;
         Ok(Self {
@@ -45,6 +46,7 @@ impl WriteHandler {
             is_commit: false,
             io_slow_us: conf.worker.io_slow_us(),
             metrics,
+            client_addr,
         })
     }
 
@@ -153,13 +155,14 @@ impl WriteHandler {
         };
 
         let log_msg = format!(
-            "Write {}-block start req_id: {}, path: {:?}, chunk_size: {}, off: {}, block_size: {}",
+            "Write {}-block start req_id: {}, path: {:?}, chunk_size: {}, off: {}, block_size: {}, client: {}",
             label,
             context.req_id,
             path,
             context.chunk_size,
             context.off,
-            ByteUnit::byte_to_string(context.block_size as u64)
+            ByteUnit::byte_to_string(context.block_size as u64),
+            self.client_addr
         );
 
         let response = BlockWriteResponse {
@@ -290,11 +293,12 @@ impl WriteHandler {
         self.is_commit = true;
 
         info!(
-            "write block end for req_id {}, is commit: {}, off: {}, len: {}",
+            "write block end for req_id {}, is commit: {}, off: {}, len: {}, client: {}",
             msg.req_id(),
             commit,
             context.off,
-            context.block.len
+            context.block.len,
+            self.client_addr
         );
 
         Ok(msg.success())

--- a/curvine-worker/src/worker/worker_server.rs
+++ b/curvine-worker/src/worker/worker_server.rs
@@ -96,7 +96,14 @@ impl WorkerService {
 impl HandlerService for WorkerService {
     type Item = WorkerHandler;
 
-    fn get_message_handler(&self, _: Option<ConnState>) -> Self::Item {
+    fn has_conn_state(&self) -> bool {
+        true
+    }
+
+    fn get_message_handler(&self, conn_info: Option<ConnState>) -> Self::Item {
+        let client_addr = conn_info
+            .map(|state| state.remote_addr.to_string())
+            .unwrap_or_default();
         WorkerHandler {
             store: self.store.clone(),
             handler: FastMutex::new(None),
@@ -105,6 +112,7 @@ impl HandlerService for WorkerService {
             rt: self.rt.clone(),
             replication_handler: WorkerReplicationHandler::new(&self.replication_manager),
             compatibility_policy: self.compatibility_policy.clone(),
+            client_addr,
         }
     }
 }


### PR DESCRIPTION
# Summary

Log the client address (ip:port) in worker block-write logs. The address is taken from the RPC connection instead of any client-reported field, so it cannot be spoofed and helps trace which client created or wrote a block.

# Issue Describe / Design

No related issue.

- The RPC framework already supports passing connection state to handlers (`HandlerService::has_conn_state`), it was just not enabled for the worker service.
- `WorkerService` now enables conn state and stores the remote address (`InetAddr`, formatted as `ip:port`) in `WorkerHandler`, which is resolved once per connection and threaded into block write handlers.
- `WriteHandler` appends `client: <ip:port>` to the "Write block start" and "write block end" log lines, covering `WriteBlock` and `WriteBlocksBatch` paths.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-worker/src/worker/worker_server.rs` | Enable `has_conn_state`, extract remote addr into `WorkerHandler` | None |
| `curvine-worker/src/worker/handler/worker_handler.rs` | Carry `client_addr` and pass it to `BlockHandler` | None |
| `curvine-worker/src/worker/handler/block_handler.rs` | Forward `client_addr` to write handlers | None |
| `curvine-worker/src/worker/handler/write_handler.rs` | Store `client_addr`, print it in block write start/end logs | Log format change only |
| `curvine-worker/src/worker/handler/batch_write_handler.rs` | Forward `client_addr` to `WriteHandler` | None |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-worker` | Not run locally | Windows dev box cannot build platform dependencies; rely on CI |

# Dependencies

- Related PRs: #1631 (independent, no dependency)
- Related issues: None
- Blocks / blocked by: None
