### PR TITLE
feat(mds): add generic KV abstraction and memory backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2538,10 +2538,15 @@ dependencies = [
 name = "curvine-mds"
 version = "0.2.0"
 dependencies = [
+ "async-trait",
  "curvine-config",
  "curvine-core-error",
+ "curvine-metrics",
  "curvine-runtime",
+ "fastrand 1.9.0",
  "log",
+ "once_cell",
+ "thiserror 1.0.69",
  "tokio",
 ]
 

--- a/curvine-mds/Cargo.toml
+++ b/curvine-mds/Cargo.toml
@@ -7,6 +7,11 @@ license.workspace = true
 [dependencies]
 curvine-config = { workspace = true }
 curvine-core-error = { workspace = true }
+curvine-metrics = { workspace = true }
 curvine-runtime = { workspace = true }
+async-trait = { workspace = true }
+fastrand = { workspace = true }
 log = { workspace = true }
+once_cell = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/curvine-mds/src/kv/backend.rs
+++ b/curvine-mds/src/kv/backend.rs
@@ -1,0 +1,275 @@
+//! Byte-level, business-agnostic KV abstraction.
+//!
+//! This module defines the stable boundary the stateless MDS repositories and
+//! the future FoundationDB backend both build on. It intentionally knows
+//! NOTHING about MDS domain types (`MetaKey`, `MetaValue`, mount tables, paths,
+//! ...). Keys and values are opaque byte strings; ordering is unsigned
+//! lexicographic over the raw bytes, which every intended backend (memory,
+//! FDB) preserves.
+//!
+//! ## Transaction model
+//!
+//! Transactions are the first-class primitive, not batches. A
+//! [`KvTransaction`] buffers writes (`put`/`delete`) and tracks the keys it
+//! reads (`get`/`multi_get`, plus explicit
+//! [`KvTransaction::add_read_conflict`]) in a read-conflict set. `commit`
+//! applies the buffered writes atomically only if no key in the read-conflict
+//! set was changed by a concurrent committed transaction; otherwise it returns
+//! [`KvError::Conflict`]. This optimistic-concurrency contract is what lets
+//! multiple stateless MDS processes write safely without a single owning node,
+//! and it mirrors FoundationDB's serializable-snapshot-isolation semantics so
+//! the FDB backend (PR 3) can implement the same trait with native behavior.
+//!
+//! Use [`run_txn`] to execute a transaction closure with automatic retry on
+//! retryable errors ([`KvError::is_retryable`]); it re-runs the closure from a
+//! fresh snapshot so read-modify-write and compare-and-set become correct
+//! under contention.
+
+use crate::kv::error::KvResult;
+use crate::kv::metrics;
+use async_trait::async_trait;
+use std::future::Future;
+use std::pin::Pin;
+use std::time::Duration;
+
+/// A single transaction against a [`KvBackend`].
+///
+/// Reads observe a consistent snapshot taken when the transaction began and add
+/// the accessed keys to the read-conflict set. Writes are buffered and applied
+/// atomically by [`KvTransaction::commit`]. After `commit` or
+/// [`KvTransaction::rollback`] the transaction must not be used again.
+#[async_trait]
+pub trait KvTransaction: Send {
+    /// Reads a single key, adding it to the read-conflict set.
+    async fn get(&mut self, key: &[u8]) -> KvResult<Option<Vec<u8>>>;
+
+    /// Reads many keys in one call, adding each to the read-conflict set.
+    /// The returned vector has one entry per input key, in order.
+    async fn multi_get(&mut self, keys: &[Vec<u8>]) -> KvResult<Vec<Option<Vec<u8>>>>;
+
+    /// Reads a single key from the transaction's snapshot WITHOUT adding it to
+    /// the read-conflict set (maps to FDB `snapshotGet`).
+    ///
+    /// Same snapshot as [`get`], so not a dirty read; the only difference is a
+    /// concurrent change to this key won't make the transaction conflict at
+    /// commit. Use only when the value read doesn't affect what the transaction
+    /// writes (advisory reads, wide scans); otherwise use [`get`].
+    ///
+    /// [`get`]: KvTransaction::get
+    async fn snapshot_get(&mut self, key: &[u8]) -> KvResult<Option<Vec<u8>>>;
+
+    /// Buffers a write of `value` at `key`.
+    fn put(&mut self, key: &[u8], value: &[u8]);
+
+    /// Buffers a delete of `key`.
+    fn delete(&mut self, key: &[u8]);
+
+    /// Explicitly adds `key` to the read-conflict set without reading it. Use
+    /// when a decision depends on a key's absence or when the value was read
+    /// through another channel.
+    fn add_read_conflict(&mut self, key: &[u8]);
+
+    /// Applies the buffered writes atomically. Returns [`KvError::Conflict`]
+    /// when a key in the read-conflict set was changed concurrently; the
+    /// transaction is then discarded and the caller should retry from a fresh
+    /// transaction (see [`run_txn`]).
+    async fn commit(&mut self) -> KvResult<()>;
+
+    /// Discards all buffered writes and releases the transaction.
+    fn rollback(&mut self);
+}
+
+/// A pluggable byte-level KV store.
+///
+/// Implementations provide transactions via [`KvBackend::begin`]; the
+/// non-transactional convenience methods have default implementations that run
+/// a single auto-committed transaction, so a backend only has to implement
+/// `begin` and `name` to be fully usable.
+#[async_trait]
+pub trait KvBackend: Send + Sync {
+    /// Short, stable backend identifier used as a metrics label
+    /// (e.g. `"memory"`, `"fdb"`). Must be low-cardinality.
+    fn name(&self) -> &'static str;
+
+    /// Starts a new transaction.
+    async fn begin(&self) -> KvResult<Box<dyn KvTransaction>>;
+
+    /// Point read of a single key.
+    async fn get(&self, key: &[u8]) -> KvResult<Option<Vec<u8>>> {
+        let mut txn = self.begin().await?;
+        let value = txn.get(key).await?;
+        txn.commit().await?;
+        Ok(value)
+    }
+
+    /// Point snapshot read of a single key (no read-conflict tracking).
+    ///
+    /// See [`KvTransaction::snapshot_get`]. In a standalone transaction the
+    /// conflict set is irrelevant so this matches [`get`](KvBackend::get); it
+    /// exists so callers can express intent that carries through when the read
+    /// later moves inside a larger transaction.
+    async fn snapshot_get(&self, key: &[u8]) -> KvResult<Option<Vec<u8>>> {
+        let mut txn = self.begin().await?;
+        let value = txn.snapshot_get(key).await?;
+        txn.commit().await?;
+        Ok(value)
+    }
+
+    /// Batch read of many keys in a single transaction.
+    async fn multi_get(&self, keys: &[Vec<u8>]) -> KvResult<Vec<Option<Vec<u8>>>> {
+        let mut txn = self.begin().await?;
+        let values = txn.multi_get(keys).await?;
+        txn.commit().await?;
+        Ok(values)
+    }
+
+    /// Point write of a single key.
+    async fn put(&self, key: &[u8], value: &[u8]) -> KvResult<()> {
+        let start = std::time::Instant::now();
+        let result = async {
+            let mut txn = self.begin().await?;
+            txn.put(key, value);
+            txn.commit().await
+        }
+        .await;
+        metrics::metrics().observe(self.name(), metrics::op::PUT, start, &result);
+        result
+    }
+
+    /// Point delete of a single key.
+    async fn delete(&self, key: &[u8]) -> KvResult<()> {
+        let start = std::time::Instant::now();
+        let result = async {
+            let mut txn = self.begin().await?;
+            txn.delete(key);
+            txn.commit().await
+        }
+        .await;
+        metrics::metrics().observe(self.name(), metrics::op::DELETE, start, &result);
+        result
+    }
+
+    /// Batch delete of many keys in a single transaction.
+    async fn batch_delete(&self, keys: &[Vec<u8>]) -> KvResult<()> {
+        let start = std::time::Instant::now();
+        let result = async {
+            let mut txn = self.begin().await?;
+            for key in keys {
+                txn.delete(key);
+            }
+            txn.commit().await
+        }
+        .await;
+        metrics::metrics().observe(self.name(), metrics::op::BATCH_DELETE, start, &result);
+        result
+    }
+
+    /// Atomic compare-and-set. Writes `new` at `key` only if the current value
+    /// equals `expected` (`None` means "the key must be absent"; a `new` of
+    /// `None` deletes the key). Returns `true` when the write was applied,
+    /// `false` when the precondition did not hold.
+    ///
+    /// Implemented as a retrying read-modify-write so it is correct under
+    /// contention on any conforming backend.
+    async fn compare_and_set(
+        &self,
+        key: &[u8],
+        expected: Option<&[u8]>,
+        new: Option<&[u8]>,
+    ) -> KvResult<bool> {
+        let key = key.to_vec();
+        let expected = expected.map(|v| v.to_vec());
+        let new = new.map(|v| v.to_vec());
+        let start = std::time::Instant::now();
+        let result = run_txn(self, DEFAULT_MAX_RETRIES, |txn| {
+            let key = key.clone();
+            let expected = expected.clone();
+            let new = new.clone();
+            Box::pin(async move {
+                let current = txn.get(&key).await?;
+                if current.as_deref() != expected.as_deref() {
+                    // Precondition failed; nothing to write. Add the key to the
+                    // conflict set so a concurrent change still forces a retry
+                    // rather than a stale `false`.
+                    txn.add_read_conflict(&key);
+                    return Ok(false);
+                }
+                match &new {
+                    Some(value) => txn.put(&key, value),
+                    None => txn.delete(&key),
+                }
+                Ok(true)
+            })
+        })
+        .await;
+        metrics::metrics().observe(
+            self.name(),
+            metrics::op::CAS,
+            start,
+            &result.as_ref().map(|_| ()).map_err(|e| e.clone()),
+        );
+        result
+    }
+}
+
+/// Default retry budget for [`run_txn`] and the convenience CAS helper.
+pub const DEFAULT_MAX_RETRIES: u32 = 16;
+
+/// Runs a transaction closure with automatic retry on retryable errors.
+///
+/// The closure receives a fresh, mutable transaction on each attempt and must
+/// perform all of its reads and buffered writes on it, returning the value to
+/// hand back on success. `run_txn` commits the transaction; if either the
+/// closure or the commit returns a retryable error ([`KvError::is_retryable`])
+/// it re-runs the closure on a brand-new transaction, up to `max_retries`
+/// times, with a short exponential backoff. Terminal errors propagate
+/// immediately.
+///
+/// The closure is `Fn` (not `FnMut`) because it may be invoked multiple times;
+/// keep it free of external mutable state that must not be repeated.
+pub async fn run_txn<B, F, T>(backend: &B, max_retries: u32, f: F) -> KvResult<T>
+where
+    B: KvBackend + ?Sized,
+    F: for<'a> Fn(
+        &'a mut dyn KvTransaction,
+    ) -> Pin<Box<dyn Future<Output = KvResult<T>> + Send + 'a>>,
+{
+    let mut attempt: u32 = 0;
+    loop {
+        let mut txn: Box<dyn KvTransaction> = backend.begin().await?;
+        let result = {
+            let txn_ref = txn.as_mut();
+            f(txn_ref).await
+        };
+
+        let outcome = match result {
+            Ok(value) => txn.commit().await.map(|_| value),
+            Err(error) => {
+                txn.rollback();
+                Err(error)
+            }
+        };
+
+        match outcome {
+            Ok(value) => return Ok(value),
+            Err(error) => {
+                if error.is_retryable() && attempt < max_retries {
+                    metrics::metrics().record_retry(backend.name());
+                    backoff(attempt).await;
+                    attempt += 1;
+                } else {
+                    return Err(error);
+                }
+            }
+        }
+    }
+}
+
+/// Exponential backoff capped at ~100ms. Attempt 0 does not sleep.
+async fn backoff(attempt: u32) {
+    if attempt == 0 {
+        return;
+    }
+    let millis = (1u64 << attempt.min(6)).min(100);
+    tokio::time::sleep(Duration::from_millis(millis)).await;
+}

