### PR TITLE
fix(worker): use stored block length for replication reads (#1634)

### DIFF
--- a/curvine-worker/src/worker/block/block_store.rs
+++ b/curvine-worker/src/worker/block/block_store.rs
@@ -237,11 +237,32 @@ impl BlockStore {
         off: i64,
         logical_len: i64,
     ) -> CommonResult<(BlockMeta, BlockReadContext)> {
+        self.open_reader_by_id_inner(id, off, Some(logical_len))
+    }
+
+    /// Opens the currently readable generation using its stored metadata length
+    /// as the logical read boundary. This is intended for internal block copies
+    /// that do not have a client-provided logical length.
+    pub fn open_reader_by_id_at_stored_len(
+        &self,
+        id: i64,
+        off: i64,
+    ) -> CommonResult<(BlockMeta, BlockReadContext)> {
+        self.open_reader_by_id_inner(id, off, None)
+    }
+
+    fn open_reader_by_id_inner(
+        &self,
+        id: i64,
+        off: i64,
+        logical_len: Option<i64>,
+    ) -> CommonResult<(BlockMeta, BlockReadContext)> {
         let state = self.read()?;
         let meta = state
             .get_readable_block(id)
             .ok_or_else(|| curvine_core_error::err_msg!(format!("block {} not exists", id)))?
             .clone();
+        let logical_len = logical_len.unwrap_or_else(|| meta.len());
         let (layout, dir) = state.layout_for(&meta)?;
         let reader = layout.open_reader(&dir, &meta, off, logical_len)?;
         Ok((meta, reader))
@@ -605,12 +626,24 @@ mod tests {
             .expect("rewrite finalize must reserve");
         let plan = reservation.prepare(block.len)?;
 
-        let (_, mut committed_reader) = store.open_reader_by_id(block.id, 0, block.len)?;
+        let (_, mut committed_reader) = store.open_reader_by_id_at_stored_len(block.id, 0)?;
         store.write()?.publish_file_finalize(&reservation, plan)?;
         assert_eq!(read_bytes(&mut committed_reader, 4)?, b"old!");
 
-        let (_, mut published_reader) = store.open_reader_by_id(block.id, 0, block.len)?;
+        let (_, mut published_reader) = store.open_reader_by_id_at_stored_len(block.id, 0)?;
         assert_eq!(read_bytes(&mut published_reader, 4)?, b"new!");
+        Ok(())
+    }
+
+    #[test]
+    fn stored_len_reader_reads_finalized_block() -> CommonResult<()> {
+        let store = create_store_with_capacity("stored-len-reader", "16MB")?;
+        let block = ExtendedBlock::with_mem(1, "4B")?;
+        finalize_block(&store, &block)?;
+
+        let (meta, mut reader) = store.open_reader_by_id_at_stored_len(block.id, 0)?;
+        assert_eq!(meta.len(), block.len);
+        assert_eq!(read_bytes(&mut reader, block.len as i32)?, vec![0; 4]);
         Ok(())
     }
 

--- a/curvine-worker/src/worker/replication/worker_replication_manager.rs
+++ b/curvine-worker/src/worker/replication/worker_replication_manager.rs
@@ -120,7 +120,9 @@ impl WorkerReplicationManager {
             Ok(permit) => permit,
             Err(e) => return err_box!("replication semaphore closed: {}", e),
         };
-        let (block_meta, mut reader) = self.block_store.open_reader_by_id(job.block_id, 0, 0)?;
+        let (block_meta, mut reader) = self
+            .block_store
+            .open_reader_by_id_at_stored_len(job.block_id, 0)?;
         if block_meta.state != BlockState::Finalized {
             return err_box!("Block: {} is not finalized", job.block_id);
         }


### PR DESCRIPTION
# Summary

Fix block replication failures caused by opening the source block reader with a
zero logical length.

Replication now derives its read boundary from the finalized block metadata
while preserving the explicit logical-length behavior used by normal client
reads and sparse/truncated blocks.

# Issue Describe / Design

Closes #1634

## Root cause

`WorkerReplicationManager::replicate_block` opened the source block with:

```rust
open_reader_by_id(job.block_id, 0, 0)
```

The third argument is the reader's logical length. After the strict logical
boundary behavior introduced for sparse and truncated block reads, zero is a
valid zero-length boundary rather than a request to infer the physical block
length.

As a result, the first replication `read_region` call failed with:

```text
offset exceeds block length, length=0, offset=0
```

The error happened while reading the source replica, before data could be
written to the target Worker.

## Reproduction

1. Start a cluster with at least three Workers and block replication enabled.
2. Write a non-empty block with fewer replicas than the configured target.
3. Allow the Master to schedule replication.
4. The source Worker opens the block reader with logical length zero.
5. The first source read fails and the replica count does not increase.

## Fix approach

Add a dedicated `BlockStore::open_reader_by_id_at_stored_len` API for internal
block-copy operations that do not have a client-provided logical length.

The API obtains the current readable `BlockMeta`, derives the logical boundary
from `BlockMeta::len()`, resolves the generation and layout, and opens the file
descriptor while holding the same dataset read lock.

The existing explicit-length API remains unchanged. In particular, this change
does not restore a `max(logical_len, physical_len)` fallback, so sparse and
truncated reads retain their exact logical boundaries.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-worker/src/worker/block/block_store.rs` | Add a stored-metadata-length reader API and share reader creation through an internal helper | Internal block copies can infer the correct logical length; explicit client read lengths are unchanged |
| `curvine-worker/src/worker/block/block_store.rs` | Add a regression test for reading a finalized non-empty block using its stored length | Test-only |
| `curvine-worker/src/worker/block/block_store.rs` | Exercise the new API in the committed-generation reader test | Test-only |
| `curvine-worker/src/worker/replication/worker_replication_manager.rs` | Open replication source readers using the finalized block metadata length | Replication can copy non-empty blocks instead of failing with a zero-length read boundary |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-worker` | PASS | 31 passed, 0 failed, 1 ignored |
| `cargo test -p curvine-tests --test replication_test test_replication_honors_source_block_capacity -- --nocapture` | PASS | Replication completed without `length=0`; source capacity was preserved |
| `cargo test -p curvine-tests --test replication_test test_block_replication_e2e -- --nocapture` | PASS | Replica count increased from 2 to 3 and 204800 bytes passed integrity verification |
| `cargo fmt --all -- --check` | PASS | |
| `git diff --check` | PASS | |

# Dependencies

- Related PRs: None
- Related issues: #1636
- Blocks / blocked by: None