### PR TITLE
feat(client): log git commit in filesystem creation

### DIFF
--- a/crates/client/curvine-client-core/src/file/curvine_filesystem.rs
+++ b/crates/client/curvine-client-core/src/file/curvine_filesystem.rs
@@ -58,8 +58,9 @@ impl CurvineFileSystem {
 
         let c = &fs.conf().client;
         info!(
-            "Create new filesystem, version: {}, masters: {}, threads: {}-{}, \
+            "Create new filesystem, commit: {}, version: {}, masters: {}, threads: {}-{}, \
             buffer(rw): {}-{}, conn timeout(ms): {}-{}, rpc timeout(ms): {}-{}, data timeout(ms): {}",
+            curvine_sys::version::GIT_VERSION,
             env!("CARGO_PKG_VERSION"),
             fs.conf().masters_string(),
             rt.io_threads(),


### PR DESCRIPTION
# Summary

Add the git commit (`curvine_sys::version::GIT_VERSION`) to the "Create new filesystem" log line, so client-side logs can be mapped to the exact build even when multiple builds share the same package version.

# Issue Describe / Design

No related issue.

- The package version alone is not enough to identify a build during development or hotfix iterations; the git short commit is already generated by `curvine-sys`'s build script and is used the same way for component version reporting.
- `curvine-client-core` already depends on `curvine-sys`, so no dependency change is needed.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `crates/client/curvine-client-core/src/file/curvine_filesystem.rs` | Add `commit: {}` (GIT_VERSION) to the filesystem creation log | Log format change only |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-client-core` | Not run locally | Windows dev box cannot build platform dependencies; rely on CI |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None
