### PR TITLE
feat(java-sdk): complete transfer and filesystem lifecycle APIs

### DIFF
--- a/crates/sdk/curvine-libsdk-java/src/java/java_abi.rs
+++ b/crates/sdk/curvine-libsdk-java/src/java/java_abi.rs
@@ -18,7 +18,7 @@ use crate::java::{JavaFilesystem, SUCCESS};
 use crate::{java_err, java_err2, LibFsReader, LibFsWriter};
 use curvine_sys::FFIUtils;
 use jni::objects::{JByteArray, JLongArray, JObject, JString};
-use jni::sys::{jarray, jboolean, jint, jlong};
+use jni::sys::{jarray, jboolean, jint, jlong, jstring};
 use jni::JNIEnv;
 
 // It's too troublesome to parse object members by jni. Here the configuration will be passed through the json string.
@@ -270,6 +270,18 @@ pub unsafe extern "C" fn Java_io_curvine_CurvineNative_delete(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn Java_io_curvine_CurvineNative_free(
+    mut env: JNIEnv,
+    _this: JObject,
+    fs_ptr: *mut JavaFilesystem,
+    path: JString,
+    recursive: jboolean,
+) -> jarray {
+    let fs = &*fs_ptr;
+    java_err2!(env, fs.free(&mut env, path, recursive))
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn Java_io_curvine_CurvineNative_getFilesystemInfo(
     mut env: JNIEnv,
     _this: JObject,
@@ -355,6 +367,18 @@ pub unsafe extern "C" fn Java_io_curvine_CurvineNative_submitLoadJob(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn Java_io_curvine_CurvineNative_submitExportJob(
+    mut env: JNIEnv,
+    _this: JObject,
+    fs_ptr: *mut JavaFilesystem,
+    source_path: JString,
+    overwrite: jboolean,
+) -> jarray {
+    let fs = &*fs_ptr;
+    java_err2!(env, fs.submit_export_job(&mut env, source_path, overwrite))
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn Java_io_curvine_CurvineNative_getJobStatus(
     mut env: JNIEnv,
     _this: JObject,
@@ -375,4 +399,15 @@ pub unsafe extern "C" fn Java_io_curvine_CurvineNative_cancelJob(
     let fs = &*fs_ptr;
     java_err!(env, fs.cancel_job(&mut env, job_id));
     SUCCESS
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_io_curvine_CurvineNative_retryJob(
+    mut env: JNIEnv,
+    _this: JObject,
+    fs_ptr: *mut JavaFilesystem,
+    job_id: JString,
+) -> jstring {
+    let fs = &*fs_ptr;
+    java_err2!(env, fs.retry_job(&mut env, job_id))
 }

--- a/crates/sdk/curvine-libsdk-java/src/java/java_filesystem.rs
+++ b/crates/sdk/curvine-libsdk-java/src/java/java_filesystem.rs
@@ -17,7 +17,7 @@ use crate::{FilesystemConf, LibFilesystem, LibFsReader, LibFsWriter};
 use curvine_core_error::{err_box, try_err};
 use curvine_error::{FsError, FsResult};
 use curvine_fs_api::proto::{
-    GetJobStatusResponse, GetMountTableResponse, MountOptionsProto, SetAttrOptsProto,
+    FreeResponse, GetJobStatusResponse, GetMountTableResponse, MountOptionsProto, SetAttrOptsProto,
     SubmitJobResponse,
 };
 use curvine_fs_api::state::{DeleteResult, LoadJobCommand, SetAttrOpts};
@@ -46,6 +46,32 @@ fn decode_set_attr_options(bytes: &[u8]) -> FsResult<SetAttrOpts> {
     }
     let options = try_err!(SetAttrOptsProto::decode(bytes));
     Ok(ProtoUtils::set_attr_opts_from_pb(options))
+}
+
+fn decode_load_job_command(
+    env: &mut JNIEnv,
+    source_path: JString,
+    target_path: JString,
+    overwrite: jboolean,
+) -> FsResult<LoadJobCommand> {
+    let source = JavaUtils::jstring_to_string(env, &source_path)?;
+    let target = if target_path.is_null() {
+        None
+    } else {
+        let value = JavaUtils::jstring_to_string(env, &target_path)?;
+        if value.trim().is_empty() {
+            None
+        } else {
+            Some(value)
+        }
+    };
+
+    let mut builder =
+        LoadJobCommand::builder(source).overwrite(JavaUtils::jbool_to_bool(overwrite));
+    if let Some(target) = target {
+        builder = builder.target_path(target);
+    }
+    Ok(builder.build())
 }
 
 impl JavaFilesystem {
@@ -138,6 +164,16 @@ impl JavaFilesystem {
         self.inner.delete(path, JavaUtils::jbool_to_bool(recursive))
     }
 
+    pub fn free(&self, env: &mut JNIEnv, path: JString, recursive: jboolean) -> FsResult<jarray> {
+        let path = JavaUtils::jstring_to_string(env, &path)?;
+        let result = self.inner.free(path, JavaUtils::jbool_to_bool(recursive))?;
+        let response = FreeResponse {
+            res: ProtoUtils::free_res_to_pb(result),
+        };
+        let bytes = ProtoUtils::encode(response)?;
+        Ok(JavaUtils::new_jarray(env, &bytes)?)
+    }
+
     pub fn get_filesystem_info(&self, env: &mut JNIEnv) -> FsResult<jarray> {
         let status = self.inner.get_filesystem_info()?;
         let byte_arr = JavaUtils::new_jarray(env, &status)?;
@@ -207,24 +243,8 @@ impl JavaFilesystem {
         target_path: JString,
         overwrite: jboolean,
     ) -> FsResult<jarray> {
-        let source = JavaUtils::jstring_to_string(env, &source_path)?;
-        let target = if target_path.is_null() {
-            None
-        } else {
-            let value = JavaUtils::jstring_to_string(env, &target_path)?;
-            if value.trim().is_empty() {
-                None
-            } else {
-                Some(value)
-            }
-        };
-
-        let mut builder =
-            LoadJobCommand::builder(source).overwrite(JavaUtils::jbool_to_bool(overwrite));
-        if let Some(target) = target {
-            builder = builder.target_path(target);
-        }
-        let result = job::submit_load_job(self.inner.session(), builder.build())?;
+        let command = decode_load_job_command(env, source_path, target_path, overwrite)?;
+        let result = job::submit_load_job(self.inner.session(), command)?;
         let response = SubmitJobResponse {
             job_id: result.job_id,
             target_path: result.target_path,
@@ -233,6 +253,26 @@ impl JavaFilesystem {
         let bytes = ProtoUtils::encode(response)?;
         let byte_arr = JavaUtils::new_jarray(env, &bytes)?;
         Ok(byte_arr)
+    }
+
+    /// Submit a Curvine-to-UFS export job. Mirrors Rust `JobClient::submit_export_job`.
+    pub fn submit_export_job(
+        &self,
+        env: &mut JNIEnv,
+        source_path: JString,
+        overwrite: jboolean,
+    ) -> FsResult<jarray> {
+        let source = JavaUtils::jstring_to_string(env, &source_path)?;
+        let command =
+            LoadJobCommand::builder(source).overwrite(JavaUtils::jbool_to_bool(overwrite));
+        let result = job::submit_export_job(self.inner.session(), command.build())?;
+        let response = SubmitJobResponse {
+            job_id: result.job_id,
+            target_path: result.target_path,
+            state: i32::from(result.state as i8),
+        };
+        let bytes = ProtoUtils::encode(response)?;
+        Ok(JavaUtils::new_jarray(env, &bytes)?)
     }
 
     /// Query load job status by id. Mirrors Rust `JobClient::get_status`.
@@ -255,6 +295,12 @@ impl JavaFilesystem {
     pub fn cancel_job(&self, env: &mut JNIEnv, job_id: JString) -> FsResult<()> {
         let job_id = JavaUtils::jstring_to_string(env, &job_id)?;
         job::cancel_job(self.inner.session(), job_id)
+    }
+
+    pub fn retry_job(&self, env: &mut JNIEnv, job_id: JString) -> FsResult<jstring> {
+        let job_id = JavaUtils::jstring_to_string(env, &job_id)?;
+        let retry_job_id = job::retry_job(self.inner.session(), job_id)?;
+        JavaUtils::new_jstring(env, Some(retry_job_id)).map_err(|e| FsError::common(e.to_string()))
     }
 
     pub fn cleanup(&self) {

--- a/crates/sdk/curvine-sdk-core/src/core/job.rs
+++ b/crates/sdk/curvine-sdk-core/src/core/job.rs
@@ -28,6 +28,12 @@ pub fn submit_load_job(session: &Session, command: LoadJobCommand) -> FsResult<L
         .block_on(async { transfer_compat::submit_load_job(session, command).await })
 }
 
+pub fn submit_export_job(session: &Session, command: LoadJobCommand) -> FsResult<LoadJobResult> {
+    session
+        .runtime()
+        .block_on(async { transfer_compat::submit_export_job(session, command).await })
+}
+
 pub fn get_job_status(session: &Session, job_id: impl AsRef<str>) -> FsResult<JobStatus> {
     session
         .runtime()
@@ -38,6 +44,12 @@ pub fn cancel_job(session: &Session, job_id: impl AsRef<str>) -> FsResult<()> {
     session
         .runtime()
         .block_on(async { transfer_compat::cancel_job(session, job_id).await })
+}
+
+pub fn retry_job(session: &Session, job_id: impl AsRef<str>) -> FsResult<String> {
+    session
+        .runtime()
+        .block_on(async { transfer_compat::retry_job(session, job_id).await })
 }
 
 pub fn wait_job_complete(

--- a/crates/sdk/curvine-sdk-core/src/core/transfer_compat.rs
+++ b/crates/sdk/curvine-sdk-core/src/core/transfer_compat.rs
@@ -56,8 +56,7 @@ pub(crate) fn validate_transfer_command(command: &LoadJobCommand) -> FsResult<()
         || command.ttl_action.is_some()
     {
         return err_box!(
-            "transfer path does not support replicas/block_size/storage_type/ttl options; \
-             use source_path, target_path, and overwrite only"
+            "transfer path does not support replicas/block_size/storage_type/ttl options"
         );
     }
     Ok(())
@@ -91,6 +90,13 @@ pub(crate) fn job_status_from_transfer(status: GetTransferStatusResponse) -> Job
     }
 }
 
+fn infer_transfer_paths(input: Path, peer: Path, kind: TransferKind) -> (Path, Path) {
+    match kind {
+        TransferKind::Load if input.is_cv() => (peer, input),
+        TransferKind::Load | TransferKind::Export => (input, peer),
+    }
+}
+
 async fn resolve_transfer_paths(
     fs: &UnifiedFileSystem,
     command: &LoadJobCommand,
@@ -104,11 +110,7 @@ async fn resolve_transfer_paths(
             Some(peer) => peer,
             None => return err_box!("{} is not mounted", command.source_path),
         };
-        if input.is_cv() {
-            (peer, input)
-        } else {
-            (input, peer)
-        }
+        infer_transfer_paths(input, peer, kind)
     };
     match kind {
         TransferKind::Load if !source.is_cv() && target.is_cv() => {}
@@ -368,6 +370,7 @@ mod tests {
         let command = LoadJobCommand::builder("s3://bucket/a").replicas(2).build();
         let err = validate_transfer_command(&command).unwrap_err();
         assert!(err.to_string().contains("does not support"));
+        assert!(!err.to_string().contains("target_path"));
 
         let command = LoadJobCommand::builder("s3://bucket/a")
             .block_size(1024)
@@ -393,6 +396,24 @@ mod tests {
 
         let command = LoadJobCommand::builder("/mnt/a").build();
         assert!(validate_transfer_command(&command).is_ok());
+    }
+
+    #[test]
+    fn infers_export_paths_without_reversing_the_cv_source() {
+        let cv_path = Path::from_str("/models/v1").unwrap();
+        let ufs_path = Path::from_str("s3://bucket/models/v1").unwrap();
+
+        let (load_source, load_target) =
+            infer_transfer_paths(cv_path.clone(), ufs_path.clone(), TransferKind::Load);
+        assert_eq!(load_source.clone_uri(), ufs_path.clone_uri());
+        assert_eq!(load_target.clone_uri(), cv_path.clone_uri());
+
+        let (export_source, export_target) =
+            infer_transfer_paths(cv_path.clone(), ufs_path.clone(), TransferKind::Export);
+        assert!(export_source.is_cv());
+        assert!(!export_target.is_cv());
+        assert_eq!(export_source.clone_uri(), cv_path.clone_uri());
+        assert_eq!(export_target.clone_uri(), ufs_path.clone_uri());
     }
 
     #[test]

--- a/crates/sdk/curvine-sdk-core/src/core/transfer_compat.rs
+++ b/crates/sdk/curvine-sdk-core/src/core/transfer_compat.rs
@@ -48,7 +48,7 @@ pub(crate) fn map_transfer_state(state: TransferState) -> JobTaskState {
     }
 }
 
-pub(crate) fn validate_transfer_load_command(command: &LoadJobCommand) -> FsResult<()> {
+pub(crate) fn validate_transfer_command(command: &LoadJobCommand) -> FsResult<()> {
     if command.replicas.is_some()
         || command.block_size.is_some()
         || command.storage_type.is_some()
@@ -56,7 +56,7 @@ pub(crate) fn validate_transfer_load_command(command: &LoadJobCommand) -> FsResu
         || command.ttl_action.is_some()
     {
         return err_box!(
-            "transfer path does not support LoadJob options replicas/block_size/storage_type/ttl; \
+            "transfer path does not support replicas/block_size/storage_type/ttl options; \
              use source_path, target_path, and overwrite only"
         );
     }
@@ -91,9 +91,10 @@ pub(crate) fn job_status_from_transfer(status: GetTransferStatusResponse) -> Job
     }
 }
 
-async fn resolve_load_paths(
+async fn resolve_transfer_paths(
     fs: &UnifiedFileSystem,
     command: &LoadJobCommand,
+    kind: TransferKind,
 ) -> FsResult<(String, String)> {
     let input = Path::from_str(&command.source_path)?;
     let (source, target) = if let Some(target_path) = &command.target_path {
@@ -109,27 +110,39 @@ async fn resolve_load_paths(
             (input, peer)
         }
     };
-    if source.is_cv() || !target.is_cv() {
-        return err_box!(
-            "load requires a UFS source and Curvine target: {} -> {}",
-            source.full_path(),
-            target.full_path()
-        );
+    match kind {
+        TransferKind::Load if !source.is_cv() && target.is_cv() => {}
+        TransferKind::Export if source.is_cv() && !target.is_cv() => {}
+        TransferKind::Load => {
+            return err_box!(
+                "load requires a UFS source and Curvine target: {} -> {}",
+                source.full_path(),
+                target.full_path()
+            )
+        }
+        TransferKind::Export => {
+            return err_box!(
+                "export requires a Curvine source and UFS target: {} -> {}",
+                source.full_path(),
+                target.full_path()
+            )
+        }
     }
     Ok((source.clone_uri(), target.clone_uri()))
 }
 
 fn build_transfer_command(
+    kind: TransferKind,
     source_path: String,
     target_path: String,
     overwrite: bool,
 ) -> TransferCommand {
     let mut command = TransferCommand {
-        kind: TransferKind::Load,
+        kind,
         source_path: source_path.clone(),
         target_path: target_path.clone(),
         client_request_id: TransferCommand::default_client_request_id_with_overwrite(
-            TransferKind::Load,
+            kind,
             &source_path,
             &target_path,
             overwrite,
@@ -156,10 +169,43 @@ pub(crate) async fn submit_load_job(
             .await;
     }
 
-    validate_transfer_load_command(&command)?;
+    validate_transfer_command(&command)?;
     let overwrite = command.overwrite.unwrap_or(true);
-    let (source_path, target_path) = resolve_load_paths(session.unified(), &command).await?;
-    let transfer_command = build_transfer_command(source_path, target_path.clone(), overwrite);
+    let (source_path, target_path) =
+        resolve_transfer_paths(session.unified(), &command, TransferKind::Load).await?;
+    let transfer_command = build_transfer_command(
+        TransferKind::Load,
+        source_path,
+        target_path.clone(),
+        overwrite,
+    );
+    let response = transfer_client(session)?.submit(transfer_command).await?;
+    Ok(load_job_result_from_submit(&response, target_path))
+}
+
+pub(crate) async fn submit_export_job(
+    session: &Session,
+    command: LoadJobCommand,
+) -> FsResult<LoadJobResult> {
+    if !transfer_enabled(session) {
+        return JobMasterClient::new(session.fs_client())
+            .submit_export_job(command)
+            .await;
+    }
+
+    validate_transfer_command(&command)?;
+    if command.target_path.is_some() {
+        return err_box!("export does not support an explicit target path");
+    }
+    let overwrite = command.overwrite.unwrap_or(true);
+    let (source_path, target_path) =
+        resolve_transfer_paths(session.unified(), &command, TransferKind::Export).await?;
+    let transfer_command = build_transfer_command(
+        TransferKind::Export,
+        source_path,
+        target_path.clone(),
+        overwrite,
+    );
     let response = transfer_client(session)?.submit(transfer_command).await?;
     Ok(load_job_result_from_submit(&response, target_path))
 }
@@ -185,6 +231,13 @@ pub(crate) async fn cancel_job(session: &Session, job_id: impl AsRef<str>) -> Fs
     }
     let _ = transfer_client(session)?.cancel(job_id, None).await?;
     Ok(())
+}
+
+pub(crate) async fn retry_job(session: &Session, job_id: impl AsRef<str>) -> FsResult<String> {
+    if !transfer_enabled(session) {
+        return err_box!("retry requires transfer.enabled=true");
+    }
+    Ok(transfer_client(session)?.retry(job_id).await?.job_id)
 }
 
 pub(crate) async fn wait_job_complete(
@@ -313,30 +366,33 @@ mod tests {
     #[test]
     fn rejects_unsupported_transfer_load_options() {
         let command = LoadJobCommand::builder("s3://bucket/a").replicas(2).build();
-        let err = validate_transfer_load_command(&command).unwrap_err();
+        let err = validate_transfer_command(&command).unwrap_err();
         assert!(err.to_string().contains("does not support"));
 
         let command = LoadJobCommand::builder("s3://bucket/a")
             .block_size(1024)
             .build();
-        assert!(validate_transfer_load_command(&command).is_err());
+        assert!(validate_transfer_command(&command).is_err());
 
         let command = LoadJobCommand::builder("s3://bucket/a")
             .storage_type(StorageType::Disk)
             .build();
-        assert!(validate_transfer_load_command(&command).is_err());
+        assert!(validate_transfer_command(&command).is_err());
 
         let command = LoadJobCommand::builder("s3://bucket/a")
             .ttl_ms(1000)
             .ttl_action(TtlAction::Delete)
             .build();
-        assert!(validate_transfer_load_command(&command).is_err());
+        assert!(validate_transfer_command(&command).is_err());
 
         let command = LoadJobCommand::builder("s3://bucket/a")
             .target_path("/mnt/a")
             .overwrite(false)
             .build();
-        assert!(validate_transfer_load_command(&command).is_ok());
+        assert!(validate_transfer_command(&command).is_ok());
+
+        let command = LoadJobCommand::builder("/mnt/a").build();
+        assert!(validate_transfer_command(&command).is_ok());
     }
 
     #[test]

--- a/crates/sdk/curvine-sdk-core/src/job.rs
+++ b/crates/sdk/curvine-sdk-core/src/job.rs
@@ -37,12 +37,20 @@ impl JobClient {
         transfer_compat::submit_load_job(&self.session, command).await
     }
 
+    pub async fn submit_export_job(&self, command: LoadJobCommand) -> FsResult<LoadJobResult> {
+        transfer_compat::submit_export_job(&self.session, command).await
+    }
+
     pub async fn get_status(&self, job_id: impl AsRef<str>) -> FsResult<JobStatus> {
         transfer_compat::get_job_status(&self.session, job_id).await
     }
 
     pub async fn cancel(&self, job_id: impl AsRef<str>) -> FsResult<()> {
         transfer_compat::cancel_job(&self.session, job_id).await
+    }
+
+    pub async fn retry(&self, job_id: impl AsRef<str>) -> FsResult<String> {
+        transfer_compat::retry_job(&self.session, job_id).await
     }
 
     pub async fn wait_complete(

--- a/crates/sdk/curvine-sdk-core/src/lib.rs
+++ b/crates/sdk/curvine-sdk-core/src/lib.rs
@@ -27,7 +27,9 @@ mod lib_fs_reader;
 pub use self::lib_fs_reader::LibFsReader;
 
 pub mod blocking_job {
-    pub use crate::core::job::{cancel_job, get_job_status, submit_load_job};
+    pub use crate::core::job::{
+        cancel_job, get_job_status, retry_job, submit_export_job, submit_load_job,
+    };
 }
 
 #[cfg(feature = "rust-sdk")]

--- a/curvine-libsdk/README.md
+++ b/curvine-libsdk/README.md
@@ -116,8 +116,9 @@ JDK **8**, Maven **≥ 3.8.1**. From workspace root, **`make build`** (with **`j
 ### Transfer load routing
 
 When the cluster has Transfer enabled, configure the Java client with the same switch and the
-reachable Transfer service addresses. `CurvineLoadClient` then keeps its existing submit/status/
-cancel API while routing those requests to Transfer instead of the legacy Master Job API:
+reachable Transfer service addresses. `CurvineTransferClient` provides load/export submission,
+status, cancellation, retry, and wait operations while routing requests to Transfer instead of
+the legacy Master Job API:
 
 ```java
 Configuration conf = new Configuration();
@@ -125,14 +126,21 @@ conf.set("fs.cv.master_addrs", "master-0:8995,master-1:8995");
 conf.set("fs.cv.transfer.enabled", "true");
 conf.set("fs.cv.transfer.endpoints", "transfer-0:9010,transfer-1:9010");
 
-try (CurvineLoadClient client = CurvineLoadClient.from(conf)) {
+try (CurvineTransferClient client = CurvineTransferClient.from(conf)) {
     LoadJobResult job = client.submitLoad(LoadJobRequest.builder()
             .sourcePath("s3://bucket/model/v1")
             .targetPath("/bucket/model/v1")
             .build());
     LoadJobStatus status = client.getJobStatus(job.getJobId());
+    LoadJobResult export = client.submitExport(ExportJobRequest.builder()
+            .sourcePath("/bucket/model/v1")
+            .build());
 }
 ```
+
+`submitLoad(request, true)` implements the CLI `cv load --force` behavior. Export targets are
+derived from the existing mount mapping; export source paths must be Curvine paths. The existing
+`CurvineLoadClient` remains a compatibility facade for load-only callers.
 
 `fs.cv.transfer.endpoints` is a comma-separated list and is independent from Master addresses.
 It must point to the externally reachable Transfer service endpoint; the client does not infer it

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineFileSystem.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineFileSystem.java
@@ -454,6 +454,14 @@ public class CurvineFileSystem extends FileSystem {
         return new CurvineFsStat(info);
     }
 
+    /** Release Curvine metadata and blocks for a path and return the released totals. */
+    public FreeResult free(Path path, boolean recursive) throws IOException {
+        if (statistics != null) {
+            statistics.incrementWriteOps(1);
+        }
+        return libFs.free(formatPath(path), recursive);
+    }
+
     public Optional<MountInfoProto> getMountInfo(Path path) throws IOException {
         if (statistics != null) {
             statistics.incrementReadOps(1);

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineFsMount.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineFsMount.java
@@ -19,13 +19,15 @@ import java.util.Objects;
 import java.util.Optional;
 
 import io.curvine.exception.CurvineException;
+import io.curvine.proto.FreeResponse;
 
 public class CurvineFsMount {
-    private final long nativeHandle;
+    private final NativeFilesystemHandle filesystem;
 
     public static long SUCCESS = 0;
 
     public CurvineFsMount(FilesystemConf conf) throws IOException {
+        long nativeHandle;
         try {
             nativeHandle = CurvineNative.newFilesystem(conf.toToml());
         } catch (Exception e) {
@@ -33,6 +35,7 @@ public class CurvineFsMount {
         }
 
         checkError(nativeHandle, "Curvine fs mount error, new curvine client failed, conf: " + conf);
+        filesystem = new NativeFilesystemHandle(nativeHandle);
     }
 
     public void checkError(long errno, String msg) throws IOException {
@@ -54,15 +57,19 @@ public class CurvineFsMount {
     }
 
     public long create(String path, boolean overwrite) throws IOException {
-        long handle = CurvineNative.create(nativeHandle, path, overwrite);
-        checkError(handle);
-        return handle;
+        return filesystem.withOpen(nativeHandle -> {
+            long handle = CurvineNative.create(nativeHandle, path, overwrite);
+            checkError(handle);
+            return handle;
+        });
     }
 
     public long append(String path, long[] tmp) throws IOException {
-        long handle = CurvineNative.append(nativeHandle, path, tmp);
-        checkError(handle);
-        return handle;
+        return filesystem.withOpen(nativeHandle -> {
+            long handle = CurvineNative.append(nativeHandle, path, tmp);
+            checkError(handle);
+            return handle;
+        });
     }
 
     public void allocChunk(long writerHandle, long[] tmp) throws IOException {
@@ -82,9 +89,11 @@ public class CurvineFsMount {
     }
 
     public long open(String path, long[] tmp) throws IOException {
-        long handle = CurvineNative.open(nativeHandle, path, tmp);
-        checkError(handle);
-        return handle;
+        return filesystem.withOpen(nativeHandle -> {
+            long handle = CurvineNative.open(nativeHandle, path, tmp);
+            checkError(handle);
+            return handle;
+        });
     }
 
     public void read(long nativeHandle, long[] tmp) throws IOException {
@@ -102,44 +111,70 @@ public class CurvineFsMount {
     }
 
     public void close() throws IOException {
-        checkError(CurvineNative.closeFilesystem(nativeHandle));
+        filesystem.close("close CurvineFsMount failed");
     }
 
     public void mkdir(String path,  boolean createParent) throws IOException {
-        checkError(CurvineNative.mkdir(nativeHandle, path, createParent));
+        filesystem.withOpen(nativeHandle -> {
+            checkError(CurvineNative.mkdir(nativeHandle, path, createParent));
+            return null;
+        });
     }
 
     public byte[] getFileStatus(String path) throws IOException {
-        byte[] bytes = CurvineNative.getFileStatus(nativeHandle, path);
-        checkError(bytes);
-        return bytes;
+        return filesystem.withOpen(nativeHandle -> {
+            byte[] bytes = CurvineNative.getFileStatus(nativeHandle, path);
+            checkError(bytes);
+            return bytes;
+        });
     }
 
     public byte[] setAttr(String path, SetAttrOpts opts) throws IOException {
         Objects.requireNonNull(opts, "opts");
-        byte[] bytes = CurvineNative.setAttr(nativeHandle, path, opts.toByteArray());
-        checkError(bytes);
-        return bytes;
+        return filesystem.withOpen(nativeHandle -> {
+            byte[] bytes = CurvineNative.setAttr(nativeHandle, path, opts.toByteArray());
+            checkError(bytes);
+            return bytes;
+        });
     }
 
     public byte[] listStatus(String path) throws IOException {
-        byte[] bytes = CurvineNative.listStatus(nativeHandle, path);
-        checkError(bytes);
-        return bytes;
+        return filesystem.withOpen(nativeHandle -> {
+            byte[] bytes = CurvineNative.listStatus(nativeHandle, path);
+            checkError(bytes);
+            return bytes;
+        });
     }
 
     public void rename(String src, String dst) throws IOException {
-        checkError(CurvineNative.rename(nativeHandle, src, dst));
+        filesystem.withOpen(nativeHandle -> {
+            checkError(CurvineNative.rename(nativeHandle, src, dst));
+            return null;
+        });
     }
 
     public void delete(String path, boolean recursive) throws IOException {
-        checkError(CurvineNative.delete(nativeHandle, path, recursive));
+        filesystem.withOpen(nativeHandle -> {
+            checkError(CurvineNative.delete(nativeHandle, path, recursive));
+            return null;
+        });
+    }
+
+    /** Release Curvine metadata and blocks for a path and return the released totals. */
+    public FreeResult free(String path, boolean recursive) throws IOException {
+        return filesystem.withOpen(nativeHandle -> {
+            byte[] bytes = CurvineNative.free(nativeHandle, path, recursive);
+            checkError(bytes);
+            return FreeResult.fromProto(FreeResponse.parseFrom(bytes).getRes());
+        });
     }
 
     public byte[] getFilesystemInfo() throws IOException {
-        byte[] bytes = CurvineNative.getFilesystemInfo(nativeHandle);
-        checkError(bytes);
-        return bytes;
+        return filesystem.withOpen(nativeHandle -> {
+            byte[] bytes = CurvineNative.getFilesystemInfo(nativeHandle);
+            checkError(bytes);
+            return bytes;
+        });
     }
 
     /**
@@ -153,13 +188,17 @@ public class CurvineFsMount {
     }
 
     public byte[] getMountInfo(String path) throws IOException {
-        byte[] bytes = CurvineNative.getMountInfo(nativeHandle, path);
-        checkError(bytes);
-        return bytes;
+        return filesystem.withOpen(nativeHandle -> {
+            byte[] bytes = CurvineNative.getMountInfo(nativeHandle, path);
+            checkError(bytes);
+            return bytes;
+        });
     }
 
     public Optional<String> togglePath(String path, boolean checkCache) throws IOException {
-        String ufsPath = CurvineNative.togglePath(nativeHandle, path, checkCache);
-        return Optional.ofNullable(ufsPath);
+        return filesystem.withOpen(nativeHandle -> {
+            String ufsPath = CurvineNative.togglePath(nativeHandle, path, checkCache);
+            return Optional.ofNullable(ufsPath);
+        });
     }
 }

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineLoadClient.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineLoadClient.java
@@ -14,172 +14,60 @@
 
 package io.curvine;
 
-import io.curvine.exception.CurvineException;
-import io.curvine.proto.GetJobStatusResponse;
-import io.curvine.proto.SubmitJobResponse;
 import org.apache.hadoop.conf.Configuration;
 
 import java.io.Closeable;
 import java.io.IOException;
 import java.time.Duration;
-import java.util.Objects;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
- * Independent Java client for Curvine load jobs.
+ * Compatibility facade for the load-only name of {@link CurvineTransferClient}.
  *
- * <p>Mirrors Rust libsdk {@code JobClient}: submit / get status / cancel, plus a
- * Java-side wait helper with explicit timeout and poll interval.
- *
- * <p>Backend routing follows cluster config {@code transfer.enabled}:
- * when {@code true}, requests go to the standalone Transfer service and responses
- * are mapped back to the existing {@link LoadJobResult} / {@link LoadJobStatus}
- * surface; when {@code false} (default), requests use the legacy Master LoadJob API.
- * For a Hadoop {@link Configuration}, set {@code fs.cv.transfer.enabled=true} and
- * {@code fs.cv.transfer.endpoints=transfer-0:9010,transfer-1:9010}. Transfer endpoints
- * are independent from Master addresses and must be reachable from the Java process.
- *
- * <p><b>Upgrade note:</b> the Java jar and bundled native lib must be upgraded together.
- * A newer native library may return job states (for example {@code PARTIAL_SUCCESS})
- * that an older jar cannot classify, which causes {@link #waitJobComplete} to poll
- * until timeout instead of returning promptly.
- *
- * <pre>{@code
- * try (CurvineLoadClient client = CurvineLoadClient.from(conf)) {
- *     LoadJobResult result = client.submitLoad(
- *             LoadJobRequest.builder()
- *                     .sourcePath("oss://bucket/path/file")
- *                     .targetPath("/mnt/path/file")
- *                     .overwrite(true)
- *                     .build());
- *     LoadJobStatus status = client.waitJobComplete(
- *             result.getJobId(), Duration.ofMinutes(10), Duration.ofSeconds(1));
- * }
- * }</pre>
- *
- * <p>Load remains UFS-to-Curvine and must stay inside an existing mount mapping;
- * this client does not implement arbitrary URI copy.
+ * <p>Backend routing follows {@code transfer.enabled}. With transfer routing enabled, this
+ * client uses the standalone Transfer service; otherwise it uses the legacy Master job API.
+ * Use {@link CurvineTransferClient} when export or retry operations are needed.
  */
 public final class CurvineLoadClient implements Closeable {
-    private static final long SUCCESS = 0;
+    private final CurvineTransferClient delegate;
 
-    private final long nativeHandle;
-    private final AtomicBoolean closed = new AtomicBoolean(false);
-
-    private CurvineLoadClient(long nativeHandle) {
-        this.nativeHandle = nativeHandle;
+    private CurvineLoadClient(CurvineTransferClient delegate) {
+        this.delegate = delegate;
     }
 
     public static CurvineLoadClient from(FilesystemConf conf) throws IOException {
-        Objects.requireNonNull(conf, "conf");
-        try {
-            long handle = CurvineNative.newFilesystem(conf.toToml());
-            if (handle < SUCCESS) {
-                throw CurvineException.create((int) handle, "failed to create CurvineLoadClient");
-            }
-            return new CurvineLoadClient(handle);
-        } catch (IllegalAccessException e) {
-            throw new IOException("failed to serialize FilesystemConf", e);
-        }
+        return new CurvineLoadClient(CurvineTransferClient.from(conf));
     }
 
     public static CurvineLoadClient from(Configuration conf) throws IOException {
-        try {
-            return from(new FilesystemConf(conf));
-        } catch (IllegalAccessException e) {
-            throw new IOException("failed to build FilesystemConf", e);
-        }
+        return new CurvineLoadClient(CurvineTransferClient.from(conf));
     }
 
     /**
      * Submit a load job. Equivalent to Rust {@code JobClient::submit_load_job}.
      */
     public LoadJobResult submitLoad(LoadJobRequest request) throws IOException {
-        ensureOpen();
-        Objects.requireNonNull(request, "request");
-        byte[] bytes = CurvineNative.submitLoadJob(
-                nativeHandle,
-                request.getSourcePath(),
-                request.getTargetPath(),
-                request.isOverwrite());
-        checkBytes(bytes);
-        return LoadJobResult.fromProto(SubmitJobResponse.parseFrom(bytes));
+        return delegate.submitLoad(request);
     }
 
-    /**
-     * Query job status by id. Equivalent to Rust {@code JobClient::get_status}.
-     */
+    public LoadJobResult submitLoad(LoadJobRequest request, boolean force) throws IOException {
+        return delegate.submitLoad(request, force);
+    }
+
+    /** Query a load job by id. */
     public LoadJobStatus getJobStatus(String jobId) throws IOException {
-        ensureOpen();
-        requireJobId(jobId);
-        byte[] bytes = CurvineNative.getJobStatus(nativeHandle, jobId);
-        checkBytes(bytes);
-        return LoadJobStatus.fromProto(GetJobStatusResponse.parseFrom(bytes));
+        return delegate.getJobStatus(jobId);
     }
 
-    /**
-     * Cancel a job by id. Equivalent to Rust {@code JobClient::cancel}.
-     */
+    /** Cancel a load job by id. */
     public void cancelJob(String jobId) throws IOException {
-        ensureOpen();
-        requireJobId(jobId);
-        long errno = CurvineNative.cancelJob(nativeHandle, jobId);
-        if (errno < SUCCESS) {
-            throw CurvineException.create((int) errno, "cancelJob failed: " + jobId);
-        }
+        delegate.cancelJob(jobId);
     }
 
-    /**
-     * Poll job status until finished or timeout.
-     *
-     * <p>Returns the final status when the job reaches {@code COMPLETED} or
-     * {@code PARTIAL_SUCCESS}. {@code FAILED} and {@code CANCELED} throw
-     * {@link IOException}. Callers should check {@link LoadJobStatus#isPartialSuccess()}
-     * (or {@link LoadJobStatus#getState()}) to decide how to handle partial success.
-     *
-     * @param jobId        job id from {@link #submitLoad}
-     * @param timeout      max wait duration
-     * @param pollInterval sleep between status queries
-     * @return final status when the job reaches a terminal success / partial-success state
-     * @throws TimeoutException if the job is still running after {@code timeout}
-     * @throws IOException      if the job fails / is canceled, or RPC fails
-     */
+    /** Poll a load job until it reaches a terminal state or the timeout expires. */
     public LoadJobStatus waitJobComplete(String jobId, Duration timeout, Duration pollInterval)
             throws IOException, TimeoutException, InterruptedException {
-        ensureOpen();
-        requireJobId(jobId);
-        Objects.requireNonNull(timeout, "timeout");
-        Objects.requireNonNull(pollInterval, "pollInterval");
-        if (timeout.isNegative() || timeout.isZero()) {
-            throw new IllegalArgumentException("timeout must be positive");
-        }
-        if (pollInterval.isNegative() || pollInterval.isZero()) {
-            throw new IllegalArgumentException("pollInterval must be positive");
-        }
-
-        long deadlineNanos = saturatingDeadlineNanos(timeout);
-        LoadJobStatus status;
-        while (true) {
-            status = getJobStatus(jobId);
-            if (status.isFinished()) {
-                if (status.isSuccessful() || status.isPartialSuccess()) {
-                    return status;
-                }
-                throw new IOException(
-                        "load job " + jobId + " ended with state " + status.getState()
-                                + (status.getProgress() != null
-                                ? ": " + status.getProgress().getMessage()
-                                : ""));
-            }
-            long remainingNanos = deadlineNanos - System.nanoTime();
-            if (remainingNanos <= 0L) {
-                throw new TimeoutException(
-                        "load job " + jobId + " not complete after " + timeout
-                                + ", last state=" + status.getState());
-            }
-            sleepNanos(Math.min(pollInterval.toNanos(), remainingNanos));
-        }
+        return delegate.waitJobComplete(jobId, timeout, pollInterval);
     }
 
     /**
@@ -187,54 +75,21 @@ public final class CurvineLoadClient implements Closeable {
      */
     public LoadJobStatus waitJobComplete(String jobId, Duration timeout)
             throws IOException, TimeoutException, InterruptedException {
-        return waitJobComplete(jobId, timeout, Duration.ofSeconds(1));
+        return delegate.waitJobComplete(jobId, timeout);
     }
 
     @Override
     public void close() throws IOException {
-        if (!closed.compareAndSet(false, true)) {
-            return;
-        }
-        long errno = CurvineNative.closeFilesystem(nativeHandle);
-        if (errno < SUCCESS) {
-            throw CurvineException.create((int) errno, "close CurvineLoadClient failed");
-        }
-    }
-
-    private void ensureOpen() throws IOException {
-        if (closed.get()) {
-            throw new IOException("CurvineLoadClient is closed");
-        }
+        delegate.close();
     }
 
     /** Compute {@code nanoTime + timeout} without wrapping on overflow. */
     static long saturatingDeadlineNanos(Duration timeout) {
-        long now = System.nanoTime();
-        long timeoutNanos = timeout.toNanos();
-        try {
-            return Math.addExact(now, timeoutNanos);
-        } catch (ArithmeticException overflow) {
-            return Long.MAX_VALUE;
-        }
+        return CurvineTransferClient.saturatingDeadlineNanos(timeout);
     }
 
     /** Sleep at least 1ns to avoid busy-looping when the interval truncates to 0ms. */
     static void sleepNanos(long nanos) throws InterruptedException {
-        long sleepNanos = Math.max(1L, nanos);
-        long sleepMs = sleepNanos / 1_000_000L;
-        int nanoPart = (int) (sleepNanos % 1_000_000L);
-        Thread.sleep(sleepMs, nanoPart);
-    }
-
-    private static void requireJobId(String jobId) {
-        if (jobId == null || jobId.trim().isEmpty()) {
-            throw new IllegalArgumentException("jobId cannot be empty");
-        }
-    }
-
-    private static void checkBytes(byte[] bytes) throws IOException {
-        if (bytes == null) {
-            throw new CurvineException("native load job call returned null");
-        }
+        CurvineTransferClient.sleepNanos(nanos);
     }
 }

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineMountClient.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineMountClient.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Explicit Java client for Curvine UFS mount lifecycle operations.
@@ -36,11 +35,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public final class CurvineMountClient implements Closeable {
     private static final long SUCCESS = 0;
 
-    private final long nativeHandle;
-    private final AtomicBoolean closed = new AtomicBoolean(false);
+    private final NativeFilesystemHandle filesystem;
 
     private CurvineMountClient(long nativeHandle) {
-        this.nativeHandle = nativeHandle;
+        this.filesystem = new NativeFilesystemHandle(nativeHandle);
     }
 
     public static CurvineMountClient from(FilesystemConf conf) throws IOException {
@@ -66,46 +64,50 @@ public final class CurvineMountClient implements Closeable {
 
     /** Create or update a UFS mount. */
     public void mount(MountRequest request) throws IOException {
-        ensureOpen();
         Objects.requireNonNull(request, "request");
-        long errno = CurvineNative.mount(
-                nativeHandle,
-                request.getUfsPath(),
-                request.getCvPath(),
-                request.getOptions().toByteArray());
-        checkError(errno, "mount failed: " + request.getCvPath());
+        filesystem.withOpen(nativeHandle -> {
+            long errno = CurvineNative.mount(
+                    nativeHandle,
+                    request.getUfsPath(),
+                    request.getCvPath(),
+                    request.getOptions().toByteArray());
+            checkError(errno, "mount failed: " + request.getCvPath());
+            return null;
+        });
     }
 
     /** Remove the UFS mount at {@code cvPath}. */
     public void unmount(String cvPath) throws IOException {
-        ensureOpen();
         String path = requirePath(cvPath, "cvPath");
-        long errno = CurvineNative.unmount(nativeHandle, path);
-        checkError(errno, "unmount failed: " + path);
+        filesystem.withOpen(nativeHandle -> {
+            long errno = CurvineNative.unmount(nativeHandle, path);
+            checkError(errno, "unmount failed: " + path);
+            return null;
+        });
     }
 
     /** Find the mount that contains either a Curvine or UFS path. */
     public Optional<MountInfoProto> getMountInfo(String path) throws IOException {
-        ensureOpen();
-        byte[] bytes = CurvineNative.getMountInfo(nativeHandle, requirePath(path, "path"));
-        checkBytes(bytes, "getMountInfo");
-        return parseMountInfo(bytes);
+        String checkedPath = requirePath(path, "path");
+        return filesystem.withOpen(nativeHandle -> {
+            byte[] bytes = CurvineNative.getMountInfo(nativeHandle, checkedPath);
+            checkBytes(bytes, "getMountInfo");
+            return parseMountInfo(bytes);
+        });
     }
 
     /** List every mount in the server's mount-table order. */
     public List<MountInfoProto> listMounts() throws IOException {
-        ensureOpen();
-        byte[] bytes = CurvineNative.getMountTable(nativeHandle);
-        checkBytes(bytes, "getMountTable");
-        return parseMountTable(bytes);
+        return filesystem.withOpen(nativeHandle -> {
+            byte[] bytes = CurvineNative.getMountTable(nativeHandle);
+            checkBytes(bytes, "getMountTable");
+            return parseMountTable(bytes);
+        });
     }
 
     @Override
     public void close() throws IOException {
-        if (!closed.compareAndSet(false, true)) {
-            return;
-        }
-        checkError(CurvineNative.closeFilesystem(nativeHandle), "close CurvineMountClient failed");
+        filesystem.close("close CurvineMountClient failed");
     }
 
     static Optional<MountInfoProto> parseMountInfo(byte[] bytes) throws IOException {
@@ -115,12 +117,6 @@ public final class CurvineMountClient implements Closeable {
 
     static List<MountInfoProto> parseMountTable(byte[] bytes) throws IOException {
         return GetMountTableResponse.parseFrom(bytes).getMountTableList();
-    }
-
-    private void ensureOpen() throws IOException {
-        if (closed.get()) {
-            throw new IOException("CurvineMountClient is closed");
-        }
     }
 
     private static void checkError(long errno, String message) throws IOException {

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineNative.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineNative.java
@@ -347,6 +347,9 @@ public class CurvineNative {
 
     public static native long delete(long nativeHandle, String path, boolean recursive) throws IOException;
 
+    /** Return the counts and bytes released by deleting a path from Curvine. */
+    public static native byte[] free(long nativeHandle, String path, boolean recursive) throws IOException;
+
     public static native byte[] getFilesystemInfo(long nativeHandle) throws IOException;
 
     /**
@@ -387,6 +390,10 @@ public class CurvineNative {
             long nativeHandle, String sourcePath, String targetPath, boolean overwrite)
             throws IOException;
 
+    /** Submit a Curvine-to-UFS export job. */
+    public static native byte[] submitExportJob(
+            long nativeHandle, String sourcePath, boolean overwrite) throws IOException;
+
     /**
      * Query load job status by job id.
      *
@@ -396,4 +403,7 @@ public class CurvineNative {
 
     /** Cancel a load job by job id. */
     public static native long cancelJob(long nativeHandle, String jobId) throws IOException;
+
+    /** Retry a failed, partial-success, or canceled transfer job. */
+    public static native String retryJob(long nativeHandle, String jobId) throws IOException;
 }

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineNative.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineNative.java
@@ -347,7 +347,7 @@ public class CurvineNative {
 
     public static native long delete(long nativeHandle, String path, boolean recursive) throws IOException;
 
-    /** Return the counts and bytes released by deleting a path from Curvine. */
+    /** Release Curvine blocks and metadata for a path and return the released totals. */
     public static native byte[] free(long nativeHandle, String path, boolean recursive) throws IOException;
 
     public static native byte[] getFilesystemInfo(long nativeHandle) throws IOException;

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineTransferClient.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineTransferClient.java
@@ -1,0 +1,223 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.curvine;
+
+import io.curvine.exception.CurvineException;
+import io.curvine.proto.GetJobStatusResponse;
+import io.curvine.proto.SubmitJobResponse;
+import org.apache.hadoop.conf.Configuration;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.TimeoutException;
+
+/** Java client for Curvine load and export jobs. */
+public final class CurvineTransferClient implements Closeable {
+    private static final long SUCCESS = 0;
+
+    private final NativeFilesystemHandle filesystem;
+    private final boolean transferEnabled;
+
+    private CurvineTransferClient(long nativeHandle, boolean transferEnabled) {
+        this.filesystem = new NativeFilesystemHandle(nativeHandle);
+        this.transferEnabled = transferEnabled;
+    }
+
+    public static CurvineTransferClient from(FilesystemConf conf) throws IOException {
+        Objects.requireNonNull(conf, "conf");
+        try {
+            long handle = CurvineNative.newFilesystem(conf.toToml());
+            if (handle < SUCCESS) {
+                throw CurvineException.create((int) handle, "failed to create CurvineTransferClient");
+            }
+            return new CurvineTransferClient(handle, conf.transfer_enabled);
+        } catch (IllegalAccessException e) {
+            throw new IOException("failed to serialize FilesystemConf", e);
+        }
+    }
+
+    public static CurvineTransferClient from(Configuration conf) throws IOException {
+        try {
+            return from(new FilesystemConf(conf));
+        } catch (IllegalAccessException e) {
+            throw new IOException("failed to build FilesystemConf", e);
+        }
+    }
+
+    /** Submit a UFS-to-Curvine load job. */
+    public LoadJobResult submitLoad(LoadJobRequest request) throws IOException {
+        Objects.requireNonNull(request, "request");
+        return filesystem.withOpen(nativeHandle -> parseSubmitResponse(CurvineNative.submitLoadJob(
+                nativeHandle,
+                request.getSourcePath(),
+                request.getTargetPath(),
+                request.isOverwrite())));
+    }
+
+    /**
+     * Submit a load and retry it when transfer routing returns an existing terminal job.
+     * Equivalent to CLI {@code cv load --force}.
+     */
+    public LoadJobResult submitLoad(LoadJobRequest request, boolean force) throws IOException {
+        checkForceAllowed(force, transferEnabled);
+        LoadJobResult result = submitLoad(request);
+        if (!force || !isTerminal(result.getState())) {
+            return result;
+        }
+        String retryJobId = retryJob(result.getJobId());
+        return new LoadJobResult(
+                retryJobId,
+                result.getTargetPath(),
+                io.curvine.proto.JobTaskStateProto.PENDING);
+    }
+
+    /** Submit a Curvine-to-UFS export job. */
+    public LoadJobResult submitExport(ExportJobRequest request) throws IOException {
+        Objects.requireNonNull(request, "request");
+        return filesystem.withOpen(nativeHandle -> parseSubmitResponse(CurvineNative.submitExportJob(
+                nativeHandle,
+                request.getSourcePath(),
+                request.isOverwrite())));
+    }
+
+    /** Query a load or export job by id. */
+    public LoadJobStatus getJobStatus(String jobId) throws IOException {
+        requireJobId(jobId);
+        return filesystem.withOpen(nativeHandle -> {
+            byte[] bytes = CurvineNative.getJobStatus(nativeHandle, jobId);
+            checkBytes(bytes);
+            return LoadJobStatus.fromProto(GetJobStatusResponse.parseFrom(bytes));
+        });
+    }
+
+    /** Cancel a load or export job by id. */
+    public void cancelJob(String jobId) throws IOException {
+        requireJobId(jobId);
+        filesystem.withOpen(nativeHandle -> {
+            long errno = CurvineNative.cancelJob(nativeHandle, jobId);
+            if (errno < SUCCESS) {
+                throw CurvineException.create((int) errno, "cancelJob failed: " + jobId);
+            }
+            return null;
+        });
+    }
+
+    /** Retry a failed, partial-success, or canceled transfer job. */
+    public String retryJob(String jobId) throws IOException {
+        requireJobId(jobId);
+        return filesystem.withOpen(nativeHandle -> {
+            String retryJobId = CurvineNative.retryJob(nativeHandle, jobId);
+            if (retryJobId == null || retryJobId.trim().isEmpty()) {
+                throw new CurvineException("native retry job call returned an empty job id");
+            }
+            return retryJobId;
+        });
+    }
+
+    /** Poll a job until it reaches a terminal state or the timeout expires. */
+    public LoadJobStatus waitJobComplete(String jobId, Duration timeout, Duration pollInterval)
+            throws IOException, TimeoutException, InterruptedException {
+        requireJobId(jobId);
+        Objects.requireNonNull(timeout, "timeout");
+        Objects.requireNonNull(pollInterval, "pollInterval");
+        if (timeout.isNegative() || timeout.isZero()) {
+            throw new IllegalArgumentException("timeout must be positive");
+        }
+        if (pollInterval.isNegative() || pollInterval.isZero()) {
+            throw new IllegalArgumentException("pollInterval must be positive");
+        }
+
+        long deadlineNanos = saturatingDeadlineNanos(timeout);
+        LoadJobStatus status;
+        while (true) {
+            status = getJobStatus(jobId);
+            if (status.isFinished()) {
+                if (status.isSuccessful() || status.isPartialSuccess()) {
+                    return status;
+                }
+                throw new IOException(
+                        "transfer job " + jobId + " ended with state " + status.getState()
+                                + (status.getProgress() != null
+                                ? ": " + status.getProgress().getMessage()
+                                : ""));
+            }
+            long remainingNanos = deadlineNanos - System.nanoTime();
+            if (remainingNanos <= 0L) {
+                throw new TimeoutException(
+                        "transfer job " + jobId + " not complete after " + timeout
+                                + ", last state=" + status.getState());
+            }
+            sleepNanos(Math.min(pollInterval.toNanos(), remainingNanos));
+        }
+    }
+
+    public LoadJobStatus waitJobComplete(String jobId, Duration timeout)
+            throws IOException, TimeoutException, InterruptedException {
+        return waitJobComplete(jobId, timeout, Duration.ofSeconds(1));
+    }
+
+    @Override
+    public void close() throws IOException {
+        filesystem.close("close CurvineTransferClient failed");
+    }
+
+    static long saturatingDeadlineNanos(Duration timeout) {
+        long now = System.nanoTime();
+        long timeoutNanos = timeout.toNanos();
+        try {
+            return Math.addExact(now, timeoutNanos);
+        } catch (ArithmeticException overflow) {
+            return Long.MAX_VALUE;
+        }
+    }
+
+    static void sleepNanos(long nanos) throws InterruptedException {
+        long sleepNanos = Math.max(1L, nanos);
+        long sleepMs = sleepNanos / 1_000_000L;
+        int nanoPart = (int) (sleepNanos % 1_000_000L);
+        Thread.sleep(sleepMs, nanoPart);
+    }
+
+    static boolean isTerminal(io.curvine.proto.JobTaskStateProto state) {
+        return state != io.curvine.proto.JobTaskStateProto.PENDING
+                && state != io.curvine.proto.JobTaskStateProto.LOADING
+                && state != io.curvine.proto.JobTaskStateProto.UNKNOWN;
+    }
+
+    static void checkForceAllowed(boolean force, boolean transferEnabled) throws IOException {
+        if (force && !transferEnabled) {
+            throw new IOException("load --force requires transfer.enabled=true");
+        }
+    }
+
+    private LoadJobResult parseSubmitResponse(byte[] bytes) throws IOException {
+        checkBytes(bytes);
+        return LoadJobResult.fromProto(SubmitJobResponse.parseFrom(bytes));
+    }
+
+    private static void requireJobId(String jobId) {
+        if (jobId == null || jobId.trim().isEmpty()) {
+            throw new IllegalArgumentException("jobId cannot be empty");
+        }
+    }
+
+    private static void checkBytes(byte[] bytes) throws IOException {
+        if (bytes == null) {
+            throw new CurvineException("native transfer job call returned null");
+        }
+    }
+}

--- a/curvine-libsdk/java/src/main/java/io/curvine/CurvineTransferClient.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/CurvineTransferClient.java
@@ -150,7 +150,7 @@ public final class CurvineTransferClient implements Closeable {
                     return status;
                 }
                 throw new IOException(
-                        "transfer job " + jobId + " ended with state " + status.getState()
+                        "job " + jobId + " ended with state " + status.getState()
                                 + (status.getProgress() != null
                                 ? ": " + status.getProgress().getMessage()
                                 : ""));
@@ -158,10 +158,10 @@ public final class CurvineTransferClient implements Closeable {
             long remainingNanos = deadlineNanos - System.nanoTime();
             if (remainingNanos <= 0L) {
                 throw new TimeoutException(
-                        "transfer job " + jobId + " not complete after " + timeout
+                        "job " + jobId + " not complete after " + timeout
                                 + ", last state=" + status.getState());
             }
-            sleepNanos(Math.min(pollInterval.toNanos(), remainingNanos));
+            sleepNanos(Math.min(saturatingDurationNanos(pollInterval), remainingNanos));
         }
     }
 
@@ -176,10 +176,16 @@ public final class CurvineTransferClient implements Closeable {
     }
 
     static long saturatingDeadlineNanos(Duration timeout) {
-        long now = System.nanoTime();
-        long timeoutNanos = timeout.toNanos();
         try {
-            return Math.addExact(now, timeoutNanos);
+            return Math.addExact(System.nanoTime(), timeout.toNanos());
+        } catch (ArithmeticException overflow) {
+            return Long.MAX_VALUE;
+        }
+    }
+
+    static long saturatingDurationNanos(Duration duration) {
+        try {
+            return duration.toNanos();
         } catch (ArithmeticException overflow) {
             return Long.MAX_VALUE;
         }
@@ -200,7 +206,7 @@ public final class CurvineTransferClient implements Closeable {
 
     static void checkForceAllowed(boolean force, boolean transferEnabled) throws IOException {
         if (force && !transferEnabled) {
-            throw new IOException("load --force requires transfer.enabled=true");
+            throw new IOException("load --force requires fs.cv.transfer.enabled=true");
         }
     }
 

--- a/curvine-libsdk/java/src/main/java/io/curvine/ExportJobRequest.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/ExportJobRequest.java
@@ -1,0 +1,63 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.curvine;
+
+/** Request to submit a Curvine-to-UFS export job. */
+public final class ExportJobRequest {
+    private final String sourcePath;
+    private final boolean overwrite;
+
+    private ExportJobRequest(Builder builder) {
+        this.sourcePath = builder.sourcePath;
+        this.overwrite = builder.overwrite;
+    }
+
+    public String getSourcePath() {
+        return sourcePath;
+    }
+
+    public boolean isOverwrite() {
+        return overwrite;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private String sourcePath;
+        private boolean overwrite = true;
+
+        private Builder() {
+        }
+
+        public Builder sourcePath(String sourcePath) {
+            this.sourcePath = sourcePath;
+            return this;
+        }
+
+        public Builder overwrite(boolean overwrite) {
+            this.overwrite = overwrite;
+            return this;
+        }
+
+        public ExportJobRequest build() {
+            if (sourcePath == null || sourcePath.trim().isEmpty()) {
+                throw new IllegalArgumentException("sourcePath cannot be empty");
+            }
+            return new ExportJobRequest(this);
+        }
+    }
+}

--- a/curvine-libsdk/java/src/main/java/io/curvine/FreeResult.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/FreeResult.java
@@ -1,0 +1,48 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.curvine;
+
+import io.curvine.proto.FreeResultProto;
+
+import java.util.Objects;
+
+/** Result of releasing Curvine file data and metadata. */
+public final class FreeResult {
+    private final long inodes;
+    private final long bytes;
+
+    private FreeResult(long inodes, long bytes) {
+        this.inodes = inodes;
+        this.bytes = bytes;
+    }
+
+    public static FreeResult fromProto(FreeResultProto proto) {
+        Objects.requireNonNull(proto, "proto");
+        return new FreeResult(proto.getInodes(), proto.getBytes());
+    }
+
+    public long getInodes() {
+        return inodes;
+    }
+
+    public long getBytes() {
+        return bytes;
+    }
+
+    @Override
+    public String toString() {
+        return "FreeResult{inodes=" + inodes + ", bytes=" + bytes + '}';
+    }
+}

--- a/curvine-libsdk/java/src/main/java/io/curvine/NativeFilesystemHandle.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/NativeFilesystemHandle.java
@@ -1,0 +1,64 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.curvine;
+
+import io.curvine.exception.CurvineException;
+
+import java.io.IOException;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/** Serializes native filesystem destruction with calls that use its handle. */
+final class NativeFilesystemHandle {
+    @FunctionalInterface
+    interface Operation<T> {
+        T run(long nativeHandle) throws IOException;
+    }
+
+    private final long nativeHandle;
+    private final ReentrantReadWriteLock lifecycleLock = new ReentrantReadWriteLock();
+    private boolean closed;
+
+    NativeFilesystemHandle(long nativeHandle) {
+        this.nativeHandle = nativeHandle;
+    }
+
+    <T> T withOpen(Operation<T> operation) throws IOException {
+        lifecycleLock.readLock().lock();
+        try {
+            if (closed) {
+                throw new IOException("Curvine filesystem is closed");
+            }
+            return operation.run(nativeHandle);
+        } finally {
+            lifecycleLock.readLock().unlock();
+        }
+    }
+
+    void close(String message) throws IOException {
+        lifecycleLock.writeLock().lock();
+        try {
+            if (closed) {
+                return;
+            }
+            long errno = CurvineNative.closeFilesystem(nativeHandle);
+            if (errno < 0) {
+                throw CurvineException.create((int) errno, message);
+            }
+            closed = true;
+        } finally {
+            lifecycleLock.writeLock().unlock();
+        }
+    }
+}

--- a/curvine-libsdk/java/src/main/java/io/curvine/NativeFilesystemHandle.java
+++ b/curvine-libsdk/java/src/main/java/io/curvine/NativeFilesystemHandle.java
@@ -52,11 +52,11 @@ final class NativeFilesystemHandle {
             if (closed) {
                 return;
             }
+            closed = true;
             long errno = CurvineNative.closeFilesystem(nativeHandle);
             if (errno < 0) {
                 throw CurvineException.create((int) errno, message);
             }
-            closed = true;
         } finally {
             lifecycleLock.writeLock().unlock();
         }

--- a/curvine-libsdk/java/src/test/java/io/curvine/ExportJobClientTest.java
+++ b/curvine-libsdk/java/src/test/java/io/curvine/ExportJobClientTest.java
@@ -1,0 +1,40 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.curvine;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ExportJobClientTest {
+    @Test
+    public void exportRequestPreservesPathAndOverwrite() {
+        ExportJobRequest request = ExportJobRequest.builder()
+                .sourcePath("/mnt/model")
+                .overwrite(false)
+                .build();
+
+        Assert.assertEquals("/mnt/model", request.getSourcePath());
+        Assert.assertFalse(request.isOverwrite());
+    }
+
+    @Test
+    public void exportRequestUsesInferredTarget() {
+        ExportJobRequest request = ExportJobRequest.builder()
+                .sourcePath("/mnt/model")
+                .build();
+
+        Assert.assertTrue(request.isOverwrite());
+    }
+}

--- a/curvine-libsdk/java/src/test/java/io/curvine/FreeResultTest.java
+++ b/curvine-libsdk/java/src/test/java/io/curvine/FreeResultTest.java
@@ -1,0 +1,32 @@
+// Copyright 2025 OPPO.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.curvine;
+
+import io.curvine.proto.FreeResultProto;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FreeResultTest {
+    @Test
+    public void fromProtoPreservesCounts() {
+        FreeResult result = FreeResult.fromProto(FreeResultProto.newBuilder()
+                .setInodes(7)
+                .setBytes(1024)
+                .build());
+
+        Assert.assertEquals(7, result.getInodes());
+        Assert.assertEquals(1024, result.getBytes());
+    }
+}

--- a/curvine-libsdk/java/src/test/java/io/curvine/LoadJobClientTest.java
+++ b/curvine-libsdk/java/src/test/java/io/curvine/LoadJobClientTest.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.time.Duration;
 
 public class LoadJobClientTest {
@@ -58,6 +59,29 @@ public class LoadJobClientTest {
         Assert.assertEquals("s3://bucket/a", request.getSourcePath());
         Assert.assertEquals("/mnt/a", request.getTargetPath());
         Assert.assertTrue(request.isOverwrite());
+    }
+
+    @Test
+    public void terminalStateDetectionMatchesForceRetrySemantics() {
+        Assert.assertFalse(CurvineTransferClient.isTerminal(JobTaskStateProto.PENDING));
+        Assert.assertFalse(CurvineTransferClient.isTerminal(JobTaskStateProto.LOADING));
+        Assert.assertFalse(CurvineTransferClient.isTerminal(JobTaskStateProto.UNKNOWN));
+        Assert.assertTrue(CurvineTransferClient.isTerminal(JobTaskStateProto.COMPLETED));
+        Assert.assertTrue(CurvineTransferClient.isTerminal(JobTaskStateProto.FAILED));
+        Assert.assertTrue(CurvineTransferClient.isTerminal(JobTaskStateProto.PARTIAL_SUCCESS));
+        Assert.assertTrue(CurvineTransferClient.isTerminal(JobTaskStateProto.CANCELED));
+    }
+
+    @Test
+    public void forceRetryRequiresTransferRouting() throws IOException {
+        try {
+            CurvineTransferClient.checkForceAllowed(true, false);
+            Assert.fail("expected force to require transfer routing");
+        } catch (IOException expected) {
+            Assert.assertTrue(expected.getMessage().contains("transfer.enabled=true"));
+        }
+        CurvineTransferClient.checkForceAllowed(false, false);
+        CurvineTransferClient.checkForceAllowed(true, true);
     }
 
     @Test

--- a/curvine-libsdk/java/src/test/java/io/curvine/LoadJobClientTest.java
+++ b/curvine-libsdk/java/src/test/java/io/curvine/LoadJobClientTest.java
@@ -78,7 +78,7 @@ public class LoadJobClientTest {
             CurvineTransferClient.checkForceAllowed(true, false);
             Assert.fail("expected force to require transfer routing");
         } catch (IOException expected) {
-            Assert.assertTrue(expected.getMessage().contains("transfer.enabled=true"));
+            Assert.assertTrue(expected.getMessage().contains("fs.cv.transfer.enabled=true"));
         }
         CurvineTransferClient.checkForceAllowed(false, false);
         CurvineTransferClient.checkForceAllowed(true, true);
@@ -186,6 +186,19 @@ public class LoadJobClientTest {
     public void saturatingDeadlineDoesNotWrap() {
         long deadline = CurvineLoadClient.saturatingDeadlineNanos(Duration.ofNanos(Long.MAX_VALUE));
         Assert.assertEquals(Long.MAX_VALUE, deadline);
+    }
+
+    @Test
+    public void saturatingDeadlineHandlesDurationConversionOverflow() {
+        long deadline = CurvineLoadClient.saturatingDeadlineNanos(Duration.ofSeconds(Long.MAX_VALUE));
+        Assert.assertEquals(Long.MAX_VALUE, deadline);
+    }
+
+    @Test
+    public void saturatingDurationHandlesConversionOverflow() {
+        Assert.assertEquals(
+                Long.MAX_VALUE,
+                CurvineTransferClient.saturatingDurationNanos(Duration.ofSeconds(Long.MAX_VALUE)));
     }
 
     @Test


### PR DESCRIPTION
# Summary

Complete the high-priority Java SDK surface for common Curvine client operations. The SDK now supports transfer job lifecycle operations, filesystem free, mount lifecycle safety, and preserves the existing load-client compatibility API.

# Issue Describe / Design

This PR closes the missing Java SDK coverage for the client operations already available through the Curvine client.

Design decisions:
- Use one CurvineTransferClient for load, export, status, cancel, retry, and wait operations.
- Keep CurvineLoadClient as a compatibility facade so existing load callers do not need to migrate immediately.
- Share native filesystem-handle lifecycle protection across filesystem and mount clients to serialize close against in-flight operations.
- Keep export target resolution aligned with the server and CLI contract; inferred export routes preserve Curvine-to-UFS direction.
- Route transfer operations through the existing legacy job RPC when the transfer service is disabled, and through the transfer RPC when enabled.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| Java SDK clients | Add CurvineTransferClient, ExportJobRequest, FreeResult, and filesystem free support. | Adds APIs; existing APIs remain compatible. |
| Mount and filesystem lifecycle | Add shared native handle guard and apply it to filesystem and mount operations. | Prevents operations racing with close; normal operation semantics unchanged. |
| JNI and Rust SDK core | Add export and retry bindings plus transfer routing and validation. | Extends the native surface without changing existing load behavior. |
| Java compatibility API and docs | Delegate CurvineLoadClient to the unified transfer client and document the full lifecycle. | Existing load entry points remain available. |
| Review fixes | Preserve inferred export direction, saturate all Duration conversions, and clarify lifecycle/configuration diagnostics. | Fixes transfer-enabled export; no API changes. |
| Tests | Add export-path, free-result, terminal-state, and lifecycle coverage. | No production behavior impact. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `cargo test -p curvine-sdk-core --all-targets` | PASS | 8 tests passed. |
| `cargo test -p curvine-libsdk-java --all-targets` | PASS | 2 tests passed. |
| `mvn -q -Dtest=FreeResultTest,ExportJobClientTest,LoadJobClientTest test` | PASS | Targeted Java SDK tests passed. |
| `mvn -q -DskipTests package` | PASS | Java SDK package build passed. |
| `cargo clippy -p curvine-sdk-core -p curvine-libsdk-java --all-targets -- -D warnings` | PASS | No warnings. |
| `cargo fmt --all -- --check` and `git diff --check` | PASS | Formatting and whitespace checks passed. |
| Full Java Maven test suite | ENVIRONMENT LIMITATION | Existing JDK 21 module-access failures occur in `CurvineNative` initialization; targeted tests and package build pass. |

# Dependencies

- Related PRs: None
- Related issues: None
- Blocks / blocked by: None