### PR TITLE
fix(libsdk): fix mount lifecycle to prevent use-after-free and double close

### DIFF
--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineFileSystem.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineFileSystem.java
@@ -20,7 +20,6 @@ import java.net.URI;
 import java.nio.file.DirectoryNotEmptyException;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.classification.InterfaceAudience;
@@ -60,30 +59,34 @@ public class CurvineFileSystem extends FileSystem {
      * Value: CachedMount containing the shared CurvineFsMount and reference count
      */
     private static final ConcurrentHashMap<String, CachedMount> MOUNT_CACHE = new ConcurrentHashMap<>();
-    
+
     private static class CachedMount {
         final CurvineFsMount mount;
-        final AtomicInteger refCount;
-        
+        int refCount;
+        private boolean closed;
+
         CachedMount(CurvineFsMount mount) {
             this.mount = mount;
-            this.refCount = new AtomicInteger(1);
+            this.refCount = 1;
         }
-    }
-    
-    static {
-        // Register shutdown hook to clean up all cached mounts
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            LOGGER.info("Shutting down CurvineFileSystem, closing {} cached mounts", MOUNT_CACHE.size());
-            for (CachedMount cached : MOUNT_CACHE.values()) {
-                try {
-                    cached.mount.close();
-                } catch (IOException e) {
-                    LOGGER.warn("Error closing cached mount", e);
-                }
+
+        /**
+         * Close the underlying mount exactly once; later calls are no-ops.
+         * The lock makes it idempotent against concurrent closes from multiple
+         * CurvineFileSystem instances sharing the mount, so the native handle
+         * is never released twice (double free).
+         */
+        synchronized void closeOnce() {
+            if (closed) {
+                return;
             }
-            MOUNT_CACHE.clear();
-        }));
+            closed = true;
+            try {
+                mount.close();
+            } catch (IOException e) {
+                LOGGER.warn("Error closing cached mount", e);
+            }
+        }
     }
 
     private CurvineFsMount libFs;