--- a/curvine-mds/src/kv/backend.rs
+++ b/curvine-mds/src/kv/backend.rs
@@ -285,11 +285,12 @@ where
     }
 }
 
-/// Exponential backoff capped at ~100ms. Attempt 0 does not sleep.
+/// Exponential backoff capped at 100ms. Attempt 0 does not sleep.
 async fn backoff(attempt: u32) {
     if attempt == 0 {
         return;
     }
-    let millis = (1u64 << attempt.min(6)).min(100);
+    // 1<<7 = 128 lets the 100ms cap actually take effect (1<<6 = 64 never would).
+    let millis = (1u64 << attempt.min(7)).min(100);
     tokio::time::sleep(Duration::from_millis(millis)).await;
 }

--- a/curvine-mds/src/kv/backend.rs
+++ b/curvine-mds/src/kv/backend.rs
@@ -94,43 +94,55 @@ pub trait KvBackend: Send + Sync {
     /// Starts a new transaction.
     async fn begin(&self) -> KvResult<Box<dyn KvTransaction>>;
 
-    /// Point read of a single key.
+    /// Point read of a single key. Tracks the key in the read-conflict set and
+    /// is wrapped in [`run_txn`], so a concurrent change during the read is
+    /// retried; `Conflict` surfaces only if it persists past
+    /// `DEFAULT_MAX_RETRIES` (a pathological write hotspot).
+    /// Use [`snapshot_get`](KvBackend::snapshot_get) for a conflict-free read.
     async fn get(&self, key: &[u8]) -> KvResult<Option<Vec<u8>>> {
-        let mut txn = self.begin().await?;
-        let value = txn.get(key).await?;
-        txn.commit().await?;
-        Ok(value)
+        let key = key.to_vec();
+        run_txn(self, DEFAULT_MAX_RETRIES, |txn| {
+            let key = key.clone();
+            Box::pin(async move { txn.get(&key).await })
+        })
+        .await
     }
 
-    /// Point snapshot read of a single key (no read-conflict tracking).
-    ///
-    /// See [`KvTransaction::snapshot_get`]. In a standalone transaction the
-    /// conflict set is irrelevant so this matches [`get`](KvBackend::get); it
-    /// exists so callers can express intent that carries through when the read
-    /// later moves inside a larger transaction.
+    /// Point snapshot read of a single key: reads the begin snapshot WITHOUT
+    /// read-conflict tracking, then rolls back. Never conflicts and never
+    /// retries. See [`KvTransaction::snapshot_get`].
     async fn snapshot_get(&self, key: &[u8]) -> KvResult<Option<Vec<u8>>> {
         let mut txn = self.begin().await?;
-        let value = txn.snapshot_get(key).await?;
-        txn.commit().await?;
-        Ok(value)
+        let out = txn.snapshot_get(key).await;
+        txn.rollback();
+        out
     }
 
-    /// Batch read of many keys in a single transaction.
+    /// Batch read of many keys. Like [`get`](KvBackend::get), tracks the keys
+    /// and is wrapped in [`run_txn`] so concurrent changes are retried.
     async fn multi_get(&self, keys: &[Vec<u8>]) -> KvResult<Vec<Option<Vec<u8>>>> {
-        let mut txn = self.begin().await?;
-        let values = txn.multi_get(keys).await?;
-        txn.commit().await?;
-        Ok(values)
+        let keys = keys.to_vec();
+        run_txn(self, DEFAULT_MAX_RETRIES, |txn| {
+            let keys = keys.clone();
+            Box::pin(async move { txn.multi_get(&keys).await })
+        })
+        .await
     }
 
-    /// Point write of a single key.
+    /// Point write of a single key. Wrapped in [`run_txn`] so a transient
+    /// conflict is retried instead of surfaced.
     async fn put(&self, key: &[u8], value: &[u8]) -> KvResult<()> {
+        let key = key.to_vec();
+        let value = value.to_vec();
         let start = std::time::Instant::now();
-        let result = async {
-            let mut txn = self.begin().await?;
-            txn.put(key, value);
-            txn.commit().await
-        }
+        let result = run_txn(self, DEFAULT_MAX_RETRIES, |txn| {
+            let key = key.clone();
+            let value = value.clone();
+            Box::pin(async move {
+                txn.put(&key, &value);
+                Ok(())
+            })
+        })
         .await;
         metrics::metrics().observe(self.name(), metrics::op::PUT, start, &result);
         result
@@ -138,12 +150,15 @@ pub trait KvBackend: Send + Sync {
 
     /// Point delete of a single key.
     async fn delete(&self, key: &[u8]) -> KvResult<()> {
+        let key = key.to_vec();
         let start = std::time::Instant::now();
-        let result = async {
-            let mut txn = self.begin().await?;
-            txn.delete(key);
-            txn.commit().await
-        }
+        let result = run_txn(self, DEFAULT_MAX_RETRIES, |txn| {
+            let key = key.clone();
+            Box::pin(async move {
+                txn.delete(&key);
+                Ok(())
+            })
+        })
         .await;
         metrics::metrics().observe(self.name(), metrics::op::DELETE, start, &result);
         result
@@ -151,14 +166,17 @@ pub trait KvBackend: Send + Sync {
 
     /// Batch delete of many keys in a single transaction.
     async fn batch_delete(&self, keys: &[Vec<u8>]) -> KvResult<()> {
+        let keys = keys.to_vec();
         let start = std::time::Instant::now();
-        let result = async {
-            let mut txn = self.begin().await?;
-            for key in keys {
-                txn.delete(key);
-            }
-            txn.commit().await
-        }
+        let result = run_txn(self, DEFAULT_MAX_RETRIES, |txn| {
+            let keys = keys.clone();
+            Box::pin(async move {
+                for key in &keys {
+                    txn.delete(key);
+                }
+                Ok(())
+            })
+        })
         .await;
         metrics::metrics().observe(self.name(), metrics::op::BATCH_DELETE, start, &result);
         result
@@ -188,10 +206,9 @@ pub trait KvBackend: Send + Sync {
             Box::pin(async move {
                 let current = txn.get(&key).await?;
                 if current.as_deref() != expected.as_deref() {
-                    // Precondition failed; nothing to write. Add the key to the
-                    // conflict set so a concurrent change still forces a retry
-                    // rather than a stale `false`.
-                    txn.add_read_conflict(&key);
+                    // `txn.get` already added `key` to the read-conflict set,
+                    // so a concurrent change still forces a retry, not a stale
+                    // `false`.
                     return Ok(false);
                 }
                 match &new {
@@ -217,16 +234,15 @@ pub const DEFAULT_MAX_RETRIES: u32 = 16;
 
 /// Runs a transaction closure with automatic retry on retryable errors.
 ///
-/// The closure receives a fresh, mutable transaction on each attempt and must
-/// perform all of its reads and buffered writes on it, returning the value to
-/// hand back on success. `run_txn` commits the transaction; if either the
-/// closure or the commit returns a retryable error ([`KvError::is_retryable`])
-/// it re-runs the closure on a brand-new transaction, up to `max_retries`
-/// times, with a short exponential backoff. Terminal errors propagate
-/// immediately.
+/// The closure gets a fresh transaction on each attempt and returns the value
+/// to hand back on success. `run_txn` commits it; if `begin`, the closure, or
+/// the commit returns an [`KvError::is_retryable`] error it re-runs on a
+/// new transaction, up to `max_retries` times with exponential backoff.
 ///
-/// The closure is `Fn` (not `FnMut`) because it may be invoked multiple times;
-/// keep it free of external mutable state that must not be repeated.
+/// Retry excludes [`KvError::MaybeCommitted`] (the write may already have
+/// applied); it and all terminal errors propagate unchanged. The closure is
+/// `Fn` because it may run multiple times — keep it free of external mutable
+/// state that must not be repeated.
 pub async fn run_txn<B, F, T>(backend: &B, max_retries: u32, f: F) -> KvResult<T>
 where
     B: KvBackend + ?Sized,
@@ -236,18 +252,22 @@ where
 {
     let mut attempt: u32 = 0;
     loop {
-        let mut txn: Box<dyn KvTransaction> = backend.begin().await?;
-        let result = {
-            let txn_ref = txn.as_mut();
-            f(txn_ref).await
-        };
-
-        let outcome = match result {
-            Ok(value) => txn.commit().await.map(|_| value),
-            Err(error) => {
-                txn.rollback();
-                Err(error)
+        // begin() failures are folded into the same retry budget.
+        let outcome = match backend.begin().await {
+            Ok(mut txn) => {
+                let result = {
+                    let txn_ref = txn.as_mut();
+                    f(txn_ref).await
+                };
+                match result {
+                    Ok(value) => txn.commit().await.map(|_| value),
+                    Err(error) => {
+                        txn.rollback();
+                        Err(error)
+                    }
+                }
             }
+            Err(error) => Err(error),
         };
 
         match outcome {

--- a/curvine-mds/src/kv/contract_tests.rs
+++ b/curvine-mds/src/kv/contract_tests.rs
@@ -1,0 +1,332 @@
+//! Backend-agnostic KV contract tests.
+//!
+//! Every assertion here is expressed against the [`KvBackend`] trait, never a
+//! concrete type, so the FoundationDB backend (a later step) can run the exact
+//! same suite by supplying its own factory. The memory backend is wired up at
+//! the bottom of this file via [`run_contract`].
+
+use crate::kv::backend::{run_txn, KvBackend, DEFAULT_MAX_RETRIES};
+use crate::kv::error::KvError;
+use crate::kv::memory::MemoryBackend;
+use std::sync::Arc;
+
+fn b(s: &str) -> Vec<u8> {
+    s.as_bytes().to_vec()
+}
+
+// ----- point operations -----
+
+async fn point_get_put_delete(be: Arc<dyn KvBackend>) {
+    assert_eq!(be.get(&b("k")).await.unwrap(), None);
+
+    be.put(&b("k"), &b("v")).await.unwrap();
+    assert_eq!(be.get(&b("k")).await.unwrap(), Some(b("v")));
+
+    be.put(&b("k"), &b("v2")).await.unwrap();
+    assert_eq!(be.get(&b("k")).await.unwrap(), Some(b("v2")));
+
+    be.delete(&b("k")).await.unwrap();
+    assert_eq!(be.get(&b("k")).await.unwrap(), None);
+    // delete of an absent key is a no-op success.
+    be.delete(&b("k")).await.unwrap();
+}
+
+// ----- batch operations -----
+
+async fn batch_get_delete(be: Arc<dyn KvBackend>) {
+    be.put(&b("a"), &b("1")).await.unwrap();
+    be.put(&b("c"), &b("3")).await.unwrap();
+
+    let got = be.multi_get(&[b("a"), b("b"), b("c")]).await.unwrap();
+    assert_eq!(got, vec![Some(b("1")), None, Some(b("3"))]);
+
+    be.batch_delete(&[b("a"), b("c"), b("missing")])
+        .await
+        .unwrap();
+    let got = be.multi_get(&[b("a"), b("c")]).await.unwrap();
+    assert_eq!(got, vec![None, None]);
+}
+
+// ----- arbitrary byte compatibility -----
+
+async fn arbitrary_bytes_round_trip(be: Arc<dyn KvBackend>) {
+    let cases = [
+        vec![0x80],
+        vec![0xFF],
+        vec![0xC0, 0xAF],
+        vec![0xE2, 0x28, 0xA1],
+        vec![b'f', b'o', 0x80, 0xFF],
+        vec![b'a', 0x00, b'b'],
+    ];
+
+    for (index, key) in cases.into_iter().enumerate() {
+        let value = vec![0x00, 0xFF, index as u8, 0x80];
+        be.put(&key, &value).await.unwrap();
+        assert_eq!(be.get(&key).await.unwrap(), Some(value));
+    }
+}
+
+async fn distinct_invalid_utf8_keys_remain_distinct(be: Arc<dyn KvBackend>) {
+    let key_1 = vec![b'f', b'o', 0x80];
+    let key_2 = vec![b'f', b'o', 0x81];
+
+    assert_eq!(
+        String::from_utf8_lossy(&key_1),
+        String::from_utf8_lossy(&key_2)
+    );
+
+    be.put(&key_1, b"value-1").await.unwrap();
+    be.put(&key_2, b"value-2").await.unwrap();
+
+    assert_eq!(be.get(&key_1).await.unwrap(), Some(b("value-1")));
+    assert_eq!(be.get(&key_2).await.unwrap(), Some(b("value-2")));
+}
+
+async fn multilingual_utf8_round_trip(be: Arc<dyn KvBackend>) {
+    let cases = [
+        ("目录/文件.txt", "中文内容"),
+        ("日本語/ファイル", "内容"),
+        ("한국어/파일", "데이터"),
+        ("emoji/😀/🚀", "✅"),
+        ("العربية/ملف", "قيمة"),
+    ];
+
+    for (key, value) in cases {
+        be.put(key.as_bytes(), value.as_bytes()).await.unwrap();
+        assert_eq!(
+            be.get(key.as_bytes()).await.unwrap(),
+            Some(value.as_bytes().to_vec())
+        );
+    }
+}
+
+async fn unicode_normalization_is_not_implicit(be: Arc<dyn KvBackend>) {
+    let composed = "é".as_bytes().to_vec();
+    let decomposed = "e\u{301}".as_bytes().to_vec();
+
+    assert_ne!(composed, decomposed);
+    be.put(&composed, b"composed").await.unwrap();
+    be.put(&decomposed, b"decomposed").await.unwrap();
+
+    assert_eq!(be.get(&composed).await.unwrap(), Some(b("composed")));
+    assert_eq!(be.get(&decomposed).await.unwrap(), Some(b("decomposed")));
+}
+
+// ----- transactional read-modify-write -----
+
+async fn txn_read_modify_write(be: Arc<dyn KvBackend>) {
+    be.put(&b("ctr"), &b("0")).await.unwrap();
+
+    // Increment inside a single transaction closure via run_txn.
+    let key = b("ctr");
+    let new = run_txn(be.as_ref(), DEFAULT_MAX_RETRIES, move |txn| {
+        let key = key.clone();
+        Box::pin(async move {
+            let cur: i64 = txn
+                .get(&key)
+                .await?
+                .map(|v| String::from_utf8(v).unwrap().parse().unwrap())
+                .unwrap_or(0);
+            let next = cur + 1;
+            txn.put(&key, next.to_string().as_bytes());
+            Ok(next)
+        })
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(new, 1);
+    assert_eq!(be.get(&b("ctr")).await.unwrap(), Some(b("1")));
+}
+
+async fn txn_atomicity_on_abort(be: Arc<dyn KvBackend>) {
+    // A transaction that returns an application error must apply no writes.
+    let key = b("x");
+    let result: Result<(), KvError> = run_txn(be.as_ref(), DEFAULT_MAX_RETRIES, move |txn| {
+        let key = key.clone();
+        Box::pin(async move {
+            txn.put(&key, b"should-not-persist".as_ref());
+            Err(KvError::Aborted("boom".into()))
+        })
+    })
+    .await;
+
+    assert!(matches!(result, Err(KvError::Aborted(_))));
+    assert_eq!(be.get(&b("x")).await.unwrap(), None);
+}
+
+// ----- compare-and-set -----
+
+async fn compare_and_set_semantics(be: Arc<dyn KvBackend>) {
+    // CAS from absent -> value.
+    assert!(be
+        .compare_and_set(&b("cas"), None, Some(&b("v1")))
+        .await
+        .unwrap());
+    assert_eq!(be.get(&b("cas")).await.unwrap(), Some(b("v1")));
+
+    // CAS with wrong expected fails and does not write.
+    assert!(!be
+        .compare_and_set(&b("cas"), Some(&b("WRONG")), Some(&b("v2")))
+        .await
+        .unwrap());
+    assert_eq!(be.get(&b("cas")).await.unwrap(), Some(b("v1")));
+
+    // CAS with correct expected succeeds.
+    assert!(be
+        .compare_and_set(&b("cas"), Some(&b("v1")), Some(&b("v2")))
+        .await
+        .unwrap());
+    assert_eq!(be.get(&b("cas")).await.unwrap(), Some(b("v2")));
+
+    // CAS delete (new = None).
+    assert!(be
+        .compare_and_set(&b("cas"), Some(&b("v2")), None)
+        .await
+        .unwrap());
+    assert_eq!(be.get(&b("cas")).await.unwrap(), None);
+}
+
+// ----- optimistic-concurrency conflict detection -----
+
+async fn concurrent_write_conflict(be: Arc<dyn KvBackend>) {
+    be.put(&b("k"), &b("0")).await.unwrap();
+
+    // Open a transaction, read k, then let another writer bump k before commit.
+    let mut txn = be.begin().await.unwrap();
+    let _ = txn.get(&b("k")).await.unwrap();
+
+    // Concurrent committed write to the same key.
+    be.put(&b("k"), &b("1")).await.unwrap();
+
+    // Our transaction now writes and must fail with Conflict.
+    txn.put(&b("k"), &b("stale"));
+    let err = txn.commit().await.unwrap_err();
+    assert!(matches!(err, KvError::Conflict));
+    assert!(err.is_retryable());
+
+    // Store reflects only the concurrent write.
+    assert_eq!(be.get(&b("k")).await.unwrap(), Some(b("1")));
+}
+
+async fn snapshot_read_does_not_conflict(be: Arc<dyn KvBackend>) {
+    be.put(&b("s"), &b("0")).await.unwrap();
+    be.put(&b("w"), &b("init")).await.unwrap();
+
+    // A transaction snapshot-reads `s` (no conflict tracking), then a
+    // concurrent writer bumps `s` before we commit.
+    let mut txn = be.begin().await.unwrap();
+    let seen = txn.snapshot_get(&b("s")).await.unwrap();
+    assert_eq!(seen, Some(b("0")));
+
+    be.put(&b("s"), &b("1")).await.unwrap();
+
+    // We write to a DIFFERENT key and commit; because `s` was read via
+    // snapshot_get it is not in the conflict set, so the commit succeeds even
+    // though `s` changed concurrently.
+    txn.put(&b("w"), &b("done"));
+    txn.commit().await.unwrap();
+
+    assert_eq!(be.get(&b("w")).await.unwrap(), Some(b("done")));
+    assert_eq!(be.get(&b("s")).await.unwrap(), Some(b("1")));
+
+    // Contrast: the same access pattern with a plain `get` MUST conflict.
+    be.put(&b("s"), &b("0")).await.unwrap();
+    let mut txn = be.begin().await.unwrap();
+    let _ = txn.get(&b("s")).await.unwrap();
+    be.put(&b("s"), &b("2")).await.unwrap();
+    txn.put(&b("w"), &b("stale"));
+    assert!(matches!(txn.commit().await, Err(KvError::Conflict)));
+}
+
+// ----- error semantics / classification -----
+
+fn error_classification() {
+    assert!(KvError::Conflict.is_retryable());
+    assert!(KvError::MaybeCommitted.is_retryable());
+    assert!(KvError::Timeout.is_retryable());
+    assert!(!KvError::Aborted("a".into()).is_retryable());
+    assert!(!KvError::Backend("b".into()).is_retryable());
+}
+
+/// Runs the whole contract against a fresh backend produced by `factory`.
+/// PR 3 can call this with an FDB-backed factory to reuse the suite verbatim.
+async fn run_contract<F>(factory: F)
+where
+    F: Fn() -> Arc<dyn KvBackend>,
+{
+    point_get_put_delete(factory()).await;
+    batch_get_delete(factory()).await;
+    arbitrary_bytes_round_trip(factory()).await;
+    distinct_invalid_utf8_keys_remain_distinct(factory()).await;
+    multilingual_utf8_round_trip(factory()).await;
+    unicode_normalization_is_not_implicit(factory()).await;
+    txn_read_modify_write(factory()).await;
+    txn_atomicity_on_abort(factory()).await;
+    compare_and_set_semantics(factory()).await;
+    concurrent_write_conflict(factory()).await;
+    snapshot_read_does_not_conflict(factory()).await;
+    error_classification();
+}
+
+// ===== memory backend bindings =====
+
+#[tokio::test]
+async fn memory_backend_satisfies_contract() {
+    run_contract(|| Arc::new(MemoryBackend::new())).await;
+}
+
+#[tokio::test]
+async fn memory_fault_injection_forces_error_and_retry() {
+    let be = MemoryBackend::new();
+    let faults = be.faults();
+
+    // A one-shot injected conflict on commit is surfaced to the caller.
+    be.put(&b("k"), &b("v")).await.unwrap();
+    faults.fail_next(crate::kv::metrics::op::COMMIT, KvError::Conflict);
+    let mut txn = be.begin().await.unwrap();
+    txn.put(&b("k"), &b("v2"));
+    assert!(matches!(txn.commit().await, Err(KvError::Conflict)));
+
+    // run_txn transparently retries past a single injected conflict and then
+    // succeeds on the second attempt.
+    faults.reset();
+    faults.fail_next(crate::kv::metrics::op::COMMIT, KvError::Conflict);
+    let key = b("k");
+    let out = run_txn(&be, DEFAULT_MAX_RETRIES, move |txn| {
+        let key = key.clone();
+        Box::pin(async move {
+            txn.put(&key, b"final".as_ref());
+            Ok(())
+        })
+    })
+    .await;
+    assert!(out.is_ok());
+    assert_eq!(be.get(&b("k")).await.unwrap(), Some(b("final")));
+}
+
+#[tokio::test]
+async fn memory_terminal_error_is_not_retried() {
+    let be = MemoryBackend::new();
+    let faults = be.faults();
+    // Queue two terminal backend errors; run_txn must stop after the first.
+    faults.fail_next(
+        crate::kv::metrics::op::COMMIT,
+        KvError::Backend("disk".into()),
+    );
+    faults.fail_next(
+        crate::kv::metrics::op::COMMIT,
+        KvError::Backend("disk".into()),
+    );
+
+    let out: Result<(), KvError> = run_txn(&be, DEFAULT_MAX_RETRIES, move |txn| {
+        Box::pin(async move {
+            txn.put(b"k".as_ref(), b"v".as_ref());
+            Ok(())
+        })
+    })
+    .await;
+    assert!(matches!(out, Err(KvError::Backend(_))));
+    // Exactly one terminal error consumed; the second remains queued.
+    faults.fail_next(crate::kv::metrics::op::GET, KvError::Timeout);
+}

--- a/curvine-mds/src/kv/contract_tests.rs
+++ b/curvine-mds/src/kv/contract_tests.rs
@@ -239,12 +239,73 @@ async fn snapshot_read_does_not_conflict(be: Arc<dyn KvBackend>) {
     assert!(matches!(txn.commit().await, Err(KvError::Conflict)));
 }
 
+/// A concurrent delete of a read key must conflict, exactly like an overwrite
+/// (a delete is a write; the reader depended on the key's existence).
+async fn concurrent_delete_of_read_key_conflicts(be: Arc<dyn KvBackend>) {
+    be.put(&b("d"), &b("live")).await.unwrap();
+
+    // T1 reads d (adds it to the conflict set) but has not committed yet.
+    let mut txn = be.begin().await.unwrap();
+    assert_eq!(txn.get(&b("d")).await.unwrap(), Some(b("live")));
+
+    // T2 concurrently deletes d and commits.
+    be.delete(&b("d")).await.unwrap();
+
+    // T1 writes an unrelated key and must conflict: d was changed concurrently.
+    txn.put(&b("other"), &b("x"));
+    let err = txn.commit().await.unwrap_err();
+    assert!(matches!(err, KvError::Conflict));
+
+    assert_eq!(be.get(&b("d")).await.unwrap(), None);
+    assert_eq!(be.get(&b("other")).await.unwrap(), None);
+}
+
+/// Two blind writers (no reads) to the same key BOTH succeed: last-writer-wins.
+/// This matches FDB, where a conflict requires a write range to intersect
+/// another txn's *read* range; validating write sets here would make the memory
+/// backend stricter than FDB.
+async fn blind_write_write_does_not_conflict(be: Arc<dyn KvBackend>) {
+    let mut t1 = be.begin().await.unwrap();
+    let mut t2 = be.begin().await.unwrap();
+
+    t1.put(&b("k"), &b("t1"));
+    t2.put(&b("k"), &b("t2"));
+
+    // Both commits succeed (no read-write conflict); the later commit wins.
+    t1.commit().await.unwrap();
+    t2.commit().await.unwrap();
+
+    assert_eq!(be.get(&b("k")).await.unwrap(), Some(b("t2")));
+}
+
+/// Reads observe the begin snapshot: keys written by another txn after begin
+/// are invisible to `get` / `snapshot_get` in the older txn.
+async fn reads_observe_begin_snapshot(be: Arc<dyn KvBackend>) {
+    be.put(&b("v"), &b("v0")).await.unwrap();
+
+    let mut txn = be.begin().await.unwrap();
+
+    // A concurrent writer changes v and creates a new key AFTER begin.
+    be.put(&b("v"), &b("v1")).await.unwrap();
+    be.put(&b("absent_key"), &b("now_here")).await.unwrap();
+
+    // T1 still sees the begin-time snapshot.
+    assert_eq!(txn.snapshot_get(&b("v")).await.unwrap(), Some(b("v0")));
+    assert_eq!(txn.snapshot_get(&b("absent_key")).await.unwrap(), None);
+
+    // Snapshot reads carry no conflict, so an unrelated write commits fine.
+    txn.put(&b("unrelated"), &b("ok"));
+    txn.commit().await.unwrap();
+    assert_eq!(be.get(&b("unrelated")).await.unwrap(), Some(b("ok")));
+}
+
 // ----- error semantics / classification -----
 
 fn error_classification() {
     assert!(KvError::Conflict.is_retryable());
-    assert!(KvError::MaybeCommitted.is_retryable());
     assert!(KvError::Timeout.is_retryable());
+    // MaybeCommitted is NOT retryable: the write may already have applied.
+    assert!(!KvError::MaybeCommitted.is_retryable());
     assert!(!KvError::Aborted("a".into()).is_retryable());
     assert!(!KvError::Backend("b".into()).is_retryable());
 }
@@ -266,6 +327,9 @@ where
     compare_and_set_semantics(factory()).await;
     concurrent_write_conflict(factory()).await;
     snapshot_read_does_not_conflict(factory()).await;
+    concurrent_delete_of_read_key_conflicts(factory()).await;
+    blind_write_write_does_not_conflict(factory()).await;
+    reads_observe_begin_snapshot(factory()).await;
     error_classification();
 }
 
@@ -327,6 +391,81 @@ async fn memory_terminal_error_is_not_retried() {
     })
     .await;
     assert!(matches!(out, Err(KvError::Backend(_))));
-    // Exactly one terminal error consumed; the second remains queued.
-    faults.fail_next(crate::kv::metrics::op::GET, KvError::Timeout);
+
+    // The second terminal error is still queued, so a second run_txn also
+    // fails immediately — proving run_txn consumed exactly one, not retried.
+    let out2: Result<(), KvError> = run_txn(&be, DEFAULT_MAX_RETRIES, move |txn| {
+        Box::pin(async move {
+            txn.put(b"k".as_ref(), b"v".as_ref());
+            Ok(())
+        })
+    })
+    .await;
+    assert!(matches!(out2, Err(KvError::Backend(_))));
+
+    // Both drained; the next commit succeeds.
+    be.put(&b("k"), &b("v")).await.unwrap();
+    assert_eq!(be.get(&b("k")).await.unwrap(), Some(b("v")));
+}
+
+#[tokio::test]
+async fn memory_maybe_committed_is_not_auto_retried() {
+    // MaybeCommitted must propagate, not be silently retried (the write may
+    // already have applied).
+    let be = MemoryBackend::new();
+    let faults = be.faults();
+    faults.fail_next(crate::kv::metrics::op::COMMIT, KvError::MaybeCommitted);
+
+    let out: Result<(), KvError> = run_txn(&be, DEFAULT_MAX_RETRIES, move |txn| {
+        Box::pin(async move {
+            txn.put(b"k".as_ref(), b"v".as_ref());
+            Ok(())
+        })
+    })
+    .await;
+    assert!(matches!(out, Err(KvError::MaybeCommitted)));
+}
+
+#[tokio::test]
+async fn memory_apply_then_unknown_does_not_double_increment() {
+    // FDB commit_unknown_result where the write landed: a run_txn increment
+    // must not be retried, or the counter advances twice.
+    let be = MemoryBackend::new();
+    let faults = be.faults();
+    be.put(&b("ctr"), &b("0")).await.unwrap();
+    faults.apply_then_unknown_next(1);
+
+    let key = b("ctr");
+    let out: Result<i64, KvError> = run_txn(&be, DEFAULT_MAX_RETRIES, move |txn| {
+        let key = key.clone();
+        Box::pin(async move {
+            let cur: i64 = txn
+                .get(&key)
+                .await?
+                .map(|v| String::from_utf8(v).unwrap().parse().unwrap())
+                .unwrap_or(0);
+            txn.put(&key, (cur + 1).to_string().as_bytes());
+            Ok(cur + 1)
+        })
+    })
+    .await;
+
+    // Unknown result surfaced, write applied exactly once (ctr == 1, not 2).
+    assert!(matches!(out, Err(KvError::MaybeCommitted)));
+    assert_eq!(be.get(&b("ctr")).await.unwrap(), Some(b("1")));
+}
+
+#[tokio::test]
+async fn memory_apply_then_unknown_does_not_flip_successful_cas() {
+    // A create-if-absent CAS whose commit lands but returns MaybeCommitted must
+    // surface the unknown result, not be retried into a false `Ok(false)`.
+    let be = MemoryBackend::new();
+    let faults = be.faults();
+    faults.apply_then_unknown_next(1);
+
+    let out = be.compare_and_set(&b("cas"), None, Some(&b("v1"))).await;
+
+    // Unknown result surfaced, value written exactly once.
+    assert!(matches!(out, Err(KvError::MaybeCommitted)));
+    assert_eq!(be.get(&b("cas")).await.unwrap(), Some(b("v1")));
 }

--- a/curvine-mds/src/kv/error.rs
+++ b/curvine-mds/src/kv/error.rs
@@ -1,0 +1,116 @@
+//! Error type for the generic KV abstraction.
+//!
+//! The single most important property of this type is the distinction between
+//! *retryable* and *terminal* failures. Stateless multi-writer correctness on a
+//! transactional backend (FoundationDB) depends on the caller being able to
+//! tell an optimistic-concurrency conflict (safe to retry the whole
+//! transaction) apart from a truly failed operation. `Conflict`,
+//! `MaybeCommitted`, `Timeout` and `Unavailable` must therefore never be
+//! collapsed into an opaque backend string; `run_txn` inspects
+//! [`KvError::is_retryable`] to decide whether to re-run the transaction
+//! closure.
+
+use thiserror::Error;
+
+/// Errors returned by any [`crate::kv::KvBackend`] / [`crate::kv::KvTransaction`]
+/// implementation. Backends map their native failures onto these variants and
+/// never leak SDK-specific types to callers.
+#[derive(Debug, Clone, Error)]
+pub enum KvError {
+    /// Optimistic-concurrency conflict: the transaction's read/write set
+    /// clashed with a concurrent commit. The commit did NOT apply. Safe to
+    /// retry the whole transaction closure (maps to FDB `not_committed`).
+    #[error("transaction conflict, retry the transaction")]
+    Conflict,
+
+    /// The commit result is unknown: the mutation may or may not have been
+    /// applied (maps to FDB `commit_unknown_result`). Only safe to retry when
+    /// the transaction body is idempotent; `run_txn` retries it because the
+    /// closure is re-run from a fresh read snapshot.
+    #[error("commit result unknown, transaction may or may not have applied")]
+    MaybeCommitted,
+
+    /// The operation exceeded its deadline. Retryable.
+    #[error("operation timed out")]
+    Timeout,
+
+    /// The backend is temporarily unavailable (e.g. FDB cluster not reachable).
+    /// Retryable with backoff.
+    #[error("backend temporarily unavailable: {0}")]
+    Unavailable(String),
+
+    /// The transaction was explicitly aborted by the caller (e.g. the
+    /// transaction closure returned an application error). Terminal.
+    #[error("transaction aborted: {0}")]
+    Aborted(String),
+
+    /// A terminal backend error that must NOT be retried.
+    ///
+    /// Not a catch-all for "any backend error": the retryable conditions
+    /// (conflict, unknown commit, timeout, transient unavailability) have their
+    /// own variants above. `Backend` is only the remaining failures re-running
+    /// can't fix (corrupted value, encoding violation, permanent I/O error).
+    #[error("kv backend error: {0}")]
+    Backend(String),
+}
+
+impl KvError {
+    /// Returns `true` when re-running the transaction closure may succeed.
+    ///
+    /// This is the contract `run_txn` relies on. Terminal variants
+    /// (`Aborted`, `Backend`) return `false` so a genuine application or
+    /// storage error propagates immediately instead of spinning in a retry
+    /// loop.
+    pub fn is_retryable(&self) -> bool {
+        matches!(
+            self,
+            KvError::Conflict
+                | KvError::MaybeCommitted
+                | KvError::Timeout
+                | KvError::Unavailable(_)
+        )
+    }
+
+    /// Short, cardinality-bounded label used for metrics. Never contains keys,
+    /// values or request identifiers so it is safe as a Prometheus label.
+    pub fn kind(&self) -> &'static str {
+        match self {
+            KvError::Conflict => "conflict",
+            KvError::MaybeCommitted => "maybe_committed",
+            KvError::Timeout => "timeout",
+            KvError::Unavailable(_) => "unavailable",
+            KvError::Aborted(_) => "aborted",
+            KvError::Backend(_) => "backend",
+        }
+    }
+}
+
+/// Convenience result alias for KV operations.
+pub type KvResult<T> = Result<T, KvError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retryable_classification() {
+        assert!(KvError::Conflict.is_retryable());
+        assert!(KvError::MaybeCommitted.is_retryable());
+        assert!(KvError::Timeout.is_retryable());
+        assert!(KvError::Unavailable("down".into()).is_retryable());
+
+        assert!(!KvError::Aborted("app".into()).is_retryable());
+        assert!(!KvError::Backend("boom".into()).is_retryable());
+    }
+
+    #[test]
+    fn kind_labels_are_bounded() {
+        // Two errors of the same variant produce the same label regardless of
+        // their payload, keeping metric cardinality bounded.
+        assert_eq!(
+            KvError::Unavailable("a".into()).kind(),
+            KvError::Unavailable("b".into()).kind()
+        );
+        assert_eq!(KvError::Backend("x".into()).kind(), "backend");
+    }
+}

--- a/curvine-mds/src/kv/error.rs
+++ b/curvine-mds/src/kv/error.rs
@@ -24,9 +24,8 @@ pub enum KvError {
     Conflict,
 
     /// The commit result is unknown: the mutation may or may not have been
-    /// applied (maps to FDB `commit_unknown_result`). Only safe to retry when
-    /// the transaction body is idempotent; `run_txn` retries it because the
-    /// closure is re-run from a fresh read snapshot.
+    /// applied (maps to FDB `commit_unknown_result`). NOT retryable —
+    /// `run_txn` surfaces it to the caller, who owns the idempotency decision.
     #[error("commit result unknown, transaction may or may not have applied")]
     MaybeCommitted,
 
@@ -55,19 +54,15 @@ pub enum KvError {
 }
 
 impl KvError {
-    /// Returns `true` when re-running the transaction closure may succeed.
-    ///
-    /// This is the contract `run_txn` relies on. Terminal variants
-    /// (`Aborted`, `Backend`) return `false` so a genuine application or
-    /// storage error propagates immediately instead of spinning in a retry
-    /// loop.
+    /// Classifies whether `run_txn` may transparently re-run the closure.
+    /// Excludes `MaybeCommitted`: the mutation may already have applied, so
+    /// retrying a non-idempotent body would double-apply or flip a successful
+    /// CAS to `false`. Only commits that provably did not apply (`Conflict`) or
+    /// never decided (`Timeout`, `Unavailable`) are retryable.
     pub fn is_retryable(&self) -> bool {
         matches!(
             self,
-            KvError::Conflict
-                | KvError::MaybeCommitted
-                | KvError::Timeout
-                | KvError::Unavailable(_)
+            KvError::Conflict | KvError::Timeout | KvError::Unavailable(_)
         )
     }
 
@@ -94,11 +89,13 @@ mod tests {
 
     #[test]
     fn retryable_classification() {
+        // Auto-retryable: the commit provably did not apply or never decided.
         assert!(KvError::Conflict.is_retryable());
-        assert!(KvError::MaybeCommitted.is_retryable());
         assert!(KvError::Timeout.is_retryable());
         assert!(KvError::Unavailable("down".into()).is_retryable());
 
+        // Not retryable: the write may already have applied, or is terminal.
+        assert!(!KvError::MaybeCommitted.is_retryable());
         assert!(!KvError::Aborted("app".into()).is_retryable());
         assert!(!KvError::Backend("boom".into()).is_retryable());
     }

--- a/curvine-mds/src/kv/memory.rs
+++ b/curvine-mds/src/kv/memory.rs
@@ -38,13 +38,18 @@ const BACKEND_NAME: &str = "memory";
 
 #[derive(Clone)]
 struct Entry {
-    value: Vec<u8>,
+    /// `Some` = live value, `None` = tombstone. Deletes keep a version-bumped
+    /// tombstone (never remove the key) so a concurrent delete of a read key
+    /// is detected as a conflict, matching FDB.
+    value: Option<Vec<u8>>,
     version: u64,
 }
 
 #[derive(Default)]
 struct Store {
-    data: BTreeMap<Vec<u8>, Entry>,
+    /// Behind an `Arc` so `begin` captures a cheap immutable read snapshot;
+    /// `commit` copy-on-writes via `Arc::make_mut`.
+    data: Arc<BTreeMap<Vec<u8>, Entry>>,
     /// Global version clock; the seq of the most recent commit.
     seq: u64,
 }
@@ -66,6 +71,9 @@ struct FaultState {
     queued: HashMap<&'static str, VecDeque<KvError>>,
     /// Probability in `[0.0, 1.0]` that any given commit returns a conflict.
     commit_conflict_prob: f64,
+    /// Number of upcoming commits that must APPLY and THEN return
+    /// [`KvError::MaybeCommitted`] (FDB `commit_unknown_result`).
+    commit_apply_then_unknown: u32,
 }
 
 impl FaultInjector {
@@ -92,11 +100,20 @@ impl FaultInjector {
         self.inner.lock().unwrap().commit_conflict_prob = prob.clamp(0.0, 1.0);
     }
 
+    /// Arms the next `count` commits to APPLY their writes and then return
+    /// [`KvError::MaybeCommitted`] (FDB `commit_unknown_result`). Unlike
+    /// `fail_next(COMMIT, MaybeCommitted)`, which fails before applying, this
+    /// exercises the "write landed but result unknown" path.
+    pub fn apply_then_unknown_next(&self, count: u32) {
+        self.inner.lock().unwrap().commit_apply_then_unknown = count;
+    }
+
     /// Clears all queued faults and resets the conflict probability.
     pub fn reset(&self) {
         let mut state = self.inner.lock().unwrap();
         state.queued.clear();
         state.commit_conflict_prob = 0.0;
+        state.commit_apply_then_unknown = 0;
     }
 
     fn take(&self, op: &'static str) -> Option<KvError> {
@@ -107,6 +124,17 @@ impl FaultInjector {
     fn maybe_commit_conflict(&self) -> bool {
         let prob = self.inner.lock().unwrap().commit_conflict_prob;
         prob > 0.0 && fastrand::f64() < prob
+    }
+
+    /// Consumes one armed apply-then-unknown token.
+    fn take_apply_then_unknown(&self) -> bool {
+        let mut state = self.inner.lock().unwrap();
+        if state.commit_apply_then_unknown > 0 {
+            state.commit_apply_then_unknown -= 1;
+            true
+        } else {
+            false
+        }
     }
 }
 
@@ -146,9 +174,15 @@ impl MemoryBackend {
         self.faults.clone()
     }
 
-    /// Number of keys currently stored (test/debug helper).
+    /// Number of live keys (test/debug helper); tombstones are not counted.
     pub fn len(&self) -> usize {
-        self.store.lock().unwrap().data.len()
+        self.store
+            .lock()
+            .unwrap()
+            .data
+            .values()
+            .filter(|e| e.value.is_some())
+            .count()
     }
 
     /// Returns `true` when the store is empty.
@@ -174,13 +208,17 @@ impl KvBackend for MemoryBackend {
             );
             return Err(error);
         }
-        let read_version = self.store.lock().unwrap().seq;
+        let (read_version, snapshot) = {
+            let store = self.store.lock().unwrap();
+            (store.seq, store.data.clone())
+        };
         metrics::metrics().observe(BACKEND_NAME, metrics::op::BEGIN, start, &Ok(()));
         metrics::metrics().txn_in_flight.inc();
         Ok(Box::new(MemTxn {
             store: self.store.clone(),
             faults: self.faults.clone(),
             read_version,
+            snapshot,
             reads: HashMap::new(),
             writes: BTreeMap::new(),
             finished: false,
@@ -196,6 +234,9 @@ struct MemTxn {
     faults: FaultInjector,
     /// Snapshot version captured at begin.
     read_version: u64,
+    /// Immutable committed-store snapshot captured at begin; all reads observe
+    /// this, so concurrent writes after begin are invisible (snapshot isolation).
+    snapshot: Arc<BTreeMap<Vec<u8>, Entry>>,
     /// Keys read (point) whose version must not have advanced by commit.
     reads: HashMap<Vec<u8>, ()>,
     /// Buffered writes applied atomically at commit.
@@ -204,18 +245,13 @@ struct MemTxn {
 }
 
 impl MemTxn {
-    /// Reads a key honoring the transaction's own buffered writes first, then
-    /// the committed snapshot.
+    /// Reads buffered writes first, then the begin-time snapshot. A tombstone
+    /// reads back as absent.
     fn read_key(&self, key: &[u8]) -> Option<Vec<u8>> {
         if let Some(pending) = self.writes.get(key) {
             return pending.clone();
         }
-        self.store
-            .lock()
-            .unwrap()
-            .data
-            .get(key)
-            .map(|e| e.value.clone())
+        self.snapshot.get(key).and_then(|e| e.value.clone())
     }
 }
 
@@ -310,7 +346,9 @@ impl KvTransaction for MemTxn {
 
         let mut store = self.store.lock().unwrap();
 
-        // Conflict check: any read key advanced past our snapshot?
+        // Conflict check: any read key advanced past our snapshot? Tombstones
+        // keep a bumped version, so a concurrent delete is caught like an
+        // overwrite.
         for key in self.reads.keys() {
             if let Some(entry) = store.data.get(key) {
                 if entry.version > self.read_version {
@@ -326,23 +364,38 @@ impl KvTransaction for MemTxn {
                 }
             }
         }
-        // No conflict: bump the version clock and apply the write set atomically.
+        // No conflict: bump the version clock and apply the write set. Deletes
+        // write a tombstone rather than removing the key.
         if !self.writes.is_empty() {
             store.seq += 1;
             let version = store.seq;
             let writes = std::mem::take(&mut self.writes);
+            let data = Arc::make_mut(&mut store.data);
             for (key, pending) in writes {
-                match pending {
-                    Some(value) => {
-                        store.data.insert(key, Entry { value, version });
-                    }
-                    None => {
-                        store.data.remove(&key);
-                    }
-                }
+                data.insert(
+                    key,
+                    Entry {
+                        value: pending,
+                        version,
+                    },
+                );
             }
         }
         drop(store);
+
+        // Apply-then-unknown fault: writes have landed, but report
+        // MaybeCommitted (FDB commit_unknown_result). run_txn must NOT retry.
+        if self.faults.take_apply_then_unknown() {
+            let error = KvError::MaybeCommitted;
+            metrics::metrics().observe(
+                BACKEND_NAME,
+                metrics::op::COMMIT,
+                start,
+                &Err(error.clone()),
+            );
+            return Err(error);
+        }
+
         metrics::metrics().observe(BACKEND_NAME, metrics::op::COMMIT, start, &Ok(()));
         Ok(())
     }

--- a/curvine-mds/src/kv/memory.rs
+++ b/curvine-mds/src/kv/memory.rs
@@ -1,0 +1,368 @@
+//! In-memory [`KvBackend`] implementation.
+//!
+//! This backend is for unit tests and MiniCluster runs that must not depend on
+//! an external service. It implements the same optimistic-concurrency contract
+//! as the future FoundationDB backend so the shared contract tests exercise
+//! identical semantics on both.
+//!
+//! This is not a complete MVCC implementation and is not intended as a
+//! production storage backend. It exists primarily for unit tests, transaction
+//! semantics validation, MiniCluster runs, and behavioral/performance
+//! comparison with the FoundationDB backend.
+//!
+//! ## Concurrency model
+//!
+//! A single global monotonically increasing `seq` acts as the version clock.
+//! Every committed key carries the `seq` of the commit that last wrote it. A
+//! transaction captures the current `seq` at `begin` as its snapshot version
+//! and records every key it reads. At `commit`, if any read key has a version
+//! greater than the snapshot version, a concurrent transaction touched it and
+//! the commit returns [`KvError::Conflict`]. This is what makes CAS and
+//! `run_txn` correct under contention.
+//!
+//! ## Fault injection
+//!
+//! A [`FaultInjector`] can be attached to force deterministic one-shot errors
+//! on specific operations, or a probabilistic commit conflict, so tests can
+//! cover the retryable/terminal error paths without racing real threads.
+
+use crate::kv::backend::{KvBackend, KvTransaction};
+use crate::kv::error::{KvError, KvResult};
+use crate::kv::metrics;
+use async_trait::async_trait;
+use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+const BACKEND_NAME: &str = "memory";
+
+#[derive(Clone)]
+struct Entry {
+    value: Vec<u8>,
+    version: u64,
+}
+
+#[derive(Default)]
+struct Store {
+    data: BTreeMap<Vec<u8>, Entry>,
+    /// Global version clock; the seq of the most recent commit.
+    seq: u64,
+}
+
+/// Deterministic fault injection for the memory backend.
+///
+/// Faults are opt-in and shared (cloneable handle). Use [`FaultInjector::fail_next`]
+/// to queue a one-shot error for a named operation (see [`crate::kv::metrics::op`]),
+/// or [`FaultInjector::set_commit_conflict_prob`] to make a fraction of commits
+/// return [`KvError::Conflict`].
+#[derive(Clone, Default)]
+pub struct FaultInjector {
+    inner: Arc<Mutex<FaultState>>,
+}
+
+#[derive(Default)]
+struct FaultState {
+    /// Per-op FIFO queue of one-shot errors.
+    queued: HashMap<&'static str, VecDeque<KvError>>,
+    /// Probability in `[0.0, 1.0]` that any given commit returns a conflict.
+    commit_conflict_prob: f64,
+}
+
+impl FaultInjector {
+    /// Creates an injector with no active faults.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Queues a single error to be returned the next time operation `op`
+    /// executes. Multiple queued errors for the same op fire in FIFO order.
+    pub fn fail_next(&self, op: &'static str, error: KvError) {
+        self.inner
+            .lock()
+            .unwrap()
+            .queued
+            .entry(op)
+            .or_default()
+            .push_back(error);
+    }
+
+    /// Sets the probability (`0.0..=1.0`) that a commit returns
+    /// [`KvError::Conflict`]. Useful for stress-testing retry logic.
+    pub fn set_commit_conflict_prob(&self, prob: f64) {
+        self.inner.lock().unwrap().commit_conflict_prob = prob.clamp(0.0, 1.0);
+    }
+
+    /// Clears all queued faults and resets the conflict probability.
+    pub fn reset(&self) {
+        let mut state = self.inner.lock().unwrap();
+        state.queued.clear();
+        state.commit_conflict_prob = 0.0;
+    }
+
+    fn take(&self, op: &'static str) -> Option<KvError> {
+        let mut state = self.inner.lock().unwrap();
+        state.queued.get_mut(op).and_then(|q| q.pop_front())
+    }
+
+    fn maybe_commit_conflict(&self) -> bool {
+        let prob = self.inner.lock().unwrap().commit_conflict_prob;
+        prob > 0.0 && fastrand::f64() < prob
+    }
+}
+
+/// In-memory KV backend. Cheap to `clone`; all clones share the same store.
+#[derive(Clone)]
+pub struct MemoryBackend {
+    store: Arc<Mutex<Store>>,
+    faults: FaultInjector,
+}
+
+impl Default for MemoryBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MemoryBackend {
+    /// Creates an empty backend with no fault injection.
+    pub fn new() -> Self {
+        Self {
+            store: Arc::new(Mutex::new(Store::default())),
+            faults: FaultInjector::new(),
+        }
+    }
+
+    /// Creates a backend that shares the given [`FaultInjector`], so a test can
+    /// hold the handle and arm faults after construction.
+    pub fn with_faults(faults: FaultInjector) -> Self {
+        Self {
+            store: Arc::new(Mutex::new(Store::default())),
+            faults,
+        }
+    }
+
+    /// Returns a handle to this backend's fault injector.
+    pub fn faults(&self) -> FaultInjector {
+        self.faults.clone()
+    }
+
+    /// Number of keys currently stored (test/debug helper).
+    pub fn len(&self) -> usize {
+        self.store.lock().unwrap().data.len()
+    }
+
+    /// Returns `true` when the store is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+#[async_trait]
+impl KvBackend for MemoryBackend {
+    fn name(&self) -> &'static str {
+        BACKEND_NAME
+    }
+
+    async fn begin(&self) -> KvResult<Box<dyn KvTransaction>> {
+        let start = Instant::now();
+        if let Some(error) = self.faults.take(metrics::op::BEGIN) {
+            metrics::metrics().observe(
+                BACKEND_NAME,
+                metrics::op::BEGIN,
+                start,
+                &Err(error.clone()),
+            );
+            return Err(error);
+        }
+        let read_version = self.store.lock().unwrap().seq;
+        metrics::metrics().observe(BACKEND_NAME, metrics::op::BEGIN, start, &Ok(()));
+        metrics::metrics().txn_in_flight.inc();
+        Ok(Box::new(MemTxn {
+            store: self.store.clone(),
+            faults: self.faults.clone(),
+            read_version,
+            reads: HashMap::new(),
+            writes: BTreeMap::new(),
+            finished: false,
+        }))
+    }
+}
+
+/// Buffered write: `Some(value)` = put, `None` = delete.
+type PendingWrite = Option<Vec<u8>>;
+
+struct MemTxn {
+    store: Arc<Mutex<Store>>,
+    faults: FaultInjector,
+    /// Snapshot version captured at begin.
+    read_version: u64,
+    /// Keys read (point) whose version must not have advanced by commit.
+    reads: HashMap<Vec<u8>, ()>,
+    /// Buffered writes applied atomically at commit.
+    writes: BTreeMap<Vec<u8>, PendingWrite>,
+    finished: bool,
+}
+
+impl MemTxn {
+    /// Reads a key honoring the transaction's own buffered writes first, then
+    /// the committed snapshot.
+    fn read_key(&self, key: &[u8]) -> Option<Vec<u8>> {
+        if let Some(pending) = self.writes.get(key) {
+            return pending.clone();
+        }
+        self.store
+            .lock()
+            .unwrap()
+            .data
+            .get(key)
+            .map(|e| e.value.clone())
+    }
+}
+
+#[async_trait]
+impl KvTransaction for MemTxn {
+    async fn get(&mut self, key: &[u8]) -> KvResult<Option<Vec<u8>>> {
+        let start = Instant::now();
+        if let Some(error) = self.faults.take(metrics::op::GET) {
+            metrics::metrics().observe(BACKEND_NAME, metrics::op::GET, start, &Err(error.clone()));
+            return Err(error);
+        }
+        self.reads.insert(key.to_vec(), ());
+        let value = self.read_key(key);
+        metrics::metrics().observe(BACKEND_NAME, metrics::op::GET, start, &Ok(()));
+        Ok(value)
+    }
+
+    async fn snapshot_get(&mut self, key: &[u8]) -> KvResult<Option<Vec<u8>>> {
+        let start = Instant::now();
+        if let Some(error) = self.faults.take(metrics::op::SNAPSHOT_GET) {
+            metrics::metrics().observe(
+                BACKEND_NAME,
+                metrics::op::SNAPSHOT_GET,
+                start,
+                &Err(error.clone()),
+            );
+            return Err(error);
+        }
+        // Snapshot read: same snapshot as `get` but deliberately NOT recorded
+        // in `self.reads`, so a concurrent change to this key won't conflict.
+        let value = self.read_key(key);
+        metrics::metrics().observe(BACKEND_NAME, metrics::op::SNAPSHOT_GET, start, &Ok(()));
+        Ok(value)
+    }
+
+    async fn multi_get(&mut self, keys: &[Vec<u8>]) -> KvResult<Vec<Option<Vec<u8>>>> {
+        let start = Instant::now();
+        if let Some(error) = self.faults.take(metrics::op::MULTI_GET) {
+            metrics::metrics().observe(
+                BACKEND_NAME,
+                metrics::op::MULTI_GET,
+                start,
+                &Err(error.clone()),
+            );
+            return Err(error);
+        }
+        let mut out = Vec::with_capacity(keys.len());
+        for key in keys {
+            self.reads.insert(key.clone(), ());
+            out.push(self.read_key(key));
+        }
+        metrics::metrics().observe(BACKEND_NAME, metrics::op::MULTI_GET, start, &Ok(()));
+        Ok(out)
+    }
+
+    fn put(&mut self, key: &[u8], value: &[u8]) {
+        self.writes.insert(key.to_vec(), Some(value.to_vec()));
+    }
+
+    fn delete(&mut self, key: &[u8]) {
+        self.writes.insert(key.to_vec(), None);
+    }
+
+    fn add_read_conflict(&mut self, key: &[u8]) {
+        self.reads.insert(key.to_vec(), ());
+    }
+
+    async fn commit(&mut self) -> KvResult<()> {
+        let start = Instant::now();
+        self.finished = true;
+        metrics::metrics().txn_in_flight.dec();
+
+        if let Some(error) = self.faults.take(metrics::op::COMMIT) {
+            metrics::metrics().observe(
+                BACKEND_NAME,
+                metrics::op::COMMIT,
+                start,
+                &Err(error.clone()),
+            );
+            return Err(error);
+        }
+        if self.faults.maybe_commit_conflict() {
+            let error = KvError::Conflict;
+            metrics::metrics().observe(
+                BACKEND_NAME,
+                metrics::op::COMMIT,
+                start,
+                &Err(error.clone()),
+            );
+            return Err(error);
+        }
+
+        let mut store = self.store.lock().unwrap();
+
+        // Conflict check: any read key advanced past our snapshot?
+        for key in self.reads.keys() {
+            if let Some(entry) = store.data.get(key) {
+                if entry.version > self.read_version {
+                    drop(store);
+                    let error = KvError::Conflict;
+                    metrics::metrics().observe(
+                        BACKEND_NAME,
+                        metrics::op::COMMIT,
+                        start,
+                        &Err(error.clone()),
+                    );
+                    return Err(error);
+                }
+            }
+        }
+        // No conflict: bump the version clock and apply the write set atomically.
+        if !self.writes.is_empty() {
+            store.seq += 1;
+            let version = store.seq;
+            let writes = std::mem::take(&mut self.writes);
+            for (key, pending) in writes {
+                match pending {
+                    Some(value) => {
+                        store.data.insert(key, Entry { value, version });
+                    }
+                    None => {
+                        store.data.remove(&key);
+                    }
+                }
+            }
+        }
+        drop(store);
+        metrics::metrics().observe(BACKEND_NAME, metrics::op::COMMIT, start, &Ok(()));
+        Ok(())
+    }
+
+    fn rollback(&mut self) {
+        if !self.finished {
+            self.finished = true;
+            metrics::metrics().txn_in_flight.dec();
+        }
+        self.writes.clear();
+        self.reads.clear();
+    }
+}
+
+impl Drop for MemTxn {
+    fn drop(&mut self) {
+        // A transaction dropped without commit/rollback still releases its
+        // in-flight slot so the gauge stays accurate.
+        if !self.finished {
+            metrics::metrics().txn_in_flight.dec();
+        }
+    }
+}

--- a/curvine-mds/src/kv/metrics.rs
+++ b/curvine-mds/src/kv/metrics.rs
@@ -1,0 +1,153 @@
+//! Observability for the KV layer.
+//!
+//! Metrics follow the project convention (see `MasterMetrics`,
+//! `curvine-client-core`): request counts, success/failure split, error kind,
+//! latency histograms and in-flight concurrency. Labels are strictly
+//! low-cardinality: `backend` (memory/fdb), `op` (get/put/...) and `kind`
+//! (a bounded [`crate::kv::KvError::kind`] value). Keys, values and request
+//! identifiers are NEVER used as labels.
+
+use crate::kv::error::KvError;
+use curvine_core_error::CommonResult;
+use curvine_metrics::{CounterVec, Gauge, HistogramVec, Metrics};
+use once_cell::sync::Lazy;
+use std::time::Instant;
+
+/// Operation label values. Kept as constants so call sites cannot introduce
+/// unbounded label cardinality by typo.
+pub mod op {
+    pub const GET: &str = "get";
+    pub const MULTI_GET: &str = "multi_get";
+    pub const SNAPSHOT_GET: &str = "snapshot_get";
+    pub const PUT: &str = "put";
+    pub const DELETE: &str = "delete";
+    pub const BATCH_DELETE: &str = "batch_delete";
+    pub const CAS: &str = "compare_and_set";
+    pub const BEGIN: &str = "begin";
+    pub const COMMIT: &str = "commit";
+}
+
+/// Latency buckets in microseconds, from sub-millisecond point reads to
+/// multi-hundred-millisecond contended commits.
+const LATENCY_BUCKETS_US: &[f64] = &[
+    50.0, 100.0, 250.0, 500.0, 1_000.0, 2_500.0, 5_000.0, 10_000.0, 25_000.0, 50_000.0, 100_000.0,
+    250_000.0,
+];
+
+/// Process-wide KV metric handles. Registered once on first access.
+pub struct KvMetrics {
+    /// Total operations attempted, by backend + op.
+    pub ops_total: CounterVec,
+    /// Operations that returned `Ok`, by backend + op.
+    pub ops_ok_total: CounterVec,
+    /// Operations that returned `Err`, by backend + op + error kind.
+    pub ops_err_total: CounterVec,
+    /// Operation latency (microseconds), by backend + op.
+    pub op_latency_us: HistogramVec,
+    /// Transaction commit conflicts, by backend.
+    pub txn_conflicts_total: CounterVec,
+    /// Transaction retries performed by `run_txn`, by backend.
+    pub txn_retries_total: CounterVec,
+    /// Currently in-flight transactions.
+    pub txn_in_flight: Gauge,
+}
+
+impl KvMetrics {
+    fn register() -> CommonResult<Self> {
+        Ok(Self {
+            ops_total: Metrics::new_counter_vec(
+                "mds_kv_ops_total",
+                "Total KV operations attempted",
+                &["backend", "op"],
+            )?,
+            ops_ok_total: Metrics::new_counter_vec(
+                "mds_kv_ops_ok_total",
+                "KV operations that succeeded",
+                &["backend", "op"],
+            )?,
+            ops_err_total: Metrics::new_counter_vec(
+                "mds_kv_ops_err_total",
+                "KV operations that failed",
+                &["backend", "op", "kind"],
+            )?,
+            op_latency_us: Metrics::new_histogram_vec_with_buckets(
+                "mds_kv_op_latency_us",
+                "KV operation latency in microseconds",
+                &["backend", "op"],
+                LATENCY_BUCKETS_US,
+            )?,
+            txn_conflicts_total: Metrics::new_counter_vec(
+                "mds_kv_txn_conflicts_total",
+                "KV transaction commit conflicts",
+                &["backend"],
+            )?,
+            txn_retries_total: Metrics::new_counter_vec(
+                "mds_kv_txn_retries_total",
+                "KV transaction retries performed by run_txn",
+                &["backend"],
+            )?,
+            txn_in_flight: Metrics::new_gauge(
+                "mds_kv_txn_in_flight",
+                "Currently in-flight KV transactions",
+            )?,
+        })
+    }
+
+    /// Records the outcome and latency of a single operation.
+    pub fn observe(&self, backend: &str, op: &str, start: Instant, result: &Result<(), KvError>) {
+        self.ops_total.with_label_values(&[backend, op]).inc();
+        self.op_latency_us
+            .with_label_values(&[backend, op])
+            .observe(start.elapsed().as_micros() as f64);
+        match result {
+            Ok(()) => self.ops_ok_total.with_label_values(&[backend, op]).inc(),
+            Err(error) => {
+                self.ops_err_total
+                    .with_label_values(&[backend, op, error.kind()])
+                    .inc();
+                if matches!(error, KvError::Conflict) {
+                    self.txn_conflicts_total.with_label_values(&[backend]).inc();
+                }
+            }
+        }
+    }
+
+    /// Records a retry of a transaction closure.
+    pub fn record_retry(&self, backend: &str) {
+        self.txn_retries_total.with_label_values(&[backend]).inc();
+    }
+}
+
+static KV_METRICS: Lazy<KvMetrics> =
+    Lazy::new(|| KvMetrics::register().expect("failed to register KV metrics"));
+
+/// Returns the process-wide KV metrics, registering them on first use.
+pub fn metrics() -> &'static KvMetrics {
+    &KV_METRICS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn observe_updates_counters() {
+        let m = metrics();
+        let backend = "metrics_unit_test";
+        let before = m.ops_total.with_label_values(&[backend, op::GET]).get();
+        m.observe(backend, op::GET, Instant::now(), &Ok(()));
+        let after = m.ops_total.with_label_values(&[backend, op::GET]).get();
+        assert_eq!(after, before + 1);
+
+        let before = m
+            .ops_err_total
+            .with_label_values(&[backend, op::COMMIT, "conflict"])
+            .get();
+        m.observe(backend, op::COMMIT, Instant::now(), &Err(KvError::Conflict));
+        let after = m
+            .ops_err_total
+            .with_label_values(&[backend, op::COMMIT, "conflict"])
+            .get();
+        assert_eq!(after, before + 1);
+    }
+}

--- a/curvine-mds/src/kv/mod.rs
+++ b/curvine-mds/src/kv/mod.rs
@@ -1,0 +1,20 @@
+//! Generic, business-agnostic byte-level KV abstraction and its in-memory
+//! backend.
+//!
+//! This module is the stable storage boundary the stateless MDS is built on.
+//! It deliberately contains NO MDS domain types (mount tables, meta keys,
+//! paths); those live in higher layers that depend only on [`KvBackend`]. The
+//! FoundationDB backend (a later step) implements the same traits so business
+//! code never touches the FDB SDK directly.
+
+mod backend;
+mod error;
+mod memory;
+pub mod metrics;
+
+pub use backend::{run_txn, KvBackend, KvTransaction, DEFAULT_MAX_RETRIES};
+pub use error::{KvError, KvResult};
+pub use memory::{FaultInjector, MemoryBackend};
+
+#[cfg(test)]
+mod contract_tests;

--- a/curvine-mds/src/lib.rs
+++ b/curvine-mds/src/lib.rs
@@ -1,3 +1,8 @@
+mod kv;
 mod server;
 
+pub use kv::{
+    run_txn, FaultInjector, KvBackend, KvError, KvResult, KvTransaction, MemoryBackend,
+    DEFAULT_MAX_RETRIES,
+};
 pub use server::Mds;


### PR DESCRIPTION
# Summary

Add a business-agnostic byte-level KV abstraction to `curvine-mds`, together with an in-memory backend, retry handling, fault injection, metrics, and reusable contract tests. This establishes the storage boundary needed by subsequent stateless MDS repositories.

# Issue Describe / Design

This is PR 2 of the stateless MDS implementation plan.

Key design decisions:
- Keep keys and values opaque as byte arrays, without introducing mount, path, or metadata domain types.
- Define transaction boundaries and optimistic conflict behavior through `KvBackend` and `KvTransaction`.
- Keep retry ownership in the shared `run_txn` helper and expose stable retryable error classification.
- Provide a deterministic memory backend and fault injector for tests without external services.

The next PR will implement the FoundationDB backend on top of this abstraction.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-mds/src/kv/backend.rs` | Add KV backend and transaction traits, convenience operations, CAS, and transaction retry helper | None; new API |
| `curvine-mds/src/kv/error.rs` | Add common KV errors and retry classification | None; new API |
| `curvine-mds/src/kv/memory.rs` | Add in-memory transactional backend and fault injection | None; used for tests and local execution |
| `curvine-mds/src/kv/metrics.rs` | Add operation, latency, error, conflict, retry, and in-flight metrics | Adds MDS KV observability |
| `curvine-mds/src/kv/contract_tests.rs` | Add reusable backend contract tests | Test-only |
| `curvine-mds/src/lib.rs` | Export the KV interfaces and memory backend | Adds public MDS APIs |
| `curvine-mds/Cargo.toml`, `Cargo.lock` | Add required dependencies | None |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo fmt --all -- --check` | PASS | |
| `CARGO_TARGET_DIR=/tmp/curvine-target cargo test -p curvine-mds` | PASS | 8 tests passed |
| Repeated parallel `cargo test -p curvine-mds --quiet` | PASS | Passed 5 consecutive runs after isolating the metrics test label |

# Dependencies

- Related PRs: #1621
- Related issues: None
- Blocks / blocked by: The next PR will add the FoundationDB backend using these interfaces