### PR TITLE
fix(worker): cancel remote writer on replication failure (#1636)

### DIFF
--- a/curvine-worker/src/worker/replication/worker_replication_manager.rs
+++ b/curvine-worker/src/worker/replication/worker_replication_manager.rs
@@ -18,15 +18,41 @@ use curvine_client_core::block::BlockWriterRemote;
 use curvine_client_core::file::FsContext;
 use curvine_config::ClusterConf;
 use curvine_core_error::{err_box, CommonResult};
+use curvine_error::FsResult;
 use curvine_fs_api::RpcCode;
 use curvine_model::{ExtendedBlock, FileType};
 use curvine_proto::{ReportBlockReplicationRequest, ReportBlockReplicationResponse};
 use curvine_runtime::runtime::{AsyncRuntime, RpcRuntime};
-use log::{error, info};
+use log::{error, info, warn};
 use once_cell::sync::OnceCell;
+use std::future::Future;
 use std::sync::Arc;
 use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::sync::Semaphore;
+
+async fn finish_replication_with_cleanup<C, F>(
+    result: CommonResult<()>,
+    cancel: C,
+    block_id: i64,
+    target_worker_id: u32,
+) -> CommonResult<()>
+where
+    C: FnOnce() -> F,
+    F: Future<Output = FsResult<()>>,
+{
+    match result {
+        Ok(()) => Ok(()),
+        Err(replication_error) => {
+            if let Err(cancel_error) = cancel().await {
+                warn!(
+                    "Failed to cancel remote writer for block {} on worker {} after replication error '{}': {}",
+                    block_id, target_worker_id, replication_error, cancel_error
+                );
+            }
+            Err(replication_error)
+        }
+    }
+}
 
 #[derive(Clone)]
 pub struct WorkerReplicationManager {
@@ -147,17 +173,28 @@ impl WorkerReplicationManager {
             target_capacity,
         )
         .await?;
-        let mut remaining = block_meta.len;
-        while remaining > 0 {
-            let size = remaining.min(self.replicate_chunk_size as i64);
-            let slice = reader.read_region(true, size as i32)?;
-            let read_len = slice.len() as i64;
-            writer.write(slice).await?;
-            remaining -= read_len;
+        let replication_result: CommonResult<()> = async {
+            let mut remaining = block_meta.len;
+            while remaining > 0 {
+                let size = remaining.min(self.replicate_chunk_size as i64);
+                let slice = reader.read_region(true, size as i32)?;
+                let read_len = slice.len() as i64;
+                writer.write(slice).await?;
+                remaining -= read_len;
+            }
+            writer.flush().await?;
+            writer.complete().await?;
+            Ok(())
         }
-        writer.flush().await?;
-        writer.complete().await?;
-        Ok(())
+        .await;
+
+        finish_replication_with_cleanup(
+            replication_result,
+            || writer.cancel(),
+            job.block_id,
+            job.target_worker_addr.worker_id,
+        )
+        .await
     }
 
     pub fn accept_job(&self, job: ReplicationJob) -> CommonResult<()> {
@@ -169,5 +206,79 @@ impl WorkerReplicationManager {
 
     pub fn with_master_client(&self, master_client: MasterClient) {
         let _ = self.master_client.set(master_client);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::finish_replication_with_cleanup;
+    use curvine_core_error::{err_box, CommonResult};
+    use curvine_error::FsError;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn successful_replication_skips_cancel() -> CommonResult<()> {
+        let cancel_calls = Arc::new(AtomicUsize::new(0));
+        let calls = cancel_calls.clone();
+
+        finish_replication_with_cleanup(
+            Ok(()),
+            move || async move {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Ok::<(), FsError>(())
+            },
+            1,
+            2,
+        )
+        .await?;
+
+        assert_eq!(cancel_calls.load(Ordering::SeqCst), 0);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn failed_replication_cancels_writer_and_preserves_error() {
+        let cancel_calls = Arc::new(AtomicUsize::new(0));
+        let calls = cancel_calls.clone();
+        let replication_result: CommonResult<()> = err_box!("source read failed");
+
+        let error = finish_replication_with_cleanup(
+            replication_result,
+            move || async move {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Ok::<(), FsError>(())
+            },
+            1,
+            2,
+        )
+        .await
+        .expect_err("replication failure must be returned");
+
+        assert_eq!(cancel_calls.load(Ordering::SeqCst), 1);
+        assert!(error.to_string().contains("source read failed"));
+    }
+
+    #[tokio::test]
+    async fn cancel_failure_does_not_replace_replication_error() {
+        let cancel_calls = Arc::new(AtomicUsize::new(0));
+        let calls = cancel_calls.clone();
+        let replication_result: CommonResult<()> = err_box!("remote write failed");
+
+        let error = finish_replication_with_cleanup(
+            replication_result,
+            move || async move {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Err(FsError::common("cancel failed"))
+            },
+            1,
+            2,
+        )
+        .await
+        .expect_err("replication failure must remain primary");
+
+        assert_eq!(cancel_calls.load(Ordering::SeqCst), 1);
+        assert!(error.to_string().contains("remote write failed"));
+        assert!(!error.to_string().contains("cancel failed"));
     }
 }


### PR DESCRIPTION
# Summary

Cancel the target remote block writer when block replication fails after the writer has been created.

Cancellation is best-effort: the original replication error remains the primary error, while cancellation failures are logged separately.

# Issue Describe / Design

Closes #1636

Root cause:

`WorkerReplicationManager::replicate_block` used early-returning `?` operations after creating `BlockWriterRemote`. If source reading, remote writing, flushing, or completion failed, the function returned without sending a cancellation request to the target Worker.

This could leave an unfinished staging block, writing metadata, or reserved storage capacity on the target Worker.

Fix approach:

- Collect the read, write, flush, and complete operations into one replication result.
- If the replication result fails, call `BlockWriterRemote::cancel()` once.
- Preserve and return the original replication error.
- Log cancellation failures without replacing the original error.
- Do not cancel after successful completion.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `curvine-worker/src/worker/replication/worker_replication_manager.rs` | Add best-effort remote writer cancellation after replication failures | Failed replication now cleans up target staging state when possible |
| `curvine-worker/src/worker/replication/worker_replication_manager.rs` | Add tests for successful completion, cancellation, and cancellation failure | No production behavior change outside the replication failure path |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-worker worker::replication::worker_replication_manager::tests -- --nocapture` | PASS | 3 passed after rebase |
| `cargo test -p curvine-worker` | PASS | 34 passed, 1 ignored |
| `cargo test -p curvine-storage-local abort_spdk` | PASS | Target abort path |
| `cargo test -p curvine-storage-local abort_and_failed_prepare_write_preserve_capacity` | PASS | Capacity cleanup |
| `cargo test -p curvine-storage-local failed_file_deallocate_keeps_block_and_capacity_reserved` | PASS | Failed deallocation behavior |
| `cargo test -p curvine-tests --test replication_test test_replication_honors_source_block_capacity -- --nocapture` | PASS | Replication capacity regression |
| `cargo test -p curvine-tests --test replication_test test_block_replication_e2e -- --nocapture` | PASS | Replica count and data integrity |
| Three-node post-open fault injection on `tikv-nxxy03`, `tikv-nxxy04-1`, and `tikv-nxxy05` | PASS | A temporary test-only fault point failed replication after the target writer opened. The target logged `is commit: false`, retained no staging/active replica, and reported `reserved_bytes = 0`; the Master did not add the failed target location. |
| Fault-free recovery read after clearing the injected rule | PASS | Restored the second replica, downloaded 2 MiB, and matched SHA-256 `399902e71e4ac567b3d6efc9f46eb903bfa93a9faf3f4c7e7a2b227f8250c337` |
| Rebase and final diff verification | PASS | `github/main` is an ancestor; one #1636 commit and one changed file remain; the #1634 patch is already present in `main` |
| `cargo fmt --all -- --check` | PASS | |
| `git diff --check` | PASS | Rechecked after rebase |
| `cargo clippy -p curvine-worker --lib --tests -- --deny warnings --allow unused_macros --allow unused_imports --allow unused_variables --allow clippy::uninlined-format-args` | PASS | Platform-specific existing warnings allowed |
| `make format` | BLOCKED | Existing macOS issues: unavailable `fuse_mount_pure` and unused `sys_call` macro under `-D warnings` |

# Dependencies

- Related PRs: #1637 (merged)
- Related issues: #1634, #1233, #1645
- Blocks / blocked by: None
- Stronger repeatable caller-level or worker fault-injection regression coverage is tracked in #1645.
