### PR TITLE
fix(java): isolate MOUNT_CACHE by client mode (#1638)

### DIFF
--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineFileSystem.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineFileSystem.java
@@ -55,7 +55,8 @@ public class CurvineFileSystem extends FileSystem {
 
     /**
      * Global cache for CurvineFsMount instances to avoid creating too many Tokio runtimes.
-     * Key: master_addrs (e.g., "master-0:8995")
+     * Key: master_addrs plus client mode (enable_unified_fs / enable_rust_read_ufs).
+     * Native conf is frozen at mount construction, so different modes cannot share a handle.
      * Value: CachedMount containing the shared CurvineFsMount and reference count
      */
     private static final ConcurrentHashMap<String, CachedMount> MOUNT_CACHE = new ConcurrentHashMap<>();
@@ -145,19 +146,30 @@ public class CurvineFileSystem extends FileSystem {
 
         this.uri = URI.create(name.getScheme() + "://" + authority);
         this.workingDir = getHomeDirectory();
-        
-        this.cacheKey = filesystemConf.master_addrs;
+
+        this.cacheKey = mountCacheKey(filesystemConf);
         this.libFs = getOrCreateMount(filesystemConf);
     }
-    
+
+    /**
+     * Isolate native mounts by Master address and client mode.
+     * Same master_addrs with different enable_unified_fs / enable_rust_read_ufs
+     * must not reuse a CurvineFsMount whose conf was already frozen into native.
+     */
+    static String mountCacheKey(FilesystemConf conf) {
+        return conf.master_addrs
+                + "|unified=" + conf.enable_unified_fs
+                + "|rust_ufs=" + conf.enable_rust_read_ufs;
+    }
+
     /**
      * Get or create a cached CurvineFsMount instance.
      * Lookup and refcount update both happen under the cache lock: an entry that is
      * still in the cache is always open, so no caller can ever observe a closed
-     * mount (no use-after-free) and exactly one instance is created per master_addrs.
+     * mount (no use-after-free). One instance is created per cache key (Master + client mode).
      */
     private CurvineFsMount getOrCreateMount(FilesystemConf conf) throws IOException {
-        String key = conf.master_addrs;
+        String key = mountCacheKey(conf);
 
         synchronized (MOUNT_CACHE) {
             CachedMount cached = MOUNT_CACHE.get(key);

--- a/curvine-libsdk/java/src/test/java/io/curvine/CurvineFileSystemMountCacheKeyTest.java
+++ b/curvine-libsdk/java/src/test/java/io/curvine/CurvineFileSystemMountCacheKeyTest.java
@@ -1,0 +1,73 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.curvine;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+/**
+ * Pure-Java tests for {@link CurvineFileSystem#mountCacheKey(FilesystemConf)}.
+ * Does not load JNI.
+ */
+public class CurvineFileSystemMountCacheKeyTest {
+
+    @Test
+    public void sameMasterDifferentUnifiedFsProducesDifferentKeys() throws Exception {
+        FilesystemConf unified = conf("localhost:8995", true, false);
+        FilesystemConf pureCv = conf("localhost:8995", false, false);
+
+        String unifiedKey = CurvineFileSystem.mountCacheKey(unified);
+        String pureCvKey = CurvineFileSystem.mountCacheKey(pureCv);
+
+        assertEquals("localhost:8995|unified=true|rust_ufs=false", unifiedKey);
+        assertEquals("localhost:8995|unified=false|rust_ufs=false", pureCvKey);
+        assertNotEquals(unifiedKey, pureCvKey);
+    }
+
+    @Test
+    public void sameMasterDifferentRustUfsProducesDifferentKeys() throws Exception {
+        FilesystemConf cacheLookup = conf("localhost:8995", true, false);
+        FilesystemConf rustUfs = conf("localhost:8995", true, true);
+
+        assertNotEquals(
+                CurvineFileSystem.mountCacheKey(cacheLookup),
+                CurvineFileSystem.mountCacheKey(rustUfs));
+    }
+
+    @Test
+    public void defaultSingleClientKeepsStableKeyPerMaster() throws Exception {
+        FilesystemConf first = conf("master-0:8995", true, false);
+        FilesystemConf second = conf("master-0:8995", true, false);
+
+        assertEquals(
+                "master-0:8995|unified=true|rust_ufs=false",
+                CurvineFileSystem.mountCacheKey(first));
+        assertEquals(
+                CurvineFileSystem.mountCacheKey(first),
+                CurvineFileSystem.mountCacheKey(second));
+    }
+
+    private static FilesystemConf conf(String masterAddrs, boolean unified, boolean rustUfs)
+            throws Exception {
+        Configuration conf = new Configuration();
+        conf.set("fs.cv.master_addrs", masterAddrs);
+        conf.set("fs.cv.enable_unified_fs", Boolean.toString(unified));
+        conf.set("fs.cv.enable_rust_read_ufs", Boolean.toString(rustUfs));
+        return new FilesystemConf(conf);
+    }
+}


### PR DESCRIPTION
# Summary

`CurvineFileSystem` kept a process-wide native mount cache keyed only by `master_addrs`. Two Hadoop `FileSystem` wrappers in the same JVM could share one `CurvineFsMount` even when `enable_unified_fs` / `enable_rust_read_ufs` differed, so Java conf and native mode silently diverged. This PR includes client mode in the cache key.

# Issue Describe / Design

Closes #1638

- Root cause: `CurvineFsMount` freezes `FilesystemConf` into native at construction (`CurvineNative.newFilesystem(conf.toToml())`). `MOUNT_CACHE` reused that handle for any later client with the same Master address.
- Reproduction: in one JVM, initialize two `CurvineFileSystem` instances against the same `master_addrs` with different `enable_unified_fs` (and/or `enable_rust_read_ufs`). The second instance reuses the first native mount; there is no exception.
- Fix approach: key native mounts by Master address plus client mode (`unified` / `rust_ufs`). Default single-client still has one cache entry per Master. Dual-mode pays a second native mount. No JNI / RPC change. Full toml-hash identity is left as a follow-up.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-libsdk/java/src/main/java/io/curvine/CurvineFileSystem.java` | `mountCacheKey` includes `enable_unified_fs` and `enable_rust_read_ufs`; comments no longer say one mount per `master_addrs` | Default (`unified=true`, `rust_ufs=false`) still one mount per Master. Different client modes no longer share a native handle. |
| `curvine-libsdk/java/src/test/java/io/curvine/CurvineFileSystemMountCacheKeyTest.java` | Pure-Java key-string tests (no JNI) | None |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `mvn -f curvine-libsdk/java/pom.xml test -Dtest=CurvineFileSystemMountCacheKeyTest,CurvineFileSystemLifecycleTest` | PASS | 8 tests (3 new key tests + 5 existing lifecycle tests) |

# Dependencies

- Related PRs: None
- Related issues: #1638
- Blocks / blocked by: None