@@ -152,26 +155,21 @@ public class CurvineFileSystem extends FileSystem {
     
     /**
      * Get or create a cached CurvineFsMount instance.
-     * This method is thread-safe and ensures only one mount is created per master_addrs.
+     * Lookup and refcount update both happen under the cache lock: an entry that is
+     * still in the cache is always open, so no caller can ever observe a closed
+     * mount (no use-after-free) and exactly one instance is created per master_addrs.
      */
     private CurvineFsMount getOrCreateMount(FilesystemConf conf) throws IOException {
         String key = conf.master_addrs;
-        
-        CachedMount cached = MOUNT_CACHE.get(key);
-        if (cached != null) {
-            cached.refCount.incrementAndGet();
-            LOGGER.debug("Reusing cached CurvineFsMount for {}, refCount={}", key, cached.refCount.get());
-            return cached.mount;
-        }
-        
+
         synchronized (MOUNT_CACHE) {
-            cached = MOUNT_CACHE.get(key);
+            CachedMount cached = MOUNT_CACHE.get(key);
             if (cached != null) {
-                cached.refCount.incrementAndGet();
-                LOGGER.debug("Reusing cached CurvineFsMount for {} (after lock), refCount={}", key, cached.refCount.get());
+                cached.refCount++;
+                LOGGER.debug("Reusing cached CurvineFsMount for {}, refCount={}", key, cached.refCount);
                 return cached.mount;
             }
-            
+
             LOGGER.info("Creating new cached CurvineFsMount for {}", key);
             CurvineFsMount newMount = new CurvineFsMount(conf);
             MOUNT_CACHE.put(key, new CachedMount(newMount));
@@ -321,15 +319,18 @@ public class CurvineFileSystem extends FileSystem {
 
     @Override
     public void close() throws IOException {
-        // Don't close the shared mount, just decrement reference count
         if (libFs != null && cacheKey != null) {
-            CachedMount cached = MOUNT_CACHE.get(cacheKey);
-            if (cached != null) {
-                int remaining = cached.refCount.decrementAndGet();
-                LOGGER.debug("Closing CurvineFileSystem for {}, remaining refCount={}", cacheKey, remaining);
-                // Note: We don't remove from cache even when refCount reaches 0
-                // because new FileSystem instances may be created later.
-                // The mount will be cleaned up by the shutdown hook.
+            CachedMount cached;
+            boolean last;
+            synchronized (MOUNT_CACHE) {
+                cached = MOUNT_CACHE.get(cacheKey);
+                last = cached != null && --cached.refCount <= 0;
+                if (last) {
+                    MOUNT_CACHE.remove(cacheKey);
+                }
+            }
+            if (last) {
+                cached.closeOnce();
             }
             libFs = null;
         }

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineFileSystem.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineFileSystem.java
@@ -74,18 +74,15 @@ public class CurvineFileSystem extends FileSystem {
          * Close the underlying mount exactly once; later calls are no-ops.
          * The lock makes it idempotent against concurrent closes from multiple
          * CurvineFileSystem instances sharing the mount, so the native handle
-         * is never released twice (double free).
+         * is never released twice (double free). Failures are propagated to
+         * the caller so an explicit close can never silently leak the mount.
          */
-        synchronized void closeOnce() {
+        synchronized void closeOnce() throws IOException {
             if (closed) {
                 return;
             }
             closed = true;
-            try {
-                mount.close();
-            } catch (IOException e) {
-                LOGGER.warn("Error closing cached mount", e);
-            }
+            mount.close();
         }
     }
 
@@ -329,10 +326,15 @@ public class CurvineFileSystem extends FileSystem {
                     MOUNT_CACHE.remove(cacheKey);
                 }
             }
-            if (last) {
-                cached.closeOnce();
+            try {
+                if (last) {
+                    cached.closeOnce();
+                }
+            } finally {
+                // Idempotent per instance even if the native close fails: the
+                // cache entry is already removed, so a retry is a no-op.
+                libFs = null;
             }
-            libFs = null;
         }
         super.close();
     }

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineInputStream.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineInputStream.java
@@ -66,6 +66,8 @@ public class CurvineInputStream extends FSInputStream {
 
     @Override
     public int read(@Nonnull byte[] buf, int offset, int length) throws IOException {
+        checkClosed();
+
         if (length == 0) {
             return 0;
         } else if (pos < 0) {
@@ -73,8 +75,6 @@ public class CurvineInputStream extends FSInputStream {
         } else if (pos >= fileSize) {
             return -1;
         }
-
-        checkClosed();
 
         if (buf.length - offset < length) {
             throw new IndexOutOfBoundsException(

--- a/curvine-libsdk/java/src/test/java/io/curvine/CurvineFileSystemLifecycleTest.java
+++ b/curvine-libsdk/java/src/test/java/io/curvine/CurvineFileSystemLifecycleTest.java
@@ -1,0 +1,212 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.curvine;
+
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.junit.After;
+import org.junit.Test;
+
+import sun.misc.Unsafe;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Pure-Java lifecycle tests for the cached mount lifecycle in CurvineFileSystem.
+ *
+ * <p>The native library is not required: a {@link FakeMount} created via {@link Unsafe}
+ * replaces the real CurvineFsMount, and the private MOUNT_CACHE / CachedMount state is
+ * driven through reflection. These tests pin the release contract:
+ * <ol>
+ *   <li>closing one of several CurvineFileSystem instances sharing a mount must not
+ *       release the native mount (no premature release);</li>
+ *   <li>closing the last instance releases the native mount exactly once;</li>
+ *   <li>a failed native close is propagated to the caller instead of being swallowed;</li>
+ *   <li>reads on a closed stream throw IOException instead of returning EOF or crashing.</li>
+ * </ol>
+ */
+public class CurvineFileSystemLifecycleTest {
+
+    private static final String KEY = "test-master-1:8995";
+
+    private final ConcurrentHashMap<String, Object> cache = mountCache();
+
+    private FakeMount fakeMount;
+    private Object cachedMount;
+
+    @After
+    public void tearDown() {
+        cache.remove(KEY);
+    }
+
+    @Test
+    public void intermediateCloseMustNotReleaseSharedMount() throws Exception {
+        fakeMount = newFakeMount();
+        cachedMount = newCachedMount(fakeMount, 2);
+
+        CurvineFileSystem fs1 = newInstance("fs1");
+        CurvineFileSystem fs2 = newInstance("fs2");
+
+        fs1.close();
+
+        assertEquals("intermediate close must not call closeFilesystem", 0, fakeMount.closeCalls);
+        assertTrue("mount must stay cached while another instance holds it", cache.containsKey(KEY));
+        assertEquals("refcount must drop by one only", 1, refCount(cachedMount));
+        assertFalse("mount must not be marked closed", isClosed(cachedMount));
+        fs2.close(); // cleanup
+    }
+
+    @Test
+    public void lastCloseReleasesSharedMountExactlyOnce() throws Exception {
+        fakeMount = newFakeMount();
+        cachedMount = newCachedMount(fakeMount, 2);
+
+        CurvineFileSystem fs1 = newInstance("fs1");
+        CurvineFileSystem fs2 = newInstance("fs2");
+
+        fs1.close();
+        fs2.close();
+
+        assertEquals("last close must release the native mount exactly once", 1, fakeMount.closeCalls);
+        assertNull("cache entry must be removed after last close", cache.get(KEY));
+    }
+
+    @Test
+    public void closeFailureIsPropagatedToCaller() throws Exception {
+        fakeMount = newFakeMount();
+        fakeMount.failClose = true;
+        cachedMount = newCachedMount(fakeMount, 1);
+
+        CurvineFileSystem fs = newInstance("fs");
+
+        IOException e = assertThrows(IOException.class, fs::close);
+        assertTrue(e.getMessage().contains("fake close failure"));
+        // A failed close must not break per-instance idempotency: retry is a no-op.
+        fs.close();
+    }
+
+    @Test
+    public void readOnClosedStreamThrowsIOException() throws Exception {
+        CurvineInputStream in = new CurvineInputStream(null, 0, 0, null);
+        setClosed(in, true);
+
+        assertThrows(IOException.class, () -> in.read(new byte[16], 0, 16));
+        // close on an already closed stream stays a no-op and must not throw
+        in.close();
+    }
+
+    @Test
+    public void readOnClosedStreamDoesNotDependOnFileSize() throws Exception {
+        // Regression: checkClosed must run before the pos >= fileSize EOF short-circuit.
+        CurvineInputStream in = new CurvineInputStream(null, 0, 0, null);
+        setClosed(in, true);
+
+        assertThrows(IOException.class, () -> in.read(new byte[16], 0, 16));
+    }
+
+    // --- helpers ---------------------------------------------------------
+
+    private CurvineFileSystem newInstance(String name) throws Exception {
+        CurvineFileSystem fs = new CurvineFileSystem();
+        setField(fs, "libFs", fakeMount);
+        setField(fs, "cacheKey", KEY);
+        return fs;
+    }
+
+    private Object newCachedMount(CurvineFsMount mount, int refCount) throws Exception {
+        Class<?> cachedMountClass = Class.forName("io.curvine.CurvineFileSystem$CachedMount");
+        Constructor<?> ctor = cachedMountClass.getDeclaredConstructor(CurvineFsMount.class);
+        ctor.setAccessible(true);
+        Object cm = ctor.newInstance(mount);
+        Field refCountField = cachedMountClass.getDeclaredField("refCount");
+        refCountField.setAccessible(true);
+        refCountField.setInt(cm, refCount);
+        cache.put(KEY, cm);
+        return cm;
+    }
+
+    private static int refCount(Object cachedMount) throws Exception {
+        Field refCountField = cachedMount.getClass().getDeclaredField("refCount");
+        refCountField.setAccessible(true);
+        return refCountField.getInt(cachedMount);
+    }
+
+    private static boolean isClosed(Object cachedMount) throws Exception {
+        Field closedField = cachedMount.getClass().getDeclaredField("closed");
+        closedField.setAccessible(true);
+        return closedField.getBoolean(cachedMount);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ConcurrentHashMap<String, Object> mountCache() {
+        try {
+            Field cacheField = CurvineFileSystem.class.getDeclaredField("MOUNT_CACHE");
+            cacheField.setAccessible(true);
+            return (ConcurrentHashMap<String, Object>) cacheField.get(null);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void setField(Object target, String name, Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    private static void setClosed(CurvineInputStream in, boolean closed) throws Exception {
+        setField(in, "closed", closed);
+    }
+
+    private static FakeMount newFakeMount() throws InstantiationException {
+        return (FakeMount) unsafe().allocateInstance(FakeMount.class);
+    }
+
+    private static Unsafe unsafe() {
+        try {
+            Field field = Unsafe.class.getDeclaredField("theUnsafe");
+            field.setAccessible(true);
+            return (Unsafe) field.get(null);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /** Fake native mount; created via {@link Unsafe} so the native constructor is never run. */
+    static class FakeMount extends CurvineFsMount {
+        int closeCalls;
+        boolean failClose;
+
+        private FakeMount() throws IOException {
+            // Never invoked: instances are allocated via Unsafe.allocateInstance.
+            super((FilesystemConf) null);
+        }
+
+        @Override
+        public void close() throws IOException {
+            closeCalls++;
+            if (failClose) {
+                throw new IOException("fake close failure");
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Summary

Fixes CurvineFileSystem mount lifecycle so the shared native mount is released
exactly once, only when the last FileSystem instance using it is closed, and is
never raced with in-flight JNI calls. Removes the JVM shutdown-hook cleanup that
crashed Spark/YARN containers at exit, and makes reads on closed streams throw.

# Issue Describe / Design

**Root cause**: the native handle is freed unconditionally by
closeWriter/closeReader/closeFilesystem once Java decides to release it. The
previous code never closed the cached mount (delegated cleanup to a JVM
shutdown hook), and that hook raced with application threads still issuing JNI
calls at JVM exit -> use-after-free (SIGSEGV in tokio::runtime::handle::Handle::
enter, observed on Spark ApplicationMaster containers).

**Fix approach**:
- CachedMount refcount: close() releases the mount only when the last
  CurvineFileSystem instance is closed (refcount reaches 0); the cache entry is
  removed under the cache lock;
- closeOnce() is synchronized and idempotent -> the native handle is released
  exactly once (no double free);
- getOrCreateMount performs lookup + refcount under the cache lock -> callers
  can never observe a closed mount (no use-after-free);
- Removed the JVM shutdown-hook cleanup: leaked mounts are left to OS
  reclamation at process exit instead of racing with in-flight calls;
- CurvineInputStream.read() now checks closed first so reads on closed streams
  throw IOException instead of silently returning EOF.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-libsdk/java/src/main/java/io/curvine/CurvineFileSystem.java` | mount refcount lifecycle, idempotent closeOnce, lock-protected cache, remove shutdown hook | Behavior change: native mount is released when the last instance closes; no exit-time fallback cleanup |
| `curvine-libsdk/java/src/main/java/io/curvine/CurvineInputStream.java` | check closed before read | Behavior change: reads on closed streams throw IOException |
| `crates/client/curvine-client-core/src/file/curvine_filesystem.rs` | log git commit in filesystem creation | None (logging only) |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `mvn compile` (curvine-libsdk/java) | PASS | JDK 8 / Maven 3.9 |
| Spark TPC-H on YARN (Spark 3.5, Hadoop 3.3) | PASS | Crash at JVM exit disappeared after removing shutdown-hook cleanup |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None
